### PR TITLE
slang: Add support for casting associate types

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -369,6 +369,14 @@ interface __BuiltinSignedArithmeticType : __BuiltinArithmeticType {}
 interface __BuiltinIntegerType : __BuiltinArithmeticType, IInteger
 {}
 
+extension<T:__BuiltinIntegerType> T
+{
+    __init(__BuiltinIntegerType value)
+    {
+        this = __intCast<T>(value);
+    }
+}
+
 /// Represents a `int` or `uint` type.
 [sealed]
 [builtin]
@@ -816,6 +824,14 @@ interface __BuiltinFloatingPointType : __BuiltinRealType, IFloat
         /// Get the value of the mathematical constant pi in this type.
     [Differentiable]
     static This getPi();
+}
+
+extension<T:__BuiltinFloatingPointType> T
+{
+    __init(__BuiltinFloatingPointType value)
+    {
+        this = __realCast<T>(value);
+    }
 }
 
 //@ hidden:


### PR DESCRIPTION
slang: Add support for casting associate typesto builtin types.

This change adds support for casting associate types to builtin types by extending the builtin types to explicitly invoke a __realCast or an __intCast.

Only the builtin floating points and ints are supported.

This fixes Issue #6960