### PR TITLE
Track slang compiler library when building neural module

### DIFF
--- a/source/standard-modules/neural/CMakeLists.txt
+++ b/source/standard-modules/neural/CMakeLists.txt
@@ -38,8 +38,11 @@ if(SLANG_GENERATORS_PATH)
     set(SLANG_COMPILER "${SLANG_GENERATORS_PATH}/slang-bootstrap${CMAKE_HOST_EXECUTABLE_SUFFIX}")
     set(SLANG_COMPILER_DEPENDENCY)
 elseif(SLANG_ENABLE_SLANGC)
-    set(SLANG_COMPILER slangc)
-    set(SLANG_COMPILER_DEPENDENCY slangc)
+    set(SLANG_COMPILER "$<TARGET_FILE:slangc>")
+    set(SLANG_COMPILER_DEPENDENCY
+        slangc
+        slang
+    )
 else()
     # As a fallback, use the system-installed `slangc` compiler
     set(SLANG_COMPILER slangc)


### PR DESCRIPTION
## Summary
- use the config-specific built slangc executable for neural module compilation
- depend on the slang compiler library so compiler changes invalidate neural.slang-module
