### PR TITLE
Update slang-rhi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,7 @@ jobs:
       - name: Run slang-rhi tests
         if: steps.filter.outputs.should-run == 'true' && matrix.platform != 'wasm' && matrix.full-gpu-tests
         run: |
-          "$bin_dir/slang-rhi-tests" -check-devices -tce=ray-tracing-*,cmd-query-resolve-host,fence-*
+          "$bin_dir/slang-rhi-tests" -check-devices
       - name: Run slangpy tests
         if: steps.filter.outputs.should-run == 'true' && matrix.platform != 'wasm' && matrix.full-gpu-tests
         shell: pwsh


### PR DESCRIPTION
Update to latest `slang-rhi` with the following important changes:
- remove use of git submodules (should make it easier to work with in the slang repo)
- fix tests that failed on Windows 11 (allow running all slang-rhi tests)

@csyonghe hope that should make life a bit easier for slang developers