### PR TITLE
Add [RemovedSince] for scheduled declaration removal

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -4690,8 +4690,35 @@ attribute_syntax [noinline] : NoInlineAttribute;
 
 /// Mark a declaration as deprecated.
 /// @param message The diagnostic message to show when the declaration is used.
+///
+/// @see `[RemovedSince]`.
 __attributeTarget(DeclBase)
 attribute_syntax [deprecated(message: String)] : DeprecatedAttribute;
+
+/// Mark a declaration as removed starting from the specified language version.
+///
+/// @param languageVersion  The first version from which the declaration is considered removed.
+/// @param message The diagnostic message to show when the declaration is used.
+///
+/// This attribute is used for a scheduled removal of a declaration.
+///
+/// An error is triggered when a declaration tagged with
+/// `[RemovedSince]` is referenced by a module that is compiled with
+/// language version `languageVersion` or higher.
+/// When an error is triggered due to removal, a possible
+/// `[deprecated]` attribute decoration for the same declaration is ignored.
+///
+/// It is not required that `languageVersion` match a version
+/// that is supported by `slangc`. This allows removal
+/// of declarations from future language versions. Value `-1`
+/// marks the declaration as removed from all language versions.
+///
+/// When a declaration is slated for removal, it is recommended to
+/// also tag it with the `[deprecated]` attribute.
+///
+/// @see `[deprecated]`.
+__attributeTarget(DeclBase)
+attribute_syntax [RemovedSince(languageVersion: int, message: String)] : RemovedSinceAttribute;
 
 /// Controls the behavior of the compiler when a differentiable function is detected to have side-effects.
 /// @category misc_types

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -1988,6 +1988,17 @@ class DeprecatedAttribute : public Attribute
     FIDDLE() String message;
 };
 
+/// A `[removedSince(languageVersion, "message")]` attribute indicates that the
+/// target has been removed since the specified language version.
+///
+FIDDLE()
+class RemovedSinceAttribute : public Attribute
+{
+    FIDDLE(...)
+    FIDDLE() int32_t sinceVersion;
+    FIDDLE() String message;
+};
+
 FIDDLE()
 class NonCopyableTypeAttribute : public Attribute
 {

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -1988,8 +1988,8 @@ class DeprecatedAttribute : public Attribute
     FIDDLE() String message;
 };
 
