### PR TITLE
Increase RTX Remix nightly workflow timeout

### DIFF
--- a/.github/workflows/compile-rtx-remix-shaders-nightly.yml
+++ b/.github/workflows/compile-rtx-remix-shaders-nightly.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   rtx-remix-shader-test:
     runs-on: windows-2022
-    timeout-minutes: 45 # Slang build ~10-15 min + RTX Remix shaders ~10-15 min + buffer
+    timeout-minutes: 180 # Slang build ~10-15 min + RTX Remix shaders ~10-15 min + buffer
 
     defaults:
       run:


### PR DESCRIPTION
Temporarily increase the timeout of RTX Remix workflow to 3h until perf regression is fixed.