### PR TITLE
Update slang-rhi deps for gfx-unit-test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,12 +142,12 @@ option(
 )
 option(
     SLANG_ENABLE_TESTS
-    "Enable test targets, some tests may require SLANG_ENABLE_GFX, SLANG_ENABLE_SLANGD or SLANG_ENABLE_SLANGRT"
+    "Enable test targets, some tests may require SLANG_ENABLE_SLANG_RHI, SLANG_ENABLE_SLANGD or SLANG_ENABLE_SLANGRT"
     ON
 )
 option(
     SLANG_ENABLE_EXAMPLES
-    "Enable example targets, requires SLANG_ENABLE_GFX"
+    "Enable example targets, requires SLANG_ENABLE_SLANG_RHI"
     ON
 )
 option(SLANG_ENABLE_REPLAYER "Enable slang-replay tool" ON)
@@ -389,8 +389,8 @@ if(SLANG_ENABLE_NVAPI AND NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(SEND_ERROR "SLANG_ENABLE_NVAPI is only supported on Windows")
 endif()
 
-if(SLANG_ENABLE_TESTS AND NOT SLANG_ENABLE_GFX)
-    message(SEND_ERROR "SLANG_ENABLE_TESTS requires SLANG_ENABLE_GFX")
+if(SLANG_ENABLE_TESTS AND NOT SLANG_ENABLE_SLANG_RHI)
+    message(SEND_ERROR "SLANG_ENABLE_TESTS requires SLANG_ENABLE_SLANG_RHI")
 endif()
 
 #

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -91,7 +91,8 @@
       "description": "Build the compile time generators used in building Slang",
       "cacheVariables": {
         "SLANG_SLANG_LLVM_FLAVOR": "DISABLE",
-        "SLANG_ENABLE_SLANG_RHI": false
+        "SLANG_ENABLE_SLANG_RHI": false,
+        "SLANG_ENABLE_TESTS": false
       }
     }
   ],

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -72,7 +72,7 @@ function(example dir)
     )
 endfunction()
 
-if(SLANG_ENABLE_EXAMPLES)
+if(SLANG_ENABLE_EXAMPLES AND SLANG_ENABLE_SLANG_RHI)
     #
     # Examples
     #

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -129,6 +129,8 @@ if(SLANG_ENABLE_GFX)
     #
     # GFX
     #
+    # `gfx` is kept here for legacy reasons. It's not used by any slang tests but some external
+    # projects use it. We should remove it in the future.
     slang_add_target(
         gfx
         ${SLANG_LIB_TYPE}
@@ -187,8 +189,9 @@ if(SLANG_ENABLE_GFX)
         FOLDER gfx
     )
 
-
-    set(modules_dest_dir $<TARGET_FILE_DIR:slang-test>)
+    # since slang-test does not depend on gfx, we just copy the gfx modules to the slangc
+    # directory. So even if slang-test is not built, the gfx modules are still available.
+    set(modules_dest_dir $<TARGET_FILE_DIR:slangc>)
     add_custom_target(
         copy-gfx-slang-modules
         COMMAND ${CMAKE_COMMAND} -E make_directory ${modules_dest_dir}
@@ -207,7 +210,7 @@ if(SLANG_ENABLE_GFX)
         DESTINATION ${runtime_subdir}
     )
 endif()
-if(SLANG_ENABLE_TESTS)
+if(SLANG_ENABLE_TESTS AND SLANG_ENABLE_SLANG_RHI)
     # The test executables and runtime-loaded modules
     slang_add_target(
         test-server
@@ -216,7 +219,7 @@ if(SLANG_ENABLE_TESTS)
         LINK_WITH_PRIVATE core compiler-core slang
         INCLUDE_FROM_PRIVATE
             unit-test
-            $<$<BOOL:${SLANG_ENABLE_SLANG_RHI}>:slang-rhi>
+            slang-rhi
         FOLDER test
     )
     slang_add_target(
@@ -239,7 +242,7 @@ if(SLANG_ENABLE_TESTS)
             stb
             ${CMAKE_DL_LIBS}
             Threads::Threads
-        INCLUDE_FROM_PRIVATE $<$<BOOL:${SLANG_ENABLE_SLANG_RHI}>:slang-rhi>
+        INCLUDE_FROM_PRIVATE slang-rhi
         REQUIRES
             # Shared libraries dlopened by slang-test
             slang-reflection-test
@@ -292,7 +295,6 @@ if(SLANG_ENABLE_TESTS)
     )
 
     # These are libraries loaded at runtime from the test executable:
