### PR TITLE
Implement MapElement for CoopMat

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -23415,6 +23415,24 @@ struct CoopMat
         };
     }
 
+    __intrinsic_op($(kIROp_CoopMatMapElementIFunc))
+    internal static This __MapElement<
+        TOperator,
+        TFunc : IFunc<T, uint32_t, uint32_t, T>
+    >(
+        This coopMat,
+        TOperator mapOp,
+        Ptr<TFunc> pMapOp
+    );
+
+    This MapElement<
+        TFunc : IFunc<T, uint32_t, uint32_t, T>
+    >(TFunc mapOp)
+    {
+        Ptr<TFunc> pMapOp = &mapOp;
+        return __MapElement(this, mapOp.operator(), pMapOp);
+    }
+
     //
     // Store
     //
@@ -24276,7 +24294,44 @@ CoopMat<T, S, M, N, CoopMatMatrixUse.MatrixAccumulator> coopMatMulAdd<
     };
 }
 
+extension<
+    let S : MemoryScope,
+    let M : int,
+    let N : int,
+    let R : linalg.CoopMatMatrixUse,
+    each Ts : __BuiltinArithmeticType
+> Tuple<expand linalg.CoopMat<each Ts, S, M, N, R>>
+{
+#if 0
+    // The type of `mapOp` gets ConcreteTypePack due to `expand each`
+    // and it cannot match to the regular flat function type.
+    // TODO: We need to fix it.
+    __intrinsic_op($(kIROp_TupleCoopMatMapElementFunc))
+    CoopMat<TR, S, M, N, R> MapElement<
+        TR : __BuiltinArithmeticType,
+    >(functype(uint32_t, uint32_t, expand each Ts)->TR mapOp);
+#endif
+
+    __intrinsic_op($(kIROp_TupleCoopMatMapElementIFunc))
+    static CoopMat<TR, S, M, N, R> __MapElement<
+        TR : __BuiltinArithmeticType,
+        TOperator,
+        TFunc : IFunc<TR, uint32_t, uint32_t, expand each Ts>
+    >(This tuple, TOperator mapOp, Ptr<TFunc> pMapOp);
+
+    [ForceInline]
+    CoopMat<TR, S, M, N, R> MapElement<
+        TR : __BuiltinArithmeticType,
+        TFunc : IFunc<TR, uint32_t, uint32_t, expand each Ts>
+    >(TFunc mapOp)
+    {
+        Ptr<TFunc> pMapOp = &mapOp;
+        return __MapElement<TR>(this, mapOp.operator(), pMapOp);
+    }
+};
+
 } // namespace linalg
+
 
 //
 // Cooperative Vector

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -24303,7 +24303,7 @@ extension<
     each Ts : __BuiltinArithmeticType
 > Tuple<linalg.CoopMat<T, S, M, N, R>, expand linalg.CoopMat<each Ts, S, M, N, R>>
 {
-    __intrinsic_op($(kIROp_TupleCoopMatMapElementFunc))
+    __intrinsic_op($(kIROp_TupleCoopMatMapElementIFunc))
     CoopMat<T, S, M, N, R> MapElement(functype(uint32_t, uint32_t, T, expand each Ts)->T mapOp);
 
     __intrinsic_op($(kIROp_TupleCoopMatMapElementIFunc))

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -24295,38 +24295,30 @@ CoopMat<T, S, M, N, CoopMatMatrixUse.MatrixAccumulator> coopMatMulAdd<
 }
 
 extension<
+    T : __BuiltinArithmeticType,
     let S : MemoryScope,
     let M : int,
     let N : int,
     let R : linalg.CoopMatMatrixUse,
     each Ts : __BuiltinArithmeticType
-> Tuple<expand linalg.CoopMat<each Ts, S, M, N, R>>
+> Tuple<linalg.CoopMat<T, S, M, N, R>, expand linalg.CoopMat<each Ts, S, M, N, R>>
 {
-#if 0
-    // The type of `mapOp` gets ConcreteTypePack due to `expand each`
-    // and it cannot match to the regular flat function type.
-    // TODO: We need to fix it.
     __intrinsic_op($(kIROp_TupleCoopMatMapElementFunc))
-    CoopMat<TR, S, M, N, R> MapElement<
-        TR : __BuiltinArithmeticType,
-    >(functype(uint32_t, uint32_t, expand each Ts)->TR mapOp);
-#endif
+    CoopMat<T, S, M, N, R> MapElement(functype(uint32_t, uint32_t, T, expand each Ts)->T mapOp);
 
     __intrinsic_op($(kIROp_TupleCoopMatMapElementIFunc))
-    static CoopMat<TR, S, M, N, R> __MapElement<
-        TR : __BuiltinArithmeticType,
+    static CoopMat<T, S, M, N, R> __MapElement<
         TOperator,
-        TFunc : IFunc<TR, uint32_t, uint32_t, expand each Ts>
+        TFunc : IFunc<T, uint32_t, uint32_t, T, expand each Ts>
     >(This tuple, TOperator mapOp, Ptr<TFunc> pMapOp);
 
     [ForceInline]
-    CoopMat<TR, S, M, N, R> MapElement<
-        TR : __BuiltinArithmeticType,
-        TFunc : IFunc<TR, uint32_t, uint32_t, expand each Ts>
+    CoopMat<T, S, M, N, R> MapElement<
+        TFunc : IFunc<T, uint32_t, uint32_t, T, expand each Ts>
     >(TFunc mapOp)
     {
         Ptr<TFunc> pMapOp = &mapOp;
-        return __MapElement<TR>(this, mapOp.operator(), pMapOp);
+        return __MapElement(this, mapOp.operator(), pMapOp);
     }
 };
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -23422,15 +23422,14 @@ struct CoopMat
     >(
         This coopMat,
         TOperator mapOp,
-        Ptr<TFunc> pMapOp
+        TFunc mapObj
     );
 
     This MapElement<
         TFunc : IFunc<T, uint32_t, uint32_t, T>
     >(TFunc mapOp)
     {
-        Ptr<TFunc> pMapOp = &mapOp;
-        return __MapElement(this, mapOp.operator(), pMapOp);
+        return __MapElement(this, mapOp.operator(), mapOp);
     }
 
     //
