### PR TITLE
Fix GLSL emitter missing bitCast from UInt64/Int64 to Double

### DIFF
--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -2406,6 +2406,20 @@ bool GLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
                     break;
                 }
                 break;
+            case BaseType::Double:
+                switch (fromType)
+                {
+                case BaseType::UInt64:
+                    m_writer->emit("uint64BitsToDouble");
+                    break;
+                case BaseType::Int64:
+                    m_writer->emit("int64BitsToDouble");
+                    break;
+                default:
+                    emitType(inst->getDataType());
+                    break;
+                }
+                break;
             case BaseType::Bool:
                 m_writer->emit("bool");
                 break;

--- a/tests/language-feature/dynamic-dispatch/glsl-double-bitcast.slang
+++ b/tests/language-feature/dynamic-dispatch/glsl-double-bitcast.slang
@@ -31,11 +31,18 @@ IValue makeValue(int kind)
     FloatImpl f; f.val = 1.0; return f;
 }
 
+// AnyValue unmarshalling reconstructs double via UInt64:
 // CHECK: uint64BitsToDouble
+
+// Explicit bit_cast exercises the Int64 -> Double path:
+// CHECK: int64BitsToDouble
 
 [numthreads(1, 1, 1)]
 void computeMain()
 {
     IValue v = makeValue(kindBuffer[0]);
     outputBuffer[0] = v.asFloat();
+
+    int64_t signedBits = int64_t(kindBuffer[0]);
+    outputBuffer[1] = float(bit_cast<double>(signedBits));
 }

--- a/tests/language-feature/dynamic-dispatch/glsl-double-bitcast.slang
+++ b/tests/language-feature/dynamic-dispatch/glsl-double-bitcast.slang
@@ -1,0 +1,41 @@
+// Regression test for GitHub issue #10505:
+// GLSL emitter was missing the bitCast from UInt64/Int64 to Double,
+// causing ICE E99999 when AnyValue unmarshalling generates
+// bitCast(UInt64) -> Double.
+
+//TEST:SIMPLE(filecheck=CHECK): -target glsl -stage compute -entry computeMain
+
+interface IValue
+{
+    float asFloat();
+}
+
+struct DoubleImpl : IValue
+{
+    double val;
+    float asFloat() { return float(val); }
+}
+
+struct FloatImpl : IValue
+{
+    float val;
+    float asFloat() { return val; }
+}
+
+RWStructuredBuffer<float> outputBuffer;
+StructuredBuffer<int> kindBuffer;
+
+IValue makeValue(int kind)
+{
+    if (kind == 0) { DoubleImpl d; d.val = 3.25; return d; }
+    FloatImpl f; f.val = 1.0; return f;
+}
+
+// CHECK: uint64BitsToDouble
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    IValue v = makeValue(kindBuffer[0]);
+    outputBuffer[0] = v.asFloat();
+}


### PR DESCRIPTION
## Summary

Fixes #10505

- Add missing `BaseType::Double` case to the `kIROp_BitCast` handler in the GLSL emitter, using standard GLSL builtins `uint64BitsToDouble` and `int64BitsToDouble`
- These mirror the already-handled reverse conversions (`doubleBitsToUint64`, `doubleBitsToInt64`)
- Add regression test that verifies GLSL compilation of dynamic dispatch with `double`-carrying structs

## Root Cause

The `switch (toType)` in `slang-emit-glsl.cpp` (line ~2294) handles many base types but was missing `BaseType::Double`. When AnyValue unmarshalling generates `bitCast(UInt64) → Double`, the switch falls through to `default:` → `diagnoseUnhandledInst()` → ICE E99999. The direct SPIR-V emitter and HLSL emitter both handle this correctly.

## Alternatives Considered

None — this is a straightforward missing-case fix following the exact pattern established by adjacent code (e.g., `BaseType::Float` dispatching to `intBitsToFloat`/`uintBitsToFloat`).

## Test Plan

- [x] New test `tests/language-feature/dynamic-dispatch/glsl-double-bitcast.slang` — verifies `uint64BitsToDouble` appears in GLSL output
- [x] Existing `layout-64bit-scalar.slang` and `layout-64bit-vector.slang` continue to pass on CPU
- [x] CI: existing tests `layout-64bit-scalar.slang` and `layout-64bit-vector.slang` should now pass the "Test Slang via glsl" step (previously failing per #10505)
