### PR TITLE
Initial rewrite of address-specialization pass

### DIFF
--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -2682,6 +2682,13 @@ DIAGNOSTIC(
     "cannot perform atomic operation because destination is neither groupshared nor from a device "
     "buffer.")
 
+DIAGNOSTIC(
+    41405,
+    Warning,
+    assignmentOfNonUserPointerToNestedPointer,
+    "assignment of a non-device 'Ptr<>' to a 'Ptr<Ptr<...>>', global-variable, or 'out' parameter, "
+    "is experimental")
+
 //
 // 5xxxx - Target code generation.
 //

--- a/source/slang/slang-ir-metal-legalize.cpp
+++ b/source/slang/slang-ir-metal-legalize.cpp
@@ -254,7 +254,7 @@ void legalizeIRForMetal(IRModule* module, DiagnosticSink* sink)
     legalizeEntryPointVaryingParamsForMetal(module, sink, entryPoints);
 
     MetalAddressSpaceAssigner metalAddressSpaceAssigner;
-    specializeAddressSpace(module, &metalAddressSpaceAssigner);
+    specializeAddressSpace(module, &metalAddressSpaceAssigner, sink);
 
     processInst(module->getModuleInst(), sink);
 }

--- a/source/slang/slang-ir-specialize-address-space.h
+++ b/source/slang/slang-ir-specialize-address-space.h
@@ -10,6 +10,7 @@ namespace Slang
 struct IRModule;
 struct IRInst;
 enum class AddressSpace : uint64_t;
+class DiagnosticSink;
 
 struct AddressSpaceSpecializationContext
 {
@@ -28,7 +29,10 @@ struct InitialAddressSpaceAssigner
 /// Specialize functions with reference/pointer parameters to use the correct address space
 /// based on the address space of the arguments.
 ///
-void specializeAddressSpace(IRModule* module, InitialAddressSpaceAssigner* addrSpaceAssigner);
+void specializeAddressSpace(
+    IRModule* module,
+    InitialAddressSpaceAssigner* addrSpaceAssigner,
+    DiagnosticSink* sink);
 
 /// Traverse the user graph of the initial insts and fix up address spaces to make sure they are
 /// consistent. This is needed after inlining a callee, the address space of the callee's

--- a/tests/language-feature/pointer/assign-addr-space-with-different-function.slang
+++ b/tests/language-feature/pointer/assign-addr-space-with-different-function.slang
@@ -1,0 +1,33 @@
+// This test is disabled sine Slang doesn't support address-space specialization of nested pointers.
+// Currently, Slang assumes all nested pointers are of the `UserPointer` address space.
+//DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -capability vk_mem_model+sm_6_0+spvGroupNonUniformBallot
+
+// Check for a warning that this test uses experimental behavior.
+//TEST:SIMPLE(filecheck=SPIRV):-stage compute -entry computeMain -target spirv -capability vk_mem_model+sm_6_0+spvGroupNonUniformBallot
+
+struct Data
+{
+    int value1;
+    float value2;
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0], stride=4):out,name=outputBuffer
+uniform int* outputBuffer;
+groupshared int shared;
+
+static int* ptr;
+
+void setPtrAddrSpace()
+{
+    //SPIRV: ([[# @LINE+1]]): warning 41405
+    ptr = &shared;
+    *ptr = 2;
+}
+
+void computeMain(uint3 group_thread_id: SV_GroupThreadID)
+{
+    setPtrAddrSpace();
+    outputBuffer[0] = *ptr;
+}
+// CHECK: 2
+// CHECK-NEXT: 0

--- a/tests/language-feature/pointer/groupshared-address-infered-from-out-param.slang
+++ b/tests/language-feature/pointer/groupshared-address-infered-from-out-param.slang
@@ -1,0 +1,40 @@
+// Tests if we handle passing groupshared address-space correctly through `out` parameters.
+//
+// This test is disabled sine Slang doesn't support address-space specialization of nested pointers & `out`.
+// Currently, Slang assumes all nested pointers are of the `UserPointer` address space.
+//DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -capability vk_mem_model+sm_6_0+spvGroupNonUniformBallot
+
+// Check for a warning that this test uses experimental behavior.
+//TEST:SIMPLE(filecheck=SPIRV):-stage compute -entry computeMain -target spirv -capability vk_mem_model+sm_6_0+spvGroupNonUniformBallot
+
+// Tests if we handle passing groupshared address-space correctly through `out` parameters.
+// CHECK: 1
+// CHECK-NEXT: 1
+// CHECK-NEXT: 2
+
+struct Data
+{
+    int value1;
+    int value2;
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0], stride=4):out,name=outputBuffer
+uniform int* outputBuffer;
+groupshared Data shared;
+
+void foo(out Data* ptr, int* output)
+{
+    shared = Data(1, 2);
+    // SPIRV: ([[# @LINE+1]]): warning 41405
+    ptr = &shared;
+    outputBuffer[0] = ptr->value1;
+}
+
+[numthreads(3, 1, 1)]
+void computeMain(uint3 group_thread_id: SV_GroupThreadID)
+{
+    Data* data = nullptr;
+    foo(data, outputBuffer);
+    outputBuffer[1] = data->value1;
+    outputBuffer[2] = data->value2;
+}

