### PR TITLE
Misc parser improvements.

### DIFF
--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -626,6 +626,9 @@ Extensions
 `SPV_KHR_vulkan_memory_model`
 > Represents the SPIR-V extension for SPV_KHR_vulkan_memory_model.
 
+`SPV_NV_bindless_texture`
+> Represents the SPIR-V extension for SPV_NV_bindless_texture.
+
 `SPV_NV_cluster_acceleration_structure`
 > Represents the SPIR-V extension for cluster acceleration structure.
 
@@ -674,6 +677,9 @@ Extensions
 
 `spvAtomicFloat64MinMaxEXT`
 > Represents the SPIR-V capability for atomic float 64 min/max operations.
+
+`spvBindlessTextureNV`
+> Represents the SPIR-V capability for the bindless texture.
 
 `spvCooperativeMatrixBlockLoadsNV`
 > Represents the SPIR-V capability for cooperative matrix 2

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -4249,6 +4249,9 @@ static void parseModernVarDeclBaseCommon(Parser* parser, VarDeclBase* decl)
         decl->type = parser->ParseTypeExp();
     }
 
+    auto modifiers = _parseOptSemantics(parser);
+    _addModifiers(decl, modifiers);
+
     if (AdvanceIf(parser, TokenType::OpAssign))
     {
         decl->initExpr = parser->ParseInitExpr();
@@ -4350,6 +4353,8 @@ static NodeBase* parseFuncDecl(Parser* parser, void* /*userData*/)
         {
             parser->PushScope(decl);
             parseModernParamList(parser, decl);
+            auto funcScope = parser->currentScope;
+            parser->PopScope();
             if (AdvanceIf(parser, "throws"))
             {
                 decl->errorType = parser->ParseTypeExp();
@@ -4358,8 +4363,6 @@ static NodeBase* parseFuncDecl(Parser* parser, void* /*userData*/)
             {
                 decl->returnType = parser->ParseTypeExp();
             }
-            auto funcScope = parser->currentScope;
-            parser->PopScope();
             maybeParseGenericConstraints(parser, genericParent);
             parser->PushScope(funcScope);
             decl->body = parseOptBody(parser);
@@ -5508,10 +5511,16 @@ Decl* Parser::ParseStruct()
                 rs->wrappedType = ParseTypeExp();
                 PushScope(rs);
                 PopScope();
-                ReadToken(TokenType::Semicolon);
+                if (!LookAheadToken(TokenType::Semicolon))
+                {
+                    this->diagnose(
+                        this->tokenReader.peekToken().loc,
+                        Diagnostics::unexpectedTokenExpectedTokenType,
+                        "';'");
+                }
                 return rs;
             }
-            if (AdvanceIf(this, TokenType::Semicolon))
+            if (LookAheadToken(TokenType::Semicolon))
             {
                 rs->hasBody = false;
                 return rs;

--- a/tests/front-end/link-time-struct-same-line.slang
+++ b/tests/front-end/link-time-struct-same-line.slang
@@ -1,0 +1,9 @@
+// Check that we can correctly parse link-time struct definitions on the same line.
+// There was a bug where the parser is expecting an identifier after `struct` definition,
+// even if the struct is a link-time struct ending with a `;`.
+
+//TEST:SIMPLE: -target slangvm
+
+interface IFoo{}
+struct FooImpl : IFoo{}
+export struct Foo1 : IFoo = FooImpl; export struct Foo2 : IFoo = FooImpl;

--- a/tests/front-end/modern-syntax-semantic.slang
+++ b/tests/front-end/modern-syntax-semantic.slang
@@ -1,0 +1,11 @@
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK): -output-using-type
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1,1,1)]
+func computeMain(tid : int : SV_DispatchThreadID) -> void
+{
+    // CHECK: 1
+    outputBuffer[0] = tid + 1;
+}

--- a/tests/front-end/struct-result-type.slang
+++ b/tests/front-end/struct-result-type.slang
@@ -1,0 +1,16 @@
+// Check that we can parse and check an anonymous struct declaration as function return type.
+
+//TEST:INTERPRET(filecheck=CHECK):
+
+module testa;
+
+func test(int a) -> struct{ int a,b; } {
+    return {a,2};
+}
+
+void main()
+{
+    let m = test(1);
+    // CHECK: 3
+    printf("%d\n", m.a + m.b);
+}


### PR DESCRIPTION
- Fix bug parsing multiple link-time structs on the same line. Closes #8553.
- Fix bug parsing anonymous struct type as function return type in modern syntax. Closes #8558
- Support semantics on modern style param/var declarations.