### PR TITLE
Unify Debug Layer Control Logic and Add Disable Option for Debug Builds

### DIFF
--- a/examples/example-base/example-base.cpp
+++ b/examples/example-base/example-base.cpp
@@ -21,7 +21,7 @@ Slang::Result WindowedAppBase::initializeBase(
     // Initialize the rendering layer.
 #ifdef _DEBUG
     // Enable debug layer in debug config.
-    gfxSetDebugLayerEnabled(true);
+    gfxEnableDebugLayer(true);
 #endif
     IDevice::Desc deviceDesc = {};
     deviceDesc.deviceType = deviceType;

--- a/examples/example-base/example-base.cpp
+++ b/examples/example-base/example-base.cpp
@@ -21,7 +21,7 @@ Slang::Result WindowedAppBase::initializeBase(
     // Initialize the rendering layer.
 #ifdef _DEBUG
     // Enable debug layer in debug config.
-    gfxEnableDebugLayer();
+    gfxSetDebugLayerEnabled(true);
 #endif
     IDevice::Desc deviceDesc = {};
     deviceDesc.deviceType = deviceType;

--- a/examples/reflection-parameter-blocks/main.cpp
+++ b/examples/reflection-parameter-blocks/main.cpp
@@ -580,7 +580,7 @@ struct ReflectionParameterBlocksExampleApp : public TestBase
         // Vulkan device up and running.
 
 #ifdef _DEBUG
-        gfx::gfxEnableDebugLayer();
+        gfx::gfxSetDebugLayerEnabled(true);
 #endif
         gfx::IDevice::Desc deviceDesc = {};
         deviceDesc.deviceType = gfx::DeviceType::Vulkan;

--- a/examples/reflection-parameter-blocks/main.cpp
+++ b/examples/reflection-parameter-blocks/main.cpp
@@ -580,7 +580,7 @@ struct ReflectionParameterBlocksExampleApp : public TestBase
         // Vulkan device up and running.
 
 #ifdef _DEBUG
-        gfx::gfxSetDebugLayerEnabled(true);
+        gfx::gfxEnableDebugLayer(true);
 #endif
         gfx::IDevice::Desc deviceDesc = {};
         deviceDesc.deviceType = gfx::DeviceType::Vulkan;

--- a/include/slang-gfx.h
+++ b/include/slang-gfx.h
@@ -207,8 +207,13 @@ public:
 
     virtual SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL findTypeByName(const char* name) = 0;
 };
-#define SLANG_UUID_IShaderProgram \
-    {0x9d32d0ad, 0x915c, 0x4ffd, {0x91, 0xe2, 0x50, 0x85, 0x54, 0xa0, 0x4a, 0x76}}
+#define SLANG_UUID_IShaderProgram                          \
+    {                                                      \
+        0x9d32d0ad, 0x915c, 0x4ffd,                        \
+        {                                                  \
+            0x91, 0xe2, 0x50, 0x85, 0x54, 0xa0, 0x4a, 0x76 \
+        }                                                  \
+    }
 
 // TODO: Confirm with Yong that we really want this naming convention
 // TODO: Rename to what?
@@ -606,8 +611,13 @@ public:
         GfxCount vertexStreamCount = 0;
     };
 };
-#define SLANG_UUID_IInputLayout \
-    {0x45223711, 0xa84b, 0x455c, {0xbe, 0xfa, 0x49, 0x37, 0x42, 0x1e, 0x8e, 0x2e}}
+#define SLANG_UUID_IInputLayout                            \
+    {                                                      \
+        0x45223711, 0xa84b, 0x455c,                        \
+        {                                                  \
+            0xbe, 0xfa, 0x49, 0x37, 0x42, 0x1e, 0x8e, 0x2e \
+        }                                                  \
+    }
 
 class IResource : public ISlangUnknown
 {
@@ -644,8 +654,13 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL setDebugName(const char* name) = 0;
     virtual SLANG_NO_THROW const char* SLANG_MCALL getDebugName() = 0;
 };
-#define SLANG_UUID_IResource \
-    {0xa0e39f34, 0x8398, 0x4522, {0x95, 0xc2, 0xeb, 0xc0, 0xf9, 0x84, 0xef, 0x3f}}
+#define SLANG_UUID_IResource                               \
+    {                                                      \
+        0xa0e39f34, 0x8398, 0x4522,                        \
+        {                                                  \
+            0x95, 0xc2, 0xeb, 0xc0, 0xf9, 0x84, 0xef, 0x3f \
+        }                                                  \
+    }
 
 struct MemoryRange
 {
@@ -669,8 +684,13 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL map(MemoryRange* rangeToRead, void** outPointer) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL unmap(MemoryRange* writtenRange) = 0;
 };
-#define SLANG_UUID_IBufferResource \
-    {0x1b274efe, 0x5e37, 0x492b, {0x82, 0x6e, 0x7e, 0xe7, 0xe8, 0xf5, 0xa4, 0x9b}}
+#define SLANG_UUID_IBufferResource                         \
+    {                                                      \
+        0x1b274efe, 0x5e37, 0x492b,                        \
+        {                                                  \
+            0x82, 0x6e, 0x7e, 0xe7, 0xe8, 0xf5, 0xa4, 0x9b \
+        }                                                  \
+    }
 
 struct DepthStencilClearValue
 {
@@ -805,8 +825,13 @@ public:
 
     virtual SLANG_NO_THROW Desc* SLANG_MCALL getDesc() = 0;
 };
-#define SLANG_UUID_ITextureResource \
-    {0xcf88a31c, 0x6187, 0x46c5, {0xa4, 0xb7, 0xeb, 0x58, 0xc7, 0x33, 0x40, 0x17}}
+#define SLANG_UUID_ITextureResource                        \
+    {                                                      \
+        0xcf88a31c, 0x6187, 0x46c5,                        \
+        {                                                  \
+            0xa4, 0xb7, 0xeb, 0x58, 0xc7, 0x33, 0x40, 0x17 \
+        }                                                  \
+    }
 
 
 enum class ComparisonFunc : uint8_t
@@ -869,8 +894,13 @@ public:
     /// When using Vulkan, this will be a VkSampler.
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(InteropHandle* outNativeHandle) = 0;
 };
-#define SLANG_UUID_ISamplerState \
-    {0x8b8055df, 0x9377, 0x401d, {0x91, 0xff, 0x3f, 0xa3, 0xbf, 0x66, 0x64, 0xf4}}
+#define SLANG_UUID_ISamplerState                           \
+    {                                                      \
+        0x8b8055df, 0x9377, 0x401d,                        \
+        {                                                  \
+            0x91, 0xff, 0x3f, 0xa3, 0xbf, 0x66, 0x64, 0xf4 \
+        }                                                  \
+    }
 
 class IResourceView : public ISlangUnknown
 {
@@ -916,8 +946,13 @@ public:
     /// view.
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(InteropHandle* outNativeHandle) = 0;
 };
-#define SLANG_UUID_IResourceView \
-    {0x7b6c4926, 0x884, 0x408c, {0xad, 0x8a, 0x50, 0x3a, 0x8e, 0x23, 0x98, 0xa4}}
+#define SLANG_UUID_IResourceView                           \
+    {                                                      \
+        0x7b6c4926, 0x884, 0x408c,                         \
+        {                                                  \
+            0xad, 0x8a, 0x50, 0x3a, 0x8e, 0x23, 0x98, 0xa4 \
+        }                                                  \
+    }
 
 class IAccelerationStructure : public IResourceView
 {
@@ -1076,8 +1111,13 @@ public:
 
     virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() = 0;
 };
-#define SLANG_UUID_IAccelerationStructure \
-    {0xa5cdda3c, 0x1d4e, 0x4df7, {0x8e, 0xf2, 0xb7, 0x3f, 0xce, 0x4, 0xde, 0x3b}}
+#define SLANG_UUID_IAccelerationStructure                 \
+    {                                                     \
+        0xa5cdda3c, 0x1d4e, 0x4df7,                       \
+        {                                                 \
+            0x8e, 0xf2, 0xb7, 0x3f, 0xce, 0x4, 0xde, 0x3b \
+        }                                                 \
+    }
 
 class IFence : public ISlangUnknown
 {
@@ -1097,8 +1137,13 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL getSharedHandle(InteropHandle* outHandle) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(InteropHandle* outNativeHandle) = 0;
 };
-#define SLANG_UUID_IFence \
-    {0x7fe1c283, 0xd3f4, 0x48ed, {0xaa, 0xf3, 0x1, 0x51, 0x96, 0x4e, 0x7c, 0xb5}}
+#define SLANG_UUID_IFence                                 \
+    {                                                     \
+        0x7fe1c283, 0xd3f4, 0x48ed,                       \
+        {                                                 \
+            0xaa, 0xf3, 0x1, 0x51, 0x96, 0x4e, 0x7c, 0xb5 \
+        }                                                 \
+    }
 
 struct ShaderOffset
 {
@@ -1196,8 +1241,13 @@ public:
         return entryPoint;
     }
 };
-#define SLANG_UUID_IShaderObject \
-    {0xc1fa997e, 0x5ca2, 0x45ae, {0x9b, 0xcb, 0xc4, 0x35, 0x9e, 0x85, 0x5, 0x85}}
+#define SLANG_UUID_IShaderObject                          \
+    {                                                     \
+        0xc1fa997e, 0x5ca2, 0x45ae,                       \
+        {                                                 \
+            0x9b, 0xcb, 0xc4, 0x35, 0x9e, 0x85, 0x5, 0x85 \
+        }                                                 \
+    }
 
 enum class StencilOp : uint8_t
 {
@@ -1358,8 +1408,13 @@ public:
         TargetLayout* depthStencil = nullptr;
     };
 };
-#define SLANG_UUID_IFramebufferLayout \
-    {0xa838785, 0xc13a, 0x4832, {0xad, 0x88, 0x64, 0x6, 0xb5, 0x4b, 0x5e, 0xba}}
+#define SLANG_UUID_IFramebufferLayout                     \
+    {                                                     \
+        0xa838785, 0xc13a, 0x4832,                        \
+        {                                                 \
+            0xad, 0x88, 0x64, 0x6, 0xb5, 0x4b, 0x5e, 0xba \
+        }                                                 \
+    }
 
 struct GraphicsPipelineStateDesc
 {
@@ -1440,16 +1495,26 @@ public:
         IShaderProgram* program;
     };
 };
-#define SLANG_UUID_IShaderTable \
-    {0xa721522c, 0xdf31, 0x4c2f, {0xa5, 0xe7, 0x3b, 0xe0, 0x12, 0x4b, 0x31, 0x78}}
+#define SLANG_UUID_IShaderTable                            \
+    {                                                      \
+        0xa721522c, 0xdf31, 0x4c2f,                        \
+        {                                                  \
+            0xa5, 0xe7, 0x3b, 0xe0, 0x12, 0x4b, 0x31, 0x78 \
+        }                                                  \
+    }
 
 class IPipelineState : public ISlangUnknown
 {
 public:
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(InteropHandle* outHandle) = 0;
 };
-#define SLANG_UUID_IPipelineState \
-    {0xca7e57d, 0x8a90, 0x44f3, {0xbd, 0xb1, 0xfe, 0x9b, 0x35, 0x3f, 0x5a, 0x72}}
+#define SLANG_UUID_IPipelineState                          \
+    {                                                      \
+        0xca7e57d, 0x8a90, 0x44f3,                         \
+        {                                                  \
+            0xbd, 0xb1, 0xfe, 0x9b, 0x35, 0x3f, 0x5a, 0x72 \
+        }                                                  \
+    }
 
 
 struct ScissorRect
@@ -1481,8 +1546,13 @@ public:
         IFramebufferLayout* layout;
     };
 };
-#define SLANG_UUID_IFrameBuffer \
-    {0xf0c0d9a, 0x4ef3, 0x4e18, {0x9b, 0xa9, 0x34, 0x60, 0xea, 0x69, 0x87, 0x95}}
+#define SLANG_UUID_IFrameBuffer                            \
+    {                                                      \
+        0xf0c0d9a, 0x4ef3, 0x4e18,                         \
+        {                                                  \
+            0x9b, 0xa9, 0x34, 0x60, 0xea, 0x69, 0x87, 0x95 \
+        }                                                  \
+    }
 
 struct WindowHandle
 {
@@ -1559,8 +1629,13 @@ public:
         TargetAccessDesc* depthStencilAccess = nullptr;
     };
 };
-#define SLANG_UUID_IRenderPassLayout \
-    {0xdaab0b1a, 0xf45d, 0x4ae9, {0xbf, 0x2c, 0xe0, 0xbb, 0x76, 0x7d, 0xfa, 0xd1}}
+#define SLANG_UUID_IRenderPassLayout                       \
+    {                                                      \
+        0xdaab0b1a, 0xf45d, 0x4ae9,                        \
+        {                                                  \
+            0xbf, 0x2c, 0xe0, 0xbb, 0x76, 0x7d, 0xfa, 0xd1 \
+        }                                                  \
+    }
 
 enum class QueryType
 {
@@ -1584,8 +1659,13 @@ public:
     getResult(GfxIndex queryIndex, GfxCount count, uint64_t* data) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL reset() = 0;
 };
-#define SLANG_UUID_IQueryPool \
-    {0xc2cc3784, 0x12da, 0x480a, {0xa8, 0x74, 0x8b, 0x31, 0x96, 0x1c, 0xa4, 0x36}}
+#define SLANG_UUID_IQueryPool                              \
+    {                                                      \
+        0xc2cc3784, 0x12da, 0x480a,                        \
+        {                                                  \
+            0xa8, 0x74, 0x8b, 0x31, 0x96, 0x1c, 0xa4, 0x36 \
+        }                                                  \
+    }
 
 
 class ICommandEncoder : public ISlangUnknown
@@ -2000,8 +2080,13 @@ public:
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(InteropHandle* outHandle) = 0;
 };
-#define SLANG_UUID_ICommandBuffer \
-    {0x5d56063f, 0x91d4, 0x4723, {0xa7, 0xa7, 0x7a, 0x15, 0xaf, 0x93, 0xeb, 0x48}}
+#define SLANG_UUID_ICommandBuffer                          \
+    {                                                      \
+        0x5d56063f, 0x91d4, 0x4723,                        \
+        {                                                  \
+            0xa7, 0xa7, 0x7a, 0x15, 0xaf, 0x93, 0xeb, 0x48 \
+        }                                                  \
+    }
 
 class ICommandBufferD3D12 : public ICommandBuffer
 {
@@ -2009,8 +2094,13 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL invalidateDescriptorHeapBinding() = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL ensureInternalDescriptorHeapsBound() = 0;
 };
-#define SLANG_UUID_ICommandBufferD3D12 \
-    {0xd56b7616, 0x6c14, 0x4841, {0x9d, 0x9c, 0x7b, 0x7f, 0xdb, 0x9f, 0xd9, 0xb8}}
+#define SLANG_UUID_ICommandBufferD3D12                     \
+    {                                                      \
+        0xd56b7616, 0x6c14, 0x4841,                        \
+        {                                                  \
+            0x9d, 0x9c, 0x7b, 0x7f, 0xdb, 0x9f, 0xd9, 0xb8 \
+        }                                                  \
+    }
 
 class ICommandQueue : public ISlangUnknown
 {
@@ -2050,8 +2140,13 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
     waitForFenceValuesOnDevice(GfxCount fenceCount, IFence** fences, uint64_t* waitValues) = 0;
 };
-#define SLANG_UUID_ICommandQueue \
-    {0x14e2bed0, 0xad0, 0x4dc8, {0xb3, 0x41, 0x6, 0x3f, 0xe7, 0x2d, 0xbf, 0xe}}
+#define SLANG_UUID_ICommandQueue                         \
+    {                                                    \
+        0x14e2bed0, 0xad0, 0x4dc8,                       \
+        {                                                \
+            0xb3, 0x41, 0x6, 0x3f, 0xe7, 0x2d, 0xbf, 0xe \
+        }                                                \
+    }
 
 class ITransientResourceHeap : public ISlangUnknown
 {
@@ -2099,8 +2194,13 @@ public:
         return result;
     }
 };
-#define SLANG_UUID_ITransientResourceHeap \
-    {0xcd48bd29, 0xee72, 0x41b8, {0xbc, 0xff, 0xa, 0x2b, 0x3a, 0xaa, 0x6d, 0xeb}}
+#define SLANG_UUID_ITransientResourceHeap                 \
+    {                                                     \
+        0xcd48bd29, 0xee72, 0x41b8,                       \
+        {                                                 \
+            0xbc, 0xff, 0xa, 0x2b, 0x3a, 0xaa, 0x6d, 0xeb \
+        }                                                 \
+    }
 
 class ITransientResourceHeapD3D12 : public ISlangUnknown
 {
@@ -2116,8 +2216,13 @@ public:
         Offset& outDescriptorOffset,
         void** outD3DDescriptorHeapHandle) = 0;
 };
-#define SLANG_UUID_ITransientResourceHeapD3D12 \
-    {0x9bc6a8bc, 0x5f7a, 0x454a, {0x93, 0xef, 0x3b, 0x10, 0x5b, 0xb7, 0x63, 0x7e}}
+#define SLANG_UUID_ITransientResourceHeapD3D12             \
+    {                                                      \
+        0x9bc6a8bc, 0x5f7a, 0x454a,                        \
+        {                                                  \
+            0x93, 0xef, 0x3b, 0x10, 0x5b, 0xb7, 0x63, 0x7e \
+        }                                                  \
+    }
 
 class ISwapchain : public ISlangUnknown
 {
@@ -2153,8 +2258,13 @@ public:
     // Toggle full screen mode.
     virtual SLANG_NO_THROW Result SLANG_MCALL setFullScreenMode(bool mode) = 0;
 };
-#define SLANG_UUID_ISwapchain \
-    {0xbe91ba6c, 0x784, 0x4308, {0xa1, 0x0, 0x19, 0xc3, 0x66, 0x83, 0x44, 0xb2}}
+#define SLANG_UUID_ISwapchain                             \
+    {                                                     \
+        0xbe91ba6c, 0x784, 0x4308,                        \
+        {                                                 \
+            0xa1, 0x0, 0x19, 0xc3, 0x66, 0x83, 0x44, 0xb2 \
+        }                                                 \
+    }
 
 struct AdapterLUID
 {
@@ -2717,8 +2827,13 @@ public:
         IShaderObject** outObject) = 0;
 };
 
-#define SLANG_UUID_IDevice \
-    {0x715bdf26, 0x5135, 0x11eb, {0xAE, 0x93, 0x02, 0x42, 0xAC, 0x13, 0x00, 0x02}}
+#define SLANG_UUID_IDevice                                 \
+    {                                                      \
+        0x715bdf26, 0x5135, 0x11eb,                        \
+        {                                                  \
+            0xAE, 0x93, 0x02, 0x42, 0xAC, 0x13, 0x00, 0x02 \
+        }                                                  \
+    }
 
 struct ShaderCacheStats
 {
@@ -2739,8 +2854,13 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL resetShaderCacheStats() = 0;
 };
 
-#define SLANG_UUID_IShaderCache \
-    {0x8eccc8ec, 0x5c04, 0x4a51, {0x99, 0x75, 0x13, 0xf8, 0xfe, 0xa1, 0x59, 0xf3}}
+#define SLANG_UUID_IShaderCache                            \
+    {                                                      \
+        0x8eccc8ec, 0x5c04, 0x4a51,                        \
+        {                                                  \
+            0x99, 0x75, 0x13, 0xf8, 0xfe, 0xa1, 0x59, 0xf3 \
+        }                                                  \
+    }
 
 class IPipelineCreationAPIDispatcher : public ISlangUnknown
 {
@@ -2765,11 +2885,21 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
     afterCreateRayTracingState(IDevice* device, slang::IComponentType* program) = 0;
 };
-#define SLANG_UUID_IPipelineCreationAPIDispatcher \
-    {0xc3d5f782, 0xeae1, 0x4da6, {0xab, 0x40, 0x75, 0x32, 0x31, 0x2, 0xb7, 0xdc}}
+#define SLANG_UUID_IPipelineCreationAPIDispatcher         \
+    {                                                     \
+        0xc3d5f782, 0xeae1, 0x4da6,                       \
+        {                                                 \
+            0xab, 0x40, 0x75, 0x32, 0x31, 0x2, 0xb7, 0xdc \
+        }                                                 \
+    }
 
-#define SLANG_UUID_IVulkanPipelineCreationAPIDispatcher \
-    {0x4fcf1274, 0x8752, 0x4743, {0xb3, 0x51, 0x47, 0xcb, 0x83, 0x71, 0xef, 0x99}}
+#define SLANG_UUID_IVulkanPipelineCreationAPIDispatcher    \
+    {                                                      \
+        0x4fcf1274, 0x8752, 0x4743,                        \
+        {                                                  \
+            0xb3, 0x51, 0x47, 0xcb, 0x83, 0x71, 0xef, 0x99 \
+        }                                                  \
+    }
 
 // Global public functions
 

--- a/include/slang-gfx.h
+++ b/include/slang-gfx.h
@@ -2933,7 +2933,7 @@ extern "C"
 
     /// Enables debug layer. The debug layer will check all `gfx` calls and verify that uses are
     /// valid.
-    SLANG_GFX_API void SLANG_MCALL gfxSetDebugLayerEnabled(bool enable);
+    SLANG_GFX_API void SLANG_MCALL gfxEnableDebugLayer(bool enable);
 
     SLANG_GFX_API const char* SLANG_MCALL gfxGetDeviceTypeName(DeviceType type);
 }

--- a/include/slang-gfx.h
+++ b/include/slang-gfx.h
@@ -2933,7 +2933,7 @@ extern "C"
 
     /// Enables debug layer. The debug layer will check all `gfx` calls and verify that uses are
     /// valid.
-    SLANG_GFX_API void SLANG_MCALL gfxEnableDebugLayer();
+    SLANG_GFX_API void SLANG_MCALL gfxSetDebugLayerEnabled(bool enable);
 
     SLANG_GFX_API const char* SLANG_MCALL gfxGetDeviceTypeName(DeviceType type);
 }

--- a/include/slang-gfx.h
+++ b/include/slang-gfx.h
@@ -207,13 +207,8 @@ public:
 
     virtual SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL findTypeByName(const char* name) = 0;
 };
-#define SLANG_UUID_IShaderProgram                          \
-    {                                                      \
-        0x9d32d0ad, 0x915c, 0x4ffd,                        \
-        {                                                  \
-            0x91, 0xe2, 0x50, 0x85, 0x54, 0xa0, 0x4a, 0x76 \
-        }                                                  \
-    }
+#define SLANG_UUID_IShaderProgram \
+    {0x9d32d0ad, 0x915c, 0x4ffd, {0x91, 0xe2, 0x50, 0x85, 0x54, 0xa0, 0x4a, 0x76}}
 
 // TODO: Confirm with Yong that we really want this naming convention
 // TODO: Rename to what?
@@ -611,13 +606,8 @@ public:
         GfxCount vertexStreamCount = 0;
     };
 };
-#define SLANG_UUID_IInputLayout                            \
-    {                                                      \
-        0x45223711, 0xa84b, 0x455c,                        \
-        {                                                  \
-            0xbe, 0xfa, 0x49, 0x37, 0x42, 0x1e, 0x8e, 0x2e \
-        }                                                  \
-    }
+#define SLANG_UUID_IInputLayout \
+    {0x45223711, 0xa84b, 0x455c, {0xbe, 0xfa, 0x49, 0x37, 0x42, 0x1e, 0x8e, 0x2e}}
 
 class IResource : public ISlangUnknown
 {
@@ -654,13 +644,8 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL setDebugName(const char* name) = 0;
     virtual SLANG_NO_THROW const char* SLANG_MCALL getDebugName() = 0;
 };
-#define SLANG_UUID_IResource                               \
-    {                                                      \
-        0xa0e39f34, 0x8398, 0x4522,                        \
-        {                                                  \
-            0x95, 0xc2, 0xeb, 0xc0, 0xf9, 0x84, 0xef, 0x3f \
-        }                                                  \
-    }
+#define SLANG_UUID_IResource \
+    {0xa0e39f34, 0x8398, 0x4522, {0x95, 0xc2, 0xeb, 0xc0, 0xf9, 0x84, 0xef, 0x3f}}
 
 struct MemoryRange
 {
@@ -684,13 +669,8 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL map(MemoryRange* rangeToRead, void** outPointer) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL unmap(MemoryRange* writtenRange) = 0;
 };
-#define SLANG_UUID_IBufferResource                         \
-    {                                                      \
-        0x1b274efe, 0x5e37, 0x492b,                        \
-        {                                                  \
-            0x82, 0x6e, 0x7e, 0xe7, 0xe8, 0xf5, 0xa4, 0x9b \
-        }                                                  \
-    }
+#define SLANG_UUID_IBufferResource \
+    {0x1b274efe, 0x5e37, 0x492b, {0x82, 0x6e, 0x7e, 0xe7, 0xe8, 0xf5, 0xa4, 0x9b}}
 
 struct DepthStencilClearValue
 {
@@ -825,13 +805,8 @@ public:
 
     virtual SLANG_NO_THROW Desc* SLANG_MCALL getDesc() = 0;
 };
-#define SLANG_UUID_ITextureResource                        \
-    {                                                      \
-        0xcf88a31c, 0x6187, 0x46c5,                        \
-        {                                                  \
-            0xa4, 0xb7, 0xeb, 0x58, 0xc7, 0x33, 0x40, 0x17 \
-        }                                                  \
-    }
+#define SLANG_UUID_ITextureResource \
+    {0xcf88a31c, 0x6187, 0x46c5, {0xa4, 0xb7, 0xeb, 0x58, 0xc7, 0x33, 0x40, 0x17}}
 
 
 enum class ComparisonFunc : uint8_t
@@ -894,13 +869,8 @@ public:
     /// When using Vulkan, this will be a VkSampler.
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(InteropHandle* outNativeHandle) = 0;
 };
-#define SLANG_UUID_ISamplerState                           \
-    {                                                      \
-        0x8b8055df, 0x9377, 0x401d,                        \
-        {                                                  \
-            0x91, 0xff, 0x3f, 0xa3, 0xbf, 0x66, 0x64, 0xf4 \
-        }                                                  \
-    }
+#define SLANG_UUID_ISamplerState \
+    {0x8b8055df, 0x9377, 0x401d, {0x91, 0xff, 0x3f, 0xa3, 0xbf, 0x66, 0x64, 0xf4}}
 
 class IResourceView : public ISlangUnknown
 {
@@ -946,13 +916,8 @@ public:
     /// view.
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(InteropHandle* outNativeHandle) = 0;
 };
