### PR TITLE
Fix SLANG_USE_SYSTEM_SPIRV_HEADERS=TRUE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,10 @@ if(${SLANG_USE_SYSTEM_UNORDERED_DENSE})
     find_package(unordered_dense CONFIG QUIET)
 endif()
 
+if(SLANG_USE_SYSTEM_SPIRV_HEADERS)
+    find_package(SPIRV-Headers REQUIRED)
+endif()
+
 add_subdirectory(external)
 
 # webgpu_dawn is only available as a fetched shared library, since Dawn's nested source

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -103,17 +103,22 @@ target_include_directories(
 )
 
 # SPIRV-Headers
-if(${SLANG_USE_SYSTEM_SPIRV_HEADERS})
-    find_package(SPIRV-Headers REQUIRED)
-elseif(NOT SLANG_OVERRIDE_SPIRV_HEADERS_PATH)
-    add_subdirectory(spirv-headers EXCLUDE_FROM_ALL ${system})
-else()
+if(SLANG_USE_SYSTEM_SPIRV_HEADERS)
+    if(SLANG_OVERRIDE_SPIRV_HEADERS_PATH)
+        message(
+            WARNING
+            "SLANG_OVERRIDE_SPIRV_HEADERS_PATH does nothing when SLANG_USE_SPIRV_HEADERS is set"
+        )
+    endif()
+elseif(SLANG_OVERRIDE_SPIRV_HEADERS_PATH)
     add_subdirectory(
         ${SLANG_OVERRIDE_SPIRV_HEADERS_PATH}/spirv-headers
         spirv-headers
         EXCLUDE_FROM_ALL
         ${system}
     )
+else()
+    add_subdirectory(spirv-headers EXCLUDE_FROM_ALL ${system})
 endif()
 
 if(SLANG_ENABLE_SLANG_GLSLANG)


### PR DESCRIPTION
find_package is locally scoped, so like other find_packages we should do it at the top level

Closes https://github.com/shader-slang/slang/issues/7643