### PR TITLE
Issue a warning if requested bindless space index is not available

### DIFF
--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -2363,6 +2363,11 @@ DIAGNOSTIC(39010, Error, expectedSpaceIndex, "expected a register space index af
 DIAGNOSTIC(39011, Error, invalidComponentMask, "invalid register component mask '$0'.")
 
 DIAGNOSTIC(
+    39012,
+    Warning,
+    requestedBindlessSpaceIndexUnavailable,
+    "requested bindless space index '$0' is unavailable, using the next available index '$1'.")
+DIAGNOSTIC(
     39013,
     Warning,
     registerModifierButNoVulkanLayout,

--- a/tests/bug/gh-8937.slang
+++ b/tests/bug/gh-8937.slang
@@ -1,0 +1,14 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -stage compute -entry computeMain -bindless-space-index 0
+
+// Test that we get a warning when the requested bindless space index is unavailable.
+
+// CHECK: warning 39012: requested bindless space index '0' is unavailable, using the next available index '1'.
+uniform StructuredBuffer<DescriptorHandle<Sampler2D>> t;
+uniform DescriptorHandle<RWStructuredBuffer<float4>> buffer;
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    (*buffer)[0] = t[0].SampleLevel(float2(0.0), 0.0);
+}
+


### PR DESCRIPTION
# Issue a warning if requested bindless space index is not available

## Problem

Previously, when a user specified a bindless space index via `-bindless-space-index <index>` (or `slang::CompilerOptionName::BindlessSpaceIndex` in the API) that was already occupied by other shader parameters, the compiler would silently fall back to the next available space index. This behavior was confusing because:

1. Users had no indication that their requested space was unavailable
2. The actual space used could differ from what was explicitly requested
3. This was particularly problematic when specifying index 0 (fixes #8937)

## Solution

The compiler now issues a warning when the requested bindless space index is already in use and a different space must be selected.

## Changes

- Added validation in `findUnusedSpaceIndex()` to detect when the requested space conflicts with existing bindings
- Added a new warning diagnostic to inform users of the conflict and the actual space index being used
- Added test coverage for the new warning behavior

Fixes: #8937 