-#define SLANG_UUID_IResourceView                           \
-    {                                                      \
-        0x7b6c4926, 0x884, 0x408c,                         \
-        {                                                  \
-            0xad, 0x8a, 0x50, 0x3a, 0x8e, 0x23, 0x98, 0xa4 \
-        }                                                  \
-    }
+#define SLANG_UUID_IResourceView \
+    {0x7b6c4926, 0x884, 0x408c, {0xad, 0x8a, 0x50, 0x3a, 0x8e, 0x23, 0x98, 0xa4}}
 
 class IAccelerationStructure : public IResourceView
 {
@@ -1111,13 +1076,8 @@ public:
 
     virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() = 0;
 };
-#define SLANG_UUID_IAccelerationStructure                 \
-    {                                                     \
-        0xa5cdda3c, 0x1d4e, 0x4df7,                       \
-        {                                                 \
-            0x8e, 0xf2, 0xb7, 0x3f, 0xce, 0x4, 0xde, 0x3b \
-        }                                                 \
-    }
+#define SLANG_UUID_IAccelerationStructure \
+    {0xa5cdda3c, 0x1d4e, 0x4df7, {0x8e, 0xf2, 0xb7, 0x3f, 0xce, 0x4, 0xde, 0x3b}}
 
 class IFence : public ISlangUnknown
 {
@@ -1137,13 +1097,8 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL getSharedHandle(InteropHandle* outHandle) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(InteropHandle* outNativeHandle) = 0;
 };
-#define SLANG_UUID_IFence                                 \
-    {                                                     \
-        0x7fe1c283, 0xd3f4, 0x48ed,                       \
-        {                                                 \
-            0xaa, 0xf3, 0x1, 0x51, 0x96, 0x4e, 0x7c, 0xb5 \
-        }                                                 \
-    }
+#define SLANG_UUID_IFence \
+    {0x7fe1c283, 0xd3f4, 0x48ed, {0xaa, 0xf3, 0x1, 0x51, 0x96, 0x4e, 0x7c, 0xb5}}
 
 struct ShaderOffset
 {
@@ -1241,13 +1196,8 @@ public:
         return entryPoint;
     }
 };
-#define SLANG_UUID_IShaderObject                          \
-    {                                                     \
-        0xc1fa997e, 0x5ca2, 0x45ae,                       \
-        {                                                 \
-            0x9b, 0xcb, 0xc4, 0x35, 0x9e, 0x85, 0x5, 0x85 \
-        }                                                 \
-    }
+#define SLANG_UUID_IShaderObject \
+    {0xc1fa997e, 0x5ca2, 0x45ae, {0x9b, 0xcb, 0xc4, 0x35, 0x9e, 0x85, 0x5, 0x85}}
 
 enum class StencilOp : uint8_t
 {
@@ -1408,13 +1358,8 @@ public:
         TargetLayout* depthStencil = nullptr;
     };
 };
-#define SLANG_UUID_IFramebufferLayout                     \
-    {                                                     \
-        0xa838785, 0xc13a, 0x4832,                        \
-        {                                                 \
-            0xad, 0x88, 0x64, 0x6, 0xb5, 0x4b, 0x5e, 0xba \
-        }                                                 \
-    }
+#define SLANG_UUID_IFramebufferLayout \
+    {0xa838785, 0xc13a, 0x4832, {0xad, 0x88, 0x64, 0x6, 0xb5, 0x4b, 0x5e, 0xba}}
 
 struct GraphicsPipelineStateDesc
 {
@@ -1495,26 +1440,16 @@ public:
         IShaderProgram* program;
     };
 };
-#define SLANG_UUID_IShaderTable                            \
-    {                                                      \
-        0xa721522c, 0xdf31, 0x4c2f,                        \
-        {                                                  \
-            0xa5, 0xe7, 0x3b, 0xe0, 0x12, 0x4b, 0x31, 0x78 \
-        }                                                  \
-    }
+#define SLANG_UUID_IShaderTable \
+    {0xa721522c, 0xdf31, 0x4c2f, {0xa5, 0xe7, 0x3b, 0xe0, 0x12, 0x4b, 0x31, 0x78}}
 
 class IPipelineState : public ISlangUnknown
 {
 public:
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(InteropHandle* outHandle) = 0;
 };
-#define SLANG_UUID_IPipelineState                          \
-    {                                                      \
-        0xca7e57d, 0x8a90, 0x44f3,                         \
-        {                                                  \
-            0xbd, 0xb1, 0xfe, 0x9b, 0x35, 0x3f, 0x5a, 0x72 \
-        }                                                  \
-    }
+#define SLANG_UUID_IPipelineState \
+    {0xca7e57d, 0x8a90, 0x44f3, {0xbd, 0xb1, 0xfe, 0x9b, 0x35, 0x3f, 0x5a, 0x72}}
 
 
 struct ScissorRect
@@ -1546,13 +1481,8 @@ public:
         IFramebufferLayout* layout;
     };
 };
-#define SLANG_UUID_IFrameBuffer                            \
-    {                                                      \
-        0xf0c0d9a, 0x4ef3, 0x4e18,                         \
-        {                                                  \
-            0x9b, 0xa9, 0x34, 0x60, 0xea, 0x69, 0x87, 0x95 \
-        }                                                  \
-    }
+#define SLANG_UUID_IFrameBuffer \
+    {0xf0c0d9a, 0x4ef3, 0x4e18, {0x9b, 0xa9, 0x34, 0x60, 0xea, 0x69, 0x87, 0x95}}
 
 struct WindowHandle
 {
@@ -1629,13 +1559,8 @@ public:
         TargetAccessDesc* depthStencilAccess = nullptr;
     };
 };
-#define SLANG_UUID_IRenderPassLayout                       \
-    {                                                      \
-        0xdaab0b1a, 0xf45d, 0x4ae9,                        \
-        {                                                  \
-            0xbf, 0x2c, 0xe0, 0xbb, 0x76, 0x7d, 0xfa, 0xd1 \
-        }                                                  \
-    }
+#define SLANG_UUID_IRenderPassLayout \
+    {0xdaab0b1a, 0xf45d, 0x4ae9, {0xbf, 0x2c, 0xe0, 0xbb, 0x76, 0x7d, 0xfa, 0xd1}}
 
 enum class QueryType
 {
@@ -1659,13 +1584,8 @@ public:
     getResult(GfxIndex queryIndex, GfxCount count, uint64_t* data) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL reset() = 0;
 };
-#define SLANG_UUID_IQueryPool                              \
-    {                                                      \
-        0xc2cc3784, 0x12da, 0x480a,                        \
-        {                                                  \
-            0xa8, 0x74, 0x8b, 0x31, 0x96, 0x1c, 0xa4, 0x36 \
-        }                                                  \
-    }
+#define SLANG_UUID_IQueryPool \
+    {0xc2cc3784, 0x12da, 0x480a, {0xa8, 0x74, 0x8b, 0x31, 0x96, 0x1c, 0xa4, 0x36}}
 
 
 class ICommandEncoder : public ISlangUnknown
@@ -2080,13 +2000,8 @@ public:
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(InteropHandle* outHandle) = 0;
 };
-#define SLANG_UUID_ICommandBuffer                          \
-    {                                                      \
-        0x5d56063f, 0x91d4, 0x4723,                        \
-        {                                                  \
-            0xa7, 0xa7, 0x7a, 0x15, 0xaf, 0x93, 0xeb, 0x48 \
-        }                                                  \
-    }
+#define SLANG_UUID_ICommandBuffer \
+    {0x5d56063f, 0x91d4, 0x4723, {0xa7, 0xa7, 0x7a, 0x15, 0xaf, 0x93, 0xeb, 0x48}}
 
 class ICommandBufferD3D12 : public ICommandBuffer
 {
@@ -2094,13 +2009,8 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL invalidateDescriptorHeapBinding() = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL ensureInternalDescriptorHeapsBound() = 0;
 };
-#define SLANG_UUID_ICommandBufferD3D12                     \
-    {                                                      \
-        0xd56b7616, 0x6c14, 0x4841,                        \
-        {                                                  \
-            0x9d, 0x9c, 0x7b, 0x7f, 0xdb, 0x9f, 0xd9, 0xb8 \
-        }                                                  \
-    }
+#define SLANG_UUID_ICommandBufferD3D12 \
+    {0xd56b7616, 0x6c14, 0x4841, {0x9d, 0x9c, 0x7b, 0x7f, 0xdb, 0x9f, 0xd9, 0xb8}}
 
 class ICommandQueue : public ISlangUnknown
 {
@@ -2140,13 +2050,8 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
     waitForFenceValuesOnDevice(GfxCount fenceCount, IFence** fences, uint64_t* waitValues) = 0;
 };
-#define SLANG_UUID_ICommandQueue                         \
-    {                                                    \
-        0x14e2bed0, 0xad0, 0x4dc8,                       \
-        {                                                \
-            0xb3, 0x41, 0x6, 0x3f, 0xe7, 0x2d, 0xbf, 0xe \
-        }                                                \
-    }
+#define SLANG_UUID_ICommandQueue \
+    {0x14e2bed0, 0xad0, 0x4dc8, {0xb3, 0x41, 0x6, 0x3f, 0xe7, 0x2d, 0xbf, 0xe}}
 
 class ITransientResourceHeap : public ISlangUnknown
 {
@@ -2194,13 +2099,8 @@ public:
         return result;
     }
 };
-#define SLANG_UUID_ITransientResourceHeap                 \
-    {                                                     \
-        0xcd48bd29, 0xee72, 0x41b8,                       \
-        {                                                 \
-            0xbc, 0xff, 0xa, 0x2b, 0x3a, 0xaa, 0x6d, 0xeb \
-        }                                                 \
-    }
+#define SLANG_UUID_ITransientResourceHeap \
+    {0xcd48bd29, 0xee72, 0x41b8, {0xbc, 0xff, 0xa, 0x2b, 0x3a, 0xaa, 0x6d, 0xeb}}
 
 class ITransientResourceHeapD3D12 : public ISlangUnknown
 {
@@ -2216,13 +2116,8 @@ public:
         Offset& outDescriptorOffset,
         void** outD3DDescriptorHeapHandle) = 0;
 };
-#define SLANG_UUID_ITransientResourceHeapD3D12             \
-    {                                                      \
-        0x9bc6a8bc, 0x5f7a, 0x454a,                        \
-        {                                                  \
-            0x93, 0xef, 0x3b, 0x10, 0x5b, 0xb7, 0x63, 0x7e \
-        }                                                  \
-    }
+#define SLANG_UUID_ITransientResourceHeapD3D12 \
+    {0x9bc6a8bc, 0x5f7a, 0x454a, {0x93, 0xef, 0x3b, 0x10, 0x5b, 0xb7, 0x63, 0x7e}}
 
 class ISwapchain : public ISlangUnknown
 {
@@ -2258,13 +2153,8 @@ public:
     // Toggle full screen mode.
     virtual SLANG_NO_THROW Result SLANG_MCALL setFullScreenMode(bool mode) = 0;
 };
-#define SLANG_UUID_ISwapchain                             \
-    {                                                     \
-        0xbe91ba6c, 0x784, 0x4308,                        \
-        {                                                 \
-            0xa1, 0x0, 0x19, 0xc3, 0x66, 0x83, 0x44, 0xb2 \
-        }                                                 \
-    }
+#define SLANG_UUID_ISwapchain \
+    {0xbe91ba6c, 0x784, 0x4308, {0xa1, 0x0, 0x19, 0xc3, 0x66, 0x83, 0x44, 0xb2}}
 
 struct AdapterLUID
 {
@@ -2827,13 +2717,8 @@ public:
         IShaderObject** outObject) = 0;
 };
 
-#define SLANG_UUID_IDevice                                 \
-    {                                                      \
-        0x715bdf26, 0x5135, 0x11eb,                        \
-        {                                                  \
-            0xAE, 0x93, 0x02, 0x42, 0xAC, 0x13, 0x00, 0x02 \
-        }                                                  \
-    }
+#define SLANG_UUID_IDevice \
+    {0x715bdf26, 0x5135, 0x11eb, {0xAE, 0x93, 0x02, 0x42, 0xAC, 0x13, 0x00, 0x02}}
 
 struct ShaderCacheStats
 {
@@ -2854,13 +2739,8 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL resetShaderCacheStats() = 0;
 };
 
-#define SLANG_UUID_IShaderCache                            \
-    {                                                      \
-        0x8eccc8ec, 0x5c04, 0x4a51,                        \
-        {                                                  \
-            0x99, 0x75, 0x13, 0xf8, 0xfe, 0xa1, 0x59, 0xf3 \
-        }                                                  \
-    }
+#define SLANG_UUID_IShaderCache \
+    {0x8eccc8ec, 0x5c04, 0x4a51, {0x99, 0x75, 0x13, 0xf8, 0xfe, 0xa1, 0x59, 0xf3}}
 
 class IPipelineCreationAPIDispatcher : public ISlangUnknown
 {
@@ -2885,21 +2765,11 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
     afterCreateRayTracingState(IDevice* device, slang::IComponentType* program) = 0;
 };
-#define SLANG_UUID_IPipelineCreationAPIDispatcher         \
-    {                                                     \
-        0xc3d5f782, 0xeae1, 0x4da6,                       \
-        {                                                 \
-            0xab, 0x40, 0x75, 0x32, 0x31, 0x2, 0xb7, 0xdc \
-        }                                                 \
-    }
+#define SLANG_UUID_IPipelineCreationAPIDispatcher \
+    {0xc3d5f782, 0xeae1, 0x4da6, {0xab, 0x40, 0x75, 0x32, 0x31, 0x2, 0xb7, 0xdc}}
 
-#define SLANG_UUID_IVulkanPipelineCreationAPIDispatcher    \
-    {                                                      \
-        0x4fcf1274, 0x8752, 0x4743,                        \
-        {                                                  \
-            0xb3, 0x51, 0x47, 0xcb, 0x83, 0x71, 0xef, 0x99 \
-        }                                                  \
-    }
+#define SLANG_UUID_IVulkanPipelineCreationAPIDispatcher \
+    {0x4fcf1274, 0x8752, 0x4743, {0xb3, 0x51, 0x47, 0xcb, 0x83, 0x71, 0xef, 0x99}}
 
 // Global public functions
 

