### PR TITLE
Fix issue on reinterpret of resource type

### DIFF
--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -572,27 +572,35 @@ struct AnyValueMarshallingContext
             IRType* dataType,
             IRInst* concreteVar) override
         {
-            SLANG_UNUSED(dataType);
             ensureOffsetAt4ByteBoundary();
-            if (fieldOffset + 1 < static_cast<uint32_t>(anyValInfo->fieldKeys.getCount()))
+
+            IRSizeAndAlignment sizeAndAlign;
+            IRIntegerValue size = 8;
+            if (SLANG_SUCCEEDED(
+                    getNaturalSizeAndAlignment(targetRequest, dataType, &sizeAndAlign)) &&
+                sizeAndAlign.size > 0)
+            {
+                size = sizeAndAlign.size;
+            }
+
+            IRIntegerValue numUints = (size + 3) / 4;
+            if (fieldOffset + numUints - 1 <
+                static_cast<uint32_t>(anyValInfo->fieldKeys.getCount()))
             {
                 auto srcVal = builder->emitLoad(concreteVar);
-                // Use uint2 instead of uint64 to avoid Int64 capability requirement
-                auto uint2Type = builder->getVectorType(builder->getUIntType(), 2);
-                auto uint2Val = builder->emitBitCast(uint2Type, srcVal);
-                auto lowBits = builder->emitElementExtract(uint2Val, IRIntegerValue(0));
-                auto highBits = builder->emitElementExtract(uint2Val, IRIntegerValue(1));
-                auto dstAddr1 = builder->emitFieldAddress(
-                    uintPtrType,
-                    anyValueVar,
-                    anyValInfo->fieldKeys[fieldOffset]);
-                builder->emitStore(dstAddr1, lowBits);
-                auto dstAddr2 = builder->emitFieldAddress(
-                    uintPtrType,
-                    anyValueVar,
-                    anyValInfo->fieldKeys[fieldOffset + 1]);
-                builder->emitStore(dstAddr2, highBits);
-                advanceOffset(8);
+                auto uintNType =
+                    builder->getVectorType(builder->getUIntType(), (IRIntegerValue)numUints);
+                auto uintNVal = builder->emitBitCast(uintNType, srcVal);
+                for (IRIntegerValue i = 0; i < numUints; i++)
+                {
+                    auto bits = builder->emitElementExtract(uintNVal, i);
+                    auto dstAddr = builder->emitFieldAddress(
+                        uintPtrType,
+                        anyValueVar,
+                        anyValInfo->fieldKeys[fieldOffset + (uint32_t)i]);
+                    builder->emitStore(dstAddr, bits);
+                }
+                advanceOffset((uint32_t)size);
             }
         }
 
@@ -942,27 +950,38 @@ struct AnyValueMarshallingContext
             IRInst* concreteVar) override
         {
             ensureOffsetAt4ByteBoundary();
-            if (fieldOffset + 1 < static_cast<uint32_t>(anyValInfo->fieldKeys.getCount()))
+
+            IRSizeAndAlignment sizeAndAlign;
+            IRIntegerValue size = 8;
+            if (SLANG_SUCCEEDED(
+                    getNaturalSizeAndAlignment(targetRequest, dataType, &sizeAndAlign)) &&
+                sizeAndAlign.size > 0)
             {
-                auto srcAddr = builder->emitFieldAddress(
-                    uintPtrType,
-                    anyValueVar,
-                    anyValInfo->fieldKeys[fieldOffset]);
-                auto lowBits = builder->emitLoad(srcAddr);
+                size = sizeAndAlign.size;
+            }
 
-                auto srcAddr1 = builder->emitFieldAddress(
-                    uintPtrType,
-                    anyValueVar,
-                    anyValInfo->fieldKeys[fieldOffset + 1]);
-                auto highBits = builder->emitLoad(srcAddr1);
-
-                // Use uint2 instead of uint64 to avoid Int64 capability requirement
-                auto uint2Type = builder->getVectorType(builder->getUIntType(), 2);
-                IRInst* components[2] = {lowBits, highBits};
-                auto uint2Val = builder->emitMakeVector(uint2Type, 2, components);
-                auto combinedBits = builder->emitBitCast(dataType, uint2Val);
+            IRIntegerValue numUints = (size + 3) / 4;
+            if (fieldOffset + numUints - 1 <
+                static_cast<uint32_t>(anyValInfo->fieldKeys.getCount()))
+            {
+                auto uintNType =
+                    builder->getVectorType(builder->getUIntType(), (IRIntegerValue)numUints);
+                List<IRInst*> components;
+                for (IRIntegerValue i = 0; i < numUints; i++)
+                {
+                    auto srcAddr = builder->emitFieldAddress(
+                        uintPtrType,
+                        anyValueVar,
+                        anyValInfo->fieldKeys[fieldOffset + (uint32_t)i]);
+                    components.add(builder->emitLoad(srcAddr));
+                }
+                auto uintNVal = builder->emitMakeVector(
+                    uintNType,
+                    (UInt)numUints,
+                    components.getBuffer());
+                auto combinedBits = builder->emitBitCast(dataType, uintNVal);
                 builder->emitStore(concreteVar, combinedBits);
-                advanceOffset(8);
+                advanceOffset((uint32_t)size);
             }
         }
 

