### PR TITLE
Fixup address spaces after inlining.

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -6813,15 +6813,14 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         {
             baseStructType = as<IRStructType>(ptrType->getValueType());
             baseId = getID(ensureInst(base));
+            SLANG_ASSERT(
+                as<IRPtrTypeBase>(fieldAddress->getFullType())->getAddressSpace() ==
+                    ptrType->getAddressSpace() &&
+                "field_address requires base and result to have same address space.");
         }
         else
         {
-            baseStructType = as<IRStructType>(base->getDataType());
-
-            auto structPtrType = builder.getPtrType(baseStructType);
-            auto varInst = emitOpVariable(parent, nullptr, structPtrType, SpvStorageClassFunction);
-            emitOpStore(parent, nullptr, varInst, base);
-            baseId = getID(varInst);
+            SLANG_UNEXPECTED("field_address requires base to be an address.");
         }
         SLANG_ASSERT(baseStructType && "field_address requires base to be a struct.");
         auto fieldId = emitIntConstant(

--- a/source/slang/slang-ir-specialize-address-space.h
+++ b/source/slang/slang-ir-specialize-address-space.h
@@ -1,6 +1,8 @@
 // slang-ir-specialize-address-space.h
 #pragma once
 
+#include "core/slang-basic.h"
+
 #include <cinttypes>
 
 namespace Slang
@@ -27,4 +29,10 @@ struct InitialAddressSpaceAssigner
 /// based on the address space of the arguments.
 ///
 void specializeAddressSpace(IRModule* module, InitialAddressSpaceAssigner* addrSpaceAssigner);
+
+/// Traverse the user graph of the initial insts and fix up address spaces to make sure they are
+/// consistent. This is needed after inlining a callee, the address space of the callee's
+/// instructions should be propagated from the arguments.
+void propagateAddressSpaceFromInsts(List<IRInst*>&& initialArgs);
+
 } // namespace Slang

--- a/tests/spirv/pointer-access.slang
+++ b/tests/spirv/pointer-access.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -O0
 
 //CHECK: OpEntryPoint
 

--- a/tests/spirv/pointer-access.slang
+++ b/tests/spirv/pointer-access.slang
@@ -1,0 +1,48 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+
+//CHECK: OpEntryPoint
+
+struct Result
+{
+    float3 value;
+};
+
+struct Indirect
+{
+    float scale;
+};
+
+struct PushConstant
+{
+    Indirect *ptr;
+};
+
+struct Payload
+{
+    uint seed;
+};
+
+ConstantBuffer<PushConstant> pushConstants;
+
+Result f3(Indirect ss, float2 randomSample)
+{
+    Result result;
+    result.value = randomSample.x;
+    return result;
+}
+
+float3 f2(inout uint seed)
+{
+    return f3(*pushConstants.ptr, float2(seed)).value;
+}
+
+float3 f1(inout Payload payload)
+{
+    return f2(payload.seed);
+}
+
+[shader("closesthit")]
+void main(inout Payload payload, in BuiltInTriangleIntersectionAttributes attr)
+{
+    f1(payload);
+}


### PR DESCRIPTION
Fixes #7654.

The problem is that when we inline a function called with a pointer-typed argument, we did not immediately propagate the address spaces from the argument into the cloned function body. So the `FieldAddress` instructions in the cloned callee still have address space `General` even when the argument is in address space `UserPointer`. When this IR reaches spirv-emit, we will be emitting invalid spirv.

This PR adds a fixup pass to propagate the address space after inlining, which fixes the addr space mismatch problem.