### PR TITLE
Fix jq single-quote argument handling on Windows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,6 +55,31 @@ jobs:
           Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files\Git\bin"
           Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files\Git\usr\bin"
 
+      # Install jq with a bash wrapper to fix Windows cmd quoting issues
+      # See: https://github.com/anthropics/claude-code-action/issues/712
+      - name: Install jq with bash wrapper (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          # Download jq for Windows to a temp location
+          $jqUrl = "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-win64.exe"
+          $jqExe = "$env:RUNNER_TEMP\jq-windows.exe"
+          Invoke-WebRequest -Uri $jqUrl -OutFile $jqExe
+
+          # Convert to Unix path for bash
+          $jqExeUnix = $jqExe -replace '\\', '/' -replace '^([A-Za-z]):', '/$1'
+
+          # Create jq.cmd wrapper in Claude's install directory (writable, in PATH)
+          # The wrapper routes through bash where single-quoted args work correctly
+          $claudeDir = "C:\Windows\ServiceProfiles\NetworkService\.local\bin"
+          New-Item -ItemType Directory -Force -Path $claudeDir | Out-Null
+          $cmdWrapper = "$claudeDir\jq.cmd"
+          $wrapperContent = "@echo off`r`n`"C:\Program Files\Git\bin\bash.exe`" -c '`"$jqExeUnix`" `"`$@`"' _ %*"
+          Set-Content -Path $cmdWrapper -Value $wrapperContent -Encoding ASCII
+
+          Write-Host "jq wrapper installed at $cmdWrapper"
+          Write-Host "jq executable at $jqExe"
+
       # Install Claude Code on Windows (the action's install.sh doesn't support Windows)
       - name: Install Claude Code (Windows)
         id: install-claude
@@ -107,10 +132,6 @@ jobs:
             Write-Host "Searched paths: $($searchPaths -join ', ')"
             exit 1
           }
-
-      # Note: jq is not installed on Windows - the claude-code-action has a bug with
-      # Windows cmd quoting for jq commands. The action's output formatting will show
-      # a warning but Claude itself runs successfully.
 
       # Format setup and environment preparation
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Fix jq single-quote argument handling on Windows for the Claude Code CI workflow.

The `claude-code-action` internally runs `jq -s '.' output.txt` for output processing, but single-quoted arguments fail in Windows cmd shell. This PR installs jq with a bash wrapper that routes execution through Git Bash where single-quoted arguments are handled correctly.

### How it works

1. Downloads `jq-win64.exe` to a temp location
2. Creates a `jq.cmd` wrapper that invokes bash with proper argument forwarding
3. Places the wrapper in a directory already in PATH

### Related

- Related to #9118 (Claude Code CI integration)
- Related to upstream issue: https://github.com/anthropics/claude-code-action/issues/712