### PR TITLE
Explicitly remove unused ByteAddressBuffer types after the legalization

### DIFF
--- a/tests/spirv/byte-address-buffer-preserve-params.slang
+++ b/tests/spirv/byte-address-buffer-preserve-params.slang
@@ -1,0 +1,28 @@
+//TEST:SIMPLE(filecheck=READONLY):-target spirv-asm -entry computeMain -stage compute -preserve-params -DREADONLY
+//TEST:SIMPLE(filecheck=WRITABLE):-target spirv-asm -entry computeMain -stage compute -preserve-params
+
+// A bug 9262 reported that Slang was crashing when `-preserve-params` is used.
+// It turned out that `KeepAlive` and `Export` decorations were not properly moved over
+// during the legalization process from ByteAddressBuffer to StructuredBuffer.
+
+RWStructuredBuffer<uint> buffer;
+
+#if defined(READONLY)
+ByteAddressBuffer byte_buffer;
+#else
+RWByteAddressBuffer byte_buffer;
+#endif
+
+//READONLY: OpName %[[BAB:[A-Za-z_][A-Za-z_0-9]*]] "byte_buffer"
+//READONLY: OpDecorate %[[BAB]] Binding 1
+//READONLY: OpDecorate %[[BAB]] NonWritable
+
+//WRITABLE: OpName %[[BAB:[A-Za-z_][A-Za-z_0-9]*]] "byte_buffer"
+//WRITABLE: OpDecorate %[[BAB]] Binding 1
+//WRITABLE-NOT: OpDecorate %[[BAB]] NonWritable
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 i: SV_DispatchThreadID)
+{
+    buffer[0] = byte_buffer.Load(0);
+}


### PR DESCRIPTION
Fixes #9262.

The bug 9262 reported that Slang was crashing when `-preserve-params` option is used and `ByteAddressBuffer` type is used.
This is related to the fact that SPIRV doesn't natively support `ByteAddressBuffer` and Slang legalizes them to `StructuredBuffer`.

The causes was due to the existence of the unused `ByteAddressBuffer` types. DCE normally removes them, but the option, `-preserve-params` was preventing them from being removed.

This PR explicitly removes the unused `ByteAddressBuffer` types after legalizing to the `StructuredBuffer` types.

Also noticed that two more decorations also had to be moved over during the legalization: `[KeepAlive]` and `[Export]`