### PR TITLE
Disable more CI workflows on master push.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,14 +1,6 @@
 name: MDL Benchmark
 
 on:
-  push:
-    branches: [master]
-    paths-ignore:
-      - "docs/**"
-      - "LICENSES/**"
-      - "LICENSE"
-      - "CONTRIBUTING.md"
-      - "README.md"
   pull_request:
     branches: [master]
     paths-ignore:

--- a/.github/workflows/check-cmdline-ref.yml
+++ b/.github/workflows/check-cmdline-ref.yml
@@ -1,8 +1,6 @@
 name: Check Command Line Reference (comment /regenerate-cmdline-ref to auto-fix)
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,8 +1,6 @@
 name: Check Formatting (comment /format to auto-fix)
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
   merge_group:

--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -1,8 +1,6 @@
 name: Check Table of Contents (comment /regenerate-toc to auto-fix)
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 jobs:

--- a/.github/workflows/falcor-compiler-perf-test.yml
+++ b/.github/workflows/falcor-compiler-perf-test.yml
@@ -3,14 +3,6 @@
 name: Falcor Compiler Perf-Test
 
 on:
-  push:
-    branches: [master]
-    paths-ignore:
-      - "docs/**"
-      - "LICENSES/**"
-      - "LICENSE"
-      - "CONTRIBUTING.md"
-      - "README.md"
   pull_request:
     branches: [master]
     paths-ignore:

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -1,14 +1,6 @@
 name: Falcor Tests
 
 on:
-  push:
-    branches: [master]
-    paths-ignore:
-      - "docs/**"
-      - "LICENSES/**"
-      - "LICENSE"
-      - "CONTRIBUTING.md"
-      - "README.md"
   pull_request:
     branches: [master]
     paths-ignore:


### PR DESCRIPTION
These workflows are already run on each PR, so disable them on main branch commits to reduce CI workload.