### PR TITLE
Update default branch to main

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,7 +2,7 @@ name: MDL Benchmark
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths-ignore:
       - "docs/**"
       - "LICENSES/**"
@@ -10,7 +10,7 @@ on:
       - "CONTRIBUTING.md"
       - "README.md"
   pull_request:
-    branches: [master]
+    branches: [main]
     paths-ignore:
       - "docs/**"
       - "LICENSES/**"

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -2,9 +2,9 @@ name: Check Formatting (comment /format to auto-fix)
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 jobs:
   check-formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -2,9 +2,9 @@ name: Check Table of Contents (comment /regenerate-toc to auto-fix)
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 jobs:
   check-formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/compile-regression-test.yml
+++ b/.github/workflows/compile-regression-test.yml
@@ -2,7 +2,7 @@ name: Compile Regression-Test
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths-ignore:
       - "docs/**"
       - "LICENSES/**"
@@ -10,7 +10,7 @@ on:
       - "CONTRIBUTING.md"
       - "README.md"
   pull_request:
-    branches: [master]
+    branches: [main]
     paths-ignore:
       - "docs/**"
       - "LICENSES/**"

--- a/.github/workflows/falcor-compiler-perf-test.yml
+++ b/.github/workflows/falcor-compiler-perf-test.yml
@@ -4,7 +4,7 @@ name: Falcor Compiler Perf-Test
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths-ignore:
       - "docs/**"
       - "LICENSES/**"
@@ -12,7 +12,7 @@ on:
       - "CONTRIBUTING.md"
       - "README.md"
   pull_request:
-    branches: [master]
+    branches: [main]
     paths-ignore:
       - "docs/**"
       - "LICENSES/**"

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -2,7 +2,7 @@ name: Falcor Tests
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths-ignore:
       - "docs/**"
       - "LICENSES/**"
@@ -10,7 +10,7 @@ on:
       - "CONTRIBUTING.md"
       - "README.md"
   pull_request:
-    branches: [master]
+    branches: [main]
     paths-ignore:
       - "docs/**"
       - "LICENSES/**"

--- a/.github/workflows/push-benchmark-results.yml
+++ b/.github/workflows/push-benchmark-results.yml
@@ -2,7 +2,7 @@ name: Push MDL Benchmark Results
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths-ignore:
       - "docs/**"
       - "LICENSES/**"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     # Also run on pushes to the main branch so that we can keep the llvm and sccache
     # caches filled in a scope available to everyone
     branches:
-      - master
+      - main
     paths-ignore:
       - "docs/**"
       - "LICENSES/**"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This document is designed to guide you in contributing to the project. It is int
 * When you submit a pull request, a CLA bot will determine whether you need to sign a CLA. Simply follow the instructions provided.
 * Please read and follow the contributor [Code of Conduct](CODE_OF_CONDUCT.md).
 * Bug reports and feature requests should be submitted via the GitHub issue tracker.
-* Changes should ideally come in as small pull requests on top of master, coming from your own personal fork of the project.
+* Changes should ideally come in as small pull requests on top of main, coming from your own personal fork of the project.
 * Large features that will involve multiple contributors or a long development time should be discussed in issues and broken down into smaller pieces that can be implemented and checked in stages.
 
 ## Table of Contents
@@ -244,11 +244,11 @@ When you push to your forked repository, `git-push` usually prints a URL that al
 
 If you missed a chance to use the URL, you can still create a PR from the GitHub webpage.
 Go to your forked repository and change the branch name to the one you used for `git-push`.
-It will show a message like "This branch is 1 commit ahead of `shader-slang/slang:master`."
+It will show a message like "This branch is 1 commit ahead of `shader-slang/slang:main`."
 You can create a PR by clicking on the message.
 
 ## Pull Request
-Once a PR is created against `shader-slang/slang:master`, the PR will be merged when the following conditions are met:
+Once a PR is created against `shader-slang/slang:main`, the PR will be merged when the following conditions are met:
 1. The PR is reviewed and got approval.
 1. All of the workflows pass.
 