-    if(SLANG_ENABLE_GFX AND SLANG_ENABLE_SLANG_RHI)
         #
         # `platform` contains all the platform abstractions for a GUI application.
         #
@@ -366,6 +368,7 @@ if(SLANG_ENABLE_TESTS)
                 platform
                 stb
                 $<$<BOOL:${SLANG_ENABLE_CUDA}>:CUDA::cuda_driver>
+            INCLUDE_FROM_PRIVATE slang-rhi
             EXTRA_COMPILE_DEFINITIONS_PRIVATE
                 $<$<BOOL:${SLANG_ENABLE_CUDA}>:RENDER_TEST_CUDA>
                 $<$<BOOL:${SLANG_ENABLE_OPTIX}>:RENDER_TEST_OPTIX>
@@ -374,7 +377,7 @@ if(SLANG_ENABLE_TESTS)
             REQUIRED_BY slang-test
             FOLDER test/tools
         )
-    endif()
+
     slang_add_target(
         slang-unit-test
         MODULE

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -217,9 +217,7 @@ if(SLANG_ENABLE_TESTS AND SLANG_ENABLE_SLANG_RHI)
         EXECUTABLE
         EXCLUDE_FROM_ALL
         LINK_WITH_PRIVATE core compiler-core slang
-        INCLUDE_FROM_PRIVATE
-            unit-test
-            slang-rhi
+        INCLUDE_FROM_PRIVATE unit-test slang-rhi
         FOLDER test
     )
     slang_add_target(
@@ -295,80 +293,80 @@ if(SLANG_ENABLE_TESTS AND SLANG_ENABLE_SLANG_RHI)
     )
 
     # These are libraries loaded at runtime from the test executable:
-        #
-        # `platform` contains all the platform abstractions for a GUI application.
-        #
-        slang_add_target(
+    #
+    # `platform` contains all the platform abstractions for a GUI application.
+    #
+    slang_add_target(
+        platform
+        ${SLANG_LIB_TYPE}
+        EXCLUDE_FROM_ALL
+        USE_FEWER_WARNINGS
+        LINK_WITH_PRIVATE
+            core
+            imgui
+            stb
+            $<$<BOOL:${SLANG_ENABLE_XLIB}>:X11::X11>
+            slang-rhi
+            "$<$<PLATFORM_ID:Darwin>:-framework Cocoa>"
+            "$<$<PLATFORM_ID:Darwin>:-framework QuartzCore>"
+            ${CMAKE_DL_LIBS}
+        LINK_WITH_FRAMEWORK Foundation Cocoa QuartzCore
+        EXTRA_COMPILE_DEFINITIONS_PRIVATE
+            $<$<BOOL:${SLANG_ENABLE_XLIB}>:SLANG_ENABLE_XLIB=1>
+        INCLUDE_FROM_PRIVATE imgui slang-rhi
+        INCLUDE_DIRECTORIES_PUBLIC
+            .
             platform
-            ${SLANG_LIB_TYPE}
-            EXCLUDE_FROM_ALL
-            USE_FEWER_WARNINGS
-            LINK_WITH_PRIVATE
-                core
-                imgui
-                stb
-                $<$<BOOL:${SLANG_ENABLE_XLIB}>:X11::X11>
-                slang-rhi
-                "$<$<PLATFORM_ID:Darwin>:-framework Cocoa>"
-                "$<$<PLATFORM_ID:Darwin>:-framework QuartzCore>"
-                ${CMAKE_DL_LIBS}
-            LINK_WITH_FRAMEWORK Foundation Cocoa QuartzCore
-            EXTRA_COMPILE_DEFINITIONS_PRIVATE
-                $<$<BOOL:${SLANG_ENABLE_XLIB}>:SLANG_ENABLE_XLIB=1>
-            INCLUDE_FROM_PRIVATE imgui slang-rhi
-            INCLUDE_DIRECTORIES_PUBLIC
-                .
-                platform
-                if
-                (not ${SLANG_OVERRIDE_GLM_PATH})
-            INCLUDE_DIRECTORIES_PUBLIC ${slang_SOURCE_DIR}/external else ()
-            INCLUDE_DIRECTORIES_PUBLIC ${SLANG_OVERRIDE_GLM_PATH} endif ()
-            EXPORT_MACRO_PREFIX SLANG_PLATFORM
-        )
+            if
+            (not ${SLANG_OVERRIDE_GLM_PATH})
+        INCLUDE_DIRECTORIES_PUBLIC ${slang_SOURCE_DIR}/external else ()
+        INCLUDE_DIRECTORIES_PUBLIC ${SLANG_OVERRIDE_GLM_PATH} endif ()
+        EXPORT_MACRO_PREFIX SLANG_PLATFORM
+    )
 
