### PR TITLE
Correct help text for `-dump-intermediate-prefix`

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -618,7 +618,7 @@ Dump the AST to a .slang-ast file next to the input.
 
 **-dump-intermediate-prefix &lt;prefix&gt;**
 
-File name prefix for [-dump-intermediates](#dump-intermediates) outputs, default is 'slang-dump-' 
+File name prefix for [-dump-intermediates](#dump-intermediates) outputs, default is no prefix 
 
 
 <a id="dump-intermediates"></a>

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -831,7 +831,7 @@ void initCommandOptions(CommandOptions& options)
         {OptionKind::DumpIntermediatePrefix,
          "-dump-intermediate-prefix",
          "-dump-intermediate-prefix <prefix>",
-         "File name prefix for -dump-intermediates outputs, default is 'slang-dump-'"},
+         "File name prefix for -dump-intermediates outputs, default is no prefix"},
         {OptionKind::DumpIntermediates,
          "-dump-intermediates",
          nullptr,


### PR DESCRIPTION
Not sure when the behavior got changed since this flag was introduced in #2856, but currently the default is no prefix.