### PR TITLE
Allow enum-typed specialization constants

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -8767,6 +8767,11 @@ bool SemanticsVisitor::isHalfType(Type* type)
     return baseType == BaseType::Half;
 }
 
+bool SemanticsVisitor::isValidSpecializationConstantType(Type* type)
+{
+    return as<BasicExpressionType>(type) || isEnumType(type);
+}
+
 bool SemanticsVisitor::isValidCompileTimeConstantType(Type* type)
 {
     return isScalarIntegerType(type) || isEnumType(type);
@@ -14016,12 +14021,11 @@ void SemanticsDeclAttributesVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
     {
         if (as<SpecializationConstantAttribute>(modifier) || as<VkConstantIdAttribute>(modifier))
         {
-            // Specialization constant.
-            // Check that type is basic type.
-            if (!as<BasicExpressionType>(varDecl->getType()) && !as<ErrorType>(varDecl->getType()))
+            if (!isValidSpecializationConstantType(varDecl->getType()) &&
+                !as<ErrorType>(varDecl->getType()))
             {
                 getSink()->diagnose(
-                    Diagnostics::SpecializationConstantMustBeScalar{.modifier = modifier});
+                    Diagnostics::SpecializationConstantMustBeScalarOrEnum{.modifier = modifier});
             }
             hasSpecConstAttr = true;
         }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1926,7 +1926,7 @@ public:
 
     void visitModifier(Modifier*);
 
-    DeclRef<VarDeclBase> tryGetIntSpecializationConstant(Expr* expr);
+    DeclRef<VarDeclBase> tryGetIntOrEnumSpecializationConstant(Expr* expr);
 
     AttributeDecl* lookUpAttributeDecl(Name* attributeName, Scope* scope);
 
@@ -2312,6 +2312,9 @@ public:
 
     /// Is `type` a scalar half type.
     bool isHalfType(Type* type);
+
+    /// Is `type` something we allow for specialization constants, i.e. scalar and enum types.
+    bool isValidSpecializationConstantType(Type* type);
 
     /// Is `type` something we allow as compile time constants, i.e. scalar integer and enum types.
     bool isValidCompileTimeConstantType(Type* type);

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -117,7 +117,7 @@ void SemanticsVisitor::visitModifier(Modifier*)
     // Do nothing with modifiers for now
 }
 
