### PR TITLE
Add diagnostic when accessing Optional<T>::value of `none`

### DIFF
--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -4158,6 +4158,13 @@ err(
     span { loc = "location", message = "cannot default-initialize struct '~structName' with '{}' because it contains resource fields" }
 )
 
+err(
+    "accessing-value-of-none-optional",
+    41027,
+    "accessing .value on an Optional that is always none",
+    span { loc = "location", message = "accessing .value on an Optional<~type:IRInst> that is always 'none'" }
+)
+
 
 -- Load semantic checking diagnostics (part 13) - AnyValue, Autodiff, Static assertions, Atomics, etc.
 -- (inlined from slang-diagnostics-semantic-checking-13.lua)

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -27,6 +27,7 @@
 #include "slang-ir-autodiff.h"
 #include "slang-ir-bind-existentials.h"
 #include "slang-ir-byte-address-legalize.h"
+#include "slang-ir-check-optional-none-usage.h"
 #include "slang-ir-check-recursion.h"
 #include "slang-ir-check-shader-parameter-type.h"
 #include "slang-ir-check-unsupported-inst.h"
@@ -1068,6 +1069,13 @@ Result linkAndOptimizeIR(
 
     if (requiredLoweringPassSet.optionalType)
         SLANG_PASS(lowerReinterpretOptional, targetProgram, sink);
+
+    // Check for accessing .value on an Optional that is always none.
+    // This must run after simplifyIR (which eliminates dead branches that
+    // might access a none value) but before lowerOptionalType (which removes
+    // IRMakeOptionalNone instructions).
+    if (targetProgram->getOptionSet().shouldRunNonEssentialValidation())
+        SLANG_PASS(checkForOptionalNoneUsage, sink);
 
     if (requiredLoweringPassSet.optionalType)
         SLANG_PASS(lowerOptionalType, sink);

--- a/source/slang/slang-ir-check-optional-none-usage.cpp
+++ b/source/slang/slang-ir-check-optional-none-usage.cpp
@@ -1,0 +1,52 @@
+// slang-ir-check-optional-none-usage.cpp
+#include "slang-ir-check-optional-none-usage.h"
+
+#include "slang-ir-util.h"
+#include "slang-ir.h"
+#include "slang-rich-diagnostics.h"
+
+namespace Slang
+{
+
+static void checkForOptionalNoneUsage(IRFunc* func, DiagnosticSink* sink)
+{
+    for (auto block : func->getBlocks())
+    {
+        for (auto inst : block->getChildren())
+        {
+            if (inst->getOp() == kIROp_GetOptionalValue &&
+                inst->getOperand(0)->getOp() == kIROp_MakeOptionalNone)
+            {
+                sink->diagnose(Diagnostics::AccessingValueOfNoneOptional{
+                    .type = inst->getDataType(),
+                    .location = inst->sourceLoc,
+                });
+            }
+        }
+    }
+}
+
+void checkForOptionalNoneUsage(IRModule* module, DiagnosticSink* sink)
+{
+    for (auto globalInst : module->getGlobalInsts())
+    {
+        switch (globalInst->getOp())
+        {
+        case kIROp_Func:
+            checkForOptionalNoneUsage(as<IRFunc>(globalInst), sink);
+            break;
+        case kIROp_Generic:
+            {
+                auto generic = as<IRGeneric>(globalInst);
+                auto innerFunc = as<IRFunc>(findGenericReturnVal(generic));
+                if (innerFunc)
+                    checkForOptionalNoneUsage(innerFunc, sink);
+                break;
+            }
+        default:
+            break;
+        }
+    }
+}
+
+} // namespace Slang

--- a/source/slang/slang-ir-check-optional-none-usage.h
+++ b/source/slang/slang-ir-check-optional-none-usage.h
@@ -1,0 +1,10 @@
+// slang-ir-check-optional-none-usage.h
+#pragma once
+
+namespace Slang
+{
+class DiagnosticSink;
+struct IRModule;
+
+void checkForOptionalNoneUsage(IRModule* module, DiagnosticSink* sink);
+} // namespace Slang

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -5432,9 +5432,9 @@ static TypeLayoutResult _createTypeLayout(TypeLayoutContext& context, Type* type
 
         // Handle conditionally-sized vectors (e.g., 0-length vectors or non-constant sizes)
         auto elementCountVal = context.tryResolveLinkTimeVal(vecType->getElementCount());
-        if (!as<ConstantIntVal>(elementCountVal))
+        if (!as<ConstantIntVal>(elementCountVal) || getIntVal(elementCountVal) == 0)
         {
-            // If the vector size is not a compile-time constant, fall back to default layout
+            // Fall back to default layout
             auto element = _createTypeLayout(context, elementType);
             RefPtr<TypeLayout> typeLayout = new TypeLayout();
             typeLayout->type = type;
@@ -6153,7 +6153,7 @@ RefPtr<TypeLayout> getSimpleVaryingParameterTypeLayout(
 
         // Handle conditionally-sized vectors (e.g., 0-length vectors or non-constant sizes)
         auto elementCountVal = context.tryResolveLinkTimeVal(vecType->getElementCount());
-        if (!as<ConstantIntVal>(elementCountVal))
+        if (!as<ConstantIntVal>(elementCountVal) || getIntVal(elementCountVal) == 0)
         {
             // If the vector size is not a compile-time constant, we cannot
             // compute a fixed layout for it. Treat it as having zero size.

--- a/tests/bugs/gh-9440.slang
+++ b/tests/bugs/gh-9440.slang
@@ -13,13 +13,13 @@ void func1(Optional<Optional<int>> a)
     unused(b);
 }
 
-// FUNC2: OpConstantComposite %_slang_Optional__slang_Optional_int %{{.+}} %false
+// FUNC2: OpConstantComposite %_slang_Optional__slang_Optional_int %{{.+}} %true
 // FUNC2: %func2 = OpFunction
 // FUNC2: OpCompositeExtract %_slang_Optional_int %{{.+}} 0
 [shader("vertex")]
 void func2()
 {
-    Optional<Optional<int>> a = Optional<Optional<int>>();
+    Optional<Optional<int>> a = Optional<Optional<int>>(0);
     unused(a);
     Optional<int> b = a.value;
     unused(b);
@@ -30,7 +30,7 @@ void func2()
 [shader("vertex")]
 void func3()
 {
-    int a = Optional<Optional<int>>().value.value;
+    int a = Optional<Optional<int>>(0).value.value;
     unused(a);
 }
 
@@ -39,7 +39,7 @@ void func3()
 [shader("vertex")]
 void func4()
 {
-    Optional<Optional<int>> a = Optional<Optional<int>>();
+    Optional<Optional<int>> a = Optional<Optional<int>>(0);
     Optional<int> b = a.value;
     int c = b.value;
     unused(c);

--- a/tests/diagnostics/optional-value-on-none.slang
+++ b/tests/diagnostics/optional-value-on-none.slang
@@ -1,0 +1,71 @@
+// Test that accessing .value on both Optional and Conditional that are always 'none' produces errors
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK_OPT): -target spirv -DTEST_OPT
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK_COND): -target spirv -DTEST_COND
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK_CONDTEX): -target spirv -DTEST_CONDTEX
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK_IFLET): -target spirv -DTEST_IFLET
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK_VALUE): -target spirv -DTEST_VALUE
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK_NESTED): -target spirv -DTEST_NESTED
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK_INLINE): -target spirv -DTEST_INLINE
+
+#if defined(TEST_CONDTEX) || defined(TEST_IFLET)
+uniform Conditional<Texture2D, false> Tex;
+#endif
+
+#ifdef TEST_INLINE
+float4 alwaysNone()
+{
+    Optional<float4> o = none;
+    return o.value;
+}
+#endif
+
+[shader("fragment")]
+float4 main() : SV_Target
+{
+#ifdef TEST_OPT
+    Optional<float4> opt = none;
+    // CHECK_OPT: error[E41027]
+    // CHECK_OPT-NEXT: --> {{.*}}:[[# @LINE+1]]:
+    return opt.value;
+#endif
+
+#ifdef TEST_COND
+    Conditional<float4, false> cond;
+    // CHECK_COND: error[E41027]
+    // CHECK_COND-NEXT: --> {{.*}}:[[# @LINE+1]]:
+    return cond.get().value;
+#endif
+
+#ifdef TEST_CONDTEX
+    // CHECK_CONDTEX: error[E41027]
+    // CHECK_CONDTEX-NEXT: --> {{.*}}:[[# @LINE+1]]:
+    return Tex.get().value.Load(int3(0));
+#endif
+
+#ifdef TEST_IFLET
+    // CHECK_IFLET-NOT: error[E41027]
+    if (let t = Tex.get())
+    {
+        return t.Load(int3(0));
+    }
+    return float4(0.0f, 0.0f, 0.0f, 1.0f);
+#endif
+
+#ifdef TEST_VALUE
+    Optional<float4> opt = float4(1.0);
+    // CHECK_VALUE-NOT: error[E41027]
+    return opt.value;
+#endif
+
+#ifdef TEST_NESTED
+    Optional<Optional<int>> opt = none;
+    // CHECK_NESTED: error[E41027]
+    // CHECK_NESTED-NEXT: --> {{.*}}:[[# @LINE+1]]:
+    return opt.value.value;
+#endif
+
+#ifdef TEST_INLINE
+    // CHECK_INLINE: error[E41027]
+    return alwaysNone();
+#endif
+}


### PR DESCRIPTION
* Add a new diagnostic error when accessing an Optional<T> with a `value` of `none`
* Fix internal compiler error in type layout computation for 0-length vectors, now generated by the vector based implementation of Conditional<T, false>
* Add diagnostic test case covering Optional<> and Conditional<>

Fixes #9813