### PR TITLE
Add regression test for HLSL class instantiation SIGSEGV (#10305)

### DIFF
--- a/tests/bugs/hlsl-class-instantiation-segfault.hlsl
+++ b/tests/bugs/hlsl-class-instantiation-segfault.hlsl
@@ -1,0 +1,11 @@
+//TEST_IGNORE_FILE:
+
+// Regression test for https://github.com/shader-slang/slang/issues/10305
+// HLSL `class` instantiation causes SIGSEGV when compiled with `-lang hlsl`.
+// Defining a class alone compiles OK; declaring a variable of class type crashes.
+// Run: slangc -lang hlsl tests/bugs/hlsl-class-instantiation-segfault.hlsl -no-codegen
+// Expected: SIGSEGV (exit 139)
+// When fixed, change to: //TEST:SIMPLE: -lang hlsl -no-codegen
+
+class X {};
+X x;


### PR DESCRIPTION
Adds regression test for #10305

Instantiating an HLSL `class` type when compiling with `-lang hlsl` causes a segmentation fault. Defining a class alone compiles successfully — the crash only occurs when a variable of the class type is declared.

**Test file:** `tests/bugs/hlsl-class-instantiation-segfault.hlsl`

```bash
slangc -lang hlsl tests/bugs/hlsl-class-instantiation-segfault.hlsl -no-codegen
# Currently: Segmentation fault (core dumped), exit 139
```

Replacing `class` with `struct` compiles without issue.