### PR TITLE
Add regression test for recursive BackwardDifferentiable hang (#10066)

### DIFF
--- a/tests/bugs/recursive-backward-diff-hang.slang
+++ b/tests/bugs/recursive-backward-diff-hang.slang
@@ -1,0 +1,20 @@
+// Regression test for https://github.com/shader-slang/slang/issues/10066
+// Compiler hangs on recursive [BackwardDifferentiable]. Uses TEST_IGNORE_FILE until fixed.
+// Run manually: timeout 5 slangc recursive-backward-diff-hang.slang -target spirv -entry computeMain -stage compute
+
+//TEST_IGNORE_FILE:
+
+[BackwardDifferentiable]
+float recursiveSum(float x, int n)
+{
+    if (n <= 0)
+        return 0.0;
+    return x + recursiveSum(x * 0.5, n - 1);
+}
+
+[numthreads(1,1,1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    DifferentialPair<float> dp = diffPair(1.0, 0.0);
+    __bwd_diff(recursiveSum)(dp, 3, 1.0);
+}


### PR DESCRIPTION
Adds regression test for #10066

The test uses `//TEST_IGNORE_FILE:` because the unfixed compiler hangs. It will be ignored by CI until the bug is fixed. To verify manually:
```bash
timeout 5 slangc tests/bugs/recursive-backward-diff-hang.slang -target glsl -entry computeMain -stage compute -o /dev/null
# Exit 124 = timeout (confirming hang)
```
