### PR TITLE
Update capability atoms reference page

### DIFF
--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -526,6 +526,9 @@ Extensions
 `GL_NV_compute_shader_derivatives`
 > Represents the GL_NV_compute_shader_derivatives extension.
 
+`GL_NV_cooperative_vector`
+> Represents the GL_NV_cooperative_vector extension.
+
 `GL_NV_fragment_shader_barycentric`
 > Represents the GL_NV_fragment_shader_barycentric extension.
 
@@ -809,9 +812,6 @@ Extensions
 
 `spvVulkanMemoryModelKHR`
 > Represents the SPIR-V capability for vulkan memory model.
-
-`GL_NV_cooperative_vector`
-> Represents the GL_NV_cooperative_vector extension.
 
 Compound Capabilities
 ----------------------


### PR DESCRIPTION
This file is automatically overwritten by the build:

https://github.com/shader-slang/slang/blob/b7df3c7aa27301f88e31ed0a7bbf230688adab6a/source/slang/CMakeLists.txt#L68-L78

It is currently out of date (running the build gives rise to unstaged changes), so this PR updates it.