### PR TITLE
Fix SPIRV OpMemberName member indices

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -5738,7 +5738,10 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             }
 
             if (!isPhysicalType)
+            {
+                id++;
                 continue;
+            }
 
             // Emit explicit struct field layout decorations if the struct is physical.
             IRIntegerValue offset = 0;


### PR DESCRIPTION
OpMemberName instructions were all using member index 0 instead of incrementing indices (0, 1, 2, ...) as required by the SPIR-V spec.

The bug was that the member index increment (id++) was only happening for physical struct types, but OpMemberName emission occurs for all struct types when they have name decorations.

This fix ensures member indices are properly incremented for both physical and non-physical struct types.

Fixes #7909