### PR TITLE
Add test-server timing and diagnostic infrastructure

### DIFF
--- a/.github/workflows/vk-gl-cts-nightly.yml
+++ b/.github/workflows/vk-gl-cts-nightly.yml
@@ -94,6 +94,7 @@ jobs:
         run: |
           Expand-Archive VK-GL-CTS_WithSlang-0.0.7-win64.zip
 
+          copy ${{ github.workspace }}\build\Release\bin\slang.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64\slang.dll
           copy ${{ github.workspace }}\build\Release\bin\slang-compiler.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64\slang-compiler.dll
           copy ${{ github.workspace }}\build\Release\bin\slang-glslang.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64\slang-glslang.dll
           copy ${{ github.workspace }}\build\Release\bin\slang-glsl-module.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64\slang-glsl-module.dll

--- a/.github/workflows/vk-gl-cts-nightly.yml
+++ b/.github/workflows/vk-gl-cts-nightly.yml
@@ -94,7 +94,6 @@ jobs:
         run: |
           Expand-Archive VK-GL-CTS_WithSlang-0.0.7-win64.zip
 
-          copy ${{ github.workspace }}\build\Release\bin\slang.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64\slang.dll
           copy ${{ github.workspace }}\build\Release\bin\slang-compiler.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64\slang-compiler.dll
           copy ${{ github.workspace }}\build\Release\bin\slang-glslang.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64\slang-glslang.dll
           copy ${{ github.workspace }}\build\Release\bin\slang-glsl-module.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64\slang-glsl-module.dll

--- a/source/compiler-core/slang-test-server-protocol.cpp
+++ b/source/compiler-core/slang-test-server-protocol.cpp
@@ -24,6 +24,7 @@ static const StructRttiInfo _makeExecuteToolTestArgsRtti()
     StructRttiBuilder builder(&obj, "TestServerProtocol::ExecuteToolTestArgs", nullptr);
     builder.addField("toolName", &obj.toolName);
     builder.addField("args", &obj.args);
+    builder.addField("testCommand", &obj.testCommand, StructRttiInfo::Flag::Optional);
     return builder.make();
 }
 /* static */ const StructRttiInfo ExecuteToolTestArgs::g_rttiInfo = _makeExecuteToolTestArgsRtti();
@@ -39,6 +40,7 @@ static const StructRttiInfo _makeExecutionResultRtti()
     builder.addField("debugLayer", &obj.debugLayer);
     builder.addField("result", &obj.result);
     builder.addField("returnCode", &obj.returnCode);
+    builder.addField("executionTimeMs", &obj.executionTimeMs, StructRttiInfo::Flag::Optional);
     return builder.make();
 }
 /* static */ const StructRttiInfo ExecutionResult::g_rttiInfo = _makeExecutionResultRtti();

--- a/source/compiler-core/slang-test-server-protocol.h
+++ b/source/compiler-core/slang-test-server-protocol.h
@@ -7,6 +7,17 @@
 #include "slang-json-value.h"
 #include "slang.h"
 
+// WARNING: ABI Compatibility
+// These structs are part of the binary interface between test-server and pre-built binaries
+// (e.g., VK-GL-CTS). Adding or removing fields will change struct layout and break
+// compatibility, causing memory corruption or crashes.
+//
+// To safely add new fields:
+// 1. First update and release new versions of all pre-built binaries that use this protocol
+// 2. Then add the new fields here
+//
+// The VK-GL-CTS nightly CI workflow will fail if this ABI is broken.
+
 namespace TestServerProtocol
 {
 
@@ -25,9 +36,10 @@ struct ExecuteUnitTestArgs
 
 struct ExecuteToolTestArgs
 {
-    String toolName;   ///< The name of the tool (will be a shared library typically - like
-                       ///< render-test). Doesn't need -tool suffix.
-    List<String> args; ///< Arguments passed to the tool during exectution
+    String toolName;    ///< The name of the tool (will be a shared library typically - like
+                        ///< render-test). Doesn't need -tool suffix.
+    List<String> args;  ///< Arguments passed to the tool during exectution
+    String testCommand; ///< Full test command for diagnostic logging (Optional)
 
     static const UnownedStringSlice g_methodName;
     static const StructRttiInfo g_rttiInfo;
@@ -44,7 +56,8 @@ struct ExecutionResult
     String stdError;
     String debugLayer;
     int32_t result = SLANG_OK;
-    int32_t returnCode = 0; ///< As returned if invoked as command line
+    int32_t returnCode = 0;     ///< As returned if invoked as command line
+    double executionTimeMs = 0; ///< Execution time in milliseconds (Optional)
 
     static const StructRttiInfo g_rttiInfo;
 };

--- a/source/core/slang-http.cpp
+++ b/source/core/slang-http.cpp
@@ -2,6 +2,16 @@
 
 #include "slang-process.h"
 #include "slang-string-util.h"
+#include "slang-test-diagnostics.h"
+
+#include <chrono>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef _WIN32
+#include <pthread.h>
+#include <unistd.h>
+#endif
 
 namespace Slang
 {
@@ -341,6 +351,8 @@ struct SleepState
 
 SlangResult HTTPPacketConnection::waitForResult(Int timeOutInMs)
 {
+    auto startTime = std::chrono::steady_clock::now();
+
     m_readResult = SLANG_OK;
 
     int64_t startTick = 0;
@@ -368,6 +380,13 @@ SlangResult HTTPPacketConnection::waitForResult(Int timeOutInMs)
         // We timed out
         if (timeOutInTicks >= 0 && int64_t(Process::getClockTick()) - startTick >= timeOutInTicks)
         {
+            if (isDiagnosticEnabled("rpc"))
+            {
+                fprintf(
+                    stderr,
+                    "[RPC-TIMEOUT] waitForResult timed out after %lldms\n",
+                    (long long)timeOutInMs);
+            }
             break;
         }
 
@@ -378,6 +397,28 @@ SlangResult HTTPPacketConnection::waitForResult(Int timeOutInMs)
         else
         {
             sleepState.reset();
+        }
+    }
+
+    if (isDiagnosticEnabled("rpc") && m_readState == ReadState::Done)
+    {
+        auto endTime = std::chrono::steady_clock::now();
+        auto duration =
+            std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
+#ifndef _WIN32
+        fprintf(
+            stderr,
+            "[RPC-WAIT] waitForResult completed in %lldms (thread=%lu)\n",
+            (long long)duration,
+            (unsigned long)pthread_self());
+#else
+        fprintf(stderr, "[RPC-WAIT] waitForResult completed in %lldms\n", duration);
+#endif
+
+        // Warn if wait took more than 1 second
+        if (duration > 1000)
+        {
+            fprintf(stderr, "[RPC-WARNING] Slow RPC wait: %lldms\n", (long long)duration);
         }
     }
 
@@ -406,6 +447,8 @@ void HTTPPacketConnection::consumeContent()
 
 SlangResult HTTPPacketConnection::write(const void* content, size_t sizeInBytes)
 {
+    auto startTime = std::chrono::steady_clock::now();
+
     // Write the header
     {
         HTTPHeader header;
@@ -419,6 +462,37 @@ SlangResult HTTPPacketConnection::write(const void* content, size_t sizeInBytes)
 
     // Write the content
     SLANG_RETURN_ON_FAIL(m_writeStream->write(content, sizeInBytes));
+
+    if (isDiagnosticEnabled("rpc"))
+    {
+        auto endTime = std::chrono::steady_clock::now();
+        auto duration =
+            std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime).count();
+#ifndef _WIN32
+        fprintf(
+            stderr,
+            "[RPC-WRITE] HTTPPacketConnection::write size=%zu duration=%lldus (thread=%lu)\n",
+            sizeInBytes,
+            (long long)duration,
+            (unsigned long)pthread_self());
+#else
+        fprintf(
+            stderr,
+            "[RPC-WRITE] HTTPPacketConnection::write size=%zu duration=%lldus\n",
+            sizeInBytes,
+            duration);
+#endif
+
+        // Warn if write took more than 100ms
+        if (duration > 100000)
+        {
+            fprintf(
+                stderr,
+                "[RPC-WARNING] Slow RPC write: %lldus for %zu bytes\n",
+                (long long)duration,
+                sizeInBytes);
+        }
+    }
 
     return SLANG_OK;
 }

--- a/source/core/slang-http.cpp
+++ b/source/core/slang-http.cpp
@@ -480,7 +480,7 @@ SlangResult HTTPPacketConnection::write(const void* content, size_t sizeInBytes)
             stderr,
             "[RPC-WRITE] HTTPPacketConnection::write size=%zu duration=%lldus\n",
             sizeInBytes,
-            duration);
+            (long long)duration);
 #endif
 
         // Warn if write took more than 100ms

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -1115,7 +1115,6 @@ SlangResult File::readAllText(const Slang::String& fileName, String& outText)
     StreamReader reader;
     SLANG_RETURN_ON_FAIL(reader.init(stream));
     SLANG_RETURN_ON_FAIL(reader.readToEnd(outText));
