### PR TITLE
Fix Metal DescriptorHandle as_type cast in dynamic dispatch

### DIFF
--- a/source/slang/slang-emit-metal.cpp
+++ b/source/slang/slang-emit-metal.cpp
@@ -835,7 +835,6 @@ bool MetalSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inO
             return true;
         }
     case kIROp_CastDescriptorHandleToUInt64:
-    case kIROp_CastDescriptorHandleToUInt2:
         {
             // Metal: DescriptorHandle is a pointer; emit C-style cast to ulong.
             m_writer->emit("(ulong)(");
@@ -844,7 +843,6 @@ bool MetalSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inO
             return true;
         }
     case kIROp_CastUInt64ToDescriptorHandle:
-    case kIROp_CastUInt2ToDescriptorHandle:
         {
             // Metal: cast integer back to pointer type.
             m_writer->emit("(");

--- a/source/slang/slang-emit-metal.cpp
+++ b/source/slang/slang-emit-metal.cpp
@@ -834,6 +834,26 @@ bool MetalSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inO
             m_writer->emit(")");
             return true;
         }
+    case kIROp_CastDescriptorHandleToUInt64:
+    case kIROp_CastDescriptorHandleToUInt2:
+        {
+            // Metal: DescriptorHandle is a pointer; emit C-style cast to ulong.
+            m_writer->emit("(ulong)(");
+            emitOperand(inst->getOperand(0), getInfo(EmitOp::General));
+            m_writer->emit(")");
+            return true;
+        }
+    case kIROp_CastUInt64ToDescriptorHandle:
+    case kIROp_CastUInt2ToDescriptorHandle:
+        {
+            // Metal: cast integer back to pointer type.
+            m_writer->emit("(");
+            emitType(inst->getDataType());
+            m_writer->emit(")(");
+            emitOperand(inst->getOperand(0), getInfo(EmitOp::General));
+            m_writer->emit(")");
+            return true;
+        }
     case kIROp_BitCast:
         {
             auto toType = inst->getDataType();

--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -676,14 +676,12 @@ struct AnyValueMarshallingContext
                             kIROp_CastDescriptorHandleToUInt64,
                             1,
                             &srcVal);
-                        auto lowBits =
-                            builder->emitCast(builder->getUIntType(), uint64Val);
+                        auto lowBits = builder->emitCast(builder->getUIntType(), uint64Val);
                         auto highBits = builder->emitShr(
                             builder->getUInt64Type(),
                             uint64Val,
                             builder->getIntValue(builder->getIntType(), 32));
-                        highBits =
-                            builder->emitCast(builder->getUIntType(), highBits);
+                        highBits = builder->emitCast(builder->getUIntType(), highBits);
 
                         auto dstAddr0 = builder->emitFieldAddress(
                             uintPtrType,
@@ -698,6 +696,9 @@ struct AnyValueMarshallingContext
                     }
                     else
                     {
+                        // Metal pointers are always 8 bytes; bitcast is invalid for
+                        // pointers on Metal so this path must not be reached.
+                        SLANG_ASSERT(!isMetalTarget(targetRequest));
                         // CUDA/CPU: bitcast works for non-pointer native handles
                         auto uintVectorType =
                             builder->getVectorType(builder->getUIntType(), numFieldsNeeded);
@@ -1092,18 +1093,14 @@ struct AnyValueMarshallingContext
                             anyValInfo->fieldKeys[fieldOffset + 1]);
                         auto highBits = builder->emitLoad(srcAddr1);
 
-                        auto lowBits64 =
-                            builder->emitCast(builder->getUInt64Type(), lowBits);
-                        auto highBits64 =
-                            builder->emitCast(builder->getUInt64Type(), highBits);
+                        auto lowBits64 = builder->emitCast(builder->getUInt64Type(), lowBits);
+                        auto highBits64 = builder->emitCast(builder->getUInt64Type(), highBits);
                         auto shiftedHigh = builder->emitShl(
                             builder->getUInt64Type(),
                             highBits64,
                             builder->getIntValue(builder->getIntType(), 32));
