### PR TITLE
Add GFX and RHI library coverage to nightly reports

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -116,7 +116,9 @@
       "inherits": "default",
       "description": "Build with code coverage instrumentation",
       "cacheVariables": {
-        "SLANG_ENABLE_COVERAGE": true
+        "SLANG_ENABLE_COVERAGE": true,
+        "CMAKE_C_FLAGS": "-fprofile-instr-generate -fcoverage-mapping",
+        "CMAKE_CXX_FLAGS": "-fprofile-instr-generate -fcoverage-mapping"
       }
     },
     {

--- a/tools/coverage/run-coverage.sh
+++ b/tools/coverage/run-coverage.sh
@@ -8,26 +8,26 @@ REPORT_ONLY=false
 WITH_SYNTHESIS=false
 TEST_ARGS=()
 for arg in "$@"; do
-  if [[ "$arg" == "--report-only" ]]; then
-    REPORT_ONLY=true
-  elif [[ "$arg" == "--with-synthesis" ]]; then
-    WITH_SYNTHESIS=true
-  else
-    TEST_ARGS+=("$arg")
-  fi
+	if [[ "$arg" == "--report-only" ]]; then
+		REPORT_ONLY=true
+	elif [[ "$arg" == "--with-synthesis" ]]; then
+		WITH_SYNTHESIS=true
+	else
+		TEST_ARGS+=("$arg")
+	fi
 done
 
 # Detect platform and set appropriate tools
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  # macOS - use xcrun to find the right tools
-  LLVM_PROFDATA="${LLVM_PROFDATA:-xcrun llvm-profdata}"
-  LLVM_COV="${LLVM_COV:-xcrun llvm-cov}"
-  LIB_EXT="dylib"
+	# macOS - use xcrun to find the right tools
+	LLVM_PROFDATA="${LLVM_PROFDATA:-xcrun llvm-profdata}"
+	LLVM_COV="${LLVM_COV:-xcrun llvm-cov}"
+	LIB_EXT="dylib"
 else
-  # Linux/Unix - use system tools
-  LLVM_PROFDATA="${LLVM_PROFDATA:-llvm-profdata}"
-  LLVM_COV="${LLVM_COV:-llvm-cov}"
-  LIB_EXT="so"
+	# Linux/Unix - use system tools
+	LLVM_PROFDATA="${LLVM_PROFDATA:-llvm-profdata}"
+	LLVM_COV="${LLVM_COV:-llvm-cov}"
+	LIB_EXT="so"
 fi
 
 # Determine paths
@@ -46,97 +46,97 @@ COVERAGE_DIR="${COVERAGE_DIR:-$BUILD_DIR/coverage-data}"
 mkdir -p "$COVERAGE_DIR"
 
 if [[ "$REPORT_ONLY" == "true" ]]; then
-  # Report-only mode: check that profdata exists
-  echo "Report-only mode: using existing coverage data"
+	# Report-only mode: check that profdata exists
+	echo "Report-only mode: using existing coverage data"
 
-  if [[ ! -f "$COVERAGE_DIR/slang-test.profdata" ]]; then
-    echo "Error: No existing coverage data found at $COVERAGE_DIR/slang-test.profdata"
-    echo "Run without --report-only first to collect coverage data"
-    exit 1
-  fi
+	if [[ ! -f "$COVERAGE_DIR/slang-test.profdata" ]]; then
+		echo "Error: No existing coverage data found at $COVERAGE_DIR/slang-test.profdata"
+		echo "Run without --report-only first to collect coverage data"
+		exit 1
+	fi
 
-  if [[ ! -f "$LIBSLANG" ]]; then
-    echo "Error: libslang not found at $LIBSLANG"
-    exit 1
-  fi
+	if [[ ! -f "$LIBSLANG" ]]; then
+		echo "Error: libslang not found at $LIBSLANG"
+		exit 1
+	fi
 else
-  # Normal mode: run tests and collect coverage
+	# Normal mode: run tests and collect coverage
 
-  # Check if binaries exist
-  if [[ ! -f "$SLANG_TEST" ]]; then
-    echo "Error: slang-test not found at $SLANG_TEST"
-    echo "Please build with coverage enabled first:"
-    echo "  cmake --preset coverage"
-    echo "  cmake --build --preset coverage"
-    exit 1
-  fi
+	# Check if binaries exist
+	if [[ ! -f "$SLANG_TEST" ]]; then
+		echo "Error: slang-test not found at $SLANG_TEST"
+		echo "Please build with coverage enabled first:"
+		echo "  cmake --preset coverage"
+		echo "  cmake --build --preset coverage"
+		exit 1
+	fi
 
-  if [[ ! -f "$LIBSLANG" ]]; then
-    echo "Error: libslang not found at $LIBSLANG"
-    exit 1
-  fi
+	if [[ ! -f "$LIBSLANG" ]]; then
+		echo "Error: libslang not found at $LIBSLANG"
+		exit 1
+	fi
 
-  # Clean up old coverage data
-  echo "Cleaning up old coverage data..."
-  rm -rf "$COVERAGE_DIR"/*.profraw "$COVERAGE_DIR"/*.profdata
+	# Clean up old coverage data
+	echo "Cleaning up old coverage data..."
+	rm -rf "$COVERAGE_DIR"/*.profraw "$COVERAGE_DIR"/*.profdata
 
-  # Set up coverage output in temp directory
-  export LLVM_PROFILE_FILE="$COVERAGE_DIR/slang-test-%p.profraw"
+	# Set up coverage output in temp directory
+	export LLVM_PROFILE_FILE="$COVERAGE_DIR/slang-test-%p.profraw"
 
-  # Run tests
-  echo
-  echo "Running tests with coverage instrumentation..."
-  echo "Coverage data directory: $COVERAGE_DIR"
-  cd "$REPO_ROOT"
-  "$SLANG_TEST" "${TEST_ARGS[@]}"
+	# Run tests
+	echo
+	echo "Running tests with coverage instrumentation..."
+	echo "Coverage data directory: $COVERAGE_DIR"
+	cd "$REPO_ROOT"
+	"$SLANG_TEST" "${TEST_ARGS[@]}"
 
-  # Run record-replay API tests with recording enabled to capture record-replay coverage
-  # This runs only the focused RecordReplayApi* tests with SLANG_RECORD_LAYER=1 to
-  # exercise the record-replay code paths. The profraw files accumulate with the main run.
-  echo
-  echo "Running record-replay API tests with recording enabled..."
-  RECORD_DIR="$COVERAGE_DIR/slang-record"
-  mkdir -p "$RECORD_DIR"
+	# Run record-replay API tests with recording enabled to capture record-replay coverage
+	# This runs only the focused RecordReplayApi* tests with SLANG_RECORD_LAYER=1 to
+	# exercise the record-replay code paths. The profraw files accumulate with the main run.
+	echo
+	echo "Running record-replay API tests with recording enabled..."
+	RECORD_DIR="$COVERAGE_DIR/slang-record"
+	mkdir -p "$RECORD_DIR"
 
-  export SLANG_RECORD_LAYER=1
-  export SLANG_RECORD_DIRECTORY="$RECORD_DIR"
+	export SLANG_RECORD_LAYER=1
+	export SLANG_RECORD_DIRECTORY="$RECORD_DIR"
 
-  # Run only the RecordReplayApi tests (fast, focused coverage)
-  "$SLANG_TEST" slang-unit-test-tool/RecordReplayApi || true
+	# Run only the RecordReplayApi tests (fast, focused coverage)
+	"$SLANG_TEST" slang-unit-test-tool/RecordReplayApi || true
 
-  unset SLANG_RECORD_LAYER
-  unset SLANG_RECORD_DIRECTORY
+	unset SLANG_RECORD_LAYER
+	unset SLANG_RECORD_DIRECTORY
 
-  # Clean up recording files (only need coverage data)
-  rm -rf "$RECORD_DIR"
+	# Clean up recording files (only need coverage data)
+	rm -rf "$RECORD_DIR"
 
-  # Optional: run synthesized compile-target tests for backend emit coverage.
-  # These exercise code generation paths (HLSL, SPIRV, Metal, etc.) without a GPU.
-  # Failures are tolerated since some targets have known gaps.
-  if [[ "$WITH_SYNTHESIS" == "true" ]]; then
-    echo
-    echo "Running synthesized compile-target tests..."
-    SYNTH_EXIT=0
-    "$SLANG_TEST" "${TEST_ARGS[@]}" -only-synthesized || SYNTH_EXIT=$?
-    if [ "$SYNTH_EXIT" -gt 128 ]; then
-      echo "Warning: synthesis pass crashed (signal $((SYNTH_EXIT - 128)))"
-    elif [ "$SYNTH_EXIT" -ne 0 ]; then
-      echo "Note: synthesis pass had test failures (exit code $SYNTH_EXIT). Coverage data still collected."
-    fi
-  fi
+	# Optional: run synthesized compile-target tests for backend emit coverage.
+	# These exercise code generation paths (HLSL, SPIRV, Metal, etc.) without a GPU.
+	# Failures are tolerated since some targets have known gaps.
+	if [[ "$WITH_SYNTHESIS" == "true" ]]; then
+		echo
+		echo "Running synthesized compile-target tests..."
+		SYNTH_EXIT=0
+		"$SLANG_TEST" "${TEST_ARGS[@]}" -only-synthesized || SYNTH_EXIT=$?
+		if [ "$SYNTH_EXIT" -gt 128 ]; then
+			echo "Warning: synthesis pass crashed (signal $((SYNTH_EXIT - 128)))"
+		elif [ "$SYNTH_EXIT" -ne 0 ]; then
+			echo "Note: synthesis pass had test failures (exit code $SYNTH_EXIT). Coverage data still collected."
+		fi
+	fi
 
-  # Check if any profraw files were generated
-  if ! ls "$COVERAGE_DIR"/slang-test-*.profraw >/dev/null 2>&1; then
-    echo
-    echo "Warning: No coverage data was generated."
-    echo "Make sure the binaries were built with SLANG_ENABLE_COVERAGE=ON"
-    exit 1
-  fi
+	# Check if any profraw files were generated
+	if ! ls "$COVERAGE_DIR"/slang-test-*.profraw >/dev/null 2>&1; then
+		echo
+		echo "Warning: No coverage data was generated."
+		echo "Make sure the binaries were built with SLANG_ENABLE_COVERAGE=ON"
+		exit 1
+	fi
 
-  # Merge coverage data
-  echo
-  echo "Merging coverage data..."
-  $LLVM_PROFDATA merge -sparse "$COVERAGE_DIR"/slang-test-*.profraw -o "$COVERAGE_DIR"/slang-test.profdata
+	# Merge coverage data
+	echo
+	echo "Merging coverage data..."
+	$LLVM_PROFDATA merge -sparse "$COVERAGE_DIR"/slang-test-*.profraw -o "$COVERAGE_DIR"/slang-test.profdata
 fi
 
 # Load slangc compiler-only ignore patterns (shared with CI workflow)
@@ -154,44 +154,65 @@ echo "slangc Compiler Coverage (excludes generated/non-compiler code):"
 echo "================================================================"
 $LLVM_COV report "$LIBSLANG" -instr-profile="$COVERAGE_DIR"/slang-test.profdata "${SLANGC_IGNORE_ARGS[@]}"
 
+# Generate GFX coverage report (if libgfx exists)
+LIBGFX="$BUILD_DIR/$CONFIG/lib/libgfx.$LIB_EXT"
+if [[ -f "$LIBGFX" ]]; then
+	echo
+	echo "GFX Library Coverage Summary:"
+	echo "============================="
+	$LLVM_COV report "$LIBGFX" -instr-profile="$COVERAGE_DIR"/slang-test.profdata 2>/dev/null || echo "(no coverage data for libgfx)"
+fi
+
+# Generate RHI coverage report via slang-test binary (slang-rhi is statically linked)
+# The slang-test executable contains the statically linked slang-rhi code
+SLANG_TEST_BIN="$BUILD_DIR/$CONFIG/bin/slang-test"
+if [[ -f "$SLANG_TEST_BIN" ]]; then
+	echo
+	echo "RHI Coverage Summary (via slang-test binary):"
+	echo "=============================================="
+	# Filter to only show slang-rhi source files by excluding everything else
+	$LLVM_COV report "$SLANG_TEST_BIN" -instr-profile="$COVERAGE_DIR"/slang-test.profdata \
+		-ignore-filename-regex='^(?!.*/external/slang-rhi/)' 2>/dev/null || echo "(no coverage data for slang-rhi)"
+fi
+
 # Generate HTML reports (optional)
 if [[ "$COVERAGE_HTML" = "1" ]]; then
