### PR TITLE
Fix pointers and C-like layout in varying parameters

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -3020,7 +3020,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         bool anyModifiers = (var->findDecoration<IRInterpolationModeDecoration>() != nullptr);
 
         // If the user didn't explicitly qualify a varying
-        // with integer type, then we need to explicitly
+        // with integer or pointer type, then we need to explicitly
         // add the `flat` modifier for GLSL.
         if (!anyModifiers)
         {
@@ -3030,7 +3030,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 layout->usesResourceKind(LayoutResourceKind::VaryingInput))
             {
                 const auto ptrType = as<IRPtrTypeBase>(var->getDataType());
-                if (ptrType && isIntegralScalarOrCompositeType(ptrType->getValueType()))
+                if (ptrType && (isIntegralScalarOrCompositeType(ptrType->getValueType()) || as<IRPtrTypeBase>(ptrType->getValueType())))
                     emitOpDecorate(
                         getSection(SpvLogicalSectionID::Annotations),
                         nullptr,

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -3030,7 +3030,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 layout->usesResourceKind(LayoutResourceKind::VaryingInput))
             {
                 const auto ptrType = as<IRPtrTypeBase>(var->getDataType());
-                if (ptrType && (isIntegralScalarOrCompositeType(ptrType->getValueType()) || as<IRPtrTypeBase>(ptrType->getValueType())))
+                if (ptrType && (isIntegralScalarOrCompositeType(ptrType->getValueType()) ||
+                                as<IRPtrTypeBase>(ptrType->getValueType())))
                     emitOpDecorate(
                         getSection(SpvLogicalSectionID::Annotations),
                         nullptr,

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -2344,13 +2344,13 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
     {
         SLANG_ASSERT(ptrType->astNodeType == ASTNodeType::PtrType);
 
+        auto typeLayout = processSimpleEntryPointParameter(context, ptrType, state, varLayout);
+        RefPtr<PointerTypeLayout> ptrTypeLayout = typeLayout.as<PointerTypeLayout>();
+
         // Work out the layout for the value/target type
         auto valueTypeLayout =
             processEntryPointVaryingParameter(context, ptrType->getValueType(), state, varLayout);
-
-        RefPtr<PointerTypeLayout> ptrTypeLayout = new PointerTypeLayout();
         ptrTypeLayout->valueTypeLayout = valueTypeLayout;
-
         return ptrTypeLayout;
     }
     else if (auto optionalType = as<OptionalType>(type))

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -5680,6 +5680,20 @@ RefPtr<TypeLayout> getSimpleVaryingParameterTypeLayout(
 
         return typeLayout;
     }
+    else if (as<PtrType>(type))
+    {
+        RefPtr<TypeLayout> typeLayout = new PointerTypeLayout();
+        typeLayout->type = type;
+        typeLayout->rules = rules;
+
+        for (int rr = 0; rr < varyingRulesCount; ++rr)
+        {
+            auto info = varyingRules[rr]->GetPointerLayout();
+            typeLayout->addResourceUsage(info.kind, info.size);
+        }
+
+        return typeLayout;
+    }
     else if (auto vecType = as<VectorExpressionType>(type))
     {
         auto elementType = vecType->getElementType();

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -1387,7 +1387,7 @@ LayoutRulesImpl kCPushConstantRulesImpl_ = {
 
 LayoutRulesImpl kCVaryingInputLayoutRulesImpl_ = {
     &kCLayoutRulesFamilyImpl,
-    &kGLSLVaryingOutputLayoutRulesImpl,
+    &kGLSLVaryingInputLayoutRulesImpl,
     &kGLSLObjectLayoutRulesImpl,
 };
 

--- a/tests/spirv/c-layout-buffer-3.slang
+++ b/tests/spirv/c-layout-buffer-3.slang
@@ -1,0 +1,46 @@
+//TEST:SIMPLE(filecheck=SPIRV): -stage fragment -entry fragmentMain -target spirv -fvk-use-c-layout
+struct A {
+    int64_t i;
+    float f;
+};
+
+struct B {
+    A a;
+    float b;
+};
+
+struct FIn
+{
+    Ptr<B> i0;
+    Ptr<B> i1;
+    float c;
+    float d;
+}
+
+struct FOut
+{
+	float4 outputColor : SV_Target0;
+}
+
+StructuredBuffer<Ptr<B>, Std430DataLayout> testBuffer;
+
+[shader("fragment")]
+FOut fragmentMain(FIn input)
+{
+
+	FOut output;
+	output.outputColor = float4(input.i0.a.f, input.i0.b, input.i1.a.f, input.i1.b)+input.c-input.d;
+    output.outputColor += testBuffer[0].b;
+	return output;
+}
+
+// SPIRV: OpDecorate %input_i0 Location 0
+// SPIRV: OpDecorate %input_i0 Flat
+// SPIRV: OpDecorate %input_i1 Location 1
+// SPIRV: OpDecorate %input_i1 Flat
+// SPIRV: OpDecorate %input_c Location 2
+// SPIRV: OpDecorate %input_d Location 3
+// SPIRV: OpMemberDecorate %A_c 0 Offset 0
+// SPIRV: OpMemberDecorate %A_c 1 Offset 8
+// SPIRV: OpMemberDecorate %B_c 0 Offset 0
+// SPIRV: OpMemberDecorate %B_c 1 Offset 16


### PR DESCRIPTION
Closes #8409, but ended up being more about fixing another bug. While the issue itself seems to only be a simple typo fix (see second commit in this PR), I found out during writing a test that pointers never got correct locations regardless of layout. Their locations were always assigned to zero due to lacking a resource usage entry in `TypeLayout`. They were also missing the `Flat` decoration, so I went ahead and added that too.

I can split this up into two separate PRs if that's preferred; both aspects just share a test right now and fix a similar-looking issue in the resulting SPIR-V.