### PR TITLE
Diagnose Ref<T> as struct field instead of ICE

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2628,10 +2628,9 @@ void SemanticsDeclHeaderVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
             auto type = varDecl->type.type;
             if (as<ExplicitRefType>(type) || as<ParamPassingModeType>(type))
             {
-                getSink()->diagnose(
-                    Diagnostics::ReferenceTypeAsStructField{
-                        .type = type,
-                        .location = varDecl->loc});
+                getSink()->diagnose(Diagnostics::ReferenceTypeAsStructField{
+                    .type = type,
+                    .location = varDecl->loc});
             }
         }
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2620,6 +2620,21 @@ void SemanticsDeclHeaderVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
             getSink()->diagnose(Diagnostics::InvalidTypeVoid{.location = varDecl->loc});
         }
 
+        // Reject reference/parameter-passing-mode types as struct fields.
+        // These types (Ref<T>, RefParam<T>, BorrowInParam<T>, etc.) represent
+        // temporary borrows and cannot be stored in struct fields.
+        if (as<AggTypeDecl>(varDecl->parentDecl))
+        {
+            auto type = varDecl->type.type;
+            if (as<ExplicitRefType>(type) || as<ParamPassingModeType>(type))
+            {
+                getSink()->diagnose(
+                    Diagnostics::ReferenceTypeAsStructField{
+                        .type = type,
+                        .location = varDecl->loc});
+            }
+        }
+
         // If this is an unsized array variable, then we first want to give
         // it a chance to infer an array size from its initializer
         //

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -1159,6 +1159,13 @@ err(
 )
 
 err(
+    "reference-type-as-struct-field",
+    30030,
+    "reference type cannot be used as struct field",
+    span { loc = "location", message = "'~type:Type' cannot be used as a struct field; reference types can only be used for function parameters and return values." }
+)
+
+err(
     "no-member-of-name-in-type",
     30027,
     "member not found",

--- a/tests/language-feature/dynamic-dispatch/diagnose-ref-type-interface-struct-field.slang
+++ b/tests/language-feature/dynamic-dispatch/diagnose-ref-type-interface-struct-field.slang
@@ -2,22 +2,13 @@
 // (Ref, RefParam, BorrowInParam) are designed for function parameters
 // and return values; they cannot be stored in struct fields because
 // there is no stable storage address to reference across struct copies.
-//
-// When T is an interface type, this is doubly problematic: the existential
-// value is stored as an AnyValue-packed tuple, and a reference into that
-// buffer would bypass the pack/unpack marshalling needed for dynamic
-// dispatch.
-//
-// Currently this triggers an internal compiler error (assert failure in
-// LoweredValInfo) instead of a user-friendly diagnostic. These tests are
-// disabled until the compiler produces a proper error message.
 
-//DISABLED_TEST:SIMPLE(filecheck=CHECK): -target spirv
-//DISABLED_TEST:SIMPLE(filecheck=CHECK): -target hlsl -stage compute -entry computeMain
-//DISABLED_TEST:SIMPLE(filecheck=CHECK): -target cuda -stage compute -entry computeMain
-//DISABLED_TEST:SIMPLE(filecheck=CHECK): -target metal -stage compute -entry computeMain
-//DISABLED_TEST:SIMPLE(filecheck=CHECK): -target wgsl -stage compute -entry computeMain
-//DISABLED_TEST:SIMPLE(filecheck=CHECK): -target cpp -stage compute -entry computeMain
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target spirv
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target hlsl -stage compute -entry computeMain
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target cuda -stage compute -entry computeMain
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target metal -stage compute -entry computeMain
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target wgsl -stage compute -entry computeMain
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target cpp -stage compute -entry computeMain
 
 [anyValueSize(16)]
 interface IFoo
@@ -37,25 +28,28 @@ struct ImplB : IFoo
     float getValue() { return v * 2; }
 }
 
-// Ref<IFoo> as a struct field: should be diagnosed rather than ICE.
+// Ref<IFoo> as a struct field: should be diagnosed.
 struct RefInterfaceField
 {
-    // CHECK: ([[# @LINE+1]]): error
     Ref<IFoo> field;
+//CHECK:      ^^^^^ reference type cannot be used as struct field
+//CHECK:      ^^^^^ cannot be used as a struct field; reference types can only be used for function parameters and return values.
 }
 
 // Ref<ConcreteType> as a struct field: same underlying issue.
 struct RefConcreteField
 {
-    // CHECK: ([[# @LINE+1]]): error
     Ref<float> field;
+//CHECK:       ^^^^^ reference type cannot be used as struct field
+//CHECK:       ^^^^^ cannot be used as a struct field; reference types can only be used for function parameters and return values.
 }
 
 // Nested: struct containing another struct with Ref<IFoo> field.
 struct InnerRef
 {
-    // CHECK: ([[# @LINE+1]]): error
     Ref<IFoo> iface;
+//CHECK:      ^^^^^ reference type cannot be used as struct field
+//CHECK:      ^^^^^ cannot be used as a struct field; reference types can only be used for function parameters and return values.
 }
 
 struct OuterRef

