### PR TITLE
Allow a compiler warning on MacOS

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -112,10 +112,13 @@ function(set_default_compile_options target)
             -Wno-invalid-offsetof
             -Wno-newline-eof
             -Wno-return-std-move
-            # Enabled warnings:
+            # Allowed warnings:
             # If a function returns an address/reference to a local, we want it to
             # produce an error, because it probably means something very bad.
             -Werror=return-local-addr
+            # Allow unused variables with a pattern of `if (auto v = as<...>(...))`.
+            # This pattern is very common in Slang code base.
+            -Wno-error=unused-but-set-variable
             # Some warnings which are on by default in MSVC
             -Wnarrowing
         )


### PR DESCRIPTION
This PR is to allow a compiler warning even when all warnings are requested to be treated as errors.

The following pattern is very common in Slang code base:
```
  if (auto var = as<...>(...))
```
And when `var` is not used, the compiler prints a warning.

Alternatively we can remove `auto var =` part but there are too many.