### PR TITLE
Fix the intermittent failures of tests/autodiff/auto-differential-type

### DIFF
--- a/source/core/slang-stream.cpp
+++ b/source/core/slang-stream.cpp
@@ -162,10 +162,15 @@ SlangResult FileStream::_init(
         SLANG_ASSERT(!"Invalid file share mode.");
         return SLANG_FAIL;
     }
+
     if (share == FileShare::None)
-        _wfopen_s(&m_handle, fileName.toWString(), wideMode);
+    {
+        m_handle = _wfsopen(fileName.toWString(), wideMode, _SH_DENYNO);
+    }
     else
+    {
         m_handle = _wfsopen(fileName.toWString(), wideMode, shFlag);
+    }
 #else
     m_handle = fopen(fileName.getBuffer(), mode);
 #endif


### PR DESCRIPTION
Closes https://github.com/shader-slang/slang/issues/6974

The use of `_wfopen_s()` was incorrect in a way the the result value had to be checked.

However, even with a proper handling of the failed case, the repro-rate was same.

The issue was reproduced at 5%~20% rate with the following commands,
  build/Release/bin/slang-test.exe tests/autodiff/auto-differential-type -api dx11 -use-test-server -server-count 8

_wfsopen appears to be a good alternative.
The intermittency failure is not observed with it; tried 1,000 times and no repro.