--- a/tests/language-feature/pointer/groupshared-address-type-needs-legalization.slang
+++ b/tests/language-feature/pointer/groupshared-address-type-needs-legalization.slang
@@ -1,0 +1,30 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly
+
+// Tests if we handle passing groupshared address-space pointers correctly to a function
+// when that data-type needs legalization (Data -> Data_natural due to `lower-buffer-element-type`).
+// CHECK: 1
+// CHECK-NEXT: 2
+// CHECK-NEXT: 0
+
+struct Data
+{
+    int value1;
+    int value2;
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0], stride=4):out,name=outputBuffer
+uniform int* outputBuffer;
+groupshared Data shared;
+
+void foo(Data* ptr)
+{
+    outputBuffer[0] = ptr.value1;
+    outputBuffer[1] = ptr.value2;
+}
+
+[numthreads(3, 1, 1)]
+void computeMain(uint3 group_thread_id: SV_GroupThreadID)
+{
+    shared = Data(1, 2);
+    foo(&shared);
+}

--- a/tests/language-feature/pointer/groupshared-ptr-to-physical.slang
+++ b/tests/language-feature/pointer/groupshared-ptr-to-physical.slang
@@ -1,0 +1,28 @@
+//TEST:SIMPLE(filecheck=SPIRV):-stage compute -entry computeMain -target spirv -capability vk_mem_model+sm_6_0+spvGroupNonUniformBallot
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -capability vk_mem_model+sm_6_0+spvGroupNonUniformBallot
+
+// Tests if we pass-through and handle pointers via groupshared-memory correctly.
+// Ensure SPIRV emits coherent operations here
+// SPIRV: OpEntryPoint
+// SPIRV-NOT: error
+
+// CHECK: 1
+// CHECK-NEXT: 0
+// CHECK-NEXT: 2
+// CHECK-NEXT: 0
+// CHECK-NEXT: 3
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name=outputBuffer
+uniform int* outputBuffer;
+
+groupshared int* sharedPtr[3];
+
+[numthreads(3, 1, 1)]
+void computeMain(uint3 group_thread_id: SV_GroupThreadID)
+{
+    sharedPtr[group_thread_id.x] = &outputBuffer[group_thread_id.x];
+    sharedPtr[group_thread_id.x] = sharedPtr[group_thread_id.x]+group_thread_id.x;
+    GroupMemoryBarrierWithGroupSync();
+
+    *sharedPtr[group_thread_id.x] = group_thread_id.x+1;
+}

--- a/tests/language-feature/pointer/load-store-groupshared-ptr-via-param.slang
+++ b/tests/language-feature/pointer/load-store-groupshared-ptr-via-param.slang
@@ -1,0 +1,36 @@
+//TEST:SIMPLE(filecheck=SPIRV):-stage compute -entry computeMain -target spirv -capability vk_mem_model+sm_6_0+spvGroupNonUniformBallot
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -capability vk_mem_model+sm_6_0+spvGroupNonUniformBallot
+
+// Tests if we pass-through and handle groupshared address space pointers correctly.
+// Ensure SPIRV emits coherent operations here
+// SPIRV: OpEntryPoint
+// SPIRV-NOT: error
+
+// CHECK: 1
+// CHECK-NEXT: 2
+// CHECK-NEXT: 0
+
+//TEST_INPUT:ubuffer(data=[0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+groupshared int[32] shared;
+
+void funcCall(uint3 group_thread_id: SV_GroupThreadID, groupshared int[32] sharedVar)
+{
+    outputBuffer[group_thread_id.x] = sharedVar[group_thread_id.x+1];
+}
+
+[numthreads(3, 1, 1)]
+void computeMain(uint3 group_thread_id: SV_GroupThreadID)
+{
+    if (WaveIsFirstLane())
+    {
+        shared[4] = 0;
+    }
+
+    // shared = {0, 1, 2, 0, 0, ...}
+    // (*sharedPtr) = {1, 2, 0, 0, ...}
+    shared[group_thread_id.x] = group_thread_id.x;
+    GroupMemoryBarrierWithGroupSync();
+    funcCall(group_thread_id, shared);
+}

