### PR TITLE
Fix seg-fault in cudaCodeGenBug test

### DIFF
--- a/tools/slang-fiddle/slang-fiddle-scrape.cpp
+++ b/tools/slang-fiddle/slang-fiddle-scrape.cpp
@@ -179,6 +179,7 @@ public:
             _sink.diagnose(SourceLoc(), fiddle::Diagnostics::internalError);
             return nullptr;
         }
+        return nullptr;
     }
 
     RefPtr<Expr> parseCppExpr()

--- a/tools/slang-unit-test/unit-test-find-check-entrypoint.cpp
+++ b/tools/slang-unit-test/unit-test-find-check-entrypoint.cpp
@@ -133,6 +133,5 @@ SLANG_UNIT_TEST(cudaCodeGenBug)
     ComPtr<slang::IBlob> code;
     auto res = linkedProgram->getEntryPointCode(0, 0, code.writeRef(), diagnosticBlob.writeRef());
     SLANG_CHECK(res == SLANG_OK);
-    SLANG_CHECK(code != nullptr);
-    SLANG_CHECK(code->getBufferSize() != 0);
+    SLANG_CHECK(code != nullptr && code->getBufferSize() != 0);
 }


### PR DESCRIPTION
`cudaCodeGenBug` is expected to fail on Linux, because the variable `code` is nullptr. When the next test tried to dereference, it causes a seg-fault.