### PR TITLE
Additional fix to calls with no_diff variadic type pack.

### DIFF
--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -29,7 +29,7 @@ SemanticsVisitor::ParamCounts SemanticsVisitor::CountParameters(
     for (auto param : params)
     {
         Index allowedArgCountToAdd = 1;
-        auto paramType = getParamType(m_astBuilder, param);
+        auto paramType = unwrapModifiedType(getParamType(m_astBuilder, param));
         if (isTypePack(paramType))
         {
             if (auto typePack = as<ConcreteTypePack>(paramType))

--- a/tests/language-feature/generics/variadic-generic-differentiable.slang
+++ b/tests/language-feature/generics/variadic-generic-differentiable.slang
@@ -46,14 +46,15 @@ void wrapper2<each T>(
     wrapper1(x, args);
 }
 
-
 void main()
 {
     // There was a bug that causes the compiler failing to treat a `no_diff TypePack` as
     // a type pack, and thus diagnose an error when resolving the following call.
     //
-    wrapper2(1, FloatParameterExtractor(), FloatParameterExtractor());
+    wrapper2(1, FloatParameterExtractor(), FloatParameterExtractor(), FloatParameterExtractor(), FloatParameterExtractor());
 }
 
+// CHECK: fff
+// CHECK: fff
 // CHECK: fff
 // CHECK: fff


### PR DESCRIPTION
#8736 wasn't a full fix and missed one more `unwrapModifiedType` call.