### PR TITLE
Add a new option to use hash for release-note script

### DIFF
--- a/docs/scripts/release-note.sh
+++ b/docs/scripts/release-note.sh
@@ -6,7 +6,7 @@
 # Usage: the script takes command-line arguments to specify the range of commits to include.
 # You can use either:
 # 1. Date-based range with --since: docs/scripts/release-note.sh --since 2025-08-06
-# 2. Hash-based range with --previous-release-hash: docs/scripts/release-note.sh --previous-release-hash abc123
+# 2. Hash-based range with --previous-hash: docs/scripts/release-note.sh --previous-hash abc123
 # 3. Legacy positional argument (deprecated): docs/scripts/release-note.sh 2024-07-01
 
 # This script is supposed to work on all Windows based shell systems including WSL and git-bash.
@@ -50,16 +50,16 @@ do
       use_hash=false
       shift 2
       ;;
-    --previous-release-hash)
+    --previous-hash)
       previous_hash="$2"
       use_hash=true
       shift 2
       ;;
     -*)
       echo "Unknown option: $1"
-      echo "Usage: $0 [--since DATE | --previous-release-hash HASH]"
-      echo "  --since DATE                    Generate notes since the given date (e.g., 2025-08-06)"
-      echo "  --previous-release-hash HASH    Generate notes since the given commit hash"
+      echo "Usage: $0 [--since DATE | --previous-hash HASH]"
+      echo "  --since DATE          Generate notes since the given date (e.g., 2025-08-06)"
+      echo "  --previous-hash HASH  Generate notes since the given commit hash"
       exit 1
       ;;
     *)
@@ -80,10 +80,10 @@ done
 # Validate arguments
 if [ "$since" = "" ] && [ "$previous_hash" = "" ]
 then
-  echo "This script requires either --since or --previous-release-hash option."
-  echo "Usage: $0 [--since DATE | --previous-release-hash HASH]"
-  echo "  --since DATE                    Generate notes since the given date (e.g., 2025-08-06)"
-  echo "  --previous-release-hash HASH    Generate notes since the given commit hash"
+  echo "This script requires either --since or --previous-hash option."
+  echo "Usage: $0 [--since DATE | --previous-hash HASH]"
+  echo "  --since DATE          Generate notes since the given date (e.g., 2025-08-06)"
+  echo "  --previous-hash HASH  Generate notes since the given commit hash"
   echo ""
   echo "Legacy usage (deprecated): $0 DATE"
   exit 1

--- a/docs/scripts/release-note.sh
+++ b/docs/scripts/release-note.sh
@@ -55,13 +55,6 @@ do
       use_hash=true
       shift 2
       ;;
-    -*)
-      echo "Unknown option: $1"
-      echo "Usage: $0 [--since DATE | --previous-hash HASH]"
-      echo "  --since DATE          Generate notes since the given date (e.g., 2025-08-06)"
-      echo "  --previous-hash HASH  Generate notes since the given commit hash"
-      exit 1
-      ;;
     *)
       # Legacy positional argument support
       if [ "$since" = "" ] && [ "$previous_hash" = "" ]

--- a/docs/scripts/release-note.sh
+++ b/docs/scripts/release-note.sh
@@ -21,16 +21,13 @@ for candidate in \
   "$(which gh.exe)" \
   "/mnt/c/Program Files/GitHub CLI/gh.exe" \
   "/c/Program Files/GitHub CLI/gh.exe" \
-  "/cygdrive/c/Program Files/GitHub CLI/gh.exe"
-do
-  if [ -x "$candidate" ]
-  then
+  "/cygdrive/c/Program Files/GitHub CLI/gh.exe"; do
+  if [ -x "$candidate" ]; then
     gh="$candidate"
     break
   fi
 done
-if [ "$gh" = "" ] || ! [ -x "$gh" ]
-then
+if [ "$gh" = "" ] || ! [ -x "$gh" ]; then
   echo "File not found: gh or gh.exe"
   echo "GitHub CLI can be downloaded from https://cli.github.com"
   exit 1
@@ -42,37 +39,34 @@ use_hash=false
 since=""
 previous_hash=""
 
-while [[ $# -gt 0 ]]
-do
+while [[ $# -gt 0 ]]; do
   case $1 in
-    --since)
-      since="$2"
+  --since)
+    since="$2"
+    use_hash=false
+    shift 2
+    ;;
+  --previous-hash)
+    previous_hash="$2"
+    use_hash=true
+    shift 2
+    ;;
+  *)
+    # Legacy positional argument support
+    if [ "$since" = "" ] && [ "$previous_hash" = "" ]; then
+      since="$1"
       use_hash=false