@@ -24310,15 +24309,14 @@ extension<
     static CoopMat<T, S, M, N, R> __MapElement<
         TOperator,
         TFunc : IFunc<T, uint32_t, uint32_t, T, expand each Ts>
-    >(This tuple, TOperator mapOp, Ptr<TFunc> pMapOp);
+    >(This tuple, TOperator mapOp, TFunc mapObj);
 
     [ForceInline]
     CoopMat<T, S, M, N, R> MapElement<
         TFunc : IFunc<T, uint32_t, uint32_t, T, expand each Ts>
     >(TFunc mapOp)
     {
-        Ptr<TFunc> pMapOp = &mapOp;
-        return __MapElement(this, mapOp.operator(), pMapOp);
+        return __MapElement(this, mapOp.operator(), mapOp);
     }
 };
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -24302,10 +24302,10 @@ extension<
     each Ts : __BuiltinArithmeticType
 > Tuple<linalg.CoopMat<T, S, M, N, R>, expand linalg.CoopMat<each Ts, S, M, N, R>>
 {
-    __intrinsic_op($(kIROp_TupleCoopMatMapElementIFunc))
+    __intrinsic_op($(kIROp_CoopMatMapElementIFunc))
     CoopMat<T, S, M, N, R> MapElement(functype(uint32_t, uint32_t, T, expand each Ts)->T mapOp);
 
-    __intrinsic_op($(kIROp_TupleCoopMatMapElementIFunc))
+    __intrinsic_op($(kIROp_CoopMatMapElementIFunc))
     static CoopMat<T, S, M, N, R> __MapElement<
         TOperator,
         TFunc : IFunc<T, uint32_t, uint32_t, T, expand each Ts>

--- a/source/slang/slang-ast-type.cpp
+++ b/source/slang/slang-ast-type.cpp
@@ -578,7 +578,19 @@ Val* FuncType::_substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet s
     List<Type*> substParamTypes;
     for (Index pp = 0; pp < getParamCount(); pp++)
     {
-        substParamTypes.add(as<Type>(getParamType(pp)->substituteImpl(astBuilder, subst, &diff)));
+        auto substParamType = as<Type>(getParamType(pp)->substituteImpl(astBuilder, subst, &diff));
+        if (auto typePack = as<ConcreteTypePack>(substParamType))
+        {
+            // Unwrap the ConcreteTypePack and add each element as a parameter
+            for (Index i = 0; i < typePack->getTypeCount(); ++i)
+            {
+                substParamTypes.add(typePack->getElementType(i));
+            }
+        }
+        else
+        {
+            substParamTypes.add(substParamType);
+        }
     }
 
     // early exit for no change...

--- a/source/slang/slang-ast-type.cpp
+++ b/source/slang/slang-ast-type.cpp
@@ -786,7 +786,18 @@ Val* ConcreteTypePack::_substituteImplOverride(
     for (Index i = 0; i < getTypeCount(); i++)
     {
         auto substType = as<Type>(getElementType(i)->substituteImpl(astBuilder, subst, &diff));
-        substElementTypes.add(substType);
+        if (auto typePack = as<ConcreteTypePack>(substType))
+        {
+            // Unwrap the ConcreteTypePack and add each element as a parameter
+            for (Index j = 0; j < typePack->getTypeCount(); ++j)
+            {
+                substElementTypes.add(typePack->getElementType(j));
+            }
+        }
+        else
+        {
+            substElementTypes.add(substType);
+        }
     }
     if (!diff)
         return this;

--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -1231,8 +1231,14 @@ struct IndexSpan
     Index index;
     Index count;
 
-    IndexSpan() : index(0), count(0) {}
-    IndexSpan(Index idx, Index cnt) : index(idx), count(cnt) {}
+    IndexSpan()
+        : index(0), count(0)
+    {
+    }
+    IndexSpan(Index idx, Index cnt)
+        : index(idx), count(cnt)
+    {
+    }
 };
 
 struct IndexSpanPair
@@ -1241,7 +1247,10 @@ struct IndexSpanPair
     IndexSpan second;
 
     IndexSpanPair() {}
-    IndexSpanPair(IndexSpan f, IndexSpan s) : first(f), second(s) {}
+    IndexSpanPair(IndexSpan f, IndexSpan s)
+        : first(f), second(s)
+    {
+    }
 };
 
 // Helper function to map type arguments between two types, handling expandable types