--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -981,8 +981,8 @@ struct AnyValueMarshallingContext
                     components.getBuffer());
                 auto combinedBits = builder->emitBitCast(dataType, uintNVal);
                 builder->emitStore(concreteVar, combinedBits);
-                advanceOffset((uint32_t)size);
             }
+            advanceOffset((uint32_t)size);
         }
 
         // unpack: AnyValue -> DescriptorHandle

--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -975,10 +975,8 @@ struct AnyValueMarshallingContext
                         anyValInfo->fieldKeys[fieldOffset + (uint32_t)i]);
                     components.add(builder->emitLoad(srcAddr));
                 }
-                auto uintNVal = builder->emitMakeVector(
-                    uintNType,
-                    (UInt)numUints,
-                    components.getBuffer());
+                auto uintNVal =
+                    builder->emitMakeVector(uintNType, (UInt)numUints, components.getBuffer());
                 auto combinedBits = builder->emitBitCast(dataType, uintNVal);
                 builder->emitStore(concreteVar, combinedBits);
             }

--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -979,8 +979,8 @@ struct AnyValueMarshallingContext
                     builder->emitMakeVector(uintNType, (UInt)numUints, components.getBuffer());
                 auto combinedBits = builder->emitBitCast(dataType, uintNVal);
                 builder->emitStore(concreteVar, combinedBits);
+                advanceOffset((uint32_t)size);
             }
-            advanceOffset((uint32_t)size);
         }
 
         // unpack: AnyValue -> DescriptorHandle

--- a/source/slang/slang-ir-lower-bit-cast.cpp
+++ b/source/slang/slang-ir-lower-bit-cast.cpp
@@ -238,14 +238,6 @@ struct BitCastLoweringContext
         auto fromType = operand->getDataType();
         auto toType = inst->getDataType();
 
-        // Resource types (e.g. RWStructuredBuffer) cannot be decomposed into basic types.
-        // Leave the bit_cast as-is for the C-like emitter which handles it as a C-style cast.
-        if (as<IRResourceTypeBase>(fromType) || as<IRResourceTypeBase>(toType) ||
-            as<IRHLSLStructuredBufferTypeBase>(fromType) || as<IRHLSLStructuredBufferTypeBase>(toType))
-        {
-            return;
-        }
-
         IRSizeAndAlignment toTypeSize;
         getNaturalSizeAndAlignment(targetProgram->getTargetReq(), toType, &toTypeSize);
         IRSizeAndAlignment fromTypeSize;
@@ -371,6 +363,10 @@ struct BitCastLoweringContext
             return;
         }
         if (as<IRSamplerStateTypeBase>(fromType) || as<IRSamplerStateTypeBase>(toType))
+        {
+            return;
+        }
+        if (as<IRHLSLStructuredBufferTypeBase>(fromType) || as<IRHLSLStructuredBufferTypeBase>(toType))
         {
             return;
         }

