### PR TITLE
Revert "Reduce the dependency to thread library (#8216)"

### DIFF
--- a/source/core/CMakeLists.txt
+++ b/source/core/CMakeLists.txt
@@ -4,7 +4,7 @@ slang_add_target(
     EXPORT_MACRO_PREFIX SLANG
     EXCLUDE_FROM_ALL
     USE_EXTRA_WARNINGS
-    LINK_WITH_PRIVATE miniz lz4_static ${CMAKE_DL_LIBS}
+    LINK_WITH_PRIVATE miniz lz4_static Threads::Threads ${CMAKE_DL_LIBS}
     LINK_WITH_PUBLIC unordered_dense::unordered_dense
     INCLUDE_DIRECTORIES_PUBLIC
         ${slang_SOURCE_DIR}/source

--- a/source/slang-rt/CMakeLists.txt
+++ b/source/slang-rt/CMakeLists.txt
@@ -5,7 +5,7 @@ if(SLANG_ENABLE_SLANGRT)
         # This compiles 'core' again with the SLANG_RT_DYNAMIC_EXPORT macro defined
         EXTRA_SOURCE_DIRS ${slang_SOURCE_DIR}/source/core
         USE_EXTRA_WARNINGS
-        LINK_WITH_PRIVATE miniz lz4_static ${CMAKE_DL_LIBS}
+        LINK_WITH_PRIVATE miniz lz4_static Threads::Threads ${CMAKE_DL_LIBS}
         LINK_WITH_PUBLIC unordered_dense::unordered_dense
         EXPORT_MACRO_PREFIX SLANG_RT
         INCLUDE_DIRECTORIES_PUBLIC ${slang_SOURCE_DIR}/include

--- a/source/slangc/CMakeLists.txt
+++ b/source/slangc/CMakeLists.txt
@@ -13,6 +13,7 @@ if(SLANG_ENABLE_SLANGC)
         LINK_WITH_PRIVATE
             core
             slang
+            Threads::Threads
             ${SLANG_GLSL_MODULE_DEPENDENCY}
         INSTALL
         EXPORT_SET_NAME SlangTargets


### PR DESCRIPTION
This cause the pthread not found issue on old glibc build. This reverts commit 113327194d4cf750af6265a560615850a8e7e6fb.