### PR TITLE
Fix static-const lowering for interface generic methods

### DIFF
--- a/tests/language-feature/constants/static-const-in-generic-interface-method-where-clause.slang
+++ b/tests/language-feature/constants/static-const-in-generic-interface-method-where-clause.slang
@@ -1,0 +1,54 @@
+// Test case for GitHub issue #8148
+// Crash when using static consts in generic interface methods with where clauses
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHK): -shaderobj -output-using-type
+
+interface IVector<T, int N>
+{
+    int getValue();
+}
+
+struct MyVector<T, int N> : IVector<T, N>
+{
+    int getValue()
+    {
+        return N;
+    }
+}
+
+interface IEncoder<T>
+{
+    static const int InDim;
+    static const int OutDim;
+
+    OutputVector eval<InputVector, OutputVector>(InputVector input)
+        where InputVector : IVector<T, InDim>
+        where OutputVector : IVector<T, OutDim>;
+}
+
+struct Encoder<T> : IEncoder<T>
+{
+    static const int InDim = 4;
+    static const int OutDim = 2;
+
+    OutputVector eval<InputVector, OutputVector>(InputVector input)
+        where InputVector : IVector<T, InDim>
+        where OutputVector : IVector<T, OutDim>
+    {
+        OutputVector ret;
+        return ret;
+    }
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+{
+    Encoder<float> encoder;
+    MyVector<float, 4> input;
+    MyVector<float, 2> output = encoder.eval<MyVector<float, 4>, MyVector<float,2>>(input);
+    outputBuffer[0] = input.getValue() + output.getValue();
+    // CHK: 6
+}


### PR DESCRIPTION
This commit fixes the incorrect hoisting of specialize inst when
its operands uses both the generaic-type-params and the static const
requirements in interface generics.

As a solution, when lowering the outer generic for anything inside
a generic interface that represent the generic parameters of the
interface, always create a fresh ThisType and ThisTypeWitness.