### PR TITLE
Add multiple slang installations note to doc

### DIFF
--- a/docs/user-guide/01-get-started.md
+++ b/docs/user-guide/01-get-started.md
@@ -9,7 +9,13 @@ Slang enables you to do many powerful things with shader code, including compili
 
 ## Installation
 
-The easiest way to start using Slang is to download a [binary release](https://github.com/shader-slang/slang/releases/) from the GitHub repository. Once you have downloaded and extracted the files from a release package, you can find the `slangc.exe` executable under `/bin/windows-x64/release/`. In this tutorial we will use the `slangc` standalone Slang compiler included in a release package. Note that `slang.dll` and `slang-glslang.dll` must be placed in the same directory as `slangc.exe` as they are required by the standalone executable.
+The easiest way to start using Slang is to download a [binary release](https://github.com/shader-slang/slang/releases/) from the GitHub repository. Once you have downloaded and extracted the files from a release package, you can find the `slangc.exe` or `slangc` executable under `/bin`. In this tutorial we will use the `slangc` standalone Slang compiler included in a release package.
+
+> #### Note: Required Dependencies ####
+> For Windows, `slang.dll` and `slang-glslang.dll` must be placed in the same directory as `slangc.exe` as they are required by the standalone executable.
+
+> #### Note: Multiple Slang Installations ####
+> If you have multiple versions of Slang installed on your system (such as Slang from the Vulkan SDK), ensure that the correct dynamic libraries are being loaded. On Linux, the `LD_LIBRARY_PATH` environment variable will override the `RUNPATH` embedded in the `slangc` executable, causing it to load `libslang.so` from the path specified in `LD_LIBRARY_PATH` first. This can lead to version mismatches and unexpected behavior.
 
 If you are interested in building from source, please refer to the [documentation on building Slang](../building.md). 
 


### PR DESCRIPTION
Added a note section under the Installation section that warns users about potential conflicts when multiple Slang installations are present on the system. The note specifically addresses:
* The scenario where Slang from Vulkan SDK might conflict with a standalone installation
* How LD_LIBRARY_PATH on Linux overrides the RUNPATH in the slangc executable

Closes https://github.com/shader-slang/slang/issues/7405