### PR TITLE
Clone all submodules for repro-remix.sh

### DIFF
--- a/extras/repro-remix.md
+++ b/extras/repro-remix.md
@@ -188,7 +188,6 @@ The script closely matches the CI workflow, with these minor differences:
 
 - First run takes ~15-20 minutes (packman download + shader compilation)
 - Subsequent runs are faster if packman cache exists (~10-15 minutes)
-- The `external/dxvk-remix` clone uses `--depth 1` (shallow) to save space
 - Packman downloads ~340MB to `C:\packman-repo` (persisted across runs)
 - Debug builds include more symbols for debugging but run slower than Release
 

--- a/extras/repro-remix.sh
+++ b/extras/repro-remix.sh
@@ -117,7 +117,7 @@ else
   log_info "Cloning dxvk-remix repository..."
   mkdir -p "$REPO_ROOT/external"
   cd "$REPO_ROOT/external"
-  git clone --recursive --depth 1 https://github.com/NVIDIAGameWorks/dxvk-remix.git
+  git clone --recursive https://github.com/NVIDIAGameWorks/dxvk-remix.git
   cd dxvk-remix
   COMMIT=$(git rev-parse HEAD)
   log_success "Cloned dxvk-remix at commit: $COMMIT"


### PR DESCRIPTION
When cloning rtx-remix under `external/dxvk-remix`, all of its submodules has to be cloned recursively.
This doesn't make a big difference in terms of cloning time and disk space.