### PR TITLE
Retry file reads in slang-test to handle intermittent I/O errors

### DIFF
--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -571,7 +571,7 @@ static SlangResult _gatherTestsForFile(
             if (testReporter)
             {
                 testReporter->messageFormat(
-                    TestMessageType::RunError,
+                    TestMessageType::Info,
                     "Retrying to read test file '%s' (attempt %d)",
                     filePath.getBuffer(),
                     retryCount + 1);


### PR DESCRIPTION
Related #8705