### PR TITLE
Add crash diagnostics and retry logging for intermittent CI failures

### DIFF
--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -180,8 +180,11 @@ jobs:
             exit 0
           fi
 
-          # Install gdb if not present
-          which gdb >/dev/null 2>&1 || (apt-get update -qq && apt-get install -y -qq gdb >/dev/null 2>&1) || true
+          # gdb is pre-installed in the container (linux-gpu-ci)
+          if ! which gdb >/dev/null 2>&1; then
+            echo "::warning::gdb not found in container — skipping core dump analysis"
+            exit 0
+          fi
 
           for core_file in $CORE_FILES; do
             core_basename=$(basename "$core_file")

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -97,6 +97,7 @@ jobs:
 
       - name: Test Slang
         run: |
+          set -o pipefail
           ulimit -c unlimited
           export SLANG_RUN_SPIRV_VALIDATION=1
           export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1
@@ -120,11 +121,11 @@ jobs:
             slang_test_args+=("-skip-list" "tests/skip-list-debug.txt")
           fi
 
-          "$bin_dir/slang-test" "${slang_test_args[@]}"
+          "$bin_dir/slang-test" "${slang_test_args[@]}" 2>&1 | tee test-output.log
 
       - name: Run slangc tests
         run: |
-          PATH=$bin_dir:$PATH tools/slangc-test/test.sh
+          PATH=$bin_dir:$PATH tools/slangc-test/test.sh 2>&1 | tee -a test-output.log
 
       - name: Test Slang via glsl
         if: inputs.config == 'release' && github.event_name == 'pull_request'
@@ -140,7 +141,8 @@ jobs:
             -expected-failure-list tests/expected-failure-via-glsl.txt \
             -expected-failure-list tests/expected-failure-github.txt \
             -expected-failure-list tests/expected-failure-linux.txt \
-            -expected-failure-list tests/expected-failure-linux-gpu.txt
+            -expected-failure-list tests/expected-failure-linux-gpu.txt \
+            2>&1 | tee -a test-output.log
 
       - name: GPU post-test diagnostics
         if: failure()
@@ -279,6 +281,20 @@ jobs:
           path: intermittency-report.json
           retention-days: 30
           if-no-files-found: ignore
+
+      - name: Compress and upload test log on failure
+        if: failure()
+        run: gzip -9 test-output.log 2>/dev/null || true
+
+      - name: Upload test log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-log-${{ inputs.config }}-slang-test
+          path: test-output.log.gz
+          retention-days: 7
+          if-no-files-found: ignore
+          compression-level: 0
 
   test-slang-rhi:
     runs-on: ["Linux", "self-hosted", "GPU"]

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -88,8 +88,16 @@ jobs:
           # Display environment configuration
           print-env-info
 
+      - name: Enable core dumps
+        run: |
+          ulimit -c unlimited
+          # Core dumps go to /tmp so they're easy to find
+          echo "/tmp/core.%p.%e" > /proc/sys/kernel/core_pattern 2>/dev/null || true
+          mkdir -p /tmp/crash-logs
+
       - name: Test Slang
         run: |
+          ulimit -c unlimited
           export SLANG_RUN_SPIRV_VALIDATION=1
           export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1
 
@@ -162,6 +170,17 @@ jobs:
           if [[ "$gpu_crashed" -eq 1 ]]; then
             exit 1
           fi
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crash-logs-${{ inputs.config }}-slang-test
+          path: |
+            /tmp/core.*
+            /tmp/crash-logs/
+          retention-days: 3
+          if-no-files-found: ignore
 
   test-slang-rhi:
     runs-on: ["Linux", "self-hosted", "GPU"]

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -214,6 +214,52 @@ jobs:
             echo "::endgroup::"
           done
 
+      - name: Enrich intermittency report with system data
+        if: always()
+        run: |
+          REPORT="intermittency-report.json"
+
+          # If slang-test didn't create the file (no retries), create a minimal one
+          if [[ ! -f "$REPORT" ]]; then
+            echo '{"retries": {"total": 0, "passed_on_retry": 0, "tests": []}, "scheduling_stopped": false}' > "$REPORT"
+          fi
+
+          # Collect GPU state
+          gpu_crashed=false
+          gpu_info=""
+          if nvidia-smi --query-gpu=name,driver_version,memory.used,temperature.gpu,pstate \
+              --format=csv,noheader 2>/dev/null; then
+            gpu_info=$(nvidia-smi --query-gpu=name,driver_version,memory.used,temperature.gpu,pstate \
+              --format=csv,noheader 2>/dev/null | head -1)
+          else
+            gpu_crashed=true
+          fi
+
+          # Count core dumps
+          core_count=$(find /tmp -name "core.*" -type f 2>/dev/null | wc -l | tr -d ' ')
+          core_files=""
+          if [[ "$core_count" -gt 0 ]]; then
+            core_files=$(find /tmp -name "core.*" -type f 2>/dev/null | xargs -I{} basename {} | tr '\n' ', ' | sed 's/,$//')
+          fi
+
+          # Use python to merge system data into existing JSON (jq may not be available)
+          python3 -c "
+          import json, sys
+          with open('$REPORT') as f:
+              data = json.load(f)
+          data['system'] = {
+              'gpu_crashed': $( [[ "$gpu_crashed" == "true" ]] && echo "True" || echo "False" ),
+              'gpu_info': '''$gpu_info'''.strip(),
+              'core_dumps': $core_count,
+              'core_files': '''$core_files'''.strip()
+          }
+          with open('$REPORT', 'w') as f:
+              json.dump(data, f, indent=2)
+          " 2>/dev/null || echo "::warning::Failed to enrich intermittency report with system data"
+
+          echo "Intermittency report:"
+          cat "$REPORT"
+
       - name: Upload crash artifacts
         if: failure()
         uses: actions/upload-artifact@v4
