### PR TITLE
neural slang: expose Layout as generic parameter

### DIFF
--- a/source/standard-modules/neural/ilayer.slang
+++ b/source/standard-modules/neural/ilayer.slang
@@ -7,10 +7,11 @@ so it does not imply dynamic dispatch.
 
 @category neural
 */
-public interface ILayer<T, InputVector, OutputVector, Storage, Activation>
+public interface ILayer<T, InputVector, OutputVector, Storage, Layout, Activation>
     where T : __BuiltinFloatingPointType
     where T.Differential == T
     where Storage : IStorage<T>
+    where Layout : IStorageLayout
     where InputVector : IVector<T>
     where OutputVector : IVector<T>
     where Activation : IActivation<T>

--- a/source/standard-modules/neural/layers.slang
+++ b/source/standard-modules/neural/layers.slang
@@ -14,7 +14,7 @@ suitable for building multi-layer perceptrons (MLPs) and similar architectures.
 
 1. **Construction:** Create a layer with weight/bias addresses pointing into your storage:
    ```
-   let layer = FFLayer<float, Vec4, Vec2, Storage, ReLU<float>>(weightAddr, biasAddr);
+   let layer = FFLayer<float, Vec4, Vec2, Storage, LinearLayout, ReLU<float>>(weightAddr, biasAddr);
    ```
 
 2. **Forward pass:** Call `eval()` with storage and input:
@@ -31,7 +31,7 @@ suitable for building multi-layer perceptrons (MLPs) and similar architectures.
 4. **With custom activation parameters** (e.g., LeakyReLU with custom alpha):
    ```
    let leakyRelu = LeakyReLU<float>(0.2);  // alpha = 0.2
-   let layer = FFLayer<float, Vec4, Vec2, Storage, LeakyReLU<float>>(weightAddr, biasAddr, leakyRelu);
+   let layer = FFLayer<float, Vec4, Vec2, Storage, LinearLayout, LeakyReLU<float>>(weightAddr, biasAddr, leakyRelu);
    ```
 
 ## Parameter Layout
@@ -49,13 +49,15 @@ public struct FFLayer<
     InputVector,
     OutputVector,
     Storage,
+    Layout,
     Activation,
     let HasBias : bool = true
 >
-    : ILayer<T, InputVector, OutputVector, Storage, Activation>
+    : ILayer<T, InputVector, OutputVector, Storage, Layout, Activation>
     where T : __BuiltinFloatingPointType
     where T.Differential == T
     where Storage : IStorage<T>
+    where Layout : IStorageLayout
     where InputVector : IVector<T>
     where OutputVector : IVector<T>
     where Activation : IActivation<T>
