### PR TITLE
Omit "Internal" category from default help text output

### DIFF
--- a/source/core/slang-command-options-writer.cpp
+++ b/source/core/slang-command-options-writer.cpp
@@ -504,8 +504,8 @@ void TextCommandOptionsWriter::appendDescriptionImpl()
     {
         const auto& category = categories[categoryIndex];
 
-        // Omit the value categories
-        if (category.kind != CategoryKind::Value)
+        // Omit the value categories and the "Internal" category for text output
+        if (category.kind != CategoryKind::Value && category.name != toSlice("Internal"))
         {
             _appendDescriptionForCategory(categoryIndex);
         }


### PR DESCRIPTION
For #7969

This changes the output text of `slangc -h` to not print the "Internal" category unless explicitly specified, as those options are intended for internal Slang dev use. The category can still be printed on its own with `slangc -h Internal`, and is listed in the available categories under the "Getting Help for Specific Categories" note at the end of the output of `slangc -h`.
The markdown help output is not affected.

Before: 468 lines of help text, 3246 words, 39448 characters
After: 447 lines, 3107 words, 38313 characters
Diff: -21 lines (approx. -4.5%), -139 words (approx. -4.3%), -1135 characters (approx. -2.9%)