### PR TITLE
Add GCP authentication to coverage and VK-GL-CTS nightly workflows

### DIFF
--- a/.github/workflows/ci-slang-coverage.yml
+++ b/.github/workflows/ci-slang-coverage.yml
@@ -39,6 +39,12 @@ jobs:
   coverage:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     timeout-minutes: 120
+    permissions:
+      id-token: write # Required for Workload Identity (GCS auth)
+      contents: read
+
+    env:
+      IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
 
     defaults:
       run:
@@ -71,6 +77,14 @@ jobs:
           clang++-18 --version
           llvm-profdata --version
           llvm-cov --version
+
+      # Authenticate to Google Cloud (skip for fork PRs - no id-token available)
+      - name: Authenticate to Google Cloud
+        if: env.IS_FORK_PR != 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: "projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider"
+          service_account: "github-ci@slang-runners.iam.gserviceaccount.com"
 
       - name: Setup
         uses: ./.github/actions/common-setup

--- a/.github/workflows/vk-gl-cts-nightly.yml
+++ b/.github/workflows/vk-gl-cts-nightly.yml
@@ -27,6 +27,11 @@ jobs:
             runs-on: [Windows, self-hosted, regression-test, vulkancts]
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 180
+    permissions:
+      id-token: write # Required for Workload Identity (GCS auth)
+      contents: read
+    env:
+      IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
     defaults:
       run:
         shell: bash
@@ -35,6 +40,13 @@ jobs:
         with:
           submodules: "true"
           fetch-depth: "0"
+      # Authenticate to Google Cloud (skip for fork PRs - no id-token available)
+      - name: Authenticate to Google Cloud
+        if: env.IS_FORK_PR != 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: "projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider"
+          service_account: "github-ci@slang-runners.iam.gserviceaccount.com"
       - name: Setup
         uses: ./.github/actions/common-setup
         with:


### PR DESCRIPTION
The coverage nightly workflow fails at the "Upload LLVM to GCS" step because GCP authentication was never configured. After a cache miss, LLVM is built from source (~1h 44m) and the upload step calls `gcloud storage cp` which requires credentials:

  ERROR: (gcloud.storage.cp) You do not currently have an active account selected.

The download side works because it falls back to curl with the public URL, but the upload has no such fallback.

Add `id-token: write` permission and `google-github-actions/auth@v2` step to both `ci-slang-coverage.yml` and `vk-gl-cts-nightly.yml`, matching the pattern used in `ci-slang-build.yml` and other workflows.

The VK-GL-CTS workflow had the same latent issue but hadn't failed yet because the LLVM cache was warm.