### PR TITLE
Fix a cyclic reference issue while checking type constraints

### DIFF
--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -829,6 +829,13 @@ public:
     //
     DeclRef<GenericDecl> getDependentGenericParent(DeclRef<Decl> declRef);
 
+    void removeInheritanceInfoFromCache(DeclRef<Decl>& key)
+    {
+        if (m_mapDeclRefToInheritanceInfo.tryGetValue(key))
+        {
+            m_mapDeclRefToInheritanceInfo.remove(key);
+        }
+    }
 private:
     /// Mapping from type declarations to the known extensiosn that apply to them
     Dictionary<AggTypeDecl*, RefPtr<CandidateExtensionList>> m_mapTypeDeclToCandidateExtensions;
@@ -1160,6 +1167,14 @@ public:
         return result;
     }
 
+    SemanticsContext withInheritanceCacheDisabled(DiagnosticSink* sink)
+    {
+        SemanticsContext result(*this);
+        result.m_sink = sink;
+        result.m_disableCachingInheritanceInfo = true;
+        return result;
+    }
+
     Decl* getDeclToExcludeFromLookup() { return m_declToExcludeFromLookup; }
 
     SemanticsContext excludeTransparentMembersFromLookup()
@@ -1178,6 +1193,7 @@ public:
         return m_shared->getGLSLBindingOffsetTracker();
     }
 
+    bool disableCachingInheritanceInfo() { return m_disableCachingInheritanceInfo; }
 private:
     SharedSemanticsContext* m_shared = nullptr;
 
@@ -1189,6 +1205,7 @@ private:
 
     bool m_excludeTransparentMembersFromLookup = false;
 
+    bool m_disableCachingInheritanceInfo = false;
 protected:
     // TODO: consider making more of this state `private`...
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -836,6 +836,7 @@ public:
             m_mapDeclRefToInheritanceInfo.remove(key);
         }
     }
+
 private:
     /// Mapping from type declarations to the known extensiosn that apply to them
     Dictionary<AggTypeDecl*, RefPtr<CandidateExtensionList>> m_mapTypeDeclToCandidateExtensions;
@@ -1194,6 +1195,7 @@ public:
     }
 
     bool disableCachingInheritanceInfo() { return m_disableCachingInheritanceInfo; }
+
 private:
     SharedSemanticsContext* m_shared = nullptr;
 
@@ -1206,6 +1208,7 @@ private:
     bool m_excludeTransparentMembersFromLookup = false;
 
     bool m_disableCachingInheritanceInfo = false;
+
 protected:
     // TODO: consider making more of this state `private`...
 