--- a/source/slang/slang-ir-lower-bit-cast.cpp
+++ b/source/slang/slang-ir-lower-bit-cast.cpp
@@ -238,6 +238,14 @@ struct BitCastLoweringContext
         auto fromType = operand->getDataType();
         auto toType = inst->getDataType();
 
+        // Resource types (e.g. RWStructuredBuffer) cannot be decomposed into basic types.
+        // Leave the bit_cast as-is for the C-like emitter which handles it as a C-style cast.
+        if (as<IRResourceTypeBase>(fromType) || as<IRResourceTypeBase>(toType) ||
+            as<IRHLSLStructuredBufferTypeBase>(fromType) || as<IRHLSLStructuredBufferTypeBase>(toType))
+        {
+            return;
+        }
+
         IRSizeAndAlignment toTypeSize;
         getNaturalSizeAndAlignment(targetProgram->getTargetReq(), toType, &toTypeSize);
         IRSizeAndAlignment fromTypeSize;

--- a/source/slang/slang-ir-lower-bit-cast.cpp
+++ b/source/slang/slang-ir-lower-bit-cast.cpp
@@ -366,7 +366,8 @@ struct BitCastLoweringContext
         {
             return;
         }
-        if (as<IRHLSLStructuredBufferTypeBase>(fromType) || as<IRHLSLStructuredBufferTypeBase>(toType))
+        if (as<IRHLSLStructuredBufferTypeBase>(fromType) ||
+            as<IRHLSLStructuredBufferTypeBase>(toType))
         {
             return;
         }

