### PR TITLE
Strip debug info only for the SpvOpExtInst of debug import type

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -2209,6 +2209,10 @@ SlangResult emitSPIRVFromIR(
 class SpirvInstructionHelper
 {
 public:
+    // The result id of the OpExtInstImport instruction, eg.g %2 below
+    // %2 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+    uint32_t m_nonSemanticDebugInfoExtSetId = 0;
+
     // The index of the SPIRV words in the blob.
     // The first 5 words are the header as defined by the SPIRV spec.
     enum SpvWordIndex
@@ -2351,6 +2355,7 @@ static SlangResult stripDbgSpirvFromArtifact(
         NonSemanticShaderDebugInfo100DebugNoScope,
         NonSemanticShaderDebugInfo100DebugInlinedAt,
         NonSemanticShaderDebugInfo100DebugLocalVariable,
+        NonSemanticShaderDebugInfo100DebugGlobalVariable,
         NonSemanticShaderDebugInfo100DebugInlinedVariable,
         NonSemanticShaderDebugInfo100DebugDeclare,
         NonSemanticShaderDebugInfo100DebugValue,
@@ -2395,6 +2400,15 @@ static SlangResult stripDbgSpirvFromArtifact(
                     return;
                 }
             }
+            else if (inst.getOpCode() == SpvOpExtInstImport)
+            {
+                // looking for result id of "OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+                auto importName = inst.getStringFromInst();
+                if (importName == "NonSemantic.Shader.DebugInfo.100")
+                {
+                    spirvInstructionHelper.m_nonSemanticDebugInfoExtSetId = inst.getOperand(0);
+                }
+            }
         });
 
     // Iterate over the instructions from the artifact and add them to the list
@@ -2415,14 +2429,19 @@ static SlangResult stripDbgSpirvFromArtifact(
                     foundDebugString = true;
                 }
                 if (!foundDebugString)
+                {
                     return;
+                }
             }
             // Also check if the instruction is an extended instruction containing DebugInfo.
             if (inst.getOpCode() == SpvOpExtInst)
             {
-                // Ignore this if the instruction contains DebugInfo.
-                if (debugExtInstNumbers.contains(inst.getOperand(3)))
+                // Ignore this if the instruction contains DebugInfo and is from the debug import
+                if (debugExtInstNumbers.contains(inst.getOperand(3)) &&
+                    inst.getOperand(2) == spirvInstructionHelper.m_nonSemanticDebugInfoExtSetId)
+                {
                     return;
+                }
             }
             // Otherwise this is a non-debug instruction and should be included.
             spirvWordsList.addRange(


### PR DESCRIPTION
The original implementation strip away all the spirv inst with `SpvOpExtInst` whose 3rd operand is in the set of `debugExtInstNumbers`.

However, `SpvOpExtInst` can refer to other type of inst, not just `DebugInfo` so the 3rd operand does not necessarily make sense to the `debugExtInstNumbers`.

For example
```
          %2 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
        %141 = OpExtInstImport "GLSL.std.450"
...
        %181 = OpExtInst %float %141 Pow %180 %float_8
```
The inst. above would be stripped away because the third operand `Pow` happens to be in the range of ``debugExtInstNumbers`.`, but that inst. actually belongs to "GLSL.std.450".

This PR checks the 2nd operand and only strip it away if it's SemanticDebugInfoExtId
