### PR TITLE
Fix slangc path used by cmdline reference doc regeneration action

### DIFF
--- a/.github/workflows/check-cmdline-ref.yml
+++ b/.github/workflows/check-cmdline-ref.yml
@@ -31,7 +31,13 @@ jobs:
       - name: Build Slang
         run: |
           cmake --preset default --fresh \
-            -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
+            -DSLANG_SLANG_LLVM_FLAVOR=DISABLE \
+            -DSLANG_ENABLE_TESTS=OFF \
+            -DSLANG_ENABLE_EXAMPLES=OFF \
+            -DSLANG_ENABLE_GFX=OFF \
+            -DSLANG_ENABLE_SLANGD=OFF \
+            -DSLANG_EXCLUDE_DAWN=ON \
+            -DSLANG_EXCLUDE_TINT=ON
           cmake --workflow --preset release
 
       - name: Generate command line reference

--- a/.github/workflows/regenerate-cmdline-ref.yml
+++ b/.github/workflows/regenerate-cmdline-ref.yml
@@ -43,7 +43,13 @@ jobs:
         run: |
           cd pr-branch
           cmake --preset default --fresh \
-            -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
+            -DSLANG_SLANG_LLVM_FLAVOR=DISABLE \
+            -DSLANG_ENABLE_TESTS=OFF \
+            -DSLANG_ENABLE_EXAMPLES=OFF \
+            -DSLANG_ENABLE_GFX=OFF \
+            -DSLANG_ENABLE_SLANGD=OFF \
+            -DSLANG_EXCLUDE_DAWN=ON \
+            -DSLANG_EXCLUDE_TINT=ON
           cmake --workflow --preset release
 
       - name: Regenerate Command Line Reference

--- a/.github/workflows/regenerate-cmdline-ref.yml
+++ b/.github/workflows/regenerate-cmdline-ref.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           cd pr-branch
           mkdir -p docs
-          "$bin_dir/slangc" -help-style markdown -h > docs/command-line-slangc-reference.md 2>&1
+          ./build/${{ env.cmake_config }}/bin/slangc -help-style markdown -h > docs/command-line-slangc-reference.md 2>&1
 
       - name: Configure Git commit signing
         id: git-info


### PR DESCRIPTION
This change uses a different path for accessing the slangc binary during the command line reference doc regeneration action, as the environment variable referenced for the bin directory may not be accurate.

This change also makes some exclusions from the slang build in the command line reference actions, to speed up those builds for checking/regenerating.