### PR TITLE
Fix for mixed block/embedded usage of structs in SPIRV

### DIFF
--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -2172,7 +2172,8 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             }
 
             // Update the global param's type to use the wrapper struct
-            auto newPtrType = builder.getPtrType(ptrType->getOp(), wrapperStruct, ptrType->getAddressSpace());
+            auto newPtrType =
+                builder.getPtrType(ptrType->getOp(), wrapperStruct, ptrType->getAddressSpace());
             globalParam->setFullType(newPtrType);
 
             // Traverse all uses of the global param and insert a FieldAddress to access the

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -2137,7 +2137,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             {
                 if (auto ptrType = as<IRPtrTypeBase>(globalParam->getDataType()))
                 {
-                    if (auto structType = as<IRStructType>(ptrType->getValueType()))
+                    if (as<IRStructType>(ptrType->getValueType()))
                     {
                         structGlobalParams.add(globalParam);
                     }

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -2168,16 +2168,11 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             }
             if (structType->findDecorationImpl(kIROp_SPIRVBufferBlockDecoration))
             {
-                builder.addDecorationIfNotExist(
-                    wrapperStruct,
-                    kIROp_SPIRVBufferBlockDecoration);
+                builder.addDecorationIfNotExist(wrapperStruct, kIROp_SPIRVBufferBlockDecoration);
             }
 
             // Update the global param's type to use the wrapper struct
-            auto newPtrType = builder.getPtrType(
-                ptrType->getOp(),
-                wrapperStruct,
-                ptrType->getAddressSpace());
+            auto newPtrType = builder.getPtrType(ptrType->getOp(), wrapperStruct, ptrType->getAddressSpace());
             globalParam->setFullType(newPtrType);
 
             // Traverse all uses of the global param and insert a FieldAddress to access the
@@ -2188,10 +2183,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 {
                     builder.setInsertBefore(use->getUser());
                     auto addr = builder.emitFieldAddress(
-                        builder.getPtrType(
-                            kIROp_PtrType,
-                            structType,
-                            ptrType->getAddressSpace()),
+                        builder.getPtrType(kIROp_PtrType, structType, ptrType->getAddressSpace()),
                         globalParam,
                         key);
                     use->set(addr);

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -2139,9 +2139,11 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             if (auto globalParam = as<IRGlobalParam>(globalInst))
             {
                 auto ptrType = as<IRPtrTypeBase>(globalParam->getDataType());
-                if (!ptrType) continue;
+                if (!ptrType)
+                    continue;
                 auto structType = as<IRStructType>(ptrType->getValueType());
-                if (!structType) continue;
+                if (!structType)
+                    continue;
 
                 if (embeddedBlockStructs.contains(structType))
                 {
@@ -2153,28 +2155,37 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                     auto key = builder.createStructKey();
                     builder.createStructField(wrapperStruct, key, structType);
 
-                    // Copy the block decoration from the inner struct to the wrapper (do not remove yet)
+                    // Copy the block decoration from the inner struct to the wrapper
                     if (structType->findDecorationImpl(kIROp_SPIRVBlockDecoration))
                     {
                         builder.addDecorationIfNotExist(wrapperStruct, kIROp_SPIRVBlockDecoration);
                     }
                     if (structType->findDecorationImpl(kIROp_SPIRVBufferBlockDecoration))
                     {
-                        builder.addDecorationIfNotExist(wrapperStruct, kIROp_SPIRVBufferBlockDecoration);
+                        builder.addDecorationIfNotExist(
+                            wrapperStruct,
+                            kIROp_SPIRVBufferBlockDecoration);
                     }
 
                     // Update the global param's type to use the wrapper struct
-                    auto newPtrType = builder.getPtrType(ptrType->getOp(), wrapperStruct, ptrType->getAddressSpace());
+                    auto newPtrType = builder.getPtrType(
+                        ptrType->getOp(),
+                        wrapperStruct,
+                        ptrType->getAddressSpace());
                     globalParam->setFullType(newPtrType);
 
-                    // Traverse all uses of the global param and insert a FieldAddress to access the inner struct
+                    // Traverse all uses of the global param and insert a FieldAddress to access the
+                    // inner struct
                     traverseUses(
                         globalParam,
                         [&](IRUse* use)
                         {
                             builder.setInsertBefore(use->getUser());
                             auto addr = builder.emitFieldAddress(
-                                builder.getPtrType(kIROp_PtrType, structType, ptrType->getAddressSpace()),
+                                builder.getPtrType(
+                                    kIROp_PtrType,
+                                    structType,
+                                    ptrType->getAddressSpace()),
                                 globalParam,
                                 key);
                             use->set(addr);
@@ -2190,7 +2201,8 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             {
                 blockDecor->removeAndDeallocate();
             }
-            if (auto bufferBlockDecor = structType->findDecorationImpl(kIROp_SPIRVBufferBlockDecoration))
+            if (auto bufferBlockDecor =
+                    structType->findDecorationImpl(kIROp_SPIRVBufferBlockDecoration))
             {
                 bufferBlockDecor->removeAndDeallocate();
             }

--- a/tests/bugs/gh-7431.slang
+++ b/tests/bugs/gh-7431.slang
@@ -1,0 +1,37 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECKOUT):-vk -compute -output-using-type
+
+// CHECKOUT:      10
+// CHECKOUT-NEXT: 20
+// CHECKOUT-NEXT: 30
+// CHECKOUT-NEXT: 40
+
+struct Test {
+    int f_int;
+};
+
+ParameterBlock<Test> pb_struct;
+uniform Test u_struct;
+uniform Test u_struct_array[2];
+
+RWStructuredBuffer<int> results;
+
+//TEST_INPUT: set pb_struct = new Test{10};
+//TEST_INPUT: uniform(data=[20 0 0 0]):name=u_struct.f_int
+//TEST_INPUT: uniform(data=[30 0 0 0]):name=u_struct_array[0].f_int
+//TEST_INPUT: uniform(data=[40 0 0 0]):name=u_struct_array[1].f_int
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=results
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid: SV_DispatchThreadID)
+{
+    if (any(tid != uint3(0)))
+        return;
+
+    results[0] = pb_struct.f_int;
+    results[1] = u_struct.f_int;
+    results[2] = u_struct_array[0].f_int;
+    results[3] = u_struct_array[1].f_int;
+}
+


### PR DESCRIPTION
Per Vulkan VUID-VkShaderModuleCreateInfo-pCode-08737, if a SPIRV struct is marked as a block, it cannot also be a field in another structure. This change iterates over a program and identifies structs with this condition, and moves the block usage into a wrapper struct.

Fixes #7431