### PR TITLE
Remove unnecessary processing in the release note script

### DIFF
--- a/docs/scripts/release-note.sh
+++ b/docs/scripts/release-note.sh
@@ -74,22 +74,6 @@ for i in $(seq $commitsCount); do
     if "$gh" issue view $pr --json labels | grep -q 'pr: breaking change'; then
       result="[BREAKING] $line"
     fi
-
-    # Get the issue number for the PR
-    body="$("$gh" issue view $pr --json body)"
-    [ "x$body" = "x" ] && break
-    issue="$(echo "$body" | grep '#[1-9][0-9][0-9][0-9][0-9]*' | sed 's|.*\#\([1-9][0-9][0-9][0-9][0-9]*\).*|\1|')"
-    [ "x$issue" = "x" ] && break
-
-    # Get the labels of the issue
-    label="$("$gh" issue view $issue --json labels)"
-    [ "x$label" = "x" ] && break
-
-    # Get the goal type from the labels
-    goal="$(echo "$label" | grep '"goal:' | sed 's|.*"goal:\([^"]*\)".*|\1|')"
-    [ "x$goal" = "x" ] && break
-
-    result+=" (#$issue:$goal)"
   done
   echo "$result"
 done


### PR DESCRIPTION
The release note script was trying to retrieve additional label information from the "issue" but when parsing logic is not reliable.

When the issue has a link to a repo other than Slang, it printed error message.  An example is #7826 that has a link to an external repo,
  https://github.com/llvm/llvm-project/issues/79043