### PR TITLE
Fix ICE when struct contains combined texture sampler on HLSL target

### DIFF
--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -3377,11 +3377,35 @@ static LegalVal declareVars(
             for (auto ee : tupleType->elements)
             {
                 auto fieldLayout = getFieldLayout(typeLayout, ee.key);
+
+                // If the parent type layout doesn't have field-level info for this key,
+                // fall back to the struct type that declares the key. This handles the
+                // case where a type was lowered (e.g., combined texture sampler lowered
+                // to a struct) but the enclosing type's layout wasn't updated to reflect
+                // the lowered type's internal structure.
+                if (!fieldLayout && typeLayout)
+                {
+                    for (auto use = ee.key->firstUse; use; use = use->nextUse)
+                    {
+                        auto field = as<IRStructField>(use->getUser());
+                        if (!field)
+                            continue;
+                        auto structType = as<IRStructType>(field->getParent());
+                        if (!structType)
+                            continue;
+                        auto layoutDecor = structType->findDecoration<IRLayoutDecoration>();
+                        if (!layoutDecor)
+                            continue;
+                        fieldLayout =
+                            getFieldLayout(cast<IRTypeLayout>(layoutDecor->getLayout()), ee.key);
+                        if (fieldLayout)
+                            break;
+                    }
+                }
+
                 IRTypeLayout* fieldTypeLayout =
                     fieldLayout ? fieldLayout->getTypeLayout() : nullptr;
 
-                // If we have a type layout coming in, we really expect to have a layout for each
-                // field.
                 SLANG_ASSERT(fieldLayout || !typeLayout);
 
                 // If we are processing layout information, then

--- a/tests/language-feature/types/conditional-resource.slang
+++ b/tests/language-feature/types/conditional-resource.slang
@@ -1,0 +1,38 @@
+//TEST:SIMPLE(filecheck=GLSL): -target glsl -entry fragMain -stage fragment
+//TEST:SIMPLE(filecheck=HLSL): -target hlsl -entry fragMain -stage fragment
+
+extern const static bool testBool = true;
+Conditional<Texture2D, testBool> testTexture;
+Conditional<SamplerState, testBool> testSampler;
+
+extern const static bool testFalse = false;
+Conditional<Texture2D, testFalse> testMissingTexture;
+
+// Conditional with a combined texture-sampler type (Sampler2D), which gets
+// lowered to a struct containing separate texture and sampler fields.
+Conditional<Sampler2D, testBool> testCombined;
+Conditional<Sampler2D, testFalse> testMissingCombined;
+
+// GLSL: uniform {{.*}}testTexture
+// GLSL: uniform {{.*}}testSampler
+// GLSL-NOT: testMissingTexture
+// GLSL: uniform sampler2D testCombined
+// GLSL-NOT: testMissingCombined
+
+// HLSL: Texture2D{{.*}}testTexture
+// HLSL: SamplerState{{.*}}testSampler
+// HLSL-NOT: testMissingTexture
+// HLSL: Texture2D{{.*}}testCombined
+// HLSL: SamplerState{{.*}}testCombined
+// HLSL-NOT: testMissingCombined
+
+[shader("fragment")]
+float4 fragMain(float2 UV : TEXCOORD) : SV_Target
+{
+    float4 result = float4(0);
+    if (testTexture.get().hasValue && testSampler.get().hasValue)
+        result += testTexture.get().value.Sample(testSampler.get().value, UV);
+    if (testCombined.get().hasValue)
+        result += testCombined.get().value.Sample(UV);
+    return result;
+}


### PR DESCRIPTION
`lowerCombinedTextureSamplers` replaces `Sampler2D` with a struct `{texture, sampler}` and attaches a proper struct type layout, but only updates layouts for top-level global params. When `Sampler2D` is nested inside another struct (e.g. `Conditional<Sampler2D>`), the enclosing struct's field layout remains a stale flat resource count. `legalizeResourceTypes` then decomposes the inner struct into a tuple but cannot find field layouts for the tuple elements, triggering an assertion failure.

Fix `declareVars` to fall back to the struct type's own `IRLayoutDecoration` when the parent type layout lacks field-level info for a tuple element's key.

Fixes #10117

Made with [Cursor](https://cursor.com)