### PR TITLE
export fewer things from module targets

### DIFF
--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -92,6 +92,10 @@ function(fetch_or_build_slang_llvm)
         )
         # If we don't include this, then the symbols in the LLVM linked here may
         # conflict with those of other LLVMs linked at runtime, for instance in mesa.
+        set_target_properties(
+            slang-llvm
+            PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN ON
+        )
         add_supported_cxx_linker_flags(
             slang-llvm
             PRIVATE

--- a/source/slang-glsl-module/CMakeLists.txt
+++ b/source/slang-glsl-module/CMakeLists.txt
@@ -26,3 +26,12 @@ slang_add_target(
     INCLUDE_DIRECTORIES_PRIVATE ${glsl_module_generated_header_dir}
     INSTALL
 )
+set_target_properties(
+    slang-glsl-module
+    PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN ON
+)
+add_supported_cxx_linker_flags(
+    slang-glsl-module
+    PRIVATE
+    "-Wl,--exclude-libs,ALL"
+)

--- a/source/slang-glslang/CMakeLists.txt
+++ b/source/slang-glslang/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Our wrapper for glslang 
+# Our wrapper for glslang
 #
 if(SLANG_ENABLE_SLANG_GLSLANG)
     slang_add_target(
@@ -14,6 +14,10 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
     )
     # Our only interface is through what we define in source/slang-glslang, in the
     # interests of hygiene, hide anything else we link in.
+    set_target_properties(
+        slang-glslang
+        PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN ON
+    )
     add_supported_cxx_linker_flags(
         slang-glslang
         PRIVATE


### PR DESCRIPTION
Closes https://github.com/shader-slang/slang/issues/7722 without adding SONAME

```
e@light-hope in ~/work/slang on HEAD (68b0125) [nix-shell] [direnv]
$ nm -DC --defined-only build/Debug/lib/libslang-llvm.so
0000000001a4b637 T createLLVMDownstreamCompiler_V4
0000000001a427ed T createLLVMFileCheck_V1
0000000001a4b91e W std::type_info::operator==(std::type_info const&) const
0000000001a4bb07 W std::_Sp_make_shared_tag::_S_ti()
0000000001059165 u std::ranges::_Cpo::iter_move
0000000005f92ac0 V typeinfo for std::_Sp_make_shared_tag
0000000005f92938 V vtable for std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>

e@light-hope in ~/work/slang on HEAD (68b0125) [nix-shell] [direnv]
$ nm -DC --defined-only build/Debug/lib/libslang-glslang.so
00000000004701a2 T glslang_compile
000000000047012b T glslang_compile_1_1
000000000046ffd9 T glslang_compile_1_2
000000000046db75 T glslang_disassembleSPIRV
000000000046da42 T glslang_disassembleSPIRVWithResult
000000000047028b T glslang_linkSPIRV
000000000046d8fa T glslang_validateSPIRV

e@light-hope in ~/work/slang on HEAD (68b0125) [nix-shell] [direnv]
$ nm -DC --defined-only build/Debug/lib/libslang-glsl-module.so
0000000000135bf9 T slang_getEmbeddedModule
```

I think that the exports from libslang-llvm are unavoidable I believe, however these are weak exports so should exhibit the same problem.

@NBickford-NV does this look good for you?