### PR TITLE
Exclude declaration-only headers from coverage reports

### DIFF
--- a/tools/coverage/slangc-ignore-patterns.sh
+++ b/tools/coverage/slangc-ignore-patterns.sh
@@ -23,6 +23,5 @@ SLANGC_IGNORE_ARGS=(
   -ignore-filename-regex='source/slang/slang-(language-server|doc-markdown-writer|doc-ast|ast-dump|repro|workspace-version)[.\-]'
 
   # FIDDLE-generated AST declaration headers (no executable code)
-  -ignore-filename-regex='source/slang/slang-ast-(decl|expr|modifier|stmt)\.h$'
-  -ignore-filename-regex='source/slang/slang-capability-val\.h$'
+  -ignore-filename-regex='source/slang/slang-ast-(expr|modifier|stmt)\.h$'
 )


### PR DESCRIPTION
## Summary

- Exclude 3 purely FIDDLE-generated AST declaration headers from coverage reports

These headers (`slang-ast-expr.h`, `slang-ast-modifier.h`, `slang-ast-stmt.h`) contain only FIDDLE macros and no executable code. They show 0% coverage as a reporting artifact since all actual code is generated into `build/source/slang/fiddle/` during compilation.

Headers with inline executable code are intentionally kept so their 0% coverage remains visible as a signal for improvement, including:
- `slang-ast-builder.h`, `slang-ast-decl.h`, `slang-ast-type.h`, `slang-ast-val.h` (inline methods, templates)
- `slang-capability-val.h` (~150 lines of inline logic)
- `slang-ir.h`, `slang-fossil.h`, `slang-syntax.h`, `slang-compile-request.h`, etc.

## Test plan

- [ ] Verify next coverage report excludes these 3 files and shows improved accuracy
- [ ] No functional changes; only affects `llvm-cov` ignore patterns