### PR TITLE
Preserve aliasedType during module serialization for default export types

### DIFF
--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -395,7 +395,7 @@ class AggTypeDecl : public AggTypeDeclBase
     // `aliasedType` is used to store the alised type (in this case `Foo`)
     // when the agg type decl is declared in the link-time alias syntax.
     //
-    TypeExp aliasedType;
+    FIDDLE() TypeExp aliasedType;
 
     bool hasBody = true;
 

--- a/tests/bugs/issue-8955.slang
+++ b/tests/bugs/issue-8955.slang
@@ -1,0 +1,31 @@
+//TEST:SIMPLE: -o tests/bugs/issue-8955.slang-module
+//TEST:SIMPLE(filecheck=CHK): -target spirv-asm tests/bugs/issue-8955.slang-module
+
+// Test for issue #8955: Using link-time struct as vertex input crashes if compiled from serialized module
+// This test verifies that default export types (export struct X = Y) properly preserve their aliasedType
+// during serialization/deserialization.
+
+//CHK:OpEntryPoint Vertex %vertexMain
+
+struct VertexOutput {
+    float4 position : SV_Position;
+};
+
+interface IVertex {
+    float3 pos();
+}
+
+struct TestVertex : IVertex {
+    [[vk::location(0)]] float3 a_pos;
+
+    float3 pos() {
+        return a_pos;
+    }
+}
+
+export struct Vertex : IVertex = TestVertex;
+
+[[shader("vertex")]]
+VertexOutput vertexMain(Vertex input) {
+    return VertexOutput(float4(input.pos(), 1.0));
+}


### PR DESCRIPTION
When compiling a Slang module containing default export types (e.g., `export struct Vertex : IVertex = TestVertex;`), the `aliasedType` field on AggTypeDecl was not being serialized/deserialized, causing the layout computation to fail when the module was later loaded.

A crash was observed in GLSL legalization when it expected a struct type layout but encountered the alias type itself, which lacks proper field layout information.

The fix is to add the `FIDDLE()` marker to the `aliasedType` fields in AggTypeDecl so that they are included in the serialization/deserialization process.

When deserializing a module, the type layout resolution now correctly identifies the aliased type and creates layouts based on the resolved type (e.g., TestVertex) rather than the alias (e.g., Vertex).

Related to: https://github.com/shader-slang/slang/pull/8603/files#top
Fixes: https://github.com/shader-slang/slang/issues/8955