### PR TITLE
Add workspace mounts to container options for Copilot compatibility

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,6 +29,8 @@ jobs:
         -v /etc/vulkan/icd.d/nvidia_icd.json:/etc/vulkan/icd.d/nvidia_icd.json:ro
         -v /usr/share/nvidia:/usr/share/nvidia:ro
         -v /usr/share/glvnd/egl_vendor.d/10_nvidia.json:/usr/share/glvnd/egl_vendor.d/10_nvidia.json:ro
+        -v /runner/_work:/__w
+        -v /runner/externals:/__e:ro
 
     defaults:
       run:


### PR DESCRIPTION
Copilot's internal steps (Validate runner OS, Start MCP Servers, etc.) run inside the specified container and require access to workspace paths.

Added mounts:
- /runner/_work -> /__w (workspace for Copilot temp scripts)
- /runner/externals -> /__e (Node.js and GitHub Actions tools)

Fixes: bash: /__w/_temp/...: No such file or directory in Copilot steps