### PR TITLE
Fix a bug that causes a struct field to be initialized twice.

### DIFF
--- a/tests/optimization/func-resource-result/init-copy-eliminate.slang
+++ b/tests/optimization/func-resource-result/init-copy-eliminate.slang
@@ -1,0 +1,36 @@
+//TEST:SIMPLE(filecheck=CHECK):-target cuda -entry computeMain -stage compute
+
+// Test on a regression that caused a field to be initialized twice in the ctor.
+
+// CHECK-COUNT-1: callOnce{{.*}}(int(1000))
+
+int callOnce(int x) { return 999; }
+
+public struct Ray
+{
+    public int calledOnce = callOnce(1000);
+    public float3 origin = {};
+    public float t_min = 0;
+    public float3 dir = {};
+    public float t_max = 0;
+
+    public __init(float3 origin, float3 dir, float t_min = 0.f, float t_max = 1000.0)
+    {
+        this.origin = origin;
+        this.dir = dir;
+        this.t_min = t_min;
+        this.t_max = t_max;
+    }
+
+    public RayDesc to_ray_desc() { return { origin, t_min, dir, t_max }; }
+};
+
+uniform float* result;
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    Ray r = Ray(float3(1,2,3), float3(4,5,6));
+    RayDesc rd = r.to_ray_desc();
+    *result = rd.Direction.x;
+}


### PR DESCRIPTION
We insert field initialization logic at the beginning of every ctor in `synthesizeCtorBody`, but then immediately inserts another round of initialization again for explicit ctors in `maybeInsertDefaultInitExpr`, both called from `SemanticsDeclBodyVisitor::visitAggTypeDecl` right next to each other.

The fix is to remove `maybeInsertDefaultInitExpr`.