### PR TITLE
manually config ccache locally

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -132,23 +132,23 @@ runs:
           echo "   To enable ccache: manually install it on the runner with admin rights"
           exit 0
         fi
-        
+
         echo "✅ ccache found on self-hosted runner - setting up local caching"
-        
+
         # Set ccache directory (local temp directory)
         ccache_dir="${{ github.workspace }}/.ccache-local"
         mkdir -p "$ccache_dir"
         echo "CCACHE_DIR=$ccache_dir" >> $GITHUB_ENV
-        
+
         # Configure ccache settings for local use only
         ccache --set-config=max_size=2G
         ccache --set-config=compression=true
         ccache --set-config=compression_level=6
         ccache --set-config=sloppiness=pch_defines,time_macros
-        
+
         # Enable ccache for CMake (set environment variables)
         echo "ccache_symlinks_path=ccache" >> $GITHUB_ENV
-        
+
         # Show initial stats
         echo "ccache configuration:"
         ccache --show-config || echo "Could not show ccache config"


### PR DESCRIPTION
This avoids uploading the ccache to github and take the cache storage.
