### PR TITLE
Add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,8 +108,9 @@ vkd3d-proton.cache.write
 .*.swp
 .*.swo
 
-# Claude local settings and memory
+# Claude local settings, memory, and worktrees
 /.claude/settings.local.json
+/.claude/worktrees/
 CLAUDE.local.md
 
 # Other temporary files


### PR DESCRIPTION
Add .claude/worktrees/ to .gitignore so that Claude Code worktree directories are not tracked by git.