### PR TITLE
Add missing capability check for SV_Barycentrics

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -5101,7 +5101,7 @@ semantic sv_wavelaneindex
 
 semantic sv_barycentrics
 {
-    [require(fragment)]
+    [require(fragment, fragmentshaderbarycentric)]
     get : float3;
 }
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -14673,6 +14673,115 @@ static void _propagateRequirement(
     }
 };
 
+// Propagate non-stage capability requirements from system value semantics on a
+// parameter declaration.
+//
+// SV_ semantics in core.meta.slang declare [require()] attributes on their
+// accessors (getters/setters). These requirements serve two purposes:
+//   1. Stage restrictions (e.g. [require(fragment)]) — validated separately by
+//      validateSystemValueSemantic in slang-check-shader.cpp, which produces
+//      specific diagnostics like "SV_X cannot be used as input in Y stage."
+//   2. Non-stage capabilities (e.g. [require(fragment, fragmentshaderbarycentric)])
+//      — need to be propagated through the capability system so the profile
+//      checker can detect missing capabilities and emit upgrade warnings.
+//
+// This function handles case (2). It looks up the SemanticDecl for SV_ modifiers,
+// finds matching accessors, and propagates their capability requirements — but
+// only when the accessor requires capabilities beyond what the stage alone
+// provides. The stage-only check (pureStage.implies) prevents duplicate
+// diagnostics with validateSystemValueSemantic.
+//
+// Scoped to ParamDecl only: the core/GLSL modules use SV_ semantics on
+// internal struct fields and other declarations where propagating capabilities
+// would conflict with the module's own capability structure. Struct fields in
+// user code are handled separately by collectStructFieldSemanticCapabilities
+// in slang-check-shader.cpp during entry point validation, where the direction
+// and stage are known.
+static void _propagateSemanticCapabilities(
+    SemanticsVisitor* visitor,
+    CapabilitySet& outCaps,
+    ParamDecl* paramDecl)
+{
+    auto semantic = paramDecl->findModifier<HLSLSimpleSemantic>();
+    if (!semantic)
+        return;
+
+    auto semanticNameSlice = semantic->name.getContent();
+    if (!semanticNameSlice.startsWithCaseInsensitive(toSlice("sv_")))
+        return;
+
+    UnownedStringSlice baseNameSlice, indexSlice;
+    splitNameAndIndex(semanticNameSlice, baseNameSlice, indexSlice);
+
+    auto scope = visitor->getSession()->coreLanguageScope;
+    if (!scope)
+        return;
+
+    auto namePool = visitor->getASTBuilder()->getGlobalSession()->getNamePool();
+    String lowerName = String(baseNameSlice).toLower();
+    auto lookupName = namePool->getName(lowerName);
+    auto lookupResult =
+        lookUp(visitor->getASTBuilder(), visitor, lookupName, scope, LookupMask::Semantic);
+
+    if (!lookupResult.isValid())
+        return;
+
+    auto semanticDecl = as<SemanticDecl>(lookupResult.item.declRef.getDecl());
+    if (!semanticDecl)
+        return;
+
+    bool isOutput = paramDecl->hasModifier<OutModifier>();
+    bool isInOut = paramDecl->hasModifier<InOutModifier>();
+
+    if (auto paramType = paramDecl->getType())
+    {
+        if (as<MeshOutputType>(paramType) || as<HLSLStreamOutputType>(paramType))
+            isOutput = true;
+    }
+
+    CapabilitySet accessorCaps;
+    for (auto member : semanticDecl->getMembers())
+    {
+        bool isGetter = as<SemanticGetterDecl>(member) != nullptr;
+        bool isSetter = as<SemanticSetterDecl>(member) != nullptr;
+        if (!isGetter && !isSetter)
+            continue;
+
+        if (!isInOut)
+        {
+            if (isOutput && isGetter)
+                continue;
+            if (!isOutput && isSetter)
+                continue;
+        }
+
+        auto requireAttr = member->findModifier<RequireCapabilityAttribute>();
+        if (!requireAttr || !requireAttr->capabilitySet)
+            continue;
+
+        auto capSet = requireAttr->capabilitySet;
+        if (capSet->getTargetSetCount() > 0)
+        {
+            auto firstTarget = capSet->getTargetSet(0);
+            if (firstTarget->getStageSetCount() > 0)
+            {
+                auto stageAtom = firstTarget->getStageSet(0)->getStage();
+                if (stageAtom != CapabilityAtom::Invalid)
+                {
+                    CapabilitySet pureStage((CapabilityName)stageAtom);
+                    if (pureStage.implies(CapabilitySet{capSet}))
+                        continue;
+                }
+            }
+        }
+
+        accessorCaps.unionWith(requireAttr->capabilitySet);
+    }
+
+    if (!accessorCaps.isEmpty())
+        outCaps.join(accessorCaps);
+}
+
 CapabilitySet getStatementCapabilityUsage(SemanticsVisitor* visitor, Stmt* stmt);
 
 template<typename ProcessFunc, typename ParentDiagnosticFunc>
@@ -14979,111 +15088,8 @@ void SemanticsDeclCapabilityVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
         [this, varDecl](DiagnosticCategory category)
         { _propagateSeeDefinitionOf(this, varDecl, category); });
 
-    // Propagate non-stage capability requirements from system value semantics.
-    //
-    // SV_ semantics in core.meta.slang declare [require()] attributes on their
-    // accessors (getters/setters). These requirements serve two purposes:
-    //   1. Stage restrictions (e.g. [require(fragment)]) — validated separately by
-    //      validateSystemValueSemantic in slang-check-shader.cpp, which produces
-    //      specific diagnostics like "SV_X cannot be used as input in Y stage."
-    //   2. Non-stage capabilities (e.g. [require(fragment, fragmentshaderbarycentric)])
-    //      — need to be propagated through the capability system so the profile
-    //      checker can detect missing capabilities and emit upgrade warnings.
-    //
-    // This block handles case (2). It looks up the SemanticDecl for SV_ modifiers,
-    // finds matching accessors, and propagates their capability requirements — but
-    // only when the accessor requires capabilities beyond what the stage alone
-    // provides. The stage-only check (pureStage.implies) prevents duplicate
-    // diagnostics with validateSystemValueSemantic.
-    //
-    // Scoped to ParamDecl only: the core/GLSL modules use SV_ semantics on
-    // internal struct fields and other declarations where propagating capabilities
-    // would conflict with the module's own capability structure. Struct fields in
-    // user code are handled separately by collectStructFieldSemanticCapabilities
-    // in slang-check-shader.cpp during entry point validation, where the direction
-    // and stage are known.
     if (auto paramDecl = as<ParamDecl>(varDecl))
