### PR TITLE
DNI: Enable slangpy tests on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,7 @@ jobs:
       config: release
       runs-on: '["ubuntu-22.04"]'
       test-category: full
+      full-gpu-tests: true
       server-count: 1
 
   # macOS tests


### PR DESCRIPTION
WIP

Add full-gpu-tests: true to Linux release configuration to evaluate running slangpy and slang-rhi tests on CPU-only ubuntu-22.04 runners.

This is a trial run to determine which tests are CPU-compatible and whether CPU testing provides value before GPU runners are available.

Fixes #8946