### PR TITLE
Fix SPIR-V `NonUniform` decorations and capabilities

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1012,10 +1012,16 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         case SpvOpImageSparseFetch:
         case SpvOpImageSparseGather:
         case SpvOpImageSparseDrefGather:
+        case SpvOpImageSparseRead:
         case SpvOpImageTexelPointer:
-        case SpvOpUntypedImageTexelPointerEXT:
             if (firstOperandIndex < inst->operandWordsCount)
                 outIndices.add(firstOperandIndex);
+            return;
+
+        case SpvOpUntypedImageTexelPointerEXT:
+            // Operand layout after result words: ImageType, Image, Coordinate, Sample.
+            if (firstOperandIndex + 1 < inst->operandWordsCount)
+                outIndices.add(firstOperandIndex + 1);
             return;
 
         default:
@@ -1076,6 +1082,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     return result;
                 }
             }
+            break;
         default:
             break;
         }
@@ -10663,11 +10670,12 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         auto maybeDecorateSampledImageResultNonUniform =
             [&](IRSPIRVAsmInst* asmInst, SpvInst* emittedInst)
         {
+            constexpr UInt kSampledImageOperandWordCount = 4;
             if (!emittedInst || emittedInst->opcode != SpvOpSampledImage)
                 return;
 
             bool needsNonUniform = false;
-            if (emittedInst->operandWordsCount >= 4)
+            if (emittedInst->operandWordsCount >= kSampledImageOperandWordCount)
             {
                 needsNonUniform = isNonUniformSpvValue(emittedInst->operandWords[2]) ||
                                   isNonUniformSpvValue(emittedInst->operandWords[3]);

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -525,6 +525,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
     ///
     void emitPhysicalLayout()
     {
+        postProcessNonUniformResources();
+
         // [2.3: Physical Layout of a SPIR-V Module and Instruction]
         //
         // > Magic Number
@@ -574,6 +576,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
     /// Map a Slang IR instruction to the corresponding SPIR-V instruction
     Dictionary<IRInst*, SpvInst*> m_mapIRInstToSpvInst;
+    Dictionary<SpvInst*, IRInst*> m_mapSpvInstToIRInst;
 
     // Sometimes we need to reserve an ID for an `IRInst` without actually
     // emitting it. We use `m_mapIRInstToSpvID` to hold all reserved SpvIDs.
@@ -584,10 +587,16 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
     // Map a Slang IR instruction to the corresponding SPIR-V debug instruction.
     Dictionary<IRInst*, SpvInst*> m_mapIRInstToSpvDebugInst;
 
+    // Track emitted IDs so later legalization steps in the emitter can reason
+    // about value provenance after SPIR-V asm snippets are lowered.
+    Dictionary<SpvWord, SpvInst*> m_mapSpvIDToInst;
+    HashSet<SpvWord> m_nonUniformValueIDs;
+
     /// Register that `irInst` maps to `spvInst`
     void registerInst(IRInst* irInst, SpvInst* spvInst)
     {
         m_mapIRInstToSpvInst.add(irInst, spvInst);
+        m_mapSpvInstToIRInst[spvInst] = irInst;
 
         // If we have reserved an SpvID for `irInst`, make sure to use it.
         SpvWord reservedID = 0;
@@ -597,6 +606,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         {
             SLANG_ASSERT(spvInst->id == 0);
             spvInst->id = reservedID;
+            m_mapSpvIDToInst[reservedID] = spvInst;
         }
     }
 
@@ -668,7 +678,540 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             id = freshID();
             inst->id = id;
         }
+        m_mapSpvIDToInst[id] = inst;
         return id;
+    }
+
+    SpvWord getExistingResultID(SpvInst* inst)
+    {
+        if (!inst)
+            return 0;
+        if (inst->id)
+        {
+            m_mapSpvIDToInst[inst->id] = inst;
+            return inst->id;
+        }
+        const auto opInfo = m_grammarInfo->opInfos.lookup(inst->opcode);
+        if (opInfo && opInfo->resultIdIndex >= 0 &&
+            UInt(opInfo->resultIdIndex) < inst->operandWordsCount)
+        {
+            const auto resultID = inst->operandWords[opInfo->resultIdIndex];
+            m_mapSpvIDToInst[resultID] = inst;
+            return resultID;
+        }
+        return 0;
+    }
+
+    // The post-pass works on emitted SPIR-V rather than IR so it can reason about
+    // values introduced late, including IDs created by `spirv_asm`.
+    enum class NonUniformResourceKind
+    {
+        None,
+        UniformBuffer,
+        SampledImage,
+        StorageBuffer,
+        StorageImage,
+        InputAttachment,
+        UniformTexelBuffer,
+        StorageTexelBuffer,
+    };
+
+    struct NonUniformSpvValueInfo
+    {
+        bool isNonUniform = false;
+        NonUniformResourceKind kind = NonUniformResourceKind::None;
+    };
+    // The post-pass only needs two answers for an emitted SPIR-V value:
+    // whether it is non-uniform, and which descriptor-indexing capability
+    // should be requested if we decorate it.
+
+    Int getFirstSPIRVOperandWordIndex(SpvInst* inst)
+    {
+        if (!inst)
+            return 0;
+
+        Int result = 0;
+        if (const auto opInfo = m_grammarInfo->opInfos.lookup(inst->opcode))
+        {
+            if (opInfo->resultTypeIndex >= result)
+                result = opInfo->resultTypeIndex + 1;
+            if (opInfo->resultIdIndex >= result)
+                result = opInfo->resultIdIndex + 1;
+        }
+        return result;
+    }
+
+    bool irTypeHasDecorationRec(IRType* type, IROp decorationOp)
+    {
+        if (!type)
+            return false;
+
+        type = as<IRType>(unwrapAttributedType(type));
+        if (type->findDecorationImpl(decorationOp))
+            return true;
+
+        if (auto arrayType = as<IRArrayTypeBase>(type))
+            return irTypeHasDecorationRec(arrayType->getElementType(), decorationOp);
+        if (auto ptrType = as<IRPtrTypeBase>(type))
+            return irTypeHasDecorationRec(ptrType->getValueType(), decorationOp);
+        if (auto parameterGroupType = as<IRParameterGroupType>(type))
+            return irTypeHasDecorationRec(parameterGroupType->getElementType(), decorationOp);
+        return false;
+    }
+
+    NonUniformResourceKind getNonUniformResourceKindForIRType(IRType* type)
+    {
+        if (!type)
+            return NonUniformResourceKind::None;
+
+        type = as<IRType>(unwrapAttributedType(type));
+        if (auto arrayType = as<IRArrayTypeBase>(type))
+            return getNonUniformResourceKindForIRType(arrayType->getElementType());
+
+        if (auto ptrType = as<IRPtrTypeBase>(type))
+        {
+            switch (ptrType->getAddressSpace())
+            {
+            case AddressSpace::StorageBuffer:
+                return NonUniformResourceKind::StorageBuffer;
+            case AddressSpace::UniformConstant:
+                return getNonUniformResourceKindForIRType(ptrType->getValueType());
+            case AddressSpace::Uniform:
+                if (irTypeHasDecorationRec(
+                        ptrType->getValueType(),
+                        kIROp_SPIRVBufferBlockDecoration))
+                {
+                    return NonUniformResourceKind::StorageBuffer;
+                }
+                if (irTypeHasDecorationRec(ptrType->getValueType(), kIROp_SPIRVBlockDecoration))
+                    return NonUniformResourceKind::UniformBuffer;
+                return getNonUniformResourceKindForIRType(ptrType->getValueType());
+            default:
+                return getNonUniformResourceKindForIRType(ptrType->getValueType());
+            }
+        }
+
+        if (as<IRConstantBufferType>(type) || as<IRParameterGroupType>(type))
+            return NonUniformResourceKind::UniformBuffer;
+
+        if (as<IRHLSLStructuredBufferTypeBase>(type) || as<IRGLSLShaderStorageBufferType>(type))
+            return NonUniformResourceKind::StorageBuffer;
+
+        if (as<IRSamplerStateTypeBase>(type))
+            return NonUniformResourceKind::SampledImage;
+
+        if (as<IRSubpassInputType>(type))
+            return NonUniformResourceKind::InputAttachment;
+
+        if (auto textureType = as<IRTextureTypeBase>(type))
+        {
+            if (textureType->isCombined())
+                return getNonUniformResourceKindForIRType(
+                    as<IRType>(getTextureTypeFromCombinedTextureSampler(textureType)));
+
+            if (textureType->GetBaseShape() == SLANG_TEXTURE_BUFFER)
+            {
+                switch (textureType->getAccess())
+                {
+                case SLANG_RESOURCE_ACCESS_READ_WRITE:
+                case SLANG_RESOURCE_ACCESS_RASTER_ORDERED:
+                case SLANG_RESOURCE_ACCESS_WRITE:
+                    return NonUniformResourceKind::StorageTexelBuffer;
+                default:
+                    return NonUniformResourceKind::UniformTexelBuffer;
+                }
+            }
+
+            switch (textureType->getAccess())
+            {
+            case SLANG_RESOURCE_ACCESS_READ_WRITE:
+            case SLANG_RESOURCE_ACCESS_RASTER_ORDERED:
+            case SLANG_RESOURCE_ACCESS_WRITE:
+                return NonUniformResourceKind::StorageImage;
+            default:
+                return NonUniformResourceKind::SampledImage;
+            }
+        }
+
+        return NonUniformResourceKind::None;
+    }
+
+    NonUniformResourceKind getNonUniformResourceKindForIRValue(IRInst* value)
+    {
+        for (auto current = value; current; )
+        {
+            if (auto irFunc = as<IRFunc>(current))
+                return getNonUniformResourceKindForIRType(irFunc->getResultType());
+
+            if (auto kind = getNonUniformResourceKindForIRType(current->getDataType());
+                kind != NonUniformResourceKind::None)
+            {
+                return kind;
+            }
+
+            switch (current->getOp())
+            {
+            case kIROp_Load:
+            case kIROp_GetElement:
+            case kIROp_GetElementPtr:
+            case kIROp_FieldExtract:
+            case kIROp_FieldAddress:
+            case kIROp_BitCast:
+            case kIROp_CopyLogical:
+                current = current->getOperand(0);
+                continue;
+            default:
+                return NonUniformResourceKind::None;
+            }
+        }
+
+        return NonUniformResourceKind::None;
+    }
+
+    void emitNonUniformDecoration(IRInst* decorationInst, SpvWord targetID)
+    {
+        if (!targetID)
+            return;
+        if (m_nonUniformValueIDs.contains(targetID))
+            return;
+        ensureExtensionDeclarationBeforeSpv15(toSlice("SPV_EXT_descriptor_indexing"));
+        requireSPIRVCapability(SpvCapabilityShaderNonUniform);
+        emitOpDecorate(
+            getSection(SpvLogicalSectionID::Annotations),
+            decorationInst,
+            targetID,
+            SpvDecorationNonUniform);
+        m_nonUniformValueIDs.add(targetID);
+    }
+
+    void requireNonUniformCapability(NonUniformResourceKind kind)
+    {
+        switch (kind)
+        {
+        case NonUniformResourceKind::UniformBuffer:
+            requireSPIRVCapability(SpvCapabilityUniformBufferArrayNonUniformIndexing);
+            break;
+        case NonUniformResourceKind::SampledImage:
+            requireSPIRVCapability(SpvCapabilitySampledImageArrayNonUniformIndexing);
+            break;
+        case NonUniformResourceKind::StorageBuffer:
+            requireSPIRVCapability(SpvCapabilityStorageBufferArrayNonUniformIndexing);
+            break;
+        case NonUniformResourceKind::StorageImage:
+            requireSPIRVCapability(SpvCapabilityStorageImageArrayNonUniformIndexing);
+            break;
+        case NonUniformResourceKind::InputAttachment:
+            requireSPIRVCapability(SpvCapabilityInputAttachmentArrayNonUniformIndexing);
+            break;
+        case NonUniformResourceKind::UniformTexelBuffer:
+            requireSPIRVCapability(SpvCapabilityUniformTexelBufferArrayNonUniformIndexing);
+            break;
+        case NonUniformResourceKind::StorageTexelBuffer:
+            requireSPIRVCapability(SpvCapabilityStorageTexelBufferArrayNonUniformIndexing);
+            break;
+        case NonUniformResourceKind::None:
+            break;
+        }
+    }
+
+    void requireNonUniformCapabilityForIRValue(IRInst* value)
+    {
+        requireNonUniformCapability(getNonUniformResourceKindForIRValue(value));
+    }
+
+    bool emitNonUniformDecorationForKind(
+        IRInst* decorationInst,
+        SpvWord targetID,
+        NonUniformResourceKind kind)
+    {
+        if (!targetID || kind == NonUniformResourceKind::None)
+            return false;
+
+        const bool hadDecoration = m_nonUniformValueIDs.contains(targetID);
+        requireNonUniformCapability(kind);
+        emitNonUniformDecoration(decorationInst, targetID);
+        return !hadDecoration && m_nonUniformValueIDs.contains(targetID);
+    }
+
+    bool emitNonUniformResourceDecoration(IRInst* decorationInst, SpvWord targetID)
+    {
+        const auto kind = getNonUniformResourceKindForValue(targetID);
+        return emitNonUniformDecorationForKind(decorationInst, targetID, kind);
+    }
+
+    // Vulkan wants `NonUniform` on the operand actually consumed as a resource by
+    // the instruction, not necessarily on the SSA value where the non-uniform index
+    // first appeared. This maps the instructions we emit to those operands.
+    void getNonUniformResourceOperandWordIndices(SpvInst* inst, ShortList<UInt>& outIndices)
+    {
+        outIndices.clear();
+        if (!inst)
+            return;
+
+        const UInt firstOperandIndex = UInt(getFirstSPIRVOperandWordIndex(inst));
+        switch (inst->opcode)
+        {
+        case SpvOpLoad:
+        case SpvOpStore:
+        case SpvOpCopyMemory:
+        case SpvOpCopyMemorySized:
+        case SpvOpArrayLength:
+        case SpvOpAtomicLoad:
+        case SpvOpAtomicStore:
+        case SpvOpAtomicExchange:
+        case SpvOpAtomicCompareExchange:
+        case SpvOpAtomicCompareExchangeWeak:
+        case SpvOpAtomicIIncrement:
+        case SpvOpAtomicIDecrement:
+        case SpvOpAtomicIAdd:
+        case SpvOpAtomicISub:
+        case SpvOpAtomicSMin:
+        case SpvOpAtomicUMin:
+        case SpvOpAtomicSMax:
+        case SpvOpAtomicUMax:
+        case SpvOpAtomicAnd:
+        case SpvOpAtomicOr:
+        case SpvOpAtomicXor:
+            if (firstOperandIndex < inst->operandWordsCount)
+                outIndices.add(firstOperandIndex);
+            if ((inst->opcode == SpvOpCopyMemory || inst->opcode == SpvOpCopyMemorySized) &&
+                firstOperandIndex + 1 < inst->operandWordsCount)
+            {
+                outIndices.add(firstOperandIndex + 1);
+            }
+            return;
+
+        case SpvOpImageSampleImplicitLod:
+        case SpvOpImageSampleExplicitLod:
+        case SpvOpImageSampleDrefImplicitLod:
+        case SpvOpImageSampleDrefExplicitLod:
+        case SpvOpImageSampleProjImplicitLod:
+        case SpvOpImageSampleProjExplicitLod:
+        case SpvOpImageSampleProjDrefImplicitLod:
+        case SpvOpImageSampleProjDrefExplicitLod:
+        case SpvOpImageFetch:
+        case SpvOpImageGather:
+        case SpvOpImageDrefGather:
+        case SpvOpImageRead:
+        case SpvOpImageWrite:
+        case SpvOpImageQueryFormat:
+        case SpvOpImageQueryOrder:
+        case SpvOpImageQuerySizeLod:
+        case SpvOpImageQuerySize:
+        case SpvOpImageQueryLod:
+        case SpvOpImageQueryLevels:
+        case SpvOpImageQuerySamples:
+        case SpvOpImageSparseSampleImplicitLod:
+        case SpvOpImageSparseSampleExplicitLod:
+        case SpvOpImageSparseSampleDrefImplicitLod:
+        case SpvOpImageSparseSampleDrefExplicitLod:
+        case SpvOpImageSparseSampleProjImplicitLod:
+        case SpvOpImageSparseSampleProjExplicitLod:
+        case SpvOpImageSparseSampleProjDrefImplicitLod:
+        case SpvOpImageSparseSampleProjDrefExplicitLod:
+        case SpvOpImageSparseFetch:
+        case SpvOpImageSparseGather:
+        case SpvOpImageSparseDrefGather:
+        case SpvOpImageTexelPointer:
+            if (firstOperandIndex < inst->operandWordsCount)
+                outIndices.add(firstOperandIndex);
+            return;
+
+        default:
+            return;
+        }
+    }
+
+    NonUniformSpvValueInfo getNonUniformSpvValueInfoRec(SpvWord valueID, HashSet<SpvWord>& visiting)
+    {
+        NonUniformSpvValueInfo result;
+        if (!valueID)
+            return result;
+        result.isNonUniform = m_nonUniformValueIDs.contains(valueID);
+        if (!visiting.add(valueID))
+            return result;
+
+        SpvInst* inst = nullptr;
+        if (!m_mapSpvIDToInst.tryGetValue(valueID, inst) || !inst)
+        {
+            visiting.remove(valueID);
+            return result;
+        }
+
+        IRInst* irInst = nullptr;
+        if (m_mapSpvInstToIRInst.tryGetValue(inst, irInst) && irInst)
+        {
+            result.kind = getNonUniformResourceKindForIRValue(irInst);
+            if (isNonUniformIRResourceValue(irInst))
+                result.isNonUniform = true;
+        }
+
+        UInt firstOperandIndex = UInt(getFirstSPIRVOperandWordIndex(inst));
+        switch (inst->opcode)
+        {
+        case SpvOpLoad:
+        case SpvOpCopyObject:
+        case SpvOpBitcast:
+        case SpvOpPhi:
+        case SpvOpSampledImage:
+        case SpvOpAccessChain:
+        case SpvOpInBoundsAccessChain:
+        case SpvOpPtrAccessChain:
+        case SpvOpInBoundsPtrAccessChain:
+        case SpvOpUntypedAccessChainKHR:
+            for (UInt i = firstOperandIndex; i < inst->operandWordsCount; ++i)
+            {
+                auto operandInfo =
+                    getNonUniformSpvValueInfoRec(inst->operandWords[i], visiting);
+                result.isNonUniform |= operandInfo.isNonUniform;
+                if (result.kind == NonUniformResourceKind::None)
+                    result.kind = operandInfo.kind;
+                if (result.isNonUniform && result.kind != NonUniformResourceKind::None)
+                {
+                    visiting.remove(valueID);
+                    return result;
+                }
+            }
+            default:
+            break;
+        }
+
+        visiting.remove(valueID);
+        return result;
+    }
+
+    NonUniformResourceKind getNonUniformResourceKindForValue(SpvWord valueID)
+    {
+        HashSet<SpvWord> visiting;
+        return getNonUniformSpvValueInfoRec(valueID, visiting).kind;
+    }
+
+    bool isNonUniformSpvValue(SpvWord valueID)
+    {
+        HashSet<SpvWord> visiting;
+        return getNonUniformSpvValueInfoRec(valueID, visiting).isNonUniform;
+    }
+
+    bool isNonUniformIRResourceValue(IRInst* value)
+    {
+        if (!value)
+            return false;
+        if (value->getOp() == kIROp_NonUniformResourceIndex)
+            return true;
+        if (value->findDecoration<IRSPIRVNonUniformResourceDecoration>())
+            return true;
+
+        if (auto getElement = as<IRGetElement>(value))
+        {
+            auto index = getElement->getOperand(1);
+            return index->getOp() == kIROp_NonUniformResourceIndex ||
+                   index->findDecoration<IRSPIRVNonUniformResourceDecoration>();
+        }
+
+        if (auto getElementPtr = as<IRGetElementPtr>(value))
+        {
+            auto index = getElementPtr->getOperand(1);
+            return index->getOp() == kIROp_NonUniformResourceIndex ||
+                   index->findDecoration<IRSPIRVNonUniformResourceDecoration>();
+        }
+
+        if (auto load = as<IRLoad>(value))
+        {
+            auto addr = load->getOperand(0);
+            if (addr->getOp() == kIROp_NonUniformResourceIndex)
+                return true;
+            if (addr->findDecoration<IRSPIRVNonUniformResourceDecoration>())
+                return true;
+            if (auto addrGetElement = as<IRGetElement>(addr))
+            {
+                auto index = addrGetElement->getOperand(1);
+                return index->getOp() == kIROp_NonUniformResourceIndex ||
+                       index->findDecoration<IRSPIRVNonUniformResourceDecoration>();
+            }
+            if (auto addrGetElementPtr = as<IRGetElementPtr>(addr))
+            {
+                auto index = addrGetElementPtr->getOperand(1);
+                return index->getOp() == kIROp_NonUniformResourceIndex ||
+                       index->findDecoration<IRSPIRVNonUniformResourceDecoration>();
+            }
+        }
+
+        return false;
+    }
+
+    void registerSPIRVResultIDsInParent(SpvInstParent* parent)
+    {
+        // The fix-up pass may revisit any already-emitted instruction, so index
+        // every result ID up front before we start chasing use-def chains.
+        for (auto child = parent->m_firstChild; child; child = child->nextSibling)
+        {
+            getExistingResultID(child);
+            registerSPIRVResultIDsInParent(child);
+        }
+    }
+
+    bool decorateNonUniformResourceOperandsInParent(SpvInstParent* parent)
+    {
+        bool changed = false;
+        ShortList<UInt> operandIndices;
+
+        for (auto child = parent->m_firstChild; child; child = child->nextSibling)
+        {
+            getNonUniformResourceOperandWordIndices(child, operandIndices);
+            for (auto operandIndex : operandIndices)
+            {
+                if (operandIndex >= child->operandWordsCount)
+                    continue;
+
+                auto operandID = child->operandWords[operandIndex];
+                const bool isNonUniform = isNonUniformSpvValue(operandID);
+                if (isNonUniform)
+                    changed |= emitNonUniformResourceDecoration(nullptr, operandID);
+            }
+
+            changed |= decorateNonUniformResourceOperandsInParent(child);
+        }
+
+        return changed;
+    }
+
+    void postProcessNonUniformResources()
+    {
+        // Earlier IR specialization is responsible for resource-typed call
+        // paths. This post-pass now focuses on retargeting NonUniform to the
+        // actual resource operands consumed by emitted SPIR-V, including values
+        // introduced late by paths like spirv_asm.
+        registerSPIRVResultIDsInParent(getSection(SpvLogicalSectionID::ConstantsAndTypes));
+        registerSPIRVResultIDsInParent(getSection(SpvLogicalSectionID::GlobalVariables));
+        registerSPIRVResultIDsInParent(getSection(SpvLogicalSectionID::FunctionDefinitions));
+        registerSPIRVResultIDsInParent(getSection(SpvLogicalSectionID::FunctionDeclarations));
+
+        bool changed = false;
+        do
+        {
+            changed = false;
+            changed |= decorateNonUniformResourceOperandsInParent(
+                getSection(SpvLogicalSectionID::FunctionDefinitions));
+            changed |= decorateNonUniformResourceOperandsInParent(
+                getSection(SpvLogicalSectionID::FunctionDeclarations));
+        } while (changed);
+    }
+
+    IRSPIRVAsmOperand* getSPIRVAsmResultIDOperand(IRSPIRVAsmInst* asmInst)
+    {
+        if (!asmInst)
+            return nullptr;
+
+        const auto opInfo = m_grammarInfo->opInfos.lookup(SpvOp(asmInst->getOpcodeOperandWord()));
+        if (!opInfo || opInfo->resultIdIndex < 0)
+            return nullptr;
+
+        const auto operands = asmInst->getSPIRVOperands();
+        const auto resultIdIndex = Index(opInfo->resultIdIndex);
+        if (resultIdIndex >= operands.getCount())
+            return nullptr;
+
+        return operands[resultIdIndex];
     }
 
     // We will build up `SpvInst`s in a stateful fashion,
@@ -4722,6 +5265,20 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 kResultID,
                 inst->getOperand(0),
                 inst->getOperand(1));
