### PR TITLE
Remove runtime check of "-ignore-abort-msg"

### DIFF
--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -185,6 +185,7 @@ jobs:
                 -DSLANG_SLANG_LLVM_FLAVOR=FETCH_BINARY \
                 "-DSLANG_SLANG_LLVM_BINARY_URL=$(pwd)/build/dist-release/slang-llvm.zip" \
                 "-DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }}" \
+                -DSLANG_IGNORE_ABORT_MSG=ON \
                 "${cmake_launcher_defines[@]}"
               cmake --workflow --preset "${{ inputs.config }}"
             elif [[ "${{ inputs.build-llvm }}" = "false" ]]; then
@@ -192,6 +193,7 @@ jobs:
               cmake --preset default --fresh \
                 -DSLANG_SLANG_LLVM_FLAVOR=DISABLE \
                 -DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }} \
+                -DSLANG_IGNORE_ABORT_MSG=ON \
                 "${cmake_launcher_defines[@]}"
               cmake --workflow --preset "${{ inputs.config }}"
             else
@@ -200,6 +202,7 @@ jobs:
               cmake --preset default --fresh \
                 -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
                 -DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }} \
+                -DSLANG_IGNORE_ABORT_MSG=ON \
                 "${cmake_launcher_defines[@]}"
               cmake --workflow --preset "${{ inputs.config }}"
             fi

--- a/.github/workflows/ci-slang-coverage.yml
+++ b/.github/workflows/ci-slang-coverage.yml
@@ -187,7 +187,6 @@ jobs:
             "-expected-failure-list" "tests/expected-failure-no-gpu.txt"
             "-skip-reference-image-generation"
             "-show-adapter-info"
-            "-ignore-abort-msg"
             "-enable-debug-layers" "true"
           )
 

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -100,7 +100,6 @@ jobs:
             "-expected-failure-list" "tests/expected-failure-linux-gpu.txt"
             "-skip-reference-image-generation"
             "-show-adapter-info"
-            "-ignore-abort-msg"
           )
 
           if [ "${{ inputs.server-count }}" -gt 1 ]; then
@@ -129,7 +128,6 @@ jobs:
             -server-count ${{ inputs.server-count }} \
             -category full \
             -emit-spirv-via-glsl \
-            -ignore-abort-msg \
             -api vk \
             -expected-failure-list tests/expected-failure-via-glsl.txt \
             -expected-failure-list tests/expected-failure-github.txt \

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -73,7 +73,6 @@ jobs:
             "-expected-failure-list" "tests/expected-failure-github.txt"
             "-skip-reference-image-generation"
             "-show-adapter-info"
-            "-ignore-abort-msg"
             "-enable-debug-layers" "${{ inputs.enable-debug-layers }}"
           )
 
@@ -129,7 +128,6 @@ jobs:
             -server-count ${{ inputs.server-count }} \
             -category ${{ inputs.test-category }} \
             -emit-spirv-via-glsl \
-            -ignore-abort-msg \
             -api vk \
             -expected-failure-list tests/expected-failure-via-glsl.txt \
             -skip-reference-image-generation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,8 +226,8 @@ On Windows, assertion failures normally open a modal dialog that blocks executio
 | `release-assert-only` | Skip debug-only assertions (`SLANG_ASSERT`, `SLANG_ASSERT_FAILURE`) and continue; `SLANG_RELEASE_ASSERT` still fires           |
 | _(unset)_             | Throws an exception                                                                                                            |
 
-The behavior on Windows after an exception is thrown is controlled by a CMake option `SLANG_IGNORE_ABORT_MSG` or `-ignore-abort-msg` command-line argument.
-Both options are highly recommended for unattended automation with LLM workflow.
+The behavior on Windows after an exception is thrown is controlled by the CMake option `SLANG_IGNORE_ABORT_MSG`.
+This option is highly recommended for unattended automation with LLM workflow; it bakes the behavior into all built executables at compile time.
 
 #### RTX Remix Testing
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,9 +133,7 @@ option(
     OFF
 )
 if(SLANG_IGNORE_ABORT_MSG)
