### PR TITLE
Fix coverage workflow LLVM setup

### DIFF
--- a/.github/workflows/ci-slang-coverage.yml
+++ b/.github/workflows/ci-slang-coverage.yml
@@ -91,7 +91,8 @@ jobs:
         uses: ./.github/actions/setup-llvm-from-gcs
         with:
           os: ${{ inputs.os }}
-          compiler: ${{ inputs.compiler }}
+          # Use gcc-built LLVM for Linux (ABI-compatible with clang-18)
+          compiler: ${{ inputs.os == 'linux' && 'gcc' || inputs.compiler }}
           platform: ${{ inputs.platform }}
           llvm-hash: ${{ hashFiles('external/build-llvm.sh') }}
           build-if-missing: "true"

--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -11,9 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  id-token: write # Required for Workload Identity (GCS auth)
   contents: read # Read slang repo
   pull-requests: write # For PR comments (if needed)
-  id-token: write # Required for GCS OIDC authentication in reusable workflow
 
 jobs:
   coverage-linux:


### PR DESCRIPTION
Fix nightly coverage workflow to work with LLVM prebuilts in GCS:
- Map clang-18 to gcc for LLVM prebuilt lookup on Linux (ABI-compatible)
- Fix duplicate id-token permission in coverage-nightly.yml