### PR TITLE
Make peephole optimization not replace param with itself

### DIFF
--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -1034,7 +1034,7 @@ struct PeepholeContext : InstPassBase
                         break;
                     }
                 }
-                if (argValue)
+                if (argValue && argValue != inst)
                 {
                     if (inst->hasUses())
                     {

--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -1022,7 +1022,10 @@ struct PeepholeContext : InstPassBase
                     SLANG_ASSERT(terminator->getArgCount() > paramIndex);
                     auto arg = terminator->getArg(paramIndex);
                     if (arg->getOp() == kIROp_undefined)
-                        continue;
+                    {
+                        argValue = nullptr;
+                        break;
+                    }
                     if (argValue == nullptr)
                         argValue = arg;
                     else if (argValue == arg)

--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -1022,10 +1022,7 @@ struct PeepholeContext : InstPassBase
                     SLANG_ASSERT(terminator->getArgCount() > paramIndex);
                     auto arg = terminator->getArg(paramIndex);
                     if (arg->getOp() == kIROp_undefined)
-                    {
-                        argValue = nullptr;
-                        break;
-                    }
+                        continue;
                     if (argValue == nullptr)
                         argValue = arg;
                     else if (argValue == arg)

--- a/tests/bugs/gh-6860.slang
+++ b/tests/bugs/gh-6860.slang
@@ -1,0 +1,20 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+// CHECK: OpEntryPoint
+func breaker()->float {
+    var x: float;
+    for (int i = 0; i < 1; ++i) {
+        if (true) {
+        } else {
+            x = 0.0;
+        }
+    }
+    return x;
+}
+
+[shader("fragment")]
+float4 fragment(float4 in: SV_Position)
+    : SV_Target
+{
+    let res = breaker();
+    return float4(0, 0, 0, 0);
+}


### PR DESCRIPTION
Fixes #6860. The peephole optimization can get stuck in an infinite loop if changes are made on every iteration in `processFunc`. In this case, an IRParam was getting constantly replaced with itself, which marked a change on each iteration when nothing changed in reality.

Although, it's kind of interesting that this can happen in the first place. I'll probably dig around for a while in case there's something deeper happening here.