### PR TITLE
Fix nextafter()

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -12381,18 +12381,36 @@ T nextafter(T x, T y)
         if (isnan(x)) return x;
         if (isnan(y)) return y;
         if (x == y) return y;
+
+        int delta = x < y ? 1 : -1;
+
         if (T is half)
         {
-            T delta = __realCast<T>(bit_cast<half>(uint16_t(1)));
-            return x + ((x < y) ? delta : -delta);
+            uint16_t val = bit_cast<uint16_t>(x);
+            if((val >> 15) != 0) // If we're negative, -1 acts like +1 on the float.
+                delta = -delta;
+            uint16_t nextval = val + uint16_t(delta);
+            if(((val^nextval) >> 15) != 0) // If sign bit changed
+                nextval += 0x8002; // Correct the overflow
+            return bit_cast<T>(nextval);
         }
         if (T is float)
         {
-            T delta = __realCast<T>(bit_cast<float>(uint32_t(1)));
-            return x + ((x < y) ? delta : -delta);
+            uint32_t val = bit_cast<uint32_t>(x);
+            if((val >> 31) != 0)
+                delta = -delta;
+            uint32_t nextval = val + uint32_t(delta);
+            if(((val^nextval) >> 31) != 0)
+                nextval += 0x80000002u;
+            return bit_cast<T>(nextval);
         }
-        T delta = __realCast<T>(bit_cast<double>(uint64_t(1)));
-        return x + ((x < y) ? delta : -delta);
+        uint64_t val = bit_cast<uint64_t>(x);
+        if((val >> 63) != 0)
+            delta = -delta;
+        uint64_t nextval = val + uint64_t(delta);
+        if(((val^nextval) >> 63) != 0)
+            nextval += 0x8000000000000002ull;
+        return bit_cast<T>(nextval);
     }
 }
 

--- a/tests/bugs/gh-8185.slang
+++ b/tests/bugs/gh-8185.slang
@@ -1,8 +1,8 @@
 //TEST_DISABLED(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -cpu -compute
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -dx12 -compute
+//TEST_DISABLED(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -dx12 -compute
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -compute
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -cuda -compute
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -wgpu -compute
+//TEST_DISABLED(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -cuda -compute
+//TEST_DISABLED(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -wgpu -compute
 
 //TEST_INPUT: ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;

--- a/tests/bugs/gh-8185.slang
+++ b/tests/bugs/gh-8185.slang
@@ -1,5 +1,5 @@
 //TEST_DISABLED(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -cpu -compute
-//TEST_DISABLED(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -dx12 -compute
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -dx12 -profile cs_6_2 -use-dxil -compute
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -emit-spirv-directly -compute
 //TEST_DISABLED(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -cuda -compute
 //TEST_DISABLED(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -wgpu -compute

--- a/tests/bugs/gh-8185.slang
+++ b/tests/bugs/gh-8185.slang
@@ -1,7 +1,7 @@
-//TEST_DISABLED(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -cpu -compute
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -cpu -compute -Xslang -DSKIP_HALF_PRECISION
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -dx12 -profile cs_6_2 -use-dxil -compute
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -emit-spirv-directly -compute
-//TEST_DISABLED(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -cuda -compute
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -cuda -compute -Xslang -DSKIP_HALF_PRECISION
 //TEST_DISABLED(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -wgpu -compute
 
 //TEST_INPUT: ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
@@ -24,12 +24,21 @@ void computeMain(int3 dispatchThreadID: SV_DispatchThreadID)
     outputBuffer[4] = bit_cast<uint32_t>(nextafter(1000.0f, 2000.0f)); // CHECK-NEXT: 447A0001
     outputBuffer[5] = bit_cast<uint32_t>(nextafter(-1000.0f, -1.0f)); // CHECK-NEXT: C479FFFF
 
+#ifdef SKIP_HALF_PRECISION
+    outputBuffer[6] = 1;
+    outputBuffer[7] = 1;
+    outputBuffer[8] = 0x8001;
+    outputBuffer[9] = 0x8001;
+    outputBuffer[10] = 0x63D1;
+    outputBuffer[11] = 0xE3CF;
+#else
     outputBuffer[6] = bit_cast<uint16_t>(nextafter(-0.0h, 1.0h)); // CHECK-NEXT: 1
     outputBuffer[7] = bit_cast<uint16_t>(nextafter(0.0h, 1.0h)); // CHECK-NEXT: 1
     outputBuffer[8] = bit_cast<uint16_t>(nextafter(-0.0h, -1.0h)); // CHECK-NEXT: 8001
     outputBuffer[9] = bit_cast<uint16_t>(nextafter(0.0h, -1.0h)); // CHECK-NEXT: 8001
     outputBuffer[10] = bit_cast<uint16_t>(nextafter(1000.0h, 2000.0h)); // CHECK-NEXT: 63D1
     outputBuffer[11] = bit_cast<uint16_t>(nextafter(-1000.0h, -1.0h)); // CHECK-NEXT: E3CF
