### PR TITLE
Fix boolean comparison for build-llvm in coverage workflow

### DIFF
--- a/.github/workflows/ci-slang-coverage.yml
+++ b/.github/workflows/ci-slang-coverage.yml
@@ -87,7 +87,7 @@ jobs:
           service_account: "github-ci@slang-runners.iam.gserviceaccount.com"
 
       - name: Setup LLVM from GCS
-        if: inputs.build-llvm == 'true'
+        if: inputs.build-llvm
         uses: ./.github/actions/setup-llvm-from-gcs
         with:
           os: ${{ inputs.os }}


### PR DESCRIPTION
Use truthy check instead of string comparison for boolean input.
The condition `inputs.build-llvm == 'true'` fails for boolean inputs
because it compares boolean to string.