### PR TITLE
Dynamic dispatch: add test for dynamic dispatch with interface parameters (#9838)

### DIFF
--- a/tests/language-feature/dynamic-dispatch/dynamic-dispatch-params.slang
+++ b/tests/language-feature/dynamic-dispatch/dynamic-dispatch-params.slang
@@ -1,4 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cpu -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
 //TEST:SIMPLE(filecheck=REPORT):-target hlsl -stage compute -entry computeMain -report-dynamic-dispatch-sites -conformance "FooA:IFoo=0" -conformance "FooB:IFoo=1" -conformance "BarA:IBar=0" -conformance "BarB:IBar=1" -conformance "MulCombiner:ICombiner=0" -conformance "AddCombiner:ICombiner=1"


### PR DESCRIPTION
Fixes #9838

Test Interface methods that take other dynamically-typed interface parameters should work correctly.

This tests nested dynamic dispatch where ICombiner.combine takes IFoo and IBar as existential parameters.

- Uses `createDynamicObject` to force runtime type selection (prevents compiler specialization)
- Tests on multiple backends: default, Vulkan (-vk), and CUDA (-cuda)
- Verifies dynamic dispatch code generation with REPORT checks