### PR TITLE
Catch abort exception from leaking from loadModule

### DIFF
--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -1491,13 +1491,29 @@ static void outputExceptionDiagnostic(
     DiagnosticSink& sink,
     slang::IBlob** outDiagnostics)
 {
-    sink.diagnoseRaw(Severity::Internal, exception.Message.getUnownedSlice());
+    try
+    {
+        sink.diagnoseRaw(Severity::Internal, exception.Message.getUnownedSlice());
+    }
+    catch (const AbortCompilationException&)
+    {
+        // Catch and ignore the AbortCompilationException that diagnoseRaw throws
+        // for Internal severity to prevent exception leak from loadModule
+    }
     sink.getBlobIfNeeded(outDiagnostics);
 }
 
 static void outputExceptionDiagnostic(DiagnosticSink& sink, slang::IBlob** outDiagnostics)
 {
-    sink.diagnoseRaw(Severity::Fatal, "An unknown exception occurred");
+    try
+    {
+        sink.diagnoseRaw(Severity::Fatal, "An unknown exception occurred");
+    }
+    catch (const AbortCompilationException&)
+    {
+        // Catch and ignore the AbortCompilationException that diagnoseRaw throws
+        // for Fatal severity to prevent exception leak from loadModule
+    }
     sink.getBlobIfNeeded(outDiagnostics);
 }
 


### PR DESCRIPTION
Fixes #6988

In `Linkage::loadModule*` calls, we catch all exceptions, but for exceptions that are a `Slang::Exception` that is not a `Slang::AbortCompilationException` we diagnose an error of `Severity::Internal` with the exception's message, and for exceptions that are not `Slang::Exception` (such as from non-Slang code) we diagnose an error of `Severity::Fatal` with the exception's message.

The issue is that when we diagnose an error with a `Severity` >= `Fatal` in `DiagnosticSink::diagnoseRaw`, we abort compilation with `SLANG_ABORT_COMPILATION`, which throws an `AbortCompilationException` that is not caught within `Linkage::loadModule*`, which are marked `SLANG_NO_THROW`, leaking the internal `AbortCompilationException` error through the API.

This change catches the `AbortCompilationException` thrown by the error diagnosis and ignores it to prevent it from leaking while we deal with the legitimate exception that was thrown.