-/// A `[removedSince(languageVersion, "message")]` attribute indicates that the
-/// target has been removed since the specified language version.
+/// A `[RemovedSince(languageVersion, "message")]` attribute indicates that the
+/// target has been removed starting from the specified language version.
 ///
 FIDDLE()
 class RemovedSinceAttribute : public Attribute

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -325,6 +325,15 @@ void SemanticsVisitor::diagnoseDeprecatedDeclRefUsage(
     {
         return;
     }
+
+    // If the expression location is the same as the declaration location, don't
+    // diagnose. This avoids diagnosing struct member fields which get
+    // referenced by synthesized constructors etc.
+    if (declRef.getDecl() && originalExpr && (declRef.getDecl()->getNameLoc() == originalExpr->loc))
+    {
+        return;
+    }
+
     if (auto deprecatedAttr = declRef.getDecl()->findModifier<DeprecatedAttribute>())
     {
         getSink()->diagnose(Diagnostics::DeprecatedUsage{

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -299,7 +299,7 @@ ContainerDecl* isStaticScopeDecl(Decl* decl)
     return nullptr;
 }
 
-void SemanticsVisitor::diagnoseDeprecatedDeclRefUsage(
+void SemanticsVisitor::diagnoseDeprecatedAndRemovedDeclRefUsage(
     DeclRef<Decl> declRef,
     SourceLoc loc,
     Expr* originalExpr)
@@ -334,6 +334,30 @@ void SemanticsVisitor::diagnoseDeprecatedDeclRefUsage(
         return;
     }
 
+    // Check if we're using a removed declaration
+    if (auto removedSinceAttr = declRef.getDecl()->findModifier<RemovedSinceAttribute>())
+    {
+        if (auto declRefExpr = as<DeclRefExpr>(originalExpr))
+        {
+            SLANG_ASSERT(declRefExpr->scope != nullptr);
+
+            auto exprModule = getModuleDecl(declRefExpr->scope);
+            SLANG_ASSERT(exprModule != nullptr);
+
+            if (exprModule->languageVersion >= removedSinceAttr->sinceVersion)
+            {
+                getSink()->diagnose(Diagnostics::RemovedUsage{
+                        .declName = declRef.getName(),
+                        .sinceVersion = removedSinceAttr->sinceVersion,
+                        .message = removedSinceAttr->message,
+                        .location = loc});
+
+                return;
+            }
+        }
+    }
+
+    // Check if we're using a deprecated declaration
     if (auto deprecatedAttr = declRef.getDecl()->findModifier<DeprecatedAttribute>())
     {
         getSink()->diagnose(Diagnostics::DeprecatedUsage{
@@ -387,7 +411,7 @@ DeclRefExpr* SemanticsVisitor::ConstructDeclRefExpr(
     // This is the bottleneck for using declarations which might be
     // deprecated, diagnose here.
     if (getSink())
-        diagnoseDeprecatedDeclRefUsage(declRef, loc, originalExpr);
+        diagnoseDeprecatedAndRemovedDeclRefUsage(declRef, loc, originalExpr);
 
     // Construct an appropriate expression based on the structured of
     // the declaration reference.

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -347,10 +347,10 @@ void SemanticsVisitor::diagnoseDeprecatedAndRemovedDeclRefUsage(
             if (exprModule->languageVersion >= removedSinceAttr->sinceVersion)
             {
                 getSink()->diagnose(Diagnostics::RemovedUsage{
-                        .declName = declRef.getName(),
-                        .sinceVersion = removedSinceAttr->sinceVersion,
-                        .message = removedSinceAttr->message,
-                        .location = loc});
+                    .declName = declRef.getName(),
+                    .sinceVersion = removedSinceAttr->sinceVersion,
+                    .message = removedSinceAttr->message,
+                    .location = loc});
 
                 return;
             }

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -304,6 +304,19 @@ void SemanticsVisitor::diagnoseDeprecatedAndRemovedDeclRefUsage(
     SourceLoc loc,
     Expr* originalExpr)
 {
+    // Resolve the module for the context
+    ModuleDecl* moduleDecl = getModuleDecl(getOuterScope());
+
+    // If we don't get the module declaration from the outer scope, we'll
+    // try the visitor context
+    if (!moduleDecl && getShared() && getShared()->getModule())
+        moduleDecl = getShared()->getModule()->getModuleDecl();
+
+    // And if we can't figure out a module, we're called in a context where we
+    // don't care about the deprecation attributes
+    if (!moduleDecl)
+        return;
+
     // This is slightly subtle, because we don't want to warn more than
     // once for the same occurrence, however in some cases this function is
     // called more than once for the same declref (specifically in the case
@@ -337,27 +350,15 @@ void SemanticsVisitor::diagnoseDeprecatedAndRemovedDeclRefUsage(
     // Check whether we're using a removed declaration
     if (auto removedSinceAttr = declRef.getDecl()->findModifier<RemovedSinceAttribute>())
     {
-        // resolve the effective scope for the expression
-        Scope* exprScope = nullptr;
-        if (auto declRefExpr = as<DeclRefExpr>(originalExpr))
-            exprScope = declRefExpr->scope;
-        if (!exprScope)
-            exprScope = getOuterScope();
-
-        // Then figure out the module where the scope belongs. That's what we'll
-        // use for the language version.
-        if (auto exprModule = exprScope ? getModuleDecl(exprScope) : nullptr)
+        if (moduleDecl->languageVersion >= removedSinceAttr->sinceVersion)
         {
-            if (exprModule->languageVersion >= removedSinceAttr->sinceVersion)
-            {
-                getSink()->diagnose(Diagnostics::RemovedUsage{
-                        .declName = declRef.getName(),
-                        .sinceVersion = removedSinceAttr->sinceVersion,
-                        .message = removedSinceAttr->message,
-                        .location = loc});
+            getSink()->diagnose(Diagnostics::RemovedUsage{
+                    .declName = declRef.getName(),
+                    .sinceVersion = removedSinceAttr->sinceVersion,
+                    .message = removedSinceAttr->message,
+                    .location = loc});
 
-                return;
-            }
+            return;
         }
     }
 

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -334,30 +334,34 @@ void SemanticsVisitor::diagnoseDeprecatedAndRemovedDeclRefUsage(
         return;
     }
 
-    // Check if we're using a removed declaration
+    // Check whether we're using a removed declaration
     if (auto removedSinceAttr = declRef.getDecl()->findModifier<RemovedSinceAttribute>())
     {
+        // resolve the effective scope for the expression
+        Scope* exprScope = nullptr;
         if (auto declRefExpr = as<DeclRefExpr>(originalExpr))
+            exprScope = declRefExpr->scope;
+        if (!exprScope)
+            exprScope = getOuterScope();
+
+        // Then figure out the module where the scope belongs. That's what we'll
+        // use for the language version.
+        if (auto exprModule = exprScope ? getModuleDecl(exprScope) : nullptr)
         {
-            SLANG_ASSERT(declRefExpr->scope != nullptr);
-
-            auto exprModule = getModuleDecl(declRefExpr->scope);
-            SLANG_ASSERT(exprModule != nullptr);
-
             if (exprModule->languageVersion >= removedSinceAttr->sinceVersion)
             {
                 getSink()->diagnose(Diagnostics::RemovedUsage{
-                    .declName = declRef.getName(),
-                    .sinceVersion = removedSinceAttr->sinceVersion,
-                    .message = removedSinceAttr->message,
-                    .location = loc});
+                        .declName = declRef.getName(),
+                        .sinceVersion = removedSinceAttr->sinceVersion,
+                        .message = removedSinceAttr->message,
+                        .location = loc});
 
                 return;
             }
         }
     }
 
-    // Check if we're using a deprecated declaration
+    // Check whether we're using a deprecated declaration
     if (auto deprecatedAttr = declRef.getDecl()->findModifier<DeprecatedAttribute>())
     {
         getSink()->diagnose(Diagnostics::DeprecatedUsage{

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -353,10 +353,10 @@ void SemanticsVisitor::diagnoseDeprecatedAndRemovedDeclRefUsage(
         if (moduleDecl->languageVersion >= removedSinceAttr->sinceVersion)
         {
             getSink()->diagnose(Diagnostics::RemovedUsage{
-                    .declName = declRef.getName(),
-                    .sinceVersion = removedSinceAttr->sinceVersion,
-                    .message = removedSinceAttr->message,
-                    .location = loc});
+                .declName = declRef.getName(),
+                .sinceVersion = removedSinceAttr->sinceVersion,
+                .message = removedSinceAttr->message,
+                .location = loc});
 
             return;
         }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1477,7 +1477,7 @@ public:
 
     Scope* getScope(SyntaxNode* node);
 
-    void diagnoseDeprecatedDeclRefUsage(DeclRef<Decl> declRef, SourceLoc loc, Expr* originalExpr);
+    void diagnoseDeprecatedAndRemovedDeclRefUsage(DeclRef<Decl> declRef, SourceLoc loc, Expr* originalExpr);
 
     DeclRef<Decl> getDefaultDeclRef(Decl* decl)
     {

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1477,7 +1477,10 @@ public:
 
     Scope* getScope(SyntaxNode* node);
 
-    void diagnoseDeprecatedAndRemovedDeclRefUsage(DeclRef<Decl> declRef, SourceLoc loc, Expr* originalExpr);
+    void diagnoseDeprecatedAndRemovedDeclRefUsage(
+        DeclRef<Decl> declRef,
+        SourceLoc loc,
+        Expr* originalExpr);
 
     DeclRef<Decl> getDefaultDeclRef(Decl* decl)
     {

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -1125,8 +1125,7 @@ Modifier* SemanticsVisitor::validateAttribute(
 
         const int32_t kMinVersion = -1;
         const int32_t kMaxVersion = 9999;
-        if ((sinceVersion->getValue() < kMinVersion) ||
-            (sinceVersion->getValue() > kMaxVersion))
+        if ((sinceVersion->getValue() < kMinVersion) || (sinceVersion->getValue() > kMaxVersion))
         {
             getSink()->diagnose(Diagnostics::RemovedSinceBadVersion{
                 .minVersion = kMinVersion,

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -1113,6 +1113,37 @@ Modifier* SemanticsVisitor::validateAttribute(
 
         deprecatedAttr->message = message;
     }
+    else if (auto removedSinceAttr = as<RemovedSinceAttribute>(attr))
+    {
+        SLANG_ASSERT(attr->args.getCount() == 2);
+
+        auto sinceVersion = checkConstantIntVal(attr->args[0]);
+        if (sinceVersion == nullptr)
+        {
+            return nullptr;
+        }
+
+        const int32_t kMinVersion = -1;
+        const int32_t kMaxVersion = 9999;
+        if ((sinceVersion->getValue() < kMinVersion) ||
+            (sinceVersion->getValue() > kMaxVersion))
+        {
+            getSink()->diagnose(Diagnostics::RemovedSinceBadVersion{
+                .minVersion = kMinVersion,
+                .maxVersion = kMaxVersion,
+                .location = removedSinceAttr->loc});
+            return nullptr;
+        }
+
+        String message;
+        if (!checkLiteralStringVal(attr->args[1], &message))
+        {
+            return nullptr;
+        }
+
+        removedSinceAttr->sinceVersion = int32_t(sinceVersion->getValue());
+        removedSinceAttr->message = message;
+    }
     else if (auto knownBuiltinAttr = as<KnownBuiltinAttribute>(attr))
     {
         SLANG_ASSERT(attr->args.getCount() == 1);

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -2599,10 +2599,24 @@ err(
 )
 
 err(
+    "removed-usage",
+    31207,
+    "use of removed declaration",
+    span { loc = "location", message = "~declName:Name has been removed since language version '~sinceVersion:Int': ~message" }
+)
+
+err(
     "require-input-decorated-var-for-parameter",
     31208,
     "shader input required",
     span { loc = "expr:Expr", message = "~func:Decl expects for argument ~paramNumber:Int a type which is a shader input (`in`) variable." }
+)
+
+err(
+    "removed-since-bad-version",
+    31209,
+    "'RemovedSince' argument 'version' exceeds allowed range",
+    span { loc = "location", message = "valid range: [~minVersion:Int, ~maxVersion:Int]" }
 )
 
 -- 3121x - Derivative group requirements

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -2615,7 +2615,7 @@ err(
 err(
     "removed-since-bad-version",
     31209,
-    "'RemovedSince' argument 'version' exceeds allowed range",
+    "'RemovedSince' argument 'version' is outside allowed range",
     span { loc = "location", message = "valid range: [~minVersion:Int, ~maxVersion:Int]" }
 )
 

--- a/tests/diagnostics/deprecation.slang
+++ b/tests/diagnostics/deprecation.slang
@@ -21,10 +21,6 @@ struct Billiards
 {
     [deprecated("puns")]
     bool bs[22];
-//diag:  ^^ use of deprecated declaration
-//diag:  ^^ bs has been deprecated: puns
-//diag:  ^^ use of deprecated declaration
-//diag:  ^^ bs has been deprecated: puns
 }
 
 int main()

--- a/tests/language-feature/api-deprecation.slang
+++ b/tests/language-feature/api-deprecation.slang
@@ -57,8 +57,13 @@ extension DeprecatedStruct
     }
 }
 
-[deprecated("This function is deprecated")]
-void deprecatedFunction()
+[deprecated("This function overload is deprecated")]
+void someFunction(int a)
+{
+}
+
+// calling this won't warn
+void someFunction(double a)
 {
 }
 
@@ -92,11 +97,15 @@ void main(uint3 threadId : SV_DispatchThreadID)
 //CHECK:     ^^^^^^^^^^^ use of deprecated declaration
 //CHECK:     ^^^^^^^^^^^ IDeprecated has been deprecated: This interface is deprecated
 
-    deprecatedFunction();
+    someFunction(5);
 /*CHECK:
-    ^^^^^^^^^^^^^^^^^^ use of deprecated declaration
-    ^^^^^^^^^^^^^^^^^^ deprecatedFunction has been deprecated: This function is deprecated
+    ^^^^^^^^^^^^ use of deprecated declaration
+    ^^^^^^^^^^^^ someFunction has been deprecated: This function overload is deprecated
 */
+
+    // no warning from this
+    someFunction(5.0);
+
 
     s.deprecatedExtendedFunction();
 /*CHECK:

--- a/tests/language-feature/api-deprecation.slang
+++ b/tests/language-feature/api-deprecation.slang
@@ -65,6 +65,12 @@ void deprecatedFunction()
 [deprecated("This typealias is deprecated")]
 typealias DeprecatedTypeDef = int;
 
+[deprecated("This enum is deprecated")]
+enum DeprecatedEnum
+{
+    DeprecatedValue, // note: enum values cannot be decorated with attributes
+};
+
 [numthreads(1,1,1)]
 void main(uint3 threadId : SV_DispatchThreadID)
 {
@@ -98,4 +104,11 @@ void main(uint3 threadId : SV_DispatchThreadID)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^ deprecatedExtendedFunction has been deprecated: This extension-provided member function is deprecated
 */
 
+    var e : DeprecatedEnum;
+//CHECK:    ^^^^^^^^^^^^^^ use of deprecated declaration
+//CHECK:    ^^^^^^^^^^^^^^ DeprecatedEnum has been deprecated: This enum is deprecated
+
+    var ev = DeprecatedEnum.DeprecatedValue;
+//CHECK:     ^^^^^^^^^^^^^^ use of deprecated declaration
+//CHECK:     ^^^^^^^^^^^^^^ DeprecatedEnum has been deprecated: This enum is deprecated
 }

--- a/tests/language-feature/api-deprecation.slang
+++ b/tests/language-feature/api-deprecation.slang
@@ -1,0 +1,101 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):
+
+// This test verifies various things that can be marked as deprecated
+
+[deprecated("This interface is deprecated")]
+interface IDeprecated
+{
+
+}
+
+struct UserOfDeprecatedInterface : IDeprecated
+//CHECK:                           ^^^^^^^^^^^ use of deprecated declaration
+//CHECK:                           ^^^^^^^^^^^ IDeprecated has been deprecated: This interface is deprecated
+{
+
+};
+
+[deprecated("This struct is deprecated")]
+struct DeprecatedStruct
+{
+
+    [deprecated("This field is deprecated")]
+    int deprecatedField;
+
+
+    __init(int initialFieldValue)
+    {
+        deprecatedField = initialFieldValue;
+//CHECK:^^^^^^^^^^^^^^^ use of deprecated declaration
+//CHECK:^^^^^^^^^^^^^^^ deprecatedField has been deprecated: This field is deprecated
+    }
+
+    [mutating]
+    void decrementDeprecatedField()
+    {
+        --deprecatedField;
+//CHECK:  ^^^^^^^^^^^^^^^ use of deprecated declaration
+//CHECK:  ^^^^^^^^^^^^^^^ deprecatedField has been deprecated: This field is deprecated
+    }
+}
+
+extension DeprecatedStruct
+//CHECK:  ^^^^^^^^^^^^^^^^ use of deprecated declaration
+//CHECK:  ^^^^^^^^^^^^^^^^ DeprecatedStruct has been deprecated: This struct is deprecated
+{
+    [deprecated("This extension-provided member function is deprecated")]
+    void deprecatedExtendedFunction()
+    {
+    }
+
+    [mutating]
+    void incrementDeprecatedField()
+    {
+        ++deprecatedField;
+//CHECK:  ^^^^^^^^^^^^^^^ use of deprecated declaration
+//CHECK:  ^^^^^^^^^^^^^^^ deprecatedField has been deprecated: This field is deprecated
+    }
+}
+
+[deprecated("This function is deprecated")]
+void deprecatedFunction()
+{
+}
+
+[deprecated("This typealias is deprecated")]
+typealias DeprecatedTypeDef = int;
+
+[numthreads(1,1,1)]
+void main(uint3 threadId : SV_DispatchThreadID)
+{
+    var v : DeprecatedTypeDef;
+//CHECK:    ^^^^^^^^^^^^^^^^^ use of deprecated declaration
+//CHECK:    ^^^^^^^^^^^^^^^^^ DeprecatedTypeDef has been deprecated: This typealias is deprecated
+
+    var s : DeprecatedStruct;
+//CHECK:    ^^^^^^^^^^^^^^^^ use of deprecated declaration
+//CHECK:    ^^^^^^^^^^^^^^^^ DeprecatedStruct has been deprecated: This struct is deprecated
+
+    s.deprecatedField = 1;
+/*CHECK:
+      ^^^^^^^^^^^^^^^ use of deprecated declaration
+      ^^^^^^^^^^^^^^^ deprecatedField has been deprecated: This field is deprecated
+*/
+
+    var if : IDeprecated;
+//CHECK:     ^^^^^^^^^^^ use of deprecated declaration
+//CHECK:     ^^^^^^^^^^^ IDeprecated has been deprecated: This interface is deprecated
+
+    deprecatedFunction();
+/*CHECK:
+    ^^^^^^^^^^^^^^^^^^ use of deprecated declaration
+    ^^^^^^^^^^^^^^^^^^ deprecatedFunction has been deprecated: This function is deprecated
+*/
+
+    s.deprecatedExtendedFunction();
+/*CHECK:
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of deprecated declaration
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ deprecatedExtendedFunction has been deprecated: This extension-provided member function is deprecated
+*/
+
+}

--- a/tests/language-feature/api-removed-since-1.slang
+++ b/tests/language-feature/api-removed-since-1.slang
@@ -57,8 +57,13 @@ extension RemovedStruct
     }
 }
 
-[RemovedSince(-1, "This function is removed")]
-void removedFunction()
+[RemovedSince(-1, "This function overload is removed")]
+void someFunction(int a)
+{
+}
+
+// not removed
+void someFunction(double a)
 {
 }
 
@@ -92,11 +97,15 @@ void main(uint3 threadId : SV_DispatchThreadID)
 //CHECK:     ^^^^^^^^ use of removed declaration
 //CHECK:     ^^^^^^^^ IRemoved has been removed since language version '-1': This interface is removed
 
-    removedFunction();
+    someFunction(5);
 /*CHECK:
-    ^^^^^^^^^^^^^^^ use of removed declaration
-    ^^^^^^^^^^^^^^^ removedFunction has been removed since language version '-1': This function is removed
+    ^^^^^^^^^^^^ use of removed declaration
+    ^^^^^^^^^^^^ someFunction has been removed since language version '-1': This function overload is removed
 */
+
+    // calling this is ok
+    someFunction(5.0);
+
 
     s.removedExtendedFunction();
 /*CHECK:

--- a/tests/language-feature/api-removed-since-1.slang
+++ b/tests/language-feature/api-removed-since-1.slang
@@ -65,6 +65,12 @@ void removedFunction()
 [RemovedSince(-1, "This typealias is removed")]
 typealias RemovedTypeDef = int;
 
+[RemovedSince(-1, "This enum is removed")]
+enum RemovedEnum
+{
+    RemovedValue, // note: enum values cannot be decorated with attributes
+};
+
 [numthreads(1,1,1)]
 void main(uint3 threadId : SV_DispatchThreadID)
 {
@@ -97,5 +103,13 @@ void main(uint3 threadId : SV_DispatchThreadID)
       ^^^^^^^^^^^^^^^^^^^^^^^ use of removed declaration
       ^^^^^^^^^^^^^^^^^^^^^^^ removedExtendedFunction has been removed since language version '-1': This extension-provided member function is removed
 */
+
+    var e : RemovedEnum;
+//CHECK:    ^^^^^^^^^^^ use of removed declaration
+//CHECK:    ^^^^^^^^^^^ RemovedEnum has been removed since language version '-1': This enum is removed
+
+    var ev = RemovedEnum.RemovedValue;
+//CHECK:     ^^^^^^^^^^^ use of removed declaration
+//CHECK:     ^^^^^^^^^^^ RemovedEnum has been removed since language version '-1': This enum is removed
 
 }

--- a/tests/language-feature/api-removed-since-1.slang
+++ b/tests/language-feature/api-removed-since-1.slang
@@ -1,0 +1,101 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):
+
+// This test verifies various things that can be marked as removed.
+
+[RemovedSince(-1, "This interface is removed")]
+interface IRemoved
+{
+
+}
+
+struct UserOfRemovedInterface : IRemoved
+//CHECK:                        ^^^^^^^^ use of removed declaration
+//CHECK:                        ^^^^^^^^ IRemoved has been removed since language version '-1': This interface is removed
+{
+
+};
+
+[RemovedSince(-1, "This struct is removed")]
+struct RemovedStruct
+{
+
+    [RemovedSince(-1, "This field is removed")]
+    int removedField;
+
+
+    __init(int initialFieldValue)
+    {
+        removedField = initialFieldValue;
+//CHECK:^^^^^^^^^^^^ use of removed declaration
+//CHECK:^^^^^^^^^^^^ removedField has been removed since language version '-1': This field is removed
+    }
+
+    [mutating]
+    void decrementRemovedField()
+    {
+        --removedField;
+//CHECK:  ^^^^^^^^^^^^ use of removed declaration
+//CHECK:  ^^^^^^^^^^^^ removedField has been removed since language version '-1': This field is removed
+    }
+}
+
+extension RemovedStruct
+//CHECK:  ^^^^^^^^^^^^^ use of removed declaration
+//CHECK:  ^^^^^^^^^^^^^ RemovedStruct has been removed since language version '-1': This struct is removed
+{
+    [RemovedSince(-1, "This extension-provided member function is removed")]
+    void removedExtendedFunction()
+    {
+    }
+
+    [mutating]
+    void incrementRemovedField()
+    {
+        ++removedField;
+//CHECK:  ^^^^^^^^^^^^ use of removed declaration
+//CHECK:  ^^^^^^^^^^^^ removedField has been removed since language version '-1': This field is removed
+    }
+}
+
+[RemovedSince(-1, "This function is removed")]
+void removedFunction()
+{
+}
+
+[RemovedSince(-1, "This typealias is removed")]
+typealias RemovedTypeDef = int;
+
+[numthreads(1,1,1)]
+void main(uint3 threadId : SV_DispatchThreadID)
+{
+    var v : RemovedTypeDef;
+//CHECK:    ^^^^^^^^^^^^^^ use of removed declaration
+//CHECK:    ^^^^^^^^^^^^^^ RemovedTypeDef has been removed since language version '-1': This typealias is removed
+
+    var s : RemovedStruct;
+//CHECK:    ^^^^^^^^^^^^^ use of removed declaration
+//CHECK:    ^^^^^^^^^^^^^ RemovedStruct has been removed since language version '-1': This struct is removed
+
+    s.removedField = 1;
+/*CHECK:
+      ^^^^^^^^^^^^ use of removed declaration
+      ^^^^^^^^^^^^ removedField has been removed since language version '-1': This field is removed
+*/
+
+    var if : IRemoved;
+//CHECK:     ^^^^^^^^ use of removed declaration
+//CHECK:     ^^^^^^^^ IRemoved has been removed since language version '-1': This interface is removed
+
+    removedFunction();
+/*CHECK:
+    ^^^^^^^^^^^^^^^ use of removed declaration
+    ^^^^^^^^^^^^^^^ removedFunction has been removed since language version '-1': This function is removed
+*/
+
+    s.removedExtendedFunction();
+/*CHECK:
+      ^^^^^^^^^^^^^^^^^^^^^^^ use of removed declaration
+      ^^^^^^^^^^^^^^^^^^^^^^^ removedExtendedFunction has been removed since language version '-1': This extension-provided member function is removed
+*/
+
+}

--- a/tests/language-feature/api-removed-since-2-helper.slang
+++ b/tests/language-feature/api-removed-since-2-helper.slang
@@ -1,0 +1,35 @@
+// Helper for api-removed-since-2.slang for checking that imported
+// symbols are checked correctly against the language version of the importer
+
+//TEST:SIMPLE:
+
+// Note: keep this version below what is in api-removed-since-2.slang
+#language slang 2025
+
+[deprecated("This struct is deprecated")]
+[RemovedSince(2027, "Use something else")]
+public struct RemovedStructSince2027
+{
+}
+
+[deprecated("This struct is deprecated")]
+[RemovedSince(2026, "Use something else")]
+public struct RemovedStructSince2026
+{
+}
+
+[RemovedSince(2026, "Use something else")]
+public struct RemovedStructSince2026NoDeprecation
+{
+}
+
+[deprecated("This struct is deprecated")]
+[RemovedSince(2024, "Use something else")]
+public struct RemovedStructSince2024
+{
+}
+
+void checkAccess()
+{
+    var s1 : RemovedStructSince2026NoDeprecation;
+}

--- a/tests/language-feature/api-removed-since-2.slang
+++ b/tests/language-feature/api-removed-since-2.slang
@@ -1,0 +1,81 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -std 2026
+
+// This test verifies the [RemovedSince] logic and that, when in
+// effect, it overrides [deprecated].
+//
+// Note: When Slang language version 2026 is removed, please bump up
+// the RemovedSince language versions in this test.
+
+[deprecated("This struct is deprecated")]
+[RemovedSince(2027, "Use something else")]
+struct RemovedStructSince2027
+{
+}
+
+[deprecated("This struct is deprecated")]
+[RemovedSince(2026, "Use something else")]
+struct RemovedStructSince2026
+{
+}
+
+[RemovedSince(2026, "Use something else")]
+struct RemovedStructSince2026NoDeprecation
+{
+}
+
+[deprecated("This struct is deprecated")]
+[RemovedSince(2024, "Use something else")]
+struct RemovedStructSince2024
+{
+}
+
+// attribute boundaries
+
+[RemovedSince(-2, "Min-1")]
+/*CHECK:
+ ^^^^^^^^^^^^ 'RemovedSince' argument 'version' exceeds allowed range
+ ^^^^^^^^^^^^ valid range: [-1, 9999]
+*/
+struct RemovedStructSinceMinMinus1
+{
+}
+
+[RemovedSince(-1, "Min")]
+struct RemovedStructSinceMin
+{
+}
+
+[RemovedSince(9999, "Max")]
+struct RemovedStructSinceMax
+{
+}
+
+[RemovedSince(10000, "Max+1")]
+/*CHECK:
+ ^^^^^^^^^^^^ 'RemovedSince' argument 'version' exceeds allowed range
+ ^^^^^^^^^^^^ valid range: [-1, 9999]
+*/
+struct RemovedStructSinceMaxPlus1
+{
+}
+
+[numthreads(1,1,1)]
+void main(uint3 threadId : SV_DispatchThreadID)
+{
+    var s1 : RemovedStructSince2024;
+//CHECK:     ^^^^^^^^^^^^^^^^^^^^^^ use of removed declaration
+//CHECK:     ^^^^^^^^^^^^^^^^^^^^^^ RemovedStructSince2024 has been removed since language version '2024': Use something else
+
+    var s2 : RemovedStructSince2026;
+//CHECK:     ^^^^^^^^^^^^^^^^^^^^^^ use of removed declaration
+//CHECK:     ^^^^^^^^^^^^^^^^^^^^^^ RemovedStructSince2026 has been removed since language version '2026': Use something else
+
+    var s3 : RemovedStructSince2026NoDeprecation;
+//CHECK:     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of removed declaration
+//CHECK:     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RemovedStructSince2026NoDeprecation has been removed since language version '2026': Use something else
+
+    var s4 : RemovedStructSince2027;
+//CHECK:     ^^^^^^^^^^^^^^^^^^^^^^ use of deprecated declaration
+//CHECK:     ^^^^^^^^^^^^^^^^^^^^^^ RemovedStructSince2027 has been deprecated: This struct is deprecated
+
+}

--- a/tests/language-feature/api-removed-since-2.slang
+++ b/tests/language-feature/api-removed-since-2.slang
@@ -33,7 +33,7 @@ struct RemovedStructSince2024
 
 [RemovedSince(-2, "Min-1")]
 /*CHECK:
- ^^^^^^^^^^^^ 'RemovedSince' argument 'version' exceeds allowed range
+ ^^^^^^^^^^^^ 'RemovedSince' argument 'version' is outside allowed range
  ^^^^^^^^^^^^ valid range: [-1, 9999]
 */
 struct RemovedStructSinceMinMinus1
@@ -52,7 +52,7 @@ struct RemovedStructSinceMax
 
 [RemovedSince(10000, "Max+1")]
 /*CHECK:
- ^^^^^^^^^^^^ 'RemovedSince' argument 'version' exceeds allowed range
+ ^^^^^^^^^^^^ 'RemovedSince' argument 'version' is outside allowed range
  ^^^^^^^^^^^^ valid range: [-1, 9999]
 */
 struct RemovedStructSinceMaxPlus1

--- a/tests/language-feature/api-removed-since-2.slang
+++ b/tests/language-feature/api-removed-since-2.slang
@@ -1,4 +1,11 @@
 //DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -std 2026
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -std 2026 -target cpp -stage compute -entry main
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -std 2026 -target cuda -stage compute -entry main
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -std 2026 -target glsl -stage compute -entry main
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -std 2026 -target hlsl -stage compute -entry main
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -std 2026 -target wgsl -stage compute -entry main
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -std 2026 -target spirv-asm -stage compute -entry main
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -std 2026 -target metal -stage compute -entry main
 
 // This test verifies the [RemovedSince] logic and that, when in
 // effect, it overrides [deprecated].
@@ -6,28 +13,8 @@
 // Note: When Slang language version 2026 is removed, please bump up
 // the RemovedSince language versions in this test.
 
-[deprecated("This struct is deprecated")]
-[RemovedSince(2027, "Use something else")]
-struct RemovedStructSince2027
-{
-}
+import "api-removed-since-2-helper";
 
-[deprecated("This struct is deprecated")]
-[RemovedSince(2026, "Use something else")]
-struct RemovedStructSince2026
-{
-}
-
-[RemovedSince(2026, "Use something else")]
-struct RemovedStructSince2026NoDeprecation
-{
-}
-
-[deprecated("This struct is deprecated")]
-[RemovedSince(2024, "Use something else")]
-struct RemovedStructSince2024
-{
-}
 
 // attribute boundaries
 


### PR DESCRIPTION
Add attribute [RemovedSince(version, message)]. It can be used to mark a declaration removed, starting from the specified language version.

The intended usage is scheduled removal of deprecated declarations in hlsl.meta.slang and other standard library modules. The reason for a removal can be a superseded declaration, for instance. An attempt to use a removed declaration triggers an error.

A small fix is also added in the handling of the attribute [deprecated]. It was possible that the declaration alone triggered a warning. This was the case with struct fields tagged with [deprecated].

Add testing for the [deprecated] and [RemovedSince] attributes.

Fixes #10700