### PR TITLE
Correct the scope for DebugLocalVariable

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -3468,7 +3468,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     spvBlock,
                     spvFunc,
                     irDebugFunc,
-                    irFunc->getDataType());
+                    irFunc->getDataType(),
+                    irFunc);
             }
             if (funcDebugScope)
             {
@@ -7964,7 +7965,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         SpvInst* firstBlock,
         SpvInst* spvFunc,
         IRDebugFunction* debugFunc,
-        IRFuncType* debugType)
+        IRFuncType* debugType,
+        IRFunc* irFunc = nullptr)
     {
         SpvInst* debugFuncInfo = nullptr;
         if (debugFunc && m_mapIRInstToSpvInst.tryGetValue(debugFunc, debugFuncInfo))
@@ -8001,6 +8003,11 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             debugFunc->getName(),
             builder.getIntValue(builder.getUIntType(), 0),
             debugFunc->getLine());
+
+        if (irFunc)
+        {
+            registerDebugInst(irFunc, debugFuncInfo);
+        }
 
         if (firstBlock && spvFunc)
         {


### PR DESCRIPTION
All of the DebugLocalVariable instructions have their scope set to DebugCompilationUnit. The scope should instead be set to a DebugFunction, or a DebugLexicalBlock which is recursively inside a DebugFunction.

Register the debug info for the function instructions, which helps findDebugScope() to find the right DebugFunction scope for DebugLocalVariable.