### PR TITLE
Fix#6784 - Add diagnostic for for-loop update expressions with no effect

### DIFF
--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -240,6 +240,31 @@ void SemanticsStmtVisitor::visitForStmt(ForStmt* stmt)
     if (stmt->sideEffectExpression)
     {
         stmt->sideEffectExpression = CheckExpr(stmt->sideEffectExpression);
+
+        // Check for common mistake where update expression has no side effect
+        auto sideEffect = stmt->sideEffectExpression;
+        if (auto infixExpr = as<InfixExpr>(sideEffect))
+        {
+            // Check if the operation is a binary operation like "+" and not "+="
+            auto funcExpr = as<DeclRefExpr>(infixExpr->functionExpr);
+            if (funcExpr && funcExpr->declRef.getDecl())
+            {
+                // Check if the operator name doesn't contain "="
+                auto opName = funcExpr->declRef.getName();
+                if (opName && !String(opName->text).contains("="))
+                {
+                    // This is a potential issue - binary operators without "=" in for-loop updates
+                    // usually don't modify variables
+                    StringBuilder builder;
+                    builder << opName->text;
+
+                    getSink()->diagnose(
+                        sideEffect,
+                        Diagnostics::forLoopUpdateExpressionHasNoEffect,
+                        builder.produceString());
+                }
+            }
+        }
     }
     subContext.checkStmt(stmt->statement);
 

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -1397,6 +1397,11 @@ DIAGNOSTIC(
     loopRunsForZeroIterations,
     "the loop runs for 0 iterations and will be removed.")
 DIAGNOSTIC(
+    30506,
+    Warning,
+    forLoopUpdateExpressionHasNoEffect,
+    "the for loop update expression '$0' has no effect; this will result in an infinite loop")
+DIAGNOSTIC(
     30510,
     Error,
     loopInDiffFuncRequireUnrollOrMaxIters,

--- a/tests/diagnostics/for-loop-warning.slang
+++ b/tests/diagnostics/for-loop-warning.slang
@@ -56,5 +56,8 @@ float doSomething(int x)
     {
         i--;
     }
+    for (int i = 1; i < 100; i + 2) //warn
+    {
+    }
     return 0.0;
 }

--- a/tests/diagnostics/for-loop-warning.slang.expected
+++ b/tests/diagnostics/for-loop-warning.slang.expected
@@ -21,6 +21,9 @@ tests/diagnostics/for-loop-warning.slang(45): warning 30505: the loop runs for 0
 tests/diagnostics/for-loop-warning.slang(51): warning 30505: the loop runs for 0 iterations and will be removed.
     for (int i = 1; i > 1; i--) // warn
     ^~~
+tests/diagnostics/for-loop-warning.slang(59): warning 30506: the for loop update expression '+' has no effect; this will result in an infinite loop
+    for (int i = 1; i < 100; i + 2) //warn
+                               ^
 tests/diagnostics/for-loop-warning.slang(23): warning 30504: the for loop is statically determined to terminate within 3 iterations, which is less than what [MaxIters] specifies.
     [MaxIters(6)] // warn
      ^~~~~~~~


### PR DESCRIPTION
This commit introduces a new warning diagnostic (30506) for cases where the update expression in a for-loop does not modify any variables, potentially leading to infinite loops. The implementation includes checks in the `SemanticsStmtVisitor` to identify such expressions and provide appropriate warnings. Additionally, tests have been added to verify the new diagnostic behavior.