### PR TITLE
Add Vulkan gfx-unit-tests to no-GPU expected failure list

### DIFF
--- a/tests/expected-failure-no-gpu.txt
+++ b/tests/expected-failure-no-gpu.txt
@@ -1,9 +1,9 @@
 # RecordReplay tests require a GPU
-slang-unit-test-tool/RecordReplay_triangle.internal
-slang-unit-test-tool/RecordReplay_ray_tracing.internal
-slang-unit-test-tool/RecordReplay_ray_tracing_pipeline.internal
-slang-unit-test-tool/RecordReplay_autodiff_texture.internal
-slang-unit-test-tool/RecordReplay_gpu_printing.internal
+slang-unit-test-tool/replayRecord_triangle.internal
+slang-unit-test-tool/replayRecord_ray_tracing.internal
+slang-unit-test-tool/replayRecord_ray_tracing_pipeline.internal
+slang-unit-test-tool/replayRecord_autodiff_texture.internal
+slang-unit-test-tool/replayRecord_gpu_printing.internal
 
 # CUDA tests require a GPU
 slang-unit-test-tool/cudaCodeGenBug.internal
@@ -19,7 +19,7 @@ gfx-unit-test-tool/linkTimeConstantStructOffsetsVulkan.internal
 gfx-unit-test-tool/linkTimeConstantVulkan.internal
 gfx-unit-test-tool/linkTimeDefaultVulkan.internal
 gfx-unit-test-tool/linkTimeLogicalOperatorsVulkan.internal
-gfx-unit-test-tool/linkTimeTypeGenerictVulkan.internal
+gfx-unit-test-tool/linkTimeTypeGenericVulkan.internal
 gfx-unit-test-tool/linkTimeTypeLayoutCache.internal
 gfx-unit-test-tool/linkTimeTypeLayoutNested.internal
 gfx-unit-test-tool/linkTimeTypeLayout.internal

--- a/tools/gfx-unit-test/link-time-type-generic.cpp
+++ b/tools/gfx-unit-test/link-time-type-generic.cpp
@@ -221,7 +221,7 @@ SLANG_UNIT_TEST(linkTimeTypeGenericD3D12)
     runTestImpl(linkTimeTypeGenericTestImpl, unitTestContext, DeviceType::D3D12);
 }
 
-SLANG_UNIT_TEST(linkTimeTypeGenerictVulkan)
+SLANG_UNIT_TEST(linkTimeTypeGenericVulkan)
 {
     runTestImpl(linkTimeTypeGenericTestImpl, unitTestContext, DeviceType::Vulkan);
 }


### PR DESCRIPTION
Coverage CI runs on GitHub-hosted ubuntu-22.04 runners without a GPU, causing 24 Vulkan gfx-unit-tests to fail consistently. These tests require a Vulkan-capable device and pass in normal CI which uses self-hosted GPU runners.