### PR TITLE
Fix spurious spvImageGatherExtended requirement from stdlib inverse()

### DIFF
--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -938,7 +938,8 @@ public matrix<T, R, C> outerProduct(vector<T, C> c, vector<T, R> r)
 }
 
 __generic<T : __BuiltinFloatingPointType, let N : int>
-[require(glsl_spirv, GLSL_400)]
+[require(glsl, GLSL_400)]
+[require(spirv)]
 public matrix<T,N,N> inverse(matrix<T,N,N> m)
 {
     __target_switch

--- a/tests/language-feature/capability/no-spurious-capability-for-inverse.slang
+++ b/tests/language-feature/capability/no-spurious-capability-for-inverse.slang
@@ -1,0 +1,19 @@
+//TEST:SIMPLE(filecheck=CHECK): -allow-glsl -target spirv -entry computeMain -stage compute -profile spirv_1_6
+
+// Verify that calling the stdlib `inverse` function does not spuriously
+// require `spvImageGatherExtended`.  The SPIR-V path only needs the
+// GLSL.std.450 `MatrixInverse` extended instruction, which is available
+// on any SPIR-V version without additional capabilities.
+
+// CHECK-NOT: spvImageGatherExtended
+// CHECK-NOT: warning
+// CHECK: computeMain
+
+RWStructuredBuffer<float4x4> buf;
+
+[shader("compute")]
+[numthreads(1,1,1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    buf[1] = inverse(buf[0]);
+}


### PR DESCRIPTION
## Summary
- The GLSL stdlib `inverse()` had `[require(glsl_spirv, GLSL_400)]`, which forced the SPIR-V path through `GLSL_400` capability resolution. `GLSL_400` includes `GL_ARB_texture_gather` as a propagated extension, which maps to `spvImageGatherExtended` on SPIR-V — causing a bogus warning 41012 ("profile implicitly upgraded to include `spvImageGatherExtended`") for a matrix inverse that has nothing to do with image operations.
- Split the require into `[require(glsl, GLSL_400)]` + `[require(spirv)]` so that SPIR-V no longer resolves through the GLSL version alias. The SPIR-V implementation only uses `OpExtInst MatrixInverse` from GLSL.std.450, which is available on any SPIR-V version without additional capabilities.

## Test plan
- [x] Added `tests/language-feature/capability/no-spurious-capability-for-inverse.slang` — compiles a shader calling `inverse()` targeting `spirv_1_6` and verifies no `spvImageGatherExtended` warning is emitted.
- [x] Verified `slang-test` passes the new test.
- [x] Reproduced the original issue with the v2026.3.1 release using the reporter's command-line flags (`-profile spirv_1_6 -target spirv -capability spvInt64Atomics+...`), confirmed the fix eliminates the warning.


Made with [Cursor](https://cursor.com)