### PR TITLE
Misc language server improvements.

### DIFF
--- a/source/compiler-core/slang-json-value.cpp
+++ b/source/compiler-core/slang-json-value.cpp
@@ -655,6 +655,9 @@ bool JSONContainer::asBool(const JSONValue& value)
         return asInteger(value) != 0;
     case JSONValue::Type::FloatLexeme:
         return asFloat(value) != 0.0;
+    case JSONValue::Type::StringLexeme:
+        return getTransientString(value).caseInsensitiveEquals(toSlice("true")) ||
+               getTransientString(value).caseInsensitiveEquals(toSlice("1"));
     default:
         return value.asBool();
     }

--- a/source/slang/slang-ast-decl-ref.cpp
+++ b/source/slang/slang-ast-decl-ref.cpp
@@ -131,9 +131,12 @@ DeclRefBase* LookupDeclRef::_substituteImplOverride(
 
 void LookupDeclRef::_toTextOverride(StringBuilder& out)
 {
-    getLookupSource()->toText(out);
-    if (out.getLength() && !out.endsWith("."))
-        out << ".";
+    if (!as<ThisType>(getLookupSource()))
+    {
+        getLookupSource()->toText(out);
+        if (out.getLength() && !out.endsWith("."))
+            out << ".";
+    }
     if (getDecl()->getName() && getDecl()->getName()->text.getLength() != 0)
     {
         out << getDecl()->getName()->text;

--- a/source/slang/slang-ast-print.cpp
+++ b/source/slang/slang-ast-print.cpp
@@ -1182,13 +1182,13 @@ void ASTPrinter::_addDeclPathRec(const DeclRef<Decl>& declRef, Index depth)
         else
         {
             parentDeclRef = isDeclRefTypeOf<Decl>(lookupDeclRef->getLookupSource());
-            if (auto thisType = as<ThisTypeDecl>(parentDeclRef.getDecl()))
+        }
+        if (auto thisType = as<ThisTypeDecl>(parentDeclRef.getDecl()))
+        {
+            if (auto baseLookupDeclRef = as<LookupDeclRef>(parentDeclRef.declRefBase))
             {
-                if (auto baseLookupDeclRef = as<LookupDeclRef>(parentDeclRef.declRefBase))
-                {
-                    // If the base type is a lookup, we want to use its source type
-                    parentDeclRef = isDeclRefTypeOf<Decl>(baseLookupDeclRef->getLookupSource());
-                }
+                // If the base type is a lookup, we want to use its source type
+                parentDeclRef = isDeclRefTypeOf<Decl>(baseLookupDeclRef->getLookupSource());
             }
         }
     }

--- a/source/slang/slang-ast-print.cpp
+++ b/source/slang/slang-ast-print.cpp
@@ -1174,13 +1174,21 @@ void ASTPrinter::_addDeclPathRec(const DeclRef<Decl>& declRef, Index depth)
     // If this is a lookup decl ref, prefix with the lookup source type instead of the parent.
     if (auto lookupDeclRef = as<LookupDeclRef>(declRef.declRefBase))
     {
-        parentDeclRef = isDeclRefTypeOf<Decl>(lookupDeclRef->getLookupSource());
-        if (auto thisType = as<ThisTypeDecl>(parentDeclRef.getDecl()))
+        if (auto extractExistentialType =
+                as<ExtractExistentialType>(lookupDeclRef->getLookupSource()))
         {
-            if (auto baseLookupDeclRef = as<LookupDeclRef>(parentDeclRef.declRefBase))
+            parentDeclRef = extractExistentialType->getOriginalInterfaceDeclRef();
+        }
+        else
+        {
+            parentDeclRef = isDeclRefTypeOf<Decl>(lookupDeclRef->getLookupSource());
+            if (auto thisType = as<ThisTypeDecl>(parentDeclRef.getDecl()))
             {
-                // If the base type is a lookup, we want to use its source type
-                parentDeclRef = isDeclRefTypeOf<Decl>(baseLookupDeclRef->getLookupSource());
+                if (auto baseLookupDeclRef = as<LookupDeclRef>(parentDeclRef.declRefBase))
+                {
+                    // If the base type is a lookup, we want to use its source type
+                    parentDeclRef = isDeclRefTypeOf<Decl>(baseLookupDeclRef->getLookupSource());
+                }
             }
         }
     }

--- a/source/slang/slang-ast-print.cpp
+++ b/source/slang/slang-ast-print.cpp
@@ -1183,7 +1183,7 @@ void ASTPrinter::_addDeclPathRec(const DeclRef<Decl>& declRef, Index depth)
         {
             parentDeclRef = isDeclRefTypeOf<Decl>(lookupDeclRef->getLookupSource());
         }
-        if (auto thisType = as<ThisTypeDecl>(parentDeclRef.getDecl()))
+        if (as<ThisTypeDecl>(parentDeclRef.getDecl()))
         {
             if (auto baseLookupDeclRef = as<LookupDeclRef>(parentDeclRef.declRefBase))
             {
@@ -1206,7 +1206,11 @@ void ASTPrinter::_addDeclPathRec(const DeclRef<Decl>& declRef, Index depth)
     }
 
     // Depending on what the parent is, we may want to format things specially
-    if (parentDeclRef.as<AggTypeDecl>() || parentDeclRef.as<SimpleTypeDecl>())
+    if (parentDeclRef.as<ThisTypeDecl>())
+    {
+        sb << "This.";
+    }
+    else if (parentDeclRef.as<AggTypeDecl>() || parentDeclRef.as<SimpleTypeDecl>())
     {
         _addDeclPathRec(parentDeclRef, depth + 1);
         sb << toSlice(".");

--- a/source/slang/slang-ast-print.cpp
+++ b/source/slang/slang-ast-print.cpp
@@ -1168,8 +1168,22 @@ void ASTPrinter::_addDeclPathRec(const DeclRef<Decl>& declRef, Index depth)
 {
     auto& sb = m_builder;
 
-    // Find the parent declaration
-    auto parentDeclRef = declRef.getParent();
+    // Find the parent declaration.
+    DeclRef<Decl> parentDeclRef;
+
+    // If this is a lookup decl ref, prefix with the lookup source type instead of the parent.
+    if (auto lookupDeclRef = as<LookupDeclRef>(declRef.declRefBase))
+    {
+        parentDeclRef = DeclRef<Decl>();
+        if (!as<ThisType>(lookupDeclRef->getLookupSource()))
+        {
+            parentDeclRef = isDeclRefTypeOf<Decl>(lookupDeclRef->getLookupSource());
+        }
+    }
+    else
+    {
+        parentDeclRef = declRef.getParent();
+    }
 
     // If the immediate parent is a generic, then we probably
     // want the declaration above that...

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -7898,7 +7898,7 @@ void SemanticsVisitor::calcOverridableCompletionCandidates(
     contentAssistInfo.completionSuggestions.formatMode =
         varDeclBase ? CompletionSuggestions::FormatMode::FuncSignatureWithoutReturnType
                     : CompletionSuggestions::FormatMode::FullSignature;
-
+    contentAssistInfo.completionSuggestions.currentPartialDecl = memberDecl;
     List<LookupResultItem> candidateItems;
     for (auto facet : inheritanceInfo.facets)
     {

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -410,7 +410,7 @@ DeclRefExpr* SemanticsVisitor::ConstructDeclRefExpr(
             SharedTypeExpr* baseTypeExpr = m_astBuilder->create<SharedTypeExpr>();
             baseTypeExpr->base.type = baseExprType;
             baseTypeExpr->type.type = m_astBuilder->getTypeType(baseExprType);
-
+            baseTypeExpr->base.exp = baseExpr;
             auto expr = m_astBuilder->create<StaticMemberExpr>();
             expr->loc = loc;
             expr->type = type;

--- a/source/slang/slang-content-assist-info.h
+++ b/source/slang/slang-content-assist-info.h
@@ -32,6 +32,7 @@ struct CompletionSuggestions
 
     ScopeKind scopeKind = ScopeKind::Invalid;
     FormatMode formatMode = FormatMode::Name;
+    Decl* currentPartialDecl = nullptr;
 
     List<LookupResultItem> candidateItems;
     Type* swizzleBaseType = nullptr;
@@ -40,10 +41,12 @@ struct CompletionSuggestions
     void clear()
     {
         scopeKind = ScopeKind::Invalid;
+        formatMode = FormatMode::Name;
         candidateItems.clear();
         elementCount[0] = 0;
         elementCount[1] = 0;
         swizzleBaseType = nullptr;
+        currentPartialDecl = nullptr;
     }
 };
 

--- a/source/slang/slang-language-server-auto-format.h
+++ b/source/slang/slang-language-server-auto-format.h
@@ -27,6 +27,7 @@ enum class FormatBehavior
 
 struct FormatOptions
 {
+    bool enableFormatOnType = true;
     String clangFormatLocation;
     String style = "file";
     String fallbackStyle = "{BasedOnStyle: Microsoft}";

--- a/source/slang/slang-language-server.h
+++ b/source/slang/slang-language-server.h
@@ -250,6 +250,7 @@ private:
     void updateSearchInWorkspace(const JSONValue& value);
     void updateCommitCharacters(const JSONValue& value);
     void updateFormattingOptions(
+        const JSONValue& enableFormatOnType,
         const JSONValue& clangFormatLoc,
         const JSONValue& clangFormatStyle,
         const JSONValue& clangFormatFallbackStyle,

--- a/tests/language-server/existential-decl-path.slang
+++ b/tests/language-server/existential-decl-path.slang
@@ -1,0 +1,13 @@
+//TEST:LANG_SERVER(filecheck=CHECK):
+interface IFoo
+{
+    int getSum();
+}
+
+void test(IFoo f)
+{
+//HOVER:10,9
+    f.getSum();
+}
+
+//CHECK: IFoo.getSum

--- a/tests/language-server/override-completion-2.slang
+++ b/tests/language-server/override-completion-2.slang
@@ -13,5 +13,5 @@ struct Impl : IFoo
     override 
 }
 
-//CHECK: associatedtype IFoo.This.B
+//CHECK: associatedtype This.B
 //CHECK: static B.AT execute(int x)

--- a/tests/language-server/override-completion-2.slang
+++ b/tests/language-server/override-completion-2.slang
@@ -13,5 +13,5 @@ struct Impl : IFoo
     override 
 }
 
-//CHECK: associatedtype B
+//CHECK: associatedtype IFoo.This.B
 //CHECK: static B.AT execute(int x)

--- a/tests/language-server/override-completion-2.slang
+++ b/tests/language-server/override-completion-2.slang
@@ -1,0 +1,17 @@
+//TEST:LANG_SERVER(filecheck=CHECK):
+interface IBar{ associatedtype AT; }
+interface IFoo
+{
+    associatedtype B : IBar;
+//HOVER:7,12
+    static B.AT execute(int x);
+}
+
+struct Impl : IFoo
+{
+//COMPLETE:13,14
+    override 
+}
+
+//CHECK: associatedtype B
+//CHECK: static B.AT execute(int x)

--- a/tests/language-server/smoke.slang.expected.txt
+++ b/tests/language-server/smoke.slang.expected.txt
@@ -16,7 +16,7 @@ content:
 --------
 activeParameter: 0
 activeSignature: 0
-func IFoo.getSum() -> int:
+func T.getSum() -> int:
 
 Returns the sum of the contents.  
 


### PR DESCRIPTION
1. Add a configuration to turn on/off format-on-type.
2. Fix `LookupDeclRef::toText` to correctly print associated type lookups.
3. Fix override completion to include `static` modifier when necessary.
4. Fix highlighting/hover for associated type declref exprs.