### PR TITLE
Fix internal error when accessing ConstantBuffer<matrix> elements

### DIFF
--- a/source/slang/slang-ir-lower-buffer-element-type.cpp
+++ b/source/slang/slang-ir-lower-buffer-element-type.cpp
@@ -2035,7 +2035,7 @@ struct LoweredElementTypeContext
         auto baseCast = as<IRCastStorageToLogical>(majorGEP->getBase());
         SLANG_ASSERT(baseCast);
         auto storageBase = baseCast->getOperand(0);
-        auto loweredMatrixType = cast<IRPtrTypeBase>(storageBase->getFullType())->getValueType();
+        auto loweredMatrixType = tryGetPointedToType(&builder, storageBase->getFullType());
         auto matrixTypeInfo =
             getTypeLoweringMap(workItem.config).mapLoweredTypeToInfo.tryGetValue(loweredMatrixType);
         SLANG_ASSERT(matrixTypeInfo);

--- a/tests/bugs/gh-9263.slang
+++ b/tests/bugs/gh-9263.slang
@@ -1,0 +1,32 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -profile spirv_1_6 -O3 -entry computeMain
+
+// Test for issue #9263: Internal Compiler Error on ConstantBuffer<matrix> access
+
+[[vk::binding(0, 0)]] RWTexture2D<float4> tex_out;
+[[vk::binding(1, 0)]] ConstantBuffer<float4x4> mat_camera;
+
+[shader("compute")]
+[numthreads(8, 8, 1)]
+void computeMain(uint3 thread_i: SV_DispatchThreadID) {
+    float4 vec;
+
+    // Test vector subscript
+    vec = mat_camera[3];
+
+    // Test scalar subscript
+    vec.x = mat_camera[3][0];
+
+    // Test member access
+    vec.x = mat_camera._41;
+
+    // Test copy to standalone float4x4 before access
+    float4x4 mat_copy = mat_camera;
+    vec = mat_copy[3];
+    vec.x = mat_copy[3][0];
+    vec.x = mat_copy._41;
+
+    // Writing output so it doesn't get optimized away
+    tex_out[thread_i.xy] = vec;
+}
+
+// CHECK: OpCapability


### PR DESCRIPTION
Use tryGetPointedToType to handle pointer-like types like ConstantBuffer, not just pointer types.

Fixes #9263