### PR TITLE
Remove support for ad hoc Slang IR compression

### DIFF
--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -959,7 +959,7 @@ Compound Capabilities
 > Collection of shader stages
 
 `meshshading`
-> Capabilities required to use mesh shading features
+> Ccapabilities required to use mesh shading features
 
 `shadermemorycontrol_compute`
 > (gfx targets) Capabilities required to use memory barriers that only work for raytracing & compute shader stages
@@ -1210,7 +1210,7 @@ Compound Capabilities
 
 Other
 ----------------------
-*Capabilities that may be deprecated*
+*Capabilities which may be deprecated*
 
 `cooperative_matrix`
 > Capabilities needed to use cooperative matrices

--- a/include/slang.h
+++ b/include/slang.h
@@ -985,7 +985,9 @@ typedef uint32_t SlangSizeT;
         ArchiveType,
         CompileCoreModule,
         Doc,
-        IrCompression,
+
+        IrCompression, //< deprecated
+
         LoadCoreModule,
         ReferenceModule,
         SaveCoreModule,

--- a/source/slang/slang-compiler-options.h
+++ b/source/slang/slang-compiler-options.h
@@ -274,7 +274,7 @@ struct CompilerOptionSet
                 result->getCount() != 0 && (*result)[0].kind == CompilerOptionValueKind::Int);
             return (*result)[0].intValue;
         }
