### PR TITLE
Remove overly strict assertion in diagnostic rendering

### DIFF
--- a/source/compiler-core/slang-rich-diagnostics-render.cpp
+++ b/source/compiler-core/slang-rich-diagnostics-render.cpp
@@ -53,16 +53,6 @@ public:
     String render(const GenericDiagnostic& diag)
     {
         DiagnosticLayout layout = createLayout(diag);
-
-        // If we're skipping the source snippet (no valid location), ensure the span message
-        // is empty - otherwise we would be silently dropping important diagnostic information
-        bool hasValidLocation =
-            layout.primaryLoc.line > 0 || layout.primaryLoc.fileName.getLength() > 0;
-        if (!hasValidLocation)
-        {
-            SLANG_ASSERT(diag.primarySpan.message.getLength() == 0);
-        }
-
         return renderFromLayout(layout);
     }
 


### PR DESCRIPTION
## Summary
- Removes an overly strict assertion in diagnostic rendering that could trigger incorrectly

## Test plan
- CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)