### PR TITLE
CI analytics: add PNG download/copy buttons to health page charts

### DIFF
--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -224,8 +224,8 @@ def build_history_chart(snapshots):
     timestamps = [_round_time(s["timestamp"][11:16]) for s in snapshots]
 
     # Only show GCP VM groups (Linux GPU and Windows GPU), exclude scaler host and test runners
-    gcp_vm_groups = ["Linux GPU (GCP)", "Windows GPU (GCP)"]
-    palette = {"Linux GPU (GCP)": "#0d6efd", "Windows GPU (GCP)": "#28a745"}
+    gcp_vm_groups = ["Linux GPU (GCP)", "Windows Build (GCP)", "Windows GPU (GCP)"]
+    palette = {"Linux GPU (GCP)": "#0d6efd", "Windows Build (GCP)": "#fd7e14", "Windows GPU (GCP)": "#28a745"}
 
     # Queue depth over time
     queued_data = [s.get("jobs_queued", 0) for s in snapshots]
@@ -363,7 +363,7 @@ def generate_health_html(queue_data, failures, output_dir):
     fetched_at = now.strftime(f"%Y-%m-%d {rounded_time} UTC")
 
     # Runner status section — only online GCP GPU runners
-    GCP_GPU_GROUPS = {"Linux GPU (GCP)", "Windows GPU (GCP)"}
+    GCP_GPU_GROUPS = {"Linux GPU (GCP)", "Windows Build (GCP)", "Windows GPU (GCP)"}
     runners_html = ""
     if queue_data and queue_data.get("self_hosted_runners"):
         runners = queue_data["self_hosted_runners"]

--- a/extras/ci/analytics/runner_config.json
+++ b/extras/ci/analytics/runner_config.json
@@ -98,7 +98,22 @@
       "self_hosted": true
     },
     {
+      "prefix": "linux-test-runner",
+      "name": "Linux GPU (GCP)",
+      "self_hosted": true
+    },
+    {
       "prefix": "win-runner-",
+      "name": "Windows GPU (GCP)",
+      "self_hosted": true
+    },
+    {
+      "prefix": "win-build-runner",
+      "name": "Windows Build (GCP)",
+      "self_hosted": true
+    },
+    {
+      "prefix": "win-test-runner",
       "name": "Windows GPU (GCP)",
       "self_hosted": true
     },


### PR DESCRIPTION
## Summary
- Reuse the shared `chart_section()` helper from `ci_visualization.py` for the three health page charts (GCP Runner VMs, Active CI Workflows, Job Queue Depth)
- Each chart now has Download PNG and Copy PNG dropdowns with transparent/white background options, anchor links, and chart titles/descriptions embedded in exported PNGs
- Add descriptions to each health page chart matching the statistics page style
- Add new runner name prefixes (`win-build-runner`, `win-test-runner`, `linux-test-runner`) for the upcoming VM naming transition, keeping old prefixes (`win-runner-`, `linux-runner-`) during the transition period
- Windows build runners (no GPU) get their own "Windows Build (GCP)" group, separate from "Windows GPU (GCP)" test runners