### PR TITLE
Fix for Generic Function Redefinition Error

### DIFF
--- a/source/slang/slang-ir-clone.cpp
+++ b/source/slang/slang-ir-clone.cpp
@@ -144,12 +144,10 @@ static void specializeLinkageDecoration(IRInst* target, IRSpecialize* oldInst, I
                 sb.append(i);
                 if (auto typeLinkage = arg->findDecoration<IRLinkageDecoration>())
                 {
-                    printf("========================== Specializing linkage for %s\n", typeLinkage->getMangledName().begin());
                     sb.append(typeLinkage->getMangledName());
                 }
                 else
                 {
-                    printf("------------------------- USE getTypeNameHint\n");
                     // getTypeNameHint may produce a name with characters that can't
                     // be part of an identifier, so we need to filter it afterward.
                     StringBuilder tmp;

--- a/source/slang/slang-ir-clone.cpp
+++ b/source/slang/slang-ir-clone.cpp
@@ -144,10 +144,12 @@ static void specializeLinkageDecoration(IRInst* target, IRSpecialize* oldInst, I
                 sb.append(i);
                 if (auto typeLinkage = arg->findDecoration<IRLinkageDecoration>())
                 {
+                    printf("========================== Specializing linkage for %s\n", typeLinkage->getMangledName().begin());
                     sb.append(typeLinkage->getMangledName());
                 }
                 else
                 {
+                    printf("------------------------- USE getTypeNameHint\n");
                     // getTypeNameHint may produce a name with characters that can't
                     // be part of an identifier, so we need to filter it afterward.
                     StringBuilder tmp;

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -719,6 +719,30 @@ void getTypeNameHint(StringBuilder& sb, IRInst* type)
     case kIROp_IntLit:
         sb << as<IRIntLit>(type)->getValue();
         break;
+    case kIROp_BoolLit:
+        sb << (as<IRBoolLit>(type)->getValue() ? "true" : "false");
+        break;
+    case kIROp_FloatLit:
+        sb << as<IRFloatLit>(type)->getValue();
+        break;
+    case kIROp_StringLit:
+        {
+            auto stringLit = as<IRStringLit>(type);
+            sb << "\"";
+            sb << stringLit->getStringSlice();
+            sb << "\"";
+        }
+        break;
+    case kIROp_VoidLit:
+        sb << "void";
+        break;
+    case kIROp_PtrLit:
+        {
+            auto ptrLit = as<IRPtrLit>(type);
+            sb << "ptr_";
+            sb << (uintptr_t)ptrLit->getValue();
+        }
+        break;
     default:
         if (auto decor = type->findDecoration<IRNameHintDecoration>())
             sb << decor->getName();

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -740,7 +740,7 @@ void getTypeNameHint(StringBuilder& sb, IRInst* type)
         {
             auto ptrLit = as<IRPtrLit>(type);
             sb << "ptr_";
-            sb << (uintptr_t)ptrLit->getValue();
+            sb << (UInt64)ptrLit->getValue();
         }
         break;
     default:

--- a/tests/language-feature/generics/generic-interface-linkage-2.slang
+++ b/tests/language-feature/generics/generic-interface-linkage-2.slang
@@ -1,0 +1,26 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+float getVal<let doStuff : bool>()
+{
+    if (doStuff)
+    {
+        return 100.0;
+    }
+    else
+    {
+        return 200.0;
+    }
+}
+
+[shader("compute")]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    // CHECK: 100.0
+    outputBuffer[0] = getVal<true>();
+    // CHECK: 200.0
+    outputBuffer[1] = getVal<false>();
+}

--- a/tests/language-feature/generics/generic-interface-linkage-2.slang
+++ b/tests/language-feature/generics/generic-interface-linkage-2.slang
@@ -1,26 +1,48 @@
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
-//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-slang -compute -compile-arg -obfuscate -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -compile-arg -obfuscate -shaderobj -output-using-type
 
-//TEST_INPUT:ubuffer(data=[0 0], stride=4):out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
-float getVal<let doStuff : bool>()
+float testBool<let doStuff : bool>()
 {
     if (doStuff)
     {
-        return 100.0;
+        return 1.0;
     }
     else
     {
-        return 200.0;
+        return 2.0;
+    }
+}
+
+enum Color {
+    RED,
+    GREEN
+}
+
+float testEnum<let e : Color>()
+{
+    if (e == Color::RED)
+    {
+        return 3.0;
+    }
+    else
+    {
+        return 4.0;
     }
 }
 
 [shader("compute")]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
-    // CHECK: 100.0
-    outputBuffer[0] = getVal<true>();
-    // CHECK: 200.0
-    outputBuffer[1] = getVal<false>();
+    // CHECK: 1.0
+    outputBuffer[0] = testBool<true>();
+    // CHECK: 2.0
+    outputBuffer[1] = testBool<false>();
+
+    // CHECK: 3.0
+    outputBuffer[2] = testEnum<Color::RED>();
+    // CHECK: 4.0
+    outputBuffer[3] = testEnum<Color::GREEN>();
 }


### PR DESCRIPTION
After PR #6688 was merged, users encountered redefinition errors when specializing generic functions with let parameters that have different constant values. For example:
```
float4 getColor<let doStuff : bool>() { ... }

// Both calls generated the same mangled name, causing redefinition error
getColor<true>();
getColor<false>();
```
```
Error: redefinition of '_ShB23F6712314C5976G00'
```

The issue was in the getTypeNameHint() function in source/slang/slang-ir-util.cpp. This function is used by PR #6688's specialized linkage decoration logic to generate mangled names for generic specializations. However, it only handled kIROp_IntLit literals but not other types like kIROp_BoolLit, causing both true and false to be omitted from the mangled name.
This PR added support for all major literal types in the getTypeNameHint() function.
