### PR TITLE
Add record and replay support for IComponentType2

### DIFF
--- a/source/slang-record-replay/record/parameter-recorder.h
+++ b/source/slang-record-replay/record/parameter-recorder.h
@@ -40,6 +40,16 @@ public:
     {
         recordValue(reinterpret_cast<SlangRecord::AddressFormat>(value));
     }
+    void recordGuid(const SlangUUID& guid)
+    {
+        recordValue(guid.data1);
+        recordValue(guid.data2);
+        recordValue(guid.data3);
+        for (int i = 0; i < 8; i++)
+        {
+            recordValue(guid.data4[i]);
+        }
+    }
     void recordStruct(SlangGlobalSessionDesc const& desc);
     void recordStruct(slang::SessionDesc const& desc);
     void recordStruct(slang::PreprocessorMacroDesc const& desc);

--- a/source/slang-record-replay/record/slang-component-type.h
+++ b/source/slang-record-replay/record/slang-component-type.h
@@ -21,6 +21,8 @@ public:
         slang::IComponentType* componentType,
         RecordManager* recordManager);
 
+    ISlangUnknown* getInterface(const Guid& guid);
+
     virtual SLANG_NO_THROW slang::ISession* SLANG_MCALL getSession() override;
     virtual SLANG_NO_THROW slang::ProgramLayout* SLANG_MCALL
     getLayout(SlangInt targetIndex = 0, slang::IBlob** outDiagnostics = nullptr) override;

--- a/source/slang-record-replay/record/slang-component-type2.cpp
+++ b/source/slang-record-replay/record/slang-component-type2.cpp
@@ -1,0 +1,91 @@
+#include "slang-component-type2.h"
+
+#include "../util/record-utility.h"
+#include "slang-composite-component-type.h"
+#include "slang-session.h"
+
+namespace SlangRecord
+{
+IComponentType2Recorder::IComponentType2Recorder(
+    slang::IComponentType2* componentType,
+    RecordManager* recordManager)
+    : m_actualComponentType2(componentType), m_recordManager(recordManager)
+{
+    SLANG_RECORD_ASSERT(m_actualComponentType2 != nullptr);
+    SLANG_RECORD_ASSERT(m_recordManager != nullptr);
+
+    m_componentType2Handle = reinterpret_cast<uint64_t>(m_actualComponentType2.get());
+    slangRecordLog(LogLevel::Verbose, "%s: %p\n", __PRETTY_FUNCTION__, componentType);
+}
+
+ISlangUnknown* IComponentType2Recorder::getInterface(const Guid& guid)
+{
+    if (guid == IComponentType2Recorder::getTypeGuid())
+        return static_cast<IComponentType2Recorder*>(this);
+    else
+        return nullptr;
+}
+
+SlangResult IComponentType2Recorder::getTargetCompileResult(
+    SlangInt targetIndex,
+    slang::ICompileResult** outCompileResult,
+    slang::IBlob** outDiagnostics)
+{
+    slangRecordLog(LogLevel::Verbose, "%s\n", __PRETTY_FUNCTION__);
+
+    ApiCallId callId = static_cast<ApiCallId>(
+        makeApiCallId(getClassId(), IComponentTypeMethodId::getTargetCompileResult));
+    ParameterRecorder* recorder{};
+    {
+        recorder = m_recordManager->beginMethodRecord(callId, m_componentType2Handle);
+        recorder->recordInt64(targetIndex);
+        recorder = m_recordManager->endMethodRecord();
+    }
+
+    SlangResult res = m_actualComponentType2->getTargetCompileResult(
+        targetIndex,
+        outCompileResult,
+        outDiagnostics);
+    {
+        recorder->recordAddress(*outCompileResult);
+        recorder->recordAddress(outDiagnostics ? *outDiagnostics : nullptr);
+        m_recordManager->apendOutput();
+    }
+
+    return res;
+}
+
+SlangResult IComponentType2Recorder::getEntryPointCompileResult(
+    SlangInt entryPointIndex,
+    SlangInt targetIndex,
+    slang::ICompileResult** outCompileResult,
+    slang::IBlob** outDiagnostics)
+{
+    slangRecordLog(LogLevel::Verbose, "%s\n", __PRETTY_FUNCTION__);
+
+    ApiCallId callId = static_cast<ApiCallId>(
+        makeApiCallId(getClassId(), IComponentTypeMethodId::getEntryPointCompileResult));
+    ParameterRecorder* recorder{};
+    {
+        recorder = m_recordManager->beginMethodRecord(callId, m_componentType2Handle);
+        recorder->recordInt64(entryPointIndex);
+        recorder->recordInt64(targetIndex);
+        recorder = m_recordManager->endMethodRecord();
+    }
+
+    SlangResult res = m_actualComponentType2->getEntryPointCompileResult(
+        entryPointIndex,
+        targetIndex,
+        outCompileResult,
+        outDiagnostics);
+
+    {
+        recorder->recordAddress(*outCompileResult);
+        recorder->recordAddress(outDiagnostics ? *outDiagnostics : nullptr);
+        m_recordManager->apendOutput();
+    }
+
+    return res;
+}
+
+} // namespace SlangRecord

--- a/source/slang-record-replay/record/slang-component-type2.h
+++ b/source/slang-record-replay/record/slang-component-type2.h
@@ -1,0 +1,53 @@
+#ifndef SLANG_COMPONENT_TYPE2_H
+#define SLANG_COMPONENT_TYPE2_H
+
+#include "../../core/slang-smart-pointer.h"
+#include "../../slang/slang-compiler.h"
+#include "../util/record-utility.h"
+#include "record-manager.h"
+#include "slang-com-helper.h"
+#include "slang-com-ptr.h"
+#include "slang.h"
+
+namespace SlangRecord
+{
+using namespace Slang;
+
+class IComponentType2Recorder : public slang::IComponentType2, public RefObject
+{
+public:
+    SLANG_COM_INTERFACE(
+        0x0c23c81d,
+        0x7e08,
+        0x4a71,
+        {0xa3, 0x0e, 0x90, 0xa2, 0xd7, 0x8a, 0xe4, 0x87})
+
+    SLANG_REF_OBJECT_IUNKNOWN_ALL
+    ISlangUnknown* getInterface(const Guid& guid);
+
+    explicit IComponentType2Recorder(
+        slang::IComponentType2* componentType,
+        RecordManager* recordManager);
+
+    virtual SLANG_NO_THROW SlangResult SLANG_MCALL getTargetCompileResult(
+        SlangInt targetIndex,
+        slang::ICompileResult** outCompileResult,
+        slang::IBlob** outDiagnostics = nullptr) override;
+    virtual SLANG_NO_THROW SlangResult SLANG_MCALL getEntryPointCompileResult(
+        SlangInt entryPointIndex,
+        SlangInt targetIndex,
+        slang::ICompileResult** outCompileResult,
+        slang::IBlob** outDiagnostics = nullptr) override;
+
+    slang::IComponentType2* getActualComponentType() const { return m_actualComponentType2; }
+
+protected:
+    virtual ApiClassId getClassId() { return ApiClassId::Class_IComponentType2; }
+
+    Slang::ComPtr<slang::IComponentType2> m_actualComponentType2;
+    uint64_t m_componentType2Handle = 0;
+    RecordManager* m_recordManager = nullptr;
+};
+} // namespace SlangRecord
+
+#endif // #ifndef SLANG_COMPONENT_TYPE2_H

