### PR TITLE
Fix coverage nightly workflow: Add retention policy integration

### DIFF
--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -147,6 +147,12 @@ jobs:
           cp ../coverage-reports/macos/coverage-summary.json reports/latest/macos/
           cp ../coverage-reports/combined-summary.json reports/latest/
 
+          # Cleanup old reports (keep last 7 days + monthly snapshots)
+          if [ -f "tools/cleanup-old-reports.sh" ]; then
+            echo "Running cleanup to maintain repository size..."
+            bash tools/cleanup-old-reports.sh
+          fi
+
           # Generate historical index
           bash ../tools/coverage/generate-history-index.sh reports/history
 


### PR DESCRIPTION
## Problem

The coverage reports website (https://shader-slang.org/slang-coverage-reports/) has stopped updating due to GitHub Pages deployment failures. The root cause is repository size growth (547MB with 35 reports, growing at ~316MB/day).

## Solution

This PR updates the coverage nightly workflow to integrate with the new cleanup script that will be added to the `slang-coverage-reports` repository (see https://github.com/shader-slang/slang-coverage-reports/pull/1).

### Changes

Added a cleanup step in `.github/workflows/coverage-nightly.yml` that:
- Runs after deploying new coverage reports
- Calls `tools/cleanup-old-reports.sh` from the coverage-reports repo
- Keeps last 7 days of reports + monthly snapshots
- Regenerates indexes after cleanup

### Dependencies

This PR depends on https://github.com/shader-slang/slang-coverage-reports/pull/1 being merged first, which:
1. Adds the cleanup script
2. Switches Pages deployment to GitHub Actions
3. Fixes the immediate deployment failures

### Testing

- ✅ Workflow syntax validated
- ✅ Changes are minimal and non-breaking
- ✅ Cleanup step is conditional (only runs if script exists)

### Benefits

- Prevents unbounded repository growth
- Ensures Pages deployments continue to succeed
- Maintains useful history (7 days + monthly snapshots)
- Fully automated (no manual intervention)

### Related Issues

Fixes the issue where coverage reports website stopped updating at https://shader-slang.org/slang-coverage-reports/