### PR TITLE
Fix readlink missing include

### DIFF
--- a/source/core/slang-platform.cpp
+++ b/source/core/slang-platform.cpp
@@ -18,6 +18,7 @@
 
 #if SLANG_LINUX_FAMILY
 #include <execinfo.h>
+#include <unistd.h>
 #endif
 
 namespace Slang


### PR DESCRIPTION
On Linux, `slang-platform.cpp` compiles with libstdc++ only because `unistd.h` is being transitively included. It fails to compile with standard libraries that don't include `unistd.h` like libc++.

This is the how it's being transitively included with libstdc++:
```
/home/mcvm/dev/slang/source/core/slang-platform.h
/home/mcvm/dev/slang/source/core/../core/slang-string.h
/home/mcvm/dev/slang/source/core/../core/slang-hash.h
/home/mcvm/dev/slang/external/unordered_dense/include/ankerl/unordered_dense.h
/usr/lib64/gcc/x86_64-unknown-linux-gnu/15.1.0/../../../../include/c++/15.1.0/memory
/usr/lib64/gcc/x86_64-unknown-linux-gnu/15.1.0/../../../../include/c++/15.1.0/bits/shared_ptr_atomic.h
/usr/lib64/gcc/x86_64-unknown-linux-gnu/15.1.0/../../../../include/c++/15.1.0/bits/atomic_base.h
/usr/lib64/gcc/x86_64-unknown-linux-gnu/15.1.0/../../../../include/c++/15.1.0/bits/atomic_wait.h
/usr/include/unistd.h
```

Tested building with `-stdlib=libc++` and `-stdlib=libstdc++`.