### PR TITLE
[neural slang] Add MLP performance benchmark

### DIFF
--- a/tests/integration/slangpy/neural/benchmarks/README.md
+++ b/tests/integration/slangpy/neural/benchmarks/README.md
@@ -1,0 +1,118 @@
+# Neural MLP Performance Benchmark
+
+Compares identical 2-layer MLP network architecture across three GPU implementations:
+
+| Backend      | Description                                                         |
+| ------------ | ------------------------------------------------------------------- |
+| **For-loop** | Scalar GPU loops (original SlangPy LinearLayer style)               |
+| **CoopVec**  | `coopVecMatMulAdd` intrinsics (original SlangPy CoopVecLinearLayer) |
+| **CoopMat**  | WaveTangledVector + FFLayer (current neural.slang module)           |
+
+## Purpose
+
+This benchmark tracks performance and guides future CoopMat optimizations by comparing against the original implementations.
+
+## Usage
+
+### Forward Pass (GPU Timing - Recommended)
+
+```bash
+# Run all implementations with GPU timestamps
+python benchmark_all_gpu_timing.py --device cuda --sweep
+
+# Vulkan backend
+python benchmark_all_gpu_timing.py --device vulkan --sweep
+
+# Specific implementation
+python benchmark_all_gpu_timing.py --device cuda --sweep --impl coopmat
+```
+
+### Backward Pass (Training)
+
+```bash
+# Run backward pass benchmark
+python benchmark_backward_gpu_timing.py --device cuda --sweep
+
+# Specific network size
+python benchmark_backward_gpu_timing.py --device cuda --size small
+```
+
+### CPU Timing (Original)
+
+```bash
+# Basic benchmark (small network, Vulkan)
+python benchmark_neural_mlp.py
+
+# Specific network size
+python benchmark_neural_mlp.py --size medium
+
+# Sweep all network sizes
+python benchmark_neural_mlp.py --sweep
+
+# JSON output for CI integration
+python benchmark_neural_mlp.py --json
+
+# Different device
+python benchmark_neural_mlp.py --device cuda
+```
+
+## Timing Methods
+
+| Method             | Script                        | Measures                     | Fair Comparison |
+| ------------------ | ----------------------------- | ---------------------------- | --------------- |
+| **GPU Timestamps** | `benchmark_all_gpu_timing.py` | Pure GPU kernel time         | ✅ Yes          |
+| CPU Timer          | `benchmark_neural_mlp.py`     | GPU + driver + sync overhead | ❌ No           |
+
+**Use GPU timing** for accurate performance comparison. CPU timing can inflate results by 3-5x due to Python/driver overhead.
+
+## Options
+
+| Option           | Default | Description                                |
+| ---------------- | ------- | ------------------------------------------ |
+| `--iterations N` | 100     | Number of measured iterations              |
+| `--warmup N`     | 10      | Number of warmup iterations                |
+| `--batch-size N` | 256     | Batch size for forward pass                |
+| `--device TYPE`  | vulkan  | Device type: vulkan, d3d12, cuda           |
+| `--size SIZE`    | small   | Network size: small, medium, large, xlarge |
+| `--sweep`        | -       | Run benchmark across all network sizes     |
+| `--json`         | -       | Output results in JSON format              |
+| `--forloop-only` | -       | Run only for-loop benchmark                |
+| `--coopvec-only` | -       | Run only CoopVec benchmark                 |
+| `--coopmat-only` | -       | Run only CoopMat benchmark                 |
+
+## Network Sizes
+
+| Size   | Architecture    | Parameters |
+| ------ | --------------- | ---------- |
+| small  | 64 → 64 → 16    | 5,200      |
+| medium | 128 → 128 → 32  | 20,640     |
+| large  | 256 → 256 → 64  | 82,240     |
+| xlarge | 512 → 512 → 128 | 328,320    |
+
+## Requirements
+
+- slangpy (`pip install slangpy`)
+- numpy
+- GPU with Vulkan (or CUDA/D3D12) support
+- For CoopVec: Cooperative vector extension support
+- For CoopMat: Cooperative matrix extension support
+
+## Files
+
+### Forward Pass
+
+| File                                      | Description                                            |
+| ----------------------------------------- | ------------------------------------------------------ |
+| `benchmark_all_gpu_timing.py`             | **GPU timing benchmark (recommended)**                 |
+| `benchmark_neural_mlp.py`                 | CPU timing benchmark (original)                        |
+| `benchmark_neural_mlp_forloop.slang`      | Scalar for-loop implementation (fp32)                  |
+| `benchmark_neural_mlp_coopvec.slang`      | CoopVec implementation (fp16)                          |
+| `benchmark_neural_mlp_coopmat.slang`      | CoopMat implementation (fp32)                          |
+| `benchmark_neural_mlp_coopmat_fp16.slang` | **CoopMat implementation (fp16, for fair comparison)** |
+
+### Backward Pass (Training)
+
+| File                                               | Description                              |
+| -------------------------------------------------- | ---------------------------------------- |
+| `benchmark_backward_gpu_timing.py`                 | **Backward pass benchmark (GPU timing)** |
+| `benchmark_neural_mlp_coopmat_backward_fp16.slang` | CoopMat backward using autodiff (fp16)   |

