### PR TITLE
Fix atomic fp16 vector SPIRV emit

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -3753,7 +3753,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     if (as<IRVectorType>(atomicInst->getDataType())->getElementType()->getOp() ==
                         kIROp_HalfType)
                     {
-                        ensureExtensionDeclaration(toSlice("VK_NV_shader_atomic_float16_vector"));
+                        ensureExtensionDeclaration(toSlice("SPV_NV_shader_atomic_fp16_vector"));
                         requireSPIRVCapability(SpvCapabilityAtomicFloat16VectorNV);
                     }
                     break;
@@ -3781,7 +3781,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     if (as<IRVectorType>(atomicInst->getDataType())->getElementType()->getOp() ==
                         kIROp_HalfType)
                     {
-                        ensureExtensionDeclaration(toSlice("VK_NV_shader_atomic_float16_vector"));
+                        ensureExtensionDeclaration(toSlice("SPV_NV_shader_atomic_fp16_vector"));
                         requireSPIRVCapability(SpvCapabilityAtomicFloat16VectorNV);
                     }
                     break;

--- a/tests/spirv/atomic-float16-vector.slang
+++ b/tests/spirv/atomic-float16-vector.slang
@@ -1,0 +1,22 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry computeMain -stage compute -emit-spirv-directly
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):name=workBuffer
+RWStructuredBuffer<half2> workBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    half2 originalValue;
+    
+    // Direct atomic operation on half2 should trigger the SPV_NV_shader_atomic_fp16_vector extension
+    originalValue = __atomic_add(workBuffer[0], half2(1.0h, 2.0h));
+    
+    outputBuffer[0] = float(originalValue.x);
+    outputBuffer[1] = float(originalValue.y);
+}
+
+// CHECK: OpCapability AtomicFloat16VectorNV
+// CHECK: OpExtension "SPV_NV_shader_atomic_fp16_vector"


### PR DESCRIPTION
Update the SPIRV emit of atomic fp16 vector extension from its previous incorrect name to SPV_NV_shader_atomic_fp16_vector.