@@ -110,12 +112,12 @@ public struct FFLayer<
         OutputVector y;
         if(HasBias)
         {
-            y = input.linearTransform<S, LinearLayout, OutputVector>(
+            y = input.linearTransform<S, Layout, OutputVector>(
                 storage, storage, weightAddress, biasAddress);
         }
         else
         {
-            y = input.linearTransform<S, LinearLayout, OutputVector>(
+            y = input.linearTransform<S, Layout, OutputVector>(
                 storage, weightAddress);
         }
         return activation.eval<OutputVector>(y);
@@ -137,13 +139,13 @@ public struct FFLayer<
         OutputVector y;
         if(HasBias)
         {
-            y = input.linearTransform<S, LinearLayout, OutputVector>(
+            y = input.linearTransform<S, Layout, OutputVector>(
                 weightStorage, biasStorage, weightAddress, biasAddress);
         }
         else
         {
             // Bias is disabled; ignore biasStorage.
-            y = input.linearTransform<S, LinearLayout, OutputVector>(
+            y = input.linearTransform<S, Layout, OutputVector>(
                 weightStorage, weightAddress);
         }
         return activation.eval<OutputVector>(y);
@@ -163,11 +165,11 @@ public struct FFLayer<
         OutputVector y;
         if(HasBias)
         {
-            y = input.linearTransform<A, LinearLayout, OutputVector>(weightAddr, biasAddr);
+            y = input.linearTransform<A, Layout, OutputVector>(weightAddr, biasAddr);
         }
         else
         {
-            y = input.linearTransform<A, LinearLayout, OutputVector>(weightAddr);
+            y = input.linearTransform<A, Layout, OutputVector>(weightAddr);
         }
         return act.eval<OutputVector>(y);
     }

--- a/tests/neural/activation-with-fflayer-test.slang
+++ b/tests/neural/activation-with-fflayer-test.slang
@@ -42,7 +42,7 @@ bool testFFLayerReLU()
     setupParams();
     let storage = Storage(params);
     
-    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, ReLU<float>, true>;
+    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, LinearLayout, ReLU<float>, true>;
     let layer = Layer(0, 4);  // weights at 0, bias at 4
     
     float[2] arr = {-1.0, 2.0};
@@ -61,7 +61,7 @@ bool testFFLayerLeakyReLU()
     setupParams();
     let storage = Storage(params);
     
-    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, LeakyReLU<float>, true>;
+    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, LinearLayout, LeakyReLU<float>, true>;
     let leakyRelu = LeakyReLU<float>(0.1);  // alpha = 0.1
     let layer = Layer(0, 4, leakyRelu);
     
@@ -81,7 +81,7 @@ bool testFFLayerSigmoid()
     setupParams();
     let storage = Storage(params);
     
-    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, Sigmoid<float>, true>;
+    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, LinearLayout, Sigmoid<float>, true>;
     let layer = Layer(0, 4);
     
     float[2] arr = {0.0, 0.0};
@@ -100,7 +100,7 @@ bool testFFLayerTanh()
     setupParams();
     let storage = Storage(params);
     
-    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, TanhActivation<float>, true>;
+    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, LinearLayout, TanhActivation<float>, true>;
     let layer = Layer(0, 4);
     
     float[2] arr = {0.0, 0.0};
@@ -119,7 +119,7 @@ bool testFFLayerExp()
     setupParams();
     let storage = Storage(params);
     
-    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, ExpActivation<float>, true>;
+    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, LinearLayout, ExpActivation<float>, true>;
     let layer = Layer(0, 4);
     
     float[2] arr = {0.0, 0.0};
@@ -138,7 +138,7 @@ bool testFFLayerIdentity()
     setupParams();
     let storage = Storage(params);
     
-    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, IdentityActivation<float>, true>;
+    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, LinearLayout, IdentityActivation<float>, true>;
     let layer = Layer(0, 4);
     
     float[2] arr = {-1.0, 2.0};
@@ -157,7 +157,7 @@ bool testFFLayerSine()
     setupParams();
     let storage = Storage(params);
     
-    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, SineActivation<float>, true>;
+    typealias Layer = FFLayer<float, Vec2, Vec2, Storage, LinearLayout, SineActivation<float>, true>;
     let layer = Layer(0, 4);
     
     float pi = 3.14159265;

--- a/tests/neural/basic-ilayer-ffn-training-test.slang
+++ b/tests/neural/basic-ilayer-ffn-training-test.slang
@@ -31,8 +31,8 @@ typealias Storage = StructuredBufferStorage<float>;
 typealias V2 = InlineVector<float, 2>;
 typealias V1 = InlineVector<float, 1>;
 typealias Act = IdentityActivation<float>;
-typealias Layer1 = FFLayer<float, V2, V2, Storage, Act, true>;
-typealias Layer2 = FFLayer<float, V2, V1, Storage, Act, true>;
+typealias Layer1 = FFLayer<float, V2, V2, Storage, LinearLayout, Act, true>;
+typealias Layer2 = FFLayer<float, V2, V1, Storage, LinearLayout, Act, true>;
 
 static const uint Base0 = 0;
 

--- a/tests/neural/basic-ilayer-frontend-smoke-test.slang
+++ b/tests/neural/basic-ilayer-frontend-smoke-test.slang
@@ -22,14 +22,14 @@ typealias Storage = StructuredBufferStorage<float>;
 typealias XVec = InlineVector<float, 4>;
 typealias YVec = InlineVector<float, 2>;
 typealias Act = ReLU<float>;
-typealias Layer = FFLayer<float, XVec, YVec, Storage, Act, true>;
+typealias Layer = FFLayer<float, XVec, YVec, Storage, LinearLayout, Act, true>;
 
 // Test: evaluate layer through ILayer constraint
 InlineVector<float, 2> evalAsLayer<L>(
     L layer,
     Storage storage,
     InlineVector<float, 4> input)
-    where L : ILayer<float, InlineVector<float, 4>, InlineVector<float, 2>, Storage, Act>
+    where L : ILayer<float, InlineVector<float, 4>, InlineVector<float, 2>, Storage, LinearLayout, Act>
 {
     return layer.eval<Storage>(storage, input);
 }

--- a/tests/neural/fflayer-autodiff-backward-test.slang
+++ b/tests/neural/fflayer-autodiff-backward-test.slang
@@ -19,7 +19,7 @@ RWStructuredBuffer<uint> testResult;
 typealias Storage = StructuredBufferStorage<float>;
 typealias Vec2 = InlineVector<float, 2>;
 typealias Act = IdentityActivation<float>;
-typealias Layer = FFLayer<float, Vec2, Vec2, Storage, Act, true>;
+typealias Layer = FFLayer<float, Vec2, Vec2, Storage, LinearLayout, Act, true>;
 
 bool approxEqual(float a, float b, float eps = 0.001)
 {

--- a/tests/neural/fflayer-two-storage-forward-test.slang
+++ b/tests/neural/fflayer-two-storage-forward-test.slang
@@ -22,7 +22,7 @@ typealias Storage = StructuredBufferStorage<float>;
 typealias Vec2 = InlineVector<float, 2>;
 typealias Vec1 = InlineVector<float, 1>;
 typealias Act = IdentityActivation<float>;
-typealias Layer = FFLayer<float, Vec2, Vec1, Storage, Act, true>;
+typealias Layer = FFLayer<float, Vec2, Vec1, Storage, LinearLayout, Act, true>;
 
 bool approxEqual(float a, float b, float eps = 0.001)
 {

--- a/tests/neural/fflayer-wavetangled-vector-test.slang
+++ b/tests/neural/fflayer-wavetangled-vector-test.slang
@@ -1,0 +1,179 @@
+// Test FFLayer with WaveTangledVector (CooperativeMatrix accelerated).
+// This verifies that FFLayer works with non-InlineVector types using Layout parameter.
+//
+// TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly
+// TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0 -xslang -experimental-feature
+
+import neural;
+
+typealias ElementType = float;
+
+// set up a 2x4 matrix for input parameters, the last 2 elements are for bias
+// W = [[1,2,3,4],[5,6,7,8]], b = [9, 10]
+//TEST_INPUT: ubuffer(data=[1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0], stride=4):name=parametersFloat
+RWStructuredBuffer<float> parametersFloat;
+
+//TEST_INPUT: ubuffer(data=[0 0 0 0 0 0 0 0 0 0], stride=4):name=parameters
+RWStructuredBuffer<ElementType> parameters;
+
+// Create a buffer to store the test result
+//TEST_INPUT: ubuffer(data=[0 0 0], stride=4):out,name=testResult
+RWStructuredBuffer<uint> testResult;
+
+//TEST_INPUT: ubuffer(data=[0 0 0 0 0 0 0 0 0 0], stride=4):name=dParameters
+RWStructuredBuffer<ElementType> dParameters;
+
+typealias Storage = StructuredBufferStorage<ElementType>;
+
+static const int InputSize = 4;
+static const int OutputSize = 2;
+static const int BatchSize = 32;
+static const int SubgroupSize = 32;
+
+typealias ShMemSize = SharedMemorySize<ElementType, TargetEnum.CUDA, ExecutionMode.Training, SubgroupSize, BatchSize / SubgroupSize>;
+typealias ShMemSizeLayer1 = ShMemSize.OfLayer1<InputSize, OutputSize>;
+typealias ShMemPool = SharedMemoryPool<ShMemSizeLayer1>;
+
+typealias InVec = WaveTangledVector<ElementType, ShMemPool, InputSize, SubgroupSize>;
+typealias OutVec = WaveTangledVector<ElementType, ShMemPool, OutputSize, SubgroupSize>;
+
+// FFLayer with WaveTangledVector and LinearLayout
+typealias Layer = FFLayer<ElementType, InVec, OutVec, Storage, LinearLayout, IdentityActivation<ElementType>, true>;
+
+// Wrapper function for autodiff
+[Differentiable]
+OutVec computeLayerOutput(Storage storage, InVec input, Layer layer)
+{
+    return layer.eval<Storage>(storage, input);
+}
+
+// Test FFLayer forward pass with WaveTangledVector
+void testFFLayerForward(int tid, int resIndex)
+{
+    // Input: x = [1, 2, 3, 4]
+    // W = [[1,2,3,4],[5,6,7,8]], b = [9, 10]
+    // Output: W*x + b = [1*1+2*2+3*3+4*4+9, 5*1+6*2+7*3+8*4+10] = [39, 80]
+    
+    ElementType[InputSize] inputData = { ElementType(1.0), ElementType(2.0), ElementType(3.0), ElementType(4.0) };
+    InVec input = InVec(inputData);
+    
+    Storage storage = Storage(parameters);
+    
+    // Create layer with weights at offset 0, bias at offset 8
+    let layer = Layer(0, 8);
+    
+    // Forward pass
+    let output = layer.eval<Storage>(storage, input);
+    
+    // Verify output: [39, 80]
+    bool isPassed = true;
+    isPassed = isPassed && (output[0] == ElementType(39.0));
+    isPassed = isPassed && (output[1] == ElementType(80.0));
+    
+    isPassed = WaveActiveAllTrue(isPassed);
+    if (tid == 0)
+    {
+        testResult[resIndex] = isPassed ? 1 : 0;
+    }
+}
+
+// Test FFLayer backward pass with WaveTangledVector (autodiff)
+void testFFLayerBackward(int tid, int resIndex)
+{
+    ElementType[InputSize] inputData = { ElementType(1.0), ElementType(2.0), ElementType(3.0), ElementType(4.0) };
+    InVec input = InVec(inputData);
+    
+    Storage storage = Storage(parameters);
+    Storage dStorage = Storage(dParameters);
+    
+    let layer = Layer(0, 8);
+    
+    // Set up differential pair for storage
+    var storagePair = DifferentialPtrPair<Storage>(storage, dStorage);
+    var inputPair = diffPair(input);
+    
+    // dOutput = [1, 1]
+    let dOutput = OutVec(1.0);
+    
+    // Backward pass
+    bwd_diff(computeLayerOutput)(storagePair, inputPair, layer, dOutput);
+    
+    // Verify input gradient: dInput = W^T * dOutput = [1+5, 2+6, 3+7, 4+8] = [6, 8, 10, 12]
+    bool isPassed = true;
+    isPassed = isPassed && (inputPair.d[0] == ElementType(6.0));
+    isPassed = isPassed && (inputPair.d[1] == ElementType(8.0));
+    isPassed = isPassed && (inputPair.d[2] == ElementType(10.0));
+    isPassed = isPassed && (inputPair.d[3] == ElementType(12.0));
+    
+    // Weight gradients are accumulated across 32 threads
+    // dW = dOutput * input^T = [1,1]^T * [1,2,3,4] = [[1,2,3,4],[1,2,3,4]]
+    // Accumulated: 32 * [[1,2,3,4],[1,2,3,4]]
+    isPassed = isPassed && (dParameters[0] == ElementType(32.0));
+    isPassed = isPassed && (dParameters[1] == ElementType(64.0));
+    isPassed = isPassed && (dParameters[2] == ElementType(96.0));
+    isPassed = isPassed && (dParameters[3] == ElementType(128.0));
+    isPassed = isPassed && (dParameters[4] == ElementType(32.0));
+    isPassed = isPassed && (dParameters[5] == ElementType(64.0));
+    isPassed = isPassed && (dParameters[6] == ElementType(96.0));
+    isPassed = isPassed && (dParameters[7] == ElementType(128.0));
+    
+    // Bias gradients: dBias = dOutput = [1, 1], accumulated: [32, 32]
+    isPassed = isPassed && (dParameters[8] == ElementType(32.0));
+    isPassed = isPassed && (dParameters[9] == ElementType(32.0));
+    
+    isPassed = WaveActiveAllTrue(isPassed);
+    if (tid == 0)
+    {
+        testResult[resIndex] = isPassed ? 1 : 0;
+    }
+}
+
+// Test FFLayer ParameterCount with WaveTangledVector
+void testFFLayerParameterCount(int tid, int resIndex)
+{
+    // For 4->2 layer with bias: 4*2 + 2 = 10
+    bool isPassed = (Layer.ParameterCount == 10);
+    
+    isPassed = WaveActiveAllTrue(isPassed);
+    if (tid == 0)
+    {
+        testResult[resIndex] = isPassed ? 1 : 0;
+    }
+}
+
+void cleanupDParameters()
+{
+    for (int i = 0; i < 10; i++)
+    {
+        dParameters[i] = ElementType(0.0);
+    }
+}
+
+void setupParameters(uint tid)
+{
+    if (tid == 0)
+    {
+        for (int i = 0; i < 10; i++)
+        {
+            parameters[i] = ElementType(parametersFloat[i]);
+        }
+    }
+}
+
+[shader("compute")]
+[numthreads(BatchSize, 1, 1)]
+void computeMain(uint tid : SV_DispatchThreadID)
+{
+    setupParameters(tid);
+    GroupMemoryBarrierWithWaveSync();
+    
+    testFFLayerParameterCount(tid, 0);
+    // BUFFER: 1
+    
+    testFFLayerForward(tid, 1);
+    // BUFFER: 1
+    
+    cleanupDParameters();
+    testFFLayerBackward(tid, 2);
+    // BUFFER: 1
+}


### PR DESCRIPTION
Fixes #9914 

expose Layout as generic parameter in ILayer/FFLayer Fix bug where FFLayer hardcoded LinearLayout in eval() method, preventing use with WaveTangledVector and other memory layouts.

Changes:
- Add Layout : IStorageLayout as generic parameter to ILayer interface
- Add Layout : IStorageLayout as generic parameter to FFLayer struct
- Update linearTransform calls to use generic Layout instead of hardcoded LinearLayout
- Update all existing FFLayer tests to include LinearLayout parameter
- Add new test fflayer-wavetangled-vector-test.slang for WaveTangledVector