### PR TITLE
Add comprehensive version logging to GPU test jobs

### DIFF
--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -27,7 +27,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.1.0
+      image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.2.0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -75,13 +75,8 @@ jobs:
           chmod +x "$bin_dir"/* 2>/dev/null || true
           echo "LD_LIBRARY_PATH=$PWD/artifacts/${cmake_config}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
-          # Verify GPU is accessible
-          echo "=== GPU Info ==="
-          nvidia-smi
-
-          # Check CUDA
-          echo "=== CUDA libraries ==="
-          ldconfig -p | grep -i cuda || echo "No CUDA libraries in ldconfig"
+          # Display environment configuration
+          print-env-info
 
       - name: Test Slang
         run: |
@@ -133,7 +128,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.1.0
+      image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.2.0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -181,6 +176,9 @@ jobs:
           chmod +x "$bin_dir"/* 2>/dev/null || true
           echo "LD_LIBRARY_PATH=$PWD/artifacts/${cmake_config}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
+          # Display environment configuration
+          print-env-info
+
       - name: Run slang-rhi tests
         run: |
           export SLANG_RHI_EXCLUDE_TESTS="md-clear*,cmd-copy*,cmd-upload*,fence*,staging-heap*,texture-create*"
@@ -204,7 +202,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.1.0
+      image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.2.0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -250,6 +248,9 @@ jobs:
 
           chmod +x "$bin_dir"/* 2>/dev/null || true
           echo "LD_LIBRARY_PATH=$lib_dir:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+
+          # Display environment configuration
+          print-env-info
 
       - name: Run slangpy tests
         run: |

--- a/docker/linux-gpu-ci.Dockerfile
+++ b/docker/linux-gpu-ci.Dockerfile
@@ -9,8 +9,8 @@
 # - .github/workflows/copilot-setup-steps.yml
 #
 # Build and push:
-#   docker build -f docker/linux-gpu-ci.Dockerfile -t ghcr.io/shader-slang/slang-linux-gpu-ci:12.5.1 .
-#   docker push ghcr.io/shader-slang/slang-linux-gpu-ci:12.5.1
+#   docker build -f docker/linux-gpu-ci.Dockerfile -t ghcr.io/shader-slang/slang-linux-gpu-ci:v1.2.0 .
+#   docker push ghcr.io/shader-slang/slang-linux-gpu-ci:v1.2.0
 
 FROM nvidia/cuda:12.5.1-devel-ubuntu22.04
 
@@ -76,6 +76,10 @@ RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.30.0/cmake-3.3
     ln -s /opt/cmake-3.30.0-linux-x86_64/bin/cmake /usr/local/bin/cmake && \
     ln -s /opt/cmake-3.30.0-linux-x86_64/bin/ctest /usr/local/bin/ctest && \
     ln -s /opt/cmake-3.30.0-linux-x86_64/bin/cpack /usr/local/bin/cpack
+
+# Install environment info script
+COPY docker/print-env-info.sh /usr/local/bin/print-env-info
+RUN chmod +x /usr/local/bin/print-env-info
 
 # Git configuration for container workflows
 RUN git config --global --add safe.directory '*'

--- a/docker/print-env-info.sh
+++ b/docker/print-env-info.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Print environment configuration in structured format
+# Displays GPU, driver, CUDA, and Vulkan information
+# Output can be parsed programmatically for analysis
+
+echo "ENV_INFO_START"
+echo "driver_version=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null || echo 'unknown')"
+echo "gpu_name=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'unknown')"
+echo "gpu_memory=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader 2>/dev/null || echo 'unknown')"
+echo "cuda_version=$(nvcc --version 2>&1 | grep -o 'release [0-9.]*' | cut -d' ' -f2 || echo 'unknown')"
+echo "vulkan_sdk=${VULKAN_SDK:-not_set}"
+echo "vulkan_layer_path=${VK_LAYER_PATH:-not_set}"
+echo "vulkan_validation_api=$(grep -o '"api_version": "[^"]*"' "${VK_LAYER_PATH}/VkLayer_khronos_validation.json" 2>/dev/null | head -1 | cut -d'"' -f4 || echo 'unknown')"
+echo "vulkan_icd_api=$(grep -o '"api_version" : "[^"]*"' /etc/vulkan/icd.d/nvidia_icd.json 2>/dev/null | cut -d'"' -f4 || echo 'unknown')"
+echo "container_image=${CONTAINER_IMAGE:-ghcr.io/shader-slang/slang-linux-gpu-ci:v1.2.0}"
+echo "runner_name=${RUNNER_NAME:-unknown}"
+echo "ENV_INFO_END"


### PR DESCRIPTION
Display driver, CUDA, Vulkan, and container versions at the start of each GPU test job (test-slang, test-slang-rhi, test-slangpy). This helps with debugging and provides clear version context in CI logs.

Output includes:
- NVIDIA driver version
- GPU model
- CUDA toolkit version
- Vulkan SDK path and validation layer version
- Container image tag

Makes it easier to correlate test results with specific versions and diagnose version-related issues.