@@ -1249,15 +1258,16 @@ static bool matchTypeArgMapping(
     Type* firstType,
     Type* secondType,
     ShortList<Type*>& outFlattenedFirst,
-    ShortList<Type*>& outFlattenedSecond, ShortList<IndexSpanPair>&outMapping)
+    ShortList<Type*>& outFlattenedSecond,
+    ShortList<IndexSpanPair>& outMapping)
 {
     // Unwrap and flatten the types
     ShortList<Type*>& firstTypes = outFlattenedFirst;
     ShortList<Type*>& secondTypes = outFlattenedSecond;
 
     // Count expandable types as we unwrap
-    Index firstExpandableCount = 0;
-    Index secondExpandableCount = 0;
+    int firstExpandableCount = 0;
+    int secondExpandableCount = 0;
 
     // Unwrap first type
     if (auto concretePack = as<ConcreteTypePack>(firstType))
@@ -1291,35 +1301,38 @@ static bool matchTypeArgMapping(
         secondExpandableCount++;
     }
 
-    Index firstCount = firstTypes.getCount();
-    Index secondCount = secondTypes.getCount();
-    Index countDifference = firstCount - secondCount;
+    int firstCount = (int)firstTypes.getCount();
+    int secondCount = (int)secondTypes.getCount();
+    int countDifference =
+        (firstCount - firstExpandableCount) - (secondCount - secondExpandableCount);
 
     // Determine which side should expand to match the other
     // We want to map the side with fewer expandables to the side with more expandables
-    bool shouldExpandFirst = false;
-    bool shouldExpandSecond = false;
-    Index typesPerExpand = 1;
+    int typesPerExpand = 0;
+    bool shouldExpandSecond = (countDifference > 0);
+    bool shouldExpandFirst = (countDifference < 0);
 
-    if (countDifference > 0)
+    if (shouldExpandSecond)
     {
         // More types on first, need to expand second
-        shouldExpandSecond = true;
         if (secondExpandableCount == 0)
             return false;
-        if (countDifference % secondExpandableCount != 0)
+
+        int countToMatch = countDifference + firstExpandableCount;
+        if (countToMatch % secondExpandableCount != 0)
             return false;
-        typesPerExpand = 1 + countDifference / secondExpandableCount;
+        typesPerExpand = countToMatch / secondExpandableCount;
     }
-    else if (countDifference < 0)
+    else if (shouldExpandFirst)
     {
         // More types on second, need to expand first
-        shouldExpandFirst = true;
         if (firstExpandableCount == 0)
             return false;
-        if ((-countDifference) % firstExpandableCount != 0)
+
+        int countToMatch = -countDifference + secondExpandableCount;
+        if (countToMatch % firstExpandableCount != 0)
             return false;
-        typesPerExpand = 1 + (-countDifference) / firstExpandableCount;
+        typesPerExpand = countToMatch / firstExpandableCount;
     }
     // If countDifference == 0, no expansion needed
 
@@ -1332,7 +1345,7 @@ static bool matchTypeArgMapping(
         IndexSpanPair mapping;
 
         // Determine spans based on expandable types and count difference
-        if (countDifference < 0)
+        if (shouldExpandFirst)
         {
             // Expanding first to match second
             if (isAbstractTypePack(firstTypes[firstIndex]))
@@ -1349,7 +1362,7 @@ static bool matchTypeArgMapping(
             }
             firstIndex++;
         }
-        else if (countDifference > 0)
+        else if (shouldExpandSecond)
         {
             // Expanding second to match first
             if (isAbstractTypePack(secondTypes[secondIndex]))
@@ -1378,8 +1391,8 @@ static bool matchTypeArgMapping(
         outMapping.add(mapping);
     }
 
-    SLANG_ASSERT(firstIndex == firstCount);
-    SLANG_ASSERT(secondIndex == secondCount);
+    SLANG_ASSERT(!shouldExpandSecond || firstIndex == firstCount);
+    SLANG_ASSERT(!shouldExpandFirst || secondIndex == secondCount);
     return true;
 }
 
@@ -1503,7 +1516,9 @@ bool SemanticsVisitor::TryUnifyTypes(
                         return false;
                 }
             }
-            else if (auto genericTypePackParamDecl = asGenericTypePackParamDecl(singleType, constraints.genericDecl))
+            else if (
+                auto genericTypePackParamDecl =
+                    asGenericTypePackParamDecl(singleType, constraints.genericDecl))
             {
                 // Single GenericTypePackParamDecl unifies with multiple types
                 for (Index i = 0; i < multipleCount; ++i)

--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -1210,22 +1210,6 @@ void SemanticsVisitor::maybeUnifyUnconstraintIntParam(
     constraints.constraints.add(c);
 }
 
-static GenericTypePackParamDecl* asGenericTypePackParamDecl(Type* type, GenericDecl* genericDecl)
-{
-    if (auto declRefType = as<DeclRefType>(type))
-    {
-        if (auto declRef = declRefType->getDeclRef())
-        {
-            if (auto typePackParamDecl = as<GenericTypePackParamDecl>(declRef.getDecl()))
-            {
-                if (typePackParamDecl->parentDecl == genericDecl)
-                    return typePackParamDecl;
-            }
-        }
-    }
-    return nullptr;
-}
-
 struct IndexSpan
 {
     Index index;
@@ -1526,9 +1510,7 @@ bool SemanticsVisitor::TryUnifyTypes(
                     unifyPairs.add(pair);
                 }
             }
-            else if (
-                auto genericTypePackParamDecl =
-                    asGenericTypePackParamDecl(singleType, constraints.genericDecl))
+            else if (isDeclRefTypeOf<GenericTypePackParamDecl>(singleType))
             {
                 // Single GenericTypePackParamDecl unifies with multiple types as a pack - one pair
                 // total For GenericTypePackParamDecl, singleType always goes to first argument (no

--- a/source/slang/slang-emit-spirv-ops.h
+++ b/source/slang/slang-emit-spirv-ops.h
@@ -2666,4 +2666,30 @@ SpvInst* emitOpTypeNodePayloadArray(IRInst* inst, const T& type)
         type);
 }
 
+// https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixPerElementOpNV
+template<typename T1, typename T2, typename T3, typename... TOperands>
+SpvInst* emiOpCooperativeMatrixPerElementOp(
+    SpvInstParent* parent,
+    IRInst* inst,
+    const T1& idResultType,
+    const T2& matrix,
+    const T3& func,
+    const TOperands&... operands)
+{
+    static_assert(isSingular<T1>);
+    static_assert(isSingular<T2>);
+    static_assert(isSingular<T3>);
+    // Emit the instruction with a variable number of operands
+    return emitInst(
+        parent,
+        inst,
+        SpvOpCooperativeMatrixPerElementOpNV,
+        idResultType,
+        kResultID,
+        matrix,
+        func,
+        operands...);
+}
+
+
 #endif // SLANG_IN_SPIRV_EMIT_CONTEXT

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -7701,9 +7701,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         }
     }
 
