### PR TITLE
Add id-token permissions to reusable workflow calls

### DIFF
--- a/.github/workflows/populate-fork-cache.yml
+++ b/.github/workflows/populate-fork-cache.yml
@@ -53,6 +53,9 @@ jobs:
   build-linux-release:
     needs: check-changes
     if: needs.check-changes.outputs.should-build == 'true'
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/ci-slang-build.yml
     with:
       os: linux
@@ -66,6 +69,9 @@ jobs:
   build-macos-release:
     needs: check-changes
     if: needs.check-changes.outputs.should-build == 'true'
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/ci-slang-build.yml
     with:
       os: macos


### PR DESCRIPTION
Reusable workflows need explicit permissions when calling workflows that request id-token:write.