### PR TITLE
Fix crash when entry point param is a struct containing an interface field

### DIFF
--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -2621,18 +2621,18 @@ struct TypeFlowSpecializationContext
 
                 // When accessing an interface-typed field and no fieldInfo has been
                 // propagated, fall back to enumerating global witness tables.
-                // See the analogous logic in analyzeFieldExtract.
+                // See the analogous logic in analyzeLoad for direct interface
+                // loads from resource pointers.
                 if (auto interfaceType = as<IRInterfaceType>(structField->getFieldType()))
                 {
                     if (!isComInterfaceType(interfaceType))
                     {
-                        HashSet<IRInst*>& tables =
-                            *module->getContainerPool().getHashSet<IRInst>();
+                        HashSet<IRInst*>& tables = *module->getContainerPool().getHashSet<IRInst>();
                         collectExistentialTables(interfaceType, tables);
                         if (tables.getCount() > 0)
                         {
-                            auto valueInfo = makeTaggedUnionType(as<IRWitnessTableSet>(
-                                builder.getSet(kIROp_WitnessTableSet, tables)));
+                            auto valueInfo = makeTaggedUnionType(
+                                as<IRWitnessTableSet>(builder.getSet(kIROp_WitnessTableSet, tables)));
                             module->getContainerPool().free(&tables);
                             return builder.getPtrTypeWithAddressSpace(
                                 (IRType*)valueInfo,
@@ -2678,13 +2678,12 @@ struct TypeFlowSpecializationContext
             {
                 if (!isComInterfaceType(interfaceType))
                 {
-                    HashSet<IRInst*>& tables =
-                        *module->getContainerPool().getHashSet<IRInst>();
+                    HashSet<IRInst*>& tables = *module->getContainerPool().getHashSet<IRInst>();
                     collectExistentialTables(interfaceType, tables);
                     if (tables.getCount() > 0)
                     {
-                        auto result = makeTaggedUnionType(as<IRWitnessTableSet>(
-                            builder.getSet(kIROp_WitnessTableSet, tables)));
+                        auto result = makeTaggedUnionType(
+                            as<IRWitnessTableSet>(builder.getSet(kIROp_WitnessTableSet, tables)));
                         module->getContainerPool().free(&tables);
                         return result;
                     }

--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -2631,8 +2631,8 @@ struct TypeFlowSpecializationContext
                         collectExistentialTables(interfaceType, tables);
                         if (tables.getCount() > 0)
                         {
-                            auto valueInfo = makeTaggedUnionType(
-                                as<IRWitnessTableSet>(builder.getSet(kIROp_WitnessTableSet, tables)));
+                            auto valueInfo = makeTaggedUnionType(as<IRWitnessTableSet>(
+                                builder.getSet(kIROp_WitnessTableSet, tables)));
                             module->getContainerPool().free(&tables);
                             return builder.getPtrTypeWithAddressSpace(
                                 (IRType*)valueInfo,
@@ -2682,8 +2682,8 @@ struct TypeFlowSpecializationContext
                     collectExistentialTables(interfaceType, tables);
                     if (tables.getCount() > 0)
                     {
-                        auto result = makeTaggedUnionType(
-                            as<IRWitnessTableSet>(builder.getSet(kIROp_WitnessTableSet, tables)));
+                        auto result = makeTaggedUnionType(as<IRWitnessTableSet>(
+                            builder.getSet(kIROp_WitnessTableSet, tables)));
                         module->getContainerPool().free(&tables);
                         return result;
                     }

--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -2618,6 +2618,29 @@ struct TypeFlowSpecializationContext
                         (IRType*)this->fieldInfo[structField],
                         as<IRPtrTypeBase>(fieldAddress->getDataType()));
                 }
+
+                // When accessing an interface-typed field and no fieldInfo has been
+                // propagated, fall back to enumerating global witness tables.
+                // See the analogous logic in analyzeFieldExtract.
+                if (auto interfaceType = as<IRInterfaceType>(structField->getFieldType()))
+                {
+                    if (!isComInterfaceType(interfaceType))
+                    {
+                        HashSet<IRInst*>& tables =
+                            *module->getContainerPool().getHashSet<IRInst>();
+                        collectExistentialTables(interfaceType, tables);
+                        if (tables.getCount() > 0)
+                        {
+                            auto valueInfo = makeTaggedUnionType(as<IRWitnessTableSet>(
+                                builder.getSet(kIROp_WitnessTableSet, tables)));
+                            module->getContainerPool().free(&tables);
+                            return builder.getPtrTypeWithAddressSpace(
+                                (IRType*)valueInfo,
+                                as<IRPtrTypeBase>(fieldAddress->getDataType()));
+                        }
+                        module->getContainerPool().free(&tables);
+                    }
+                }
             }
         }
 
@@ -2644,6 +2667,29 @@ struct TypeFlowSpecializationContext
             if (this->fieldInfo.containsKey(structField))
             {
                 return this->fieldInfo[structField];
+            }
+
+            // When extracting an interface-typed field from a struct and no fieldInfo
+            // has been propagated (e.g. the struct was loaded from a constant buffer
+            // rather than constructed via MakeStruct), fall back to enumerating all
+            // globally available witness tables for the interface. This mirrors the
+            // logic in analyzeLoad for direct interface loads from resource pointers.
+            if (auto interfaceType = as<IRInterfaceType>(structField->getFieldType()))
+            {
+                if (!isComInterfaceType(interfaceType))
+                {
+                    HashSet<IRInst*>& tables =
+                        *module->getContainerPool().getHashSet<IRInst>();
+                    collectExistentialTables(interfaceType, tables);
+                    if (tables.getCount() > 0)
+                    {
+                        auto result = makeTaggedUnionType(as<IRWitnessTableSet>(
+                            builder.getSet(kIROp_WitnessTableSet, tables)));
+                        module->getContainerPool().free(&tables);
+                        return result;
+                    }
+                    module->getContainerPool().free(&tables);
+                }
             }
         }
         return none();

--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -2641,6 +2641,17 @@ struct TypeFlowSpecializationContext
                         module->getContainerPool().free(&tables);
                     }
                 }
+                else if (
+                    auto boundInterfaceType = as<IRBoundInterfaceType>(structField->getFieldType()))
+                {
+                    auto valueInfo =
+                        makeTaggedUnionType(cast<IRWitnessTableSet>(builder.getSingletonSet(
+                            kIROp_WitnessTableSet,
+                            boundInterfaceType->getWitnessTable())));
+                    return builder.getPtrTypeWithAddressSpace(
+                        (IRType*)valueInfo,
+                        as<IRPtrTypeBase>(fieldAddress->getDataType()));
+                }
             }
         }
 
