### PR TITLE
Fix Windows build race: proxy DLL .pdb collision

### DIFF
--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -392,6 +392,7 @@ include(\"${slang_SOURCE_DIR}/cmake/RegenerateDllExports.cmake\")
     # Set output name to slang (produces slang.dll) and match directories
     set_target_properties(slang-proxy PROPERTIES
         OUTPUT_NAME slang
+        PDB_NAME slang-proxy
         RUNTIME_OUTPUT_DIRECTORY "${slang_runtime_dir}"
         ARCHIVE_OUTPUT_DIRECTORY "${slang_archive_dir}"
     )


### PR DESCRIPTION
## Summary
- Follow-up to #10698 which fixed the `.ilk` collision
- Both `slang-proxy` (`slang.dll`) and `slang-dispatcher` (`slang.exe`) still write to `Debug\bin\slang.pdb`, causing `LNK1201` when Ninja links them in parallel
- Fix: set `PDB_NAME slang-proxy` so the proxy writes to `slang-proxy.pdb` instead

## Test plan
- [ ] Windows debug CI build passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)