### PR TITLE
Add logic needed so that users can access the methods constrained by a `TypeCoercionConstraint`

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2830,12 +2830,16 @@ internal T __builtin_cast<T, U>(U u);
 // If T is implicitly convertible to U, then vector<T,N> is implicitly convertible to vector<U,N>.
 __generic<ToType, let N : int> extension vector<ToType,N>
 {
+    //`ToType_T` is used as a workaround since Slang does not support contextual resolution for available members
+    // of a type. (see error 38044)
     __implicit_conversion(constraint)
     __intrinsic_op(BuiltinCast)
     __init<FromType, ToType_T>(vector<FromType,N> value) 
         where ToType_T == ToType
         where ToType_T(FromType) implicit;
 
+    //`ToType_T` is used as a workaround since Slang does not support contextual resolution for available members
+    // of a type. (see error 38044)
     __implicit_conversion(constraint +)
     [__unsafeForceInlineEarly]
     [__readNone]
@@ -2851,6 +2855,8 @@ __generic<ToType, let N : int> extension vector<ToType,N>
 // If T is implicitly convertible to U, then matrix<T,R,C,L> is implicitly convertible to matrix<U,R,C,L>.
 __generic<ToType, let R : int, let C : int, let L : int> extension matrix<ToType,R,C,L>
 {
+    //`ToType_T` is used as a workaround since Slang does not support contextual resolution for available members
+    // of a type. (see error 38044)
     __implicit_conversion(constraint)
     __intrinsic_op(BuiltinCast)
     __init<FromType, ToType_T>(matrix<FromType,R,C,L> value)

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2831,7 +2831,7 @@ internal T __builtin_cast<T, U>(U u);
 __generic<ToType, let N : int> extension vector<ToType,N>
 {
     //`ToType_T` is used as a workaround since Slang does not support contextual resolution for available members
-    // of a type. (see error 38044)
+    // of a type through constraints (see error 38044).
     __implicit_conversion(constraint)
     __intrinsic_op(BuiltinCast)
     __init<FromType, ToType_T>(vector<FromType,N> value) 
@@ -2839,7 +2839,7 @@ __generic<ToType, let N : int> extension vector<ToType,N>
         where ToType_T(FromType) implicit;
 
     //`ToType_T` is used as a workaround since Slang does not support contextual resolution for available members
-    // of a type. (see error 38044)
+    // of a type through constraints (see error 38044).
     __implicit_conversion(constraint +)
     [__unsafeForceInlineEarly]
     [__readNone]
@@ -2856,7 +2856,7 @@ __generic<ToType, let N : int> extension vector<ToType,N>
 __generic<ToType, let R : int, let C : int, let L : int> extension matrix<ToType,R,C,L>
 {
     //`ToType_T` is used as a workaround since Slang does not support contextual resolution for available members
-    // of a type. (see error 38044)
+    // of a type through constraints (see error 38044).
     __implicit_conversion(constraint)
     __intrinsic_op(BuiltinCast)
     __init<FromType, ToType_T>(matrix<FromType,R,C,L> value)

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2836,13 +2836,17 @@ __generic<ToType, let N : int> extension vector<ToType,N>
 {
     __implicit_conversion(constraint)
     __intrinsic_op(BuiltinCast)
-    __init<FromType>(vector<FromType,N> value) where ToType(FromType) implicit;
+    __init<FromType, ToType_T>(vector<FromType,N> value) 
+        where ToType_T == ToType
+        where ToType_T(FromType) implicit;
 
-    __implicit_conversion(constraint+)
+    __implicit_conversion(constraint +)
     [__unsafeForceInlineEarly]
     [__readNone]
     [TreatAsDifferentiable]
-    __init<FromType>(FromType value) where ToType(FromType) implicit
+    __init<FromType, ToType_T>(FromType value)
+        where ToType_T == ToType
+        where ToType_T(FromType) implicit
     {
         this = __builtin_cast<vector<ToType,N>>(vector<FromType,N>(value));
     }
@@ -2853,7 +2857,9 @@ __generic<ToType, let R : int, let C : int, let L : int> extension matrix<ToType
 {
     __implicit_conversion(constraint)
     __intrinsic_op(BuiltinCast)
-    __init<FromType>(matrix<FromType,R,C,L> value) where ToType(FromType) implicit;
+    __init<FromType, ToType_T>(matrix<FromType,R,C,L> value)
+        where ToType_T == ToType
+        where ToType_T(FromType) implicit;
 }
 
 //@ hidden:

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -384,6 +384,11 @@ public:
                 break;
             }
         }
+        else if (auto knownMethodDecl = as<KnownMethodDecl>(parent.getDecl()))
+        {
+            return getMemberConstraintDeclRef(knownMethodDecl->constraintDecl, memberDecl)
+                .template as<T>();
+        }
         else if (auto directDeclRef = as<DirectDeclRef>(parent.declRefBase))
         {
             return makeDeclRef(memberDecl);
@@ -449,6 +454,11 @@ public:
     {
         auto result = getOrCreate<LookupDeclRef>(declToLookup, base, subtypeWitness);
         return result;
+    }
+
+    DeclRef<Decl> getMemberConstraintDeclRef(TypeCoercionConstraintDecl* constraintDecl, Decl* declToLookup)
+    {
+        return getOrCreate<MemberConstraintDeclRef>(declToLookup, constraintDecl);
     }
 
     DeclRef<Decl> getLookupDeclRef(SubtypeWitness* subtypeWitness, Decl* declToLookup)

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -456,7 +456,9 @@ public:
         return result;
     }
 
-    DeclRef<Decl> getMemberConstraintDeclRef(TypeCoercionConstraintDecl* constraintDecl, Decl* declToLookup)
+    DeclRef<Decl> getMemberConstraintDeclRef(
+        TypeCoercionConstraintDecl* constraintDecl,
+        Decl* declToLookup)
     {
         return getOrCreate<MemberConstraintDeclRef>(declToLookup, constraintDecl);
     }

--- a/source/slang/slang-ast-decl-ref.cpp
+++ b/source/slang/slang-ast-decl-ref.cpp
@@ -427,10 +427,7 @@ Val* LookupDeclRef::tryResolve(SubtypeWitness* newWitness, Type* newLookupSource
     return innerDeclRefType;
 }
 
-DeclRefBase* MemberConstraintDeclRef::_substituteImplOverride(
-    ASTBuilder*,
-    SubstitutionSet,
-    int*)
+DeclRefBase* MemberConstraintDeclRef::_substituteImplOverride(ASTBuilder*, SubstitutionSet, int*)
 {
     return this;
 }

--- a/source/slang/slang-ast-decl-ref.cpp
+++ b/source/slang/slang-ast-decl-ref.cpp
@@ -427,6 +427,36 @@ Val* LookupDeclRef::tryResolve(SubtypeWitness* newWitness, Type* newLookupSource
     return innerDeclRefType;
 }
 
+DeclRefBase* MemberConstraintDeclRef::_substituteImplOverride(
+    ASTBuilder*,
+    SubstitutionSet,
+    int*)
+{
+    return this;
+}
+
+void MemberConstraintDeclRef::_toTextOverride(StringBuilder& out)
+{
+    out << "MemberConstraintDeclRef<";
+    out << ">(";
+    if (getDecl()->getName() && getDecl()->getName()->text.getLength() != 0)
+    {
+        out << getDecl()->getName()->text;
+    }
+    out << getConstraintDecl();
+    out << ")";
+}
+
+Val* MemberConstraintDeclRef::_resolveImplOverride()
+{
+    return this;
+}
+
+DeclRefBase* MemberConstraintDeclRef::_getBaseOverride()
+{
+    return nullptr;
+}
+
 DeclRefBase* GenericAppDeclRef::_substituteImplOverride(
     ASTBuilder* astBuilder,
     SubstitutionSet subst,

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -1004,6 +1004,7 @@ class TypeCoercionConstraintDecl : public Decl
     SourceLoc whereTokenLoc = SourceLoc();
     FIDDLE() TypeExp fromType;
     FIDDLE() TypeExp toType;
+    FIDDLE() DeclRef<KnownMethodDecl> syntheticFacetDeclRef;
 };
 
 FIDDLE()

--- a/source/slang/slang-ast-decl.h
+++ b/source/slang/slang-ast-decl.h
@@ -536,6 +536,18 @@ class InheritanceDecl : public TypeConstraintDecl
 
 // TODO: may eventually need sub-classes for explicit/direct vs. implicit/indirect inheritance
 
+// A container that contains a method we know that exists via a constraint.
+// This container is used as a 'synthetic facet' for member-lookup.
+// This container is currently only designed around containing one synthetic method.
+FIDDLE()
+class KnownMethodDecl : public AggTypeDeclBase
+{
+    FIDDLE(...)
+    // The original type this synthetic facet is a facet for.
+    FIDDLE() Type* thisType;
+    FIDDLE() TypeCoercionConstraintDecl* constraintDecl;
+    Type* getThisType() const { return thisType; }
+};
 
 // A declaration that represents a simple (non-aggregate) type
 //

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -95,7 +95,7 @@ private:
 
 // A DeclRef that encodes that there is some member accessible called to `decl`.
 // This `decl` is not the real value and must be resolved via the original constraint
-// it comes from
+// it comes from.
 FIDDLE()
 class MemberConstraintDeclRef : public DeclRefBase
 {
@@ -107,7 +107,7 @@ public:
         setOperands(placeholderDecl, constraintDecl);
     }
 
-    // The source type that we are looking up from.
+    // The constraint that we resolve our declref with.
     TypeCoercionConstraintDecl* getConstraintDecl()
     {
         return as<TypeCoercionConstraintDecl>(getDeclOperand(1));

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -93,9 +93,10 @@ private:
     Val* tryResolve(SubtypeWitness* newWitness, Type* newLookupSource);
 };
 
-// A DeclRef that encodes that there is some member accessible called to `decl`.
-// This `decl` is not the real value and must be resolved via the original constraint
-// it comes from.
+// A DeclRef that encodes that there is some `placeholderDecl` that was looked-up from
+// a synthetic facet, defined on some variation of a explicit member constraint (ex: type-coercion constraint).
+// This `placeholderDecl` can be resolved into a "real" declaration via the original constraint it comes from
+// subsituting.
 FIDDLE()
 class MemberConstraintDeclRef : public DeclRefBase
 {

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -93,6 +93,38 @@ private:
     Val* tryResolve(SubtypeWitness* newWitness, Type* newLookupSource);
 };
 
+// A DeclRef that encodes that there is some member accessible called to `decl`.
+// This `decl` is not the real value and must be resolved via the original constraint
+// it comes from
+FIDDLE()
+class MemberConstraintDeclRef : public DeclRefBase
+{
+    FIDDLE(...)
+public:
+
+    MemberConstraintDeclRef(Decl* placeholderDecl, TypeCoercionConstraintDecl* constraintDecl)
+    { 
+        setOperands(placeholderDecl, constraintDecl);
+    }
+
+    // The source type that we are looking up from.
+    TypeCoercionConstraintDecl* getConstraintDecl()
+    {
+        return as<TypeCoercionConstraintDecl>(getDeclOperand(1));
+    }
+
+    DeclRefBase* _substituteImplOverride(
+        ASTBuilder* astBuilder,
+        SubstitutionSet subst,
+        int* ioDiff);
+
+    void _toTextOverride(StringBuilder& out);
+
+    Val* _resolveImplOverride();
+
+    DeclRefBase* _getBaseOverride();
+};
+
 // Represents a specialization of a generic decl.
 FIDDLE()
 class GenericAppDeclRef : public DeclRefBase

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -94,17 +94,16 @@ private:
 };
 
 // A DeclRef that encodes that there is some `placeholderDecl` that was looked-up from
-// a synthetic facet, defined on some variation of a explicit member constraint (ex: type-coercion constraint).
-// This `placeholderDecl` can be resolved into a "real" declaration via the original constraint it comes from
-// subsituting.
+// a synthetic facet, defined on some variation of a explicit member constraint (ex: type-coercion
+// constraint). This `placeholderDecl` can be resolved into a "real" declaration via the original
+// constraint it comes from subsituting.
 FIDDLE()
 class MemberConstraintDeclRef : public DeclRefBase
 {
     FIDDLE(...)
 public:
-
     MemberConstraintDeclRef(Decl* placeholderDecl, TypeCoercionConstraintDecl* constraintDecl)
-    { 
+    {
         setOperands(placeholderDecl, constraintDecl);
     }
 

--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -352,25 +352,19 @@ Type* SemanticsVisitor::TryJoinTypes(ConstraintSystem* constraints, QualType lef
     return nullptr;
 }
 
-bool addTypeCoercionWitnessToArgs(
+bool checkTypeCoercionWitnessValidity(
     ASTBuilder* astBuilder,
     SemanticsVisitor* visitor,
     TypeCoercionConstraintDecl* constraintDecl,
-    DeclRef<GenericDecl> genericDeclRef,
+    Type* fromType,
+    Type* toType,
+    DeclRef<GenericDecl>* maybeGenericDeclRef,
     SemanticsVisitor::OverloadResolveContext* maybeContext,
-    HashSet<Decl*>* maybeConstrainedGenericParams,
-    ShortList<Val*>& args,
-    bool shouldEmitError)
+    bool shouldEmitError,
+    TypeCoercionWitness** outTypeCoercionWitness)
 {
-    // To emit an error, `maybeContext` must be provided.
-    SLANG_ASSERT(!shouldEmitError || shouldEmitError && maybeContext);
+    SLANG_ASSERT(!shouldEmitError || shouldEmitError && maybeContext && maybeGenericDeclRef);
 
-    DeclRef<TypeCoercionConstraintDecl> constraintDeclRef =
-        astBuilder
-            ->getGenericAppDeclRef(genericDeclRef, args.getArrayView().arrayView, constraintDecl)
-            .as<TypeCoercionConstraintDecl>();
-    auto fromType = getFromType(astBuilder, constraintDeclRef);
-    auto toType = getToType(astBuilder, constraintDeclRef);
     TypeCoercionWitness* typeCoercionWitness = nullptr;
     DeclRef<Decl> declRefUsedToConvert{};
     ConversionCost conversionCost = kConversionCost_Impossible;
@@ -419,10 +413,46 @@ bool addTypeCoercionWitnessToArgs(
                 .toType = toType,
                 .location = maybeContext->loc});
             visitor->getSink()->diagnose(
-                Diagnostics::SeeDefinitionOf{.decl = genericDeclRef.getDecl()->inner});
+                Diagnostics::SeeDefinitionOf{.decl = maybeGenericDeclRef->getDecl()->inner});
         }
         return false;
     }
+
+    if (outTypeCoercionWitness)
+        *outTypeCoercionWitness = typeCoercionWitness;
+    return true;
+}
+
+bool addTypeCoercionWitnessToArgs(
+    ASTBuilder* astBuilder,
+    SemanticsVisitor* visitor,
+    TypeCoercionConstraintDecl* constraintDecl,
+    DeclRef<GenericDecl> genericDeclRef,
+    SemanticsVisitor::OverloadResolveContext* maybeContext,
+    HashSet<Decl*>* maybeConstrainedGenericParams,
+    ShortList<Val*>& args,
+    bool shouldEmitError)
+{
+    SLANG_ASSERT(!shouldEmitError || shouldEmitError && maybeContext && genericDeclRef);
+
+    DeclRef<TypeCoercionConstraintDecl> constraintDeclRef =
+        astBuilder
+            ->getGenericAppDeclRef(genericDeclRef, args.getArrayView().arrayView, constraintDecl)
+            .as<TypeCoercionConstraintDecl>();
+    auto fromType = getFromType(astBuilder, constraintDeclRef);
+    auto toType = getToType(astBuilder, constraintDeclRef);
+    TypeCoercionWitness* typeCoercionWitness = nullptr;
+    if (!checkTypeCoercionWitnessValidity(
+            astBuilder,
+            visitor,
+            constraintDecl,
+            fromType,
+            toType,
+            &genericDeclRef,
+            maybeContext,
+            shouldEmitError,
+            &typeCoercionWitness))
+        return false;
 
     if (maybeConstrainedGenericParams)
     {

--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -439,6 +439,13 @@ bool addTypeCoercionWitnessToArgs(
     // If `_coerce` accepted the conversion but didn't provide an explicit
     // witness object, treat it as a builtin conversion witness so later
     // lowering still has a concrete generic argument to pass through.
+    //
+    // Despite this workaround, hitting this case is a bug in `_coerce`.
+    // The solution is to narrow-down on the particular `toType` and
+    // `fromType` that causes this result. In theory we should emit
+    // an error here, but to do this we need to implement more
+    // logic connecting `_coerce` to `TypeCoercionConstraint`
+    // so that we don't break existing (and unrelated) user code.
     if (!typeCoercionWitness)
         typeCoercionWitness = astBuilder->getBuiltinTypeCoercionWitness(fromType, toType);
 

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -1715,6 +1715,9 @@ bool SemanticsVisitor::_coerce(
                             // Skip witness arguments (SubtypeWitness)
                             if (as<SubtypeWitness>(toArg) && as<SubtypeWitness>(fromArg))
                                 continue;
+                            // Skip witness arguments (TypeCoercionWitness)
+                            if (as<TypeCoercionWitness>(toArg) && as<TypeCoercionWitness>(fromArg))
+                                continue;
                             // Non-witness arguments must be equal
                             if (!toArg->equals(fromArg))
                             {
@@ -2644,6 +2647,11 @@ bool SemanticsVisitor::_coerce(
                     ImplicitCastMethod{*overloadContext.bestCandidate, cost});
             }
         }
+        if (outWitnessOfConversion)
+           *outWitnessOfConversion = getASTBuilder()->getDeclRefTypeCoercionWitness(
+               fromType,
+               toType,
+               overloadContext.bestCandidate->item.declRef);
         return true;
     }
     if (!cachedMethod)

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -2654,10 +2654,10 @@ bool SemanticsVisitor::_coerce(
             }
         }
         if (outWitnessOfConversion)
-           *outWitnessOfConversion = getASTBuilder()->getDeclRefTypeCoercionWitness(
-               fromType,
-               toType,
-               overloadContext.bestCandidate->item.declRef);
+            *outWitnessOfConversion = getASTBuilder()->getDeclRefTypeCoercionWitness(
+                fromType,
+                toType,
+                overloadContext.bestCandidate->item.declRef);
         return true;
     }
     if (!cachedMethod)

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -4069,7 +4069,7 @@ void SemanticsDeclHeaderVisitor::visitTypeCoercionConstraintDecl(TypeCoercionCon
     paramDecl->type = decl->fromType;
     paramDecl->nameAndLoc.name = getName("value");
     paramDecl->nameAndLoc.loc = decl->loc;
-    
+
     auto syntheticFunctionDecl = astBuilder->create<ConstructorDecl>();
     syntheticFunctionDecl->returnType = decl->toType;
     syntheticFunctionDecl->nameAndLoc.name = getName("$init");
@@ -4081,8 +4081,7 @@ void SemanticsDeclHeaderVisitor::visitTypeCoercionConstraintDecl(TypeCoercionCon
         addModifier(syntheticFunctionDecl, implicitConversionModifier);
 
     auto parentDecl = getModuleDecl(decl->parentDecl);
-    DeclRef<KnownMethodDecl> syntheticFacetDeclRef =
-        astBuilder->create<KnownMethodDecl>();
+    DeclRef<KnownMethodDecl> syntheticFacetDeclRef = astBuilder->create<KnownMethodDecl>();
     KnownMethodDecl* syntheticFacetDecl = syntheticFacetDeclRef.getDecl();
     syntheticFacetDecl->constraintDecl = decl;
     syntheticFacetDecl->ownedScope = astBuilder->create<Scope>();
@@ -4092,9 +4091,9 @@ void SemanticsDeclHeaderVisitor::visitTypeCoercionConstraintDecl(TypeCoercionCon
     syntheticFacetDecl->nameAndLoc.loc = decl->loc;
     syntheticFacetDecl->addMember(syntheticFunctionDecl);
     syntheticFacetDecl->thisType = getToType(astBuilder, decl);
-    
+
     decl->syntheticFacetDeclRef = syntheticFacetDeclRef;
-    
+
     // To resolve calling a method constrained via a `TypeCoercionWitness` we must
     // add a synthetic facet to our `ToType` and resolve the methods existence via
     // specialization. As a result, if a user specifies a `ToType` not defined in the
@@ -4117,7 +4116,8 @@ void SemanticsDeclHeaderVisitor::visitTypeCoercionConstraintDecl(TypeCoercionCon
                     return;
             }
         }
-        else if (isAssociatedTypeDecl(decl->parentDecl) &&
+        else if (
+            isAssociatedTypeDecl(decl->parentDecl) &&
             toTypeDeclRefType->getDeclRef().getDecl() == decl->parentDecl)
             return;
     }
@@ -5973,8 +5973,7 @@ bool SemanticsVisitor::doesTypeSatisfyConstraintRequirements(
     //
     bool conformance = true;
     Val* witness = nullptr;
-    for (auto requiredConstraintDeclRef :
-         getMembers(m_astBuilder, requirementDeclRef))
+    for (auto requiredConstraintDeclRef : getMembers(m_astBuilder, requirementDeclRef))
     {
         if (auto genericTypeConstraintDecl =
                 requiredConstraintDeclRef.as<GenericTypeConstraintDecl>())
@@ -6017,8 +6016,9 @@ bool SemanticsVisitor::doesTypeSatisfyConstraintRequirements(
                 conformance = false;
             }
         }
-        else if (auto typeCoercionConstraintDeclRef = requiredConstraintDeclRef
-                     .as<TypeCoercionConstraintDecl>())
+        else if (
+            auto typeCoercionConstraintDeclRef =
+                requiredConstraintDeclRef.as<TypeCoercionConstraintDecl>())
         {
             auto astBuilder = getASTBuilder();
             auto fromType = getFromType(astBuilder, typeCoercionConstraintDeclRef);
@@ -14254,7 +14254,8 @@ void SemanticsDeclBasesVisitor::_validateExtensionDeclGenericParams(ExtensionDec
         // Also collect declarations referenced by generic & type-coercion constraints
         for (auto constraintDeclRef : getMembers(getASTBuilder(), genericDecl))
         {
-            if (auto genericTypeConstraintDeclRef = constraintDeclRef.as<GenericTypeConstraintDecl>())
+            if (auto genericTypeConstraintDeclRef =
+                    constraintDeclRef.as<GenericTypeConstraintDecl>())
                 collectReferencedDecls(
                     genericTypeConstraintDeclRef.getDecl()->sup.type,
                     genericParamsReferencedByConstraints);

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -4053,11 +4053,11 @@ void SemanticsDeclHeaderVisitor::visitTypeCoercionConstraintDecl(TypeCoercionCon
     if (!decl->toType.type)
         decl->toType = TranslateTypeNodeForced(decl->toType);
 
-    // To resolve calling a method constrainted via a `TypeCoercionWitness` we must
-    // add a synthetic facet to our `ToType` and resolve the methods existance via
+    // To resolve calling a method constrained via a `TypeCoercionWitness` we must
+    // add a synthetic facet to our `ToType` and resolve the methods existence via
     // specialization. As a result, if a user specifies a `ToType` not defined in the
     // current scopes generic parameter list, we have a problem: we cannot retroactively add methods
-    // to an already baked `InheritanceInfo` (so the method constrainted will not be accessible).
+    // to an already baked `InheritanceInfo` (so the method constrained will not be accessible).
     //
     // If a user intends to constrain a type declared outside the current scope they need to use
     // type equality constraints.
@@ -4067,7 +4067,7 @@ void SemanticsDeclHeaderVisitor::visitTypeCoercionConstraintDecl(TypeCoercionCon
     {
         if (as<GenericDecl>(decl->parentDecl))
         {
-            auto toTypeDecl = as<DeclRefType>(decl->toType)->getDeclRef().getDecl();
+            auto toTypeDecl = toTypeDeclRefType->getDeclRef().getDecl();
             for (auto genericTypeParamDecl :
                  decl->parentDecl->getMembersOfType<GenericTypeParamDeclBase>())
             {

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -4117,6 +4117,9 @@ void SemanticsDeclHeaderVisitor::visitTypeCoercionConstraintDecl(TypeCoercionCon
                     return;
             }
         }
+        else if (isAssociatedTypeDecl(decl->parentDecl) &&
+            toTypeDeclRefType->getDeclRef().getDecl() == decl->parentDecl)
+            return;
     }
     getSink()->diagnose(
         Diagnostics::TypeCoerceConstraintToTypeMustBeDefinedInTheCurrentScopesGeneric{
@@ -5965,49 +5968,72 @@ bool SemanticsVisitor::doesTypeSatisfyConstraintRequirements(
 {
     SLANG_UNUSED(satisfyingType);
 
-    // We will enumerate the type constraints placed on the
+    // We will enumerate the constraints placed on the
     // associated type and see if they can be satisfied.
     //
     bool conformance = true;
     Val* witness = nullptr;
     for (auto requiredConstraintDeclRef :
-         getMembersOfType<GenericTypeConstraintDecl>(m_astBuilder, requirementDeclRef))
+         getMembers(m_astBuilder, requirementDeclRef))
     {
-        // Grab the type we expect to conform to from the constraint.
-        auto requiredSuperType = getSup(m_astBuilder, requiredConstraintDeclRef);
+        if (auto genericTypeConstraintDecl =
+                requiredConstraintDeclRef.as<GenericTypeConstraintDecl>())
+        {
+            // Grab the type we expect to conform to from the constraint.
+            auto requiredSuperType = getSup(m_astBuilder, genericTypeConstraintDecl);
 
-        auto subType = getSub(m_astBuilder, requiredConstraintDeclRef);
-        witness = tryGetSubtypeWitness(subType, requiredSuperType);
+            auto subType = getSub(m_astBuilder, genericTypeConstraintDecl);
+            witness = tryGetSubtypeWitness(subType, requiredSuperType);
 
-        if (witness)
-        {
-            auto genConstraint = as<GenericTypeConstraintDecl>(requiredConstraintDeclRef.getDecl());
-            if (genConstraint && genConstraint->isEqualityConstraint &&
-                !isTypeEqualityWitness(witness))
-                witness = nullptr;
-        }
-        if (witness)
-        {
-            // If a subtype witness was found, then the conformance
-            // appears to hold, and we can satisfy that requirement.
-            witnessTable->add(requiredConstraintDeclRef.getDecl(), RequirementWitness(witness));
-        }
-        else
-        {
-            // Is our constraint optional? If so, then our conformance is still fine.
-            // We'll just use a NoneWitness.
-            //
-            if (requiredConstraintDeclRef.getDecl()->findModifier<OptionalConstraintModifier>())
+            if (witness)
             {
-                witnessTable->add(
-                    requiredConstraintDeclRef.getDecl(),
-                    m_astBuilder->getOrCreate<NoneWitness>());
-                continue;
+                auto genConstraint =
+                    as<GenericTypeConstraintDecl>(genericTypeConstraintDecl.getDecl());
+                if (genConstraint && genConstraint->isEqualityConstraint &&
+                    !isTypeEqualityWitness(witness))
+                    witness = nullptr;
             }
+            if (witness)
+            {
+                // If a subtype witness was found, then the conformance
+                // appears to hold, and we can satisfy that requirement.
+                witnessTable->add(genericTypeConstraintDecl.getDecl(), RequirementWitness(witness));
+            }
+            else
+            {
+                // Is our constraint optional? If so, then our conformance is still fine.
+                // We'll just use a NoneWitness.
+                //
+                if (genericTypeConstraintDecl.getDecl()->findModifier<OptionalConstraintModifier>())
+                {
+                    witnessTable->add(
+                        genericTypeConstraintDecl.getDecl(),
+                        m_astBuilder->getOrCreate<NoneWitness>());
+                    continue;
+                }
 
-            // If a witness couldn't be found, then the conformance
-            // seems like it will fail.
-            conformance = false;
+                // If a witness couldn't be found, then the conformance
+                // seems like it will fail.
+                conformance = false;
+            }
+        }
+        else if (auto typeCoercionConstraintDeclRef = requiredConstraintDeclRef
+                     .as<TypeCoercionConstraintDecl>())
+        {
+            auto astBuilder = getASTBuilder();
+            auto fromType = getFromType(astBuilder, typeCoercionConstraintDeclRef);
+            auto toType = getToType(astBuilder, typeCoercionConstraintDeclRef);
+            if (!checkTypeCoercionWitnessValidity(
+                    astBuilder,
+                    this,
+                    typeCoercionConstraintDeclRef.getDecl(),
+                    fromType,
+                    toType,
+                    nullptr,
+                    nullptr,
+                    false,
+                    nullptr))
+                conformance = false;
         }
     }
     return conformance;

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -4052,6 +4052,35 @@ void SemanticsDeclHeaderVisitor::visitTypeCoercionConstraintDecl(TypeCoercionCon
         decl->fromType = TranslateTypeNodeForced(decl->fromType);
     if (!decl->toType.type)
         decl->toType = TranslateTypeNodeForced(decl->toType);
+
+    // To resolve calling a method constrainted via a `TypeCoercionWitness` we must
+    // add a synthetic facet to our `ToType` and resolve the methods existance via
+    // specialization. As a result, if a user specifies a `ToType` not defined in the
+    // current scopes generic parameter list, we have a problem: we cannot retroactively add methods
+    // to an already baked `InheritanceInfo` (so the method constrainted will not be accessible).
+    //
+    // If a user intends to constrain a type declared outside the current scope they need to use
+    // type equality constraints.
+    //
+    auto toTypeDeclRefType = as<DeclRefType>(decl->toType);
+    if (toTypeDeclRefType)
+    {
+        if (as<GenericDecl>(decl->parentDecl))
+        {
+            auto toTypeDecl = as<DeclRefType>(decl->toType)->getDeclRef().getDecl();
+            for (auto genericTypeParamDecl :
+                 decl->parentDecl->getMembersOfType<GenericTypeParamDeclBase>())
+            {
+                if (genericTypeParamDecl == toTypeDecl)
+                    return;
+            }
+        }
+    }
+    getSink()->diagnose(
+        Diagnostics::TypeCoerceConstraintToTypeMustBeDefinedInTheCurrentScopesGeneric{
+            .toType = decl->toType,
+            .locationOfGenericParameterList = decl->parentDecl,
+            .location = decl->loc});
 }
 
 void SemanticsDeclHeaderVisitor::visitNonEmptyPackConstraintDecl(NonEmptyPackConstraintDecl* decl)
@@ -14050,13 +14079,24 @@ void SemanticsDeclBasesVisitor::_validateExtensionDeclGenericParams(ExtensionDec
 
         HashSet<Decl*> genericParamsReferencedByConstraints;
 
-        // Also collect declarations referenced by generic constraints
-        for (auto constraint :
-             getMembersOfType<GenericTypeConstraintDecl>(getASTBuilder(), genericDecl))
+        // Also collect declarations referenced by generic & type-coercion constraints
+        for (auto constraintDeclRef : getMembers(getASTBuilder(), genericDecl))
         {
-            collectReferencedDecls(
-                constraint.getDecl()->sup.type,
-                genericParamsReferencedByConstraints);
+            if (auto genericTypeConstraintDeclRef = constraintDeclRef.as<GenericTypeConstraintDecl>())
+                collectReferencedDecls(
+                    genericTypeConstraintDeclRef.getDecl()->sup.type,
+                    genericParamsReferencedByConstraints);
+            else if (
+                auto typeCoercionConstraintDeclRef =
+                    constraintDeclRef.as<TypeCoercionConstraintDecl>())
+            {
+                collectReferencedDecls(
+                    typeCoercionConstraintDeclRef.getDecl()->toType.type,
+                    genericParamsReferencedByConstraints);
+                collectReferencedDecls(
+                    typeCoercionConstraintDeclRef.getDecl()->fromType.type,
+                    genericParamsReferencedByConstraints);
+            }
         }
 
         // Note: We intentionally do NOT check inheritance declarations in the extension.
@@ -14220,6 +14260,10 @@ Type* SemanticsVisitor::calcThisType(DeclRef<Decl> declRef)
         ensureDecl(extDeclRef, DeclCheckState::CanUseExtensionTargetType);
         auto targetType = getTargetType(m_astBuilder, extDeclRef);
         return calcThisType(targetType);
+    }
+    else if (auto knownMethodDecl = declRef.as<KnownMethodDecl>())
+    {
+        return calcThisType(knownMethodDecl.getDecl()->getThisType());
     }
     else
     {

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -4053,6 +4053,41 @@ void SemanticsDeclHeaderVisitor::visitTypeCoercionConstraintDecl(TypeCoercionCon
     if (!decl->toType.type)
         decl->toType = TranslateTypeNodeForced(decl->toType);
 
+    auto astBuilder = getASTBuilder();
+
+    // Pre-generate a container (`KnownMethodDecl`) that will function as a synthetic-facet
+    // during member lookup. Put inside it a synthetic-method that signifies
+    // that a particular type contains some method of the form `ToType __init(FromType)`.
+    auto paramDecl = astBuilder->create<ParamDecl>();
+    paramDecl->type = decl->fromType;
+    paramDecl->nameAndLoc.name = getName("value");
+    paramDecl->nameAndLoc.loc = decl->loc;
+    
+    auto syntheticFunctionDecl = astBuilder->create<ConstructorDecl>();
+    syntheticFunctionDecl->returnType = decl->toType;
+    syntheticFunctionDecl->nameAndLoc.name = getName("$init");
+    syntheticFunctionDecl->nameAndLoc.loc = decl->loc;
+    syntheticFunctionDecl->addMember(paramDecl);
+
+    // `syntheticFunctionDecl` should be an implicit conversion if the constraint is `implicit`
+    if (auto implicitConversionModifier = decl->findModifier<ImplicitConversionModifier>())
+        addModifier(syntheticFunctionDecl, implicitConversionModifier);
+
+    auto parentDecl = getModuleDecl(decl->parentDecl);
+    DeclRef<KnownMethodDecl> syntheticFacetDeclRef =
+        astBuilder->create<KnownMethodDecl>();
+    KnownMethodDecl* syntheticFacetDecl = syntheticFacetDeclRef.getDecl();
+    syntheticFacetDecl->constraintDecl = decl;
+    syntheticFacetDecl->ownedScope = astBuilder->create<Scope>();
+    syntheticFacetDecl->ownedScope->parent = getScope(parentDecl);
+    syntheticFacetDecl->ownedScope->containerDecl = syntheticFacetDecl;
+    syntheticFacetDecl->parentDecl = parentDecl;
+    syntheticFacetDecl->nameAndLoc.loc = decl->loc;
+    syntheticFacetDecl->addMember(syntheticFunctionDecl);
+    syntheticFacetDecl->thisType = getToType(astBuilder, decl);
+    
+    decl->syntheticFacetDeclRef = syntheticFacetDeclRef;
+    
     // To resolve calling a method constrained via a `TypeCoercionWitness` we must
     // add a synthetic facet to our `ToType` and resolve the methods existence via
     // specialization. As a result, if a user specifies a `ToType` not defined in the

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -3604,7 +3604,8 @@ bool addTypeCoercionWitnessToArgs(
     ShortList<Val*>& args,
     bool shouldEmitError);
 
-// Returns `false` if coerce fails, `true` if success, `outTypeCoercionWitness` maybe filled on success.
+// Returns `false` if coerce fails, `true` if success, `outTypeCoercionWitness` maybe filled on
+// success.
 bool checkTypeCoercionWitnessValidity(
     ASTBuilder* astBuilder,
     SemanticsVisitor* visitor,

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -3604,6 +3604,18 @@ bool addTypeCoercionWitnessToArgs(
     ShortList<Val*>& args,
     bool shouldEmitError);
 
+// Returns `false` if coerce fails, `true` if success, `outTypeCoercionWitness` maybe filled on success.
+bool checkTypeCoercionWitnessValidity(
+    ASTBuilder* astBuilder,
+    SemanticsVisitor* visitor,
+    TypeCoercionConstraintDecl* constraintDecl,
+    Type* fromType,
+    Type* toType,
+    DeclRef<GenericDecl>* maybeGenericDeclRef,
+    SemanticsVisitor::OverloadResolveContext* maybeContext,
+    bool shouldEmitError,
+    TypeCoercionWitness** outTypeCoercionWitness);
+
 bool addHasDiffTypeInfoWitnessToArgs(
     ASTBuilder* astBuilder,
     SemanticsVisitor* visitor,

--- a/source/slang/slang-check-inheritance.cpp
+++ b/source/slang/slang-check-inheritance.cpp
@@ -405,7 +405,7 @@ InheritanceInfo SharedSemanticsContext::_calcInheritanceInfo(
         return result;
     };
 
-    
+
     auto tryToAddTypeCoercionConstraintFacet =
         [&](DeclRef<TypeCoercionConstraintDecl> typeCoercionConstraintDeclRef)
     {
@@ -449,10 +449,9 @@ InheritanceInfo SharedSemanticsContext::_calcInheritanceInfo(
             // In the case where we have an aggregate type or `extension`
             // declaration, we can use the explicit list of direct bases.
             //
-            for (auto constraintDeclRef :
-                 getMembers(_getASTBuilder(), containerDeclRef))
+            for (auto constraintDeclRef : getMembers(_getASTBuilder(), containerDeclRef))
             {
-                if(auto typeConstraintDeclRef = constraintDeclRef.as<TypeConstraintDecl>())
+                if (auto typeConstraintDeclRef = constraintDeclRef.as<TypeConstraintDecl>())
                 {
                     // Note: In certain cases something takes the *syntactic* form of an inheritance
                     // clause, but it is not actually something that should be treated as implying
@@ -486,16 +485,18 @@ InheritanceInfo SharedSemanticsContext::_calcInheritanceInfo(
                             visitor.calcThisType(interfaceDeclRef));
                     }
 
-                    // The only case we will ever see a GenericTypeConstraintDecl inside a AggTypeDecl
-                    // is when AggTypeDecl is a associatedtype decl. In this case, we will only lookup
-                    // the type constraint if the constraint is on the associated type itself.
+                    // The only case we will ever see a GenericTypeConstraintDecl inside a
+                    // AggTypeDecl is when AggTypeDecl is a associatedtype decl. In this case, we
+                    // will only lookup the type constraint if the constraint is on the associated
+                    // type itself.
                     //
                     auto genericTypeConstraintDeclRef =
                         typeConstraintDeclRef.as<GenericTypeConstraintDecl>();
                     if (genericTypeConstraintDeclRef)
                     {
-                        // If the base expr on the constraint isn't even a `VarExpr`, then it can't be
-                        // referencing the associated type itself and we can skip this constraint.
+                        // If the base expr on the constraint isn't even a `VarExpr`, then it can't
+                        // be referencing the associated type itself and we can skip this
+                        // constraint.
                         if (!genericTypeConstraintDeclRef.getDecl()->sub.type &&
                             !as<VarExpr>(genericTypeConstraintDeclRef.getDecl()->sub.exp))
                             continue;
@@ -505,8 +506,8 @@ InheritanceInfo SharedSemanticsContext::_calcInheritanceInfo(
                         typeConstraintDeclRef,
                         DeclCheckState::CanUseBaseOfInheritanceDecl);
 
-                    // For generic type constraint decls, always make sure it is about the type being
-                    // checked.
+                    // For generic type constraint decls, always make sure it is about the type
+                    // being checked.
                     //
                     if (genericTypeConstraintDeclRef)
                     {
@@ -529,7 +530,9 @@ InheritanceInfo SharedSemanticsContext::_calcInheritanceInfo(
 
                     addDirectBaseType(baseType, satisfyingWitness);
                 }
-                else if (auto typeCoercionConstraintDeclRef = constraintDeclRef.as<TypeCoercionConstraintDecl>())
+                else if (
+                    auto typeCoercionConstraintDeclRef =
+                        constraintDeclRef.as<TypeCoercionConstraintDecl>())
                 {
                     tryToAddTypeCoercionConstraintFacet(typeCoercionConstraintDeclRef);
                 }
@@ -635,7 +638,10 @@ InheritanceInfo SharedSemanticsContext::_calcInheritanceInfo(
                     continue;
 
                 // Further check the constraint, since we now need the sup-type.
-                ensureDecl(&visitor, constraintDeclRef.getDecl(), DeclCheckState::CanSpecializeGeneric);
+                ensureDecl(
+                    &visitor,
+                    constraintDeclRef.getDecl(),
+                    DeclCheckState::CanSpecializeGeneric);
 
                 auto superType = getSup(astBuilder, constraintDeclRef);
 
@@ -643,12 +649,15 @@ InheritanceInfo SharedSemanticsContext::_calcInheritanceInfo(
                 // adding the base to our list of direct bases is as straightforward
                 // as in all the preceding cases.
                 //
-                auto satisfyingWitness =
-                    _getASTBuilder()->getDeclaredSubtypeWitness(selfType, superType, constraintDeclRef);
+                auto satisfyingWitness = _getASTBuilder()->getDeclaredSubtypeWitness(
+                    selfType,
+                    superType,
+                    constraintDeclRef);
                 addDirectBaseType(superType, satisfyingWitness);
             }
             else if (
-                auto typeCoercionConstraintDeclRef = genericDeclRefMember.as<TypeCoercionConstraintDecl>())
+                auto typeCoercionConstraintDeclRef =
+                    genericDeclRefMember.as<TypeCoercionConstraintDecl>())
             {
                 tryToAddTypeCoercionConstraintFacet(typeCoercionConstraintDeclRef);
             }

--- a/source/slang/slang-check-inheritance.cpp
+++ b/source/slang/slang-check-inheritance.cpp
@@ -549,64 +549,128 @@ InheritanceInfo SharedSemanticsContext::_calcInheritanceInfo(
         bool selfIsGenericParamType =
             isDeclRefTypeOf<GenericTypeParamDeclBase>(selfType) != nullptr;
 
-        for (auto constraintDeclRef :
-             getMembersOfType<GenericTypeConstraintDecl>(astBuilder, genericDeclRef))
+        for (auto genericDeclRefMember : getMembers(astBuilder, genericDeclRef))
         {
-            if (constraintDeclRef.getDecl()->checkState.isBeingChecked())
-                continue;
-
-            ensureDecl(&visitor, constraintDeclRef.getDecl(), DeclCheckState::ScopesWired);
-
-            // Check only the sub-type.
-            visitor.CheckConstraintSubType(constraintDeclRef.getDecl()->sub);
-            auto sub = constraintDeclRef.getDecl()->sub;
-
-            // If the sub-type part of the generic constraint is a member expression, it can't
-            // possibly be defining a constraint for a generic type parameter, so we skip it
-            // to avoid circular checking on the generic param type.
-            if (selfIsGenericParamType && as<MemberExpr>(sub.exp))
-                continue;
-
-            if (!sub.type)
-                sub = visitor.TranslateTypeNodeForced(sub);
-
-            // Canonicalize the constraint declRef to make sure we have a full reference to it.
-            constraintDeclRef =
-                createDefaultSubstitutionsIfNeeded(astBuilder, &visitor, constraintDeclRef)
-                    .as<GenericTypeConstraintDecl>();
-
-            auto subType = constraintDeclRef.substitute(astBuilder, sub.type);
-
-            // We only consider constraints where the type represented
-            // by `declRef` is the subtype, since those
-            // constraints are the ones that give us information about
-            // the declared supertypes.
-            //
-            auto subDeclRefType = as<DeclRefType>(subType);
-            if (!subDeclRefType)
+            if (auto constraintDeclRef = as<GenericTypeConstraintDecl>(genericDeclRefMember))
             {
-                if (auto subEachType = as<EachType>(subType))
-                {
-                    subDeclRefType = subEachType->getElementDeclRefType();
-                }
-                if (!subDeclRefType)
+                if (constraintDeclRef.getDecl()->checkState.isBeingChecked())
                     continue;
+
+                ensureDecl(&visitor, constraintDeclRef.getDecl(), DeclCheckState::ScopesWired);
+
+                // Check only the sub-type.
+                visitor.CheckConstraintSubType(constraintDeclRef.getDecl()->sub);
+                auto sub = constraintDeclRef.getDecl()->sub;
+
+                // If the sub-type part of the generic constraint is a member expression, it can't
+                // possibly be defining a constraint for a generic type parameter, so we skip it
+                // to avoid circular checking on the generic param type.
+                if (selfIsGenericParamType && as<MemberExpr>(sub.exp))
+                    continue;
+
+                if (!sub.type)
+                    sub = visitor.TranslateTypeNodeForced(sub);
+
+                // Canonicalize the constraint declRef to make sure we have a full reference to it.
+                constraintDeclRef =
+                    createDefaultSubstitutionsIfNeeded(astBuilder, &visitor, constraintDeclRef)
+                        .as<GenericTypeConstraintDecl>();
+
+                auto subType = constraintDeclRef.substitute(astBuilder, sub.type);
+
+                // We only consider constraints where the type represented
+                // by `declRef` is the subtype, since those
+                // constraints are the ones that give us information about
+                // the declared supertypes.
+                //
+                auto subDeclRefType = as<DeclRefType>(subType);
+                if (!subDeclRefType)
+                {
+                    if (auto subEachType = as<EachType>(subType))
+                    {
+                        subDeclRefType = subEachType->getElementDeclRefType();
+                    }
+                    if (!subDeclRefType)
+                        continue;
+                }
+                if (subDeclRefType->getDeclRef() != declRef)
+                    continue;
+
+                // Further check the constraint, since we now need the sup-type.
+                ensureDecl(&visitor, constraintDeclRef.getDecl(), DeclCheckState::CanSpecializeGeneric);
+
+                auto superType = getSup(astBuilder, constraintDeclRef);
+
+                // Because the constraint is a declared inheritance relationship,
+                // adding the base to our list of direct bases is as straightforward
+                // as in all the preceding cases.
+                //
+                auto satisfyingWitness =
+                    _getASTBuilder()->getDeclaredSubtypeWitness(selfType, superType, constraintDeclRef);
+                addDirectBaseType(superType, satisfyingWitness);
             }
-            if (subDeclRefType->getDeclRef() != declRef)
-                continue;
+            else if (
+                auto typeCoercionConstraintDeclRef = genericDeclRefMember.as<TypeCoercionConstraintDecl>())
+            {
+                auto typeCoercionConstraintDecl = typeCoercionConstraintDeclRef.getDecl();
+                ensureDecl(
+                    &visitor,
+                    typeCoercionConstraintDecl,
+                    DeclCheckState::CanSpecializeGeneric);
 
-            // Further check the constraint, since we now need the sup-type.
-            ensureDecl(&visitor, constraintDeclRef.getDecl(), DeclCheckState::CanSpecializeGeneric);
+                // Only add synthetic facets if the `selfType` is equal to the `toType`. Otherwise
+                // we will be adding $init's that are nonsensical. Expected form: `ToType __init(FromType);`.
+                auto toType = getToType(astBuilder, typeCoercionConstraintDecl);
+                if (!selfType->equals(toType))
+                    continue;
 
-            auto superType = getSup(astBuilder, constraintDeclRef);
+                auto fromType = getFromType(astBuilder, typeCoercionConstraintDecl);
 
-            // Because the constraint is a declared inheritance relationship,
-            // adding the base to our list of direct bases is as straightforward
-            // as in all the preceding cases.
-            //
-            auto satisfyingWitness =
-                _getASTBuilder()->getDeclaredSubtypeWitness(selfType, superType, constraintDeclRef);
-            addDirectBaseType(superType, satisfyingWitness);
+                // Create a synthetic-facet from our `KnownMethodDecl` and put inside it our synthetic-method
+                // that signifies that type-coercion with a particular type is possible
+                auto paramDecl = astBuilder->create<ParamDecl>();
+                paramDecl->type = TypeExp(fromType);
+                paramDecl->nameAndLoc.name = visitor.getName("value");
+                paramDecl->nameAndLoc.loc = typeCoercionConstraintDecl->loc;
+                
+                auto syntheticFunctionDecl = astBuilder->create<ConstructorDecl>();
+                syntheticFunctionDecl->returnType = TypeExp(toType);
+                syntheticFunctionDecl->nameAndLoc.name = visitor.getName("$init");
+                syntheticFunctionDecl->nameAndLoc.loc = typeCoercionConstraintDecl->loc;
+                syntheticFunctionDecl->addMember(paramDecl);
+
+                // `syntheticFunctionDecl` should be an implicit conversion if the constraint is `implicit`
+                if (auto implicitConversioModifier = typeCoercionConstraintDecl->findModifier<ImplicitConversionModifier>())
+                    addModifier(syntheticFunctionDecl, implicitConversioModifier);
+
+                auto parentDecl = getModule()->getModuleDecl();
+                DeclRef<KnownMethodDecl> syntheticFacetDeclRef =
+                    astBuilder->create<KnownMethodDecl>();
+                KnownMethodDecl* syntheticFacetDecl = syntheticFacetDeclRef.getDecl();
+                syntheticFacetDecl->constraintDecl = typeCoercionConstraintDecl;
+                syntheticFacetDecl->ownedScope = astBuilder->create<Scope>();
+                syntheticFacetDecl->ownedScope->parent = visitor.getScope(parentDecl);
+                syntheticFacetDecl->ownedScope->containerDecl = syntheticFacetDecl;
+                syntheticFacetDecl->parentDecl = parentDecl;
+                syntheticFacetDecl->nameAndLoc.loc = typeCoercionConstraintDecl->loc;
+                syntheticFacetDecl->addMember(syntheticFunctionDecl);
+                syntheticFacetDecl->thisType = selfType;
+                
+                auto syntheticAsAType = DeclRefType::create(astBuilder, syntheticFacetDeclRef);
+                auto syntheticAsAWitness = astBuilder->getTypeEqualityWitness(syntheticAsAType);
+
+                // Add a synthetic facet so that the frontend can pretend they have access to a
+                // valid `__init` function. This facet is `self` since the definition must come
+                // directly from `toType` for it to be an `__init`.
+                Facet typeCoercionFacet = new (arena) Facet::Impl(
+                    astBuilder,
+                    selfFacetKind,
+                    Facet::Directness::Self,
+                    syntheticFacetDeclRef,
+                    syntheticAsAType,
+                    syntheticAsAWitness);
+                allFacets.add(typeCoercionFacet);
+            }
         }
     }
 

--- a/source/slang/slang-check-inheritance.cpp
+++ b/source/slang/slang-check-inheritance.cpp
@@ -640,8 +640,8 @@ InheritanceInfo SharedSemanticsContext::_calcInheritanceInfo(
                 syntheticFunctionDecl->addMember(paramDecl);
 
                 // `syntheticFunctionDecl` should be an implicit conversion if the constraint is `implicit`
-                if (auto implicitConversioModifier = typeCoercionConstraintDecl->findModifier<ImplicitConversionModifier>())
-                    addModifier(syntheticFunctionDecl, implicitConversioModifier);
+                if (auto implicitConversionModifier = typeCoercionConstraintDecl->findModifier<ImplicitConversionModifier>())
+                    addModifier(syntheticFunctionDecl, implicitConversionModifier);
 
                 auto parentDecl = getModule()->getModuleDecl();
                 DeclRef<KnownMethodDecl> syntheticFacetDeclRef =

--- a/source/slang/slang-check-inheritance.cpp
+++ b/source/slang/slang-check-inheritance.cpp
@@ -624,38 +624,8 @@ InheritanceInfo SharedSemanticsContext::_calcInheritanceInfo(
                 if (!selfType->equals(toType))
                     continue;
 
-                auto fromType = getFromType(astBuilder, typeCoercionConstraintDecl);
 
-                // Create a synthetic-facet from our `KnownMethodDecl` and put inside it our synthetic-method
-                // that signifies that type-coercion with a particular type is possible
-                auto paramDecl = astBuilder->create<ParamDecl>();
-                paramDecl->type = TypeExp(fromType);
-                paramDecl->nameAndLoc.name = visitor.getName("value");
-                paramDecl->nameAndLoc.loc = typeCoercionConstraintDecl->loc;
-                
-                auto syntheticFunctionDecl = astBuilder->create<ConstructorDecl>();
-                syntheticFunctionDecl->returnType = TypeExp(toType);
-                syntheticFunctionDecl->nameAndLoc.name = visitor.getName("$init");
-                syntheticFunctionDecl->nameAndLoc.loc = typeCoercionConstraintDecl->loc;
-                syntheticFunctionDecl->addMember(paramDecl);
-
-                // `syntheticFunctionDecl` should be an implicit conversion if the constraint is `implicit`
-                if (auto implicitConversionModifier = typeCoercionConstraintDecl->findModifier<ImplicitConversionModifier>())
-                    addModifier(syntheticFunctionDecl, implicitConversionModifier);
-
-                auto parentDecl = getModule()->getModuleDecl();
-                DeclRef<KnownMethodDecl> syntheticFacetDeclRef =
-                    astBuilder->create<KnownMethodDecl>();
-                KnownMethodDecl* syntheticFacetDecl = syntheticFacetDeclRef.getDecl();
-                syntheticFacetDecl->constraintDecl = typeCoercionConstraintDecl;
-                syntheticFacetDecl->ownedScope = astBuilder->create<Scope>();
-                syntheticFacetDecl->ownedScope->parent = visitor.getScope(parentDecl);
-                syntheticFacetDecl->ownedScope->containerDecl = syntheticFacetDecl;
-                syntheticFacetDecl->parentDecl = parentDecl;
-                syntheticFacetDecl->nameAndLoc.loc = typeCoercionConstraintDecl->loc;
-                syntheticFacetDecl->addMember(syntheticFunctionDecl);
-                syntheticFacetDecl->thisType = selfType;
-                
+                auto syntheticFacetDeclRef = typeCoercionConstraintDecl->syntheticFacetDeclRef;
                 auto syntheticAsAType = DeclRefType::create(astBuilder, syntheticFacetDeclRef);
                 auto syntheticAsAWitness = astBuilder->getTypeEqualityWitness(syntheticAsAType);
 

--- a/source/slang/slang-check-inheritance.cpp
+++ b/source/slang/slang-check-inheritance.cpp
@@ -405,6 +405,37 @@ InheritanceInfo SharedSemanticsContext::_calcInheritanceInfo(
         return result;
     };
 
+    
+    auto tryToAddTypeCoercionConstraintFacet =
+        [&](DeclRef<TypeCoercionConstraintDecl> typeCoercionConstraintDeclRef)
+    {
+        auto typeCoercionConstraintDecl = typeCoercionConstraintDeclRef.getDecl();
+        ensureDecl(&visitor, typeCoercionConstraintDecl, DeclCheckState::CanSpecializeGeneric);
+
+        // Only add synthetic facets if the `selfType` is equal to the `toType`. Otherwise
+        // we will be adding $init's that are nonsensical. Expected form: `ToType
+        // __init(FromType);`.
+        auto toType = getToType(astBuilder, typeCoercionConstraintDeclRef);
+        if (!selfType->equals(toType))
+            return;
+
+        auto syntheticFacetDeclRef = typeCoercionConstraintDecl->syntheticFacetDeclRef;
+        auto syntheticAsAType = DeclRefType::create(astBuilder, syntheticFacetDeclRef);
+        auto syntheticAsAWitness = astBuilder->getTypeEqualityWitness(syntheticAsAType);
+
+        // Add a synthetic facet so that the frontend can pretend they have access to a
+        // valid `__init` function. This facet is `self` since the definition must come
+        // directly from `toType` for it to be an `__init`.
+        Facet typeCoercionFacet = new (arena) Facet::Impl(
+            astBuilder,
+            selfFacetKind,
+            Facet::Directness::Self,
+            syntheticFacetDeclRef,
+            syntheticAsAType,
+            syntheticAsAWitness);
+        allFacets.add(typeCoercionFacet);
+    };
+
     // We now look at the structure of the declaration itself
     // to help us enumerate the direct bases.
     //
@@ -418,83 +449,90 @@ InheritanceInfo SharedSemanticsContext::_calcInheritanceInfo(
             // In the case where we have an aggregate type or `extension`
             // declaration, we can use the explicit list of direct bases.
             //
-            for (auto typeConstraintDeclRef :
-                 getMembersOfType<TypeConstraintDecl>(_getASTBuilder(), containerDeclRef))
+            for (auto constraintDeclRef :
+                 getMembers(_getASTBuilder(), containerDeclRef))
             {
-                // Note: In certain cases something takes the *syntactic* form of an inheritance
-                // clause, but it is not actually something that should be treated as implying
-                // a subtype relationship. For example, an `enum` declaration can use what looks
-                // like an inheritance clause to indicate its underlying "tag type."
-                //
-                // We skip such pseudo-inheritance relationships for the purposes of determining
-                // the linearized list of bases.
-                //
-                if (typeConstraintDeclRef.getDecl()->hasModifier<IgnoreForLookupModifier>())
-                    continue;
-
-                Type* subTypeForWitness = selfType;
-                if (auto interfaceDeclRef = containerDeclRef.as<InterfaceDecl>())
+                if(auto typeConstraintDeclRef = constraintDeclRef.as<TypeConstraintDecl>())
                 {
-                    // If we're dealing with an interface decl, we'll need to
-                    // represent the constraint as a lookup on the 'this' type of the
-                    // interface.
+                    // Note: In certain cases something takes the *syntactic* form of an inheritance
+                    // clause, but it is not actually something that should be treated as implying
+                    // a subtype relationship. For example, an `enum` declaration can use what looks
+                    // like an inheritance clause to indicate its underlying "tag type."
                     //
+                    // We skip such pseudo-inheritance relationships for the purposes of determining
+                    // the linearized list of bases.
+                    //
+                    if (typeConstraintDeclRef.getDecl()->hasModifier<IgnoreForLookupModifier>())
+                        continue;
 
-                    typeConstraintDeclRef = substituteDeclRef(
-                                                SubstitutionSet(declRef),
-                                                astBuilder,
-                                                visitor.getRequirementAsLookedUpDecl(
+                    Type* subTypeForWitness = selfType;
+                    if (auto interfaceDeclRef = containerDeclRef.as<InterfaceDecl>())
+                    {
+                        // If we're dealing with an interface decl, we'll need to
+                        // represent the constraint as a lookup on the 'this' type of the
+                        // interface.
+                        //
+
+                        typeConstraintDeclRef = substituteDeclRef(
+                                                    SubstitutionSet(declRef),
                                                     astBuilder,
-                                                    typeConstraintDeclRef.getDecl()))
-                                                .as<TypeConstraintDecl>();
-                    subTypeForWitness = substituteType(
-                        SubstitutionSet(declRef),
-                        astBuilder,
-                        visitor.calcThisType(interfaceDeclRef));
-                }
+                                                    visitor.getRequirementAsLookedUpDecl(
+                                                        astBuilder,
+                                                        typeConstraintDeclRef.getDecl()))
+                                                    .as<TypeConstraintDecl>();
+                        subTypeForWitness = substituteType(
+                            SubstitutionSet(declRef),
+                            astBuilder,
+                            visitor.calcThisType(interfaceDeclRef));
+                    }
 
-                // The only case we will ever see a GenericTypeConstraintDecl inside a AggTypeDecl
-                // is when AggTypeDecl is a associatedtype decl. In this case, we will only lookup
-                // the type constraint if the constraint is on the associated type itself.
-                //
-                auto genericTypeConstraintDeclRef =
-                    typeConstraintDeclRef.as<GenericTypeConstraintDecl>();
-                if (genericTypeConstraintDeclRef)
-                {
-                    // If the base expr on the constraint isn't even a `VarExpr`, then it can't be
-                    // referencing the associated type itself and we can skip this constraint.
-                    if (!genericTypeConstraintDeclRef.getDecl()->sub.type &&
-                        !as<VarExpr>(genericTypeConstraintDeclRef.getDecl()->sub.exp))
+                    // The only case we will ever see a GenericTypeConstraintDecl inside a AggTypeDecl
+                    // is when AggTypeDecl is a associatedtype decl. In this case, we will only lookup
+                    // the type constraint if the constraint is on the associated type itself.
+                    //
+                    auto genericTypeConstraintDeclRef =
+                        typeConstraintDeclRef.as<GenericTypeConstraintDecl>();
+                    if (genericTypeConstraintDeclRef)
+                    {
+                        // If the base expr on the constraint isn't even a `VarExpr`, then it can't be
+                        // referencing the associated type itself and we can skip this constraint.
+                        if (!genericTypeConstraintDeclRef.getDecl()->sub.type &&
+                            !as<VarExpr>(genericTypeConstraintDeclRef.getDecl()->sub.exp))
+                            continue;
+                    }
+
+                    visitor.ensureDecl(
+                        typeConstraintDeclRef,
+                        DeclCheckState::CanUseBaseOfInheritanceDecl);
+
+                    // For generic type constraint decls, always make sure it is about the type being
+                    // checked.
+                    //
+                    if (genericTypeConstraintDeclRef)
+                    {
+                        auto subType = getSub(astBuilder, genericTypeConstraintDeclRef);
+                        if (subType != selfType)
+                            continue;
+                    }
+                    else if (currentDeclRef != declRef)
+                    {
                         continue;
+                    }
+                    // The base type and subtype witness can easily be determined
+                    // using the `InheritanceDecl`.
+                    //
+                    auto baseType = getSup(astBuilder, typeConstraintDeclRef);
+                    auto satisfyingWitness = astBuilder->getDeclaredSubtypeWitness(
+                        subTypeForWitness,
+                        baseType,
+                        typeConstraintDeclRef);
+
+                    addDirectBaseType(baseType, satisfyingWitness);
                 }
-
-                visitor.ensureDecl(
-                    typeConstraintDeclRef,
-                    DeclCheckState::CanUseBaseOfInheritanceDecl);
-
-                // For generic type constraint decls, always make sure it is about the type being
-                // checked.
-                //
-                if (genericTypeConstraintDeclRef)
+                else if (auto typeCoercionConstraintDeclRef = constraintDeclRef.as<TypeCoercionConstraintDecl>())
                 {
-                    auto subType = getSub(astBuilder, genericTypeConstraintDeclRef);
-                    if (subType != selfType)
-                        continue;
+                    tryToAddTypeCoercionConstraintFacet(typeCoercionConstraintDeclRef);
                 }
-                else if (currentDeclRef != declRef)
-                {
-                    continue;
-                }
-                // The base type and subtype witness can easily be determined
-                // using the `InheritanceDecl`.
-                //
-                auto baseType = getSup(astBuilder, typeConstraintDeclRef);
-                auto satisfyingWitness = astBuilder->getDeclaredSubtypeWitness(
-                    subTypeForWitness,
-                    baseType,
-                    typeConstraintDeclRef);
-
-                addDirectBaseType(baseType, satisfyingWitness);
             }
         }
 
@@ -612,34 +650,7 @@ InheritanceInfo SharedSemanticsContext::_calcInheritanceInfo(
             else if (
                 auto typeCoercionConstraintDeclRef = genericDeclRefMember.as<TypeCoercionConstraintDecl>())
             {
-                auto typeCoercionConstraintDecl = typeCoercionConstraintDeclRef.getDecl();
-                ensureDecl(
-                    &visitor,
-                    typeCoercionConstraintDecl,
-                    DeclCheckState::CanSpecializeGeneric);
-
-                // Only add synthetic facets if the `selfType` is equal to the `toType`. Otherwise
-                // we will be adding $init's that are nonsensical. Expected form: `ToType __init(FromType);`.
-                auto toType = getToType(astBuilder, typeCoercionConstraintDecl);
-                if (!selfType->equals(toType))
-                    continue;
-
-
-                auto syntheticFacetDeclRef = typeCoercionConstraintDecl->syntheticFacetDeclRef;
-                auto syntheticAsAType = DeclRefType::create(astBuilder, syntheticFacetDeclRef);
-                auto syntheticAsAWitness = astBuilder->getTypeEqualityWitness(syntheticAsAType);
-
-                // Add a synthetic facet so that the frontend can pretend they have access to a
-                // valid `__init` function. This facet is `self` since the definition must come
-                // directly from `toType` for it to be an `__init`.
-                Facet typeCoercionFacet = new (arena) Facet::Impl(
-                    astBuilder,
-                    selfFacetKind,
-                    Facet::Directness::Self,
-                    syntheticFacetDeclRef,
-                    syntheticAsAType,
-                    syntheticAsAWitness);
-                allFacets.add(typeCoercionFacet);
+                tryToAddTypeCoercionConstraintFacet(typeCoercionConstraintDeclRef);
             }
         }
     }

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -3859,7 +3859,7 @@ err(
 err(
     "type-coerce-constraint-to-type-must-be-defined-in-the-current-scopes-generic",
     38044,
-    "type coerce constraint ToType must be defined in the current scopes generic parameter list",
+    "type coerce constraint ToType must be defined in the current scope's generic parameter list",
     span { loc = "location", message = "the ToType of a type coerce constraint ('~toType:Type') must be defined in the current scope's generic parameter list. Consider adding to '~locationOfGenericParameterList:Decl' the generic parameter 'ToType' with constraint 'where ToType == ~toType:Type'" }
 )
 

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -3856,6 +3856,13 @@ err(
     span { loc = "location", message = "'~fromType:Type' is not convertible to '~toType:Type', not satisfying the type coerce constraint '~toType:Type(~fromType:Type)'" }
 )
 
+err(
+    "type-coerce-constraint-to-type-must-be-defined-in-the-current-scopes-generic",
+    38044,
+    "type coerce constraint ToType must be defined in the current scopes generic parameter list",
+    span { loc = "location", message = "the ToType of a type coerce constraint ('~toType:Type') must be defined in the current scope's generic parameter list. Consider adding to '~locationOfGenericParameterList:Decl' the generic parameter 'ToType' with constraint 'where ToType == ~toType:Type'" }
+)
+
 --
 -- 382xx: module imports
 --

--- a/source/slang/slang-ir-remove-unused-generic-param.cpp
+++ b/source/slang/slang-ir-remove-unused-generic-param.cpp
@@ -131,9 +131,12 @@ struct RemoveUnusedGenericParamContext : InstPassBase
                                 specialize->getBase(),
                                 newArgs.getCount(),
                                 newArgs.getBuffer());
-                            specialize->transferDecorationsTo(newSpecialize);
-                            specialize->replaceUsesWith(newSpecialize);
-                            specialize->removeAndDeallocate();
+                            if (specialize != newSpecialize)
+                            {
+                                specialize->transferDecorationsTo(newSpecialize);
+                                specialize->replaceUsesWith(newSpecialize);
+                                specialize->removeAndDeallocate();
+                            }
                         }
                     }
                     for (auto param : paramsToRemove)

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -11866,11 +11866,13 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         TypeCoercionConstraintDecl* constraintDecl)
     {
         auto subBuilder = subContext->irBuilder;
-        auto fromType = lowerType(subContext, constraintDecl->fromType.Ptr());
-        auto toType = lowerType(subContext, constraintDecl->toType);
-        auto funcType = subBuilder->getFuncType(1, &fromType, toType);
+        auto subFromType = getFromType(subContext->astBuilder, constraintDecl);
+        auto irFromType = lowerType(subContext, subFromType);
+        auto subToType = getToType(subContext->astBuilder, constraintDecl);
+        auto irToType = lowerType(subContext, subToType);
+        auto funcType = subBuilder->getFuncType(1, &irFromType, irToType);
         auto param = subBuilder->emitParam(funcType);
-        addNameHint(context, param, constraintDecl);
+        addNameHint(context, param, "$init");
         subContext->setValue(constraintDecl, LoweredValInfo::simple(param));
     }
 
@@ -13770,7 +13772,16 @@ LoweredValInfo emitDeclRef(IRGenContext* context, Decl* decl, DeclRefBase* subst
     const auto initialSubst = subst;
     SLANG_UNUSED(initialSubst);
 
-
+    if (auto memberConstraintDeclRef = as<MemberConstraintDeclRef>(subst))
+    {
+        auto constraintDecl = memberConstraintDeclRef->getConstraintDecl();
+        // `TypeCoercionWitness` should map to a `Param` already in an outer scope generic.
+        // This `Param` is subsituted out during specialization to resolve our method.
+        auto loweredDeclInfo = context->findLoweredDecl(constraintDecl);
+        SLANG_ASSERT(loweredDeclInfo);
+        return *loweredDeclInfo;
+    }
+    
     if (as<ThisTypeDecl>(decl))
     {
         // A declref to ThisType decl should be lowered differently

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9859,7 +9859,14 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
     LoweredValInfo visitTypeCoercionConstraintDecl(TypeCoercionConstraintDecl* decl)
     {
-        if (const auto globalGenericParamDecl = as<GlobalGenericParamDecl>(decl->parentDecl))
+        if (auto assocTypeDecl = as<AssocTypeDecl>(decl->parentDecl))
+        {
+            if (const auto interfaceDecl = as<InterfaceDecl>(assocTypeDecl->parentDecl))
+            {
+                return LoweredValInfo::simple(getInterfaceRequirementKey(decl));
+            }
+        }
+        else if (const auto globalGenericParamDecl = as<GlobalGenericParamDecl>(decl->parentDecl))
         {
             SLANG_UNUSED(globalGenericParamDecl);
             auto builder = getBuilder();

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -13820,7 +13820,7 @@ LoweredValInfo emitDeclRef(IRGenContext* context, Decl* decl, DeclRefBase* subst
         SLANG_ASSERT(loweredDeclInfo);
         return *loweredDeclInfo;
     }
-    
+
     if (as<ThisTypeDecl>(decl))
     {
         // A declref to ThisType decl should be lowered differently

--- a/source/slang/slang-syntax.h
+++ b/source/slang/slang-syntax.h
@@ -16,14 +16,14 @@ inline Type* getSup(ASTBuilder* astBuilder, DeclRef<TypeConstraintDecl> const& d
     return declRef.substitute(astBuilder, declRef.getDecl()->getSup().type);
 }
 
+inline Type* getToType(ASTBuilder* astBuilder, DeclRef<TypeCoercionConstraintDecl> const& declRef)
+{
+    return declRef.substitute(astBuilder, declRef.getDecl()->toType.Ptr());
+}
+
 inline Type* getFromType(ASTBuilder* astBuilder, DeclRef<TypeCoercionConstraintDecl> const& declRef)
 {
     return declRef.substitute(astBuilder, declRef.getDecl()->fromType.Ptr());
-}
-
-inline Type* getToType(ASTBuilder* astBuilder, DeclRef<TypeCoercionConstraintDecl> const& declRef)
-{
-    return declRef.substitute(astBuilder, declRef.getDecl()->toType);
 }
 
 inline Type* getBaseType(

--- a/source/slang/slang.natvis
+++ b/source/slang/slang.natvis
@@ -349,6 +349,7 @@
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::EmptyDecl">(Slang::EmptyDecl*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::SyntaxDecl">(Slang::SyntaxDecl*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::DeclGroup">(Slang::DeclGroup*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::TypeCoercionConstraintDecl">(Slang::TypeCoercionConstraintDecl*)&amp;astNodeType</ExpandedItem>
             <Item Name="Decl">(Slang::DeclBase*)this,!</Item>
         </Expand>
     </Type>
@@ -395,6 +396,7 @@
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::EmptyDecl">(Slang::EmptyDecl*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::SyntaxDecl">(Slang::SyntaxDecl*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::DeclGroup">(Slang::DeclGroup*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::TypeCoercionConstraintDecl">(Slang::TypeCoercionConstraintDecl*)&amp;astNodeType</ExpandedItem>
             <Item Name="Decl">(Slang::Decl*)this,!</Item>
         </Expand>
     </Type>

--- a/source/slang/slang.natvis
+++ b/source/slang/slang.natvis
@@ -350,6 +350,7 @@
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::SyntaxDecl">(Slang::SyntaxDecl*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::DeclGroup">(Slang::DeclGroup*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::TypeCoercionConstraintDecl">(Slang::TypeCoercionConstraintDecl*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::KnownMethodDecl">(Slang::KnownMethodDecl*)&amp;astNodeType</ExpandedItem>
             <Item Name="Decl">(Slang::DeclBase*)this,!</Item>
         </Expand>
     </Type>
@@ -397,6 +398,7 @@
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::SyntaxDecl">(Slang::SyntaxDecl*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::DeclGroup">(Slang::DeclGroup*)&amp;astNodeType</ExpandedItem>
             <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::TypeCoercionConstraintDecl">(Slang::TypeCoercionConstraintDecl*)&amp;astNodeType</ExpandedItem>
+            <ExpandedItem Condition="astNodeType == Slang::ASTNodeType::KnownMethodDecl">(Slang::KnownMethodDecl*)&amp;astNodeType</ExpandedItem>
             <Item Name="Decl">(Slang::Decl*)this,!</Item>
         </Expand>
     </Type>

--- a/tests/language-feature/extensions/extension-with-where-clause-2.slang
+++ b/tests/language-feature/extensions/extension-with-where-clause-2.slang
@@ -1,6 +1,6 @@
-//TEST:SIMPLE(filecheck=CHECK_FAIL): -target spirv -entry computeMain -stage compute -DFAIL
-//TEST:SIMPLE(filecheck=CHECK_PASS): -target spirv -entry computeMain -stage compute
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK): -slang -compute -shaderobj -output-using-type
+// TEST:SIMPLE(filecheck=CHECK_FAIL): -target spirv -entry computeMain -stage compute -DFAIL
+// TEST:SIMPLE(filecheck=CHECK_PASS): -target spirv -entry computeMain -stage compute
+// TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK): -slang -compute -shaderobj -output-using-type -xslang -Wno-30856
 
 interface ITwoParamGeneric<A, B>
 {
@@ -21,12 +21,19 @@ struct NotPrimitiveCastable
     double data;
 }
 
-extension<A, B> Foo<A,B> 
-    where int(A)
+extension<A, B, C,
 #ifdef FAIL
-    where NotPrimitiveCastable(B)
+    D,
+#endif
+    E> Foo<A,B> 
+    where C == int
+    where C(A)
+#ifdef FAIL
+    where D == NotPrimitiveCastable
+    where D(B)
 #else
-    where float(B)
+    where E == float
+    where E(B)
 #endif
 {
     [mutating]

--- a/tests/language-feature/generics/type-coerce-constraint-3.slang
+++ b/tests/language-feature/generics/type-coerce-constraint-3.slang
@@ -1,0 +1,51 @@
+//TEST:SIMPLE(filecheck=NEGATIVE_CHECK_1): -target spirv -stage compute -entry computeMain -DNEGATIVE_CHECK_1
+
+// NEGATIVE_CHECK_1 tests that the compile fails since `FromType` cannot be converted to `ToType` given the
+// type information the user provided to the function. More `where` constraints would be needed to get
+// this code to compile: super-type constraints or type-coerce-constraint.
+
+struct CustomStruct1
+{
+    int data = 1;
+    int getData()
+    {
+        return data;
+    }
+}
+struct CustomStruct2
+{
+    int data = 1;
+    __init(CustomStruct1 other)
+    {
+        data = 2;
+    }
+    int getData()
+    {
+        return data;
+    }
+}
+
+RWStructuredBuffer<int> outputBuffer;
+
+// NEGATIVE_CHECK_1-DAG: note:
+// NEGATIVE_CHECK_1-DAG: {{.*}}:[[# @LINE+1]]:
+ToType castableConstraint<ToType, FromType>() where ToType(FromType)
+{
+    return ToType();
+}
+
+ToType logic<ToType, FromType>()
+{
+    // NEGATIVE_CHECK_1-DAG: error[E38043]:
+    // NEGATIVE_CHECK_1-DAG-NEXT: {{.*}}:[[# @LINE+1]]:
+    return castableConstraint<ToType, FromType>();
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // CHECK: 1
+    var t = logic<CustomStruct2, CustomStruct1>();
+    outputBuffer[0] = t.getData();
+}

--- a/tests/language-feature/generics/type-coerce-constraint-3.slang
+++ b/tests/language-feature/generics/type-coerce-constraint-3.slang
@@ -1,6 +1,6 @@
-//TEST:SIMPLE(filecheck=NEGATIVE_CHECK_1): -target spirv -stage compute -entry computeMain -DNEGATIVE_CHECK_1
+//TEST:SIMPLE(filecheck=NEGATIVE_CHECK): -target spirv -stage compute -entry computeMain
 
-// NEGATIVE_CHECK_1 tests that the compile fails since `FromType` cannot be converted to `ToType` given the
+// NEGATIVE_CHECK tests that the compile fails since `FromType` cannot be converted to `ToType` given the
 // type information the user provided to the function. More `where` constraints would be needed to get
 // this code to compile: super-type constraints or type-coerce-constraint.
 
@@ -27,8 +27,8 @@ struct CustomStruct2
 
 RWStructuredBuffer<int> outputBuffer;
 
-// NEGATIVE_CHECK_1-DAG: note:
-// NEGATIVE_CHECK_1-DAG: {{.*}}:[[# @LINE+1]]:
+// NEGATIVE_CHECK-DAG: note:
+// NEGATIVE_CHECK-DAG: {{.*}}:[[# @LINE+1]]:
 ToType castableConstraint<ToType, FromType>() where ToType(FromType)
 {
     return ToType();
@@ -36,8 +36,8 @@ ToType castableConstraint<ToType, FromType>() where ToType(FromType)
 
 ToType logic<ToType, FromType>()
 {
-    // NEGATIVE_CHECK_1-DAG: error[E38043]:
-    // NEGATIVE_CHECK_1-DAG: {{.*}}:[[# @LINE+1]]:
+    // NEGATIVE_CHECK-DAG: error[E38043]:
+    // NEGATIVE_CHECK-DAG: {{.*}}:[[# @LINE+1]]:
     return castableConstraint<ToType, FromType>();
 }
 

--- a/tests/language-feature/generics/type-coerce-constraint-3.slang
+++ b/tests/language-feature/generics/type-coerce-constraint-3.slang
@@ -37,7 +37,7 @@ ToType castableConstraint<ToType, FromType>() where ToType(FromType)
 ToType logic<ToType, FromType>()
 {
     // NEGATIVE_CHECK_1-DAG: error[E38043]:
-    // NEGATIVE_CHECK_1-DAG-NEXT: {{.*}}:[[# @LINE+1]]:
+    // NEGATIVE_CHECK_1-DAG: {{.*}}:[[# @LINE+1]]:
     return castableConstraint<ToType, FromType>();
 }
 

--- a/tests/language-feature/generics/type-coerce-constraint-4.slang
+++ b/tests/language-feature/generics/type-coerce-constraint-4.slang
@@ -1,0 +1,57 @@
+// TEST(compute):COMPARE_COMPUTE(filecheck-buffer=POSITIVE_CHECK): -slang -compute
+// TEST(compute):COMPARE_COMPUTE(filecheck-buffer=POSITIVE_CHECK): -vk -compute
+
+// POSITIVE_CHECK tests that the compile works since FromType can be converted to ToType
+// via the info the type-coerce-constraint propagates (`where ToType(FromType)`) from the `logic` method.
+
+// TEST_INPUT:ubuffer(data=[2 3 0 0], stride=4)name=inputBuffer
+RWStructuredBuffer<int> inputBuffer;
+
+// TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+struct CustomStruct1
+{
+    int data = 1;
+    __init(int other)
+    {
+        data = other;
+    }
+    int getData()
+    {
+        return data;
+    }
+}
+struct CustomStruct2
+{
+    int data = 1;
+    __init(CustomStruct1 other)
+    {
+        data = other.getData()+inputBuffer[1];
+    }
+    int getData()
+    {
+        return data;
+    }
+}
+
+ToType castableConstraint<ToType, FromType>(FromType dataIn) where ToType(FromType)
+{
+    return ToType(dataIn);
+}
+
+ToType logic<ToType, FromType>(FromType dataIn) where ToType(FromType)
+{
+    return castableConstraint<ToType, FromType>(dataIn);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // POSITIVE_CHECK: 5
+    int data = inputBuffer[0];
+    CustomStruct1 dataIn = CustomStruct1(data);
+    var t = logic<CustomStruct2, CustomStruct1>(dataIn);
+    outputBuffer[0] = t.getData();
+}

--- a/tests/language-feature/generics/type-coerce-constraint-5.slang
+++ b/tests/language-feature/generics/type-coerce-constraint-5.slang
@@ -1,0 +1,62 @@
+// TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=POSITIVE_CHECK): -slang -compute -shaderobj
+// TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=POSITIVE_CHECK): -vk -compute -shaderobj
+
+// POSITIVE_CHECK tests a type-coerce-constraint in a struct generics argument list.
+
+struct WrappedData1
+{
+    int data;
+    __init(WrappedData2 other)
+    {
+        data = other.getData()+inputBuffer[1];
+    }
+    int getData()
+    {
+        return data;
+    }
+}
+
+struct WrappedData2
+{
+    int data;
+    __init(int other)
+    {
+        data = other;
+    }
+    int getData()
+    {
+        return data;
+    }
+}
+
+struct CustomStruct1<T, U> where T(U)
+{
+    T data;
+    __init(U other)
+    {
+        data = (T)other;
+    }
+    T getData()
+    {
+        return data;
+    }
+}
+
+// TEST_INPUT:ubuffer(data=[2 3 0 0], stride=4)name=inputBuffer
+RWStructuredBuffer<int> inputBuffer;
+
+// TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // POSITIVE_CHECK: 5
+    int data = inputBuffer[0];
+    WrappedData2 wrappedData = WrappedData2(data);
+    CustomStruct1<WrappedData1, WrappedData2> processedData =
+        CustomStruct1<WrappedData1, WrappedData2>(wrappedData);
+    outputBuffer[1] = 1;
+    outputBuffer[0] = processedData.getData().getData();
+}

--- a/tests/language-feature/generics/type-coerce-constraint-6.slang
+++ b/tests/language-feature/generics/type-coerce-constraint-6.slang
@@ -1,0 +1,59 @@
+// TEST(compute):COMPARE_COMPUTE(filecheck-buffer=POSITIVE_CHECK): -slang -compute
+// TEST(compute):COMPARE_COMPUTE(filecheck-buffer=POSITIVE_CHECK): -vk -compute
+
+// POSITIVE_CHECK tests that a user can declare/use nested concrete types in
+// their type-coerce-constraint, propegating type-coerce-constraint properties
+
+// TEST_INPUT:ubuffer(data=[2 3 0 0], stride=4)name=inputBuffer
+RWStructuredBuffer<int> inputBuffer;
+
+// TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+struct CustomStruct1
+{
+    int data = 1;
+    __init(int other)
+    {
+        data = other;
+    }
+    int getData()
+    {
+        return data;
+    }
+}
+struct CustomStruct2
+{
+    int data = 1;
+    __init(CustomStruct1 other)
+    {
+        data = other.getData()+inputBuffer[1];
+    }
+    int getData()
+    {
+        return data;
+    }
+}
+
+ToType castableConstraint<ToType, FromType>(FromType dataIn) where ToType(FromType)
+{
+    return ToType(dataIn);
+}
+
+ToType logic<ToType, FromType>(FromType dataIn)
+    where ToType == CustomStruct2
+    where ToType(FromType)
+{
+    return castableConstraint<ToType, FromType>(dataIn);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // POSITIVE_CHECK: 5
+    int data = inputBuffer[0];
+    CustomStruct1 dataIn = CustomStruct1(data);
+    var t = logic(dataIn);
+    outputBuffer[0] = t.getData();
+}

--- a/tests/language-feature/generics/type-coerce-constraint-7.slang
+++ b/tests/language-feature/generics/type-coerce-constraint-7.slang
@@ -1,6 +1,7 @@
-//TEST:SIMPLE(filecheck=NEGATIVE_CHECK_1): -target spirv -stage compute -entry computeMain
+//TEST:SIMPLE(filecheck=NEGATIVE_CHECK): -target spirv -stage compute -entry computeMain
 
-// tests that we emit an error when a user uses a concrete type as a ToType for a type coercion constraint
+// NEGATIVE_CHECK tests that we emit an error when a user uses a concrete type as a ToType for a type coercion constraint
+// and this ToType does not have its declaration in the immediate parent generic argument list
 
 RWStructuredBuffer<int> inputBuffer;
 RWStructuredBuffer<int> outputBuffer;
@@ -33,22 +34,22 @@ struct CustomStruct2
 CustomStruct2 logic<FromType>(FromType dataIn)
     where CustomStruct2(FromType)
 {
-    // NEGATIVE_CHECK_1-DAG: error[E38044]:
-    // NEGATIVE_CHECK_1-DAG: {{.*}}:[[# @LINE+1]]:
+    // NEGATIVE_CHECK-DAG: error[E38044]:
+    // NEGATIVE_CHECK-DAG: {{.*}}:[[# @LINE+1]]:
     return CustomStruct2(dataIn);
 }
 
 struct CustomStruct3<T>
 {
-    // NEGATIVE_CHECK_1-DAG: error[E38044]:
-    // NEGATIVE_CHECK_1-DAG: {{.*}}:[[# @LINE+1]]:
+    // NEGATIVE_CHECK-DAG: error[E38044]:
+    // NEGATIVE_CHECK-DAG: {{.*}}:[[# @LINE+1]]:
     void convert<>() where CustomStruct1(int)
     {
 
     }
 
-    // NEGATIVE_CHECK_1-DAG: error[E38044]:
-    // NEGATIVE_CHECK_1-DAG: {{.*}}:[[# @LINE+1]]:
+    // NEGATIVE_CHECK-DAG: error[E38044]:
+    // NEGATIVE_CHECK-DAG: {{.*}}:[[# @LINE+1]]:
     void convert<>() where T(int)
     {
 

--- a/tests/language-feature/generics/type-coerce-constraint-7.slang
+++ b/tests/language-feature/generics/type-coerce-constraint-7.slang
@@ -56,6 +56,14 @@ struct CustomStruct3<T>
     }
 }
 
+interface IAssociatedTypeStruct<T>
+{
+    associatedtype U;
+    // NEGATIVE_CHECK-DAG: error[E38044]:
+    // NEGATIVE_CHECK-DAG: {{.*}}:[[# @LINE+1]]:
+    associatedtype T where U(float);
+}
+
 [shader("compute")]
 [numthreads(1, 1, 1)]
 void computeMain()

--- a/tests/language-feature/generics/type-coerce-constraint-7.slang
+++ b/tests/language-feature/generics/type-coerce-constraint-7.slang
@@ -34,21 +34,21 @@ CustomStruct2 logic<FromType>(FromType dataIn)
     where CustomStruct2(FromType)
 {
     // NEGATIVE_CHECK_1-DAG: error[E38044]:
-    // NEGATIVE_CHECK_1-DAG-NEXT: {{.*}}:[[# @LINE+1]]:
+    // NEGATIVE_CHECK_1-DAG: {{.*}}:[[# @LINE+1]]:
     return CustomStruct2(dataIn);
 }
 
 struct CustomStruct3<T>
 {
     // NEGATIVE_CHECK_1-DAG: error[E38044]:
-    // NEGATIVE_CHECK_1-DAG-NEXT: {{.*}}:[[# @LINE+1]]:
+    // NEGATIVE_CHECK_1-DAG: {{.*}}:[[# @LINE+1]]:
     void convert<>() where CustomStruct1(int)
     {
 
     }
 
     // NEGATIVE_CHECK_1-DAG: error[E38044]:
-    // NEGATIVE_CHECK_1-DAG-NEXT: {{.*}}:[[# @LINE+1]]:
+    // NEGATIVE_CHECK_1-DAG: {{.*}}:[[# @LINE+1]]:
     void convert<>() where T(int)
     {
 

--- a/tests/language-feature/generics/type-coerce-constraint-7.slang
+++ b/tests/language-feature/generics/type-coerce-constraint-7.slang
@@ -1,0 +1,66 @@
+//TEST:SIMPLE(filecheck=NEGATIVE_CHECK_1): -target spirv -stage compute -entry computeMain
+
+// tests that we emit an error when a user uses a concrete type as a ToType for a type coercion constraint
+
+RWStructuredBuffer<int> inputBuffer;
+RWStructuredBuffer<int> outputBuffer;
+
+struct CustomStruct1
+{
+    int data = 1;
+    __init(int other)
+    {
+        data = other;
+    }
+    int getData()
+    {
+        return data;
+    }
+}
+struct CustomStruct2
+{
+    int data = 1;
+    __init(CustomStruct1 other)
+    {
+        data = other.getData()+inputBuffer[1];
+    }
+    int getData()
+    {
+        return data;
+    }
+}
+
+CustomStruct2 logic<FromType>(FromType dataIn)
+    where CustomStruct2(FromType)
+{
+    // NEGATIVE_CHECK_1-DAG: error[E38044]:
+    // NEGATIVE_CHECK_1-DAG-NEXT: {{.*}}:[[# @LINE+1]]:
+    return CustomStruct2(dataIn);
+}
+
+struct CustomStruct3<T>
+{
+    // NEGATIVE_CHECK_1-DAG: error[E38044]:
+    // NEGATIVE_CHECK_1-DAG-NEXT: {{.*}}:[[# @LINE+1]]:
+    void convert<>() where CustomStruct1(int)
+    {
+
+    }
+
+    // NEGATIVE_CHECK_1-DAG: error[E38044]:
+    // NEGATIVE_CHECK_1-DAG-NEXT: {{.*}}:[[# @LINE+1]]:
+    void convert<>() where T(int)
+    {
+
+    }
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    int data = inputBuffer[0];
+    CustomStruct1 dataIn = CustomStruct1(data);
+    var t = logic(dataIn);
+    outputBuffer[0] = t.getData();
+}

--- a/tests/language-feature/generics/type-coerce-constraint-8.slang
+++ b/tests/language-feature/generics/type-coerce-constraint-8.slang
@@ -1,0 +1,82 @@
+// TEST(compute):COMPARE_COMPUTE(filecheck-buffer=POSITIVE_CHECK): -slang -compute
+// TEST(compute):COMPARE_COMPUTE(filecheck-buffer=POSITIVE_CHECK): -vk -compute
+
+// POSITIVE_CHECK tests that Associated type works as expected with Type Coercion Constraints
+
+// TEST_INPUT:ubuffer(data=[1 2 3 0], stride=4)name=inputBuffer
+RWStructuredBuffer<int> inputBuffer;
+
+// TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+interface Data
+{
+    int getData();
+}
+struct DataImpl : Data
+{
+    int data;
+    __init(int other)
+    {
+        data = other + 1;
+    }
+    int getData()
+    {
+        return data;
+    }
+}
+
+interface MaybeCastInt
+{
+    int getData();
+}
+
+struct MaybeCastIntImpl1 : MaybeCastInt
+{
+    int data;
+    __init<T : Data>(T other)
+    {
+        data = other.getData() + 1;
+    }
+    int getData()
+    {
+        return data;
+    }
+}
+struct MaybeCastIntImpl2 : MaybeCastInt
+{
+    int data;
+    __init<T : Data>(T other)
+    {
+        data = other.getData() + 2;
+    }
+    int getData()
+    {
+        return data;
+    }
+}
+
+interface CustomStruct<U : Data>
+{
+    associatedtype T
+        where T : MaybeCastInt
+        where T(U);
+}
+
+  struct CustomStructImpl1<U : Data> : CustomStruct<U>
+{
+    typealias T = MaybeCastIntImpl1;
+}
+struct CustomStructImpl2<U : Data> : CustomStruct<U>
+{
+    typealias T = MaybeCastIntImpl2;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // POSITIVE_CHECK: 4
+    DataImpl loadedData = DataImpl(inputBuffer[1]);
+    outputBuffer[0] = CustomStructImpl1<DataImpl>().T(loadedData).getData();
+}

--- a/tests/language-feature/generics/type-coerce-constraint-9.slang
+++ b/tests/language-feature/generics/type-coerce-constraint-9.slang
@@ -1,0 +1,63 @@
+//TEST:SIMPLE(filecheck=NEGATIVE_CHECK): -target spirv -stage compute -entry computeMain
+
+// NEGATIVE_CHECK tests that Associated type fails to compile as expected with Type Coercion Constraints
+// due to non-conforming type
+
+// TEST_INPUT:ubuffer(data=[1 2 3 0], stride=4)name=inputBuffer
+RWStructuredBuffer<int> inputBuffer;
+
+// TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+interface MaybeCastInt
+{
+    int getData();
+}
+
+struct MaybeCastIntImpl1 : MaybeCastInt
+{
+    int data;
+    int getData()
+    {
+        return data;
+    }
+}
+struct MaybeCastIntImpl2 : MaybeCastInt
+{
+    int data;
+    int getData()
+    {
+        return data;
+    }
+}
+
+interface CustomStruct<U>
+{
+    associatedtype T
+        where T : MaybeCastInt
+        where T(U);
+}
+
+struct CustomStructImpl1<U> : CustomStruct<U>
+{
+    // NEGATIVE_CHECK-DAG: error[E38105]:
+    // NEGATIVE_CHECK-DAG: {{.*}}:[[# @LINE+1]]:
+    typealias T = MaybeCastIntImpl1;
+}
+struct CustomStructImpl2<U> : CustomStruct<U>
+{
+    typealias T = MaybeCastIntImpl2;
+}
+
+struct UncastableTarget
+{
+    int data1;
+    double data2;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    outputBuffer[0] = CustomStructImpl1<UncastableTarget>.T(inputBuffer[1]).getData();
+}


### PR DESCRIPTION
Necessary feature to implement #9003

Important Changes:
* Added logic so that Type Coercion Constraints function as expected by the user, allowing the user to access a constrained `__init` method (example: `tests\language-feature\generics\type-coerce-constraint-4.slang`). 
    * `KnownMethodDecl` was added to represent a synthetic facet that contains methods a type is known to have access to (but is resolved later on in IR). This concept connects to `MemberConstraintDeclRef` which is the result of a lookup into a `KnownMethodDecl`.
    * `KnownMethodDecl` is generated when building an InheritanceInfo with a `TypeCoercionConstraintDecl`. Refer to changes in `source/slang/slang-check-inheritance.cpp`.
    * Emit error when using types not defined in the same generic-param-list as the Type-coercion-constraint, as a `ToType`. This was done since it is fundementally incorrect to allow this behavior (the constraint should only apply for the current context, but for this we need a new type). This change is further described in the changes to `SemanticsDeclHeaderVisitor::visitTypeCoercionConstraintDecl`.

Note: the implementation direction was primarily for supporting type-coercion-constraints, although it seems the actual logic ended-up-with is fairly close to what would likely be needed for a more general 'explicit member [method] constraint'.