### PR TITLE
Add DebugGlobalVariable instructions to SPIR-V output

### DIFF
--- a/source/slang/slang-emit-spirv-ops-debug-info-ext.h
+++ b/source/slang/slang-emit-spirv-ops-debug-info-ext.h
@@ -555,6 +555,42 @@ SpvInst* emitOpDebugLocalVariable(
 }
 
 template<typename T>
+SpvInst* emitOpDebugGlobalVariable(
+    SpvInstParent* parent,
+    IRInst* inst,
+    const T& idResultType,
+    SpvInst* set,
+    IRInst* name,
+    SpvInst* type,
+    IRInst* source,
+    IRInst* line,
+    IRInst* col,
+    SpvInst* scope,
+    IRInst* linkageName,
+    SpvInst* variable,
+    IRInst* flags)
+{
+    static_assert(isSingular<T>);
+    return emitInst(
+        parent,
+        inst,
+        SpvOpExtInst,
+        idResultType,
+        kResultID,
+        set,
+        SpvWord(18),  // DebugGlobalVariable opcode in NonSemantic.Shader.DebugInfo.100
+        name,
+        type,
+        source,
+        line,
+        col,
+        scope,
+        linkageName,
+        variable,
+        flags);
+}
+
+template<typename T>
 SpvInst* emitOpDebugInlinedVariable(
     SpvInstParent* parent,
     IRInst* inst,

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -3215,6 +3215,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         if (layout)
             emitVarLayout(param, varInst, layout);
         emitDecorations(param, getID(varInst));
+        maybeEmitDebugGlobalVariable(param, varInst);
         return varInst;
     }
 
@@ -3237,6 +3238,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         if (layout)
             emitVarLayout(globalVar, varInst, layout);
         emitDecorations(globalVar, getID(varInst));
+        maybeEmitDebugGlobalVariable(globalVar, varInst);
         return varInst;
     }
 
@@ -3891,6 +3893,42 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             return actualHelperVar;
         }
         return nullptr;
+    }
+
+    void maybeEmitDebugGlobalVariable(IRInst* globalInst, SpvInst* spvVar)
+    {
+        if (!m_NonSemanticDebugInfoExtInst)
+            return;
+            
+        auto scope = findDebugScope(globalInst->getModule()->getModuleInst());
+        if (!scope)
+            return;
+            
+        auto name = getName(globalInst);
+        IRBuilder builder(globalInst);
+        auto varType = tryGetPointedToType(&builder, globalInst->getDataType());
+        auto debugType = emitDebugType(varType);
+        
+        // Use default debug source and line info similar to struct debug type emission
+        auto loc = globalInst->findDecoration<IRDebugLocationDecoration>();
+        IRInst* source = loc ? loc->getSource() : m_defaultDebugSource;
+        IRInst* line = loc ? loc->getLine() : builder.getIntValue(builder.getUIntType(), 0);
+        IRInst* col = loc ? loc->getCol() : line;
+        
+        emitOpDebugGlobalVariable(
+            getSection(SpvLogicalSectionID::GlobalVariables),
+            nullptr,  // Don't associate with IR inst to avoid duplicate registration
+            m_voidType,
+            getNonSemanticDebugInfoExtInst(),
+            name,
+            debugType,
+            source,
+            line,
+            col,
+            scope,
+            name,  // linkageName same as name
+            spvVar,
+            builder.getIntValue(builder.getUIntType(), 0));  // flags
     }
 
     SpvInst* emitMakeUInt64(SpvInstParent* parent, IRInst* inst)
@@ -8521,6 +8559,54 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 getNonSemanticDebugInfoExtInst(),
                 debugBaseType,
                 builder.getIntValue(builder.getUIntType(), kDebugTypeAtomicQualifier));
+        }
+        else if (type->getOp() == kIROp_TextureType)
+        {
+            // Declare variables for debug location like struct handling does
+            IRInst* source = m_defaultDebugSource;
+            IRInst* line = builder.getIntValue(builder.getUIntType(), 0);
+            IRInst* col = line;
+            
+            // Emit a composite debug type for texture types
+            return emitOpDebugTypeComposite(
+                getSection(SpvLogicalSectionID::ConstantsAndTypes),
+                nullptr,
+                m_voidType,
+                getNonSemanticDebugInfoExtInst(),
+                name,
+                builder.getIntValue(builder.getUIntType(), 0), // Class (0 = struct)
+                source,
+                line,
+                col,
+                scope,
+                name,
+                builder.getIntValue(builder.getUIntType(), 0), // Size (unknown)
+                builder.getIntValue(builder.getUIntType(), kUnknownPhysicalLayout),
+                List<SpvInst*>()); // No members
+        }
+        else if (type->getOp() == kIROp_SamplerStateType)
+        {
+            // Declare variables for debug location like struct handling does
+            IRInst* source = m_defaultDebugSource;
+            IRInst* line = builder.getIntValue(builder.getUIntType(), 0);
+            IRInst* col = line;
+            
+            // Emit a composite debug type for sampler types
+            return emitOpDebugTypeComposite(
+                getSection(SpvLogicalSectionID::ConstantsAndTypes),
+                nullptr,
+                m_voidType,
+                getNonSemanticDebugInfoExtInst(),
+                name,
+                builder.getIntValue(builder.getUIntType(), 1), // Class (1 = union/sampler)
+                source,
+                line,
+                col,
+                scope,
+                name,
+                builder.getIntValue(builder.getUIntType(), 0), // Size (unknown)
+                builder.getIntValue(builder.getUIntType(), kUnknownPhysicalLayout),
+                List<SpvInst*>()); // No members
         }
         return ensureInst(m_voidType);
     }

--- a/tests/spirv/debug-variable-scope.slang
+++ b/tests/spirv/debug-variable-scope.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage fragment -g2 -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -entry main -stage fragment -g2 -emit-spirv-directly
 
 Texture2D    testTex      :   register(t0);
 SamplerState testSampler  :   register(s0);
@@ -16,6 +16,9 @@ float4 main(PSIn input) : SV_TARGET
     float4 colVal = testTex.SampleBias(testSampler, tc, bias);
     return float4(colVal.xyz, 1.0);
 }
+
+// CHECK: %[[COMPILATION_UNIT_ID:[0-9]+]] = OpExtInst %void {{.*}} DebugCompilationUnit
+// CHECK: DebugGlobalVariable %{{[0-9]+}} %{{[0-9]+}} %{{[0-9]+}} %{{.*}} %{{.*}} %[[COMPILATION_UNIT_ID]]
 
 // CHECK: %[[FUNC_ID:[0-9]+]] = OpExtInst %void {{.*}} DebugFunction %{{[0-9]+}}
 // CHECK: DebugLocalVariable %{{[0-9]+}} %{{[0-9]+}} %{{[0-9]+}} %{{.*}} %{{.*}} %[[FUNC_ID]]


### PR DESCRIPTION
Implements generation of DebugGlobalVariable instructions for global variables like Texture2D and SamplerState in SPIR-V debug information output. Adds debug type support for texture and sampler types using DebugTypeComposite.

Fixes https://github.com/shader-slang/slang/issues/7684