### PR TITLE
Invoke `clang++` on C++ code instead of `clang`

### DIFF
--- a/source/compiler-core/slang-gcc-compiler-util.cpp
+++ b/source/compiler-core/slang-gcc-compiler-util.cpp
@@ -796,7 +796,7 @@ static SlangResult _parseGCCFamilyLine(
     SLANG_UNUSED(loader);
 
     ComPtr<IDownstreamCompiler> compiler;
-    if (SLANG_SUCCEEDED(createCompiler(ExecutableLocation(path, "clang"), compiler)))
+    if (SLANG_SUCCEEDED(createCompiler(ExecutableLocation(path, "clang++"), compiler)))
     {
         set->addCompiler(compiler);
     }


### PR DESCRIPTION
Currently, if Clang is selected as the C++ compiler, Clang tries to invoke a binary named `clang`. For instance:

```sh
slangc -default-downstream-compiler cpp clang tests/cpu-program/cpu-hello-world-test.slang -target executable -o hello
```

This results in compilation errors, because `clang` is a C compiler, not a C++ compiler:

```
clang 19.1: /tmp/unknown-3POW6h.cpp(4): error :  'cmath' file not found
    4 | #include <cmath>
      |          ^~~~~~~
1 error generated.
```

This PR fixes that by invoking `clang++` instead.