+#endif
 
     // CHECK-NEXT: 1
     // CHECK-NEXT: 0

--- a/tests/bugs/gh-8185.slang
+++ b/tests/bugs/gh-8185.slang
@@ -1,6 +1,6 @@
 //TEST_DISABLED(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -cpu -compute
 //TEST_DISABLED(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -dx12 -compute
-//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -compute
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -emit-spirv-directly -compute
 //TEST_DISABLED(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -cuda -compute
 //TEST_DISABLED(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -wgpu -compute
 

--- a/tests/bugs/gh-8185.slang
+++ b/tests/bugs/gh-8185.slang
@@ -1,0 +1,52 @@
+//TEST_DISABLED(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -cpu -compute
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -dx12 -compute
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -compute
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -cuda -compute
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -wgpu -compute
+
+//TEST_INPUT: ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<uint> outputBuffer;
+
+void write_double(double f, int i)
+{
+    uint64_t v = bit_cast<uint64_t>(f);
+    outputBuffer[i] = uint32_t(v);
+    outputBuffer[i+1] = uint32_t(v >> 32);
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID: SV_DispatchThreadID)
+{
+    outputBuffer[0] = bit_cast<uint32_t>(nextafter(-0.0f, 1.0f)); // CHECK: 1
+    outputBuffer[1] = bit_cast<uint32_t>(nextafter(0.0f, 1.0f)); // CHECK-NEXT: 1
+    outputBuffer[2] = bit_cast<uint32_t>(nextafter(-0.0f, -1.0f)); // CHECK-NEXT: 80000001
+    outputBuffer[3] = bit_cast<uint32_t>(nextafter(0.0f, -1.0f)); // CHECK-NEXT: 80000001
+    outputBuffer[4] = bit_cast<uint32_t>(nextafter(1000.0f, 2000.0f)); // CHECK-NEXT: 447A0001
+    outputBuffer[5] = bit_cast<uint32_t>(nextafter(-1000.0f, -1.0f)); // CHECK-NEXT: C479FFFF
+
+    outputBuffer[6] = bit_cast<uint16_t>(nextafter(-0.0h, 1.0h)); // CHECK-NEXT: 1
+    outputBuffer[7] = bit_cast<uint16_t>(nextafter(0.0h, 1.0h)); // CHECK-NEXT: 1
+    outputBuffer[8] = bit_cast<uint16_t>(nextafter(-0.0h, -1.0h)); // CHECK-NEXT: 8001
+    outputBuffer[9] = bit_cast<uint16_t>(nextafter(0.0h, -1.0h)); // CHECK-NEXT: 8001
+    outputBuffer[10] = bit_cast<uint16_t>(nextafter(1000.0h, 2000.0h)); // CHECK-NEXT: 63D1
+    outputBuffer[11] = bit_cast<uint16_t>(nextafter(-1000.0h, -1.0h)); // CHECK-NEXT: E3CF
+
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 0
+    write_double(nextafter(-0.0l, 1.0l), 12);
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 0
+    write_double(nextafter(0.0l, 1.0l), 14);
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 80000000
+    write_double(nextafter(-0.0l, -1.0l), 16);
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 80000000
+    write_double(nextafter(0.0l, -1.0l), 18);
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 408F4000
+    write_double(nextafter(1000.0l, 2000.0l), 20);
+    // CHECK-NEXT: FFFFFFFF
+    // CHECK-NEXT: C08F3FFF
+    write_double(nextafter(-1000.0l, -1.0l), 22);
+}


### PR DESCRIPTION
Fixes #8185. The previous implementation is incorrect and basically only works in the `x = 0` case. `delta` was the smallest possible positive value representable as a float, but that's below the rounding error of addition with almost all reasonably sized floats.

This fixed implementation is based on bit twiddling instead. I've checked the float case against the C++ `nextafterf` with both a -inf -> inf and inf -> -inf sweep, in addition to the test included in this PR.