### PR TITLE
Add `const` qualifier to `TargetDesc::compilerOptionEntries`

### DIFF
--- a/include/slang.h
+++ b/include/slang.h
@@ -3917,7 +3917,7 @@ struct TargetDesc
 
     /** Pointer to an array of compiler option entries, whose size is compilerOptionEntryCount.
      */
-    CompilerOptionEntry* compilerOptionEntries = nullptr;
+    const CompilerOptionEntry* compilerOptionEntries = nullptr;
 
     /** Number of additional compiler option entries.
      */

--- a/source/slang-record-replay/replay/json-consumer.cpp
+++ b/source/slang-record-replay/replay/json-consumer.cpp
@@ -676,7 +676,7 @@ JsonConsumer::JsonConsumer(const Slang::String& filePath)
 void JsonConsumer::_writeCompilerOptionEntryHelper(
     Slang::StringBuilder& builder,
     int indent,
-    slang::CompilerOptionEntry* compilerOptionEntries,
+    const slang::CompilerOptionEntry* compilerOptionEntries,
     uint32_t compilerOptionEntryCount,
     bool isLastField)
 {

--- a/source/slang-record-replay/replay/json-consumer.h
+++ b/source/slang-record-replay/replay/json-consumer.h
@@ -588,7 +588,7 @@ public:
     static void _writeCompilerOptionEntryHelper(
         Slang::StringBuilder& builder,
         int indent,
-        slang::CompilerOptionEntry* compilerOptionEntries,
+        const slang::CompilerOptionEntry* compilerOptionEntries,
         uint32_t compilerOptionEntryCount,
         bool isLast = false);
     static void _writeGlobalSessionDescHelper(

--- a/source/slang/slang-compiler-options.cpp
+++ b/source/slang/slang-compiler-options.cpp
@@ -4,7 +4,7 @@
 
 namespace Slang
 {
-void CompilerOptionSet::load(uint32_t count, slang::CompilerOptionEntry* entries)
+void CompilerOptionSet::load(uint32_t count, const slang::CompilerOptionEntry* entries)
 {
     for (uint32_t i = 0; i < count; i++)
     {

--- a/source/slang/slang-compiler-options.h
+++ b/source/slang/slang-compiler-options.h
@@ -89,7 +89,7 @@ class Session;
 
 struct CompilerOptionSet
 {
-    void load(uint32_t count, slang::CompilerOptionEntry* entries);
+    void load(uint32_t count, const slang::CompilerOptionEntry* entries);
 
     void buildHash(DigestBuilder<SHA1>& builder);
 


### PR DESCRIPTION
Added the `const` qualifier to `TargetDesc::compilerOptionEntries` to help client applications maintain proper `const`-correctness.