### PR TITLE
Fix uninitalized ASTBuiler

### DIFF
--- a/source/slang/slang-module.cpp
+++ b/source/slang/slang-module.cpp
@@ -278,6 +278,8 @@ SLANG_NO_THROW SlangResult SLANG_MCALL Module::serialize(ISlangBlob** outSeriali
 
 SLANG_NO_THROW SlangResult SLANG_MCALL Module::writeToFile(char const* fileName)
 {
+    SLANG_AST_BUILDER_RAII(m_astBuilder);
+
     SerialContainerUtil::WriteOptions writeOptions;
     FileStream fileStream;
     SLANG_RETURN_ON_FAIL(fileStream.init(fileName, FileMode::Create));


### PR DESCRIPTION
When the user application calls, IModule::serialzie(), the "current-builder" was not initialized and it was using one from the previous run that became invalid.

This PR sets the "current-builder" at the beginning of IModule::serialize() to void crashes.