### PR TITLE
[Language Server]: Don't eagerly check file upon open doc.

### DIFF
--- a/source/slang/slang-language-server.cpp
+++ b/source/slang/slang-language-server.cpp
@@ -248,14 +248,6 @@ SlangResult LanguageServerCore::didOpenTextDocument(const DidOpenTextDocumentPar
 {
     String canonicalPath = uriToCanonicalPath(args.textDocument.uri);
     m_workspace->openDoc(canonicalPath, args.textDocument.text);
-
-    auto version = m_workspace->getCurrentVersion();
-    Module* parsedModule = version->getOrLoadModule(canonicalPath);
-    if (!parsedModule)
-    {
-        return SLANG_FAIL;
-    }
-
     return SLANG_OK;
 }
 
@@ -272,6 +264,7 @@ SlangResult LanguageServer::didOpenTextDocument(const DidOpenTextDocumentParams&
     {
         publishDiagnostics();
     }
+    m_pendingModulesToUpdateDiagnostics.add(uriToCanonicalPath(args.textDocument.uri));
     return result;
 }
 


### PR DESCRIPTION
Fixes high latency when opening a big folder.

For some reason, vscode is sending openDoc to langauge server on many files that are not opened by the user. The language server should defer checking these files upon opening them.