### PR TITLE
Treat IR_RayQueryType alike opaque types

### DIFF
--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -2752,8 +2752,13 @@ bool isIROpaqueType(IRType* type)
     switch (type->getOp())
     {
     case kIROp_TextureType:
+    case kIROp_GLSLImageType:
     case kIROp_SamplerStateType:
     case kIROp_SamplerComparisonStateType:
+    case kIROp_SubpassInputType:
+    case kIROp_RaytracingAccelerationStructureType:
+    case kIROp_RayQueryType:
+    case kIROp_HitObjectType:
         return true;
     default:
         return false;

--- a/tests/spirv/unbounded-acceleration-structure-array.slang
+++ b/tests/spirv/unbounded-acceleration-structure-array.slang
@@ -1,0 +1,45 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry rayGenMain -stage raygeneration -emit-spirv-directly
+
+// Test for issue #8902: unbounded arrays of RaytracingAccelerationStructure
+// should not emit ArrayStride decoration since acceleration structures are opaque types.
+
+// CHECK: OpCapability RuntimeDescriptorArray
+// CHECK: OpCapability RayTracingKHR
+// CHECK: OpTypeAccelerationStructureKHR
+// CHECK: OpTypeRuntimeArray
+// CHECK-NOT: OpDecorate %{{.*}} ArrayStride
+// CHECK: OpVariable %{{.*}} UniformConstant
+
+[[vk::binding(0, 0)]] RaytracingAccelerationStructure kTLAS[];
+
+struct RayPayload {
+  float3 color;
+};
+
+[shader("raygeneration")]
+void rayGenMain() {
+  RayDesc ray;
+  ray.Origin = float3(0, 0, 0);
+  ray.Direction = float3(0, 0, 1);
+  ray.TMin = 0.1;
+  ray.TMax = 100.0;
+
+  RayPayload payload = { float3(0.0, 0.0, 0.0) };
+
+  // Access the unbounded array - should produce valid SPIR-V without ArrayStride
+  TraceRay(
+    kTLAS[0],
+    RAY_FLAG_FORCE_OPAQUE,
+    0xff,
+    0,
+    0,
+    0,
+    ray,
+    payload
+  );
+}
+
+[shader("miss")]
+void missMain(inout RayPayload payload) {
+  payload.color = float3(0.0, 0.0, 0.0);
+}


### PR DESCRIPTION
Those types should be treated as opque in IR and should not emit ArrayStride decoration in spirv.

Fixes: https://github.com/shader-slang/slang/issues/8902