### PR TITLE
Only append slangc --help value categories if explicitly specified

### DIFF
--- a/source/core/slang-command-options-writer.cpp
+++ b/source/core/slang-command-options-writer.cpp
@@ -502,7 +502,13 @@ void TextCommandOptionsWriter::appendDescriptionImpl()
     const auto& categories = m_commandOptions->getCategories();
     for (Index categoryIndex = 0; categoryIndex < categories.getCount(); ++categoryIndex)
     {
-        _appendDescriptionForCategory(categoryIndex);
+        const auto& category = categories[categoryIndex];
+        
+        // For the value category, only include the "help-category" category
+        if (category.kind != CategoryKind::Value || category.name == "help-category")
+        {
+            _appendDescriptionForCategory(categoryIndex);
+        }
     }
 
     // Add instructions for getting help for specific categories

--- a/source/core/slang-command-options-writer.cpp
+++ b/source/core/slang-command-options-writer.cpp
@@ -504,8 +504,8 @@ void TextCommandOptionsWriter::appendDescriptionImpl()
     {
         const auto& category = categories[categoryIndex];
         
-        // For the value category, only include the "help-category" category
-        if (category.kind != CategoryKind::Value || category.name == "help-category")
+        // Omit the value categories
+        if (category.kind != CategoryKind::Value)
         {
             _appendDescriptionForCategory(categoryIndex);
         }
@@ -516,7 +516,16 @@ void TextCommandOptionsWriter::appendDescriptionImpl()
     m_builder << "=====================================\n\n";
     m_builder << "To get help for a specific category of options or values, use: slangc -h "
                  "<help-category>\n";
-    m_builder << "See the <help-category> section above for the list of categories.\n\n";
+    m_builder << m_options.indent << "<help-category> can be: ";
+
+    List<UnownedStringSlice> categoryNames;
+    for (const auto& category : categories)
+    {
+        categoryNames.add(category.name);
+    }
+
+    _appendWrappedIndented(0, categoryNames, toSlice(", "));
+    m_builder << "\n\n";
 }
 
 void TextCommandOptionsWriter::_appendDescriptionForCategory(Index categoryIndex)

--- a/source/core/slang-command-options-writer.cpp
+++ b/source/core/slang-command-options-writer.cpp
@@ -524,7 +524,7 @@ void TextCommandOptionsWriter::appendDescriptionImpl()
         categoryNames.add(category.name);
     }
 
-    _appendWrappedIndented(0, categoryNames, toSlice(", "));
+    _appendWrappedIndented(1, categoryNames, toSlice(", "));
     m_builder << "\n\n";
 }
 

--- a/source/core/slang-command-options-writer.cpp
+++ b/source/core/slang-command-options-writer.cpp
@@ -503,7 +503,7 @@ void TextCommandOptionsWriter::appendDescriptionImpl()
     for (Index categoryIndex = 0; categoryIndex < categories.getCount(); ++categoryIndex)
     {
         const auto& category = categories[categoryIndex];
-        
+
         // Omit the value categories
         if (category.kind != CategoryKind::Value)
         {


### PR DESCRIPTION
Fixes #7088

`slangc --help` prints long lists of possible values for each of the value categories like `<capability>`. This information takes up more than half of the text output, and is largely redundant as we already list the values where they are mentioned, e.g.
```
Target
======

Target code generation options

  -capability <capability>[+<capability>...]: Add optional capabilities to a code generation target. See Capabilities 
    below.
    <capability> can be: spirv_1_{ 0, 1, 2, 3, 4, 5 }, Invalid, textualTarget, hlsl, glsl, c, cpp, cuda, metal, spirv,
    ...
```

This change omits the separate value categories from the full `slangc  --help` output, e.g.
```
<capability>
============

A capability describes an optional feature that a target may or may not support. When a -capability is specified, the 
compiler may assume that the target supports that capability, and generate code accordingly.

  spirv_1_{ 0, 1, 2, 3, 4, 5 }: minimum supported SPIR - V version
  Invalid
  ...
```
These separate value categories can still be accessed by passing them as args, e.g. `slangc --help capability` will print just the `<capability>` list above.