-    SpvInst* emitCoopMatMapElementWithIFunc(
-        SpvInstParent* parent,
-        IRCoopMatMapElementIFunc* inst)
+    SpvInst* emitCoopMatMapElementWithIFunc(SpvInstParent* parent, IRCoopMatMapElementIFunc* inst)
     {
         ensureExtensionDeclaration(UnownedStringSlice("SPV_NV_cooperative_matrix2"));
         requireSPIRVCapability(SpvCapabilityCooperativeMatrixPerElementOperationsNV);
@@ -7713,7 +7711,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         IRInst* mat0 = nullptr;
 
         UInt tupleCount = 0;
-        IRInst* tuple = tuple = as<IRMakeStruct>(matOrTuple);
+        IRInst* tuple = as<IRMakeStruct>(matOrTuple);
         if (tuple)
         {
             mat0 = tuple->getOperand(0);

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -790,7 +790,6 @@ INST(TorchGetCudaStream, TorchGetCudaStream, 0, 0)
 INST(TorchTensorGetView, TorchTensorGetView, 0, 0)
 
 INST(CoopMatMapElementIFunc, CoopMatMapElementIFunc, 2, 0)
-INST(TupleCoopMatMapElementIFunc, TupleCoopMatMapElementIFunc, 2, 0)
 
 INST(AllocateOpaqueHandle, allocateOpaqueHandle, 0, 0)
 

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -789,9 +789,8 @@ INST(AllocateTorchTensor, allocTorchTensor, 0, 0)
 INST(TorchGetCudaStream, TorchGetCudaStream, 0, 0)
 INST(TorchTensorGetView, TorchTensorGetView, 0, 0)
 
-INST(CoopMatMapElementIFunc, CoopMatMapElementIFunc, 3, 0)
-INST(TupleCoopMatMapElementFunc, TupleCoopMatMapElementFunc, 2, 0)
-INST(TupleCoopMatMapElementIFunc, TupleCoopMatMapElementIFunc, 3, 0)
+INST(CoopMatMapElementIFunc, CoopMatMapElementIFunc, 2, 0)
+INST(TupleCoopMatMapElementIFunc, TupleCoopMatMapElementIFunc, 2, 0)
 
 INST(AllocateOpaqueHandle, allocateOpaqueHandle, 0, 0)
 

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -789,6 +789,10 @@ INST(AllocateTorchTensor, allocTorchTensor, 0, 0)
 INST(TorchGetCudaStream, TorchGetCudaStream, 0, 0)
 INST(TorchTensorGetView, TorchTensorGetView, 0, 0)
 
+INST(CoopMatMapElementIFunc, CoopMatMapElementIFunc, 3, 0)
+INST(TupleCoopMatMapElementFunc, TupleCoopMatMapElementFunc, 2, 0)
+INST(TupleCoopMatMapElementIFunc, TupleCoopMatMapElementIFunc, 3, 0)
+
 INST(AllocateOpaqueHandle, allocateOpaqueHandle, 0, 0)
 
     // Return the register index thtat a resource is bound to.

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -3124,23 +3124,16 @@ struct IRMakeCoopVector : IRInst
     IR_LEAF_ISA(MakeCoopVector)
 };
 
-struct IRCoopMatMapElementIFuncBase : IRInst
-{
-    IRFunc* getIFuncCall() { return as<IRFunc>(getOperand(1)); }
-    IRInst* getIFuncThis() { return getOperand(2); }
-    void setIFuncCall(IRFunc* func) { setOperand(1, func); }
-};
-
-struct IRCoopMatMapElementIFunc : IRCoopMatMapElementIFuncBase
+struct IRCoopMatMapElementIFunc : IRInst
 {
     IR_LEAF_ISA(CoopMatMapElementIFunc)
     IRInst* getCoopMat() { return getOperand(0); }
-};
-
-struct IRTupleCoopMatMapElementIFunc : IRCoopMatMapElementIFuncBase
-{
-    IR_LEAF_ISA(TupleCoopMatMapElementIFunc)
     IRInst* getTuple() { return getOperand(0); }
+    IRFunc* getIFuncCall() { return as<IRFunc>(getOperand(1)); }
+    IRInst* getIFuncThis() { return getOperand(2); }
+
+    bool hasIFuncThis() { return getOperandCount() > 2; }
+    void setIFuncCall(IRFunc* func) { setOperand(1, func); }
 };
 
 // An Instruction that creates a differential pair value from a
@@ -4260,7 +4253,7 @@ public:
     IRInst* emitGetTupleElement(IRType* type, IRInst* tuple, UInt element);
     IRInst* emitGetTupleElement(IRType* type, IRInst* tuple, IRInst* element);
 
-    IRInst* emitCoopMatMapElementFunc(IRType* type, IROp op, IRInst* tuple, IRInst* func);
+    IRInst* emitCoopMatMapElementFunc(IRType* type, IRInst* tuple, IRInst* func);
 
     IRInst* emitGetElement(IRType* type, IRInst* arrayLikeType, IRIntegerValue element);
     IRInst* emitGetElementPtr(IRType* type, IRInst* arrayLikeType, IRIntegerValue element);

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -3143,13 +3143,6 @@ struct IRTupleCoopMatMapElementIFunc : IRCoopMatMapElementIFuncBase
     IRInst* getTuple() { return getOperand(0); }
 };
 
