### PR TITLE
Implement IFloat.scale for vectors, matrices

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1185,7 +1185,7 @@ ${{{{
          __intrinsic_op($(kIROp_FRem)) This mod(This other);
          __intrinsic_op($(kIROp_Neg))  This neg();
          __intrinsic_op($(kIROp_FloatCast)) float toFloat();
-         __intrinsic_op($(kIROp_Mul)) This scale<T:__BuiltinFloatingPointType>(T s) { return __mul(this, __realCast<This>(s)); }
+         [__unsafeForceInlineEarly] This scale<T:__BuiltinFloatingPointType>(T s) { return __mul(this, __realCast<This>(s)); }
         typedef $(kBaseTypes[tt].name) Differential;
     
         [__unsafeForceInlineEarly]
@@ -2020,7 +2020,7 @@ extension vector<T,N> : IFloat
     __intrinsic_op($(kIROp_Div)) This div(This other);
     __intrinsic_op($(kIROp_FRem)) This mod(This other);
     __intrinsic_op($(kIROp_Neg)) This neg();
-    __intrinsic_op($(kIROp_Mul)) This scale<T1:__BuiltinFloatingPointType>(T1 s) { return this.mul(__realCast<T>(s)); }
+    [__unsafeForceInlineEarly] This scale<T1:__BuiltinFloatingPointType>(T1 s) { return this.mul(__realCast<T>(s)); }
     [__unsafeForceInlineEarly] float toFloat() { return __realCast<float>(this[0]); }
 
     [OverloadRank(-1)]
@@ -2088,8 +2088,7 @@ extension matrix<T,N,M,L> : IFloat
     [TreatAsDifferentiable] __intrinsic_op($(kIROp_Div)) This div(This other);
     [TreatAsDifferentiable] __intrinsic_op($(kIROp_FRem)) This mod(This other);
     [TreatAsDifferentiable] __intrinsic_op($(kIROp_Neg)) This neg();
-    [TreatAsDifferentiable] __intrinsic_op($(kIROp_Mul)) This scale<T1:__BuiltinFloatingPointType>(T1 s) { return this.mul(__realCast<T>(s)); }
-    [TreatAsDifferentiable][__unsafeForceInlineEarly] This scale<T1:__BuiltinFloatingPointType>(T1 s);
+    [TreatAsDifferentiable][__unsafeForceInlineEarly] This scale<T1:__BuiltinFloatingPointType>(T1 s) { return this.mul(__realCast<T>(s)); }
     [TreatAsDifferentiable][__unsafeForceInlineEarly] float toFloat() { return __realCast<float>(this[0][0]); }
 
     [OverloadRank(-1)]

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2020,7 +2020,7 @@ extension vector<T,N> : IFloat
     __intrinsic_op($(kIROp_Div)) This div(This other);
     __intrinsic_op($(kIROp_FRem)) This mod(This other);
     __intrinsic_op($(kIROp_Neg)) This neg();
-    __intrinsic_op($(kIROp_Mul)) This scale<T1 : __BuiltinFloatingPointType>(T1 s) { return this.mul(__realCast<T>(s)); }
+    __intrinsic_op($(kIROp_Mul)) This scale<T1:__BuiltinFloatingPointType>(T1 s) { return this.mul(__realCast<T>(s)); }
     [__unsafeForceInlineEarly] float toFloat() { return __realCast<float>(this[0]); }
 
     [OverloadRank(-1)]
@@ -2088,7 +2088,7 @@ extension matrix<T,N,M,L> : IFloat
     [TreatAsDifferentiable] __intrinsic_op($(kIROp_Div)) This div(This other);
     [TreatAsDifferentiable] __intrinsic_op($(kIROp_FRem)) This mod(This other);
     [TreatAsDifferentiable] __intrinsic_op($(kIROp_Neg)) This neg();
-    [TreatAsDifferentiable] __intrinsic_op($(kIROp_Mul)) This scale<T1:__BuiltinFloatingPointType>(T1 s);
+    [TreatAsDifferentiable] __intrinsic_op($(kIROp_Mul)) This scale<T1:__BuiltinFloatingPointType>(T1 s) { return this.mul(matrix<T,N,M,L>(__realCast<T>(s))); }
     [TreatAsDifferentiable][__unsafeForceInlineEarly] This scale<T1:__BuiltinFloatingPointType>(T1 s);
     [TreatAsDifferentiable][__unsafeForceInlineEarly] float toFloat() { return __realCast<float>(this[0][0]); }
 

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2020,7 +2020,7 @@ extension vector<T,N> : IFloat
     __intrinsic_op($(kIROp_Div)) This div(This other);
     __intrinsic_op($(kIROp_FRem)) This mod(This other);
     __intrinsic_op($(kIROp_Neg)) This neg();
-    __intrinsic_op($(kIROp_Mul)) This scale<T1:__BuiltinFloatingPointType>(T1 s);
+    __intrinsic_op($(kIROp_Mul)) This scale<T1 : __BuiltinFloatingPointType>(T1 s) { return this.mul(__realCast<T>(s)); }
     [__unsafeForceInlineEarly] float toFloat() { return __realCast<float>(this[0]); }
 
     [OverloadRank(-1)]

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2088,7 +2088,7 @@ extension matrix<T,N,M,L> : IFloat
     [TreatAsDifferentiable] __intrinsic_op($(kIROp_Div)) This div(This other);
     [TreatAsDifferentiable] __intrinsic_op($(kIROp_FRem)) This mod(This other);
     [TreatAsDifferentiable] __intrinsic_op($(kIROp_Neg)) This neg();
-    [TreatAsDifferentiable] __intrinsic_op($(kIROp_Mul)) This scale<T1:__BuiltinFloatingPointType>(T1 s) { return this.mul(matrix<T,N,M,L>(__realCast<T>(s))); }
+    [TreatAsDifferentiable] __intrinsic_op($(kIROp_Mul)) This scale<T1:__BuiltinFloatingPointType>(T1 s) { return this.mul(__realCast<T>(s)); }
     [TreatAsDifferentiable][__unsafeForceInlineEarly] This scale<T1:__BuiltinFloatingPointType>(T1 s);
     [TreatAsDifferentiable][__unsafeForceInlineEarly] float toFloat() { return __realCast<float>(this[0][0]); }
 

--- a/tests/bugs/gh-7156-ifloat-scale.slang
+++ b/tests/bugs/gh-7156-ifloat-scale.slang
@@ -1,0 +1,22 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-hlsl -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgpu -compute -output-using-type
+
+// CHECK: 10
+
+//TEST_INPUT:ubuffer(data=[0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+// Use of IFloat.scale used to cause an internal compiler error
+func double_it<T: IFloat>(value: T) -> T {
+    return value.scale(2.0);
+}
+
+[numthreads(1, 1, 1)]
+[shader("compute")]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    outputBuffer[dispatchThreadID.x] = double_it(float2(1.0, 2.0)).x + double_it(4.0);
+}
+

--- a/tests/bugs/gh-7156-ifloat-scale.slang
+++ b/tests/bugs/gh-7156-ifloat-scale.slang
@@ -3,7 +3,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgpu -compute -output-using-type
 
-// CHECK: 10
+// CHECK: 1210.0
 
 //TEST_INPUT:ubuffer(data=[0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
@@ -17,6 +17,10 @@ func double_it<T: IFloat>(value: T) -> T {
 [shader("compute")]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
-    outputBuffer[dispatchThreadID.x] = double_it(float2(1.0, 2.0)).x + double_it(4.0);
+    let mat = matrix<float,4,4>(1,0,0,1, 0,1,1,0, 0,0,1,0, 0,0,0,1);
+    let vi = vector<float,4>(100,100,100,100);
+    let dm = double_it(mat);
+    let dm_sum = dot(dm[0], vi) + dot(dm[1], vi) + dot(dm[2], vi) + dot(dm[3], vi);
+    outputBuffer[dispatchThreadID.x] = double_it(float2(1.0, 2.0)).x + double_it(4.0) + dm_sum;
 }
 


### PR DESCRIPTION
Generic implementation of IFloat.scale for float vectors and matrices. Prevents an internal compiler error when writing generic functions for use with both scalar and vector/matrix types. Includes a test.

Fixes #7156