### PR TITLE
Add regression test for HitObject.FromRayQuery SPIR-V failure (#10307)

### DIFF
--- a/tests/bugs/hitobject-fromrayquery-spirv.slang
+++ b/tests/bugs/hitobject-fromrayquery-spirv.slang
@@ -1,0 +1,24 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-assembly -entry main -stage raygeneration
+// CHECK: OpEntryPoint
+
+// Regression test for https://github.com/shader-slang/slang/issues/10307
+// HitObject.FromRayQuery fails on SPIR-V with error 41009 in hlsl.meta.slang:23722.
+// Other HitObject methods (MakeNop, Invoke, IsNop) work correctly on SPIR-V.
+
+RaytracingAccelerationStructure accelStruct;
+
+[shader("raygeneration")]
+void main()
+{
+    RayDesc ray;
+    ray.Origin = float3(0, 0, 0);
+    ray.Direction = float3(0, 0, 1);
+    ray.TMin = 0.0;
+    ray.TMax = 1000.0;
+
+    RayQuery<RAY_FLAG_FORCE_OPAQUE> rq;
+    rq.TraceRayInline(accelStruct, RAY_FLAG_FORCE_OPAQUE, 0xFF, ray);
+    rq.Proceed();
+
+    HitObject hitObj = HitObject.FromRayQuery(rq);
+}


### PR DESCRIPTION
Adds regression test for #10307.

`HitObject.FromRayQuery(rq)` on the SPIR-V target produces error 41009 from the stdlib (`hlsl.meta.slang:23722`): "non-void function must return in all cases." Other HitObject methods (`MakeNop`, `Invoke`, state queries) work correctly on SPIR-V.

```
slangc test.slang -target spirv -o test.spv
# hlsl.meta.slang(23722): error 41009: non-void function must return in all cases for target 'spirv'
```
