### PR TITLE
Fix incorrect use of reinterpret_cast and union

### DIFF
--- a/include/slang-com-helper.h
+++ b/include/slang-com-helper.h
@@ -6,7 +6,9 @@
 
 #include "slang.h"
 
+#include <algorithm>
 #include <atomic>
+#include <iterator>
 
 /* !!!!!!!!!!!!!!!!!!!!! Macros to help checking SlangResult !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!*/
 
@@ -98,19 +100,8 @@ typedef SlangUUID Guid;
 
 SLANG_FORCE_INLINE bool operator==(const Slang::Guid& aIn, const Slang::Guid& bIn)
 {
-    using namespace Slang;
-    // Use the largest type the honors the alignment of Guid
-    typedef uint32_t CmpType;
-    union GuidCompare
-    {
-        Guid guid;
-        CmpType data[sizeof(Guid) / sizeof(CmpType)];
-    };
-    // Type pun - so compiler can 'see' the pun and not break aliasing rules
-    const CmpType* a = reinterpret_cast<const GuidCompare&>(aIn).data;
-    const CmpType* b = reinterpret_cast<const GuidCompare&>(bIn).data;
-    // Make the guid comparison a single branch, by not using short circuit
-    return ((a[0] ^ b[0]) | (a[1] ^ b[1]) | (a[2] ^ b[2]) | (a[3] ^ b[3])) == 0;
+    return aIn.data1 == bIn.data1 && aIn.data2 == bIn.data2 && aIn.data3 == bIn.data3 &&
+           std::equal(aIn.data4, aIn.data4 + std::size(aIn.data4), bIn.data4);
 }
 
 SLANG_FORCE_INLINE bool operator!=(const Slang::Guid& a, const Slang::Guid& b)


### PR DESCRIPTION
I wasn't entirely sure, according to discussion https://github.com/llvm/llvm-project/issues/173167, it turned out that compilers do not provide type-punning in such cases and such use of reinterpret_cast and union leads to undefined behavior.

```cpp
struct SlangUUID
    {
        uint32_t data1;
        uint16_t data2;
        uint16_t data3;
        uint8_t data4[8];
    };

bool foo(const SlangUUID& aIn, const SlangUUID& bIn)
{
    typedef uint32_t CmpType;
    union GuidCompare
    {
        SlangUUID guid;
        CmpType data[sizeof(SlangUUID) / sizeof(CmpType)];
    };
    const CmpType* a = reinterpret_cast<const GuidCompare&>(aIn).data;
    const CmpType* b = reinterpret_cast<const GuidCompare&>(bIn).data;

    return ((a[0] ^ b[0]) | (a[1] ^ b[1]) | (a[2] ^ b[2]) | (a[3] ^ b[3])) == 0;
}
```
the _structure_ is converted to a _union_ (with a member of array of `uint32[4]`), and these types are not pointer-interconvertible (this is undefined behavior according to the C++ standard) (**[basic.compound#5]**).
https://eel.is/c++draft/basic.compound#5
https://eel.is/c++draft/conv.qual#2
https://eel.is/c++draft/class.mem#general-30