### PR TITLE
Fix for OpUConvert producing invalid opcode when to/from signs differ

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -7300,10 +7300,23 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             // Perform unsigned conversion first to an unsigned integer of the same width as the
             // result then perform bit cast to the signed result type. This is done because SPIRV's
             // unsigned conversion (`OpUConvert`) requires result type to be unsigned.
+            auto builderType = builder.getType(getOppositeSignIntTypeOp(toType->getOp()));
+            auto elementCount = 1;
+            if (auto vecType = as<IRVectorType>(toTypeV))
+            {
+                if (auto count = as<IRIntLit>(vecType->getElementCount()))
+                    elementCount = count->getValue();
+            }
+            // If the type is a vector type then we need to create the appropriate builder type
+            if (elementCount > 1)
+            {
+                builderType = builder.getVectorType(builderType, elementCount);
+            }
+
             auto unsignedV = emitOpUConvert(
                 parent,
                 nullptr,
-                builder.getType(getOppositeSignIntTypeOp(toType->getOp())),
+                builderType,
                 inst->getOperand(0));
             return emitOpBitcast(parent, inst, toTypeV, unsignedV);
         }

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -7301,7 +7301,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             // result then perform bit cast to the signed result type. This is done because SPIRV's
             // unsigned conversion (`OpUConvert`) requires result type to be unsigned.
             auto builderType = builder.getType(getOppositeSignIntTypeOp(toType->getOp()));
-            auto elementCount = 1;
+            int64_t elementCount = 1;
             if (auto vecType = as<IRVectorType>(toTypeV))
             {
                 if (auto count = as<IRIntLit>(vecType->getElementCount()))


### PR DESCRIPTION
This fixes a bug when emitting the OpUConvert opcode where, if the to/from types differ in signage it would output a conversion with a scalar result rather than a vector.

Repro sample:
```
RWTexture2D<uint> tex;

void writeFlags(int2 position, RWTexture2D<uint> flagsTexture, uint flags)
{
    flagsTexture[position] = flags;
}

[shader("compute")]
[numthreads(1,1,1)]
void main(uint3 threadId : SV_DispatchThreadID)
{
    uint16_t2 position = uint16_t2(threadId.xy);
    uint flags = 1;
    writeFlags(position, tex, flags);
}
```

Validated with spirv-val:
```
error: line 99: Expected input to have the same dimension as Result Type: UConvert
  %65 = OpUConvert %uint %51
```