### PR TITLE
Emit E30300 for is/as operators on unrelated concrete types

### DIFF
--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -6286,6 +6286,34 @@ Expr* SemanticsExprVisitor::visitTryExpr(TryExpr* expr)
     return expr;
 }
 
+static bool _isTypeParametric(Type* type)
+{
+    if (!type)
+        return false;
+    if (as<ThisType>(type))
+        return true;
+    if (auto declRefType = as<DeclRefType>(type))
+    {
+        auto decl = declRefType->getDeclRef().getDecl();
+        if (as<GenericTypeParamDecl>(decl) || as<AssocTypeDecl>(decl))
+            return true;
+        // Check generic arguments for parametric types.
+        // E.g., Container<T> contains the generic param T.
+        if (auto genericApp = as<GenericAppDeclRef>(declRefType->getDeclRefBase()))
+        {
+            for (Index i = 0; i < genericApp->getArgCount(); i++)
+            {
+                if (auto argType = as<Type>(genericApp->getArg(i)))
+                {
+                    if (_isTypeParametric(argType))
+                        return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
 Expr* SemanticsExprVisitor::visitIsTypeExpr(IsTypeExpr* expr)
 {
     expr->typeExpr = CheckProperType(expr->typeExpr);
@@ -6336,6 +6364,15 @@ Expr* SemanticsExprVisitor::visitIsTypeExpr(IsTypeExpr* expr)
         }
         return expr;
     }
+
+    // If we reach here with no witness and both the value type and target type are concrete
+    // (not generic type parameters, associated types, or ThisType), the `is` check is always
+    // statically false and the user is using `is` incorrectly on unrelated concrete types.
+    if (!isInterfaceType(valueType) && !_isTypeParametric(valueType) &&
+        !_isTypeParametric(expr->typeExpr.type))
+    {
+        getSink()->diagnose(Diagnostics::IsOperatorValueMustBeInterfaceType{.expr = expr});
+    }
     return expr;
 }
 
@@ -6382,6 +6419,16 @@ Expr* SemanticsExprVisitor::visitAsTypeExpr(AsTypeExpr* expr)
         }
         expr->value = maybeOpenExistential(expr->value);
         return expr;
+    }
+
+    // If we reach here with no witness and both the value type and target type are concrete
+    // (not generic type parameters, associated types, or ThisType), the `as` cast always
+    // fails and the user is using `as` incorrectly on unrelated concrete types.
+    auto asValueType = expr->value->type.type;
+    if (!isInterfaceType(asValueType) && !_isTypeParametric(asValueType) &&
+        !_isTypeParametric(typeExpr.type))
+    {
+        getSink()->diagnose(Diagnostics::IsOperatorValueMustBeInterfaceType{.expr = expr});
     }
 
     expr->typeExpr = typeExpr.exp;

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -6295,7 +6295,8 @@ static bool _isTypeParametric(Type* type)
     if (auto declRefType = as<DeclRefType>(type))
     {
         auto decl = declRefType->getDeclRef().getDecl();
-        if (as<GenericTypeParamDeclBase>(decl) || as<AssocTypeDecl>(decl))
+        if (as<GenericTypeParamDeclBase>(decl) || as<AssocTypeDecl>(decl) ||
+            as<ThisTypeDecl>(decl))
             return true;
         // Check generic arguments for parametric types.
         // E.g., Container<T> contains the generic param T.

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -6295,8 +6295,7 @@ static bool _isTypeParametric(Type* type)
     if (auto declRefType = as<DeclRefType>(type))
     {
         auto decl = declRefType->getDeclRef().getDecl();
-        if (as<GenericTypeParamDeclBase>(decl) || as<AssocTypeDecl>(decl) ||
-            as<ThisTypeDecl>(decl))
+        if (as<GenericTypeParamDeclBase>(decl) || as<AssocTypeDecl>(decl) || as<ThisTypeDecl>(decl))
             return true;
         // Check generic arguments for parametric types.
         // E.g., Container<T> contains the generic param T.

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -6368,10 +6368,13 @@ Expr* SemanticsExprVisitor::visitIsTypeExpr(IsTypeExpr* expr)
     // If we reach here with no witness and both the value type and target type are concrete
     // (not generic type parameters, associated types, or ThisType), the `is` check is always
     // statically false and the user is using `is` incorrectly on unrelated concrete types.
+    // Note: _isTypeParametric only handles DeclRefType-based types (incl. recursive generic args).
+    // Builtin composite types like arrays or vectors with embedded generic params are not checked,
+    // but these are unlikely to appear in `is`/`as` expressions in practice.
     if (!isInterfaceType(valueType) && !_isTypeParametric(valueType) &&
         !_isTypeParametric(expr->typeExpr.type))
     {
-        getSink()->diagnose(Diagnostics::IsOperatorValueMustBeInterfaceType{.expr = expr});
+        getSink()->diagnose(Diagnostics::IsAsOnUnrelatedConcreteTypes{.expr = expr});
     }
     return expr;
 }
@@ -6428,7 +6431,7 @@ Expr* SemanticsExprVisitor::visitAsTypeExpr(AsTypeExpr* expr)
     if (!isInterfaceType(asValueType) && !_isTypeParametric(asValueType) &&
         !_isTypeParametric(typeExpr.type))
     {
-        getSink()->diagnose(Diagnostics::IsOperatorValueMustBeInterfaceType{.expr = expr});
+        getSink()->diagnose(Diagnostics::IsAsOnUnrelatedConcreteTypes{.expr = expr});
     }
 
     expr->typeExpr = typeExpr.exp;

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -6371,7 +6371,8 @@ Expr* SemanticsExprVisitor::visitIsTypeExpr(IsTypeExpr* expr)
     // Note: _isTypeParametric only handles DeclRefType-based types (incl. recursive generic args).
     // Builtin composite types like arrays or vectors with embedded generic params are not checked,
     // but these are unlikely to appear in `is`/`as` expressions in practice.
-    if (!isInterfaceType(valueType) && !_isTypeParametric(valueType) &&
+    if (!as<ErrorType>(valueType) && !as<ErrorType>(expr->typeExpr.type) &&
+        !isInterfaceType(valueType) && !_isTypeParametric(valueType) &&
         !_isTypeParametric(expr->typeExpr.type))
     {
         getSink()->diagnose(Diagnostics::IsAsOnUnrelatedConcreteTypes{.expr = expr});
@@ -6428,7 +6429,8 @@ Expr* SemanticsExprVisitor::visitAsTypeExpr(AsTypeExpr* expr)
     // (not generic type parameters, associated types, or ThisType), the `as` cast always
     // fails and the user is using `as` incorrectly on unrelated concrete types.
     auto asValueType = expr->value->type.type;
-    if (!isInterfaceType(asValueType) && !_isTypeParametric(asValueType) &&
+    if (!as<ErrorType>(asValueType) && !as<ErrorType>(typeExpr.type) &&
+        !isInterfaceType(asValueType) && !_isTypeParametric(asValueType) &&
         !_isTypeParametric(typeExpr.type))
     {
         getSink()->diagnose(Diagnostics::IsAsOnUnrelatedConcreteTypes{.expr = expr});

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -6295,7 +6295,7 @@ static bool _isTypeParametric(Type* type)
     if (auto declRefType = as<DeclRefType>(type))
     {
         auto decl = declRefType->getDeclRef().getDecl();
-        if (as<GenericTypeParamDecl>(decl) || as<AssocTypeDecl>(decl))
+        if (as<GenericTypeParamDeclBase>(decl) || as<AssocTypeDecl>(decl))
             return true;
         // Check generic arguments for parametric types.
         // E.g., Container<T> contains the generic param T.

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -6295,7 +6295,8 @@ static bool _isTypeParametric(Type* type)
     if (auto declRefType = as<DeclRefType>(type))
     {
         auto decl = declRefType->getDeclRef().getDecl();
-        if (as<GenericTypeParamDeclBase>(decl) || as<AssocTypeDecl>(decl) || as<ThisTypeDecl>(decl))
+        if (as<GenericTypeParamDeclBase>(decl) || as<AssocTypeDecl>(decl) ||
+            as<ThisTypeDecl>(decl) || as<GlobalGenericParamDecl>(decl))
             return true;
         // Check generic arguments for parametric types.
         // E.g., Container<T> contains the generic param T.

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -1442,8 +1442,8 @@ err(
 err(
     "is-as-on-unrelated-concrete-types",
     30303,
-    "'is'/'as' on unrelated concrete types is always false",
-    span { loc = "expr:Expr", message = "'is'/'as' comparison between unrelated concrete types is always false. Use an interface-typed expression for runtime type checks." }
+    "'is'/'as' on unrelated concrete types",
+    span { loc = "expr:Expr", message = "'is'/'as' on unrelated concrete types will never succeed. Use an interface-typed expression for runtime type checks." }
 )
 
 err(

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -1441,7 +1441,7 @@ err(
 
 err(
     "is-as-on-unrelated-concrete-types",
-    30303,
+    30304,
     "'is'/'as' on unrelated concrete types",
     span { loc = "expr:Expr", message = "'is'/'as' on unrelated concrete types will never succeed. Use an interface-typed expression for runtime type checks." }
 )

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -1440,6 +1440,13 @@ err(
 )
 
 err(
+    "is-as-on-unrelated-concrete-types",
+    30303,
+    "'is'/'as' on unrelated concrete types is always false",
+    span { loc = "expr:Expr", message = "'is'/'as' comparison between unrelated concrete types is always false. Use an interface-typed expression for runtime type checks." }
+)
+
+err(
     "expected-function",
     33070,
     "expected a function",

--- a/tests/diagnostics/is-as-parametric-exclusions.slang
+++ b/tests/diagnostics/is-as-parametric-exclusions.slang
@@ -24,12 +24,14 @@ bool testGenericParam<T>(T val)
 {
     return val is Dog;
 }
+//CHECK-NOT: unrelated concrete types
 
 // Nested generic arg - should NOT trigger E30303
 bool testNestedGeneric<T>(Box<T> box)
 {
     return box is Box<Dog>;
 }
+//CHECK-NOT: unrelated concrete types
 
 // Unrelated concrete types - SHOULD trigger E30303
 void testConcreteMismatch()

--- a/tests/diagnostics/is-as-parametric-exclusions.slang
+++ b/tests/diagnostics/is-as-parametric-exclusions.slang
@@ -1,0 +1,44 @@
+// Test that `is`/`as` operators do NOT emit E30303 for parametric types
+// (generic type parameters, nested generic args) and DO emit E30303 for
+// unrelated concrete types.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):
+
+struct Dog
+{
+    int bark;
+}
+
+struct Cat
+{
+    float meow;
+}
+
+struct Box<T>
+{
+    T value;
+}
+
+// Generic type parameter - should NOT trigger E30303
+bool testGenericParam<T>(T val)
+{
+    return val is Dog;
+}
+
+// Nested generic arg - should NOT trigger E30303
+bool testNestedGeneric<T>(Box<T> box)
+{
+    return box is Box<Dog>;
+}
+
+// Unrelated concrete types - SHOULD trigger E30303
+void testConcreteMismatch()
+{
+    Dog d;
+    bool b = d is Cat;
+//CHECK: 'is'/'as' on unrelated concrete types is always false
+//CHECK: 'is'/'as' comparison between unrelated concrete types is always false.
+    let c = d as Cat;
+//CHECK: 'is'/'as' on unrelated concrete types is always false
+//CHECK: 'is'/'as' comparison between unrelated concrete types is always false.
+}

--- a/tests/diagnostics/is-as-parametric-exclusions.slang
+++ b/tests/diagnostics/is-as-parametric-exclusions.slang
@@ -40,9 +40,9 @@ void testConcreteMismatch()
 {
     Dog d;
     bool b = d is Cat;
-//CHECK: 'is'/'as' on unrelated concrete types is always false
-//CHECK: 'is'/'as' comparison between unrelated concrete types is always false.
+//CHECK: 'is'/'as' on unrelated concrete types
+//CHECK: 'is'/'as' on unrelated concrete types will never succeed.
     let c = d as Cat;
-//CHECK: 'is'/'as' on unrelated concrete types is always false
-//CHECK: 'is'/'as' comparison between unrelated concrete types is always false.
+//CHECK: 'is'/'as' on unrelated concrete types
+//CHECK: 'is'/'as' on unrelated concrete types will never succeed.
 }

--- a/tests/diagnostics/is-as-parametric-exclusions.slang
+++ b/tests/diagnostics/is-as-parametric-exclusions.slang
@@ -22,6 +22,7 @@ struct Box<T>
 // Generic type parameter - should NOT trigger E30303
 bool testGenericParam<T>(T val)
 {
+    let d = val as Dog;
     return val is Dog;
 }
 //CHECK-NOT: unrelated concrete types
@@ -29,6 +30,7 @@ bool testGenericParam<T>(T val)
 // Nested generic arg - should NOT trigger E30303
 bool testNestedGeneric<T>(Box<T> box)
 {
+    let dogBox = box as Box<Dog>;
     return box is Box<Dog>;
 }
 //CHECK-NOT: unrelated concrete types

--- a/tests/language-feature/interface-as-rhs-error.slang
+++ b/tests/language-feature/interface-as-rhs-error.slang
@@ -61,15 +61,15 @@ void main()
     bool isTest2 = (other is AnotherType);
     bool isTest3 = (ConcreteImpl is ConcreteImpl);
     bool isTest4 = (AnotherType is ConcreteImpl);
-//diag:                         ^^ 'is'/'as' operator requires interface-typed expression
-//diag:                         ^^ 'is'/'as' operator requires an interface-typed expression.
+//diag:                         ^^ 'is'/'as' on unrelated concrete types is always false
+//diag:                         ^^ 'is'/'as' comparison between unrelated concrete types is always false.
 
     // Test as operator directly
     let asTest1 = impl as AnotherType;
-//diag:                ^^ 'is'/'as' operator requires interface-typed expression
-//diag:                ^^ 'is'/'as' operator requires an interface-typed expression.
+//diag:                ^^ 'is'/'as' on unrelated concrete types is always false
+//diag:                ^^ 'is'/'as' comparison between unrelated concrete types is always false.
     let asTest2 = other as ConcreteImpl;
-//diag:                 ^^ 'is'/'as' operator requires interface-typed expression
-//diag:                 ^^ 'is'/'as' operator requires an interface-typed expression.
+//diag:                 ^^ 'is'/'as' on unrelated concrete types is always false
+//diag:                 ^^ 'is'/'as' comparison between unrelated concrete types is always false.
     let asTest3 = impl as ConcreteImpl;
 }

--- a/tests/language-feature/interface-as-rhs-error.slang
+++ b/tests/language-feature/interface-as-rhs-error.slang
@@ -61,15 +61,15 @@ void main()
     bool isTest2 = (other is AnotherType);
     bool isTest3 = (ConcreteImpl is ConcreteImpl);
     bool isTest4 = (AnotherType is ConcreteImpl);
-//diag:                         ^^ 'is'/'as' on unrelated concrete types is always false
-//diag:                         ^^ 'is'/'as' comparison between unrelated concrete types is always false.
+//diag:                         ^^ 'is'/'as' on unrelated concrete types
+//diag:                         ^^ 'is'/'as' on unrelated concrete types will never succeed.
 
     // Test as operator directly
     let asTest1 = impl as AnotherType;
-//diag:                ^^ 'is'/'as' on unrelated concrete types is always false
-//diag:                ^^ 'is'/'as' comparison between unrelated concrete types is always false.
+//diag:                ^^ 'is'/'as' on unrelated concrete types
+//diag:                ^^ 'is'/'as' on unrelated concrete types will never succeed.
     let asTest2 = other as ConcreteImpl;
-//diag:                 ^^ 'is'/'as' on unrelated concrete types is always false
-//diag:                 ^^ 'is'/'as' comparison between unrelated concrete types is always false.
+//diag:                 ^^ 'is'/'as' on unrelated concrete types
+//diag:                 ^^ 'is'/'as' on unrelated concrete types will never succeed.
     let asTest3 = impl as ConcreteImpl;
 }

--- a/tests/language-feature/interface-as-rhs-error.slang
+++ b/tests/language-feature/interface-as-rhs-error.slang
@@ -1,4 +1,4 @@
-//DIAGNOSTIC_TEST:SIMPLE(diag=diag): -target spirv
+//DIAGNOSTIC_TEST:SIMPLE(diag=diag):
 
 interface IMyInterface
 {
@@ -61,9 +61,15 @@ void main()
     bool isTest2 = (other is AnotherType);
     bool isTest3 = (ConcreteImpl is ConcreteImpl);
     bool isTest4 = (AnotherType is ConcreteImpl);
+//diag:                         ^^ 'is'/'as' operator requires interface-typed expression
+//diag:                         ^^ 'is'/'as' operator requires an interface-typed expression.
 
     // Test as operator directly
     let asTest1 = impl as AnotherType;
+//diag:                ^^ 'is'/'as' operator requires interface-typed expression
+//diag:                ^^ 'is'/'as' operator requires an interface-typed expression.
     let asTest2 = other as ConcreteImpl;
+//diag:                 ^^ 'is'/'as' operator requires interface-typed expression
+//diag:                 ^^ 'is'/'as' operator requires an interface-typed expression.
     let asTest3 = impl as ConcreteImpl;
 }

--- a/tests/language-feature/interfaces/diagnose-is-non-interface-lhs.slang
+++ b/tests/language-feature/interfaces/diagnose-is-non-interface-lhs.slang
@@ -1,13 +1,6 @@
 // Test E30300: 'is'/'as' operator on a concrete (non-interface) typed expression.
-//
-// DISABLED: E30300 (IsOperatorValueMustBeInterfaceType) is unreachable dead code.
-// The diagnostic appears in both visitIsTypeExpr and visitAsTypeExpr
-// of slang-check-expr.cpp. Both guards require a non-interface type to
-// have a subtype relationship, but Slang has no struct inheritance — the only subtype
-// relationships are through interface conformance, so isInterfaceType() is always true
-// when these guards are reached.
 
-//DISABLE_DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target spirv
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):
 
 [anyValueSize(8)]
 interface IFoo
@@ -30,7 +23,9 @@ void test()
 {
     Other o;
     bool b = o is Impl;
-    //CHECK: ^ 'is'/'as' operator requires an interface-typed expression
-    Impl c = o as Impl;
-    //CHECK: ^ 'is'/'as' operator requires an interface-typed expression
+//CHECK:       ^^ 'is'/'as' operator requires interface-typed expression
+//CHECK:       ^^ 'is'/'as' operator requires an interface-typed expression.
+    let c = o as Impl;
+//CHECK:      ^^ 'is'/'as' operator requires interface-typed expression
+//CHECK:      ^^ 'is'/'as' operator requires an interface-typed expression.
 }

--- a/tests/language-feature/interfaces/diagnose-is-non-interface-lhs.slang
+++ b/tests/language-feature/interfaces/diagnose-is-non-interface-lhs.slang
@@ -1,4 +1,4 @@
-// Test E30300: 'is'/'as' operator on a concrete (non-interface) typed expression.
+// Test E30304: 'is'/'as' on unrelated concrete types.
 
 //DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):
 

--- a/tests/language-feature/interfaces/diagnose-is-non-interface-lhs.slang
+++ b/tests/language-feature/interfaces/diagnose-is-non-interface-lhs.slang
@@ -23,9 +23,9 @@ void test()
 {
     Other o;
     bool b = o is Impl;
-//CHECK:       ^^ 'is'/'as' on unrelated concrete types is always false
-//CHECK:       ^^ 'is'/'as' comparison between unrelated concrete types is always false.
+//CHECK:       ^^ 'is'/'as' on unrelated concrete types
+//CHECK:       ^^ 'is'/'as' on unrelated concrete types will never succeed.
     let c = o as Impl;
-//CHECK:      ^^ 'is'/'as' on unrelated concrete types is always false
-//CHECK:      ^^ 'is'/'as' comparison between unrelated concrete types is always false.
+//CHECK:      ^^ 'is'/'as' on unrelated concrete types
+//CHECK:      ^^ 'is'/'as' on unrelated concrete types will never succeed.
 }

--- a/tests/language-feature/interfaces/diagnose-is-non-interface-lhs.slang
+++ b/tests/language-feature/interfaces/diagnose-is-non-interface-lhs.slang
@@ -23,9 +23,9 @@ void test()
 {
     Other o;
     bool b = o is Impl;
-//CHECK:       ^^ 'is'/'as' operator requires interface-typed expression
-//CHECK:       ^^ 'is'/'as' operator requires an interface-typed expression.
+//CHECK:       ^^ 'is'/'as' on unrelated concrete types is always false
+//CHECK:       ^^ 'is'/'as' comparison between unrelated concrete types is always false.
     let c = o as Impl;
-//CHECK:      ^^ 'is'/'as' operator requires interface-typed expression
-//CHECK:      ^^ 'is'/'as' operator requires an interface-typed expression.
+//CHECK:      ^^ 'is'/'as' on unrelated concrete types is always false
+//CHECK:      ^^ 'is'/'as' comparison between unrelated concrete types is always false.
 }

--- a/tests/language-feature/interfaces/is-as-nested-generic.slang
+++ b/tests/language-feature/interfaces/is-as-nested-generic.slang
@@ -1,0 +1,70 @@
+// is-as-nested-generic.slang
+
+// Functional test: verify that `is`/`as` on generic-parameterized interface
+// values produce correct results (issue #10563).
+
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+
+[anyValueSize(16)]
+interface IAnimal
+{
+    int speak();
+}
+
+struct Dog : IAnimal
+{
+    int val;
+    int speak() { return val; }
+}
+
+struct Cat : IAnimal
+{
+    int val;
+    int speak() { return val; }
+}
+
+struct Box<T : IAnimal>
+{
+    T value;
+}
+
+//TEST_INPUT: type_conformance Dog:IAnimal = 0
+//TEST_INPUT: type_conformance Cat:IAnimal = 1
+
+bool testIsAnimal<T : IAnimal>(IAnimal animal)
+{
+    return animal is T;
+}
+
+int testAsAnimal<T : IAnimal>(IAnimal animal)
+{
+    let result = animal as T;
+    if (result.hasValue)
+        return result.value.speak();
+    return -1;
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    Dog d = { 10 };
+    int2 data = int2(10, 0);
+    IAnimal animal = createDynamicObject<IAnimal, int2>(0, data);
+
+    // Dog is Dog -> true (1)
+    outputBuffer[0] = testIsAnimal<Dog>(animal) ? 1 : 0;
+    // Dog is Cat -> false (0)
+    outputBuffer[1] = testIsAnimal<Cat>(animal) ? 1 : 0;
+    // Dog as Dog -> 10
+    outputBuffer[2] = testAsAnimal<Dog>(animal);
+    // Dog as Cat -> -1
+    outputBuffer[3] = testAsAnimal<Cat>(animal);
+}
+
+// CHECK: 1
+// CHECK: 0
+// CHECK: 10
+// CHECK: -1


### PR DESCRIPTION
## Summary
- Emit E30300 (`IsOperatorValueMustBeInterfaceType`) when `is`/`as` operators are used with two unrelated concrete types (e.g., `f is Bar` where `f` is `Foo`)
- Previously this silently compiled, resolving to `false` via a `TypeEquals` IR op
- Generic type parameters, associated types, and `ThisType` are correctly excluded from the check

## Motivation
Fixes #10563. The `TypeEquals` fallthrough in `visitIsTypeExpr`/`visitAsTypeExpr` was designed for generic type parameters (`T is int`), not concrete-vs-concrete comparisons where the result is always statically determinable.

## Technical Details
Added `_isTypeParametric()` helper that checks whether a type involves generic parameters (including recursively through `GenericAppDeclRef` arguments). At the fallthrough point of both `visitIsTypeExpr` and `visitAsTypeExpr`, if neither the value type nor the target type is parametric or an interface type, E30300 is emitted.

Existing generic uses like `T is int` (in `optional-generic.slang`) and `T is float` (in `static_assert.slang`) continue to work correctly because the type parameter check excludes them.

## Test Plan
- [x] Enabled previously-disabled test: `tests/language-feature/interfaces/diagnose-is-non-interface-lhs.slang`
- [x] Updated existing test: `tests/language-feature/interface-as-rhs-error.slang` with expected diagnostics
- [x] Verified generic `T is int` still works (`tests/bugs/optional-generic.slang`)
- [x] Verified `static_assert(T is float)` still works (`tests/language-feature/static_assert.slang`)
- [x] Full test suite: 4275/4275 passed, 0 regressions