### PR TITLE
Fix an autodiff crash

### DIFF
--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -11879,7 +11879,8 @@ LoweredValInfo emitDeclRef(IRGenContext* context, Decl* decl, DeclRefBase* subst
                     // Because ThisTypeWitness is defined inside the interface, we need to have
                     // a copy at the use site.
                     IRCloneEnv env;
-                    auto localThisTypeWitness = cloneInst(&env, context->irBuilder, context->thisTypeWitness);
+                    auto localThisTypeWitness =
+                        cloneInst(&env, context->irBuilder, context->thisTypeWitness);
                     auto irSatisfyingVal = context->irBuilder->emitLookupInterfaceMethodInst(
                         type,
                         localThisTypeWitness,

--- a/tests/autodiff/differential-ptr-pair-with-associate-type.slang
+++ b/tests/autodiff/differential-ptr-pair-with-associate-type.slang
@@ -1,0 +1,42 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
+interface IFoo<T>
+{
+    associatedtype Parameters : IDifferentiablePtrType;
+    property DifferentialPtrPair<Parameters> parametersDual { get; }
+}
+
+extension<T: __BuiltinFloatingPointType> T: IDifferentiablePtrType
+{
+    typealias Differential = T;
+}
+
+struct Foo<T:__BuiltinFloatingPointType> : IFoo<T>
+{
+    typealias Parameters = Array<T, 1>;
+    property DifferentialPtrPair<Parameters> parametersDual
+    {
+        get
+        {
+            Parameters primal = {T(1)};
+            Parameters diff   = {T(2)};
+            return DifferentialPtrPair<Parameters>(primal, diff);
+        }
+    }
+}
+
+//TEST_INPUT:ubuffer(data=[0 0], stride=4):out,name=output
+RWStructuredBuffer<float> output;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    Foo<float> foo;
+    let res = foo.parametersDual;
+    output[0] = res.p[0];
+    output[1] = res.d[0];
+
+    // CHECK: 1.0
+    // CHECK: 2.0
+}


### PR DESCRIPTION
Close #8201.

The root cause of this crash is that when lowering the generic interface method, it's possible that the function parameters or return type could access the interface requirement entry. This could cause a scope problem. Because the interface requirement entry is defined inside the interface generic, while we are inserting inst in the interface method generic, it's invalid to access any IRInsts defined in other generic.

To fix this issue, we change any access to the interface requirement entry by a lookup inst, and this lookup inst will be specialized away at post-link stage.