### PR TITLE
Fix SPIR-V emit crash for tess factors

### DIFF
--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -921,6 +921,73 @@ struct PeepholeContext : InstPassBase
                     maybeRemoveOldInst(inst);
                     changed = true;
                 }
+                else
+                {
+                    // Handle common BuiltinCast cases that need to be lowered before emit.
+                    // In particular, legalization for tessellation-factor builtins may require
+                    // reshaping between vector and array representations (e.g. float4 <->
+                    // float[4]).
+                    auto val = inst->getOperand(0);
+                    auto fromType = val->getDataType();
+                    auto toType = inst->getFullType();
+
+                    // vector -> array
+                    if (auto fromVec = as<IRVectorType>(fromType))
+                    {
+                        if (auto toArr = as<IRArrayTypeBase>(toType))
+                        {
+                            if (isTypeEqual(fromVec->getElementType(), toArr->getElementType()))
+                            {
+                                auto fromCountLit = as<IRIntLit>(fromVec->getElementCount());
+                                auto toCountLit = as<IRIntLit>(toArr->getElementCount());
+                                if (fromCountLit && toCountLit &&
+                                    fromCountLit->getValue() == toCountLit->getValue())
+                                {
+                                    List<IRInst*> elems;
+                                    auto count = (UInt)fromCountLit->getValue();
+                                    elems.setCount((Index)count);
+                                    for (UInt i = 0; i < count; ++i)
+                                    {
+                                        elems[(Index)i] = builder.emitElementExtract(val, i);
+                                    }
+                                    auto newInst =
+                                        builder.emitMakeArray(toType, count, elems.getBuffer());
+                                    inst->replaceUsesWith(newInst);
+                                    maybeRemoveOldInst(inst);
+                                    changed = true;
+                                }
+                            }
+                        }
+                    }
+                    // array -> vector
+                    else if (auto fromArr = as<IRArrayTypeBase>(fromType))
+                    {
+                        if (auto toVec = as<IRVectorType>(toType))
+                        {
+                            if (isTypeEqual(fromArr->getElementType(), toVec->getElementType()))
+                            {
+                                auto fromCountLit = as<IRIntLit>(fromArr->getElementCount());
+                                auto toCountLit = as<IRIntLit>(toVec->getElementCount());
+                                if (fromCountLit && toCountLit &&
+                                    fromCountLit->getValue() == toCountLit->getValue())
+                                {
+                                    List<IRInst*> elems;
+                                    auto count = (UInt)fromCountLit->getValue();
+                                    elems.setCount((Index)count);
+                                    for (UInt i = 0; i < count; ++i)
+                                    {
+                                        elems[(Index)i] = builder.emitElementExtract(val, i);
+                                    }
+                                    auto newInst =
+                                        builder.emitMakeVector(toType, count, elems.getBuffer());
+                                    inst->replaceUsesWith(newInst);
+                                    maybeRemoveOldInst(inst);
+                                    changed = true;
+                                }
+                            }
+                        }
+                    }
+                }
             }
             break;
         case kIROp_VectorReshape:

--- a/tests/current-bugs/spirv-hull-sv_tessfactor-float4-cast-crash.slang
+++ b/tests/current-bugs/spirv-hull-sv_tessfactor-float4-cast-crash.slang
@@ -1,0 +1,57 @@
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv-asm -stage hull -entry hullMain -allow-glsl
+
+/*
+Repro for SPIR-V emit crash when using vector types for tessellation-factor builtins.
+
+HLSL requires:
+- SV_TessFactor: float[4] for quad (float[3] tri, float[2] line)
+- SV_InsideTessFactor: float[2] for quad (float[1] tri)
+
+Slang currently allows authoring `float4`/`float2` here (and docs show this form),
+but SPIR-V legalization introduces a BuiltinCast (vector -> array) which the SPIR-V
+emitter doesn't handle, leading to an internal error like:
+
+(0): error 99999: Slang compilation aborted due to an exception of ...: unimplemented:
+Unhandled local inst in spirv-emit:
+let  %1 : %2    = BuiltinCast(%3)
+*/
+
+struct PerVertex
+{
+    float4 position : SV_Position;
+};
+
+// SPIRV: OpCapability Tessellation
+// SPIRV: OpDecorate %gl_TessLevelOuter BuiltIn TessLevelOuter
+// SPIRV: OpDecorate %gl_TessLevelOuter Patch
+// SPIRV: OpDecorate %gl_TessLevelInner BuiltIn TessLevelInner
+// SPIRV: OpDecorate %gl_TessLevelInner Patch
+
+// Hull Shader (HS)
+[shader("hull")]
+[domain("quad")]
+[partitioning("fractional_odd")]
+[outputtopology("triangle_cw")]
+[outputcontrolpoints(4)]
+[patchconstantfunc("constants")]
+PerVertex hullMain(InputPatch<PerVertex, 4> patch, uint i : SV_OutputControlPointID)
+{
+    return patch[i];
+}
+
+struct PatchTessFactors
+{
+    // This is the problematic case: vector types on tessellation-factor builtins.
+    float4 EdgeTessFactor : SV_TessFactor;
+    float2 InsideTessFactor : SV_InsideTessFactor;
+};
+
+PatchTessFactors constants(InputPatch<PerVertex, 4> patch)
+{
+    PatchTessFactors o;
+    o.EdgeTessFactor = float4(1.0, 2.0, 3.0, 4.0);
+    o.InsideTessFactor = float2(0.5, 0.5);
+    return o;
+}
+
+


### PR DESCRIPTION
fixes #9496 

Fix SPIR-V emit crash for tess factors using vector types: Implement kIROp_BuiltinCast lowering in slang-emit-spirv for vector from/to array reshapes (e.g. float4/float2 tess factors)
Add a regression test covering SV_TessFactor/SV_InsideTessFactor on hull shaders.