### PR TITLE
Fix prelinkIR crash from self-referencing Generic subtrees

### DIFF
--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -2527,16 +2527,17 @@ void prelinkIR(Module* module, IRModule* irModule, const List<IRInst*>& external
         specContext.shared->symbols.remove(mangledName);
         specContext.builder->setInsertBefore(existingInst);
 
-        // Remove existing inst from the module before cloning so our duplication-check
-        // (`checkIRDuplicate`) doesn't complain.
-        existingInst->removeFromParent();
+        // Strip the linkage decoration from existingInst so that checkIRDuplicate
+        // (debug-only) won't find a name conflict when the clone is created.
+        // We intentionally keep existingInst in the module tree so that its children
+        // (e.g. Specialize insts inside a Generic's body that reference the Generic
+        // itself) remain connected to the module during replaceUsesWith. Removing it
+        // from parent would orphan the entire subtree and crash the dedup/hoisting
+        // logic when it encounters those children as users with no module.
+        if (auto linkageDecor = existingInst->findDecoration<IRLinkageDecoration>())
+            linkageDecor->removeAndDeallocate();
 
         auto cloned = cloneValue(&specContext, originalInst);
-
-        // Replace uses and deallocate immediately rather than deferring to a second pass.
-        // Deferring causes crashes when existingInst A is a user of existingInst B: both
-        // get removed from parent in the first pass, then B's replaceUsesWith encounters
-        // orphaned A (no module) and crashes in the dedup/hoisting logic.
         existingInst->replaceUsesWith(cloned);
         existingInst->removeAndDeallocate();
     }

--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -2528,7 +2528,7 @@ void prelinkIR(Module* module, IRModule* irModule, const List<IRInst*>& external
         specContext.builder->setInsertBefore(existingInst);
 
         // Strip the linkage decoration from existingInst so that checkIRDuplicate
-        // (debug-only) won't find a name conflict when the clone is created.
+        // won't find a name conflict when the clone is created.
         // We intentionally keep existingInst in the module tree so that its children
         // (e.g. Specialize insts inside a Generic's body that reference the Generic
         // itself) remain connected to the module during replaceUsesWith. Removing it


### PR DESCRIPTION
Follow-up to #10835, which merged the two-phase prelinkIR loop into a single pass but did not fix the crash. The CI release build still segfaults when slang-bootstrap compiles neural.slang-module.

Root cause
----------

The previous fix addressed cross-references between *different* prelink symbols but missed self-referencing within a *single* symbol. A Generic inst (e.g. operator+<T>) contains a Block with a Specialize inst that references the Generic itself:

    Generic (existingInst)
      └── Block
            └── Specialize(thisGeneric, T)  -- points back to Generic

When prelinkIR calls existingInst->removeFromParent(), the entire subtree is disconnected from the module. Then replaceUsesWith walks all users of existingInst and finds the Specialize inside its own body. The Specialize is hoistable, so the dedup logic calls tryHoistInst, which does inst->getModule(). The parent chain walks:

    Specialize -> Block -> Generic -> parent=NULL

getModule() returns NULL and the code crashes.

Fix
---

Instead of removing existingInst from the module tree (which was only needed to prevent checkIRDuplicate from finding a name conflict in debug builds), strip the linkage decoration from existingInst before cloning. This avoids the debug duplicate-name check while keeping the entire subtree connected to the module, so all children have valid parent chains during replaceUsesWith.

The sequence is now:
  1. Remove linkage decoration (satisfies checkIRDuplicate)
  2. Clone from imported module
  3. replaceUsesWith (subtree still in module -- children are not orphaned)
  4. removeAndDeallocate (cleanup)

Made-with: Cursor