### PR TITLE
Add RHI Device Caching and Test Prefix Exclusion

### DIFF
--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -278,6 +278,10 @@ static rhi::DeviceType _toRenderType(Slang::RenderApiType apiType)
         {
             outOptions.showAdapterInfo = true;
         }
+        else if (argValue == "-cache-rhi-device")
+        {
+            outOptions.cacheRhiDevice = true;
+        }
         else
         {
             // Lookup

--- a/tools/render-test/options.h
+++ b/tools/render-test/options.h
@@ -96,6 +96,9 @@ struct Options
 
     bool skipSPIRVValidation = false;
 
+    // Whether to enable RHI device caching (default: false in render-test)
+    bool cacheRhiDevice = false;
+
     Slang::List<Slang::String> capabilities;
 
     Options() { downstreamArgs.addName("slang"); }

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -1584,7 +1584,8 @@ static SlangResult _innerMain(
                 //
                 // We also don't want to output the 'Unable to create renderer' error, as this isn't
                 // an error.
-                SlangResult res = SLANG_E_NOT_AVAILABLE; // Default to not available if device creation fails
+                SlangResult res =
+                    SLANG_E_NOT_AVAILABLE; // Default to not available if device creation fails
                 if (!options.onlyStartup)
                 {
                     fprintf(stderr, "Unable to create renderer %s\n", rendererName.getBuffer());

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -1577,7 +1577,7 @@ static SlangResult _innerMain(
                     rhiDevice = nullptr;
                 }
             }
-            
+
             // Check result for both cached and non-cached paths
             if (SLANG_FAILED(res) || !rhiDevice)
             {

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -1559,8 +1559,20 @@ static SlangResult _innerMain(
             {
                 getRHI()->enableDebugLayers();
             }
-            auto cachedDevice = DeviceCache::acquireDevice(desc);
-            if (!cachedDevice)
+            Slang::ComPtr<rhi::IDevice> rhiDevice;
+            if (options.cacheRhiDevice)
+            {
+                rhiDevice = DeviceCache::acquireDevice(desc);
+            }
+            else
+            {
+                auto result = rhi::getRHI()->createDevice(desc, rhiDevice.writeRef());
+                if (SLANG_FAILED(result))
+                {
+                    rhiDevice = nullptr;
+                }
+            }
+            if (!rhiDevice)
             {
                 // We need to be careful here about SLANG_E_NOT_AVAILABLE. This return value means
                 // that the renderer couldn't be created because it required *features* that were
@@ -1580,7 +1592,7 @@ static SlangResult _innerMain(
 
                 return res;
             }
-            deviceWrapper = CachedDeviceWrapper(cachedDevice);
+            deviceWrapper = CachedDeviceWrapper(rhiDevice);
             SLANG_ASSERT(deviceWrapper);
         }
 

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -1441,7 +1441,7 @@ static SlangResult _innerMain(
         }
     }
 
-    renderer_test::CoreToRHIDebugBridge debugCallback;
+    static renderer_test::CoreToRHIDebugBridge debugCallback;
     debugCallback.setCoreCallback(stdWriters->getDebugCallback());
 
     // Use the profile name set on options if set

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -1617,11 +1617,12 @@ static SlangResult _innerMain(
         app.finalize();
     }
 
-    
-    // Force cleanup of cached devices before shutdown
-    DeviceCache::forceCleanup();
-
     return SLANG_OK;
+}
+
+SLANG_TEST_TOOL_API void cleanDeviceCache()
+{
+    DeviceCache::cleanCache();
 }
 
 SLANG_TEST_TOOL_API SlangResult innerMain(

--- a/tools/render-test/slang-test-device-cache.cpp
+++ b/tools/render-test/slang-test-device-cache.cpp
@@ -1,0 +1,145 @@
+#include <algorithm>
+#include "slang-test-device-cache.h"
+
+// Static member definitions
+std::mutex DeviceCache::s_mutex;
+std::unordered_map<DeviceCache::DeviceCacheKey, DeviceCache::CachedDevice, DeviceCache::DeviceCacheKeyHash> DeviceCache::s_deviceCache;
+std::chrono::steady_clock::time_point DeviceCache::s_lastCleanup = std::chrono::steady_clock::now();
+
+bool DeviceCache::DeviceCacheKey::operator==(const DeviceCacheKey& other) const
+{
+    return deviceType == other.deviceType &&
+           enableValidation == other.enableValidation &&
+           enableRayTracingValidation == other.enableRayTracingValidation &&
+           profileName == other.profileName &&
+           requiredFeatures == other.requiredFeatures;
+}
+
+std::size_t DeviceCache::DeviceCacheKeyHash::operator()(const DeviceCacheKey& key) const
+{
+    std::size_t h1 = std::hash<int>{}(static_cast<int>(key.deviceType));
+    std::size_t h2 = std::hash<bool>{}(key.enableValidation);
+    std::size_t h3 = std::hash<bool>{}(key.enableRayTracingValidation);
+    std::size_t h4 = std::hash<std::string>{}(key.profileName);
+    
+    std::size_t h5 = 0;
+    for (const auto& feature : key.requiredFeatures)
+    {
+        h5 ^= std::hash<std::string>{}(feature) + 0x9e3779b9 + (h5 << 6) + (h5 >> 2);
+    }
+    
+    return h1 ^ (h2 << 1) ^ (h3 << 2) ^ (h4 << 3) ^ (h5 << 4);
+}
+
+DeviceCache::CachedDevice::CachedDevice() 
+    : refCount(0), lastUsed(std::chrono::steady_clock::now()) 
+{
+}
+
+void DeviceCache::cleanupUnusedDevices()
+{
+    auto now = std::chrono::steady_clock::now();
+    if (now - s_lastCleanup < CLEANUP_INTERVAL)
+        return;
+        
+    s_lastCleanup = now;
+    
+    auto it = s_deviceCache.begin();
+    while (it != s_deviceCache.end())
+    {
+        if (it->second.refCount == 0 && (now - it->second.lastUsed) > DEVICE_TIMEOUT)
+        {
+            it = s_deviceCache.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}
+
+Slang::ComPtr<rhi::IDevice> DeviceCache::acquireDevice(const rhi::DeviceDesc& desc)
+{
+    // Only cache Vulkan devices to avoid the Tegra driver issue
+    if (desc.deviceType != rhi::DeviceType::Vulkan)
+    {
+        Slang::ComPtr<rhi::IDevice> device;
+        auto result = rhi::getRHI()->createDevice(desc, device.writeRef());
+        if (SLANG_SUCCEEDED(result))
+            return device;
+        return nullptr;
+    }
+    
+    std::lock_guard<std::mutex> lock(s_mutex);
+    
+    // Create cache key
+    DeviceCacheKey key;
+    key.deviceType = desc.deviceType;
+    key.enableValidation = desc.enableValidation;
+    key.enableRayTracingValidation = desc.enableRayTracingValidation;
+    key.profileName = desc.slang.targetProfile ? desc.slang.targetProfile : "";
+    
+    // Add required features to key
+    for (int i = 0; i < desc.requiredFeatureCount; ++i)
+    {
+        key.requiredFeatures.push_back(desc.requiredFeatures[i]);
+    }
+    std::sort(key.requiredFeatures.begin(), key.requiredFeatures.end());
+    
+    // Clean up old devices periodically
+    cleanupUnusedDevices();
+    
+    // Check if we have a cached device
+    auto it = s_deviceCache.find(key);
+    if (it != s_deviceCache.end())
+    {
+        it->second.refCount++;
+        it->second.lastUsed = std::chrono::steady_clock::now();
+        return it->second.device;
+    }
+    
+    // Create new device
+    Slang::ComPtr<rhi::IDevice> device;
+    auto result = rhi::getRHI()->createDevice(desc, device.writeRef());
+    if (SLANG_FAILED(result))
+    {
+        return nullptr;
+    }
+    
+    // Cache the device
+    CachedDevice& cached = s_deviceCache[key];
+    cached.device = device;
+    cached.refCount = 1;
+    cached.lastUsed = std::chrono::steady_clock::now();
+    
+    return device;
+}
+
+void DeviceCache::releaseDevice(rhi::IDevice* device)
+{
+    if (!device)
+        return;
+        
+    // Only manage Vulkan devices
+    if (device->getDeviceType() != rhi::DeviceType::Vulkan)
+        return;
+        
+    std::lock_guard<std::mutex> lock(s_mutex);
+    
+    // Find the device in cache and decrement ref count
+    for (auto& pair : s_deviceCache)
+    {
+        if (pair.second.device.get() == device)
+        {
+            pair.second.refCount--;
+            pair.second.lastUsed = std::chrono::steady_clock::now();
+            break;
+        }
+    }
+}
+
+void DeviceCache::forceCleanup()
+{
+    std::lock_guard<std::mutex> lock(s_mutex);
+    s_deviceCache.clear();
+}

--- a/tools/render-test/slang-test-device-cache.cpp
+++ b/tools/render-test/slang-test-device-cache.cpp
@@ -85,7 +85,7 @@ SlangResult DeviceCache::acquireDevice(const rhi::DeviceDesc& desc, rhi::IDevice
 {
     if (!outDevice)
         return SLANG_E_INVALID_ARG;
-    
+
     *outDevice = nullptr;
 
     // Skip caching for CUDA devices due to crashes

--- a/tools/render-test/slang-test-device-cache.h
+++ b/tools/render-test/slang-test-device-cache.h
@@ -33,7 +33,6 @@ public:
     {
         Slang::ComPtr<rhi::IDevice> device;
         int refCount;
-        std::chrono::steady_clock::time_point lastUsed;
         uint64_t creationOrder;
         
         CachedDevice();

--- a/tools/render-test/slang-test-device-cache.h
+++ b/tools/render-test/slang-test-device-cache.h
@@ -1,16 +1,17 @@
 #pragma once
 
-#include <slang-rhi.h>
 #include <chrono>
 #include <mutex>
+#include <slang-rhi.h>
+#include <string>
 #include <unordered_map>
 #include <vector>
-#include <string>
 
 // Device Cache for preventing NVIDIA Tegra driver state corruption
 // This cache reuses Vulkan instances and devices to avoid the VK_ERROR_INCOMPATIBLE_DRIVER
 // issue that occurs after ~19 device creation/destruction cycles on Tegra platforms.
-// Uses ComPtr for automatic device lifecycle management - devices are released when removed from cache.
+// Uses ComPtr for automatic device lifecycle management - devices are released when removed from
+// cache.
 class DeviceCache
 {
 public:
@@ -21,33 +22,33 @@ public:
         bool enableRayTracingValidation;
         std::string profileName;
         std::vector<std::string> requiredFeatures;
-        
+
         bool operator==(const DeviceCacheKey& other) const;
     };
-    
+
     struct DeviceCacheKeyHash
     {
         std::size_t operator()(const DeviceCacheKey& key) const;
     };
-    
+
     struct CachedDevice
     {
         Slang::ComPtr<rhi::IDevice> device;
         uint64_t creationOrder;
-        
+
         CachedDevice();
     };
-    
+
 private:
     static constexpr int MAX_CACHED_DEVICES = 10;
-    
+
     // Use function-local statics to control destruction order (Meyer's singleton pattern)
     static std::mutex& getMutex();
     static std::unordered_map<DeviceCacheKey, CachedDevice, DeviceCacheKeyHash>& getDeviceCache();
     static uint64_t& getNextCreationOrder();
-    
+
     static void evictOldestDeviceIfNeeded();
-    
+
 public:
     static Slang::ComPtr<rhi::IDevice> acquireDevice(const rhi::DeviceDesc& desc);
     static void cleanCache();
@@ -58,22 +59,23 @@ class CachedDeviceWrapper
 {
 private:
     Slang::ComPtr<rhi::IDevice> m_device;
-    
+
 public:
     CachedDeviceWrapper() = default;
-    
-    CachedDeviceWrapper(Slang::ComPtr<rhi::IDevice> device) : m_device(device) {}
-    
-    ~CachedDeviceWrapper()
+
+    CachedDeviceWrapper(Slang::ComPtr<rhi::IDevice> device)
+        : m_device(device)
     {
     }
-    
+
+    ~CachedDeviceWrapper() {}
+
     // Move constructor
     CachedDeviceWrapper(CachedDeviceWrapper&& other) noexcept
         : m_device(std::move(other.m_device))
     {
     }
-    
+
     // Move assignment
     CachedDeviceWrapper& operator=(CachedDeviceWrapper&& other) noexcept
     {
@@ -83,14 +85,14 @@ public:
         }
         return *this;
     }
-    
+
     // Delete copy constructor and assignment
     CachedDeviceWrapper(const CachedDeviceWrapper&) = delete;
     CachedDeviceWrapper& operator=(const CachedDeviceWrapper&) = delete;
-    
+
     rhi::IDevice* get() const { return m_device.get(); }
     rhi::IDevice* operator->() const { return m_device.get(); }
     operator bool() const { return m_device != nullptr; }
-    
+
     Slang::ComPtr<rhi::IDevice>& getComPtr() { return m_device; }
 };

--- a/tools/render-test/slang-test-device-cache.h
+++ b/tools/render-test/slang-test-device-cache.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <chrono>
 #include <mutex>
 #include <slang-rhi.h>
 #include <string>
@@ -50,7 +49,7 @@ private:
     static void evictOldestDeviceIfNeeded();
 
 public:
-    static Slang::ComPtr<rhi::IDevice> acquireDevice(const rhi::DeviceDesc& desc);
+    static SlangResult acquireDevice(const rhi::DeviceDesc& desc, rhi::IDevice** outDevice);
     static void cleanCache();
 };
 

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -76,6 +76,7 @@ static bool _isSubCommand(const char* arg)
         "  -verbose-paths                 Use verbose paths in output\n"
         "  -category <name>               Only run tests in specified category\n"
         "  -exclude <name>                Exclude tests in specified category\n"
+        "  -exclude-prefix <prefix>       Exclude tests with specified path prefix\n"
         "  -api <expr>                    Enable specific APIs (e.g., 'vk+dx12' or '+dx11')\n"
         "  -synthesizedTestApi <expr>     Set APIs for synthesized tests\n"
         "  -skip-api-detection            Skip API availability detection\n"
@@ -356,6 +357,18 @@ static bool _isSubCommand(const char* arg)
             {
                 optionsOut->excludeCategories.add(category, category);
             }
+        }
+        else if (strcmp(arg, "-exclude-prefix") == 0)
+        {
+            if (argCursor == argEnd)
+            {
+                stdError.print("error: expected operand for '%s'\n", arg);
+                showHelp(stdError);
+                return SLANG_FAIL;
+            }
+            Slang::StringBuilder sb;
+            Slang::Path::simplify(*argCursor++, Slang::Path::SimplifyStyle::NoRoot, sb);
+            optionsOut->excludePrefixes.add(sb);
         }
         else if (strcmp(arg, "-api") == 0)
         {

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -92,6 +92,7 @@ static bool _isSubCommand(const char* arg)
         "  -capability <name>             Compile with the given capability\n"
         "  -enable-debug-layers [true|false] Enable or disable Validation Layer for Vulkan\n"
         "                                 and Debug Device for DX\n"
+        "  -cache-rhi-device [true|false] Enable or disable RHI device caching (default: true)\n"
 #if _DEBUG
         "  -disable-debug-layers          Disable the debug layers (default enabled in debug "
         "build)\n"
@@ -499,6 +500,26 @@ static bool _isSubCommand(const char* arg)
                 ((value[0] == 'o' || value[0] == 'O') && (value[1] == 'f' || value[1] == 'F')))
             {
                 optionsOut->enableDebugLayers = false;
+            }
+        }
+        else if (strcmp(arg, "-cache-rhi-device") == 0)
+        {
+            optionsOut->cacheRhiDevice = true;
+
+            if (argCursor == argEnd)
+            {
+                stdError.print("error: expected operand for '%s'\n", arg);
+                showHelp(stdError);
+                return SLANG_FAIL;
+            }
+
+            // Check for false variants
+            const char* value = *argCursor++;
+            if (value[0] == 'f' || value[0] == 'F' || value[0] == 'n' || value[0] == 'N' ||
+                value[0] == '0' ||
+                ((value[0] == 'o' || value[0] == 'O') && (value[1] == 'f' || value[1] == 'F')))
+            {
+                optionsOut->cacheRhiDevice = false;
             }
         }
 #if _DEBUG

--- a/tools/slang-test/options.h
+++ b/tools/slang-test/options.h
@@ -136,6 +136,9 @@ struct Options
 
     bool emitSPIRVDirectly = true;
 
+    // Whether to enable RHI device caching in render-test (default: true in slang-test)
+    bool cacheRhiDevice = true;
+
     Slang::HashSet<Slang::String> capabilities;
     Slang::HashSet<Slang::String> expectedFailureList;
 

--- a/tools/slang-test/options.h
+++ b/tools/slang-test/options.h
@@ -64,6 +64,9 @@ struct Options
     // only run test cases with names have one of these prefixes.
     Slang::List<Slang::String> testPrefixes;
 
+    // skip test cases with names that have one of these prefixes.
+    Slang::List<Slang::String> excludePrefixes;
+
     // verbosity level for output
     VerbosityLevel verbosity = VerbosityLevel::Info;
 

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -4766,6 +4766,15 @@ static bool shouldRunTest(TestContext* context, String filePath)
     if (!endsWithAllowedExtension(context, filePath))
         return false;
 
+    // Check exclude prefixes first - if any match, skip the test
+    for (auto& excludePrefix : context->options.excludePrefixes)
+    {
+        if (filePath.startsWith(excludePrefix))
+        {
+            return false;
+        }
+    }
+
     if (!context->options.testPrefixes.getCount())
     {
         return true;

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -4776,6 +4776,11 @@ static bool shouldRunTest(TestContext* context, String filePath)
     {
         if (filePath.startsWith(excludePrefix))
         {
+            if (context->options.verbosity == VerbosityLevel::Verbose)
+            {
+                context->getTestReporter()->messageFormat(
+                    TestMessageType::Info, "%s file is excluded from the test because it is found from the exclusion list\n", filePath.getBuffer());
+            }
             return false;
         }
     }

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -5451,14 +5451,13 @@ SlangResult innerMain(int argc, char** argv)
 
 int main(int argc, char** argv)
 {
-        // Fallback: run without cleanup if context initialization fails
-        SlangResult res = innerMain(argc, argv);
-        slang::shutdown();
-        Slang::RttiInfo::deallocateAll();
+    // Fallback: run without cleanup if context initialization fails
+    SlangResult res = innerMain(argc, argv);
+    slang::shutdown();
+    Slang::RttiInfo::deallocateAll();
 
 #ifdef _MSC_VER
-        _CrtDumpMemoryLeaks();
+    _CrtDumpMemoryLeaks();
 #endif
-        return SLANG_SUCCEEDED(res) ? 0 : 1;
-    
+    return SLANG_SUCCEEDED(res) ? 0 : 1;
 }

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -5429,33 +5429,14 @@ SlangResult innerMain(int argc, char** argv)
         }
 
         reporter.outputSummary();
+
+        cleanupRenderTestDeviceCache(context);
         return reporter.didAllSucceed() ? SLANG_OK : SLANG_FAIL;
     }
 }
 
 int main(int argc, char** argv)
 {
-    // Create a context for cleanup purposes
-    TestContext cleanupContext;
-    if (SLANG_SUCCEEDED(cleanupContext.init(argv[0])))
-    {
-        // Run the main test logic
-        SlangResult res = innerMain(argc, argv);
-        
-        // Clean up any cached devices from render-test-main before shutdown 
-        // to prevent use-after-free during static destruction
-        cleanupRenderTestDeviceCache(cleanupContext);
-        
-        slang::shutdown();
-        Slang::RttiInfo::deallocateAll();
-
-#ifdef _MSC_VER
-        _CrtDumpMemoryLeaks();
-#endif
-        return SLANG_SUCCEEDED(res) ? 0 : 1;
-    }
-    else
-    {
         // Fallback: run without cleanup if context initialization fails
         SlangResult res = innerMain(argc, argv);
         slang::shutdown();
@@ -5465,5 +5446,5 @@ int main(int argc, char** argv)
         _CrtDumpMemoryLeaks();
 #endif
         return SLANG_SUCCEEDED(res) ? 0 : 1;
-    }
+    
 }

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -4779,7 +4779,10 @@ static bool shouldRunTest(TestContext* context, String filePath)
             if (context->options.verbosity == VerbosityLevel::Verbose)
             {
                 context->getTestReporter()->messageFormat(
-                    TestMessageType::Info, "%s file is excluded from the test because it is found from the exclusion list\n", filePath.getBuffer());
+                    TestMessageType::Info,
+                    "%s file is excluded from the test because it is found from the exclusion "
+                    "list\n",
+                    filePath.getBuffer());
             }
             return false;
         }

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -3643,6 +3643,11 @@ static void _addRenderTestOptions(const Options& options, CommandLine& ioCmdLine
     {
         ioCmdLine.addArg("-enable-debug-layers");
     }
+
+    if (options.cacheRhiDevice)
+    {
+        ioCmdLine.addArg("-cache-rhi-device");
+    }
 }
 
 static SlangResult _extractProfileTime(const UnownedStringSlice& text, double& timeOut)

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -130,7 +130,8 @@ TestContext::InnerMainFunc TestContext::getInnerMainFunc(const String& dirPath, 
             loader->loadPlatformSharedLibrary(path.begin(), tool.m_sharedLibrary.writeRef())))
     {
         tool.m_func = (InnerMainFunc)tool.m_sharedLibrary->findFuncByName("innerMain");
-        tool.m_cleanDeviceCacheFunc = (CleanDeviceCacheFunc)tool.m_sharedLibrary->findFuncByName("cleanDeviceCache");
+        tool.m_cleanDeviceCacheFunc =
+            (CleanDeviceCacheFunc)tool.m_sharedLibrary->findFuncByName("cleanDeviceCache");
     }
 
     m_sharedLibTools.add(name, tool);
