### PR TITLE
dynamic dispatch: add tests for generic methods in interfaces (#9886)

### DIFF
--- a/tests/language-feature/dynamic-dispatch/generic-method-constrained.slang
+++ b/tests/language-feature/dynamic-dispatch/generic-method-constrained.slang
@@ -84,18 +84,21 @@ float testComputeScaled(int id, float val, float scale)
 }
 
 [numthreads(1, 1, 1)]
-void computeMain()
+void computeMain(int id : SV_DispatchThreadID)
 {
+    // id is a runtime value (== 0 for the single thread) so the compiler cannot
+    // propagate constants into the helper functions and optimize away the dispatch.
+
     // compute<Constant>: AddOneProcessor returns val+1, NegateProcessor returns -val
-    outputBuffer[0] = testComputeConstant(0, 4.0);  // CHECK: 5
-    outputBuffer[1] = testComputeConstant(1, 4.0);  // CHECK: -4
+    outputBuffer[0] = testComputeConstant(id,     4.0);  // CHECK: 5
+    outputBuffer[1] = testComputeConstant(id + 1, 4.0);  // CHECK: -4
 
     // compute<Doubled>: same method, different T — Doubled.get() = val*2
     // AddOneProcessor: 3.0*2 + 1 = 7, NegateProcessor: -(3.0*2) = -6
-    outputBuffer[2] = testComputeDoubled(0, 3.0);   // CHECK: 7
-    outputBuffer[3] = testComputeDoubled(1, 3.0);   // CHECK: -6
+    outputBuffer[2] = testComputeDoubled(id,     3.0);   // CHECK: 7
+    outputBuffer[3] = testComputeDoubled(id + 1, 3.0);   // CHECK: -6
 
     // computeScaled<Constant>: AddOneProcessor returns val*scale+1, NegateProcessor returns -(val*scale)
-    outputBuffer[4] = testComputeScaled(0, 2.0, 3.0); // CHECK: 7
-    outputBuffer[5] = testComputeScaled(1, 2.0, 3.0); // CHECK: -6
+    outputBuffer[4] = testComputeScaled(id,     2.0, 3.0); // CHECK: 7
+    outputBuffer[5] = testComputeScaled(id + 1, 2.0, 3.0); // CHECK: -6
 }

--- a/tests/language-feature/dynamic-dispatch/generic-method-dispatch.slang
+++ b/tests/language-feature/dynamic-dispatch/generic-method-dispatch.slang
@@ -78,26 +78,29 @@ int testIdentityInt(int id, int x)
 }
 
 [numthreads(1, 1, 1)]
-void computeMain()
+void computeMain(int id : SV_DispatchThreadID)
 {
+    // id is a runtime value (== 0 for the single thread) so the compiler cannot
+    // propagate constants into the helper functions and optimize away the dispatch.
+
     // doubled<float>: IdentitySerializer returns x+x, NegatingSerializer returns -(x+x)
-    outputBuffer[0] = testDoubledFloat(0, 3.0);   // CHECK: 6
-    outputBuffer[1] = testDoubledFloat(1, 3.0);   // CHECK: -6
+    outputBuffer[0] = testDoubledFloat(id,     3.0);   // CHECK: 6
+    outputBuffer[1] = testDoubledFloat(id + 1, 3.0);   // CHECK: -6
 
     // doubled<int>: same method, different type argument — dispatch to same 2 types
-    outputBuffer[2] = float(testDoubledInt(0, 5)); // CHECK: 10
-    outputBuffer[3] = float(testDoubledInt(1, 5)); // CHECK: -10
+    outputBuffer[2] = float(testDoubledInt(id,     5)); // CHECK: 10
+    outputBuffer[3] = float(testDoubledInt(id + 1, 5)); // CHECK: -10
 
     // identity<float>: unconstrained generic method, both implementations return value as-is
-    outputBuffer[4] = testIdentityFloat(0, 7.0);  // CHECK: 7
-    outputBuffer[5] = testIdentityFloat(1, 7.0);  // CHECK: 7
+    outputBuffer[4] = testIdentityFloat(id,     7.0);  // CHECK: 7
+    outputBuffer[5] = testIdentityFloat(id + 1, 7.0);  // CHECK: 7
 
     // identity<int>: same method, different type argument
-    outputBuffer[6] = float(testIdentityInt(0, 9)); // CHECK: 9
-    outputBuffer[7] = float(testIdentityInt(1, 9)); // CHECK: 9
+    outputBuffer[6] = float(testIdentityInt(id,     9)); // CHECK: 9
+    outputBuffer[7] = float(testIdentityInt(id + 1, 9)); // CHECK: 9
 
     // process<T> is void — verify it compiles and can be called through dynamic dispatch
-    ISerializer s = makeSerializer(0);
+    ISerializer s = makeSerializer(id);
     s.process<float>(1.0);
     s.process<int>(42);
 }


### PR DESCRIPTION
Fixes #9886 

Tests that interface methods with generic type parameters (method<T>()) dispatch correctly at runtime through dynamically-typed interface objects. Covers unconstrained generics, multiple type arguments (float and int), void generic methods, and methods with user-defined interface constraints (T : IValue).