### PR TITLE
Emit additional diagnostic for invalid pointer taking operations

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2583,6 +2583,7 @@ __prefix Ref<T> operator*(Ptr<T, addrSpace> value);
 
 __generic<T>
 __intrinsic_op(0)
+[KnownBuiltin("OperatorAddressOf")]
 [require(cpp_cuda_spirv)]
 __prefix Ptr<T, $( (uint64_t)AddressSpace::UserPointer)ULL> operator&(__ref T value);
 

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2583,7 +2583,7 @@ __prefix Ref<T> operator*(Ptr<T, addrSpace> value);
 
 __generic<T>
 __intrinsic_op(0)
-[KnownBuiltin("OperatorAddressOf")]
+[KnownBuiltin($( (int)KnownBuiltinDeclName::OperatorAddressOf))]
 [require(cpp_cuda_spirv)]
 __prefix Ptr<T, $( (uint64_t)AddressSpace::UserPointer)ULL> operator&(__ref T value);
 

--- a/source/slang/slang-ast-support-types.cpp
+++ b/source/slang/slang-ast-support-types.cpp
@@ -96,28 +96,4 @@ void printDiagnosticArg(StringBuilder& sb, ParameterDirection direction)
     }
 }
 
-KnownBuiltinDeclName getKnownBuiltinDeclNameFromString(UnownedStringSlice name)
-{
-    if (name == "GeometryStreamAppend")
-        return KnownBuiltinDeclName::GeometryStreamAppend;
-    else if (name == "GeometryStreamRestart")
-        return KnownBuiltinDeclName::GeometryStreamRestart;
-    else if (name == "GetAttributeAtVertex")
-        return KnownBuiltinDeclName::GetAttributeAtVertex;
-    else if (name == "DispatchMesh")
-        return KnownBuiltinDeclName::DispatchMesh;
-    else if (name == "saturated_cooperation")
-        return KnownBuiltinDeclName::saturated_cooperation;
-    else if (name == "saturated_cooperation_using")
-        return KnownBuiltinDeclName::saturated_cooperation_using;
-    else if (name == "IDifferentiable")
-        return KnownBuiltinDeclName::IDifferentiable;
-    else if (name == "IDifferentiablePtr")
-        return KnownBuiltinDeclName::IDifferentiablePtr;
-    else if (name == "NullDifferential")
-        return KnownBuiltinDeclName::NullDifferential;
-    else
-        return KnownBuiltinDeclName::COUNT;
-}
-
 } // namespace Slang

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -233,6 +233,7 @@ FIDDLE() namespace Slang
         IDifferentiable,
         IDifferentiablePtr,
         NullDifferential,
+        OperatorAddressOf,
         COUNT
     };
 

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2959,7 +2959,9 @@ Expr* SemanticsVisitor::CheckInvokeExprWithCheckedOperands(InvokeExpr* expr)
                                 auto funcDeclRef = getDeclRef(m_astBuilder, funcDeclRefExpr);
                                 if (funcDeclRef)
                                 {
-                                    auto knownBuiltinAttr = funcDeclRef.getDecl()->findModifier<KnownBuiltinAttribute>();
+                                    auto knownBuiltinAttr =
+                                        funcDeclRef.getDecl()
+                                            ->findModifier<KnownBuiltinAttribute>();
                                     if (knownBuiltinAttr)
                                     {
                                         if (auto constantIntVal =

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2663,7 +2663,7 @@ Expr* SemanticsExprVisitor::visitTupleExpr(TupleExpr* expr)
     return expr;
 }
 
-void SemanticsVisitor::maybeDiagnoseThisNotLValue(Expr* expr)
+void SemanticsVisitor::maybeDiagnoseConstVariableAssignment(Expr* expr)
 {
     // We will try to handle expressions of the form:
     //
@@ -2688,15 +2688,11 @@ void SemanticsVisitor::maybeDiagnoseThisNotLValue(Expr* expr)
             break;
         }
     }
-    //
-    // Now we check to see if we have a `this` expression,
-    // and if it is immutable.
-    if (auto thisExpr = as<ThisExpr>(e))
+
+    // Check if we're trying to assign to a non-l-value (const variable, immutable member, etc.)
+    if (!expr->type.isLeftValue)
     {
-        if (!thisExpr->type.isLeftValue)
-        {
-            getSink()->diagnoseWithoutSourceView(thisExpr, Diagnostics::thisIsImmutableByDefault);
-        }
+        getSink()->diagnoseWithoutSourceView(expr, Diagnostics::attemptingToAssignToConstVariable);
     }
 }
 
