### PR TITLE
[SPIR-V] Fix error of extern function signature

### DIFF
--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -868,9 +868,20 @@ void fixUpFuncType(IRFunc* func, IRType* resultType)
     builder.setInsertBefore(func);
 
     List<IRType*> paramTypes;
-    for (auto param : func->getParams())
+    if (func->isDefinition())
     {
-        paramTypes.add(param->getFullType());
+        for (auto param : func->getParams())
+        {
+            paramTypes.add(param->getFullType());
+        }
+    }
+    else
+    {
+        auto funcType = as<IRFuncType>(func->getFullType());
+        for (auto paramType : funcType->getParamTypes())
+        {
+            paramTypes.add(paramType);
+        }
     }
 
     auto funcType = builder.getFuncType(paramTypes, resultType);

--- a/tests/spirv/extern-func-signature.slang
+++ b/tests/spirv/extern-func-signature.slang
@@ -1,0 +1,14 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -emit-spirv-directly -incomplete-library -O0
+
+RWByteAddressBuffer buf;
+
+[numthreads(1,1,1)]
+[shader("compute")]
+// CHECK: OpTypeFunction %void
+void main()
+{
+    buf.Store(0, f(0));
+}
+
+// CHECK: OpTypeFunction %int %int
+extern int f(int);


### PR DESCRIPTION
As for extern function, it's not definition, that is no params. After legalize, the function type hasn't params, it's a error signature.

When we fix the function type, extern function should check the param types in function type instead of params.