+            if (result)
+            {
+                auto imageOperand = ensureInst(inst->getOperand(0));
+                auto samplerOperand = ensureInst(inst->getOperand(1));
+                auto needNonUniform =
+                    isNonUniformIRResourceValue(inst->getOperand(0)) ||
+                    isNonUniformIRResourceValue(inst->getOperand(1)) ||
+                    isNonUniformSpvValue(getID(imageOperand)) ||
+                    isNonUniformSpvValue(getID(samplerOperand));
+                if (needNonUniform)
+                {
+                    emitNonUniformResourceDecoration(nullptr, getID(result));
+                }
+            }
             break;
         case kIROp_Add:
         case kIROp_Sub:
@@ -6001,14 +6558,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
         case kIROp_SPIRVNonUniformResourceDecoration:
             {
-                ensureExtensionDeclarationBeforeSpv15(toSlice("SPV_EXT_descriptor_indexing"));
-
-                requireSPIRVCapability(SpvCapabilityShaderNonUniform);
-                emitOpDecorate(
-                    getSection(SpvLogicalSectionID::Annotations),
-                    decoration,
-                    dstID,
-                    SpvDecorationNonUniform);
+                requireNonUniformCapabilityForIRValue(decoration->getParent());
+                emitNonUniformDecoration(decoration, dstID);
             }
             break;
 
