### PR TITLE
Emit debug information for enum type variables

### DIFF
--- a/source/slang/slang-ir-insert-debug-value-store.cpp
+++ b/source/slang/slang-ir-insert-debug-value-store.cpp
@@ -88,6 +88,12 @@ bool DebugValueStoreContext::isDebuggableType(IRType* type)
             debuggable = false; // specTypeDebuggable;
             break;
         }
+    case kIROp_EnumType:
+        {
+            auto enumType = as<IREnumType>(type);
+            debuggable = isDebuggableType(enumType->getTagType());
+            break;
+        }
     default:
         if (as<IRBasicType>(type))
             debuggable = true;

--- a/tests/spirv/debug-info-enum.slang
+++ b/tests/spirv/debug-info-enum.slang
@@ -1,0 +1,22 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -g2 -O0
+// Tests generation of DebugLocalVariable and DebugDeclare for enum variables
+
+//CHECK: [[E_STR:%[0-9]+]] = OpString "e"
+//CHECK: [[E_VAR:%[A-Za-z0-9_]+]] = OpExtInst {{.*}} DebugLocalVariable [[E_STR]]
+//CHECK: OpExtInst {{.*}} DebugDeclare [[E_VAR]]
+
+enum MyEnum {
+    VALUE_A,
+    VALUE_B,
+    VALUE_C
+};
+
+RWStructuredBuffer<MyEnum> out;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main()
+{
+    MyEnum e = MyEnum.VALUE_A;
+    out[0] = e;
+}


### PR DESCRIPTION
* Allow IROp_EnumType as a debuggable type, enabling debug information for variables of that type to be emitted.
* Add test coverage checking SPIR-V DebugLocalVariable and DebugDeclare instructions are emitted.

Fixes #9966