-DeclRef<VarDeclBase> SemanticsVisitor::tryGetIntSpecializationConstant(Expr* expr)
+DeclRef<VarDeclBase> SemanticsVisitor::tryGetIntOrEnumSpecializationConstant(Expr* expr)
 {
     // First type-check the expression as normal
     expr = CheckExpr(expr);
@@ -125,7 +125,7 @@ DeclRef<VarDeclBase> SemanticsVisitor::tryGetIntSpecializationConstant(Expr* exp
     if (IsErrorExpr(expr))
         return DeclRef<VarDeclBase>();
 
-    if (!isScalarIntegerType(expr->type))
+    if (!isValidCompileTimeConstantType(expr->type))
         return DeclRef<VarDeclBase>();
 
     auto specConstVar = as<VarExpr>(expr);
@@ -404,7 +404,7 @@ Modifier* SemanticsVisitor::validateAttribute(
             auto arg = attr->args[i];
             if (arg)
             {
-                auto specConstDecl = tryGetIntSpecializationConstant(arg);
+                auto specConstDecl = tryGetIntOrEnumSpecializationConstant(arg);
                 if (specConstDecl)
                 {
                     numThreadsAttr->extents[i] = nullptr;
@@ -1989,7 +1989,7 @@ Modifier* SemanticsVisitor::checkModifier(
             auto arg = attr->args[i];
             if (arg)
             {
-                auto specConstDecl = tryGetIntSpecializationConstant(arg);
+                auto specConstDecl = tryGetIntOrEnumSpecializationConstant(arg);
                 if (specConstDecl)
                 {
                     attr->specConstExtents[i] = specConstDecl;

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -2578,10 +2578,10 @@ err(
 -- Specialization and push constants
 
 err(
-    "specialization-constant-must-be-scalar",
+    "specialization-constant-must-be-scalar-or-enum",
     31218,
     "specialization constant type error",
-    span { loc = "modifier:Modifier", message = "specialization constant must be a scalar." }
+    span { loc = "modifier:Modifier", message = "specialization constant must be a scalar or enum type." }
 )
 
 err(

--- a/tests/diagnostics/specialization-constants.slang
+++ b/tests/diagnostics/specialization-constants.slang
@@ -5,9 +5,23 @@ struct T { int x; int y; }
 [vk::constant_id(1)]
 /*diag:
      ^^^^^^^^^^^ specialization constant type error
-     ^^^^^^^^^^^ specialization constant must be a scalar.
+     ^^^^^^^^^^^ specialization constant must be a scalar or enum type.
 */
 const T st;
+
+[SpecializationConstant]
+/*diag:
+ ^^^^^^^^^^^^^^^^^^^^^^ specialization constant type error
+ ^^^^^^^^^^^^^^^^^^^^^^ specialization constant must be a scalar or enum type.
+*/
+const int2 v;
+
+[vk::constant_id(2)]
+/*diag:
+     ^^^^^^^^^^^ specialization constant type error
+     ^^^^^^^^^^^ specialization constant must be a scalar or enum type.
+*/
+const float2x2 m;
 
 [vk::constant_id(1)]
 static const int x = 2;
@@ -20,7 +34,7 @@ static const int x = 2;
 [vk::constant_id(1)]
 /*diag:
      ^^^^^^^^^^^ specialization constant type error
-     ^^^^^^^^^^^ specialization constant must be a scalar.
+     ^^^^^^^^^^^ specialization constant must be a scalar or enum type.
 */
 const int y;
 /*diag:

--- a/tests/spirv/spec-constant-enum-glsl-local-size.slang
+++ b/tests/spirv/spec-constant-enum-glsl-local-size.slang
@@ -1,0 +1,28 @@
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv -stage compute -entry main -allow-glsl
+// SPIR-V-only: validates LocalSizeId/SpecId emission for GLSL local_size_* enum specialization constants.
+
+#version 450
+
+enum class GroupSize : int
+{
+    X = 8,
+    Y = 4,
+};
+
+[vk::constant_id(3)]
+const GroupSize groupSizeX = GroupSize::X;
+
+[vk::constant_id(4)]
+const GroupSize groupSizeY = GroupSize::Y;
+
+// SPIRV-DAG: OpExecutionModeId %main LocalSizeId %[[SX:[0-9A-Za-z_]+]] %[[SY:[0-9A-Za-z_]+]] %[[SZ:[0-9A-Za-z_]+]]
+// SPIRV-DAG: OpDecorate %[[SX]] SpecId 3
+// SPIRV-DAG: OpDecorate %[[SY]] SpecId 4
+// SPIRV-DAG: %[[SX]] = OpSpecConstant %int 8
+// SPIRV-DAG: %[[SY]] = OpSpecConstant %int 4
+// SPIRV-DAG: %[[SZ]] = OpConstant %int 1
+layout(local_size_x = groupSizeX, local_size_y = groupSizeY, local_size_z = 1) in;
+
+void main()
+{
+}

--- a/tests/spirv/spec-constant-enum-numthreads.slang
+++ b/tests/spirv/spec-constant-enum-numthreads.slang
@@ -1,0 +1,43 @@
+//TEST:SIMPLE(filecheck=GLSL): -target glsl
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv
+// NOTE: Validates target-specific specialization ID/local size emission in
+// generated GLSL/SPIR-V text output.
+
+// SPIRV-DAG: OpExecutionModeId %{{.*}} LocalSizeId %[[SX:[0-9A-Za-z_]+]] %[[SY:[0-9A-Za-z_]+]] %[[SZ:[0-9A-Za-z_]+]]
+// SPIRV-DAG: OpDecorate %[[SX]] SpecId 3
+// SPIRV-DAG: OpDecorate %[[SY]] SpecId 4
+// SPIRV-DAG: %[[SX]] = OpSpecConstant %int 8
+// SPIRV-DAG: %[[SY]] = OpSpecConstant %int 4
+// SPIRV-DAG: %[[SZ]] = OpConstant %int 1
+
+// GLSL: layout(constant_id = 3)
+// GLSL-NEXT: int groupSizeX_0 = 8;
+//
+// GLSL: layout(constant_id = 4)
+// GLSL-NEXT: int groupSizeY_0 = 4;
+//
+// GLSL: layout(local_size_x_id = 3, local_size_y_id = 4, local_size_z = 1) in;
+
+enum class GroupSize : int
+{
+    X = 8,
+    Y = 4,
+    Z = 1,
+}
+
+[vk::constant_id(3)]
+const GroupSize groupSizeX = GroupSize::X;
+
+[vk::constant_id(4)]
+const GroupSize groupSizeY = GroupSize::Y;
+
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(groupSizeX, groupSizeY, 1)]
+void computeMain()
+{
+    int3 size = WorkgroupSize();
+    outputBuffer[0] = size.x;
+    outputBuffer[1] = size.y;
+    outputBuffer[2] = size.z;
+}

--- a/tests/spirv/spec-constant-enum-signed-unsigned.slang
+++ b/tests/spirv/spec-constant-enum-signed-unsigned.slang
@@ -1,0 +1,33 @@
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv
+// SPIR-V-only: checks OpSpecConstant/SpecId emission for signed/unsigned enum specialization constants.
+
+// SPIRV-DAG: OpDecorate %[[SIGNED:[0-9A-Za-z_]+]] SpecId 21
+// SPIRV-DAG: OpDecorate %[[UNSIGNED:[0-9A-Za-z_]+]] SpecId 22
+// SPIRV-DAG: %[[SIGNED]] = OpSpecConstant %int -3
+// SPIRV-DAG: %[[UNSIGNED]] = OpSpecConstant %uint 7
+
+enum class SignedMode : int
+{
+    Neg = -3,
+}
+
+enum class UnsignedMode : uint
+{
+    Seven = 7,
+}
+
+[vk::constant_id(21)]
+const SignedMode signedMode = SignedMode::Neg;
+
+[vk::constant_id(22)]
+const UnsignedMode unsignedMode = UnsignedMode::Seven;
+
+RWStructuredBuffer<int> outputBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main(uint3 id : SV_DispatchThreadID)
+{
+    outputBuffer[0] = (int)signedMode;
+    outputBuffer[1] = (int)(uint)unsignedMode;
+}

--- a/tests/spirv/spec-constant-enum-typedef.slang
+++ b/tests/spirv/spec-constant-enum-typedef.slang
@@ -1,0 +1,25 @@
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv
+// SPIR-V-only: checks OpSpecConstant/SpecId emission for enum typedef specialization constants.
+
+// SPIRV-DAG: OpDecorate %[[MODE:[0-9A-Za-z_]+]] SpecId 5
+// SPIRV-DAG: %[[MODE]] = OpSpecConstant %uint 2
+
+enum class Mode : uint32_t
+{
+    Add = 2,
+    Multiply = 9,
+}
+
+typedef Mode ModeTypedef;
+
+[vk::constant_id(5)]
+const ModeTypedef mode = Mode::Add;
+
+RWStructuredBuffer<uint> outputBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main(uint3 id : SV_DispatchThreadID)
+{
+    outputBuffer[id.x] = (uint)mode;
+}

--- a/tests/spirv/spec-constant-enum.slang
+++ b/tests/spirv/spec-constant-enum.slang
@@ -1,0 +1,28 @@
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv
+// SPIR-V-only: checks OpSpecConstant/SpecId emission for enum specialization constants,
+// including a plain enum class that uses the default int backing type.
+
+// SPIRV-DAG: OpDecorate %[[MODE_B:[0-9A-Za-z_]+]] SpecId 11
+// SPIRV-DAG: %[[MODE_A:[0-9A-Za-z_]+]] = OpSpecConstant %int 2
+// SPIRV-DAG: %[[MODE_B]] = OpSpecConstant %int 9
+
+enum class Mode
+{
+    Add = 2,
+    Multiply = 9,
+}
+
+[SpecializationConstant]
+const Mode modeA = Mode::Add;
+
+[vk::constant_id(11)]
+const Mode modeB = Mode::Multiply;
+
+RWStructuredBuffer<int> outputBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main(uint3 id : SV_DispatchThreadID)
+{
+    outputBuffer[id.x] = (int)modeA + (int)modeB;
+}


### PR DESCRIPTION
Allow enum types both when specialization constants types are checked and then they are consumed.

Closes #9877.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Compiler Impact Summary

This PR updates semantic analysis to allow enum types to be used as specialization constants and in places where integer specialization-constant expressions are expected, and it adds SPIR-V-focused tests validating enum-backed specialization constants.

### Compiler Stages Affected
- Semantic Analysis (Modified)
  - source/slang/slang-check-decl.cpp: SemanticsDeclAttributesVisitor::checkVarDeclCommon now treats enum types as valid specialization-constant variable types.
  - source/slang/slang-check-modifier.cpp: SemanticsVisitor::tryGetIntSpecializationConstant now accepts enum-typed expressions in addition to scalar-integer expressions.
- Lexer, Parser, IR, Codegen: No changes introduced by this PR.

### Target Backends Impacted
- SPIR-V: Directly impacted and explicitly tested — new tests under tests/spirv/ exercise enum-backed specialization constants (including signed/unsigned enums, typedefed enums, use in local workgroup sizes / numthreads) and validate SpecId decorations, OpSpecConstant values, and OpExecutionModeId emission.
- GLSL: Exercised via SPIR-V/GLSL test expectations in the new tests.
- HLSL, Metal, CUDA, WGSL: No direct code changes; may be indirectly affected only insofar as the compiler now accepts enum-backed specialization constants that downstream backends must handle.

### Public API
- No modifications to public API headers (include/slang.h, slang-com-helper.h).

### Tests
- Multiple new tests added under tests/spirv/ (spec-constant-enum*.slang) covering enum specialization constants in various scenarios to verify SPIR-V emission and runtime-cast behavior.

### Summary
A small, localized semantic change enabling enums (represented as scalar integers) to be valid specialization-constant types, accompanied by comprehensive SPIR-V tests. No changes to lexer, parser, IR passes, codegen, or public headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->