### PR TITLE
Matrix legalization for missing instructions & MakeMatrix of vectors

### DIFF
--- a/source/slang/slang-ir-legalize-matrix-types.cpp
+++ b/source/slang/slang-ir-legalize-matrix-types.cpp
@@ -525,6 +525,8 @@ struct MatrixTypeLoweringContext
         case kIROp_Sub:
         case kIROp_Mul:
         case kIROp_Div:
+        case kIROp_IRem:
+        case kIROp_FRem:
         case kIROp_Lsh:
         case kIROp_Rsh:
         case kIROp_And:

--- a/source/slang/slang-ir-legalize-matrix-types.cpp
+++ b/source/slang/slang-ir-legalize-matrix-types.cpp
@@ -135,7 +135,8 @@ struct MatrixTypeLoweringContext
                 for (IRIntegerValue col = 0; col < columnCount->getValue(); col++)
                 {
                     SLANG_ASSERT(
-                        operandIndex < makeMatrix->getOperandCount() && "Operand index out of bounds");
+                        operandIndex < makeMatrix->getOperandCount() &&
+                        "Operand index out of bounds");
                     rowElements.add(getReplacement(makeMatrix->getOperand(operandIndex)));
                     operandIndex++;
                 }
@@ -160,7 +161,8 @@ struct MatrixTypeLoweringContext
                 rowVectors.add(rowVector);
             }
         }
-        else SLANG_ASSERT_FAILURE("makeMatrix operand count must match matrix dimensions");
+        else
+            SLANG_ASSERT_FAILURE("makeMatrix operand count must match matrix dimensions");
 
         SLANG_ASSERT(
             rowVectors.getCount() == rowCount->getValue() &&


### PR DESCRIPTION
Fixes these issues:
* During matrix legalization, `MakeMatrix` crashed if it was given a list of vectors instead of individual elements.
* Matrix casts, IRem, and Frem would be emitted using arrays, e.g. `IntToFloatCast` with `float2[2]` parameters.

I found these bugs while enabling various `hlsl-intrinsic` tests for the LLVM target. For now, I've chose to get rid of all matrix types with the matrix legalization pass so that the LLVM emitter doesn't need to be aware. These bugs were preventing `tests/hlsl-intrinsic/matrix-double-reduced-intrinsic.slang` and `tests/hlsl-intrinsic/matrix-double.slang` from passing there.