-  HTML_DIR="${COVERAGE_HTML_DIR:-$REPO_ROOT/coverage-html}"
+	HTML_DIR="${COVERAGE_HTML_DIR:-$REPO_ROOT/coverage-html}"
 
-  echo
-  echo "Generating HTML coverage report (full library)..."
-  $LLVM_COV show "$LIBSLANG" \
-    -instr-profile="$COVERAGE_DIR"/slang-test.profdata \
-    -format=html \
-    -output-dir="$HTML_DIR"
-  echo "HTML report generated in $HTML_DIR/index.html"
+	echo
+	echo "Generating HTML coverage report (full library)..."
+	$LLVM_COV show "$LIBSLANG" \
+		-instr-profile="$COVERAGE_DIR"/slang-test.profdata \
+		-format=html \
+		-output-dir="$HTML_DIR"
+	echo "HTML report generated in $HTML_DIR/index.html"
 
-  SLANGC_HTML_DIR="${HTML_DIR}-slangc"
-  echo
-  echo "Generating HTML coverage report (slangc compiler only)..."
-  $LLVM_COV show "$LIBSLANG" \
-    -instr-profile="$COVERAGE_DIR"/slang-test.profdata \
-    -format=html \
-    -output-dir="$SLANGC_HTML_DIR" \
-    "${SLANGC_IGNORE_ARGS[@]}"
-  echo "HTML report generated in $SLANGC_HTML_DIR/index.html"
+	SLANGC_HTML_DIR="${HTML_DIR}-slangc"
+	echo
+	echo "Generating HTML coverage report (slangc compiler only)..."
+	$LLVM_COV show "$LIBSLANG" \
+		-instr-profile="$COVERAGE_DIR"/slang-test.profdata \
+		-format=html \
+		-output-dir="$SLANGC_HTML_DIR" \
+		"${SLANGC_IGNORE_ARGS[@]}"
+	echo "HTML report generated in $SLANGC_HTML_DIR/index.html"
 
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "Opening reports in browser..."
-    open "$HTML_DIR/index.html"
-    open "$SLANGC_HTML_DIR/index.html"
-  fi
+	if [[ "$OSTYPE" == "darwin"* ]]; then
+		echo "Opening reports in browser..."
+		open "$HTML_DIR/index.html"
+		open "$SLANGC_HTML_DIR/index.html"
+	fi
 fi
 
 # Generate lcov format (optional, useful for CI integration)
 if [[ "$COVERAGE_LCOV" = "1" ]]; then
