### PR TITLE
Add default constructor for Ptr type

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1279,6 +1279,12 @@ struct Ptr
         [nonmutating]
         ref;
     }
+
+    [ForceInline]
+    __init()
+    {
+        return __default<Ptr<T, addrSpace>>();
+    }
 };
 
 //@hidden:

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1279,12 +1279,6 @@ struct Ptr
         [nonmutating]
         ref;
     }
-
-    [ForceInline]
-    __init()
-    {
-        return __default<Ptr<T, addrSpace>>();
-    }
 };
 
 //@hidden:

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -236,7 +236,8 @@ bool SemanticsVisitor::isCStyleType(Type* type, HashSet<Type*>& isVisit)
 
     // 1. It has to be basic scalar, vector or matrix type, or user-defined struct.
     if (as<VectorExpressionType>(type) || as<MatrixExpressionType>(type) ||
-        as<BasicExpressionType>(type) || isDeclRefTypeOf<EnumDecl>(type).getDecl())
+        as<BasicExpressionType>(type) || isDeclRefTypeOf<EnumDecl>(type).getDecl() ||
+        as<PtrType>(type))
         return cacheResult(true);
 
 

--- a/tests/spirv/pointer-default-constructor.slang
+++ b/tests/spirv/pointer-default-constructor.slang
@@ -1,0 +1,21 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -emit-spirv-directly -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
+RWStructuredBuffer<uint> outputBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    float* a = {};
+    float* b = a + 32;
+
+    // CHECK: 0
+    outputBuffer[0] = uint(uint64_t(a));
+    // CHECK: 128
+    outputBuffer[1] = uint(uint64_t(b));
+    // CHECK: 1
+    outputBuffer[2] = uint(a == nullptr);
+    // CHECK: 1
+    outputBuffer[3] = uint(Ptr<int>() != Ptr<int>(0xAB64));
+}

--- a/tests/spirv/pointer-default-constructor.slang
+++ b/tests/spirv/pointer-default-constructor.slang
@@ -3,19 +3,24 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
 
+struct MyStruct
+{
+    int* ptr;
+}
+
 [shader("compute")]
 [numthreads(1, 1, 1)]
 void computeMain()
 {
     float* a = {};
-    float* b = a + 32;
+    MyStruct ms = {};
 
     // CHECK: 0
     outputBuffer[0] = uint(uint64_t(a));
-    // CHECK: 128
-    outputBuffer[1] = uint(uint64_t(b));
     // CHECK: 1
-    outputBuffer[2] = uint(a == nullptr);
+    outputBuffer[1] = uint(a == nullptr);
+    // CHECK: 0
+    outputBuffer[2] = uint(uint64_t(ms.ptr));
     // CHECK: 1
-    outputBuffer[3] = uint(Ptr<int>() != Ptr<int>(0xAB64));
+    outputBuffer[3] = uint(ms.ptr == nullptr);
 }


### PR DESCRIPTION
Make `Ptr` type a c-tyle type to be able to initialize pointer variables with the `{}` syntax.