### PR TITLE
Add DebugVar for the entry point parameters

### DIFF
--- a/source/slang/slang-ir-insert-debug-value-store.cpp
+++ b/source/slang/slang-ir-insert-debug-value-store.cpp
@@ -135,7 +135,9 @@ void DebugValueStoreContext::insertDebugValueStore(IRFunc* func)
         // Store the initial value of the parameter into the debug var.
         IRInst* paramVal = nullptr;
         if (!isRefParam)
+        {
             paramVal = param;
+        }
         else if (as<IRInOutType>(param->getDataType()))
         {
             paramVal = builder.emitLoad(param);
@@ -151,7 +153,7 @@ void DebugValueStoreContext::insertDebugValueStore(IRFunc* func)
             //
             // However, we still want to emit the debug information in the form of
             // what the end user expects. That means emitting DebugVar for the
-	    // entry point parameter may not be enough. If its type is struct,
+            // entry point parameter may not be enough. If its type is struct,
             // we are going to emit the debug-variable explicitly for each member
             // of the entry point param.
             //
@@ -163,14 +165,13 @@ void DebugValueStoreContext::insertDebugValueStore(IRFunc* func)
                     if (!isDebuggableType(fieldType))
                         continue;
 
-                    // Create debug var for struct member with naming like "input.pos"
                     auto memberDebugVar = builder.emitDebugVar(
                         fieldType,
                         funcDebugLoc->getSource(),
                         funcDebugLoc->getLine(),
                         funcDebugLoc->getCol());
 
-                    // Set name hint combining parameter and field names
+                    // Set name hint combining parameter and field names like "input.pos"
                     if (auto paramNameHint = param->findDecoration<IRNameHintDecoration>())
                     {
                         if (auto fieldNameHint =
@@ -185,16 +186,13 @@ void DebugValueStoreContext::insertDebugValueStore(IRFunc* func)
                         }
                     }
 
-                    // Store the member debug var for later use
-                    // We'll emit DebugValue for it when we have the field value
-                    if (paramVal)
-                    {
-                        auto fieldVal = builder.emitFieldExtract(paramVal, field->getKey());
-                        builder.emitDebugValue(memberDebugVar, fieldVal);
-                    }
+                    // Map the member debug var to each member variable
+                    auto fieldVal = builder.emitFieldExtract(paramVal, field->getKey());
+                    builder.emitDebugValue(memberDebugVar, fieldVal);
                 }
             }
         }
+
         if (paramVal)
         {
             builder.emitDebugValue(debugVar, paramVal);

--- a/tests/spirv/debug-entry-point-struct-members.slang
+++ b/tests/spirv/debug-entry-point-struct-members.slang
@@ -1,5 +1,9 @@
 //TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -entry main -stage fragment -g2 -emit-spirv-directly
 
+// This test is to make sure Slang emits Debug info for the member variables
+// of the entry point param after the entry point param is legalized, unused,
+// and removed.
+
 struct VertexInput
 {
     float4 position : SV_Position;
@@ -16,16 +20,16 @@ float4 main(VertexInput input) : SV_TARGET
 // CHECK: OpName %input_position "input.position"
 // CHECK: OpName %input_color{{(_[0-9]+)?}} "input.color"
 
-// Verify basic debug infrastructure exists
-// CHECK: DebugCompilationUnit
-// CHECK: DebugFunction
-
 // Verify that DebugLocalVariable is generated for the entry point parameter
 // CHECK: %input = OpExtInst %void %{{[0-9]+}} DebugLocalVariable
 
 // Verify that DebugLocalVariable is generated for individual struct members
 // CHECK: %input_position = OpExtInst %void %{{[0-9]+}} DebugLocalVariable
-// CHECK: %input_color{{(_[0-9]+)?}} = OpExtInst %void %{{[0-9]+}} DebugLocalVariable
+// CHECK: %input_color{{[^ ]*}} = OpExtInst %void %{{[0-9]+}} DebugLocalVariable
 
-// Verify that DebugValue instructions are generated
+// Verify that DebugValue instructions are generated for the entry point param
 // CHECK: DebugValue %input
+
+// Verify that DebugValue instructions are generated for the members
+// CHECK: DebugDeclare %input_position
+// CHECK: DebugDeclare %input_color

--- a/tests/spirv/debug-get-attribute-at-vertex.slang
+++ b/tests/spirv/debug-get-attribute-at-vertex.slang
@@ -44,8 +44,12 @@ float4 main(FragmentInput input) : SV_Target
 // CHECK: %input_position = OpExtInst %void %{{[0-9]+}} DebugLocalVariable
 // CHECK: %input_color{{(_[0-9]+)?}} = OpExtInst %void %{{[0-9]+}} DebugLocalVariable
 
-// Verify that DebugValue instructions map the debug variables correctly
+// Verify that DebugValue instructions are generated for the entry point param
 // CHECK: DebugValue %input
+
+// Verify that DebugValue instructions are generated for the members
+// CHECK: DebugDeclare %input_position
+// CHECK: DebugDeclare %input_color
 
 // Verify GetAttributeAtVertex generates proper SPIR-V access patterns
 // The key test: ensure it accesses the global variable directly, not a local copy


### PR DESCRIPTION
This commit is to emit DebugVar for the entry point param even when the param is removed during the legalization process.

When its type is "struct", we need to emit DebugVar for each member variable explicitly.

Fixes https://github.com/shader-slang/slang/issues/7693