@@ -269,8 +269,8 @@ When your branch is out of sync with top-of-tree, submit a merge commit to keep 
 
 Use these commands to sync your branch:
 ```
-$ git fetch upstream master
-$ git merge upstream/master # resolve any conflicts here
+$ git fetch upstream main
+$ git merge upstream/main # resolve any conflicts here
 $ git submodule update --recursive
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Slang
 =====
-![CI Status](https://github.com/shader-slang/slang/actions/workflows/ci.yml/badge.svg?branch=master)
+![CI Status](https://github.com/shader-slang/slang/actions/workflows/ci.yml/badge.svg?branch=main)
 ![CTS Status](https://github.com/shader-slang/slang/actions/workflows/vk-gl-cts-nightly.yml/badge.svg)
 
 Slang is a shading language that makes it easier to build and maintain large shader codebases in a modular and extensible fashion, while also maintaining the highest possible performance on modern GPUs and graphics APIs.
@@ -82,7 +82,7 @@ The following guidelines should be observed by contributors:
 
 * Please follow the contributor [Code of Conduct](CODE_OF_CONDUCT.md).
 * Bugs reports and feature requests should go through the GitHub issue tracker
-* Changes should ideally come in as small pull requests on top of `master`, coming from your own personal fork of the project
+* Changes should ideally come in as small pull requests on top of `main`, coming from your own personal fork of the project
 * Large features that will involve multiple contributors or a long development time should be discussed in issues, and broken down into smaller pieces that can be implemented and checked in in stages
 
 [Contribution guide](CONTRIBUTING.md) describes the workflow for contributors at more detail.

--- a/docs/_layouts/user-guide.html
+++ b/docs/_layouts/user-guide.html
@@ -182,7 +182,7 @@
   <div id="centeringDiv">
     <div id="navDiv">
     {% include_relative nav.html %}
-    <a class="editButton" title="Edit this page" href="https://github.com/{{ site.github.repository_nwo }}/edit/master/docs/{{ page.path }}">
+    <a class="editButton" title="Edit this page" href="https://github.com/{{ site.github.repository_nwo }}/edit/main/docs/{{ page.path }}">
       <svg class="editIcon" height="16" viewBox="0 0 16 16" version="1.1" width="16" aria-hidden="true">
         <path fill-rule="evenodd"
           d="M11.013 1.427a1.75 1.75 0 012.474 0l1.086 1.086a1.75 1.75 0 010 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 01-.927-.928l.929-3.25a1.75 1.75 0 01.445-.758l8.61-8.61zm1.414 1.06a.25.25 0 00-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 000-.354l-1.086-1.086zM11.189 6.25L9.75 4.81l-6.286 6.287a.25.25 0 00-.064.108l-.558 1.953 1.953-.558a.249.249 0 00.108-.064l6.286-6.286z">

--- a/docs/gfx-user-guide/01-getting-started.md
+++ b/docs/gfx-user-guide/01-getting-started.md
@@ -7,7 +7,7 @@ Getting Started with Slang Graphics Layer
 
 [//]: # (ShortTitle: Getting Started)
 
-In this article, we provide instructions on installing the graphics layer into your application, and demonstrate the basic use of the graphics layer via a simple compute shader example. We will use the same [hello-world.slang](https://github.com/shader-slang/slang/blob/master/examples/hello-world/hello-world.slang) shader from the `hello-world` example in the [Slang getting started tutorial](../user-guide/01-get-started.html).
+In this article, we provide instructions on installing the graphics layer into your application, and demonstrate the basic use of the graphics layer via a simple compute shader example. We will use the same [hello-world.slang](https://github.com/shader-slang/slang/blob/main/examples/hello-world/hello-world.slang) shader from the `hello-world` example in the [Slang getting started tutorial](../user-guide/01-get-started.html).
 
 Installation
 ------------------

--- a/docs/update_spirv.md
+++ b/docs/update_spirv.md
@@ -122,7 +122,7 @@ spv-amd-shader-trinary-minmax.insts.inc
 
 ## Build Slang and run slang-test
 
-There are many ways to build Slang executables. Refer to the [document](https://github.com/shader-slang/slang/blob/master/docs/building.md) for more detail.
+There are many ways to build Slang executables. Refer to the [document](https://github.com/shader-slang/slang/blob/main/docs/building.md) for more detail.
 For a quick reference, you can build with the following commands,
 ```
 cmake.exe --preset vs2019

