### PR TITLE
Fix UBSan errors: `memcpy()` and `memcmp()` called with null pointers

### DIFF
--- a/source/core/slang-blob.h
+++ b/source/core/slang-blob.h
@@ -280,7 +280,14 @@ public:
 protected:
     // Ctor
     // NOTE! Takes a copy of the input data
-    RawBlob(const void* data, size_t size) { memcpy(m_data.allocateTerminated(size), data, size); }
+    RawBlob(const void* data, size_t size)
+    {
+        m_data.allocateTerminated(size);
+        if (size > 0)
+        {
+            memcpy(m_data.getData(), data, size);
+        }
+    }
 
     void* getObject(const Guid& guid);
 

--- a/source/core/slang-rtti-util.cpp
+++ b/source/core/slang-rtti-util.cpp
@@ -578,38 +578,16 @@ static bool _isStructDefault(const StructRttiInfo* type, const void* src)
     // setting the count if it is <= capacity just sets the count (ie things aren't released(!)).
 
     List<Byte>& dstList = *(List<Byte>*)dst;
-    const Index oldCount = dstList.getCount();
-    if (oldCount == count)
-    {
-        return SLANG_OK;
-    }
-    if (count < oldCount)
-    {
-        dstList.unsafeShrinkToCount(count);
-        return SLANG_OK;
-    }
 
     const auto typeFuncs = typeMap->getFuncsForType(elementType);
     SLANG_ASSERT(typeFuncs.isValid());
-
-    const Index dstCapacity = dstList.getCapacity();
-    void* oldBuffer = dstList.detachBuffer();
 
     void* newBuffer = ::malloc(count * elementType->m_size);
     // Initialize it all first
     typeFuncs.ctorArray(typeMap, elementType, newBuffer, count);
 
-    typeFuncs.copyArray(typeMap, elementType, newBuffer, oldBuffer, oldCount);
-
     // Attach the new buffer
     dstList.attachBuffer((Byte*)newBuffer, count, count);
-
-    // Free the old buffer
-    if (oldBuffer)
-    {
-        typeFuncs.dtorArray(typeMap, elementType, oldBuffer, dstCapacity);
-        ::free(oldBuffer);
-    }
 
     return SLANG_OK;
 }

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -2286,10 +2286,13 @@ IRConstant* IRBuilder::_findOrEmitConstant(IRConstant& keyInst)
             IRConstant::StringValue& dstString = irValue->value.stringVal;
 
             dstString.numChars = uint32_t(sliceSize);
-            // Turn into pointer to avoid warning of array overrun
-            char* dstChars = dstString.chars;
-            // Copy the chars
-            memcpy(dstChars, slice.begin(), sliceSize);
+            if (sliceSize > 0)
+            {
+                // Turn into pointer to avoid warning of array overrun
+                char* dstChars = dstString.chars;
+                // Copy the chars
+                memcpy(dstChars, slice.begin(), sliceSize);
+            }
 
             break;
         }

--- a/tools/slang-unit-test/unit-test-persistent-cache.cpp
+++ b/tools/slang-unit-test/unit-test-persistent-cache.cpp
@@ -27,6 +27,11 @@ inline ComPtr<ISlangBlob> createRandomBlob(size_t size)
 
 inline bool isBlobEqual(ISlangBlob* a, ISlangBlob* b)
 {
+    if (a->getBufferSize() == 0 || b->getBufferSize() == 0)
+    {
+        return a->getBufferSize() == b->getBufferSize();
+    }
+
     return a->getBufferSize() == b->getBufferSize() &&
            ::memcmp(a->getBufferPointer(), b->getBufferPointer(), a->getBufferSize()) == 0;
 }


### PR DESCRIPTION
glibc's implementation of `string.h` uses GCC's `nonnull` function attribute to indicate that arguments must be non-null pointers. This causes UBSan to report errors when `memcpy()` and `memcmp()` are called with a null destination or source pointer, even when `n` is zero. E.g.:

```
.../source/slang/../core/../core/slang-blob.h:283:86: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
```

Related to #9099.