### PR TITLE
Fix debug source mapping for #line remapped locations

### DIFF
--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -7923,21 +7923,54 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
     }
 };
 
-IRInst* getOrEmitDebugSource(IRGenContext* context, PathInfo path)
+IRInst* getOrEmitDebugSource(IRGenContext* context, SourceLoc loc)
 {
-    if (auto result = context->shared->mapSourcePathToDebugSourceInst.tryGetValue(path.foundPath))
-        return *result;
+    auto sourceManager = context->getLinkage()->getSourceManager();
+    auto sourceView = sourceManager->findSourceView(loc);
+    if (!sourceView)
+        return nullptr;
 
+    IRInst* debugSourceInst = nullptr;
+
+    // Do a best-effort attempt to retrieve the nominal source file.
+    auto pathInfo = sourceView->getPathInfo(loc, SourceLocType::Emit);
+    String sourcePath = pathInfo.getName();
+
+    // If the source file path corresponds to an existing SourceFile in the source manager, use it.
+    auto source = sourceManager->findSourceFileByPathRecursively(sourcePath);
+    if (!source)
+    {
+        sourcePath = pathInfo.getMostUniqueIdentity();
+        source = sourceManager->findSourceFile(sourcePath);
+    }
+    if (source &&
+        context->shared->mapSourceFileToDebugSourceInst.tryGetValue(source, debugSourceInst))
+    {
+        return debugSourceInst;
+    }
+
+    if (sourcePath.getLength() == 0)
+    {
+        return nullptr;
+    }
+
+    if (context->shared->mapSourcePathToDebugSourceInst.tryGetValue(sourcePath, debugSourceInst))
+    {
+        return debugSourceInst;
+    }
+
+    // If the source manager does not have an entry for the corresponding file name, make sure we
+    // still emit a source file entry in the spirv module.
     ComPtr<ISlangBlob> outBlob;
     UnownedStringSlice content;
 
     // Only embed source content for Standard and Maximal debug level
     if (context->debugInfoLevel >= DebugInfoLevel::Standard)
     {
-        if (path.hasFileFoundPath())
+        if (pathInfo.hasFileFoundPath())
         {
             context->getLinkage()->getFileSystemExt()->loadFile(
-                path.foundPath.getBuffer(),
+                pathInfo.foundPath.getBuffer(),
                 outBlob.writeRef());
         }
         if (outBlob)
@@ -7947,9 +7980,13 @@ IRInst* getOrEmitDebugSource(IRGenContext* context, PathInfo path)
 
     IRBuilder builder(*context->irBuilder);
     builder.setInsertInto(context->irBuilder->getModule());
-    auto debugSrcInst = builder.emitDebugSource(path.foundPath.getUnownedSlice(), content, false);
-    context->shared->mapSourcePathToDebugSourceInst[path.foundPath] = debugSrcInst;
-    return debugSrcInst;
+    debugSourceInst = builder.emitDebugSource(sourcePath.getUnownedSlice(), content, false);
+    context->shared->mapSourcePathToDebugSourceInst[sourcePath] = debugSourceInst;
+    if (source)
+    {
+        context->shared->mapSourceFileToDebugSourceInst.add(source, debugSourceInst);
+    }
+    return debugSourceInst;
 }
 
 void maybeEmitDebugLine(
@@ -7971,31 +8008,13 @@ void maybeEmitDebugLine(
             loc = stmt->loc;
     }
 
-    auto sourceManager = context->getLinkage()->getSourceManager();
-    auto sourceView = sourceManager->findSourceView(loc);
-    if (!sourceView)
+    IRInst* debugSourceInst = getOrEmitDebugSource(context, loc);
+    if (!debugSourceInst)
         return;
 
-    IRInst* debugSourceInst = nullptr;
+    auto sourceManager = context->getLinkage()->getSourceManager();
     auto humaneLoc = sourceManager->getHumaneLoc(loc, SourceLocType::Emit);
 
-    // Do a best-effort attempt to retrieve the nominal source file.
-    auto pathInfo = sourceView->getPathInfo(loc, SourceLocType::Emit);
-
-    // If the source file path correspond to an existing SourceFile in the source manager, use it.
-    auto source = sourceManager->findSourceFileByPathRecursively(pathInfo.foundPath);
-    if (!source)
-        source = sourceManager->findSourceFile(pathInfo.getMostUniqueIdentity());
-    if (source)
-    {
-        context->shared->mapSourceFileToDebugSourceInst.tryGetValue(source, debugSourceInst);
-    }
-    // If the source manager does not have an entry for the corresponding file name, make sure we
-    // still emit an source file entry in the spirv module.
-    if (!debugSourceInst)
-    {
-        debugSourceInst = getOrEmitDebugSource(context, pathInfo);
-    }
     if (visitor)
         visitor->startBlockIfNeeded(stmt);
     context->irBuilder->emitDebugLine(
@@ -8011,19 +8030,16 @@ void maybeAddDebugLocationDecoration(IRGenContext* context, IRInst* inst)
     // Only emit debug location info if debug level is at least Minimal
     if (context->debugInfoLevel == DebugInfoLevel::None)
         return;
-    auto sourceView = context->getLinkage()->getSourceManager()->findSourceView(inst->sourceLoc);
-    if (!sourceView)
+
+    IRInst* debugSourceInst = getOrEmitDebugSource(context, inst->sourceLoc);
+    if (!debugSourceInst)
         return;
-    auto source = sourceView->getSourceFile();
-    IRInst* debugSourceInst = nullptr;
-    if (context->shared->mapSourceFileToDebugSourceInst.tryGetValue(source, debugSourceInst))
-    {
-        auto humaneLoc = context->getLinkage()->getSourceManager()->getHumaneLoc(
-            inst->sourceLoc,
-            SourceLocType::Emit);
-        context->irBuilder
-            ->addDebugLocationDecoration(inst, debugSourceInst, humaneLoc.line, humaneLoc.column);
-    }
+
+    auto sourceManager = context->getLinkage()->getSourceManager();
+    auto humaneLoc = sourceManager->getHumaneLoc(inst->sourceLoc, SourceLocType::Emit);
+
+    context->irBuilder
+        ->addDebugLocationDecoration(inst, debugSourceInst, humaneLoc.line, humaneLoc.column);
 }
 
 void lowerStmt(IRGenContext* context, Stmt* stmt)
@@ -9718,29 +9734,21 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                         SourceLocType::Emit);
 
                     // Find the debug source for this file
-                    auto sourceView =
-                        context->getLinkage()->getSourceManager()->findSourceView(decl->loc);
-                    if (sourceView)
+                    IRInst* debugSourceInst = getOrEmitDebugSource(context, decl->loc);
+                    if (debugSourceInst)
                     {
-                        auto source = sourceView->getSourceFile();
-                        IRInst* debugSourceInst = nullptr;
-                        if (context->shared->mapSourceFileToDebugSourceInst.tryGetValue(
-                                source,
-                                debugSourceInst))
-                        {
-                            auto debugVar = builder->emitDebugVar(
-                                varType,
-                                debugSourceInst,
-                                builder->getIntValue(builder->getUIntType(), humaneLoc.line),
-                                builder->getIntValue(builder->getUIntType(), humaneLoc.column),
-                                nullptr);
+                        auto debugVar = builder->emitDebugVar(
+                            varType,
+                            debugSourceInst,
+                            builder->getIntValue(builder->getUIntType(), humaneLoc.line),
+                            builder->getIntValue(builder->getUIntType(), humaneLoc.column),
+                            nullptr);
 
-                            // Copy name hint from the declaration
-                            addNameHint(context, debugVar, decl);
+                        // Copy name hint from the declaration
+                        addNameHint(context, debugVar, decl);
 
-                            // Emit debug value to associate the constant with the debug variable
-                            builder->emitDebugValue(debugVar, initVal.val);
-                        }
+                        // Emit debug value to associate the constant with the debug variable
+                        builder->emitDebugValue(debugVar, initVal.val);
                     }
                 }
 

