### PR TITLE
Fix operator precedence in OptiX ray payload pointer casting

### DIFF
--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -877,9 +877,9 @@ bool CUDASourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
         }
     case kIROp_GetOptiXRayPayloadPtr:
         {
-            m_writer->emit("(");
+            m_writer->emit("((");
             emitType(inst->getDataType());
-            m_writer->emit(")getOptiXRayPayloadPtr()");
+            m_writer->emit(")getOptiXRayPayloadPtr())");
             return true;
         }
     case kIROp_GetOptiXHitAttribute:


### PR DESCRIPTION
Added extra parentheses around the cast to ensure proper operator precedence when dereferencing the OptiX ray payload pointer. This fixes the issue where the compiler was treating the expression as (RayPayload_0 *)getOptiXRayPayloadPtr()->color_0 instead of ((RayPayload_0 *)getOptiXRayPayloadPtr())->color_0.

Error:
```

  nvrtc 12.9: tests/cuda/optix-cluster.slang(17): error : expression
must have pointer-to-class type but it has type "void *"
  nvrtc 12.9: note :       (RayPayload_0
*)getOptiXRayPayloadPtr()->color_0 = color_1;
  nvrtc 12.9: note :                
```       ^

Tested using:
./build/Debug/bin/slangc -target ptx -Xnvrtc
-I"/home/haaggarwal/NVIDIA-OptiX-SDK-9.0.0-linux64-x86_64/include" -DSLANG_CUDA_ENABLE_OPTIX  -entry closestHitShaderA ./tests/cuda/optix-cluster.slang