### PR TITLE
[DO NOT MERGE] Add __supportImplicitDerivatives with the respective IR op

### DIFF
--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -1318,6 +1318,12 @@ Compound Capabilities
 `texture_gather`
 > Capabilities required to use 'vertex/fragment/geometry shader only' texture gather operations
 
+`texture_implicit_lod`
+> Capabilities required for implicit level of detail texturing
+> 
+> In general, this capability is available in the fragment stage and
+> in other stages where implicit derivatives are enabled.
+
 `texture_querylevels`
 > Capabilities required to query texture level info
 

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -3684,6 +3684,11 @@ __Addr<T> __getLegalizedSPIRVGlobalParamAddr(T val);
 __intrinsic_op($(kIROp_RequireComputeDerivative))
 void __requireComputeDerivative();
 
+// Returns true when the current execution environment has implicit
+// derivatives. This function will not try to enable the derivatives.
+__intrinsic_op($(kIROp_SupportImplicitDerivatives))
+bool __supportImplicitDerivatives();
+
 __intrinsic_op($(kIROp_RequireMaximallyReconverges))
 void __requireMaximallyReconverges();
 

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -2094,6 +2094,14 @@ alias image_size = texture_sm_4_1_compute_fragment | GL_ARB_shader_image_size;
 /// Capabilities required to query texture sample info
 /// [Compound]
 alias texture_size = texture_sm_4_1 | GL_ARB_shader_image_size;
+/// Capabilities required for implicit level of detail texturing
+///
+/// In general, this capability is available in the fragment stage and
+/// in other stages where implicit derivatives are enabled.
+/// [Compound]
+alias texture_implicit_lod = fragment
+                           | raytracingstages_compute_amplification_mesh + GL_NV_compute_shader_derivatives
+                           ;
 /// Capabilities required to query texture LOD info
 /// [Compound]
 alias texture_querylod = texture_sm_4_1 | GL_EXT_texture_query_lod;

--- a/source/slang/slang-capability.h
+++ b/source/slang/slang-capability.h
@@ -288,7 +288,7 @@ public:
     // This is used for adding conjunctions directly and efficently, this is not functionally a
     // join. if `knownStage`/`knownTarget` is not CapabilityAtom::Invalid, the given atom will be
     // assumed as an assigned key atom (faster)
