### PR TITLE
Add an __undefined literal expression

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -972,7 +972,7 @@ matrix<T,N,M> select(matrix<bool,N,M> condition, matrix<T,N,M> ifTrue, matrix<T,
     case hlsl:
         return __hlsl_select(condition, ifTrue, ifFalse);
     default:
-        matrix<T,N,M> result;
+        matrix<T,N,M> result = __undefined;
         [[unroll]]
         for (uint32_t i = 0; i < N; i++)
             result[i] = select(condition[i], ifTrue[i], ifFalse[i]);
@@ -1894,7 +1894,7 @@ __generic<T>
 [__unsafeForceInlineEarly]
 T __attachToNativeRef(NativeRef<T> nativeVal)
 {
-    T result;
+    T result = __undefined;
     __managed_ptr_attach(result, nativeVal);
     return result;
 }
@@ -3178,21 +3178,6 @@ __generic<T>
 [__unsafeForceInlineEarly]
 __intrinsic_op($(kIROp_BitfieldExtract))
 T bitfieldExtract(T value, uint offset, uint bits);
-
-/// Use an otherwise unused value
-/// This can be used to silence the warning about returning before initializing an out paramter.
-__generic<T>
-[__readNone]
-[ForceInline]
-__intrinsic_op($(kIROp_Unmodified))
-void unused(inout T){}
-
-// This can be used to silence the warning about not writing to an inout parameter.
-__generic<T>
-[__readNone]
-[ForceInline]
-__intrinsic_op($(kIROp_Unmodified))
-void unmodified(out T){}
 
 // Specialized function
 

--- a/source/slang/diff.meta.slang
+++ b/source/slang/diff.meta.slang
@@ -1381,7 +1381,7 @@ extension Array<T, N> : IDifferentiable
     [__unsafeForceInlineEarly]
     static Differential dadd(Differential a, Differential b)
     {
-        Array<T.Differential, N> result;
+        Array<T.Differential, N> result = __undefined;
         for (int i = 0; i < N; i++)
             result[i] = T.dadd(a[i], b[i]);
         return result;
@@ -1391,7 +1391,7 @@ extension Array<T, N> : IDifferentiable
     [__unsafeForceInlineEarly]
     static Differential dmul(U a, Differential b)
     {
-        Array<T.Differential, N> result;
+        Array<T.Differential, N> result = __undefined;
         for (int i = 0; i < N; i++)
             result[i] = T.dmul<U>(a, b[i]);
         return result;
@@ -1508,8 +1508,8 @@ __generic<T : __BuiltinFloatingPointType, let N : int, let M : int>
 [BackwardDifferentiable]
 void __d_mul(inout DifferentialPair<vector<T, N>> left, inout DifferentialPair<matrix<T, N, M>> right, vector<T, M>.Differential dOut)
 {
-    vector<T, N>.Differential left_d_result;
-    matrix<T, N, M>.Differential right_d_result;
+    vector<T, N>.Differential left_d_result = __undefined;
+    matrix<T, N, M>.Differential right_d_result = __undefined;
     [ForceUnroll]
     for (int i = 0; i < N; ++i)
     {
@@ -1545,8 +1545,8 @@ __generic<T : __BuiltinFloatingPointType, let N : int, let M : int>
 [BackwardDifferentiable]
 void __d_mul(inout DifferentialPair<matrix<T, N, M>> left, inout DifferentialPair<vector<T, M>> right, vector<T, N>.Differential dOut)
 {
-    matrix<T, N, M>.Differential left_d_result;
-    vector<T, M>.Differential right_d_result;
+    matrix<T, N, M>.Differential left_d_result = __undefined;
+    vector<T, M>.Differential right_d_result = __undefined;
     [ForceUnroll]
     for (int j = 0; j < M; ++j)
     {
@@ -1582,14 +1582,14 @@ __generic<T : __BuiltinFloatingPointType, let R : int, let N : int, let C : int>
 [BackwardDifferentiable]
 void mul(inout DifferentialPair<matrix<T, R, N>> left, inout DifferentialPair<matrix<T, N, C>> right, matrix<T, R, C>.Differential dOut)
 {
-    matrix<T, R, N>.Differential left_d_result;
+    matrix<T, R, N>.Differential left_d_result = __undefined;
     [ForceUnroll]
     for (int r = 0; r < R; ++r)
         [ForceUnroll]
         for (int n = 0; n < N; ++n)
             left_d_result[r][n] = T(0.0);
 
-    matrix<T, N, C>.Differential right_d_result;
+    matrix<T, N, C>.Differential right_d_result = __undefined;
     [ForceUnroll]
     for (int n = 0; n < N; ++n)
         [ForceUnroll]
@@ -1639,7 +1639,7 @@ __generic<T : __BuiltinFloatingPointType, let N : int>
 [BackwardDifferentiable]
 void __d_dot(inout DifferentialPair<vector<T, N>> dpx, inout DifferentialPair<vector<T, N>> dpy, T.Differential dOut)
 {
-    vector<T, N>.Differential x_d_result, y_d_result;
+    vector<T, N>.Differential x_d_result = __undefined, y_d_result = __undefined;
     [ForceUnroll]
     for (int i = 0; i < N; ++i)
     {
@@ -1710,8 +1710,8 @@ void __d_cross(inout DifferentialPair<vector<T, 3>> a, inout DifferentialPair<ve
     DifferentialPair<vector<T, N>> __d_##NAME##_vector(                                      \
         DifferentialPair<vector<T, N>> dpx, DifferentialPair<vector<T, N>> dpy)              \
     {                                                                                        \
-        vector<T, N> result;                                                                 \
-        vector<T, N>.Differential d_result;                                                  \
+        vector<T, N> result = __undefined;                                                   \
+        vector<T, N>.Differential d_result = __undefined;                                    \
         [ForceUnroll] for (int i = 0; i < N; ++i)                                            \
         {                                                                                    \
             DifferentialPair<T> dp_elem = __d_##NAME(                                        \
@@ -1728,8 +1728,8 @@ void __d_cross(inout DifferentialPair<vector<T, 3>> a, inout DifferentialPair<ve
     DifferentialPair<matrix<T, M, N>> __d_##NAME##_matrix(                                   \
         DifferentialPair<matrix<T, M, N>> dpx, DifferentialPair<matrix<T, M, N>> dpy)        \
     {                                                                                        \
-        matrix<T, M, N> result;                                                              \
-        matrix<T, M, N>.Differential d_result;                                               \
+        matrix<T, M, N> result = __undefined;                                                \
+        matrix<T, M, N>.Differential d_result = __undefined;                                 \
         [ForceUnroll] for (int i = 0; i < M; ++i)                                            \
         [ForceUnroll] for (int j = 0; j < N; ++j)                                            \
         {                                                                                    \
@@ -1749,7 +1749,7 @@ void __d_cross(inout DifferentialPair<vector<T, 3>> a, inout DifferentialPair<ve
             inout DifferentialPair<vector<T, N>> dpy,                                        \
             vector<T, N>.Differential dOut)                                                  \
     {                                                                                        \
-        vector<T, N>.Differential left_d_result, right_d_result;                             \
+        vector<T, N>.Differential left_d_result = __undefined, right_d_result = __undefined; \
         [ForceUnroll] for (int i = 0; i < N; ++i)                                            \
         {                                                                                    \
             DifferentialPair<T> left_dp = diffPair(dpx.p[i], T.dzero());                     \
@@ -1769,7 +1769,8 @@ void __d_cross(inout DifferentialPair<vector<T, 3>> a, inout DifferentialPair<ve
             inout DifferentialPair<matrix<T, M, N>> dpy,                                     \
             matrix<T, M, N>.Differential dOut)                                               \
     {                                                                                        \
-        matrix<T, M, N>.Differential left_d_result, right_d_result;                          \
+        matrix<T, M, N>.Differential left_d_result = __undefined;                            \
+        matrix<T, M, N>.Differential right_d_result = __undefined;                           \
         [ForceUnroll] for (int i = 0; i < M; ++i)                                            \
         [ForceUnroll] for (int j = 0; j < N; ++j)                                            \
         {                                                                                    \
@@ -1792,8 +1793,8 @@ void __d_cross(inout DifferentialPair<vector<T, 3>> a, inout DifferentialPair<ve
         DifferentialPair<vector<T, N>> dpy,                                                  \
         DifferentialPair<vector<T, N>> dpz)                                                  \
     {                                                                                        \
-        vector<T, N> result;                                                                 \
-        vector<T, N>.Differential d_result;                                                  \
+        vector<T, N> result = __undefined;                                                   \
+        vector<T, N>.Differential d_result = __undefined;                                    \
         [ForceUnroll] for (int i = 0; i < N; ++i)                                            \
         {                                                                                    \
             DifferentialPair<T> dp_elem = __d_##NAME(                                        \
@@ -1813,8 +1814,8 @@ void __d_cross(inout DifferentialPair<vector<T, 3>> a, inout DifferentialPair<ve
         DifferentialPair<matrix<T, M, N>> dpy,                                               \
         DifferentialPair<matrix<T, M, N>> dpz)                                               \
     {                                                                                        \
-        matrix<T, M, N> result;                                                              \
-        matrix<T, M, N>.Differential d_result;                                               \
+        matrix<T, M, N> result = __undefined;                                                \
+        matrix<T, M, N>.Differential d_result = __undefined;                                 \
         [ForceUnroll] for (int i = 0; i < M; ++i)                                            \
         [ForceUnroll] for (int j = 0; j < N; ++j)                                            \
         {                                                                                    \
@@ -1836,7 +1837,9 @@ void __d_cross(inout DifferentialPair<vector<T, 3>> a, inout DifferentialPair<ve
             inout DifferentialPair<vector<T, N>> dpz,                                        \
             vector<T, N>.Differential dOut)                                                  \
     {                                                                                        \
-        vector<T, N>.Differential left_d_result, middle_d_result, right_d_result;            \
+        vector<T, N>.Differential left_d_result = __undefined;                               \
+        vector<T, N>.Differential middle_d_result = __undefined;                             \
+        vector<T, N>.Differential right_d_result = __undefined;                              \
         [ForceUnroll] for (int i = 0; i < N; ++i)                                            \
         {                                                                                    \
             DifferentialPair<T> left_dp = diffPair(dpx.p[i], T.dzero());                     \
@@ -1861,7 +1864,9 @@ void __d_cross(inout DifferentialPair<vector<T, 3>> a, inout DifferentialPair<ve
             inout DifferentialPair<matrix<T, M, N>> dpz,                                     \
             matrix<T, M, N>.Differential dOut)                                               \
     {                                                                                        \
-        matrix<T, M, N>.Differential left_d_result, middle_d_result, right_d_result;         \
+        matrix<T, M, N>.Differential left_d_result = __undefined;                            \
+        matrix<T, M, N>.Differential middle_d_result = __undefined;                          \
+        matrix<T, M, N>.Differential right_d_result = __undefined;                           \
         [ForceUnroll] for (int i = 0; i < M; ++i)                                            \
         [ForceUnroll] for (int j = 0; j < N; ++j)                                            \
         {                                                                                    \
@@ -1902,7 +1907,7 @@ void __d_cross(inout DifferentialPair<vector<T, 3>> a, inout DifferentialPair<ve
     DifferentialPair<matrix<T, M, N>> __d_##NAME##_m(DifferentialPair<matrix<T, M, N>> dpm)  \
     {                                                                                        \
         typealias ReturnType = vector<T, N>;                                                 \
-        matrix<T, M, N>.Differential diff;                                                   \
+        matrix<T, M, N>.Differential diff = __undefined;                                     \
         [ForceUnroll] for (int i = 0; i < M; i++)                                            \
         {                                                                                    \
             var dpx = diffPair(dpm.p[i], dpm.d[i]);                                          \
@@ -1934,7 +1939,7 @@ void __d_cross(inout DifferentialPair<vector<T, 3>> a, inout DifferentialPair<ve
         inout DifferentialPair<matrix<T, M, N>> m, matrix<T, M, N>.Differential mdOut)       \
     {                                                                                        \
         typealias ReturnType = vector<T, N>;                                                 \
-        matrix<T, M, N>.Differential diff;                                                   \
+        matrix<T, M, N>.Differential diff = __undefined;                                     \
         [ForceUnroll] for (int i = 0; i < M; i++)                                            \
         {                                                                                    \
             var dpx = diffPair(m.p[i], m.d[i]);                                              \
@@ -2210,8 +2215,8 @@ __generic<T : __BuiltinFloatingPointType, let N : int>
 DifferentialPair<vector<T, N>> __d_copysign_vector(
     DifferentialPair<vector<T, N>> dpx, DifferentialPair<vector<T, N>> dpy)
 {
-    vector<T, N> result;
-    vector<T, N>.Differential d_result;
+    vector<T, N> result = __undefined;
+    vector<T, N>.Differential d_result = __undefined;
     [ForceUnroll] for (int i = 0; i < N; ++i)
     {
         DifferentialPair<T> dp_elem = __d_copysign(
@@ -2232,7 +2237,7 @@ void __d_copysign_vector(
     inout DifferentialPair<vector<T, N>> dpy,
     vector<T, N>.Differential dOut)
 {
-    vector<T, N>.Differential x_d_result, y_d_result;
+    vector<T, N>.Differential x_d_result = __undefined, y_d_result = __undefined;
     [ForceUnroll] for (int i = 0; i < N; ++i)
     {
         DifferentialPair<T> x_dp = DifferentialPair<T>(dpx.p[i], __slang_noop_cast<T.Differential>(dpx.d[i]));
@@ -2544,7 +2549,7 @@ __generic<T : __BuiltinFloatingPointType>
 [PrimalSubstituteOf(dst)]
 vector<T, 4> __dst_impl(vector<T, 4> src0, vector<T, 4> src1)
 {
-    vector<T, 4> dest;
+    vector<T, 4> dest = __undefined;
     dest.x = T(1.0);
     dest.y = src0.y * src1.y;
     dest.z = src0.z;

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -4,10 +4,10 @@
 #define lowp
 
 #define VECTOR_MAP_UNARY(TYPE, COUNT, FUNC, VALUE) \
-    vector<TYPE,COUNT> result; [ForceUnroll] for(int i = 0; i < COUNT; ++i) { result[i] = FUNC(VALUE[i]); } return result
+    vector<TYPE,COUNT> result = __undefined; [ForceUnroll] for(int i = 0; i < COUNT; ++i) { result[i] = FUNC(VALUE[i]); } return result
 
 #define VECTOR_MAP_TRINARY(TYPE, COUNT, FUNC, A, B, C) \
-    vector<TYPE,COUNT> result; [ForceUnroll] for(int i = 0; i < COUNT; ++i) { result[i] = FUNC(A[i], B[i], C[i]); } return result
+    vector<TYPE,COUNT> result = __undefined; [ForceUnroll] for(int i = 0; i < COUNT; ++i) { result[i] = FUNC(A[i], B[i], C[i]); } return result
 
 //
 // OpenGL 4.60 spec
@@ -597,7 +597,7 @@ public vector<T, N> mix(vector<T, N> x, vector<T, N> y, vector<bool, N> a)
         result:$$vector<T,N> = OpSelect $a $y $x
     };
     default:
-        vector<T, N> result;
+        vector<T, N> result = __undefined;
         [ForceUnroll]
         for (int i = 0; i < N; i++)
         {
@@ -890,7 +890,7 @@ public matrix<T, R, C> outerProduct(vector<T, C> c, vector<T, R> r)
         result:$$matrix<T,R,C> = OpOuterProduct $c $r
     };
     default:
-        matrix<T, R, C> result;
+        matrix<T, R, C> result = __undefined;
         for (int j = 0; j < R; ++j)
         {
             for (int i = 0; i < C; ++i)
@@ -927,13 +927,15 @@ public uint uaddCarry(highp uint x, highp uint y, out lowp uint carry)
     __target_switch
     {
     case glsl: __intrinsic_asm "uaddCarry";
-    case spirv: return spirv_asm {
-        %ResType = OpTypeStruct $$uint $$uint;
-        %temp:%ResType = OpIAddCarry $x $y;
-        %carry:$$uint = OpCompositeExtract %temp 1;
-        OpStore &carry %carry;
-        result:$$uint = OpCompositeExtract %temp 0
-    };
+    case spirv:
+        carry = __undefined;
+        return spirv_asm {
+            %ResType = OpTypeStruct $$uint $$uint;
+            %temp:%ResType = OpIAddCarry $x $y;
+            %carry:$$uint = OpCompositeExtract %temp 1;
+            OpStore &carry %carry;
+            result:$$uint = OpCompositeExtract %temp 0
+        };
     default:
         let result = x * y;
         carry = ((result < x || result < y) ? 1 : 0);
@@ -950,14 +952,17 @@ public vector<uint,N> uaddCarry(highp vector<uint,N> x, highp vector<uint,N> y, 
     __target_switch
     {
     case glsl: __intrinsic_asm "uaddCarry";
-    case spirv: return spirv_asm {
-        %ResType = OpTypeStruct $$vector<uint,N> $$vector<uint,N>;
-        %temp:%ResType = OpIAddCarry $x $y;
-        %carry:$$vector<uint,N> = OpCompositeExtract %temp 1;
-        OpStore &carry %carry;
-        result:$$vector<uint,N> = OpCompositeExtract %temp 0
-    };
+    case spirv:
+        carry = __undefined;
+        return spirv_asm {
+            %ResType = OpTypeStruct $$vector<uint,N> $$vector<uint,N>;
+            %temp:%ResType = OpIAddCarry $x $y;
+            %carry:$$vector<uint,N> = OpCompositeExtract %temp 1;
+            OpStore &carry %carry;
+            result:$$vector<uint,N> = OpCompositeExtract %temp 0
+        };
     default:
+        carry = __undefined;
         VECTOR_MAP_TRINARY(uint, N, uaddCarry, x, y, carry);
     }
 }
@@ -970,13 +975,15 @@ public uint usubBorrow(highp uint x, highp uint y, out lowp uint borrow)
     __target_switch
     {
     case glsl: __intrinsic_asm "usubBorrow";
-    case spirv: return spirv_asm {
-        %ResType = OpTypeStruct $$uint $$uint;
-        %temp:%ResType = OpISubBorrow $x $y;
-        %borrow:$$uint = OpCompositeExtract %temp 1;
-        OpStore &borrow %borrow;
-        result:$$uint = OpCompositeExtract %temp 0
-    };
+    case spirv:
+        borrow = __undefined;
+        return spirv_asm {
+            %ResType = OpTypeStruct $$uint $$uint;
+            %temp:%ResType = OpISubBorrow $x $y;
+            %borrow:$$uint = OpCompositeExtract %temp 1;
+            OpStore &borrow %borrow;
+            result:$$uint = OpCompositeExtract %temp 0
+        };
     default:
         borrow = (y > x) ? 1 : 0;
         return x - y;
@@ -992,14 +999,17 @@ public vector<uint,N> usubBorrow(highp vector<uint,N> x, highp vector<uint,N> y,
     __target_switch
     {
     case glsl: __intrinsic_asm "usubBorrow";
-    case spirv: return spirv_asm {
-        %ResType = OpTypeStruct $$vector<uint,N> $$vector<uint,N>;
-        %temp:%ResType = OpISubBorrow $x $y;
-        %borrow:$$vector<uint,N> = OpCompositeExtract %temp 1;
-        OpStore &borrow %borrow;
-        result:$$vector<uint,N> = OpCompositeExtract %temp 0
-    };
+    case spirv:
+        borrow = __undefined;
+        return spirv_asm {
+            %ResType = OpTypeStruct $$vector<uint,N> $$vector<uint,N>;
+            %temp:%ResType = OpISubBorrow $x $y;
+            %borrow:$$vector<uint,N> = OpCompositeExtract %temp 1;
+            OpStore &borrow %borrow;
+            result:$$vector<uint,N> = OpCompositeExtract %temp 0
+        };
     default:
+        borrow = __undefined;
         VECTOR_MAP_TRINARY(uint, N, usubBorrow, x, y, borrow);
     }
 }
@@ -1012,14 +1022,17 @@ public void umulExtended(highp uint x, highp uint y, out highp uint msb, out hig
     __target_switch
     {
     case glsl: __intrinsic_asm "umulExtended";
-    case spirv: spirv_asm {
-        %ResType = OpTypeStruct $$uint $$uint;
-        %temp:%ResType = OpUMulExtended $x $y;
-        %lsb:$$uint = OpCompositeExtract %temp 0;
-        %msb:$$uint = OpCompositeExtract %temp 1;
-        OpStore &lsb %lsb;
-        OpStore &msb %msb;
-    };
+    case spirv:
+        msb = __undefined;
+        lsb = __undefined;
+        spirv_asm {
+            %ResType = OpTypeStruct $$uint $$uint;
+            %temp:%ResType = OpUMulExtended $x $y;
+            %lsb:$$uint = OpCompositeExtract %temp 0;
+            %msb:$$uint = OpCompositeExtract %temp 1;
+            OpStore &lsb %lsb;
+            OpStore &msb %msb;
+        };
     default:
         uint64_t result = x * y;
         msb = uint(result >> 32);
@@ -1036,15 +1049,20 @@ public void umulExtended(highp vector<uint,N> x, highp vector<uint,N> y, out hig
     __target_switch
     {
     case glsl: __intrinsic_asm "umulExtended";
-    case spirv: spirv_asm {
-        %ResType = OpTypeStruct $$vector<uint,N> $$vector<uint,N>;
-        %temp:%ResType = OpUMulExtended $x $y;
-        %lsb:$$vector<uint,N> = OpCompositeExtract %temp 0;
-        %msb:$$vector<uint,N> = OpCompositeExtract %temp 1;
-        OpStore &lsb %lsb;
-        OpStore &msb %msb;
-    };
+    case spirv:
+        msb = __undefined;
+        lsb = __undefined;
+        spirv_asm {
+            %ResType = OpTypeStruct $$vector<uint,N> $$vector<uint,N>;
+            %temp:%ResType = OpUMulExtended $x $y;
+            %lsb:$$vector<uint,N> = OpCompositeExtract %temp 0;
+            %msb:$$vector<uint,N> = OpCompositeExtract %temp 1;
+            OpStore &lsb %lsb;
+            OpStore &msb %msb;
+        };
     default:
+        msb = __undefined;
+        lsb = __undefined;
         [ForceUnroll]
         for(int i = 0; i < N; ++i)
         {
@@ -1061,14 +1079,17 @@ public void imulExtended(highp int x, highp int y, out highp int msb, out highp 
     __target_switch
     {
     case glsl: __intrinsic_asm "imulExtended";
-    case spirv: spirv_asm {
-        %ResType = OpTypeStruct $$int $$int;
-        %temp:%ResType = OpSMulExtended $x $y;
-        %lsb:$$int = OpCompositeExtract %temp 0;
-        %msb:$$int = OpCompositeExtract %temp 1;
-        OpStore &lsb %lsb;
-        OpStore &msb %msb;
-    };
+    case spirv:
+        msb = __undefined;
+        lsb = __undefined;
+        spirv_asm {
+            %ResType = OpTypeStruct $$int $$int;
+            %temp:%ResType = OpSMulExtended $x $y;
+            %lsb:$$int = OpCompositeExtract %temp 0;
+            %msb:$$int = OpCompositeExtract %temp 1;
+            OpStore &lsb %lsb;
+            OpStore &msb %msb;
+        };
     default:
         int64_t result = x * y;
         msb = int(result >> 32);
@@ -1085,15 +1106,20 @@ public void imulExtended(highp vector<int,N> x, highp vector<int,N> y, out highp
     __target_switch
     {
     case glsl: __intrinsic_asm "imulExtended";
-    case spirv: spirv_asm {
-        %ResType = OpTypeStruct $$vector<int,N> $$vector<int,N>;
-        %temp:%ResType = OpSMulExtended $x $y;
-        %lsb:$$vector<int,N> = OpCompositeExtract %temp 0;
-        %msb:$$vector<int,N> = OpCompositeExtract %temp 1;
-        OpStore &lsb %lsb;
-        OpStore &msb %msb;
-    };
+    case spirv:
+        msb = __undefined;
+        lsb = __undefined;
+        spirv_asm {
+            %ResType = OpTypeStruct $$vector<int,N> $$vector<int,N>;
+            %temp:%ResType = OpSMulExtended $x $y;
+            %lsb:$$vector<int,N> = OpCompositeExtract %temp 0;
+            %msb:$$vector<int,N> = OpCompositeExtract %temp 1;
+            OpStore &lsb %lsb;
+            OpStore &msb %msb;
+        };
     default:
+        msb = __undefined;
+        lsb = __undefined;
         [ForceUnroll]
         for(int i = 0; i < N; ++i)
         {

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -1193,6 +1193,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 , "HLSL supports only float and half type textures");
             __intrinsic_asm ".Sample";
         case spirv:
+            status = __undefined;
             return spirv_asm
             {
                 OpCapability MinLod;
@@ -1285,6 +1286,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 , "HLSL supports only float and half type textures");
             return __getTexture().SampleBias(__getSampler(), location, bias, offset, clamp, status);
         case spirv:
+            status = __undefined;
             return spirv_asm
             {
                 OpCapability SparseResidency;
@@ -1427,6 +1429,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 , "HLSL supports only float and half type textures");
             return __getTexture().SampleCmp(__getComparisonSampler(), location, compareValue, offset, clamp, status);
         case spirv:
+            status = __undefined;
             return spirv_asm
             {
                 OpCapability MinLod;
@@ -1570,6 +1573,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 , "HLSL supports only float and half type textures");
             return __getTexture().SampleCmpLevel(__getComparisonSampler(), location, compareValue, level, offset, status);
         case spirv:
+            status = __undefined;
             return spirv_asm
             {
                 OpCapability SparseResidency;
@@ -1825,6 +1829,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 , "HLSL supports only float and half type textures");
             return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY, offset, lodClamp, status);
         case spirv:
+            status = __undefined;
             return spirv_asm
             {
                 OpCapability MinLod;
@@ -1941,6 +1946,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 , "HLSL supports only float and half type textures");
             return __getTexture().SampleLevel(__getSampler(), location, level, offset, status);
         case spirv:
+            status = __undefined;
             return spirv_asm
             {
                 OpCapability SparseResidency;
@@ -2446,6 +2452,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 , "HLSL supports only float and half type textures");
             __intrinsic_asm ".Sample";
         case spirv:
+            status = __undefined;
             return spirv_asm
             {
                 OpCapability MinLod;
@@ -2607,6 +2614,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 , "HLSL supports only float and half type textures");
             __intrinsic_asm ".SampleBias";
         case spirv:
+            status = __undefined;
             return spirv_asm
             {
                 OpCapability MinLod;
@@ -2771,6 +2779,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 , "HLSL supports only float and half type textures");
             __intrinsic_asm ".SampleCmp";
         case spirv:
+            status = __undefined;
             return spirv_asm
             {
                 OpCapability MinLod;
@@ -2912,6 +2921,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 , "HLSL supports only float and half type textures");
             __intrinsic_asm ".SampleCmpLevel";
         case spirv:
+            status = __undefined;
             return spirv_asm
             {
                 OpCapability SparseResidency;
@@ -3268,6 +3278,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 , "HLSL supports only float and half type textures");
             __intrinsic_asm ".SampleGrad";
         case spirv:
+            status = __undefined;
             return spirv_asm
             {
                 OpCapability MinLod;
@@ -3460,6 +3471,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 , "HLSL supports only float and half type textures");
             __intrinsic_asm ".SampleLevel";
         case spirv:
+            status = __undefined;
             return spirv_asm
             {
                 OpCapability SparseResidency;
@@ -4357,6 +4369,7 @@ extension _Texture<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,format>
              let lod = location[lodLoc];
              if (isCombined != 0)
              {
+                 status = __undefined;
                  return spirv_asm
                  {
                      OpCapability SparseResidency;
@@ -4373,6 +4386,7 @@ extension _Texture<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,format>
              }
              else
              {
+                 status = __undefined;
                  return spirv_asm
                  {
                      OpCapability SparseResidency;
@@ -4567,6 +4581,7 @@ extension _Texture<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,format>
         case spirv:
              if (isCombined != 0)
              {
+                 status = __undefined;
                  return spirv_asm
                  {
                      OpCapability SparseResidency;
@@ -4583,6 +4598,7 @@ extension _Texture<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,format>
              }
              else
              {
+                 status = __undefined;
                  return spirv_asm
                  {
                      OpCapability SparseResidency;
@@ -6765,22 +6781,22 @@ struct TriangleStream
 };
 
 #define VECTOR_MAP_UNARY(TYPE, COUNT, FUNC, VALUE) \
-    vector<TYPE,COUNT> result; for(int i = 0; i < COUNT; ++i) { result[i] = FUNC(VALUE[i]); } return result
+    vector<TYPE,COUNT> result = __undefined; for(int i = 0; i < COUNT; ++i) { result[i] = FUNC(VALUE[i]); } return result
 
 #define MATRIX_MAP_UNARY(TYPE, ROWS, COLS, FUNC, VALUE) \
-    matrix<TYPE,ROWS,COLS> result; for(int i = 0; i < ROWS; ++i) { result[i] = FUNC(VALUE[i]); } return result
+    matrix<TYPE,ROWS,COLS> result = __undefined; for(int i = 0; i < ROWS; ++i) { result[i] = FUNC(VALUE[i]); } return result
 
 #define VECTOR_MAP_BINARY(TYPE, COUNT, FUNC, LEFT, RIGHT) \
-    vector<TYPE,COUNT> result; for(int i = 0; i < COUNT; ++i) { result[i] = FUNC(LEFT[i], RIGHT[i]); } return result
+    vector<TYPE,COUNT> result = __undefined; for(int i = 0; i < COUNT; ++i) { result[i] = FUNC(LEFT[i], RIGHT[i]); } return result
 
 #define MATRIX_MAP_BINARY(TYPE, ROWS, COLS, FUNC, LEFT, RIGHT) \
-    matrix<TYPE,ROWS,COLS> result; for(int i = 0; i < ROWS; ++i) { result[i] = FUNC(LEFT[i], RIGHT[i]); } return result
+    matrix<TYPE,ROWS,COLS> result = __undefined; for(int i = 0; i < ROWS; ++i) { result[i] = FUNC(LEFT[i], RIGHT[i]); } return result
 
 #define VECTOR_MAP_TRINARY(TYPE, COUNT, FUNC, A, B, C) \
-    vector<TYPE,COUNT> result; for(int i = 0; i < COUNT; ++i) { result[i] = FUNC(A[i], B[i], C[i]); } return result
+    vector<TYPE,COUNT> result = __undefined; for(int i = 0; i < COUNT; ++i) { result[i] = FUNC(A[i], B[i], C[i]); } return result
 
 #define MATRIX_MAP_TRINARY(TYPE, ROWS, COLS, FUNC, A, B, C) \
-    matrix<TYPE,ROWS,COLS> result; for(int i = 0; i < ROWS; ++i) { result[i] = FUNC(A[i], B[i], C[i]); } return result
+    matrix<TYPE,ROWS,COLS> result = __undefined; for(int i = 0; i < ROWS; ++i) { result[i] = FUNC(A[i], B[i], C[i]); } return result
 
 //@public:
 
@@ -8827,7 +8843,7 @@ vector<uint, N> countbits(vector<T, N> value)
         // wgsl only supports 32-bit integers
         if (T is int32_t)
         {
-            vector<uint32_t, N> ret;
+            vector<uint32_t, N> ret = __undefined;
             for (int i = 0; i < N; i++)
             {
                 ret[i] = countbits(__intCast<uint32_t>(value[i]));
@@ -9631,7 +9647,7 @@ matrix<T,N,M> EvaluateAttributeAtSample(__constref matrix<T,N,M> x, uint samplei
     case glsl:
         return __EvaluateAttributeAtSample(__ResolveVaryingInputRef(x), sampleindex);
     default:
-        matrix<T,N,M> result;
+        matrix<T,N,M> result = __undefined;
         for(int i = 0; i < N; ++i)
         {
             result[i] = EvaluateAttributeAtSample(x[i], sampleindex);
@@ -9734,7 +9750,7 @@ matrix<T,N,M> EvaluateAttributeSnapped(__constref matrix<T,N,M> x, int2 offset)
     case glsl:
         return __EvaluateAttributeSnapped(__ResolveVaryingInputRef(x), offset);
     default:
-        matrix<T,N,M> result;
+        matrix<T,N,M> result = __undefined;
         for(int i = 0; i < N; ++i)
         {
             result[i] = EvaluateAttributeSnapped(x[i], offset);
@@ -10646,9 +10662,11 @@ T frexp(T x, out int exp)
     case glsl: __intrinsic_asm "frexp";
     case hlsl: __intrinsic_asm "frexp";
     case metal: __intrinsic_asm "frexp($0, *($1))";
-    case spirv: return spirv_asm {
-        result:$$T = OpExtInst glsl450 Frexp $x &exp
-    };
+    case spirv:
+        exp = __undefined;
+        return spirv_asm {
+            result:$$T = OpExtInst glsl450 Frexp $x &exp
+        };
     case wgsl:
         T fract;
         __wgsl_frexp<T>(x, fract, exp);
@@ -10676,14 +10694,17 @@ vector<T, N> frexp(vector<T, N> x, out vector<int, N> exp)
     case glsl: __intrinsic_asm "frexp";
     case hlsl: __intrinsic_asm "frexp";
     case metal: __intrinsic_asm "frexp($0, *($1))";
-    case spirv: return spirv_asm {
-        result:$$vector<T, N> = OpExtInst glsl450 Frexp $x &exp
-    };
+    case spirv:
+        exp = __undefined;
+        return spirv_asm {
+            result:$$vector<T, N> = OpExtInst glsl450 Frexp $x &exp
+        };
     case wgsl:
         vector<T,N> fract;
         __wgsl_frexp<T>(x, fract, exp);
         return fract;
     default:
+        exp = __undefined;
         VECTOR_MAP_BINARY(T, N, frexp, x, exp);
     }
 }
@@ -10707,6 +10728,7 @@ matrix<T, N, M> frexp(matrix<T, N, M> x, out matrix<int, N, M, L> exp)
     {
     case hlsl: __intrinsic_asm "frexp";
     default:
+        exp = __undefined;
         MATRIX_MAP_BINARY(T, N, M, frexp, x, exp);
     }
 }
@@ -11539,7 +11561,7 @@ vector<T, N> ldexp(vector<T, N> x, vector<E, N> exp)
     };
     case wgsl: __intrinsic_asm "ldexp";
     default:
-        vector<T,N> temp;
+        vector<T,N> temp = __undefined;
         [ForceUnroll]
         for (int i = 0; i < N; ++i)
             temp[i] = __realCast<T>(exp[i]);
@@ -12516,9 +12538,11 @@ T modf(T x, out T ip)
     case hlsl: __intrinsic_asm "modf";
     case glsl: __intrinsic_asm "modf";
     case metal: __intrinsic_asm "modf($0, *($1))";
-    case spirv: return spirv_asm {
-        result:$$T = OpExtInst glsl450 Modf $x &ip
-    };
+    case spirv:
+        ip = __undefined;
+        return spirv_asm {
+            result:$$T = OpExtInst glsl450 Modf $x &ip
+        };
     case wgsl:
         T fract;
         __wgsl_modf<T>(x, fract, ip);
@@ -12546,14 +12570,17 @@ vector<T,N> modf(vector<T,N> x, out vector<T,N> ip)
     case hlsl: __intrinsic_asm "modf";
     case glsl: __intrinsic_asm "modf";
     case metal: __intrinsic_asm "modf($0, *($1))";
-    case spirv: return spirv_asm {
-        result:$$vector<T,N> = OpExtInst glsl450 Modf $x &ip
-    };
+    case spirv:
+        ip = __undefined;
+        return spirv_asm {
+            result:$$vector<T,N> = OpExtInst glsl450 Modf $x &ip
+        };
     case wgsl:
         vector<T,N> fract;
         __wgsl_modf<T>(x, fract, ip);
         return fract;
     default:
+        ip = __undefined;
         VECTOR_MAP_BINARY(T, N, modf, x, ip);
     }
 }
@@ -12577,6 +12604,7 @@ matrix<T,N,M> modf(matrix<T,N,M> x, out matrix<T,N,M,L> ip)
     {
     case hlsl: __intrinsic_asm "modf";
     default:
+        ip = __undefined;
         MATRIX_MAP_BINARY(T, N, M, modf, x, ip);
     }
 }
@@ -12698,7 +12726,7 @@ vector<T, M> mul(vector<T, N> left, matrix<T, N, M> right)
     };
     case wgsl: __intrinsic_asm "($1 * $0)";
     default:
-        vector<T,M> result;
+        vector<T,M> result = __undefined;
         for( int j = 0; j < M; ++j )
         {
             T sum = T(0);
@@ -12723,7 +12751,7 @@ vector<T, M> mul(vector<T, N> left, matrix<T, N, M> right)
     case hlsl: __intrinsic_asm "mul";
     case wgsl: __intrinsic_asm "($1 * $0)";
     default:
-        vector<T,M> result;
+        vector<T,M> result = __undefined;
         for( int j = 0; j < M; ++j )
         {
             T sum = T(0);
@@ -12749,7 +12777,7 @@ vector<T, M> mul(vector<T, N> left, matrix<T, N, M> right)
     case hlsl: __intrinsic_asm "mul";
     case wgsl: __intrinsic_asm "($1 * $0)";
     default:
-        vector<T,M> result;
+        vector<T,M> result = __undefined;
         for( int j = 0; j < M; ++j )
         {
             T sum = T(0);
@@ -12779,7 +12807,7 @@ vector<T,N> mul(matrix<T,N,M> left, vector<T,M> right)
     };
     case wgsl: __intrinsic_asm "($1 * $0)";
     default:
-        vector<T,N> result;
+        vector<T,N> result = __undefined;
         for( int i = 0; i < N; ++i )
         {
             T sum = T(0);
@@ -12804,7 +12832,7 @@ vector<T,N> mul(matrix<T,N,M> left, vector<T,M> right)
     case hlsl: __intrinsic_asm "mul";
     case wgsl: __intrinsic_asm "($1 * $0)";
     default:
-        vector<T,N> result;
+        vector<T,N> result = __undefined;
         for( int i = 0; i < N; ++i )
         {
             T sum = T(0);
@@ -12830,7 +12858,7 @@ vector<T,N> mul(matrix<T,N,M> left, vector<T,M> right)
     case hlsl: __intrinsic_asm "mul";
     case wgsl: __intrinsic_asm "($1 * $0)";
     default:
-        vector<T,N> result;
+        vector<T,N> result = __undefined;
         for( int i = 0; i < N; ++i )
         {
             T sum = T(0);
@@ -12860,7 +12888,7 @@ matrix<T,R,C> mul(matrix<T,R,N> left, matrix<T,N,C> right)
     };
     case wgsl: __intrinsic_asm "($1 * $0)";
     default:
-        matrix<T,R,C> result;
+        matrix<T,R,C> result = __undefined;
         for( int r = 0; r < R; ++r)
         for( int c = 0; c < C; ++c)
         {
@@ -12886,7 +12914,7 @@ matrix<T,R,C> mul(matrix<T,R,N> left, matrix<T,N,C> right)
     case hlsl: __intrinsic_asm "mul";
     case wgsl: __intrinsic_asm "($1 * $0)";
     default:
-        matrix<T,R,C> result;
+        matrix<T,R,C> result = __undefined;
         for( int r = 0; r < R; ++r)
         for( int c = 0; c < C; ++c)
         {
@@ -12913,7 +12941,7 @@ matrix<T,R,C> mul(matrix<T,R,N> left, matrix<T,N,C> right)
     case hlsl: __intrinsic_asm "mul";
     case wgsl: __intrinsic_asm "($1 * $0)";
     default:
-        matrix<T,R,C> result;
+        matrix<T,R,C> result = __undefined;
         for( int r = 0; r < R; ++r)
         for( int c = 0; c < C; ++c)
         {
@@ -14396,7 +14424,7 @@ matrix<T, M, N> transpose(matrix<T, N, M> x)
     };
     case wgsl: __intrinsic_asm "transpose";
     default:
-        matrix<T,M,N> result;
+        matrix<T,M,N> result = __undefined;
         for(int r = 0; r < M; ++r)
             for(int c = 0; c < N; ++c)
                 result[r][c] = x[c][r];
@@ -14414,7 +14442,7 @@ matrix<T, M, N> transpose(matrix<T, N, M> x)
     case hlsl: __intrinsic_asm "transpose";
     // GLSL, WGSL, SPIR-V, and Metal don't support integer matrices when lowered, so transpose it manually
     default:
-        matrix<T, M, N> result;
+        matrix<T, M, N> result = __undefined;
         for (int r = 0; r < M; ++r)
             for (int c = 0; c < N; ++c)
                 result[r][c] = x[c][r];
@@ -14436,7 +14464,7 @@ matrix<T, M, N> transpose(matrix<T, N, M> x)
     };
     // GLSL, WGSL, and Metal don't support bool matrices when lowered, so transpose it manually
     default:
-        matrix<T, M, N> result;
+        matrix<T, M, N> result = __undefined;
         for (int r = 0; r < M; ++r)
             for (int c = 0; c < N; ++c)
                 result[r][c] = x[c][r];
@@ -15762,7 +15790,7 @@ matrix<T, N, M> WaveActive$(opName.hlslName)(matrix<T, N, M> expr)
     case hlsl:
         __intrinsic_asm "WaveActive$(opName.hlslName)";
     default:
-        matrix<T,N,M> result;
+        matrix<T,N,M> result = __undefined;
         [ForceUnroll]
         for (int i = 0; i < N; ++i)
             result[i] = WaveActive$(opName.hlslName)(expr[i]);
@@ -15847,7 +15875,7 @@ matrix<T, N, M> WaveActive$(opName.name)(matrix<T, N, M> expr)
     case hlsl:
         __intrinsic_asm "WaveActive$(opName.name)";
     default:
-        matrix<T, N, M> result;
+        matrix<T, N, M> result = __undefined;
         [ForceUnroll]
         for (int i = 0; i < N; ++i)
             result[i] = WaveActive$(opName.name)(expr[i]);
@@ -15947,7 +15975,7 @@ matrix<T, N, M> WaveActive$(opName.hlslName)(matrix<T, N, M> expr)
     case hlsl:
         __intrinsic_asm "WaveActive$(opName.hlslName)";
     default:
-        matrix<T, N, M> result;
+        matrix<T, N, M> result = __undefined;
         [ForceUnroll]
         for (int i = 0; i < N; ++i)
             result[i] = WaveActive$(opName.hlslName)(expr[i]);
@@ -16319,7 +16347,7 @@ matrix<T, N, M> WavePrefixProduct(matrix<T, N, M> expr)
     case hlsl:
         __intrinsic_asm "WavePrefixProduct";
     default:
-        matrix<T, N, M> result;
+        matrix<T, N, M> result = __undefined;
         for (int i = 0; i < N; ++i)
             result[i] = WavePrefixProduct(expr[i]);
         return result;
@@ -16402,7 +16430,7 @@ matrix<T,N,M> WavePrefixSum(matrix<T,N,M> expr)
     case hlsl:
         __intrinsic_asm "WavePrefixSum";
     default:
-        matrix<T, N, M> result;
+        matrix<T, N, M> result = __undefined;
         for (int i = 0; i < N; ++i)
             result[i] = WavePrefixSum(expr[i]);
         return result;
@@ -16464,7 +16492,7 @@ matrix<T,N,M> WaveReadLaneFirst(matrix<T,N,M> expr)
         return WaveMaskReadLaneFirst(WaveGetActiveMask(), expr);
     case hlsl: __intrinsic_asm "WaveReadLaneFirst";
     default:
-        matrix<T, N, M> result;
+        matrix<T, N, M> result = __undefined;
         for (int i = 0; i < N; ++i)
             result[i] = WaveReadLaneFirst(expr[i]);
         return result;
@@ -16534,7 +16562,7 @@ matrix<T, N, M> WaveBroadcastLaneAt(matrix<T, N, M> value, constexpr int lane)
     case cuda: __intrinsic_asm "_waveShuffleMultiple(_getActiveMask(), $0, $1)";
     case hlsl: __intrinsic_asm "WaveReadLaneAt";
     default:
-        matrix<T, N, M> result;
+        matrix<T, N, M> result = __undefined;
         for (int i = 0; i < N; ++i)
             result[i] = WaveBroadcastLaneAt(value[i], lane);
         return result;
@@ -16599,7 +16627,7 @@ matrix<T, N, M> WaveReadLaneAt(matrix<T, N, M> value, int lane)
     case cuda: __intrinsic_asm "_waveShuffleMultiple(_getActiveMask(), $0, $1)";
     case hlsl: __intrinsic_asm "WaveReadLaneAt";
     default:
-        matrix<T,N,M> result;
+        matrix<T,N,M> result = __undefined;
         for (int i = 0; i < N; ++i)
             result[i] = WaveReadLaneAt(value[i], lane);
         return result;
@@ -17069,7 +17097,7 @@ matrix<T,N,M> WaveMulti$(opName.name)(matrix<T,N,M> value, uint4 mask)
     case cuda:
         __intrinsic_asm "_wave$(opName.name)Multiple($1.x, $0)";
     default:
-        matrix<T, N, M> result;
+        matrix<T, N, M> result = __undefined;
         for (int i = 0; i < N; ++i)
             result[i] = WaveMulti$(opName.name)(value[i], mask);
         return result;
@@ -17180,7 +17208,7 @@ matrix<T,N,M> WaveMultiPrefix$(opName.name)(matrix<T,N,M> value, uint4 mask)
         __intrinsic_asm "_wavePrefix$(opName.cudaName)Multiple($1.x, $0) $(opName.cudaExtraOperation)";
     ${{{{ } }}}}
     default:
-        matrix<T, N, M> result;
+        matrix<T, N, M> result = __undefined;
         for (int i = 0; i < N; ++i)
             result[i] = WaveMultiPrefix$(opName.name)(value[i], mask);
         return result;
@@ -17263,7 +17291,7 @@ matrix<T, N, M> WaveMulti$(opName.name)(matrix<T, N, M> value, uint4 mask)
     case cuda:
         __intrinsic_asm "_wave$(opName.name)Multiple($1.x, $0)";
     default:
-        matrix<T, N, M> result;
+        matrix<T, N, M> result = __undefined;
         [ForceUnroll]
         for (int i = 0; i < N; ++i)
             result[i] = WaveMulti$(opName.name)(value[i], mask);
@@ -17355,7 +17383,7 @@ __generic<T : __BuiltinArithmeticType, let N : int, let M : int>
 [require(glsl_spirv, subgroup_partitioned)]
 matrix<T, N, M> WaveMultiPrefix$(opName.name)(matrix<T, N, M> value, uint4 mask)
 {
-    matrix<T, N, M> result;
+    matrix<T, N, M> result = __undefined;
     [ForceUnroll]
     for (int i = 0; i < N; ++i)
         result[i] = WaveMultiPrefix$(opName.name)(value[i], mask);
@@ -17429,7 +17457,7 @@ matrix<T, N, M> WaveMultiBit$(opName.name)(matrix<T, N, M> value, uint4 mask)
     case cuda:
         __intrinsic_asm "_wave$(opName.name)Multiple($1.x, $0)";
     default:
-        matrix<T,N,M> result;
+        matrix<T,N,M> result = __undefined;
         [ForceUnroll]
         for (int i = 0; i < N; ++i)
             result[i] = WaveMultiBit$(opName.name)(value[i], mask);
@@ -17540,7 +17568,7 @@ ${{{{
     }
 }}}}
     default:
-        matrix<T,N,M> result;
+        matrix<T,N,M> result = __undefined;
         [ForceUnroll]
         for (int i = 0; i < N; ++i)
             result[i] = WaveMultiPrefix$(opName.name)(value[i], mask);
@@ -20714,6 +20742,7 @@ struct HitObject
                 let direction = Ray.Direction;
                 let tmin = Ray.TMin;
                 let tmax = Ray.TMax;
+                __return_val = __undefined;
                 spirv_asm
                 {
                     OpExtension "SPV_NV_shader_invocation_reorder";
@@ -20757,6 +20786,7 @@ struct HitObject
         __target_switch
         {
         case hlsl:
+            __return_val = __undefined;
             __traceMotionRayHLSL(
                 AccelerationStructure,
                 RayFlags,
@@ -20806,6 +20836,7 @@ struct HitObject
                 let direction = Ray.Direction;
                 let tmin = Ray.TMin;
                 let tmax = Ray.TMax;
+                __return_val = __undefined;
                 spirv_asm
                 {
                     OpExtension "SPV_NV_shader_invocation_reorder";
@@ -20902,6 +20933,7 @@ struct HitObject
                 let direction = Ray.Direction;
                 let tmin = Ray.TMin;
                 let tmax = Ray.TMax;
+                __return_val = __undefined;
                 spirv_asm
                 {
                     OpExtension "SPV_NV_shader_invocation_reorder";
@@ -20977,6 +21009,7 @@ struct HitObject
             let direction = Ray.Direction;
             let tmin = Ray.TMin;
             let tmax = Ray.TMax;
+            __return_val = __undefined;
             spirv_asm
             {
                 OpExtension "SPV_NV_ray_tracing_motion_blur";
@@ -21066,6 +21099,7 @@ struct HitObject
             let direction = Ray.Direction;
             let tmin = Ray.TMin;
             let tmax = Ray.TMax;
+            __return_val = __undefined;
             spirv_asm
             {
                 OpExtension "SPV_NV_shader_invocation_reorder";
@@ -21134,6 +21168,7 @@ struct HitObject
             let direction = Ray.Direction;
             let tmin = Ray.TMin;
             let tmax = Ray.TMax;
+            __return_val = __undefined;
             spirv_asm
             {
                 OpExtension "SPV_NV_ray_tracing_motion_blur";
@@ -21179,6 +21214,7 @@ struct HitObject
                 let direction = Ray.Direction;
                 let tmin = Ray.TMin;
                 let tmax = Ray.TMax;
+                __return_val = __undefined;
                 spirv_asm
                 {
                     OpExtension "SPV_NV_shader_invocation_reorder";
@@ -21216,6 +21252,7 @@ struct HitObject
                 let direction = Ray.Direction;
                 let tmin = Ray.TMin;
                 let tmax = Ray.TMax;
+                __return_val = __undefined;
                 spirv_asm
                 {
                     OpExtension "SPV_NV_ray_tracing_motion_blur";
@@ -21253,6 +21290,7 @@ struct HitObject
             __glslMakeNop(__return_val);
         case cuda: __intrinsic_asm "slangOptixMakeNopHitObject";
         case spirv:
+            __return_val = __undefined;
             spirv_asm
             {
                 OpExtension "SPV_NV_shader_invocation_reorder";
@@ -22509,7 +22547,7 @@ func saturated_cooperation_using<A, B, C>(
         // The representative lanes for all lanes
         var allRepresentatives = WaveActiveBitOr(ourRepresentative);
 
-        C ret;
+        C ret = __undefined;
 
         // Iterate over set bits in mask from low to high.
         // In each iteration the lowest bit is cleared.
@@ -22798,6 +22836,7 @@ ${
         case glsl:
             __intrinsic_asm "textureFootprintNV($p, $*2)";
         case spirv:
+            footprint = __undefined;
             return spirv_asm {
                 OpCapability ImageFootprintNV;
                 OpExtension "SPV_NV_shader_image_footprint";
@@ -22826,6 +22865,7 @@ ${
         case glsl:
             __intrinsic_asm "textureFootprintNV($p, $*2)";
         case spirv:
+            footprint = __undefined;
             return spirv_asm {
                 OpCapability ImageFootprintNV;
                 OpExtension "SPV_NV_shader_image_footprint";
@@ -22855,6 +22895,7 @@ ${
         case glsl:
             __intrinsic_asm "textureFootprintClampNV($p, $*2)";
         case spirv:
+            footprint = __undefined;
             return spirv_asm {
                 OpCapability ImageFootprintNV;
                 OpCapability MinLod;
@@ -22886,6 +22927,7 @@ ${
         case glsl:
             __intrinsic_asm "textureFootprintClampNV($p, $*2)";
         case spirv:
+            footprint = __undefined;
             return spirv_asm {
                 OpCapability ImageFootprintNV;
                 OpCapability MinLod;
@@ -22916,6 +22958,7 @@ ${
         case glsl:
             __intrinsic_asm "textureFootprintLodNV($p, $*2)";
         case spirv:
+            footprint = __undefined;
             return spirv_asm {
                 OpCapability ImageFootprintNV;
                 OpExtension "SPV_NV_shader_image_footprint";
@@ -22950,6 +22993,7 @@ ${{{
         case glsl:
             __intrinsic_asm "textureFootprintGradNV($p, $*2)";
         case spirv:
+            footprint = __undefined;
             return spirv_asm {
                 OpCapability ImageFootprintNV;
                 OpExtension "SPV_NV_shader_image_footprint";
@@ -22981,6 +23025,7 @@ ${{{
         case glsl:
             __intrinsic_asm "textureFootprintGradClampNV($p, $*2)";
         case spirv:
+            footprint = __undefined;
             return spirv_asm {
                 OpCapability ImageFootprintNV;
                 OpCapability MinLod;
@@ -26294,7 +26339,7 @@ struct CoopVec<T : __BuiltinArithmeticType, let N : int> : IArray<T>, IArithmeti
         case optix_coopvec:
             __intrinsic_asm "optixCoopVecLoad<$TR>((CUdeviceptr)(&($0)))";
         default:
-            CoopVec<T,N> result;
+            CoopVec<T,N> result = __undefined;
             for(int i = 0; i < N; ++i)
                 result[i] = data[i + __byteToElemOffset<T>(byteOffset16ByteAligned)];
             return result;

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -164,6 +164,11 @@ Type* SharedASTBuilder::getOverloadedType()
     return m_overloadedType;
 }
 
+Type* SharedASTBuilder::getUndefinedLiteralType()
+{
+    return m_astBuilder->getOrCreate<UndefinedLiteralType>();
+}
+
 void SharedASTBuilder::registerBuiltinDecl(Decl* decl, BuiltinTypeModifier* modifier)
 {
     auto type = DeclRefType::create(m_astBuilder, makeDeclRef<Decl>(decl));

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -48,6 +48,7 @@ public:
     Type* getBottomType();
     Type* getInitializerListType();
     Type* getOverloadedType();
+    Type* getUndefinedLiteralType();
 
     SyntaxClass<NodeBase> findSyntaxClass(Name* name);
 

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -910,4 +910,10 @@ public:
     FIDDLE() List<SPIRVAsmInst> insts;
 };
 
+FIDDLE()
+class UndefinedLiteralExpr : public Expr
+{
+    FIDDLE(...)
+};
+
 } // namespace Slang

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -94,6 +94,8 @@ FIDDLE() namespace Slang
 
         kConversionCost_GenericParamUpcast = 1,
         kConversionCost_LambdaToFunc = 1,
+        kConversionCost_FromUndefinedLiteral = 1,
+
         kConversionCost_UnconstraintGenericParam = 20,
         kConversionCost_SizedArrayToUnsizedArray = 30,
 

--- a/source/slang/slang-ast-type.cpp
+++ b/source/slang/slang-ast-type.cpp
@@ -1421,4 +1421,14 @@ bool isNonCopyableType(Type* type)
     return false;
 }
 
+void UndefinedLiteralType::_toTextOverride(StringBuilder& out)
+{
+    out.append("undefined-value literal");
+}
+
+Type* UndefinedLiteralType::_createCanonicalTypeOverride()
+{
+    return this;
+}
+
 } // namespace Slang

--- a/source/slang/slang-ast-type.h
+++ b/source/slang/slang-ast-type.h
@@ -1179,7 +1179,17 @@ class ModifiedType : public Type
     Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 };
 
-bool isCopyableType(Type* type);
+// The type of an `__undefined` literal expression.
+FIDDLE()
+class UndefinedLiteralType : public Type
+{
+    FIDDLE(...)
+
+    void _toTextOverride(StringBuilder& out);
+    Type* _createCanonicalTypeOverride();
+};
+
+bool isCopyableType(Type * type);
 bool isNonCopyableType(Type* type);
 
 } // namespace Slang

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -1926,6 +1926,12 @@ Expr* SemanticsExprVisitor::visitStringLiteralExpr(StringLiteralExpr* expr)
     return expr;
 }
 
+Expr* SemanticsExprVisitor::visitUndefinedLiteralExpr(UndefinedLiteralExpr* expr)
+{
+    expr->type = getASTBuilder()->getSharedASTBuilder()->getUndefinedLiteralType();
+    return expr;
+}
+
 IntVal* SemanticsVisitor::getIntVal(IntegerLiteralExpr* expr)
 {
     return m_astBuilder->getIntVal(expr->type.type, expr->value);

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -3017,6 +3017,7 @@ public:
     Expr* visitIntegerLiteralExpr(IntegerLiteralExpr* expr);
     Expr* visitFloatingPointLiteralExpr(FloatingPointLiteralExpr* expr);
     Expr* visitStringLiteralExpr(StringLiteralExpr* expr);
+    Expr* visitUndefinedLiteralExpr(UndefinedLiteralExpr* expr);
 
     Expr* visitIndexExpr(IndexExpr* subscriptExpr);
 

--- a/source/slang/slang-core-module-textures.h
+++ b/source/slang/slang-core-module-textures.h
@@ -30,6 +30,12 @@ static const struct BaseTextureAccessInfo
     {"Feedback", SLANG_RESOURCE_ACCESS_FEEDBACK},
 };
 
+//
+// TODO: This entire file and its implementation approach is a sign that something
+// should have been fixed in how the `.meta.slang` generation logic was being structured
+// and/or implemented. Going back to just having raw C++ code bashing strings together
+// is not the right solution for this kind of problem.
+//
 struct TextureTypeInfo
 {
     TextureTypeInfo(
@@ -68,6 +74,7 @@ public:
         const char* funcName,
         const String& glsl,
         const String& cuda,
+        const String& spirvPrefixBeforeASMBlocks,
         const String& spirvDefault,
         const String& spirvRWDefault,
         const String& spirvCombined,
@@ -76,26 +83,28 @@ public:
     void writeFuncWithSig(
         const char* funcName,
         const String& sig,
-        const String& glsl = String{},
-        const String& spirvDefault = String{},
-        const String& spirvRWDefault = String{},
-        const String& spirvCombined = String{},
-        const String& cuda = String{},
-        const String& metal = String{},
-        const String& wgsl = String{},
-        const ReadNoneMode readNoneMode = ReadNoneMode::Never);
+        const String& glsl,
+        const String& spirvPrefixBeforeASMBlocks,
+        const String& spirvDefault,
+        const String& spirvRWDefault,
+        const String& spirvCombined,
+        const String& cuda,
+        const String& metal,
+        const String& wgsl,
+        const ReadNoneMode readNoneMode);
     void writeFunc(
         const char* returnType,
         const char* funcName,
         const String& params,
-        const String& glsl = String{},
-        const String& spirvDefault = String{},
-        const String& spirvRWDefault = String{},
-        const String& spirvCombined = String{},
-        const String& cuda = String{},
-        const String& metal = String{},
-        const String& wgsl = String{},
-        const ReadNoneMode readNoneMode = ReadNoneMode::Never);
+        const String& glsl,
+        const String& spirvPrefixBeforeASMBlocks,
+        const String& spirvDefault,
+        const String& spirvRWDefault,
+        const String& spirvCombined,
+        const String& cuda,
+        const String& metal,
+        const String& wgsl,
+        const ReadNoneMode readNoneMode);
 
     // A pointer to a string representing the current level of indentation
     const char* i;

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -2389,6 +2389,7 @@ void CLikeSourceEmitter::defaultEmitInstExpr(IRInst* inst, const EmitOpInfo& inO
         break;
 
     case kIROp_LoadFromUninitializedMemory:
+    case kIROp_DeliberatelyUninitialized:
     case kIROp_Poison:
     case kIROp_DefaultConstruct:
         m_writer->emit(getName(inst));
@@ -3247,6 +3248,7 @@ void CLikeSourceEmitter::_emitInst(IRInst* inst)
         emitLiveness(inst);
         break;
     case kIROp_LoadFromUninitializedMemory:
+    case kIROp_DeliberatelyUninitialized:
     case kIROp_Poison:
     case kIROp_DefaultConstruct:
         {

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -4539,6 +4539,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             result = emitGetStringHash(inst);
             break;
         case kIROp_LoadFromUninitializedMemory:
+        case kIROp_DeliberatelyUninitialized:
         case kIROp_Poison:
             result = emitOpUndef(parent, inst, inst->getDataType());
             break;

--- a/source/slang/slang-emit-vm.cpp
+++ b/source/slang/slang-emit-vm.cpp
@@ -494,6 +494,7 @@ public:
         {
         case kIROp_Poison:
         case kIROp_LoadFromUninitializedMemory:
+        case kIROp_DeliberatelyUninitialized:
             {
                 // We basically handle an undefined value by allocating a
                 // temporary and then not initializing it.

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -2145,6 +2145,7 @@ InstPair ForwardDiffTranscriber::transcribeInstImpl(IRBuilder* builder, IRInst* 
 
     case kIROp_Poison:
     case kIROp_LoadFromUninitializedMemory:
+    case kIROp_DeliberatelyUninitialized:
         return transcribeUndefined(builder, origInst);
 
     case kIROp_Reinterpret:

--- a/source/slang/slang-ir-autodiff-primal-hoist.cpp
+++ b/source/slang/slang-ir-autodiff-primal-hoist.cpp
@@ -2668,6 +2668,7 @@ static bool shouldStoreInst(IRInst* inst)
     case kIROp_ExtractExistentialType:
     case kIROp_ExtractExistentialWitnessTable:
     case kIROp_LoadFromUninitializedMemory:
+    case kIROp_DeliberatelyUninitialized:
     case kIROp_Poison:
     case kIROp_GetSequentialID:
     case kIROp_GetStringHash:

--- a/source/slang/slang-ir-insts-stable-names.lua
+++ b/source/slang/slang-ir-insts-stable-names.lua
@@ -685,5 +685,5 @@ return {
 	["StoreBase.copyLogical"] = 681,
 	["MakeStorageTypeLoweringConfig"] = 682,
 	["Decoration.experimentalModule"] = 683,
-	["Undefined.DeliberatelyUninitialized"] = 680,
+	["Undefined.DeliberatelyUninitialized"] = 684,
 }

--- a/source/slang/slang-ir-insts-stable-names.lua
+++ b/source/slang/slang-ir-insts-stable-names.lua
@@ -685,4 +685,5 @@ return {
 	["StoreBase.copyLogical"] = 681,
 	["MakeStorageTypeLoweringConfig"] = 682,
 	["Decoration.experimentalModule"] = 683,
+	["Undefined.DeliberatelyUninitialized"] = 680,
 }

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -3633,6 +3633,7 @@ $(type_info.return_type) $(type_info.method_name)(
     IRInst* emitGpuForeach(List<IRInst*> args);
 
     IRLoadFromUninitializedMemory* emitLoadFromUninitializedMemory(IRType* type);
+    IRDeliberatelyUninitialized* emitDeliberatelyUninitialized(IRType* type);
     IRPoison* emitPoison(IRType* type);
 
     IRInst* emitReinterpret(IRInst* type, IRInst* value);

--- a/source/slang/slang-ir-insts.lua
+++ b/source/slang/slang-ir-insts.lua
@@ -769,6 +769,23 @@ local insts = {
 		--
 		{ LoadFromUninitializedMemory = {} },
 
+		-- A value representing a deliberate choice by a programmer to *not* initialize a variable/field/etc.
+		--
+		-- Storing a `DeliberatelyUninitialized` into a variable (or other memory location)
+		-- communicates that a programmer believes their code will fully initialize that
+		-- memory before it is ever read on any execution path, but that the code they
+		-- use to achieve that initialization is beyond the capabilities of the Slang front-end
+		-- initialization checking to validate.
+		--
+		-- If the compiler can prove that some operation *must* (if executed) observe
+		-- this undefined value, when reading from a variable, then the compiler is still
+		-- permitted to diagnose an error.  If, however, the compiler cannot rule out the
+		-- possibility that such an operation would instead observe a different value
+		-- (perhaps a value `store`d to an address that might alias the one being `load`ed
+		-- from), then it should presume that such an alternative value will be observed.
+		--
+		{ DeliberatelyUninitialized = {} },
+
 		-- An undefined value that is infectious.
 		--
 		-- Semantically, a poison value of some type T can be thought of as a

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -2069,6 +2069,7 @@ static LegalVal legalizeInst(
         result = legalizePrintf(context, args);
         break;
     case kIROp_LoadFromUninitializedMemory:
+    case kIROp_DeliberatelyUninitialized:
     case kIROp_Poison:
         return legalizeUndefined(context, inst);
     case kIROp_GpuForeach:

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3018,6 +3018,14 @@ IRLoadFromUninitializedMemory* IRBuilder::emitLoadFromUninitializedMemory(IRType
     return inst;
 }
 
+IRDeliberatelyUninitialized* IRBuilder::emitDeliberatelyUninitialized(IRType* type)
+{
+    auto inst =
+        createInst<IRDeliberatelyUninitialized>(this, kIROp_DeliberatelyUninitialized, type);
+    addInst(inst);
+    return inst;
+}
+
 IRPoison* IRBuilder::emitPoison(IRType* type)
 {
     auto inst = createInst<IRPoison>(this, kIROp_Poison, type);
@@ -8346,6 +8354,7 @@ bool IRInst::mightHaveSideEffects(SideEffectAnalysisOptions options)
 
         // Undefined values are treated as having no side effects.
     case kIROp_LoadFromUninitializedMemory:
+    case kIROp_DeliberatelyUninitialized:
     case kIROp_Poison:
 
     case kIROp_Nop:

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -4935,6 +4935,25 @@ struct ExprLoweringVisitorBase : public ExprVisitor<Derived, LoweredValInfo>
         UNREACHABLE_RETURN(LoweredValInfo());
     }
 
+    LoweredValInfo visitUndefinedLiteralExpr(UndefinedLiteralExpr* expr)
+    {
+        //
+        // We will lower an undefined-value literal to a
+        // `deliberatelyUninitialized` value of the corresponding type
+        // (the `IRDeliberatelyUninitialized` instruction type
+        // is a subtype of the more general `IRUndefined`, and indicates
+        // the specific semantics of `__undefined` should be used for
+        // this particular value in IR analysis passes).
+        //
+
+        auto builder = context->irBuilder;
+
+        auto type = lowerType(context, expr->type);
+        auto undefinedValue = builder->emitDeliberatelyUninitialized(type);
+
+        return LoweredValInfo::simple(undefinedValue);
+    }
+
     LoweredValInfo visitSPIRVAsmExpr(SPIRVAsmExpr* expr)
     {
         // Although the surface syntax can have an empty ASM block, the IR asm

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -7091,6 +7091,13 @@ static NodeBase* parseTreatAsDifferentiableExpr(Parser* parser, void* /*userData
     return noDiffExpr;
 }
 
+static NodeBase* parseUndefinedLiteralExpr(Parser* parser, void* /*userData*/)
+{
+    auto undefinedLiteralExpr = parser->astBuilder->create<UndefinedLiteralExpr>();
+    return undefinedLiteralExpr;
+}
+
+
 static bool _isFinite(double value)
 {
     // Lets type pun double to uint64_t, so we can detect special double values
@@ -9689,6 +9696,7 @@ static const SyntaxParseInfo g_parseSyntaxEntries[] = {
     _makeParseExpr("alignof", parseAlignOfExpr),
     _makeParseExpr("countof", parseCountOfExpr),
     _makeParseExpr("__getAddress", parseAddressOfExpr),
+    _makeParseExpr("__undefined", parseUndefinedLiteralExpr),
 };
 
 ConstArrayView<SyntaxParseInfo> getSyntaxParseInfos()


### PR DESCRIPTION
This change adds a new form of literal expression, `__undefined`, which can be used as the initial value for variables to indicate that the compiler should emit no code to compute or store an initial value (beyond whatever might happen to be required for a downstream compiler to accept the Slang compiler's output).

This feature is largely motivated by my ongoing work to clean up the Slang language and compiler's rules around checking of initialization behavior. A common pattern in existing code is that types such as arrays will be initialized using a loop that writes to individual elements:

    int a[10];
    for(int i = 0; i < 10; ++i)
        a[i] = i;
    doSomethingWith(a[someIndex]);

In order for the compiler to validate that the read from `a[someIndex]` is valid (does not access an uninitialized memory location), for an unknown value of `someIndex`, the compiler must confirm that `a` has been fully initialized prior to the call, which in practice means that each of its elements has been fully initialized. While the above case is straightforward, and some compilers can analyze such loops to confirm initialization status, we do not have the necessary analysis code in Slang at present, and there will always be cases that are too complex for static analysis to handle.

To date we have been dealing with situations like this by simply making our checking for initialization very conservative. The Slang compiler only diagnoses an issue when it can prove that a read (or read-modify-write) access would *definitely* access an uninitialized memory location, and those diagnostics are currently only warnings, rather than errors. It is desirable to tighten up this behavior, but doing so means that a lot of existing code written in an idiomatic fashion would start to generate errors. We need to provide options for users to make such code compatible with any upcoming language version with more strict initialization rules.

For the example above, a conventional way to silence any compiler diagnostic about the access `a[someIndex]` would be to explicitly initialize `a` as part of its declaration, e.g.:

    int a[10] = { 0 };

For small arrays of simple types, such an approach might be fine, but many users of Slang end up working with larger arrays and/or complex types, where the cost of initializing an array up front, only to execute a loop that overwrites all those initial values, is undesirable.

The new `__undefined` literal provides a way for users to indicate to the compiler that they are intentionally leaving a variable in an undefined state at the point of declaration, but that they believe that their code ensures the prior to any read access the variable (or the specific memory location being read) will have been fully initialized to some well-defined value.

Note that the compiler can (and should) still diagnose an problem if it can prove that a read access will access a memory location containing an `__undefined` value, so this feature does not simply give programmers a way to "turn off" the checking logic. In brief, the desired rules that a new initialization checking pass should implement are as follows:

* If the compiler determines that an access *could* (if executed) read uninitialized memory, it will emit a diagnostic.
* If the compiler can prove that an access *will* (if executed) read memory with `__undefined` contents, it will emit a diagnostic.
* Otherwise, no diagnostic should be emitted for that access.

Note that this change does *not* include a new checking pass that implements the above rules and takes advantage of the information provided by `__undefined` initializers; this change is just concerned with putting the infrastructure in place.

In addition to adding the `__undefined` literal expression, this change also updates the code for the Slang builtin modules to make use of `__undefined` in places where the (in-progress) validation pass would otherwise emit a diagnostic. These changes fall into two main categories:

* Places where a loop is used to initialize a variable (or `out` parameter) element-by-element.

* Places where a variable (or `out` parameter) is initialized by code inside a `spirv_asm` block (because these blocks are opaque to the compiler's analysis - see issue #9035).