### PR TITLE
[DNI] ptr-to-groupshared.slang: Declare capability+extension VariablePointers+SPV_KHR_variable_pointers

### DIFF
--- a/tests/language-feature/pointer/ptr-to-groupshared.slang
+++ b/tests/language-feature/pointer/ptr-to-groupshared.slang
@@ -25,6 +25,9 @@ void foo(Ptr<Data, Access::ReadWrite, AddressSpace::GroupShared> ptr)
 [numthreads(3, 1, 1)]
 void computeMain(uint3 group_thread_id: SV_GroupThreadID)
 {
+    spirv_asm { OpCapability VariablePointers; };
+    spirv_asm { OpExtension "SPV_KHR_variable_pointers"; };
+
     shared = Data(1, 2);
     foo(__getAddress(shared));
 }


### PR DESCRIPTION
Declaring the capability triggers incorrect computation by the test on my machine.

GPU: NVIDIA GeForce RTX 3080
Driver version: Nvidia 580.95.05
Ubuntu 24.04.3 LTS

In slangc -O0 output, I see that the only difference is 

    OpCapability VariablePointers
    OpExtension "SPV_KHR_variable_pointers"

in the SPIR-V output.

In slangc regular output, I see that when capability `VariablePointers` is declared, there are extra statements. This suggests that the SPIRV tools optimizer has behavioral changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to enable variable pointers support in SPIR-V shader compilation.
  * Minor formatting adjustments in test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->