### PR TITLE
Reduce Windows GPU test parallelism to fix OOM failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,7 @@ jobs:
       runs-on: '["Windows", "self-hosted", "GCP-T4"]'
       test-category: full
       full-gpu-tests: true
+      server-count: 4
 
   test-windows-release-cl-x86_64-gpu:
     needs: [filter, build-windows-release-cl-x86_64-gpu]
@@ -241,6 +242,7 @@ jobs:
       runs-on: '["Windows", "self-hosted", "GCP-T4"]'
       test-category: full
       full-gpu-tests: true
+      server-count: 4
 
   # MaterialX Integration Tests (Windows only for initial validation)
   test-materialx-windows-release:


### PR DESCRIPTION
## Summary
- Windows CI GPU tests were running with `server-count: 8` (the default), causing `CUDA_ERROR_OUT_OF_MEMORY` and `E_OUTOFMEMORY` cascading failures on the T4 GPUs (16 GB VRAM)
- Reduce to `server-count: 4` for both debug and release Windows GPU jobs, matching the Linux GPU runner configuration
- Example failure: https://github.com/shader-slang/slang/actions/runs/22406658734/job/64870590341 — 556 test failures (370 CUDA, 186 other APIs) due to OOM cascade

## Test plan
- [ ] Verify Windows GPU CI jobs pass without OOM errors
- [ ] Confirm test runtime increase is acceptable