### PR TITLE
neural: add frontend APIs

### DIFF
--- a/source/standard-modules/neural/activations.slang
+++ b/source/standard-modules/neural/activations.slang
@@ -1,0 +1,220 @@
+implementing neural;
+
+__include iactivation;
+
+/**
+Identity activation: returns input unchanged.
+*/
+public struct IdentityActivation<T> : IActivation<T>
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+{
+    public __init() {}
+
+    [NoDiffThis]
+    [Differentiable]
+    public Vector eval<Vector>(Vector input)
+        where Vector : IVector<T>
+    {
+        return input;
+    }
+}
+
+/**
+ReLU activation: max(x, 0).
+*/
+public struct ReLU<T> : IActivation<T>
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+{
+    public __init() {}
+
+    [NoDiffThis]
+    [Differentiable]
+    public Vector eval<Vector>(Vector input)
+        where Vector : IVector<T>
+    {
+        Vector output = Vector();
+        [ForceUnroll]
+        for (int i = 0; i < Vector.Size; i++)
+            output[i] = max(input[i], T(0));
+        return output;
+    }
+}
+
+/**
+LeakyReLU activation: x < 0 ? alpha*x : x
+
+Construct with the leak coefficient alpha (typically 0.01).
+*/
+public struct LeakyReLU<T> : IActivation<T>
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+{
+    /// Leak coefficient for negative inputs.
+    public T alpha;
+
+    /// Constructor with optional alpha value (defaults to 0.01).
+    public __init(T alpha = T(0.01))
+    {
+        this.alpha = alpha;
+    }
+
+    [NoDiffThis]
+    [Differentiable]
+    public Vector eval<Vector>(Vector input)
+        where Vector : IVector<T>
+    {
+        Vector output = Vector();
+        [ForceUnroll]
+        for (int i = 0; i < Vector.Size; i++)
+        {
+            let x = input[i];
+            output[i] = (x < T(0)) ? alpha * x : x;
+        }
+        return output;
+    }
+}
+
+/**
+Sigmoid activation: 1 / (1 + exp(-x))
+*/
+public struct Sigmoid<T> : IActivation<T>
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+{
+    public __init() {}
+
+    [NoDiffThis]
+    [Differentiable]
+    public Vector eval<Vector>(Vector input)
+        where Vector : IVector<T>
+    {
+        Vector output = Vector();
+        [ForceUnroll]
+        for (int i = 0; i < Vector.Size; i++)
+        {
+            let x = input[i];
+            output[i] = T(1) / (T(1) + exp(-x));
+        }
+        return output;
+    }
+}
+
+/**
+Tanh activation.
+*/
+public struct TanhActivation<T> : IActivation<T>
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+{
+    public __init() {}
+
+    [NoDiffThis]
+    [Differentiable]
+    public Vector eval<Vector>(Vector input)
+        where Vector : IVector<T>
+    {
+        Vector output = Vector();
+        [ForceUnroll]
+        for (int i = 0; i < Vector.Size; i++)
+            output[i] = tanh(input[i]);
+        return output;
+    }
+}
+
+/**
+Exp activation: exp(x)
+*/
+public struct ExpActivation<T> : IActivation<T>
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+{
+    public __init() {}
+
+    [NoDiffThis]
+    [Differentiable]
+    public Vector eval<Vector>(Vector input)
+        where Vector : IVector<T>
+    {
+        Vector output = Vector();
+        [ForceUnroll]
+        for (int i = 0; i < Vector.Size; i++)
+            output[i] = exp(input[i]);
+        return output;
+    }
+}
+
+/**
+Sine activation: sin(x)
+*/
+public struct SineActivation<T> : IActivation<T>
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+{
+    public __init() {}
+
+    [NoDiffThis]
+    [Differentiable]
+    public Vector eval<Vector>(Vector input)
+        where Vector : IVector<T>
+    {
+        Vector output = Vector();
+        [ForceUnroll]
+        for (int i = 0; i < Vector.Size; i++)
+            output[i] = sin(input[i]);
+        return output;
+    }
+}
+
+/**
+SiLU (Sigmoid Linear Unit) activation, also known as Swish: x * sigmoid(x)
+*/
+public struct SiLU<T> : IActivation<T>
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+{
+    public __init() {}
+
+    [NoDiffThis]
+    [Differentiable]
+    public Vector eval<Vector>(Vector input)
+        where Vector : IVector<T>
+    {
+        Vector output = Vector();
+        [ForceUnroll]
+        for (int i = 0; i < Vector.Size; i++)
+        {
+            let x = input[i];
+            output[i] = x / (T(1) + exp(-x));  // x * sigmoid(x)
+        }
+        return output;
+    }
+}
+
+/**
+QuickGELU activation: x * sigmoid(1.702 * x)
+
+A fast approximation of GELU (Gaussian Error Linear Unit).
+*/
+public struct QuickGELU<T> : IActivation<T>
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+{
+    public __init() {}
+
+    [NoDiffThis]
+    [Differentiable]
+    public Vector eval<Vector>(Vector input)
+        where Vector : IVector<T>
+    {
+        Vector output = Vector();
+        [ForceUnroll]
+        for (int i = 0; i < Vector.Size; i++)
+        {
+            let x = input[i];
+            output[i] = x / (T(1) + exp(T(-1.702) * x));  // x * sigmoid(1.702 * x)
+        }
+        return output;
+    }
+}

--- a/source/standard-modules/neural/iactivation.slang
+++ b/source/standard-modules/neural/iactivation.slang
@@ -1,0 +1,28 @@
+implementing neural;
+
+/**
+Activation function interface for neural network operations.
+Defines a differentiable mapping from an input vector to an output vector of the same shape.
+
+Activations that require parameters (e.g., LeakyReLU's alpha) store them as member fields.
+Parameterless activations (e.g., ReLU, Sigmoid) can be used with the default constructor.
+
+@param T Scalar element type (float/half/double).
+@category neural
+*/
+public interface IActivation<T>
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+{
+    /// Default constructor. Required so that activations are explicitly default-constructed
+    /// rather than zero-initialized when used with `Activation()` in layer constructors.
+    __init();
+
+    /// Apply activation function element-wise.
+    /// @param input Input vector.
+    /// @return Output vector with activation applied.
+    [NoDiffThis]
+    [Differentiable]
+    public Vector eval<Vector>(Vector input)
+        where Vector : IVector<T>;
+}

