### PR TITLE
Improved half/float16 support for CPU target

### DIFF
--- a/prelude/slang-cpp-scalar-intrinsics.h
+++ b/prelude/slang-cpp-scalar-intrinsics.h
@@ -20,6 +20,12 @@ namespace SLANG_PRELUDE_NAMESPACE
 #define SLANG_PRELUDE_PI 3.14159265358979323846
 #endif
 
+union Union16
+{
+    uint16_t u;
+    int16_t i;
+    half h;
+};
 
 union Union32
 {
@@ -61,8 +67,9 @@ SLANG_FORCE_INLINE float _bitCastUIntToFloat(uint32_t ui)
     return u.f;
 }
 
-// ----------------------------- F16 -----------------------------------------
+half U16_ashalf(uint16_t x);
 
+// ----------------------------- F16 -----------------------------------------
 
 // This impl is based on FloatToHalf that is in Slang codebase
 SLANG_FORCE_INLINE uint32_t f32tof16(const float value)
@@ -147,6 +154,233 @@ SLANG_FORCE_INLINE float f16tof32(const uint32_t value)
     }
 
     return _bitCastUIntToFloat(sign | (exponent << 23) | (mantissa << 13));
+}
+
+SLANG_FORCE_INLINE uint16_t F16_asuint(half h)
+{
+    Union16 u;
+    u.h = h;
+    return u.u;
+}
+
+SLANG_FORCE_INLINE int16_t F16_asint(half h)
+{
+    Union16 u;
+    u.h = h;
+    return u.i;
+}
+
+SLANG_FORCE_INLINE half F16_ceil(half f)
+{
+    return half(::ceilf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_floor(half f)
+{
+    return half(::floorf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_round(half f)
+{
+    return half(::roundf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_sin(half f)
+{
+    return half(::sinf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_cos(half f)
+{
+    return half(::cosf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_tan(half f)
+{
+    return half(::tanf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_asin(half f)
+{
+    return half(::asinf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_acos(half f)
+{
+    return half(::acosf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_atan(half f)
+{
+    return half(::atanf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_sinh(half f)
+{
+    return half(::sinhf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_cosh(half f)
+{
+    return half(::coshf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_tanh(half f)
+{
+    return half(::tanhf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_asinh(half f)
+{
+    return half(::asinhf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_acosh(half f)
+{
+    return half(::acosh(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_atanh(half f)
+{
+    return half(::atanh(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_log2(half f)
+{
+    return half(::log2f(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_log(half f)
+{
+    return half(::logf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_log10(half f)
+{
+    return half(::log10f(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_exp2(half f)
+{
+    return half(::exp2f(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_exp(half f)
+{
+    return half(::expf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_abs(half f)
+{
+    return U16_ashalf(F16_asuint(f)&0x7FFF);
+}
+
+SLANG_FORCE_INLINE half F16_trunc(half f)
+{
+    return half(::truncf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_sqrt(half f)
+{
+    return half(::sqrtf(float(f)));
+}
+
+SLANG_FORCE_INLINE bool F16_isnan(half f)
+{
+    uint16_t u = F16_asuint(f);
+    return (u&0x7C00) == 0x7C00 && (u&0x3FF) != 0;
+}
+
+SLANG_FORCE_INLINE bool F16_isfinite(half f)
+{
+    uint16_t u = F16_asuint(f);
+    return (u&0x7C00) != 0x7C00;
+}
+
+SLANG_FORCE_INLINE bool F16_isinf(half f)
+{
+    uint16_t u = F16_asuint(f);
+    return (u&0x7C00) == 0x7C00 && (u&0x3FF) == 0;
+}
+
+SLANG_FORCE_INLINE half F16_min(half a, half b)
+{
+    if(F16_isnan(a)) return b;
+    if(F16_isnan(b)) return a;
+    return a < b ? a : b;
+}
+
+SLANG_FORCE_INLINE half F16_max(half a, half b)
+{
+    if(F16_isnan(a)) return b;
+    if(F16_isnan(b)) return a;
+    return a > b ? a : b;
+}
+
+SLANG_FORCE_INLINE half F16_pow(half a, half b)
+{
+    return half(::powf(float(a), float(b)));
+}
+
+SLANG_FORCE_INLINE half F16_fmod(half a, half b)
+{
+    return half(::fmodf(float(a), float(b)));
+}
+
+SLANG_FORCE_INLINE half F16_remainder(half a, half b)
+{
+    return half(::remainderf(float(a), float(b)));
+}
+
+SLANG_FORCE_INLINE half F16_atan2(half a, half b)
+{
+    return half(::atan2f(float(a), float(b)));
+}
+
+SLANG_FORCE_INLINE half F16_frexp(half x, int* e)
+{
+    return half(::frexpf(float(x), e));
+}
+
+SLANG_FORCE_INLINE half F16_modf(half x, half* ip)
+{
+    float ipf;
+    float res = ::modff(float(x), &ipf);
+    *ip = half(ipf);
+    return half(res);
+}
+
+SLANG_FORCE_INLINE half F16_fma(half a, half b, half c)
+{
+    return half(::fmaf(float(a), float(b), float(c)));
+}
+
+SLANG_FORCE_INLINE half F16_calcSafeRadians(half radians)
+{
+    // Put 0 to 2pi cycles to cycle around 0 to 1
+    float a = float(radians) * (1.0f / float(SLANG_PRELUDE_PI * 2));
+    // Get truncated fraction, as value in  0 - 1 range
+    a = a - ::floorf(a);
+    // Convert back to 0 - 2pi range
+    return half(a * float(SLANG_PRELUDE_PI * 2));
+}
+
+SLANG_FORCE_INLINE half F16_rsqrt(half f)
+{
+    return half(1.0f / ::sqrtf(float(f)));
+}
+
+SLANG_FORCE_INLINE half F16_sign(half f)
+{
+    uint16_t u = F16_asuint(f);
+    if((u&0x7FFF) == 0) return f;
+    return (u&0x8000) != 0 ? U16_ashalf(0xBC00) : U16_ashalf(0x3C00);
+}
+
+SLANG_FORCE_INLINE half F16_frac(half h)
+{
+    float f = float(h);
+    return half(f - ::floorf(f));
 }
 
 // ----------------------------- F32 -----------------------------------------
@@ -656,6 +890,13 @@ SLANG_FORCE_INLINE uint32_t U16_countbits(uint16_t v)
     }
     return c;
 #endif
+}
+
+SLANG_FORCE_INLINE half U16_ashalf(uint16_t x)
+{
+    Union16 u;
+    u.u = x;
+    return u.h;
 }
 
 // ----------------------------- I16 -----------------------------------------

--- a/prelude/slang-cpp-types-core.h
+++ b/prelude/slang-cpp-types-core.h
@@ -271,6 +271,51 @@ SLANG_FORCE_INLINE Vector<T, n> _slang_vector_reshape(const Vector<OtherT, m> ot
 
 typedef uint32_t uint;
 
+#if __cplusplus >= 202302L
+#include <stdfloat> // C++23
+#else
+#define __STDC_WANT_IEC_60559_TYPES_EXT__
+#include <cfloat>
+#endif
+
+#ifdef FLT16_MIN
+typedef _Float16 half;
+#elif __STDCPP_FLOAT16_T__ == 1
+typedef std::float16_t half;
+#else
+uint32_t f32tof16(const float value);
+float f16tof32(const uint32_t value);
+struct half
+{
+    uint16_t data;
+
+    half() {}
+    explicit half(float f) { store(f); }
+
+    SLANG_FORCE_INLINE void store(float f) { data = f32tof16(f); }
+    SLANG_FORCE_INLINE float load() const { return f16tof32(data); }
+
+    half operator+(half other) const { return load() + other.load(); }
+    half operator-(half other) const { return load() - other.load(); }
+    half operator*(half other) const { return load() * other.load(); }
+    half operator/(half other) const { return load() / other.load(); }
+    half& operator+=(half other) { store(load() + other.load()); return *this; }
+    half& operator-=(half other) { store(load() - other.load()); return *this; }
+    half& operator*=(half other) { store(load() * other.load()); return *this; }
+    half& operator/=(half other) { store(load() / other.load()); return *this; }
+
+    bool operator<(half other) const { return load() < other.load(); }
+    bool operator>(half other) const { return load() > other.load(); }
+    bool operator<=(half other) const { return load() <= other.load(); }
+    bool operator>=(half other) const { return load() >= other.load(); }
+    bool operator==(half other) const { return load() == other.load(); }
+    bool operator!=(half other) const { return load() != other.load(); }
+
+    explicit operator float() const { return load(); }
+};
+#endif
+
+
 #define SLANG_VECTOR_BINARY_OP(T, op)            \
     template<int n>                              \
     SLANG_FORCE_INLINE Vector<T, n> operator op( \

--- a/prelude/slang-cpp-types-core.h
+++ b/prelude/slang-cpp-types-core.h
@@ -295,10 +295,10 @@ struct half
     SLANG_FORCE_INLINE void store(float f) { data = f32tof16(f); }
     SLANG_FORCE_INLINE float load() const { return f16tof32(data); }
 
-    half operator+(half other) const { return load() + other.load(); }
-    half operator-(half other) const { return load() - other.load(); }
-    half operator*(half other) const { return load() * other.load(); }
-    half operator/(half other) const { return load() / other.load(); }
+    half operator+(half other) const { return half(load() + other.load()); }
+    half operator-(half other) const { return half(load() - other.load()); }
+    half operator*(half other) const { return half(load() * other.load()); }
+    half operator/(half other) const { return half(load() / other.load()); }
     half& operator+=(half other) { store(load() + other.load()); return *this; }
     half& operator-=(half other) { store(load() - other.load()); return *this; }
     half& operator*=(half other) { store(load() * other.load()); return *this; }

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -7348,7 +7348,7 @@ matrix<uint,N,M> asuint(matrix<uint,N,M> x)
 // Float->unsigned cases:
 
 [__readNone]
-[require(cuda_glsl_hlsl_spirv, shader5_sm_5_0)]
+[require(cpp_cuda_glsl_hlsl_spirv, shader5_sm_5_0)]
 uint16_t asuint16(float16_t value)
 {
     __target_switch
@@ -7359,11 +7359,13 @@ uint16_t asuint16(float16_t value)
     case spirv: return spirv_asm {
         OpBitcast $$uint16_t result $value
     };
+    default:
+        return bit_cast<uint16_t>(value);
     }
 }
 
 [__readNone]
-[require(cuda_glsl_hlsl_spirv, shader5_sm_5_0)]
+[require(cpp_cuda_glsl_hlsl_spirv, shader5_sm_5_0)]
 vector<uint16_t,N> asuint16<let N : int>(vector<float16_t,N> value)
 {
     __target_switch
@@ -7378,14 +7380,14 @@ vector<uint16_t,N> asuint16<let N : int>(vector<float16_t,N> value)
 }
 
 [__readNone]
-[require(cuda_glsl_hlsl_spirv, shader5_sm_5_0)]
+[require(cpp_cuda_glsl_hlsl_spirv, shader5_sm_5_0)]
 matrix<uint16_t,R,C> asuint16<let R : int, let C : int>(matrix<float16_t,R,C> value)
 { MATRIX_MAP_UNARY(uint16_t, R, C, asuint16, value); }
 
 // Unsigned->float cases:
 
 [__readNone]
-[require(cuda_glsl_hlsl_spirv, shader5_sm_5_0)]
+[require(cpp_cuda_glsl_hlsl_spirv, shader5_sm_5_0)]
 float16_t asfloat16(uint16_t value)
 {
     __target_switch
@@ -7396,6 +7398,8 @@ float16_t asfloat16(uint16_t value)
     case spirv: return spirv_asm {
         OpBitcast $$float16_t result $value
     };
+    default:
+        return bit_cast<float16_t>(value);
     }
 }
 

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -1062,6 +1062,13 @@ void CPPSourceEmitter::emitSimpleValueImpl(IRInst* inst)
     if (inst->getOp() == kIROp_FloatLit)
     {
         IRConstant* constantInst = static_cast<IRConstant*>(inst);
+
+        IRType* type = constantInst->getDataType();
+        if (type && type->getOp() == kIROp_HalfType)
+        {
+            m_writer->emit("half(");
+        }
+
         switch (constantInst->getFloatKind())
         {
         case IRConstant::FloatKind::Nan:
@@ -1088,13 +1095,17 @@ void CPPSourceEmitter::emitSimpleValueImpl(IRInst* inst)
 
                 // If the literal is a float, then we need to add 'f' at end, as
                 // without literal suffix the value defaults to double.
-                IRType* type = constantInst->getDataType();
                 if (type && type->getOp() == kIROp_FloatType)
                 {
                     m_writer->emitChar('f');
                 }
                 break;
             }
+        }
+
+        if (type && type->getOp() == kIROp_HalfType)
+        {
+            m_writer->emit(")");
         }
     }
     else

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -100,12 +100,8 @@ static const char s_xyzwNames[] = "xyzw";
         return UnownedStringSlice("uint64_t");
     case kIROp_UIntPtrType:
         return UnownedStringSlice("uintptr_t");
-
-        // Not clear just yet how we should handle half... we want all processing as float
-        // probly, but when reading/writing to memory converting
     case kIROp_HalfType:
         return UnownedStringSlice("half");
-
     case kIROp_FloatType:
         return UnownedStringSlice("float");
     case kIROp_DoubleType:
@@ -240,12 +236,6 @@ SlangResult CPPSourceEmitter::calcTypeName(IRType* type, CodeGenTarget target, S
 {
     switch (type->getOp())
     {
-    case kIROp_HalfType:
-        {
-            // Special case half
-            out << getBuiltinTypeName(kIROp_FloatType);
-            return SLANG_OK;
-        }
     case kIROp_VectorType:
         {
             auto vecType = static_cast<IRVectorType*>(type);

--- a/tests/hlsl-intrinsic/scalar-half.slang
+++ b/tests/hlsl-intrinsic/scalar-half.slang
@@ -1,0 +1,96 @@
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -dx12 -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//DISABLED_TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-wgpu -compute -shaderobj
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    int idx = int(dispatchThreadID.x);
+    
+    half f = half(idx) * 1.0h / 4.0h;
+
+    half ft = 0.0h;
+    
+    // fmod
+    ft += trunc(((f % 0.11h) * 100) + 0.5h);
+    
+    ft += sin(f);
+    ft += cos(f);
+    ft += tan(f);
+    
+    ft += asin(f);
+    ft += acos(f);
+    ft += atan(f);
+    
+    ft += length(f - 0.5h);
+    
+    ft += atan2(f, 2.0h);
+    
+    {
+        half sf, cf;
+        sincos(f, sf, cf);
+        
+        ft += sf;
+        ft += cf;
+    }
+    
+    ft += rcp(1.0h + f);
+    ft += half(sign(f - 0.5h));
+    
+    ft += saturate(f * 4 - 2.0h);
+    
+    ft += sqrt(f);
+    ft += rsqrt(1.0h + f);
+    
+    ft += exp2(f);
+    ft += exp(f);
+        
+        
+    ft += frac(f * 3);
+    ft += ceil(f * 5 - 3);
+    
+    ft += floor(f * 10 - 7);
+    ft += trunc(f * 7);
+     
+   
+    ft += log(f + 10.0h);
+    ft += log2(f * 3 + 2);
+
+    {
+        half v[] = { 1, 10, 100, 1000 };
+        ft += trunc(log10(v[idx]) + 0.5h);
+    }
+       
+    ft += abs(f * 4 - 2.0h);
+    
+    ft += min(0.5h, f);
+    ft += max(f, 0.75h);
+
+    ft += pow(0.5h, f);
+
+    ft += smoothstep(0.2h, 0.7h, f);
+    ft += lerp(-100, 100, f);
+
+
+    ft += clamp(f, 0.1h, 0.3h);
+
+    ft += step(f, 0.5h);
+
+    int vi = asint16(f - f) + idx;
+    
+    ft += half(vi);
+
+    ft += ldexp(23.2h, f);
+
+    uint16_t vu = asuint16(f);
+    ft += asfloat16(vu);
+    
+    outputBuffer[idx] = int(ft * 16);
+}


### PR DESCRIPTION
Most fp16 features are currently unavailable on the CPU target, so much so that `half` was getting lowered as `float`. Almost all `F16_*` intrinsics lacked an implementation, despite calls to them being emitted. This PR implements working, but potentially really slow implementations for the type, so that it can be used. Most of the implemented intrinsics work by converting halfs to floats for computation.

The core problem here is that while GCC and Clang can support FP16 via `_Float16` and `std::float16_t`, MSVC doesn't support either. Implementing this feature by always using the built-in type would've been ideal, since they can utilize actual hardware: AVX512 has some FP16 extension, for example, and apparently GCC has some optimized SSE2 implementation of float<->half conversion. ARM also has some FP16 instructions apparently.

DRAFT: needs more testing; should check if the `_Float16` path works via `-mavx512fp16` 