### PR TITLE
Small fix to buffer load specialization pass to allow more specialization to happen.

### DIFF
--- a/source/slang/slang-ir-specialize-buffer-load-arg.cpp
+++ b/source/slang/slang-ir-specialize-buffer-load-arg.cpp
@@ -89,7 +89,7 @@ struct FuncBufferLoadSpecializationCondition : FunctionCallSpecializeCondition
                 a = argLoad->getPtr();
 
                 // We can safely defer a load to the callee if the source dest is immutable.
-                if (isPointerToImmutableLocation(a))
+                if (isPointerToImmutableLocation(getRootAddr(a)))
                     continue;
 
                 // Otherwise, we check if there is no other instructions in between the load and the

--- a/tests/optimization/wrapped-array.slang
+++ b/tests/optimization/wrapped-array.slang
@@ -1,7 +1,12 @@
 //TEST:SIMPLE(filecheck=CHECK):-target spirv
 
 // CHECK: OpEntryPoint
-// CHECK-NOT: OpCompositeExtract
+
+// Make sure we never load the entire TensorList struct to local registers,
+// instead, we should specialize the fetch function to directly load the
+// element tensor from gTensors.
+
+// CHECK-NOT: OpLoad %TensorList_std140
 
 struct RWTensor<T, let D : int>
 {


### PR DESCRIPTION
This allows us to further cleanup unnecessary copies in the target code we generate.

Part of effort of #8652.