### PR TITLE
Fix Metal MSL invalid as_type cast for 64-bit RWByteAddressBuffer.Store values

### DIFF
--- a/tests/metal/rwbyteaddressbuffer-store-64bit.slang
+++ b/tests/metal/rwbyteaddressbuffer-store-64bit.slang
@@ -1,0 +1,22 @@
+//TEST:SIMPLE(filecheck=CHECK): -target metal
+
+// Test that RWByteAddressBuffer.Store() with 64-bit values generates valid Metal code
+// This is a regression test for https://github.com/shader-slang/slang/issues/7534
+
+RWByteAddressBuffer buffer;
+
+[numthreads(1, 1, 1)]
+void main(uint3 dispatchThreadId : SV_DispatchThreadID)
+{
+    // 64-bit literals should be truncated to 32-bit before as_type cast
+    int64_t i64 = -123;
+    buffer.Store(0, i64);
+    buffer.Store(0, -123ll);
+
+    uint64_t u64 = 123;
+    buffer.Store(0, u64);
+    buffer.Store(0, 123ull);
+}
+
+// CHECK: as_type<uint32_t>(uint32_t(-123LL))
+// CHECK: as_type<uint32_t>(uint32_t(123ULL))


### PR DESCRIPTION
Metal doesn't allow as_type casts between different-sized types. When RWByteAddressBuffer.Store() is called with 64-bit values (int64_t, uint64_t, or 64-bit literals like -123LL, 123ULL), the generated Metal code as_type<uint32_t>(64bit_value) causes compilation errors.

Fix by detecting 64-bit basic types and wrapping them with uint32_t() cast to truncate before the as_type cast:
- as_type<uint32_t>(-123LL) -> as_type<uint32_t>(uint32_t(-123LL))
- as_type<uint32_t>(123ULL) -> as_type<uint32_t>(uint32_t(123ULL))

Fixes #7534

Generated with [Claude Code](https://claude.ai/code)