### PR TITLE
Add CMake and build tools installation for larger runner

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,6 +30,17 @@ jobs:
           submodules: recursive
           fetch-depth: 2
 
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential ninja-build git python3 wget
+
+          # Install CMake 3.30 (required for CMakePresets.json version 6)
+          wget -q https://github.com/Kitware/CMake/releases/download/v3.30.0/cmake-3.30.0-linux-x86_64.tar.gz
+          tar -xzf cmake-3.30.0-linux-x86_64.tar.gz -C /tmp
+          sudo ln -sf /tmp/cmake-3.30.0-linux-x86_64/bin/cmake /usr/local/bin/cmake
+          sudo ln -sf /tmp/cmake-3.30.0-linux-x86_64/bin/ctest /usr/local/bin/ctest
+
       - name: Verify GPU access
         run: |
           echo "=== GPU Information ==="


### PR DESCRIPTION
Larger runner doesn't have build tools pre-installed. Install:
- CMake 3.30 (required for CMakePresets.json v6)
- build-essential, ninja-build, git, python3

CMake extracted to /tmp and symlinked to avoid permission issues.