### PR TITLE
Fix intermittent failure of slang-unit-test-tool/ReplayRecord

### DIFF
--- a/examples/example-winmain/main.cpp
+++ b/examples/example-winmain/main.cpp
@@ -1,3 +1,4 @@
+#define _CRT_SECURE_NO_WARNINGS
 #include "../stacktrace-windows/common.h"
 
 #include <stdio.h>

--- a/examples/stacktrace-windows/common.cpp
+++ b/examples/stacktrace-windows/common.cpp
@@ -163,7 +163,7 @@ int exceptionFilter(FILE* logFile, _EXCEPTION_POINTERS* exception)
     FILE* file = logFile ? logFile : stdout;
     fprintf(
         file,
-        "error: Exception 0x%x occurred. Stack trace:\n",
+        "error: Exception 0x%lx occurred. Stack trace:\n",
         exception->ExceptionRecord->ExceptionCode);
 
     HANDLE process = GetCurrentProcess();

--- a/tools/gfx/d3d12/d3d12-shader-table.cpp
+++ b/tools/gfx/d3d12/d3d12-shader-table.cpp
@@ -61,6 +61,8 @@ RefPtr<BufferResource> ShaderTableImpl::createDeviceBuffer(
         if (name.getLength())
         {
             void* shaderId = stateObjectProperties->GetShaderIdentifier(name.toWString().begin());
+            if (nullptr == shaderId)
+                throw Exception(String("Failed to get shader identifier for '") + name + "'");
             memcpy(dest, shaderId, D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES);
         }
         if (overwrite.size)

--- a/tools/slang-unit-test/unit-test-record-replay.cpp
+++ b/tools/slang-unit-test/unit-test-record-replay.cpp
@@ -268,6 +268,11 @@ static SlangResult replayExample(UnitTestContext* context, List<entryHashInfo>& 
 {
     List<String> fileNames;
     findRecordFileName(&fileNames);
+    if (fileNames.getCount() == 0)
+    {
+        getTestReporter()->message(TestMessageType::TestFailure, "No record files found\n");
+        return SLANG_FAIL;
+    }
 
     List<String> optArgs;
     String recordFileName = Path::combine("slang-record", fileNames[0]);
@@ -406,7 +411,7 @@ static SlangResult runTest(UnitTestContext* context, const char* testName)
     }
 
 error:
-    res = cleanupRecordFiles();
+    cleanupRecordFiles();
     return res;
 }
 


### PR DESCRIPTION
Three problems are fixed:
    1. the graphics driver sometimes returns nullptr from `GetShaderIdentifier()`,
    2. `findRecordFileName()` may not find any records at all,
    3. the return value from cleanupRecordFiles() overwrote the error value in `res` and it returned SLANG_OK even when there were errors.