--- a/docs/user-guide/01-get-started.md
+++ b/docs/user-guide/01-get-started.md
@@ -99,4 +99,4 @@ Note that in the generated GLSL code, all shader parameters are qualified with e
 
 ## The full example
 
-The full Vulkan example that sets up and runs the `hello-world.slang` shader is located in the [/examples/hello-world](https://github.com/shader-slang/slang/tree/master/examples/hello-world) directory of the Slang repository. The example code initializes a Vulkan context and runs the compiled SPIRV code. The example code demonstrates how to use the Slang API to load and compile shaders.
+The full Vulkan example that sets up and runs the `hello-world.slang` shader is located in the [/examples/hello-world](https://github.com/shader-slang/slang/tree/main/examples/hello-world) directory of the Slang repository. The example code initializes a Vulkan context and runs the compiled SPIRV code. The example code demonstrates how to use the Slang API to load and compile shaders.

--- a/docs/user-guide/05-capabilities.md
+++ b/docs/user-guide/05-capabilities.md
@@ -25,7 +25,7 @@ a `discard` statement, it shall be a type-check error.
 ## Capability Atoms and Capability Requirements
 
 Slang models code generation targets, shader stages, API extensions and hardware features as distinct capability atoms. For example, `GLSL_460` is a capability atom that stands for the GLSL 460 code generation target,
-`compute` is an atom that represents the compute shader stage, `_sm_6_7` is an atom representing the shader model 6.7 feature set in D3D, `SPV_KHR_ray_tracing` is an atom representing the `SPV_KHR_ray_tracing` SPIR-V extension, and `spvShaderClockKHR` is an atom for the `ShaderClockKHR` SPIRV capability. For a complete list of capabilities supported by the Slang compiler, check the [capability definition file](https://github.com/shader-slang/slang/blob/master/source/slang/slang-capabilities.capdef).
+`compute` is an atom that represents the compute shader stage, `_sm_6_7` is an atom representing the shader model 6.7 feature set in D3D, `SPV_KHR_ray_tracing` is an atom representing the `SPV_KHR_ray_tracing` SPIR-V extension, and `spvShaderClockKHR` is an atom for the `ShaderClockKHR` SPIRV capability. For a complete list of capabilities supported by the Slang compiler, check the [capability definition file](https://github.com/shader-slang/slang/blob/main/source/slang/slang-capabilities.capdef).
 
 A capability **requirement** can be a single capability atom, a conjunction of capability atoms, or a disjunction of conjunction of capability atoms. A function can declare its
 capability requirement with the following syntax:

--- a/docs/user-guide/07-autodiff.md
+++ b/docs/user-guide/07-autodiff.md
@@ -555,7 +555,7 @@ Most often, this is because a lot of shader operations may just not have a funct
 texture sampling. In such cases, Slang provides a `[PrimalSubstitute(fn)]` attribute that can be used to provide
 a reference implementation that Slang can differentiate to generate the derivative function.
 
-The following is a small snippet with bilinear texture sampling. For a full example application that uses this concept, see the [texture differentiation sample](https://github.com/shader-slang/slang/tree/master/examples/autodiff-texture) in the Slang repository.
+The following is a small snippet with bilinear texture sampling. For a full example application that uses this concept, see the [texture differentiation sample](https://github.com/shader-slang/slang/tree/main/examples/autodiff-texture) in the Slang repository.
 
 ```csharp
 [PrimalSubstitute(sampleTextureBiliear_reference)]

--- a/docs/user-guide/08-compiling.md
+++ b/docs/user-guide/08-compiling.md
@@ -150,7 +150,7 @@ The `slangc` tool, included in binary distributions of Slang, is a command-line 
 
 ### All Available Options
 
-See [slangc command line reference](https://github.com/shader-slang/slang/blob/master/docs/command-line-slangc-reference.md) for a complete list of compiler options supported by the `slangc` tool.
+See [slangc command line reference](https://github.com/shader-slang/slang/blob/main/docs/command-line-slangc-reference.md) for a complete list of compiler options supported by the `slangc` tool.
 
 
 ### A Simple `slangc` Example
@@ -271,7 +271,7 @@ The main other options are:
 
 * `-O<level>` can be used to control optimization levels when the Slang compiler invokes downstream code generator
 
-See [slangc command line reference](https://github.com/shader-slang/slang/blob/master/docs/command-line-slangc-reference.md) for a complete list of compiler options supported by the `slangc` tool.
+See [slangc command line reference](https://github.com/shader-slang/slang/blob/main/docs/command-line-slangc-reference.md) for a complete list of compiler options supported by the `slangc` tool.
 
 ### Downstream Arguments
 

--- a/docs/user-guide/09-reflection.md
+++ b/docs/user-guide/09-reflection.md
@@ -14,7 +14,7 @@ Our goals in this chapter are to:
 * Provide an underlying mental model for how Slang's reflection information represents the structure of a program
 
 We will describe the structure of a program that traverses all of the parameters of a shader program and prints information (including binding locations) for them.
-The code shown here is derived from the [reflection-api](https://github.com/shader-slang/slang/tree/master/examples/reflection-api) example that is included in the Slang repository.
+The code shown here is derived from the [reflection-api](https://github.com/shader-slang/slang/tree/main/examples/reflection-api) example that is included in the Slang repository.
 Readers may find it helpful to follow along with that code, to see a more complete picture of what is presented here.
 
 Compiling a Program

--- a/examples/nv-aftermath-example/README.md
+++ b/examples/nv-aftermath-example/README.md
@@ -2,7 +2,7 @@ Nsight Aftermath Crash Example
 ==============================
 
 * Demonstrates use of aftermath API to capture a dump with a GPU crash
-* Uses the [obfuscation feature](https://github.com/shader-slang/slang/blob/master/docs/user-guide/a1-03-obfuscation.md)
+* Uses the [obfuscation feature](https://github.com/shader-slang/slang/blob/main/docs/user-guide/a1-03-obfuscation.md)
 * Uses an `emit` source map
 * Demonstrates use of file system compile products
 * Forces a crash via time out, executing a shader that is purposefully slow
@@ -33,7 +33,7 @@ Typically D3D12 debug run produces the following files...
 * aftermath-dump-X.bin          - The Aftermath crash capture/s
 * aftermath-debug-info-X.bin    - The Aftermath debug info/s
 
-Having emit source maps, can be useful as discussed in [the documentation](https://github.com/shader-slang/slang/blob/master/docs/user-guide/a1-03-obfuscation.md#emit-source-maps), but isn't a requirement. If emit source maps are disabled the source maps `fragment-0.map`/`vertex-0.map` will *not* be produced. In this scenario the mapping to the obfuscated source file is embedded into the kernel/s directly. 
+Having emit source maps, can be useful as discussed in [the documentation](https://github.com/shader-slang/slang/blob/main/docs/user-guide/a1-03-obfuscation.md#emit-source-maps), but isn't a requirement. If emit source maps are disabled the source maps `fragment-0.map`/`vertex-0.map` will *not* be produced. In this scenario the mapping to the obfuscated source file is embedded into the kernel/s directly. 
 
 A Vulkan run will emit "spv" files, D3D12 will emit "dxil" files and D3D11 will emit "dxbc" files. 
 
@@ -42,5 +42,5 @@ The example source describes how to switch between emit source files, and differ
 ## Links
 
 * [nsight aftermath](https://developer.nvidia.com/nsight-aftermath)
-* [obfuscation](https://github.com/shader-slang/slang/blob/master/docs/user-guide/a1-03-obfuscation.md)
+* [obfuscation](https://github.com/shader-slang/slang/blob/main/docs/user-guide/a1-03-obfuscation.md)
 * [source map](https://github.com/source-map/source-map-spec)

--- a/examples/nv-aftermath-example/main.cpp
+++ b/examples/nv-aftermath-example/main.cpp
@@ -26,7 +26,7 @@ static const ExampleResources resourceBase("nv-aftermath-example");
 // In addition it uses obfuscation and source maps to allow source level
 // debugging via aftermath even with obfuscation.
 //
-// * [obfuscation](https://github.com/shader-slang/slang/blob/master/docs/user-guide/a1-03-obfuscation.md)
+// * [obfuscation](https://github.com/shader-slang/slang/blob/main/docs/user-guide/a1-03-obfuscation.md)
 // * [source map](https://github.com/source-map/source-map-spec)
 
 struct Vertex

--- a/tests/experiments/generic/alternative-array-type.slang
+++ b/tests/experiments/generic/alternative-array-type.slang
@@ -2,7 +2,7 @@
 
 /* The docs claim that for arrays we can use the 'alternate' style 
 
-https://github.com/shader-slang/slang/blob/master/docs/language-reference/04-types.md
+https://github.com/shader-slang/slang/blob/main/docs/language-reference/04-types.md
 
 > int[10] a;
 

--- a/tests/experiments/generic/equality-3.slang
+++ b/tests/experiments/generic/equality-3.slang
@@ -4,7 +4,7 @@
 
 This style is discussed in the documentation here (on This type):
 
-https://github.com/shader-slang/slang/blob/master/docs/user-guide/04-interfaces-generics.md
+https://github.com/shader-slang/slang/blob/main/docs/user-guide/04-interfaces-generics.md
 
 Still has limitiation that it only works for an an implementation of an interface.  
  */

--- a/tests/experiments/generic/inheritance.slang
+++ b/tests/experiments/generic/inheritance.slang
@@ -6,7 +6,7 @@ Works.
 
 Docs state inheritance isn't available (although states it might in the future).
 
-https://github.com/shader-slang/slang/blob/master/docs/language-reference/07-declarations.md
+https://github.com/shader-slang/slang/blob/main/docs/language-reference/07-declarations.md
 
 > Currently only interface types may be named in the inheritance clause of a structure type. When a structure type declares that it inherits from an interface, the programmer asserts that the structure type implements the required members of the interface.
 

--- a/tests/experiments/generic/interface.slang
+++ b/tests/experiments/generic/interface.slang
@@ -7,7 +7,7 @@ interface IThing<T>
 */
 
 // Docs say this should work...
-// https://github.com/shader-slang/slang/blob/master/docs/language-reference/07-declarations.md
+// https://github.com/shader-slang/slang/blob/main/docs/language-reference/07-declarations.md
 
 interface IThing<T>
 {

--- a/tools/slang-test/README.md
+++ b/tools/slang-test/README.md
@@ -112,7 +112,7 @@ slang-test slang-unit-test-tool/<test-name>
 # e.g. run the `byteEncode` test.
 slang-test slang-unit-test-tool/byteEncode
 ```
-These tests are located in the [tools/slang-unit-test](https://github.com/shader-slang/slang/tree/master/tools/slang-unit-test) directory, and defined with macros like `SLANG_UNIT_TEST(byteEncode)`.
+These tests are located in the [tools/slang-unit-test](https://github.com/shader-slang/slang/tree/main/tools/slang-unit-test) directory, and defined with macros like `SLANG_UNIT_TEST(byteEncode)`.
 
 ### gfx-unit-test-tool
 ```bash
@@ -122,4 +122,4 @@ slang-test gfx-unit-test-tool/<test-name>
 # e.g. run the `precompiledTargetModule2Vulkan` test.
 slang-test gfx-unit-test-tool/precompiledTargetModule2Vulkan
 ```
-These tests are located in [tools/gfx-unit-test](https://github.com/shader-slang/slang/tree/master/tools/gfx-unit-test), and likewise defined using macros like `SLANG_UNIT_TEST(precompiledTargetModule2Vulkan)`.
+These tests are located in [tools/gfx-unit-test](https://github.com/shader-slang/slang/tree/main/tools/gfx-unit-test), and likewise defined using macros like `SLANG_UNIT_TEST(precompiledTargetModule2Vulkan)`.


### PR DESCRIPTION
Migrate slang repo to use default branch as main
instead of master.