@@ -225,12 +271,12 @@ jobs:
           retention-days: 3
           if-no-files-found: ignore
 
-      - name: Upload retry report
+      - name: Upload intermittency report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: retry-report-${{ inputs.config }}-slang-test
-          path: retry-report.json
+          name: intermittency-report-${{ inputs.config }}-slang-test
+          path: intermittency-report.json
           retention-days: 30
           if-no-files-found: ignore
 

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -171,6 +171,46 @@ jobs:
             exit 1
           fi
 
+      - name: Analyze core dumps
+        if: failure()
+        run: |
+          CORE_FILES=$(find /tmp -name "core.*" -type f 2>/dev/null)
+          if [[ -z "$CORE_FILES" ]]; then
+            echo "No core dumps found"
+            exit 0
+          fi
+
+          # Install gdb if not present
+          which gdb >/dev/null 2>&1 || (apt-get update -qq && apt-get install -y -qq gdb >/dev/null 2>&1) || true
+
+          for core_file in $CORE_FILES; do
+            core_basename=$(basename "$core_file")
+            # Extract executable name from core pattern: core.PID.EXECUTABLE
+            exe_name=$(echo "$core_basename" | cut -d. -f3)
+            if [[ -z "$exe_name" ]]; then
+              exe_name="test-server"
+            fi
+
+            binary=$(find "$bin_dir" -name "$exe_name" -type f 2>/dev/null | head -1)
+            if [[ -z "$binary" ]]; then
+              echo "::warning::Core dump $core_basename: could not find binary '$exe_name'"
+              continue
+            fi
+
+            echo ""
+            echo "::group::Core dump analysis: $core_basename ($exe_name)"
+            gdb -batch \
+              -ex "set pagination off" \
+              -ex "echo === Signal ===\n" \
+              -ex "info signal" \
+              -ex "echo \n=== Backtrace ===\n" \
+              -ex "bt full 30" \
+              -ex "echo \n=== All Threads ===\n" \
+              -ex "thread apply all bt 15" \
+              "$binary" "$core_file" 2>&1 || echo "(gdb analysis failed)"
+            echo "::endgroup::"
+          done
+
       - name: Upload crash artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -182,6 +182,15 @@ jobs:
           retention-days: 3
           if-no-files-found: ignore
 
+      - name: Upload retry report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: retry-report-${{ inputs.config }}-slang-test
+          path: retry-report.json
+          retention-days: 30
+          if-no-files-found: ignore
+
   test-slang-rhi:
     runs-on: ["Linux", "self-hosted", "GPU"]
     timeout-minutes: 30

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -104,6 +104,15 @@ jobs:
 
           # Execute slang-test with all arguments
           "$bin_dir/slang-test" "${slang_test_args[@]}"
+      - name: Upload retry report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: retry-report-${{ inputs.os }}-${{ inputs.config }}-slang-test
+          path: retry-report.json
+          retention-days: 30
+          if-no-files-found: ignore
+
       - name: Run Slang examples
         # Run examples on release for pull requests, and not on merge_group, to reduce CI load.
         if: inputs.full-gpu-tests && inputs.config == 'release' && github.event_name == 'pull_request'

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -104,12 +104,12 @@ jobs:
 
           # Execute slang-test with all arguments
           "$bin_dir/slang-test" "${slang_test_args[@]}"
-      - name: Upload retry report
+      - name: Upload intermittency report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: retry-report-${{ inputs.os }}-${{ inputs.config }}-slang-test
-          path: retry-report.json
+          name: intermittency-report-${{ inputs.os }}-${{ inputs.config }}-slang-test
+          path: intermittency-report.json
           retention-days: 30
           if-no-files-found: ignore
 

--- a/docker/linux-gpu-ci.Dockerfile
+++ b/docker/linux-gpu-ci.Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update && apt-get install -y \
     python3 \
     python3-pip \
     python-is-python3 \
+    gdb \
     libx11-dev \
     libxcursor-dev \
     libxrandr-dev \

--- a/extras/analyze-ci-crash.sh
+++ b/extras/analyze-ci-crash.sh
@@ -85,11 +85,11 @@ if ! gh run download "$RUN_ID" --repo "$REPO" --name "$CRASH_ARTIFACT" --dir "$W
 	gh run download "$RUN_ID" --repo "$REPO" --pattern "*crash*" --dir "$WORK_DIR/crash" 2>&1 || true
 	gh run download "$RUN_ID" --repo "$REPO" --pattern "*retry*" --dir "$WORK_DIR/retry" 2>&1 || true
 
-	# Show retry report if available
-	if [[ -f "$WORK_DIR/retry/retry-report.json" ]]; then
+	# Show intermittency report if available
+	if [[ -f "$WORK_DIR/retry/intermittency-report.json" ]]; then
 		echo ""
-		echo "=== Retry Report ==="
-		cat "$WORK_DIR/retry/retry-report.json"
+		echo "=== Intermittency Report ==="
+		cat "$WORK_DIR/retry/intermittency-report.json"
 	fi
 
 	echo ""
@@ -205,17 +205,17 @@ GDB_EOF
 	fi
 done
 
-# Step 5: Also show retry report if available
+# Step 5: Also show intermittency report if available
 echo ""
-echo "=== Step 5: Checking retry report ==="
+echo "=== Step 5: Checking intermittency report ==="
 gh run download "$RUN_ID" --repo "$REPO" --pattern "*retry*${CONFIG}*" --dir "$WORK_DIR/retry" 2>&1 || true
 
