### PR TITLE
Update CI container to Vulkan SDK 1.4.321.1 to fix validation layer bug

### DIFF
--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -27,7 +27,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/shader-slang/slang-linux-gpu-ci:12.5.1
+      image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.1.0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -133,7 +133,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/shader-slang/slang-linux-gpu-ci:12.5.1
+      image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.1.0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -204,7 +204,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/shader-slang/slang-linux-gpu-ci:12.5.1
+      image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.1.0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/docker/linux-gpu-ci.Dockerfile
+++ b/docker/linux-gpu-ci.Dockerfile
@@ -1,7 +1,7 @@
 # Linux GPU CI Container Image
 #
 # Base image with CUDA 12.5.1 for GPU testing on self-hosted runners
-# Requires driver 555.42.02 or newer
+# Requires driver 550.54.15 or newer
 #
 # Used by:
 # - .github/workflows/ci-slang-build-container.yml
@@ -48,12 +48,18 @@ RUN apt-get update && apt-get install -y \
     glslang-tools \
     && rm -rf /var/lib/apt/lists/*
 
-# Install newer Vulkan validation layers from LunarG
-RUN wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add - && \
-    wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list && \
-    apt-get update && \
-    apt-get install -y vulkan-validationlayers && \
-    rm -rf /var/lib/apt/lists/*
+# Install Vulkan SDK 1.4.321.1 from tarball (apt packages discontinued after 1.4.313)
+# Using tarball to get the fixed validation layers that resolve cooperative vector issues
+ENV VULKAN_SDK=/opt/vulkan-sdk/1.4.321.1/x86_64
+ENV PATH="${VULKAN_SDK}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${VULKAN_SDK}/lib:${LD_LIBRARY_PATH}"
+ENV VK_LAYER_PATH="${VULKAN_SDK}/share/vulkan/explicit_layer.d"
+
+RUN wget -q https://sdk.lunarg.com/sdk/download/1.4.321.1/linux/vulkansdk-linux-x86_64-1.4.321.1.tar.xz && \
+    tar -xf vulkansdk-linux-x86_64-1.4.321.1.tar.xz && \
+    mkdir -p /opt/vulkan-sdk && \
+    mv 1.4.321.1 /opt/vulkan-sdk/ && \
+    rm -rf vulkansdk-linux-x86_64-1.4.321.1.tar.xz
 
 # Install runtime libraries for test execution
 RUN apt-get update && apt-get install -y \

--- a/tests/expected-failure-linux-gpu.txt
+++ b/tests/expected-failure-linux-gpu.txt
@@ -61,3 +61,9 @@ tests/language-feature/pointer/ptr-to-groupshared-1.slang (vk)
 
 # Ray tracing tests - CUDA/OptiX issues on T4
 tests/pipeline/ray-tracing/raygen.slang (cuda)
+
+# Cooperative vector via-glsl failures with driver 580+ - T4 specific
+# These tests fail only when using -emit-spirv-via-glsl with driver 580+
+# Regular SPIRV emission works fine
+tests/cooperative-vector/load-store-arbitrary-array-vec.slang (vk)
+tests/cooperative-vector/load-store-arbitrary-array.slang (vk)

--- a/tests/expected-glsl-failure-github.txt
+++ b/tests/expected-glsl-failure-github.txt
@@ -1,0 +1,3 @@
+tests/cooperative-vector/matrix-mul-bias-structuredbuffer-packed.slang (vk)
+tests/cooperative-vector/matrix-mul-structuredbuffer-packed.slang (vk)
+tests/cooperative-vector/outer-product-structuredbuffer.slang (vk)


### PR DESCRIPTION
## Summary

Upgrades Vulkan SDK from 1.4.313.0 to 1.4.321.1 with proper installation and environment configuration. Enables Linux GPU CI runner upgrade to driver 580.126.09 (CUDA 13.0).

## Changes

**docker/linux-gpu-ci.Dockerfile:**
- Install Vulkan SDK 1.4.321.1 to /opt/vulkan-sdk (not /usr/local/lib)
- Set environment variables: VULKAN_SDK, PATH, LD_LIBRARY_PATH, VK_LAYER_PATH
- Update driver requirement to 550.54.15 or newer

**.github/workflows/ci-slang-test-container.yml:**
- Update container tag from 12.5.1 to v1.1.0

**tests/expected-failure-linux-gpu.txt:**
- Add 2 via-glsl cooperative-vector failures

**tests/expected-glsl-failure-github.txt (new):**
- Add 3 via-glsl cooperative-vector structuredbuffer failures

## Root Cause

Vulkan SDK 1.4.321.1 fixes validation layer bug where int32_t was treated as uint32_t (KhronosGroup/Vulkan-ValidationLayers#10137). Proper environment configuration ensures validation layers and ICD are discovered correctly.

With correct Vulkan SDK setup, all cooperative vector and matrix tests pass on driver 580+. Only 5 tests fail in via-glsl translation mode (glslang limitation).

## Test Results

All Linux GPU runners upgraded to driver 580.126.09 (CUDA 13.0). All cooperative vector and matrix tests passing except 5 via-glsl specific failures.

## References

- Fixes #7715
- Addresses #9603
- Co-authored-by: Kai Zhang