### PR TITLE
Add packages:read permission for container image authentication

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -17,6 +17,7 @@ jobs:
       contents: read
       pull-requests: write
       checks: write
+      packages: read
 
     container:
       image: ghcr.io/shader-slang/slang-linux-gpu-ci:12.4.1


### PR DESCRIPTION
Copilot workflow needs packages:read to authenticate and pull private container images from ghcr.io using GITHUB_TOKEN.

Without this permission, container pull fails with 'denied' error even though container.credentials are specified.

Fixes: Error response from daemon: denied when pulling ghcr.io/shader-slang/slang-linux-gpu-ci:12.4.1