-  LCOV_FILE="${COVERAGE_LCOV_FILE:-$REPO_ROOT/coverage.lcov}"
-  echo
-  echo "Generating LCOV format report..."
-  $LLVM_COV export "$LIBSLANG" \
-    -instr-profile="$COVERAGE_DIR"/slang-test.profdata \
-    -format=lcov >"$LCOV_FILE"
-  echo "LCOV report generated: $LCOV_FILE"
+	LCOV_FILE="${COVERAGE_LCOV_FILE:-$REPO_ROOT/coverage.lcov}"
+	echo
+	echo "Generating LCOV format report..."
+	$LLVM_COV export "$LIBSLANG" \
+		-instr-profile="$COVERAGE_DIR"/slang-test.profdata \
+		-format=lcov >"$LCOV_FILE"
+	echo "LCOV report generated: $LCOV_FILE"
 fi
 
 echo
@@ -199,17 +220,17 @@ echo "Coverage data files:"
 echo "  - $COVERAGE_DIR/slang-test.profdata (merged profile data)"
 echo "  - $COVERAGE_DIR/*.profraw (raw profile data - can be deleted)"
 if [[ "$COVERAGE_HTML" = "1" ]]; then
-  echo "  - ${COVERAGE_HTML_DIR:-$REPO_ROOT/coverage-html}/ (HTML report - full library)"
-  echo "  - ${COVERAGE_HTML_DIR:-$REPO_ROOT/coverage-html}-slangc/ (HTML report - slangc compiler only)"
+	echo "  - ${COVERAGE_HTML_DIR:-$REPO_ROOT/coverage-html}/ (HTML report - full library)"
+	echo "  - ${COVERAGE_HTML_DIR:-$REPO_ROOT/coverage-html}-slangc/ (HTML report - slangc compiler only)"
 fi
 if [[ "$COVERAGE_LCOV" = "1" ]]; then
