### PR TITLE
Enable sizeof/alignof for DescriptorHandle<T> with target-aware resol…

### DIFF
--- a/source/slang/slang-ast-natural-layout.cpp
+++ b/source/slang/slang-ast-natural-layout.cpp
@@ -209,6 +209,13 @@ NaturalSize ASTNaturalLayoutContext::_calcSizeImpl(Type* type)
         size.append(calcSize(optionalType->getValueType()));
         return size;
     }
+    else if (as<DescriptorHandleType>(type))
+    {
+        // DescriptorHandleType has target-dependent size/alignment.
+        // Return invalid so that sizeof/alignof gets lowered to IR instructions
+        // which can be resolved later with target information.
+        return NaturalSize::makeInvalid();
+    }
     else if (auto declRefType = as<DeclRefType>(type))
     {
         if (const auto enumDeclRef = declRefType->getDeclRef().as<EnumDecl>())

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -4221,15 +4221,9 @@ Expr* SemanticsExprVisitor::visitSizeOfLikeExpr(SizeOfLikeExpr* sizeOfLikeExpr)
             return sizeOfLikeExpr;
         }
 
-        // DescriptorHandle size is target-dependent, so sizeof/alignof cannot be
-        // evaluated at compile-time. Users should use reflection API instead.
-        if (as<DescriptorHandleType>(type))
-        {
-            getSink()->diagnose(sizeOfLikeExpr, Diagnostics::sizeOfDescriptorHandleNotAllowed);
-
-            sizeOfLikeExpr->type = m_astBuilder->getErrorType();
-            return sizeOfLikeExpr;
-        }
+        // Note: DescriptorHandle size is target-dependent (uint64_t for spvBindlessTextureNV,
+        // uint2 otherwise). The size calculation is deferred to IR level where target
+        // capabilities are available. See slang-ir-peephole.cpp for the resolution logic.
     }
 
     sizeOfLikeExpr->sizedType = type;