-RETRY_FILE=$(find "$WORK_DIR/retry" -name "retry-report.json" 2>/dev/null | head -1)
+RETRY_FILE=$(find "$WORK_DIR/retry" -name "intermittency-report.json" 2>/dev/null | head -1)
 if [[ -n "$RETRY_FILE" ]]; then
 	echo "Retry report:"
 	cat "$RETRY_FILE"
 else
-	echo "No retry report found (no tests were retried, or retries not yet enabled)"
+	echo "No intermittency report found (no tests were retried, or retries not yet enabled)"
 fi
 
 echo ""

--- a/extras/analyze-ci-crash.sh
+++ b/extras/analyze-ci-crash.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Analyze core dumps from CI test failures
+#
+# Downloads crash artifacts and build artifacts from a CI run,
+# then runs gdb in the matching container to extract stack traces.
+#
+# Usage:
+#   extras/analyze-ci-crash.sh <run-id-or-url> [--config debug|release]
+#
+# Examples:
+#   extras/analyze-ci-crash.sh 24341817865
+#   extras/analyze-ci-crash.sh https://github.com/shader-slang/slang/actions/runs/24341817865
+#   extras/analyze-ci-crash.sh 24341817865 --config debug
+#
+# Requirements:
+#   - gh CLI (authenticated)
+#   - docker
+
+set -euo pipefail
+
+REPO="shader-slang/slang"
+CONFIG="release"
+CONTAINER_IMAGE="ghcr.io/shader-slang/slang-linux-gpu-ci:v1.5.1"
+
+# Parse arguments
+RUN_ID=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--config)
+		CONFIG="$2"
+		shift 2
+		;;
+	http*)
+		# Extract run ID from URL
+		RUN_ID=$(echo "$1" | grep -oE '[0-9]{10,}')
+		shift
+		;;
+	*)
+		RUN_ID="$1"
+		shift
+		;;
+	esac
+done
+
+if [[ -z "$RUN_ID" ]]; then
+	echo "Usage: extras/analyze-ci-crash.sh <run-id-or-url> [--config debug|release]"
+	exit 1
+fi
+
+echo "=== CI Crash Analyzer ==="
+echo "Run ID: $RUN_ID"
+echo "Config: $CONFIG"
+echo ""
+
+WORK_DIR=$(mktemp -d)
+echo "Working directory: $WORK_DIR"
+
+cleanup() {
+	echo ""
+	echo "Crash data preserved at: $WORK_DIR"
+	echo "Clean up manually: rm -rf $WORK_DIR"
+}
+trap cleanup EXIT
+
+# Step 1: Check what artifacts are available
+echo ""
+echo "=== Step 1: Checking available artifacts ==="
+gh run view "$RUN_ID" --repo "$REPO" --json jobs --jq '.jobs[] | select(.conclusion == "failure") | .name' 2>&1 || true
+echo ""
+
+CRASH_ARTIFACT="crash-logs-${CONFIG}-slang-test"
+BUILD_ARTIFACT="slang-tests-linux-x86_64-gcc-${CONFIG}"
+
+echo "Looking for artifacts:"
+echo "  Crash: $CRASH_ARTIFACT"
+echo "  Build: $BUILD_ARTIFACT"
+echo ""
+
+# Step 2: Download crash artifacts
+echo "=== Step 2: Downloading crash artifacts ==="
+if ! gh run download "$RUN_ID" --repo "$REPO" --name "$CRASH_ARTIFACT" --dir "$WORK_DIR/crash" 2>&1; then
+	echo "No crash artifact found ($CRASH_ARTIFACT)"
+	echo ""
+	echo "Available artifacts:"
+	gh run download "$RUN_ID" --repo "$REPO" --pattern "*crash*" --dir "$WORK_DIR/crash" 2>&1 || true
+	gh run download "$RUN_ID" --repo "$REPO" --pattern "*retry*" --dir "$WORK_DIR/retry" 2>&1 || true
+
+	# Show retry report if available
+	if [[ -f "$WORK_DIR/retry/retry-report.json" ]]; then
+		echo ""
+		echo "=== Retry Report ==="
+		cat "$WORK_DIR/retry/retry-report.json"
+	fi
+
+	echo ""
+	echo "No core dumps found. The test server may have exited without crashing."
+	echo "Check the CI log for JSON RPC failure details:"
+	echo "  gh run view $RUN_ID --repo $REPO --log | grep 'JSON RPC failure\\|FAILED test'"
+	exit 0
+fi
+
+# Count core files
+CORE_COUNT=$(find "$WORK_DIR/crash" -name "core.*" 2>/dev/null | wc -l)
+echo "Found $CORE_COUNT core dump(s)"
+
+if [[ "$CORE_COUNT" -eq 0 ]]; then
+	echo "No core dumps in the artifact. Listing contents:"
+	find "$WORK_DIR/crash" -type f
+	exit 0
+fi
+
+# Step 3: Download build artifacts (for debug symbols)
+echo ""
+echo "=== Step 3: Downloading build artifacts ==="
+if ! gh run download "$RUN_ID" --repo "$REPO" --name "$BUILD_ARTIFACT" --dir "$WORK_DIR/build" 2>&1; then
+	echo "Warning: Could not download build artifact ($BUILD_ARTIFACT)"
+	echo "Stack traces will lack symbol names."
+fi
+
+# Step 4: Analyze each core dump
+echo ""
+echo "=== Step 4: Analyzing core dumps ==="
+
+# Find the binary path in the build artifact
+if [[ "$CONFIG" == "release" ]]; then
+	CMAKE_CONFIG="Release"
+elif [[ "$CONFIG" == "debug" ]]; then
+	CMAKE_CONFIG="Debug"
+else
+	CMAKE_CONFIG="RelWithDebInfo"
+fi
+
+for core_file in "$WORK_DIR"/crash/core.*; do
+	[[ -f "$core_file" ]] || continue
+
+	# Extract executable name from core file name (core.PID.EXECUTABLE)
+	core_basename=$(basename "$core_file")
+	exe_name=$(echo "$core_basename" | cut -d. -f3)
+	if [[ -z "$exe_name" ]]; then
+		exe_name="test-server"
+	fi
+
+	echo ""
+	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	echo "Core dump: $core_basename"
+	echo "Executable: $exe_name"
+	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+	# Find the matching binary
+	BINARY=$(find "$WORK_DIR/build" -name "$exe_name" -type f 2>/dev/null | head -1)
+	if [[ -z "$BINARY" ]]; then
+		BINARY=$(find "$WORK_DIR/build" -name "$exe_name" -o -name "${exe_name}.exe" 2>/dev/null | head -1)
+	fi
+
+	if [[ -z "$BINARY" ]]; then
+		echo "Warning: Could not find binary '$exe_name' in build artifacts"
+		echo "Attempting analysis without symbols..."
+		BINARY=""
+	else
+		echo "Binary: $BINARY"
+	fi
+
+	# Run gdb in the container for accurate library resolution
+	echo ""
+	echo "--- Backtrace ---"
+
+	GDB_COMMANDS=$(
+		cat <<'GDB_EOF'
+set pagination off
+set print thread-events off
+echo \n=== Signal Info ===\n
+info signal
+echo \n=== Backtrace (crashing thread) ===\n
+bt full 30
+echo \n=== All Thread Backtraces ===\n
+thread apply all bt 15
+echo \n=== Registers ===\n
+info registers
+quit
+GDB_EOF
+	)
+
+	if [[ -n "$BINARY" ]]; then
+		docker run --rm \
+			-v "$WORK_DIR:/analysis:ro" \
+			"$CONTAINER_IMAGE" \
+			bash -c "
+                apt-get update -qq && apt-get install -y -qq gdb >/dev/null 2>&1
+                gdb -batch \
+                    -ex 'set pagination off' \
+                    -ex 'bt full 30' \
+                    -ex 'thread apply all bt 15' \
+                    -ex 'info registers' \
+                    '/analysis/build/$CMAKE_CONFIG/bin/$exe_name' \
+                    '/analysis/crash/$core_basename' \
+                    2>&1
+            " 2>&1 || echo "(gdb analysis failed — container may not match the CI environment)"
+	else
+		echo "(No binary available for gdb analysis)"
+		echo "Core file preserved at: $core_file"
+		echo "To analyze manually:"
+		echo "  docker run --rm -it -v $WORK_DIR:/analysis $CONTAINER_IMAGE bash"
+		echo "  apt-get update && apt-get install -y gdb"
+		echo "  gdb <binary> /analysis/crash/$core_basename"
+	fi
+done
+
+# Step 5: Also show retry report if available
+echo ""
+echo "=== Step 5: Checking retry report ==="
+gh run download "$RUN_ID" --repo "$REPO" --pattern "*retry*${CONFIG}*" --dir "$WORK_DIR/retry" 2>&1 || true
+
+RETRY_FILE=$(find "$WORK_DIR/retry" -name "retry-report.json" 2>/dev/null | head -1)
+if [[ -n "$RETRY_FILE" ]]; then
+	echo "Retry report:"
+	cat "$RETRY_FILE"
+else
+	echo "No retry report found (no tests were retried, or retries not yet enabled)"
+fi
+
+echo ""
+echo "=== Analysis complete ==="

