### PR TITLE
Add CI check for SPIRV-Tools generated files consistency

### DIFF
--- a/.github/workflows/check-spirv-tools-generated.yml
+++ b/.github/workflows/check-spirv-tools-generated.yml
@@ -10,18 +10,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-spirv-consistency:
-    name: Check SPIRV-Tools Generated Files Consistency
+  check-spirv-changes:
+    name: Check if SPIRV files were modified
     runs-on: ubuntu-latest
+    outputs:
+      spirv-modified: ${{ steps.check-changes.outputs.spirv-modified }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-          submodules: recursive
 
       - name: Check if SPIRV-Tools or SPIRV-Headers were modified
-        id: check-spirv-changes
+        id: check-changes
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             git fetch origin ${{ github.base_ref }}
@@ -30,29 +31,81 @@ jobs:
             BASE=HEAD^1
           fi
 
-          # Check if spirv-tools or spirv-headers submodules were modified
-          if git diff --name-only $BASE...HEAD | grep -E '^external/(spirv-tools|spirv-headers)(/|$)'; then
+          # Check if spirv-tools, spirv-headers, or spirv-tools-generated were modified
+          if git diff --name-only $BASE...HEAD | grep -E '^external/(spirv-tools|spirv-headers|spirv-tools-generated)(/|$)'; then
             echo "spirv-modified=true" >> $GITHUB_OUTPUT
-            echo "SPIRV-Tools or SPIRV-Headers submodules were modified"
+            echo "SPIRV-Tools, SPIRV-Headers, or SPIRV-Tools-Generated files were modified"
           else
             echo "spirv-modified=false" >> $GITHUB_OUTPUT
-            echo "No SPIRV-Tools or SPIRV-Headers changes detected, skipping check"
+            echo "No SPIRV-related changes detected, skipping check"
           fi
 
+  spirv-check-summary:
+    name: SPIRV Check Summary
+    runs-on: ubuntu-latest
+    needs: [check-spirv-changes, check-spirv-consistency]
+    if: always()
+    steps:
+      - name: Report Results
+        run: |
+          echo "Change detection result: ${{ needs.check-spirv-changes.result }}"
+          echo "SPIRV modified: ${{ needs.check-spirv-changes.outputs.spirv-modified }}"
+          echo "Consistency check result: ${{ needs.check-spirv-consistency.result }}"
+
+          # Check if change detection failed
+          if [[ "${{ needs.check-spirv-changes.result }}" != "success" ]]; then
+            echo "❌ SPIRV change detection failed"
+            exit 1
+          fi
+
+          # Check results based on whether SPIRV files were modified
+          if [[ "${{ needs.check-spirv-changes.outputs.spirv-modified }}" == "true" ]]; then
+            # SPIRV files were modified, so consistency check should have run
+            if [[ "${{ needs.check-spirv-consistency.result }}" == "success" ]]; then
+              echo "✅ SPIRV-Tools generated files check passed"
+            elif [[ "${{ needs.check-spirv-consistency.result }}" == "failure" ]]; then
+              echo "❌ SPIRV-Tools generated files check failed"
+              exit 1
+            elif [[ "${{ needs.check-spirv-consistency.result }}" == "skipped" ]]; then
+              echo "⚠️ SPIRV-Tools generated files check was skipped unexpectedly"
+              exit 1
+            else
+              echo "⚠️ SPIRV-Tools generated files check had unexpected result: ${{ needs.check-spirv-consistency.result }}"
+              exit 1
+            fi
+          else
+            # No SPIRV files were modified, consistency check should be skipped
+            if [[ "${{ needs.check-spirv-consistency.result }}" == "skipped" ]]; then
+              echo "ℹ️ No SPIRV-related changes detected - check skipped as expected"
+            else
+              echo "⚠️ Expected consistency check to be skipped, but got: ${{ needs.check-spirv-consistency.result }}"
+              exit 1
+            fi
+          fi
+
+  check-spirv-consistency:
+    name: Check SPIRV-Tools Generated Files Consistency
+    runs-on: ubuntu-latest
+    needs: check-spirv-changes
+    if: needs.check-spirv-changes.outputs.spirv-modified == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          submodules: recursive
+
       - name: Set up Python
-        if: steps.check-spirv-changes.outputs.spirv-modified == 'true'
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
 
       - name: Install build dependencies
-        if: steps.check-spirv-changes.outputs.spirv-modified == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build
 
       - name: Check SPIRV-Headers consistency
-        if: steps.check-spirv-changes.outputs.spirv-modified == 'true'
         run: |
           # Get the commit hash that spirv-tools expects for spirv-headers from DEPS file
           cd external/spirv-tools
@@ -79,7 +132,6 @@ jobs:
           fi
 
       - name: Build SPIRV-Tools to generate files
-        if: steps.check-spirv-changes.outputs.spirv-modified == 'true'
         run: |
           cd external/spirv-tools
 
@@ -94,7 +146,6 @@ jobs:
           ls -la build/*.h build/*.inc 2>/dev/null || echo "No generated header files found"
 
       - name: Check generated files consistency
-        if: steps.check-spirv-changes.outputs.spirv-modified == 'true'
         run: |
           cd external/spirv-tools/build
 
@@ -140,7 +191,7 @@ jobs:
           fi
 
       - name: Summary
-        if: always() && steps.check-spirv-changes.outputs.spirv-modified == 'true'
+        if: always()
         run: |
           if [ "${{ job.status }}" == "success" ]; then
             echo "✅ SPIRV-Tools generated files check passed"
@@ -150,8 +201,3 @@ jobs:
             echo "that match the current version of external/spirv-tools/"
           fi
 
-      - name: Skip message
-        if: steps.check-spirv-changes.outputs.spirv-modified == 'false'
-        run: |
-          echo "ℹ️  No SPIRV-Tools or SPIRV-Headers changes detected in this PR"
-          echo "Skipping SPIRV-Tools generated files consistency check"

--- a/.github/workflows/check-spirv-tools-generated.yml
+++ b/.github/workflows/check-spirv-tools-generated.yml
@@ -200,4 +200,3 @@ jobs:
             echo "Please ensure that external/spirv-tools-generated/ contains the correct generated files"
             echo "that match the current version of external/spirv-tools/"
           fi
-

--- a/.github/workflows/check-spirv-tools-generated.yml
+++ b/.github/workflows/check-spirv-tools-generated.yml
@@ -1,0 +1,157 @@
+name: Check SPIRV-Tools Generated Files
+
+on:
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-spirv-consistency:
+    name: Check SPIRV-Tools Generated Files Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          submodules: recursive
+
+      - name: Check if SPIRV-Tools or SPIRV-Headers were modified
+        id: check-spirv-changes
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git fetch origin ${{ github.base_ref }}
+            BASE=origin/${{ github.base_ref }}
+          else
+            BASE=HEAD^1
+          fi
+
+          # Check if spirv-tools or spirv-headers submodules were modified
+          if git diff --name-only $BASE...HEAD | grep -E '^external/(spirv-tools|spirv-headers)(/|$)'; then
+            echo "spirv-modified=true" >> $GITHUB_OUTPUT
+            echo "SPIRV-Tools or SPIRV-Headers submodules were modified"
+          else
+            echo "spirv-modified=false" >> $GITHUB_OUTPUT
+            echo "No SPIRV-Tools or SPIRV-Headers changes detected, skipping check"
+          fi
+
+      - name: Set up Python
+        if: steps.check-spirv-changes.outputs.spirv-modified == 'true'
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Install build dependencies
+        if: steps.check-spirv-changes.outputs.spirv-modified == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build
+
+      - name: Check SPIRV-Headers consistency
+        if: steps.check-spirv-changes.outputs.spirv-modified == 'true'
+        run: |
+          # Get the commit hash that spirv-tools expects for spirv-headers from DEPS file
+          cd external/spirv-tools
+          EXPECTED_SPIRV_HEADERS_COMMIT=$(grep "'spirv_headers_revision':" DEPS | sed "s/.*'spirv_headers_revision'.*'\\([^']*\\)'.*/\\1/")
+          echo "Expected SPIRV-Headers commit (from DEPS): $EXPECTED_SPIRV_HEADERS_COMMIT"
+
+          # Get the current commit hash of our spirv-headers submodule
+          cd ../spirv-headers
+          ACTUAL_SPIRV_HEADERS_COMMIT=$(git log -1 --format="%H")
+          echo "Actual SPIRV-Headers commit: $ACTUAL_SPIRV_HEADERS_COMMIT"
+
+          # Compare the commits
+          if [ "$EXPECTED_SPIRV_HEADERS_COMMIT" != "$ACTUAL_SPIRV_HEADERS_COMMIT" ]; then
+            echo "❌ SPIRV-Headers commit mismatch!"
+            echo "   Expected: $EXPECTED_SPIRV_HEADERS_COMMIT"
+            echo "   Actual:   $ACTUAL_SPIRV_HEADERS_COMMIT"
+            echo ""
+            echo "Please update external/spirv-headers to match the commit used by external/spirv-tools:"
+            echo "  git -C external/spirv-headers fetch"
+            echo "  git -C external/spirv-headers checkout $EXPECTED_SPIRV_HEADERS_COMMIT"
+            exit 1
+          else
+            echo "✅ SPIRV-Headers commit is consistent"
+          fi
+
+      - name: Build SPIRV-Tools to generate files
+        if: steps.check-spirv-changes.outputs.spirv-modified == 'true'
+        run: |
+          cd external/spirv-tools
+
+          # Sync dependencies (this might require additional setup for private repos)
+          python3 utils/git-sync-deps || echo "Warning: git-sync-deps failed, continuing anyway"
+
+          # Configure and build
+          cmake . -B build -G Ninja
+          cmake --build build --config Release
+
+          echo "Generated files in build directory:"
+          ls -la build/*.h build/*.inc 2>/dev/null || echo "No generated header files found"
+
+      - name: Check generated files consistency
+        if: steps.check-spirv-changes.outputs.spirv-modified == 'true'
+        run: |
+          cd external/spirv-tools/build
+
+          echo "Comparing generated files with committed files in spirv-tools-generated/"
+
+          MISMATCH_FOUND=false
+
+          # Compare each generated file with the committed version
+          for f in *.h *.inc; do
+            if [ -f "$f" ]; then
+              committed_file="../../spirv-tools-generated/$f"
+              if [ ! -f "$committed_file" ]; then
+                echo "❌ Missing file in spirv-tools-generated/: $f"
+                MISMATCH_FOUND=true
+              elif ! diff -q "$f" "$committed_file" > /dev/null; then
+                echo "❌ File differs: $f"
+                MISMATCH_FOUND=true
+              else
+                echo "✅ File matches: $f"
+              fi
+            fi
+          done
+
+          if [ "$MISMATCH_FOUND" = true ]; then
+            echo ""
+            echo "❌ Generated files are not consistent with committed files!"
+            echo ""
+            echo "To fix this issue, please regenerate the files following these steps:"
+            echo "1. cd external/spirv-tools"
+            echo "2. python3 utils/git-sync-deps"
+            echo "3. cmake . -B build"
+            echo "4. cmake --build build --config Release"
+            echo "5. cd .."
+            echo "6. rm spirv-tools-generated/*.h spirv-tools-generated/*.inc"
+            echo "7. cp spirv-tools/build/*.h spirv-tools/build/*.inc spirv-tools-generated/"
+            echo "8. git add spirv-tools-generated/"
+            echo ""
+            echo "See docs/update_spirv.md for detailed instructions."
+            exit 1
+          else
+            echo ""
+            echo "✅ All generated files are consistent!"
+          fi
+
+      - name: Summary
+        if: always() && steps.check-spirv-changes.outputs.spirv-modified == 'true'
+        run: |
+          if [ "${{ job.status }}" == "success" ]; then
+            echo "✅ SPIRV-Tools generated files check passed"
+          else
+            echo "❌ SPIRV-Tools generated files check failed"
+            echo "Please ensure that external/spirv-tools-generated/ contains the correct generated files"
+            echo "that match the current version of external/spirv-tools/"
+          fi
+
+      - name: Skip message
+        if: steps.check-spirv-changes.outputs.spirv-modified == 'false'
+        run: |
+          echo "ℹ️  No SPIRV-Tools or SPIRV-Headers changes detected in this PR"
+          echo "Skipping SPIRV-Tools generated files consistency check"

--- a/.github/workflows/check-spirv-tools-generated.yml
+++ b/.github/workflows/check-spirv-tools-generated.yml
@@ -1,8 +1,6 @@
 name: Check SPIRV-Tools Generated Files
 
 on:
-  pull_request:
-    branches: [master]
   workflow_dispatch:
 
 concurrency:
@@ -10,84 +8,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-spirv-changes:
-    name: Check if SPIRV files were modified
-    runs-on: ubuntu-latest
-    outputs:
-      spirv-modified: ${{ steps.check-changes.outputs.spirv-modified }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Check if SPIRV-Tools or SPIRV-Headers were modified
-        id: check-changes
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            git fetch origin ${{ github.base_ref }}
-            BASE=origin/${{ github.base_ref }}
-          else
-            BASE=HEAD^1
-          fi
-
-          # Check if spirv-tools, spirv-headers, or spirv-tools-generated were modified
-          if git diff --name-only $BASE...HEAD | grep -E '^external/(spirv-tools|spirv-headers|spirv-tools-generated)(/|$)'; then
-            echo "spirv-modified=true" >> $GITHUB_OUTPUT
-            echo "SPIRV-Tools, SPIRV-Headers, or SPIRV-Tools-Generated files were modified"
-          else
-            echo "spirv-modified=false" >> $GITHUB_OUTPUT
-            echo "No SPIRV-related changes detected, skipping check"
-          fi
-
-  spirv-check-summary:
-    name: SPIRV Check Summary
-    runs-on: ubuntu-latest
-    needs: [check-spirv-changes, check-spirv-consistency]
-    if: always()
-    steps:
-      - name: Report Results
-        run: |
-          echo "Change detection result: ${{ needs.check-spirv-changes.result }}"
-          echo "SPIRV modified: ${{ needs.check-spirv-changes.outputs.spirv-modified }}"
-          echo "Consistency check result: ${{ needs.check-spirv-consistency.result }}"
-
-          # Check if change detection failed
-          if [[ "${{ needs.check-spirv-changes.result }}" != "success" ]]; then
-            echo "❌ SPIRV change detection failed"
-            exit 1
-          fi
-
-          # Check results based on whether SPIRV files were modified
-          if [[ "${{ needs.check-spirv-changes.outputs.spirv-modified }}" == "true" ]]; then
-            # SPIRV files were modified, so consistency check should have run
-            if [[ "${{ needs.check-spirv-consistency.result }}" == "success" ]]; then
-              echo "✅ SPIRV-Tools generated files check passed"
-            elif [[ "${{ needs.check-spirv-consistency.result }}" == "failure" ]]; then
-              echo "❌ SPIRV-Tools generated files check failed"
-              exit 1
-            elif [[ "${{ needs.check-spirv-consistency.result }}" == "skipped" ]]; then
-              echo "⚠️ SPIRV-Tools generated files check was skipped unexpectedly"
-              exit 1
-            else
-              echo "⚠️ SPIRV-Tools generated files check had unexpected result: ${{ needs.check-spirv-consistency.result }}"
-              exit 1
-            fi
-          else
-            # No SPIRV files were modified, consistency check should be skipped
-            if [[ "${{ needs.check-spirv-consistency.result }}" == "skipped" ]]; then
-              echo "ℹ️ No SPIRV-related changes detected - check skipped as expected"
-            else
-              echo "⚠️ Expected consistency check to be skipped, but got: ${{ needs.check-spirv-consistency.result }}"
-              exit 1
-            fi
-          fi
-
   check-spirv-consistency:
     name: Check SPIRV-Tools Generated Files Consistency
     runs-on: ubuntu-latest
-    needs: check-spirv-changes
-    if: needs.check-spirv-changes.outputs.spirv-modified == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/check-spirv-tools-generated.yml
+++ b/.github/workflows/check-spirv-tools-generated.yml
@@ -3,6 +3,9 @@ name: Check SPIRV-Tools Generated Files
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -13,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 2
           submodules: recursive
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: "3.x"
 
@@ -32,8 +35,13 @@ jobs:
         run: |
           # Get the commit hash that spirv-tools expects for spirv-headers from DEPS file
           cd external/spirv-tools
-          EXPECTED_SPIRV_HEADERS_COMMIT=$(grep "'spirv_headers_revision':" DEPS | sed "s/.*'spirv_headers_revision'.*'\\([^']*\\)'.*/\\1/")
+          EXPECTED_SPIRV_HEADERS_COMMIT=$(grep spirv_headers_revision DEPS | grep -o "'[a-f0-9]\{40\}'" | tr -d "'")
           echo "Expected SPIRV-Headers commit (from DEPS): $EXPECTED_SPIRV_HEADERS_COMMIT"
+
+          if [ -z "$EXPECTED_SPIRV_HEADERS_COMMIT" ]; then
+            echo "❌ Could not extract spirv_headers_revision from DEPS"
+            exit 1
+          fi
 
           # Get the current commit hash of our spirv-headers submodule
           cd ../spirv-headers
@@ -59,7 +67,7 @@ jobs:
           cd external/spirv-tools
 
           # Sync dependencies (this might require additional setup for private repos)
-          python3 utils/git-sync-deps || echo "Warning: git-sync-deps failed, continuing anyway"
+          python3 utils/git-sync-deps
 
           # Configure and build
           cmake . -B build -G Ninja
@@ -76,21 +84,33 @@ jobs:
 
           MISMATCH_FOUND=false
 
+          # Enable nullglob to skip unmatched patterns explicitly.
+          shopt -s nullglob
+
           # Compare each generated file with the committed version
           for f in *.h *.inc; do
-            if [ -f "$f" ]; then
-              committed_file="../../spirv-tools-generated/$f"
-              if [ ! -f "$committed_file" ]; then
-                echo "❌ Missing file in spirv-tools-generated/: $f"
-                MISMATCH_FOUND=true
-              elif ! diff -q "$f" "$committed_file" > /dev/null; then
-                echo "❌ File differs: $f"
-                MISMATCH_FOUND=true
-              else
-                echo "✅ File matches: $f"
-              fi
+            committed_file="../../spirv-tools-generated/$f"
+            if [ ! -f "$committed_file" ]; then
+              echo "❌ Missing file in spirv-tools-generated/: $f"
+              MISMATCH_FOUND=true
+            elif ! diff -q "$f" "$committed_file" > /dev/null; then
+              echo "❌ File differs: $f"
+              MISMATCH_FOUND=true
+            else
+              echo "✅ File matches: $f"
             fi
           done
+
+          # Check for orphaned committed files that are no longer generated.
+          for committed in ../../spirv-tools-generated/*.h ../../spirv-tools-generated/*.inc; do
+            filename=$(basename "$committed")
+            if [ ! -f "$filename" ]; then
+              echo "❌ Orphaned file in spirv-tools-generated (should be removed): $filename"
+              MISMATCH_FOUND=true
+            fi
+          done
+
+          shopt -u nullglob
 
           if [ "$MISMATCH_FOUND" = true ]; then
             echo ""


### PR DESCRIPTION
- Validates external/spirv-tools-generated matches current spirv-tools build
- Adds a manual-dispatch workflow for SPIRV-Tools generated-file validation
- Checks spirv-headers commit consistency with spirv-tools DEPS
- Provides clear error messages and fix instructions

Fixes https://github.com/shader-slang/slang/issues/8509

## Reviewer Directives (maintained by agent)

- [human @gtong-nv] Keep the SPIRV-Tools generated-files check out of per-CL CI; run it as an independent manual workflow for SPIRV-Tools update work. (https://github.com/shader-slang/slang/pull/8510#issuecomment-3325402749)
