### PR TITLE
Fix tuple AST & IR layout size queries

### DIFF
--- a/source/slang/slang-ast-natural-layout.cpp
+++ b/source/slang/slang-ast-natural-layout.cpp
@@ -153,6 +153,12 @@ NaturalSize ASTNaturalLayoutContext::_calcSizeImpl(Type* type)
         // Initialize empty
         NaturalSize size = NaturalSize::makeEmpty();
 
+        // We can't compute the size of an abstract type pack yet.
+        if (isAbstractTypePack(tupleType->getTypePack()))
+        {
+            return NaturalSize::makeInvalid();
+        }
+
         // Accumulate over all the member types
         for (auto cur = 0; cur < tupleType->getMemberCount(); cur++)
         {

--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -281,8 +281,6 @@ struct PeepholeContext : InstPassBase
                         baseType,
                         &sizeAlignment)))
                     break;
-                if (sizeAlignment.size == 0)
-                    break;
 
                 IRBuilder builder(module);
                 IRBuilderSourceLocRAII srcLocRAII(&builder, inst->sourceLoc);

--- a/tests/hlsl-intrinsic/size-of/size-of-tuple.slang
+++ b/tests/hlsl-intrinsic/size-of/size-of-tuple.slang
@@ -1,0 +1,48 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -shaderobj
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0], stride=4):out,name outputBuffer
+
+RWStructuredBuffer<int> outputBuffer;
+
+struct Thing<each T>
+{
+    int val;
+    Tuple<expand each T> tuple;
+};
+
+int tupleSize1<T>(T vals)
+{
+    return sizeof(Tuple<T>);
+}
+
+int tupleSize2<each T>(T vals)
+{
+    return sizeof(Tuple<expand each T>);
+}
+
+int tupleSize3<each T>(T vals)
+{
+    return sizeof(Tuple<int, expand each T>);
+}
+
+int tupleSize4<each T>(T vals)
+{
+    return sizeof(Thing<expand each T>);
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    outputBuffer[0] = tupleSize2(); // CHECK: 0
+    outputBuffer[1] = tupleSize3(); // CHECK-NEXT: 4
+    outputBuffer[2] = tupleSize4(); // CHECK-NEXT: 4
+
+    outputBuffer[3] = tupleSize1(1); // CHECK-NEXT: 4
+    outputBuffer[4] = tupleSize2(1,2); // CHECK-NEXT: 8
+    outputBuffer[5] = tupleSize3(1,2,3); // CHECK-NEXT: 10
+    outputBuffer[6] = tupleSize4(1,2,3,4); // CHECK-NEXT: 14
+}


### PR DESCRIPTION
Fixes #7501. Curiously, there were three separate problems causing the issue.

On the AST side, a size of 0 was reported due to `getMemberCount()` returning zero with an abstract type pack. I fixed that by preventing `_calcSizeImpl` from giving a size to a tuple with an abstract type pack.

After fixing this, I found another issue on the IR layout side; `_calcSizeAndAlignment` just never added tuple members' sizes to the total. So I made it match they way StructTypes are handled.

Finally, `slang-ir-peephole.cpp` was never lowering `sizeof` if the resulting size would've been 0. This may have made some sense long ago, but now that zero-sized arrays, `Conditional<T, bool>` and empty tuples exist, 0 is clearly a valid value for `sizeof` now. So if removing this check causes more errors, I think they should instead be fixed by making `getNaturalSizeAndAlignment` return a failure instead of a 0 size.