### PR TITLE
Fix MSVC compiler complains about different calling convention between interface and impl when building Win32 binaries (#7845)

### DIFF
--- a/include/slang.h
+++ b/include/slang.h
@@ -4201,7 +4201,7 @@ struct IMetadata : public ISlangCastable
     /*
     Returns the debug build identifier for a base and debug spirv pair.
     */
-    virtual const char* getDebugBuildIdentifier() = 0;
+    virtual const char* SLANG_MCALL getDebugBuildIdentifier() = 0;
 };
     #define SLANG_UUID_IMetadata IMetadata::getTypeGuid()
 
@@ -4217,9 +4217,9 @@ struct ICompileResult : public ISlangCastable
         0x41e5,
         {0x9f, 0x12, 0x4b, 0xad, 0x4d, 0x9e, 0xaa, 0xe4})
 
-    virtual uint32_t getItemCount() = 0;
-    virtual SlangResult getItemData(uint32_t index, IBlob** outblob) = 0;
-    virtual SlangResult getMetadata(IMetadata** outMetadata) = 0;
+    virtual uint32_t SLANG_MCALL getItemCount() = 0;
+    virtual SlangResult SLANG_MCALL getItemData(uint32_t index, IBlob** outblob) = 0;
+    virtual SlangResult SLANG_MCALL getMetadata(IMetadata** outMetadata) = 0;
 };
     #define SLANG_UUID_ICompileResult ICompileResult::getTypeGuid()
 


### PR DESCRIPTION
Fix #7845 