### PR TITLE
Fix CI analytics date range filtering

### DIFF
--- a/extras/ci/analytics/ci_visualization.py
+++ b/extras/ci/analytics/ci_visualization.py
@@ -973,6 +973,20 @@ def generate_statistics(data, config, output_dir):
             "fill": True,
             "tension": 0.1,
         })
+    parallel_datasets_js = ",".join(
+        (
+            "{"
+            f"label:{json.dumps(ds['label'])}, "
+            f"data:sliceData({json.dumps(ds['data'])},30), "
+            f"_allData:{json.dumps(ds['data'])}, "
+            f"borderColor:{json.dumps(ds['borderColor'])}, "
+            f"backgroundColor:{json.dumps(ds['backgroundColor'])}, "
+            f"fill:{json.dumps(ds['fill'])}, "
+            f"tension:{json.dumps(ds['tension'])}"
+            "}"
+        )
+        for ds in parallel_datasets
+    )
 
     # Build and test wait times per day
     build_wait_by_date = data.get("build_wait_by_date", {})
@@ -1143,6 +1157,10 @@ const allMqFailure = {json.dumps(mq_failure_per_day)};
 const allMqCancelled = {json.dumps(mq_cancelled_per_day)};
 const allMqFailRate = {json.dumps(mq_fail_rate_per_day)};
 const allMqTat = {json.dumps(mq_avg_tat_per_day)};
+const allQueueWaitAvg = {json.dumps(cap_avg_queue)};
+const allQueueWaitP50 = {json.dumps(cap_p50_queue)};
+const allQueueWaitP90 = {json.dumps(cap_p90_queue)};
+const allQueueWaitP95 = {json.dumps(cap_p95_queue)};
 const hasMqData = {json.dumps(has_mq_data)};
 
 let charts = [];
@@ -1300,25 +1318,25 @@ new Chart(document.getElementById('byGroup_canvas').getContext('2d'), {{
 }});
 
 // Parallelization rate
-new Chart(document.getElementById('parallelRate_canvas').getContext('2d'), {{
-  type: 'line',
+makeChart('parallelRate_canvas', 'line', {{
   data: {{
-    labels: {json.dumps(dates)},
-    datasets: {json.dumps(parallel_datasets)}
+    labels: sliceData(allLabels, 30),
+    datasets: [
+      {parallel_datasets_js}
+    ]
   }},
   options: {{responsive:true, scales:{{y:{{stacked:true,min:0,title:{{display:true,text:'Avg Concurrent Runners'}}}}}}}}
 }});
 
 // Queue wait time percentiles
-new Chart(document.getElementById('queueWait_canvas').getContext('2d'), {{
-  type: 'line',
+makeChart('queueWait_canvas', 'line', {{
   data: {{
-    labels: {json.dumps(dates)},
+    labels: sliceData(allLabels, 30),
     datasets: [
-      {{label:'Avg', data:{json.dumps(cap_avg_queue)}, borderColor:'#0d6efd', fill:false, tension:0.1}},
-      {{label:'p50', data:{json.dumps(cap_p50_queue)}, borderColor:'#28a745', borderDash:[5,5], fill:false, tension:0.1}},
-      {{label:'p90', data:{json.dumps(cap_p90_queue)}, borderColor:'#ffc107', borderDash:[5,5], fill:false, tension:0.1}},
-      {{label:'p95', data:{json.dumps(cap_p95_queue)}, borderColor:'#dc3545', borderDash:[5,5], fill:false, tension:0.1}},
+      {{label:'Avg', data:sliceData(allQueueWaitAvg,30), _allData:allQueueWaitAvg, borderColor:'#0d6efd', fill:false, tension:0.1}},
+      {{label:'p50', data:sliceData(allQueueWaitP50,30), _allData:allQueueWaitP50, borderColor:'#28a745', borderDash:[5,5], fill:false, tension:0.1}},
+      {{label:'p90', data:sliceData(allQueueWaitP90,30), _allData:allQueueWaitP90, borderColor:'#ffc107', borderDash:[5,5], fill:false, tension:0.1}},
+      {{label:'p95', data:sliceData(allQueueWaitP95,30), _allData:allQueueWaitP95, borderColor:'#dc3545', borderDash:[5,5], fill:false, tension:0.1}},
     ]
   }},
   options: {{responsive:true, scales:{{y:{{title:{{display:true,text:'Minutes'}}}}}}}}

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -270,6 +270,56 @@ class TestStatisticsRunnerNamePrefixes(unittest.TestCase):
 
         self.assertIn("Windows Build (GCP)", html)
 
+    def test_statistics_range_filter_wires_parallel_and_queue_percentile_charts(self):
+        """Range selector must update Average Concurrent Runners and queue percentiles."""
+        config = {
+            "label_groups": [],
+            "runner_name_prefixes": [
+                {"prefix": "linux-runner-", "name": "Linux GPU (GCP)", "self_hosted": True},
+            ],
+            "non_production_periods": {"runners": {}},
+        }
+
+        base = datetime.now(timezone.utc).replace(hour=12, minute=0, second=0, microsecond=0)
+        jobs = []
+        for offset in (3, 2):
+            created = (base - ci_health.timedelta(days=offset)).strftime("%Y-%m-%dT%H:%M:%SZ")
+            completed = (
+                base - ci_health.timedelta(days=offset) + ci_health.timedelta(minutes=30)
+            ).strftime("%Y-%m-%dT%H:%M:%SZ")
+            jobs.append(
+                {
+                    "name": "build-linux-debug",
+                    "workflow_name": "CI",
+                    "run_id": offset,
+                    "run_created_at": created,
+                    "created_at": created,
+                    "started_at": created,
+                    "completed_at": completed,
+                    "conclusion": "success",
+                    "event": "push",
+                    "head_branch": "main",
+                    "labels": [],
+                    "runner_name": "linux-runner-1",
+                    "duration_seconds": 1800,
+                    "queued_seconds": offset * 60,
+                    "html_url": "",
+                }
+            )
+
+        data = ci_visualization.process_jobs(jobs, config)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            ci_visualization.generate_statistics(data, config, tmp)
+            with open(os.path.join(tmp, "statistics.html"), encoding="utf-8") as f:
+                html = f.read()
+
+        self.assertIn("makeChart('parallelRate_canvas', 'line'", html)
+        self.assertIn("_allData", html)
+        self.assertIn("const allQueueWaitAvg =", html)
+        self.assertIn("const allQueueWaitP95 =", html)
+        self.assertIn("makeChart('queueWait_canvas', 'line'", html)
+
 
 class TestPRsMergedChart(unittest.TestCase):
     def test_statistics_includes_prs_merged_chart_when_data_present(self):


### PR DESCRIPTION
## Summary
- make Average Concurrent Runners follow the selected statistics date range
- make Queue Wait Time Percentiles follow the selected statistics date range
- add regression coverage for the range-aware chart wiring

## Testing
- python3 -m unittest extras.ci.analytics.tests.test_ci_analytics