### PR TITLE
Fix unnecessary rebuilds of generated code

### DIFF
--- a/source/slang-core-module/CMakeLists.txt
+++ b/source/slang-core-module/CMakeLists.txt
@@ -37,16 +37,27 @@ foreach(meta_source ${core_module_meta_source})
     )
 endforeach()
 
+set(core_module_meta_stamp
+    "${core_module_meta_output_dir}/slang-core-module-meta.stamp"
+)
+set_source_files_properties(${core_module_meta_generated_headers} PROPERTIES GENERATED TRUE)
 add_custom_command(
-    OUTPUT ${core_module_meta_generated_headers}
+    OUTPUT ${core_module_meta_stamp}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${core_module_meta_output_dir}
     COMMAND
         slang-generate ${core_module_meta_source} --target-directory
         ${core_module_meta_output_dir}
+    COMMAND ${CMAKE_COMMAND} -E touch ${core_module_meta_stamp}
     DEPENDS ${core_module_meta_source} slang-generate
+    BYPRODUCTS ${core_module_meta_generated_headers}
     WORKING_DIRECTORY "${core_module_meta_source_dir}"
     VERBATIM
 )
+add_custom_target(
+    generate_core_module_meta_headers
+    DEPENDS ${core_module_meta_stamp}
+)
+set_target_properties(generate_core_module_meta_headers PROPERTIES FOLDER generated)
 
 #
 # Generate embedded core module source library (or a dummy library with just nullptrs)
@@ -80,6 +91,7 @@ slang_add_target(
     TARGET_NAME slang-embedded-core-module-source
     EXTRA_COMPILE_DEFINITIONS_PRIVATE SLANG_EMBED_CORE_MODULE_SOURCE
     EXPLICIT_SOURCE ${core_module_meta_generated_headers}
+    REQUIRES generate_core_module_meta_headers
     EXCLUDE_FROM_ALL
 )
 