-        return getDefault(name).intValue != 0;
+        return getDefault(name).intValue;
     }
     String getStringOption(CompilerOptionName name)
     {

--- a/source/slang/slang-compiler.cpp
+++ b/source/slang/slang-compiler.cpp
@@ -2165,9 +2165,6 @@ SlangResult EndToEndCompileRequest::writeContainerToStream(Stream* stream)
     // Set up options
     SerialContainerUtil::WriteOptions options;
 
-    options.compressionType = linkage->m_optionSet.getEnumOption<SerialCompressionType>(
-        CompilerOptionName::IrCompression);
-
     // If debug information is enabled, enable writing out source locs
     if (_shouldWriteSourceLocs(linkage))
     {

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -2424,11 +2424,7 @@ SlangResult OptionsParser::_parse(int argc, char const* const* argv)
             {
                 CommandLineArg name;
                 SLANG_RETURN_ON_FAIL(m_reader.expectArg(name));
-                SerialCompressionType compressionType;
-                SLANG_RETURN_ON_FAIL(SerialParseUtil::parseCompressionType(
-                    name.value.getUnownedSlice(),
-                    compressionType));
-                linkage->m_optionSet.set(optionKind, compressionType);
+                // TODO: doagnose deprecated option
                 break;
             }
         case OptionKind::EmbedDownstreamIR:

--- a/source/slang/slang-serialize-container.h
+++ b/source/slang/slang-serialize-container.h
@@ -83,9 +83,6 @@ struct SerialContainerUtil
 {
     struct WriteOptions
     {
-        SerialCompressionType compressionType =
-            SerialCompressionType::VariableByteLite; ///< If compression is used what type to use
-                                                     ///< (only some parts can be compressed)
         SerialOptionFlags optionFlags =
             SerialOptionFlag::ASTModule |
             SerialOptionFlag::IRModule; ///< Flags controlling what is written

--- a/source/slang/slang-serialize-ir-types.cpp
+++ b/source/slang/slang-serialize-ir-types.cpp
@@ -37,17 +37,6 @@ casts it.
         {0, 0}  // Int64,
 };
 
-// Check all compressible chunk ids, start with upper case 'S'
-SLANG_COMPILE_TIME_ASSERT(SLANG_FOUR_CC_GET_FIRST_CHAR(IRSerialBinary::kInstFourCc) == 'S');
-SLANG_COMPILE_TIME_ASSERT(SLANG_FOUR_CC_GET_FIRST_CHAR(IRSerialBinary::kChildRunFourCc) == 'S');
-SLANG_COMPILE_TIME_ASSERT(
-    SLANG_FOUR_CC_GET_FIRST_CHAR(IRSerialBinary::kExternalOperandsFourCc) == 'S');
-
-// Compressed version starts with 's'
-SLANG_COMPILE_TIME_ASSERT(
-    SLANG_FOUR_CC_GET_FIRST_CHAR(SLANG_MAKE_COMPRESSED_FOUR_CC(IRSerialBinary::kInstFourCc)) ==
-    's');
-
 struct PrefixString;
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! IRSerialData !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/source/slang/slang-serialize-ir-types.h
+++ b/source/slang/slang-serialize-ir-types.h
@@ -29,11 +29,6 @@ struct IRSerialBinary
     static const FourCC kChildRunFourCc = SLANG_FOUR_CC('S', 'L', 'c', 'r');
     static const FourCC kExternalOperandsFourCc = SLANG_FOUR_CC('S', 'L', 'e', 'o');
 
-    static const FourCC kCompressedInstFourCc = SLANG_MAKE_COMPRESSED_FOUR_CC(kInstFourCc);
-    static const FourCC kCompressedChildRunFourCc = SLANG_MAKE_COMPRESSED_FOUR_CC(kChildRunFourCc);
-    static const FourCC kCompressedExternalOperandsFourCc =
-        SLANG_MAKE_COMPRESSED_FOUR_CC(kExternalOperandsFourCc);
-
     static const FourCC kUInt32RawSourceLocFourCc = SLANG_FOUR_CC('S', 'r', 's', '4');
 
     /// Debug information is held elsewhere, but if this optional section exists, it maps

--- a/source/slang/slang-serialize-ir.h
+++ b/source/slang/slang-serialize-ir.h
@@ -28,7 +28,6 @@ struct IRSerialWriter
     /// Write to a container
     static Result writeContainer(
         const IRSerialData& data,
-        SerialCompressionType compressionType,
         RiffContainer* container);
 
     /// Get an instruction index from an instruction
@@ -98,7 +97,6 @@ struct IRSerialReader
     /// Read a stream to fill in dataOut IRSerialData
     static Result readContainer(
         RiffContainer::ListChunk* module,
-        SerialCompressionType containerCompressionType,
         IRSerialData* outData);
 
     /// Read a module from serial data

--- a/source/slang/slang-serialize-source-loc.cpp
+++ b/source/slang/slang-serialize-source-loc.cpp
@@ -386,7 +386,6 @@ SlangResult SerialSourceLocReader::read(
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! DebugSerialData !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
 
 /* static */ Result SerialSourceLocData::writeContainer(
-    SerialCompressionType moduleCompressionType,
     RiffContainer* container)
 {
     RiffContainer::ScopeChunk debugChunkScope(
@@ -394,20 +393,19 @@ SlangResult SerialSourceLocReader::read(
         RiffContainer::Chunk::Kind::List,
         SerialSourceLocData::kDebugFourCc);
 
-    SLANG_RETURN_ON_FAIL(SerialRiffUtil::writeArrayUncompressedChunk(
+    SLANG_RETURN_ON_FAIL(SerialRiffUtil::writeArrayChunk(
         SerialSourceLocData::kDebugStringFourCc,
         m_stringTable,
         container));
-    SLANG_RETURN_ON_FAIL(SerialRiffUtil::writeArrayUncompressedChunk(
+    SLANG_RETURN_ON_FAIL(SerialRiffUtil::writeArrayChunk(
         SerialSourceLocData::kDebugLineInfoFourCc,
         m_lineInfos,
         container));
-    SLANG_RETURN_ON_FAIL(SerialRiffUtil::writeArrayUncompressedChunk(
+    SLANG_RETURN_ON_FAIL(SerialRiffUtil::writeArrayChunk(
         SerialSourceLocData::kDebugAdjustedLineInfoFourCc,
         m_adjustedLineInfos,
         container));
     SLANG_RETURN_ON_FAIL(SerialRiffUtil::writeArrayChunk(
-        moduleCompressionType,
         SerialSourceLocData::kDebugSourceInfoFourCc,
         m_sourceInfos,
         container));
@@ -416,7 +414,6 @@ SlangResult SerialSourceLocReader::read(
 }
 
 /* static */ Result SerialSourceLocData::readContainer(
-    SerialCompressionType moduleCompressionType,
     RiffContainer::ListChunk* listChunk)
 {
     SLANG_ASSERT(listChunk->getSubType() == SerialSourceLocData::kDebugFourCc);
@@ -435,26 +432,24 @@ SlangResult SerialSourceLocReader::read(
         case SerialSourceLocData::kDebugStringFourCc:
             {
                 SLANG_RETURN_ON_FAIL(
-                    SerialRiffUtil::readArrayUncompressedChunk(dataChunk, m_stringTable));
+                    SerialRiffUtil::readArrayChunk(dataChunk, m_stringTable));
                 break;
             }
         case SerialSourceLocData::kDebugLineInfoFourCc:
             {
                 SLANG_RETURN_ON_FAIL(
-                    SerialRiffUtil::readArrayUncompressedChunk(dataChunk, m_lineInfos));
+                    SerialRiffUtil::readArrayChunk(dataChunk, m_lineInfos));
                 break;
             }
         case SerialSourceLocData::kDebugAdjustedLineInfoFourCc:
             {
                 SLANG_RETURN_ON_FAIL(
-                    SerialRiffUtil::readArrayUncompressedChunk(dataChunk, m_adjustedLineInfos));
+                    SerialRiffUtil::readArrayChunk(dataChunk, m_adjustedLineInfos));
                 break;
             }
-        case SLANG_MAKE_COMPRESSED_FOUR_CC(SerialSourceLocData::kDebugSourceInfoFourCc):
         case SerialSourceLocData::kDebugSourceInfoFourCc:
             {
                 SLANG_RETURN_ON_FAIL(SerialRiffUtil::readArrayChunk(
-                    moduleCompressionType,
                     dataChunk,
                     m_sourceInfos));
                 break;

--- a/source/slang/slang-serialize-source-loc.h
+++ b/source/slang/slang-serialize-source-loc.h
@@ -135,9 +135,9 @@ public:
 
     bool operator==(const ThisType& rhs) const;
 
-    Result writeContainer(SerialCompressionType moduleCompressionType, RiffContainer* container);
+    Result writeContainer(
+        RiffContainer* container);
     Result readContainer(
-        SerialCompressionType moduleCompressionType,
         RiffContainer::ListChunk* listChunk);
 
     List<char> m_stringTable;                   ///< String table for debug use only

--- a/source/slang/slang-serialize-types.cpp
+++ b/source/slang/slang-serialize-types.cpp
@@ -145,7 +145,6 @@ struct ByteReader
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!! SerialRiffUtil !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 /* static */ Result SerialRiffUtil::writeArrayChunk(
-    SerialCompressionType compressionType,
     FourCC chunkId,
     const void* data,
     size_t numEntries,
@@ -160,52 +159,17 @@ struct ByteReader
         return SLANG_OK;
     }
 
-    // Make compressed fourCC
-    chunkId = (compressionType != SerialCompressionType::None)
-                  ? SLANG_MAKE_COMPRESSED_FOUR_CC(chunkId)
-                  : chunkId;
-
     ScopeChunk scope(container, Chunk::Kind::Data, chunkId);
 
-    switch (compressionType)
-    {
-    case SerialCompressionType::None:
-        {
-            SerialBinary::ArrayHeader header;
-            header.numEntries = uint32_t(numEntries);
+    SerialBinary::ArrayHeader header;
+    header.numEntries = uint32_t(numEntries);
 
-            container->write(&header, sizeof(header));
-            container->write(data, typeSize * numEntries);
-            break;
-        }
-    case SerialCompressionType::VariableByteLite:
-        {
-            List<uint8_t> compressedPayload;
-
-            size_t numCompressedEntries = (numEntries * typeSize) / sizeof(uint32_t);
-            ByteEncodeUtil::encodeLiteUInt32(
-                (const uint32_t*)data,
-                numCompressedEntries,
-                compressedPayload);
-
-            SerialBinary::CompressedArrayHeader header;
-            header.numEntries = uint32_t(numEntries);
-            header.numCompressedEntries = uint32_t(numCompressedEntries);
-
-            container->write(&header, sizeof(header));
-            container->write(compressedPayload.getBuffer(), compressedPayload.getCount());
-            break;
-        }
-    default:
-        {
-            return SLANG_FAIL;
-        }
-    }
+    container->write(&header, sizeof(header));
+    container->write(data, typeSize * numEntries);
     return SLANG_OK;
 }
 
 /* static */ Result SerialRiffUtil::readArrayChunk(
-    SerialCompressionType compressionType,
     RiffContainer::DataChunk* dataChunk,
     ListResizer& listOut)
 {
@@ -214,90 +178,14 @@ struct ByteReader
     RiffReadHelper read = dataChunk->asReadHelper();
     const size_t typeSize = listOut.getTypeSize();
 
-    switch (compressionType)
-    {
-    case SerialCompressionType::VariableByteLite:
-        {
-            Bin::CompressedArrayHeader header;
-            SLANG_RETURN_ON_FAIL(read.read(header));
+    Bin::ArrayHeader header;
+    SLANG_RETURN_ON_FAIL(read.read(header));
+    const size_t payloadSize = header.numEntries * typeSize;
+    SLANG_ASSERT(payloadSize == read.getRemainingSize());
+    void* dst = listOut.setSize(header.numEntries);
+    ::memcpy(dst, read.getData(), payloadSize);
 
-            void* dst = listOut.setSize(header.numEntries);
-            SLANG_ASSERT(
-                header.numCompressedEntries ==
-                uint32_t((header.numEntries * typeSize) / sizeof(uint32_t)));
-
-            // Decode..
-            ByteEncodeUtil::decodeLiteUInt32(
-                read.getData(),
-                header.numCompressedEntries,
-                (uint32_t*)dst);
-            break;
-        }
-    case SerialCompressionType::None:
-        {
-            // Read uncompressed
-            Bin::ArrayHeader header;
-            SLANG_RETURN_ON_FAIL(read.read(header));
-            const size_t payloadSize = header.numEntries * typeSize;
-            SLANG_ASSERT(payloadSize == read.getRemainingSize());
-            void* dst = listOut.setSize(header.numEntries);
-            ::memcpy(dst, read.getData(), payloadSize);
-            break;
-        }
-    }
     return SLANG_OK;
 }
-
-// !!!!!!!!!!!!!!!!!!!!!!!!!!!! SerialParseUtil !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-// clang-format off
-#define SLANG_SERIAL_BINARY_COMPRESSION_TYPE(x) \
-    x(None, none) \
-    x(VariableByteLite, lite)
-// clang-format on
-
-/* static */ SlangResult SerialParseUtil::parseCompressionType(
-    const UnownedStringSlice& text,
-    SerialCompressionType& outType)
-{
-    struct Pair
-    {
-        UnownedStringSlice name;
-        SerialCompressionType type;
-    };
-
-    // clang-format off
-#define SLANG_SERIAL_BINARY_PAIR(type, name) \
-    {UnownedStringSlice::fromLiteral(#name), SerialCompressionType::type},
-    // clang-format on
-
-    static const Pair s_pairs[] = {SLANG_SERIAL_BINARY_COMPRESSION_TYPE(SLANG_SERIAL_BINARY_PAIR)};
-
-    for (const auto& pair : s_pairs)
-    {
-        if (pair.name == text)
-        {
-            outType = pair.type;
-            return SLANG_OK;
-        }
-    }
-    return SLANG_FAIL;
-}
-
-/* static */ UnownedStringSlice SerialParseUtil::getText(SerialCompressionType type)
-{
-#define SLANG_SERIAL_BINARY_CASE(type, name) \
-    case SerialCompressionType::type:        \
-        return UnownedStringSlice::fromLiteral(#name);
-    switch (type)
-    {
-        SLANG_SERIAL_BINARY_COMPRESSION_TYPE(SLANG_SERIAL_BINARY_CASE)
-    default:
-        break;
-    }
-    SLANG_ASSERT(!"Unknown compression type");
-    return UnownedStringSlice::fromLiteral("unknown");
-}
-
 
 } // namespace Slang

--- a/source/slang/slang-serialize-types.h
+++ b/source/slang/slang-serialize-types.h
@@ -40,16 +40,6 @@ struct SerialOptionFlag
 };
 typedef SerialOptionFlag::Type SerialOptionFlags;
 
-
-// Compression styles
-
-enum class SerialCompressionType : uint8_t
-{
-    None,
-    VariableByteLite,
-};
-
-
 struct SerialStringData
 {
     enum class StringIndex : uint32_t;
@@ -91,16 +81,6 @@ struct SerialStringTableUtil
         const List<UnownedStringSlice>& slices,
         StringSlicePool& pool,
         List<StringSlicePool::Handle>& indexMap);
-};
-
-struct SerialParseUtil
-{
-    /// Given text, finds the compression type
-    static SlangResult parseCompressionType(
-        const UnownedStringSlice& text,
-        SerialCompressionType& outType);
-    /// Given a compression type, return text
-    static UnownedStringSlice getText(SerialCompressionType type);
 };
 
 struct SerialListUtil
@@ -160,30 +140,14 @@ struct SerialBinary
     /// An entry point
     static const FourCC kEntryPointFourCc = SLANG_FOUR_CC('E', 'P', 'n', 't');
 
-    /// Container
-    static const FourCC kContainerHeaderFourCc = SLANG_FOUR_CC('S', 'c', 'h', 'd');
-
     // Module header
     static const FourCC kModuleHeaderFourCc = SLANG_FOUR_CC('S', 'm', 'h', 'd');
-
-    struct ContainerHeader
-    {
-        uint32_t compressionType; ///< Holds the compression type used (if used at all)
-    };
 
     struct ArrayHeader
     {
         uint32_t numEntries;
     };
-    struct CompressedArrayHeader
-    {
-        uint32_t numEntries;           ///< The number of entries
-        uint32_t numCompressedEntries; ///< The amount of compressed entries
-    };
 };
-
-// Replace first char with 's'
-#define SLANG_MAKE_COMPRESSED_FOUR_CC(fourCc) SLANG_FOUR_CC_REPLACE_FIRST_CHAR(fourCc, 's')
 
 struct SerialRiffUtil
 {
@@ -223,7 +187,6 @@ struct SerialRiffUtil
     };
 
     static Result writeArrayChunk(
-        SerialCompressionType compressionType,
         FourCC chunkId,
         const void* data,
         size_t numEntries,
@@ -232,28 +195,11 @@ struct SerialRiffUtil
 
     template<typename T>
     static Result writeArrayChunk(
-        SerialCompressionType compressionType,
         FourCC chunkId,
         const List<T>& array,
         RiffContainer* container)
     {
         return writeArrayChunk(
-            compressionType,
-            chunkId,
-            array.begin(),
-            size_t(array.getCount()),
-            sizeof(T),
-            container);
-    }
-
-    template<typename T>
-    static Result writeArrayUncompressedChunk(
-        FourCC chunkId,
-        const List<T>& array,
-        RiffContainer* container)
-    {
-        return writeArrayChunk(
-            SerialCompressionType::None,
             chunkId,
             array.begin(),
             size_t(array.getCount()),
@@ -262,31 +208,16 @@ struct SerialRiffUtil
     }
 
     static Result readArrayChunk(
-        SerialCompressionType compressionType,
         RiffContainer::DataChunk* dataChunk,
         ListResizer& listOut);
 
     template<typename T>
     static Result readArrayChunk(
-        SerialCompressionType moduleCompressionType,
         RiffContainer::DataChunk* dataChunk,
         List<T>& arrayOut)
     {
-        SerialCompressionType compressionType = SerialCompressionType::None;
-        if (dataChunk->m_fourCC == SLANG_MAKE_COMPRESSED_FOUR_CC(dataChunk->m_fourCC))
-        {
-            // If it has compression, use the compression type set in the header
-            compressionType = moduleCompressionType;
-        }
         ListResizerForType<T> resizer(arrayOut);
-        return readArrayChunk(compressionType, dataChunk, resizer);
-    }
-
-    template<typename T>
-    static Result readArrayUncompressedChunk(RiffContainer::DataChunk* chunk, List<T>& arrayOut)
-    {
-        ListResizerForType<T> resizer(arrayOut);
-        return readArrayChunk(SerialCompressionType::None, chunk, resizer);
+        return readArrayChunk(dataChunk, resizer);
     }
 };
 

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3486,7 +3486,6 @@ void FrontEndCompileRequest::generateIR()
         {
             SerialContainerUtil::WriteOptions options;
 
-            options.compressionType = SerialCompressionType::None;
             options.sourceManager = getSourceManager();
             options.optionFlags |= SerialOptionFlag::SourceLocation;
 


### PR DESCRIPTION
This change is part of a larger effort to clean up the approach to serialization in the Slang compiler. The overall goal is to simplify and streamline all of the serialization-related logic, so that we are left with code that is less "clever," and easier to understand for contributors to the codebase.

Removing support for compression of serialized Slang IR has benefits that include:

* Reduction in code complexity: consider things like the subtle way that the `FOURCC`s for compressed chunks were being computed from the uncompressed versions, and the mental overhead that goes into understanding that, for anybody who would dare to touch this code.

* Reduction in testing burden: there have been, de facto, two very different code paths for serialization of the Slang IR, and it is not clear that the existing test corpus for Slang has sufficient coverage for both options. By having only a single code path, every test that performs any amount of IR serialization helps with test coverage of that one path.

* Opportunity to explore alternatives. This is perhaps a reiteration of the first point, but once the code is stripped down to the simplest thing that could possibly work (I am not claiming it has reached that point yet), it becomes easier for contributors to understand, and it becomes more tractable for somebody to come along with an improved approach that performs better (in either compression ratio or performance) while still being maintainable.

In my own local setup, I found that removing support for Slang IR compression led to the `slang-core-module-generated.h` file increasing in size from 46.1MB to 47.4MB. This increase in the `.h` file size for the core library binary only resulted in a release build of `slang.dll` increasing from 20.0MB to 20.2MB. Removing the ad hoc compression support has almost no impact on the size of actual binary Slang modules *so long* as the additional LZ4 compression step is being applied to them.