### PR TITLE
Add a unit test to verify the separate debuginfo with modules

### DIFF
--- a/tools/slang-unit-test/unit-test-obfuscation-with-debug.cpp
+++ b/tools/slang-unit-test/unit-test-obfuscation-with-debug.cpp
@@ -330,9 +330,8 @@ static SlangResult verifySeparateDebugOutput(
     bool strippedHasDebugInstructions = spirvAsmContainsDebugInstructions(strippedAsm);
     if (strippedHasDebugInstructions)
     {
-        printf(
-            "  ✗ FAIL: Stripped SPIR-V contains debug instructions (OpSource, OpName, "
-            "DebugExpression, etc.)\n");
+        printf("  ✗ FAIL: Stripped SPIR-V contains debug instructions (OpSource, OpName, "
+               "DebugExpression, etc.)\n");
         printf("  This indicates debug info was not properly stripped!\n");
         return SLANG_FAIL;
     }
@@ -506,9 +505,8 @@ SLANG_UNIT_TEST(obfuscationWithSeparateDebug)
     if (!compileResult)
     {
         printf("ERROR: getEntryPointCompileResult returned SLANG_OK but compileResult is NULL!\n");
-        printf(
-            "This likely means EmitSeparateDebug is not properly enabled or supported for this "
-            "target.\n");
+        printf("This likely means EmitSeparateDebug is not properly enabled or supported for this "
+               "target.\n");
     }
     SLANG_CHECK_ABORT(compileResult != nullptr);
 


### PR DESCRIPTION
## Overview

This test verifies that Slang correctly combines **obfuscation** with **separate debug output** for SPIR-V shaders. It ensures the compiler produces both a stripped (obfuscated) SPIR-V and a separate debug SPIR-V that can be linked together via a shared Debug Build Identifier (DBI).

## Test Workflow

### Step 1: Compile Library Modules
- Compiles `MathLibrary` and `ColorLibrary` with:
  - Debug info level 2 (`-g2`)
  - Obfuscation enabled
- Serializes modules to IR blobs

### Step 2: Compile Final Shader with Separate Debug
- Loads serialized libraries
- Compiles `InlineShader` and `FinalShader` with:
  - Debug info level 2
  - Obfuscation enabled
  - Separate debug output enabled
- Produces two SPIR-V outputs: **stripped** and **debug**

### Step 3: Verification

The test verifies three critical properties:

1. **No debug info in stripped SPIR-V**: Stripped output must not contain debug instructions (`OpSource`, `OpName`, `OpLine`, `DebugExpression`, etc.)

2. **Obfuscation check**: 
   - Stripped SPIR-V must have **0 `OpName` instructions** (fully obfuscated)
   - Debug SPIR-V should preserve `OpName` instructions for debugging

3. **DBI matching**: Both stripped and debug SPIR-V files must contain the same Debug Build Identifier for linking

## Key Features

- Uses SPIR-V assembly format for text-based verification
- Optional file dumping and verbose logging (disabled by default for CI)

This test ensures that obfuscation and separate debug can be used together without breaking the debug workflow.