-        slang_add_target(
-            gfx-unit-test
-            MODULE
-            EXCLUDE_FROM_ALL
-            EXTRA_COMPILE_DEFINITIONS_PRIVATE SLANG_SHARED_LIBRARY_TOOL
-            USE_FEWER_WARNINGS
-            LINK_WITH_PRIVATE core slang unit-test stb platform slang-rhi
-            INCLUDE_FROM_PRIVATE slang-rhi
-            INCLUDE_DIRECTORIES_PUBLIC
-                .
-                platform
-                if
-                (not ${SLANG_OVERRIDE_GLM_PATH})
-            INCLUDE_DIRECTORIES_PUBLIC ${slang_SOURCE_DIR}/external else ()
-            INCLUDE_DIRECTORIES_PUBLIC ${SLANG_OVERRIDE_GLM_PATH} endif ()
-            OUTPUT_NAME gfx-unit-test-tool
-            REQUIRED_BY slang-test
-            FOLDER test/tools
-        )
+    slang_add_target(
+        gfx-unit-test
+        MODULE
+        EXCLUDE_FROM_ALL
+        EXTRA_COMPILE_DEFINITIONS_PRIVATE SLANG_SHARED_LIBRARY_TOOL
+        USE_FEWER_WARNINGS
+        LINK_WITH_PRIVATE core slang unit-test stb platform slang-rhi
+        INCLUDE_FROM_PRIVATE slang-rhi
+        INCLUDE_DIRECTORIES_PUBLIC
+            .
+            platform
+            if
+            (not ${SLANG_OVERRIDE_GLM_PATH})
+        INCLUDE_DIRECTORIES_PUBLIC ${slang_SOURCE_DIR}/external else ()
+        INCLUDE_DIRECTORIES_PUBLIC ${SLANG_OVERRIDE_GLM_PATH} endif ()
+        OUTPUT_NAME gfx-unit-test-tool
+        REQUIRED_BY slang-test
+        FOLDER test/tools
+    )
 
-        slang_add_target(
-            render-test
-            MODULE
-            EXCLUDE_FROM_ALL
-            EXTRA_COMPILE_DEFINITIONS_PRIVATE SLANG_SHARED_LIBRARY_TOOL
-            USE_FEWER_WARNINGS
-            LINK_WITH_PRIVATE
-                core
-                compiler-core
-                slang
-                slang-rhi
-                platform
-                stb
-                $<$<BOOL:${SLANG_ENABLE_CUDA}>:CUDA::cuda_driver>
-            INCLUDE_FROM_PRIVATE slang-rhi
-            EXTRA_COMPILE_DEFINITIONS_PRIVATE
-                $<$<BOOL:${SLANG_ENABLE_CUDA}>:RENDER_TEST_CUDA>
-                $<$<BOOL:${SLANG_ENABLE_OPTIX}>:RENDER_TEST_OPTIX>
-            EXTRA_COMPILE_OPTIONS_PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/EHa>
-            OUTPUT_NAME render-test-tool
-            REQUIRED_BY slang-test
-            FOLDER test/tools
-        )
+    slang_add_target(
+        render-test
+        MODULE
+        EXCLUDE_FROM_ALL
+        EXTRA_COMPILE_DEFINITIONS_PRIVATE SLANG_SHARED_LIBRARY_TOOL
+        USE_FEWER_WARNINGS
+        LINK_WITH_PRIVATE
+            core
+            compiler-core
+            slang
+            slang-rhi
+            platform
+            stb
+            $<$<BOOL:${SLANG_ENABLE_CUDA}>:CUDA::cuda_driver>
+        INCLUDE_FROM_PRIVATE slang-rhi
+        EXTRA_COMPILE_DEFINITIONS_PRIVATE
+            $<$<BOOL:${SLANG_ENABLE_CUDA}>:RENDER_TEST_CUDA>
+            $<$<BOOL:${SLANG_ENABLE_OPTIX}>:RENDER_TEST_OPTIX>
+        EXTRA_COMPILE_OPTIONS_PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/EHa>
+        OUTPUT_NAME render-test-tool
+        REQUIRED_BY slang-test
+        FOLDER test/tools
+    )
 
     slang_add_target(
         slang-unit-test

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -187,38 +187,6 @@ if(SLANG_ENABLE_GFX)
         FOLDER gfx
     )
 
