### PR TITLE
CI analytics: fix runner name prefixes for new VM naming

### DIFF
--- a/extras/ci/analytics/runner_config.json
+++ b/extras/ci/analytics/runner_config.json
@@ -98,7 +98,7 @@
       "self_hosted": true
     },
     {
-      "prefix": "linux-test-runner",
+      "prefix": "linux-test-",
       "name": "Linux GPU (GCP)",
       "self_hosted": true
     },
@@ -108,12 +108,12 @@
       "self_hosted": true
     },
     {
-      "prefix": "win-build-runner",
+      "prefix": "win-build-",
       "name": "Windows Build (GCP)",
       "self_hosted": true
     },
     {
-      "prefix": "win-test-runner",
+      "prefix": "win-test-",
       "name": "Windows GPU (GCP)",
       "self_hosted": true
     },


### PR DESCRIPTION
## Summary
- Fix runner name prefixes to match actual scale set naming pattern (e.g. `win-build-1c6ceb2e`, not `win-build-runner`)
- Shorten prefixes from `win-build-runner`/`win-test-runner`/`linux-test-runner` to `win-build-`/`win-test-`/`linux-test-`