### PR TITLE
Fix the scope issue when lowering diffPtrType

### DIFF
--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -718,12 +718,6 @@ bool isImportedDecl(IRGenContext* context, Decl* decl, bool& outIsExplicitExtern
     return false;
 }
 
-bool isAbstractWitnessTable(IRInst* inst);
-static IRInst* maybeCloneThisTypeWitness(
-    IRGenContext* context,
-    IRInst* thisTypeWitness,
-    Type* thisType);
-
 /// Should the given `decl` nested in `parentDecl` be treated as a static rather than instance
 /// declaration?
 bool isEffectivelyStatic(Decl* decl, ContainerDecl* parentDecl);
@@ -2317,7 +2311,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
 
         auto isRefThisTypeWitness = [](IRInst* inst) -> IRThisTypeWitness*
         {
-            for(;;)
+            for (;;)
             {
                 if (auto thisTypeWitness = as<IRThisTypeWitness>(inst))
                     return thisTypeWitness;
@@ -2353,7 +2347,8 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
                 {
                     // Clone the ThisTypeWitness at current insert location
                     // The constraint type is stored in the witness table type, not as an operand
-                    auto witnessTableType = as<IRWitnessTableTypeBase>(thisTypeWitness->getDataType());
+                    auto witnessTableType =
+                        as<IRWitnessTableTypeBase>(thisTypeWitness->getDataType());
                     SLANG_ASSERT(witnessTableType);
                     auto constraintType = (IRType*)witnessTableType->getConformanceType();
                     auto newThisTypeWitness = getBuilder()->createThisTypeWitness(constraintType);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -2309,7 +2309,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
                     operands.add(argVal);
                 });
 
-        auto isRefThisTypeWitness = [](IRInst* inst) -> IRThisTypeWitness*
+        auto findThisTypeWitness = [](IRInst* inst) -> IRThisTypeWitness*
         {
             for (;;)
             {
@@ -2326,7 +2326,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
 
         for (Index i = 0; i < operands.getCount(); i++)
         {
-            if (auto thisTypeWitness = isRefThisTypeWitness(operands[i]))
+            if (auto thisTypeWitness = findThisTypeWitness(operands[i]))
             {
                 // Check if thisTypeWitness is already in scope at current insert location
                 auto currentInsertLoc = getBuilder()->getInsertLoc().getParent();

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -2346,7 +2346,7 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
                 if (needsClone)
                 {
                     // Clone the ThisTypeWitness at current insert location
-                    // The constraint type is stored in the witness table type, not as an operand
+                    // because it exists in the interface scope that is not accessible from here.
                     auto witnessTableType =
                         as<IRWitnessTableTypeBase>(thisTypeWitness->getDataType());
                     SLANG_ASSERT(witnessTableType);

--- a/tests/autodiff/diff-ptr-type-generic.slang
+++ b/tests/autodiff/diff-ptr-type-generic.slang
@@ -1,0 +1,54 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -cuda -compute -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+interface IBufferPointer<T> : IDifferentiablePtrType
+{
+    [Differentiable]
+    T load(uint idx);
+}
+
+struct MyBufferPointer<T> : IBufferPointer<T>
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+{
+    typealias Differential = MyBufferPointer<T.Differential>;
+
+    RWStructuredBuffer<T> buf;
+    uint offset;
+
+    [BackwardDerivative(load_bwd)]
+    T load(uint idx) { return buf[offset + idx]; }
+
+    static void load_bwd(DifferentialPtrPair<This> pair, uint idx, T.Differential grad)
+    {
+        pair.d.buf[pair.d.offset + idx] += grad;
+    }
+}
+
+[Differentiable]
+float test(MyBufferPointer<float> p, uint idx)
+{
+    return p.load(idx) + p.load(idx + 1);
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint id : SV_DispatchThreadID)
+{
+    outputBuffer[0] = 1; // CHECK: 1
+    outputBuffer[1] = 2; // CHECK: 2
+
+    // Denote the first two elements in the buffer as the primal buffer and the last two elements for the derivative.
+    MyBufferPointer<float> p = { outputBuffer, 0 };
+    MyBufferPointer<float>.Differential dp = { outputBuffer, 2 };
+    var pair = DifferentialPtrPair<MyBufferPointer<float>>(p, dp);
+
+    bwd_diff(test)(pair, 0, 1.5f);
+
+    // Check locations [2] and [3] in the buffer
+    // CHECK: 1.5
+    // CHECK: 1.5
+}


### PR DESCRIPTION
Close #9879.

This PR fixes a scope issue when lowering `DifferentialPtrPairType` in generic interface methods. The problem occurs when a `IRThisTypeWitness` remains in the scope of a generic interface while being used in a method inserted in a different scope, requiring the witness to be cloned to the current insertion location.

Changes:

- Adds logic to detect and clone `IRThisTypeWitness` instances that are out of scope during type lowering
- Adds a regression test for differential pointer types with generic interfaces