--- a/tests/preprocessor/line.slang
+++ b/tests/preprocessor/line.slang
@@ -1,19 +1,26 @@
-//TEST:SIMPLE:
+//TEST:SIMPLE(filecheck=CHECK):
 // #line support
+// Foo* is not defined so expect diagnostics for each function
 
+//CHECK: line.slang([[#@LINE+1]]):
 FooA a() { return 0; }
 
+//CHECK: b.slang(99):
 #line 99 "b.slang"
 FooB b() { return 0; }
 
+//CHECK: line.slang([[#@LINE+2]]):
 #line default
 FooC c() { return 0; }
 
+//CHECK: d.slang(603):
 #line 603 "d.slang"
 FooD d() { return 0; }
 
+//CHECK: d.slang(40):
 #line 40
 FooE e() { return 0; }
 
+//CHECK: line.slang([[#@LINE+2]]):
 #line
 FooF f() { return 0; }

--- a/tests/spirv/debug-info-line-function.slang
+++ b/tests/spirv/debug-info-line-function.slang
@@ -1,0 +1,64 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -g2 -O0 -preserve-embedded-source
+// Tests generation of DebugFunction and DebugLine with #line preprocessor directive specifying different files
+
+// Get the IDs for the Source argument in DebugFunction/DebugLine
+//CHECK-DAG: [[DEBUGINFOLINE_FILE:%[0-9]+]] = OpString {{.*}}debug-info-line-function.slang"
+//CHECK-DAG: [[B_FILE:%[0-9]+]] = OpString {{.*}}b.slang"
+//CHECK-DAG: [[D_FILE:%[0-9]+]] = OpString {{.*}}d.slang"
+//CHECK-DAG: [[DEBUGINFOLINE_SOURCE:%[0-9]+]] = {{.*}} DebugSource [[DEBUGINFOLINE_FILE]]
+//CHECK-DAG: [[B_SOURCE:%[0-9]+]] = {{.*}} DebugSource [[B_FILE]]
+//CHECK-DAG: [[D_SOURCE:%[0-9]+]] = {{.*}} DebugSource [[D_FILE]]
+
+// DebugFunctions are declared together in the "; Types, variables and constants" section
+// Assume the integers for the line numbers are in the form %uint_{linenumber}
+//CHECK: DebugFunction %{{[0-9]+}} %{{[0-9]+}} [[DEBUGINFOLINE_SOURCE]] %uint_[[#@LINE+9]]
+//CHECK: DebugFunction %{{[0-9]+}} %{{[0-9]+}} [[B_SOURCE]] %uint_99
+//CHECK: DebugFunction %{{[0-9]+}} %{{[0-9]+}} [[DEBUGINFOLINE_SOURCE]] %uint_[[#@LINE+20]]
+//CHECK: DebugFunction %{{[0-9]+}} %{{[0-9]+}} [[D_SOURCE]] %uint_603
+//CHECK: DebugFunction %{{[0-9]+}} %{{[0-9]+}} [[D_SOURCE]] %uint_40
+//CHECK: DebugFunction %{{[0-9]+}} %{{[0-9]+}} [[DEBUGINFOLINE_SOURCE]] %uint_[[#@LINE+38]]
+
+//CHECK:; Function a
+//CHECK: DebugLine [[DEBUGINFOLINE_SOURCE]] %uint_[[#@LINE+1]]
+int a() { return 0; }
+
+//CHECK:; Function b
+//CHECK: DebugLine [[B_SOURCE]] %uint_99
+#line 99 "b.slang"
+int b()
+{
+    return 0;
+}
+
+//CHECK:; Function c
+//CHECK: DebugLine [[DEBUGINFOLINE_SOURCE]] %uint_[[#@LINE+2]]
+#line default
+int c()
+{
+    return 0;
+}
+
+//CHECK:; Function d
+//CHECK: DebugLine [[D_SOURCE]] %uint_603
+#line 603 "d.slang"
+int d() { return 0; }
+
+//CHECK:; Function e
+//CHECK: DebugLine [[D_SOURCE]] %uint_40
+#line 40
+int e()
+{
+    return 0;
+}
+
+//CHECK:; Function f
+//CHECK: DebugLine [[DEBUGINFOLINE_SOURCE]] %uint_[[#@LINE+2]]
+#line
+int f() { return 0; }
+
+RWStructuredBuffer<int> out;
+[shader("compute")]
+void main()
+{
+    out[0] = a() + b() + c() + d() + e() + f();
+}

