### PR TITLE
Test: Decouple SlangPy CI dispatch (DO NOT MERGE)

### DIFF
--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -196,25 +196,3 @@ jobs:
       - name: Run slang-rhi tests (OptiX 8.1)
         run: |
           "$bin_dir/slang-rhi-tests" -check-devices -optix-version=80100 -tc="ray-tracing-*.cuda"
-
-  # Trigger SlangPy tests in the SlangPy repository
-  # This job dispatches a repository_dispatch event to trigger SlangPy CI
-  # SlangPy will build Slang from source and run tests against SlangPy TOT
-  trigger-slangpy-tests:
-    runs-on: ubuntu-latest
-    if: always()
-
-    steps:
-      - name: Trigger SlangPy CI
-        if: github.event_name == 'pull_request'
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.SLANGPY_DISPATCH_TOKEN }}
-          repository: shader-slang/slangpy
-          event-type: slang-pr-test
-          client-payload: |
-            {
-              "slang_pr_number": "${{ github.event.pull_request.number }}",
-              "slang_commit_sha": "${{ github.event.pull_request.head.sha }}",
-              "slang_ref": "${{ github.event.pull_request.head.sha }}"
-            }

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -171,25 +171,3 @@ jobs:
         if: inputs.os == 'windows' || inputs.os == 'linux'
         run: |
           "$bin_dir/slang-rhi-tests" -check-devices -optix-version=80100 -tc="ray-tracing-*.cuda"
-
-  # Trigger SlangPy tests in the SlangPy repository
-  # This job dispatches a repository_dispatch event to trigger SlangPy CI
-  # SlangPy will build Slang from source and run tests against SlangPy TOT
-  trigger-slangpy-tests:
-    runs-on: ubuntu-latest
-    if: inputs.full-gpu-tests && (github.event_name == 'pull_request' || inputs.config == 'release')
-
-    steps:
-      - name: Trigger SlangPy CI
-        if: github.event_name == 'pull_request'
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.SLANGPY_DISPATCH_TOKEN }}
-          repository: shader-slang/slangpy
-          event-type: slang-pr-test
-          client-payload: |
-            {
-              "slang_pr_number": "${{ github.event.pull_request.number }}",
-              "slang_commit_sha": "${{ github.event.pull_request.head.sha }}",
-              "slang_ref": "${{ github.event.pull_request.head.sha }}"
-            }

--- a/.github/workflows/ci-trigger-slangpy.yml
+++ b/.github/workflows/ci-trigger-slangpy.yml
@@ -1,0 +1,32 @@
+name: Trigger SlangPy CI
+
+# Use pull_request_target so this workflow has access to repository secrets
+# even for PRs from forks. This is safe because the workflow only dispatches
+# metadata (PR number, SHA) and never checks out or executes PR code.
+on:
+  pull_request_target:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  trigger-slangpy-tests:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft != true
+
+    steps:
+      - name: Trigger SlangPy CI
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.SLANGPY_DISPATCH_TOKEN }}
+          repository: shader-slang/slangpy
+          event-type: slang-pr-test
+          client-payload: |
+            {
+              "slang_pr_number": "${{ github.event.pull_request.number }}",
+              "slang_commit_sha": "${{ github.event.pull_request.head.sha }}",
+              "slang_ref": "${{ github.event.pull_request.head.sha }}"
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,6 @@ jobs:
     needs: [filter, build-linux-debug-gcc-x86_64]
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-slang-test-container.yml
-    secrets: inherit
     with:
       config: debug
       server-count: 4
@@ -158,7 +157,6 @@ jobs:
     needs: [filter, build-linux-release-gcc-x86_64]
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-slang-test-container.yml
-    secrets: inherit
     with:
       config: release
       server-count: 4
@@ -168,7 +166,6 @@ jobs:
     needs: [filter, build-macos-debug-clang-aarch64]
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-slang-test.yml
-    secrets: inherit
     with:
       os: macos
       compiler: clang
@@ -183,7 +180,6 @@ jobs:
     needs: [filter, build-macos-release-clang-aarch64]
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-slang-test.yml
-    secrets: inherit
     with:
       os: macos
       compiler: clang
@@ -199,7 +195,6 @@ jobs:
     needs: [filter, build-linux-debug-gcc-aarch64]
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-slang-test.yml
-    secrets: inherit
     with:
       os: linux
       compiler: gcc
@@ -213,7 +208,6 @@ jobs:
     needs: [filter, build-linux-release-gcc-aarch64]
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-slang-test.yml
-    secrets: inherit
     with:
       os: linux
       compiler: gcc
@@ -228,7 +222,6 @@ jobs:
     needs: [filter, build-windows-debug-cl-x86_64-gpu]
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-slang-test.yml
-    secrets: inherit
     with:
       os: windows
       compiler: cl
@@ -242,7 +235,6 @@ jobs:
     needs: [filter, build-windows-release-cl-x86_64-gpu]
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-slang-test.yml
-    secrets: inherit
     with:
       os: windows
       compiler: cl


### PR DESCRIPTION
Testing that SLANGPY_DISPATCH_TOKEN works from upstream branch. Close after verifying.