### PR TITLE
Split overloaded uses of RefType in front-end

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1332,6 +1332,10 @@ struct Ptr<
     __init(int64_t val);
 
     // By default, getter is not an L value
+    //
+    // TODO(tfoley): Yes... yes it *is* an l-value,
+    // because that's a `ref` accessor down there...
+    //
     __generic<TInt : __BuiltinIntegerType>
     __subscript(TInt index) -> T
     {
@@ -1341,12 +1345,13 @@ struct Ptr<
     }
 };
 
+/*
 extension<T, AddressSpace addrSpace> Ptr<T, Access::ReadWrite, addrSpace>
 {
     // We have a `ref` accessor if we are ReadWrite. This means only `ReadWrite`
     // can be used as an L-value.
     __generic<TInt : __BuiltinIntegerType>
-    __subscript(TInt index) -> Ref<T>
+    __subscript(TInt index) -> ExplicitRef<T, Access::ReadWrite, addrSpace>
     {
         // If a 'Ptr[index]' is referred to by a '__ref', call 'kIROp_GetOffsetPtr(index)'
         __intrinsic_op($(kIROp_GetOffsetPtr))
@@ -1354,6 +1359,7 @@ extension<T, AddressSpace addrSpace> Ptr<T, Access::ReadWrite, addrSpace>
         ref;
     }
 }
+*/
 
 //@hidden:
 __intrinsic_op($(kIROp_AlignedAttr))
@@ -1508,28 +1514,33 @@ extension uintptr_t : IRangedValue
 }
 
 //@hidden:
-__generic<T>
-__magic_type(OutType)
-__intrinsic_type($(kIROp_OutType))
-struct Out
-{};
 
-__generic<T>
-__magic_type(InOutType)
-__intrinsic_type($(kIROp_InOutType))
-struct InOut
-{};
-
-__generic<T>
-__magic_type(RefType)
+__magic_type(ExplicitRefType)
 __intrinsic_type($(kIROp_RefType))
-struct Ref
+struct ExplicitRef<
+    T, 
+    Access access = Access::ReadWrite, 
+    AddressSpace addrSpace = AddressSpace::Device>
 {};
 
-__generic<T>
-__magic_type(ConstRefType)
+__magic_type(OutParamType)
+__intrinsic_type($(kIROp_OutType))
+struct OutParam<T>
+{};
+
+__magic_type(InOutParamType)
+__intrinsic_type($(kIROp_InOutType))
+struct InOutParam<T>
+{};
+
+__magic_type(RefParamType)
+__intrinsic_type($(kIROp_RefType))
+struct RefParam<T>
+{};
+
+__magic_type(ConstRefParamType)
 __intrinsic_type($(kIROp_ConstRefType))
-struct ConstRef
+struct ConstRefParam<T>
 {};
 
 // __Addr<T> is AddressSpace::Generic since Slang will specalize & validate the address-space
@@ -2672,15 +2683,9 @@ for (auto op : intrinsicUnaryOps)
 }}}}
 
 // Only ReadWrite is an L-value.
-__generic<T, AddressSpace addrSpace>
+__generic<T, Access access, AddressSpace addrSpace>
 __intrinsic_op(0)
-__prefix Ref<T> operator*(Ptr<T, Access::ReadWrite, addrSpace> value);
-
-// Unknown access qualifier or Access::Read access qualifier is a promise
-// that the pointer is not going to be used as an L-value.
-__generic<$(ptrTypeParameterList)>
-__intrinsic_op(0)
-__prefix ConstRef<T> operator*($(fullPtrType) value);
+__prefix ExplicitRef<T, access, addrSpace> operator*(Ptr<T, access, addrSpace> value);
 
 // TODO: [require(cpu)]. This cannot be done yet since this change breaks slangpy
 __generic<T>

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -10352,10 +10352,10 @@ matrix<T, N, M> fwidth_fine(matrix<T, N, M> x)
 }
 
 __intrinsic_op($(kIROp_ResolveVaryingInputRef))
-Ref<T> __ResolveVaryingInputRef<T>(__constref T attribute);
+ExplicitRef<T, Access.Read> __ResolveVaryingInputRef<T>(__constref T attribute);
 
 __intrinsic_op($(kIROp_GetPerVertexInputArray))
