### PR TITLE
Cleanups related to RIFF support

### DIFF
--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -152,6 +152,9 @@ Versions
 `hlsl_nvapi`
 > Represents HLSL NVAPI support.
 
+`hlsl_2018`
+> Represet HLSL compatibility support.
+
 `dxil_lib`
 > Represents capabilities required for DXIL Library compilation.
 

--- a/examples/ray-tracing/main.cpp
+++ b/examples/ray-tracing/main.cpp
@@ -423,13 +423,13 @@ struct RayTracing : public WindowedAppBase
             IBufferResource::Desc asBufferDesc;
             asBufferDesc.type = IResource::Type::Buffer;
             asBufferDesc.defaultState = ResourceState::AccelerationStructure;
-            asBufferDesc.sizeInBytes = (Size)compactedSize;
+            asBufferDesc.sizeInBytes = (gfx::Size)compactedSize;
             gBLASBuffer = gDevice->createBufferResource(asBufferDesc);
             IAccelerationStructure::CreateDesc createDesc;
             createDesc.buffer = gBLASBuffer;
             createDesc.kind = IAccelerationStructure::Kind::BottomLevel;
             createDesc.offset = 0;
-            createDesc.size = (Size)compactedSize;
+            createDesc.size = (gfx::Size)compactedSize;
             gDevice->createAccelerationStructure(createDesc, gBLAS.writeRef());
 
             commandBuffer = gTransientHeaps[0]->createCommandBuffer();

