### PR TITLE
SharedLibrary::loadWithPlatformPath: Use RTLD_LOCAL in dlopen()

### DIFF
--- a/source/core/slang-platform.cpp
+++ b/source/core/slang-platform.cpp
@@ -246,7 +246,7 @@ SLANG_COMPILE_TIME_ASSERT(E_OUTOFMEMORY == SLANG_E_OUT_OF_MEMORY);
     }
     if (strlen(platformFileName) == 0)
         platformFileName = nullptr;
-    const auto mode = RTLD_NOW | RTLD_GLOBAL | (isUnclosable ? RTLD_NODELETE : 0);
+    const auto mode = RTLD_NOW | RTLD_LOCAL | (isUnclosable ? RTLD_NODELETE : 0);
     void* h = dlopen(platformFileName, mode);
     if (!h)
     {


### PR DESCRIPTION
Load the shared libraries with RTLD_LOCAL flag (default) instead of the RTLD_GLOBAL flag.

When the same library is opened multiple times in RTLD_GLOBAL mode, the symbols and memory is shared between all instances. This causes issues with static initializers and deinitializers, which are executed on library load/unload. Specifically, the shared symbols will be initialized and deinitialized multiple times. Switching to the default RTLD_LOCAL mode sidesteps this issues, since different library instances have their own sets of internal symbols.

Fixes #10785