@@ -10105,6 +10656,45 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
     {
         SpvInst* last = nullptr;
 
+        auto maybeDecorateSampledImageResultNonUniform =
+            [&](IRSPIRVAsmInst* asmInst, SpvInst* emittedInst)
+        {
+            if (!emittedInst || emittedInst->opcode != SpvOpSampledImage)
+                return;
+
+            bool needsNonUniform = false;
+            if (emittedInst->operandWordsCount >= 4)
+            {
+                needsNonUniform = isNonUniformSpvValue(emittedInst->operandWords[2]) ||
+                                  isNonUniformSpvValue(emittedInst->operandWords[3]);
+            }
+
+            for (const auto operand : asmInst->getSPIRVOperands())
+            {
+                if (needsNonUniform)
+                    break;
+                if (operand->getOp() != kIROp_SPIRVAsmOperandInst)
+                    continue;
+
+                auto value = operand->getValue();
+                if (isNonUniformIRResourceValue(value))
+                {
+                    needsNonUniform = true;
+                    break;
+                }
+            }
+
+            if (!needsNonUniform)
+                return;
+
+            SpvWord resultId = getExistingResultID(emittedInst);
+
+            if (!resultId)
+                return;
+
+            emitNonUniformResourceDecoration(nullptr, resultId);
+        };
+
         // This keeps track of the named IDs used in the asm block
         Dictionary<UnownedStringSlice, SpvWord> idMap;
 
@@ -10517,20 +11107,18 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                             };
                         });
 
-                    // The result operand is the one at index 1, after the
-                    // opcode itself.
-                    // If this happens to be an "id" operand, then we need to
-                    // correct the Id we have stored in our map with the actual
-                    // memoized result. This is safe because a condition on
-                    // memoized instructions is that they come before their
-                    // uses.
-                    const auto resOperand = cast<IRSPIRVAsmOperand>(spvInst->getOperand(1));
-                    if (resOperand->getOp() == kIROp_SPIRVAsmOperandId)
+                    // If the asm instruction names a result id, remap that
+                    // symbolic name to the memoized result so later uses see
+                    // the actual SPIR-V id assigned during emission.
+                    const auto resOperand = getSPIRVAsmResultIDOperand(spvInst);
+                    if (resOperand && resOperand->getOp() == kIROp_SPIRVAsmOperandId)
                     {
                         const auto idName =
                             cast<IRStringLit>(resOperand->getValue())->getStringSlice();
                         idMap[idName] = last->id;
                     }
+
+                    maybeDecorateSampledImageResultNonUniform(spvInst, last);
                 }
                 else
                 {
@@ -10582,6 +11170,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                                 emitOperand(memoryScope);
                             }
                         });
+
+                    maybeDecorateSampledImageResultNonUniform(spvInst, last);
                 }
             }
         }

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -682,7 +682,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         return id;
     }
 
-    SpvWord getExistingResultID(SpvInst* inst)
+    SpvWord ensureResultIDRegistered(SpvInst* inst)
     {
         if (!inst)
             return 0;
@@ -1013,6 +1013,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         case SpvOpImageSparseGather:
         case SpvOpImageSparseDrefGather:
         case SpvOpImageTexelPointer:
+        case SpvOpUntypedImageTexelPointerEXT:
             if (firstOperandIndex < inst->operandWordsCount)
                 outIndices.add(firstOperandIndex);
             return;
@@ -1052,6 +1053,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         case SpvOpLoad:
         case SpvOpCopyObject:
         case SpvOpBitcast:
+        case SpvOpImage:
         case SpvOpPhi:
         case SpvOpSampledImage:
         case SpvOpAccessChain:
@@ -1059,6 +1061,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         case SpvOpPtrAccessChain:
         case SpvOpInBoundsPtrAccessChain:
         case SpvOpUntypedAccessChainKHR:
+        case SpvOpImageTexelPointer:
+        case SpvOpUntypedImageTexelPointerEXT:
             for (UInt i = firstOperandIndex; i < inst->operandWordsCount; ++i)
             {
                 auto operandInfo =
@@ -1072,7 +1076,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     return result;
                 }
             }
-            default:
+        default:
             break;
         }
 
@@ -1145,7 +1149,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         // every result ID up front before we start chasing use-def chains.
         for (auto child = parent->m_firstChild; child; child = child->nextSibling)
         {
-            getExistingResultID(child);
+            ensureResultIDRegistered(child);
             registerSPIRVResultIDsInParent(child);
         }
     }
@@ -10687,7 +10691,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             if (!needsNonUniform)
                 return;
 
-            SpvWord resultId = getExistingResultID(emittedInst);
+            SpvWord resultId = ensureResultIDRegistered(emittedInst);
 
             if (!resultId)
                 return;
@@ -10697,6 +10701,47 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
         // This keeps track of the named IDs used in the asm block
         Dictionary<UnownedStringSlice, SpvWord> idMap;
