### PR TITLE
Use container workflow for Linux x86_64 in populate-fork-cache

### DIFF
--- a/.github/workflows/populate-fork-cache.yml
+++ b/.github/workflows/populate-fork-cache.yml
@@ -53,113 +53,26 @@ jobs:
   build-linux-release:
     needs: check-changes
     if: needs.check-changes.outputs.should-build == 'true'
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          submodules: recursive
-          fetch-depth: 1
-
-      # Restore existing cache for incremental builds
-      - name: Restore sccache cache
-        uses: actions/cache/restore@v4
-        with:
-          path: /tmp/.cache/sccache
-          key: sccache-linux-gcc-x86_64-release-${{ needs.check-changes.outputs.last-commit }}
-          restore-keys: |
-            sccache-linux-gcc-x86_64-release-
-            sccache-linux-gcc-x86_64-
-
-      # Setup sccache with LOCAL backend only (no GCS bucket = local disk)
-      - name: Setup sccache (local backend)
-        uses: ./.github/actions/setup-sccache
-        with:
-          platform: linux
-
-      - name: Setup
-        uses: ./.github/actions/common-setup
-        with:
-          os: linux
-          compiler: gcc
-          platform: x86_64
-          config: release
-          build-llvm: true
-
-      - name: Build Slang
-        run: |
-          # Verify sccache_path is set
-          if [ -z "${sccache_path}" ]; then
-            echo "ERROR: sccache_path not set"
-            exit 1
-          fi
-
-          cmake --preset default --fresh \
-            -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
-            -DCMAKE_C_COMPILER_LAUNCHER="${sccache_path}" \
-            -DCMAKE_CXX_COMPILER_LAUNCHER="${sccache_path}" \
-            -DCMAKE_COMPILE_WARNING_AS_ERROR=false
-          cmake --build --preset release -j$(nproc)
-
-      - name: Save sccache cache for fork PRs
-        uses: actions/cache/save@v4
-        with:
-          path: /tmp/.cache/sccache
-          key: sccache-linux-gcc-x86_64-release-${{ needs.check-changes.outputs.last-commit }}
+    uses: ./.github/workflows/ci-slang-build-container.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
+    with:
+      config: release
+      runs-on: '["ubuntu-22.04"]'
 
   build-linux-debug:
     needs: check-changes
     if: needs.check-changes.outputs.should-build == 'true'
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          submodules: recursive
-          fetch-depth: 1
-
-      # Restore existing cache for incremental builds
-      - name: Restore sccache cache
-        uses: actions/cache/restore@v4
-        with:
-          path: /tmp/.cache/sccache
-          key: sccache-linux-gcc-x86_64-debug-${{ needs.check-changes.outputs.last-commit }}
-          restore-keys: |
-            sccache-linux-gcc-x86_64-debug-
-            sccache-linux-gcc-x86_64-
-
-      - name: Setup sccache (local backend)
-        uses: ./.github/actions/setup-sccache
-        with:
-          platform: linux
-
-      - name: Setup
-        uses: ./.github/actions/common-setup
-        with:
-          os: linux
-          compiler: gcc
-          platform: x86_64
-          config: debug
-          build-llvm: true
-
-      - name: Build Slang
-        run: |
-          if [ -z "${sccache_path}" ]; then
-            echo "ERROR: sccache_path not set"
-            exit 1
-          fi
-          cmake --preset default --fresh \
-            -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
-            -DCMAKE_C_COMPILER_LAUNCHER="${sccache_path}" \
-            -DCMAKE_CXX_COMPILER_LAUNCHER="${sccache_path}" \
-            -DCMAKE_COMPILE_WARNING_AS_ERROR=false
-          cmake --build --preset debug -j$(nproc)
-
-      - name: Save sccache cache for fork PRs
-        uses: actions/cache/save@v4
-        with:
-          path: /tmp/.cache/sccache
-          key: sccache-linux-gcc-x86_64-debug-${{ needs.check-changes.outputs.last-commit }}
+    uses: ./.github/workflows/ci-slang-build-container.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
+    with:
+      config: debug
+      runs-on: '["ubuntu-22.04"]'
 
   build-macos-release:
     needs: check-changes
@@ -393,6 +306,7 @@ jobs:
         build-linux-aarch64-debug,
       ]
     if: |
+      always() &&
       needs.check-changes.outputs.should-build == 'true' &&
       needs.build-linux-release.result == 'success' &&
       needs.build-linux-debug.result == 'success' &&


### PR DESCRIPTION
Call ci-slang-build-container.yml as reusable workflow for Linux x86_64 debug and release to match fork PR build environment exactly. Container workflow handles its own cache save.