### PR TITLE
Fix attempt to construct an abstract AST node

### DIFF
--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -880,7 +880,7 @@ void SemanticsStmtVisitor::tryInferLoopMaxIterations(ForStmt* stmt)
     // if the loop body modifies the induction variable.
     //
     auto maxItersAttr = m_astBuilder->create<InferredMaxItersAttribute>();
-    auto litExpr = m_astBuilder->create<LiteralExpr>();
+    auto litExpr = m_astBuilder->create<IntegerLiteralExpr>();
     litExpr->type.type = m_astBuilder->getIntType();
     litExpr->token.setName(getNamePool()->getName(String(iterations)));
     maxItersAttr->args.add(litExpr);

--- a/tests/bugs/serialization/gh-6892.slang
+++ b/tests/bugs/serialization/gh-6892.slang
@@ -1,0 +1,9 @@
+//TEST:COMPILE: tests/bugs/serialization/gh-6892.slang -o tests/bugs/serialization/gh-6892.slang-module
+
+// assertion failure when compiling to a slang module
+
+void f()
+{
+    for (int i = 0; i < 1; ++i)
+        ;
+}


### PR DESCRIPTION
Work on #6892

The function `tryInferLoopMaxIterations` in `slang-check-stmt.cpp` was doing:

    auto litExpr = m_astBuilder->create<LiteralExpr>();

but the declaration of `LiteralExpr` in `slang-ast-expr.h` had been marked as abstract, during the switch to using the `slang-fiddle` tool to generate code:

    FIDDLE(abstract)
    class LiteralExpr : public Expr
    { ... }

In this case, the intention of the AST design is that `LiteralExpr` should be kept abstract, and only the concrete subclasses should ever be instantiated.

Because of some historical design choices, the `ASTNodeType` enumeration includes both the concrete and abstract AST classes, so the code ended up constructing a `LiteralExpr` that had the tag `ASTNodeType::LiteralExpr`. Then attempts to use the `ASTNodeDispatcher` code on such a node caused crashes, because the dispatcher code only included `case` statements for the non-abstract `ASTNodeType`s.

The quick fix here was to change the `tryInferLoopMaxIterations` function to instead do:

    auto litExpr = m_astBuilder->create<IntegerLiteralExpr>();

A test case was added to help catch any future regressions on this specific issue.

A more long-term fix should involve introducing code that statically and/or dynamically prohibits the creation of instances of AST node classes that have been marked abstract.