+        HashSet<UnownedStringSlice> pendingNonUniformSymbolicDecorations;
+
+        const auto getAsmNonUniformDecorationTarget =
+            [&](IRSPIRVAsmInst* asmInst, SpvWord& ioTargetID, UnownedStringSlice& ioTargetName) -> bool
+        {
+            const SpvOp opcode = SpvOp(asmInst->getOpcodeOperandWord());
+            if (opcode != SpvOpDecorate && opcode != SpvOpDecorateId)
+                return false;
+
+            const auto operands = asmInst->getSPIRVOperands();
+            if (operands.getCount() < 2)
+                return false;
+
+            const auto decorationOperand = operands[1];
+            const auto decorationValue = as<IRConstant>(decorationOperand->getValue());
+            if (!decorationValue ||
+                SpvDecoration(getIntVal(decorationValue)) != SpvDecorationNonUniform)
+            {
+                return false;
+            }
+
+            const auto targetOperand = operands[0];
+            switch (targetOperand->getOp())
+            {
+            case kIROp_SPIRVAsmOperandId:
+                ioTargetName = cast<IRStringLit>(targetOperand->getValue())->getStringSlice();
+                if (SpvWord mappedID = 0; idMap.tryGetValue(ioTargetName, mappedID))
+                {
+                    ioTargetID = mappedID;
+                }
+                return true;
+
+            case kIROp_SPIRVAsmOperandInst:
+            case kIROp_SPIRVAsmOperandBuiltinVar:
+                ioTargetID = getID(ensureInst(targetOperand->getValue()));
+                return ioTargetID != 0;
+
+            default:
+                return false;
+            }
+        };
 
         for (const auto spvInst : inst->getInsts())
         {
@@ -11035,6 +11080,25 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                         }
                         continue;
                     }
+                case SpvOpDecorate:
+                case SpvOpDecorateId:
+                    {
+                        SpvWord targetID = 0;
+                        UnownedStringSlice targetName;
+                        if (getAsmNonUniformDecorationTarget(spvInst, targetID, targetName))
+                        {
+                            if (targetID)
+                            {
+                                emitNonUniformDecoration(nullptr, targetID);
+                            }
+                            else if (targetName.getLength())
+                            {
+                                pendingNonUniformSymbolicDecorations.add(targetName);
+                            }
+                            continue;
+                        }
+                        break;
+                    }
                 default:
                     break;
                 }
@@ -11115,7 +11179,13 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     {
                         const auto idName =
                             cast<IRStringLit>(resOperand->getValue())->getStringSlice();
+                        SpvWord oldID = 0;
+                        idMap.tryGetValue(idName, oldID);
                         idMap[idName] = last->id;
+                        if (pendingNonUniformSymbolicDecorations.contains(idName))
+                            emitNonUniformDecoration(nullptr, last->id);
+                        else if (oldID && oldID != last->id && m_nonUniformValueIDs.contains(oldID))
+                            emitNonUniformDecoration(nullptr, last->id);
                     }
 
                     maybeDecorateSampledImageResultNonUniform(spvInst, last);
@@ -11170,6 +11240,17 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                                 emitOperand(memoryScope);
                             }
                         });
+
+                    if (const auto resOperand = getSPIRVAsmResultIDOperand(spvInst))
+                    {
+                        if (resOperand->getOp() == kIROp_SPIRVAsmOperandId)
+                        {
+                            const auto idName =
+                                cast<IRStringLit>(resOperand->getValue())->getStringSlice();
+                            if (pendingNonUniformSymbolicDecorations.contains(idName))
+                                emitNonUniformDecoration(nullptr, ensureResultIDRegistered(last));
+                        }
+                    }
 
                     maybeDecorateSampledImageResultNonUniform(spvInst, last);
                 }

