### PR TITLE
Remove redundant [payload] attribute (Fix #7528)

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -4205,8 +4205,6 @@ attribute_syntax [__AlwaysFoldIntoUseSiteAttribute] : AlwaysFoldIntoUseSiteAttri
 __attributeTarget(FunctionDeclBase)
 attribute_syntax [noinline] : NoInlineAttribute;
 
-__attributeTarget(StructDecl)
-attribute_syntax [payload] : PayloadAttribute;
 
 /// Mark a declaration as deprecated.
 /// @param message The diagnostic message to show when the declaration is used.

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -1909,16 +1909,6 @@ class RequireFullQuadsAttribute : public Attribute
     FIDDLE(...)
 };
 
-/// A `[payload]` attribute indicates that a `struct` type will be used as
-/// a ray payload for `TraceRay()` calls, and thus also as input/output
-/// for shaders in the ray tracing pipeline that might be invoked for
-/// such a ray.
-///
-FIDDLE()
-class PayloadAttribute : public Attribute
-{
-    FIDDLE(...)
-};
 
 /// A `[raypayload]` attribute indicates that a `struct` type will be used as
 /// a ray payload for `TraceRay()` calls, and thus also as input/output

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -1692,10 +1692,6 @@ void HLSLSourceEmitter::_emitStageAccessSemantic(
 
 void HLSLSourceEmitter::emitPostKeywordTypeAttributesImpl(IRInst* inst)
 {
-    if (const auto payloadDecoration = inst->findDecoration<IRPayloadDecoration>())
-    {
-        m_writer->emit("[payload] ");
-    }
 
     // Get the target profile to determine if PAQs are supported
     bool enablePAQs = false;

--- a/source/slang/slang-ir-inst-defs.h
+++ b/source/slang/slang-ir-inst-defs.h
@@ -1019,7 +1019,6 @@ INST_RANGE(BindingQuery, GetRegisterIndex, GetRegisterSpace)
     INST(GLSLLocationDecoration, glslLocation, 1, 0)
     INST(GLSLOffsetDecoration, glslOffset, 1, 0)
     INST(VkStructOffsetDecoration, vkStructOffset, 1, 0)
-    INST(PayloadDecoration, payload, 0, 0)
     INST(RayPayloadDecoration, raypayload, 0, 0)
 
     /* Mesh Shader outputs */

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -1646,10 +1646,6 @@ struct IRStageWriteAccessDecoration : public IRStageAccessDecoration
     IR_LEAF_ISA(StageWriteAccessDecoration)
 };
 
-struct IRPayloadDecoration : public IRDecoration
-{
-    IR_LEAF_ISA(PayloadDecoration)
-};
 
 struct IRRayPayloadDecoration : public IRDecoration
 {

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9628,10 +9628,6 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         addNameHint(context, irAggType, decl);
         addLinkageDecoration(context, irAggType, decl);
 
-        if (const auto payloadAttribute = decl->findModifier<PayloadAttribute>())
-        {
-            subBuilder->addDecoration(irAggType, kIROp_PayloadDecoration);
-        }
 
         if (const auto rayPayloadAttribute = decl->findModifier<RayPayloadAttribute>())
         {


### PR DESCRIPTION
Removes the PayloadAttribute class and related infrastructure that was made redundant by PR #6595, which added ray payload access qualifiers (PAQs) per the DXR spec. The new [raypayload] attribute with access qualifiers provides the same functionality.

Changes:
- Remove PayloadAttribute class from slang-ast-modifier.h
- Remove [payload] attribute syntax from core.meta.slang
- Remove PayloadDecoration IR instruction and related processing
- Remove HLSL emission of [payload] attribute
- Remove IR lowering support for old PayloadAttribute

The new [raypayload] attribute with PAQ support remains unchanged.