--- a/source/slang-record-replay/record/slang-composite-component-type.cpp
+++ b/source/slang-record-replay/record/slang-composite-component-type.cpp
@@ -16,8 +16,8 @@ CompositeComponentTypeRecorder::CompositeComponentTypeRecorder(
 ISlangUnknown* CompositeComponentTypeRecorder::getInterface(const Guid& guid)
 {
     // Record the queryInterface call
-    ApiCallId callId = static_cast<ApiCallId>(
-        makeApiCallId(getClassId(), IComponentTypeMethodId::queryInterface));
+    ApiCallId callId =
+        static_cast<ApiCallId>(makeApiCallId(getClassId(), IComponentTypeMethodId::queryInterface));
     ParameterRecorder* recorder{};
     {
         recorder = m_recordManager->beginMethodRecord(callId, m_componentHandle);

--- a/source/slang-record-replay/record/slang-composite-component-type.cpp
+++ b/source/slang-record-replay/record/slang-composite-component-type.cpp
@@ -19,6 +19,7 @@ ISlangUnknown* CompositeComponentTypeRecorder::getInterface(const Guid& guid)
     {
         return static_cast<ISlangUnknown*>(this);
     }
-    return nullptr;
+    // Delegate to the base class for IComponentType2 support.
+    return IComponentTypeRecorder::getInterface(guid);
 }
 } // namespace SlangRecord

--- a/source/slang-record-replay/replay/decoder-consumer.h
+++ b/source/slang-record-replay/replay/decoder-consumer.h
@@ -459,6 +459,19 @@ public:
         uint32_t compilerOptionEntryCount,
         slang::CompilerOptionEntry* compilerOptionEntries,
         ObjectID outDiagnosticsId) = 0;
+
+    // IComponentType2 methods.
+    virtual void IComponentType2_getTargetCompileResult(
+        ObjectID objectId,
+        SlangInt targetIndex,
+        ObjectID outCompileResultId,
+        ObjectID outDiagnosticsId) = 0;
+    virtual void IComponentType2_getEntryPointCompileResult(
+        ObjectID objectId,
+        SlangInt entryPointIndex,
+        SlangInt targetIndex,
+        ObjectID outCompileResultId,
+        ObjectID outDiagnosticsIdId) = 0;
 };
 } // namespace SlangRecord
 

--- a/source/slang-record-replay/replay/decoder-consumer.h
+++ b/source/slang-record-replay/replay/decoder-consumer.h
@@ -399,6 +399,11 @@ public:
         slang::CompilerOptionEntry* compilerOptionEntries,
         ObjectID outDiagnosticsId) = 0;
 
+    virtual void ICompositeComponentType_queryInterface(
+        ObjectID objectId,
+        const SlangUUID& guid,
+        ObjectID outInterfaceId) = 0;
+
     // ITypeConformance
     virtual void ITypeConformance_getSession(ObjectID objectId, ObjectID outSessionId) = 0;
     virtual void ITypeConformance_getLayout(

--- a/source/slang-record-replay/replay/json-consumer.cpp
+++ b/source/slang-record-replay/replay/json-consumer.cpp
@@ -624,9 +624,17 @@ void CommonInterfaceWriter::queryInterface(
 
             Slang::String guidString = Slang::StringUtil::makeStringWithFormat(
                 "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-                guid.data1, guid.data2, guid.data3,
-                guid.data4[0], guid.data4[1], guid.data4[2], guid.data4[3],
-                guid.data4[4], guid.data4[5], guid.data4[6], guid.data4[7]);
+                guid.data1,
+                guid.data2,
+                guid.data3,
+                guid.data4[0],
+                guid.data4[1],
+                guid.data4[2],
+                guid.data4[3],
+                guid.data4[4],
+                guid.data4[5],
+                guid.data4[6],
+                guid.data4[7]);
             _writePair(builder, indent, "guid", guidString);
 
             _writePairNoComma(

--- a/source/slang-record-replay/replay/json-consumer.cpp
+++ b/source/slang-record-replay/replay/json-consumer.cpp
@@ -603,6 +603,44 @@ void CommonInterfaceWriter::getEntryPointCompileResult(
     m_fileStream.flush();
 }
 
+void CommonInterfaceWriter::queryInterface(
+    ObjectID objectId,
+    const SlangUUID& guid,
+    ObjectID outInterfaceId)
+{
+    Slang::StringBuilder builder;
+    int indent = 0;
+
+    Slang::String functionName = m_className;
+    functionName = functionName + "::queryInterface";
+    {
+        ScopeWritterForKey scopeWritter(&builder, &indent, functionName);
+        {
+            _writePair(
+                builder,
+                indent,
+                "this",
+                Slang::StringUtil::makeStringWithFormat("0x%llX", objectId));
+
+            Slang::String guidString = Slang::StringUtil::makeStringWithFormat(
+                "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+                guid.data1, guid.data2, guid.data3,
+                guid.data4[0], guid.data4[1], guid.data4[2], guid.data4[3],
+                guid.data4[4], guid.data4[5], guid.data4[6], guid.data4[7]);
+            _writePair(builder, indent, "guid", guidString);
+
+            _writePairNoComma(
+                builder,
+                indent,
+                "outInterface",
+                Slang::StringUtil::makeStringWithFormat("0x%llX", outInterfaceId));
+        }
+    }
+
+    m_fileStream.write(builder.begin(), builder.getLength());
+    m_fileStream.flush();
+}
+
 JsonConsumer::JsonConsumer(const Slang::String& filePath)
 {
     if (!Slang::File::exists(Slang::Path::getParentDirectory(filePath)))
@@ -3004,6 +3042,14 @@ void JsonConsumer::ICompositeComponentType_linkWithOptions(
         outDiagnosticsId);
 }
 
+void JsonConsumer::ICompositeComponentType_queryInterface(
+    ObjectID objectId,
+    const SlangUUID& guid,
+    ObjectID outInterfaceId)
+{
+    SANITY_CHECK();
+    m_compositeComponentTypeHelper.queryInterface(objectId, guid, outInterfaceId);
+}
 
 // ITypeConformance
 void JsonConsumer::ITypeConformance_getSession(ObjectID objectId, ObjectID outSessionId)

--- a/source/slang-record-replay/replay/json-consumer.cpp
+++ b/source/slang-record-replay/replay/json-consumer.cpp
@@ -527,6 +527,81 @@ void CommonInterfaceWriter::linkWithOptions(
     m_fileStream.flush();
 }
 
+void CommonInterfaceWriter::getTargetCompileResult(
+    ObjectID objectId,
+    SlangInt targetIndex,
+    ObjectID outCompileResultId,
+    ObjectID outDiagnosticsId)
+{
+    Slang::StringBuilder builder;
+    int indent = 0;
+
+    Slang::String functionName = m_className;
+    functionName = functionName + "::getTargetCompileResult";
+    {
+        ScopeWritterForKey scopeWritter(&builder, &indent, functionName);
+        {
+            _writePair(
+                builder,
+                indent,
+                "this",
+                Slang::StringUtil::makeStringWithFormat("0x%llX", objectId));
+            _writePair(builder, indent, "targetIndex", targetIndex);
+            _writePair(
+                builder,
+                indent,
+                "outCompileResult",
+                Slang::StringUtil::makeStringWithFormat("0x%llX", outCompileResultId));
+            _writePairNoComma(
+                builder,
+                indent,
+                "outDiagnostics",
+                Slang::StringUtil::makeStringWithFormat("0x%llX", outDiagnosticsId));
+        }
+    }
+
+    m_fileStream.write(builder.begin(), builder.getLength());
+    m_fileStream.flush();
+}
+
+void CommonInterfaceWriter::getEntryPointCompileResult(
+    ObjectID objectId,
+    SlangInt entryPointIndex,
+    SlangInt targetIndex,
+    ObjectID outCompileResultId,
+    ObjectID outDiagnosticsId)
+{
+    Slang::StringBuilder builder;
+    int indent = 0;
+
+    Slang::String functionName = m_className;
+    functionName = functionName + "::getEntryPointCompileResult";
+    {
+        ScopeWritterForKey scopeWritter(&builder, &indent, functionName);
+        {
+            _writePair(
+                builder,
+                indent,
+                "this",
+                Slang::StringUtil::makeStringWithFormat("0x%llX", objectId));
+            _writePair(builder, indent, "entryPointIndex", entryPointIndex);
+            _writePair(builder, indent, "targetIndex", targetIndex);
+            _writePair(
+                builder,
+                indent,
+                "outCompileResult",
+                Slang::StringUtil::makeStringWithFormat("0x%llX", outCompileResultId));
+            _writePairNoComma(
+                builder,
+                indent,
+                "outDiagnostics",
+                Slang::StringUtil::makeStringWithFormat("0x%llX", outDiagnosticsId));
+        }
+    }
+
+    m_fileStream.write(builder.begin(), builder.getLength());
+    m_fileStream.flush();
+}
 
 JsonConsumer::JsonConsumer(const Slang::String& filePath)
 {
@@ -3063,6 +3138,33 @@ void JsonConsumer::ITypeConformance_linkWithOptions(
         outLinkedComponentTypeId,
         compilerOptionEntryCount,
         compilerOptionEntries,
+        outDiagnosticsId);
+}
+
+void JsonConsumer::IComponentType2_getTargetCompileResult(
+    ObjectID objectId,
+    SlangInt targetIndex,
+    ObjectID outCompileResultId,
+    ObjectID outDiagnosticsId)
+{
+    SANITY_CHECK();
+    m_componentType2Helper
+        .getTargetCompileResult(objectId, targetIndex, outCompileResultId, outDiagnosticsId);
+}
+
+void JsonConsumer::IComponentType2_getEntryPointCompileResult(
+    ObjectID objectId,
+    SlangInt entryPointIndex,
+    SlangInt targetIndex,
+    ObjectID outCompileResultId,
+    ObjectID outDiagnosticsId)
+{
+    SANITY_CHECK();
+    m_componentType2Helper.getEntryPointCompileResult(
+        objectId,
+        entryPointIndex,
+        targetIndex,
+        outCompileResultId,
         outDiagnosticsId);
 }
 }; // namespace SlangRecord

--- a/source/slang-record-replay/replay/json-consumer.h
+++ b/source/slang-record-replay/replay/json-consumer.h
@@ -85,10 +85,7 @@ public:
         slang::CompilerOptionEntry* compilerOptionEntries,
         ObjectID outDiagnosticsId);
 
