### PR TITLE
Fix undefined behaviour after IRInst::removeAndDeallocate

### DIFF
--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -8478,9 +8478,6 @@ void IRInst::removeAndDeallocate()
     }
     removeArguments();
     removeFromParent();
-
-    // Run destructor to be sure...
-    this->~IRInst();
 }
 
 void IRInst::removeAndDeallocateAllDecorationsAndChildren()


### PR DESCRIPTION
Fixes #7542 and potentially many more issues, at least with release builds on GCC 15. The issue description has the analysis of what I think is going on. In any case, many passes read insts after `removeAndDeallocate()` has been called on them; while this in itself is a bit questionable, it turns into UB due to the manual destructor call done in `removeAndDeallocate()`.

Since the destructor marks the end of the object's lifetime, you're not supposed to read from it afterwards anyway, so I guess GCC 15 just optimizes all prior assignments away.