### PR TITLE
Add cache restore to populate-fork-cache workflow

### DIFF
--- a/.github/workflows/populate-fork-cache.yml
+++ b/.github/workflows/populate-fork-cache.yml
@@ -61,6 +61,16 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
+      # Restore existing cache for incremental builds
+      - name: Restore sccache cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/.cache/sccache
+          key: sccache-linux-gcc-x86_64-release-${{ needs.check-changes.outputs.last-commit }}
+          restore-keys: |
+            sccache-linux-gcc-x86_64-release-
+            sccache-linux-gcc-x86_64-
+
       # Setup sccache with LOCAL backend only (no GCS bucket = local disk)
       - name: Setup sccache (local backend)
         uses: ./.github/actions/setup-sccache
@@ -108,6 +118,16 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
+      # Restore existing cache for incremental builds
+      - name: Restore sccache cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/.cache/sccache
+          key: sccache-linux-gcc-x86_64-debug-${{ needs.check-changes.outputs.last-commit }}
+          restore-keys: |
+            sccache-linux-gcc-x86_64-debug-
+            sccache-linux-gcc-x86_64-
+
       - name: Setup sccache (local backend)
         uses: ./.github/actions/setup-sccache
         with:
@@ -151,6 +171,16 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           submodules: recursive
           fetch-depth: 1
+
+      # Restore existing cache for incremental builds
+      - name: Restore sccache cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/.cache/sccache
+          key: sccache-macos-clang-aarch64-release-${{ needs.check-changes.outputs.last-commit }}
+          restore-keys: |
+            sccache-macos-clang-aarch64-release-
+            sccache-macos-clang-aarch64-
 
       - name: Setup sccache (local backend)
         uses: ./.github/actions/setup-sccache
@@ -200,6 +230,16 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
+      # Restore existing cache for incremental builds
+      - name: Restore sccache cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/.cache/sccache
+          key: sccache-macos-clang-aarch64-debug-${{ needs.check-changes.outputs.last-commit }}
+          restore-keys: |
+            sccache-macos-clang-aarch64-debug-
+            sccache-macos-clang-aarch64-
+
       - name: Setup sccache (local backend)
         uses: ./.github/actions/setup-sccache
         with:
@@ -244,6 +284,16 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
+      # Restore existing cache for incremental builds
+      - name: Restore sccache cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/.cache/sccache
+          key: sccache-linux-gcc-aarch64-release-${{ needs.check-changes.outputs.last-commit }}
+          restore-keys: |
+            sccache-linux-gcc-aarch64-release-
+            sccache-linux-gcc-aarch64-
+
       - name: Setup sccache (local backend)
         uses: ./.github/actions/setup-sccache
         with:
@@ -287,6 +337,16 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           submodules: recursive
           fetch-depth: 1
+
+      # Restore existing cache for incremental builds
+      - name: Restore sccache cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/.cache/sccache
+          key: sccache-linux-gcc-aarch64-debug-${{ needs.check-changes.outputs.last-commit }}
+          restore-keys: |
+            sccache-linux-gcc-aarch64-debug-
+            sccache-linux-gcc-aarch64-
 
       - name: Setup sccache (local backend)
         uses: ./.github/actions/setup-sccache


### PR DESCRIPTION
Improve populate-fork-cache workflow:
- Expand to all 6 configurations (debug + release for Linux x86_64, macOS aarch64, Linux aarch64)
- Add cache restore before builds for incremental compilation
- Use /tmp/.cache/sccache for consistent path across environments