### PR TITLE
Restrict the release tag name to a pattern the build script expects

### DIFF
--- a/.github/workflows/release-linux-glibc-2-27.yml
+++ b/.github/workflows/release-linux-glibc-2-27.yml
@@ -2,7 +2,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "v*"
+      - "v20[2-9][0-9].[0-9]*"
 
 name: ubuntu18-gcc11 Release
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     # We are not caching the builds so we don't want to run the release workflow for every push to master;
     # The release workflow is only triggered by tags or manual dispatch
     tags:
-      - "v*"
+      - "v20[2-9][0-9].[0-9]*"
 jobs:
   release:
     strategy:


### PR DESCRIPTION
Previously there were tag name `vulkan` and it was causing build errors. The cmake build script currently expect the name to be in a pattern of `v2025.1` which starts with `v` and followed by numbers.