### PR TITLE
Fix regression in partial specialization of existential arguments

### DIFF
--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -1789,11 +1789,12 @@ struct SpecializationContext
                 auto valType = val->getFullType();
                 if (!isCompileTimeConstantType(valType))
                 {
-                    // If the `argument` is not specialized yet, don't aggressively specialize the parameter.
+                    // If the `argument` is not specialized yet, don't aggressively specialize the
+                    // parameter.
                     //
-                    // If we specialize the parameter type too early, we will lose the opportunity to specialize the
-                    // callee later. The principal is to always let the specialization happen at the same time for both
-                    // on argument and parameter.
+                    // If we specialize the parameter type too early, we will lose the opportunity
+                    // to specialize the callee later. The principal is to always let the
+                    // specialization happen at the same time for both on argument and parameter.
                     continue;
                 }
                 else if (auto extractExistentialType = as<IRExtractExistentialType>(valType))

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -1787,7 +1787,8 @@ struct SpecializationContext
                 // created.
                 //
                 auto valType = val->getFullType();
-                if (isCompileTimeConstantType(valType))
+                if (isCompileTimeConstantType(valType) &&
+                    isCompileTimeConstantType(oldParam->getFullType()))
                 {
                     if (auto extractExistentialType = as<IRExtractExistentialType>(valType))
                     {
@@ -1847,14 +1848,14 @@ struct SpecializationContext
             }
 
             // If we go here, then the parameter is either not an existential type,
-            // or the argument is not a specialized yet.
+            // or the argument/parameter is not specialized yet.
             //
             // For first case there is nothing interesting to do. The new function
             // will also have a parameter of the exact same type, and we'll use that
             // instead of the original parameter.
             //
             //
-            // For the second case if the argument is not specialized yet, don't
+            // For the second case if the argument/parameter is not specialized yet, don't
             // aggressively specialize the parameter.
             //
             // If we specialize the parameter type too early, we will lose the opportunity

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -1795,6 +1795,14 @@ struct SpecializationContext
                     // If we specialize the parameter type too early, we will lose the opportunity
                     // to specialize the callee later. The principal is to always let the
                     // specialization happen at the same time for both on argument and parameter.
+                    //
+                    // Note we should not use `createParam` here, because this call won't assign the
+                    // parent to the new parameter, therefore during the cloning process, some
+                    // existential related IR inst could be hoisted to the global scope, which is
+                    // unexpected. Instead, we should use cloneInst here, such that the new
+                    // parameter will be inserted into the function scope.
+                    auto newParam = (IRParam*)cloneInst(&cloneEnv, builder, oldParam);
+                    newParams.add(newParam);
                     continue;
                 }
                 else if (auto extractExistentialType = as<IRExtractExistentialType>(valType))

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -1787,7 +1787,16 @@ struct SpecializationContext
                 // created.
                 //
                 auto valType = val->getFullType();
