### PR TITLE
Fix int64 typedef cuda by making it 

### DIFF
--- a/prelude/slang-cuda-prelude.h
+++ b/prelude/slang-cuda-prelude.h
@@ -281,10 +281,18 @@ typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
 typedef size_t uintptr_t;
 
-#endif
-
 typedef long long longlong;
 typedef unsigned long long ulonglong;
+
+#else
+
+// When not using NVRTC, match the platform's int64_t definition for signed type
+// On Linux: int64_t is 'long', on Windows: int64_t is 'long long'
+typedef int64_t longlong;
+// ulonglong must remain 'unsigned long long' to match CUDA's atomic operations
+typedef unsigned long long ulonglong;
+
+#endif
 
 typedef unsigned char uchar;
 typedef unsigned short ushort;

--- a/tests/bugs/gh-9053-int64-kernel-param.slang
+++ b/tests/bugs/gh-9053-int64-kernel-param.slang
@@ -1,0 +1,14 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -stage compute -entry computeMain
+// Test int64_t as kernel parameter with platform-aware typedef
+// Verifies that kernel parameter uses 'longlong' type, which adapts to platform:
+//   - On Linux: longlong = long (matches Linux's int64_t)
+//   - On Windows: longlong = long long (matches Windows' int64_t)
+// This ensures ABI compatibility between kernel and wrapper code on all platforms
+//CHECK: computeMain(longlong value_{{[0-9]+}})
+
+[numthreads(1, 1, 1)]
+void computeMain(int64_t value)
+{
+    // Simple kernel that takes int64_t parameter
+    // This should compile and match the platform's int64_t type
+}


### PR DESCRIPTION
- Issue: Kernel parameters with int64_t caused linking errors on Linux
- Fix: Made longlong typedef platform-aware by using typedef int64_t longlong in non-NVRTC mode

Platform's int64_t -->  longlong becomes 
Linux - long    
Window - long long