### PR TITLE
Add CI retry workflow for rerunning failed jobs

### DIFF
--- a/.github/workflows/ci-retry.yml
+++ b/.github/workflows/ci-retry.yml
@@ -1,0 +1,22 @@
+name: Retry Failed CI Jobs
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "The run ID to retry after it completes"
+        required: true
+
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for run to complete and rerun failed jobs
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Waiting for run ${{ inputs.run_id }} to complete..."
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          echo "Run completed. Rerunning failed jobs..."
+          gh run rerun ${{ inputs.run_id }} --failed


### PR DESCRIPTION
Prerequisite for testing the auto-retry mechanism in #10429.

Adds a `workflow_dispatch` workflow (`ci-retry.yml`) that:
1. Accepts a `run_id` input
2. Watches the run until it completes (`gh run watch`)
3. Reruns only the failed jobs (`gh run rerun --failed`)

This workflow is harmless on its own — it only runs when manually dispatched or called by other workflows. It needs to be on master for `gh workflow run` to be able to invoke it.