### PR TITLE
Fix noperspective modifier for SV_Barycentrics in SPIRV and GLSL

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -6211,11 +6211,16 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     requireSPIRVCapability(SpvCapabilityFragmentBarycentricKHR);
                     ensureExtensionDeclaration(
                         UnownedStringSlice("SPV_KHR_fragment_shader_barycentric"));
-                    return getBuiltinGlobalVar(inst->getFullType(), SpvBuiltInBaryCoordKHR, inst);
 
-                    // TODO: There is also the `gl_BaryCoordNoPerspNV` builtin, which
-                    // we ought to use if the `noperspective` modifier has been
-                    // applied to this varying input.
+                    auto interpolationModeDecor = inst->findDecoration<IRInterpolationModeDecoration>();
+                    if (interpolationModeDecor && interpolationModeDecor->getMode() == IRInterpolationMode::NoPerspective)
+                    {
+                        return getBuiltinGlobalVar(inst->getFullType(), SpvBuiltInBaryCoordNoPerspKHR, inst);
+                    }
+                    else
+                    {
+                        return getBuiltinGlobalVar(inst->getFullType(), SpvBuiltInBaryCoordKHR, inst);
+                    }
                 }
                 else if (semanticName == "sv_cullprimitive")
                 {

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -6212,14 +6212,22 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     ensureExtensionDeclaration(
                         UnownedStringSlice("SPV_KHR_fragment_shader_barycentric"));
 
-                    auto interpolationModeDecor = inst->findDecoration<IRInterpolationModeDecoration>();
-                    if (interpolationModeDecor && interpolationModeDecor->getMode() == IRInterpolationMode::NoPerspective)
+                    auto interpolationModeDecor =
+                        inst->findDecoration<IRInterpolationModeDecoration>();
+                    if (interpolationModeDecor &&
+                        interpolationModeDecor->getMode() == IRInterpolationMode::NoPerspective)
                     {
-                        return getBuiltinGlobalVar(inst->getFullType(), SpvBuiltInBaryCoordNoPerspKHR, inst);
+                        return getBuiltinGlobalVar(
+                            inst->getFullType(),
+                            SpvBuiltInBaryCoordNoPerspKHR,
+                            inst);
                     }
                     else
                     {
-                        return getBuiltinGlobalVar(inst->getFullType(), SpvBuiltInBaryCoordKHR, inst);
+                        return getBuiltinGlobalVar(
+                            inst->getFullType(),
+                            SpvBuiltInBaryCoordKHR,
+                            inst);
                     }
                 }
                 else if (semanticName == "sv_cullprimitive")

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -898,7 +898,8 @@ GLSLSystemValueInfo* getGLSLSystemValueInfo(
                         }
                     }
                 }
-                if (hasNoPerspective) break;
+                if (hasNoPerspective)
+                    break;
             }
         }
         name = hasNoPerspective ? "gl_BaryCoordNoPerspEXT" : "gl_BaryCoordEXT";

--- a/tests/pipeline/rasterization/get-attribute-at-vertex-struct.slang
+++ b/tests/pipeline/rasterization/get-attribute-at-vertex-struct.slang
@@ -1,0 +1,38 @@
+// get-attribute-at-vertex-struct.slang
+
+// Test GetAttributeAtVertex and SV_Barycentrics on struct members
+
+//TEST:SIMPLE(filecheck=CHECK-SPIRV):-target spirv -entry main -stage fragment -profile glsl_450+GL_EXT_fragment_shader_barycentric
+//TEST:SIMPLE(filecheck=CHECK-GLSL):-target glsl -entry main -stage fragment -profile glsl_450+GL_EXT_fragment_shader_barycentric
+
+// CHECK-SPIRV: OpCapability FragmentBarycentricKHR
+// CHECK-SPIRV: OpExtension "SPV_KHR_fragment_shader_barycentric"
+
+// CHECK-SPIRV: OpEntryPoint Fragment %main "main"
+// CHECK-SPIRV: OpDecorate %{{.*}} BuiltIn BaryCoordKHR
+// CHECK-SPIRV: OpDecorate %{{.*}} BuiltIn BaryCoordNoPerspKHR
+// CHECK-SPIRV: %{{.*}} = OpAccessChain %_ptr_Input_{{.*}} %{{.*}} %uint_0
+// CHECK-SPIRV: %{{.*}} = OpAccessChain %_ptr_Input_{{.*}} %{{.*}} %uint_1
+// CHECK-SPIRV: %{{.*}} = OpAccessChain %_ptr_Input_{{.*}} %{{.*}} %uint_2
+
+// CHECK-GLSL: #extension GL_EXT_fragment_shader_barycentric : require
+// CHECK-GLSL-DAG: gl_BaryCoordEXT
+// CHECK-GLSL-DAG: gl_BaryCoordNoPerspEXT
+
+struct Input
+{
+    pervertex float4 color : COLOR;
+    float3 bary : SV_Barycentrics;
+    noperspective float3 baryNoPerspective : SV_Barycentrics;
+}
+
+[shader("fragment")]
+void main(
+    Input input,
+    out float4 result : SV_Target)
+{
+    result = input.bary.x * GetAttributeAtVertex(input.color, 0)
+        + input.bary.y * GetAttributeAtVertex(input.color, 1)
+        + input.bary.z * GetAttributeAtVertex(input.color, 2)
+        + input.baryNoPerspective.x * 0.1f;
+}

