### PR TITLE
Use LoadLibraryExA instead of LoadLibraryA

### DIFF
--- a/source/core/slang-platform.cpp
+++ b/source/core/slang-platform.cpp
@@ -119,8 +119,8 @@ SLANG_COMPILE_TIME_ASSERT(E_OUTOFMEMORY == SLANG_E_OUT_OF_MEMORY);
         return SLANG_OK;
     }
 
-    // https://docs.microsoft.com/en-us/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya
-    const HMODULE h = LoadLibraryA(platformFileName);
+    // https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexa
+    const HMODULE h = LoadLibraryExA(platformFileName, nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
     if (!h)
     {
         const DWORD lastError = GetLastError();


### PR DESCRIPTION
Slangpy uses AddDllDirectory to specify locations of Slang DLL files. LoadLibraryA ignores this so instead use LoadLibraryExA.