### PR TITLE
Print expected-failure-list file info at startup of slang-test

### DIFF
--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -528,6 +528,7 @@ static bool _isSubCommand(const char* arg)
             File::readAllText(fileName, text);
             List<UnownedStringSlice> lines;
             StringUtil::split(text.getUnownedSlice(), '\n', lines);
+            int fileEntryCount = 0;
             for (auto line : lines)
             {
                 // Remove comments (everything after '#' character)
@@ -543,8 +544,13 @@ static bool _isSubCommand(const char* arg)
                 if (trimmedLine.getLength() > 0)
                 {
                     optionsOut->expectedFailureList.add(trimmedLine);
+                    fileEntryCount++;
                 }
             }
+            Options::ExpectedFailureFileInfo fileInfo;
+            fileInfo.fileName = fileName;
+            fileInfo.count = fileEntryCount;
+            optionsOut->expectedFailureFiles.add(fileInfo);
         }
         else if (strcmp(arg, "-skip-list") == 0)
         {
@@ -694,6 +700,16 @@ static bool _isSubCommand(const char* arg)
     {
         // If the test directory isn't set, use the "tests" directory
         optionsOut->testDir = String("tests/");
+    }
+
+    if (optionsOut->verbosity >= VerbosityLevel::Info &&
+        optionsOut->expectedFailureFiles.getCount() > 0)
+    {
+        stdOut.print("Expected failure lists:\n");
+        for (const auto& fileInfo : optionsOut->expectedFailureFiles)
+        {
+            stdOut.print(" - %s : %d tests\n", fileInfo.fileName.getBuffer(), fileInfo.count);
+        }
     }
 
     return SLANG_OK;

--- a/tools/slang-test/options.h
+++ b/tools/slang-test/options.h
@@ -141,6 +141,15 @@ struct Options
 
     Slang::HashSet<Slang::String> capabilities;
     Slang::HashSet<Slang::String> expectedFailureList;
+
+    // Per-file info for expected failure lists: (fileName, count) pairs, in order added.
+    struct ExpectedFailureFileInfo
+    {
+        Slang::String fileName;
+        int count;
+    };
+    Slang::List<ExpectedFailureFileInfo> expectedFailureFiles;
+
     Slang::List<Slang::String> skipList;
 
     // Ignore abort message dialog popup on Windows


### PR DESCRIPTION
This PR prints information about the expected-failure-list files.

With this PR, the result will look like the following:
```
Supported backends: fxc dxc glslang spirv-dis clang ...
Expected failure lists:
 - tests/expected-failure-github.txt : 19 tests
Check vk,vulkan: Supported
Check dx12,d3d12: Supported
...
```