### PR TITLE
Fix PR project workflow to check org membership instead of team

### DIFF
--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,7 +1,7 @@
 name: Add PR to Project Board
 
 # Adds new PRs to the shader-slang project board and sets the "Source" field
-# to "Internal" (dev team member) or "Community" (everyone else).
+# to "Internal" (org member) or "Community" (everyone else).
 #
 # Uses pull_request_target so secrets are available for fork PRs.
 # This workflow only reads PR metadata and makes API calls — it never
@@ -17,22 +17,21 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Check if PR author is in dev team
-        id: check_team
+      - name: Check if PR author is in shader-slang org
+        id: check_org
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.SLANGBOT_MEMBERS_READONLY }}
           script: |
             const username = context.payload.pull_request.user.login;
-            let isTeamMember = false;
+            let isOrgMember = false;
 
             try {
-              await github.rest.teams.getMembershipForUserInOrg({
+              await github.rest.orgs.checkMembershipForUser({
                 org: 'shader-slang',
-                team_slug: 'dev',
                 username,
               });
-              isTeamMember = true;
+              isOrgMember = true;
             } catch (error) {
               if (error.status !== 404) {
                 throw error;
@@ -40,14 +39,14 @@ jobs:
             }
 
             console.log(`PR author: ${username}`);
-            console.log(`Is dev team member: ${isTeamMember}`);
+            console.log(`Is org member: ${isOrgMember}`);
 
-            core.setOutput('source', isTeamMember ? 'Internal' : 'Community');
+            core.setOutput('source', isOrgMember ? 'Internal' : 'Community');
 
       - name: Add PR to project board and set Source field
         uses: actions/github-script@v7
         env:
-          SOURCE: ${{ steps.check_team.outputs.source }}
+          SOURCE: ${{ steps.check_org.outputs.source }}
         with:
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           script: |


### PR DESCRIPTION
## Summary
- The add-pr-to-project workflow was checking `dev` team membership, but the intent is to classify all shader-slang org members as Internal
- Switches from `teams.getMembershipForUserInOrg` to `orgs.checkMembershipForUser`