### PR TITLE
Improve CI disk space cleanup with more directories and better logging

### DIFF
--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -56,9 +56,9 @@ jobs:
             /host_root/usr/local/lib/heroku \
           ; do
             if [ -d "$dir" ]; then
-              size=$(du -sh "$dir" 2>/dev/null | cut -f1)
+              size=$(du -sh "$dir" 2>/dev/null | cut -f1 || echo "unknown")
               echo "Removing $dir ($size)..."
-              rm -rf "$dir"
+              rm -rf "$dir" || true
             fi
           done
           echo "=== Disk space after cleanup ==="


### PR DESCRIPTION
Replace individual `rm -rf` commands with a loop that reports the size of each directory before removing it:
- Add several more large pre-installed packages to the cleanup list (~4.5 GB additional savings): `.ghcup`, `powershell`, `chromium`, `boost`, `msedge`, `chrome`, `heroku`
- Directories that don't exist on the runner are silently skipped
 - Follow-up to #10016.