### PR TITLE
Allow 1D SV_DispatchThreadID in CPU targets

### DIFF
--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -1465,6 +1465,7 @@ struct CPUEntryPointVaryingParamLegalizeContext : EntryPointVaryingParamLegalize
     IRInst* groupThreadID = nullptr;
     IRInst* groupExtents = nullptr;
     IRInst* dispatchThreadID = nullptr;
+    IRInst* dispatchThreadID1D = nullptr;
     IRInst* groupThreadIndex = nullptr;
 
     void beginEntryPointImpl() SLANG_OVERRIDE
@@ -1472,6 +1473,7 @@ struct CPUEntryPointVaryingParamLegalizeContext : EntryPointVaryingParamLegalize
         groupID = nullptr;
         groupThreadID = nullptr;
         dispatchThreadID = nullptr;
+        dispatchThreadID1D = nullptr;
 
         IRBuilder builder(m_module);
 
@@ -1512,6 +1514,8 @@ struct CPUEntryPointVaryingParamLegalizeContext : EntryPointVaryingParamLegalize
 
         dispatchThreadID =
             emitCalcDispatchThreadID(builder, uint3Type, groupID, groupThreadID, groupExtents);
+        UInt idx = 0;
+        dispatchThreadID1D = builder.emitSwizzle(uintType, dispatchThreadID, 1, &idx);
 
         groupThreadIndex = emitCalcGroupIndex(builder, groupThreadID, groupExtents);
     }
@@ -1535,8 +1539,10 @@ struct CPUEntryPointVaryingParamLegalizeContext : EntryPointVaryingParamLegalize
         case SystemValueSemanticName::GroupIndex:
             return LegalizedVaryingVal::makeValue(groupThreadIndex);
         case SystemValueSemanticName::DispatchThreadID:
-            return LegalizedVaryingVal::makeValue(dispatchThreadID);
-
+            if (as<IRBasicType>(info.type))
+                return LegalizedVaryingVal::makeValue(dispatchThreadID1D);
+            else
+                return LegalizedVaryingVal::makeValue(dispatchThreadID);
         default:
             return diagnoseUnsupportedSystemVal(info);
         }

--- a/tests/language-feature/enums/enum-switch-2.slang
+++ b/tests/language-feature/enums/enum-switch-2.slang
@@ -1,4 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cpu -slang -compute -shaderobj -output-using-type
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
 
 enum class E : uint32_t


### PR DESCRIPTION
The varying param legalization pass didn't deal with this 1D form of SV_DispatchThreadID for CPU targets:

```slang
void computeMain(int i : SV_DispatchThreadID)
```

Instead, it just overrode the type of `i` with an `uint3`, breaking lots of code that attempted to use `i` for something, like a `switch` statement for example.

I ran across this when going through `language-feature` tests for the LLVM target, which will also use this legalization pass. I'm separately submitting this now because this also fixes the existing CPU target. The test I enable in this PR is one that was previously generating broken code on CPU.

(somewhat related issue: #7468)