### PR TITLE
Remove the semantic decoration from the original entry struct

### DIFF
--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -1908,6 +1908,9 @@ private:
                     field->getKey(),
                     fieldParam);
 
+                // Remove the sementic info from the original struct
+                semanticInfoToRemove.add(field);
+
                 IRVarLayout* fieldLayout =
                     structTypeLayout ? structTypeLayout->getFieldLayout(fieldIndex) : nullptr;
                 if (varLayout)


### PR DESCRIPTION
When we legalize the entry point param, there are cases where we need to reconstruct a struct for the parameter and the original struct wouldn't be used. But if the user tries to use the origianl struct as a type for a function parameter, we will end up using both the original struct and the synthesized struct at the same time.

On Metal and WGSL, it causes an error when an identical semtaic is used on more than one variable.

This commit removes the semantics from the original struct after cloning the type.

Fixes https://github.com/shader-slang/slang/issues/8141
Related to https://github.com/shader-slang/slang/issues/7693