### PR TITLE
Add structured environment dump for Windows and macOS CI tests

### DIFF
--- a/.github/actions/common-test-setup/action.yml
+++ b/.github/actions/common-test-setup/action.yml
@@ -118,6 +118,16 @@ runs:
         # Platform-specific API checks - fail if APIs are not available
         if [[ "${{ inputs.os }}" == "macos" ]]; then
           check_api_support "mtl,metal"
+
+          # Structured environment dump (matches Linux print-env-info format)
+          echo "ENV_INFO_START"
+          echo "gpu_name=$(system_profiler SPDisplaysDataType 2>/dev/null | grep 'Chipset Model\|Chip:' | head -1 | sed 's/.*: //' || echo 'unknown')"
+          echo "gpu_memory=$(system_profiler SPDisplaysDataType 2>/dev/null | grep 'VRAM\|Memory:' | head -1 | sed 's/.*: //' || echo 'unknown')"
+          echo "metal_support=$(system_profiler SPDisplaysDataType 2>/dev/null | grep 'Metal Support' | head -1 | sed 's/.*: //' || echo 'unknown')"
+          echo "macos_version=$(sw_vers -productVersion 2>/dev/null || echo 'unknown')"
+          echo "runner_name=${RUNNER_NAME:-unknown}"
+          echo "os=macos"
+          echo "ENV_INFO_END"
         elif [[ "${{ inputs.os }}" == "windows" ]]; then
           check_api_support "vk,vulkan" "dx12,d3d12" "dx11,d3d11" "cuda"
 
@@ -127,6 +137,17 @@ runs:
           nvidia-smi -q | grep Version || (echo "ERROR: NVIDIA driver (nvidia-smi) not available on Windows" && exit 1)
           echo "Printing Vulkan SDK version: ..."
           vulkaninfo | grep -i version || (echo "ERROR: Vulkan SDK (vulkaninfo) not available on Windows" && exit 1)
-        fi        
+
+          # Structured environment dump (matches Linux print-env-info format)
+          echo "ENV_INFO_START"
+          echo "driver_version=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null || echo 'unknown')"
+          echo "gpu_name=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'unknown')"
+          echo "gpu_memory=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader 2>/dev/null || echo 'unknown')"
+          echo "cuda_version=$(nvcc --version 2>&1 | grep -o 'release [0-9.]*' | cut -d' ' -f2 || echo 'unknown')"
+          echo "vulkan_sdk=${VULKAN_SDK:-not_set}"
+          echo "runner_name=${RUNNER_NAME:-unknown}"
+          echo "os=windows"
+          echo "ENV_INFO_END"
+        fi
         echo "All environment variables:"
         env | sort

--- a/.github/actions/common-test-setup/action.yml
+++ b/.github/actions/common-test-setup/action.yml
@@ -122,14 +122,17 @@ runs:
           # Structured environment dump (matches Linux print-env-info format)
           echo "ENV_INFO_START"
           gpu_info=$(system_profiler SPDisplaysDataType 2>/dev/null || true)
-          gpu_name=$(echo "$gpu_info" | grep 'Chipset Model' | head -1 | sed 's/.*: //')
+          gpu_name=$(echo "$gpu_info" | grep -E 'Chipset Model' | head -1 | sed 's/.*: //' || true)
           if [[ -z "$gpu_name" ]]; then
-            gpu_name=$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo 'unknown')
+            gpu_name=$(sysctl -n machdep.cpu.brand_string 2>/dev/null || true)
           fi
-          echo "gpu_name=$gpu_name"
-          echo "gpu_cores=$(echo "$gpu_info" | grep 'Total Number of Cores' | head -1 | sed 's/.*: //' || echo 'unknown')"
-          echo "metal_support=$(echo "$gpu_info" | grep 'Metal Support' | head -1 | sed 's/.*: //' || echo 'unknown')"
-          echo "macos_version=$(sw_vers -productVersion 2>/dev/null || echo 'unknown')"
+          echo "gpu_name=${gpu_name:-unknown}"
+          gpu_cores=$(echo "$gpu_info" | grep -E 'Total Number of Cores' | head -1 | sed 's/.*: //' || true)
+          echo "gpu_cores=${gpu_cores:-unknown}"
+          metal_support=$(echo "$gpu_info" | grep -E 'Metal Support' | head -1 | sed 's/.*: //' || true)
+          echo "metal_support=${metal_support:-unknown}"
+          macos_version=$(sw_vers -productVersion 2>/dev/null || true)
+          echo "macos_version=${macos_version:-unknown}"
           echo "runner_name=${RUNNER_NAME:-unknown}"
           echo "os=macos"
           echo "ENV_INFO_END"
@@ -145,10 +148,14 @@ runs:
 
           # Structured environment dump (matches Linux print-env-info format)
           echo "ENV_INFO_START"
-          echo "driver_version=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null || echo 'unknown')"
-          echo "gpu_name=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'unknown')"
-          echo "gpu_memory=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader 2>/dev/null || echo 'unknown')"
-          echo "cuda_version=$(nvcc --version 2>&1 | grep -o 'release [0-9.]*' | cut -d' ' -f2 || echo 'unknown')"
+          driver_version=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null || true)
+          echo "driver_version=${driver_version:-unknown}"
+          gpu_name=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || true)
+          echo "gpu_name=${gpu_name:-unknown}"
+          gpu_memory=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader 2>/dev/null || true)
+          echo "gpu_memory=${gpu_memory:-unknown}"
+          cuda_version=$(nvcc --version 2>&1 | grep -o 'release [0-9.]*' | cut -d' ' -f2 || true)
+          echo "cuda_version=${cuda_version:-unknown}"
           echo "vulkan_sdk=${VULKAN_SDK:-not_set}"
           echo "runner_name=${RUNNER_NAME:-unknown}"
           echo "os=windows"

