### PR TITLE
Update C++ standard to C++20

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -175,7 +175,7 @@ function(set_default_compile_options target)
             ON
             # C++ standard
             CXX_STANDARD
-            17
+            20
             # pic
             POSITION_INDEPENDENT_CODE
             ON

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -752,7 +752,7 @@ String Path::getRelativePath(String base, String path)
     auto result = std::filesystem::relative(p2, p1, ec);
     if (ec)
         return path;
-    return String(UnownedStringSlice(result.generic_u8string().c_str()));
+    return String(reinterpret_cast<const char*>(result.generic_u8string().c_str()));
 }
 
 SlangResult Path::remove(const String& path)

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -7,9 +7,6 @@
 // similar in spirit to LLVM (but much simpler).
 //
 
-#if defined(__cpp_lib_bit_cast)
-#include <bit>
-#endif
 #include "../compiler-core/slang-source-loc.h"
 #include "../compiler-core/slang-source-map.h"
 #include "../core/slang-basic.h"
@@ -17,6 +14,7 @@
 #include "slang-container-pool.h"
 #include "slang-type-system-shared.h"
 
+#include <bit>
 #include <functional>
 
 namespace Slang
@@ -105,11 +103,7 @@ enum IRMemoryOrder
 
 inline int32_t operator&(const IROpMask m, const IROp o)
 {
-#if defined(__cpp_lib_bit_cast)
     return std::bit_cast<int32_t>(m) & std::bit_cast<int32_t>(o);
-#else
-    return (int32_t)m & (int32_t)o;
-#endif
 }
 
 inline int32_t operator&(const IROp o, const IROpMask m)

--- a/tools/gfx/metal/metal-device.cpp
+++ b/tools/gfx/metal/metal-device.cpp
@@ -562,7 +562,7 @@ Result DeviceImpl::createBufferResource(
         resourceOptions = MTL::ResourceStorageModePrivate;
         break;
     case MemoryType::Upload:
-        resourceOptions = MTL::ResourceStorageModeShared | MTL::CPUCacheModeWriteCombined;
+        resourceOptions = MTL::ResourceStorageModeShared | MTL::ResourceCPUCacheModeWriteCombined;
         break;
     case MemoryType::ReadBack:
         resourceOptions = MTL::ResourceStorageModeShared;
@@ -584,7 +584,7 @@ Result DeviceImpl::createBufferResource(
         NS::SharedPtr<MTL::Buffer> stagingBuffer = NS::TransferPtr(m_device->newBuffer(
             initData,
             bufferSize,
-            MTL::ResourceStorageModeShared | MTL::CPUCacheModeWriteCombined));
+            MTL::ResourceStorageModeShared | MTL::ResourceCPUCacheModeWriteCombined));
         MTL::CommandBuffer* commandBuffer = m_commandQueue->commandBuffer();
         MTL::BlitCommandEncoder* encoder = commandBuffer->blitCommandEncoder();
         if (!stagingBuffer || !commandBuffer || !encoder)

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -58,7 +58,7 @@ extern "C"
 
 extern "C"
 {
-    __declspec(dllexport) extern const char* D3D12SDKPath = u8".\\D3D12\\";
+    __declspec(dllexport) extern const char* D3D12SDKPath = ".\\D3D12\\";
 }
 #endif
 

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -28,7 +28,7 @@ extern "C"
 
 extern "C"
 {
-    __declspec(dllexport) extern const char* D3D12SDKPath = u8".\\D3D12\\";
+    __declspec(dllexport) extern const char* D3D12SDKPath = ".\\D3D12\\";
 }
 #endif
 


### PR DESCRIPTION
Closes https://github.com/shader-slang/slang/issues/6945

Updated https://github.com/shader-slang/slang/issues/5537 to include c++17 header check