### PR TITLE
Improve perf with `-separate-debug-info`

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -2326,8 +2326,7 @@ public:
         SpvWord* word = nullptr;
     };
 
-    SpirvInstructionHelper()
-    {}
+    SpirvInstructionHelper() {}
 
     // Load the SPIRV instructions from the artifact into a data blob that
     // we can read.


### PR DESCRIPTION
When Slang form a new spirv code without the debug info, List container had to reserve the memory space before adding items in it.

This improves the given repro test time from 56 minutes to 6 minutes.