### PR TITLE
Enable LLVM cache for builds in self-hosted machines

### DIFF
--- a/.github/workflows/compile-regression-test.yml
+++ b/.github/workflows/compile-regression-test.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   build:
     timeout-minutes: 100
-    continue-on-error: true
+    continue-on-error: false
     strategy:
       fail-fast: false
       matrix:
@@ -55,7 +55,6 @@ jobs:
           platform: ${{matrix.platform}}
           config: ${{matrix.config}}
           build-llvm: true
-          use-cached-llvm: false
       - name: Build Slang
         run: |
           cmake --preset default --fresh \

--- a/.github/workflows/falcor-compiler-perf-test.yml
+++ b/.github/workflows/falcor-compiler-perf-test.yml
@@ -49,7 +49,6 @@ jobs:
           platform: ${{matrix.platform}}
           config: ${{matrix.config}}
           build-llvm: true
-          use-cached-llvm: false
 
       - name: Build Slang
         run: |

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build:
     timeout-minutes: 100
-    continue-on-error: true
+    continue-on-error: false
     strategy:
       fail-fast: false
       matrix:
@@ -46,7 +46,6 @@ jobs:
           platform: ${{matrix.platform}}
           config: ${{matrix.config}}
           build-llvm: true
-          use-cached-llvm: false
       - name: setup-falcor
         shell: pwsh
         run: |

--- a/.github/workflows/push-benchmark-results.yml
+++ b/.github/workflows/push-benchmark-results.yml
@@ -30,7 +30,6 @@ jobs:
           platform: x86_64
           config: release
           build-llvm: true
-          use-cached-llvm: false
       - name: Build Slang
         run: |
           cmake --preset default --fresh -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM -DCMAKE_COMPILE_WARNING_AS_ERROR=false


### PR DESCRIPTION
MSVC in the self-hosted machines has been updated to 14.44, which should be compatible with the saved LLVM build caches.

Update `continue-on-error` to `false` in some workflows so it's clear when the build is failed.