--- a/source/standard-modules/neural/bindless-storage.slang
+++ b/source/standard-modules/neural/bindless-storage.slang
@@ -62,9 +62,10 @@ public struct BindlessAddress<T> : IPointerLikeAddress<T>
         {
         case cuda:
             // On CUDA, use packed vector atomic for types that support it (half2, bfloat16x2).
-            let scalarPtr = &handle[baseIndex + index];
-            let vecPtr = reinterpret<vector<T, 2>*>(scalarPtr);
-            __atomic_reduce_add(vecPtr[0], value);
+            // baseIndex and index are in units of T, but vecBuffer is in units of vector<T,2>,
+            // so divide by 2 to convert from scalar to vector element index.
+            RWStructuredBuffer<vector<T, 2>> vecBuffer = reinterpret<RWStructuredBuffer<vector<T, 2>>>(*handle);
+            __atomic_reduce_add(vecBuffer[(baseIndex + index) / 2], value);
         default:
             // On other targets, fall back to two scalar atomic adds.
             atomicAdd(index, value[0]);

--- a/source/standard-modules/neural/bindless-storage.slang
+++ b/source/standard-modules/neural/bindless-storage.slang
@@ -62,10 +62,9 @@ public struct BindlessAddress<T> : IPointerLikeAddress<T>
         {
         case cuda:
             // On CUDA, use packed vector atomic for types that support it (half2, bfloat16x2).
-            // baseIndex and index are in units of T, but vecBuffer is in units of vector<T,2>,
-            // so divide by 2 to convert from scalar to vector element index.
-            RWStructuredBuffer<vector<T, 2>> vecBuffer = reinterpret<RWStructuredBuffer<vector<T, 2>>>(*handle);
-            __atomic_reduce_add(vecBuffer[(baseIndex + index) / 2], value);
+            let scalarPtr = &handle[baseIndex + index];
+            let vecPtr = reinterpret<vector<T, 2>*>(scalarPtr);
+            __atomic_reduce_add(vecPtr[0], value);
         default:
             // On other targets, fall back to two scalar atomic adds.
             atomicAdd(index, value[0]);

--- a/tests/compute/reinterpret-structured-buffer.slang
+++ b/tests/compute/reinterpret-structured-buffer.slang
@@ -1,0 +1,34 @@
+// Test reinterpret_cast of RWStructuredBuffer<half> to RWStructuredBuffer<half2>.
+// Verifies that AnyValue marshalling correctly handles the full size of
+// StructuredBuffer on CUDA (16 bytes: T* data + size_t count).
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
+
+// Input buffer: 4 half values = [1.0, 2.0, 3.0, 4.0]
+//TEST_INPUT: ubuffer(data=[0x40003C00 0x44004200], stride=2, count=4):name=inputBuffer
+uniform RWStructuredBuffer<half>.Handle inputBuffer;
+
+//TEST_INPUT: ubuffer(data=[0 0 0 0], stride=2, count=4):out,name=outputBuffer
+RWStructuredBuffer<half> outputBuffer;
+
+[numthreads(1, 1, 1)]
+[shader("compute")]
+void computeMain()
+{
+    RWStructuredBuffer<half2> vecBuffer = reinterpret<RWStructuredBuffer<half2>>(*inputBuffer);
+
+    __atomic_reduce_add(vecBuffer[0], half2(1.0h, 2.0h));
+    
+    half2 v0 = vecBuffer[0];
+    half2 v1 = vecBuffer[1];
+
+    outputBuffer[0] = v0.x;
+    outputBuffer[1] = v0.y;
+    outputBuffer[2] = v1.x;
+    outputBuffer[3] = v1.y;
+}
+
+// CHECK: 2.0
+// CHECK-NEXT: 4.0
+// CHECK-NEXT: 3.0
+// CHECK-NEXT: 4.0

--- a/tests/neural/basic-coopmat-vector-test.slang
+++ b/tests/neural/basic-coopmat-vector-test.slang
@@ -1,8 +1,8 @@
-// TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_POINTER=0 -emit-spirv-directly
-// TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_POINTER=0
+// // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_POINTER=0 -emit-spirv-directly
+// // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_POINTER=0
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=1 -xslang -DTEST_POINTER=0
-// TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_POINTER=1
-// TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=1 -xslang -DTEST_POINTER=1
+// // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_POINTER=1
+// // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=1 -xslang -DTEST_POINTER=1
 
 import neural;
 
@@ -146,7 +146,6 @@ void BasicTestWithBias(int tid, int resIndex)
     bool isPassed = true;
     isPassed = isPassed && (outputVec[0] == ElementType(39.0) && outputVec[1] == ElementType(80.0));
 
-
     var weightDiffPair = DifferentialPtrPair<Address>(weightAddress, dWeightAddress);
     var biasDiffPair = DifferentialPtrPair<Address>(biasAddress, dBiasAddress);
     let dOutput = OutVectorType(1.0);
@@ -173,7 +172,6 @@ void BasicTestWithBias(int tid, int resIndex)
     // dBias = {1, 1}
     isPassed = isPassed &&
         dParameters[8] == 32.0 && dParameters[9] == 32.0;
-
 
     isPassed = WaveActiveAllTrue(isPassed);
     if (tid == 0)
@@ -251,5 +249,5 @@ void computeMain(uint tid : SV_DispatchThreadID)
 
     cleanupDParameters();
     BasicTestWithBias(tid, 1);
-    // BUFFER: 1
+    // BUFFER-NEXT: 1
 }

--- a/tests/neural/basic-coopmat-vector-test.slang
+++ b/tests/neural/basic-coopmat-vector-test.slang
@@ -1,8 +1,8 @@
-// // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_POINTER=0 -emit-spirv-directly
-// // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_POINTER=0
+// TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_POINTER=0 -emit-spirv-directly
+// TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_POINTER=0
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=1 -xslang -DTEST_POINTER=0
-// // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_POINTER=1
-// // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=1 -xslang -DTEST_POINTER=1
+// TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_POINTER=1
+// TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=1 -xslang -DTEST_POINTER=1
 
 import neural;
 


### PR DESCRIPTION
Close https://github.com/shader-slang/slang/issues/10126.

This PR address two issues:

- correctly handle the packing of resource handles: we previously hardcode the size of the handles, however the size of resource handle could be varying with targets.

- Skip processing bitcast of storage buffer in processingBitCast call. After the pass of lowering the reinterpret, we could insert bitCast insts, and we will need to skip the processing of the bit cast of resource handles because we couldn't handle that.
