### PR TITLE
Install a pkgconfig file for slang-compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -644,6 +644,21 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
             NAMESPACE ${PROJECT_NAME}::
             DESTINATION ${SLANG_CMAKE_CONFIG_DIR}
         )
+
+        if(UNIX)
+            configure_file(
+                "${PROJECT_SOURCE_DIR}/extras/pkgconfig/slang-compiler.pc.in"
+                "${PROJECT_BINARY_DIR}/slang-compiler.pc"
+                @ONLY
+            )
+
+            # TODO: When build system is changed to respect CMAKE_INSTALL_LIBDIR,
+            # update this destination.
+            install(
+                FILES "${PROJECT_BINARY_DIR}/slang-compiler.pc"
+                DESTINATION "lib/pkgconfig"
+            )
+        endif()
     endif()
 endif()
 

--- a/extras/pkgconfig/slang-compiler.pc.in
+++ b/extras/pkgconfig/slang-compiler.pc.in
@@ -1,0 +1,13 @@
+prefix=${pcfiledir}/../..
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: slang-compiler
+Description: Slang shading language compiler library
+Version: @SLANG_VERSION_NUMERIC@
+Libs: -L${libdir} -lslang-compiler
+Cflags: -I${includedir}
+
+# Note: pkg-config --static is not currently supported,
+# so Libs.private is not populated.


### PR DESCRIPTION
A pkgconfig file is used in Linux ecossystem by the various build
systems to find the slang-compiler library.

This patch doesn't change the current cmake support files that are
installed -- these provide more information for users that already use
CMake.

This was suggested in the past in #4016, but at the time there were some
issues with the library name.

Note the current build system intentionally chooses `lib` instead of
`CMAKE_INSTALL_LIBDIR`, so propagating that choice into the pkgconfig
file.   Same for `include`.