### PR TITLE
Fix the release CI broken

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,6 @@ jobs:
             -DSLANG_ENABLE_EXAMPLES=OFF \
             -DSLANG_ENABLE_RELEASE_LTO=ON \
             -DSLANG_STANDARD_MODULE_DEVELOP_BUILD=OFF \
-            -DSLANG_ENABLE_NEURAL_MODULE=OFF \
             "-DSLANG_SLANG_LLVM_FLAVOR=$(
               [[ "${{matrix.build-slang-llvm}}" = "true" ]] && echo "USE_SYSTEM_LLVM" || echo "DISABLE")" \
             ${{matrix.extra-cmake-flags}}

--- a/source/standard-modules/CMakeLists.txt
+++ b/source/standard-modules/CMakeLists.txt
@@ -2,11 +2,6 @@
 # setup the standard module configuration
 #
 
-# Option to enable/disable neural module build (can be disabled if it breaks CI)
-# TODO: there is release CI break, so we add this flag to disable the neural module build for now.
-# Issue: https://github.com/shader-slang/slang/issues/9864 is opened to track this.
-option(SLANG_ENABLE_NEURAL_MODULE "Build the neural standard module" ON)
-
 #
 # Neural module configuration
 # SLANG_STANDARD_MODULE_DIR_NAME is the output directory name for all the standard modules, currently there is only neural module
@@ -45,6 +40,4 @@ add_custom_target(
 set_target_properties(generate_standard_module_config_header PROPERTIES FOLDER "generated")
 
 # Build the neural module
-if(SLANG_ENABLE_NEURAL_MODULE)
-    add_subdirectory(neural)
-endif()
+add_subdirectory(neural)


### PR DESCRIPTION
Close #9864.

The bug was an uninitialized pointer field diffThisType in DerivativeRequirementDecl class (source/slang/slang-ast-decl.h line 1021). The field was declared without a default initializer:

This caused crashes in release builds because the uninitialized memory contained garbage that the serializer tried to dereference. Debug builds typically zero-initialize memory, masking the bug.