### PR TITLE
Properly error out when Image::Load is called with sampler

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -3806,7 +3806,9 @@ extension _Texture<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,format>
     {
         __target_switch
         {
-        case hlsl: __intrinsic_asm ".Load";
+        case hlsl:
+            static_assert(isCombined == 0, "Load operations on combined texture samplers are not supported in HLSL");
+            __intrinsic_asm ".Load";
         case spirv:
              const int lodLoc = Shape.dimensions+isArray;
              let coord = __vectorReshape<Shape.dimensions+isArray>(location);
@@ -3910,7 +3912,9 @@ extension _Texture<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,format>
         __target_switch
         {
             case cpp:
+                __intrinsic_asm ".Load";
             case hlsl:
+                static_assert(isCombined == 0, "Load operations on combined texture samplers are not supported in HLSL");
                 __intrinsic_asm ".Load";
             case metal:
                 switch (Shape.flavor)
@@ -3988,7 +3992,9 @@ extension _Texture<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,format>
         __target_switch
         {
             case cpp:
+                __intrinsic_asm ".Load";
             case hlsl:
+                static_assert(isCombined == 0, "Load operations on combined texture samplers are not supported in HLSL");
                 __intrinsic_asm ".Load";
             case glsl:
                 if (isCombined == 0)
@@ -4022,7 +4028,9 @@ extension _Texture<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,format>
     {
         __target_switch
         {
-        case hlsl: __intrinsic_asm ".Load";
+        case hlsl:
+            static_assert(isCombined == 0, "Load operations on combined texture samplers are not supported in HLSL");
+            __intrinsic_asm ".Load";
         case spirv:
              if (isCombined != 0)
              {

--- a/tests/hlsl-intrinsic/texture/partial-resident-texture-combined.slang
+++ b/tests/hlsl-intrinsic/texture/partial-resident-texture-combined.slang
@@ -1,5 +1,5 @@
 // TODO: There are issues running tests combined texture samplers in DX12. (Github issue #6982)
-//DISABLE_TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-slang -compute -shaderobj -output-using-type -use-dxil -profile cs_6_7 -dx12 -Xslang -DTARGET_DX12
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-slang -compute -shaderobj -output-using-type -use-dxil -profile cs_6_7 -dx12 -Xslang -DTARGET_DX12
 
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-vk -compute -shaderobj -output-using-type -emit-spirv-directly -render-feature hardware-device -xslang -DVK
 


### PR DESCRIPTION
This can resolve the issue described in 
- https://github.com/shader-slang/slang/issues/6982

With this PR, when `Load` function in HLSL is used with a Sampler, Slang will print an error message due to `static_assert`.

But the disabled test cannot be re-enabled yet.
I am preparing another fix for it.