### PR TITLE
Allow variable declaration in a new line after struct declaration

### DIFF
--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -3073,9 +3073,32 @@ static DeclBase* ParseDeclaratorDecl(
                 // The token after the `}` is at the start of its
                 // own line, which means it can't be on the same line.
                 //
-                // This means the programmer probably wants to
-                // just treat this as a declaration.
-                return declGroupBuilder.getResult();
+                // However, we need to check if this could be a variable
+                // declarator that just happens to be on a new line.
+                // If the next token is an identifier followed by `=`, `,`, or `;`,
+                // it's likely a variable declaration.
+                if (peekToken(parser).type == TokenType::Identifier)
+                {
+                    // Look ahead to see if this looks like a variable declarator
+                    if (parser->LookAheadToken(TokenType::OpAssign, 1) ||
+                        parser->LookAheadToken(TokenType::Comma, 1) ||
+                        parser->LookAheadToken(TokenType::Semicolon, 1) ||
+                        parser->LookAheadToken(TokenType::LBracket, 1))
+                    {
+                        // This looks like a variable declarator, continue parsing
+                    }
+                    else
+                    {
+                        // This doesn't look like a variable declarator,
+                        // treat the struct declaration as complete
+                        return declGroupBuilder.getResult();
+                    }
+                }
+                else
+                {
+                    // Not an identifier, so definitely not a variable declarator
+                    return declGroupBuilder.getResult();
+                }
             }
         }
     }

--- a/tests/language-feature/struct-variable-newline.slang
+++ b/tests/language-feature/struct-variable-newline.slang
@@ -1,0 +1,31 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF): -shaderobj
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+// Test case for issue 8187: Variable name on new line after struct declaration
+static const struct
+{
+    int value;
+}
+structOnNewLine = { 1 };
+
+// Test another variable on new line
+static const struct
+{
+    int data;
+}
+secondStruct = { 2 };
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    // BUF: 1
+    outputBuffer[0] = structOnNewLine.value;
+    // BUF: 2
+    outputBuffer[1] = secondStruct.data;
+    // BUF: 3
+    outputBuffer[2] = 3;
+    // BUF: 4
+    outputBuffer[3] = 4;
+}


### PR DESCRIPTION
Fixes https://github.com/shader-slang/slang/issues/8187