### PR TITLE
Metal: route pointer/vector bitcasts through uint64_t

### DIFF
--- a/source/slang/slang-emit-metal.cpp
+++ b/source/slang/slang-emit-metal.cpp
@@ -839,14 +839,51 @@ bool MetalSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inO
             auto toType = inst->getDataType();
             auto fromType = inst->getOperand(0)->getDataType();
 
-            // Metal doesn't allow as_type<> casts involving pointer types.
-            // Use C-style cast for pointer-to-pointer, pointer-to-int, and int-to-pointer.
-            bool toIsPointer = as<IRPtrTypeBase>(toType) || as<IRRawPointerTypeBase>(toType);
-            bool fromIsPointer = as<IRPtrTypeBase>(fromType) || as<IRRawPointerTypeBase>(fromType);
-
-            if (toIsPointer || fromIsPointer)
+            auto isMetalPointerLike = [](IRType* t) -> bool
             {
-                // C-style cast for pointer conversions
+                if (as<IRPtrTypeBase>(t) || as<IRRawPointerTypeBase>(t))
+                    return true;
+                if (auto descType = as<IRDescriptorHandleType>(t))
+                {
+                    auto resType = descType->getResourceType();
+                    // Textures and samplers emit as opaque Metal types
+                    // (texture2d<...>, sampler) rather than pointers, so the
+                    // uint64_t bridge doesn't apply to them.
+                    if (as<IRTextureTypeBase>(resType) ||
+                        as<IRSamplerStateTypeBase>(resType))
+                    {
+                        return false;
+                    }
+                    return true;
+                }
+                return false;
+            };
+            bool toIsPointer = isMetalPointerLike(toType);
+            bool fromIsPointer = isMetalPointerLike(fromType);
+            bool toIsVector = as<IRVectorType>(toType) != nullptr;
+            bool fromIsVector = as<IRVectorType>(fromType) != nullptr;
+
+            if (fromIsPointer && toIsVector)
+            {
+                // pointer -> vector: convert pointer to uint64_t, then as_type to vector.
+                m_writer->emit("as_type<");
+                emitType(toType);
+                m_writer->emit(">(uint64_t(");
+                emitOperand(inst->getOperand(0), getInfo(EmitOp::General));
+                m_writer->emit("))");
+            }
+            else if (fromIsVector && toIsPointer)
+            {
+                // vector -> pointer: as_type to uint64_t, then C-style cast to pointer.
+                m_writer->emit("((");
+                emitType(toType);
+                m_writer->emit(")(as_type<uint64_t>(");
+                emitOperand(inst->getOperand(0), getInfo(EmitOp::General));
+                m_writer->emit(")))");
+            }
+            else if (toIsPointer || fromIsPointer)
+            {
+                // C-style cast for pointer-to-pointer and pointer-to/from-scalar.
                 m_writer->emit("(");
                 emitType(toType);
                 m_writer->emit(")(");

--- a/tests/language-feature/dynamic-dispatch/layout-descriptor-handle-array.slang
+++ b/tests/language-feature/dynamic-dispatch/layout-descriptor-handle-array.slang
@@ -6,7 +6,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type -render-feature bindless -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -profile sm_6_6 -render-feature bindless
-// Metal disabled: DescriptorHandle as_type cast bug (https://github.com/shader-slang/slang/issues/10477)
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-mtl -compute -shaderobj -output-using-type
 
 interface IIndexedSource
 {

--- a/tests/language-feature/dynamic-dispatch/layout-descriptor-handle-dispatch.slang
+++ b/tests/language-feature/dynamic-dispatch/layout-descriptor-handle-dispatch.slang
@@ -7,7 +7,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type -render-feature bindless -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -profile sm_6_6 -render-feature bindless
-// Metal disabled: DescriptorHandle as_type cast bug (https://github.com/shader-slang/slang/issues/10477)
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-mtl -compute -shaderobj -output-using-type
 
 interface IDataSource
 {

--- a/tests/language-feature/dynamic-dispatch/layout-descriptor-handle-multi.slang
+++ b/tests/language-feature/dynamic-dispatch/layout-descriptor-handle-multi.slang
@@ -7,7 +7,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type -render-feature bindless -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -profile sm_6_6 -render-feature bindless
-// Metal disabled: DescriptorHandle as_type cast bug (https://github.com/shader-slang/slang/issues/10477)
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-mtl -compute -shaderobj -output-using-type
 
 interface IMultiSource
 {


### PR DESCRIPTION
Metal doesn't allow as_type<> casts involving pointer types, and also rejects C-style casts directly between a pointer and a vector type.

This treats DescriptorHandle as pointer-like when its inner type emits as a Metal pointer - for example, buffers.

Enables the relevant tests for Metal.

Fix for #10477.