### PR TITLE
Fix severity override handling for numeric diagnostic IDs

### DIFF
--- a/source/slang/slang-diagnostics.cpp
+++ b/source/slang/slang-diagnostics.cpp
@@ -99,8 +99,14 @@ SlangResult overrideDiagnostic(
         diagnosticId = diagnostic->id;
     }
 
-    // If we are only allowing certain original severities check it's the right type
-    if (diagnostic && originalSeverity != Severity::Disable &&
+    // If we are only allowing certain original severities check it's the right type.
+    // However, when using numeric IDs, we skip this check because multiple diagnostics
+    // can share the same ID with different severities (e.g., both warnings and errors
+    // may use ID 41024). The override will still be applied to all diagnostics with
+    // that ID regardless of their individual severities.
+    bool usedNumericId =
+        identifier.getLength() > 0 && (CharUtil::isDigit(identifier[0]) || identifier[0] == '-');
+    if (!usedNumericId && diagnostic && originalSeverity != Severity::Disable &&
         diagnostic->severity != originalSeverity)
     {
         // Strictly speaking the diagnostic name is known, but it's not the right severity


### PR DESCRIPTION
## Summary
- Fixes severity override handling when using numeric diagnostic IDs

## Test plan
- CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)