### PR TITLE
Fix incorrect SLANG_RETURN_ON_FAIL usage in slang-test

### DIFF
--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -5364,7 +5364,7 @@ SlangResult innerMain(int argc, char** argv)
 
     // The context holds useful things used during testing
     TestContext context;
-    SLANG_RETURN_ON_FAIL(SLANG_FAILED(context.init(argv[0])))
+    SLANG_RETURN_ON_FAIL(context.init(argv[0]))
 
     auto& categorySet = context.categorySet;
 


### PR DESCRIPTION
## Summary
- Fixes incorrect error handling in slang-test-main.cpp where `SLANG_RETURN_ON_FAIL(SLANG_FAILED(...))` was incorrectly wrapping the init call
- `SLANG_RETURN_ON_FAIL` already checks for failure, so wrapping in `SLANG_FAILED()` inverts the logic - it would return on success instead of failure

## Test plan
- CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)