--- a/extras/analyze-intermittency-reports.sh
+++ b/extras/analyze-intermittency-reports.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
-# Analyze retry reports from recent CI runs to identify flaky tests
+# Analyze intermittency reports from recent CI runs to identify flaky tests
 #
-# Downloads retry-report.json artifacts from recent CI runs and aggregates
+# Downloads intermittency-report.json artifacts from recent CI runs and aggregates
 # them to show which tests are most frequently intermittent.
 #
 # Usage:
-#   extras/analyze-retry-reports.sh [--runs N] [--workflow NAME]
+#   extras/analyze-intermittency-reports.sh [--runs N] [--workflow NAME]
 #
 # Examples:
-#   extras/analyze-retry-reports.sh                    # Last 20 CI runs
-#   extras/analyze-retry-reports.sh --runs 50          # Last 50 runs
-#   extras/analyze-retry-reports.sh --workflow "CI"     # Specific workflow
+#   extras/analyze-intermittency-reports.sh                    # Last 20 CI runs
+#   extras/analyze-intermittency-reports.sh --runs 50          # Last 50 runs
+#   extras/analyze-intermittency-reports.sh --workflow "CI"     # Specific workflow
 #
 # Requirements:
 #   - gh CLI (authenticated)
@@ -33,7 +33,7 @@ while [[ $# -gt 0 ]]; do
 		shift 2
 		;;
 	*)
-		echo "Usage: extras/analyze-retry-reports.sh [--runs N] [--workflow NAME]"
+		echo "Usage: extras/analyze-intermittency-reports.sh [--runs N] [--workflow NAME]"
 		exit 1
 		;;
 	esac
@@ -42,7 +42,7 @@ done
 WORK_DIR=$(mktemp -d)
 trap "rm -rf $WORK_DIR" EXIT
 
-echo "=== Retry Report Analysis ==="
+echo "=== Intermittency Report Analysis ==="
 echo "Repository: $REPO"
 echo "Workflow: $WORKFLOW"
 echo "Analyzing last $NUM_RUNS runs..."
@@ -57,8 +57,8 @@ RUN_COUNT=$(echo "$RUN_IDS" | wc -l | tr -d ' ')
 echo "Found $RUN_COUNT completed runs"
 echo ""
 
-# Step 2: Download retry reports
-echo "Downloading retry reports..."
+# Step 2: Download intermittency reports
+echo "Downloading intermittency reports..."
 DOWNLOAD_COUNT=0
 REPORT_COUNT=0
 
@@ -66,23 +66,23 @@ for run_id in $RUN_IDS; do
 	DOWNLOAD_COUNT=$((DOWNLOAD_COUNT + 1))
 	printf "\r  Progress: %d/%d runs checked" "$DOWNLOAD_COUNT" "$RUN_COUNT"
 
-	# Download all retry-report artifacts for this run
+	# Download all intermittency-report artifacts for this run
 	gh run download "$run_id" --repo "$REPO" \
-		--pattern "retry-report-*" \
+		--pattern "intermittency-report-*" \
 		--dir "$WORK_DIR/$run_id" 2>/dev/null || continue
 
 	# Get run metadata
 	RUN_DATE=$(gh run view "$run_id" --repo "$REPO" --json createdAt --jq '.createdAt' 2>/dev/null | cut -dT -f1)
 
 	# Tag each report with run metadata
-	for report_dir in "$WORK_DIR/$run_id"/retry-report-*; do
+	for report_dir in "$WORK_DIR/$run_id"/intermittency-report-*; do
 		[[ -d "$report_dir" ]] || continue
-		report_file="$report_dir/retry-report.json"
+		report_file="$report_dir/intermittency-report.json"
 		[[ -f "$report_file" ]] || continue
 
-		# Extract platform info from artifact name (retry-report-<os>-<config>-slang-test)
+		# Extract platform info from artifact name (intermittency-report-<os>-<config>-slang-test)
 		artifact_name=$(basename "$report_dir")
-		platform=$(echo "$artifact_name" | sed 's/retry-report-//; s/-slang-test$//')
+		platform=$(echo "$artifact_name" | sed 's/intermittency-report-//; s/-slang-test$//')
 
 		# Add metadata to a combined file
 		jq --arg run_id "$run_id" \
@@ -99,14 +99,14 @@ echo ""
 echo ""
 
 if [[ "$REPORT_COUNT" -eq 0 ]]; then
-	echo "No retry reports found in the last $NUM_RUNS runs."
+	echo "No intermittency reports found in the last $NUM_RUNS runs."
 	echo "This means either:"
 	echo "  - No tests needed retries (good!)"
 	echo "  - Retry reporting is not yet enabled (PR #10813)"
 	exit 0
 fi
 
-echo "Found $REPORT_COUNT retry reports with data"
+echo "Found $REPORT_COUNT intermittency reports with data"
 echo ""
 
 # Step 3: Aggregate results
@@ -115,7 +115,7 @@ echo "Most frequently retried tests (last $NUM_RUNS runs)"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 # Extract all test entries with pass/fail status
-jq -r '.tests[] | "\(.name)\t\(.passed_on_retry)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null |
+jq -r '.retries.tests[] | "\(.name)\t\(.passed_on_retry)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null |
 	sort |
 	awk -F'\t' '
     {
@@ -135,7 +135,7 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo "By platform"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-jq -r '"\(.platform)\t\(.total_retried)\t\(.passed_on_retry)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null |
+jq -r '"\(.platform)\t\(.retries.total)\t\(.retries.passed_on_retry)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null |
 	awk -F'\t' '
     {
         retries[$1] += $2
@@ -155,7 +155,7 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo "Timeline (most recent first)"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-jq -r '"\(.date)\t\(.platform)\t\(.total_retried)\t\(.passed_on_retry)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null |
+jq -r '"\(.date)\t\(.platform)\t\(.retries.total)\t\(.retries.passed_on_retry)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null |
 	sort -rn |
 	awk -F'\t' '
     {
@@ -170,7 +170,7 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo "Always-fail tests (never pass on retry — likely real bugs)"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-jq -r '.tests[] | "\(.name)\t\(.passed_on_retry)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null |
+jq -r '.retries.tests[] | "\(.name)\t\(.passed_on_retry)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null |
 	sort |
 	awk -F'\t' '
     {
@@ -188,6 +188,36 @@ jq -r '.tests[] | "\(.name)\t\(.passed_on_retry)"' "$WORK_DIR/all-reports.jsonl"
         if (found == 0) print "  (none — all retried tests passed at least once)"
     }
 ' | sort -rn
+
+echo ""
+
+# Step 5: GPU crashes and core dumps
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "GPU crashes and core dumps"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+GPU_CRASHES=$(jq -r 'select(.system.gpu_crashed == true) | "\(.date)\t\(.platform)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null | wc -l | tr -d ' ')
+CORE_DUMP_RUNS=$(jq -r 'select(.system.core_dumps > 0) | "\(.date)\t\(.platform)\t\(.system.core_dumps)\t\(.system.core_files)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null)
+
+echo "  GPU crashes: $GPU_CRASHES"
+if [[ "$GPU_CRASHES" -gt 0 ]]; then
+	echo "  Runs with GPU crashes:"
+	jq -r 'select(.system.gpu_crashed == true) | "    \(.date)  \(.platform)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null
+fi
+
+CORE_COUNT=$(echo "$CORE_DUMP_RUNS" | grep -c . 2>/dev/null || echo "0")
+echo "  Runs with core dumps: $CORE_COUNT"
+if [[ -n "$CORE_DUMP_RUNS" && "$CORE_COUNT" -gt 0 ]]; then
+	echo "$CORE_DUMP_RUNS" | awk -F'\t' '{printf "    %s  %-25s %s core(s): %s\n", $1, $2, $3, $4}'
+fi
+
+# Step 6: Scheduling stopped (too many consecutive failures)
+STOPPED_COUNT=$(jq -r 'select(.scheduling_stopped == true) | "\(.date)\t\(.platform)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null | wc -l | tr -d ' ')
+echo ""
+echo "  Test scheduling stopped (cascade failure): $STOPPED_COUNT"
+if [[ "$STOPPED_COUNT" -gt 0 ]]; then
+	jq -r 'select(.scheduling_stopped == true) | "    \(.date)  \(.platform)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null
+fi
 
 echo ""
 echo "=== Analysis complete ==="

--- a/extras/analyze-retry-reports.sh
+++ b/extras/analyze-retry-reports.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Analyze retry reports from recent CI runs to identify flaky tests
+#
+# Downloads retry-report.json artifacts from recent CI runs and aggregates
+# them to show which tests are most frequently intermittent.
+#
+# Usage:
+#   extras/analyze-retry-reports.sh [--runs N] [--workflow NAME]
+#
+# Examples:
+#   extras/analyze-retry-reports.sh                    # Last 20 CI runs
+#   extras/analyze-retry-reports.sh --runs 50          # Last 50 runs
+#   extras/analyze-retry-reports.sh --workflow "CI"     # Specific workflow
+#
+# Requirements:
+#   - gh CLI (authenticated)
+#   - jq
+
+set -euo pipefail
+
+REPO="shader-slang/slang"
+NUM_RUNS=20
+WORKFLOW="CI"
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--runs)
+		NUM_RUNS="$2"
+		shift 2
+		;;
+	--workflow)
+		WORKFLOW="$2"
+		shift 2
+		;;
+	*)
+		echo "Usage: extras/analyze-retry-reports.sh [--runs N] [--workflow NAME]"
+		exit 1
+		;;
+	esac
+done
+
+WORK_DIR=$(mktemp -d)
+trap "rm -rf $WORK_DIR" EXIT
+
+echo "=== Retry Report Analysis ==="
+echo "Repository: $REPO"
+echo "Workflow: $WORKFLOW"
+echo "Analyzing last $NUM_RUNS runs..."
+echo ""
+
+# Step 1: Get recent run IDs
+RUN_IDS=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" --limit "$NUM_RUNS" \
+	--json databaseId,conclusion,createdAt \
+	--jq '.[] | select(.conclusion == "success" or .conclusion == "failure") | .databaseId')
+
+RUN_COUNT=$(echo "$RUN_IDS" | wc -l | tr -d ' ')
+echo "Found $RUN_COUNT completed runs"
+echo ""
+
+# Step 2: Download retry reports
+echo "Downloading retry reports..."
+DOWNLOAD_COUNT=0
+REPORT_COUNT=0
+
+for run_id in $RUN_IDS; do
+	DOWNLOAD_COUNT=$((DOWNLOAD_COUNT + 1))
+	printf "\r  Progress: %d/%d runs checked" "$DOWNLOAD_COUNT" "$RUN_COUNT"
+
+	# Download all retry-report artifacts for this run
+	gh run download "$run_id" --repo "$REPO" \
+		--pattern "retry-report-*" \
+		--dir "$WORK_DIR/$run_id" 2>/dev/null || continue
+
+	# Get run metadata
+	RUN_DATE=$(gh run view "$run_id" --repo "$REPO" --json createdAt --jq '.createdAt' 2>/dev/null | cut -dT -f1)
+
+	# Tag each report with run metadata
+	for report_dir in "$WORK_DIR/$run_id"/retry-report-*; do
+		[[ -d "$report_dir" ]] || continue
+		report_file="$report_dir/retry-report.json"
+		[[ -f "$report_file" ]] || continue
+
+		# Extract platform info from artifact name (retry-report-<os>-<config>-slang-test)
+		artifact_name=$(basename "$report_dir")
+		platform=$(echo "$artifact_name" | sed 's/retry-report-//; s/-slang-test$//')
+
+		# Add metadata to a combined file
+		jq --arg run_id "$run_id" \
+			--arg date "$RUN_DATE" \
+			--arg platform "$platform" \
+			'{run_id: $run_id, date: $date, platform: $platform} + .' \
+			"$report_file" >>"$WORK_DIR/all-reports.jsonl" 2>/dev/null
+
+		REPORT_COUNT=$((REPORT_COUNT + 1))
+	done
+done
+
+echo ""
+echo ""
+
+if [[ "$REPORT_COUNT" -eq 0 ]]; then
+	echo "No retry reports found in the last $NUM_RUNS runs."
+	echo "This means either:"
+	echo "  - No tests needed retries (good!)"
+	echo "  - Retry reporting is not yet enabled (PR #10813)"
+	exit 0
+fi
+
+echo "Found $REPORT_COUNT retry reports with data"
+echo ""
+
+# Step 3: Aggregate results
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Most frequently retried tests (last $NUM_RUNS runs)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Extract all test entries with pass/fail status
+jq -r '.tests[] | "\(.name)\t\(.passed_on_retry)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null |
+	sort |
+	awk -F'\t' '
+    {
+        count[$1]++
+        if ($2 == "true") passed[$1]++
+    }
+    END {
+        for (test in count) {
+            p = (test in passed) ? passed[test] : 0
+            printf "%4d  %-70s [%d/%d passed on retry]\n", count[test], test, p, count[test]
+        }
+    }
+' | sort -rn
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "By platform"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+jq -r '"\(.platform)\t\(.total_retried)\t\(.passed_on_retry)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null |
+	awk -F'\t' '
+    {
+        retries[$1] += $2
+        passed[$1] += $3
+        runs[$1]++
+    }
+    END {
+        for (platform in retries) {
+            printf "  %-25s %3d retries across %2d runs (%d passed on retry)\n",
+                platform ":", retries[platform], runs[platform], passed[platform]
+        }
+    }
+' | sort -t: -k2 -rn
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Timeline (most recent first)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+jq -r '"\(.date)\t\(.platform)\t\(.total_retried)\t\(.passed_on_retry)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null |
+	sort -rn |
+	awk -F'\t' '
+    {
+        printf "  %s  %-25s %2d retried, %2d passed on retry\n", $1, $2, $3, $4
+    }
+'
+
+echo ""
+
+# Step 4: Identify always-fail tests (never pass on retry)
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Always-fail tests (never pass on retry — likely real bugs)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+jq -r '.tests[] | "\(.name)\t\(.passed_on_retry)"' "$WORK_DIR/all-reports.jsonl" 2>/dev/null |
+	sort |
+	awk -F'\t' '
+    {
+        count[$1]++
+        if ($2 == "true") passed[$1]++
+    }
+    END {
+        found = 0
+        for (test in count) {
+            if (!(test in passed) && count[test] >= 2) {
+                printf "%4d  %s\n", count[test], test
+                found++
+            }
+        }
+        if (found == 0) print "  (none — all retried tests passed at least once)"
+    }
+' | sort -rn
+
+echo ""
+echo "=== Analysis complete ==="

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -6130,30 +6130,42 @@ SlangResult innerMain(int argc, char** argv)
                         passedCount,
                         (int)retryResults.getCount());
 
-                    // Write retry report as JSON for CI artifact collection
-                    FILE* reportFile = fopen("retry-report.json", "w");
+                    // Write intermittency report as JSON for CI artifact collection
+                    FILE* reportFile = fopen("intermittency-report.json", "w");
                     if (reportFile)
                     {
                         fprintf(reportFile, "{\n");
+                        fprintf(reportFile, "  \"retries\": {\n");
                         fprintf(
                             reportFile,
-                            "  \"total_retried\": %d,\n",
+                            "    \"total\": %d,\n",
                             (int)retryResults.getCount());
-                        fprintf(reportFile, "  \"passed_on_retry\": %d,\n", passedCount);
-                        fprintf(reportFile, "  \"tests\": [\n");
+                        fprintf(
+                            reportFile,
+                            "    \"passed_on_retry\": %d,\n",
+                            passedCount);
+                        fprintf(reportFile, "    \"tests\": [\n");
                         for (Index i = 0; i < retryResults.getCount(); i++)
                         {
                             auto& rr = retryResults[i];
                             fprintf(
                                 reportFile,
-                                "    {\"name\": \"%s\", \"passed_on_retry\": %s}%s\n",
+                                "      {\"name\": \"%s\", \"passed_on_retry\": %s}%s\n",
                                 rr.testName.getBuffer(),
                                 rr.passedOnRetry ? "true" : "false",
                                 (i < retryResults.getCount() - 1) ? "," : "");
                         }
-                        fprintf(reportFile, "  ]\n}\n");
+                        fprintf(reportFile, "    ]\n");
+                        fprintf(reportFile, "  },\n");
+                        fprintf(
+                            reportFile,
+                            "  \"scheduling_stopped\": %s\n",
+                            context.stopSchedulingTests.load() ? "true" : "false");
+                        fprintf(reportFile, "}\n");
                         fclose(reportFile);
-                        printf("Retry report written to retry-report.json\n");
+                        printf(
+                            "Intermittency report written to "
+                            "intermittency-report.json\n");
                     }
                 }
             }

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -6080,9 +6080,20 @@ SlangResult innerMain(int argc, char** argv)
             if (context.failedFileTests.getCount() <= kFailedTestLimitForRetry)
             {
                 if (context.failedFileTests.getCount() > 0)
+                {
                     printf(
                         "Retrying %d failed tests...\n",
                         (int)context.failedFileTests.getCount());
+                    printf("Tests to retry:\n");
+                    for (auto& test : context.failedFileTests)
+                    {
+                        FileTestInfoImpl* fileTestInfo =
+                            static_cast<FileTestInfoImpl*>(test.Ptr());
+                        printf("  - %s\n", fileTestInfo->testName.getBuffer());
+                    }
+                }
+                int retriedCount = 0;
+                int retryPassedCount = 0;
                 for (auto& test : context.failedFileTests)
                 {
                     context.isRetry = true;
@@ -6096,6 +6107,23 @@ SlangResult innerMain(int argc, char** argv)
                         fileTestInfo->testName,
                         fileTestInfo->options);
                     reporter.addResult(newResult);
+                    retriedCount++;
+                    if (newResult == TestResult::Pass)
+                        retryPassedCount++;
+                }
+                if (retriedCount > 0)
+                {
+                    printf(
+                        "\nRetry summary: %d/%d tests passed on retry "
+                        "(intermittent failures)\n",
+                        retryPassedCount,
+                        retriedCount);
+                    if (retryPassedCount < retriedCount)
+                    {
+                        printf("Tests that still failed after retry:\n");
+                        // The reporter already has the results, so we just note
+                        // this for visibility
+                    }
                 }
             }
             else

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -6092,8 +6092,13 @@ SlangResult innerMain(int argc, char** argv)
                         printf("  - %s\n", fileTestInfo->testName.getBuffer());
                     }
                 }
