### PR TITLE
fix a crash when using type equality constaint

### DIFF
--- a/source/slang/slang-ast-base.h
+++ b/source/slang/slang-ast-base.h
@@ -673,12 +673,7 @@ class DeclRefBase : public Val
     SourceLoc getNameLoc() const;
     SourceLoc getLoc() const;
     DeclRefBase* getParent();
-    String toString() const
-    {
-        StringBuilder sb;
-        const_cast<DeclRefBase*>(this)->toText(sb);
-        return sb.produceString();
-    }
+    String toString() const;
     DeclRefBase* getBase();
     void toText(StringBuilder& out);
 };

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -931,12 +931,22 @@ top:
     {
         return bIsSubtypeOfCWitness;
     }
+    else if (auto declAIsSubtypeOfBWitness = as<DeclaredSubtypeWitness>(aIsSubtypeOfBWitness))
+    {
+        if (declAIsSubtypeOfBWitness->isEquality())
+            return bIsSubtypeOfCWitness;
+    }
 
     // Similarly, if `b == c`, then the `a <: b` witness is a witness for `a <: c`
     //
     if (as<TypeEqualityWitness>(bIsSubtypeOfCWitness))
     {
         return aIsSubtypeOfBWitness;
+    }
+    else if (auto declBIsSubtypeOfCWitness = as<DeclaredSubtypeWitness>(bIsSubtypeOfCWitness))
+    {
+        if (declBIsSubtypeOfCWitness->isEquality())
+            return declBIsSubtypeOfCWitness;
     }
 
     // HACK: There is downstream code generation logic that assumes that

--- a/source/slang/slang-ast-decl-ref.cpp
+++ b/source/slang/slang-ast-decl-ref.cpp
@@ -426,6 +426,14 @@ SourceLoc DeclRefBase::getLoc() const
     return getDecl()->loc;
 }
 
+// Keep this function here for better debuggin purpose
+String DeclRefBase::toString() const
+{
+    StringBuilder sb;
+    const_cast<DeclRefBase*>(this)->toText(sb);
+    return sb.produceString();
+}
+
 DeclRefBase* DeclRefBase::getParent()
 {
     auto astBuilder = getCurrentASTBuilder();

--- a/tests/autodiff/self-differential-type-equality-constraint.slang
+++ b/tests/autodiff/self-differential-type-equality-constraint.slang
@@ -1,0 +1,35 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type
+
+interface IV : IDifferentiablePtrType{
+	int get();
+}
+
+struct V : IV
+{
+	typealias Differential = This;
+
+	int get()
+	{
+		return 12;
+	}
+}
+
+int g<T:IV>(DifferentialPtrPair<T> obj)
+	where T.Differential == T
+{
+	return obj.d.get();
+}
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+[shader("compute")]
+void computeMain()
+{
+	V v = {};
+	DifferentialPtrPair<V> p = {v, v};
+
+	// BUFFER: 12
+	outputBuffer[0] = g(p);
+}


### PR DESCRIPTION
Close #8193.

When constructing `TransitiveTypeWitness` node, we should check if there is operand that represents two equal times. Currently, we only check whether the operand is `TypeEqualityWitness`, which is not good enough, because a `DeclaredSubtypeWitness` could also be representing two same types, in that case, we should also const fold this kind of witness.

Fails to do so, we could finally ends up with a generating a lookup witness IR on a generic parameter that is not supposed to be looked up.