### PR TITLE
Disable Clang optimizations for `Session::get*LibraryCode()` functions

### DIFF
--- a/source/slang-core-module/slang-embedded-core-module-source.cpp
+++ b/source/slang-core-module/slang-embedded-core-module-source.cpp
@@ -329,7 +329,9 @@ struct IntrinsicOpInfo
 #if SLANG_CLANG
 // Clang takes around 10 minutes to compile this file with optimizations, with EarlyCSEPass taking
 // ~95% of the execution time. Disabling optimizations here reduces the compilation time to seconds
-// and has no noticeable impact on run-time performance.
+// and has no noticeable impact on run-time performance. These functions are only called once,
+// either at build time by slang-bootstrap, or on the first run of the slang-compiler library,
+// depending on the value of the SLANG_EMBED_CORE_MODULE CMake option.
 #pragma clang optimize off
 #endif
 


### PR DESCRIPTION
Clang was taking around 10 minutes to compile
`slang-embedded-core-module-source.cpp` with optimizations. Disabling
optimizations for these functions reduced the compilation time to about
12 seconds on my machine (Intel Core Ultra 7 165H), and had no
noticeable impact on run-time performance.

Run-time performance with optimizations:

```
$ hyperfine --shell=none './build/generators/Release/bin/slang-bootstrap -archive-type riff-lz4 -save-core-module-bin-source slang-core-module-generated.h -save-glsl-module-bin-source slang-glsl-module-generated.h'
Benchmark 1: ./build/generators/Release/bin/slang-bootstrap -archive-type riff-lz4 -save-core-module-bin-source slang-core-module-generated.h -save-glsl-module-bin-source slang-glsl-module-generated.h
  Time (mean ± σ):      2.545 s ±  0.035 s    [User: 2.333 s, System: 0.210 s]
  Range (min … max):    2.496 s …  2.620 s    10 runs
```

Run-time performance without optimizations:

```
$ hyperfine --shell=none './build/generators/Release/bin/slang-bootstrap -archive-type riff-lz4 -save-core-module-bin-source slang-core-module-generated.h -save-glsl-module-bin-source slang-glsl-module-generated.h'
Benchmark 1: ./build/generators/Release/bin/slang-bootstrap -archive-type riff-lz4 -save-core-module-bin-source slang-core-module-generated.h -save-glsl-module-bin-source slang-glsl-module-generated.h
  Time (mean ± σ):      2.564 s ±  0.039 s    [User: 2.350 s, System: 0.213 s]
  Range (min … max):    2.512 s …  2.614 s    10 runs
```

Disabling optimizations also makes
`slang-embedded-core-module-source.cpp.o` slightly smaller:

- 7.84 MiB with optimizations,
- 7.37 MiB without optimizations.

Fixes #9054.