### PR TITLE
Fix sccache cache misses for macOS and Linux aarch64 builds

### DIFF
--- a/.github/workflows/populate-sccache.yml
+++ b/.github/workflows/populate-sccache.yml
@@ -123,7 +123,8 @@ jobs:
             -DSLANG_ENABLE_PCH=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER="${sccache_path}" \
             -DCMAKE_CXX_COMPILER_LAUNCHER="${sccache_path}" \
-            -DCMAKE_COMPILE_WARNING_AS_ERROR=true
+            -DCMAKE_COMPILE_WARNING_AS_ERROR=true \
+            -DSLANG_IGNORE_ABORT_MSG=ON
           cmake --build --preset release -j"$(sysctl -n hw.ncpu)"
 
       - name: Save sccache cache
@@ -177,7 +178,8 @@ jobs:
             -DSLANG_ENABLE_PCH=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER="${sccache_path}" \
             -DCMAKE_CXX_COMPILER_LAUNCHER="${sccache_path}" \
-            -DCMAKE_COMPILE_WARNING_AS_ERROR=true
+            -DCMAKE_COMPILE_WARNING_AS_ERROR=true \
+            -DSLANG_IGNORE_ABORT_MSG=ON
           cmake --build --preset debug -j"$(sysctl -n hw.ncpu)"
 
       - name: Save sccache cache
@@ -231,7 +233,8 @@ jobs:
             -DSLANG_ENABLE_PCH=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER="${sccache_path}" \
             -DCMAKE_CXX_COMPILER_LAUNCHER="${sccache_path}" \
-            -DCMAKE_COMPILE_WARNING_AS_ERROR=false
+            -DCMAKE_COMPILE_WARNING_AS_ERROR=false \
+            -DSLANG_IGNORE_ABORT_MSG=ON
           cmake --build --preset release -j$(nproc)
 
       - name: Save sccache cache
@@ -285,7 +288,8 @@ jobs:
             -DSLANG_ENABLE_PCH=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER="${sccache_path}" \
             -DCMAKE_CXX_COMPILER_LAUNCHER="${sccache_path}" \
-            -DCMAKE_COMPILE_WARNING_AS_ERROR=false
+            -DCMAKE_COMPILE_WARNING_AS_ERROR=false \
+            -DSLANG_IGNORE_ABORT_MSG=ON
           cmake --build --preset debug -j$(nproc)
 
       - name: Save sccache cache


### PR DESCRIPTION
## Summary
- Add `-DSLANG_IGNORE_ABORT_MSG=ON` to the 4 inline cmake configure commands in `populate-sccache.yml` (macOS release/debug, Linux aarch64 release/debug)
- This flag was added to `ci-slang-build.yml` in #10637 but not to the populate workflow's inline steps, causing `SLANG_IGNORE_ABORT_MSG=1` to be defined in CI builds but not in the populate cache — every sccache lookup is a miss due to differing compiler flags
- Windows builds were unaffected because they reuse `ci-slang-build.yml` (which already includes the flag)
- macOS builds have been at 0% sccache hit rate since March 23, adding ~7-8 minutes to each macOS build

## Test plan
- [ ] Verify populate-sccache workflow succeeds after merge
- [ ] Check sccache statistics in the next macOS CI build show >90% hit rate
- [ ] Confirm macOS build times drop back to ~10 minutes