### PR TITLE
Diagnose if extension declares new interface requirements

### DIFF
--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -2724,13 +2724,6 @@ DIAGNOSTIC(
 DIAGNOSTIC(45001, Error, unresolvedSymbol, "unresolved external symbol '$0'.")
 
 DIAGNOSTIC(
-    45002,
-    Error,
-    functionDeclarationWithoutDefinition,
-    "function '$0' is declared but not defined. Extensions cannot declare new interface "
-    "requirements; function declarations in extensions must have a body.")
-
-DIAGNOSTIC(
     41201,
     Warning,
     expectDynamicUniformArgument,

--- a/tests/diagnostics/extension-interface-requirement.slang
+++ b/tests/diagnostics/extension-interface-requirement.slang
@@ -1,0 +1,60 @@
+// extension-interface-requirement.slang
+
+// Test that extension method declarations without bodies are properly diagnosed.
+// Extensions cannot declare new interface requirements - they must provide implementations.
+// See https://github.com/shader-slang/slang/issues/9198
+
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):-target spirv
+
+// Simple interface
+public interface IROTensor<T, let D : int>
+{
+    T read_buffer(int idx);
+}
+
+// Concrete type implementing the interface
+public struct ROTensor<T, let D : int> : IROTensor<T, D>
+{
+    public StructuredBuffer<T> _data;
+    public uint[D] _strides;
+    public uint _offset;
+
+    public T read_buffer(int idx)
+    {
+        return _data[idx];
+    }
+}
+
+// Helper function
+int _idx(int i0, uint stride[1], uint offset)
+{
+    return i0 * stride[0] + offset;
+}
+
+// This concrete extension works fine - it has a function body
+public extension<T> ROTensor<T, 1>
+{
+    public T load(int i0)
+    {
+        int idx = _idx(i0, this._strides, this._offset);
+        return this.read_buffer(idx);
+    }
+}
+
+// ERROR: Extension with generic type parameter that declares a method without a body.
+// Extensions cannot declare new interface requirements.
+public extension<T, TensorType : IROTensor<T, 1>> TensorType
+{
+    // CHECK: ([[# @LINE+1]]): error 45001
+    public T loadGeneric(int i0);  // Error: function declaration without definition
+}
+
+// Test entry point
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main()
+{
+    ROTensor<float, 1> tensor;
+    float value = tensor.load(0);
+    float value2 = tensor.loadGeneric(0);  // Uses the extension method
+}


### PR DESCRIPTION
## Summary

This PR adds a diagnostic for missing symbol definitions during the IR linking phase. When `cloneGlobalValueWithLinkage` selects the "best value" for a symbol, it now validates that the value is actually usable—meaning it must either:

- Have a function body (a concrete definition)
- Be marked as a target intrinsic (via appropriate decoration)
- Be marked as an imported symbol (e.g., `DLLImport` decoration)
- Have SPIRV instruction or autodiff decorations

If none of these conditions are met, the compiler now emits a linker error indicating the symbol lacks a definition, along with note diagnostics listing all candidate values that were considered.

## Background

Previously, declaring a method signature in an extension without providing a body would silently proceed through compilation until hitting an internal error during code emission ("unexpected IR opcode"). This made it difficult to diagnose issues where users accidentally declared interface-like requirements in extensions—something that isn't semantically valid since extensions cannot add new requirements to existing types.

## Changes

- **`source/slang/slang-ir-link.cpp`**: Added validation in `cloneGlobalValueWithLinkage` to check that the selected best value has a valid definition. Added helper function `isFunctionDefinedOrImported` to perform the check. Emits a clear diagnostic when a symbol is referenced but has no definition.

- **`tests/diagnostics/extension-interface-requirement.slang`**: Added test case covering the scenario where an extension declares a method without a body.


Closes #9198