### PR TITLE
Fix documentation of __targetHasImplicitDerivatives()

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1523,6 +1523,7 @@ A capability describes an optional feature that a target may or may not support.
 * `consumestructuredbuffer` 
 * `structuredbuffer` 
 * `structuredbuffer_rw` 
+* `implicit_derivatives_sampling` 
 * `fragmentprocessing` 
 * `fragmentprocessing_derivativecontrol` 
 * `getattributeatvertex` 

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -1124,6 +1124,20 @@ Compound Capabilities
 `image_size`
 > Capabilities required to query image (RWTexture) size info
 
+`implicit_derivatives_sampling`
+> Capabilities required for implicit derivatives sampling.
+> 
+> This capability is required by texture sampling functions such as `_Texture.Sample()`
+> where the level of detail is determined by implicit derivatives.
+> 
+> @remark In GLSL, implicit level-of-detail `texture()` functions use the base texture when
+> the implicit derivatives are unavailable. When this capability is not present, invocations of
+> these functions are translated to invocations of `_Texture.SampleLevelZero()`.
+> 
+> @remark Implicit derivatives for the compute stage can be enabled by declaring capability `GL_NV_compute_shader_derivatives` (GLSL),
+> `SPV_KHR_compute_shader_derivatives` (SPIR-V), or profile `cs_6_6` (HLSL).
+> 
+
 `memorybarrier`
 > Capabilities required to use sm_5_0 style memory barriers
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -700,7 +700,7 @@ struct _Texture<T:ITexelElement, Shape: __ITextureShape, let isArray:int, let is
 //@hidden:
 
 // Returns true when the stage supports implicit derivatives on the
-// target. This must match with compound capability `fragmentprocessing`.
+// target. This must match with capability `implicit_derivatives_sampling`.
 //
 [__readNone]
 [ForceInline]

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -2033,6 +2033,23 @@ alias structuredbuffer = sm_4_0_version;
 /// [Compound]
 alias structuredbuffer_rw = sm_4_0_version;
 
+/// Capabilities required for implicit derivatives sampling.
+///
+/// This capability is required by texture sampling functions such as `_Texture.Sample()`
+/// where the level of detail is determined by implicit derivatives.
+///
+/// @remark In GLSL, implicit level-of-detail `texture()` functions use the base texture when
+/// the implicit derivatives are unavailable. When this capability is not present, invocations of
+/// these functions are translated to invocations of `_Texture.SampleLevelZero()`.
+///
+/// @remark Implicit derivatives for the compute stage can be enabled by declaring capability `GL_NV_compute_shader_derivatives` (GLSL),
+/// `SPV_KHR_compute_shader_derivatives` (SPIR-V), or profile `cs_6_6` (HLSL).
+///
+/// [compound]
+alias implicit_derivatives_sampling = fragment
+                                    | raytracingstages_compute_amplification_mesh + GL_NV_compute_shader_derivatives
+                                    ;
+
 /// Capabilities required to use fragment derivative operations (without GLSL derivativecontrol)
 /// [Compound]
 alias fragmentprocessing = fragment + _sm_5_0


### PR DESCRIPTION
Also, add capability `implicit_derivatives_sampling`. This should be a
requirement for functions such as _Texture.Sample() and
_Texture.CalculateLevelOfDetail(). But currently this requirement cannot
be added without complex __target_switch/__stage_switch constructs in
GLSL texture() functions because the calling function has to have at least
the capabilities of the called function.
    
Further, enforcing the implicit derivatives requirement with static_assert()
does not allow capabilities to be added on demand, which has too high
a likelihood of breaking existing code. Therefore, we'll accept that we may
generate invalid code without proper diagnostics for now.

Issue #8683