### PR TITLE
Use D3DCOMPILE_SKIP_OPTIMIZATION for Maximal debug info with no optimization

### DIFF
--- a/source/compiler-core/slang-fxc-compiler.cpp
+++ b/source/compiler-core/slang-fxc-compiler.cpp
@@ -301,7 +301,7 @@ SlangResult FXCDownstreamCompiler::compile(const CompileOptions& inOptions, IArt
         break;
 
     // FXC has limited debug control options - it only supports a binary on/off for debug info
-    // This covers DebugInfoType::Minimal, DebugInfoType::Standard, and DebugInfoType::Maximal
+    // This covers DebugInfoType::Minimal, DebugInfoType::Standard
     default:
         flags |= D3DCOMPILE_DEBUG;
         // If optimization is disabled, FXC will generate much more usable debug information with


### PR DESCRIPTION
Fixes #10324
Closes #10327