### PR TITLE
Fix metallib-asm target parsing by adding missing comma

### DIFF
--- a/source/core/slang-type-text-util.cpp
+++ b/source/core/slang-type-text-util.cpp
@@ -78,7 +78,7 @@ static const TypeTextUtil::CompileTargetInfo s_compileTargetInfos[] = {
     {SLANG_METAL, "metal", "metal", "Metal shader source"},
     {SLANG_METAL_LIB, "metallib", "metallib", "Metal Library Bytecode"},
     {SLANG_METAL_LIB_ASM,
-     "metallib-asm"
+     "metallib-asm",
      "metallib-asm",
      "Metal Library Bytecode assembly"},
     {SLANG_WGSL, "wgsl", "wgsl", "WebGPU shading language source"},


### PR DESCRIPTION
The metallib-asm target was not being recognized from command line because of a syntax error in the target string definition in slang-type-text-util.cpp. A missing comma after the first "metallib-asm" string caused C++ string literal concatenation to create a malformed string.

Resolves #7774

Generated with [Claude Code](https://claude.ai/code)