-Ref<Array<T, 3>> __GetPerVertexInputArray<T>(__constref T attribute);
+ExplicitRef<Array<T, 3>, Access.Read> __GetPerVertexInputArray<T>(__constref T attribute);
 
 T __GetAttributeAtVertex<T>(__constref T attribute, uint vertexIndex)
 {
@@ -17399,14 +17399,14 @@ void CallShader(uint shaderIndex, inout Payload payload)
 // side effect typed use locations (`inout`,`out`, etc.) are managed.
 __generic<T>
 __intrinsic_op($(kIROp_ForceVarIntoStructTemporarily))
-Ref<T> __forceVarIntoStructTemporarily(inout T maybeStruct);
+ExplicitRef<T> __forceVarIntoStructTemporarily(inout T maybeStruct);
 
 // Some functions require a struct type which is decorated with a [raypayload]
 // attribute. This will do the same as __forceVarIntoStructTemporarily and also
 // ensure that the struct type in question is decorated appropriately.
 __generic<T>
 __intrinsic_op($(kIROp_ForceVarIntoRayPayloadStructTemporarily))
-Ref<T> __forceVarIntoRayPayloadStructTemporarily(inout T maybeStruct);
+ExplicitRef<T> __forceVarIntoRayPayloadStructTemporarily(inout T maybeStruct);
 
 __generic<payload_t>
 [require(hlsl, raytracing)]
@@ -19891,7 +19891,7 @@ extension __SubpassImpl<T, 1>
 // We access the HitObjectAttributes via this function for the desired type, and it acts *as if* it's just an access
 // to the global t.
 [ForceInline]
-Ref<T> __hitObjectAttributes<T>()
+ExplicitRef<T> __hitObjectAttributes<T>()
 {
     [__vulkanHitObjectAttributes]   
     static T t;
@@ -22683,7 +22683,7 @@ namespace vk
         T *_ptr;
         [ForceInline] __init(T *ptr) { _ptr = ptr; }
         [ForceInline] __init(uint64_t val) { _ptr = (T *)val; }
-        [ForceInline] Ref<T> Get() { return *_ptr; }
+        [ForceInline] ExplicitRef<T> Get() { return *_ptr; }
         [ForceInline] T *getPtr() { return _ptr;}
     }
     [ForceInline]
@@ -23526,7 +23526,7 @@ struct CoopMat
     __intrinsic_op($(kIROp_GetElementPtr))
     [__ref]
     [__NoSideEffect]
-    Ref<T> __indexRef(int index);
+    ExplicitRef<T> __indexRef(int index);
 
     /// Returns the count as an integer value.
     [ForceInline]
@@ -25005,7 +25005,7 @@ struct CoopVec<T : __BuiltinArithmeticType, let N : int> : IArray<T>, IArithmeti
     __intrinsic_op($(kIROp_GetElementPtr))
     [__ref]
     [__NoSideEffect]
-    Ref<T> __indexRef(int index);
+    ExplicitRef<T> __indexRef(int index);
 
     [ForceInline]
     [__NoSideEffect]

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -500,22 +500,27 @@ Type* ASTBuilder::getScalarLayoutType()
 // Construct the type `Out<valueType>`
 OutType* ASTBuilder::getOutType(Type* valueType)
 {
-    return dynamicCast<OutType>(getPtrType(valueType, "OutType"));
+    return dynamicCast<OutType>(getPtrType(valueType, "OutParamType"));
 }
 
 InOutType* ASTBuilder::getInOutType(Type* valueType)
 {
-    return dynamicCast<InOutType>(getPtrType(valueType, "InOutType"));
+    return dynamicCast<InOutType>(getPtrType(valueType, "InOutParamType"));
 }
 
-RefType* ASTBuilder::getRefType(Type* valueType)
+RefParamType* ASTBuilder::getRefParamType(Type* valueType)
 {
-    return dynamicCast<RefType>(getPtrType(valueType, "RefType"));
+    return dynamicCast<RefParamType>(getPtrType(valueType, "RefParamType"));
 }
 
-ConstRefType* ASTBuilder::getConstRefType(Type* valueType)
+ConstRefParamType* ASTBuilder::getConstRefParamType(Type* valueType)
 {
-    return dynamicCast<ConstRefType>(getPtrType(valueType, "ConstRefType"));
+    return dynamicCast<ConstRefParamType>(getPtrType(valueType, "ConstRefParamType"));
+}
+
+ExplicitRefType* ASTBuilder::getExplicitRefType(Type* valueType)
+{
+    return dynamicCast<ExplicitRefType>(getPtrType(valueType, "ExplicitRefType"));
 }
 
 OptionalType* ASTBuilder::getOptionalType(Type* valueType)

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -533,17 +533,23 @@ public:
     PtrType* getPtrType(Type* valueType, AccessQualifier accessQualifier, AddressSpace addrSpace);
     PtrType* getPtrType(Type* valueType, Val* accessQualifier, Val* addrSpace);
 
-    // Construct the type `Out<valueType>`
-    OutType* getOutType(Type* valueType);
+    // Construct the type `OutParam<valueType>`
+    OutParamType* getOutType(Type* valueType);
 
-    // Construct the type `InOut<valueType>`
-    InOutType* getInOutType(Type* valueType);
+    // Construct the type `InOutParam<valueType>`
+    InOutParamType* getInOutType(Type* valueType);
+
+    // Construct the type `RefParam<valueType>`
+    RefParamType* getRefParamType(Type* valueType);
+
+    // Construct the type `ConstRefParam<valueType>`
+    ConstRefParamType* getConstRefParamType(Type* valueType);
 
     // Construct the type `Ref<valueType>`
-    RefType* getRefType(Type* valueType);
+    ExplicitRefType* getExplicitRefType(Type* valueType);
 
-    // Construct the type `ConstRef<valueType>`
-    ConstRefType* getConstRefType(Type* valueType);
+    // Construct the type `Ref<valueType, .Read>`
+    ExplicitRefType* getExplicitConstRefType(Type* valueType);
 
     // Construct the type `Optional<valueType>`
     OptionalType* getOptionalType(Type* valueType);

--- a/source/slang/slang-ast-natural-layout.cpp
+++ b/source/slang/slang-ast-natural-layout.cpp
@@ -174,8 +174,29 @@ NaturalSize ASTNaturalLayoutContext::_calcSizeImpl(Type* type)
     }
     else if (auto optionalType = as<OptionalType>(type))
     {
-        if (isNullableType(optionalType->getValueType()))
+        // Sometimes a type `T` has an unused bit pattern that
+        // can be used to represent the null/absent optional value,
+        // and for such types the size of an `Optional<T>` can be
+        // the same as a `T`, by making use of that unused pattern.
+        //
+        if (doesTypeHaveAnUnusedBitPatternThatCanBeUsedForOptionalRepresentation(optionalType->getValueType()))
             return calcSize(optionalType->getValueType());
+
+        // For all other types, an `Optional<T>` is laid out more-or-less
+        // as a tuple of a `bool` and a `T`.
+        //
+        // TODO(tfoley): This appears to be the exact *opposite* of how
+        // we should be laying out optionals if we want to be at all
+        // efficient about space. For various targets and layout modes
+        // (with natural layout currently being one of them), a type
+        // can have "tail padding," when its size is not a multiple of
+        // its alignment. In such cases laying things out as `(T, bool)`
+        // can both end up takign advantage of the tail padding of `T`
+        // when present *or* for types `T` that don't include tail
+        // padding in their layout, but have an alignment N > 1
+        // the `(T, bool)` order will then *create* N-1 bytes of tail
+        // padding (that can possibly be exploited elsewhere).
+        //
         NaturalSize size = NaturalSize::makeEmpty();
         size.append(calcSize(m_astBuilder->getBoolType()));
         size.append(calcSize(optionalType->getValueType()));

--- a/source/slang/slang-ast-support-types.cpp
+++ b/source/slang/slang-ast-support-types.cpp
@@ -11,13 +11,26 @@ namespace Slang
 QualType::QualType(Type* type)
     : type(type), isLeftValue(false)
 {
-    if (as<RefType>(type))
+    if (auto refType = as<ExplicitRefType>(type))
     {
-        isLeftValue = true;
-    }
-    else if (as<ConstRefType>(type))
-    {
-        isLeftValue = false;
+        if (auto optAccessQualifier = refType->tryGetAccessQualifierValue())
+        {
+            auto accessQualifier = *optAccessQualifier;
+            switch (accessQualifier)
+            {
+            case AccessQualifier::ReadWrite:
+                isLeftValue = true;
+                break;
+
+            case AccessQualifier::Read:
+                isLeftValue = false;
+                break;
+
+            default:
+                SLANG_UNEXPECTED("unhandled access qualifier");
+                break;
+            }
+        }
     }
 }
 

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -687,6 +687,8 @@ class PtrTypeBase : public BuiltinType
     Type* getValueType();
     Val* getAccessQualifier();
     Val* getAddressSpace();
+
+    std::optional<AccessQualifier> tryGetAccessQualifierValue();
 };
 
 FIDDLE()
