### PR TITLE
Diagnostics: Fix error code padding and bounds check

### DIFF
--- a/source/compiler-core/slang-rich-diagnostics-render.cpp
+++ b/source/compiler-core/slang-rich-diagnostics-render.cpp
@@ -231,7 +231,8 @@ private:
     String repeat(char c, Int64 n) const
     {
         String ret;
-        ret.appendRepeatedChar(c, n);
+        if (n > 0)
+            ret.appendRepeatedChar(c, n);
         return ret;
     }
 
@@ -611,11 +612,12 @@ private:
                                      ? TerminalColor::Red
                                      : TerminalColor::Yellow;
         ss << color(sevColor, layout.header.severity);
-        String codeStr = String(layout.header.code);
-        while (codeStr.getLength() < 4)
-            codeStr = "0" + codeStr;
-        ss << "[E" << codeStr << "]"
-           << ": " << color(TerminalColor::BoldRegular, layout.header.message) << "\n";
+        if (layout.header.code >= 0)
+        {
+            String codeStr = String(layout.header.code);
+            ss << "[E" << repeat('0', 5 - codeStr.getLength()) << codeStr << "]";
+        }
+        ss << ": " << color(TerminalColor::BoldRegular, layout.header.message) << "\n";
 
         // Skip location and source snippet for diagnostics without meaningful locations
         // (line 0 indicates SourceLoc() was used, meaning no source location)
@@ -666,10 +668,16 @@ String renderDiagnosticMachineReadable(SourceManager* sm, const GenericDiagnosti
     // Format:
     // E<code>\t<severity>\t<filename>\t<beginline>\t<begincol>\t<endline>\t<endcol>\t<message>
 
-    // Format the error code as E#### (e.g., E0001, E1234)
-    String codeStr = String(diag.code);
-    while (codeStr.getLength() < 4)
-        codeStr = "0" + codeStr;
+    // Format the error code as E##### (e.g., E00001, E12345)
+    // Use empty string for negative codes (-1 is used as placeholder for no code)
+    String codeStr;
+    if (diag.code >= 0)
+    {
+        String numStr = String(diag.code);
+        String padding;
+        padding.appendRepeatedChar('0', std::max<Int64>(0, 5 - numStr.getLength()));
+        codeStr = padding + numStr;
+    }
 
     // Helper lambda to output a span in the machine-readable format
     // Returns false if the span was skipped (0,0 location with no message)


### PR DESCRIPTION
## Summary
- Add bounds check in `repeat()` function to handle negative counts
- Change error code formatting from 4 digits to 5 digits
- Handle negative diagnostic codes (used as placeholder for no code)

## Test plan
- Run CI tests to verify behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes diagnostic error code formatting and adds robustness to the diagnostic rendering system in the Slang compiler.

## Changes Made

**Modified Files:**
- `source/compiler-core/slang-rich-diagnostics-render.cpp`
- `source/compiler-core/slang-rich-diagnostics-render.h`

**Key Changes:**
1. **Bounds check in `repeat()` function**: Added guard to prevent appending repeated characters when `n <= 0`, avoiding unintended behavior with negative counts
2. **Error code padding format**: Updated from 4-digit (`E####`) to 5-digit (`E#####`) format with zero-padding for positive diagnostic codes
3. **Negative code handling**: Extended machine-readable diagnostic format to properly handle negative diagnostic codes (used as placeholder for "no code"), rendering them as empty code strings instead of attempting to format negative values

## Impact Analysis

**Compiler Stages Affected:** None  
This change is isolated to the diagnostic rendering layer (output formatting) and does not modify the lexer, parser, semantic analyzer, IR, or codegen stages.

**Target Backends:** None  
The change only affects how diagnostics are displayed to users and does not impact code generation for SPIRV, HLSL, GLSL, Metal, CUDA, WGSL, or any other backend.

**Public API Headers:** No modifications  
The public API headers (`include/slang.h`, `include/slang-com-helper.h`) are not modified by this PR.

**Scope:** Internal infrastructure (diagnostic rendering)  
This is a non-breaking change to how error codes are formatted in diagnostic messages without affecting compiler behavior or generated code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->