-struct IRTupleCoopMatMapElementFunc : IRInst
-{
-    IR_LEAF_ISA(TupleCoopMatMapElementFunc)
-    IRInst* getTuple() { return getOperand(0); }
-    IRFunc* getFuncCall() { return as<IRFunc>(getOperand(1)); }
-};
-
 // An Instruction that creates a differential pair value from a
 // primal and differential.
 
@@ -4266,6 +4259,8 @@ public:
 
     IRInst* emitGetTupleElement(IRType* type, IRInst* tuple, UInt element);
     IRInst* emitGetTupleElement(IRType* type, IRInst* tuple, IRInst* element);
+
+    IRInst* emitCoopMatMapElementFunc(IRType* type, IROp op, IRInst* tuple, IRInst* func);
 
     IRInst* emitGetElement(IRType* type, IRInst* arrayLikeType, IRIntegerValue element);
     IRInst* emitGetElementPtr(IRType* type, IRInst* arrayLikeType, IRIntegerValue element);

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -3124,6 +3124,32 @@ struct IRMakeCoopVector : IRInst
     IR_LEAF_ISA(MakeCoopVector)
 };
 
+struct IRCoopMatMapElementIFuncBase : IRInst
+{
+    IRFunc* getIFuncCall() { return as<IRFunc>(getOperand(1)); }
+    IRInst* getIFuncThis() { return getOperand(2); }
+    void setIFuncCall(IRFunc* func) { setOperand(1, func); }
+};
+
+struct IRCoopMatMapElementIFunc : IRCoopMatMapElementIFuncBase
+{
+    IR_LEAF_ISA(CoopMatMapElementIFunc)
+    IRInst* getCoopMat() { return getOperand(0); }
+};
+
+struct IRTupleCoopMatMapElementIFunc : IRCoopMatMapElementIFuncBase
+{
+    IR_LEAF_ISA(TupleCoopMatMapElementIFunc)
+    IRInst* getTuple() { return getOperand(0); }
+};
+
+struct IRTupleCoopMatMapElementFunc : IRInst
+{
+    IR_LEAF_ISA(TupleCoopMatMapElementFunc)
+    IRInst* getTuple() { return getOperand(0); }
+    IRFunc* getFuncCall() { return as<IRFunc>(getOperand(1)); }
+};
+
 // An Instruction that creates a differential pair value from a
 // primal and differential.
 

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -112,6 +112,12 @@ static void registerLegalizedValue(
     IRInst* irValue,
     LegalVal const& legalVal)
 {
+    if (legalVal.flavor == LegalFlavor::none)
+    {
+        // TODO: Not sure what needs to happen.
+        int a = 0;
+        ++a;
+    }
     context->mapValToLegalVal[irValue] = legalVal;
 }
 

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -1524,6 +1524,8 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             paramTypes.add(targetFunc->getParamType(i));
         }
 
+        SLANG_ASSERT(paramTypes.getCount() >= 4);
+
         IRType* tempTypes[4];
         tempTypes[3] = builder.getPtrType(paramTypes[0]);
         tempTypes[0] = paramTypes[1];
@@ -1570,8 +1572,14 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         builder.setInsertBefore(mapElementIFunc);
 
         auto ifuncCall = mapElementIFunc->getIFuncCall();
-        auto funcSynth = createWrapperFunctionForPerElement(builder, ifuncCall);
-        mapElementIFunc->setIFuncCall(funcSynth);
+
+        // `this` of the functor is optional.
+        // Skip the synthesis if `this` is not passed.
+        if (ifuncCall->getParamCount() > 3)
+        {
+            auto funcSynth = createWrapperFunctionForPerElement(builder, ifuncCall);
+            mapElementIFunc->setIFuncCall(funcSynth);
+        }
     }
 
     void legalizeSPIRVEntryPoint(IRFunc* func, IREntryPointDecoration* entryPointDecor)

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -1566,19 +1566,19 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         return wrapperFunc;
     }
 
-    void processCoopMatMapElementIFunc(IRCoopMatMapElementIFuncBase* mapElementIFunc)
+    void processCoopMatMapElementIFunc(IRCoopMatMapElementIFunc* inst)
     {
-        IRBuilder builder{mapElementIFunc};
-        builder.setInsertBefore(mapElementIFunc);
+        IRBuilder builder{inst};
+        builder.setInsertBefore(inst);
 
-        auto ifuncCall = mapElementIFunc->getIFuncCall();
+        auto ifuncCall = inst->getIFuncCall();
 
         // `this` of the functor is optional.
         // Skip the synthesis if `this` is not passed.
         if (ifuncCall->getParamCount() > 3)
         {
             auto funcSynth = createWrapperFunctionForPerElement(builder, ifuncCall);
-            mapElementIFunc->setIFuncCall(funcSynth);
+            inst->setIFuncCall(funcSynth);
         }
     }
 
