### PR TITLE
Check the available VK extensions before using CoopVec APIs in GFX

### DIFF
--- a/include/slang-gfx.h
+++ b/include/slang-gfx.h
@@ -1723,6 +1723,36 @@ struct ClearResourceViewFlags
     };
 };
 
+enum class CooperativeVectorComponentType
+{
+    Float16 = 0,
+    Float32 = 1,
+    Float64 = 2,
+    SInt8 = 3,
+    SInt16 = 4,
+    SInt32 = 5,
+    SInt64 = 6,
+    UInt8 = 7,
+    UInt16 = 8,
+    UInt32 = 9,
+    UInt64 = 10,
+    SInt8Packed = 11,
+    UInt8Packed = 12,
+    FloatE4M3 = 13,
+    FloatE5M2 = 14,
+};
+
+struct CooperativeVectorProperties
+{
+    CooperativeVectorComponentType inputType;
+    CooperativeVectorComponentType inputInterpretation;
+    CooperativeVectorComponentType matrixInterpretation;
+    CooperativeVectorComponentType biasInterpretation;
+    CooperativeVectorComponentType resultType;
+    bool transpose;
+};
+
+
 class IResourceCommandEncoder : public ICommandEncoder
 {
     // {F99A00E9-ED50-4088-8A0E-3B26755031EA}
@@ -2779,6 +2809,10 @@ public:
         Size* outAlignment) = 0;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(Size* outAlignment) = 0;
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL getCooperativeVectorProperties(
+        CooperativeVectorProperties* properties,
+        uint32_t* propertyCount) = 0;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL createShaderObject2(
         slang::ISession* slangSession,

--- a/tools/gfx/debug-layer/debug-device.cpp
+++ b/tools/gfx/debug-layer/debug-device.cpp
@@ -685,6 +685,14 @@ Result DebugDevice::getTextureRowAlignment(size_t* outAlignment)
     return baseObject->getTextureRowAlignment(outAlignment);
 }
 
+Result DebugDevice::getCooperativeVectorProperties(
+    CooperativeVectorProperties* properties,
+    uint32_t* propertyCount)
+{
+    SLANG_GFX_API_FUNC;
+    return baseObject->getCooperativeVectorProperties(properties, propertyCount);
+}
+
 Result DebugDevice::createShaderTable(const IShaderTable::Desc& desc, IShaderTable** outTable)
 {
     SLANG_GFX_API_FUNC;

--- a/tools/gfx/debug-layer/debug-device.h
+++ b/tools/gfx/debug-layer/debug-device.h
@@ -161,6 +161,11 @@ public:
         size_t* outSize,
         size_t* outAlignment) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(size_t* outAlignment) override;
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL getCooperativeVectorProperties(
+        CooperativeVectorProperties* properties,
+        uint32_t* propertyCount) override;
+
     virtual SLANG_NO_THROW Result SLANG_MCALL
     createShaderTable(const IShaderTable::Desc& desc, IShaderTable** outTable) override;
 };

--- a/tools/gfx/renderer-shared.cpp
+++ b/tools/gfx/renderer-shared.cpp
@@ -770,6 +770,14 @@ Result RendererBase::getTextureRowAlignment(Size* outAlignment)
     return SLANG_E_NOT_AVAILABLE;
 }
 
+Result RendererBase::getCooperativeVectorProperties(
+    CooperativeVectorProperties* properties,
+    uint32_t* propertyCount)
+{
+    *propertyCount = 0;
+    return SLANG_E_NOT_AVAILABLE;
+}
+
 Result RendererBase::getShaderObjectLayout(
     slang::ISession* session,
     slang::TypeReflection* type,

--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -1338,6 +1338,10 @@ public:
     // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE.
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(size_t* outAlignment) override;
 
+    // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE.
+    virtual SLANG_NO_THROW Result SLANG_MCALL
+    getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertyCount) override;
+
     Result getEntryPointCodeFromShaderCache(
         slang::IComponentType* program,
         SlangInt entryPointIndex,
@@ -1392,6 +1396,7 @@ protected:
 
 protected:
     Slang::List<Slang::String> m_features;
+    std::vector<CooperativeVectorProperties> m_cooperativeVectorProperties;
 
 public:
     SlangContext slangContext;

--- a/tools/gfx/renderer-shared.h
+++ b/tools/gfx/renderer-shared.h
@@ -1339,8 +1339,9 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(size_t* outAlignment) override;
 
     // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE.
-    virtual SLANG_NO_THROW Result SLANG_MCALL
-    getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertyCount) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getCooperativeVectorProperties(
+        CooperativeVectorProperties* properties,
+        uint32_t* propertyCount) override;
 
     Result getEntryPointCodeFromShaderCache(
         slang::IComponentType* program,

--- a/tools/gfx/vulkan/vk-api.cpp
+++ b/tools/gfx/vulkan/vk-api.cpp
@@ -86,17 +86,6 @@ Slang::Result VulkanApi::initPhysicalDevice(VkPhysicalDevice physicalDevice)
     vkGetPhysicalDeviceFeatures(m_physicalDevice, &m_deviceFeatures);
     vkGetPhysicalDeviceMemoryProperties(m_physicalDevice, &m_deviceMemoryProperties);
 
-    if (vkGetPhysicalDeviceCooperativeVectorPropertiesNV)
-    {
-        uint32_t nProps = 0;
-        vkGetPhysicalDeviceCooperativeVectorPropertiesNV(m_physicalDevice, &nProps, nullptr);
-        m_cooperativeVectorProperties.setCount(nProps);
-        vkGetPhysicalDeviceCooperativeVectorPropertiesNV(
-            m_physicalDevice,
-            &nProps,
-            m_cooperativeVectorProperties.getBuffer());
-    }
-
     return SLANG_OK;
 }
 