--- a/source/slang/slang-ir-float-non-uniform-resource-index.cpp
+++ b/source/slang/slang-ir-float-non-uniform-resource-index.cpp
@@ -92,6 +92,9 @@ void processNonUniformResourceIndex(
                     else if (floatMode == NonUniformResourceIndexFloatMode::SPIRV &&
                              user->getOperand(1) == inst)
                     {
+                        // Only SPIR-V needs the index itself to carry resource non-uniform
+                        // provenance after this rewrite. Other backends continue to reason about
+                        // the wrapper on the source index directly.
                         // Replace getElement(obj, nonUniformRes(i)), into
                         // nonUniformRes(getElement(obj, i)).
                         newUser = builder.emitElementExtract(

--- a/source/slang/slang-ir-float-non-uniform-resource-index.cpp
+++ b/source/slang/slang-ir-float-non-uniform-resource-index.cpp
@@ -80,7 +80,6 @@ void processNonUniformResourceIndex(
                     }
                     break;
                 case kIROp_GetElement:
-                    // Ignore when `NonUniformResourceIndex` is not on base
                     if (user->getOperand(0) == inst)
                     {
                         // Replace getElement(nonuniformRes(obj), i), into
@@ -89,6 +88,16 @@ void processNonUniformResourceIndex(
                             user->getFullType(),
                             inst->getOperand(0),
                             user->getOperand(1));
+                    }
+                    else if (floatMode == NonUniformResourceIndexFloatMode::SPIRV &&
+                             user->getOperand(1) == inst)
+                    {
+                        // Replace getElement(obj, nonUniformRes(i)), into
+                        // nonUniformRes(getElement(obj, i)).
+                        newUser = builder.emitElementExtract(
+                            user->getFullType(),
+                            user->getOperand(0),
+                            inst->getOperand(0));
                     }
                     break;
                 case kIROp_Swizzle:
@@ -106,6 +115,22 @@ void processNonUniformResourceIndex(
                             kIROp_Swizzle,
                             operands.getCount(),
                             operands.getArrayView().getBuffer());
+                    }
+                    break;
+                case kIROp_MakeCombinedTextureSampler:
+                    // Replace makeCombined(nonUniformRes(tex), samp), into
+                    // nonUniformRes(makeCombined(tex, samp)).
+                    // Also handle a non-uniform sampler operand conservatively.
+                    if (user->getOperand(0) == inst || user->getOperand(1) == inst)
+                    {
+                        auto textureOperand =
+                            user->getOperand(0) == inst ? inst->getOperand(0) : user->getOperand(0);
+                        auto samplerOperand =
+                            user->getOperand(1) == inst ? inst->getOperand(0) : user->getOperand(1);
+                        newUser = builder.emitMakeCombinedTextureSampler(
+                            user->getFullType(),
+                            textureOperand,
+                            samplerOperand);
                     }
                     break;
                 case kIROp_NonUniformResourceIndex:
@@ -142,6 +167,7 @@ void processNonUniformResourceIndex(
                 case kIROp_CastDescriptorHandleToUInt2:
                 case kIROp_GetElement:
                 case kIROp_Swizzle:
+                case kIROp_MakeCombinedTextureSampler:
                     resWorkList.add(nonuniformUser);
                     break;
                 };

--- a/source/slang/slang-ir-specialize-function-call.cpp
+++ b/source/slang/slang-ir-specialize-function-call.cpp
@@ -63,6 +63,7 @@ bool FunctionCallSpecializeCondition::isParamSuitableForSpecialization(
         case kIROp_FieldAddress:
         case kIROp_FieldExtract:
         case kIROp_Load:
+        case kIROp_CastDynamicResource:
             {
                 auto base = arg->getOperand(0);
 
@@ -642,6 +643,14 @@ struct FunctionParameterSpecializationContext
             auto oldBase = oldArg->getOperand(0);
             getCallInfoForArg(ioInfo, oldBase);
         }
+        else if (oldArg->getOp() == kIROp_CastDynamicResource)
+        {
+            auto oldBase = oldArg->getOperand(0);
+            // Bindless resource arguments may pass through CastDynamicResource
+            // before reaching a specialized helper, so keep walking through the
+            // cast when forming the specialization key.
+            getCallInfoForArg(ioInfo, oldBase);
+        }
         else if (oldArg->getOp() == kIROp_CastDescriptorHandleToResource)
         {
             // We are accessing a resource from a bindless handle.
@@ -928,6 +937,21 @@ struct FunctionParameterSpecializationContext
             auto builder = getBuilder();
             builder->setInsertInto(ioInfo.newBodyInsts);
             auto newVal = builder->emitLoad(oldArg->getFullType(), newPtr);
+
+            return newVal;
+        }
+        else if (oldArg->getOp() == kIROp_CastDynamicResource)
+        {
+            auto oldBase = oldArg->getOperand(0);
+            auto newBase = getSpecializedValueForArg(ioInfo, oldBase);
+
+            auto builder = getBuilder();
+            builder->setInsertInto(ioInfo.newBodyInsts);
+            IRInst* newOperands[] = {newBase};
+            // Rebuild the cast in the specialized clone so downstream
+            // legalization still sees the original dynamic-resource shape.
+            auto newVal =
+                builder->emitIntrinsicInst(oldArg->getFullType(), kIROp_CastDynamicResource, 1, newOperands);
 
             return newVal;
         }

--- a/source/slang/slang-ir-specialize-resources.cpp
+++ b/source/slang/slang-ir-specialize-resources.cpp
@@ -64,6 +64,9 @@ struct ResourceParameterSpecializationCondition : FunctionCallSpecializeConditio
         if (isKhronosTarget(targetRequest))
         {
             if (targetProgram->getOptionSet().shouldEmitSPIRVDirectly())
+                // Direct SPIR-V relies on this earlier specialization step to
+                // rewrite resource-typed helper calls before emission; the
+                // emitter no longer mirrors non-uniform state across calls.
                 return isIllegalSPIRVParameterType(type, isArray);
             else
                 return isIllegalGLSLParameterType(type);

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -578,6 +578,14 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                             // index).
                             IRBuilder builder(getElement);
                             builder.setInsertBefore(user);
+                            auto index = getElement->getIndex();
+                            auto indexValue = index;
+                            const bool isNonUniformIndex =
+                                index->getOp() == kIROp_NonUniformResourceIndex ||
+                                index->findDecoration<IRSPIRVNonUniformResourceDecoration>() !=
+                                    nullptr;
+                            if (index->getOp() == kIROp_NonUniformResourceIndex)
+                                indexValue = index->getOperand(0);
                             auto newAddr = builder.emitElementAddress(
                                 builder.getPtrType(
                                     innerElementType,
@@ -585,7 +593,18 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                                     addressSpace,
                                     dataLayout),
                                 inst,
-                                getElement->getIndex());
+                                indexValue);
+                            if (isNonUniformIndex)
+                            {
+                                // Preserve non-uniform provenance when array resource indexing
+                                // is rewritten into a pointer-valued access chain.
+                                if (!indexValue
+                                         ->findDecoration<IRSPIRVNonUniformResourceDecoration>())
+                                {
+                                    builder.addSPIRVNonUniformResourceDecoration(indexValue);
+                                }
+                                builder.addSPIRVNonUniformResourceDecoration(newAddr);
+                            }
                             user->replaceUsesWith(newAddr);
                             user->removeAndDeallocate();
                             return;

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -596,14 +596,12 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                                 indexValue);
                             if (isNonUniformIndex)
                             {
-                                // Preserve non-uniform provenance when array resource indexing
-                                // is rewritten into a pointer-valued access chain.
-                                if (!indexValue
-                                         ->findDecoration<IRSPIRVNonUniformResourceDecoration>())
+                                // Preserve non-uniform provenance on the rewritten access chain
+                                // without mutating the shared index SSA that other uses may rely on.
+                                if (!newAddr->findDecoration<IRSPIRVNonUniformResourceDecoration>())
                                 {
-                                    builder.addSPIRVNonUniformResourceDecoration(indexValue);
+                                    builder.addSPIRVNonUniformResourceDecoration(newAddr);
                                 }
-                                builder.addSPIRVNonUniformResourceDecoration(newAddr);
                             }
                             user->replaceUsesWith(newAddr);
                             user->removeAndDeallocate();

--- a/tests/bugs/nonuniform-dynamic-resource-bindless.slang
+++ b/tests/bugs/nonuniform-dynamic-resource-bindless.slang
@@ -1,0 +1,58 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv-assembly -profile spirv_1_3 -entry main -stage compute -emit-spirv-directly
+
+// Exercise non-uniform dynamic-resource indexing across storage buffers,
+// sampled images, sampled-image formation, and storage images.
+
+// CHECK-DAG: OpCapability ShaderNonUniform
+// CHECK-DAG: OpCapability RuntimeDescriptorArray
+// CHECK-DAG: OpCapability SampledImageArrayNonUniformIndexing
+// CHECK-DAG: OpCapability StorageBufferArrayNonUniformIndexing
+// CHECK-DAG: OpCapability StorageImageArrayNonUniformIndexing
+// CHECK-DAG: %[[BUF_AC:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_Uniform_StructuredBuffer %bindless_storage_buffers %[[BUF_IDX:[A-Za-z0-9_]+]]
+// CHECK-DAG: %[[BUF_PTR:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_Uniform_float %[[BUF_AC]] %int_0 %int_0
+// CHECK-DAG: %[[TEX_AC:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_UniformConstant_21 %bindless_storage_buffers_0 %[[TEX_IDX:[A-Za-z0-9_]+]]
+// CHECK-DAG: %[[TEX:[A-Za-z0-9_]+]] = OpLoad %21 %[[TEX_AC]]
+// CHECK-DAG: %sampledImage = OpSampledImage
+// CHECK-DAG: %[[IMG_AC:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_UniformConstant_30 %bindless_storage_buffers_1 %[[IMG_IDX:[A-Za-z0-9_]+]]
+// CHECK-DAG: %[[RW_IMG:[A-Za-z0-9_]+]] = OpLoad %30 %[[IMG_AC]]
+// CHECK-DAG: OpDecorate %[[BUF_IDX]] NonUniform
+// CHECK-DAG: OpDecorate %[[BUF_AC]] NonUniform
+// CHECK-DAG: OpDecorate %[[BUF_PTR]] NonUniform
+// CHECK-DAG: OpDecorate %[[TEX_IDX]] NonUniform
+// CHECK-DAG: OpDecorate %[[TEX_AC]] NonUniform
+// CHECK-DAG: OpDecorate %[[TEX]] NonUniform
+// CHECK-DAG: OpDecorate %[[IMG_IDX]] NonUniform
+// CHECK-DAG: OpDecorate %[[IMG_AC]] NonUniform
+// CHECK-DAG: OpDecorate %[[RW_IMG]] NonUniform
+// CHECK-DAG: OpDecorate %sampledImage NonUniform
+
+[vk::binding(0, 0)]
+RWTexture1D<float> render_target;
+
+[vk::binding(1, 0)]
+SamplerState sampler;
+
+[vk::binding(2, 0)]
+__DynamicResource<__DynamicResourceKind.General> bindless_storage_buffers[];
+
+[shader("compute")]
+[numthreads(8, 8, 1)]
+void main(uint index: SV_DispatchThreadID)
+{
+    const StructuredBuffer<float> buffer =
+        bindless_storage_buffers[NonUniformResourceIndex(index)]
+            .asOpaqueDescriptor<StructuredBuffer<float>>();
+
+    const Texture1D<float> tex1d =
+        bindless_storage_buffers[NonUniformResourceIndex(index)]
+            .asOpaqueDescriptor<Texture1D<float>>();
+
+    const RWTexture1D<float> rwtex1d =
+        bindless_storage_buffers[NonUniformResourceIndex(index)]
+            .asOpaqueDescriptor<RWTexture1D<float>>();
+
+    render_target[0] = buffer[0];
+    render_target[1] = tex1d[0];
+    render_target[2] = tex1d.SampleLevel(sampler, 0.0, 0);
+    rwtex1d[0] = 1.0;
+}

--- a/tests/bugs/nonuniform-dynamic-resource-bindless.slang
+++ b/tests/bugs/nonuniform-dynamic-resource-bindless.slang
@@ -10,11 +10,11 @@
 // CHECK-DAG: OpCapability StorageImageArrayNonUniformIndexing
 // CHECK-DAG: %[[BUF_AC:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_Uniform_StructuredBuffer %bindless_storage_buffers %[[BUF_IDX:[A-Za-z0-9_]+]]
 // CHECK-DAG: %[[BUF_PTR:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_Uniform_float %[[BUF_AC]] %int_0 %int_0
-// CHECK-DAG: %[[TEX_AC:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_UniformConstant_21 %bindless_storage_buffers_0 %[[TEX_IDX:[A-Za-z0-9_]+]]
-// CHECK-DAG: %[[TEX:[A-Za-z0-9_]+]] = OpLoad %21 %[[TEX_AC]]
-// CHECK-DAG: %sampledImage = OpSampledImage
-// CHECK-DAG: %[[IMG_AC:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_UniformConstant_30 %bindless_storage_buffers_1 %[[IMG_IDX:[A-Za-z0-9_]+]]
-// CHECK-DAG: %[[RW_IMG:[A-Za-z0-9_]+]] = OpLoad %30 %[[IMG_AC]]
+// CHECK-DAG: %[[TEX_AC:[A-Za-z0-9_]+]] = OpAccessChain %[[TEX_PTR_T:[A-Za-z0-9_]+]] %bindless_storage_buffers_0 %[[TEX_IDX:[A-Za-z0-9_]+]]
+// CHECK-DAG: %[[TEX:[A-Za-z0-9_]+]] = OpLoad %[[TEX_T:[A-Za-z0-9_]+]] %[[TEX_AC]]
+// CHECK-DAG: %[[SAMPLED_IMAGE:[A-Za-z0-9_]+]] = OpSampledImage
+// CHECK-DAG: %[[IMG_AC:[A-Za-z0-9_]+]] = OpAccessChain %[[IMG_PTR_T:[A-Za-z0-9_]+]] %bindless_storage_buffers_1 %[[IMG_IDX:[A-Za-z0-9_]+]]
+// CHECK-DAG: %[[RW_IMG:[A-Za-z0-9_]+]] = OpLoad %[[IMG_T:[A-Za-z0-9_]+]] %[[IMG_AC]]
 // CHECK-DAG: OpDecorate %[[BUF_IDX]] NonUniform
 // CHECK-DAG: OpDecorate %[[BUF_AC]] NonUniform
 // CHECK-DAG: OpDecorate %[[BUF_PTR]] NonUniform
@@ -24,7 +24,7 @@
 // CHECK-DAG: OpDecorate %[[IMG_IDX]] NonUniform
 // CHECK-DAG: OpDecorate %[[IMG_AC]] NonUniform
 // CHECK-DAG: OpDecorate %[[RW_IMG]] NonUniform
-// CHECK-DAG: OpDecorate %sampledImage NonUniform
+// CHECK-DAG: OpDecorate %[[SAMPLED_IMAGE]] NonUniform
 
 [vk::binding(0, 0)]
 RWTexture1D<float> render_target;

--- a/tests/bugs/nonuniform-image-spirv-asm.slang
+++ b/tests/bugs/nonuniform-image-spirv-asm.slang
@@ -1,0 +1,32 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage compute -emit-spirv-directly
+
+// Ensure raw spirv_asm NonUniform decorations seed the post-pass, and that
+// non-uniform provenance propagates through OpImage to the consuming image op.
+
+// CHECK: OpCapability SampledImageArrayNonUniformIndexing
+// CHECK-DAG: OpDecorate %sampledImage NonUniform
+// CHECK-DAG: OpDecorate %image NonUniform
+// CHECK: %sampledImage = OpSampledImage
+// CHECK: %image = OpImage
+// CHECK: OpImageQuerySizeLod {{.*}} %image
+
+Texture2D<float> textures[8];
+SamplerState samp;
+RWTexture2D<float4> outputTex;
+
+[numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID)
+{
+    Texture2D<float> tex = textures[0];
+    int zero = 0;
+    int2 size = spirv_asm
+    {
+        %sampledImageType = OpTypeSampledImage $$Texture2D<float>;
+        %sampledImage : %sampledImageType = OpSampledImage $tex $samp;
+        OpDecorate %sampledImage NonUniform;
+        %image : $$Texture2D<float> = OpImage %sampledImage;
+        %size : $$int2 = OpImageQuerySizeLod %image $zero;
+        __truncate $$int2 result $$int2 %size;
+    };
+    outputTex[uint2(0, 0)] = float4(size, 0, 0);
+}

--- a/tests/bugs/nonuniform-input-attachment.slang
+++ b/tests/bugs/nonuniform-input-attachment.slang
@@ -1,0 +1,18 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage fragment -emit-spirv-directly -allow-glsl
+
+#version 450
+
+// CHECK: OpCapability InputAttachmentArrayNonUniformIndexing
+// CHECK-DAG: %[[ATTACH_PTR:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_UniformConstant_{{[A-Za-z0-9_]+}} %subpasses %{{[A-Za-z0-9_]+}}
+// CHECK-DAG: %[[ATTACH:[A-Za-z0-9_]+]] = OpLoad %{{[A-Za-z0-9_]+}} %[[ATTACH_PTR]]
+// CHECK-DAG: OpDecorate %[[ATTACH_PTR]] NonUniform
+// CHECK-DAG: OpDecorate %[[ATTACH]] NonUniform
+
+layout(input_attachment_index = 0, set = 0, binding = 0) uniform subpassInput subpasses[4];
+layout(location = 0) flat in int idx;
+layout(location = 0) out vec4 outColor;
+
+void main()
+{
+    outColor = subpassLoad(subpasses[NonUniformResourceIndex(idx)]);
+}

--- a/tests/bugs/nonuniform-input-attachment.slang
+++ b/tests/bugs/nonuniform-input-attachment.slang
@@ -7,6 +7,7 @@
 // CHECK-DAG: %[[ATTACH:[A-Za-z0-9_]+]] = OpLoad %{{[A-Za-z0-9_]+}} %[[ATTACH_PTR]]
 // CHECK-DAG: OpDecorate %[[ATTACH_PTR]] NonUniform
 // CHECK-DAG: OpDecorate %[[ATTACH]] NonUniform
+// CHECK: %{{[A-Za-z0-9_]+}} = OpImageRead %{{[A-Za-z0-9_]+}} %[[ATTACH]] %{{[A-Za-z0-9_]+}}
 
 layout(input_attachment_index = 0, set = 0, binding = 0) uniform subpassInput subpasses[4];
 layout(location = 0) flat in int idx;

--- a/tests/bugs/nonuniform-resource-function-call-mixed.slang
+++ b/tests/bugs/nonuniform-resource-function-call-mixed.slang
@@ -1,0 +1,47 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage compute -emit-spirv-directly
+
+// The same helper is called once with a uniform resource and once with a
+// non-uniformly indexed resource. The direct-SPIR-V resource specialization
+// trigger is what causes the non-uniform call site to get its own helper clone.
+// If that trigger is removed, both calls collapse back to the original
+// resource-typed helper shape and the checks below fail.
+
+// CHECK: OpCapability SampledImageArrayNonUniformIndexing
+// CHECK-DAG: %[[UNIFORM_CALL:[A-Za-z0-9_]+]] = OpFunctionCall %float %sampleHelper %int_0 %{{[A-Za-z0-9_]+}}
+// CHECK-DAG: %[[IDX:[A-Za-z0-9_]+]] = OpCompositeExtract %uint %{{[A-Za-z0-9_]+}} 0
+// CHECK-DAG: %[[NONUNIFORM_CALL:[A-Za-z0-9_]+]] = OpFunctionCall %float %sampleHelper_0 %[[IDX]] %{{[A-Za-z0-9_]+}}
+// CHECK-DAG: OpDecorate %[[NONUNIFORM_ACCESS:[A-Za-z0-9_]+]] NonUniform
+// CHECK-DAG: OpDecorate %[[NONUNIFORM_SAMPLED:[A-Za-z0-9_]+]] NonUniform
+// CHECK-LABEL: %sampleHelper_0 = OpFunction
+// CHECK: %[[NONUNIFORM_PARAM:[A-Za-z0-9_]+]] = OpFunctionParameter %uint
+// CHECK: %[[NONUNIFORM_SAMPLER_PARAM:[A-Za-z0-9_]+]] = OpFunctionParameter %11
+// CHECK: %[[NONUNIFORM_ACCESS]] = OpAccessChain %_ptr_UniformConstant_{{[A-Za-z0-9_]+}} %resources %[[NONUNIFORM_PARAM]]
+// CHECK: %[[NONUNIFORM_LOAD:[A-Za-z0-9_]+]] = OpLoad %{{[A-Za-z0-9_]+}} %[[NONUNIFORM_ACCESS]]
+// CHECK: %[[NONUNIFORM_SAMPLED]] = OpSampledImage %{{[A-Za-z0-9_]+}} %[[NONUNIFORM_LOAD]] %[[NONUNIFORM_SAMPLER_PARAM]]
+
+[vk::binding(0, 0)]
+RWTexture1D<float> render_target;
+
+[vk::binding(1, 0)]
+SamplerState sampler;
+
+[vk::binding(2, 0)]
+__DynamicResource<__DynamicResourceKind.General> resources[];
+
+[noinline]
+float sampleHelper(Texture1D<float> tex, SamplerState s)
+{
+    return tex.SampleLevel(s, 0.0, 0);
+}
+
+[shader("compute")]
+[numthreads(8, 8, 1)]
+void main(uint index: SV_DispatchThreadID)
+{
+    Texture1D<float> uniformTex = resources[0].asOpaqueDescriptor<Texture1D<float>>();
+    Texture1D<float> nonUniformTex =
+        resources[NonUniformResourceIndex(index)].asOpaqueDescriptor<Texture1D<float>>();
+
+    render_target[0] = sampleHelper(uniformTex, sampler);
+    render_target[1] = sampleHelper(nonUniformTex, sampler);
+}

--- a/tests/bugs/nonuniform-resource-function-call-mixed.slang
+++ b/tests/bugs/nonuniform-resource-function-call-mixed.slang
@@ -14,7 +14,7 @@
 // CHECK-DAG: OpDecorate %[[NONUNIFORM_SAMPLED:[A-Za-z0-9_]+]] NonUniform
 // CHECK-LABEL: %sampleHelper_0 = OpFunction
 // CHECK: %[[NONUNIFORM_PARAM:[A-Za-z0-9_]+]] = OpFunctionParameter %uint
-// CHECK: %[[NONUNIFORM_SAMPLER_PARAM:[A-Za-z0-9_]+]] = OpFunctionParameter %11
+// CHECK: %[[NONUNIFORM_SAMPLER_PARAM:[A-Za-z0-9_]+]] = OpFunctionParameter %{{[A-Za-z0-9_]+}}
 // CHECK: %[[NONUNIFORM_ACCESS]] = OpAccessChain %_ptr_UniformConstant_{{[A-Za-z0-9_]+}} %resources %[[NONUNIFORM_PARAM]]
 // CHECK: %[[NONUNIFORM_LOAD:[A-Za-z0-9_]+]] = OpLoad %{{[A-Za-z0-9_]+}} %[[NONUNIFORM_ACCESS]]
 // CHECK: %[[NONUNIFORM_SAMPLED]] = OpSampledImage %{{[A-Za-z0-9_]+}} %[[NONUNIFORM_LOAD]] %[[NONUNIFORM_SAMPLER_PARAM]]

--- a/tests/bugs/nonuniform-resource-function-call.slang
+++ b/tests/bugs/nonuniform-resource-function-call.slang
@@ -1,0 +1,40 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage compute -emit-spirv-directly
+
+// CHECK: OpCapability SampledImageArrayNonUniformIndexing
+// CHECK-DAG: %[[CALL_IDX:[A-Za-z0-9_]+]] = OpCompositeExtract %uint %{{[A-Za-z0-9_]+}} 0
+// CHECK-DAG: OpDecorate %[[NONUNIFORM_ACCESS:[A-Za-z0-9_]+]] NonUniform
+// CHECK-DAG: OpDecorate %[[NONUNIFORM_SAMPLED_IMAGE:[A-Za-z0-9_]+]] NonUniform
+// CHECK-DAG: %[[UNIFORM_CALL:[A-Za-z0-9_]+]] = OpFunctionCall %float %sampleHelper %int_0 %{{[A-Za-z0-9_]+}}
+// CHECK-DAG: %[[NONUNIFORM_CALL:[A-Za-z0-9_]+]] = OpFunctionCall %float %sampleHelper_0 %[[CALL_IDX]] %{{[A-Za-z0-9_]+}}
+// CHECK-LABEL: %sampleHelper_0 = OpFunction
+// CHECK: %[[NONUNIFORM_PARAM:[A-Za-z0-9_]+]] = OpFunctionParameter %uint
+// CHECK: %[[NONUNIFORM_SAMPLER_PARAM:[A-Za-z0-9_]+]] = OpFunctionParameter %11
+// CHECK: %[[NONUNIFORM_ACCESS]] = OpAccessChain %_ptr_UniformConstant_23 %resources %[[NONUNIFORM_PARAM]]
+// CHECK: %[[NONUNIFORM_LOAD:[A-Za-z0-9_]+]] = OpLoad %23 %[[NONUNIFORM_ACCESS]]
+// CHECK: %[[NONUNIFORM_SAMPLED_IMAGE]] = OpSampledImage %31 %[[NONUNIFORM_LOAD]] %[[NONUNIFORM_SAMPLER_PARAM]]
+
+[vk::binding(0, 0)]
+RWTexture1D<float> render_target;
+
+[vk::binding(1, 0)]
+SamplerState sampler;
+
+[vk::binding(2, 0)]
+__DynamicResource<__DynamicResourceKind.General> resources[];
+
+[noinline]
+float sampleHelper(Texture1D<float> tex, SamplerState s)
+{
+    return tex.SampleLevel(s, 0.0, 0);
+}
+
+[shader("compute")]
+[numthreads(8, 8, 1)]
+void main(uint index: SV_DispatchThreadID)
+{
+    Texture1D<float> uniformTex = resources[0].asOpaqueDescriptor<Texture1D<float>>();
+    Texture1D<float> tex =
+        resources[NonUniformResourceIndex(index)].asOpaqueDescriptor<Texture1D<float>>();
+    render_target[1] = sampleHelper(uniformTex, sampler);
+    render_target[0] = sampleHelper(tex, sampler);
+}

--- a/tests/bugs/nonuniform-resource-function-call.slang
+++ b/tests/bugs/nonuniform-resource-function-call.slang
@@ -4,14 +4,14 @@
 // CHECK-DAG: %[[CALL_IDX:[A-Za-z0-9_]+]] = OpCompositeExtract %uint %{{[A-Za-z0-9_]+}} 0
 // CHECK-DAG: OpDecorate %[[NONUNIFORM_ACCESS:[A-Za-z0-9_]+]] NonUniform
 // CHECK-DAG: OpDecorate %[[NONUNIFORM_SAMPLED_IMAGE:[A-Za-z0-9_]+]] NonUniform
-// CHECK-DAG: %[[UNIFORM_CALL:[A-Za-z0-9_]+]] = OpFunctionCall %float %sampleHelper %int_0 %{{[A-Za-z0-9_]+}}
-// CHECK-DAG: %[[NONUNIFORM_CALL:[A-Za-z0-9_]+]] = OpFunctionCall %float %sampleHelper_0 %[[CALL_IDX]] %{{[A-Za-z0-9_]+}}
-// CHECK-LABEL: %sampleHelper_0 = OpFunction
+// CHECK-DAG: %[[UNIFORM_CALL:[A-Za-z0-9_]+]] = OpFunctionCall %float %[[UNIFORM_HELPER:[A-Za-z0-9_]+]] %int_0 %{{[A-Za-z0-9_]+}}
+// CHECK-DAG: %[[NONUNIFORM_CALL:[A-Za-z0-9_]+]] = OpFunctionCall %float %[[NONUNIFORM_HELPER:[A-Za-z0-9_]+]] %[[CALL_IDX]] %{{[A-Za-z0-9_]+}}
+// CHECK: %[[NONUNIFORM_HELPER]] = OpFunction %float DontInline %{{[A-Za-z0-9_]+}}
 // CHECK: %[[NONUNIFORM_PARAM:[A-Za-z0-9_]+]] = OpFunctionParameter %uint
-// CHECK: %[[NONUNIFORM_SAMPLER_PARAM:[A-Za-z0-9_]+]] = OpFunctionParameter %11
-// CHECK: %[[NONUNIFORM_ACCESS]] = OpAccessChain %_ptr_UniformConstant_23 %resources %[[NONUNIFORM_PARAM]]
-// CHECK: %[[NONUNIFORM_LOAD:[A-Za-z0-9_]+]] = OpLoad %23 %[[NONUNIFORM_ACCESS]]
-// CHECK: %[[NONUNIFORM_SAMPLED_IMAGE]] = OpSampledImage %31 %[[NONUNIFORM_LOAD]] %[[NONUNIFORM_SAMPLER_PARAM]]
+// CHECK: %[[NONUNIFORM_SAMPLER_PARAM:[A-Za-z0-9_]+]] = OpFunctionParameter %{{[A-Za-z0-9_]+}}
+// CHECK: %[[NONUNIFORM_ACCESS]] = OpAccessChain %[[RESOURCE_PTR_T:[A-Za-z0-9_]+]] %resources %[[NONUNIFORM_PARAM]]
+// CHECK: %[[NONUNIFORM_LOAD:[A-Za-z0-9_]+]] = OpLoad %[[RESOURCE_T:[A-Za-z0-9_]+]] %[[NONUNIFORM_ACCESS]]
+// CHECK: %[[NONUNIFORM_SAMPLED_IMAGE]] = OpSampledImage %[[SAMPLED_IMAGE_T:[A-Za-z0-9_]+]] %[[NONUNIFORM_LOAD]] %[[NONUNIFORM_SAMPLER_PARAM]]
 
 [vk::binding(0, 0)]
 RWTexture1D<float> render_target;

--- a/tests/bugs/nonuniform-sampled-image-copyobject-spirv-asm.slang
+++ b/tests/bugs/nonuniform-sampled-image-copyobject-spirv-asm.slang
@@ -1,0 +1,38 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage compute -emit-spirv-directly -O0
+
+// Ensure the non-uniform post-pass propagates through OpCopyObject before
+// decorating the sampled-image value actually consumed by sampling.
+
+// CHECK: OpCapability SampledImageArrayNonUniformIndexing
+// CHECK-DAG: OpDecorate %[[NU_IDX:[A-Za-z0-9_]+]] NonUniform
+// CHECK-DAG: %sampledImage = OpSampledImage
+// CHECK-DAG: %sampledImageCopy = OpCopyObject
+// CHECK-DAG: OpDecorate %sampledImageCopy NonUniform
+// CHECK: OpImageSampleExplicitLod {{.*}} %sampledImageCopy
+
+Texture2D<float> textures[8];
+SamplerState samp;
+RWTexture2D<float4> outputTex;
+
+cbuffer Params
+{
+    uint idx;
+};
+
+[numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID)
+{
+    uint i = idx + tid.x;
+    Texture2D<float> tex = textures[NonUniformResourceIndex(i)];
+    float2 loc = float2(0.0, 0.0);
+    float lod = 0.0;
+    float value = spirv_asm
+    {
+        %sampledImageType = OpTypeSampledImage $$Texture2D<float>;
+        %sampledImage : %sampledImageType = OpSampledImage $tex $samp;
+        %sampledImageCopy : %sampledImageType = OpCopyObject %sampledImage;
+        %sampled : __sampledType(float) = OpImageSampleExplicitLod %sampledImageCopy $loc Lod $lod;
+        __truncate $$float result __sampledType(float) %sampled;
+    };
+    outputTex[uint2(0, 0)] = value.xxxx;
+}

--- a/tests/bugs/nonuniform-sampled-image-spirv-asm.slang
+++ b/tests/bugs/nonuniform-sampled-image-spirv-asm.slang
@@ -1,0 +1,38 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage compute -emit-spirv-directly
+
+// Ensure typed spirv_asm OpSampledImage decoration targets the sampled-image
+// result, not the named OpTypeSampledImage helper ID.
+
+// CHECK: OpCapability SampledImageArrayNonUniformIndexing
+// CHECK: OpDecorate %[[NU_IDX:[A-Za-z0-9_]+]] NonUniform
+// CHECK-NOT: OpDecorate %sampledImageType NonUniform
+// CHECK: OpDecorate %sampledImage NonUniform
+// CHECK: OpAccessChain %{{.*}} %{{.*}} %[[NU_IDX]]
+// CHECK: %sampledImage = OpSampledImage
+// CHECK: OpImageSampleExplicitLod {{.*}} %sampledImage
+
+Texture2D<float> textures[8];
+SamplerState samp;
+RWTexture2D<float4> outputTex;
+
+cbuffer Params
+{
+    uint idx;
+};
+
+[numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID)
+{
+    uint i = idx + tid.x;
+    Texture2D<float> tex = textures[NonUniformResourceIndex(i)];
+    float2 loc = float2(0.0, 0.0);
+    float lod = 0.0;
+    float value = spirv_asm
+    {
+        %sampledImageType = OpTypeSampledImage $$Texture2D<float>;
+        %sampledImage : %sampledImageType = OpSampledImage $tex $samp;
+        %sampled : __sampledType(float) = OpImageSampleExplicitLod %sampledImage $loc Lod $lod;
+        __truncate $$float result __sampledType(float) %sampled;
+    };
+    outputTex[uint2(0, 0)] = value.xxxx;
+}

--- a/tests/bugs/nonuniform-sampled-image.slang
+++ b/tests/bugs/nonuniform-sampled-image.slang
@@ -1,0 +1,28 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage compute -emit-spirv-directly
+
+// Ensure non-uniform sampled-image values carry the NonUniform decoration to
+// the OpSampledImage result and request the corresponding capability.
+
+// CHECK: OpCapability SampledImageArrayNonUniformIndexing
+// CHECK-DAG: OpDecorate %[[NU_IDX:[A-Za-z0-9_]+]] NonUniform
+// CHECK-DAG: OpDecorate %sampledImage NonUniform
+// CHECK: OpAccessChain %{{.*}} %{{.*}} %[[NU_IDX]]
+// CHECK: %sampledImage = OpSampledImage
+// CHECK: OpImageSampleExplicitLod {{.*}} %sampledImage
+
+Texture2D<float4> textures[8];
+SamplerState samp;
+RWTexture2D<float4> outputTex;
+
+cbuffer Params
+{
+    uint idx;
+};
+
+[numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID)
+{
+    uint i = idx + tid.x;
+    float4 v = textures[NonUniformResourceIndex(i)].SampleLevel(samp, float2(0.0, 0.0), 0.0);
+    outputTex[uint2(0, 0)] = v;
+}

--- a/tests/bugs/nonuniform-storage-texel-buffer.slang
+++ b/tests/bugs/nonuniform-storage-texel-buffer.slang
@@ -5,6 +5,7 @@
 // CHECK-DAG: %[[TEXEL:[A-Za-z0-9_]+]] = OpLoad %{{[A-Za-z0-9_]+}} %[[TEXEL_PTR]]
 // CHECK-DAG: OpDecorate %[[TEXEL_PTR]] NonUniform
 // CHECK-DAG: OpDecorate %[[TEXEL]] NonUniform
+// CHECK: OpImageWrite %[[TEXEL]]
 
 [vk::binding(0, 0)]
 RWBuffer<float> buffers[8];

--- a/tests/bugs/nonuniform-storage-texel-buffer.slang
+++ b/tests/bugs/nonuniform-storage-texel-buffer.slang
@@ -1,0 +1,17 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage compute -emit-spirv-directly
+
+// CHECK: OpCapability StorageTexelBufferArrayNonUniformIndexing
+// CHECK-DAG: %[[TEXEL_PTR:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_UniformConstant_{{[A-Za-z0-9_]+}} %buffers %{{[A-Za-z0-9_]+}}
+// CHECK-DAG: %[[TEXEL:[A-Za-z0-9_]+]] = OpLoad %{{[A-Za-z0-9_]+}} %[[TEXEL_PTR]]
+// CHECK-DAG: OpDecorate %[[TEXEL_PTR]] NonUniform
+// CHECK-DAG: OpDecorate %[[TEXEL]] NonUniform
+
+[vk::binding(0, 0)]
+RWBuffer<float> buffers[8];
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main(uint index: SV_DispatchThreadID)
+{
+    buffers[NonUniformResourceIndex(index)][0] = 1.0;
+}

--- a/tests/bugs/nonuniform-uniform-buffer.slang
+++ b/tests/bugs/nonuniform-uniform-buffer.slang
@@ -1,0 +1,27 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage compute -emit-spirv-directly
+
+// CHECK: OpCapability UniformBufferArrayNonUniformIndexing
+// CHECK-DAG: %[[BUFFER_PTR:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_Uniform_{{[A-Za-z0-9_]+}} %resources %{{[A-Za-z0-9_]+}}
+// CHECK-DAG: %[[FIELD_PTR:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_Uniform_float %[[BUFFER_PTR]] %int_0
+// CHECK-DAG: OpDecorate %[[BUFFER_PTR]] NonUniform
+// CHECK-DAG: OpDecorate %[[FIELD_PTR]] NonUniform
+
+struct Data
+{
+    float value;
+};
+
+[vk::binding(0, 0)]
+RWTexture1D<float> render_target;
+
+[vk::binding(1, 0)]
+__DynamicResource<__DynamicResourceKind.General> resources[];
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main(uint index: SV_DispatchThreadID)
+{
+    ConstantBuffer<Data> buffer =
+        resources[NonUniformResourceIndex(index)].asOpaqueDescriptor<ConstantBuffer<Data>>();
+    render_target[0] = buffer.value;
+}

--- a/tests/bugs/nonuniform-uniform-buffer.slang
+++ b/tests/bugs/nonuniform-uniform-buffer.slang
@@ -3,7 +3,6 @@
 // CHECK: OpCapability UniformBufferArrayNonUniformIndexing
 // CHECK-DAG: %[[BUFFER_PTR:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_Uniform_{{[A-Za-z0-9_]+}} %resources %{{[A-Za-z0-9_]+}}
 // CHECK-DAG: %[[FIELD_PTR:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_Uniform_float %[[BUFFER_PTR]] %int_0
-// CHECK-DAG: OpDecorate %[[BUFFER_PTR]] NonUniform
 // CHECK-DAG: OpDecorate %[[FIELD_PTR]] NonUniform
 
 struct Data

--- a/tests/bugs/nonuniform-uniform-texel-buffer.slang
+++ b/tests/bugs/nonuniform-uniform-texel-buffer.slang
@@ -1,0 +1,20 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage compute -emit-spirv-directly
+
+// CHECK: OpCapability UniformTexelBufferArrayNonUniformIndexing
+// CHECK-DAG: %[[TEXEL_PTR:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_UniformConstant_{{[A-Za-z0-9_]+}} %buffers %{{[A-Za-z0-9_]+}}
+// CHECK-DAG: %[[TEXEL:[A-Za-z0-9_]+]] = OpLoad %{{[A-Za-z0-9_]+}} %[[TEXEL_PTR]]
+// CHECK-DAG: OpDecorate %[[TEXEL_PTR]] NonUniform
+// CHECK-DAG: OpDecorate %[[TEXEL]] NonUniform
+
+[vk::binding(0, 0)]
+Buffer<float> buffers[8];
+
+[vk::binding(1, 0)]
+RWTexture1D<float> render_target;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main(uint index: SV_DispatchThreadID)
+{
+    render_target[0] = buffers[NonUniformResourceIndex(index)][0];
+}

--- a/tests/bugs/nonuniform-uniform-texel-buffer.slang
+++ b/tests/bugs/nonuniform-uniform-texel-buffer.slang
@@ -5,6 +5,7 @@
 // CHECK-DAG: %[[TEXEL:[A-Za-z0-9_]+]] = OpLoad %{{[A-Za-z0-9_]+}} %[[TEXEL_PTR]]
 // CHECK-DAG: OpDecorate %[[TEXEL_PTR]] NonUniform
 // CHECK-DAG: OpDecorate %[[TEXEL]] NonUniform
+// CHECK: {{OpImageFetch|OpImageRead}} {{.*}} %[[TEXEL]]
 
 [vk::binding(0, 0)]
 Buffer<float> buffers[8];

--- a/tests/compute/nonuniformres-as-function-parameter.slang
+++ b/tests/compute/nonuniformres-as-function-parameter.slang
@@ -68,7 +68,7 @@ void main(uint3 pixelIndex : SV_DispatchThreadID)
     uint nonUniformIdx = NonUniformResourceIndex(bufferIdx);
     RWStructuredBuffer<uint> buffer = globalBuffer[nonUniformIdx];
 
-    // CHECK_SPV: %[[VAR1]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %bufferIdx
+    // CHECK_SPV: %[[VAR1_AC:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %bufferIdx
 
     // CHECK_GLSL_SPV: %[[VAR1]] = OpCopyObject %uint %{{.*}}
 
@@ -89,7 +89,7 @@ void main(uint3 pixelIndex : SV_DispatchThreadID)
 
     // Test case 2: Make sure we cover the case for the different data type of the index.
     // In this case, slang will specialize the function to 'MyStruct func(int)'
-    // CHECK_SPV: %[[VAR2]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %bufferIdx2
+    // CHECK_SPV: %[[VAR2_AC:[a-zA-Z0-9_]+]] = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer{{.*}} %{{.*}} %bufferIdx2
 
 
     // CHECK_GLSL_SPV: %[[VAR2]] = OpCopyObject %int %{{.*}}
@@ -145,4 +145,3 @@ void main(uint3 pixelIndex : SV_DispatchThreadID)
     outputBuffer[2] = uint3(myStruct3.a, myStruct3.b, myStruct3.c);
     outputBuffer[3] = uint3(myStruct4.a, myStruct4.b, myStruct4.c);
 }
-


### PR DESCRIPTION
Hey, this is an attempt to resolve #10525.

_Disclaimer: this was vibe-coded with Codex_, and personally I still have very little Slang compiler exposure. I've attempted to at least guide Codex along a sane path, and I've done a few local review loops. I can't guarantee that this is appropriate architecturally, but it resolves the issue in the game I'm porting to Slang. Of course, feel free to smite the PR if you think this is the wrong fix. Thanks :)

