### PR TITLE
Fix issue that struct with  member is not its Differential type

### DIFF
--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -1293,15 +1293,17 @@ Type* SemanticsVisitor::tryGetDifferentialType(ASTBuilder* builder, Type* type)
 
 bool SemanticsVisitor::canStructBeUsedAsSelfDifferentialType(AggTypeDecl* aggTypeDecl)
 {
-    // A struct can be used as its own differential type if all its members are differentiable
-    // and their differential types are the same as the original types.
+    // A struct can be used as its own differential type if all its members are differentiable, and
+    // none of the member is decorated with "no_diff", and their differential types are the same as
+    // the original types.
     //
     bool canBeUsed = true;
     for (auto varDecl : aggTypeDecl->getDirectMemberDeclsOfType<VarDecl>())
     {
         // Try to get the differential type of the member.
         Type* diffType = tryGetDifferentialType(getASTBuilder(), varDecl->getType());
-        if (!diffType || !diffType->equals(varDecl->getType()))
+        if (!diffType || !diffType->equals(varDecl->getType()) ||
+            varDecl->findModifier<NoDiffModifier>())
         {
             canBeUsed = false;
             break;

--- a/tests/autodiff/differential-type-syntheize-diagnostics.slang
+++ b/tests/autodiff/differential-type-syntheize-diagnostics.slang
@@ -1,0 +1,31 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):
+
+struct PartlyDiffable : IDifferentiable
+{
+    no_diff float noDiffMember;
+    float diffMember;
+}
+
+float func(PartlyDiffable.Differential x)
+{
+   // CHECK: error 30027: 'noDiffMember' is not a member of 'PartlyDiffable.Differential'.
+   // CHECK-NOT: error 30027: 'diffMember.
+    return x.noDiffMember;
+}
+
+float func1(PartlyDiffable.Differential x)
+{
+   // CHECK-NOT: error 30027: 'diffMember.
+    return x.diffMember;
+}
+
+RWStructuredBuffer<float> out;
+
+[shader("compute")]
+void compute()
+{
+    // CHECK: error 39999: no overload for 'Differential' applicable to arguments of type (float, float)
+    var diff = PartlyDiffable.Differential(1.0f, 2.0f);
+    out[0] = func(diff);
+    out[1] = func1(diff);
+}

--- a/tests/autodiff/differential-type-syntheize-diagnostics.slang
+++ b/tests/autodiff/differential-type-syntheize-diagnostics.slang
@@ -8,14 +8,13 @@ struct PartlyDiffable : IDifferentiable
 
 float func(PartlyDiffable.Differential x)
 {
-   // CHECK: error 30027: 'noDiffMember' is not a member of 'PartlyDiffable.Differential'.
-   // CHECK-NOT: error 30027: 'diffMember.
+   // CHECK: ([[# @LINE+1]]): error 30027: 'noDiffMember' is not a member of 'PartlyDiffable.Differential'.
     return x.noDiffMember;
 }
 
 float func1(PartlyDiffable.Differential x)
 {
-   // CHECK-NOT: error 30027: 'diffMember.
+   // CHECK-NOT: ([[# @LINE+1]]): error 30027: 'diffMember.
     return x.diffMember;
 }
 
@@ -24,7 +23,7 @@ RWStructuredBuffer<float> out;
 [shader("compute")]
 void compute()
 {
-    // CHECK: error 39999: no overload for 'Differential' applicable to arguments of type (float, float)
+    // CHECK:  ([[# @LINE+1]]): error 39999: no overload for 'Differential' applicable to arguments of type (float, float)
     var diff = PartlyDiffable.Differential(1.0f, 2.0f);
     out[0] = func(diff);
     out[1] = func1(diff);


### PR DESCRIPTION
Close #6176.

If the struct has a `no_diff` member, it should not be its Differential type. We miss this check.