### PR TITLE
Treat logical AND and OR as constant-fold-able

### DIFF
--- a/source/slang/slang-ir-constexpr.cpp
+++ b/source/slang/slang-ir-constexpr.cpp
@@ -97,6 +97,8 @@ bool opCanBeConstExpr(IROp op)
     case kIROp_Less:
     case kIROp_Neq:
     case kIROp_Eql:
+    case kIROp_And:
+    case kIROp_Or:
     case kIROp_BitAnd:
     case kIROp_BitOr:
     case kIROp_BitXor:

--- a/source/slang/slang-ir-sccp.cpp
+++ b/source/slang/slang-ir-sccp.cpp
@@ -126,6 +126,8 @@ struct SCCPContext
         case kIROp_Leq:
         case kIROp_Geq:
         case kIROp_Less:
+        case kIROp_And:
+        case kIROp_Or:
         case kIROp_IRem:
         case kIROp_FRem:
         case kIROp_Greater:

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -89,6 +89,8 @@ struct SpecializationContext
         case kIROp_Leq:
         case kIROp_Geq:
         case kIROp_Less:
+        case kIROp_And:
+        case kIROp_Or:
         case kIROp_IRem:
         case kIROp_FRem:
         case kIROp_Greater:

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -2790,6 +2790,8 @@ bool canOperationBeSpecConst(IROp op, IRType* resultType, IRInst* const* fixedAr
     case kIROp_Geq:
     case kIROp_Less:
     case kIROp_Greater:
+    case kIROp_And:
+    case kIROp_Or:
         {
             IRInst* operand1;
             IRInst* operand2;

--- a/tests/language-feature/generics/logical-and-constant-folding.slang
+++ b/tests/language-feature/generics/logical-and-constant-folding.slang
@@ -1,0 +1,31 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHK): -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[1.0 2.0 3.0 4.0], stride=4):name=gInput
+RWStructuredBuffer<float> gInput;
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=gOutput
+RWStructuredBuffer<float> gOutput;
+
+//CHK:1
+//CHK-NEXT:2
+//CHK-NEXT:3
+//CHK-NEXT:4
+
+struct AppInput<bool COND0, int COND1>
+{
+    float3 position;
+    Conditional<float4, COND0 && (0 < COND1)> attr;
+};
+
+[Shader("compute")]
+[NumThreads(4, 1, 1)]
+void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+{
+    uint tid = dispatchThreadID.x;
+
+    AppInput<true, 1> t1;
+    t1.attr.set(gInput[tid]);
+
+    if (let value = t1.attr.get())
+        gOutput[tid] = value.x;
+}


### PR DESCRIPTION
The logical AND and logical OR should be treated as an IR that can be constant-fold-able.