### PR TITLE
Send PR title and author in SlangPy CI dispatch payload

### DIFF
--- a/.github/workflows/ci-trigger-slangpy.yml
+++ b/.github/workflows/ci-trigger-slangpy.yml
@@ -43,23 +43,34 @@ jobs:
           PR_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
           PR_IS_FORK=$(echo "$PR_JSON" | jq -r '.head.repo.fork')
           PR_HEAD_REPO=$(echo "$PR_JSON" | jq -r '.head.repo.full_name')
+          PR_TITLE=$(echo "$PR_JSON" | jq -r '.title' | head -1 | cut -c1-80)
+          PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.user.login')
           echo "number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
           echo "sha=$PR_SHA" >> "$GITHUB_OUTPUT"
           echo "is_fork_pr=$PR_IS_FORK" >> "$GITHUB_OUTPUT"
           echo "head_repo=$PR_HEAD_REPO" >> "$GITHUB_OUTPUT"
+          echo "title=$PR_TITLE" >> "$GITHUB_OUTPUT"
+          echo "author=$PR_AUTHOR" >> "$GITHUB_OUTPUT"
 
       - name: Get PR info (automatic trigger)
         if: github.event_name == 'pull_request_target'
         id: pr_auto
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
           echo "is_fork_pr=${{ github.event.pull_request.head.repo.fork }}" >> "$GITHUB_OUTPUT"
           echo "head_repo=${{ github.event.pull_request.head.repo.full_name }}" >> "$GITHUB_OUTPUT"
+          # Use first line only; truncate to keep run-name readable
+          echo "title=$(echo "$PR_TITLE" | head -1 | cut -c1-80)" >> "$GITHUB_OUTPUT"
+          echo "author=${{ github.event.pull_request.user.login }}" >> "$GITHUB_OUTPUT"
 
       - name: Get PR info (merge queue)
         if: github.event_name == 'merge_group'
         id: pr_mq
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           QUEUE_REF="${{ github.event.merge_group.head_ref || github.ref_name }}"
           PR_NUMBER=$(echo "$QUEUE_REF" | sed -n 's|.*/pr-\([0-9]*\)-.*|\1|p')
@@ -70,6 +81,11 @@ jobs:
           echo "checkout_repo=${{ github.repository }}" >> "$GITHUB_OUTPUT"
           echo "is_fork_pr=false" >> "$GITHUB_OUTPUT"
           echo "head_repo=${{ github.repository }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$PR_NUMBER" ]; then
+            PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER")
+            echo "title=$(echo "$PR_JSON" | jq -r '.title' | head -1 | cut -c1-80)" >> "$GITHUB_OUTPUT"
+            echo "author=$(echo "$PR_JSON" | jq -r '.user.login')" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Post pending status
         uses: actions/github-script@v7
@@ -86,19 +102,26 @@ jobs:
             });
 
       - name: Trigger SlangPy CI
-        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+        uses: actions/github-script@v7
+        env:
+          PR_TITLE: ${{ steps.pr_auto.outputs.title || steps.pr_manual.outputs.title || steps.pr_mq.outputs.title }}
         with:
-          token: ${{ secrets.SLANGPY_DISPATCH_TOKEN }}
-          repository: shader-slang/slangpy
-          event-type: slang-pr-test
-          client-payload: |
-            {
-              "slang_pr_number": "${{ steps.pr_auto.outputs.number || steps.pr_manual.outputs.number || steps.pr_mq.outputs.number }}",
-              "slang_commit_sha": "${{ steps.pr_auto.outputs.sha || steps.pr_manual.outputs.sha || steps.pr_mq.outputs.sha }}",
-              "slang_ref": "${{ steps.pr_mq.outputs.ref || steps.pr_auto.outputs.sha || steps.pr_manual.outputs.sha }}",
-              "slang_checkout_mode": "${{ steps.pr_mq.outputs.checkout_mode || 'pr' }}",
-              "slang_checkout_repo": "${{ steps.pr_mq.outputs.checkout_repo || github.repository }}",
-              "is_fork_pr": "${{ steps.pr_auto.outputs.is_fork_pr || steps.pr_manual.outputs.is_fork_pr || steps.pr_mq.outputs.is_fork_pr }}",
-              "slang_pr_head_repo": "${{ steps.pr_auto.outputs.head_repo || steps.pr_manual.outputs.head_repo || steps.pr_mq.outputs.head_repo }}",
-              "slang_trigger_source": "${{ github.event_name }}"
-            }
+          github-token: ${{ secrets.SLANGPY_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'shader-slang',
+              repo: 'slangpy',
+              event_type: 'slang-pr-test',
+              client_payload: {
+                slang_pr_number: `${{ steps.pr_auto.outputs.number || steps.pr_manual.outputs.number || steps.pr_mq.outputs.number }}`,
+                slang_commit_sha: `${{ steps.pr_auto.outputs.sha || steps.pr_manual.outputs.sha || steps.pr_mq.outputs.sha }}`,
+                slang_ref: `${{ steps.pr_mq.outputs.ref || steps.pr_auto.outputs.sha || steps.pr_manual.outputs.sha }}`,
+                slang_checkout_mode: `${{ steps.pr_mq.outputs.checkout_mode }}` || 'pr',
+                slang_checkout_repo: `${{ steps.pr_mq.outputs.checkout_repo }}` || '${{ github.repository }}',
+                is_fork_pr: `${{ steps.pr_auto.outputs.is_fork_pr || steps.pr_manual.outputs.is_fork_pr || steps.pr_mq.outputs.is_fork_pr }}`,
+                slang_pr_head_repo: `${{ steps.pr_auto.outputs.head_repo || steps.pr_manual.outputs.head_repo || steps.pr_mq.outputs.head_repo }}`,
+                slang_trigger_source: '${{ github.event_name }}',
+                slang_pr_title: process.env.PR_TITLE || '',
+                slang_pr_author: `${{ steps.pr_auto.outputs.author || steps.pr_manual.outputs.author || steps.pr_mq.outputs.author }}`
+              }
+            });


### PR DESCRIPTION
## Summary
- Adds `slang_pr_title` and `slang_pr_author` to the cross-repo dispatch payload sent to SlangPy CI
- Extracts title and author in all three trigger paths (manual, automatic, merge queue)
- Truncates titles to 80 chars to keep run-names readable
- Switches dispatch from `peter-evans/repository-dispatch` to `actions/github-script` to safely handle special characters in PR titles
- Companion PR: https://github.com/shader-slang/slangpy/pull/885