### PR TITLE
Avoid inserting underscore to _snorm format name if it has one already

### DIFF
--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -1185,8 +1185,15 @@ bool findVkImageFormatByName(const UnownedStringSlice& name, ImageFormat* outFor
     if (name.endsWith(kSNorm))
     {
         StringBuilder buf;
-        //  format names end with snormal after a '_', so replace with that
-        buf << name.head(name.getLength() - kSNorm.getLength()) << "_" << kSNorm;
+        auto prefix = name.head(name.getLength() - kSNorm.getLength());
+        buf << prefix;
+        // format names end with snormal after a '_', so add an underscore
+        // if the prefix doesn't already end with one
+        if (prefix.getLength() == 0 || prefix[prefix.getLength() - 1] != '_')
+        {
+            buf << "_";
+        }
+        buf << kSNorm;
         return findImageFormatByName(buf.getUnownedSlice(), outFormat);
     }
 

--- a/tests/bindings/vk-image-format.slang
+++ b/tests/bindings/vk-image-format.slang
@@ -5,6 +5,7 @@
 //CHECK: layout(r32f)
 //CHECK: layout(r16_snorm)
 //CHECK: layout(r11f_g11f_b10f)
+//CHECK: layout(rgba16_snorm)
 
 // Something typical
 [vk::image_format("r32f")]
@@ -18,6 +19,10 @@ RWTexture2D<float> snormTexture;
 [vk::image_format("r11g11b10f")]
 RWTexture2D<float4> specialTexture;
 
+// snorm with underscore in format name
+[vk::image_format("rgba16_snorm")]
+RWTexture2D<float4> snormTextureWithUnderscore;
+
 cbuffer C
 {
 	uint2 index;
@@ -30,6 +35,7 @@ float4 main(): SV_Target
     result += typicalTexture[index];
     result += snormTexture[index];
     result += specialTexture[index];
+    result += snormTextureWithUnderscore[index];
     
     return result;
 }


### PR DESCRIPTION
Fixes #7556 

VK image formats that end with `_snorm` are not properly recognized by Slang because `findVkImageFormatByName` adds an underscore if it detects that the format name ends with `snorm`. This allows developers to use the format without underscores, e.g. `rgba16snorm` is recognized as `rgba16_snorm`, but adds an extra underscore if there is one already, e.g.  `rgba16_snorm` is rejected as `rgba16__snorm`.
This change adds a check for the underscore in the name, only adding one if `snorm` is not preceded by `_`, so both `rgba16snorm` and `rgba16_snorm` are mapped to `rgba16_snorm`, etc.