### PR TITLE
Adding slang-test option to ignore abort popup message

### DIFF
--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -66,6 +66,7 @@ jobs:
             "-expected-failure-list" "tests/expected-failure-github.txt"
             "-skip-reference-image-generation"
             "-show-adapter-info"
+            "-ignore-abort-msg"
             "-enable-debug-layers" "${{ inputs.enable-debug-layers }}"
           )
 
@@ -106,10 +107,10 @@ jobs:
             -server-count ${{ inputs.server-count }} \
             -category ${{ inputs.test-category }} \
             -emit-spirv-via-glsl \
+            -ignore-abort-msg \
             -api vk \
             -expected-failure-list tests/expected-failure-via-glsl.txt \
-            -skip-reference-image-generation \
-            -show-adapter-info
+            -skip-reference-image-generation
 
   # Run slang-rhi tests when:
   # 1. full-gpu-tests is enabled AND

--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -278,6 +278,12 @@ static rhi::DeviceType _toRenderType(Slang::RenderApiType apiType)
         {
             outOptions.showAdapterInfo = true;
         }
+        else if (argValue == "-ignore-abort-msg")
+        {
+#ifdef _MSC_VER
+            _set_abort_behavior(0, _WRITE_ABORT_MSG);
+#endif
+        }
         else if (argValue == "-cache-rhi-device")
         {
             outOptions.cacheRhiDevice = true;

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -90,6 +90,13 @@ static bool _isSubCommand(const char* arg)
         "  -use-test-server               Run tests using test server\n"
         "  -use-fully-isolated-test-server  Run each test in isolated server\n"
         "  -capability <name>             Compile with the given capability\n"
+
+        // Recent Windows runtime versions started opening a dialog popup window when
+        // `abort()` is called, which breaks the CI workflow and some scripts that
+        // expect a normal termination.
+        // It can be helpful for debugging but we should ignore it for CI.
+        "  -ignore-abort-msg              Ignore abort message dialog popup on Windows\n"
+
         "  -enable-debug-layers [true|false] Enable or disable Validation Layer for Vulkan\n"
         "                                 and Debug Device for DX\n"
         "  -cache-rhi-device [true|false] Enable or disable RHI device caching (default: true)\n"
@@ -432,6 +439,13 @@ static bool _isSubCommand(const char* arg)
                 return SLANG_FAIL;
             }
             optionsOut->capabilities.add(*argCursor++);
+        }
+        else if (strcmp(arg, "-ignore-abort-msg") == 0)
+        {
+            optionsOut->ignoreAbortMsg = true;
+#ifdef _MSC_VER
+            _set_abort_behavior(0, _WRITE_ABORT_MSG);
+#endif
         }
         else if (strcmp(arg, "-expected-failure-list") == 0)
         {

--- a/tools/slang-test/options.h
+++ b/tools/slang-test/options.h
@@ -142,6 +142,9 @@ struct Options
     Slang::HashSet<Slang::String> capabilities;
     Slang::HashSet<Slang::String> expectedFailureList;
 
+    // Ignore abort message dialog popup on Windows
+    bool ignoreAbortMsg = false;
+
     /// Parse the args, report any errors into stdError, and write the results into optionsOut
     static SlangResult parse(
         int argc,

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -3644,6 +3644,11 @@ static void _addRenderTestOptions(const Options& options, CommandLine& ioCmdLine
         ioCmdLine.addArg("-enable-debug-layers");
     }
 
+    if (options.ignoreAbortMsg)
+    {
+        ioCmdLine.addArg("-ignore-abort-msg");
+    }
+
     if (options.cacheRhiDevice)
     {
         ioCmdLine.addArg("-cache-rhi-device");

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -196,6 +196,12 @@ SlangResult TestContext::_createJSONRPCConnection(RefPtr<JSONRPCConnection>& out
     {
         CommandLine cmdLine;
         cmdLine.setExecutableLocation(ExecutableLocation(exeDirectoryPath, "test-server"));
+
+        if (options.ignoreAbortMsg)
+        {
+            cmdLine.addArg("-ignore-abort-msg");
+        }
+
         SLANG_RETURN_ON_FAIL(Process::create(
             cmdLine,
             Process::Flag::AttachDebugger | Process::Flag::DisableStdErrRedirection,

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -191,6 +191,18 @@ SlangResult TestServer::init(int argc, const char* const* argv)
 {
     m_exePath = argv[0];
 
+    // Command-line argument parsing
+    for (int i = 1; i < argc; i++)
+    {
+        if (strcmp(argv[i], "-ignore-abort-msg") == 0)
+        {
+#ifdef _MSC_VER
+            _set_abort_behavior(0, _WRITE_ABORT_MSG);
+#endif
+        }
+        // Ignore unknown arguments for now
+    }
+
     String canonicalPath;
     if (SLANG_SUCCEEDED(Path::getCanonical(m_exePath, canonicalPath)))
     {


### PR DESCRIPTION
With the recent Windows runtime libraries, a new popup window started appearing when `abort()` is called. This was observed when VVL prints a message as a part of WGPU test.

Although it can be helpful when we want to debug it, it breaks the behavior of CI scripts when the tests are expected to continue even when they fail. When the test fail, CI script stops in the middle and wait for a user to click on a button on the dialog window, which cannot happen. As a result, when there is a VVL error message, CI run stops in the middle and the testing stops prematurely.

This commit adds a new command-line argument, `-ignore-abort-msg`, that ignores the abort message and it wouldn't show the dialog popup window.

From the implementation perspective, there are three places that are related.
- slang-test itself should turn off the flag.
- render-test should turn off the flag after getting the argument from slang-test
- test-server should turn off the flag after getting the argument from slang-test

When test-server runs render-test, the arguments are already handled by slang-test, so test-server needs to just pass through the arguments.