### PR TITLE
Fix incorrect debug function type

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -2409,8 +2409,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 getSection(SpvLogicalSectionID::ConstantsAndTypes),
                 nullptr,
                 nullptr,
-                as<IRDebugFunction>(inst),
-                nullptr);
+                as<IRDebugFunction>(inst));
         case kIROp_DebugInlinedAt:
             return emitDebugInlinedAt(
                 getSection(SpvLogicalSectionID::ConstantsAndTypes),
@@ -3587,7 +3586,6 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     spvBlock,
                     spvFunc,
                     irDebugFunc,
-                    irFunc->getDataType(),
                     irFunc);
             }
             if (funcDebugScope)
@@ -4792,8 +4790,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 getSection(SpvLogicalSectionID::ConstantsAndTypes),
                 nullptr,
                 nullptr,
-                as<IRDebugFunction>(inst),
-                nullptr);
+                as<IRDebugFunction>(inst));
         case kIROp_DebugInlinedAt:
             return emitDebugInlinedAt(
                 getSection(SpvLogicalSectionID::ConstantsAndTypes),
@@ -8559,7 +8556,6 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         SpvInst* firstBlock,
         SpvInst* spvFunc,
         IRDebugFunction* debugFunc,
-        IRFuncType* debugType,
         IRFunc* irFunc = nullptr)
     {
         SpvInst* debugFuncInfo = nullptr;
@@ -8572,15 +8568,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         if (!scope)
             return nullptr;
 
-        SpvInst* neededDebugType = nullptr;
-        if (debugType)
-        {
-            neededDebugType = emitDebugType(debugType);
-        }
-        else
-        {
-            neededDebugType = emitDebugType(as<IRFuncType>(debugFunc->getDebugType()));
-        }
+        SpvInst* neededDebugType = emitDebugType(as<IRFuncType>(debugFunc->getDebugType()));
+        SLANG_ASSERT(neededDebugType);
 
         IRBuilder builder(debugFunc);
         debugFuncInfo = emitOpDebugFunction(

--- a/source/slang/slang-ir-lower-generic-function.cpp
+++ b/source/slang/slang-ir-lower-generic-function.cpp
@@ -122,6 +122,7 @@ struct GenericFunctionLoweringContext
             }
         }
         cloneInstDecorationsAndChildren(&cloneEnv, sharedContext->module, func, loweredFunc);
+        fixUpDebugFuncType(loweredFunc);
 
         auto block = as<IRBlock>(loweredFunc->getFirstChild());
         for (auto param : clonedParams)


### PR DESCRIPTION
IRDebugFunction is supposed to have all information needed to emit SPIRV code for DebugFunction.
However, there was a case where a wrong DebugType information was inserted to IRDebugFunction.

This commit fix up the problem in the first place and removes the need of handling cases where IRDebugFunction doesn't have a right type during the emit stage.

Fixes https://github.com/shader-slang/slang/issues/8992