### PR TITLE
Update function type after inserting KernelContext parameter

### DIFF
--- a/source/slang/slang-ir-explicit-global-context.cpp
+++ b/source/slang/slang-ir-explicit-global-context.cpp
@@ -564,6 +564,9 @@ struct IntroduceExplicitGlobalContextPass
                 builder.emitStore(fieldPtr, var);
             }
         }
+
+        // Update entry point function type after potentially adding parameters.
+        fixUpFuncType(entryPointFunc);
     }
 
     void replaceUsesOfGlobalParam(IRGlobalParam* globalParam)


### PR DESCRIPTION
Without this, there are functions with missing parameters in their type in the IR after running the `introduceExplicitGlobalContext` pass:

```
[layout(%15)]
[export("_SV4test12outputBuffer")]
[nameHint("outputBuffer")]
let  %outputBuffer      : _     = key
[noSideEffect]
[export("_S4test7dostuffp1pi_ff")]
[nameHint("dostuff")]
func %dostuff   : Func(Float, Float)
{
block %34(
                [nameHint("f")]
                param %f        : Float,
                [nameHint("kernelContext")]
                param %kernelContext    : Ptr(%KernelContext, 0 : UInt64, 1 : UInt64)):
        let  %35        : Float = mul(%f, %f)
        let  %36        : Ptr(ConstantBuffer(%GlobalParams, DefaultLayout), 0 : UInt64, 1 : UInt64)     = get_field_addr(%kernelContext, %globalParams)
        let  %37        : ConstantBuffer(%GlobalParams, DefaultLayout)  = load(%36)
        let  %38        : Ptr(RWStructuredBuffer(Float, DefaultLayout, %20))    = get_field_addr(%37, %outputBuffer)
        let  %39        : RWStructuredBuffer(Float, DefaultLayout, %20) = load(%38)
        let  %40        : Ptr(Float)    = rwstructuredBufferGetElementPtr(%39, 1 : Int)
        let  %41        : Float = load(%40)
        let  %42        : Float = mul(%35, %41)
        return_val(%42)
}
```

Not sure why this doesn't seem to negatively affect existing targets, but it sure is an issue for the LLVM target I'm working on. I could've left this fix for that PR, but I want to check now if this causes any issues with the existing targets using the CI.

This also happens with the entry point functions, where the function type is not updated after adding `ComputeThreadVaryingInput`. This had no effect in the C++ target because `convertEntryPointPtrParamsToRawPtrs(irModule);` is called right after and fixes it.