### PR TITLE
Re-add macOS cross-compile setup to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,18 @@ jobs:
 
           - { build-slang-llvm: false }
           - { os: linux, platform: x86_64, build-slang-llvm: true }
-          - { os: windows, platform: x86_64, arch: amd64, build-slang-llvm: true }
-          - { os: macos, platform: aarch64, arch: arm64, build-slang-llvm: true }
+          - {
+              os: windows,
+              platform: x86_64,
+              arch: amd64,
+              build-slang-llvm: true,
+            }
+          - {
+              os: macos,
+              platform: aarch64,
+              arch: arm64,
+              build-slang-llvm: true,
+            }
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
     container: ${{ matrix.image || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,15 +40,37 @@ jobs:
             }
           - {
               os: windows,
+              platform: x86_64,
+              arch: amd64,
               runs-on: ["Windows", "self-hosted", "GCP-T4"],
               compiler: cl,
             }
-          - { os: macos, runs-on: macos-latest, compiler: clang }
+          - {
+              os: windows,
+              platform: aarch64,
+              arch: amd64_arm64,
+              runs-on: ["Windows", "self-hosted", "GCP-T4"],
+              compiler: cl,
+            }
+          - {
+              os: macos,
+              platform: x86_64,
+              arch: x86_64,
+              runs-on: macos-latest,
+              compiler: clang,
+            }
+          - {
+              os: macos,
+              platform: aarch64,
+              arch: arm64,
+              runs-on: macos-latest,
+              compiler: clang,
+            }
 
           - { build-slang-llvm: false }
           - { os: linux, platform: x86_64, build-slang-llvm: true }
-          - { os: windows, platform: x86_64, build-slang-llvm: true }
-          - { os: macos, platform: aarch64, build-slang-llvm: true }
+          - { os: windows, platform: x86_64, arch: amd64, build-slang-llvm: true }
+          - { os: macos, platform: aarch64, arch: arm64, build-slang-llvm: true }
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
     container: ${{ matrix.image || '' }}
@@ -78,11 +100,16 @@ jobs:
           mkdir build-platform-generators
           cmake --install build --config Release --component generators --prefix build-platform-generators
 
-      - name: Setup Windows dev tools for host and target architecture
+      - name: Setup Windows dev tools for target architecture
         if: matrix.os == 'windows'
         uses: ilammy/msvc-dev-cmd@v1
         with:
-          arch: ${{ matrix.platform == 'aarch64' && 'amd64_arm64' || 'amd64' }}
+          arch: ${{ matrix.arch }}
+
+      - name: Setup macOS dev tools for target architecture
+        if: matrix.os == 'macos'
+        run: |
+          echo "CMAKE_OSX_ARCHITECTURES=${{ matrix.arch }}" >> "$GITHUB_ENV"
 
       - name: Build Slang
         run: |


### PR DESCRIPTION
For #8564

Similar to #8580, this re-adds the cross-compile target setup step for macOS releases that was erroneously removed in https://github.com/shader-slang/slang/pull/8470, which made x86_64 releases build aarch64 binaries.

It also simplifies the workflow logic a bit by adding a separate `arch` variable to the release matrix, which refers to the target architecture in the manner that the setup requires, so that we do not have to replace the string `"aarch64"` with `"arm64"` in setting `CMAKE_OSX_ARCHITECTURES` for native aarch64 macOS builds and do not have to conditionally set the MSVC `arch` to `amd64_arm64` for Windows cross-compilation.