--- a/source/slang/slang-check-inheritance.cpp
+++ b/source/slang/slang-check-inheritance.cpp
@@ -512,10 +512,10 @@ InheritanceInfo SharedSemanticsContext::_calcInheritanceInfo(
                 // because if the inheritance info is not completed for some type due to the above
                 // reason, we will still have chance to check later on when everything is ready.
                 //
-                // This solution might be too aggressive to abandon the cache. The more smart solution
-                // is that we can check if sub has any dependency constraintDeclRef that is being checked,
-                // then we will know that it's expected to fail here, so we can disable the cache only in
-                // that case.
+                // This solution might be too aggressive to abandon the cache. The more smart
+                // solution is that we can check if sub has any dependency constraintDeclRef that is
+                // being checked, then we will know that it's expected to fail here, so we can
+                // disable the cache only in that case.
                 auto typeRepr = subVisitor.TranslateTypeNodeImpl(sub.exp);
 
                 if (tmpSink.getErrorCount() != 0)

--- a/source/slang/slang-check-inheritance.cpp
+++ b/source/slang/slang-check-inheritance.cpp
@@ -29,9 +29,11 @@ InheritanceInfo SharedSemanticsContext::getInheritanceInfo(
     // inheritance graph, and we need to avoid crashing or going
     // into an infinite loop in such cases.
     //
+
     m_mapTypeToInheritanceInfo[type] = InheritanceInfo();
 
     auto info = _calcInheritanceInfo(type, circularityInfo);
+
     m_mapTypeToInheritanceInfo[type] = info;
 
     return info;
@@ -93,9 +95,11 @@ InheritanceInfo SharedSemanticsContext::_getInheritanceInfo(
     // inheritance graph, and we need to avoid crashing or going
     // into an infinite loop in such cases.
     //
+
     m_mapDeclRefToInheritanceInfo[declRef] = InheritanceInfo();
 
     auto info = _calcInheritanceInfo(declRef, selfType, circularityInfo);
+
     m_mapDeclRefToInheritanceInfo[declRef] = info;
 
     getSession()->m_typeDictionarySize = Math::Max(
@@ -490,11 +494,42 @@ InheritanceInfo SharedSemanticsContext::_calcInheritanceInfo(
             // If the sub-type part of the generic constraint is a member expression, it can't
             // possibly be defining a constraint for a generic type parameter, so we skip it
             // to avoid circular checking on the generic param type.
-            if (selfIsGenericParamType && as<MemberExpr>(sub.exp))
+            if (selfIsGenericParamType && (as<MemberExpr>(sub.exp)))
                 continue;
 
             if (!sub.type)
-                sub = visitor.TranslateTypeNodeForced(sub);
+            {
+                DiagnosticSink tmpSink;
+                SemanticsVisitor subVisitor(visitor.withInheritanceCacheDisabled(&tmpSink));
+                auto orgQualType = sub.exp->type;
+
+                // The idea here is that not all the constraintDeclRef is possibly related to
+                // the selfType. So we shouldn't report any errors if it's failed to check its
+                // type, because at this point, there is possible some of other constraints that
+                // is dependent by this one is being check now, so it's expected to fail here. We
+                // can leave the upper level caller to report the error when the inheritance info
+                // doesn't satisfy the requirement. Meanwhile, we should also disable the cache
+                // because if the inheritance info is not completed for some type due to the above
+                // reason, we will still have chance to check later on when everything is ready.
+                //
+                // This solution might be too aggressive to abandon the cache. The more smart solution
+                // is that we can check if sub has any dependency constraintDeclRef that is being checked,
+                // then we will know that it's expected to fail here, so we can disable the cache only in
+                // that case.
+                auto typeRepr = subVisitor.TranslateTypeNodeImpl(sub.exp);
+
+                if (tmpSink.getErrorCount() != 0)
+                {
+                    sub.exp->checked = false;
+                    sub.exp->type = orgQualType;
+                    sub.type = nullptr;
+                    continue;
+                }
+
+                TypeExp result;
+                sub.exp = typeRepr;
+                sub.type = subVisitor.ExtractTypeFromTypeRepr(typeRepr);
+            }
             auto subType = constraintDeclRef.substitute(astBuilder, sub.type);
 
             // We only consider constraints where the type represented

--- a/source/slang/slang-lookup.cpp
+++ b/source/slang/slang-lookup.cpp
@@ -606,8 +606,8 @@ static void _lookUpMembersInSuperTypeDeclImpl(
         {
             if (auto declRefType = as<DeclRefType>(selfType))
             {
-                auto declRef = declRefType->getDeclRef();
-                semantics->getShared()->removeInheritanceInfoFromCache(declRef);
+                auto decl = declRefType->getDeclRef();
+                semantics->getShared()->removeInheritanceInfoFromCache(decl);
             }
         }
     }

--- a/source/slang/slang-lookup.cpp
+++ b/source/slang/slang-lookup.cpp
@@ -602,6 +602,14 @@ static void _lookUpMembersInSuperTypeDeclImpl(
     {
         selfType = selfType->getCanonicalType();
         inheritanceInfo = semantics->getShared()->getInheritanceInfo(selfType);
+        if (semantics->disableCachingInheritanceInfo())
+        {
+            if (auto declRefType = as<DeclRefType>(selfType))
+            {
+                auto declRef = declRefType->getDeclRef();
+                semantics->getShared()->removeInheritanceInfoFromCache(declRef);
+            }
+        }
     }
 
     _lookupMembersInSuperTypeFacets(

--- a/tests/language-feature/generics/type-constraints-dependency.slang
+++ b/tests/language-feature/generics/type-constraints-dependency.slang
@@ -1,0 +1,57 @@
+// TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -output-using-type
+// TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type
+
+
+public interface IFoo<T> : IDifferentiablePtrType
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+{
+    static const int Val;
+}
+
+struct FooImp<T> : IFoo<T>
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+{
+    typealias Differential = FooImp<T.Differential>;
+    static const int Val = 16;
+}
+
+public interface IBar<T> : IDifferentiable
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+{
+     public associatedtype Differential : IBar<T.Differential>;
+     static const int Val;
+}
+
+struct BarImp<T> : IBar<T>
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+{
+    typealias Differential = BarImp<T.Differential>;
+    static const int Val = 32;
+}
+
+public struct MyStruct<T, Foo, Bar>
+    where T : __BuiltinFloatingPointType
+    where T == T.Differential           // checking this now
+    where Foo : IFoo<T>          // checking this now.
+    where Foo.Differential : IFoo<T.Differential>
+    where Bar : IBar<T>
+{
+    static const int ParameterCount = Foo.Val * Bar.Val;
+}
+
+// TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    MyStruct<float, FooImp<float>, BarImp<float>> s;
+    outputBuffer[0] = s.ParameterCount;
+    // CHECK: 512
+}
+


### PR DESCRIPTION
Close #9622.

The root cause of this issue is that we diagnose the error too early when collecting the inheritance info of a generic type parameter, because some of the checking might not be ready. Assume this case:

```
interface IFoo<T> where T:XXX where T.Differential == T
func<U, Foo>()
   where U:XXX
   where U == U.Differential
   where Foo : IFoo<U>
   where Foo.Differential : IFoo<U.Differential>
```

this code will report error that `typeof(S)` doesn't have member of `Differential`. That is because we check `Foo.Differential` while ` Foo : IFoo<U>` is being checked.

The reason of this is because of following sequence:

- checking Type constraints `Foo : IFoo<U>`
   - checking GenericAppExpr `IFoo<U>` : it will find a candidate - `IFoo<T> T:XXX where T.Differential == T`
      - it will check constraint of this generic: check whether "U.Differential == U" is satisfied
        - collect inheritance info of `U.Differential`

Now in collecting the inheritance info of `U.Differential`, we will find the dependent generic parent of `U`, which is the `func` again, so we will check all the type constraints of `func`, and finally it will start checking `Foo.Differential : IFoo<U.Differential>`. But note that  `Foo : IFoo<U>` is still being checked now, so the `Foo`'s type is unknown, we cannot lookup the member of `Differential`. Therefore, error will be reported.

The current solution for this issue is that we will use subVisitor to suppress the error in this case because it's ok to have error in this case. If there is error, the inheritance info will be incomplete, then the upper level caller will also fail because it can't find all the type constraints to satisfy the requirement. And we also disable the cache in this case, so in the later inheritance info collection when every thing is ready, there will still be chance to get the complete inheritance info.