### PR TITLE
Use self-hosted runner for Windows release build

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -27,12 +27,11 @@ runs:
       uses: ilammy/msvc-dev-cmd@v1
 
     - name: Install dependencies (Linux only)
+      if: inputs.os == 'linux'
       shell: bash
       run: |
-        if [[ "${{ inputs.os }}" == "linux" ]]; then
-            sudo apt-get update
-            sudo apt-get install -y libx11-dev 
-        fi
+        sudo apt-get update
+        sudo apt-get install -y libx11-dev
 
     - name: Setup Node.js (Linux only)
       if: inputs.os == 'linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,6 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{matrix.platform == 'aarch64' && 'amd64_arm64' || 'amd64'}}
-          sdk: "10.0.19041.0"
 
       - name: Change dev tools to host arch (linux and macos)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
               compiler: gcc,
               build-slang-llvm: false,
             }
-          - { os: windows, runs-on: windows-latest, compiler: cl }
+          - { os: windows, runs-on: ["Windows", "self-hosted", "GCP-T4"], compiler: cl }
           - { os: macos, runs-on: macos-latest, compiler: clang }
 
           - { build-slang-llvm: false }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,12 +58,7 @@ jobs:
         with:
           submodules: "recursive"
           fetch-depth: "0"
-      - name: Install dependencies
-        run: |
-          if [[ "${{ matrix.os }}" == "linux" ]]; then
-              sudo apt-get update
-              sudo apt-get install -y libx11-dev
-          fi
+
       - name: Setup
         uses: ./.github/actions/common-setup
         with:
@@ -78,24 +73,6 @@ jobs:
           cmake --workflow --preset generators --fresh
           mkdir build-platform-generators
           cmake --install build --config Release --component generators --prefix build-platform-generators
-
-      - name: Change dev tools to host arch (windows)
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: ${{matrix.platform == 'aarch64' && 'amd64_arm64' || 'amd64'}}
-
-      - name: Change dev tools to host arch (linux and macos)
-        run: |
-          if [[ "${{matrix.os}}" == linux* && "${{matrix.platform}}" == "aarch64" && "$(uname -m)" != "aarch64" ]]; then
-            export CC=aarch64-linux-gnu-gcc
-            export CXX=aarch64-linux-gnu-g++
-          fi
-          CMAKE_OSX_ARCHITECTURES="${{matrix.platform}}"
-          CMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES//aarch64/arm64}
-
-          echo "CC=$CC" >> "$GITHUB_ENV"
-          echo "CXX=$CXX" >> "$GITHUB_ENV"
-          echo "CMAKE_OSX_ARCHITECTURES=$CMAKE_OSX_ARCHITECTURES" >> "$GITHUB_ENV"
 
       - name: Build Slang
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,11 @@ jobs:
               compiler: gcc,
               build-slang-llvm: false,
             }
-          - { os: windows, runs-on: ["Windows", "self-hosted", "GCP-T4"], compiler: cl }
+          - {
+              os: windows,
+              runs-on: ["Windows", "self-hosted", "GCP-T4"],
+              compiler: cl,
+            }
           - { os: macos, runs-on: macos-latest, compiler: clang }
 
           - { build-slang-llvm: false }


### PR DESCRIPTION
- Remove hard-coded Win SDK version.
- Using self-hosted machine for building release package in Windows.
- Remove the steps from release.yml that have been done in common steup.