### PR TITLE
Fixed BaseType enums (AddressSpace, MemoryScope and AccessQualifier) type lowering

### DIFF
--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -2722,6 +2722,10 @@ IRType* IRBuilder::getType(IROp op, IRInst* operand0)
 
 IRBasicType* IRBuilder::getBasicType(BaseType baseType)
 {
+    if ((UInt)baseType > (UInt)BaseType::CountOfPrimitives)
+    {
+        baseType = getBaseEnumUnderlyingType(baseType);
+    }
     return (IRBasicType*)getType(IROp((UInt)kIROp_FirstBasicType + (UInt)baseType));
 }
 

--- a/source/slang/slang-type-system-shared.cpp
+++ b/source/slang/slang-type-system-shared.cpp
@@ -2,6 +2,54 @@
 
 #include "../core/slang-common.h"
 
+#include <bit>
+#include <type_traits>
+
 namespace Slang
 {
+template<typename T>
+static constexpr BaseType GetBaseType()
+{
+    if constexpr (std::is_same_v<T, void>)
+    {
+        return BaseType::Void;
+    }
+    else if constexpr (std::is_same_v<T, bool>)
+    {
+        return BaseType::Bool;
+    }
+    else if constexpr (std::is_same_v<T, char>)
+    {
+        return BaseType::Char;
+    }
+    else if constexpr (std::is_integral_v<T>)
+    {
+        constexpr UInt rank = std::bit_width(sizeof(T)) - 1;
+        constexpr BaseType base = std::is_signed_v<T> ? BaseType::Int8 : BaseType::UInt8;
+        return BaseType((UInt)base + rank);
+    }
+    else if constexpr (std::is_floating_point_v<T>)
+    {
+        constexpr UInt rank = std::bit_width(sizeof(T)) - 1;
+        return BaseType((UInt)BaseType::Half + rank);
+    }
+    else
+    {
+        static_assert(false, "Cannot deduce BaseType");
+    }
+    return {};
 }
+
+static constexpr const BaseType BaseEnumUnderlyingType[] = {
+#define FILL_BASE_ENUM(Enum) GetBaseType<typename std::underlying_type_t<Enum>>(),
+    FOREACH_BASE_ENUM(FILL_BASE_ENUM)
+#undef FILL_BASE_ENUM
+};
+
+BaseType getBaseEnumUnderlyingType(BaseType enumBaseType)
+{
+    SLANG_ASSERT((UInt)enumBaseType > (UInt)BaseType::CountOfPrimitives);
+    SLANG_ASSERT((UInt)enumBaseType < (UInt)BaseType::CountOf);
+    return BaseEnumUnderlyingType[(UInt)enumBaseType - ((UInt)BaseType::CountOfPrimitives + 1)];
+}
+} // namespace Slang

--- a/source/slang/slang-type-system-shared.h
+++ b/source/slang/slang-type-system-shared.h
@@ -23,6 +23,8 @@ namespace Slang
     X(IntPtr)                \
     X(UIntPtr)               \
     X(CountOfPrimitives)     \
+    /* end */
+#define FOREACH_BASE_ENUM(X) \
     X(AddressSpace)          \
     X(MemoryScope)           \
     X(AccessQualifier)       \
@@ -32,6 +34,7 @@ enum class BaseType
 {
 #define DEFINE_BASE_TYPE(NAME) NAME,
     FOREACH_BASE_TYPE(DEFINE_BASE_TYPE)
+    FOREACH_BASE_ENUM(DEFINE_BASE_TYPE)
 #undef DEFINE_BASE_TYPE
 
         CountOf,
@@ -138,6 +141,7 @@ enum class AccessQualifier : uint64_t
     Read = 1,
 };
 
+BaseType getBaseEnumUnderlyingType(BaseType enumBaseType);
 } // namespace Slang
 
 #endif


### PR DESCRIPTION
Proposed solution [2] of #8406. It is a quicker fix than proposed solution [3].

This is an automatically extensible solution (if other BaseType enums were to be added in the future) for this issue. 