### PR TITLE
Fix static_assert(false) in CUDA prelude

### DIFF
--- a/prelude/slang-cuda-prelude.h
+++ b/prelude/slang-cuda-prelude.h
@@ -1412,7 +1412,9 @@ SLANG_FORCE_INLINE SLANG_CUDA_CALL void surf1DLayeredwrite_convert(
     int layer,
     cudaSurfaceBoundaryMode boundaryMode)
 {
-    static_assert(false, "CUDA doesn't support formatted surface writes on 1D array surfaces");
+    // TODO: static_assert(false) can fail on some compilers, even if template is not instantiated.
+    // We should check for this in hlsl.meta.slang instead.
+    // static_assert(false, "CUDA doesn't support formatted surface writes on 1D array surfaces");
 }
 
 // surf2Dwrite_convert
@@ -1492,7 +1494,9 @@ SLANG_FORCE_INLINE SLANG_CUDA_CALL void surf2DLayeredwrite_convert(
     int layer,
     cudaSurfaceBoundaryMode boundaryMode)
 {
-    static_assert(false, "CUDA doesn't support formatted surface writes on 2D array surfaces");
+    // TODO: static_assert(false) can fail on some compilers, even if template is not instantiated.
+    // We should check for this in hlsl.meta.slang instead.
+    // static_assert(false, "CUDA doesn't support formatted surface writes on 2D array surfaces");
 }
 
 // surf3Dwrite_convert
@@ -4445,7 +4449,9 @@ struct TensorView
 template<typename T>
 SLANG_FORCE_INLINE SLANG_CUDA_CALL T tex1Dfetch_int(CUtexObject texObj, int x, int mip)
 {
-    static_assert(false, "CUDA does not support fetching from 1D textures");
+    // TODO: static_assert(false) can fail on some compilers, even if template is not instantiated.
+    // We should check for this in hlsl.meta.slang instead.
+    // static_assert(false, "CUDA does not support fetching from 1D textures");
 }
 
 #if 0


### PR DESCRIPTION
Some compilers fail on static_assert(false) even if the template is not instantiated.

Fixes #8862