### PR TITLE
Fix test-server debug issues with gfx-unit-test-tool (#7119)

### DIFF
--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -4755,6 +4755,9 @@ static SlangResult runUnitTestModule(
             {
                 TestReporter::TestScope scopeTest(reporter, options.command);
                 ExecuteResult exeRes;
+                // Initialize the ExecuteResult, otherwise we can get bogus
+                // error results.
+                exeRes.init();
 
                 SlangResult rpcRes = _executeRPC(
                     context,
@@ -5068,15 +5071,14 @@ SlangResult innerMain(int argc, char** argv)
             // Try the unit tests up to 3 times
             for (bool isRetry : {false, true, true})
             {
-                // Use default spawn type for unit tests as the test server one is unstable
-                auto spawnType = SpawnType::Default;
+                auto spawnType = context.getFinalSpawnType();
                 context.isRetry = isRetry;
                 if (isRetry)
                 {
                     if (context.failedUnitTests.getCount() == 0)
                         break;
 
-                    printf("Retrying unit tests with default spawn type...\n");
+                    printf("Retrying unit tests...\n");
                     context.options.testPrefixes = context.failedUnitTests;
                     context.failedUnitTests.clear();
                 }

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -446,6 +446,12 @@ SlangResult TestServer::_executeUnitTest(const JSONRPCCall& call)
     unitTestContext.workDirectory = "";
     unitTestContext.enabledApis = RenderApiFlags(args.enabledApis);
     unitTestContext.executableDirectory = m_exeDirectory.getBuffer();
+    // When using test server, any validation warning printed from the backend
+    // gets misinterpreted as the result from the test.
+    // This is due to the limitation that Slang RPC implementation expects only
+    // one time communication. Set enableDebugLayers to false to avoid Vulkan
+    // test failures when running on debug using test server.
+    unitTestContext.enableDebugLayers = false;
 
     auto testCount = testModule->getTestCount();
     SLANG_ASSERT(testIndex >= 0 && testIndex < testCount);


### PR DESCRIPTION
Previously when running slang-test with "-use-test-server" to run slang-unit-test-tool and gfx-unit-test-tool tests, these would fail with a message like, "error: Unable to launch tool". These issues appear to have been resolved, however debug runs of gfx-unit-test-tool using "-use-test-server" were still showing errors of the following nature:

````
error: rpc failed
error: result code = -858993460
standard error = {
}
standard output = {
}

ignored test: 'gfx-unit-test-tool/uint16BufferTestVulkan.internal'
````

These errors all appeared to be the result of Vulkan VUID print outs and were occuring for nearly every Vulkan test.

Existing comments in slang-test-main.cpp indicated that VUID print outs get misinterpreted as the result from a test due to limitations in the Slang RPC implementation. Slang-test then correctly disables use of VK debug layers when the spawn type is UseTestServer. However, this argument is only passed to the test server when running standard tests (see ExecuteToolTestArgs vs ExecuteUnitTestArgs).

This change hard codes `unitTestContext.enableDebugLayers = false;` in test-server-main.cpp when running unit tests, as otherwise this will currently result in all Vulkan tests being ignored.

Additional tweaks were made to slang-test-main.cpp to restore the spawn type for unit tests and to prevent bogus rpc error result codes.