### PR TITLE
Implement SV_VulkanSamplePosition

### DIFF
--- a/docs/user-guide/a2-01-spirv-target-specific.md
+++ b/docs/user-guide/a2-01-spirv-target-specific.md
@@ -95,9 +95,10 @@ The system-value semantics are translated to the following SPIR-V code.
 | `SV_ViewID`                   | `BuiltIn ViewIndex`               |
 | `SV_ViewportArrayIndex`       | `BuiltIn ViewportIndex`           |
 | `SV_VulkanInstanceID`         | `BuiltIn InstanceIndex`           |
+| `SV_VulkanSamplePosition`     | `BuiltIn SamplePosition`          |
 | `SV_VulkanVertexID`           | `BuiltIn VertexIndex`             |
 
-*Note* that `SV_DrawIndex`, `SV_FragInvocationCount`, `SV_FragSize`, `SV_PointSize` and `SV_PointCoord` are Slang-specific semantics that are not defined in HLSL.
+*Note* that `SV_DrawIndex`, `SV_FragInvocationCount`, `SV_FragSize`, `SV_PointSize`, `SV_PointCoord` and `SV_VulkanSamplePosition` are Slang-specific semantics that are not defined in HLSL.
 Also *Note* that `SV_InstanceID`/`SV_VertexID` counts all instances/vertices in a draw call, unlike how `InstanceIndex`/`VertexIndex` is relative to `BaseInstance`/`BaseVertex`.
 See [Using SV_InstanceID/SV_VertexID with SPIR-V target](#using-sv_instanceid-and-sv_vertexid-with-spir-v-target)
 

--- a/docs/user-guide/a2-02-metal-target-specific.md
+++ b/docs/user-guide/a2-02-metal-target-specific.md
@@ -47,6 +47,7 @@ The system-value semantics are translated to the following Metal attributes:
 | `SV_StartVertexLocation`    | `[[base_vertex]]`                                    |
 | `SV_StartInstanceLocation`  | `[[base_instance]]`                                  |
 | `SV_VulkanInstanceID`       | `[[instance_id]]`                                    |
+| `SV_VulkanSamplePosition`   | `(Not supported)`                                    |
 | `SV_VulkanVertexID`         | `[[vertex_id]]`                                      |
 
 Custom semantics are mapped to user attributes:

--- a/docs/user-guide/a2-03-wgsl-target-specific.md
+++ b/docs/user-guide/a2-03-wgsl-target-specific.md
@@ -53,6 +53,7 @@ The system-value semantics are translated to the following WGSL code.
 | SV_ViewID | *Not supported* |
 | SV_ViewportArrayIndex | *Not supported* |
 | SV_VulkanInstanceID | `@builtin(instance_index)` |
+| SV_VulkanSamplePosition | *Not supported* |
 | SV_VulkanVertexID | `@builtin(vertex_index)` |
 
 

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -219,6 +219,8 @@ public in int gl_BaseInstance : SV_StartInstanceLocation;
 public in int gl_FragInvocationCountEXT : SV_FragInvocationCount;
 public in int2 gl_FragSizeEXT : SV_FragSize;
 
+public in float2 gl_SamplePosition : SV_VulkanSamplePosition;
+
 
 // Override operator* behavior to compute algebric product of matrices and vectors.
 

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -6182,6 +6182,11 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     requireSPIRVCapability(SpvCapabilitySampleRateShading);
                     return getBuiltinGlobalVar(inst->getFullType(), SpvBuiltInSampleId, inst);
                 }
+                else if (semanticName == "sv_vulkansampleposition")
+                {
+                    requireSPIRVCapability(SpvCapabilitySampleRateShading);
+                    return getBuiltinGlobalVar(inst->getFullType(), SpvBuiltInSamplePosition, inst);
+                }
                 else if (semanticName == "sv_stencilref")
                 {
                     requireSPIRVCapability(SpvCapabilityStencilExportEXT);

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -756,6 +756,14 @@ GLSLSystemValueInfo* getGLSLSystemValueInfo(
         requiredType = builder->getBasicType(BaseType::Int);
         name = "gl_SampleID";
     }
+    else if (semanticName == "sv_vulkansampleposition")
+    {
+        context->requireGLSLVersion(ProfileVersion::GLSL_400);
+        requiredType = builder->getVectorType(
+            builder->getBasicType(BaseType::Float),
+            builder->getIntValue(builder->getIntType(), 2));
+        name = "gl_SamplePosition";
+    }
     else if (semanticName == "sv_stencilref")
     {
         // uint in hlsl, int in glsl

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -1821,11 +1821,12 @@ static RefPtr<TypeLayout> processSimpleEntryPointParameter(
             // We need to compute whether an entry point consumes
             // any sample-rate inputs, and along with explicitly
             // `sample`-qualified parameters, we also need to
-            // detect use of `SV_SampleIndex` as an input.
+            // detect use of `SV_SampleIndex` and
+            // `SV_VulkanSamplePosition` as an input.
             //
             if (state.directionMask & kEntryPointParameterDirection_Input)
             {
-                if (sn == "sv_sampleindex")
+                if (sn == "sv_sampleindex" || sn == "sv_vulkansampleposition")
                 {
                     state.isSampleRate = true;
                 }

--- a/tests/spirv/sv-vulkan-sample-position.slang
+++ b/tests/spirv/sv-vulkan-sample-position.slang
@@ -1,0 +1,21 @@
+//TEST:SIMPLE(filecheck=CHECK-SPIRV): -target spirv -stage fragment -entry main
+//TEST:SIMPLE(filecheck=CHECK-GLSL): -target glsl -stage fragment -entry main
+
+// Test for SV_VulkanSamplePosition support
+
+// CHECK-SPIRV: OpCapability SampleRateShading
+// CHECK-SPIRV-DAG: OpDecorate {{.*}} BuiltIn SamplePosition
+// CHECK-GLSL-DAG: gl_SamplePosition
+
+import glsl;
+
+struct FragmentInput
+{
+    float2 samplePosition : SV_VulkanSamplePosition;
+}
+
+[shader("fragment")]
+float4 main(FragmentInput input) : SV_Target
+{
+    return float4(input.samplePosition.x, gl_SamplePosition.y, 0.0, 1.0);
+}


### PR DESCRIPTION
-Adds semantic SV_VulkanSamplePosition that emits corresponding gl_SamplePosition and SpvBuiltinSamplePosition
-Adds gl_SamplePosition property to glsl.meta.slang
-Adds SPIRV and GLSL tests for the semantic and property
-Plan is to later implement SV_SamplePosition that follows HLSL range of -0.5 to +0.5,
 and emits GetRenderTargetSamplePosition(SV_SampleIndex) which needs more complicated IR manipulation for HLSL and Metal

Fixes #7906