### PR TITLE
Use local backend when populating fork cache

### DIFF
--- a/.github/workflows/populate-fork-cache.yml
+++ b/.github/workflows/populate-fork-cache.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: master
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 10
 
       - name: Check if source changed since last cache
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: master
+          ref: ${{ github.event.repository.default_branch }}
           submodules: recursive
           fetch-depth: 1
 
@@ -78,6 +78,12 @@ jobs:
 
       - name: Build Slang
         run: |
+          # Verify sccache_path is set
+          if [ -z "${sccache_path}" ]; then
+            echo "ERROR: sccache_path not set"
+            exit 1
+          fi
+
           cmake --preset default --fresh \
             -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
             -DCMAKE_C_COMPILER_LAUNCHER="${sccache_path}" \
@@ -89,7 +95,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ~/.cache/sccache
-          key: sccache-linux-gcc-x86_64-release-${{ github.sha }}
+          key: sccache-linux-gcc-x86_64-release-${{ needs.check-changes.outputs.last-commit }}
 
   build-macos-release:
     needs: check-changes
@@ -98,7 +104,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: master
+          ref: ${{ github.event.repository.default_branch }}
           submodules: recursive
           fetch-depth: 1
 
@@ -107,6 +113,14 @@ jobs:
         uses: ./.github/actions/setup-sccache
         with:
           platform: macos
+
+      - name: Verify sccache setup
+        run: |
+          if [ -z "${sccache_path}" ]; then
+            echo "ERROR: sccache_path not set by setup-sccache action"
+            exit 1
+          fi
+          echo "✅ sccache path: ${sccache_path}"
 
       - name: Setup
         uses: ./.github/actions/common-setup
@@ -124,13 +138,13 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER="${sccache_path}" \
             -DCMAKE_CXX_COMPILER_LAUNCHER="${sccache_path}" \
             -DCMAKE_COMPILE_WARNING_AS_ERROR=false
-          cmake --build --preset release -j$(nproc)
+          cmake --build --preset release -j"$(sysctl -n hw.ncpu)"
 
       - name: Save sccache cache for fork PRs
         uses: actions/cache/save@v4
         with:
           path: ~/.cache/sccache
-          key: sccache-macos-clang-aarch64-release-${{ github.sha }}
+          key: sccache-macos-clang-aarch64-release-${{ needs.check-changes.outputs.last-commit }}
 
   mark-cached:
     needs: [check-changes, build-linux-release, build-macos-release]
@@ -139,7 +153,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: master
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
 
       - name: Create cache marker file


### PR DESCRIPTION
sccache defaults to GCS, we want to use local backend to save to GHA cache for forked PRs.