-    void queryInterface(
-        ObjectID objectId,
-        const SlangUUID& guid,
-        ObjectID outInterfaceId);
+    void queryInterface(ObjectID objectId, const SlangUUID& guid, ObjectID outInterfaceId);
 
     // IComponentType2 methods.
     void getTargetCompileResult(
@@ -151,13 +148,16 @@ public:
         ObjectID objectId,
         SlangSourceLanguage inSourceLanguage,
         ObjectID outPreludeId) override;
-    virtual void IGlobalSession_createCompileRequest(ObjectID objectId, ObjectID outCompileRequest) override;
+    virtual void IGlobalSession_createCompileRequest(ObjectID objectId, ObjectID outCompileRequest)
+        override;
     virtual void IGlobalSession_addBuiltins(
         ObjectID objectId,
         char const* sourcePath,
         char const* sourceString) override;
-    virtual void IGlobalSession_setSharedLibraryLoader(ObjectID objectId, ObjectID loaderId) override;
-    virtual void IGlobalSession_getSharedLibraryLoader(ObjectID objectId, ObjectID outLoaderId) override;
+    virtual void IGlobalSession_setSharedLibraryLoader(ObjectID objectId, ObjectID loaderId)
+        override;
+    virtual void IGlobalSession_getSharedLibraryLoader(ObjectID objectId, ObjectID outLoaderId)
+        override;
     virtual void IGlobalSession_checkCompileTargetSupport(
         ObjectID objectId,
         SlangCompileTarget target) override;
@@ -186,9 +186,13 @@ public:
         SlangCompileTarget source,
         SlangCompileTarget target) override;
 
-    virtual void IGlobalSession_getCompilerElapsedTime(ObjectID objectId) override { (void)objectId; }
+    virtual void IGlobalSession_getCompilerElapsedTime(ObjectID objectId) override
+    {
+        (void)objectId;
+    }
 
-    virtual void IGlobalSession_setSPIRVCoreGrammar(ObjectID objectId, char const* jsonPath) override;
+    virtual void IGlobalSession_setSPIRVCoreGrammar(ObjectID objectId, char const* jsonPath)
+        override;
     virtual void IGlobalSession_parseCommandLineArguments(
         ObjectID objectId,
         int argc,
@@ -286,11 +290,13 @@ public:
         SlangInt conformanceIdOverride,
         ObjectID outDiagnosticsId) override;
 
-    virtual void ISession_createCompileRequest(ObjectID objectId, ObjectID outCompileRequestId) override;
+    virtual void ISession_createCompileRequest(ObjectID objectId, ObjectID outCompileRequestId)
+        override;
 
     virtual void ISession_getLoadedModuleCount(ObjectID objectId) override { (void)objectId; }
 
-    virtual void ISession_getLoadedModule(ObjectID objectId, SlangInt index, ObjectID outModuleId) override;
+    virtual void ISession_getLoadedModule(ObjectID objectId, SlangInt index, ObjectID outModuleId)
+        override;
 
     virtual void ISession_isBinaryModuleUpToDate(ObjectID objectId) override { (void)objectId; }
 
@@ -385,7 +391,10 @@ public:
         ObjectID outDiagnosticsId,
         ObjectID retProgramLayoutId) override;
 
-    virtual void IEntryPoint_getSpecializationParamCount(ObjectID objectId) override { (void)objectId; };
+    virtual void IEntryPoint_getSpecializationParamCount(ObjectID objectId) override
+    {
+        (void)objectId;
+    }
 
     virtual void IEntryPoint_getEntryPointCode(
         ObjectID objectId,
@@ -436,7 +445,8 @@ public:
         ObjectID outDiagnosticsId) override;
 
     // ICompositeComponentType
-    virtual void ICompositeComponentType_getSession(ObjectID objectId, ObjectID outSessionId) override;
+    virtual void ICompositeComponentType_getSession(ObjectID objectId, ObjectID outSessionId)
+        override;
     virtual void ICompositeComponentType_getLayout(
         ObjectID objectId,
         SlangInt targetIndex,

--- a/source/slang-record-replay/replay/json-consumer.h
+++ b/source/slang-record-replay/replay/json-consumer.h
@@ -85,6 +85,11 @@ public:
         slang::CompilerOptionEntry* compilerOptionEntries,
         ObjectID outDiagnosticsId);
 
+    void queryInterface(
+        ObjectID objectId,
+        const SlangUUID& guid,
+        ObjectID outInterfaceId);
+
     // IComponentType2 methods.
     void getTargetCompileResult(
         ObjectID objectId,
@@ -490,6 +495,11 @@ public:
         uint32_t compilerOptionEntryCount,
         slang::CompilerOptionEntry* compilerOptionEntries,
         ObjectID outDiagnosticsId) override;
+
+    virtual void ICompositeComponentType_queryInterface(
+        ObjectID objectId,
+        const SlangUUID& guid,
+        ObjectID outInterfaceId) override;
 
     // ITypeConformance
     virtual void ITypeConformance_getSession(ObjectID objectId, ObjectID outSessionId) override;

--- a/source/slang-record-replay/replay/json-consumer.h
+++ b/source/slang-record-replay/replay/json-consumer.h
@@ -28,6 +28,9 @@ public:
         case ApiClassId::Class_ITypeConformance:
             m_className = "ITypeConformance";
             break;
+        case ApiClassId::Class_IComponentType2:
+            m_className = "IComponentType2";
+            break;
         default:
             slangRecordLog(LogLevel::Error, "Invalid classNo %u\n", classId);
             break;
@@ -82,6 +85,19 @@ public:
         slang::CompilerOptionEntry* compilerOptionEntries,
         ObjectID outDiagnosticsId);
 
+    // IComponentType2 methods.
+    void getTargetCompileResult(
+        ObjectID objectId,
+        SlangInt targetIndex,
+        ObjectID outCompileResultId,
+        ObjectID outDiagnosticsId);
+    void getEntryPointCompileResult(
+        ObjectID objectId,
+        SlangInt entryPointIndex,
+        SlangInt targetIndex,
+        ObjectID outCompileResultId,
+        ObjectID outDiagnosticsId);
+
 protected:
     Slang::String m_className;
     Slang::FileStream& m_fileStream;
