### PR TITLE
Fix SPIRV emission crash for static const variables from cbuffer members

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -2345,7 +2345,9 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 // Global field address operations can occur for cbuffer field access.
                 // Emit this as a field address operation.
                 auto fieldAddrInst = as<IRFieldAddress>(inst);
-                return emitFieldAddress(getSection(SpvLogicalSectionID::ConstantsAndTypes), fieldAddrInst);
+                return emitFieldAddress(
+                    getSection(SpvLogicalSectionID::ConstantsAndTypes),
+                    fieldAddrInst);
             }
         default:
             {

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -2332,6 +2332,21 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             return emitDebugInlinedAt(
                 getSection(SpvLogicalSectionID::ConstantsAndTypes),
                 as<IRDebugInlinedAt>(inst));
+        case kIROp_Load:
+            {
+                // Global loads are not typical in SPIRV, but we can handle the case where
+                // we're loading from a field address (e.g., cbuffer member) by emitting
+                // the load operation directly into the constants section.
+                auto loadInst = as<IRLoad>(inst);
+                return emitLoad(getSection(SpvLogicalSectionID::ConstantsAndTypes), loadInst);
+            }
+        case kIROp_FieldAddress:
+            {
+                // Global field address operations can occur for cbuffer field access.
+                // Emit this as a field address operation.
+                auto fieldAddrInst = as<IRFieldAddress>(inst);
+                return emitFieldAddress(getSection(SpvLogicalSectionID::ConstantsAndTypes), fieldAddrInst);
+            }
         default:
             {
                 if (isSpecConstRateType(inst->getFullType()))

--- a/tests/bugs/static-const-cbuffer-member-spirv-8212.slang
+++ b/tests/bugs/static-const-cbuffer-member-spirv-8212.slang
@@ -3,7 +3,7 @@
 // Test for issue #8212: slangc crashes when initializing "static const" variable to cbuffer member for SPIRV target
 // This test verifies that the compilation doesn't crash, which was the main issue.
 
-extern static const float VALUE = Value;
+static const float VALUE = Value;
 
 cbuffer Options
 {
@@ -18,5 +18,6 @@ void computeMain(uint3 thread_id : SV_DispatchThreadID)
 {
     outputBuffer[thread_id.x] = float4(thread_id.y + VALUE);
 }
+
 
 // SPIRV: OpTypeFloat

--- a/tests/bugs/static-const-cbuffer-member-spirv-8212.slang
+++ b/tests/bugs/static-const-cbuffer-member-spirv-8212.slang
@@ -1,0 +1,22 @@
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -emit-spirv-directly -profile cs_6_2 -entry computeMain
+
+// Test for issue #8212: slangc crashes when initializing "static const" variable to cbuffer member for SPIRV target
+// This test verifies that the compilation doesn't crash, which was the main issue.
+
+extern static const float VALUE = Value;
+
+cbuffer Options
+{
+    float Value;
+}
+
+RWStructuredBuffer<float4> outputBuffer;
+
+[numthreads(1, 1, 1)]
+[shader("compute")]
+void computeMain(uint3 thread_id : SV_DispatchThreadID)
+{
+    outputBuffer[thread_id.x] = float4(thread_id.y + VALUE);
+}
+
+// SPIRV: OpTypeFloat


### PR DESCRIPTION
Fixes issue #8212 where slangc would crash when compiling static const variables initialized with cbuffer members for SPIRV targets.

The issue was that the SPIRV emitter's emitGlobalInst() function did not handle kIROp_Load and kIROp_FieldAddress instructions at global scope.

Generated with [Claude Code](https://claude.ai/code)