### PR TITLE
Allow regular params to propagate constexpr-ness

### DIFF
--- a/source/slang/slang-ir-constexpr.cpp
+++ b/source/slang/slang-ir-constexpr.cpp
@@ -177,8 +177,6 @@ IRLoop* isLoopPhi(IRParam* param)
 
 bool opCanBeConstExprByBackwardPass(IRInst* value)
 {
-    if (value->getOp() == kIROp_Param)
-        return isLoopPhi(as<IRParam, IRDynamicCastBehavior::NoUnwrap>(value));
     if (opCanBeConstExpr(value->getOp()))
         return true;
     if (auto callInst = as<IRCall>(value))


### PR DESCRIPTION
The https://github.com/shader-slang/slang/pull/3139 added a check to prevent the op_param from propagating constexpr-ness unless it's loopPhi. 
I'm not sure if that is intentional, but removing it fixes #6370, and still keep the same behavior that the loop counters can be used as constexpr - somehow bypassing the constexpr-ness requirement from the callee functions.

Fixes #6370