### PR TITLE
Allow simplifying self-referential Phi parameters

### DIFF
--- a/source/slang/slang-ir-simplify-cfg.cpp
+++ b/source/slang/slang-ir-simplify-cfg.cpp
@@ -728,9 +728,9 @@ static bool simplifyBoolPhiParams(IRBlock* block)
 
 static bool removeTrivialPhiParams(IRBlock* block)
 {
-    // We can remove a phi parmeter if:
-    // 1. all arguments to a parameter is the same (not really a phi).
-    // 2. the arguments to the parameter is always the same as arguments to another existing
+    // We can remove a phi parameter if:
+    // 1. all non-self-referential arguments to a parameter are the same (not really a phi).
+    // 2. the arguments to the parameter are always the same as arguments to another existing
     // parameter (duplicate phi).
 
     bool changed = false;
@@ -765,7 +765,10 @@ static bool removeTrivialPhiParams(IRBlock* block)
         termInsts.add(termInst);
         for (UInt i = 0; i < termInst->getArgCount(); i++)
         {
-            if (args[i].areKnownValueSame)
+            // Self-referential parameters can be skipped, as they cannot
+            // introduce a new value. The phi can only have multiple different
+            // values if non-self-referential arguments differ.
+            if (args[i].areKnownValueSame && termInst->getArg(i) != params[i])
             {
                 if (args[i].knownValue == nullptr)
                     args[i].knownValue = termInst->getArg(i);

--- a/tests/bugs/gh-6860.slang
+++ b/tests/bugs/gh-6860.slang
@@ -1,0 +1,20 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+// CHECK: OpEntryPoint
+func breaker()->float {
+    var x: float;
+    for (int i = 0; i < 1; ++i) {
+        if (true) {
+        } else {
+            x = 0.0;
+        }
+    }
+    return x;
+}
+
+[shader("fragment")]
+float4 fragment(float4 in: SV_Position)
+    : SV_Target
+{
+    let res = breaker();
+    return float4(0, 0, 0, 0);
+}

--- a/tests/bugs/gh-6862.slang
+++ b/tests/bugs/gh-6862.slang
@@ -1,0 +1,29 @@
+//TEST:SIMPLE(filecheck=CHECK):-stage fragment -entry fragment -target wgsl
+
+func dummy(b: StructuredBuffer<float>)->float {
+    return 0;
+}
+
+func breaker(b: StructuredBuffer<float>)->float {
+    // CHECK-NOT: var<storage, read> {{.*}} : array<f32> = {{.*}};
+    var x: float = 0;
+    for (int i = 0; i < 1; ++i) {
+        x = dummy(b);
+        if (true) {
+        } else {
+            return 0;
+            x = 0;
+        }
+    }
+    return x;
+}
+
+StructuredBuffer<float> b;
+
+[shader("fragment")]
+float4 fragment(float4 in: SV_Position)
+    : SV_Target
+{
+    let res = breaker(b);
+    return float4(res, 0, 0, 0);
+}


### PR DESCRIPTION
Fixes #6862 and #6860, and supersedes #6861 and #6866.

In both cases, unnecessary phis were sticking around, as they had two options: the value before the loop, and themselves. Since in this case the only possible value it could have is the value before the loop, the phi can be removed. This fixes both issues, as both are related to unnecessary self-referential phis messing up optimization or WGSL output.