### PR TITLE
Fix SPIR-V emit for SV_DepthLessEqual and SV_DepthGreaterEqual

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -4850,7 +4850,15 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         if (mode == SpvExecutionModeMax)
             return;
 
-        requireSPIRVExecutionMode(nullptr, getIRInstSpvID(entryPoint), mode);
+        // Vulkan spec requires DepthReplacing exec mode when storing to FragDepth,
+        // in addition to DepthLess/DepthGreater modes.
+        requireSPIRVExecutionMode(
+            nullptr,
+            getIRInstSpvID(entryPoint),
+            SpvExecutionModeDepthReplacing);
+
+        if (mode != SpvExecutionModeDepthReplacing)
+            requireSPIRVExecutionMode(nullptr, getIRInstSpvID(entryPoint), mode);
     }
 
     // Make user type name conform to `SPV_GOOGLE_user_type` spec.

--- a/tests/spirv/depth-replacing-gt-lt.slang
+++ b/tests/spirv/depth-replacing-gt-lt.slang
@@ -1,0 +1,16 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+// CHECK: OpExecutionMode {{.*}} DepthReplacing
+// CHECK: OpExecutionMode %FS_WriteDepthGt DepthGreater
+// CHECK: OpExecutionMode %FS_WriteDepthLt DepthLess
+
+[shader("fragment")]
+void FS_WriteDepthGt(out float depth: SV_DepthGreaterEqual)
+{
+    depth = 0.5;
+}
+
+[shader("fragment")]
+void FS_WriteDepthLt(out float depth: SV_DepthLessEqual)
+{
+    depth = 0.5;
+}


### PR DESCRIPTION
Validator complains about the following code. This PR fixes that.

```slang
[shader("fragment")]
void FSMain(out float depth: SV_DepthLessEqual) {
    depth = 0.5;
}
```

```
>spirv-val --target-env vulkan1.3 test.spv
error: line 17: [VUID-FragDepth-FragDepth-04216] Vulkan spec requires DepthReplacing execution mode to be declared when using BuiltIn FragDepth. ID <0> (OpStore) is referencing ID <7> (OpVariable) which is decorated with BuiltIn FragDepth in function <2>.
  OpStore %gl_FragDepth %float_0_5
```
