### PR TITLE
Require `override` keyword for overriding default interface methods.

### DIFF
--- a/docs/user-guide/06-interfaces-generics.md
+++ b/docs/user-guide/06-interfaces-generics.md
@@ -58,6 +58,17 @@ interface IFoo
 struct MyType : IFoo {}
 ```
 
+A concrete type that provides its overriding implementation to an interface method requirement that has a default implementation must be explicitly marked as 'override'. For example:
+
+```slang
+struct MyType2 : IFoo
+{
+    // Explicitly mark `getVal` as `override` is needed
+    // because `IFoo.getVal` has a body.
+    override int getVal() { return 1; }
+}
+```
+
 Generics
 ---------------------
 

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -67,6 +67,21 @@ class InternalModifier : public VisibilityModifier
 };
 
 FIDDLE()
+class OverrideModifier : public Modifier
+{
+    FIDDLE(...)
+};
+
+// Marks that a decl is verified to be overriding another decl defined in a base type.
+FIDDLE()
+class IsOverridingModifier : public Modifier
+{
+    FIDDLE(...)
+
+    FIDDLE() Decl* overridedDecl;
+};
+
+FIDDLE()
 class RequireModifier : public Modifier
 {
     FIDDLE(...)

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -78,7 +78,7 @@ class IsOverridingModifier : public Modifier
 {
     FIDDLE(...)
 
-    FIDDLE() Decl* overridedDecl;
+    FIDDLE() Decl* overridedDecl = nullptr;
 };
 
 FIDDLE()

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1892,7 +1892,10 @@ public:
         DeclRef<CallableDecl> requirement,
         DeclRef<CallableDecl> method);
 
-    void markOverridingDecl(Decl* memberDecl, DeclRef<Decl> requiredMemberDeclRef);
+    void markOverridingDecl(
+        ConformanceCheckingContext* context,
+        Decl* memberDecl,
+        DeclRef<Decl> requiredMemberDeclRef);
 
     /// Attempt to synthesize a method that can satisfy `requiredMemberDeclRef` using
     /// `lookupResult`.

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1892,6 +1892,8 @@ public:
         DeclRef<CallableDecl> requirement,
         DeclRef<CallableDecl> method);
 
+    void markOverridingDecl(Decl* memberDecl, DeclRef<Decl> requiredMemberDeclRef);
+
     /// Attempt to synthesize a method that can satisfy `requiredMemberDeclRef` using
     /// `lookupResult`.
     ///

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -1529,6 +1529,8 @@ bool isModifierAllowedOnDecl(bool isGLSLInput, ASTNodeType modifierType, Decl* d
         return isGlobalDecl(decl) || isEffectivelyStatic(decl);
     case ASTNodeType::DynModifier:
         return as<InterfaceDecl>(decl) || as<VarDecl>(decl) || as<ParamDecl>(decl);
+    case ASTNodeType::OverrideModifier:
+        return as<FunctionDeclBase>(decl) && as<AggTypeDecl>(getParentDecl(decl));
     default:
         return true;
     }

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -1731,6 +1731,17 @@ DIAGNOSTIC(
     invalidExtensionOnInterface,
     "cannot extend interface type '$0'. consider using a generic extension: `extension<T:$0> T "
     "{...}`.")
+DIAGNOSTIC(
+    30853,
+    Error,
+    missingOverride,
+    "missing 'override' keyword for methods that overrides the default implementation in the "
+    "interface.")
+DIAGNOSTIC(
+    30854,
+    Error,
+    overrideModifierNotOverridingBaseDecl,
+    "'$0' marked as 'override' is not overriding any base declarations.")
 
 // 309xx: subscripts
 DIAGNOSTIC(

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -9467,6 +9467,7 @@ static const SyntaxParseInfo g_parseSyntaxEntries[] = {
     _makeParseModifier("writeonly", parseWriteonlyModifier),
     _makeParseModifier("export", getSyntaxClass<HLSLExportModifier>()),
     _makeParseModifier("dynamic_uniform", getSyntaxClass<DynamicUniformModifier>()),
+    _makeParseModifier("override", getSyntaxClass<OverrideModifier>()),
 
     // Modifiers for geometry shader input
     _makeParseModifier("point", getSyntaxClass<HLSLPointModifier>()),

--- a/tests/diagnostics/missing-override.slang
+++ b/tests/diagnostics/missing-override.slang
@@ -1,0 +1,20 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):
+
+interface IFoo
+{
+    int getVal() { return 0; }
+}
+
+struct Impl : IFoo
+{
+    // Missing override for getVal, which should trigger a diagnostic.
+    // CHECK: ([[# @LINE+1]]): error 30853
+    int getVal() { return 1; }
+}
+
+struct Impl2 : IFoo
+{
+    // Overriding getVal with a different signature should also trigger a diagnostic.
+    // CHECK: ([[# @LINE+1]]): error 30854
+    override int getVal(int x) { return x; }
+}

--- a/tests/language-feature/interfaces/default-method-generic-interface.slang
+++ b/tests/language-feature/interfaces/default-method-generic-interface.slang
@@ -30,7 +30,7 @@ struct Impl2 : IFoo<2>
     }
     
     // overriding default implementation.
-    int getGreaterVal<int x>()
+    override int getGreaterVal<int x>()
     {
         return 100 + x;
     }

--- a/tests/language-feature/interfaces/override-default-method.slang
+++ b/tests/language-feature/interfaces/override-default-method.slang
@@ -1,0 +1,40 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj -output-using-type
+
+// Test that a generic interface method can have a body providing default implementation.
+
+interface IFoo
+{
+    int getVal();
+    int getGreaterVal<int x>()
+    {
+        return getVal() + x;
+    }
+}
+
+struct Impl : IFoo
+{
+    int getVal()
+    {
+        return 42;
+    }
+    
+    // override default implementation for getGreaterVal.
+    override int getGreaterVal<int x>()
+    {
+        return getVal() + x + 1; // Adding 1 to differentiate from the default implementation.
+    }
+}
+
+int test<T:IFoo>(T v) { return v.getGreaterVal<1>(); }
+
+//TEST_INPUT: set resultBuffer = out ubuffer(data=[0 0 0 0], stride=4)
+RWStructuredBuffer<int> resultBuffer;
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    Impl impl = {};
+    int result = test(impl);
+    resultBuffer[0] = result;
+    // CHECK: 44
+}


### PR DESCRIPTION
This change requires explicit `override` modifier for functions that overrides a default interface implementation.
Part of the default interface method proposal.