### PR TITLE
[CUDA] Fix incorrect `kIROp_RaytracingAccelerationStructureType` emitting logic

### DIFF
--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -214,6 +214,7 @@ SlangResult CUDASourceEmitter::calcTypeName(IRType* type, CodeGenTarget target, 
             out << "TensorView";
             return SLANG_OK;
         }
+    case kIROp_RaytracingAccelerationStructureType:
     case kIROp_HitObjectType:
         {
             out << "OptixTraversableHandle";
@@ -250,22 +251,6 @@ SlangResult CUDASourceEmitter::calcTypeName(IRType* type, CodeGenTarget target, 
                 break;
             }
 
-            break;
-        }
-    }
-
-    if (auto untypedBufferType = as<IRUntypedBufferResourceType>(type))
-    {
-        switch (untypedBufferType->getOp())
-        {
-        case kIROp_RaytracingAccelerationStructureType:
-            {
-                m_writer->emit("OptixTraversableHandle");
-                return SLANG_OK;
-                break;
-            }
-
-        default:
             break;
         }
     }

--- a/source/slang/slang-intrinsic-expand.cpp
+++ b/source/slang/slang-intrinsic-expand.cpp
@@ -446,7 +446,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
             // there is a format conversion required between the type associated by the resource and
             // the backing ImageFormat. Currently this is only implemented on CUDA, where there are
             // specialized versions of the RWTexture writes that will do a format conversion.
-            if (m_emitter->getTarget() == CodeGenTarget::CUDASource)
+            if (isCUDATarget(m_emitter->getTargetReq()))
             {
                 IRInst* resourceInst = m_callInst->getArg(0);
 

--- a/tests/cuda/raygeneration.slang
+++ b/tests/cuda/raygeneration.slang
@@ -1,6 +1,11 @@
 //TEST:SIMPLE(filecheck=CHECK): -target cuda
 //TEST:SIMPLE(filecheck=CHECK-PTX): -target ptx
 
+// Test that we emit a valid raygeneration kernel.
+// This test will fail if either: (1) `OptixTraversableHandle` is not emitted
+// as a local var for `RaytracingAccelerationStructure` or (2)`RaytracingAccelerationStructure`
+// is not hoisted into use-site.
+
 // CHECK: void{{.*}}raygenMain
 // CHECK-PTX: .visible .entry{{.*}}raygenMain
 

--- a/tests/cuda/raygeneration.slang
+++ b/tests/cuda/raygeneration.slang
@@ -1,0 +1,86 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda
+//TEST:SIMPLE(filecheck=CHECK-PTX): -target ptx
+
+// CHECK: void{{.*}}raygenMain
+// CHECK-PTX: .visible .entry{{.*}}raygenMain
+
+struct Ray {
+    float3 origin;
+    float t_min;
+    float3 dir;
+    float t_max;
+
+    __init(float3 origin, float3 dir, float t_min = 0.f, float t_max = 1000.0)
+    {
+        this.origin = origin;
+        this.dir = dir;
+        this.t_min = t_min;
+        this.t_max = t_max;
+    }
+
+    RayDesc to_ray_desc() { return { origin, t_min, dir, t_max }; }
+};
+
+
+struct Camera {
+    float3 position;
+    float3 image_u;
+    float3 image_v;
+    float3 image_w;
+
+    Ray get_ray(float2 uv)
+    {
+        uv = uv * 2 - 1;
+        float3 dir = normalize(uv.x * image_u + uv.y * image_v + image_w);
+        return Ray(position, dir);
+    }
+};
+
+struct Scene {
+    RaytracingAccelerationStructure tlas;
+
+    Camera camera;
+};
+
+struct Path {
+    uint2 pixel;
+    uint vertex_index;
+    Ray ray;
+    float3 thp;
+    float3 L;
+    int rng;
+
+    __init(uint2 pixel, Ray ray, int rng)
+    {
+        this.pixel = pixel;
+        this.vertex_index = 0;
+        this.ray = ray;
+        this.thp = float3(1);
+        this.L = float3(0);
+        this.rng = rng;
+    }
+};
+ParameterBlock<Scene> g_scene;
+RWTexture2D<float4> g_output;
+
+[require(sm_6_8, cuda)]
+[shader("raygeneration")]
+void raygenMain()
+{
+    uint2 pixel = DispatchRaysIndex().xy;
+    float3 L = float3(0);
+    Ray ray = g_scene.camera.get_ray(pixel.xy);
+    Path path = Path(pixel, ray, 1);
+    TraceRay(
+        g_scene.tlas,
+        0,
+        0xff,
+        0,
+        0,
+        0,
+        path.ray.to_ray_desc(),
+        path
+    );
+    L += path.L;
+    g_output[pixel] = float4(L, 1);
+}


### PR DESCRIPTION
Fixes: #8167

Current emitting logic does not work, this has been corrected.
The provided test ensures our CUDA code is valid by compiling PTX from it.

`m_writer->emit("OptixTraversableHandle");` should be `out <<` since `out` adds to type-name-cache; otherwise using a type twice will produce bad type-names (since we filled type-name cache with "" instead of "typeName")