--- a/tests/spirv/debug-info-line-variable.slang
+++ b/tests/spirv/debug-info-line-variable.slang
@@ -1,0 +1,67 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -g2 -O0 -preserve-embedded-source
+// Tests generation of DebugLocalVariable and DebugDeclare with #line preprocessor directive specifying different files
+
+// Get the IDs for the Source argument in DebugLine/DebugFunction/DebugLocalVariable
+//CHECK-DAG: [[DEBUGINFOLINE_FILE:%[0-9]+]] = OpString {{.*}}debug-info-line-variable.slang"
+//CHECK-DAG: [[B_FILE:%[0-9]+]] = OpString {{.*}}b.slang"
+//CHECK-DAG: [[DEBUGINFOLINE_SOURCE:%[0-9]+]] = {{.*}} DebugSource [[DEBUGINFOLINE_FILE]]
+//CHECK-DAG: [[B_SOURCE:%[0-9]+]] = {{.*}} DebugSource [[B_FILE]]
+
+// Get the IDs for the variable strings
+//CHECK-DAG: [[T_STR:%[0-9]+]] = OpString "t"
+//CHECK-DAG: [[U_STR:%[0-9]+]] = OpString "u"
+//CHECK-DAG: [[V_STR:%[0-9]+]] = OpString "v"
+//CHECK-DAG: [[I_STR:%[0-9]+]] = OpString "i"
+//CHECK-DAG: [[J_STR:%[0-9]+]] = OpString "j"
+//CHECK-DAG: [[K_STR:%[0-9]+]] = OpString "k"
+
+// Assume the integers for the line numbers are in the form %uint_{linenumber}
+// Check for DebugLocalVariable's Name, Source, and Line arguments
+//CHECK: DebugFunction %{{[0-9]+}} %{{[0-9]+}} [[B_SOURCE]] %uint_[[#%u,B_FUNC_LINE:]]
+//CHECK: [[T_VAR:%[a-zA-Z0-9_]+]] = {{.*}} DebugLocalVariable [[T_STR]] %{{[0-9]+}} [[B_SOURCE]] %uint_[[#B_FUNC_LINE]]
+//CHECK: [[U_VAR:%[a-zA-Z0-9_]+]] = {{.*}} DebugLocalVariable [[U_STR]] %{{[0-9]+}} [[B_SOURCE]] %uint_[[#B_FUNC_LINE+4]]
+//CHECK: [[V_VAR:%[a-zA-Z0-9_]+]] = {{.*}} DebugLocalVariable [[V_STR]] %{{[0-9]+}} [[B_SOURCE]] %uint_[[#B_FUNC_LINE+7]]
+
+//CHECK: DebugFunction %{{[0-9]+}} %{{[0-9]+}} [[DEBUGINFOLINE_SOURCE]] %uint_[[#%u,C_FUNC_LINE:]]
+//CHECK: [[I_VAR:%[a-zA-Z0-9_]+]] = {{.*}} DebugLocalVariable [[I_STR]] %{{[0-9]+}} [[DEBUGINFOLINE_SOURCE]] %uint_[[#C_FUNC_LINE]]
+//CHECK: [[J_VAR:%[a-zA-Z0-9_]+]] = {{.*}} DebugLocalVariable [[J_STR]] %{{[0-9]+}} [[DEBUGINFOLINE_SOURCE]] %uint_[[#C_FUNC_LINE+4]]
+//CHECK: [[K_VAR:%[a-zA-Z0-9_]+]] = {{.*}} DebugLocalVariable [[K_STR]] %{{[0-9]+}} [[DEBUGINFOLINE_SOURCE]] %uint_[[#C_FUNC_LINE+7]]
+
+//CHECK:; Function b
+//CHECK: DebugLine [[B_SOURCE]] %uint_[[#B_FUNC_LINE: == 99]]
+//CHECK: DebugDeclare [[T_VAR]]
+#line 99 "b.slang"
+int b(int t)
+{
+//CHECK: DebugLine [[B_SOURCE]] %uint_[[#99+4]]
+//CHECK: DebugDeclare [[U_VAR]]
+    int u = 2;
+//CHECK: DebugLine [[B_SOURCE]] %uint_[[#99+7]]
+//CHECK: DebugDeclare [[V_VAR]]
+    let v = 3;
+//CHECK: DebugLine [[B_SOURCE]] %uint_[[#99+9]]
+    return t - u - v;
+}
+
+//CHECK:; Function c
+//CHECK: DebugLine [[DEBUGINFOLINE_SOURCE]] %uint_[[#C_FUNC_LINE: == @LINE+3]]
+//CHECK: DebugDeclare [[I_VAR]]
+#line default
+int c(int i)
+{
+//CHECK: DebugLine [[DEBUGINFOLINE_SOURCE]] %uint_[[#@LINE+2]]
+//CHECK: DebugDeclare [[J_VAR]]
+    int j = 0;
+//CHECK: DebugLine [[DEBUGINFOLINE_SOURCE]] %uint_[[#@LINE+2]]
+//CHECK: DebugDeclare [[K_VAR]]
+    let k = 1;
+//CHECK: DebugLine [[DEBUGINFOLINE_SOURCE]] %uint_[[#@LINE+1]]
+    return i + j + k;
+}
+
+RWStructuredBuffer<int> out;
+[shader("compute")]
+void main()
+{
+    out[0] = b(10) + c(-1);
+}


### PR DESCRIPTION
* maybeAddDebugLocationDecoration was not resolving #line remapped source locations, leading to an incorrect file and line shown on entering a function in shader debuggers.
* Refactor debug source resolution from maybeEmitDebugLine into getOrEmitDebugSource, to allow it to be shared.
* Use the refactored getOrEmitDebugSource function in maybeEmitDebugLine, maybeAddDebugLocationDecoration, and visitVarDecl.
* Add test coverage for expected line numbers for the SPIR-V DebugLine, DebugFunction, DebugLocalVariable, and DebugDeclare instructions.
* Update the tests/preprocessor/line.slang test to check for expected line numbers.

Fixes #9943