### PR TITLE
Add GCP auth to benchmark and compile-regression-test workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,11 +16,21 @@ concurrency:
 jobs:
   build:
     runs-on: [Windows, self-hosted, benchmark]
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
           fetch-depth: "0"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: "projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider"
+          service_account: "github-ci@slang-runners.iam.gserviceaccount.com"
+
       - name: Common setup
         uses: ./.github/actions/common-setup
         with:

--- a/.github/workflows/compile-regression-test.yml
+++ b/.github/workflows/compile-regression-test.yml
@@ -39,6 +39,9 @@ jobs:
             full-gpu-tests: false
             runs-on: [Windows, self-hosted, regression-test]
     runs-on: ${{ matrix.runs-on }}
+    permissions:
+      id-token: write
+      contents: read
     defaults:
       run:
         shell: bash
@@ -47,6 +50,13 @@ jobs:
         with:
           submodules: "recursive"
           fetch-depth: "0"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: "projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider"
+          service_account: "github-ci@slang-runners.iam.gserviceaccount.com"
+
       - name: Setup
         uses: ./.github/actions/common-setup
         with:


### PR DESCRIPTION
These workflows use common-setup which now requires GCP authentication to download LLVM from GCS.