### PR TITLE
Add workflow to track PR source on project board

### DIFF
--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -92,7 +92,7 @@ jobs:
             console.log(`Added PR to project, item ID: ${itemId}`);
 
             // Set the Source field
-            await github.graphql(`
+            const updateResult = await github.graphql(`
               mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
                 updateProjectV2ItemFieldValue(input: {
                   projectId: $projectId,
@@ -109,5 +109,9 @@ jobs:
               fieldId: SOURCE_FIELD_ID,
               optionId: optionId,
             });
+
+            if (!updateResult?.updateProjectV2ItemFieldValue?.projectV2Item?.id) {
+              throw new Error('Failed to set Source field: unexpected response');
+            }
 
             console.log(`Set Source field to: ${source}`);


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that triggers on PR creation
- Automatically adds the PR to [project board #13](https://github.com/orgs/shader-slang/projects/13/views/1)
- Sets the "Source" field to "Internal" (dev team member) or "Community" (external contributor)
- Uses `pull_request_target` so secrets are available for fork PRs (workflow never checks out PR code)