### PR TITLE
Bump the min shader model version for CUDA 12.8+

### DIFF
--- a/source/compiler-core/slang-nvrtc-compiler.cpp
+++ b/source/compiler-core/slang-nvrtc-compiler.cpp
@@ -1051,21 +1051,19 @@ SlangResult NVRTCDownstreamCompiler::compile(
         SemanticVersion version(3);
 
         // Newer releases of NVRTC only support newer CUDA architectures.
-        if (m_desc.version.m_major >= 12)
+        if (m_desc.version.m_major > 12 ||
+            (m_desc.version.m_major == 12 && m_desc.version.m_minor >= 8))
         {
             // NVRTC 12.8+ warns about architectures prior to compute_75 being deprecated
             // The exact warning message is:
             //   nvrtc 12.8: nvrtc: warning : Architectures prior to '<compute/sm>_75' are
             //   deprecated and may be removed in a future release
-            if (m_desc.version.m_minor >= 8)
-            {
-                version = SemanticVersion(7, 5);
-            }
-            else
-            {
-                // NVRTC 12.0 supports `compute_50` and up
-                version = SemanticVersion(5, 0);
-            }
+            version = SemanticVersion(7, 5);
+        }
+        else if (m_desc.version.m_major == 12)
+        {
+            // NVRTC 12.0 supports `compute_50` and up
+            version = SemanticVersion(5, 0);
         }
         else if (m_desc.version.m_major == 11)
         {

--- a/source/compiler-core/slang-nvrtc-compiler.cpp
+++ b/source/compiler-core/slang-nvrtc-compiler.cpp
@@ -1053,9 +1053,19 @@ SlangResult NVRTCDownstreamCompiler::compile(
         // Newer releases of NVRTC only support newer CUDA architectures.
         if (m_desc.version.m_major >= 12)
         {
-            // NVRTC in CUDA 12 only supports `compute_50` and up
-            // (with everything before `compute_52` being deprecated).
-            version = SemanticVersion(5, 0);
+            // NVRTC 12.8+ warns about architectures prior to compute_75 being deprecated
+            // The exact warning message is:
+            //   nvrtc 12.8: nvrtc: warning : Architectures prior to '<compute/sm>_75' are
+            //   deprecated and may be removed in a future release
+            if (m_desc.version.m_minor >= 8)
+            {
+                version = SemanticVersion(7, 5);
+            }
+            else
+            {
+                // NVRTC 12.0 supports `compute_50` and up
+                version = SemanticVersion(5, 0);
+            }
         }
         else if (m_desc.version.m_major == 11)
         {


### PR DESCRIPTION
CUDAU 12.8+ prints a warning that shader model before 7.5 is deprecated.
This PR bumps the minimum shader model version from 5.0 to 7.5 when nvrtc version is 12.8 or above.

Closes https://github.com/shader-slang/slang/issues/7026
- https://github.com/shader-slang/slang/issues/7026