--- a/source/standard-modules/neural/ilayer.slang
+++ b/source/standard-modules/neural/ilayer.slang
@@ -1,0 +1,30 @@
+implementing neural;
+
+/**
+Layer interface (compile-time, GPU-friendly).
+This interface is intended to be used as a *generic constraint* (no existential storage),
+so it does not imply dynamic dispatch.
+
+@category neural
+*/
+public interface ILayer<T, InputVector, OutputVector, Storage, Activation>
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+    where Storage : IStorage<T>
+    where InputVector : IVector<T>
+    where OutputVector : IVector<T>
+    where Activation : IActivation<T>
+{
+    /// Forward evaluation: y = f(x).
+    /// Storage is passed as parameter to enable autodiff gradient routing.
+    /// Method-level generic `S` is required for `linearTransform` constraints.
+    /// @param storage Weight/bias storage (primal for forward, gradient for backward via autodiff).
+    /// @param input Input vector.
+    /// @return Output vector.
+    [Differentiable]
+    public OutputVector eval<S>(S storage, InputVector input)
+        where S : IStorage<T>
+        where S.Differential : IStorage<T.Differential>
+        where S.Address == S.Differential.Address
+        where S.Address == Storage.Address;
+}

--- a/source/standard-modules/neural/layers.slang
+++ b/source/standard-modules/neural/layers.slang
@@ -1,0 +1,174 @@
+implementing neural;
+
+__include iactivation;
+__include ilayer;
+__include "buffer-storage";
+
+/**
+A fully-connected (feed-forward) neural network layer that computes `y = Activation(W*x + b)`.
+
+`FFLayer` represents a single linear transformation followed by an activation function,
+suitable for building multi-layer perceptrons (MLPs) and similar architectures.
+
+## Usage
+
+1. **Construction:** Create a layer with weight/bias addresses pointing into your storage:
+   ```
+   let layer = FFLayer<float, Vec4, Vec2, Storage, ReLU<float>>(weightAddr, biasAddr);
+   ```
+
+2. **Forward pass:** Call `eval()` with storage and input:
+   ```
+   let output = layer.eval<Storage>(storage, input);
+   ```
+
+3. **Training (backward pass):** Use autodiff with `DifferentialPtrPair`:
+   ```
+   var storagePair = DifferentialPtrPair<Storage>(storage, gradStorage);
+   bwd_diff(computeOutput)(storagePair, inputPair, layer, dOutput);
+   ```
+
+4. **With custom activation parameters** (e.g., LeakyReLU with custom alpha):
+   ```
+   let leakyRelu = LeakyReLU<float>(0.2);  // alpha = 0.2
+   let layer = FFLayer<float, Vec4, Vec2, Storage, LeakyReLU<float>>(weightAddr, biasAddr, leakyRelu);
+   ```
+
+## Parameter Layout
+
+Parameters are packed as a contiguous block in storage:
+
+- **weights:** `Out * In` scalars, row-major by output row: `W[row * In + col]`
+- **bias (optional):** `Out` scalars immediately following weights
+
+`FFLayer` is generic over `Storage : IStorage<T>`. Address arithmetic uses
+`Storage.getOffset()` so different storage backends can define their own addressing scheme.
+*/
+public struct FFLayer<
+    T,
+    InputVector,
+    OutputVector,
+    Storage,
+    Activation,
+    let HasBias : bool = true
+>
+    : ILayer<T, InputVector, OutputVector, Storage, Activation>
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+    where Storage : IStorage<T>
+    where InputVector : IVector<T>
+    where OutputVector : IVector<T>
+    where Activation : IActivation<T>
+{
+    public static const int ParameterCount =
+        OutputVector.Size * InputVector.Size + (HasBias ? OutputVector.Size : 0);
+
+    /// Addresses are stored as members (integers, not differentiable).
+    internal Storage.Address weightAddress;
+    internal Storage.Address biasAddress;
+
+    /// Activation function instance (stores any activation-specific parameters).
+    internal Activation activation;
+
+    /// Constructor for layers without bias.
+    /// @param weightAddr Address of weights in storage.
+    /// @param act Activation function instance (defaults to default-constructed Activation).
+    public __init(Storage.Address weightAddr, Activation act = Activation())
+    {
+        weightAddress = weightAddr;
+        activation = act;
+    }
+
+    /// Constructor for layers with bias.
+    /// @param weightAddr Address of weights in storage.
+    /// @param biasAddr Address of bias in storage.
+    /// @param act Activation function instance (defaults to default-constructed Activation).
+    public __init(Storage.Address weightAddr, Storage.Address biasAddr, Activation act = Activation())
+    {
+        weightAddress = weightAddr;
+        biasAddress = biasAddr;
+        activation = act;
+    }
+
+    public static Storage.Address nextAddress(Storage.Address baseAddress)
+    {
+        return Storage.getOffset(baseAddress, ParameterCount);
+    }
+
+    /// Forward evaluation: y = Activation(W*x + b).
+    /// Storage is passed as parameter to enable autodiff gradient routing.
+    /// @param storage Weight/bias storage (primal for forward, gradient for backward via autodiff).
+    /// @param input Input vector.
+    /// @return Output vector after linear transform and activation.
+    [Differentiable]
+    public OutputVector eval<S>(S storage, InputVector input)
+        where S : IStorage<T>
+        where S.Differential : IStorage<T.Differential>
+        where S.Address == S.Differential.Address
+        where S.Address == Storage.Address
+    {
+        OutputVector y;
+        if(HasBias)
+        {
+            y = input.linearTransform<S, LinearLayout, OutputVector>(
+                storage, storage, weightAddress, biasAddress);
+        }
+        else
+        {
+            y = input.linearTransform<S, LinearLayout, OutputVector>(
+                storage, weightAddress);
+        }
+        return activation.eval<OutputVector>(y);
+    }
+
+    /// Forward evaluation with weights and bias coming from different storages.
+    /// This is useful when weights and bias are stored in separate buffers (or otherwise
+    /// distinct storage instances).
+    [Differentiable]
+    public OutputVector eval<S>(
+        S weightStorage,
+        S biasStorage,
+        InputVector input)
+            where S : IStorage<T>
+            where S.Differential : IStorage<T.Differential>
+            where S.Address == S.Differential.Address
+            where S.Address == Storage.Address
+    {
+        OutputVector y;
+        if(HasBias)
+        {
+            y = input.linearTransform<S, LinearLayout, OutputVector>(
+                weightStorage, biasStorage, weightAddress, biasAddress);
+        }
+        else
+        {
+            // Bias is disabled; ignore biasStorage.
+            y = input.linearTransform<S, LinearLayout, OutputVector>(
+                weightStorage, weightAddress);
+        }
+        return activation.eval<OutputVector>(y);
+    }
+
+    /// Evaluate layer using Address-based API (bindless/pointer-like storage).
+    /// Caller provides addresses directly; does not use stored addresses.
+    /// @param weightAddr Weight address (pointer-like).
+    /// @param biasAddr Bias address (pointer-like). Ignored if HasBias=false.
+    /// @param act Activation function instance.
+    /// @param input Input vector.
+    [Differentiable]
+    public static OutputVector eval<A>(A weightAddr, A biasAddr, Activation act, InputVector input)
+        where A : IPointerLikeAddress<T>
+        where A.Differential : IPointerLikeAddress<T.Differential>
+    {
+        OutputVector y;
+        if(HasBias)
+        {
+            y = input.linearTransform<A, LinearLayout, OutputVector>(weightAddr, biasAddr);
+        }
+        else
+        {
+            y = input.linearTransform<A, LinearLayout, OutputVector>(weightAddr);
+        }
+        return act.eval<OutputVector>(y);
+    }
+}

