### PR TITLE
Fix linking failures with multiple definition errors

### DIFF
--- a/cmake/Glob.cmake
+++ b/cmake/Glob.cmake
@@ -53,6 +53,12 @@ function(slang_glob_sources var dir)
         list(FILTER files EXCLUDE REGEX "(^|/)open-gl/.*")
     endif()
 
+    # Exclude generated directories to prevent duplicate symbol definitions
+    # These directories contain generated .cpp files that are explicitly
+    # included in their own specialized targets (slang-capability-lookup, slang-lookup-tables)
+    list(FILTER files EXCLUDE REGEX "(^|/)capability/.*")
+    list(FILTER files EXCLUDE REGEX "(^|/)slang-lookup-tables/.*")
+
     list(APPEND ${var} ${files})
     set(${var} ${${var}} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
Fixes #7696 by excluding generated directories from slang_glob_sources
to prevent duplicate symbol definitions when LTO is enabled.

The issue occurred because slang-common-objects target was including
generated .cpp files that were also explicitly included in specialized
targets (slang-capability-lookup, slang-lookup-tables), causing 
duplicate symbols during LTO linking.

Generated with [Claude Code](https://claude.ai/code)