@@ -2682,13 +2693,20 @@ struct TypeFlowSpecializationContext
                     collectExistentialTables(interfaceType, tables);
                     if (tables.getCount() > 0)
                     {
-                        auto result = makeTaggedUnionType(as<IRWitnessTableSet>(
-                            builder.getSet(kIROp_WitnessTableSet, tables)));
+                        auto result = makeTaggedUnionType(
+                            as<IRWitnessTableSet>(builder.getSet(kIROp_WitnessTableSet, tables)));
                         module->getContainerPool().free(&tables);
                         return result;
                     }
                     module->getContainerPool().free(&tables);
                 }
+            }
+            else if (
+                auto boundInterfaceType = as<IRBoundInterfaceType>(structField->getFieldType()))
+            {
+                return makeTaggedUnionType(cast<IRWitnessTableSet>(builder.getSingletonSet(
+                    kIROp_WitnessTableSet,
+                    boundInterfaceType->getWitnessTable())));
             }
         }
         return none();

--- a/tests/language-feature/dynamic-dispatch/diagnose-entry-point-interface-in-struct.slang
+++ b/tests/language-feature/dynamic-dispatch/diagnose-entry-point-interface-in-struct.slang
@@ -1,10 +1,15 @@
 // A struct containing an interface-typed field used as an entry point
-// parameter currently crashes (SPIRV) or triggers an internal error (HLSL).
-// This test is disabled until the compiler properly handles existential
-// types nested inside struct-typed entry point parameters.
+// parameter should generate dynamic dispatch code when conformances
+// are registered.
+//
+// SPIRV and WGSL targets hit a separate assertion in storage-to-logical
+// type legalization and are left disabled until that is resolved.
 
