### PR TITLE
Fix coverage nightly workflow id-token permission

### DIFF
--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -13,7 +13,7 @@ concurrency:
 permissions:
   contents: read # Read slang repo
   pull-requests: write # For PR comments (if needed)
-  # Note: GITHUB_TOKEN automatically has write access to other org repos
+  id-token: write # Required for GCS OIDC authentication in reusable workflow
 
 jobs:
   coverage-linux:


### PR DESCRIPTION
The coverage nightly workflow started failing after PR #9904 and #9950
introduced GCS-based caching with Workload Identity Federation. PR #9977
added `id-token: write` and GCP auth to `ci-slang-coverage.yml` (the
reusable workflow), but the caller `coverage-nightly.yml` was not updated.

Since `coverage-nightly.yml` explicitly restricts permissions, any
unlisted permission defaults to `none`. This caused the reusable
workflow's coverage job to fail with: "The nested job 'coverage' is
requesting 'id-token: write', but is only allowed 'id-token: none'."

Add `id-token: write` to the caller workflow to raise the permissions
ceiling.

Failing run: https://github.com/shader-slang/slang/actions/runs/21931936339