### PR TITLE
Fix pragma warning scope issue across modules

### DIFF
--- a/tests/pragma-warning/dbg1.slang
+++ b/tests/pragma-warning/dbg1.slang
@@ -1,0 +1,7 @@
+import "dbg2.h";
+import "dbg3.h";
+
+[numthreads(128, 1, 1)]
+[outputtopology("triangle")]
+[shader("mesh")]
+void main(){}

--- a/tests/pragma-warning/dbg2.h.slang
+++ b/tests/pragma-warning/dbg2.h.slang
@@ -1,0 +1,16 @@
+module "dbg2.h";
+
+// load-bearing comment load-bearing comment load-bearing comment load-bearing comment
+public bool bar(float a, out float b)
+{
+  if(a <= 0.0)
+  {
+#pragma warning(disable: 41018) // Disable warning 41018 : returning without initializing some variables/parameters
+    return false;
+#pragma warning(default: 41018)
+  }
+
+  b = a;
+
+  return true;
+}

--- a/tests/pragma-warning/dbg3.h.slang
+++ b/tests/pragma-warning/dbg3.h.slang
@@ -1,0 +1,9 @@
+module "dbg3.h";
+
+public bool foo(float a, out float b) {
+#pragma warning(disable: 41018) // Disable warning 41018 : returning without initializing some variables/parameters
+    if (a > 0) return true;
+#pragma warning(default: 41018)
+    b = 0;
+    return false;
+}

--- a/tests/pragma/pragma-warning-regression-9109-module-a.slang
+++ b/tests/pragma/pragma-warning-regression-9109-module-a.slang
@@ -1,0 +1,18 @@
+module "pragma-warning-regression-9109-module-a";
+
+// A longer comment to ensure this module has more content and later source locations
+// This simulates the scenario where module A gets processed first and has higher
+// absolute source locations than module B, which would cause the original bug.
+// More content here to push the locations higher...
+// Even more content to ensure we have significantly larger source locations...
+// Additional padding to make this file longer...
+// And some more lines for good measure...
+public bool moduleAFunction(float input, out float result) {
+    if (input <= 0.0) {
+#pragma warning(disable: 41018)  // Disable uninitialized out parameter warning
+        return false;
+#pragma warning(default: 41018)  // Re-enable the warning
+    }
+    result = input * 2.0;
+    return true;
+}

--- a/tests/pragma/pragma-warning-regression-9109-module-b.slang
+++ b/tests/pragma/pragma-warning-regression-9109-module-b.slang
@@ -1,0 +1,10 @@
+module "pragma-warning-regression-9109-module-b";
+
+// Module B with shorter content to have lower absolute source locations
+public bool moduleBFunction(float input, out float result) {
+#pragma warning(disable: 41018)  // This should NOT generate warning 15615 anymore
+    if (input > 5.0) return true;  // This should still generate warning 41018
+#pragma warning(default: 41018)
+    result = 0.0;
+    return false;
+}

--- a/tests/pragma/pragma-warning-regression-9109.slang
+++ b/tests/pragma/pragma-warning-regression-9109.slang
@@ -1,0 +1,26 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -skip-spirv-validation
+
+// Regression test for issue #9109
+// This test ensures that #pragma warning directives work correctly across modules
+// when different modules have interleaved absolute source locations.
+// Previously, pragma warnings in module B could be rejected with warning 15615
+// if they had "earlier" absolute locations than pragma warnings in module A.
+
+import "pragma-warning-regression-9109-module-a.slang";
+import "pragma-warning-regression-9109-module-b.slang";
+
+// CHECK-NOT: warning 15615
+
+// We expect to see warning 41018 from module B since the pragma only disables it
+// for the early return case, not for the entire function
+// CHECK: warning 41018
+
+[numthreads(1, 1, 1)]
+[shader("compute")]
+void main() {
+    float a = 1.0f;
+    float b;
+
+    bool resultA = moduleAFunction(a, b);
+    bool resultB = moduleBFunction(a, b);
+}


### PR DESCRIPTION
Fixes issue where #pragma warning directives in modules could be incorrectly rejected with warning 15615 when they had "earlier" absolute source locations than pragma warnings in previously processed modules.

The issue was in WarningTimeline::addEntry() which only allowed adding pragma entries if their location was greater than all previously seen locations. This worked for single files but failed for modules where different files could have interleaved absolute location ranges.

The fix adds source file boundary detection by comparing PathInfo uniqueIdentity values. If a pragma warning is in a different source file than the last timeline entry, it's allowed even if the absolute location is "backwards".

Changes:
- Modified WarningTimeline::addEntry() to accept optional SourceManager
- Added differentSourceFile check using PathInfo.getMostUniqueIdentity()
- Updated all call sites to pass sourceManager parameter
- Added regression test covering the cross-module scenario

Fixes #9109