### PR TITLE
Add specific labels for the benchmark to pick right runners

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [Windows, self-hosted]
+    runs-on: [Windows, self-hosted, benchmark]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/push-benchmark-results.yml
+++ b/.github/workflows/push-benchmark-results.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [Windows, benchmark, self-hosted]
+    runs-on: [Windows, self-hosted, benchmark]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/vk-gl-cts-nightly.yml
+++ b/.github/workflows/vk-gl-cts-nightly.yml
@@ -24,7 +24,7 @@ jobs:
             warnings-as-errors: true
             test-category: full
             full-gpu-tests: false
-            runs-on: [Windows, self-hosted]
+            runs-on: [Windows, self-hosted, regression-test]
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 180
     defaults:


### PR DESCRIPTION
This should allow us to easily stage or avoid problematic runners by setting the runner lables.