-    #
-    # `platform` contains all the platform abstractions for a GUI application.
-    #
-    slang_add_target(
-        platform
-        ${SLANG_LIB_TYPE}
-        EXCLUDE_FROM_ALL
-        USE_FEWER_WARNINGS
-        LINK_WITH_PRIVATE
-            core
-            imgui
-            stb
-            $<$<BOOL:${SLANG_ENABLE_XLIB}>:X11::X11>
-            $<$<BOOL:${SLANG_ENABLE_SLANG_RHI}>:slang-rhi>
-            "$<$<PLATFORM_ID:Darwin>:-framework Cocoa>"
-            "$<$<PLATFORM_ID:Darwin>:-framework QuartzCore>"
-            ${CMAKE_DL_LIBS}
-        LINK_WITH_FRAMEWORK Foundation Cocoa QuartzCore
-        EXTRA_COMPILE_DEFINITIONS_PRIVATE
-            $<$<BOOL:${SLANG_ENABLE_XLIB}>:SLANG_ENABLE_XLIB=1>
-        INCLUDE_FROM_PRIVATE
-            imgui
-            $<$<BOOL:${SLANG_ENABLE_SLANG_RHI}>:slang-rhi>
-        INCLUDE_DIRECTORIES_PUBLIC
-            .
-            platform
-            if
-            (not ${SLANG_OVERRIDE_GLM_PATH})
-        INCLUDE_DIRECTORIES_PUBLIC ${slang_SOURCE_DIR}/external else ()
-        INCLUDE_DIRECTORIES_PUBLIC ${SLANG_OVERRIDE_GLM_PATH} endif ()
-        EXPORT_MACRO_PREFIX SLANG_PLATFORM
-    )
 
     set(modules_dest_dir $<TARGET_FILE_DIR:slang-test>)
     add_custom_target(
@@ -296,7 +264,9 @@ if(SLANG_ENABLE_TESTS)
         PROPERTY VS_STARTUP_PROJECT slang-test
     )
 
-    add_dependencies(slang-test copy-gfx-slang-modules)
+    if(SLANG_ENABLE_GFX)
+        add_dependencies(slang-test copy-gfx-slang-modules)
+    endif()
 
     include(CTest)
     add_test(
@@ -322,7 +292,40 @@ if(SLANG_ENABLE_TESTS)
     )
 
     # These are libraries loaded at runtime from the test executable:
