### PR TITLE
Fix Git safe.directory configuration for container workflows

### DIFF
--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -25,6 +25,9 @@ jobs:
         shell: bash
 
     steps:
+      - name: Configure Git safe directory
+        run: git config --global --add safe.directory '*'
+
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -47,6 +47,9 @@ jobs:
         shell: bash
 
     steps:
+      - name: Configure Git safe directory
+        run: git config --global --add safe.directory '*'
+
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
@@ -150,6 +153,9 @@ jobs:
         shell: bash
 
     steps:
+      - name: Configure Git safe directory
+        run: git config --global --add safe.directory '*'
+
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
@@ -218,6 +224,9 @@ jobs:
         shell: bash
 
     steps:
+      - name: Configure Git safe directory
+        run: git config --global --add safe.directory '*'
+
       - uses: actions/checkout@v4
 
       - name: Download artifacts

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -38,6 +38,9 @@ jobs:
         shell: bash
 
     steps:
+      - name: Configure Git safe directory
+        run: git config --global --add safe.directory '*'
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Add git config step before checkout action in all container workflows. GitHub Actions temporarily overrides HOME during checkout, preventing the global git config from the Dockerfile from being accessible. This causes 'dubious ownership' errors when initializing submodules.

The fix adds a 'Configure Git safe directory' step before each checkout action to ensure git can work with the repository and submodules.