### PR TITLE
Save sccache cache in merge queue instead of master

### DIFF
--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -160,9 +160,9 @@ jobs:
             exit 1
           fi
 
-      # Save sccache cache for fork PRs (master only)
-      - name: Save sccache cache (master only)
-        if: github.ref == 'refs/heads/master'
+      # Save sccache cache for fork PRs (merge queue only)
+      - name: Save sccache cache (merge queue)
+        if: github.event_name == 'merge_group'
         uses: actions/cache/save@v4
         with:
           path: /github/home/.cache/sccache

--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -281,9 +281,9 @@ jobs:
           path: artifacts-staging/
           retention-days: 1
 
-      # Save sccache local cache for fork PRs to restore from (master only)
-      - name: Save sccache cache (master only)
-        if: runner.environment != 'self-hosted' && github.ref == 'refs/heads/master'
+      # Save sccache local cache for fork PRs to restore from (merge queue only)
+      - name: Save sccache cache (merge queue)
+        if: runner.environment != 'self-hosted' && github.event_name == 'merge_group'
         uses: actions/cache/save@v4
         with:
           path: ~/.cache/sccache


### PR DESCRIPTION
CI workflow runs on merge_group (merge queue), not on push to master. Change save condition to populate cache during merge queue runs so fork PRs can restore from it.