### PR TITLE
Use LOAD_LIBRARY_SEARCH_DEFAULT_DIRS for LoadLibraryExW

### DIFF
--- a/source/core/slang-platform.cpp
+++ b/source/core/slang-platform.cpp
@@ -141,10 +141,7 @@ SLANG_COMPILE_TIME_ASSERT(E_OUTOFMEMORY == SLANG_E_OUT_OF_MEMORY);
     // https://docs.microsoft.com/en-us/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibraryw
     String platformFileNameStr(platformFileName);
     OSString wideFileName = platformFileNameStr.toWString();
-    HMODULE handle = LoadLibraryExW(
-        wideFileName, 
-        nullptr, 
-        LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+    HMODULE handle = LoadLibraryExW(wideFileName, nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 
     if (!handle)
         handle = LoadLibraryW(wideFileName);


### PR DESCRIPTION
Before:
- Uses `LOAD_LIBRARY_SEARCH_USER_DIRS` in `LoadLibraryExW`, which might cause exception if there is no pathes added by `AddDllDirectory()`

After:
- Use the composite flag `LOAD_LIBRARY_SEARCH_DEFAULT_DIRS`, which searches for several locations.
- Will still search dir added by `AddDllDirectory()`, but avoids empty path seraching if there is no AddDllDirectory() calls.

Related to https://github.com/shader-slang/slang/issues/8462