### PR TITLE
Fix preprocessor AtStartOfLine flag regression in macro

### DIFF
--- a/source/slang/slang-preprocessor.cpp
+++ b/source/slang/slang-preprocessor.cpp
@@ -1996,7 +1996,10 @@ Token MacroInvocation::_readTokenImpl()
             // at start of line, if it is, we must mark the first token as start of line
             // as well, otherwise the expanded code could be invalid.
             if (m_isStartOfLine)
+            {
                 token.flags |= TokenFlag::AtStartOfLine;
+                m_isStartOfLine = false;
+            }
             return token;
         }
 
@@ -2023,7 +2026,10 @@ Token MacroInvocation::_readTokenImpl()
             // at start of line, if it is, we must mark the first token as start of line
             // as well, otherwise the expanded code could be invalid.
             if (m_isStartOfLine)
+            {
                 token.flags |= TokenFlag::AtStartOfLine;
+                m_isStartOfLine = false;
+            }
             return token;
         }
 


### PR DESCRIPTION
This fixes a regression introduced by PR https://github.com/shader-slang/slang/pull/9495 where the AtStartOfLine flag was being set on ALL tokens from a macro expansion instead of just the first token.

Root Cause:
PR https://github.com/shader-slang/slang/pull/9495 added code to preserve line breaks in macro expansions by setting AtStartOfLine on the first token when a macro is invoked at the start of a line. However, the implementation
was missing a check to ensure the flag is only set ONCE, leading to all tokens getting the flag.

Solution:
Apply `AtStartOfLine` only to the first token during the macro expansion.