### PR TITLE
Add check for NVRTC backend in unit test cudaCodeGenBug

### DIFF
--- a/tools/slang-unit-test/unit-test-find-check-entrypoint.cpp
+++ b/tools/slang-unit-test/unit-test-find-check-entrypoint.cpp
@@ -78,6 +78,13 @@ SLANG_UNIT_TEST(findAndCheckEntryPoint)
 // tests/compute/simple.slang should cover the same issue.
 SLANG_UNIT_TEST(cudaCodeGenBug)
 {
+    // We need the CUDA backend for this test
+    if (!SLANG_SUCCEEDED(
+            unitTestContext->slangGlobalSession->checkPassThroughSupport(SLANG_PASS_THROUGH_NVRTC)))
+    {
+        SLANG_IGNORE_TEST;
+    }
+
     // Source for a module that contains an undecorated entrypoint.
     const char* userSourceBody = R"(
         RWStructuredBuffer<float> outputBuffer;


### PR DESCRIPTION
Test `slang-unit-test-tool/cudaCodeGenBug.internal` requires that the CUDA toolkit is available. Add a check for the NVRTC backend to avoid a failure when this is not the case.

Fixes #6636