-                        auto combined = builder->emitBitOr(
-                            builder->getUInt64Type(),
-                            lowBits64,
-                            shiftedHigh);
+                        auto combined =
+                            builder->emitBitOr(builder->getUInt64Type(), lowBits64, shiftedHigh);
 
                         auto result = builder->emitIntrinsicInst(
                             dataType,
@@ -1114,6 +1111,9 @@ struct AnyValueMarshallingContext
                     }
                     else
                     {
+                        // Metal pointers are always 8 bytes; bitcast is invalid for
+                        // pointers on Metal so this path must not be reached.
+                        SLANG_ASSERT(!isMetalTarget(targetRequest));
                         // CUDA/CPU: bitcast works for non-pointer native handles
                         auto uintVectorType =
                             builder->getVectorType(builder->getUIntType(), numFieldsNeeded);
@@ -1128,10 +1128,8 @@ struct AnyValueMarshallingContext
                             components[i] = builder->emitLoad(srcAddr);
                         }
 
-                        auto uintVecVal = builder->emitMakeVector(
-                            uintVectorType,
-                            numFieldsNeeded,
-                            components);
+                        auto uintVecVal =
+                            builder->emitMakeVector(uintVectorType, numFieldsNeeded, components);
                         auto result = builder->emitBitCast(dataType, uintVecVal);
                         builder->emitStore(concreteVar, result);
                     }

--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -5,6 +5,7 @@
 #include "slang-ir-layout.h"
 #include "slang-ir-util.h"
 #include "slang-legalize-types.h"
