### PR TITLE
Avoid ImageGatherExtended capability for constant offset in Gather

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -3681,7 +3681,6 @@ vector<T.Element,4> __texture_gather_offset(
         __intrinsic_asm "$0.gather($1, $2, $3, metal::component($4))";
     case spirv:
         return spirv_asm {
-            OpCapability ImageGatherExtended;
             %sampledImage : __sampledImageType(texture) = OpSampledImage $texture $s;
             result:$$vector<T.Element,4> = OpImageGather %sampledImage $location $component Offset $offset;
         };
@@ -3735,7 +3734,6 @@ vector<T.Element,4> __texture_gather_offset(
         __intrinsic_asm "textureGatherOffset($0, $1, $2, $3)";
     case spirv:
         return spirv_asm {
-            OpCapability ImageGatherExtended;
             result:$$vector<T.Element,4> = OpImageGather $sampler $location $component Offset $offset;
         };
     }

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -2,6 +2,7 @@
 #include "slang-ir-spirv-legalize.h"
 
 #include "slang-emit-base.h"
+#include "spirv/unified1/spirv.h"
 #include "slang-ir-call-graph.h"
 #include "slang-ir-clone.h"
 #include "slang-ir-composite-reg-to-mem.h"
@@ -30,6 +31,38 @@
 
 namespace Slang
 {
+
+// Helper to check if an IR instruction represents a compile-time constant value.
+// Used to determine if Offset can be converted to ConstOffset for image gather operations.
+static bool isIRConstantValue(IRInst* inst)
+{
+    if (!inst)
+        return false;
+
+    switch (inst->getOp())
+    {
+    case kIROp_IntLit:
+    case kIROp_FloatLit:
+    case kIROp_BoolLit:
+    case kIROp_StringLit:
+        return true;
+
+    case kIROp_MakeVector:
+    case kIROp_MakeArray:
+    case kIROp_MakeStruct:
+    case kIROp_MakeMatrix:
+        // Check if all operands are constant
+        for (UInt i = 0; i < inst->getOperandCount(); i++)
+        {
+            if (!isIRConstantValue(inst->getOperand(i)))
+                return false;
+        }
+        return true;
+
+    default:
+        return false;
+    }
+}
 
 //
 // Legalization of IR for direct SPIRV emit.
@@ -1495,6 +1528,28 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         return (as<IRSPIRVAsmInst>(inst) || as<IRSPIRVAsmOperand>(inst));
     }
 
+    static SpvOp getSpvOpCodeFromAsmInst(IRSPIRVAsmInst* spvInst)
+    {
+        if (spvInst->getOperandCount() == 0)
+            return SpvOpMax; // invalid
+
+        // Get the opcode operand - must be a literal or enum
+        auto opcodeOperand = spvInst->getOpcodeOperand();
+        if (opcodeOperand->getOp() == kIROp_SPIRVAsmOperandTruncate)
+            return SpvOpMax; // ignore
+
+        auto opcodeValue = opcodeOperand->getValue();
+        if (!opcodeValue)
+            return SpvOpMax;
+
+        auto opcodeLit = as<IRIntLit>(opcodeValue);
+        if (!opcodeLit)
+            return SpvOpMax;
+
+        SpvOp opcode = (SpvOp)opcodeLit->getValue();
+        return opcode;
+    }
+
     void processConvertTexel(IRInst* asmBlockInst, IRInst* inst)
     {
         // If we see `__convertTexel(x)`, we need to return a vector<__sampledElementType(x), 4>.
@@ -1522,6 +1577,96 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         inst->removeAndDeallocate();
     }
 
+    // Legalizes image gather operations (OpImageGather/OpImageDrefGather) to use ConstOffset
+    // instead of Offset when the offset value is a compile-time constant.
+    // Per SPIR-V spec:
+    // - ConstOffset (0x0008): for compile-time constants, no capability needed
+    // - Offset (0x0010): for runtime values, requires ImageGatherExtended capability
+    void processImageGatherOffset(IRSPIRVAsm* asmBlock, IRSPIRVAsmInst* spvInst)
+    {
+        // Find the image operand mask operand
+        Index operandIdx = 0;
+        IRSPIRVAsmOperand* maskOperand = nullptr;
+        uint32_t mask = 0;
+
+        for (auto operand : spvInst->getSPIRVOperands())
+        {
+            if (operand->getOp() == kIROp_SPIRVAsmOperandLiteral ||
+                operand->getOp() == kIROp_SPIRVAsmOperandEnum)
+            {
+                if (auto valInst = as<IRIntLit>(operand->getOperand(0)))
+                {
+                    uint32_t val = uint32_t(valInst->getValue());
+                    // Check if Offset bit (0x0010) is set but not ConstOffset (0x0008)
+                    if ((val & SpvImageOperandsOffsetMask) &&
+                        !(val & SpvImageOperandsConstOffsetMask))
+                    {
+                        maskOperand = operand;
+                        mask = val;
+                        break;
+                    }
+                }
+            }
+            operandIdx++;
+        }
+
+        if (!maskOperand)
+            return;
+
+        // Find the offset value operand.
+        // Count how many operands come before the offset based on mask bits.
+        Index offsetOperandIdx = operandIdx + 1;
+        if (mask & SpvImageOperandsBiasMask)
+            offsetOperandIdx++;
+        if (mask & SpvImageOperandsLodMask)
+            offsetOperandIdx++;
+        if (mask & SpvImageOperandsGradMask)
+            offsetOperandIdx += 2;
+
+        // Find the offset value operand
+        Index currentIdx = 0;
+        IRInst* offsetValue = nullptr;
+        for (auto op : spvInst->getSPIRVOperands())
+        {
+            if (currentIdx == offsetOperandIdx)
+            {
+                if (op->getOp() == kIROp_SPIRVAsmOperandInst)
+                {
+                    offsetValue = op->getValue();
+                }
+                break;
+            }
+            currentIdx++;
+        }
+
+        IRBuilder builder(asmBlock->getModule());
+        if (offsetValue && isIRConstantValue(offsetValue))
+        {
+            // Force reset the `Offset` mask to `ConstOffset` mask.
+            uint32_t newMask =
+                (mask & ~SpvImageOperandsOffsetMask) | SpvImageOperandsConstOffsetMask;
+            auto newMaskLit = builder.getIntValue(builder.getIntType(), newMask);
+            builder.replaceOperand(&maskOperand->getOperands()[0], newMaskLit);
+        }
+        else
+        {
+            // The offset value is not constant.
+            // Keep the `Offset` mask but insert `OpCapability ImageGatherExtended`
+            // at the beginning of the asm block
+            builder.setInsertInto(asmBlock);
+            if (auto firstChild = asmBlock->getFirstChild())
+                builder.setInsertBefore(firstChild);
+            auto capabilityLit =
+                builder.getIntValue(builder.getIntType(), SpvCapabilityImageGatherExtended);
+            auto capOpcodeOperand =
+                builder.emitSPIRVAsmOperandEnum(builder.getIntValue(builder.getIntType(), SpvOpCapability));
+            auto capabilityOperand = builder.emitSPIRVAsmOperandEnum(capabilityLit);
+            List<IRInst*> operands;
+            operands.add(capabilityOperand);
+            builder.emitSPIRVAsmInst(capOpcodeOperand, operands);
+        }
+    }
+
     void processSPIRVAsm(IRSPIRVAsm* inst)
     {
         // Move anything that is not an spirv instruction to the outer parent.
@@ -1531,6 +1676,16 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 child->insertBefore(inst);
             else if (child->getOp() == kIROp_SPIRVAsmOperandConvertTexel)
                 processConvertTexel(inst, child);
+            else if (auto spvInst = as<IRSPIRVAsmInst>(child))
+            {
+                switch (getSpvOpCodeFromAsmInst(spvInst))
+                {
+                case SpvOpImageGather:
+                case SpvOpImageDrefGather:
+                    processImageGatherOffset(inst, spvInst);
+                    break;
+                }
+            }
         }
     }
 

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -2,7 +2,6 @@
 #include "slang-ir-spirv-legalize.h"
 
 #include "slang-emit-base.h"
