### PR TITLE
Re-enabled tests disabled due to the bug in SPIRV-Tools

### DIFF
--- a/tests/bugs/spirv-opt-SROA-of-globals.slang
+++ b/tests/bugs/spirv-opt-SROA-of-globals.slang
@@ -1,8 +1,6 @@
-//  DISABLED: SPIRV-Tools ADCE pass is temporarily disabled (see #9675).
-//  This test explicitly verifies SROA with ADCE behavior - requires full optimization pipeline.
-//DISABLE_TEST:SIMPLE(filecheck=CHECK): -target spirv -fvk-use-entrypoint-name -enable-experimental-passes
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -fvk-use-entrypoint-name -enable-experimental-passes
 
-// This test checks that spirv-opt is running SROA (scalar replacement of aggregates) to 
+// This test checks that spirv-opt is running SROA (scalar replacement of aggregates) to
 // hoist out all member variables of a struct. If this sucsessfully runs, we should not see
 // any `OpCompositeConstruct` of our `%Data` struct.
 // Note: SROA will only run for 100 elements if spirv-opt does not manually set the spirv-opt `scalar-replacement` option

--- a/tests/bugs/vk-structured-buffer-load.hlsl
+++ b/tests/bugs/vk-structured-buffer-load.hlsl
@@ -1,8 +1,6 @@
-//  DISABLED: SPIRV-Tools ADCE pass is temporarily disabled (see #9675).
-//  This test requires ADCE for SPIRV optimization to produce expected output.
-//DISABLE_TEST:CROSS_COMPILE: -profile glsl_460+GL_NV_ray_tracing -entry HitMain -stage closesthit -target spirv-assembly
+//TEST:CROSS_COMPILE: -profile glsl_460+GL_NV_ray_tracing -entry HitMain -stage closesthit -target spirv-assembly
 //TEST:SIMPLE(filecheck=DXIL): -target dxil -entry HitMain -stage closesthit -profile sm_6_5
-//DISABLE_TEST:SIMPLE(filecheck=SPV): -target spirv
+//TEST:SIMPLE(filecheck=SPV): -target spirv
 
 // DXIL: define void @
 // SPV: OpEntryPoint

--- a/tests/optimization/arrray-storage-lowering.slang
+++ b/tests/optimization/arrray-storage-lowering.slang
@@ -1,8 +1,5 @@
-//  DISABLED: SPIRV-Tools ADCE pass is temporarily disabled (see #9675).
-//  This FileCheck test requires ADCE to eliminate OpCompositeConstruct. Runtime test (.1) still passes.
-//DISABLE_TEST:SIMPLE(filecheck=SPV): -target spirv
-
-// TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type -emit-spirv-directly
+//TEST:SIMPLE(filecheck=SPV): -target spirv
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type -emit-spirv-directly
 
 struct DoubleNested
 {

--- a/tests/spirv/debug-levels.slang
+++ b/tests/spirv/debug-levels.slang
@@ -1,10 +1,7 @@
 // TEST:SIMPLE(filecheck=CHECK_NONE): -target spirv -g0 -emit-spirv-directly
 // TEST:SIMPLE(filecheck=CHECK_MINIMAL): -target spirv -g1 -emit-spirv-directly
-//  DISABLED: SPIRV-Tools v2025.5 crashes during optimization when processing DebugValue
-//  instructions that reference pointer values. Assertion in def_use_manager.cpp:56.
-//  This appears to be a SPIRV-Tools regression - works with -O0. Tracking issue #9634
-// DISABLE_TEST:SIMPLE(filecheck=CHECK_STANDARD): -target spirv -g2 -emit-spirv-directly
-// DISABLE_TEST:SIMPLE(filecheck=CHECK_MAXIMAL): -target spirv -g3 -emit-spirv-directly
+// TEST:SIMPLE(filecheck=CHECK_STANDARD): -target spirv -g2 -emit-spirv-directly
+// TEST:SIMPLE(filecheck=CHECK_MAXIMAL): -target spirv -g3 -emit-spirv-directly
 
 // Test that verifies different debug information levels generate appropriate debug info:
 // - g0/none: No debug info at all
@@ -66,11 +63,11 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
     // Call inline helper functions - should generate DebugInlinedAt at g2/g3
     float localValue = computeValue(float(tid.x), float(tid.y));
     int localIndex = processIndex(tid.y, tid.z);
-    
+
     MyStruct result;
     result.value = float4(localValue, tid.y, tid.z, 1.0);
     result.index = localIndex;
-    
+
     outputBuffer[tid.x + tid.y * 8] = result;
 }
 


### PR DESCRIPTION
This PR re-enables tests disabled by PR #9617.

Only ones that still need to be re-enabled are:
```
tests/bugs/gh-7925.slang
tests/bugs/gh-9918.slang
```
And they are tracked by an issue https://github.com/shader-slang/slang/issues/9315
