### PR TITLE
Use parallel-safe temporary file names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       config: debug
       runs-on: '["ubuntu-22.04"]'
       test-category: smoke
-      server-count: 1
+      server-count: 8
 
   test-linux-release-gcc-x86_64:
     needs: [filter, build-linux-release-gcc-x86_64]
@@ -148,7 +148,7 @@ jobs:
       config: release
       runs-on: '["ubuntu-22.04"]'
       test-category: full
-      server-count: 1
+      server-count: 8
 
   # macOS tests
   test-macos-debug-clang-aarch64:


### PR DESCRIPTION
Fixes #8627