### PR TITLE
Clean up DeviceCache before test-server exits

### DIFF
--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -641,7 +641,7 @@ SlangResult _execute(int argc, const char* const* argv)
     // after the GPU driver's own static destructors, causing segfaults from
     // corrupted vtables.
     typedef void (*CleanDeviceCacheFunc)();
-    ISlangSharedLibrary* renderTestLib = server.loadSharedLibrary("render-test");
+    ISlangSharedLibrary* renderTestLib = server.loadSharedLibrary("render-test-tool");
     if (renderTestLib)
     {
         auto cleanFunc = (CleanDeviceCacheFunc)renderTestLib->findFuncByName("cleanDeviceCache");


### PR DESCRIPTION
Call `cleanDeviceCache()` in test-server before exit to avoid static destruction order crash. The `DeviceCache` static singleton holds Vulkan/CUDA devices that segfault when destroyed after the GPU driver's own destructors have run.

Fixes #10596. Pre-existing bug, 100% reproducible with `server-count 8`.