--- a/tests/language-feature/pointer/load-store-groupshared-ptr-via-ptr.slang
+++ b/tests/language-feature/pointer/load-store-groupshared-ptr-via-ptr.slang
@@ -1,0 +1,39 @@
+//TEST:SIMPLE(filecheck=SPIRV):-stage compute -entry computeMain -target spirv -capability vk_mem_model+sm_6_0+spvGroupNonUniformBallot
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -capability vk_mem_model+sm_6_0+spvGroupNonUniformBallot
+
+// Tests if we pass-through and handle groupshared address space pointers correctly.
+// Ensure SPIRV emits coherent operations here
+// SPIRV: OpEntryPoint
+// SPIRV-NOT: error
+
+// CHECK: 1
+// CHECK-NEXT: 2
+// CHECK-NEXT: 0
+
+//TEST_INPUT:ubuffer(data=[0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+groupshared int[32] shared;
+
+void funcCall(uint3 group_thread_id: SV_GroupThreadID, Ptr<int> sharedPtr)
+{
+    outputBuffer[group_thread_id.x] = sharedPtr[group_thread_id.x];
+}
+
+[numthreads(3, 1, 1)]
+void computeMain(uint3 group_thread_id: SV_GroupThreadID)
+{
+    if (WaveIsFirstLane())
+    {
+        shared[4] = 0;
+    }
+    // we take a pointer to a groupshared array, offset of 1 element.
+    // This is to ensure that the pointer is working correctly.
+    Ptr<int> sharedPtr = &shared[1];
+
+    // shared = {0, 1, 2, 0, 0, ...}
+    // (*sharedPtr) = {1, 2, 0, 0, ...}
+    shared[group_thread_id.x] = group_thread_id.x;
+    GroupMemoryBarrierWithGroupSync();
+    funcCall(group_thread_id, sharedPtr);
+}

--- a/tests/language-feature/pointer/userpointer-as-out-param.slang
+++ b/tests/language-feature/pointer/userpointer-as-out-param.slang
@@ -1,0 +1,33 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -capability vk_mem_model+sm_6_0+spvGroupNonUniformBallot
+
+// Tests if we handle passing device address-space correctly through `out` parameters.
+// CHECK: 1
+// CHECK-NEXT: 1
+// CHECK-NEXT: 2
+
+struct Data
+{
+    int value1;
+    int value2;
+}
+
+//TEST_INPUT:ubuffer(data=[1 2 0], stride=4),name=inputBuffer
+uniform int* inputBuffer;
+
+//TEST_INPUT:ubuffer(data=[0 0 0], stride=4):out,name=outputBuffer
+uniform int* outputBuffer;
+
+void foo(out int* ptr, int* output)
+{
+    ptr = &inputBuffer[0];
+    outputBuffer[0] = ptr[0];
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 group_thread_id: SV_GroupThreadID)
+{
+    int* data = nullptr;
+    foo(data, outputBuffer);
+    outputBuffer[1] = data[0];
+    outputBuffer[2] = data[1];
+}

--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -176,7 +176,7 @@ static rhi::DeviceType _toRenderType(Slang::RenderApiType apiType)
             SLANG_RETURN_ON_FAIL(reader.expectArg(capabilities));
 
             List<UnownedStringSlice> values;
-            StringUtil::split(capabilities.getUnownedSlice(), ',', values);
+            StringUtil::split(capabilities.getUnownedSlice(), '+', values);
 
             for (const auto& value : values)
             {


### PR DESCRIPTION
Fixes: #8197 

Changes:
* Change the address-space specializer heuristic to be more stable & logically consistent for future additions
    * Track use-chains to determine address-spaces instead of setting-addr-space based on direct use-site.
* This change should make `groupshared`/`storage` pointers more functional.
* This pass is faster in the case of larger code bases ==> does not need to reiterate the IR for **every** changed address-space
    * Running the IR pass more than once should not be a huge-performance loss
* Fix a minor bug in how we parse capabilities since it is incorrect syntax: `+` should be used for join instead of `,`
* emit SPIR-V `VariablePointer` Capability in more scenarios

  

Known limitations that this PR will not address (requires significant additions to support):
1. We do not track address-space conflicts/inconsistencies
2. `out Ptr<T>` fails
    * I suspect with the new design we could support `out` via:
        * Recursively processing all `IRCall`
        * Specializing-address-space of arguments of an `out` parameter with `mapInstToAddrSpace[arg] = AddressSpaceNode(outParam);`
3.  `Ptr<Ptr<...>>` fails
    * Likely requires significant additional logic