@@ -1820,10 +1820,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 processBitFieldOp(inst);
                 break;
             case kIROp_CoopMatMapElementIFunc:
-                processCoopMatMapElementIFunc(as<IRCoopMatMapElementIFuncBase>(inst));
-                break;
-            case kIROp_TupleCoopMatMapElementIFunc:
-                processCoopMatMapElementIFunc(as<IRCoopMatMapElementIFuncBase>(inst));
+                processCoopMatMapElementIFunc(as<IRCoopMatMapElementIFunc>(inst));
                 break;
 
             case kIROp_DebugValue:

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -4467,10 +4467,10 @@ IRInst* IRBuilder::emitGetTupleElement(IRType* type, IRInst* tuple, UInt element
     return emitGetTupleElement(type, tuple, getIntValue(getIntType(), element));
 }
 
-IRInst* IRBuilder::emitCoopMatMapElementFunc(IRType* type, IROp op, IRInst* tuple, IRInst* func)
+IRInst* IRBuilder::emitCoopMatMapElementFunc(IRType* type, IRInst* tuple, IRInst* func)
 {
     IRInst* args[] = {tuple, func};
-    return emitIntrinsicInst(type, op, 2, args);
+    return emitIntrinsicInst(type, kIROp_CoopMatMapElementIFunc, 2, args);
 }
 
 IRInst* IRBuilder::emitMakeResultError(IRType* resultType, IRInst* errorVal)

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -4467,6 +4467,12 @@ IRInst* IRBuilder::emitGetTupleElement(IRType* type, IRInst* tuple, UInt element
     return emitGetTupleElement(type, tuple, getIntValue(getIntType(), element));
 }
 
+IRInst* IRBuilder::emitCoopMatMapElementFunc(IRType* type, IROp op, IRInst* tuple, IRInst* func)
+{
+    IRInst* args[] = {tuple, func};
+    return emitIntrinsicInst(type, op, 2, args);
+}
+
 IRInst* IRBuilder::emitMakeResultError(IRType* resultType, IRInst* errorVal)
 {
     return emitIntrinsicInst(resultType, kIROp_MakeResultError, 1, &errorVal);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -1191,6 +1191,13 @@ top:
                 lowered = extractField(context, boundMemberInfo->type, base, fieldDeclRef);
                 goto top;
             }
