### PR TITLE
Emit per-member DebugValue for optimized struct locals

### DIFF
--- a/source/slang/slang-emit-spirv-ops-debug-info-ext.h
+++ b/source/slang/slang-emit-spirv-ops-debug-info-ext.h
@@ -618,7 +618,7 @@ SpvInst* emitOpDebugValue(
     IRInst* inst,
     const T& idResultType,
     SpvInst* set,
-    IRInst* localVar,
+    SpvInst* localVar,
     IRInst* value,
     SpvInst* expression,
     const Ts& indices)

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -4303,6 +4303,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             builder.getIntValue(builder.getUIntType(), 0),
             debugVar->getArgIndex());
 
+        registerDebugInst(debugVar, spvDebugLocalVar);
+
         if (hasBackingVar)
         {
             emitOpDebugDeclare(
@@ -9514,15 +9516,19 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 if (!structType)
                     return false;
                 UInt fieldIndex = 0;
+                bool foundField = false;
                 for (auto field : structType->getFields())
                 {
                     if (field->getKey() == key)
                     {
                         type = unwrapAttributedType(field->getFieldType());
+                        foundField = true;
                         break;
                     }
                     fieldIndex++;
                 }
+                if (!foundField)
+                    return false;
                 spvAccessChain.add(emitIntConstant(fieldIndex, builder.getIntType()));
             }
             else
@@ -9537,7 +9543,13 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                         matrixType->getColumnCount());
                 else
                     return false;
-                spvAccessChain.add(ensureInst(element));
+                // DebugValue index operands must be constant integers.
+                auto indexOperand = element;
+                if (auto globalValueRef = as<IRGlobalValueRef>(indexOperand))
+                    indexOperand = globalValueRef->getValue();
+                if (!as<IRIntLit>(indexOperand))
+                    return false;
+                spvAccessChain.add(ensureInst(indexOperand));
             }
         }
         return true;
@@ -9548,12 +9560,12 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         auto debugVar = debugValue->getDebugVar();
         auto debugValueVal = debugValue->getValue();
         // We are asked to update the value for a debug variable.
-        // A debug variable is already emited as a OpDebugVariable +
-        // OpVariable + OpDebugDeclare. We only need to store the new value
-        // into the associated OpVariable. The `debugValue->getDebugVar()` inst
-        // already maps to the `OpVariable` SpvInst, so we just need to emit
-        // code for a store into the subset of the OpVariable with the correct
-        // accesschain defined in the debug value inst.
+        // A debug variable is already emitted as an OpDebugLocalVariable +
+        // OpVariable + OpDebugDeclare. We need to both:
+        // 1. Emit an OpDebugValue (can be helpful if the OpVariable gets
+        //    optimized out).
+        // 2. Store the new value into the associated OpVariable (for the
+        //    DebugDeclare association).
         //
         IRBuilder builder(debugValue);
         builder.setInsertBefore(debugValue);
@@ -9568,42 +9580,48 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             return nullptr;
         if (!spvDebugVar)
             return nullptr;
