### PR TITLE
CI health: add administration:read for runners endpoint

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      administration: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The CI health workflow needs administration:read permission on GITHUB_TOKEN to access the runners endpoint (repos/{repo}/actions/runners). Without it, the health page records empty runner data in snapshots.