### PR TITLE
[CI] Skip slangpy test_blit.py::test_generate_mips for CUDA

### DIFF
--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -212,4 +212,4 @@ jobs:
           echo "Running pytest on slangpy tests..."
           export PYTHONPATH="$SITE_PACKAGES"
           python -m pytest "$SITE_PACKAGES/slangpy/tests" -ra -n auto --maxprocesses=3 \
-            --deselect "$SITE_PACKAGES/slangpy/tests/device/test_blit.py::test_generate_mips[compute-DeviceType.cuda]"
+            --deselect "device/test_blit.py::test_generate_mips[compute-DeviceType.cuda]"


### PR DESCRIPTION
This skips a new test from slangpy that is hitting an internal assert in slang CI, uncaught in testing due to slangpy's CI testing using release builds.

See https://github.com/shader-slang/slangpy/issues/575 for details
