### PR TITLE
Add check for backtrace availability

### DIFF
--- a/include/slang.h
+++ b/include/slang.h
@@ -489,6 +489,18 @@ convention for interface methods.
     #define SLANG_UNALIGNED_ACCESS 0
 #endif
 
+// Backtrace
+#if SLANG_LINUX_FAMILY
+    #include <features.h> // for __GLIBC__ define, if using GNU libc
+    #if defined(__GLIBC__) || (__ANDROID_API__ >= 33)
+        #define SLANG_HAS_BACKTRACE 1
+    #else
+        #define SLANG_HAS_BACKTRACE 0
+    #endif
+#else
+    #define SLANG_HAS_BACKTRACE 0
+#endif
+
 // One endianness must be set
 #if ((SLANG_BIG_ENDIAN | SLANG_LITTLE_ENDIAN) == 0)
     #error "Couldn't determine endianness"

--- a/source/core/slang-platform.cpp
+++ b/source/core/slang-platform.cpp
@@ -15,9 +15,11 @@
 #include <dlfcn.h>
 #endif
 
+#if SLANG_HAS_BACKTRACE
+#include <execinfo.h>
+#endif
 
 #if SLANG_LINUX_FAMILY
-#include <execinfo.h>
 #include <unistd.h>
 #endif
 
@@ -354,7 +356,7 @@ static const PlatformFlags s_familyFlags[int(PlatformFamily::CountOf)] = {
 
 /* static */ void PlatformUtil::backtrace()
 {
-#if SLANG_LINUX_FAMILY
+#if SLANG_HAS_BACKTRACE
     // Print stack trace for debugging assistance
     void* stackTrace[64];
     int stackDepth = ::backtrace(stackTrace, 64);


### PR DESCRIPTION
The header execinfo.h and the related backtrace functionality is not available on all linux platforms. In particular it's missing on musl linux and on Android before API version 33. This causes compilation errors on those platforms.

With this change, we first check if backtrace functionality is available by checking if we are using glibc or a compatible Android version.

Tested on manylinux_2_28 with glibc 2.28 and musllinux_1_2 with musl 1.2, has not been tested on Android.