### PR TITLE
add "slang.workspaceFlavor" to language server config, allowing selecting standard/vfx

### DIFF
--- a/source/slang/slang-language-server.h
+++ b/source/slang/slang-language-server.h
@@ -261,6 +261,7 @@ private:
         const JSONValue& allowLineBreakInRange);
     void updateInlayHintOptions(const JSONValue& deducedTypes, const JSONValue& parameterNames);
     void updateTraceOptions(const JSONValue& value);
+    void updateWorkspaceFlavor(const JSONValue& value);
 
     void sendConfigRequest();
     void registerCapability(const char* methodName);

--- a/source/slang/slang-workspace-version.cpp
+++ b/source/slang/slang-workspace-version.cpp
@@ -575,7 +575,7 @@ void WorkspaceVersion::ensureWorkspaceFlavor(UnownedStringSlice path)
     if (flavor != WorkspaceFlavor::Standard)
         return;
 
-    if (path.endsWithCaseInsensitive(".vfx"))
+    if (workspace->workspaceFlavor == WorkspaceFlavor::VFX || path.endsWithCaseInsensitive(".vfx"))
     {
         // Setup linkage for vfx files.
         // TODO: consider supporting this as an external config file.

--- a/source/slang/slang-workspace-version.h
+++ b/source/slang/slang-workspace-version.h
@@ -172,6 +172,7 @@ public:
     OrderedHashSet<String> workspaceSearchPaths;
     List<OwnedPreprocessorMacroDefinition> predefinedMacros;
     bool searchInWorkspace = true;
+    WorkspaceFlavor workspaceFlavor = WorkspaceFlavor::Standard;
 
     slang::IGlobalSession* slangGlobalSession;
     Dictionary<String, RefPtr<DocumentVersion>> openedDocuments;


### PR DESCRIPTION
Slang supports VFX syntax by checking file extension. We use a forked Source 2 where our format is the same but our extension is ".shader" and our includes are ".hlsl" which also require `EnableEffectAnnotations`.

This adds the configurability to the language server which enables us to offer full intellisense to users developing shaders.

Happy to make this work differently if it's not the way.