### PR TITLE
Omit "Repro" category from default help text output

### DIFF
--- a/source/core/slang-command-options-writer.cpp
+++ b/source/core/slang-command-options-writer.cpp
@@ -504,8 +504,9 @@ void TextCommandOptionsWriter::appendDescriptionImpl()
     {
         const auto& category = categories[categoryIndex];
 
-        // Omit the value categories and the "Internal" category for text output
-        if (category.kind != CategoryKind::Value && category.name != toSlice("Internal"))
+        // Omit the value categories as well as the "Internal" and "Repro" categories from the text output
+        if (category.kind != CategoryKind::Value && category.name != toSlice("Internal") &&
+            category.name != toSlice("Repro"))
         {
             _appendDescriptionForCategory(categoryIndex);
         }


### PR DESCRIPTION
For #7969

This changes the output text of slangc -h to not print the "Repro" category unless explicitly specified, as those options are for the unmaintained repro system. The category can still be printed on its own with `slangc -h Repro`, and is listed in the available categories under the "Getting Help for Specific Categories" note at the end of the output of `slangc -h`.
The markdown help output is not affected.