### PR TITLE
Fix `specializeRTTIObject` to use non-zero RTTI value to work with `Optional<T>`.

### DIFF
--- a/source/slang/slang-emit-vm.cpp
+++ b/source/slang/slang-emit-vm.cpp
@@ -247,6 +247,17 @@ public:
             operand = addConstantValue(constantInst);
             mapInstToOperand[inst] = operand;
         }
+        else if (auto constantVector = as<IRMakeVector>(inst))
+        {
+            SLANG_ASSERT(constantVector->getOperandCount() > 0);
+            operand = ensureInst(constantVector->getOperand(0));
+            for (UInt i = 1; i < constantVector->getOperandCount(); i++)
+            {
+                ensureInst(constantVector->getOperand(i));
+            }
+            operand.size *= (uint32_t)constantVector->getOperandCount();
+            mapInstToOperand[inst] = operand;
+        }
         else
         {
             SLANG_UNEXPECTED("unsupported global inst for vm bytecode emit");

--- a/source/slang/slang-ir-lower-existential.cpp
+++ b/source/slang/slang-ir-lower-existential.cpp
@@ -68,13 +68,15 @@ struct ExistentialLoweringContext
         auto witnessTableIdType = cast<IRWitnessTableIDType>(tupleType->getOperand(1));
         auto anyValueType = cast<IRAnyValueType>(tupleType->getOperand(2));
 
-        // Create a null value for `rttiObject` for now since it will not be used.
+        // Create a standin value for `rttiObject` for now since it will not be used
+        // other than test for null in the case of `Optional<IFoo>`.
         auto uint2Type = builder->getVectorType(
             builder->getUIntType(),
             builder->getIntValue(builder->getIntType(), 2));
+        IRInst* standinVal = builder->getIntValue(builder->getUIntType(), 0xFFFFFFFF);
         IRInst* zero = builder->getIntValue(builder->getUIntType(), 0);
-        IRInst* zeroVectorArgs[] = {zero, zero};
-        IRInst* rttiObject = builder->emitMakeVector(uint2Type, 2, zeroVectorArgs);
+        IRInst* standinRTTIVectorArgs[] = {standinVal, zero};
+        IRInst* rttiObject = builder->emitMakeVector(uint2Type, 2, standinRTTIVectorArgs);
 
         // Pack the user provided value into `AnyValue`.
         IRInst* packedValue = inst->getValue();

--- a/source/slang/slang-ir-lower-generics.cpp
+++ b/source/slang/slang-ir-lower-generics.cpp
@@ -23,11 +23,11 @@
 namespace Slang
 {
 // Replace all uses of RTTI objects with its sequential ID.
-// Currently we don't use RTTI objects at all, so all of them
-// are 0.
+// Currently we don't use RTTI objects other than check for null/invalid value,
+// so all of them are 0xFFFFFFFF.
 void specializeRTTIObjectReferences(SharedGenericsLoweringContext* sharedContext)
 {
-    uint32_t id = 0;
+    uint32_t id = 0xFFFFFFFF;
     for (auto rtti : sharedContext->mapTypeToRTTIObject)
     {
         IRBuilder builder(sharedContext->module);

--- a/tests/language-feature/types/optional-ifoo.slang
+++ b/tests/language-feature/types/optional-ifoo.slang
@@ -1,0 +1,26 @@
+//TEST:INTERPRET(filecheck=CHECK):
+
+interface IFoo
+{
+    int get_result();
+}
+
+struct FooImpl : IFoo
+{
+    int get_result() { return data; }
+    int data;
+}
+
+Optional<IFoo> generate_foo(int i)
+{
+    FooImpl result = {};
+    result.data = i;
+    return { result };
+}
+
+void main()
+{
+    // CHECK: hasValue: 1
+    let result_foo = generate_foo(100);
+    printf("hasValue: %d\n", (int)result_foo.hasValue);
+}


### PR DESCRIPTION
Closes #8673.

The issue is that we use the RTTI field of an existential to check if it is null. We have the logic to help the user to fill in a non-zero value for the RTTI field when such an object is filled from the host. However, when there is slang code creating an existential value, we still have old logic in the compiler that just fills in 0 for the RTTI field, causing an `Optional<IFoo>.hasValue` to always return false in such cases.