-      shift 2
-      ;;
-    --previous-hash)
-      previous_hash="$2"
-      use_hash=true
-      shift 2
-      ;;
-    *)
-      # Legacy positional argument support
-      if [ "$since" = "" ] && [ "$previous_hash" = "" ]
-      then
-        since="$1"
-        use_hash=false
-      else
-        echo "Too many arguments or mixed argument styles"
-        exit 1
-      fi
-      shift
-      ;;
+    else
+      echo "Too many arguments or mixed argument styles"
+      exit 1
+    fi
+    shift
+    ;;
   esac
 done
 
 # Validate arguments
-if [ "$since" = "" ] && [ "$previous_hash" = "" ]
-then
+if [ "$since" = "" ] && [ "$previous_hash" = "" ]; then
   echo "This script requires either --since or --previous-hash option."
   echo "Usage: $0 [--since DATE | --previous-hash HASH]"
   echo "  --since DATE          Generate notes since the given date (e.g., 2025-08-06)"
@@ -83,8 +77,7 @@ then
 fi
 
 # Get commits based on the specified range
-if [ "$use_hash" = true ]
-then
+if [ "$use_hash" = true ]; then
   commits="$(git log --oneline "$previous_hash"..HEAD)"
 else
   commits="$(git log --oneline --since "$since")"
@@ -93,8 +86,7 @@ commitsCount="$(echo "$commits" | wc -l)"
 
 echo "=== Breaking changes ==="
 breakingChanges=""
-for i in $(seq "$commitsCount")
-do
+for i in $(seq "$commitsCount"); do
   line="$(echo "$commits" | head -n "$i" | tail -1)"
 
   # Get PR number from the git commit title
@@ -102,13 +94,11 @@ do
   [ "$pr" = "" ] && continue
 
   # Check if the PR is marked as a breaking change
-  if "$gh" issue view "$pr" --json labels | grep -q 'pr: breaking change'
-  then
+  if "$gh" issue view "$pr" --json labels | grep -q 'pr: breaking change'; then
     breakingChanges+="$line"
   fi
 done
-if [ "$breakingChanges" = "" ]
-then
+if [ "$breakingChanges" = "" ]; then
   echo "No breaking changes"
 else
   echo "$breakingChanges"
@@ -116,18 +106,15 @@ fi
 echo ""
 
 echo "=== All changes for this release ==="
-for i in $(seq "$commitsCount")
-do
+for i in $(seq "$commitsCount"); do
   line="$(echo "$commits" | head -n "$i" | tail -1)"
 
   result="$line"
   # Get PR number from the git commit title
   pr="$(echo "$line" | grep '#[1-9][0-9][0-9][0-9][0-9]*' | sed 's|.* (\#\([1-9][0-9][0-9][0-9][0-9]*\))|\1|')"
-  if [ "$pr" != "" ]
-  then
+  if [ "$pr" != "" ]; then
     # Mark breaking changes with "[BREAKING]"
-    if "$gh" issue view "$pr" --json labels | grep -q 'pr: breaking change'
-    then
+    if "$gh" issue view "$pr" --json labels | grep -q 'pr: breaking change'; then
       result="[BREAKING] $line"
     fi
   fi

--- a/docs/scripts/release-note.sh
+++ b/docs/scripts/release-note.sh
@@ -21,13 +21,16 @@ for candidate in \
   "$(which gh.exe)" \
   "/mnt/c/Program Files/GitHub CLI/gh.exe" \
   "/c/Program Files/GitHub CLI/gh.exe" \
-  "/cygdrive/c/Program Files/GitHub CLI/gh.exe"; do
-  if [ -x "$candidate" ]; then
+  "/cygdrive/c/Program Files/GitHub CLI/gh.exe"
+do
+  if [ -x "$candidate" ]
+  then
     gh="$candidate"
     break
   fi
 done
-if [ "x$gh" = "x" ] || ! [ -x "$gh" ]; then
+if [ "$gh" = "" ] || ! [ -x "$gh" ]
+then
   echo "File not found: gh or gh.exe"
   echo "GitHub CLI can be downloaded from https://cli.github.com"
   exit 1
@@ -39,7 +42,8 @@ use_hash=false
 since=""
 previous_hash=""
 
