### PR TITLE
TEMP: Test Windows driver 581.80 on runner-2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
       compiler: cl
       platform: x86_64
       config: debug
-      runs-on: '["Windows", "self-hosted", "GCP-T4"]'
+      runs-on: '["Windows", "self-hosted", "r581.80"]'
       test-category: full
       full-gpu-tests: true
 
@@ -186,7 +186,7 @@ jobs:
       compiler: cl
       platform: x86_64
       config: release
-      runs-on: '["Windows", "self-hosted", "GCP-T4"]'
+      runs-on: '["Windows", "self-hosted", "r581.80"]'
       test-category: full
       full-gpu-tests: true
 


### PR DESCRIPTION
Modifies Windows GPU test jobs to run only on runner with r581.80 label. This isolates testing to slang-win-2022-runner-2 which has driver 581.80.

Testing to verify GPU backends are detected after driver upgrade.

This commit should NOT be merged - for testing only.