### PR TITLE
Support tensor addressing

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1109,11 +1109,11 @@ A capability describes an optional feature that a target may or may not support.
 * `SPV_KHR_compute_shader_derivatives` : enables the SPV_KHR_compute_shader_derivatives extension 
 * `SPV_GOOGLE_user_type` : enables the SPV_GOOGLE_user_type extension 
 * `SPV_EXT_replicated_composites` : enables the SPV_EXT_replicated_composites extension 
+* `SPV_KHR_vulkan_memory_model` : enables the SPV_KHR_vulkan_memory_model extension 
 * `SPV_NV_cooperative_vector` : enables the SPV_NV_cooperative_vector extension 
 * `SPV_KHR_cooperative_matrix` : enables the SPV_KHR_cooperative_matrix extension 
-* `SPV_NV_cooperative_matrix2` : enables the SPV_NV_cooperative_matrix2 extension 
 * `SPV_NV_tensor_addressing` : enables the SPV_NV_tensor_addressing extension 
-* `SPV_KHR_vulkan_memory_model` : enables the SPV_KHR_vulkan_memory_model extension 
+* `SPV_NV_cooperative_matrix2` : enables the SPV_NV_cooperative_matrix2 extension 
 * `spvAtomicFloat32AddEXT` 
 * `spvAtomicFloat16AddEXT` 
 * `spvAtomicFloat64AddEXT` 
@@ -1292,6 +1292,7 @@ A capability describes an optional feature that a target may or may not support.
 * `cooperative_matrix_tensor_addressing` 
 * `cooperative_matrix_block_load` 
 * `tensor_addressing` 
+* `cooperative_matrix_2` 
 * `pixel` 
 * `tesscontrol` 
 * `tesseval` 

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -447,20 +447,20 @@ Extensions
 `SPV_EXT_replicated_composites`
 > Represents the SPIR-V extension for SPV_EXT_replicated_composites.
 
+`SPV_KHR_vulkan_memory_model`
+> Represents the SPIR-V extension for SPV_KHR_vulkan_memory_model.
+
 `SPV_NV_cooperative_vector`
 > Represents the SPIR-V extension for SPV_NV_cooperative_vector.
 
 `SPV_KHR_cooperative_matrix`
 > Represents the SPIR-V extension for SPV_KHR_cooperative_matrix.
 
-`SPV_NV_cooperative_matrix2`
-> Represents the SPIR-V extension for SPV_NV_cooperative_matrix2.
-
 `SPV_NV_tensor_addressing`
 > Represents the SPIR-V extension for SPV_NV_tensor_addressing.
 
-`SPV_KHR_vulkan_memory_model`
-> Represents the SPIR-V extension for SPV_KHR_vulkan_memory_model.
+`SPV_NV_cooperative_matrix2`
+> Represents the SPIR-V extension for SPV_NV_cooperative_matrix2.
 
 `spvAtomicFloat32AddEXT`
 > Represents the SPIR-V capability for atomic float 32 add operations.

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -990,6 +990,9 @@ Compound Capabilities
 `tensor_addressing`
 > Capabilities needed to use tensor addressing
 
+`cooperative_matrix_2`
+> Capabilities needed to use tensor addressing
+
 `any_stage`
 > Collection of all shader stages
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -22523,13 +22523,13 @@ enum CoopMatMatrixUse
     MatrixAccumulator = 2,
 };
 
-enum CoopMatMatrixLayout : uint
+enum CoopMatMatrixLayout
 {
     RowMajor = 0,
     ColumnMajor = 1,
 };
 
