### PR TITLE
Fix ICE when using groupshared with interface-typed variables

### DIFF
--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -2377,8 +2377,21 @@ struct TypeFlowSpecializationContext
                 auto valueInfo = as<IRPtrTypeBase>(addrInfo)->getValueType();
                 return valueInfo;
             }
-            else
-                return none(); // No info for the address
+
+            // If there is no type flow info for the address but the loaded type
+            // is an interface, enumerate all conforming types globally.
+            // This handles groupshared global variables (and arrays thereof)
+            // with interface types, where the address traces back to a module-scope
+            // global variable that type flow analysis cannot track.
+            if (auto interfaceType = as<IRInterfaceType>(loadInst->getDataType()))
+            {
+                if (!isComInterfaceType(interfaceType))
+                {
+                    return findGlobalTables(interfaceType);
+                }
+            }
+
+            return none();
         }
         else if (as<IRRWStructuredBufferLoad>(inst) || as<IRStructuredBufferLoad>(inst))
         {

--- a/tests/language-feature/dynamic-dispatch/diagnose-groupshared-interface.slang
+++ b/tests/language-feature/dynamic-dispatch/diagnose-groupshared-interface.slang
@@ -1,15 +1,16 @@
-// Direct groupshared variables with interface types currently trigger an
-// ICE because the existential lowering passes do not handle groupshared-rate
-// variables. The existential layout is known after compilation, so this may
-// be a fixable limitation rather than a fundamental incompatibility.
-// Disabled until the fix lands. See https://github.com/shader-slang/slang/issues/10144
+// Direct groupshared variables with interface types.
+// Verifies that the type flow analysis properly handles loads from
+// interface-typed global variables by enumerating conforming types,
+// enabling dynamic dispatch without requiring struct wrapping.
+//
+// See https://github.com/shader-slang/slang/issues/10144
 //
 // The struct-wrapping workaround is validated by
 // groupshared-struct-with-interface.slang.
 
 // --- Scenario 1: Direct groupshared interface variable ---
-//DISABLE_TEST:SIMPLE(filecheck=CHK1): -target spirv -stage compute -entry scenario1
-//DISABLE_TEST:SIMPLE(filecheck=CHK1): -target hlsl -stage compute -entry scenario1
+//TEST:SIMPLE(filecheck=SPV1):-target spirv-asm -stage compute -entry scenario1
+//TEST:SIMPLE(filecheck=HLSL1):-target hlsl -stage compute -entry scenario1
 
 interface IValue
 {
@@ -32,21 +33,27 @@ groupshared IValue sharedVal;
 
 RWStructuredBuffer<float> outputBuffer;
 
+// SPV1: OpEntryPoint
+// HLSL1: groupshared
 [numthreads(64, 1, 1)]
 void scenario1(uint3 tid : SV_DispatchThreadID)
 {
     if (tid.x == 0)
         sharedVal = ScalarValue(42.0);
+    else if (tid.x == 1)
+        sharedVal = DoubleValue(10.0);
     GroupMemoryBarrierWithGroupSync();
     outputBuffer[tid.x] = sharedVal.get();
 }
 
 // --- Scenario 2: Groupshared array of interface-typed values ---
-//DISABLE_TEST:SIMPLE(filecheck=CHK2): -target spirv -stage compute -entry scenario2
-//DISABLE_TEST:SIMPLE(filecheck=CHK2): -target hlsl -stage compute -entry scenario2
+//TEST:SIMPLE(filecheck=SPV2):-target spirv-asm -stage compute -entry scenario2
+//TEST:SIMPLE(filecheck=HLSL2):-target hlsl -stage compute -entry scenario2
 
 groupshared IValue sharedArray[4];
 
+// SPV2: OpEntryPoint
+// HLSL2: groupshared
 [numthreads(4, 1, 1)]
 void scenario2(uint3 tid : SV_DispatchThreadID)
 {


### PR DESCRIPTION
## Summary

Fixes #10144

- Fix type flow analysis to handle loads from global variables with interface types
- Enable `groupshared IFoo` and `groupshared IFoo arr[N]` to compile with dynamic dispatch on all targets

## Root Cause

The type flow analysis in `specializeModule` did not handle loads from global variables with interface types. Since global variables live at module scope, `tryGetInfo()` always returned `none()`, preventing the specialization pass from generating tagged-union-based dynamic dispatch code. This caused unresolved `lookupWitness` instructions to reach the emitters, triggering an ICE (error 99999) on all targets.

The struct-wrapping workaround (`groupshared struct { IFoo member; }`) worked because `get_field_addr` produces a function-local instruction that type flow analysis could track.

## Approach

Added a fallback in `analyzeLoad` (`slang-ir-typeflow-specialize.cpp`): when the address has no type flow info and the loaded type is a non-COM interface, enumerate all conforming types globally via `findGlobalTables()` -- the same path already used for resource pointers. This enables the existing specialization and dispatch machinery to work for bare interface-typed groupshared variables.

## Changes

- `source/slang/slang-ir-typeflow-specialize.cpp`: Add interface type fallback in `analyzeLoad`
- `tests/language-feature/dynamic-dispatch/diagnose-groupshared-interface.slang`: Enable previously disabled test (was `DISABLE_TEST`) with scenarios for direct interface variable and array of interfaces

## Test plan

- [x] Original reproducer compiles on SPIRV and HLSL (was ICE)
- [x] Array of interface types compiles on SPIRV and HLSL (was ICE)
- [x] Existing `groupshared-struct-with-interface.slang` test still passes
- [x] All 464 dynamic-dispatch tests pass (100%)
- [x] All 1170 language-feature tests pass (1 pre-existing failure on master: `ptr-extension.slang`)
- [x] CI full test suite
