### PR TITLE
Add sections to the global `IRModule` to organize different instruction kinds into buckets

### DIFF
--- a/source/slang/slang-check-out-of-bound-access.cpp
+++ b/source/slang/slang-check-out-of-bound-access.cpp
@@ -67,11 +67,9 @@ struct OutOfBoundAccessChecker : public InstPassBase
         // By this point, we assume that all generics of non-trivial functions
         // have been specialized away into `IRFunc`s
         //
-        for (auto globalInst : module->getGlobalInsts())
+        for (auto inst : module->getFuncs())
         {
-            auto func = as<IRFunc>(globalInst);
-            if (!func)
-                continue;
+            auto func = as<IRFunc>(inst);
 
             for (auto block : func->getBlocks())
             {

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -1626,7 +1626,7 @@ bool CLikeSourceEmitter::shouldFoldInstIntoUseSites(IRInst* inst)
     // If the instruction is at global scope, then it might represent
     // a constant (e.g., the value of an enum case).
     //
-    if (as<IRModuleInst>(inst->getParent()))
+    if (isAtModuleScope(inst))
     {
         if (!inst->mightHaveSideEffects())
             return true;
@@ -2028,7 +2028,7 @@ void CLikeSourceEmitter::emitInstResultDecl(IRInst* inst)
 
     emitRateQualifiers(inst);
 
-    if (as<IRModuleInst>(inst->getParent()))
+    if (isAtModuleScope(inst))
     {
         // "Ordinary" instructions at module scope are constants
 
@@ -4821,7 +4821,7 @@ void CLikeSourceEmitter::_emitInstAsVarInitializerImpl(IRInst* inst)
 
 bool _isFoldableValue(IRInst* val)
 {
-    if (val->getParent() && val->getParent()->getOp() == kIROp_ModuleInst)
+    if (isAtModuleScope(val))
         return true;
 
     switch (val->getOp())

--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -224,7 +224,7 @@ UnownedStringSlice CUDASourceEmitter::getVectorPrefix(IROp op)
 void CUDASourceEmitter::emitTempModifiers(IRInst* temp)
 {
     CPPSourceEmitter::emitTempModifiers(temp);
-    if (as<IRModuleInst>(temp->getParent()))
+    if (isAtModuleScope(temp))
     {
         m_writer->emit("__device__ ");
     }

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -86,7 +86,7 @@ void GLSLSourceEmitter::beforeComputeEmitActions(IRModule* module)
     buildEntryPointReferenceGraph(this->m_referencingEntryPoints, module);
 
     IRBuilder builder(module);
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto globalInst : module->getFuncs())
     {
         if (auto func = as<IRGlobalValueWithCode>(globalInst))
         {

--- a/source/slang/slang-emit-llvm.cpp
+++ b/source/slang/slang-emit-llvm.cpp
@@ -1098,7 +1098,7 @@ struct LLVMEmitter
         if (mapInstToLLVM.containsKey(inst))
             return mapInstToLLVM.getValue(inst);
 
-        bool globalInstruction = inst->getParent()->getOp() == kIROp_ModuleInst;
+        bool globalInstruction = isAtModuleScope(inst);
 
         auto op = inst->getOp();
 
@@ -2629,7 +2629,7 @@ struct LLVMEmitter
 
     void emitGlobalDebugInfo(IRModule* irModule)
     {
-        for (auto inst : irModule->getGlobalInsts())
+        for (auto inst : irModule->getAnnotations())
         {
             if (auto debugSource = as<IRDebugSource>(inst))
             {
@@ -2648,11 +2648,14 @@ struct LLVMEmitter
 
     void emitGlobalDeclarations(IRModule* irModule)
     {
-        for (auto inst : irModule->getGlobalInsts())
+        for (auto inst : irModule->getFuncs())
         {
             if (auto func = as<IRFunc>(inst))
                 ensureFuncDecl(func);
-            else if (auto globalVar = as<IRGlobalVar>(inst))
+        }
+        for (auto inst : irModule->getGlobalVars())
+        {
+            if (auto globalVar = as<IRGlobalVar>(inst))
                 emitGlobalVarDecl(globalVar);
         }
     }

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -621,7 +621,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     }
                 }
             }
-            else if (as<IRFunc>(parent) || as<IRModuleInst>(parent))
+            else if (as<IRFunc>(parent) || isModuleScopeParent(parent))
             {
                 SpvInst* spvInst = nullptr;
                 if (m_mapIRInstToSpvDebugInst.tryGetValue(parent, spvInst))

--- a/source/slang/slang-emit-torch.cpp
+++ b/source/slang/slang-emit-torch.cpp
@@ -214,11 +214,9 @@ void TorchCppSourceEmitter::emitModuleImpl(IRModule* module, DiagnosticSink* sin
     // Emit PyBind declarations.
     m_writer->emit("PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {\n");
     m_writer->indent();
-    for (auto inst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
         auto func = as<IRFunc>(inst);
-        if (!func)
-            continue;
         auto decor = func->findDecoration<IRTorchEntryPointDecoration>();
         if (!decor)
             continue;

--- a/source/slang/slang-emit-vm.cpp
+++ b/source/slang/slang-emit-vm.cpp
@@ -1145,12 +1145,9 @@ public:
         }
 
         // Emit remaining funcitons, if they are called by entry points.
-        for (auto globalInst : linkedIR.module->getGlobalInsts())
+        for (auto globalInst : linkedIR.module->getFuncs())
         {
             auto func = as<IRFunc>(globalInst);
-
-            if (!func)
-                continue;
 
             // Skip if already emitted as an entry point.
             if (entryPointSet.contains(func))

--- a/source/slang/slang-emit-wgsl.cpp
+++ b/source/slang/slang-emit-wgsl.cpp
@@ -749,7 +749,7 @@ void WGSLSourceEmitter::emitLayoutQualifiersImpl(IRVarLayout* layout)
 
 static bool isStaticConst(IRInst* inst)
 {
-    if (inst->getParent()->getOp() == kIROp_ModuleInst)
+    if (isAtModuleScope(inst))
     {
         return true;
     }

--- a/source/slang/slang-ir-any-value-inference.cpp
+++ b/source/slang/slang-ir-any-value-inference.cpp
@@ -107,19 +107,16 @@ void inferAnyValueSizeWhereNecessary(
 
     HashSet<IRInst*> implementedInterfaces;
     // Add all interface type that are implemented by at least one type to a set.
-    for (auto inst : module->getGlobalInsts())
+    for (auto wt : module->getWitnessTables())
     {
-        if (inst->getOp() == kIROp_WitnessTable)
-        {
-            auto interfaceType =
-                cast<IRWitnessTableType>(inst->getDataType())->getConformanceType();
-            implementedInterfaces.add(interfaceType);
-        }
+        auto interfaceType =
+            cast<IRWitnessTableType>(wt->getDataType())->getConformanceType();
+        implementedInterfaces.add(interfaceType);
     }
 
     // Collect all interface types that require inference.
     HashSet<IRInterfaceType*> interfaceTypes;
-    for (auto inst : module->getGlobalInsts())
+    for (auto inst : module->getStructTypes())
     {
         if (inst->getOp() == kIROp_InterfaceType)
         {
@@ -185,7 +182,7 @@ void inferAnyValueSizeWhereNecessary(
             // Only consider implementations at the top-level (ignore those nested
             // in generics)
             //
-            if (concreteImpl->getParent() == module->getModuleInst())
+            if (isAtModuleScope(concreteImpl))
                 implList.add(concreteImpl);
         }
 

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -2802,7 +2802,7 @@ struct ForwardDiffTranslationContext
     {
         if (as<IRGlobalValueWithCode>(origInst))
             return true;
-        if (origInst->parent && origInst->parent->getOp() == kIROp_ModuleInst)
+        if (isAtModuleScope(origInst))
             return true;
         if (isChildInstOf(currentParent, origInst->getParent()))
             return true;
@@ -3289,7 +3289,7 @@ struct ForwardDiffTranslationContext
         // At this point we should not see any global insts that are differentiable.
         // If the inst's parent is IRModule, return (inst, null).
         //
-        if (as<IRModuleInst>(origInst->getParent()) && !as<IRType>(origInst))
+        if (isAtModuleScope(origInst) && !as<IRType>(origInst))
             return InstPair(origInst, nullptr);
 
         IRBuilderSourceLocRAII sourceLocationScope(builder, origInst->sourceLoc);

--- a/source/slang/slang-ir-autodiff-primal-hoist.cpp
+++ b/source/slang/slang-ir-autodiff-primal-hoist.cpp
@@ -430,7 +430,7 @@ RefPtr<HoistedPrimalsInfo> AutodiffCheckpointPolicyBase::processFunc(
              operand++, opIndex++)
         {
             if (!_isDifferentialInst(operand->get()) && !as<IRFunc>(operand->get()) &&
-                !as<IRBlock>(operand->get()) && !(as<IRModuleInst>(operand->get()->getParent())) &&
+                !as<IRBlock>(operand->get()) && !isAtModuleScope(operand->get()) &&
                 !isDifferentialBlock(getBlock(operand->get())))
                 workList.add(operand);
         }
@@ -672,7 +672,7 @@ RefPtr<HoistedPrimalsInfo> AutodiffCheckpointPolicyBase::processFunc(
                 // actions.
                 //
                 auto calleeUse = &call->getOperands()[0];
-                if (!as<IRModuleInst>(calleeUse->get()->getParent()) &&
+                if (!isAtModuleScope(calleeUse->get()) &&
                     !processedUses.contains(calleeUse))
                     addPrimalOperandsToWorkList(call);
 

--- a/source/slang/slang-ir-autodiff-transpose.cpp
+++ b/source/slang/slang-ir-autodiff-transpose.cpp
@@ -1106,7 +1106,7 @@ struct DiffTransposePass
                 if (instParent->getParent() == fwdBlock->getParent())
                     externInsts.add(inst);
 
-                if (as<IRModuleInst>(instParent))
+                if (isModuleScopeParent(instParent))
                     globalInsts.add(inst);
             }
         }

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -201,7 +201,7 @@ AutoDiffSharedContext::AutoDiffSharedContext(
 {
     auto module = moduleInst->getModule();
 
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto globalInst : module->getGenerics())
     {
         if (auto generic = as<IRGeneric>(globalInst))
         {
@@ -669,7 +669,7 @@ void DifferentiableTypeConformanceContext::markDiffTypeInst(
     IRType* primalType)
 {
     // Ignore module-level insts.
-    if (as<IRModuleInst>(diffInst->getParent()))
+    if (isAtModuleScope(diffInst))
         return;
 
     // Also ignore generic-container-level insts.
@@ -975,7 +975,7 @@ void checkAutodiffPatterns(IRModule* module, TargetProgram* target, DiagnosticSi
     // For now, we have only 1 check to see if methods that have side-effects
     // are marked with prefer-recompute
     //
-    for (auto inst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
         if (auto func = as<IRFunc>(inst))
         {

--- a/source/slang/slang-ir-bind-existentials.cpp
+++ b/source/slang/slang-ir-bind-existentials.cpp
@@ -73,13 +73,8 @@ struct BindExistentialSlots
         // We will search for global shader parameters that make
         // use of existential specialization parameters.
         //
-        for (auto inst : module->getGlobalInsts())
+        for (auto globalParam : module->getGlobalParams())
         {
-            // We only care about global shader parameters.
-            //
-            auto globalParam = as<IRGlobalParam>(inst);
-            if (!globalParam)
-                continue;
 
             // We only care about global shader parameters
             // that have existential specialization parameters,

--- a/source/slang/slang-ir-bit-field-accessors.cpp
+++ b/source/slang/slang-ir-bit-field-accessors.cpp
@@ -162,11 +162,9 @@ static void synthesizeBitFieldSetter(IRFunc* func, IRBitFieldAccessorDecoration*
 
 void synthesizeBitFieldAccessors(IRModule* module)
 {
-    for (const auto inst : module->getModuleInst()->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        const auto func = as<IRFunc>(getResolvedInstForDecorations(inst));
-        if (!func)
-            continue;
+        auto func = as<IRFunc>(inst);
         const auto bfd = func->findDecoration<IRBitFieldAccessorDecoration>();
         if (!bfd)
             continue;

--- a/source/slang/slang-ir-call-graph.cpp
+++ b/source/slang/slang-ir-call-graph.cpp
@@ -99,13 +99,13 @@ void buildEntryPointReferenceGraph(
         }
     };
 
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        if (globalInst->getOp() == kIROp_Func &&
-            (globalInst->findDecoration<IREntryPointDecoration>() ||
-             globalInst->findDecoration<IRCudaKernelDecoration>()))
+        auto func = as<IRFunc>(inst);
+        if (func->findDecoration<IREntryPointDecoration>() ||
+            func->findDecoration<IRCudaKernelDecoration>())
         {
-            visit(as<IRFunc>(globalInst), globalInst);
+            visit(func, func);
         }
     }
     for (Index i = 0; i < workList.getCount(); i++)

--- a/source/slang/slang-ir-check-differentiability.cpp
+++ b/source/slang/slang-ir-check-differentiability.cpp
@@ -53,7 +53,7 @@ public:
             }
         };
 
-        if (as<IRModuleInst>(code->getParent()))
+        if (isAtModuleScope(code))
         {
             traverseUsers(
                 code,
@@ -809,7 +809,7 @@ public:
         if (!sharedContext.isInterfaceAvailable && !sharedContext.isPtrInterfaceAvailable)
             return;
 
-        for (auto inst : module->getGlobalInsts())
+        for (auto inst : module->getGenerics())
         {
             if (auto genericInst = as<IRGeneric>(inst))
             {
@@ -817,7 +817,10 @@ public:
                         as<IRGlobalValueWithCode>(findInnerMostGenericReturnVal(genericInst)))
                     processFunc(innerFunc);
             }
-            else if (auto funcInst = as<IRGlobalValueWithCode>(inst))
+        }
+        for (auto inst : module->getFuncs())
+        {
+            if (auto funcInst = as<IRGlobalValueWithCode>(inst))
             {
                 processFunc(funcInst);
             }

--- a/source/slang/slang-ir-check-optional-none-usage.cpp
+++ b/source/slang/slang-ir-check-optional-none-usage.cpp
@@ -28,24 +28,9 @@ static void checkForOptionalNoneUsage(IRFunc* func, DiagnosticSink* sink)
 
 void checkForOptionalNoneUsage(IRModule* module, DiagnosticSink* sink)
 {
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        switch (globalInst->getOp())
-        {
-        case kIROp_Func:
-            checkForOptionalNoneUsage(as<IRFunc>(globalInst), sink);
-            break;
-        case kIROp_Generic:
-            {
-                auto generic = as<IRGeneric>(globalInst);
-                auto innerFunc = as<IRFunc>(findGenericReturnVal(generic));
-                if (innerFunc)
-                    checkForOptionalNoneUsage(innerFunc, sink);
-                break;
-            }
-        default:
-            break;
-        }
+        checkForOptionalNoneUsage(as<IRFunc>(inst), sink);
     }
 }
 

--- a/source/slang/slang-ir-check-recursion.cpp
+++ b/source/slang/slang-ir-check-recursion.cpp
@@ -62,18 +62,9 @@ void checkTypeRecursion(HashSet<IRInst*>& checkedTypes, IRInst* type, Diagnostic
 void checkForRecursiveTypes(IRModule* module, DiagnosticSink* sink)
 {
     HashSet<IRInst*> checkedTypes;
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto structType : module->getStructTypes())
     {
-        switch (globalInst->getOp())
-        {
-        case kIROp_StructType:
-            {
-                checkTypeRecursion(checkedTypes, globalInst, sink);
-            }
-            break;
-        default:
-            break;
-        }
+        checkTypeRecursion(checkedTypes, structType, sink);
     }
 }
 
@@ -121,20 +112,13 @@ void checkFunctionRecursion(HashSet<IRFunc*>& checkedFuncs, IRFunc* func, Diagno
 void checkForRecursiveFunctions(IRModule* module, TargetRequest* target, DiagnosticSink* sink)
 {
     HashSet<IRFunc*> checkedFuncsForRecursionDetection;
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        switch (globalInst->getOp())
-        {
-        case kIROp_Func:
-            if (!isCPUTarget(target))
-                checkFunctionRecursion(
-                    checkedFuncsForRecursionDetection,
-                    as<IRFunc>(globalInst),
-                    sink);
-            break;
-        default:
-            break;
-        }
+        if (!isCPUTarget(target))
+            checkFunctionRecursion(
+                checkedFuncsForRecursionDetection,
+                as<IRFunc>(inst),
+                sink);
     }
 }
 

--- a/source/slang/slang-ir-composite-reg-to-mem.cpp
+++ b/source/slang/slang-ir-composite-reg-to-mem.cpp
@@ -198,12 +198,9 @@ void convertCompositeTypeParametersToPointers(IRFunc* func)
 
 void convertCompositeTypeParametersToPointers(IRModule* module)
 {
-    for (auto inst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        if (auto func = as<IRFunc>(inst))
-        {
-            convertCompositeTypeParametersToPointers(func);
-        }
+        convertCompositeTypeParametersToPointers(as<IRFunc>(inst));
     }
 }
 } // namespace Slang

--- a/source/slang/slang-ir-constexpr.cpp
+++ b/source/slang/slang-ir-constexpr.cpp
@@ -616,10 +616,12 @@ void propagateConstExpr(IRModule* module, DiagnosticSink* sink)
 
     // We will build an initial work list with all of the global values in it.
 
-    for (auto ii : module->getGlobalInsts())
-    {
+    for (auto ii : module->getFuncs())
         maybeAddToWorkList(&context, ii);
-    }
+    for (auto ii : module->getGlobalVars())
+        maybeAddToWorkList(&context, ii);
+    for (auto ii : module->getGenerics())
+        maybeAddToWorkList(&context, ii);
 
     // We will iterate applying propagation to one global value at a time
     // until we run out.
@@ -657,22 +659,10 @@ void propagateConstExpr(IRModule* module, DiagnosticSink* sink)
     // we find that they are *required* to be `constexpr`, but *cannot*
     // be, for some reason.
 
-    for (auto ii : module->getGlobalInsts())
-    {
-        switch (ii->getOp())
-        {
-        default:
-            break;
-
-        case kIROp_Func:
-        case kIROp_GlobalVar:
-            {
-                IRGlobalValueWithCode* code = (IRGlobalValueWithCode*)ii;
-                validateConstExpr(&context, code);
-            }
-            break;
-        }
-    }
+    for (auto inst : module->getFuncs())
+        validateConstExpr(&context, as<IRGlobalValueWithCode>(inst));
+    for (auto inst : module->getGlobalVars())
+        validateConstExpr(&context, as<IRGlobalValueWithCode>(inst));
 }
 
 } // namespace Slang

--- a/source/slang/slang-ir-dce.cpp
+++ b/source/slang/slang-ir-dce.cpp
@@ -492,13 +492,10 @@ bool trimOptimizableType(IRStructType* type)
 bool trimOptimizableTypes(IRModule* module)
 {
     bool changed = false;
-    for (auto inst : module->getGlobalInsts())
+    for (auto type : module->getStructTypes())
     {
-        if (auto type = as<IRStructType>(inst))
-        {
-            if (type->findDecoration<IROptimizableTypeDecoration>())
-                changed |= trimOptimizableType(type);
-        }
+        if (type->findDecoration<IROptimizableTypeDecoration>())
+            changed |= trimOptimizableType(as<IRStructType>(type));
     }
     return changed;
 }

--- a/source/slang/slang-ir-deduplicate-generic-children.cpp
+++ b/source/slang/slang-ir-deduplicate-generic-children.cpp
@@ -31,12 +31,9 @@ bool deduplicateGenericChildren(IRGeneric* genericInst)
 bool deduplicateGenericChildren(IRModule* module)
 {
     bool changed = false;
-    for (auto inst : module->getGlobalInsts())
+    for (auto gen : module->getGenerics())
     {
-        if (auto gen = as<IRGeneric>(inst))
-        {
-            changed |= deduplicateGenericChildren(gen);
-        }
+        changed |= deduplicateGenericChildren(as<IRGeneric>(gen));
     }
     return changed;
 }

--- a/source/slang/slang-ir-defer-buffer-load.cpp
+++ b/source/slang/slang-ir-defer-buffer-load.cpp
@@ -380,13 +380,10 @@ void deferBufferLoad(IRModule* module, CodeGenContext* codeGenContext)
 {
     DeferBufferLoadContext context;
     context.codeGenContext = codeGenContext;
-    for (auto childInst : module->getGlobalInsts())
-    {
-        if (auto code = as<IRGlobalValueWithCode>(childInst))
-        {
-            context.deferBufferLoad(code);
-        }
-    }
+    for (auto inst : module->getFuncs())
+        context.deferBufferLoad(as<IRGlobalValueWithCode>(inst));
+    for (auto inst : module->getGlobalVars())
+        context.deferBufferLoad(as<IRGlobalValueWithCode>(inst));
 }
 
 } // namespace Slang

--- a/source/slang/slang-ir-dll-export.cpp
+++ b/source/slang/slang-ir-dll-export.cpp
@@ -38,18 +38,12 @@ struct DllExportContext
             IRDllExportDecoration* exportDecoration;
         };
         List<Candidate> candidates;
-        for (auto childFunc : module->getGlobalInsts())
+        for (auto inst : module->getFuncs())
         {
-            switch (childFunc->getOp())
+            auto func = as<IRFunc>(inst);
+            if (auto dllExportDecoration = func->findDecoration<IRDllExportDecoration>())
             {
-            case kIROp_Func:
-                if (auto dllExportDecoration = childFunc->findDecoration<IRDllExportDecoration>())
-                {
-                    candidates.add(Candidate{as<IRFunc>(childFunc), dllExportDecoration});
-                }
-                break;
-            default:
-                break;
+                candidates.add(Candidate{func, dllExportDecoration});
             }
         }
 

--- a/source/slang/slang-ir-dll-import.cpp
+++ b/source/slang/slang-ir-dll-import.cpp
@@ -188,18 +188,12 @@ struct DllImportContext
 
     void processModule()
     {
-        for (auto childFunc : module->getGlobalInsts())
+        for (auto inst : module->getFuncs())
         {
-            switch (childFunc->getOp())
+            auto func = as<IRFunc>(inst);
+            if (auto dllImportDecoration = func->findDecoration<IRDllImportDecoration>())
             {
-            case kIROp_Func:
-                if (auto dllImportDecoration = childFunc->findDecoration<IRDllImportDecoration>())
-                {
-                    processFunc(as<IRFunc>(childFunc), dllImportDecoration);
-                }
-                break;
-            default:
-                break;
+                processFunc(func, dllImportDecoration);
             }
         }
     }

--- a/source/slang/slang-ir-eliminate-multilevel-break.cpp
+++ b/source/slang/slang-ir-eliminate-multilevel-break.cpp
@@ -636,13 +636,10 @@ void eliminateMultiLevelBreak(IRModule* irModule, TargetProgram* targetProgram)
     EliminateMultiLevelBreakContext context;
     context.irModule = irModule;
     context.targetProgram = targetProgram;
-    for (auto globalInst : irModule->getGlobalInsts())
-    {
-        if (auto codeInst = as<IRGlobalValueWithCode>(globalInst))
-        {
-            context.processFunc(codeInst);
-        }
-    }
+    for (auto inst : irModule->getFuncs())
+        context.processFunc(as<IRGlobalValueWithCode>(inst));
+    for (auto inst : irModule->getGlobalVars())
+        context.processFunc(as<IRGlobalValueWithCode>(inst));
 }
 
 void eliminateMultiLevelBreakForFunc(

--- a/source/slang/slang-ir-eliminate-phis.cpp
+++ b/source/slang/slang-ir-eliminate-phis.cpp
@@ -95,21 +95,10 @@ struct PhiEliminationContext
     //
     void eliminatePhisInModule()
     {
-        for (auto inst : m_module->getGlobalInsts())
-        {
-            switch (inst->getOp())
-            {
-            default:
-                continue;
-
-            case kIROp_Func:
-            case kIROp_GlobalVar:
-                break;
-            }
-
-            auto code = (IRGlobalValueWithCode*)inst;
-            eliminatePhisInFunc(code);
-        }
+        for (auto inst : m_module->getFuncs())
+            eliminatePhisInFunc(as<IRGlobalValueWithCode>(inst));
+        for (auto inst : m_module->getGlobalVars())
+            eliminatePhisInFunc(as<IRGlobalValueWithCode>(inst));
     }
 
     // Within a single function, we are primarily concerned with processing

--- a/source/slang/slang-ir-entry-point-decorations.cpp
+++ b/source/slang/slang-ir-entry-point-decorations.cpp
@@ -23,7 +23,7 @@ public:
 
     void check()
     {
-        for (auto inst : m_module->getGlobalInsts())
+        for (auto inst : m_module->getFuncs())
         {
             const auto func = as<IRFunc>(inst);
             if (!func)

--- a/source/slang/slang-ir-entry-point-pass.cpp
+++ b/source/slang/slang-ir-entry-point-pass.cpp
@@ -14,7 +14,7 @@ void PerEntryPointPass::processModule(IRModule* module)
     // pass should be run after the entry point(s) have
     // been specialized to their generic type parameters.
 
-    for (auto inst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
         // We are only interested in entry points.
         //

--- a/source/slang/slang-ir-entry-point-raw-ptr-params.cpp
+++ b/source/slang/slang-ir-entry-point-raw-ptr-params.cpp
@@ -28,7 +28,7 @@ struct ConvertEntryPointPtrParamsToRawPtrsPass
         // Now we loop over global-scope instructions searching
         // for any entry points.
         //
-        for (auto inst : m_module->getGlobalInsts())
+        for (auto inst : m_module->getFuncs())
         {
             auto func = as<IRFunc>(inst);
             if (!func)

--- a/source/slang/slang-ir-explicit-global-init.cpp
+++ b/source/slang/slang-ir-explicit-global-init.cpp
@@ -78,7 +78,7 @@ struct MoveGlobalVarInitializationToEntryPointsPass
         // initialization) and function (to compute the
         // initial value).
         //
-        for (auto inst : m_module->getGlobalInsts())
+        for (auto inst : m_module->getGlobalVars())
         {
             auto globalVar = as<IRGlobalVar>(inst);
             if (!globalVar)
@@ -102,7 +102,7 @@ struct MoveGlobalVarInitializationToEntryPointsPass
         // all the global variables that were identified
         // and processed in the first pass.
         //
-        for (auto inst : m_module->getGlobalInsts())
+        for (auto inst : m_module->getFuncs())
         {
             auto func = as<IRFunc>(inst);
             if (!func)
@@ -222,7 +222,7 @@ struct MoveGlobalVarInitializationToEntryPointsPass
                 if (auto returnInst = as<IRReturn>(initFirstBlock->getTerminator()))
                 {
                     if (returnInst->getVal() &&
-                        returnInst->getVal()->getParent() == m_module->getModuleInst())
+                        isAtModuleScope(returnInst->getVal()))
                     {
                         initVal = returnInst->getVal();
                     }

--- a/source/slang/slang-ir-fix-entrypoint-callsite.cpp
+++ b/source/slang/slang-ir-fix-entrypoint-callsite.cpp
@@ -96,7 +96,7 @@ void fixEntryPointCallsites(IRFunc* entryPoint)
 
 void fixEntryPointCallsites(IRModule* module)
 {
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto globalInst : module->getFuncs())
     {
         if (globalInst->findDecoration<IREntryPointDecoration>())
             fixEntryPointCallsites((IRFunc*)globalInst);

--- a/source/slang/slang-ir-float-non-uniform-resource-index.cpp
+++ b/source/slang/slang-ir-float-non-uniform-resource-index.cpp
@@ -221,9 +221,9 @@ void floatNonUniformResourceIndex(IRModule* module, NonUniformResourceIndexFloat
     // insts to the right place in the IR module.
 
     List<IRInst*> workList;
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto globalInst : module->getFuncs())
     {
-        auto func = as<IRGlobalValueWithCode>(getGenericReturnVal(globalInst));
+        auto func = as<IRGlobalValueWithCode>(globalInst);
         if (!func)
             continue;
         workList.clear();

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -5078,7 +5078,7 @@ void legalizeConstantBufferLoadForGLSL(IRModule* module)
     // we need to replace it with a `MakeStruct` inst where each field is separately
     // loaded.
     IRBuilder builder(module);
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto globalInst : module->getFuncs())
     {
         if (auto func = as<IRGlobalValueWithCode>(globalInst))
         {
@@ -5127,7 +5127,7 @@ void legalizeDispatchMeshPayloadForGLSL(IRModule* module)
 {
     // Find out DispatchMesh function
     IRGlobalValueWithCode* dispatchMeshFunc = nullptr;
-    for (const auto globalInst : module->getGlobalInsts())
+    for (const auto globalInst : module->getFuncs())
     {
         if (const auto func = as<IRGlobalValueWithCode>(globalInst))
         {
@@ -5165,7 +5165,7 @@ void legalizeDispatchMeshPayloadForGLSL(IRModule* module)
                 SLANG_ASSERT(payloadType);
 
                 const bool isGroupsharedGlobal =
-                    payload->getParent() == module->getModuleInst() &&
+                    isAtModuleScope(payload) &&
                     composeGetters<IRGroupSharedRate>(payload, &IRInst::getRate);
                 if (isGroupsharedGlobal)
                 {
@@ -5221,7 +5221,7 @@ void legalizeDynamicResourcesForGLSL(IRModule* module, CodeGenContext* context)
 
     // At this stage, we can safely remove the generic `getDescriptorFromHandle` function
     // despite it being marked `export`.
-    for (auto inst : module->getGlobalInsts())
+    for (auto inst : module->getGenerics())
     {
         if (auto genFunc = as<IRGeneric>(inst))
         {
@@ -5236,7 +5236,7 @@ void legalizeDynamicResourcesForGLSL(IRModule* module, CodeGenContext* context)
         inst->removeAndDeallocate();
     }
 
-    for (auto inst : module->getGlobalInsts())
+    for (auto inst : module->getGlobalParams())
     {
         auto param = as<IRGlobalParam>(inst);
 

--- a/source/slang/slang-ir-hlsl-legalize.cpp
+++ b/source/slang/slang-ir-hlsl-legalize.cpp
@@ -107,13 +107,9 @@ void searchChildrenForForceVarIntoStructTemporarily(IRModule* module, IRInst* in
 
 void legalizeNonStructParameterToStructForHLSL(IRModule* module)
 {
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto func : module->getFuncs())
     {
-        // Only process functions - at this stage generics are already resolved,
-        // and the search only handles Block and Call children.
-        if (globalInst->getOp() != kIROp_Func)
-            continue;
-        searchChildrenForForceVarIntoStructTemporarily(module, globalInst);
+        searchChildrenForForceVarIntoStructTemporarily(module, func);
     }
 }
 

--- a/source/slang/slang-ir-insert-debug-value-store.cpp
+++ b/source/slang/slang-ir-insert-debug-value-store.cpp
@@ -268,19 +268,9 @@ void DebugValueStoreContext::insertDebugValueStore(IRFunc* func)
 
 void insertDebugValueStore(DebugValueStoreContext& context, IRModule* module)
 {
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        if (auto genericInst = as<IRGeneric>(globalInst))
-        {
-            if (auto func = as<IRFunc>(findGenericReturnVal(genericInst)))
-            {
-                context.insertDebugValueStore(func);
-            }
-        }
-        else if (auto func = as<IRFunc>(globalInst))
-        {
-            context.insertDebugValueStore(func);
-        }
+        context.insertDebugValueStore(as<IRFunc>(inst));
     }
 }
 } // namespace Slang

--- a/source/slang/slang-ir-insts-stable-names.lua
+++ b/source/slang/slang-ir-insts-stable-names.lua
@@ -825,5 +825,6 @@ return {
 	["Type.Conditional"] = 849,
 	["getConditionalValue"] = 850,
 	["makeConditionalValue"] = 851,
-  ["SpecializeExistentialsInType"] = 852
+  ["SpecializeExistentialsInType"] = 852,
+	["moduleSection"] = 853
 }

--- a/source/slang/slang-ir-insts.lua
+++ b/source/slang/slang-ir-insts.lua
@@ -826,6 +826,7 @@ local insts = {
 	{
 		module = { struct_name = "ModuleInst", parent = true },
 	},
+	{ moduleSection = { struct_name = "ModuleSection", parent = true } },
 	{ block = { parent = true } },
 
 	-- A global inst representing an alias of another symbol, under a different mangled name.

--- a/source/slang/slang-ir-legalize-array-return-type.cpp
+++ b/source/slang/slang-ir-legalize-array-return-type.cpp
@@ -82,14 +82,12 @@ void legalizeArrayReturnType(IRModule* module)
 {
     IRBuilder builder(module);
 
-    for (auto inst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        if (auto func = as<IRFunc>(inst))
+        auto func = as<IRFunc>(inst);
+        if (func->getResultType()->getOp() == kIROp_ArrayType)
         {
-            if (func->getResultType()->getOp() == kIROp_ArrayType)
-            {
-                makeFuncReturnViaOutParam(builder, func);
-            }
+            makeFuncReturnViaOutParam(builder, func);
         }
     }
 }

--- a/source/slang/slang-ir-legalize-uniform-buffer-load.cpp
+++ b/source/slang/slang-ir-legalize-uniform-buffer-load.cpp
@@ -5,26 +5,27 @@ namespace Slang
 void legalizeUniformBufferLoad(IRModule* module)
 {
     List<IRLoad*> workList;
-    for (auto globalInst : module->getGlobalInsts())
+    auto collectLoads = [&](IRGlobalValueWithCode* code)
     {
-        if (auto func = as<IRGlobalValueWithCode>(globalInst))
+        for (auto block : code->getBlocks())
         {
-            for (auto block : func->getBlocks())
+            for (auto inst : block->getChildren())
             {
-                for (auto inst : block->getChildren())
+                if (auto load = as<IRLoad>(inst))
                 {
-                    if (auto load = as<IRLoad>(inst))
-                    {
-                        auto uniformBufferType =
-                            as<IRConstantBufferType>(load->getPtr()->getDataType());
-                        if (!uniformBufferType)
-                            continue;
-                        workList.add(load);
-                    }
+                    auto uniformBufferType =
+                        as<IRConstantBufferType>(load->getPtr()->getDataType());
+                    if (!uniformBufferType)
+                        continue;
+                    workList.add(load);
                 }
             }
         }
-    }
+    };
+    for (auto inst : module->getFuncs())
+        collectLoads(as<IRGlobalValueWithCode>(inst));
+    for (auto inst : module->getGlobalVars())
+        collectLoads(as<IRGlobalValueWithCode>(inst));
 
     IRBuilder builder(module);
     for (auto load : workList)

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -361,7 +361,7 @@ public:
         // We now search for entry-point definitions in the IR module.
         // All entry points should appear at the global scope.
         //
-        for (auto inst : module->getGlobalInsts())
+        for (auto inst : module->getFuncs())
         {
             // Entry points are IR functions.
             //

--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -2427,7 +2427,7 @@ struct IRPrelinkContext : IRSpecContext
         };
 
         auto builderForClone = builder;
-        if (as<IRModuleInst>(originalVal->getParent()))
+        if (isAtModuleScope(originalVal))
         {
             // If we are cloning a global value, we will use the module builder.
             builderForClone = &shared->builderStorage;

--- a/source/slang/slang-ir-loop-unroll.cpp
+++ b/source/slang/slang-ir-loop-unroll.cpp
@@ -573,17 +573,17 @@ bool unrollLoopsInModule(IRModule* module, TargetProgram* target, DiagnosticSink
 {
     SLANG_PROFILE;
 
-    for (auto inst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        if (as<IRGeneric>(inst))
-            continue;
-
-        if (auto func = as<IRGlobalValueWithCode>(inst))
-        {
-            bool result = unrollLoopsInFunc(target, module, func, sink);
-            if (!result)
-                return false;
-        }
+        bool result = unrollLoopsInFunc(target, module, as<IRGlobalValueWithCode>(inst), sink);
+        if (!result)
+            return false;
+    }
+    for (auto inst : module->getGlobalVars())
+    {
+        bool result = unrollLoopsInFunc(target, module, as<IRGlobalValueWithCode>(inst), sink);
+        if (!result)
+            return false;
     }
     return true;
 }

--- a/source/slang/slang-ir-lower-dynamic-dispatch-insts.cpp
+++ b/source/slang/slang-ir-lower-dynamic-dispatch-insts.cpp
@@ -902,7 +902,7 @@ struct SequentialIDTagLoweringContext : public InstPassBase
         StringBuilder generatedMangledName;
 
         auto linkage = getLinkage();
-        for (auto inst : module->getGlobalInsts())
+        for (auto inst : module->getWitnessTables())
         {
             if (inst->getOp() == kIROp_WitnessTable)
             {

--- a/source/slang/slang-ir-lower-matrix-swizzle-store.cpp
+++ b/source/slang/slang-ir-lower-matrix-swizzle-store.cpp
@@ -89,18 +89,8 @@ void lowerMatrixSwizzleStores(IRModule* module)
 {
     List<IRMatrixSwizzleStore*> instsToLower;
 
-    for (auto globalInst : module->getGlobalInsts())
+    auto collectFromFunc = [&](IRFunc* func)
     {
-        auto func = as<IRFunc>(globalInst);
-        if (!func)
-        {
-            auto gen = as<IRGeneric>(globalInst);
-            if (gen)
-                func = as<IRFunc>(findGenericReturnVal(gen));
-        }
-        if (!func)
-            continue;
-
         for (auto block : func->getBlocks())
         {
             for (auto inst : block->getChildren())
@@ -109,6 +99,23 @@ void lowerMatrixSwizzleStores(IRModule* module)
                     instsToLower.add(matSwizzleStore);
             }
         }
+    };
+    for (auto globalInst : module->getFuncs())
+    {
+        auto func = as<IRFunc>(globalInst);
+        if (!func)
+            continue;
+        collectFromFunc(func);
+    }
+    for (auto globalInst : module->getGenerics())
+    {
+        auto gen = as<IRGeneric>(globalInst);
+        if (!gen)
+            continue;
+        auto func = as<IRFunc>(findGenericReturnVal(gen));
+        if (!func)
+            continue;
+        collectFromFunc(func);
     }
 
     if (instsToLower.getCount() == 0)

--- a/source/slang/slang-ir-metadata.cpp
+++ b/source/slang/slang-ir-metadata.cpp
@@ -119,26 +119,26 @@ void collectMetadata(const IRModule* irModule, ArtifactPostEmitMetadata& outMeta
 {
     // Scan the instructions looking for global resource declarations
     // and exported functions.
-    for (const auto& inst : irModule->getGlobalInsts())
+    for (auto inst : irModule->getFuncs())
     {
+        if (inst->findDecoration<IRDownstreamModuleExportDecoration>())
+        {
+            auto name = inst->findDecoration<IRExportDecoration>()->getMangledName();
+            outMetadata.m_exportedFunctionMangledNames.add(name);
+        }
+
+        // Collect metadata from entrypoint params.
         if (auto func = as<IRFunc>(inst))
         {
-            if (func->findDecoration<IRDownstreamModuleExportDecoration>())
-            {
-                auto name = func->findDecoration<IRExportDecoration>()->getMangledName();
-                outMetadata.m_exportedFunctionMangledNames.add(name);
-            }
-
-            // Collect metadata from entrypoint params.
             for (auto param : func->getParams())
             {
                 collectMetadataFromInst(param, outMetadata);
             }
         }
+    }
 
-        auto param = as<IRGlobalParam>(inst);
-        if (!param)
-            continue;
+    for (auto param : irModule->getGlobalParams())
+    {
         collectMetadataFromInst(param, outMetadata);
     }
 }

--- a/source/slang/slang-ir-metal-legalize.cpp
+++ b/source/slang/slang-ir-metal-legalize.cpp
@@ -250,19 +250,17 @@ static void processInst(IRInst* inst, TargetProgram* targetProgram, DiagnosticSi
 void legalizeIRForMetal(IRModule* module, TargetProgram* targetProgram, DiagnosticSink* sink)
 {
     List<EntryPointInfo> entryPoints;
-    for (auto inst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        if (auto func = as<IRFunc>(inst))
+        auto func = as<IRFunc>(inst);
+        if (auto entryPointDecor = func->findDecoration<IREntryPointDecoration>())
         {
-            if (auto entryPointDecor = func->findDecoration<IREntryPointDecoration>())
-            {
-                EntryPointInfo info;
-                info.entryPointDecor = entryPointDecor;
-                info.entryPointFunc = func;
-                entryPoints.add(info);
-            }
-            legalizeFuncBody(func);
+            EntryPointInfo info;
+            info.entryPointDecor = entryPointDecor;
+            info.entryPointFunc = func;
+            entryPoints.add(info);
         }
+        legalizeFuncBody(func);
     }
 
     legalizeEntryPointVaryingParamsForMetal(module, sink, entryPoints);

--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -1903,7 +1903,7 @@ struct PeepholeContext : InstPassBase
         // The associatedtype is represented as a LookupWitnessMethod, so we will need to check the
         // type after the lookupWitnessMethod is fully specialized. This is to make something like
         // this to work: `if (IFoo.AssociatedType is int)`
-        return type->parent->getOp() == kIROp_ModuleInst && !as<IRGlobalGenericParam>(type) &&
+        return isAtModuleScope(type) && !as<IRGlobalGenericParam>(type) &&
                !as<IRLookupWitnessMethod>(type);
     }
 

--- a/source/slang/slang-ir-propagate-func-properties.cpp
+++ b/source/slang/slang-ir-propagate-func-properties.cpp
@@ -200,7 +200,7 @@ bool propagateFuncPropertiesImpl(IRModule* module, FuncPropertyPropagationContex
         workListSet.clear();
 
         // Add side effect free functions and their transitive callers to work list.
-        for (auto inst : module->getGlobalInsts())
+        auto processInitialFuncs = [&](IRInst* inst)
         {
             auto genericInst = as<IRGeneric>(inst);
             if (genericInst)
@@ -214,10 +214,14 @@ bool propagateFuncPropertiesImpl(IRModule* module, FuncPropertyPropagationContex
                     addCallersToWorkList(func);
                 }
             }
-        }
+        };
+        for (auto inst : module->getFuncs())
+            processInitialFuncs(inst);
+        for (auto inst : module->getGenerics())
+            processInitialFuncs(inst);
 
         // Add remaining functions to work list.
-        for (auto inst : module->getGlobalInsts())
+        auto processRemainingFuncs = [&](IRInst* inst)
         {
             auto genericInst = as<IRGeneric>(inst);
             if (genericInst)
@@ -228,7 +232,11 @@ bool propagateFuncPropertiesImpl(IRModule* module, FuncPropertyPropagationContex
             {
                 addToWorkList(func);
             }
-        }
+        };
+        for (auto inst : module->getFuncs())
+            processRemainingFuncs(inst);
+        for (auto inst : module->getGenerics())
+            processRemainingFuncs(inst);
 
         IRBuilder builder(module);
 

--- a/source/slang/slang-ir-pytorch-cpp-binding.cpp
+++ b/source/slang/slang-ir-pytorch-cpp-binding.cpp
@@ -1102,14 +1102,12 @@ IRFunc* generateCUDAWrapperForFunc(IRFunc* func, DiagnosticSink* sink)
 void lowerBuiltinTypesForKernelEntryPoints(IRModule* module, DiagnosticSink*)
 {
     List<IRFunc*> cudaKernels;
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        if (auto func = as<IRFunc>(globalInst))
+        auto func = as<IRFunc>(inst);
+        if (func->findDecoration<IRCudaKernelDecoration>())
         {
-            if (func->findDecoration<IRCudaKernelDecoration>())
-            {
-                cudaKernels.add(func);
-            }
+            cudaKernels.add(func);
         }
     }
 
@@ -1237,14 +1235,12 @@ void lowerBuiltinTypesForKernelEntryPoints(IRModule* module, DiagnosticSink*)
 void generateHostFunctionsForAutoBindCuda(IRModule* module, DiagnosticSink* sink)
 {
     List<IRFunc*> autoBindRequests;
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        if (auto func = as<IRFunc>(globalInst))
+        auto func = as<IRFunc>(inst);
+        if (func->findDecoration<IRAutoPyBindCudaDecoration>())
         {
-            if (func->findDecoration<IRAutoPyBindCudaDecoration>())
-            {
-                autoBindRequests.add(func);
-            }
+            autoBindRequests.add(func);
         }
     }
 
@@ -1259,30 +1255,28 @@ void generatePyTorchCppBinding(IRModule* module, DiagnosticSink* sink)
     List<IRFunc*> workList;
     List<IRFunc*> cudaKernels;
     List<IRType*> typesToExport;
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        if (auto func = as<IRFunc>(globalInst))
+        auto func = as<IRFunc>(inst);
+        if (func->findDecoration<IRTorchEntryPointDecoration>())
         {
-            if (func->findDecoration<IRTorchEntryPointDecoration>())
-            {
-                workList.add(func);
-            }
-            else if (func->findDecoration<IRCudaKernelDecoration>())
-            {
-                cudaKernels.add(func);
-            }
-            else
-            {
-                // Remove all other export decorations if this is not a cuda host func.
-                if (auto decor = func->findDecoration<IRPublicDecoration>())
-                    decor->removeAndDeallocate();
-                if (auto decor = func->findDecoration<IRHLSLExportDecoration>())
-                    decor->removeAndDeallocate();
-                if (auto decor = func->findDecoration<IRKeepAliveDecoration>())
-                    decor->removeAndDeallocate();
-                if (auto decor = func->findDecoration<IRDllExportDecoration>())
-                    decor->removeAndDeallocate();
-            }
+            workList.add(func);
+        }
+        else if (func->findDecoration<IRCudaKernelDecoration>())
+        {
+            cudaKernels.add(func);
+        }
+        else
+        {
+            // Remove all other export decorations if this is not a cuda host func.
+            if (auto decor = func->findDecoration<IRPublicDecoration>())
+                decor->removeAndDeallocate();
+            if (auto decor = func->findDecoration<IRHLSLExportDecoration>())
+                decor->removeAndDeallocate();
+            if (auto decor = func->findDecoration<IRKeepAliveDecoration>())
+                decor->removeAndDeallocate();
+            if (auto decor = func->findDecoration<IRDllExportDecoration>())
+                decor->removeAndDeallocate();
         }
     }
 
@@ -1318,12 +1312,10 @@ void generatePyTorchCppBinding(IRModule* module, DiagnosticSink* sink)
 void removeTorchKernels(IRModule* module)
 {
     List<IRInst*> toRemove;
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto func : module->getFuncs())
     {
-        if (!as<IRFunc>(globalInst))
-            continue;
-        if (globalInst->findDecoration<IRTorchEntryPointDecoration>())
-            toRemove.add(globalInst);
+        if (func->findDecoration<IRTorchEntryPointDecoration>())
+            toRemove.add(func);
     }
     for (auto inst : toRemove)
         inst->removeAndDeallocate();
@@ -1334,12 +1326,12 @@ void handleAutoBindNames(IRModule* module)
     // We need to rewrite extern-cpp names for functions that have an auto-bind decoration.
     // since the name needs to be used for the host function.
     //
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto func : module->getFuncs())
     {
-        if (auto autobindDecor = globalInst->findDecoration<IRAutoPyBindCudaDecoration>())
+        if (auto autobindDecor = func->findDecoration<IRAutoPyBindCudaDecoration>())
         {
             // Find an extern decoration on the original function, and append a prefix to the name.
-            if (auto externCppHint = globalInst->findDecoration<IRExternCppDecoration>())
+            if (auto externCppHint = func->findDecoration<IRExternCppDecoration>())
             {
                 IRBuilder builder(module);
 
@@ -1347,7 +1339,7 @@ void handleAutoBindNames(IRModule* module)
                 StringBuilder nameBuilder;
                 nameBuilder << "__kernel__" << externCppHint->getName();
                 externCppHint->removeAndDeallocate();
-                builder.addExternCppDecoration(globalInst, nameBuilder.getUnownedSlice());
+                builder.addExternCppDecoration(func, nameBuilder.getUnownedSlice());
             }
 
             autobindDecor->removeAndDeallocate();
@@ -1360,19 +1352,16 @@ void removeTorchAndCUDAEntryPoints(IRModule* module)
     // Go through global insts, find cuda & torch related entry points and remove the keep-alive
     // decoration.
     IRBuilder builder(module);
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto func : module->getFuncs())
     {
-        if (auto func = as<IRFunc>(globalInst))
+        if (func->findDecoration<IRAutoPyBindCudaDecoration>() ||
+            func->findDecoration<IRTorchEntryPointDecoration>() ||
+            func->findDecoration<IRCudaKernelDecoration>())
         {
-            if (func->findDecoration<IRAutoPyBindCudaDecoration>() ||
-                func->findDecoration<IRTorchEntryPointDecoration>() ||
-                func->findDecoration<IRCudaKernelDecoration>())
-            {
-                if (auto keepAlive = func->findDecoration<IRKeepAliveDecoration>())
-                    keepAlive->removeAndDeallocate();
-                if (auto hlslExport = func->findDecoration<IRHLSLExportDecoration>())
-                    hlslExport->removeAndDeallocate();
-            }
+            if (auto keepAlive = func->findDecoration<IRKeepAliveDecoration>())
+                keepAlive->removeAndDeallocate();
+            if (auto hlslExport = func->findDecoration<IRHLSLExportDecoration>())
+                hlslExport->removeAndDeallocate();
         }
     }
 }
@@ -1380,13 +1369,11 @@ void removeTorchAndCUDAEntryPoints(IRModule* module)
 void generateDerivativeWrappers(IRModule* module, DiagnosticSink* sink)
 {
     SLANG_UNUSED(sink);
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        if (!as<IRFunc>(globalInst))
-            continue;
-
+        auto func = as<IRFunc>(inst);
         // Look for methods marked with auto-bind and have derivatives registered.
-        if (auto autoBindDecoration = globalInst->findDecoration<IRAutoPyBindCudaDecoration>())
+        if (auto autoBindDecoration = func->findDecoration<IRAutoPyBindCudaDecoration>())
         {
             if (autoBindDecoration->getFwdDiffFuncOperand())
             {
@@ -1406,7 +1393,6 @@ void generateDerivativeWrappers(IRModule* module, DiagnosticSink* sink)
 
                 // Create a new wrapper function.
                 IRBuilder builder(module);
-                auto func = cast<IRFunc>(globalInst);
                 auto wrapperFunc = builder.createFunc();
                 builder.setInsertInto(wrapperFunc);
                 builder.emitBlock();
@@ -1472,7 +1458,6 @@ void generateDerivativeWrappers(IRModule* module, DiagnosticSink* sink)
 
                 // Create a new wrapper function.
                 IRBuilder builder(module);
-                auto func = cast<IRFunc>(globalInst);
                 auto wrapperFunc = builder.createFunc();
                 builder.setInsertInto(wrapperFunc);
                 builder.emitBlock();

--- a/source/slang/slang-ir-redundancy-removal.cpp
+++ b/source/slang/slang-ir-redundancy-removal.cpp
@@ -111,17 +111,10 @@ struct RedundancyRemovalContext
 bool removeRedundancy(IRModule* module, bool hoistLoopInvariantInsts)
 {
     bool changed = false;
-    for (auto inst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        if (auto genericInst = as<IRGeneric>(inst))
-        {
-            removeRedundancyInFunc(genericInst, hoistLoopInvariantInsts);
-            inst = findGenericReturnVal(genericInst);
-        }
-        if (auto func = as<IRFunc>(inst))
-        {
-            changed |= removeRedundancyInFunc(func, hoistLoopInvariantInsts);
-        }
+        auto func = as<IRFunc>(inst);
+        changed |= removeRedundancyInFunc(func, hoistLoopInvariantInsts);
     }
     return changed;
 }
@@ -364,22 +357,20 @@ void removeAvailableInDownstreamModuleDecorations(IRModule* module, CodeGenTarge
 {
     List<IRInst*> toRemove;
     auto builder = IRBuilder(module);
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        if (auto funcInst = as<IRFunc>(globalInst))
+        auto funcInst = as<IRFunc>(inst);
+        if (auto dec = funcInst->findDecoration<IRAvailableInDownstreamIRDecoration>())
         {
-            if (auto dec = globalInst->findDecoration<IRAvailableInDownstreamIRDecoration>())
+            if ((dec->getTarget() == CodeGenTarget::DXIL && target == CodeGenTarget::HLSL) ||
+                (dec->getTarget() == target))
             {
-                if ((dec->getTarget() == CodeGenTarget::DXIL && target == CodeGenTarget::HLSL) ||
-                    (dec->getTarget() == target))
+                // Gut the function definition, turning it into a declaration
+                for (auto block : funcInst->getBlocks())
                 {
-                    // Gut the function definition, turning it into a declaration
-                    for (auto block : funcInst->getBlocks())
-                    {
-                        toRemove.add(block);
-                    }
-                    builder.addDecoration(funcInst, kIROp_DownstreamModuleImportDecoration);
+                    toRemove.add(block);
                 }
+                builder.addDecoration(funcInst, kIROp_DownstreamModuleImportDecoration);
             }
         }
     }

--- a/source/slang/slang-ir-resolve-varying-input-ref.cpp
+++ b/source/slang/slang-ir-resolve-varying-input-ref.cpp
@@ -82,7 +82,7 @@ void resolveVaryingInputRef(IRFunc* func)
 
 void resolveVaryingInputRef(IRModule* module)
 {
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto globalInst : module->getFuncs())
     {
         if (globalInst->findDecoration<IREntryPointDecoration>())
             resolveVaryingInputRef((IRFunc*)globalInst);

--- a/source/slang/slang-ir-simplify-cfg.cpp
+++ b/source/slang/slang-ir-simplify-cfg.cpp
@@ -1005,16 +1005,10 @@ static bool processFunc(IRGlobalValueWithCode* func, CFGSimplificationOptions op
 bool simplifyCFG(IRModule* module, CFGSimplificationOptions options)
 {
     bool changed = false;
-    for (auto inst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        if (auto genericInst = as<IRGeneric>(inst))
-        {
-            inst = findGenericReturnVal(genericInst);
-        }
-        if (auto func = as<IRFunc>(inst))
-        {
-            changed |= processFunc(func, options);
-        }
+        auto func = as<IRFunc>(inst);
+        changed |= processFunc(func, options);
     }
     return changed;
 }

--- a/source/slang/slang-ir-specialize-address-space.cpp
+++ b/source/slang/slang-ir-specialize-address-space.cpp
@@ -358,18 +358,32 @@ struct AddressSpaceContext : public AddressSpaceSpecializationContext
 
     void processModule()
     {
-        for (auto globalInst : module->getGlobalInsts())
+        for (auto globalVar : module->getGlobalVars())
         {
-            auto addrSpace = getLeafInstAddressSpace(globalInst);
+            auto addrSpace = getLeafInstAddressSpace(globalVar);
             if (addrSpace != AddressSpace::Generic)
             {
-                mapInstToAddrSpace[globalInst] = addrSpace;
+                mapInstToAddrSpace[globalVar] = addrSpace;
             }
-            if (auto func = as<IRFunc>(globalInst))
+        }
+        for (auto globalParam : module->getGlobalParams())
+        {
+            auto addrSpace = getLeafInstAddressSpace(globalParam);
+            if (addrSpace != AddressSpace::Generic)
             {
-                if (func->findDecoration<IREntryPointDecoration>())
-                    workList.add(func);
+                mapInstToAddrSpace[globalParam] = addrSpace;
             }
+        }
+        for (auto inst : module->getFuncs())
+        {
+            auto addrSpace = getLeafInstAddressSpace(inst);
+            if (addrSpace != AddressSpace::Generic)
+            {
+                mapInstToAddrSpace[inst] = addrSpace;
+            }
+            auto func = as<IRFunc>(inst);
+            if (func && func->findDecoration<IREntryPointDecoration>())
+                workList.add(func);
         }
 
         HashSet<IRFunc*> newWorkList;

--- a/source/slang/slang-ir-specialize-resources.cpp
+++ b/source/slang/slang-ir-specialize-resources.cpp
@@ -156,13 +156,9 @@ struct ResourceOutputSpecializationPass
         // (which must appear at the global level) and specializing
         // them if needed.
         //
-        for (auto inst : module->getGlobalInsts())
+        for (auto inst : module->getFuncs())
         {
-            auto func = as<IRFunc>(inst);
-            if (!func)
-                continue;
-
-            changed |= processFunc(func);
+            changed |= processFunc(as<IRFunc>(inst));
         }
         return changed;
     }

--- a/source/slang/slang-ir-specialize-stage-switch.cpp
+++ b/source/slang/slang-ir-specialize-stage-switch.cpp
@@ -27,15 +27,13 @@ bool funcHasGetCurrentStageInst(IRGlobalValueWithCode* func)
 void discoverStageSpecificFunctions(HashSet<IRInst*>& stageSpecificFunctions, IRModule* module)
 {
     List<IRInst*> workList;
-    for (auto inst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        if (auto func = as<IRGlobalValueWithCode>(inst))
+        auto func = as<IRGlobalValueWithCode>(inst);
+        if (func && funcHasGetCurrentStageInst(func))
         {
-            if (funcHasGetCurrentStageInst(func))
-            {
-                workList.add(inst);
-                stageSpecificFunctions.add(func);
-            }
+            workList.add(inst);
+            stageSpecificFunctions.add(inst);
         }
     }
     for (Index i = 0; i < workList.getCount(); i++)

--- a/source/slang/slang-ir-specialize-target-switch.cpp
+++ b/source/slang/slang-ir-specialize-target-switch.cpp
@@ -99,7 +99,7 @@ void specializeTargetSwitch(
 
 void specializeTargetSwitch(TargetRequest* target, IRModule* module, DiagnosticSink* sink)
 {
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto globalInst : module->getFuncs())
     {
         if (auto code = as<IRGlobalValueWithCode>(globalInst))
         {

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -3551,7 +3551,7 @@ IRInst* specializeGenericWithSetArgs(
         else
         {
             // For everything else, just set the parameter type to the argument;
-            SLANG_ASSERT(specArg->getParent()->getOp() == kIROp_ModuleInst);
+            SLANG_ASSERT(isAtModuleScope(specArg));
             cloneEnv.mapOldValToNew[param] = specArg;
         }
     }

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -1046,13 +1046,13 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         builder.setInsertBefore(inst);
         if (!m_mapArrayValueToVar.tryGetValue(x, y))
         {
-            if (x->getParent()->getOp() == kIROp_ModuleInst)
+            if (isAtModuleScope(x))
                 builder.setInsertBefore(inst);
             else
                 setInsertAfterOrdinaryInst(&builder, x);
             y = builder.emitVar(x->getDataType(), AddressSpace::Function);
             builder.emitStore(y, x);
-            if (x->getParent()->getOp() != kIROp_ModuleInst)
+            if (!isAtModuleScope(x))
                 m_mapArrayValueToVar.set(x, y);
         }
         builder.setInsertBefore(inst);
@@ -1485,13 +1485,14 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         for (auto operand = inst->getOperands(); opIndex < inst->getOperandCount();
              operand++, opIndex++)
         {
-            if (operand->get()->getParent() != m_module->getModuleInst())
+            if (!isAtModuleScope(operand->get()))
                 return;
 
             if (as<IRGlobalParam>(operand->get()))
                 return;
         }
-        inst->insertAtEnd(m_module->getModuleInst());
+        auto sectionKind = getSectionKindForInst(inst);
+        inst->insertAtEnd(m_module->getOrCreateSection(sectionKind));
     }
 
     void processDefaultConstruct(IRInst* inst)
@@ -1536,7 +1537,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
     {
         maybeHoistConstructInstToGlobalScope(inst);
 
-        if (inst->getOp() == kIROp_MakeVector && inst->getParent()->getOp() == kIROp_ModuleInst &&
+        if (inst->getOp() == kIROp_MakeVector && isAtModuleScope(inst) &&
             inst->getOperandCount() !=
                 (UInt)getIntVal(as<IRVectorType>(inst->getDataType())->getElementCount()))
         {
@@ -2073,11 +2074,9 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
     // This fills gaps after legalization where only the access-chain inst was decorated.
     void propagateNonUniformAccessChainDecorations()
     {
-        for (auto globalInst : m_module->getGlobalInsts())
+        for (auto globalInst : m_module->getFuncs())
         {
             auto func = as<IRFunc>(globalInst);
-            if (!func)
-                continue;
 
             for (auto block : func->getBlocks())
             {
@@ -2270,11 +2269,9 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         // Work list of load/store insts to add Aligned attribute to.
         List<IRInst*> loadStoreInsts;
 
-        for (auto globalInst : m_module->getGlobalInsts())
+        for (auto globalInst : m_module->getFuncs())
         {
             auto func = as<IRFunc>(globalInst);
-            if (!func)
-                continue;
             for (auto block : func->getBlocks())
             {
                 for (auto inst : block->getChildren())

--- a/source/slang/slang-ir-ssa-simplification.cpp
+++ b/source/slang/slang-ir-ssa-simplification.cpp
@@ -75,11 +75,8 @@ void simplifyIR(
         changed |= peepholeOptimizeGlobalScope(target, module);
         changed |= trimOptimizableTypes(module);
 
-        for (auto inst : module->getGlobalInsts())
+        auto processCodeInst = [&](IRGlobalValueWithCode* func)
         {
-            auto func = as<IRGlobalValueWithCode>(inst);
-            if (!func)
-                continue;
             bool funcChanged = true;
             int funcIterationCount = 0;
             while (funcChanged && funcIterationCount < kMaxFuncIterations)
@@ -104,7 +101,11 @@ void simplifyIR(
                 changed |= funcChanged;
                 funcIterationCount++;
             }
-        }
+        };
+        for (auto inst : module->getFuncs())
+            processCodeInst(as<IRGlobalValueWithCode>(inst));
+        for (auto inst : module->getGlobalVars())
+            processCodeInst(as<IRGlobalValueWithCode>(inst));
         iterationCounter++;
     }
     eliminateDeadCode(module, options.deadCodeElimOptions);

--- a/source/slang/slang-ir-ssa.cpp
+++ b/source/slang/slang-ir-ssa.cpp
@@ -1619,7 +1619,11 @@ bool constructSSA(IRModule* module, IRInst* globalVal)
 bool constructSSA(IRModule* module)
 {
     bool changed = false;
-    for (auto ii : module->getGlobalInsts())
+    for (auto ii : module->getFuncs())
+    {
+        changed |= constructSSA(module, ii);
+    }
+    for (auto ii : module->getGlobalVars())
     {
         changed |= constructSSA(module, ii);
     }

--- a/source/slang/slang-ir-strip-legalization-insts.cpp
+++ b/source/slang/slang-ir-strip-legalization-insts.cpp
@@ -9,51 +9,42 @@ namespace Slang
 
 void stripLegalizationOnlyInstructions(IRModule* module)
 {
-    for (auto inst : module->getGlobalInsts())
+    // Remove global param entry point param decoration.
+    for (auto inst : module->getGlobalParams())
     {
-        switch (inst->getOp())
+        if (const auto entryPointParamDecoration =
+                inst->findDecoration<IREntryPointParamDecoration>())
+            entryPointParamDecoration->removeAndDeallocate();
+    }
+
+    // Remove witness tables.
+    // Our goal here is to empty out any witness tables in
+    // the IR so that they don't keep other symbols alive
+    // further into compilation. Luckily we expect all
+    // witness tables to live directly at the global scope
+    // (or inside of a generic, which we can ignore for
+    // now because the emit logic also ignores generics),
+    // and there is a single function we can call to
+    // remove all of the content from the witness tables
+    // (since the key-value associations are stored as
+    // children of each table).
+    for (auto inst : module->getWitnessTables())
+    {
+        auto witnessTable = as<IRWitnessTable>(inst);
+        if (!witnessTable)
+            continue;
+        auto conformanceType = witnessTable->getConformanceType();
+        if (!conformanceType ||
+            !conformanceType->findDecoration<IRComInterfaceDecoration>())
         {
-        // Remove global param entry point param decoration.
-        case kIROp_GlobalParam:
-            {
-                if (const auto entryPointParamDecoration =
-                        inst->findDecoration<IREntryPointParamDecoration>())
-                    entryPointParamDecoration->removeAndDeallocate();
-                break;
-            }
-
-        // Remove witness tables.
-        // Our goal here is to empty out any witness tables in
-        // the IR so that they don't keep other symbols alive
-        // further into compilation. Luckily we expect all
-        // witness tables to live directly at the global scope
-        // (or inside of a generic, which we can ignore for
-        // now because the emit logic also ignores generics),
-        // and there is a single function we can call to
-        // remove all of the content from the witness tables
-        // (since the key-value associations are stored as
-        // children of each table).
-        case kIROp_WitnessTable:
-            {
-                auto witnessTable = as<IRWitnessTable>(inst);
-                auto conformanceType = witnessTable->getConformanceType();
-                if (!conformanceType ||
-                    !conformanceType->findDecoration<IRComInterfaceDecoration>())
-                {
-                    witnessTable->removeAndDeallocateAllDecorationsAndChildren();
-                }
-                break;
-            }
-
-        default:
-            break;
+            witnessTable->removeAndDeallocateAllDecorationsAndChildren();
         }
     }
 }
 
 void unpinWitnessTables(IRModule* module)
 {
-    for (auto inst : module->getGlobalInsts())
+    for (auto inst : module->getWitnessTables())
     {
         auto witnessTable = as<IRWitnessTable>(inst);
         if (!witnessTable)

--- a/source/slang/slang-ir-strip.cpp
+++ b/source/slang/slang-ir-strip.cpp
@@ -54,23 +54,12 @@ void stripFrontEndOnlyInstructions(IRModule* module, IRStripOptions const& optio
 
 void stripImportedWitnessTable(IRModule* module)
 {
-    for (auto globalInst : module->getGlobalInsts())
+    auto processWitnessTableInst = [&](IRInst* globalInst, IRInst* inst)
     {
-        auto inst = globalInst;
-        switch (globalInst->getOp())
-        {
-        case kIROp_Generic:
-            inst = findInnerMostGenericReturnVal(as<IRGeneric>(globalInst));
-            break;
-        case kIROp_WitnessTable:
-            break;
-        default:
-            continue;
-        }
         if (!inst || inst->getOp() != kIROp_WitnessTable)
-            continue;
+            return;
         if (!globalInst->findDecoration<IRImportDecoration>())
-            continue;
+            return;
         IRInst* nextChild = nullptr;
         for (auto child = inst->getFirstChild(); child;)
         {
@@ -79,7 +68,11 @@ void stripImportedWitnessTable(IRModule* module)
                 child->removeAndDeallocate();
             child = nextChild;
         }
-    }
+    };
+    for (auto gen : module->getGenerics())
+        processWitnessTableInst(gen, findInnerMostGenericReturnVal(as<IRGeneric>(gen)));
+    for (auto wt : module->getWitnessTables())
+        processWitnessTableInst(wt, wt);
 }
 
 } // namespace Slang

--- a/source/slang/slang-ir-translate.cpp
+++ b/source/slang/slang-ir-translate.cpp
@@ -371,7 +371,7 @@ IRInst* _resolveInstRec(TranslationContext* ctx, IRInst* inst)
     // If we still have something that's not in the global scope, then something went wrong.
     // since all operations after this point require this.
     //
-    SLANG_ASSERT(as<IRModuleInst>(instWithCanonicalOperands->getParent()));
+    SLANG_ASSERT(isAtModuleScope(instWithCanonicalOperands));
 
     // TODO: Group these.
     if (as<IRTranslateBase>(instWithCanonicalOperands) ||

--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -140,7 +140,7 @@ struct InstWithContext
         // reference. An explicit IRSpecialize instruction must be provided as
         // context.
         //
-        SLANG_ASSERT(func->getParent()->getOp() == kIROp_ModuleInst);
+        SLANG_ASSERT(isAtModuleScope(func));
 
         context = func;
     }
@@ -467,7 +467,7 @@ IRInst* getArrayStride(IRArrayType* arrayType)
 // Helper to test if an inst is in the global scope.
 bool isGlobalInst(IRInst* inst)
 {
-    return inst->getParent()->getOp() == kIROp_ModuleInst;
+    return isAtModuleScope(inst);
 }
 
 // This is fairly fundamental check:
@@ -1060,7 +1060,7 @@ struct TypeFlowSpecializationContext
             return none();
 
         // Global insts always have no info.
-        if (as<IRModuleInst>(inst->getParent()))
+        if (isAtModuleScope(inst))
             return none();
 
         return _tryGetInfo(InstWithContext(context, inst));
@@ -1534,10 +1534,12 @@ struct TypeFlowSpecializationContext
         // discoverContext encounters the corresponding IRSpecialize context or when
         // propagateToCallSite/specializeCall resolves the callee.
         //
-        for (auto inst : module->getGlobalInsts())
-            if (auto func = as<IRFunc>(inst))
-                if (isEntryPoint(func) && !isInvalidExistentialSpecialization(func))
-                    discoverContext(func, workQueue);
+        for (auto inst : module->getFuncs())
+        {
+            auto func = as<IRFunc>(inst);
+            if (isEntryPoint(func) && !isInvalidExistentialSpecialization(func))
+                discoverContext(func, workQueue);
+        }
 
         // Process until fixed point.
         while (workQueue.hasItems())
@@ -3645,7 +3647,7 @@ struct TypeFlowSpecializationContext
             //
 
             IRType* typeOfSpecialization = nullptr;
-            if (inst->getDataType()->getParent()->getOp() == kIROp_ModuleInst)
+            if (isAtModuleScope(inst->getDataType()))
                 typeOfSpecialization = inst->getDataType();
             else if (auto funcType = as<IRFuncType>(inst->getDataType()))
             {
@@ -5279,7 +5281,7 @@ struct TypeFlowSpecializationContext
     bool replaceType(IRInst* context, IRInst* inst)
     {
         // If the inst is a global val, we won't modify it.
-        if (as<IRModuleInst>(inst->getParent()))
+        if (isAtModuleScope(inst))
         {
             if (as<IRType>(inst) || as<IRWitnessTable>(inst) || as<IRFunc>(inst) ||
                 as<IRGeneric>(inst))

--- a/source/slang/slang-ir-uniformity.cpp
+++ b/source/slang/slang-ir-uniformity.cpp
@@ -435,7 +435,7 @@ struct ValidateUniformityContext
     {
         InstWorkList workList(module);
 
-        for (auto globalInst : module->getGlobalInsts())
+        for (auto globalInst : module->getFuncs())
         {
             if (auto code = as<IRGlobalValueWithCode>(globalInst))
             {

--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -725,19 +725,25 @@ static void checkUninitializedGlobals(IRGlobalVar* variable, DiagnosticSink* sin
 
 void checkForUsingUninitializedValues(IRModule* module, DiagnosticSink* sink)
 {
-    for (auto inst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
         if (auto func = as<IRFunc>(inst))
         {
             checkUninitializedValues(func, sink);
         }
-        else if (auto generic = as<IRGeneric>(inst))
+    }
+    for (auto inst : module->getGenerics())
+    {
+        if (auto generic = as<IRGeneric>(inst))
         {
             auto retVal = findGenericReturnVal(generic);
             if (auto funcVal = as<IRFunc>(retVal))
                 checkUninitializedValues(funcVal, sink);
         }
-        else if (auto global = as<IRGlobalVar>(inst))
+    }
+    for (auto inst : module->getGlobalVars())
+    {
+        if (auto global = as<IRGlobalVar>(inst))
         {
             checkUninitializedGlobals(global, sink);
         }

--- a/source/slang/slang-ir-user-type-hint.cpp
+++ b/source/slang/slang-ir-user-type-hint.cpp
@@ -9,11 +9,8 @@ namespace Slang
 
 void addUserTypeHintDecorations(IRModule* module)
 {
-    for (auto globalInst : module->getGlobalInsts())
+    for (auto inst : module->getGlobalParams())
     {
-        auto inst = as<IRGlobalParam>(globalInst);
-        if (!inst)
-            continue;
         if (inst->getDataType())
         {
             // Preserve the original type name as a decoration before we do any type lowering.

--- a/source/slang/slang-ir-validate.cpp
+++ b/source/slang/slang-ir-validate.cpp
@@ -254,7 +254,7 @@ void validateIRInstOperand(IRValidateContext* context, IRInst* inst, IRUse* oper
     }
 
     // We allow out-of-order def-use in global scope.
-    bool allInGlobalScope = inst->getParent() && inst->getParent()->getOp() == kIROp_ModuleInst;
+    bool allInGlobalScope = isAtModuleScope(inst);
     if (allInGlobalScope)
     {
         for (UInt i = 0; i < inst->getOperandCount(); i++)
@@ -264,7 +264,7 @@ void validateIRInstOperand(IRValidateContext* context, IRInst* inst, IRUse* oper
                 continue;
             if (!op->getParent())
                 continue;
-            if (op->getParent()->getOp() != kIROp_ModuleInst)
+            if (!isAtModuleScope(op))
             {
                 allInGlobalScope = false;
                 break;
@@ -415,6 +415,35 @@ void validateIRInst(IRInst* inst)
     validateIRInst(context, inst);
 }
 
+void validateModuleSections(IRValidateContext* context, IRModule* module, IRModuleInst* moduleInst)
+{
+    // Check that every non-decoration direct child of IRModuleInst is an IRModuleSection.
+    for (auto child : moduleInst->getChildren())
+    {
+        validate(
+            context,
+            as<IRModuleSection>(child) != nullptr,
+            child,
+            "all non-decoration direct children of IRModuleInst must be IRModuleSection");
+    }
+
+    // Check that every instruction in a section belongs in that section.
+    for (int i = 0; i < (int)IRModuleSectionKind::Count; i++)
+    {
+        auto section = module->getSection((IRModuleSectionKind)i);
+        if (!section)
+            continue;
+        for (auto inst : section->getChildren())
+        {
+            validate(
+                context,
+                getSectionKindForInst(inst) == (IRModuleSectionKind)i,
+                inst,
+                "instruction is in the wrong section");
+        }
+    }
+}
+
 void validateIRModule(IRModule* module, DiagnosticSink* sink)
 {
     IRValidateContext contextStorage;
@@ -428,6 +457,10 @@ void validateIRModule(IRModule* module, DiagnosticSink* sink)
     validate(context, moduleInst->parent == nullptr, moduleInst, "module instruction parent");
     validate(context, moduleInst->prev == nullptr, moduleInst, "module instruction prev");
     validate(context, moduleInst->next == nullptr, moduleInst, "module instruction next");
+
+    // Validate section invariants if sections exist.
+    if (module->getSection(IRModuleSectionKind::Funcs) != nullptr)
+        validateModuleSections(context, module, moduleInst);
 
     validateIRInst(context, moduleInst);
 }

--- a/source/slang/slang-ir-wgsl-legalize.cpp
+++ b/source/slang/slang-ir-wgsl-legalize.cpp
@@ -215,11 +215,9 @@ struct GlobalInstInliningContext : public GlobalInstInliningContextGeneric
 void legalizeIRForWGSL(IRModule* module, TargetProgram* targetProgram, DiagnosticSink* sink)
 {
     List<EntryPointInfo> entryPoints;
-    for (auto inst : module->getGlobalInsts())
+    for (auto inst : module->getFuncs())
     {
-        IRFunc* const func{as<IRFunc>(inst)};
-        if (!func)
-            continue;
+        auto func = as<IRFunc>(inst);
         IREntryPointDecoration* const entryPointDecor =
             func->findDecoration<IREntryPointDecoration>();
         if (!entryPointDecor)

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -211,6 +211,50 @@ void IRUse::clear()
     }
 }
 
+// IRFlattenedGlobalInstIterator
+
+// Helper: advance to the next sibling section that has children.
+static IRInst* _findNextNonEmptySection(IRInst* section)
+{
+    while (section)
+    {
+        section = section->next;
+        if (!section)
+            return nullptr;
+        if (section->getOp() == kIROp_ModuleSection && section->getFirstChild())
+            return section;
+    }
+    return nullptr;
+}
+
+void IRFlattenedGlobalInstIterator::operator++()
+{
+    if (!inst)
+        return;
+
+    inst = inst->next;
+    if (inst)
+        return;
+
+    // End of current section's children. Advance to next non-empty section.
+    section = _findNextNonEmptySection(section);
+    inst = section ? section->getFirstChild() : nullptr;
+}
+
+IRFlattenedGlobalInstIterator IRFlattenedGlobalInstRange::begin()
+{
+    if (!moduleInst)
+        return IRFlattenedGlobalInstIterator(nullptr, nullptr);
+
+    // Find the first section with children.
+    IRInst* sec = moduleInst->getFirstChild();
+    while (sec && (sec->getOp() != kIROp_ModuleSection || !sec->getFirstChild()))
+        sec = sec->next;
+    if (sec)
+        return IRFlattenedGlobalInstIterator(sec->getFirstChild(), sec);
+    return IRFlattenedGlobalInstIterator(nullptr, nullptr);
+}
+
 // IRInstListBase
 
 void IRInstListBase::Iterator::operator++()
@@ -1674,6 +1718,13 @@ void addHoistableInst(IRBuilder* builder, IRInst* inst)
     //
     SLANG_ASSERT(parent);
 
+    // If the resolved parent is the module inst, route to the appropriate section.
+    if (as<IRModuleInst>(parent))
+    {
+        auto sectionKind = getSectionKindForInst(inst);
+        parent = builder->getModule()->getOrCreateSection(sectionKind);
+    }
+
     // Once we determine the parent instruction that the
     // new instruction should be inserted into, we need
     // to find an appropriate place to insert it.
@@ -1732,7 +1783,7 @@ void addHoistableInst(IRBuilder* builder, IRInst* inst)
     // else, we want to ensure that an instruction comes after
     // its type and operands.
     //
-    if (!as<IRModuleInst>(parent))
+    if (!isModuleScopeParent(parent))
     {
         // We need to make sure that if any of
         // the operands of `inst` come from the same
@@ -2597,7 +2648,7 @@ static void addGlobalValue(IRBuilder* builder, IRInst* value)
     {
         // Inserting into the top level of a module?
         // That is fine, and we can stop searching.
-        if (as<IRModuleInst>(parent))
+        if (isModuleScopeParent(parent))
             break;
 
         // Inserting into a basic block inside of
@@ -2619,6 +2670,13 @@ static void addGlobalValue(IRBuilder* builder, IRInst* value)
     if (!parent)
     {
         parent = builder->getModule()->getModuleInst();
+    }
+
+    // If landing at module scope, route to the appropriate section.
+    if (as<IRModuleInst>(parent))
+    {
+        auto sectionKind = getSectionKindForInst(value);
+        parent = builder->getModule()->getOrCreateSection(sectionKind);
     }
 
     // If it turns out that we are inserting into the
@@ -4800,6 +4858,133 @@ IRInst* IRBuilder::addIntermediateContextFieldDifferentialTypeDecoration(
     return addDecoration(target, kIROp_IntermediateContextFieldDifferentialTypeDecoration, witness);
 }
 
+const char* getSectionKindName(IRModuleSectionKind kind)
+{
+    switch (kind)
+    {
+    case IRModuleSectionKind::Funcs:
+        return "Funcs";
+    case IRModuleSectionKind::Generics:
+        return "Generics";
+    case IRModuleSectionKind::StructTypes:
+        return "StructTypes";
+    case IRModuleSectionKind::GlobalVars:
+        return "GlobalVars";
+    case IRModuleSectionKind::GlobalParams:
+        return "GlobalParams";
+    case IRModuleSectionKind::Hoistables:
+        return "Hoistables";
+    case IRModuleSectionKind::WitnessTables:
+        return "WitnessTables";
+    case IRModuleSectionKind::Annotations:
+        return "Annotations";
+    case IRModuleSectionKind::Capabilities:
+        return "Capabilities";
+    case IRModuleSectionKind::Literals:
+        return "Literals";
+    case IRModuleSectionKind::Keys:
+        return "Keys";
+    case IRModuleSectionKind::Misc:
+        return "Misc";
+    default:
+        SLANG_UNEXPECTED("unknown section kind");
+    }
+}
+
+IRModuleSectionKind getSectionKindForInst(IRInst* inst)
+{
+    auto op = inst->getOp();
+
+    // Functions
+    if (op == kIROp_Func)
+        return IRModuleSectionKind::Funcs;
+
+    // Generics (generic funcs, types, witness tables, etc.)
+    if (op == kIROp_Generic)
+        return IRModuleSectionKind::Generics;
+
+    // Constants / Literals
+    if (op >= kIROp_FirstConstant && op <= kIROp_LastConstant)
+        return IRModuleSectionKind::Literals;
+
+    // Types (struct, class, enum, interface, and all other type defs)
+    if (op >= kIROp_FirstType && op <= kIROp_LastType)
+        return IRModuleSectionKind::StructTypes;
+
+    // Global variables and constants
+    if (op == kIROp_GlobalVar || op == kIROp_GlobalConstant)
+        return IRModuleSectionKind::GlobalVars;
+
+    // Global parameters
+    if (op == kIROp_GlobalParam)
+        return IRModuleSectionKind::GlobalParams;
+
+    // Witness tables
+    if (op == kIROp_WitnessTable)
+        return IRModuleSectionKind::WitnessTables;
+
+    // Keys
+    if (op == kIROp_StructKey || op == kIROp_IndexedFieldKey)
+        return IRModuleSectionKind::Keys;
+
+    // Capabilities
+    if (op >= kIROp_FirstCapabilitySet && op <= kIROp_LastCapabilitySet)
+        return IRModuleSectionKind::Capabilities;
+
+    // Annotations
+    if (op == kIROp_Annotation || op == kIROp_DifferentiableTypeAnnotation ||
+        op == kIROp_WitnessTableAnnotation || op == kIROp_DebugSource)
+        return IRModuleSectionKind::Annotations;
+
+    // Hoistable instructions (Specialize, etc.) that are not types, literals, or other categories
+    if (getIROpInfo(op).isHoistable())
+        return IRModuleSectionKind::Hoistables;
+
+    // Everything else
+    return IRModuleSectionKind::Misc;
+}
+
+IRModuleSection* IRModule::getOrCreateSection(IRModuleSectionKind kind)
+{
+    auto& section = m_sections[(int)kind];
+    if (!section)
+    {
+        section = _allocateInst<IRModuleSection>(kIROp_ModuleSection, 0);
+        section->insertAtEnd(m_moduleInst);
+
+        // Add a name hint for IR dump readability.
+        IRBuilder builder(this);
+        builder.addNameHintDecoration(section, UnownedStringSlice(getSectionKindName(kind)));
+    }
+    return section;
+}
+
+void IRModule::_rebuildSectionTable()
+{
+    // Scan the module inst's direct children for section nodes
+    // and populate the m_sections array by matching NameHint decorations.
+    for (auto child = m_moduleInst->getFirstChild(); child; child = child->next)
+    {
+        if (auto section = as<IRModuleSection>(child))
+        {
+            // Determine which section kind this is by checking its first child's
+            // expected section kind, or by matching the NameHint decoration.
+            if (auto nameHint = section->findDecoration<IRNameHintDecoration>())
+            {
+                auto name = nameHint->getName();
+                for (int i = 0; i < (int)IRModuleSectionKind::Count; i++)
+                {
+                    if (name == getSectionKindName((IRModuleSectionKind)i))
+                    {
+                        m_sections[i] = section;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
 RefPtr<IRModule> IRModule::create(Session* session)
 {
     RefPtr<IRModule> module = new IRModule(session);
@@ -4808,6 +4993,10 @@ RefPtr<IRModule> IRModule::create(Session* session)
 
     module->m_moduleInst = moduleInst;
     moduleInst->module = module;
+
+    // Eagerly create all sections so the flattened iterator always sees sections.
+    for (int i = 0; i < (int)IRModuleSectionKind::Count; i++)
+        module->getOrCreateSection((IRModuleSectionKind)i);
 
     return module;
 }
@@ -7160,7 +7349,7 @@ IRSetBase* IRBuilder::getSet(IROp op, const HashSet<IRInst*>& elements)
 {
     // Verify that all operands are global instructions
     for (auto element : elements)
-        if (element->getParent()->getOp() != kIROp_ModuleInst)
+        if (!isAtModuleScope(element))
             SLANG_ASSERT_FAILURE("createSet called with non-global operands");
 
     List<IRInst*>* sortedElements = getModule()->getContainerPool().getList<IRInst>();
@@ -8009,9 +8198,10 @@ static void dumpInst(IRDumpContext* context, IRInst* inst)
 
 void dumpIRModule(IRDumpContext* context, IRModule* module)
 {
-    for (auto ii : module->getGlobalInsts())
+    // Dump the actual structure including sections.
+    for (auto child : module->getModuleInst()->getDirectChildren())
     {
-        dumpInst(context, ii);
+        dumpInst(context, child);
     }
 }
 
@@ -8558,7 +8748,7 @@ static void _maybeHoistOperand(IRUse* use)
                 continue;
 
             // We allow out-of-order uses in global scope.
-            if (operand->getParent() && operand->getParent()->getOp() == kIROp_ModuleInst)
+            if (isAtModuleScope(operand))
                 continue;
 
             // If the operand is defined after user, move it to before user.

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1897,6 +1897,32 @@ IRInst* findSpecializeReturnVal(IRSpecialize* specialize);
 //
 IRInst* getResolvedInstForDecorations(IRInst* inst, bool resolveThroughDifferentiation = false);
 
+// Iterator that walks global instructions by descending into IRModuleSection children.
+// Yields the children of each section, skipping the section nodes themselves.
+struct IRFlattenedGlobalInstIterator
+{
+    IRInst* inst;      // current instruction (a child of a section)
+    IRInst* section;   // current section
+
+    IRFlattenedGlobalInstIterator() : inst(nullptr), section(nullptr) {}
+    IRFlattenedGlobalInstIterator(IRInst* inst, IRInst* section) : inst(inst), section(section) {}
+
+    void operator++();
+    IRInst* operator*() { return inst; }
+    bool operator!=(IRFlattenedGlobalInstIterator const& other) { return inst != other.inst; }
+};
+
+struct IRFlattenedGlobalInstRange
+{
+    IRInst* moduleInst; // The IRModuleInst
+
+    IRFlattenedGlobalInstRange() : moduleInst(nullptr) {}
+    IRFlattenedGlobalInstRange(IRInst* moduleInst) : moduleInst(moduleInst) {}
+
+    IRFlattenedGlobalInstIterator begin();
+    IRFlattenedGlobalInstIterator end() { return IRFlattenedGlobalInstIterator(nullptr, nullptr); }
+};
+
 // The IR module itself is represented as an instruction, which
 // serves at the root of the tree of all instructions in the module.
 FIDDLE()
@@ -1908,8 +1934,63 @@ struct IRModuleInst : IRInst
     // that need it.
     IRModule* module;
 
-    IRInstListBase getGlobalInsts() { return getChildren(); }
+    IRFlattenedGlobalInstRange getGlobalInsts() { return IRFlattenedGlobalInstRange(this); }
+
+    // Direct children access (includes section nodes themselves).
+    IRInstListBase getDirectChildren() { return getChildren(); }
 };
+
+// A section within an IR module that groups related global instructions.
+// Sections are direct children of IRModuleInst and contain global instructions
+// of a specific category (funcs, types, generics, etc.).
+FIDDLE()
+struct IRModuleSection : IRInst
+{
+    FIDDLE(leafInst())
+
+    IRInstListBase getInsts() { return getChildren(); }
+};
+
+/// Returns true if `parent` is a valid "module scope" parent for global instructions.
+/// This includes both IRModuleInst and IRModuleSection.
+inline bool isModuleScopeParent(IRInst* parent)
+{
+    if (!parent)
+        return false;
+    auto op = parent->getOp();
+    return op == kIROp_ModuleInst || op == kIROp_ModuleSection;
+}
+
+/// Returns true if `inst` is at module/global scope (its parent is the module or a section).
+inline bool isAtModuleScope(IRInst* inst)
+{
+    return inst && isModuleScopeParent(inst->getParent());
+}
+
+// Categories of global instructions within an IR module.
+// Each section groups instructions that passes commonly need to iterate together.
+enum class IRModuleSectionKind
+{
+    Funcs,        // IRFunc (non-generic functions)
+    Generics,     // IRGeneric (all generics: generic funcs, types, witness tables, etc.)
+    StructTypes,  // IRStructType, IRClassType, IREnumType, IRInterfaceType, and other type defs
+    GlobalVars,   // IRGlobalVar, IRGlobalConstant
+    GlobalParams, // IRGlobalParam
+    Hoistables,   // IRSpecialize, hoistable non-type non-literal ops
+    WitnessTables, // IRWitnessTable (non-generic)
+    Annotations,  // IRAnnotation and related metadata
+    Capabilities, // IRCapabilityConjunction, IRCapabilityDisjunction
+    Literals,     // IRConstant subtypes (IntLit, FloatLit, StringLit, etc.)
+    Keys,         // IRStructKey, IRIndexedFieldKey
+    Misc,         // Catch-all for uncategorized global instructions
+    Count,
+};
+
+/// Returns the section kind that a given instruction should be placed in.
+IRModuleSectionKind getSectionKindForInst(IRInst* inst);
+
+/// Returns a human-readable name for a section kind (used for NameHint decorations).
+const char* getSectionKindName(IRModuleSectionKind kind);
 
 struct IRModule;
 
@@ -2109,7 +2190,41 @@ public:
     }
     void invalidateAllAnalysis() { m_mapInstToAnalysis.clear(); }
 
-    IRInstListBase getGlobalInsts() const { return getModuleInst()->getChildren(); }
+    IRFlattenedGlobalInstRange getGlobalInsts() const
+    {
+        return IRFlattenedGlobalInstRange(getModuleInst());
+    }
+
+    /// Get the section for a given kind, or null if not yet created.
+    IRModuleSection* getSection(IRModuleSectionKind kind) const
+    {
+        return m_sections[(int)kind];
+    }
+
+    /// Get or create the section for a given kind.
+    IRModuleSection* getOrCreateSection(IRModuleSectionKind kind);
+
+    /// Rebuild m_sections[] from deserialized module children.
+    /// Called after deserialization to populate the sections array.
+    void _rebuildSectionTable();
+
+    /// Get instructions in a specific section.
+    IRInstListBase getSectionInsts(IRModuleSectionKind kind) const
+    {
+        if (auto sec = getSection(kind))
+            return sec->getChildren();
+        return IRInstListBase();
+    }
+
+    /// Convenience: iterate specific sections.
+    IRInstListBase getFuncs() const { return getSectionInsts(IRModuleSectionKind::Funcs); }
+    IRInstListBase getGenerics() const { return getSectionInsts(IRModuleSectionKind::Generics); }
+    IRInstListBase getStructTypes() const { return getSectionInsts(IRModuleSectionKind::StructTypes); }
+    IRInstListBase getGlobalVars() const { return getSectionInsts(IRModuleSectionKind::GlobalVars); }
+    IRInstListBase getGlobalParams() const { return getSectionInsts(IRModuleSectionKind::GlobalParams); }
+    IRInstListBase getWitnessTables() const { return getSectionInsts(IRModuleSectionKind::WitnessTables); }
+    IRInstListBase getAnnotations() const { return getSectionInsts(IRModuleSectionKind::Annotations); }
+    IRInstListBase getKeys() const { return getSectionInsts(IRModuleSectionKind::Keys); }
 
     Name* getName() const { return m_name; }
     void setName(Name* name) { m_name = name; }
@@ -2164,8 +2279,8 @@ public:
     // It represents the version of module regarding semantics and doesn't have
     // anything to do with serialization format
     //
-    const static UInt k_minSupportedModuleVersion = 4;
-    const static UInt k_maxSupportedModuleVersion = 14;
+    const static UInt k_minSupportedModuleVersion = 15;
+    const static UInt k_maxSupportedModuleVersion = 15;
     static_assert(k_minSupportedModuleVersion <= k_maxSupportedModuleVersion);
 
 private:
@@ -2191,6 +2306,9 @@ private:
     /// `IRModuleInst` for the module the instruction belongs to, if any.
     ///
     FIDDLE() IRModuleInst* m_moduleInst = nullptr;
+
+    /// Sections indexed by IRModuleSectionKind.
+    IRModuleSection* m_sections[(int)IRModuleSectionKind::Count] = {};
 
     // The name of the module.
     FIDDLE() Name* m_name = nullptr;

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9722,10 +9722,10 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
     void ensureInsertAtGlobalScope(IRBuilder* builder)
     {
         auto inst = builder->getInsertLoc().getInst();
-        if (inst->getOp() == kIROp_ModuleInst)
+        if (isModuleScopeParent(inst))
             return;
 
-        while (inst && inst->getParent() && inst->getParent()->getOp() != kIROp_ModuleInst)
+        while (inst && inst->getParent() && !isModuleScopeParent(inst->getParent()))
         {
             inst = inst->getParent();
         }
@@ -12204,7 +12204,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                         //
                         // If it's in the global scope, we're good if we use the same type.
                         //
-                        if (!as<IRModuleInst>(param.originalParam->getFullType()->getParent()))
+                        if (!isAtModuleScope(param.originalParam->getFullType()))
                             param.clonedParam->setFullType((IRType*)cloneInst(
                                 &cloneEnv,
                                 &typeBuilder,

--- a/source/slang/slang-serialize-ir.cpp
+++ b/source/slang/slang-serialize-ir.cpp
@@ -705,6 +705,9 @@ void IRSerialReadContext::handleIRModule(IRReadSerializer const& serializer, IRM
     serialize(serializer, value->m_name);
     serialize(serializer, value->m_version);
     value->m_moduleInst = deserializeFromFlatModule(serializer, value);
+
+    // Rebuild the section table from the deserialized module children.
+    value->_rebuildSectionTable();
 }
 
 //


### PR DESCRIPTION
This is just an experiment to see if splitting the module into sections to organize instructions is helpful for performance. 

The idea came about when we realized we had about ~100 passes that scanned the global scope looking for something specific (e.g. funcs/witness-tables/struct-types/etc..), and 1000s of unrelated instructions like annotations, capability conjunctions and literals.

Preliminary results, unfortunately, are negative. On some selected files in the slang test suite, the improvement is 5% or less. This seems to indicate that the time spent scanning the global scope is relatively small.

I've opened the draft so we can test with larger codebases to see if there's any impact (or if we're missing some additional changes that could help unlock performance)