### PR TITLE
Fix conflicting GLSL extension requirements in HitObject methods

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -21956,9 +21956,6 @@ int __hitObjectAttributesLocation(__ref Attributes attributes);
 /// and its related functions are available in raytracing shader types only.
 /// @category raytracing Ray-tracing
 __glsl_extension(GL_EXT_ray_tracing)
-__glsl_extension(GL_EXT_buffer_reference_uvec2)
-__glsl_extension(GL_EXT_shader_invocation_reorder)
-__glsl_extension(GL_NV_shader_invocation_reorder)
 [__NonCopyableType]
 __intrinsic_type($(kIROp_HitObjectType))
 struct HitObject
@@ -22003,6 +22000,7 @@ struct HitObject
             }
         case _GL_NV_shader_invocation_reorder:
             {
+                __requireTargetExtension("GL_NV_shader_invocation_reorder");
                 // Conditional: if T is int (location), pass directly; else convert data to location
                 if (T is int)
                 {
@@ -22050,6 +22048,8 @@ struct HitObject
         case glsl: // use GL_EXT until KHR is available.
         //case _GL_EXT_shader_invocation_reorder: // Not sure why, but needs to be commented out.
             {
+                __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+                __requireTargetExtension("GL_EXT_shader_invocation_reorder");
                 // Conditional: if T is int (location), pass directly; else convert data to location
                 if (T is int)
                 {
@@ -22207,6 +22207,8 @@ struct HitObject
         {
         case _GL_NV_shader_invocation_reorder:
             {
+                __requireTargetExtension("GL_NV_ray_tracing_motion_blur");
+                __requireTargetExtension("GL_NV_shader_invocation_reorder");
                 // Conditional: if T is int (location), pass directly; else convert data to location
                 if (T is int)
                 {
@@ -22254,6 +22256,8 @@ struct HitObject
         case glsl: // use GL_EXT until KHR is available.
         //case _GL_EXT_shader_invocation_reorder: // Not sure why, but needs to be commented out.
             {
+                __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+                __requireTargetExtension("GL_EXT_shader_invocation_reorder");
                 // Conditional: if T is int (location), pass directly; else convert data to location
                 if (T is int)
                 {
@@ -22746,9 +22750,12 @@ struct HitObject
         {
         case hlsl_nvapi: __intrinsic_asm "($2=NvMakeMiss($0,$1))";
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __glslMakeMissNV(__return_val, MissShaderIndex, Ray.Origin, Ray.TMin, Ray.Direction, Ray.TMax);
         case glsl: // use GL_EXT until KHR is available.
         //case _GL_EXT_shader_invocation_reorder: // Not sure why, but needs to be commented out.
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             // EXT spec requires RayFlags parameter, pass 0 as default
             __glslMakeMissEXT(__return_val, 0, MissShaderIndex, Ray.Origin, Ray.TMin, Ray.Direction, Ray.TMax);
         case cuda: __intrinsic_asm "optixMakeMissHitObject";
@@ -22789,9 +22796,13 @@ struct HitObject
         __target_switch
         {
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_ray_tracing_motion_blur");
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __glslMakeMissMotionNV(__return_val, MissShaderIndex, Ray.Origin, Ray.TMin, Ray.Direction, Ray.TMax, CurrentTime);
         case glsl: // use GL_EXT until KHR is available.
         //case _GL_EXT_shader_invocation_reorder: // Not sure why, but needs to be commented out.
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             // EXT requires RayFlags parameter - use 0 as default
             __glslMakeMissMotionEXT(__return_val, 0, MissShaderIndex, Ray.Origin, Ray.TMin, Ray.Direction, Ray.TMax, CurrentTime);
         case cuda: __intrinsic_asm "optixMakeMissHitObject";
@@ -22923,6 +22934,7 @@ struct HitObject
                 __forceVarIntoRayPayloadStructTemporarily(Payload));
         case _GL_NV_shader_invocation_reorder:
             {
+                __requireTargetExtension("GL_NV_shader_invocation_reorder");
                 [__vulkanRayPayload]
                 static payload_t p;
 
@@ -22937,6 +22949,8 @@ struct HitObject
         case glsl: // use GL_EXT until KHR is available.
         //case _GL_EXT_shader_invocation_reorder: // Not sure why, but needs to be commented out.
             {
+                __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+                __requireTargetExtension("GL_EXT_shader_invocation_reorder");
                 [__vulkanRayPayload]
                 static payload_t p;
 
@@ -23140,9 +23154,6 @@ struct HitObject
 
         /// Queries shader table index from HitObject. Valid if the hit object represents a hit or a miss.
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [ForceInline]
     [require(cuda_glsl_hlsl_spirv, ser_raygen_closesthit_miss)]
     uint GetShaderTableIndex()
@@ -23152,9 +23163,12 @@ struct HitObject
         case hlsl:
             __intrinsic_asm ".GetShaderTableIndex";
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetShaderBindingTableRecordIndexNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetShaderBindingTableRecordIndexEXT($0)";
         case cuda: __intrinsic_asm "slangOptixHitObjectGetSbtRecordIndex";
         case spvShaderInvocationReorderNV:
@@ -23202,9 +23216,6 @@ struct HitObject
     }
         /// Returns the instance index of a hit. Valid if the hit object represents a hit.
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [ForceInline]
     [require(cuda_glsl_hlsl_spirv, ser_raygen_closesthit_miss)]
     uint GetInstanceIndex()
@@ -23214,9 +23225,12 @@ struct HitObject
         case hlsl:
             __intrinsic_asm ".GetInstanceIndex";
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetInstanceIdNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetInstanceIdEXT($0)";
         case cuda: __intrinsic_asm "slangOptixHitObjectGetInstanceIndex";
         case spvShaderInvocationReorderNV:
@@ -23238,9 +23252,6 @@ struct HitObject
 
         /// Returns the instance ID of a hit. Valid if the hit object represents a hit.
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [ForceInline]
     [require(cuda_glsl_hlsl_spirv, ser_raygen_closesthit_miss)]
     uint GetInstanceID()
@@ -23250,9 +23261,12 @@ struct HitObject
         case hlsl:
             __intrinsic_asm ".GetInstanceID";
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetInstanceCustomIndexNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetInstanceCustomIndexEXT($0)";
         case cuda: __intrinsic_asm "slangOptixHitObjectGetInstanceId";
         case spvShaderInvocationReorderNV:
@@ -23274,9 +23288,6 @@ struct HitObject
 
         /// Returns the geometry index of a hit. Valid if the hit object represents a hit.
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [ForceInline]
     [require(cuda_glsl_hlsl_spirv, ser_raygen_closesthit_miss)]
     uint GetGeometryIndex()
@@ -23286,9 +23297,12 @@ struct HitObject
         case hlsl:
             __intrinsic_asm ".GetGeometryIndex";
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetGeometryIndexNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetGeometryIndexEXT($0)";
         case cuda: __intrinsic_asm "slangOptixHitObjectGetSbtGASIndex";
         case spvShaderInvocationReorderNV:
@@ -23310,9 +23324,6 @@ struct HitObject
 
         /// Returns the primitive index of a hit. Valid if the hit object represents a hit.
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [ForceInline]
     [require(cuda_glsl_hlsl_spirv, ser_raygen_closesthit_miss)]
     uint GetPrimitiveIndex()
@@ -23322,9 +23333,12 @@ struct HitObject
         case hlsl:
             __intrinsic_asm ".GetPrimitiveIndex";
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetPrimitiveIndexNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetPrimitiveIndexEXT($0)";
         case cuda: __intrinsic_asm "slangOptixHitObjectGetPrimitiveIndex";
         case spvShaderInvocationReorderNV:
@@ -23346,9 +23360,6 @@ struct HitObject
 
         /// Returns the hit kind. Valid if the hit object represents a hit.
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [ForceInline]
     [require(cuda_glsl_hlsl_spirv, ser_raygen_closesthit_miss)]
     uint GetHitKind()
@@ -23358,9 +23369,12 @@ struct HitObject
         case hlsl:
             __intrinsic_asm ".GetHitKind";
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetHitKindNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetHitKindEXT($0)";
         case cuda: __intrinsic_asm "optixHitObjectGetHitKind()";
         case spvShaderInvocationReorderNV:
@@ -23507,9 +23521,6 @@ struct HitObject
         /// Returns 4x3 world-to-object transform matrix. Valid if the hit object represents a hit.
         /// Note: NVAPI/SPIRV/GLSL extension. DXR 1.3 uses GetWorldToObject3x4() and GetWorldToObject4x3().
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [ForceInline]
     [require(cuda_glsl_spirv, ser_raygen_closesthit_miss)]
     [require(nvapi, ser_raygen_closesthit_miss)]
@@ -23519,9 +23530,12 @@ struct HitObject
         {
         case hlsl_nvapi: __intrinsic_asm ".GetWorldToObject";
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetWorldToObjectNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetWorldToObjectEXT($0)";
         case cuda: __intrinsic_asm "slangOptixHitObjectGetWorldToObject";
         case spvShaderInvocationReorderNV:
@@ -23544,9 +23558,6 @@ struct HitObject
         /// Returns 4x3 object-to-world transform matrix. Valid if the hit object represents a hit.
         /// Note: NVAPI/SPIRV/GLSL extension. DXR 1.3 uses GetObjectToWorld3x4() and GetObjectToWorld4x3().
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [ForceInline]
     [require(cuda_glsl_spirv, ser_raygen_closesthit_miss)]
     [require(nvapi, ser_raygen_closesthit_miss)]
@@ -23556,9 +23567,12 @@ struct HitObject
         {
         case hlsl_nvapi: __intrinsic_asm ".GetObjectToWorld";
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetObjectToWorldNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetObjectToWorldEXT($0)";
         case cuda: __intrinsic_asm "slangOptixHitObjectGetObjectToWorld";
         case spvShaderInvocationReorderNV:
@@ -23579,19 +23593,19 @@ struct HitObject
     }
 
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_ray_tracing_motion_blur)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [ForceInline]
     [require(cuda_glsl_spirv, ser_raygen_closesthit_miss)]
     float GetCurrentTime() {
         __target_switch
         {
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_ray_tracing_motion_blur");
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetCurrentTimeNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetCurrentTimeEXT($0)";
         case cuda: __intrinsic_asm "slangOptixHitObjectGetRayTime";
         case spvShaderInvocationReorderNV:
@@ -23613,9 +23627,6 @@ struct HitObject
 
         /// Returns object-space ray origin. Valid if the hit object represents a hit.
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [ForceInline]
     [require(cuda_glsl_hlsl_spirv, ser_raygen_closesthit_miss)]
     float3 GetObjectRayOrigin() {
@@ -23624,9 +23635,12 @@ struct HitObject
         case hlsl:
             __intrinsic_asm ".GetObjectRayOrigin";
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetObjectRayOriginNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetObjectRayOriginEXT($0)";
         case cuda: __intrinsic_asm "optixGetObjectRayOrigin()";
         case spvShaderInvocationReorderNV:
@@ -23648,9 +23662,6 @@ struct HitObject
 
         /// Returns object-space ray direction. Valid if the hit object represents a hit.
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [ForceInline]
     [require(cuda_glsl_hlsl_spirv, ser_raygen_closesthit_miss)]
     float3 GetObjectRayDirection() {
@@ -23659,9 +23670,12 @@ struct HitObject
         case hlsl:
             __intrinsic_asm ".GetObjectRayDirection";
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetObjectRayDirectionNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetObjectRayDirectionEXT($0)";
         case cuda: __intrinsic_asm "optixGetObjectRayDirection()";
         case spvShaderInvocationReorderNV:
@@ -23682,18 +23696,18 @@ struct HitObject
     }
 
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [ForceInline]
     [require(glsl_spirv, ser_raygen_closesthit_miss)]
     uint2 GetShaderRecordBufferHandle() {
         __target_switch
         {
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetShaderRecordBufferHandleNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetShaderRecordBufferHandleEXT($0)";
         case spvShaderInvocationReorderNV:
             return spirv_asm
@@ -23714,9 +23728,6 @@ struct HitObject
 
     /// Returns the attributes of a hit. Valid if the hit object represents a hit or a miss.
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [ForceInline]
     [require(cuda_glsl_hlsl_spirv, ser_raygen_closesthit_miss)]
     attr_t GetAttributes<attr_t>()
@@ -23734,6 +23745,8 @@ struct HitObject
             __intrinsic_asm ".GetAttributes";
         case _GL_NV_shader_invocation_reorder:
             {
+                __requireTargetExtension("GL_NV_shader_invocation_reorder");
+
                 // Work out the location
                 int attributeLocation = __hitObjectAttributesLocation(__hitObjectAttributes<attr_t>());
 
@@ -23746,6 +23759,9 @@ struct HitObject
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
             {
+                __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+                __requireTargetExtension("GL_EXT_shader_invocation_reorder");
+
                 // Work out the location
                 int attributeLocation = __hitObjectAttributesLocation(__hitObjectAttributes<attr_t>());
 
@@ -24220,52 +24236,52 @@ struct HitObject
     }
 
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [require(glsl, ser_raygen_closesthit_miss)]
     static void __glslMakeNop(out HitObject hitObj)
     {
         __target_switch
         {
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectRecordEmptyNV";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectRecordEmptyEXT";
         }
     }
 
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [require(glsl, ser_raygen_closesthit_miss)]
     float3 __glslGetRayDirection()
     {
         __target_switch
         {
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetObjectRayDirectionNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetObjectRayDirectionEXT($0)";
         }
     }
 
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [require(glsl, ser_raygen_closesthit_miss)]
     float3 __glslGetRayWorldDirection()
     {
         __target_switch
         {
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetWorldRayDirectionNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetWorldRayDirectionEXT($0)";
         }
     }
@@ -24283,18 +24299,18 @@ struct HitObject
     }
 
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [require(glsl, ser_raygen_closesthit_miss)]
     float3 __glslGetRayWorldOrigin()
     {
         __target_switch
         {
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetWorldRayOriginNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetWorldRayOriginEXT($0)";
         }
     }
@@ -24312,18 +24328,18 @@ struct HitObject
     }
 
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [require(glsl, ser_raygen_closesthit_miss)]
     float __glslGetTMax()
     {
         __target_switch
         {
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetRayTMaxNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetRayTMaxEXT($0)";
         }
     }
@@ -24341,18 +24357,18 @@ struct HitObject
     }
 
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [require(glsl, ser_raygen_closesthit_miss)]
     float __glslGetTMin()
     {
         __target_switch
         {
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetRayTMinNV($0)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetRayTMinEXT($0)";
         }
     }
@@ -24475,18 +24491,18 @@ struct HitObject
 
 
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [require(glsl, ser_raygen_closesthit_miss)]
     void __glslGetAttributes(int attributeLocation)
     {
         __target_switch
         {
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetAttributesNV($0, $1)";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectGetAttributesEXT($0, $1)";
         }
     }
@@ -24505,9 +24521,6 @@ struct HitObject
     }
 
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [require(glsl, ser_raygen_closesthit_miss)]
     static void __glslTraceRay(
         out HitObject hitObject,
@@ -24526,9 +24539,12 @@ struct HitObject
         __target_switch
         {
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectTraceRayNV";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectTraceRayEXT";
         }
     }
@@ -25026,10 +25042,6 @@ struct HitObject
     }
 
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_ray_tracing_motion_blur)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [require(glsl, ser_motion_raygen_closesthit_miss)]
     static void __glslTraceMotionRay(
         out HitObject hitObject,
@@ -25049,9 +25061,13 @@ struct HitObject
         __target_switch
         {
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_ray_tracing_motion_blur");
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectTraceRayMotionNV";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectTraceRayMotionEXT";
         }
     }
@@ -25059,7 +25075,6 @@ struct HitObject
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_EXT_buffer_reference_uvec2)
     __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_ray_tracing_motion_blur)
     [require(glsl, ser_motion_raygen_closesthit_miss)]
     static void __glslTraceMotionRayEXT(
         out HitObject hitObject,
@@ -25078,14 +25093,11 @@ struct HitObject
     {
         __target_switch
         {
-        case _GL_EXT_shader_invocation_reorder_motion: __intrinsic_asm "hitObjectTraceRayMotionEXT";
+        case _GL_EXT_shader_invocation_reorder: __intrinsic_asm "hitObjectTraceRayMotionEXT";
         }
     }
 
     __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_EXT_buffer_reference_uvec2)
-    __glsl_extension(GL_EXT_shader_invocation_reorder)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
     [require(glsl, ser_raygen_closesthit_miss)]
     static void __glslInvoke(
         HitObject hitObj,
@@ -25094,9 +25106,12 @@ struct HitObject
         __target_switch
         {
         case _GL_NV_shader_invocation_reorder:
+            __requireTargetExtension("GL_NV_shader_invocation_reorder");
             __intrinsic_asm "hitObjectExecuteShaderNV";
         case glsl: // use GL_EXT until KHR is available.
         case _GL_EXT_shader_invocation_reorder:
+            __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+            __requireTargetExtension("GL_EXT_shader_invocation_reorder");
             __intrinsic_asm "hitObjectExecuteShaderEXT";
         }
     }
@@ -25125,9 +25140,6 @@ struct HitObject
     /// Where possible, reordering will also attempt to retain locality in the thread's launch indices
     /// (DispatchRaysIndex in DXR).
 __glsl_extension(GL_EXT_ray_tracing)
-__glsl_extension(GL_EXT_buffer_reference_uvec2)
-__glsl_extension(GL_EXT_shader_invocation_reorder)
-__glsl_extension(GL_NV_shader_invocation_reorder)
 [ForceInline]
 [require(cuda_glsl_hlsl_spirv, ser_raygen)]
 void ReorderThread( uint CoherenceHint, uint NumCoherenceHintBitsFromLSB )
@@ -25137,9 +25149,12 @@ void ReorderThread( uint CoherenceHint, uint NumCoherenceHintBitsFromLSB )
     case hlsl_nvapi: __intrinsic_asm "NvReorderThread";
     case hlsl: __intrinsic_asm "dx::MaybeReorderThread";
     case _GL_NV_shader_invocation_reorder:
+        __requireTargetExtension("GL_NV_shader_invocation_reorder");
         __intrinsic_asm "reorderThreadNV";
     case glsl: // use GL_EXT until KHR is available.
     case _GL_EXT_shader_invocation_reorder:
+        __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+        __requireTargetExtension("GL_EXT_shader_invocation_reorder");
         __intrinsic_asm "reorderThreadEXT";
     case cuda: __intrinsic_asm "optixReorder";
     case spvShaderInvocationReorderNV:
@@ -25176,9 +25191,6 @@ void ReorderThread( uint CoherenceHint, uint NumCoherenceHintBitsFromLSB )
     /// of equal coherence hints, it will attempt to maximize locality in 3D space of the ray hit (if any).
 
 __glsl_extension(GL_EXT_ray_tracing)
-__glsl_extension(GL_EXT_buffer_reference_uvec2)
-__glsl_extension(GL_EXT_shader_invocation_reorder)
-__glsl_extension(GL_NV_shader_invocation_reorder)
 [ForceInline]
 [require(cuda_glsl_hlsl_spirv, ser_raygen)]
 void ReorderThread( HitObject HitOrMiss, uint CoherenceHint, uint NumCoherenceHintBitsFromLSB )
@@ -25188,9 +25200,12 @@ void ReorderThread( HitObject HitOrMiss, uint CoherenceHint, uint NumCoherenceHi
     case hlsl_nvapi: __intrinsic_asm "NvReorderThread";
     case hlsl: __intrinsic_asm "dx::MaybeReorderThread";
     case _GL_NV_shader_invocation_reorder:
+        __requireTargetExtension("GL_NV_shader_invocation_reorder");
         __intrinsic_asm "reorderThreadNV";
     case glsl: // use GL_EXT until KHR is available.
     case _GL_EXT_shader_invocation_reorder:
+        __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+        __requireTargetExtension("GL_EXT_shader_invocation_reorder");
         __intrinsic_asm "reorderThreadEXT";
     case cuda: __intrinsic_asm "optixReorder($1, $2)";
     case spvShaderInvocationReorderNV:
@@ -25217,9 +25232,6 @@ void ReorderThread( HitObject HitOrMiss, uint CoherenceHint, uint NumCoherenceHi
     // With CoherenceHint and NumCoherenceHintBitsFromLSB as 0, meaning they are ignored.
 
 __glsl_extension(GL_EXT_ray_tracing)
-__glsl_extension(GL_EXT_buffer_reference_uvec2)
-__glsl_extension(GL_EXT_shader_invocation_reorder)
-__glsl_extension(GL_NV_shader_invocation_reorder)
 [ForceInline]
 [require(cuda_glsl_hlsl_spirv, ser_raygen)]
 void ReorderThread( HitObject HitOrMiss )
@@ -25229,9 +25241,12 @@ void ReorderThread( HitObject HitOrMiss )
     case hlsl_nvapi: __intrinsic_asm "NvReorderThread";
     case hlsl: __intrinsic_asm "dx::MaybeReorderThread";
     case _GL_NV_shader_invocation_reorder:
+        __requireTargetExtension("GL_NV_shader_invocation_reorder");
         __intrinsic_asm "reorderThreadNV";
     case glsl: // use GL_EXT until KHR is available.
     case _GL_EXT_shader_invocation_reorder:
+        __requireTargetExtension("GL_EXT_buffer_reference_uvec2");
+        __requireTargetExtension("GL_EXT_shader_invocation_reorder");
         __intrinsic_asm "reorderThreadEXT";
     case cuda: __intrinsic_asm "optixReorder()";
     case spvShaderInvocationReorderNV:


### PR DESCRIPTION
Replace a function modifier style with inline function call style GLSL extension requirements.
Changed from:
 - `__glsl_extension(GL_EXT_buffer_reference_uvec2)`,
 - `__glsl_extension(GL_EXT_shader_invocation_reorder)`,
 - `__glsl_extension(GL_NV_shader_invocation_reorder)` and
 - `__glsl_extension(GL_NV_ray_tracing_motion_blur)`

to:
 - `__requireTargetExtension("GL_EXT_buffer_reference_uvec2")`,
 - `__requireTargetExtension("GL_EXT_shader_invocation_reorder")`,
 - `__requireTargetExtension("GL_NV_shader_invocation_reorder")` and
 - `__requireTargetExtension("GL_NV_ray_tracing_motion_blur")` respectively.

This is to avoid a case where the user requested to use NV extension but the emitted GLSL shader requires both EXT and NV extensions.