### PR TITLE
Fix SPIRV headers precedence

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -215,13 +215,12 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
 
         # Tools
         if(NOT SLANG_OVERRIDE_SPIRV_TOOLS_PATH)
-            add_subdirectory(spirv-tools EXCLUDE_FROM_ALL ${system})
+            add_subdirectory(spirv-tools EXCLUDE_FROM_ALL)
         else()
             add_subdirectory(
                 ${SLANG_OVERRIDE_SPIRV_TOOLS_PATH}/spirv-tools
                 spirv-tools
                 EXCLUDE_FROM_ALL
-                ${system}
             )
         endif()
     endif()


### PR DESCRIPTION
Remove SYSTEM flag from SPIRV-Headers to fix MacOS header precedence.

When the path is registered as SYSTEM, it is used with `-isystem` option not `-I` option and it gets less searching order on MacOS.

When spirv.h is installed on the system directory, it will end up using the system installed spirv.h, which is most likely an older version than we should use.