-enum CoopMatClampMode : uint
+enum CoopMatClampMode
 {
     Undefined,
     Constant,
@@ -22565,7 +22565,7 @@ __intrinsic_type($(kIROp_TensorAddressingTensorLayoutType))
 [require(tensor_addressing)]
 __generic<
     let Dim : uint32_t,
-    let ClampMode : uint32_t = 0 // CoopMatClampMode = CoopMatClampMode.Undefined
+    let ClampMode : CoopMatClampMode = CoopMatClampMode.Undefined
 >
 struct TensorLayout
 {
@@ -22600,7 +22600,7 @@ ${{{{
 
 
 extension<
-    let ClampMode : uint32_t //  : CoopMatClampMode
+    let ClampMode : CoopMatClampMode
 > TensorLayout<$(iDim), ClampMode>
 {
     [require(tensor_addressing)]
@@ -23024,22 +23024,24 @@ struct CoopMat
 
     [require(cooperative_matrix)]
     void Store<
-        let matrixLayout : uint32_t //  : CoopMatMatrixLayout
+        let matrixLayout : CoopMatMatrixLayout
     >(RWByteAddressBuffer buffer, uint element, uint stride)
     {
-        __store(__getEquivalentStructuredBuffer<T>(buffer), element, stride, matrixLayout);
+        __store<matrixLayout>(__getEquivalentStructuredBuffer<T>(buffer), element, stride);
     }
 
     [require(cooperative_matrix)]
     void Store<
-        let matrixLayout : uint32_t //  : CoopMatMatrixLayout
+        let matrixLayout : CoopMatMatrixLayout
     >(RWStructuredBuffer<T> buffer, uint element, uint stride)
     {
-        __store(buffer, element, stride, matrixLayout);
+        __store<matrixLayout>(buffer, element, stride);
     }
 
     [require(cooperative_matrix)]
-    internal void __Store(RWStructuredBuffer<T> buffer, uint element, uint stride, constexpr CoopMatMatrixLayout matrixLayout)
+    internal void __store<
+        let matrixLayout : CoopMatMatrixLayout
+    >(RWStructuredBuffer<T> buffer, uint element, uint stride)
     {
         let zero = 0;
         let alignment = 16U;
@@ -23053,7 +23055,7 @@ struct CoopMat
 
     [require(cooperative_matrix)]
     void Store<
-        let matrixLayout : uint32_t //  : CoopMatMatrixLayout
+        let matrixLayout : CoopMatMatrixLayout
     >(T* buffer, uint element, uint stride)
     {
         let alignment = 16U;
@@ -23067,7 +23069,7 @@ struct CoopMat
     [ForceInline]
     [require(cooperative_matrix)]
     void Store<
-        let matrixLayout : uint32_t, //  : CoopMatMatrixLayout
+        let matrixLayout : CoopMatMatrixLayout,
         let V : int
     >(__ref groupshared T[V] data, uint element, uint stride)
     {
@@ -23083,7 +23085,7 @@ struct CoopMat
     [ForceInline]
     [require(cooperative_matrix)]
     void Store<
-        let matrixLayout : uint32_t, //  : CoopMatMatrixLayout
+        let matrixLayout : CoopMatMatrixLayout,
         U,
         let V : int
     >(__ref groupshared U[V] data, uint element, uint stride)
@@ -23100,7 +23102,7 @@ struct CoopMat
     [ForceInline]
     [require(cooperative_matrix)]
     void Store<
-        let matrixLayout : uint32_t, //  : CoopMatMatrixLayout
+        let matrixLayout : CoopMatMatrixLayout,
         U,
         let V : int,
         let L : int
@@ -23120,11 +23122,19 @@ struct CoopMat
     // Load
     //
 
+${{{{
+    for (const char* RW : { "", "RW" })
+    {
+}}}}
+
     [__NoSideEffect]
     [require(cooperative_matrix)]
     static This Load<
-        let matrixLayout : uint32_t //  : CoopMatMatrixLayout
-    >(ByteAddressBuffer buffer, uint element, uint stride)
+        let matrixLayout : CoopMatMatrixLayout
+    >(
+        $(RW)ByteAddressBuffer buffer,
+        uint element,
+        uint stride)
     {
         return Load<matrixLayout>(__getEquivalentStructuredBuffer<T>(buffer), element, stride);
     }
@@ -23132,17 +23142,11 @@ struct CoopMat
     [__NoSideEffect]
     [require(cooperative_matrix)]
     static This Load<
-        let matrixLayout : uint32_t //  : CoopMatMatrixLayout
-    >(RWByteAddressBuffer buffer, uint element, uint stride)
-    {
-        return Load<matrixLayout>(__getEquivalentStructuredBuffer<T>(buffer), element, stride);
-    }
-
-    [__NoSideEffect]
-    [require(cooperative_matrix)]
-    static This Load<
-        let matrixLayout : uint32_t //  : CoopMatMatrixLayout
-    >(StructuredBuffer<T> buffer, uint element, uint stride)
+        let matrixLayout : CoopMatMatrixLayout
+    >(
+        $(RW)StructuredBuffer<T> buffer,
+        uint element,
+        uint stride)
     {
         let zero = 0;
         let alignment = 16U;
@@ -23154,27 +23158,15 @@ struct CoopMat
         };
     }
 
-    [__NoSideEffect]
-    [require(cooperative_matrix)]
-    static This Load<
-        let matrixLayout : uint32_t //  : CoopMatMatrixLayout
-    >(RWStructuredBuffer<T> buffer, uint element, uint stride)
-    {
-        let zero = 0;
-        let alignment = 16U;
-        return spirv_asm
-        {
-            %storagePointerType = OpTypePointer StorageBuffer $$T;
-            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
-            result:$$CoopMat<T, S, M, N, R> = OpCooperativeMatrixLoadKHR %pointer $matrixLayout $stride Aligned !alignment;
-        };
-    }
+${{{{
+    } // RW
+}}}}
 
     [ForceInline]
     [__NoSideEffect]
     [require(cooperative_matrix)]
     static This Load<
-        let matrixLayout : uint32_t //  : CoopMatMatrixLayout
+        let matrixLayout : CoopMatMatrixLayout
     >(T* buffer, uint element, uint stride)
     {
         let alignment = 16;
@@ -23188,7 +23180,7 @@ struct CoopMat
     [ForceInline]
     [require(cooperative_matrix)]
     static This Load<
-        let matrixLayout : uint32_t, //  : CoopMatMatrixLayout
+        let matrixLayout : CoopMatMatrixLayout,
         let V : int
     >(__constref groupshared T[V] data, uint element, uint stride)
     {
@@ -23204,7 +23196,7 @@ struct CoopMat
     [ForceInline]
     [require(cooperative_matrix)]
     static This Load<
-        let matrixLayout : uint32_t, //  : CoopMatMatrixLayout
+        let matrixLayout : CoopMatMatrixLayout,
         U,
         let V : int
     >(__constref groupshared U[V] data, uint element, uint stride)
@@ -23221,7 +23213,7 @@ struct CoopMat
     [ForceInline]
     [require(cooperative_matrix)]
     static This Load<
-        let matrixLayout : uint32_t, //  : CoopMatMatrixLayout
+        let matrixLayout : CoopMatMatrixLayout,
         U,
         let V : int,
         let L : int
@@ -23317,79 +23309,6 @@ struct CoopMat
     // Load with TensorLayout and TensorView
     //
 
-    [require(cooperative_matrix_tensor_addressing)]
-    static This Load<
-        let Dim : uint32_t,
-        let ClampMode : uint32_t //  : CoopMatClampMode
-    >(
-        ByteAddressBuffer buffer,
-        uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
-    {
-        return Load<Dim, ClampMode>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout);
-    }
-
-    [require(cooperative_matrix_tensor_addressing)]
-    static This Load<
-        let Dim : uint32_t,
-        let ClampMode : uint32_t //  : CoopMatClampMode
-    >(
-        RWByteAddressBuffer buffer,
-        uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
-    {
-        return Load<Dim, ClampMode>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout);
-    }
-
-    [require(cooperative_matrix_tensor_addressing)]
-    static This Load<
-        let Dim : uint32_t,
-        let ClampMode : uint32_t //  : CoopMatClampMode
-    >(
-        StructuredBuffer<T> buffer,
-        uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
-    {
-        let zero = 0;
-        let alignment = 16U;
-
-        // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
-        This ret;
-        return spirv_asm
-        {
-            OpCapability CooperativeMatrixTensorAddressingNV;
-            OpExtension "SPV_NV_cooperative_matrix2";
-            %storagePointerType = OpTypePointer StorageBuffer $$T;
-            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
-            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment None;
-        };
-    }
-
-    [require(cooperative_matrix_tensor_addressing)]
-    static This Load<
-        let Dim : uint32_t,
-        let ClampMode : uint32_t //  : CoopMatClampMode
-    >(
-        RWStructuredBuffer<T> buffer,
-        uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
-    {
-        let zero = 0;
-        let alignment = 16U;
-
-        // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
-        This ret;
-        return spirv_asm
-        {
-            OpCapability CooperativeMatrixTensorAddressingNV;
-            OpExtension "SPV_NV_cooperative_matrix2";
-            %storagePointerType = OpTypePointer StorageBuffer $$T;
-            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
-            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment None;
-        };
-    }
-
-
 ${{{{
     StringBuilder tensorViewTypes;
     StringBuilder tensorViewParams;
@@ -23398,49 +23317,100 @@ ${{{{
         tensorViewTypes << ", let p" << j << " : uint32_t = " << kMaxCoopMatTensorDimension;
         tensorViewParams << ", p" << j;
     }
+
+    for (const char* RW : { "", "RW" })
+    {
 }}}}
 
     [require(cooperative_matrix_tensor_addressing)]
     static This Load<
         let Dim : uint32_t,
-        let ClampMode : uint32_t, //  : CoopMatClampMode
-        let DimView : uint32_t,
-        let HasDimensions : bool
-        $(tensorViewTypes)
+        let ClampMode : CoopMatClampMode
     >(
-        ByteAddressBuffer buffer,
+        $(RW)ByteAddressBuffer buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
-        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView)
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
     {
-        return Load<Dim, ClampMode, DimView, HasDimensions $(tensorViewParams)>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, tensorView);
+        return __loadLayout<Dim, ClampMode>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout);
     }
 
     [require(cooperative_matrix_tensor_addressing)]
     static This Load<
         let Dim : uint32_t,
-        let ClampMode : uint32_t, //  : CoopMatClampMode
-        let DimView : uint32_t,
-        let HasDimensions : bool
-        $(tensorViewTypes)
+        let ClampMode : CoopMatClampMode
     >(
-        RWByteAddressBuffer buffer,
+        $(RW)StructuredBuffer<T> buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
-        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView)
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
     {
-        return Load<Dim, ClampMode, DimView, HasDimensions $(tensorViewParams)>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, tensorView);
+        return __loadLayout<Dim, ClampMode>(buffer, element, tensorLayout);
+    }
+
+    [require(cooperative_matrix_tensor_addressing)]
+    static This __loadLayout<
+        let Dim : uint32_t,
+        let ClampMode : CoopMatClampMode
+    >(
+        $(RW)StructuredBuffer<T> buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
+    {
+        let zero = 0;
+        let alignment = 16U;
+
+        // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
+        This ret;
+        return spirv_asm
+        {
+            OpCapability CooperativeMatrixTensorAddressingNV;
+            OpExtension "SPV_NV_cooperative_matrix2";
+            %storagePointerType = OpTypePointer StorageBuffer $$T;
+            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
+            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment None;
+        };
     }
 
     [require(cooperative_matrix_tensor_addressing)]
     static This Load<
         let Dim : uint32_t,
-        let ClampMode : uint32_t, //  : CoopMatClampMode
+        let ClampMode : CoopMatClampMode,
         let DimView : uint32_t,
         let HasDimensions : bool
         $(tensorViewTypes)
     >(
-        StructuredBuffer<T> buffer,
+        $(RW)ByteAddressBuffer buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView)
+    {
+        return __loadView<Dim, ClampMode, DimView, HasDimensions $(tensorViewParams)>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, tensorView);
+    }
+
+    [require(cooperative_matrix_tensor_addressing)]
+    static This Load<
+        let Dim : uint32_t,
+        let ClampMode : CoopMatClampMode,
+        let DimView : uint32_t,
+        let HasDimensions : bool
+        $(tensorViewTypes)
+    >(
+        $(RW)StructuredBuffer<T> buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams) > tensorView)
+    {
+        return __loadView<Dim, ClampMode, DimView, HasDimensions $(tensorViewParams)>(buffer, element, tensorLayout, tensorView);
+    }
+
+    [require(cooperative_matrix_tensor_addressing)]
+    static This __loadView<
+        let Dim : uint32_t,
+        let ClampMode : CoopMatClampMode,
+        let DimView : uint32_t,
+        let HasDimensions : bool
+        $(tensorViewTypes)
+    >(
+        $(RW)StructuredBuffer<T> buffer,
         uint element,
         tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
         tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams) > tensorView)
@@ -23460,77 +23430,41 @@ ${{{{
         };
     }
 
-    [require(cooperative_matrix_tensor_addressing)]
+    [require(cooperative_matrix_block_load)]
     static This Load<
-        let Dim : uint32_t,
-        let ClampMode : uint32_t, //  : CoopMatClampMode
-        let DimView : uint32_t,
-        let HasDimensions : bool
-        $(tensorViewTypes)
-    >(
-        RWStructuredBuffer<T> buffer,
-        uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
-        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams) > tensorView)
-    {
-        let zero = 0;
-        let alignment = 16U;
-
-        // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
-        This ret;
-        return spirv_asm
-        {
-            OpCapability CooperativeMatrixTensorAddressingNV;
-            OpExtension "SPV_NV_cooperative_matrix2";
-            %storagePointerType = OpTypePointer StorageBuffer $$T;
-            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
-            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment TensorView $tensorView;
-        };
-    }
-
-    //
-    // TODO: The name should be just `Load` but using `LoadDecode` for now.
-    //   It is beause the name `Load` somehow conflicts with the other overloading,
-    //     `This Load<let matrixLayout : CoopMatMatrixLayout>(...)`.
-    //   The error message is:
-    //     "expected an expression of type 'uint', got 'typeof(uint32_t)'"
-    //
-
-    [require(cooperative_matrix_block_load)]
-    static This LoadDecode<
         U,
         let Dim : uint32_t,
-        let ClampMode : uint32_t //  : CoopMatClampMode
+        let ClampMode : CoopMatClampMode
     >(
-        ByteAddressBuffer buffer,
+        $(RW)ByteAddressBuffer buffer,
         uint element,
         tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
         functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
     {
-        return LoadDecode<U, Dim, ClampMode>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, decodeFunc);
+        return __loadLayoutDecode<U, Dim, ClampMode>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, decodeFunc);
     }
 
     [require(cooperative_matrix_block_load)]
-    static This LoadDecode<
+    static This Load<
         U,
         let Dim : uint32_t,
-        let ClampMode : uint32_t //  : CoopMatClampMode
+        let ClampMode : CoopMatClampMode
     >(
-        RWByteAddressBuffer buffer,
+        $(RW)StructuredBuffer<T> buffer,
         uint element,
         tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
         functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
     {
-        return LoadDecode<U, Dim, ClampMode>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, decodeFunc);
+        return __loadLayoutDecode<U, Dim, ClampMode>(buffer, element, tensorLayout, decodeFunc);
     }
 
     [require(cooperative_matrix_block_load)]
-    static This LoadDecode<
+    static This __loadLayoutDecode<
         U,
         let Dim : uint32_t,
-        let ClampMode : uint32_t //  : CoopMatClampMode
+        let ClampMode : CoopMatClampMode
     >(
-        StructuredBuffer<T> buffer,
+        $(RW)StructuredBuffer<T> buffer,
         uint element,
         tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
         functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
@@ -23551,77 +23485,51 @@ ${{{{
     }
 
     [require(cooperative_matrix_block_load)]
-    static This LoadDecode<
+    static This Load<
         U,
         let Dim : uint32_t,
-        let ClampMode : uint32_t //  : CoopMatClampMode
-    >(
-        RWStructuredBuffer<T> buffer,
-        uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
-        functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
-    {
-        let zero = 0;
-        let alignment = 16U;
-
-        // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
-        This ret;
-        return spirv_asm
-        {
-            OpCapability CooperativeMatrixBlockLoadsNV;
-            OpExtension "SPV_NV_cooperative_matrix2";
-            %storagePointerType = OpTypePointer StorageBuffer $$T;
-            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
-            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment DecodeFunc $decodeFunc;
-        };
-    }
-
-    [require(cooperative_matrix_block_load)]
-    static This LoadDecode<
-        U,
-        let Dim : uint32_t,
-        let ClampMode : uint32_t, //  : CoopMatClampMode
+        let ClampMode : CoopMatClampMode,
         let DimView : uint32_t,
         let HasDimensions : bool
         $(tensorViewTypes)
     >(
-        ByteAddressBuffer buffer,
+        $(RW)ByteAddressBuffer buffer,
         uint element,
         tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
         tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView,
         functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
     {
-        return LoadDecode<U, Dim, ClampMode, DimView, HasDimensions $(tensorViewParams)>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, tensorView, decodeFunc);
+        return __loadViewDecode<U, Dim, ClampMode, DimView, HasDimensions $(tensorViewParams)>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, tensorView, decodeFunc);
     }
 
     [require(cooperative_matrix_block_load)]
-    static This LoadDecode<
+    static This Load<
         U,
         let Dim : uint32_t,
-        let ClampMode : uint32_t, //  : CoopMatClampMode
+        let ClampMode : CoopMatClampMode,
         let DimView : uint32_t,
         let HasDimensions : bool
         $(tensorViewTypes)
     >(
-        RWByteAddressBuffer buffer,
+        $(RW)StructuredBuffer<T> buffer,
         uint element,
         tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
         tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView,
         functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
     {
-        return LoadDecode<U, Dim, ClampMode, DimView, HasDimensions $(tensorViewParams)>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, tensorView, decodeFunc);
+        return __loadViewDecode<U, Dim, ClampMode, DimView, HasDimensions $(tensorViewParams)>(buffer, element, tensorLayout, tensorView, decodeFunc);
     }
 
     [require(cooperative_matrix_block_load)]
-    static This LoadDecode<
+    static This __loadViewDecode<
         U,
         let Dim : uint32_t,
-        let ClampMode : uint32_t, //  : CoopMatClampMode
+        let ClampMode : CoopMatClampMode,
         let DimView : uint32_t,
         let HasDimensions : bool
         $(tensorViewTypes)
     >(
-        StructuredBuffer<T> buffer,
+        $(RW)StructuredBuffer<T> buffer,
         uint element,
         tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
         tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView,
@@ -23643,41 +23551,14 @@ ${{{{
         };
     }
 
-    [require(cooperative_matrix_block_load)]
-    static This LoadDecode<
-        U,
-        let Dim : uint32_t,
-        let ClampMode : uint32_t, //  : CoopMatClampMode
-        let DimView : uint32_t,
-        let HasDimensions : bool
-        $(tensorViewTypes)
-    >(
-        RWStructuredBuffer<T> buffer,
-        uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
-        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView,
-        functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
-    {
-        let zero = 0;
-        let alignment = 16U;
-
-        // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
-        This ret;
-        return spirv_asm
-        {
-            OpCapability CooperativeMatrixTensorAddressingNV;
-            OpCapability CooperativeMatrixBlockLoadsNV;
-            OpExtension "SPV_NV_cooperative_matrix2";
-            %storagePointerType = OpTypePointer StorageBuffer $$T;
-            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
-            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment TensorView|DecodeFunc $tensorView $decodeFunc;
-        };
-    }
+${{{{
+    } // RW
+}}}}
 
     [require(cooperative_matrix_tensor_addressing)]
     void Store<
         let Dim : uint32_t,
-        let ClampMode : uint32_t //  : CoopMatClampMode
+        let ClampMode : CoopMatClampMode
     >(
         RWByteAddressBuffer buffer,
         uint element,
@@ -23689,7 +23570,7 @@ ${{{{
     [require(cooperative_matrix_tensor_addressing)]
     void Store<
         let Dim : uint32_t,
-        let ClampMode : uint32_t //  : CoopMatClampMode
+        let ClampMode : CoopMatClampMode
     >(
         RWStructuredBuffer<T> buffer,
         uint element,
@@ -23715,7 +23596,7 @@ ${{{{
     [require(cooperative_matrix_tensor_addressing)]
     void Store<
         let Dim : uint32_t,
-        let ClampMode : uint32_t, //  : CoopMatClampMode
+        let ClampMode : CoopMatClampMode,
         let DimView : uint32_t,
         let HasDimensions : bool
         $(tensorViewTypes)
@@ -23731,7 +23612,7 @@ ${{{{
     [require(cooperative_matrix_tensor_addressing)]
     void Store<
         let Dim : uint32_t,
-        let ClampMode : uint32_t, //  : CoopMatClampMode
+        let ClampMode : CoopMatClampMode,
         let DimView : uint32_t,
         let HasDimensions : bool
         $(tensorViewTypes)
@@ -23774,7 +23655,7 @@ CoopMat<T, S, M, N, R> coopMatLoad<
     let M : int,
     let N : int,
     let R : CoopMatMatrixUse,
-    let matrixLayout : uint32_t //  : CoopMatMatrixLayout
+    let matrixLayout : CoopMatMatrixLayout
 >(
     ByteAddressBuffer buffer,
     uint element,
@@ -23791,7 +23672,7 @@ CoopMat<T, S, M, N, R> coopMatLoad<
     let M : int,
     let N : int,
     let R : CoopMatMatrixUse,
-    let matrixLayout : uint32_t //  : CoopMatMatrixLayout
+    let matrixLayout : CoopMatMatrixLayout
 >(
     RWByteAddressBuffer buffer,
     uint element,
@@ -23808,7 +23689,7 @@ CoopMat<T, S, M, N, R> coopMatLoad<
     let M : int,
     let N : int,
     let R : CoopMatMatrixUse,
-    let matrixLayout : uint32_t //  : CoopMatMatrixLayout
+    let matrixLayout : CoopMatMatrixLayout
 >(
     StructuredBuffer<T> buffer,
     uint element,
@@ -23825,7 +23706,7 @@ CoopMat<T, S, M, N, R> coopMatLoad<
     let M : int,
     let N : int,
     let R : CoopMatMatrixUse,
-    let matrixLayout : uint32_t //  : CoopMatMatrixLayout
+    let matrixLayout : CoopMatMatrixLayout
 >(
     RWStructuredBuffer<T> buffer,
     uint element,
@@ -23842,7 +23723,7 @@ CoopMat<T, S, M, N, R> coopMatLoad<
     let M : int,
     let N : int,
     let R : CoopMatMatrixUse,
-    let matrixLayout : uint32_t //  : CoopMatMatrixLayout
+    let matrixLayout : CoopMatMatrixLayout
 >(
     T* buffer,
     uint element,
@@ -23859,7 +23740,7 @@ CoopMat<T, S, M, N, R> coopMatLoad<
     let M : int,
     let N : int,
     let R : CoopMatMatrixUse,
-    let matrixLayout : uint32_t, //  : CoopMatMatrixLayout
+    let matrixLayout : CoopMatMatrixLayout,
     let U : int
 >(
     __constref groupshared T[U] data,

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -23329,7 +23329,7 @@ ${{{{
     >(
         $(RW)ByteAddressBuffer buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
+        TensorLayout<Dim, ClampMode> tensorLayout)
     {
         return __loadLayout<Dim, ClampMode>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout);
     }
@@ -23341,7 +23341,7 @@ ${{{{
     >(
         $(RW)StructuredBuffer<T> buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
+        TensorLayout<Dim, ClampMode> tensorLayout)
     {
         return __loadLayout<Dim, ClampMode>(buffer, element, tensorLayout);
     }
@@ -23353,7 +23353,7 @@ ${{{{
     >(
         $(RW)StructuredBuffer<T> buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
+        TensorLayout<Dim, ClampMode> tensorLayout)
     {
         let zero = 0;
         let alignment = 16U;
@@ -23380,8 +23380,8 @@ ${{{{
     >(
         $(RW)ByteAddressBuffer buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
-        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView)
+        TensorLayout<Dim, ClampMode> tensorLayout,
+        TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView)
     {
         return __loadView<Dim, ClampMode, DimView, HasDimensions $(tensorViewParams)>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, tensorView);
     }
@@ -23396,8 +23396,8 @@ ${{{{
     >(
         $(RW)StructuredBuffer<T> buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
-        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams) > tensorView)
+        TensorLayout<Dim, ClampMode> tensorLayout,
+        TensorView<DimView, HasDimensions $(tensorViewParams) > tensorView)
     {
         return __loadView<Dim, ClampMode, DimView, HasDimensions $(tensorViewParams)>(buffer, element, tensorLayout, tensorView);
     }
@@ -23412,8 +23412,8 @@ ${{{{
     >(
         $(RW)StructuredBuffer<T> buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
-        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams) > tensorView)
+        TensorLayout<Dim, ClampMode> tensorLayout,
+        TensorView<DimView, HasDimensions $(tensorViewParams) > tensorView)
     {
         let zero = 0;
         let alignment = 16U;
@@ -23438,7 +23438,7 @@ ${{{{
     >(
         $(RW)ByteAddressBuffer buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        TensorLayout<Dim, ClampMode> tensorLayout,
         functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
     {
         return __loadLayoutDecode<U, Dim, ClampMode>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, decodeFunc);
@@ -23452,7 +23452,7 @@ ${{{{
     >(
         $(RW)StructuredBuffer<T> buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        TensorLayout<Dim, ClampMode> tensorLayout,
         functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
     {
         return __loadLayoutDecode<U, Dim, ClampMode>(buffer, element, tensorLayout, decodeFunc);
@@ -23466,7 +23466,7 @@ ${{{{
     >(
         $(RW)StructuredBuffer<T> buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        TensorLayout<Dim, ClampMode> tensorLayout,
         functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
     {
         let zero = 0;
@@ -23495,8 +23495,8 @@ ${{{{
     >(
         $(RW)ByteAddressBuffer buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
-        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView,
+        TensorLayout<Dim, ClampMode> tensorLayout,
+        TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView,
         functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
     {
         return __loadViewDecode<U, Dim, ClampMode, DimView, HasDimensions $(tensorViewParams)>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, tensorView, decodeFunc);
@@ -23513,8 +23513,8 @@ ${{{{
     >(
         $(RW)StructuredBuffer<T> buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
-        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView,
+        TensorLayout<Dim, ClampMode> tensorLayout,
+        TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView,
         functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
     {
         return __loadViewDecode<U, Dim, ClampMode, DimView, HasDimensions $(tensorViewParams)>(buffer, element, tensorLayout, tensorView, decodeFunc);
@@ -23531,8 +23531,8 @@ ${{{{
     >(
         $(RW)StructuredBuffer<T> buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
-        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView,
+        TensorLayout<Dim, ClampMode> tensorLayout,
+        TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView,
         functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
     {
         let zero = 0;
@@ -23562,7 +23562,7 @@ ${{{{
     >(
         RWByteAddressBuffer buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
+        TensorLayout<Dim, ClampMode> tensorLayout)
     {
         Store(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout);
     }
@@ -23574,7 +23574,7 @@ ${{{{
     >(
         RWStructuredBuffer<T> buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
+        TensorLayout<Dim, ClampMode> tensorLayout)
     {
         let zero = 0;
         let alignment = 16U;
@@ -23603,8 +23603,8 @@ ${{{{
     >(
         RWByteAddressBuffer buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
-        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView)
+        TensorLayout<Dim, ClampMode> tensorLayout,
+        TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView)
     {
         Store(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, tensorView);
     }
@@ -23619,8 +23619,8 @@ ${{{{
     >(
         RWStructuredBuffer<T> buffer,
         uint element,
-        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
-        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView)
+        TensorLayout<Dim, ClampMode> tensorLayout,
+        TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView)
     {
         let zero = 0;
         let alignment = 16U;

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -22523,13 +22523,13 @@ enum CoopMatMatrixUse
     MatrixAccumulator = 2,
 };
 
-enum CoopMatMatrixLayout
+enum CoopMatMatrixLayout : uint
 {
     RowMajor = 0,
     ColumnMajor = 1,
 };
 
-enum CoopMatClampMode
+enum CoopMatClampMode : uint
 {
     Undefined,
     Constant,
@@ -22537,6 +22537,243 @@ enum CoopMatClampMode
     Repeat,
     RepeatMirrored
 };
+
+
+${{{{
+// SPIRV described that the max value for `Dim` is 5.
+//
+// https://github.khronos.org/SPIRV-Registry/extensions/NV/SPV_NV_tensor_addressing.html#OpTypeTensorLayoutNV
+// OpTypeTensorLayoutNV:
+// Dim is the number of dimensions in the tensor layout, and must be a constant
+// instruction with scalar 32-bit integer type. The value must be greater than
+// zero and less than or equal to 5.
+//
+// https://github.khronos.org/SPIRV-Registry/extensions/NV/SPV_NV_tensor_addressing.html#OpTypeTensorViewNV
+// OpTypeTensorViewNV:
+// Dim is the number of dimensions in the tensor view, and must be a constant
+// instruction with scalar 32-bit integer type. The value must be greater than
+// zero and less than or equal to 5.
+//
+const int kMaxCoopMatTensorDimension = 5;
+}}}}
+
+//
+// TensorLayout
+//
+
+__intrinsic_type($(kIROp_TensorAddressingTensorLayoutType))
+[require(tensor_addressing)]
+__generic<
+    let Dim : uint32_t,
+    let ClampMode : uint32_t = 0 // CoopMatClampMode = CoopMatClampMode.Undefined
+>
+struct TensorLayout
+{
+    __intrinsic_op($(kIROp_MakeTensorAddressingTensorLayout))
+    __init();
+};
+
+
+${{{{
+    for (int iDim = 1; iDim < kMaxCoopMatTensorDimension; ++iDim)
+    {
+        StringBuilder dimParams;
+        StringBuilder dimAsms;
+        StringBuilder strideParams;
+        StringBuilder strideAsms;
+        StringBuilder sliceParams;
+        StringBuilder sliceAsms;
+        StringBuilder blockSizeParams;
+        StringBuilder blockSizeAsms;
+        for (int j = 1; j < iDim; ++j)
+        {
+            dimParams << ", uint32_t dim" << j;
+            dimAsms << " $dim" << j;
+            strideParams << ", uint32_t stride" << j;
+            strideAsms << " $stride" << j;
+            sliceParams << ", uint32_t offset" << j << ", uint32_t span" << j;
+            sliceAsms << " $offset" << j << " $span" << j;
+            blockSizeParams << ", uint32_t blockSize" << j;
+            blockSizeAsms << " $blockSize" << j;
+        }
+}}}}
+
+
+extension<
+    let ClampMode : uint32_t //  : CoopMatClampMode
+> TensorLayout<$(iDim), ClampMode>
+{
+    [require(tensor_addressing)]
+    This Dimension(uint32_t dim0 $(dimParams))
+    {
+        __target_switch
+        {
+        case spirv:
+            return spirv_asm
+            {
+                result:$$This = OpTensorLayoutSetDimensionNV $this $dim0 $(dimAsms)
+            };
+        }
+    }
+
+    [require(tensor_addressing)]
+    This Stride(uint32_t stride0 $(strideParams))
+    {
+        __target_switch
+        {
+        case spirv:
+            return spirv_asm
+            {
+                result:$$This = OpTensorLayoutSetStrideNV $this $stride0 $(strideAsms);
+            };
+        }
+    }
+
+    [require(tensor_addressing)]
+    This Slice(uint32_t offset0, uint32_t span0 $(sliceParams))
+    {
+        __target_switch
+        {
+        case spirv:
+            return spirv_asm
+            {
+                result:$$This = OpTensorLayoutSliceNV $this $offset0 $span0 $(sliceAsms);
+            };
+        }
+    }
+
+    [require(tensor_addressing)]
+    This ClampValue(CoopMatClampMode clampMode)
+    {
+        __target_switch
+        {
+        case spirv:
+            return spirv_asm
+            {
+                result:$$This = OpTensorLayoutSetClampValueNV $this $clampMode;
+            };
+        }
+    }
+
+    [require(tensor_addressing)]
+    This BlockSize(uint32_t blockSize0 $(blockSizeParams))
+    {
+        __target_switch
+        {
+        case spirv:
+            return spirv_asm
+            {
+                result:$$This = OpTensorLayoutSetBlockSizeNV $this $blockSize0 $(blockSizeAsms);
+            };
+        }
+    }
+};
+
+${{{{
+    } // iDim
+}}}}
+
+//
+// TensorView
+//
+
+${{{{
+    StringBuilder tensorViewStruct;
+    for (int j = 0; j < kMaxCoopMatTensorDimension; ++j)
+    {
+        // Assigning the max value as a default value,
+        // because the max value is an invalid value and it allows us to check if the value
+        // is explicitly set by the user or not.
+        tensorViewStruct << ", let p" << j << " : uint32_t = 0xff";
+    }
+}}}}
+
+__intrinsic_type($(kIROp_TensorAddressingTensorViewType))
+__generic<
+    let Dim : uint32_t,
+    let HasDimensions : bool
+    $(tensorViewStruct)
+>
+struct TensorView
+{
+    __intrinsic_op($(kIROp_MakeTensorAddressingTensorView))
+    __init();
+};
+
+${{{{
+    for (int iDim = 1; iDim < kMaxCoopMatTensorDimension; ++iDim)
+    {
+        StringBuilder tensorViewTypes;
+        StringBuilder tensorViewExtensions;
+        StringBuilder dimParams;
+        StringBuilder dimAsms;
+        StringBuilder strideParams;
+        StringBuilder strideAsms;
+        for (int j = 1; j < iDim; ++j)
+        {
+            tensorViewTypes << ", let Dim" << j << " : uint32_t";
+            tensorViewExtensions << ", Dim" << j;
+            dimParams << ", uint32_t dim" << j;
+            dimAsms << " $dim" << j;
+            strideParams << ", uint32_t stride" << j;
+            strideAsms << " $stride" << j;
+        }
+        for (int j = iDim; j < kMaxCoopMatTensorDimension; ++j)
+        {
+            tensorViewExtensions << ", 0xff";
+        }
+}}}}
+
+[require(tensor_addressing)]
+extension<
+    let HasDimensions : bool,
+    let Dim0 : uint32_t
+    $(tensorViewTypes)
+> TensorView<$(iDim), HasDimensions, Dim0 $(tensorViewExtensions)>
+{
+    [require(tensor_addressing)]
+    This Dimension(uint32_t dim0 $(dimParams))
+    {
+        __target_switch
+        {
+        case spirv:
+            return spirv_asm
+            {
+                result:$$This = OpTensorViewSetDimensionNV $this $dim0 $(dimAsms);
+            };
+        }
+    }
+
+    [require(tensor_addressing)]
+    This Stride(uint32_t stride0 $(strideParams))
+    {
+        __target_switch
+        {
+        case spirv:
+            return spirv_asm
+            {
+                result:$$This = OpTensorViewSetStrideNV $this $stride0 $(strideAsms);
+            };
+        }
+    }
+
+    [require(tensor_addressing)]
+    This Clip(uint clipRowOffset, uint clipRowSpan, uint clipColOffset, uint clipColSpan)
+    {
+        __target_switch
+        {
+        case spirv:
+            return spirv_asm
+            {
+                result:$$This = OpTensorViewSetClipNV $this $clipRowOffset $clipRowSpan $clipColOffset $clipColSpan;
+            };
+        }
+    }
+};
+
+${{{{
+    } // iDim
+}}}}
 
 
 //
@@ -22787,18 +23024,18 @@ struct CoopMat
 
     [require(cooperative_matrix)]
     void Store<
-        let matrixLayout : CoopMatMatrixLayout
-    >(RWStructuredBuffer<T> buffer, uint element, uint stride)
+        let matrixLayout : uint32_t //  : CoopMatMatrixLayout
+    >(RWByteAddressBuffer buffer, uint element, uint stride)
     {
-        __Store(buffer, element, stride, matrixLayout);
+        __store(__getEquivalentStructuredBuffer<T>(buffer), element, stride, matrixLayout);
     }
 
     [require(cooperative_matrix)]
     void Store<
-        let matrixLayout : CoopMatMatrixLayout
-    >(RWByteAddressBuffer buffer, uint element, uint stride)
+        let matrixLayout : uint32_t //  : CoopMatMatrixLayout
+    >(RWStructuredBuffer<T> buffer, uint element, uint stride)
     {
-        __Store(__getEquivalentStructuredBuffer<T>(buffer), element, stride, matrixLayout);
+        __store(buffer, element, stride, matrixLayout);
     }
 
     [require(cooperative_matrix)]
@@ -22816,7 +23053,7 @@ struct CoopMat
 
     [require(cooperative_matrix)]
     void Store<
-        let matrixLayout : CoopMatMatrixLayout
+        let matrixLayout : uint32_t //  : CoopMatMatrixLayout
     >(T* buffer, uint element, uint stride)
     {
         let alignment = 16U;
@@ -22830,7 +23067,7 @@ struct CoopMat
     [ForceInline]
     [require(cooperative_matrix)]
     void Store<
-        let matrixLayout : CoopMatMatrixLayout,
+        let matrixLayout : uint32_t, //  : CoopMatMatrixLayout
         let V : int
     >(__ref groupshared T[V] data, uint element, uint stride)
     {
@@ -22846,7 +23083,7 @@ struct CoopMat
     [ForceInline]
     [require(cooperative_matrix)]
     void Store<
-        let matrixLayout : CoopMatMatrixLayout,
+        let matrixLayout : uint32_t, //  : CoopMatMatrixLayout
         U,
         let V : int
     >(__ref groupshared U[V] data, uint element, uint stride)
@@ -22863,7 +23100,7 @@ struct CoopMat
     [ForceInline]
     [require(cooperative_matrix)]
     void Store<
-        let matrixLayout : CoopMatMatrixLayout,
+        let matrixLayout : uint32_t, //  : CoopMatMatrixLayout
         U,
         let V : int,
         let L : int
@@ -22886,7 +23123,7 @@ struct CoopMat
     [__NoSideEffect]
     [require(cooperative_matrix)]
     static This Load<
-        let matrixLayout : CoopMatMatrixLayout
+        let matrixLayout : uint32_t //  : CoopMatMatrixLayout
     >(ByteAddressBuffer buffer, uint element, uint stride)
     {
         return Load<matrixLayout>(__getEquivalentStructuredBuffer<T>(buffer), element, stride);
@@ -22895,7 +23132,7 @@ struct CoopMat
     [__NoSideEffect]
     [require(cooperative_matrix)]
     static This Load<
-        let matrixLayout : CoopMatMatrixLayout
+        let matrixLayout : uint32_t //  : CoopMatMatrixLayout
     >(RWByteAddressBuffer buffer, uint element, uint stride)
     {
         return Load<matrixLayout>(__getEquivalentStructuredBuffer<T>(buffer), element, stride);
@@ -22904,7 +23141,7 @@ struct CoopMat
     [__NoSideEffect]
     [require(cooperative_matrix)]
     static This Load<
-        let matrixLayout : CoopMatMatrixLayout
+        let matrixLayout : uint32_t //  : CoopMatMatrixLayout
     >(StructuredBuffer<T> buffer, uint element, uint stride)
     {
         let zero = 0;
@@ -22920,7 +23157,7 @@ struct CoopMat
     [__NoSideEffect]
     [require(cooperative_matrix)]
     static This Load<
-        let matrixLayout : CoopMatMatrixLayout
+        let matrixLayout : uint32_t //  : CoopMatMatrixLayout
     >(RWStructuredBuffer<T> buffer, uint element, uint stride)
     {
         let zero = 0;
@@ -22937,7 +23174,7 @@ struct CoopMat
     [__NoSideEffect]
     [require(cooperative_matrix)]
     static This Load<
-        let matrixLayout : CoopMatMatrixLayout
+        let matrixLayout : uint32_t //  : CoopMatMatrixLayout
     >(T* buffer, uint element, uint stride)
     {
         let alignment = 16;
@@ -22951,7 +23188,7 @@ struct CoopMat
     [ForceInline]
     [require(cooperative_matrix)]
     static This Load<
-        let matrixLayout : CoopMatMatrixLayout,
+        let matrixLayout : uint32_t, //  : CoopMatMatrixLayout
         let V : int
     >(__constref groupshared T[V] data, uint element, uint stride)
     {
@@ -22967,7 +23204,7 @@ struct CoopMat
     [ForceInline]
     [require(cooperative_matrix)]
     static This Load<
-        let matrixLayout : CoopMatMatrixLayout,
+        let matrixLayout : uint32_t, //  : CoopMatMatrixLayout
         U,
         let V : int
     >(__constref groupshared U[V] data, uint element, uint stride)
@@ -22984,7 +23221,7 @@ struct CoopMat
     [ForceInline]
     [require(cooperative_matrix)]
     static This Load<
-        let matrixLayout : CoopMatMatrixLayout,
+        let matrixLayout : uint32_t, //  : CoopMatMatrixLayout
         U,
         let V : int,
         let L : int
@@ -23076,6 +23313,451 @@ struct CoopMat
         return true;
     }
 
+    //
+    // Load with TensorLayout and TensorView
+    //
+
+    [require(cooperative_matrix_tensor_addressing)]
+    static This Load<
+        let Dim : uint32_t,
+        let ClampMode : uint32_t //  : CoopMatClampMode
+    >(
+        ByteAddressBuffer buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
+    {
+        return Load<Dim, ClampMode>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout);
+    }
+
+    [require(cooperative_matrix_tensor_addressing)]
+    static This Load<
+        let Dim : uint32_t,
+        let ClampMode : uint32_t //  : CoopMatClampMode
+    >(
+        RWByteAddressBuffer buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
+    {
+        return Load<Dim, ClampMode>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout);
+    }
+
+    [require(cooperative_matrix_tensor_addressing)]
+    static This Load<
+        let Dim : uint32_t,
+        let ClampMode : uint32_t //  : CoopMatClampMode
+    >(
+        StructuredBuffer<T> buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
+    {
+        let zero = 0;
+        let alignment = 16U;
+
+        // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
+        This ret;
+        return spirv_asm
+        {
+            OpCapability CooperativeMatrixTensorAddressingNV;
+            OpExtension "SPV_NV_cooperative_matrix2";
+            %storagePointerType = OpTypePointer StorageBuffer $$T;
+            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
+            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment None;
+        };
+    }
+
+    [require(cooperative_matrix_tensor_addressing)]
+    static This Load<
+        let Dim : uint32_t,
+        let ClampMode : uint32_t //  : CoopMatClampMode
+    >(
+        RWStructuredBuffer<T> buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
+    {
+        let zero = 0;
+        let alignment = 16U;
+
+        // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
+        This ret;
+        return spirv_asm
+        {
+            OpCapability CooperativeMatrixTensorAddressingNV;
+            OpExtension "SPV_NV_cooperative_matrix2";
+            %storagePointerType = OpTypePointer StorageBuffer $$T;
+            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
+            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment None;
+        };
+    }
+
+
+${{{{
+    StringBuilder tensorViewTypes;
+    StringBuilder tensorViewParams;
+    for (int j = 0; j < kMaxCoopMatTensorDimension; ++j)
+    {
+        tensorViewTypes << ", let p" << j << " : uint32_t = " << kMaxCoopMatTensorDimension;
+        tensorViewParams << ", p" << j;
+    }
+}}}}
+
+    [require(cooperative_matrix_tensor_addressing)]
+    static This Load<
+        let Dim : uint32_t,
+        let ClampMode : uint32_t, //  : CoopMatClampMode
+        let DimView : uint32_t,
+        let HasDimensions : bool
+        $(tensorViewTypes)
+    >(
+        ByteAddressBuffer buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView)
+    {
+        return Load<Dim, ClampMode, DimView, HasDimensions $(tensorViewParams)>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, tensorView);
+    }
+
+    [require(cooperative_matrix_tensor_addressing)]
+    static This Load<
+        let Dim : uint32_t,
+        let ClampMode : uint32_t, //  : CoopMatClampMode
+        let DimView : uint32_t,
+        let HasDimensions : bool
+        $(tensorViewTypes)
+    >(
+        RWByteAddressBuffer buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView)
+    {
+        return Load<Dim, ClampMode, DimView, HasDimensions $(tensorViewParams)>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, tensorView);
+    }
+
+    [require(cooperative_matrix_tensor_addressing)]
+    static This Load<
+        let Dim : uint32_t,
+        let ClampMode : uint32_t, //  : CoopMatClampMode
+        let DimView : uint32_t,
+        let HasDimensions : bool
+        $(tensorViewTypes)
+    >(
+        StructuredBuffer<T> buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams) > tensorView)
+    {
+        let zero = 0;
+        let alignment = 16U;
+
+        // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
+        This ret;
+        return spirv_asm
+        {
+            OpCapability CooperativeMatrixTensorAddressingNV;
+            OpExtension "SPV_NV_cooperative_matrix2";
+            %storagePointerType = OpTypePointer StorageBuffer $$T;
+            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
+            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment TensorView $tensorView;
+        };
+    }
+
+    [require(cooperative_matrix_tensor_addressing)]
+    static This Load<
+        let Dim : uint32_t,
+        let ClampMode : uint32_t, //  : CoopMatClampMode
+        let DimView : uint32_t,
+        let HasDimensions : bool
+        $(tensorViewTypes)
+    >(
+        RWStructuredBuffer<T> buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams) > tensorView)
+    {
+        let zero = 0;
+        let alignment = 16U;
+
+        // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
+        This ret;
+        return spirv_asm
+        {
+            OpCapability CooperativeMatrixTensorAddressingNV;
+            OpExtension "SPV_NV_cooperative_matrix2";
+            %storagePointerType = OpTypePointer StorageBuffer $$T;
+            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
+            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment TensorView $tensorView;
+        };
+    }
+
+    //
+    // TODO: The name should be just `Load` but using `LoadDecode` for now.
+    //   It is beause the name `Load` somehow conflicts with the other overloading,
+    //     `This Load<let matrixLayout : CoopMatMatrixLayout>(...)`.
+    //   The error message is:
+    //     "expected an expression of type 'uint', got 'typeof(uint32_t)'"
+    //
+
+    [require(cooperative_matrix_block_load)]
+    static This LoadDecode<
+        U,
+        let Dim : uint32_t,
+        let ClampMode : uint32_t //  : CoopMatClampMode
+    >(
+        ByteAddressBuffer buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
+    {
+        return LoadDecode<U, Dim, ClampMode>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, decodeFunc);
+    }
+
+    [require(cooperative_matrix_block_load)]
+    static This LoadDecode<
+        U,
+        let Dim : uint32_t,
+        let ClampMode : uint32_t //  : CoopMatClampMode
+    >(
+        RWByteAddressBuffer buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
+    {
+        return LoadDecode<U, Dim, ClampMode>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, decodeFunc);
+    }
+
+    [require(cooperative_matrix_block_load)]
+    static This LoadDecode<
+        U,
+        let Dim : uint32_t,
+        let ClampMode : uint32_t //  : CoopMatClampMode
+    >(
+        StructuredBuffer<T> buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
+    {
+        let zero = 0;
+        let alignment = 16U;
+
+        // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
+        This ret;
+        return spirv_asm
+        {
+            OpCapability CooperativeMatrixBlockLoadsNV;
+            OpExtension "SPV_NV_cooperative_matrix2";
+            %storagePointerType = OpTypePointer StorageBuffer $$T;
+            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
+            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment DecodeFunc $decodeFunc;
+        };
+    }
+
+    [require(cooperative_matrix_block_load)]
+    static This LoadDecode<
+        U,
+        let Dim : uint32_t,
+        let ClampMode : uint32_t //  : CoopMatClampMode
+    >(
+        RWStructuredBuffer<T> buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
+    {
+        let zero = 0;
+        let alignment = 16U;
+
+        // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
+        This ret;
+        return spirv_asm
+        {
+            OpCapability CooperativeMatrixBlockLoadsNV;
+            OpExtension "SPV_NV_cooperative_matrix2";
+            %storagePointerType = OpTypePointer StorageBuffer $$T;
+            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
+            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment DecodeFunc $decodeFunc;
+        };
+    }
+
+    [require(cooperative_matrix_block_load)]
+    static This LoadDecode<
+        U,
+        let Dim : uint32_t,
+        let ClampMode : uint32_t, //  : CoopMatClampMode
+        let DimView : uint32_t,
+        let HasDimensions : bool
+        $(tensorViewTypes)
+    >(
+        ByteAddressBuffer buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView,
+        functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
+    {
+        return LoadDecode<U, Dim, ClampMode, DimView, HasDimensions $(tensorViewParams)>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, tensorView, decodeFunc);
+    }
+
+    [require(cooperative_matrix_block_load)]
+    static This LoadDecode<
+        U,
+        let Dim : uint32_t,
+        let ClampMode : uint32_t, //  : CoopMatClampMode
+        let DimView : uint32_t,
+        let HasDimensions : bool
+        $(tensorViewTypes)
+    >(
+        RWByteAddressBuffer buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView,
+        functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
+    {
+        return LoadDecode<U, Dim, ClampMode, DimView, HasDimensions $(tensorViewParams)>(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, tensorView, decodeFunc);
+    }
+
+    [require(cooperative_matrix_block_load)]
+    static This LoadDecode<
+        U,
+        let Dim : uint32_t,
+        let ClampMode : uint32_t, //  : CoopMatClampMode
+        let DimView : uint32_t,
+        let HasDimensions : bool
+        $(tensorViewTypes)
+    >(
+        StructuredBuffer<T> buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView,
+        functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
+    {
+        let zero = 0;
+        let alignment = 16U;
+
+        // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
+        This ret;
+        return spirv_asm
+        {
+            OpCapability CooperativeMatrixTensorAddressingNV;
+            OpCapability CooperativeMatrixBlockLoadsNV;
+            OpExtension "SPV_NV_cooperative_matrix2";
+            %storagePointerType = OpTypePointer StorageBuffer $$T;
+            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
+            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment TensorView|DecodeFunc $tensorView $decodeFunc;
+        };
+    }
+
+    [require(cooperative_matrix_block_load)]
+    static This LoadDecode<
+        U,
+        let Dim : uint32_t,
+        let ClampMode : uint32_t, //  : CoopMatClampMode
+        let DimView : uint32_t,
+        let HasDimensions : bool
+        $(tensorViewTypes)
+    >(
+        RWStructuredBuffer<T> buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView,
+        functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
+    {
+        let zero = 0;
+        let alignment = 16U;
+
+        // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
+        This ret;
+        return spirv_asm
+        {
+            OpCapability CooperativeMatrixTensorAddressingNV;
+            OpCapability CooperativeMatrixBlockLoadsNV;
+            OpExtension "SPV_NV_cooperative_matrix2";
+            %storagePointerType = OpTypePointer StorageBuffer $$T;
+            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
+            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment TensorView|DecodeFunc $tensorView $decodeFunc;
+        };
+    }
+
+    [require(cooperative_matrix_tensor_addressing)]
+    void Store<
+        let Dim : uint32_t,
+        let ClampMode : uint32_t //  : CoopMatClampMode
+    >(
+        RWByteAddressBuffer buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
+    {
+        Store(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout);
+    }
+
+    [require(cooperative_matrix_tensor_addressing)]
+    void Store<
+        let Dim : uint32_t,
+        let ClampMode : uint32_t //  : CoopMatClampMode
+    >(
+        RWStructuredBuffer<T> buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout)
+    {
+        let zero = 0;
+        let alignment = 16U;
+
+        __target_switch
+        {
+        case spirv:
+            spirv_asm
+            {
+                OpCapability CooperativeMatrixTensorAddressingNV;
+                OpExtension "SPV_NV_cooperative_matrix2";
+                %storagePointerType = OpTypePointer StorageBuffer $$T;
+                %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
+                OpCooperativeMatrixStoreTensorNV %pointer $this $tensorLayout Aligned !alignment None;
+            };
+        }
+    }
+
+    [require(cooperative_matrix_tensor_addressing)]
+    void Store<
+        let Dim : uint32_t,
+        let ClampMode : uint32_t, //  : CoopMatClampMode
+        let DimView : uint32_t,
+        let HasDimensions : bool
+        $(tensorViewTypes)
+    >(
+        RWByteAddressBuffer buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView)
+    {
+        Store(__getEquivalentStructuredBuffer<T>(buffer), element, tensorLayout, tensorView);
+    }
+
+    [require(cooperative_matrix_tensor_addressing)]
+    void Store<
+        let Dim : uint32_t,
+        let ClampMode : uint32_t, //  : CoopMatClampMode
+        let DimView : uint32_t,
+        let HasDimensions : bool
+        $(tensorViewTypes)
+    >(
+        RWStructuredBuffer<T> buffer,
+        uint element,
+        tensor_addressing.TensorLayout<Dim, ClampMode> tensorLayout,
+        tensor_addressing.TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView)
+    {
+        let zero = 0;
+        let alignment = 16U;
+
+        __target_switch
+        {
+        case spirv:
+            spirv_asm
+            {
+                OpCapability CooperativeMatrixTensorAddressingNV;
+                OpExtension "SPV_NV_cooperative_matrix2";
+                %storagePointerType = OpTypePointer StorageBuffer $$T;
+                %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
+                OpCooperativeMatrixStoreTensorNV %pointer $this $tensorLayout Aligned !alignment TensorView $tensorView;
+            };
+        }
+    }
+
 } // struct CoopMat
 
 
@@ -23092,13 +23774,13 @@ CoopMat<T, S, M, N, R> coopMatLoad<
     let M : int,
     let N : int,
     let R : CoopMatMatrixUse,
-    let matrixLayout : CoopMatMatrixLayout
+    let matrixLayout : uint32_t //  : CoopMatMatrixLayout
 >(
     ByteAddressBuffer buffer,
     uint element,
     uint stride)
 {
-    return CoopMat<T, S, M, N, R>.Load<matrixLayout>(buffer, element, stride);
+    return CoopMat<T, S, M, N, R>.Load<matrixLayout>(__getEquivalentStructuredBuffer<T>(buffer), element, stride);
 }
 
 [ForceInline]
@@ -23109,13 +23791,13 @@ CoopMat<T, S, M, N, R> coopMatLoad<
     let M : int,
     let N : int,
     let R : CoopMatMatrixUse,
-    let matrixLayout : CoopMatMatrixLayout
+    let matrixLayout : uint32_t //  : CoopMatMatrixLayout
 >(
     RWByteAddressBuffer buffer,
     uint element,
     uint stride)
 {
-    return CoopMat<T, S, M, N, R>.Load<matrixLayout>(buffer, element, stride);
+    return CoopMat<T, S, M, N, R>.Load<matrixLayout>(__getEquivalentStructuredBuffer<T>(buffer), element, stride);
 }
 
 [ForceInline]
@@ -23126,7 +23808,7 @@ CoopMat<T, S, M, N, R> coopMatLoad<
     let M : int,
     let N : int,
     let R : CoopMatMatrixUse,
-    let matrixLayout : CoopMatMatrixLayout
+    let matrixLayout : uint32_t //  : CoopMatMatrixLayout
 >(
     StructuredBuffer<T> buffer,
     uint element,
@@ -23143,7 +23825,7 @@ CoopMat<T, S, M, N, R> coopMatLoad<
     let M : int,
     let N : int,
     let R : CoopMatMatrixUse,
-    let matrixLayout : CoopMatMatrixLayout
+    let matrixLayout : uint32_t //  : CoopMatMatrixLayout
 >(
     RWStructuredBuffer<T> buffer,
     uint element,
@@ -23160,7 +23842,7 @@ CoopMat<T, S, M, N, R> coopMatLoad<
     let M : int,
     let N : int,
     let R : CoopMatMatrixUse,
-    let matrixLayout : CoopMatMatrixLayout
+    let matrixLayout : uint32_t //  : CoopMatMatrixLayout
 >(
     T* buffer,
     uint element,
@@ -23177,7 +23859,7 @@ CoopMat<T, S, M, N, R> coopMatLoad<
     let M : int,
     let N : int,
     let R : CoopMatMatrixUse,
-    let matrixLayout : CoopMatMatrixLayout,
+    let matrixLayout : uint32_t, //  : CoopMatMatrixLayout
     let U : int
 >(
     __constref groupshared T[U] data,

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -567,25 +567,25 @@ def SPV_GOOGLE_user_type : _spirv_1_0;
 /// [EXT]
 def SPV_EXT_replicated_composites : _spirv_1_0;
 
+/// Represents the SPIR-V extension for SPV_KHR_vulkan_memory_model.
+/// [EXT]
+def SPV_KHR_vulkan_memory_model : _spirv_1_3;
+
 /// Represents the SPIR-V extension for SPV_NV_cooperative_vector.
 /// [EXT]
-def SPV_NV_cooperative_vector : _spirv_1_6 + SPV_EXT_replicated_composites;
+def SPV_NV_cooperative_vector : _spirv_1_6 + SPV_EXT_replicated_composites + SPV_KHR_vulkan_memory_model;
 
 /// Represents the SPIR-V extension for SPV_KHR_cooperative_matrix.
 /// [EXT]
-def SPV_KHR_cooperative_matrix : _spirv_1_6 + SPV_EXT_physical_storage_buffer;
-
-/// Represents the SPIR-V extension for SPV_NV_cooperative_matrix2.
-/// [EXT]
-def SPV_NV_cooperative_matrix2 : _spirv_1_6 + SPV_KHR_cooperative_matrix;
+def SPV_KHR_cooperative_matrix : _spirv_1_6 + SPV_EXT_physical_storage_buffer + SPV_KHR_vulkan_memory_model;
 
 /// Represents the SPIR-V extension for SPV_NV_tensor_addressing.
 /// [EXT]
 def SPV_NV_tensor_addressing : _spirv_1_6;
 
-/// Represents the SPIR-V extension for SPV_KHR_vulkan_memory_model.
+/// Represents the SPIR-V extension for SPV_NV_cooperative_matrix2.
 /// [EXT]
-def SPV_KHR_vulkan_memory_model : _spirv_1_3;
+def SPV_NV_cooperative_matrix2 : SPV_NV_tensor_addressing + SPV_KHR_cooperative_matrix;
 
 // SPIRV Capabilities.
 
@@ -747,7 +747,7 @@ def spvCooperativeVectorTrainingNV : SPV_NV_cooperative_vector;
 
 /// Represents the SPIR-V capability for cooperative matrices
 /// [EXT]
-def spvCooperativeMatrixKHR : SPV_KHR_cooperative_matrix + SPV_KHR_vulkan_memory_model;
+def spvCooperativeMatrixKHR : SPV_KHR_cooperative_matrix;
 
 /// Represents the SPIR-V capability for cooperative matrix 2
 /// [EXT]

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -747,7 +747,7 @@ def spvCooperativeVectorTrainingNV : SPV_NV_cooperative_vector;
 
 /// Represents the SPIR-V capability for cooperative matrices
 /// [EXT]
-def spvCooperativeMatrixKHR : SPV_KHR_cooperative_matrix;
+def spvCooperativeMatrixKHR : SPV_KHR_cooperative_matrix + SPV_KHR_vulkan_memory_model;
 
 /// Represents the SPIR-V capability for cooperative matrix 2
 /// [EXT]
@@ -1183,6 +1183,9 @@ alias cooperative_matrix_block_load = spvCooperativeMatrixBlockLoadsNV;
 /// Capabilities needed to use tensor addressing
 /// [Compound]
 alias tensor_addressing = spvTensorAddressingNV;
+/// Capabilities needed to use tensor addressing
+/// [Compound]
+alias cooperative_matrix_2 = spvCooperativeMatrixKHR + spvCooperativeMatrixReductionsNV + spvCooperativeMatrixConversionsNV + spvCooperativeMatrixPerElementOperationsNV + spvCooperativeMatrixTensorAddressingNV + spvCooperativeMatrixBlockLoadsNV + spvTensorAddressingNV;
 
 // Non-internal shader stages
 //

--- a/source/slang/slang-emit-spirv-ops.h
+++ b/source/slang/slang-emit-spirv-ops.h
@@ -174,6 +174,56 @@ SpvInst* emitOpTypeCoopMat(
         matrixUse);
 }
 
+// https://github.khronos.org/SPIRV-Registry/extensions/NV/SPV_NV_tensor_addressing.html#OpTypeTensorLayoutNV
+template<typename T1, typename T2>
+SpvInst* emitOpTypeTensorLayout(IRInst* inst, const T1& dim, const T2& clampMode)
+{
+    static_assert(isSingular<T1>);
+    return emitInstMemoized(
+        getSection(SpvLogicalSectionID::ConstantsAndTypes),
+        inst,
+        SpvOpTypeTensorLayoutNV,
+        kResultID,
+        dim,
+        clampMode);
+}
+
+// https://github.khronos.org/SPIRV-Registry/extensions/NV/SPV_NV_tensor_addressing.html#OpTypeTensorViewNV
+template<typename T1, typename T2, typename... TPerms>
+SpvInst* emitOpTypeTensorView(
+    IRInst* inst,
+    const T1& dim,
+    const T2& hasDimensions,
+    const TPerms&... perms)
+{
+    static_assert(isSingular<T1>);
+    static_assert(isSingular<T2>);
+    return emitInstMemoized(
+        getSection(SpvLogicalSectionID::ConstantsAndTypes),
+        inst,
+        SpvOpTypeTensorViewNV,
+        kResultID,
+        dim,
+        hasDimensions,
+        perms...);
+}
+
+// https://github.khronos.org/SPIRV-Registry/extensions/NV/SPV_NV_tensor_addressing.html#OpCreateTensorLayoutNV
+template<typename T1>
+SpvInst* emitOpCreateTensorLayout(SpvInstParent* parent, IRInst* inst, const T1& idResultType)
+{
+    static_assert(isSingular<T1>);
+    return emitInst(parent, inst, SpvOpCreateTensorLayoutNV, idResultType, kResultID);
+}
+
+// https://github.khronos.org/SPIRV-Registry/extensions/NV/SPV_NV_tensor_addressing.html#OpCreateTensorViewNV
+template<typename T1>
+SpvInst* emitOpCreateTensorView(SpvInstParent* parent, IRInst* inst, const T1& idResultType)
+{
+    static_assert(isSingular<T1>);
+    return emitInst(parent, inst, SpvOpCreateTensorViewNV, idResultType, kResultID);
+}
+
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpTypeMatrix
 template<typename T>
 SpvInst* emitOpTypeMatrix(IRInst* inst, const T& columnType, const SpvLiteralInteger& columnCount)

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -238,6 +238,10 @@ INST(RayQueryType, RayQuery, 1, HOISTABLE)
 INST(HitObjectType, HitObject, 0, HOISTABLE)
 INST(CoopVectorType, CoopVectorType, 2, HOISTABLE)
 INST(CoopMatrixType, CoopMatrixType, 5, HOISTABLE)
+INST(TensorAddressingTensorLayoutType, TensorAddressingTensorLayoutType, 2, HOISTABLE)
+INST(TensorAddressingTensorViewType, TensorAddressingTensorViewType, 3, HOISTABLE)
+INST(MakeTensorAddressingTensorLayout, MakeTensorAddressingTensorLayout, 0, 0)
+INST(MakeTensorAddressingTensorView, MakeTensorAddressingTensorView, 0, 0)
 
 // Opaque type that can be dynamically cast to other resource types.
 INST(DynamicResourceType, DynamicResource, 0, HOISTABLE)

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -1806,6 +1806,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 }
             }
         }
+
         // Scan through the entry points and find the max version required.
         auto processInst = [&](IRInst* globalInst)
         {

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1882,6 +1882,23 @@ struct IRCoopMatrixType : IRType
     IR_LEAF_ISA(CoopMatrixType)
 };
 
+struct IRTensorAddressingTensorLayoutType : IRType
+{
+    IRInst* getDimension() { return getOperand(0); }
+    IRInst* getClampMode() { return getOperand(1); }
+
+    IR_LEAF_ISA(TensorAddressingTensorLayoutType)
+};
+
+struct IRTensorAddressingTensorViewType : IRType
+{
+    IRInst* getDimension() { return getOperand(0); }
+    IRInst* getHasDimension() { return getOperand(1); }
+    IRInst* getPermutation(int index) { return getOperand(2 + index); }
+
+    IR_LEAF_ISA(TensorAddressingTensorViewType)
+};
+
 bool isDefinition(IRInst* inVal);
 
 // A structure type is represented as a parent instruction,

--- a/tests/cooperative-matrix/load-store-tensorlayout.slang
+++ b/tests/cooperative-matrix/load-store-tensorlayout.slang
@@ -1,0 +1,87 @@
+//TEST(compute):SIMPLE(filecheck=SPIRV):-target spirv-asm -entry computeMain -stage compute -skip-spirv-validation
+//TEST(compute):SIMPLE(filecheck=SPIRV_BL):-target spirv-asm -entry computeMain -stage compute -skip-spirv-validation -DBLOCK_LOAD
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -skip-spirv-validation -render-feature cooperative-matrix-tensor-addressing
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -skip-spirv-validation -render-feature cooperative-matrix-tensor-addressing -Xslang -DRW
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BL):-vk -output-using-type -emit-spirv-directly -Xslang -DBLOCK_LOAD -skip-spirv-validation -render-feature cooperative-matrix-block-loads
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BL):-vk -output-using-type -emit-spirv-directly -Xslang -DBLOCK_LOAD -skip-spirv-validation -render-feature cooperative-matrix-block-loads -Xslang -DRW
+
+//CHECK: 0
+//CHECK-NEXT: 0
+//CHECK-NEXT: 0
+//CHECK-NEXT: 0
+//CHECK-NEXT: 5
+//CHECK-NEXT: 6
+//CHECK-NEXT: 0
+//CHECK-NEXT: 0
+//CHECK-NEXT: 9
+
+//CHECK_BL: 0
+//CHECK_BL-NEXT: 0
+//CHECK_BL-NEXT: 0
+//CHECK_BL-NEXT: 0
+//CHECK_BL-NEXT: 7
+//CHECK_BL-NEXT: C
+//CHECK_BL-NEXT: 0
+//CHECK_BL-NEXT: 0
+//CHECK_BL-NEXT: C
+//CHECK_BL-NEXT: 11
+//CHECK_BL-NEXT: 0
+//CHECK_BL-NEXT: 0
+
+//TEST_INPUT:ubuffer(data=[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24], stride=4, count=256),name=buf
+
+#if defined(RW)
+    RWByteAddressBuffer inputBuffer;
+#else // #if defined(RW)
+    ByteAddressBuffer inputBuffer;
+#endif // #else // #if defined(RW)
+
+//TEST_INPUT:ubuffer(stride=4, count=256):out,name=outputBuffer
+RWByteAddressBuffer outputBuffer;
+
+using namespace tensor_addressing;
+typealias CoopMatType = CoopMat<int32_t, MemoryScope.Subgroup, 16, 16, CoopMatMatrixUse.MatrixAccumulator>;
+
+int32_t decodeFunc(uint32_t* encoded, uint32_t blockCoord[2], uint32_t coordInBlock[2])
+{
+    uint32_t coord = blockCoord[1] * 4 + blockCoord[0];
+    uint32_t mask = (0xff << (coordInBlock[0] * 8));
+    return int32_t(encoded[coord] & mask) + 1;
+}
+
+[numthreads(32, 1, 1)]
+void computeMain()
+{
+    //SPIRV: = OpCreateTensorLayoutNV %
+    TensorLayout<2, CoopMatClampMode.Undefined> tl;
+
+    //SPIRV: = OpTensorLayoutSetDimensionNV %
+    let tl1 = tl.Dimension(32, 16);
+
+    //SPIRV: = OpTensorLayoutSetStrideNV %
+    let tl2 = tl1.Stride(4, 1);
+
+    //SPIRV: = OpTensorLayoutSliceNV %
+    let tl3 = tl2.Slice(4, 24, 0, 16);
+
+    //SPIRV: = OpTensorLayoutSetClampValueNV %
+    let tl4 = tl3.ClampValue(CoopMatClampMode.Repeat);
+
+    //SPIRV: = OpTensorLayoutSetBlockSizeNV %
+    let tl5 = tl4.BlockSize(4, 8);
+
+#if defined(BLOCK_LOAD)
+    //SPIRV_BL: = OpCooperativeMatrixLoadTensorNV %{{.*}} DecodeFunc %
+    let mat = CoopMatType.LoadDecode<uint32_t>(inputBuffer, 0, tl5, decodeFunc);
+
+#else // #if defined(BLOCK_LOAD)
+    //SPIRV: = OpCooperativeMatrixLoadTensorNV %{{.*}} None
+    let mat = CoopMatType.Load(inputBuffer, 0, tl5);
+
+#endif // #else // #if defined(BLOCK_LOAD)
+
+    //SPIRV:OpCooperativeMatrixStoreTensorNV %{{.*}} None
+    mat.Store(outputBuffer, 0, tl5);
+}

--- a/tests/cooperative-matrix/load-store-tensorlayout.slang
+++ b/tests/cooperative-matrix/load-store-tensorlayout.slang
@@ -4,8 +4,8 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -skip-spirv-validation -render-feature cooperative-matrix-tensor-addressing
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -skip-spirv-validation -render-feature cooperative-matrix-tensor-addressing -Xslang -DRW
 
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BL):-vk -output-using-type -emit-spirv-directly -Xslang -DBLOCK_LOAD -skip-spirv-validation -render-feature cooperative-matrix-block-loads
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BL):-vk -output-using-type -emit-spirv-directly -Xslang -DBLOCK_LOAD -skip-spirv-validation -render-feature cooperative-matrix-block-loads -Xslang -DRW
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BL):-vk -output-using-type -emit-spirv-directly -skip-spirv-validation -render-feature cooperative-matrix-block-loads -Xslang -DBLOCK_LOAD
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BL):-vk -output-using-type -emit-spirv-directly -skip-spirv-validation -render-feature cooperative-matrix-block-loads -Xslang -DBLOCK_LOAD -Xslang -DRW
 
 //CHECK: 0
 //CHECK-NEXT: 0
@@ -74,7 +74,7 @@ void computeMain()
 
 #if defined(BLOCK_LOAD)
     //SPIRV_BL: = OpCooperativeMatrixLoadTensorNV %{{.*}} DecodeFunc %
-    let mat = CoopMatType.LoadDecode<uint32_t>(inputBuffer, 0, tl5, decodeFunc);
+    let mat = CoopMatType.Load<uint32_t>(inputBuffer, 0, tl5, decodeFunc);
 
 #else // #if defined(BLOCK_LOAD)
     //SPIRV: = OpCooperativeMatrixLoadTensorNV %{{.*}} None

--- a/tests/cooperative-matrix/load-store-tensorlayout.slang
+++ b/tests/cooperative-matrix/load-store-tensorlayout.slang
@@ -41,7 +41,8 @@
 //TEST_INPUT:ubuffer(stride=4, count=256):out,name=outputBuffer
 RWByteAddressBuffer outputBuffer;
 
-using namespace tensor_addressing;
+using namespace linalg;
+
 typealias CoopMatType = CoopMat<int32_t, MemoryScope.Subgroup, 16, 16, CoopMatMatrixUse.MatrixAccumulator>;
 
 int32_t decodeFunc(uint32_t* encoded, uint32_t blockCoord[2], uint32_t coordInBlock[2])

--- a/tests/cooperative-matrix/load-store-tensorview.slang
+++ b/tests/cooperative-matrix/load-store-tensorview.slang
@@ -73,7 +73,7 @@ void computeMain()
 
 #if defined(BLOCK_LOAD)
     //SPIRV_BL: = OpCooperativeMatrixLoadTensorNV %{{.*}} TensorView|DecodeFunc %
-    let mat = CoopMatType.LoadDecode<uint32_t>(inputBuffer, 0, tl3, tvRowMajor, decodeFunc);
+    let mat = CoopMatType.Load<uint32_t>(inputBuffer, 0, tl3, tvRowMajor, decodeFunc);
 
 #else // #if defined(BLOCK_LOAD)
     //SPIRV: OpCooperativeMatrixLoadTensorNV %

--- a/tests/cooperative-matrix/load-store-tensorview.slang
+++ b/tests/cooperative-matrix/load-store-tensorview.slang
@@ -1,0 +1,87 @@
+//TEST(compute):SIMPLE(filecheck=SPIRV):-target spirv-asm -entry computeMain -stage compute -skip-spirv-validation
+//TEST(compute):SIMPLE(filecheck=SPIRV_BL):-target spirv-asm -entry computeMain -stage compute -skip-spirv-validation -DBLOCK_LOAD
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -skip-spirv-validation -render-feature cooperative-matrix-tensor-addressing
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -skip-spirv-validation -render-feature cooperative-matrix-tensor-addressing -Xslang -DRW
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BL):-vk -output-using-type -emit-spirv-directly -Xslang -DBLOCK_LOAD -render-feature cooperative-matrix-block-loads -skip-spirv-validation
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_BL):-vk -output-using-type -emit-spirv-directly -Xslang -DBLOCK_LOAD -render-feature cooperative-matrix-block-loads -skip-spirv-validation -Xslang -DRW
+
+//CHECK: 2
+//CHECK-NEXT: 2
+//CHECK-NEXT: 2
+//CHECK-NEXT: 2
+//CHECK-NEXT: 12
+//CHECK-NEXT: 12
+//CHECK-NEXT: 12
+//CHECK-NEXT: 12
+//CHECK-NEXT: 0
+
+//CHECK_BL: 7
+//CHECK_BL-NEXT: 1
+//CHECK_BL-NEXT: 1
+//CHECK_BL-NEXT: 1
+//CHECK_BL-NEXT: 18
+//CHECK_BL-NEXT: 1
+//CHECK_BL-NEXT: 1
+//CHECK_BL-NEXT: 1
+//CHECK_BL-NEXT: 0
+
+//TEST_INPUT:ubuffer(data=[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24], stride=4, count=256),name=buf
+
+#if defined(RW)
+    RWByteAddressBuffer inputBuffer;
+#else // #if defined(RW)
+    ByteAddressBuffer inputBuffer;
+#endif // #else // #if defined(RW)
+
+//TEST_INPUT:ubuffer(stride=4, count=256):out,name=outputBuffer
+RWByteAddressBuffer outputBuffer;
+
+using namespace tensor_addressing;
+typealias CoopMatType = CoopMat<int32_t, MemoryScope.Subgroup, 16, 16, CoopMatMatrixUse.MatrixAccumulator>;
+
+int32_t decodeFunc(uint32_t* encoded, uint32_t blockCoord[2], uint32_t coordInBlock[2])
+{
+    uint32_t coord = blockCoord[1] * 4 + blockCoord[0];
+    uint32_t mask = (0xff << (coordInBlock[0] * 8));
+    return int32_t(encoded[coord] & mask) + 1;
+}
+
+[numthreads(32, 1, 1)]
+void computeMain()
+{
+    TensorLayout<2, CoopMatClampMode.Undefined> tl;
+
+    let tl1 = tl.Dimension(16, 16);
+    let tl2 = tl1.Slice(0, 16, 0, 16);
+    let tl3 = tl2.BlockSize(4, 1);
+
+    //SPIRV: = OpTypeTensorViewNV %{{[^%]*}} %false %{{[^%]*}} %{{[^%]*$}}
+    //SPIRV: = OpCreateTensorViewNV %
+    TensorView<2, false, 0, 1> tvRowMajor;
+    TensorView<2, false, 1, 0> tvColumnMajor;
+
+    //SPIRV: = OpTensorViewSetDimensionNV %
+    let tvColumnMajor1 = tvColumnMajor.Dimension(16, 8);
+
+    //SPIRV: = OpTensorViewSetStrideNV %
+    let tvColumnMajor2 = tvColumnMajor1.Stride(8, 1);
+
+    //SPIRV: = OpTensorViewSetClipNV %
+    let tvColumnMajor3 = tvColumnMajor2.Clip(0, 8, 0, 64);
+
+#if defined(BLOCK_LOAD)
+    //SPIRV_BL: = OpCooperativeMatrixLoadTensorNV %{{.*}} TensorView|DecodeFunc %
+    let mat = CoopMatType.LoadDecode<uint32_t>(inputBuffer, 0, tl3, tvRowMajor, decodeFunc);
+
+#else // #if defined(BLOCK_LOAD)
+    //SPIRV: OpCooperativeMatrixLoadTensorNV %
+    //SPIRV-SAME: TensorView
+    let mat = CoopMatType.Load(inputBuffer, 0, tl3, tvRowMajor);
+
+#endif // #else // #if defined(BLOCK_LOAD)
+
+    //SPIRV: OpCooperativeMatrixStoreTensorNV {{.*}} TensorView %
+    mat.Store(outputBuffer, 0, tl3, tvColumnMajor3);
+}

--- a/tests/cooperative-matrix/load-store-tensorview.slang
+++ b/tests/cooperative-matrix/load-store-tensorview.slang
@@ -38,7 +38,8 @@
 //TEST_INPUT:ubuffer(stride=4, count=256):out,name=outputBuffer
 RWByteAddressBuffer outputBuffer;
 
-using namespace tensor_addressing;
+using namespace linalg;
+
 typealias CoopMatType = CoopMat<int32_t, MemoryScope.Subgroup, 16, 16, CoopMatMatrixUse.MatrixAccumulator>;
 
 int32_t decodeFunc(uint32_t* encoded, uint32_t blockCoord[2], uint32_t coordInBlock[2])


### PR DESCRIPTION
This commit implements two new types and related Load/Store functions in `CoopMat`.
- tensor_addrressing.TensorLayout
- tensor_addressing.TensorView
- CoopMat.Load(..., TensorLayout)
- CoopMat.Load(..., TensorLayout, TensorView)
- CoopMat.Store(..., TensorLayout)
- CoopMat.Store(..., TensorLayout, TensorView)
- CoopMat.LoadDecode(..., TensorLayout, TensorView)

Currently there are two workarounds to avoid preexisted problems in Slang.
1. When `enum` is used as generic-parameter, Slang accepts overloading that have the same enum at same location. A workaround is to use `uint` instead of `enum`. ([issue 7061](https://github.com/shader-slang/slang/issues/7061))
2. When there are two overloading, `Load<uint>(...)` and `Load<U>(...)`, the first overloading seems to shadow the second one. A workaround is to rename the second function name to something different in a way to avoid overloading.  ([issue 7061](https://github.com/shader-slang/slang/issues/7061))

Close https://github.com/shader-slang/slang/issues/6874
Close https://github.com/shader-slang/slang/issues/6873