### PR TITLE
Disable DXC backend CoopVec multiply tests with matrix

### DIFF
--- a/tests/cooperative-vector/matrix-mul-bias-mut.slang
+++ b/tests/cooperative-vector/matrix-mul-bias-mut.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_9 -Xslang... -Xdxc -Vd -X.
 
-//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
+//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
 //DXIL: result code = 0
 
 // CHECK: type: half

--- a/tests/cooperative-vector/matrix-mul-bias-packed-mut.slang
+++ b/tests/cooperative-vector/matrix-mul-bias-packed-mut.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_9 -Xslang... -Xdxc -Vd -X.
 
-//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
+//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
 //DXIL: result code = 0
 
 // CHECK: type: int32_t

--- a/tests/cooperative-vector/matrix-mul-bias-packed.slang
+++ b/tests/cooperative-vector/matrix-mul-bias-packed.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_9 -Xslang... -Xdxc -Vd -X.
 
-//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
+//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
 //DXIL: result code = 0
 
 // CHECK: type: int32_t

--- a/tests/cooperative-vector/matrix-mul-bias.slang
+++ b/tests/cooperative-vector/matrix-mul-bias.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_9 -Xslang... -Xdxc -Vd -X.
 
-//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
+//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
 //DXIL: result code = 0
 
 // CHECK: type: half

--- a/tests/cooperative-vector/matrix-mul-byteaddress.slang
+++ b/tests/cooperative-vector/matrix-mul-byteaddress.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_9 -Xslang... -Xdxc -Vd -X.
 
-//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
+//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
 //DXIL: result code = 0
 
 // CHECK: type: half

--- a/tests/cooperative-vector/matrix-mul-mut.slang
+++ b/tests/cooperative-vector/matrix-mul-mut.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_9 -Xslang... -Xdxc -Vd -X.
 
-//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
+//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
 //DXIL: result code = 0
 
 // CHECK: type: half

--- a/tests/cooperative-vector/matrix-mul-packed-mut.slang
+++ b/tests/cooperative-vector/matrix-mul-packed-mut.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_9 -Xslang... -Xdxc -Vd -X.
 
-//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
+//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
 //DXIL: result code = 0
 
 // CHECK: type: int32_t

--- a/tests/cooperative-vector/matrix-mul-packed.slang
+++ b/tests/cooperative-vector/matrix-mul-packed.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_9 -Xslang... -Xdxc -Vd -X.
 
-//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
+//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
 //DXIL: result code = 0
 
 // CHECK: type: int32_t

--- a/tests/cooperative-vector/matrix-mul.slang
+++ b/tests/cooperative-vector/matrix-mul.slang
@@ -2,7 +2,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_9 -Xslang... -Xdxc -Vd -X.
 
-//TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
+//DISABLE_TEST(compute):SIMPLE(filecheck=DXIL):-target dxil -profile cs_6_9 -entry computeMain
 //DXIL: result code = 0
 
 // CHECK: type: half


### PR DESCRIPTION
Currently two submodules try to copy dxcompiler.dll to `build/{Config}/bin` directory when you build with cmake: slang-binaries and slang-rhi.

dxcompiler.dll from slang-binaries is a custom built binary to support the coopertive-vector early last year. We should switch over to use dxcompiler.dll that comes from the official dxc package that slang-rhi uses.

Unfortunately, if dxcompiler.dll from slang-rhi is used, some of the tests for cooperative-vector multiplication with matrix fails. CI machines tend to end up using dxcompiler.dll from slang-binaries submodule but I have seen it coming from slang-rhi when I build locally.

This problem was discovered and addressed while I was preparing a PR:
 https://github.com/shader-slang/slang/pull/10550

But it had been in a review process too long and I decided to disable those problematic tests for now as early as possible to resolve intermittent CI failures or unexpected local testing failures.

Those tests will be re-enabled when the PR 10550 is merged.