### PR TITLE
Test container approach for Copilot workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -78,11 +78,55 @@ jobs:
           echo "=== CUDA version ==="
           nvcc --version
 
+      # LLVM caching support - restore cached LLVM build if available
+      - name: Restore cached LLVM
+        uses: actions/cache/restore@v4
+        id: cache-llvm
+        with:
+          path: build/llvm-project-install
+          key: llvm-linux-gcc-x86_64-${{ hashFiles('external/build-llvm.sh') }}
+
+      # Build LLVM from source if cache miss (takes 15-25 minutes)
+      - name: Build LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: |
+          ./external/build-llvm.sh \
+            --install-prefix "${{ github.workspace }}/build/llvm-project-install" \
+            --repo "https://${{ github.token }}@github.com/llvm/llvm-project"
+
+      # Save LLVM cache only on master branch to avoid cache pollution
+      - name: Save LLVM cache
+        uses: actions/cache/save@v4
+        if: steps.cache-llvm.outputs.cache-hit != 'true' && github.ref == 'refs/heads/master'
+        with:
+          path: build/llvm-project-install
+          key: ${{ steps.cache-llvm.outputs.cache-primary-key }}
+
+      # Set LLVM paths for CMake to find the installation
+      - name: Set LLVM paths
+        run: |
+          echo "LLVM_DIR=${{ github.workspace }}/build/llvm-project-install" >> $GITHUB_ENV
+          echo "Clang_DIR=${{ github.workspace }}/build/llvm-project-install" >> $GITHUB_ENV
+
+      # Verify LLVM installation
+      - name: Verify LLVM installation
+        run: |
+          echo "=== LLVM Installation ==="
+          if [ -d build/llvm-project-install ]; then
+            echo "LLVM installed at: build/llvm-project-install"
+            echo "LLVM_DIR=$LLVM_DIR"
+            echo "Clang_DIR=$Clang_DIR"
+            ls -lh build/llvm-project-install/lib/ | head -20
+          else
+            echo "ERROR: LLVM not found at build/llvm-project-install"
+            exit 1
+          fi
+
       - name: Configure CMake
         run: |
           cmake --preset default --fresh \
             -DSLANG_ENABLE_CUDA=ON \
-            -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
+            -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM
 
       - name: Build Slang
         run: |


### PR DESCRIPTION
Apply workaround from github.com/orgs/community/discussions/170315: mount /home/runner and add NET_ADMIN/NET_RAW capabilities.

Use existing ghcr.io/shader-slang/slang-linux-gpu-ci:v1.3.0 image. Remove prerequisite installation steps (pre-installed in container).