### PR TITLE
Fix WebAssembly build to run in browsers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "external/glslang"]
 	path = external/glslang
-	url = https://github.com/KhronosGroup/glslang
+	url = https://github.com/jvepsalainen-nv/glslang
+	branch = fix-emscripten-pthread
 [submodule "external/tinyobjloader"]
 	path = external/tinyobjloader
 	url = https://github.com/syoyo/tinyobjloader

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,7 +425,12 @@ endif()
 # calls above
 #
 
-find_package(Threads REQUIRED)
+if(NOT EMSCRIPTEN)
+    find_package(Threads REQUIRED)
+else()
+    # Create a dummy Threads::Threads target for Emscripten builds
+    add_library(Threads::Threads INTERFACE IMPORTED)
+endif()
 
 if(${SLANG_USE_SYSTEM_UNORDERED_DENSE})
     find_package(unordered_dense CONFIG QUIET)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -34,7 +34,7 @@
         "SLANG_ENABLE_TESTS": "OFF",
         "CMAKE_C_FLAGS_INIT": "-fwasm-exceptions -Os",
         "CMAKE_CXX_FLAGS_INIT": "-fwasm-exceptions -Os",
-        "CMAKE_EXE_LINKER_FLAGS": "-sASSERTIONS -sALLOW_MEMORY_GROWTH -fwasm-exceptions --export=__cpp_exception"
+        "CMAKE_EXE_LINKER_FLAGS": "-sASSERTIONS -sALLOW_MEMORY_GROWTH -fwasm-exceptions --export=__cpp_exception -sENVIRONMENT=web"
       }
     },
     {

--- a/source/slang-wasm/CMakeLists.txt
+++ b/source/slang-wasm/CMakeLists.txt
@@ -27,8 +27,6 @@ if(EMSCRIPTEN)
         PUBLIC
         "--bind"
         "--emit-tsd" "interface.d.ts"
-        "-sEXPORT_ES6=1"
-        "-sMODULARIZE=1"
         "-sEXPORTED_RUNTIME_METHODS=['FS']"
     )
 endif()


### PR DESCRIPTION
The Emscripten build was including Node.js-specific syscalls like __syscall_poll that aren't available in browsers, causing the WASM module to fail at instantiation.

Changes:
- Add -sENVIRONMENT=web flag to target browsers exclusively
- Remove ES6 module exports to use traditional script loading
- Make Threads package optional for Emscripten builds
- Update glslang submodule to exclude Emscripten from pthread linking

The wgpu-slang-wasm example now successfully compiles and runs Slang shaders in the browser.