+            else if (auto methodDeclRef = declRef.as<CallableDecl>())
+            {
+                auto funcVal = emitDeclRef(context, declRef, boundMemberInfo->type);
+                SLANG_RELEASE_ASSERT(funcVal.flavor == LoweredValInfo::Flavor::Simple);
+                lowered = funcVal;
+                goto top;
+            }
             else
             {
 
@@ -4584,7 +4591,8 @@ struct ExprLoweringVisitorBase : public ExprVisitor<Derived, LoweredValInfo>
         else if (auto callableDeclRef = declRef.as<CallableDecl>())
         {
             RefPtr<BoundMemberInfo> boundMemberInfo = new BoundMemberInfo();
-            boundMemberInfo->type = nullptr;
+            boundMemberInfo->type =
+                lowerType(context, getResultType(context->astBuilder, callableDeclRef));
             boundMemberInfo->base = loweredBase;
             boundMemberInfo->declRef = callableDeclRef;
 

--- a/tests/cooperative-matrix/map-element-single.slang
+++ b/tests/cooperative-matrix/map-element-single.slang
@@ -1,6 +1,6 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=0 -render-feature cooperative-matrix-per-element-operations
-//DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=1 -render-feature cooperative-matrix-per-element-operations
-//DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=2 -render-feature cooperative-matrix-per-element-operations
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=1 -render-feature cooperative-matrix-per-element-operations
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=2 -render-feature cooperative-matrix-per-element-operations
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=3 -render-feature cooperative-matrix-per-element-operations
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=4 -render-feature cooperative-matrix-per-element-operations
 

--- a/tests/cooperative-matrix/map-element-tuple.slang
+++ b/tests/cooperative-matrix/map-element-tuple.slang
@@ -1,8 +1,9 @@
-//DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=0 -render-feature cooperative-matrix-per-element-operations
-//DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=1 -render-feature cooperative-matrix-per-element-operations
-//DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=2 -render-feature cooperative-matrix-per-element-operations
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=3 -render-feature cooperative-matrix-per-element-operations
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=4 -render-feature cooperative-matrix-per-element-operations
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=0
+//DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=1
+//DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=2
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=3
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=4
+//-render-feature cooperative-matrix-per-element-operations
 
 //CHECK:type: int32_t
 //CHECK-NEXT:9
@@ -47,21 +48,21 @@ void computeMain()
     CoopMatType result;
 
 #if TEST_MODE == 0
-    result = makeTuple(mat1, mat2, mat3).MapElement<int>(MapOp);
+    result = makeTuple(mat1, mat2, mat3).MapElement(MapOp);
 
 #elif TEST_MODE == 1
     let f = ((uint32_t x, uint32_t y, int a, int b, int c) => a + b + c + 1 + 2 + 3);
-    result = makeTuple(mat1, mat2, mat3).MapElement<int>(f);
+    result = makeTuple(mat1, mat2, mat3).MapElement(f);
 
 #elif TEST_MODE == 2
-    result = makeTuple(mat1, mat2, mat3).MapElement<int>((uint32_t x, uint32_t y, int a, int b, int c) => a + b + c + 1 + 2 + 3);
+    result = makeTuple(mat1, mat2, mat3).MapElement((uint32_t x, uint32_t y, int a, int b, int c) => a + b + c + 1 + 2 + 3);
 
 #elif TEST_MODE == 3
     let f = ((uint32_t x, uint32_t y, int a, int b, int c) => a + b + c + c0 + c1 + c2);
-    result = makeTuple(mat1, mat2, mat3).MapElement<int>(f);
+    result = makeTuple(mat1, mat2, mat3).MapElement(f);
 
 #elif TEST_MODE == 4
-    result = makeTuple(mat1, mat2, mat3).MapElement<int>((uint32_t x, uint32_t y, int a, int b, int c) => a + b + c + c0 + c1 + c2);
+    result = makeTuple(mat1, mat2, mat3).MapElement((uint32_t x, uint32_t y, int a, int b, int c) => a + b + c + c0 + c1 + c2);
 #endif
 
     result.Store<CoopMatMatrixLayout.RowMajor>(outputBuffer, 0, stride);

--- a/tests/cooperative-matrix/map-element-tuple.slang
+++ b/tests/cooperative-matrix/map-element-tuple.slang
@@ -1,17 +1,23 @@
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=0 -render-feature cooperative-matrix-per-element-operations
+//DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=0 -render-feature cooperative-matrix-per-element-operations
 //DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=1 -render-feature cooperative-matrix-per-element-operations
 //DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=2 -render-feature cooperative-matrix-per-element-operations
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=3 -render-feature cooperative-matrix-per-element-operations
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=4 -render-feature cooperative-matrix-per-element-operations
 
-//CHECK: type: int32_t
-//CHECK-NEXT: 8
-//CHECK-NEXT: 10
-//CHECK-NEXT: 12
-//CHECK-NEXT: 14
+//CHECK:type: int32_t
+//CHECK-NEXT:9
+//CHECK-NEXT:12
+//CHECK-NEXT:15
+//CHECK-NEXT:14
 
 //TEST_INPUT:ubuffer(data=[1 2 3 4], stride=4),name=input1
 StructuredBuffer<int> input1;
+
+//TEST_INPUT:ubuffer(data=[0 1 2 3], stride=4),name=input2
+StructuredBuffer<int> input2;
+
+//TEST_INPUT:ubuffer(data=[2 3 4 1], stride=4),name=input3
+StructuredBuffer<int> input3;
 
 //TEST_INPUT:ubuffer(stride=4, count=256):out,name=outputBuffer
 RWStructuredBuffer<int32_t> outputBuffer;
@@ -20,16 +26,18 @@ using namespace linalg;
 
 typealias CoopMatType = CoopMat<int, MemoryScope.Subgroup, 16, 16, CoopMatMatrixUse.MatrixAccumulator>;
 
-int MapOp(uint32_t row, uint32_t col, int value)
+int MapOp(uint32_t row, uint32_t col, int a, int b, int c)
 {
-    return value * 2 + 1 + 2 + 3;
+    return a + b + c + 1 + 2 + 3;
 }
 
 [numthreads(32, 1, 1)]
 void computeMain()
 {
     let stride = 16;
-    CoopMatType mat1 = CoopMatType.Load<CoopMatMatrixLayout.RowMajor>(input1, 0, stride);
+    let mat1 = CoopMatType.Load<CoopMatMatrixLayout.RowMajor>(input1, 0, stride);
+    let mat2 = CoopMatType.Load<CoopMatMatrixLayout.RowMajor>(input2, 0, stride);
+    let mat3 = CoopMatType.Load<CoopMatMatrixLayout.RowMajor>(input3, 0, stride);
 
     // Testing the capturing lambda
     int c0 = 1;
@@ -39,25 +47,21 @@ void computeMain()
     CoopMatType result;
 
 #if TEST_MODE == 0
-    result = mat1.MapElement(MapOp);
+    result = makeTuple(mat1, mat2, mat3).MapElement<int>(MapOp);
 
 #elif TEST_MODE == 1
-    // Lambda via a temp variable (no capture)
-    let func = ((uint32_t row, uint32_t column, int value) => value * 2 + 1 + 2 + 3);
-    result = mat1.MapElement(func);
+    let f = ((uint32_t x, uint32_t y, int a, int b, int c) => a + b + c + 1 + 2 + 3);
+    result = makeTuple(mat1, mat2, mat3).MapElement<int>(f);
 
 #elif TEST_MODE == 2
-    // Directly use lambda (no capture)
-    result = mat1.MapElement((uint32_t row, uint32_t column, int value) => value * 2 + 1 + 2 + 3);
+    result = makeTuple(mat1, mat2, mat3).MapElement<int>((uint32_t x, uint32_t y, int a, int b, int c) => a + b + c + 1 + 2 + 3);
 
 #elif TEST_MODE == 3
-    // Lambda via a temp variable (capture)
-    let func = ((uint32_t row, uint32_t column, int value) => value * 2 + c0 + c1 + c2);
-    result = mat1.MapElement(func);
+    let f = ((uint32_t x, uint32_t y, int a, int b, int c) => a + b + c + c0 + c1 + c2);
+    result = makeTuple(mat1, mat2, mat3).MapElement<int>(f);
 
 #elif TEST_MODE == 4
-    // Directly use lambda (capture)
-    result = mat1.MapElement((uint32_t row, uint32_t column, int value) => value * 2 + c0 + c1 + c2);
+    result = makeTuple(mat1, mat2, mat3).MapElement<int>((uint32_t x, uint32_t y, int a, int b, int c) => a + b + c + c0 + c1 + c2);
 #endif
 
     result.Store<CoopMatMatrixLayout.RowMajor>(outputBuffer, 0, stride);

--- a/tests/cooperative-matrix/map-element-tuple.slang
+++ b/tests/cooperative-matrix/map-element-tuple.slang
@@ -1,9 +1,8 @@
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=0
-//DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=1
-//DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=2
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=3
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=4
-//-render-feature cooperative-matrix-per-element-operations
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=0 -render-feature cooperative-matrix-per-element-operations
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=1 -render-feature cooperative-matrix-per-element-operations
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=2 -render-feature cooperative-matrix-per-element-operations
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=3 -render-feature cooperative-matrix-per-element-operations
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -Xslang -DTEST_MODE=4 -render-feature cooperative-matrix-per-element-operations
 
 //CHECK:type: int32_t
 //CHECK-NEXT:9

--- a/tests/language-feature/tuple/tuple-expand-multiple.slang
+++ b/tests/language-feature/tuple/tuple-expand-multiple.slang
@@ -1,0 +1,33 @@
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK): -output-using-type
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0], stride=4)
+RWStructuredBuffer<int> outputBuffer;
+
+extension<
+    T0 : __BuiltinArithmeticType,
+    each Ts0 : __BuiltinArithmeticType,
+    each Ts1 : __BuiltinArithmeticType
+> Tuple<T0, T0, expand each Ts0, expand each Ts1>
+{
+    static int getSize_Ts0() { return countof(Ts0); }
+    static int getSize_Ts1() { return countof(Ts1); }
+}
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    int i = 2;
+    float f0 = 3, f1 = 5;
+    uint ui0 = 4, ui1 = 6;
+
+    let s0 = makeTuple(i, i, f0, ui0); // T, Ts0, Ts1
+    let s1 = makeTuple(i, i, f0, ui0, f1, ui1); // T, Ts0, Ts0, Ts1, Ts1
+
+    outputBuffer[0] = s0.getSize_Ts0();
+    outputBuffer[1] = s0.getSize_Ts1();
+    outputBuffer[2] = s1.getSize_Ts0();
+    outputBuffer[3] = s1.getSize_Ts1();
+
+    // CHECK-COUNT-2:1
+    // CHECK-COUNT-2:2
+}

