### PR TITLE
Note that `Slang::String` is owned/null-terminated

### DIFF
--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -201,7 +201,7 @@ public:
     /// Trims any 'c' from the start or the end, and returns as a substring
     UnownedStringSlice trim(char c) const;
 
-    /// Trims any horizonatl whitespace from start and returns as a substring
+    /// Trims any horizontal whitespace from start and returns as a substring
     UnownedStringSlice trimStart() const;
 
     static constexpr bool kHasUniformHash = true;
@@ -459,9 +459,8 @@ private:
 };
 
 /*!
-@brief Represents a UTF-8 encoded string.
+@brief Represents an owned, zero-terminated UTF-8 encoded string.
 */
-
 class SLANG_RT_API String
 {
     friend struct StringSlice;


### PR DESCRIPTION
This PR makes three minor documentation improvements in `source/core/slang-string.h`:

1. Fixed a typo.
2. Documented the fact that `Slang::String` is owning and zero-terminated.
3. Removed a stray newline after the `Slang::String` docstring that was preventing VS Code from picking it up.