### PR TITLE
Revert "Add Linux ARM64 (aarch64) CI support with CPU-only tests"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,31 +94,6 @@ jobs:
       config: release
       runs-on: '["macos-latest"]'
 
-  # Linux ARM64 builds (GitHub-hosted)
-  build-linux-debug-gcc-aarch64:
-    needs: [filter]
-    if: needs.filter.outputs.should-run == 'true'
-    uses: ./.github/workflows/ci-slang-build.yml
-    with:
-      os: linux
-      compiler: gcc
-      platform: aarch64
-      config: debug
-      runs-on: '["ubuntu-24.04-arm"]'
-      warnings-as-errors: false
-
-  build-linux-release-gcc-aarch64:
-    needs: [filter]
-    if: needs.filter.outputs.should-run == 'true'
-    uses: ./.github/workflows/ci-slang-build.yml
-    with:
-      os: linux
-      compiler: gcc
-      platform: aarch64
-      config: release
-      runs-on: '["ubuntu-24.04-arm"]'
-      warnings-as-errors: false
-
   # Windows builds (self-hosted)
   build-windows-debug-cl-x86_64-gpu:
     needs: [filter]
@@ -188,33 +163,6 @@ jobs:
       full-gpu-tests: true
       server-count: 3
 
-  # Linux ARM64 tests (GitHub-hosted, CPU only)
-  test-linux-debug-gcc-aarch64:
-    needs: [filter, build-linux-debug-gcc-aarch64]
-    if: needs.filter.outputs.should-run == 'true'
-    uses: ./.github/workflows/ci-slang-test.yml
-    with:
-      os: linux
-      compiler: gcc
-      platform: aarch64
-      config: debug
-      runs-on: '["ubuntu-24.04-arm"]'
-      test-category: smoke
-      full-gpu-tests: false
-
-  test-linux-release-gcc-aarch64:
-    needs: [filter, build-linux-release-gcc-aarch64]
-    if: needs.filter.outputs.should-run == 'true'
-    uses: ./.github/workflows/ci-slang-test.yml
-    with:
-      os: linux
-      compiler: gcc
-      platform: aarch64
-      config: release
-      runs-on: '["ubuntu-24.04-arm"]'
-      test-category: smoke
-      full-gpu-tests: false
-
   # Windows GPU tests (self-hosted)
   test-windows-debug-cl-x86_64-gpu:
     needs: [filter, build-windows-debug-cl-x86_64-gpu]
@@ -242,7 +190,7 @@ jobs:
       test-category: full
       full-gpu-tests: true
 
-  # MaterialX Integration Tests (Windows only for initial validation)
+  # MaterialX Integration Tests (Windows only)
   test-materialx-windows-release:
     needs: [filter, build-windows-release-cl-x86_64-gpu]
     if: needs.filter.outputs.should-run == 'true' && github.event_name == 'pull_request'
@@ -263,8 +211,6 @@ jobs:
         test-macos-debug-clang-aarch64,
         test-linux-release-gcc-x86_64,
         test-linux-debug-gcc-x86_64,
-        test-linux-release-gcc-aarch64,
-        test-linux-debug-gcc-aarch64,
         test-materialx-windows-release,
       ]
     runs-on: ubuntu-latest
@@ -279,8 +225,6 @@ jobs:
           echo "macOS Debug ARM64: ${{ needs.test-macos-debug-clang-aarch64.result }}"
           echo "Linux Release x64: ${{ needs.test-linux-release-gcc-x86_64.result }}"
           echo "Linux Debug x64: ${{ needs.test-linux-debug-gcc-x86_64.result }}"
-          echo "Linux Release ARM64: ${{ needs.test-linux-release-gcc-aarch64.result }}"
-          echo "Linux Debug ARM64: ${{ needs.test-linux-debug-gcc-aarch64.result }}"
           echo "MaterialX Windows: ${{ needs.test-materialx-windows-release.result }}"
 
           # Check if any required jobs failed (allow success or skipped)
@@ -290,8 +234,6 @@ jobs:
              [[ "${{ needs.test-macos-debug-clang-aarch64.result }}" == "failure" ]] || \
              [[ "${{ needs.test-linux-release-gcc-x86_64.result }}" == "failure" ]] || \
              [[ "${{ needs.test-linux-debug-gcc-x86_64.result }}" == "failure" ]] || \
-             [[ "${{ needs.test-linux-release-gcc-aarch64.result }}" == "failure" ]] || \
-             [[ "${{ needs.test-linux-debug-gcc-aarch64.result }}" == "failure" ]] || \
              [[ "${{ needs.test-materialx-windows-release.result }}" == "failure" ]] || \
              [[ "${{ needs.test-windows-release-cl-x86_64-gpu.result }}" == "cancelled" ]] || \
              [[ "${{ needs.test-windows-debug-cl-x86_64-gpu.result }}" == "cancelled" ]] || \
@@ -299,8 +241,6 @@ jobs:
              [[ "${{ needs.test-macos-debug-clang-aarch64.result }}" == "cancelled" ]] || \
              [[ "${{ needs.test-linux-release-gcc-x86_64.result }}" == "cancelled" ]] || \
              [[ "${{ needs.test-linux-debug-gcc-x86_64.result }}" == "cancelled" ]] || \
