### PR TITLE
Remove SLANG_UNREFLECTED

### DIFF
--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -44,7 +44,7 @@ class NodeBase
     ASTNodeType astNodeType = ASTNodeType(-1);
 
 #ifdef _DEBUG
-    SLANG_UNREFLECTED int32_t _debugUID = 0;
+    int32_t _debugUID = 0;
 #endif
 };
 
@@ -112,7 +112,6 @@ class Scope : public NodeBase
     // The parent of this scope (where lookup should go if nothing is found locally)
     Scope* parent = nullptr;
 
-    SLANG_UNREFLECTED
     // The next sibling of this scope (a peer for lookup)
     Scope* nextSibling = nullptr;
 };
@@ -479,7 +478,7 @@ protected:
 
 private:
     mutable Val* m_resolvedVal = nullptr;
-    SLANG_UNREFLECTED mutable Index m_resolvedValEpoch = 0;
+    mutable Index m_resolvedValEpoch = 0;
 };
 
 template<int N, typename T, typename... Ts>
@@ -585,7 +584,7 @@ protected:
     // semantic checking, since Val deduplication requires the entire semantic checking process to
     // stick with one ASTBuilder.
     // Call getCurrentASTBuilder() to obtain the right ASTBuilder for semantic checking.
-    SLANG_UNREFLECTED ASTBuilder* m_astBuilderForReflection;
+    ASTBuilder* m_astBuilderForReflection;
 };
 
 template<typename T>
@@ -772,12 +771,12 @@ public:
     bool isChildOf(Decl* other) const;
 
     // Track the decl reference that caused the requirement of a capability atom.
-    SLANG_UNREFLECTED List<ProvenenceNodeWithLoc> capabilityRequirementProvenance;
+    List<ProvenenceNodeWithLoc> capabilityRequirementProvenance;
 
-    SLANG_UNREFLECTED bool hiddenFromLookup = false;
+    bool hiddenFromLookup = false;
 
 private:
-    SLANG_UNREFLECTED DeclRefBase* m_defaultDeclRef = nullptr;
+    DeclRefBase* m_defaultDeclRef = nullptr;
 };
 
 FIDDLE(abstract)

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -86,15 +86,13 @@ class ContainerDecl : public Decl
 
     Index getDeclIndex(Decl* d);
 
-    SLANG_UNREFLECTED // We don't want to reflect the following fields
-
-        private :
-        // Denotes how much of Members has been placed into the dictionary/transparentMembers.
-        // If this value equals the Members.getCount(), the dictionary is completely full and valid.
-        // If it's >= 0, then the Members after dictionaryLastCount are all that need to be added.
-        // If it < 0 it means that the dictionary/transparentMembers is invalid and needs to be
-        // recreated.
-        Index dictionaryLastCount = 0;
+private:
+    // Denotes how much of Members has been placed into the dictionary/transparentMembers.
+    // If this value equals the Members.getCount(), the dictionary is completely full and valid.
+    // If it's >= 0, then the Members after dictionaryLastCount are all that need to be added.
+    // If it < 0 it means that the dictionary/transparentMembers is invalid and needs to be
+    // recreated.
+    Index dictionaryLastCount = 0;
 
     // Dictionary for looking up members by name.
     // This is built on demand before performing lookup.
@@ -192,7 +190,7 @@ FIDDLE()
 class StructDecl : public AggTypeDecl
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
+
     // We will use these auxiliary to help in synthesizing the member initialize constructor.
     Slang::HashSet<VarDeclBase*> m_membersVisibleInCtor;
 };
@@ -539,8 +537,6 @@ class ModuleDecl : public NamespaceDeclBase
 
     FIDDLE() DeclVisibility defaultVisibility = DeclVisibility::Internal;
 
-    SLANG_UNREFLECTED
-
     /// Map a type to the list of extensions of that type (if any) declared in this module
     ///
     /// This mapping is filled in during semantic checking, as `ExtensionDecl`s get checked.
@@ -564,7 +560,6 @@ class UsingDecl : public Decl
     /// An expression that identifies the entity (e.g., a namespace) to be brought into `scope`
     Expr* arg = nullptr;
 
-    SLANG_UNREFLECTED
     /// The scope that the entity named by `arg` will be brought into
     Scope* scope = nullptr;
 };
@@ -580,7 +575,6 @@ class FileReferenceDeclBase : public Decl
     SourceLoc startLoc;
     SourceLoc endLoc;
 
-    SLANG_UNREFLECTED
     // The scope that we want to import into
     Scope* scope = nullptr;
 };
@@ -722,8 +716,6 @@ class SyntaxDecl : public Decl
     FIDDLE(...)
     // What type of syntax node will be produced when parsing with this keyword?
     FIDDLE() SyntaxClass<NodeBase> syntaxClass;
-
-    SLANG_UNREFLECTED
 
     // Callback to invoke in order to parse syntax with this keyword.
     SyntaxParseCallback parseCallback = nullptr;

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -33,7 +33,6 @@ class DeclRefExpr : public Expr
     // The original expr before DeclRef resolution.
     Expr* originalExpr = nullptr;
 
-    SLANG_UNREFLECTED
     // The scope in which to perform lookup
     Scope* scope = nullptr;
 };
