### PR TITLE
Fix #9018 - HitObject.GetCurrentTime had incorrect availability

### DIFF
--- a/prelude/slang-cuda-prelude.h
+++ b/prelude/slang-cuda-prelude.h
@@ -4407,6 +4407,13 @@ static __forceinline__ __device__ uint slangOptixHitObjectGetInstanceId(OptixTra
 }
 #endif
 
+#if (OPTIX_VERSION >= 80000)
+static __forceinline__ __device__ float slangOptixHitObjectGetRayTime(OptixTraversableHandle* Obj)
+{
+    return optixHitObjectGetRayTime();
+}
+#endif
+
 #if (OPTIX_VERSION >= 80100)
 static __forceinline__ __device__ uint
 slangOptixHitObjectGetSbtGASIndex(OptixTraversableHandle* Obj)

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -18146,31 +18146,6 @@ void TraceRay(
     }
 }
 
-// NOTE!
-// The name of the following functions may change when DXR supports
-// a feature similar to the `GL_NV_ray_tracing_motion_blur` extension
-//
-// https://github.com/KhronosGroup/GLSL/blob/master/extensions/nv/GLSL_NV_ray_tracing_motion_blur.txt
-
-__generic<payload_t>
-[require(hlsl, raytracing_motionblur)]
-void __traceMotionRayHLSL(
-        RaytracingAccelerationStructure AccelerationStructure,
-        uint RayFlags,
-        uint InstanceInclusionMask,
-        uint RayContributionToHitGroupIndex,
-        uint MultiplierForGeometryContributionToHitGroupIndex,
-        uint MissShaderIndex,
-        RayDesc Ray,
-        float CurrentTime,
-        inout payload_t Payload)
-{
-    __target_switch
-    {
-    case hlsl: __intrinsic_asm "TraceMotionRay";
-    }
-}
-
 __glsl_extension(GL_NV_ray_tracing_motion_blur)
 [require(glsl, raytracing_motionblur_raygen_closesthit_miss)]
 void __traceMotionRay(
@@ -18206,7 +18181,7 @@ void __traceMotionRay(
 /// @remarks Extended version of TraceRay with motion blur support
 /// @category raytracing
 [ForceInline]
-[require(glsl_hlsl_spirv, raytracing_motionblur_raygen_closesthit_miss)]
+[require(glsl_spirv, raytracing_motionblur_raygen_closesthit_miss)]
 __generic<payload_t>
 void TraceMotionRay(
     RaytracingAccelerationStructure AccelerationStructure,
@@ -18221,18 +18196,6 @@ void TraceMotionRay(
 {
     __target_switch
     {
-    case hlsl:
-        __traceMotionRayHLSL(
-            AccelerationStructure,
-            RayFlags,
-            InstanceInclusionMask,
-            RayContributionToHitGroupIndex,
-            MultiplierForGeometryContributionToHitGroupIndex,
-            MissShaderIndex,
-            Ray,
-            CurrentTime,
-            __forceVarIntoRayPayloadStructTemporarily(Payload));
-        return;
     case glsl:
     {
         [__vulkanRayPayload]
@@ -18762,12 +18725,11 @@ float4x3 WorldToObject4x3()
 __glsl_extension(GL_NV_ray_tracing_motion_blur)
 __glsl_extension(GL_EXT_ray_tracing)
 [NonUniformReturn]
-[require(glsl_hlsl_spirv, raytracing_motionblur_anyhit_closesthit_intersection_miss)]
+[require(glsl_spirv, raytracing_motionblur_anyhit_closesthit_intersection_miss)]
 float RayCurrentTime()
 {
     __target_switch
     {
-    case hlsl:  __intrinsic_asm "RayCurrentTime";
     case glsl:  __intrinsic_asm "(gl_CurrentRayTimeNV)";
     case spirv:
         return spirv_asm
@@ -20854,7 +20816,7 @@ struct HitObject
         /// Executes motion ray traversal (including anyhit and intersection shaders) like TraceRay, but returns the
         /// resulting hit information as a HitObject and does not trigger closesthit or miss shaders.
     [ForceInline]
-    [require(cuda_glsl_hlsl_spirv, ser_motion_raygen_closesthit_miss)]
+    [require(cuda_glsl_spirv, ser_motion_raygen_closesthit_miss)]
     static HitObject TraceMotionRay<payload_t>(
         RaytracingAccelerationStructure AccelerationStructure,
         uint RayFlags,
@@ -20868,17 +20830,6 @@ struct HitObject
     {
         __target_switch
         {
-        case hlsl:
-            __traceMotionRayHLSL(
-                AccelerationStructure,
-                RayFlags,
-                InstanceInclusionMask,
-                RayContributionToHitGroupIndex,
-                MultiplierForGeometryContributionToHitGroupIndex,
-                MissShaderIndex,
-                Ray,
-                CurrentTime,
-                __forceVarIntoRayPayloadStructTemporarily(Payload));
         case glsl_nv:
             {
                 [__vulkanRayPayload]
@@ -21123,7 +21074,6 @@ struct HitObject
     [ForceInline]
     [require(cuda, ser_motion_raygen_closesthit_miss)]
     [require(glsl_nv, ser_motion_raygen_closesthit_miss)]
-    [require(hlsl, ser_motion_raygen_closesthit_miss)]
     [require(spirv_nv, ser_motion_raygen_closesthit_miss)]
     static HitObject MakeMotionHit<attr_t>(
         RaytracingAccelerationStructure AccelerationStructure,
@@ -21139,7 +21089,6 @@ struct HitObject
     {
         __target_switch
         {
-        case hlsl: __intrinsic_asm "MakeMotionHit";
         case glsl:
         {
             // Save the attributes
@@ -21423,7 +21372,7 @@ struct HitObject
         /// See MakeMiss but handles Motion
         /// Currently only supported on VK
     [ForceInline]
-    [require(cuda_glsl_hlsl_spirv, ser_motion_raygen_closesthit_miss)]
+    [require(cuda_glsl_spirv, ser_motion_raygen_closesthit_miss)]
     static HitObject MakeMotionMiss(
         uint MissShaderIndex,
         RayDesc Ray,
@@ -21431,7 +21380,6 @@ struct HitObject
     {
         __target_switch
         {
-        case hlsl_nvapi: __intrinsic_asm "($3=NvMakeMotionMiss($0,$1,$2))";
         case glsl_nv:
             __glslMakeMotionMiss(__return_val, MissShaderIndex, Ray.Origin, Ray.TMin, Ray.Direction, Ray.TMax, CurrentTime);
         case glsl:
@@ -22176,7 +22124,7 @@ struct HitObject
     }
 
     [ForceInline]
-    [require(glsl_spirv, ser_raygen_closesthit_miss)]
+    [require(cuda_glsl_spirv, ser_raygen_closesthit_miss)]
     float GetCurrentTime() {
         __target_switch
         {
@@ -22184,6 +22132,7 @@ struct HitObject
             __intrinsic_asm "hitObjectGetCurrentTimeNV($0)";
         case glsl:
             __intrinsic_asm "hitObjectGetCurrentTimeEXT($0)";
+        case cuda: __intrinsic_asm "slangOptixHitObjectGetRayTime";
         case spirv_nv:
             return spirv_asm
             {

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -1211,7 +1211,7 @@ alias ser = raytracing + GL_NV_shader_invocation_reorder | raytracing + GL_EXT_s
 
 /// Capabilities needed for raytracing-motionblur
 /// [Compound]
-alias motionblur = GL_NV_ray_tracing_motion_blur | _sm_6_3 + hlsl_nvapi | cuda;
+alias motionblur = GL_NV_ray_tracing_motion_blur | cuda;
 /// Capabilities needed for compute-shader rayquery
 /// [Compound]
 alias rayquery = GL_EXT_ray_query | _sm_6_3;

--- a/tests/cuda/optix-ser.slang
+++ b/tests/cuda/optix-ser.slang
@@ -173,4 +173,14 @@ void rayGenerationMain()
 
     outputBuffer[idx] += uint(rayD.TMin > 0);
     outputBuffer[idx] += uint(rayD.TMax < ray.TMin);
+
+    // Test GetCurrentTime for motion hit objects (issue #9018)
+    // CHECK: slangOptixHitObjectGetRayTime
+    // CHECK-PTX: _optix_hitobject_get_ray_time
+    float currentTime0 = motionHitObj[0].GetCurrentTime();
+    // CHECK: slangOptixHitObjectGetRayTime
+    // CHECK-PTX: _optix_hitobject_get_ray_time
+    float currentTime1 = miss[1].GetCurrentTime();
+    outputBuffer[idx] += uint(currentTime0 >= 0.f);
+    outputBuffer[idx] += uint(currentTime1 >= 0.f);
 }

--- a/tests/nv-extensions/nv-ray-tracing-motion-blur.slang
+++ b/tests/nv-extensions/nv-ray-tracing-motion-blur.slang
@@ -1,5 +1,4 @@
 //TEST:SIMPLE(filecheck=CHECK_SPV): -emit-spirv-directly -stage raygeneration -entry main -target spirv-assembly
-//TEST:SIMPLE(filecheck=CHECK_HLSL): -stage raygeneration -entry main -target hlsl
 //TEST:SIMPLE(filecheck=CHECK_GLSL): -stage raygeneration -entry main -target glsl
 
 #define TRACING_EPSILON 1e-6
@@ -122,9 +121,6 @@ void main()
 // CHECK_SPV: %{{.*}} = OpVariable %_ptr_RayPayload{{NV|KHR}}_ReflectionRay{{.*}} RayPayload
 // CHECK_SPV: OpTraceRayMotionNV
 // CHECK_SPV: OpTraceRayKHR
-
-// CHECK_HLSL: TraceMotionRay
-// CHECK_HLSL: TraceRay
 
 // CHECK_GLSL: traceRayMotionNV(
 // CHECK_GLSL: traceRayEXT(

--- a/tests/vkray/raygen-trace-ray-param-non-struct.slang
+++ b/tests/vkray/raygen-trace-ray-param-non-struct.slang
@@ -39,17 +39,17 @@ void main()
              someInData1);
     outputBuffer1[0] = outputBuffer1[0]+someInData1;
 
+    // Motion blur not supported in HLSL - removed TraceMotionRay test
     // CHECK: rayPayload{{_[0-9]}}.data{{_[0-9]}} = rayPayload{{.*}}.data{{.*}};
-    // CHECK: TraceMotionRay(
+    // CHECK: TraceRay(
     // CHECK: rayPayload{{.*}}.data{{.*}};
-    TraceMotionRay(as,
+    TraceRay(as,
             1,
             0xff,
             0,
             0,
             2,
             ray,
-            0.0f,
             someInData1);
     outputBuffer1[0] = outputBuffer1[0]+someInData1;
 
@@ -64,20 +64,6 @@ void main()
              2,
              ray,
              someInData1);
-    outputBuffer1[0] = outputBuffer1[0]+someInData1;
-
-    // CHECK: rayPayload{{_[0-9]}}.data{{_[0-9]}} = {{.*}}
-    // CHECK: TraceMotionRay(
-    // CHECK: rayPayload{{.*}}.data{{.*}};
-    HitObject::TraceMotionRay(as,
-            1,
-            0xff,
-            0,
-            0,
-            2,
-            ray,
-            0.0f,
-            someInData1);
     outputBuffer1[0] = outputBuffer1[0]+someInData1;
 
     // CHECK: rayPayload{{_[0-9]}}.data{{_[0-9]}} = {{.*}}

--- a/tests/vkray/raygen-trace-ray-param-struct.slang
+++ b/tests/vkray/raygen-trace-ray-param-struct.slang
@@ -31,17 +31,7 @@ void main()
              someInData1);
     outputBuffer1[0] = outputBuffer1[0]+someInData1.data;
 
-    // CHECK: TraceMotionRay(
-    TraceMotionRay(as,
-            1,
-            0xff,
-            0,
-            0,
-            2,
-            ray,
-            0.0f,
-            someInData1);
-    outputBuffer1[0] = outputBuffer1[0]+someInData1.data;
+    // Motion blur not supported in HLSL - removed TraceMotionRay test
 
     // CHECK: NvTraceRayHitObject(
     HitObject::TraceRay(as,
@@ -52,18 +42,6 @@ void main()
              2,
              ray,
              someInData1);
-    outputBuffer1[0] = outputBuffer1[0]+someInData1.data;
-
-    // CHECK: TraceMotionRay(
-    HitObject::TraceMotionRay(as,
-            1,
-            0xff,
-            0,
-            0,
-            2,
-            ray,
-            0.0f,
-            someInData1);
     outputBuffer1[0] = outputBuffer1[0]+someInData1.data;
 
     // CHECK: NvInvokeHitObject(


### PR DESCRIPTION
Motion blur is NOT supported in HLSL or NVAPI, but GetCurrentTime and other motion functions incorrectly claimed HLSL support.

Changes:
- source/slang/slang-capabilities.capdef: Removed hlsl_nvapi from motionblur capability
- source/slang/hlsl.meta.slang: Removed HLSL support from GetCurrentTime, TraceMotionRay, MakeMotionHit, MakeMotionMiss, and RayCurrentTime. Deleted unused __traceMotionRayHLSL function.
- source/slang/glsl.meta.slang: Added motion blur extension and capability to hitObjectGetCurrentTimeNV and hitObjectGetCurrentTimeEXT
- prelude/slang-cuda-prelude.h: Added slangOptixHitObjectGetRayTime wrapper for OptiX 8.0+
- tests/cuda/optix-ser.slang: Added test for GetCurrentTime on motion hit objects with CUDA and PTX checks
- tests/nv-extensions/nv-ray-tracing-motion-blur.slang: Removed HLSL test case (motion blur not supported)
- tests/vkray/raygen-trace-ray-param-*.slang: Removed TraceMotionRay calls (HLSL-only tests, motion blur not supported)