### PR TITLE
Fixed wrong enum in user guide code example for bindless descriptor access

### DIFF
--- a/docs/user-guide/03-convenience-features.md
+++ b/docs/user-guide/03-convenience-features.md
@@ -697,7 +697,7 @@ export T getDescriptorFromHandle<T>(DescriptorHandle<T> handle) where T : IOpaqu
     __target_switch
     {
     case spirv:
-        if (T.kind == ResourceKind.Sampler)
+        if (T.kind == DescriptorKind.Sampler)
             return samplerHandles[((uint2)handle).x].asOpaqueDescriptor<T>();
         else
             return resourceHandles[((uint2)handle).x].asOpaqueDescriptor<T>();


### PR DESCRIPTION
Code example used ResourceKind instead of DescriptorKind. ResourceKind doesn't exist. 'Fixes' #8755.