--- a/source/standard-modules/neural/neural.slang
+++ b/source/standard-modules/neural/neural.slang
@@ -26,7 +26,9 @@ InlineVector<float, 4> input = InlineVector<float, 4>({1.0, 2.0, 3.0, 4.0});
 StructuredBufferStorage<float> storage = StructuredBufferStorage<float>(weightsBuffer);
 
 // Perform linear transformation: output = W * input
-InlineVector<float, 2> output = input.eval<2, false>(storage, 0);
+uint weightAddress = 0;
+InlineVector<float, 2> output = input.linearTransform<StructuredBufferStorage<float>, InlineVector<float, 2>>(
+    storage, weightAddress);
 ```
 */
 [ExperimentalModule]
@@ -40,3 +42,9 @@ __include "buffer-storage";
 __include "accelerate-vector-coopmat";
 __include "vectorized-reader";
 __include "shared-memory-pool";
+
+// Frontend APIs built on the primitives above
+__include "iactivation";
+__include "activations";
+__include "ilayer";
+__include "layers";

--- a/tests/neural/activation-coopmat-vector-test.slang
+++ b/tests/neural/activation-coopmat-vector-test.slang
@@ -1,0 +1,209 @@
+// Test activation functions with CooperativeMatrix accelerated WaveTangledVector type.
+// This test covers the same activation functions as activation-functions-test.slang
+// but uses WaveTangledVector instead of InlineVector.
+//
+// Only run on CUDA and Vulkan (SPIR-V) which support cooperative matrix operations.
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0 -xslang -experimental-feature
+
+import neural;
+
+//TEST_INPUT: ubuffer(data=[0 0 0 0 0 0 0 0 0], stride=4):out,name=testResult
+RWStructuredBuffer<uint> testResult;
+
+typealias ElementType = float;
+
+static const int VecSize = 3;
+static const int SubgroupSize = 32;
+static const int BatchSize = 32;
+
+typealias ShMemSize = SharedMemorySize<ElementType, TargetEnum.CUDA, ExecutionMode.Inference, SubgroupSize, BatchSize / SubgroupSize>;
+// Use a dummy layer size for shared memory calculation (we only need minimal shared memory for activations)
+typealias ShMemSizeLayer = ShMemSize.OfLayer1<VecSize, VecSize>;
+typealias ShMemPool = SharedMemoryPool<ShMemSizeLayer>;
+typealias Vec3 = WaveTangledVector<ElementType, ShMemPool, VecSize, SubgroupSize>;
+
+// Helper: check if two floats are approximately equal
+bool approxEqual(ElementType a, ElementType b, ElementType eps = 0.0001)
+{
+    return abs(a - b) < eps;
+}
+
+bool approxEqualVec3(Vec3 a, Vec3 b, ElementType eps = 0.0001)
+{
+    return approxEqual(a[0], b[0], eps) &&
+           approxEqual(a[1], b[1], eps) &&
+           approxEqual(a[2], b[2], eps);
+}
+
+// Test 1: IdentityActivation - returns input unchanged
+bool testIdentity()
+{
+    ElementType[VecSize] arr = {-1.0, 0.0, 2.5};
+    let input = Vec3(arr);
+    
+    let output = IdentityActivation<ElementType>().eval<Vec3>(input);
+    
+    // Expected: same as input
+    return approxEqualVec3(output, input);
+}
+
+// Test 2: ReLU - max(x, 0)
+bool testReLU()
+{
+    ElementType[VecSize] arr = {-2.0, 0.0, 3.0};
+    let input = Vec3(arr);
+    
+    let output = ReLU<ElementType>().eval<Vec3>(input);
+    
+    // Expected: [0, 0, 3]
+    ElementType[VecSize] expectedArr = {0.0, 0.0, 3.0};
+    let expected = Vec3(expectedArr);
+    return approxEqualVec3(output, expected);
+}
+
+// Test 3: LeakyReLU - x < 0 ? alpha*x : x
+bool testLeakyReLU()
+{
+    ElementType[VecSize] arr = {-2.0, 0.0, 3.0};
+    let input = Vec3(arr);
+    ElementType alpha = 0.1;
+    
+    let output = LeakyReLU<ElementType>(alpha).eval<Vec3>(input);
+    
+    // Expected: [-0.2, 0, 3]
+    ElementType[VecSize] expectedArr = {-0.2, 0.0, 3.0};
+    let expected = Vec3(expectedArr);
+    return approxEqualVec3(output, expected);
+}
+
+// Test 4: Sigmoid - 1 / (1 + exp(-x))
+bool testSigmoid()
+{
+    ElementType[VecSize] arr = {0.0, 1.0, -1.0};
+    let input = Vec3(arr);
+    
+    let output = Sigmoid<ElementType>().eval<Vec3>(input);
+    
+    // Expected: sigmoid(0)=0.5, sigmoid(1)≈0.7311, sigmoid(-1)≈0.2689
+    ElementType[VecSize] expectedArr = {0.5, 0.7310586, 0.2689414};
+    let expected = Vec3(expectedArr);
+    return approxEqualVec3(output, expected, 0.001);
+}
+
+// Test 5: TanhActivation - tanh(x)
+bool testTanh()
+{
+    ElementType[VecSize] arr = {0.0, 1.0, -1.0};
+    let input = Vec3(arr);
+    
+    let output = TanhActivation<ElementType>().eval<Vec3>(input);
+    
+    // Expected: tanh(0)=0, tanh(1)≈0.7616, tanh(-1)≈-0.7616
+    ElementType[VecSize] expectedArr = {0.0, 0.7615942, -0.7615942};
+    let expected = Vec3(expectedArr);
+    return approxEqualVec3(output, expected, 0.001);
+}
+
+// Test 6: ExpActivation - exp(x)
+bool testExp()
+{
+    ElementType[VecSize] arr = {0.0, 1.0, -1.0};
+    let input = Vec3(arr);
+    
+    let output = ExpActivation<ElementType>().eval<Vec3>(input);
+    
+    // Expected: exp(0)=1, exp(1)≈2.7183, exp(-1)≈0.3679
+    ElementType[VecSize] expectedArr = {1.0, 2.7182818, 0.3678794};
+    let expected = Vec3(expectedArr);
+    return approxEqualVec3(output, expected, 0.001);
+}
+
+// Test 7: SineActivation - sin(x)
+bool testSine()
+{
+    ElementType pi = 3.14159265;
+    ElementType[VecSize] arr = {0.0, pi / 2.0, pi};
+    let input = Vec3(arr);
+    
+    let output = SineActivation<ElementType>().eval<Vec3>(input);
+    
+    // Expected: sin(0)=0, sin(pi/2)=1, sin(pi)≈0
+    ElementType[VecSize] expectedArr = {0.0, 1.0, 0.0};
+    let expected = Vec3(expectedArr);
+    return approxEqualVec3(output, expected, 0.001);
+}
+
+// Test 8: SiLU (Swish) - x * sigmoid(x)
+bool testSiLU()
+{
+    ElementType[VecSize] arr = {0.0, 1.0, -1.0};
+    let input = Vec3(arr);
+    
+    let output = SiLU<ElementType>().eval<Vec3>(input);
+    
+    // Expected: SiLU(0)=0, SiLU(1)=1*sigmoid(1)≈0.7311, SiLU(-1)=-1*sigmoid(-1)≈-0.2689
+    ElementType[VecSize] expectedArr = {0.0, 0.7310586, -0.2689414};
+    let expected = Vec3(expectedArr);
+    return approxEqualVec3(output, expected, 0.001);
+}
+
+// Test 9: QuickGELU - x * sigmoid(1.702 * x)
+bool testQuickGELU()
+{
+    ElementType[VecSize] arr = {0.0, 1.0, -1.0};
+    let input = Vec3(arr);
+    
+    let output = QuickGELU<ElementType>().eval<Vec3>(input);
+    
+    // Expected: QuickGELU(0)=0, QuickGELU(1)=1*sigmoid(1.702)≈0.8458, QuickGELU(-1)=-1*sigmoid(-1.702)≈-0.1542
+    ElementType[VecSize] expectedArr = {0.0, 0.8458, -0.1542};
+    let expected = Vec3(expectedArr);
+    return approxEqualVec3(output, expected, 0.001);
+}
+
+[shader("compute")]
+[numthreads(BatchSize, 1, 1)]
+void computeMain(uint tid : SV_DispatchThreadID)
+{
+    // All threads compute the same result, but we only write from thread 0
+    bool results[9];
+    results[0] = testIdentity();
+    results[1] = testReLU();
+    results[2] = testLeakyReLU();
+    results[3] = testSigmoid();
+    results[4] = testTanh();
+    results[5] = testExp();
+    results[6] = testSine();
+    results[7] = testSiLU();
+    results[8] = testQuickGELU();
+
+    // Ensure all threads in the wave agree on the results
+    for (int i = 0; i < 9; i++)
+    {
+        results[i] = WaveActiveAllTrue(results[i]);
+    }
+
+    if (tid == 0)
+    {
+        testResult[0] = results[0];
+        testResult[1] = results[1];
+        testResult[2] = results[2];
+        testResult[3] = results[3];
+        testResult[4] = results[4];
+        testResult[5] = results[5];
+        testResult[6] = results[6];
+        testResult[7] = results[7];
+        testResult[8] = results[8];
+    }
+
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+}

--- a/tests/neural/activation-functions-test.slang
+++ b/tests/neural/activation-functions-test.slang
@@ -1,0 +1,179 @@
+// Comprehensive test for all activation functions in the neural module.
+// This test uses InlineVector. For CooperativeMatrix accelerated WaveTangledVector tests,
+// see activation-coopmat-vector-test.slang.
+//
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-dx12 -compute -shaderobj -profile cs_6_6 -xslang -experimental-feature -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -output-using-type -xslang -experimental-feature
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0 -xslang -experimental-feature
+
+import neural;
+
+//TEST_INPUT: ubuffer(data=[0 0 0 0 0 0 0 0 0], stride=4):out,name=testResult
+RWStructuredBuffer<uint> testResult;
+
+typealias Vec3 = InlineVector<float, 3>;
+
+// Helper: check if two floats are approximately equal
+bool approxEqual(float a, float b, float eps = 0.0001)
+{
+    return abs(a - b) < eps;
+}
+
+bool approxEqualVec3(Vec3 a, Vec3 b, float eps = 0.0001)
+{
+    return approxEqual(a[0], b[0], eps) &&
+           approxEqual(a[1], b[1], eps) &&
+           approxEqual(a[2], b[2], eps);
+}
+
+// Test 1: IdentityActivation - returns input unchanged
+bool testIdentity()
+{
+    float[3] arr = {-1.0, 0.0, 2.5};
+    let input = Vec3(arr);
+    
+    let output = IdentityActivation<float>().eval<Vec3>(input);
+    
+    // Expected: same as input
+    return approxEqualVec3(output, input);
+}
+
+// Test 2: ReLU - max(x, 0)
+bool testReLU()
+{
+    float[3] arr = {-2.0, 0.0, 3.0};
+    let input = Vec3(arr);
+    
+    let output = ReLU<float>().eval<Vec3>(input);
+    
+    // Expected: [0, 0, 3]
+    float[3] expectedArr = {0.0, 0.0, 3.0};
+    let expected = Vec3(expectedArr);
+    return approxEqualVec3(output, expected);
+}
+
+// Test 3: LeakyReLU - x < 0 ? alpha*x : x
+bool testLeakyReLU()
+{
+    float[3] arr = {-2.0, 0.0, 3.0};
+    let input = Vec3(arr);
+    float alpha = 0.1;
+    
+    let output = LeakyReLU<float>(alpha).eval<Vec3>(input);
+    
+    // Expected: [-0.2, 0, 3]
+    float[3] expectedArr = {-0.2, 0.0, 3.0};
+    let expected = Vec3(expectedArr);
+    return approxEqualVec3(output, expected);
+}
+
+// Test 4: Sigmoid - 1 / (1 + exp(-x))
+bool testSigmoid()
+{
+    float[3] arr = {0.0, 1.0, -1.0};
+    let input = Vec3(arr);
+    
+    let output = Sigmoid<float>().eval<Vec3>(input);
+    
+    // Expected: sigmoid(0)=0.5, sigmoid(1)≈0.7311, sigmoid(-1)≈0.2689
+    float[3] expectedArr = {0.5, 0.7310586, 0.2689414};
+    let expected = Vec3(expectedArr);
+    return approxEqualVec3(output, expected, 0.001);
+}
+
+// Test 5: TanhActivation - tanh(x)
+bool testTanh()
+{
+    float[3] arr = {0.0, 1.0, -1.0};
+    let input = Vec3(arr);
+    
+    let output = TanhActivation<float>().eval<Vec3>(input);
+    
+    // Expected: tanh(0)=0, tanh(1)≈0.7616, tanh(-1)≈-0.7616
+    float[3] expectedArr = {0.0, 0.7615942, -0.7615942};
+    let expected = Vec3(expectedArr);
+    return approxEqualVec3(output, expected, 0.001);
+}
+
+// Test 6: ExpActivation - exp(x)
+bool testExp()
+{
+    float[3] arr = {0.0, 1.0, -1.0};
+    let input = Vec3(arr);
+    
+    let output = ExpActivation<float>().eval<Vec3>(input);
+    
+    // Expected: exp(0)=1, exp(1)≈2.7183, exp(-1)≈0.3679
+    float[3] expectedArr = {1.0, 2.7182818, 0.3678794};
+    let expected = Vec3(expectedArr);
+    return approxEqualVec3(output, expected, 0.001);
+}
+
+// Test 7: SineActivation - sin(x)
+bool testSine()
+{
+    float pi = 3.14159265;
+    float[3] arr = {0.0, pi / 2.0, pi};
+    let input = Vec3(arr);
+    
+    let output = SineActivation<float>().eval<Vec3>(input);
+    
+    // Expected: sin(0)=0, sin(pi/2)=1, sin(pi)≈0
+    float[3] expectedArr = {0.0, 1.0, 0.0};
+    let expected = Vec3(expectedArr);
+    return approxEqualVec3(output, expected, 0.001);
+}
+
+// Test 8: SiLU (Swish) - x * sigmoid(x)
+bool testSiLU()
+{
+    float[3] arr = {0.0, 1.0, -1.0};
+    let input = Vec3(arr);
+    
+    let output = SiLU<float>().eval<Vec3>(input);
+    
+    // Expected: SiLU(0)=0, SiLU(1)=1*sigmoid(1)≈0.7311, SiLU(-1)=-1*sigmoid(-1)≈-0.2689
+    float[3] expectedArr = {0.0, 0.7310586, -0.2689414};
+    let expected = Vec3(expectedArr);
+    return approxEqualVec3(output, expected, 0.001);
+}
+
+// Test 9: QuickGELU - x * sigmoid(1.702 * x)
+bool testQuickGELU()
+{
+    float[3] arr = {0.0, 1.0, -1.0};
+    let input = Vec3(arr);
+    
+    let output = QuickGELU<float>().eval<Vec3>(input);
+    
+    // Expected: QuickGELU(0)=0, QuickGELU(1)=1*sigmoid(1.702)≈0.8458, QuickGELU(-1)=-1*sigmoid(-1.702)≈-0.1542
+    float[3] expectedArr = {0.0, 0.8458, -0.1542};
+    let expected = Vec3(expectedArr);
+    return approxEqualVec3(output, expected, 0.001);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    testResult[0] = testIdentity();
+    testResult[1] = testReLU();
+    testResult[2] = testLeakyReLU();
+    testResult[3] = testSigmoid();
+    testResult[4] = testTanh();
+    testResult[5] = testExp();
+    testResult[6] = testSine();
+    testResult[7] = testSiLU();
+    testResult[8] = testQuickGELU();
+
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+}

--- a/tests/neural/activation-with-fflayer-test.slang
+++ b/tests/neural/activation-with-fflayer-test.slang
@@ -1,0 +1,192 @@
+// Test activations integrated with FFLayer (layer + activation end-to-end).
+//
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-dx12 -compute -shaderobj -profile cs_6_6 -xslang -experimental-feature -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -output-using-type -xslang -experimental-feature
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0 -xslang -experimental-feature
+
+import neural;
+
+// Simple weights for testing: identity-like transform
+// For 2x2 -> 2: W = [[1,0],[0,1]], b = [0,0]
+// This makes W*x + b = x (for 2D input/output)
+//TEST_INPUT: ubuffer(data=[1.0 0.0 0.0 1.0 0.0 0.0], stride=4):name=identityParams
+RWStructuredBuffer<float> identityParams;
+
+// Params buffer (will be copied from identityParams)
+//TEST_INPUT: ubuffer(data=[0.0 0.0 0.0 0.0 0.0 0.0], stride=4):name=params
+RWStructuredBuffer<float> params;
+
+//TEST_INPUT: ubuffer(data=[0 0 0 0 0 0 0], stride=4):out,name=testResult
+RWStructuredBuffer<uint> testResult;
+
+typealias Storage = StructuredBufferStorage<float>;
+typealias Vec2 = InlineVector<float, 2>;
+
+// Helper: check if two floats are approximately equal
+bool approxEqual(float a, float b, float eps = 0.0001)
+{
+    return abs(a - b) < eps;
+}
+
+void setupParams()
+{
+    for(int i = 0; i < 6; i++)
+        params[i] = identityParams[i];
+}
+
+// Test ReLU with FFLayer
+// Input: [-1, 2] -> W*x+b = [-1, 2] -> ReLU = [0, 2]
+bool testFFLayerReLU()
+{
+    setupParams();
+    let storage = Storage(params);
+    
+    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, ReLU<float>, true>;
+    let layer = Layer(0, 4);  // weights at 0, bias at 4
+    
+    float[2] arr = {-1.0, 2.0};
+    let x = Vec2(arr);
+    
+    let y = layer.eval<Storage>(storage, x);
+    
+    // ReLU([-1, 2]) = [0, 2]
+    return approxEqual(y[0], 0.0) && approxEqual(y[1], 2.0);
+}
+
+// Test LeakyReLU with FFLayer
+// Input: [-1, 2] -> W*x+b = [-1, 2] -> LeakyReLU(alpha=0.1) = [-0.1, 2]
+bool testFFLayerLeakyReLU()
+{
+    setupParams();
+    let storage = Storage(params);
+    
+    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, LeakyReLU<float>, true>;
+    let leakyRelu = LeakyReLU<float>(0.1);  // alpha = 0.1
+    let layer = Layer(0, 4, leakyRelu);
+    
+    float[2] arr = {-1.0, 2.0};
+    let x = Vec2(arr);
+    
+    let y = layer.eval<Storage>(storage, x);
+    
+    // LeakyReLU([-1, 2], 0.1) = [-0.1, 2]
+    return approxEqual(y[0], -0.1) && approxEqual(y[1], 2.0);
+}
+
+// Test Sigmoid with FFLayer
+// Input: [0, 0] -> W*x+b = [0, 0] -> Sigmoid = [0.5, 0.5]
+bool testFFLayerSigmoid()
+{
+    setupParams();
+    let storage = Storage(params);
+    
+    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, Sigmoid<float>, true>;
+    let layer = Layer(0, 4);
+    
+    float[2] arr = {0.0, 0.0};
+    let x = Vec2(arr);
+    
+    let y = layer.eval<Storage>(storage, x);
+    
+    // Sigmoid([0, 0]) = [0.5, 0.5]
+    return approxEqual(y[0], 0.5) && approxEqual(y[1], 0.5);
+}
+
+// Test TanhActivation with FFLayer
+// Input: [0, 0] -> W*x+b = [0, 0] -> Tanh = [0, 0]
+bool testFFLayerTanh()
+{
+    setupParams();
+    let storage = Storage(params);
+    
+    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, TanhActivation<float>, true>;
+    let layer = Layer(0, 4);
+    
+    float[2] arr = {0.0, 0.0};
+    let x = Vec2(arr);
+    
+    let y = layer.eval<Storage>(storage, x);
+    
+    // Tanh([0, 0]) = [0, 0]
+    return approxEqual(y[0], 0.0) && approxEqual(y[1], 0.0);
+}
+
+// Test ExpActivation with FFLayer
+// Input: [0, 0] -> W*x+b = [0, 0] -> Exp = [1, 1]
+bool testFFLayerExp()
+{
+    setupParams();
+    let storage = Storage(params);
+    
+    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, ExpActivation<float>, true>;
+    let layer = Layer(0, 4);
+    
+    float[2] arr = {0.0, 0.0};
+    let x = Vec2(arr);
+    
+    let y = layer.eval<Storage>(storage, x);
+    
+    // Exp([0, 0]) = [1, 1]
+    return approxEqual(y[0], 1.0) && approxEqual(y[1], 1.0);
+}
+
+// Test IdentityActivation with FFLayer
+// Input: [-1, 2] -> W*x+b = [-1, 2] -> Identity = [-1, 2]
+bool testFFLayerIdentity()
+{
+    setupParams();
+    let storage = Storage(params);
+    
+    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, IdentityActivation<float>, true>;
+    let layer = Layer(0, 4);
+    
+    float[2] arr = {-1.0, 2.0};
+    let x = Vec2(arr);
+    
+    let y = layer.eval<Storage>(storage, x);
+    
+    // Identity([-1, 2]) = [-1, 2]
+    return approxEqual(y[0], -1.0) && approxEqual(y[1], 2.0);
+}
+
+// Test SineActivation with FFLayer
+// Input: [0, pi/2] -> W*x+b = [0, pi/2] -> Sin = [0, 1]
+bool testFFLayerSine()
+{
+    setupParams();
+    let storage = Storage(params);
+    
+    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, SineActivation<float>, true>;
+    let layer = Layer(0, 4);
+    
+    float pi = 3.14159265;
+    float[2] arr = {0.0, pi / 2.0};
+    let x = Vec2(arr);
+    
+    let y = layer.eval<Storage>(storage, x);
+    
+    // Sin([0, pi/2]) = [0, 1]
+    return approxEqual(y[0], 0.0, 0.001) && approxEqual(y[1], 1.0, 0.001);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    testResult[0] = testFFLayerReLU();
+    testResult[1] = testFFLayerLeakyReLU();
+    testResult[2] = testFFLayerSigmoid();
+    testResult[3] = testFFLayerTanh();
+    testResult[4] = testFFLayerExp();
+    testResult[5] = testFFLayerIdentity();
+    testResult[6] = testFFLayerSine();
+
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+    // BUFFER: 1
+}

--- a/tests/neural/basic-ilayer-ffn-training-test.slang
+++ b/tests/neural/basic-ilayer-ffn-training-test.slang
@@ -1,0 +1,93 @@
+// Unit test for ILayer with multi-layer FFN (forward pass only).
+//
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-dx12 -compute -shaderobj -profile cs_6_6 -xslang -experimental-feature -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -output-using-type -xslang -experimental-feature
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0 -xslang -experimental-feature
+
+import neural;
+
+// Parameter packing:
+// Layer1: FFLayer<float, InlineVector<float,2>, InlineVector<float,2>, IdentityActivation<float>, HasBias=true>
+//   weights (2x2): [ 2, -1;
+//                   0.5, 3 ]
+//   bias (2): [ 1, -2 ]
+// Layer2: FFLayer<float, InlineVector<float,2>, InlineVector<float,1>, IdentityActivation<float>, HasBias=true>
+//   weights (1x2): [ -2, 4 ]
+//   bias (1): [ 0.5 ]
+//
+// Total params: (2*2 + 2) + (1*2 + 1) = 9
+
+//TEST_INPUT: ubuffer(data=[2.0 -1.0 0.5 3.0  1.0 -2.0  -2.0 4.0  0.5], stride=4):name=parametersFloat
+RWStructuredBuffer<float> parametersFloat;
+
+//TEST_INPUT: ubuffer(data=[0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0], stride=4):name=params
+RWStructuredBuffer<float> params;
+
+//TEST_INPUT: ubuffer(data=[0 0], stride=4):out,name=resultBuffer
+RWStructuredBuffer<uint> resultBuffer;
+
+typealias Storage = StructuredBufferStorage<float>;
+typealias V2 = InlineVector<float, 2>;
+typealias V1 = InlineVector<float, 1>;
+typealias Act = IdentityActivation<float>;
+typealias Layer1 = FFLayer<float, V2, V2, Storage, Act, true>;
+typealias Layer2 = FFLayer<float, V2, V1, Storage, Act, true>;
+
+static const uint Base0 = 0;
+
+bool forwardCheck()
+{
+    let storage = Storage(params);
+
+    float[2] xArr = { 1.5, -2.0 };
+    let x = V2(xArr);
+
+    // Layer1: weights at 0 (4 floats: 2x2), bias at 4 (2 floats)
+    let layer1 = Layer1(0, 4);
+    // Layer2: weights at 6 (2 floats: 1x2), bias at 8 (1 float)
+    let layer2 = Layer2(6, 8);
+
+    let h = layer1.eval<Storage>(storage, x);
+    let y = layer2.eval<Storage>(storage, h);
+
+    // Expected:
+    // h = W1*x + b1
+    //   = [2*1.5 + (-1)*(-2), 0.5*1.5 + 3*(-2)] + [1, -2]
+    //   = [3 + 2, 0.75 - 6] + [1, -2]
+    //   = [5 + 1, -5.25 - 2]
+    //   = [6, -7.25]
+    //
+    // y = W2*h + b2
+    //   = [-2*6 + 4*(-7.25)] + 0.5
+    //   = [-12 - 29] + 0.5
+    //   = -41 + 0.5
+    //   = -40.5
+    return (y[0] == -40.5);
+}
+
+bool parameterCountCheck()
+{
+    // Layer1: 2*2 + 2 = 6 parameters
+    // Layer2: 1*2 + 1 = 3 parameters
+    // Total: 9
+    bool layer1Ok = (Layer1.ParameterCount == 6);
+    bool layer2Ok = (Layer2.ParameterCount == 3);
+    bool addressOk = (Layer1.nextAddress(Base0) == 6);
+    return layer1Ok && layer2Ok && addressOk;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // Copy parametersFloat -> params
+    for (int i = 0; i < 9; i++)
+        params[i] = parametersFloat[i];
+
+    resultBuffer[0] = forwardCheck();
+    resultBuffer[1] = parameterCountCheck();
+
+    // BUFFER: 1
+    // BUFFER-NEXT: 1
+}

--- a/tests/neural/basic-ilayer-frontend-smoke-test.slang
+++ b/tests/neural/basic-ilayer-frontend-smoke-test.slang
@@ -1,0 +1,73 @@
+// Basic test for builtin neural "frontend" APIs (layers + activations).
+//
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-dx12 -compute -shaderobj -profile cs_6_6 -xslang -experimental-feature -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -output-using-type -xslang -experimental-feature
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0 -xslang -experimental-feature
+
+import neural;
+
+// Parameters: FFLayer<float, 4, 2, ..., HasBias=true>
+// weights = 2x4 matrix, bias = 2
+//TEST_INPUT: ubuffer(data=[1.0 2.0 3.0 4.0  5.0 6.0 7.0 8.0  9.0 10.0], stride=4):name=parametersFloat
+RWStructuredBuffer<float> parametersFloat;
+
+//TEST_INPUT: ubuffer(data=[0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0], stride=4):name=params
+RWStructuredBuffer<float> params;
+
+//TEST_INPUT: ubuffer(data=[0 0], stride=4):out,name=testResult
+RWStructuredBuffer<uint> testResult;
+
+typealias Storage = StructuredBufferStorage<float>;
+typealias XVec = InlineVector<float, 4>;
+typealias YVec = InlineVector<float, 2>;
+typealias Act = ReLU<float>;
+typealias Layer = FFLayer<float, XVec, YVec, Storage, Act, true>;
+
+// Test: evaluate layer through ILayer constraint
+InlineVector<float, 2> evalAsLayer<L>(
+    L layer,
+    Storage storage,
+    InlineVector<float, 4> input)
+    where L : ILayer<float, InlineVector<float, 4>, InlineVector<float, 2>, Storage, Act>
+{
+    return layer.eval<Storage>(storage, input);
+}
+
+bool forwardTest()
+{
+    // Copy parametersFloat -> params
+    for(int i=0;i<10;i++) params[i] = parametersFloat[i];
+
+    let storage = Storage(params);
+    // Weights at offset 0 (8 floats: 2x4), bias at offset 8 (2 floats)
+    let layer = Layer(0, 8);
+
+    // Input x = [1,2,3,4]
+    float[4] xArr = {1.0, 2.0, 3.0, 4.0};
+    let x = InlineVector<float, 4>(xArr);
+
+    // Layer: y = ReLU(W*x + b)
+    let y = evalAsLayer<Layer>(layer, storage, x);
+
+    // Expected: W*x + b = [1*1+2*2+3*3+4*4 + 9, 5*1+6*2+7*3+8*4 + 10] = [39, 80]
+    // ReLU([39, 80]) = [39, 80]
+    return (y[0] == 39.0) && (y[1] == 80.0);
+}
+
+bool parameterCountTest()
+{
+    // FFLayer<float, 4->2, HasBias=true> should have 4*2 + 2 = 10 parameters
+    return Layer.ParameterCount == 10;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    testResult[0] = forwardTest();
+    testResult[1] = parameterCountTest();
+
+    // BUFFER: 1
+    // BUFFER-NEXT: 1
+}

--- a/tests/neural/fflayer-autodiff-backward-test.slang
+++ b/tests/neural/fflayer-autodiff-backward-test.slang
@@ -1,0 +1,104 @@
+// Test FFLayer backward pass via autodiff.
+// Verifies that autodiff correctly computes gradients through eval<S>().
+//
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type
+
+import neural;
+
+// Weights: W = [[1,2],[3,4]], bias = [0.5, -0.5]
+//TEST_INPUT: ubuffer(data=[1.0 2.0 3.0 4.0 0.5 -0.5], stride=4):name=params
+RWStructuredBuffer<float> params;
+
+// Gradient buffer for weight gradients
+//TEST_INPUT: ubuffer(data=[0.0 0.0 0.0 0.0 0.0 0.0], stride=4):name=gradParams
+RWStructuredBuffer<float> gradParams;
+
+//TEST_INPUT: ubuffer(data=[0 0], stride=4):out,name=testResult
+RWStructuredBuffer<uint> testResult;
+
+typealias Storage = StructuredBufferStorage<float>;
+typealias Vec2 = InlineVector<float, 2>;
+typealias Act = IdentityActivation<float>;
+typealias Layer = FFLayer<float, Vec2, Vec2, Storage, Act, true>;
+
+bool approxEqual(float a, float b, float eps = 0.001)
+{
+    return abs(a - b) < eps;
+}
+
+// Test forward pass
+bool testForwardPass()
+{
+    let storage = Storage(params);
+    let layer = Layer(0, 4);
+
+    float[2] xArr = {1.0, 2.0};
+    let x = Vec2(xArr);
+    let y = layer.eval<Storage>(storage, x);
+
+    // W = [[1,2],[3,4]], b = [0.5, -0.5]
+    // y = W*x + b = [1*1+2*2, 3*1+4*2] + [0.5, -0.5] = [5, 11] + [0.5, -0.5] = [5.5, 10.5]
+    return approxEqual(y[0], 5.5) && approxEqual(y[1], 10.5);
+}
+
+// Wrapper function for autodiff - takes DifferentialPtrPair for storage
+[Differentiable]
+Vec2 computeOutput(Storage storage, Vec2 input, Layer layer)
+{
+    return layer.eval<Storage>(storage, input);
+}
+
+// Test backward pass using autodiff
+bool testBackwardPass()
+{
+    // Reset gradient buffer
+    for (int i = 0; i < 6; i++)
+        gradParams[i] = 0.0;
+
+    let storage = Storage(params);
+    let gradStorage = Storage(gradParams);
+    let layer = Layer(0, 4);
+
+    float[2] xArr = {1.0, 2.0};
+    let x = Vec2(xArr);
+
+    // Create DifferentialPtrPair for storage (primal, gradient)
+    var storagePair = DifferentialPtrPair<Storage>(storage, gradStorage);
+    
+    // Create diffPair for input
+    var inputPair = diffPair(x);
+    
+    // Output gradient: dL/dy = [1, 1]
+    let dOutput = Vec2(1.0);
+
+    // Use bwd_diff to compute gradients
+    bwd_diff(computeOutput)(storagePair, inputPair, layer, dOutput);
+
+    // Expected weight gradients:
+    // dL/dW = dy * x^T where dy = [1, 1], x = [1, 2]
+    // dW[0,0] = dy[0] * x[0] = 1 * 1 = 1
+    // dW[0,1] = dy[0] * x[1] = 1 * 2 = 2
+    // dW[1,0] = dy[1] * x[0] = 1 * 1 = 1
+    // dW[1,1] = dy[1] * x[1] = 1 * 2 = 2
+    // dB[0] = dy[0] = 1
+    // dB[1] = dy[1] = 1
+
+    bool w00 = approxEqual(gradParams[0], 1.0);
+    bool w01 = approxEqual(gradParams[1], 2.0);
+    bool w10 = approxEqual(gradParams[2], 1.0);
+    bool w11 = approxEqual(gradParams[3], 2.0);
+    bool b0 = approxEqual(gradParams[4], 1.0);
+    bool b1 = approxEqual(gradParams[5], 1.0);
+
+    return w00 && w01 && w10 && w11 && b0 && b1;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    testResult[0] = testForwardPass();
+    testResult[1] = testBackwardPass();
+    // BUFFER: 1
+    // BUFFER: 1
+}

--- a/tests/neural/fflayer-two-storage-forward-test.slang
+++ b/tests/neural/fflayer-two-storage-forward-test.slang
@@ -1,0 +1,56 @@
+// Test FFLayer eval() with separate weight/bias storage instances.
+//
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-dx12 -compute -shaderobj -profile cs_6_6 -xslang -experimental-feature -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -output-using-type -xslang -experimental-feature
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0 -xslang -experimental-feature
+
+import neural;
+
+// Weights (Output=1, Input=2): [w0, w1]
+//TEST_INPUT: ubuffer(data=[3.0 4.0], stride=4):name=weights
+RWStructuredBuffer<float> weights;
+
+// Bias (Output=1): [b]
+//TEST_INPUT: ubuffer(data=[0.5], stride=4):name=bias
+RWStructuredBuffer<float> bias;
+
+//TEST_INPUT: ubuffer(data=[0], stride=4):out,name=testResult
+RWStructuredBuffer<uint> testResult;
+
+typealias Storage = StructuredBufferStorage<float>;
+typealias Vec2 = InlineVector<float, 2>;
+typealias Vec1 = InlineVector<float, 1>;
+typealias Act = IdentityActivation<float>;
+typealias Layer = FFLayer<float, Vec2, Vec1, Storage, Act, true>;
+
+bool approxEqual(float a, float b, float eps = 0.001)
+{
+    return abs(a - b) < eps;
+}
+
+bool testTwoStorageForward()
+{
+    let wStorage = Storage(weights);
+    let bStorage = Storage(bias);
+
+    // weightAddress=0 in weights buffer, biasAddress=0 in bias buffer
+    let layer = Layer(0, 0);
+
+    float[2] xArr = { 1.0, 2.0 };
+    let x = Vec2(xArr);
+
+    let y = layer.eval<Storage>(wStorage, bStorage, x);
+
+    // Expected: 3*1 + 4*2 + 0.5 = 11.5
+    return approxEqual(y[0], 11.5);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    testResult[0] = testTwoStorageForward();
+    // BUFFER: 1
+}
+


### PR DESCRIPTION
Fixes #9517 

- Add builtin neural frontend building blocks:
  - IActivation + common activations (ReLU/LeakyReLU/Sigmoid/Tanh/Exp/Sine)
  - ILayer/LinearLayer/FFLayer on top of InlineVector.linearTransform
  - Storage passed as parameter to eval for autodiff backward support
- Wire new files into standard module neural.slang
- Add tests:
  - ILayer frontend smoke test: ILayer + IActivation
  - ILayer FFN training test: multi-layer forward pass
  - Activation functions test with FFLayer
  - Autodiff backward test using bwd_diff()