### PR TITLE
Fix UBSan errors: vptr check failures due to lack of RTTI

### DIFF
--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -91,12 +91,6 @@ function(fetch_or_build_slang_llvm)
             target_compile_options(slang-llvm PRIVATE -wd4244 /Zc:preprocessor)
         endif()
 
-        if(NOT LLVM_ENABLE_RTTI)
-            # Make sure that we don't disable rtti if this library wasn't compiled with
-            # support
-            add_supported_cxx_flags(slang-llvm PRIVATE -fno-rtti /GR-)
-        endif()
-
         # TODO: Put a check here that libslang-llvm.so doesn't have a 'NEEDED'
         # directive for libLLVM-21.so, it's almost certainly going to break at
         # runtime in surprising ways when linked alongside Mesa (or anything else

--- a/external/build-llvm.sh
+++ b/external/build-llvm.sh
@@ -134,6 +134,9 @@ cmake_arguments_for_slang=(
   -DLLVM_ENABLE_PROJECTS=clang
   "-DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64"
   -DLLVM_BUILD_TOOLS=0
+  # slang-llvm is built with RTTI enabled to support UndefinedBehaviorSanitizer's vptr checks, so
+  # LLVM should be built with RTTI as well
+  -DLLVM_ENABLE_RTTI=1
   # Get LLVM to use the static linked version of the msvc runtime
   "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>"
   "-DLLVM_USE_CRT_RELEASE=MT"


### PR DESCRIPTION
Fixes lots of `member call on address [...] which does not point to an
object of type '[...]'` UBSan errors, e.g.:

```
.../source/compiler-core/slang-downstream-compiler-set.cpp:88:46: runtime error: member call on address 0x73ce982dc260 which does not point to an object of type 'Slang::IDownstreamCompiler'
```

UBSan's vptr/dynamic type checks require RTTI, as it assumes that a
vtable is invalid if the vtable prefix points to a null type info
pointer:

https://github.com/llvm/llvm-project/blob/ea9addae8336e92222214036bbec821e6b29d8bc/compiler-rt/lib/ubsan/ubsan_type_hash_itanium.cpp#L215-L217

But as LLVM is built without RTTI by default, slang-llvm was being built
without RTTI.

Related to #9099.