-    {
-        if (auto semantic = paramDecl->findModifier<HLSLSimpleSemantic>())
-        {
-            auto semanticNameSlice = semantic->name.getContent();
-            if (semanticNameSlice.startsWithCaseInsensitive(toSlice("sv_")))
-            {
-                UnownedStringSlice baseNameSlice, indexSlice;
-                splitNameAndIndex(semanticNameSlice, baseNameSlice, indexSlice);
-
-                auto scope = getSession()->coreLanguageScope;
-                if (scope)
-                {
-                    auto namePool = getASTBuilder()->getGlobalSession()->getNamePool();
-                    String lowerName = String(baseNameSlice).toLower();
-                    auto lookupName = namePool->getName(lowerName);
-                    auto lookupResult =
-                        lookUp(getASTBuilder(), this, lookupName, scope, LookupMask::Semantic);
-
-                    if (lookupResult.isValid())
-                    {
-                        if (auto semanticDecl =
-                                as<SemanticDecl>(lookupResult.item.declRef.getDecl()))
-                        {
-                            bool isOutput = paramDecl->hasModifier<OutModifier>();
-                            bool isInOut = paramDecl->hasModifier<InOutModifier>();
-
-                            if (auto paramType = paramDecl->getType())
-                            {
-                                if (as<MeshOutputType>(paramType) ||
-                                    as<HLSLStreamOutputType>(paramType))
-                                    isOutput = true;
-                            }
-
-                            CapabilitySet accessorCaps;
-                            for (auto member : semanticDecl->getMembers())
-                            {
-                                bool isGetter = as<SemanticGetterDecl>(member) != nullptr;
-                                bool isSetter = as<SemanticSetterDecl>(member) != nullptr;
-                                if (!isGetter && !isSetter)
-                                    continue;
-
-                                if (!isInOut)
-                                {
-                                    if (isOutput && isGetter)
-                                        continue;
-                                    if (!isOutput && isSetter)
-                                        continue;
-                                }
-
-                                auto requireAttr =
-                                    member->findModifier<RequireCapabilityAttribute>();
-                                if (!requireAttr || !requireAttr->capabilitySet)
-                                    continue;
-
-                                auto capSet = requireAttr->capabilitySet;
-                                if (capSet->getTargetSetCount() > 0)
-                                {
-                                    auto firstTarget = capSet->getTargetSet(0);
-                                    if (firstTarget->getStageSetCount() > 0)
-                                    {
-                                        auto stageAtom = firstTarget->getStageSet(0)->getStage();
-                                        if (stageAtom != CapabilityAtom::Invalid)
-                                        {
-                                            CapabilitySet pureStage((CapabilityName)stageAtom);
-                                            if (pureStage.implies(CapabilitySet{capSet}))
-                                                continue;
-                                        }
-                                    }
-                                }
-
-                                accessorCaps.unionWith(requireAttr->capabilitySet);
-                            }
-
-                            if (!accessorCaps.isEmpty())
-                                mutableCapSet.join(accessorCaps);
-                        }
-                    }
-                }
-            }
-        }
-    }
+        _propagateSemanticCapabilities(this, mutableCapSet, paramDecl);
 
     varDecl->inferredCapabilityRequirements = mutableCapSet.freeze(getASTBuilder());
 }

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -14673,51 +14673,6 @@ static void _propagateRequirement(
     }
 };
 
-// Collect non-stage capability requirements from a SemanticDecl's accessors.
-//
-// Iterates the getters/setters of a SemanticDecl, filters by direction, and
-// collects capabilities that go beyond what the stage alone requires. This
-// prevents duplicating stage-only diagnostics produced by
-// validateSystemValueSemantic in slang-check-shader.cpp.
-//
-// Parallel to collectSemanticAccessorCaps in slang-check-shader.cpp, which
-// handles struct fields during entry point validation.
-static void _collectSemanticAccessorCaps(
-    SemanticDecl* semanticDecl,
-    bool isOutput,
-    bool isInOut,
-    Stage stage,
-    CapabilitySet& outCaps)
-{
-    for (auto member : semanticDecl->getMembers())
-    {
-        bool isGetter = as<SemanticGetterDecl>(member) != nullptr;
-        bool isSetter = as<SemanticSetterDecl>(member) != nullptr;
-        if (!isGetter && !isSetter)
-            continue;
-
-        if (!isInOut)
-        {
-            if (isOutput && isGetter)
-                continue;
-            if (!isOutput && isSetter)
-                continue;
-        }
-
-        auto requireAttr = member->findModifier<RequireCapabilityAttribute>();
-        if (!requireAttr || !requireAttr->capabilitySet)
-            continue;
-
-        if (requireAttr->capabilitySet->isIncompatibleWith(getAtomFromStage(stage)))
-            continue;
-
-        if (isStageOnlySemanticRequirement(requireAttr->capabilitySet, stage))
-            continue;
-
-        outCaps.unionWith(requireAttr->capabilitySet);
-    }
-}
-
 // Propagate non-stage capability requirements from system value semantics on a
 // parameter declaration.
 //
