### PR TITLE
Minor Documentation Update to Remove Outdated Section

### DIFF
--- a/docs/user-guide/a2-03-wgsl-target-specific.md
+++ b/docs/user-guide/a2-03-wgsl-target-specific.md
@@ -91,14 +91,6 @@ ConstantBuffer translates to the `uniform` address space with `read` access mode
 ByteAddressBuffer and RWByteAddressBuffer translate to `array<u32>` in the `storage` address space, with the `read` and `read_write` access modes in WGSL, respectively.
 StructuredBuffer and RWStructuredBuffer with struct type T translate to `array<T>` in the `storage` address space, with with the `read` and `read_write` access modes in WGSL, respectively.
 
-
-Specialization Constants
-------------------------
-
-Specialization constants are not supported when targeting WGSL, at the moment.
-They should map to 'override declarations' in WGSL, however this is not yet implemented.
-
-
 Interlocked operations
 ----------------------
 

--- a/docs/user-guide/toc.html
+++ b/docs/user-guide/toc.html
@@ -249,7 +249,6 @@
 <li data-link="wgsl-target-specific#supported-hlsl-features-when-targeting-wgsl"><span>Supported HLSL features when targeting WGSL</span></li>
 <li data-link="wgsl-target-specific#supported-atomic-types"><span>Supported atomic types</span></li>
 <li data-link="wgsl-target-specific#constantbuffer-rwrasterizerorderedstructuredbuffer-rwrasterizerorderedbyteaddressbuffer"><span>ConstantBuffer, (RW/RasterizerOrdered)StructuredBuffer, (RW/RasterizerOrdered)ByteAddressBuffer</span></li>
-<li data-link="wgsl-target-specific#specialization-constants"><span>Specialization Constants</span></li>
 <li data-link="wgsl-target-specific#interlocked-operations"><span>Interlocked operations</span></li>
 <li data-link="wgsl-target-specific#entry-point-parameter-handling"><span>Entry Point Parameter Handling</span></li>
 <li data-link="wgsl-target-specific#parameter-blocks"><span>Parameter blocks</span></li>


### PR DESCRIPTION
As mentioned in #8316 , there is a small duplicated and outdated section in WGSL-Specific Functionalities documentation about specialization constants support,
remove the outdated duplicated one
<img width="893" height="146" alt="image" src="https://github.com/user-attachments/assets/abcd7521-645b-4bd6-b926-ce2d978775bd" />
as there is a new section in the page
<img width="851" height="319" alt="image" src="https://github.com/user-attachments/assets/f52e5230-812b-4b29-88f4-bfff890f37ed" />


