### PR TITLE
Emit DBI for slang IR modules

### DIFF
--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -4,6 +4,8 @@
 #include "../core/slang-char-util.h"
 #include "../core/slang-hash.h"
 #include "../core/slang-performance-profiler.h"
+#include "../core/slang-string-util.h"
+#include "../core/slang-crypto.h"
 #include "../core/slang-random-generator.h"
 #include "slang-check.h"
 #include "slang-ir-autodiff.h"
@@ -12037,6 +12039,41 @@ static void ensureAllDeclsRec(IRGenContext* context, Decl* decl)
     }
 }
 
+// Generate a build identifier string for a translation unit based only on source file content
+String generateBuildIdentifierForTranslationUnit(TranslationUnitRequest* translationUnit)
+{
+    // Create a hash based only on the source files content
+    // This ensures the build identifier is consistent regardless of compile options
+
+    // Start with the module name as a base
+    StringBuilder sb;
+    sb << getText(translationUnit->getModuleDecl()->getName());
+
+    // Add the actual content of each source file
+    for (auto source : translationUnit->getSourceFiles())
+    {
+        // Include the actual source content only
+        auto content = source->getContent();
+        if (content.getLength() > 0)
+            sb << "_" << content;
+    }
+
+    // Generate a hash of the combined string
+    String combinedString = sb.produceString();
+
+    // Use SHA1 to generate a 20-byte hash
+    DigestBuilder<SHA1> builder;
+    builder.append(combinedString.getUnownedSlice());
+    auto digest = builder.finalize();
+
+    // Convert each byte to hex string
+    StringBuilder hashSb;
+    for (size_t i = 0; i < sizeof(digest.data) / sizeof(digest.data[0]); i++)
+        hashSb << StringUtil::makeStringWithFormat("%02x", digest.data[i]);
+    String result = hashSb.produceString();
+    return result;
+}
+
 RefPtr<IRModule> generateIRForTranslationUnit(
     ASTBuilder* astBuilder,
     TranslationUnitRequest* translationUnit)
@@ -12085,6 +12122,13 @@ RefPtr<IRModule> generateIRForTranslationUnit(
             context->shared->mapSourceFileToDebugSourceInst.add(source, debugSource);
         }
     }
+
+    // Always emit DebugBuildIdentifier instruction for all compiles
+    // Generate a build identifier based on the translation unit's content
+    builder->setInsertInto(module->getModuleInst());
+    String buildIdentifier = generateBuildIdentifierForTranslationUnit(translationUnit);
+    int buildIdentifierFlags = 0;
+    builder->emitDebugBuildIdentifier(buildIdentifier.getUnownedSlice(), buildIdentifierFlags);
 
     // For now, we will assume that *all* global-scope declarations
     // represent public/exported symbols.

--- a/tests/ir/debug-build-identifier-ir.slang
+++ b/tests/ir/debug-build-identifier-ir.slang
@@ -1,0 +1,12 @@
+//TEST(compute):SIMPLE(filecheck=CHECK):-dump-ir -stage compute -entry main -g2
+
+void main()
+{
+    float x = 1.0;
+    float y = 2.0;
+    float result = x + y;
+}
+
+// CHECK: module
+// CHECK: func main
+// CHECK: DebugBuildIdentifier("{{.*}}", 0 : UInt)


### PR DESCRIPTION
Emit the DBI instruction for Slang IR modules as a hash of the input source code only, ignoring compile options.