### PR TITLE
slang: Add support for generating a subset of IRBuilder methods

### DIFF
--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -3509,8 +3509,12 @@ FIDDLE(allOtherInstStructs())
 
 struct IRBuilderSourceLocRAII;
 
+FIDDLE()
 struct IRBuilder
 {
+    // Auto-generated IRBuilder methods for IR instructions with operands
+    FIDDLE(generateAllIRBuilderMethods())
+
 private:
     /// Deduplication context from the module.
     IRDeduplicationContext* m_dedupContext = nullptr;
@@ -3674,18 +3678,15 @@ public:
     IRBasicType* getCharType();
     IRStringType* getStringType();
     IRNativeStringType* getNativeStringType();
-    IRNativePtrType* getNativePtrType(IRType* valueType);
 
     IRType* getCapabilitySetType();
 
     IRAssociatedType* getAssociatedType(ArrayView<IRInterfaceType*> constraintTypes);
     IRThisType* getThisType(IRType* interfaceType);
     IRRawPointerType* getRawPointerType();
-    IRRTTIPointerType* getRTTIPointerType(IRInst* rttiPtr);
     IRRTTIType* getRTTIType();
     IRRTTIHandleType* getRTTIHandleType();
     IRAnyValueType* getAnyValueType(IRIntegerValue size);
-    IRAnyValueType* getAnyValueType(IRInst* size);
     IRDynamicType* getDynamicType();
 
     IRTargetTupleType* getTargetTupleType(UInt count, IRType* const* types);
@@ -3706,9 +3707,6 @@ public:
         IRType* type,
         IRInst* pattern,
         ArrayView<IRInst*> capture);
-
-    IRResultType* getResultType(IRType* valueType, IRType* errorType);
-    IROptionalType* getOptionalType(IRType* valueType);
 
     IRBasicBlockType* getBasicBlockType();
     IRWitnessTableType* getWitnessTableType(IRType* baseType);
@@ -3748,11 +3746,6 @@ public:
         IRInst* isCombined,
         IRInst* format);
 
-    IRComPtrType* getComPtrType(IRType* valueType);
-
-    /// Get a 'SPIRV literal'
-    IRSPIRVLiteralType* getSPIRVLiteralType(IRType* type);
-
     IRArrayTypeBase* getArrayTypeBase(
         IROp op,
         IRType* elementType,
@@ -3767,20 +3760,8 @@ public:
 
     IRUnsizedArrayType* getUnsizedArrayType(IRType* elementType, IRInst* stride);
 
-    IRVectorType* getVectorType(IRType* elementType, IRInst* elementCount);
-
     IRVectorType* getVectorType(IRType* elementType, IRIntegerValue elementCount);
 
-    IRCoopVectorType* getCoopVectorType(IRType* elementType, IRInst* elementCount);
-
-    IRMatrixType* getMatrixType(
-        IRType* elementType,
-        IRInst* rowCount,
-        IRInst* columnCount,
-        IRInst* layout);
-
-    IRArrayListType* getArrayListType(IRType* elementType);
-    IRTensorViewType* getTensorViewType(IRType* elementType);
     IRTorchTensorType* getTorchTensorType(IRType* elementType);
 
     IRDifferentialPairType* getDifferentialPairType(IRType* valueType, IRInst* witnessTable);
@@ -3790,8 +3771,6 @@ public:
     IRDifferentialPairUserCodeType* getDifferentialPairUserCodeType(
         IRType* valueType,
         IRInst* witnessTable);
-
-    IRBackwardDiffIntermediateContextType* getBackwardDiffIntermediateContextType(IRInst* func);
 
     IRFuncType* getFuncType(UInt paramCount, IRType* const* paramTypes, IRType* resultType);
 
@@ -3814,8 +3793,6 @@ public:
     IRGroupSharedRate* getGroupSharedRate();
     IRActualGlobalRate* getActualGlobalRate();
     IRSpecConstRate* getSpecConstRate();
-
-    IRRateQualifiedType* getRateQualifiedType(IRRate* rate, IRType* dataType);
 
     IRType* getBindExistentialsType(IRInst* baseType, UInt slotArgCount, IRInst* const* slotArgs);
 
@@ -3852,17 +3829,6 @@ public:
     IRMetalMeshGridPropertiesType* getMetalMeshGridPropertiesType()
     {
         return (IRMetalMeshGridPropertiesType*)getType(kIROp_MetalMeshGridPropertiesType);
-    }
-
-    IRMetalMeshType* getMetalMeshType(
-        IRType* vertexType,
-        IRType* primitiveType,
-        IRInst* numVertices,
-        IRInst* numPrimitives,
-        IRInst* topology)
-    {
-        IRInst* ops[5] = {vertexType, primitiveType, numVertices, numPrimitives, topology};
-        return (IRMetalMeshType*)getType(kIROp_MetalMeshType, 5, ops);
     }
 
     IRInst* emitDebugSource(UnownedStringSlice fileName, UnownedStringSlice source);

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -3603,7 +3603,12 @@ protected:
         }
 
         const auto topologyEnum = outputDeco->getTopologyType();
-        IRInst* topologyConst = builder.getIntValue(builder.getIntType(), topologyEnum);
+        IRIntLit* topologyConst = as<IRIntLit>(builder.getIntValue(builder.getIntType(), topologyEnum));
+        if (topologyConst == nullptr)
+        {
+            SLANG_UNEXPECTED("Failed to convert IRInst to IRIntLit for the topology count of Metal mesh");
+            return;
+        }
 
         IRType* vertexType = nullptr;
         IRType* indicesType = nullptr;

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3109,6 +3109,14 @@ IRBackwardDiffIntermediateContextType* IRBuilder::getBackwardDiffIntermediateCon
         getType(kIROp_BackwardDiffIntermediateContextType, 1, &func);
 }
 
+
+IRMetalMeshType* IRBuilder::getMetalMeshType(IRType* vertexType, IRType* primitiveType,
+    IRInst* numVertices, IRInst* numPrimitives, IRIntLit* topology)
+{
+    IRInst* ops[5] = {vertexType, primitiveType, numVertices, numPrimitives, topology};
+    return (IRMetalMeshType*)getType(kIROp_MetalMeshType, 5, ops);
+}
+
 IRFuncType* IRBuilder::getFuncType(UInt paramCount, IRType* const* paramTypes, IRType* resultType)
 {
     return (IRFuncType*)createIntrinsicInst(


### PR DESCRIPTION
This change adds support for generating the getter IRBuilder methods for the IR instructions defined in slang-ir-insts.lua with explicit operands.

Since there was a mismatch in the type of getMetalMeshType's topology parameter compared to the type described in the Lua definition of MetalMeshType, the getter for this type is updated to reflect IRIntLit (as defined in the Lua definition of the type) instead of IRInst.

Clients of getMetalMeshType are updated to reflect the change in its signature.

The definition of getMetalMeshType is also moved to slang-ir.cpp since Fiddle only generates the signature of the getters and not their bodies.

Closes #7185