### PR TITLE
Add narrow repro for #9267: autodiff gradient depends on load pattern

### DIFF
--- a/tests/bugs/9267-autodiff-max-gradient-README.md
+++ b/tests/bugs/9267-autodiff-max-gradient-README.md
@@ -1,0 +1,20 @@
+# Narrow repro for #9267: autodiff max() gradient depends on load pattern
+
+Two kernels compute the same loss (`abs(pos) - half` -> `max(exceed, 0)` -> sum).
+`loss_kernel_vec_max` uses `loadVecOnce<3>` (loop with mutable index).
+`loss_kernel_vec_max_manual` uses three manual `loadOnce` calls.
+Same `max()`, same inputs. Gradients differ -- max abs error 0.1667.
+
+The bug is in how the backward pass reverses the loadVecOnce loop index,
+not in the `max()` tie-breaking rule.
+
+## Run
+
+```bash
+python3 tests/bugs/9267-autodiff-max-gradient-runner.py
+# Exit 1 = gradients differ (bug present)
+# Exit 0 = gradients match (fixed)
+```
+
+Requires PyTorch, slangtorch, CUDA. Tested with Slang 2026.2.2,
+slangtorch 1.3.19, PyTorch 2.10.0, CUDA 13.0.

--- a/tests/bugs/9267-autodiff-max-gradient-runner.py
+++ b/tests/bugs/9267-autodiff-max-gradient-runner.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Run repro for GitHub #9267: max() autodiff gradient depends on load pattern.
+Requires: PyTorch, slangtorch, CUDA.
+
+Usage:
+  python tests/bugs/9267-autodiff-max-gradient-runner.py
+
+Reveals the bug when gradients from loss_kernel_vec_max (loadVecOnce) differ
+from loss_kernel_vec_max_manual (manual loadOnce) for the same inputs.
+"""
+from pathlib import Path
+import sys
+
+try:
+    import torch
+    import slangtorch
+except ImportError as e:
+    print("Need PyTorch and slangtorch:", e, file=sys.stderr)
+    sys.exit(1)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SLANG_FILE = SCRIPT_DIR / "9267-autodiff-max-gradient.slang"
+THREADS = 256
+
+
+def main():
+    if not torch.cuda.is_available():
+        print("CUDA is required", file=sys.stderr)
+        sys.exit(1)
+
+    if not SLANG_FILE.exists():
+        print("Slang file not found:", SLANG_FILE, file=sys.stderr)
+        sys.exit(1)
+
+    module = slangtorch.loadModule(
+        str(SLANG_FILE),
+        verbose=False,
+    )
+
+    device = torch.device("cuda")
+    # Same test data as #9267
+    positions_base = torch.tensor(
+        [
+            [0.40, -0.20, 0.15],
+            [-0.35, 0.50, -0.25],
+            [0.10, 0.05, -0.45],
+        ],
+        dtype=torch.float32,
+        device=device,
+    )
+    dims = torch.tensor(
+        [
+            [0.60, 0.50, 0.40],
+            [0.70, 0.90, 0.80],
+            [0.20, 0.30, 0.90],
+        ],
+        dtype=torch.float32,
+        device=device,
+    )
+    n = positions_base.shape[0]
+    scale = 1.0 / max(int(n), 1)
+
+    class LossFn(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, positions, dims, kernel_name):
+            positions = positions.contiguous()
+            dims = dims.contiguous()
+            n = positions.shape[0]
+            scale = 1.0 / max(int(n), 1)
+            loss = torch.empty((n,), dtype=positions.dtype, device=positions.device)
+            blocks = (n + THREADS - 1) // THREADS
+            kernel = getattr(module, kernel_name)
+            kernel(
+                count=n,
+                invCount=scale,
+                positions=positions,
+                dims=dims,
+                lossOut=loss,
+            ).launchRaw(blockSize=(THREADS, 1, 1), gridSize=(blocks, 1, 1))
+            ctx.save_for_backward(positions, dims, loss)
+            ctx.n = n
+            ctx.scale = scale
+            ctx.kernel_name = kernel_name
+            ctx.input_shape = positions.shape
+            return loss
+
+        @staticmethod
+        def backward(ctx, grad_loss):
+            positions, dims, loss = ctx.saved_tensors
+            grad_positions = torch.zeros_like(positions)
+            grad_loss = grad_loss.contiguous()
+            blocks = (ctx.n + THREADS - 1) // THREADS
+            kernel = getattr(module, ctx.kernel_name)
+            kernel.bwd(
+                count=ctx.n,
+                invCount=ctx.scale,
+                positions=(positions, grad_positions),
+                dims=dims,
+                lossOut=(loss, grad_loss),
+            ).launchRaw(blockSize=(THREADS, 1, 1), gridSize=(blocks, 1, 1))
+            return grad_positions.view(ctx.input_shape), None, None
+
+    p_vec = positions_base.clone().detach().requires_grad_(True)
+    p_manual = positions_base.clone().detach().requires_grad_(True)
+    loss_vec = LossFn.apply(p_vec, dims, "loss_kernel_vec_max")
+    loss_manual = LossFn.apply(p_manual, dims, "loss_kernel_vec_max_manual")
+
+    loss_vec.sum().backward()
+    loss_manual.sum().backward()
+
+    g_vec = p_vec.grad.detach().cpu()
+    g_manual = p_manual.grad.detach().cpu()
+
+    # Reference: PyTorch relu
+    p_ref = positions_base.clone().detach().requires_grad_(True)
+    half = dims * 0.5
+    exceed = p_ref.abs() - half
+    loss_ref = torch.relu(exceed).sum(dim=-1) * scale
+    loss_ref.sum().backward()
+    g_ref = p_ref.grad.detach().cpu()
+
+    diff_vec_ref = (g_vec - g_ref).abs().max().item()
+    diff_manual_ref = (g_manual - g_ref).abs().max().item()
+    diff_vec_vs_manual = (g_vec - g_manual).abs().max().item()
+
+    print("Gradient comparison:")
+    print("  vec_max vs reference (max abs error):", diff_vec_ref)
+    print("  vec_max_manual vs reference (max abs error):", diff_manual_ref)
+    print("  vec_max vs vec_max_manual (max abs error):", diff_vec_vs_manual)
+    print()
+    if diff_vec_vs_manual > 1e-5:
+        print("BUG REPRODUCED: vec_max and vec_max_manual gradients differ (same math).")
+        print("grad(vec_max):")
+        print(g_vec)
+        print("grad(vec_max_manual):")
+        print(g_manual)
+        sys.exit(1)
+    else:
+        print("Gradients match (bug not seen with this build/data).")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/bugs/9267-autodiff-max-gradient.slang
+++ b/tests/bugs/9267-autodiff-max-gradient.slang
@@ -1,0 +1,99 @@
+// Minimal repro for GitHub #9267: max() autodiff gradient depends on load pattern.
+// Run with run_9267_reveal.py (slangtorch + PyTorch). Reveals bug when gradient
+// from loadVecOnce path != gradient from manual load path.
+//
+// Kernels: loss_kernel_vec_max (loadVecOnce<3> + max) vs loss_kernel_vec_max_manual
+// (manual loadOnce x3 + same max). Same math; gradients must match.
+
+__generic<T : __BuiltinFloatingPointType>
+extension TensorView<T>
+{
+    __generic<let M : int, let R : int, let N : int>
+    vector<T, M> loadVec(vector<uint, N> x)
+    {
+        vector<T, M> result;
+        [ForceUnroll]
+        for (int j = 0; j < M; j++)
+        {
+            result[j] = this.load(x);
+            x[R] += 1;
+        }
+        return result;
+    }
+    __generic<let M : int, let N : int>
+    vector<T, M> loadVec(vector<uint, N> x)
+    {
+        return this.loadVec<M, N - 1, N>(x);
+    }
+}
+
+__generic<T : __BuiltinFloatingPointType, A : IDiffTensorWrapper>
+extension DiffTensorView<T, A>
+{
+    [Differentiable]
+    __generic<let M : int, let R : int, let N : int>
+    vector<T, M> loadVecOnce(vector<uint, N> x)
+    {
+        vector<T, M> result;
+        [ForceUnroll]
+        for (int j = 0; j < M; j++)
+        {
+            result[j] = this.loadOnce(x);
+            x[R] += 1;
+        }
+        return result;
+    }
+    [Differentiable]
+    __generic<let M : int, let N : int>
+    vector<T, M> loadVecOnce(vector<uint, N> x)
+    {
+        return this.loadVecOnce<M, N - 1, N>(x);
+    }
+}
+
+[CUDAKernel]
+[Differentiable]
+[AutoPyBindCUDA]
+void loss_kernel_vec_max(
+    no_diff uint count,
+    no_diff float invCount,
+    DiffTensorView<float> positions,
+    no_diff TensorView<float> dims,
+    DiffTensorView<float> lossOut)
+{
+    uint idx = cudaThreadIdx().x + cudaBlockIdx().x * cudaBlockDim().x;
+    if (idx >= count) return;
+    float3 pos = positions.loadVecOnce<3>(uint2(idx, 0));
+    float3 half = no_diff(dims.loadVec<3>(uint2(idx, 0))) * 0.5f;
+    float3 exceed = abs(pos) - half;
+    float3 relu = max(exceed, float3(0.0f));
+    float loss_value = (relu.x + relu.y + relu.z) * invCount;
+    lossOut.storeOnce(idx, loss_value);
+}
+
+[CUDAKernel]
+[Differentiable]
+[AutoPyBindCUDA]
+void loss_kernel_vec_max_manual(
+    no_diff uint count,
+    no_diff float invCount,
+    DiffTensorView<float> positions,
+    no_diff TensorView<float> dims,
+    DiffTensorView<float> lossOut)
+{
+    uint idx = cudaThreadIdx().x + cudaBlockIdx().x * cudaBlockDim().x;
+    if (idx >= count) return;
+    float3 pos;
+    pos.x = positions.loadOnce(uint2(idx, 0));
+    pos.y = positions.loadOnce(uint2(idx, 1));
+    pos.z = positions.loadOnce(uint2(idx, 2));
+    float3 half;
+    half.x = dims.load(uint2(idx, 0));
+    half.y = dims.load(uint2(idx, 1));
+    half.z = dims.load(uint2(idx, 2));
+    half = half * 0.5f;
+    float3 exceed = abs(pos) - half;
+    float3 relu = max(exceed, float3(0.0f));
+    float loss_value = (relu.x + relu.y + relu.z) * invCount;
+    lossOut.storeOnce(idx, loss_value);
+}


### PR DESCRIPTION
## Narrow repro for #9267

Two Slang kernels compute the same loss. One uses `loadVecOnce<3>` (loop + mutable index), the other uses three manual `loadOnce` calls. Same `max()`, same inputs.

**Result:** Gradients differ. Max abs error 0.1667 (= 1/6, the `invCount`). The loadVecOnce path routes gradient to wrong tensor indices.

**The bug is not the `max()` tie-breaking rule.** Both kernels use the same `max()`. The issue is how the backward pass reverses the `loadVecOnce` loop index arithmetic. Manual loads produce correct gradients; the loop path doesn't.

### Files

- `tests/bugs/9267-autodiff-max-gradient.slang` -- two kernels (loadVecOnce vs manual)
- `tests/bugs/9267-autodiff-max-gradient-runner.py` -- runs both, compares, exits 1 if they differ
- `tests/bugs/9267-autodiff-max-gradient-README.md` -- details

### Run

```bash
python3 tests/bugs/9267-autodiff-max-gradient-runner.py
```

Requires slangtorch + PyTorch + CUDA. Tested with Slang 2026.2.2, PyTorch 2.10.0, slangtorch 1.3.19, CUDA 13.0, RTX A3000.

### Gradient output

```
grad(vec_max):
[[ 0.3333, -0.0000,  0.0000],
 [-0.1667,  0.3333, -0.0000],
 [ 0.1667,  0.0000, -0.1667]]

grad(vec_max_manual):
[[0.3333, -0.0000, -0.0000],
 [0.0000, 0.3333, -0.0000],
 [0.0000, -0.0000, 0.0000]]
```

Refs: #9267
