### PR TITLE
Harden CI web fetches against transient HTTP failures

### DIFF
--- a/.github/actions/format-setup/action.yml
+++ b/.github/actions/format-setup/action.yml
@@ -14,9 +14,15 @@ runs:
       shell: bash
       run: |
         tmpdir=$(mktemp -d)
-        curl -L -H "Authorization: token ${{github.token}}" \
+        curl -fL --retry 3 --retry-delay 5 -H "Authorization: token ${{github.token}}" \
           -o "$tmpdir/clang-format" \
           https://github.com/shader-slang/slang-binaries/raw/306d22efc0f5f72c7230b0b6b7c99f03c46995bd/clang-format/x86_64-linux/bin/clang-format
+        if file "$tmpdir/clang-format" | grep -qi "HTML\|text"; then
+          echo "Error: downloaded clang-format is not a valid binary"
+          file "$tmpdir/clang-format"
+          head -5 "$tmpdir/clang-format"
+          exit 1
+        fi
         chmod +x "$tmpdir/clang-format"
         echo "$tmpdir" >> $GITHUB_PATH
 
@@ -30,8 +36,14 @@ runs:
       shell: bash
       run: |
         tmpdir=$(mktemp -d)
-        curl -L -H "Authorization: token ${{github.token}}" \
+        curl -fL --retry 3 --retry-delay 5 -H "Authorization: token ${{github.token}}" \
           -o "$tmpdir/shfmt" \
           https://github.com/mvdan/sh/releases/download/v3.10.0/shfmt_v3.10.0_linux_amd64
+        if file "$tmpdir/shfmt" | grep -qi "HTML\|text"; then
+          echo "Error: downloaded shfmt is not a valid binary"
+          file "$tmpdir/shfmt"
+          head -5 "$tmpdir/shfmt"
+          exit 1
+        fi
         chmod +x "$tmpdir/shfmt"
         echo "$tmpdir" >> $GITHUB_PATH

--- a/.github/actions/setup-llvm-from-gcs/action.yml
+++ b/.github/actions/setup-llvm-from-gcs/action.yml
@@ -46,7 +46,7 @@ runs:
           gcloud storage cp "${GCS_PATH}" /tmp/llvm-prebuilt.tar.gz
         elif curl -f -s -I "${PUBLIC_URL}" >/dev/null 2>&1; then
           echo "✅ Found LLVM prebuilt in GCS (public access), downloading..."
-          curl -L -o /tmp/llvm-prebuilt.tar.gz "${PUBLIC_URL}"
+          curl -fL --retry 3 --retry-delay 5 -o /tmp/llvm-prebuilt.tar.gz "${PUBLIC_URL}"
         else
           echo "⚠️  LLVM prebuilt not found in GCS"
           echo "cache-hit=false" >> $GITHUB_OUTPUT

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -26,7 +26,10 @@ runs:
         fi
 
         echo "Installing sccache for $ARCH ($SCCACHE_ARCH)"
-        curl -fL https://github.com/mozilla/sccache/releases/download/v0.7.4/sccache-v0.7.4-${SCCACHE_ARCH}.tar.gz | tar xz
+        curl -fL --retry 3 --retry-delay 5 -o /tmp/sccache.tar.gz \
+          https://github.com/mozilla/sccache/releases/download/v0.7.4/sccache-v0.7.4-${SCCACHE_ARCH}.tar.gz
+        tar xz -f /tmp/sccache.tar.gz
+        rm /tmp/sccache.tar.gz
 
         # Try with sudo if available, otherwise install directly (for containers running as root)
         if command -v sudo &> /dev/null; then
@@ -65,7 +68,7 @@ runs:
 
           # Use .zip release to avoid tar path issues on Windows
           $zipFile = Join-Path $env:RUNNER_TEMP "sccache.zip"
-          curl.exe -L -o $zipFile https://github.com/mozilla/sccache/releases/download/v0.7.4/sccache-v0.7.4-x86_64-pc-windows-msvc.zip
+          curl.exe -fL --retry 3 --retry-delay 5 -o $zipFile https://github.com/mozilla/sccache/releases/download/v0.7.4/sccache-v0.7.4-x86_64-pc-windows-msvc.zip
           Expand-Archive -Path $zipFile -DestinationPath $env:RUNNER_TEMP -Force
           Move-Item (Join-Path $env:RUNNER_TEMP "sccache-v0.7.4-x86_64-pc-windows-msvc\sccache.exe") (Join-Path $installDir "sccache.exe")
           $installDir | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8

--- a/.github/workflows/ci-slang-coverage.yml
+++ b/.github/workflows/ci-slang-coverage.yml
@@ -61,7 +61,9 @@ jobs:
         shell: bash
         run: |
           # Add LLVM APT repository
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          curl -fsSL --retry 3 --retry-delay 5 -o /tmp/llvm-snapshot.gpg.key https://apt.llvm.org/llvm-snapshot.gpg.key
+          sudo apt-key add /tmp/llvm-snapshot.gpg.key
+          rm /tmp/llvm-snapshot.gpg.key
           sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main"
           sudo apt-get update
 


### PR DESCRIPTION
## Summary
- Add `curl -f` (fail on HTTP errors), `--retry 3 --retry-delay 5`, and content validation to all binary downloads in CI actions
- Prevents HTML error pages (e.g. GitHub 501) from being saved as binaries and executed — the root cause of intermittent `/format` failures
- Download to files before piping to `tar`/`apt-key` so retries don't concatenate partial outputs

Fixes #10601