### PR TITLE
Don't run full gpu tests on merge queue.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
     branches: [master]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 jobs:
   build:
     strategy:
@@ -70,9 +70,11 @@ jobs:
             compiler: cl
             platform: x86_64
             test-category: full
-            full-gpu-tests: true
-            runs-on: [Windows, self-hosted, GCP-T4]
-            has-gpu: true
+            # Run full gpu tests on PR/Main branch, but not on merge_group.
+            full-gpu-tests: ${{ github.event_name != 'merge_group' }}
+            # Run on self-hosted machine when using full-gpu-tests, otherwise on github runners.
+            runs-on: ${{ github.event_name == 'merge_group' && 'windows-latest' || '[Windows, self-hosted, GCP-T4]' }}
+            has-gpu: ${{ github.event_name != 'merge_group' }}
             server-count: 8
           # Self-hosted full gpu build - debug
           - os: windows
@@ -80,9 +82,9 @@ jobs:
             compiler: cl
             platform: x86_64
             test-category: full
-            full-gpu-tests: true
-            runs-on: [Windows, self-hosted, GCP-T4]
-            has-gpu: true
+            full-gpu-tests: ${{ github.event_name != 'merge_group' }}
+            runs-on: ${{ github.event_name == 'merge_group' && 'windows-latest' || '[Windows, self-hosted, GCP-T4]' }}
+            has-gpu: ${{ github.event_name != 'merge_group' }}
             server-count: 8
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,8 @@ jobs:
             # Run full gpu tests on PR/Main branch, but not on merge_group.
             full-gpu-tests: ${{ github.event_name != 'merge_group' }}
             # Run on self-hosted machine when using full-gpu-tests, otherwise on github runners.
-            runs-on: ${{ github.event_name == 'merge_group' && 'windows-latest' || '[Windows, self-hosted, GCP-T4]' }}
-            has-gpu: ${{ github.event_name != 'merge_group' }}
+            runs-on: ['Windows', 'self-hosted', 'GCP-T4']
+            has-gpu: true
             server-count: 8
           # Self-hosted full gpu build - debug
           - os: windows
@@ -83,8 +83,8 @@ jobs:
             platform: x86_64
             test-category: full
             full-gpu-tests: ${{ github.event_name != 'merge_group' }}
-            runs-on: ${{ github.event_name == 'merge_group' && 'windows-latest' || '[Windows, self-hosted, GCP-T4]' }}
-            has-gpu: ${{ github.event_name != 'merge_group' }}
+            runs-on: ['Windows', 'self-hosted', 'GCP-T4']
+            has-gpu: true
             server-count: 8
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
Our merge queue takes a long time to drain. This PR disables full GPU and SlangPy/SlangRHI tests on merge queues.

This is fine because full tests are still run on PRs and each master branch commits, so we are still capturing all regressions.

We run a smaller set of checks in the merge queue just to make sure there aren't merge errors.