### PR TITLE
Fix passing a capability as a string into Slang crashes/is-invalid

### DIFF
--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -549,10 +549,23 @@ void validateEntryPoint(EntryPoint* entryPoint, DiagnosticSink* sink)
                 targetOptionSet.hasOption(CompilerOptionName::Profile) &&
                 (targetOptionSet.getIntOption(CompilerOptionName::Profile) !=
                  SLANG_PROFILE_UNKNOWN);
-            bool specificCapabilityRequested =
-                targetOptionSet.hasOption(CompilerOptionName::Capability) &&
-                (targetOptionSet.getIntOption(CompilerOptionName::Capability) !=
-                 SLANG_CAPABILITY_UNKNOWN);
+            bool specificCapabilityRequested = false;
+            for (auto atomVal : targetOptionSet.getArray(CompilerOptionName::Capability))
+            {
+                switch (atomVal.kind)
+                {
+                case CompilerOptionValueKind::Int:
+                    if (atomVal.intValue != SLANG_CAPABILITY_UNKNOWN)
+                        specificCapabilityRequested = true;
+                    break;
+                case CompilerOptionValueKind::String:
+                    // User made a specific capability request
+                    specificCapabilityRequested = true;
+                    break;
+                }
+                if (specificCapabilityRequested)
+                    break;
+            }
 
             if (auto declaredCapsMod =
                     entryPointFuncDecl->findModifier<ExplicitlyDeclaredCapabilityModifier>())

--- a/tests/language-feature/capability/capability-as-string.slang
+++ b/tests/language-feature/capability/capability-as-string.slang
@@ -1,0 +1,19 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -profile spirv_1_3 -capability spvAtomicFloat64MinMaxEXT
+
+// Tests if slang being providing capabilities as a string works as intended
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[require(SPV_EXT_shader_atomic_float_min_max)]
+void foo() {}
+
+[shader("compute")]
+[numthreads(1,1,1)]
+void computeMain()
+{
+    foo();
+    outputBuffer[0] = 1;
+}
+
+//CHECK: 1


### PR DESCRIPTION
Fixes: #7869 

Changes:
* Instead of assuming capabilities are an `int` option, handle the string case
    * if a string-capability is passed in, we have a very intentionally added a capability, consider this as a sign that "a specific capability was requested"

Why is this a breaking change?
* We currently do not warn/error always with capabilities (in user-code using the slang-api) due to this bug. Now we will warn, this "breaks" code