### PR TITLE
Use GitHub runners for Windows releases, disable CUDA for aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
               arch: amd64_arm64,
               runs-on: windows-latest,
               compiler: cl,
+              extra-cmake-flags: "-DSLANG_ENABLE_CUDA=0",
             }
           - {
               os: macos,
@@ -145,7 +146,8 @@ jobs:
             -DSLANG_ENABLE_EXAMPLES=OFF \
             -DSLANG_ENABLE_RELEASE_LTO=ON \
             "-DSLANG_SLANG_LLVM_FLAVOR=$(
-              [[ "${{matrix.build-slang-llvm}}" = "true" ]] && echo "USE_SYSTEM_LLVM" || echo "DISABLE")"
+              [[ "${{matrix.build-slang-llvm}}" = "true" ]] && echo "USE_SYSTEM_LLVM" || echo "DISABLE")" \
+            ${{matrix.extra-cmake-flags}}
 
           cmake --build --preset "${{matrix.config}}"
 


### PR DESCRIPTION
For #8596
Fixes #8597

This switches our release workflow back to using GitHub's `windows-latest` runners, which we were using previously.

It also adds the variable `extra-cmake-flags` to the `windows-aarch64` entry in the workflow's matrix with the value `"-DSLANG_ENABLE_CUDA=0"`. If we are cross-compiling aarch64 on x86_64, and the x86_64 CUDA Toolkit is installed, it will be auto-detected by cmake and the build will fail (no aarch64 version of CUDA Toolkit exists).
The `windows-latest` runners do not have CUDA Toolkit, so they do not encounter this issue, but if we do end up building on runners that do (such as the temporary move to self-hosted runners), adding that flag eliminates that potential problem.

This release workflow does build properly on `windows-latest` with `extra-cmake-flags`: https://github.com/aidanfnv/slang/actions/runs/18293521738