### PR TITLE
Fix a bug in examples/reflection-api

### DIFF
--- a/examples/reflection-api/main.cpp
+++ b/examples/reflection-api/main.cpp
@@ -587,18 +587,18 @@ struct ReflectingPrinting
                 auto containerVarLayout = typeLayout->getContainerVarLayout();
                 auto elementVarLayout = typeLayout->getElementVarLayout();
 
-                key("container");
-                {
-                    SCOPED_OBJECT();
-                    printOffsets(containerVarLayout, accessPath);
-                }
-
                 AccessPath innerOffsets = accessPath;
                 innerOffsets.deepestConstantBufer = innerOffsets.leaf;
                 if (containerVarLayout->getTypeLayout()->getSize(
                         slang::ParameterCategory::SubElementRegisterSpace) != 0)
                 {
                     innerOffsets.deepestParameterBlock = innerOffsets.leaf;
+                }
+
+                key("container");
+                {
+                    SCOPED_OBJECT();
+                    printOffsets(containerVarLayout, innerOffsets);
                 }
 
                 key("content");


### PR DESCRIPTION
The bug here is subtle enough that it was missed during development of the example, and it it unlikely to be hit by typical applications. All that said, it is good to ensure that this example does things correctly, since we are pointing developers to it as an example of how to correctly extract information using the reflection API.

In order to get the bug to surface, one can target Vulkan/SPIR-V using input code like:

```
struct Small
{
    float4 v;
    Texture2D t;
}
struct Big
{
    float4 u;
    ConstantBuffer<Small> smallCB;
    ParameterBlock<Small> smallPB;
}
ConstantBuffer<Big> bigCB;
```

Without this change, the example would display an incorrect cumulative offset for `bigCB.smallPB.t`. The incorrectly-computed offset showed that the `binding`s consumed by `bigCB.smallCB` (for both its constant buffer and its `t` field) were being included in the offset computed for the `t` within the parameter block (when the outer parameter block should have caused those offsets to be ignored).

The underlying bug in the example is that when recursively printing the cumulative offsets for the "container" and "content" part of a buffer/block, the example was including the buffer/block in the `AccessPath` when printing cumulative offsets for the "content" part, but not for the "container" part. The fix is just to shift the order of things and use the same `AccessPath` when printing both the "container" and "content" parts of a buffer/block.

It is difficult to be 100% certain that this change is correct, and that there are no corner cases where the new code gives unexpected/wrong results. I have manually tested the example code by throwing a variety of shader parameter declarations at it, and the new logic seems robust.

We are probably at the point where the code of this example probably needs to be turned into a stand-alone tool that we can use as part of our automated testing. That will have to wait for a future change; the goal of this change is to just get the simple bug fixe checked in.