@@ -709,7 +711,14 @@ class PtrType : public PtrTypeBase
     void _toTextOverride(StringBuilder& out);
 };
 
-/// A pointer-like type used to represent a parameter "direction"
+/// A pointer-like type used to represent a parameter-passing mode.
+///
+/// Historically the codebase has referredd to different parameter-passing
+/// modes as parameter "directions," because they initially included
+/// only `in`, `out`, and `inout`. The name is confusing when applied
+/// to things like `ref` parameters, but we haven't had time to rename
+/// everything yet.
+///
 FIDDLE()
 class ParamDirectionType : public PtrTypeBase
 {
@@ -720,44 +729,64 @@ class ParamDirectionType : public PtrTypeBase
 // logical pointer that is passed for an `out`
 // or `in out` parameter
 FIDDLE(abstract)
-class OutTypeBase : public ParamDirectionType
+class OutParamTypeBase : public ParamDirectionType
 {
     FIDDLE(...)
 };
+using OutTypeBase = OutParamTypeBase;
 
 // The type for an `out` parameter, e.g., `out T`
 FIDDLE()
-class OutType : public OutTypeBase
+class OutParamType : public OutParamTypeBase
 {
     FIDDLE(...)
 };
+using OutType = OutParamType;
 
 // The type for an `in out` parameter, e.g., `in out T`
 FIDDLE()
-class InOutType : public OutTypeBase
+class InOutParamType : public OutParamTypeBase
 {
     FIDDLE(...)
 };
-
-FIDDLE(abstract)
-class RefTypeBase : public ParamDirectionType
-{
-    FIDDLE(...)
-};
+using InOutType = InOutParamType;
 
 // The type for an `ref` parameter, e.g., `ref T`
 FIDDLE()
-class RefType : public RefTypeBase
+class RefParamType : public ParamDirectionType
+{
+    FIDDLE(...)
+};
+
+/// The type for an `constref` parameter, e.g., `constref T`
+///
+/// Note that, despite the modifier currently used to represent
+/// this case in code, this is *not* comparable to the `ref`
+/// parameter-passing mode, and is instead an input-only
+/// equivalent of `inout`.
+///
+FIDDLE()
+class ConstRefParamType : public ParamDirectionType
+{
+    FIDDLE(...)
+};
+
+/// A reference type that is explicitly named somewhere in code (`Ref<T>`).
+///
+/// The explicit reference types are distinct from the
+/// parameter-passing mode wrapper types like `RefParamType`.
+/// An explicit reference type is a type that code written in
+/// Slang is allowed to name (e.g., by having a function that
+/// returns a `Ref<T>`), even if those uses may only occur
+/// in the core module. In constrast, the parameter-passing
+/// mode wrapper types should only ever be used as part of
+/// the encoding of a `FuncType`.
+///
+FIDDLE()
+class ExplicitRefType : public PtrTypeBase
 {
     FIDDLE(...)
     void _toTextOverride(StringBuilder& out);
-};
-
-// The type for an `constref` parameter, e.g., `constref T`
-FIDDLE()
-class ConstRefType : public RefTypeBase
-{
-    FIDDLE(...)
 };
 
 FIDDLE()

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -1465,7 +1465,7 @@ bool SemanticsVisitor::_coerce(
         }
     }
 
