### PR TITLE
Fix ComPtr asssignment of raw pointer in the doc

### DIFF
--- a/docs/user-guide/08-compiling.md
+++ b/docs/user-guide/08-compiling.md
@@ -769,7 +769,7 @@ For example:
 
 ```c++
 Slang::ComPtr<IBlob> diagnostics;
-Slang::ComPtr<IModule> module = session->loadModule("MyShaders", diagnostics.writeRef());
+Slang::ComPtr<IModule> module(session->loadModule("MyShaders", diagnostics.writeRef()));
 ```
 
 In this example, if any diagnostic messages were produced when loading `MyShaders`, then the `diagnostics` pointer will be set to a blob that contains the textual content of those diagnostics.


### PR DESCRIPTION
`session->loadModule()` returns a raw pointer `IModule*`, and `ComPtr` ctor is marked `explicit`, making the implict raw pointer -> ComPtr invalid.

Update the docs to reflect that.

Closes: https://github.com/shader-slang/slang/issues/8820