### PR TITLE
Allow building LLVM 13 with newer compilers

### DIFF
--- a/external/build-llvm.sh
+++ b/external/build-llvm.sh
@@ -135,6 +135,8 @@ cmake_arguments_for_slang=(
   "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>"
   "-DLLVM_USE_CRT_RELEASE=MT"
   "-DLLVM_USE_CRT_DEBUG=MTd"
+  # Allow building with newer compilers
+  -DCMAKE_CXX_FLAGS="-include cstdint"
 )
 build_dir=$source_dir/build
 mkdir -p "$build_dir"


### PR DESCRIPTION
Currently `external/build-llvm.sh` works with GCC 11 which we use in CI, but does not work with GCC 13 or newer:

```
In file included from /home/saestep/github/shader-slang/slang/build/slang-llvm_src/llvm/lib/Support/Signals.cpp:14:
/home/saestep/github/shader-slang/slang/build/slang-llvm_src/llvm/include/llvm/Support/Signals.h:119:24: error: unknown type name 'uintptr_t'; did you mean '__intptr_t'?
  119 |   void CleanupOnSignal(uintptr_t Context);
      |                        ^~~~~~~~~
      |                        __intptr_t
```

And also does not work with any version of Clang that I've tried, including Clang 12 and Clang 13 (although I don't quite understand why Clang 13 wouldn't be able to build itself):

```
In file included from /home/saestep/github/shader-slang/slang/build/slang-llvm_src/llvm/lib/Support/Signals.cpp:14:
/home/saestep/github/shader-slang/slang/build/slang-llvm_src/llvm/include/llvm/Support/Signals.h:119:8: error: variable or field 'CleanupOnSignal' declared void
  119 |   void CleanupOnSignal(uintptr_t Context);
      |        ^~~~~~~~~~~~~~~
/home/saestep/github/shader-slang/slang/build/slang-llvm_src/llvm/include/llvm/Support/Signals.h:119:24: error: 'uintptr_t' was not declared in this scope
  119 |   void CleanupOnSignal(uintptr_t Context);
      |                        ^~~~~~~~~
/home/saestep/github/shader-slang/slang/build/slang-llvm_src/llvm/include/llvm/Support/Signals.h:18:1: note: 'uintptr_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   17 | #include <string>
  +++ |+#include <cstdint>
   18 |
```

This is because [GCC 13 started requiring explicit `#include <cstdint>`](https://gcc.gnu.org/gcc-13/porting_to.html), which was not added to `llvm/include/llvm/Support/Signals.h` until llvm/llvm-project@ff1681ddb303223973653f7f5f3f3435b48a1983 a few months after the `llvmorg-13.0.1` tag.

This PR allows LLVM 13 to be built with Clang, and with newer versions of GCC, by implicitly including `<cstdint>`.