-                if (auto extractExistentialType = as<IRExtractExistentialType>(valType))
+                if (!isCompileTimeConstantType(valType))
+                {
+                    // If the `argument` is not specialized yet, don't aggressively specialize the parameter.
+                    //
+                    // If we specialize the parameter type too early, we will lose the opportunity to specialize the
+                    // callee later. The principal is to always let the specialization happen at the same time for both
+                    // on argument and parameter.
+                    continue;
+                }
+                else if (auto extractExistentialType = as<IRExtractExistentialType>(valType))
                 {
                     valType = extractExistentialType->getOperand(0)->getDataType();
                     auto newParam = builder->createParam(valType);

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -1787,50 +1787,37 @@ struct SpecializationContext
                 // created.
                 //
                 auto valType = val->getFullType();
-                if (!isCompileTimeConstantType(valType))
+                if (isCompileTimeConstantType(valType))
                 {
-                    // If the `argument` is not specialized yet, don't aggressively specialize the
-                    // parameter.
-                    //
-                    // If we specialize the parameter type too early, we will lose the opportunity
-                    // to specialize the callee later. The principal is to always let the
-                    // specialization happen at the same time for both on argument and parameter.
-                    //
-                    // Note we should not use `createParam` here, because this call won't assign the
-                    // parent to the new parameter, therefore during the cloning process, some
-                    // existential related IR inst could be hoisted to the global scope, which is
-                    // unexpected. Instead, we should use cloneInst here, such that the new
-                    // parameter will be inserted into the function scope.
-                    auto newParam = (IRParam*)cloneInst(&cloneEnv, builder, oldParam);
-                    newParams.add(newParam);
-                    continue;
-                }
-                else if (auto extractExistentialType = as<IRExtractExistentialType>(valType))
-                {
-                    valType = extractExistentialType->getOperand(0)->getDataType();
-                    auto newParam = builder->createParam(valType);
-                    newParams.add(newParam);
-                    replacementVal = newParam;
-                }
-                else
-                {
-                    auto newParam = builder->createParam(valType);
-                    newParams.add(newParam);
+                    if (auto extractExistentialType = as<IRExtractExistentialType>(valType))
+                    {
+                        valType = extractExistentialType->getOperand(0)->getDataType();
+                        auto newParam = builder->createParam(valType);
+                        newParams.add(newParam);
+                        replacementVal = newParam;
+                    }
+                    else
+                    {
+                        auto newParam = builder->createParam(valType);
+                        newParams.add(newParam);
 
-                    // Within the body of the function we cannot just use `val`
-                    // directly, because the existing code expects an existential
-                    // value, including its witness table.
-                    //
-                    // Therefore we will create a `makeExistential(newParam, witnessTable)`
-                    // in the body of the new function and use *that* as the replacement
-                    // value for the original parameter (since it will have the
-                    // correct existential type, and stores the right witness table).
-                    //
-                    auto newMakeExistential = builder->emitMakeExistential(
-                        oldParam->getFullType(),
-                        newParam,
-                        witnessTable);
-                    replacementVal = newMakeExistential;
+                        // Within the body of the function we cannot just use `val`
+                        // directly, because the existing code expects an existential
+                        // value, including its witness table.
+                        //
+                        // Therefore we will create a `makeExistential(newParam, witnessTable)`
+                        // in the body of the new function and use *that* as the replacement
+                        // value for the original parameter (since it will have the
+                        // correct existential type, and stores the right witness table).
+                        //
+                        auto newMakeExistential = builder->emitMakeExistential(
+                            oldParam->getFullType(),
+                            newParam,
+                            witnessTable);
+                        replacementVal = newMakeExistential;
+                    }
+                    cloneEnv.mapOldValToNew.add(oldParam, replacementVal);
+                    continue;
                 }
             }
             else if (auto oldWrapExistential = as<IRWrapExistential>(arg))
@@ -1855,24 +1842,32 @@ struct SpecializationContext
                     newParam,
                     oldWrapExistential->getSlotOperandCount(),
                     oldWrapExistential->getSlotOperands());
-                replacementVal = newWrapExistential;
-            }
-            else
-            {
-                // For parameters that don't have an existential type,
-                // there is nothing interesting to do. The new function
-                // will also have a parameter of the exact same type,
-                // and we'll use that instead of the original parameter.
-                //
-                auto newParam = builder->createParam(oldParam->getFullType());
-                newParams.add(newParam);
-                replacementVal = newParam;
+                cloneEnv.mapOldValToNew.add(oldParam, newWrapExistential);
+                continue;
             }
 
-            // Whatever replacement value was constructed, we need to
-            // register it as the replacement for the original parameter.
+            // If we go here, then the parameter is either not an existential type,
+            // or the argument is not a specialized yet.
             //
