### PR TITLE
Update falcor perf test path

### DIFF
--- a/.github/workflows/falcor-compiler-perf-test.yml
+++ b/.github/workflows/falcor-compiler-perf-test.yml
@@ -100,5 +100,5 @@ jobs:
         run: |
           $filename = '${{ fromJson(steps.download.outputs.downloaded_files)[0] }}'
           Expand-Archive $filename -DestinationPath .\falcor-perf-test
-          $env:PATH += ";.\build\${{matrix.config}}\bin";
+          $env:PATH = ".\build\${{matrix.config}}\bin;" + $env:PATH
           .\falcor-perf-test\bin\Release\falcor_perftest.exe


### PR DESCRIPTION
Update the falcor perf test path environment variable so that it checks existing paths only after the build path. This is needed to prevent it from accidentally using a previously installed version of Slang.