### PR TITLE
Run full check on merge_queue, but not on push.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,16 +2,17 @@
 
 To configure cmake, run `cmake --preset default --fresh`.
 To build, run `cmake --workflow --preset debug` or `cmake --workflow --preset release`.
+Build instructions can be found in docs/building.md
 
 ## Formatting
 
 Your PR needs to be formatted according to our coding style.
-Run `./extras/formatting.sh` script to format your changes before creating a PR.
+Run `./extras/formatting.sh` script to format your changes before submitting them.
 
 ## Labeling your PR
 
 All PRs needs to be labeled as either "pr: non-breaking" or "pr: breaking".
-Label your PR as "pr: breaking" if you are introducing public API changes that breaks ABI compabibility,
+Add the "pr: breaking" label to  your PR if you are introducing public API changes that breaks ABI compabibility,
 or you are introducing changes to the Slang language that will cause the compiler to error out on existing Slang code.
 It is rare for a PR to be a breaking change.
 
@@ -19,4 +20,28 @@ It is rare for a PR to be a breaking change.
 
 Your PR should include a regression test for the bug you are fixing.
 Normally, these tests present as a `.slang` file under `tests/` directory.
-You will need to run your test with `slang-test tests/path/to/your-new-test.slang`. 
+You will need to run your test with `slang-test tests/path/to/your-new-test.slang`.
+You will need to build the `slang-test` target first.
+Note that your execution environment does not have a GPU, so you can't run any tests that requires a GPU locally, for example,
+you won't be able to run a shader test using D3D12, Vulkan, Metal or WGSL.
+
+If the changes you are making is not specific to a particular GPU target, you can craft your test case to run on the CPU
+by writing the following as the first line of your test shader:
+
+```
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-output-using-type -cpu
+```
+See `tests/language-feature/lambda/lambda-0.slang` for a full example.
+
+Or you can craft your test to run with `slangi`  (byte-code interpreter), such as:
+
+```
+//TEST:INTERPRET(filecheck=CHECK):
+void main()
+{
+    //CHECK: hello!
+    printf("hello!");
+}
+```
+
+If you are working on a GPU specific feature, don't try to run the test locally, just leave your PR to the CI for verification.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   merge_group:
     types: [checks_requested]
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 concurrency:
@@ -71,7 +69,7 @@ jobs:
             platform: x86_64
             test-category: full
             # Run full gpu tests on PR/Main branch, but not on merge_group.
-            full-gpu-tests: ${{ github.event_name != 'merge_group' }}
+            full-gpu-tests: true
             # Run on self-hosted machine when using full-gpu-tests, otherwise on github runners.
             runs-on: ["Windows", "self-hosted", "GCP-T4"]
             has-gpu: true
@@ -82,8 +80,8 @@ jobs:
             compiler: cl
             platform: x86_64
             test-category: full
-            full-gpu-tests: ${{ github.event_name != 'merge_group' }}
-            runs-on: ["Windows", "self-hosted", "GCP-T4"]
+            full-gpu-tests: true
+            runs-on: ['Windows', 'self-hosted', 'GCP-T4']
             has-gpu: true
             server-count: 8
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
             platform: x86_64
             test-category: full
             full-gpu-tests: true
-            runs-on: ['Windows', 'self-hosted', 'GCP-T4']
+            runs-on: ["Windows", "self-hosted", "GCP-T4"]
             has-gpu: true
             server-count: 8
       fail-fast: false


### PR DESCRIPTION
It is better to keep full tests on merge_queue and disable rerunning the tests on `push` to master.

Closes #7595.