-        if (spvDebugVar->opcode != SpvOpVariable)
+
+        // Emit an OpDebugValue if possible.
+        //
+        SpvInst* spvDebugLocalVar = nullptr;
+        m_mapIRInstToSpvDebugInst.tryGetValue(rootVar, spvDebugLocalVar);
+        if (spvDebugLocalVar)
         {
-            // If the root variable can't be represented by a normal variable,
-            // try to emit a DebugValue if possible. Usually this means that the variable
-            // represents a shader resource.
-            //
             // SPIR-V requires the access chain specified in a DebugValue operation to
             // be fully static. We will skip emitting the debug inst if the access chain
             // isn't static.
             //
-            auto type = unwrapAttributedType(debugVar->getDataType());
+            auto type = rootVar->getDataType();
+            if (auto pointedToType = tryGetPointedToType(&builder, type))
+                type = pointedToType;
+            else
+                type = as<IRType>(unwrapAttributedType(type));
             List<SpvInst*> accessChain;
             bool isConstAccessChain =
                 translateIRAccessChain(builder, type, irAccessChain, accessChain);
 
             if (isConstAccessChain)
             {
-                return emitOpDebugValue(
+                emitOpDebugValue(
                     parent,
-                    debugValue,
+                    nullptr,
                     m_voidType,
                     getNonSemanticDebugInfoExtInst(),
-                    rootVar,
+                    spvDebugLocalVar,
                     debugValueVal,
                     getDwarfExpr(),
                     accessChain);
             }
-
-            // Fallback to not emit anything for now.
-            return nullptr;
         }
 
-        // The ordinary case is the debug variable has a backing ordinary variable.
-        // We can simply emit a store into the backing variable for the DebugValue operation.
+        // If the debug variable has a backing OpVariable, emit a store into it
+        // to keep the DebugDeclare association in sync.
         //
-        return emitStore(parent, debugValue, debugVar, debugValueVal);
+        if (spvDebugVar->opcode == SpvOpVariable)
+            return emitStore(parent, debugValue, debugVar, debugValueVal);
+
+        // Fallback to not emit anything.
+        return nullptr;
     }
 
     void maybeAssignAnonymousMemberNames(IRStructType* structType)

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -1877,6 +1877,44 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         }
     }
 
