### PR TITLE
ci: fix RTX Remix workflow by skipping CPack packaging

### DIFF
--- a/.github/workflows/compile-rtx-remix-shaders-nightly.yml
+++ b/.github/workflows/compile-rtx-remix-shaders-nightly.yml
@@ -75,7 +75,7 @@ jobs:
           enableCrossOsArchive: false
 
       # Build Slang from checked-out source
-      # Uses the same approach as CI: cmake --preset default + cmake --workflow --preset release
+      # Note: We only need slangc.exe, so skip the packaging step to avoid CPack errors
       - name: Build Slang
         run: |
           echo "Building Slang..."
@@ -94,8 +94,8 @@ jobs:
             -DSLANG_ENABLE_SLANG_GLSLANG=ON \
             -DSLANG_ENABLE_TESTS=OFF
 
-          # Build using workflow preset (configure + build + package)
-          cmake --workflow --preset release
+          # Build only (skip packaging to avoid gfx.slang install error)
+          cmake --build --preset release
 
           endTime=$(date +%s)
           duration=$(( (endTime - startTime) / 60 ))


### PR DESCRIPTION
Fix RTX Remix nightly workflow due to a CPack error when trying to install gfx.slang:

  CMake Error: file INSTALL cannot find "gfx.slang": File exists.

Since this workflow only needs the compiled slangc.exe binary (not a distribution package), we can skip the packaging step entirely by using `cmake --build --preset release`.

This fixes the build failure while preserving the workflow's functionality.

Fixes #8655