### PR TITLE
Install curl before Copilot preparation step

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -35,6 +35,10 @@ jobs:
         shell: bash
 
     steps:
+      - name: Install curl (required for Copilot preparation)
+        run: |
+          apt-get update && apt-get install -y curl
+
       - name: Install Git
         run: |
           apt-get update && apt-get install -y git


### PR DESCRIPTION
Copilot's preparation step needs curl to download the runtime, but the CUDA container doesn't include curl by default. This causes the download to fail silently with exit code 2.

Install curl as the very first step so it's available when Copilot's internal preparation runs.

Fixes: Prepare Copilot (Linux) fails with exit code 2