--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -1032,12 +1032,6 @@ DIAGNOSTIC(
 
 DIAGNOSTIC(30099, Error, sizeOfArgumentIsInvalid, "argument to sizeof is invalid")
 DIAGNOSTIC(
-    30100,
-    Error,
-    sizeOfDescriptorHandleNotAllowed,
-    "sizeof/alignof of 'DescriptorHandle' is not allowed because its size is target-dependent; "
-    "use reflection API to query size at runtime")
-DIAGNOSTIC(
     30083,
     Error,
     countOfArgumentIsInvalid,

--- a/tests/language-feature/descriptor-handle/desc-handle-sizeof-bindless.slang
+++ b/tests/language-feature/descriptor-handle/desc-handle-sizeof-bindless.slang
@@ -1,0 +1,43 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -capability spvBindlessTextureNV -stage compute -entry computeMain
+
+// Test that sizeof/alignof of DescriptorHandle with spvBindlessTextureNV capability
+// returns correct values. With spvBindlessTextureNV, DescriptorHandle is uint64_t
+// (8 bytes, 8-byte aligned) instead of uint2.
+
+RWStructuredBuffer<int> outputBuffer;
+
+struct TestStruct
+{
+    float4x4 matrix;
+    DescriptorHandle<Texture2D> tex;
+}
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // sizeof should be 8 (uint64_t)
+    outputBuffer[0] = sizeof(DescriptorHandle<Texture2D>);
+    outputBuffer[1] = sizeof(Texture2D.Handle);
+    outputBuffer[2] = sizeof(DescriptorHandle<SamplerState>);
+
+    // alignof should be 8 (uint64_t alignment)
+    outputBuffer[3] = alignof(DescriptorHandle<Texture2D>);
+    outputBuffer[4] = alignof(Texture2D.Handle);
+    outputBuffer[5] = alignof(DescriptorHandle<SamplerState>);
+
+    // TestStruct should have proper size accounting for uint64_t alignment
+    outputBuffer[6] = sizeof(TestStruct);
+    outputBuffer[7] = alignof(TestStruct);
+}
+
+// Verify constants are defined (order-independent)
+// CHECK-DAG: %int_8 = OpConstant %int 8
+
+// Verify sizeof and alignof values are stored as 8
+// The first 6 stores should all be int_8 (sizeof=8, alignof=8 for DescriptorHandle)
+// CHECK: OpStore {{%[0-9]+}} %int_8
+// CHECK: OpStore {{%[0-9]+}} %int_8
+// CHECK: OpStore {{%[0-9]+}} %int_8
+// CHECK: OpStore {{%[0-9]+}} %int_8
+// CHECK: OpStore {{%[0-9]+}} %int_8
+// CHECK: OpStore {{%[0-9]+}} %int_8

--- a/tests/language-feature/descriptor-handle/desc-handle-sizeof.slang
+++ b/tests/language-feature/descriptor-handle/desc-handle-sizeof.slang
@@ -1,37 +1,43 @@
-//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target spirv -entry computeMain -stage compute
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj -output-using-type
 
-// Test that sizeof/alignof of DescriptorHandle produces an error because
-// the size is target-dependent (uint2 vs uint64_t depending on target).
-// Users should use reflection API to query size at runtime instead.
+// LLVM/CPU backend doesn't support DescriptorHandle
+//DISABLE_TEST(compute):COMPARE_COMPUTE: -llvm
 
+// Test that sizeof/alignof of DescriptorHandle works correctly.
+// DescriptorHandle is represented as uint2 (8 bytes) on most targets,
+// or uint64_t (8 bytes, 8-byte aligned) with spvBindlessTextureNV.
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<int> outputBuffer;
+
+struct TestStruct
+{
+    float4x4 matrix;
+    DescriptorHandle<Texture2D> tex;
+}
 
 [numthreads(1, 1, 1)]
 void computeMain()
 {
-    // sizeof tests
-    // CHECK: error 30100
+    // sizeof tests - DescriptorHandle is always 8 bytes (uint2 or uint64_t)
     outputBuffer[0] = sizeof(DescriptorHandle<Texture2D>);
-
-    // CHECK: error 30100
     outputBuffer[1] = sizeof(Texture2D.Handle);
-
-    // CHECK: error 30100
     outputBuffer[2] = sizeof(DescriptorHandle<SamplerState>);
-
-    // CHECK: error 30100
     outputBuffer[3] = sizeof(DescriptorHandle<StructuredBuffer<float4>>);
 
-    // alignof tests
-    // CHECK: error 30100
-    outputBuffer[4] = alignof(DescriptorHandle<Texture2D>);
-
-    // CHECK: error 30100
-    outputBuffer[5] = alignof(Texture2D.Handle);
-
-    // CHECK: error 30100
-    outputBuffer[6] = alignof(DescriptorHandle<SamplerState>);
-
-    // CHECK: error 30100
-    outputBuffer[7] = alignof(DescriptorHandle<StructuredBuffer<float4>>);
+    // alignof tests - alignment depends on target (4 or 8 bytes)
+    // We just verify they return non-zero valid values
+    outputBuffer[4] = alignof(DescriptorHandle<Texture2D>);// > 0 ? 1 : 0;
+    outputBuffer[5] = alignof(Texture2D.Handle);// > 0 ? 1 : 0;
+    outputBuffer[6] = alignof(DescriptorHandle<SamplerState>);// > 0 ? 1 : 0;
+    outputBuffer[7] = alignof(DescriptorHandle<StructuredBuffer<float4>>);// > 0 ? 1 : 0;
 }
+
+// CHECK: 8
+// CHECK: 8
+// CHECK: 8
+// CHECK: 8
+// CHECK: {{[48]}}
+// CHECK: {{[48]}}
+// CHECK: {{[48]}}
+// CHECK: {{[48]}}


### PR DESCRIPTION
…ution

Instead of diagnosing an error for sizeof(DescriptorHandle<T>) as done in PR #9571, this change enables sizeof/alignof to work by resolving the size and alignment at IR level based on target capabilities.

DescriptorHandle<T> is represented differently based on target capability:
- With spvBindlessTextureNV: uint64_t (8 bytes, 8-byte aligned)
- Without: uint2 (8 bytes, alignment varies by target)

Changes:
1. slang-ast-natural-layout.cpp:
   - Add explicit check for DescriptorHandleType to return invalid size
   - Forces sizeof/alignof to be resolved at IR level with target info

2. slang-ir-peephole.cpp:
   - Add special handling for DescriptorHandleType in sizeof/alignof
   - Check for spvBindlessTextureNV capability to select underlying type
   - Use getNaturalSizeAndAlignment for both uint64_t and uint2 cases to respect target-specific layout rules

3. Tests:
   - desc-handle-sizeof.slang: Runtime compute test on GPU backends
   - desc-handle-sizeof-bindless.slang: Compile test with spvBindlessTextureNV