-    if(SLANG_ENABLE_GFX)
+    if(SLANG_ENABLE_GFX AND SLANG_ENABLE_SLANG_RHI)
+        #
+        # `platform` contains all the platform abstractions for a GUI application.
+        #
+        slang_add_target(
+            platform
+            ${SLANG_LIB_TYPE}
+            EXCLUDE_FROM_ALL
+            USE_FEWER_WARNINGS
+            LINK_WITH_PRIVATE
+                core
+                imgui
+                stb
+                $<$<BOOL:${SLANG_ENABLE_XLIB}>:X11::X11>
+                slang-rhi
+                "$<$<PLATFORM_ID:Darwin>:-framework Cocoa>"
+                "$<$<PLATFORM_ID:Darwin>:-framework QuartzCore>"
+                ${CMAKE_DL_LIBS}
+            LINK_WITH_FRAMEWORK Foundation Cocoa QuartzCore
+            EXTRA_COMPILE_DEFINITIONS_PRIVATE
+                $<$<BOOL:${SLANG_ENABLE_XLIB}>:SLANG_ENABLE_XLIB=1>
+            INCLUDE_FROM_PRIVATE
+                imgui
+                slang-rhi
+            INCLUDE_DIRECTORIES_PUBLIC
+                .
+                platform
+                if
+                (not ${SLANG_OVERRIDE_GLM_PATH})
+            INCLUDE_DIRECTORIES_PUBLIC ${slang_SOURCE_DIR}/external else ()
+            INCLUDE_DIRECTORIES_PUBLIC ${SLANG_OVERRIDE_GLM_PATH} endif ()
+            EXPORT_MACRO_PREFIX SLANG_PLATFORM
+        )
+
         slang_add_target(
             gfx-unit-test
             MODULE
@@ -335,8 +338,8 @@ if(SLANG_ENABLE_TESTS)
                 unit-test
                 stb
                 platform
-                $<$<BOOL:${SLANG_ENABLE_SLANG_RHI}>:slang-rhi>
-            INCLUDE_FROM_PRIVATE $<$<BOOL:${SLANG_ENABLE_SLANG_RHI}>:slang-rhi>
+                slang-rhi
+            INCLUDE_FROM_PRIVATE slang-rhi
             INCLUDE_DIRECTORIES_PUBLIC
                 .
                 platform
@@ -348,30 +351,29 @@ if(SLANG_ENABLE_TESTS)
             REQUIRED_BY slang-test
             FOLDER test/tools
         )
-        if(SLANG_ENABLE_SLANG_RHI)
-            slang_add_target(
-                render-test
-                MODULE
-                EXCLUDE_FROM_ALL
-                EXTRA_COMPILE_DEFINITIONS_PRIVATE SLANG_SHARED_LIBRARY_TOOL
-                USE_FEWER_WARNINGS
-                LINK_WITH_PRIVATE
-                    core
-                    compiler-core
-                    slang
-                    slang-rhi
-                    platform
-                    stb
-                    $<$<BOOL:${SLANG_ENABLE_CUDA}>:CUDA::cuda_driver>
-                EXTRA_COMPILE_DEFINITIONS_PRIVATE
-                    $<$<BOOL:${SLANG_ENABLE_CUDA}>:RENDER_TEST_CUDA>
-                    $<$<BOOL:${SLANG_ENABLE_OPTIX}>:RENDER_TEST_OPTIX>
-                EXTRA_COMPILE_OPTIONS_PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/EHa>
-                OUTPUT_NAME render-test-tool
-                REQUIRED_BY slang-test
-                FOLDER test/tools
-            )
-        endif()
+
+        slang_add_target(
+            render-test
+            MODULE
+            EXCLUDE_FROM_ALL
+            EXTRA_COMPILE_DEFINITIONS_PRIVATE SLANG_SHARED_LIBRARY_TOOL
+            USE_FEWER_WARNINGS
+            LINK_WITH_PRIVATE
+                core
+                compiler-core
+                slang
+                slang-rhi
+                platform
+                stb
+                $<$<BOOL:${SLANG_ENABLE_CUDA}>:CUDA::cuda_driver>
+            EXTRA_COMPILE_DEFINITIONS_PRIVATE
+                $<$<BOOL:${SLANG_ENABLE_CUDA}>:RENDER_TEST_CUDA>
+                $<$<BOOL:${SLANG_ENABLE_OPTIX}>:RENDER_TEST_OPTIX>
+            EXTRA_COMPILE_OPTIONS_PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/EHa>
+            OUTPUT_NAME render-test-tool
+            REQUIRED_BY slang-test
+            FOLDER test/tools
+        )
     endif()
     slang_add_target(
         slang-unit-test


### PR DESCRIPTION
This PR marks the `slang-rhi` a required dependecy for `platform` and `gfx-unit-test`, and only build them when `SLANG_ENABLE_SLANG_RHI=ON`.
This should allow the slang still to be built without those tests components when `SLANG_ENABLE_SLANG_RHI=OFF`.