### PR TITLE
Fix pragma warning rejection when using import statements

### DIFF
--- a/source/slang/slang-compile-request.cpp
+++ b/source/slang/slang-compile-request.cpp
@@ -308,6 +308,14 @@ void FrontEndCompileRequest::parseTranslationUnit(TranslationUnitRequest* transl
         module->getIncludedSourceFileMap().addIfNotExists(sourceFile, nullptr);
     }
 
+    // For a new translation unit, we need to reset the WarningStateTracker
+    // to avoid pragma state pollution from previously parsed modules.
+    // This is only done for the first file of the translation unit.
+    // Subsequent files (if any) in the same translation unit, as well as
+    // files included via __include during semantic checking, will reuse
+    // the tracker to preserve pragma states within the module.
+    getSink()->setSourceWarningStateTracker(nullptr);
+
     for (auto sourceFile : translationUnit->getSourceFiles())
     {
         SourceLanguage sourceLanguage = translationUnit->sourceLanguage;

--- a/tests/bugs/gh-9109/basic-module-a.slang
+++ b/tests/bugs/gh-9109/basic-module-a.slang
@@ -1,0 +1,14 @@
+module "basic-module-a.slang";
+
+// This module has a long comment to ensure that any absolute location
+// offset caused by content length doesn't affect pragma warning handling
+// in other modules. The bug in issue 9109 was that pragma warnings could
+// be rejected based on the length of comments in unrelated modules.
+
+public bool foo(float a, out float b) {
+#pragma warning(disable: 41018) // Disable warning 41018 : returning without initializing some variables/parameters
+    if (a > 0) return true;
+#pragma warning(default: 41018)
+    b = 0;
+    return false;
+}

--- a/tests/bugs/gh-9109/basic-module-b.slang
+++ b/tests/bugs/gh-9109/basic-module-b.slang
@@ -1,0 +1,15 @@
+module "basic-module-b.slang";
+
+public bool bar(float a, out float b)
+{
+    if(a <= 0.0)
+    {
+#pragma warning(disable: 41018) // Disable warning 41018 : returning without initializing some variables/parameters
+        return false;
+#pragma warning(default: 41018)
+    }
+
+    b = a;
+
+    return true;
+}

--- a/tests/bugs/gh-9109/basic.slang
+++ b/tests/bugs/gh-9109/basic.slang
@@ -1,0 +1,22 @@
+// Test: pragma warning with import statements
+// Ensures pragma warnings work correctly across imported modules.
+// This is a regression test for issue 9109 where pragma warnings
+// were incorrectly rejected when used with import statements.
+//TEST:SIMPLE(filecheck=CHECK):
+
+import "basic-module-a.slang";
+import "basic-module-b.slang";
+
+void main()
+{
+    // These functions use pragma warning(disable: 41018) and pragma warning(default: 41018)
+    // If the pragma warnings weren't working correctly, we'd get warning 15615 errors
+    // during compilation. A successful compile means the pragmas were accepted.
+    float out1 = 0.0f;
+    foo(5.0f, out1);
+
+    float out2 = 0.0f;
+    bar(10.0f, out2);
+}
+
+// CHECK-NOT: warning 15615

--- a/tests/bugs/gh-9109/main.slang
+++ b/tests/bugs/gh-9109/main.slang
@@ -1,0 +1,17 @@
+// Regression test for GitHub issue #9109
+// The bug was that pragma warnings were rejected based on the length
+// of comments in other imported modules.
+//TEST:SIMPLE(filecheck=CHECK):
+
+import "module-a.slang";
+import "module-b.slang";
+
+void main()
+{
+    float b = 0.0f;
+    foo(5.0f, b);
+}
+
+// CHECK-NOT: warning 15615
+// This verifies that pragma warning directives are accepted in all modules
+// regardless of the length of code or comments in other modules.

--- a/tests/bugs/gh-9109/module-a.slang
+++ b/tests/bugs/gh-9109/module-a.slang
@@ -1,0 +1,15 @@
+module "module-a.slang";
+
+// This file deliberately includes a long comment to test the original bug.
+// The bug in issue 9109 was that pragma warnings could be incorrectly
+// rejected in one module based on the length of comments in another module.
+// The longer this comment, the more it would trigger the bug if it weren't fixed.
+// This helps ensure that pragma warning states are properly isolated between modules.
+
+public bool foo(float a, out float b) {
+#pragma warning(disable: 41018) // Disable warning 41018 : returning without initializing some variables/parameters
+    if (a > 0) return true;
+#pragma warning(default: 41018)
+    b = 0;
+    return false;
+}

--- a/tests/bugs/gh-9109/module-b.slang
+++ b/tests/bugs/gh-9109/module-b.slang
@@ -1,0 +1,9 @@
+module "module-b.slang";
+
+public bool baz(float a, out float b) {
+#pragma warning(disable: 41018) // Disable warning 41018 : returning without initializing some variables/parameters
+    if (a > 0) return true;
+#pragma warning(default: 41018)
+    b = 0;
+    return false;
+}


### PR DESCRIPTION
When using module `import` statements, #pragma warning directives were being incorrectly rejected with warning 15615 ("Cannot insert #pragma warning here"). The rejection was dependent on factors in other modules such as comment length, making it appear to be a random or non-deterministic bug.

The fix for issue 7941 (PR 7942) introduced proper pragma state tracking across __include'd files by reusing the same WarningStateTracker across files in a single module. However, this inadvertently caused pragma state to be shared across different modules when using import statements.

When multiple modules were imported, the absolute location values from different modules could overlap or be out of order. When a pragma was added in a later module, its location might be less than the `maxKnownLocation` from the previous module's pragmas, causing the WarningTimeline::addEntry() check to fail and reject the pragma as invalid.

Reset the WarningStateTracker when parsing a new translation unit (module). This ensures each module gets a fresh pragma state tracker, preventing cross- module contamination. Within a single module:
- Files parsed via __include during semantic checking reuse the tracker
- Preserving pragma state within the module as intended by PR 7942

The fix is minimal: a single call to getSink()->setSourceWarningStateTracker(nullptr) at the start of parseTranslationUnit(), before parsing any files in the module.

Added regression tests in tests/bugs/gh-9109/:
- main.slang + module-a.slang + module-b.slang Tests the exact scenario from issue 9109 with varying module sizes
- basic.slang + basic-module-a.slang + basic-module-b.slang Tests basic pragma warning functionality with multiple imported modules

Verified existing pragma warning tests still pass:
- tests/diagnostics/pragma-warning-multifile-main.slang (PR 7942)
- tests/diagnostics/nested-pragma-main.slang (PR 7942)
- tests/diagnostics/pragma-warning-single-file.slang (PR 7942)