### PR TITLE
Avoid invalidating caches for synthesized function extensions

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -15380,14 +15380,7 @@ void SharedSemanticsContext::registerCandidateExtension(Decl* typeDecl, Extensio
     _getCandidateExtensionList(typeDecl, m_mapDeclToCandidateExtensions).add(extDecl);
 
     // Remove the cached inheritanceInfo about typeDecl, if `extDecl` inherits new types.
-    bool invalidateSubtypes = false;
-    if (as<InterfaceDecl>(typeDecl))
-    {
-        // If we are extending an interface, we are effectively extending all types
-        // that inherits the interface. So we need to remove all inheritance info
-        // that is related to the interface.
-        invalidateSubtypes = true;
-    }
+    bool invalidateSubtypes = as<InterfaceDecl>(typeDecl) != nullptr;
     bool hasInheritanceMember = false;
     bool hasImplicitCastMember = false;
     for (auto member : extDecl->getDirectMemberDecls())
@@ -15402,6 +15395,53 @@ void SharedSemanticsContext::registerCandidateExtension(Decl* typeDecl, Extensio
                 hasImplicitCastMember = true;
         }
     }
+
+    if (as<FunctionDeclBase>(typeDecl))
+    {
+        // Auto-diff synthesizes many function extensions. Fully invalidating the
+        // shared caches on every synthesized function extension causes a large
+        // amount of repeated semantic work, but we still need to drop any
+        // entries cached directly for the extended function type.
+        ShortList<DeclRef<Decl>, 16> keysToRemove;
+        for (auto& kv : m_mapDeclRefToInheritanceInfo)
+        {
+            if (kv.first.getDecl() == typeDecl)
+            {
+                keysToRemove.add(kv.first);
+            }
+        }
+        for (auto& key : keysToRemove)
+        {
+            m_mapDeclRefToInheritanceInfo.remove(key);
+        }
+
+        if (hasInheritanceMember)
+        {
+            auto isTypeForFunctionDecl = [typeDecl](Type* type)
+            {
+                if (auto declRefType = as<DeclRefType>(type))
+                    return declRefType->getDeclRef().getDecl() == typeDecl;
+                return false;
+            };
+
+            ShortList<TypePair, 16> typePairsToRemove;
+            for (auto& kv : m_mapTypePairToSubtypeWitness)
+            {
+                if (isTypeForFunctionDecl(kv.first.type0) ||
+                    isTypeForFunctionDecl(kv.first.type1))
+                {
+                    typePairsToRemove.add(kv.first);
+                }
+            }
+            for (auto& key : typePairsToRemove)
+            {
+                m_mapTypePairToSubtypeWitness.remove(key);
+            }
+        }
+
+        return;
+    }
+
     auto isTypeUpToDate = [this](Type* type)
     {
         if (auto declRefType = as<DeclRefType>(type))

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -15379,138 +15379,30 @@ void SharedSemanticsContext::registerCandidateExtension(Decl* typeDecl, Extensio
     //
     _getCandidateExtensionList(typeDecl, m_mapDeclToCandidateExtensions).add(extDecl);
 
-    // Remove the cached inheritanceInfo about typeDecl, if `extDecl` inherits new types.
-    bool invalidateSubtypes = as<InterfaceDecl>(typeDecl) != nullptr;
-    bool hasInheritanceMember = false;
     bool hasImplicitCastMember = false;
     for (auto member : extDecl->getDirectMemberDecls())
     {
-        if (as<InheritanceDecl>(member))
-        {
-            hasInheritanceMember = true;
-        }
-        else if (auto ctorDecl = as<ConstructorDecl>(member))
+        if (auto ctorDecl = as<ConstructorDecl>(member))
         {
             if (ctorDecl->hasModifier<ImplicitConversionModifier>())
                 hasImplicitCastMember = true;
         }
     }
 
-    if (as<FunctionDeclBase>(typeDecl))
-    {
-        // Auto-diff synthesizes many function extensions. Fully invalidating the
-        // shared caches on every synthesized function extension causes a large
-        // amount of repeated semantic work, but we still need to drop any
-        // entries cached directly for the extended function type.
-        ShortList<DeclRef<Decl>, 16> keysToRemove;
-        for (auto& kv : m_mapDeclRefToInheritanceInfo)
-        {
-            if (kv.first.getDecl() == typeDecl)
-            {
-                keysToRemove.add(kv.first);
-            }
-        }
-        for (auto& key : keysToRemove)
-        {
-            m_mapDeclRefToInheritanceInfo.remove(key);
-        }
-
-        if (hasInheritanceMember)
-        {
-            auto isTypeForFunctionDecl = [typeDecl](Type* type)
-            {
-                if (auto declRefType = as<DeclRefType>(type))
-                    return declRefType->getDeclRef().getDecl() == typeDecl;
-                return false;
-            };
-
-            ShortList<TypePair, 16> typePairsToRemove;
-            for (auto& kv : m_mapTypePairToSubtypeWitness)
-            {
-                if (isTypeForFunctionDecl(kv.first.type0) ||
-                    isTypeForFunctionDecl(kv.first.type1))
-                {
-                    typePairsToRemove.add(kv.first);
-                }
-            }
-            for (auto& key : typePairsToRemove)
-            {
-                m_mapTypePairToSubtypeWitness.remove(key);
-            }
-        }
-
-        return;
-    }
-
-    auto isTypeUpToDate = [this](Type* type)
-    {
-        if (auto declRefType = as<DeclRefType>(type))
-        {
-            return m_mapDeclRefToInheritanceInfo.containsKey(declRefType->getDeclRef());
-        }
-        return m_mapTypeToInheritanceInfo.containsKey(type);
-    };
-    auto isInheritanceInfoAffected = [typeDecl](InheritanceInfo& info)
-    {
-        for (auto f : info.facets)
-            if (f.getImpl()->getDeclRef().getDecl() == typeDecl)
-            {
-                return true;
-            }
-        return false;
-    };
-    if (invalidateSubtypes)
-    {
-        decltype(m_mapTypeToInheritanceInfo) newMapTypeToInheritanceInfo;
-        for (auto& kv : m_mapTypeToInheritanceInfo)
-        {
-            if (!isInheritanceInfoAffected(kv.second))
-            {
-                newMapTypeToInheritanceInfo.add(kv.first, kv.second);
-            }
-        }
-        m_mapTypeToInheritanceInfo = _Move(newMapTypeToInheritanceInfo);
-    }
-
-    ShortList<DeclRef<Decl>, 16> keysToRemove;
-    for (auto& kv : m_mapDeclRefToInheritanceInfo)
-    {
-        // We can confirm the type is affected by the new extension,
-        // if the declref type points to typeDecl.
-        if (kv.first.getDecl() == typeDecl)
-        {
-            keysToRemove.add(kv.first);
-            continue;
-        }
-
-        // If we are extending interface types (and in the future any struct type
-        // if we decide to have full inheritance support),
-        // we also need to account for conformant that implements the interface.
-        if (invalidateSubtypes && isInheritanceInfoAffected(kv.second))
-        {
-            keysToRemove.add(kv.first);
-        }
-    }
-    for (auto& key : keysToRemove)
-    {
-        m_mapDeclRefToInheritanceInfo.remove(key);
-    }
-
-    if (hasInheritanceMember || invalidateSubtypes)
-    {
-        ShortList<TypePair, 16> typePairsToRemove;
-        for (auto& kv : m_mapTypePairToSubtypeWitness)
-        {
-            if (!isTypeUpToDate(kv.first.type0) || !isTypeUpToDate(kv.first.type1))
-            {
-                typePairsToRemove.add(kv.first);
-            }
-        }
-        for (auto& key : typePairsToRemove)
-        {
-            m_mapTypePairToSubtypeWitness.remove(key);
-        }
-    }
+    // A new extension can affect not only `typeDecl` itself, but also any cached
+    // type whose linearized facets reference `typeDecl` transitively. Historically
+    // we handled that by scanning the entire inheritance/subtype cache and removing
+    // every potentially-affected entry. That is correct, but it turns extension
+    // registration into a global cache invalidation point and makes synthesized
+    // function extensions especially expensive.
+    //
+    // Instead we bump a per-declaration extension epoch here. Each cached
+    // inheritance result snapshots the epochs of the declarations that contributed
+    // facets to it, and subtype cache entries snapshot the inheritance-cache
+    // generations of their endpoints. Old entries therefore get discarded lazily
+    // when they are queried again, without forcing us to iterate the giant global
+    // dictionaries up front.
+    bumpDeclExtensionEpoch(typeDecl);
 
     if (hasImplicitCastMember)
     {

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -628,6 +628,39 @@ struct InheritanceInfo
     FacetList facets;
 };
 
+/// Records the extension epoch observed for one declaration dependency.
+///
+/// Inheritance and subtype cache entries can depend on many declarations via
+/// transitive facets. We snapshot the epoch for each contributing declaration so
+/// we can validate lazily instead of eagerly scanning and invalidating large
+/// global cache dictionaries when a new extension is registered.
+struct DeclExtensionEpochStamp
+{
+    Decl* decl = nullptr;
+    UInt epoch = 0;
+};
+
+/// Cached inheritance info plus the declaration epochs it depends on.
+///
+/// The `generation` value changes whenever the entry is recomputed. Subtype
+/// cache entries record the generations they were built against so they can
+/// cheaply detect when either endpoint's inheritance info has changed.
+struct InheritanceInfoCacheEntry
+{
+    InheritanceInfo info;
+    List<DeclExtensionEpochStamp> dependencyEpochs;
+    UInt generation = 0;
+    bool isComputing = false;
+};
+
+/// Cached subtype query plus the inheritance cache generations it depended on.
+struct SubtypeWitnessCacheEntry
+{
+    SubtypeWitness* witness = nullptr;
+    UInt subTypeGeneration = 0;
+    UInt superTypeGeneration = 0;
+};
+
 /// Cached information about how to convert between two types.
 struct ImplicitCastMethod
 {
@@ -815,16 +848,8 @@ public:
         InheritanceCircularityInfo* circularityInfo);
 
     /// Try get subtype witness from cache, returns true if cache contains a result for the query.
-    bool tryGetSubtypeWitnessFromCache(Type* sub, Type* sup, SubtypeWitness*& outWitness)
-    {
-        auto pair = TypePair{sub, sup};
-        return m_mapTypePairToSubtypeWitness.tryGetValue(pair, outWitness);
-    }
-    void cacheSubtypeWitness(Type* sub, Type* sup, SubtypeWitness*& outWitness)
-    {
-        auto pair = TypePair{sub, sup};
-        m_mapTypePairToSubtypeWitness[pair] = outWitness;
-    }
+    bool tryGetSubtypeWitnessFromCache(Type* sub, Type* sup, SubtypeWitness*& outWitness);
+    void cacheSubtypeWitness(Type* sub, Type* sup, SubtypeWitness*& outWitness);
     ImplicitCastMethod* tryGetImplicitCastMethod(ImplicitCastMethodKey key)
     {
         return m_mapTypePairToImplicitCastMethod.tryGetValue(key);
@@ -882,6 +907,20 @@ private:
         DeclRef<Decl> declRef,
         Type* selfType,
         InheritanceCircularityInfo* circularityInfo);
+
+    UInt getDeclExtensionEpoch(Decl* decl) const;
+    void bumpDeclExtensionEpoch(Decl* decl);
+
+    bool _isInheritanceInfoCacheEntryUpToDate(InheritanceInfoCacheEntry const& entry) const;
+
+    void _collectInheritanceInfoDependencyEpochs(
+        Decl* subjectDecl,
+        InheritanceInfo const& info,
+        List<DeclExtensionEpochStamp>& outDependencyEpochs) const;
+
+    UInt _getInheritanceInfoCacheGeneration(
+        Type* type,
+        InheritanceCircularityInfo* circularityInfo = nullptr);
 
     void getDependentGenericParentImpl(DeclRef<GenericDecl>& genericParent, DeclRef<Decl> declRef);
 
@@ -985,11 +1024,13 @@ private:
         SubtypeWitness* selfIsSubtypeOfBase,
         SubtypeWitness* baseIsSubtypeOfFacet);
 
-    Dictionary<Type*, InheritanceInfo> m_mapTypeToInheritanceInfo;
-    Dictionary<DeclRef<Decl>, InheritanceInfo> m_mapDeclRefToInheritanceInfo;
-    Dictionary<TypePair, SubtypeWitness*> m_mapTypePairToSubtypeWitness;
+    Dictionary<Type*, InheritanceInfoCacheEntry> m_mapTypeToInheritanceInfo;
+    Dictionary<DeclRef<Decl>, InheritanceInfoCacheEntry> m_mapDeclRefToInheritanceInfo;
+    Dictionary<TypePair, SubtypeWitnessCacheEntry> m_mapTypePairToSubtypeWitness;
     Dictionary<ImplicitCastMethodKey, ImplicitCastMethod> m_mapTypePairToImplicitCastMethod;
     Dictionary<Type*, bool> m_isCStyleTypeCache;
+    Dictionary<Decl*, UInt> m_mapDeclToExtensionEpoch;
+    UInt m_nextInheritanceInfoCacheGeneration = 1;
 };
 
 /// Local/scoped state of the semantic-checking system

