### PR TITLE
Fix SPIR-V emit crash from void-typed debug variables in cleanUpVoidType

### DIFF
--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -2614,6 +2614,11 @@ struct IRDebugVar : IRInst
     IRInst* getLine() { return getOperand(1); }
     IRInst* getCol() { return getOperand(2); }
     IRInst* getArgIndex() { return getOperandCount() >= 4 ? getOperand(3) : nullptr; }
+    void setArgIndex(IRInst* argIndex)
+    {
+        if (getOperandCount() >= 4)
+            setOperand(3, argIndex);
+    }
 };
 
 FIDDLE()

--- a/tests/spirv/debug-var-void-argument.slang
+++ b/tests/spirv/debug-var-void-argument.slang
@@ -1,0 +1,42 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -g2 -O0
+//
+// When function arguments are legalized to Void and removed from the function
+// signature, debug variable metadata for the remaining arguments must be
+// remapped to the correct argument indices.
+// Tests both int[0] (zero-length array) and Conditional<T, false> (struct
+// whose only field is specialized away) as sources of void-typed parameters.
+
+struct MyStruct
+{
+    Conditional<float3, false> m_color;
+}
+
+void f(int[0] dropped, MyStruct alsoDropped, int kept)
+{
+    int x = kept;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    MyStruct s;
+    f({}, s, 0);
+}
+
+// The removed parameters should not appear as debug variables.
+// CHECK-NOT: OpString "dropped"
+// CHECK-NOT: OpString "alsoDropped"
+
+// CHECK-DAG: [[KEPT_STR:%[0-9]+]] = OpString "kept"
+// kept's DebugLocalVariable ArgNumber (last operand) should be 1 after
+// both void parameters are removed and the index is remapped.
+// CHECK-DAG: [[KEPT_DBGVAR:%[A-Za-z_0-9]+]] = OpExtInst %void {{%[0-9]+}} DebugLocalVariable [[KEPT_STR]] %{{[0-9]+}} %{{[0-9]+}} %uint_{{[0-9]+}} %uint_{{[0-9]+}} %{{[0-9]+}} %uint_0 %uint_1
+
+// f() should have a single runtime parameter after void cleanup.
+// CHECK-LABEL: ; Function f
+// CHECK: %{{[A-Za-z_0-9]+}} = OpFunction %void None %{{[0-9]+}}
+// CHECK: [[KEPT_PARAM:%[A-Za-z_0-9]+]] = OpFunctionParameter %int
+// CHECK: %{{[0-9]+}} = OpLabel
+// CHECK: DebugDeclare [[KEPT_DBGVAR]]
+// CHECK: OpFunctionEnd

--- a/tests/spirv/debug-var-void-variable.slang
+++ b/tests/spirv/debug-var-void-variable.slang
@@ -1,0 +1,30 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -g2 -O0
+// Zero-length array variables are legalized to void types and removed.
+// Check we do not generate debug info for the removed variables.
+
+void f(int[0] droppedArg)
+{
+    int[0] droppedLocal = {};
+    int kept = 1;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    f({});
+}
+
+// The droppedArg and droppedLocal variables should not appear in the output.
+// CHECK-NOT: OpString "droppedArg"
+// CHECK-NOT: OpString "droppedLocal"
+
+// Check the kept variable has debug info
+// CHECK-DAG: [[KEPT_STR:%[0-9]+]] = OpString "kept"
+// CHECK-DAG: [[KEPT_DBGVAR:%[A-Za-z_0-9]+]] = OpExtInst %void {{%[0-9]+}} DebugLocalVariable [[KEPT_STR]] %{{[0-9]+}} %{{[0-9]+}} %uint_{{[0-9]+}} %uint_{{[0-9]+}} %{{[0-9]+}} %uint_0
+
+// f() should have no parameters after empty-array legalization + void cleanup
+// CHECK-LABEL: ; Function f
+// CHECK: %{{[A-Za-z_0-9]+}} = OpFunction %void None %{{[0-9]+}}
+// CHECK-NOT: OpFunctionParameter
+// CHECK: DebugDeclare [[KEPT_DBGVAR]]


### PR DESCRIPTION
* The cleanUpVoidType IR pass was generating DebugValues equal to void_constant, which is not lowerable to a SPIR-V DebugValue, causing an 'Unknown global inst in spirv-emit' compilation error.
* Add processing of DebugVars and DebugValues to the cleanUpVoidType pass, removing any with a type of VoidType
* Remap DebugVar arg indices when function parameters are modified, so the indices map correctly to IRFunc parameter indices.
* Add test case covering void type function arguments and local variables
* Add test case covering functions with modified argument indices after void type removal

Slang repro:
void f(int[0] droppedArg)
{
    int[0] droppedLocal = {};
    int kept = 1;
}

IR after cleanUpVoidType (before):
func %f : Func(Void)
{
    let %droppedArg   : Ptr(Void) = DebugVar(...)
    DebugValue(%droppedArg, void_constant)
    let %droppedLocal : Ptr(Void) = DebugVar(...)
    DebugValue(%droppedLocal, %10)
    let %kept         : Ptr(Int)  = DebugVar(...)
    DebugValue(%kept, 1 : Int)
}
... Unhandled global inst in spirv-emit: ... void_constant

IR after cleanUpVoidType (after):
func %f : Func(Void)
{
    let %kept : Ptr(Int) = DebugVar(...)
    DebugValue(%kept, 1 : Int)
}

Fixes #10060