### PR TITLE
Mark HLSL only RWStructuredBuffer::IncrementCounter and DecrementCounter

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -6604,6 +6604,7 @@ struct $(item.name)
     /// @return The post-decremented counter value.
     /// @remarks
     /// This function is not implemented when targeting non-HLSL.
+    [require(hlsl)]
     uint DecrementCounter();
 
     /// Get the dimensions of the buffer.
@@ -6630,6 +6631,7 @@ struct $(item.name)
     /// @return The pre-incremented counter value.
     /// @remarks
     /// This function is not implemented when targeting non-HLSL.
+    [require(hlsl)]
     uint IncrementCounter();
 
     /// Load a element from the buffer at the specified location.


### PR DESCRIPTION
These functions are declared without body so seems to turn into implicit target intrinsic that only works for HLSL.

Currently, compiling for SPIRV crashes in `deferStorageToLogicalCasts()` due to `auto calleeFunc = as<IRGlobalValueWithParams>(call->getCallee())` being nullptr since it's a kIROp_Specialize. Working around the crash gives an error message: `hlsl.meta.slang(6062): error 29000: unable to parse target intrinsic snippet: .IncrementCounter`

With proper require it gives error message: 
```
tests/fp16AtomicsRawTestCS.comp(11): error 36107: entrypoint 'cs_main' uses features that are not available in 'compute' stage for 'spirv' compilation target.
void cs_main( uint3 threadID : SV_DispatchThreadID )
     ^~~~~~~
external/nvapi/nvHLSLExtnsInternal.h(89): note: see using of 'IncrementCounter'
    uint index = g_NvidiaExt.IncrementCounter();
                             ^~~~~~~~~~~~~~~~
hlsl.meta.slang(6633): note: see definition of 'IncrementCounter'
hlsl.meta.slang(6632): note: see declaration of 'require'
```

https://github.com/shader-slang/slang/pull/2120 mentions possible implementation of IncrementCounter for other targets.
As an aside, IncrementCounter is also used by NVAPI to indicate HLSL extensions.