--- a/tools/gfx-unit-test/buffer-barrier-test.cpp
+++ b/tools/gfx-unit-test/buffer-barrier-test.cpp
@@ -146,6 +146,7 @@ void barrierTestImpl(IDevice* device, UnitTestContext* context)
 
 void barrierTestAPI(UnitTestContext* context, Slang::RenderApiFlag::Enum api)
 {
+    gfxSetDebugLayerEnabled(context->enableDebugLayers);
     if ((api & context->enabledApis) == 0)
     {
         SLANG_IGNORE_TEST

--- a/tools/gfx-unit-test/buffer-barrier-test.cpp
+++ b/tools/gfx-unit-test/buffer-barrier-test.cpp
@@ -146,7 +146,7 @@ void barrierTestImpl(IDevice* device, UnitTestContext* context)
 
 void barrierTestAPI(UnitTestContext* context, Slang::RenderApiFlag::Enum api)
 {
-    gfxSetDebugLayerEnabled(context->enableDebugLayers);
+    gfxEnableDebugLayer(context->enableDebugLayers);
     if ((api & context->enabledApis) == 0)
     {
         SLANG_IGNORE_TEST

--- a/tools/gfx-unit-test/existing-device-handle-test.cpp
+++ b/tools/gfx-unit-test/existing-device-handle-test.cpp
@@ -83,7 +83,7 @@ void existingDeviceHandleTestImpl(IDevice* device, UnitTestContext* context)
 
 void existingDeviceHandleTestAPI(UnitTestContext* context, Slang::RenderApiFlag::Enum api)
 {
-    gfxSetDebugLayerEnabled(context->enableDebugLayers);
+    gfxEnableDebugLayer(context->enableDebugLayers);
     if ((api & context->enabledApis) == 0)
     {
         SLANG_IGNORE_TEST;

--- a/tools/gfx-unit-test/existing-device-handle-test.cpp
+++ b/tools/gfx-unit-test/existing-device-handle-test.cpp
@@ -83,6 +83,7 @@ void existingDeviceHandleTestImpl(IDevice* device, UnitTestContext* context)
 
 void existingDeviceHandleTestAPI(UnitTestContext* context, Slang::RenderApiFlag::Enum api)
 {
+    gfxSetDebugLayerEnabled(context->enableDebugLayers);
     if ((api & context->enabledApis) == 0)
     {
         SLANG_IGNORE_TEST;

--- a/tools/gfx-unit-test/get-buffer-resource-handle-test.cpp
+++ b/tools/gfx-unit-test/get-buffer-resource-handle-test.cpp
@@ -53,7 +53,7 @@ void getBufferResourceHandleTestImpl(IDevice* device, UnitTestContext* context)
 
 void getBufferResourceHandleTestAPI(UnitTestContext* context, Slang::RenderApiFlag::Enum api)
 {
-    gfxSetDebugLayerEnabled(context->enableDebugLayers);
+    gfxEnableDebugLayer(context->enableDebugLayers);
     if ((api & context->enabledApis) == 0)
     {
         SLANG_IGNORE_TEST;

--- a/tools/gfx-unit-test/get-buffer-resource-handle-test.cpp
+++ b/tools/gfx-unit-test/get-buffer-resource-handle-test.cpp
@@ -53,6 +53,7 @@ void getBufferResourceHandleTestImpl(IDevice* device, UnitTestContext* context)
 
 void getBufferResourceHandleTestAPI(UnitTestContext* context, Slang::RenderApiFlag::Enum api)
 {
+    gfxSetDebugLayerEnabled(context->enableDebugLayers);
     if ((api & context->enabledApis) == 0)
     {
         SLANG_IGNORE_TEST;

--- a/tools/gfx-unit-test/get-cmd-buffer-handle-test.cpp
+++ b/tools/gfx-unit-test/get-cmd-buffer-handle-test.cpp
@@ -49,6 +49,7 @@ void getBufferHandleTestImpl(IDevice* device, UnitTestContext* context)
 
 void getBufferHandleTestAPI(UnitTestContext* context, Slang::RenderApiFlag::Enum api)
 {
+    gfxSetDebugLayerEnabled(context->enableDebugLayers);
     if ((api & context->enabledApis) == 0)
     {
         SLANG_IGNORE_TEST;

--- a/tools/gfx-unit-test/get-cmd-buffer-handle-test.cpp
+++ b/tools/gfx-unit-test/get-cmd-buffer-handle-test.cpp
@@ -49,7 +49,7 @@ void getBufferHandleTestImpl(IDevice* device, UnitTestContext* context)
 
 void getBufferHandleTestAPI(UnitTestContext* context, Slang::RenderApiFlag::Enum api)
 {
-    gfxSetDebugLayerEnabled(context->enableDebugLayers);
+    gfxEnableDebugLayer(context->enableDebugLayers);
     if ((api & context->enabledApis) == 0)
     {
         SLANG_IGNORE_TEST;

--- a/tools/gfx-unit-test/get-cmd-queue-handle-test.cpp
+++ b/tools/gfx-unit-test/get-cmd-queue-handle-test.cpp
@@ -38,7 +38,7 @@ void getQueueHandleTestImpl(IDevice* device, UnitTestContext* context)
 
 void getQueueHandleTestAPI(UnitTestContext* context, Slang::RenderApiFlag::Enum api)
 {
-    gfxSetDebugLayerEnabled(context->enableDebugLayers);
+    gfxEnableDebugLayer(context->enableDebugLayers);
     if ((api & context->enabledApis) == 0)
     {
         SLANG_IGNORE_TEST;

--- a/tools/gfx-unit-test/get-cmd-queue-handle-test.cpp
+++ b/tools/gfx-unit-test/get-cmd-queue-handle-test.cpp
@@ -38,6 +38,7 @@ void getQueueHandleTestImpl(IDevice* device, UnitTestContext* context)
 
 void getQueueHandleTestAPI(UnitTestContext* context, Slang::RenderApiFlag::Enum api)
 {
+    gfxSetDebugLayerEnabled(context->enableDebugLayers);
     if ((api & context->enabledApis) == 0)
     {
         SLANG_IGNORE_TEST;

--- a/tools/gfx-unit-test/get-texture-resource-handle-test.cpp
+++ b/tools/gfx-unit-test/get-texture-resource-handle-test.cpp
@@ -50,7 +50,7 @@ void getTextureResourceHandleTestImpl(IDevice* device, UnitTestContext* context)
 
 void getTextureResourceHandleTestAPI(UnitTestContext* context, Slang::RenderApiFlag::Enum api)
 {
-    gfxSetDebugLayerEnabled(context->enableDebugLayers);
+    gfxEnableDebugLayer(context->enableDebugLayers);
     if ((api & context->enabledApis) == 0)
     {
         SLANG_IGNORE_TEST;

--- a/tools/gfx-unit-test/get-texture-resource-handle-test.cpp
+++ b/tools/gfx-unit-test/get-texture-resource-handle-test.cpp
@@ -50,6 +50,7 @@ void getTextureResourceHandleTestImpl(IDevice* device, UnitTestContext* context)
 
 void getTextureResourceHandleTestAPI(UnitTestContext* context, Slang::RenderApiFlag::Enum api)
 {
+    gfxSetDebugLayerEnabled(context->enableDebugLayers);
     if ((api & context->enabledApis) == 0)
     {
         SLANG_IGNORE_TEST;

--- a/tools/gfx-unit-test/gfx-test-util.cpp
+++ b/tools/gfx-unit-test/gfx-test-util.cpp
@@ -323,13 +323,7 @@ Slang::ComPtr<gfx::IDevice> createTestingDevice(
     void* extDescPtrs[2] = {&extDesc, &slangExtDesc};
     deviceDesc.extendedDescs = extDescPtrs;
 
-    // TODO: We should also set the debug callback
-    // (And in general reduce the differences (and duplication) between
-    // here and render-test-main.cpp)
-#ifdef _DEBUG
-    gfx::gfxEnableDebugLayer();
-#endif
-
+    gfx::gfxSetDebugLayerEnabled(context->enableDebugLayers);
     auto createDeviceResult = gfxCreateDevice(&deviceDesc, device.writeRef());
     if (SLANG_FAILED(createDeviceResult))
     {

--- a/tools/gfx-unit-test/gfx-test-util.cpp
+++ b/tools/gfx-unit-test/gfx-test-util.cpp
@@ -323,7 +323,7 @@ Slang::ComPtr<gfx::IDevice> createTestingDevice(
     void* extDescPtrs[2] = {&extDesc, &slangExtDesc};
     deviceDesc.extendedDescs = extDescPtrs;
 
-    gfx::gfxSetDebugLayerEnabled(context->enableDebugLayers);
+    gfx::gfxEnableDebugLayer(context->enableDebugLayers);
     auto createDeviceResult = gfxCreateDevice(&deviceDesc, device.writeRef());
     if (SLANG_FAILED(createDeviceResult))
     {

--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -17,12 +17,6 @@
 #include "d3d12-swap-chain.h"
 #include "d3d12-vertex-layout.h"
 
-#ifdef _DEBUG
-#define ENABLE_DEBUG_LAYER 1
-#else
-#define ENABLE_DEBUG_LAYER 0
-#endif
-
 #ifdef GFX_NVAPI
 #include "../nvapi/nvapi-include.h"
 #endif
@@ -534,7 +528,7 @@ Result DeviceImpl::initialize(const Desc& desc)
 
 
     // If Aftermath is enabled, we can't enable the D3D12 debug layer as well
-    if (ENABLE_DEBUG_LAYER || isGfxDebugLayerEnabled() && !g_isAftermathEnabled)
+    if (isGfxDebugLayerEnabled() && !g_isAftermathEnabled)
     {
         m_D3D12GetDebugInterface =
             (PFN_D3D12_GET_DEBUG_INTERFACE)loadProc(d3dModule, "D3D12GetDebugInterface");
@@ -569,10 +563,7 @@ Result DeviceImpl::initialize(const Desc& desc)
     if (desc.existingDeviceHandles.handles[0].handleValue == 0)
     {
         FlagCombiner combiner;
-        // TODO: we should probably provide a command-line option
-        // to override UseDebug of default rather than leave it
-        // up to each back-end to specify.
-        if (ENABLE_DEBUG_LAYER || isGfxDebugLayerEnabled())
+        if (isGfxDebugLayerEnabled())
         {
             combiner.add(
                 DeviceCheckFlag::UseDebug,

--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -51,16 +51,12 @@ struct ShaderModelInfo
 };
 // List of shader models. Do not change oldest to newest order.
 static ShaderModelInfo kKnownShaderModels[] = {
-#define SHADER_MODEL_INFO_DXBC(major, minor)                                    \
-    {                                                                           \
-        D3D_SHADER_MODEL_##major##_##minor, SLANG_DXBC, "sm_" #major "_" #minor \
-    }
+#define SHADER_MODEL_INFO_DXBC(major, minor) \
+    {D3D_SHADER_MODEL_##major##_##minor, SLANG_DXBC, "sm_" #major "_" #minor}
     SHADER_MODEL_INFO_DXBC(5, 1),
 #undef SHADER_MODEL_INFO_DXBC
-#define SHADER_MODEL_INFO_DXIL(major, minor)                                    \
-    {                                                                           \
-        (D3D_SHADER_MODEL)0x##major##minor, SLANG_DXIL, "sm_" #major "_" #minor \
-    }
+#define SHADER_MODEL_INFO_DXIL(major, minor) \
+    {(D3D_SHADER_MODEL)0x##major##minor, SLANG_DXIL, "sm_" #major "_" #minor}
     SHADER_MODEL_INFO_DXIL(6, 0),
     SHADER_MODEL_INFO_DXIL(6, 1),
     SHADER_MODEL_INFO_DXIL(6, 2),

--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -51,12 +51,16 @@ struct ShaderModelInfo
 };
 // List of shader models. Do not change oldest to newest order.
 static ShaderModelInfo kKnownShaderModels[] = {
-#define SHADER_MODEL_INFO_DXBC(major, minor) \
-    {D3D_SHADER_MODEL_##major##_##minor, SLANG_DXBC, "sm_" #major "_" #minor}
+#define SHADER_MODEL_INFO_DXBC(major, minor)                                    \
+    {                                                                           \
+        D3D_SHADER_MODEL_##major##_##minor, SLANG_DXBC, "sm_" #major "_" #minor \
+    }
     SHADER_MODEL_INFO_DXBC(5, 1),
 #undef SHADER_MODEL_INFO_DXBC
-#define SHADER_MODEL_INFO_DXIL(major, minor) \
-    {(D3D_SHADER_MODEL)0x##major##minor, SLANG_DXIL, "sm_" #major "_" #minor}
+#define SHADER_MODEL_INFO_DXIL(major, minor)                                    \
+    {                                                                           \
+        (D3D_SHADER_MODEL)0x##major##minor, SLANG_DXIL, "sm_" #major "_" #minor \
+    }
     SHADER_MODEL_INFO_DXIL(6, 0),
     SHADER_MODEL_INFO_DXIL(6, 1),
     SHADER_MODEL_INFO_DXIL(6, 2),

--- a/tools/gfx/d3d12/d3d12-helper-functions.cpp
+++ b/tools/gfx/d3d12/d3d12-helper-functions.cpp
@@ -10,15 +10,8 @@
 #include "d3d12-query.h"
 #include "d3d12-transient-heap.h"
 
-#ifdef _DEBUG
-#define ENABLE_DEBUG_LAYER 1
-#else
-#define ENABLE_DEBUG_LAYER 0
-#endif
-
 namespace gfx
 {
-
 using namespace Slang;
 
 namespace d3d12

--- a/tools/gfx/render.cpp
+++ b/tools/gfx/render.cpp
@@ -9,327 +9,333 @@
 
 namespace gfx
 {
-using namespace Slang;
+    using namespace Slang;
 
-Result SLANG_MCALL createD3D11Device(const IDevice::Desc* desc, IDevice** outDevice);
-Result SLANG_MCALL createD3D12Device(const IDevice::Desc* desc, IDevice** outDevice);
-Result SLANG_MCALL createVKDevice(const IDevice::Desc* desc, IDevice** outDevice);
-Result SLANG_MCALL createMetalDevice(const IDevice::Desc* desc, IDevice** outDevice);
-Result SLANG_MCALL createCUDADevice(const IDevice::Desc* desc, IDevice** outDevice);
-Result SLANG_MCALL createCPUDevice(const IDevice::Desc* desc, IDevice** outDevice);
+    Result SLANG_MCALL createD3D11Device(const IDevice::Desc* desc, IDevice** outDevice);
+    Result SLANG_MCALL createD3D12Device(const IDevice::Desc* desc, IDevice** outDevice);
+    Result SLANG_MCALL createVKDevice(const IDevice::Desc* desc, IDevice** outDevice);
+    Result SLANG_MCALL createMetalDevice(const IDevice::Desc* desc, IDevice** outDevice);
+    Result SLANG_MCALL createCUDADevice(const IDevice::Desc* desc, IDevice** outDevice);
+    Result SLANG_MCALL createCPUDevice(const IDevice::Desc* desc, IDevice** outDevice);
 
-Result SLANG_MCALL getD3D11Adapters(List<AdapterInfo>& outAdapters);
-Result SLANG_MCALL getD3D12Adapters(List<AdapterInfo>& outAdapters);
-Result SLANG_MCALL getVKAdapters(List<AdapterInfo>& outAdapters);
-Result SLANG_MCALL getMetalAdapters(List<AdapterInfo>& outAdapters);
-Result SLANG_MCALL getCUDAAdapters(List<AdapterInfo>& outAdapters);
+    Result SLANG_MCALL getD3D11Adapters(List<AdapterInfo>& outAdapters);
+    Result SLANG_MCALL getD3D12Adapters(List<AdapterInfo>& outAdapters);
+    Result SLANG_MCALL getVKAdapters(List<AdapterInfo>& outAdapters);
+    Result SLANG_MCALL getMetalAdapters(List<AdapterInfo>& outAdapters);
+    Result SLANG_MCALL getCUDAAdapters(List<AdapterInfo>& outAdapters);
 
-Result SLANG_MCALL reportD3DLiveObjects();
+    Result SLANG_MCALL reportD3DLiveObjects();
 
-static bool debugLayerEnabled = false;
-bool isGfxDebugLayerEnabled()
-{
-    return debugLayerEnabled;
-}
+// Enable debug layer (validation layer) by default for DEBUG build
+#if _DEBUG
+    static bool debugLayerEnabled = true;
+#else
+    static bool debugLayerEnabled = false;
+#endif
 
-/* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Global Renderer Functions !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
+    bool isGfxDebugLayerEnabled()
+    {
+        return debugLayerEnabled;
+    }
+
+    /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Global Renderer Functions !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
 
 #define GFX_FORMAT_SIZE(name, blockSizeInBytes, pixelsPerBlock) {blockSizeInBytes, pixelsPerBlock},
 
-static const uint32_t s_formatSizeInfo[][2] = {GFX_FORMAT(GFX_FORMAT_SIZE)};
+    static const uint32_t s_formatSizeInfo[][2] = { GFX_FORMAT(GFX_FORMAT_SIZE) };
 
-static bool _checkFormat()
-{
-    Index value = 0;
-    Index count = 0;
+    static bool _checkFormat()
+    {
+        Index value = 0;
+        Index count = 0;
 
-    // Check the values are in the same order
+        // Check the values are in the same order
 #define GFX_FORMAT_CHECK(name, blockSizeInBytes, pixelsPerblock) \
     count += Index(Index(Format::name) == value++);
-    GFX_FORMAT(GFX_FORMAT_CHECK)
+        GFX_FORMAT(GFX_FORMAT_CHECK)
 
-    const bool r = (count == Index(Format::_Count));
-    SLANG_ASSERT(r);
-    return r;
-}
+            const bool r = (count == Index(Format::_Count));
+        SLANG_ASSERT(r);
+        return r;
+    }
 
-// We don't make static because we will get a warning that it's unused
-static const bool _checkFormatResult = _checkFormat();
+    // We don't make static because we will get a warning that it's unused
+    static const bool _checkFormatResult = _checkFormat();
 
-struct FormatInfoMap
-{
-    FormatInfoMap()
+    struct FormatInfoMap
     {
-        // Set all to nothing initially
-        for (auto& info : m_infos)
+        FormatInfoMap()
         {
-            info.channelCount = 0;
-            info.channelType = SLANG_SCALAR_TYPE_NONE;
+            // Set all to nothing initially
+            for (auto& info : m_infos)
+            {
+                info.channelCount = 0;
+                info.channelType = SLANG_SCALAR_TYPE_NONE;
+            }
+
+            set(Format::R32G32B32A32_TYPELESS, SLANG_SCALAR_TYPE_UINT32, 4);
+            set(Format::R32G32B32_TYPELESS, SLANG_SCALAR_TYPE_UINT32, 3);
+            set(Format::R32G32_TYPELESS, SLANG_SCALAR_TYPE_UINT32, 2);
+            set(Format::R32_TYPELESS, SLANG_SCALAR_TYPE_UINT32, 1);
+
+            set(Format::R16G16B16A16_TYPELESS, SLANG_SCALAR_TYPE_UINT16, 4);
+            set(Format::R16G16_TYPELESS, SLANG_SCALAR_TYPE_UINT16, 2);
+            set(Format::R16_TYPELESS, SLANG_SCALAR_TYPE_UINT16, 1);
+
+            set(Format::R8G8B8A8_TYPELESS, SLANG_SCALAR_TYPE_UINT8, 4);
+            set(Format::R8G8_TYPELESS, SLANG_SCALAR_TYPE_UINT8, 2);
+            set(Format::R8_TYPELESS, SLANG_SCALAR_TYPE_UINT8, 1);
+            set(Format::B8G8R8A8_TYPELESS, SLANG_SCALAR_TYPE_UINT8, 4);
+
+            set(Format::R32G32B32A32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 4);
+            set(Format::R32G32B32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 3);
+            set(Format::R32G32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 2);
+            set(Format::R32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 1);
+
+            set(Format::R16G16B16A16_FLOAT, SLANG_SCALAR_TYPE_FLOAT16, 4);
+            set(Format::R16G16_FLOAT, SLANG_SCALAR_TYPE_FLOAT16, 2);
+            set(Format::R16_FLOAT, SLANG_SCALAR_TYPE_FLOAT16, 1);
+
+            set(Format::R64_UINT, SLANG_SCALAR_TYPE_UINT64, 1);
+
+            set(Format::R32G32B32A32_UINT, SLANG_SCALAR_TYPE_UINT32, 4);
+            set(Format::R32G32B32_UINT, SLANG_SCALAR_TYPE_UINT32, 3);
+            set(Format::R32G32_UINT, SLANG_SCALAR_TYPE_UINT32, 2);
+            set(Format::R32_UINT, SLANG_SCALAR_TYPE_UINT32, 1);
+
+            set(Format::R16G16B16A16_UINT, SLANG_SCALAR_TYPE_UINT16, 4);
+            set(Format::R16G16_UINT, SLANG_SCALAR_TYPE_UINT16, 2);
+            set(Format::R16_UINT, SLANG_SCALAR_TYPE_UINT16, 1);
+
+            set(Format::R8G8B8A8_UINT, SLANG_SCALAR_TYPE_UINT8, 4);
+            set(Format::R8G8_UINT, SLANG_SCALAR_TYPE_UINT8, 2);
+            set(Format::R8_UINT, SLANG_SCALAR_TYPE_UINT8, 1);
+
+            set(Format::R64_SINT, SLANG_SCALAR_TYPE_INT64, 1);
+
+            set(Format::R32G32B32A32_SINT, SLANG_SCALAR_TYPE_INT32, 4);
+            set(Format::R32G32B32_SINT, SLANG_SCALAR_TYPE_INT32, 3);
+            set(Format::R32G32_SINT, SLANG_SCALAR_TYPE_INT32, 2);
+            set(Format::R32_SINT, SLANG_SCALAR_TYPE_INT32, 1);
+
+            set(Format::R16G16B16A16_SINT, SLANG_SCALAR_TYPE_INT16, 4);
+            set(Format::R16G16_SINT, SLANG_SCALAR_TYPE_INT16, 2);
+            set(Format::R16_SINT, SLANG_SCALAR_TYPE_INT16, 1);
+
+            set(Format::R8G8B8A8_SINT, SLANG_SCALAR_TYPE_INT8, 4);
+            set(Format::R8G8_SINT, SLANG_SCALAR_TYPE_INT8, 2);
+            set(Format::R8_SINT, SLANG_SCALAR_TYPE_INT8, 1);
+
+            set(Format::R16G16B16A16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+            set(Format::R16G16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 2);
+            set(Format::R16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
+
+            set(Format::R8G8B8A8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+            set(Format::R8G8B8A8_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4);
+            set(Format::R8G8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 2);
+            set(Format::R8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
+            set(Format::B8G8R8A8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+            set(Format::B8G8R8A8_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4);
+            set(Format::B8G8R8X8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+            set(Format::B8G8R8X8_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4);
+
+            set(Format::R16G16B16A16_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+            set(Format::R16G16_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 2);
+            set(Format::R16_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
+
+            set(Format::R8G8B8A8_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+            set(Format::R8G8_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 2);
+            set(Format::R8_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
+
+            set(Format::D32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 1);
+            set(Format::D16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
+            set(Format::D32_FLOAT_S8_UINT, SLANG_SCALAR_TYPE_FLOAT32, 2);
+            set(Format::R32_FLOAT_X32_TYPELESS, SLANG_SCALAR_TYPE_FLOAT32, 2);
+
+            set(Format::B4G4R4A4_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+            set(Format::B5G6R5_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 3);
+            set(Format::B5G5R5A1_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+
+            set(Format::R9G9B9E5_SHAREDEXP, SLANG_SCALAR_TYPE_FLOAT32, 3);
+            set(Format::R10G10B10A2_TYPELESS, SLANG_SCALAR_TYPE_FLOAT32, 4);
+            set(Format::R10G10B10A2_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+            set(Format::R10G10B10A2_UINT, SLANG_SCALAR_TYPE_UINT32, 4);
+            set(Format::R11G11B10_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 3);
+
+            set(Format::BC1_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
+            set(Format::BC1_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
+            set(Format::BC2_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
+            set(Format::BC2_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
+            set(Format::BC3_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
+            set(Format::BC3_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
+            set(Format::BC4_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1, 4, 4);
+            set(Format::BC4_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 1, 4, 4);
+            set(Format::BC5_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 2, 4, 4);
+            set(Format::BC5_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 2, 4, 4);
+            set(Format::BC6H_UF16, SLANG_SCALAR_TYPE_FLOAT32, 3, 4, 4);
+            set(Format::BC6H_SF16, SLANG_SCALAR_TYPE_FLOAT32, 3, 4, 4);
+            set(Format::BC7_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
+            set(Format::BC7_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
         }
 
-        set(Format::R32G32B32A32_TYPELESS, SLANG_SCALAR_TYPE_UINT32, 4);
-        set(Format::R32G32B32_TYPELESS, SLANG_SCALAR_TYPE_UINT32, 3);
-        set(Format::R32G32_TYPELESS, SLANG_SCALAR_TYPE_UINT32, 2);
-        set(Format::R32_TYPELESS, SLANG_SCALAR_TYPE_UINT32, 1);
-
-        set(Format::R16G16B16A16_TYPELESS, SLANG_SCALAR_TYPE_UINT16, 4);
-        set(Format::R16G16_TYPELESS, SLANG_SCALAR_TYPE_UINT16, 2);
-        set(Format::R16_TYPELESS, SLANG_SCALAR_TYPE_UINT16, 1);
-
-        set(Format::R8G8B8A8_TYPELESS, SLANG_SCALAR_TYPE_UINT8, 4);
-        set(Format::R8G8_TYPELESS, SLANG_SCALAR_TYPE_UINT8, 2);
-        set(Format::R8_TYPELESS, SLANG_SCALAR_TYPE_UINT8, 1);
-        set(Format::B8G8R8A8_TYPELESS, SLANG_SCALAR_TYPE_UINT8, 4);
-
-        set(Format::R32G32B32A32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 4);
-        set(Format::R32G32B32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 3);
-        set(Format::R32G32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 2);
-        set(Format::R32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 1);
-
-        set(Format::R16G16B16A16_FLOAT, SLANG_SCALAR_TYPE_FLOAT16, 4);
-        set(Format::R16G16_FLOAT, SLANG_SCALAR_TYPE_FLOAT16, 2);
-        set(Format::R16_FLOAT, SLANG_SCALAR_TYPE_FLOAT16, 1);
-
-        set(Format::R64_UINT, SLANG_SCALAR_TYPE_UINT64, 1);
-
-        set(Format::R32G32B32A32_UINT, SLANG_SCALAR_TYPE_UINT32, 4);
-        set(Format::R32G32B32_UINT, SLANG_SCALAR_TYPE_UINT32, 3);
-        set(Format::R32G32_UINT, SLANG_SCALAR_TYPE_UINT32, 2);
-        set(Format::R32_UINT, SLANG_SCALAR_TYPE_UINT32, 1);
-
-        set(Format::R16G16B16A16_UINT, SLANG_SCALAR_TYPE_UINT16, 4);
-        set(Format::R16G16_UINT, SLANG_SCALAR_TYPE_UINT16, 2);
-        set(Format::R16_UINT, SLANG_SCALAR_TYPE_UINT16, 1);
-
-        set(Format::R8G8B8A8_UINT, SLANG_SCALAR_TYPE_UINT8, 4);
-        set(Format::R8G8_UINT, SLANG_SCALAR_TYPE_UINT8, 2);
-        set(Format::R8_UINT, SLANG_SCALAR_TYPE_UINT8, 1);
-
-        set(Format::R64_SINT, SLANG_SCALAR_TYPE_INT64, 1);
-
-        set(Format::R32G32B32A32_SINT, SLANG_SCALAR_TYPE_INT32, 4);
-        set(Format::R32G32B32_SINT, SLANG_SCALAR_TYPE_INT32, 3);
-        set(Format::R32G32_SINT, SLANG_SCALAR_TYPE_INT32, 2);
-        set(Format::R32_SINT, SLANG_SCALAR_TYPE_INT32, 1);
-
-        set(Format::R16G16B16A16_SINT, SLANG_SCALAR_TYPE_INT16, 4);
-        set(Format::R16G16_SINT, SLANG_SCALAR_TYPE_INT16, 2);
-        set(Format::R16_SINT, SLANG_SCALAR_TYPE_INT16, 1);
-
-        set(Format::R8G8B8A8_SINT, SLANG_SCALAR_TYPE_INT8, 4);
-        set(Format::R8G8_SINT, SLANG_SCALAR_TYPE_INT8, 2);
-        set(Format::R8_SINT, SLANG_SCALAR_TYPE_INT8, 1);
-
-        set(Format::R16G16B16A16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-        set(Format::R16G16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 2);
-        set(Format::R16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
-
-        set(Format::R8G8B8A8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-        set(Format::R8G8B8A8_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4);
-        set(Format::R8G8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 2);
-        set(Format::R8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
-        set(Format::B8G8R8A8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-        set(Format::B8G8R8A8_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4);
-        set(Format::B8G8R8X8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-        set(Format::B8G8R8X8_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4);
-
-        set(Format::R16G16B16A16_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-        set(Format::R16G16_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 2);
-        set(Format::R16_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
-
-        set(Format::R8G8B8A8_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-        set(Format::R8G8_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 2);
-        set(Format::R8_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
-
-        set(Format::D32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 1);
-        set(Format::D16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
-        set(Format::D32_FLOAT_S8_UINT, SLANG_SCALAR_TYPE_FLOAT32, 2);
-        set(Format::R32_FLOAT_X32_TYPELESS, SLANG_SCALAR_TYPE_FLOAT32, 2);
-
-        set(Format::B4G4R4A4_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-        set(Format::B5G6R5_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 3);
-        set(Format::B5G5R5A1_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-
-        set(Format::R9G9B9E5_SHAREDEXP, SLANG_SCALAR_TYPE_FLOAT32, 3);
-        set(Format::R10G10B10A2_TYPELESS, SLANG_SCALAR_TYPE_FLOAT32, 4);
-        set(Format::R10G10B10A2_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-        set(Format::R10G10B10A2_UINT, SLANG_SCALAR_TYPE_UINT32, 4);
-        set(Format::R11G11B10_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 3);
-
-        set(Format::BC1_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
-        set(Format::BC1_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
-        set(Format::BC2_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
-        set(Format::BC2_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
-        set(Format::BC3_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
-        set(Format::BC3_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
-        set(Format::BC4_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1, 4, 4);
-        set(Format::BC4_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 1, 4, 4);
-        set(Format::BC5_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 2, 4, 4);
-        set(Format::BC5_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 2, 4, 4);
-        set(Format::BC6H_UF16, SLANG_SCALAR_TYPE_FLOAT32, 3, 4, 4);
-        set(Format::BC6H_SF16, SLANG_SCALAR_TYPE_FLOAT32, 3, 4, 4);
-        set(Format::BC7_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
-        set(Format::BC7_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
-    }
-
-    void set(
-        Format format,
-        SlangScalarType type,
-        Index channelCount,
-        uint32_t blockWidth = 1,
-        uint32_t blockHeight = 1)
-    {
-        FormatInfo& info = m_infos[Index(format)];
-        info.channelCount = uint8_t(channelCount);
-        info.channelType = uint8_t(type);
-
-        auto sizeInfo = s_formatSizeInfo[Index(format)];
-        info.blockSizeInBytes = sizeInfo[0];
-        info.pixelsPerBlock = sizeInfo[1];
-        info.blockWidth = blockWidth;
-        info.blockHeight = blockHeight;
-    }
-
-    const FormatInfo& get(Format format) const { return m_infos[Index(format)]; }
-
-    FormatInfo m_infos[Index(Format::_Count)];
-};
-
-static const FormatInfoMap s_formatInfoMap;
-
-static void _compileTimeAsserts()
-{
-    SLANG_COMPILE_TIME_ASSERT(SLANG_COUNT_OF(s_formatSizeInfo) == int(Format::_Count));
-}
-
-extern "C"
-{
-    SLANG_GFX_API bool SLANG_MCALL gfxIsCompressedFormat(Format format)
-    {
-        switch (format)
+        void set(
+            Format format,
+            SlangScalarType type,
+            Index channelCount,
+            uint32_t blockWidth = 1,
+            uint32_t blockHeight = 1)
         {
-        case Format::BC1_UNORM:
-        case Format::BC1_UNORM_SRGB:
-        case Format::BC2_UNORM:
-        case Format::BC2_UNORM_SRGB:
-        case Format::BC3_UNORM:
-        case Format::BC3_UNORM_SRGB:
-        case Format::BC4_UNORM:
-        case Format::BC4_SNORM:
-        case Format::BC5_UNORM:
-        case Format::BC5_SNORM:
-        case Format::BC6H_UF16:
-        case Format::BC6H_SF16:
-        case Format::BC7_UNORM:
-        case Format::BC7_UNORM_SRGB:
-            return true;
-        default:
-            return false;
+            FormatInfo& info = m_infos[Index(format)];
+            info.channelCount = uint8_t(channelCount);
+            info.channelType = uint8_t(type);
+
+            auto sizeInfo = s_formatSizeInfo[Index(format)];
+            info.blockSizeInBytes = sizeInfo[0];
+            info.pixelsPerBlock = sizeInfo[1];
+            info.blockWidth = blockWidth;
+            info.blockHeight = blockHeight;
         }
+
+        const FormatInfo& get(Format format) const { return m_infos[Index(format)]; }
+
+        FormatInfo m_infos[Index(Format::_Count)];
+    };
+
+    static const FormatInfoMap s_formatInfoMap;
+
+    static void _compileTimeAsserts()
+    {
+        SLANG_COMPILE_TIME_ASSERT(SLANG_COUNT_OF(s_formatSizeInfo) == int(Format::_Count));
     }
 
-    SLANG_GFX_API bool SLANG_MCALL gfxIsTypelessFormat(Format format)
+    extern "C"
     {
-        switch (format)
+        SLANG_GFX_API bool SLANG_MCALL gfxIsCompressedFormat(Format format)
         {
-        case Format::R32G32B32A32_TYPELESS:
-        case Format::R32G32B32_TYPELESS:
-        case Format::R32G32_TYPELESS:
-        case Format::R32_TYPELESS:
-        case Format::R16G16B16A16_TYPELESS:
-        case Format::R16G16_TYPELESS:
-        case Format::R16_TYPELESS:
-        case Format::R8G8B8A8_TYPELESS:
-        case Format::R8G8_TYPELESS:
-        case Format::R8_TYPELESS:
-        case Format::B8G8R8A8_TYPELESS:
-        case Format::R10G10B10A2_TYPELESS:
-            return true;
-        default:
-            return false;
+            switch (format)
+            {
+            case Format::BC1_UNORM:
+            case Format::BC1_UNORM_SRGB:
+            case Format::BC2_UNORM:
+            case Format::BC2_UNORM_SRGB:
+            case Format::BC3_UNORM:
+            case Format::BC3_UNORM_SRGB:
+            case Format::BC4_UNORM:
+            case Format::BC4_SNORM:
+            case Format::BC5_UNORM:
+            case Format::BC5_SNORM:
+            case Format::BC6H_UF16:
+            case Format::BC6H_SF16:
+            case Format::BC7_UNORM:
+            case Format::BC7_UNORM_SRGB:
+                return true;
+            default:
+                return false;
+            }
         }
-    }
 
-    SLANG_GFX_API SlangResult SLANG_MCALL gfxGetFormatInfo(Format format, FormatInfo* outInfo)
-    {
-        *outInfo = s_formatInfoMap.get(format);
-        return SLANG_OK;
-    }
-
-    SLANG_GFX_API SlangResult SLANG_MCALL
-    gfxGetAdapters(DeviceType type, ISlangBlob** outAdaptersBlob)
-    {
-        List<AdapterInfo> adapters;
-
-        switch (type)
+        SLANG_GFX_API bool SLANG_MCALL gfxIsTypelessFormat(Format format)
         {
+            switch (format)
+            {
+            case Format::R32G32B32A32_TYPELESS:
+            case Format::R32G32B32_TYPELESS:
+            case Format::R32G32_TYPELESS:
+            case Format::R32_TYPELESS:
+            case Format::R16G16B16A16_TYPELESS:
+            case Format::R16G16_TYPELESS:
+            case Format::R16_TYPELESS:
+            case Format::R8G8B8A8_TYPELESS:
+            case Format::R8G8_TYPELESS:
+            case Format::R8_TYPELESS:
+            case Format::B8G8R8A8_TYPELESS:
+            case Format::R10G10B10A2_TYPELESS:
+                return true;
+            default:
+                return false;
+            }
+        }
+
+        SLANG_GFX_API SlangResult SLANG_MCALL gfxGetFormatInfo(Format format, FormatInfo* outInfo)
+        {
+            *outInfo = s_formatInfoMap.get(format);
+            return SLANG_OK;
+        }
+
+        SLANG_GFX_API SlangResult SLANG_MCALL
+            gfxGetAdapters(DeviceType type, ISlangBlob** outAdaptersBlob)
+        {
+            List<AdapterInfo> adapters;
+
+            switch (type)
+            {
 #if SLANG_ENABLE_DIRECTX
-        case DeviceType::DirectX11:
-            SLANG_RETURN_ON_FAIL(getD3D11Adapters(adapters));
-            break;
-        case DeviceType::DirectX12:
-            SLANG_RETURN_ON_FAIL(getD3D12Adapters(adapters));
-            break;
+            case DeviceType::DirectX11:
+                SLANG_RETURN_ON_FAIL(getD3D11Adapters(adapters));
+                break;
+            case DeviceType::DirectX12:
+                SLANG_RETURN_ON_FAIL(getD3D12Adapters(adapters));
+                break;
 #endif
 #if SLANG_WINDOWS_FAMILY
-        case DeviceType::OpenGl:
-            return SLANG_E_NOT_IMPLEMENTED;
+            case DeviceType::OpenGl:
+                return SLANG_E_NOT_IMPLEMENTED;
 #endif
 #if SLANG_WINDOWS_FAMILY || SLANG_LINUX_FAMILY
-        // Assume no Vulkan or CUDA on MacOS or Cygwin
-        case DeviceType::Vulkan:
-            SLANG_RETURN_ON_FAIL(getVKAdapters(adapters));
-            break;
-        case DeviceType::CUDA:
-            SLANG_RETURN_ON_FAIL(getCUDAAdapters(adapters));
-            break;
+                // Assume no Vulkan or CUDA on MacOS or Cygwin
+            case DeviceType::Vulkan:
+                SLANG_RETURN_ON_FAIL(getVKAdapters(adapters));
+                break;
+            case DeviceType::CUDA:
+                SLANG_RETURN_ON_FAIL(getCUDAAdapters(adapters));
+                break;
 #endif
 #if SLANG_APPLE_FAMILY
-        case DeviceType::Vulkan:
-            SLANG_RETURN_ON_FAIL(getVKAdapters(adapters));
-            break;
-        case DeviceType::Metal:
-            SLANG_RETURN_ON_FAIL(getMetalAdapters(adapters));
-            break;
+            case DeviceType::Vulkan:
+                SLANG_RETURN_ON_FAIL(getVKAdapters(adapters));
+                break;
+            case DeviceType::Metal:
+                SLANG_RETURN_ON_FAIL(getMetalAdapters(adapters));
+                break;
 #endif
-        case DeviceType::CPU:
-            return SLANG_E_NOT_IMPLEMENTED;
-        default:
-            return SLANG_E_INVALID_ARG;
+            case DeviceType::CPU:
+                return SLANG_E_NOT_IMPLEMENTED;
+            default:
+                return SLANG_E_INVALID_ARG;
+            }
+
+            auto adaptersBlob =
+                RawBlob::create(adapters.getBuffer(), adapters.getCount() * sizeof(AdapterInfo));
+            if (outAdaptersBlob)
+                returnComPtr(outAdaptersBlob, adaptersBlob);
+
+            return SLANG_OK;
         }
 
-        auto adaptersBlob =
-            RawBlob::create(adapters.getBuffer(), adapters.getCount() * sizeof(AdapterInfo));
-        if (outAdaptersBlob)
-            returnComPtr(outAdaptersBlob, adaptersBlob);
-
-        return SLANG_OK;
-    }
-
-    SlangResult _createDevice(const IDevice::Desc* desc, IDevice** outDevice)
-    {
-        switch (desc->deviceType)
+        SlangResult _createDevice(const IDevice::Desc* desc, IDevice** outDevice)
         {
+            switch (desc->deviceType)
+            {
 #if SLANG_ENABLE_DIRECTX
-        case DeviceType::DirectX11:
+            case DeviceType::DirectX11:
             {
                 return createD3D11Device(desc, outDevice);
             }
-        case DeviceType::DirectX12:
+            case DeviceType::DirectX12:
             {
                 return createD3D12Device(desc, outDevice);
             }
 #endif
 #if SLANG_WINDOWS_FAMILY
-        case DeviceType::OpenGl:
+            case DeviceType::OpenGl:
             {
                 return createGLDevice(desc, outDevice);
             }
-        case DeviceType::Vulkan:
+            case DeviceType::Vulkan:
             {
                 return createVKDevice(desc, outDevice);
             }
-        case DeviceType::Default:
+            case DeviceType::Default:
             {
                 IDevice::Desc newDesc = *desc;
                 newDesc.deviceType = DeviceType::DirectX12;
@@ -348,15 +354,15 @@ extern "C"
             }
             break;
 #elif SLANG_APPLE_FAMILY
-        case DeviceType::Vulkan:
+            case DeviceType::Vulkan:
             {
                 return createVKDevice(desc, outDevice);
             }
-        case DeviceType::Metal:
+            case DeviceType::Metal:
             {
                 return createMetalDevice(desc, outDevice);
             }
-        case DeviceType::Default:
+            case DeviceType::Default:
             {
                 IDevice::Desc newDesc = *desc;
                 newDesc.deviceType = DeviceType::Metal;
@@ -368,11 +374,11 @@ extern "C"
                 return SLANG_FAIL;
             }
 #elif SLANG_LINUX_FAMILY && !defined(__CYGWIN__)
-        case DeviceType::Vulkan:
+            case DeviceType::Vulkan:
             {
                 return createVKDevice(desc, outDevice);
             }
-        case DeviceType::Default:
+            case DeviceType::Default:
             {
                 IDevice::Desc newDesc = *desc;
                 newDesc.deviceType = DeviceType::Vulkan;
@@ -381,109 +387,109 @@ extern "C"
                 return SLANG_FAIL;
             }
 #endif
-        case DeviceType::CUDA:
+            case DeviceType::CUDA:
             {
                 return createCUDADevice(desc, outDevice);
             }
-        case DeviceType::CPU:
+            case DeviceType::CPU:
             {
                 return createCPUDevice(desc, outDevice);
             }
             break;
 
-        default:
-            return SLANG_FAIL;
+            default:
+                return SLANG_FAIL;
+            }
         }
-    }
 
-    SLANG_GFX_API SlangResult SLANG_MCALL
-    gfxCreateDevice(const IDevice::Desc* desc, IDevice** outDevice)
-    {
-        ComPtr<IDevice> innerDevice;
-        auto resultCode = _createDevice(desc, innerDevice.writeRef());
-        if (SLANG_FAILED(resultCode))
-            return resultCode;
-        if (!debugLayerEnabled)
+        SLANG_GFX_API SlangResult SLANG_MCALL
+            gfxCreateDevice(const IDevice::Desc* desc, IDevice** outDevice)
         {
-            returnComPtr(outDevice, innerDevice);
+            ComPtr<IDevice> innerDevice;
+            auto resultCode = _createDevice(desc, innerDevice.writeRef());
+            if (SLANG_FAILED(resultCode))
+                return resultCode;
+            if (!debugLayerEnabled)
+            {
+                returnComPtr(outDevice, innerDevice);
+                return resultCode;
+            }
+            RefPtr<debug::DebugDevice> debugDevice = new debug::DebugDevice();
+            debugDevice->baseObject = innerDevice;
+            returnComPtr(outDevice, debugDevice);
             return resultCode;
         }
-        RefPtr<debug::DebugDevice> debugDevice = new debug::DebugDevice();
-        debugDevice->baseObject = innerDevice;
-        returnComPtr(outDevice, debugDevice);
-        return resultCode;
-    }
 
-    SLANG_GFX_API SlangResult SLANG_MCALL gfxReportLiveObjects()
-    {
+        SLANG_GFX_API SlangResult SLANG_MCALL gfxReportLiveObjects()
+        {
 #if SLANG_ENABLE_DIRECTX
-        SLANG_RETURN_ON_FAIL(reportD3DLiveObjects());
+            SLANG_RETURN_ON_FAIL(reportD3DLiveObjects());
 #endif
-        return SLANG_OK;
-    }
-
-    SLANG_GFX_API SlangResult SLANG_MCALL gfxSetDebugCallback(IDebugCallback* callback)
-    {
-        _getDebugCallback() = callback;
-        return SLANG_OK;
-    }
-
-    SLANG_GFX_API void SLANG_MCALL gfxEnableDebugLayer()
-    {
-        debugLayerEnabled = true;
-    }
-
-    const char* SLANG_MCALL gfxGetDeviceTypeName(DeviceType type)
-    {
-        switch (type)
-        {
-        case gfx::DeviceType::Unknown:
-            return "Unknown";
-        case gfx::DeviceType::Default:
-            return "Default";
-        case gfx::DeviceType::DirectX11:
-            return "DirectX11";
-        case gfx::DeviceType::DirectX12:
-            return "DirectX12";
-        case gfx::DeviceType::OpenGl:
-            return "OpenGL";
-        case gfx::DeviceType::Vulkan:
-            return "Vulkan";
-        case gfx::DeviceType::Metal:
-            return "Metal";
-        case gfx::DeviceType::CPU:
-            return "CPU";
-        case gfx::DeviceType::CUDA:
-            return "CUDA";
-        default:
-            return "?";
+            return SLANG_OK;
         }
-    }
 
-
-    void SLANG_MCALL gfxGetIdentityProjection(ProjectionStyle style, float projMatrix[16])
-    {
-        switch (style)
+        SLANG_GFX_API SlangResult SLANG_MCALL gfxSetDebugCallback(IDebugCallback* callback)
         {
-        case ProjectionStyle::DirectX:
-        case ProjectionStyle::OpenGl:
+            _getDebugCallback() = callback;
+            return SLANG_OK;
+        }
+
+        SLANG_GFX_API void SLANG_MCALL gfxSetDebugLayerEnabled(bool enable)
+        {
+            debugLayerEnabled = enable;
+        }
+
+        const char* SLANG_MCALL gfxGetDeviceTypeName(DeviceType type)
+        {
+            switch (type)
             {
-                static const float kIdentity[] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
+            case gfx::DeviceType::Unknown:
+                return "Unknown";
+            case gfx::DeviceType::Default:
+                return "Default";
+            case gfx::DeviceType::DirectX11:
+                return "DirectX11";
+            case gfx::DeviceType::DirectX12:
+                return "DirectX12";
+            case gfx::DeviceType::OpenGl:
+                return "OpenGL";
+            case gfx::DeviceType::Vulkan:
+                return "Vulkan";
+            case gfx::DeviceType::Metal:
+                return "Metal";
+            case gfx::DeviceType::CPU:
+                return "CPU";
+            case gfx::DeviceType::CUDA:
+                return "CUDA";
+            default:
+                return "?";
+            }
+        }
+
+
+        void SLANG_MCALL gfxGetIdentityProjection(ProjectionStyle style, float projMatrix[16])
+        {
+            switch (style)
+            {
+            case ProjectionStyle::DirectX:
+            case ProjectionStyle::OpenGl:
+            {
+                static const float kIdentity[] = { 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 };
                 ::memcpy(projMatrix, kIdentity, sizeof(kIdentity));
                 break;
             }
-        case ProjectionStyle::Vulkan:
+            case ProjectionStyle::Vulkan:
             {
-                static const float kIdentity[] = {1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
+                static const float kIdentity[] = { 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 };
                 ::memcpy(projMatrix, kIdentity, sizeof(kIdentity));
                 break;
             }
-        default:
+            default:
             {
                 assert(!"Not handled");
             }
+            }
         }
     }
-}
 
 } // namespace gfx

--- a/tools/gfx/render.cpp
+++ b/tools/gfx/render.cpp
@@ -434,7 +434,7 @@ namespace gfx
             return SLANG_OK;
         }
 
-        SLANG_GFX_API void SLANG_MCALL gfxSetDebugLayerEnabled(bool enable)
+        SLANG_GFX_API void SLANG_MCALL gfxEnableDebugLayer(bool enable)
         {
             debugLayerEnabled = enable;
         }

--- a/tools/gfx/render.cpp
+++ b/tools/gfx/render.cpp
@@ -9,333 +9,333 @@
 
 namespace gfx
 {
-    using namespace Slang;
+using namespace Slang;
 
-    Result SLANG_MCALL createD3D11Device(const IDevice::Desc* desc, IDevice** outDevice);
-    Result SLANG_MCALL createD3D12Device(const IDevice::Desc* desc, IDevice** outDevice);
-    Result SLANG_MCALL createVKDevice(const IDevice::Desc* desc, IDevice** outDevice);
-    Result SLANG_MCALL createMetalDevice(const IDevice::Desc* desc, IDevice** outDevice);
-    Result SLANG_MCALL createCUDADevice(const IDevice::Desc* desc, IDevice** outDevice);
-    Result SLANG_MCALL createCPUDevice(const IDevice::Desc* desc, IDevice** outDevice);
+Result SLANG_MCALL createD3D11Device(const IDevice::Desc* desc, IDevice** outDevice);
+Result SLANG_MCALL createD3D12Device(const IDevice::Desc* desc, IDevice** outDevice);
+Result SLANG_MCALL createVKDevice(const IDevice::Desc* desc, IDevice** outDevice);
+Result SLANG_MCALL createMetalDevice(const IDevice::Desc* desc, IDevice** outDevice);
+Result SLANG_MCALL createCUDADevice(const IDevice::Desc* desc, IDevice** outDevice);
+Result SLANG_MCALL createCPUDevice(const IDevice::Desc* desc, IDevice** outDevice);
 
-    Result SLANG_MCALL getD3D11Adapters(List<AdapterInfo>& outAdapters);
-    Result SLANG_MCALL getD3D12Adapters(List<AdapterInfo>& outAdapters);
-    Result SLANG_MCALL getVKAdapters(List<AdapterInfo>& outAdapters);
-    Result SLANG_MCALL getMetalAdapters(List<AdapterInfo>& outAdapters);
-    Result SLANG_MCALL getCUDAAdapters(List<AdapterInfo>& outAdapters);
+Result SLANG_MCALL getD3D11Adapters(List<AdapterInfo>& outAdapters);
+Result SLANG_MCALL getD3D12Adapters(List<AdapterInfo>& outAdapters);
+Result SLANG_MCALL getVKAdapters(List<AdapterInfo>& outAdapters);
+Result SLANG_MCALL getMetalAdapters(List<AdapterInfo>& outAdapters);
+Result SLANG_MCALL getCUDAAdapters(List<AdapterInfo>& outAdapters);
 
-    Result SLANG_MCALL reportD3DLiveObjects();
+Result SLANG_MCALL reportD3DLiveObjects();
 
 // Enable debug layer (validation layer) by default for DEBUG build
 #if _DEBUG
-    static bool debugLayerEnabled = true;
+static bool debugLayerEnabled = true;
 #else
-    static bool debugLayerEnabled = false;
+static bool debugLayerEnabled = false;
 #endif
 
-    bool isGfxDebugLayerEnabled()
-    {
-        return debugLayerEnabled;
-    }
+bool isGfxDebugLayerEnabled()
+{
+    return debugLayerEnabled;
+}
 
-    /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Global Renderer Functions !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
+/* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Global Renderer Functions !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
 
 #define GFX_FORMAT_SIZE(name, blockSizeInBytes, pixelsPerBlock) {blockSizeInBytes, pixelsPerBlock},
 
-    static const uint32_t s_formatSizeInfo[][2] = { GFX_FORMAT(GFX_FORMAT_SIZE) };
+static const uint32_t s_formatSizeInfo[][2] = {GFX_FORMAT(GFX_FORMAT_SIZE)};
 
-    static bool _checkFormat()
-    {
-        Index value = 0;
-        Index count = 0;
+static bool _checkFormat()
+{
+    Index value = 0;
+    Index count = 0;
 
-        // Check the values are in the same order
+    // Check the values are in the same order
 #define GFX_FORMAT_CHECK(name, blockSizeInBytes, pixelsPerblock) \
     count += Index(Index(Format::name) == value++);
-        GFX_FORMAT(GFX_FORMAT_CHECK)
+    GFX_FORMAT(GFX_FORMAT_CHECK)
 
-            const bool r = (count == Index(Format::_Count));
-        SLANG_ASSERT(r);
-        return r;
+    const bool r = (count == Index(Format::_Count));
+    SLANG_ASSERT(r);
+    return r;
+}
+
+// We don't make static because we will get a warning that it's unused
+static const bool _checkFormatResult = _checkFormat();
+
+struct FormatInfoMap
+{
+    FormatInfoMap()
+    {
+        // Set all to nothing initially
+        for (auto& info : m_infos)
+        {
+            info.channelCount = 0;
+            info.channelType = SLANG_SCALAR_TYPE_NONE;
+        }
+
+        set(Format::R32G32B32A32_TYPELESS, SLANG_SCALAR_TYPE_UINT32, 4);
+        set(Format::R32G32B32_TYPELESS, SLANG_SCALAR_TYPE_UINT32, 3);
+        set(Format::R32G32_TYPELESS, SLANG_SCALAR_TYPE_UINT32, 2);
+        set(Format::R32_TYPELESS, SLANG_SCALAR_TYPE_UINT32, 1);
+
+        set(Format::R16G16B16A16_TYPELESS, SLANG_SCALAR_TYPE_UINT16, 4);
+        set(Format::R16G16_TYPELESS, SLANG_SCALAR_TYPE_UINT16, 2);
+        set(Format::R16_TYPELESS, SLANG_SCALAR_TYPE_UINT16, 1);
+
+        set(Format::R8G8B8A8_TYPELESS, SLANG_SCALAR_TYPE_UINT8, 4);
+        set(Format::R8G8_TYPELESS, SLANG_SCALAR_TYPE_UINT8, 2);
+        set(Format::R8_TYPELESS, SLANG_SCALAR_TYPE_UINT8, 1);
+        set(Format::B8G8R8A8_TYPELESS, SLANG_SCALAR_TYPE_UINT8, 4);
+
+        set(Format::R32G32B32A32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 4);
+        set(Format::R32G32B32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 3);
+        set(Format::R32G32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 2);
+        set(Format::R32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 1);
+
+        set(Format::R16G16B16A16_FLOAT, SLANG_SCALAR_TYPE_FLOAT16, 4);
+        set(Format::R16G16_FLOAT, SLANG_SCALAR_TYPE_FLOAT16, 2);
+        set(Format::R16_FLOAT, SLANG_SCALAR_TYPE_FLOAT16, 1);
+
+        set(Format::R64_UINT, SLANG_SCALAR_TYPE_UINT64, 1);
+
+        set(Format::R32G32B32A32_UINT, SLANG_SCALAR_TYPE_UINT32, 4);
+        set(Format::R32G32B32_UINT, SLANG_SCALAR_TYPE_UINT32, 3);
+        set(Format::R32G32_UINT, SLANG_SCALAR_TYPE_UINT32, 2);
+        set(Format::R32_UINT, SLANG_SCALAR_TYPE_UINT32, 1);
+
+        set(Format::R16G16B16A16_UINT, SLANG_SCALAR_TYPE_UINT16, 4);
+        set(Format::R16G16_UINT, SLANG_SCALAR_TYPE_UINT16, 2);
+        set(Format::R16_UINT, SLANG_SCALAR_TYPE_UINT16, 1);
+
+        set(Format::R8G8B8A8_UINT, SLANG_SCALAR_TYPE_UINT8, 4);
+        set(Format::R8G8_UINT, SLANG_SCALAR_TYPE_UINT8, 2);
+        set(Format::R8_UINT, SLANG_SCALAR_TYPE_UINT8, 1);
+
+        set(Format::R64_SINT, SLANG_SCALAR_TYPE_INT64, 1);
+
+        set(Format::R32G32B32A32_SINT, SLANG_SCALAR_TYPE_INT32, 4);
+        set(Format::R32G32B32_SINT, SLANG_SCALAR_TYPE_INT32, 3);
+        set(Format::R32G32_SINT, SLANG_SCALAR_TYPE_INT32, 2);
+        set(Format::R32_SINT, SLANG_SCALAR_TYPE_INT32, 1);
+
+        set(Format::R16G16B16A16_SINT, SLANG_SCALAR_TYPE_INT16, 4);
+        set(Format::R16G16_SINT, SLANG_SCALAR_TYPE_INT16, 2);
+        set(Format::R16_SINT, SLANG_SCALAR_TYPE_INT16, 1);
+
+        set(Format::R8G8B8A8_SINT, SLANG_SCALAR_TYPE_INT8, 4);
+        set(Format::R8G8_SINT, SLANG_SCALAR_TYPE_INT8, 2);
+        set(Format::R8_SINT, SLANG_SCALAR_TYPE_INT8, 1);
+
+        set(Format::R16G16B16A16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+        set(Format::R16G16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 2);
+        set(Format::R16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
+
+        set(Format::R8G8B8A8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+        set(Format::R8G8B8A8_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4);
+        set(Format::R8G8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 2);
+        set(Format::R8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
+        set(Format::B8G8R8A8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+        set(Format::B8G8R8A8_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4);
+        set(Format::B8G8R8X8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+        set(Format::B8G8R8X8_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4);
+
+        set(Format::R16G16B16A16_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+        set(Format::R16G16_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 2);
+        set(Format::R16_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
+
+        set(Format::R8G8B8A8_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+        set(Format::R8G8_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 2);
+        set(Format::R8_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
+
+        set(Format::D32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 1);
+        set(Format::D16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
+        set(Format::D32_FLOAT_S8_UINT, SLANG_SCALAR_TYPE_FLOAT32, 2);
+        set(Format::R32_FLOAT_X32_TYPELESS, SLANG_SCALAR_TYPE_FLOAT32, 2);
+
+        set(Format::B4G4R4A4_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+        set(Format::B5G6R5_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 3);
+        set(Format::B5G5R5A1_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+
+        set(Format::R9G9B9E5_SHAREDEXP, SLANG_SCALAR_TYPE_FLOAT32, 3);
+        set(Format::R10G10B10A2_TYPELESS, SLANG_SCALAR_TYPE_FLOAT32, 4);
+        set(Format::R10G10B10A2_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
+        set(Format::R10G10B10A2_UINT, SLANG_SCALAR_TYPE_UINT32, 4);
+        set(Format::R11G11B10_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 3);
+
+        set(Format::BC1_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
+        set(Format::BC1_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
+        set(Format::BC2_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
+        set(Format::BC2_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
+        set(Format::BC3_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
+        set(Format::BC3_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
+        set(Format::BC4_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1, 4, 4);
+        set(Format::BC4_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 1, 4, 4);
+        set(Format::BC5_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 2, 4, 4);
+        set(Format::BC5_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 2, 4, 4);
+        set(Format::BC6H_UF16, SLANG_SCALAR_TYPE_FLOAT32, 3, 4, 4);
+        set(Format::BC6H_SF16, SLANG_SCALAR_TYPE_FLOAT32, 3, 4, 4);
+        set(Format::BC7_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
+        set(Format::BC7_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
     }
 
-    // We don't make static because we will get a warning that it's unused
-    static const bool _checkFormatResult = _checkFormat();
-
-    struct FormatInfoMap
+    void set(
+        Format format,
+        SlangScalarType type,
+        Index channelCount,
+        uint32_t blockWidth = 1,
+        uint32_t blockHeight = 1)
     {
-        FormatInfoMap()
-        {
-            // Set all to nothing initially
-            for (auto& info : m_infos)
-            {
-                info.channelCount = 0;
-                info.channelType = SLANG_SCALAR_TYPE_NONE;
-            }
+        FormatInfo& info = m_infos[Index(format)];
+        info.channelCount = uint8_t(channelCount);
+        info.channelType = uint8_t(type);
 
-            set(Format::R32G32B32A32_TYPELESS, SLANG_SCALAR_TYPE_UINT32, 4);
-            set(Format::R32G32B32_TYPELESS, SLANG_SCALAR_TYPE_UINT32, 3);
-            set(Format::R32G32_TYPELESS, SLANG_SCALAR_TYPE_UINT32, 2);
-            set(Format::R32_TYPELESS, SLANG_SCALAR_TYPE_UINT32, 1);
-
-            set(Format::R16G16B16A16_TYPELESS, SLANG_SCALAR_TYPE_UINT16, 4);
-            set(Format::R16G16_TYPELESS, SLANG_SCALAR_TYPE_UINT16, 2);
-            set(Format::R16_TYPELESS, SLANG_SCALAR_TYPE_UINT16, 1);
-
-            set(Format::R8G8B8A8_TYPELESS, SLANG_SCALAR_TYPE_UINT8, 4);
-            set(Format::R8G8_TYPELESS, SLANG_SCALAR_TYPE_UINT8, 2);
-            set(Format::R8_TYPELESS, SLANG_SCALAR_TYPE_UINT8, 1);
-            set(Format::B8G8R8A8_TYPELESS, SLANG_SCALAR_TYPE_UINT8, 4);
-
-            set(Format::R32G32B32A32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 4);
-            set(Format::R32G32B32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 3);
-            set(Format::R32G32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 2);
-            set(Format::R32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 1);
-
-            set(Format::R16G16B16A16_FLOAT, SLANG_SCALAR_TYPE_FLOAT16, 4);
-            set(Format::R16G16_FLOAT, SLANG_SCALAR_TYPE_FLOAT16, 2);
-            set(Format::R16_FLOAT, SLANG_SCALAR_TYPE_FLOAT16, 1);
-
-            set(Format::R64_UINT, SLANG_SCALAR_TYPE_UINT64, 1);
-
-            set(Format::R32G32B32A32_UINT, SLANG_SCALAR_TYPE_UINT32, 4);
-            set(Format::R32G32B32_UINT, SLANG_SCALAR_TYPE_UINT32, 3);
-            set(Format::R32G32_UINT, SLANG_SCALAR_TYPE_UINT32, 2);
-            set(Format::R32_UINT, SLANG_SCALAR_TYPE_UINT32, 1);
-
-            set(Format::R16G16B16A16_UINT, SLANG_SCALAR_TYPE_UINT16, 4);
-            set(Format::R16G16_UINT, SLANG_SCALAR_TYPE_UINT16, 2);
-            set(Format::R16_UINT, SLANG_SCALAR_TYPE_UINT16, 1);
-
-            set(Format::R8G8B8A8_UINT, SLANG_SCALAR_TYPE_UINT8, 4);
-            set(Format::R8G8_UINT, SLANG_SCALAR_TYPE_UINT8, 2);
-            set(Format::R8_UINT, SLANG_SCALAR_TYPE_UINT8, 1);
-
-            set(Format::R64_SINT, SLANG_SCALAR_TYPE_INT64, 1);
-
-            set(Format::R32G32B32A32_SINT, SLANG_SCALAR_TYPE_INT32, 4);
-            set(Format::R32G32B32_SINT, SLANG_SCALAR_TYPE_INT32, 3);
-            set(Format::R32G32_SINT, SLANG_SCALAR_TYPE_INT32, 2);
-            set(Format::R32_SINT, SLANG_SCALAR_TYPE_INT32, 1);
-
-            set(Format::R16G16B16A16_SINT, SLANG_SCALAR_TYPE_INT16, 4);
-            set(Format::R16G16_SINT, SLANG_SCALAR_TYPE_INT16, 2);
-            set(Format::R16_SINT, SLANG_SCALAR_TYPE_INT16, 1);
-
-            set(Format::R8G8B8A8_SINT, SLANG_SCALAR_TYPE_INT8, 4);
-            set(Format::R8G8_SINT, SLANG_SCALAR_TYPE_INT8, 2);
-            set(Format::R8_SINT, SLANG_SCALAR_TYPE_INT8, 1);
-
-            set(Format::R16G16B16A16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-            set(Format::R16G16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 2);
-            set(Format::R16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
-
-            set(Format::R8G8B8A8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-            set(Format::R8G8B8A8_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4);
-            set(Format::R8G8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 2);
-            set(Format::R8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
-            set(Format::B8G8R8A8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-            set(Format::B8G8R8A8_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4);
-            set(Format::B8G8R8X8_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-            set(Format::B8G8R8X8_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4);
-
-            set(Format::R16G16B16A16_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-            set(Format::R16G16_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 2);
-            set(Format::R16_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
-
-            set(Format::R8G8B8A8_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-            set(Format::R8G8_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 2);
-            set(Format::R8_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
-
-            set(Format::D32_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 1);
-            set(Format::D16_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1);
-            set(Format::D32_FLOAT_S8_UINT, SLANG_SCALAR_TYPE_FLOAT32, 2);
-            set(Format::R32_FLOAT_X32_TYPELESS, SLANG_SCALAR_TYPE_FLOAT32, 2);
-
-            set(Format::B4G4R4A4_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-            set(Format::B5G6R5_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 3);
-            set(Format::B5G5R5A1_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-
-            set(Format::R9G9B9E5_SHAREDEXP, SLANG_SCALAR_TYPE_FLOAT32, 3);
-            set(Format::R10G10B10A2_TYPELESS, SLANG_SCALAR_TYPE_FLOAT32, 4);
-            set(Format::R10G10B10A2_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4);
-            set(Format::R10G10B10A2_UINT, SLANG_SCALAR_TYPE_UINT32, 4);
-            set(Format::R11G11B10_FLOAT, SLANG_SCALAR_TYPE_FLOAT32, 3);
-
-            set(Format::BC1_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
-            set(Format::BC1_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
-            set(Format::BC2_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
-            set(Format::BC2_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
-            set(Format::BC3_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
-            set(Format::BC3_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
-            set(Format::BC4_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 1, 4, 4);
-            set(Format::BC4_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 1, 4, 4);
-            set(Format::BC5_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 2, 4, 4);
-            set(Format::BC5_SNORM, SLANG_SCALAR_TYPE_FLOAT32, 2, 4, 4);
-            set(Format::BC6H_UF16, SLANG_SCALAR_TYPE_FLOAT32, 3, 4, 4);
-            set(Format::BC6H_SF16, SLANG_SCALAR_TYPE_FLOAT32, 3, 4, 4);
-            set(Format::BC7_UNORM, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
-            set(Format::BC7_UNORM_SRGB, SLANG_SCALAR_TYPE_FLOAT32, 4, 4, 4);
-        }
-
-        void set(
-            Format format,
-            SlangScalarType type,
-            Index channelCount,
-            uint32_t blockWidth = 1,
-            uint32_t blockHeight = 1)
-        {
-            FormatInfo& info = m_infos[Index(format)];
-            info.channelCount = uint8_t(channelCount);
-            info.channelType = uint8_t(type);
-
-            auto sizeInfo = s_formatSizeInfo[Index(format)];
-            info.blockSizeInBytes = sizeInfo[0];
-            info.pixelsPerBlock = sizeInfo[1];
-            info.blockWidth = blockWidth;
-            info.blockHeight = blockHeight;
-        }
-
-        const FormatInfo& get(Format format) const { return m_infos[Index(format)]; }
-
-        FormatInfo m_infos[Index(Format::_Count)];
-    };
-
-    static const FormatInfoMap s_formatInfoMap;
-
-    static void _compileTimeAsserts()
-    {
-        SLANG_COMPILE_TIME_ASSERT(SLANG_COUNT_OF(s_formatSizeInfo) == int(Format::_Count));
+        auto sizeInfo = s_formatSizeInfo[Index(format)];
+        info.blockSizeInBytes = sizeInfo[0];
+        info.pixelsPerBlock = sizeInfo[1];
+        info.blockWidth = blockWidth;
+        info.blockHeight = blockHeight;
     }
 
-    extern "C"
+    const FormatInfo& get(Format format) const { return m_infos[Index(format)]; }
+
+    FormatInfo m_infos[Index(Format::_Count)];
+};
+
+static const FormatInfoMap s_formatInfoMap;
+
+static void _compileTimeAsserts()
+{
+    SLANG_COMPILE_TIME_ASSERT(SLANG_COUNT_OF(s_formatSizeInfo) == int(Format::_Count));
+}
+
+extern "C"
+{
+    SLANG_GFX_API bool SLANG_MCALL gfxIsCompressedFormat(Format format)
     {
-        SLANG_GFX_API bool SLANG_MCALL gfxIsCompressedFormat(Format format)
+        switch (format)
         {
-            switch (format)
-            {
-            case Format::BC1_UNORM:
-            case Format::BC1_UNORM_SRGB:
-            case Format::BC2_UNORM:
-            case Format::BC2_UNORM_SRGB:
-            case Format::BC3_UNORM:
-            case Format::BC3_UNORM_SRGB:
-            case Format::BC4_UNORM:
-            case Format::BC4_SNORM:
-            case Format::BC5_UNORM:
-            case Format::BC5_SNORM:
-            case Format::BC6H_UF16:
-            case Format::BC6H_SF16:
-            case Format::BC7_UNORM:
-            case Format::BC7_UNORM_SRGB:
-                return true;
-            default:
-                return false;
-            }
+        case Format::BC1_UNORM:
+        case Format::BC1_UNORM_SRGB:
+        case Format::BC2_UNORM:
+        case Format::BC2_UNORM_SRGB:
+        case Format::BC3_UNORM:
+        case Format::BC3_UNORM_SRGB:
+        case Format::BC4_UNORM:
+        case Format::BC4_SNORM:
+        case Format::BC5_UNORM:
+        case Format::BC5_SNORM:
+        case Format::BC6H_UF16:
+        case Format::BC6H_SF16:
+        case Format::BC7_UNORM:
+        case Format::BC7_UNORM_SRGB:
+            return true;
+        default:
+            return false;
         }
+    }
 
-        SLANG_GFX_API bool SLANG_MCALL gfxIsTypelessFormat(Format format)
+    SLANG_GFX_API bool SLANG_MCALL gfxIsTypelessFormat(Format format)
+    {
+        switch (format)
         {
-            switch (format)
-            {
-            case Format::R32G32B32A32_TYPELESS:
-            case Format::R32G32B32_TYPELESS:
-            case Format::R32G32_TYPELESS:
-            case Format::R32_TYPELESS:
-            case Format::R16G16B16A16_TYPELESS:
-            case Format::R16G16_TYPELESS:
-            case Format::R16_TYPELESS:
-            case Format::R8G8B8A8_TYPELESS:
-            case Format::R8G8_TYPELESS:
-            case Format::R8_TYPELESS:
-            case Format::B8G8R8A8_TYPELESS:
-            case Format::R10G10B10A2_TYPELESS:
-                return true;
-            default:
-                return false;
-            }
+        case Format::R32G32B32A32_TYPELESS:
+        case Format::R32G32B32_TYPELESS:
+        case Format::R32G32_TYPELESS:
+        case Format::R32_TYPELESS:
+        case Format::R16G16B16A16_TYPELESS:
+        case Format::R16G16_TYPELESS:
+        case Format::R16_TYPELESS:
+        case Format::R8G8B8A8_TYPELESS:
+        case Format::R8G8_TYPELESS:
+        case Format::R8_TYPELESS:
+        case Format::B8G8R8A8_TYPELESS:
+        case Format::R10G10B10A2_TYPELESS:
+            return true;
+        default:
+            return false;
         }
+    }
 
-        SLANG_GFX_API SlangResult SLANG_MCALL gfxGetFormatInfo(Format format, FormatInfo* outInfo)
+    SLANG_GFX_API SlangResult SLANG_MCALL gfxGetFormatInfo(Format format, FormatInfo* outInfo)
+    {
+        *outInfo = s_formatInfoMap.get(format);
+        return SLANG_OK;
+    }
+
+    SLANG_GFX_API SlangResult SLANG_MCALL
+    gfxGetAdapters(DeviceType type, ISlangBlob** outAdaptersBlob)
+    {
+        List<AdapterInfo> adapters;
+
+        switch (type)
         {
-            *outInfo = s_formatInfoMap.get(format);
-            return SLANG_OK;
-        }
-
-        SLANG_GFX_API SlangResult SLANG_MCALL
-            gfxGetAdapters(DeviceType type, ISlangBlob** outAdaptersBlob)
-        {
-            List<AdapterInfo> adapters;
-
-            switch (type)
-            {
 #if SLANG_ENABLE_DIRECTX
-            case DeviceType::DirectX11:
-                SLANG_RETURN_ON_FAIL(getD3D11Adapters(adapters));
-                break;
-            case DeviceType::DirectX12:
-                SLANG_RETURN_ON_FAIL(getD3D12Adapters(adapters));
-                break;
+        case DeviceType::DirectX11:
+            SLANG_RETURN_ON_FAIL(getD3D11Adapters(adapters));
+            break;
+        case DeviceType::DirectX12:
+            SLANG_RETURN_ON_FAIL(getD3D12Adapters(adapters));
+            break;
 #endif
 #if SLANG_WINDOWS_FAMILY
-            case DeviceType::OpenGl:
-                return SLANG_E_NOT_IMPLEMENTED;
+        case DeviceType::OpenGl:
+            return SLANG_E_NOT_IMPLEMENTED;
 #endif
 #if SLANG_WINDOWS_FAMILY || SLANG_LINUX_FAMILY
-                // Assume no Vulkan or CUDA on MacOS or Cygwin
-            case DeviceType::Vulkan:
-                SLANG_RETURN_ON_FAIL(getVKAdapters(adapters));
-                break;
-            case DeviceType::CUDA:
-                SLANG_RETURN_ON_FAIL(getCUDAAdapters(adapters));
-                break;
+            // Assume no Vulkan or CUDA on MacOS or Cygwin
+        case DeviceType::Vulkan:
+            SLANG_RETURN_ON_FAIL(getVKAdapters(adapters));
+            break;
+        case DeviceType::CUDA:
+            SLANG_RETURN_ON_FAIL(getCUDAAdapters(adapters));
+            break;
 #endif
 #if SLANG_APPLE_FAMILY
-            case DeviceType::Vulkan:
-                SLANG_RETURN_ON_FAIL(getVKAdapters(adapters));
-                break;
-            case DeviceType::Metal:
-                SLANG_RETURN_ON_FAIL(getMetalAdapters(adapters));
-                break;
+        case DeviceType::Vulkan:
+            SLANG_RETURN_ON_FAIL(getVKAdapters(adapters));
+            break;
+        case DeviceType::Metal:
+            SLANG_RETURN_ON_FAIL(getMetalAdapters(adapters));
+            break;
 #endif
-            case DeviceType::CPU:
-                return SLANG_E_NOT_IMPLEMENTED;
-            default:
-                return SLANG_E_INVALID_ARG;
-            }
-
-            auto adaptersBlob =
-                RawBlob::create(adapters.getBuffer(), adapters.getCount() * sizeof(AdapterInfo));
-            if (outAdaptersBlob)
-                returnComPtr(outAdaptersBlob, adaptersBlob);
-
-            return SLANG_OK;
+        case DeviceType::CPU:
+            return SLANG_E_NOT_IMPLEMENTED;
+        default:
+            return SLANG_E_INVALID_ARG;
         }
 
-        SlangResult _createDevice(const IDevice::Desc* desc, IDevice** outDevice)
+        auto adaptersBlob =
+            RawBlob::create(adapters.getBuffer(), adapters.getCount() * sizeof(AdapterInfo));
+        if (outAdaptersBlob)
+            returnComPtr(outAdaptersBlob, adaptersBlob);
+
+        return SLANG_OK;
+    }
+
+    SlangResult _createDevice(const IDevice::Desc* desc, IDevice** outDevice)
+    {
+        switch (desc->deviceType)
         {
-            switch (desc->deviceType)
-            {
 #if SLANG_ENABLE_DIRECTX
-            case DeviceType::DirectX11:
+        case DeviceType::DirectX11:
             {
                 return createD3D11Device(desc, outDevice);
             }
-            case DeviceType::DirectX12:
+        case DeviceType::DirectX12:
             {
                 return createD3D12Device(desc, outDevice);
             }
 #endif
 #if SLANG_WINDOWS_FAMILY
-            case DeviceType::OpenGl:
+        case DeviceType::OpenGl:
             {
                 return createGLDevice(desc, outDevice);
             }
-            case DeviceType::Vulkan:
+        case DeviceType::Vulkan:
             {
                 return createVKDevice(desc, outDevice);
             }
-            case DeviceType::Default:
+        case DeviceType::Default:
             {
                 IDevice::Desc newDesc = *desc;
                 newDesc.deviceType = DeviceType::DirectX12;
@@ -354,15 +354,15 @@ namespace gfx
             }
             break;
 #elif SLANG_APPLE_FAMILY
-            case DeviceType::Vulkan:
+        case DeviceType::Vulkan:
             {
                 return createVKDevice(desc, outDevice);
             }
-            case DeviceType::Metal:
+        case DeviceType::Metal:
             {
                 return createMetalDevice(desc, outDevice);
             }
-            case DeviceType::Default:
+        case DeviceType::Default:
             {
                 IDevice::Desc newDesc = *desc;
                 newDesc.deviceType = DeviceType::Metal;
@@ -374,11 +374,11 @@ namespace gfx
                 return SLANG_FAIL;
             }
 #elif SLANG_LINUX_FAMILY && !defined(__CYGWIN__)
-            case DeviceType::Vulkan:
+        case DeviceType::Vulkan:
             {
                 return createVKDevice(desc, outDevice);
             }
-            case DeviceType::Default:
+        case DeviceType::Default:
             {
                 IDevice::Desc newDesc = *desc;
                 newDesc.deviceType = DeviceType::Vulkan;
@@ -387,109 +387,109 @@ namespace gfx
                 return SLANG_FAIL;
             }
 #endif
-            case DeviceType::CUDA:
+        case DeviceType::CUDA:
             {
                 return createCUDADevice(desc, outDevice);
             }
-            case DeviceType::CPU:
+        case DeviceType::CPU:
             {
                 return createCPUDevice(desc, outDevice);
             }
             break;
 
-            default:
-                return SLANG_FAIL;
-            }
+        default:
+            return SLANG_FAIL;
         }
+    }
 
-        SLANG_GFX_API SlangResult SLANG_MCALL
-            gfxCreateDevice(const IDevice::Desc* desc, IDevice** outDevice)
+    SLANG_GFX_API SlangResult SLANG_MCALL
+    gfxCreateDevice(const IDevice::Desc* desc, IDevice** outDevice)
+    {
+        ComPtr<IDevice> innerDevice;
+        auto resultCode = _createDevice(desc, innerDevice.writeRef());
+        if (SLANG_FAILED(resultCode))
+            return resultCode;
+        if (!debugLayerEnabled)
         {
-            ComPtr<IDevice> innerDevice;
-            auto resultCode = _createDevice(desc, innerDevice.writeRef());
-            if (SLANG_FAILED(resultCode))
-                return resultCode;
-            if (!debugLayerEnabled)
-            {
-                returnComPtr(outDevice, innerDevice);
-                return resultCode;
-            }
-            RefPtr<debug::DebugDevice> debugDevice = new debug::DebugDevice();
-            debugDevice->baseObject = innerDevice;
-            returnComPtr(outDevice, debugDevice);
+            returnComPtr(outDevice, innerDevice);
             return resultCode;
         }
+        RefPtr<debug::DebugDevice> debugDevice = new debug::DebugDevice();
+        debugDevice->baseObject = innerDevice;
+        returnComPtr(outDevice, debugDevice);
+        return resultCode;
+    }
 
-        SLANG_GFX_API SlangResult SLANG_MCALL gfxReportLiveObjects()
-        {
+    SLANG_GFX_API SlangResult SLANG_MCALL gfxReportLiveObjects()
+    {
 #if SLANG_ENABLE_DIRECTX
-            SLANG_RETURN_ON_FAIL(reportD3DLiveObjects());
+        SLANG_RETURN_ON_FAIL(reportD3DLiveObjects());
 #endif
-            return SLANG_OK;
-        }
+        return SLANG_OK;
+    }
 
-        SLANG_GFX_API SlangResult SLANG_MCALL gfxSetDebugCallback(IDebugCallback* callback)
-        {
-            _getDebugCallback() = callback;
-            return SLANG_OK;
-        }
+    SLANG_GFX_API SlangResult SLANG_MCALL gfxSetDebugCallback(IDebugCallback* callback)
+    {
+        _getDebugCallback() = callback;
+        return SLANG_OK;
+    }
 
-        SLANG_GFX_API void SLANG_MCALL gfxEnableDebugLayer(bool enable)
-        {
-            debugLayerEnabled = enable;
-        }
+    SLANG_GFX_API void SLANG_MCALL gfxEnableDebugLayer(bool enable)
+    {
+        debugLayerEnabled = enable;
+    }
 
-        const char* SLANG_MCALL gfxGetDeviceTypeName(DeviceType type)
+    const char* SLANG_MCALL gfxGetDeviceTypeName(DeviceType type)
+    {
+        switch (type)
         {
-            switch (type)
+        case gfx::DeviceType::Unknown:
+            return "Unknown";
+        case gfx::DeviceType::Default:
+            return "Default";
+        case gfx::DeviceType::DirectX11:
+            return "DirectX11";
+        case gfx::DeviceType::DirectX12:
+            return "DirectX12";
+        case gfx::DeviceType::OpenGl:
+            return "OpenGL";
+        case gfx::DeviceType::Vulkan:
+            return "Vulkan";
+        case gfx::DeviceType::Metal:
+            return "Metal";
+        case gfx::DeviceType::CPU:
+            return "CPU";
+        case gfx::DeviceType::CUDA:
+            return "CUDA";
+        default:
+            return "?";
+        }
+    }
+
+
+    void SLANG_MCALL gfxGetIdentityProjection(ProjectionStyle style, float projMatrix[16])
+    {
+        switch (style)
+        {
+        case ProjectionStyle::DirectX:
+        case ProjectionStyle::OpenGl:
             {
-            case gfx::DeviceType::Unknown:
-                return "Unknown";
-            case gfx::DeviceType::Default:
-                return "Default";
-            case gfx::DeviceType::DirectX11:
-                return "DirectX11";
-            case gfx::DeviceType::DirectX12:
-                return "DirectX12";
-            case gfx::DeviceType::OpenGl:
-                return "OpenGL";
-            case gfx::DeviceType::Vulkan:
-                return "Vulkan";
-            case gfx::DeviceType::Metal:
-                return "Metal";
-            case gfx::DeviceType::CPU:
-                return "CPU";
-            case gfx::DeviceType::CUDA:
-                return "CUDA";
-            default:
-                return "?";
-            }
-        }
-
-
-        void SLANG_MCALL gfxGetIdentityProjection(ProjectionStyle style, float projMatrix[16])
-        {
-            switch (style)
-            {
-            case ProjectionStyle::DirectX:
-            case ProjectionStyle::OpenGl:
-            {
-                static const float kIdentity[] = { 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 };
+                static const float kIdentity[] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
                 ::memcpy(projMatrix, kIdentity, sizeof(kIdentity));
                 break;
             }
-            case ProjectionStyle::Vulkan:
+        case ProjectionStyle::Vulkan:
             {
-                static const float kIdentity[] = { 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 };
+                static const float kIdentity[] = {1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
                 ::memcpy(projMatrix, kIdentity, sizeof(kIdentity));
                 break;
             }
-            default:
+        default:
             {
                 assert(!"Not handled");
             }
-            }
         }
     }
+}
 
 } // namespace gfx

--- a/tools/gfx/vulkan/vk-device.cpp
+++ b/tools/gfx/vulkan/vk-device.cpp
@@ -214,7 +214,7 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
 #endif
         }
 
-        gfxSetDebugLayerEnabled(useValidationLayer);
+        gfxEnableDebugLayer(useValidationLayer);
         if (isGfxDebugLayerEnabled())
             instanceExtensions.add(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
 

--- a/tools/gfx/vulkan/vk-device.cpp
+++ b/tools/gfx/vulkan/vk-device.cpp
@@ -214,7 +214,8 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
 #endif
         }
 
-        if (ENABLE_VALIDATION_LAYER || isGfxDebugLayerEnabled())
+        gfxSetDebugLayerEnabled(useValidationLayer);
+        if (isGfxDebugLayerEnabled())
             instanceExtensions.add(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
 
         VkInstanceCreateInfo instanceCreateInfo = {VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
@@ -1027,7 +1028,7 @@ SlangResult DeviceImpl::initialize(const Desc& desc)
         descriptorSetAllocator.m_api = &m_api;
         initDeviceResult = initVulkanInstanceAndDevice(
             desc.existingDeviceHandles.handles,
-            ENABLE_VALIDATION_LAYER != 0 || isGfxDebugLayerEnabled());
+            isGfxDebugLayerEnabled());
         if (initDeviceResult == SLANG_OK)
             break;
     }

--- a/tools/gfx/vulkan/vk-helper-functions.h
+++ b/tools/gfx/vulkan/vk-helper-functions.h
@@ -23,158 +23,158 @@
 namespace gfx
 {
 
-    using namespace Slang;
+using namespace Slang;
 
-    namespace vk
+namespace vk
+{
+
+// In order to bind shader parameters to the correct locations, we need to
+// be able to describe those locations. Most shader parameters in Vulkan
+// simply consume a single `binding`, but we also need to deal with
+// parameters that represent push-constant ranges.
+//
+// In more complex cases we might be binding an entire "sub-object" like
+// a parameter block, an entry point, etc. For the general case, we need
+// to be able to represent a composite offset that includes offsets for
+// each of the cases that Vulkan supports.
+
+/// A "simple" binding offset that records `binding`, `set`, etc. offsets
+struct SimpleBindingOffset
+{
+    /// An offset in GLSL/SPIR-V `binding`s
+    uint32_t binding = 0;
+
+    /// The descriptor `set` that the `binding` field should be understood as an index into
+    uint32_t bindingSet = 0;
+
+    /// The offset in push-constant ranges (not bytes)
+    uint32_t pushConstantRange = 0;
+
+    /// Create a default (zero) offset
+    SimpleBindingOffset() {}
+
+    /// Create an offset based on offset information in the given Slang `varLayout`
+    SimpleBindingOffset(slang::VariableLayoutReflection* varLayout)
     {
-
-        // In order to bind shader parameters to the correct locations, we need to
-        // be able to describe those locations. Most shader parameters in Vulkan
-        // simply consume a single `binding`, but we also need to deal with
-        // parameters that represent push-constant ranges.
-        //
-        // In more complex cases we might be binding an entire "sub-object" like
-        // a parameter block, an entry point, etc. For the general case, we need
-        // to be able to represent a composite offset that includes offsets for
-        // each of the cases that Vulkan supports.
-
-        /// A "simple" binding offset that records `binding`, `set`, etc. offsets
-        struct SimpleBindingOffset
+        if (varLayout)
         {
-            /// An offset in GLSL/SPIR-V `binding`s
-            uint32_t binding = 0;
+            bindingSet = (uint32_t)varLayout->getBindingSpace(
+                SLANG_PARAMETER_CATEGORY_DESCRIPTOR_TABLE_SLOT);
+            binding =
+                (uint32_t)varLayout->getOffset(SLANG_PARAMETER_CATEGORY_DESCRIPTOR_TABLE_SLOT);
+            pushConstantRange =
+                (uint32_t)varLayout->getOffset(SLANG_PARAMETER_CATEGORY_PUSH_CONSTANT_BUFFER);
+        }
+    }
 
-            /// The descriptor `set` that the `binding` field should be understood as an index into
-            uint32_t bindingSet = 0;
+    /// Add any values in the given `offset`
+    void operator+=(SimpleBindingOffset const& offset)
+    {
+        binding += offset.binding;
+        bindingSet += offset.bindingSet;
+        pushConstantRange += offset.pushConstantRange;
+    }
+};
 
-            /// The offset in push-constant ranges (not bytes)
-            uint32_t pushConstantRange = 0;
+// While a "simple" binding offset representation will work in many cases,
+// once we need to deal with layout for programs with interface-type parameters
+// that have been statically specialized, we also need to track the offset
+// for where to bind any "pending" data that arises from the process of static
+// specialization.
+//
+// In order to conveniently track both the "primary" and "pending" offset information,
+// we will define a more complete `BindingOffset` type that combines simple
+// binding offsets for the primary and pending parts.
 
-            /// Create a default (zero) offset
-            SimpleBindingOffset() {}
+/// A representation of the offset at which to bind a shader parameter or sub-object
+struct BindingOffset : SimpleBindingOffset
+{
+    // Offsets for "primary" data are stored directly in the `BindingOffset`
+    // via the inheritance from `SimpleBindingOffset`.
 
-            /// Create an offset based on offset information in the given Slang `varLayout`
-            SimpleBindingOffset(slang::VariableLayoutReflection* varLayout)
-            {
-                if (varLayout)
-                {
-                    bindingSet = (uint32_t)varLayout->getBindingSpace(
-                        SLANG_PARAMETER_CATEGORY_DESCRIPTOR_TABLE_SLOT);
-                    binding =
-                        (uint32_t)varLayout->getOffset(SLANG_PARAMETER_CATEGORY_DESCRIPTOR_TABLE_SLOT);
-                    pushConstantRange =
-                        (uint32_t)varLayout->getOffset(SLANG_PARAMETER_CATEGORY_PUSH_CONSTANT_BUFFER);
-                }
-            }
+    /// Offset for any "pending" data
+    SimpleBindingOffset pending;
 
-            /// Add any values in the given `offset`
-            void operator+=(SimpleBindingOffset const& offset)
-            {
-                binding += offset.binding;
-                bindingSet += offset.bindingSet;
-                pushConstantRange += offset.pushConstantRange;
-            }
-        };
+    /// Create a default (zero) offset
+    BindingOffset() {}
 
-        // While a "simple" binding offset representation will work in many cases,
-        // once we need to deal with layout for programs with interface-type parameters
-        // that have been statically specialized, we also need to track the offset
-        // for where to bind any "pending" data that arises from the process of static
-        // specialization.
-        //
-        // In order to conveniently track both the "primary" and "pending" offset information,
-        // we will define a more complete `BindingOffset` type that combines simple
-        // binding offsets for the primary and pending parts.
+    /// Create an offset from a simple offset
+    explicit BindingOffset(SimpleBindingOffset const& offset)
+        : SimpleBindingOffset(offset)
+    {
+    }
 
-        /// A representation of the offset at which to bind a shader parameter or sub-object
-        struct BindingOffset : SimpleBindingOffset
-        {
-            // Offsets for "primary" data are stored directly in the `BindingOffset`
-            // via the inheritance from `SimpleBindingOffset`.
+    /// Create an offset based on offset information in the given Slang `varLayout`
+    BindingOffset(slang::VariableLayoutReflection* varLayout)
+        : SimpleBindingOffset(varLayout), pending(varLayout->getPendingDataLayout())
+    {
+    }
 
-            /// Offset for any "pending" data
-            SimpleBindingOffset pending;
+    /// Add any values in the given `offset`
+    void operator+=(SimpleBindingOffset const& offset) { SimpleBindingOffset::operator+=(offset); }
 
-            /// Create a default (zero) offset
-            BindingOffset() {}
+    /// Add any values in the given `offset`
+    void operator+=(BindingOffset const& offset)
+    {
+        SimpleBindingOffset::operator+=(offset);
+        pending += offset.pending;
+    }
+};
 
-            /// Create an offset from a simple offset
-            explicit BindingOffset(SimpleBindingOffset const& offset)
-                : SimpleBindingOffset(offset)
-            {
-            }
+/// Context information required when binding shader objects to the pipeline
+struct RootBindingContext
+{
+    /// The pipeline layout being used for binding
+    VkPipelineLayout pipelineLayout;
 
-            /// Create an offset based on offset information in the given Slang `varLayout`
-            BindingOffset(slang::VariableLayoutReflection* varLayout)
-                : SimpleBindingOffset(varLayout), pending(varLayout->getPendingDataLayout())
-            {
-            }
+    /// An allocator to use for descriptor sets during binding
+    DescriptorSetAllocator* descriptorSetAllocator;
 
-            /// Add any values in the given `offset`
-            void operator+=(SimpleBindingOffset const& offset) { SimpleBindingOffset::operator+=(offset); }
+    /// The device being used
+    DeviceImpl* device;
 
-            /// Add any values in the given `offset`
-            void operator+=(BindingOffset const& offset)
-            {
-                SimpleBindingOffset::operator+=(offset);
-                pending += offset.pending;
-            }
-        };
+    /// The descriptor sets that are being allocated and bound
+    List<VkDescriptorSet>* descriptorSets;
 
-        /// Context information required when binding shader objects to the pipeline
-        struct RootBindingContext
-        {
-            /// The pipeline layout being used for binding
-            VkPipelineLayout pipelineLayout;
+    /// Information about all the push-constant ranges that should be bound
+    ConstArrayView<VkPushConstantRange> pushConstantRanges;
+};
 
-            /// An allocator to use for descriptor sets during binding
-            DescriptorSetAllocator* descriptorSetAllocator;
+Size calcRowSize(Format format, int width);
+GfxCount calcNumRows(Format format, int height);
 
-            /// The device being used
-            DeviceImpl* device;
+VkAttachmentLoadOp translateLoadOp(IRenderPassLayout::TargetLoadOp loadOp);
+VkAttachmentStoreOp translateStoreOp(IRenderPassLayout::TargetStoreOp storeOp);
+VkPipelineCreateFlags translateRayTracingPipelineFlags(RayTracingPipelineFlags::Enum flags);
 
-            /// The descriptor sets that are being allocated and bound
-            List<VkDescriptorSet>* descriptorSets;
+uint32_t getMipLevelSize(uint32_t mipLevel, uint32_t size);
+VkImageLayout translateImageLayout(ResourceState state);
 
-            /// Information about all the push-constant ranges that should be bound
-            ConstArrayView<VkPushConstantRange> pushConstantRanges;
-        };
+VkAccessFlagBits calcAccessFlags(ResourceState state);
+VkPipelineStageFlagBits calcPipelineStageFlags(ResourceState state, bool src);
+VkAccessFlags translateAccelerationStructureAccessFlag(AccessFlag access);
 
-        Size calcRowSize(Format format, int width);
-        GfxCount calcNumRows(Format format, int height);
+VkBufferUsageFlagBits _calcBufferUsageFlags(ResourceState state);
+VkBufferUsageFlagBits _calcBufferUsageFlags(ResourceStateSet states);
+VkImageUsageFlagBits _calcImageUsageFlags(ResourceState state);
+VkImageViewType _calcImageViewType(ITextureResource::Type type, const ITextureResource::Desc& desc);
+VkImageUsageFlagBits _calcImageUsageFlags(ResourceStateSet states);
+VkImageUsageFlags _calcImageUsageFlags(
+    ResourceStateSet states,
+    MemoryType memoryType,
+    const void* initData);
 
-        VkAttachmentLoadOp translateLoadOp(IRenderPassLayout::TargetLoadOp loadOp);
-        VkAttachmentStoreOp translateStoreOp(IRenderPassLayout::TargetStoreOp storeOp);
-        VkPipelineCreateFlags translateRayTracingPipelineFlags(RayTracingPipelineFlags::Enum flags);
+VkAccessFlags calcAccessFlagsFromImageLayout(VkImageLayout layout);
+VkPipelineStageFlags calcPipelineStageFlagsFromImageLayout(VkImageLayout layout);
 
-        uint32_t getMipLevelSize(uint32_t mipLevel, uint32_t size);
-        VkImageLayout translateImageLayout(ResourceState state);
+VkImageAspectFlags getAspectMaskFromFormat(VkFormat format);
 
-        VkAccessFlagBits calcAccessFlags(ResourceState state);
-        VkPipelineStageFlagBits calcPipelineStageFlags(ResourceState state, bool src);
-        VkAccessFlags translateAccelerationStructureAccessFlag(AccessFlag access);
+AdapterLUID getAdapterLUID(VulkanApi api, VkPhysicalDevice physicaDevice);
 
-        VkBufferUsageFlagBits _calcBufferUsageFlags(ResourceState state);
-        VkBufferUsageFlagBits _calcBufferUsageFlags(ResourceStateSet states);
-        VkImageUsageFlagBits _calcImageUsageFlags(ResourceState state);
-        VkImageViewType _calcImageViewType(ITextureResource::Type type, const ITextureResource::Desc& desc);
-        VkImageUsageFlagBits _calcImageUsageFlags(ResourceStateSet states);
-        VkImageUsageFlags _calcImageUsageFlags(
-            ResourceStateSet states,
-            MemoryType memoryType,
-            const void* initData);
+} // namespace vk
 
-        VkAccessFlags calcAccessFlagsFromImageLayout(VkImageLayout layout);
-        VkPipelineStageFlags calcPipelineStageFlagsFromImageLayout(VkImageLayout layout);
+Result SLANG_MCALL getVKAdapters(List<AdapterInfo>& outAdapters);
 
-        VkImageAspectFlags getAspectMaskFromFormat(VkFormat format);
-
-        AdapterLUID getAdapterLUID(VulkanApi api, VkPhysicalDevice physicaDevice);
-
-    } // namespace vk
-
-    Result SLANG_MCALL getVKAdapters(List<AdapterInfo>& outAdapters);
-
-    Result SLANG_MCALL createVKDevice(const IDevice::Desc* desc, IDevice** outRenderer);
+Result SLANG_MCALL createVKDevice(const IDevice::Desc* desc, IDevice** outRenderer);
 
 } // namespace gfx

--- a/tools/gfx/vulkan/vk-helper-functions.h
+++ b/tools/gfx/vulkan/vk-helper-functions.h
@@ -7,13 +7,6 @@
 
 // Vulkan has a different coordinate system to ogl
 // http://anki3d.org/vulkan-coordinate-system/
-#ifndef ENABLE_VALIDATION_LAYER
-#if _DEBUG
-#define ENABLE_VALIDATION_LAYER 1
-#else
-#define ENABLE_VALIDATION_LAYER 0
-#endif
-#endif
 
 #ifdef _MSC_VER
 #include <stddef.h>
@@ -30,158 +23,158 @@
 namespace gfx
 {
 
-using namespace Slang;
+    using namespace Slang;
 
-namespace vk
-{
-
-// In order to bind shader parameters to the correct locations, we need to
-// be able to describe those locations. Most shader parameters in Vulkan
-// simply consume a single `binding`, but we also need to deal with
-// parameters that represent push-constant ranges.
-//
-// In more complex cases we might be binding an entire "sub-object" like
-// a parameter block, an entry point, etc. For the general case, we need
-// to be able to represent a composite offset that includes offsets for
-// each of the cases that Vulkan supports.
-
-/// A "simple" binding offset that records `binding`, `set`, etc. offsets
-struct SimpleBindingOffset
-{
-    /// An offset in GLSL/SPIR-V `binding`s
-    uint32_t binding = 0;
-
-    /// The descriptor `set` that the `binding` field should be understood as an index into
-    uint32_t bindingSet = 0;
-
-    /// The offset in push-constant ranges (not bytes)
-    uint32_t pushConstantRange = 0;
-
-    /// Create a default (zero) offset
-    SimpleBindingOffset() {}
-
-    /// Create an offset based on offset information in the given Slang `varLayout`
-    SimpleBindingOffset(slang::VariableLayoutReflection* varLayout)
+    namespace vk
     {
-        if (varLayout)
+
+        // In order to bind shader parameters to the correct locations, we need to
+        // be able to describe those locations. Most shader parameters in Vulkan
+        // simply consume a single `binding`, but we also need to deal with
+        // parameters that represent push-constant ranges.
+        //
+        // In more complex cases we might be binding an entire "sub-object" like
+        // a parameter block, an entry point, etc. For the general case, we need
+        // to be able to represent a composite offset that includes offsets for
+        // each of the cases that Vulkan supports.
+
+        /// A "simple" binding offset that records `binding`, `set`, etc. offsets
+        struct SimpleBindingOffset
         {
-            bindingSet = (uint32_t)varLayout->getBindingSpace(
-                SLANG_PARAMETER_CATEGORY_DESCRIPTOR_TABLE_SLOT);
-            binding =
-                (uint32_t)varLayout->getOffset(SLANG_PARAMETER_CATEGORY_DESCRIPTOR_TABLE_SLOT);
-            pushConstantRange =
-                (uint32_t)varLayout->getOffset(SLANG_PARAMETER_CATEGORY_PUSH_CONSTANT_BUFFER);
-        }
-    }
+            /// An offset in GLSL/SPIR-V `binding`s
+            uint32_t binding = 0;
 
-    /// Add any values in the given `offset`
-    void operator+=(SimpleBindingOffset const& offset)
-    {
-        binding += offset.binding;
-        bindingSet += offset.bindingSet;
-        pushConstantRange += offset.pushConstantRange;
-    }
-};
+            /// The descriptor `set` that the `binding` field should be understood as an index into
+            uint32_t bindingSet = 0;
 
-// While a "simple" binding offset representation will work in many cases,
-// once we need to deal with layout for programs with interface-type parameters
-// that have been statically specialized, we also need to track the offset
-// for where to bind any "pending" data that arises from the process of static
-// specialization.
-//
-// In order to conveniently track both the "primary" and "pending" offset information,
-// we will define a more complete `BindingOffset` type that combines simple
-// binding offsets for the primary and pending parts.
+            /// The offset in push-constant ranges (not bytes)
+            uint32_t pushConstantRange = 0;
 
-/// A representation of the offset at which to bind a shader parameter or sub-object
-struct BindingOffset : SimpleBindingOffset
-{
-    // Offsets for "primary" data are stored directly in the `BindingOffset`
-    // via the inheritance from `SimpleBindingOffset`.
+            /// Create a default (zero) offset
+            SimpleBindingOffset() {}
 
-    /// Offset for any "pending" data
-    SimpleBindingOffset pending;
+            /// Create an offset based on offset information in the given Slang `varLayout`
+            SimpleBindingOffset(slang::VariableLayoutReflection* varLayout)
+            {
+                if (varLayout)
+                {
+                    bindingSet = (uint32_t)varLayout->getBindingSpace(
+                        SLANG_PARAMETER_CATEGORY_DESCRIPTOR_TABLE_SLOT);
+                    binding =
+                        (uint32_t)varLayout->getOffset(SLANG_PARAMETER_CATEGORY_DESCRIPTOR_TABLE_SLOT);
+                    pushConstantRange =
+                        (uint32_t)varLayout->getOffset(SLANG_PARAMETER_CATEGORY_PUSH_CONSTANT_BUFFER);
+                }
+            }
 
-    /// Create a default (zero) offset
-    BindingOffset() {}
+            /// Add any values in the given `offset`
+            void operator+=(SimpleBindingOffset const& offset)
+            {
+                binding += offset.binding;
+                bindingSet += offset.bindingSet;
+                pushConstantRange += offset.pushConstantRange;
+            }
+        };
 
-    /// Create an offset from a simple offset
-    explicit BindingOffset(SimpleBindingOffset const& offset)
-        : SimpleBindingOffset(offset)
-    {
-    }
+        // While a "simple" binding offset representation will work in many cases,
+        // once we need to deal with layout for programs with interface-type parameters
+        // that have been statically specialized, we also need to track the offset
+        // for where to bind any "pending" data that arises from the process of static
+        // specialization.
+        //
+        // In order to conveniently track both the "primary" and "pending" offset information,
+        // we will define a more complete `BindingOffset` type that combines simple
+        // binding offsets for the primary and pending parts.
 
-    /// Create an offset based on offset information in the given Slang `varLayout`
-    BindingOffset(slang::VariableLayoutReflection* varLayout)
-        : SimpleBindingOffset(varLayout), pending(varLayout->getPendingDataLayout())
-    {
-    }
+        /// A representation of the offset at which to bind a shader parameter or sub-object
+        struct BindingOffset : SimpleBindingOffset
+        {
+            // Offsets for "primary" data are stored directly in the `BindingOffset`
+            // via the inheritance from `SimpleBindingOffset`.
 
-    /// Add any values in the given `offset`
-    void operator+=(SimpleBindingOffset const& offset) { SimpleBindingOffset::operator+=(offset); }
+            /// Offset for any "pending" data
+            SimpleBindingOffset pending;
 
-    /// Add any values in the given `offset`
-    void operator+=(BindingOffset const& offset)
-    {
-        SimpleBindingOffset::operator+=(offset);
-        pending += offset.pending;
-    }
-};
+            /// Create a default (zero) offset
+            BindingOffset() {}
 
-/// Context information required when binding shader objects to the pipeline
-struct RootBindingContext
-{
-    /// The pipeline layout being used for binding
-    VkPipelineLayout pipelineLayout;
+            /// Create an offset from a simple offset
+            explicit BindingOffset(SimpleBindingOffset const& offset)
+                : SimpleBindingOffset(offset)
+            {
+            }
 
-    /// An allocator to use for descriptor sets during binding
-    DescriptorSetAllocator* descriptorSetAllocator;
+            /// Create an offset based on offset information in the given Slang `varLayout`
+            BindingOffset(slang::VariableLayoutReflection* varLayout)
+                : SimpleBindingOffset(varLayout), pending(varLayout->getPendingDataLayout())
+            {
+            }
 
-    /// The device being used
-    DeviceImpl* device;
+            /// Add any values in the given `offset`
+            void operator+=(SimpleBindingOffset const& offset) { SimpleBindingOffset::operator+=(offset); }
 
-    /// The descriptor sets that are being allocated and bound
-    List<VkDescriptorSet>* descriptorSets;
+            /// Add any values in the given `offset`
+            void operator+=(BindingOffset const& offset)
+            {
+                SimpleBindingOffset::operator+=(offset);
+                pending += offset.pending;
+            }
+        };
 
-    /// Information about all the push-constant ranges that should be bound
-    ConstArrayView<VkPushConstantRange> pushConstantRanges;
-};
+        /// Context information required when binding shader objects to the pipeline
+        struct RootBindingContext
+        {
+            /// The pipeline layout being used for binding
+            VkPipelineLayout pipelineLayout;
 
-Size calcRowSize(Format format, int width);
-GfxCount calcNumRows(Format format, int height);
+            /// An allocator to use for descriptor sets during binding
+            DescriptorSetAllocator* descriptorSetAllocator;
 
-VkAttachmentLoadOp translateLoadOp(IRenderPassLayout::TargetLoadOp loadOp);
-VkAttachmentStoreOp translateStoreOp(IRenderPassLayout::TargetStoreOp storeOp);
-VkPipelineCreateFlags translateRayTracingPipelineFlags(RayTracingPipelineFlags::Enum flags);
+            /// The device being used
+            DeviceImpl* device;
 
-uint32_t getMipLevelSize(uint32_t mipLevel, uint32_t size);
-VkImageLayout translateImageLayout(ResourceState state);
+            /// The descriptor sets that are being allocated and bound
+            List<VkDescriptorSet>* descriptorSets;
 
-VkAccessFlagBits calcAccessFlags(ResourceState state);
-VkPipelineStageFlagBits calcPipelineStageFlags(ResourceState state, bool src);
-VkAccessFlags translateAccelerationStructureAccessFlag(AccessFlag access);
+            /// Information about all the push-constant ranges that should be bound
+            ConstArrayView<VkPushConstantRange> pushConstantRanges;
+        };
 
-VkBufferUsageFlagBits _calcBufferUsageFlags(ResourceState state);
-VkBufferUsageFlagBits _calcBufferUsageFlags(ResourceStateSet states);
-VkImageUsageFlagBits _calcImageUsageFlags(ResourceState state);
-VkImageViewType _calcImageViewType(ITextureResource::Type type, const ITextureResource::Desc& desc);
-VkImageUsageFlagBits _calcImageUsageFlags(ResourceStateSet states);
-VkImageUsageFlags _calcImageUsageFlags(
-    ResourceStateSet states,
-    MemoryType memoryType,
-    const void* initData);
+        Size calcRowSize(Format format, int width);
+        GfxCount calcNumRows(Format format, int height);
 
-VkAccessFlags calcAccessFlagsFromImageLayout(VkImageLayout layout);
-VkPipelineStageFlags calcPipelineStageFlagsFromImageLayout(VkImageLayout layout);
+        VkAttachmentLoadOp translateLoadOp(IRenderPassLayout::TargetLoadOp loadOp);
+        VkAttachmentStoreOp translateStoreOp(IRenderPassLayout::TargetStoreOp storeOp);
+        VkPipelineCreateFlags translateRayTracingPipelineFlags(RayTracingPipelineFlags::Enum flags);
 
-VkImageAspectFlags getAspectMaskFromFormat(VkFormat format);
+        uint32_t getMipLevelSize(uint32_t mipLevel, uint32_t size);
+        VkImageLayout translateImageLayout(ResourceState state);
 
-AdapterLUID getAdapterLUID(VulkanApi api, VkPhysicalDevice physicaDevice);
+        VkAccessFlagBits calcAccessFlags(ResourceState state);
+        VkPipelineStageFlagBits calcPipelineStageFlags(ResourceState state, bool src);
+        VkAccessFlags translateAccelerationStructureAccessFlag(AccessFlag access);
 
-} // namespace vk
+        VkBufferUsageFlagBits _calcBufferUsageFlags(ResourceState state);
+        VkBufferUsageFlagBits _calcBufferUsageFlags(ResourceStateSet states);
+        VkImageUsageFlagBits _calcImageUsageFlags(ResourceState state);
+        VkImageViewType _calcImageViewType(ITextureResource::Type type, const ITextureResource::Desc& desc);
+        VkImageUsageFlagBits _calcImageUsageFlags(ResourceStateSet states);
+        VkImageUsageFlags _calcImageUsageFlags(
+            ResourceStateSet states,
+            MemoryType memoryType,
+            const void* initData);
 
-Result SLANG_MCALL getVKAdapters(List<AdapterInfo>& outAdapters);
+        VkAccessFlags calcAccessFlagsFromImageLayout(VkImageLayout layout);
+        VkPipelineStageFlags calcPipelineStageFlagsFromImageLayout(VkImageLayout layout);
 
-Result SLANG_MCALL createVKDevice(const IDevice::Desc* desc, IDevice** outRenderer);
+        VkImageAspectFlags getAspectMaskFromFormat(VkFormat format);
+
+        AdapterLUID getAdapterLUID(VulkanApi api, VkPhysicalDevice physicaDevice);
+
+    } // namespace vk
+
+    Result SLANG_MCALL getVKAdapters(List<AdapterInfo>& outAdapters);
+
+    Result SLANG_MCALL createVKDevice(const IDevice::Desc* desc, IDevice** outRenderer);
 
 } // namespace gfx

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -88,8 +88,9 @@ static bool _isSubCommand(const char* arg)
         "  -use-test-server               Run tests using test server\n"
         "  -use-fully-isolated-test-server  Run each test in isolated server\n"
         "  -capability <name>             Compile with the given capability\n"
- #if _DEBUG
-        "  -disable-debug-layers          Disable the debug layers (default enabled in debug build)\n"
+#if _DEBUG
+        "  -disable-debug-layers          Disable the debug layers (default enabled in debug "
+        "build)\n"
 #endif
         "\n"
         "Output modes:\n"

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -1,4 +1,4 @@
-// test-context.cpp
+// options.cpp
 #include "options.h"
 
 #include "../../source/core/slang-io.h"
@@ -88,6 +88,9 @@ static bool _isSubCommand(const char* arg)
         "  -use-test-server               Run tests using test server\n"
         "  -use-fully-isolated-test-server  Run each test in isolated server\n"
         "  -capability <name>             Compile with the given capability\n"
+ #if _DEBUG
+        "  -disable-debug-layers          Disable the debug layers (default enabled in debug build)\n"
+#endif
         "\n"
         "Output modes:\n"
         "  -appveyor                      Use AppVeyor output format\n"
@@ -406,6 +409,12 @@ static bool _isSubCommand(const char* arg)
         {
             optionsOut->skipReferenceImageGeneration = true;
         }
+#if _DEBUG
+        else if (strcmp(arg, "-disable-debug-layers") == 0)
+        {
+            optionsOut->debugLayerEnabled = false;
+        }
+#endif
         else
         {
             stdError.print("unknown option '%s'\n", arg);

--- a/tools/slang-test/options.h
+++ b/tools/slang-test/options.h
@@ -83,6 +83,15 @@ struct Options
     // integration builds.
     bool dumpOutputOnFailure = false;
 
+    // When true it will run with debug layer (e.g. vulkan validation layer)
+#if _DEBUG
+    // Default is true for debug build
+    bool debugLayerEnabled = true;
+#else
+    // Default is false for release build
+    bool debugLayerEnabled = false;
+#endif
+
     // Set the default spawn type to use
     // Having tests isolated, slows down testing considerably, so using UseSharedLibrary is the most
     // desirable default usually.

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -3658,8 +3658,7 @@ TestResult runComputeComparisonImpl(
                   nullptr,
                   ".expected.txt",
                   actualOutputContent,
-                  [](const auto& a, const auto& e)
-                  {
+                  [](const auto& a, const auto& e) {
                       return SLANG_SUCCEEDED(
                           _compareWithType(a.getUnownedSlice(), e.getUnownedSlice()));
                   });

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -155,7 +155,7 @@ struct TestInput
     SpawnType spawnType;
 };
 
-typedef TestResult (*TestCallback)(TestContext* context, TestInput& input);
+typedef TestResult(*TestCallback)(TestContext* context, TestInput& input);
 
 // Globals
 
@@ -232,15 +232,15 @@ void skipToEndOfLine(char const** ioCursor)
 
         case '\r':
         case '\n':
+        {
+            cursor++;
+            int d = *cursor;
+            if ((c ^ d) == ('\r' ^ '\n'))
             {
                 cursor++;
-                int d = *cursor;
-                if ((c ^ d) == ('\r' ^ '\n'))
-                {
-                    cursor++;
-                }
             }
-            [[fallthrough]];
+        }
+        [[fallthrough]];
         case 0:
             *ioCursor = cursor;
             return;
@@ -275,9 +275,9 @@ static bool _isEndOfLineOrParens(char c)
     case '\r':
     case 0:
     case ')':
-        {
-            return true;
-        }
+    {
+        return true;
+    }
     default:
         return false;
     }
@@ -383,30 +383,30 @@ static SlangResult _parseArg(const char** ioCursor, UnownedStringSlice& outArg)
         switch (*cursor)
         {
         default:
-            {
-                ++cursor;
-                break;
-            }
+        {
+            ++cursor;
+            break;
+        }
         case '"':
-            {
-                // If we have quotes let's just parse them as is and make output
-                auto escapeHandler = StringEscapeUtil::getHandler(StringEscapeUtil::Style::Space);
-                SLANG_RETURN_ON_FAIL(escapeHandler->lexQuoted(cursor, &cursor));
-                break;
-            }
+        {
+            // If we have quotes let's just parse them as is and make output
+            auto escapeHandler = StringEscapeUtil::getHandler(StringEscapeUtil::Style::Space);
+            SLANG_RETURN_ON_FAIL(escapeHandler->lexQuoted(cursor, &cursor));
+            break;
+        }
         case 0:
         case '\r':
         case '\n':
         case ' ':
         case '\t':
-            {
-                char const* argEnd = cursor;
-                assert(argBegin != argEnd);
+        {
+            char const* argEnd = cursor;
+            assert(argBegin != argEnd);
 
-                outArg = UnownedStringSlice(argBegin, argEnd);
-                *ioCursor = cursor;
-                return SLANG_OK;
-            }
+            outArg = UnownedStringSlice(argBegin, argEnd);
+            *ioCursor = cursor;
+            return SLANG_OK;
+        }
         }
     }
 }
@@ -757,14 +757,14 @@ static TestResult _validateOutput(
     String fileCheckPrefix;
     const TestResult result =
         input.testOptions->getFileCheckPrefix(fileCheckPrefix)
-            ? _fileCheckTest(*context, input.filePath, fileCheckPrefix, actualOutput)
-            : _fileComparisonTest(
-                  *context,
-                  input,
-                  defaultExpectedContent,
-                  ".expected",
-                  actualOutput,
-                  compare);
+        ? _fileCheckTest(*context, input.filePath, fileCheckPrefix, actualOutput)
+        : _fileComparisonTest(
+            *context,
+            input,
+            defaultExpectedContent,
+            ".expected",
+            actualOutput,
+            compare);
 
     // If the test failed, then we write the actual output to a file
     // so that we can easily diff it from the command line and
@@ -1067,35 +1067,35 @@ static PassThroughFlags _getPassThroughFlagsForTarget(SlangCompileTarget target)
     case SLANG_METAL:
     case SLANG_WGSL:
     case SLANG_HOST_VM:
-        {
-            return 0;
-        }
+    {
+        return 0;
+    }
     case SLANG_WGSL_SPIRV:
     case SLANG_WGSL_SPIRV_ASM:
-        {
-            return PassThroughFlag::Tint;
-        }
+    {
+        return PassThroughFlag::Tint;
+    }
     case SLANG_DXBC:
     case SLANG_DXBC_ASM:
-        {
-            return PassThroughFlag::Fxc;
-        }
+    {
+        return PassThroughFlag::Fxc;
+    }
     case SLANG_SPIRV:
     case SLANG_SPIRV_ASM:
-        {
-            return PassThroughFlag::Glslang;
-        }
+    {
+        return PassThroughFlag::Glslang;
+    }
     case SLANG_DXIL:
     case SLANG_DXIL_ASM:
-        {
-            return PassThroughFlag::Dxc;
-        }
+    {
+        return PassThroughFlag::Dxc;
+    }
 
     case SLANG_METAL_LIB:
     case SLANG_METAL_LIB_ASM:
-        {
-            return PassThroughFlag::Metal;
-        }
+    {
+        return PassThroughFlag::Metal;
+    }
 
     case SLANG_SHADER_HOST_CALLABLE:
     case SLANG_HOST_HOST_CALLABLE:
@@ -1103,19 +1103,19 @@ static PassThroughFlags _getPassThroughFlagsForTarget(SlangCompileTarget target)
     case SLANG_HOST_EXECUTABLE:
     case SLANG_SHADER_SHARED_LIBRARY:
     case SLANG_HOST_SHARED_LIBRARY:
-        {
-            return PassThroughFlag::Generic_C_CPP;
-        }
+    {
+        return PassThroughFlag::Generic_C_CPP;
+    }
     case SLANG_PTX:
-        {
-            return PassThroughFlag::NVRTC;
-        }
+    {
+        return PassThroughFlag::NVRTC;
+    }
 
     default:
-        {
-            SLANG_ASSERT(!"Unknown type");
-            return 0;
-        }
+    {
+        SLANG_ASSERT(!"Unknown type");
+        return 0;
+    }
     }
 }
 
@@ -1182,7 +1182,7 @@ static SlangResult _extractRenderTestRequirements(
 
         // If a render option isn't set use defaultRenderType
         renderApiType = (foundRenderApiType == RenderApiType::Unknown) ? foundLanguageRenderType
-                                                                       : foundRenderApiType;
+            : foundRenderApiType;
     }
 
     // The native language for the API
@@ -1343,7 +1343,7 @@ static RenderApiFlags _getAvailableRenderApiFlags(TestContext* context)
                 // Check that the session has the generic C/CPP compiler availability - which is all
                 // we should need for CPU target
                 if (SLANG_SUCCEEDED(context->getSession()->checkPassThroughSupport(
-                        SLANG_PASS_THROUGH_GENERIC_C_CPP)))
+                    SLANG_PASS_THROUGH_GENERIC_C_CPP)))
                 {
                     availableRenderApiFlags |= RenderApiFlags(1) << int(apiType);
                 }
@@ -1373,9 +1373,9 @@ static RenderApiFlags _getAvailableRenderApiFlags(TestContext* context)
                 // Run the render-test tool and see if the device could startup
                 ExecuteResult exeRes;
                 if (SLANG_SUCCEEDED(
-                        spawnAndWaitSharedLibrary(context, "device-startup", cmdLine, exeRes)) &&
+                    spawnAndWaitSharedLibrary(context, "device-startup", cmdLine, exeRes)) &&
                     TestToolUtil::getReturnCodeFromInt(exeRes.resultCode) ==
-                        ToolReturnCode::Success)
+                    ToolReturnCode::Success)
                 {
                     availableRenderApiFlags |= RenderApiFlags(1) << int(apiType);
                     StdWriters::getOut().print(
@@ -1425,7 +1425,7 @@ static RenderApiFlags _getAvailableRenderApiFlags(TestContext* context)
                     // Run render-test to get adapter info
                     ExecuteResult exeRes;
                     if (SLANG_SUCCEEDED(
-                            spawnAndWaitSharedLibrary(context, "adapter-info", cmdLine, exeRes)))
+                        spawnAndWaitSharedLibrary(context, "adapter-info", cmdLine, exeRes)))
                     {
                         // Output the adapter info
                         StdWriters::getOut().print(
@@ -1477,23 +1477,23 @@ ToolReturnCode spawnAndWait(
     switch (finalSpawnType)
     {
     case SpawnType::UseExe:
-        {
-            spawnResult = spawnAndWaitExe(context, testPath, cmdLine, outExeRes);
-            break;
-        }
+    {
+        spawnResult = spawnAndWaitExe(context, testPath, cmdLine, outExeRes);
+        break;
+    }
     case SpawnType::Default:
     case SpawnType::UseSharedLibrary:
-        {
-            spawnResult = spawnAndWaitSharedLibrary(context, testPath, cmdLine, outExeRes);
-            break;
-        }
+    {
+        spawnResult = spawnAndWaitSharedLibrary(context, testPath, cmdLine, outExeRes);
+        break;
+    }
     case SpawnType::UseFullyIsolatedTestServer:
     case SpawnType::UseTestServer:
-        {
-            spawnResult =
-                spawnAndWaitTestServer(context, finalSpawnType, testPath, cmdLine, outExeRes);
-            break;
-        }
+    {
+        spawnResult =
+            spawnAndWaitTestServer(context, finalSpawnType, testPath, cmdLine, outExeRes);
+        break;
+    }
     default:
         break;
     }
@@ -1617,7 +1617,7 @@ static SlangResult _initSlangCompiler(TestContext* context, CommandLine& ioCmdLi
             SLANG_RETURN_ON_FAIL(
                 TestToolUtil::getIncludePath(rootPath, "external/nvapi/nvHLSLExtns.h", includePath))
 
-            StringBuilder buf;
+                StringBuilder buf;
 
             // Include the NVAPI header
             buf << "#include ";
@@ -1735,10 +1735,10 @@ static bool _areResultsEqual(TestOptions::Type type, const String& a, const Stri
     case TestOptions::Type::Normal:
         return a == b;
     default:
-        {
-            SLANG_ASSERT(!"Unknown test type");
-            return false;
-        }
+    {
+        SLANG_ASSERT(!"Unknown test type");
+        return false;
+    }
     }
 }
 
@@ -1947,8 +1947,8 @@ TestResult runExecutableTest(TestContext* context, TestInput& input)
 
         // Compare if they are the same
         if (!StringUtil::areLinesEqual(
-                actualOutput.getUnownedSlice(),
-                expectedOutput.getUnownedSlice()))
+            actualOutput.getUnownedSlice(),
+            expectedOutput.getUnownedSlice()))
         {
             context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
             return TestResult::Fail;
@@ -1966,7 +1966,7 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
     if (!context->m_languageServerConnection)
     {
         if (SLANG_FAILED(context->createLanguageServerJSONRPCConnection(
-                context->m_languageServerConnection)))
+            context->m_languageServerConnection)))
         {
             return TestResult::Fail;
         }
@@ -1984,9 +1984,9 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
     wsFolder.uri = URI::fromLocalFilePath(Path::getParentDirectory(fullPath).getUnownedSlice()).uri;
     initParams.workspaceFolders.add(wsFolder);
     if (SLANG_FAILED(connection->sendCall(
-            LanguageServerProtocol::InitializeParams::methodName,
-            &initParams,
-            JSONValue::makeInt(0))))
+        LanguageServerProtocol::InitializeParams::methodName,
+        &initParams,
+        JSONValue::makeInt(0))))
     {
         return TestResult::Fail;
     }
@@ -2021,24 +2021,24 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
     bool diagnosticsReceived = false;
     auto waitForNonDiagnosticResponse = [&]() -> SlangResult
     {
-        repeat:
-            if (SLANG_FAILED(connection->waitForResult(-1)))
-                return SLANG_FAIL;
-            if (connection->getMessageType() == JSONRPCMessageType::Call)
+    repeat:
+        if (SLANG_FAILED(connection->waitForResult(-1)))
+            return SLANG_FAIL;
+        if (connection->getMessageType() == JSONRPCMessageType::Call)
+        {
+            JSONRPCCall call;
+            connection->getRPC(&call);
+            if (call.method == "textDocument/publishDiagnostics")
             {
-                JSONRPCCall call;
-                connection->getRPC(&call);
-                if (call.method == "textDocument/publishDiagnostics")
-                {
-                    diagnosticsReceived = true;
-                    LanguageServerProtocol::PublishDiagnosticsParams arg;
-                    if (SLANG_FAILED(connection->getMessage(&arg)))
-                        return SLANG_FAIL;
-                    diagnostics.add(arg);
-                    goto repeat;
-                }
+                diagnosticsReceived = true;
+                LanguageServerProtocol::PublishDiagnosticsParams arg;
+                if (SLANG_FAILED(connection->getMessage(&arg)))
+                    return SLANG_FAIL;
+                diagnostics.add(arg);
+                goto repeat;
             }
-            return SLANG_OK;
+        }
+        return SLANG_OK;
     };
 
     List<UnownedStringSlice> lines;
@@ -2070,9 +2070,9 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
             params.position.character = int(colPos - 1);
             params.textDocument.uri = openDocParams.textDocument.uri;
             if (SLANG_FAILED(connection->sendCall(
-                    LanguageServerProtocol::CompletionParams::methodName,
-                    &params,
-                    JSONValue::makeInt(callId++))))
+                LanguageServerProtocol::CompletionParams::methodName,
+                &params,
+                JSONValue::makeInt(callId++))))
             {
                 return TestResult::Fail;
             }
@@ -2107,9 +2107,9 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
             params.position.character = int(colPos - 1);
             params.textDocument.uri = openDocParams.textDocument.uri;
             if (SLANG_FAILED(connection->sendCall(
-                    LanguageServerProtocol::SignatureHelpParams::methodName,
-                    &params,
-                    JSONValue::makeInt(callId++))))
+                LanguageServerProtocol::SignatureHelpParams::methodName,
+                &params,
+                JSONValue::makeInt(callId++))))
             {
                 return TestResult::Fail;
             }
@@ -2149,9 +2149,9 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
             params.position.character = int(colPos - 1);
             params.textDocument.uri = openDocParams.textDocument.uri;
             if (SLANG_FAILED(connection->sendCall(
-                    LanguageServerProtocol::HoverParams::methodName,
-                    &params,
-                    JSONValue::makeInt(callId++))))
+                LanguageServerProtocol::HoverParams::methodName,
+                &params,
+                JSONValue::makeInt(callId++))))
             {
                 return TestResult::Fail;
             }
@@ -2167,8 +2167,8 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
             else if (SLANG_SUCCEEDED(connection->getMessage(&hover)))
             {
                 actualOutputSB << "range: " << hover.range.start.line << ","
-                               << hover.range.start.character << " - " << hover.range.end.line
-                               << "," << hover.range.end.character;
+                    << hover.range.start.character << " - " << hover.range.end.line
+                    << "," << hover.range.end.character;
                 actualOutputSB << "\ncontent:\n" << hover.contents.value << "\n";
             }
         }
@@ -2185,8 +2185,8 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
                 for (auto msg : item.diagnostics)
                 {
                     actualOutputSB << msg.range.start.line << "," << msg.range.start.character
-                                   << "-" << msg.range.end.line << "," << msg.range.end.character
-                                   << " " << msg.message;
+                        << "-" << msg.range.end.line << "," << msg.range.end.character
+                        << " " << msg.message;
                 }
             }
         }
@@ -2365,8 +2365,8 @@ TestResult runSimpleLineTest(TestContext* context, TestInput& input)
     // Parse all the diagnostics so we can extract line numbers
     auto diagnostics = ArtifactDiagnostics::create();
     if (SLANG_FAILED(ParseDiagnosticUtil::parseDiagnostics(
-            exeRes.standardError.getUnownedSlice(),
-            diagnostics)) ||
+        exeRes.standardError.getUnownedSlice(),
+        diagnostics)) ||
         diagnostics->getCount() <= 0)
     {
         // Write out the diagnostics which couldn't be parsed.
@@ -2574,7 +2574,7 @@ TestResult runReflectionTest(TestContext* context, TestInput& input)
     // Extrac the stand
     ParseDiagnosticUtil::OutputInfo outputInfo;
     if (SLANG_SUCCEEDED(
-            ParseDiagnosticUtil::parseOutputInfo(actualOutput.getUnownedSlice(), outputInfo)))
+        ParseDiagnosticUtil::parseOutputInfo(actualOutput.getUnownedSlice(), outputInfo)))
     {
         const auto toolReturnCode = ToolReturnCode(outputInfo.resultCode);
 
@@ -2592,7 +2592,7 @@ TestResult runReflectionTest(TestContext* context, TestInput& input)
 
             JSONValue value;
             if (SLANG_FAILED(
-                    _parseJSON(outputInfo.stdOut.getUnownedSlice(), &sink, &container, value)))
+                _parseJSON(outputInfo.stdOut.getUnownedSlice(), &sink, &container, value)))
             {
                 // Unable to parse as JSON
 
@@ -2741,7 +2741,7 @@ static TestResult runCPPCompilerSharedLibrary(TestContext* context, TestInput& i
             sourceArtifact.writeRef());
     }
 
-    TerminatedCharSlice includePaths[] = {TerminatedCharSlice(".")};
+    TerminatedCharSlice includePaths[] = { TerminatedCharSlice(".") };
 
     options.sourceArtifacts = makeSlice(sourceArtifact.readRef(), 1);
     options.includePaths = makeSlice(includePaths, SLANG_COUNT_OF(includePaths));
@@ -2773,8 +2773,8 @@ static TestResult runCPPCompilerSharedLibrary(TestContext* context, TestInput& i
 
             // Compare if they are the same
             if (!StringUtil::areLinesEqual(
-                    actualOutput.getUnownedSlice(),
-                    expectedOutput.getUnownedSlice()))
+                actualOutput.getUnownedSlice(),
+                expectedOutput.getUnownedSlice()))
             {
                 context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
                 return TestResult::Fail;
@@ -2785,7 +2785,7 @@ static TestResult runCPPCompilerSharedLibrary(TestContext* context, TestInput& i
     {
         SharedLibrary::Handle handle;
         if (SLANG_FAILED(
-                SharedLibrary::loadWithPlatformPath(sharedLibraryPath.getBuffer(), handle)))
+            SharedLibrary::loadWithPlatformPath(sharedLibraryPath.getBuffer(), handle)))
         {
             return TestResult::Fail;
         }
@@ -2863,7 +2863,7 @@ static TestResult runCPPCompilerExecute(TestContext* context, TestInput& input)
 
     options.sourceLanguage = (ext == "c") ? SLANG_SOURCE_LANGUAGE_C : SLANG_SOURCE_LANGUAGE_CPP;
 
-    TerminatedCharSlice filePaths[] = {SliceUtil::asTerminatedCharSlice(filePath)};
+    TerminatedCharSlice filePaths[] = { SliceUtil::asTerminatedCharSlice(filePath) };
 
     auto helper = DefaultArtifactHelper::getSingleton();
 
@@ -2925,8 +2925,8 @@ static TestResult runCPPCompilerExecute(TestContext* context, TestInput& input)
 
         // Compare if they are the same
         if (!StringUtil::areLinesEqual(
-                actualOutput.getUnownedSlice(),
-                expectedOutput.getUnownedSlice()))
+            actualOutput.getUnownedSlice(),
+            expectedOutput.getUnownedSlice()))
         {
             context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
             return TestResult::Fail;
@@ -2970,28 +2970,28 @@ static TestResult generateExpectedOutput(
         {
         case SLANG_DXIL:
         case SLANG_DXIL_ASM:
-            {
-                expectedCmdLine.addArg(filePath + ".hlsl");
-                expectedCmdLine.addArg("-pass-through");
-                expectedCmdLine.addArg("dxc");
-                break;
-            }
+        {
+            expectedCmdLine.addArg(filePath + ".hlsl");
+            expectedCmdLine.addArg("-pass-through");
+            expectedCmdLine.addArg("dxc");
+            break;
+        }
         case SLANG_DXBC:
         case SLANG_DXBC_ASM:
-            {
-                expectedCmdLine.addArg(filePath + ".hlsl");
-                expectedCmdLine.addArg("-pass-through");
-                expectedCmdLine.addArg("fxc");
-                break;
-            }
+        {
+            expectedCmdLine.addArg(filePath + ".hlsl");
+            expectedCmdLine.addArg("-pass-through");
+            expectedCmdLine.addArg("fxc");
+            break;
+        }
         default:
-            {
-                expectedCmdLine.addArg(filePath + ".glsl");
-                expectedCmdLine.addArg("-emit-spirv-via-glsl");
-                expectedCmdLine.addArg("-pass-through");
-                expectedCmdLine.addArg("glslang");
-                break;
-            }
+        {
+            expectedCmdLine.addArg(filePath + ".glsl");
+            expectedCmdLine.addArg("-emit-spirv-via-glsl");
+            expectedCmdLine.addArg("-pass-through");
+            expectedCmdLine.addArg("glslang");
+            break;
+        }
         }
     }
 
@@ -3119,8 +3119,8 @@ TestResult runCrossCompilerTest(TestContext* context, TestInput& input)
     else
     {
         if (!StringUtil::areLinesEqual(
-                actualOutput.getUnownedSlice(),
-                expectedOutput.getUnownedSlice()))
+            actualOutput.getUnownedSlice(),
+            expectedOutput.getUnownedSlice()))
         {
             result = TestResult::Fail;
             context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
@@ -3371,8 +3371,8 @@ TestResult runGLSLComparisonTest(TestContext* context, TestInput& input)
         return TestResult::Fail;
 
     if (!StringUtil::areLinesEqual(
-            actualOutput.getUnownedSlice(),
-            expectedOutput.getUnownedSlice()))
+        actualOutput.getUnownedSlice(),
+        expectedOutput.getUnownedSlice()))
     {
         context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
 
@@ -3543,28 +3543,28 @@ static SlangResult _compareWithType(
         switch (scalarType)
         {
         default:
+        {
+            if (lineActual.trim() != lineRef.trim())
             {
-                if (lineActual.trim() != lineRef.trim())
-                {
-                    return SLANG_FAIL;
-                }
-                break;
+                return SLANG_FAIL;
             }
+            break;
+        }
         case ScalarType::Float16:
         case ScalarType::Float32:
         case ScalarType::Float64:
+        {
+
+            // Compare as double
+            double valueA = _textToDouble(lineActual);
+            double valueB = _textToDouble(lineRef);
+
+            if (!Math::AreNearlyEqual(valueA, valueB, differenceThreshold))
             {
-
-                // Compare as double
-                double valueA = _textToDouble(lineActual);
-                double valueB = _textToDouble(lineRef);
-
-                if (!Math::AreNearlyEqual(valueA, valueB, differenceThreshold))
-                {
-                    return SLANG_FAIL;
-                }
-                break;
+                return SLANG_FAIL;
             }
+            break;
+        }
         }
     }
 
@@ -3607,8 +3607,10 @@ TestResult runComputeComparisonImpl(
     // gets misinterpreted as the result from the test.
     // This is due to the limitation that Slang RPC implementation expects only
     // one time communication.
-    if (input.spawnType != SpawnType::UseTestServer)
+    if (context->options.debugLayerEnabled && input.spawnType != SpawnType::UseTestServer)
+    {
         cmdLine.addArg("-enable-debug-layers");
+    }
 #endif
 
     if (context->isExecuting())
@@ -3649,23 +3651,23 @@ TestResult runComputeComparisonImpl(
     String fileCheckPrefix;
     auto bufferResult =
         input.testOptions->getFileCheckBufferPrefix(fileCheckPrefix)
-            ? _fileCheckTest(*context, input.filePath, fileCheckPrefix, actualOutputContent)
-            : _fileComparisonTest(
-                  *context,
-                  input,
-                  nullptr,
-                  ".expected.txt",
-                  actualOutputContent,
-                  [](const auto& a, const auto& e) {
-                      return SLANG_SUCCEEDED(
-                          _compareWithType(a.getUnownedSlice(), e.getUnownedSlice()));
-                  });
+        ? _fileCheckTest(*context, input.filePath, fileCheckPrefix, actualOutputContent)
+        : _fileComparisonTest(
+            *context,
+            input,
+            nullptr,
+            ".expected.txt",
+            actualOutputContent,
+            [](const auto& a, const auto& e) {
+        return SLANG_SUCCEEDED(
+            _compareWithType(a.getUnownedSlice(), e.getUnownedSlice()));
+    });
     return std::max(compileResult, bufferResult);
 }
 
 TestResult runSlangComputeComparisonTest(TestContext* context, TestInput& input)
 {
-    const char* langOpts[] = {"-slang", "-compute"};
+    const char* langOpts[] = { "-slang", "-compute" };
     return runComputeComparisonImpl(context, input, langOpts, SLANG_COUNT_OF(langOpts));
 }
 
@@ -3676,13 +3678,13 @@ TestResult runSlangComputeComparisonTestEx(TestContext* context, TestInput& inpu
 
 TestResult runHLSLComputeTest(TestContext* context, TestInput& input)
 {
-    const char* langOpts[] = {"--hlsl-rewrite", "-compute"};
+    const char* langOpts[] = { "--hlsl-rewrite", "-compute" };
     return runComputeComparisonImpl(context, input, langOpts, SLANG_COUNT_OF(langOpts));
 }
 
 TestResult runSlangRenderComputeComparisonTest(TestContext* context, TestInput& input)
 {
-    const char* langOpts[] = {"-slang", "-gcompute"};
+    const char* langOpts[] = { "-slang", "-gcompute" };
     return runComputeComparisonImpl(context, input, langOpts, SLANG_COUNT_OF(langOpts));
 }
 
@@ -3810,7 +3812,7 @@ SlangResult STBImage::read(const char* filename)
 bool STBImage::isComparable(const ThisType& rhs) const
 {
     return (this == &rhs) || (m_width == rhs.m_width && m_height == rhs.m_height &&
-                              m_numChannels == rhs.m_numChannels);
+        m_numChannels == rhs.m_numChannels);
 }
 
 
@@ -3988,8 +3990,8 @@ TestResult runHLSLRenderComparisonTestImpl(
 
     // Compare text output only if we generated the expected output
     if (!context->options.skipReferenceImageGeneration && !StringUtil::areLinesEqual(
-                                                              actualOutput.getUnownedSlice(),
-                                                              expectedOutput.getUnownedSlice()))
+        actualOutput.getUnownedSlice(),
+        expectedOutput.getUnownedSlice()))
     {
         context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
 
@@ -4059,7 +4061,7 @@ static const TestCommandInfo s_testCommandInfos[] = {
     {"COMPILE", &runCompile, 0},
     {"DOC", &runDocTest, 0},
     {"LANG_SERVER", &runLanguageServerTest, 0},
-    {"EXECUTABLE", &runExecutableTest, RenderApiFlag::CPU}};
+    {"EXECUTABLE", &runExecutableTest, RenderApiFlag::CPU} };
 
 const TestCommandInfo* _findTestCommandInfoByCommand(const UnownedStringSlice& name)
 {
@@ -4194,9 +4196,9 @@ static void _calcSynthesizedTests(
                 case SLANG_SOURCE_LANGUAGE_GLSL:
                 case SLANG_SOURCE_LANGUAGE_C:
                 case SLANG_SOURCE_LANGUAGE_CPP:
-                    {
-                        isCrossCompile = false;
-                    }
+                {
+                    isCrossCompile = false;
+                }
                 default:
                     break;
                 }
@@ -4286,7 +4288,7 @@ static bool _canIgnore(TestContext* context, const TestDetails& details)
 
     // Are all the required backends available?
     if (((requirements.usedBackendFlags & context->availableBackendFlags) !=
-         requirements.usedBackendFlags))
+        requirements.usedBackendFlags))
     {
         return true;
     }
@@ -4344,11 +4346,11 @@ static SlangResult _runTestsOnFile(TestContext* context, String filePath)
             context->setTestRequirements(&requirements);
             runTest(context, filePath, filePath, filePath, testDetails.options);
 
-            //
+
             apiUsedFlags |= requirements.usedRenderApiFlags;
             explictUsedApiFlags |= (requirements.explicitRenderApi != RenderApiType::Unknown)
-                                       ? (RenderApiFlags(1) << int(requirements.explicitRenderApi))
-                                       : 0;
+                ? (RenderApiFlags(1) << int(requirements.explicitRenderApi))
+                : 0;
         }
         context->setTestRequirements(nullptr);
     }
@@ -4703,6 +4705,7 @@ static SlangResult runUnitTestModule(
     unitTestContext.slangGlobalSession = context->getSession();
     unitTestContext.workDirectory = "";
     unitTestContext.enabledApis = context->options.enabledApis;
+    unitTestContext.enableDebugLayers = context->options.debugLayerEnabled;
     unitTestContext.executableDirectory = context->exeDirectoryPath.getBuffer();
 
     auto testCount = testModule->getTestCount();
@@ -4730,7 +4733,7 @@ static SlangResult runUnitTestModule(
         {
             if (testPassesCategoryMask(context, testOptions))
             {
-                tests.add(TestItem{testFunc, testName, command});
+                tests.add(TestItem{ testFunc, testName, command });
             }
         }
     }
@@ -4842,7 +4845,7 @@ SlangResult innerMain(int argc, char** argv)
     TestContext context;
     SLANG_RETURN_ON_FAIL(SLANG_FAILED(context.init(argv[0])))
 
-    auto& categorySet = context.categorySet;
+        auto& categorySet = context.categorySet;
 
     // Set up our test categories here
     auto fullTestCategory = categorySet.add("full", nullptr);
@@ -4881,7 +4884,7 @@ SlangResult innerMain(int argc, char** argv)
     categorySet.defaultCategory = fullTestCategory;
 
     // All following values are initialized to '0', so null.
-    TestCategory* passThroughCategories[SLANG_PASS_THROUGH_COUNT_OF] = {nullptr};
+    TestCategory* passThroughCategories[SLANG_PASS_THROUGH_COUNT_OF] = { nullptr };
 
     // Work out what backends/pass-thrus are available
     {

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -155,7 +155,7 @@ struct TestInput
     SpawnType spawnType;
 };
 
-typedef TestResult(*TestCallback)(TestContext* context, TestInput& input);
+typedef TestResult (*TestCallback)(TestContext* context, TestInput& input);
 
 // Globals
 
@@ -232,15 +232,15 @@ void skipToEndOfLine(char const** ioCursor)
 
         case '\r':
         case '\n':
-        {
-            cursor++;
-            int d = *cursor;
-            if ((c ^ d) == ('\r' ^ '\n'))
             {
                 cursor++;
+                int d = *cursor;
+                if ((c ^ d) == ('\r' ^ '\n'))
+                {
+                    cursor++;
+                }
             }
-        }
-        [[fallthrough]];
+            [[fallthrough]];
         case 0:
             *ioCursor = cursor;
             return;
@@ -275,9 +275,9 @@ static bool _isEndOfLineOrParens(char c)
     case '\r':
     case 0:
     case ')':
-    {
-        return true;
-    }
+        {
+            return true;
+        }
     default:
         return false;
     }
@@ -383,30 +383,30 @@ static SlangResult _parseArg(const char** ioCursor, UnownedStringSlice& outArg)
         switch (*cursor)
         {
         default:
-        {
-            ++cursor;
-            break;
-        }
+            {
+                ++cursor;
+                break;
+            }
         case '"':
-        {
-            // If we have quotes let's just parse them as is and make output
-            auto escapeHandler = StringEscapeUtil::getHandler(StringEscapeUtil::Style::Space);
-            SLANG_RETURN_ON_FAIL(escapeHandler->lexQuoted(cursor, &cursor));
-            break;
-        }
+            {
+                // If we have quotes let's just parse them as is and make output
+                auto escapeHandler = StringEscapeUtil::getHandler(StringEscapeUtil::Style::Space);
+                SLANG_RETURN_ON_FAIL(escapeHandler->lexQuoted(cursor, &cursor));
+                break;
+            }
         case 0:
         case '\r':
         case '\n':
         case ' ':
         case '\t':
-        {
-            char const* argEnd = cursor;
-            assert(argBegin != argEnd);
+            {
+                char const* argEnd = cursor;
+                assert(argBegin != argEnd);
 
-            outArg = UnownedStringSlice(argBegin, argEnd);
-            *ioCursor = cursor;
-            return SLANG_OK;
-        }
+                outArg = UnownedStringSlice(argBegin, argEnd);
+                *ioCursor = cursor;
+                return SLANG_OK;
+            }
         }
     }
 }
@@ -757,14 +757,14 @@ static TestResult _validateOutput(
     String fileCheckPrefix;
     const TestResult result =
         input.testOptions->getFileCheckPrefix(fileCheckPrefix)
-        ? _fileCheckTest(*context, input.filePath, fileCheckPrefix, actualOutput)
-        : _fileComparisonTest(
-            *context,
-            input,
-            defaultExpectedContent,
-            ".expected",
-            actualOutput,
-            compare);
+            ? _fileCheckTest(*context, input.filePath, fileCheckPrefix, actualOutput)
+            : _fileComparisonTest(
+                  *context,
+                  input,
+                  defaultExpectedContent,
+                  ".expected",
+                  actualOutput,
+                  compare);
 
     // If the test failed, then we write the actual output to a file
     // so that we can easily diff it from the command line and
@@ -1067,35 +1067,35 @@ static PassThroughFlags _getPassThroughFlagsForTarget(SlangCompileTarget target)
     case SLANG_METAL:
     case SLANG_WGSL:
     case SLANG_HOST_VM:
-    {
-        return 0;
-    }
+        {
+            return 0;
+        }
     case SLANG_WGSL_SPIRV:
     case SLANG_WGSL_SPIRV_ASM:
-    {
-        return PassThroughFlag::Tint;
-    }
+        {
+            return PassThroughFlag::Tint;
+        }
     case SLANG_DXBC:
     case SLANG_DXBC_ASM:
-    {
-        return PassThroughFlag::Fxc;
-    }
+        {
+            return PassThroughFlag::Fxc;
+        }
     case SLANG_SPIRV:
     case SLANG_SPIRV_ASM:
-    {
-        return PassThroughFlag::Glslang;
-    }
+        {
+            return PassThroughFlag::Glslang;
+        }
     case SLANG_DXIL:
     case SLANG_DXIL_ASM:
-    {
-        return PassThroughFlag::Dxc;
-    }
+        {
+            return PassThroughFlag::Dxc;
+        }
 
     case SLANG_METAL_LIB:
     case SLANG_METAL_LIB_ASM:
-    {
-        return PassThroughFlag::Metal;
-    }
+        {
+            return PassThroughFlag::Metal;
+        }
 
     case SLANG_SHADER_HOST_CALLABLE:
     case SLANG_HOST_HOST_CALLABLE:
@@ -1103,19 +1103,19 @@ static PassThroughFlags _getPassThroughFlagsForTarget(SlangCompileTarget target)
     case SLANG_HOST_EXECUTABLE:
     case SLANG_SHADER_SHARED_LIBRARY:
     case SLANG_HOST_SHARED_LIBRARY:
-    {
-        return PassThroughFlag::Generic_C_CPP;
-    }
+        {
+            return PassThroughFlag::Generic_C_CPP;
+        }
     case SLANG_PTX:
-    {
-        return PassThroughFlag::NVRTC;
-    }
+        {
+            return PassThroughFlag::NVRTC;
+        }
 
     default:
-    {
-        SLANG_ASSERT(!"Unknown type");
-        return 0;
-    }
+        {
+            SLANG_ASSERT(!"Unknown type");
+            return 0;
+        }
     }
 }
 
@@ -1182,7 +1182,7 @@ static SlangResult _extractRenderTestRequirements(
 
         // If a render option isn't set use defaultRenderType
         renderApiType = (foundRenderApiType == RenderApiType::Unknown) ? foundLanguageRenderType
-            : foundRenderApiType;
+                                                                       : foundRenderApiType;
     }
 
     // The native language for the API
@@ -1343,7 +1343,7 @@ static RenderApiFlags _getAvailableRenderApiFlags(TestContext* context)
                 // Check that the session has the generic C/CPP compiler availability - which is all
                 // we should need for CPU target
                 if (SLANG_SUCCEEDED(context->getSession()->checkPassThroughSupport(
-                    SLANG_PASS_THROUGH_GENERIC_C_CPP)))
+                        SLANG_PASS_THROUGH_GENERIC_C_CPP)))
                 {
                     availableRenderApiFlags |= RenderApiFlags(1) << int(apiType);
                 }
@@ -1373,9 +1373,9 @@ static RenderApiFlags _getAvailableRenderApiFlags(TestContext* context)
                 // Run the render-test tool and see if the device could startup
                 ExecuteResult exeRes;
                 if (SLANG_SUCCEEDED(
-                    spawnAndWaitSharedLibrary(context, "device-startup", cmdLine, exeRes)) &&
+                        spawnAndWaitSharedLibrary(context, "device-startup", cmdLine, exeRes)) &&
                     TestToolUtil::getReturnCodeFromInt(exeRes.resultCode) ==
-                    ToolReturnCode::Success)
+                        ToolReturnCode::Success)
                 {
                     availableRenderApiFlags |= RenderApiFlags(1) << int(apiType);
                     StdWriters::getOut().print(
@@ -1425,7 +1425,7 @@ static RenderApiFlags _getAvailableRenderApiFlags(TestContext* context)
                     // Run render-test to get adapter info
                     ExecuteResult exeRes;
                     if (SLANG_SUCCEEDED(
-                        spawnAndWaitSharedLibrary(context, "adapter-info", cmdLine, exeRes)))
+                            spawnAndWaitSharedLibrary(context, "adapter-info", cmdLine, exeRes)))
                     {
                         // Output the adapter info
                         StdWriters::getOut().print(
@@ -1477,23 +1477,23 @@ ToolReturnCode spawnAndWait(
     switch (finalSpawnType)
     {
     case SpawnType::UseExe:
-    {
-        spawnResult = spawnAndWaitExe(context, testPath, cmdLine, outExeRes);
-        break;
-    }
+        {
+            spawnResult = spawnAndWaitExe(context, testPath, cmdLine, outExeRes);
+            break;
+        }
     case SpawnType::Default:
     case SpawnType::UseSharedLibrary:
-    {
-        spawnResult = spawnAndWaitSharedLibrary(context, testPath, cmdLine, outExeRes);
-        break;
-    }
+        {
+            spawnResult = spawnAndWaitSharedLibrary(context, testPath, cmdLine, outExeRes);
+            break;
+        }
     case SpawnType::UseFullyIsolatedTestServer:
     case SpawnType::UseTestServer:
-    {
-        spawnResult =
-            spawnAndWaitTestServer(context, finalSpawnType, testPath, cmdLine, outExeRes);
-        break;
-    }
+        {
+            spawnResult =
+                spawnAndWaitTestServer(context, finalSpawnType, testPath, cmdLine, outExeRes);
+            break;
+        }
     default:
         break;
     }
@@ -1617,7 +1617,7 @@ static SlangResult _initSlangCompiler(TestContext* context, CommandLine& ioCmdLi
             SLANG_RETURN_ON_FAIL(
                 TestToolUtil::getIncludePath(rootPath, "external/nvapi/nvHLSLExtns.h", includePath))
 
-                StringBuilder buf;
+            StringBuilder buf;
 
             // Include the NVAPI header
             buf << "#include ";
@@ -1735,10 +1735,10 @@ static bool _areResultsEqual(TestOptions::Type type, const String& a, const Stri
     case TestOptions::Type::Normal:
         return a == b;
     default:
-    {
-        SLANG_ASSERT(!"Unknown test type");
-        return false;
-    }
+        {
+            SLANG_ASSERT(!"Unknown test type");
+            return false;
+        }
     }
 }
 
@@ -1947,8 +1947,8 @@ TestResult runExecutableTest(TestContext* context, TestInput& input)
 
         // Compare if they are the same
         if (!StringUtil::areLinesEqual(
-            actualOutput.getUnownedSlice(),
-            expectedOutput.getUnownedSlice()))
+                actualOutput.getUnownedSlice(),
+                expectedOutput.getUnownedSlice()))
         {
             context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
             return TestResult::Fail;
@@ -1966,7 +1966,7 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
     if (!context->m_languageServerConnection)
     {
         if (SLANG_FAILED(context->createLanguageServerJSONRPCConnection(
-            context->m_languageServerConnection)))
+                context->m_languageServerConnection)))
         {
             return TestResult::Fail;
         }
@@ -1984,9 +1984,9 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
     wsFolder.uri = URI::fromLocalFilePath(Path::getParentDirectory(fullPath).getUnownedSlice()).uri;
     initParams.workspaceFolders.add(wsFolder);
     if (SLANG_FAILED(connection->sendCall(
-        LanguageServerProtocol::InitializeParams::methodName,
-        &initParams,
-        JSONValue::makeInt(0))))
+            LanguageServerProtocol::InitializeParams::methodName,
+            &initParams,
+            JSONValue::makeInt(0))))
     {
         return TestResult::Fail;
     }
@@ -2021,24 +2021,24 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
     bool diagnosticsReceived = false;
     auto waitForNonDiagnosticResponse = [&]() -> SlangResult
     {
-    repeat:
-        if (SLANG_FAILED(connection->waitForResult(-1)))
-            return SLANG_FAIL;
-        if (connection->getMessageType() == JSONRPCMessageType::Call)
-        {
-            JSONRPCCall call;
-            connection->getRPC(&call);
-            if (call.method == "textDocument/publishDiagnostics")
+        repeat:
+            if (SLANG_FAILED(connection->waitForResult(-1)))
+                return SLANG_FAIL;
+            if (connection->getMessageType() == JSONRPCMessageType::Call)
             {
-                diagnosticsReceived = true;
-                LanguageServerProtocol::PublishDiagnosticsParams arg;
-                if (SLANG_FAILED(connection->getMessage(&arg)))
-                    return SLANG_FAIL;
-                diagnostics.add(arg);
-                goto repeat;
+                JSONRPCCall call;
+                connection->getRPC(&call);
+                if (call.method == "textDocument/publishDiagnostics")
+                {
+                    diagnosticsReceived = true;
+                    LanguageServerProtocol::PublishDiagnosticsParams arg;
+                    if (SLANG_FAILED(connection->getMessage(&arg)))
+                        return SLANG_FAIL;
+                    diagnostics.add(arg);
+                    goto repeat;
+                }
             }
-        }
-        return SLANG_OK;
+            return SLANG_OK;
     };
 
     List<UnownedStringSlice> lines;
@@ -2070,9 +2070,9 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
             params.position.character = int(colPos - 1);
             params.textDocument.uri = openDocParams.textDocument.uri;
             if (SLANG_FAILED(connection->sendCall(
-                LanguageServerProtocol::CompletionParams::methodName,
-                &params,
-                JSONValue::makeInt(callId++))))
+                    LanguageServerProtocol::CompletionParams::methodName,
+                    &params,
+                    JSONValue::makeInt(callId++))))
             {
                 return TestResult::Fail;
             }
@@ -2107,9 +2107,9 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
             params.position.character = int(colPos - 1);
             params.textDocument.uri = openDocParams.textDocument.uri;
             if (SLANG_FAILED(connection->sendCall(
-                LanguageServerProtocol::SignatureHelpParams::methodName,
-                &params,
-                JSONValue::makeInt(callId++))))
+                    LanguageServerProtocol::SignatureHelpParams::methodName,
+                    &params,
+                    JSONValue::makeInt(callId++))))
             {
                 return TestResult::Fail;
             }
@@ -2149,9 +2149,9 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
             params.position.character = int(colPos - 1);
             params.textDocument.uri = openDocParams.textDocument.uri;
             if (SLANG_FAILED(connection->sendCall(
-                LanguageServerProtocol::HoverParams::methodName,
-                &params,
-                JSONValue::makeInt(callId++))))
+                    LanguageServerProtocol::HoverParams::methodName,
+                    &params,
+                    JSONValue::makeInt(callId++))))
             {
                 return TestResult::Fail;
             }
@@ -2167,8 +2167,8 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
             else if (SLANG_SUCCEEDED(connection->getMessage(&hover)))
             {
                 actualOutputSB << "range: " << hover.range.start.line << ","
-                    << hover.range.start.character << " - " << hover.range.end.line
-                    << "," << hover.range.end.character;
+                               << hover.range.start.character << " - " << hover.range.end.line
+                               << "," << hover.range.end.character;
                 actualOutputSB << "\ncontent:\n" << hover.contents.value << "\n";
             }
         }
@@ -2185,8 +2185,8 @@ TestResult runLanguageServerTest(TestContext* context, TestInput& input)
                 for (auto msg : item.diagnostics)
                 {
                     actualOutputSB << msg.range.start.line << "," << msg.range.start.character
-                        << "-" << msg.range.end.line << "," << msg.range.end.character
-                        << " " << msg.message;
+                                   << "-" << msg.range.end.line << "," << msg.range.end.character
+                                   << " " << msg.message;
                 }
             }
         }
@@ -2365,8 +2365,8 @@ TestResult runSimpleLineTest(TestContext* context, TestInput& input)
     // Parse all the diagnostics so we can extract line numbers
     auto diagnostics = ArtifactDiagnostics::create();
     if (SLANG_FAILED(ParseDiagnosticUtil::parseDiagnostics(
-        exeRes.standardError.getUnownedSlice(),
-        diagnostics)) ||
+            exeRes.standardError.getUnownedSlice(),
+            diagnostics)) ||
         diagnostics->getCount() <= 0)
     {
         // Write out the diagnostics which couldn't be parsed.
@@ -2574,7 +2574,7 @@ TestResult runReflectionTest(TestContext* context, TestInput& input)
     // Extrac the stand
     ParseDiagnosticUtil::OutputInfo outputInfo;
     if (SLANG_SUCCEEDED(
-        ParseDiagnosticUtil::parseOutputInfo(actualOutput.getUnownedSlice(), outputInfo)))
+            ParseDiagnosticUtil::parseOutputInfo(actualOutput.getUnownedSlice(), outputInfo)))
     {
         const auto toolReturnCode = ToolReturnCode(outputInfo.resultCode);
 
@@ -2592,7 +2592,7 @@ TestResult runReflectionTest(TestContext* context, TestInput& input)
 
             JSONValue value;
             if (SLANG_FAILED(
-                _parseJSON(outputInfo.stdOut.getUnownedSlice(), &sink, &container, value)))
+                    _parseJSON(outputInfo.stdOut.getUnownedSlice(), &sink, &container, value)))
             {
                 // Unable to parse as JSON
 
@@ -2741,7 +2741,7 @@ static TestResult runCPPCompilerSharedLibrary(TestContext* context, TestInput& i
             sourceArtifact.writeRef());
     }
 
-    TerminatedCharSlice includePaths[] = { TerminatedCharSlice(".") };
+    TerminatedCharSlice includePaths[] = {TerminatedCharSlice(".")};
 
     options.sourceArtifacts = makeSlice(sourceArtifact.readRef(), 1);
     options.includePaths = makeSlice(includePaths, SLANG_COUNT_OF(includePaths));
@@ -2773,8 +2773,8 @@ static TestResult runCPPCompilerSharedLibrary(TestContext* context, TestInput& i
 
             // Compare if they are the same
             if (!StringUtil::areLinesEqual(
-                actualOutput.getUnownedSlice(),
-                expectedOutput.getUnownedSlice()))
+                    actualOutput.getUnownedSlice(),
+                    expectedOutput.getUnownedSlice()))
             {
                 context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
                 return TestResult::Fail;
@@ -2785,7 +2785,7 @@ static TestResult runCPPCompilerSharedLibrary(TestContext* context, TestInput& i
     {
         SharedLibrary::Handle handle;
         if (SLANG_FAILED(
-            SharedLibrary::loadWithPlatformPath(sharedLibraryPath.getBuffer(), handle)))
+                SharedLibrary::loadWithPlatformPath(sharedLibraryPath.getBuffer(), handle)))
         {
             return TestResult::Fail;
         }
@@ -2863,7 +2863,7 @@ static TestResult runCPPCompilerExecute(TestContext* context, TestInput& input)
 
     options.sourceLanguage = (ext == "c") ? SLANG_SOURCE_LANGUAGE_C : SLANG_SOURCE_LANGUAGE_CPP;
 
-    TerminatedCharSlice filePaths[] = { SliceUtil::asTerminatedCharSlice(filePath) };
+    TerminatedCharSlice filePaths[] = {SliceUtil::asTerminatedCharSlice(filePath)};
 
     auto helper = DefaultArtifactHelper::getSingleton();
 
@@ -2925,8 +2925,8 @@ static TestResult runCPPCompilerExecute(TestContext* context, TestInput& input)
 
         // Compare if they are the same
         if (!StringUtil::areLinesEqual(
-            actualOutput.getUnownedSlice(),
-            expectedOutput.getUnownedSlice()))
+                actualOutput.getUnownedSlice(),
+                expectedOutput.getUnownedSlice()))
         {
             context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
             return TestResult::Fail;
@@ -2970,28 +2970,28 @@ static TestResult generateExpectedOutput(
         {
         case SLANG_DXIL:
         case SLANG_DXIL_ASM:
-        {
-            expectedCmdLine.addArg(filePath + ".hlsl");
-            expectedCmdLine.addArg("-pass-through");
-            expectedCmdLine.addArg("dxc");
-            break;
-        }
+            {
+                expectedCmdLine.addArg(filePath + ".hlsl");
+                expectedCmdLine.addArg("-pass-through");
+                expectedCmdLine.addArg("dxc");
+                break;
+            }
         case SLANG_DXBC:
         case SLANG_DXBC_ASM:
-        {
-            expectedCmdLine.addArg(filePath + ".hlsl");
-            expectedCmdLine.addArg("-pass-through");
-            expectedCmdLine.addArg("fxc");
-            break;
-        }
+            {
+                expectedCmdLine.addArg(filePath + ".hlsl");
+                expectedCmdLine.addArg("-pass-through");
+                expectedCmdLine.addArg("fxc");
+                break;
+            }
         default:
-        {
-            expectedCmdLine.addArg(filePath + ".glsl");
-            expectedCmdLine.addArg("-emit-spirv-via-glsl");
-            expectedCmdLine.addArg("-pass-through");
-            expectedCmdLine.addArg("glslang");
-            break;
-        }
+            {
+                expectedCmdLine.addArg(filePath + ".glsl");
+                expectedCmdLine.addArg("-emit-spirv-via-glsl");
+                expectedCmdLine.addArg("-pass-through");
+                expectedCmdLine.addArg("glslang");
+                break;
+            }
         }
     }
 
@@ -3119,8 +3119,8 @@ TestResult runCrossCompilerTest(TestContext* context, TestInput& input)
     else
     {
         if (!StringUtil::areLinesEqual(
-            actualOutput.getUnownedSlice(),
-            expectedOutput.getUnownedSlice()))
+                actualOutput.getUnownedSlice(),
+                expectedOutput.getUnownedSlice()))
         {
             result = TestResult::Fail;
             context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
@@ -3371,8 +3371,8 @@ TestResult runGLSLComparisonTest(TestContext* context, TestInput& input)
         return TestResult::Fail;
 
     if (!StringUtil::areLinesEqual(
-        actualOutput.getUnownedSlice(),
-        expectedOutput.getUnownedSlice()))
+            actualOutput.getUnownedSlice(),
+            expectedOutput.getUnownedSlice()))
     {
         context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
 
@@ -3543,28 +3543,28 @@ static SlangResult _compareWithType(
         switch (scalarType)
         {
         default:
-        {
-            if (lineActual.trim() != lineRef.trim())
             {
-                return SLANG_FAIL;
+                if (lineActual.trim() != lineRef.trim())
+                {
+                    return SLANG_FAIL;
+                }
+                break;
             }
-            break;
-        }
         case ScalarType::Float16:
         case ScalarType::Float32:
         case ScalarType::Float64:
-        {
-
-            // Compare as double
-            double valueA = _textToDouble(lineActual);
-            double valueB = _textToDouble(lineRef);
-
-            if (!Math::AreNearlyEqual(valueA, valueB, differenceThreshold))
             {
-                return SLANG_FAIL;
+
+                // Compare as double
+                double valueA = _textToDouble(lineActual);
+                double valueB = _textToDouble(lineRef);
+
+                if (!Math::AreNearlyEqual(valueA, valueB, differenceThreshold))
+                {
+                    return SLANG_FAIL;
+                }
+                break;
             }
-            break;
-        }
         }
     }
 
@@ -3651,23 +3651,24 @@ TestResult runComputeComparisonImpl(
     String fileCheckPrefix;
     auto bufferResult =
         input.testOptions->getFileCheckBufferPrefix(fileCheckPrefix)
-        ? _fileCheckTest(*context, input.filePath, fileCheckPrefix, actualOutputContent)
-        : _fileComparisonTest(
-            *context,
-            input,
-            nullptr,
-            ".expected.txt",
-            actualOutputContent,
-            [](const auto& a, const auto& e) {
-        return SLANG_SUCCEEDED(
-            _compareWithType(a.getUnownedSlice(), e.getUnownedSlice()));
-    });
+            ? _fileCheckTest(*context, input.filePath, fileCheckPrefix, actualOutputContent)
+            : _fileComparisonTest(
+                  *context,
+                  input,
+                  nullptr,
+                  ".expected.txt",
+                  actualOutputContent,
+                  [](const auto& a, const auto& e)
+                  {
+                      return SLANG_SUCCEEDED(
+                          _compareWithType(a.getUnownedSlice(), e.getUnownedSlice()));
+                  });
     return std::max(compileResult, bufferResult);
 }
 
 TestResult runSlangComputeComparisonTest(TestContext* context, TestInput& input)
 {
-    const char* langOpts[] = { "-slang", "-compute" };
+    const char* langOpts[] = {"-slang", "-compute"};
     return runComputeComparisonImpl(context, input, langOpts, SLANG_COUNT_OF(langOpts));
 }
 
@@ -3678,13 +3679,13 @@ TestResult runSlangComputeComparisonTestEx(TestContext* context, TestInput& inpu
 
 TestResult runHLSLComputeTest(TestContext* context, TestInput& input)
 {
-    const char* langOpts[] = { "--hlsl-rewrite", "-compute" };
+    const char* langOpts[] = {"--hlsl-rewrite", "-compute"};
     return runComputeComparisonImpl(context, input, langOpts, SLANG_COUNT_OF(langOpts));
 }
 
 TestResult runSlangRenderComputeComparisonTest(TestContext* context, TestInput& input)
 {
-    const char* langOpts[] = { "-slang", "-gcompute" };
+    const char* langOpts[] = {"-slang", "-gcompute"};
     return runComputeComparisonImpl(context, input, langOpts, SLANG_COUNT_OF(langOpts));
 }
 
@@ -3812,7 +3813,7 @@ SlangResult STBImage::read(const char* filename)
 bool STBImage::isComparable(const ThisType& rhs) const
 {
     return (this == &rhs) || (m_width == rhs.m_width && m_height == rhs.m_height &&
-        m_numChannels == rhs.m_numChannels);
+                              m_numChannels == rhs.m_numChannels);
 }
 
 
@@ -3990,8 +3991,8 @@ TestResult runHLSLRenderComparisonTestImpl(
 
     // Compare text output only if we generated the expected output
     if (!context->options.skipReferenceImageGeneration && !StringUtil::areLinesEqual(
-        actualOutput.getUnownedSlice(),
-        expectedOutput.getUnownedSlice()))
+                                                              actualOutput.getUnownedSlice(),
+                                                              expectedOutput.getUnownedSlice()))
     {
         context->getTestReporter()->dumpOutputDifference(expectedOutput, actualOutput);
 
@@ -4061,7 +4062,7 @@ static const TestCommandInfo s_testCommandInfos[] = {
     {"COMPILE", &runCompile, 0},
     {"DOC", &runDocTest, 0},
     {"LANG_SERVER", &runLanguageServerTest, 0},
-    {"EXECUTABLE", &runExecutableTest, RenderApiFlag::CPU} };
+    {"EXECUTABLE", &runExecutableTest, RenderApiFlag::CPU}};
 
 const TestCommandInfo* _findTestCommandInfoByCommand(const UnownedStringSlice& name)
 {
@@ -4196,9 +4197,9 @@ static void _calcSynthesizedTests(
                 case SLANG_SOURCE_LANGUAGE_GLSL:
                 case SLANG_SOURCE_LANGUAGE_C:
                 case SLANG_SOURCE_LANGUAGE_CPP:
-                {
-                    isCrossCompile = false;
-                }
+                    {
+                        isCrossCompile = false;
+                    }
                 default:
                     break;
                 }
@@ -4288,7 +4289,7 @@ static bool _canIgnore(TestContext* context, const TestDetails& details)
 
     // Are all the required backends available?
     if (((requirements.usedBackendFlags & context->availableBackendFlags) !=
-        requirements.usedBackendFlags))
+         requirements.usedBackendFlags))
     {
         return true;
     }
@@ -4349,8 +4350,8 @@ static SlangResult _runTestsOnFile(TestContext* context, String filePath)
 
             apiUsedFlags |= requirements.usedRenderApiFlags;
             explictUsedApiFlags |= (requirements.explicitRenderApi != RenderApiType::Unknown)
-                ? (RenderApiFlags(1) << int(requirements.explicitRenderApi))
-                : 0;
+                                       ? (RenderApiFlags(1) << int(requirements.explicitRenderApi))
+                                       : 0;
         }
         context->setTestRequirements(nullptr);
     }
@@ -4733,7 +4734,7 @@ static SlangResult runUnitTestModule(
         {
             if (testPassesCategoryMask(context, testOptions))
             {
-                tests.add(TestItem{ testFunc, testName, command });
+                tests.add(TestItem{testFunc, testName, command});
             }
         }
     }
@@ -4845,7 +4846,7 @@ SlangResult innerMain(int argc, char** argv)
     TestContext context;
     SLANG_RETURN_ON_FAIL(SLANG_FAILED(context.init(argv[0])))
 
-        auto& categorySet = context.categorySet;
+    auto& categorySet = context.categorySet;
 
     // Set up our test categories here
     auto fullTestCategory = categorySet.add("full", nullptr);
@@ -4884,7 +4885,7 @@ SlangResult innerMain(int argc, char** argv)
     categorySet.defaultCategory = fullTestCategory;
 
     // All following values are initialized to '0', so null.
-    TestCategory* passThroughCategories[SLANG_PASS_THROUGH_COUNT_OF] = { nullptr };
+    TestCategory* passThroughCategories[SLANG_PASS_THROUGH_COUNT_OF] = {nullptr};
 
     // Work out what backends/pass-thrus are available
     {

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -181,6 +181,8 @@ public:
     Slang::RefPtr<Slang::JSONRPCConnection> m_languageServerConnection;
 
     bool isRetry;
+    bool enableDebugLayers;
+
     std::mutex mutexFailedTests;
     Slang::List<Slang::RefPtr<FileTestInfo>> failedFileTests;
     Slang::List<Slang::String> failedUnitTests;

--- a/tools/unit-test/slang-unit-test.h
+++ b/tools/unit-test/slang-unit-test.h
@@ -43,6 +43,7 @@ struct UnitTestContext
     const char* workDirectory;
     const char* executableDirectory;
     Slang::RenderApiFlags enabledApis;
+    bool enableDebugLayers;
 };
 
 typedef void (*UnitTestFunc)(UnitTestContext*);


### PR DESCRIPTION
This PR refactors and unifies the debug layer control logic in slang-test. A new `-disable-debug-layers` option is introduced, allowing debug builds to skip enabling the validation (debug) layer. This is currently needed to ensure stability in the debug test suite.

Previously, different toggles such as `ENABLE_VALIDATION_LAYER`, `ENABLE_DEBUG_LAYER`, and `debugLayerEnabled` were used inconsistently across different components of slang-test. This PR standardizes the logic by using a single variable, debugLayerEnabled, to control the enabling/disabling of the debug layer internally.

Notes:
By default, the debug/validation layer is enabled in debug builds and is not supported in release builds of slang-test.

Fixes: #7132