### PR TITLE
Add hand-editable CI status page to analytics dashboard

### DIFF
--- a/.github/workflows/ci-analytics.yml
+++ b/.github/workflows/ci-analytics.yml
@@ -53,6 +53,11 @@ jobs:
             --pr-input /tmp/pr_merges.json \
             --output ci_analytics_repo
 
+      - name: Generate status page
+        run: |
+          python3 extras/ci/analytics/ci_status.py \
+            --output ci_analytics_repo
+
       - name: Push to analytics repo
         run: |
           cd ci_analytics_repo

--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -39,12 +39,17 @@ jobs:
           python3 extras/ci/analytics/ci_health.py \
             --output ci_analytics_repo
 
+      - name: Generate status page
+        run: |
+          python3 extras/ci/analytics/ci_status.py \
+            --output ci_analytics_repo
+
       - name: Push health page
         run: |
           cd ci_analytics_repo
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add health.html
+          git add health.html status.html
           git add health_snapshots.jsonl 2>/dev/null || true
           git diff --cached --quiet || {
             git commit -m "Update CI health $(date -u +%Y-%m-%dT%H:%M)" &&

--- a/extras/ci/analytics/ci_status.py
+++ b/extras/ci/analytics/ci_status.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+CI Status Page Generator
+
+Reads hand-edited status_updates.json from the analytics output directory
+and generates status.html for the CI analytics dashboard.
+
+The status_updates.json file lives in the analytics repo (shader-slang/slang-ci-analytics)
+so it can be updated without PRing the main slang repo.
+
+Usage:
+    python3 ci_status.py --output ./ci_analytics_repo
+"""
+
+import argparse
+import html as html_mod
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from ci_visualization import page_template
+
+SEVERITY_COLORS = {
+    "info": ("#0d6efd", "#cfe2ff"),
+    "warning": ("#fd7e14", "#fff3cd"),
+    "critical": ("#dc3545", "#f8d7da"),
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate CI status page from status_updates.json."
+    )
+    parser.add_argument(
+        "--output", default="ci_analytics", help="Output directory (also where status_updates.json is read from)"
+    )
+    return parser.parse_args()
+
+
+def load_status_updates(output_dir):
+    """Load status entries from the analytics repo directory."""
+    path = os.path.join(output_dir, "status_updates.json")
+    if not os.path.exists(path):
+        return []
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        entries = data.get("entries", [])
+        if not isinstance(entries, list):
+            print(f"Warning: status_updates.json 'entries' is not a list", file=sys.stderr)
+            return []
+        return entries
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"Warning: could not read status_updates.json: {e}", file=sys.stderr)
+        return []
+
+
+def render_entry(entry):
+    """Render a single status entry as an HTML card."""
+    sev = entry.get("severity", "info")
+    fg, bg = SEVERITY_COLORS.get(sev, SEVERITY_COLORS["info"])
+    title = html_mod.escape(str(entry.get("title", "")))
+    body = html_mod.escape(str(entry.get("body", ""))).replace("\n", "<br>")
+    date = html_mod.escape(str(entry.get("date", "")))
+    author = html_mod.escape(str(entry.get("author", "")))
+
+    author_html = f" &mdash; {author}" if author else ""
+    return f"""<div style="border-left:4px solid {fg};background:{bg};padding:15px 20px;margin-bottom:15px;border-radius:4px">
+  <span style="background:{fg};color:white;padding:2px 8px;border-radius:3px;font-size:0.8em;text-transform:uppercase">{html_mod.escape(sev)}</span>
+  <strong style="margin-left:10px;font-size:1.1em">{title}</strong>
+  <div style="color:#6c757d;font-size:0.85em;margin-top:4px">{date}{author_html}</div>
+  <div style="margin-top:8px">{body}</div>
+</div>"""
+
+
+def generate_status_html(output_dir):
+    """Generate status.html from status_updates.json."""
+    entries = load_status_updates(output_dir)
+
+    # Filter to visible entries only (default visible if not specified)
+    visible = [e for e in entries if e.get("visible", True)]
+
+    # Sort by date descending
+    visible.sort(key=lambda e: e.get("date", ""), reverse=True)
+
+    if visible:
+        cards = "\n".join(render_entry(e) for e in visible)
+        body = f"""<h1>CI Status</h1>
+<p style="color:#6c757d">Known issues and maintenance notices. Edit <code>status_updates.json</code> in the
+<a href="https://github.com/shader-slang/slang-ci-analytics">analytics repo</a> to update.</p>
+{cards}"""
+    else:
+        body = """<h1>CI Status</h1>
+<p style="color:#6c757d">Known issues and maintenance notices. Edit <code>status_updates.json</code> in the
+<a href="https://github.com/shader-slang/slang-ci-analytics">analytics repo</a> to update.</p>
+<div style="background:#d1e7dd;border-left:4px solid #198754;padding:15px 20px;border-radius:4px;color:#0f5132">
+  <strong>All Systems Operational</strong> &mdash; No known issues.
+</div>"""
+
+    os.makedirs(output_dir, exist_ok=True)
+    with open(os.path.join(output_dir, "status.html"), "w") as f:
+        f.write(page_template("Status", body, "Status"))
+
+
+def main():
+    args = parse_args()
+    generate_status_html(args.output)
+    print(f"Generated status.html in {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/extras/ci/analytics/ci_visualization.py
+++ b/extras/ci/analytics/ci_visualization.py
@@ -281,6 +281,7 @@ def nav_html(active=""):
         ("index.html", "Home"),
         ("statistics.html", "Statistics"),
         ("health.html", "Health"),
+        ("status.html", "Status"),
     ]
     items = []
     for href, label in links:

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -11,6 +11,7 @@ if ANALYTICS_DIR not in sys.path:
     sys.path.insert(0, ANALYTICS_DIR)
 
 import ci_health
+import ci_status
 import ci_visualization
 
 
@@ -446,6 +447,119 @@ class TestUtilityBehavior(unittest.TestCase):
             snaps = ci_health.load_snapshots(tmp, hours=1)
 
         self.assertEqual([s["id"] for s in snaps], [2])
+
+
+class TestStatusPage(unittest.TestCase):
+    def test_generate_with_entries(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data = {
+                "entries": [
+                    {
+                        "date": "2026-03-12",
+                        "severity": "warning",
+                        "title": "Runner flaky",
+                        "body": "Investigating.",
+                        "author": "testuser",
+                    },
+                    {
+                        "date": "2026-03-10",
+                        "severity": "info",
+                        "title": "Maintenance",
+                        "body": "Scheduled downtime.",
+                        "author": "admin",
+                    },
+                ]
+            }
+            with open(os.path.join(tmp, "status_updates.json"), "w") as f:
+                json.dump(data, f)
+
+            ci_status.generate_status_html(tmp)
+
+            with open(os.path.join(tmp, "status.html")) as f:
+                html = f.read()
+            self.assertIn("Runner flaky", html)
+            self.assertIn("Maintenance", html)
+            self.assertIn("testuser", html)
+            # warning entry should appear before info (sorted by date desc)
+            self.assertGreater(html.index("Maintenance"), html.index("Runner flaky"))
+
+    def test_generate_empty_entries(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with open(os.path.join(tmp, "status_updates.json"), "w") as f:
+                json.dump({"entries": []}, f)
+
+            ci_status.generate_status_html(tmp)
+
+            with open(os.path.join(tmp, "status.html")) as f:
+                html = f.read()
+            self.assertIn("All Systems Operational", html)
+
+    def test_generate_no_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ci_status.generate_status_html(tmp)
+
+            with open(os.path.join(tmp, "status.html")) as f:
+                html = f.read()
+            self.assertIn("All Systems Operational", html)
+
+    def test_severity_colors(self):
+        for sev in ("info", "warning", "critical"):
+            entry = {"severity": sev, "title": f"Test {sev}", "body": "x"}
+            rendered = ci_status.render_entry(entry)
+            fg, bg = ci_status.SEVERITY_COLORS[sev]
+            self.assertIn(fg, rendered)
+            self.assertIn(bg, rendered)
+
+    def test_html_escaping(self):
+        entry = {
+            "title": "<script>alert(1)</script>",
+            "body": "a < b & c > d",
+            "author": "<img>",
+        }
+        rendered = ci_status.render_entry(entry)
+        self.assertNotIn("<script>", rendered)
+        self.assertIn("&lt;script&gt;", rendered)
+        self.assertIn("a &lt; b &amp; c &gt; d", rendered)
+
+    def test_hidden_entries_not_rendered(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data = {
+                "entries": [
+                    {"date": "2026-03-12", "severity": "info", "title": "Visible", "body": "shown", "visible": True},
+                    {"date": "2026-03-11", "severity": "warning", "title": "Hidden", "body": "not shown", "visible": False},
+                ]
+            }
+            with open(os.path.join(tmp, "status_updates.json"), "w") as f:
+                json.dump(data, f)
+
+            ci_status.generate_status_html(tmp)
+
+            with open(os.path.join(tmp, "status.html")) as f:
+                html = f.read()
+            self.assertIn("Visible", html)
+            self.assertNotIn("Hidden", html)
+
+    def test_all_hidden_shows_all_clear(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data = {
+                "entries": [
+                    {"date": "2026-03-12", "severity": "info", "title": "Old issue", "body": "resolved", "visible": False},
+                ]
+            }
+            with open(os.path.join(tmp, "status_updates.json"), "w") as f:
+                json.dump(data, f)
+
+            ci_status.generate_status_html(tmp)
+
+            with open(os.path.join(tmp, "status.html")) as f:
+                html = f.read()
+            self.assertIn("All Systems Operational", html)
+            self.assertNotIn("Old issue", html)
+
+    def test_nav_includes_status(self):
+        nav = ci_visualization.nav_html("Status")
+        self.assertIn("status.html", nav)
+        self.assertIn("Status", nav)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds a new "Status" page to the CI analytics site for posting known CI issues, maintenance windows, and notices
- Status data lives in `status_updates.json` in the analytics repo (`shader-slang/slang-ci-analytics`) for easy editing without PRing the main repo
- Entries support severity levels (`info`/`warning`/`critical`) with color-coded cards and a `visible` field to hide resolved entries while keeping history
- Shows "All Systems Operational" when no visible entries exist
- Regenerated on both daily analytics and 15-minute health cycles