### PR TITLE
Clean up legacy fork cache and GCS references

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,5 +1,5 @@
 name: Setup sccache
-description: Install and configure sccache with local disk backend for Linux, macOS, and Windows
+description: Install and configure sccache for Linux, macOS, and Windows
 
 inputs:
   platform:

--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -86,7 +86,7 @@ jobs:
           workload_identity_provider: "projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider"
           service_account: "github-ci@slang-runners.iam.gserviceaccount.com"
 
-      # Setup sccache with local disk backend (no GCS)
+      # Setup sccache
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
         with:
@@ -189,7 +189,7 @@ jobs:
             exit 1
           fi
 
-      # Save sccache cache for fork PRs (master only)
+      # Save sccache cache (master only, for populate-sccache workflow)
       - name: Save sccache cache (master only)
         if: github.ref == 'refs/heads/master'
         uses: actions/cache/save@v4

--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -31,7 +31,7 @@ on:
         type: number
         default: 8
       save-sccache:
-        description: "Save sccache to GitHub Actions cache (for populate-fork-cache on master)"
+        description: "Save sccache to GitHub Actions cache (for populate-sccache on master)"
         required: false
         type: boolean
         default: false
@@ -84,7 +84,7 @@ jobs:
           workload_identity_provider: "projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider"
           service_account: "github-ci@slang-runners.iam.gserviceaccount.com"
 
-      # Setup sccache with local disk backend
+      # Setup sccache
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
         with:
@@ -293,7 +293,7 @@ jobs:
           path: artifacts-staging/
           retention-days: 1
 
-      # Save sccache cache (only when explicitly requested, e.g. from populate-fork-cache on master)
+      # Save sccache cache (only when explicitly requested, e.g. from populate-sccache on master)
       - name: Save sccache cache
         if: inputs.save-sccache && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         uses: actions/cache/save@v4

--- a/.github/workflows/populate-sccache.yml
+++ b/.github/workflows/populate-sccache.yml
@@ -44,7 +44,7 @@ jobs:
             echo "✅ Cache already populated for commit ${CURRENT_COMMIT}"
             echo "should-build=false" >> $GITHUB_OUTPUT
           else
-            echo "🔨 Building to populate fork PR cache for commit ${CURRENT_COMMIT}"
+            echo "🔨 Building to populate sccache for commit ${CURRENT_COMMIT}"
             echo "should-build=true" >> $GITHUB_OUTPUT
           fi
         env:
@@ -127,7 +127,7 @@ jobs:
             -DCMAKE_COMPILE_WARNING_AS_ERROR=true
           cmake --build --preset release -j"$(sysctl -n hw.ncpu)"
 
-      - name: Save sccache cache for fork PRs
+      - name: Save sccache cache
         uses: actions/cache/save@v4
         with:
           path: /tmp/.cache/sccache
@@ -182,7 +182,7 @@ jobs:
             -DCMAKE_COMPILE_WARNING_AS_ERROR=true
           cmake --build --preset debug -j"$(sysctl -n hw.ncpu)"
 
-      - name: Save sccache cache for fork PRs
+      - name: Save sccache cache
         uses: actions/cache/save@v4
         with:
           path: /tmp/.cache/sccache
@@ -237,7 +237,7 @@ jobs:
             -DCMAKE_COMPILE_WARNING_AS_ERROR=false
           cmake --build --preset release -j$(nproc)
 
-      - name: Save sccache cache for fork PRs
+      - name: Save sccache cache
         uses: actions/cache/save@v4
         with:
           path: /tmp/.cache/sccache
@@ -292,7 +292,7 @@ jobs:
             -DCMAKE_COMPILE_WARNING_AS_ERROR=false
           cmake --build --preset debug -j$(nproc)
 
-      - name: Save sccache cache for fork PRs
+      - name: Save sccache cache
         uses: actions/cache/save@v4
         with:
           path: /tmp/.cache/sccache


### PR DESCRIPTION
Update comments and descriptions to reflect current architecture where sccache is used for all builds, not just fork PRs.