### PR TITLE
Prefer IntegerType over LogicalType integer matrix mul() overloads

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -12188,6 +12188,7 @@ vector<T, M> mul(vector<T, N> left, matrix<T, N, M> right)
 }
 __generic<T : __BuiltinLogicalType, let N : int, let M : int>
 [__readNone]
+[OverloadRank(-1)]
 [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, sm_4_0_version)]
 vector<T, M> mul(vector<T, N> left, matrix<T, N, M> right)
 {
@@ -12351,6 +12352,7 @@ matrix<T,R,C> mul(matrix<T,R,N> left, matrix<T,N,C> right)
 }
 __generic<T : __BuiltinLogicalType, let R : int, let N : int, let C : int>
 [__readNone]
+[OverloadRank(-1)]
 [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, sm_4_0_version)]
 matrix<T,R,C> mul(matrix<T,R,N> left, matrix<T,N,C> right)
 {

--- a/tests/hlsl-intrinsic/matrix-int-mul.slang
+++ b/tests/hlsl-intrinsic/matrix-int-mul.slang
@@ -1,0 +1,18 @@
+//TEST:SIMPLE(filecheck=CHECK):-target hlsl -entry main -stage compute
+
+//CHECK-NOT: error 39999: ambiguous call to 'mul'
+
+[shader("compute")]
+void main() {
+    int2x2 matrixA = {
+        1, 2,
+        3, 4
+    };
+    int2 vecA = {
+        1, 2
+    };
+
+    int2x2 matrixB = mul(matrixA, matrixA); // M * M
+    int2   vecB    = mul(vecA,    matrixA); // V * M
+    int2   vecC    = mul(matrixA, vecA);    // M * V
+}


### PR DESCRIPTION
Integer mul(matrix, matrix) and mul(vector, matrix) are not disambiguated between __BuiltinIntegerType and __BuiltinLogicalType, emitting an ambiguous call compilation error.

Use the OverloadRank attribute to prefer the IntegerType overload over the LogicalType overload.

Fixes #8424