### PR TITLE
Fix #9051: Add atomicAdd wrapper for signed int64_t on CUDA

### DIFF
--- a/prelude/slang-cuda-prelude.h
+++ b/prelude/slang-cuda-prelude.h
@@ -2245,17 +2245,23 @@ struct ByteAddressBuffer
 
 // Signed 64-bit atomic wrappers
 // CUDA only supports unsigned long long atomics, so we cast signed to unsigned
-__device__ __forceinline__ long long atomicExch(long long* address, long long val)
+// Use longlong type with explicit unsigned long long casts for platform portability
+__device__ __forceinline__ longlong atomicExch(longlong* address, longlong val)
 {
-    return (long long)atomicExch((unsigned long long*)address, (unsigned long long)val);
+    return (longlong)atomicExch((unsigned long long*)address, (unsigned long long)val);
 }
 
-__device__ __forceinline__ long long atomicCAS(long long* address, long long compare, long long val)
+__device__ __forceinline__ longlong atomicCAS(longlong* address, longlong compare, longlong val)
 {
-    return (long long)atomicCAS(
+    return (longlong)atomicCAS(
         (unsigned long long*)address,
         (unsigned long long)compare,
         (unsigned long long)val);
+}
+
+__device__ __forceinline__ longlong atomicAdd(longlong* address, longlong val)
+{
+    return (longlong)atomicAdd((unsigned long long*)address, (unsigned long long)val);
 }
 
 // Float bitwise atomic compare-and-swap

--- a/tests/bugs/gh-9051-int64-atomic-add-cuda.slang
+++ b/tests/bugs/gh-9051-int64-atomic-add-cuda.slang
@@ -1,0 +1,16 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -stage compute -entry computeMain
+// Test int64_t atomic operations on CUDA
+//CHECK: atomicAdd
+
+RWStructuredBuffer<int64_t> buffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    int64_t oldValue;
+    // This should compile without errors and generate atomicAdd call
+    InterlockedAdd(buffer[0], 1, oldValue);
+
+    // Also test without the old value output
+    InterlockedAdd(buffer[1], 42);
+}


### PR DESCRIPTION
CUDA only provides atomicAdd for unsigned long long, not signed.