### PR TITLE
Fix Linux CUDA detection in render-test

### DIFF
--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -1650,6 +1650,7 @@ static SlangResult _innerMain(
                 if (SLANG_FAILED(
                         spSessionCheckPassThroughSupport(session, SLANG_PASS_THROUGH_NVRTC)))
                     return SLANG_FAIL;
+                break;
 #else
                 return SLANG_FAIL;
 #endif


### PR DESCRIPTION
Fixes #9170

Add a missing break statement that was causing the CUDA startup check to fall through to the CPU case and fail when no C++ compiler was detected.