### PR TITLE
Fix Sample() with depth texture + sampler comparison state; add minimal repro

### DIFF
--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -1063,7 +1063,10 @@ void GLSLSourceEmitter::_emitGLSLTextureOrTextureSamplerType(
     {
         m_writer->emit("Array");
     }
-    if (type->isShadow())
+
+    // Note: we're adding 'Shadow' only for combined texture/sampler types. Plain texture
+    // types don't have depth/shadow variants in GLSL. (Issue #8802)
+    if (type->isCombined() && type->isShadow())
     {
         m_writer->emit("Shadow");
     }

--- a/tests/bugs/gh-8802-glsl-depth-texture-2d.slang
+++ b/tests/bugs/gh-8802-glsl-depth-texture-2d.slang
@@ -1,0 +1,40 @@
+//TEST:SIMPLE(filecheck=POSITIVE): -entry fragMain -stage fragment -target glsl
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=POSITIVE_RESULT): -vk -emit-spirv-via-glsl
+
+// This is a minimal repro for issue 8802
+
+//TEST_INPUT: ubuffer(data=[0], stride=4):out,name outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+//TEST_INPUT: Texture2D(format=D32Float, size=4, content = zero):name texHandle
+DepthTexture2D texHandle;
+
+//TEST_INPUT: Sampler(depthCompare):name samplerComparisonState
+SamplerComparisonState samplerComparisonState;
+
+[shader("fragment")]
+void fragMain()
+{
+// POSITIVE-NOT: {{(error|warning).*}}:
+// POSITIVE: result code = 0
+// POSITIVE-NOT: {{(error|warning).*}}:
+// POSITIVE-LABEL: main
+// POSITIVE-NOT: {{(error|warning).*}}:
+
+// Check that we get a properly constructed shadow sampler
+// POSITIVE: textureLod(sampler2DShadow(texHandle{{[^,]*}},samplerComparisonState{{[^,)]*}}),
+// POSITIVE-NOT: {{(error|warning).*}}:
+
+    int ret = 0;
+    ret = int((texHandle.SampleCmpLevelZero(samplerComparisonState, float2(0, 0), float(0))).x);
+    outputBuffer[0] = 0x12345 + ret;
+}
+
+[numthreads(4, 1, 1)]
+void computeMain()
+{
+    int ret = 0;
+    ret = int((texHandle.SampleCmpLevelZero(samplerComparisonState, float2(0, 0), float(0))).x);
+    outputBuffer[0] = 0x12345 + ret;
+}
+// POSITIVE_RESULT: 12345


### PR DESCRIPTION
When something such as depthTexHandle.SampleCmpLevelZero(samplerComparisonState, ...) was translated to GLSL, Slangc erroneously translated this as sampler2DShadowShadow(depthTexHandle,samplerComparisonState, ...). The first 'Shadow' comes from the depthTexHandle type and the second 'Shadow' comes from the sampler state type (comparison = shadow sampler).

To fix this while keeping things compatible with the existing use cases, emit the first 'Shadow' in GLSLSourceEmitter::_emitGLSLTextureOrTextureSamplerType() only when the type is a combined texture/sampler type. The sampler state type should decide the sampler type.

Also, add a minimal repro for this issue.

Fixes #8802