### PR TITLE
Add tests for ref/constref interface-typed struct fields

### DIFF
--- a/tests/language-feature/dynamic-dispatch/diagnose-ref-interface-struct-field.slang
+++ b/tests/language-feature/dynamic-dispatch/diagnose-ref-interface-struct-field.slang
@@ -1,0 +1,84 @@
+// The __ref and __constref modifiers are parameter-only qualifiers.
+// When applied to struct fields, the compiler rejects them with error 31201
+// ("modifier not allowed here"). This holds regardless of whether the field
+// type is an interface or a concrete type, but the interface case is
+// particularly important because storing a reference to an AnyValue-packed
+// existential tuple in a struct field would bypass the pack/unpack
+// marshalling required for dynamic dispatch.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+//TEST:SIMPLE(filecheck=CHECK): -target hlsl -stage compute -entry computeMain
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -stage compute -entry computeMain
+//TEST:SIMPLE(filecheck=CHECK): -target metal -stage compute -entry computeMain
+//TEST:SIMPLE(filecheck=CHECK): -target wgsl -stage compute -entry computeMain
+//TEST:SIMPLE(filecheck=CHECK): -target cpp -stage compute -entry computeMain
+
+[anyValueSize(16)]
+interface IFoo
+{
+    float getValue();
+}
+
+struct ImplA : IFoo
+{
+    float v;
+    float getValue() { return v; }
+}
+
+// Direct __ref to interface type on struct field.
+struct RefFieldDirect
+{
+    // CHECK: ([[# @LINE+1]]): error 31201
+    __ref IFoo field;
+}
+
+// Direct __constref to interface type on struct field.
+struct ConstrefFieldDirect
+{
+    // CHECK: ([[# @LINE+1]]): error 31201
+    __constref IFoo field;
+}
+
+// __ref on a concrete type struct field (same restriction applies).
+struct RefFieldConcrete
+{
+    // CHECK: ([[# @LINE+1]]): error 31201
+    __ref float field;
+}
+
+// __constref on a concrete type struct field.
+struct ConstrefFieldConcrete
+{
+    // CHECK: ([[# @LINE+1]]): error 31201
+    __constref float field;
+}
+
+// Both __ref and __constref on fields in the same struct.
+struct MixedRefFields
+{
+    // CHECK: ([[# @LINE+1]]): error 31201
+    __ref IFoo refField;
+    // CHECK: ([[# @LINE+1]]): error 31201
+    __constref IFoo constrefField;
+}
+
+// Nested struct: inner struct tries to use __ref on interface field.
+struct Inner
+{
+    // CHECK: ([[# @LINE+1]]): error 31201
+    __ref IFoo iface;
+}
+
+struct Outer
+{
+    Inner inner;
+    float value;
+}
+
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    outputBuffer[0] = 0.0;
+}

--- a/tests/language-feature/dynamic-dispatch/diagnose-ref-type-interface-struct-field.slang
+++ b/tests/language-feature/dynamic-dispatch/diagnose-ref-type-interface-struct-field.slang
@@ -1,0 +1,72 @@
+// Using Ref<T> as a struct field type is not supported. Reference types
+// (Ref, RefParam, BorrowInParam) are designed for function parameters
+// and return values; they cannot be stored in struct fields because
+// there is no stable storage address to reference across struct copies.
+//
+// When T is an interface type, this is doubly problematic: the existential
+// value is stored as an AnyValue-packed tuple, and a reference into that
+// buffer would bypass the pack/unpack marshalling needed for dynamic
+// dispatch.
+//
+// Currently this triggers an internal compiler error (assert failure in
+// LoweredValInfo) instead of a user-friendly diagnostic. These tests are
+// disabled until the compiler produces a proper error message.
+
+//DISABLED_TEST:SIMPLE(filecheck=CHECK): -target spirv
+//DISABLED_TEST:SIMPLE(filecheck=CHECK): -target hlsl -stage compute -entry computeMain
+//DISABLED_TEST:SIMPLE(filecheck=CHECK): -target cuda -stage compute -entry computeMain
+//DISABLED_TEST:SIMPLE(filecheck=CHECK): -target metal -stage compute -entry computeMain
+//DISABLED_TEST:SIMPLE(filecheck=CHECK): -target wgsl -stage compute -entry computeMain
+//DISABLED_TEST:SIMPLE(filecheck=CHECK): -target cpp -stage compute -entry computeMain
+
+[anyValueSize(16)]
+interface IFoo
+{
+    float getValue();
+}
+
+struct ImplA : IFoo
+{
+    float v;
+    float getValue() { return v; }
+}
+
+struct ImplB : IFoo
+{
+    float v;
+    float getValue() { return v * 2; }
+}
+
+// Ref<IFoo> as a struct field: should be diagnosed rather than ICE.
+struct RefInterfaceField
+{
+    // CHECK: ([[# @LINE+1]]): error
+    Ref<IFoo> field;
+}
+
+// Ref<ConcreteType> as a struct field: same underlying issue.
+struct RefConcreteField
+{
+    // CHECK: ([[# @LINE+1]]): error
+    Ref<float> field;
+}
+
+// Nested: struct containing another struct with Ref<IFoo> field.
+struct InnerRef
+{
+    // CHECK: ([[# @LINE+1]]): error
+    Ref<IFoo> iface;
+}
+
+struct OuterRef
+{
+    InnerRef inner;
+}
+
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    outputBuffer[0] = 0.0;
+}


### PR DESCRIPTION
Add diagnostic tests verifying that __ref/__constref modifiers are rejected on struct fields (error 31201), and a disabled test documenting that Ref<T> as a struct field type causes an ICE instead of a proper diagnostic.