-
     return SLANG_OK;
 }
 

--- a/source/core/slang-process-util.h
+++ b/source/core/slang-process-util.h
@@ -17,12 +17,14 @@ struct ExecuteResult
         standardOutput = String();
         standardError = String();
         debugLayer = String();
+        executionTimeMs = 0;
     }
 
     ResultCode resultCode;
     String standardOutput;
     String standardError;
     String debugLayer;
+    double executionTimeMs = 0; ///< Execution time in milliseconds
 };
 
 struct ProcessUtil

--- a/source/core/slang-stream.cpp
+++ b/source/core/slang-stream.cpp
@@ -1,12 +1,18 @@
 #include "slang-stream.h"
 #ifdef _WIN32
 #include <share.h>
+#include <windows.h>
 #endif
 #include "slang-io.h"
 #include "slang-process.h"
+#include "slang-test-diagnostics.h"
 
 #include <stdio.h>
 #include <thread>
+
+#ifndef _WIN32
+#include <pthread.h>
+#endif
 
 namespace Slang
 {
@@ -191,6 +197,28 @@ SlangResult FileStream::_init(
         return SLANG_E_CANNOT_OPEN;
     }
 
+    // Debug logging for file descriptor tracking
+    if (isDiagnosticEnabled("fd"))
+    {
+#ifdef _WIN32
+        fprintf(
+            stderr,
+            "[FD-DEBUG] Opened '%s' mode='%s' fd=%d (thread=%lu)\n",
+            fileName.getBuffer(),
+            mode,
+            _fileno(m_handle),
+            (unsigned long)GetCurrentThreadId());
+#else
+        fprintf(
+            stderr,
+            "[FD-DEBUG] Opened '%s' mode='%s' fd=%d (thread=%lu)\n",
+            fileName.getBuffer(),
+            mode,
+            fileno(m_handle),
+            (unsigned long)pthread_self());
+#endif
+    }
+
     // Just set the access specified
     m_fileAccess = access;
     return SLANG_OK;
@@ -260,11 +288,9 @@ SlangResult FileStream::read(void* buffer, size_t length, size_t& outBytesRead)
         // If we have reached the end, then reading nothing is ok.
         if (!m_endReached)
         {
-            // Verify EOF using file position.
+            // Use file position to verify EOF, don't rely on feof()
             Int64 currentPos = getPosition();
             Int64 currentSize = 0;
-
-// Save position, seek to end, get size, restore position
 #if defined(_WIN32) || defined(__CYGWIN__)
             _fseeki64(m_handle, 0, SEEK_END);
             currentSize = _ftelli64(m_handle);
@@ -277,7 +303,6 @@ SlangResult FileStream::read(void* buffer, size_t length, size_t& outBytesRead)
 
             if (currentPos >= currentSize)
             {
-                // Confirmed at EOF
                 m_endReached = true;
             }
             else
@@ -320,6 +345,23 @@ void FileStream::close()
 {
     if (m_handle)
     {
+        if (isDiagnosticEnabled("fd"))
+        {
+#ifdef _WIN32
+            fprintf(
+                stderr,
+                "[FD-DEBUG] Closing fd=%d (thread=%lu)\n",
+                _fileno(m_handle),
+                (unsigned long)GetCurrentThreadId());
+#else
+            fprintf(
+                stderr,
+                "[FD-DEBUG] Closing fd=%d (thread=%lu)\n",
+                fileno(m_handle),
+                (unsigned long)pthread_self());
+#endif
+        }
+
         fclose(m_handle);
         m_handle = nullptr;
 

--- a/source/core/slang-test-diagnostics.h
+++ b/source/core/slang-test-diagnostics.h
@@ -1,0 +1,44 @@
+// slang-test-diagnostics.h
+// Diagnostic control for slang-test debugging
+// Enabled via SLANG_TEST_DIAGNOSTICS environment variable
+
+#ifndef SLANG_TEST_DIAGNOSTICS_H
+#define SLANG_TEST_DIAGNOSTICS_H
+
+#include <cstdlib>
+#include <cstring>
+
+namespace Slang
+{
+
+// Check if a diagnostic category is enabled via SLANG_TEST_DIAGNOSTICS env var
+// Categories: timing, timing-phases, rpc, fd, pipe, all
+inline bool isDiagnosticEnabled(const char* category)
+{
+#ifdef _WIN32
+    static const char* diagnostics = []() -> const char*
+    {
+        static char buffer[256];
+        char* buf = nullptr;
+        size_t len = 0;
+        if (_dupenv_s(&buf, &len, "SLANG_TEST_DIAGNOSTICS") == 0 && buf != nullptr)
+        {
+            strncpy_s(buffer, sizeof(buffer), buf, _TRUNCATE);
+            free(buf);
+            return buffer;
+        }
+        return nullptr;
+    }();
+#else
+    static const char* diagnostics = getenv("SLANG_TEST_DIAGNOSTICS");
+#endif
+    if (!diagnostics)
+        return false;
+    if (strcmp(diagnostics, "all") == 0 || strcmp(diagnostics, "1") == 0)
+        return true;
+    return strstr(diagnostics, category) != nullptr;
+}
+
+} // namespace Slang
+
+#endif // SLANG_TEST_DIAGNOSTICS_H

--- a/source/core/slang-test-diagnostics.h
+++ b/source/core/slang-test-diagnostics.h
@@ -5,38 +5,41 @@
 #ifndef SLANG_TEST_DIAGNOSTICS_H
 #define SLANG_TEST_DIAGNOSTICS_H
 
-#include <cstdlib>
-#include <cstring>
+#include "slang-platform.h"
+#include "slang-string.h"
 
 namespace Slang
 {
 
-// Check if a diagnostic category is enabled via SLANG_TEST_DIAGNOSTICS env var
+// Check if a diagnostic category is enabled via SLANG_TEST_DIAGNOSTICS env var.
 // Categories: timing, timing-phases, rpc, fd, pipe, all
+// Thread-safe: reads the env var once and caches the result.
 inline bool isDiagnosticEnabled(const char* category)
 {
-#ifdef _WIN32
-    static const char* diagnostics = []() -> const char*
+    // Cache the environment variable value. The static String is initialized once
+    // in a thread-safe manner (C++11 guarantees thread-safe static initialization).
+    static String diagnostics = []() -> String
     {
-        static char buffer[256];
-        char* buf = nullptr;
-        size_t len = 0;
-        if (_dupenv_s(&buf, &len, "SLANG_TEST_DIAGNOSTICS") == 0 && buf != nullptr)
+        StringBuilder envValue;
+        if (SLANG_SUCCEEDED(PlatformUtil::getEnvironmentVariable(
+                UnownedStringSlice("SLANG_TEST_DIAGNOSTICS"),
+                envValue)))
         {
-            strncpy_s(buffer, sizeof(buffer), buf, _TRUNCATE);
-            free(buf);
-            return buffer;
+            return envValue.toString();
         }
-        return nullptr;
+        return String();
     }();
-#else
-    static const char* diagnostics = getenv("SLANG_TEST_DIAGNOSTICS");
-#endif
-    if (!diagnostics)
+
+    if (diagnostics.getLength() == 0)
         return false;
-    if (strcmp(diagnostics, "all") == 0 || strcmp(diagnostics, "1") == 0)
+    UnownedStringSlice diagSlice = diagnostics.getUnownedSlice();
+    if (diagSlice.caseInsensitiveEquals(UnownedStringSlice("all")) ||
+        diagSlice.caseInsensitiveEquals(UnownedStringSlice("1")))
         return true;
-    return strstr(diagnostics, category) != nullptr;
+    // Case-insensitive substring search
+    String lowerDiag = diagnostics.toLower();
+    String lowerCat = String(category).toLower();
+    return lowerDiag.indexOf(lowerCat) != Index(-1);
 }
 
 } // namespace Slang

--- a/source/core/slang-text-io.cpp
+++ b/source/core/slang-text-io.cpp
@@ -144,6 +144,7 @@ Byte StreamReader::readBufferByte()
 SlangResult StreamReader::readToEnd(String& outString)
 {
     StringBuilder sb(16384);
+
     while (!isEnd())
     {
         auto ch = read();

--- a/source/core/unix/slang-unix-process.cpp
+++ b/source/core/unix/slang-unix-process.cpp
@@ -359,7 +359,11 @@ SlangResult UnixPipeStream::read(void* buffer, size_t length, size_t& outReadByt
 
         outReadBytes = size_t(count);
 
-        // Log pipe read operation if debug enabled
+        // Log pipe read operation if debug enabled.
+        // Note: this writes to stderr directly, which is fine because:
+        // - In the test-server process, stderr is captured by slang-test via
+        //   drainTestServerStderr() and forwarded to the parent's stderr.
+        // - In the slang-test process itself, stderr goes directly to the console.
         if (isDiagnosticEnabled("pipe") && count > 0)
         {
             auto endTime = std::chrono::steady_clock::now();

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -14,6 +14,7 @@
 #include "../../source/core/slang-std-writers.h"
 #include "../../source/core/slang-string-escape-util.h"
 #include "../../source/core/slang-string-util.h"
+#include "../../source/core/slang-test-diagnostics.h"
 #include "../../source/core/slang-token-reader.h"
 #include "../../source/core/slang-type-text-util.h"
 #include "slang-com-helper.h"
@@ -47,6 +48,7 @@
 #include "../../prelude/slang-cpp-types.h"
 
 #include <atomic>
+#include <chrono>
 #include <thread>
 
 #if defined(_WIN32)
@@ -55,6 +57,22 @@ SLANG_RHI_EXPORT_AGILITY_SDK
 #endif
 
 using namespace Slang;
+
+// Helper function to check if phase-level timing is enabled
+static bool isPhaseTimingEnabled()
+{
+    static bool enabled = Slang::isDiagnosticEnabled("timing-phases");
+    return enabled;
+}
+
+// Helper to output phase timing (only when timing-phases is enabled)
+static void reportPhaseTiming(const char* phaseName, double durationMs)
+{
+    if (isPhaseTimingEnabled())
+    {
+        fprintf(stderr, "[TIMING] %s completed: %.3fms\n", phaseName, durationMs);
+    }
+}
 
 // Constants for slang-test specific options
 static const char* kPreserveEmbeddedSourceOption = "-preserve-embedded-source";
@@ -994,7 +1012,15 @@ Result spawnAndWaitExe(
             commandLine.begin());
     }
 
+    // Time the process execution phase
+    auto execStartTime = std::chrono::steady_clock::now();
     Result res = ProcessUtil::execute(cmdLine, outRes);
+    auto execEndTime = std::chrono::steady_clock::now();
+    auto execDurationMs =
+        std::chrono::duration_cast<std::chrono::microseconds>(execEndTime - execStartTime).count() /
+        1000.0;
+    reportPhaseTiming("exe:process-execute", execDurationMs);
+
     if (SLANG_FAILED(res))
     {
         //        fprintf(stderr, "failed to run test '%S'\n", testPath.ToWString());
@@ -1039,7 +1065,16 @@ Result spawnAndWaitSharedLibrary(
             testCmdLine.toString().getBuffer());
     }
 
+    // Time the function lookup phase
+    auto lookupStartTime = std::chrono::steady_clock::now();
     auto func = context->getInnerMainFunc(context->options.binDir, exeName);
+    auto lookupEndTime = std::chrono::steady_clock::now();
+    auto lookupDurationMs =
+        std::chrono::duration_cast<std::chrono::microseconds>(lookupEndTime - lookupStartTime)
+            .count() /
+        1000.0;
+    reportPhaseTiming("sharedlib:function-lookup", lookupDurationMs);
+
     if (func)
     {
         StringBuilder stdErrorString;
@@ -1075,8 +1110,16 @@ Result spawnAndWaitSharedLibrary(
             args.add(cmdArg.getBuffer());
         }
 
+        // Time the execution phase
+        auto execStartTime = std::chrono::steady_clock::now();
         SlangResult res =
             func(&stdWriters, context->getSession(), int(args.getCount()), args.begin());
+        auto execEndTime = std::chrono::steady_clock::now();
+        auto execDurationMs =
+            std::chrono::duration_cast<std::chrono::microseconds>(execEndTime - execStartTime)
+                .count() /
+            1000.0;
+        reportPhaseTiming("sharedlib:execution", execDurationMs);
 
         StdWriters::setSingleton(prevStdWriters);
 
@@ -1221,6 +1264,11 @@ static Result _executeRPC(
     outRes.standardError = exeRes.stdError;
     outRes.standardOutput = exeRes.stdOut;
     outRes.debugLayer = exeRes.debugLayer;
+    outRes.executionTimeMs = exeRes.executionTimeMs;
+
+    // Drain test-server stderr (phase timing diagnostics) before returning
+    // so it appears before the test result
+    context->drainTestServerStderr();
 
     return SLANG_OK;
 }
@@ -1250,6 +1298,7 @@ Result spawnAndWaitTestServer(
 
     args.toolName = exeName;
     args.args = inCmdLine.m_args;
+    args.testCommand = testPath;
 
     return _executeRPC(
         context,
@@ -1719,6 +1768,9 @@ ToolReturnCode spawnAndWait(
 
     const auto finalSpawnType = context->getFinalSpawnType(spawnType);
 
+    // Start timing the test execution
+    auto startTime = std::chrono::steady_clock::now();
+
     SlangResult spawnResult = SLANG_FAIL;
     switch (finalSpawnType)
     {
@@ -1743,6 +1795,14 @@ ToolReturnCode spawnAndWait(
     default:
         break;
     }
+
+    // Calculate execution time
+    auto endTime = std::chrono::steady_clock::now();
+    auto durationMs =
+        std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime).count() / 1000.0;
+
+    // Report execution time (measured locally)
+    context->getTestReporter()->addExecutionTime(durationMs / 1000.0);
 
     if (SLANG_FAILED(spawnResult))
     {

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -311,7 +311,10 @@ void TestContext::drainTestServerStderr()
     if (!stderrStream)
         return;
 
-    // Read any available data from the test-server's stderr and forward to our stderr
+    // Read any available data from the test-server's stderr and forward to our stderr.
+    // This is safe to call while the test-server is running: on Unix, the underlying
+    // UnixPipeStream::read uses poll() which returns immediately when no data is available.
+    // On Windows, the pipe read similarly returns when no data is buffered.
     List<uint8_t> buffer;
     buffer.setCount(4096);
 

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -10,6 +10,7 @@
 #include "../../source/core/slang-platform.h"
 #include "../../source/core/slang-render-api-util.h"
 #include "../../source/core/slang-std-writers.h"
+#include "../../source/core/slang-stream.h"
 #include "../../source/core/slang-string-util.h"
 #include "../../source/core/slang-test-tool-util.h"
 #include "filecheck.h"
@@ -141,6 +142,9 @@ public:
     Slang::JSONRPCConnection* getOrCreateJSONRPCConnection();
     void destroyRPCConnection();
 
+    /// Drain and print any stderr output from test-server processes
+    void drainTestServerStderr();
+
     /// Ctor
     TestContext();
     /// Dtor
@@ -204,6 +208,7 @@ protected:
     };
 
     Slang::List<Slang::RefPtr<Slang::JSONRPCConnection>> m_jsonRpcConnections;
+    Slang::List<Slang::RefPtr<Slang::BufferedReadStream>> m_testServerStderrStreams;
     Slang::List<TestReporter*> m_reporters;
     Slang::List<TestRequirements*> m_testRequirements = nullptr;
 

--- a/tools/slang-test/test-reporter.cpp
+++ b/tools/slang-test/test-reporter.cpp
@@ -3,6 +3,7 @@
 
 #include "../../source/core/slang-process-util.h"
 #include "../../source/core/slang-string-util.h"
+#include "../../source/core/slang-test-diagnostics.h"
 #include "options.h"
 
 #include <mutex>
@@ -326,26 +327,11 @@ static void _appendEncodedTeamCityString(const UnownedStringSlice& in, StringBui
 static void _appendTime(double timeInSec, StringBuilder& out)
 {
     SLANG_ASSERT(timeInSec >= 0.0);
-    if (timeInSec == 0.0 || timeInSec >= 1.0)
-    {
-        out << timeInSec << "s";
-        return;
-    }
-    timeInSec *= 1000.0f;
-    if (timeInSec > 1.0f)
-    {
-        out << timeInSec << "ms";
-        return;
-    }
-    timeInSec *= 1000.0f;
-    if (timeInSec > 1.0f)
-    {
-        out << timeInSec << "us";
-        return;
-    }
-
-    timeInSec *= 1000.0f;
-    out << timeInSec << "ns";
+    // Always output in milliseconds for consistency
+    double timeInMs = timeInSec * 1000.0;
+    char buffer[32];
+    snprintf(buffer, sizeof(buffer), "%.3fms", timeInMs);
+    out << buffer;
 }
 
 void TestReporter::_addResult(TestInfo info)
@@ -435,7 +421,9 @@ void TestReporter::_addResult(TestInfo info)
         StringBuilder buffer;
         if (info.executionTime > 0.0f)
         {
+            buffer << "(";
             _appendTime(info.executionTime, buffer);
+            buffer << ")";
         }
         printf(
             "%s test: '%S' %s\n",
@@ -746,6 +734,82 @@ void TestReporter::outputSummary()
                     }
                 }
                 printf("---\n");
+            }
+
+            // Print timing summary if timing diagnostics are enabled
+            if (isDiagnosticEnabled("timing"))
+            {
+                double totalTimeMs = 0.0;
+                double passedTimeMs = 0.0;
+                double failedTimeMs = 0.0;
+                double ignoredTimeMs = 0.0;
+                double expectedFailTimeMs = 0.0;
+
+                for (const auto& testInfo : m_testInfos)
+                {
+                    double timeMs = testInfo.executionTime * 1000.0;
+                    totalTimeMs += timeMs;
+                    switch (testInfo.testResult)
+                    {
+                    case TestResult::Pass:
+                        passedTimeMs += timeMs;
+                        break;
+                    case TestResult::Fail:
+                        failedTimeMs += timeMs;
+                        break;
+                    case TestResult::Ignored:
+                        ignoredTimeMs += timeMs;
+                        break;
+                    case TestResult::ExpectedFail:
+                        expectedFailTimeMs += timeMs;
+                        break;
+                    default:
+                        break;
+                    }
+                }
+
+                printf("\n[TIMING-SUMMARY] Test Execution Timing\n");
+                printf("%-20s %8s %12s %12s\n", "Category", "Count", "Total(ms)", "Avg(ms)");
+                printf("--------------------------------------------------------\n");
+                printf(
+                    "%-20s %8d %12.3f %12.3f\n",
+                    "All tests",
+                    m_totalTestCount,
+                    totalTimeMs,
+                    m_totalTestCount > 0 ? totalTimeMs / m_totalTestCount : 0.0);
+                printf(
+                    "%-20s %8d %12.3f %12.3f\n",
+                    "Passed",
+                    m_passedTestCount,
+                    passedTimeMs,
+                    m_passedTestCount > 0 ? passedTimeMs / m_passedTestCount : 0.0);
+                printf(
+                    "%-20s %8d %12.3f %12.3f\n",
+                    "Failed",
+                    m_failedTestCount,
+                    failedTimeMs,
+                    m_failedTestCount > 0 ? failedTimeMs / m_failedTestCount : 0.0);
+                if (m_expectedFailedTestCount > 0)
+                {
+                    printf(
+                        "%-20s %8d %12.3f %12.3f\n",
+                        "Expected failures",
+                        m_expectedFailedTestCount,
+                        expectedFailTimeMs,
+                        m_expectedFailedTestCount > 0
+                            ? expectedFailTimeMs / m_expectedFailedTestCount
+                            : 0.0);
+                }
+                if (m_ignoredTestCount > 0)
+                {
+                    printf(
+                        "%-20s %8d %12.3f %12.3f\n",
+                        "Ignored",
+                        m_ignoredTestCount,
+                        ignoredTimeMs,
+                        m_ignoredTestCount > 0 ? ignoredTimeMs / m_ignoredTestCount : 0.0);
+                }
+                printf("\n");
             }
 
             break;

--- a/tools/slang-unit-test/unit-test-json-native.cpp
+++ b/tools/slang-unit-test/unit-test-json-native.cpp
@@ -2,6 +2,7 @@
 
 #include "../../source/compiler-core/slang-json-native.h"
 #include "../../source/compiler-core/slang-json-parser.h"
+#include "../../source/compiler-core/slang-test-server-protocol.h"
 #include "../../source/core/slang-rtti-info.h"
 #include "unit-test/slang-unit-test.h"
 
@@ -159,4 +160,215 @@ static SlangResult _check()
 SLANG_UNIT_TEST(JSONNative)
 {
     SLANG_CHECK(SLANG_SUCCEEDED(_check()));
+}
+
+// Helper to parse JSON string and convert to native type
+template<typename T>
+static SlangResult _parseJsonToNative(
+    const char* jsonStr,
+    T* outValue,
+    SourceManager* sourceManager,
+    RttiTypeFuncsMap* typeMap)
+{
+    DiagnosticSink sink(sourceManager, &JSONLexer::calcLexemeLocation);
+    RefPtr<JSONContainer> container(new JSONContainer(sourceManager));
+
+    String contents(jsonStr);
+    SourceFile* sourceFile =
+        sourceManager->createSourceFileWithString(PathInfo::makeUnknown(), contents);
+    SourceView* sourceView = sourceManager->createSourceView(sourceFile, nullptr, SourceLoc());
+
+    JSONLexer lexer;
+    lexer.init(sourceView, &sink);
+
+    JSONBuilder builder(container);
+    JSONParser parser;
+    SLANG_RETURN_ON_FAIL(parser.parse(&lexer, sourceView, &builder, &sink));
+
+    JSONToNativeConverter converter(container, typeMap, &sink);
+    SLANG_RETURN_ON_FAIL(
+        converter.convert(builder.getRootValue(), GetRttiInfo<T>::get(), outValue));
+
+    return SLANG_OK;
+}
+
+// Helper to serialize native type to JSON string
+template<typename T>
+static SlangResult _serializeNativeToJson(
+    const T* value,
+    String& outJson,
+    SourceManager* sourceManager,
+    RttiTypeFuncsMap* typeMap)
+{
+    DiagnosticSink sink(sourceManager, nullptr);
+    RefPtr<JSONContainer> container(new JSONContainer(sourceManager));
+
+    NativeToJSONConverter converter(container, typeMap, &sink);
+    JSONValue jsonValue;
+    SLANG_RETURN_ON_FAIL(converter.convert(GetRttiInfo<T>::get(), value, jsonValue));
+
+    JSONWriter writer(JSONWriter::IndentationStyle::Allman);
+    container->traverseRecursively(jsonValue, &writer);
+    outJson = writer.getBuilder().produceString();
+
+    return SLANG_OK;
+}
+
+// Test that test-server protocol structures can be serialized/deserialized correctly.
+static SlangResult _checkProtocolRoundTrip()
+{
+    SourceManager sourceManager;
+    sourceManager.initialize(nullptr, nullptr);
+    auto typeMap = JSONNativeUtil::getTypeFuncsMap();
+
+    // Test 1: ExecuteToolTestArgs round-trip (without optional testCommand)
+    {
+        const char* json = R"({"toolName": "render-test", "args": ["-api", "vk"]})";
+        TestServerProtocol::ExecuteToolTestArgs args;
+        SLANG_RETURN_ON_FAIL(_parseJsonToNative(json, &args, &sourceManager, &typeMap));
+        SLANG_CHECK(args.toolName == "render-test");
+        SLANG_CHECK(args.args.getCount() == 2);
+        SLANG_CHECK(args.testCommand.getLength() == 0); // Optional field defaults to empty
+    }
+
+    // Test 2: ExecuteToolTestArgs with optional testCommand
+    {
+        const char* json =
+            R"({"toolName": "render-test", "args": [], "testCommand": "tests/compute/simple.slang"})";
+        TestServerProtocol::ExecuteToolTestArgs args;
+        SLANG_RETURN_ON_FAIL(_parseJsonToNative(json, &args, &sourceManager, &typeMap));
+        SLANG_CHECK(args.toolName == "render-test");
+        SLANG_CHECK(args.testCommand == "tests/compute/simple.slang");
+    }
+
+    // Test 3: ExecutionResult round-trip (without optional executionTimeMs)
+    {
+        const char* json =
+            R"({"stdOut": "ok", "stdError": "", "debugLayer": "", "result": 0, "returnCode": 0})";
+        TestServerProtocol::ExecutionResult result;
+        SLANG_RETURN_ON_FAIL(_parseJsonToNative(json, &result, &sourceManager, &typeMap));
+        SLANG_CHECK(result.stdOut == "ok");
+        SLANG_CHECK(result.result == 0);
+        SLANG_CHECK(result.returnCode == 0);
+        SLANG_CHECK(result.executionTimeMs == 0); // Optional field defaults to 0
+    }
+
+    // Test 4: ExecutionResult with optional executionTimeMs
+    {
+        const char* json =
+            R"({"stdOut": "", "stdError": "", "debugLayer": "", "result": 0, "returnCode": 0, "executionTimeMs": 123.5})";
+        TestServerProtocol::ExecutionResult result;
+        SLANG_RETURN_ON_FAIL(_parseJsonToNative(json, &result, &sourceManager, &typeMap));
+        SLANG_CHECK(result.executionTimeMs == 123.5);
+    }
+
+    // Test 5: ExecutionResult serialization
+    {
+        TestServerProtocol::ExecutionResult result;
+        result.stdOut = "output";
+        result.stdError = "";
+        result.debugLayer = "";
+        result.result = 0;
+        result.returnCode = 0;
+        result.executionTimeMs = 42.0;
+
+        String jsonOutput;
+        SLANG_RETURN_ON_FAIL(_serializeNativeToJson(&result, jsonOutput, &sourceManager, &typeMap));
+
+        // Verify expected fields are present
+        SLANG_CHECK(jsonOutput.indexOf("stdOut") >= 0);
+        SLANG_CHECK(jsonOutput.indexOf("result") >= 0);
+        SLANG_CHECK(jsonOutput.indexOf("executionTimeMs") >= 0);
+    }
+
+    return SLANG_OK;
+}
+
+SLANG_UNIT_TEST(TestServerProtocolRoundTrip)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_checkProtocolRoundTrip()));
+}
+
+// Test that array-style JSON-RPC works with Optional fields (backward compatibility).
+// This simulates an older client sending fewer array elements than the struct has fields,
+// where the missing fields are marked as Optional.
+static SlangResult _checkArrayStyleOptionalFields()
+{
+    SourceManager sourceManager;
+    sourceManager.initialize(nullptr, nullptr);
+    auto typeMap = JSONNativeUtil::getTypeFuncsMap();
+
+    // Test: Array-style parsing with missing Optional field (testCommand)
+    // Old clients send: ["toolName", ["arg1", "arg2"]]
+    // New struct has: toolName, args, testCommand (Optional)
+    {
+        // This JSON represents array-style params: [toolName, args] without testCommand
+        const char* json = R"(["render-test", ["-api", "vk"]])";
+        TestServerProtocol::ExecuteToolTestArgs args;
+
+        DiagnosticSink sink(&sourceManager, &JSONLexer::calcLexemeLocation);
+        RefPtr<JSONContainer> container(new JSONContainer(&sourceManager));
+
+        String contents(json);
+        SourceFile* sourceFile =
+            sourceManager.createSourceFileWithString(PathInfo::makeUnknown(), contents);
+        SourceView* sourceView = sourceManager.createSourceView(sourceFile, nullptr, SourceLoc());
+
+        JSONLexer lexer;
+        lexer.init(sourceView, &sink);
+
+        JSONBuilder builder(container);
+        JSONParser parser;
+        SLANG_RETURN_ON_FAIL(parser.parse(&lexer, sourceView, &builder, &sink));
+
+        JSONToNativeConverter converter(container, &typeMap, &sink);
+        SLANG_RETURN_ON_FAIL(converter.convertArrayToStruct(
+            builder.getRootValue(),
+            GetRttiInfo<TestServerProtocol::ExecuteToolTestArgs>::get(),
+            &args));
+
+        SLANG_CHECK(args.toolName == "render-test");
+        SLANG_CHECK(args.args.getCount() == 2);
+        SLANG_CHECK(args.args[0] == "-api");
+        SLANG_CHECK(args.args[1] == "vk");
+        SLANG_CHECK(args.testCommand.getLength() == 0); // Optional field defaults to empty
+    }
+
+    // Test: Array-style parsing with all fields provided (including Optional)
+    {
+        const char* json = R"(["render-test", ["-api", "vk"], "tests/compute/simple.slang"])";
+        TestServerProtocol::ExecuteToolTestArgs args;
+
+        DiagnosticSink sink(&sourceManager, &JSONLexer::calcLexemeLocation);
+        RefPtr<JSONContainer> container(new JSONContainer(&sourceManager));
+
+        String contents(json);
+        SourceFile* sourceFile =
+            sourceManager.createSourceFileWithString(PathInfo::makeUnknown(), contents);
+        SourceView* sourceView = sourceManager.createSourceView(sourceFile, nullptr, SourceLoc());
+
+        JSONLexer lexer;
+        lexer.init(sourceView, &sink);
+
+        JSONBuilder builder(container);
+        JSONParser parser;
+        SLANG_RETURN_ON_FAIL(parser.parse(&lexer, sourceView, &builder, &sink));
+
+        JSONToNativeConverter converter(container, &typeMap, &sink);
+        SLANG_RETURN_ON_FAIL(converter.convertArrayToStruct(
+            builder.getRootValue(),
+            GetRttiInfo<TestServerProtocol::ExecuteToolTestArgs>::get(),
+            &args));
+
+        SLANG_CHECK(args.toolName == "render-test");
+        SLANG_CHECK(args.args.getCount() == 2);
+        SLANG_CHECK(args.testCommand == "tests/compute/simple.slang");
+    }
+
+    return SLANG_OK;
+}
+
+SLANG_UNIT_TEST(ArrayStyleOptionalFields)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_checkArrayStyleOptionalFields()));
 }

--- a/tools/test-server/test-server-chronometer.h
+++ b/tools/test-server/test-server-chronometer.h
@@ -1,0 +1,226 @@
+// test-server-chronometer.h
+// Lightweight chronometer for timing test-server phases
+// Enabled via SLANG_TEST_DIAGNOSTICS=timing environment variable
+
+#ifndef TEST_SERVER_CHRONOMETER_H
+#define TEST_SERVER_CHRONOMETER_H
+
+#include "../../source/core/slang-dictionary.h"
+#include "../../source/core/slang-process.h"
+#include "../../source/core/slang-string.h"
+#include "../../source/core/slang-test-diagnostics.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+
+namespace TestServer
+{
+using namespace Slang;
+
+// Timing information for a single event type
+struct TimingInfo
+{
+    int invocationCount = 0;
+    std::chrono::nanoseconds totalDuration = std::chrono::nanoseconds::zero();
+    std::chrono::nanoseconds minDuration = std::chrono::nanoseconds::max();
+    std::chrono::nanoseconds maxDuration = std::chrono::nanoseconds::zero();
+};
+
+// Simple chronometer for test-server phase timing
+// Enabled via SLANG_TEST_DIAGNOSTICS=timing (or "all")
+// Phase details enabled via SLANG_TEST_DIAGNOSTICS=timing-phases
+class Chronometer
+{
+public:
+    using Clock = std::chrono::steady_clock;
+    using TimePoint = Clock::time_point;
+    using Duration = std::chrono::nanoseconds;
+
+    // Start timing a test - returns start time for use with endTest
+    // Returns invalid time point if timing is disabled, so executionTimeMs stays at default 0.0
+    TimePoint beginTest()
+    {
+        if (!isEnabled())
+            return TimePoint{};
+        return Clock::now();
+    }
+
+    // End timing a test and return duration in milliseconds
+    // Returns 0.0 if timing is disabled or start time is invalid
+    double endTest(TimePoint startTime)
+    {
+        if (startTime == TimePoint{})
+            return 0.0;
+
+        auto endTime = Clock::now();
+        auto duration = std::chrono::duration_cast<Duration>(endTime - startTime);
+        return std::chrono::duration_cast<std::chrono::microseconds>(duration).count() / 1000.0;
+    }
+
+    // Start timing a named event (returns invalid time if disabled)
+    TimePoint start(const char* eventName)
+    {
+        if (!isEnabled())
+            return TimePoint{};
+
+        if (isPhaseLoggingEnabled())
+        {
+            fprintf(stderr, "[TIMING] %s started (pid=%u)\n", eventName, Process::getId());
+        }
+        return Clock::now();
+    }
+
+    // Stop timing and record the result
+    void stop(const char* eventName, TimePoint startTime)
+    {
+        if (!isEnabled() || startTime == TimePoint{})
+            return;
+
+        auto endTime = Clock::now();
+        auto duration = std::chrono::duration_cast<Duration>(endTime - startTime);
+
+        // Find or create entry for this event
+        TimingInfo* info = nullptr;
+        for (auto& kv : m_data)
+        {
+            if (strcmp(kv.key, eventName) == 0)
+            {
+                info = &kv.value;
+                break;
+            }
+        }
+        if (!info)
+        {
+            m_data.add(eventName, TimingInfo{});
+            // Get the newly added entry
+            info = &m_data.getLast().value;
+        }
+
+        info->invocationCount++;
+        info->totalDuration += duration;
+        if (duration < info->minDuration)
+            info->minDuration = duration;
+        if (duration > info->maxDuration)
+            info->maxDuration = duration;
+
+        if (isPhaseLoggingEnabled())
+        {
+            auto ms =
+                std::chrono::duration_cast<std::chrono::microseconds>(duration).count() / 1000.0;
+            fprintf(
+                stderr,
+                "[TIMING] %s completed: %.3fms (pid=%u)\n",
+                eventName,
+                ms,
+                Process::getId());
+        }
+    }
+
+    // Print summary report to stderr (only when phase logging is enabled)
+    void printSummary()
+    {
+        if (!isPhaseLoggingEnabled() || m_data.getCount() == 0)
+            return;
+
+        fprintf(
+            stderr,
+            "\n[TIMING-SUMMARY] Test Server Timing Report (pid=%u)\n",
+            Process::getId());
+        fprintf(
+            stderr,
+            "%-35s %8s %12s %12s %12s %12s\n",
+            "Event",
+            "Count",
+            "Total(ms)",
+            "Avg(ms)",
+            "Min(ms)",
+            "Max(ms)");
+        fprintf(
+            stderr,
+            "%s\n",
+            "--------------------------------------------------------------------------------------"
+            "---------");
+
+        for (const auto& kv : m_data)
+        {
+            auto totalMs =
+                std::chrono::duration_cast<std::chrono::microseconds>(kv.value.totalDuration)
+                    .count() /
+                1000.0;
+            auto avgMs = kv.value.invocationCount > 0 ? totalMs / kv.value.invocationCount : 0.0;
+            auto minMs = std::chrono::duration_cast<std::chrono::microseconds>(kv.value.minDuration)
+                             .count() /
+                         1000.0;
+            auto maxMs = std::chrono::duration_cast<std::chrono::microseconds>(kv.value.maxDuration)
+                             .count() /
+                         1000.0;
+
+            // Handle the case where minDuration was never updated
+            if (kv.value.invocationCount == 0)
+            {
+                minMs = 0.0;
+            }
+
+            fprintf(
+                stderr,
+                "%-35s %8d %12.3f %12.3f %12.3f %12.3f\n",
+                kv.key,
+                kv.value.invocationCount,
+                totalMs,
+                avgMs,
+                minMs,
+                maxMs);
+        }
+        fprintf(stderr, "\n");
+    }
+
+    // Check if timing is enabled (SLANG_TEST_DIAGNOSTICS=timing)
+    static bool isEnabled()
+    {
+        static bool enabled = isDiagnosticEnabled("timing");
+        return enabled;
+    }
+
+    // Check if phase-level logging is enabled (SLANG_TEST_DIAGNOSTICS=timing-phases)
+    static bool isPhaseLoggingEnabled()
+    {
+        static bool enabled = isDiagnosticEnabled("timing-phases");
+        return enabled;
+    }
+
+    // Clear all timing data
+    void clear() { m_data.clear(); }
+
+private:
+    OrderedDictionary<const char*, TimingInfo> m_data;
+};
+
+// RAII helper for automatic timing of scopes
+class ScopedTimer
+{
+public:
+    ScopedTimer(Chronometer& chrono, const char* eventName)
+        : m_chronometer(chrono), m_eventName(eventName), m_startTime(chrono.start(eventName))
+    {
+    }
+
+    ~ScopedTimer() { m_chronometer.stop(m_eventName, m_startTime); }
+
+    // Non-copyable
+    ScopedTimer(const ScopedTimer&) = delete;
+    ScopedTimer& operator=(const ScopedTimer&) = delete;
+
+private:
+    Chronometer& m_chronometer;
+    const char* m_eventName;
+    Chronometer::TimePoint m_startTime;
+};
+
+// Convenience macro for timing a scope
+// Usage: SCOPED_TIMER(m_chronometer, "phase-name");
+#define SCOPED_TIMER(chrono, name) ::TestServer::ScopedTimer _scopedTimer##__LINE__(chrono, name)
+
+} // namespace TestServer
+
+#endif // TEST_SERVER_CHRONOMETER_H

--- a/tools/test-server/test-server-chronometer.h
+++ b/tools/test-server/test-server-chronometer.h
@@ -219,7 +219,10 @@ private:
 
 // Convenience macro for timing a scope
 // Usage: SCOPED_TIMER(m_chronometer, "phase-name");
-#define SCOPED_TIMER(chrono, name) ::TestServer::ScopedTimer _scopedTimer##__LINE__(chrono, name)
+#define SCOPED_TIMER_CONCAT_(a, b) a##b
+#define SCOPED_TIMER_CONCAT(a, b) SCOPED_TIMER_CONCAT_(a, b)
+#define SCOPED_TIMER(chrono, name) \
+    ::TestServer::ScopedTimer SCOPED_TIMER_CONCAT(_scopedTimer, __LINE__)(chrono, name)
 
 } // namespace TestServer
 

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -4,19 +4,23 @@
 #include "../../source/compiler-core/slang-test-server-protocol.h"
 #include "../../source/core/slang-io.h"
 #include "../../source/core/slang-process-util.h"
+#include "../../source/core/slang-process.h"
 #include "../../source/core/slang-secure-crt.h"
 #include "../../source/core/slang-shared-library.h"
 #include "../../source/core/slang-string-util.h"
 #include "../../source/core/slang-string.h"
+#include "../../source/core/slang-test-diagnostics.h"
 #include "../../source/core/slang-test-tool-util.h"
 #include "../../source/core/slang-writer.h"
 #include "../render-test/slang-support.h"
 #include "gfx-unit-test/gfx-test-util.h"
 #include "slang-com-helper.h"
 #include "slang-rhi.h"
+#include "test-server-chronometer.h"
 #include "test-server-diagnostics.h"
 #include "unit-test/slang-unit-test.h"
 
+#include <chrono>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -95,6 +99,8 @@ protected:
 
     RefPtr<JSONRPCConnection> m_connection; ///< RPC connection, recieves calls to execute and
                                             ///< returns results via JSON-RPC
+
+    Chronometer m_chronometer; ///< For timing test execution phases
 };
 
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!!! TestServer !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
@@ -348,6 +354,14 @@ TestServer::InnerMainFunc TestServer::getToolFunction(const String& name, Diagno
 
 SlangResult TestServer::_executeSingle()
 {
+    // Debug logging for test-server operations (writes to stderr, not RPC stdout)
+    auto startTime = std::chrono::steady_clock::now();
+
+    if (isDiagnosticEnabled("rpc"))
+    {
+        fprintf(stderr, "[TEST-SERVER] Waiting for RPC message (pid=%d)\n", Process::getId());
+    }
+
     // Block waiting for content (or error/closed)
     SLANG_RETURN_ON_FAIL(m_connection->waitForResult());
 
@@ -366,20 +380,73 @@ SlangResult TestServer::_executeSingle()
             JSONRPCCall call;
             SLANG_RETURN_ON_FAIL(m_connection->getRPCOrSendError(&call));
 
+            if (isDiagnosticEnabled("rpc"))
+            {
+                fprintf(
+                    stderr,
+                    "[TEST-SERVER] Received call: %s (pid=%d)\n",
+                    String(call.method).getBuffer(),
+                    Process::getId());
+            }
+
             // Do different things
             if (call.method == TestServerProtocol::QuitArgs::g_methodName)
             {
+                if (isDiagnosticEnabled("rpc"))
+                {
+                    fprintf(
+                        stderr,
+                        "[TEST-SERVER] Quit request received (pid=%d)\n",
+                        Process::getId());
+                }
                 m_quit = true;
                 return SLANG_OK;
             }
             else if (call.method == TestServerProtocol::ExecuteUnitTestArgs::g_methodName)
             {
                 SLANG_RETURN_ON_FAIL(_executeUnitTest(call));
+
+                if (isDiagnosticEnabled("rpc"))
+                {
+                    auto endTime = std::chrono::steady_clock::now();
+                    auto duration =
+                        std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime)
+                            .count();
+                    fprintf(
+                        stderr,
+                        "[TEST-SERVER] ExecuteUnitTest completed in %lldms (pid=%d)\n",
+                        (long long)duration,
+                        Process::getId());
+                }
+
                 return SLANG_OK;
             }
             else if (call.method == TestServerProtocol::ExecuteToolTestArgs::g_methodName)
             {
                 SLANG_RETURN_ON_FAIL(_executeTool(call));
+
+                if (isDiagnosticEnabled("rpc"))
+                {
+                    auto endTime = std::chrono::steady_clock::now();
+                    auto duration =
+                        std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime)
+                            .count();
+                    fprintf(
+                        stderr,
+                        "[TEST-SERVER] ExecuteTool completed in %lldms (pid=%d)\n",
+                        (long long)duration,
+                        Process::getId());
+
+                    // Warn if test took more than 5 seconds
+                    if (duration > 5000)
+                    {
+                        fprintf(
+                            stderr,
+                            "[TEST-SERVER-WARNING] Slow test execution: %lldms\n",
+                            (long long)duration);
+                    }
+                }
+
                 break;
             }
             else
@@ -422,14 +489,14 @@ SlangResult TestServer::_executeUnitTest(const JSONRPCCall& call)
 
     auto sink = m_connection->getSink();
 
-    IUnitTestModule* testModule = getUnitTestModule(args.moduleName, m_connection->getSink());
+    IUnitTestModule* testModule = getUnitTestModule(args.moduleName, sink);
     if (!testModule)
     {
         sink->diagnose(SourceLoc(), ServerDiagnostics::unableToFindUnitTestModule, args.moduleName);
         return m_connection->sendError(JSONRPC::ErrorCode::InvalidParams, id);
     }
 
-    const Index testIndex = _findTestIndex(testModule, args.testName);
+    Index testIndex = _findTestIndex(testModule, args.testName);
     if (testIndex < 0)
     {
         sink->diagnose(SourceLoc(), ServerDiagnostics::unableToFindTest, args.testName);
@@ -443,7 +510,6 @@ SlangResult TestServer::_executeUnitTest(const JSONRPCCall& call)
 
     testModule->setTestReporter(&testReporter);
 
-    // Assume we will used the shared session
     slang::IGlobalSession* session = getOrCreateGlobalSession();
     if (!session)
     {
@@ -463,6 +529,7 @@ SlangResult TestServer::_executeUnitTest(const JSONRPCCall& call)
 
     UnitTestFunc testFunc = testModule->getTestFunc(testIndex);
 
+    auto testStartTime = m_chronometer.beginTest();
     try
     {
         testFunc(&unitTestContext);
@@ -473,6 +540,7 @@ SlangResult TestServer::_executeUnitTest(const JSONRPCCall& call)
     }
 
     TestServerProtocol::ExecutionResult result;
+    result.executionTimeMs = m_chronometer.endTest(testStartTime);
     result.result = SLANG_OK;
     result.debugLayer = coreDebugCallback.getString();
 
@@ -545,10 +613,12 @@ SlangResult TestServer::_executeTool(const JSONRPCCall& call)
         stdWriters.setWriter(SLANG_WRITER_CHANNEL_DIAGNOSTIC, stdErrorWriter);
     }
 
+    auto testStartTime = m_chronometer.beginTest();
     const SlangResult funcRes =
         func(&stdWriters, session, int(toolArgs.getCount()), toolArgs.begin());
 
     TestServerProtocol::ExecutionResult result;
+    result.executionTimeMs = m_chronometer.endTest(testStartTime);
     result.result = funcRes;
     result.stdError = stdError;
     result.stdOut = stdOut;


### PR DESCRIPTION
Fixes #9249

Re-applies #9066 with fixes for VK-GL-CTS backwards compatibility.

## Features
- Add executionTimeMs to ExecutionResult for test timing measurement
- Add testCommand to ExecuteToolTestArgs for diagnostic context
- Add Chronometer class for measuring test execution phases
- Enable timing via SLANG_TEST_DIAGNOSTICS=timing environment variable

## Diagnostics
- Add SLANG_TEST_DIAGNOSTICS environment variable for debug output control
- Categories: timing, timing-phases, rpc, fd, pipe, all
- Add RPC-level logging for test-server communication debugging
- Add phase timing output for performance analysis

## Backwards compatibility
- Fix convertArrayToStruct to handle Optional fields in array-style JSON-RPC
- Older clients sending fewer array elements now work if missing fields are Optional
- Enables backward-compatible protocol evolution