### PR TITLE
Add Git Bash to PATH before cache restore on Windows

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -63,9 +63,11 @@ runs:
           $installDir = Join-Path $env:RUNNER_TEMP "sccache-bin"
           New-Item -ItemType Directory -Force -Path $installDir | Out-Null
           $archive = Join-Path $env:RUNNER_TEMP "sccache.tar.gz"
-          curl -L -o $archive https://github.com/mozilla/sccache/releases/download/v0.7.4/sccache-v0.7.4-x86_64-pc-windows-msvc.tar.gz
-          tar xzf $archive -C $env:RUNNER_TEMP
-          Move-Item (Join-Path $env:RUNNER_TEMP "sccache-v0.7.4-x86_64-pc-windows-msvc/sccache.exe") (Join-Path $installDir "sccache.exe")
+          curl.exe -L -o $archive https://github.com/mozilla/sccache/releases/download/v0.7.4/sccache-v0.7.4-x86_64-pc-windows-msvc.tar.gz
+          Push-Location $env:RUNNER_TEMP
+          tar xzf $archive
+          Pop-Location
+          Move-Item (Join-Path $env:RUNNER_TEMP "sccache-v0.7.4-x86_64-pc-windows-msvc\sccache.exe") (Join-Path $installDir "sccache.exe")
           $installDir | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
           & (Join-Path $installDir "sccache.exe") --version
         }

--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -58,8 +58,8 @@ jobs:
         if: inputs.os == 'windows'
         shell: pwsh
         run: |
-          Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files\Git\bin"
-          Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files\Git\usr\bin"
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Windows self-hosted runners need Git Bash tools (gzip) in PATH for actions/cache to extract cached sccache objects. Add Git Bash paths before the cache restore step.