### PR TITLE
Scope GPU retry to merge queue and revert to github.token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,7 @@ jobs:
   # Capped at 2 automatic retries via run_attempt check.
   retry-on-gpu-failure:
     needs: [check-ci]
-    if: failure() && fromJSON(github.run_attempt) < 3
+    if: failure() && github.event_name == 'merge_group' && fromJSON(github.run_attempt) < 3
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -335,7 +335,7 @@ jobs:
       - name: Check for GPU health check failures and dispatch retry
         env:
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.SLANGBOT_PAT }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gpu_failures=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" \
             --jq '[.jobs[]


### PR DESCRIPTION
## Summary

PR #10782 switched `retry-on-gpu-failure` from `github.token` to `SLANGBOT_PAT` to fix a 403 on PR events, but `SLANGBOT_PAT` also gets a 403 in merge queue context ("Must have admin rights"), and fork PRs can't access repo secrets at all — the `gh api` call silently fails and GPU crashes go undetected.

Auto-retry only matters in the merge queue where it unblocks the merge train. This scopes the job to `merge_group` events and reverts to `github.token` which worked in that context before #10782.

Merge queue 403: https://github.com/shader-slang/slang/actions/runs/24338244183/job/71068779297
Fork PR silent failure: https://github.com/shader-slang/slang/actions/runs/24349896871/job/71102053054?pr=10814

## Test plan

- [ ] Verify next merge queue GPU failure triggers retry successfully
- [ ] Verify PR runs no longer attempt the retry job