### PR TITLE
Fix crash when passing struct with interface field by value

### DIFF
--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -508,7 +508,7 @@ bool isGlobalInst(IRInst* inst)
 // accept the refinement (this is useful in cases like `UnsizedArrayType`, where
 // we only want to refine it if we can determine a concrete size).
 //
-bool isConcreteType(IRInst* inst)
+static bool isConcreteTypeImpl(IRInst* inst, HashSet<IRInst*>* visiting)
 {
     if (!inst)
         return false;
@@ -536,10 +536,10 @@ bool isConcreteType(IRInst* inst)
                                // methods that do use this
         return false;
     case kIROp_ArrayType:
-        return isConcreteType(cast<IRArrayType>(inst)->getElementType()) &&
+        return isConcreteTypeImpl(cast<IRArrayType>(inst)->getElementType(), visiting) &&
                isGlobalInst(cast<IRArrayType>(inst)->getElementCount());
     case kIROp_OptionalType:
-        return isConcreteType(cast<IROptionalType>(inst)->getValueType());
+        return isConcreteTypeImpl(cast<IROptionalType>(inst)->getValueType(), visiting);
     case kIROp_ConditionalType:
         {
             auto conditionalType = cast<IRConditionalType>(inst);
@@ -548,26 +548,47 @@ bool isConcreteType(IRInst* inst)
             {
                 if (!boolLit->getValue())
                     return true;
-                return isConcreteType(conditionalType->getValueType());
+                return isConcreteTypeImpl(conditionalType->getValueType(), visiting);
             }
             else if (auto intLit = as<IRIntLit>(hasValueInst))
             {
                 if (getIntVal(intLit) == 0)
                     return true;
-                return isConcreteType(conditionalType->getValueType());
+                return isConcreteTypeImpl(conditionalType->getValueType(), visiting);
             }
             return false;
         }
     case kIROp_DifferentialPairType:
-        return isConcreteType(cast<IRDifferentialPairTypeBase>(inst)->getValueType());
+        return isConcreteTypeImpl(cast<IRDifferentialPairTypeBase>(inst)->getValueType(), visiting);
     case kIROp_AttributedType:
-        return isConcreteType(cast<IRAttributedType>(inst)->getBaseType());
+        return isConcreteTypeImpl(cast<IRAttributedType>(inst)->getBaseType(), visiting);
     case kIROp_TupleType:
         {
             // Tuple is concrete if all element types are concrete
             for (UInt i = 0; i < inst->getOperandCount(); i++)
             {
-                if (!isConcreteType(inst->getOperand(i)))
+                if (!isConcreteTypeImpl(inst->getOperand(i), visiting))
+                    return false;
+            }
+            return true;
+        }
+    case kIROp_StructType:
+        {
+            // Struct is concrete only if all field types are concrete.
+            // A struct containing an interface-typed field is non-concrete
+            // and needs type-flow specialization.
+            // Use a visited set to guard against cyclic types (e.g. pack-branch
+            // types that resolve back to the same struct).
+            HashSet<IRInst*> localVisiting;
+            if (!visiting)
+                visiting = &localVisiting;
+            if (visiting->contains(inst))
+                return true; // Cycle detected: conservatively treat as concrete
+            visiting->add(inst);
+            auto structType = cast<IRStructType>(inst);
+            for (auto field : structType->getFields())
+            {
+                if (!isConcreteTypeImpl(field->getFieldType(), visiting))
                     return false;
             }
             return true;
@@ -580,7 +601,7 @@ bool isConcreteType(IRInst* inst)
     {
         if (ptrType->getAddressSpace() == AddressSpace::UserPointer)
             return true; // Don't refine user pointers (for now)
-        return isConcreteType(ptrType->getValueType());
+        return isConcreteTypeImpl(ptrType->getValueType(), visiting);
     }
 
     if (auto generic = as<IRGeneric>(inst))
@@ -590,6 +611,11 @@ bool isConcreteType(IRInst* inst)
     }
 
     return true;
+}
+
+bool isConcreteType(IRInst* inst)
+{
+    return isConcreteTypeImpl(inst, nullptr);
 }
 
 // Create info for a concrete type, using `paramType` as a union mask to determine
@@ -3882,8 +3908,14 @@ struct TypeFlowSpecializationContext
 
             if (!paramInfo)
             {
-                // Non-concrete param with no info yet - not ready to propagate.
-                return nullptr;
+                // Non-concrete param with no info yet - use VoidLit so the
+                // interprocedural edge is still registered. This allows
+                // propagation to proceed (e.g. diagnostics for __ref params
+                // with dynamic dispatch types) even before full info arrives.
+                IRBuilder builder(module);
+                bindings.add(builder.getVoidValue());
+                argIndex++;
+                continue;
             }
 
             hasAnyBinding = true;
