### PR TITLE
Fix BitCast emitting bit shifts with too small integer types

### DIFF
--- a/source/slang/slang-ir-extract-value-from-type.cpp
+++ b/source/slang/slang-ir-extract-value-from-type.cpp
@@ -331,12 +331,21 @@ IRInst* extractMultiByteValueAtOffset(
             src,
             restSize,
             offset + firstHalfSize);
+
+        auto resultType = builder.getUIntType();
+        if (size > 4)
+        {
+            resultType = builder.getUInt64Type();
+            firstHalf = builder.emitCast(resultType, firstHalf);
+            secondHalf = builder.emitCast(resultType, secondHalf);
+        }
+
         uint32_t shift = firstHalfSize * 8;
         auto resultValue = builder.emitBitOr(
-            builder.getUIntType(),
+            resultType,
             firstHalf,
             builder.emitShl(
-                builder.getUIntType(),
+                resultType,
                 secondHalf,
                 builder.getIntValue(builder.getUIntType(), shift)));
         return resultValue;


### PR DESCRIPTION
Closes #7790. Not including a test, since reproducing this concisely seems spectacularly difficult; removing superficially unrelated code seems to cause the compiler to take a different, non-broken path.

#7717 introduced this problem, but only indirectly by starting to use `emitBitCast` with different types than before. At least with the C++ emitter, this caused the generated code to look like this:
```cpp
#line 56
static int32_t * unpackAnyValue8_0(AnyValue8 _S7)
{

#line 56
    return (slang_bit_cast<int32_t *>(uint64_t((_S7.field0_0) | ((_S7.field1_0) << 32U))));
}
```
where GCC aptly notes the following:
```
slang-cpu-utils/tests/sort_test.slang: In function 'int32_t* unpackAnyValue8_0(AnyValue8)':
slang-cpu-utils/tests/sort_test.slang:56:81: warning: left shift count >= width of type [-Wshift-count-overflow]
```
Indeed, `field1_0` is uint32_t, so it isn't valid to shift by that much. This PR changes `extractMultiByteValueAtOffset` (and by extension, `extractValueAtOffset` and `BitCastLoweringContext::readObject`) to not produce such overflowing shifts anymore, by upgrading the type if the result value won't fit in a plain `uint` anymore.