### PR TITLE
Fix nvrtc lib searching in CUDA_PATH

### DIFF
--- a/source/compiler-core/slang-nvrtc-compiler.cpp
+++ b/source/compiler-core/slang-nvrtc-compiler.cpp
@@ -554,11 +554,11 @@ static SlangResult _findNVRTC(NVRTCPathVisitor& visitor)
         }
     }
 
-    // If we don't have a candidate try CUDA_PATH
+    // If we don't have a candidate, try CUDA_PATH
     if (!visitor.hasCandidates())
     {
         StringBuilder buf;
-        if (!SLANG_SUCCEEDED(PlatformUtil::getEnvironmentVariable(
+        if (SLANG_SUCCEEDED(PlatformUtil::getEnvironmentVariable(
                 UnownedStringSlice::fromLiteral("CUDA_PATH"),
                 buf)))
         {


### PR DESCRIPTION
If `CUDA_PATH` is found in the env var - `SLANG_SUCCEEDED` returned, we should use that to search for nvrtc lib.