### PR TITLE
Fix Copilot path mapping - mount _work to work not _work

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,7 +33,8 @@ jobs:
         -v /etc/vulkan/icd.d/nvidia_icd.json:/etc/vulkan/icd.d/nvidia_icd.json:ro
         -v /usr/share/nvidia:/usr/share/nvidia:ro
         -v /usr/share/glvnd/egl_vendor.d/10_nvidia.json:/usr/share/glvnd/egl_vendor.d/10_nvidia.json:ro
-        -v /runner:/home/runner
+        -v /runner/_work:/home/runner/work
+        -v /runner/externals:/home/runner/externals
 
     defaults:
       run:


### PR DESCRIPTION
Copilot expects paths like:
  /home/runner/work/_temp/***-action-main/ebpf/launch.sh

Previous mount created wrong structure:
  -v /runner:/home/runner → /home/runner/_work (incorrect)

Correct mounts:
  -v /runner/_work:/home/runner/work → /home/runner/work (correct)
  -v /runner/externals:/home/runner/externals

This matches Copilot's expected directory layout where workspace is at /home/runner/work, not /home/runner/_work.