### PR TITLE
Fix bug in lock-file slang-unit-test

### DIFF
--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -1316,9 +1316,17 @@ void LockFile::close()
         return;
 
 #if SLANG_WINDOWS_FAMILY
-    ::CloseHandle(m_fileHandle);
+    if (m_fileHandle != INVALID_HANDLE_VALUE)
+    {
+        ::CloseHandle(m_fileHandle);
+        m_fileHandle = INVALID_HANDLE_VALUE;
+    }
 #else
-    ::close(m_fileHandle);
+    if (m_fileHandle != -1)
+    {
+        ::close(m_fileHandle);
+        m_fileHandle = -1;
+    }
 #endif
 
     m_isOpen = false;
@@ -1409,6 +1417,11 @@ SlangResult LockFile::unlock()
 LockFile::LockFile()
     : m_isOpen(false)
 {
+#if SLANG_WINDOWS_FAMILY
+    m_fileHandle = INVALID_HANDLE_VALUE;
+#else
+    m_fileHandle = -1;
+#endif
 }
 
 LockFile::~LockFile()

--- a/tools/slang-unit-test/unit-test-lock-file.cpp
+++ b/tools/slang-unit-test/unit-test-lock-file.cpp
@@ -37,10 +37,16 @@ SLANG_UNIT_TEST(lockFileSync)
     SLANG_IGNORE_TEST
 #endif
 
+    // Clean up any leftover lock file from previous runs
+    File::remove(fileName);
+
     // Test using multiple threads.
     {
         static std::atomic<uint32_t> lockCounter;
         static std::atomic<uint32_t> unlockCounter;
+
+        lockCounter = 0;
+        unlockCounter = 0;
 
         struct LockTask
         {


### PR DESCRIPTION
This commit fixes two problems.
 1. uninitialized file handle for lock-file test
 2. uninitialized static variable for lock-file test

The first bug is more of speculartive rather than actual bug.

The second bug was causing heap corruption when it was retried, because the counter was not reset to zero on "retry" and it wrote data to an invalida range in an array.