### PR TITLE
Diagnose unconstrained generic specialization with existential type (#10263)

### DIFF
--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -5044,6 +5044,9 @@ struct TypeFlowSpecializationContext
         HashSet<IRInst*> processedSet;
         while (globalWorkList.hasItems())
         {
+            if (sink->getErrorCount() > 0)
+                break;
+
             auto globalInst = globalWorkList.dequeue();
 
             switch (globalInst->getOp())
@@ -5057,6 +5060,10 @@ struct TypeFlowSpecializationContext
                     hasChanges |= removeAnnotations(func);
                     hasChanges |= eliminateDeadCode(func);
                     hasChanges |= specializeFunc(func, globalWorkList);
+
+                    if (sink->getErrorCount() > 0)
+                        break;
+
                     hasChanges |= eliminateDeadCode(func);
                     hasChanges |= resolveTypesInFunc(func);
 
@@ -6339,12 +6346,18 @@ struct TypeFlowSpecializationContext
                     globalsWorkList.enqueue(callee);
                 }
             }
+            else if (auto specCallee = as<IRSpecialize>(callee))
+            {
+                // The callee is an IRSpecialize with set-tag-typed args that is NOT
+                // a set-specialized generic. This happens when an existential type
+                // flows into an unconstrained generic (no interface constraint), so
+                // the typeflow pass cannot generate dispatch code. Emit E33180.
+                emitExistentialSpecializationDiagnostic(specCallee, inst->sourceLoc, inst);
+                module->getContainerPool().free(&callArgs);
+                return false;
+            }
             else
             {
-                // If we reach here, then something is wrong. Our callee is an inst of
-                // tag-type, but we could not resolve it through the dispatch action
-                // collection or set-specialized generic paths.
-                //
                 SLANG_UNEXPECTED(
                     "Unexpected operand type for type-flow specialization of Call inst");
             }
@@ -7606,13 +7619,15 @@ struct TypeFlowSpecializationContext
     {
         bool hasChanges = false;
 
+        auto errorsBefore = sink->getErrorCount();
+
         // Part 1: Information Propagation
         //    This phase propagates type information through the module
         //    and records them into different maps in the current context.
         //
         performInformationPropagation();
 
-        if (sink->getErrorCount() > 0)
+        if (sink->getErrorCount() > errorsBefore)
         {
             // If there were errors during propagation, we bail out early.
             return false;

--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -7058,6 +7058,16 @@ struct TypeFlowSpecializationContext
                 args.getCount(),
                 args.getBuffer());
 
+            // Preserve existential-specialization diagnostics when rewriting a
+            // specialize instruction into its lowered form. Without this, the
+            // shared checker can miss post-rewrite IRSpecialize nodes.
+            if (inst->findDecoration<IRDisallowSpecializationWithExistentialsDecoration>())
+            {
+                builder.addDecoration(
+                    newInst,
+                    kIROp_DisallowSpecializationWithExistentialsDecoration);
+            }
+
             inst->replaceUsesWith(newInst);
             inst->removeAndDeallocate();
         }

--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -3675,13 +3675,6 @@ struct TypeFlowSpecializationContext
                             typeOfSpecialization,
                             arg,
                             specializationArgs);
-                        if (inst->findDecoration<
-                                IRDisallowSpecializationWithExistentialsDecoration>())
-                        {
-                            builder.addDecoration(
-                                newSpec,
-                                kIROp_DisallowSpecializationWithExistentialsDecoration);
-                        }
                         specializedSet.add(newSpec);
                     });
             }
@@ -3692,12 +3685,6 @@ struct TypeFlowSpecializationContext
                 builder.setInsertInto(module);
                 auto newSpec =
                     builder.emitSpecializeInst(typeOfSpecialization, operand, specializationArgs);
-                if (inst->findDecoration<IRDisallowSpecializationWithExistentialsDecoration>())
-                {
-                    builder.addDecoration(
-                        newSpec,
-                        kIROp_DisallowSpecializationWithExistentialsDecoration);
-                }
                 specializedSet.add(newSpec);
             }
 
@@ -7063,16 +7050,6 @@ struct TypeFlowSpecializationContext
                 inst->getBase(),
                 args.getCount(),
                 args.getBuffer());
-
-            // Preserve existential-specialization diagnostics when rewriting a
-            // specialize instruction into its lowered form. Without this, the
-            // shared checker can miss post-rewrite IRSpecialize nodes.
-            if (inst->findDecoration<IRDisallowSpecializationWithExistentialsDecoration>())
-            {
-                builder.addDecoration(
-                    newInst,
-                    kIROp_DisallowSpecializationWithExistentialsDecoration);
-            }
 
             inst->replaceUsesWith(newInst);
             inst->removeAndDeallocate();

--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -3671,10 +3671,18 @@ struct TypeFlowSpecializationContext
                             return;
                         }
 
