### PR TITLE
Correct output buffer size in nested parameter block test, add CPU target test

### DIFF
--- a/tests/bindings/nested-parameter-block-2.slang
+++ b/tests/bindings/nested-parameter-block-2.slang
@@ -44,13 +44,17 @@ void computeMain(uint3 sv_dispatchThreadID : SV_DispatchThreadID)
     // CHECK-NEXT: 4
     // CHECK-NEXT: 4
     // CHECK-NEXT: 4
-    // CHECK-NEXT: 4
-    // CHECK-NEXT: 4
-    // CHECK-NEXT: 4
-    // CHECK-NEXT: 4
-    // CHECK-NEXT: 4
-    // CHECK-NEXT: 4
-    // CHECK-NEXT: 4
-    // CHECK-NEXT: 4
-    pb2.resultBuffer[sv_dispatchThreadID.x] = scene.sceneCb.value.x + scene.data[0].x + scene.material.cb.value.x + scene.material.data[0].x;
+    // CHECK-NEXT: 5
+    // CHECK-NEXT: 5
+    // CHECK-NEXT: 5
+    // CHECK-NEXT: 5
+    // CHECK-NEXT: 6
+    // CHECK-NEXT: 6
+    // CHECK-NEXT: 6
+    // CHECK-NEXT: 6
+    // CHECK-NEXT: 7
+    // CHECK-NEXT: 7
+    // CHECK-NEXT: 7
+    // CHECK-NEXT: 7
+    pb2.resultBuffer[sv_dispatchThreadID.x] = sv_dispatchThreadID.x + scene.sceneCb.value.x + scene.data[0].x + scene.material.cb.value.x + scene.material.data[0].x;
 }


### PR DESCRIPTION
Fixes https://github.com/shader-slang/slang-rhi/issues/535

The test `nested-parameter-block-2.slang` fails on CPU targets with the error `free(): invalid next size (fast)` due to the output buffer writes failing a buffer bounds check. The output buffer has 4 elements and uses `stride=4`, so it is a 16-byte buffer, but it is being used to store 4 `uint4` values, which are each 16 bytes, so a 64-byte buffer is required.

Writing beyond the first 16 bytes in the buffer results in failing this bounds checking in `slang-rhi` for CPU targets, but results in undefined behavior in Vulkan and Metal, and a no-op in D3D.

The test is passing despite the undersized 16-byte buffer because the test only checks the first 4 elements, which all fit into those 16 bytes. Adding additional checks beyond that point results in a failure on all platforms as the later elements are not actually being written to the buffer. Increasing the buffer size fixes that.

This change modifies the test to use a 64-byte output buffer with `stride=16,count=4`, and adds additional checks for the elements to guarantee that all expected values are actually being written to that buffer.