--- a/tools/gfx/vulkan/vk-device.cpp
+++ b/tools/gfx/vulkan/vk-device.cpp
@@ -758,16 +758,6 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             deviceCreateInfo.pNext = &extendedFeatures.vulkan12Features;
         }
 
-        if (extendedFeatures.cooperativeVectorFeatures.cooperativeVector)
-        {
-            deviceExtensions.add(VK_NV_COOPERATIVE_VECTOR_EXTENSION_NAME);
-
-            extendedFeatures.cooperativeVectorFeatures.pNext = (void*)deviceCreateInfo.pNext;
-            deviceCreateInfo.pNext = &extendedFeatures.cooperativeVectorFeatures;
-
-            m_features.add("cooperative-vector");
-        }
-
         VkPhysicalDeviceProperties2 extendedProps = {
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2};
         VkPhysicalDeviceRayTracingPipelinePropertiesKHR rtProps = {

--- a/tools/gfx/vulkan/vk-device.cpp
+++ b/tools/gfx/vulkan/vk-device.cpp
@@ -730,6 +730,12 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
                 "ray-tracing-validation");
         }
 
+        SIMPLE_EXTENSION_FEATURE(
+            extendedFeatures.cooperativeVectorFeatures,
+            cooperativeVector,
+            VK_NV_COOPERATIVE_VECTOR_EXTENSION_NAME,
+            "cooperative-vector");
+
 #undef SIMPLE_EXTENSION_FEATURE
 
         if (extendedFeatures.vulkan12Features.shaderBufferInt64Atomics)
@@ -1546,6 +1552,47 @@ Result DeviceImpl::getTextureRowAlignment(Size* outAlignment)
 {
     *outAlignment = 1;
     return SLANG_OK;
+}
+
+Result DeviceImpl::getCooperativeVectorProperties(
+    CooperativeVectorProperties* properties,
+    uint32_t* propertyCount)
+{
+    if (!m_api.m_extendedFeatures.cooperativeVectorFeatures.cooperativeVector ||
+        !m_api.vkGetPhysicalDeviceCooperativeVectorPropertiesNV)
+        return SLANG_E_NOT_AVAILABLE;
+
+    if (m_cooperativeVectorProperties.empty())
+    {
+        uint32_t vkPropertyCount = 0;
+        m_api.vkGetPhysicalDeviceCooperativeVectorPropertiesNV(
+            m_api.m_physicalDevice,
+            &vkPropertyCount,
+            nullptr);
+        std::vector<VkCooperativeVectorPropertiesNV> vkProperties(vkPropertyCount);
+        SLANG_VK_RETURN_ON_FAIL(m_api.vkGetPhysicalDeviceCooperativeVectorPropertiesNV(
+            m_api.m_physicalDevice,
+            &vkPropertyCount,
+            vkProperties.data()));
+        for (const auto& vkProps : vkProperties)
+        {
+            CooperativeVectorProperties props;
+            props.inputType =
+                VulkanUtil::translateCooperativeVectorComponentType(vkProps.inputType);
+            props.inputInterpretation =
+                VulkanUtil::translateCooperativeVectorComponentType(vkProps.inputInterpretation);
+            props.matrixInterpretation =
+                VulkanUtil::translateCooperativeVectorComponentType(vkProps.matrixInterpretation);
+            props.biasInterpretation =
+                VulkanUtil::translateCooperativeVectorComponentType(vkProps.biasInterpretation);
+            props.resultType =
+                VulkanUtil::translateCooperativeVectorComponentType(vkProps.resultType);
+            props.transpose = vkProps.transpose;
+            m_cooperativeVectorProperties.push_back(props);
+        }
+    }
+
+    return RendererBase::getCooperativeVectorProperties(properties, propertyCount);
 }
 
 Result DeviceImpl::createTextureResource(

--- a/tools/gfx/vulkan/vk-device.h
+++ b/tools/gfx/vulkan/vk-device.h
@@ -129,6 +129,10 @@ public:
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(Size* outAlignment) override;
 
+    virtual SLANG_NO_THROW Result SLANG_MCALL getCooperativeVectorProperties(
+        CooperativeVectorProperties* properties,
+        uint32_t* propertyCount) override;
+
     virtual SLANG_NO_THROW Result SLANG_MCALL
     createFence(const IFence::Desc& desc, IFence** outFence) override;
 

--- a/tools/gfx/vulkan/vk-util.cpp
+++ b/tools/gfx/vulkan/vk-util.cpp
@@ -608,6 +608,46 @@ VkSamplerReductionMode VulkanUtil::translateReductionOp(TextureReductionOp op)
     }
 }
 
