### PR TITLE
Enable Slack notifications for Sascha Willems shader nightly CI

### DIFF
--- a/.github/workflows/compile-sascha-willems-shaders-nightly.yml
+++ b/.github/workflows/compile-sascha-willems-shaders-nightly.yml
@@ -116,7 +116,7 @@ jobs:
               "Sascha-Willems-Nightly": ":green-check-mark: Sascha Willems shader nightly status: ${{ job.status }}"
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SWILLEMS_VULKAN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SWILLEMS_VK }}
 
       - name: Failure notification
         id: slack-notify-failure
@@ -128,4 +128,4 @@ jobs:
               "Sascha-Willems-Nightly": ":alert: :alert: :alert: :alert: :alert: :alert:\nSascha Willems shader nightly status: ${{ job.status }}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SWILLEMS_VULKAN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SWILLEMS_VK }}


### PR DESCRIPTION
## Summary
- Enable Slack webhook notifications for the Sascha Willems Vulkan shaders nightly CI workflow
- Success and failure notifications are sent only on scheduled runs (not manual dispatches)
- Uses the `SLACK_WEBHOOK_SWILLEMS_VK` repository secret

## Test plan
- Verify the `SLACK_WEBHOOK_SWILLEMS_VK` secret is configured in the repository
- Trigger the workflow manually to confirm the action runs (notifications are gated to `schedule` events only)
- Wait for the next nightly run to confirm Slack messages are delivered