### PR TITLE
Fix `tests\bugs\op-select-return-composite.slang` Test Failing

### DIFF
--- a/tests/bugs/op-select-return-composite.slang
+++ b/tests/bugs/op-select-return-composite.slang
@@ -1,6 +1,6 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-d3d12 -output-using-type -use-dxil
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -output-using-type
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -output-using-type -profile spirv_1_3
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -output-using-type -profile sm_6_0
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;


### PR DESCRIPTION
What is fixed:
Since we make `vk` tests compile as GLSL, we must use a capability that specifies a GLSL equivalent.
If we do not do this, we will get an error since we are not specifying GLSL capabilities (but are specifying a profile).
Since a profile is specified, we emit capability errors.