### PR TITLE
Fix rpc errors on slang-unit-tests

### DIFF
--- a/source/compiler-core/slang-test-server-protocol.cpp
+++ b/source/compiler-core/slang-test-server-protocol.cpp
@@ -11,6 +11,7 @@ static const StructRttiInfo _makeExecuteUnitTestArgsRtti()
     builder.addField("moduleName", &obj.moduleName);
     builder.addField("testName", &obj.testName);
     builder.addField("enabledApis", &obj.enabledApis);
+    builder.addField("enableDebugLayers", &obj.enableDebugLayers);
     return builder.make();
 }
 /* static */ const UnownedStringSlice ExecuteUnitTestArgs::g_methodName =


### PR DESCRIPTION
Fix a mistake caused by a recent PR
- https://github.com/shader-slang/slang/pull/7300

The new argument added was not properly sent to the client process, because it was not reflected on its RTTI data.
This caused all of gfx-unit-test to fail when ran with debug build.