@@ -582,7 +581,7 @@ FIDDLE()
 class ThisExpr : public Expr
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
+
     Scope* scope = nullptr;
 };
 
@@ -592,7 +591,7 @@ FIDDLE()
 class ReturnValExpr : public Expr
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
+
     Scope* scope = nullptr;
 };
 
@@ -721,7 +720,7 @@ FIDDLE()
 class ThisTypeExpr : public Expr
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
+
     Scope* scope = nullptr;
 };
 

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -760,7 +760,7 @@ FIDDLE()
 class UncheckedAttribute : public AttributeBase
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
+
     Scope* scope = nullptr;
 };
 
@@ -769,7 +769,6 @@ FIDDLE()
 class UncheckedGLSLLayoutAttribute : public AttributeBase
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
 };
 
 // GLSL `binding` layout qualifier, does not include `set`.
@@ -777,7 +776,6 @@ FIDDLE()
 class UncheckedGLSLBindingLayoutAttribute : public UncheckedGLSLLayoutAttribute
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
 };
 
 // GLSL `set` layout qualifier, does not include `binding`.
@@ -785,7 +783,6 @@ FIDDLE()
 class UncheckedGLSLSetLayoutAttribute : public UncheckedGLSLLayoutAttribute
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
 };
 
 // GLSL `offset` layout qualifier.
@@ -793,70 +790,60 @@ FIDDLE()
 class UncheckedGLSLOffsetLayoutAttribute : public UncheckedGLSLLayoutAttribute
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
 };
 
 FIDDLE()
 class UncheckedGLSLInputAttachmentIndexLayoutAttribute : public UncheckedGLSLLayoutAttribute
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
 };
 
 FIDDLE()
 class UncheckedGLSLLocationLayoutAttribute : public UncheckedGLSLLayoutAttribute
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
 };
 
 FIDDLE()
 class UncheckedGLSLIndexLayoutAttribute : public UncheckedGLSLLayoutAttribute
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
 };
 
 FIDDLE()
 class UncheckedGLSLConstantIdAttribute : public UncheckedGLSLLayoutAttribute
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
 };
 
 FIDDLE()
 class UncheckedGLSLRayPayloadAttribute : public UncheckedGLSLLayoutAttribute
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
 };
 
 FIDDLE()
 class UncheckedGLSLRayPayloadInAttribute : public UncheckedGLSLLayoutAttribute
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
 };
 
 FIDDLE()
 class UncheckedGLSLHitObjectAttributesAttribute : public UncheckedGLSLLayoutAttribute
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
 };
 
 FIDDLE()
 class UncheckedGLSLCallablePayloadAttribute : public UncheckedGLSLLayoutAttribute
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
 };
 
 FIDDLE()
 class UncheckedGLSLCallablePayloadInAttribute : public UncheckedGLSLLayoutAttribute
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
 };
 
 // A `[name(arg0, ...)]` style attribute that has been validated.
@@ -1051,7 +1038,6 @@ FIDDLE()
 class GLSLImplicitOffsetLayoutAttribute : public AttributeBase
 {
     FIDDLE(...)
-    SLANG_UNREFLECTED
 };
 
 FIDDLE()
@@ -1582,7 +1568,7 @@ class DifferentiableAttribute : public Attribute
     /// Mapping from types to subtype witnesses for conformance to IDifferentiable.
     const OrderedDictionary<Type*, SubtypeWitness*>& getMapTypeToIDifferentiableWitness();
 
-    SLANG_UNREFLECTED ValSet m_typeRegistrationWorkingSet;
+    ValSet m_typeRegistrationWorkingSet;
 
 private:
     OrderedDictionary<Type*, SubtypeWitness*> m_mapToIDifferentiableWitness;

--- a/source/slang/slang-ast-stmt.h
+++ b/source/slang/slang-ast-stmt.h
@@ -106,7 +106,6 @@ class BreakableStmt : public ScopeStmt
     ///
     UniqueStmtIDNode* uniqueID = kInvalidUniqueID;
 
-    SLANG_UNREFLECTED
     typedef UniqueStmtIDNode* UniqueID;
     static constexpr UniqueID kInvalidUniqueID = nullptr;
 };

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -15,8 +15,6 @@
 #include <assert.h>
 #include <type_traits>
 
-#define SLANG_UNREFLECTED /* empty */
-
 FIDDLE(hidden class RefObject;)
 
 FIDDLE() namespace Slang

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -615,7 +615,7 @@ class MatrixExpressionType : public ArithmeticExpressionType
     BasicExpressionType* _getScalarTypeOverride();
 
 private:
-    SLANG_UNREFLECTED Type* rowType = nullptr;
+    Type* rowType = nullptr;
 };
 
 FIDDLE()
@@ -915,9 +915,6 @@ class ExtractExistentialType : public Type
     {
         setOperands(inDeclRef, inOriginalInterfaceType, inOriginalInterfaceDeclRef);
     }
-
-    // Following fields will not be reflected (and thus won't be serialized, etc.)
-    SLANG_UNREFLECTED
 
     // A cached decl-ref to the original interface's ThisType Decl, with
     // a witness that refers to the type extracted here.


### PR DESCRIPTION
The `SLANG_UNREFLECTED` macro has been completely meaningless since we switched away from the old AST serialization/reflection approach, so the lingering uses of it in the code as pointless at best and misleading/confusing at worst.