What follows is mostly Codex-generated, with human guidance and small tweaks.

# Summary

This PR generalizes Slang's SPIR-V handling of non-uniform resource indexing so `NonUniform` is applied to the resource operand actually consumed by the relevant SPIR-V instruction. The matching non-uniform indexing capability is also emitted for that resource kind.

Vulkan/SPIR-V requires `NonUniform` on the actual resource operand consumed by the memory or sampling instruction, not just on the original index expression. That means non-uniform provenance must survive through function calls as well as through direct indexing chains.

For direct SPIR-V function-call cases, the fix here is intentionally narrower than "full interprocedural uniformity tracking." Instead of adding a new uniformity-specific specialization system, this PR reuses the existing resource-parameter specialization machinery when a resource-typed argument is visibly derived from non-uniform indexing. That keeps the actual resource access inside the specialized callee, which in turn preserves the right `NonUniform` placement for downstream SPIR-V consumers like `spirv-cross`.

This is follow-up work on:

- issue [#9849](https://github.com/shader-slang/slang/issues/9849)
- PR [#9871](https://github.com/shader-slang/slang/pull/9871)

Detailed context, spec references, and follow-up issue drafts are captured in description of #10525

# What This Changes

## IR legalization

- extend non-uniform propagation to `MakeCombinedTextureSampler`
- preserve non-uniform provenance when SPIR-V legalization rewrites array resource indexing into pointer-valued access chains
- extend IR-side `IRSPIRVNonUniformResourceDecoration` propagation so more non-uniform resource uses already carry the right provenance before SPIR-V emission
- reuse existing resource-parameter specialization for direct-SPIR-V calls where a resource argument is derived from non-uniform indexing

## SPIR-V emitter

- keep a general non-uniform resource post-pass, but narrow it to decorating actual consumed operands
- centralize `NonUniform` decoration emission and capability requests by resource kind, including direct reuse of IR type information when emitting explicit `IRSPIRVNonUniformResourceDecoration`
- register emitted result IDs up front so the post-pass can revisit values introduced late, including `spirv_asm`
- decorate the actual resource operand used by the consuming instruction
- decorate `OpSampledImage` results when the sampled image is non-uniform
- request the matching non-uniform indexing capability for:
  - sampled images
  - storage buffers
  - storage images
  - uniform buffers
  - input attachments
  - uniform texel buffers
  - storage texel buffers
- fix the `spirv_asm` path so decoration is applied to the `OpSampledImage` result ID, not to the separately declared `OpTypeSampledImage` ID

# User-visible Effect

This fixes SPIR-V generation for non-uniform resource indexing in cases beyond the original `gh-9849` repro, including:

- sampled-image formation through `OpSampledImage`
- `OpImageFetch`
- storage-buffer loads through descriptor arrays
- storage-image writes
- uniform-buffer loads through descriptor arrays
- input attachments
- uniform texel buffers
- storage texel buffers
- resource-typed helper calls fed from non-uniform indexing
- `spirv_asm` sampled-image formation

In the affected cases Slang now emits the required combination of:

- `OpDecorate %value NonUniform`
- `OpCapability SampledImageArrayNonUniformIndexing`
- `OpCapability StorageBufferArrayNonUniformIndexing`
- `OpCapability StorageImageArrayNonUniformIndexing`
- other matching capabilities as needed by the resource kind

# Tests

Existing coverage retained:

- `tests/bugs/gh-9849.slang`

Adjusted existing regression check:

- `tests/compute/nonuniformres-as-function-parameter.slang`

New coverage added:

- `tests/bugs/nonuniform-dynamic-resource-bindless.slang`
- `tests/bugs/nonuniform-input-attachment.slang`
- `tests/bugs/nonuniform-resource-function-call-mixed.slang`
- `tests/bugs/nonuniform-resource-function-call.slang`
- `tests/bugs/nonuniform-sampled-image-copyobject-spirv-asm.slang`
- `tests/bugs/nonuniform-sampled-image-spirv-asm.slang`
- `tests/bugs/nonuniform-sampled-image.slang`
- `tests/bugs/nonuniform-storage-texel-buffer.slang`
- `tests/bugs/nonuniform-uniform-buffer.slang`
- `tests/bugs/nonuniform-uniform-texel-buffer.slang`

# Verification

Verified locally with:

- `slangc -target spirv`
- `spirv-dis | FileCheck`
- `spirv-val`
- `spirv-val --target-env vulkan1.2`
- `spirv-cross --vulkan-semantics`
- built the full Release tree and ran the non-RHI `slang-test` suite locally (`-exclude-prefix gfx-unit-test-tool/`)

Status:

- generalized non-uniform coverage passes `FileCheck`
- bindless, input-attachment, texel-buffer, uniform-buffer, sampled-image, asm, `gh-9849`, and function-call regressions pass `spirv-val` and `spirv-val --target-env vulkan1.2`
- the function-call regression now reconstructs to `nonuniformEXT(...)` under `spirv-cross --vulkan-semantics`
- the uniform-buffer repro now emits `OpCapability UniformBufferArrayNonUniformIndexing` and reconstructs to `nonuniformEXT(...)` under `spirv-cross --vulkan-semantics`

# Reviewer Notes

- For the sake of simplicity, this PR does not address the separate opaque-resource-return validation issue reported in #10526

Fixes #10525