### PR TITLE
Add regression tests for HLSL typedef modifier ICE (#10306)

### DIFF
--- a/tests/bugs/hlsl-precise-typedef-ice.hlsl
+++ b/tests/bugs/hlsl-precise-typedef-ice.hlsl
@@ -1,8 +1,10 @@
-//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -lang hlsl -no-codegen
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -lang hlsl -no-codegen
 
 // Regression test for https://github.com/shader-slang/slang/issues/10306
-// `typedef precise float` triggers ICE 99999 in `-lang hlsl` mode.
+// `typedef precise float` should not trigger ICE 99999 in `-lang hlsl` mode.
 
 typedef precise float pfloat;
-//CHECK: 99999
+
+// CHECK-NOT: 99999
+
 pfloat g_val;

--- a/tests/bugs/hlsl-volatile-typedef-ice.hlsl
+++ b/tests/bugs/hlsl-volatile-typedef-ice.hlsl
@@ -1,8 +1,10 @@
-//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -lang hlsl -no-codegen
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -lang hlsl -no-codegen
 
 // Regression test for https://github.com/shader-slang/slang/issues/10306
-// `typedef volatile float` triggers ICE 99999 in `-lang hlsl` mode.
+// `typedef volatile float` should not trigger ICE 99999 in `-lang hlsl` mode.
 
 typedef volatile float vfloat;
-//CHECK: 99999
+
+// CHECK-NOT: 99999
+
 vfloat g_val;

--- a/tests/expected-failure-github.txt
+++ b/tests/expected-failure-github.txt
@@ -20,3 +20,7 @@ tests/bugs/array-size-groupshared.slang.1 syn (wgpu)
 tests/bugs/generic-groupshared.slang.2 syn (wgpu)
 tests/compute/groupshared.slang.4 syn (wgpu)
 tests/metal/groupshared-threadlocal-same-parameter.slang.4 syn (wgpu)
+
+# HLSL typedef modifier ICE, tracking on github #10306
+tests/bugs/hlsl-volatile-typedef-ice.hlsl
+tests/bugs/hlsl-precise-typedef-ice.hlsl


### PR DESCRIPTION
Adds regression tests for #10306

Using HLSL type modifiers `volatile` or `precise` inside a `typedef` declaration when compiling with `-lang hlsl` triggers internal error 99999.

**Test files:**
- `tests/bugs/hlsl-volatile-typedef-ice.hlsl` — `typedef volatile float t;`
- `tests/bugs/hlsl-precise-typedef-ice.hlsl` — `typedef precise int t;`

```bash
slangc -lang hlsl tests/bugs/hlsl-volatile-typedef-ice.hlsl -no-codegen
# Currently: internal error 99999: unknown type modifier in semantic checking

slangc -lang hlsl tests/bugs/hlsl-precise-typedef-ice.hlsl -no-codegen
# Currently: internal error 99999: unknown type modifier in semantic checking
```

Related: extends scope of #10239 (direction qualifiers in func syntax) and closed #4475 (const in typedef).