### PR TITLE
Fix to perform a bitcast prior to composite insert if there is a signedness mismatch

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -7059,7 +7059,6 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         return result;
     }
 
-
     SpvInst* emitSwizzleSet(SpvInstParent* parent, IRSwizzleSet* inst)
     {
         if (inst->getElementCount() == 1)


### PR DESCRIPTION
Sample repro:
```
void pSampling(inout int2 pPos, uint offset)
{
  pPos.x += offset;
  pPos.y += offset;
}

uint3 getP(float3 coord)
{
  return uint3(coord);
}

[shader("compute")]
[numthreads(1,1,1)]
void main(uint3 threadId : SV_DispatchThreadID)
{
    uint3 p = getP(threadId);
    pSampling(p.xy, 1);
}
```

spirv-val produces:
```
error: line 127: The Object type (OpTypeInt) does not match the type that results from indexing into the Composite (OpTypeInt).
  %250 = OpCompositeInsert %v3uint %139 %188 0
```

Appears to be missing a bitcast op to convert that int to a uint before inserting:
```
%139 = OpCompositeExtract %int %240 0
%250 = OpCompositeInsert %v3uint %139 %188 0
```