### PR TITLE
Enable GPU persistence mode on CI runners to prevent NVML corruption

### DIFF
--- a/extras/scaler/internal/gcp/startup.sh
+++ b/extras/scaler/internal/gcp/startup.sh
@@ -99,7 +99,11 @@ fi
 # Without this, NVML can lose track of GPU processes when they exit inside Docker,
 # causing "Failed to initialize NVML: Unknown Error".
 log "  Enabling GPU persistence mode..."
-nvidia-smi -pm 1 2>/dev/null || true
+if pm_out="$(nvidia-smi -pm 1 2>&1)"; then
+  log "  GPU persistence mode enabled."
+else
+  log "WARNING: Failed to enable GPU persistence mode: ${pm_out}"
+fi
 
 # Verify GPU devices
 log "  GPU devices:"


### PR DESCRIPTION
Enable `nvidia-smi -pm 1` in the runner startup script to keep the NVIDIA driver state alive between GPU workloads. Without persistence mode, NVML can lose track of GPU processes when they exit inside Docker containers, causing `Failed to initialize NVML: Unknown Error` — the silent GPU wedge seen intermittently in CI.

This is a host-level fix that doesn't require container changes like `--pid=host` (which would weaken container isolation by sharing the host PID namespace).

Verified on GCP T4 VM that persistence mode is currently disabled on our runner image.

Reference: https://stackoverflow.com/questions/72932940

See #10596 for the full investigation.