### PR TITLE
Enable regression test for Tuple<IFoo, int> dispatch return (#10172)

### DIFF
--- a/tests/language-feature/dynamic-dispatch/return-interface-from-dispatch.slang
+++ b/tests/language-feature/dynamic-dispatch/return-interface-from-dispatch.slang
@@ -1,0 +1,119 @@
+// Dynamically dispatched methods returning interface-typed values.
+// Wrapper functions must correctly handle packing for:
+// 1. Direct interface return values (tag + AnyValue)
+// 2. Out parameters writing back complete existential representations
+// 3. Inout parameters preserving the ability to change concrete type
+//
+// For composite return containing interfaces (Tuple<IFoo, int>), see
+// return-interface-tuple-limitation.slang (fixed in #10172).
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cpu -compute -shaderobj -output-using-type
+//DIAGNOSTIC_TEST:SIMPLE(diag=REPORT,non-exhaustive):-target hlsl -stage compute -entry computeMain -report-dynamic-dispatch-sites -conformance "FactoryA:IFactory=0" -conformance "FactoryB:IFactory=1" -conformance "FooA:IFoo=0" -conformance "FooB:IFoo=1"
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+//TEST_INPUT: type_conformance FactoryA:IFactory = 0
+//TEST_INPUT: type_conformance FactoryB:IFactory = 1
+//TEST_INPUT: type_conformance FooA:IFoo = 0
+//TEST_INPUT: type_conformance FooB:IFoo = 1
+
+interface IFoo
+{
+    float eval();
+}
+
+interface IFactory
+{
+    IFoo create();
+    void createOut(out IFoo result);
+    void modify(inout IFoo item);
+}
+
+struct FooA : IFoo
+{
+    float val;
+    float eval() { return val; }
+}
+
+struct FooB : IFoo
+{
+    float val;
+    float eval() { return val * 2.0; }
+}
+
+struct FactoryA : IFactory
+{
+    float dummy;
+    IFoo create() { return FooA(3.0); }
+    void createOut(out IFoo result) { result = FooA(7.0); }
+    void modify(inout IFoo item) { item = FooB(11.0); }
+}
+
+struct FactoryB : IFactory
+{
+    float dummy;
+    IFoo create() { return FooB(4.0); }
+    void createOut(out IFoo result) { result = FooB(8.0); }
+    void modify(inout IFoo item) { item = FooA(13.0); }
+}
+
+IFactory createFactory(uint id)
+{
+    return createDynamicObject<IFactory>(id, 0.0);
+}
+
+float testCreate(int id)
+{
+    IFactory factory = createFactory(uint(id));
+    IFoo foo = factory.create();
+    return foo.eval();
+//REPORT: generated dynamic dispatch code for this site. 2 possible types
+}
+
+float testCreateOut(int id)
+{
+    IFactory factory = createFactory(uint(id));
+    IFoo result;
+    factory.createOut(result);
+    return result.eval();
+}
+
+float testModify(int id)
+{
+    IFactory factory = createFactory(uint(id));
+    IFoo item = FooA(100.0);
+    factory.modify(item);
+    return item.eval();
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(int id : SV_DispatchThreadID)
+{
+    // Pattern 1: Direct interface return
+    // FactoryA.create() -> FooA(3.0).eval() = 3.0
+    outputBuffer[0] = testCreate(id);
+    // CHECK: 3.0
+    // FactoryB.create() -> FooB(4.0).eval() = 4.0 * 2.0 = 8.0
+    outputBuffer[1] = testCreate(id + 1);
+    // CHECK: 8.0
+
+    // Pattern 2: Out parameter
+    // FactoryA.createOut -> FooA(7.0).eval() = 7.0
+    outputBuffer[2] = testCreateOut(id);
+    // CHECK: 7.0
+    // FactoryB.createOut -> FooB(8.0).eval() = 8.0 * 2.0 = 16.0
+    outputBuffer[3] = testCreateOut(id + 1);
+    // CHECK: 16.0
+
+    // Pattern 3: Inout parameter (concrete type changes)
+    // FactoryA.modify(FooA(100)) -> replaces with FooB(11.0) -> 11.0 * 2.0 = 22.0
+    outputBuffer[4] = testModify(id);
+    // CHECK: 22.0
+    // FactoryB.modify(FooA(100)) -> replaces with FooA(13.0) -> 13.0
+    outputBuffer[5] = testModify(id + 1);
+    // CHECK: 13.0
+}

--- a/tests/language-feature/dynamic-dispatch/return-interface-tuple-limitation.slang
+++ b/tests/language-feature/dynamic-dispatch/return-interface-tuple-limitation.slang
@@ -1,0 +1,87 @@
+// Returning a Tuple<IFoo, int> from a dynamically dispatched interface method.
+// Previously crashed the compiler during tuple lowering (assert failure:
+// loweredTupleInfo in slang-ir-lower-tuple-types.cpp). Fixed by improvements
+// to dispatch wrapper code generation. (#10172)
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cpu -compute -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+//TEST_INPUT: type_conformance FactoryA:IFactory = 0
+//TEST_INPUT: type_conformance FactoryB:IFactory = 1
+//TEST_INPUT: type_conformance FooA:IFoo = 0
+//TEST_INPUT: type_conformance FooB:IFoo = 1
+
+interface IFoo
+{
+    float eval();
+}
+
+interface IFactory
+{
+    Tuple<IFoo, int> createWithMeta();
+}
+
+struct FooA : IFoo
+{
+    float val;
+    float eval() { return val; }
+}
+
+struct FooB : IFoo
+{
+    float val;
+    float eval() { return val * 2.0; }
+}
+
+struct FactoryA : IFactory
+{
+    float dummy;
+
+    Tuple<IFoo, int> createWithMeta()
+    {
+        Tuple<IFoo, int> result = { FooB(5.0), 42 };
+        return result;
+    }
+}
+
+struct FactoryB : IFactory
+{
+    float dummy;
+
+    Tuple<IFoo, int> createWithMeta()
+    {
+        Tuple<IFoo, int> result = { FooA(6.0), 99 };
+        return result;
+    }
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(int id : SV_DispatchThreadID)
+{
+    // FactoryA.createWithMeta() -> (FooB(5.0), 42)
+    // FooB(5.0).eval() = 5.0 * 2.0 = 10.0, plus 42 = 52.0
+    IFactory factoryA = createDynamicObject<IFactory>(uint(0), 0.0);
+    Tuple<IFoo, int> pairA = factoryA.createWithMeta();
+    outputBuffer[0] = pairA._0.eval() + float(pairA._1);
+    // CHECK: 52.0
+
+    // FactoryB.createWithMeta() -> (FooA(6.0), 99)
+    // FooA(6.0).eval() = 6.0, plus 99 = 105.0
+    IFactory factoryB = createDynamicObject<IFactory>(uint(1), 0.0);
+    Tuple<IFoo, int> pairB = factoryB.createWithMeta();
+    outputBuffer[1] = pairB._0.eval() + float(pairB._1);
+    // CHECK: 105.0
+
+    // Test extracting just the interface element
+    outputBuffer[2] = pairA._0.eval();
+    // CHECK: 10.0
+
+    // Test extracting just the int element
+    outputBuffer[3] = float(pairB._1);
+    // CHECK: 99.0
+}


### PR DESCRIPTION
Fixes #10172

## Summary
- Convert the disabled `return-interface-tuple-limitation.slang` test into an active compute regression test
- The original crash (`SLANG_ASSERT(loweredTupleInfo)` in tuple lowering) no longer reproduces on current master
- Test validates correct runtime values when `Tuple<IFoo, int>` is returned from a dynamically dispatched interface method
- Covers `-slang`, `-vk`, `-cuda`, and `-cpu` backends with 4 output checks (52.0, 105.0, 10.0, 99.0)
- Updates cross-reference comment in `return-interface-from-dispatch.slang`

## Test Plan
- CPU compute test: PASSED locally
- LLVM/Slang synthetic test: PASSED
- slangc HLSL compilation: clean (no crash)

**Note:** Fork base is behind upstream master. If merge conflicts appear on the test files, the content in this PR is the intended final version (active compute test replacing the disabled diagnostic test).