### PR TITLE
clean disk space

### DIFF
--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -39,15 +39,13 @@ jobs:
         run: |
           echo "=== Disk space before cleanup ==="
           df -h /host_root || true
-          # Remove large pre-installed software from the GitHub runner host
+          # Remove large pre-installed software from the GitHub runner host.
+          # NOTE: Do NOT remove /opt/hostedtoolcache - it is used by GitHub
+          # Actions (e.g. setup-gcloud) for tool caching and removal breaks steps.
           rm -rf /host_root/usr/share/dotnet || true
           rm -rf /host_root/usr/local/lib/android || true
           rm -rf /host_root/opt/ghc || true
           rm -rf /host_root/usr/share/swift || true
-          rm -rf /host_root/opt/hostedtoolcache || true
-          # Remove pre-cached Docker images on the host
-          rm -rf /host_root/usr/local/share/powershell || true
-          rm -rf /host_root/usr/local/share/chromium || true
           echo "=== Disk space after cleanup ==="
           df -h /host_root || true
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR does not modify the Slang shader compiler or its compilation stages. It is an infrastructure change to the GitHub Actions CI workflow file .github/workflows/ci-slang-build-container.yml.

Changes:
- Add container volume mount options: --user root -v /:/host_root
- Insert a "Free disk space on host" workflow step that reports disk space, removes several large pre-installed host packages/caches under /host_root (dotnet, Android SDK, GHC, Swift), and reports disk space again
- Keep existing CI steps (including Configure Git safe directory, checkout, build, artifact staging) unchanged otherwise

Impact:
- Compiler stages (lexer, parser, semantic analysis, IR, codegen): unaffected
- Target backends (SPIR-V, HLSL, GLSL, Metal, CUDA, WGSL): unaffected (note: workflow still builds with CUDA enabled as before)
- Public API headers (include/slang.h, include/slang-com-helper.h): not modified
- No source changes to compiler code
<!-- end of auto-generated comment: release notes by coderabbit.ai -->