### PR TITLE
Fixed various queryInterface implementations

### DIFF
--- a/tools/gfx/debug-layer/debug-transient-heap.cpp
+++ b/tools/gfx/debug-layer/debug-transient-heap.cpp
@@ -43,7 +43,7 @@ Result DebugTransientResourceHeap::finish()
 }
 
 Result DebugTransientResourceHeap::createCommandBuffer(ICommandBuffer** outCommandBuffer)
-{ 
+{
     SLANG_GFX_API_FUNC;
     RefPtr<DebugCommandBuffer> outObject = new DebugCommandBuffer();
     outObject->m_transientHeap = this;

--- a/tools/gfx/debug-layer/debug-transient-heap.cpp
+++ b/tools/gfx/debug-layer/debug-transient-heap.cpp
@@ -14,7 +14,11 @@ namespace debug
 SlangResult DebugTransientResourceHeap::queryInterface(SlangUUID const& uuid, void** outObject)
 {
     if (uuid == GfxGUID::IID_ISlangUnknown || uuid == GfxGUID::IID_ITransientResourceHeap)
+    {
         *outObject = static_cast<ITransientResourceHeap*>(this);
+        addRef();
+        return SLANG_OK;
+    }
     if (uuid == GfxGUID::IID_ITransientResourceHeapD3D12)
     {
         RefPtr<DebugTransientResourceHeapD3D12> result = new DebugTransientResourceHeapD3D12();
@@ -22,10 +26,8 @@ SlangResult DebugTransientResourceHeap::queryInterface(SlangUUID const& uuid, vo
         returnComPtr((ITransientResourceHeapD3D12**)outObject, result);
         return SLANG_OK;
     }
-    else
-    {
-        return baseObject->queryInterface(uuid, outObject);
-    }
+
+    return baseObject->queryInterface(uuid, outObject);
 }
 
 Result DebugTransientResourceHeap::synchronizeAndReset()
@@ -41,7 +43,7 @@ Result DebugTransientResourceHeap::finish()
 }
 
 Result DebugTransientResourceHeap::createCommandBuffer(ICommandBuffer** outCommandBuffer)
-{
+{ 
     SLANG_GFX_API_FUNC;
     RefPtr<DebugCommandBuffer> outObject = new DebugCommandBuffer();
     outObject->m_transientHeap = this;

--- a/tools/gfx/renderer-shared.cpp
+++ b/tools/gfx/renderer-shared.cpp
@@ -405,8 +405,13 @@ SlangResult RendererBase::queryInterface(SlangUUID const& uuid, void** outObject
         return SLANG_OK;
     }
 
-    *outObject = getInterface(uuid);
-    return SLANG_OK;
+    if (IDevice* device_ptr = getInterface(uuid))
+    {
+        *outObject = device_ptr;
+        addRef();
+        return SLANG_OK;
+    }
+    return SLANG_E_NO_INTERFACE;
 }
 
 IDevice* gfx::RendererBase::getInterface(const Guid& guid)


### PR DESCRIPTION
Hello all,

I am doing something similar as https://github.com/shader-slang/slang/pull/5978 where i am writing COM wrappers for slang. All went good for the core slang lib and reflections APIs thus far, but i hit a few issues with the gfx wrapper.
First one is in the IDevice implementation, in the case another uuid was queried than IDevice it would return null with the OK code. This would crash when the .Net runtime tries to query the interface.

https://github.com/shader-slang/slang/blob/043278a527ab5744674417a08d924c67a60a486b/tools/gfx/renderer-shared.cpp#L398-L410

I hit another snag in the debug transient heap, weirdly the inner object was returned instead of the debug wrapper version. I supposed this was unintended looking at the code. It would cause an access violation when subsequently using the compute encoder to bind a pipeline state. Let me know if those changes are ok or if i need to adjust anything, its my first time digging and debugging this codebase!
So far i ran the shader-object, raytracing and model viewer examples without error with the changes.
I am going to continue going through the interfaces and see if i hit other issues that i can do something about.
