### PR TITLE
Add Payload Access Qualifiers to the raytracing examples

### DIFF
--- a/examples/ray-tracing-pipeline/shaders.slang
+++ b/examples/ray-tracing-pipeline/shaders.slang
@@ -19,9 +19,9 @@ struct Primitive
     float3 getColor() { return color.xyz; }
 };
 
-struct RayPayload
+struct [raypayload] RayPayload
 {
-    float4 color;
+    float4 color : read(caller) : write(caller, closesthit, miss);
 };
 
 uniform RWTexture2D resultTexture;
@@ -104,5 +104,5 @@ float4 fragmentMain(
     uniform RWTexture2D t)
     : SV_Target
 {
-    return t.Load(sv_position.xy);
+    return t.Load(uint2(sv_position.xy));
 }

--- a/examples/ray-tracing/shaders.slang
+++ b/examples/ray-tracing/shaders.slang
@@ -49,6 +49,8 @@ bool traceRayFirstHit(
         primitiveIndex = q.CommittedPrimitiveIndex();
         return true;
     }
+    primitiveIndex = q.CandidatePrimitiveIndex();
+    unused(t);
     return false;
 }
 
@@ -80,6 +82,8 @@ bool traceRayNearestHit(
         primitiveIndex = q.CommittedPrimitiveIndex();
         return true;
     }
+    primitiveIndex = q.CandidatePrimitiveIndex();
+    unused(t);
     return false;
 }
 
@@ -103,7 +107,7 @@ void computeMain(
 
     float4 resultColor = 0;
 
-    int primitiveIndex;
+    int primitiveIndex = 0;
     float intersectionT;
     if (traceRayNearestHit(sceneBVH, uniforms.cameraPosition.xyz, rayDir, intersectionT, primitiveIndex))
     {
@@ -140,5 +144,5 @@ float4 fragmentMain(
     uniform RWTexture2D t)
     : SV_Target
 {
-    return t.Load(sv_position.xy);
+    return t.Load(uint2(sv_position.xy));
 }


### PR DESCRIPTION
This changes added Payload Access Qualifiers to fix the DXC error
```
[Slang]: ERROR: dxc 1.9: ../../examples/ray-tracing-pipeline/shaders.slang(24): error : payload field 'color_0' has no payload access qualifiers.
```

Also addresses some warnings.

Fixes: #7089