### PR TITLE
Add placeholder workflow for RTX Remix shader compilation testing

### DIFF
--- a/.github/workflows/compile-rtx-remix-shaders-nightly.yml
+++ b/.github/workflows/compile-rtx-remix-shaders-nightly.yml
@@ -1,0 +1,13 @@
+name: RTX Remix Shaders (Nightly)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * *"
+
+jobs:
+  rtx-remix-shader-test:
+    runs-on: windows-2022
+    steps:
+      - name: Placeholder
+        run: echo "Workflow framework placeholder. Real implementation in PR."


### PR DESCRIPTION
This adds a minimal workflow framework that can be manually triggered or run on a nightly schedule. The placeholder allows the workflow to be registered with GitHub Actions, enabling testing of the full implementation from a PR branch before merging.

The complete implementation (including dxvk-remix cloning, packman setup, and shader compilation steps) will be added in a subsequent PR and can be tested by manually triggering this workflow from the feature branch.

Related to #8655