### PR TITLE
Fix Phi elimination pass sometimes creating broken insts in release builds

### DIFF
--- a/source/slang/slang-ir-eliminate-phis.cpp
+++ b/source/slang/slang-ir-eliminate-phis.cpp
@@ -904,20 +904,21 @@ struct PhiEliminationContext
         }
 
         // Once we are sure all the assignment operations have been performed,
-        // we can set about replacing the unconditional branch itself.
+        // we can set about removing the phi arguments from the unconditional
+        // branch itself.
         //
-        replaceBranch(branch);
+        updateBranch(branch);
     }
 
-    // Replacing the branch instruction at the end of a predecessor block
+    // Updating the branch instruction at the end of a predecessor block
     // is relatively simple, and just a bit of busy-work.
     //
-    void replaceBranch(IRUnconditionalBranch* oldBranch)
+    void updateBranch(IRUnconditionalBranch* branch)
     {
         // When creating a replacement instruction here, we need to make sure
         // that we keep all the operands that weren't phi arguments.
         //
-        Count oldOperandCount = oldBranch->getOperandCount();
+        Count oldOperandCount = branch->getOperandCount();
         Count paramCount = getParamCount();
         Count newOperandCount = oldOperandCount - paramCount;
 
@@ -934,32 +935,13 @@ struct PhiEliminationContext
         static const Count kMaxNewOperandCount = 3;
         SLANG_ASSERT(newOperandCount <= kMaxNewOperandCount);
 
-        ShortList<IRInst*> newOperands;
-        for (Index i = 0; i < newOperandCount; ++i)
+        // Eliminate phi parameters
+        for (UInt i = 0, j = 0; i < (UInt)phiInfos.getCount(); i++)
         {
-            newOperands.add(oldBranch->getOperand(i));
+            if (phiInfos[i].param.temp)
+                branch->removeOperand(newOperandCount+j);
+            else ++j;
         }
-
-        // Add operands for any remaining phi parameters that has not been eliminated.
-        for (UInt i = 0; i < (UInt)phiInfos.getCount(); i++)
-        {
-            if (!phiInfos[i].param.temp)
-                newOperands.add(oldBranch->getArg(i));
-        }
-
-        auto newBranch = m_builder.emitIntrinsicInst(
-            oldBranch->getFullType(),
-            oldBranch->getOp(),
-            newOperands.getCount(),
-            newOperands.getArrayView().getBuffer());
-        oldBranch->transferDecorationsTo(newBranch);
-        newBranch->sourceLoc = oldBranch->sourceLoc;
-
-        // TODO: We could consider just modifying `branch` in-place by clearing
-        // the relevant operands for the phi arguments and setting its operand
-        // count to a lower value.
-        //
-        oldBranch->removeAndDeallocate();
     }
 
     bool canLoadBeFoldedAtInst(IRInst* load, IRInst* useSite)


### PR DESCRIPTION
This one was really hard to track down, and I'm still not 100% sure what was happening.

The `oldBranch` that was removed in `replaceBranch` was somehow _not_ getting removed and the `newBranch` was _not_ being inserted, even though both lines of code did run. This caused the IR dump to look like this:
```
block %29:
        loop(<null>, <null>, <null>, <null>) # <- the pointer for this IRInst was `oldBranch`, even after it got deleted....
```
which crashed the compiler in a later pass. Interestingly, there are multiple loops and only one does this.

This only happened in release builds, so it seems like there's some undefined behaviour going on. Due to past experiences, I'm a bit suspicious of the cached dominator tree; removing stuff while querying the dominator tree has caused me similar issues in the past.

In any case, there was a helpful TODO comment that mentioned that `replaceBranch` could be converted into an in-place version. So I did that, and that got rid of the problem too.

Kinda WIP; just checking first if tests pass with this approach while trying to minify my bug-triggering code into a new test as well.