### PR TITLE
disallow `static const` variables without default-value

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2363,19 +2363,19 @@ void SemanticsDeclHeaderVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
         bool isStatic = false;
         bool isConst = false;
         bool isExtern = false;
-        for(auto modifier : varDecl->modifiers)
+        for (auto modifier : varDecl->modifiers)
         {
-            if(as<HLSLStaticModifier>(modifier))
+            if (as<HLSLStaticModifier>(modifier))
                 isStatic = true;
-            else if(as<ConstModifier>(modifier))
+            else if (as<ConstModifier>(modifier))
                 isConst = true;
-            else if(as<ExternModifier>(modifier))
+            else if (as<ExternModifier>(modifier))
                 isExtern = true;
 
-            if(isStatic && isConst && isExtern)
+            if (isStatic && isConst && isExtern)
                 break;
         }
-        if(isStatic && isConst &&
+        if (isStatic && isConst &&
             // Don't error for extern variables
             // Don't error for interface member variables
             !isExtern && !as<InterfaceDecl>(varDecl->parentDecl))

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2356,6 +2356,27 @@ void SemanticsDeclHeaderVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
         // global variables and struct fields to prevent mangling.
         addModifier(varDecl, m_astBuilder->create<ExternCppModifier>());
     }
+
+    // Check for static const variables without initializers
+    if (varDecl->hasModifier<HLSLStaticModifier>() && varDecl->hasModifier<ConstModifier>())
+    {
+        if (!varDecl->initExpr)
+        {
+            // Don't error for extern variables
+            if (!varDecl->hasModifier<ExternModifier>())
+            {
+                // Don't error for interface member variables
+                if (!as<InterfaceDecl>(varDecl->parentDecl))
+                {
+                    getSink()->diagnose(
+                        varDecl,
+                        Diagnostics::staticConstVariableRequiresInitializer,
+                        varDecl->getName());
+                }
+            }
+        }
+    }
+
     checkVisibility(varDecl);
 }
 

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -1510,6 +1510,12 @@ DIAGNOSTIC(
     constGlobalVarWithInitRequiresStatic,
     "global const variable with initializer must be declared static: '$0'")
 
+DIAGNOSTIC(
+    31225,
+    Error,
+    staticConstVariableRequiresInitializer,
+    "static const variable '$0' must have an initializer")
+
 // Enums
 
 DIAGNOSTIC(32000, Error, invalidEnumTagType, "invalid tag type for 'enum': '$0'")

--- a/tests/bugs/static-const-without-default-value.slang
+++ b/tests/bugs/static-const-without-default-value.slang
@@ -1,0 +1,33 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -stage compute -entry computeMain -emit-spirv-directly
+// CHECK: error 31225
+// CHECK-NOT: error 31225
+// CHECK-NOT: error 31225
+
+// Test cases for static const variables without initializers
+
+// This should cause an error - static const without initializer
+static const int globalVar;
+
+// This should NOT cause an error - extern static const
+extern static const int externVar;
+
+interface ITest
+{
+    // This should NOT cause an error - interface member
+    static const int interfaceVar;
+}
+
+// This should NOT cause an error - has initializer
+static const int initializedVar = 42;
+
+// This should NOT cause an error - not static
+const int nonStaticVar;
+
+// This should NOT cause an error - not const
+static int nonConstVar;
+
+[numthreads(1,1,1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    // Empty compute shader for testing
+}

--- a/tests/bugs/static-const-without-default-value.slang
+++ b/tests/bugs/static-const-without-default-value.slang
@@ -1,12 +1,11 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv -stage compute -entry computeMain -emit-spirv-directly
-// CHECK: error 31225
-// CHECK-NOT: error 31225
-// CHECK-NOT: error 31225
+// TEST:SIMPLE(filecheck=CHECK): -target spirv -stage compute -entry computeMain -emit-spirv-directly
 
-// Test cases for static const variables without initializers
+// Test cases for static const variables without initializers producing an error
 
-// This should cause an error - static const without initializer
+// CHECK: ([[# @LINE+1]]): error 31225
 static const int globalVar;
+
+// CHECK-NOT: error 31225
 
 // This should NOT cause an error - extern static const
 extern static const int externVar;
@@ -19,15 +18,10 @@ interface ITest
 
 // This should NOT cause an error - has initializer
 static const int initializedVar = 42;
-
-// This should NOT cause an error - not static
 const int nonStaticVar;
-
-// This should NOT cause an error - not const
 static int nonConstVar;
 
 [numthreads(1,1,1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
-    // Empty compute shader for testing
 }


### PR DESCRIPTION
Fixes #7989

Changes:
* Add validation in SemanticsDeclHeaderVisitor::checkVarDeclCommon to detect static const variables without initializers and emit proper error diagnostics instead of allowing an uninitialized `static const`
* Do not error if `extern static const` or if `interface` member

