### PR TITLE
Fix the issue when detecting the reachable inst for auto-diff worklist

### DIFF
--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -3351,6 +3351,57 @@ struct AutoDiffPass : public InstPassBase
     // on this filtered list.
     // For a generic, we will add it to the list only when it's a function and it's used by other
     // function, because that is the case of dynamic dispatch.
+
+    // Helper function to check if a generic function is reachable by recursively
+    // checking the reference chain. The `visitedSet` is used to detect circular
+    // references (e.g., A->B->C->A), which are considered unreachable.
+    bool isGenericFunctionReachable(IRGeneric* genericInst, HashSet<IRInst*>& visitedSet)
+    {
+        // If we've already visited this generic, we have a circular reference.
+        // Circular references are considered unreachable.
+        if (visitedSet.contains(genericInst))
+            return false;
+
+        // Only process generics that return a function
+        if (!as<IRFunc>(findInnerMostGenericReturnVal(genericInst)))
+            return false;
+
+        // Mark as visited before checking uses to handle circular references
+        visitedSet.add(genericInst);
+
+        for (auto use = genericInst->firstUse; use; use = use->nextUse)
+        {
+            auto user = use->getUser();
+
+            // If used directly at module level, it's reachable
+            if (as<IRModuleInst>(user->parent))
+                return true;
+
+            // Walk up the parent chain to find the containing function or generic
+            for (; user; user = user->parent)
+            {
+                if (auto genericUser = as<IRGeneric>(user))
+                {
+                    // If the user is a generic that returns a function,
+                    // recursively check if that generic is reachable
+                    if (as<IRFunc>(findInnerMostGenericReturnVal(genericUser)))
+                    {
+                        if (isGenericFunctionReachable(genericUser, visitedSet))
+                            return true;
+                    }
+                    break;
+                }
+                else if (as<IRFunc>(user))
+                {
+                    // Used by a non-generic function, it's reachable
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     bool isReachableInst(IRInst* inst)
     {
         switch (inst->getOp())
@@ -3363,27 +3414,12 @@ struct AutoDiffPass : public InstPassBase
         case kIROp_Func:
             return true;
         case kIROp_Generic:
-            // For generic, if it's a generic function and it's used by any other reachable
-            // inst, we will consider it reachable.
-            auto genericIR = as<IRGeneric>(inst);
-            if (as<IRFunc>(findInnerMostGenericReturnVal(genericIR)))
             {
-                for (auto use = inst->firstUse; use; use = use->nextUse)
-                {
-                    auto user = use->getUser();
-                    if (as<IRModuleInst>(user->parent))
-                        return true;
-
-                    for (; user; user = user->parent)
-                    {
-                        if (auto genericUser = as<IRGeneric>(user))
-                            return (
-                                as<IRFunc>(findInnerMostGenericReturnVal(genericUser)) != nullptr);
-
-                        else if (as<IRFunc>(user))
-                            return true;
-                    }
-                }
+                // For generic, if it's a generic function and it's used by any other reachable
+                // inst, we will consider it reachable.
+                auto genericIR = as<IRGeneric>(inst);
+                HashSet<IRInst*> visitedSet;
+                return isGenericFunctionReachable(genericIR, visitedSet);
             }
         }
         return false;


### PR DESCRIPTION
We currently use a naive way to detect whether generic function is reachable to be transcribed in the auto-diff pass.
For example, if A is used by B, where both A and B are generic function, then we think A is reachable. This helps in lot of cases to reduce the needs of transcribing unused functions, however it doesn't solve the problem in more complicated situations.

For example, if the use chain is something like (assume all users are generic functions):
A -> B -> C -> A

in this case, A is still unreachable, because even though B is using A, B is finally only used by A. This is just a cyclic reference chain, and we can safely treat A as unreachable.

For the actual implementation, in order to avoid unnecessary traverse of the chain, we also add a cache to remember which node in the reference chain is unreachable.

For example:

D->E->A -> B -> C -> A
----------^

for the chain like this, we can just stop at first A because we know A is unreachable. So if D is only used by A, then it's unreachable as well.