### PR TITLE
Language server highlighting fix for generic value param.

### DIFF
--- a/source/slang/slang-language-server-semantic-tokens.cpp
+++ b/source/slang/slang-language-server-semantic-tokens.cpp
@@ -61,8 +61,6 @@ List<SemanticToken> getSemanticTokens(
 {
     auto manager = linkage->getSourceManager();
 
-    auto cbufferName = linkage->getNamePool()->getName(toSlice("ConstantBuffer"));
-
     List<SemanticToken> result;
     auto maybeInsertToken = [&](const SemanticToken& token)
     {
@@ -97,10 +95,9 @@ List<SemanticToken> getSemanticTokens(
             if (target->hasModifier<BuiltinTypeModifier>())
                 return;
             token.type = SemanticTokenType::Type;
-            if (name == cbufferName)
-            {
-                token.length = doc->getTokenLength(token.line, token.col);
-            }
+            token.length = doc->getTokenLength(token.line, token.col);
+            if (token.length == 0)
+                return;
         }
         else if (as<ConstructorDecl>(target))
         {

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -1517,6 +1517,7 @@ static Decl* ParseGenericParamDecl(Parser* parser, GenericDecl* genericDecl)
     {
         // default case is a type parameter
         auto paramDecl = parser->astBuilder->create<GenericValueParamDecl>();
+        parser->FillPosition(paramDecl);
         paramDecl->nameAndLoc = NameLoc(parser->ReadToken(TokenType::Identifier));
         if (AdvanceIf(parser, TokenType::Colon))
         {

--- a/tests/language-server/gen-val-param.slang
+++ b/tests/language-server/gen-val-param.slang
@@ -1,0 +1,16 @@
+//TEST:LANG_SERVER(filecheck=CHECK):
+struct LongTypeNameLongTypeName
+{
+    int x;
+    int y;
+}
+
+[numthreads(1,1,1)]
+void computeMain<let geparam : int>()
+{
+    int abc = 2;
+    //HOVER:13,47
+    LongTypeNameLongTypeName var = {abc, geparam};
+    // Check that language server can report correct line number for geparam.
+    // CHECK: (9)
+}


### PR DESCRIPTION
Fix two small highlighting/goto-definition issues in language server.

1. Generic value parameter doesn't have proper sourceloc. (tested by a hover test).
2. `LongTypeName obj = {...}` incorrectly highlights `{...}` as a type name. (cannot be tested due to lack of semantic tokens test)