### PR TITLE
Switch Linux aarch64 release builder to 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           - {
               os: linux,
               platform: aarch64,
-              runs-on: ubuntu-24.04-arm,
+              runs-on: ubuntu-22.04-arm,
               compiler: gcc,
             }
           - {


### PR DESCRIPTION
Build the Linux aarch64 release packages on an Ubuntu 22.04 builder instead of Ubuntu 24.04, so that we harmonize all of our Linux platform builds on the same glibc dependency.

Fixes #8804