@@ -94,98 +110,98 @@ public:
     virtual ~JsonConsumer() = default;
     virtual void CreateGlobalSession(
         SlangGlobalSessionDesc const& desc,
-        ObjectID outGlobalSessionId);
+        ObjectID outGlobalSessionId) override;
     virtual void IGlobalSession_createSession(
         ObjectID objectId,
         slang::SessionDesc const& desc,
-        ObjectID outSessionId);
-    virtual void IGlobalSession_findProfile(ObjectID objectId, char const* name);
+        ObjectID outSessionId) override;
+    virtual void IGlobalSession_findProfile(ObjectID objectId, char const* name) override;
     virtual void IGlobalSession_setDownstreamCompilerPath(
         ObjectID objectId,
         SlangPassThrough passThrough,
-        char const* path);
+        char const* path) override;
     virtual void IGlobalSession_setDownstreamCompilerPrelude(
         ObjectID objectId,
         SlangPassThrough inPassThrough,
-        char const* prelude);
+        char const* prelude) override;
     virtual void IGlobalSession_getDownstreamCompilerPrelude(
         ObjectID objectId,
         SlangPassThrough inPassThrough,
-        ObjectID outPreludeId);
+        ObjectID outPreludeId) override;
 
-    virtual void IGlobalSession_getBuildTagString(ObjectID objectId) { (void)objectId; }
+    virtual void IGlobalSession_getBuildTagString(ObjectID objectId) override { (void)objectId; }
 
     virtual void IGlobalSession_setDefaultDownstreamCompiler(
         ObjectID objectId,
         SlangSourceLanguage sourceLanguage,
-        SlangPassThrough defaultCompiler);
+        SlangPassThrough defaultCompiler) override;
     virtual void IGlobalSession_getDefaultDownstreamCompiler(
         ObjectID objectId,
-        SlangSourceLanguage sourceLanguage);
+        SlangSourceLanguage sourceLanguage) override;
     virtual void IGlobalSession_setLanguagePrelude(
         ObjectID objectId,
         SlangSourceLanguage inSourceLanguage,
-        char const* prelude);
+        char const* prelude) override;
     virtual void IGlobalSession_getLanguagePrelude(
         ObjectID objectId,
         SlangSourceLanguage inSourceLanguage,
-        ObjectID outPreludeId);
-    virtual void IGlobalSession_createCompileRequest(ObjectID objectId, ObjectID outCompileRequest);
+        ObjectID outPreludeId) override;
+    virtual void IGlobalSession_createCompileRequest(ObjectID objectId, ObjectID outCompileRequest) override;
     virtual void IGlobalSession_addBuiltins(
         ObjectID objectId,
         char const* sourcePath,
-        char const* sourceString);
-    virtual void IGlobalSession_setSharedLibraryLoader(ObjectID objectId, ObjectID loaderId);
-    virtual void IGlobalSession_getSharedLibraryLoader(ObjectID objectId, ObjectID outLoaderId);
+        char const* sourceString) override;
+    virtual void IGlobalSession_setSharedLibraryLoader(ObjectID objectId, ObjectID loaderId) override;
+    virtual void IGlobalSession_getSharedLibraryLoader(ObjectID objectId, ObjectID outLoaderId) override;
     virtual void IGlobalSession_checkCompileTargetSupport(
         ObjectID objectId,
-        SlangCompileTarget target);
+        SlangCompileTarget target) override;
     virtual void IGlobalSession_checkPassThroughSupport(
         ObjectID objectId,
-        SlangPassThrough passThrough);
+        SlangPassThrough passThrough) override;
     virtual void IGlobalSession_compileCoreModule(
         ObjectID objectId,
-        slang::CompileCoreModuleFlags flags);
+        slang::CompileCoreModuleFlags flags) override;
     virtual void IGlobalSession_loadCoreModule(
         ObjectID objectId,
         const void* coreModule,
-        size_t coreModuleSizeInBytes);
+        size_t coreModuleSizeInBytes) override;
     virtual void IGlobalSession_saveCoreModule(
         ObjectID objectId,
         SlangArchiveType archiveType,
-        ObjectID outBlobId);
-    virtual void IGlobalSession_findCapability(ObjectID objectId, char const* name);
+        ObjectID outBlobId) override;
+    virtual void IGlobalSession_findCapability(ObjectID objectId, char const* name) override;
     virtual void IGlobalSession_setDownstreamCompilerForTransition(
         ObjectID objectId,
         SlangCompileTarget source,
         SlangCompileTarget target,
-        SlangPassThrough compiler);
+        SlangPassThrough compiler) override;
     virtual void IGlobalSession_getDownstreamCompilerForTransition(
         ObjectID objectId,
         SlangCompileTarget source,
-        SlangCompileTarget target);
+        SlangCompileTarget target) override;
 
-    virtual void IGlobalSession_getCompilerElapsedTime(ObjectID objectId) { (void)objectId; }
+    virtual void IGlobalSession_getCompilerElapsedTime(ObjectID objectId) override { (void)objectId; }
 
-    virtual void IGlobalSession_setSPIRVCoreGrammar(ObjectID objectId, char const* jsonPath);
+    virtual void IGlobalSession_setSPIRVCoreGrammar(ObjectID objectId, char const* jsonPath) override;
     virtual void IGlobalSession_parseCommandLineArguments(
         ObjectID objectId,
         int argc,
         const char* const* argv,
         ObjectID outSessionDescId,
-        ObjectID outAllocationId);
+        ObjectID outAllocationId) override;
     virtual void IGlobalSession_getSessionDescDigest(
         ObjectID objectId,
         slang::SessionDesc* sessionDesc,
-        ObjectID outBlobId);
+        ObjectID outBlobId) override;
 
     // ISession
-    virtual void ISession_getGlobalSession(ObjectID objectId, ObjectID outGlobalSessionId);
+    virtual void ISession_getGlobalSession(ObjectID objectId, ObjectID outGlobalSessionId) override;
     virtual void ISession_loadModule(
         ObjectID objectId,
         const char* moduleName,
         ObjectID outDiagnostics,
-        ObjectID outModuleId);
+        ObjectID outModuleId) override;
 
     virtual void ISession_loadModuleFromIRBlob(
         ObjectID objectId,
@@ -193,27 +209,27 @@ public:
         const char* path,
         slang::IBlob* source,
         ObjectID outDiagnosticsId,
-        ObjectID outModuleId);
+        ObjectID outModuleId) override;
     virtual void ISession_loadModuleFromSource(
         ObjectID objectId,
         const char* moduleName,
         const char* path,
         slang::IBlob* source,
         ObjectID outDiagnosticsId,
-        ObjectID outModuleId);
+        ObjectID outModuleId) override;
     virtual void ISession_loadModuleFromSourceString(
         ObjectID objectId,
         const char* moduleName,
         const char* path,
         const char* string,
         ObjectID outDiagnosticsId,
-        ObjectID outModuleId);
+        ObjectID outModuleId) override;
     virtual void ISession_createCompositeComponentType(
         ObjectID objectId,
         ObjectID* componentTypeIds,
         SlangInt componentTypeCount,
         ObjectID outCompositeComponentTypeIds,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
 
     virtual void ISession_specializeType(
         ObjectID objectId,
@@ -221,7 +237,7 @@ public:
         slang::SpecializationArg const* specializationArgs,
         SlangInt specializationArgCount,
         ObjectID outDiagnosticsId,
-        ObjectID outTypeReflectionId);
+        ObjectID outTypeReflectionId) override;
 
     virtual void ISession_getTypeLayout(
         ObjectID objectId,
@@ -229,33 +245,33 @@ public:
         SlangInt targetIndex,
         slang::LayoutRules rules,
         ObjectID outDiagnosticsId,
-        ObjectID outTypeLayoutReflection);
+        ObjectID outTypeLayoutReflection) override;
 
     virtual void ISession_getContainerType(
         ObjectID objectId,
         ObjectID elementType,
         slang::ContainerType containerType,
         ObjectID outDiagnosticsId,
-        ObjectID outTypeReflectionId);
+        ObjectID outTypeReflectionId) override;
 
