### PR TITLE
Use CUDA 13 in all Linux CI workflows

### DIFF
--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     timeout-minutes: 120
     container:
-      image: ghcr.io/shader-slang/slang-linux-gpu-ci:12.5.1
+      image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.3.0
       options: --user root
 
     defaults:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -75,29 +75,29 @@ jobs:
           sudo ln -sf /tmp/cmake-3.30.0-linux-x86_64/bin/cpack /usr/local/bin/cpack
           rm -f cmake-3.30.0-linux-x86_64.tar.gz
 
-          # Install CUDA Toolkit 12.5.1 (matching container image)
-          wget -q https://developer.download.nvidia.com/compute/cuda/12.5.1/local_installers/cuda_12.5.1_555.42.06_linux.run
-          sudo sh cuda_12.5.1_555.42.06_linux.run --silent --toolkit --no-opengl-libs --no-drm --no-man-page || echo "CUDA install returned error but may have partially succeeded"
+          # Install CUDA Toolkit 13.0.0 (matching container image)
+          wget -q https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda_13.0.0_580.65.06_linux.run
+          sudo sh cuda_13.0.0_580.65.06_linux.run --silent --toolkit --no-opengl-libs --no-drm --no-man-page || echo "CUDA install returned error but may have partially succeeded"
           # Remove installer (4GB file) to prevent it from being committed
-          rm -f cuda_12.5.1_555.42.06_linux.run
+          rm -f cuda_13.0.0_580.65.06_linux.run
 
           # Verify and configure CUDA paths
-          if [ -d /usr/local/cuda-12.5 ]; then
+          if [ -d /usr/local/cuda-13.0 ]; then
             echo "CUDA installed successfully"
             # Fix permissions - installer creates files with restrictive permissions
-            sudo chmod -R a+rX /usr/local/cuda-12.5
-            ls -la /usr/local/cuda-12.5/bin/nvcc
-            echo "/usr/local/cuda-12.5/bin" >> $GITHUB_PATH
-            echo "LD_LIBRARY_PATH=/usr/local/cuda-12.5/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" >> $GITHUB_ENV
+            sudo chmod -R a+rX /usr/local/cuda-13.0
+            ls -la /usr/local/cuda-13.0/bin/nvcc
+            echo "/usr/local/cuda-13.0/bin" >> $GITHUB_PATH
+            echo "LD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" >> $GITHUB_ENV
           else
-            echo "WARNING: CUDA not installed at /usr/local/cuda-12.5"
+            echo "WARNING: CUDA not installed at /usr/local/cuda-13.0"
             ls -la /usr/local/ | grep cuda || echo "No CUDA directories found"
           fi
 
       - name: Verify GPU access
         run: |
-          export PATH=/usr/local/cuda-12.5/bin:$PATH
-          export LD_LIBRARY_PATH=/usr/local/cuda-12.5/lib64:$LD_LIBRARY_PATH
+          export PATH=/usr/local/cuda-13.0/bin:$PATH
+          export LD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64:$LD_LIBRARY_PATH
 
           echo "=== GPU Information ==="
           nvidia-smi
@@ -152,8 +152,8 @@ jobs:
 
       - name: Configure CMake
         run: |
-          export PATH=/usr/local/cuda-12.5/bin:$PATH
-          export LD_LIBRARY_PATH=/usr/local/cuda-12.5/lib64:$LD_LIBRARY_PATH
+          export PATH=/usr/local/cuda-13.0/bin:$PATH
+          export LD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64:$LD_LIBRARY_PATH
 
           cmake --preset default --fresh \
             -DSLANG_ENABLE_CUDA=ON \
@@ -161,7 +161,7 @@ jobs:
 
       - name: Build Slang
         run: |
-          export PATH=/usr/local/cuda-12.5/bin:$PATH
-          export LD_LIBRARY_PATH=/usr/local/cuda-12.5/lib64:$LD_LIBRARY_PATH
+          export PATH=/usr/local/cuda-13.0/bin:$PATH
+          export LD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64:$LD_LIBRARY_PATH
 
           cmake --build --preset debug -j$(nproc)

--- a/.github/workflows/test-arc-runner.yml
+++ b/.github/workflows/test-arc-runner.yml
@@ -14,7 +14,7 @@ jobs:
         run: docker --version
 
       - name: Test CUDA container with GPU
-        run: docker run --rm --gpus all nvidia/cuda:12.5.1-base-ubuntu22.04 nvidia-smi
+        run: docker run --rm --gpus all nvidia/cuda:13.0.0-base-ubuntu22.04 nvidia-smi
 
       - name: Check Vulkan ICD configuration
         run: |

--- a/docker/linux-gpu-ci.Dockerfile
+++ b/docker/linux-gpu-ci.Dockerfile
@@ -93,5 +93,5 @@ RUN echo "=== Installed Tools ===" && \
 
 # Set labels for identification
 LABEL org.opencontainers.image.source=https://github.com/shader-slang/slang
-LABEL org.opencontainers.image.description="Slang Linux GPU CI container with CUDA 12.5.1"
+LABEL org.opencontainers.image.description="Slang Linux GPU CI container with CUDA 13.0.1"
 LABEL org.opencontainers.image.licenses=MIT


### PR DESCRIPTION
Copilot setup and builds should all use same image label for consistency.