--- a/source/core/slang-char-encode.h
+++ b/source/core/slang-char-encode.h
@@ -21,7 +21,7 @@ template<typename ReadByteFunc>
 Char32 getUnicodePointFromUTF8(const ReadByteFunc& readByte)
 {
     Char32 codePoint = 0;
-    uint32_t leading = Byte(readByte());
+    uint32_t leading = uint32_t(readByte());
     uint32_t mask = 0x80;
     Index count = 0;
     while (leading & mask)

--- a/source/core/slang-common.h
+++ b/source/core/slang-common.h
@@ -4,6 +4,7 @@
 #include "slang.h"
 
 #include <assert.h>
+#include <cstddef>
 #include <stdint.h>
 
 #define VARIADIC_TEMPLATE
@@ -11,35 +12,155 @@
 namespace Slang
 {
 
+/// Signed 32-bit integer.
+///
+/// This type should be used when the exact size
+/// in bits is important (e.g., when dealing with
+/// explicit binary file formats, etc.). Otherwise
+/// prefer the plain `Int` type or a semantically
+/// richer type like `Count` or `Index`.
+///
 typedef int32_t Int32;
+
+/// Unsigned 32-bit integer.
+///
+/// This type should be used when the exact size
+/// in bits is important (e.g., when dealing with
+/// explicit binary file formats, etc.). Otherwise
+/// prefer the plain `Int` type or a semantically
+/// richer type like `Count` or `Index`.
+///
 typedef uint32_t UInt32;
 
+/// Signed 64-bit integer.
+///
+/// This type should be used when the exact size
+/// in bits is important (e.g., when dealing with
+/// explicit binary file formats, etc.). Otherwise
+/// prefer the plain `Int` type or a semantically
+/// richer type like `Count` or `Index`.
+///
 typedef int64_t Int64;
+
+/// Unsigned 64-bit integer.
+///
+/// This type should be used when the exact size
+/// in bits is important (e.g., when dealing with
+/// explicit binary file formats, etc.). Otherwise
+/// prefer the plain `Int` type or a semantically
+/// richer type like `Count` or `Index`.
+///
 typedef uint64_t UInt64;
 
-// Define
-typedef SlangUInt UInt;
+/// "Default" integer type for the Slang codebase.
+///
+/// When there is not a clear reason to another
+/// integer type, use this one.
+///
+/// Note that this type is currently defined to be
+/// the same as the `SlangInt` type exposed through
+/// the public Slang API, but this may not be the
+/// case forever.
+///
 typedef SlangInt Int;
+
+/// "Default" unsigned integer type for the Slang codebase.
+///
+/// Only use this type when you explicitly need
+/// an unsigned type that's the same size as `Int`.
+/// Otherwise you should probably just be using `Int`.
+///
+/// Note that this type is currently defined to be
+/// the same as the `SlangUInt` type exposed through
+/// the public Slang API, but this may not be the
+/// case forever.
+///
+typedef SlangUInt UInt;
 
 static const UInt kMaxUInt = ~UInt(0);
 static const Int kMaxInt = Int(kMaxUInt >> 1);
 
-//	typedef unsigned short Word;
-
 typedef intptr_t PtrInt;
 
-// TODO(JS): It looks like Index is actually 64 bit on 64 bit targets(!)
-// Previous discussions landed on Index being int32_t.
-
-// Type used for indexing, in arrays/views etc. Signed.
+/// Default type for indices.
+///
+/// This is (and should always be) an alias for `Int`.
+///
+/// Use this type to document the intention that an
+/// integer parameter/variable/etc. represents an
+/// index into some kind of sequence, or any other
+/// kind of ordinal number.
+///
 typedef Int Index;
-typedef UInt UIndex;
-typedef Int Count;
-typedef UInt UCount;
 
 static const Index kMaxIndex = kMaxInt;
 
-typedef uint8_t Byte;
+/// Unsigned equivalent of `Index`.
+///
+/// Please don't use this unless you have a good reason.
+///
+typedef UInt UIndex;
+
+/// Default type for counts.
+///
+/// This is (and should always be) an alias for `Int`.
+///
+/// Use this type to document the intention that an
+/// integer parameter/variable/etc. represents a
+/// count of the number of elements in some container,
+/// or any other kind of cardinal number.
+///
+typedef Int Count;
+
+/// Unsigned equivalent of `Count`.
+///
+/// Please don't use this unless you have a good reason.
+///
+typedef UInt UCount;
+
+
+/// Explicit type for when manipulating bytes.
+///
+/// Use this type to document the intention that a
+/// parameter/variable/etc. represents an 8-bit byte, with
+/// no particular interpretation of that byte as
+/// any higher-level type.
+///
+/// Note that the `char` types have special semantics
+/// when it comes to "type punning" that are not shared
+/// with other types like `uint8_t`. Using a variation
+/// of `char` here helps avoid the possibility of undefined
+/// behavior when code reads other types to/from arrays
+/// of `Byte`s.
+///
+/// We are not using `std::byte` here because that is
+/// defined as an `enum class` and does not support
+/// mathematical or bitwise operations, which a lot
+/// of the Slang codebase does on `Byte`s.
+///
+typedef unsigned char Byte;
+
+/// Preferred integer type for sizes measured in bytes.
+///
+/// Use this type to document the intention that an
+/// integer parameter/variable/etc. represents the
+/// size of something, in bytes, rather than being
+/// some other kind of integer.
+///
+/// Comparable to the `isize` type in Rust.
+///
+using Size = intptr_t;
+
+/// Unsigned integer type for sizes measured in bytes.
+///
+/// This is the unsigned equivalent of `Size`.
+/// By convention, code in the Slang codebase should
+/// default to using signed types like `Size` whenever
+/// possible, especially in the public API of types/subsystems.
+///
+/// Comparable to the `usize` type in Rust.
+///
+using USize = uintptr_t;
 
 // TODO(JS):
 // Perhaps these should be named Utf8, Utf16 and UnicodePoint/Rune/etc? For now, just keep it simple

--- a/source/core/slang-common.h
+++ b/source/core/slang-common.h
@@ -147,20 +147,15 @@ typedef unsigned char Byte;
 /// size of something, in bytes, rather than being
 /// some other kind of integer.
 ///
-/// Comparable to the `isize` type in Rust.
+/// Note that this type is unsigned, despite the stated
+/// default in the Slang codebase being signed integer
+/// types. The reason for this is that variables
+/// holding sizes are often compared against the
+/// result of the `sizeof` operator, which yields
+/// a `size_t`. Our hands are, to some extent, tied
+/// on this matter.
 ///
-using Size = intptr_t;
-
-/// Unsigned integer type for sizes measured in bytes.
-///
-/// This is the unsigned equivalent of `Size`.
-/// By convention, code in the Slang codebase should
-/// default to using signed types like `Size` whenever
-/// possible, especially in the public API of types/subsystems.
-///
-/// Comparable to the `usize` type in Rust.
-///
-using USize = uintptr_t;
+using Size = size_t;
 
 // TODO(JS):
 // Perhaps these should be named Utf8, Utf16 and UnicodePoint/Rune/etc? For now, just keep it simple

--- a/source/core/slang-riff-file-system.cpp
+++ b/source/core/slang-riff-file-system.cpp
@@ -117,14 +117,10 @@ SlangResult RiffFileSystem::saveFileBlob(const char* path, ISlangBlob* dataBlob)
 SlangResult RiffFileSystem::loadArchive(const void* archive, size_t archiveSizeInBytes)
 {
     // Load the riff
-    RiffContainer container;
+    auto rootList = RIFF::RootChunk::getFromBlob(archive, archiveSizeInBytes);
 
-    MemoryStreamBase stream(FileAccess::Read, archive, archiveSizeInBytes);
-    SLANG_RETURN_ON_FAIL(RiffUtil::read(&stream, container));
-
-    RiffContainer::ListChunk* rootList = container.getRoot();
     // Make sure it's the right type
-    if (rootList == nullptr || rootList->m_fourCC != RiffFileSystemBinary::kContainerFourCC)
+    if (rootList == nullptr || rootList->getType() != RiffFileSystemBinary::kContainerFourCC)
     {
         return SLANG_FAIL;
     }
@@ -133,10 +129,11 @@ SlangResult RiffFileSystem::loadArchive(const void* archive, size_t archiveSizeI
     _clear();
 
     // Find the header
-    const auto header = rootList->findContainedData<RiffFileSystemBinary::Header>(
-        RiffFileSystemBinary::kHeaderFourCC);
+    auto headerChunk = rootList->findDataChunk(RiffFileSystemBinary::kHeaderFourCC);
 
-    CompressionSystemType compressionType = CompressionSystemType(header->compressionSystemType);
+    const auto header = headerChunk->readPayloadAs<RiffFileSystemBinary::Header>();
+
+    CompressionSystemType compressionType = CompressionSystemType(header.compressionSystemType);
     switch (compressionType)
     {
     case CompressionSystemType::None:
@@ -162,52 +159,56 @@ SlangResult RiffFileSystem::loadArchive(const void* archive, size_t archiveSizeI
     // Read all of the contained data
 
     {
-        List<RiffContainer::DataChunk*> srcEntries;
-        rootList->findContained(RiffFileSystemBinary::kEntryFourCC, srcEntries);
-
-        for (auto chunk : srcEntries)
+        for (auto chunk : rootList->getChildren())
         {
-            auto data = chunk->getSingleData();
+            auto dataChunk = as<RIFF::DataChunk>(chunk);
+            if (!dataChunk)
+                continue;
 
-            const uint8_t* srcData = (const uint8_t*)data->getPayload();
-            const size_t dataSize = data->getSize();
+            if (dataChunk->getType() != RiffFileSystemBinary::kEntryFourCC)
+                continue;
 
-            if (dataSize < sizeof(RiffFileSystemBinary::Entry))
+            auto payloadData = (const uint8_t*)dataChunk->getPayload();
+            auto payloadSize = dataChunk->getPayloadSize();
+
+            if (payloadSize < sizeof(RiffFileSystemBinary::Entry))
             {
                 return SLANG_FAIL;
             }
 
-            auto srcEntry = (const RiffFileSystemBinary::Entry*)srcData;
-            srcData += sizeof(*srcEntry);
+            MemoryReader reader(payloadData, payloadSize);
+
+            RiffFileSystemBinary::Entry srcEntry;
+            reader.read(srcEntry);
 
             // Check if seems plausible
-            if (sizeof(RiffFileSystemBinary::Entry) + srcEntry->compressedSize +
-                    srcEntry->pathSize !=
-                dataSize)
+            if (sizeof(RiffFileSystemBinary::Entry) + srcEntry.compressedSize +
+                    srcEntry.pathSize !=
+                payloadSize)
             {
                 return SLANG_FAIL;
             }
 
             Entry dstEntry;
 
-            const char* path = (const char*)srcData;
-            srcData += srcEntry->pathSize;
+            const char* path = (const char*)reader.getRemainingData();
+            reader.skip(srcEntry.pathSize);
 
-            dstEntry.m_canonicalPath = UnownedStringSlice(path, srcEntry->pathSize - 1);
-            dstEntry.m_type = (SlangPathType)srcEntry->pathType;
-            dstEntry.m_uncompressedSizeInBytes = srcEntry->uncompressedSize;
+            dstEntry.m_canonicalPath = UnownedStringSlice(path, srcEntry.pathSize - 1);
+            dstEntry.m_type = (SlangPathType)srcEntry.pathType;
+            dstEntry.m_uncompressedSizeInBytes = srcEntry.uncompressedSize;
 
             switch (dstEntry.m_type)
             {
             case SLANG_PATH_TYPE_FILE:
                 {
-                    if (srcData + srcEntry->compressedSize != data->getPayloadEnd())
+                    if (reader.getRemainingSize() != srcEntry.compressedSize)
                     {
                         return SLANG_FAIL;
                     }
 
                     // Get the compressed data
-                    dstEntry.m_contents = RawBlob::create(srcData, srcEntry->compressedSize);
+                    dstEntry.m_contents = RawBlob::create(reader.getRemainingData(), srcEntry.compressedSize);
                     break;
                 }
             case SLANG_PATH_TYPE_DIRECTORY:
@@ -235,11 +236,9 @@ SlangResult RiffFileSystem::storeArchive(bool blobOwnsContent, ISlangBlob** outB
     // All blobs are owned in this style
     SLANG_UNUSED(blobOwnsContent)
 
-    RiffContainer container;
-    RiffContainer::ScopeChunk scopeContainer(
-        &container,
-        RiffContainer::Chunk::Kind::List,
-        RiffFileSystemBinary::kContainerFourCC);
+    RIFF::Builder builder;
+    RIFF::BuildCursor cursor(builder);
+    SLANG_SCOPED_RIFF_BUILDER_LIST_CHUNK(cursor, RiffFileSystemBinary::kContainerFourCC);
 
     {
         RiffFileSystemBinary::Header header;
@@ -247,7 +246,7 @@ SlangResult RiffFileSystem::storeArchive(bool blobOwnsContent, ISlangBlob** outB
                                                           ? m_compressionSystem->getSystemType()
                                                           : CompressionSystemType::None;
         header.compressionSystemType = uint32_t(compressionSystemType);
-        container.addDataChunk(RiffFileSystemBinary::kHeaderFourCC, &header, sizeof(header));
+        cursor.addDataChunk(RiffFileSystemBinary::kHeaderFourCC, &header, sizeof(header));
     }
 
     for (const auto& [_, srcEntry] : m_entries)
@@ -258,10 +257,7 @@ SlangResult RiffFileSystem::storeArchive(bool blobOwnsContent, ISlangBlob** outB
             continue;
         }
 
-        RiffContainer::ScopeChunk scopeData(
-            &container,
-            RiffContainer::Chunk::Kind::Data,
-            RiffFileSystemBinary::kEntryFourCC);
+        SLANG_SCOPED_RIFF_BUILDER_DATA_CHUNK(cursor, RiffFileSystemBinary::kEntryFourCC);
 
         RiffFileSystemBinary::Entry dstEntry;
         dstEntry.uncompressedSize = 0;
@@ -278,41 +274,32 @@ SlangResult RiffFileSystem::storeArchive(bool blobOwnsContent, ISlangBlob** outB
         }
 
         // Entry header
-        container.write(&dstEntry, sizeof(dstEntry));
+        cursor.addData(&dstEntry, sizeof(dstEntry));
 
         // Path
-        container.write(
+        cursor.addData(
             srcEntry.m_canonicalPath.getBuffer(),
             srcEntry.m_canonicalPath.getLength() + 1);
 
         // Add the contained data without copying
         if (blob)
         {
-            RiffContainer::Data* data = container.addData();
-            container.setUnowned(
-                data,
+            cursor.addUnownedData(
                 const_cast<void*>(blob->getBufferPointer()),
                 blob->getBufferSize());
         }
     }
 
-    OwnedMemoryStream stream(FileAccess::Write);
-    // We now write the RiffContainer to the stream
-    SLANG_RETURN_ON_FAIL(RiffUtil::write(container.getRoot(), true, &stream));
-
-    List<uint8_t> data;
-    stream.swapContents(data);
-
-    *outBlob = ListBlob::moveCreate(data).detach();
+    SLANG_RETURN_ON_FAIL(builder.writeToBlob(outBlob));
     return SLANG_OK;
 }
 
 /* static */ bool RiffFileSystem::isArchive(const void* data, size_t sizeInBytes)
 {
-    MemoryStreamBase stream(FileAccess::Read, data, sizeInBytes);
-    RiffListHeader header;
-    return SLANG_SUCCEEDED(RiffUtil::readHeader(&stream, header)) &&
-           header.subType == RiffFileSystemBinary::kContainerFourCC;
+    auto rootList = RIFF::RootChunk::getFromBlob(data, sizeInBytes);
+    if (!rootList) return false;
+    
+    return rootList->getType() == RiffFileSystemBinary::kContainerFourCC;
 }
 
 } // namespace Slang

--- a/source/core/slang-riff-file-system.h
+++ b/source/core/slang-riff-file-system.h
@@ -11,9 +11,9 @@ namespace Slang
 // The riff information used for RiffArchiveFileSystem
 struct RiffFileSystemBinary
 {
-    static const FourCC kContainerFourCC = SLANG_FOUR_CC('S', 'c', 'o', 'n');
-    static const FourCC kEntryFourCC = SLANG_FOUR_CC('S', 'f', 'i', 'l');
-    static const FourCC kHeaderFourCC = SLANG_FOUR_CC('S', 'h', 'e', 'a');
+    static const FourCC::RawValue kContainerFourCC = SLANG_FOUR_CC('S', 'c', 'o', 'n');
+    static const FourCC::RawValue kEntryFourCC = SLANG_FOUR_CC('S', 'f', 'i', 'l');
+    static const FourCC::RawValue kHeaderFourCC = SLANG_FOUR_CC('S', 'h', 'e', 'a');
 
     struct Header
     {

--- a/source/core/slang-riff.cpp
+++ b/source/core/slang-riff.cpp
@@ -96,7 +96,7 @@ void BoundsCheckedChunkPtr::_set(Chunk const* chunk, Size sizeLimit)
     // must be big enough to hold the larger header
     // that list chunks use.
     //
-    if (auto listChunk = as<ListChunk>(chunk))
+    if (as<ListChunk>(chunk))
     {
         if (reportedSize < sizeof(ListChunk::Header))
         {

--- a/source/core/slang-semantic-version.cpp
+++ b/source/core/slang-semantic-version.cpp
@@ -93,6 +93,28 @@ void SemanticVersion::append(StringBuilder& buf) const
     return bestVersion;
 }
 
+bool SemanticVersion::isBackwardsCompatibleWith(const ThisType& otherVersion) const
+{
+    // Compatibility is not guaranteed across major revisions.
+    //
+    if (m_major != otherVersion.m_major)
+        return false;
+
+    // Within a given major revision, a version with a higher
+    // minor revision is backwards-compatible with one that
+    // has a lower minor revision, but not vice-versa.
+    //
+    if (m_minor < otherVersion.m_minor)
+        return false;
+
+    // If the major and minor revisions pass our check, then
+    // we consider it a match. Note that this intentionally
+    // doesn't check the path version at all.
+    //
+    return true;
+}
+
+
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! MatchSemanticVersion !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 /* static */ SemanticVersion MatchSemanticVersion::findAnyBest(

--- a/source/core/slang-stream.h
+++ b/source/core/slang-stream.h
@@ -303,6 +303,12 @@ struct StreamUtil
     /// Appends all bytes that can be read from stream into bytes
     static SlangResult readAll(Stream* stream, size_t readSize, List<Byte>& ioBytes);
 
+    /// Appends all bytes that can be read from stream into bytes
+    static SlangResult readAll(Stream* stream, List<Byte>& ioBytes)
+    {
+        return readAll(stream, 0, ioBytes);
+    }
+
     /// Read as much as can be read until a 0 sized read, or an error and append onto ioBytes
     /// Read size controls the size of each buffer read. Passing 0, will use the default read size.
     static SlangResult read(Stream* stream, size_t readSize, List<Byte>& ioBytes);

--- a/source/core/slang-text-io.cpp
+++ b/source/core/slang-text-io.cpp
@@ -125,7 +125,7 @@ SlangResult StreamReader::readBuffer()
     return SLANG_OK;
 }
 
-char StreamReader::readBufferChar()
+Byte StreamReader::readBufferByte()
 {
     if (m_index < m_buffer.getCount())
     {

--- a/source/core/slang-text-io.h
+++ b/source/core/slang-text-io.h
@@ -74,23 +74,23 @@ protected:
         {
         case CharEncodeType::UTF8:
             {
-                codePoint = getUnicodePointFromUTF8([&]() -> Byte { return readBufferChar(); });
+                codePoint = getUnicodePointFromUTF8([&]() -> Byte { return readBufferByte(); });
                 break;
             }
         case CharEncodeType::UTF16:
             {
-                codePoint = getUnicodePointFromUTF16([&]() -> Byte { return readBufferChar(); });
+                codePoint = getUnicodePointFromUTF16([&]() -> Byte { return readBufferByte(); });
                 break;
             }
         case CharEncodeType::UTF16Reversed:
             {
                 codePoint =
-                    getUnicodePointFromUTF16Reversed([&]() -> Byte { return readBufferChar(); });
+                    getUnicodePointFromUTF16Reversed([&]() -> Byte { return readBufferByte(); });
                 break;
             }
         case CharEncodeType::UTF32:
             {
-                codePoint = getUnicodePointFromUTF32([&]() -> Byte { return readBufferChar(); });
+                codePoint = getUnicodePointFromUTF32([&]() -> Byte { return readBufferByte(); });
                 break;
             }
         }
@@ -99,11 +99,11 @@ protected:
     }
 
 private:
-    char readBufferChar();
+    Byte readBufferByte();
     SlangResult readBuffer();
 
     RefPtr<Stream> m_stream;
-    List<char> m_buffer;
+    List<Byte> m_buffer;
 
     CharEncodeType m_encodingType = CharEncodeType::UTF8;
     CharEncoding* m_encoding = nullptr;

--- a/source/core/slang-writer.h
+++ b/source/core/slang-writer.h
@@ -188,7 +188,7 @@ public:
         SLANG_OVERRIDE;
 
     /// Ctor
-    StringWriter(StringBuilder* builder, WriterFlags flags)
+    StringWriter(StringBuilder* builder, WriterFlags flags = 0)
         : Parent(flags), m_builder(builder)
     {
     }

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -2364,12 +2364,14 @@ public:
     ///
     RefPtr<Module> findOrLoadSerializedModuleForModuleLibrary(
         ModuleChunk const* moduleChunk,
+        RIFF::ListChunk const* libraryChunk,
         DiagnosticSink* sink);
 
     RefPtr<Module> loadSerializedModule(
         Name* moduleName,
         const PathInfo& moduleFilePathInfo,
         ModuleChunk const* moduleChunk,
+        RIFF::ListChunk const* containerChunk, //< The outer container, if there is one.
         SourceLoc const& requestingLoc,
         DiagnosticSink* sink);
 
@@ -2377,6 +2379,7 @@ public:
         Module* module,
         const PathInfo& moduleFilePathInfo,
         ModuleChunk const* moduleChunk,
+        RIFF::ListChunk const* containerChunk, //< The outer container, if there is one.
         DiagnosticSink* sink);
 
     SourceFile* loadSourceFile(String pathFrom, String path);

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -34,7 +34,7 @@ namespace Slang
 struct PathInfo;
 struct IncludeHandler;
 struct SharedSemanticsContext;
-struct ModuleChunkRef;
+struct ModuleChunk;
 
 class ProgramLayout;
 class PtrType;
@@ -2363,20 +2363,20 @@ public:
     /// Otherwise, return null.
     ///
     RefPtr<Module> findOrLoadSerializedModuleForModuleLibrary(
-        ModuleChunkRef moduleChunk,
+        ModuleChunk const* moduleChunk,
         DiagnosticSink* sink);
 
     RefPtr<Module> loadSerializedModule(
         Name* moduleName,
         const PathInfo& moduleFilePathInfo,
-        ModuleChunkRef moduleChunk,
+        ModuleChunk const* moduleChunk,
         SourceLoc const& requestingLoc,
         DiagnosticSink* sink);
 
     SlangResult loadSerializedModuleContents(
         Module* module,
         const PathInfo& moduleFilePathInfo,
-        ModuleChunkRef moduleChunk,
+        ModuleChunk const* moduleChunk,
         DiagnosticSink* sink);
 
     SourceFile* loadSourceFile(String pathFrom, String path);
@@ -2387,8 +2387,7 @@ public:
         Name* name,
         PathInfo const& pathInfo);
 
-    bool isBinaryModuleUpToDate(String fromPath, RiffContainer* container);
-    bool isBinaryModuleUpToDate(String fromPath, ModuleChunkRef moduleChunk);
+    bool isBinaryModuleUpToDate(String fromPath, RIFF::ListChunk const* baseChunk);
 
     RefPtr<Module> findOrImportModule(
         Name* name,

--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -935,8 +935,7 @@ void CUDASourceEmitter::handleRequiredCapabilitiesImpl(IRInst* inst)
     {
         if (auto smDecoration = as<IRRequireCUDASMVersionDecoration>(decoration))
         {
-            SemanticVersion version;
-            version.setFromInteger(SemanticVersion::IntegerType(smDecoration->getCUDASMVersion()));
+            SemanticVersion version = smDecoration->getCUDASMVersion();
             m_extensionTracker->requireSMVersion(version);
         }
     }

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -3074,11 +3074,8 @@ void GLSLSourceEmitter::handleRequiredCapabilitiesImpl(IRInst* inst)
             }
         case kIROp_RequireSPIRVVersionDecoration:
             {
-                auto intValue =
-                    static_cast<IRRequireSPIRVVersionDecoration*>(decoration)->getSPIRVVersion();
-                SemanticVersion version;
-                version.setFromInteger(SemanticVersion::IntegerType(intValue));
-                _requireSPIRVVersion(version);
+                _requireSPIRVVersion(
+                    static_cast<IRRequireSPIRVVersionDecoration*>(decoration)->getSPIRVVersion());
                 break;
             }
         }

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -396,7 +396,7 @@ struct IRRequireSPIRVVersionDecoration : IRDecoration
     IR_LEAF_ISA(RequireGLSLVersionDecoration)
 
     IRConstant* getSPIRVVersionOperand() { return cast<IRConstant>(getOperand(0)); }
-    IntegerLiteralValue getSPIRVVersion() { return getSPIRVVersionOperand()->value.intVal; }
+    SemanticVersion getSPIRVVersion() { return SemanticVersion::fromRaw(getSPIRVVersionOperand()->value.intVal); }
 };
 
 struct IRRequireCapabilityAtomDecoration : IRDecoration
@@ -420,7 +420,7 @@ struct IRRequireCUDASMVersionDecoration : IRDecoration
     IR_LEAF_ISA(RequireCUDASMVersionDecoration)
 
     IRConstant* getCUDASMVersionOperand() { return cast<IRConstant>(getOperand(0)); }
-    IntegerLiteralValue getCUDASMVersion() { return getCUDASMVersionOperand()->value.intVal; }
+    SemanticVersion getCUDASMVersion() { return SemanticVersion::fromRaw(getCUDASMVersionOperand()->value.intVal); }
 };
 
 struct IRRequireGLSLExtensionDecoration : IRDecoration
@@ -4940,13 +4940,18 @@ public:
             getStringValue(prelude));
     }
 
+    IRInst* getSemanticVersionValue(SemanticVersion const& value)
+    {
+        SemanticVersion::RawValue rawValue = value.getRawValue();
+        return getIntValue(getBasicType(BaseType::UInt64), rawValue);
+    }
+
     void addRequireSPIRVVersionDecoration(IRInst* value, const SemanticVersion& version)
     {
-        SemanticVersion::IntegerType intValue = version.toInteger();
         addDecoration(
             value,
             kIROp_RequireSPIRVVersionDecoration,
-            getIntValue(getBasicType(BaseType::UInt64), intValue));
+            getSemanticVersionValue(version));
     }
 
     void addSPIRVNonUniformResourceDecoration(IRInst* value)
@@ -4956,11 +4961,10 @@ public:
 
     void addRequireCUDASMVersionDecoration(IRInst* value, const SemanticVersion& version)
     {
-        SemanticVersion::IntegerType intValue = version.toInteger();
         addDecoration(
             value,
             kIROp_RequireCUDASMVersionDecoration,
-            getIntValue(getBasicType(BaseType::UInt64), intValue));
+            getSemanticVersionValue(version));
     }
 
     void addRequireCapabilityAtomDecoration(IRInst* value, CapabilityName atom)

--- a/source/slang/slang-module-library.cpp
+++ b/source/slang/slang-module-library.cpp
@@ -69,7 +69,7 @@ SlangResult loadModuleLibrary(
 
     for (auto moduleChunk : container->getModules())
     {
-        auto loadedModule = linkage->findOrLoadSerializedModuleForModuleLibrary(moduleChunk, sink);
+        auto loadedModule = linkage->findOrLoadSerializedModuleForModuleLibrary(moduleChunk, container, sink);
         if (!loadedModule)
             return SLANG_FAIL;
 

--- a/source/slang/slang-repro.h
+++ b/source/slang/slang-repro.h
@@ -29,14 +29,17 @@ struct ReproUtil
         kPatchVersion = 0,
     };
 
-    static const uint32_t kSlangStateFourCC =
-        SLANG_FOUR_CC('S', 'L', 'S', 'T'); ///< Holds all the slang specific chunks
-    static const RiffSemanticVersion g_semanticVersion;
+    static const FourCC::RawValue kSlangStateFileFourCC =
+        SLANG_FOUR_CC('S', 'L', 'S', 'T'); ///< Root chunk for repro state file.
+
+    static const FourCC::RawValue kSlangStateDataFourCC =
+        SLANG_FOUR_CC('d', 'a', 't', 'a'); ///< Holds the actual binary data.
+
+    static const SemanticVersion g_semanticVersion;
 
     struct Header
     {
-        RiffHeader m_chunk;                    ///< The chunk
-        RiffSemanticVersion m_semanticVersion; ///< The semantic version
+        SemanticVersion m_semanticVersion; ///< The semantic version
         StableHashCode32
             m_typeHash; ///< A hash based on the binary representation. If doesn't match then not
                         ///< binary compatible (extra check over semantic versioning)

--- a/source/slang/slang-serialize-ast.cpp
+++ b/source/slang/slang-serialize-ast.cpp
@@ -59,9 +59,9 @@ public:
     {
         auto containerChunk = encoder->getRIFFChunk();
 
-        RiffContainer::Chunk* declChunk = nullptr;
-        RiffContainer::Chunk* importedDeclChunk = nullptr;
-        RiffContainer::Chunk* valChunk = nullptr;
+        RIFF::ChunkBuilder* declChunk = nullptr;
+        RIFF::ChunkBuilder* importedDeclChunk = nullptr;
+        RIFF::ChunkBuilder* valChunk = nullptr;
         {
             Encoder::WithArray withList(encoder);
             declChunk = encoder->getRIFFChunk();
@@ -102,7 +102,6 @@ public:
             }
         } while (!done);
 
-        RiffContainer::calcAndSetSize(containerChunk);
         encoder->setRIFFChunk(containerChunk);
     }
 
@@ -345,7 +344,7 @@ public:
 
     void encodeValue(NameLoc const& value) { encode(value.name); }
 
-    void encodeValue(SemanticVersion value) { encoder->encode(value.toInteger()); }
+    void encodeValue(SemanticVersion value) { encoder->encode(value.getRawValue()); }
 
     void encodeValue(CapabilitySet const& value)
     {
@@ -668,13 +667,13 @@ public:
         Linkage* linkage,
         ASTBuilder* astBuilder,
         DiagnosticSink* sink,
-        RiffContainer::Chunk* rootChunk,
+        RIFF::Chunk const* baseChunk,
         SerialSourceLocReader* sourceLocReader,
         SourceLoc requestingSourceLoc)
         : _linkage(linkage)
         , _astBuilder(astBuilder)
         , _sink(sink)
-        , _rootChunk(static_cast<RiffContainer::ListChunk*>(rootChunk))
+        , _baseChunk(as<RIFF::ListChunk>(baseChunk))
         , _sourceLocReader(sourceLocReader)
         , _requestingSourceLoc(requestingSourceLoc)
     {
@@ -687,7 +686,7 @@ public:
 
     SlangResult decodeAll()
     {
-        auto cursor = _rootChunk->getFirstContainedChunk();
+        auto cursor = _baseChunk->getChildren().begin();
 
         // There are a few different top-level chunks that
         // hold different arrays that we need in order
@@ -705,23 +704,23 @@ public:
         // the `ModuleDecl` itself, which should be the
         // first entry in the list.
         //
-        auto declChunk = cursor;
-        cursor = cursor->m_next;
+        auto declChunk = *cursor;
+        ++cursor;
 
         // Next there is a list of all the declarations
         // referenced inside of the module that need to
         // be imported in from outside.
         //
-        auto importedDeclChunk = cursor;
-        cursor = cursor->m_next;
+        auto importedDeclChunk = *cursor;
+        ++cursor;
 
         // Then there are all the `Val`-derived nodes that
         // are needed by the module, which will need to be
         // deduplicated so that they are unique within the
         // current compilation context.
         //
-        auto valChunk = cursor;
-        cursor = cursor->m_next;
+        auto valChunk = *cursor;
+        ++cursor;
 
         // The process of decoding the module is then spread
         // over a number of steps.
@@ -792,7 +791,7 @@ private:
     };
 
     ASTBuilder* _astBuilder = nullptr;
-    RiffContainer::ListChunk* _rootChunk = nullptr;
+    RIFF::ListChunk const* _baseChunk = nullptr;
 
     List<Decl*> _decls;
     List<Decl*> _importedDecls;
@@ -801,7 +800,7 @@ private:
     typedef Int ValID;
     Val* getValByID(ValID id) { return _vals[id]; }
 
-    SlangResult decodeImportedDecls(RiffContainer::Chunk* importedDeclChunk)
+    SlangResult decodeImportedDecls(RIFF::Chunk const* importedDeclChunk)
     {
         Decoder decoder(importedDeclChunk);
 
@@ -849,7 +848,7 @@ private:
         return module->getModuleDecl();
     }
 
-    SlangResult decodeVals(RiffContainer::Chunk* valChunk)
+    SlangResult decodeVals(RIFF::Chunk const* valChunk)
     {
         Decoder decoder(valChunk);
 
@@ -862,7 +861,7 @@ private:
         return SLANG_OK;
     }
 
-    SlangResult createEmptyShells(RiffContainer::Chunk* declChunk)
+    SlangResult createEmptyShells(RIFF::Chunk const* declChunk)
     {
         Decoder decoder(declChunk);
 
@@ -925,7 +924,7 @@ private:
         return SyntaxClass<NodeBase>(nodeType).createInstance(_astBuilder);
     }
 
-    SlangResult fillEmptyShells(RiffContainer::Chunk* declChunk)
+    SlangResult fillEmptyShells(RIFF::Chunk const* declChunk)
     {
         Index declIndex = 0;
 
@@ -1190,8 +1189,8 @@ private:
 
     void decodeValue(SemanticVersion& value, Decoder& decoder)
     {
-        SemanticVersion::IntegerType rawValue = decoder.decode<SemanticVersion::IntegerType>();
-        value.setFromInteger(rawValue);
+        SemanticVersion::RawValue rawValue = decoder.decode<SemanticVersion::RawValue>();
+        value.setRawValue(rawValue);
     }
 
     void decodeValue(CapabilitySet& value, Decoder& decoder)
@@ -1541,7 +1540,7 @@ ModuleDecl* readSerializedModuleAST(
     Linkage* linkage,
     ASTBuilder* astBuilder,
     DiagnosticSink* sink,
-    RiffContainer::Chunk* chunk,
+    RIFF::Chunk const* chunk,
     SerialSourceLocReader* sourceLocReader,
     SourceLoc requestingSourceLoc)
 {

--- a/source/slang/slang-serialize-ast.h
+++ b/source/slang/slang-serialize-ast.h
@@ -20,7 +20,7 @@ ModuleDecl* readSerializedModuleAST(
     Linkage* linkage,
     ASTBuilder* astBuilder,
     DiagnosticSink* sink,
-    RiffContainer::Chunk* chunk,
+    RIFF::Chunk const* chunk,
     SerialSourceLocReader* sourceLocReader,
     SourceLoc requestingSourceLoc);
 

--- a/source/slang/slang-serialize-container.cpp
+++ b/source/slang/slang-serialize-container.cpp
@@ -217,8 +217,6 @@ public:
         {
             if (auto irModule = module->getIRModule())
             {
-                Encoder::WithKeyValuePair withKey(&_encoder, PropertyKeys<Module>::IRModule);
-
                 IRSerialData serialData;
                 IRSerialWriter writer;
                 SLANG_RETURN_ON_FAIL(
@@ -468,11 +466,11 @@ String ModuleChunk::getName() const
 
 IRModuleChunk const* ModuleChunk::findIR() const
 {
-    auto foundProperty = findListChunk(PropertyKeys<Module>::IRModule);
-    if (!foundProperty)
+    auto foundChunk = findListChunk(IRSerialBinary::kIRModuleFourCc);
+    if (!foundChunk)
         return nullptr;
 
-    return static_cast<IRModuleChunk const*>(foundProperty->getFirstChild().get());
+    return static_cast<IRModuleChunk const*>(foundChunk);
 }
 
 ASTModuleChunk const* ModuleChunk::findAST() const

--- a/source/slang/slang-serialize-container.cpp
+++ b/source/slang/slang-serialize-container.cpp
@@ -551,6 +551,17 @@ DebugChunk const* DebugChunk::find(RIFF::ListChunk const* baseChunk)
     return static_cast<DebugChunk const*>(found);
 }
 
+DebugChunk const* DebugChunk::find(
+    RIFF::ListChunk const* baseChunk,
+    RIFF::ListChunk const* containerChunk)
+{
+    if (auto found = find(baseChunk))
+        return found;
+    if (containerChunk)
+        return find(containerChunk);
+    return nullptr;
+}
+
 SlangResult readSourceLocationsFromDebugChunk(
     DebugChunk const* debugChunk,
     SourceManager* sourceManager,

--- a/source/slang/slang-serialize-container.cpp
+++ b/source/slang/slang-serialize-container.cpp
@@ -17,20 +17,36 @@ namespace Slang
 {
 struct ModuleEncodingContext
 {
+private:
+    SerialContainerUtil::WriteOptions const& _options;
+    Stream* _stream = nullptr;
+
+    // The string pool used across the whole of the container
+    StringSlicePool _containerStringPool;
+    RefPtr<SerialSourceLocWriter> _sourceLocWriter;
+
+    RIFF::Builder _riff;
+    Encoder _encoder;
+
 public:
     ModuleEncodingContext(SerialContainerUtil::WriteOptions const& options, Stream* stream)
-        : options(options), encoder(stream), containerStringPool(StringSlicePool::Style::Default)
+        : _options(options)
+        , _stream(stream)
+        , _containerStringPool(StringSlicePool::Style::Default)
     {
         if (options.optionFlags & SerialOptionFlag::SourceLocation)
         {
-            sourceLocWriter = new SerialSourceLocWriter(options.sourceManager);
+            _sourceLocWriter = new SerialSourceLocWriter(options.sourceManager);
         }
+
+        _encoder = Encoder(_riff);
     }
 
     ~ModuleEncodingContext()
     {
-        encoder.setRIFFChunk(encoder.getRIFF()->getRoot());
+        _encoder = Encoder(_riff.getRootChunk());
         encodeFinalPieces();
+        _riff.writeTo(_stream);
     }
 
     SlangResult encodeModuleList(FrontEndCompileRequest* frontEndReq)
@@ -39,7 +55,7 @@ public:
         // is simply a matter of encoding the module for each
         // of the translation units that got compiled.
         //
-        Encoder::WithKeyValuePair withArray(&encoder, SerialBinary::kModuleListFourCc);
+        Encoder::WithKeyValuePair withArray(&_encoder, SerialBinary::kModuleListFourCc);
         for (TranslationUnitRequest* translationUnit : frontEndReq->translationUnits)
         {
             SLANG_RETURN_ON_FAIL(encode(translationUnit->module));
@@ -49,14 +65,14 @@ public:
 
     SlangResult encode(FrontEndCompileRequest* frontEndReq)
     {
-        Encoder::WithObject withObject(&encoder, SerialBinary::kContainerFourCc);
+        Encoder::WithObject withObject(&_encoder, SerialBinary::kContainerFourCc);
         SLANG_RETURN_ON_FAIL(encodeModuleList(frontEndReq));
         return SLANG_OK;
     }
 
     SlangResult encode(EndToEndCompileRequest* request)
     {
-        Encoder::WithObject withObject(&encoder, SerialBinary::kContainerFourCc);
+        Encoder::WithObject withObject(&_encoder, SerialBinary::kContainerFourCc);
 
         // Encoding an end-to-end compile request starts with the same
         // work as for a front-end request: we encode each of
@@ -85,7 +101,7 @@ public:
         auto sink = request->getSink();
         auto program = request->getSpecializedGlobalAndEntryPointsComponentType();
         {
-            Encoder::WithArray withArray(&encoder); // kContainerFourCc
+            Encoder::WithArray withArray(&_encoder);
 
             for (auto target : linkage->targets)
             {
@@ -98,7 +114,7 @@ public:
         // and we need to encode information about each of them.
         //
         {
-            Encoder::WithArray withArray(&encoder, SerialBinary::kEntryPointListFourCc);
+            Encoder::WithArray withArray(&_encoder, SerialBinary::kEntryPointListFourCc);
 
             auto entryPointCount = program->getEntryPointCount();
             for (Index ii = 0; ii < entryPointCount; ++ii)
@@ -127,34 +143,34 @@ public:
         IRSerialWriter writer;
 
         SLANG_RETURN_ON_FAIL(
-            writer.write(irModule, sourceLocWriter, options.optionFlags, &serialData));
-        SLANG_RETURN_ON_FAIL(IRSerialWriter::writeContainer(serialData, encoder.getRIFF()));
+            writer.write(irModule, _sourceLocWriter, _options.optionFlags, &serialData));
+        SLANG_RETURN_ON_FAIL(IRSerialWriter::writeTo(serialData, _encoder));
 
         return SLANG_OK;
     }
 
-    void encode(Name* name) { encoder.encode(name->text); }
+    void encode(Name* name) { _encoder.encode(name->text); }
 
-    void encode(String const& value) { encoder.encode(value); }
+    void encode(String const& value) { _encoder.encode(value); }
 
-    void encode(uint32_t value) { encoder.encode(UInt(value)); }
+    void encode(uint32_t value) { _encoder.encode(UInt(value)); }
 
-    void encodeData(void const* data, size_t size) { encoder.encodeData(data, size); }
+    void encodeData(void const* data, size_t size) { _encoder.encodeData(data, size); }
 
     SlangResult encode(EntryPoint* entryPoint, String const& entryPointMangledName)
     {
-        Encoder::WithObject withObject(&encoder, SerialBinary::kEntryPointFourCc);
+        Encoder::WithObject withObject(&_encoder, SerialBinary::kEntryPointFourCc);
 
         {
-            Encoder::WithObject withProperty(&encoder, SerialBinary::kNameFourCC);
+            Encoder::WithObject withProperty(&_encoder, SerialBinary::kNameFourCC);
             encode(entryPoint->getName());
         }
         {
-            Encoder::WithObject withProperty(&encoder, SerialBinary::kProfileFourCC);
+            Encoder::WithObject withProperty(&_encoder, SerialBinary::kProfileFourCC);
             encode(entryPoint->getProfile().raw);
         }
         {
-            Encoder::WithObject withProperty(&encoder, SerialBinary::kMangledNameFourCC);
+            Encoder::WithObject withProperty(&_encoder, SerialBinary::kMangledNameFourCC);
             encode(entryPointMangledName);
         }
 
@@ -164,10 +180,10 @@ public:
 
     SlangResult encode(Module* module)
     {
-        if (!(options.optionFlags & (SerialOptionFlag::IRModule | SerialOptionFlag::ASTModule)))
+        if (!(_options.optionFlags & (SerialOptionFlag::IRModule | SerialOptionFlag::ASTModule)))
             return SLANG_OK;
 
-        Encoder::WithObject withModule(&encoder, SerialBinary::kModuleFourCC);
+        Encoder::WithObject withModule(&_encoder, SerialBinary::kModuleFourCC);
 
         // The first piece that we write for a module is its header.
         // The header is intended to provide information that can be
@@ -180,15 +196,15 @@ public:
             // sense to serialize it separately from all the rest.
             //
             {
-                Encoder::WithObject withProperty(&encoder, SerialBinary::kNameFourCC);
-                encoder.encodeString(module->getNameObj()->text);
+                Encoder::WithObject withProperty(&_encoder, SerialBinary::kNameFourCC);
+                _encoder.encodeString(module->getNameObj()->text);
             }
 
             // The header includes a digest of all the compile options and
             // the files that the compiled result depended on.
             //
             auto digest = module->computeDigest();
-            encoder.encodeData(PropertyKeys<Module>::Digest, digest.data, sizeof(digest.data));
+            _encoder.encodeData(PropertyKeys<Module>::Digest, digest.data, sizeof(digest.data));
 
             // The header includes an array of the paths of all of the
             // files that the compiled result depended on.
@@ -199,30 +215,30 @@ public:
         // If serialization of Slang IR modules is enabled, and there
         // is IR available for this module, then we we encode it.
         //
-        if ((options.optionFlags & SerialOptionFlag::IRModule))
+        if ((_options.optionFlags & SerialOptionFlag::IRModule))
         {
             if (auto irModule = module->getIRModule())
             {
-                Encoder::WithKeyValuePair withKey(&encoder, PropertyKeys<Module>::IRModule);
+                Encoder::WithKeyValuePair withKey(&_encoder, PropertyKeys<Module>::IRModule);
 
                 IRSerialData serialData;
                 IRSerialWriter writer;
                 SLANG_RETURN_ON_FAIL(
-                    writer.write(irModule, sourceLocWriter, options.optionFlags, &serialData));
-                SLANG_RETURN_ON_FAIL(IRSerialWriter::writeContainer(serialData, encoder.getRIFF()));
+                    writer.write(irModule, _sourceLocWriter, _options.optionFlags, &serialData));
+                SLANG_RETURN_ON_FAIL(IRSerialWriter::writeTo(serialData, _encoder));
             }
         }
 
         // If serialization of AST information is enabled, and we have AST
         // information available, then we serialize it here.
         //
-        if (options.optionFlags & SerialOptionFlag::ASTModule)
+        if (_options.optionFlags & SerialOptionFlag::ASTModule)
         {
             if (auto moduleDecl = module->getModuleDecl())
             {
-                Encoder::WithKeyValuePair withKey(&encoder, PropertyKeys<Module>::ASTModule);
+                Encoder::WithKeyValuePair withKey(&_encoder, PropertyKeys<Module>::ASTModule);
 
-                writeSerializedModuleAST(&encoder, moduleDecl, sourceLocWriter);
+                writeSerializedModuleAST(&_encoder, moduleDecl, _sourceLocWriter);
             }
         }
 
@@ -231,7 +247,7 @@ public:
 
     SlangResult encodeModuleDependencyPaths(Module* module)
     {
-        Encoder::WithObject withProperty(&encoder, PropertyKeys<Module>::FileDependencies);
+        Encoder::WithObject withProperty(&_encoder, PropertyKeys<Module>::FileDependencies);
 
         // TODO(tfoley): This is some of the most complicated logic
         // in the encoding system, because it tries to translate
@@ -305,7 +321,7 @@ public:
         }
         Path::getCanonical(linkageRoot, linkageRoot);
 
-        Encoder::WithArray withArray(&encoder);
+        Encoder::WithArray withArray(&_encoder);
         for (auto file : fileDependencies)
         {
             if (file->getPathInfo().hasFoundPath())
@@ -322,26 +338,26 @@ public:
                         auto relativeModulePath =
                             Path::getRelativePath(linkageRoot, canonicalModulePath);
 
-                        encoder.encodeString(relativeModulePath);
+                        _encoder.encodeString(relativeModulePath);
                     }
                     else
                     {
                         // For all other dependnet files, store them as relative paths with respect
                         // to the module's path.
                         canonicalFilePath = Path::getRelativePath(moduleDir, canonicalFilePath);
-                        encoder.encodeString(canonicalFilePath);
+                        _encoder.encodeString(canonicalFilePath);
                     }
                 }
                 else
                 {
                     // If the module is coming from string instead of an actual file, store it as
                     // is.
-                    encoder.encodeString(canonicalModulePath);
+                    _encoder.encodeString(canonicalModulePath);
                 }
             }
             else
             {
-                encoder.encodeString(file->getPathInfo().getMostUniqueIdentity());
+                _encoder.encodeString(file->getPathInfo().getMostUniqueIdentity());
             }
         }
 
@@ -351,38 +367,28 @@ public:
     SlangResult encodeFinalPieces()
     {
         // We can now output the debug information. This is for all IR and AST
-        if (sourceLocWriter)
+        if (_sourceLocWriter)
         {
             // Write out the debug info
             SerialSourceLocData debugData;
-            sourceLocWriter->write(&debugData);
+            _sourceLocWriter->write(&debugData);
 
-            debugData.writeContainer(encoder.getRIFF());
+            debugData.writeTo(_encoder);
         }
 
         // Write the container string table
-        if (containerStringPool.getAdded().getCount() > 0)
+        if (_containerStringPool.getAdded().getCount() > 0)
         {
-            Encoder::WithKeyValuePair withKey(&encoder, SerialBinary::kStringTableFourCc);
+            Encoder::WithKeyValuePair withKey(&_encoder, SerialBinary::kStringTableFourCc);
 
             List<char> encodedTable;
-            SerialStringTableUtil::encodeStringTable(containerStringPool, encodedTable);
+            SerialStringTableUtil::encodeStringTable(_containerStringPool, encodedTable);
 
-            encoder.encodeData(encodedTable.getBuffer(), encodedTable.getCount());
+            _encoder.encodeData(encodedTable.getBuffer(), encodedTable.getCount());
         }
 
         return SLANG_OK;
     }
-
-
-private:
-    SerialContainerUtil::WriteOptions const& options;
-    RefPtr<SerialSourceLocWriter> sourceLocWriter;
-
-    // The string pool used across the whole of the container
-    StringSlicePool containerStringPool;
-
-    Encoder encoder;
 };
 
 //
@@ -421,123 +427,119 @@ private:
     return SLANG_OK;
 }
 
-String StringChunkRef::getValue()
+String StringChunk::getValue() const
 {
-    return Decoder(ptr()).decodeString();
+    return Decoder(this).decodeString();
 }
 
-ChunkRefList<StringChunkRef> ModuleChunkRef::getFileDependencies()
+RIFF::ChunkList<StringChunk> ModuleChunk::getFileDependencies() const
 {
-    Decoder decoder(ptr());
+    Decoder decoder(this);
     Decoder::WithProperty withProperty(decoder, PropertyKeys<Module>::FileDependencies);
-    return ChunkRefList<StringChunkRef>(as<RiffContainer::ListChunk>(decoder.getCursor()));
+    return as<RIFF::ListChunk>(decoder.getCurrentChunk())->getChildren().cast<StringChunk>();
 }
 
-ModuleChunkRef ModuleChunkRef::find(RiffContainer* container)
+ModuleChunk const* ModuleChunk::find(RIFF::ListChunk const* baseChunk)
 {
-    auto found = container->getRoot()->findListRec(SerialBinary::kModuleFourCC);
-    return ModuleChunkRef(found);
+    auto found = baseChunk->findListChunkRec(SerialBinary::kModuleFourCC);
+    return static_cast<ModuleChunk const*>(found);
 }
 
-SHA1::Digest ModuleChunkRef::getDigest()
+SHA1::Digest ModuleChunk::getDigest() const
 {
-    auto foundChunk =
-        static_cast<RiffContainer::DataChunk*>(ptr()->findContained(PropertyKeys<Module>::Digest));
+    auto foundChunk = findDataChunk(PropertyKeys<Module>::Digest);
     if (!foundChunk)
     {
         SLANG_UNEXPECTED("module chunk had no digest");
     }
-    if (foundChunk->calcPayloadSize() != sizeof(SHA1::Digest))
-    {
-        SLANG_UNEXPECTED("module digest chunk had wrong size");
-    }
-
-    SHA1::Digest digest;
-    foundChunk->getPayload(&digest);
-    return digest;
+    return foundChunk->readPayloadAs<SHA1::Digest>();
 }
 
-String ModuleChunkRef::getName()
+String ModuleChunk::getName() const
 {
     // TODO(tfoley): This kind of logic needs a way
     // to be greatly simplified, so that we don't
     // have to express such complicated logic for
     // simply extracting a single string property...
     //
-    Decoder decoder(ptr());
+    Decoder decoder(this);
     Decoder::WithProperty withProperty(decoder, SerialBinary::kNameFourCC);
     return decoder.decodeString();
 }
 
 
-IRModuleChunkRef ModuleChunkRef::findIR()
+IRModuleChunk const* ModuleChunk::findIR() const
 {
-    auto foundProperty = ptr()->findContainedList(PropertyKeys<Module>::IRModule);
+    auto foundProperty = findListChunk(PropertyKeys<Module>::IRModule);
     if (!foundProperty)
-        return IRModuleChunkRef(nullptr);
-    return IRModuleChunkRef(
-        static_cast<RiffContainer::ListChunk*>(foundProperty->getFirstContainedChunk()));
+        return nullptr;
+
+    return static_cast<IRModuleChunk const*>(foundProperty->getFirstChild().get());
 }
 
-ASTModuleChunkRef ModuleChunkRef::findAST()
+ASTModuleChunk const* ModuleChunk::findAST() const
 {
-    auto foundProperty = ptr()->findContainedList(PropertyKeys<Module>::ASTModule);
+    auto foundProperty = findListChunk(PropertyKeys<Module>::ASTModule);
     if (!foundProperty)
-        return ASTModuleChunkRef(nullptr);
-    return ASTModuleChunkRef(
-        static_cast<RiffContainer::ListChunk*>(foundProperty->getFirstContainedChunk()));
+        return nullptr;
+
+    return static_cast<ASTModuleChunk const*>(foundProperty->getFirstChild().get());
 }
 
-ContainerChunkRef ContainerChunkRef::find(RiffContainer* container)
+ContainerChunk const* ContainerChunk::find(RIFF::ListChunk const* baseChunk)
 {
-    auto found = container->getRoot()->findListRec(SerialBinary::kContainerFourCc);
-    return ContainerChunkRef(found);
+    auto found = baseChunk->findListChunkRec(SerialBinary::kContainerFourCc);
+    return static_cast<ContainerChunk const*>(found);
 }
 
-ChunkRefList<ModuleChunkRef> ContainerChunkRef::getModules()
+RIFF::ChunkList<ModuleChunk> ContainerChunk::getModules() const
 {
-    auto found = ptr()->findContainedList(SerialBinary::kModuleListFourCc);
-    return ChunkRefList<ModuleChunkRef>(found);
+    auto found = findListChunk(SerialBinary::kModuleListFourCc);
+    if (!found)
+        return RIFF::ChunkList<ModuleChunk>();
+    return found->getChildren().cast<ModuleChunk>();
 }
 
-ChunkRefList<EntryPointChunkRef> ContainerChunkRef::getEntryPoints()
+RIFF::ChunkList<EntryPointChunk> ContainerChunk::getEntryPoints() const
 {
-    auto found = ptr()->findContainedList(SerialBinary::kEntryPointListFourCc);
-    return ChunkRefList<EntryPointChunkRef>(found);
+    auto found = findListChunk(SerialBinary::kEntryPointListFourCc);
+    if (!found)
+        return RIFF::ChunkList<EntryPointChunk>();
+    return found->getChildren().cast<EntryPointChunk>();
 }
 
-String EntryPointChunkRef::getMangledName() const
+String EntryPointChunk::getMangledName() const
 {
     // TODO(tfoley): This kind of logic needs a way
     // to be greatly simplified, so that we don't
     // have to express such complicated logic for
     // simply extracting a single string property...
     //
-    Decoder decoder(ptr());
+    Decoder decoder(this);
     Decoder::WithProperty withProperty(decoder, SerialBinary::kMangledNameFourCC);
     return decoder.decodeString();
 }
 
-String EntryPointChunkRef::getName() const
+String EntryPointChunk::getName() const
 {
     // TODO(tfoley): This kind of logic needs a way
     // to be greatly simplified, so that we don't
     // have to express such complicated logic for
     // simply extracting a single string property...
     //
-    Decoder decoder(ptr());
+    Decoder decoder(this);
     Decoder::WithProperty withProperty(decoder, SerialBinary::kNameFourCC);
     return decoder.decodeString();
 }
 
-Profile EntryPointChunkRef::getProfile() const
+Profile EntryPointChunk::getProfile() const
 {
     // TODO(tfoley): This kind of logic needs a way
     // to be greatly simplified, so that we don't
     // have to express such complicated logic for
     // simply extracting a single string property...
     //
-    Decoder decoder(ptr());
+    Decoder decoder(this);
     Decoder::WithProperty withProperty(decoder, SerialBinary::kProfileFourCC);
 
     Profile::RawVal rawVal;
@@ -547,28 +549,14 @@ Profile EntryPointChunkRef::getProfile() const
 }
 
 
-RiffContainer::ListChunk* findDebugChunk(RiffContainer::Chunk* startingChunk)
+DebugChunk const* DebugChunk::find(RIFF::ListChunk const* baseChunk)
 {
-    if (!startingChunk)
-        return nullptr;
-
-    RiffContainer::ListChunk* container = as<RiffContainer::ListChunk>(startingChunk);
-    if (!container)
-        container = startingChunk->m_parent;
-
-    for (; container; container = container->m_parent)
-    {
-        if (auto debugChunk = container->findContainedList(SerialSourceLocData::kDebugFourCc))
-        {
-            return debugChunk;
-        }
-    }
-
-    return nullptr;
+    auto found = baseChunk->findListChunkRec(SerialSourceLocData::kDebugFourCc);
+    return static_cast<DebugChunk const*>(found);
 }
 
 SlangResult readSourceLocationsFromDebugChunk(
-    RiffContainer::ListChunk* debugChunk,
+    DebugChunk const* debugChunk,
     SourceManager* sourceManager,
     RefPtr<SerialSourceLocReader>& outReader)
 {
@@ -585,7 +573,7 @@ SlangResult readSourceLocationsFromDebugChunk(
     // from the RIFF into the intermediate structure.
     //
     SerialSourceLocData intermediateData;
-    SLANG_RETURN_ON_FAIL(intermediateData.readContainer(debugChunk));
+    SLANG_RETURN_ON_FAIL(intermediateData.readFrom(debugChunk));
 
     // After reading the data into the intermediate representation,
     // we turn it into a `SerialSourceLocReader`, which vends source
@@ -601,7 +589,7 @@ SlangResult readSourceLocationsFromDebugChunk(
 
 SlangResult decodeModuleIR(
     RefPtr<IRModule>& outIRModule,
-    RiffContainer::Chunk* chunk,
+    IRModuleChunk const* chunk,
     Session* session,
     SerialSourceLocReader* sourceLocReader)
 {
@@ -617,11 +605,8 @@ SlangResult decodeModuleIR(
     // are deserializing IR nodes directly from the format written
     // into the RIFF.
     //
-    auto listChunk = as<RiffContainer::ListChunk>(chunk);
-    if (!listChunk)
-        return SLANG_FAIL;
     IRSerialData serialData;
-    SLANG_RETURN_ON_FAIL(IRSerialReader::readContainer(listChunk, &serialData));
+    SLANG_RETURN_ON_FAIL(IRSerialReader::readFrom(chunk, &serialData));
 
     // Next we read the actual IR representation out from the
     // `serialData`. This is the step that may pull source-location
@@ -648,13 +633,11 @@ SlangResult decodeModuleIR(
     OwnedMemoryStream memoryStream(FileAccess::ReadWrite);
 
     {
-        RiffContainer riffContainer;
+        RIFF::Builder builder;
+        RIFF::BuildCursor cursor(builder);
 
-        // Need to put all of this in a container
-        RiffContainer::ScopeChunk containerScope(
-            &riffContainer,
-            RiffContainer::Chunk::Kind::List,
-            SerialBinary::kContainerFourCc);
+        // Need to put all of this in a module chunk
+        SLANG_SCOPED_RIFF_BUILDER_LIST_CHUNK(cursor, SerialBinary::kModuleFourCC);
 
         RefPtr<SerialSourceLocWriter> sourceLocWriter;
 
@@ -669,7 +652,7 @@ SlangResult decodeModuleIR(
             SLANG_RETURN_ON_FAIL(
                 writer.write(module, sourceLocWriter, options.optionFlags, &irData));
         }
-        SLANG_RETURN_ON_FAIL(IRSerialWriter::writeContainer(irData, &riffContainer));
+        SLANG_RETURN_ON_FAIL(IRSerialWriter::writeTo(irData, cursor));
 
         // Write the debug info Riff container
         if (sourceLocWriter)
@@ -677,10 +660,10 @@ SlangResult decodeModuleIR(
             SerialSourceLocData serialData;
             sourceLocWriter->write(&serialData);
 
-            SLANG_RETURN_ON_FAIL(serialData.writeContainer(&riffContainer));
+            SLANG_RETURN_ON_FAIL(serialData.writeTo(cursor));
         }
 
-        SLANG_RETURN_ON_FAIL(RiffUtil::write(&riffContainer, &memoryStream));
+        SLANG_RETURN_ON_FAIL(builder.writeTo(&memoryStream));
     }
 
     // Reset stream
@@ -692,33 +675,42 @@ SlangResult decodeModuleIR(
     // The read ir module
     RefPtr<IRModule> irReadModule;
     {
-        RiffContainer riffContainer;
-        SLANG_RETURN_ON_FAIL(RiffUtil::read(&memoryStream, riffContainer));
+        auto streamContents = memoryStream.getContents();
 
-        RiffContainer::ListChunk* rootList = riffContainer.getRoot();
+        auto rootChunk = RIFF::RootChunk::getFromBlob(
+            streamContents.getBuffer(),
+            streamContents.getCount());
+        if (!rootChunk)
+        {
+            return SLANG_FAIL;
+        }
+
+        auto moduleChunk = ModuleChunk::find(rootChunk);
+        if (!moduleChunk)
+        {
+            return SLANG_FAIL;
+        }
 
         RefPtr<SerialSourceLocReader> sourceLocReader;
 
         // If we have debug info then find and read it
         if (options.optionFlags & SerialOptionFlag::SourceLocation)
         {
-            RiffContainer::ListChunk* debugList =
-                rootList->findContainedList(SerialSourceLocData::kDebugFourCc);
-            if (!debugList)
+            auto debugChunk = DebugChunk::find(moduleChunk);
+            if (!debugChunk)
             {
                 return SLANG_FAIL;
             }
             SerialSourceLocData sourceLocData;
-            SLANG_RETURN_ON_FAIL(sourceLocData.readContainer(debugList));
+            SLANG_RETURN_ON_FAIL(sourceLocData.readFrom(debugChunk));
 
             sourceLocReader = new SerialSourceLocReader;
             SLANG_RETURN_ON_FAIL(sourceLocReader->read(&sourceLocData, &workSourceManager));
         }
 
         {
-            RiffContainer::ListChunk* irList =
-                rootList->findContainedList(IRSerialBinary::kIRModuleFourCc);
-            if (!irList)
+            auto irChunk = moduleChunk->findIR();
+            if (!irChunk)
             {
                 return SLANG_FAIL;
             }
@@ -726,7 +718,7 @@ SlangResult decodeModuleIR(
             {
                 IRSerialData irReadData;
                 IRSerialReader reader;
-                SLANG_RETURN_ON_FAIL(reader.readContainer(irList, &irReadData));
+                SLANG_RETURN_ON_FAIL(reader.readFrom(irChunk, &irReadData));
 
                 // Check the stream read data is the same
                 if (irData != irReadData)

--- a/source/slang/slang-serialize-container.h
+++ b/source/slang/slang-serialize-container.h
@@ -104,7 +104,19 @@ public:
 struct DebugChunk : RIFF::ListChunk
 {
 public:
-    static DebugChunk const* find(RIFF::ListChunk const* baseChunk);
+    /// Search for a debug information chunk.
+    static DebugChunk const* find(
+        RIFF::ListChunk const* baseChunk);
+
+    /// Search for a debug information chunk.
+    ///
+    /// The search will initially look in `baseChunk`, but
+    /// if that fails, it will fall back to the `containerChunk`
+    /// if that is non-null.
+    ///
+    static DebugChunk const* find(
+        RIFF::ListChunk const* baseChunk,
+        RIFF::ListChunk const* containerChunk);
 };
 
 SlangResult readSourceLocationsFromDebugChunk(

--- a/source/slang/slang-serialize-ir-types.h
+++ b/source/slang/slang-serialize-ir-types.h
@@ -20,20 +20,20 @@ class Name;
 struct IRSerialBinary
 {
     /// IR module list
-    static const FourCC kIRModuleFourCc = SLANG_FOUR_CC('S', 'i', 'm', 'd');
+    static const FourCC::RawValue kIRModuleFourCc = SLANG_FOUR_CC('S', 'i', 'm', 'd');
 
     /* NOTE! All FourCC that can be compressed must start with capital 'S', because compressed
     version is the same FourCC with the 'S' replaced with 's' */
 
-    static const FourCC kInstFourCc = SLANG_FOUR_CC('S', 'L', 'i', 'n');
-    static const FourCC kChildRunFourCc = SLANG_FOUR_CC('S', 'L', 'c', 'r');
-    static const FourCC kExternalOperandsFourCc = SLANG_FOUR_CC('S', 'L', 'e', 'o');
+    static const FourCC::RawValue kInstFourCc = SLANG_FOUR_CC('S', 'L', 'i', 'n');
+    static const FourCC::RawValue kChildRunFourCc = SLANG_FOUR_CC('S', 'L', 'c', 'r');
+    static const FourCC::RawValue kExternalOperandsFourCc = SLANG_FOUR_CC('S', 'L', 'e', 'o');
 
-    static const FourCC kUInt32RawSourceLocFourCc = SLANG_FOUR_CC('S', 'r', 's', '4');
+    static const FourCC::RawValue kUInt32RawSourceLocFourCc = SLANG_FOUR_CC('S', 'r', 's', '4');
 
     /// Debug information is held elsewhere, but if this optional section exists, it maps
     /// instructions to locs
-    static const FourCC kDebugSourceLocRunFourCc = SLANG_FOUR_CC('S', 'd', 's', 'r');
+    static const FourCC::RawValue kDebugSourceLocRunFourCc = SLANG_FOUR_CC('S', 'd', 's', 'r');
 };
 
 struct IRSerialData

--- a/source/slang/slang-serialize-ir.h
+++ b/source/slang/slang-serialize-ir.h
@@ -13,6 +13,8 @@
 
 namespace Slang
 {
+struct IRModuleChunk : RIFF::ListChunk
+{};
 
 struct IRSerialWriter
 {
@@ -26,7 +28,7 @@ struct IRSerialWriter
         IRSerialData* serialData);
 
     /// Write to a container
-    static Result writeContainer(const IRSerialData& data, RiffContainer* container);
+    static Result writeTo(const IRSerialData& data, RIFF::BuildCursor& cursor);
 
     /// Get an instruction index from an instruction
     Ser::InstIndex getInstIndex(IRInst* inst) const
@@ -93,7 +95,7 @@ struct IRSerialReader
     typedef IRSerialData Ser;
 
     /// Read a stream to fill in dataOut IRSerialData
-    static Result readContainer(RiffContainer::ListChunk* module, IRSerialData* outData);
+    static Result readFrom(IRModuleChunk const* irModuleChunk, IRSerialData* outData);
 
     /// Read a module from serial data
     Result read(

--- a/source/slang/slang-serialize-source-loc.cpp
+++ b/source/slang/slang-serialize-source-loc.cpp
@@ -385,47 +385,44 @@ SlangResult SerialSourceLocReader::read(
 
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! DebugSerialData !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
 
-/* static */ Result SerialSourceLocData::writeContainer(RiffContainer* container)
+/* static */ Result SerialSourceLocData::writeTo(RIFF::BuildCursor& cursor)
 {
-    RiffContainer::ScopeChunk debugChunkScope(
-        container,
-        RiffContainer::Chunk::Kind::List,
-        SerialSourceLocData::kDebugFourCc);
+    SLANG_SCOPED_RIFF_BUILDER_LIST_CHUNK(cursor, SerialSourceLocData::kDebugFourCc);
 
     SLANG_RETURN_ON_FAIL(SerialRiffUtil::writeArrayChunk(
         SerialSourceLocData::kDebugStringFourCc,
         m_stringTable,
-        container));
+        cursor));
     SLANG_RETURN_ON_FAIL(SerialRiffUtil::writeArrayChunk(
         SerialSourceLocData::kDebugLineInfoFourCc,
         m_lineInfos,
-        container));
+        cursor));
     SLANG_RETURN_ON_FAIL(SerialRiffUtil::writeArrayChunk(
         SerialSourceLocData::kDebugAdjustedLineInfoFourCc,
         m_adjustedLineInfos,
-        container));
+        cursor));
     SLANG_RETURN_ON_FAIL(SerialRiffUtil::writeArrayChunk(
         SerialSourceLocData::kDebugSourceInfoFourCc,
         m_sourceInfos,
-        container));
+        cursor));
 
     return SLANG_OK;
 }
 
-/* static */ Result SerialSourceLocData::readContainer(RiffContainer::ListChunk* listChunk)
+/* static */ Result SerialSourceLocData::readFrom(RIFF::ListChunk const* listChunk)
 {
-    SLANG_ASSERT(listChunk->getSubType() == SerialSourceLocData::kDebugFourCc);
+    SLANG_ASSERT(listChunk->getType() == SerialSourceLocData::kDebugFourCc);
 
     clear();
-    for (RiffContainer::Chunk* chunk = listChunk->m_containedChunks; chunk; chunk = chunk->m_next)
+    for(auto chunk : listChunk->getChildren())
     {
-        RiffContainer::DataChunk* dataChunk = as<RiffContainer::DataChunk>(chunk);
+        auto dataChunk = as<RIFF::DataChunk>(chunk);
         if (!dataChunk)
         {
             continue;
         }
 
-        switch (dataChunk->m_fourCC)
+        switch (dataChunk->getType())
         {
         case SerialSourceLocData::kDebugStringFourCc:
             {

--- a/source/slang/slang-serialize-source-loc.h
+++ b/source/slang/slang-serialize-source-loc.h
@@ -21,12 +21,12 @@ public:
     typedef SerialStringData::StringIndex StringIndex;
 
     // The list that contains all the subsequent modules
-    static const FourCC kDebugFourCc = SLANG_FOUR_CC('S', 'd', 'e', 'b');
+    static const FourCC::RawValue kDebugFourCc = SLANG_FOUR_CC('S', 'd', 'e', 'b');
 
-    static const FourCC kDebugStringFourCc = SLANG_FOUR_CC('S', 'd', 's', 't');
-    static const FourCC kDebugLineInfoFourCc = SLANG_FOUR_CC('S', 'd', 'l', 'n');
-    static const FourCC kDebugAdjustedLineInfoFourCc = SLANG_FOUR_CC('S', 'd', 'a', 'l');
-    static const FourCC kDebugSourceInfoFourCc = SLANG_FOUR_CC('S', 'd', 's', 'o');
+    static const FourCC::RawValue kDebugStringFourCc = SLANG_FOUR_CC('S', 'd', 's', 't');
+    static const FourCC::RawValue kDebugLineInfoFourCc = SLANG_FOUR_CC('S', 'd', 'l', 'n');
+    static const FourCC::RawValue kDebugAdjustedLineInfoFourCc = SLANG_FOUR_CC('S', 'd', 'a', 'l');
+    static const FourCC::RawValue kDebugSourceInfoFourCc = SLANG_FOUR_CC('S', 'd', 's', 'o');
 
     struct SourceRange
     {
@@ -135,8 +135,8 @@ public:
 
     bool operator==(const ThisType& rhs) const;
 
-    Result writeContainer(RiffContainer* container);
-    Result readContainer(RiffContainer::ListChunk* listChunk);
+    Result writeTo(RIFF::BuildCursor& cursor);
+    Result readFrom(RIFF::ListChunk const* chunk);
 
     List<char> m_stringTable;                   ///< String table for debug use only
     List<LineInfo> m_lineInfos;                 ///< Line information

--- a/source/slang/slang-serialize-types.cpp
+++ b/source/slang/slang-serialize-types.cpp
@@ -149,41 +149,38 @@ struct ByteReader
     const void* data,
     size_t numEntries,
     size_t typeSize,
-    RiffContainer* container)
+    RIFF::BuildCursor& cursor)
 {
-    typedef RiffContainer::Chunk Chunk;
-    typedef RiffContainer::ScopeChunk ScopeChunk;
-
     if (numEntries == 0)
     {
         return SLANG_OK;
     }
 
-    ScopeChunk scope(container, Chunk::Kind::Data, chunkId);
+    SLANG_SCOPED_RIFF_BUILDER_DATA_CHUNK(cursor, chunkId);
 
     SerialBinary::ArrayHeader header;
     header.numEntries = uint32_t(numEntries);
 
-    container->write(&header, sizeof(header));
-    container->write(data, typeSize * numEntries);
+    cursor.addData(&header, sizeof(header));
+    cursor.addData(data, typeSize * numEntries);
     return SLANG_OK;
 }
 
 /* static */ Result SerialRiffUtil::readArrayChunk(
-    RiffContainer::DataChunk* dataChunk,
+    RIFF::DataChunk const* dataChunk,
     ListResizer& listOut)
 {
     typedef SerialBinary Bin;
 
-    RiffReadHelper read = dataChunk->asReadHelper();
-    const size_t typeSize = listOut.getTypeSize();
+    MemoryReader reader(dataChunk->getPayload(), dataChunk->getPayloadSize());
+    const Size typeSize = listOut.getTypeSize();
 
     Bin::ArrayHeader header;
-    SLANG_RETURN_ON_FAIL(read.read(header));
-    const size_t payloadSize = header.numEntries * typeSize;
-    SLANG_ASSERT(payloadSize == read.getRemainingSize());
+    SLANG_RETURN_ON_FAIL(reader.read(header));
+    const Size payloadSize = header.numEntries * typeSize;
+    SLANG_ASSERT(payloadSize == reader.getRemainingSize());
     void* dst = listOut.setSize(header.numEntries);
-    ::memcpy(dst, read.getData(), payloadSize);
+    ::memcpy(dst, reader.getRemainingData(), payloadSize);
 
     return SLANG_OK;
 }

--- a/source/slang/slang-serialize-types.h
+++ b/source/slang/slang-serialize-types.h
@@ -125,7 +125,6 @@ struct PropertyKeys<Module>
 {
     static const FourCC::RawValue Digest = SLANG_FOUR_CC('S', 'H', 'A', '1');
     static const FourCC::RawValue ASTModule = SLANG_FOUR_CC('a', 's', 't', ' ');
-    static const FourCC::RawValue IRModule = SLANG_FOUR_CC('i', 'r', ' ', ' ');
     static const FourCC::RawValue FileDependencies = SLANG_FOUR_CC('f', 'd', 'e', 'p');
 };
 

--- a/source/slang/slang-serialize-types.h
+++ b/source/slang/slang-serialize-types.h
@@ -123,66 +123,66 @@ struct PropertyKeys
 template<>
 struct PropertyKeys<Module>
 {
-    static const FourCC Digest = SLANG_FOUR_CC('S', 'H', 'A', '1');
-    static const FourCC ASTModule = SLANG_FOUR_CC('a', 's', 't', ' ');
-    static const FourCC IRModule = SLANG_FOUR_CC('i', 'r', ' ', ' ');
-    static const FourCC FileDependencies = SLANG_FOUR_CC('f', 'd', 'e', 'p');
+    static const FourCC::RawValue Digest = SLANG_FOUR_CC('S', 'H', 'A', '1');
+    static const FourCC::RawValue ASTModule = SLANG_FOUR_CC('a', 's', 't', ' ');
+    static const FourCC::RawValue IRModule = SLANG_FOUR_CC('i', 'r', ' ', ' ');
+    static const FourCC::RawValue FileDependencies = SLANG_FOUR_CC('f', 'd', 'e', 'p');
 };
 
 // For types/FourCC that work for serializing in general (not just IR).
 struct SerialBinary
 {
-    static const FourCC kRiffFourCc = RiffFourCC::kRiff;
+    static const FourCC::RawValue kRiffFourCc = RIFF::RootChunk::kTag;
 
     /// Container
-    static const FourCC kContainerFourCc = SLANG_FOUR_CC('S', 'L', 'm', 'c');
+    static const FourCC::RawValue kContainerFourCc = SLANG_FOUR_CC('S', 'L', 'm', 'c');
 
     /// A string table
-    static const FourCC kStringTableFourCc = SLANG_FOUR_CC('S', 'L', 's', 't');
+    static const FourCC::RawValue kStringTableFourCc = SLANG_FOUR_CC('S', 'L', 's', 't');
 
     /// TranslationUnitList
-    static const FourCC kModuleListFourCc = SLANG_FOUR_CC('S', 'L', 'm', 'l');
+    static const FourCC::RawValue kModuleListFourCc = SLANG_FOUR_CC('S', 'L', 'm', 'l');
 
     /// An entry point
-    static const FourCC kEntryPointFourCc = SLANG_FOUR_CC('E', 'P', 'n', 't');
+    static const FourCC::RawValue kEntryPointFourCc = SLANG_FOUR_CC('E', 'P', 'n', 't');
 
-    static const FourCC kEntryPointListFourCc = SLANG_FOUR_CC('e', 'p', 't', 's');
+    static const FourCC::RawValue kEntryPointListFourCc = SLANG_FOUR_CC('e', 'p', 't', 's');
 
     // Module
-    static const FourCC kModuleFourCC = SLANG_FOUR_CC('s', 'm', 'o', 'd');
+    static const FourCC::RawValue kModuleFourCC = SLANG_FOUR_CC('s', 'm', 'o', 'd');
 
     // The following are "generic" codes, suitable for
     // use when serializing content using JSON-like structure.
     //
-    static const FourCC kObjectFourCC = SLANG_FOUR_CC('o', 'b', 'j', ' ');
-    static const FourCC kPairFourCC = SLANG_FOUR_CC('p', 'a', 'i', 'r');
-    static const FourCC kArrayFourCC = SLANG_FOUR_CC('a', 'r', 'r', 'y');
-    static const FourCC kDictionaryFourCC = SLANG_FOUR_CC('d', 'i', 'c', 't');
-    static const FourCC kNullFourCC = SLANG_FOUR_CC('n', 'u', 'l', 'l');
-    static const FourCC kStringFourCC = SLANG_FOUR_CC('s', 't', 'r', ' ');
-    static const FourCC kTrueFourCC = SLANG_FOUR_CC('t', 'r', 'u', 'e');
-    static const FourCC kFalseFourCC = SLANG_FOUR_CC('f', 'a', 'l', 's');
-    static const FourCC kInt32FourCC = SLANG_FOUR_CC('i', '3', '2', ' ');
-    static const FourCC kUInt32FourCC = SLANG_FOUR_CC('u', '3', '2', ' ');
-    static const FourCC kFloat32FourCC = SLANG_FOUR_CC('f', '3', '2', ' ');
-    static const FourCC kInt64FourCC = SLANG_FOUR_CC('i', '6', '4', ' ');
-    static const FourCC kUInt64FourCC = SLANG_FOUR_CC('u', '6', '4', ' ');
-    static const FourCC kFloat64FourCC = SLANG_FOUR_CC('f', '6', '4', ' ');
+    static const FourCC::RawValue kObjectFourCC = SLANG_FOUR_CC('o', 'b', 'j', ' ');
+    static const FourCC::RawValue kPairFourCC = SLANG_FOUR_CC('p', 'a', 'i', 'r');
+    static const FourCC::RawValue kArrayFourCC = SLANG_FOUR_CC('a', 'r', 'r', 'y');
+    static const FourCC::RawValue kDictionaryFourCC = SLANG_FOUR_CC('d', 'i', 'c', 't');
+    static const FourCC::RawValue kNullFourCC = SLANG_FOUR_CC('n', 'u', 'l', 'l');
+    static const FourCC::RawValue kStringFourCC = SLANG_FOUR_CC('s', 't', 'r', ' ');
+    static const FourCC::RawValue kTrueFourCC = SLANG_FOUR_CC('t', 'r', 'u', 'e');
+    static const FourCC::RawValue kFalseFourCC = SLANG_FOUR_CC('f', 'a', 'l', 's');
+    static const FourCC::RawValue kInt32FourCC = SLANG_FOUR_CC('i', '3', '2', ' ');
+    static const FourCC::RawValue kUInt32FourCC = SLANG_FOUR_CC('u', '3', '2', ' ');
+    static const FourCC::RawValue kFloat32FourCC = SLANG_FOUR_CC('f', '3', '2', ' ');
+    static const FourCC::RawValue kInt64FourCC = SLANG_FOUR_CC('i', '6', '4', ' ');
+    static const FourCC::RawValue kUInt64FourCC = SLANG_FOUR_CC('u', '6', '4', ' ');
+    static const FourCC::RawValue kFloat64FourCC = SLANG_FOUR_CC('f', '6', '4', ' ');
 
     // The following codes are suitable for use when serializing
     // content that represents a logical file system.
     //
-    static const FourCC kDirectoryFourCC = SLANG_FOUR_CC('d', 'i', 'r', ' ');
-    static const FourCC kFileFourCC = SLANG_FOUR_CC('f', 'i', 'l', 'e');
-    static const FourCC kNameFourCC = SLANG_FOUR_CC('n', 'a', 'm', 'e');
-    static const FourCC kPathFourCC = SLANG_FOUR_CC('p', 'a', 't', 'h');
-    static const FourCC kDataFourCC = SLANG_FOUR_CC('d', 'a', 't', 'a');
+    static const FourCC::RawValue kDirectoryFourCC = SLANG_FOUR_CC('d', 'i', 'r', ' ');
+    static const FourCC::RawValue kFileFourCC = SLANG_FOUR_CC('f', 'i', 'l', 'e');
+    static const FourCC::RawValue kNameFourCC = SLANG_FOUR_CC('n', 'a', 'm', 'e');
+    static const FourCC::RawValue kPathFourCC = SLANG_FOUR_CC('p', 'a', 't', 'h');
+    static const FourCC::RawValue kDataFourCC = SLANG_FOUR_CC('d', 'a', 't', 'a');
 
     // TODO(tfoley): Figure out where to put all of these so that
     // they can be more usefully addressed.
     //
-    static const FourCC kMangledNameFourCC = SLANG_FOUR_CC('m', 'g', 'n', 'm');
-    static const FourCC kProfileFourCC = SLANG_FOUR_CC('p', 'r', 'o', 'f');
+    static const FourCC::RawValue kMangledNameFourCC = SLANG_FOUR_CC('m', 'g', 'n', 'm');
+    static const FourCC::RawValue kProfileFourCC = SLANG_FOUR_CC('p', 'r', 'o', 'f');
 
 
     struct ArrayHeader
@@ -233,23 +233,23 @@ struct SerialRiffUtil
         const void* data,
         size_t numEntries,
         size_t typeSize,
-        RiffContainer* container);
+        RIFF::BuildCursor& cursor);
 
     template<typename T>
-    static Result writeArrayChunk(FourCC chunkId, const List<T>& array, RiffContainer* container)
+    static Result writeArrayChunk(FourCC chunkId, const List<T>& array, RIFF::BuildCursor& cursor)
     {
         return writeArrayChunk(
             chunkId,
             array.begin(),
             size_t(array.getCount()),
             sizeof(T),
-            container);
+            cursor);
     }
 
-    static Result readArrayChunk(RiffContainer::DataChunk* dataChunk, ListResizer& listOut);
+    static Result readArrayChunk(RIFF::DataChunk const* dataChunk, ListResizer& listOut);
 
     template<typename T>
-    static Result readArrayChunk(RiffContainer::DataChunk* dataChunk, List<T>& arrayOut)
+    static Result readArrayChunk(RIFF::DataChunk const* dataChunk, List<T>& arrayOut)
     {
         ListResizerForType<T> resizer(arrayOut);
         return readArrayChunk(dataChunk, resizer);

--- a/source/slang/slang-serialize.h
+++ b/source/slang/slang-serialize.h
@@ -370,7 +370,7 @@ public:
     float decodeFloat32() { return float(decodeFloat()); }
     double decodeFloat64() { return decodeFloat(); }
 
-    FourCC getTag() { return _cursor ? _cursor->getType() : 0; }
+    FourCC getTag() { return _cursor ? _cursor->getType() : FourCC(0); }
 
     Int32 _decodeImpl(Int32*) { return decodeInt32(); }
     UInt32 _decodeImpl(UInt32*) { return decodeUInt32(); }

--- a/source/slang/slang-serialize.h
+++ b/source/slang/slang-serialize.h
@@ -438,7 +438,7 @@ public:
             SLANG_UNEXPECTED("invalid format in RIFF");
         }
 
-        _cursor = listChunk->getFirstChild();
+        _cursor = found->getFirstChild();
     }
 
     bool hasElements() { return _cursor != nullptr; }

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -4582,7 +4582,7 @@ static TypeLayoutResult _updateLayout(
     if (layoutResultPtr)
     {
         // Check the layout is the same!
-        SLANG_ASSERT(layoutResultPtr->layout.get() == result.layout);
+        SLANG_ASSERT(layoutResultPtr->layout == result.layout);
         // Update the info
         layoutResultPtr->info = result.info;
     }

--- a/tools/gfx-unit-test/copy-texture-tests.cpp
+++ b/tools/gfx-unit-test/copy-texture-tests.cpp
@@ -37,7 +37,7 @@ struct BaseCopyTextureTest
     IDevice* device;
     UnitTestContext* context;
 
-    Size alignedRowStride;
+    gfx::Size alignedRowStride;
 
     RefPtr<TextureInfo> srcTextureInfo;
     RefPtr<TextureInfo> dstTextureInfo;

--- a/tools/gfx-unit-test/gfx-test-texture-util.cpp
+++ b/tools/gfx-unit-test/gfx-test-texture-util.cpp
@@ -42,7 +42,7 @@ TextureAspect getTextureAspect(Format format)
     }
 }
 
-Size getTexelSize(Format format)
+gfx::Size getTexelSize(Format format)
 {
     FormatInfo info;
     GFX_CHECK_CALL_ABORT(gfxGetFormatInfo(format, &info));
@@ -285,8 +285,8 @@ List<uint8_t> removePadding(
     ISlangBlob* pixels,
     GfxCount width,
     GfxCount height,
-    Size rowPitch,
-    Size pixelSize)
+    gfx::Size rowPitch,
+    gfx::Size pixelSize)
 {
     List<uint8_t> buffer;
     buffer.setCount(height * rowPitch);

--- a/tools/gfx-unit-test/gfx-test-texture-util.h
+++ b/tools/gfx-unit-test/gfx-test-texture-util.h
@@ -12,9 +12,9 @@ namespace gfx_test
 {
 struct Strides
 {
-    Size x;
-    Size y;
-    Size z;
+    gfx::Size x;
+    gfx::Size y;
+    gfx::Size z;
 };
 
 struct ValidationTextureFormatBase : RefObject
@@ -194,7 +194,7 @@ struct TextureInfo : RefObject
 };
 
 TextureAspect getTextureAspect(Format format);
-Size getTexelSize(Format format);
+gfx::Size getTexelSize(Format format);
 GfxIndex getSubresourceIndex(GfxIndex mipLevel, GfxCount mipLevelCount, GfxIndex baseArrayLayer);
 RefPtr<ValidationTextureFormatBase> getValidationTextureFormat(Format format);
 void generateTextureData(
@@ -205,8 +205,8 @@ List<uint8_t> removePadding(
     ISlangBlob* pixels,
     GfxCount width,
     GfxCount height,
-    Size rowPitch,
-    Size pixelSize);
+    gfx::Size rowPitch,
+    gfx::Size pixelSize);
 Slang::Result writeImage(const char* filename, ISlangBlob* pixels, uint32_t width, uint32_t height);
 Slang::Result writeImage(
     const char* filename,

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -838,7 +838,7 @@ void RenderTestApp::_initializeAccelerationStructure()
     {
         AccelerationStructureInstanceDescType nativeInstanceDescType =
             getAccelerationStructureInstanceDescType(m_device);
-        Size nativeInstanceDescSize =
+        rhi::Size nativeInstanceDescSize =
             getAccelerationStructureInstanceDescSize(nativeInstanceDescType);
 
         List<AccelerationStructureInstanceDescGeneric> genericInstanceDescs;

--- a/tools/slang-unit-test/unit-test-riff.cpp
+++ b/tools/slang-unit-test/unit-test-riff.cpp
@@ -9,7 +9,7 @@ using namespace Slang;
 static void _writeRandom(
     RandomGenerator* rand,
     size_t maxSize,
-    RiffContainer& ioContainer,
+    RIFF::BuildCursor& cursor,
     List<uint8_t>& ioData)
 {
     while (true)
@@ -27,84 +27,263 @@ static void _writeRandom(
         rand->nextData(ioData.getBuffer() + oldCount, allocSize);
 
         // Write
-        ioContainer.write(ioData.getBuffer() + oldCount, allocSize);
+        cursor.addData(ioData.getBuffer() + oldCount, allocSize);
     }
 
     // Should be a single block with same data as the List
-    RiffContainer::DataChunk* dataChunk =
-        as<RiffContainer::DataChunk>(ioContainer.getCurrentChunk());
+    auto dataChunk =
+        as<RIFF::DataChunkBuilder>(cursor.getCurrentChunk());
     SLANG_ASSERT(dataChunk);
+}
+
+namespace
+{
+    struct DumpContext
+    {
+    private:
+        WriterHelper _writer;
+        Count _indent = 0;
+        Count _hexByteCount = 0;
+        bool _isRoot = true;
+
+    public:
+        DumpContext(ISlangWriter* writer)
+            : _writer(writer)
+        {}
+
+        void beginListChunk(RIFF::Chunk::Type type)
+        {
+            _dumpIndent();
+            // If it's the root it's 'riff'
+            _dumpRiffType(_isRoot ? RIFF::RootChunk::kTag : RIFF::ListChunk::kTag);
+            _writer.put(" ");
+            _dumpRiffType(type);
+            _writer.put("\n");
+            _indent++;
+        }
+
+        void endListChunk()
+        {
+            _indent--;
+        }
+
+        void beginDataChunk(RIFF::Chunk::Type type)
+        {
+            _dumpIndent();
+            // Write out the name
+            _dumpRiffType(type);
+            _writer.put("\n");
+            _indent++;
+
+            _hexByteCount = 0;
+        }
+
+        void endDataChunk()
+        {
+            _indent--;
+        }
+
+        void handleData(void const* data, Size size)
+        {
+            auto cursor = static_cast<Byte const*>(data);
+            auto remainingSize = size;
+            while (remainingSize--)
+            {
+                auto byte = *cursor++;
+
+                static const Count kBytesPerLine = 32;
+                static const Count kBytesPerCluster = 4;
+                if (_hexByteCount % kBytesPerLine == 0)
+                {
+                    _writer.put("\n");
+                    _dumpIndent();
+                }
+                else if (_hexByteCount % kBytesPerCluster == 0)
+                {
+                    _writer.put(" ");
+                }
+                _hexByteCount++;
+
+                char text[4] = { 0, 0, ' ', 0};
+
+                char const* hexDigits = "0123456789abcdef";
+                text[0] = hexDigits[(byte >> 4) & 0xF];
+                text[1] = hexDigits[(byte >> 0) & 0xF];
+
+                _writer.put(text);
+            }
+        }
+
+        void _dumpIndent()
+        {
+            for (int i = 0; i < _indent; ++i)
+            {
+                _writer.put("  ");
+            }
+        }
+        void _dumpRiffType(FourCC fourCC)
+        {
+            auto rawValue = FourCC::RawValue(fourCC);
+
+            char text[5];
+            for (int i = 0; i < 4; ++i)
+            {
+                text[i] = char(rawValue & 0xFF);
+                rawValue >>= 8;
+            }
+            text[4] = 0;
+            _writer.put(text);
+        }
+    };
+
+} // namespace
+
+static void _dump(RIFF::Chunk const* chunk, DumpContext context)
+{
+    if (auto listChunk = as<RIFF::ListChunk>(chunk))
+    {
+        context.beginListChunk(listChunk->getType());
+        for (auto child : listChunk->getChildren())
+            _dump(child, context);
+        context.endListChunk();
+    }
+    else if (auto dataChunk = as<RIFF::DataChunk>(chunk))
+    {
+        context.beginDataChunk(dataChunk->getType());
+        context.handleData(dataChunk->getPayload(), dataChunk->getPayloadSize());
+        context.endDataChunk();
+    }
+}
+
+static void _dump(RIFF::ChunkBuilder* chunk, DumpContext context)
+{
+    if (auto listChunk = as<RIFF::ListChunkBuilder>(chunk))
+    {
+        context.beginListChunk(listChunk->getType());
+        for (auto child : listChunk->getChildren())
+            _dump(child, context);
+        context.endListChunk();
+    }
+    else if (auto dataChunk = as<RIFF::DataChunkBuilder>(chunk))
+    {
+        context.beginDataChunk(dataChunk->getType());
+        for (auto shard : dataChunk->getShards())
+            context.handleData(shard->getPayload(), shard->getPayloadSize());
+        context.endDataChunk();
+    }
+}
+
+static bool _isSingleShard(RIFF::DataChunkBuilder* chunk)
+{
+    Count count = 0;
+    for (auto shard : chunk->getShards())
+    {
+        count++;
+        if (count > 1)
+            break;
+    }
+    return count == 1;
+}
+
+static bool _isEqual(RIFF::DataChunkBuilder* chunk, void const* data, Size size)
+{
+    auto remainingData = static_cast<Byte const*>(data);
+    auto remainingSize = size;
+
+    for (auto shard : chunk->getShards())
+    {
+        // If there is more content in the chunk than remains
+        // to compare against, then there is no chance of a match.
+        //
+        auto shardSize = shard->getPayloadSize();
+        if (shard->getPayloadSize() > remainingSize)
+        {
+            return false;
+        }
+
+        // Contents must match, byte-for-byte.
+        //
+        if (::memcmp(remainingData, shard->getPayload(), shardSize) != 0)
+        {
+            return false;
+        }
+
+        remainingData += shardSize;
+        remainingSize -= shardSize;
+    }
+
+    // If we reach the end of the chunk, then we have
+    // a match if there is no data remaining to
+    // compare against.
+    //
+    return remainingSize == 0;
 }
 
 SLANG_UNIT_TEST(riff)
 {
-    typedef RiffContainer::ScopeChunk ScopeChunk;
-    typedef RiffContainer::Chunk::Kind Kind;
-
     const FourCC markThings = SLANG_FOUR_CC('T', 'H', 'I', 'N');
     const FourCC markData = SLANG_FOUR_CC('D', 'A', 'T', 'A');
 
     {
-        RiffContainer container;
+        RIFF::Builder riffBuilder;
+        RIFF::BuildCursor cursor(riffBuilder);
 
         {
-            ScopeChunk scopeContainer(&container, Kind::List, markThings);
+            SLANG_SCOPED_RIFF_BUILDER_LIST_CHUNK(cursor, markThings);
             {
-                ScopeChunk scopeChunk(&container, Kind::Data, markData);
+                SLANG_SCOPED_RIFF_BUILDER_DATA_CHUNK(cursor, markData);
 
                 const char hello[] = "Hello ";
                 const char world[] = "World!";
 
-                container.write(hello, sizeof(hello));
-                container.write(world, sizeof(world));
+                cursor.addData(hello, sizeof(hello));
+                cursor.addData(world, sizeof(world));
             }
 
             {
-                ScopeChunk scopeChunk(&container, Kind::Data, markData);
+                SLANG_SCOPED_RIFF_BUILDER_DATA_CHUNK(cursor, markData);
 
                 const char test0[] = "Testing... ";
                 const char test1[] = "Testing!";
 
-                container.write(test0, sizeof(test0));
-                container.write(test1, sizeof(test1));
+                cursor.addData(test0, sizeof(test0));
+                cursor.addData(test1, sizeof(test1));
             }
 
             {
-                ScopeChunk innerScopeContainer(&container, Kind::List, markThings);
+                SLANG_SCOPED_RIFF_BUILDER_LIST_CHUNK(cursor, markThings);
 
                 {
-                    ScopeChunk scopeChunk(&container, Kind::Data, markData);
+                    SLANG_SCOPED_RIFF_BUILDER_DATA_CHUNK(cursor, markData);
 
                     const char another[] = "Another?";
-                    container.write(another, sizeof(another));
+                    cursor.addData(another, sizeof(another));
                 }
             }
         }
 
-        SLANG_CHECK(container.isFullyConstructed());
-        SLANG_CHECK(RiffContainer::isChunkOk(container.getRoot()));
+        SLANG_CHECK(cursor.getCurrentChunk() == nullptr);
+        SLANG_CHECK(riffBuilder.getRootChunk() != nullptr);
 
         {
             StringBuilder builder;
             {
-                StringWriter writer(&builder, 0);
-                RiffUtil::dump(container.getRoot(), &writer);
+                StringWriter writer(&builder);
+                _dump(riffBuilder.getRootChunk(), &writer);
             }
 
             {
-                OwnedMemoryStream stream(FileAccess::ReadWrite);
-                SLANG_CHECK(SLANG_SUCCEEDED(RiffUtil::write(container.getRoot(), true, &stream)));
+                ComPtr<ISlangBlob> blob;
+                SLANG_CHECK(SLANG_SUCCEEDED(riffBuilder.writeToBlob(blob.writeRef())));
 
-                stream.seek(SeekOrigin::Start, 0);
-
-                RiffContainer readContainer;
-                SLANG_CHECK(SLANG_SUCCEEDED(RiffUtil::read(&stream, readContainer)));
+                auto rootChunk = RIFF::RootChunk::getFromBlob(blob);
+                SLANG_CHECK(rootChunk != nullptr);
 
                 // Dump the read contents
                 StringBuilder readBuilder;
                 {
                     StringWriter writer(&readBuilder, 0);
-                    RiffUtil::dump(readContainer.getRoot(), &writer);
+                    _dump(rootChunk, &writer);
                 }
 
                 // They should be the same
@@ -116,29 +295,31 @@ SLANG_UNIT_TEST(riff)
     // Test writing as a stream only allocates a single data block (as long as there is enough
     // space).
     {
-        RiffContainer container;
+        RIFF::Builder builder;
+        RIFF::BuildCursor cursor(builder);
 
-        ScopeChunk scopeChunk(&container, Kind::List, markData);
+        SLANG_SCOPED_RIFF_BUILDER_LIST_CHUNK(cursor, markThings);
         {
-            ScopeChunk scopeChunk(&container, Kind::Data, markData);
+            SLANG_SCOPED_RIFF_BUILDER_DATA_CHUNK(cursor, markData);
+
             RefPtr<RandomGenerator> rand = RandomGenerator::create(0x345234);
 
             List<uint8_t> data;
             _writeRandom(
                 rand,
-                container.getMemoryArena().getBlockPayloadSize() / 2,
-                container,
+                builder._getMemoryArena().getBlockPayloadSize() / 2,
+                cursor,
                 data);
 
             // Should be a single block with same data as the List
-            RiffContainer::DataChunk* dataChunk =
-                as<RiffContainer::DataChunk>(container.getCurrentChunk());
+            RIFF::DataChunkBuilder* dataChunk =
+                as<RIFF::DataChunkBuilder>(cursor.getCurrentChunk());
             SLANG_ASSERT(dataChunk);
 
-            // It should be a single block
-            SLANG_CHECK(dataChunk->getSingleData() != nullptr);
+            // It should be a single shard
+            SLANG_CHECK(_isSingleShard(dataChunk));
 
-            SLANG_CHECK(dataChunk->isEqual(data.getBuffer(), data.getCount()));
+            SLANG_CHECK(_isEqual(dataChunk, data.getBuffer(), data.getCount()));
         }
     }
 
@@ -148,23 +329,24 @@ SLANG_UNIT_TEST(riff)
 
         for (Int i = 0; i < 100; ++i)
         {
-            RiffContainer container;
+            RIFF::Builder builder;
+            RIFF::BuildCursor cursor(builder);
 
             const size_t maxSize = rand->nextInt32InRange(
                 1,
-                int32_t(container.getMemoryArena().getBlockPayloadSize() * 3));
+                int32_t(builder._getMemoryArena().getBlockPayloadSize() * 3));
 
-            ScopeChunk scopeChunk(&container, Kind::List, markData);
+            SLANG_SCOPED_RIFF_BUILDER_LIST_CHUNK(cursor, markThings);
             {
-                ScopeChunk scopeChunk(&container, Kind::Data, markData);
+                SLANG_SCOPED_RIFF_BUILDER_DATA_CHUNK(cursor, markData);
 
                 List<uint8_t> data;
-                _writeRandom(rand, maxSize, container, data);
+                _writeRandom(rand, maxSize, cursor, data);
 
                 // Should be a single block with same data as the List
-                RiffContainer::DataChunk* dataChunk =
-                    as<RiffContainer::DataChunk>(container.getCurrentChunk());
-                SLANG_CHECK(dataChunk && dataChunk->isEqual(data.getBuffer(), data.getCount()));
+                RIFF::DataChunkBuilder* dataChunk =
+                    as<RIFF::DataChunkBuilder>(cursor.getCurrentChunk());
+                SLANG_CHECK(dataChunk && _isEqual(dataChunk, data.getBuffer(), data.getCount()));
             }
         }
     }


### PR DESCRIPTION
This change ends up being an almost complete rewrite of the subsystem in `slang-riff.{h,cpp}`.

The original design of `RiffContainer` had a single type servicing the cases when the code wants to *read* a RIFF as well as when it wants to *write* a RIFF. It also contained a lot of API surface area, much of which only got used in a small number of places, if at all.

The biggest change in the new implementation is that there is a strong separation between reading and writing of RIFF-structured data.

Reading
-------

When reading, the new `RIFF::Chunk` type can be used to traverse the hierarchy of a RIFF-structured file in memory without needing to make a copy of it. One concrete consequence of this change is that we no longer make extra copies of the entire serialized core module (one copy of the compressed version, and then one copy of the decompressed version), as part of creating a global session; instead, the code is able to directly traverse the RIFF hierarchy in the `ISlangBlob` that the archive file system returns.

The implementation includes a fair bit of validation logic to try to make sure that code is defensive against accidentally corrupted or malformed input (for example, see `RIFF::RootChunk::getFromBlob()`, `RIFF::ListChunk::getFirstChild()`, and `RIFF::BoundsCheckedChunkPtr::getNextSibling()`), although it is certainly not hardened against malicious input.

Because reading of RIFF data is now being done without any copying, any code reading from RIFF chunks needs to be robust against unaligned data. Fortunately, there were very few locations in the codebase that were assuming alignment when reading from RIFF files, and those few locations were easy enough to fix.

Some of the code related top deserialization of Slang modules was already using wrapper types around pointers to chunks in a `RiffContainer` (e.g., `ModuleChunkRef`). These use cases could be conveniently ported to declare subtypes of `RIFF::Chunk`, which allows all of that code to pass around pointer directly into the serialized RIFF data, while also maintaining some static typing so that we can clearly tell, e.g., an `ASTModuleChunk` from an `IRModuleChunk`.

Writing
-------

What used to be the `RiffContainer` type is now split between `RIFF::Builder`, which owns the tree of chunks, and `RIFF::BuildCursor`, which factors out the stateful part of `RiffContainer` where it had a notion of a "current chunk."

The builder uses a hierarchy of `RIFF::ChunkBuilder` types, distinct from the `RIFF::Chunk` types that are used for reading.

A lot of the functionality has been stripped out from this version. The hope is that what remains is easier to understand, and will be easier to maintain going forward.

Other Stuff
-----------

Smaller changes include:

* Made the RIFF `FourCC` type use a `union` so that it is easier to see the textual version of a `FourCC` when debugging.

* Took a lot of the RIFF-related functionality that was only being used by `unit-test-riff.cpp` and moved it into the unit test file itself. If we ever want that stuff to be public API again, we could migrate the code back, but I don't see that happening.

* Removed the `RiffSemanticVersion` type, since it was only being used by `slang-repro.{h,cpp}`, which could easily just use `SemanticVersion`. Also cleaned up some other use cases or `SemanticVersion` based on changes to its exposed API.

* Added a `Size` type to `slang-common.h` to go along with `Index` and `Count` in terms of documenting intent. Dealt with the fallout around `slang-gfx` and `slang-rhi` already defining their own `Size` types.

* Changed the `Byte` type in `slang-common.h` to be `unsigned char`, to help us try to avoid undefined behavior when doing type punning using arrays of `Byte`s.