### PR TITLE
Fix the parsing error on release-note.sh

### DIFF
--- a/docs/scripts/release-note.sh
+++ b/docs/scripts/release-note.sh
@@ -90,7 +90,7 @@ for i in $(seq "$commitsCount"); do
   line="$(echo "$commits" | head -n "$i" | tail -1)"
 
   # Get PR number from the git commit title
-  pr="$(echo "$line" | grep '#[1-9][0-9][0-9][0-9][0-9]*' | sed 's|.* (\#\([1-9][0-9][0-9][0-9][0-9]*\))|\1|')"
+  pr="$(echo "$line" | grep '#[1-9][0-9][0-9][0-9][0-9]*' | sed 's|.*(\#\([1-9][0-9][0-9][0-9][0-9]*\))$|\1|')"
   [ "$pr" = "" ] && continue
 
   # Check if the PR is marked as a breaking change
@@ -110,7 +110,7 @@ for i in $(seq "$commitsCount"); do
 
   result="$line"
   # Get PR number from the git commit title
-  pr="$(echo "$line" | grep '#[1-9][0-9][0-9][0-9][0-9]*' | sed 's|.* (\#\([1-9][0-9][0-9][0-9][0-9]*\))|\1|')"
+  pr="$(echo "$line" | grep '#[1-9][0-9][0-9][0-9][0-9]*' | sed 's|.*(\#\([1-9][0-9][0-9][0-9][0-9]*\))$|\1|')"
   if [ "$pr" != "" ]; then
     # Mark breaking changes with "[BREAKING]"
     if "$gh" issue view "$pr" --json labels | grep -q 'pr: breaking change'; then


### PR DESCRIPTION
Fixing the string parsing pattern to handle a bit strange case of the commit title.
```
de9037e7e Fix coverage nightly workflow id-token permission (#9993)
8d37bd0fb Add cache restore for use-local-sccache in container workflow (#9990)
75e0c7119 Add atomic_reduce intrinsic for cuda target(#9969) <================ STRANGE
ce3bbb1fd Specialize `[CUDAKernel]` functions as compute stage entry point for `__stage_switch` (#9970)
6bb1b4a49 Add use-local-sccache input to force local backend in container (#9988)
b32145ef1 Use container workflow for Linux x86_64 in populate-fork-cache (#9987)
```
Note that the commit, `75e0c7119`, shows the PR number without a white-space character, which never happened before.