--- a/tests/pipeline/rasterization/get-attribute-at-vertex.slang
+++ b/tests/pipeline/rasterization/get-attribute-at-vertex.slang
@@ -2,23 +2,32 @@
 
 // Basic test for `GetAttributeAtVertex` function
 
-//TEST:SIMPLE(filecheck=CHECK):-emit-spirv-directly -target spirv -entry main -stage fragment -profile glsl_450+GL_EXT_fragment_shader_barycentric
+//TEST:SIMPLE(filecheck=CHECK-SPIRV):-emit-spirv-directly -target spirv -entry main -stage fragment -profile glsl_450+GL_EXT_fragment_shader_barycentric
+//TEST:SIMPLE(filecheck=CHECK-GLSL):-target glsl -entry main -stage fragment -profile glsl_450+GL_EXT_fragment_shader_barycentric
 
-// CHECK: OpCapability FragmentBarycentricKHR
-// CHECK: OpExtension "SPV_KHR_fragment_shader_barycentric"
+// CHECK-SPIRV: OpCapability FragmentBarycentricKHR
+// CHECK-SPIRV: OpExtension "SPV_KHR_fragment_shader_barycentric"
 
-// CHECK: OpEntryPoint Fragment %main "main"
-// CHECK: %{{.*}} = OpAccessChain %_ptr_Input_{{.*}} %{{.*}} %uint_0
-// CHECK: %{{.*}} = OpAccessChain %_ptr_Input_{{.*}} %{{.*}} %uint_1
-// CHECK: %{{.*}} = OpAccessChain %_ptr_Input_{{.*}} %{{.*}} %uint_2
+// CHECK-SPIRV: OpEntryPoint Fragment %main "main"
+// CHECK-SPIRV: OpDecorate %{{.*}} BuiltIn BaryCoordKHR
+// CHECK-SPIRV: OpDecorate %{{.*}} BuiltIn BaryCoordNoPerspKHR
+// CHECK-SPIRV: %{{.*}} = OpAccessChain %_ptr_Input_{{.*}} %{{.*}} %uint_0
+// CHECK-SPIRV: %{{.*}} = OpAccessChain %_ptr_Input_{{.*}} %{{.*}} %uint_1
+// CHECK-SPIRV: %{{.*}} = OpAccessChain %_ptr_Input_{{.*}} %{{.*}} %uint_2
+
+// CHECK-GLSL: #extension GL_EXT_fragment_shader_barycentric : require
+// CHECK-GLSL-DAG: gl_BaryCoordEXT
+// CHECK-GLSL-DAG: gl_BaryCoordNoPerspEXT
 
 [shader("fragment")]
 void main(
     pervertex float4 color : COLOR,
     float3 bary : SV_Barycentrics,
+    noperspective float3 baryNoPerspective : SV_Barycentrics,
     out float4 result : SV_Target)
 {
     result = bary.x * GetAttributeAtVertex(color, 0)
            + bary.y * GetAttributeAtVertex(color, 1)
-           + bary.z * GetAttributeAtVertex(color, 2);
+           + bary.z * GetAttributeAtVertex(color, 2)
+           + baryNoPerspective.x * 0.1f;
 }

--- a/tests/pipeline/rasterization/get-attribute-at-vertex.slang
+++ b/tests/pipeline/rasterization/get-attribute-at-vertex.slang
@@ -2,7 +2,7 @@
 
 // Basic test for `GetAttributeAtVertex` function
 
-//TEST:SIMPLE(filecheck=CHECK-SPIRV):-emit-spirv-directly -target spirv -entry main -stage fragment -profile glsl_450+GL_EXT_fragment_shader_barycentric
+//TEST:SIMPLE(filecheck=CHECK-SPIRV):-target spirv -entry main -stage fragment -profile glsl_450+GL_EXT_fragment_shader_barycentric
 //TEST:SIMPLE(filecheck=CHECK-GLSL):-target glsl -entry main -stage fragment -profile glsl_450+GL_EXT_fragment_shader_barycentric
 
 // CHECK-SPIRV: OpCapability FragmentBarycentricKHR


### PR DESCRIPTION
Fix noperspective modifier for SV_Barycentrics in SPIRV and GLSL

- Added test case with both regular and noperspective SV_Barycentrics inputs

This PR addresses issue #7816

Generated with [Claude Code](https://claude.ai/code)