### PR TITLE
Allow `flake.nix` users to run Vulkan tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,14 @@
             pkgs.prettier
             pkgs.python3
             pkgs.shfmt
+            pkgs.vulkan-loader # Ensure this gets built to use in library path.
             pkgs.xorg.libX11
+          ];
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+            # In addition to this, running the Vulkan tests on Linux distros
+            # other than NixOS may require the use of nixGL:
+            # https://github.com/nix-community/nixGL
+            pkgs.vulkan-loader
           ];
         };
       }


### PR DESCRIPTION
This PR puts the [Khronos official Vulkan Loader](https://github.com/NixOS/nixpkgs/blob/6027c30c8e9810896b92429f0092f624f7b1aace/pkgs/by-name/vu/vulkan-loader/package.nix#L22-L27) in `LD_LIBRARY_PATH` for the `flake.nix` dev shell, allowing Vulkan tests to run.

For example, before this PR:

```
$ build/Debug/bin/slang-test tests/compute/array-param.slang
Supported backends: glslang spirv-dis clang gcc genericcpp llvm spirv-opt
found test: 'tests/compute/array-param.slang'
Check vk,vulkan: Not Supported
Check cuda: Not Supported
ignored test: 'tests/compute/array-param.slang (cuda)' 
passed test: 'tests/compute/array-param.slang.1 (cpu)' 
ignored test: 'tests/compute/array-param.slang.2 (dx11)' 
ignored test: 'tests/compute/array-param.slang.3 (dx12)' 
ignored test: 'tests/compute/array-param.slang.4 (vk)' 

===
100% of tests passed (1/1), 4 tests ignored
===
```

In contrast, after this PR (on an Ubuntu machine with an NVIDIA GPU):

```
$ nixGLNvidia build/Debug/bin/slang-test tests/compute/array-param.slang
Supported backends: glslang spirv-dis clang gcc genericcpp llvm spirv-opt
found test: 'tests/compute/array-param.slang'
Check vk,vulkan: Supported
Check cuda: Not Supported
ignored test: 'tests/compute/array-param.slang (cuda)' 
passed test: 'tests/compute/array-param.slang.1 (cpu)' 
ignored test: 'tests/compute/array-param.slang.2 (dx11)' 
ignored test: 'tests/compute/array-param.slang.3 (dx12)' 
passed test: 'tests/compute/array-param.slang.4 (vk)' 

===
100% of tests passed (2/2), 3 tests ignored
===
```