### PR TITLE
Initial bfloat16 support

### DIFF
--- a/source/slang-core-module/slang-embedded-core-module-source.cpp
+++ b/source/slang-core-module/slang-embedded-core-module-source.cpp
@@ -56,6 +56,7 @@ enum BaseTypeConversionRank : uint8_t
     kBaseTypeConversionRank_Int32,
     kBaseTypeConversionRank_IntPtr,
     kBaseTypeConversionRank_Int64,
+    kBaseTypeConversionRank_Bfloat16,
     kBaseTypeConversionRank_Error,
 };
 
@@ -149,6 +150,12 @@ static const BaseTypeConversionInfo kBaseTypes[] = {
      UINT_MASK,
      kBaseTypeConversionKind_Unsigned,
      kBaseTypeConversionRank_IntPtr},
+
+    {"bfloat16",
+     BaseType::BFloat16,
+     FLOAT_MASK,
+     kBaseTypeConversionKind_Float,
+     kBaseTypeConversionRank_Bfloat16},
 };
 
 void Session::finalizeSharedASTBuilder()
@@ -185,6 +192,12 @@ ConversionCost getBaseTypeConversionCost(
     {
         // Thse should represent the exact same type.
         return kConversionCost_None;
+    }
+
+    if (toInfo.tag == BaseType::BFloat16 || fromInfo.tag == BaseType::BFloat16)
+    {
+        // TODO: determine this properly.
+        return kConversionCost_GeneralConversion;
     }
 
     // Conversions within the same kind are easist to handle

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -8691,6 +8691,25 @@ T dot(vector<T, N> x, vector<T, N> y)
     }
 }
 
+__generic<let N : int>
+[__readNone]
+[require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, sm_4_0_version)]
+bfloat16 dot(vector<bfloat16, N> x, vector<bfloat16, N> y)
+{
+    __target_switch
+    {
+    case spirv:
+        return spirv_asm
+        {
+            OpExtension "SPV_KHR_bfloat16";
+            OpCapability BFloat16DotProductKHR;
+            result:$$bfloat16 = OpDot $x $y;
+        };
+    default:
+        __intrinsic_asm "dot";
+    }
+}
+
 __generic<T : __BuiltinIntegerType, let N : int>
 [__readNone]
 [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, sm_4_0_version)]

--- a/source/slang/slang-emit-spirv-ops.h
+++ b/source/slang/slang-emit-spirv-ops.h
@@ -121,6 +121,20 @@ SpvInst* emitOpTypeFloat(IRInst* inst, const SpvLiteralInteger& width)
         width);
 }
 
+SpvInst* emitOpTypeFloat(
+    IRInst* inst,
+    const SpvLiteralInteger& width,
+    const SpvFPEncoding& encoding)
+{
+    return emitInstMemoized(
+        getSection(SpvLogicalSectionID::ConstantsAndTypes),
+        inst,
+        SpvOpTypeFloat,
+        kResultID,
+        width,
+        encoding);
+}
+
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpTypeVector
 template<typename T>
 SpvInst* emitOpTypeVector(

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -951,6 +951,11 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     return SpvLiteralBits::from32(FloatAsInt((float)fval->getValue()));
                 break;
             }
+        case kIROp_BFloat16Type:
+            {
+                // TODO:
+                break;
+            }
         case kIROp_Int64Type:
         case kIROp_UInt64Type:
 #if SLANG_PTR_IS_64
@@ -1034,6 +1039,11 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 inst,
                 type,
                 SpvLiteralBits::from32(uint32_t(FloatToHalf(float(val)))));
+        }
+        else if (type->getOp() == kIROp_BFloat16Type)
+        {
+            // TODO.
+            SLANG_UNEXPECTED("missing case in SPIR-V emitFloatConstant");
         }
         else
         {
@@ -1545,6 +1555,14 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     requireSPIRVCapability(SpvCapabilityFloat16);
                 return emitOpTypeFloat(inst, SpvLiteralInteger::from32(int32_t(i.width)));
             }