-//DISABLED_TEST:SIMPLE(filecheck=CHECK): -target spirv -stage compute -entry computeMain -conformance "ImplA:IFoo=0"
-//DISABLED_TEST:SIMPLE(filecheck=CHECK): -target hlsl -stage compute -entry computeMain -conformance "ImplA:IFoo=0"
+//TEST:SIMPLE(filecheck=HLSL): -target hlsl -stage compute -entry computeMain -conformance "ImplA:IFoo=0" -conformance "ImplB:IFoo=1"
+//TEST:SIMPLE(filecheck=GLSL): -target glsl -stage compute -entry computeMain -conformance "ImplA:IFoo=0" -conformance "ImplB:IFoo=1"
+//DISABLED_TEST:SIMPLE(filecheck=SPIRV): -target spirv-asm -stage compute -entry computeMain -conformance "ImplA:IFoo=0" -conformance "ImplB:IFoo=1"
+//TEST:SIMPLE(filecheck=MTL): -target metal -stage compute -entry computeMain -conformance "ImplA:IFoo=0" -conformance "ImplB:IFoo=1"
+//DISABLED_TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage compute -entry computeMain -conformance "ImplA:IFoo=0" -conformance "ImplB:IFoo=1"
 
 [anyValueSize(16)]
 interface IFoo
@@ -18,6 +23,12 @@ struct ImplA : IFoo
     float getValue() { return v; }
 }
 
+struct ImplB : IFoo
+{
+    float v;
+    float getValue() { return v * 2.0; }
+}
+
 struct Params
 {
     IFoo foo;
@@ -26,7 +37,10 @@ struct Params
 
 RWStructuredBuffer<float> outputBuffer;
 
-// CHECK: computeMain
+// HLSL: s_dispatch_IFoo{{.*}}getValue
+// HLSL: void computeMain
+// GLSL: void main()
+// MTL: void computeMain
 [numthreads(1, 1, 1)]
 void computeMain(uniform Params p)
 {

--- a/tests/language-feature/dynamic-dispatch/diagnose-entry-point-interface-in-struct.slang
+++ b/tests/language-feature/dynamic-dispatch/diagnose-entry-point-interface-in-struct.slang
@@ -37,6 +37,11 @@ struct Params
 
 RWStructuredBuffer<float> outputBuffer;
 
+void takeRef(inout IFoo f, RWStructuredBuffer<float> buf)
+{
+    buf[1] = f.getValue();
+}
+
 // HLSL: s_dispatch_IFoo{{.*}}getValue
 // HLSL: void computeMain
 // GLSL: void main()
@@ -45,4 +50,5 @@ RWStructuredBuffer<float> outputBuffer;
 void computeMain(uniform Params p)
 {
     outputBuffer[0] = p.foo.getValue() * p.scale;
+    takeRef(p.foo, outputBuffer);
 }


### PR DESCRIPTION
## Summary

- Fix crash (SPIRV segfault / HLSL ICE 99999) when a `uniform` entry point parameter is a struct that contains an interface-typed field (#10261)
- The typeflow specialization pass now discovers witness tables for interface fields nested inside structs loaded from constant buffers, enabling proper dynamic dispatch code generation

## Root Cause

The typeflow analysis in `slang-ir-typeflow-specialize.cpp` has a fast-path in `analyzeLoad` that discovers witness tables when loading an interface type directly from a resource pointer (constant buffer). However, when the interface is nested inside a struct (`load(CB.p) : Params` → `get_field(_, foo) : IFoo`), the `load` sees a struct type and the `get_field` finds no `fieldInfo` because no `MakeStruct` ever created the value — it came from GPU memory.

## Fix

In `analyzeFieldExtract` and `analyzeFieldAddress`, when extracting/accessing an interface-typed field from a struct and `fieldInfo` has no entry, fall back to enumerating globally available witness tables for that interface — mirroring the existing logic in `analyzeLoad` for direct interface loads from resource pointers.

## Test Plan

- [x] Enable the previously-disabled test `diagnose-entry-point-interface-in-struct.slang` for HLSL, GLSL, and Metal targets with multi-conformance dispatch
- [x] Verify `s_dispatch_IFoo_getValue` switch-based dispatch function is generated in HLSL output
- [x] All 542 dynamic-dispatch tests pass
- [x] All 1475 language-feature tests pass
- [x] All 159 unit tests pass

## Notes

SPIRV and WGSL targets hit a separate assertion (`resultType`) in the storage-to-logical type legalization step. This is a distinct downstream issue and those test targets remain disabled.

Fixes #10261
