### PR TITLE
Use non-GPU runners for Windows builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       compiler: cl
       platform: x86_64
       config: debug
-      runs-on: '["Windows", "self-hosted", "GCP-T4"]'
+      runs-on: '["Windows", "self-hosted", "build"]'
 
   build-windows-release-cl-x86_64-gpu:
     needs: [filter]
@@ -142,7 +142,7 @@ jobs:
       compiler: cl
       platform: x86_64
       config: release
-      runs-on: '["Windows", "self-hosted", "GCP-T4"]'
+      runs-on: '["Windows", "self-hosted", "build"]'
 
   # Linux tests (self-hosted GPU runner, containerized)
   test-linux-debug-gcc-x86_64:

--- a/.github/workflows/populate-fork-cache.yml
+++ b/.github/workflows/populate-fork-cache.yml
@@ -310,7 +310,7 @@ jobs:
       compiler: cl
       platform: x86_64
       config: release
-      runs-on: '["Windows", "self-hosted", "GCP-T4"]'
+      runs-on: '["Windows", "self-hosted", "build"]'
       warnings-as-errors: true
       build-llvm: true
       save-sccache: true
@@ -327,7 +327,7 @@ jobs:
       compiler: cl
       platform: x86_64
       config: debug
-      runs-on: '["Windows", "self-hosted", "GCP-T4"]'
+      runs-on: '["Windows", "self-hosted", "build"]'
       warnings-as-errors: true
       build-llvm: true
       save-sccache: true


### PR DESCRIPTION
## Summary
- Route Windows build jobs to dedicated non-GPU runners using the `build` label
- Windows test jobs continue using GPU runners with the `GCP-T4` label
- Frees GPU capacity for test jobs that actually need it

The non-GPU build runner scale set is already deployed and ready to accept jobs.

Related to #10256