### PR TITLE
Enable Slack notifications for RTX Remix nightly CI

### DIFF
--- a/.github/workflows/compile-rtx-remix-shaders-nightly.yml
+++ b/.github/workflows/compile-rtx-remix-shaders-nightly.yml
@@ -298,12 +298,22 @@ jobs:
         env:
           BUILD_RESULT: ${{ job.status }}
 
-      # Slack notification on failure (for scheduled runs only)
-      # Temporarily disabled with "&& false" due to known incompatibility with RTX Remix shaders
-      # Re-enable once RTX Remix updates their shader code and Slang version
+      # Slack notifications (for scheduled runs only)
+      - name: Success notification
+        id: slack-notify-success
+        if: ${{ github.event_name == 'schedule' && success() }}
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "RTX-Remix-Nightly": ":green-check-mark: RTX Remix nightly status: ${{ job.status }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
       - name: Failure notification
         id: slack-notify-failure
-        if: ${{ github.event_name == 'schedule' && !success() && false }}
+        if: ${{ github.event_name == 'schedule' && !success() }}
         uses: slackapi/slack-github-action@v1.26.0
         with:
           payload: |


### PR DESCRIPTION
Add both success and failure Slack notifications to the RTX Remix shader compilation workflow, following the same pattern as other nightly workflows (vk-gl-cts-nightly).

Changes:
- Add success notification with green check emoji for passing builds
- Enable failure notification with alert emojis and run link
- Both notifications only trigger for scheduled runs

This completes the follow-up task to enable alerts now that the CI is expected to pass with ToT in both Slang and Remix.

Fixes #9272