### PR TITLE
check constexpr of the nested calls

### DIFF
--- a/.github/workflows/add-issue-labels.yml
+++ b/.github/workflows/add-issue-labels.yml
@@ -1,0 +1,61 @@
+name: Add Issue Labels
+
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      test_username:
+        description: "GitHub username to test with"
+        required: true
+        type: string
+
+jobs:
+  add-dev-opened-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Check if issue creator is in Nvidia dev team
+        id: check_team
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.SLANGBOT_PAT }}
+          script: |
+            const response = await github.rest.teams.listMembersInOrg({
+              org: 'shader-slang',
+              team_slug: 'dev'
+            });
+
+            // For testing, use the provided username otherwise use the actual issue creator
+            const username = '${{ github.event.inputs.test_username || github.event.issue.user.login }}';
+
+            // Check if user is in the Nvidia dev team
+            const isTeamMember = response.data.some(member =>
+              member.login === username &&
+              member.login !== 'fairywreath'
+            );
+
+            console.log(`Checking membership for: ${username}`);
+            console.log(`Is Nvidia dev team member: ${isTeamMember}`);
+
+            core.setOutput('is_team_member', isTeamMember);
+
+      - name: Add Dev Opened Label
+        if: steps.check_team.outputs.is_team_member == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.SLANGBOT_PAT }}
+          script: |
+            // Only add label if this is a real issue and not a test run
+            if (context.eventName === 'issues') {
+              github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['Dev Opened']
+              });
+            } else {
+              console.log('Test run - would add label to issue if this was a real issue');
+            }

