### PR TITLE
Add readthedocs tables of contents to Slang User Guide

### DIFF
--- a/docs/user-guide/a1-special-topics.md
+++ b/docs/user-guide/a1-special-topics.md
@@ -13,3 +13,16 @@ In this chapter:
 3. [Obfuscation](a1-03-obfuscation.md)
 4. [Interoperation with target-specific code](a1-04-interop.md)
 5. [Uniformity Analysis](a1-05-uniformity.md)
+
+<!-- RTD-TOC-START
+```{toctree}
+:titlesonly:
+:hidden:
+
+Handling Matrix Layout Differences on Different Platforms <a1-01-matrix-layout>
+Using Slang to Write PyTorch Kernels <a1-02-slangpy>
+Obfuscation <a1-03-obfuscation>
+Interoperation with Target-Specific Code <a1-04-interop>
+Uniformity Analysis <a1-05-uniformity>
+```
+RTD-TOC-END -->

--- a/docs/user-guide/a2-target-specific-features.md
+++ b/docs/user-guide/a2-target-specific-features.md
@@ -11,3 +11,14 @@ In this chapter:
 1. [SPIR-V target specific](./a2-01-spirv-target-specific.md)
 2. [Metal target specific](./a2-02-metal-target-specific.md)
 3. [WGSL target specific](./a2-03-wgsl-target-specific.md)
+
+<!-- RTD-TOC-START
+```{toctree}
+:titlesonly:
+:hidden:
+
+SPIR-V target specific <a2-01-spirv-target-specific>
+Metal target specific <a2-02-metal-target-specific>
+WGSL target specific <a2-03-wgsl-target-specific>
+```
+RTD-TOC-END -->

--- a/docs/user-guide/a3-reference.md
+++ b/docs/user-guide/a3-reference.md
@@ -9,3 +9,13 @@ Reference
 In this chapter:
 1. [Reference for all Capability Profiles](a3-01-reference-capability-profiles.md)
 2. [Reference for all Capability Atoms](a3-02-reference-capability-atoms.md)
+
+<!-- RTD-TOC-START
+```{toctree}
+:titlesonly:
+:hidden:
+
+Reference for all Capability Profiles <a3-01-reference-capability-profiles>
+Reference for all Capability Atoms <a3-02-reference-capability-atoms>
+```
+RTD-TOC-END -->

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -11,3 +11,26 @@ Welcome to the Slang User's Guide, an introduction to the Slang language, compil
 - The reflection API that allows the host application to query the details of shader code in order to generate the right shader kernel and to set shader parameters correctly.
 
 Note: this documentation is still under active development. While the coverage on language features is complete, we are still working on the remaining chapters on Slang's compilation and reflection API.
+
+<!-- RTD-TOC-START
+```{toctree}
+:titlesonly:
+:hidden:
+
+Introduction <00-introduction>
+Getting Started with Slang <01-get-started>
+Conventional Language Features <02-conventional-features>
+Basic Convenience Features <03-convenience-features>
+Modules and Access Control <04-modules-and-access-control>
+Capabilities <05-capabilities>
+Interfaces and Generics <06-interfaces-generics>
+Automatic Differentiation <07-autodiff>
+Compiling Code with Slang <08-compiling>
+Using the Reflection API <09-reflection>
+Supported Compilation Targets <09-targets>
+Link-time Specialization and Module Precompilation <10-link-time-specialization>
+Special Topics <a1-special-topics>
+Target-specific Features <a2-target-specific-features>
+Reference <a3-reference>
+```
+RTD-TOC-END -->


### PR DESCRIPTION
For https://github.com/shader-slang/shader-slang.github.io/issues/72

This change adds hidden (commented out) tables of contents to the index of the User Guide, as well as each of the additional chapters, so that readthedocs will render the User Guide structure.