### PR TITLE
Respect isShadow() flag when setting depth type in SPIR-V backend

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -2681,7 +2681,11 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
         // Vulkan spec 16.1: "The “Depth” operand of OpTypeImage is ignored."
         SpvWord depth =
-            ImageOpConstants::unknownDepthImage; // No knowledge of if this is a depth image
+            inst->isShadow()
+                ? ImageOpConstants::isDepthImage       // But we respect the `isShadow` flag of the
+                                                       // texture
+                : ImageOpConstants::unknownDepthImage; // No knowledge of if this is a depth image
+
         SpvWord ms = inst->isMultisample() ? ImageOpConstants::isMultisampled
                                            : ImageOpConstants::notMultisampled;
 

--- a/tests/spirv/depth-texture.slang
+++ b/tests/spirv/depth-texture.slang
@@ -1,0 +1,38 @@
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -entry psMain -stage pixel
+
+// SPIRV: OpTypeImage %{{.*}} 2D 1 0 0 1 Unknown
+
+__generic<let sampleCount : int = 0, let format : int = 0>
+typealias DepthTexture2D = _Texture<
+    float,
+    __Shape2D,
+    0, // isArray
+    0, // isMS
+    sampleCount,
+    0, // access
+    1, // isShadow
+    0, // isCombined
+    format
+>;
+
+[[vk::binding(0, 0)]] DepthTexture2D depthTexture : register(t0);
+[[vk::binding(1, 0)]] SamplerComparisonState comparisonSampler : register(s0);
+
+[[shader("pixel")]]
+float4 psMain(
+    float4 position : SV_POSITION,
+    float2 texCoord : TEXCOORD0
+) : SV_TARGET {
+    float comparison = depthTexture.SampleCmp(
+        comparisonSampler,
+        texCoord,
+        0.5
+    );
+
+    if (comparison != 0.0) {
+        return float4(1.0, 1.0, 1.0, 1.0);
+    } else {
+        return float4(0.0, 0.0, 0.0, 1.0);
+    }
+}


### PR DESCRIPTION
This is important for SPIR-V targets that need to know if a texture is designated as a depth texture or not (for example WebGPU).

I didn't change the default behavior for when isShadow() is not set, since I didn't want to make the change too invasive.