### PR TITLE
Fix CI health workflow: use PAT instead of invalid administration permission

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -11,7 +11,6 @@ jobs:
     permissions:
       contents: read
       actions: read
-      administration: read
 
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +24,7 @@ jobs:
 
       - name: Generate health page
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CI_ANALYTICS_PAT }}
         run: |
           python3 extras/ci/analytics/ci_health.py \
             --output ci_analytics_repo


### PR DESCRIPTION
administration:read is not a valid GITHUB_TOKEN workflow permission, causing workflow parse failures. Switches to CI_ANALYTICS_PAT which now has administration:read on the slang repo for accessing the runners endpoint.