### PR TITLE
Add diagnostic note for concrete-to-interface pointer cast (#9962)

### DIFF
--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -2544,6 +2544,23 @@ bool SemanticsVisitor::_coerce(
                         .fromType = fromType.type,
                         .toType = toType,
                         .location = fromExpr->loc});
+
+                    if (auto fromPtrType = as<PtrType>(fromType.type))
+                    {
+                        if (auto toPtrType = as<PtrType>(toType))
+                        {
+                            auto fromVal = fromPtrType->getValueType();
+                            auto toVal = toPtrType->getValueType();
+                            if (!isInterfaceType(fromVal) && isInterfaceType(toVal) &&
+                                tryGetSubtypeWitness(fromVal, toVal))
+                            {
+                                sink->diagnose(Diagnostics::NoteConcreteToInterfacePtrUnsafe{
+                                    .from = fromVal,
+                                    .to = toVal,
+                                    .location = fromExpr->loc});
+                            }
+                        }
+                    }
                 }
             }
             // For general implicit conversions with high cost, emit a warning

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -5146,6 +5146,13 @@ standalone_note(
     span { loc = "location" }
 )
 
+standalone_note(
+    "note-concrete-to-interface-ptr-unsafe",
+    -1,
+    "implicit conversion from '~from:Type*' to '~to:Type*' is not allowed because the pointed-to data layouts are not bit equivalent",
+    span { loc = "location" }
+)
+
 -- IR-specific variants for use in IR linking and lowering passes
 -- These take IRInst* instead of Decl*
 

--- a/tests/language-feature/dynamic-dispatch/diagnose-ptr-to-interface-implicit-cast.slang
+++ b/tests/language-feature/dynamic-dispatch/diagnose-ptr-to-interface-implicit-cast.slang
@@ -5,7 +5,7 @@
 // 3. Ptr<struct> -> Ptr<struct>    (no struct inheritance in Slang)
 // 4. Ptr<interface supertype> -> Ptr<interface subtype> (narrowing)
 
-//TEST:SIMPLE(filecheck=CHECK): -target spirv
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target spirv
 
 interface IBase
 {
@@ -45,17 +45,20 @@ void computeMain()
 
     // 2. Ptr<interface> -> Ptr<struct>: rejected
     // CHECK: error[E30019]
+    // CHECK-NOT: not bit equivalent
     Foo* pf2 = ip;
 
     // 3. Ptr<struct> -> Ptr<another struct>: rejected (no struct inheritance)
     Bar b;
     // CHECK: error[E30019]
+    // CHECK-NOT: not bit equivalent
     Foo* pf3 = &b;
 
     // 4. Ptr<interface supertype> -> Ptr<interface subtype>: rejected (narrowing)
     IBase ib;
     IBase* ibp = &ib;
     // CHECK: error[E30019]
+    // CHECK-NOT: not bit equivalent
     IDerived* dp = ibp;
 
     outputBuffer[0] = 0;

--- a/tests/language-feature/dynamic-dispatch/diagnose-ptr-to-interface-implicit-cast.slang
+++ b/tests/language-feature/dynamic-dispatch/diagnose-ptr-to-interface-implicit-cast.slang
@@ -1,19 +1,32 @@
-// Implicit conversion from a concrete pointer (Foo*) to an interface pointer
-// (IFoo*) is not allowed. The type checker requires an explicit cast because
-// the memory layouts differ: Foo contains only its fields, while IFoo contains
-// a tag, witness table, and AnyValue payload.
+// Implicit pointer conversions between incompatible types are rejected.
+// All four directions are tested per reviewer feedback:
+// 1. Ptr<struct> -> Ptr<interface>  (memory layout mismatch)
+// 2. Ptr<interface> -> Ptr<struct>  (memory layout mismatch)
+// 3. Ptr<struct> -> Ptr<struct>    (no struct inheritance in Slang)
+// 4. Ptr<interface supertype> -> Ptr<interface subtype> (narrowing)
 
 //TEST:SIMPLE(filecheck=CHECK): -target spirv
 
-interface IFoo
+interface IBase
 {
     int getVal();
 }
 
-struct Foo : IFoo
+interface IDerived : IBase
+{
+    int getExtra();
+}
+
+struct Foo : IDerived
 {
     int val;
     int getVal() { return val; }
+    int getExtra() { return val + 1; }
+}
+
+struct Bar
+{
+    int val;
 }
 
 RWStructuredBuffer<int> outputBuffer;
@@ -25,9 +38,25 @@ void computeMain()
     f.val = 5;
     Foo* pf = &f;
 
-    // Implicit conversion: error
+    // 1. Ptr<struct> -> Ptr<interface>: rejected (layout mismatch)
     // CHECK: error[E30019]
-    IFoo* ip = pf;
+    // CHECK: not bit equivalent
+    IBase* ip = pf;
+
+    // 2. Ptr<interface> -> Ptr<struct>: rejected
+    // CHECK: error[E30019]
+    Foo* pf2 = ip;
+
+    // 3. Ptr<struct> -> Ptr<another struct>: rejected (no struct inheritance)
+    Bar b;
+    // CHECK: error[E30019]
+    Foo* pf3 = &b;
+
+    // 4. Ptr<interface supertype> -> Ptr<interface subtype>: rejected (narrowing)
+    IBase ib;
+    IBase* ibp = &ib;
+    // CHECK: error[E30019]
+    IDerived* dp = ibp;
 
     outputBuffer[0] = 0;
 }

--- a/tests/language-feature/dynamic-dispatch/diagnose-ptr-to-interface-implicit-cast.slang
+++ b/tests/language-feature/dynamic-dispatch/diagnose-ptr-to-interface-implicit-cast.slang
@@ -5,7 +5,7 @@
 // 3. Ptr<struct> -> Ptr<struct>    (no struct inheritance in Slang)
 // 4. Ptr<interface supertype> -> Ptr<interface subtype> (narrowing)
 
-//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target spirv
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive): -target spirv
 
 interface IBase
 {


### PR DESCRIPTION
Fixes #9962

When `Foo*` → `IFoo*` implicit conversion is attempted (where `Foo : IFoo`), emit a specific compiler note explaining why it is rejected:

> implicit conversion from 'Foo*' to 'IFoo*' is not allowed because the pointed-to data layouts are not bit equivalent

This gives users a clear explanation instead of just the generic `E30019: type mismatch` error.

**Changes:**
- `slang-diagnostics.lua`: new `note-concrete-to-interface-ptr-unsafe` diagnostic
- `slang-check-conversion.cpp`: detect `Ptr<Concrete>` → `Ptr<Interface>` in the type mismatch path and emit the note
- `diagnose-ptr-to-interface-implicit-cast.slang`: 4 negative test cases per reviewer feedback:
  1. `Ptr<struct>` → `Ptr<interface>` (layout mismatch, with "not bit equivalent" note)
  2. `Ptr<interface>` → `Ptr<struct>` (layout mismatch)
  3. `Ptr<struct>` → `Ptr<another struct>` (no struct inheritance)
  4. `Ptr<interface supertype>` → `Ptr<interface subtype>` (narrowing)