--- a/.github/actions/common-test-setup/action.yml
+++ b/.github/actions/common-test-setup/action.yml
@@ -123,12 +123,9 @@ runs:
           echo "ENV_INFO_START"
           gpu_info=$(system_profiler SPDisplaysDataType 2>/dev/null || true)
           gpu_name=$(echo "$gpu_info" | grep -E 'Chipset Model' | head -1 | sed 's/.*: //' || true)
-          if [[ -z "$gpu_name" ]]; then
-            gpu_name=$(sysctl -n machdep.cpu.brand_string 2>/dev/null || true)
-          fi
           echo "gpu_name=${gpu_name:-unknown}"
-          gpu_cores=$(echo "$gpu_info" | grep -E 'Total Number of Cores' | head -1 | sed 's/.*: //' || true)
-          echo "gpu_cores=${gpu_cores:-unknown}"
+          gpu_memory=$(echo "$gpu_info" | grep -E 'VRAM' | head -1 | sed 's/.*: //' || true)
+          echo "gpu_memory=${gpu_memory:-unknown}"
           metal_support=$(echo "$gpu_info" | grep -E 'Metal Support' | head -1 | sed 's/.*: //' || true)
           echo "metal_support=${metal_support:-unknown}"
           macos_version=$(sw_vers -productVersion 2>/dev/null || true)

--- a/.github/actions/common-test-setup/action.yml
+++ b/.github/actions/common-test-setup/action.yml
@@ -145,11 +145,11 @@ runs:
 
           # Structured environment dump (matches Linux print-env-info format)
           echo "ENV_INFO_START"
-          driver_version=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null || true)
+          driver_version=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -1 || true)
           echo "driver_version=${driver_version:-unknown}"
-          gpu_name=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || true)
+          gpu_name=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1 || true)
           echo "gpu_name=${gpu_name:-unknown}"
-          gpu_memory=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader 2>/dev/null || true)
+          gpu_memory=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader 2>/dev/null | head -1 || true)
           echo "gpu_memory=${gpu_memory:-unknown}"
           cuda_version=$(nvcc --version 2>&1 | grep -o 'release [0-9.]*' | cut -d' ' -f2 || true)
           echo "cuda_version=${cuda_version:-unknown}"

--- a/.github/actions/common-test-setup/action.yml
+++ b/.github/actions/common-test-setup/action.yml
@@ -121,9 +121,14 @@ runs:
 
           # Structured environment dump (matches Linux print-env-info format)
           echo "ENV_INFO_START"
-          echo "gpu_name=$(system_profiler SPDisplaysDataType 2>/dev/null | grep 'Chipset Model\|Chip:' | head -1 | sed 's/.*: //' || echo 'unknown')"
-          echo "gpu_memory=$(system_profiler SPDisplaysDataType 2>/dev/null | grep 'VRAM\|Memory:' | head -1 | sed 's/.*: //' || echo 'unknown')"
-          echo "metal_support=$(system_profiler SPDisplaysDataType 2>/dev/null | grep 'Metal Support' | head -1 | sed 's/.*: //' || echo 'unknown')"
+          gpu_info=$(system_profiler SPDisplaysDataType 2>/dev/null || true)
+          gpu_name=$(echo "$gpu_info" | grep 'Chipset Model' | head -1 | sed 's/.*: //')
+          if [[ -z "$gpu_name" ]]; then
+            gpu_name=$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo 'unknown')
+          fi
+          echo "gpu_name=$gpu_name"
+          echo "gpu_cores=$(echo "$gpu_info" | grep 'Total Number of Cores' | head -1 | sed 's/.*: //' || echo 'unknown')"
+          echo "metal_support=$(echo "$gpu_info" | grep 'Metal Support' | head -1 | sed 's/.*: //' || echo 'unknown')"
           echo "macos_version=$(sw_vers -productVersion 2>/dev/null || echo 'unknown')"
           echo "runner_name=${RUNNER_NAME:-unknown}"
           echo "os=macos"


### PR DESCRIPTION
## Summary
- Add `ENV_INFO_START`/`ENV_INFO_END` structured environment dump blocks to Windows and macOS CI test runs, matching the existing Linux `print-env-info` format
- Windows reports: driver version, GPU name/memory, CUDA version, Vulkan SDK path
- macOS reports: GPU name/memory, Metal support level, macOS version

## Test plan
- [x] Verify Windows CI logs contain the `ENV_INFO_START`/`ENV_INFO_END` block — confirmed on commit 6c15ebb (driver=581.80, gpu=Tesla T4, memory=15360 MiB, cuda=12.5)
- [x] Verify macOS CI logs contain the `ENV_INFO_START`/`ENV_INFO_END` block — confirmed on commit 6c15ebb (gpu/memory/metal=unknown on headless runner, macos_version=15.7.4)
- [x] Verify Linux CI is unaffected (uses separate container workflow) — confirmed, no duplicate ENV_INFO block