### PR TITLE
Fix the missing newline characters for the breaking changes

### DIFF
--- a/docs/scripts/release-note.sh
+++ b/docs/scripts/release-note.sh
@@ -95,7 +95,7 @@ for i in $(seq "$commitsCount"); do
 
   # Check if the PR is marked as a breaking change
   if "$gh" issue view "$pr" --json labels | grep -q 'pr: breaking change'; then
-    breakingChanges+="$line"
+    breakingChanges+="$line"$'\n'
   fi
 done
 if [ "$breakingChanges" = "" ]; then
@@ -103,7 +103,6 @@ if [ "$breakingChanges" = "" ]; then
 else
   echo "$breakingChanges"
 fi
-echo ""
 
 echo "=== All changes for this release ==="
 for i in $(seq "$commitsCount"); do


### PR DESCRIPTION
When generating the release note, the script was missing the new line characters for the breaking changes.

The following is an example of the problem:
> === Breaking changes ===
https://github.com/shader-slang/slang/commit/72761cc366f10a5bdce6c09d0c3213522a515f99 Add error diagnostic for integer literals that don't fit into uint64_t (https://github.com/shader-slang/slang/pull/9208)https://github.com/shader-slang/slang/commit/cc73e8dcf0e10eb6ead8cf3009850b4b8e6ab9a5 Remove the deprecated hlsl_coopvec_poc capability that was for POC CoopVec (https://github.com/shader-slang/slang/pull/9213)https://github.com/shader-slang/slang/commit/4280f24832600b0f9b2ded0b45a7d7da2d04d73a Add type-flow analysis pass for specialized dynamic dispatch (https://github.com/shader-slang/slang/pull/7968)

With this PR, it will be fixed as below:
>=== Breaking changes ===
https://github.com/shader-slang/slang/commit/72761cc366f10a5bdce6c09d0c3213522a515f99 Add error diagnostic for integer literals that don't fit into uint64_t (https://github.com/shader-slang/slang/pull/9208)
https://github.com/shader-slang/slang/commit/cc73e8dcf0e10eb6ead8cf3009850b4b8e6ab9a5 Remove the deprecated hlsl_coopvec_poc capability that was for POC CoopVec (https://github.com/shader-slang/slang/pull/9213)
https://github.com/shader-slang/slang/commit/4280f24832600b0f9b2ded0b45a7d7da2d04d73a Add type-flow analysis pass for specialized dynamic dispatch (https://github.com/shader-slang/slang/pull/7968)