### PR TITLE
disable ray-tracing-pipeline test

### DIFF
--- a/tools/slang-unit-test/unit-test-record-replay.cpp
+++ b/tools/slang-unit-test/unit-test-record-replay.cpp
@@ -455,10 +455,14 @@ SLANG_UNIT_TEST(RecordReplay_ray_tracing)
     SLANG_CHECK(SLANG_SUCCEEDED(runTest(unitTestContext, "ray-tracing")));
 }
 
+// This causes a Windows Graphics driver crash.
+// Temporarily disabled; issue #8022
+#if 0
 SLANG_UNIT_TEST(RecordReplay_ray_tracing_pipeline)
 {
     SLANG_CHECK(SLANG_SUCCEEDED(runTest(unitTestContext, "ray-tracing-pipeline")));
 }
+#endif
 
 SLANG_UNIT_TEST(RecordReplay_autodiff_texture)
 {


### PR DESCRIPTION
Disabling ray-tracing-pipeline test as a part of slang-test.
Because it appears to cause a crash on Windows Graphics driver.
We should re-enable once the issue is resolved.

Related to
- https://github.com/shader-slang/slang/issues/8022
- https://github.com/shader-slang/slang/issues/7965