### PR TITLE
Add <help-category> list and hint on usage in slangc -h

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -38,6 +38,7 @@ slangc -help-style markdown -h
 * [vulkan-shift](#vulkan-shift)
 * [capability](#capability)
 * [file-extension](#file-extension)
+* [help-category](#help-category)
 
 <a id="General"></a>
 ## General
@@ -94,7 +95,7 @@ Emit IR typically as a '.slang-module' when outputting to a container.
 <a id="h"></a>
 ### -h, -help, --help
 
-**-h or -h &lt;help-category&gt;**
+**-h or -h &lt;[help-category](#help-category)&gt;**
 
 Print this message, or help in specified category. 
 
@@ -1598,4 +1599,37 @@ A [&lt;language&gt;](#language), &lt;format&gt;, and/or [&lt;stage&gt;](#stage) 
 * `zip` : container 
 * `slang-module`, `slang-library` : Slang Module/Library 
 * `dir` : Container as a directory 
+
+<a id="help-category"></a>
+## help-category
+
+Available help categories for the [-h](#h) option 
+
+* `General` : General options 
+* `Target` : Target code generation options 
+* `Downstream` : Downstream compiler options 
+* `Debugging` : Compiler debugging/instrumentation options 
+* `Repro` : Slang repro system related 
+* `Experimental` : Experimental options (use at your own risk) 
+* `Internal` : Internal-use options (use at your own risk) 
+* `Deprecated` : Deprecated options (allowed but ignored; may be removed in future) 
+* `compiler` : Downstream Compilers (aka Pass through) 
+* `language` : Language 
+* `language-version` : Language Version 
+* `archive-type` : Archive Type 
+* `line-directive-mode` : Line Directive Mode 
+* `debug-info-format` : Debug Info Format 
+* `fp-mode` : Floating Point Mode 
+* `fp-denormal-mode` : Floating Point Denormal Handling Mode 
+* `help-style` : Help Style 
+* `optimization-level` : Optimization Level 
+* `debug-level` : Debug Level 
+* `file-system-type` : File System Type 
+* `source-embed-style` : Source Embed Style 
+* `target` : Target 
+* `stage` : Stage 
+* `vulkan-shift` : Vulkan Shift 
+* `capability` : A capability describes an optional feature that a target may or may not support. When a [-capability](#capability-1) is specified, the compiler may assume that the target supports that capability, and generate code accordingly. 
+* `file-extension` : A [&lt;language&gt;](#language), &lt;format&gt;, and/or [&lt;stage&gt;](#stage) may be inferred from the extension of an input or [-o](#o) path 
+* `help-category` : Available help categories for the [-h](#h) option 
 

--- a/source/core/slang-command-options-writer.cpp
+++ b/source/core/slang-command-options-writer.cpp
@@ -504,11 +504,12 @@ void TextCommandOptionsWriter::appendDescriptionImpl()
     {
         _appendDescriptionForCategory(categoryIndex);
     }
-    
+
     // Add instructions for getting help for specific categories
     m_builder << "Getting Help for Specific Categories\n";
     m_builder << "=====================================\n\n";
-    m_builder << "To get help for a specific category of options or values, use: slangc -h <help-category>\n";
+    m_builder << "To get help for a specific category of options or values, use: slangc -h "
+                 "<help-category>\n";
     m_builder << "See the <help-category> section above for the list of categories.\n\n";
 }
 

--- a/source/core/slang-command-options-writer.cpp
+++ b/source/core/slang-command-options-writer.cpp
@@ -504,6 +504,51 @@ void TextCommandOptionsWriter::appendDescriptionImpl()
     {
         _appendDescriptionForCategory(categoryIndex);
     }
+    
+    // Add instructions for getting help for specific categories
+    m_builder << "Getting Help for Specific Categories\n";
+    m_builder << "=====================================\n\n";
+    m_builder << "To get help for a specific category of options or values, use: slangc -h <category>\n\n";
+    
+    // Collect option categories
+    StringBuilder optionCategoriesText;
+    bool firstOption = true;
+    for (Index categoryIndex = 0; categoryIndex < categories.getCount(); ++categoryIndex)
+    {
+        const auto& category = categories[categoryIndex];
+        if (category.kind == CommandOptions::CategoryKind::Option)
+        {
+            if (!firstOption) optionCategoriesText << ", ";
+            optionCategoriesText << category.name;
+            firstOption = false;
+        }
+    }
+    
+    m_builder << "Available option categories:\n";
+    if (optionCategoriesText.getLength() > 0)
+    {
+        _appendText(1, optionCategoriesText.getUnownedSlice());
+    }
+    
+    // Collect value categories
+    StringBuilder valueCategoriesText;
+    bool firstValue = true;
+    for (Index categoryIndex = 0; categoryIndex < categories.getCount(); ++categoryIndex)
+    {
+        const auto& category = categories[categoryIndex];
+        if (category.kind == CommandOptions::CategoryKind::Value)
+        {
+            if (!firstValue) valueCategoriesText << ", ";
+            valueCategoriesText << category.name;
+            firstValue = false;
+        }
+    }
+    
+    m_builder << "Available value categories:\n";
+    if (valueCategoriesText.getLength() > 0)
+    {
+        _appendText(1, valueCategoriesText.getUnownedSlice());
+    }
 }
 
 void TextCommandOptionsWriter::_appendDescriptionForCategory(Index categoryIndex)

--- a/source/core/slang-command-options-writer.cpp
+++ b/source/core/slang-command-options-writer.cpp
@@ -508,47 +508,8 @@ void TextCommandOptionsWriter::appendDescriptionImpl()
     // Add instructions for getting help for specific categories
     m_builder << "Getting Help for Specific Categories\n";
     m_builder << "=====================================\n\n";
-    m_builder << "To get help for a specific category of options or values, use: slangc -h <category>\n\n";
-    
-    // Collect option categories
-    StringBuilder optionCategoriesText;
-    bool firstOption = true;
-    for (Index categoryIndex = 0; categoryIndex < categories.getCount(); ++categoryIndex)
-    {
-        const auto& category = categories[categoryIndex];
-        if (category.kind == CommandOptions::CategoryKind::Option)
-        {
-            if (!firstOption) optionCategoriesText << ", ";
-            optionCategoriesText << category.name;
-            firstOption = false;
-        }
-    }
-    
-    m_builder << "Available option categories:\n";
-    if (optionCategoriesText.getLength() > 0)
-    {
-        _appendText(1, optionCategoriesText.getUnownedSlice());
-    }
-    
-    // Collect value categories
-    StringBuilder valueCategoriesText;
-    bool firstValue = true;
-    for (Index categoryIndex = 0; categoryIndex < categories.getCount(); ++categoryIndex)
-    {
-        const auto& category = categories[categoryIndex];
-        if (category.kind == CommandOptions::CategoryKind::Value)
-        {
-            if (!firstValue) valueCategoriesText << ", ";
-            valueCategoriesText << category.name;
-            firstValue = false;
-        }
-    }
-    
-    m_builder << "Available value categories:\n";
-    if (valueCategoriesText.getLength() > 0)
-    {
-        _appendText(1, valueCategoriesText.getUnownedSlice());
-    }
+    m_builder << "To get help for a specific category of options or values, use: slangc -h <help-category>\n";
+    m_builder << "See the <help-category> section above for the list of categories.\n\n";
 }
 
 void TextCommandOptionsWriter::_appendDescriptionForCategory(Index categoryIndex)

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -359,7 +359,6 @@ void initCommandOptions(CommandOptions& options)
         }
     }
 
-    
 
     /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! General !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
 

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -348,7 +348,7 @@ void initCommandOptions(CommandOptions& options)
         options.addCategory(
             CategoryKind::Value,
             "help-category",
-            "Available help categories for -h option");
+            "Available help categories for the -h option");
 
         // Add all existing categories as valid help category values
         const auto& categories = options.getCategories();

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -342,6 +342,25 @@ void initCommandOptions(CommandOptions& options)
         options.addValues(pairs, SLANG_COUNT_OF(pairs));
     }
 
+    /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! help-category !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
+
+    {
+        options.addCategory(
+            CategoryKind::Value,
+            "help-category",
+            "Available help categories for -h option");
+
+        // Add all existing categories as valid help category values
+        const auto& categories = options.getCategories();
+        for (Index categoryIndex = 0; categoryIndex < categories.getCount(); ++categoryIndex)
+        {
+            const auto& category = categories[categoryIndex];
+            options.addValue(category.name, category.description);
+        }
+    }
+
+    
+
     /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! General !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
 
     options.setCategory("General");


### PR DESCRIPTION
For #7088 

The output of `slangc --help` is very long, and although it is split into subsections based on categories, it is not immediately obvious from the wall of text that the `-h` option can take a category as a value to only display that category. You have to look in the "General" category near the top of the help output to find that `-h` can take an optional value `<help-category>`. Furthermore, these categories are not listed in the output.

This change adds a new value category for `<help-category>` values as the last help category, listing all of the preceding categories (and itself), with this message at the end of the text output advising users that they can narrow down the output of `slangc -h`.
```
Getting Help for Specific Categories
=====================================

To get help for a specific category of options or values, use: slangc -h <help-category>
See the <help-category> section above for the list of categories.
```