--- a/source/slang/slang-ir-constexpr.cpp
+++ b/source/slang/slang-ir-constexpr.cpp
@@ -178,7 +178,10 @@ IRLoop* isLoopPhi(IRParam* param)
 bool opCanBeConstExprByBackwardPass(IRInst* value)
 {
     if (value->getOp() == kIROp_Param)
-        return isLoopPhi(as<IRParam, IRDynamicCastBehavior::NoUnwrap>(value));
+    {
+        return true;
+        // return isLoopPhi(as<IRParam, IRDynamicCastBehavior::NoUnwrap>(value));
+    }
     if (opCanBeConstExpr(value->getOp()))
         return true;
     if (auto callInst = as<IRCall>(value))

--- a/source/slang/slang-ir-constexpr.cpp
+++ b/source/slang/slang-ir-constexpr.cpp
@@ -177,13 +177,11 @@ IRLoop* isLoopPhi(IRParam* param)
 
 bool opCanBeConstExprByBackwardPass(IRInst* value)
 {
-    if (value->getOp() == kIROp_Param)
+    if (opCanBeConstExpr(value->getOp()))
     {
         return true;
-        // return isLoopPhi(as<IRParam, IRDynamicCastBehavior::NoUnwrap>(value));
     }
-    if (opCanBeConstExpr(value->getOp()))
-        return true;
+
     if (auto callInst = as<IRCall>(value))
     {
         return !callInst->mightHaveSideEffects();

--- a/source/slang/slang-ir-constexpr.cpp
+++ b/source/slang/slang-ir-constexpr.cpp
@@ -229,7 +229,7 @@ bool maybeMarkConstExprBackwardPass(PropagateConstExprContext* context, IRInst* 
         {
             // We've just changed a function parameter to
             // be `constexpr`. We need to remember that
-            // fact so taht we can mark callers of this
+            // fact so that we can mark callers of this
             // function as `constexpr` themselves.
 
             for (auto u = code->firstUse; u; u = u->nextUse)
@@ -442,7 +442,12 @@ bool checkInstConstExprRecursively(PropagateConstExprContext* context, IRInst* i
             {
                 for (auto ii : block->getOrdinaryInsts())
                 {
-                    // If we find a call instruction
+                    // skip for recursive calls
+                    if (ii == inst)
+                    {
+                        continue;
+                    }
+                    // If we find a call instruction to check
                     if (as<IRCall>(ii))
                     {
                         changedInThisInst = checkInstConstExprRecursively(context, ii);
@@ -507,7 +512,7 @@ bool propagateConstExprBackward(PropagateConstExprContext* context, IRGlobalValu
         {
             for (auto ii = bb->getLastInst(); ii; ii = ii->getPrevInst())
             {
-                changedThisIteration = checkInstConstExprRecursively(context, ii);
+                changedThisIteration |= checkInstConstExprRecursively(context, ii);
             }
 
             if (bb != code->getFirstBlock())

--- a/source/slang/slang-ir-constexpr.cpp
+++ b/source/slang/slang-ir-constexpr.cpp
@@ -343,11 +343,148 @@ bool propagateConstExprForward(PropagateConstExprContext* context, IRGlobalValue
     }
 }
 
+// a help function to propagate constexpr from an instruction or the func call of an instruction
+bool checkInstConstExprRecursively(PropagateConstExprContext* context, IRInst* inst)
+{
+    bool changedInThisInst = false;
+
+    if (isConstExpr(inst))
+    {
+        // If this instruction is `constexpr`, then its operands should be too.
+        UInt argCount = inst->getOperandCount();
+        for (UInt aa = 0; aa < argCount; ++aa)
+        {
+            auto arg = inst->getOperand(aa);
+            if (isConstExpr(arg))
+                continue;
+
+            if (!opCanBeConstExprByBackwardPass(arg))
+                continue;
+
+            if (maybeMarkConstExprBackwardPass(context, arg))
+            {
+                changedInThisInst = true;
+            }
+        }
+    }
+    else if (inst->getOp() == kIROp_Call)
+    {
+        // A non-constexpr call might be calling a function with one or
+        // more constexpr parameters. We should check if we can resolve
+        // the callee for this call statically, and if so try to propagate
+        // constexpr from the parameters back to the arguments.
+        auto callInst = (IRCall*)inst;
+
+        UInt operandCount = callInst->getOperandCount();
+
+        UInt firstCallArg = 1;
+        UInt callArgCount = operandCount - firstCallArg;
+
+        auto callee = callInst->getOperand(0);
+
+        // If we are calling a generic operation, then
+        // try to follow through the `specialize` chain
+        // and find the callee.
+        //
+        // TODO: This probably shouldn't be required,
+        // since we can hopefully use the type of the
+        // callee in all cases.
+        //
+        while (auto specInst = as<IRSpecialize>(callee))
+        {
+            auto genericInst = as<IRGeneric>(specInst->getBase());
+            if (!genericInst)
+                break;
+
+            auto returnVal = findGenericReturnVal(genericInst);
+            if (!returnVal)
+                break;
+
+            callee = returnVal;
+        }
+
+        auto calleeFunc = as<IRFunc>(callee);
+        if (calleeFunc && isDefinition(calleeFunc))
+        {
+            // We have an IR-level function definition we are calling,
+            // and thus we can propagate `constexpr` information
+            // through its `IRParam`s.
+
+            auto calleeFuncType = calleeFunc->getDataType();
+
+            UInt callParamCount = calleeFuncType->getParamCount();
+            SLANG_RELEASE_ASSERT(callParamCount == callArgCount);
+
+            // If the callee has a definition, then we can read `constexpr`
+            // information off of the parameters of its first IR block.
+            if (auto calleeFirstBlock = calleeFunc->getFirstBlock())
+            {
+                UInt paramCounter = 0;
+                for (auto pp = calleeFirstBlock->getFirstParam(); pp;
+                    pp = pp->getNextParam())
+                {
+                    UInt paramIndex = paramCounter++;
+
+                    auto param = pp;
+                    auto arg = callInst->getOperand(firstCallArg + paramIndex);
+
+                    if (isConstExpr(param))
+                    {
+                        if (maybeMarkConstExprBackwardPass(context, arg))
+                        {
+                            changedInThisInst = true;
+                        }
+                    }
+                }
+            }
+                // Iterate through all instructions in all blocks
+                for (auto block : calleeFunc->getBlocks()) {
+                    for (auto ii : block->getOrdinaryInsts()) {
+                        // If we find a call instruction
+                        if (as<IRCall>(ii)) {
+                            changedInThisInst = checkInstConstExprRecursively(context, ii);
+                        }
+                    }
+                }
+        }
+        else
+        {
+            // If we don't have a concrete callee function
+            // definition, then we need to extract the
+            // type of the callee instruction, and try to work
+            // with that.
+            //
+            // Note that this does not allow us to propagate
+            // `constexpr` information from the body of a callee
+            // back to call sites.
+            auto calleeType = callee->getDataType();
+            if (auto caleeFuncType = as<IRFuncType>(calleeType))
+            {
+                auto paramCount = caleeFuncType->getParamCount();
+                for (UInt pp = 0; pp < paramCount; ++pp)
+                {
+                    auto paramType = caleeFuncType->getParamType(pp);
+                    auto arg = callInst->getOperand(firstCallArg + pp);
+                    if (isConstExpr(paramType))
+                    {
+                        if (maybeMarkConstExprBackwardPass(context, arg))
+                        {
+                            changedInThisInst = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return changedInThisInst;
+}
 
 // Propagate `constexpr`-ness in a backward direction, from an instruction
 // to its operands.
 bool propagateConstExprBackward(PropagateConstExprContext* context, IRGlobalValueWithCode* code)
 {
+
     IRBuilder builder(context->getModule());
     builder.setInsertInto(code);
 
@@ -367,130 +504,13 @@ bool propagateConstExprBackward(PropagateConstExprContext* context, IRGlobalValu
         {
             for (auto ii = bb->getLastInst(); ii; ii = ii->getPrevInst())
             {
-                if (isConstExpr(ii))
-                {
-                    // If this instruction is `constexpr`, then its operands should be too.
-                    UInt argCount = ii->getOperandCount();
-                    for (UInt aa = 0; aa < argCount; ++aa)
-                    {
-                        auto arg = ii->getOperand(aa);
-                        if (isConstExpr(arg))
-                            continue;
+                changedThisIteration = checkInstConstExprRecursively(context, ii);
 
-                        if (!opCanBeConstExprByBackwardPass(arg))
-                            continue;
-
-                        if (maybeMarkConstExprBackwardPass(context, arg))
-                        {
-                            changedThisIteration = true;
-                        }
-                    }
-                }
-                else if (ii->getOp() == kIROp_Call)
-                {
-                    // A non-constexpr call might be calling a function with one or
-                    // more constexpr parameters. We should check if we can resolve
-                    // the callee for this call statically, and if so try to propagate
-                    // constexpr from the parameters back to the arguments.
-                    auto callInst = (IRCall*)ii;
-
-                    UInt operandCount = callInst->getOperandCount();
-
-                    UInt firstCallArg = 1;
-                    UInt callArgCount = operandCount - firstCallArg;
-
-                    auto callee = callInst->getOperand(0);
-
-                    // If we are calling a generic operation, then
-                    // try to follow through the `specialize` chain
-                    // and find the callee.
-                    //
-                    // TODO: This probably shouldn't be required,
-                    // since we can hopefully use the type of the
-                    // callee in all cases.
-                    //
-                    while (auto specInst = as<IRSpecialize>(callee))
-                    {
-                        auto genericInst = as<IRGeneric>(specInst->getBase());
-                        if (!genericInst)
-                            break;
-
-                        auto returnVal = findGenericReturnVal(genericInst);
-                        if (!returnVal)
-                            break;
-
-                        callee = returnVal;
-                    }
-
-                    auto calleeFunc = as<IRFunc>(callee);
-                    if (calleeFunc && isDefinition(calleeFunc))
-                    {
-                        // We have an IR-level function definition we are calling,
-                        // and thus we can propagate `constexpr` information
-                        // through its `IRParam`s.
-
-                        auto calleeFuncType = calleeFunc->getDataType();
-
-                        UInt callParamCount = calleeFuncType->getParamCount();
-                        SLANG_RELEASE_ASSERT(callParamCount == callArgCount);
-
-                        // If the callee has a definition, then we can read `constexpr`
-                        // information off of the parameters of its first IR block.
-                        if (auto calleeFirstBlock = calleeFunc->getFirstBlock())
-                        {
-                            UInt paramCounter = 0;
-                            for (auto pp = calleeFirstBlock->getFirstParam(); pp;
-                                 pp = pp->getNextParam())
-                            {
-                                UInt paramIndex = paramCounter++;
-
-                                auto param = pp;
-                                auto arg = callInst->getOperand(firstCallArg + paramIndex);
-
-                                if (isConstExpr(param))
-                                {
-                                    if (maybeMarkConstExprBackwardPass(context, arg))
-                                    {
-                                        changedThisIteration = true;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // If we don't have a concrete callee function
-                        // definition, then we need to extract the
-                        // type of the callee instruction, and try to work
-                        // with that.
-                        //
-                        // Note that this does not allow us to propagate
-                        // `constexpr` information from the body of a callee
-                        // back to call sites.
-                        auto calleeType = callee->getDataType();
-                        if (auto caleeFuncType = as<IRFuncType>(calleeType))
-                        {
-                            auto paramCount = caleeFuncType->getParamCount();
-                            for (UInt pp = 0; pp < paramCount; ++pp)
-                            {
-                                auto paramType = caleeFuncType->getParamType(pp);
-                                auto arg = callInst->getOperand(firstCallArg + pp);
-                                if (isConstExpr(paramType))
-                                {
-                                    if (maybeMarkConstExprBackwardPass(context, arg))
-                                    {
-                                        changedThisIteration = true;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
             }
 
             if (bb != code->getFirstBlock())
             {
-                // A parameter in anything butr the first block is
+                // A parameter in anything but the first block is
                 // conceptually a phi node, which means its operands
                 // are the corresponding values from the terminating
                 // branch in a predecessor block.


### PR DESCRIPTION
This change aims to report error when the nested func requires constexpr, and the caller calls wrapper func with non-cost params.
For example, the following should failed to compile because RWTexture2D<T>::Load requires offset to be constexpr.

```
Texture2D<float3> input;
RWTexture2D<float3> output;

float3 LoadSourceColor(int2 offset) {
    int3 pixelPos = int3(0,0,0);
    return input.Load(pixelPos, offset);
}

[shader("compute")]
void Test() {
    float3 result = 0;

    [ForceUnroll]
    for (int i = 0; i < 3; i++) {
        //result += input.Load( int3(0,0,0), int2( i, i ));
        result += LoadSourceColor(int2( i, i ));
    }

    output[0] = result;
}
```
Fixes: #6370