### PR TITLE
Make the issue headings bigger

### DIFF
--- a/.github/ISSUE_TEMPLATE/compiler-bug.md
+++ b/.github/ISSUE_TEMPLATE/compiler-bug.md
@@ -7,24 +7,24 @@ assignees: ''
 
 ---
 
-**Issue Description**
+# Issue Description
 A clear and concise description of what the bug is.
 Before filing the issue, please make sure the bug can be reproduced with the latest release of Slang.
 
-**Reproducer Code**
+# Reproducer Code
 If the issue can be reproduced with a simple code, include the **self-contained** Slang code along with a `slangc` commandline invocation, or the C++ code that calls the Slang API to compile the code.
 
-**Expected Behavior**
+# Expected Behavior
 A clear and concise description of what you expected to happen, e.g. code should compile successfully, resulting SPIRV should have XXX opcode/capability.
 
-**Actual Behavior**
+# Actual Behavior
 A clear and concise description of what actually happened.
 
-**Environment:**
+# Environment
  - Slang Version (release version number or commit hash)
  - OS
  - GPU/Driver version, if the bug is a runtime result error.
-- Any related environment variables.
+ - Any related environment variables.
 
-**Additional context**
+# Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature-request---improvement.md
+++ b/.github/ISSUE_TEMPLATE/feature-request---improvement.md
@@ -7,14 +7,14 @@ assignees: ''
 
 ---
 
-**Problem Description**
+# Problem Description
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Preferred Solution**
+# Preferred Solution
 A clear and concise description of what you want to happen.
 
-**Alternative Solutions**
+# Alternative Solutions
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+# Additional context
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Currently the issue template makes the subtitle "bold". It is a little hard to navigate between the subtitle because the bold is not very obvious.

This commit makes them to use a bigger font.

Before the change,
<img width="839" height="488" alt="image" src="https://github.com/user-attachments/assets/08abec42-8389-4404-89a1-5a70670000cd" />

After the change,
<img width="840" height="544" alt="image" src="https://github.com/user-attachments/assets/e2ffdac1-f8dc-40fa-a317-8dda965f3377" />
