### PR TITLE
Export CUDA paths in each step for nvcc availability

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -50,6 +50,9 @@ jobs:
 
       - name: Verify GPU access
         run: |
+          export PATH=/usr/local/cuda-12.4/bin:$PATH
+          export LD_LIBRARY_PATH=/usr/local/cuda-12.4/lib64:$LD_LIBRARY_PATH
+
           echo "=== GPU Information ==="
           nvidia-smi
           echo "=== CMake version ==="
@@ -59,10 +62,16 @@ jobs:
 
       - name: Configure CMake
         run: |
+          export PATH=/usr/local/cuda-12.4/bin:$PATH
+          export LD_LIBRARY_PATH=/usr/local/cuda-12.4/lib64:$LD_LIBRARY_PATH
+
           cmake --preset default --fresh \
             -DSLANG_ENABLE_CUDA=ON \
             -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
 
       - name: Build Slang
         run: |
+          export PATH=/usr/local/cuda-12.4/bin:$PATH
+          export LD_LIBRARY_PATH=/usr/local/cuda-12.4/lib64:$LD_LIBRARY_PATH
+
           cmake --build --preset debug -j$(nproc)


### PR DESCRIPTION
GITHUB_PATH and GITHUB_ENV don't take effect in the same step. Export CUDA paths explicitly in each step that needs nvcc:
- Verify step (nvcc --version)
- Configure step (CMake needs to find nvcc)
- Build step (compilation uses nvcc)

PATH: /usr/local/cuda-12.4/bin
LD_LIBRARY_PATH: /usr/local/cuda-12.4/lib64