### PR TITLE
Restore SlangPy test jobs, make cross-repo dispatch manual-only

### DIFF
--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -196,3 +196,139 @@ jobs:
       - name: Run slang-rhi tests (OptiX 8.1)
         run: |
           "$bin_dir/slang-rhi-tests" -check-devices -optix-version=80100 -tc="ray-tracing-*.cuda"
+
+  test-slangpy:
+    runs-on: ["Linux", "self-hosted", "GPU"]
+    timeout-minutes: 30
+    if: always()
+
+    permissions:
+      contents: read
+      packages: read
+
+    container:
+      image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.3.0
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: >-
+        --gpus all
+        --user root
+        --device /dev/nvidia-modeset:/dev/nvidia-modeset
+        --device /dev/dri:/dev/dri
+        -e NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics
+        -v /etc/vulkan/icd.d/nvidia_icd.json:/etc/vulkan/icd.d/nvidia_icd.json:ro
+        -v /usr/share/nvidia:/usr/share/nvidia:ro
+        -v /usr/share/glvnd/egl_vendor.d/10_nvidia.json:/usr/share/glvnd/egl_vendor.d/10_nvidia.json:ro
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Configure Git safe directory
+        run: git config --global --add safe.directory '*'
+
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: slang-tests-linux-x86_64-gcc-${{ inputs.config }}
+          path: artifacts
+
+      - name: Setup test environment
+        run: |
+          if [[ "${{ inputs.config }}" == "release" ]]; then
+            cmake_config="Release"
+          else
+            cmake_config="Debug"
+          fi
+          echo "cmake_config=$cmake_config" >> $GITHUB_ENV
+
+          bin_dir="$PWD/artifacts/${cmake_config}/bin"
+          lib_dir="$PWD/artifacts/${cmake_config}/lib"
+          echo "bin_dir=$bin_dir" >> $GITHUB_ENV
+          echo "lib_dir=$lib_dir" >> $GITHUB_ENV
+
+          chmod +x "$bin_dir"/* 2>/dev/null || true
+          echo "LD_LIBRARY_PATH=$lib_dir:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+
+          # Display environment configuration
+          print-env-info
+
+      - name: Run slangpy tests
+        run: |
+          python3 --version
+          echo "Cleaning up existing installations and installing slangpy..."
+
+          # Try to uninstall existing slangpy
+          python3 -m pip uninstall -y slangpy || echo "slangpy not found or already removed"
+
+          # Install slangpy
+          python3 -m pip install --verbose slangpy --user
+
+          # Get site packages directory
+          SITE_PACKAGES=$(python3 -c "import slangpy; import os; print(os.path.dirname(os.path.dirname(slangpy.__file__)))" | tail -n 1)
+          echo "Site packages directory: $SITE_PACKAGES"
+          echo "bin_dir location: $bin_dir"
+          echo "lib_dir location: $lib_dir"
+
+          #
+          # THIS IS A HUGE HACK, the latest slangpy release hardcoded this
+          # directory when looking for slangc. We should remove the offending
+          # code from slangpy and just put slangc into PATH here. The offending
+          # code is find_slangc() in
+          # slangpy/tests/device/test_precompiled_modules.py
+          #
+          # See https://github.com/shader-slang/slangpy/issues/696
+          #
+          SLANGC_TARGET_DIR="$SITE_PACKAGES/build/pip/_deps/slang-src/bin"
+          mkdir -p "$SLANGC_TARGET_DIR"
+          # Copy slangc binary to the expected location
+          if [[ "${{ inputs.os }}" == "windows" ]]; then
+              cp -v "$bin_dir/slangc.exe" "$SLANGC_TARGET_DIR/"
+          else
+              cp -v "$bin_dir/slangc" "$SLANGC_TARGET_DIR/"
+              chmod +x "$SLANGC_TARGET_DIR/slangc"
+          fi
+
+          # Remove old slang libraries and copy new ones
+          echo "Removing old slang libraries..."
+          rm -f "$SITE_PACKAGES/slangpy"/libslang*
+
+          echo "Copying new slang libraries..."
+          cp -v "$lib_dir"/libslang*.* "$SITE_PACKAGES/slangpy/" || { echo "Failed to copy library files"; exit 1; }
+
+          # Create symlink for the old library version that slangpy extension was linked against
+          echo "Creating symlink for slangpy compatibility..."
+          ln -sf libslang-compiler.so "$SITE_PACKAGES/slangpy/libslang-compiler.so.0.2025.24.3"
+
+          echo "Listing files in slangpy directory..."
+          ls -la "$SITE_PACKAGES/slangpy/"
+
+          echo "Installing python packages..."
+          curl -fsSL https://raw.githubusercontent.com/shader-slang/slangpy/main/requirements-dev.txt -o requirements-dev.txt
+          python3 -m pip install -r requirements-dev.txt --user
+          python3 -m pip install pytest-github-actions-annotate-failures --user
+          python3 -m pip install pytest-xdist --user
+
+          echo "Running pytest on slangpy tests..."
+          export PYTHONPATH="$SITE_PACKAGES"
+          export SLANG_RUN_SPIRV_VALIDATION=1
+
+          # First attempt: run with parallel execution
+          if python3 -m pytest "$SITE_PACKAGES/slangpy/tests" -ra -n auto --maxprocesses=3
+          then
+            echo "All tests passed on first attempt."
+          else
+            echo ""
+            echo "========================================"
+            echo "Some tests failed. Re-running failed tests sequentially..."
+            echo "========================================"
+            echo ""
+            # Re-run only the failed tests without parallelism
+            #   --lf, --last-failed   Rerun only the tests that failed at the last run
+            #   -n 0                  Rerun the tests sequentially
+            python3 -m pytest "$SITE_PACKAGES/slangpy/tests" -ra -n 0 --lf
+          fi

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -171,3 +171,187 @@ jobs:
         if: inputs.os == 'windows' || inputs.os == 'linux'
         run: |
           "$bin_dir/slang-rhi-tests" -check-devices -optix-version=80100 -tc="ray-tracing-*.cuda"
+
+  # Run slangpy tests and examples when:
+  # 1. full-gpu-tests is enabled AND
+  # 2. Either it's a pull request OR config is release
+  # This is to reduce the CI load but do some check on pull requests.
+  # Includes both slangpy pytest tests and slangpy-samples examples.
+  test-slangpy:
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    timeout-minutes: 60
+    if: inputs.full-gpu-tests && (github.event_name == 'pull_request' || inputs.config == 'release')
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Common Test Setup
+        uses: ./.github/actions/common-test-setup
+        with:
+          os: ${{ inputs.os }}
+          compiler: ${{ inputs.compiler }}
+          platform: ${{ inputs.platform }}
+          config: ${{ inputs.config }}
+          artifact-suffix: ${{ inputs.artifact-suffix }}
+
+      - name: Setup Python
+        if: ${{ runner.environment != 'self-hosted' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Run slangpy tests
+        run: |
+          python --version
+          echo "Cleaning up existing installations and installing slangpy..."
+
+          # Try to uninstall existing slangpy
+          python -m pip uninstall -y slangpy || echo "slangpy not found or already removed"
+
+          # Install slangpy
+          python -m pip install --verbose slangpy --user
+
+          # Get site packages directory
+          SITE_PACKAGES=$(python -c "import slangpy; import os; print(os.path.dirname(os.path.dirname(slangpy.__file__)))" | tail -n 1)
+          echo "Site packages directory: $SITE_PACKAGES"
+          echo "bin_dir location: $bin_dir"
+          echo "lib_dir location: $lib_dir"
+
+          #
+          # THIS IS A HUGE HACK, the latest slangpy release hardcoded this
+          # directory when looking for slangc. We should remove the offending
+          # code from slangpy and just put slangc into PATH here. The offending
+          # code is find_slangc() in
+          # slangpy/tests/device/test_precompiled_modules.py
+          #
+          # See https://github.com/shader-slang/slangpy/issues/696
+          #
+          SLANGC_TARGET_DIR="$SITE_PACKAGES/build/pip/_deps/slang-src/bin"
+          mkdir -p "$SLANGC_TARGET_DIR"
+          # Copy slangc binary to the expected location
+          if [[ "${{ inputs.os }}" == "windows" ]]; then
+              cp -v "$bin_dir/slangc.exe" "$SLANGC_TARGET_DIR/"
+          else
+              cp -v "$bin_dir/slangc" "$SLANGC_TARGET_DIR/"
+              chmod +x "$SLANGC_TARGET_DIR/slangc"
+          fi
+
+          # Copy library files
+          if [[ "${{ inputs.os }}" == "windows" ]]; then
+            cp -v "$bin_dir"/slang*.dll "$SITE_PACKAGES/slangpy/" || { echo "Failed to copy library files"; exit 1; }
+          else
+
+            # This is kind of awkward because the version numbers might be
+            # different between the old libslang-compiler and the new one, so
+            # we need to make sure we overwrite the old one. This logic also
+            # tries to avoid making assumptions about filename extension due to
+            # differences in macos and Linux conventions.
+
+            # There should only be one libslang-compiler library present; the
+            # one that slangpy linked to.
+            OLD_SLANGLIB=$(find "$SITE_PACKAGES/slangpy/" -type f -name "libslang-compiler.*")
+            echo "old slang library location: $OLD_SLANGLIB"
+
+            # Find the new libslang-compiler library via developer symlink
+            # filename. This is unlikely to still be a symlink since it went
+            # through artifactory, but in practice symlink or not shouldn't
+            # matter, since we copy the rest of the libraries over.
+            NEW_SLANGLIB=$(find "$lib_dir" -name "libslang-compiler.*" ! -name "*.*.*")
+            echo "new slang library location: $NEW_SLANGLIB"
+
+            cp "$NEW_SLANGLIB" "$OLD_SLANGLIB" || { echo "Failed to copy main library file"; exit 1; }
+
+            # Copy the rest of the library files
+            cp "$lib_dir"/libslang*.* "$SITE_PACKAGES/slangpy/" || { echo "Failed to copy library files"; exit 1; }
+          fi
+
+          echo "Listing files in slangpy directory..."
+          ls -la "$SITE_PACKAGES/slangpy/"
+
+          # Export SITE_PACKAGES for use in slangpy-samples step
+          echo "SITE_PACKAGES=$SITE_PACKAGES" >> $GITHUB_ENV
+
+          echo "Installing python packages..."
+          curl -fsSL https://raw.githubusercontent.com/shader-slang/slangpy/main/requirements-dev.txt -o requirements-dev.txt
+          python -m pip install -r requirements-dev.txt --user
+          python -m pip install pytest-github-actions-annotate-failures --user
+          python -m pip install pytest-xdist --user
+
+          echo "Running pytest on slangpy tests..."
+          export PYTHONPATH="$SITE_PACKAGES"
+          export SLANG_RUN_SPIRV_VALIDATION=1
+
+          # First attempt: run with parallel execution
+          if python -m pytest "$SITE_PACKAGES/slangpy/tests" -ra -n auto --maxprocesses=3
+          then
+            echo "All tests passed on first attempt."
+          else
+            echo ""
+            echo "========================================"
+            echo "Some tests failed. Re-running failed tests sequentially..."
+            echo "========================================"
+            echo ""
+            # Re-run only the failed tests without parallelism (-n 0 disables xdist)
+            #   --lf, --last-failed   Rerun only the tests that failed at the last run
+            #   -n 0                  Rerun the tests sequentially
+            python -m pytest "$SITE_PACKAGES/slangpy/tests" -ra -n 0 --lf
+          fi
+
+      - name: Clone slangpy-samples
+        # Skip on macOS debug due to intermittent failures in test_toy_restir
+        if: ${{ !(inputs.os == 'macos' && inputs.config == 'debug') }}
+        run: |
+          # Clone slangpy-samples and checkout the tag matching the installed
+          # slangpy version. This ensures compatibility between the slangpy
+          # release and the samples. Falls back to main if no matching tag exists.
+          echo "Cloning slangpy-samples repository..."
+
+          # Detect installed slangpy version
+          SLANGPY_VERSION=$(python -c "import slangpy; print(slangpy.__version__)" 2>/dev/null || echo "unknown")
+          echo "Installed slangpy version: $SLANGPY_VERSION"
+
+          # Try to clone specific version tag directly, fallback to main if it fails
+          if [ "$SLANGPY_VERSION" != "unknown" ]; then
+            if git clone --branch "v${SLANGPY_VERSION}" --depth 1 https://github.com/shader-slang/slangpy-samples.git 2>/dev/null; then
+              echo "Successfully cloned version tag v${SLANGPY_VERSION}"
+            else
+              echo "Warning: No matching tag found for v${SLANGPY_VERSION}, cloning main branch"
+              git clone --depth 1 https://github.com/shader-slang/slangpy-samples.git
+            fi
+          else
+            echo "Warning: Could not detect slangpy version, cloning main branch"
+            git clone --depth 1 https://github.com/shader-slang/slangpy-samples.git
+          fi
+
+      - name: Install slangpy-samples dependencies
+        # Skip on macOS debug due to intermittent failures in test_toy_restir
+        if: ${{ !(inputs.os == 'macos' && inputs.config == 'debug') }}
+        run: |
+          echo "Installing slangpy-samples dependencies..."
+          python -m pip install -r slangpy-samples/requirements.txt --user
+
+      - name: Run slangpy-samples tests
+        # Skip on macOS debug due to intermittent failures in test_toy_restir
+        # Skip test_check_urls because URL checking is not required for slang CI
+        if: ${{ !(inputs.os == 'macos' && inputs.config == 'debug') }}
+        run: |
+          echo "Running slangpy-samples tests..."
+          export SLANG_RUN_SPIRV_VALIDATION=1
+
+          if python -m pytest "slangpy-samples/tests" -n 4 -k "not test_check_urls"
+          then
+            echo "All tests passed on first attempt."
+          else
+            echo ""
+            echo "========================================"
+            echo "Some tests failed. Re-running failed tests sequentially..."
+            echo "========================================"
+            echo ""
+            # Re-run only the failed tests without parallelism (-n 0 disables xdist)
+            #   --lf, --last-failed   Rerun only the tests that failed at the last run
+            #   -n 0                  Rerun the tests sequentially
+            python -m pytest "slangpy-samples/tests" -n 0 --lf -k "not test_check_urls"
+          fi

--- a/.github/workflows/ci-trigger-slangpy.yml
+++ b/.github/workflows/ci-trigger-slangpy.yml
@@ -3,24 +3,31 @@ name: Trigger SlangPy CI
 permissions:
   contents: read
 
-# Use pull_request_target so this workflow has access to repository secrets
-# even for PRs from forks. This is safe because the workflow only dispatches
-# metadata (PR number, SHA) and never checks out or executes PR code.
+# Manual-only trigger for now. Cross-repo dispatch to SlangPy is functional
+# but needs performance tuning before being enabled on every PR.
+# To test a PR against SlangPy, run this workflow manually and provide the
+# PR number.
 on:
-  pull_request_target:
-    branches: [master]
-    types: [opened, synchronize, reopened, ready_for_review]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Slang PR number to test against SlangPy"
+        required: true
+        type: string
 
 jobs:
   trigger-slangpy-tests:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft != true
 
     steps:
+      - name: Get PR info
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_SHA=$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr_number }} --jq '.head.sha')
+          echo "sha=$PR_SHA" >> "$GITHUB_OUTPUT"
+
       - name: Trigger SlangPy CI
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
@@ -29,7 +36,7 @@ jobs:
           event-type: slang-pr-test
           client-payload: |
             {
-              "slang_pr_number": "${{ github.event.pull_request.number }}",
-              "slang_commit_sha": "${{ github.event.pull_request.head.sha }}",
-              "slang_ref": "${{ github.event.pull_request.head.sha }}"
+              "slang_pr_number": "${{ inputs.pr_number }}",
+              "slang_commit_sha": "${{ steps.pr.outputs.sha }}",
+              "slang_ref": "${{ steps.pr.outputs.sha }}"
             }


### PR DESCRIPTION
## Summary
- Restore the original `test-slangpy` jobs in `ci-slang-test.yml` and `ci-slang-test-container.yml`
- Change `ci-trigger-slangpy.yml` from automatic (`pull_request_target`) to manual (`workflow_dispatch`)
- The cross-repo dispatch to SlangPy is functional but needs performance tuning before being enabled on every PR

The manual trigger accepts a PR number as input, so it can still be used on-demand for specific PRs.

Relates to #9220