### PR TITLE
Add CI testing for slangpy-samples

### DIFF
--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -214,14 +214,11 @@ jobs:
           # Export SITE_PACKAGES for use in slangpy-samples step
           echo "SITE_PACKAGES=$SITE_PACKAGES" >> $GITHUB_ENV
 
-          # Skip package installation on self-hosted runners to avoid permission issues
-          if [[ ! "${{ inputs.runs-on }}" =~ self-hosted ]]; then
-            echo "Installing python packages..."
-            curl -fsSL https://raw.githubusercontent.com/shader-slang/slangpy/main/requirements-dev.txt -o requirements-dev.txt
-            python -m pip install -r requirements-dev.txt --user
-            python -m pip install pytest-github-actions-annotate-failures --user
-            python -m pip install pytest-xdist --user
-          fi
+          echo "Installing python packages..."
+          curl -fsSL https://raw.githubusercontent.com/shader-slang/slangpy/main/requirements-dev.txt -o requirements-dev.txt
+          python -m pip install -r requirements-dev.txt --user
+          python -m pip install pytest-github-actions-annotate-failures --user
+          python -m pip install pytest-xdist --user
 
           echo "Running pytest on slangpy tests..."
           export PYTHONPATH="$SITE_PACKAGES"


### PR DESCRIPTION
Adds testing for the [slangpy-samples](https://github.com/shader-slang/slangpy-samples) repository to provide integration testing of slangpy with real-world examples.

# Implementation

The `test-slangpy` job now includes slangpy-samples testing alongside the existing slangpy pytest tests. After running slangpy's own tests, the job:

1. Clones the `slangpy-samples` repository
2. Installs dependencies from `requirements.txt`
3. Runs `pytest -n 4 slangpy-samples/tests` (parallel execution with 4 workers)

The implementation follows the [original issue's preferred solution](https://github.com/shader-slang/slang/issues/8186#issue-2470127027).

# When It Runs

Same conditions as the main slangpy tests, ensuring we test integration examples alongside the core slangpy functionality.

Fixes #8186