### PR TITLE
add task shader alias

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1102,7 +1102,7 @@ Stage
 * `miss` 
 * `callable` 
 * `mesh` 
-* `amplification` 
+* `amplification`, `task` 
 * `dispatch` 
 
 <a id="vulkan-shift"></a>
@@ -1383,6 +1383,7 @@ A capability describes an optional feature that a target may or may not support.
 * `callable` 
 * `miss` 
 * `mesh` 
+* `task` 
 * `amplification` 
 * `any_stage` 
 * `amplification_mesh` 
@@ -1585,6 +1586,8 @@ A [&lt;language&gt;](#language), &lt;format&gt;, and/or [&lt;stage&gt;](#stage) 
 * `tesc` : glsl (hull) 
 * `tese` : glsl (domain) 
 * `comp` : glsl (compute) 
+* `mesh` : glsl (mesh) 
+* `task` : glsl (amplification) 
 * `slang` 
 * `spv` : SPIR-V 
 * `spv-asm` : SPIR-V assembly 

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -106,6 +106,9 @@ Stages
 `mesh`
 > Mesh shader stage & mesh shader capabilities
 
+`task`
+> Task shader stage & mesh shader capabilities
+
 `amplification`
 > Amplification shader stage & mesh shader capabilities
 

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -1270,6 +1270,10 @@ alias miss = _miss + raytracing;
 /// [Stage]
 alias mesh = _mesh + _meshshading;
 
+/// Task shader stage & mesh shader capabilities
+/// [Stage]
+alias task = _amplification + _meshshading;
+
 /// Amplification shader stage & mesh shader capabilities
 /// [Stage]
 alias amplification = _amplification + _meshshading;

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -325,6 +325,8 @@ void initCommandOptions(CommandOptions& options)
             {"tesc", "glsl (hull)"},
             {"tese", "glsl (domain)"},
             {"comp", "glsl (compute)"},
+            {"mesh", "glsl (mesh)"},
+            {"task", "glsl (amplification)"},
             {"slang", nullptr},
             {"spv", "SPIR-V"},
             {"spv-asm", "SPIR-V assembly"},
@@ -1305,11 +1307,14 @@ void OptionsParser::addInputForeignShaderPath(
     };
 
     static const Entry entries[] = {
+        {".vert", Profile::GLSL_Vertex},
         {".frag", Profile::GLSL_Fragment},
         {".geom", Profile::GLSL_Geometry},
         {".tesc", Profile::GLSL_TessControl},
         {".tese", Profile::GLSL_TessEval},
-        {".comp", Profile::GLSL_Compute}};
+        {".comp", Profile::GLSL_Compute},
+        {".mesh", Profile::GLSL_Mesh},
+        {".task", Profile::GLSL_Task}};
 
     for (Index i = 0; i < SLANG_COUNT_OF(entries); ++i)
     {

--- a/source/slang/slang-profile-defs.h
+++ b/source/slang/slang-profile-defs.h
@@ -73,6 +73,7 @@ PROFILE_STAGE(Callable, callable, SLANG_STAGE_CALLABLE)
 
 PROFILE_STAGE(Mesh, mesh, SLANG_STAGE_MESH)
 PROFILE_STAGE(Amplification, amplification, SLANG_STAGE_AMPLIFICATION)
+PROFILE_STAGE_ALIAS(Task, task, Amplification)
 PROFILE_STAGE(Dispatch, dispatch, SLANG_STAGE_DISPATCH)
 
 // Note: HLSL and Direct3D convention erroneously uses the term "Pixel Shader"
@@ -322,6 +323,8 @@ P(Compute, compute, 430)
 P(Compute, compute, 440)
 P(Compute, compute, 450)
 
+P(Mesh, mesh, 450)
+
 #undef P
 #define P(UPPER, LOWER, STAGE, VERSION) \
     PROFILE(GLSL_##UPPER##_##VERSION, glsl_##LOWER##_##VERSION, STAGE, GLSL_##VERSION)
@@ -340,6 +343,8 @@ P(TessEval, tess_eval, Domain, 430)
 P(TessEval, tess_eval, Domain, 440)
 P(TessEval, tess_eval, Domain, 450)
 
+P(Task, task, Amplification, 450)
+
 #undef P
 
 // Define a default profile for each GLSL stage that just
@@ -351,6 +356,8 @@ PROFILE_ALIAS(GLSL_Geometry, GLSL_Geometry_450, glsl_geometry)
 PROFILE_ALIAS(GLSL_TessControl, GLSL_TessControl_450, glsl_tess_control)
 PROFILE_ALIAS(GLSL_TessEval, GLSL_TessEval_450, glsl_tess_eval)
 PROFILE_ALIAS(GLSL_Compute, GLSL_Compute_450, glsl_compute)
+PROFILE_ALIAS(GLSL_Mesh, GLSL_Mesh_450, glsl_mesh)
+PROFILE_ALIAS(GLSL_Task, GLSL_Task_450, glsl_task)
 
 // TODO: define a profile for each GLSL *version* that we can
 // use as a catch-all when the stage can be inferred from


### PR DESCRIPTION
in vulkan terminology, an amplification shader is referred to as task shader. so, same as with tessellation control and evaluation shaders, adding this one as an alias.

also on the way of adding task shader fixed some inconsistencies like not having a profile for glsl mesh shader.