### PR TITLE
Fix compiler warning on Windows about -build-id

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -152,8 +152,8 @@ function(set_default_compile_options target)
 
     add_supported_cxx_flags(${target} PRIVATE ${warning_flags})
 
-    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-        # valid linker options only for GNU/Clang
+    if(NOT WIN32)
+        # these options are for ELF specific and not for Windows
         add_supported_cxx_linker_flags(
             ${target}
             PRIVATE


### PR DESCRIPTION
This PR fixes the compiler warning like following, lld-link: warning: ignoring unknown argument '--no-undefined' lld-link: warning: ignoring unknown argument '--build-id', did you mean '-build-id'

chatGPT said that those options are for ELF and not for Windows:

These warnings happen because the Clang toolchain on Windows is invoking lld-link, which is the LLVM linker frontend for link.exe compatibility (i.e., it acts like the MSVC linker). The arguments --no-undefined and --build-id are ELF-specific flags, which are valid when targeting Linux, but not valid in the PE/COFF (Windows) environment.

Here's a breakdown:

⚠️ Warning messages explained:
lld-link: warning: ignoring unknown argument '--no-undefined' → This is a Linux/ELF flag. On Windows, this has no effect and is unknown.

lld-link: warning: ignoring unknown argument '--build-id', did you mean '-build-id' → Again, --build-id is for ELF binaries to include a unique build ID. Not valid for Windows targets.