### PR TITLE
Update LLVM from 13.0.1 to 14.0.6

### DIFF
--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -60,7 +60,7 @@ function(fetch_or_build_slang_llvm)
             endif()
         endif()
     elseif(SLANG_SLANG_LLVM_FLAVOR STREQUAL "USE_SYSTEM_LLVM")
-        find_package(LLVM 13.0 REQUIRED CONFIG)
+        find_package(LLVM 14.0 REQUIRED CONFIG)
         find_package(Clang REQUIRED CONFIG)
 
         llvm_target_from_components(llvm-dep filecheck native orcjit)
@@ -104,7 +104,7 @@ function(fetch_or_build_slang_llvm)
         endif()
 
         # TODO: Put a check here that libslang-llvm.so doesn't have a 'NEEDED'
-        # directive for libLLVM-13.so, it's almost certainly going to break at
+        # directive for libLLVM-14.so, it's almost certainly going to break at
         # runtime in surprising ways when linked alongside Mesa (or anything else
         # pulling in libLLVM.so)
     endif()

--- a/docs/building.md
+++ b/docs/building.md
@@ -219,7 +219,7 @@ There are several options for getting llvm-support:
       the case that a prebuilt binary can't be found then the build will proceed
       as though `DISABLE` was chosen
 - Use a system supplied LLVM: `-DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM`, you
-  must have llvm-13.0 and a matching libclang installed. It's important that
+  must have llvm-14.0 and a matching libclang installed. It's important that
   either:
     - You don't end up linking to a dynamic libllvm.so, this will almost
       certainly cause multiple versions of LLVM to be loaded at runtime,

--- a/external/build-llvm.ps1
+++ b/external/build-llvm.ps1
@@ -55,7 +55,7 @@ $null = Register-EngineEvent PowerShell.Exiting -Action $cleanup
 
 # Default values
 $repo = "https://github.com/llvm/llvm-project"
-$branch = "llvmorg-13.0.1"
+$branch = "llvmorg-14.0.6"
 $sourceDir = $tempDir.FullName
 $installPrefix = ""
 $config = "Release"

--- a/external/build-llvm.sh
+++ b/external/build-llvm.sh
@@ -54,7 +54,7 @@ trap cleanup EXIT SIGHUP SIGINT SIGTERM
 # Options and parsing
 #
 repo=https://github.com/llvm/llvm-project
-branch=llvmorg-13.0.1
+branch=llvmorg-14.0.6
 source_dir=$temp_dir
 install_prefix=
 config=Release

--- a/source/slang-llvm/slang-llvm.cpp
+++ b/source/slang-llvm/slang-llvm.cpp
@@ -28,7 +28,6 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Signals.h"
-#include "llvm/Support/TargetRegistry.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/Timer.h"
@@ -239,12 +238,12 @@ void* LLVMJITSharedLibrary::findSymbolAddressByName(char const* name)
 
 static void _ensureSufficientStack() {}
 
-static void _llvmErrorHandler(void* userData, const std::string& message, bool genCrashDiag)
+static void _llvmErrorHandler(void* userData, const char* message, bool genCrashDiag)
 {
     // DiagnosticsEngine& diags = *static_cast<DiagnosticsEngine*>(userData);
     // diags.Report(diag::err_fe_error_backend) << message;
 
-    printf("Clang/LLVM fatal error: %s\n", message.c_str());
+    printf("Clang/LLVM fatal error: %s\n", message);
 
     // Run the interrupt handlers to make sure any special cleanups get done, in
     // particular that we remove files registered with RemoveFileOnSignal.


### PR DESCRIPTION
Full set of mutually exclusive choices for upgrading LLVM:

- #8031 (you are here)
- #8035
- #8036
- #8034
- #8038
- #8039
- #8033

Alternative to #8028. Required some minor changes due to these upstream commits:

- llvm/llvm-project@e463b69736da8b0a950ecd937cf990401bdfcdeb
- llvm/llvm-project@89b57061f7b769e9ea9bf6ed686e284f3e55affe