### PR TITLE
Minor createDynamicObject refactors

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -3156,11 +3156,90 @@ __generic<T, U>
 __intrinsic_op($(kIROp_BitCast))
 T bit_cast(U value);
 
-// Create Existential object
+/// Reinterpret `U` as a type that conforms to interface `T`. The precise
+/// underlying type is determined by `coherenceId`.
+///
+/// The compiler automatically assigns coherence IDs that can be retrieved by
+/// `ISession::getTypeConformanceWitnessSequentialID`. These automatic IDs can
+/// be overriden by `ISession::getTypeConformanceWitnessSequentialID`.
+///
+/// Note that the returned object can not be used in a context that requires
+/// monomorphization. That is, the object returned by `createDynamicObject` can
+/// only be used through the interface `T`. For example, the following will
+/// **not** work:
+/// ```
+/// float3 shadeMaterial<M: IMaterial>(M m, ShadingParameters p) {
+///     return m.shadeWith(p);
+/// }
+///
+/// float3 shadeObject(Object o) {
+///     IMaterial material = createDynamicObject<IMaterial, MaterialParameters>(o.material.id, o.material.params);
+///     // This fails: we can't monomorphize to a dynamic type!
+///     return shadeMaterial(material);
+/// }
+/// ```
+///
+/// @param T Interface to which the returned object will conform.
+/// @param U Type for the source data
+/// @param coherenceId Coherence ID used to determine the underlying type.
+/// @param value Data to be reinterpreted.
+///
+/// @example
+///
+/// ```csharp
+/// interface IDistribution {
+///     float samplePdf(float f);
+/// }
+///
+/// // ISession::getTypeConformanceWitnessSequentialID is 1
+/// struct Logistic : IDistribution {
+///     float mu;
+///     float s2; // 2 * s
+///
+///     float samplePdf(float f) {
+///         return 0.5 + 0.5 * tanh((f - mu) / s2);
+///     }
+/// }
+///
+/// // ISession::getTypeConformanceWitnessSequentialID is 2
+/// struct Gaussian : IDistribution {
+///     float mu;
+///     float sigma2; // 2 * sigma^2
+///     float norm;   // 1 / (sqrt(2 * pi * sigma * sigma))
+///
+///     float samplePdf(float f) {
+///         float d = (f - mu);
+///         d *= d;
+///         return norm * exp(d / sigma2);
+///     }
+/// }
+///
+/// struct DistributionParameters {
+///     int kind;
+///     float4 data;
+/// }
+///
+/// float sampleDistribution(DistributionParameters d, float f) {
+///     IDistribution d = createDynamicObject<IDistribution, float4>(d.kind, d.data);
+///     return d.samplePdf(f);
+/// }
+/// ```
+///
+/// If we then provide a buffer like:
+/// ```
+/// distributions = [
+///     DistributionParameters(1, {0.0, 2.0, NaN, NaN}),
+///     DistributionParameters(2, {0.0, 2.0, 0.56418958 NaN}),
+/// ]
+/// ```
+///
+/// Anything using `distributions[0]` will use a logistic distribution with
+/// mean 0 and scale 1, while `distributions[1]` will be a Gaussian
+/// distribution with mean 0 and standard deviation of 1.
 __generic<T, U>
 [__unsafeForceInlineEarly]
 __intrinsic_op($(kIROp_CreateExistentialObject))
-T createDynamicObject(uint typeId, U value);
+T createDynamicObject(uint coherenceId, U value);
 
 /// Reinterpret type `U` as type `T`. `T` and `U`
 /// can be any scalar, vector, matrix, struct or array types.

--- a/source/slang/slang-ir-check-specialize-generic-with-existential.h
+++ b/source/slang/slang-ir-check-specialize-generic-with-existential.h
@@ -6,8 +6,8 @@ namespace Slang
 class DiagnosticSink;
 struct IRModule;
 
-/// This IR check pass is will diagnose error when a generic is specialized with
-// an existential type.
-void addDecorationsForGenericsSpecializedWithExistentials(IRModule* module, DiagnosticSink* sink);
+/// This IR check pass is will add an annotation on `IRSpecialize` instructions when a generic is
+/// specialized with an existential type.
+void addDecorationsForGenericsSpecializedWithExistentials(IRModule* module);
 
 } // namespace Slang

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -13215,8 +13215,10 @@ RefPtr<IRModule> generateIRForTranslationUnit(
         if (translationUnit->getModuleDecl()->languageVersion >=
             SlangLanguageVersion::SLANG_LANGUAGE_VERSION_2025)
         {
-            // We do not allow specializing a generic function with an existential type.
-            addDecorationsForGenericsSpecializedWithExistentials(module, compileRequest->getSink());
+            // We do not allow specializing a generic function with an existential type, in most contexts.
+            //
+            // This is done by adding a decoration because only the typeflow-specialize pass actually knows whether a marked specialization is legal.
+            addDecorationsForGenericsSpecializedWithExistentials(module);
         }
     }
 

--- a/tests/language-feature/dynamic-dispatch/interface-extension-diagnose.slang
+++ b/tests/language-feature/dynamic-dispatch/interface-extension-diagnose.slang
@@ -33,6 +33,10 @@ extension<T : IInterface> T
     }
 }
 
+// TEST_INPUT: type_conformance A:IInterface = 0
+// TEST_INPUT: type_conformance B:IInterface = 1
+// TEST_INPUT: type_conformance C:IInterface = 2
+
 IInterface factoryAB(uint id, float x)
 {
     if (id == 0)
@@ -53,9 +57,37 @@ float f(uint id, float x)
     return calcTwice(obj, x);
 }
 
+float dynamicF(uint id, float x)
+{
+    IInterface obj = createDynamicObject<IInterface, float>(id, x);
+    // CHECK: ([[# @LINE+1]]): error 33180
+    return obj.calcTwice(x);
+}
+
+float dceCalcTwice(IInterface obj, float x)
+{
+    if (false) {
+        // This check doesn't work right now because the actual errors are
+        // emitted during specialization, which happens after DCE.
+        // todo-check
+        // ([[# @LINE+1]]): error 33180
+        return obj.calcTwice(x);
+    } else {
+        return 0;
+    }
+}
+
+float dceF(uint id, float x)
+{
+    IInterface obj = factoryAB(id, x);
+    return dceCalcTwice(obj, x);
+}
+
 [numthreads(1, 1, 1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     outputBuffer[0] = f(0, 3);
     outputBuffer[1] = f(1, 3); 
+    outputBuffer[2] = dynamicF(int(outputBuffer[0]), 3);
+    outputBuffer[3] = dceF(1, 3);
 }


### PR DESCRIPTION
This is the outcome of my investigation for #8635. I tried a couple of approaches, but ran in to the following issues:
- There isn't a clear infrastructure for propagating state bits along the IR dataflow graph, so it's hard to track where `createDynamicObject` values end up.
- Existential types in general don't really have formal semantics yet.
- We don't know that specialization is needed until IR codegen, and even then it's sometimes allowed for existentials anyway (the `language-feature/generics/specialize-with-existential-*` cases). This makes adding errors when the specialization happens on a dead-code branch basically impossible because DCE happens before specialization.

This PR contains the subset of my changes that I'm relatively confident are harmless.

CC @csyonghe  @tangent-vector  and @saipraveenb25.