### PR TITLE
Restore Properties section name in stdlib reference

### DIFF
--- a/source/slang/slang-doc-markdown-writer.cpp
+++ b/source/slang/slang-doc-markdown-writer.cpp
@@ -1989,7 +1989,7 @@ void DocMarkdownWriter::writeAggType(
         _getDeclsOfType<PropertyDecl>(this, page, properties);
         if (properties.getCount())
         {
-            out << toSlice("## m_currentPage->path\n\n");
+            out << toSlice("## Properties\n\n");
             _appendAsBullets(_getAsNameAndTextList(properties), true, 0);
             out << toSlice("\n");
         }


### PR DESCRIPTION
Fixes https://github.com/shader-slang/shader-slang.github.io/issues/98

This change restores the name of the "Properties" section in the Standard Modules Reference after I accidently overwrote it with some code in https://github.com/shader-slang/slang/pull/6904