### PR TITLE
Fix slang's slangpy CI testing across versions

### DIFF
--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -210,13 +210,18 @@ jobs:
             # tries to avoid making assumptions about filename extension due to
             # differences in macos and Linux conventions.
 
-            # There should be only one libslang-compiler library present; the
+            # There should only be one libslang-compiler library present; the
             # one that slangpy linked to.
             OLD_SLANGLIB=$(find "$SITE_PACKAGES/slangpy/" -type f -name "libslang-compiler.*")
-            # Find the name of the new libslang-compiler library via symlink
-            NEW_SLANGLIB=$(find "$lib_dir" -type l -name "libslang-compiler.*" | xargs realpath)
             echo "old slang library location: $OLD_SLANGLIB"
+
+            # Find the new libslang-compiler library via developer symlink
+            # filename. This is unlikely to still be a symlink since it went
+            # through artifactory, but in practice symlink or not shouldn't
+            # matter, since we copy the rest of the libraries over.
+            NEW_SLANGLIB=$(find "$lib_dir" -name "libslang-compiler.*" ! -name "*.*.*")
             echo "new slang library location: $NEW_SLANGLIB"
+
             cp "$NEW_SLANGLIB" "$OLD_SLANGLIB" || { echo "Failed to copy main library file"; exit 1; }
 
             # Copy the rest of the library files


### PR DESCRIPTION
Relates to #8828

Whenever you're testing, say, a slang 2025.22 release using slangpy built against slang 2025.21.2, you need to account for the library name difference when attempting to overwrite the slang libraries in the locally installed python site-package.

This change plugs a hole in testing that could occur in the time between when a new slang release is made, and when an updated slangpy release is pushed to PyPI that uses that new slang release.