### PR TITLE
fix spirv-opt bug

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/shader-slang/slang-binaries
 [submodule "external/spirv-tools"]
 	path = external/spirv-tools
-	url = https://github.com/shader-slang/SPIRV-Tools.git
+	url = https://github.com/KhronosGroup/SPIRV-Tools.git
 [submodule "external/spirv-headers"]
 	path = external/spirv-headers
 	url = https://github.com/KhronosGroup/SPIRV-Headers.git


### PR DESCRIPTION
Close #7491.

As the PR KhronosGroup/SPIRV-Tools#6198 is already merged, we can switch spirv-tools repo to upstream repo now.