### PR TITLE
Fix usage tracking for ParameterBlocks

### DIFF
--- a/source/slang/slang-ir-metadata.cpp
+++ b/source/slang/slang-ir-metadata.cpp
@@ -92,7 +92,7 @@ void collectMetadataFromInst(IRInst* param, ArtifactPostEmitMetadata& outMetadat
         varLayout->findOffsetAttr(LayoutResourceKind::SubElementRegisterSpace);
     if (!containerSpaceOffset)
         return;
-    spaceOffset += containerSpaceOffset->getOffset();
+    spaceOffset = containerSpaceOffset->getOffset();
     for (auto sizeAttr : containerVarLayout->getTypeLayout()->getSizeAttrs())
     {
         auto kind = sizeAttr->getResourceKind();


### PR DESCRIPTION
Usage tracking for constant buffers generated from ParameterBlock can be incorrect.
In some cases, a default constant buffer is emitted for a ParameterBlock, but is not reported as used by isParameterLocationUsed().

# Minimal repro
```
struct Block
{
    RWTexture2D<float4> tex;
    uniform float color;
}

ParameterBlock<Block> block;
uniform float val;

[shader("compute")]
[numthreads(16, 16, 1)]
void main()
{
    block.tex[0] = block.color + val;
}
```

# Observed output

The generated HLSL contains a default constant buffer for the ParameterBlock:
```
cbuffer block_0 : register(b0, space1)
{
    Block_0 block_0;
}
```

# Observed behavior

Querying parameter usage metadata:
```
entryPointMetadata->isParameterLocationUsed(
    SLANG_PARAMETER_CATEGORY_CONSTANT_BUFFER,
    /*space=*/1,
    /*register=*/0,
    isUsed);
```

returns **false**.

# Change

When collecting metadata for a ParameterBlock, the register space used for the default constant buffer is now applied directly instead of being accumulated with an existing space offset.

# Result

After this change, the constant buffer binding corresponding to the ParameterBlock is correctly reported as used.