### PR TITLE
Disable periadic diagnostic update on language-server on CI

### DIFF
--- a/source/slang/slang-language-server.h
+++ b/source/slang/slang-language-server.h
@@ -83,6 +83,9 @@ struct LanguageServerStartupOptions
     // Are we working with Visual Studio client?
     bool isVisualStudio = false;
 
+    // A flag to control periodic diagnostic update. Defaults to true.
+    bool periodicDiagnosticUpdate = true;
+
     SLANG_API void parse(int argc, const char* const* argv);
 };
 

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -213,6 +213,8 @@ SlangResult TestContext::createLanguageServerJSONRPCConnection(RefPtr<JSONRPCCon
     {
         CommandLine cmdLine;
         cmdLine.setExecutableLocation(ExecutableLocation(exeDirectoryPath, "slangd"));
+        cmdLine.addArg("-periodic-diagnostic-update");
+        cmdLine.addArg("false");
         SLANG_RETURN_ON_FAIL(Process::create(cmdLine, Process::Flag::AttachDebugger, process));
     }
 


### PR DESCRIPTION
The "textDocument/publishDiagnostics" Notification in the official Language Server Protocol, or LSP for short, is a notification that the server sends to the client such as VSCode or Visual Studio without the client having to ask for it. Its purpose is to provide a list of errors, warnings, or other informational "squiggles" for a specific file.

Because the notification is an asynchronous push notification, it is receieved as an unexpected RPC message during the slang-test CI tests. When a notificatoin is unexpectedly sent to slang-test, the communication goes out-of-sync and the rest of language-server based tests intermittently fails.

In order to address the problem, this PR adds a new command-line argument to change the behavior of the notification and it will be sent in a more deterministic manner where the notification can be sent only in one of three cases: didOpen, didChange, and didClose. Because these evets are only ways to cause a new notification, we can still expect to get the same diagnostic messages without missing any of them. For slang-test CI test, this new option will be used to make the notification more deterministic.