### PR TITLE
Add slang-neural-module as dependency of slang-test

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -273,6 +273,7 @@ if(SLANG_ENABLE_TESTS AND SLANG_ENABLE_SLANG_RHI)
             slangd
             test-server
             test-process
+            slang-neural-module
         OPTIONAL_REQUIRES
             slang-rt
             slang-glslang


### PR DESCRIPTION
## Summary
- Adds slang-neural-module as a build dependency of slang-test

## Test plan
- CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)