### PR TITLE
slangd: Canonicalize all paths found from search paths into URIs

### DIFF
--- a/source/slang/slang-language-server.cpp
+++ b/source/slang/slang-language-server.cpp
@@ -2265,31 +2265,6 @@ void LanguageServer::updateSearchPaths(const JSONValue& value)
         List<String> searchPaths;
         if (SLANG_SUCCEEDED(converter.convert(value, &searchPaths)))
         {
-            // Check for relative paths and warn the user
-            List<String> relativePaths;
-            for (const auto& path : searchPaths)
-            {
-                if (!Path::isAbsolute(path))
-                {
-                    relativePaths.add(path);
-                }
-            }
-            
-            if (relativePaths.getCount() > 0)
-            {
-                StringBuilder msgBuilder;
-                msgBuilder << "Warning: slang.additionalSearchPaths contains relative path(s): ";
-                for (Index i = 0; i < relativePaths.getCount(); i++)
-                {
-                    if (i > 0)
-                        msgBuilder << ", ";
-                    msgBuilder << "'" << relativePaths[i] << "'";
-                }
-                msgBuilder << ". Relative paths may not work as expected. Please use absolute paths.";
-                logMessage(1, msgBuilder.produceString()); // 2 = Warning
-                logMessage(2, msgBuilder.produceString()); // 2 = Warning
-            }
-            
             if (m_core.m_workspace->updateSearchPaths(searchPaths))
             {
                 sendRefreshRequests(m_connection);


### PR DESCRIPTION
Fixes #8286

Many uses of `URI::fromLocalFilePath` in the Slang language server are on paths that are canonicalized (made absolute) by `Path::getCanonical`, but currently `LanguageServerCore::gotoDefinition` does not canonicalize paths from `PathInfo::foundPath` before transforming them into URIs with `fromLocalFilePath` and returning.
As a result, if `foundPath` is relative, which will be the case if there is a relative path in the `slang.additionalSearchPaths` setting, `gotoDefinition` returns a the relative path prepended with `file://`, which is not a valid URI for a local filepath according to the [IETF URI Spec](https://datatracker.ietf.org/doc/html/rfc3986).

This change adds calls to `getCanonical` on every path used by `fromLocalFilePath` for which we do not already use `getCanonical` on.