### PR TITLE
Fix slang-rhi static linking when building from slang repo

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -311,6 +311,9 @@ if(SLANG_ENABLE_SLANG_RHI)
         )
     endif()
 
+    # Link slang-rhi to slang (propagates SLANG_STATIC when building static)
+    target_link_libraries(slang-rhi PUBLIC slang)
+
     # Output slang-rhi-tests to the bin directory so we can run it easily.
     set_target_properties(
         slang-rhi-tests


### PR DESCRIPTION
When SLANG_RHI_BUILD_FROM_SLANG_REPO is set, slang-rhi's CMakeLists.txt skips the target_link_libraries(slang-rhi PUBLIC slang) call because it's inside an if(NOT SLANG_RHI_BUILD_FROM_SLANG_REPO) block.

This causes linker errors when building with SLANG_LIB_TYPE=STATIC because the SLANG_STATIC preprocessor definition (which controls whether slang.h uses __declspec(dllimport)) isn't propagated to slang-rhi.

Add the missing target_link_libraries call in external/CMakeLists.txt after adding the slang-rhi subdirectory.