### PR TITLE
Fixed crash in slang-ir-autodiff-loop-analysis.cpp

### DIFF
--- a/source/core/slang-dictionary.h
+++ b/source/core/slang-dictionary.h
@@ -150,6 +150,25 @@ public:
 
     auto erase(ConstIterator const& it) { return map.erase(it); }
 
+    // Removes all values satifying the predicate:
+    // bool predicate(pair<Key, Value>)
+    template<class Predicate>
+    void removeIf(Predicate&& predicate)
+    {
+        auto it = begin();
+        while (it != end())
+        {
+            if (predicate(*it))
+            {
+                it = erase(it);
+            }
+            else
+            {
+                ++it;
+            }
+        }
+    }
+
     // Reserves enough space for the specified number of values
     void reserve(Index size) { map.reserve(std::size_t(size)); };
 

--- a/source/core/slang-dictionary.h
+++ b/source/core/slang-dictionary.h
@@ -148,6 +148,8 @@ public:
     // Erases the value at the specified key if it exists
     void remove(const TKey& key) { map.erase(key); }
 
+    auto erase(ConstIterator const& it) { return map.erase(it); }
+
     // Reserves enough space for the specified number of values
     void reserve(Index size) { map.reserve(std::size_t(size)); };
 

--- a/source/core/slang-dictionary.h
+++ b/source/core/slang-dictionary.h
@@ -148,11 +148,9 @@ public:
     // Erases the value at the specified key if it exists
     void remove(const TKey& key) { map.erase(key); }
 
-    auto erase(ConstIterator const& it) { return map.erase(it); }
-
     // Removes all values satifying the predicate:
     // bool predicate(pair<Key, Value>)
-    template<class Predicate>
+    template<typename Predicate>
     void removeIf(Predicate&& predicate)
     {
         auto it = begin();
@@ -160,7 +158,7 @@ public:
         {
             if (predicate(*it))
             {
-                it = erase(it);
+                it = map.erase(it);
             }
             else
             {

--- a/source/slang/slang-ir-autodiff-loop-analysis.cpp
+++ b/source/slang/slang-ir-autodiff-loop-analysis.cpp
@@ -252,18 +252,8 @@ void StatementSet::disjunct(StatementSet other)
     // Remove any insts that don't have a corresponding statement in the other set,
     // since this effectively means "any".
     //
-    auto statement = statements.begin();
-    while (statement != statements.end())
-    {
-        if (!other.statements.containsKey(statement->first))
-        {
-            statement = statements.erase(statement);
-        }
-        else
-        {
-            ++statement;
-        }
-    }
+    statements.removeIf([&](auto const& statement)
+                        { return !other.statements.containsKey(statement.first); });
 }
 
 void StatementSet::conjunct(StatementSet other)

--- a/source/slang/slang-ir-autodiff-loop-analysis.cpp
+++ b/source/slang/slang-ir-autodiff-loop-analysis.cpp
@@ -252,10 +252,17 @@ void StatementSet::disjunct(StatementSet other)
     // Remove any insts that don't have a corresponding statement in the other set,
     // since this effectively means "any".
     //
-    for (auto& statement : statements)
+    auto statement = statements.begin();
+    while (statement != statements.end())
     {
-        if (!other.statements.containsKey(statement.first))
-            statements.remove(statement.first);
+        if (!other.statements.containsKey(statement->first))
+        {
+            statement = statements.erase(statement);
+        }
+        else
+        {
+            ++statement;
+        }
     }
 }
 


### PR DESCRIPTION
In slang-ir-autodiff-loop-analysis.cpp (added by 41e7e565eb3dfa13562cbfa3e8641874c2c6d66c), there was a filtering of a dictionary with a range for loop, which is not permitted. I replaced it with proper iterator handling. 

This was crashing when I was running tests (compiled with MSVC). I find it surprising that some of the latest commits passed all the tests and did not have this issue. I may be doing something wrong, but I can't find what?