@@ -156,7 +157,8 @@ void TestContext::setInnerMainFunc(const String& name, InnerMainFunc func)
 TestContext::CleanDeviceCacheFunc TestContext::getCleanDeviceCacheFunc(const String& name)
 {
     SharedLibraryTool* tool = m_sharedLibTools.tryGetValue(name);
-    if (tool) {
+    if (tool)
+    {
         return tool->m_cleanDeviceCacheFunc;
     }
 

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -155,26 +155,12 @@ void TestContext::setInnerMainFunc(const String& name, InnerMainFunc func)
 
 TestContext::CleanDeviceCacheFunc TestContext::getCleanDeviceCacheFunc(const String& name)
 {
-    StringBuilder sharedLibToolBuilder;
-    sharedLibToolBuilder.append(name);
-    sharedLibToolBuilder.append("-tool");
-
-    StringBuilder path;
-    SharedLibrary::appendPlatformFileName(sharedLibToolBuilder.getUnownedSlice(), path);
-
-    DefaultSharedLibraryLoader* loader = DefaultSharedLibraryLoader::getSingleton();
-
-    SharedLibraryTool tool = {};
-
-    if (SLANG_SUCCEEDED(
-            loader->loadPlatformSharedLibrary(path.begin(), tool.m_sharedLibrary.writeRef())))
-    {
-        tool.m_func = (InnerMainFunc)tool.m_sharedLibrary->findFuncByName("innerMain");
-        tool.m_cleanDeviceCacheFunc = (CleanDeviceCacheFunc)tool.m_sharedLibrary->findFuncByName("cleanDeviceCache");
+    SharedLibraryTool* tool = m_sharedLibTools.tryGetValue(name);
+    if (tool) {
+        return tool->m_cleanDeviceCacheFunc;
     }
 
-    m_sharedLibTools.add(name, tool);
-    return tool.m_cleanDeviceCacheFunc;
+    return nullptr;
 }
 
 DownstreamCompilerSet* TestContext::getCompilerSet()

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -130,6 +130,7 @@ TestContext::InnerMainFunc TestContext::getInnerMainFunc(const String& dirPath, 
             loader->loadPlatformSharedLibrary(path.begin(), tool.m_sharedLibrary.writeRef())))
     {
         tool.m_func = (InnerMainFunc)tool.m_sharedLibrary->findFuncByName("innerMain");
+        tool.m_cleanDeviceCacheFunc = (CleanDeviceCacheFunc)tool.m_sharedLibrary->findFuncByName("cleanDeviceCache");
     }
 
     m_sharedLibTools.add(name, tool);
@@ -150,6 +151,30 @@ void TestContext::setInnerMainFunc(const String& name, InnerMainFunc func)
         tool.m_func = func;
         m_sharedLibTools.add(name, tool);
     }
+}
+
+TestContext::CleanDeviceCacheFunc TestContext::getCleanDeviceCacheFunc(const String& name)
+{
+    StringBuilder sharedLibToolBuilder;
+    sharedLibToolBuilder.append(name);
+    sharedLibToolBuilder.append("-tool");
+
+    StringBuilder path;
+    SharedLibrary::appendPlatformFileName(sharedLibToolBuilder.getUnownedSlice(), path);
+
+    DefaultSharedLibraryLoader* loader = DefaultSharedLibraryLoader::getSingleton();
+
+    SharedLibraryTool tool = {};
+
+    if (SLANG_SUCCEEDED(
+            loader->loadPlatformSharedLibrary(path.begin(), tool.m_sharedLibrary.writeRef())))
+    {
+        tool.m_func = (InnerMainFunc)tool.m_sharedLibrary->findFuncByName("innerMain");
+        tool.m_cleanDeviceCacheFunc = (CleanDeviceCacheFunc)tool.m_sharedLibrary->findFuncByName("cleanDeviceCache");
+    }
+
+    m_sharedLibTools.add(name, tool);
+    return tool.m_cleanDeviceCacheFunc;
 }
 
 DownstreamCompilerSet* TestContext::getCompilerSet()

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -101,7 +101,7 @@ public:
     InnerMainFunc getInnerMainFunc(const Slang::String& dirPath, const Slang::String& name);
     /// Set the function for the shared library
     void setInnerMainFunc(const Slang::String& name, InnerMainFunc func);