-    set(slang_ignore_abort_msg_arg -ignore-abort-msg)
-else()
-    set(slang_ignore_abort_msg_arg)
+    add_compile_definitions(SLANG_IGNORE_ABORT_MSG=1)
 endif()
 option(
     SLANG_ENABLE_ASAN

--- a/docs/building.md
+++ b/docs/building.md
@@ -265,7 +265,7 @@ works for any given binary.
 | `SLANG_SLANG_LLVM_BINARY_URL`     | System dependent           | URL specifying the location of the slang-llvm prebuilt library                               |
 | `SLANG_USE_SCCACHE`               | `FALSE`                    | Use sccache as compiler launcher (auto-disables PCH)                                         |
 | `SLANG_GENERATORS_PATH`           | ``                         | Path to an installed `all-generators` target for cross compilation                           |
-| `SLANG_IGNORE_ABORT_MSG`          | `FALSE`                    | Ignore the system modal abort dialog while running build tools to help LLM workflow      |
+| `SLANG_IGNORE_ABORT_MSG`          | `FALSE`                    | Suppress the Windows modal abort dialog at compile time (baked into all built executables; recommended for unattended/LLM-driven builds) |
 
 The following options relate to optional dependencies for additional backends
 and running additional tests. Left unchanged they are auto detected, however

--- a/extras/ci-gpu-stress-loop.sh
+++ b/extras/ci-gpu-stress-loop.sh
@@ -192,7 +192,6 @@ docker run --rm \
             -expected-failure-list tests/expected-failure-linux-gpu.txt \
             -skip-reference-image-generation \
             -show-adapter-info \
-            -ignore-abort-msg \
             -use-test-server \
             -server-count 4 \
             2>&1

--- a/source/slang-core-module/CMakeLists.txt
+++ b/source/slang-core-module/CMakeLists.txt
@@ -42,7 +42,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E make_directory ${core_module_meta_output_dir}
     COMMAND
         slang-generate ${core_module_meta_source} --target-directory
-        ${core_module_meta_output_dir} ${slang_ignore_abort_msg_arg}
+        ${core_module_meta_output_dir}
     DEPENDS ${core_module_meta_source} slang-generate
     WORKING_DIRECTORY "${core_module_meta_source_dir}"
     VERBATIM
@@ -118,7 +118,7 @@ add_custom_command(
     COMMAND
         slang-bootstrap -archive-type riff-lz4 -save-core-module-bin-source
         ${core_module_generated_header} -save-glsl-module-bin-source
-        ${glsl_module_generated_header} ${slang_ignore_abort_msg_arg}
+        ${glsl_module_generated_header}
     DEPENDS slang-bootstrap slang-without-embedded-core-module
     VERBATIM
 )

--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -33,7 +33,6 @@ add_custom_command(
     COMMAND
         slang-fiddle -i "${SLANG_FIDDLE_INPUT_DIR}/" -o
         "${SLANG_FIDDLE_OUTPUT_DIR}/" ${SLANG_FIDDLE_INPUT_FILE_NAMES}
-        ${slang_ignore_abort_msg_arg}
     DEPENDS ${SLANG_FIDDLE_INPUTS} ${SLANG_FIDDLE_LUA_INPUTS} slang-fiddle
     WORKING_DIRECTORY ${slang_SOURCE_DIR}
     VERBATIM

--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -128,6 +128,11 @@ int wmain(int argc, wchar_t** argv)
 {
     int result = 0;
 
+#if SLANG_IGNORE_ABORT_MSG && defined(_MSC_VER)
+    // Suppress the modal abort() dialog in unattended/LLM-driven builds.
+    _set_abort_behavior(0, _WRITE_ABORT_MSG);
+#endif
+
     {
         // Convert the wide-character Unicode arguments to UTF-8,
         // since that is what Slang expects on the API side.
@@ -136,17 +141,7 @@ int wmain(int argc, wchar_t** argv)
         for (int ii = 0; ii < argc; ++ii)
         {
             String arg = String::fromWString(argv[ii]);
-            if (arg == "-ignore-abort-msg" || arg == "--ignore-abort-msg")
-            {
-#ifdef _MSC_VER
-                // Suppress the modal abort() dialog in unattended/LLM-driven builds.
-                _set_abort_behavior(0, _WRITE_ABORT_MSG);
-#endif
-            }
-            else
-            {
-                args.add(arg);
-            }
+            args.add(arg);
         }
 
         // argBuffers holds raw pointers into the String buffers owned by args.

--- a/tools/coverage/run-coverage-local.sh
+++ b/tools/coverage/run-coverage-local.sh
@@ -123,7 +123,6 @@ if [[ "$SKIP_TEST" == "false" ]]; then
     "-expected-failure-list" "tests/expected-failure-no-gpu.txt"
     "-skip-reference-image-generation"
     "-show-adapter-info"
-    "-ignore-abort-msg"
     "-enable-debug-layers" "true"
   )
 

--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -321,12 +321,6 @@ static rhi::DeviceType _toRenderType(Slang::RenderApiType apiType)
         {
             outOptions.showAdapterInfo = true;
         }
-        else if (argValue == "-ignore-abort-msg")
-        {
-#ifdef _MSC_VER
-            _set_abort_behavior(0, _WRITE_ABORT_MSG);
-#endif
-        }
         else if (argValue == "-cache-rhi-device")
         {
             outOptions.cacheRhiDevice = true;

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -2014,6 +2014,12 @@ SLANG_TEST_TOOL_API SlangResult innerMain(
 int main(int argc, char** argv)
 {
     using namespace Slang;
+
+#if SLANG_IGNORE_ABORT_MSG && defined(_MSC_VER)
+    // Suppress the modal abort() dialog in unattended/LLM-driven builds.
+    _set_abort_behavior(0, _WRITE_ABORT_MSG);
+#endif
+
     SlangSession* session = spCreateSession(nullptr);
 
     TestToolUtil::setSessionDefaultPreludeFromExePath(argv[0], session);

--- a/tools/slang-fiddle/slang-fiddle-main.cpp
+++ b/tools/slang-fiddle/slang-fiddle-main.cpp
@@ -407,6 +407,11 @@ int main(int argc, char const* const* argv)
     using namespace fiddle;
     using namespace Slang;
 
+#if SLANG_IGNORE_ABORT_MSG && defined(_MSC_VER)
+    // Suppress the modal abort() dialog in unattended/LLM-driven builds.
+    _set_abort_behavior(0, _WRITE_ABORT_MSG);
+#endif
+
     ComPtr<ISlangWriter> writer(
         new FileWriter(stderr, WriterFlag::IsUnowned | WriterFlag::AutoFlush));
 

--- a/tools/slang-fiddle/slang-fiddle-options.h
+++ b/tools/slang-fiddle/slang-fiddle-options.h
@@ -50,15 +50,6 @@ public:
             {
                 outputPathPrefix = expectArg(argCursor, argEnd);
             }
-            else if (
-                arg == UnownedTerminatedStringSlice("-ignore-abort-msg") ||
-                arg == UnownedTerminatedStringSlice("--ignore-abort-msg"))
-            {
-#ifdef _MSC_VER
-                // Suppress the modal abort() dialog in unattended/LLM-driven builds.
-                _set_abort_behavior(0, _WRITE_ABORT_MSG);
-#endif
-            }
             else
             {
                 sink.diagnose(SourceLoc(), Diagnostics::unknownOption, arg);

--- a/tools/slang-generate/main.cpp
+++ b/tools/slang-generate/main.cpp
@@ -854,6 +854,11 @@ List<RefPtr<SourceFile>> gSourceFiles;
 
 int main(int argc, const char* const* argv)
 {
+#if SLANG_IGNORE_ABORT_MSG && defined(_MSC_VER)
+    // Suppress the modal abort() dialog in unattended/LLM-driven builds.
+    _set_abort_behavior(0, _WRITE_ABORT_MSG);
+#endif
+
     // Parse command-line arguments.
     List<String> inputPaths;
     String outputDir;
@@ -871,14 +876,7 @@ int main(int argc, const char* const* argv)
         for (; argCursor != argEnd; ++argCursor)
         {
             const auto arg = UnownedStringSlice(*argCursor);
-            if (arg == "-ignore-abort-msg" || arg == "--ignore-abort-msg")
-            {
-#ifdef _MSC_VER
-                // Suppress the modal abort() dialog in unattended/LLM-driven builds.
-                _set_abort_behavior(0, _WRITE_ABORT_MSG);
-#endif
-            }
-            else if (arg == "--target-directory")
+            if (arg == "--target-directory")
             {
                 argCursor++;
                 if (argCursor == argEnd)

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -104,12 +104,6 @@ static bool _isSubCommand(const char* arg)
         "  -only-synthesized             Only run synthesized compile-target tests\n"
         "                                 (implies -synthesize-compile-targets)\n"
 
-        // Recent Windows runtime versions started opening a dialog popup window when
-        // `abort()` is called, which breaks the CI workflow and some scripts that
-        // expect a normal termination.
-        // It can be helpful for debugging but we should ignore it for CI.
-        "  -ignore-abort-msg              Ignore abort message dialog popup on Windows\n"
-
         "  -enable-debug-layers [true|false] Enable or disable Validation Layer for Vulkan\n"
         "                                 and Debug Device for DX\n"
         "  -cache-rhi-device [true|false] Enable or disable RHI device caching (default: true)\n"
@@ -507,13 +501,6 @@ static bool _isSubCommand(const char* arg)
                 return SLANG_FAIL;
             }
             optionsOut->capabilities.add(*argCursor++);
-        }
-        else if (strcmp(arg, "-ignore-abort-msg") == 0)
-        {
-            optionsOut->ignoreAbortMsg = true;
-#ifdef _MSC_VER
-            _set_abort_behavior(0, _WRITE_ABORT_MSG);
-#endif
         }
         else if (strcmp(arg, "-expected-failure-list") == 0)
         {

--- a/tools/slang-test/options.h
+++ b/tools/slang-test/options.h
@@ -152,9 +152,6 @@ struct Options
 
     Slang::List<Slang::String> skipList;
 
-    // Ignore abort message dialog popup on Windows
-    bool ignoreAbortMsg = false;
-
     /// Parse the args, report any errors into stdError, and write the results into optionsOut
     static SlangResult parse(
         int argc,

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -3838,11 +3838,6 @@ static void _addRenderTestOptions(const Options& options, CommandLine& ioCmdLine
         ioCmdLine.addArg("-enable-debug-layers");
     }
 
-    if (options.ignoreAbortMsg)
-    {
-        ioCmdLine.addArg("-ignore-abort-msg");
-    }
-
     if (options.cacheRhiDevice)
     {
         ioCmdLine.addArg("-cache-rhi-device");
@@ -6080,6 +6075,11 @@ int main(int argc, char** argv)
     // Ignore SIGPIPE so that writing to a broken pipe (e.g. a crashed test-server)
     // returns EPIPE instead of killing this process (exit code 141).
     signal(SIGPIPE, SIG_IGN);
+#endif
+
+#if SLANG_IGNORE_ABORT_MSG && defined(_MSC_VER)
+    // Suppress the modal abort() dialog in unattended/LLM-driven builds.
+    _set_abort_behavior(0, _WRITE_ABORT_MSG);
 #endif
 
     // Fallback: run without cleanup if context initialization fails

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -202,11 +202,6 @@ SlangResult TestContext::_createJSONRPCConnection(RefPtr<JSONRPCConnection>& out
         CommandLine cmdLine;
         cmdLine.setExecutableLocation(ExecutableLocation(exeDirectoryPath, "test-server"));
 
-        if (options.ignoreAbortMsg)
-        {
-            cmdLine.addArg("-ignore-abort-msg");
-        }
-
         SLANG_RETURN_ON_FAIL(Process::create(
             cmdLine,
             Process::Flag::AttachDebugger | Process::Flag::DisableStdErrRedirection,

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -195,17 +195,10 @@ SlangResult TestServer::init(int argc, const char* const* argv)
 {
     m_exePath = argv[0];
 
-    // Command-line argument parsing
-    for (int i = 1; i < argc; i++)
-    {
-        if (strcmp(argv[i], "-ignore-abort-msg") == 0)
-        {
-#ifdef _MSC_VER
-            _set_abort_behavior(0, _WRITE_ABORT_MSG);
+#if SLANG_IGNORE_ABORT_MSG && defined(_MSC_VER)
+    // Suppress the modal abort() dialog in unattended/LLM-driven builds.
+    _set_abort_behavior(0, _WRITE_ABORT_MSG);
 #endif
-        }
-        // Ignore unknown arguments for now
-    }
 
     String canonicalPath;
     if (SLANG_SUCCEEDED(Path::getCanonical(m_exePath, canonicalPath)))


### PR DESCRIPTION
There are two knobs to control the Windows modal popup dialog when an exception is thrown. This PR removes the runtime knob and replace them with the cmake configuration setting. Because I realized that there are too many places to use the runtime command-line arguments.

When SLANG_IGNORE_ABORT_MSG is ON at cmake configure time, CMake defines SLANG_IGNORE_ABORT_MSG=1 as a compile definition so all built executables call _set_abort_behavior at startup unconditionally, without requiring a -ignore-abort-msg command-line argument.

Remove all runtime option parsing of -ignore-abort-msg from slangc, slang-generate, slang-fiddle, render-test, test-server, and slang-test. Update CI build workflows to pass -DSLANG_IGNORE_ABORT_MSG=ON at configure time and remove the runtime flag from test invocations.