### PR TITLE
Fix the issue that produce long mangled name

### DIFF
--- a/source/slang/slang-ir-clone.cpp
+++ b/source/slang/slang-ir-clone.cpp
@@ -138,23 +138,28 @@ static void specializeLinkageDecoration(IRInst* target, IRSpecialize* oldInst, I
             {
                 specializationProvider = targetAsSpec;
             }
+
+            DigestBuilder<SHA1> digestBuilder;
             for (UInt i = 0; i < specializationProvider->getArgCount(); ++i)
             {
                 auto arg = specializationProvider->getArg(i);
-                sb.append(i);
                 if (auto typeLinkage = arg->findDecoration<IRLinkageDecoration>())
                 {
-                    sb.append(typeLinkage->getMangledName());
+                    digestBuilder.append(typeLinkage->getMangledName().begin());
                 }
                 else
                 {
                     // getTypeNameHint may produce a name with characters that can't
                     // be part of an identifier, so we need to filter it afterward.
-                    StringBuilder tmp;
-                    getTypeNameHint(tmp, arg);
-                    emitNameForLinkage(sb, tmp.getUnownedSlice());
+                    StringBuilder typeNameHint;
+                    StringBuilder linkageName;
+                    getTypeNameHint(typeNameHint, arg);
+                    emitNameForLinkage(linkageName, typeNameHint.getUnownedSlice());
+                    digestBuilder.append(linkageName.getUnownedSlice().begin());
                 }
             }
+            sb.append(digestBuilder.finalize().toString());
+
             if (auto previousLinkage = target->findDecoration<IRLinkageDecoration>())
             {
                 // Overwrite the previous linkage decoration, since it was not specialized


### PR DESCRIPTION
Close #9211.

We use the SHA1 to combine all the arguments's linkage mangled name as the final name for the specialized linkage mangle name.

Previously, it was always appending everything together, so it could be explode the name length very fast.