-#include "spirv/unified1/spirv.h"
 #include "slang-ir-call-graph.h"
 #include "slang-ir-clone.h"
 #include "slang-ir-composite-reg-to-mem.h"
@@ -28,6 +27,7 @@
 #include "slang-ir-validate.h"
 #include "slang-ir.h"
 #include "slang-legalize-types.h"
+#include "spirv/unified1/spirv.h"
 
 namespace Slang
 {
@@ -1658,8 +1658,8 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 builder.setInsertBefore(firstChild);
             auto capabilityLit =
                 builder.getIntValue(builder.getIntType(), SpvCapabilityImageGatherExtended);
-            auto capOpcodeOperand =
-                builder.emitSPIRVAsmOperandEnum(builder.getIntValue(builder.getIntType(), SpvOpCapability));
+            auto capOpcodeOperand = builder.emitSPIRVAsmOperandEnum(
+                builder.getIntValue(builder.getIntType(), SpvOpCapability));
             auto capabilityOperand = builder.emitSPIRVAsmOperandEnum(capabilityLit);
             List<IRInst*> operands;
             operands.add(capabilityOperand);

--- a/tests/bugs/gh-9382-gather-constoffset.slang
+++ b/tests/bugs/gh-9382-gather-constoffset.slang
@@ -1,0 +1,31 @@
+//TEST:SIMPLE(filecheck=CONST_OFFSET): -target spirv-asm -entry main -stage fragment -DCONST_OFFSET
+//TEST:SIMPLE(filecheck=OFFSET): -target spirv-asm -entry main -stage fragment
+
+// When `OpImageGather` takes a compile-time constant value as its `offset` value,
+// it is enough to use a flag `ConstOffset` and it shouldn't use
+// `ImageGatherExtended` capability unnecessarilly.
+// When the `offset` value is a runtime value, `ImageGatherExtended` is required,
+// and the flag must be `Offset` instead of `ConstOffset`.
+
+// CONST_OFFSET-NOT:OpCapability ImageGatherExtended
+// OFFSET:OpCapability ImageGatherExtended
+
+[[vk::binding(0, 0)]]
+Texture2D<float> tex;
+
+[[vk::binding(1, 0)]]
+SamplerState s;
+
+[shader("fragment")]
+float4 main([[vk::location(0)]] float2 uv : UV) : SV_Target
+{
+#if defined(CONST_OFFSET)
+    // CONST_OFFSET:OpImageGather %
+    // CONST_OFFSET-SAME: ConstOffset %
+    return tex.Gather(s, uv, int2(2, 1));
+#else
+    // OFFSET:OpImageGather %
+    // OFFSET-SAME: {{ }}Offset %
+    return tex.Gather(s, uv, int2(uv));
+#endif
+}


### PR DESCRIPTION
When `Texture.Gather()` is called with an offset value, the offset value should be a compile-time constant and the SPIRV OpCode should use `ConstOffset` mask. But when `ImageGatherExtended` capability is used, the offset can be a runtime value and it must use `Offset` mask if the offset is a runtime value.

Slang had been always requiring `ImageGatherExtended` capability and using `Offset` even when the offset value is actually a compile-time value.

This PR conditionally requires the capability, `ImageGatherExtended`, based on whether the offset value is a compile-time value or not. Also a proper mask value is applied; `ConstOffset` for a compile-time offset value and `Offset` of a runtime offset value.

Fixes #9382