### PR TITLE
Use GitHub larger runner for Copilot to avoid path issues

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -10,8 +10,9 @@ on:
 
 jobs:
   copilot-setup-steps:
-    # Use self-hosted ARC runner with GPU support for Copilot
-    runs-on: [self-hosted, Linux, GPU, arc]
+    # Use GitHub larger runner with GPU support for Copilot
+    # Avoids path mapping issues with ARC runners (/runner vs /home/runner)
+    runs-on: slang-larger-runner-1
 
     permissions:
       contents: read
@@ -33,8 +34,6 @@ jobs:
         -v /etc/vulkan/icd.d/nvidia_icd.json:/etc/vulkan/icd.d/nvidia_icd.json:ro
         -v /usr/share/nvidia:/usr/share/nvidia:ro
         -v /usr/share/glvnd/egl_vendor.d/10_nvidia.json:/usr/share/glvnd/egl_vendor.d/10_nvidia.json:ro
-        -v /runner/_work:/home/runner/work
-        -v /runner/externals:/home/runner/externals
 
     defaults:
       run:


### PR DESCRIPTION
GitHub larger runners use standard /home/runner paths (not /runner), eliminating the need for path workarounds required with ARC runners.

Changed:
- runs-on: slang-larger-runner-1 (was: [self-hosted, Linux, GPU, arc])
- Removed /runner bind-mount workarounds (not needed)

Benefits:
- No path mapping conflicts with Copilot's hardcoded /home/runner paths
- Pre-authenticated to ghcr.io (no auth issues)
- Standard GitHub Actions environment

Container specification remains for CUDA build environment.