-    // matrix type with different layouts are convertible
+    // matrix types with different layouts are convertible
     if (auto fromMatrixType = as<MatrixExpressionType>(fromType))
     {
         if (auto toMatrixType = as<MatrixExpressionType>(toType))
@@ -1491,6 +1491,14 @@ bool SemanticsVisitor::_coerce(
         }
     }
 
+    // We allow a value of a `struct` type to be coerced to a function
+    // type if the `struct` provides an appropriate method for calling
+    // instances of that type.
+    //
+    // TODO(tfoley): This can and should be opened up to work for any
+    // type (or at least any nominal type) that supports the required
+    // operation.
+    //
     if (auto toFuncType = as<FuncType>(toType))
     {
         if (auto fromLambdaType = isDeclRefTypeOf<StructDecl>(fromType))
@@ -1541,6 +1549,16 @@ bool SemanticsVisitor::_coerce(
         // Is toType and fromType the same via some type equality witness?
         // If so there is no need to do any conversion.
         //
+        // Note that this is a somewhat messy case to have, since we *already*
+        // have a check for type equality above this point. For this code to
+        // execute we would need to have a case where the `To` and `From` types
+        // are considered distinct by `Type::equals` but `tryGetSubtypeWitness`
+        // is still able to produce a witness for the equality of the two types.
+        //
+        // TODO(tfoley): Try to set things up so that we can have an invariant
+        // that two types count as equal for `Type::equals` if and only if a
+        // type equality witness for those types can be dervied.
+        //
         if (isTypeEqualityWitness(fromIsToWitness))
         {
             if (outToExpr)
@@ -1562,29 +1580,54 @@ bool SemanticsVisitor::_coerce(
         return _failedCoercion(toType, outToExpr, fromExpr, sink);
     }
 
-    // We allow implicit conversion of a parameter group type like
-    // `ConstantBuffer<X>` or `ParameterBlock<X>` to its element
-    // type `X`.
+    // If the type that we are converting from is a parameter group type
+    // (something like `ConstantBuffer<X>` or `ParameterBlock<X>`) and we
+    // are converting to some type `Y`, then we want to allow for a multi-step
+    // conversion where we first implicitly dereference the parameter group
+    // to get an `X`, and then convert the resulting `X` to a `Y`.
+    //
+    // An important special case of the above is when `X == Y`, in which
+    // case we are just converting, e.g., a `ConstantBuffer<X>` to an `X`.
+    //
+    // TODO(tfoley): When this conditional detects a parameter group type
+    // it funnels the coercion logic into only considering conversions that
+    // involve an automatic dereference. We need to ensure that any other
+    // kinds of conversion that could apply to a parameter group are considered
+    // earlier in this function, or else they will never actually be considered.
+    // Notably, with this logic in place it is impossible for there to be any
+    // conversion operations from a parameter-group type defined in code
+    // (e.g., a constructor for a `DescriptorHandle`-like type that takes
+    // a `ConstantBufer<T>` parameter will never be considered as part of conversion
+    // logic, because we will first extract the `T` and then try to convert *that*).
     //
     if (auto fromParameterGroupType = as<ParameterGroupType>(fromType))
     {
         auto fromElementType = fromParameterGroupType->getElementType();
 
-        // If we convert, e.g., `ConstantBuffer<A> to `A`, we will allow
-        // subsequent conversion of `A` to `B` if such a conversion
-        // is possible.
-        //
-        ConversionCost subCost = kConversionCost_None;
-
         DerefExpr* derefExpr = nullptr;
         if (outToExpr)
         {
+            // TODO(tfoley): The logic here effectively assumes that any
+            // parameter-group type is read-only, because we are not
+            // setting the `isLeftValue` flag of the `QualType` based
+            // on the type of the container. That is, a `StorageBuffer<X>`
+            // and a `ConstantBuffer<X>` would both derive the `QualType`
+            // of the dereferenced expression from `X` alone, and ignore
+            // that one of these should yield an l-value and the other
+            // shouldn't.
+            //
+            // In practice, we should have a centralized function that
+            // handles dereferenencing of any `Expr`, and computes the
+            // correct type for the result, so that the logic here can
+            // exactly mirror other cases of implicit dereference.
+            //
             derefExpr = m_astBuilder->create<DerefExpr>();
             derefExpr->base = fromExpr;
             derefExpr->type = QualType(fromElementType);
             derefExpr->checked = true;
         }
 
+        ConversionCost subCost = kConversionCost_None;
         if (!_coerce(site, toType, outToExpr, fromElementType, derefExpr, sink, &subCost))
         {
             return false;
@@ -1595,40 +1638,74 @@ bool SemanticsVisitor::_coerce(
         return true;
     }
 
-    if (auto refType = as<RefTypeBase>(toType))
+    // Because (for various bad reasons) we currently support an explicit
+    // `Ref<T>` type (used to define some of our core-module functions),
+    // we have to account for the case where an expression of type `T`
+    // is being coerced to a `Ref<T>`.
+    //
+    if (auto refType = as<ExplicitRefType>(toType))
     {
+        // TODO(tfoley): This logic is deeply and fundamentally incorrect.
+        // It presumes that if an expression of type `T` can coerce to
+        // type `U` then it can also coerce to a *reference* to `U`.
+        // That means that because we support, say, implicit coercion of
+        // an `int` to a `float`, this logic will support implicit coercion
+        // of an `int` l-value to a `Ref<float>`!!!!
+        //
         ConversionCost cost;
         if (!canCoerce(refType->getValueType(), fromType, fromExpr, &cost))
             return false;
-        if (as<RefType>(toType) && !fromExpr->type.isLeftValue)
-            return false;
-        ConversionCost subCost = kConversionCost_GetRef;
 
-        MakeRefExpr* refExpr = nullptr;
+        // Depending on whether the result of the coercion would be an l-value
+        // or not, we may need to restrict the source to be an l-value.
+        //
+        // TODO(tfoley): Here we are again hijacking the `QualType` constructor
+        // to do the direct work. It's still not clear where this logic should
+        // live. In the longer run, I'm hopeful that we will get rid of
+        // the explicit `Ref` type entirely (since it was a design mistake to
+        // begin with), and thus not have to deal with the miserable mess that
+        // it pushes back on various parts of the compiler.
+        //
+        auto qualRefType = QualType(refType);
+        if (qualRefType.isLeftValue && !fromExpr->type.isLeftValue)
+        {
+            // The result type would be an l-value, but the source isn't,
+            // so there is no way to support the conversion.
+            //
+            return false;
+        }
+
+        ConversionCost subCost = kConversionCost_GetRef;
+        if (outCost)
+            *outCost = subCost;
+
         if (outToExpr)
         {
-            refExpr = m_astBuilder->create<MakeRefExpr>();
+            auto refExpr = m_astBuilder->create<MakeRefExpr>();
             refExpr->base = fromExpr;
-            refExpr->type = QualType(refType);
-            refExpr->type.isLeftValue = false;
+            refExpr->type = qualRefType;
             refExpr->checked = true;
             *outToExpr = refExpr;
         }
-        if (outCost)
-            *outCost = subCost;
+
         return true;
     }
 
+    // TODO(tfoley): I was told that explicit `Ref` types should not
+    // be seen by most of the compiler because they would be automatically
+    // eliminated via `maybeOpenRef()` before other code needs to deal
+    // with them... but that doesn't seem to be the case given how much
+    // code here in type coercion is having to account for the possibility
+    // of `Ref` types.
 
-    // Allow implicit dereferencing a reference type.
-    if (auto fromRefType = as<RefTypeBase>(fromType))
+    // If we find ourselves in a situation where we need to coerce an
+    // expression of type `Ref<T>`, we will first unwrap the reference
+    // to get an expression of type `T` and then coerce *that*.
+    //
+    if (auto fromRefType = as<ExplicitRefType>(fromType))
     {
         auto fromValueType = fromRefType->getValueType();
 
-        // If we convert, e.g., `ConstantBuffer<A> to `A`, we will allow
-        // subsequent conversion of `A` to `B` if such a conversion
-        // is possible.
-        //
         ConversionCost subCost = kConversionCost_None;
 
         Expr* openRefExpr = nullptr;
@@ -1641,6 +1718,26 @@ bool SemanticsVisitor::_coerce(
         {
             return false;
         }
+
+        //
+        // TODO(tfoley): This logic treats the implicit dereferencing
+        // of a `Ref<T>` as an additional conversion cost, so that
+        // a function with an explicit `Ref<T>` parameter would end up
+        // being preferred over one with just a `T`.
+        //
+        // Making that distinction and introducing this cost seems to have
+        // very little benefit, and risks causing developer confusion,
+        // because for the most part references are invisible to the user
+        // (intentionally).
+        //
+        // We don't want to support explicit `Ref<T>` types in parameter
+        // positions anyway (people can use either a `ref` parameter or
+        // an explicit `Ptr<T>`), so the whole thing is moot.
+        //
+        // For that matter, we probably should just remove explicit
+        // `Ref<T>` types from the language, since they were never
+        // intended to be there in the first place.
+        //
 
         if (outCost)
             *outCost = subCost + kConversionCost_ImplicitDereference;
@@ -2189,6 +2286,13 @@ Expr* SemanticsVisitor::coerce(
         // clobber the type on `fromExpr`, and an invariant here is that coercion
         // really shouldn't *change* the expression that is passed in, but should
         // introduce new AST nodes to coerce its value to a different type...
+        //
+        // TODO(tfoley): Based on the comment above it seems like my past self
+        // wrote this code, but looking at it now, I'm unsure why we want to return
+        // an expression with an error type when we have the `toType` that is
+        // expected *right there*. It would be good to investigate whether changing
+        // this to return an expression of the expected type would Just Work.
+        //
         return CreateImplicitCastExpr(m_astBuilder->getErrorType(), fromExpr);
     }
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1649,7 +1649,7 @@ EnumDecl* isEnumType(Type* type)
     return nullptr;
 }
 
-bool isNullableType(Type* type)
+bool doesTypeHaveAnUnusedBitPatternThatCanBeUsedForOptionalRepresentation(Type* type)
 {
     if (as<PtrTypeBase>(type))
         return true;
@@ -1659,7 +1659,9 @@ bool isNullableType(Type* type)
         return true;
     if (as<OptionalType>(type))
         return true;
-    if (as<RefTypeBase>(type))
+    // TODO(tfoley): Somebody put the explicit `Ref<T>` types
+    // here as a list of a nullable type, and it is 
+    if (as<ExplicitRefType>(type))
         return true;
     if (as<NativeStringType>(type))
         return true;

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -3239,7 +3239,7 @@ bool isImmutableBufferType(Type* type);
 
 // Check if `type` is nullable. An `Optional<T>` will occupy the same space as `T`, if `T`
 // is nullable.
-bool isNullableType(Type* type);
+bool doesTypeHaveAnUnusedBitPatternThatCanBeUsedForOptionalRepresentation(Type* type);
 
 EnumDecl* isEnumType(Type* type);
 

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -778,13 +778,13 @@ Type* getParamTypeWithDirectionWrapper(ASTBuilder* astBuilder, DeclRef<VarDeclBa
     case kParameterDirection_In:
         return result;
     case kParameterDirection_ConstRef:
-        return astBuilder->getConstRefType(result);
+        return astBuilder->getConstRefParamType(result);
     case kParameterDirection_Out:
         return astBuilder->getOutType(result);
     case kParameterDirection_InOut:
         return astBuilder->getInOutType(result);
     case kParameterDirection_Ref:
-        return astBuilder->getRefType(result);
+        return astBuilder->getRefParamType(result);
     default:
         return result;
     }

--- a/source/slang/slang-check-type.cpp
+++ b/source/slang/slang-check-type.cpp
@@ -27,7 +27,7 @@ Type* getPointedToTypeIfCanImplicitDeref(Type* type)
     {
         return ptrType->getValueType();
     }
-    else if (auto refType = as<RefType>(type))
+    else if (auto refType = as<ExplicitRefType>(type))
     {
         return refType->getValueType();
     }

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -925,13 +925,18 @@ FuncType* getFuncType(ASTBuilder* astBuilder, DeclRef<CallableDecl> const& declR
         {
             paramType = astBuilder->getErrorType();
         }
+
+        // TODO(tfoley): This code should first compute the appropriate
+        // parameter-passing mode ("direction") for the `paramDecl` and
+        // then use that mode to decide which wrapper type to use.
+        //
         if (paramDecl->findModifier<RefModifier>())
         {
-            paramType = astBuilder->getRefType(paramType);
+            paramType = astBuilder->getRefParamType(paramType);
         }
         else if (paramDecl->findModifier<ConstRefModifier>())
         {
-            paramType = astBuilder->getConstRefType(paramType);
+            paramType = astBuilder->getConstRefParamType(paramType);
         }
         else if (paramDecl->findModifier<OutModifier>())
         {

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -5088,9 +5088,25 @@ static TypeLayoutResult _createTypeLayout(TypeLayoutContext& context, Type* type
     }
     else if (auto optionalType = as<OptionalType>(type))
     {
-        // OptionalType should be laid out the same way as Tuple<T, bool>.
-        if (isNullableType(optionalType->getValueType()))
+        // Sometimes a type `T` has an unused bit pattern that
+        // can be used to represent the null/absent optional value,
+        // and for such types the size of an `Optional<T>` can be
+        // the same as a `T`, by making use of that unused pattern.
+        //
+        if (doesTypeHaveAnUnusedBitPatternThatCanBeUsedForOptionalRepresentation(optionalType->getValueType()))
             return _createTypeLayout(context, optionalType->getValueType());
+
+        // For all other types, an `Optional<T>` is laid out more-or-less
+        // as tuple of a `T` and a `bool`.
+        //
+        // TODO(tfoley): This code implements the `(T,bool)` ordering,
+        // which provides more easy opportunities to generate compact
+        // layouts by using "tail padding" than the `(bool, T)` ordering.
+        // However the "natural layout" implementation does not match
+        // what is being done here (it uses the `(bool, T)` ordering).
+        // The discrepancy should probably be fixed, but doing so would
+        // technically be a breaking change.
+        //
         Array<Type*, 2> types =
             makeArray(optionalType->getValueType(), context.astBuilder->getBoolType());
         auto tupleType = context.astBuilder->getTupleType(types.getView());


### PR DESCRIPTION
Overview
========

This change is the start of an attempt to address how the Slang compiler codebase has ended up conflating two similar, but semantically distinct, concepts:

* The long-standing notion of `ref` parameters (only allowed for use in the builtin modules), which are encoded using a wrapper `Type` in the AST as part of the representation of the parameters of a `FuncType`.

* A recently-introduced notion of explicit reference types that mirror the built-in `Ptr` type, with a relationship comparable to that between pointer and reference types in C++.

The change splits the `Ref<T>` type in the core module into two distinct types, with one for each of the two use cases. Similarly, the `RefType` class in the compiler's AST is split into two distinct classes, to represent the two cases.

Background
==========

The `Ref<T>` type in the core module (hidden and not intended for users to ever see or use) was originally introduced to encode the `ref` parameter-passing mode, comparable to the hidden `Out<T>` and `InOut<T>` types used to encode `out` and `inout` parameter-passing modes. The `Ref<T>` type in the core module was encoded as a instance of the `RefType` class in the Slang AST (similar to how `Out<T>` mapped to an `OutType`). These AST classes were *only* intended to be used by the compiler front-end as part of its encoding of function types. The `FuncType` class needed a way to distinguish an `inout int` parameter from a plain (implicitly `in`) `int` parameter, so these wrapper like `RefType` and `OutType` were introduced to encode both the parameter type (`T`) and the parameter-passing mode in a form that could be passed around as a `Type`.

Notably, the `Ref<T>` type (and `Out<T>`, etc.) were *not* intended to be type names that ever get uttered in Slang code (not even in the builtin modules), and the vast majority of the compiler code was not supposed to ever encounter them. They were an implementation detail of `FuncType`, and nothing else.

(In hindsight it may have been a mistake to use a nominal type declared in the core module to implement these wrappers; it might have been a good idea to use an entirely separate class of `Type` for this case...)

Recent changes to the builtin modules introduced functions that wanted to *return* a reference (so that the parameter-passing-mode modifiers like `ref` could not trivially be used), and as part of those changes the appealingly-named `Ref<T>` type in the core module was re-used for this new case. Builtin operations were declared with an explicit `Ref<T>` return type, and parts of the compiler front-end that had previously been blissfully unaware of the AST's `RefType` (and `InOutType`, etc.) had to start accounting for the possibility that an explicit `Ref<T>` would show up.

Related changes also introduced a comparable conflation of the (unfortunately-named) `constref` parameter-passing modifier and builtin operations that wanted to return an explicit reference that is read-only. Both use cases were mapped to the core-module `ConstRef<T>` type, which appeared in the AST as an instance of the `ConstRefType` class.

The overlapping use of `ConstRef<T>`` is actually significantly more troublesome than the `Ref<T>` case because, despite what its name implies, `constref` was not really supposed to be the read-only analogue of `ref`, but rather it is closer to the "immutable value borrow" analogue to `inout`'s "mutable value borrow." The semantics of a "value borrow" vs. a "memory reference" in Slang have not been very carefully codified, and the conflation around `ConstRef<T>` has contributed to things becoming increasingly muddy in the compiler back-end.

Main Changes
============

Core Module
-----------

The `Ref<T>` type has been replaced with two distinct types, with one for each use case:

* `RefParam<T>` is intended for use when encoding a `ref` parameter in a function type

* `ExplicitRef<T>` is intended for use when an operation in a builtin module wants to return a reference

The other types used to represent parameter-passing modes (e.g., `InOut<T>`) were renamed to better indicate that their role in defining parameter types (e.g., `InOutParam<T>`).

The `ExplicitRef<T>` type was given additional generic parameters for the allowed access and the address space, akin to what `Ptr<T>` now supports. The pointer dereference operator (prefix `*`) in the core module should now properly propagate the access and address space of the pointer over to the reference that gets returned.

The two distinct use cases of `ConstRef<T>` were not split in the way as `Ref<T>`, instead the case for the `constref` parameter-passing mode uses `ConstParamRef<T>`, while cases that previously used `ConstRef<T>` to represent a read-only explicit reference instead now use `ExplicitRef<T, Access.Read>`.

Prior to this change there were two subscripts declared on pointers: one in the `Ptr` type itself, and another in an `extension` for pointers with `Access.ReadWrite`. The comments on the code seemed to indicate that the catch-all subscript used to only have a `get` accessor, while the `ref` was only available on read-write pointers, but it seems that subsequent changes converted the default subscript to support `ref`. This change eliminates the subscript added via `extension`, since it is redundant.

AST and Front-End
=================

Similar to the changes in the core module, the AST `RefType` class was split into:

* `RefParamType` for the case of encoding `ref` parameters

* `ExplicitRefType` for the case where the user meant an explicit reference type

All the other classes that represent wrappers for encoding parameter-passing modes (e.g., `OutType`) were similarly renamed (e.g., `OutParamType`).

The `ConstRefType` class was simply renamed to `ConstRefParamType`, because any use cases of `ConstRefType` that intended an explicit reference type will now use `ExplicitRefType` with `Acccess.Read`.

For convenience, this change includes type aliases to map the old names for these types over to the new ones (e.g., `using OutType = OutParamType`) so that the change doesn't need to affect quite so many lines of code. The `RefType` and `ConstRefType` names are intentionally left undefined, since it woudl be unsafe to assume that existing use sites should default to either of the two possible interpretations.

All use cases of `RefType` and `ConstRefType` (and their former shared base class `RefTypeBase`) were audited and updated to refer to either `RefParamType`/`ConstRefParamType` or `ExplicitRefType`, as appropriate (based on whether the context of the code indicated it was working with parameter-passing mode wrapper types, or explicit reference types).

In many (many) cases comments were added to the code that was updated (and some unrelated code that needed to be audited along the way) to note cases where there appears to be something fishy going on in the compiler and/or there are obvious opportunities for next-step improvement.

The `QualType` constructor used to infer l-value-ness when passed a `RefType` or `ConstRefType`; that code was introduced to support explicit  reference types. The code was updated to consult the access argument of an `ExplicitRefType` to try and determine the right l-value-ness to use. There is some ambiguity about what should be done in the case where the value of the generic argument representing the access cannot be statically determined; a better solution may be needed.

Many other cases in the front-end that were working with `RefType` and `ConstRefType` for explicit references also need to figure out l-value-ness, and these were changed to rely on the logic already added to `QualType` so that it wouldn't have to be duplicated. It isn't clear if this structure is the best way to tackle the problem, but it seems to at least be an upgrade over the more strictly ad-hoc logic that was in place before.

Future Work
===========

IR-Level Work
-------------

The most obvious next step to take is that the split that was made in the compiler front-end needs to be properly plumbed through all of the back-end. There appears to be a lot of code in the back end of the compiler that has made the same conflation of `ref` parameters and explicit reference types that the front-end did. In practice, any uses of `ExplicitRef<T>` in the front-end should desugar into plain pointer-based code in the IR.

Clean Up Parameter-Passing Modes
--------------------------------

The code that handles different parameter-passing modes (`ParameterDirection`s) and their wrapper types is somewhat scattered and messy (as found while auditing use cases of `RefType`). A cleanup pass is warranted to ensure that most code only needs to think about `ParameterDirection`s. There should ideally be only a single operation in the front-end that handles determining the `ParameterDirection` of a parameter based on its modifiers. Similarly, there should be one operation to wrap a value type based on a parameter direction, and one operation to derive a `ParameterDirection` from the wrapper type. Ideally, the accessors for `FuncType` should not provide unrestricted access to the potentially-wrapped parameter types, and should instead return some kind of `ParamInfo` struct that encodes both a `ParameterDirection` and the unwrapped `Type` of the parameter.

Clean Up `QualType`
-------------------

A significant piece of future work that appears required is to drastically clean up and improve the way that `QualType`s are represente and handled in the front-end. There are currently various distinct `bool` flags in `QualType` (some with very unclear meaning) and differnet parts of the codebase consult/modify only subsets of them; a clear enumeration of the "value categories" (to use the C++ terminology) that Slang supports could be quite helpful. Naively, a `QualType` should at least encode the basic information that a `Ptr` type encodes:

* A value type
* Allowed access (read-only, read-write, etc.)
* Address space

The main additional thing that a `QualType` needs is a way to distinguish cases where an expression evaluates to:

* A reference to a memory location, where all the information from a `Ptr` is relevant
* A simple value, such that the access and address space are irrelevant
* A reference to an abstract storage location (a `property`, `subscript`, or an implicit conversion that needs to support being an l-value), in which case address space is irrelevant and the "allowed access" basically amounts to a listing of the accessors the storage location supports

Eliminate Explicit Reference Types
----------------------------------

Finally, twe should eventually eliminate the `ExplicitRef<T>` type from the core module (and all of the supporting code from the front-end), since the feature is not a good fit for the Slang language. We should find some other way to decorate operations in the builtin module that need to returns a reference rather than a value (note how `ref` accessors already avoided exposing explicit reference types, by design).