### PR TITLE
CI analytics: stack concurrent runners chart and improve PNG export

### DIFF
--- a/extras/ci/analytics/ci_visualization.py
+++ b/extras/ci/analytics/ci_visualization.py
@@ -258,8 +258,15 @@ function downloadChart(canvasId, bg) {
 function copyChart(canvasId, bg) {
   var tmp = renderChartPng(canvasId, bg);
   if (!tmp) return;
+  if (!window.isSecureContext || !navigator.clipboard || !window.ClipboardItem) {
+    console.error('Clipboard API not available (requires HTTPS or localhost)');
+    downloadChart(canvasId, bg);
+    return;
+  }
   tmp.toBlob(function(blob) {
-    navigator.clipboard.write([new ClipboardItem({'image/png': blob})]);
+    navigator.clipboard.write([new ClipboardItem({'image/png': blob})]).catch(function(err) {
+      console.error('Failed to copy chart to clipboard:', err);
+    });
   }, 'image/png');
 }
 """


### PR DESCRIPTION
## Summary
- Stack the Average Concurrent Runners chart so runner groups are visually stacked rather than overlapping
- Replace the PNG download button with a dropdown offering transparent or white background exports
- Exported PNGs now include the chart title and description rendered above the chart

## Test plan
- Open the generated `statistics.html` and verify the concurrent runners chart is stacked
- Use the "Download PNG" dropdown on any chart to test both transparent and white background exports
- Verify exported PNGs include heading and description text above the chart