### PR TITLE
Add a new option "-capability" to slang-test and render-test

### DIFF
--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -170,6 +170,19 @@ static rhi::DeviceType _toRenderType(Slang::RenderApiType apiType)
         {
             outOptions.generateSPIRVDirectly = false;
         }
+        else if (argValue == "-capability" || argValue == "-capabilities")
+        {
+            String capabilities;
+            SLANG_RETURN_ON_FAIL(reader.expectArg(capabilities));
+
+            List<UnownedStringSlice> values;
+            StringUtil::split(capabilities.getUnownedSlice(), ',', values);
+
+            for (const auto& value : values)
+            {
+                outOptions.capabilities.add(value);
+            }
+        }
         else if (argValue == "-only-startup")
         {
             outOptions.onlyStartup = true;

--- a/tools/render-test/options.h
+++ b/tools/render-test/options.h
@@ -95,6 +95,8 @@ struct Options
 
     bool skipSPIRVValidation = false;
 
+    Slang::List<Slang::String> capabilities;
+
     Options() { downstreamArgs.addName("slang"); }
 
     static SlangResult parse(

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -211,6 +211,15 @@ static SlangResult _compileProgramImpl(
         sessionOptionEntries.add(entry);
     }
 
+    for (auto& capability : options.capabilities)
+    {
+        slang::CompilerOptionEntry entry;
+        entry.name = slang::CompilerOptionName::Capability;
+        entry.value.kind = slang::CompilerOptionValueKind::String;
+        entry.value.stringValue0 = capability.getBuffer();
+        sessionOptionEntries.add(entry);
+    }
+
     sessionDesc.compilerOptionEntryCount = sessionOptionEntries.getCount();
     sessionDesc.compilerOptionEntries = sessionOptionEntries.getBuffer();
 

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -87,6 +87,7 @@ static bool _isSubCommand(const char* arg)
         "  -use-shared-library            Run tests in-process using shared library\n"
         "  -use-test-server               Run tests using test server\n"
         "  -use-fully-isolated-test-server  Run each test in isolated server\n"
+        "  -capability <name>             Compile with the given capability\n"
         "\n"
         "Output modes:\n"
         "  -appveyor                      Use AppVeyor output format\n"
@@ -358,6 +359,16 @@ static bool _isSubCommand(const char* arg)
         else if (strcmp(arg, "-emit-spirv-via-glsl") == 0)
         {
             optionsOut->emitSPIRVDirectly = false;
+        }
+        else if (strcmp(arg, "-capability") == 0)
+        {
+            if (argCursor == argEnd)
+            {
+                stdError.print("error: expected operand for '%s'\n", arg);
+                showHelp(stdError);
+                return SLANG_FAIL;
+            }
+            optionsOut->capabilities.add(*argCursor++);
         }
         else if (strcmp(arg, "-expected-failure-list") == 0)
         {

--- a/tools/slang-test/options.h
+++ b/tools/slang-test/options.h
@@ -123,6 +123,7 @@ struct Options
 
     bool emitSPIRVDirectly = true;
 
+    Slang::HashSet<Slang::String> capabilities;
     Slang::HashSet<Slang::String> expectedFailureList;
 
     /// Parse the args, report any errors into stdError, and write the results into optionsOut

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1583,6 +1583,12 @@ static SlangResult _initSlangCompiler(TestContext* context, CommandLine& ioCmdLi
         ioCmdLine.addArgIfNotFound("-verbose-paths");
     }
 
+    for (auto& capability : context->options.capabilities)
+    {
+        ioCmdLine.addArg("-capability");
+        ioCmdLine.addArg(capability.getBuffer());
+    }
+
     // Look for definition of a slot
 
     {
@@ -3381,6 +3387,12 @@ static void _addRenderTestOptions(const Options& options, CommandLine& ioCmdLine
     if (!options.emitSPIRVDirectly)
     {
         ioCmdLine.addArg("-emit-spirv-via-glsl");
+    }
+
+    for (auto capability : options.capabilities)
+    {
+        ioCmdLine.addArg("-capability");
+        ioCmdLine.addArg(capability);
     }
 }
 


### PR DESCRIPTION
This allows us to apply a certain capability while running slang-test.
You can use a command-line argument like,
```
slang-test.exe tests/compute/frem.slang -api vk -capability vk_mem_model
```
And you can also add an option for render-test like,
```
//TEST(compute):COMPARE_COMPUTE:-cpu -shaderobj -output-using-type -capability vk_mem_model
```