-  echo "  - ${COVERAGE_LCOV_FILE:-$REPO_ROOT/coverage.lcov} (LCOV format for CI tools)"
+	echo "  - ${COVERAGE_LCOV_FILE:-$REPO_ROOT/coverage.lcov} (LCOV format for CI tools)"
 fi
 
 # Clean up raw profraw files to save space (only in normal mode)
 if [[ "$REPORT_ONLY" != "true" ]]; then
-  echo
-  echo "Cleaning up raw profile data..."
-  rm -f "$COVERAGE_DIR"/*.profraw
-  echo "Kept merged profile data at: $COVERAGE_DIR/slang-test.profdata"
+	echo
+	echo "Cleaning up raw profile data..."
+	rm -f "$COVERAGE_DIR"/*.profraw
+	echo "Kept merged profile data at: $COVERAGE_DIR/slang-test.profdata"
 fi


### PR DESCRIPTION
## Summary
- Instrument slang-rhi (external submodule) with coverage flags via global CMAKE_CXX_FLAGS
- Add GFX and RHI coverage report sections to `run-coverage.sh`
- Previously only `libslang.so` was measured — 104K lines (22% of codebase) were invisible

## Motivation
The nightly coverage report only measures `libslang.so`. Two significant libraries are completely unmeasured:
- **slang-rhi** (61K lines) — statically linked into slang-test, uses plain `add_library` so `SLANG_ENABLE_COVERAGE` per-target flags don't apply
- **libgfx** (43K lines) — already instrumented via `slang_add_target`, but never reported

## Technical Details

**CMakePresets.json**: Add `-fprofile-instr-generate -fcoverage-mapping` to `CMAKE_C_FLAGS` and `CMAKE_CXX_FLAGS` in the coverage preset. This instruments ALL targets globally, including external submodules that don't use `slang_add_target`.

**run-coverage.sh**: Add two new report sections after the existing libslang reports:
- **GFX**: `llvm-cov report libgfx.{so,dylib}` — direct shared library measurement
- **RHI**: `llvm-cov report slang-test` with `-ignore-filename-regex` to filter only `external/slang-rhi/` sources — since slang-rhi is statically linked into slang-test

Both sections are conditional — they only run if the respective binary exists.

## Verified locally (macOS, Metal + CPU)

| Target | Line Coverage | Function Coverage |
|--------|-------------|-------------------|
| libslang (full) | 69.06% | 62.17% |
| libslang (slangc) | 76.17% | 72.78% |
| **libgfx** (new) | **17.03%** | **14.68%** |
| **slang-rhi** (new) | **54.86%** | **55.51%** |

GFX is low because only Metal backend is available on macOS. On Linux GPU runners (Vulkan + CUDA), expect significantly higher numbers.

## For GPU coverage (follow-up)
With the `linux-gpu-coverage-ci` container (#10783), this same code would produce higher GFX/RHI numbers since Vulkan and CUDA backends would be exercised. No additional changes needed — `run-coverage.sh` detects binaries automatically.

## Related
- Container support: #10783
- Windows coverage: #10810

## Test plan
- [x] Local macOS run produces GFX and RHI coverage numbers
- [ ] Linux nightly produces GFX and RHI sections
- [ ] No regression in libslang/slangc coverage numbers