### PR TITLE
Implement emitOpDebugTypeFunction for SPIR-V

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -8798,16 +8798,23 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             return ensureInst(m_voidType);
 
         IRBuilder builder(type);
-        if (as<IRFuncType>(type))
+        if (IRFuncType* funcType = as<IRFuncType>(type))
         {
+            SpvInst* returnType = emitDebugType(funcType->getResultType());
+
             List<SpvInst*> argTypes;
+            for (UInt i = 0; i < funcType->getParamCount(); ++i)
+            {
+                argTypes.add(emitDebugType(funcType->getParamType(i)));
+            }
+
             return emitOpDebugTypeFunction(
                 getSection(SpvLogicalSectionID::ConstantsAndTypes),
                 nullptr,
                 m_voidType,
                 getNonSemanticDebugInfoExtInst(),
                 builder.getIntValue(builder.getUIntType(), 0),
-                ensureInst(m_voidType),
+                returnType,
                 argTypes);
         }
 

--- a/tests/spirv/debug-return-types.slang
+++ b/tests/spirv/debug-return-types.slang
@@ -1,0 +1,24 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -gdwarf -g3 -O0 -line-directive-mode glsl -stage fragment -entry main -emit-spirv-directly
+
+struct VSOutput {
+    int x;
+};
+
+float3x3 MatrixTranspose(float3x3 m) {
+    return float3x3(
+        m[0][0], m[1][0], m[2][0],
+        m[0][1], m[1][1], m[2][1],
+        m[0][2], m[1][2], m[2][2]
+    );
+}
+
+float4 main(VSOutput input) : SV_TARGET {
+    float3x3 m = MatrixTranspose(float3x3(1.0));
+    return float4(1.0, 1.0, 1.0, 1.0);
+}
+
+// CHECK: %[[VECTOR:[0-9]+]] = OpExtInst %void %{{[a-zA-Z0-9_]+}} DebugTypeVector
+// CHECK: %[[VSOUTPUT:[0-9]+]] = OpExtInst %void %{{[a-zA-Z0-9_]+}} DebugTypePointer
+// CHECK: {{.*}} = OpExtInst %void %{{[a-zA-Z0-9_]+}} DebugTypeFunction %{{[a-zA-Z0-9_]+}} %[[VECTOR]] %[[VSOUTPUT]]
+// CHECK: %[[MATRIX:[0-9]+]] = OpExtInst %void %{{[a-zA-Z0-9_]+}} DebugTypeMatrix
+// CHECK: {{.*}} = OpExtInst %void %{{[a-zA-Z0-9_]+}} DebugTypeFunction %{{[a-zA-Z0-9_]+}} %[[MATRIX]] %[[MATRIX]]


### PR DESCRIPTION
The arguments to emitOpDebugTypeFunction (in slang-emit-spirv.cpp) are placeholders, and always emit SPIR-V DebugTypeFunction instructions that suggest that the function has the signature `void (void)`.

Pull the result and parameter types from the function type, and emit those details with the DebugTypeFunction instruction.

Add a test (debug-return-types.slang) to verify that the function types are set correctly in the SPIR-V output.

This patch includes a workaround to issue #8992.

Fixes issue #8991