@@ -2722,14 +2718,10 @@ Expr* SemanticsVisitor::checkAssignWithCheckedOperands(AssignExpr* expr)
         }
         else
         {
-            getSink()->diagnose(expr, Diagnostics::assignNonLValue);
+            // Provide a more helpful diagnostic about const variable assignment
+            maybeDiagnoseConstVariableAssignment(expr->left);
 
-            // As a special case, check if the LHS expression is derived
-            // from a `this` parameter (implicitly or explicitly), which
-            // is immutable. We can give the user a bit more context into
-            // what is going on.
-            //
-            maybeDiagnoseThisNotLValue(expr->left);
+            getSink()->diagnose(expr, Diagnostics::assignNonLValue);
         }
     }
     expr->type = type;
@@ -3013,7 +3005,7 @@ Expr* SemanticsVisitor::CheckInvokeExprWithCheckedOperands(InvokeExpr* expr)
                                         implicitCastExpr->type);
                                 }
 
-                                maybeDiagnoseThisNotLValue(argExpr);
+                                maybeDiagnoseConstVariableAssignment(argExpr);
                             }
                         }
                     }

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2965,12 +2965,10 @@ Expr* SemanticsVisitor::CheckInvokeExprWithCheckedOperands(InvokeExpr* expr)
                             {
                                 // Emit additional diagnostic for invalid pointer taking operations
                                 auto funcDeclRef = getDeclRef(m_astBuilder, funcDeclRefExpr);
-                                if (funcDeclRef && getText(funcDeclRefExpr->name) == "&")
+                                if (funcDeclRef)
                                 {
-                                    auto intrinsicMod =
-                                        funcDeclRef.getDecl()->findModifier<IntrinsicOpModifier>();
-                                    // Emit only for intrinsic pointer taking operations
-                                    if (intrinsicMod && intrinsicMod->op == 0)
+                                    auto knownBuiltinAttr = funcDeclRef.getDecl()->findModifier<KnownBuiltinAttribute>();
+                                    if (knownBuiltinAttr && knownBuiltinAttr->name == "OperatorAddressOf")
                                     {
                                         getSink()->diagnose(
                                             argExpr,

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2960,11 +2960,19 @@ Expr* SemanticsVisitor::CheckInvokeExprWithCheckedOperands(InvokeExpr* expr)
                                 if (funcDeclRef)
                                 {
                                     auto knownBuiltinAttr = funcDeclRef.getDecl()->findModifier<KnownBuiltinAttribute>();
-                                    if (knownBuiltinAttr && knownBuiltinAttr->name == "OperatorAddressOf")
+                                    if (knownBuiltinAttr)
                                     {
-                                        getSink()->diagnose(
-                                            argExpr,
-                                            Diagnostics::cannotTakeConstantPointers);
+                                        if (auto constantIntVal =
+                                                as<ConstantIntVal>(knownBuiltinAttr->name))
+                                        {
+                                            if (constantIntVal->getValue() ==
+                                                (int)KnownBuiltinDeclName::OperatorAddressOf)
+                                            {
+                                                getSink()->diagnose(
+                                                    argExpr,
+                                                    Diagnostics::cannotTakeConstantPointers);
+                                            }
+                                        }
                                     }
                                 }
 

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2963,6 +2963,21 @@ Expr* SemanticsVisitor::CheckInvokeExprWithCheckedOperands(InvokeExpr* expr)
                             }
                             else if (!as<ErrorType>(argExpr->type))
                             {
+                                // Emit additional diagnostic for invalid pointer taking operations
+                                auto funcDeclRef = getDeclRef(m_astBuilder, funcDeclRefExpr);
+                                if (funcDeclRef && getText(funcDeclRefExpr->name) == "&")
+                                {
+                                    auto intrinsicMod =
+                                        funcDeclRef.getDecl()->findModifier<IntrinsicOpModifier>();
+                                    // Emit only for intrinsic pointer taking operations
+                                    if (intrinsicMod && intrinsicMod->op == 0)
+                                    {
+                                        getSink()->diagnose(
+                                            argExpr,
+                                            Diagnostics::cannotTakeConstantPointers);
+                                    }
+                                }
+
                                 getSink()->diagnose(
                                     argExpr,
                                     Diagnostics::argumentExpectedLValue,

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -2278,7 +2278,7 @@ public:
 
     /// Given an immutable `expr` used as an l-value emit a special diagnostic if it was derived
     /// from `this`.
-    void maybeDiagnoseThisNotLValue(Expr* expr);
+    void maybeDiagnoseConstVariableAssignment(Expr* expr);
 
     // Figure out what type an initializer/constructor declaration
     // is supposed to return. In most cases this is just the type

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -913,7 +913,7 @@ bool SemanticsVisitor::TryCheckOverloadCandidateDirections(
                         context.loc,
                         Diagnostics::mutatingMethodOnImmutableValue,
                         funcDeclRef.getName());
-                    maybeDiagnoseThisNotLValue(context.baseExpr);
+                    maybeDiagnoseConstVariableAssignment(context.baseExpr);
                 }
                 return false;
             }

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -700,6 +700,7 @@ DIAGNOSTIC(
     Error,
     argumentExpectedLValue,
     "argument passed to parameter '$0' must be l-value.")
+DIAGNOSTIC(30078, Error, cannotTakeConstantPointers, "Can not take constant pointers")
 DIAGNOSTIC(
     30048,
     Error,

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -700,7 +700,11 @@ DIAGNOSTIC(
     Error,
     argumentExpectedLValue,
     "argument passed to parameter '$0' must be l-value.")
-DIAGNOSTIC(30078, Error, cannotTakeConstantPointers, "Not allowed to take pointer of an immutable object")
+DIAGNOSTIC(
+    30078,
+    Error,
+    cannotTakeConstantPointers,
+    "Not allowed to take pointer of an immutable object")
 DIAGNOSTIC(
     30048,
     Error,

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -700,7 +700,7 @@ DIAGNOSTIC(
     Error,
     argumentExpectedLValue,
     "argument passed to parameter '$0' must be l-value.")
-DIAGNOSTIC(30078, Error, cannotTakeConstantPointers, "Can not take constant pointers")
+DIAGNOSTIC(30078, Error, cannotTakeConstantPointers, "Not allowed to take pointer of an immutable object")
 DIAGNOSTIC(
     30048,
     Error,

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -710,9 +710,10 @@ DIAGNOSTIC(
 DIAGNOSTIC(
     30049,
     Note,
-    thisIsImmutableByDefault,
-    "a 'this' parameter is an immutable parameter by default in Slang; apply the `[mutating]` "
-    "attribute to the function declaration to opt in to a mutable `this`")
+    attemptingToAssignToConstVariable,
+    "attempting to assign to a const variable or immutable member; use '[mutating]' attribute on "
+    "the containing method to allow modification")
+
 DIAGNOSTIC(
     30050,
     Error,

--- a/source/slang/slang-ir-fuse-satcoop.cpp
+++ b/source/slang/slang-ir-fuse-satcoop.cpp
@@ -457,7 +457,7 @@ static IRCall* tryFuseCalls(IRBuilder& builder, IRCall* f, IRCall* g)
 //
 // Identify calls which we can fuse
 //
-IRCall* isKnownFunction(const char* n, IRInst* i)
+IRCall* isKnownFunction(KnownBuiltinDeclName expectedNameEnum, IRInst* i)
 {
     auto call = as<IRCall>(i);
     if (!call)
@@ -478,9 +478,7 @@ IRCall* isKnownFunction(const char* n, IRInst* i)
     if (!h)
         return nullptr;
 
-    // Convert string to enum for comparison
-    auto expectedEnum = getKnownBuiltinDeclNameFromString(UnownedStringSlice(n));
-    if (h->getName() != expectedEnum)
+    if (h->getName() != expectedNameEnum)
         return nullptr;
     return call;
 }
@@ -525,7 +523,7 @@ static void fuseCallsInBlock(IRBuilder& builder, IRBlock* block)
     List<IRCall*> toInline;
     for (auto inst : block->getChildren())
     {
-        if (auto sat_coop = isKnownFunction("saturated_cooperation", inst))
+        if (auto sat_coop = isKnownFunction(KnownBuiltinDeclName::saturated_cooperation, inst))
             toInline.add(sat_coop);
     }
     for (auto c : toInline)
@@ -541,7 +539,7 @@ static void fuseCallsInBlock(IRBuilder& builder, IRBlock* block)
     for (auto inst = block->getFirstInst(); inst != block->getTerminator();
          inst = inst->getNextInst())
     {
-        if (auto call = isKnownFunction("saturated_cooperation_using", inst))
+        if (auto call = isKnownFunction(KnownBuiltinDeclName::saturated_cooperation_using, inst))
         {
             if (lastCall)
             {

--- a/tests/diagnostics/implicit-cast-lvalue.slang.expected
+++ b/tests/diagnostics/implicit-cast-lvalue.slang.expected
@@ -7,6 +7,7 @@ tests/diagnostics/implicit-cast-lvalue.slang(19): error 30047: argument passed t
     a(y);
       ^
 tests/diagnostics/implicit-cast-lvalue.slang(19): note 30063: argument was implicitly cast from 'double' to 'float', and Slang does not support using an implicit cast as an l-value with this type
+tests/diagnostics/implicit-cast-lvalue.slang(19): note 30049: attempting to assign to a const variable or immutable member; use '[mutating]' attribute on the containing method to allow modification
 }
 standard output = {
 }

--- a/tests/diagnostics/invalid-constant-pointer-taking.slang
+++ b/tests/diagnostics/invalid-constant-pointer-taking.slang
@@ -1,0 +1,23 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -stage compute -entry computeMain -target spirv
+
+RWStructuredBuffer<float> mutable_float_buffer;
+RWStructuredBuffer<uint> mutable_uint_buffer;
+
+StructuredBuffer<float> constant_float_buffer;
+StructuredBuffer<uint> constant_uint_buffer;
+
+[shader("compute")]
+[numthreads(1,1,1)]
+void computeMain(uint3 threadId : SV_DispatchThreadID)
+{
+    float* mutablePtr = &mutable_float_buffer[threadId.x];
+
+    InterlockedAdd(mutable_uint_buffer[threadId.x], 1);
+
+    // Constant pointers arent a thing in slang
+    // CHECK: error 30078:
+    float* ptr = &constant_float_buffer[threadId.x];
+
+
+    InterlockedAdd(constant_uint_buffer[0], 1);
+}

--- a/tests/diagnostics/methods/mutating-method-on-rvalue.slang.expected
+++ b/tests/diagnostics/methods/mutating-method-on-rvalue.slang.expected
@@ -3,10 +3,11 @@ standard error = {
 tests/diagnostics/methods/mutating-method-on-rvalue.slang(13): error 30050: mutating method 'increment' cannot be called on an immutable value
         increment();
                  ^
-tests/diagnostics/methods/mutating-method-on-rvalue.slang(13): note 30049: a 'this' parameter is an immutable parameter by default in Slang; apply the `[mutating]` attribute to the function declaration to opt in to a mutable `this`
+tests/diagnostics/methods/mutating-method-on-rvalue.slang(13): note 30049: attempting to assign to a const variable or immutable member; use '[mutating]' attribute on the containing method to allow modification
 tests/diagnostics/methods/mutating-method-on-rvalue.slang(25): error 30050: mutating method 'increment' cannot be called on an immutable value
     gCounter.increment();
                       ^
+tests/diagnostics/methods/mutating-method-on-rvalue.slang(25): note 30049: attempting to assign to a const variable or immutable member; use '[mutating]' attribute on the containing method to allow modification
 }
 standard output = {
 }

--- a/tests/diagnostics/setter-method.slang.expected
+++ b/tests/diagnostics/setter-method.slang.expected
@@ -1,13 +1,13 @@
 result code = -1
 standard error = {
+tests/diagnostics/setter-method.slang(16): note 30049: attempting to assign to a const variable or immutable member; use '[mutating]' attribute on the containing method to allow modification
 tests/diagnostics/setter-method.slang(16): error 30011: left of '=' is not an l-value.
         center = value;
                ^
-tests/diagnostics/setter-method.slang(16): note 30049: a 'this' parameter is an immutable parameter by default in Slang; apply the `[mutating]` attribute to the function declaration to opt in to a mutable `this`
+tests/diagnostics/setter-method.slang(21): note 30049: attempting to assign to a const variable or immutable member; use '[mutating]' attribute on the containing method to allow modification
 tests/diagnostics/setter-method.slang(21): error 30011: left of '=' is not an l-value.
         this.radius = value;
                     ^
-tests/diagnostics/setter-method.slang(21): note 30049: a 'this' parameter is an immutable parameter by default in Slang; apply the `[mutating]` attribute to the function declaration to opt in to a mutable `this`
 }
 standard output = {
 }


### PR DESCRIPTION
The original diagnostics for the pointer taking operation just shows "expecting l-value".
This PR adds additional message to better convey the error message.

Fixes: https://github.com/shader-slang/slang/issues/6743