### PR TITLE
Correct HitTriangleVertexPosition documentation

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -19471,7 +19471,7 @@ uint GeometryIndex()
 /// Get the vertex positions of the currently hit triangle in any-hit or closest-hit shader.
 /// https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_ray_tracing_position_fetch.txt
 /// @param index Index of the vertex (0-2)
-/// @return World-space position of the specified vertex
+/// @return Object-space position of the specified vertex
 /// @remarks Requires ray tracing position fetch extension
 /// @see GL_EXT_ray_tracing_position_fetch
 /// @category raytracing


### PR DESCRIPTION
Fixes #9040 

Corrects the Doxygen return comment for HitTriangleVertexPosition from "World-space" to "Object-space".

The [HitTriangleVertexPosition page on the docs site](https://docs.shader-slang.org/en/latest/external/core-module-reference/global-decls/hittrianglevertexposition-03bh.html) will get this correction with the next Slang release, since that page comes from the stdlib-reference repo, which gets changes pushed to it from this repo by the release workflow.