+    void emitPerMemberDebugValue(IRBuilder& builder, IRInst* debugVar, IRInst* value)
+    {
+        auto valueType = as<IRType>(unwrapAttributedType(value->getDataType()));
+        if (auto structType = as<IRStructType>(valueType))
+        {
+            for (auto field : structType->getFields())
+            {
+                auto fieldDebugVar = builder.emitFieldAddress(debugVar, field->getKey());
+                auto fieldValue =
+                    builder.emitFieldExtract(field->getFieldType(), value, field->getKey());
+                emitPerMemberDebugValue(builder, fieldDebugVar, fieldValue);
+            }
+            return;
+        }
+
+        auto debugValue = builder.emitDebugValue(debugVar, value);
+        addToWorkList(debugValue);
+    }
+
+    void processDebugValue(IRDebugValue* inst)
+    {
+        auto valueType = as<IRType>(unwrapAttributedType(inst->getValue()->getDataType()));
+        if (as<IRStructType>(valueType))
+        {
+            // Decompose the struct into per-member DebugValue updates to help
+            // shader debuggers resolve the struct value.
+            IRBuilder builder(inst);
+            builder.setInsertBefore(inst);
+            emitPerMemberDebugValue(builder, inst->getDebugVar(), inst->getValue());
+            inst->removeAndDeallocate();
+            return;
+        }
+
+        // Unsupported type, remove the DebugValue.
+        if (!isSimpleDataType(valueType))
+            inst->removeAndDeallocate();
+    }
+
     List<IRInst*> m_instsToRemove;
     void processWorkList()
     {
@@ -2009,8 +2047,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 break;
 
             case kIROp_DebugValue:
-                if (!isSimpleDataType(as<IRDebugValue>(inst)->getDebugVar()->getDataType()))
-                    inst->removeAndDeallocate();
+                processDebugValue(as<IRDebugValue>(inst));
                 break;
             case kIROp_DebugVar:
                 if (!isSimpleDataType(as<IRDebugVar>(inst)->getDataType()))

--- a/tests/spirv/debug-struct-member-values-array.slang
+++ b/tests/spirv/debug-struct-member-values-array.slang
@@ -1,0 +1,48 @@
+//TEST:SIMPLE(filecheck=CHECK_O0): -target spirv -g2 -O0
+//TEST:SIMPLE(filecheck=CHECK_OPT): -target spirv -g2 -O1
+//TEST:SIMPLE(filecheck=CHECK_OPT): -target spirv -g2 -O2
+
+// Test that a struct with an array member has proper debug info.
+// Exercises the array index path in translateIRAccessChain.
+
+struct WithArray
+{
+    float a;
+    float values[3];
+};
+
+RWStructuredBuffer<float> output;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main(uint tid : SV_DispatchThreadID)
+{
+    WithArray s;
+    s.a = 1.0;
+    s.values[0] = 2.0;
+    s.values[1] = 3.0;
+    s.values[2] = float(tid);
+    output[0] = s.a + s.values[0] + s.values[1] + s.values[2];
+}
+
+// -O0: struct uses both DebugDeclare and per-member DebugValue.
+// CHECK_O0-DAG: DebugTypeArray
+// CHECK_O0-DAG: DebugTypeComposite
+// CHECK_O0-DAG: [[S_STR:%[0-9]+]] = OpString "s"
+// CHECK_O0-DAG: [[S:%[A-Za-z_0-9]+]] = OpExtInst %void {{.*}} DebugLocalVariable [[S_STR]]
+// CHECK_O0-DAG: DebugDeclare [[S]]
+// CHECK_O0-DAG: DebugValue [[S]] {{.*}} %int_0{{$}}
+// CHECK_O0-DAG: DebugValue [[S]] {{.*}} %int_1 %int_0{{$}}
+// CHECK_O0-DAG: DebugValue [[S]] {{.*}} %int_1 %int_1{{$}}
+// CHECK_O0-DAG: DebugValue [[S]] {{.*}} %int_1 %int_2{{$}}
+
+// -O1/-O2: per-member DebugValue with array access chain indices.
+// CHECK_OPT-DAG: DebugTypeArray
+// CHECK_OPT-DAG: DebugTypeComposite
+// CHECK_OPT-DAG: [[S_STR:%[0-9]+]] = OpString "s"
+// CHECK_OPT-DAG: [[S:%[A-Za-z_0-9]+]] = OpExtInst %void {{.*}} DebugLocalVariable [[S_STR]]
+// CHECK_OPT-NOT: DebugDeclare [[S]]
+// CHECK_OPT-DAG: DebugValue [[S]] {{.*}} %int_0{{$}}
+// CHECK_OPT-DAG: DebugValue [[S]] {{.*}} %int_1 %int_0{{$}}
+// CHECK_OPT-DAG: DebugValue [[S]] {{.*}} %int_1 %int_1{{$}}
+// CHECK_OPT-DAG: DebugValue [[S]] {{.*}} %int_1 %int_2{{$}}

--- a/tests/spirv/debug-struct-member-values-matrix.slang
+++ b/tests/spirv/debug-struct-member-values-matrix.slang
@@ -1,0 +1,57 @@
+//TEST:SIMPLE(filecheck=CHECK_O0): -target spirv -g2 -O0
+//TEST:SIMPLE(filecheck=CHECK_OPT): -target spirv -g2 -O1
+//TEST:SIMPLE(filecheck=CHECK_OPT): -target spirv -g2 -O2
+
+// Test that a struct with a non-square matrix member has proper debug info.
+
+struct WithMatrix
+{
+    float2x3 m;
+    float a;
+};
+
+RWStructuredBuffer<float> output;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main(uint tid : SV_DispatchThreadID)
+{
+    WithMatrix s;
+    s.m[0][0] = 1.0;
+    s.m[0][1] = 2.0;
+    s.m[0][2] = 3.0;
+    s.m[1][0] = 4.0;
+    s.m[1][1] = 5.0;
+    s.m[1][2] = float(tid);
+    s.a = 7.0;
+    output[0] =
+        s.m[0][0] + s.m[0][1] + s.m[0][2] + s.m[1][0] + s.m[1][1] + s.m[1][2] + s.a;
+}
+
+// -O0: struct uses DebugDeclare and per-member DebugValue.
+// CHECK_O0-DAG: DebugTypeMatrix
+// CHECK_O0-DAG: DebugTypeComposite
+// CHECK_O0-DAG: [[S_STR:%[0-9]+]] = OpString "s"
+// CHECK_O0-DAG: [[S:%[A-Za-z_0-9]+]] = OpExtInst %void {{.*}} DebugLocalVariable [[S_STR]]
+// CHECK_O0-DAG: DebugDeclare [[S]]
+// CHECK_O0-DAG: DebugValue [[S]] {{.*}} %int_0 %int_0 %int_0{{$}}
+// CHECK_O0-DAG: DebugValue [[S]] {{.*}} %int_0 %int_0 %int_1{{$}}
+// CHECK_O0-DAG: DebugValue [[S]] {{.*}} %int_0 %int_0 %int_2{{$}}
+// CHECK_O0-DAG: DebugValue [[S]] {{.*}} %int_0 %int_1 %int_0{{$}}
+// CHECK_O0-DAG: DebugValue [[S]] {{.*}} %int_0 %int_1 %int_1{{$}}
+// CHECK_O0-DAG: DebugValue [[S]] {{.*}} %int_0 %int_1 %int_2{{$}}
+// CHECK_O0-DAG: DebugValue [[S]] {{.*}} %int_1{{$}}
+
+// -O1/-O2: struct should use per-member DebugValue, not DebugDeclare.
+// CHECK_OPT-DAG: DebugTypeMatrix
+// CHECK_OPT-DAG: DebugTypeComposite
+// CHECK_OPT-DAG: [[S_STR:%[0-9]+]] = OpString "s"
+// CHECK_OPT-DAG: [[S:%[A-Za-z_0-9]+]] = OpExtInst %void {{.*}} DebugLocalVariable [[S_STR]]
+// CHECK_OPT-NOT: DebugDeclare [[S]]
+// CHECK_OPT-DAG: DebugValue [[S]] {{.*}} %int_0 %int_0 %int_0{{$}}
+// CHECK_OPT-DAG: DebugValue [[S]] {{.*}} %int_0 %int_0 %int_1{{$}}
+// CHECK_OPT-DAG: DebugValue [[S]] {{.*}} %int_0 %int_0 %int_2{{$}}
+// CHECK_OPT-DAG: DebugValue [[S]] {{.*}} %int_0 %int_1 %int_0{{$}}
+// CHECK_OPT-DAG: DebugValue [[S]] {{.*}} %int_0 %int_1 %int_1{{$}}
+// CHECK_OPT-DAG: DebugValue [[S]] {{.*}} %int_0 %int_1 %int_2{{$}}
+// CHECK_OPT-DAG: DebugValue [[S]] {{.*}} %int_1{{$}}

--- a/tests/spirv/debug-struct-member-values-nested.slang
+++ b/tests/spirv/debug-struct-member-values-nested.slang
@@ -1,0 +1,51 @@
+//TEST:SIMPLE(filecheck=CHECK_O0): -target spirv -g2 -O0
+//TEST:SIMPLE(filecheck=CHECK_OPT): -target spirv -g2 -O1
+//TEST:SIMPLE(filecheck=CHECK_OPT): -target spirv -g2 -O2
+
+// Test that nested struct local variable members have proper debug info
+// that a shader debugger can resolve, both with and without optimizations
+// enabled.
+
+struct Inner
+{
+    float x;
+    int y;
+};
+
+struct Outer
+{
+    Inner inner;
+    float z;
+};
+
+RWStructuredBuffer<float> output;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main(uint tid : SV_DispatchThreadID)
+{
+    Outer o;
+    o.inner.x = 1.0;
+    o.inner.y = int(tid);
+    o.z = 3.0;
+    output[0] = o.inner.x + float(o.inner.y) + o.z;
+}
+
+// -O0: struct uses both DebugDeclare and per-member DebugValue.
+// CHECK_O0-DAG: DebugTypeComposite
+// CHECK_O0-DAG: [[O_STR:%[0-9]+]] = OpString "o"
+// CHECK_O0-DAG: [[O:%[A-Za-z_0-9]+]] = OpExtInst %void {{.*}} DebugLocalVariable [[O_STR]]
+// CHECK_O0-DAG: DebugDeclare [[O]]
+// CHECK_O0-DAG: DebugValue [[O]] {{.*}} %int_0 %int_0{{$}}
+// CHECK_O0-DAG: DebugValue [[O]] {{.*}} %int_0 %int_1{{$}}
+// CHECK_O0-DAG: DebugValue [[O]] {{.*}} %int_1{{$}}
+
+// -O1/-O2: nested struct should use DebugValue per leaf member with
+// multi-level access chain indices.
+// CHECK_OPT-DAG: DebugTypeComposite
+// CHECK_OPT-DAG: [[O_STR:%[0-9]+]] = OpString "o"
+// CHECK_OPT-DAG: [[O:%[A-Za-z_0-9]+]] = OpExtInst %void {{.*}} DebugLocalVariable [[O_STR]]
+// CHECK_OPT-NOT: DebugDeclare [[O]]
+// CHECK_OPT-DAG: DebugValue [[O]] {{.*}} %int_0 %int_0{{$}}
+// CHECK_OPT-DAG: DebugValue [[O]] {{.*}} %int_0 %int_1{{$}}
+// CHECK_OPT-DAG: DebugValue [[O]] {{.*}} %int_1{{$}}

--- a/tests/spirv/debug-struct-member-values-param.slang
+++ b/tests/spirv/debug-struct-member-values-param.slang
@@ -1,0 +1,55 @@
+//TEST:SIMPLE(filecheck=CHECK_O0): -target spirv -g2 -O0
+//TEST:SIMPLE(filecheck=CHECK_OPT): -target spirv -g2 -O1
+//TEST:SIMPLE(filecheck=CHECK_OPT): -target spirv -g2 -O2
+
+// Test that a struct-typed by-value function parameter has proper debug
+// info through the parameter initialization path.
+
+struct MyStruct
+{
+    float a;
+    int b;
+};
+
+RWStructuredBuffer<float> output;
+
+float processStruct(MyStruct param)
+{
+    return param.a + float(param.b);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main(uint tid : SV_DispatchThreadID)
+{
+    MyStruct local;
+    local.a = 1.0;
+    local.b = int(tid);
+    output[0] = processStruct(local);
+}
+
+// -O0: both the local and parameter structs use DebugDeclare and per-member DebugValue.
+// CHECK_O0-DAG: [[LOCAL_STR:%[0-9]+]] = OpString "local"
+// CHECK_O0-DAG: [[PARAM_STR:%[0-9]+]] = OpString "param"
+// CHECK_O0-DAG: DebugTypeComposite
+// CHECK_O0-DAG: [[LOCAL:%[A-Za-z_0-9]+]] = OpExtInst %void {{.*}} DebugLocalVariable [[LOCAL_STR]]
+// CHECK_O0-DAG: [[PARAM:%[A-Za-z_0-9]+]] = OpExtInst %void {{.*}} DebugLocalVariable [[PARAM_STR]]
+// CHECK_O0-DAG: DebugDeclare [[LOCAL]]
+// CHECK_O0-DAG: DebugDeclare [[PARAM]]
+// CHECK_O0-DAG: DebugValue [[LOCAL]] {{.*}} %int_0{{$}}
+// CHECK_O0-DAG: DebugValue [[LOCAL]] {{.*}} %int_1{{$}}
+// CHECK_O0-DAG: DebugValue [[PARAM]] {{.*}} %int_0{{$}}
+// CHECK_O0-DAG: DebugValue [[PARAM]] {{.*}} %int_1{{$}}
+
+// -O1/-O2: both the local and parameter structs use per-member DebugValue.
+// CHECK_OPT-DAG: [[LOCAL_STR:%[0-9]+]] = OpString "local"
+// CHECK_OPT-DAG: [[PARAM_STR:%[0-9]+]] = OpString "param"
+// CHECK_OPT-DAG: DebugTypeComposite
+// CHECK_OPT-DAG: [[LOCAL:%[A-Za-z_0-9]+]] = OpExtInst %void {{.*}} DebugLocalVariable [[LOCAL_STR]]
+// CHECK_OPT-DAG: [[PARAM:%[A-Za-z_0-9]+]] = OpExtInst %void {{.*}} DebugLocalVariable [[PARAM_STR]]
+// CHECK_OPT-NOT: DebugDeclare [[LOCAL]]
+// CHECK_OPT-NOT: DebugDeclare [[PARAM]]
+// CHECK_OPT-DAG: DebugValue [[LOCAL]] {{.*}} %int_0{{$}}
+// CHECK_OPT-DAG: DebugValue [[LOCAL]] {{.*}} %int_1{{$}}
+// CHECK_OPT-DAG: DebugValue [[PARAM]] {{.*}} %int_0{{$}}
+// CHECK_OPT-DAG: DebugValue [[PARAM]] {{.*}} %int_1{{$}}

--- a/tests/spirv/debug-struct-member-values.slang
+++ b/tests/spirv/debug-struct-member-values.slang
@@ -1,0 +1,46 @@
+//TEST:SIMPLE(filecheck=CHECK_O0): -target spirv -g2 -O0
+//TEST:SIMPLE(filecheck=CHECK_OPT): -target spirv -g2 -O1
+//TEST:SIMPLE(filecheck=CHECK_OPT): -target spirv -g2 -O2
+
+// Test that struct local variable members have proper debug info that a shader
+// debugger can resolve, both with and without optimizations enabled.
+
+struct MyStruct
+{
+    float a;
+    float3 b;
+    int c;
+};
+
+RWStructuredBuffer<float> output;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main(uint tid : SV_DispatchThreadID)
+{
+    MyStruct s;
+    s.a = 1.0;
+    s.b = float3(2.0, 3.0, 4.0);
+    s.c = int(tid);
+    output[0] = s.a + s.b.x + float(s.c);
+}
+
+// -O0: struct uses both DebugDeclare and per-member DebugValue.
+// CHECK_O0-DAG: DebugTypeMember
+// CHECK_O0-DAG: DebugTypeComposite
+// CHECK_O0-DAG: [[S_STR:%[0-9]+]] = OpString "s"
+// CHECK_O0-DAG: [[S:%[A-Za-z_0-9]+]] = OpExtInst %void {{.*}} DebugLocalVariable [[S_STR]]
+// CHECK_O0-DAG: DebugDeclare [[S]]
+// CHECK_O0-DAG: DebugValue [[S]] {{.*}} %int_0{{$}}
+// CHECK_O0-DAG: DebugValue [[S]] {{.*}} %int_1{{$}}
+// CHECK_O0-DAG: DebugValue [[S]] {{.*}} %int_2{{$}}
+
+// -O1/-O2: struct should use per-member DebugValue, not DebugDeclare.
+// CHECK_OPT-DAG: DebugTypeMember
+// CHECK_OPT-DAG: DebugTypeComposite
+// CHECK_OPT-DAG: [[S_STR:%[0-9]+]] = OpString "s"
+// CHECK_OPT-DAG: [[S:%[A-Za-z_0-9]+]] = OpExtInst %void {{.*}} DebugLocalVariable [[S_STR]]
+// CHECK_OPT-NOT: DebugDeclare [[S]]
+// CHECK_OPT-DAG: DebugValue [[S]] {{.*}} %int_0{{$}}
+// CHECK_OPT-DAG: DebugValue [[S]] {{.*}} %int_1{{$}}
+// CHECK_OPT-DAG: DebugValue [[S]] {{.*}} %int_2{{$}}


### PR DESCRIPTION
With optimizations enabled, debug backing variables and related debug information for structs can be optimized out, causing missing or undefined values for structs in shader debuggers. Instead, emit per-member DebugValue instructions for structs that survive optimization.

- Modify maybeEmitDebugVarBackingLocalVarDeclaration() to skip generating a debug backing variable for structs when optimization is enabled, allowing DebugValue to be generated instead.
- Update setDebugValue to iterate over a struct's fields to emit per-member DebugValue instructions.
- Add new debug-struct-member-values test.

Fixes #10540