### PR TITLE
Handle getEquivalentStructuredBuffer(castDynamicResource) in byte address legalization pass.

### DIFF
--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -941,6 +941,19 @@ struct ByteAddressBufferLegalizationContext
         {
             return getEquivalentStructuredBufferParam(elementType, byteAddressBufferParam);
         }
+        else if (auto castDynamicResource = as<IRCastDynamicResource>(byteAddressBuffer))
+        {
+            // If the underlying structured buffer is a CastDynamicResource,
+            // we can simply cast the dynamic resource into the byte address buffer type instead.
+            auto arg = castDynamicResource->getOperand(0);
+            return m_builder.emitIntrinsicInst(
+                getEquivalentStructuredBufferParamType(
+                    elementType,
+                    byteAddressBuffer->getDataType()),
+                kIROp_CastDynamicResource,
+                1,
+                &arg);
+        }
 
         if (byteAddressBuffer->getOp() == kIROp_GetElement)
         {

--- a/tests/language-feature/descriptor-handle/byte-address-buffer-handle.slang
+++ b/tests/language-feature/descriptor-handle/byte-address-buffer-handle.slang
@@ -1,0 +1,38 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+
+// CHECK: OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer %resourceHandles
+
+[vk::binding(0, 0)]
+__DynamicResource<__DynamicResourceKind.General> resourceHandles[];
+
+[vk::binding(0, 1)]
+__DynamicResource<__DynamicResourceKind.Sampler> samplerHandles[];
+
+export T getDescriptorFromHandle<T>(DescriptorHandle<T> handle) where T : IOpaqueDescriptor
+{
+    __target_switch
+    {
+    case spirv:
+        if (T.kind == DescriptorKind.Sampler) {
+            return samplerHandles[((uint2)handle).x].asOpaqueDescriptor<T>();
+        }
+        else {
+            return resourceHandles[((uint2)handle).x].asOpaqueDescriptor<T>();
+        }
+    default:
+        return defaultGetDescriptorFromHandle(handle);
+    }
+}
+
+// test.slang
+struct PushConstant
+{
+    RWByteAddressBuffer.Handle test_buffer;
+};
+[[vk::push_constant]] PushConstant constant;
+
+[shader("fragment")]
+void main_test_fs(float2 fragment_coord: SV_Position, out float4 color: SV_Target)
+{
+    color = float4(constant.test_buffer.Load<uint3>(0), 1.0);
+}


### PR DESCRIPTION
This is crash that be triggered by providing custom `getDescriptorFromHandle` and use it to return access a ByteAddressBuffer from a bindless handle.

Closes #8355.