### PR TITLE
Fix #8314 - Enable tests/compute/texture-subscript.slang for CUDA

### DIFF
--- a/tests/compute/texture-subscript.slang
+++ b/tests/compute/texture-subscript.slang
@@ -1,5 +1,6 @@
 //TEST:SIMPLE(filecheck=METAL): -target metal -entry computeMain -stage compute
 //TEST:SIMPLE(filecheck=METALLIB): -target metallib -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=CUDA): -target cuda -entry computeMain -stage compute
 // Metal lacks RWTexture GFX backend support. 
 // Due to this, Metal compute test is disabled
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUF): -slang -output-using-type -shaderobj -mtl
@@ -7,6 +8,17 @@
 
 //METAL-NOT: error 41402
 //METALLIB: @computeMain
+
+//CUDA: CUsurfObject outputTexture1D_{{[0-9]+}};
+//CUDA: CUsurfObject outputTexture2D_{{[0-9]+}};
+//CUDA: CUsurfObject outputTexture3D_{{[0-9]+}};
+//CUDA: globalParams_{{[0-9]+}}->outputTexture1D_{{[0-9]+}}[{{.*}}]
+//CUDA: globalParams_{{[0-9]+}}->outputTexture2D_{{[0-9]+}}[{{.*}}]
+//CUDA: globalParams_{{[0-9]+}}->outputTexture3D_{{[0-9]+}}[{{.*}}]
+//CUDA: surf1Dread<{{.*}}>
+//CUDA: surf2Dread<{{.*}}>
+//CUDA: surf3Dread<{{.*}}>
+//CUDA: surf2DLayeredread<{{.*}}>
 
 //TEST_INPUT: RWTexture1D(format=RGBA8Sint, size=8, content = zero, mipMaps = 1):name outputTexture1D
 RWTexture1D<int4> outputTexture1D;


### PR DESCRIPTION
The test can be enabled