-while [[ $# -gt 0 ]]; do
+while [[ $# -gt 0 ]]
+do
   case $1 in
     --since)
       since="$2"
@@ -60,7 +64,8 @@ while [[ $# -gt 0 ]]; do
       ;;
     *)
       # Legacy positional argument support
-      if [ "x$since" = "x" ] && [ "x$previous_hash" = "x" ]; then
+      if [ "$since" = "" ] && [ "$previous_hash" = "" ]
+      then
         since="$1"
         use_hash=false
       else
@@ -73,7 +78,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Validate arguments
-if [ "x$since" = "x" ] && [ "x$previous_hash" = "x" ]; then
+if [ "$since" = "" ] && [ "$previous_hash" = "" ]
+then
   echo "This script requires either --since or --previous-release-hash option."
   echo "Usage: $0 [--since DATE | --previous-release-hash HASH]"
   echo "  --since DATE                    Generate notes since the given date (e.g., 2025-08-06)"
@@ -84,28 +90,32 @@ if [ "x$since" = "x" ] && [ "x$previous_hash" = "x" ]; then
 fi
 
 # Get commits based on the specified range
-if [ "$use_hash" = true ]; then
-  commits="$(git log --oneline $previous_hash..HEAD)"
+if [ "$use_hash" = true ]
+then
+  commits="$(git log --oneline "$previous_hash"..HEAD)"
 else
-  commits="$(git log --oneline --since $since)"
+  commits="$(git log --oneline --since "$since")"
 fi
 commitsCount="$(echo "$commits" | wc -l)"
 
 echo "=== Breaking changes ==="
 breakingChanges=""
-for i in $(seq $commitsCount); do
-  line="$(echo "$commits" | head -$i | tail -1)"
+for i in $(seq "$commitsCount")
+do
+  line="$(echo "$commits" | head -n "$i" | tail -1)"
 
   # Get PR number from the git commit title
   pr="$(echo "$line" | grep '#[1-9][0-9][0-9][0-9][0-9]*' | sed 's|.* (\#\([1-9][0-9][0-9][0-9][0-9]*\))|\1|')"
-  [ "x$pr" = "x" ] && continue
+  [ "$pr" = "" ] && continue
 
   # Check if the PR is marked as a breaking change
-  if "$gh" issue view $pr --json labels | grep -q 'pr: breaking change'; then
+  if "$gh" issue view "$pr" --json labels | grep -q 'pr: breaking change'
+  then
     breakingChanges+="$line"
   fi
 done
-if [ "x$breakingChanges" = "x" ]; then
+if [ "$breakingChanges" = "" ]
+then
   echo "No breaking changes"
 else
   echo "$breakingChanges"
@@ -113,19 +123,20 @@ fi
 echo ""
 
 echo "=== All changes for this release ==="
-for i in $(seq $commitsCount); do
-  line="$(echo "$commits" | head -$i | tail -1)"
+for i in $(seq "$commitsCount")
+do
+  line="$(echo "$commits" | head -n "$i" | tail -1)"
 
   result="$line"
-  for dummy in 1; do
-    # Get PR number from the git commit title
-    pr="$(echo "$line" | grep '#[1-9][0-9][0-9][0-9][0-9]*' | sed 's|.* (\#\([1-9][0-9][0-9][0-9][0-9]*\))|\1|')"
-    [ "x$pr" = "x" ] && break
-
+  # Get PR number from the git commit title
+  pr="$(echo "$line" | grep '#[1-9][0-9][0-9][0-9][0-9]*' | sed 's|.* (\#\([1-9][0-9][0-9][0-9][0-9]*\))|\1|')"
+  if [ "$pr" != "" ]
+  then
     # Mark breaking changes with "[BREAKING]"
-    if "$gh" issue view $pr --json labels | grep -q 'pr: breaking change'; then
+    if "$gh" issue view "$pr" --json labels | grep -q 'pr: breaking change'
+    then
       result="[BREAKING] $line"
     fi
-  done
+  fi
   echo "$result"
 done


### PR DESCRIPTION
This commit adds a new command-line argument for `docs/script/release-note.sh`, which is `--previous-release-hash`.
It will allow us to generate the release note at more finer granularity.

The current help message is following,
```
Usage: ./docs/scripts/release-note.sh [--since DATE | --previous-release-hash HASH]
  --since DATE                    Generate notes since the given date (e.g., 2025-08-06)
  --previous-release-hash HASH    Generate notes since the given commit hash

Legacy usage (deprecated): ./docs/scripts/release-note.sh DATE
```

Fixes
- https://github.com/shader-slang/slang/issues/5188
- https://github.com/shader-slang/slang/issues/6887