### PR TITLE
Fix sccache cross-contamination between debug and release builds

### DIFF
--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -76,7 +76,6 @@ jobs:
           key: sccache-linux-gcc-x86_64-${{ inputs.config }}-${{ github.sha }}
           restore-keys: |
             sccache-linux-gcc-x86_64-${{ inputs.config }}-
-            sccache-linux-gcc-x86_64-
 
       # Authenticate to Google Cloud for LLVM downloads (skip for fork PRs)
       - name: Authenticate to Google Cloud

--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -74,7 +74,6 @@ jobs:
           key: sccache-${{ inputs.os }}-${{ inputs.compiler }}-${{ inputs.platform }}-${{ inputs.config }}-${{ github.sha }}
           restore-keys: |
             sccache-${{ inputs.os }}-${{ inputs.compiler }}-${{ inputs.platform }}-${{ inputs.config }}-
-            sccache-${{ inputs.os }}-${{ inputs.compiler }}-${{ inputs.platform }}-
 
       # Authenticate to Google Cloud for LLVM downloads (skip for fork PRs)
       - name: Authenticate to Google Cloud

--- a/.github/workflows/populate-sccache.yml
+++ b/.github/workflows/populate-sccache.yml
@@ -93,7 +93,6 @@ jobs:
           key: sccache-macos-clang-aarch64-release-${{ needs.check-changes.outputs.last-commit }}
           restore-keys: |
             sccache-macos-clang-aarch64-release-
-            sccache-macos-clang-aarch64-
 
       - name: Setup sccache (local backend)
         uses: ./.github/actions/setup-sccache
@@ -152,7 +151,6 @@ jobs:
           key: sccache-macos-clang-aarch64-debug-${{ needs.check-changes.outputs.last-commit }}
           restore-keys: |
             sccache-macos-clang-aarch64-debug-
-            sccache-macos-clang-aarch64-
 
       - name: Setup sccache (local backend)
         uses: ./.github/actions/setup-sccache
@@ -207,7 +205,6 @@ jobs:
           key: sccache-linux-gcc-aarch64-release-${{ needs.check-changes.outputs.last-commit }}
           restore-keys: |
             sccache-linux-gcc-aarch64-release-
-            sccache-linux-gcc-aarch64-
 
       - name: Setup sccache (local backend)
         uses: ./.github/actions/setup-sccache
@@ -262,7 +259,6 @@ jobs:
           key: sccache-linux-gcc-aarch64-debug-${{ needs.check-changes.outputs.last-commit }}
           restore-keys: |
             sccache-linux-gcc-aarch64-debug-
-            sccache-linux-gcc-aarch64-
 
       - name: Setup sccache (local backend)
         uses: ./.github/actions/setup-sccache


### PR DESCRIPTION
## Summary
- Remove config-less sccache `restore-keys` fallback that could restore a debug cache into a release build (or vice versa)
- This was the root cause of intermittent Vulkan SIGSEGV crashes and RPC pipe failures in Linux GPU CI

## Details

The sccache `restore-keys` in our build workflows had two fallback prefixes:
```yaml
restore-keys: |
  sccache-linux-gcc-x86_64-release-
  sccache-linux-gcc-x86_64-
```

The second prefix strips the build config and matches **both** debug and release caches. When no release cache existed for a new commit, GitHub Actions fell back to this broad prefix and restored the most recently created cache — which could be a **debug** cache.

This caused release builds to link with debug-compiled objects, producing binaries that segfault on Vulkan (`SIGSEGV` in `benchmark-command.vulkan`). The poisoned cache was then saved as a release cache and propagated to all subsequent builds.

**Timeline of the incident (2026-03-04):**
- 06:14 UTC: Populate workflow builds release with 321 cache misses (clean rebuild), saves good cache
- 06:46 UTC: Populate workflow tries release build, no release cache for new commit, falls back to broad prefix, **restores debug cache** `sccache-linux-gcc-x86_64-debug-2eeac7f1`, saves poisoned cache as `sccache-linux-gcc-x86_64-release-b90a4738`
- 07:35+ UTC: All subsequent release builds restore from poisoned cache → Vulkan SIGSEGV → all Linux GPU release tests fail

**Evidence:** Passing release artifacts were ~304-309 MB; failing ones were ~282 MB (debug objects are smaller). The failing build logs confirmed: `Cache restored from key: sccache-linux-gcc-x86_64-debug-...` in a release build.

## Fix
Remove the config-less fallback line from all 6 `restore-keys` blocks across 3 workflow files, so release builds only restore from release caches and debug from debug.