### PR TITLE
include limits.h in slang-platform.cpp

### DIFF
--- a/source/core/slang-platform.cpp
+++ b/source/core/slang-platform.cpp
@@ -20,6 +20,7 @@
 #endif
 
 #if SLANG_LINUX_FAMILY
+#include <limits.h>
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
fixes https://github.com/shader-slang/slang/issues/8472

Fixes an issue with GCC 9.4.0 on Ubuntu 20.04, it will throw an error about PATH_MAX not being declared.