-    inline void addConjunction(
+    void addConjunction(
         CapabilityAtomSet conjunction,
         CapabilityAtom knownTarget,
         CapabilityAtom knownStage);

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -437,6 +437,7 @@ void calcRequiredLoweringPassSet(
         result.resolveVaryingInputRef = true;
         break;
     case kIROp_GetCurrentStage:
+    case kIROp_SupportImplicitDerivatives:
         result.specializeStageSwitch = true;
         break;
     case kIROp_MissingReturn:
@@ -1199,7 +1200,7 @@ Result linkAndOptimizeIR(
     // After dynamic dispatch logic is resolved into ordinary function calls,
     // we can now run our stage specialization logic.
     if (requiredLoweringPassSet.specializeStageSwitch)
-        specializeStageSwitch(irModule);
+        specializeStageSwitch(targetRequest, irModule);
     if (sink->getErrorCount() != 0)
         return SLANG_FAIL;
 #if 0

--- a/source/slang/slang-ir-insts-stable-names.lua
+++ b/source/slang/slang-ir-insts-stable-names.lua
@@ -685,4 +685,5 @@ return {
 	["StoreBase.copyLogical"] = 681,
 	["MakeStorageTypeLoweringConfig"] = 682,
 	["Decoration.experimentalModule"] = 683,
+	["SupportImplicitDerivatives"] = 684,
 }

--- a/source/slang/slang-ir-insts.lua
+++ b/source/slang/slang-ir-insts.lua
@@ -1231,6 +1231,7 @@ local insts = {
 	},
 	{ RequireTargetExtension = { operands = { { "extension" } } } },
 	{ RequireComputeDerivative = {} },
+	{ SupportImplicitDerivatives = {} },
 	{ StaticAssert = { operands = { { "condition" }, { "message" } } } },
 	{ Printf = { operands = { { "format" } } } },
 	-- Quad control execution modes.

--- a/source/slang/slang-ir-specialize-stage-switch.h
+++ b/source/slang/slang-ir-specialize-stage-switch.h
@@ -3,11 +3,13 @@
 
 namespace Slang
 {
+
+struct TargetRequest;
 struct IRModule;
 
 // Repalce all stage_switch insts with the case that matches current calling entrypoint.
 //
-void specializeStageSwitch(IRModule* module);
+void specializeStageSwitch(TargetRequest* targetRequest, IRModule* module);
 
 } // namespace Slang
 

--- a/tests/language-feature/support-implicit-derivatives.slang
+++ b/tests/language-feature/support-implicit-derivatives.slang
@@ -1,0 +1,95 @@
+//TEST:SIMPLE(filecheck=VK_VTX):              -target spirv -stage vertex   -entry vertexMain
+//TEST:SIMPLE(filecheck=VK_FRAG):             -target spirv -stage fragment -entry fragmentMain
+//TEST:SIMPLE(filecheck=VK_COMPUTE_NODERIVS): -target spirv -stage compute  -entry computeMain
+//TEST:SIMPLE(filecheck=VK_COMPUTE_DERIVS):   -target spirv -stage compute  -entry computeMain -capability SPV_KHR_compute_shader_derivatives -DCOMPUTE_DERIVS
+//TEST:SIMPLE(filecheck=GLSL_VTX):  -target glsl  -stage vertex   -entry vertexMain
+//TEST:SIMPLE(filecheck=GLSL_FRAG): -target glsl  -stage fragment -entry fragmentMain
+//TEST:SIMPLE(filecheck=HLSL_VTX):  -target hlsl  -stage vertex   -entry vertexMain
+//TEST:SIMPLE(filecheck=HLSL_FRAG): -target hlsl  -stage fragment -entry fragmentMain
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+Sampler1D<float> uniform_sampler1D;
+
+int returnSupportDerivatives()
+{
+    return int(__supportImplicitDerivatives());
+}
+
+[ForceInline]
+int sampleWithImplicitOrExplicitLod()
+{
+    if (__supportImplicitDerivatives())
+    {
+        return int(100 * uniform_sampler1D.Sample(float(0)));
+    }
+    else
+    {
+        return int(100 * uniform_sampler1D.SampleLevelZero(float(0)));
+    }
+}
+
+[shader("vertex")]
+void vertexMain()
+{
+    // VK_VTX-NOT: OpImageSampleImplicitLod
+    // VK_VTX:     OpImageSampleExplicitLod
+    // VK_VTX-NOT: OpImageSampleImplicitLod
+
+    // GLSL_VTX-NOT: textureLod(
+    // GLSL_VTX:     texture(
+    // GLSL_VTX-NOT: textureLod(
+
+    // HLSL_VTX-NOT: Sample(
+    // HLSL_VTX: SampleLevel(
+    // HLSL_VTX-NOT: Sample(
+
+    static_assert(!__supportImplicitDerivatives(), "Vertex shaders don't support implicit derivatives");
+    outputBuffer[0] = returnSupportDerivatives();
+    outputBuffer[1] = sampleWithImplicitOrExplicitLod();
+}
+
+[shader("fragment")]
+void fragmentMain()
+{
+    // VK_FRAG-NOT: OpImageSampleExplicitLod
+    // VK_FRAG:     OpImageSampleImplicitLod
+    // VK_FRAG-NOT: OpImageSampleExplicitLod
+
+    // GLSL_FRAG-NOT: textureLod(
+    // GLSL_FRAG:     texture(
+    // GLSL_FRAG-NOT: textureLod(
+
+    // HLSL_FRAG-NOT: SampleLevel(
+    // HLSL_FRAG:     Sample(
+    // HLSL_FRAG-NOT: SampleLevel(
+
+    static_assert(__supportImplicitDerivatives(), "Fragment shaders support implicit derivatives");
+    outputBuffer[0] = returnSupportDerivatives();
+    outputBuffer[1] = sampleWithImplicitOrExplicitLod();
+}
+
+[shader("compute")]
+[numthreads(2, 2, 1)]
+void computeMain()
+{
+    outputBuffer[0] = returnSupportDerivatives();
+
+    // VK_COMPUTE_DERIVS-NOT: OpImageSampleExplicitLod
+    // VK_COMPUTE_DERIVS:     OpImageSampleImplicitLod
+    // VK_COMPUTE_DERIVS-NOT: OpImageSampleExplicitLod
+
+    // VK_COMPUTE_NODERIVS-NOT: OpImageSampleImplicitLod
+    // VK_COMPUTE_NODERIVS:     OpImageSampleExplicitLod
+    // VK_COMPUTE_NODERIVS-NOT: OpImageSampleImplicitLod
+
+#if defined(COMPUTE_DERIVS)
+    static_assert(__supportImplicitDerivatives(), "Check that implicit derivatives are currently enabled in compute");
+#else
+    static_assert(!__supportImplicitDerivatives(), "Check that implicit derivatives are not currently enabled in compute");
+#endif
+
+    outputBuffer[0] = returnSupportDerivatives();
+    outputBuffer[1] = sampleWithImplicitOrExplicitLod();
+}


### PR DESCRIPTION
Add IR op for determining the support for implicit derivatives based on whether the corresponding capability is available.

This commit **should not** be merged at this time. The reason being that we should rather investigate on implementing a proper `if constexpr (checkCapability(...))` or similar construction. In this light, the IR op would only be a temporary clean-up. However, it is somewhat unlikely that `__targetHasImplicitDerivatives()` would get out of sync with the capability definitions, since implicit-LOD sampling is a well-established feature.

Issue #8683