### PR TITLE
Fix _getLaneId() for multi-dimensional CUDA thread blocks

### DIFF
--- a/docs/cuda-target.md
+++ b/docs/cuda-target.md
@@ -292,9 +292,15 @@ Will require 3 times as many steps as the earlier scalar example just using a si
 
 ## WaveGetLaneIndex
 
-'WaveGetLaneIndex' defaults to `(threadIdx.x & SLANG_CUDA_WARP_MASK)`. Depending on how the kernel is launched this could be incorrect. There are other ways to get lane index, for example using inline assembly. This mechanism though is apparently slower than the simple method used here. There is support for using the asm mechanism in the CUDA prelude using the `SLANG_USE_ASM_LANE_ID` preprocessor define to enable the feature.
+`WaveGetLaneIndex` computes the lane index by linearizing the thread index across all dimensions and masking to the warp size:
 
-There is potential to calculate the lane id using the [numthreads] markup in Slang/HLSL, but that also requires some assumptions of how that maps to a lane index.
+```
+((threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x) & SLANG_CUDA_WARP_MASK
+```
+
+This handles multi-dimensional thread blocks correctly as long as the linearized thread index maps to consecutive warp lanes, which is the standard CUDA thread-to-lane mapping.
+
+Alternatively, defining `SLANG_USE_ASM_LANE_ID` before including the CUDA prelude switches to an inline PTX assembly implementation (`mov.u32 %0, %laneid`). The assembly version is always correct regardless of launch configuration, but is slower than the arithmetic default.
 
 ## Unsupported Intrinsics
 

