### PR TITLE
Fix GPU retry dispatch permission in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
       - name: Check for GPU health check failures and dispatch retry
         env:
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.SLANGBOT_PAT }}
         run: |
           gpu_failures=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" \
             --jq '[.jobs[]


### PR DESCRIPTION
## Summary
- The `retry-on-gpu-failure` job correctly detects GPU crashes but the `gh workflow run ci-retry.yml` dispatch fails with HTTP 403 in merge queue context because `github.token` lacks `workflow_dispatch` permission
- Replace `github.token` with `secrets.SLANGBOT_PAT` which has the required scope
- Observed in https://github.com/shader-slang/slang/actions/runs/24189791673/job/70616286497

## Test plan
- [ ] Verify next merge queue GPU failure triggers retry successfully