### PR TITLE
Add SYSLOG capability to CI containers for dmesg access

### DIFF
--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -34,6 +34,7 @@ jobs:
       options: >-
         --gpus all
         --user root
+        --cap-add SYSLOG
         --device /dev/nvidia-modeset:/dev/nvidia-modeset
         --device /dev/dri:/dev/dri
         -e NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics
@@ -164,6 +165,7 @@ jobs:
       options: >-
         --gpus all
         --user root
+        --cap-add SYSLOG
         --device /dev/nvidia-modeset:/dev/nvidia-modeset
         --device /dev/dri:/dev/dri
         -e NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics


### PR DESCRIPTION
## Summary
Add `--cap-add SYSLOG` to both `test-slang` and `test-slang-rhi` container options so the GPU post-failure diagnostics step (#10535) can read kernel logs via `dmesg`.

Without this capability, `dmesg` returns "Operation not permitted" even as root inside the container. With it, GPU driver messages (Xid errors, segfaults, NVRM faults) are captured on test failure.

Verified on a GCP VM that `--cap-add SYSLOG` is sufficient (no need for `--privileged` or `SYS_ADMIN`).

## Test plan
- [x] Verified `dmesg` works with `--cap-add SYSLOG` on GCP VM
- [x] Verified `dmesg` fails without it
- [ ] CI passes