### PR TITLE
Omit listing values in slangc -h cmdline output, show how to list them seperately

### DIFF
--- a/source/core/slang-command-options-writer.cpp
+++ b/source/core/slang-command-options-writer.cpp
@@ -599,14 +599,8 @@ void TextCommandOptionsWriter::_appendDescriptionForCategory(Index categoryIndex
 
                 m_builder << m_options.indent << m_options.indent;
 
-                m_builder << "<" << usageCat.name << "> can be: ";
-
-                List<UnownedStringSlice> optionNames;
-                options.getCategoryOptionNames(usageCategoryIndex, optionNames);
-
-                _appendWrappedIndented(2, optionNames, toSlice(", "));
-
-                m_builder << "\n";
+                m_builder << "To get a list of values that can be used for <" << usageCat.name << ">, ";
+                m_builder << "use \"slangc -h " << usageCat.name << "\"\n";
             }
         }
     }


### PR DESCRIPTION
For #7969 

This changes the output text of `slangc -h` to not default to printing lists of values that can be used with each option, instead telling the user how to display that list seperately using  `slangc -h <help-category>` if they want to.

e.g. instead of giving a huge list of possible values for <capability>,
```
  -capability <capability>[+<capability>...]: Add optional capabilities to a code generation target. See Capabilities
    below.
    <capability> can be ...
```
we tell the user how to get that list:
```
  -capability <capability>[+<capability>...]: Add optional capabilities to a code generation target. See Capabilities
    below.
    To get a list of values that can be used for <capability>, use "slangc -h capability"
```
where `slangc -h capability` prints the \<capability\> category, which lists the values.

This reduces the length of the help output significantly and does not affect the markdown output.
Before: 468 lines, 3246 words, 39448 characters
After: 274 lines, 2410 words, 18679 characters