### PR TITLE
Fix an issue in extension override.

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -533,6 +533,7 @@ interface ITexelElement
 {
     associatedtype Element : __BuiltinArithmeticType;
     static const int elementCount;
+    [OverloadRank(-1)]
     __init(Element x);
 }
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -7545,7 +7545,7 @@ void SemanticsVisitor::checkExtensionConformance(ExtensionDecl* decl)
                        .as<ExtensionDecl>();
     auto targetType = getTargetType(m_astBuilder, declRef);
 
-    // Make a copy of inhertanceDecls firstsince `checkConformance` may modify decl->members.
+    // Make a copy of inhertanceDecls first since `checkConformance` may modify decl->members.
     auto inheritanceDecls = decl->getMembersOfType<InheritanceDecl>().toList();
     for (auto inheritanceDecl : inheritanceDecls)
     {
@@ -7598,7 +7598,7 @@ void SemanticsVisitor::checkAggTypeConformance(AggTypeDecl* decl)
         // just with `abstract` methods that replicate things?
         // (That's what C# does).
 
-        // Make a copy of inhertanceDecls firstsince `checkConformance` may modify decl->members.
+        // Make a copy of inhertanceDecls first since `checkConformance` may modify decl->members.
         auto inheritanceDecls = decl->getMembersOfType<InheritanceDecl>().toList();
         for (auto inheritanceDecl : inheritanceDecls)
         {

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -7545,7 +7545,9 @@ void SemanticsVisitor::checkExtensionConformance(ExtensionDecl* decl)
                        .as<ExtensionDecl>();
     auto targetType = getTargetType(m_astBuilder, declRef);
 
-    for (auto inheritanceDecl : decl->getMembersOfType<InheritanceDecl>())
+    // Make a copy of inhertanceDecls firstsince `checkConformance` may modify decl->members.
+    auto inheritanceDecls = decl->getMembersOfType<InheritanceDecl>().toList();
+    for (auto inheritanceDecl : inheritanceDecls)
     {
         checkConformance(targetType, inheritanceDecl, decl);
     }

--- a/source/slang/slang-check-inheritance.cpp
+++ b/source/slang/slang-check-inheritance.cpp
@@ -450,14 +450,15 @@ InheritanceInfo SharedSemanticsContext::_calcInheritanceInfo(
                 // then we need to add the extension itself as a facet.
                 //
                 auto extDeclRef =
-                    createDefaultSubstitutionsIfNeeded(astBuilder, &visitor, extensionDecl);
-                auto selfExtFacet = new (arena) Facet::Impl(
+                    createDefaultSubstitutionsIfNeeded(astBuilder, &visitor, extensionDecl)
+                        .as<ExtensionDecl>();
+                auto extInheritanceInfo = getInheritanceInfo(extDeclRef, circularityInfo);
+                addDirectBaseFacet(
                     Facet::Kind::Extension,
-                    Facet::Directness::Direct,
-                    extDeclRef,
                     selfType,
-                    astBuilder->getTypeEqualityWitness(selfType));
-                allFacets.add(selfExtFacet);
+                    selfIsSelf,
+                    extDeclRef,
+                    extInheritanceInfo);
             }
         }
 

--- a/tests/language-feature/extensions/extension-override-2.slang
+++ b/tests/language-feature/extensions/extension-override-2.slang
@@ -1,0 +1,41 @@
+//TEST:INTERPRET(filecheck=CHECK):
+interface IBar
+{}
+
+interface IFoo : IBar
+{
+    void execute();
+}
+
+struct Impl : IFoo
+{
+    void execute()
+    {
+        printf("Impl::execute();\n");
+    }
+}
+
+extension<T:IBar> T : IFoo
+{
+    void execute()
+    {
+        printf("Extension::execute();\n");
+    }
+}
+
+struct Base : IBar{}
+
+void test<T:IFoo>(T t)
+{
+    t.execute();
+}
+
+void main()
+{
+    // CHECK: Impl::execute();
+    Impl f;
+    test(f);
+    // CHECK: Extension::execute();
+    Base b;
+    test(b);
+}


### PR DESCRIPTION
Closes #7364.

Given:

```slang
interface IBar
{}

interface IFoo : IBar
{
    void execute();
}

extension<T:IBar> T : IFoo
{
    void execute()
    {
        printf("Extension::execute();\n");
    }
}
void test<T:IFoo>(T t)
{
    t.execute();
}
```

There is an issue in `CompareLookupResultItems` during checking `t.execute` in `test`, which would prefer `extension::execute` over a lookup of `IFoo.execute` using the witness parameter. This is because `CompareLookupResultItems` always prefers a concrete definition over an interface definition. This shouldn't be the case when the concrete definition is in a free-form generic extension.