### PR TITLE
Fix undefined behaviour in obfuscate-specialization-naming test

### DIFF
--- a/tests/bugs/obfuscate-specialization-naming.slang
+++ b/tests/bugs/obfuscate-specialization-naming.slang
@@ -14,7 +14,7 @@ int doThing(RWStructuredBuffer<int> buf, int index)
     return buf[index];
 }
 
-[numthreads(16, 1, 1)]
+[numthreads(4, 1, 1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     int tid = int(dispatchThreadID.x); 


### PR DESCRIPTION
This test was reading and writing past the end of the buffers. It probably didn't cause issues before due to only being run on fairly resilient drivers, but technically this is UB in Vulkan. Found it while debugging intermittent test crashes with the LLVM target; this caused memory corruption there.