### PR TITLE
Add dynamic specialization logic for `OpGetElement`.

### DIFF
--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -1186,6 +1186,9 @@ struct TypeFlowSpecializationContext
         case kIROp_FieldExtract:
             info = analyzeFieldExtract(context, as<IRFieldExtract>(inst));
             break;
+        case kIROp_GetElement:
+            info = analyzeGetElement(context, as<IRGetElement>(inst));
+            break;
         case kIROp_MakeOptionalNone:
             info = analyzeMakeOptionalNone(context, as<IRMakeOptionalNone>(inst));
             break;
@@ -1741,6 +1744,26 @@ struct TypeFlowSpecializationContext
                 return this->fieldInfo[structField];
             }
         }
+        return none();
+    }
+
+    IRInst* analyzeGetElement(IRInst* context, IRGetElement* getElement)
+    {
+        // If the base info is an array of some type, we can return that element type.
+        // as the info for the get-element inst.
+        //
+
+        IRBuilder builder(module);
+
+        auto baseInfo = tryGetInfo(context, getElement->getBase());
+        if (!baseInfo)
+            return none();
+
+        if (auto arrayInfo = as<IRArrayType>(baseInfo))
+        {
+            return arrayInfo->getElementType();
+        }
+
         return none();
     }
 

--- a/tests/language-feature/dynamic-dispatch/array-of-interfaces-1.slang
+++ b/tests/language-feature/dynamic-dispatch/array-of-interfaces-1.slang
@@ -1,0 +1,51 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type -Xslang -Wno-41020
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+//
+// Test struct fields with array of interface types, with a single implementation for the 
+// interface.
+// 
+
+public interface Term 
+{
+  float evaluate(float4 u);
+}
+
+public struct Sum 
+{
+  Term terms[16];
+  uint count;
+
+  public __init() 
+  { 
+    count = 0; 
+    for (uint i = 0; i < 16; i++) 
+      terms[i] = Multiply();
+  }
+
+  [mutating]
+  public void add(Term term, float weight) 
+  {
+    terms[count] = term;
+    count += 1;
+  }
+
+  public float evaluate(float4 u) { return terms[0].evaluate(u); }
+}
+
+public struct Multiply : Term 
+{
+  public float evaluate(float4 u) { return u.x * u.y; }
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 threadId: SV_DispatchThreadID) {
+
+  let pixel = uint2(threadId.x, threadId.y);
+  Sum terms;
+  terms.add(Multiply(), 1.0);
+  outputBuffer[0] = terms.evaluate(float4(0.5)); // CHECK: 0.25
+}

--- a/tests/language-feature/dynamic-dispatch/array-of-interfaces-2.slang
+++ b/tests/language-feature/dynamic-dispatch/array-of-interfaces-2.slang
@@ -1,0 +1,60 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type -Xslang -Wno-41020
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+//
+// Test struct fields with array of optional interface types.
+// 
+
+public interface Term 
+{
+    float evaluate(float4 u);
+}
+
+public struct Sum 
+{
+    Optional<Term> terms[16];
+    uint count;
+
+    public __init() 
+    { 
+        count = 0; 
+        for (uint i = 0; i < 16; i++) 
+            terms[i] = none;
+    }
+
+    [mutating]
+    public void add(Term term, float weight) 
+    {
+        terms[count] = term;
+        count += 1;
+    }
+
+    public float evaluate(float4 u) 
+    { 
+        if (let termOpt = terms[0])
+        {
+            return termOpt.evaluate(u); 
+        }
+        else
+        {
+            return 0.0;
+        }
+    }
+}
+
+public struct Multiply : Term 
+{
+  public float evaluate(float4 u) { return u.x * u.y; }
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 threadId: SV_DispatchThreadID) {
+
+  let pixel = uint2(threadId.x, threadId.y);
+  Sum terms;
+  terms.add(Multiply(), 1.0);
+  outputBuffer[0] = terms.evaluate(float4(0.5)); // CHECK: 0.25
+}

--- a/tests/language-feature/dynamic-dispatch/array-of-interfaces-3.slang
+++ b/tests/language-feature/dynamic-dispatch/array-of-interfaces-3.slang
@@ -1,0 +1,85 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type -Xslang -Wno-41020
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+//
+// Test struct fields with array of optional interface types, with multiple
+// implementations for the interface.
+// 
+
+public interface Term 
+{
+    float4 evaluate(float4 u);
+}
+
+public struct Sum 
+{
+    Optional<Term> terms[16];
+    uint count;
+
+    public __init() 
+    { 
+        count = 0; 
+        for (uint i = 0; i < 16; i++) 
+            terms[i] = none;
+    }
+
+    [mutating]
+    public void add(Term term) 
+    {
+        terms[count] = term;
+        count += 1;
+    }
+
+    public float4 evaluate(float4 u) 
+    { 
+        float4 val = 0.f;
+
+        for (uint i = 0; i < count; i++)
+        {
+            if (let termOpt = terms[i])
+                val += termOpt.evaluate(u);
+        }
+        
+        return val;
+    }
+}
+
+public struct Multiply : Term
+{
+    float factor;
+    public __init(float factor) { this.factor = factor; }
+    public float4 evaluate(float4 u) { return u * factor; }
+}
+
+public struct Pow : Term
+{
+    int exponent;
+    public __init(int exponent) { this.exponent = exponent; }
+    public float4 evaluate(float4 u) { return pow(u.x, exponent); }
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 threadId: SV_DispatchThreadID) 
+{
+    {
+        Sum terms;
+        terms.add(Multiply(3.f));
+        terms.add(Pow(2));
+        
+        // 0.5 * 3 + (0.5 ^ 2) = 1.5 + 0.25 = 1.75
+        outputBuffer[0] = terms.evaluate(float4(0.5)).x; // CHECK: 1.75
+    }
+
+    {
+        Sum terms;
+        terms.add(Multiply(4.f));
+        terms.add(Pow(3));
+        terms.add(Pow(4));
+
+        // 0.5 * 4 + (0.5 ^ 3) + (0.5 ^ 4) = 2.0 + 0.125 + 0.0625 = 2.1875
+        outputBuffer[1] = terms.evaluate(float4(0.5)).x; // CHECK: 2.1875
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/shader-slang/slang/issues/9747
- Adds an analysis method for `OpGetElement`. Previously, we were only handling `OpGetElementPtr`
- Adds three variants of tests for arrays of interfaces (and optional interfaces) in structs.