-    virtual void ISession_getDynamicType(ObjectID objectId, ObjectID outTypeReflectionId);
+    virtual void ISession_getDynamicType(ObjectID objectId, ObjectID outTypeReflectionId) override;
 
     virtual void ISession_getTypeRTTIMangledName(
         ObjectID objectId,
         ObjectID typeId,
-        ObjectID outNameBlobId);
+        ObjectID outNameBlobId) override;
 
     virtual void ISession_getTypeConformanceWitnessMangledName(
         ObjectID objectId,
         ObjectID typeId,
         ObjectID interfaceTypeId,
-        ObjectID outNameBlobId);
+        ObjectID outNameBlobId) override;
 
     virtual void ISession_getTypeConformanceWitnessSequentialID(
         ObjectID objectId,
         ObjectID typeId,
         ObjectID interfaceTypeId,
-        uint32_t outId);
+        uint32_t outId) override;
 
     virtual void ISession_createTypeConformanceComponentType(
         ObjectID objectId,
@@ -263,278 +279,291 @@ public:
         ObjectID interfaceTypeId,
         ObjectID outConformanceId,
         SlangInt conformanceIdOverride,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
 
-    virtual void ISession_createCompileRequest(ObjectID objectId, ObjectID outCompileRequestId);
+    virtual void ISession_createCompileRequest(ObjectID objectId, ObjectID outCompileRequestId) override;
 
-    virtual void ISession_getLoadedModuleCount(ObjectID objectId) { (void)objectId; }
+    virtual void ISession_getLoadedModuleCount(ObjectID objectId) override { (void)objectId; }
 
-    virtual void ISession_getLoadedModule(ObjectID objectId, SlangInt index, ObjectID outModuleId);
+    virtual void ISession_getLoadedModule(ObjectID objectId, SlangInt index, ObjectID outModuleId) override;
 
-    virtual void ISession_isBinaryModuleUpToDate(ObjectID objectId) { (void)objectId; }
+    virtual void ISession_isBinaryModuleUpToDate(ObjectID objectId) override { (void)objectId; }
 
     // IModule
     virtual void IModule_findEntryPointByName(
         ObjectID objectId,
         char const* name,
-        ObjectID outEntryPointId);
+        ObjectID outEntryPointId) override;
 
-    virtual void IModule_getDefinedEntryPointCount(ObjectID objectId) { (void)objectId; }
+    virtual void IModule_getDefinedEntryPointCount(ObjectID objectId) override { (void)objectId; }
 
     virtual void IModule_getDefinedEntryPoint(
         ObjectID objectId,
         SlangInt32 index,
-        ObjectID outEntryPointId);
-    virtual void IModule_serialize(ObjectID objectId, ObjectID outSerializedBlobId);
-    virtual void IModule_writeToFile(ObjectID objectId, char const* fileName);
+        ObjectID outEntryPointId) override;
+    virtual void IModule_serialize(ObjectID objectId, ObjectID outSerializedBlobId) override;
+    virtual void IModule_writeToFile(ObjectID objectId, char const* fileName) override;
 
-    virtual void IModule_getName(ObjectID objectId) { (void)objectId; }
-    virtual void IModule_getFilePath(ObjectID objectId) { (void)objectId; }
-    virtual void IModule_getUniqueIdentity(ObjectID objectId) { (void)objectId; }
+    virtual void IModule_getName(ObjectID objectId) override { (void)objectId; }
+    virtual void IModule_getFilePath(ObjectID objectId) override { (void)objectId; }
+    virtual void IModule_getUniqueIdentity(ObjectID objectId) override { (void)objectId; }
 
     virtual void IModule_findAndCheckEntryPoint(
         ObjectID objectId,
         char const* name,
         SlangStage stage,
         ObjectID outEntryPointId,
-        ObjectID outDiagnostics);
+        ObjectID outDiagnostics) override;
 
-    virtual void IModule_getSession(ObjectID objectId, ObjectID outSessionId);
+    virtual void IModule_getSession(ObjectID objectId, ObjectID outSessionId) override;
     virtual void IModule_getLayout(
         ObjectID objectId,
         SlangInt targetIndex,
         ObjectID outDiagnosticsId,
-        ObjectID retProgramLayoutId);
+        ObjectID retProgramLayoutId) override;
 
-    virtual void IModule_getSpecializationParamCount(ObjectID objectId) { (void)objectId; }
+    virtual void IModule_getSpecializationParamCount(ObjectID objectId) override { (void)objectId; }
 
     virtual void IModule_getEntryPointCode(
         ObjectID objectId,
         SlangInt entryPointIndex,
         SlangInt targetIndex,
         ObjectID outCodeId,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
     virtual void IModule_getTargetCode(
         ObjectID objectId,
         SlangInt targetIndex,
         ObjectID outCodeId,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
     virtual void IModule_getResultAsFileSystem(
         ObjectID objectId,
         SlangInt entryPointIndex,
         SlangInt targetIndex,
-        ObjectID outFileSystem);
+        ObjectID outFileSystem) override;
     virtual void IModule_getEntryPointHash(
         ObjectID objectId,
         SlangInt entryPointIndex,
         SlangInt targetIndex,
-        ObjectID outHashId);
+        ObjectID outHashId) override;
     virtual void IModule_specialize(
         ObjectID objectId,
         slang::SpecializationArg const* specializationArgs,
         SlangInt specializationArgCount,
         ObjectID outSpecializedComponentTypeId,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
     virtual void IModule_link(
         ObjectID objectId,
         ObjectID outLinkedComponentTypeId,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
     virtual void IModule_getEntryPointHostCallable(
         ObjectID objectId,
         int entryPointIndex,
         int targetIndex,
         ObjectID outSharedLibrary,
-        ObjectID outDiagnostics);
+        ObjectID outDiagnostics) override;
     virtual void IModule_renameEntryPoint(
         ObjectID objectId,
         const char* newName,
-        ObjectID outEntryPointId);
+        ObjectID outEntryPointId) override;
     virtual void IModule_linkWithOptions(
         ObjectID objectId,
         ObjectID outLinkedComponentTypeId,
         uint32_t compilerOptionEntryCount,
         slang::CompilerOptionEntry* compilerOptionEntries,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
 
     // IEntryPoint
-    virtual void IEntryPoint_getSession(ObjectID objectId, ObjectID outSessionId);
+    virtual void IEntryPoint_getSession(ObjectID objectId, ObjectID outSessionId) override;
     virtual void IEntryPoint_getLayout(
         ObjectID objectId,
         SlangInt targetIndex,
         ObjectID outDiagnosticsId,
-        ObjectID retProgramLayoutId);
+        ObjectID retProgramLayoutId) override;
 
-    virtual void IEntryPoint_getSpecializationParamCount(ObjectID objectId) { (void)objectId; };
+    virtual void IEntryPoint_getSpecializationParamCount(ObjectID objectId) override { (void)objectId; };
 
     virtual void IEntryPoint_getEntryPointCode(
         ObjectID objectId,
         SlangInt entryPointIndex,
         SlangInt targetIndex,
         ObjectID outCodeId,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
     virtual void IEntryPoint_getTargetCode(
         ObjectID objectId,
         SlangInt targetIndex,
         ObjectID outCodeId,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
     virtual void IEntryPoint_getResultAsFileSystem(
         ObjectID objectId,
         SlangInt entryPointIndex,
         SlangInt targetIndex,
-        ObjectID outFileSystem);
+        ObjectID outFileSystem) override;
     virtual void IEntryPoint_getEntryPointHash(
         ObjectID objectId,
         SlangInt entryPointIndex,
         SlangInt targetIndex,
-        ObjectID outHashId);
+        ObjectID outHashId) override;
     virtual void IEntryPoint_specialize(
         ObjectID objectId,
         slang::SpecializationArg const* specializationArgs,
         SlangInt specializationArgCount,
         ObjectID outSpecializedComponentTypeId,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
     virtual void IEntryPoint_link(
         ObjectID objectId,
         ObjectID outLinkedComponentTypeId,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
     virtual void IEntryPoint_getEntryPointHostCallable(
         ObjectID objectId,
         int entryPointIndex,
         int targetIndex,
         ObjectID outSharedLibrary,
-        ObjectID outDiagnostics);
+        ObjectID outDiagnostics) override;
     virtual void IEntryPoint_renameEntryPoint(
         ObjectID objectId,
         const char* newName,
-        ObjectID outEntryPointId);
+        ObjectID outEntryPointId) override;
     virtual void IEntryPoint_linkWithOptions(
         ObjectID objectId,
         ObjectID outLinkedComponentTypeId,
         uint32_t compilerOptionEntryCount,
         slang::CompilerOptionEntry* compilerOptionEntries,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
 
     // ICompositeComponentType
-    virtual void ICompositeComponentType_getSession(ObjectID objectId, ObjectID outSessionId);
+    virtual void ICompositeComponentType_getSession(ObjectID objectId, ObjectID outSessionId) override;
     virtual void ICompositeComponentType_getLayout(
         ObjectID objectId,
         SlangInt targetIndex,
         ObjectID outDiagnosticsId,
-        ObjectID retProgramLayoutId);
+        ObjectID retProgramLayoutId) override;
 
