### PR TITLE
Fix glibc-2.27 release build Docker API version mismatch

### DIFF
--- a/.github/workflows/release-linux-glibc-2-27.yml
+++ b/.github/workflows/release-linux-glibc-2-27.yml
@@ -25,7 +25,7 @@ jobs:
             -v ${{ github.workspace }}:/home/app \
             -v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt \
             gztong/ubuntu18-gcc11:glibc2.28 \
-            bash -c '
+            bash -euo pipefail -c '
               export PATH=/opt/cmake-3.25.0-linux-x86_64/bin:$PATH
               cd /home/app
               git config --global --add safe.directory /home/app


### PR DESCRIPTION
Replace addnab/docker-run-action@v3 with a direct docker run command in the glibc-2.27 release workflow. The action bundles Docker client 20.10 (API v1.41), which is now incompatible with the GitHub runner's Docker daemon requiring minimum API v1.44.