### PR TITLE
Fix ICE when using ByteAddressBuffer.Load/Store with interface types

### DIFF
--- a/source/slang/slang-ir-translate.cpp
+++ b/source/slang/slang-ir-translate.cpp
@@ -362,10 +362,13 @@ IRInst* _resolveInstRec(TranslationContext* ctx, IRInst* inst)
     // At this point, we've resolved anything that can be translated & not in the global scope (i.e.
     // things like arithmetic operations)
     //
-    // If we still have something that's not in the global scope, then something went wrong.
-    // since all operations after this point require this.
+    // If the instruction is not at module scope, it cannot be resolved further.
+    // This can happen when a generic is specialized with an existential/interface type,
+    // producing function-local instructions that reach this resolution logic.
+    // Return the instruction as-is and let later passes handle the diagnostic.
     //
-    SLANG_ASSERT(as<IRModuleInst>(instWithCanonicalOperands->getParent()));
+    if (!as<IRModuleInst>(instWithCanonicalOperands->getParent()))
+        return instWithCanonicalOperands;
 
     // TODO: Group these.
     if (as<IRTranslateBase>(instWithCanonicalOperands) ||

--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -234,10 +234,10 @@ bool isInvalidExistentialSpecialization(IRInst* specializedValue)
                 }
                 if (inst->getOp() == kIROp_ByteAddressBufferStore)
                 {
-                    // The stored value operand (operand index 2) may have an interface
-                    // type.
-                    if (inst->getOperandCount() > 2 &&
-                        as<IRInterfaceType>(inst->getOperand(2)->getDataType()))
+                    // Operands: (buffer, offset, alignment, value).
+                    // The stored value is at index 3.
+                    if (inst->getOperandCount() > 3 &&
+                        as<IRInterfaceType>(inst->getOperand(3)->getDataType()))
                         return true;
                 }
 

--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -223,6 +223,24 @@ bool isInvalidExistentialSpecialization(IRInst* specializedValue)
         {
             for (auto inst : block->getOrdinaryInsts())
             {
+                // Detect ByteAddressBufferLoad/Store specialized with an interface type.
+                // When byteAddressBufferLoad<IFoo> is specialized, the result type of
+                // the load instruction (or an operand type of the store) will be an
+                // interface type, which is not supported.
+                if (inst->getOp() == kIROp_ByteAddressBufferLoad)
+                {
+                    if (as<IRInterfaceType>(inst->getDataType()))
+                        return true;
+                }
+                if (inst->getOp() == kIROp_ByteAddressBufferStore)
+                {
+                    // The stored value operand (operand index 2) may have an interface
+                    // type.
+                    if (inst->getOperandCount() > 2 &&
+                        as<IRInterfaceType>(inst->getOperand(2)->getDataType()))
+                        return true;
+                }
+
                 auto call = as<IRCall>(inst);
                 if (!call)
                     continue;

--- a/tests/bugs/byte-address-buffer-interface-load-store.slang
+++ b/tests/bugs/byte-address-buffer-interface-load-store.slang
@@ -3,6 +3,7 @@
 // GitHub issue: #10376
 
 //DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target spirv -stage compute -entry computeMain -conformance "ImplA:IFoo=1"
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target hlsl -stage compute -entry computeMain -conformance "ImplA:IFoo=1"
 
 [anyValueSize(8)]
 interface IFoo

--- a/tests/bugs/byte-address-buffer-interface-load-store.slang
+++ b/tests/bugs/byte-address-buffer-interface-load-store.slang
@@ -1,0 +1,34 @@
+// Test that using ByteAddressBuffer.Load<T>/Store<T> with an interface type
+// emits a diagnostic instead of crashing the compiler.
+// GitHub issue: #10376
+
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target spirv -stage compute -entry computeMain -conformance "ImplA:IFoo=1"
+
+[anyValueSize(8)]
+interface IFoo
+{
+    float getValue();
+}
+
+struct ImplA : IFoo
+{
+    float v;
+    float getValue() { return v; }
+}
+
+RWByteAddressBuffer byteBuffer;
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    ImplA a;
+    a.v = 7.0;
+    IFoo fooA = a;
+    byteBuffer.Store<IFoo>(0, fooA);
+
+    IFoo loaded = byteBuffer.Load<IFoo>(0);
+    outputBuffer[0] = loaded.getValue();
+}
+
+// CHECK: error[E33180]


### PR DESCRIPTION
## Summary
- Fix crash (ICE/segfault) when `RWByteAddressBuffer.Load<T>` or `.Store<T>` is specialized with an interface type
- Emit clean E33180 diagnostic instead of crashing
- Add regression test

## Motivation
Fixes #10376. When `T` is an interface type (e.g. `IFoo`), the specialized function contains `byteAddressBufferLoad` with an interface result type that no downstream IR pass can lower, causing an ICE during code emission on all targets (SPIRV, HLSL, CPU).

## Technical Details
**Root cause**: After `specializeModule` resolves `Load<IFoo>`, the specialized function body contains `byteAddressBufferLoad` returning an interface type. The typeflow specialization pass then encounters function-local existential operations (e.g. `extractExistentialWitnessTable`) and `_resolveInstRec` asserts they should be at module scope.

**Fix approach** (two parts):
1. **`slang-ir-typeflow-specialize.cpp`**: Extend `isInvalidExistentialSpecialization()` body scan to detect `kIROp_ByteAddressBufferLoad` with interface result type and `kIROp_ByteAddressBufferStore` with interface operand type. This triggers the existing E33180 diagnostic before the typeflow pass attempts analysis.
2. **`slang-ir-translate.cpp`**: Replace the `SLANG_ASSERT` in `_resolveInstRec` with a graceful early return for function-local instructions, as a defensive safety net.

**Why this approach over alternatives**: A broader check (rejecting all generics specialized with interface types) was explored but caused regressions in legitimate dynamic dispatch tests. The targeted ByteAddressBuffer check is narrowly scoped to the unsupported pattern.

## Test Plan
- [x] New regression test: `tests/bugs/byte-address-buffer-interface-load-store.slang`
- [x] Original reproducer emits E33180 on SPIRV and HLSL targets
- [x] Full test suite: 4303/4303 passed, 0 regressions