### PR TITLE
Enable link-time constant expressions in generic type parameters

### DIFF
--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -1692,7 +1692,7 @@ Val* FuncCallIntVal::tryFoldImpl(
         LOGICAL_OPERATOR_CASE(&&)
         LOGICAL_OPERATOR_CASE(||)
         // Special cases need their "operator" names quoted.
-        SPECIAL_OPERATOR_CASE("!", resultValue = ((constArgs[0]->getValue() != 0) ? 1 : 0);)
+        SPECIAL_OPERATOR_CASE("!", resultValue = ((constArgs[0]->getValue() == 0) ? 1 : 0);)
         SPECIAL_OPERATOR_CASE("~", resultValue = ~constArgs[0]->getValue();)
         SPECIAL_OPERATOR_CASE("?:",
                               resultValue = constArgs[0]->getValue() != 0

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2106,11 +2106,23 @@ IntVal* SemanticsVisitor::tryConstantFoldExpr(
         }
         else if (opName == getName("!"))
         {
-            resultValue = constArgVals[0] != 0;
+            resultValue = constArgVals[0] == 0;
         }
         else if (opName == getName("~"))
         {
             resultValue = ~constArgVals[0];
+        }
+        else if (opName == getName("&&"))
+        {
+            if (argCount != 2)
+                return nullptr;
+            resultValue = (constArgVals[0] != 0) && (constArgVals[1] != 0);
+        }
+        else if (opName == getName("||"))
+        {
+            if (argCount != 2)
+                return nullptr;
+            resultValue = (constArgVals[0] != 0) || (constArgVals[1] != 0);
         }
 
         // simple binary operators

--- a/source/slang/slang-ir-constexpr.cpp
+++ b/source/slang/slang-ir-constexpr.cpp
@@ -103,6 +103,7 @@ bool opCanBeConstExpr(IROp op)
     case kIROp_BitOr:
     case kIROp_BitXor:
     case kIROp_BitNot:
+    case kIROp_Not:
     case kIROp_Lsh:
     case kIROp_Rsh:
     case kIROp_Select:

--- a/tests/compute/conditional-link-time-const.slang
+++ b/tests/compute/conditional-link-time-const.slang
@@ -1,0 +1,79 @@
+// conditional-link-time-const.slang
+// Test that logical operators (!, &&, ||) work with link-time constants
+// in Conditional<> type parameters using extern const with default values.
+// This is similar to the unit test but without linking an override module.
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-slang -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-cpu -compute -shaderobj
+
+// Expected output with default values (HAS_FEATURE=false, ENABLE_EXTRA=false):
+// - notValue: !false = true, has value 5.0
+// - andValue: false && false = false, empty (0.0)
+// - orValue: false || !false = true, has value 20.0
+// Total: 5.0 + 0.0 + 20.0 = 25.0 = 0x19
+//CHK:19
+
+extern static const bool HAS_FEATURE = false;
+extern static const bool ENABLE_EXTRA = false;
+
+// Define a struct with Conditional fields that use link-time constants
+struct TestData<bool notFlag, bool andFlag, bool orFlag>
+{
+    Conditional<float, notFlag> notValue;
+    Conditional<float, andFlag> andValue;
+    Conditional<float, orFlag> orValue;
+
+    __init(float notVal, float andVal, float orVal)
+    {
+        notValue = notVal;
+        andValue = andVal;
+        orValue = orVal;
+    }
+
+    float sum()
+    {
+        float result = 0.0f;
+
+        if (let v = notValue.get())
+            result += v;
+
+        if (let v = andValue.get())
+            result += v;
+
+        if (let v = orValue.get())
+            result += v;
+
+        return result;
+    }
+}
+
+// Instantiate the struct with link-time constant expressions
+// With defaults (HAS_FEATURE=false, ENABLE_EXTRA=false):
+// - !HAS_FEATURE = !false = true
+// - HAS_FEATURE && ENABLE_EXTRA = false && false = false
+// - HAS_FEATURE || !ENABLE_EXTRA = false || true = true
+typealias TestInstance = TestData<
+    !HAS_FEATURE,
+    HAS_FEATURE && ENABLE_EXTRA,
+    HAS_FEATURE || !ENABLE_EXTRA
+>;
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+{
+    // Create an instance and initialize with test values
+    TestInstance testData = TestInstance(5.0f, 10.0f, 20.0f);
+
+    // Sum the values that are present based on link-time constants
+    // With defaults (HAS_FEATURE=false, ENABLE_EXTRA=false):
+    // - notValue: !false = true, field exists, contributes 5.0
+    // - andValue: false && false = false, field removed, contributes 0.0
+    // - orValue: false || true = true, field exists, contributes 20.0
+    // Expected: 5.0 + 0.0 + 20.0 = 25.0
+
+    outputBuffer[0] = int(testData.sum());
+}

--- a/tests/compute/logical-operators-constant-fold.slang
+++ b/tests/compute/logical-operators-constant-fold.slang
@@ -1,0 +1,59 @@
+// logical-operators-constant-fold.slang
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-slang -compute -shaderobj
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-vk -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHK):-cpu -compute -shaderobj
+
+// Test that logical operators (!, &&, ||) are correctly constant-folded.
+// This test verifies fixes for bugs where !false was folded to false (should be true)
+// and !true was folded to true (should be false), and ensures compound expressions
+// with && and || also work correctly.
+
+// Expected output: all tests pass (output = 1)
+//CHK:1
+
+// Test case 1: Direct constant folding with regular static const
+static const bool FALSE_VAL = false;
+static const bool TRUE_VAL = true;
+
+static const bool NOT_FALSE = !FALSE_VAL;  // Should be true
+static const bool NOT_TRUE = !TRUE_VAL;    // Should be false
+
+// Test case 2: Compound expressions with && and ||
+static const bool AND_TEST = TRUE_VAL && !FALSE_VAL;   // true && true = true
+static const bool OR_TEST = FALSE_VAL || !FALSE_VAL;   // false || true = true
+static const bool COMPLEX = !FALSE_VAL && !TRUE_VAL;   // true && false = false
+
+// Test case 3: Using logical operators in generic type arguments
+struct ValueHolder<bool condition>
+{
+    static const int value = condition ? 1 : 0;
+};
+
+// With regular static const
+typealias TestNotFalse = ValueHolder<!FALSE_VAL>;              // ValueHolder<true>
+typealias TestNotTrue = ValueHolder<!TRUE_VAL>;                // ValueHolder<false>
+typealias TestAnd = ValueHolder<TRUE_VAL && !FALSE_VAL>;       // ValueHolder<true>
+typealias TestOr = ValueHolder<FALSE_VAL || !FALSE_VAL>;       // ValueHolder<true>
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+{
+    // All conditions should be true if logical operators work correctly
+    bool allCorrect = true
+        // Regular static const tests
+        && (NOT_FALSE == true)                // !false should be true
+        && (NOT_TRUE == false)                // !true should be false
+        && (AND_TEST == true)                 // true && true should be true
+        && (OR_TEST == true)                  // false || true should be true
+        && (COMPLEX == false)                 // true && false should be false
+        && (TestNotFalse.value == 1)          // ValueHolder<true>.value should be 1
+        && (TestNotTrue.value == 0)           // ValueHolder<false>.value should be 0
+        && (TestAnd.value == 1)               // ValueHolder<true>.value should be 1
+        && (TestOr.value == 1)                // ValueHolder<true>.value should be 1
+        ;
+
+    outputBuffer[0] = allCorrect ? 1 : 0;
+}

--- a/tools/gfx-unit-test/link-time-logical-operators.cpp
+++ b/tools/gfx-unit-test/link-time-logical-operators.cpp
@@ -1,0 +1,147 @@
+// link-time-logical-operators.cpp
+// Test that logical operators work correctly with link-time constants
+// and that extern const values can be overridden properly.
+
+#include "core/slang-basic.h"
+#include "core/slang-blob.h"
+#include "gfx-test-util.h"
+#include "slang-rhi.h"
+#include "slang-rhi/shader-cursor.h"
+#include "unit-test/slang-unit-test.h"
+
+using namespace rhi;
+
+namespace gfx_test
+{
+static Slang::Result loadProgram(
+    rhi::IDevice* device,
+    Slang::ComPtr<rhi::IShaderProgram>& outShaderProgram,
+    const char* shaderModuleName,
+    const char* entryPointName,
+    slang::ProgramLayout*& slangReflection,
+    const char* additionalModuleSource)
+{
+    Slang::ComPtr<slang::ISession> slangSession;
+    SLANG_RETURN_ON_FAIL(device->getSlangSession(slangSession.writeRef()));
+    Slang::ComPtr<slang::IBlob> diagnosticsBlob;
+    slang::IModule* module = slangSession->loadModule(shaderModuleName, diagnosticsBlob.writeRef());
+    diagnoseIfNeeded(diagnosticsBlob);
+    if (!module)
+        return SLANG_FAIL;
+
+    auto additionalModuleBlob =
+        Slang::UnownedRawBlob::create(additionalModuleSource, strlen(additionalModuleSource));
+    slang::IModule* additionalModule =
+        slangSession->loadModuleFromSource("linkedConstants", "path", additionalModuleBlob);
+
+    ComPtr<slang::IEntryPoint> computeEntryPoint;
+    SLANG_RETURN_ON_FAIL(
+        module->findEntryPointByName(entryPointName, computeEntryPoint.writeRef()));
+
+    Slang::List<slang::IComponentType*> componentTypes;
+    componentTypes.add(module);
+    componentTypes.add(computeEntryPoint);
+    componentTypes.add(additionalModule);
+
+    Slang::ComPtr<slang::IComponentType> composedProgram;
+    SlangResult result = slangSession->createCompositeComponentType(
+        componentTypes.getBuffer(),
+        componentTypes.getCount(),
+        composedProgram.writeRef(),
+        diagnosticsBlob.writeRef());
+    diagnoseIfNeeded(diagnosticsBlob);
+    SLANG_RETURN_ON_FAIL(result);
+
+    ComPtr<slang::IComponentType> linkedProgram;
+    result = composedProgram->link(linkedProgram.writeRef(), diagnosticsBlob.writeRef());
+    diagnoseIfNeeded(diagnosticsBlob);
+    SLANG_RETURN_ON_FAIL(result);
+
+    composedProgram = linkedProgram;
+    slangReflection = composedProgram->getLayout();
+
+    ShaderProgramDesc programDesc = {};
+    programDesc.slangGlobalScope = composedProgram.get();
+
+    auto shaderProgram = device->createShaderProgram(programDesc);
+
+    outShaderProgram = shaderProgram;
+    return SLANG_OK;
+}
+
+void linkTimeLogicalOperatorsTestImpl(IDevice* device, UnitTestContext* context)
+{
+    ComPtr<IShaderProgram> shaderProgram;
+    slang::ProgramLayout* slangReflection;
+    GFX_CHECK_CALL_ABORT(loadProgram(
+        device,
+        shaderProgram,
+        "link-time-logical-operators",
+        "computeMain",
+        slangReflection,
+        R"(
+            export static const bool HAS_FEATURE = true;
+            export static const bool ENABLE_EXTRA = true;
+        )"));
+
+    ComputePipelineDesc pipelineDesc = {};
+    pipelineDesc.program = shaderProgram.get();
+    ComPtr<rhi::IComputePipeline> pipelineState;
+    GFX_CHECK_CALL_ABORT(device->createComputePipeline(pipelineDesc, pipelineState.writeRef()));
+
+    const int numberCount = 1;
+    float initialData[] = {0.0f};
+    BufferDesc bufferDesc = {};
+    bufferDesc.size = numberCount * sizeof(float);
+    bufferDesc.format = Format::Undefined;
+    bufferDesc.elementSize = sizeof(float);
+    bufferDesc.usage = BufferUsage::ShaderResource | BufferUsage::UnorderedAccess |
+                       BufferUsage::CopyDestination | BufferUsage::CopySource;
+    bufferDesc.defaultState = ResourceState::UnorderedAccess;
+    bufferDesc.memoryType = MemoryType::DeviceLocal;
+
+    ComPtr<IBuffer> outputBuffer;
+    GFX_CHECK_CALL_ABORT(
+        device->createBuffer(bufferDesc, (void*)initialData, outputBuffer.writeRef()));
+
+    // After linking with HAS_FEATURE=true and ENABLE_EXTRA=true:
+    // - notValue: Conditional<float, !true> = Conditional<float, false> (empty, contributes 0.0)
+    // - andValue: Conditional<float, true && true> = Conditional<float, true> (has value 10.0)
+    // - orValue: Conditional<float, true || false> = Conditional<float, true> (has value 20.0)
+    // The Conditional values are initialized in the shader code itself
+
+    // Execute the compute shader
+    {
+        auto queue = device->getQueue(QueueType::Graphics);
+        auto commandEncoder = queue->createCommandEncoder();
+        auto encoder = commandEncoder->beginComputePass();
+
+        auto rootObject = encoder->bindPipeline(pipelineState);
+
+        ShaderCursor rootCursor(rootObject);
+        rootCursor.getPath("Output").setBinding(Binding(outputBuffer));
+
+        encoder->dispatchCompute(1, 1, 1);
+        encoder->end();
+        queue->submit(commandEncoder->finish());
+        queue->waitOnHost();
+    }
+
+    // Expected result when HAS_FEATURE=true, ENABLE_EXTRA=true:
+    // Test 1: !true = false, notValue is empty, adds 0.0
+    // Test 2: true && true = true, andValue has value, adds 10.0
+    // Test 3: true || false = true, orValue has value, adds 20.0
+    // Total: 0.0 + 10.0 + 20.0 = 30.0
+    compareComputeResult(device, outputBuffer, std::array{30.0f});
+}
+
+SLANG_UNIT_TEST(linkTimeLogicalOperatorsD3D12)
+{
+    runTestImpl(linkTimeLogicalOperatorsTestImpl, unitTestContext, DeviceType::D3D12);
+}
+
+SLANG_UNIT_TEST(linkTimeLogicalOperatorsVulkan)
+{
+    runTestImpl(linkTimeLogicalOperatorsTestImpl, unitTestContext, DeviceType::Vulkan);
+}
+} // namespace gfx_test

--- a/tools/gfx-unit-test/link-time-logical-operators.slang
+++ b/tools/gfx-unit-test/link-time-logical-operators.slang
@@ -1,0 +1,63 @@
+// Test that logical operators (!, &&, ||) work with link-time constants
+// in Conditional<> type parameters, and that extern const values can be overridden.
+
+extern static const bool HAS_FEATURE = false;
+extern static const bool ENABLE_EXTRA = false;
+
+// Define a struct with Conditional fields that use link-time constants
+// Generic params are bool because Conditional expects bool, and !, &&, || return bool
+struct TestData<bool notFlag, bool andFlag, bool orFlag>
+{
+    Conditional<float, notFlag> notValue;
+    Conditional<float, andFlag> andValue;
+    Conditional<float, orFlag> orValue;
+
+    __init(float notVal, float andVal, float orVal)
+    {
+        notValue = notVal;
+        andValue = andVal;
+        orValue = orVal;
+    }
+
+    float sum()
+    {
+        float result = 0.0f;
+
+        if (let v = notValue.get())
+            result += v;
+
+        if (let v = andValue.get())
+            result += v;
+
+        if (let v = orValue.get())
+            result += v;
+
+        return result;
+    }
+}
+
+// Instantiate the struct with link-time constant expressions
+typealias TestInstance = TestData<
+    !HAS_FEATURE,                    // notValue: !false = true (default), !true = false (override)
+    HAS_FEATURE && ENABLE_EXTRA,     // andValue: false && false = false (default), true && true = true (override)
+    HAS_FEATURE || !ENABLE_EXTRA     // orValue: false || true = true (default), true || false = true (override)
+>;
+
+RWStructuredBuffer<float> Output;
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void computeMain()
+{
+    // Create an instance and initialize with test values
+    TestInstance testData = TestInstance(5.0f, 10.0f, 20.0f);
+
+    // Sum the values that are present based on link-time constants
+    // When HAS_FEATURE = true, ENABLE_EXTRA = true (overridden at link time):
+    // - notValue: !true = false, field is removed, contributes 0.0
+    // - andValue: true && true = true, field exists, contributes 10.0
+    // - orValue: true || false = true, field exists, contributes 20.0
+    // Expected: 0.0 + 10.0 + 20.0 = 30.0
+
+    Output[0] = testData.sum();
+}


### PR DESCRIPTION
Fixes the ability to use extern const values and logical expressions
(e.g., !flag) as generic type parameters like Conditional<T, !HAS_FEATURE>.

Previously failed with error 40012: "expected a compile-time constant".

Solution:
1. Add kIROp_Not to opCanBeConstExpr() in slang-ir-constexpr.cpp - this
   allows the constexpr propagation pass to recognize logical NOT as a
   valid constexpr operation. (Note: kIROp_And/kIROp_Or were already
   added in commit https://github.com/lujinwangnv/slang/commit/f022290af1239cbad78bbe20168c642198c47dde)

Also fixed two bugs in logical operator constant folding:
- NOT operator (!) had inverted logic (!false folded to false instead of true)
  in both slang-ast-val.cpp and slang-check-expr.cpp
- AND (&&) and OR (||) operators weren't being folded in the front-end

Added tests:
- tools/gfx-unit-test/link-time-logical-operators.*: Link-time override test
- tests/compute/logical-operators-constant-fold.slang: Operator folding test
- tests/compute/conditional-link-time-const.slang: Extern const with defaults