### PR TITLE
Update CMake version to 3.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
       - name: Build Slang
         if: steps.filter.outputs.should-run == 'true'
         run: |
+          echo "cmake version: $(cmake --version)"
           if [[ "${{ matrix.platform }}" = "wasm" ]]; then
               git clone https://github.com/emscripten-core/emsdk.git
               pushd emsdk

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.26)
 
 # Our module dir, include that now so that we can get the version automatically
 # from git describe


### PR DESCRIPTION
https://github.com/shader-slang/slang/commit/0cb89b3062f89ec5f5c5812f0164f8c90f3f9aba uses `BUILD_LOCAL_INTERFACE`, which reques cmake 3.26+

Fixes: #7453