### PR TITLE
Fix data race in expected failure list copying across test threads

### DIFF
--- a/tools/slang-test/test-reporter.cpp
+++ b/tools/slang-test/test-reporter.cpp
@@ -102,7 +102,17 @@ Result TestReporter::init(
 {
     m_outputMode = outputMode;
     m_isSubReporter = isSubReporter;
-    m_expectedFailureList = expectedFailureList;
+
+    // Deep copy the expected failure list to avoid sharing ref-counted
+    // StringRepresentation objects across threads (RefObject::referenceCount
+    // is not atomic, so concurrent addReference/releaseReference from
+    // multiple threads causes data races and heap corruption).
+    m_expectedFailureList.clear();
+    for (const auto& s : expectedFailureList)
+    {
+        m_expectedFailureList.add(String(s.getUnownedSlice()));
+    }
+
     return SLANG_OK;
 }
 


### PR DESCRIPTION
Fixes https://github.com/shader-slang/slang/issues/9787

The root-cause is that the implementation of `Slang::String` is not thread-safe.
In other words, `RefObject::addReference()` is not using an atomic increment.
And when multiple threads finish their job, there is a race condition on the destruction of the String-s.

This PR makes a deep copy of the String-s so that it works more reliably when the threads exit.