### PR TITLE
Unconditionally emit the DebugBuildIdentifier

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -714,12 +714,10 @@ Result linkAndOptimizeIR(
     auto irModule = outLinkedIR.module;
     auto irEntryPoints = outLinkedIR.entryPoints;
 
-    // For now, only emit the debug build identifier if separate debug info is enabled
-    // and only if there are targets.
-    // TODO: We will ultimately need to change this to always emit the instruction.
-    if (targetCompilerOptions.shouldEmitSeparateDebugInfo())
+    // Build identifier is a hash of the source code and compile options.
+    // Only emit the identifier if there is an entry point.
+    if (irEntryPoints.getCount() > 0)
     {
-        // Build identifier is a hash of the source code and compile options.
         String buildIdentifier = getBuildIdentifierString(codeGenContext->getProgram());
         int buildIdentifierFlags = 0;
         IRBuilder builder(irModule);

--- a/source/slang/slang-pass-through.cpp
+++ b/source/slang/slang-pass-through.cpp
@@ -77,6 +77,7 @@ PassThroughMode getDownstreamCompilerRequiredForTarget(CodeGenTarget target)
     case CodeGenTarget::CSource:
     case CodeGenTarget::Metal:
     case CodeGenTarget::WGSL:
+    case CodeGenTarget::HostVM:
         {
             return PassThroughMode::None;
         }


### PR DESCRIPTION
Unconditionally emit the DebugBuildIdentifier instruction regardless of wether separate debugging was requested.

DO NOT SUBMIT!!!!

I am creating this PR to test the CI. This passes locally but I want to confirm. We are not yet ready for this to be merged!!!