### PR TITLE
Fix SLANG_USE_SYSTEM_SPIRV_HEADERS 

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -103,29 +103,31 @@ target_include_directories(
 )
 
 # SPIRV-Headers
-if(NOT ${SLANG_USE_SYSTEM_SPIRV_HEADERS})
-    if(NOT SLANG_OVERRIDE_SPIRV_HEADERS_PATH)
-        add_subdirectory(spirv-headers EXCLUDE_FROM_ALL ${system})
-    else()
-        add_subdirectory(
-            ${SLANG_OVERRIDE_SPIRV_HEADERS_PATH}/spirv-headers
-            spirv-headers
-            EXCLUDE_FROM_ALL
-            ${system}
-        )
-    endif()
+if(${SLANG_USE_SYSTEM_SPIRV_HEADERS})
+    find_package(SPIRV-Headers REQUIRED)
+elseif(NOT SLANG_OVERRIDE_SPIRV_HEADERS_PATH)
+    add_subdirectory(spirv-headers EXCLUDE_FROM_ALL ${system})
+else()
+    add_subdirectory(
+        ${SLANG_OVERRIDE_SPIRV_HEADERS_PATH}/spirv-headers
+        spirv-headers
+        EXCLUDE_FROM_ALL
+        ${system}
+    )
 endif()
 
 if(SLANG_ENABLE_SLANG_GLSLANG)
+    # When using spirv headers via find_package, SPIRV-Headers_SOURCE_DIR is not set
+    # SPIRV-Tools requires that variable, as it uses it to detect if SPIRV-Headers is provided by the consumer.
+    # Fake a source build by setting it here. Ideally SPIRV-Tools should not depend on _SOURCE_DIR
+    if (${SLANG_USE_SYSTEM_SPIRV_HEADERS})
+        get_target_property(SPIRV-Headers_SOURCE_DIR SPIRV-Headers::SPIRV-Headers INTERFACE_INCLUDE_DIRECTORIES)
+        cmake_path(GET SPIRV-Headers_SOURCE_DIR PARENT_PATH SPIRV-Headers_SOURCE_DIR)
+    endif()
+
     # SPIRV-Tools
     set(SPIRV_TOOLS_BUILD_STATIC ON)
     set(SPIRV_WERROR OFF)
-    # Headers
-    if(NOT SLANG_OVERRIDE_SPIRV_HEADERS_PATH)
-        set(SPIRV_HEADER_DIR "${CMAKE_CURRENT_LIST_DIR}/spirv-headers/")
-    else()
-        set(SPIRV_HEADER_DIR ${SLANG_OVERRIDE_SPIRV_HEADERS_PATH}/spirv-headers)
-    endif()
     set(SPIRV_SKIP_TESTS ON)
     # Tools
     if(NOT SLANG_OVERRIDE_SPIRV_TOOLS_PATH)

--- a/source/compiler-core/CMakeLists.txt
+++ b/source/compiler-core/CMakeLists.txt
@@ -5,7 +5,7 @@ slang_add_target(
     EXCLUDE_FROM_ALL
     USE_EXTRA_WARNINGS
     LINK_WITH_PRIVATE core
-    INCLUDE_FROM_PUBLIC SPIRV-Headers
+    INCLUDE_FROM_PUBLIC SPIRV-Headers::SPIRV-Headers
 )
 if(NOT MSVC)
     # This is necessary to compile the DXC headers

--- a/source/slang-core-module/CMakeLists.txt
+++ b/source/slang-core-module/CMakeLists.txt
@@ -61,7 +61,7 @@ set(core_module_source_common_args
     core
     slang-capability-defs
     slang-fiddle-output
-    SPIRV-Headers
+    SPIRV-Headers::SPIRV-Headers
     INCLUDE_DIRECTORIES_PRIVATE
     ../slang
     ${core_module_meta_output_dir}

--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -100,17 +100,7 @@ slang_add_target(
 # generated lookup tables
 #
 
-if(NOT SLANG_USE_SYSTEM_SPIRV_HEADERS)
-    if(NOT SLANG_OVERRIDE_SPIRV_HEADERS_PATH)
-        set(SLANG_SPIRV_HEADERS_INCLUDE_DIR
-            "${slang_SOURCE_DIR}/external/spirv-headers/include"
-        )
-    else()
-        set(SLANG_SPIRV_HEADERS_INCLUDE_DIR
-            "${SLANG_OVERRIDE_SPIRV_HEADERS_PATH}/spirv-headers/include"
-        )
-    endif()
-endif()
+get_target_property(SLANG_SPIRV_HEADERS_INCLUDE_DIR SPIRV-Headers::SPIRV-Headers INTERFACE_INCLUDE_DIRECTORIES)
 
 set(SLANG_LOOKUP_GENERATOR_INPUT_JSON
     "${SLANG_SPIRV_HEADERS_INCLUDE_DIR}/spirv/unified1/extinst.glsl.std.450.grammar.json"

--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -164,7 +164,7 @@ slang_add_target(
         ${SLANG_LOOKUP_GENERATED_SOURCE}
         ${SLANG_SPIRV_CORE_GRAMMAR_SOURCE}
     EXPORT_TYPE_AS ${SLANG_LIB_TYPE}
-    LINK_WITH_PRIVATE core SPIRV-Headers
+    LINK_WITH_PRIVATE core SPIRV-Headers::SPIRV-Headers
     EXCLUDE_FROM_ALL
     FOLDER generated
 )
@@ -226,7 +226,7 @@ set(slang_link_args
     slang-capability-lookup
     slang-fiddle-output
     slang-lookup-tables
-    SPIRV-Headers
+    SPIRV-Headers::SPIRV-Headers
 )
 set(slang_interface_args INCLUDE_DIRECTORIES_PUBLIC ${slang_SOURCE_DIR}/include)
 set(slang_public_lib_args


### PR DESCRIPTION
When set, SLANG_USE_SYSTEM_SPIRV_HEADERS didn't provide any cmake targets to link against resulting in build errors.

- Call `find_package` to bring in the installed cmake targets. 
- Other minor refactorings to work with the installed package along with the vendored.