### PR TITLE
Fix duplicate mangled names for interface requirements

### DIFF
--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -997,12 +997,15 @@ void sortBlocksInFunc(IRGlobalValueWithCode* func)
         block->insertAtEnd(func);
 }
 
-void removeLinkageDecorations(IRGlobalValueWithCode* func)
+void removeLinkageDecorations(IRInst* inst)
 {
+    if (!inst)
+        return;
+        
     List<IRInst*> toRemove;
-    for (auto inst : func->getDecorations())
+    for (auto decoration : inst->getDecorations())
     {
-        switch (inst->getOp())
+        switch (decoration->getOp())
         {
         case kIROp_ImportDecoration:
         case kIROp_ExportDecoration:
@@ -1013,14 +1016,14 @@ void removeLinkageDecorations(IRGlobalValueWithCode* func)
         case kIROp_CudaDeviceExportDecoration:
         case kIROp_DllExportDecoration:
         case kIROp_HLSLExportDecoration:
-            toRemove.add(inst);
+            toRemove.add(decoration);
             break;
         default:
             break;
         }
     }
-    for (auto inst : toRemove)
-        inst->removeAndDeallocate();
+    for (auto decoration : toRemove)
+        decoration->removeAndDeallocate();
 }
 
 void setInsertBeforeOrdinaryInst(IRBuilder* builder, IRInst* inst)

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -1001,7 +1001,7 @@ void removeLinkageDecorations(IRInst* inst)
 {
     if (!inst)
         return;
-        
+
     List<IRInst*> toRemove;
     for (auto decoration : inst->getDecorations())
     {

--- a/source/slang/slang-ir-util.h
+++ b/source/slang/slang-ir-util.h
@@ -253,7 +253,7 @@ IRInst* emitLoopBlocks(
 void sortBlocksInFunc(IRGlobalValueWithCode* func);
 
 // Remove all linkage decorations from func.
-void removeLinkageDecorations(IRGlobalValueWithCode* func);
+void removeLinkageDecorations(IRInst* inst);
 
 IRInst* findInterfaceRequirement(IRInterfaceType* type, IRInst* key);
 

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9338,6 +9338,14 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             {
                 auto requirementVal = ensureDecl(subContext, requirementDeclRef.getDecl()).val;
 
+                // Remove linkage decorations from the requirement value to prevent
+                // duplicate mangled names and allow DCE to clean up unused functions.
+                // Interface requirements only need the type information, not the linkage.
+                if (auto func = as<IRGlobalValueWithCode>(requirementVal))
+                {
+                    removeLinkageDecorations(func);
+                }
+
                 switch (requirementVal->getOp())
                 {
                 default:

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9338,17 +9338,17 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             {
                 auto requirementVal = ensureDecl(subContext, requirementDeclRef.getDecl()).val;
 
-                // Remove linkage decorations from the requirement value to prevent
-                // duplicate mangled names and allow DCE to clean up unused functions.
-                // Interface requirements only need the type information, not the linkage.
-                if (auto func = as<IRGlobalValueWithCode>(requirementVal))
-                {
-                    removeLinkageDecorations(func);
-                }
-
                 switch (requirementVal->getOp())
                 {
                 default:
+                    // Remove linkage decorations from the requirement value to prevent
+                    // duplicate mangled names and allow DCE to clean up unused functions.
+                    // Interface requirements only need the type information, not the linkage.
+                    if (auto func = as<IRGlobalValueWithCode>(requirementVal))
+                    {
+                        removeLinkageDecorations(func);
+                    }
+
                     // For the majority of requirements, we only care about its type in an
                     // interface definition, so we store only the type from the lowered IR
                     // in the interface entry.

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9344,10 +9344,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                     // Remove linkage decorations from the requirement value to prevent
                     // duplicate mangled names and allow DCE to clean up unused functions.
                     // Interface requirements only need the type information, not the linkage.
-                    if (auto func = as<IRGlobalValueWithCode>(requirementVal))
-                    {
-                        removeLinkageDecorations(func);
-                    }
+                    removeLinkageDecorations(requirementVal);
 
                     // For the majority of requirements, we only care about its type in an
                     // interface definition, so we store only the type from the lowered IR


### PR DESCRIPTION
Fixes #7761

Remove linkage decorations from interface method requirement values to prevent duplicate mangled names and allow DCE to clean up unused functions.

Interface requirements only need the type information, not the linkage, so the generated IRFunc with export decorations was causing conflicts.

Generated with [Claude Code](https://claude.ai/code)