### PR TITLE
Add diagnostic tests for bit_cast on interface-typed values (#9920)

### DIFF
--- a/tests/language-feature/dynamic-dispatch/bit-cast-interface-roundtrip.slang
+++ b/tests/language-feature/dynamic-dispatch/bit-cast-interface-roundtrip.slang
@@ -7,9 +7,12 @@
 // the existential's byte-level layout at compile time, and bit_cast fails with
 // a size mismatch.
 //
-// Once issue #9920 is resolved, the compiler should expose a stable existential
-// layout so that bit_cast<RawType>(interfaceValue) and
-// bit_cast<IFoo>(rawValue) produce correct round-trip results.
+// Two sub-issues block this feature:
+//   #10221 — bit_cast extracts concrete payload instead of full existential
+//   #10222 — specialization lowers existential to compact tagged-union
+//
+// Once resolved, bit_cast<RawType>(interfaceValue) and
+// bit_cast<IFoo>(rawValue) should produce correct round-trip results.
 
 //TEST:SIMPLE(filecheck=CHECK):-target hlsl -stage compute -entry computeMain -conformance "FooA:IFoo=0" -conformance "FooB:IFoo=1"
 
@@ -45,6 +48,9 @@ float testRoundTrip(int typeId, float val)
     IFoo foo = createDynamicObject<IFoo>(typeId, val);
     // CHECK: error 41202
     RawExistential raw = bit_cast<RawExistential>(foo);
+    // The reverse cast would also fail, but the compiler bails out after the
+    // first error above so no second diagnostic is emitted today.  A partial
+    // fix to #10221 or #10222 could change that; add a CHECK here when it does.
     IFoo foo2 = bit_cast<IFoo>(raw);
     return foo2.eval();
 }

--- a/tests/language-feature/dynamic-dispatch/bit-cast-interface-serialize.slang
+++ b/tests/language-feature/dynamic-dispatch/bit-cast-interface-serialize.slang
@@ -1,10 +1,10 @@
 // Manual serialization of interface-typed values into a raw uint buffer using
 // bit_cast, then deserialization back to interface type.
 //
-// This is blocked on the same limitation as bit-cast-interface-roundtrip:
-// the compiler's tagged-union representation for existentials does not match
-// the expected full existential tuple layout, causing a size mismatch in
-// bit_cast.  See issue #9920.
+// Blocked on the same two sub-issues as bit-cast-interface-roundtrip:
+//   #10221 — bit_cast extracts concrete payload instead of full existential
+//   #10222 — specialization lowers existential to compact tagged-union
+// See parent issue #9920.
 
 //TEST:SIMPLE(filecheck=CHECK):-target hlsl -stage compute -entry computeMain -conformance "FooA:IFoo=0" -conformance "FooB:IFoo=1"
 
@@ -46,6 +46,9 @@ IFoo deserialize(RWStructuredBuffer<uint> buf, int baseSlot)
     RawExistential raw;
     for (int i = 0; i < kRawUints; i++)
         raw.data[i] = buf[baseSlot + i];
+    // This cast would also fail, but the compiler bails out after the first
+    // error in serialize() so no second diagnostic is emitted today.  A partial
+    // fix to #10221 or #10222 could change that; add a CHECK here when it does.
     return bit_cast<IFoo>(raw);
 }
 


### PR DESCRIPTION
Fixes #9920

Two tests document the current limitation: bit_cast between interface-typed values and raw structs fails with error 41202 (size mismatch) because the compiler opens the existential before bit_cast sees it and optimizes the representation into a compact tagged union.

The found issues are tracked by:  #10221, #10222
