### PR TITLE
Ensure temporary DiagnosticSinks inherit parent configuration

### DIFF
--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -394,7 +394,12 @@ bool SemanticsVisitor::createInvokeExprForExplicitCtor(
                 fromInitializerListExpr->args);
 
             DiagnosticSink tempSink(getSourceManager(), nullptr);
-            tempSink.setFlags(getSink()->getFlags());
+            if (auto parentSink = getSink())
+            {
+                tempSink.setFlags(parentSink->getFlags());
+                tempSink.setDiagnosticColorMode(parentSink->getDiagnosticColorMode());
+                tempSink.setEnableUnicode(parentSink->getEnableUnicode());
+            }
 
             SemanticsVisitor subVisitor(withSink(&tempSink));
             ctorInvokeExpr = subVisitor.CheckTerm(ctorInvokeExpr);
@@ -479,6 +484,12 @@ bool SemanticsVisitor::createInvokeExprForSynthesizedCtor(
     }
 
     DiagnosticSink tempSink(getSourceManager(), nullptr);
+    if (auto parentSink = getSink())
+    {
+        tempSink.setFlags(parentSink->getFlags());
+        tempSink.setDiagnosticColorMode(parentSink->getDiagnosticColorMode());
+        tempSink.setEnableUnicode(parentSink->getEnableUnicode());
+    }
     SemanticsVisitor subVisitor(withSink(&tempSink));
 
     // First make sure the struct is fully checked, otherwise the synthesized constructor may not be

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -2876,6 +2876,12 @@ Expr* SemanticsVisitor::ResolveInvoke(InvokeExpr* expr)
     bool typeOverloadChecked = false;
 
     DiagnosticSink collectedErrorsSink(getSourceManager(), nullptr);
+    if (auto parentSink = getSink())
+    {
+        collectedErrorsSink.setFlags(parentSink->getFlags());
+        collectedErrorsSink.setDiagnosticColorMode(parentSink->getDiagnosticColorMode());
+        collectedErrorsSink.setEnableUnicode(parentSink->getEnableUnicode());
+    }
     if (expr->arguments.getCount() == 1 && !as<ExplicitCtorInvokeExpr>(expr) &&
         !as<InitializerListExpr>(expr->arguments[0]))
     {


### PR DESCRIPTION
## Summary
- Ensures temporary DiagnosticSinks inherit configuration from parent sinks

## Test plan
- CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)