### PR TITLE
[WiP] Allow _Texture.Sample() functions in other than fragment stages

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -917,6 +917,68 @@ void __wgsl_check_texture_type_texel_offset()
          , "WGSL texture shape must be 2D or 3D when sampling with texel offsets");
 }
 
+[require(spirv)]
+[__readNone]
+[ForceInline]
+bool __spirv_stage_supports_implicit_lod_sampling()
+{
+    __stage_switch
+    {
+    case fragment:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+[require(hlsl)]
+[__readNone]
+[ForceInline]
+bool __hlsl_stage_supports_implicit_lod_sampling()
+{
+    __stage_switch
+    {
+    case fragment:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+[require(wgsl)]
+[__readNone]
+[ForceInline]
+bool __wgsl_stage_supports_implicit_lod_sampling()
+{
+    __stage_switch
+    {
+    case fragment:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+[__readNone]
+[ForceInline]
+bool __stage_supports_implicit_lod_sampling()
+{
+    __target_switch
+    {
+    case spirv:
+        return __spirv_stage_supports_implicit_lod_sampling();
+    case hlsl:
+        return __hlsl_stage_supports_implicit_lod_sampling();
+    case wgsl:
+        return __wgsl_stage_supports_implicit_lod_sampling();
+    default:
+        return true;
+    }
+}
+
 
 //@public:
 
@@ -1010,11 +1072,20 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     ///
     /// For HLSL/D3D targets, the texture element type must be a scalar or vector of float or half types.
     ///
+    /// This function is available in all stages. When the implicit
+    /// LOD or gradient is not available, LOD=0 is used. This follows
+    /// the GLSL convention.
+    ///
     [__readNone]
     [ForceInline]
     [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
     T Sample(vector<float, Shape.dimensions+isArray> location)
     {
+        if (!__stage_supports_implicit_lod_sampling())
+        {
+            return SampleLevel(location, 0.0f);
+        }
+
         __requireComputeDerivative();
         __target_switch
         {
@@ -1073,6 +1144,11 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
     T Sample(vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset)
     {
+        if (!__stage_supports_implicit_lod_sampling())
+        {
+            return SampleLevel(location, 0.0f, offset);
+        }
+
         __requireComputeDerivative();
         __target_switch
         {
@@ -1104,6 +1180,11 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_clamp_fragment)]
     T Sample(vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset, float clamp)
     {
+        if (!__stage_supports_implicit_lod_sampling())
+        {
+            return SampleLevel(location, clamp, offset);
+        }
+
         __requireComputeDerivative();
         __target_switch
         {
@@ -1131,6 +1212,11 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     [ForceInline]
     T Sample(vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset, float clamp, out uint status)
     {
+        if (!__stage_supports_implicit_lod_sampling())
+        {
+            return SampleLevel(location, clamp, offset, status);
+        }
+
         __requireComputeDerivative();
         __target_switch
         {
@@ -1252,6 +1338,11 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
     float SampleCmp(vector<float, Shape.dimensions+isArray> location, float compareValue)
     {
+        if (!__stage_supports_implicit_lod_sampling())
+        {
+            return SampleCmpLevelZero(location, compareValue);
+        }
+
         __requireComputeDerivative();
         __target_switch
         {
@@ -1309,6 +1400,11 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
     float SampleCmp(vector<float, Shape.dimensions+isArray> location, float compareValue, constexpr vector<int, Shape.planeDimensions> offset)
     {
+        if (!__stage_supports_implicit_lod_sampling())
+        {
+            return SampleCmpLevelZero(location, compareValue, offset);
+        }
+
         __requireComputeDerivative();
         __target_switch
         {
@@ -1344,6 +1440,11 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     [require(hlsl_spirv, sm_5_0)]
     float SampleCmp(vector<float, Shape.dimensions+isArray> location, float compareValue, constexpr vector<int, Shape.planeDimensions> offset, float clamp, out uint status)
     {
+        if (!__stage_supports_implicit_lod_sampling())
+        {
+            return SampleCmpLevel(location, compareValue, clamp, offset, status);
+        }
+
         __requireComputeDerivative();
         __target_switch
         {
@@ -1925,6 +2026,11 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
     [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
     T Sample(SamplerState s, vector<float, Shape.dimensions+isArray> location)
     {
+        if (!__stage_supports_implicit_lod_sampling())
+        {
+            return SampleLevel(s, location, 0.0f);
+        }
+
         __requireComputeDerivative();
         __target_switch
         {
@@ -2028,6 +2134,11 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
     [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
     T Sample(SamplerState s, vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset)
     {
+        if (!__stage_supports_implicit_lod_sampling())
+        {
+            return SampleLevel(s, location, 0.0f, offset);
+        }
+
         __requireComputeDerivative();
         __target_switch
         {
@@ -2091,6 +2202,11 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
     [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0_fragment)]
     T Sample(SamplerState s, vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset, float clamp)
     {
+        if (!__stage_supports_implicit_lod_sampling())
+        {
+            return SampleLevel(s, location, clamp, offset);
+        }
+
         __requireComputeDerivative();
         __target_switch
         {
@@ -2138,6 +2254,11 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
     [ForceInline]
     T Sample(SamplerState s, vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset, float clamp, out uint status)
     {
+        if (!__stage_supports_implicit_lod_sampling())
+        {
+            return SampleLevel(s, location, clamp, offset, status);
+        }
+
         __requireComputeDerivative();
         __target_switch
         {
@@ -2330,6 +2451,11 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
     [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
     float SampleCmp(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue)
     {
+        if (!__stage_supports_implicit_lod_sampling())
+        {
+            return SampleCmpLevelZero(s, location, compareValue);
+        }
+
         __requireComputeDerivative();
         __target_switch
         {
@@ -2416,6 +2542,11 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
     [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
     float SampleCmp(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue, constexpr vector<int, Shape.planeDimensions> offset)
     {
+        if (!__stage_supports_implicit_lod_sampling())
+        {
+            return SampleCmpLevelZero(s, location, compareValue, offset);
+        }
+
         __requireComputeDerivative();
         __target_switch
         {
@@ -2463,6 +2594,11 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
     [require(hlsl_spirv, sm_5_0)]
     float SampleCmp(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue, constexpr vector<int, Shape.planeDimensions> offset, float clamp, out uint status)
     {
+        if (!__stage_supports_implicit_lod_sampling())
+        {
+            return SampleCmpLevel(s, location, compareValue, clamp, offset, status);
+        }
+
         __requireComputeDerivative();
         __target_switch
         {

--- a/tests/bugs/glsl-sample-implicit-lod-8683.slang
+++ b/tests/bugs/glsl-sample-implicit-lod-8683.slang
@@ -1,0 +1,50 @@
+//TEST:SIMPLE(filecheck=VK-CHECK-VTX): -target spirv -stage vertex -entry vertexMain -allow-glsl
+//TEST:SIMPLE(filecheck=VK-CHECK-FRAG): -target spirv -stage fragment -entry fragmentMain -allow-glsl
+//TEST:SIMPLE(filecheck=GLSL-CHECK-VTX): -target glsl -stage vertex -entry vertexMain -allow-glsl
+//TEST:SIMPLE(filecheck=GLSL-CHECK-FRAG): -target glsl -stage fragment -entry fragmentMain -allow-glsl
+//TEST:SIMPLE(filecheck=HLSL-CHECK-VTX): -target hlsl -stage vertex -entry vertexMain -allow-glsl
+//TEST:SIMPLE(filecheck=HLSL-CHECK-FRAG): -target hlsl -stage fragment -entry fragmentMain -allow-glsl
+
+// Regression test for https://github.com/shader-slang/slang/issues/8683
+//
+// GLSL specifies that texture sampling with implicit LOD is always
+// allowed. In fragment stage, LOD from rasterizer is used. In other
+// stages, LOD=0 is used. In SPIR-V (as well as HLSL, WGSL), LOD=0
+// must be explicitly used.
+
+#version 450
+
+layout(set=0,binding=0) uniform sampler2D uBumpTexture;
+
+[shader("vertex")]
+void vertexMain() {
+
+// VK-CHECK-VTX: OpImageSampleExplicitLod
+// VK-CHECK-VTX-NOT: OpImageSampleImplicitLod
+
+// GLSL-CHECK-VTX: texture(
+
+// HLSL-CHECK-VTX: SampleLevel(
+// HLSL-CHECK-VTX-NOT: Sample(
+
+    vec3 val = texture(uBumpTexture, vec2(0,0)).rgb;
+
+    gl_Position = vec4(val, 0);
+}
+
+
+[shader("fragment")]
+void fragmentMain() {
+
+// VK-CHECK-FRAG: OpImageSampleImplicitLod
+// VK-CHECK-FRAG-NOT: OpImageSampleExplicitLod
+
+// GLSL-CHECK-FRAG: texture(
+
+// HLSL-CHECK-FRAG-NOT: SampleLevel(
+// HLSL-CHECK-FRAG: Sample(
+
+    vec3 val = texture(uBumpTexture, vec2(0,0)).rgb;
+
+    gl_Position = vec4(val, 0);
+}

--- a/tests/hlsl-intrinsic/texture/texture-intrinsics.slang
+++ b/tests/hlsl-intrinsic/texture/texture-intrinsics.slang
@@ -83,6 +83,37 @@ float testOperations<let isShadow : int>(
     uint status;
 
     /*
+        <Template Type> Object.Sample()
+    */
+    val += x1D.Sample(samplerState, u);
+    val += x2D.Sample(samplerState, float2(u, u));
+    val += x3D.Sample(samplerState, float3(u, u, u));
+    val += xCube.Sample(samplerState, normalize(float3(u, 1 - u, u)));
+
+    val += x1DArray.Sample(samplerState, float2(u, 0));
+    val += x2DArray.Sample(samplerState, float3(u, u, 0));
+    val += xCubeArray.Sample(samplerState, float4(u, u, u, 0));
+
+    // Offset variant
+    //  NOTE: The "cpu" profile does not like these, so it's disabled for now
+    val += x1D.Sample(samplerState, u, 1);
+    val += x2D.Sample(samplerState, float2(u, u), int2(1, 1));
+    val += x3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1));
+
+    val += x1DArray.Sample(samplerState, float2(u, 0), 1);
+    val += x2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1));
+
+    // Status variant
+#if !defined(VK)
+    val += x1D.Sample(samplerState, u, 1, status);
+    val += x2D.Sample(samplerState, float2(u, u), int2(1, 1), status);
+    val += x3D.Sample(samplerState, float3(u, u, u), int3(1, 1, 1), status);
+
+    val += x1DArray.Sample(samplerState, float2(u, 0), 1, status);
+    val += x2DArray.Sample(samplerState, float3(u, u, 0), int2(1, 1), status);
+#endif
+
+    /*
         <Template Type> Object.SampleLevel()
     */
     val += x1D.SampleLevel(samplerState, u, 0);
@@ -117,6 +148,34 @@ float testOperations<let isShadow : int>(
         float Object.SampleCmpLevelZero()
     */
     // NOTE: These are having issues with vulkan (glsl)
+    // SampleCmp() requires format with VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT.
+    val += x1D.SampleCmp(shadowSampler, u, 0);
+    val += x2D.SampleCmp(shadowSampler, float2(u, u), 0);
+    val += x1DArray.SampleCmp(shadowSampler, float2(u, u), 0);
+    val += xCube.SampleCmp(shadowSampler, normalize(float3(u, 1 - u, u)), 0);
+    val += x2DArray.SampleCmp(shadowSampler, normalize(float3(u, 1 - u, u)), 0);
+    val += xCubeArray.SampleCmp(shadowSampler, normalize(float4(u, 1-u, u, u)), 0);
+
+    // Offset variant
+    val += x1D.SampleCmp(shadowSampler, u, 0, 0);
+    val += x2D.SampleCmp(shadowSampler, float2(u, u), 0, int2(0, 0));
+    // TextureCube does not have an offset version of this
+
+    // Status variant
+#if !defined(VK)
+
+    val += x1D.SampleCmp(shadowSampler, u, 0, 0, status);
+    val += x2D.SampleCmp(shadowSampler, float2(u, u), 0, int2(0, 0), status);
+
+    val += x1DArray.SampleCmp(shadowSampler, float2(u, u), 0, 0, status);
+    val += x2DArray.SampleCmp(shadowSampler, normalize(float3(u, 1 - u, u)), 0, int2(0, 0), status);
+#endif
+
+
+    /*
+        float Object.SampleCmpLevelZero()
+    */
+    // NOTE: These are having issues with vulkan (glsl)
     // SampleCmpLevelZero() requires format with VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT.
     val += x1D.SampleCmpLevelZero(shadowSampler, u, 0);
     val += x2D.SampleCmpLevelZero(shadowSampler, float2(u, u), 0);
@@ -131,7 +190,7 @@ float testOperations<let isShadow : int>(
     // TextureCube does not have an offset version of this
 
     // Status variant
-    #if !defined(VK)
+#if !defined(VK)
 
     val += x1D.SampleCmpLevelZero(shadowSampler, u, 0, 0, status);
     val += x2D.SampleCmpLevelZero(shadowSampler, float2(u, u), 0, int2(0, 0), status);
@@ -409,19 +468,19 @@ void computeMain(int3 dispatchThreadID: SV_DispatchThreadID)
     outputBuffer[idx] = val;
 }
 
-// DX11: 708
-// DX11: 708
-// DX11: 708
-// DX11: 708
-// DX12: 708
-// DX12: 708
-// DX12: 708
-// DX12: 708
-// DX12CS6: 754
-// DX12CS6: 754
-// DX12CS6: 754
-// DX12CS6: 754
-// VK: 718
-// VK: 718
-// VK: 718
-// VK: 718
+// DX11: 766
+// DX11: 766
+// DX11: 766
+// DX11: 766
+// DX12: 766
+// DX12: 766
+// DX12: 766
+// DX12: 766
+// DX12CS6: 812
+// DX12CS6: 812
+// DX12CS6: 812
+// DX12CS6: 812
+// VK: 758
+// VK: 758
+// VK: 758
+// VK: 758


### PR DESCRIPTION
Add logic in _Texture.Sample() functions such that they work correctly in other than fragment stages. When thus invoked, assume LOD=0, similar to how GLSL and Metal treat implicit LOD sampling in non-fragment stages.

Issue #8683