### PR TITLE
Diagnostics: Remove TTY flag from test tools

### DIFF
--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1049,7 +1049,9 @@ Result spawnAndWaitSharedLibrary(
         rhiDebugBridge.setCoreCallback(&coreDebugCallback);
 
         // Say static so not released
-        StringWriter stdError(&stdErrorString, WriterFlag::IsConsole | WriterFlag::IsStatic);
+        StringWriter stdError(&stdErrorString, WriterFlag::IsStatic);
+        // Use IsConsole on stdout because we have tests which output spirv
+        // which we want to have disassembled
         StringWriter stdOut(&stdOutString, WriterFlag::IsConsole | WriterFlag::IsStatic);
 
         StdWriters* prevStdWriters = StdWriters::getSingleton();

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -530,9 +530,10 @@ SlangResult TestServer::_executeTool(const JSONRPCCall& call)
     StringBuilder stdError;
     renderer_test::CoreDebugCallback debugCallback;
 
-    // Make writer/s act as if they are the console.
+    RefPtr<StringWriter> stdErrorWriter(new StringWriter(&stdError));
+    // Use IsConsole on stdout because we have tests which output spirv
+    // which we want to have disassembled
     RefPtr<StringWriter> stdOutWriter(new StringWriter(&stdOut, WriterFlag::IsConsole));
-    RefPtr<StringWriter> stdErrorWriter(new StringWriter(&stdError, WriterFlag::IsConsole));
 
     stdWriters.setWriter(SLANG_WRITER_CHANNEL_STD_ERROR, stdErrorWriter);
     stdWriters.setWriter(SLANG_WRITER_CHANNEL_STD_OUTPUT, stdOutWriter);


### PR DESCRIPTION
## Summary
- Removes `WriterFlag::IsConsole` from StringWriters in slang-test and test-server
- This changes how test output behaves (no longer pretends to be a console/TTY)

## Test plan
- Run CI tests to verify behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)