### PR TITLE
Let `flake.nix` users run Vulkan and CUDA tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,9 @@
           inherit system;
           config.allowUnfree = true; # Necessary for CUDA.
         };
+
+        # CUDA is not supported on all platforms, e.g. macOS.
+        cuda = if pkgs.stdenv.hostPlatform.isLinux then pkgs.cudatoolkit else pkgs.emptyDirectory;
       in
       {
         # We want to use Clang instead of GCC because it seems to behave better
@@ -49,7 +52,7 @@
             pkgs.python3
 
             # Needed for running some of the tests.
-            pkgs.cudatoolkit
+            cuda
             pkgs.xorg.libX11
 
             # Other useful tools.
@@ -62,7 +65,7 @@
 
           # Needed for running some of the tests.
           LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
-            pkgs.cudatoolkit
+            cuda
             pkgs.vulkan-loader
           ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,10 @@
     flake-utils.lib.eachDefaultSystem (
       system:
       let
-        pkgs = import nixpkgs { inherit system; };
+        pkgs = import nixpkgs {
+          inherit system;
+          config.allowUnfree = true; # Necessary for CUDA.
+        };
       in
       {
         # We want to use Clang instead of GCC because it seems to behave better
@@ -39,16 +42,28 @@
               }
             ])
 
+            # Needed for building.
             pkgs.clang
             pkgs.cmake
+            pkgs.ninja
+            pkgs.python3
+
+            # Needed for running some of the tests.
+            pkgs.cudatoolkit
+            pkgs.xorg.libX11
+
+            # Other useful tools.
             pkgs.gersemi
             pkgs.lldb
-            pkgs.ninja
             pkgs.nixfmt-rfc-style
             pkgs.prettier
-            pkgs.python3
             pkgs.shfmt
-            pkgs.xorg.libX11
+          ];
+
+          # Needed for running some of the tests.
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+            pkgs.cudatoolkit
+            pkgs.vulkan-loader
           ];
         };
       }


### PR DESCRIPTION
Before this PR:

```
$ build/Debug/bin/slang-test tests/language-feature/constants/static-array-indexing.slang
Supported backends: glslang spirv-dis clang genericcpp llvm spirv-opt
found test: 'tests/language-feature/constants/static-array-indexing.slang'
Check vk,vulkan: Not Supported
Check cuda: Not Supported
ignored test: 'tests/language-feature/constants/static-array-indexing.slang (dx11)' 

===
0% of tests passed (0/0), 1 tests ignored
===
```

After:

```
$ build/Debug/bin/slang-test tests/language-feature/constants/static-array-indexing.slang
Supported backends: glslang spirv-dis clang genericcpp nvrtc llvm spirv-opt
found test: 'tests/language-feature/constants/static-array-indexing.slang'
Check vk,vulkan: Supported
Check cuda: Supported
ignored test: 'tests/language-feature/constants/static-array-indexing.slang (dx11)' 

===
0% of tests passed (0/0), 1 tests ignored
===
```

However, this doesn't yet work correctly. For instance:

```
$ build/Debug/bin/slang-test tests/compute/half-calc.slang
Supported backends: glslang spirv-dis clang genericcpp nvrtc llvm spirv-opt
found test: 'tests/compute/half-calc.slang'
Check vk,vulkan: Supported
Check cuda: Supported
ignored test: 'tests/compute/half-calc.slang (dx12)' 
ignored test: 'tests/compute/half-calc.slang.1 (vk)' 
Unable to create renderer [CUDA] 
error: ERROR:
EXPECTED{{{
result code = 0
standard error = {
}
standard output = {
}
}}}
ACTUAL{{{
result code = 1
standard error = {
}
standard output = {
}
debug layer = {
cuInit(0) failed: (null) ((null))
At /home/sam/github/shader-slang/slang/external/slang-rhi/src/cuda/cuda-device.cpp:137
}
}}}

error: ERROR:
EXPECTED{{{
0
40400000
40C00000
41100000
}}}
ACTUAL{{{
}}}

ignored test: 'tests/compute/half-calc.slang.2 (cuda)' 
Retrying 1 failed tests...
Unable to create renderer [CUDA] 
error: ERROR:
EXPECTED{{{
result code = 0
standard error = {
}
standard output = {
}
}}}
ACTUAL{{{
result code = 1
standard error = {
}
standard output = {
}
debug layer = {
cuInit(0) failed: (null) ((null))
At /home/sam/github/shader-slang/slang/external/slang-rhi/src/cuda/cuda-device.cpp:137
}
}}}

error: ERROR:
EXPECTED{{{
0
40400000
40C00000
41100000
}}}
ACTUAL{{{
}}}

FAILED test: 'tests/compute/half-calc.slang.2 (cuda)' 

===
0% of tests passed (0/1), 3 tests ignored
===

1 failing tests:
---
tests/compute/half-calc.slang.2 (cuda)
---
```