--- a/prelude/slang-cuda-prelude.h
+++ b/prelude/slang-cuda-prelude.h
@@ -3014,9 +3014,8 @@ struct RWByteAddressBuffer
 #ifndef SLANG_USE_ASM_LANE_ID
 __forceinline__ __device__ uint32_t _getLaneId()
 {
-    // If the launch is (or I guess some multiple of the warp size)
-    // we try this mechanism, which is apparently faster.
-    return threadIdx.x & SLANG_CUDA_WARP_MASK;
+    return ((threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x) &
+           SLANG_CUDA_WARP_MASK;
 }
 #else
 __forceinline__ __device__ uint32_t _getLaneId()

--- a/tests/cuda/wave-lane-index-multidim-3d.slang
+++ b/tests/cuda/wave-lane-index-multidim-3d.slang
@@ -1,0 +1,88 @@
+// Test that WaveGetLaneIndex() returns correct values for 3D thread blocks (z > 1).
+// With numthreads(4,4,2), the 32 threads form exactly 1 warp.
+// The linearized index is threadIdx.z * (4*4) + threadIdx.y * 4 + threadIdx.x,
+// so the lane index should equal the SV_GroupIndex directly.
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
+
+uniform RWStructuredBuffer<float> outputBuffer;
+
+[shader("compute")]
+[numthreads(4,4,2)]
+void computeMain(uint lane : SV_GroupIndex)
+{
+    uint i = lane * 2;
+    outputBuffer[i + 0] = WaveIsFirstLane() ? 1.0 : 0.0;
+    outputBuffer[i + 1] = float(WaveGetLaneIndex());
+}
+
+// 32 threads in one warp. WaveIsFirstLane()=true only for lane 0.
+// WaveGetLaneIndex() should be 0..31.
+
+// CHECK: 1.0
+// CHECK: 0.0
+// CHECK: 0.0
+// CHECK: 1.0
+// CHECK: 0.0
+// CHECK: 2.0
+// CHECK: 0.0
+// CHECK: 3.0
+// CHECK: 0.0
+// CHECK: 4.0
+// CHECK: 0.0
+// CHECK: 5.0
+// CHECK: 0.0
+// CHECK: 6.0
+// CHECK: 0.0
+// CHECK: 7.0
+// CHECK: 0.0
+// CHECK: 8.0
+// CHECK: 0.0
+// CHECK: 9.0
+// CHECK: 0.0
+// CHECK: 10.0
+// CHECK: 0.0
+// CHECK: 11.0
+// CHECK: 0.0
+// CHECK: 12.0
+// CHECK: 0.0
+// CHECK: 13.0
+// CHECK: 0.0
+// CHECK: 14.0
+// CHECK: 0.0
+// CHECK: 15.0
+// CHECK: 0.0
+// CHECK: 16.0
+// CHECK: 0.0
+// CHECK: 17.0
+// CHECK: 0.0
+// CHECK: 18.0
+// CHECK: 0.0
+// CHECK: 19.0
+// CHECK: 0.0
+// CHECK: 20.0
+// CHECK: 0.0
+// CHECK: 21.0
+// CHECK: 0.0
+// CHECK: 22.0
+// CHECK: 0.0
+// CHECK: 23.0
+// CHECK: 0.0
+// CHECK: 24.0
+// CHECK: 0.0
+// CHECK: 25.0
+// CHECK: 0.0
+// CHECK: 26.0
+// CHECK: 0.0
+// CHECK: 27.0
+// CHECK: 0.0
+// CHECK: 28.0
+// CHECK: 0.0
+// CHECK: 29.0
+// CHECK: 0.0
+// CHECK: 30.0
+// CHECK: 0.0
+// CHECK: 31.0

--- a/tests/cuda/wave-lane-index-multidim.slang
+++ b/tests/cuda/wave-lane-index-multidim.slang
@@ -1,0 +1,156 @@
+// Test that WaveGetLaneIndex() returns correct values for multi-dimensional thread blocks.
+// With numthreads(8,8,1), the 64 threads form 2 warps of 32.
+// Previously _getLaneId() used `threadIdx.x & 31` which only returned 0-7,
+// ignoring threadIdx.y. The fix uses the linearized thread index.
+
+// TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
+// TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
+
+uniform RWStructuredBuffer<float> outputBuffer;
+
+[shader("compute")]
+[numthreads(8,8,1)]
+void computeMain(uint lane : SV_GroupIndex)
+{
+    uint i = lane * 2;
+    outputBuffer[i + 0] = WaveIsFirstLane() ? 1.0 : 0.0;
+    outputBuffer[i + 1] = float(WaveGetLaneIndex());
+}
+
+// With 64 threads and CUDA warp size 32, we get 2 warps.
+// Warp 0 (lanes 0-31): WaveIsFirstLane()=true only for lane 0
+// Warp 1 (lanes 32-63): WaveIsFirstLane()=true only for lane 32
+
+// Warp 0
+// CHECK: 1.0
+// CHECK: 0.0
+// CHECK: 0.0
+// CHECK: 1.0
+// CHECK: 0.0
+// CHECK: 2.0
+// CHECK: 0.0
+// CHECK: 3.0
+// CHECK: 0.0
+// CHECK: 4.0
+// CHECK: 0.0
+// CHECK: 5.0
+// CHECK: 0.0
+// CHECK: 6.0
+// CHECK: 0.0
+// CHECK: 7.0
+// CHECK: 0.0
+// CHECK: 8.0
+// CHECK: 0.0
+// CHECK: 9.0
+// CHECK: 0.0
+// CHECK: 10.0
+// CHECK: 0.0
+// CHECK: 11.0
+// CHECK: 0.0
+// CHECK: 12.0
+// CHECK: 0.0
+// CHECK: 13.0
+// CHECK: 0.0
+// CHECK: 14.0
+// CHECK: 0.0
+// CHECK: 15.0
+// CHECK: 0.0
+// CHECK: 16.0
+// CHECK: 0.0
+// CHECK: 17.0
+// CHECK: 0.0
+// CHECK: 18.0
+// CHECK: 0.0
+// CHECK: 19.0
+// CHECK: 0.0
+// CHECK: 20.0
+// CHECK: 0.0
+// CHECK: 21.0
+// CHECK: 0.0
+// CHECK: 22.0
+// CHECK: 0.0
+// CHECK: 23.0
+// CHECK: 0.0
+// CHECK: 24.0
+// CHECK: 0.0
+// CHECK: 25.0
+// CHECK: 0.0
+// CHECK: 26.0
+// CHECK: 0.0
+// CHECK: 27.0
+// CHECK: 0.0
+// CHECK: 28.0
+// CHECK: 0.0
+// CHECK: 29.0
+// CHECK: 0.0
+// CHECK: 30.0
+// CHECK: 0.0
+// CHECK: 31.0
+
+// Warp 1
+// CHECK: 1.0
+// CHECK: 0.0
+// CHECK: 0.0
+// CHECK: 1.0
+// CHECK: 0.0
+// CHECK: 2.0
+// CHECK: 0.0
+// CHECK: 3.0
+// CHECK: 0.0
+// CHECK: 4.0
+// CHECK: 0.0
+// CHECK: 5.0
+// CHECK: 0.0
+// CHECK: 6.0
+// CHECK: 0.0
+// CHECK: 7.0
+// CHECK: 0.0
+// CHECK: 8.0
+// CHECK: 0.0
+// CHECK: 9.0
+// CHECK: 0.0
+// CHECK: 10.0
+// CHECK: 0.0
+// CHECK: 11.0
+// CHECK: 0.0
+// CHECK: 12.0
+// CHECK: 0.0
+// CHECK: 13.0
+// CHECK: 0.0
+// CHECK: 14.0
+// CHECK: 0.0
+// CHECK: 15.0
+// CHECK: 0.0
+// CHECK: 16.0
+// CHECK: 0.0
+// CHECK: 17.0
+// CHECK: 0.0
+// CHECK: 18.0
+// CHECK: 0.0
+// CHECK: 19.0
+// CHECK: 0.0
+// CHECK: 20.0
+// CHECK: 0.0
+// CHECK: 21.0
+// CHECK: 0.0
+// CHECK: 22.0
+// CHECK: 0.0
+// CHECK: 23.0
+// CHECK: 0.0
+// CHECK: 24.0
+// CHECK: 0.0
+// CHECK: 25.0
+// CHECK: 0.0
+// CHECK: 26.0
+// CHECK: 0.0
+// CHECK: 27.0
+// CHECK: 0.0
+// CHECK: 28.0
+// CHECK: 0.0
+// CHECK: 29.0
+// CHECK: 0.0
+// CHECK: 30.0
+// CHECK: 0.0
+// CHECK: 31.0


### PR DESCRIPTION
Close https://github.com/shader-slang/slangpy/issues/892

The previous implementation used `threadIdx.x & SLANG_CUDA_WARP_MASK` which only works for 1D launches where blockDim.x >= warpSize. For multi-dimensional blocks like numthreads(8,8,1), threadIdx.x only ranges 0-7, causing WaveGetLaneIndex() to return incorrect values.

Use the linearized thread index instead so the lane ID is correct regardless of thread block dimensions.

Made-with: Cursor