### PR TITLE
Fix FileStream EOF detection

### DIFF
--- a/source/core/slang-stream.cpp
+++ b/source/core/slang-stream.cpp
@@ -248,12 +248,31 @@ SlangResult FileStream::read(void* buffer, size_t length, size_t& outBytesRead)
         // If we have reached the end, then reading nothing is ok.
         if (!m_endReached)
         {
-            // If we are not at the end of the file we should be able to read some bytes
-            if (!feof(m_handle))
+            // Verify EOF using file position.
+            Int64 currentPos = getPosition();
+            Int64 currentSize = 0;
+
+// Save position, seek to end, get size, restore position
+#if defined(_WIN32) || defined(__CYGWIN__)
+            _fseeki64(m_handle, 0, SEEK_END);
+            currentSize = _ftelli64(m_handle);
+            _fseeki64(m_handle, currentPos, SEEK_SET);
+#else
+            fseeko(m_handle, 0, SEEK_END);
+            currentSize = ftello(m_handle);
+            fseeko(m_handle, currentPos, SEEK_SET);
+#endif
+
+            if (currentPos >= currentSize)
             {
+                // Confirmed at EOF
+                m_endReached = true;
+            }
+            else
+            {
+                // Not at EOF but got 0 bytes - genuine error
                 return SLANG_FAIL;
             }
-            m_endReached = true;
         }
     }
     return SLANG_OK;


### PR DESCRIPTION
Fixes #8627

feof() can conflict with fread() returning 0 bytes at EOF.

This is a fix for the race condition where:
- fread() returns 0 bytes (at EOF)
- feof() returns false (FILE EOF flag not yet set)
- m_endReached never set
- StreamReader::readToEnd() loops infinitely