--- a/source/slang/slang-check-inheritance.cpp
+++ b/source/slang/slang-check-inheritance.cpp
@@ -8,6 +8,134 @@
 
 namespace Slang
 {
+UInt SharedSemanticsContext::getDeclExtensionEpoch(Decl* decl) const
+{
+    if (!decl)
+        return 0;
+
+    if (auto epoch = m_mapDeclToExtensionEpoch.tryGetValue(decl))
+        return *epoch;
+
+    return 0;
+}
+
+void SharedSemanticsContext::bumpDeclExtensionEpoch(Decl* decl)
+{
+    if (!decl)
+        return;
+
+    m_mapDeclToExtensionEpoch[decl] = getDeclExtensionEpoch(decl) + 1;
+}
+
+bool SharedSemanticsContext::_isInheritanceInfoCacheEntryUpToDate(
+    InheritanceInfoCacheEntry const& entry) const
+{
+    for (auto const& stamp : entry.dependencyEpochs)
+    {
+        if (getDeclExtensionEpoch(stamp.decl) != stamp.epoch)
+            return false;
+    }
+
+    return true;
+}
+
+void SharedSemanticsContext::_collectInheritanceInfoDependencyEpochs(
+    Decl* subjectDecl,
+    InheritanceInfo const& info,
+    List<DeclExtensionEpochStamp>& outDependencyEpochs) const
+{
+    outDependencyEpochs.clear();
+
+    auto addDependency = [&](Decl* decl)
+    {
+        if (!decl)
+            return;
+
+        for (auto const& stamp : outDependencyEpochs)
+        {
+            if (stamp.decl == decl)
+                return;
+        }
+
+        DeclExtensionEpochStamp stamp;
+        stamp.decl = decl;
+        stamp.epoch = getDeclExtensionEpoch(decl);
+        outDependencyEpochs.add(stamp);
+    };
+
+    // Always depend on the subject declaration itself. This ensures a cache entry
+    // for `T` gets revalidated when a new extension that directly targets `T` is
+    // registered, even if the previous inheritance info happened to be empty.
+    addDependency(subjectDecl);
+
+    for (auto facet : info.facets)
+    {
+        addDependency(facet->getDeclRef().getDecl());
+    }
+}
+
+UInt SharedSemanticsContext::_getInheritanceInfoCacheGeneration(
+    Type* type,
+    InheritanceCircularityInfo* circularityInfo)
+{
+    if (auto declRefType = as<DeclRefType>(type))
+    {
+        _getInheritanceInfo(declRefType->getDeclRef(), declRefType, circularityInfo);
+        if (auto entry = m_mapDeclRefToInheritanceInfo.tryGetValue(declRefType->getDeclRef()))
+            return entry->generation;
+        return 0;
+    }
+
+    getInheritanceInfo(type, circularityInfo);
+    if (auto entry = m_mapTypeToInheritanceInfo.tryGetValue(type))
+        return entry->generation;
+    return 0;
+}
+
+bool SharedSemanticsContext::tryGetSubtypeWitnessFromCache(
+    Type* sub,
+    Type* sup,
+    SubtypeWitness*& outWitness)
+{
+    auto pair = TypePair{sub, sup};
+    auto cachedEntry = m_mapTypePairToSubtypeWitness.tryGetValue(pair);
+    if (!cachedEntry)
+        return false;
+
+    auto entry = *cachedEntry;
+
+    UInt currentSubTypeGeneration = _getInheritanceInfoCacheGeneration(sub);
+    UInt currentSuperTypeGeneration = _getInheritanceInfoCacheGeneration(sup);
+    if (entry.subTypeGeneration != currentSubTypeGeneration ||
+        entry.superTypeGeneration != currentSuperTypeGeneration)
+    {
+        m_mapTypePairToSubtypeWitness.remove(pair);
+        return false;
+    }
+
+    outWitness = entry.witness;
+    return true;
+}
+
+void SharedSemanticsContext::cacheSubtypeWitness(Type* sub, Type* sup, SubtypeWitness*& outWitness)
+{
+    auto pair = TypePair{sub, sup};
+    UInt subTypeGeneration = _getInheritanceInfoCacheGeneration(sub);
+    UInt superTypeGeneration = _getInheritanceInfoCacheGeneration(sup);
+
+    // A zero generation means one of the endpoint inheritance entries is still
+    // being recomputed. In that state we don't want to pin a subtype answer to a
+    // stale or incomplete inheritance snapshot.
+    if (!subTypeGeneration || !superTypeGeneration)
+        return;
+
+    SubtypeWitnessCacheEntry entry;
+    entry.witness = outWitness;
+    entry.subTypeGeneration = subTypeGeneration;
+    entry.superTypeGeneration = superTypeGeneration;
+    m_mapTypePairToSubtypeWitness[pair] = entry;
+}
+
 InheritanceInfo SharedSemanticsContext::getInheritanceInfo(
     Type* type,
     InheritanceCircularityInfo* circularityInfo)
@@ -20,20 +148,35 @@ InheritanceInfo SharedSemanticsContext::getInheritanceInfo(
         return _getInheritanceInfo(declRefType->getDeclRef(), declRefType, circularityInfo);
 
     // Non ordinary types are cached on m_mapTypeToInheritanceInfo.
+    // Each entry also snapshots the extension epochs of the declarations that
+    // contributed facets to it, so we can validate lazily after new extensions
+    // are registered instead of eagerly purging the whole cache.
     if (auto found = m_mapTypeToInheritanceInfo.tryGetValue(type))
-        return *found;
+    {
+        if (found->isComputing)
+            return found->info;
 
-    // Note: we install a null pointer into the dictionary to act
-    // as a sentinel during the processing of calculating the inheritnace
-    // info. If we encounter this sentinel value during the calcuation,
-    // it means that there was some kind of circular dependency in the
-    // inheritance graph, and we need to avoid crashing or going
-    // into an infinite loop in such cases.
-    //
-    m_mapTypeToInheritanceInfo[type] = InheritanceInfo();
+        if (_isInheritanceInfoCacheEntryUpToDate(*found))
+            return found->info;
+    }
+
+    // Mark the entry as in-progress before recursing so we can break cycles
+    // during inheritance calculation without re-entering the same work.
+    {
+        auto& entry = m_mapTypeToInheritanceInfo[type];
+        entry.info = InheritanceInfo();
+        entry.dependencyEpochs.clear();
+        entry.generation = 0;
+        entry.isComputing = true;
+    }
 
     auto info = _calcInheritanceInfo(type, circularityInfo);
-    m_mapTypeToInheritanceInfo[type] = info;
+
+    auto& entry = m_mapTypeToInheritanceInfo[type];
+    entry.info = info;
+    _collectInheritanceInfoDependencyEpochs(nullptr, info, entry.dependencyEpochs);
+    entry.generation = m_nextInheritanceInfoCacheGeneration++;
+    entry.isComputing = false;
 
     return info;
 }
@@ -85,19 +228,31 @@ InheritanceInfo SharedSemanticsContext::_getInheritanceInfo(
     // possible.
 
     if (auto found = m_mapDeclRefToInheritanceInfo.tryGetValue(declRef))
-        return *found;
+    {
+        if (found->isComputing)
+            return found->info;
 
-    // Note: we install a null pointer into the dictionary to act
-    // as a sentinel during the processing of calculating the inheritnace
-    // info. If we encounter this sentinel value during the calcuation,
-    // it means that there was some kind of circular dependency in the
-    // inheritance graph, and we need to avoid crashing or going
-    // into an infinite loop in such cases.
-    //
-    m_mapDeclRefToInheritanceInfo[declRef] = InheritanceInfo();
+        if (_isInheritanceInfoCacheEntryUpToDate(*found))
+            return found->info;
+    }
+
+    // Mark the entry as in-progress before recursing so we can break cycles
+    // during inheritance calculation without re-entering the same work.
+    {
+        auto& entry = m_mapDeclRefToInheritanceInfo[declRef];
+        entry.info = InheritanceInfo();
+        entry.dependencyEpochs.clear();
+        entry.generation = 0;
+        entry.isComputing = true;
+    }
 
     auto info = _calcInheritanceInfo(declRef, selfType, circularityInfo);
-    m_mapDeclRefToInheritanceInfo[declRef] = info;
+
+    auto& entry = m_mapDeclRefToInheritanceInfo[declRef];
+    entry.info = info;
+    _collectInheritanceInfoDependencyEpochs(declRef.getDecl(), info, entry.dependencyEpochs);
+    entry.generation = m_nextInheritanceInfoCacheGeneration++;
+    entry.isComputing = false;
 
     getSession()->m_typeDictionarySize = Math::Max(
         getSession()->m_typeDictionarySize,


### PR DESCRIPTION
This brings compile time of `core` module to the same range before the autodiff overhaul.
The key is to make function extensions (that we will synthesis on the fly during type checking) not invalidate any type checking caches.

## Summary
- skip shared inheritance/subtype cache invalidation for synthesized function extensions
- keep the synthesized extension registered for candidate-extension lookup
- avoid repeated semantic work during autodiff higher-order conformance synthesis

## Testing
- `tests/autodiff` on `45ccce9a3`: 1063/1063 passed, 292 ignored
- `tests/autodiff` on current `official/master` (`f09c7e8f4`) with this patch: 1066/1066 passed, 293 ignored