### PR TITLE
Add `lock` file to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,4 +105,5 @@ vkd3d-proton.cache.write
 
 # Other temporary files
 /generators
+/lock
 /tests/library/linked.spirv


### PR DESCRIPTION
This file keeps getting created and deleted: it was originally created in #6310, then I deleted it in #6620, then it was accidentally added in #7579, then deleted again in #7577. We should just have it in `.gitignore`.