### PR TITLE
Fix reflection JSON writing userAttribs section twice for some cases.

### DIFF
--- a/source/slang/slang-reflection-json.cpp
+++ b/source/slang/slang-reflection-json.cpp
@@ -420,8 +420,6 @@ static void emitReflectionVarLayoutJSON(PrettyWriter& writer, slang::VariableLay
     emitReflectionModifierInfoJSON(writer, var->getVariable());
 
     emitReflectionVarBindingInfoJSON(writer, var);
-
-    emitUserAttributes(writer, var->getVariable());
     writer.dedent();
     writer << "\n}";
 }

--- a/tests/reflection/attribute.slang.expected
+++ b/tests/reflection/attribute.slang.expected
@@ -35,15 +35,7 @@ standard output = {
                                     ]
                                 }
                             ],
-                            "binding": {"kind": "uniform", "offset": 4, "size": 4, "elementStride": 0},
-                            "userAttribs": [
-                                {
-                                    "name": "DefaultValue",
-                                    "arguments": [
-                                        1
-                                    ]
-                                }
-                            ]
+                            "binding": {"kind": "uniform", "offset": 4, "size": 4, "elementStride": 0}
                         }
                     ],
                     "userAttribs": [
@@ -87,15 +79,7 @@ standard output = {
                                         ]
                                     }
                                 ],
-                                "binding": {"kind": "uniform", "offset": 4, "size": 4, "elementStride": 0},
-                                "userAttribs": [
-                                    {
-                                        "name": "DefaultValue",
-                                        "arguments": [
-                                            1
-                                        ]
-                                    }
-                                ]
+                                "binding": {"kind": "uniform", "offset": 4, "size": 4, "elementStride": 0}
                             }
                         ],
                         "userAttribs": [
@@ -144,15 +128,7 @@ standard output = {
                                     ]
                                 }
                             ],
-                            "binding": {"kind": "uniform", "offset": 4, "size": 4, "elementStride": 0},
-                            "userAttribs": [
-                                {
-                                    "name": "DefaultValue",
-                                    "arguments": [
-                                        2
-                                    ]
-                                }
-                            ]
+                            "binding": {"kind": "uniform", "offset": 4, "size": 4, "elementStride": 0}
                         }
                     ],
                     "userAttribs": [
@@ -196,15 +172,7 @@ standard output = {
                                         ]
                                     }
                                 ],
-                                "binding": {"kind": "uniform", "offset": 4, "size": 4, "elementStride": 0},
-                                "userAttribs": [
-                                    {
-                                        "name": "DefaultValue",
-                                        "arguments": [
-                                            2
-                                        ]
-                                    }
-                                ]
+                                "binding": {"kind": "uniform", "offset": 4, "size": 4, "elementStride": 0}
                             }
                         ],
                         "userAttribs": [


### PR DESCRIPTION
`emitReflectionVarLayoutJSON` will output the `userAttribs` section twice as it gets output by `emitReflectionModifierInfoJSON` first before being output again by a direct call to `emitUserAttributes`.

It seems the answer here is to just remove the extra explicit call to `emitUserAttributes` and rely on the call in `emitReflectionModifierInfoJSON`?