### PR TITLE
Add regression test for global type_param ICE (#10309)

### DIFF
--- a/tests/bugs/global-typeparam-ice.slang
+++ b/tests/bugs/global-typeparam-ice.slang
@@ -1,0 +1,25 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-assembly -entry main -stage compute
+// CHECK: OpEntryPoint GLCompute
+
+// Regression test for https://github.com/shader-slang/slang/issues/10309
+// A global variable whose type is a type_param causes ICE 99999 on SPIR-V:
+// "Unexpected context type for parameter info retrieval"
+// Using type_param only in function signatures works correctly.
+
+interface IMaterial
+{
+    float3 shade(float3 normal);
+}
+
+type_param T : IMaterial;
+
+T material;
+
+RWStructuredBuffer<float3> output;
+
+[shader("compute")]
+[numthreads(1,1,1)]
+void main(uint3 tid : SV_DispatchThreadID)
+{
+    output[tid.x] = material.shade(float3(0, 1, 0));
+}


### PR DESCRIPTION
Adds regression test for #10309.

Declaring a global variable with a `type_param` type (`type_param T : IFoo; T material;` at module scope) triggers ICE 99999 on the SPIR-V target: "Unexpected context type for parameter info retrieval." Using `type_param` only in function signatures works correctly.

```
slangc test.slang -target spirv -o test.spv
# error 99999: Unexpected context type for parameter info retrieval
```
