### PR TITLE
Fix ambiguous `==` comparison in Session destructor

### DIFF
--- a/source/slang/slang-global-session.cpp
+++ b/source/slang/slang-global-session.cpp
@@ -146,7 +146,7 @@ Session::~Session()
     //
     coreModules = decltype(coreModules)();
 
-    if (getCurrentASTBuilder() == m_rootASTBuilder)
+    if (getCurrentASTBuilder() == m_rootASTBuilder.get())
         setCurrentASTBuilder(nullptr);
 }
 


### PR DESCRIPTION
This will fix a build error in the SlangPy nightly Windows builds: https://github.com/shader-slang/slangpy/actions/runs/22745086843/job/65967070708

The comparison `getCurrentASTBuilder() == m_rootASTBuilder` in `Session::~Session()` compares an `ASTBuilder*` (returned by `getCurrentASTBuilder()`) against a `RefPtr<ASTBuilder>`. In C++20, this is ambiguous because the compiler can either rewrite it as `m_rootASTBuilder.operator==(ptr)` using `RefPtr::operator==(const T*)`, or convert the `RefPtr` to `T*` via its implicit `operator T*()` and use the built-in pointer `==`.

This adds an explicit `.get()` call to extract the raw pointer, making the comparison unambiguous.
