### PR TITLE
Allow implicit conversion from Optional<T> to Optional<U>

### DIFF
--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -1443,6 +1443,52 @@ bool SemanticsVisitor::_coerce(
         return true;
     }
 
+    // Optional<T> can be cast into Optional<U> if T is coercible to U
+    if (auto fromOptionalType = as<OptionalType>(fromType))
+    {
+        if (auto toOptionalType = as<OptionalType>(toType))
+        {
+            Type* fromValueType = fromOptionalType->getValueType();
+            Type* toValueType = toOptionalType->getValueType();
+
+            // Check if we can coerce from the inner type to the target inner type
+            // We need a dummy expression to check coercion possibility
+            ConversionCost innerCost = kConversionCost_Impossible;
+            if (_coerce(site, toValueType, nullptr, fromValueType, nullptr, sink, &innerCost))
+            {
+                if (outCost)
+                {
+                    // Cost is the inner conversion cost plus a small penalty for optional wrapping
+                    *outCost = innerCost + 1;
+                }
+
+                if (outToExpr)
+                {
+                    // Step 1: Create unchecked MemberExpr for .value access
+                    auto memberExpr = getASTBuilder()->create<MemberExpr>();
+                    memberExpr->baseExpression = fromExpr;
+                    memberExpr->name = getName("value");
+                    memberExpr->loc = fromExpr->loc;
+
+                    // Apply semantic checking to resolve the member access
+                    auto unwrapExpr = CheckExpr(memberExpr);
+
+                    // Step 2: Convert T to U using the general coercion
+                    Expr* castExpr = nullptr;
+                    _coerce(site, toValueType, &castExpr, fromValueType, unwrapExpr, sink, nullptr);
+
+                    // Step 3: Wrap it with Optional<U> using MakeOptionalExpr
+                    auto resultExpr = getASTBuilder()->create<MakeOptionalExpr>();
+                    resultExpr->value = castExpr;
+                    resultExpr->type = toType;
+                    resultExpr->loc = fromExpr->loc;
+                    *outToExpr = resultExpr;
+                }
+                return true;
+            }
+        }
+    }
+
     // A enum type can be converted into its underlying tag type.
     if (auto enumDecl = isEnumType(fromType))
     {

--- a/tests/language-feature/types/optional-interface-implicit-conversion.slang
+++ b/tests/language-feature/types/optional-interface-implicit-conversion.slang
@@ -1,0 +1,70 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHK):-vk -shaderobj -output-using-type -Xslang -DEXPLICIT_CAST
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHK):-vk -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=gOutput
+RWStructuredBuffer<int> gOutput;
+
+interface ICash
+{
+    int getValue();
+}
+
+struct Cash : ICash
+{
+    int value;
+    override int getValue() { return value; }
+}
+
+interface IBank
+{
+    associatedtype ConcreteCashType : ICash;
+
+    Optional<ConcreteCashType> makeCash();
+}
+
+struct Bank : IBank
+{
+    typedef Cash ConcreteCashType;
+
+    override Optional<ConcreteCashType> makeCash()
+    {
+        Cash cash;
+        // CHK: 42
+        cash.value = 42;
+        return cash;
+    }
+
+    // Adding a dummy member variable, because an empty struct
+    // may go through a different optimization pass
+    int dummy;
+    __init() { dummy = 0; }
+}
+
+Optional<ICash> makeCash<BankType : IBank>(BankType bank)
+{
+    Optional<BankType.ConcreteCashType> maybeCash = bank.makeCash();
+
+#if defined(EXPLICIT_CAST)
+    if (let raw = maybeCash)
+        return Optional<ICash>(raw);
+    return none;
+#else
+    // Implicit conversion:
+    // Optional<Cash> -> Optional<ICash>
+    return maybeCash;
+#endif
+}
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    Bank bank;
+
+    Optional<ICash> maybeCash = makeCash(bank);
+
+    if (let v = maybeCash)
+    {
+        gOutput[0] = v.getValue();
+    }
+}
+


### PR DESCRIPTION
Allow implicit conversion from `Optional<T>` to `Optional<U>` when `T` conforms to `U`.