### PR TITLE
Disable branching subgroup test for WGSL

### DIFF
--- a/tests/hlsl-intrinsic/wave-is-first-lane.slang
+++ b/tests/hlsl-intrinsic/wave-is-first-lane.slang
@@ -6,8 +6,8 @@
 //TEST:COMPARE_COMPUTE_EX:-cuda -compute -capability cuda_sm_7_0 -shaderobj
 //TEST:COMPARE_COMPUTE_EX:-metal -compute -shaderobj
 
-// WGSL doesn't support wave functions in a dynamic control flow; it works with uniform control flow.
-//TEST:COMPARE_COMPUTE_EX:-wgpu -compute -shaderobj
+// WGSL doesn't support wave functions in a dynamic control flow; it works only with uniform control flow.
+//DISABLE_TEST:COMPARE_COMPUTE_EX:-wgpu -compute -shaderobj
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0  0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;


### PR DESCRIPTION
WGSL doesn't allow subgroup related functions in a branching. It must be used in a uniform flow. This commit disables a test for such case.

Note that the test was supposed to be disabled on the previous PR, but it was mistakenly not disabled.
- #8386