-                        specializedSet.add(builder.emitSpecializeInst(
+                        auto newSpec = builder.emitSpecializeInst(
                             typeOfSpecialization,
                             arg,
-                            specializationArgs));
+                            specializationArgs);
+                        if (inst->findDecoration<
+                                IRDisallowSpecializationWithExistentialsDecoration>())
+                        {
+                            builder.addDecoration(
+                                newSpec,
+                                kIROp_DisallowSpecializationWithExistentialsDecoration);
+                        }
+                        specializedSet.add(newSpec);
                     });
             }
             else
@@ -3682,8 +3690,15 @@ struct TypeFlowSpecializationContext
                 // Concrete case..
                 IRBuilder builder(module);
                 builder.setInsertInto(module);
-                specializedSet.add(
-                    builder.emitSpecializeInst(typeOfSpecialization, operand, specializationArgs));
+                auto newSpec =
+                    builder.emitSpecializeInst(typeOfSpecialization, operand, specializationArgs);
+                if (inst->findDecoration<IRDisallowSpecializationWithExistentialsDecoration>())
+                {
+                    builder.addDecoration(
+                        newSpec,
+                        kIROp_DisallowSpecializationWithExistentialsDecoration);
+                }
+                specializedSet.add(newSpec);
             }
 
             IRBuilder builder(module);
