### PR TITLE
Fix cpp/cuda emit issue

### DIFF
--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -1555,10 +1555,10 @@ bool CPPSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOut
             auto base = inst->getOperand(0);
             auto outerPrec = getInfo(EmitOp::General);
             emitOperand(base, outerPrec);
-            m_writer->emit(")");
             m_writer->emit("[");
             emitOperand(inst->getOperand(1), EmitOpInfo());
             m_writer->emit("])");
+            m_writer->emit(")");
             return true;
         }
     case kIROp_swizzle:

--- a/tests/cuda/cuda-rwstructuredbuffer-getelementptr.slang
+++ b/tests/cuda/cuda-rwstructuredbuffer-getelementptr.slang
@@ -1,0 +1,20 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda
+//TEST:SIMPLE(filecheck=CHECK): -target cpp
+
+struct MyType
+{
+    RWStructuredBuffer<int> output;
+}
+
+ParameterBlock<MyType> input;
+
+[shader("compute")]
+[numthreads(1,1,1)]
+void computeMain(uint id : SV_DispatchThreadID)
+{
+    // make sure we don't emit &(input->output)[idx] where
+    // the address operator will take higher precedence than the indexing operator.
+    // CHECK: &({{.*}}->output_0[{{.*}}])
+    input.output[id] = id * 2;
+}
+


### PR DESCRIPTION
For CUDA/CPP target, we generated invalid code for accessing RWStructuredBuffer, e.g.:

&(RWStructuredBuffer)[idx]

This expression is not right, because &RWStructuredBuffer could take precedence. But we really want to express
like this `&(RWStructuredBuffer[idx])`.

This leads illegal memory access in cuda.