### PR TITLE
Fix issue in match parameter type that depend on an associatedtype.

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -4407,7 +4407,7 @@ bool SemanticsVisitor::doesGenericSignatureMatchRequirement(
             auto satisfyingWitness = m_astBuilder->getDeclaredSubtypeWitness(
                 getSub(m_astBuilder, satisfyingConstraintDeclRef),
                 getSup(m_astBuilder, satisfyingConstraintDeclRef),
-                satisfyingConstraintDeclRef);
+                satisfyingConstraintDeclRef.getDecl());
 
             requiredSubstArgs.add(satisfyingWitness);
         }

--- a/tests/language-feature/interfaces/assoctype-param.slang
+++ b/tests/language-feature/interfaces/assoctype-param.slang
@@ -1,0 +1,32 @@
+//TEST:INTERPRET(filecheck=CHECK):
+
+public interface IDataTrait {
+    public associatedtype InputType;
+    public static const int32_t kElementCount;
+}
+
+public struct DataTrait0 : IDataTrait {
+    public typedef float InputType;
+    public static const int32_t kElementCount = 2;
+}
+
+public interface IGenericInterface<Ti : IFloat> {
+    public Array<Di.InputType, Di.kElementCount> eval<Di : IDataTrait>(const Di.InputType interface_input);
+}
+
+public struct GenericImpl<T : IFloat> : IGenericInterface<T>
+{
+    public Array<Dx.InputType, Dx.kElementCount> eval<Dx : IDataTrait>(
+        const Dx.InputType impl_input)
+    {
+        return makeArrayFromElement<Dx.InputType, Dx.kElementCount>(impl_input);
+    }
+}
+
+void main()
+{
+    GenericImpl<float> f;
+    let rs = f.eval<DataTrait0>(1.0);
+    printf("result is %f\n", rs[0]);
+    // CHECK: result is 1.0
+}


### PR DESCRIPTION
Closes #7451.

Given:

```
public interface IDataTrait {
    public associatedtype InputType;
}

public interface IBar {
    public void eval<Di : IDataTrait>(Di.InputType interface_input);
}

struct Impl : IBar
{
    public void eval<Dx : IDataTrait>(Dx.InputType impl_input);
}
```

The default declref to `Impl.eval.Dx.InputType` is `LookupDeclRef(InputType, Dx, witness = DeclaredSubtypeWitness(declRef = DirectDeclRef(Impl.eval.Dx_is_IDataTrait))`.

However when we try to match the implementation signature to interface signature, we will form a declref to `IBar.eval.Di` using substition `Di = Dx`, `witness(Di:IDataTrait) = DeclaredSubtypeWitness(MemberDeclRef(GenericAppDeclRef(Impl.eval,DeclRefType(Dx)), Dx_is_IDataTrait)`, causing the pointer identity of the specialized declref to mismatch.

The fix is to exclude any default substitutions when forming a declref to the declared witness in the generic signature matching step.