-             [[ "${{ needs.test-linux-release-gcc-aarch64.result }}" == "cancelled" ]] || \
-             [[ "${{ needs.test-linux-debug-gcc-aarch64.result }}" == "cancelled" ]] || \
              [[ "${{ needs.test-materialx-windows-release.result }}" == "cancelled" ]]; then
             echo "One or more CI jobs failed or were cancelled"
             exit 1

--- a/source/compiler-core/slang-downstream-compiler.cpp
+++ b/source/compiler-core/slang-downstream-compiler.cpp
@@ -152,22 +152,13 @@ SlangResult CommandLineDownstreamCompiler::compile(
     }
 #endif
 
-    // Execute the compiler
-    // Note: Don't use SLANG_RETURN_ON_FAIL here because we want to parse diagnostics
-    // even if the compiler exits with non-zero code (e.g., link errors)
-    SlangResult executeResult = ProcessUtil::execute(cmdLine, exeRes);
+    SLANG_RETURN_ON_FAIL(ProcessUtil::execute(cmdLine, exeRes));
 
 #if 0
     {
         printf("stdout=\"%s\"\nstderr=\"%s\"\nret=%d\n", exeRes.standardOutput.getBuffer(), exeRes.standardError.getBuffer(), int(exeRes.resultCode));
     }
 #endif
-
-    // If execute completely failed (couldn't run the process), return failure
-    if (SLANG_FAILED(executeResult))
-    {
-        return executeResult;
-    }
 
     // Go through the list of artifacts in the artifactList and check if they exist.
     //

--- a/source/compiler-core/slang-gcc-compiler-util.cpp
+++ b/source/compiler-core/slang-gcc-compiler-util.cpp
@@ -325,50 +325,8 @@ static SlangResult _parseGCCFamilyLine(
     }
     else if (split.getCount() == 4)
     {
-        const auto split0 = split[0].trim();
-        const auto split1 = split[1].trim();
-        const auto split2 = split[2].trim();
-
-        // Check for GCC 13.x format: "gcc 13.3: filename: link error : message"
-        // or "gcc 13.3: : link error : message" (when filename is empty)
-        // Verify it's actually a link error by checking split[2] contains "link"
-        if ((split0.startsWith(UnownedStringSlice::fromLiteral("gcc")) ||
-             split0.startsWith(UnownedStringSlice::fromLiteral("g++"))) &&
-            split2.indexOf(UnownedStringSlice::fromLiteral("link")) != -1)
-        {
-            // "link error" is not a standard severity keyword
-            outDiagnostic.severity = Severity::Error;
-            outDiagnostic.stage = Diagnostic::Stage::Link;
-            // Use split1 as filename if not empty
-            if (split1.getLength() > 0)
-            {
-                outDiagnostic.filePath = allocator.allocate(split1);
-            }
-            outDiagnostic.text = allocator.allocate(split[3].trim());
-            outLineParseResult = LineParseResult::Single;
-            return SLANG_OK;
-        }
-
         // Probably a link error, give the source line
         String ext = Path::getPathExt(split[0]);
-
-        // Check if this is a link error based on message content
-        if (split[3].indexOf(UnownedStringSlice::fromLiteral("undefined reference")) != -1)
-        {
-            // This is a link error with format: filepath:line:section:message
-            Int lineNumber = 0;
-            if (SLANG_SUCCEEDED(StringUtil::parseInt(split1, lineNumber)))
-            {
-                outDiagnostic.filePath = allocator.allocate(split[0]);
-                outDiagnostic.location.line = lineNumber;
-                outDiagnostic.location.column = 0;
-                outDiagnostic.severity = Diagnostic::Severity::Error;
-                outDiagnostic.stage = Diagnostic::Stage::Link;
-                outDiagnostic.text = allocator.allocate(split[3]);
-                outLineParseResult = LineParseResult::Single;
-                return SLANG_OK;
-            }
-        }
 
         // Maybe a bit fragile -> but probably okay for now
         if (ext != "o" && ext != "obj")
@@ -391,27 +349,7 @@ static SlangResult _parseGCCFamilyLine(
     }
     else if (split.getCount() >= 5)
     {
-        Index undefinedIdx =
-            split[4].indexOf(UnownedStringSlice::fromLiteral("undefined reference"));
-        bool startsWithParen = split[3].trim().startsWith(UnownedStringSlice::fromLiteral("("));
-
-        // Check if this is a link error: file:line:section:message (where section is like
-        // "(.text+0x0)") vs regular error: file:line:column:severity:message
-        if (undefinedIdx != -1 || startsWithParen)
-        {
-            // Link error format: /usr/bin/ld:file:line:section:message
-            // split[0] is "/usr/bin/ld", split[1] is the file
-            outDiagnostic.filePath = allocator.allocate(split[1]);
-            StringUtil::parseInt(split[2], outDiagnostic.location.line);
-            outDiagnostic.location.column = 0;
-            outDiagnostic.severity = Diagnostic::Severity::Error;
-            outDiagnostic.stage = Diagnostic::Stage::Link;
-            outDiagnostic.text = allocator.allocate(split[4].begin(), split.getLast().end());
-            outLineParseResult = LineParseResult::Single;
-            return SLANG_OK;
-        }
-
-        // Regular error line: file:line:column:severity:message
+        // Probably a regular error line
         SLANG_RETURN_ON_FAIL(_parseSeverity(split[3].trim(), outDiagnostic.severity));
 
         outDiagnostic.filePath = allocator.allocate(split[0]);


### PR DESCRIPTION
Reverts shader-slang/slang#9725

To be remerged when we have a cached version of LLVM available