-            cloneEnv.mapOldValToNew.add(oldParam, replacementVal);
+            // For first case there is nothing interesting to do. The new function
+            // will also have a parameter of the exact same type, and we'll use that
+            // instead of the original parameter.
+            //
+            //
+            // For the second case if the argument is not specialized yet, don't
+            // aggressively specialize the parameter.
+            //
+            // If we specialize the parameter type too early, we will lose the opportunity
+            // to specialize the callee later. The principal is to always let the
+            // specialization happen at the same time for both on argument and parameter.
+            //
+            // Note we should not use `createParam` here, because this call won't assign the
+            // parent to the new parameter, therefore during the cloning process, some
+            // existential related IR inst could be hoisted to the global scope, which is
+            // unexpected. Instead, we should use cloneInst here, such that the new
+            // parameter will be inserted into the function scope.
+            auto newParam = (IRParam*)cloneInst(&cloneEnv, builder, oldParam);
+            newParams.add(newParam);
         }
 
         // The above steps have accomplished the "first phase"

--- a/tests/bugs/gh-6589.slang
+++ b/tests/bugs/gh-6589.slang
@@ -1,0 +1,63 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+
+// This is a test that checks that we can apply partial specialization to a function
+// we won't specialize the function parameters too aggressively. Instead, we will specialize
+// the parameters at the same time of specializing the arguments. Otherwise, we could lose
+// the chance to specialize the argument.
+//
+// In this test, `matrix_vector_interfaces` will be fully specialized, otherwise the compile
+// will fail because we don't allow opaque type in the existential type. So as long as the target
+// spirv code can be generated, we are good.
+
+// CHECK: %main
+public interface ITensor<T : IDifferentiable, let D : int>
+{
+    public T get(int idx);
+
+}
+
+public interface IRWTensor<T : IDifferentiable, let D : int> : ITensor<T, D>
+{
+}
+
+
+public struct RWTensor<T : IDifferentiable, let D : int> : IRWTensor<T, D>
+{
+    public RWStructuredBuffer<T> buffer;
+    public T get(int idx) { return buffer[idx]; }
+}
+
+public struct GradInOutTensor<T : IDifferentiable, let D : int> : IRWTensor<T, D>
+{
+    public RWTensor<T, D> primal;
+    public T get(int idx) { return primal.get(idx); }
+}
+
+struct CallData
+{
+    GradInOutTensor<float, 3> weights;
+    GradInOutTensor<float, 2> biases;
+    RWStructuredBuffer<float> _result;
+}
+ParameterBlock<CallData> call_data;
+
+float matrix_vector_interfaces(ITensor<float, 2> weights, ITensor<float, 1> biases)
+{
+    return weights.get(0);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    float _result;
+    GradInOutTensor<float, 2> weights;
+    GradInOutTensor<float, 1> biases;
+
+    weights.primal.buffer = call_data.weights.primal.buffer;
+    biases.primal.buffer = call_data.biases.primal.buffer;
+
+    _result = matrix_vector_interfaces(weights, biases);
+
+    call_data._result[0] = _result;
+}


### PR DESCRIPTION
Close #6589.

In PR #6487, we support partial specialization. However there is a corner case we didn't handle correctly.

For the IR like this:

```
%val: specialize(...) = some inst;
%arg1: specialize(...) = makeExistential(%val, ...);
%arg2: %SomeConcreteType: load(...);
call func(%arg1, %arg2);
```

when we specialize the `call func` instruct, we will also specialize the function parameters.

On our existing logic, when we find an argument is a `makeExistential`, we will always extract the existential value, and use its type as the new parameter.

But in this case, %arg1 is not fully specialized yet, so it's type will still be a `specialize`. In this case, we will change the function's first parameter from an existential type to a `specialize`. This will result in that we lose the chance to specialize the first argument in the next iteration, because the first parameter of this function is not an existential type any more.

The reason behind this is that we should always keep specializing the arguments and parameters at the same time.

So this PR just does a check before specializing the parameters that if the argument cannot be fully specialized, we won't specialize the parameter this early. Instead, we will wait for the next iteration until the argument can be specialized.

