### PR TITLE
Fix underflow in rounding in type layout reflection in 32-bit builds

### DIFF
--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -52,9 +52,15 @@ static size_t _roundUpToPowerOfTwo(size_t value)
     value--;
 #if SLANG_VC && 0
     // TODO: Disabled to avoid build failure on aarch64/windows
-    return 1ULL << (64 - (size_t)__lzcnt64(value));
+    if constexpr (sizeof(size_t) > 4)
+        return size_t(1) << (sizeof(size_t) * 8 - __lzcnt64(value));
+    else
+        return size_t(1) << (sizeof(size_t) * 8 - __lzcnt(value));
 #elif SLANG_GCC || SLANG_CLANG
-    return 1ULL << (sizeof(size_t) * 8 - __builtin_clzll(value));
+    if constexpr (sizeof(size_t) > 4)
+        return size_t(1) << (sizeof(size_t) * 8 - __builtin_clzll(value));
+    else
+        return size_t(1) << (sizeof(size_t) * 8 - __builtin_clzl(value));
 #else
     value |= value >> 1;
     value |= value >> 2;


### PR DESCRIPTION
Fixes https://github.com/shader-slang/slang-playground/issues/179

In `static size_t _roundUpToPowerOfTwo(size_t value)`, the GCC/Clang path computes `1ULL << (sizeof(size_t) * 8 - __builtin_clzll(value))`. `__builtin_clzll` counts leading zeros in a 64-bit `unsigned long long`, but `sizeof(size_t) * 8` is 32 on 32-bit targets, so the subtraction underflows and we get an undefined shift result.

In 32-bit builds such as the WASM build used by the Slang Playground, this manifests as a round to 0, breaking uniform buffer alignment. Vectors like `float4` get `uniformAlignment = 0` instead of 16, so all uniform parameters are reported at `offset = 0` in the reflection JSON despite the generated WGSL correctly using `@align(16)`.

This fix checks the result of `sizeof(size_t)` like the `#else` branch of `_roundUpToPowerOfTwo` and uses `__builtin_clzl` instead of `__builtin_clzll` if `size_t` is 4 bytes or less (and therefore 32-bits long).