### PR TITLE
Fix cuda_fp16 header issue

### DIFF
--- a/source/compiler-core/slang-nvrtc-compiler.cpp
+++ b/source/compiler-core/slang-nvrtc-compiler.cpp
@@ -127,7 +127,7 @@ protected:
         nvrtcProgram m_program;
     };
 
-    SlangResult _findCUDAIncludePath(String& outIncludePath);
+    SlangResult _findCUDAIncludePath(String& outPath);
     SlangResult _getCUDAIncludePath(String& outIncludePath);
 
     SlangResult _findOptixIncludePath(String& outIncludePath);
@@ -706,10 +706,13 @@ SlangResult NVRTCDownstreamCompiler::_findCUDAIncludePath(String& outPath)
     }
 
 #if SLANG_LINUX_FAMILY
-    // Try /usr/include
+    List<String> candidatePaths;
+    candidatePaths.add("/usr/local/include");
+    candidatePaths.add("/usr/local/cuda/include");
+    candidatePaths.add("/usr/include");
+    
+    for (const String& includePath : candidatePaths)
     {
-        String includePath = "/usr/include";
-
         if (File::exists(Path::combine(includePath, g_fp16HeaderName)))
         {
             outPath = includePath;
@@ -717,7 +720,6 @@ SlangResult NVRTCDownstreamCompiler::_findCUDAIncludePath(String& outPath)
         }
     }
 #endif
-
     return SLANG_E_NOT_FOUND;
 }
 


### PR DESCRIPTION
This fixes the header include issue. However, it does not add a diagnostic. That will be added in a separate PR.