### PR TITLE
Remove the GCP-T4 to allow slang CI to run all self-hosted machines

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -115,24 +115,6 @@ runs:
         fi
         echo SCCACHE_IGNORE_SERVER_IO_ERROR=1 >> "$GITHUB_ENV"
 
-    # Install swiftshader
-    - uses: robinraju/release-downloader@v1.11
-      continue-on-error: true
-      with:
-        latest: true
-        repository: "shader-slang/swiftshader"
-        out-file-path: "swiftshader"
-        extract: true
-        fileName: "vk_swiftshader_${{inputs.os}}_${{inputs.platform}}.zip"
-
-    - name: Install SwiftShader
-      shell: bash
-      run: |
-        case "${{inputs.os}}" in
-          windows*) echo "${{github.workspace}}/swiftshader/" >> "$GITHUB_PATH";;
-          *) echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+${LD_LIBRARY_PATH}:}${{github.workspace}}/swiftshader" >> "$GITHUB_ENV";;
-        esac
-
     # Put spirv-tools in path
     - shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
             platform: x86_64
             test-category: full
             full-gpu-tests: true
-            runs-on: [Windows, self-hosted, GCP-T4]
+            runs-on: [Windows, self-hosted]
             has-gpu: true
             server-count: 8
           # Self-hosted full gpu build - debug
@@ -81,7 +81,7 @@ jobs:
             platform: x86_64
             test-category: full
             full-gpu-tests: true
-            runs-on: [Windows, self-hosted, GCP-T4]
+            runs-on: [Windows, self-hosted]
             has-gpu: true
             server-count: 8
       fail-fast: false


### PR DESCRIPTION
- [Remove the GCP-T4 to allow slang CI to run all self-hosted machines](https://github.com/shader-slang/slang/commit/2443239444d5eed85ade0a5bfd831c9483270687)
- [Remove SwiftShader from common-setup](https://github.com/shader-slang/slang/commit/99fd3cbc8abe523f3aa2ba35fbd904e64c970f70)