### PR TITLE
Reduce merge_group CI workload.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,8 +277,8 @@ jobs:
               -enable-debug-layers ${{ matrix.enable-debug-layers }}
           fi
       - name: Run Slang examples
-         # Run CI examples on debug+release for pull requests, and only on release for merge_group, to reduce CI load.
-        if: steps.filter.outputs.should-run == 'true' && matrix.platform != 'wasm' && matrix.full-gpu-tests && (github.event_name == 'pull_request' || matrix.config == 'release')
+        # Run GLSL backend tests on release for pull requests, and not on merge_group, to reduce CI load.
+        if: steps.filter.outputs.should-run == 'true' && matrix.platform != 'wasm' && matrix.full-gpu-tests && matrix.config == 'release' && github.event_name == 'pull_request'
         run: |
           .github/workflows/ci-examples.sh \
            --bin-dir "$bin_dir" \
@@ -291,8 +291,8 @@ jobs:
         run: |
           PATH=$bin_dir:$PATH tools/slangc-test/test.sh
       - name: Test Slang via glsl
-        # Run GLSL backend tests on debug+release for pull requests, and only on release for merge_group, to reduce CI load.
-        if: steps.filter.outputs.should-run == 'true' && matrix.platform != 'wasm' && matrix.full-gpu-tests && (github.event_name == 'pull_request' || matrix.config == 'release')
+        # Run GLSL backend tests on release for pull requests, and not on merge_group, to reduce CI load.
+        if: steps.filter.outputs.should-run == 'true' && matrix.platform != 'wasm' && matrix.full-gpu-tests && matrix.config == 'release' && github.event_name == 'pull_request'
         run: |
           export SLANG_RUN_SPIRV_VALIDATION=1
           export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,8 @@ jobs:
               -enable-debug-layers ${{ matrix.enable-debug-layers }}
           fi
       - name: Run Slang examples
-        if: steps.filter.outputs.should-run == 'true' && matrix.platform != 'wasm' && matrix.full-gpu-tests
+         # Run CI examples on debug+release for pull requests, and only on release for merge_group, to reduce CI load.
+        if: steps.filter.outputs.should-run == 'true' && matrix.platform != 'wasm' && matrix.full-gpu-tests && (github.event_name == 'pull_request' || matrix.config == 'release')
         run: |
           .github/workflows/ci-examples.sh \
            --bin-dir "$bin_dir" \
@@ -290,7 +291,8 @@ jobs:
         run: |
           PATH=$bin_dir:$PATH tools/slangc-test/test.sh
       - name: Test Slang via glsl
-        if: steps.filter.outputs.should-run == 'true' && matrix.full-gpu-tests && matrix.platform != 'wasm' && matrix.config != 'debug'
+        # Run GLSL backend tests on debug+release for pull requests, and only on release for merge_group, to reduce CI load.
+        if: steps.filter.outputs.should-run == 'true' && matrix.platform != 'wasm' && matrix.full-gpu-tests && (github.event_name == 'pull_request' || matrix.config == 'release')
         run: |
           export SLANG_RUN_SPIRV_VALIDATION=1
           export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1
@@ -304,11 +306,13 @@ jobs:
             -skip-reference-image-generation \
             -show-adapter-info
       - name: Run slang-rhi tests
-        if: steps.filter.outputs.should-run == 'true' && matrix.platform != 'wasm' && matrix.full-gpu-tests
+        # Run slang-rhi tests on debug+release for pull requests, and only on release for merge_group, to reduce CI load.
+        if: steps.filter.outputs.should-run == 'true' && matrix.platform != 'wasm' && matrix.full-gpu-tests && (github.event_name == 'pull_request' || matrix.config == 'release')
         run: |
           "$bin_dir/slang-rhi-tests" -check-devices
       - name: Run slangpy tests
-        if: steps.filter.outputs.should-run == 'true' && matrix.platform != 'wasm' && matrix.full-gpu-tests
+        # Run slangpy tests on debug+release for pull requests, and only on release for merge_group, to reduce CI load.
+        if: steps.filter.outputs.should-run == 'true' && matrix.platform != 'wasm' && matrix.full-gpu-tests && (github.event_name == 'pull_request' || matrix.config == 'release')
         shell: pwsh
         run: |
           python --version


### PR DESCRIPTION
Don't run the following tests on Debug config for commits in the merge_group:
- Slang-RHI tests on Debug Config.
- SlangPy tests on Debug config.

Don't run the following tests on merge_group:
- Examples
- GLSL backend