### PR TITLE
Add workflow_dispatch trigger to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,6 +8,12 @@ permissions:
   id-token: write
 
 on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue or PR number to test with"
+        required: false
+        type: number
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -26,6 +32,7 @@ jobs:
   claude:
     name: Claude Code Assistant
     if: |
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||


### PR DESCRIPTION
Allows manual workflow execution for testing configuration changes without requiring @claude mentions.

Related to #9118