### PR TITLE
Use the system-installed `slangc` compiler when building without dependencies

### DIFF
--- a/source/standard-modules/neural/CMakeLists.txt
+++ b/source/standard-modules/neural/CMakeLists.txt
@@ -39,7 +39,8 @@ elseif(SLANG_ENABLE_SLANGC)
     set(SLANG_COMPILER slangc)
     set(SLANG_COMPILER_DEPENDENCY slangc)
 else()
-    set(SLANG_COMPILER)
+    # As a fallback, use the system-installed `slangc` compiler
+    set(SLANG_COMPILER slangc)
     set(SLANG_COMPILER_DEPENDENCY)
 endif()
 


### PR DESCRIPTION
Use the system-installed `slangc` compiler (from the Vulkan SDK etc) when the project is built without one.