@@ -6348,19 +6363,10 @@ struct TypeFlowSpecializationContext
             }
             else if (auto specCallee = as<IRSpecialize>(callee))
             {
-                // The callee is an IRSpecialize whose args lack IRSetBase elements
-                // (isSetSpecializedGeneric returned false), meaning the generic has
-                // no interface constraint — an existential type flowed into an
-                // unconstrained generic, so dispatch code cannot be generated.
-                //
-                // Note: isInvalidExistentialSpecialization is not applicable here.
-                // It checks pre-typeflow representations (ExtractExistentialType,
-                // InterfaceType, etc.), but by this point the typeflow pass has
-                // transformed existential args into set-tag ops (e.g.,
-                // GetTagFromTaggedUnion with IRSetTagType). The code structure
-                // itself provides the guard: only unconstrained-generic callees
-                // that escaped both the dispatch-action and set-specialized-generic
-                // paths reach this branch.
+                // The callee is an IRSpecialize that escaped both the dispatch-action
+                // and set-specialized-generic resolution paths. This happens when an
+                // existential type flows into an unconstrained generic (no interface
+                // constraint), so the typeflow pass cannot generate dispatch code.
                 emitExistentialSpecializationDiagnostic(specCallee, inst->sourceLoc, inst);
                 module->getContainerPool().free(&callArgs);
                 return false;
@@ -7638,25 +7644,16 @@ struct TypeFlowSpecializationContext
     {
         bool hasChanges = false;
 
-        auto errorsBefore = sink->getErrorCount();
-
         // Part 1: Information Propagation
         //    This phase propagates type information through the module
         //    and records them into different maps in the current context.
         //
         performInformationPropagation();
 
-        if (sink->getErrorCount() > errorsBefore)
-        {
-            // If there were errors during propagation, we bail out early.
-            return false;
-        }
-
         if (sink->getErrorCount() > 0)
         {
-            // Pre-existing errors from earlier passes: propagation (read-only) ran
-            // to collect its own diagnostics, but don't mutate IR in the lowering
-            // phase when the module is already known-invalid.
+            // If there are any diagnostics after propagation, don't continue into
+            // the mutating lowering phase.
             return false;
         }
 

--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -6348,10 +6348,19 @@ struct TypeFlowSpecializationContext
             }
             else if (auto specCallee = as<IRSpecialize>(callee))
             {
-                // The callee is an IRSpecialize with set-tag-typed args that is NOT
-                // a set-specialized generic. This happens when an existential type
-                // flows into an unconstrained generic (no interface constraint), so
-                // the typeflow pass cannot generate dispatch code. Emit E33180.
+                // The callee is an IRSpecialize whose args lack IRSetBase elements
+                // (isSetSpecializedGeneric returned false), meaning the generic has
+                // no interface constraint — an existential type flowed into an
+                // unconstrained generic, so dispatch code cannot be generated.
+                //
+                // Note: isInvalidExistentialSpecialization is not applicable here.
+                // It checks pre-typeflow representations (ExtractExistentialType,
+                // InterfaceType, etc.), but by this point the typeflow pass has
+                // transformed existential args into set-tag ops (e.g.,
+                // GetTagFromTaggedUnion with IRSetTagType). The code structure
+                // itself provides the guard: only unconstrained-generic callees
+                // that escaped both the dispatch-action and set-specialized-generic
+                // paths reach this branch.
                 emitExistentialSpecializationDiagnostic(specCallee, inst->sourceLoc, inst);
                 module->getContainerPool().free(&callArgs);
                 return false;
@@ -7630,6 +7639,14 @@ struct TypeFlowSpecializationContext
         if (sink->getErrorCount() > errorsBefore)
         {
             // If there were errors during propagation, we bail out early.
+            return false;
+        }
+
+        if (sink->getErrorCount() > 0)
+        {
+            // Pre-existing errors from earlier passes: propagation (read-only) ran
+            // to collect its own diagnostics, but don't mutate IR in the lowering
+            // phase when the module is already known-invalid.
             return false;
         }
 

--- a/tests/language-feature/dynamic-dispatch/diagnose-specialize-unconstrained-generic-with-assoc-type.slang
+++ b/tests/language-feature/dynamic-dispatch/diagnose-specialize-unconstrained-generic-with-assoc-type.slang
@@ -1,13 +1,12 @@
 // When the return value of an interface method (whose type is an associated
 // type) is passed to an unconstrained generic function, the type parameter
-// cannot be statically resolved. The compiler should emit error 33180, but
-// currently produces an internal compiler error (99999) instead.
+// cannot be statically resolved. The compiler must emit error 33180 instead
+// of crashing.
 
-// Disabled: ICE -- should emit error 33180 but crashes with error 99999
-//DISABLE_TEST:SIMPLE(filecheck=CHECK): -target spirv
-//DISABLE_TEST:SIMPLE(filecheck=CHECK): -target hlsl -stage compute -entry computeMain
-//DISABLE_TEST:SIMPLE(filecheck=CHECK): -target glsl -stage compute -entry computeMain
-//DISABLE_TEST:SIMPLE(filecheck=CHECK): -target metal -stage compute -entry computeMain
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target spirv
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target hlsl -stage compute -entry computeMain
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target glsl -stage compute -entry computeMain
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target metal -stage compute -entry computeMain
 
 #lang slang 2025
 
@@ -45,7 +44,8 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     ITransform obj = factory(dispatchThreadID.x);
     var result = obj.transform(1.0);
-    // CHECK: ([[# @LINE+1]]): error 33180
     let processed = process(result);
+//CHECK:                   ^ cannot specialize generic with existential type
+//CHECK:                   ^ specializing 'process' with an existential type is not allowed. All generic arguments must be statically resolvable at compile time.
     outputBuffer[0] = 0;
 }

--- a/tests/language-feature/dynamic-dispatch/diagnose-unconstrained-generic-func.slang
+++ b/tests/language-feature/dynamic-dispatch/diagnose-unconstrained-generic-func.slang
@@ -1,18 +1,13 @@
 // An unconstrained generic function cannot be specialized with an
 // existential type because the concrete type is not known at compile
 // time. When the generic type parameter T is inferred from an
-// interface-typed argument, the compiler must reject the call.
-//
-// Unlike the constrained case (T : IFoo), where the compiler
-// recognizes the pattern and emits error 33180, unconstrained generics
-// currently crash with an internal compiler error (99999) during
-// type-flow specialization instead of producing a diagnostic.
+// interface-typed argument, the compiler must reject the call with
+// error 33180 instead of crashing.
 
-// Disabled: ICE -- should emit error 33180 but crashes with error 99999
-//DISABLE_TEST:SIMPLE(filecheck=CHECK): -target spirv
-//DISABLE_TEST:SIMPLE(filecheck=CHECK): -target hlsl -stage compute -entry computeMain
-//DISABLE_TEST:SIMPLE(filecheck=CHECK): -target glsl -stage compute -entry computeMain
-//DISABLE_TEST:SIMPLE(filecheck=CHECK): -target metal -stage compute -entry computeMain
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target spirv
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target hlsl -stage compute -entry computeMain
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target glsl -stage compute -entry computeMain
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target metal -stage compute -entry computeMain
 
 #lang slang 2025
 
@@ -51,10 +46,9 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     IFoo obj = makeInterface(dispatchThreadID.x);
 
-    // Inferring T from an interface-typed argument requires specializing
-    // the generic with the existential type, which is not allowed.
-    // CHECK: ([[# @LINE+1]]): error 33180
     IFoo result = identity(obj);
+//CHECK:                  ^ cannot specialize generic with existential type
+//CHECK:                  ^ specializing 'identity' with an existential type is not allowed. All generic arguments must be statically resolvable at compile time.
 
     outputBuffer[0] = result.calc(3.0);
 }


### PR DESCRIPTION
Fixes #10263

Fix ICE (error 99997) when an existential type flows into an unconstrained generic function, emitting error E33180 instead.

Pattern fixed:

Interface-typed variable passed to unconstrained generic (#10263): functionCallTest(testVariant) where testVariant is ITest
Root cause: After typeflow analysis transforms existential types into set-tag-based IR representations, the original ExtractExistentialType args become tagged-union ops (e.g. GetTagFromTaggedUnion). When such an IRSpecialize callee has set-tag-typed args but is NOT a set-specialized generic (no witness table for dispatch), the typeflow pass crashed in specializeCall with "Unexpected operand type".

Fix:

In the else branch of specializeCall's callee resolution, detect IRSpecialize callees that couldn't be handled by either the dispatch-action or set-specialized-generic paths and emit E33180.
Add error-count checks in performDynamicInstLowering to bail out after the diagnostic, preventing follow-on segfaults from partially-lowered IR.
Use consistent > 0 error check in both processModule and performDynamicInstLowering.
Note on #9934: The associated-type variant (#9934) is also diagnosed correctly (E33180 instead of ICE) via the same specializeCall fallback. Extending the decoration pass to recognize associated-type patterns for earlier detection is deferred as follow-up work on that issue.