### PR TITLE
Emit E50100 for StructuredBuffer<IInterface> without conformances

### DIFF
--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -2382,6 +2382,11 @@ struct TypeFlowSpecializationContext
                     }
                     else
                     {
+                        StringBuilder typeStr;
+                        printDiagnosticArg(typeStr, interfaceType);
+                        sink->diagnose(Diagnostics::NoTypeConformancesFoundForInterface{
+                            .interfaceType = typeStr.produceString(),
+                            .location = inst->sourceLoc});
                         module->getContainerPool().free(&tables);
                         return none();
                     }

--- a/tests/diagnostics/no-type-conformance-structured-buffer.slang
+++ b/tests/diagnostics/no-type-conformance-structured-buffer.slang
@@ -1,8 +1,8 @@
-//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target spirv -entry computeMain -stage compute
-//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target hlsl -entry computeMain -stage compute
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):-target spirv -entry computeMain -stage compute
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):-target hlsl -entry computeMain -stage compute
 
-// Test that loading from StructuredBuffer<IInterface> without -conformance flags
-// produces a clean E50100 diagnostic instead of crashing (issue #10519).
+// Test that loading from StructuredBuffer<IInterface> and RWStructuredBuffer<IInterface>
+// without -conformance flags produces a clean E50100 diagnostic instead of crashing (issue #10519).
 
 interface IFoo
 {
@@ -16,6 +16,7 @@ struct Impl : IFoo
 }
 
 StructuredBuffer<IFoo> inputBuffer;
+RWStructuredBuffer<IFoo> rwInputBuffer;
 RWStructuredBuffer<float> outputBuffer;
 
 [numthreads(1, 1, 1)]
@@ -24,4 +25,7 @@ void computeMain()
     outputBuffer[0] = inputBuffer[0].getValue();
 //CHECK:                         ^ no type conformances found
 //CHECK:                         ^ No type conformances are found for interface 'IFoo'. Code generation for current target requires at least one implementation type present in the linkage.
+    outputBuffer[1] = rwInputBuffer[0].getValue();
+//CHECK:                                       ^ no type conformances found
+//CHECK:                                       ^ No type conformances are found for interface 'IFoo'. Code generation for current target requires at least one implementation type present in the linkage.
 }

--- a/tests/diagnostics/no-type-conformance-structured-buffer.slang
+++ b/tests/diagnostics/no-type-conformance-structured-buffer.slang
@@ -1,0 +1,27 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target spirv -entry computeMain -stage compute
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target hlsl -entry computeMain -stage compute
+
+// Test that loading from StructuredBuffer<IInterface> without -conformance flags
+// produces a clean E50100 diagnostic instead of crashing (issue #10519).
+
+interface IFoo
+{
+    float getValue();
+}
+
+struct Impl : IFoo
+{
+    float v;
+    float getValue() { return v; }
+}
+
+StructuredBuffer<IFoo> inputBuffer;
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    outputBuffer[0] = inputBuffer[0].getValue();
+//CHECK:                         ^ no type conformances found
+//CHECK:                         ^ No type conformances are found for interface 'IFoo'. Code generation for current target requires at least one implementation type present in the linkage.
+}


### PR DESCRIPTION
## Summary
- Fixes #10519 — `StructuredBuffer<IInterface>` without `-conformance` flags caused ICE/crash instead of a clean diagnostic
- Root cause: `analyzeLoad()` in the typeflow specialization pass silently returned `none()` for `StructuredBufferLoad`/`RWStructuredBufferLoad` when no witness tables were found, unlike the identical code paths for `IRLoad` and `CreateExistentialObject` which correctly emit E50100
- Added the missing E50100 diagnostic emission, matching the existing pattern

## Test plan
- [x] New diagnostic test `tests/diagnostics/no-type-conformance-structured-buffer.slang` verifies E50100 on both SPIRV and HLSL targets
- [x] Existing `tests/diagnostics/no-type-conformance.slang` still passes
- [x] Compilation with `-conformance` flag still succeeds
- [x] Full CI test suite
