### PR TITLE
Omit "Invalid" capability from slangc -h output

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1132,7 +1132,6 @@ Vulkan Shift
 A capability describes an optional feature that a target may or may not support. When a [-capability](#capability-1) is specified, the compiler may assume that the target supports that capability, and generate code accordingly. 
 
 * `spirv_1_{ 0`, `1`, `2`, `3`, `4`, `5 }` : minimum supported SPIR - V version 
-* `Invalid` 
 * `textualTarget` 
 * `hlsl` 
 * `glsl` 

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -282,7 +282,7 @@ void initCommandOptions(CommandOptions& options)
 
         for (auto name : names)
         {
-            if (name.startsWith("__") || name.startsWith("spirv_1_") || name.startsWith("_"))
+            if (name.startsWith("__") || name.startsWith("spirv_1_") || name.startsWith("_") || name == "Invalid")
             {
                 continue;
             }


### PR DESCRIPTION
Following up on a comment on #8012, this change adds the `Invalid` capability to the capabilities that we exclude from showing in the `slangc -h` output, as it is obviously not a valid capability that can be used,