-    virtual void ICompositeComponentType_getSpecializationParamCount(ObjectID objectId)
+    virtual void ICompositeComponentType_getSpecializationParamCount(ObjectID objectId) override
     {
         (void)objectId;
-    };
+    }
 
     virtual void ICompositeComponentType_getEntryPointCode(
         ObjectID objectId,
         SlangInt entryPointIndex,
         SlangInt targetIndex,
         ObjectID outCodeId,
-        ObjectID outDiagnostics);
+        ObjectID outDiagnostics) override;
     virtual void ICompositeComponentType_getTargetCode(
         ObjectID objectId,
         SlangInt targetIndex,
         ObjectID outCodeId,
-        ObjectID outDiagnostics);
+        ObjectID outDiagnostics) override;
     virtual void ICompositeComponentType_getResultAsFileSystem(
         ObjectID objectId,
         SlangInt entryPointIndex,
         SlangInt targetIndex,
-        ObjectID outFileSystem);
+        ObjectID outFileSystem) override;
     virtual void ICompositeComponentType_getEntryPointHash(
         ObjectID objectId,
         SlangInt entryPointIndex,
         SlangInt targetIndex,
-        ObjectID outHashId);
+        ObjectID outHashId) override;
     virtual void ICompositeComponentType_specialize(
         ObjectID objectId,
         slang::SpecializationArg const* specializationArgs,
         SlangInt specializationArgCount,
         ObjectID outSpecializedComponentTypeId,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
     virtual void ICompositeComponentType_link(
         ObjectID objectId,
         ObjectID outLinkedComponentTypeId,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
     virtual void ICompositeComponentType_getEntryPointHostCallable(
         ObjectID objectId,
         int entryPointIndex,
         int targetIndex,
         ObjectID outSharedLibrary,
-        ObjectID outDiagnostics);
+        ObjectID outDiagnostics) override;
     virtual void ICompositeComponentType_renameEntryPoint(
         ObjectID objectId,
         const char* newName,
-        ObjectID outEntryPointId);
+        ObjectID outEntryPointId) override;
     virtual void ICompositeComponentType_linkWithOptions(
         ObjectID objectId,
         ObjectID outLinkedComponentTypeId,
         uint32_t compilerOptionEntryCount,
         slang::CompilerOptionEntry* compilerOptionEntries,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
 
     // ITypeConformance
-    virtual void ITypeConformance_getSession(ObjectID objectId, ObjectID outSessionId);
+    virtual void ITypeConformance_getSession(ObjectID objectId, ObjectID outSessionId) override;
     virtual void ITypeConformance_getLayout(
         ObjectID objectId,
         SlangInt targetIndex,
         ObjectID outDiagnosticsId,
-        ObjectID retProgramLayoutId);
+        ObjectID retProgramLayoutId) override;
 
-    virtual void ITypeConformance_getSpecializationParamCount(ObjectID objectId)
+    virtual void ITypeConformance_getSpecializationParamCount(ObjectID objectId) override
     {
         (void)objectId;
-    };
+    }
 
     virtual void ITypeConformance_getEntryPointCode(
         ObjectID objectId,
         SlangInt entryPointIndex,
         SlangInt targetIndex,
         ObjectID outCodeId,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
     virtual void ITypeConformance_getTargetCode(
         ObjectID objectId,
         SlangInt targetIndex,
         ObjectID outCodeId,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
     virtual void ITypeConformance_getResultAsFileSystem(
         ObjectID objectId,
         SlangInt entryPointIndex,
         SlangInt targetIndex,
-        ObjectID outFileSystem);
+        ObjectID outFileSystem) override;
     virtual void ITypeConformance_getEntryPointHash(
         ObjectID objectId,
         SlangInt entryPointIndex,
         SlangInt targetIndex,
-        ObjectID outHashId);
+        ObjectID outHashId) override;
     virtual void ITypeConformance_specialize(
         ObjectID objectId,
         slang::SpecializationArg const* specializationArgs,
         SlangInt specializationArgCount,
         ObjectID outSpecializedComponentTypeId,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
     virtual void ITypeConformance_link(
         ObjectID objectId,
         ObjectID outLinkedComponentTypeId,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
     virtual void ITypeConformance_getEntryPointHostCallable(
         ObjectID objectId,
         int entryPointIndex,
         int targetIndex,
         ObjectID outSharedLibrary,
-        ObjectID outDiagnostics);
+        ObjectID outDiagnostics) override;
     virtual void ITypeConformance_renameEntryPoint(
         ObjectID objectId,
         const char* newName,
-        ObjectID outEntryPointId);
+        ObjectID outEntryPointId) override;
     virtual void ITypeConformance_linkWithOptions(
         ObjectID objectId,
         ObjectID outLinkedComponentTypeId,
         uint32_t compilerOptionEntryCount,
         slang::CompilerOptionEntry* compilerOptionEntries,
-        ObjectID outDiagnosticsId);
+        ObjectID outDiagnosticsId) override;
+
+    // IComponentType2 methods.
+    virtual void IComponentType2_getTargetCompileResult(
+        ObjectID objectId,
+        SlangInt targetIndex,
+        ObjectID outCompileResultId,
+        ObjectID outDiagnosticsId) override;
+    virtual void IComponentType2_getEntryPointCompileResult(
+        ObjectID objectId,
+        SlangInt entryPointIndex,
+        SlangInt targetIndex,
+        ObjectID outCompileResultId,
+        ObjectID outDiagnosticsId) override;
 
     static void _writeCompilerOptionEntryHelper(
         Slang::StringBuilder& builder,
@@ -564,6 +593,7 @@ private:
         ApiClassId::Class_ICompositeComponentType,
         m_fileStream};
     CommonInterfaceWriter m_typeConformanceHelper{ApiClassId::Class_ITypeConformance, m_fileStream};
+    CommonInterfaceWriter m_componentType2Helper{ApiClassId::Class_IComponentType2, m_fileStream};
 };
 } // namespace SlangRecord
 #endif // JSON_CONSUMER_H

--- a/source/slang-record-replay/replay/replay-consumer.cpp
+++ b/source/slang-record-replay/replay/replay-consumer.cpp
@@ -74,6 +74,28 @@ SlangResult CommonInterfaceReplayer::getLayout(
     return res;
 }
 
+SlangResult CommonInterfaceReplayer::queryInterface(
+    ObjectID objectId,
+    const SlangUUID& guid,
+    ObjectID outInterfaceId)
+{
+    slang::IComponentType* pObj = getObjectPointer(objectId);
+    if (pObj == nullptr)
+    {
+        return SLANG_FAIL;
+    }
+
+    void* outInterface = nullptr;
+    SlangResult res = pObj->queryInterface(guid, &outInterface);
+
+    if (res == SLANG_OK && outInterface != nullptr)
+    {
+        m_objectMap.add(outInterfaceId, outInterface);
+    }
+
+    return res;
+}
+
 SlangResult CommonInterfaceReplayer::getEntryPointCode(
     ObjectID objectId,
     SlangInt entryPointIndex,
@@ -1694,6 +1716,15 @@ void ReplayConsumer::ICompositeComponentType_linkWithOptions(
         compilerOptionEntries,
         outDiagnosticsId);
     FAIL_WITH_LOG(ICompositeComponentType::linkWithOptions);
+}
+
+void ReplayConsumer::ICompositeComponentType_queryInterface(
+    ObjectID objectId,
+    const SlangUUID& guid,
+    ObjectID outInterfaceId)
+{
+    SlangResult res = m_commonReplayer.queryInterface(objectId, guid, outInterfaceId);
+    FAIL_WITH_LOG(ICompositeComponentType::queryInterface);
 }
 
 

