### PR TITLE
Skip lambda capture for static variables

### DIFF
--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -3466,7 +3466,7 @@ Expr* SemanticsExprVisitor::maybeRegisterLambdaCapture(Expr* exprIn)
     if (!srcDecl)
         return exprIn;
 
-    if (as<VarDeclBase>(srcDecl) && (isGlobalDecl(srcDecl) || isEffectivelyStatic(srcDecl)))
+    if (as<VarDeclBase>(srcDecl) && (isGlobalDecl(srcDecl) || srcDecl->hasModifier<HLSLStaticModifier>()))
         return exprIn;
 
     auto lambdaScope = m_parentLambdaExpr->paramScopeDecl;

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -3466,7 +3466,7 @@ Expr* SemanticsExprVisitor::maybeRegisterLambdaCapture(Expr* exprIn)
     if (!srcDecl)
         return exprIn;
 
-    if (as<VarDeclBase>(srcDecl) && isGlobalDecl(srcDecl))
+    if (as<VarDeclBase>(srcDecl) && (isGlobalDecl(srcDecl) || isEffectivelyStatic(srcDecl)))
         return exprIn;
 
     auto lambdaScope = m_parentLambdaExpr->paramScopeDecl;

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -3466,7 +3466,8 @@ Expr* SemanticsExprVisitor::maybeRegisterLambdaCapture(Expr* exprIn)
     if (!srcDecl)
         return exprIn;
 
-    if (as<VarDeclBase>(srcDecl) && (isGlobalDecl(srcDecl) || srcDecl->hasModifier<HLSLStaticModifier>()))
+    if (as<VarDeclBase>(srcDecl) &&
+        (isGlobalDecl(srcDecl) || srcDecl->hasModifier<HLSLStaticModifier>()))
         return exprIn;
 
     auto lambdaScope = m_parentLambdaExpr->paramScopeDecl;

--- a/tests/bugs/gh-8220.slang
+++ b/tests/bugs/gh-8220.slang
@@ -1,0 +1,13 @@
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage compute -entry main
+
+[shader("compute")]
+[numthreads(4, 4, 4)]
+void main()
+{
+    static groupshared Array<float, 4096> array;
+
+    let lambda = () => { return array[1]; };
+    array[0] = lambda();
+}
+
+// WGSL-NOT: array<f32, i32(4096)>,

--- a/tests/language-feature/lambda/lambda-static.slang
+++ b/tests/language-feature/lambda/lambda-static.slang
@@ -1,0 +1,43 @@
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0 0], stride=4)
+RWStructuredBuffer<int> outputBuffer;
+
+IFunc<int> foo<int x>(int s)
+{
+     static int v = x;
+     let f = ()=>{return v;};
+     v += s;
+     return f;
+}
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    IFunc<int> lambda1;
+    IFunc<int> lambda2;
+
+    {
+        static int a = 4;
+        int b = a;
+        lambda1 = () => { return a; };
+        lambda2 = () => { return b; };
+        a++;
+    }
+
+    let lambda3 = foo<3>(0);
+    let lambda4 = foo<3>(2);
+    let lambda5 = foo<8>(0);
+
+    // CHECK: 5
+    outputBuffer[0] = lambda1();
+    // CHECK-NEXT: 4
+    outputBuffer[1] = lambda2();
+    // CHECK-NEXT: 5
+    outputBuffer[2] = lambda3();
+    // CHECK-NEXT: 5
+    outputBuffer[3] = lambda4();
+    // CHECK-NEXT: 8
+    outputBuffer[4] = lambda5();
+}


### PR DESCRIPTION
Closes #8220. They're already skipped for global variables, so I don't see a reason why static variables ought to be captured either. At least I can't see any lifetime issues with doing this.