### PR TITLE
Disable ENABLE_TOOL_SEARCH in claude-code-runner

### DIFF
--- a/.github/actions/claude-code-runner/action.yml
+++ b/.github/actions/claude-code-runner/action.yml
@@ -509,7 +509,8 @@ runs:
               "GITHUB_EVENT_NAME": "${{ github.event_name }}",
               "GITHUB_ACTOR": "${{ github.actor }}",
               "DISABLE_TELEMETRY": "1",
-              "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1"
+              "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+              "ENABLE_TOOL_SEARCH": "false"
             }
           }
 
@@ -554,7 +555,8 @@ runs:
               "GITHUB_REPOSITORY": "${{ github.repository }}",
               "GITHUB_EVENT_NAME": "${{ github.event_name }}",
               "GITHUB_ACTOR": "${{ github.actor }}",
-              "DISABLE_TELEMETRY": "1"
+              "DISABLE_TELEMETRY": "1",
+              "ENABLE_TOOL_SEARCH": "false"
             }
           }
 


### PR DESCRIPTION
Adds `ENABLE_TOOL_SEARCH=false` to the `settings.env` in both execution paths (NV Inference and LLMGW) of the `claude-code-runner` composite action. This disables automatic tool search/discovery for all 3 Claude workflows since allowed tools are already explicitly listed.