### PR TITLE
Disable automatic `#include` insertion for clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+Completion:
+  HeaderInsertion: Never # This repo does not follow include-what-you-use.

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751949589,
-        "narHash": "sha256-mgFxAPLWw0Kq+C8P3dRrZrOYEQXOtKuYVlo9xvPntt8=",
+        "lastModified": 1753432016,
+        "narHash": "sha256-cnL5WWn/xkZoyH/03NNUS7QgW5vI7D1i74g48qplCvg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b008d60392981ad674e04016d25619281550a9d",
+        "rev": "6027c30c8e9810896b92429f0092f624f7b1aace",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,10 +21,23 @@
         # the latter brings in GCC by default on Linux.
         devShell = pkgs.mkShellNoCC {
           buildInputs = [
-            # Must put `clang-tools` before `clang` for clangd to work properly.
-            # We use `llvmPackages_17.clang-tools` instead of just `clang-tools`
-            # to match the `clang-format` version used in CI.
-            pkgs.llvmPackages_17.clang-tools
+            # We must list clangd before the `clang` package to make sure it
+            # comes earlier on the `PATH`, and we must get it from the
+            # `clang-tools` package so that it is wrapped properly.
+            (pkgs.linkFarm "clangd-21" [
+              {
+                name = "bin/clangd";
+                # New enough to support `HeaderInsertion: Never` in `.clangd`.
+                path = "${pkgs.llvmPackages_21.clang-tools}/bin/clangd";
+              }
+            ])
+            (pkgs.linkFarm "clang-format-17" [
+              {
+                name = "bin/clang-format";
+                # Match the clang-format version used in CI.
+                path = "${pkgs.llvmPackages_17.clang-tools}/bin/clang-format";
+              }
+            ])
 
             pkgs.clang
             pkgs.cmake


### PR DESCRIPTION
When editing files in this repo with clangd, `#include`s get automatically inserted despite not being strictly needed. [This is by design](https://clangd.llvm.org/guides/include-cleaner), but because this repo simply does not follow the `#include` style preferred by clangd, it makes more sense to just disable that feature. This PR adds a `.clangd` file to set clangd's [`HeaderInsertion`](https://clangd.llvm.org/config#headerinsertion) config setting to `Never`, to make editing easier for clangd users in this repo.

Because that config setting was only introduced in clangd version 21, and LLVM 21 was only made available in Nixpkgs very recently via NixOS/nixpkgs#426014, this PR also bumps the Nixpkgs version in `flake.lock`.