### PR TITLE
Add error handling in `createCompositeComponentType()` for `nullptr` entries in `componentTypes[]`

### DIFF
--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -307,6 +307,7 @@ DIAGNOSTIC(
     needToEnableExperimentFeature,
     "'$0' is an experimental module, need to enable"
     "'-experimental-feature' to load this module")
+DIAGNOSTIC(105, Error, nullComponentType, "componentTypes[$0] is `nullptr`")
 
 //
 // 001xx - Downstream Compilers


### PR DESCRIPTION
Add error handling in `createCompositeComponentType()` for `nullptr` entries in `componentTypes[]`.