### PR TITLE
dynamic dispatch: add test for interface pointer field in implementation (#9836)

### DIFF
--- a/tests/language-feature/dynamic-dispatch/interface-ptr-in-impl.slang
+++ b/tests/language-feature/dynamic-dispatch/interface-ptr-in-impl.slang
@@ -99,6 +99,6 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     outputBuffer[2] = callThroughInterface(typeSelector[2], 10.0);  // CHECK: 10.0
     
     // Test 4: SimpleImpl again
-    // typeSelector[3] = 2 → SimpleImpl, value = 5.0, result = 5.0 * 2.0 = 10.0
-    outputBuffer[3] = callThroughInterface(typeSelector[3], 5.0);   // CHECK: 10.0
+    // typeSelector[3] = 2 → SimpleImpl, value = 4.0, result = 4.0 * 2.0 = 8.0
+    outputBuffer[3] = callThroughInterface(typeSelector[3], 4.0);   // CHECK: 8.0
 }


### PR DESCRIPTION
Fixes #9836

Add test verifying that an interface implementation can contain a pointer to
that interface (`IFoo*`), which is valid because pointers have fixed size
regardless of the pointee type.

The test uses dynamic dispatch (concrete type selected at runtime via input
buffer) to verify that `GoodImpl` with an `IFoo*` field participates correctly
in existential packing and dispatch.

- Adds `tests/language-feature/dynamic-dispatch/interface-ptr-in-impl.slang`
- Tests on CPU, CUDA, Vulkan (`-emit-spirv-directly`), and LLVM backends
- Includes `-report-dynamic-dispatch-sites` check confirming dispatch code
  is generated for 2 possible types
- No compiler changes needed — the `IFoo*` field already compiles correctly

Note: The `IFoo*` pointer is only initialized to `nullptr` in this test.
Testing actual pointer dereferencing (`ptr->foo()`) requires slang-test
infrastructure to embed device addresses in buffer data. See #10015.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes in This PR

This PR introduces a new regression test file and makes **no changes to the Slang compiler itself**. 

### File Changes
- **Added**: `tests/language-feature/dynamic-dispatch/interface-ptr-in-impl.slang` (+104 lines)
  - A test verifying that a struct implementing an interface can contain a pointer field to that interface (e.g., `IFoo*`)
  - Tests dynamic dispatch scenarios on CPU, CUDA, Vulkan (with `-emit-spirv-directly`), and LLVM backends
  - Includes a `-report-dynamic-dispatch-sites` check confirming dispatch code generation

### Compiler Impact
- **Compiler Stages Affected**: None
  - No changes to lexer, parser, semantic analysis, IR, or code generation
  - The feature already works; this PR adds test coverage for existing functionality

- **Target Backends Affected**: None
  - The test validates existing support across CPU, CUDA, Vulkan, and LLVM
  - No backend modifications required

- **Public API Headers**: None
  - No changes to `include/slang.h`, `slang-com-helper.h`, or other public APIs

### Summary
This is a pure test addition that validates the compiler already correctly handles interface pointers in struct implementations as a consequence of pointer types having fixed size independent of the pointee type. The PR addresses issue #9836 by confirming this capability works end-to-end with dynamic dispatch across multiple target platforms, without requiring any compiler changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->