+CooperativeVectorComponentType VulkanUtil::translateCooperativeVectorComponentType(
+    VkComponentTypeKHR type)
+{
+    switch (type)
+    {
+    case VK_COMPONENT_TYPE_FLOAT16_KHR:
+        return CooperativeVectorComponentType::Float16;
+    case VK_COMPONENT_TYPE_FLOAT32_KHR:
+        return CooperativeVectorComponentType::Float32;
+    case VK_COMPONENT_TYPE_FLOAT64_KHR:
+        return CooperativeVectorComponentType::Float64;
+    case VK_COMPONENT_TYPE_SINT8_KHR:
+        return CooperativeVectorComponentType::SInt8;
+    case VK_COMPONENT_TYPE_SINT16_KHR:
+        return CooperativeVectorComponentType::SInt16;
+    case VK_COMPONENT_TYPE_SINT32_KHR:
+        return CooperativeVectorComponentType::SInt32;
+    case VK_COMPONENT_TYPE_SINT64_KHR:
+        return CooperativeVectorComponentType::SInt64;
+    case VK_COMPONENT_TYPE_UINT8_KHR:
+        return CooperativeVectorComponentType::UInt8;
+    case VK_COMPONENT_TYPE_UINT16_KHR:
+        return CooperativeVectorComponentType::UInt16;
+    case VK_COMPONENT_TYPE_UINT32_KHR:
+        return CooperativeVectorComponentType::UInt32;
+    case VK_COMPONENT_TYPE_UINT64_KHR:
+        return CooperativeVectorComponentType::UInt64;
+    case VK_COMPONENT_TYPE_SINT8_PACKED_NV:
+        return CooperativeVectorComponentType::SInt8Packed;
+    case VK_COMPONENT_TYPE_UINT8_PACKED_NV:
+        return CooperativeVectorComponentType::UInt8Packed;
+    case VK_COMPONENT_TYPE_FLOAT_E4M3_NV:
+        return CooperativeVectorComponentType::FloatE4M3;
+    case VK_COMPONENT_TYPE_FLOAT_E5M2_NV:
+        return CooperativeVectorComponentType::FloatE5M2;
+    default:
+        return CooperativeVectorComponentType(0);
+    }
+}
+
 /* static */ Slang::Result VulkanUtil::handleFail(VkResult res)
 {
     if (res != VK_SUCCESS)

--- a/tools/gfx/vulkan/vk-util.h
+++ b/tools/gfx/vulkan/vk-util.h
@@ -130,6 +130,9 @@ struct VulkanUtil
     static VkStencilOpState translateStencilState(DepthStencilOpDesc desc);
 
     static VkSamplerReductionMode translateReductionOp(TextureReductionOp op);
+
+    static CooperativeVectorComponentType translateCooperativeVectorComponentType(
+        VkComponentTypeKHR type);
 };
 
 struct AccelerationStructureBuildGeometryInfoBuilder


### PR DESCRIPTION
Closes https://github.com/shader-slang/slang/issues/6791

Basically the PR defers the call to `vkGetPhysicalDeviceCooperativeVectorPropertiesNV` after we get the list of available extensions.

The exact same modification was already implemented on slang-rhi and this PR ports over from slang-rhi to slang-gfx.
In other words, there is no new lines written and all of them are copy-and-pasted from slang-rhi to slang-gfx.