### PR TITLE
Do not print errors in _coerce when "JustTrying".

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1866,7 +1866,8 @@ void SemanticsDeclHeaderVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
             if (auto initExpr = varDecl->initExpr)
             {
                 initExpr = CheckTerm(initExpr);
-                initExpr = coerce(CoercionSite::Initializer, varDecl->type.Ptr(), initExpr);
+                initExpr =
+                    coerce(CoercionSite::Initializer, varDecl->type.Ptr(), initExpr, getSink());
                 varDecl->initExpr = initExpr;
 
                 maybeInferArraySizeForVariable(varDecl);
@@ -2346,7 +2347,7 @@ void SemanticsDeclBodyVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
         if (initExpr->type.isWriteOnly)
             getSink()->diagnose(initExpr, Diagnostics::readingFromWriteOnly);
 
-        initExpr = coerce(CoercionSite::Initializer, varDecl->type.Ptr(), initExpr);
+        initExpr = coerce(CoercionSite::Initializer, varDecl->type.Ptr(), initExpr, getSink());
         varDecl->initExpr = initExpr;
 
         // We need to ensure that any variable doesn't introduce
@@ -4946,7 +4947,7 @@ bool SemanticsVisitor::trySynthesizeMethodRequirementWitness(
     // so we also need to coerce the result of the call to
     // the expected type.
     //
-    auto coercedCall = subVisitor.coerce(CoercionSite::Return, resultType, checkedCall);
+    auto coercedCall = subVisitor.coerce(CoercionSite::Return, resultType, checkedCall, getSink());
 
     // If our overload resolution or type coercion failed,
     // then we have not been able to synthesize a witness
@@ -5801,7 +5802,7 @@ bool SemanticsVisitor::synthesizeAccessorRequirements(
             // the expected type of the property.
             //
             auto coercedMemberRef =
-                subVisitor.coerce(CoercionSite::Return, resultType, synBoundStorageExpr);
+                subVisitor.coerce(CoercionSite::Return, resultType, synBoundStorageExpr, getSink());
             auto synReturn = m_astBuilder->create<ReturnStmt>();
             synReturn->expression = coercedMemberRef;
 
@@ -8090,7 +8091,7 @@ void SemanticsDeclBodyVisitor::visitEnumCaseDecl(EnumCaseDecl* decl)
     if (auto initExpr = decl->tagExpr)
     {
         initExpr = CheckTerm(initExpr);
-        initExpr = coerce(CoercionSite::General, tagType, initExpr);
+        initExpr = coerce(CoercionSite::General, tagType, initExpr, getSink());
 
         // We want to enforce that this is an integer constant
         // expression.
@@ -9137,7 +9138,7 @@ void SemanticsDeclBodyVisitor::visitParamDecl(ParamDecl* paramDecl)
         // actual type of the parameter.
         //
         initExpr = CheckTerm(initExpr);
-        initExpr = coerce(CoercionSite::Initializer, typeExpr.type, initExpr);
+        initExpr = coerce(CoercionSite::Initializer, typeExpr.type, initExpr, getSink());
         paramDecl->initExpr = initExpr;
 
         // TODO: a default argument expression needs to
@@ -9282,7 +9283,7 @@ void SemanticsDeclBodyVisitor::synthesizeCtorBodyForBases(
         invoke->arguments.addRange(argumentList);
 
         auto assign = m_astBuilder->create<AssignExpr>();
-        assign->left = coerce(CoercionSite::Initializer, declRefType, thisExpr);
+        assign->left = coerce(CoercionSite::Initializer, declRefType, thisExpr, getSink());
         assign->right = invoke;
 
         auto stmt = m_astBuilder->create<ExpressionStmt>();

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -518,7 +518,7 @@ Expr* SemanticsVisitor::constructDerefExpr(Expr* base, QualType elementType, Sou
 {
     if (auto resPtrType = as<DescriptorHandleType>(base->type))
     {
-        return coerce(CoercionSite::ExplicitCoercion, resPtrType->getElementType(), base);
+        return coerce(CoercionSite::ExplicitCoercion, resPtrType->getElementType(), base, getSink());
     }
 
     auto derefExpr = m_astBuilder->create<DerefExpr>();
@@ -2249,7 +2249,7 @@ IntVal* SemanticsVisitor::CheckIntegerConstantExpression(
     switch (coercionType)
     {
     case IntegerConstantExpressionCoercionType::SpecificType:
-        expr = coerce(CoercionSite::General, expectedType, inExpr);
+        expr = coerce(CoercionSite::General, expectedType, inExpr, sink);
         break;
     case IntegerConstantExpressionCoercionType::AnyInteger:
         if (isScalarIntegerType(inExpr->type))
@@ -2257,7 +2257,7 @@ IntVal* SemanticsVisitor::CheckIntegerConstantExpression(
         else if (isEnumType(inExpr->type))
             expr = inExpr;
         else
-            expr = coerce(CoercionSite::General, m_astBuilder->getIntType(), inExpr);
+            expr = coerce(CoercionSite::General, m_astBuilder->getIntType(), inExpr, sink);
         break;
     default:
         break;
@@ -2522,7 +2522,7 @@ Expr* SemanticsVisitor::checkAssignWithCheckedOperands(AssignExpr* expr)
         type = atomicType->getElementType();
     }
     auto right = maybeOpenRef(expr->right);
-    expr->right = coerce(CoercionSite::Assignment, type, right);
+    expr->right = coerce(CoercionSite::Assignment, type, right, getSink());
 
     if (!expr->left->type.isLeftValue)
     {
@@ -2951,7 +2951,7 @@ Expr* SemanticsExprVisitor::convertToLogicOperatorExpr(InvokeExpr* expr)
             // to handle if this expression doesn't support short-circuiting.
             for (auto& arg : expr->arguments)
             {
-                arg = coerce(CoercionSite::Argument, m_astBuilder->getBoolType(), arg);
+                arg = coerce(CoercionSite::Argument, m_astBuilder->getBoolType(), arg, getSink());
             }
 
             expr->functionExpr = CheckTerm(expr->functionExpr);
@@ -3915,7 +3915,11 @@ Expr* SemanticsExprVisitor::visitTypeCastExpr(TypeCastExpr* expr)
                         auto checkedInitListExpr = visitInitializerListExpr(initListExpr);
 
 
-                        return coerce(CoercionSite::General, typeExp.type, checkedInitListExpr);
+                        return coerce(
+                            CoercionSite::General,
+                            typeExp.type,
+                            checkedInitListExpr,
+                            getSink());
                     }
                 }
             }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1674,6 +1674,7 @@ public:
         Expr** outToExpr,
         QualType fromType,
         Expr* fromExpr,
+        DiagnosticSink* sink,
         ConversionCost* outCost);
 
     /// Check whether implicit type coercion from `fromType` to `toType` is possible.
@@ -1698,7 +1699,7 @@ public:
     Expr* createCastToInterfaceExpr(Type* toType, Expr* fromExpr, Val* witness);
 
     /// Implicitly coerce `fromExpr` to `toType` and diagnose errors if it isn't possible
-    Expr* coerce(CoercionSite site, Type* toType, Expr* fromExpr);
+    Expr* coerce(CoercionSite site, Type* toType, Expr* fromExpr, DiagnosticSink* sink);
 
     // Fill in default substitutions for the 'subtype' part of a type constraint decl
     void CheckConstraintSubType(TypeExp& typeExp);

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -828,7 +828,7 @@ Modifier* SemanticsVisitor::validateAttribute(
                 if (!typeChecked)
                 {
                     arg = CheckTerm(arg);
-                    arg = coerce(CoercionSite::Argument, paramDecl->getType(), arg);
+                    arg = coerce(CoercionSite::Argument, paramDecl->getType(), arg, getSink());
                 }
             }
             paramIndex++;

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -481,7 +481,11 @@ bool SemanticsVisitor::TryCheckGenericOverloadCandidateTypes(
             }
             else
             {
-                arg = coerce(CoercionSite::Argument, getType(m_astBuilder, valParamRef), arg);
+                arg = coerce(
+                    CoercionSite::Argument,
+                    getType(m_astBuilder, valParamRef),
+                    arg,
+                    getSink());
             }
 
             // If we have an argument to work with, then we will
@@ -712,7 +716,7 @@ bool SemanticsVisitor::TryCheckOverloadCandidateTypes(
         }
         else
         {
-            Expr* coercedExpr = coerce(CoercionSite::Argument, paramType, arg.argExpr);
+            Expr* coercedExpr = coerce(CoercionSite::Argument, paramType, arg.argExpr, getSink());
 
             // Check if concrete-to-interface coercion caused loss of l-valueness.
             if (coercedExpr && !coercedExpr->type.isLeftValue && paramType.isLeftValue &&
@@ -2650,6 +2654,7 @@ Expr* SemanticsVisitor::ResolveInvoke(InvokeExpr* expr)
                                             &resultExpr,
                                             expr->arguments[0]->type,
                                             expr->arguments[0],
+                                            getSink(),
                                             &conversionCost);
                 if (coerceResult)
                     return resultExpr;

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -255,7 +255,7 @@ Expr* SemanticsVisitor::checkPredicateExpr(Expr* expr)
     }
     Expr* e = expr;
     e = CheckTerm(e);
-    e = coerce(CoercionSite::General, m_astBuilder->getBoolType(), e);
+    e = coerce(CoercionSite::General, m_astBuilder->getBoolType(), e, getSink());
     return e;
 }
 
@@ -408,7 +408,7 @@ void SemanticsStmtVisitor::visitCaseStmt(CaseStmt* stmt)
 
     // Check that the type for the `case` is consistent with the type for the `switch`.
     auto expr = CheckExpr(stmt->expr);
-    expr = coerce(CoercionSite::Argument, switchStmt->condition->type, expr);
+    expr = coerce(CoercionSite::Argument, switchStmt->condition->type, expr, getSink());
 
     // coerce to type being switch on, and ensure that value is a compile-time constant
     // The Vals in the AST are pointer-unique, making them easy to check for duplicates
@@ -574,7 +574,7 @@ void SemanticsStmtVisitor::visitReturnStmt(ReturnStmt* stmt)
             if (!m_parentLambdaExpr && expectedReturnType)
             {
                 stmt->expression =
-                    coerce(CoercionSite::Return, expectedReturnType, stmt->expression);
+                    coerce(CoercionSite::Return, expectedReturnType, stmt->expression, getSink());
             }
         }
     }

--- a/tests/language-feature/generics/generic-overload.slang
+++ b/tests/language-feature/generics/generic-overload.slang
@@ -1,0 +1,37 @@
+//TEST(compute):SIMPLE(filecheck=CHECK_EXPLICIT): -target spirv-asm -entry computeMain -stage compute -DEXPLICIT
+//TEST(compute):SIMPLE(filecheck=CHECK_OVERLOAD): -target spirv-asm -entry computeMain -stage compute -DOVERLOAD
+
+enum CoopMatMatrixLayout
+{
+    RowMajor = 0,
+    ColumnMajor = 1,
+};
+
+int Load<let me : CoopMatMatrixLayout>(int inVal)
+{
+    return int(inVal % 10);
+}
+
+#if !defined(EXPLICIT)
+int Load<let Dim : uint, let ClampMode : uint>(int inVal, int inVal2)
+{
+    return Load<CoopMatMatrixLayout.RowMajor>(inVal);
+}
+#endif
+
+[Shader("compute")]
+[NumThreads(4, 1, 1)]
+void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+{
+    int tid = dispatchThreadID.x;
+
+#if defined(EXPLICIT)
+    //CHECK_EXPLICIT: error 30019: expected an expression of type 'CoopMatMatrixLayout', got 'int'
+    //CHECK_EXPLICIT: note: explicit conversion from 'int' to 'CoopMatMatrixLayout' is possible
+    int outVal = Load<0>(tid);
+
+#elif defined(OVERLOAD)
+    //CHECK_OVERLOAD-NOT: error {{[1-9][0-9]*}}
+    int outVal = Load<CoopMatMatrixLayout.RowMajor>(tid);
+#endif
+}


### PR DESCRIPTION
While figuring out which generic-overload works best, `_coerce()` is printing errors and Slang compilation terminates prematurely.

When `TryCheckGenericOverloadCandidateTypes()` is calling `_coerce()` in "JustTrying" mode, the error messages should be snoozed.

The following logic shows the intention of how to silence the error messages, but the chain of `sink` was broken in the middle and `_coerce()` was using `getSink()` from the SemanticVisitor.

 val = ExtractGenericArgInteger(
   arg,
   getType(m_astBuilder, valParamRef),
   context.mode == OverloadResolveContext::Mode::JustTrying ? nullptr : getSink());

Closes https://github.com/shader-slang/slang/issues/7061