### PR TITLE
Use stdout for -dump-ir instead of stderr

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -210,7 +210,7 @@ static void dumpIRIfEnabled(
 {
     if (codeGenContext->shouldDumpIR())
     {
-        DiagnosticSinkWriter writer(codeGenContext->getSink());
+        FileWriter writer(stdout, WriterFlag::IsUnowned);
         // FILE* f = nullptr;
         // fopen_s(&f, (String("dump-") + label + ".txt").getBuffer(), "wt");
         // FileWriter writer(f, 0);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -12083,7 +12083,7 @@ RefPtr<IRModule> generateIRForTranslationUnit(
 #if 0
     if (compileRequest->optionSet.shouldDumpIR())
     {
-        DiagnosticSinkWriter writer(compileRequest->getSink());
+        FileWriter writer(stdout, WriterFlag::IsUnowned);
         dumpIR(
             module,
             compileRequest->m_irDumpOptions,
@@ -12322,7 +12322,7 @@ RefPtr<IRModule> generateIRForTranslationUnit(
     // then we can dump the initial IR for the module here.
     if (compileRequest->optionSet.shouldDumpIR())
     {
-        DiagnosticSinkWriter writer(compileRequest->getSink());
+        FileWriter writer(stdout, WriterFlag::IsUnowned);
 
         dumpIR(
             module,

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -3936,7 +3936,7 @@ SlangResult EndToEndCompileRequest::executeActionsInner()
 
                 if (frontEndReq->optionSet.shouldDumpIR())
                 {
-                    DiagnosticSinkWriter writer(frontEndReq->getSink());
+                    FileWriter writer(stdout, WriterFlag::IsUnowned);
 
                     dumpIR(
                         translationUnit->getModule()->getIRModule(),


### PR DESCRIPTION
For #6990

This changes the IR dumping to use FileWriter to write to stdout, instead of using the DiagnosticSinkWriter which uses stderr.