### PR TITLE
Fix wasm releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,4 +300,6 @@ jobs:
         with:
           name: slang-build-${{matrix.os}}-${{matrix.platform}}-${{matrix.compiler}}-${{matrix.config}}
           # The install directory used in the packaging step
-          path: build/dist-${{matrix.config}}/**/ZIP/slang/*
+          path: |
+            build/dist-${{matrix.config}}/**/ZIP/slang/*
+            build.em/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,4 +302,4 @@ jobs:
           # The install directory used in the packaging step
           path: |
             build/dist-${{matrix.config}}/**/ZIP/slang/*
-            build.em/
+            build.em/Release


### PR DESCRIPTION
Although the CI workflow successfully builds the WASM static libraries, it does not properly package them so they do not end up being shared in releases.

This PR fixes the problem in the most straightforward way, though I'm guessing a proper fix might be to change the emscripten build workflow so that the resulting files end up at the location expected by the upload-artifacts actoin, like with other workflows.