### PR TITLE
Add dynamic dispatch tests for special interface members (#9887)

### DIFF
--- a/tests/language-feature/dynamic-dispatch/special-members-dispatch.slang
+++ b/tests/language-feature/dynamic-dispatch/special-members-dispatch.slang
@@ -1,0 +1,137 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cpu -compute -shaderobj -output-using-type
+//TEST:SIMPLE(filecheck=REPORT):-target hlsl -stage compute -entry computeMain -report-dynamic-dispatch-sites
+
+// Test for GitHub issue #9887: Dynamic Dispatch of Special Members
+// Verifies that property getters, subscript getters, function call operators (operator()),
+// and constructors (__init) all work correctly through dynamic dispatch.
+//
+// Note: Property setters and subscript setters through dynamic dispatch are a known
+// limitation (unimplemented type packing). See special-members-setter-limitation.slang.
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+interface IFullFeatured
+{
+    __init(int value);
+
+    property float value { get; set; }
+
+    __subscript(int i) -> float { get; set; }
+
+    float operator()(float x, float y);
+
+    int getValue();
+}
+
+// ImplA: identity implementation
+struct ImplA : IFullFeatured
+{
+    int _val;
+    float _storage;
+
+    // __init initializes both fields from value
+    __init(int value) { _val = value; _storage = float(value); }
+
+    property float value
+    {
+        get { return float(_val); }
+        set { _val = int(newValue); }
+    }
+
+    __subscript(int i) -> float
+    {
+        get { return _storage; }
+        set { _storage = newValue; }
+    }
+
+    float operator()(float x, float y) { return x + y; }
+
+    int getValue() { return _val; }
+}
+
+// ImplB: scaled implementation — multiplies/divides by _scale=2.0
+struct ImplB : IFullFeatured
+{
+    int _val;
+    float _storage;
+    float _scale;
+
+    // __init doubles _val and initializes _storage and _scale
+    __init(int value) { _val = value * 2; _storage = float(value); _scale = 2.0; }
+
+    property float value
+    {
+        get { return float(_val) * _scale; }
+        set { _val = int(newValue / _scale); }
+    }
+
+    __subscript(int i) -> float
+    {
+        get { return _storage * _scale; }
+        set { _storage = newValue / _scale; }
+    }
+
+    float operator()(float x, float y) { return x * y; }
+
+    int getValue() { return _val; }
+}
+
+IFullFeatured makeObj(int id)
+{
+    if (id == 0) return ImplA(10);
+    else return ImplB(10);
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(int id : SV_DispatchThreadID)
+{
+    // --- ImplA (id=0): ImplA(10) -> _val=10, _storage=10.0 ---
+    IFullFeatured objA = makeObj(id);
+
+    // Property getter via dynamic dispatch
+    outputBuffer[0] = objA.value;               // ImplA: float(10) = 10.0
+    // REPORT-DAG: ([[# @LINE-1]]): {{.*}} generated {{.*}} dispatch code{{.*}} 2 possible types:
+    // CHECK: 10.0
+
+    // Subscript getter via dynamic dispatch
+    outputBuffer[1] = objA[0];                  // ImplA: _storage = 10.0
+    // REPORT-DAG: ([[# @LINE-1]]): {{.*}} generated {{.*}} dispatch code{{.*}} 2 possible types:
+    // CHECK: 10.0
+
+    // Function call operator via dynamic dispatch
+    outputBuffer[2] = objA(2.0, 3.0);           // ImplA: 2.0 + 3.0 = 5.0
+    // REPORT-DAG: ([[# @LINE-1]]): {{.*}} generated {{.*}} dispatch code{{.*}} 2 possible types:
+    // CHECK: 5.0
+
+    // Regular method to verify __init ran correctly
+    outputBuffer[3] = float(objA.getValue());   // ImplA: _val = 10
+    // REPORT-DAG: ([[# @LINE-1]]): {{.*}} generated {{.*}} dispatch code{{.*}} 2 possible types:
+    // CHECK: 10.0
+
+    // --- ImplB (id+1=1): ImplB(10) -> _val=20, _storage=10.0, _scale=2.0 ---
+    IFullFeatured objB = makeObj(id + 1);
+
+    // Property getter via dynamic dispatch
+    outputBuffer[4] = objB.value;               // ImplB: float(20)*2.0 = 40.0
+    // REPORT-DAG: ([[# @LINE-1]]): {{.*}} generated {{.*}} dispatch code{{.*}} 2 possible types:
+    // CHECK: 40.0
+
+    // Subscript getter via dynamic dispatch
+    outputBuffer[5] = objB[0];                  // ImplB: 10.0*2.0 = 20.0
+    // REPORT-DAG: ([[# @LINE-1]]): {{.*}} generated {{.*}} dispatch code{{.*}} 2 possible types:
+    // CHECK: 20.0
+
+    // Function call operator via dynamic dispatch
+    outputBuffer[6] = objB(2.0, 3.0);           // ImplB: 2.0 * 3.0 = 6.0
+    // REPORT-DAG: ([[# @LINE-1]]): {{.*}} generated {{.*}} dispatch code{{.*}} 2 possible types:
+    // CHECK: 6.0
+
+    // Regular method to verify __init ran correctly
+    outputBuffer[7] = float(objB.getValue());   // ImplB: _val = 20
+    // REPORT-DAG: ([[# @LINE-1]]): {{.*}} generated {{.*}} dispatch code{{.*}} 2 possible types:
+    // CHECK: 20.0
+}

--- a/tests/language-feature/dynamic-dispatch/special-members-generic-subscript.slang
+++ b/tests/language-feature/dynamic-dispatch/special-members-generic-subscript.slang
@@ -1,0 +1,87 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cpu -compute -shaderobj -output-using-type
+//TEST:SIMPLE(filecheck=REPORT):-target hlsl -stage compute -entry computeMain -report-dynamic-dispatch-sites
+
+// Test for GitHub issue #9887: Dynamic Dispatch of Special Members — Generic Subscript
+// Verifies that a generic subscript operator __subscript<T>(T index) -> float works
+// correctly through dynamic dispatch with multiple type arguments for T.
+//
+// The same generic subscript is called with T=int, T=float, and T=uint at different
+// call sites, each generating its own dispatch function (similar to generic methods).
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+interface ILookup
+{
+    __subscript<T>(T index) -> float { get; }
+}
+
+// ImplA: returns _val + _bonus regardless of index
+struct ImplA : ILookup
+{
+    float _val;
+    float _bonus;
+
+    __subscript<T>(T index) -> float
+    {
+        get { return _val + _bonus; }
+    }
+}
+
+// ImplB: returns _val * _scale regardless of index
+struct ImplB : ILookup
+{
+    float _val;
+    float _scale;
+
+    __subscript<T>(T index) -> float
+    {
+        get { return _val * _scale; }
+    }
+}
+
+// ImplA(5.0, 2.0) -> subscript returns 5.0 + 2.0 = 7.0
+// ImplB(3.0, 4.0) -> subscript returns 3.0 * 4.0 = 12.0
+ILookup makeObj(int id)
+{
+    if (id == 0) { ImplA a; a._val = 5.0; a._bonus = 2.0; return a; }
+    else { ImplB b; b._val = 3.0; b._scale = 4.0; return b; }
+}
+
+float testInt(int id)
+{
+    ILookup obj = makeObj(id);
+    return obj[int(0)];   // T=int
+    // REPORT-DAG: ([[# @LINE-1]]): {{.*}} generated {{.*}} dispatch code{{.*}} 2 possible types:
+}
+
+float testFloat(int id)
+{
+    ILookup obj = makeObj(id);
+    return obj[float(0.5)]; // T=float — separate dispatch function from T=int
+    // REPORT-DAG: ([[# @LINE-1]]): {{.*}} generated {{.*}} dispatch code{{.*}} 2 possible types:
+}
+
+float testUint(int id)
+{
+    ILookup obj = makeObj(id);
+    return obj[uint(2)];  // T=uint — another separate dispatch function
+    // REPORT-DAG: ([[# @LINE-1]]): {{.*}} generated {{.*}} dispatch code{{.*}} 2 possible types:
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(int id : SV_DispatchThreadID)
+{
+    // ImplA (id=0): all subscript calls return 7.0
+    outputBuffer[0] = testInt(id);    // CHECK: 7.0
+    outputBuffer[1] = testFloat(id);  // CHECK: 7.0
+    outputBuffer[2] = testUint(id);   // CHECK: 7.0
+
+    // ImplB (id+1=1): all subscript calls return 12.0
+    outputBuffer[3] = testInt(id + 1);    // CHECK: 12.0
+    outputBuffer[4] = testFloat(id + 1);  // CHECK: 12.0
+    outputBuffer[5] = testUint(id + 1);   // CHECK: 12.0
+}

--- a/tests/language-feature/dynamic-dispatch/special-members-setter-limitation.slang
+++ b/tests/language-feature/dynamic-dispatch/special-members-setter-limitation.slang
@@ -1,0 +1,81 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=CHECK): -target hlsl -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=CHECK): -target cpp -entry computeMain -stage compute
+
+//
+// Limitation: Property setters and subscript setters through dynamic dispatch
+//
+// When a property setter or subscript setter is invoked through an interface-typed variable
+// (dynamic dispatch), the compiler emits a controlled error (not a crash/segfault):
+//   error 99999: unimplemented: Unimplemented type packing
+//
+// The mutation requires repacking the modified concrete value back into the AnyValue
+// storage of the existential interface value, which is not yet implemented.
+//
+// When this limitation is fixed, this test should be replaced with a positive
+// compute test verifying correct runtime behavior.
+//
+
+interface IFullFeatured
+{
+    property float value { get; set; }
+    __subscript(int i) -> float { get; set; }
+}
+
+struct ImplA : IFullFeatured
+{
+    int _val;
+    float _storage;
+    property float value
+    {
+        get { return float(_val); }
+        set { _val = int(newValue); }
+    }
+    __subscript(int i) -> float
+    {
+        get { return _storage; }
+        set { _storage = newValue; }
+    }
+}
+
+struct ImplB : IFullFeatured
+{
+    int _val;
+    float _storage;
+    float _scale;
+    property float value
+    {
+        get { return float(_val) * _scale; }
+        set { _val = int(newValue / _scale); }
+    }
+    __subscript(int i) -> float
+    {
+        get { return _storage * _scale; }
+        set { _storage = newValue / _scale; }
+    }
+}
+
+IFullFeatured makeObj(int id)
+{
+    if (id == 0) { ImplA a; a._val = 10; a._storage = 0.0; return a; }
+    else { ImplB b; b._val = 20; b._storage = 0.0; b._scale = 2.0; return b; }
+}
+
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(int id : SV_DispatchThreadID)
+{
+    IFullFeatured obj = makeObj(id);
+
+    // Property setter through dynamic dispatch — emits error 99999: unimplemented type packing
+    // CHECK: error 99999
+    obj.value = 5.0;
+
+    // Subscript setter through dynamic dispatch — same limitation
+    obj[0] = 3.0;
+
+    outputBuffer[0] = obj.value;
+    outputBuffer[1] = obj[0];
+}


### PR DESCRIPTION
Fixes #9887

Test that property getters, subscript getters, function call operators (operator()), and constructors (__init) dispatch correctly through interface-typed variables at runtime. Also test generic subscript (__subscript<T>) with multiple type arguments (int, float, uint).

Document known limitation: property/subscript setters through dynamic dispatch fail with "unimplemented type packing" (error 99999). issue #10111 created for tracking purpose.