--- a/tests/integration/slangpy/neural/benchmarks/benchmark_backward_gpu_timing.py
+++ b/tests/integration/slangpy/neural/benchmarks/benchmark_backward_gpu_timing.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+MLP Backward Pass Benchmark - GPU Timestamps
+
+Fair comparison of backward pass (training) performance:
+- CoopMat (neural.slang) backward pass
+- Tin2 backward pass (run separately via CUDA)
+
+Same conditions as forward pass:
+- 256 CTAs, 32 threads each
+- fp16 data type
+- GPU timestamps
+"""
+
+import argparse
+import numpy as np
+from pathlib import Path
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    import slangpy as spy
+    from slangpy.core.calldata import SLANG_PATH
+except ImportError:
+    print("Error: slangpy not found. Please install slangpy first.")
+    exit(1)
+
+# Network configurations (same as forward)
+NETWORK_CONFIGS = {
+    "small": {"input": 64, "hidden": 64, "output": 16},
+    "medium": {"input": 128, "hidden": 128, "output": 32},
+    "large": {"input": 256, "hidden": 256, "output": 64},
+    "xlarge": {"input": 512, "hidden": 512, "output": 128},
+}
+
+BATCH_SIZE = 256
+WARMUP_ITERATIONS = 50
+BENCHMARK_ITERATIONS = 200
+
+
+@dataclass
+class BenchmarkResult:
+    """Results from a benchmark run."""
+    name: str
+    backend: str
+    network: str
+    time_ms: float
+    throughput: float
+    success: bool
+    error: Optional[str] = None
+
+
+def get_network_config(size_name: str) -> dict:
+    """Get network configuration for a given size."""
+    config = NETWORK_CONFIGS[size_name]
+    input_size = config["input"]
+    hidden_size = config["hidden"]
+    output_size = config["output"]
+    
+    layer1_weights = input_size * hidden_size
+    layer1_biases = hidden_size
+    layer2_weights = hidden_size * output_size
+    layer2_biases = output_size
+    total_params = layer1_weights + layer1_biases + layer2_weights + layer2_biases
+    
+    return {
+        "input_size": input_size,
+        "hidden_size": hidden_size,
+        "output_size": output_size,
+        "layer1_weights": layer1_weights,
+        "layer1_biases": layer1_biases,
+        "layer2_weights": layer2_weights,
+        "layer2_biases": layer2_biases,
+        "total_params": total_params,
+    }
+
+
+def find_neural_module_dir():
+    """Find the neural.slang-module directory."""
+    slang_root = Path(__file__).resolve().parents[5]
+    candidates = [
+        slang_root / "build" / "Release" / "lib" / "slang-standard-module-2026.1",
+        slang_root / "build" / "Debug" / "lib" / "slang-standard-module-2026.1",
+    ]
+    for candidate in candidates:
+        neural_module = candidate / "neural.slang-module"
+        if neural_module.exists():
+            return candidate
+    return None
+
+
+def run_benchmark_with_gpu_timing(
+    device,
+    kernel,
+    thread_count: list,
+    dispatch_args: dict,
+    warmup_iterations: int,
+    benchmark_iterations: int,
+    batch_size: int,
+) -> tuple:
+    """Run benchmark using GPU timestamps. Returns (avg_time_ms, throughput)."""
+    
+    # Warmup
+    for _ in range(warmup_iterations):
+        kernel.dispatch(thread_count=thread_count, **dispatch_args)
+    device.wait_for_idle()
+    
+    # Create query pool for GPU timestamps
+    query_pool = device.create_query_pool(
+        type=spy.QueryType.timestamp,
+        count=2,
+    )
+    
+    # Benchmark with GPU timestamps
+    query_pool.reset()
+    command_encoder = device.create_command_encoder()
+    
+    # Record start timestamp
+    command_encoder.write_timestamp(query_pool, 0)
+    
+    # Dispatch all iterations (no sync between iterations)
+    for _ in range(benchmark_iterations):
+        kernel.dispatch(
+            thread_count=thread_count,
+            command_encoder=command_encoder,
+            **dispatch_args,
+        )
+    
+    # Record end timestamp
+    command_encoder.write_timestamp(query_pool, 1)
+    
+    # Submit and wait
+    device.submit_command_buffer(command_encoder.finish())
+    device.wait_for_idle()
+    
+    # Get timestamp results
+    timestamps = query_pool.get_results(0, 2)
+    frequency = float(device.info.timestamp_frequency)
+    
+    elapsed_ticks = timestamps[1] - timestamps[0]
+    total_time_ms = (elapsed_ticks / frequency) * 1000
+    avg_time_ms = total_time_ms / benchmark_iterations
+    throughput = batch_size / (avg_time_ms / 1000)
+    
+    return avg_time_ms, throughput
+
+
+def run_coopmat_backward_benchmark(device_type_str: str, network_size: str) -> BenchmarkResult:
+    """Run CoopMat backward pass benchmark with GPU timestamps."""
+    config = get_network_config(network_size)
+    network_str = f"{config['input_size']}->{config['hidden_size']}->{config['output_size']}"
+    
+    try:
+        device_type_map = {
+            "vulkan": spy.DeviceType.vulkan,
+            "cuda": spy.DeviceType.cuda,
+        }
+        device_type = device_type_map[device_type_str.lower()]
+        test_dir = Path(__file__).resolve().parent
+        
+        defines = {
+            "INPUT_SIZE": str(config['input_size']),
+            "HIDDEN_SIZE": str(config['hidden_size']),
+            "OUTPUT_SIZE": str(config['output_size']),
+        }
+        
+        neural_module_dir = find_neural_module_dir()
+        include_paths = [str(test_dir)]
+        if neural_module_dir:
+            include_paths.append(str(neural_module_dir))
+        
+        compiler_options = spy.SlangCompilerOptions({
+            "include_paths": include_paths,
+            "enable_experimental_features": True,
+            "defines": defines,
+        })
+        
+        device = spy.Device(
+            type=device_type,
+            enable_debug_layers=False,
+            compiler_options=compiler_options,
+        )
+        
+        try:
+            # Load backward module
+            module = device.load_module("benchmark_neural_mlp_coopmat_backward_fp16.slang")
+            dtype = np.float16
+            
+            backward_program = device.link_program(
+                modules=[module],
+                entry_points=[module.entry_point("compute_batch_backward")]
+            )
+            backward_kernel = device.create_compute_kernel(backward_program)
+            
+            # Initialize parameters
+            rng = np.random.default_rng(42)
+            params_data = np.zeros(config['total_params'], dtype=dtype)
+            scale1 = np.sqrt(2.0 / config['input_size'])
+            params_data[:config['layer1_weights']] = (rng.standard_normal(config['layer1_weights']) * scale1).astype(dtype)
+            offset = config['layer1_weights'] + config['layer1_biases']
+            scale2 = np.sqrt(2.0 / config['hidden_size'])
+            params_data[offset:offset + config['layer2_weights']] = (rng.standard_normal(config['layer2_weights']) * scale2).astype(dtype)
+            
+            inputs_data = rng.standard_normal(BATCH_SIZE * config['input_size']).astype(dtype)
+            grad_outputs_data = rng.standard_normal(BATCH_SIZE * config['output_size']).astype(dtype)
+            
+            # Create buffers
+            params_buf = device.create_buffer(
+                data=params_data,
+                usage=spy.BufferUsage.shader_resource | spy.BufferUsage.unordered_access,
+            )
+            inputs_buf = device.create_buffer(
+                data=inputs_data, 
+                usage=spy.BufferUsage.shader_resource,
+            )
+            grad_outputs_buf = device.create_buffer(
+                data=grad_outputs_data,
+                usage=spy.BufferUsage.shader_resource,
+            )
+            grad_params_buf = device.create_buffer(
+                data=np.zeros(config['total_params'], dtype=dtype),
+                usage=spy.BufferUsage.unordered_access,
+            )
+            grad_inputs_buf = device.create_buffer(
+                data=np.zeros(BATCH_SIZE * config['input_size'], dtype=dtype),
+                usage=spy.BufferUsage.unordered_access,
+            )
+            
+            # 32 threads per group (1 warp)
+            thread_count = [BATCH_SIZE * 32, 1, 1]
+            
+            dispatch_args = {
+                "params": params_buf,
+                "inputs": inputs_buf,
+                "grad_outputs": grad_outputs_buf,
+                "grad_params": grad_params_buf,
+                "grad_inputs": grad_inputs_buf,
+                "batch_size": BATCH_SIZE,
+            }
+            
+            avg_time_ms, throughput = run_benchmark_with_gpu_timing(
+                device, backward_kernel, thread_count, dispatch_args,
+                WARMUP_ITERATIONS, BENCHMARK_ITERATIONS, BATCH_SIZE
+            )
+            
+            return BenchmarkResult(
+                name="CoopMat-Backward",
+                backend=device_type_str,
+                network=network_str,
+                time_ms=avg_time_ms,
+                throughput=throughput,
+                success=True,
+            )
+        finally:
+            device.close()
+            
+    except Exception as e:
+        import traceback
+        return BenchmarkResult(
+            name="CoopMat-Backward",
+            backend=device_type_str,
+            network=network_str,
+            time_ms=0,
+            throughput=0,
+            success=False,
+            error=f"{str(e)}\n{traceback.format_exc()}",
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="MLP Backward Pass Benchmark with GPU Timestamps")
+    parser.add_argument("--device", choices=["cuda", "vulkan"], default="cuda", help="Device type")
+    parser.add_argument("--size", choices=list(NETWORK_CONFIGS.keys()), help="Network size (or --sweep for all)")
+    parser.add_argument("--sweep", action="store_true", help="Run all network sizes")
+    args = parser.parse_args()
+    
+    print("=" * 100)
+    print("MLP BACKWARD Pass Benchmark - GPU Timestamps")
+    print("=" * 100)
+    print(f"Device: {args.device.upper()}")
+    print(f"Timing: GPU timestamps (equivalent to CUDA events)")
+    print(f"Batch size: {BATCH_SIZE} samples")
+    print(f"Warmup: {WARMUP_ITERATIONS}, Benchmark: {BENCHMARK_ITERATIONS} iterations")
+    print(f"Pass: BACKWARD (computes weight gradients)")
+    print()
+    
+    sizes = list(NETWORK_CONFIGS.keys()) if args.sweep else [args.size or "small"]
+    
+    print(f"{'Size':<10} {'Network':<18} {'Impl':<18} {'Backend':<8} {'Time (ms)':<12} {'Throughput':<15} {'Status'}")
+    print("-" * 110)
+    
+    for size_name in sizes:
+        config = NETWORK_CONFIGS[size_name]
+        network_str = f"{config['input']}->{config['hidden']}->{config['output']}"
+        
+        result = run_coopmat_backward_benchmark(args.device, size_name)
+        if result.success:
+            print(f"{size_name:<10} {network_str:<18} {result.name:<18} {args.device:<8} {result.time_ms:<12.4f} {result.throughput:<15.0f} OK")
+        else:
+            error_short = result.error.split('\n')[0][:40] if result.error else "Unknown"
+            print(f"{size_name:<10} {network_str:<18} {result.name:<18} {args.device:<8} {'FAILED':<12} {'':<15} {error_short}")
+    
+    print()
+    print("=" * 100)
+    print("\nTo compare with Tin backward pass, run:")
+    print("  cd Tin-repo/benchmarks/mlp_perf/comparison/build")
+    print("  ./bench_tin2_256cta_backward_fp16")
+    print("=" * 100)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/slangpy/neural/benchmarks/benchmark_neural_mlp.py
+++ b/tests/integration/slangpy/neural/benchmarks/benchmark_neural_mlp.py
@@ -1,0 +1,969 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+Neural MLP Performance Benchmark: For-loop vs CoopVec vs CoopMat
+
+Compares identical network architecture with three implementations:
+  - For-loop: Scalar GPU loops (original SlangPy LinearLayer style)
+  - CoopVec: coopVecMatMulAdd intrinsics (original SlangPy CoopVecLinearLayer style)
+  - CoopMat: WaveTangledVector + FFLayer (current neural.slang module)
+
+This benchmark tracks performance and guides future CoopMat optimizations.
+
+Usage:
+    python benchmark_neural_mlp.py [OPTIONS]
+
+Options:
+    --iterations N          Number of measured iterations (default: 100)
+    --warmup N              Number of warmup iterations (default: 10)
+    --batch-size N          Batch size for forward pass (default: 256)
+    --json                  Output results in JSON format
+    --forloop-only          Run only for-loop benchmark
+    --coopvec-only          Run only CoopVec benchmark  
+    --coopmat-only          Run only CoopMat benchmark
+    --device TYPE           Device type: vulkan, d3d12, cuda (default: vulkan)
+    --size SIZE             Network size: small, medium, large, xlarge (default: small)
+    --sweep                 Run benchmark across all network sizes
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+try:
+    import slangpy as spy
+    from slangpy.core.calldata import SLANG_PATH
+except ImportError:
+    print("Error: slangpy not found. Please install slangpy first.")
+    sys.exit(1)
+
+def find_neural_module_dir() -> Optional[str]:
+    """Find the neural module directory (from slang build)."""
+    # Look for neural.slang-module in standard locations
+    test_dir = Path(__file__).resolve().parent
+    
+    # Common build locations relative to slang repo
+    slang_repo = test_dir.parent.parent.parent.parent.parent  # tests/integration/slangpy/neural/benchmarks -> root
+    
+    possible_paths = [
+        slang_repo / "build" / "Release" / "lib" / "slang-standard-module-2026.1",
+        slang_repo / "build" / "Debug" / "lib" / "slang-standard-module-2026.1",
+        slang_repo / "build.release" / "lib" / "slang-standard-module-2026.1",
+        slang_repo / "build.debug" / "lib" / "slang-standard-module-2026.1",
+    ]
+    
+    for path in possible_paths:
+        if (path / "neural.slang-module").exists():
+            return str(path)
+    
+    return None
+
+# Network size configurations
+NETWORK_SIZES = {
+    "small": {"input": 64, "hidden": 64, "output": 16},      # 5,200 params
+    "medium": {"input": 128, "hidden": 128, "output": 32},   # 20,640 params
+    "large": {"input": 256, "hidden": 256, "output": 64},    # 82,240 params
+    "xlarge": {"input": 512, "hidden": 512, "output": 128},  # 328,320 params
+}
+
+def get_network_config(size_name: str) -> dict:
+    """Get network configuration for a given size."""
+    config = NETWORK_SIZES[size_name]
+    input_size = config["input"]
+    hidden_size = config["hidden"]
+    output_size = config["output"]
+    
+    layer1_weights = input_size * hidden_size
+    layer1_biases = hidden_size
+    layer2_weights = hidden_size * output_size
+    layer2_biases = output_size
+    total_params = layer1_weights + layer1_biases + layer2_weights + layer2_biases
+    
+    return {
+        "input_size": input_size,
+        "hidden_size": hidden_size,
+        "output_size": output_size,
+        "layer1_weights": layer1_weights,
+        "layer1_biases": layer1_biases,
+        "layer2_weights": hidden_size * output_size,
+        "layer2_biases": output_size,
+        "total_params": total_params,
+        "layer1_weight_offset": 0,
+        "layer1_bias_offset": layer1_weights,
+        "layer2_weight_offset": layer1_weights + layer1_biases,
+        "layer2_bias_offset": layer1_weights + layer1_biases + layer2_weights,
+    }
+
+# Default network configuration (small)
+INPUT_SIZE = 64
+HIDDEN_SIZE = 64
+OUTPUT_SIZE = 16
+LAYER1_WEIGHTS = INPUT_SIZE * HIDDEN_SIZE
+LAYER1_BIASES = HIDDEN_SIZE
+LAYER2_WEIGHTS = HIDDEN_SIZE * OUTPUT_SIZE
+LAYER2_BIASES = OUTPUT_SIZE
+TOTAL_PARAMS = LAYER1_WEIGHTS + LAYER1_BIASES + LAYER2_WEIGHTS + LAYER2_BIASES
+
+
+@dataclass
+class BenchmarkResult:
+    """Results from a single benchmark run."""
+    backend: str
+    device_type: str
+    batch_size: int
+    iterations: int
+    warmup_iterations: int
+    total_time_ms: float
+    avg_time_ms: float
+    min_time_ms: float
+    max_time_ms: float
+    throughput_samples_per_sec: float
+    success: bool
+    error_message: Optional[str] = None
+
+
+@dataclass
+class BenchmarkComparison:
+    """Comparison between For-loop, CoopVec, and CoopMat implementations."""
+    forloop: Optional[BenchmarkResult]  # Scalar GPU loops
+    coopvec: Optional[BenchmarkResult]  # Original CoopVec intrinsics
+    coopmat: Optional[BenchmarkResult]  # Current neural module
+    
+    def get_coopvec_vs_coopmat_speedup(self) -> Optional[float]:
+        """Get speedup ratio (coopvec_time / coopmat_time). >1 means CoopMat is faster."""
+        if (self.coopvec and self.coopmat and 
+            self.coopvec.success and self.coopmat.success and
+            self.coopmat.avg_time_ms > 0):
+            return self.coopvec.avg_time_ms / self.coopmat.avg_time_ms
+        return None
+    
+    def get_forloop_vs_coopvec_speedup(self) -> Optional[float]:
+        """Get speedup ratio (forloop_time / coopvec_time). >1 means CoopVec is faster."""
+        if (self.forloop and self.coopvec and 
+            self.forloop.success and self.coopvec.success and
+            self.coopvec.avg_time_ms > 0):
+            return self.forloop.avg_time_ms / self.coopvec.avg_time_ms
+        return None
+    
+    def get_forloop_vs_coopmat_speedup(self) -> Optional[float]:
+        """Get speedup ratio (forloop_time / coopmat_time). >1 means CoopMat is faster."""
+        if (self.forloop and self.coopmat and 
+            self.forloop.success and self.coopmat.success and
+            self.coopmat.avg_time_ms > 0):
+            return self.forloop.avg_time_ms / self.coopmat.avg_time_ms
+        return None
+
+
+def run_forloop_benchmark(
+    device_type_str: str,
+    batch_size: int,
+    iterations: int,
+    warmup: int,
+    network_size: str = "small",
+) -> BenchmarkResult:
+    """Run for-loop benchmark using scalar GPU loops (original LinearLayer style)."""
+    try:
+        config = get_network_config(network_size)
+        device_type_map = {
+            "vulkan": spy.DeviceType.vulkan,
+            "d3d12": spy.DeviceType.d3d12,
+            "cuda": spy.DeviceType.cuda,
+        }
+        device_type = device_type_map[device_type_str.lower()]
+        test_dir = Path(__file__).resolve().parent
+        
+        # Pass network size as preprocessor defines (dict format)
+        defines = {
+            "INPUT_SIZE": str(config['input_size']),
+            "HIDDEN_SIZE": str(config['hidden_size']),
+            "OUTPUT_SIZE": str(config['output_size']),
+        }
+        
+        compiler_options = spy.SlangCompilerOptions({
+            "include_paths": [test_dir, SLANG_PATH],
+            "debug_info": spy.SlangDebugInfoLevel.standard,
+            "defines": defines,
+        })
+        
+        device = spy.Device(
+            type=device_type,
+            enable_debug_layers=False,
+            compiler_options=compiler_options,
+            label=f"neural-mlp-benchmark-forloop-{device_type_str}",
+        )
+        
+        try:
+            module = device.load_module("benchmark_neural_mlp_forloop.slang")
+            
+            # Create compute kernel
+            forward_program = device.link_program(
+                modules=[module],
+                entry_points=[module.entry_point("compute_batch_forward")]
+            )
+            forward_kernel = device.create_compute_kernel(forward_program)
+            
+            # Initialize parameters using config
+            rng = np.random.default_rng(42)
+            params_data = np.zeros(config['total_params'], dtype=np.float32)
+            
+            # Layer 1 weights (He initialization)
+            scale1 = np.sqrt(2.0 / config['input_size'])
+            params_data[:config['layer1_weights']] = rng.standard_normal(config['layer1_weights']).astype(np.float32) * scale1
+            
+            # Layer 2 weights
+            offset = config['layer1_weights'] + config['layer1_biases']
+            scale2 = np.sqrt(2.0 / config['hidden_size'])
+            params_data[offset:offset + config['layer2_weights']] = rng.standard_normal(config['layer2_weights']).astype(np.float32) * scale2
+            
+            inputs_data = rng.standard_normal(batch_size * config['input_size']).astype(np.float32)
+            
+            # Create buffers
+            params_buf = device.create_buffer(
+                data=params_data,
+                usage=spy.BufferUsage.shader_resource,
+            )
+            inputs_buf = device.create_buffer(
+                data=inputs_data,
+                usage=spy.BufferUsage.shader_resource,
+            )
+            outputs_buf = device.create_buffer(
+                data=np.zeros(batch_size * config['output_size'], dtype=np.float32),
+                usage=spy.BufferUsage.unordered_access,
+            )
+            
+            # Calculate thread count (one thread per sample, 64 threads per group)
+            thread_count = ((batch_size + 63) // 64) * 64
+            
+            # Warmup
+            for _ in range(warmup):
+                forward_kernel.dispatch(
+                    thread_count=[thread_count, 1, 1],
+                    params=params_buf,
+                    inputs=inputs_buf,
+                    outputs=outputs_buf,
+                    batch_size=batch_size,
+                )
+            device.wait_for_idle()
+            
+            # Measured iterations with GPU timestamps
+            query_pool = device.create_query_pool(type=spy.QueryType.timestamp, count=iterations * 2)
+            for i in range(iterations):
+                command_encoder = device.create_command_encoder()
+                command_encoder.write_timestamp(query_pool, i * 2)
+                forward_kernel.dispatch(
+                    thread_count=[thread_count, 1, 1],
+                    command_encoder=command_encoder,
+                    params=params_buf,
+                    inputs=inputs_buf,
+                    outputs=outputs_buf,
+                    batch_size=batch_size,
+                )
+                command_encoder.write_timestamp(query_pool, i * 2 + 1)
+                device.submit_command_buffer(command_encoder.finish())
+            device.wait()
+            
+            # Get GPU timestamps and convert to ms
+            queries = np.array(query_pool.get_results(0, iterations * 2))
+            frequency = float(device.info.timestamp_frequency)
+            times = list((queries[1::2] - queries[0::2]) / frequency * 1000.0)
+            
+            total_time = sum(times)
+            avg_time = total_time / iterations
+            min_time = min(times)
+            max_time = max(times)
+            throughput = (batch_size * iterations) / (total_time / 1000)
+            
+            return BenchmarkResult(
+                backend=f"For-loop ({network_size})",
+                device_type=device_type.name,
+                batch_size=batch_size,
+                iterations=iterations,
+                warmup_iterations=warmup,
+                total_time_ms=total_time,
+                avg_time_ms=avg_time,
+                min_time_ms=min_time,
+                max_time_ms=max_time,
+                throughput_samples_per_sec=throughput,
+                success=True,
+            )
+        finally:
+            device.close()
+            
+    except Exception as e:
+        import traceback
+        return BenchmarkResult(
+            backend=f"For-loop ({network_size})",
+            device_type=device_type_str,
+            batch_size=batch_size,
+            iterations=iterations,
+            warmup_iterations=warmup,
+            total_time_ms=0,
+            avg_time_ms=0,
+            min_time_ms=0,
+            max_time_ms=0,
+            throughput_samples_per_sec=0,
+            success=False,
+            error_message=f"{str(e)}\n{traceback.format_exc()}",
+        )
+
+
+def run_coopvec_benchmark(
+    device_type_str: str,
+    batch_size: int,
+    iterations: int,
+    warmup: int,
+    network_size: str = "small",
+) -> BenchmarkResult:
+    """Run CoopVec benchmark using coopVecMatMulAdd intrinsics (original CoopVecLinearLayer style)."""
+    try:
+        config = get_network_config(network_size)
+        device_type_map = {
+            "vulkan": spy.DeviceType.vulkan,
+            "d3d12": spy.DeviceType.d3d12,
+            "cuda": spy.DeviceType.cuda,
+        }
+        device_type = device_type_map[device_type_str.lower()]
+        test_dir = Path(__file__).resolve().parent
+        
+        # Pass network size as preprocessor defines (dict format)
+        defines = {
+            "INPUT_SIZE": str(config['input_size']),
+            "HIDDEN_SIZE": str(config['hidden_size']),
+            "OUTPUT_SIZE": str(config['output_size']),
+        }
+        
+        compiler_options = spy.SlangCompilerOptions({
+            "include_paths": [test_dir, SLANG_PATH],
+            "debug_info": spy.SlangDebugInfoLevel.standard,
+            "enable_experimental_features": True,
+            "defines": defines,
+        })
+        
+        device = spy.Device(
+            type=device_type,
+            enable_debug_layers=False,
+            compiler_options=compiler_options,
+            label=f"neural-mlp-benchmark-coopvec-{device_type_str}",
+        )
+        
+        try:
+            # Check for cooperative vector support
+            if not device.has_feature(spy.Feature.cooperative_vector):
+                return BenchmarkResult(
+                    backend=f"CoopVec ({network_size})",
+                    device_type=device_type.name,
+                    batch_size=batch_size,
+                    iterations=iterations,
+                    warmup_iterations=warmup,
+                    total_time_ms=0,
+                    avg_time_ms=0,
+                    min_time_ms=0,
+                    max_time_ms=0,
+                    throughput_samples_per_sec=0,
+                    success=False,
+                    error_message="Cooperative vector not supported on this device",
+                )
+            
+            module = device.load_module("benchmark_neural_mlp_coopvec.slang")
+            
+            # Create compute kernel
+            forward_program = device.link_program(
+                modules=[module],
+                entry_points=[module.entry_point("compute_batch_forward")]
+            )
+            forward_kernel = device.create_compute_kernel(forward_program)
+            
+            # Initialize parameters (half precision for CoopVec)
+            rng = np.random.default_rng(42)
+            
+            # Separate buffers for weights and biases
+            scale1 = np.sqrt(2.0 / config['input_size'])
+            layer1_weights_data = rng.standard_normal(config['layer1_weights']).astype(np.float16) * scale1
+            layer1_biases_data = np.zeros(config['layer1_biases'], dtype=np.float16)
+            
+            scale2 = np.sqrt(2.0 / config['hidden_size'])
+            layer2_weights_data = rng.standard_normal(config['layer2_weights']).astype(np.float16) * scale2
+            layer2_biases_data = np.zeros(config['layer2_biases'], dtype=np.float16)
+            
+            inputs_data = rng.standard_normal(batch_size * config['input_size']).astype(np.float16)
+            
+            # Create buffers
+            buffer_usage = spy.BufferUsage.shader_resource | spy.BufferUsage.unordered_access
+            
+            layer1_weights_buf = device.create_buffer(data=layer1_weights_data, usage=buffer_usage)
+            layer1_biases_buf = device.create_buffer(data=layer1_biases_data, usage=buffer_usage)
+            layer2_weights_buf = device.create_buffer(data=layer2_weights_data, usage=buffer_usage)
+            layer2_biases_buf = device.create_buffer(data=layer2_biases_data, usage=buffer_usage)
+            inputs_buf = device.create_buffer(data=inputs_data, usage=spy.BufferUsage.shader_resource)
+            outputs_buf = device.create_buffer(
+                data=np.zeros(batch_size * config['output_size'], dtype=np.float16),
+                usage=spy.BufferUsage.unordered_access,
+            )
+            
+            # Create network params struct with device addresses
+            network_params = {
+                "layer1_weights": layer1_weights_buf.device_address,
+                "layer1_biases": layer1_biases_buf.device_address,
+                "layer2_weights": layer2_weights_buf.device_address,
+                "layer2_biases": layer2_biases_buf.device_address,
+            }
+            
+            # Dispatch one thread group (32 threads) per sample
+            num_groups = batch_size
+            
+            # Warmup
+            for _ in range(warmup):
+                forward_kernel.dispatch(
+                    thread_count=[num_groups * 32, 1, 1],
+                    network=network_params,
+                    inputs=inputs_buf,
+                    outputs=outputs_buf,
+                    batch_size=batch_size,
+                )
+            device.wait_for_idle()
+            
+            # Measured iterations with GPU timestamps
+            query_pool = device.create_query_pool(type=spy.QueryType.timestamp, count=iterations * 2)
+            for i in range(iterations):
+                command_encoder = device.create_command_encoder()
+                command_encoder.write_timestamp(query_pool, i * 2)
+                forward_kernel.dispatch(
+                    thread_count=[num_groups * 32, 1, 1],
+                    command_encoder=command_encoder,
+                    network=network_params,
+                    inputs=inputs_buf,
+                    outputs=outputs_buf,
+                    batch_size=batch_size,
+                )
+                command_encoder.write_timestamp(query_pool, i * 2 + 1)
+                device.submit_command_buffer(command_encoder.finish())
+            device.wait()
+            
+            # Get GPU timestamps and convert to ms
+            queries = np.array(query_pool.get_results(0, iterations * 2))
+            frequency = float(device.info.timestamp_frequency)
+            times = list((queries[1::2] - queries[0::2]) / frequency * 1000.0)
+            
+            total_time = sum(times)
+            avg_time = total_time / iterations
+            min_time = min(times)
+            max_time = max(times)
+            throughput = (batch_size * iterations) / (total_time / 1000)
+            
+            return BenchmarkResult(
+                backend=f"CoopVec ({network_size})",
+                device_type=device_type.name,
+                batch_size=batch_size,
+                iterations=iterations,
+                warmup_iterations=warmup,
+                total_time_ms=total_time,
+                avg_time_ms=avg_time,
+                min_time_ms=min_time,
+                max_time_ms=max_time,
+                throughput_samples_per_sec=throughput,
+                success=True,
+            )
+        finally:
+            device.close()
+            
+    except Exception as e:
+        import traceback
+        return BenchmarkResult(
+            backend=f"CoopVec ({network_size})",
+            device_type=device_type_str,
+            batch_size=batch_size,
+            iterations=iterations,
+            warmup_iterations=warmup,
+            total_time_ms=0,
+            avg_time_ms=0,
+            min_time_ms=0,
+            max_time_ms=0,
+            throughput_samples_per_sec=0,
+            success=False,
+            error_message=f"{str(e)}\n{traceback.format_exc()}",
+        )
+
+
+def run_coopmat_benchmark(
+    device_type_str: str,
+    batch_size: int,
+    iterations: int,
+    warmup: int,
+    network_size: str = "small",
+) -> BenchmarkResult:
+    """Run CoopMat benchmark using WaveTangledVector (current neural module)."""
+    try:
+        config = get_network_config(network_size)
+        device_type_map = {
+            "vulkan": spy.DeviceType.vulkan,
+            "d3d12": spy.DeviceType.d3d12,
+            "cuda": spy.DeviceType.cuda,
+        }
+        device_type = device_type_map[device_type_str.lower()]
+        test_dir = Path(__file__).resolve().parent
+        
+        # Pass network size as preprocessor defines (dict format)
+        defines = {
+            "INPUT_SIZE": str(config['input_size']),
+            "HIDDEN_SIZE": str(config['hidden_size']),
+            "OUTPUT_SIZE": str(config['output_size']),
+        }
+        
+        # Find neural module directory for CoopMat
+        neural_module_dir = find_neural_module_dir()
+        if neural_module_dir is None:
+            return BenchmarkResult(
+                backend=f"CoopMat ({network_size})",
+                device_type=device_type_str,
+                batch_size=batch_size,
+                iterations=iterations,
+                warmup_iterations=warmup,
+                total_time_ms=0,
+                avg_time_ms=0,
+                min_time_ms=0,
+                max_time_ms=0,
+                throughput_samples_per_sec=0,
+                success=False,
+                error_message="Neural module not found - build slang first",
+            )
+        
+        include_paths = [test_dir, neural_module_dir, SLANG_PATH]
+        compiler_options = spy.SlangCompilerOptions({
+            "include_paths": include_paths,
+            "debug_info": spy.SlangDebugInfoLevel.standard,
+            "enable_experimental_features": True,
+            "defines": defines,
+        })
+        
+        device = spy.Device(
+            type=device_type,
+            enable_debug_layers=False,
+            compiler_options=compiler_options,
+            label=f"neural-mlp-benchmark-coopmat-{device_type_str}",
+        )
+        
+        try:
+            # Check for cooperative matrix support
+            if not device.has_feature(spy.Feature.cooperative_matrix):
+                return BenchmarkResult(
+                    backend=f"CoopMat ({network_size})",
+                    device_type=device_type.name,
+                    batch_size=batch_size,
+                    iterations=iterations,
+                    warmup_iterations=warmup,
+                    total_time_ms=0,
+                    avg_time_ms=0,
+                    min_time_ms=0,
+                    max_time_ms=0,
+                    throughput_samples_per_sec=0,
+                    success=False,
+                    error_message="Cooperative matrix not supported on this device",
+                )
+            
+            module = device.load_module("benchmark_neural_mlp_coopmat_fp16.slang")
+            
+            # Create compute kernel for batch forward
+            forward_program = device.link_program(
+                modules=[module],
+                entry_points=[module.entry_point("compute_batch_forward")]
+            )
+            forward_kernel = device.create_compute_kernel(forward_program)
+            
+            # Initialize parameters using config (fp16 for fair comparison with Tin)
+            rng = np.random.default_rng(42)
+            params_data = np.zeros(config['total_params'], dtype=np.float16)
+            
+            # Layer 1 weights (He initialization)
+            scale1 = np.sqrt(2.0 / config['input_size'])
+            params_data[:config['layer1_weights']] = rng.standard_normal(config['layer1_weights']).astype(np.float16) * scale1
+            
+            # Layer 2 weights
+            offset = config['layer1_weights'] + config['layer1_biases']
+            scale2 = np.sqrt(2.0 / config['hidden_size'])
+            params_data[offset:offset + config['layer2_weights']] = rng.standard_normal(config['layer2_weights']).astype(np.float16) * scale2
+            
+            inputs_data = rng.standard_normal(batch_size * config['input_size']).astype(np.float16)
+            
+            # Create buffers (fp16)
+            params_buf = device.create_buffer(
+                data=params_data,
+                usage=spy.BufferUsage.shader_resource | spy.BufferUsage.unordered_access,
+            )
+            inputs_buf = device.create_buffer(
+                data=inputs_data,
+                usage=spy.BufferUsage.shader_resource,
+            )
+            outputs_buf = device.create_buffer(
+                data=np.zeros(batch_size * config['output_size'], dtype=np.float16),
+                usage=spy.BufferUsage.unordered_access,
+            )
+            
+            # Dispatch one thread group (32 threads) per sample
+            num_groups = batch_size
+            
+            # Warmup
+            for _ in range(warmup):
+                forward_kernel.dispatch(
+                    thread_count=[num_groups * 32, 1, 1],
+                    params=params_buf,
+                    inputs=inputs_buf,
+                    outputs=outputs_buf,
+                    batch_size=batch_size,
+                )
+            device.wait_for_idle()
+            
+            # Measured iterations with GPU timestamps
+            query_pool = device.create_query_pool(type=spy.QueryType.timestamp, count=iterations * 2)
+            for i in range(iterations):
+                command_encoder = device.create_command_encoder()
+                command_encoder.write_timestamp(query_pool, i * 2)
+                forward_kernel.dispatch(
+                    thread_count=[num_groups * 32, 1, 1],
+                    command_encoder=command_encoder,
+                    params=params_buf,
+                    inputs=inputs_buf,
+                    outputs=outputs_buf,
+                    batch_size=batch_size,
+                )
+                command_encoder.write_timestamp(query_pool, i * 2 + 1)
+                device.submit_command_buffer(command_encoder.finish())
+            device.wait()
+            
+            # Get GPU timestamps and convert to ms
+            queries = np.array(query_pool.get_results(0, iterations * 2))
+            frequency = float(device.info.timestamp_frequency)
+            times = list((queries[1::2] - queries[0::2]) / frequency * 1000.0)
+            
+            total_time = sum(times)
+            avg_time = total_time / iterations
+            min_time = min(times)
+            max_time = max(times)
+            throughput = (batch_size * iterations) / (total_time / 1000)
+            
+            return BenchmarkResult(
+                backend=f"CoopMat ({network_size})",
+                device_type=device_type.name,
+                batch_size=batch_size,
+                iterations=iterations,
+                warmup_iterations=warmup,
+                total_time_ms=total_time,
+                avg_time_ms=avg_time,
+                min_time_ms=min_time,
+                max_time_ms=max_time,
+                throughput_samples_per_sec=throughput,
+                success=True,
+            )
+        finally:
+            device.close()
+            
+    except Exception as e:
+        import traceback
+        return BenchmarkResult(
+            backend=f"CoopMat ({network_size})",
+            device_type=device_type_str,
+            batch_size=batch_size,
+            iterations=iterations,
+            warmup_iterations=warmup,
+            total_time_ms=0,
+            avg_time_ms=0,
+            min_time_ms=0,
+            max_time_ms=0,
+            throughput_samples_per_sec=0,
+            success=False,
+            error_message=f"{str(e)}\n{traceback.format_exc()}",
+        )
+
+
+def print_table_results(comparison: BenchmarkComparison, network_size: str = "small"):
+    """Print benchmark results as a formatted table."""
+    config = get_network_config(network_size)
+    print("\n" + "=" * 110)
+    print("Neural MLP Performance Benchmark: For-loop vs CoopVec vs CoopMat")
+    print("=" * 110)
+    print(f"Network: {config['input_size']} -> {config['hidden_size']} -> {config['output_size']} (2-layer MLP with LeakyReLU)")
+    print(f"Total Parameters: {config['total_params']}")
+    print("")
+    print("Backends (all run on GPU):")
+    print("  - For-loop: Scalar loops (original SlangPy LinearLayer style)")
+    print("  - CoopVec:  coopVecMatMulAdd intrinsics (original SlangPy CoopVecLinearLayer style)")
+    print("  - CoopMat:  WaveTangledVector + FFLayer (current neural.slang module)")
+    print("-" * 110)
+    
+    def format_result(result: Optional[BenchmarkResult], metric: str) -> str:
+        if result is None:
+            return "N/A"
+        if not result.success:
+            return "FAILED"
+        
+        metric_map = {
+            "Device": result.device_type,
+            "Batch Size": str(result.batch_size),
+            "Iterations": str(result.iterations),
+            "Warmup": str(result.warmup_iterations),
+            "Total Time (ms)": f"{result.total_time_ms:.2f}",
+            "Avg Time (ms)": f"{result.avg_time_ms:.4f}",
+            "Min Time (ms)": f"{result.min_time_ms:.4f}",
+            "Max Time (ms)": f"{result.max_time_ms:.4f}",
+            "Throughput (samples/s)": f"{result.throughput_samples_per_sec:.0f}",
+        }
+        return metric_map.get(metric, "N/A")
+    
+    print(f"\n{'Metric':<25} {'For-loop':<25} {'CoopVec':<25} {'CoopMat':<25}")
+    print("-" * 100)
+    
+    metrics = [
+        "Device", "Batch Size", "Iterations", "Warmup",
+        "Total Time (ms)", "Avg Time (ms)", "Min Time (ms)", "Max Time (ms)",
+        "Throughput (samples/s)"
+    ]
+    
+    for metric in metrics:
+        forloop_val = format_result(comparison.forloop, metric)
+        coopvec_val = format_result(comparison.coopvec, metric)
+        coopmat_val = format_result(comparison.coopmat, metric)
+        print(f"{metric:<25} {forloop_val:<25} {coopvec_val:<25} {coopmat_val:<25}")
+    
+    print("-" * 100)
+    
+    # Print error messages if any
+    if comparison.forloop and not comparison.forloop.success:
+        print(f"\nFor-loop Error: {comparison.forloop.error_message[:300]}...")
+    if comparison.coopvec and not comparison.coopvec.success:
+        print(f"\nCoopVec Error: {comparison.coopvec.error_message[:300]}...")
+    if comparison.coopmat and not comparison.coopmat.success:
+        print(f"\nCoopMat Error: {comparison.coopmat.error_message[:300]}...")
+    
+    print("\n--- Performance Comparison ---")
+    
+    # For-loop vs CoopVec
+    speedup_fl_cv = comparison.get_forloop_vs_coopvec_speedup()
+    if speedup_fl_cv is not None:
+        print(f"\nFor-loop vs CoopVec:")
+        if speedup_fl_cv > 1.0:
+            print(f"  CoopVec is {speedup_fl_cv:.2f}x faster than For-loop")
+        elif speedup_fl_cv < 1.0:
+            print(f"  CoopVec is {1/speedup_fl_cv:.2f}x slower than For-loop")
+        else:
+            print(f"  Similar performance")
+    
+    # CoopVec vs CoopMat (the key comparison)
+    speedup_cv_cm = comparison.get_coopvec_vs_coopmat_speedup()
+    if speedup_cv_cm is not None:
+        print(f"\nCoopVec vs CoopMat (Original vs Current):")
+        if speedup_cv_cm > 1.0:
+            print(f"  CoopMat is {speedup_cv_cm:.2f}x FASTER than CoopVec")
+        elif speedup_cv_cm < 1.0:
+            print(f"  *** CoopMat is {1/speedup_cv_cm:.2f}x SLOWER than CoopVec (needs optimization) ***")
+        else:
+            print(f"  Similar performance")
+    
+    # For-loop vs CoopMat
+    speedup_fl_cm = comparison.get_forloop_vs_coopmat_speedup()
+    if speedup_fl_cm is not None:
+        print(f"\nFor-loop vs CoopMat:")
+        if speedup_fl_cm > 1.0:
+            print(f"  CoopMat is {speedup_fl_cm:.2f}x faster than For-loop")
+        elif speedup_fl_cm < 1.0:
+            print(f"  CoopMat is {1/speedup_fl_cm:.2f}x slower than For-loop")
+        else:
+            print(f"  Similar performance")
+    
+    print("\n" + "=" * 110 + "\n")
+
+
+def print_json_results(comparison: BenchmarkComparison):
+    """Print benchmark results as JSON."""
+    result = {
+        "network": {
+            "input_size": INPUT_SIZE,
+            "hidden_size": HIDDEN_SIZE,
+            "output_size": OUTPUT_SIZE,
+            "total_params": TOTAL_PARAMS,
+        },
+        "forloop": asdict(comparison.forloop) if comparison.forloop else None,
+        "coopvec": asdict(comparison.coopvec) if comparison.coopvec else None,
+        "coopmat": asdict(comparison.coopmat) if comparison.coopmat else None,
+        "speedup_forloop_vs_coopvec": comparison.get_forloop_vs_coopvec_speedup(),
+        "speedup_coopvec_vs_coopmat": comparison.get_coopvec_vs_coopmat_speedup(),
+        "speedup_forloop_vs_coopmat": comparison.get_forloop_vs_coopmat_speedup(),
+        "coopmat_needs_optimization": (comparison.get_coopvec_vs_coopmat_speedup() or 0) < 1.0,
+    }
+    print(json.dumps(result, indent=2))
+
+
+def run_single_size_benchmark(args, network_size: str):
+    """Run benchmark for a single network size."""
+    config = get_network_config(network_size)
+    
+    if not args.json:
+        print(f"\nNeural MLP Performance Benchmark")
+        print(f"Network: {config['input_size']} -> {config['hidden_size']} -> {config['output_size']} ({config['total_params']} params)")
+        print(f"Device: {args.device}")
+    
+    forloop_result = None
+    coopvec_result = None
+    coopmat_result = None
+    
+    # Determine which benchmarks to run
+    run_forloop = not (args.coopvec_only or args.coopmat_only)
+    run_coopvec = not (args.forloop_only or args.coopmat_only)
+    run_coopmat = not (args.forloop_only or args.coopvec_only)
+    
+    # Run For-loop benchmark
+    if run_forloop:
+        if not args.json:
+            print(f"\nRunning For-loop benchmark...")
+        forloop_result = run_forloop_benchmark(
+            args.device, args.batch_size, args.iterations, args.warmup, network_size
+        )
+        if not args.json:
+            if forloop_result.success:
+                print(f"  Completed: avg {forloop_result.avg_time_ms:.4f} ms/iteration")
+            else:
+                print(f"  FAILED: {forloop_result.error_message[:100]}...")
+    
+    # Run CoopVec benchmark
+    if run_coopvec:
+        if not args.json:
+            print(f"\nRunning CoopVec benchmark...")
+        coopvec_result = run_coopvec_benchmark(
+            args.device, args.batch_size, args.iterations, args.warmup, network_size
+        )
+        if not args.json:
+            if coopvec_result.success:
+                print(f"  Completed: avg {coopvec_result.avg_time_ms:.4f} ms/iteration")
+            else:
+                print(f"  FAILED: {coopvec_result.error_message[:100]}...")
+    
+    # Run CoopMat benchmark
+    if run_coopmat:
+        if not args.json:
+            print(f"\nRunning CoopMat benchmark...")
+        coopmat_result = run_coopmat_benchmark(
+            args.device, args.batch_size, args.iterations, args.warmup, network_size
+        )
+        if not args.json:
+            if coopmat_result.success:
+                print(f"  Completed: avg {coopmat_result.avg_time_ms:.4f} ms/iteration")
+            else:
+                print(f"  FAILED: {coopmat_result.error_message[:100]}...")
+    
+    return BenchmarkComparison(
+        forloop=forloop_result,
+        coopvec=coopvec_result,
+        coopmat=coopmat_result,
+    )
+
+
+def print_sweep_results(all_results: dict):
+    """Print results from a sweep across network sizes."""
+    print("\n" + "=" * 140)
+    print("Neural MLP Performance Sweep: For-loop vs CoopVec vs CoopMat")
+    print("=" * 140)
+    print("\nAll backends run on GPU. Times in ms per iteration.")
+    print("-" * 140)
+    print(f"{'Size':<10} {'Network':<18} {'Params':<10} {'For-loop':<12} {'CoopVec':<12} {'CoopMat':<12} {'CoopMat vs For-loop':<22} {'CoopMat vs CoopVec':<20}")
+    print("-" * 140)
+    
+    for size_name, comparison in all_results.items():
+        config = get_network_config(size_name)
+        network_str = f"{config['input_size']}->{config['hidden_size']}->{config['output_size']}"
+        
+        forloop_time = f"{comparison.forloop.avg_time_ms:.4f}" if comparison.forloop and comparison.forloop.success else "FAILED"
+        coopvec_time = f"{comparison.coopvec.avg_time_ms:.4f}" if comparison.coopvec and comparison.coopvec.success else "FAILED"
+        coopmat_time = f"{comparison.coopmat.avg_time_ms:.4f}" if comparison.coopmat and comparison.coopmat.success else "FAILED"
+        
+        # CoopMat vs For-loop comparison
+        speedup_fl = comparison.get_forloop_vs_coopmat_speedup()
+        if speedup_fl and speedup_fl < 1.0:
+            speedup_fl_str = f"{1/speedup_fl:.2f}x slower"
+        elif speedup_fl and speedup_fl > 1.0:
+            speedup_fl_str = f"{speedup_fl:.2f}x faster"
+        else:
+            speedup_fl_str = "N/A"
+        
+        # CoopMat vs CoopVec comparison
+        speedup_cv = comparison.get_coopvec_vs_coopmat_speedup()
+        if speedup_cv and speedup_cv < 1.0:
+            speedup_cv_str = f"{1/speedup_cv:.2f}x slower"
+        elif speedup_cv and speedup_cv > 1.0:
+            speedup_cv_str = f"{speedup_cv:.2f}x faster"
+        else:
+            speedup_cv_str = "N/A"
+        
+        print(f"{size_name:<10} {network_str:<18} {config['total_params']:<10} {forloop_time:<12} {coopvec_time:<12} {coopmat_time:<12} {speedup_fl_str:<22} {speedup_cv_str:<20}")
+    
+    print("-" * 140)
+    print("\nCoopMat vs X: >1x slower means CoopMat takes more time than X")
+    print("=" * 140 + "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Neural MLP Benchmark: For-loop vs CoopVec vs CoopMat",
+    )
+    parser.add_argument("--iterations", type=int, default=100)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=256)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--forloop-only", action="store_true")
+    parser.add_argument("--coopvec-only", action="store_true")
+    parser.add_argument("--coopmat-only", action="store_true")
+    parser.add_argument("--device", type=str, default="vulkan", choices=["vulkan", "d3d12", "cuda"])
+    parser.add_argument("--size", type=str, default="small", choices=["small", "medium", "large", "xlarge"],
+                        help="Network size: small (64->64->16), medium (128->128->32), large (256->256->64), xlarge (512->512->128)")
+    parser.add_argument("--sweep", action="store_true", help="Run benchmark across all network sizes")
+    
+    args = parser.parse_args()
+    
+    if args.sweep:
+        # Run benchmark for all sizes
+        all_results = {}
+        for size_name in ["small", "medium", "large", "xlarge"]:
+            if not args.json:
+                print(f"\n{'='*60}")
+                print(f"Running {size_name.upper()} network...")
+                print(f"{'='*60}")
+            all_results[size_name] = run_single_size_benchmark(args, size_name)
+        
+        # Print summary
+        if not args.json:
+            print_sweep_results(all_results)
+        else:
+            # JSON output for sweep
+            result = {
+                "sweep": True,
+                "sizes": {
+                    name: {
+                        "network": get_network_config(name),
+                        "forloop": asdict(comp.forloop) if comp.forloop else None,
+                        "coopvec": asdict(comp.coopvec) if comp.coopvec else None,
+                        "coopmat": asdict(comp.coopmat) if comp.coopmat else None,
+                        "speedup_coopvec_vs_coopmat": comp.get_coopvec_vs_coopmat_speedup(),
+                    }
+                    for name, comp in all_results.items()
+                }
+            }
+            print(json.dumps(result, indent=2))
+    else:
+        # Run benchmark for single size
+        comparison = run_single_size_benchmark(args, args.size)
+        
+        # Output results
+        if args.json:
+            print_json_results(comparison)
+        else:
+            print_table_results(comparison, args.size)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/slangpy/neural/benchmarks/benchmark_neural_mlp_coopmat.slang
+++ b/tests/integration/slangpy/neural/benchmarks/benchmark_neural_mlp_coopmat.slang
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// CoopMat neural MLP benchmark using WaveTangledVector backend.
+// Network architecture configurable via preprocessor defines.
+// This matches the original neuralnetwork library benchmark for fair comparison.
+
+import neural;
+
+// Network configuration - use defines or defaults
+#ifndef INPUT_SIZE
+#define INPUT_SIZE 64
+#endif
+#ifndef HIDDEN_SIZE
+#define HIDDEN_SIZE 64
+#endif
+#ifndef OUTPUT_SIZE
+#define OUTPUT_SIZE 16
+#endif
+
+// CoopMat configuration
+static const int SubgroupSize = 32;
+static const int BatchSize = 32;
+
+typealias Storage = StructuredBufferStorage<float>;
+
+// Parameter layout:
+// Layer 1: weights [INPUT_SIZE * HIDDEN_SIZE], biases [HIDDEN_SIZE]
+// Layer 2: weights [HIDDEN_SIZE * OUTPUT_SIZE], biases [OUTPUT_SIZE]
+static const int LAYER1_WEIGHTS = INPUT_SIZE * HIDDEN_SIZE;
+static const int LAYER1_BIASES = HIDDEN_SIZE;
+static const int LAYER2_WEIGHTS = HIDDEN_SIZE * OUTPUT_SIZE;
+static const int LAYER2_BIASES = OUTPUT_SIZE;
+
+static const int PARAM_COUNT = LAYER1_WEIGHTS + LAYER1_BIASES + LAYER2_WEIGHTS + LAYER2_BIASES;
+
+// Parameter offsets
+static const uint LAYER1_WEIGHT_OFFSET = 0u;
+static const uint LAYER1_BIAS_OFFSET = uint(LAYER1_WEIGHTS);
+static const uint LAYER2_WEIGHT_OFFSET = uint(LAYER1_WEIGHTS + LAYER1_BIASES);
+static const uint LAYER2_BIAS_OFFSET = uint(LAYER1_WEIGHTS + LAYER1_BIASES + LAYER2_WEIGHTS);
+
+// Query functions
+public int get_input_size() { return INPUT_SIZE; }
+public int get_hidden_size() { return HIDDEN_SIZE; }
+public int get_output_size() { return OUTPUT_SIZE; }
+public int get_total_params() { return PARAM_COUNT; }
+
+// Shared memory size calculation for 2-layer network
+typealias ShMemSize = SharedMemorySize<float, TargetEnum.CUDA, ExecutionMode.Inference, SubgroupSize, BatchSize / SubgroupSize>;
+typealias ShMemSizeLayer1 = ShMemSize.OfLayer1<INPUT_SIZE, HIDDEN_SIZE>;
+typealias ShMemSizeLayer2 = ShMemSize.OfLayer1<HIDDEN_SIZE, OUTPUT_SIZE>;
+// Use max of both layers for shared memory pool
+typealias ShMemSizeTotal = ShMemSizeLayer1;  // Assuming layer1 needs more (larger input)
+
+// Compute shader entry point - one thread group per sample
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void compute_batch_forward(
+    uint3 gid : SV_GroupID,
+    uint gtid : SV_GroupIndex,
+    RWStructuredBuffer<float> params,
+    StructuredBuffer<float> inputs,
+    RWStructuredBuffer<float> outputs,
+    uniform int batch_size)
+{
+    // Each thread group processes one sample
+    int sampleIdx = int(gid.x);
+    if (sampleIdx >= batch_size)
+        return;
+    
+    // Define CoopMat types inside shader function
+    typealias ShMemPool = SharedMemoryPool<ShMemSizeTotal>;
+    
+    // Layer 1: INPUT -> HIDDEN
+    typealias VInput = WaveTangledVector<float, ShMemPool, INPUT_SIZE, SubgroupSize>;
+    typealias VHidden = WaveTangledVector<float, ShMemPool, HIDDEN_SIZE, SubgroupSize>;
+    typealias Act1 = ReLU<float>;
+    typealias Layer1 = FFLayer<float, VInput, VHidden, Storage, LinearLayout, Act1, true>;
+    
+    // Layer 2: HIDDEN -> OUTPUT
+    typealias VOutput = WaveTangledVector<float, ShMemPool, OUTPUT_SIZE, SubgroupSize>;
+    typealias Act2 = ReLU<float>;
+    typealias Layer2 = FFLayer<float, VHidden, VOutput, Storage, LinearLayout, Act2, true>;
+    
+    let storage = Storage(params);
+    let layer1 = Layer1(LAYER1_WEIGHT_OFFSET, LAYER1_BIAS_OFFSET);
+    let layer2 = Layer2(LAYER2_WEIGHT_OFFSET, LAYER2_BIAS_OFFSET);
+    
+    // Load input for this sample
+    float inputArr[INPUT_SIZE];
+    int inBaseIdx = sampleIdx * INPUT_SIZE;
+    [ForceUnroll]
+    for (int i = 0; i < INPUT_SIZE; i++)
+    {
+        inputArr[i] = inputs[inBaseIdx + i];
+    }
+    
+    // Forward pass through 2 layers
+    let input = VInput(inputArr);
+    let hidden = layer1.eval<Storage>(storage, input);
+    let output = layer2.eval<Storage>(storage, hidden);
+    
+    // Only first thread writes result
+    if (gtid == 0)
+    {
+        int outBaseIdx = sampleIdx * OUTPUT_SIZE;
+        [ForceUnroll]
+        for (int i = 0; i < OUTPUT_SIZE; i++)
+        {
+            outputs[outBaseIdx + i] = output[i];
+        }
+    }
+}

--- a/tests/integration/slangpy/neural/benchmarks/benchmark_neural_mlp_coopmat_backward_fp16.slang
+++ b/tests/integration/slangpy/neural/benchmarks/benchmark_neural_mlp_coopmat_backward_fp16.slang
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// CoopMat neural MLP BACKWARD pass benchmark using WaveTangledVector backend.
+// FP16 version for fair comparison with Tin2/Tin3 fp16 backward benchmarks.
+// Uses autodiff (bwd_diff) for backward pass computation.
+
+import neural;
+
+// Network configuration - use defines or defaults
+#ifndef INPUT_SIZE
+#define INPUT_SIZE 64
+#endif
+#ifndef HIDDEN_SIZE
+#define HIDDEN_SIZE 64
+#endif
+#ifndef OUTPUT_SIZE
+#define OUTPUT_SIZE 16
+#endif
+
+// CoopMat configuration
+static const int SubgroupSize = 32;
+static const int BatchSize = 32;
+
+// Use half precision storage
+typealias Storage = StructuredBufferStorage<half>;
+
+// Parameter layout:
+// Layer 1: weights [INPUT_SIZE * HIDDEN_SIZE], biases [HIDDEN_SIZE]
+// Layer 2: weights [HIDDEN_SIZE * OUTPUT_SIZE], biases [OUTPUT_SIZE]
+static const int LAYER1_WEIGHTS = INPUT_SIZE * HIDDEN_SIZE;
+static const int LAYER1_BIASES = HIDDEN_SIZE;
+static const int LAYER2_WEIGHTS = HIDDEN_SIZE * OUTPUT_SIZE;
+static const int LAYER2_BIASES = OUTPUT_SIZE;
+
+static const int PARAM_COUNT = LAYER1_WEIGHTS + LAYER1_BIASES + LAYER2_WEIGHTS + LAYER2_BIASES;
+
+// Parameter offsets
+static const uint LAYER1_WEIGHT_OFFSET = 0u;
+static const uint LAYER1_BIAS_OFFSET = uint(LAYER1_WEIGHTS);
+static const uint LAYER2_WEIGHT_OFFSET = uint(LAYER1_WEIGHTS + LAYER1_BIASES);
+static const uint LAYER2_BIAS_OFFSET = uint(LAYER1_WEIGHTS + LAYER1_BIASES + LAYER2_WEIGHTS);
+
+// Query functions
+public int get_input_size() { return INPUT_SIZE; }
+public int get_hidden_size() { return HIDDEN_SIZE; }
+public int get_output_size() { return OUTPUT_SIZE; }
+public int get_total_params() { return PARAM_COUNT; }
+
+// Shared memory size calculation for 2-layer network (using half)
+// Use Training mode for backward pass
+typealias ShMemSize = SharedMemorySize<half, TargetEnum.CUDA, ExecutionMode.Training, SubgroupSize, BatchSize / SubgroupSize>;
+typealias ShMemSizeLayer1 = ShMemSize.OfLayer1<INPUT_SIZE, HIDDEN_SIZE>;
+typealias ShMemSizeLayer2 = ShMemSize.OfLayer1<HIDDEN_SIZE, OUTPUT_SIZE>;
+typealias ShMemSizeTotal = ShMemSizeLayer1;
+
+// Define vector types globally for use in differentiable function
+typealias ShMemPool = SharedMemoryPool<ShMemSizeTotal>;
+typealias VInput = WaveTangledVector<half, ShMemPool, INPUT_SIZE, SubgroupSize>;
+typealias VHidden = WaveTangledVector<half, ShMemPool, HIDDEN_SIZE, SubgroupSize>;
+typealias VOutput = WaveTangledVector<half, ShMemPool, OUTPUT_SIZE, SubgroupSize>;
+typealias Act = ReLU<half>;
+typealias Layer1 = FFLayer<half, VInput, VHidden, Storage, LinearLayout, Act, true>;
+typealias Layer2 = FFLayer<half, VHidden, VOutput, Storage, LinearLayout, Act, true>;
+
+// Differentiable forward function for autodiff
+[Differentiable]
+VOutput mlpForward(Storage storage, VInput input, Layer1 layer1, Layer2 layer2)
+{
+    let hidden = layer1.eval<Storage>(storage, input);
+    let output = layer2.eval<Storage>(storage, hidden);
+    return output;
+}
+
+// Compute shader entry point - one thread group per sample
+// Backward pass: computes weight gradients via autodiff
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void compute_batch_backward(
+    uint3 gid : SV_GroupID,
+    uint gtid : SV_GroupIndex,
+    RWStructuredBuffer<half> params,         // Network parameters
+    StructuredBuffer<half> inputs,           // Original inputs
+    StructuredBuffer<half> grad_outputs,     // Gradient from loss
+    RWStructuredBuffer<half> grad_params,    // Output: accumulated parameter gradients
+    RWStructuredBuffer<half> grad_inputs,    // Output: input gradients
+    uniform int batch_size)
+{
+    // Each thread group processes one sample
+    int sampleIdx = int(gid.x);
+    if (sampleIdx >= batch_size)
+        return;
+    
+    // Create storage objects
+    let storage = Storage(params);
+    let gradStorage = Storage(grad_params);
+    
+    // Create layers
+    let layer1 = Layer1(LAYER1_WEIGHT_OFFSET, LAYER1_BIAS_OFFSET);
+    let layer2 = Layer2(LAYER2_WEIGHT_OFFSET, LAYER2_BIAS_OFFSET);
+    
+    // Load input for this sample
+    half inputArr[INPUT_SIZE];
+    int inBaseIdx = sampleIdx * INPUT_SIZE;
+    [ForceUnroll]
+    for (int i = 0; i < INPUT_SIZE; i++)
+    {
+        inputArr[i] = inputs[inBaseIdx + i];
+    }
+    let input = VInput(inputArr);
+    
+    // Load gradient from loss
+    half gradOutArr[OUTPUT_SIZE];
+    int gradOutBaseIdx = sampleIdx * OUTPUT_SIZE;
+    [ForceUnroll]
+    for (int i = 0; i < OUTPUT_SIZE; i++)
+    {
+        gradOutArr[i] = grad_outputs[gradOutBaseIdx + i];
+    }
+    let dOutput = VOutput(gradOutArr);
+    
+    // Create DifferentialPtrPair for storage (primal, gradient)
+    var storagePair = DifferentialPtrPair<Storage>(storage, gradStorage);
+    
+    // Create diffPair for input
+    var inputPair = diffPair(input);
+    
+    // Compute backward pass using autodiff
+    bwd_diff(mlpForward)(storagePair, inputPair, layer1, layer2, dOutput);
+    
+    // Write input gradients (from inputPair.d)
+    if (gtid == 0)
+    {
+        int gradInBaseIdx = sampleIdx * INPUT_SIZE;
+        [ForceUnroll]
+        for (int i = 0; i < INPUT_SIZE; i++)
+        {
+            grad_inputs[gradInBaseIdx + i] = inputPair.d[i];
+        }
+    }
+}

--- a/tests/integration/slangpy/neural/benchmarks/benchmark_neural_mlp_coopmat_fp16.slang
+++ b/tests/integration/slangpy/neural/benchmarks/benchmark_neural_mlp_coopmat_fp16.slang
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// CoopMat neural MLP benchmark using WaveTangledVector backend.
+// FP16 version for fair comparison with Tin2/Tin3 fp16 benchmarks.
+// Network architecture configurable via preprocessor defines.
+
+import neural;
+
+// Network configuration - use defines or defaults
+#ifndef INPUT_SIZE
+#define INPUT_SIZE 64
+#endif
+#ifndef HIDDEN_SIZE
+#define HIDDEN_SIZE 64
+#endif
+#ifndef OUTPUT_SIZE
+#define OUTPUT_SIZE 16
+#endif
+
+// CoopMat configuration
+static const int SubgroupSize = 32;
+static const int BatchSize = 32;
+
+// Use half precision storage
+typealias Storage = StructuredBufferStorage<half>;
+
+// Parameter layout:
+// Layer 1: weights [INPUT_SIZE * HIDDEN_SIZE], biases [HIDDEN_SIZE]
+// Layer 2: weights [HIDDEN_SIZE * OUTPUT_SIZE], biases [OUTPUT_SIZE]
+static const int LAYER1_WEIGHTS = INPUT_SIZE * HIDDEN_SIZE;
+static const int LAYER1_BIASES = HIDDEN_SIZE;
+static const int LAYER2_WEIGHTS = HIDDEN_SIZE * OUTPUT_SIZE;
+static const int LAYER2_BIASES = OUTPUT_SIZE;
+
+static const int PARAM_COUNT = LAYER1_WEIGHTS + LAYER1_BIASES + LAYER2_WEIGHTS + LAYER2_BIASES;
+
+// Parameter offsets
+static const uint LAYER1_WEIGHT_OFFSET = 0u;
+static const uint LAYER1_BIAS_OFFSET = uint(LAYER1_WEIGHTS);
+static const uint LAYER2_WEIGHT_OFFSET = uint(LAYER1_WEIGHTS + LAYER1_BIASES);
+static const uint LAYER2_BIAS_OFFSET = uint(LAYER1_WEIGHTS + LAYER1_BIASES + LAYER2_WEIGHTS);
+
+// Query functions
+public int get_input_size() { return INPUT_SIZE; }
+public int get_hidden_size() { return HIDDEN_SIZE; }
+public int get_output_size() { return OUTPUT_SIZE; }
+public int get_total_params() { return PARAM_COUNT; }
+
+// Shared memory size calculation for 2-layer network (using half)
+typealias ShMemSize = SharedMemorySize<half, TargetEnum.CUDA, ExecutionMode.Inference, SubgroupSize, BatchSize / SubgroupSize>;
+typealias ShMemSizeLayer1 = ShMemSize.OfLayer1<INPUT_SIZE, HIDDEN_SIZE>;
+typealias ShMemSizeLayer2 = ShMemSize.OfLayer1<HIDDEN_SIZE, OUTPUT_SIZE>;
+// Use max of both layers for shared memory pool
+typealias ShMemSizeTotal = ShMemSizeLayer1;  // Assuming layer1 needs more (larger input)
+
+// Compute shader entry point - one thread group per sample
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void compute_batch_forward(
+    uint3 gid : SV_GroupID,
+    uint gtid : SV_GroupIndex,
+    RWStructuredBuffer<half> params,
+    StructuredBuffer<half> inputs,
+    RWStructuredBuffer<half> outputs,
+    uniform int batch_size)
+{
+    // Each thread group processes one sample
+    int sampleIdx = int(gid.x);
+    if (sampleIdx >= batch_size)
+        return;
+    
+    // Define CoopMat types inside shader function (using half)
+    typealias ShMemPool = SharedMemoryPool<ShMemSizeTotal>;
+    
+    // Layer 1: INPUT -> HIDDEN
+    typealias VInput = WaveTangledVector<half, ShMemPool, INPUT_SIZE, SubgroupSize>;
+    typealias VHidden = WaveTangledVector<half, ShMemPool, HIDDEN_SIZE, SubgroupSize>;
+    typealias Act1 = ReLU<half>;
+    typealias Layer1 = FFLayer<half, VInput, VHidden, Storage, LinearLayout, Act1, true>;
+    
+    // Layer 2: HIDDEN -> OUTPUT
+    typealias VOutput = WaveTangledVector<half, ShMemPool, OUTPUT_SIZE, SubgroupSize>;
+    typealias Act2 = ReLU<half>;
+    typealias Layer2 = FFLayer<half, VHidden, VOutput, Storage, LinearLayout, Act2, true>;
+    
+    let storage = Storage(params);
+    let layer1 = Layer1(LAYER1_WEIGHT_OFFSET, LAYER1_BIAS_OFFSET);
+    let layer2 = Layer2(LAYER2_WEIGHT_OFFSET, LAYER2_BIAS_OFFSET);
+    
+    // Load input for this sample
+    half inputArr[INPUT_SIZE];
+    int inBaseIdx = sampleIdx * INPUT_SIZE;
+    [ForceUnroll]
+    for (int i = 0; i < INPUT_SIZE; i++)
+    {
+        inputArr[i] = inputs[inBaseIdx + i];
+    }
+    
+    // Forward pass through 2 layers
+    let input = VInput(inputArr);
+    let hidden = layer1.eval<Storage>(storage, input);
+    let output = layer2.eval<Storage>(storage, hidden);
+    
+    // Only first thread writes result
+    if (gtid == 0)
+    {
+        int outBaseIdx = sampleIdx * OUTPUT_SIZE;
+        [ForceUnroll]
+        for (int i = 0; i < OUTPUT_SIZE; i++)
+        {
+            outputs[outBaseIdx + i] = output[i];
+        }
+    }
+}

--- a/tests/integration/slangpy/neural/benchmarks/benchmark_neural_mlp_coopvec.slang
+++ b/tests/integration/slangpy/neural/benchmarks/benchmark_neural_mlp_coopvec.slang
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// CoopVec benchmark using direct coopVecMatMulAdd intrinsics.
+// Network architecture configurable via preprocessor defines.
+// This mimics the original SlangPy samples (CoopVecLinearLayer).
+
+// Use half precision like original samples
+typealias NFloat = half;
+static const CoopVecComponentType kComponentType = CoopVecComponentType.Float16;
+
+// Network configuration - use defines or defaults
+#ifndef INPUT_SIZE
+#define INPUT_SIZE 64
+#endif
+#ifndef HIDDEN_SIZE
+#define HIDDEN_SIZE 64
+#endif
+#ifndef OUTPUT_SIZE
+#define OUTPUT_SIZE 16
+#endif
+
+// MLVec wrapper for CoopVec (from original mlp example)
+struct MLVec<let N : int>
+{
+    CoopVec<NFloat, N> data;
+    
+    static MLVec<N> fromArray(NFloat arr[N])
+    {
+        MLVec<N> result;
+        [ForceUnroll]
+        for (int i = 0; i < N; i++)
+            result.data[i] = arr[i];
+        return result;
+    }
+    
+    NFloat[N] toArray()
+    {
+        NFloat[N] arr;
+        [ForceUnroll]
+        for (int i = 0; i < N; i++)
+            arr[i] = data[i];
+        return arr;
+    }
+}
+
+// Feed-forward layer using CoopVec (from original mlp example)
+struct FeedForwardLayer<let InputSize : int, let OutputSize : int>
+{
+    void* weights;
+    void* biases;
+    
+    MLVec<OutputSize> eval(MLVec<InputSize> input)
+    {
+        // Compute mul(weights, inputVec) + biases
+        var output = coopVecMatMulAdd<NFloat, OutputSize>(
+            input.data, kComponentType,
+            weights, kComponentType,
+            biases, kComponentType,
+            CoopVecMatrixLayout.RowMajor,
+            false,
+            InputSize * sizeof(NFloat));
+        
+        // LeakyReLU activation
+        output = max(output, output * NFloat(0.01h));
+        return {output};
+    }
+}
+
+// Network parameters passed from host
+public struct NetworkParams
+{
+    void* layer1_weights;
+    void* layer1_biases;
+    void* layer2_weights;
+    void* layer2_biases;
+}
+
+// Query functions
+public int get_input_size() { return INPUT_SIZE; }
+public int get_hidden_size() { return HIDDEN_SIZE; }
+public int get_output_size() { return OUTPUT_SIZE; }
+
+// Compute shader entry point - one thread group per sample
+[shader("compute")]
+[numthreads(32, 1, 1)]
+[require(spvCooperativeVectorNV)]
+void compute_batch_forward(
+    uint3 gid : SV_GroupID,
+    uint gtid : SV_GroupIndex,
+    uniform NetworkParams network,
+    StructuredBuffer<NFloat> inputs,
+    RWStructuredBuffer<NFloat> outputs,
+    uniform int batch_size)
+{
+    // Each thread group processes one sample
+    int sampleIdx = int(gid.x);
+    if (sampleIdx >= batch_size)
+        return;
+    
+    // Setup layers
+    FeedForwardLayer<INPUT_SIZE, HIDDEN_SIZE> layer1;
+    layer1.weights = network.layer1_weights;
+    layer1.biases = network.layer1_biases;
+    
+    FeedForwardLayer<HIDDEN_SIZE, OUTPUT_SIZE> layer2;
+    layer2.weights = network.layer2_weights;
+    layer2.biases = network.layer2_biases;
+    
+    // Load input into array
+    int inBaseIdx = sampleIdx * INPUT_SIZE;
+    NFloat inputArr[INPUT_SIZE];
+    [ForceUnroll]
+    for (int i = 0; i < INPUT_SIZE; i++)
+    {
+        inputArr[i] = inputs[inBaseIdx + i];
+    }
+    
+    // Forward pass
+    let input = MLVec<INPUT_SIZE>.fromArray(inputArr);
+    let hidden = layer1.eval(input);
+    let output = layer2.eval(hidden);
+    
+    // Write output (only first thread in group)
+    if (gtid == 0)
+    {
+        let outArr = output.toArray();
+        int outBaseIdx = sampleIdx * OUTPUT_SIZE;
+        [ForceUnroll]
+        for (int i = 0; i < OUTPUT_SIZE; i++)
+        {
+            outputs[outBaseIdx + i] = outArr[i];
+        }
+    }
+}

--- a/tests/integration/slangpy/neural/benchmarks/benchmark_neural_mlp_forloop.slang
+++ b/tests/integration/slangpy/neural/benchmarks/benchmark_neural_mlp_forloop.slang
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// For-loop (scalar) benchmark - matches original SlangPy LinearLayer style.
+// Network architecture configurable via preprocessor defines.
+// This is the scalar baseline running on GPU without tensor core acceleration.
+
+// Network configuration - use defines or defaults
+#ifndef INPUT_SIZE
+#define INPUT_SIZE 64
+#endif
+#ifndef HIDDEN_SIZE
+#define HIDDEN_SIZE 64
+#endif
+#ifndef OUTPUT_SIZE
+#define OUTPUT_SIZE 16
+#endif
+
+// Parameter offsets in flat buffer
+static const int LAYER1_WEIGHT_OFFSET = 0;
+static const int LAYER1_BIAS_OFFSET = INPUT_SIZE * HIDDEN_SIZE;
+static const int LAYER2_WEIGHT_OFFSET = LAYER1_BIAS_OFFSET + HIDDEN_SIZE;
+static const int LAYER2_BIAS_OFFSET = LAYER2_WEIGHT_OFFSET + HIDDEN_SIZE * OUTPUT_SIZE;
+
+// Linear layer forward pass using for-loops (matches original LinearLayer)
+void linearLayerForward<let NumInputs : int, let NumOutputs : int>(
+    StructuredBuffer<float> weights,
+    int weightOffset,
+    StructuredBuffer<float> biases, 
+    int biasOffset,
+    float input[NumInputs],
+    out float output[NumOutputs])
+{
+    for (int row = 0; row < NumOutputs; ++row)
+    {
+        float sum = biases[biasOffset + row];
+        [ForceUnroll]
+        for (int col = 0; col < NumInputs; ++col)
+        {
+            sum += weights[weightOffset + row * NumInputs + col] * input[col];
+        }
+        output[row] = sum;
+    }
+}
+
+// LeakyReLU activation
+void leakyReLU<let N : int>(inout float x[N])
+{
+    [ForceUnroll]
+    for (int i = 0; i < N; ++i)
+    {
+        if (x[i] < 0.0f)
+            x[i] *= 0.01f;
+    }
+}
+
+// Query functions
+public int get_input_size() { return INPUT_SIZE; }
+public int get_hidden_size() { return HIDDEN_SIZE; }
+public int get_output_size() { return OUTPUT_SIZE; }
+
+// Compute shader entry point - one thread per sample
+[shader("compute")]
+[numthreads(64, 1, 1)]
+void compute_batch_forward(
+    uint3 tid : SV_DispatchThreadID,
+    StructuredBuffer<float> params,
+    StructuredBuffer<float> inputs,
+    RWStructuredBuffer<float> outputs,
+    uniform int batch_size)
+{
+    int sampleIdx = tid.x;
+    if (sampleIdx >= batch_size)
+        return;
+    
+    // Load input
+    float input[INPUT_SIZE];
+    int inBaseIdx = sampleIdx * INPUT_SIZE;
+    [ForceUnroll]
+    for (int i = 0; i < INPUT_SIZE; ++i)
+    {
+        input[i] = inputs[inBaseIdx + i];
+    }
+    
+    // Layer 1: Input -> Hidden
+    float hidden[HIDDEN_SIZE];
+    linearLayerForward<INPUT_SIZE, HIDDEN_SIZE>(
+        params, LAYER1_WEIGHT_OFFSET,
+        params, LAYER1_BIAS_OFFSET,
+        input, hidden);
+    leakyReLU<HIDDEN_SIZE>(hidden);
+    
+    // Layer 2: Hidden -> Output
+    float output[OUTPUT_SIZE];
+    linearLayerForward<HIDDEN_SIZE, OUTPUT_SIZE>(
+        params, LAYER2_WEIGHT_OFFSET,
+        params, LAYER2_BIAS_OFFSET,
+        hidden, output);
+    leakyReLU<OUTPUT_SIZE>(output);
+    
+    // Write output
+    int outBaseIdx = sampleIdx * OUTPUT_SIZE;
+    [ForceUnroll]
+    for (int i = 0; i < OUTPUT_SIZE; ++i)
+    {
+        outputs[outBaseIdx + i] = output[i];
+    }
+}

--- a/tests/integration/slangpy/neural/benchmarks/benchmark_single_layer_backward.py
+++ b/tests/integration/slangpy/neural/benchmarks/benchmark_single_layer_backward.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+Single Layer Backward Pass Benchmark
+
+Simplified backward pass comparison: single layer (Input -> Output)
+This requires much less shared memory than 2-layer MLP.
+
+Network sizes:
+- tiny:  32 -> 16 (528 params)
+- small: 64 -> 16 (1,040 params)
+- medium: 128 -> 32 (4,128 params)
+"""
+
+import argparse
+import numpy as np
+from pathlib import Path
+
+try:
+    import slangpy as spy
+    from slangpy.core.calldata import SLANG_PATH
+except ImportError:
+    print("Error: slangpy not found")
+    exit(1)
+
+# Single-layer network configurations
+NETWORK_CONFIGS = {
+    "tiny": {"input": 32, "output": 16},
+    "small": {"input": 64, "output": 16},
+    "medium": {"input": 128, "output": 32},
+    "large": {"input": 256, "output": 64},
+}
+
+BATCH_SIZE = 256
+WARMUP = 50
+ITERATIONS = 200
+
+
+def find_neural_module_dir():
+    """Find the neural.slang-module directory."""
+    slang_root = Path(__file__).resolve().parents[5]
+    candidates = [
+        slang_root / "build" / "Release" / "lib" / "slang-standard-module-2026.1",
+        slang_root / "build" / "Debug" / "lib" / "slang-standard-module-2026.1",
+    ]
+    for candidate in candidates:
+        neural_module = candidate / "neural.slang-module"
+        if neural_module.exists():
+            return candidate
+    return None
+
+
+def run_single_layer_backward(device_type_str: str, size: str):
+    """Run single-layer backward benchmark."""
+    config = NETWORK_CONFIGS[size]
+    input_size = config["input"]
+    output_size = config["output"]
+    
+    # Single layer: weights [input x output] + biases [output]
+    total_params = input_size * output_size + output_size
+    
+    print(f"\n{'='*70}")
+    print(f"Single Layer Backward: {input_size} -> {output_size}")
+    print(f"Parameters: {total_params}")
+    print(f"{'='*70}")
+    
+    neural_module_dir = find_neural_module_dir()
+    if not neural_module_dir:
+        print("ERROR: neural.slang-module not found")
+        return None
+    
+    device_type_map = {
+        "vulkan": spy.DeviceType.vulkan,
+        "cuda": spy.DeviceType.cuda,
+    }
+    device_type = device_type_map[device_type_str.lower()]
+    test_dir = Path(__file__).resolve().parent
+    
+    # Defines for shader
+    defines = {
+        "INPUT_SIZE": str(input_size),
+        "OUTPUT_SIZE": str(output_size),
+    }
+    
+    include_paths = [str(test_dir), str(neural_module_dir), SLANG_PATH]
+    
+    compiler_options = spy.SlangCompilerOptions({
+        "include_paths": include_paths,
+        "debug_info": spy.SlangDebugInfoLevel.standard,
+        "enable_experimental_features": True,
+        "defines": defines,
+    })
+    
+    try:
+        device = spy.Device(
+            type=device_type,
+            enable_debug_layers=True,
+            compiler_options=compiler_options,
+        )
+        
+        module = device.load_module("benchmark_single_layer_backward.slang")
+        
+        # Link and create kernel
+        program = device.link_program(
+            modules=[module],
+            entry_points=[module.entry_point("compute_single_layer_backward")]
+        )
+        kernel = device.create_compute_kernel(program)
+        
+        # Allocate buffers
+        rng = np.random.default_rng(42)
+        
+        params_data = rng.standard_normal(total_params).astype(np.float16) * 0.1
+        inputs_data = rng.standard_normal(BATCH_SIZE * input_size).astype(np.float16) * 0.1
+        grad_outputs_data = rng.standard_normal(BATCH_SIZE * output_size).astype(np.float16) * 0.1
+        
+        params_buf = device.create_buffer(
+            data=params_data,
+            usage=spy.BufferUsage.shader_resource | spy.BufferUsage.unordered_access,
+        )
+        inputs_buf = device.create_buffer(
+            data=inputs_data,
+            usage=spy.BufferUsage.shader_resource,
+        )
+        grad_outputs_buf = device.create_buffer(
+            data=grad_outputs_data,
+            usage=spy.BufferUsage.shader_resource,
+        )
+        grad_params_buf = device.create_buffer(
+            data=np.zeros(total_params, dtype=np.float16),
+            usage=spy.BufferUsage.unordered_access,
+        )
+        grad_inputs_buf = device.create_buffer(
+            data=np.zeros(BATCH_SIZE * input_size, dtype=np.float16),
+            usage=spy.BufferUsage.unordered_access,
+        )
+        
+        thread_count = [BATCH_SIZE, 1, 1]
+        
+        # Warmup
+        print(f"Warming up ({WARMUP} iterations)...")
+        for _ in range(WARMUP):
+            kernel.dispatch(
+                thread_count=thread_count,
+                params=params_buf,
+                inputs=inputs_buf,
+                grad_outputs=grad_outputs_buf,
+                grad_params=grad_params_buf,
+                grad_inputs=grad_inputs_buf,
+                batch_size=BATCH_SIZE,
+            )
+        device.wait()
+        
+        # Benchmark with GPU timestamps
+        print(f"Benchmarking ({ITERATIONS} iterations)...")
+        query_pool = device.create_query_pool(type=spy.QueryType.timestamp, count=2)
+        
+        command_encoder = device.create_command_encoder()
+        command_encoder.write_timestamp(query_pool, 0)
+        
+        for _ in range(ITERATIONS):
+            kernel.dispatch(
+                thread_count=thread_count,
+                command_encoder=command_encoder,
+                params=params_buf,
+                inputs=inputs_buf,
+                grad_outputs=grad_outputs_buf,
+                grad_params=grad_params_buf,
+                grad_inputs=grad_inputs_buf,
+                batch_size=BATCH_SIZE,
+            )
+        
+        command_encoder.write_timestamp(query_pool, 1)
+        device.submit_command_buffer(command_encoder.finish())
+        device.wait()
+        
+        # Calculate results
+        timestamps = np.array(query_pool.get_results(0, 2))
+        frequency = float(device.info.timestamp_frequency)
+        elapsed_ticks = timestamps[1] - timestamps[0]
+        total_time_ms = (elapsed_ticks / frequency) * 1000
+        avg_time_ms = total_time_ms / ITERATIONS
+        throughput = BATCH_SIZE / (avg_time_ms / 1000)
+        
+        print(f"\nResults:")
+        print(f"  Backend: {device_type_str}")
+        print(f"  Network: {input_size} -> {output_size}")
+        print(f"  Avg time: {avg_time_ms:.4f} ms")
+        print(f"  Throughput: {throughput:.0f} samples/s")
+        
+        device.close()
+        return avg_time_ms
+        
+    except Exception as e:
+        print(f"FAILED: {e}")
+        import traceback
+        traceback.print_exc()
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Single Layer Backward Benchmark")
+    parser.add_argument("--device", default="cuda", choices=["cuda", "vulkan"])
+    parser.add_argument("--size", default="small", choices=list(NETWORK_CONFIGS.keys()))
+    parser.add_argument("--all", action="store_true", help="Run all sizes")
+    args = parser.parse_args()
+    
+    print("="*70)
+    print("Single Layer Backward Pass Benchmark")
+    print("="*70)
+    print(f"Batch size: {BATCH_SIZE}")
+    print(f"Warmup: {WARMUP}, Iterations: {ITERATIONS}")
+    print(f"Backend: {args.device}")
+    
+    if args.all:
+        results = {}
+        for size in NETWORK_CONFIGS.keys():
+            time_ms = run_single_layer_backward(args.device, size)
+            if time_ms:
+                results[size] = time_ms
+        
+        print("\n" + "="*70)
+        print("Summary: Single Layer Backward (CoopMat)")
+        print("="*70)
+        print(f"{'Size':<10} {'Network':<15} {'Time (ms)':<12} {'Status'}")
+        print("-"*50)
+        for size, config in NETWORK_CONFIGS.items():
+            net = f"{config['input']}->{config['output']}"
+            if size in results:
+                print(f"{size:<10} {net:<15} {results[size]:<12.4f} OK")
+            else:
+                print(f"{size:<10} {net:<15} {'N/A':<12} FAILED")
+    else:
+        run_single_layer_backward(args.device, args.size)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/slangpy/neural/benchmarks/benchmark_single_layer_backward.slang
+++ b/tests/integration/slangpy/neural/benchmarks/benchmark_single_layer_backward.slang
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Simple SINGLE LAYER backward pass benchmark.
+// Input -> Output directly (no hidden layer)
+// This should require much less shared memory than 2-layer MLP.
+
+import neural;
+
+// Network configuration - single layer: INPUT_SIZE -> OUTPUT_SIZE
+#ifndef INPUT_SIZE
+#define INPUT_SIZE 64
+#endif
+#ifndef OUTPUT_SIZE
+#define OUTPUT_SIZE 16
+#endif
+
+// CoopMat configuration
+static const int SubgroupSize = 32;
+static const int BatchSize = 32;
+
+// Use half precision storage
+typealias Storage = StructuredBufferStorage<half>;
+
+// Single layer parameter layout:
+// weights [INPUT_SIZE * OUTPUT_SIZE], biases [OUTPUT_SIZE]
+static const int LAYER_WEIGHTS = INPUT_SIZE * OUTPUT_SIZE;
+static const int LAYER_BIASES = OUTPUT_SIZE;
+static const int PARAM_COUNT = LAYER_WEIGHTS + LAYER_BIASES;
+
+static const uint WEIGHT_OFFSET = 0u;
+static const uint BIAS_OFFSET = uint(LAYER_WEIGHTS);
+
+// Query functions
+public int get_input_size() { return INPUT_SIZE; }
+public int get_output_size() { return OUTPUT_SIZE; }
+public int get_total_params() { return PARAM_COUNT; }
+
+// Shared memory size for single layer (much smaller than 2-layer!)
+typealias ShMemSize = SharedMemorySize<half, TargetEnum.CUDA, ExecutionMode.Training, SubgroupSize, BatchSize / SubgroupSize>;
+typealias ShMemSizeLayer = ShMemSize.OfLayer1<INPUT_SIZE, OUTPUT_SIZE>;
+
+// Define vector types
+typealias ShMemPool = SharedMemoryPool<ShMemSizeLayer>;
+typealias VInput = WaveTangledVector<half, ShMemPool, INPUT_SIZE, SubgroupSize>;
+typealias VOutput = WaveTangledVector<half, ShMemPool, OUTPUT_SIZE, SubgroupSize>;
+typealias Act = ReLU<half>;
+typealias Layer = FFLayer<half, VInput, VOutput, Storage, LinearLayout, Act, true>;
+
+// Simple differentiable forward function - just one layer!
+[Differentiable]
+VOutput singleLayerForward(Storage storage, VInput input, Layer layer)
+{
+    return layer.eval<Storage>(storage, input);
+}
+
+// Compute shader entry point - one thread group per sample
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void compute_single_layer_backward(
+    uint3 gid : SV_GroupID,
+    uint gtid : SV_GroupIndex,
+    RWStructuredBuffer<half> params,
+    StructuredBuffer<half> inputs,
+    StructuredBuffer<half> grad_outputs,
+    RWStructuredBuffer<half> grad_params,
+    RWStructuredBuffer<half> grad_inputs,
+    uniform int batch_size)
+{
+    int sampleIdx = int(gid.x);
+    if (sampleIdx >= batch_size)
+        return;
+    
+    let storage = Storage(params);
+    let gradStorage = Storage(grad_params);
+    let layer = Layer(WEIGHT_OFFSET, BIAS_OFFSET);
+    
+    // Load input
+    half inputArr[INPUT_SIZE];
+    int inBaseIdx = sampleIdx * INPUT_SIZE;
+    [ForceUnroll]
+    for (int i = 0; i < INPUT_SIZE; i++)
+    {
+        inputArr[i] = inputs[inBaseIdx + i];
+    }
+    let input = VInput(inputArr);
+    
+    // Load output gradient
+    half gradOutArr[OUTPUT_SIZE];
+    int gradOutBaseIdx = sampleIdx * OUTPUT_SIZE;
+    [ForceUnroll]
+    for (int i = 0; i < OUTPUT_SIZE; i++)
+    {
+        gradOutArr[i] = grad_outputs[gradOutBaseIdx + i];
+    }
+    let dOutput = VOutput(gradOutArr);
+    
+    // Backward pass
+    var storagePair = DifferentialPtrPair<Storage>(storage, gradStorage);
+    var inputPair = diffPair(input);
+    
+    bwd_diff(singleLayerForward)(storagePair, inputPair, layer, dOutput);
+    
+    // Write input gradients
+    if (gtid == 0)
+    {
+        int gradInBaseIdx = sampleIdx * INPUT_SIZE;
+        [ForceUnroll]
+        for (int i = 0; i < INPUT_SIZE; i++)
+        {
+            grad_inputs[gradInBaseIdx + i] = inputPair.d[i];
+        }
+    }
+}


### PR DESCRIPTION
Fixes #9739

Move neural MLP benchmark from slangpy repo to slang repo.

This benchmark compares three GPU implementations of a 2-layer MLP:
- For-loop: Scalar GPU loops (baseline)
- CoopVec: coopVecMatMulAdd intrinsics (original SlangPy style)
- CoopMat: WaveTangledVector + FFLayer (current neural.slang module)

The benchmark tracks performance across different network sizes and guides future CoopMat optimizations.