### PR TITLE
Add use-local-sccache input to force local backend in container

### DIFF
--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -9,6 +9,10 @@ on:
       runs-on:
         required: true
         type: string
+      use-local-sccache:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   # Uses nvidia/cuda container for CUDA support.
@@ -58,12 +62,12 @@ jobs:
           workload_identity_provider: "projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider"
           service_account: "github-ci@slang-runners.iam.gserviceaccount.com"
 
-      # Setup sccache (GCS for internal, local disk for fork PRs)
+      # Setup sccache (GCS for internal, local disk for fork PRs or when use-local-sccache is true)
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
         with:
           platform: linux
-          gcs-bucket: ${{ env.IS_FORK_PR != 'true' && 'slang-ci-cache' || '' }}
+          gcs-bucket: ${{ (env.IS_FORK_PR != 'true' && inputs.use-local-sccache != true) && 'slang-ci-cache' || '' }}
 
       - name: Setup LLVM from GCS
         uses: ./.github/actions/setup-llvm-from-gcs

--- a/.github/workflows/populate-fork-cache.yml
+++ b/.github/workflows/populate-fork-cache.yml
@@ -61,6 +61,7 @@ jobs:
     with:
       config: release
       runs-on: '["ubuntu-22.04"]'
+      use-local-sccache: true
 
   build-linux-debug:
     needs: check-changes
@@ -73,6 +74,7 @@ jobs:
     with:
       config: debug
       runs-on: '["ubuntu-22.04"]'
+      use-local-sccache: true
 
   build-macos-release:
     needs: check-changes


### PR DESCRIPTION
Add use-local-sccache input to ci-slang-build-container.yml to allow populate-fork-cache workflow to force local disk backend instead of GCS. This ensures populated caches use local backend for fork PRs to restore.