### PR TITLE
Fix handling of include lines with spaces by slang-embed

### DIFF
--- a/tools/slang-embed/slang-embed.cpp
+++ b/tools/slang-embed/slang-embed.cpp
@@ -197,10 +197,9 @@ struct App
 
         for (auto line : lineReader)
         {
-            auto trimedLine = line.trimStart();
-            if (trimedLine.startsWith("#include"))
+            auto fileName = getIncludedFileName(line);
+            if (fileName.getLength())
             {
-                auto fileName = Slang::StringUtil::getAtInSplit(trimedLine, ' ', 1);
                 bool isSystemInclude = false;
 
                 // Handle both quoted and angle-bracket includes
@@ -322,6 +321,23 @@ struct App
             }
             fprintf(outputFile, "\\n\"\n");
         }
+    }
+
+    static Slang::UnownedStringSlice getIncludedFileName(Slang::UnownedStringSlice line)
+    {
+        auto trimmedLine = line.trimStart();
+        if (!trimmedLine.startsWith("#"))
+        {
+            return Slang::UnownedStringSlice();
+        }
+        auto preprocessorLine = trimmedLine.tail(sizeof("#") - 1).trimStart();
+        if (!preprocessorLine.startsWith("include"))
+        {
+            return Slang::UnownedStringSlice();
+        }
+        auto includeLine = preprocessorLine.tail(sizeof("include") - 1).trimStart();
+
+        return Slang::StringUtil::getAtInSplit(includeLine, ' ', 0);
     }
 
     void processInputFile()


### PR DESCRIPTION
Since version 4.8.0, `unordered_dense` header is split into two files. The main header includes `stl.h`, however, it uses preprocessor style with spaces after the initial `#`[^1]. This is not handled by the `slang-embed` which results in compilation error when building executables:

```
gcc 14.3: /tmp/unknown-tofGRH.cpp(7723): error :  stl.h: No such file or directory
 7723 | #        include "stl.h"
      |                  ^~~~~~~
compilation terminated.
```

This PR makes the whitespace handling around the include directive a bit more robust so that the `stl.h` file is embedded correctly.

Related to #6674

[^1]: https://github.com/martinus/unordered_dense/blob/v4.8.0/include/ankerl/unordered_dense.h#L94