### PR TITLE
Fix diagnostic rendering for no-source sections

### DIFF
--- a/source/compiler-core/slang-rich-diagnostics-render.cpp
+++ b/source/compiler-core/slang-rich-diagnostics-render.cpp
@@ -518,15 +518,22 @@ private:
         return rows;
     }
 
-    // When source text is unavailable (e.g. built-in modules), emit any span
-    // labels that would otherwise be lost, as plain indented text.
-    void renderOrphanedLabels(StringBuilder& ss, const SectionLayout& section)
+    // When source text is unavailable (e.g. built-in modules), render span
+    // labels with a compact gutter structure (pipe + closing corner), using a
+    // minimal gutter width since there are no line numbers to display.
+    void renderOrphanedLabels(StringBuilder& ss, const SectionLayout& section, Int64 gutterWidth)
     {
+        String gutter =
+            repeat(' ', gutterWidth + 1) + color(TerminalColor::Cyan, m_glyphs.vertical);
         for (const auto& block : section.blocks)
             for (const auto& line : block.lines)
                 for (const auto& span : line.spans)
                     if (span.label.getLength() > 0)
-                        ss << "  = " << span.label << "\n";
+                        ss << gutter << " " << color(TerminalColor::BoldRed, span.label) << "\n";
+        ss << color(
+                  TerminalColor::Cyan,
+                  repeat(m_glyphs.secondaryUnderline, gutterWidth + 1) + m_glyphs.gutterCorner)
+           << "\n";
     }
 
     void renderSectionBody(StringBuilder& ss, const SectionLayout& section)
@@ -668,11 +675,11 @@ private:
             layout.primaryLoc.line > 0 || layout.primaryLoc.fileName.getLength() > 0;
         if (hasValidLocation)
         {
-            renderLocation(ss, layout.primaryLoc);
-
-            if (layout.primarySection.blocks.getCount() > 0)
+            bool primaryHasSource = sectionHasSourceAvailable(layout.primarySection);
+            if (primaryHasSource)
             {
-                if (sectionHasSourceAvailable(layout.primarySection))
+                renderLocation(ss, layout.primaryLoc);
+                if (layout.primarySection.blocks.getCount() > 0)
                 {
                     ss << repeat(' ', layout.primarySection.maxGutterWidth + 1)
                        << color(TerminalColor::Cyan, m_glyphs.vertical) << "\n";
@@ -685,19 +692,25 @@ private:
                                   m_glyphs.gutterCorner)
                        << "\n";
                 }
-                else
-                {
-                    renderOrphanedLabels(ss, layout.primarySection);
-                }
+            }
+            else
+            {
+                constexpr Int64 kOrphanGutterWidth = 0;
+                DiagnosticLayout::Location loc = layout.primaryLoc;
+                loc.gutterIndent = kOrphanGutterWidth;
+                renderLocation(ss, loc);
+                if (layout.primarySection.blocks.getCount() > 0)
+                    renderOrphanedLabels(ss, layout.primarySection, kOrphanGutterWidth);
             }
         }
         for (const auto& note : layout.notes)
         {
             ss << "\n" << color(TerminalColor::Cyan, "note") << ": " << note.message << "\n";
-            renderNoteLocation(ss, note.loc);
-            if (note.section.blocks.getCount() > 0)
+            bool noteHasSource = sectionHasSourceAvailable(note.section);
+            if (noteHasSource)
             {
-                if (sectionHasSourceAvailable(note.section))
+                renderNoteLocation(ss, note.loc);
+                if (note.section.blocks.getCount() > 0)
                 {
                     ss << repeat(' ', note.section.maxGutterWidth + 1)
                        << color(TerminalColor::Cyan, m_glyphs.vertical) << "\n";
@@ -708,10 +721,15 @@ private:
                                   m_glyphs.gutterCorner)
                        << "\n";
                 }
-                else
-                {
-                    renderOrphanedLabels(ss, note.section);
-                }
+            }
+            else
+            {
+                constexpr Int64 kOrphanGutterWidth = 0;
+                DiagnosticLayout::Location noteLoc = note.loc;
+                noteLoc.gutterIndent = kOrphanGutterWidth;
+                renderNoteLocation(ss, noteLoc);
+                if (note.section.blocks.getCount() > 0)
+                    renderOrphanedLabels(ss, note.section, kOrphanGutterWidth);
             }
         }
         return ss.produceString();

--- a/tests/diagnostics/rich-diag-no-source.slang
+++ b/tests/diagnostics/rich-diag-no-source.slang
@@ -1,5 +1,5 @@
 //TEST:SIMPLE(diag=CHK):-target hlsl -stage compute -entry computeMain
-//TEST:SIMPLE:-target hlsl -stage compute -entry computeMain
+//TEST:SIMPLE(filecheck=FC):-target hlsl -stage compute -entry computeMain
 
 // Test that diagnostics pointing to built-in modules (where source text is
 // unavailable) don't render empty source sections.
@@ -16,3 +16,8 @@ void computeMain()
 //CHK: HLSL supports only float and half type textures
 //CHK: see call to 'Sample'
 }
+
+// FC: error[E41400]: static assertion failed
+// FC-NEXT: --> hlsl.meta.slang:{{[0-9]+}}:{{[0-9]+}}
+// FC-NEXT:  | static assertion failed, HLSL supports only float and half type textures
+// FC-NEXT: -'


### PR DESCRIPTION
When a diagnostic points to a built-in module where source text is
unavailable, the rendering was broken in several ways: the gutter
was excessively wide (based on the unseen line number), there was a
disconnected '= ' prefix for span labels, and no visual gutter
structure (pipe/closing corner).

Now no-source sections render with a compact gutter (width 0), the
span labels appear inside a proper pipe structure with a closing
corner, and the label text is rendered in bold red.