### PR TITLE
Add sanitizer ignorelist for prebuilt slang-llvm compatibility

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -221,7 +221,7 @@ function(set_default_compile_options target)
                     -fsanitize=address
                     -fsanitize=undefined
                     -fno-sanitize-recover=undefined
-                    -fsanitize-ignorelist=${CMAKE_SOURCE_DIR}/cmake/sanitizer-ignorelist.txt
+                    -fsanitize-ignorelist=${PROJECT_SOURCE_DIR}/cmake/sanitizer-ignorelist.txt
             )
             target_link_options(
                 ${target}

--- a/cmake/sanitizer-ignorelist.txt
+++ b/cmake/sanitizer-ignorelist.txt
@@ -6,6 +6,8 @@
 # calls virtual methods on ILLVMBuilder (a COM interface returned by the
 # non-instrumented library).
 #
-# Skip vptr checks for types defined in slang-llvm sources.
+# Skip vptr checks for COM interfaces whose implementation lives in slang-llvm.
+# The type: pattern suppresses checks at all call sites regardless of which
+# source file the virtual call is in (e.g. slang-emit-llvm.cpp, slang-emit.cpp).
 [vptr]
-src:*slang-llvm*
+type:*ILLVMBuilder*


### PR DESCRIPTION
The prebuilt libslang-llvm is not compiled with sanitizers, so UBSan's vptr checker cannot validate vtables from objects created inside it. This causes false-positive "invalid vptr" aborts when sanitized code (SLANG_ENABLE_ASAN=ON) calls virtual methods on ILLVMBuilder, a COM interface returned by the non-instrumented library.

Add a sanitizer ignorelist file that skips vptr checks for types defined in slang-llvm sources, and pass it to Clang via -fsanitize-ignorelist when ASAN is enabled.

Fixes #9781