--- a/source/slang-record-replay/replay/replay-consumer.cpp
+++ b/source/slang-record-replay/replay/replay-consumer.cpp
@@ -320,6 +320,58 @@ SlangResult CommonInterfaceReplayer::linkWithOptions(
     return res;
 }
 
+SlangResult CommonInterfaceReplayer::getTargetCompileResult(
+    ObjectID objectId,
+    SlangInt targetIndex,
+    ObjectID outCompileResultId,
+    ObjectID outDiagnosticsId)
+{
+    InputObjectSanityCheck(objectId);
+
+    slang::IComponentType2* pObj = getObjectPointer2(objectId);
+    slang::ICompileResult* outCompileResultType{};
+    slang::IBlob* outDiagnostics{};
+
+    SlangResult res =
+        pObj->getTargetCompileResult(targetIndex, &outCompileResultType, &outDiagnostics);
+
+    if (outCompileResultType && SLANG_SUCCEEDED(res))
+    {
+        m_objectMap.addIfNotExists(outCompileResultId, outCompileResultType);
+    }
+
+    ReplayConsumer::printDiagnosticMessage(outDiagnostics);
+    return res;
+}
+
+SlangResult CommonInterfaceReplayer::getEntryPointCompileResult(
+    ObjectID objectId,
+    SlangInt entryPointIndex,
+    SlangInt targetIndex,
+    ObjectID outCompileResultId,
+    ObjectID outDiagnosticsId)
+{
+    InputObjectSanityCheck(objectId);
+
+    slang::IComponentType2* pObj = getObjectPointer2(objectId);
+    slang::ICompileResult* outCompileResultType{};
+    slang::IBlob* outDiagnostics{};
+
+    SlangResult res = pObj->getEntryPointCompileResult(
+        entryPointIndex,
+        targetIndex,
+        &outCompileResultType,
+        &outDiagnostics);
+
+    if (outCompileResultType && SLANG_SUCCEEDED(res))
+    {
+        m_objectMap.addIfNotExists(outCompileResultId, outCompileResultType);
+    }
+
+    ReplayConsumer::printDiagnosticMessage(outDiagnostics);
+    return res;
+}
+
 
 void ReplayConsumer::printDiagnosticMessage(slang::IBlob* diagnosticsBlob)
 {
@@ -1784,5 +1836,34 @@ void ReplayConsumer::ITypeConformance_linkWithOptions(
     FAIL_WITH_LOG(ITypeConformance::linkWithOptions);
 }
 
+void ReplayConsumer::IComponentType2_getTargetCompileResult(
+    ObjectID objectId,
+    SlangInt targetIndex,
+    ObjectID outCompileResultId,
+    ObjectID outDiagnosticsId)
+{
+    SlangResult res = m_commonReplayer.getTargetCompileResult(
+        objectId,
+        targetIndex,
+        outCompileResultId,
+        outDiagnosticsId);
+    FAIL_WITH_LOG(IComponentType2::getTargetCompileResult);
+}
+
+void ReplayConsumer::IComponentType2_getEntryPointCompileResult(
+    ObjectID objectId,
+    SlangInt entryPointIndex,
+    SlangInt targetIndex,
+    ObjectID outCompileResultId,
+    ObjectID outDiagnosticsId)
+{
+    SlangResult res = m_commonReplayer.getEntryPointCompileResult(
+        objectId,
+        entryPointIndex,
+        targetIndex,
+        outCompileResultId,
+        outDiagnosticsId);
+    FAIL_WITH_LOG(IComponentType2::getEntryPointCompileResult);
+}
 
 }; // namespace SlangRecord

--- a/source/slang-record-replay/replay/replay-consumer.h
+++ b/source/slang-record-replay/replay/replay-consumer.h
@@ -73,10 +73,7 @@ public:
         slang::CompilerOptionEntry* compilerOptionEntries,
         ObjectID outDiagnosticsId);
 
-    SlangResult queryInterface(
-        ObjectID objectId,
-        const SlangUUID& guid,
-        ObjectID outInterfaceId);
+    SlangResult queryInterface(ObjectID objectId, const SlangUUID& guid, ObjectID outInterfaceId);
 
     // IComponentType2 methods.
     SlangResult getTargetCompileResult(

--- a/source/slang-record-replay/replay/replay-consumer.h
+++ b/source/slang-record-replay/replay/replay-consumer.h
@@ -73,6 +73,19 @@ public:
         slang::CompilerOptionEntry* compilerOptionEntries,
         ObjectID outDiagnosticsId);
 
+    // IComponentType2 methods.
+    SlangResult getTargetCompileResult(
+        ObjectID objectId,
+        SlangInt targetIndex,
+        ObjectID outCompileResultId,
+        ObjectID outDiagnosticsId);
+    SlangResult getEntryPointCompileResult(
+        ObjectID objectId,
+        SlangInt entryPointIndex,
+        SlangInt targetIndex,
+        ObjectID outCompileResultId,
+        ObjectID outDiagnosticsId);
+
 private:
     inline slang::IComponentType* getObjectPointer(ObjectID objectId)
     {
@@ -87,6 +100,21 @@ private:
         }
 
         return static_cast<slang::IComponentType*>(objPtr);
+    }
+
+    inline slang::IComponentType2* getObjectPointer2(ObjectID objectId)
+    {
+        void* objPtr = nullptr;
+
+        // If the object is not found, there must be something wrong with the record/replay
+        // logic, so report an error.
+        if (!m_objectMap.tryGetValue(objectId, objPtr))
+        {
+            slangRecordLog(LogLevel::Error, "Object not found in the object map: %d\n", objectId);
+            std::abort();
+        }
+
+        return static_cast<slang::IComponentType2*>(objPtr);
     }
 
     Slang::Dictionary<ObjectID, void*>& m_objectMap;
@@ -551,6 +579,19 @@ public:
         ObjectID outLinkedComponentTypeId,
         uint32_t compilerOptionEntryCount,
         slang::CompilerOptionEntry* compilerOptionEntries,
+        ObjectID outDiagnosticsId) override;
+
+    // IComponentType2 methods.
+    virtual void IComponentType2_getTargetCompileResult(
+        ObjectID objectId,
+        SlangInt targetIndex,
+        ObjectID outCompileResultId,
+        ObjectID outDiagnosticsId) override;
+    virtual void IComponentType2_getEntryPointCompileResult(
+        ObjectID objectId,
+        SlangInt entryPointIndex,
+        SlangInt targetIndex,
+        ObjectID outCompileResultId,
         ObjectID outDiagnosticsId) override;
 
     static void printDiagnosticMessage(slang::IBlob* diagnosticsBlob);

--- a/source/slang-record-replay/replay/replay-consumer.h
+++ b/source/slang-record-replay/replay/replay-consumer.h
@@ -73,6 +73,11 @@ public:
         slang::CompilerOptionEntry* compilerOptionEntries,
         ObjectID outDiagnosticsId);
 
+    SlangResult queryInterface(
+        ObjectID objectId,
+        const SlangUUID& guid,
+        ObjectID outInterfaceId);
+
     // IComponentType2 methods.
     SlangResult getTargetCompileResult(
         ObjectID objectId,
@@ -519,6 +524,11 @@ public:
         uint32_t compilerOptionEntryCount,
         slang::CompilerOptionEntry* compilerOptionEntries,
         ObjectID outDiagnosticsId) override;
+
+    virtual void ICompositeComponentType_queryInterface(
+        ObjectID objectId,
+        const SlangUUID& guid,
+        ObjectID outInterfaceId) override;
 
     // ITypeConformance
     virtual void ITypeConformance_getSession(ObjectID objectId, ObjectID outSessionId) override;

