### PR TITLE
Don't run test if applyBinding fails

### DIFF
--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -1112,7 +1112,7 @@ Result RenderTestApp::update()
         auto passEncoder = encoder->beginComputePass();
         auto rootObject =
             passEncoder->bindPipeline(static_cast<IComputePipeline*>(m_pipeline.get()));
-        applyBinding(rootObject);
+        SLANG_RETURN_ON_FAIL(applyBinding(rootObject));
         passEncoder->dispatchCompute(
             m_options.computeDispatchSize[0],
             m_options.computeDispatchSize[1],
@@ -1125,7 +1125,7 @@ Result RenderTestApp::update()
         auto rootObject = passEncoder->bindPipeline(
             static_cast<IRayTracingPipeline*>(m_pipeline.get()),
             m_shaderTable);
-        applyBinding(rootObject);
+        SLANG_RETURN_ON_FAIL(applyBinding(rootObject));
         passEncoder->dispatchRays(
             0,
             m_options.computeDispatchSize[0],
@@ -1151,7 +1151,7 @@ Result RenderTestApp::update()
         auto passEncoder = encoder->beginRenderPass(renderPass);
         auto rootObject =
             passEncoder->bindPipeline(static_cast<IRenderPipeline*>(m_pipeline.get()));
-        applyBinding(rootObject);
+        SLANG_RETURN_ON_FAIL(applyBinding(rootObject));
         setProjectionMatrix(rootObject);
 
         RenderState state;


### PR DESCRIPTION
Small QoL improvement to slang-test; if bindings fail, there is no reason to run the test, as it will print an error anyway. Because `applyBinding` bails immediately if any bindings are invalid, valid bindings can also get skipped, which can then cause crashes and all kinds of weirdness in the test.

One way to cause these crashes is to add
```slang
//TEST_INPUT: uniform(data=[20 0 0 0]):name=nonexistentbuffer
```
at the beginning of a CPU test; it'll cause the valid buffers after that to not get bound and their pointers will be left as `nullptr`, segfaulting in the test. After this PR, the relevant error is printed without the segfault:
```
error: could not find shader parameter matching 'nonexistentbuffer'
```