### PR TITLE
Fix nullptr_t compiling failure

### DIFF
--- a/source/core/slang-riff.h
+++ b/source/core/slang-riff.h
@@ -303,7 +303,7 @@ public:
     BoundsCheckedChunkPtr() {}
 
     /// Initialize a null pointer
-    BoundsCheckedChunkPtr(nullptr_t) {}
+    BoundsCheckedChunkPtr(std::nullptr_t) {}
 
 
     /// Initialize a pointer to a chunk, with a size limit.


### PR DESCRIPTION
Fixes when building with Clang 14.0 with a series of non-conventional cmake options

```
/usr/bin/ccache /usr/bin/clang++ -DMINIZ_STATIC_DEFINE -DNOMINMAX -DSLANG_ENABLE_DXIL_SUPPORT=0 -DSLANG_STATIC -DSTB_IMAGE_STATIC -DUNICODE -DVC_EXTRALEAN -DWIN32_LEAN_AND_MEAN -D_UNICODE -I/slang/source -I/slang/include -I/slang/external/miniz -I/slang/build/external/miniz -I/slang/external/lz4/build/cmake/../../lib -I/slang/external/unordered_dense/include -O3 -DNDEBUG -flto=thin -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wno-switch -Wno-parentheses -Wno-unused-local-typedefs -Wno-assume -Wno-reorder -Wno-invalid-offsetof -Wno-newline-eof -Wno-return-std-move -Wnarrowing -Wextra -std=gnu++20 -MD -MT source/core/CMakeFiles/core.dir/slang-archive-file-system.cpp.o -MF source/core/CMakeFiles/core.dir/slang-archive-file-system.cpp.o.d -o source/core/CMakeFiles/core.dir/slang-archive-file-system.cpp.o -c /slang/source/core/slang-archive-file-system.cpp
In file included from /slang/source/core/slang-archive-file-system.cpp:8:
In file included from /slang/source/core/slang-riff-file-system.h:6:
/slang/source/core/slang-riff.h:306:27: error: unknown type name 'nullptr_t'; did you mean 'std::nullptr_t'?
    BoundsCheckedChunkPtr(nullptr_t) {}
                          ^~~~~~~~~
                          std::nullptr_t

```