### PR TITLE
Fix intermittent Vulkan test failures from libEGL_nvidia.so crash

### DIFF
--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -17,7 +17,14 @@ on:
 
 jobs:
   # Run GPU tests in container with Vulkan and CUDA support.
-  # Requires mounting host NVIDIA Vulkan ICD and EGL vendor config for Vulkan to work.
+  #
+  # Vulkan ICD: We use libEGL_nvidia.so.0 as the Vulkan ICD instead of the
+  # default libGLX_nvidia.so.0. This avoids a TOCTOU race in libEGL_nvidia.so's
+  # EGL initialization path (driver 580.x) that causes intermittent segfaults
+  # when libglvnd loads the EGL vendor. Using libEGL_nvidia as the ICD directly
+  # (it exports vk_icd* symbols) bypasses the buggy EGL init code path.
+  # We also skip mounting the EGL vendor JSON (10_nvidia.json) to prevent
+  # libglvnd from triggering EGL initialization.
   test-slang:
     runs-on: ["Linux", "self-hosted", "GPU"]
     timeout-minutes: 60
@@ -38,9 +45,7 @@ jobs:
         --device /dev/nvidia-modeset:/dev/nvidia-modeset
         --device /dev/dri:/dev/dri
         -e NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics
-        -v /etc/vulkan/icd.d/nvidia_icd.json:/etc/vulkan/icd.d/nvidia_icd.json:ro
         -v /usr/share/nvidia:/usr/share/nvidia:ro
-        -v /usr/share/glvnd/egl_vendor.d/10_nvidia.json:/usr/share/glvnd/egl_vendor.d/10_nvidia.json:ro
 
     defaults:
       run:
@@ -55,6 +60,28 @@ jobs:
             exit 1
           fi
           echo "GPU: $output"
+
+      - name: Setup Vulkan ICD
+        run: |
+          # Use libEGL_nvidia.so.0 as the Vulkan ICD instead of the default
+          # libGLX_nvidia.so.0. Both export vk_icd* symbols. The default ICD
+          # (libGLX) causes the NVIDIA driver to internally initialize EGL via
+          # libglvnd, which hits a TOCTOU race in libEGL_nvidia.so (driver
+          # 580.x) that intermittently segfaults test-server processes.
+          # Using libEGL_nvidia directly as the ICD avoids the libglvnd EGL
+          # vendor dispatch path entirely.
+          mkdir -p /etc/vulkan/icd.d
+          cat > /etc/vulkan/icd.d/nvidia_icd.json <<'EOF'
+          {
+              "file_format_version": "1.0.1",
+              "ICD": {
+                  "library_path": "libEGL_nvidia.so.0",
+                  "api_version": "1.4.312"
+              }
+          }
+          EOF
+          rm -f /usr/share/glvnd/egl_vendor.d/10_nvidia.json 2>/dev/null || true
+          echo "Vulkan ICD configured: libEGL_nvidia.so.0"
 
       - name: Configure Git safe directory
         run: git config --global --add safe.directory '*'
@@ -183,9 +210,7 @@ jobs:
         --device /dev/nvidia-modeset:/dev/nvidia-modeset
         --device /dev/dri:/dev/dri
         -e NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics
-        -v /etc/vulkan/icd.d/nvidia_icd.json:/etc/vulkan/icd.d/nvidia_icd.json:ro
         -v /usr/share/nvidia:/usr/share/nvidia:ro
-        -v /usr/share/glvnd/egl_vendor.d/10_nvidia.json:/usr/share/glvnd/egl_vendor.d/10_nvidia.json:ro
 
     defaults:
       run:
@@ -200,6 +225,23 @@ jobs:
             exit 1
           fi
           echo "GPU: $output"
+
+      - name: Setup Vulkan ICD
+        run: |
+          # Use libEGL_nvidia.so.0 as the Vulkan ICD instead of the default
+          # libGLX_nvidia.so.0. See test-slang job comment for details.
+          mkdir -p /etc/vulkan/icd.d
+          cat > /etc/vulkan/icd.d/nvidia_icd.json <<'EOF'
+          {
+              "file_format_version": "1.0.1",
+              "ICD": {
+                  "library_path": "libEGL_nvidia.so.0",
+                  "api_version": "1.4.312"
+              }
+          }
+          EOF
+          rm -f /usr/share/glvnd/egl_vendor.d/10_nvidia.json 2>/dev/null || true
+          echo "Vulkan ICD configured: libEGL_nvidia.so.0"
 
       - name: Configure Git safe directory
         run: git config --global --add safe.directory '*'

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -64,18 +64,36 @@ jobs:
       - name: Setup Vulkan ICD
         run: |
           # See job-level comment for why we override the Vulkan ICD.