--- a/tests/language-feature/dynamic-dispatch/diagnose-ref-type-interface-struct-field.slang
+++ b/tests/language-feature/dynamic-dispatch/diagnose-ref-type-interface-struct-field.slang
@@ -57,6 +57,22 @@ struct OuterRef
     InnerRef inner;
 }
 
+// RefParam<T> as a struct field: also rejected.
+struct RefParamField
+{
+    RefParam<float> p;
+//CHECK:            ^ reference type cannot be used as struct field
+//CHECK:            ^ cannot be used as a struct field; reference types can only be used for function parameters and return values.
+}
+
+// BorrowInParam<T> as a struct field: also rejected.
+struct BorrowInParamField
+{
+    BorrowInParam<float> p;
+//CHECK:                 ^ reference type cannot be used as struct field
+//CHECK:                 ^ cannot be used as a struct field; reference types can only be used for function parameters and return values.
+}
+
 RWStructuredBuffer<float> outputBuffer;
 
 [numthreads(1, 1, 1)]

--- a/tests/language-feature/dynamic-dispatch/diagnose-ref-type-interface-struct-field.slang
+++ b/tests/language-feature/dynamic-dispatch/diagnose-ref-type-interface-struct-field.slang
@@ -73,6 +73,30 @@ struct BorrowInParamField
 //CHECK:                 ^ cannot be used as a struct field; reference types can only be used for function parameters and return values.
 }
 
+// OutParam<T> as a struct field: also rejected.
+struct OutParamField
+{
+    OutParam<float> p;
+//CHECK:            ^ reference type cannot be used as struct field
+//CHECK:            ^ cannot be used as a struct field; reference types can only be used for function parameters and return values.
+}
+
+// BorrowInOutParam<T> as a struct field: also rejected.
+struct BorrowInOutParamField
+{
+    BorrowInOutParam<float> p;
+//CHECK:                    ^ reference type cannot be used as struct field
+//CHECK:                    ^ cannot be used as a struct field; reference types can only be used for function parameters and return values.
+}
+
+// Ref<T> in a class field: same restriction applies to all aggregate types.
+class ClassWithRefField
+{
+    Ref<float> field;
+//CHECK:       ^^^^^ reference type cannot be used as struct field
+//CHECK:       ^^^^^ cannot be used as a struct field; reference types can only be used for function parameters and return values.
+}
+
 RWStructuredBuffer<float> outputBuffer;
 
 [numthreads(1, 1, 1)]


### PR DESCRIPTION
## Summary
- Using `Ref<T>` (or `RefParam<T>`, `BorrowInParam<T>`, etc.) as a struct field type triggered an internal compiler error (`assert failure: info.flavor == LoweredValInfo::Flavor::Simple`) instead of a user-friendly diagnostic
- Added a semantic check in `SemanticsDeclHeaderVisitor::checkVarDeclCommon()` that rejects `ExplicitRefType` and `ParamPassingModeType` when used as struct field types, producing error 30030
- Enabled the previously disabled test from #10258

Fixes #10259

## Root Cause
`Ref<T>` is a type (`ExplicitRefType : PtrTypeBase`), not a modifier. The existing modifier checker catches `__ref`/`__constref` on struct fields (error 31201), but the type-level `Ref<T>` bypassed all modifier validation. When IR lowering encountered a pointer-typed struct field, `LoweredValInfo` had a `Ptr` flavor instead of `Simple`, triggering the assertion in `slang-lower-to-ir.cpp`.

## Test plan
- [x] Reproducer from issue no longer ICEs, produces clear error 30030
- [x] Enabled `diagnose-ref-type-interface-struct-field.slang` (all 6 target variants pass)
- [x] Existing `diagnose-ref-interface-struct-field.slang` (__ref modifier tests) still pass
- [x] Full `tests/language-feature/dynamic-dispatch/` suite passes (458/458)
- [x] Full `tests/diagnostics/` suite passes (370/370)
