### PR TITLE
Fix subtle bug when looking up symbols during pre-linking step

### DIFF
--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -2313,7 +2313,7 @@ struct IRPrelinkContext : IRSpecContext
         if (auto linkage = originalVal->findDecoration<IRLinkageDecoration>())
         {
             RefPtr<IRSpecSymbol> symbol;
-            if (shared->symbols.tryGetValue(linkage->getMangledName()), symbol)
+            if (shared->symbols.tryGetValue(linkage->getMangledName(), symbol))
             {
                 return symbol->irGlobalValue;
             }


### PR DESCRIPTION
The code uses this statement where the `symbol` parameter is outside the function call, 
Presumably, this compiles since C++ uses the last value in a comma separated set of statements, but leads to incorrect behavior since symbols that have entries will fail this check and not use their existing values.

```cpp
RefPtr<IRSpecSymbol> symbol;
if (shared->symbols.tryGetValue(linkage->getMangledName()), symbol) { /* */ }
```

It should be: 
```cpp
RefPtr<IRSpecSymbol> symbol;
if (shared->symbols.tryGetValue(linkage->getMangledName(), symbol)) { /* */ }
```