@@ -104,6 +116,14 @@ set(glsl_module_generated_header_dir
 set(glsl_module_generated_header
     ${glsl_module_generated_header_dir}/slang-glsl-module-generated.h
 )
+set(core_module_headers_stamp
+    ${core_module_generated_header_dir}/slang-core-module-headers.stamp
+)
+set_source_files_properties(
+    ${core_module_generated_header}
+    ${glsl_module_generated_header}
+    PROPERTIES GENERATED TRUE
+)
 
 # Propagate to parent directory scope, so they're visible to
 # slang-glsl-module/CMakeLists.txt
@@ -114,19 +134,21 @@ set(glsl_module_generated_header_dir
 set(glsl_module_generated_header ${glsl_module_generated_header} PARENT_SCOPE)
 
 add_custom_command(
-    OUTPUT ${core_module_generated_header} ${glsl_module_generated_header}
+    OUTPUT ${core_module_headers_stamp}
     COMMAND
         slang-bootstrap -archive-type riff-lz4 -save-core-module-bin-source
         ${core_module_generated_header} -save-glsl-module-bin-source
         ${glsl_module_generated_header}
+    COMMAND ${CMAKE_COMMAND} -E touch ${core_module_headers_stamp}
     DEPENDS slang-bootstrap slang-without-embedded-core-module
+    BYPRODUCTS ${core_module_generated_header} ${glsl_module_generated_header}
     VERBATIM
 )
 # Add a target so that we can depend on the above step when we create the glsl
 # module
 add_custom_target(
     generate_core_module_headers
-    DEPENDS ${core_module_generated_header} ${glsl_module_generated_header}
+    DEPENDS ${core_module_headers_stamp}
 )
 set_target_properties(generate_core_module_headers PROPERTIES FOLDER generated)
 

--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -27,16 +27,28 @@ list(
 )
 list(TRANSFORM SLANG_FIDDLE_OUTPUTS PREPEND "${SLANG_FIDDLE_OUTPUT_DIR}/")
 
+# Use a stamp file as the primary output so the generator run is tracked
+# even when generated content doesn't change.
+set(SLANG_FIDDLE_STAMP "${SLANG_FIDDLE_OUTPUT_DIR}/slang-fiddle.stamp")
+set_source_files_properties(${SLANG_FIDDLE_OUTPUTS} PROPERTIES GENERATED TRUE)
+
 add_custom_command(
-    OUTPUT ${SLANG_FIDDLE_OUTPUTS}
+    OUTPUT ${SLANG_FIDDLE_STAMP}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${SLANG_FIDDLE_OUTPUT_DIR}
     COMMAND
         slang-fiddle -i "${SLANG_FIDDLE_INPUT_DIR}/" -o
         "${SLANG_FIDDLE_OUTPUT_DIR}/" ${SLANG_FIDDLE_INPUT_FILE_NAMES}
+    COMMAND ${CMAKE_COMMAND} -E touch ${SLANG_FIDDLE_STAMP}
     DEPENDS ${SLANG_FIDDLE_INPUTS} ${SLANG_FIDDLE_LUA_INPUTS} slang-fiddle
+    BYPRODUCTS ${SLANG_FIDDLE_OUTPUTS}
     WORKING_DIRECTORY ${slang_SOURCE_DIR}
     VERBATIM
 )
+add_custom_target(
+    generate_slang_fiddle_outputs
+    DEPENDS ${SLANG_FIDDLE_STAMP}
+)
+set_target_properties(generate_slang_fiddle_outputs PROPERTIES FOLDER generated)
 add_library(
     slang-fiddle-output
     INTERFACE
@@ -44,6 +56,7 @@ add_library(
     ${SLANG_FIDDLE_OUTPUTS}
 )
 set_target_properties(slang-fiddle-output PROPERTIES FOLDER generated)
+add_dependencies(slang-fiddle-output generate_slang_fiddle_outputs)
 target_include_directories(
     slang-fiddle-output
     INTERFACE ${SLANG_FIDDLE_OUTPUT_DIR}
@@ -65,23 +78,33 @@ set(SLANG_CAPABILITY_GENERATED_SOURCE
     ${SLANG_CAPABILITY_GENERATED_HEADERS}
     "${SLANG_CAPABILITY_OUTPUT_DIR}/slang-lookup-capability-defs.cpp"
 )
+set(SLANG_CAPABILITY_STAMP "${SLANG_CAPABILITY_OUTPUT_DIR}/slang-capability.stamp")
+set_source_files_properties(${SLANG_CAPABILITY_GENERATED_SOURCE} PROPERTIES GENERATED TRUE)
 add_custom_command(
-    OUTPUT ${SLANG_CAPABILITY_GENERATED_SOURCE}
+    OUTPUT ${SLANG_CAPABILITY_STAMP}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${SLANG_CAPABILITY_OUTPUT_DIR}
     COMMAND
         slang-capability-generator ${SLANG_CAPABILITY_SOURCE} --target-directory
         ${SLANG_CAPABILITY_OUTPUT_DIR} --doc
         "${slang_SOURCE_DIR}/docs/user-guide/a3-02-reference-capability-atoms.md"
+    COMMAND ${CMAKE_COMMAND} -E touch ${SLANG_CAPABILITY_STAMP}
     DEPENDS ${SLANG_CAPABILITY_SOURCE} slang-capability-generator
+    BYPRODUCTS ${SLANG_CAPABILITY_GENERATED_SOURCE}
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
     VERBATIM
 )
+add_custom_target(
+    generate_slang_capability_definitions
+    DEPENDS ${SLANG_CAPABILITY_STAMP}
+)
+set_target_properties(generate_slang_capability_definitions PROPERTIES FOLDER generated)
 slang_add_target(
     slang-capability-defs
     OBJECT
     EXPORT_MACRO_PREFIX SLANG
     USE_EXTRA_WARNINGS
     EXPLICIT_SOURCE ${SLANG_CAPABILITY_GENERATED_HEADERS}
+    REQUIRES generate_slang_capability_definitions
     EXPORT_TYPE_AS ${SLANG_LIB_TYPE}
     LINK_WITH_PRIVATE core
     INCLUDE_DIRECTORIES_PUBLIC
@@ -121,22 +144,33 @@ set(SLANG_LOOKUP_GENERATOR_OUTPUT_DIR
 set(SLANG_LOOKUP_GENERATED_SOURCE
     "${SLANG_LOOKUP_GENERATOR_OUTPUT_DIR}/slang-lookup-GLSLstd450.cpp"
 )
+set(SLANG_LOOKUP_GENERATED_STAMP
+    "${SLANG_LOOKUP_GENERATOR_OUTPUT_DIR}/slang-lookup-GLSLstd450.stamp"
+)
+set_source_files_properties(${SLANG_LOOKUP_GENERATED_SOURCE} PROPERTIES GENERATED TRUE)
 set(SLANG_RECORD_REPLAY_SYSTEM
     "${slang_SOURCE_DIR}/source/slang-record-replay/record"
     "${slang_SOURCE_DIR}/source/slang-record-replay/util"
 )
 
 add_custom_command(
-    OUTPUT ${SLANG_LOOKUP_GENERATED_SOURCE}
+    OUTPUT ${SLANG_LOOKUP_GENERATED_STAMP}
     COMMAND
         ${CMAKE_COMMAND} -E make_directory ${SLANG_LOOKUP_GENERATOR_OUTPUT_DIR}
     COMMAND
         slang-lookup-generator ${SLANG_LOOKUP_GENERATOR_INPUT_JSON}
         ${SLANG_LOOKUP_GENERATED_SOURCE} "GLSLstd450" "GLSLstd450"
         "spirv/unified1/GLSL.std.450.h"
+    COMMAND ${CMAKE_COMMAND} -E touch ${SLANG_LOOKUP_GENERATED_STAMP}
     DEPENDS ${SLANG_LOOKUP_GENERATOR_INPUT_JSON} slang-lookup-generator
+    BYPRODUCTS ${SLANG_LOOKUP_GENERATED_SOURCE}
     VERBATIM
 )
+add_custom_target(
+    generate_slang_lookup_tables
+    DEPENDS ${SLANG_LOOKUP_GENERATED_STAMP}
+)
+set_target_properties(generate_slang_lookup_tables PROPERTIES FOLDER generated)
 
 set(SLANG_SPIRV_CORE_SOURCE_JSON
     "${SLANG_SPIRV_HEADERS_INCLUDE_DIR}/spirv/unified1/spirv.core.grammar.json"
@@ -144,16 +178,27 @@ set(SLANG_SPIRV_CORE_SOURCE_JSON
 set(SLANG_SPIRV_CORE_GRAMMAR_SOURCE
     "${SLANG_LOOKUP_GENERATOR_OUTPUT_DIR}/slang-spirv-core-grammar-embed.cpp"
 )
+set(SLANG_SPIRV_CORE_GRAMMAR_STAMP
+    "${SLANG_LOOKUP_GENERATOR_OUTPUT_DIR}/slang-spirv-core-grammar.stamp"
+)
+set_source_files_properties(${SLANG_SPIRV_CORE_GRAMMAR_SOURCE} PROPERTIES GENERATED TRUE)
 add_custom_command(
-    OUTPUT ${SLANG_SPIRV_CORE_GRAMMAR_SOURCE}
+    OUTPUT ${SLANG_SPIRV_CORE_GRAMMAR_STAMP}
     COMMAND
         ${CMAKE_COMMAND} -E make_directory ${SLANG_LOOKUP_GENERATOR_OUTPUT_DIR}
     COMMAND
         slang-spirv-embed-generator ${SLANG_SPIRV_CORE_SOURCE_JSON}
         ${SLANG_SPIRV_CORE_GRAMMAR_SOURCE}
+    COMMAND ${CMAKE_COMMAND} -E touch ${SLANG_SPIRV_CORE_GRAMMAR_STAMP}
     DEPENDS ${SLANG_SPIRV_CORE_SOURCE_JSON} slang-spirv-embed-generator
+    BYPRODUCTS ${SLANG_SPIRV_CORE_GRAMMAR_SOURCE}
     VERBATIM
 )
+add_custom_target(
+    generate_slang_spirv_core_grammar
+    DEPENDS ${SLANG_SPIRV_CORE_GRAMMAR_STAMP}
+)
+set_target_properties(generate_slang_spirv_core_grammar PROPERTIES FOLDER generated)
 
 slang_add_target(
     slang-lookup-tables
@@ -163,6 +208,7 @@ slang_add_target(
     EXPLICIT_SOURCE
         ${SLANG_LOOKUP_GENERATED_SOURCE}
         ${SLANG_SPIRV_CORE_GRAMMAR_SOURCE}
+    REQUIRES generate_slang_lookup_tables generate_slang_spirv_core_grammar
     EXPORT_TYPE_AS ${SLANG_LIB_TYPE}
     LINK_WITH_PRIVATE core SPIRV-Headers::SPIRV-Headers
     EXCLUDE_FROM_ALL


### PR DESCRIPTION
Generator commands often produce unchanged output, but tracking these
files as primary CMake outputs caused repeated generator runs and
cascading rebuilds whenever the generator executable was newer than
outputs.

This change uses stamp files as the tracked OUTPUT, with actual
generated files listed as BYPRODUCTS. CMake now tracks generator runs
via the stamp file without forcing output timestamps to change when
content is unchanged.

Affected generators:
- slang-generate (core-module-meta headers)
- slang-fiddle (fiddle outputs)
- slang-capability-generator (capability definitions)
- slang-spirv-embed-generator (SPIR-V grammar)
- slang-lookup-generator (lookup tables)
- slang-bootstrap (core module headers)

Each generator now has:
- A .stamp file as the OUTPUT (always touched after running)
- Generated files as BYPRODUCTS (timestamps only change when content
  changes)
- An explicit custom target for other targets to depend on

Fixes #9722 