### PR TITLE
Disable Mesa Vulkan device select layer in CI containers

### DIFF
--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -38,6 +38,7 @@ jobs:
         --device /dev/nvidia-modeset:/dev/nvidia-modeset
         --device /dev/dri:/dev/dri
         -e NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics
+        -e VK_LOADER_LAYERS_DISABLE=VK_LAYER_MESA_device_select
         -v /etc/vulkan/icd.d/nvidia_icd.json:/etc/vulkan/icd.d/nvidia_icd.json:ro
         -v /usr/share/nvidia:/usr/share/nvidia:ro
         -v /usr/share/glvnd/egl_vendor.d/10_nvidia.json:/usr/share/glvnd/egl_vendor.d/10_nvidia.json:ro
@@ -171,6 +172,7 @@ jobs:
         --device /dev/nvidia-modeset:/dev/nvidia-modeset
         --device /dev/dri:/dev/dri
         -e NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics
+        -e VK_LOADER_LAYERS_DISABLE=VK_LAYER_MESA_device_select
         -v /etc/vulkan/icd.d/nvidia_icd.json:/etc/vulkan/icd.d/nvidia_icd.json:ro
         -v /usr/share/nvidia:/usr/share/nvidia:ro
         -v /usr/share/glvnd/egl_vendor.d/10_nvidia.json:/usr/share/glvnd/egl_vendor.d/10_nvidia.json:ro


### PR DESCRIPTION
Disable the `VK_LAYER_MESA_device_select` implicit Vulkan layer in CI containers. This layer loads the system `libLLVM-15.so.1` (from `mesa-vulkan-drivers`) into test-server processes, causing `llvm::UpgradeOperandBundles()` null pointer crashes when multiple servers initialize Vulkan concurrently.

The layer is unnecessary — CI always uses the NVIDIA Vulkan ICD mounted from the host.

Verified on GCP T4 VM: debug test suite with `server-count 4` goes from ~11 segfaults per run to zero with this env var.

Fixes #10596.