+        case kIROp_BFloat16Type:
+            {
+                requireBfloat16Extension();
+                return emitOpTypeFloat(
+                    inst,
+                    SpvLiteralInteger::from32(16),
+                    SpvFPEncoding::SpvFPEncodingBFloat16KHR);
+            }
         case kIROp_PtrType:
         case kIROp_RefType:
         case kIROp_ConstRefType:
@@ -1697,6 +1715,12 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
                 IRBuilder builder(m_irModule);
                 auto coopMatType = static_cast<IRCoopMatrixType*>(inst);
+                if (coopMatType->getElementType()->getOp() == kIROp_BFloat16Type)
+                {
+                    requireSPIRVCapability(SpvCapabilityBFloat16CooperativeMatrixKHR);
+                    requireBfloat16Extension();
+                }
+
                 return emitOpTypeCoopMat(
                     coopMatType,
                     coopMatType->getElementType(),
@@ -7917,6 +7941,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             case kIROp_FloatType:
             case kIROp_DoubleType:
             case kIROp_HalfType:
+            case kIROp_BFloat16Type:
                 spvEncoding = 3; // Float
                 break;
             case kIROp_BoolType:
@@ -8552,6 +8577,12 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     ops...);
             }
         }
+    }
+
+    void requireBfloat16Extension()
+    {
+        ensureExtensionDeclaration(UnownedStringSlice("SPV_KHR_bfloat16"));
+        requireSPIRVCapability(SpvCapabilityBFloat16TypeKHR);
     }
 
     SPIRVEmitContext(IRModule* module, TargetProgram* program, DiagnosticSink* sink)

--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -149,6 +149,7 @@ struct AnyValueMarshallingContext
         case kIROp_UInt8Type:
         case kIROp_UInt16Type:
         case kIROp_HalfType:
+        case kIROp_BFloat16Type:
         case kIROp_BoolType:
         case kIROp_IntPtrType:
         case kIROp_UIntPtrType:
@@ -336,6 +337,7 @@ struct AnyValueMarshallingContext
             case kIROp_Int16Type:
             case kIROp_UInt16Type:
             case kIROp_HalfType:
+            case kIROp_BFloat16Type:
                 {
                     ensureOffsetAt2ByteBoundary();
                     if (fieldOffset < static_cast<uint32_t>(anyValInfo->fieldKeys.getCount()))
@@ -580,6 +582,7 @@ struct AnyValueMarshallingContext
             case kIROp_Int16Type:
             case kIROp_UInt16Type:
             case kIROp_HalfType:
+            case kIROp_BFloat16Type:
                 {
                     ensureOffsetAt2ByteBoundary();
                     if (fieldOffset < static_cast<uint32_t>(anyValInfo->fieldKeys.getCount()))
@@ -879,6 +882,7 @@ SlangInt _getAnyValueSizeRaw(IRType* type, SlangInt offset)
     case kIROp_Int16Type:
     case kIROp_UInt16Type:
     case kIROp_HalfType:
+    case kIROp_BFloat16Type:
         return alignUp(offset, 2) + 2;
     case kIROp_UInt8Type:
     case kIROp_Int8Type:

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -11,6 +11,7 @@
 
 #include "slang-ir-insts.h"
 #include "slang-ir-layout.h"
+#include "slang-ir.h"
 
 namespace Slang
 {
@@ -854,6 +855,7 @@ struct ByteAddressBufferLegalizationContext
         case kIROp_Int16Type:
         case kIROp_UInt16Type:
         case kIROp_HalfType:
+        case kIROp_BFloat16Type:
             return BaseType::UInt16;
         case kIROp_Int64Type:
         case kIROp_UInt64Type:

--- a/source/slang/slang-ir-layout.cpp
+++ b/source/slang/slang-ir-layout.cpp
@@ -117,6 +117,7 @@ static Result _calcSizeAndAlignment(
         BASE(Int16, 2);
         BASE(UInt16, 2);
         BASE(Half, 2);
+        BASE(BFloat16, 2);
 
         BASE(Int, 4);
         BASE(UInt, 4);

--- a/source/slang/slang-ir-lower-bit-cast.cpp
+++ b/source/slang/slang-ir-lower-bit-cast.cpp
@@ -167,6 +167,7 @@ struct BitCastLoweringContext
             }
             break;
         case kIROp_HalfType:
+        case kIROp_BFloat16Type:
         case kIROp_Int16Type:
         case kIROp_UInt16Type:
             {

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -4,6 +4,7 @@
 #include "slang-ir-dce.h"
 #include "slang-ir-dominators.h"
 #include "slang-ir-insts.h"
+#include "slang-ir.h"
 
 namespace Slang
 {
@@ -127,6 +128,7 @@ IROp getTypeStyle(IROp op)
     case kIROp_HalfType:
     case kIROp_FloatType:
     case kIROp_DoubleType:
+    case kIROp_BFloat16Type:
         {
             // All float like
             return kIROp_FloatType;
@@ -159,6 +161,7 @@ IROp getTypeStyle(BaseType op)
     case BaseType::Half:
     case BaseType::Float:
     case BaseType::Double:
+    case BaseType::BFloat16:
         return kIROp_FloatType;
     default:
         return kIROp_Invalid;
@@ -461,6 +464,9 @@ void getTypeNameHint(StringBuilder& sb, IRInst* type)
         break;
     case kIROp_DoubleType:
         sb << "double";
+        break;
+    case kIROp_BFloat16Type:
+        sb << "bfloat16";
         break;
     case kIROp_IntType:
         sb << "int";
@@ -1873,6 +1879,8 @@ UnownedStringSlice getBasicTypeNameHint(IRType* basicType)
         return UnownedStringSlice::fromLiteral("half");
     case kIROp_DoubleType:
         return UnownedStringSlice::fromLiteral("double");
+    case kIROp_BFloat16Type:
+        return UnownedStringSlice::fromLiteral("bfloat16");
     case kIROp_BoolType:
         return UnownedStringSlice::fromLiteral("bool");
     case kIROp_VoidType:

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3965,6 +3965,7 @@ IRInst* IRBuilder::emitDefaultConstruct(IRType* type, bool fallback)
     case kIROp_FloatType:
     case kIROp_HalfType:
     case kIROp_DoubleType:
+    case kIROp_BFloat16Type:
         return getFloatValue(type, 0.0);
     case kIROp_VoidType:
         return getVoidValue();
@@ -4121,6 +4122,7 @@ static TypeCastStyle _getTypeStyleId(IRType* type)
     case kIROp_FloatType:
     case kIROp_HalfType:
     case kIROp_DoubleType:
+    case kIROp_BFloat16Type:
         return TypeCastStyle::Float;
     case kIROp_BoolType:
         return TypeCastStyle::Bool;
@@ -7796,6 +7798,7 @@ bool isFloatingType(IRType* t)
         case BaseType::Float:
         case BaseType::Half:
         case BaseType::Double:
+        case BaseType::BFloat16:
             return true;
         default:
             return false;
@@ -7894,6 +7897,7 @@ FloatInfo getFloatingTypeInfo(const IRType* floatType)
     switch (floatType->getOp())
     {
     case kIROp_HalfType:
+    case kIROp_BFloat16Type:
         return {16};
     case kIROp_FloatType:
         return {32};

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -4686,6 +4686,7 @@ struct ExprLoweringVisitorBase : public ExprVisitor<Derived, LoweredValInfo>
             case BaseType::Half:
             case BaseType::Float:
             case BaseType::Double:
+            case BaseType::BFloat16:
                 return LoweredValInfo::simple(getBuilder()->getFloatValue(type, 0.0));
             }
         }

--- a/source/slang/slang-mangle.cpp
+++ b/source/slang/slang-mangle.cpp
@@ -191,6 +191,9 @@ void emitBaseType(ManglingContext* context, BaseType baseType)
     case BaseType::IntPtr:
         emitRaw(context, "ip");
         break;
+    case BaseType::BFloat16:
+        emitRaw(context, "bf");
+        break;
     default:
         SLANG_UNEXPECTED("unimplemented case in base type mangling");
         break;

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -117,6 +117,8 @@ struct DefaultLayoutRulesImpl : SimpleLayoutRulesImpl
             return SimpleLayoutInfo(LayoutResourceKind::Uniform, 4, 4);
         case BaseType::Double:
             return SimpleLayoutInfo(LayoutResourceKind::Uniform, 8, 8);
+        case BaseType::BFloat16:
+            return SimpleLayoutInfo(LayoutResourceKind::Uniform, 4, 4);
 
         default:
             SLANG_UNEXPECTED("uhandled scalar type");

--- a/source/slang/slang-type-system-shared.h
+++ b/source/slang/slang-type-system-shared.h
@@ -22,6 +22,7 @@ namespace Slang
     X(Char)                  \
     X(IntPtr)                \
     X(UIntPtr)               \
+    X(BFloat16)              \
     /* end */
 
 enum class BaseType

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -82,6 +82,7 @@ namespace Slang
      BaseTypeInfo::Flag::Signed | BaseTypeInfo::Flag::Integer,
      uint8_t(BaseType::IntPtr)},
     {uint8_t(sizeof(uintptr_t)), BaseTypeInfo::Flag::Integer, uint8_t(BaseType::UIntPtr)},
+    {uint8_t(sizeof(uint16_t)), BaseTypeInfo::Flag::FloatingPoint, uint8_t(BaseType::BFloat16)},
 };
 
 /* static */ bool BaseTypeInfo::check()
@@ -133,6 +134,8 @@ namespace Slang
         return UnownedStringSlice::fromLiteral("intptr_t");
     case BaseType::UIntPtr:
         return UnownedStringSlice::fromLiteral("uintptr_t");
+    case BaseType::BFloat16:
+        return UnownedStringSlice::fromLiteral("bfloat16");
     default:
         {
             SLANG_ASSERT(!"Unknown basic type");
@@ -3194,7 +3197,8 @@ static void _calcViewInitiatingHierarchy(
     for (auto& [_, value] : outHierarchy)
     {
         value.sort(
-            [](SourceView* a, SourceView* b) -> bool {
+            [](SourceView* a, SourceView* b) -> bool
+            {
                 return a->getInitiatingSourceLoc().getRaw() < b->getInitiatingSourceLoc().getRaw();
             });
     }


### PR DESCRIPTION
Related to #7077.

Adds support for [SPV_KHR_bfloat16](https://github.khronos.org/SPIRV-Registry/extensions/KHR/SPV_KHR_bfloat16.html).
`bfloat16` use is limited to only cooperative matrices and dot products, arithmetic operations cannot be performed directly.  This limitation also applies to CUDA. 

This PR adds initial support for properly emitting the type and supporting dot operations. Coop matrix support will be added at a later time, after CM2 support is merged.. Also see implementation details section below for current issues adding `bfloat16` to `CoopMat`.

### Draft task List

- [x] Support type and dot ops for SPIRV
- [ ] Emit type for other targets?
- [ ]  Add tests
- [ ] Agree on implementation details

### Implementation details
Because `bfloat16` does not support arithmetic operations, the builtin type does not implement `__BuiltinArithmeticType`(and hence also does not implement `__BuiltinFloatingPointType`). The only issue here is that the currently `CoopMat`'s  element type argument requires `__BuiltinArithmeticType`. `__BuiltinArithmeticType` is used here as  a type-checking mechanism and there is nothing inherently required by the  `__BuiltinArithmeticType` interface for the element type as all operations are performed to the coop mat type itself, at least when targetting SPIRV. 

The only real use-case for the element type being an arithmetic is to implement the `IComparable` interface as `CoopMat` implements `IArithmetic` - an effort to separate `IComparable` from `IArithmetic` is tracked here https://github.com/shader-slang/slang/issues/6966.  IMO the cleanest solution is to have `CoopMat` drop the requirement for its element type to be `__BuiltinArithmeticType` so that `bfloat16` can be used as an element type, although this may pose some (engineering) difficulties if we ever plan to manually support other targets for cooperative matrices.

The other option is to fully "implement" `__BuiltinArithmeticType` for `bfloat16` and just error out when the arithmetic ops are actually used but this is not ideal. Any other ideas are welcome.