### PR TITLE
Fix UBSan error: load of invalid `SpvOp` value

### DIFF
--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -8492,7 +8492,7 @@ static std::optional<SPIRVAsmInst> parseSPIRVAsmInst(Parser* parser)
 
     const auto& opcodeWord = spirvInfo->opcodes.lookup(ret.opcode.token.getContent());
     const auto& opInfo = opcodeWord ? spirvInfo->opInfos.lookup(*opcodeWord) : std::nullopt;
-    ret.opcode.knownValue = opcodeWord.value_or(SpvOp(0xffffffff));
+    ret.opcode.knownValue = opcodeWord.value_or(SpvOpMax);
 
     // If we couldn't find any info, but used this assignment syntax, raise
     // an error
@@ -8588,7 +8588,7 @@ static std::optional<SPIRVAsmInst> parseSPIRVAsmInst(Parser* parser)
     }
 
     if (ret.opcode.flavor == SPIRVAsmOperand::Flavor::NamedValue &&
-        ret.opcode.knownValue == (SpvWord)(SpvOp(0xffffffff)))
+        ret.opcode.knownValue == (SpvWord)SpvOpMax)
     {
         if (ret.opcode.token.type == TokenType::IntegerLiteral)
         {


### PR DESCRIPTION
Changes the opcode value used for unknown SPIR-V opcode names from 0xffffffff to `SpvOpMax`. Fixes the following UBSan errors:

```
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/optional:1034:30: runtime error: load of value 4294967295, which is not a valid value for type 'SpvOp_'
.../source/slang/slang-lookup-tables/slang-spirv-core-grammar-embed.cpp:2726:12: runtime error: load of value 4294967295, which is not a valid value for type 'const SpvOp' (aka 'const SpvOp_')
```

Related to #9099.