### PR TITLE
Add Metal support for WaveGetActiveMask and WaveActiveCountBits

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -13934,7 +13934,7 @@ WaveMask __WaveGetActiveMask();
 
 __glsl_extension(GL_KHR_shader_subgroup_ballot)
 __spirv_version(1.3)
-[require(cuda_glsl_hlsl_spirv, subgroup_ballot_activemask)]
+[require(cuda_glsl_hlsl_metal_spirv, subgroup_ballot_activemask)]
 WaveMask WaveGetActiveMask()
 {
     __target_switch
@@ -13943,6 +13943,8 @@ WaveMask WaveGetActiveMask()
         __intrinsic_asm "subgroupBallot(true).x";
     case hlsl:
         __intrinsic_asm "WaveActiveBallot(true).x";
+    case metal:
+        __intrinsic_asm "((uint32_t)((simd_vote::vote_t)simd_ballot(true)))";
     case spirv:
         let _true = true;
         return (spirv_asm
@@ -15501,7 +15503,7 @@ uint4 WaveActiveBallot(bool condition)
 }
 
 /// @category wave
-[require(cuda_glsl_hlsl_spirv, subgroup_basic_ballot)]
+[require(cuda_glsl_hlsl_metal_spirv, subgroup_basic_ballot)]
 uint WaveActiveCountBits(bool value)
 {
     __target_switch
@@ -15598,7 +15600,7 @@ bool WaveIsFirstLane()
 // This implementation tries to limit the amount of work required by the actual lane count.
 /// @category wave
 __spirv_version(1.3)
-[require(cpp_cuda_glsl_hlsl_spirv, subgroup_basic_ballot)]
+[require(cpp_cuda_glsl_hlsl_metal_spirv, subgroup_basic_ballot)]
 uint _WaveCountBits(uint4 value)
 {
     __target_switch

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -2153,6 +2153,7 @@ alias subgroup_ballot_activemask = spirv_1_0 + GL_KHR_shader_subgroup_ballot
                       | glsl + GL_KHR_shader_subgroup_ballot
                       | _sm_6_0
                       | _cuda_sm_7_0
+                      | metal
                       ;
 /// Capabilities required to use GLSL-style subgroup operations 'subgroup_basic_ballot'
 /// [Compound]


### PR DESCRIPTION
  ## Summary

  - Add Metal platform support for `WaveGetActiveMask()` and `WaveActiveCountBits()` wave intrinsics
  - Update capability requirements to include Metal platform for subgroup ballot operations
  - Implement Metal-specific intrinsic assembly using `simd_ballot()` and `simd_vote` APIs

  ## Changes

  - **source/slang/hlsl.meta.slang**:
    - Add Metal target case for `WaveGetActiveMask()` using `simd_ballot(true)`
    - Update capability requirements from `cuda_glsl_hlsl_spirv` to `cuda_glsl_hlsl_metal_spirv` for wave ballot functions
  - **source/slang/slang-capabilities.capdef**:
    - Add `metal` to `subgroup_ballot_activemask` capability alias