### PR TITLE
Fix Windows build race: proxy DLL .ilk collision

### DIFF
--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -395,7 +395,8 @@ include(\"${slang_SOURCE_DIR}/cmake/RegenerateDllExports.cmake\")
         RUNTIME_OUTPUT_DIRECTORY "${slang_runtime_dir}"
         ARCHIVE_OUTPUT_DIRECTORY "${slang_archive_dir}"
     )
-    
+    target_link_options(slang-proxy PRIVATE "$<$<CXX_COMPILER_ID:MSVC>:/INCREMENTAL:NO>")
+
     # Install the proxy DLL alongside slang-compiler.dll
     install(
         TARGETS slang-proxy


### PR DESCRIPTION
## Summary
- Both `slang-proxy` (`slang.dll`) and `slang-dispatcher` (`slang.exe`) output to the same directory with the same base name `slang`, causing MSVC to produce conflicting `Debug\bin\slang.ilk` incremental link files when Ninja links them in parallel
- This results in `LNK1104: cannot open file 'Debug\bin\slang.ilk'` on every Windows debug build since PR #10684 changed the Ninja dependency graph enough to expose this latent race
- Fix: disable incremental linking for the proxy DLL — it's a trivial forwarding stub that doesn't benefit from it

## Test plan
- [ ] Windows debug CI build passes (currently failing on every run)
- [ ] Sccache populate workflow recovers

🤖 Generated with [Claude Code](https://claude.ai/claude-code)