### PR TITLE
Fix slang-no-embedded-core-module-source embedding core module source

### DIFF
--- a/source/slang-core-module/CMakeLists.txt
+++ b/source/slang-core-module/CMakeLists.txt
@@ -69,8 +69,6 @@ set(core_module_source_common_args
     generated
     EXPLICIT_SOURCE
     ./slang-embedded-core-module-source.cpp
-    EXTRA_COMPILE_DEFINITIONS_PRIVATE
-    SLANG_EMBED_CORE_MODULE_SOURCE
     EXPORT_MACRO_PREFIX
     SLANG
     EXPORT_TYPE_AS

--- a/source/slang-core-module/slang-embedded-core-module-source.cpp
+++ b/source/slang-core-module/slang-embedded-core-module-source.cpp
@@ -394,6 +394,7 @@ ComPtr<ISlangBlob> Session::getAutodiffLibraryCode()
 
 ComPtr<ISlangBlob> Session::getGLSLLibraryCode()
 {
+#if SLANG_EMBED_CORE_MODULE_SOURCE
     if (!glslLibraryCode)
     {
         const String path = getCoreModulePath();
@@ -401,6 +402,7 @@ ComPtr<ISlangBlob> Session::getGLSLLibraryCode()
 #include "glsl.meta.slang.h"
         glslLibraryCode = StringBlob::moveCreate(sb);
     }
+#endif
     return glslLibraryCode;
 }
 } // namespace Slang


### PR DESCRIPTION
Fixes #7876 (hopefully).

`SLANG_EMBED_CORE_MODULE_SOURCE` is always defined in `core_module_source_common_args`, even for the `slang-no-embedded-core-module-source` target. This is incorrect, because that target is specifically supposed to not embed the sources. 

Because `slang-no-embedded-core-module-source` doesn't depend on `core_module_meta_generated_headers`, there is no guarantee that the headers exist, and the build can fail occasionally.

Additionally, the `glsl.meta.slang` module was always embedded. I changed this to be in line with the other modules and only embed when `SLANG_EMBED_CORE_MODULE_SOURCE` is defined.