-    
+
     /// Get the device cache cleanup function (from shared library)
     CleanDeviceCacheFunc getCleanDeviceCacheFunc(const Slang::String& name);
 

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -90,6 +90,7 @@ class TestContext
 {
 public:
     typedef Slang::TestToolUtil::InnerMainFunc InnerMainFunc;
+    typedef void (*CleanDeviceCacheFunc)();
 
     /// Get the slang session
     SlangSession* getSession() const { return m_session; }
@@ -100,6 +101,9 @@ public:
     InnerMainFunc getInnerMainFunc(const Slang::String& dirPath, const Slang::String& name);
     /// Set the function for the shared library
     void setInnerMainFunc(const Slang::String& name, InnerMainFunc func);
+    
+    /// Get the device cache cleanup function (from shared library)
+    CleanDeviceCacheFunc getCleanDeviceCacheFunc(const Slang::String& name);
 
     void setTestRequirements(TestRequirements* req);
 
@@ -196,6 +200,7 @@ protected:
     {
         Slang::ComPtr<ISlangSharedLibrary> m_sharedLibrary;
         InnerMainFunc m_func;
+        CleanDeviceCacheFunc m_cleanDeviceCacheFunc;
     };
 
     Slang::List<Slang::RefPtr<Slang::JSONRPCConnection>> m_jsonRpcConnections;


### PR DESCRIPTION
# Add RHI Device Caching and Test Prefix Exclusion

## Summary

This PR introduces two key improvements to the Slang test infrastructure:

1. **RHI Device Caching**: Implements device caching to significantly speed up test execution by reusing graphics devices across tests, **RHI Device Caching reduces slang-test execution time from ~15 minutes to ~5 minutes in Windows release builds**
2. **Test Prefix Exclusion**: Adds `-exclude-prefix` option to skip tests matching specified path prefixes

## Changes

### RHI Device Caching
- **New `DeviceCache` class** (`slang-test-device-cache.h/cpp`): Thread-safe device cache with LRU eviction (max 10 devices)
- **Cache control option**: `-cache-rhi-device` flag in both `slang-test` and `render-test`
  - Default: **enabled** in slang-test, **disabled** in render-test when run standalone
  - Automatically skips caching for CUDA devices (due to driver issues)
- **Performance benefit**: Eliminates expensive device creation/destruction cycles, especially beneficial for Vulkan on Tegra platforms

### Test Prefix Exclusion
- **New `-exclude-prefix <prefix>` option** in slang-test
- Allows excluding entire test directories or patterns from execution
- Complements existing `-category` and individual test filtering options

### Usage Examples
```bash
# Enable device caching (default)
slang-test

# Disable device caching
slang-test -cache-rhi-device false

# Exclude tests from specific directories
slang-test -exclude-prefix tests/problematic/
slang-test -exclude-prefix tests/slow/ -exclude-prefix tests/experimental/
```

This change should significantly improve test execution performance, particularly in CI environments with frequent device operations. This is needed for running the GPU test in aarch64, where repeated device creation/destroy is causing driver issues.

Needed by: https://github.com/shader-slang/slang/issues/8346