### PR TITLE
Debugging code improvement for IR tracking

### DIFF
--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -1739,6 +1739,7 @@ void IRBuilder::_maybeSetSourceLoc(IRInst* inst)
 
 #if SLANG_ENABLE_IR_BREAK_ALLOC
 SLANG_API uint32_t _slangIRAllocBreak = 0xFFFFFFFF;
+static bool _slangIRAllocBreakFirst = true;
 uint32_t& _debugGetIRAllocCounter()
 {
     static uint32_t counter = 0;
@@ -1746,6 +1747,12 @@ uint32_t& _debugGetIRAllocCounter()
 }
 uint32_t _debugGetAndIncreaseInstCounter()
 {
+    if (_slangIRAllocBreakFirst)
+    {
+        // You can set a breakpoint here to break on the first allocation
+        _slangIRAllocBreakFirst = false;
+    }
+
     if (_slangIRAllocBreak != 0xFFFFFFFF && _debugGetIRAllocCounter() == _slangIRAllocBreak)
     {
 #if _WIN32 && defined(_MSC_VER)


### PR DESCRIPTION
When you track IR creation with `_debugUID` or `_slangIRAllocBreak`, you had to set a break point near `_slangIRAllocBreak` is used and unset it after changing the value of `_slangIRAllocBreak`.

Then, when you re-run slangc for more debuggin, you have to set the break-point again, because it was unset.

With this change, you can keep the break-point in the new line, and it will hit only once per debugging session.

Not a big improvement, but I found this useful because it requires less manual handling of the break-points.