+          # Read the existing NVIDIA ICD JSON (injected by the container toolkit)
+          # and swap only the library_path, preserving api_version and formatting.
+          source_icd=""
+          for candidate in \
+            /etc/vulkan/icd.d/nvidia_icd.json \
+            /usr/share/vulkan/icd.d/nvidia_icd.json; do
+            if [ -f "$candidate" ]; then
+              source_icd="$candidate"
+              break
+            fi
+          done
+          if [ -z "$source_icd" ]; then
+            echo "::warning::No existing NVIDIA ICD JSON found, using defaults"
+            source_icd=""
+          fi
           mkdir -p /etc/vulkan/icd.d
-          cat > /etc/vulkan/icd.d/nvidia_icd.json <<'EOF'
-          {
-              "file_format_version": "1.0.1",
-              "ICD": {
-                  "library_path": "libEGL_nvidia.so.0",
-                  "api_version": "1.4.312"
-              }
-          }
-          EOF
+          python3 -c "
+          import json, sys
+          if '$source_icd':
+              with open('$source_icd') as f:
+                  icd = json.load(f)
+          else:
+              icd = {'file_format_version': '1.0.1', 'ICD': {'api_version': '1.4.312'}}
+          icd['ICD']['library_path'] = 'libEGL_nvidia.so.0'
+          with open('/etc/vulkan/icd.d/nvidia_icd.json', 'w') as f:
+              json.dump(icd, f, indent=4)
+              f.write('\n')
+          print(f\"Vulkan ICD configured: libEGL_nvidia.so.0 (api_version={icd['ICD'].get('api_version', 'unknown')})\")
+          "
           rm -f /usr/share/glvnd/egl_vendor.d/10_nvidia.json 2>/dev/null || true
-          echo "Vulkan ICD configured: libEGL_nvidia.so.0"
 
       - name: Configure Git safe directory
         run: git config --global --add safe.directory '*'
@@ -223,18 +241,34 @@ jobs:
       - name: Setup Vulkan ICD
         run: |
           # See test-slang job comment for why we override the Vulkan ICD.
+          source_icd=""
+          for candidate in \
+            /etc/vulkan/icd.d/nvidia_icd.json \
+            /usr/share/vulkan/icd.d/nvidia_icd.json; do
+            if [ -f "$candidate" ]; then
+              source_icd="$candidate"
+              break
+            fi
+          done
+          if [ -z "$source_icd" ]; then
+            echo "::warning::No existing NVIDIA ICD JSON found, using defaults"
+            source_icd=""
+          fi
           mkdir -p /etc/vulkan/icd.d
-          cat > /etc/vulkan/icd.d/nvidia_icd.json <<'EOF'
-          {
-              "file_format_version": "1.0.1",
-              "ICD": {
-                  "library_path": "libEGL_nvidia.so.0",
-                  "api_version": "1.4.312"
-              }
-          }
-          EOF
+          python3 -c "
+          import json, sys
+          if '$source_icd':
+              with open('$source_icd') as f:
+                  icd = json.load(f)
+          else:
+              icd = {'file_format_version': '1.0.1', 'ICD': {'api_version': '1.4.312'}}
+          icd['ICD']['library_path'] = 'libEGL_nvidia.so.0'
+          with open('/etc/vulkan/icd.d/nvidia_icd.json', 'w') as f:
+              json.dump(icd, f, indent=4)
+              f.write('\n')
+          print(f\"Vulkan ICD configured: libEGL_nvidia.so.0 (api_version={icd['ICD'].get('api_version', 'unknown')})\")
+          "
           rm -f /usr/share/glvnd/egl_vendor.d/10_nvidia.json 2>/dev/null || true
-          echo "Vulkan ICD configured: libEGL_nvidia.so.0"
 
       - name: Configure Git safe directory
         run: git config --global --add safe.directory '*'

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -19,12 +19,12 @@ jobs:
   # Run GPU tests in container with Vulkan and CUDA support.
   #
   # Vulkan ICD: We use libEGL_nvidia.so.0 as the Vulkan ICD instead of the
-  # default libGLX_nvidia.so.0. This avoids a TOCTOU race in libEGL_nvidia.so's
-  # EGL initialization path (driver 580.x) that causes intermittent segfaults
-  # when libglvnd loads the EGL vendor. Using libEGL_nvidia as the ICD directly
-  # (it exports vk_icd* symbols) bypasses the buggy EGL init code path.
-  # We also skip mounting the EGL vendor JSON (10_nvidia.json) to prevent
-  # libglvnd from triggering EGL initialization.
+  # default libGLX_nvidia.so.0 to avoid an intermittent crash in the EGL
+  # initialization path of driver 580.x. Both libraries export vk_icd* symbols.
+  # The default ICD causes the driver to load libEGL_nvidia.so via libglvnd's
+  # EGL vendor dispatch, which has a null-deref bug that crashes test-server
+  # processes. Using libEGL_nvidia directly as the ICD skips the EGL vendor
+  # dispatch entirely, so the buggy code path is never reached.
   test-slang:
     runs-on: ["Linux", "self-hosted", "GPU"]
     timeout-minutes: 60
@@ -63,13 +63,7 @@ jobs:
 
       - name: Setup Vulkan ICD
         run: |
-          # Use libEGL_nvidia.so.0 as the Vulkan ICD instead of the default
-          # libGLX_nvidia.so.0. Both export vk_icd* symbols. The default ICD
-          # (libGLX) causes the NVIDIA driver to internally initialize EGL via
-          # libglvnd, which hits a TOCTOU race in libEGL_nvidia.so (driver
-          # 580.x) that intermittently segfaults test-server processes.
-          # Using libEGL_nvidia directly as the ICD avoids the libglvnd EGL
-          # vendor dispatch path entirely.
+          # See job-level comment for why we override the Vulkan ICD.
           mkdir -p /etc/vulkan/icd.d
           cat > /etc/vulkan/icd.d/nvidia_icd.json <<'EOF'
           {
@@ -228,8 +222,7 @@ jobs:
 
       - name: Setup Vulkan ICD
         run: |
-          # Use libEGL_nvidia.so.0 as the Vulkan ICD instead of the default
-          # libGLX_nvidia.so.0. See test-slang job comment for details.
+          # See test-slang job comment for why we override the Vulkan ICD.
           mkdir -p /etc/vulkan/icd.d
           cat > /etc/vulkan/icd.d/nvidia_icd.json <<'EOF'
           {

--- a/extras/scaler/internal/gcp/startup.sh
+++ b/extras/scaler/internal/gcp/startup.sh
@@ -105,6 +105,18 @@ else
   log "WARNING: Failed to enable GPU persistence mode: ${pm_out}"
 fi
 
+# Create /dev/char symlinks for all NVIDIA device nodes. Recent runc versions
+# with cgroup v2 require these symlinks to properly inject devices into
+# containers. Without them, containers can intermittently lose GPU access
+# with "Failed to initialize NVML: Unknown Error".
+# See: https://github.com/NVIDIA/nvidia-docker/issues/1730
+log "  Creating /dev/char symlinks..."
+if nvidia-ctk system create-dev-char-symlinks --create-all >/dev/null 2>&1; then
+  log "  /dev/char symlinks created."
+else
+  log "WARNING: Failed to create /dev/char symlinks (nvidia-ctk may not be installed)"
+fi
+
 # Verify GPU devices
 log "  GPU devices:"
 ls -la /dev/nvidia* 2>&1 | while read -r line; do log "    $line"; done || true

--- a/extras/scaler/internal/gcp/startup.sh
+++ b/extras/scaler/internal/gcp/startup.sh
@@ -111,10 +111,10 @@ fi
 # with "Failed to initialize NVML: Unknown Error".
 # See: https://github.com/NVIDIA/nvidia-docker/issues/1730
 log "  Creating /dev/char symlinks..."
-if nvidia-ctk system create-dev-char-symlinks --create-all >/dev/null 2>&1; then
+if ctk_out="$(nvidia-ctk system create-dev-char-symlinks --create-all 2>&1)"; then
   log "  /dev/char symlinks created."
 else
-  log "WARNING: Failed to create /dev/char symlinks (nvidia-ctk may not be installed)"
+  log "WARNING: Failed to create /dev/char symlinks: ${ctk_out}"
 fi
 
 # Verify GPU devices


### PR DESCRIPTION
## Summary
- Work around a crash in `libEGL_nvidia.so` (driver 580.x) that intermittently crashes test-server processes during Linux GPU CI tests
- Use `libEGL_nvidia.so.0` as the Vulkan ICD instead of `libGLX_nvidia.so.0` — both export `vk_icd*` symbols, but this avoids the buggy libglvnd EGL vendor initialization
- Remove the EGL vendor JSON mount (`10_nvidia.json`) to prevent any EGL initialization
- Add `/dev/char` symlink creation to scaler VM startup to prevent boot-time NVML failures with cgroup v2

## Background

The crash is a null pointer dereference at offset `0xa988a` in `libEGL_nvidia.so.580.126.09`. A function loads a global pointer, null-checks it, calls another function that can clear the global, then writes to the pointer without re-checking for null. The faulting instruction (`movb $0x1, 0x18(%rdi)` where `rdi=0`) is identical across all observed crashes.

The EGL library gets loaded because the CI container mounts the NVIDIA EGL vendor JSON, and the NVIDIA Vulkan driver internally triggers EGL initialization ~60-120s into the test suite via libglvnd. Using `libEGL_nvidia.so.0` directly as the Vulkan ICD bypasses the libglvnd EGL vendor dispatch and prevents the EGL-specific code from ever executing.

Separately, recent `runc` versions with cgroup v2 require `/dev/char` symlinks for NVIDIA device nodes to properly inject GPUs into containers ([nvidia-docker#1730](https://github.com/NVIDIA/nvidia-docker/issues/1730)). Without them, VMs can boot with broken NVML. The scaler startup script now calls `nvidia-ctk system create-dev-char-symlinks --create-all` to ensure these exist.

Stress testing on ephemeral GCP T4 VMs showed ~23% failure rate before these changes and 0% after (16 runs).