### PR TITLE
(draft) Fix typename/alias error for InternallyLinkedListNode

### DIFF
--- a/source/core/slang-internally-linked-list.h
+++ b/source/core/slang-internally-linked-list.h
@@ -119,7 +119,7 @@ private:
 };
 
 template<typename T>
-using InternallyLinkedListNode = InternallyLinkedList<T>::Node;
+using InternallyLinkedListNode = typename InternallyLinkedList<T>::Node;
 
 } // namespace Slang
 


### PR DESCRIPTION
Case dismissed: Use somerthing like
```bash
CC=clang-18 CXX=clang++-18   
```
before cmake config commands (or maybe all cmake commands during your slang build-installtion process)

(This may be a clang version issue. Ignore it for now)

Reproducing the issue:

Prerequisites/steps:
```bash
cd $REPOROOT
git clone https://github.com/shader-slang/slang --recursive
# don't `cd` into it yet:
git fetch https://github.com/shader-slang/slang.git 'refs/tags/*:refs/tags/*'
cd slang
cmake --preset default
cmake --build --preset releaseWithDebugInfo
```

The main step:
```bash
cmake --build --preset releaseWithDebugInfo
```

```txt
[0/2] Re-checking globbed directories...
[84/965] Building CXX object source/core/CMakeFiles/core.dir/RelWithDebInfo/slang-archive-file-system.cpp.o
FAILED: source/core/CMakeFiles/core.dir/RelWithDebInfo/slang-archive-file-system.cpp.o
/usr/bin/clang++ -DMINIZ_STATIC_DEFINE -DNOMINMAX -DSLANG_ENABLE_DXIL_SUPPORT=1 -DSLANG_STATIC -DUNICODE -DVC_EXTRALEAN -DWIN32_LEAN_AND_MEAN -D_UNICODE -DCMAKE_INTDIR=\"RelWithDebInfo\" -I/dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/source -I/dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/include -isystem /dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/external/miniz -isystem /dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/build/external/miniz -isystem /dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/external/lz4/build/cmake/../../lib -isystem /dataneura/gpu-experimentations/experiments/20_slang_shad
ers/slang/external/unordered_dense/include -O2 -g -DNDEBUG -std=gnu++20 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -g -Wall -Wno-switch -Wno-parentheses -Wno-unused-local-typedefs -Wno-assume -Wno-reorder -Wno-invalid-offsetof -Wno-newline-eof -Wno-return-std-move -Wno-unused-but-set-variable -Wnarrowing -Wextra -MD -MT source/core/CMakeFiles/core.dir/RelWithDebInfo/slang-archive-file-system.cpp.o -MF source/core/CMakeFiles/core.dir/RelWithDebInfo/slang-archive-file-system.cpp.o.d -o source/core/CMakeFiles/core.dir/RelWithDebInfo/slang-archive-file-system.cpp.o -c /dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/source/core/slang-archive-file-system.cpp
In file included from /dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/source/core/slang-archive-file-system.cpp:8:
In file included from /dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/source/core/slang-riff-file-system.h:6:
In file included from /dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/source/core/slang-riff.h:19:
/dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/source/core/slang-internally-linked-list.h:122:34: error: missing 'typename' prior to dependent type name 'InternallyLinkedList<T>::Node'
using InternallyLinkedListNode = InternallyLinkedList<T>::Node;
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                 typename
1 error generated.
[85/965] Building CXX object source/core/CMakeFiles/core.dir/RelWithDebInfo/slang-blob-builder.cpp.o
FAILED: source/core/CMakeFiles/core.dir/RelWithDebInfo/slang-blob-builder.cpp.o
/usr/bin/clang++ -DMINIZ_STATIC_DEFINE -DNOMINMAX -DSLANG_ENABLE_DXIL_SUPPORT=1 -DSLANG_STATIC -DUNICODE -DVC_EXTRALEAN -DWIN32_LEAN_AND_MEAN -D_UNICODE -DCMAKE_INTDIR=\"RelWithDebInfo\" -I/dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/source -I/dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/include -isystem /dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/external/miniz -isystem /dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/build/external/miniz -isystem /dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/external/lz4/build/cmake/../../lib -isystem /dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/external/unordered_dense/include -O2 -g -DNDEBUG -std=gnu++20 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -g -Wall -Wno-switch -Wno-parentheses -Wno-unused-local-typedefs -Wno-assume -Wno-reorder -Wno-invalid-offsetof -Wno-newline-eof -Wno-return-std-move -Wno-unused-but-set-variable -Wnarrowing -Wextra -MD -MT source/core/CMakeFiles/core.dir/RelWithDebInfo/slang-blob-builder.cpp.o -MF source/core/CMakeFiles/core.dir/RelWithDebInfo/slang-blob-builder.cpp.o.d -o source/core/CMakeFiles/core.dir/RelWithDebInfo/slang-blob-builder.cpp.o -c /dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/source/core/slang-blob-builder.cpp
In file included from /dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/source/core/slang-blob-builder.cpp:2:
In file included from /dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/source/core/slang-blob-builder.h:26:
/dataneura/gpu-experimentations/experiments/20_slang_shaders/slang/source/core/slang-internally-linked-list.h:122:34: error: missing 'typename' prior to dependent type name 'InternallyLinkedList<T>::Node'
using InternallyLinkedListNode = InternallyLinkedList<T>::Node;
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                 typename
1 error generated.
[89/965] Building CXX object external/slang-rhi/CMakeFiles/slang-rhi.dir/RelWithDebInfo/src/cuda/optix-api-impl-9_0.cpp.o
ninja: build stopped: subcommand failed.
```
