### PR TITLE
Implement HitObject.GetRayTCurrent for OptiX backend

### DIFF
--- a/prelude/slang-cuda-prelude.h
+++ b/prelude/slang-cuda-prelude.h
@@ -5618,6 +5618,13 @@ static __forceinline__ __device__ float slangOptixHitObjectGetRayTime(OptixTrave
 #endif
 
 #if (OPTIX_VERSION >= 80100)
+static __forceinline__ __device__ float slangOptixHitObjectGetRayTmax(OptixTraversableHandle* Obj)
+{
+    return optixHitObjectGetRayTmax();
+}
+#endif
+
+#if (OPTIX_VERSION >= 80100)
 static __forceinline__ __device__ uint
 slangOptixHitObjectGetSbtGASIndex(OptixTraversableHandle* Obj)
 {

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -23589,14 +23589,16 @@ struct HitObject
     }
 
         /// Returns the parametric ending point (T value at hit/miss). Valid if the hit object represents a hit or a miss.
-        /// DXR 1.3 only.
+        /// DXR 1.3 and OptiX.
     [ForceInline]
     [require(hlsl, ser_dxr_raygen_closesthit_miss)]
+    [require(cuda, ser_raygen_closesthit_miss)]
     float GetRayTCurrent()
     {
         __target_switch
         {
         case hlsl: __intrinsic_asm ".GetRayTCurrent";
+        case cuda: __intrinsic_asm "slangOptixHitObjectGetRayTmax";
         }
     }
 

--- a/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-get-ray-tcurrent-cuda.slang
+++ b/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-get-ray-tcurrent-cuda.slang
@@ -1,0 +1,33 @@
+// Test HitObject.GetRayTCurrent for CUDA/OptiX target
+
+//TEST:SIMPLE(filecheck=CUDA): -target cuda -entry rayGenShader -stage raygeneration
+
+//TEST_INPUT: set sceneBVH = AccelerationStructure
+uniform RaytracingAccelerationStructure sceneBVH;
+
+//TEST_INPUT:set resultBuffer = out ubuffer(data=[0 0], stride=4)
+uniform RWStructuredBuffer<float> resultBuffer;
+
+struct MyPayload
+{
+    float val;
+};
+
+[shader("raygeneration")]
+void rayGenShader()
+{
+    RayDesc ray;
+    ray.Origin = float3(0.1, 0.1, 0.1);
+    ray.Direction = float3(0.0, 0.0, 1.0);
+    ray.TMin = 0.001;
+    ray.TMax = 10000.0;
+
+    MyPayload payload = { 0.0 };
+
+    // CUDA: optixTraverse
+    HitObject hitobj = HitObject::TraceRay(sceneBVH, RAY_FLAG_NONE, ~0, 0, 0, 0, ray, payload);
+
+    // Test HitObject.GetRayTCurrent() lowered to optixHitObjectGetRayTmax on CUDA/OptiX
+    // CUDA: slangOptixHitObjectGetRayTmax
+    resultBuffer[0] = hitobj.GetRayTCurrent();
+}


### PR DESCRIPTION
Lower `HitObject.GetRayTCurrent` to `optixHitObjectGetRayTmax` when targeting CUDA/OptiX.

Closes #10094

Generated with [Claude Code](https://claude.ai/code)