### PR TITLE
"kDefaultTargetFlags" exposing TU-local entity with modules 

### DIFF
--- a/include/slang.h
+++ b/include/slang.h
@@ -722,7 +722,7 @@ typedef uint32_t SlangSizeT;
         // This flag will be deprecated, use CompilerOption instead.
         SLANG_TARGET_FLAG_GENERATE_SPIRV_DIRECTLY = 1 << 10,
     };
-    constexpr static SlangTargetFlags kDefaultTargetFlags =
+    inline constexpr SlangTargetFlags kDefaultTargetFlags =
         SLANG_TARGET_FLAG_GENERATE_SPIRV_DIRECTLY;
 
     /*!


### PR DESCRIPTION
The current declaration of `kDefaultTargetFlags` causes problems when used with C++ modules:

```
usr/local/include/slang.h:3824:8: error: ‘struct slang::TargetDesc’ exposes TU-local entity ‘kDefaultTargetFlags’
 3824 | struct TargetDesc
      |        ^~~~~~~~~~
/usr/local/include/slang.h:725:39: note: ‘kDefaultTargetFlags’ declared with internal linkage
  725 |     constexpr static SlangTargetFlags kDefaultTargetFlags =
      |                                       ^~~~~~~~~~~~~~~~~~~

```

I propose this fix.