### PR TITLE
dynamic dispatch: diagnostic for interface-typed field

### DIFF
--- a/source/slang/slang-diagnostic-defs.h
+++ b/source/slang/slang-diagnostic-defs.h
@@ -2599,6 +2599,11 @@ DIAGNOSTIC(
 
 DIAGNOSTIC(41000, Warning, unreachableCode, "unreachable code detected")
 DIAGNOSTIC(41001, Error, recursiveType, "type '$0' contains cyclic reference to itself.")
+DIAGNOSTIC(
+    41002,
+    Error,
+    cyclicInterfaceDependency,
+    "interface '$0' has cyclic dependency on itself through its implementations.")
 
 DIAGNOSTIC(
     41009,

--- a/tests/language-feature/dynamic-dispatch/interface-field-in-implementation.slang
+++ b/tests/language-feature/dynamic-dispatch/interface-field-in-implementation.slang
@@ -1,0 +1,37 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+
+// Test for issue #9835: Error when ALL implementations of an interface
+// contain self-referential fields (no base case for AnyValue size calculation).
+//
+// The check is done at IR level during AnyValue size inference.
+
+// CHECK: error 41002: interface 'IFoo' has cyclic dependency on itself through its implementations.
+
+interface IFoo
+{
+    float compute(float x);
+}
+
+// ALL implementations are self-referential - this is the error case.
+// There's no base case to calculate the AnyValue size.
+
+export struct BadImpl1 : IFoo
+{
+    IFoo inner;  // Self-referential
+    float compute(float x) { return inner.compute(x) + 1.0f; }
+}
+
+export struct BadImpl2 : IFoo
+{
+    IFoo other;  // Also self-referential
+    float compute(float x) { return other.compute(x) * 2.0f; }
+}
+
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    IFoo f = createDynamicObject<IFoo>(0, 1.0f);
+    outputBuffer[0] = f.compute(1.0f);
+}


### PR DESCRIPTION
Fixes #9835 

Add diagnostic for cyclic interface dependencies in interface implementations (#9835)

When ALL implementations of an interface contain interface-typed fields (IFoo, IFoo[], or other interface types) that reference the same interface, it creates infinite recursion in the existential representation (AnyValue size cannot be calculated).

This adds error 41002 which is emitted during AnyValue size inference in the IR lowering phase when such cyclic dependencies are detected.

The check:
- Separates implementations into self-referential and non-self-referential
- First calculates size from non-self-referential impls (base case)
- Only errors if ALL implementations are self-referential (no base case)

This allows valid patterns like CompositeTransformer (which has non-self-referential base impls) while catching truly cyclic cases.

Changes:
- Added error 41002: cyclicInterfaceDependency in slang-diagnostic-defs.h
- Modified inferAnyValueSizeWhereNecessary() in slang-ir-any-value-inference.cpp
- Added test case in tests/language-feature/dynamic-dispatch/