@@ -6345,9 +6377,16 @@ struct TypeFlowSpecializationContext
         if (auto setTag = as<IRSetTagType>(callee->getDataType()))
         {
             // Expect a callee-set to be associated with call.
-            auto calleeSet =
-                cast<IRElementOfSetType>(this->callSiteInfo[InstWithContext(context, inst)])
-                    ->getSet();
+            // The info-propagation phase may not record this call site when a
+            // struct with an existential field is passed by value — bail out
+            // gracefully instead of crashing on a missing dictionary entry.
+            auto callSiteInfoPtr = this->callSiteInfo.tryGetValue(InstWithContext(context, inst));
+            if (!callSiteInfoPtr || !*callSiteInfoPtr)
+            {
+                module->getContainerPool().free(&callArgs);
+                return false;
+            }
+            auto calleeSet = cast<IRElementOfSetType>(*callSiteInfoPtr)->getSet();
             if (!calleeSet->isSingleton() && !calleeSet->isEmpty())
             {
                 // Multiple callees case:
@@ -6478,9 +6517,13 @@ struct TypeFlowSpecializationContext
         }
         else if (isGlobalInst(callee))
         {
-            auto calleeSet =
-                as<IRElementOfSetType>(this->callSiteInfo[InstWithContext(context, inst)])
-                    ->getSet();
+            auto callSiteInfoPtr = this->callSiteInfo.tryGetValue(InstWithContext(context, inst));
+            if (!callSiteInfoPtr || !*callSiteInfoPtr)
+            {
+                module->getContainerPool().free(&callArgs);
+                return false;
+            }
+            auto calleeSet = as<IRElementOfSetType>(*callSiteInfoPtr)->getSet();
             SLANG_ASSERT(calleeSet->isSingleton());
 
             if (isIntrinsic(callee))

--- a/tests/bugs/gh-10394.slang
+++ b/tests/bugs/gh-10394.slang
@@ -1,0 +1,40 @@
+// Test that passing a struct with an interface-typed field by value to a
+// function compiles successfully for the CPU/C++ target.
+// See: https://github.com/shader-slang/slang/issues/10394
+
+//TEST:SIMPLE(filecheck=CHECK): -target cpp -stage compute -entry computeMain -conformance "ImplA:IFoo=0"
+
+[anyValueSize(8)]
+interface IFoo
+{
+    int getValue();
+}
+
+struct ImplA : IFoo
+{
+    int v;
+    int getValue() { return v; }
+}
+
+struct Params
+{
+    IFoo foo;
+    int scale;
+}
+
+int dispatch(Params p)
+{
+    return p.foo.getValue() * p.scale;
+}
+
+ConstantBuffer<Params> gParams;
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    outputBuffer[0] = dispatch(gParams);
+}
+
+// CHECK: getValue
+// CHECK: computeMain


### PR DESCRIPTION
## Summary
- Fix segfault/assertion failure when passing a struct containing an interface-typed field by value to a function
- Add `kIROp_StructType` handling to `isConcreteType()` so the type-flow pass correctly identifies structs with interface fields as non-concrete
- Fix `maybeGetBoundFunc()` to register interprocedural edges even when parameter info is unavailable
- Add defensive guards in `specializeCall()` to prevent crashes from missing propagation info

## Motivation
Fixes #10394. Enables the DISABLED tests in #10393.

When `isConcreteType()` encounters a struct type, it falls through to the default `return true`. This causes the type-flow specialization pass to skip inter-procedural existential propagation for functions receiving such structs. `extractExistentialType` inside the called function then has no propagation info, leading to a segfault (release) or assertion failure (debug) in `_resolveInstRec`.

## Technical Details
**Root cause**: `isConcreteType()` in `slang-ir-typeflow-specialize.cpp` did not have a case for `kIROp_StructType`, so structs with interface fields were incorrectly classified as "concrete". This is the same pattern as `TupleType`, `ArrayType`, etc. which already have recursive field-checking cases, and mirrors the existing `typeIncludesDynamicDispatch()` function which already handles `StructType` with recursive field checking.

**Fix approach** (3 changes):
1. **`isConcreteType` → `isConcreteTypeImpl`**: Refactored into a `static` implementation function with an optional `HashSet<IRInst*>*` parameter for cycle detection. Added `kIROp_StructType` case that recurses into field types. The `HashSet` is only stack-allocated when a struct is first encountered, and reused for nested recursion. Cycles (e.g. pack-branch types) are detected and conservatively treated as concrete.
2. **`maybeGetBoundFunc`**: When a non-concrete parameter has no propagation info yet, use `VoidLit` binding instead of returning `nullptr`. This ensures interprocedural edges are still registered, allowing propagation and diagnostics (e.g. `__ref` params with dynamic dispatch types) to proceed.
3. **`specializeCall`**: Guard two `callSiteInfo[]` lookups with `tryGetValue()` to return false instead of null-deref when info is missing (defense-in-depth).

**Why the previous approach failed**: The first iteration added the `isConcreteType` struct case but (a) reverted the `_resolveInstRec` early return needed for function-scoped types, and (b) didn't fix `maybeGetBoundFunc`, which returned `nullptr` when params had no info — preventing interprocedural edge registration and causing diagnostic tests to lose `__ref`/`__constref` warnings.

**Test results**: 0 regressions across 1158 language-feature tests, 452 dynamic-dispatch tests, 161 generics tests, and 369 bug regression tests.

## Test plan
- [x] `tests/bugs/gh-10394.slang` — verifies the crash fix (struct with interface field, CPU/C++ target)
- [x] `tests/language-feature/dynamic-dispatch/diagnose-ref-interface-in-struct.slang` — verifies `__ref`/`__constref` diagnostics still fire
- [x] `tests/language-feature/generics/pack-branch-forwarded-pack-cyclic-type.slang` — verifies cycle detection handles pack-branch types
- [x] Full dynamic-dispatch test suite (452/452 pass)
- [x] Full language-feature test suite (1158/1158 pass)
