### PR TITLE
ci: Enable slangpy tests on Linux debug

### DIFF
--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -198,7 +198,7 @@ jobs:
   test-slangpy:
     runs-on: ["Linux", "self-hosted", "GPU"]
     timeout-minutes: 30
-    if: always() && inputs.config == 'release'
+    if: always()
 
     permissions:
       contents: read


### PR DESCRIPTION
Slangpy version 0.40.1 includes fix to enable running CI tests on debug builds.

Fixes #9390