--- a/tests/language-feature/tuple/tuple-expand-multiple.slang
+++ b/tests/language-feature/tuple/tuple-expand-multiple.slang
@@ -1,6 +1,6 @@
 //TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK): -output-using-type
 
-//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0], stride=4)
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0 0 0], stride=4)
 RWStructuredBuffer<int> outputBuffer;
 
 extension<
@@ -20,14 +20,18 @@ void computeMain()
     float f0 = 3, f1 = 5;
     uint ui0 = 4, ui1 = 6;
 
-    let s0 = makeTuple(i, i, f0, ui0); // T, Ts0, Ts1
-    let s1 = makeTuple(i, i, f0, ui0, f1, ui1); // T, Ts0, Ts0, Ts1, Ts1
+    let s0 = makeTuple(i, i); // T, T
+    let s1 = makeTuple(i, i, f0, ui0); // T, T, Ts0, Ts1
+    let s2 = makeTuple(i, i, f0, ui0, f1, ui1); // T, T, Ts0, Ts0, Ts1, Ts1
 
     outputBuffer[0] = s0.getSize_Ts0();
     outputBuffer[1] = s0.getSize_Ts1();
     outputBuffer[2] = s1.getSize_Ts0();
     outputBuffer[3] = s1.getSize_Ts1();
+    outputBuffer[4] = s2.getSize_Ts0();
+    outputBuffer[5] = s2.getSize_Ts1();
 
+    // CHECK-COUNT-2:0
     // CHECK-COUNT-2:1
     // CHECK-COUNT-2:2
 }

--- a/tests/language-feature/tuple/tuple-expand.slang
+++ b/tests/language-feature/tuple/tuple-expand.slang
@@ -1,0 +1,25 @@
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK): -output-using-type
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0], stride=4)
+RWStructuredBuffer<int> outputBuffer;
+
+struct X<B, each T, each U>
+{
+    int getTSize() { return countof(T); }
+    int getUSize() { return countof(U); }
+}
+
+func foo<each T, each U>() -> X<bool, expand Ptr<each T>, int, expand Ptr<each U>, float> // unify
+{
+    return {};
+}
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    let x = foo<int, float>();
+
+    outputBuffer[0] = x.getTSize();
+    outputBuffer[1] = x.getUSize();
+    // CHECK-COUNT-2: 2
+}


### PR DESCRIPTION
With this PR, MapElement works for the following signatures:
 - CoopMat<...>::MapElement(functype(...));
 - CoopMat<...>::MapElement(capturing-lambda);
 - CoopMat<...>::MapElement(not-capturing-lambda);

 - Tuple<CoopMat<...>,...>::MapElement(functype(...));
 - Tuple<CoopMat<...>,...>::MapElement(capturing-lambda);
 - Tuple<CoopMat<...>,...>::MapElement(not-capturing-lambda);

Note: New tests are effectively disabled because currently the CI runners don't have a graphics driver that supports CoopMat2 features.