### PR TITLE
Darwin CMake: Use OUTPUT instead of POST_BUILD for debug symbols task to avoid empty debug info.

### DIFF
--- a/cmake/SlangTarget.cmake
+++ b/cmake/SlangTarget.cmake
@@ -356,10 +356,17 @@ function(slang_add_target dir type)
                     WORKING_DIRECTORY ${output_dir}
                     VERBATIM
                 )
-                add_custom_target(
-                    ${target}-split-debug-info ALL
-                    DEPENDS ${split_debug_stamp}
-                )
+                if(ARG_EXCLUDE_FROM_ALL)
+                    add_custom_target(
+                        ${target}-split-debug-info
+                        DEPENDS ${split_debug_stamp}
+                    )
+                else()
+                    add_custom_target(
+                        ${target}-split-debug-info ALL
+                        DEPENDS ${split_debug_stamp}
+                    )
+                endif()
                 add_dependencies(${target}-split-debug-info ${target})
             else()
                 add_custom_command(


### PR DESCRIPTION
This fixes an issue where, re-building without any changes to the `.dylib` files will cause the `.dwarf` debug files to be re-emitted from the already stripped `.dylib` files, resulting in blank `.dwarf`.