--- a/source/slang-record-replay/replay/slang-decoder.cpp
+++ b/source/slang-record-replay/replay/slang-decoder.cpp
@@ -423,6 +423,12 @@ bool SlangDecoder::processITypeConformanceMethods(
     case ApiCallId::ITypeConformance_linkWithOptions:
         ITypeConformance_linkWithOptions(objectId, parameterBlock);
         break;
+    case ApiCallId::IComponentType2_getTargetCompileResult:
+        IComponentType2_getTargetCompileResult(objectId, parameterBlock);
+        break;
+    case ApiCallId::IComponentType2_getEntryPointCompileResult:
+        IComponentType2_getEntryPointCompileResult(objectId, parameterBlock);
+        break;
     }
     return true;
 }
@@ -3153,6 +3159,76 @@ void SlangDecoder::ITypeConformance_linkWithOptions(
             outLinkedComponentTypeId,
             compilerOptionEntryCount,
             compilerOptionEntries.data(),
+            outDiagnosticsId);
+    }
+}
+
+void SlangDecoder::IComponentType2_getTargetCompileResult(
+    ObjectID objectId,
+    ParameterBlock const& parameterBlock)
+{
+    size_t readByte = 0;
+    int64_t targetIndex = 0;
+    readByte = ParameterDecoder::decodeInt64(
+        parameterBlock.parameterBuffer,
+        parameterBlock.parameterBufferSize,
+        targetIndex);
+
+    ObjectID outCompileResultId = 0;
+    ObjectID outDiagnosticsId = 0;
+    readByte = ParameterDecoder::decodeAddress(
+        parameterBlock.outputBuffer,
+        parameterBlock.outputBufferSize,
+        outCompileResultId);
+    readByte += ParameterDecoder::decodeAddress(
+        parameterBlock.outputBuffer + readByte,
+        parameterBlock.outputBufferSize - readByte,
+        outDiagnosticsId);
+
+    for (auto consumer : m_consumers)
+    {
+        consumer->IComponentType2_getTargetCompileResult(
+            objectId,
+            targetIndex,
+            outCompileResultId,
+            outDiagnosticsId);
+    }
+}
+
+void SlangDecoder::IComponentType2_getEntryPointCompileResult(
+    ObjectID objectId,
+    ParameterBlock const& parameterBlock)
+{
+    size_t readByte = 0;
+    int64_t targetIndex = 0;
+    int64_t entryPointIndex = 0;
+    readByte = ParameterDecoder::decodeInt64(
+        parameterBlock.parameterBuffer,
+        parameterBlock.parameterBufferSize,
+        targetIndex);
+    readByte += ParameterDecoder::decodeInt64(
+        parameterBlock.parameterBuffer + readByte,
+        parameterBlock.parameterBufferSize - readByte,
+        entryPointIndex);
+
+    ObjectID outCompileResultId = 0;
+    ObjectID outDiagnosticsId = 0;
+    readByte = ParameterDecoder::decodeAddress(
+        parameterBlock.outputBuffer,
+        parameterBlock.outputBufferSize,
+        outCompileResultId);
+    readByte += ParameterDecoder::decodeAddress(
+        parameterBlock.outputBuffer + readByte,
+        parameterBlock.outputBufferSize - readByte,
+        outDiagnosticsId);
+
+    for (auto consumer : m_consumers)
+    {
+        consumer->IComponentType2_getEntryPointCompileResult(
+            objectId,
+            entryPointIndex,
+            targetIndex,
+            outCompileResultId,
             outDiagnosticsId);
     }
 }

--- a/source/slang-record-replay/replay/slang-decoder.cpp
+++ b/source/slang-record-replay/replay/slang-decoder.cpp
@@ -2801,7 +2801,7 @@ void SlangDecoder::ICompositeComponentType_queryInterface(
     ParameterBlock const& parameterBlock)
 {
     size_t readByte = 0;
-    
+
     // Decode the GUID
     SlangUUID guid;
     readByte = ParameterDecoder::decodeUint32(
@@ -2833,10 +2833,7 @@ void SlangDecoder::ICompositeComponentType_queryInterface(
 
     for (auto consumer : m_consumers)
     {
-        consumer->ICompositeComponentType_queryInterface(
-            objectId,
-            guid,
-            outInterfaceId);
+        consumer->ICompositeComponentType_queryInterface(objectId, guid, outInterfaceId);
     }
 }
 

--- a/source/slang-record-replay/replay/slang-decoder.h
+++ b/source/slang-record-replay/replay/slang-decoder.h
@@ -247,6 +247,14 @@ public:
     void ITypeConformance_renameEntryPoint(ObjectID objectId, ParameterBlock const& parameterBlock);
     void ITypeConformance_linkWithOptions(ObjectID objectId, ParameterBlock const& parameterBlock);
 
+    // IComponentType2 methods.
+    void IComponentType2_getTargetCompileResult(
+        ObjectID objectId,
+        ParameterBlock const& parameterBlock);
+    void IComponentType2_getEntryPointCompileResult(
+        ObjectID objectId,
+        ParameterBlock const& parameterBlock);
+
 private:
     Slang::List<IDecoderConsumer*> m_consumers;
 };

--- a/source/slang-record-replay/replay/slang-decoder.h
+++ b/source/slang-record-replay/replay/slang-decoder.h
@@ -223,6 +223,9 @@ public:
     void ICompositeComponentType_linkWithOptions(
         ObjectID objectId,
         ParameterBlock const& parameterBlock);
+    void ICompositeComponentType_queryInterface(
+        ObjectID objectId,
+        ParameterBlock const& parameterBlock);
 
     void ITypeConformance_getSession(ObjectID objectId, ParameterBlock const& parameterBlock);
     void ITypeConformance_getLayout(ObjectID objectId, ParameterBlock const& parameterBlock);

--- a/source/slang-record-replay/util/record-format.h
+++ b/source/slang-record-replay/util/record-format.h
@@ -60,6 +60,7 @@ enum IComponentTypeMethodId : uint16_t
     linkWithOptions = 0x0015,
     getTargetCompileResult = 0x0016,
     getEntryPointCompileResult = 0x0017,
+    queryInterface = 0x0018,
 };
 
 enum ApiCallId : uint32_t
@@ -192,6 +193,8 @@ enum ApiCallId : uint32_t
         makeApiCallId(Class_ICompositeComponentType, IComponentTypeMethodId::renameEntryPoint),
     ICompositeComponentType_linkWithOptions =
         makeApiCallId(Class_ICompositeComponentType, IComponentTypeMethodId::linkWithOptions),
+    ICompositeComponentType_queryInterface =
+        makeApiCallId(Class_ICompositeComponentType, IComponentTypeMethodId::queryInterface),
 
     ITypeConformance_getSession =
         makeApiCallId(Class_ITypeConformance, IComponentTypeMethodId::getSession),

--- a/source/slang-record-replay/util/record-format.h
+++ b/source/slang-record-replay/util/record-format.h
@@ -30,6 +30,7 @@ enum ApiClassId : uint16_t
     Class_IEntryPoint = 5,
     Class_ICompositeComponentType = 6,
     Class_ITypeConformance = 7,
+    Class_IComponentType2 = 8,
     Unknown = 0xFFFF
 };
 
@@ -57,6 +58,8 @@ enum IComponentTypeMethodId : uint16_t
     getEntryPointHostCallable = 0x0013,
     renameEntryPoint = 0x0014,
     linkWithOptions = 0x0015,
+    getTargetCompileResult = 0x0016,
+    getEntryPointCompileResult = 0x0017,
 };
 
 enum ApiCallId : uint32_t
@@ -213,6 +216,12 @@ enum ApiCallId : uint32_t
         makeApiCallId(Class_ITypeConformance, IComponentTypeMethodId::renameEntryPoint),
     ITypeConformance_linkWithOptions =
         makeApiCallId(Class_ITypeConformance, IComponentTypeMethodId::linkWithOptions),
+
+    // IComponentType2 methods.
+    IComponentType2_getTargetCompileResult =
+        makeApiCallId(Class_IComponentType2, IComponentTypeMethodId::getTargetCompileResult),
+    IComponentType2_getEntryPointCompileResult =
+        makeApiCallId(Class_IComponentType2, IComponentTypeMethodId::getEntryPointCompileResult),
 };
 
 struct FunctionHeader


### PR DESCRIPTION
Add record and replay support for the IComponentType2 struct and its functions getTargetCompileResult and getEntryPointCompileResult.