### PR TITLE
DNI: test dxvk-remix PR #116 for struct initialization fixes

### DIFF
--- a/.github/workflows/compile-rtx-remix-shaders-nightly.yml
+++ b/.github/workflows/compile-rtx-remix-shaders-nightly.yml
@@ -75,7 +75,7 @@ jobs:
           enableCrossOsArchive: false
 
       # Build Slang from checked-out source
-      # Uses the same approach as CI: cmake --preset default + cmake --workflow --preset release
+      # Note: We only need slangc.exe, so skip the packaging step
       - name: Build Slang
         run: |
           echo "Building Slang..."
@@ -94,8 +94,8 @@ jobs:
             -DSLANG_ENABLE_SLANG_GLSLANG=ON \
             -DSLANG_ENABLE_TESTS=OFF
 
-          # Build using workflow preset (configure + build + package)
-          cmake --workflow --preset release
+          # Build only (skip packaging to avoid gfx.slang install error)
+          cmake --build --preset release
 
           endTime=$(date +%s)
           duration=$(( (endTime - startTime) / 60 ))


### PR DESCRIPTION
Modify RTX Remix nightly workflow to test NVIDIAGameWorks/dxvk-remix#116, which fixes struct initialization for DirectPathTextures and IndirectPathTextures to comply with stricter Slang compiler rules (error 41024 in v2025.23.1+).

Changes:
- Fetch and checkout PR #116 (init-shader-structs branch)
- Remove shallow clone to enable PR fetching
- Update submodules after checkout