### PR TITLE
Fix macOS code signing for versioned libraries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,23 +180,43 @@ jobs:
           security list-keychain -d user -s "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${KEYCHAIN_PASSWORD}" "$KEYCHAIN_PATH"
 
+          # Extract version from tag for versioned library names
+          triggering_ref=${{ github.ref_name }}
+          if [[ $triggering_ref =~ ^v[0-9] ]]; then
+            version=${triggering_ref#v}
+          else
+            version=$triggering_ref
+          fi
+
+          echo "Version detected: $version"
+          echo "lib_dir: ${lib_dir}"
+          echo "bin_dir: ${bin_dir}"
+
+          # Build array with explicit version-based paths
           binaries=(
-            "${lib_dir}/libslang-compiler.0.*.dylib"
-            "${lib_dir}/libslang-rt.0.*.dylib"
-            "${lib_dir}/libslang-glslang.dylib"
-            "${lib_dir}/libslang-glsl-module-*.dylib"
-            "${lib_dir}/libslang-llvm.dylib"
-            "${lib_dir}/libgfx.0.*.dylib"
+            "${lib_dir}/libslang-compiler.0.${version}.dylib"
+            "${lib_dir}/libslang-rt.0.${version}.dylib"
+            "${lib_dir}/libslang-glslang-${version}.dylib"
+            "${lib_dir}/libslang-glsl-module-${version}.dylib"
+            "${lib_dir}/libgfx.0.${version}.dylib"
             "${bin_dir}/slangd"
             "${bin_dir}/slangc"
           )
 
-          # Sign main binaries
+          # Conditionally add libslang-llvm if it exists (only with LLVM builds)
+          if [[ -f "${lib_dir}/libslang-llvm.dylib" ]]; then
+            binaries+=("${lib_dir}/libslang-llvm.dylib")
+          fi
+
+          # Sign main binaries with error checking
           for b in "${binaries[@]}"; do
             if [[ -f "$b" ]]; then
               echo "Signing binary '$b'..."
               /usr/bin/codesign --force --options runtime -s "${IDENTITY_ID}" "$b" -v
               7z a "slang-macos-dist.zip" "$b"
+            else
+              echo "ERROR: Expected binary not found: $b"
+              exit 1
             fi
           done
 


### PR DESCRIPTION
## Summary

Fixes #8901

Replace wildcard patterns with explicit version-substituted paths in the release workflow's code signing step. After PR #8746 renamed libraries and added version numbers, wildcards like `libslang-compiler.0.*.dylib` don't expand properly in bash conditionals, causing libraries to be silently skipped and shipped unsigned.

## Changes

- Extract version from git tag (same approach as Package Slang step)
- Use explicit version-substituted paths instead of wildcards
- Add error handling to fail if expected binaries are missing
- Conditionally include libslang-llvm.dylib for LLVM builds only
- Add debug output for troubleshooting

## Test plan

- Will be validated in next release when workflow runs
- Expected libraries should be signed successfully
- macOS should accept the signed libraries