-                int retriedCount = 0;
-                int retryPassedCount = 0;
+                struct RetryResult
+                {
+                    String testName;
+                    bool passedOnRetry;
+                };
+                List<RetryResult> retryResults;
+
                 for (auto& test : context.failedFileTests)
                 {
                     context.isRetry = true;
@@ -6107,22 +6112,48 @@ SlangResult innerMain(int argc, char** argv)
                         fileTestInfo->testName,
                         fileTestInfo->options);
                     reporter.addResult(newResult);
-                    retriedCount++;
-                    if (newResult == TestResult::Pass)
-                        retryPassedCount++;
+                    RetryResult rr;
+                    rr.testName = fileTestInfo->testName;
+                    rr.passedOnRetry = (newResult == TestResult::Pass);
+                    retryResults.add(rr);
                 }
-                if (retriedCount > 0)
+                if (retryResults.getCount() > 0)
                 {
+                    int passedCount = 0;
+                    for (auto& rr : retryResults)
+                        if (rr.passedOnRetry)
+                            passedCount++;
+
                     printf(
                         "\nRetry summary: %d/%d tests passed on retry "
                         "(intermittent failures)\n",
-                        retryPassedCount,
-                        retriedCount);
-                    if (retryPassedCount < retriedCount)
+                        passedCount,
+                        (int)retryResults.getCount());
+
+                    // Write retry report as JSON for CI artifact collection
+                    FILE* reportFile = fopen("retry-report.json", "w");
+                    if (reportFile)
                     {
-                        printf("Tests that still failed after retry:\n");
-                        // The reporter already has the results, so we just note
-                        // this for visibility
+                        fprintf(reportFile, "{\n");
+                        fprintf(
+                            reportFile,
+                            "  \"total_retried\": %d,\n",
+                            (int)retryResults.getCount());
+                        fprintf(reportFile, "  \"passed_on_retry\": %d,\n", passedCount);
+                        fprintf(reportFile, "  \"tests\": [\n");
+                        for (Index i = 0; i < retryResults.getCount(); i++)
+                        {
+                            auto& rr = retryResults[i];
+                            fprintf(
+                                reportFile,
+                                "    {\"name\": \"%s\", \"passed_on_retry\": %s}%s\n",
+                                rr.testName.getBuffer(),
+                                rr.passedOnRetry ? "true" : "false",
+                                (i < retryResults.getCount() - 1) ? "," : "");
+                        }
+                        fprintf(reportFile, "  ]\n}\n");
+                        fclose(reportFile);
+                        printf("Retry report written to retry-report.json\n");
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Collect intermittency data from all CI test runs (Linux GPU, Windows, macOS)
- Enable core dumps and automated stack trace analysis in Linux GPU CI
- Provide scripts for offline crash analysis and flaky test trend analysis

## Motivation
CI tests fail intermittently with "JSON RPC failure" when test server processes crash. Three patterns observed:
1. Vulkan test server cascade crash (one server dies, 20+ subsequent Vulkan tests fail)
2. GFX Vulkan instance creation failure (all 24 Vulkan unit tests)
3. CPU test server crash under ASAN

No diagnostic data is collected, and the retry logic runs silently.

## Changes

### `intermittency-report.json` — collected from every CI run

Written by slang-test (retries) and enriched by CI workflow (system data):
```json
{
  "retries": {
    "total": 3, "passed_on_retry": 2,
    "tests": [{"name": "...", "passed_on_retry": true}]
  },
  "scheduling_stopped": false,
  "system": {
    "gpu_crashed": false,
    "gpu_info": "Tesla T4, 535.183.01, ...",
    "core_dumps": 0,
    "core_files": ""
  }
}
```

### CI workflows
- **`ci-slang-test-container.yml`** (Linux GPU):
  - Enable core dumps (`ulimit -c unlimited`)
  - Analyze core dumps in-place with gdb (stack traces in CI log)
  - Enrich intermittency report with GPU state and core dump info
  - Upload crash artifacts (3-day) and intermittency report (30-day)
- **`ci-slang-test.yml`** (Windows, macOS):
  - Upload intermittency report (30-day)

### Container (`docker/linux-gpu-ci.Dockerfile`)
- Add `gdb` for in-place core dump analysis

### slang-test (`tools/slang-test/slang-test-main.cpp`)
- Log which tests are being retried
- Print retry summary (N/M passed on retry)
- Write `intermittency-report.json` with per-test results

### Scripts
- **`extras/analyze-intermittency-reports.sh`** — download reports from last N CI runs, show:
  - Most frequently retried tests with pass-on-retry rate
  - Breakdown by platform
  - Timeline of retries per run
  - Always-fail tests (never pass on retry)
  - GPU crashes and core dumps
  - Scheduling stopped (cascade failures)
- **`extras/analyze-ci-crash.sh`** — download crash artifacts from a specific CI run, run gdb in matching container for stack trace extraction

## Post-merge steps
Rebuild and push the GPU CI container with gdb:
```bash
docker build -f docker/linux-gpu-ci.Dockerfile -t ghcr.io/shader-slang/slang-linux-gpu-ci:v1.6.0 .
docker push ghcr.io/shader-slang/slang-linux-gpu-ci:v1.6.0
```
Then update container version references in workflows.

## Related
- #10812

## Test plan
- [ ] `intermittency-report.json` uploaded from all platforms
- [ ] Core dump analysis prints stack trace in CI log on crash
- [ ] `extras/analyze-intermittency-reports.sh` aggregates data
- [ ] `extras/analyze-ci-crash.sh` works for offline analysis
- [ ] No regression in test pass rate