### PR TITLE
Avoid dead code causing broken & invalid Phi nodes

### DIFF
--- a/source/slang/slang-ir-ssa.cpp
+++ b/source/slang/slang-ir-ssa.cpp
@@ -435,8 +435,8 @@ IRInst* tryRemoveTrivialPhi(ConstructSSAContext* context, PhiInfo* phiInfo)
 
         auto parentBlock = as<IRBlock>(usedVal->parent);
         bool deadCode = usedVal->getOp() == kIROp_undefined && parentBlock &&
-            parentBlock->getPredecessors().getCount() == 0 &&
-            parentBlock->getPrevBlock() != nullptr;
+                        parentBlock->getPredecessors().getCount() == 0 &&
+                        parentBlock->getPrevBlock() != nullptr;
 
         if (usedVal == same || usedVal == phi || deadCode)
         {

--- a/source/slang/slang-ir-ssa.cpp
+++ b/source/slang/slang-ir-ssa.cpp
@@ -428,18 +428,35 @@ IRInst* tryRemoveTrivialPhi(ConstructSSAContext* context, PhiInfo* phiInfo)
     // to the phi itself.
 
     IRInst* same = nullptr;
+    IRInst* undefinedVal = nullptr;
+    bool multipleUndefined = false;
     for (auto u : phiInfo->operands)
     {
         auto usedVal = u.get();
         SLANG_ASSERT(usedVal);
 
-        if (usedVal == same || usedVal == phi || usedVal->getOp() == kIROp_undefined)
+        if (usedVal->getOp() == kIROp_undefined)
         {
-            // Either this is a self-reference, or it refers
-            // to the same value we've seen already, or it is
-            // an undefined value that can be ignored.
+            // Since undefined values are undefined, we can
+            // ignore them in favor of a defined value in
+            // the phi. We still need to keep it around
+            // though, in case we don't find any defined
+            // values and have to use it instead.
+            if (undefinedVal != usedVal && undefinedVal != nullptr)
+            {
+                multipleUndefined = true;
+            }
+            undefinedVal = usedVal;
             continue;
         }
+
+        if (usedVal == same || usedVal == phi)
+        {
+            // Either this is a self-reference, or it refers
+            // to the same value we've seen already.
+            continue;
+        }
+
         if (same != nullptr)
         {
             // We've found at least two distinct values
@@ -457,19 +474,36 @@ IRInst* tryRemoveTrivialPhi(ConstructSSAContext* context, PhiInfo* phiInfo)
         }
     }
 
+
     if (!same)
     {
-        // There were no operands other than the phi itself.
-        // This implies that the value at the use sites should
-        // actually be undefined.
-        //
-        // For now we will simply return in this case, without
-        // removing the phi node.
-        //
-        // TODO: Construct a value for `same` that represents an
-        // undefined value with the same type as `phi`.
-        //
-        return phi;
+        if (undefinedVal)
+        {
+            // Didn't find any defined values, so we'll have to make
+            // do with the undefined ones.
+            if (multipleUndefined)
+            {
+                // Multiple undefined values, so just keep the phi.
+                return phi;
+            }
+
+            // Single undefined, so proceed with it.
+            same = undefinedVal;
+        }
+        else
+        {
+            // There were no operands other than the phi itself.
+            // This implies that the value at the use sites should
+            // actually be undefined.
+            //
+            // For now we will simply return in this case, without
+            // removing the phi node.
+            //
+            // TODO: Construct a value for `same` that represents an
+            // undefined value with the same type as `phi`.
+            //
+            return phi;
+        }
     }
 
     // Removing this phi as trivial may make other phi nodes

--- a/source/slang/slang-ir-ssa.cpp
+++ b/source/slang/slang-ir-ssa.cpp
@@ -433,10 +433,17 @@ IRInst* tryRemoveTrivialPhi(ConstructSSAContext* context, PhiInfo* phiInfo)
         auto usedVal = u.get();
         SLANG_ASSERT(usedVal);
 
-        if (usedVal == same || usedVal == phi)
+        auto parentBlock = as<IRBlock>(usedVal->parent);
+        bool deadCode = usedVal->getOp() == kIROp_undefined && parentBlock &&
+            parentBlock->getPredecessors().getCount() == 0 &&
+            parentBlock->getPrevBlock() != nullptr;
+
+        if (usedVal == same || usedVal == phi || deadCode)
         {
             // Either this is a self-reference, or it refers
-            // to the same value we've seen already.
+            // to the same value we've seen already, or the
+            // value is from dead code and can therefore be
+            // ignored.
             continue;
         }
         if (same != nullptr)

--- a/source/slang/slang-ir-ssa.cpp
+++ b/source/slang/slang-ir-ssa.cpp
@@ -433,10 +433,11 @@ IRInst* tryRemoveTrivialPhi(ConstructSSAContext* context, PhiInfo* phiInfo)
         auto usedVal = u.get();
         SLANG_ASSERT(usedVal);
 
-        if (usedVal == same || usedVal == phi)
+        if (usedVal == same || usedVal == phi || usedVal->getOp() == kIROp_undefined)
         {
             // Either this is a self-reference, or it refers
-            // to the same value we've seen already.
+            // to the same value we've seen already, or it is
+            // an undefined value that can be ignored.
             continue;
         }
         if (same != nullptr)

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -11826,6 +11826,7 @@ RefPtr<IRModule> generateIRForTranslationUnit(
         insertDebugValueStore(module);
     }
 
+
     // Next, attempt to promote local variables to SSA
     // temporaries and do basic simplifications.
     //

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -11826,24 +11826,10 @@ RefPtr<IRModule> generateIRForTranslationUnit(
         insertDebugValueStore(module);
     }
 
-    IRDeadCodeEliminationOptions dceOptions = IRDeadCodeEliminationOptions();
-    dceOptions.keepExportsAlive = true;
-    dceOptions.keepLayoutsAlive = true;
-    dceOptions.useFastAnalysis = true;
-
-    // Do first pass of dead code elimination before SSA to prevent dead code
-    // blocks creating unnecessary and even broken phi nodes.
-    for (auto inst : module->getGlobalInsts())
-    {
-        if (auto func = as<IRGlobalValueWithCode>(inst))
-            eliminateDeadCode(func, dceOptions);
-    }
-
     // Next, attempt to promote local variables to SSA
     // temporaries and do basic simplifications.
     //
     constructSSA(module);
-
     applySparseConditionalConstantPropagation(module, compileRequest->getSink());
 
     bool minimumOptimizations =
@@ -11854,6 +11840,11 @@ RefPtr<IRModule> generateIRForTranslationUnit(
         auto peepholeOptions = PeepholeOptimizationOptions::getPrelinking();
         peepholeOptimize(nullptr, module, peepholeOptions);
     }
+
+    IRDeadCodeEliminationOptions dceOptions = IRDeadCodeEliminationOptions();
+    dceOptions.keepExportsAlive = true;
+    dceOptions.keepLayoutsAlive = true;
+    dceOptions.useFastAnalysis = true;
 
     for (auto inst : module->getGlobalInsts())
     {

--- a/tests/bugs/gh-6862.slang
+++ b/tests/bugs/gh-6862.slang
@@ -1,0 +1,29 @@
+//TEST:SIMPLE(filecheck=CHECK):-stage fragment -entry fragment -target wgsl
+//
+func dummy(b: StructuredBuffer<float>)->float {
+    return 0;
+}
+
+func breaker(b: StructuredBuffer<float>)->float {
+    // CHECK-NOT: var<storage, read> {{.*}} : array<f32> = {{.*}};
+    var x: float = 0;
+    for (int i = 0; i < 1; ++i) {
+        x = dummy(b);
+        if (true) {
+        } else {
+            return 0;
+            x = 0;
+        }
+    }
+    return x;
+}
+
+StructuredBuffer<float> b;
+
+[shader("fragment")]
+float4 fragment(float4 in: SV_Position)
+    : SV_Target
+{
+    let res = breaker(b);
+    return float4(res, 0, 0, 0);
+}


### PR DESCRIPTION
Fixes #6862.

```slang
func breaker(b: StructuredBuffer<float>)->float {
    var x: float = 0;
    for (int i = 0; i < 1; ++i) {
        x = dummy(b);
        if (true) {
        } else {
            return 0;
            x = 0;
        }
    }
    return x;
}
```

This one was a real doozy to debug. What's happening here, is that a phi node is inserted for `b` in the loop, because the `after`/reconvergence block of the if-else is preceded by both the empty true-branch and the `x = 0;`. There's no issue in recursively finding a value for `b` in the true-branch, because it has predecessors. However, because the `x = 0;` block is dead code, it has no predecessors and thus yields an undefined value for `b` in `readVarRec`. This means that SSA doesn't "know" that the value of 'b' never actually changes, because figuring out its value hits a false dead-end at the dead code.

So the phi for `b` has to select between the known defined value from the true-branch and an undefined value from the false-branch, and cannot be removed. This causes the creation of an unnecessary variable for `b`, which apparently isn't valid in WGSL.