### PR TITLE
Add WASM platform support to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,13 +192,13 @@ jobs:
 
           # WASM packaging
           if [[ "${{ matrix.platform }}" == "wasm" ]]; then
-            wasm_base=slang-wasm-${version}
-            mkdir -p "${wasm_base}"
-            cp build.em/Release/bin/slang-wasm.wasm "${wasm_base}/slang-wasm.wasm"
-            cp build.em/Release/bin/slang-wasm.js "${wasm_base}/slang-wasm.js"
-            cp build.em/Release/bin/interface.d.ts "${wasm_base}/interface.d.ts"
-            (cd "${wasm_base}" && zip -r "../${wasm_base}.zip" .)
-            echo "SLANG_WASM_ARCHIVE_ZIP=${wasm_base}.zip" >> "$GITHUB_OUTPUT"
+            base=slang-${version}-${{matrix.platform}}
+            mkdir -p "${base}"
+            cp build.em/Release/bin/slang-wasm.wasm "${base}/slang-wasm.wasm"
+            cp build.em/Release/bin/slang-wasm.js "${base}/slang-wasm.js"
+            cp build.em/Release/bin/interface.d.ts "${base}/interface.d.ts"
+            (cd "${base}" && zip -r "../${base}.zip" .)
+            echo "SLANG_BINARY_ARCHIVE_ZIP=${base}.zip" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -259,7 +259,6 @@ jobs:
             ${{ steps.package.outputs.SLANG_BINARY_ARCHIVE_TAR }}
             ${{ steps.package.outputs.SLANG_DEBUG_INFO_ARCHIVE_ZIP }}
             ${{ steps.package.outputs.SLANG_DEBUG_INFO_ARCHIVE_TAR }}
-            ${{ steps.package.outputs.SLANG_WASM_ARCHIVE_ZIP }}
             ${{ steps.notarize.outputs.SLANG_NOTARIZED_DIST }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,11 @@ jobs:
       matrix:
         os: [linux, macos, windows]
         config: [release]
-        platform: [x86_64, aarch64]
+        platform: [x86_64, aarch64, wasm]
         test-category: [smoke]
+        exclude:
+          - { os: windows, platform: wasm }
+          - { os: macos, platform: wasm }
         include:
           - {
               os: linux,
@@ -27,6 +30,13 @@ jobs:
               platform: aarch64,
               runs-on: ubuntu-24.04-arm,
               compiler: gcc,
+            }
+          - {
+              os: linux,
+              platform: wasm,
+              runs-on: ubuntu-22.04,
+              compiler: gcc,
+              build-slang-llvm: false,
             }
           - { os: windows, runs-on: windows-latest, compiler: cl }
           - { os: macos, runs-on: macos-latest, compiler: clang }
@@ -90,6 +100,18 @@ jobs:
 
       - name: Build Slang
         run: |
+          if [[ "${{ matrix.platform }}" == "wasm" ]]; then
+            git clone https://github.com/emscripten-core/emsdk.git
+            pushd emsdk
+              ./emsdk install latest
+              ./emsdk activate latest
+              source ./emsdk_env.sh
+            popd
+            emcmake cmake -DSLANG_GENERATORS_PATH=build-platform-generators/bin --preset emscripten -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
+            cmake --build --preset emscripten --config Release --target slang-wasm
+            exit 0
+          fi
+
           if [[ "${{ matrix.os }}" == "windows" && "${{ matrix.config }}" != "release" && "${{ matrix.config }}" != "releaseWithDebugInfo" ]]; then
               echo "Please see ci.yml for the steps to make non-release builds work on Windows" >&2
               exit 1
@@ -160,13 +182,6 @@ jobs:
       - name: Package Slang
         id: package
         run: |
-          # Package main binaries
-          cpack --preset "$config" -G ZIP
-          cpack --preset "$config" -G TGZ
-          # Package debug info
-          cpack --preset "$config-debug-info" -G ZIP
-          cpack --preset "$config-debug-info" -G TGZ
-
           triggering_ref=${{ github.ref_name }}
           if [[ $triggering_ref =~ ^v[0-9] ]]; then
             version=${triggering_ref#v}
@@ -174,6 +189,25 @@ jobs:
             version=$triggering_ref
           fi
           base=slang-${version}-${{matrix.os}}-${{matrix.platform}}
+
+          # WASM packaging
+          if [[ "${{ matrix.platform }}" == "wasm" ]]; then
+            wasm_base=slang-wasm-${version}
+            mkdir -p "${wasm_base}"
+            cp build.em/Release/bin/slang-wasm.wasm "${wasm_base}/slang-wasm.wasm"
+            cp build.em/Release/bin/slang-wasm.js "${wasm_base}/slang-wasm.js"
+            cp build.em/Release/bin/interface.d.ts "${wasm_base}/interface.d.ts"
+            (cd "${wasm_base}" && zip -r "../${wasm_base}.zip" .)
+            echo "SLANG_WASM_ARCHIVE_ZIP=${wasm_base}.zip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Package main binaries
+          cpack --preset "$config" -G ZIP
+          cpack --preset "$config" -G TGZ
+          # Package debug info
+          cpack --preset "$config-debug-info" -G ZIP
+          cpack --preset "$config-debug-info" -G TGZ
 
           # Move main packages
           mv "$(pwd)/build/dist-${config}/slang.zip" "${base}.zip"
@@ -225,6 +259,7 @@ jobs:
             ${{ steps.package.outputs.SLANG_BINARY_ARCHIVE_TAR }}
             ${{ steps.package.outputs.SLANG_DEBUG_INFO_ARCHIVE_ZIP }}
             ${{ steps.package.outputs.SLANG_DEBUG_INFO_ARCHIVE_TAR }}
+            ${{ steps.package.outputs.SLANG_WASM_ARCHIVE_ZIP }}
             ${{ steps.notarize.outputs.SLANG_NOTARIZED_DIST }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is a first pass at adding WASM builds to releases. ~~I haven't tested the outputs yet but it appears to build successfully in my fork at least.~~

Edit: Made a fake release in my fork for testing, seems to be working well for my use case at least: https://github.com/davidar/slang/releases/tag/v2025.999

Fixes #8207