@@ -14757,15 +14712,6 @@ static void _propagateSemanticCapabilities(
     if (!semanticDecl)
         return;
 
-    bool isOutput = paramDecl->hasModifier<OutModifier>();
-    bool isInOut = paramDecl->hasModifier<InOutModifier>();
-
-    if (auto paramType = paramDecl->getType())
-    {
-        if (as<MeshOutputType>(paramType) || as<HLSLStreamOutputType>(paramType))
-            isOutput = true;
-    }
-
     // SV_ semantics are only meaningful at entry point boundaries.
     auto parentFunc = as<FunctionDeclBase>(paramDecl->parentDecl);
     if (!parentFunc)
@@ -14775,8 +14721,29 @@ static void _propagateSemanticCapabilities(
         return;
     Stage stage = getStageFromAtom(entryPointAttr->capabilitySet->getTargetStage());
 
+    // Determine direction, matching the InOutModifier-first pattern used by
+    // validateSystemValueSemantic (InOutModifier inherits from OutModifier).
     CapabilitySet accessorCaps;
-    _collectSemanticAccessorCaps(semanticDecl, isOutput, isInOut, stage, accessorCaps);
+    if (paramDecl->hasModifier<InOutModifier>())
+    {
+        collectSemanticAccessorCaps(semanticDecl, SemanticDirection::Input, stage, accessorCaps);
+        collectSemanticAccessorCaps(semanticDecl, SemanticDirection::Output, stage, accessorCaps);
+    }
+    else
+    {
+        bool isOutput = paramDecl->hasModifier<OutModifier>();
+        if (auto paramType = paramDecl->getType())
+        {
+            if (as<MeshOutputType>(paramType) || as<HLSLStreamOutputType>(paramType))
+                isOutput = true;
+        }
+        collectSemanticAccessorCaps(
+            semanticDecl,
+            isOutput ? SemanticDirection::Output : SemanticDirection::Input,
+            stage,
+            accessorCaps);
+    }
+
     if (!accessorCaps.isEmpty())
         outCaps.join(accessorCaps);
 }

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -15063,12 +15063,10 @@ void SemanticsDeclCapabilityVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
                                     auto firstTarget = capSet->getTargetSet(0);
                                     if (firstTarget->getStageSetCount() > 0)
                                     {
-                                        auto stageAtom =
-                                            firstTarget->getStageSet(0)->getStage();
+                                        auto stageAtom = firstTarget->getStageSet(0)->getStage();
                                         if (stageAtom != CapabilityAtom::Invalid)
                                         {
-                                            CapabilitySet pureStage(
-                                                (CapabilityName)stageAtom);
+                                            CapabilitySet pureStage((CapabilityName)stageAtom);
                                             if (pureStage.implies(CapabilitySet{capSet}))
                                                 continue;
                                         }

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -14708,6 +14708,9 @@ static void _collectSemanticAccessorCaps(
         if (!requireAttr || !requireAttr->capabilitySet)
             continue;
 
+        if (requireAttr->capabilitySet->isIncompatibleWith(getAtomFromStage(stage)))
+            continue;
+
         if (isStageOnlySemanticRequirement(requireAttr->capabilitySet, stage))
             continue;
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -14673,23 +14673,6 @@ static void _propagateRequirement(
     }
 };
 
-// Look up a SemanticDecl by name in the given scope.
-// Parallel to lookUpSemanticDecl in slang-check-shader.cpp.
-static SemanticDecl* _lookUpSemanticDecl(
-    ASTBuilder* astBuilder,
-    SemanticsVisitor* visitor,
-    const String& semanticName,
-    Scope* scope)
-{
-    auto namePool = astBuilder->getGlobalSession()->getNamePool();
-    String lowerName = semanticName.toLower();
-    auto name = namePool->getName(lowerName);
-    auto lookupResult = lookUp(astBuilder, visitor, name, scope, LookupMask::Semantic);
-    if (!lookupResult.isValid())
-        return nullptr;
-    return as<SemanticDecl>(lookupResult.item.declRef.getDecl());
-}
-
 // Collect non-stage capability requirements from a SemanticDecl's accessors.
 //
 // Iterates the getters/setters of a SemanticDecl, filters by direction, and
@@ -14697,9 +14680,8 @@ static SemanticDecl* _lookUpSemanticDecl(
 // prevents duplicating stage-only diagnostics produced by
 // validateSystemValueSemantic in slang-check-shader.cpp.
 //
-// Parallel to the accessor loop in collectStructFieldSemanticCapabilities
-// (slang-check-shader.cpp), which handles struct fields during entry point
-// validation.
+// Parallel to collectSemanticAccessorCaps in slang-check-shader.cpp, which
+// handles struct fields during entry point validation.
 static void _collectSemanticAccessorCaps(
     SemanticDecl* semanticDecl,
     bool isOutput,
@@ -14725,21 +14707,8 @@ static void _collectSemanticAccessorCaps(
         if (!requireAttr || !requireAttr->capabilitySet)
             continue;
 
-        auto capSet = requireAttr->capabilitySet;
-        if (capSet->getTargetSetCount() > 0)
-        {
-            auto firstTarget = capSet->getTargetSet(0);
-            if (firstTarget->getStageSetCount() > 0)
-            {
-                auto stageAtom = firstTarget->getStageSet(0)->getStage();
-                if (stageAtom != CapabilityAtom::Invalid)
-                {
-                    CapabilitySet pureStage((CapabilityName)stageAtom);
-                    if (pureStage.implies(CapabilitySet{capSet}))
-                        continue;
-                }
-            }
-        }
+        if (isStageOnlySemanticRequirement(requireAttr->capabilitySet))
+            continue;
 
         outCaps.unionWith(requireAttr->capabilitySet);
     }
@@ -14780,7 +14749,7 @@ static void _propagateSemanticCapabilities(
         return;
 
     auto semanticDecl =
-        _lookUpSemanticDecl(visitor->getASTBuilder(), visitor, String(baseNameSlice), scope);
+        lookUpSemanticDecl(visitor->getASTBuilder(), visitor, String(baseNameSlice), scope);
     if (!semanticDecl)
         return;
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -14686,6 +14686,7 @@ static void _collectSemanticAccessorCaps(
     SemanticDecl* semanticDecl,
     bool isOutput,
     bool isInOut,
+    Stage stage,
     CapabilitySet& outCaps)
 {
     for (auto member : semanticDecl->getMembers())
@@ -14707,7 +14708,7 @@ static void _collectSemanticAccessorCaps(
         if (!requireAttr || !requireAttr->capabilitySet)
             continue;
 
-        if (isStageOnlySemanticRequirement(requireAttr->capabilitySet))
+        if (isStageOnlySemanticRequirement(requireAttr->capabilitySet, stage))
             continue;
 
         outCaps.unionWith(requireAttr->capabilitySet);
@@ -14762,8 +14763,17 @@ static void _propagateSemanticCapabilities(
             isOutput = true;
     }
 
+    // SV_ semantics are only meaningful at entry point boundaries.
+    auto parentFunc = as<FunctionDeclBase>(paramDecl->parentDecl);
+    if (!parentFunc)
+        return;
+    auto entryPointAttr = parentFunc->findModifier<EntryPointAttribute>();
+    if (!entryPointAttr || !entryPointAttr->capabilitySet)
+        return;
+    Stage stage = getStageFromAtom(entryPointAttr->capabilitySet->getTargetStage());
+
     CapabilitySet accessorCaps;
-    _collectSemanticAccessorCaps(semanticDecl, isOutput, isInOut, accessorCaps);
+    _collectSemanticAccessorCaps(semanticDecl, isOutput, isInOut, stage, accessorCaps);
     if (!accessorCaps.isEmpty())
         outCaps.join(accessorCaps);
 }

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -14673,73 +14673,39 @@ static void _propagateRequirement(
     }
 };
 
-// Propagate non-stage capability requirements from system value semantics on a
-// parameter declaration.
-//
-// SV_ semantics in core.meta.slang declare [require()] attributes on their
-// accessors (getters/setters). These requirements serve two purposes:
-//   1. Stage restrictions (e.g. [require(fragment)]) — validated separately by
-//      validateSystemValueSemantic in slang-check-shader.cpp, which produces
-//      specific diagnostics like "SV_X cannot be used as input in Y stage."
-//   2. Non-stage capabilities (e.g. [require(fragment, fragmentshaderbarycentric)])
-//      — need to be propagated through the capability system so the profile
-//      checker can detect missing capabilities and emit upgrade warnings.
-//
-// This function handles case (2). It looks up the SemanticDecl for SV_ modifiers,
-// finds matching accessors, and propagates their capability requirements — but
-// only when the accessor requires capabilities beyond what the stage alone
-// provides. The stage-only check (pureStage.implies) prevents duplicate
-// diagnostics with validateSystemValueSemantic.
-//
-// Scoped to ParamDecl only: the core/GLSL modules use SV_ semantics on
-// internal struct fields and other declarations where propagating capabilities
-// would conflict with the module's own capability structure. Struct fields in
-// user code are handled separately by collectStructFieldSemanticCapabilities
-// in slang-check-shader.cpp during entry point validation, where the direction
-// and stage are known.
-static void _propagateSemanticCapabilities(
+// Look up a SemanticDecl by name in the given scope.
+// Parallel to lookUpSemanticDecl in slang-check-shader.cpp.
+static SemanticDecl* _lookUpSemanticDecl(
+    ASTBuilder* astBuilder,
     SemanticsVisitor* visitor,
-    CapabilitySet& outCaps,
-    ParamDecl* paramDecl)
+    const String& semanticName,
+    Scope* scope)
 {
-    auto semantic = paramDecl->findModifier<HLSLSimpleSemantic>();
-    if (!semantic)
-        return;
-
-    auto semanticNameSlice = semantic->name.getContent();
-    if (!semanticNameSlice.startsWithCaseInsensitive(toSlice("sv_")))
-        return;
-
-    UnownedStringSlice baseNameSlice, indexSlice;
-    splitNameAndIndex(semanticNameSlice, baseNameSlice, indexSlice);
-
-    auto scope = visitor->getSession()->coreLanguageScope;
-    if (!scope)
-        return;
-
-    auto namePool = visitor->getASTBuilder()->getGlobalSession()->getNamePool();
-    String lowerName = String(baseNameSlice).toLower();
-    auto lookupName = namePool->getName(lowerName);
-    auto lookupResult =
-        lookUp(visitor->getASTBuilder(), visitor, lookupName, scope, LookupMask::Semantic);
-
+    auto namePool = astBuilder->getGlobalSession()->getNamePool();
+    String lowerName = semanticName.toLower();
+    auto name = namePool->getName(lowerName);
+    auto lookupResult = lookUp(astBuilder, visitor, name, scope, LookupMask::Semantic);
     if (!lookupResult.isValid())
-        return;
+        return nullptr;
+    return as<SemanticDecl>(lookupResult.item.declRef.getDecl());
+}
 
-    auto semanticDecl = as<SemanticDecl>(lookupResult.item.declRef.getDecl());
-    if (!semanticDecl)
-        return;
-
-    bool isOutput = paramDecl->hasModifier<OutModifier>();
-    bool isInOut = paramDecl->hasModifier<InOutModifier>();
-
-    if (auto paramType = paramDecl->getType())
-    {
-        if (as<MeshOutputType>(paramType) || as<HLSLStreamOutputType>(paramType))
-            isOutput = true;
-    }
-
-    CapabilitySet accessorCaps;
+// Collect non-stage capability requirements from a SemanticDecl's accessors.
+//
+// Iterates the getters/setters of a SemanticDecl, filters by direction, and
+// collects capabilities that go beyond what the stage alone requires. This
+// prevents duplicating stage-only diagnostics produced by
+// validateSystemValueSemantic in slang-check-shader.cpp.
+//
+// Parallel to the accessor loop in collectStructFieldSemanticCapabilities
+// (slang-check-shader.cpp), which handles struct fields during entry point
+// validation.
+static void _collectSemanticAccessorCaps(
+    SemanticDecl* semanticDecl,
+    bool isOutput,
+    bool isInOut,
+    CapabilitySet& outCaps)
+{
     for (auto member : semanticDecl->getMembers())
     {
         bool isGetter = as<SemanticGetterDecl>(member) != nullptr;
@@ -14775,9 +14741,60 @@ static void _propagateSemanticCapabilities(
             }
         }
 
-        accessorCaps.unionWith(requireAttr->capabilitySet);
+        outCaps.unionWith(requireAttr->capabilitySet);
+    }
+}
+
+// Propagate non-stage capability requirements from system value semantics on a
+// parameter declaration.
+//
+// SV_ semantics in core.meta.slang declare [require()] attributes on their
+// accessors (getters/setters). Stage-only requirements are validated by
+// validateSystemValueSemantic (slang-check-shader.cpp); this function
+// propagates non-stage capabilities so the profile checker can detect missing
+// capabilities and emit upgrade warnings.
+//
+// Scoped to ParamDecl only: the core/GLSL modules use SV_ semantics on
+// internal struct fields where propagating capabilities would conflict with
+// the module's capability structure. Struct fields in user entry point
+// parameters are handled by collectStructFieldSemanticCapabilities in
+// slang-check-shader.cpp.
+static void _propagateSemanticCapabilities(
+    SemanticsVisitor* visitor,
+    CapabilitySet& outCaps,
+    ParamDecl* paramDecl)
+{
+    auto semantic = paramDecl->findModifier<HLSLSimpleSemantic>();
+    if (!semantic)
+        return;
+
+    auto semanticNameSlice = semantic->name.getContent();
+    if (!semanticNameSlice.startsWithCaseInsensitive(toSlice("sv_")))
+        return;
+
+    UnownedStringSlice baseNameSlice, indexSlice;
+    splitNameAndIndex(semanticNameSlice, baseNameSlice, indexSlice);
+
+    auto scope = visitor->getSession()->coreLanguageScope;
+    if (!scope)
+        return;
+
+    auto semanticDecl =
+        _lookUpSemanticDecl(visitor->getASTBuilder(), visitor, String(baseNameSlice), scope);
+    if (!semanticDecl)
+        return;
+
+    bool isOutput = paramDecl->hasModifier<OutModifier>();
+    bool isInOut = paramDecl->hasModifier<InOutModifier>();
+
+    if (auto paramType = paramDecl->getType())
+    {
+        if (as<MeshOutputType>(paramType) || as<HLSLStreamOutputType>(paramType))
+            isOutput = true;
     }
 
+    CapabilitySet accessorCaps;
+    _collectSemanticAccessorCaps(semanticDecl, isOutput, isInOut, accessorCaps);
     if (!accessorCaps.isEmpty())
         outCaps.join(accessorCaps);
 }

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -17,6 +17,7 @@
 #include "slang-ast-print.h"
 #include "slang-ast-synthesis.h"
 #include "slang-lookup.h"
+#include "slang-parameter-binding.h"
 #include "slang-parser.h"
 #include "slang-rich-diagnostics.h"
 #include "slang-syntax.h"
@@ -14977,6 +14978,115 @@ void SemanticsDeclCapabilityVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
         { _propagateRequirement(this, mutableCapSet, varDecl, node, nodeCaps, refLoc); },
         [this, varDecl](DiagnosticCategory category)
         { _propagateSeeDefinitionOf(this, varDecl, category); });
+
+    // Propagate non-stage capability requirements from system value semantics.
+    //
+    // SV_ semantics in core.meta.slang declare [require()] attributes on their
+    // accessors (getters/setters). These requirements serve two purposes:
+    //   1. Stage restrictions (e.g. [require(fragment)]) — validated separately by
+    //      validateSystemValueSemantic in slang-check-shader.cpp, which produces
+    //      specific diagnostics like "SV_X cannot be used as input in Y stage."
+    //   2. Non-stage capabilities (e.g. [require(fragment, fragmentshaderbarycentric)])
+    //      — need to be propagated through the capability system so the profile
+    //      checker can detect missing capabilities and emit upgrade warnings.
+    //
+    // This block handles case (2). It looks up the SemanticDecl for SV_ modifiers,
+    // finds matching accessors, and propagates their capability requirements — but
+    // only when the accessor requires capabilities beyond what the stage alone
+    // provides. The stage-only check (pureStage.implies) prevents duplicate
+    // diagnostics with validateSystemValueSemantic.
+    //
+    // Scoped to ParamDecl only: the core/GLSL modules use SV_ semantics on
+    // internal struct fields and other declarations where propagating capabilities
+    // would conflict with the module's own capability structure. Struct fields in
+    // user code are handled separately by collectStructFieldSemanticCapabilities
+    // in slang-check-shader.cpp during entry point validation, where the direction
+    // and stage are known.
+    if (auto paramDecl = as<ParamDecl>(varDecl))
+    {
+        if (auto semantic = paramDecl->findModifier<HLSLSimpleSemantic>())
+        {
+            auto semanticNameSlice = semantic->name.getContent();
+            if (semanticNameSlice.startsWithCaseInsensitive(toSlice("sv_")))
+            {
+                UnownedStringSlice baseNameSlice, indexSlice;
+                splitNameAndIndex(semanticNameSlice, baseNameSlice, indexSlice);
+
+                auto scope = getSession()->coreLanguageScope;
+                if (scope)
+                {
+                    auto namePool = getASTBuilder()->getGlobalSession()->getNamePool();
+                    String lowerName = String(baseNameSlice).toLower();
+                    auto lookupName = namePool->getName(lowerName);
+                    auto lookupResult =
+                        lookUp(getASTBuilder(), this, lookupName, scope, LookupMask::Semantic);
+
+                    if (lookupResult.isValid())
+                    {
+                        if (auto semanticDecl =
+                                as<SemanticDecl>(lookupResult.item.declRef.getDecl()))
+                        {
+                            bool isOutput = paramDecl->hasModifier<OutModifier>();
+                            bool isInOut = paramDecl->hasModifier<InOutModifier>();
+
+                            if (auto paramType = paramDecl->getType())
+                            {
+                                if (as<MeshOutputType>(paramType) ||
+                                    as<HLSLStreamOutputType>(paramType))
+                                    isOutput = true;
+                            }
+
+                            CapabilitySet accessorCaps;
+                            for (auto member : semanticDecl->getMembers())
+                            {
+                                bool isGetter = as<SemanticGetterDecl>(member) != nullptr;
+                                bool isSetter = as<SemanticSetterDecl>(member) != nullptr;
+                                if (!isGetter && !isSetter)
+                                    continue;
+
+                                if (!isInOut)
+                                {
+                                    if (isOutput && isGetter)
+                                        continue;
+                                    if (!isOutput && isSetter)
+                                        continue;
+                                }
+
+                                auto requireAttr =
+                                    member->findModifier<RequireCapabilityAttribute>();
+                                if (!requireAttr || !requireAttr->capabilitySet)
+                                    continue;
+
+                                auto capSet = requireAttr->capabilitySet;
+                                if (capSet->getTargetSetCount() > 0)
+                                {
+                                    auto firstTarget = capSet->getTargetSet(0);
+                                    if (firstTarget->getStageSetCount() > 0)
+                                    {
+                                        auto stageAtom =
+                                            firstTarget->getStageSet(0)->getStage();
+                                        if (stageAtom != CapabilityAtom::Invalid)
+                                        {
+                                            CapabilitySet pureStage(
+                                                (CapabilityName)stageAtom);
+                                            if (pureStage.implies(CapabilitySet{capSet}))
+                                                continue;
+                                        }
+                                    }
+                                }
+
+                                accessorCaps.unionWith(requireAttr->capabilitySet);
+                            }
+
+                            if (!accessorCaps.isEmpty())
+                                mutableCapSet.join(accessorCaps);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     varDecl->inferredCapabilityRequirements = mutableCapSet.freeze(getASTBuilder());
 }
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -70,14 +70,14 @@ SemanticDecl* lookUpSemanticDecl(
 /// set, which would duplicate the more specific diagnostics produced by
 /// validateSystemValueSemantic (e.g. "SV_X cannot be used in Y stage").
 ///
-/// Extracts a stage atom from the capability set and constructs a pure-stage
-/// CapabilitySet, then uses CapabilitySet::implies() to check whether the stage
-/// alone satisfies every alternative in the requirement. The implies() call
-/// checks all target sets and stage sets, so this is comprehensive for the
-/// common case of single-stage accessors. For hypothetical multi-stage
-/// disjunctions (e.g. [require(fragment+capA | compute+capB)]), it
-/// conservatively returns false (non-stage-only), which is the safe direction.
-bool isStageOnlySemanticRequirement(const CapabilitySetVal* capSet);
+/// Constructs a pure-stage CapabilitySet from @p stage, then uses
+/// CapabilitySet::implies() to check whether the stage alone satisfies every
+/// alternative in the requirement. The implies() call checks all target sets
+/// and stage sets, so this is comprehensive for the common case of
+/// single-stage accessors. For hypothetical multi-stage disjunctions (e.g.
+/// [require(fragment+capA | compute+capB)]), it conservatively returns false
+/// (non-stage-only), which is the safe direction.
+bool isStageOnlySemanticRequirement(const CapabilitySetVal* capSet, Stage stage);
 
 /// Create a new component type based on `inComponentType`, but with all its requiremetns filled.
 RefPtr<ComponentType> fillRequirements(ComponentType* inComponentType);

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -55,6 +55,13 @@ bool isUniformParameterType(Type* type);
 
 bool isSlang2026OrLater(SemanticsVisitor* visitor);
 
+/// Direction of a semantic value (input from previous stage, or output to next stage).
+enum class SemanticDirection
+{
+    Input,
+    Output,
+};
+
 /// Look up a SemanticDecl by name in the given scope.
 /// Semantic names in core.meta.slang are stored lowercase for case-insensitive matching.
 SemanticDecl* lookUpSemanticDecl(
@@ -81,6 +88,20 @@ SemanticDecl* lookUpSemanticDecl(
 /// Callers must first filter out accessors incompatible with the current stage
 /// (via isIncompatibleWith), so this only sees capSets compatible with @p stage.
 bool isStageOnlySemanticRequirement(const CapabilitySetVal* capSet, Stage stage);
+
+/// Collect non-stage capability requirements from a SemanticDecl's accessors.
+///
+/// Iterates the getters/setters of a SemanticDecl, filters by direction, skips
+/// accessors incompatible with the given stage, and collects capabilities that go
+/// beyond what the stage alone requires. This prevents duplicating stage-only
+/// diagnostics produced by validateSystemValueSemantic.
+///
+/// For inout parameters, callers should invoke this twice (once per direction).
+void collectSemanticAccessorCaps(
+    SemanticDecl* semanticDecl,
+    SemanticDirection direction,
+    Stage stage,
+    CapabilitySet& outCaps);
 
 /// Create a new component type based on `inComponentType`, but with all its requiremetns filled.
 RefPtr<ComponentType> fillRequirements(ComponentType* inComponentType);

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -55,6 +55,30 @@ bool isUniformParameterType(Type* type);
 
 bool isSlang2026OrLater(SemanticsVisitor* visitor);
 
+/// Look up a SemanticDecl by name in the given scope.
+/// Semantic names in core.meta.slang are stored lowercase for case-insensitive matching.
+SemanticDecl* lookUpSemanticDecl(
+    ASTBuilder* astBuilder,
+    SemanticsVisitor* visitor,
+    const String& semanticName,
+    Scope* scope);
+
+/// Determine whether a semantic accessor's capability requirement is purely a
+/// stage restriction, with no additional non-stage capabilities.
+///
+/// Used to avoid propagating stage-only requirements into the inferred capability
+/// set, which would duplicate the more specific diagnostics produced by
+/// validateSystemValueSemantic (e.g. "SV_X cannot be used in Y stage").
+///
+/// Current approach: construct a CapabilitySet from the accessor's stage atom
+/// alone and check if it implies the full requirement. If so, the requirement
+/// adds nothing beyond the stage and can be skipped. This is a heuristic that
+/// only examines the first target set and first stage set of the capability —
+/// it works correctly for all current semantic declarations, which have a single
+/// stage per accessor, but may need refinement if future semantics use
+/// multi-target or multi-stage disjunctions on a single accessor.
+bool isStageOnlySemanticRequirement(const CapabilitySetVal* capSet);
+
 /// Create a new component type based on `inComponentType`, but with all its requiremetns filled.
 RefPtr<ComponentType> fillRequirements(ComponentType* inComponentType);
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -70,13 +70,13 @@ SemanticDecl* lookUpSemanticDecl(
 /// set, which would duplicate the more specific diagnostics produced by
 /// validateSystemValueSemantic (e.g. "SV_X cannot be used in Y stage").
 ///
-/// Current approach: construct a CapabilitySet from the accessor's stage atom
-/// alone and check if it implies the full requirement. If so, the requirement
-/// adds nothing beyond the stage and can be skipped. This is a heuristic that
-/// only examines the first target set and first stage set of the capability —
-/// it works correctly for all current semantic declarations, which have a single
-/// stage per accessor, but may need refinement if future semantics use
-/// multi-target or multi-stage disjunctions on a single accessor.
+/// Extracts a stage atom from the capability set and constructs a pure-stage
+/// CapabilitySet, then uses CapabilitySet::implies() to check whether the stage
+/// alone satisfies every alternative in the requirement. The implies() call
+/// checks all target sets and stage sets, so this is comprehensive for the
+/// common case of single-stage accessors. For hypothetical multi-stage
+/// disjunctions (e.g. [require(fragment+capA | compute+capB)]), it
+/// conservatively returns false (non-stage-only), which is the safe direction.
 bool isStageOnlySemanticRequirement(const CapabilitySetVal* capSet);
 
 /// Create a new component type based on `inComponentType`, but with all its requiremetns filled.

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -77,6 +77,9 @@ SemanticDecl* lookUpSemanticDecl(
 /// single-stage accessors. For hypothetical multi-stage disjunctions (e.g.
 /// [require(fragment+capA | compute+capB)]), it conservatively returns false
 /// (non-stage-only), which is the safe direction.
+///
+/// Callers must first filter out accessors incompatible with the current stage
+/// (via isIncompatibleWith), so this only sees capSets compatible with @p stage.
 bool isStageOnlySemanticRequirement(const CapabilitySetVal* capSet, Stage stage);
 
 /// Create a new component type based on `inComponentType`, but with all its requiremetns filled.

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -14,12 +14,7 @@
 namespace Slang
 {
 
-// Direction of a semantic value (input from previous stage, or output to next stage)
-enum class SemanticDirection
-{
-    Input,
-    Output,
-};
+// SemanticDirection is declared in slang-check-impl.h
 
 static bool isValidThreadDispatchIDType(Type* type)
 {
@@ -301,16 +296,7 @@ bool isStageOnlySemanticRequirement(const CapabilitySetVal* capSet, Stage stage)
     return pureStage.implies(CapabilitySet{capSet});
 }
 
-// Collect non-stage capability requirements from a SemanticDecl's accessors.
-//
-// Iterates the getters/setters of a SemanticDecl, filters by direction, skips
-// accessors incompatible with the given stage, and collects capabilities that go
-// beyond what the stage alone requires. This prevents duplicating stage-only
-// diagnostics produced by validateSystemValueSemantic.
-//
-// Parallel to _collectSemanticAccessorCaps in slang-check-decl.cpp, which handles
-// direct parameters (and additionally supports inout).
-static void collectSemanticAccessorCaps(
+void collectSemanticAccessorCaps(
     SemanticDecl* semanticDecl,
     SemanticDirection direction,
     Stage stage,
@@ -1086,36 +1072,54 @@ void validateEntryPoint(EntryPoint* entryPoint, DiagnosticSink* sink)
             // Propagate non-stage capability requirements from SV_ semantics
             // on struct fields. Direct parameters are handled by the capability
             // visitor; this covers the struct-based entry point parameter case.
+            // Propagate non-stage capability requirements from SV_ semantics
+            // on struct fields, matching the InOutModifier-first pattern used
+            // by validateSystemValueSemantic above (InOutModifier inherits from
+            // OutModifier, so checking OutModifier alone would misclassify
+            // inout params as output-only).
             CapabilitySet structSemanticCaps;
             for (const auto& param : entryPointFuncDecl->getParameters())
             {
-                SemanticDirection dir = SemanticDirection::Input;
-                if (param->hasModifier<OutModifier>())
-                    dir = SemanticDirection::Output;
+                auto paramType = param->getType();
+                if (!paramType)
+                    continue;
 
-                if (auto paramType = param->getType())
+                if (param->hasModifier<InOutModifier>())
                 {
                     collectStructFieldSemanticCapabilities(
                         &visitor,
                         paramType,
                         stage,
-                        dir,
+                        SemanticDirection::Input,
+                        scope,
+                        structSemanticCaps);
+                    collectStructFieldSemanticCapabilities(
+                        &visitor,
+                        paramType,
+                        stage,
+                        SemanticDirection::Output,
                         scope,
                         structSemanticCaps);
                 }
-
-                if (param->hasModifier<InOutModifier>())
+                else if (param->hasModifier<OutModifier>())
                 {
-                    if (auto paramType = param->getType())
-                    {
-                        collectStructFieldSemanticCapabilities(
-                            &visitor,
-                            paramType,
-                            stage,
-                            SemanticDirection::Output,
-                            scope,
-                            structSemanticCaps);
-                    }
+                    collectStructFieldSemanticCapabilities(
+                        &visitor,
+                        paramType,
+                        stage,
+                        SemanticDirection::Output,
+                        scope,
+                        structSemanticCaps);
+                }
+                else
+                {
+                    collectStructFieldSemanticCapabilities(
+                        &visitor,
+                        paramType,
+                        stage,
+                        SemanticDirection::Input,
+                        scope,
+                        structSemanticCaps);
                 }
             }
             if (!structSemanticCaps.isEmpty())

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -282,17 +282,35 @@ static void validateSystemValueSemanticForType(
 
 bool isStageOnlySemanticRequirement(const CapabilitySetVal* capSet)
 {
-    if (capSet->getTargetSetCount() == 0)
-        return false;
+    // Find a valid stage atom from any target/stage set. We search all of them
+    // rather than assuming [0][0] is valid, in case a target set is empty or
+    // degenerate.
+    CapabilityAtom stageAtom = CapabilityAtom::Invalid;
+    for (Index ti = 0; ti < capSet->getTargetSetCount() && stageAtom == CapabilityAtom::Invalid;
+         ++ti)
+    {
+        auto targetSet = capSet->getTargetSet(ti);
+        for (Index si = 0; si < targetSet->getStageSetCount(); ++si)
+        {
+            stageAtom = targetSet->getStageSet(si)->getStage();
+            if (stageAtom != CapabilityAtom::Invalid)
+                break;
+        }
+    }
 
-    auto firstTarget = capSet->getTargetSet(0);
-    if (firstTarget->getStageSetCount() == 0)
-        return false;
-
-    auto stageAtom = firstTarget->getStageSet(0)->getStage();
     if (stageAtom == CapabilityAtom::Invalid)
         return false;
 
+    // Construct a capability set from just the stage atom and check if it
+    // implies the full requirement. CapabilitySet::implies() checks ALL target
+    // sets and stage sets in capSet, not just the one we extracted the stage
+    // from, so this is a comprehensive check: if the stage alone can satisfy
+    // every alternative in the capability set, it's stage-only.
+    //
+    // If capSet has alternatives with different stages (e.g. a hypothetical
+    // [require(fragment+capA | compute+capB)]), the pure-stage set built from
+    // one stage won't imply the other-stage alternatives, so implies() returns
+    // false and we conservatively report it as non-stage-only.
     CapabilitySet pureStage((CapabilityName)stageAtom);
     return pureStage.implies(CapabilitySet{capSet});
 }

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -282,6 +282,122 @@ static void validateSystemValueSemanticForType(
     }
 }
 
+// Collect non-stage capability requirements from SV_ semantics on struct fields.
+//
+// Direct parameters with SV_ semantics have their capabilities propagated by
+// SemanticsDeclCapabilityVisitor::checkVarDeclCommon. However, struct fields
+// cannot be handled there because the core/GLSL modules use SV_ semantics on
+// internal struct fields where propagating capabilities would conflict with the
+// module's own capability structure.
+//
+// This function handles the struct field case during entry point validation,
+// where the stage and direction are known. It recurses into struct-typed
+// parameters to find fields with SV_ semantics that have non-stage capability
+// requirements (e.g. fragmentshaderbarycentric on SV_Barycentrics).
+static void collectStructFieldSemanticCapabilities(
+    SemanticsVisitor* visitor,
+    Type* type,
+    Stage stage,
+    SemanticDirection direction,
+    Scope* scope,
+    CapabilitySet& outCaps,
+    UInt recursionDepth = 0)
+{
+    static constexpr UInt kMaxRecursionDepth = 128;
+    if (!type || recursionDepth >= kMaxRecursionDepth)
+        return;
+
+    type = unwrapConditionalType(type);
+
+    if (auto meshOutputType = as<MeshOutputType>(type))
+    {
+        type = unwrapConditionalType(meshOutputType->getElementType());
+        direction = SemanticDirection::Output;
+    }
+    else if (auto streamOutputType = as<HLSLStreamOutputType>(type))
+    {
+        type = unwrapConditionalType(streamOutputType->getElementType());
+        direction = SemanticDirection::Output;
+    }
+
+    auto astBuilder = visitor->getASTBuilder();
+
+    auto declRefType = as<DeclRefType>(type);
+    if (!declRefType)
+        return;
+    auto structDeclRef = declRefType->getDeclRef().as<StructDecl>();
+    if (!structDeclRef)
+        return;
+
+    for (auto fieldDeclRef : getFields(astBuilder, structDeclRef, MemberFilterStyle::Instance))
+    {
+        auto fieldDecl = fieldDeclRef.getDecl();
+
+        if (auto fieldType = fieldDecl->getType())
+            collectStructFieldSemanticCapabilities(
+                visitor,
+                fieldType,
+                stage,
+                direction,
+                scope,
+                outCaps,
+                recursionDepth + 1);
+
+        auto semantic = fieldDecl->findModifier<HLSLSimpleSemantic>();
+        if (!semantic)
+            continue;
+
+        auto semanticNameSlice = semantic->name.getContent();
+        if (!semanticNameSlice.startsWithCaseInsensitive(toSlice("sv_")))
+            continue;
+
+        UnownedStringSlice baseNameSlice, indexSlice;
+        splitNameAndIndex(semanticNameSlice, baseNameSlice, indexSlice);
+
+        auto semanticDecl = lookUpSemanticDecl(astBuilder, visitor, String(baseNameSlice), scope);
+        if (!semanticDecl)
+            continue;
+
+        bool isOutput = (direction == SemanticDirection::Output);
+
+        for (auto member : semanticDecl->getMembers())
+        {
+            bool isGetter = as<SemanticGetterDecl>(member) != nullptr;
+            bool isSetter = as<SemanticSetterDecl>(member) != nullptr;
+            if (!isGetter && !isSetter)
+                continue;
+            if (isSetter != isOutput)
+                continue;
+
+            auto requireAttr = member->findModifier<RequireCapabilityAttribute>();
+            if (!requireAttr || !requireAttr->capabilitySet)
+                continue;
+
+            if (requireAttr->capabilitySet->isIncompatibleWith(getAtomFromStage(stage)))
+                continue;
+
+            // Only propagate if the accessor has capabilities beyond the stage.
+            auto capSet = requireAttr->capabilitySet;
+            if (capSet->getTargetSetCount() > 0)
+            {
+                auto firstTarget = capSet->getTargetSet(0);
+                if (firstTarget->getStageSetCount() > 0)
+                {
+                    auto stageAtom = firstTarget->getStageSet(0)->getStage();
+                    if (stageAtom != CapabilityAtom::Invalid)
+                    {
+                        CapabilitySet pureStage((CapabilityName)stageAtom);
+                        if (pureStage.implies(CapabilitySet{capSet}))
+                            continue;
+                    }
+                }
+            }
+
+            outCaps.join(requireAttr->capabilitySet);
+        }
+    }
+}
+
 // Validate system value semantics on a declaration recursively.
 // and validates any SV_ semantic against the SemanticDecl definitions in core module.
 static void validateSystemValueSemantic(
@@ -943,6 +1059,49 @@ void validateEntryPoint(EntryPoint* entryPoint, DiagnosticSink* sink)
                 stage,
                 SemanticDirection::Output,
                 scope);
+
+            // Propagate non-stage capability requirements from SV_ semantics
+            // on struct fields. Direct parameters are handled by the capability
+            // visitor; this covers the struct-based entry point parameter case.
+            CapabilitySet structSemanticCaps;
+            for (const auto& param : entryPointFuncDecl->getParameters())
+            {
+                SemanticDirection dir = SemanticDirection::Input;
+                if (param->hasModifier<OutModifier>())
+                    dir = SemanticDirection::Output;
+
+                if (auto paramType = param->getType())
+                {
+                    collectStructFieldSemanticCapabilities(
+                        &visitor,
+                        paramType,
+                        stage,
+                        dir,
+                        scope,
+                        structSemanticCaps);
+                }
+
+                if (param->hasModifier<InOutModifier>())
+                {
+                    if (auto paramType = param->getType())
+                    {
+                        collectStructFieldSemanticCapabilities(
+                            &visitor,
+                            paramType,
+                            stage,
+                            SemanticDirection::Output,
+                            scope,
+                            structSemanticCaps);
+                    }
+                }
+            }
+            if (!structSemanticCaps.isEmpty())
+            {
+                CapabilitySet entryCaps{entryPointFuncDecl->inferredCapabilityRequirements};
+                entryCaps.join(structSemanticCaps);
+                entryPointFuncDecl->inferredCapabilityRequirements =
+                    entryCaps.freeze(getCurrentASTBuilder());
+            }
         }
     }
 

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -282,6 +282,59 @@ static void validateSystemValueSemanticForType(
     }
 }
 
+// Collect non-stage capability requirements from a SemanticDecl's accessors.
+//
+// Iterates the getters/setters of a SemanticDecl, filters by direction, skips
+// accessors incompatible with the given stage, and collects capabilities that go
+// beyond what the stage alone requires. This prevents duplicating stage-only
+// diagnostics produced by validateSystemValueSemantic.
+//
+// Parallel to _collectSemanticAccessorCaps in slang-check-decl.cpp, which handles
+// direct parameters (and additionally supports inout).
+static void collectSemanticAccessorCaps(
+    SemanticDecl* semanticDecl,
+    SemanticDirection direction,
+    Stage stage,
+    CapabilitySet& outCaps)
+{
+    bool isOutput = (direction == SemanticDirection::Output);
+
+    for (auto member : semanticDecl->getMembers())
+    {
+        bool isGetter = as<SemanticGetterDecl>(member) != nullptr;
+        bool isSetter = as<SemanticSetterDecl>(member) != nullptr;
+        if (!isGetter && !isSetter)
+            continue;
+        if (isSetter != isOutput)
+            continue;
+
+        auto requireAttr = member->findModifier<RequireCapabilityAttribute>();
+        if (!requireAttr || !requireAttr->capabilitySet)
+            continue;
+
+        if (requireAttr->capabilitySet->isIncompatibleWith(getAtomFromStage(stage)))
+            continue;
+
+        auto capSet = requireAttr->capabilitySet;
+        if (capSet->getTargetSetCount() > 0)
+        {
+            auto firstTarget = capSet->getTargetSet(0);
+            if (firstTarget->getStageSetCount() > 0)
+            {
+                auto stageAtom = firstTarget->getStageSet(0)->getStage();
+                if (stageAtom != CapabilityAtom::Invalid)
+                {
+                    CapabilitySet pureStage((CapabilityName)stageAtom);
+                    if (pureStage.implies(CapabilitySet{capSet}))
+                        continue;
+                }
+            }
+        }
+
+        outCaps.join(requireAttr->capabilitySet);
+    }
+}
+
 // Collect non-stage capability requirements from SV_ semantics on struct fields.
 //
 // Direct parameters with SV_ semantics have their capabilities propagated by
@@ -358,43 +411,7 @@ static void collectStructFieldSemanticCapabilities(
         if (!semanticDecl)
             continue;
 
-        bool isOutput = (direction == SemanticDirection::Output);
-
-        for (auto member : semanticDecl->getMembers())
-        {
-            bool isGetter = as<SemanticGetterDecl>(member) != nullptr;
-            bool isSetter = as<SemanticSetterDecl>(member) != nullptr;
-            if (!isGetter && !isSetter)
-                continue;
-            if (isSetter != isOutput)
-                continue;
-
-            auto requireAttr = member->findModifier<RequireCapabilityAttribute>();
-            if (!requireAttr || !requireAttr->capabilitySet)
-                continue;
-
-            if (requireAttr->capabilitySet->isIncompatibleWith(getAtomFromStage(stage)))
-                continue;
-
-            // Only propagate if the accessor has capabilities beyond the stage.
-            auto capSet = requireAttr->capabilitySet;
-            if (capSet->getTargetSetCount() > 0)
-            {
-                auto firstTarget = capSet->getTargetSet(0);
-                if (firstTarget->getStageSetCount() > 0)
-                {
-                    auto stageAtom = firstTarget->getStageSet(0)->getStage();
-                    if (stageAtom != CapabilityAtom::Invalid)
-                    {
-                        CapabilitySet pureStage((CapabilityName)stageAtom);
-                        if (pureStage.implies(CapabilitySet{capSet}))
-                            continue;
-                    }
-                }
-            }
-
-            outCaps.join(requireAttr->capabilitySet);
-        }
+        collectSemanticAccessorCaps(semanticDecl, direction, stage, outCaps);
     }
 }
 

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -88,9 +88,7 @@ static bool isSemanticTypeCompatible(SemanticsVisitor* visitor, Type* expectedTy
     return expectedIsVector == typeIsVector;
 }
 
-// Look up a SemanticDecl by name in the given scope.
-// Semantic names in core.meta.slang are stored lowercase for case-insensitive matching.
-static SemanticDecl* lookUpSemanticDecl(
+SemanticDecl* lookUpSemanticDecl(
     ASTBuilder* astBuilder,
     SemanticsVisitor* visitor,
     const String& semanticName,
@@ -282,6 +280,23 @@ static void validateSystemValueSemanticForType(
     }
 }
 
+bool isStageOnlySemanticRequirement(const CapabilitySetVal* capSet)
+{
+    if (capSet->getTargetSetCount() == 0)
+        return false;
+
+    auto firstTarget = capSet->getTargetSet(0);
+    if (firstTarget->getStageSetCount() == 0)
+        return false;
+
+    auto stageAtom = firstTarget->getStageSet(0)->getStage();
+    if (stageAtom == CapabilityAtom::Invalid)
+        return false;
+
+    CapabilitySet pureStage((CapabilityName)stageAtom);
+    return pureStage.implies(CapabilitySet{capSet});
+}
+
 // Collect non-stage capability requirements from a SemanticDecl's accessors.
 //
 // Iterates the getters/setters of a SemanticDecl, filters by direction, skips
@@ -315,21 +330,8 @@ static void collectSemanticAccessorCaps(
         if (requireAttr->capabilitySet->isIncompatibleWith(getAtomFromStage(stage)))
             continue;
 
-        auto capSet = requireAttr->capabilitySet;
-        if (capSet->getTargetSetCount() > 0)
-        {
-            auto firstTarget = capSet->getTargetSet(0);
-            if (firstTarget->getStageSetCount() > 0)
-            {
-                auto stageAtom = firstTarget->getStageSet(0)->getStage();
-                if (stageAtom != CapabilityAtom::Invalid)
-                {
-                    CapabilitySet pureStage((CapabilityName)stageAtom);
-                    if (pureStage.implies(CapabilitySet{capSet}))
-                        continue;
-                }
-            }
-        }
+        if (isStageOnlySemanticRequirement(requireAttr->capabilitySet))
+            continue;
 
         outCaps.join(requireAttr->capabilitySet);
     }

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -1072,10 +1072,9 @@ void validateEntryPoint(EntryPoint* entryPoint, DiagnosticSink* sink)
             // Propagate non-stage capability requirements from SV_ semantics
             // on struct fields. Direct parameters are handled by the capability
             // visitor; this covers the struct-based entry point parameter case.
-            // Propagate non-stage capability requirements from SV_ semantics
-            // on struct fields, matching the InOutModifier-first pattern used
-            // by validateSystemValueSemantic above (InOutModifier inherits from
-            // OutModifier, so checking OutModifier alone would misclassify
+            // We check InOutModifier before OutModifier, matching the pattern
+            // used by validateSystemValueSemantic above (InOutModifier inherits
+            // from OutModifier, so checking OutModifier alone would misclassify
             // inout params as output-only).
             CapabilitySet structSemanticCaps;
             for (const auto& param : entryPointFuncDecl->getParameters())

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -282,6 +282,9 @@ static void validateSystemValueSemanticForType(
 
 bool isStageOnlySemanticRequirement(const CapabilitySetVal* capSet, Stage stage)
 {
+    if (!capSet)
+        return false;
+
     auto stageAtom = getAtomFromStage(stage);
     if (stageAtom == CapabilityAtom::Invalid)
         return false;
@@ -290,6 +293,10 @@ bool isStageOnlySemanticRequirement(const CapabilitySetVal* capSet, Stage stage)
     // implies the full requirement. CapabilitySet::implies() checks ALL target
     // sets and stage sets in capSet, so this is a comprehensive check: if the
     // stage alone can satisfy every alternative, it's stage-only.
+    //
+    // Callers must first filter out accessors incompatible with the current
+    // stage (via isIncompatibleWith), so this only ever sees capSets that are
+    // compatible with @p stage.
     CapabilitySet pureStage((CapabilityName)stageAtom);
     return pureStage.implies(CapabilitySet{capSet});
 }

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -280,37 +280,16 @@ static void validateSystemValueSemanticForType(
     }
 }
 
-bool isStageOnlySemanticRequirement(const CapabilitySetVal* capSet)
+bool isStageOnlySemanticRequirement(const CapabilitySetVal* capSet, Stage stage)
 {
-    // Find a valid stage atom from any target/stage set. We search all of them
-    // rather than assuming [0][0] is valid, in case a target set is empty or
-    // degenerate.
-    CapabilityAtom stageAtom = CapabilityAtom::Invalid;
-    for (Index ti = 0; ti < capSet->getTargetSetCount() && stageAtom == CapabilityAtom::Invalid;
-         ++ti)
-    {
-        auto targetSet = capSet->getTargetSet(ti);
-        for (Index si = 0; si < targetSet->getStageSetCount(); ++si)
-        {
-            stageAtom = targetSet->getStageSet(si)->getStage();
-            if (stageAtom != CapabilityAtom::Invalid)
-                break;
-        }
-    }
-
+    auto stageAtom = getAtomFromStage(stage);
     if (stageAtom == CapabilityAtom::Invalid)
         return false;
 
     // Construct a capability set from just the stage atom and check if it
     // implies the full requirement. CapabilitySet::implies() checks ALL target
-    // sets and stage sets in capSet, not just the one we extracted the stage
-    // from, so this is a comprehensive check: if the stage alone can satisfy
-    // every alternative in the capability set, it's stage-only.
-    //
-    // If capSet has alternatives with different stages (e.g. a hypothetical
-    // [require(fragment+capA | compute+capB)]), the pure-stage set built from
-    // one stage won't imply the other-stage alternatives, so implies() returns
-    // false and we conservatively report it as non-stage-only.
+    // sets and stage sets in capSet, so this is a comprehensive check: if the
+    // stage alone can satisfy every alternative, it's stage-only.
     CapabilitySet pureStage((CapabilityName)stageAtom);
     return pureStage.implies(CapabilitySet{capSet});
 }
@@ -348,7 +327,7 @@ static void collectSemanticAccessorCaps(
         if (requireAttr->capabilitySet->isIncompatibleWith(getAtomFromStage(stage)))
             continue;
 
-        if (isStageOnlySemanticRequirement(requireAttr->capabilitySet))
+        if (isStageOnlySemanticRequirement(requireAttr->capabilitySet, stage))
             continue;
 
         outCaps.join(requireAttr->capabilitySet);

--- a/tests/diagnostics/capability-check-sv-barycentrics.slang
+++ b/tests/diagnostics/capability-check-sv-barycentrics.slang
@@ -30,3 +30,12 @@ float4 fragmentMainStruct(PSInput input) : SV_Target
 {
     return float4(input.barycentrics, 1.0);
 }
+
+// Test 3: No warning when the capability is already in the profile
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK3):-stage fragment -entry fragmentMainWithCap -target spirv -profile spirv_1_4+spvFragmentBarycentricKHR
+
+[shader("fragment")]
+float4 fragmentMainWithCap(float3 barycentrics : SV_Barycentrics) : SV_Target
+{
+    return float4(barycentrics, 1.0);
+}

--- a/tests/diagnostics/capability-check-sv-barycentrics.slang
+++ b/tests/diagnostics/capability-check-sv-barycentrics.slang
@@ -1,0 +1,32 @@
+// Test that SV_Barycentrics correctly requires the fragmentshaderbarycentric capability.
+
+// Test 1: Direct parameter
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK1):-stage fragment -entry fragmentMain -target spirv -profile spirv_1_6
+
+[shader("fragment")]
+float4 fragmentMain(float3 barycentrics : SV_Barycentrics) : SV_Target
+/*CHECK1:
+       ^^^^^^^^^^^^ profile implicitly upgraded
+       ^^^^^^^^^^^^ entry point 'fragmentMain' uses additional capabilities that are not part of the specified profile 'spirv_1_6'. The profile setting is automatically updated to include these capabilities: 'spvFragmentBarycentricKHR'
+*/
+{
+    return float4(barycentrics, 1.0);
+}
+
+// Test 2: Struct field
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK2):-stage fragment -entry fragmentMainStruct -target spirv -profile spirv_1_6
+
+struct PSInput
+{
+    float3 barycentrics : SV_Barycentrics;
+};
+
+[shader("fragment")]
+float4 fragmentMainStruct(PSInput input) : SV_Target
+/*CHECK2:
+       ^^^^^^^^^^^^^^^^^^ profile implicitly upgraded
+       ^^^^^^^^^^^^^^^^^^ entry point 'fragmentMainStruct' uses additional capabilities that are not part of the specified profile 'spirv_1_6'. The profile setting is automatically updated to include these capabilities: 'spvFragmentBarycentricKHR'
+*/
+{
+    return float4(input.barycentrics, 1.0);
+}


### PR DESCRIPTION
SV_Barycentrics requires the `fragmentshaderbarycentric` capability
(mapping to `SPV_KHR_fragment_shader_barycentric` on SPIR-V, `sm_6_1` on
HLSL, and Metal's barycentric support), but the semantic declaration in
`core.meta.slang` only required the `fragment` stage. This meant compiling
a shader using `SV_Barycentrics` with `-target spirv -profile spirv_1_6`
produced no warning about the missing capability.

**Changes:**

- Add `fragmentshaderbarycentric` to the `[require]` attribute on the
  `sv_barycentrics` getter in `core.meta.slang`.
- Propagate non-stage capability requirements from system value semantic
  accessors to entry point parameters via `SemanticsDeclCapabilityVisitor`
  in `slang-check-decl.cpp`, so the profile checker can detect and report
  missing capabilities.
- For struct-based entry point parameters, handle capability propagation
  from struct fields during entry point validation in
  `slang-check-shader.cpp`, where the direction and stage context are
  known.
- Refactor shared helpers (`lookUpSemanticDecl`, `isStageOnlySemanticRequirement`)
  into `slang-check-impl.h` and extract accessor capability collection into
  dedicated functions in both `slang-check-decl.cpp` and `slang-check-shader.cpp`.
- Add diagnostic test covering both direct-parameter and struct-field
  cases.

Fixes #10584

Made with [Cursor](https://cursor.com)