+#include "slang-target.h"
 
 namespace Slang
 {
@@ -654,7 +655,6 @@ struct AnyValueMarshallingContext
             {
                 // Bindless targets (CUDA, CPU, Metal): DescriptorHandle is a native type
                 // Marshal as raw bytes based on actual size (8 or 16 bytes)
-                // Use uint2 instead of uint64 to avoid Int64 capability requirement
                 SLANG_UNUSED(dataType);
 
                 auto srcVal = builder->emitLoad(concreteVar);
@@ -666,18 +666,52 @@ struct AnyValueMarshallingContext
                 if (fieldOffset + numFieldsNeeded <=
                     static_cast<uint32_t>(anyValInfo->fieldKeys.getCount()))
                 {
-                    auto uintVectorType =
-                        builder->getVectorType(builder->getUIntType(), numFieldsNeeded);
-                    auto uintVectorVal = builder->emitBitCast(uintVectorType, srcVal);
-
-                    for (IRIntegerValue i = 0; i < numFieldsNeeded; i++)
+                    if (isMetalTarget(targetRequest) && sizeInBytes == 8)
                     {
-                        auto bits = builder->emitElementExtract(uintVectorVal, i);
-                        auto dstAddr = builder->emitFieldAddress(
+                        // Metal: DescriptorHandle is a pointer; as_type<> can't cast
+                        // between pointer and non-pointer types. Convert through uint64
+                        // using CastDescriptorHandleToUInt64 which emits a C-style cast.
+                        auto uint64Val = builder->emitIntrinsicInst(
+                            builder->getUInt64Type(),
+                            kIROp_CastDescriptorHandleToUInt64,
+                            1,
+                            &srcVal);
+                        auto lowBits =
+                            builder->emitCast(builder->getUIntType(), uint64Val);
+                        auto highBits = builder->emitShr(
+                            builder->getUInt64Type(),
+                            uint64Val,
+                            builder->getIntValue(builder->getIntType(), 32));
+                        highBits =
+                            builder->emitCast(builder->getUIntType(), highBits);
+
+                        auto dstAddr0 = builder->emitFieldAddress(
                             uintPtrType,
                             anyValueVar,
-                            anyValInfo->fieldKeys[fieldOffset + i]);
-                        builder->emitStore(dstAddr, bits);
+                            anyValInfo->fieldKeys[fieldOffset]);
+                        builder->emitStore(dstAddr0, lowBits);
+                        auto dstAddr1 = builder->emitFieldAddress(
+                            uintPtrType,
+                            anyValueVar,
+                            anyValInfo->fieldKeys[fieldOffset + 1]);
+                        builder->emitStore(dstAddr1, highBits);
+                    }
+                    else
+                    {
+                        // CUDA/CPU: bitcast works for non-pointer native handles
+                        auto uintVectorType =
+                            builder->getVectorType(builder->getUIntType(), numFieldsNeeded);
+                        auto uintVectorVal = builder->emitBitCast(uintVectorType, srcVal);
+
+                        for (IRIntegerValue i = 0; i < numFieldsNeeded; i++)
+                        {
+                            auto bits = builder->emitElementExtract(uintVectorVal, i);
+                            auto dstAddr = builder->emitFieldAddress(
+                                uintPtrType,
+                                anyValueVar,
+                                anyValInfo->fieldKeys[fieldOffset + i]);
+                            builder->emitStore(dstAddr, bits);
+                        }
                     }
                 }
                 advanceOffset((uint32_t)sizeInBytes);
@@ -1033,7 +1067,6 @@ struct AnyValueMarshallingContext
             {
                 // Bindless targets (CUDA, CPU, Metal): DescriptorHandle is a native type
                 // Unmarshal from raw bytes based on actual size (8 or 16 bytes)
-                // Use uint2 instead of uint64 to avoid Int64 capability requirement
 
                 // sizeInBytes should be either 8 or 16
                 const IRIntegerValue numFieldsNeeded = (sizeInBytes + 3) / 4;
@@ -1042,23 +1075,66 @@ struct AnyValueMarshallingContext
                 if (fieldOffset + numFieldsNeeded <=
                     static_cast<uint32_t>(anyValInfo->fieldKeys.getCount()))
                 {
-                    auto uintVectorType =
-                        builder->getVectorType(builder->getUIntType(), numFieldsNeeded);
-                    IRInst* components[4]; // max 4 uints needed
-
-                    for (IRIntegerValue i = 0; i < numFieldsNeeded; i++)
+                    if (isMetalTarget(targetRequest) && sizeInBytes == 8)
                     {
-                        auto srcAddr = builder->emitFieldAddress(
+                        // Metal: DescriptorHandle is a pointer; as_type<> can't cast
+                        // between pointer and non-pointer types. Reconstruct through
+                        // uint64 using CastUInt64ToDescriptorHandle.
+                        auto srcAddr0 = builder->emitFieldAddress(
                             uintPtrType,
                             anyValueVar,
-                            anyValInfo->fieldKeys[fieldOffset + i]);
-                        components[i] = builder->emitLoad(srcAddr);
-                    }
+                            anyValInfo->fieldKeys[fieldOffset]);
+                        auto lowBits = builder->emitLoad(srcAddr0);
 
-                    auto uintVecVal =
-                        builder->emitMakeVector(uintVectorType, numFieldsNeeded, components);
-                    auto result = builder->emitBitCast(dataType, uintVecVal);
-                    builder->emitStore(concreteVar, result);
+                        auto srcAddr1 = builder->emitFieldAddress(
+                            uintPtrType,
+                            anyValueVar,
+                            anyValInfo->fieldKeys[fieldOffset + 1]);
+                        auto highBits = builder->emitLoad(srcAddr1);
+
+                        auto lowBits64 =
+                            builder->emitCast(builder->getUInt64Type(), lowBits);
+                        auto highBits64 =
+                            builder->emitCast(builder->getUInt64Type(), highBits);
+                        auto shiftedHigh = builder->emitShl(
+                            builder->getUInt64Type(),
+                            highBits64,
+                            builder->getIntValue(builder->getIntType(), 32));
+                        auto combined = builder->emitBitOr(
+                            builder->getUInt64Type(),
+                            lowBits64,
+                            shiftedHigh);
+
+                        auto result = builder->emitIntrinsicInst(
+                            dataType,
+                            kIROp_CastUInt64ToDescriptorHandle,
+                            1,
+                            &combined);
+                        builder->emitStore(concreteVar, result);
+                    }
+                    else
+                    {
+                        // CUDA/CPU: bitcast works for non-pointer native handles
+                        auto uintVectorType =
+                            builder->getVectorType(builder->getUIntType(), numFieldsNeeded);
+                        IRInst* components[4]; // max 4 uints needed
+
+                        for (IRIntegerValue i = 0; i < numFieldsNeeded; i++)
+                        {
+                            auto srcAddr = builder->emitFieldAddress(
+                                uintPtrType,
+                                anyValueVar,
+                                anyValInfo->fieldKeys[fieldOffset + i]);
+                            components[i] = builder->emitLoad(srcAddr);
+                        }
+
+                        auto uintVecVal = builder->emitMakeVector(
+                            uintVectorType,
+                            numFieldsNeeded,
+                            components);
+                        auto result = builder->emitBitCast(dataType, uintVecVal);
+                        builder->emitStore(concreteVar, result);
+                    }
                 }
                 advanceOffset((uint32_t)sizeInBytes);
             }

--- a/tests/language-feature/dynamic-dispatch/layout-descriptor-handle-array.slang
+++ b/tests/language-feature/dynamic-dispatch/layout-descriptor-handle-array.slang
@@ -6,7 +6,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type -render-feature bindless -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -profile sm_6_6 -render-feature bindless
-// Metal disabled: DescriptorHandle as_type cast bug (https://github.com/shader-slang/slang/issues/10477)
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-mtl -compute -shaderobj -output-using-type
 
 interface IIndexedSource
 {

--- a/tests/language-feature/dynamic-dispatch/layout-descriptor-handle-dispatch.slang
+++ b/tests/language-feature/dynamic-dispatch/layout-descriptor-handle-dispatch.slang
@@ -7,7 +7,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type -render-feature bindless -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -profile sm_6_6 -render-feature bindless
-// Metal disabled: DescriptorHandle as_type cast bug (https://github.com/shader-slang/slang/issues/10477)
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-mtl -compute -shaderobj -output-using-type
 
 interface IDataSource
 {

--- a/tests/language-feature/dynamic-dispatch/layout-descriptor-handle-multi.slang
+++ b/tests/language-feature/dynamic-dispatch/layout-descriptor-handle-multi.slang
@@ -7,7 +7,7 @@
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type -render-feature bindless -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -profile sm_6_6 -render-feature bindless
-// Metal disabled: DescriptorHandle as_type cast bug (https://github.com/shader-slang/slang/issues/10477)
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-mtl -compute -shaderobj -output-using-type
 
 interface IMultiSource
 {

--- a/tests/metal/descriptor-handle-dynamic-dispatch.slang
+++ b/tests/metal/descriptor-handle-dynamic-dispatch.slang
@@ -1,0 +1,54 @@
+// Regression test for https://github.com/shader-slang/slang/issues/10477
+// DescriptorHandle<T> in dynamic dispatch must not emit as_type<> casts
+// between pointer and non-pointer types on Metal. Instead, the pack/unpack
+// should go through ulong (C-style cast) to convert pointer <-> integer.
+
+//TEST:SIMPLE(filecheck=CHECK):-target metal -entry computeMain -stage compute
+
+interface ISource
+{
+    float get(int i);
+}
+
+struct BufSource : ISource
+{
+    StructuredBuffer<float>.Handle h;
+    float get(int i) { return h[i]; }
+}
+
+struct ConstSource : ISource
+{
+    float v;
+    float get(int i) { return v; }
+}
+
+ISource make(int kind, StructuredBuffer<float>.Handle h)
+{
+    if (kind == 0)
+    {
+        BufSource s;
+        s.h = h;
+        return s;
+    }
+    ConstSource c;
+    c.v = 1.0;
+    return c;
+}
+
+uniform StructuredBuffer<float>.Handle buf;
+RWStructuredBuffer<float> output;
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    ISource src = make(0, buf);
+    output[0] = src.get(0);
+}
+
+// Verify pack uses (ulong) cast, not as_type
+// CHECK: (ulong)(
+// Verify unpack uses pointer cast from ulong, not as_type
+// CHECK: (float device*)(
+// Verify no as_type casts involving pointers appear
+// CHECK-NOT: as_type<uint2>({{.*}}device
+// CHECK-NOT: as_type<float device


### PR DESCRIPTION
## Summary

Fixes #10477

- On Metal, `DescriptorHandle<T>` is emitted as a pointer type (e.g., `device float*`), but the AnyValue pack/unpack code used `emitBitCast` which becomes `as_type<>` in Metal — invalid for pointer↔non-pointer casts
- For Metal targets, convert through `uint64` using `CastDescriptorHandleToUInt64`/`CastUInt64ToDescriptorHandle` IR ops with C-style casts `(ulong)(ptr)` / `(ptrType)(ulong_val)` in the Metal emitter, then split/combine via standard integer shift/truncate operations
- Re-enables Metal test lines in existing `layout-descriptor-handle-{dispatch,multi,array}.slang` tests

### Changes
- `source/slang/slang-ir-any-value-marshalling.cpp`: Metal-specific path in bindless `marshalDescriptorHandle` that avoids bitcast between pointer and non-pointer types
- `source/slang/slang-emit-metal.cpp`: Override `CastDescriptorHandleToUInt64`/`CastUInt64ToDescriptorHandle` (and UInt2 variants) to emit proper pointer↔integer C-style casts
- `tests/metal/descriptor-handle-dynamic-dispatch.slang`: New compile-only regression test verifying the Metal output uses `(ulong)` casts instead of `as_type`

## Test plan

- [x] New `tests/metal/descriptor-handle-dynamic-dispatch.slang` compile test (filecheck on Metal output)
- [x] Existing `layout-descriptor-handle-dispatch.slang` CPU test passes
- [x] Existing `layout-descriptor-handle-multi.slang` CPU test passes
- [x] Existing `layout-descriptor-handle-array.slang` CPU test passes
- [x] CI: Metal GPU tests for re-enabled `-mtl` test lines
