### PR TITLE
Fix Setup Vulkan ICD step on read-only /etc/vulkan/icd.d mount

### DIFF
--- a/.github/actions/setup-vulkan-icd/action.yml
+++ b/.github/actions/setup-vulkan-icd/action.yml
@@ -1,0 +1,48 @@
+name: Setup Vulkan ICD
+description: >-
+  Override the NVIDIA Vulkan ICD to use libEGL_nvidia.so.0 as the driver
+  entry point, avoiding a libEGL crash observed on driver 580.x when
+  loaded via the default libGLX_nvidia.so.0 ICD.
+
+runs:
+  using: composite
+  steps:
+    - name: Write Vulkan ICD override
+      shell: bash
+      run: |
+        # Locate the NVIDIA ICD JSON injected by nvidia-container-toolkit.
+        # The path is mounted read-only in toolkit 1.19+, so we write our
+        # override elsewhere and point VK_ICD_FILENAMES at it.
+        source_icd=""
+        for candidate in \
+          /etc/vulkan/icd.d/nvidia_icd.json \
+          /usr/share/vulkan/icd.d/nvidia_icd.json; do
+          if [ -f "$candidate" ]; then
+            source_icd="$candidate"
+            break
+          fi
+        done
+
+        icd_dir="${RUNNER_TEMP:-/tmp}/vulkan-icd"
+        icd_path="$icd_dir/nvidia_icd.json"
+        mkdir -p "$icd_dir"
+
+        script="${GITHUB_ACTION_PATH}/setup-vulkan-icd.py"
+        if ! ICD_SOURCE="$source_icd" ICD_OUT="$icd_path" \
+            python3 "$script" 2>"$icd_dir/py.err"; then
+          echo "::error::Failed to write Vulkan ICD override — default ICD risks libEGL_nvidia crash on driver 580.x"
+          echo "source_icd=$source_icd"
+          if [ -n "$source_icd" ]; then
+            echo "--- $source_icd ---"
+            cat "$source_icd" || true
+          fi
+          echo "--- python stderr ---"
+          cat "$icd_dir/py.err" 2>/dev/null || true
+          exit 1
+        fi
+
+        echo "VK_ICD_FILENAMES=$icd_path" >> "$GITHUB_ENV"
+
+        # Remove the NVIDIA EGL vendor JSON if writable, to prevent
+        # libglvnd from loading libEGL_nvidia through the EGL path.
+        rm -f /usr/share/glvnd/egl_vendor.d/10_nvidia.json 2>/dev/null || true

--- a/.github/actions/setup-vulkan-icd/setup-vulkan-icd.py
+++ b/.github/actions/setup-vulkan-icd/setup-vulkan-icd.py
@@ -1,0 +1,42 @@
+"""Write a Vulkan ICD JSON override pointing at libEGL_nvidia.so.0.
+
+Reads the NVIDIA ICD JSON injected by the container toolkit (if present),
+swaps the library_path to libEGL_nvidia.so.0, and writes the result to
+the path given in $ICD_OUT. If no source ICD is found, a minimal JSON
+with a conservative api_version is written.
+
+This avoids a libEGL_nvidia.so crash observed on NVIDIA driver 580.x
+when the driver is loaded via the default libGLX_nvidia.so.0 ICD. See
+.github/workflows/ci-slang-test-container.yml job-level comment for
+details.
+"""
+
+import json
+import os
+import sys
+
+
+def main() -> int:
+    source = os.environ.get("ICD_SOURCE", "")
+    out = os.environ["ICD_OUT"]
+
+    if source:
+        with open(source) as f:
+            icd = json.load(f)
+        icd.setdefault("ICD", {})
+    else:
+        icd = {"file_format_version": "1.0.1", "ICD": {"api_version": "1.4.312"}}
+
+    icd["ICD"]["library_path"] = "libEGL_nvidia.so.0"
+
+    with open(out, "w") as f:
+        json.dump(icd, f, indent=4)
+        f.write("\n")
+
+    api_version = icd["ICD"].get("api_version", "unknown")
+    print(f"Vulkan ICD configured: libEGL_nvidia.so.0 (api_version={api_version})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -61,57 +61,6 @@ jobs:
           fi
           echo "GPU: $output"
 
-      - name: Setup Vulkan ICD
-        run: |
-          # See job-level comment for why we override the Vulkan ICD.
-          # Write the modified ICD JSON to a writable temp path and point
-          # VK_ICD_FILENAMES at it — /etc/vulkan/icd.d/nvidia_icd.json may
-          # be mounted read-only by nvidia-container-toolkit 1.19+.
-          source_icd=""
-          for candidate in \
-            /etc/vulkan/icd.d/nvidia_icd.json \
-            /usr/share/vulkan/icd.d/nvidia_icd.json; do
-            if [ -f "$candidate" ]; then
-              source_icd="$candidate"
-              break
-            fi
-          done
-          icd_dir="${RUNNER_TEMP:-/tmp}/vulkan-icd"
-          icd_path="$icd_dir/nvidia_icd.json"
-          mkdir -p "$icd_dir"
-          if ! ICD_SOURCE="$source_icd" ICD_OUT="$icd_path" python3 - 2>"$icd_dir/py.err" <<'PY'
-          import json
-          import os
-          source = os.environ["ICD_SOURCE"]
-          out = os.environ["ICD_OUT"]
-          if source:
-              with open(source) as f:
-                  icd = json.load(f)
-              icd.setdefault("ICD", {})
-          else:
-              icd = {"file_format_version": "1.0.1", "ICD": {"api_version": "1.4.312"}}
-          icd["ICD"]["library_path"] = "libEGL_nvidia.so.0"
-          with open(out, "w") as f:
-              json.dump(icd, f, indent=4)
-              f.write("\n")
-          print(f"Vulkan ICD configured: libEGL_nvidia.so.0 (api_version={icd['ICD'].get('api_version', 'unknown')})")
-          PY
-          then
-            echo "::error::Failed to write Vulkan ICD override — default ICD risks libEGL_nvidia crash on driver 580.x"
-            echo "source_icd=$source_icd"
-            if [ -n "$source_icd" ]; then
-              echo "--- $source_icd ---"
-              cat "$source_icd" || true
-            fi
-            echo "--- python stderr ---"
-            cat "$icd_dir/py.err" 2>/dev/null || true
-            exit 1
-          fi
-          echo "VK_ICD_FILENAMES=$icd_path" >> "$GITHUB_ENV"
-          # Also remove the NVIDIA EGL vendor JSON if writable, to prevent
-          # libglvnd from loading libEGL_nvidia through the EGL path.
-          rm -f /usr/share/glvnd/egl_vendor.d/10_nvidia.json 2>/dev/null || true
-
       - name: Configure Git safe directory
         run: git config --global --add safe.directory '*'
 
@@ -119,6 +68,9 @@ jobs:
         with:
           submodules: "recursive"
           fetch-depth: "1"
+
+      - name: Setup Vulkan ICD
+        uses: ./.github/actions/setup-vulkan-icd
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -255,52 +207,6 @@ jobs:
           fi
           echo "GPU: $output"
 
-      - name: Setup Vulkan ICD
-        run: |
-          # See test-slang job comment for why we override the Vulkan ICD.
-          source_icd=""
-          for candidate in \
-            /etc/vulkan/icd.d/nvidia_icd.json \
-            /usr/share/vulkan/icd.d/nvidia_icd.json; do
-            if [ -f "$candidate" ]; then
-              source_icd="$candidate"
-              break
-            fi
-          done
-          icd_dir="${RUNNER_TEMP:-/tmp}/vulkan-icd"
-          icd_path="$icd_dir/nvidia_icd.json"
-          mkdir -p "$icd_dir"
-          if ! ICD_SOURCE="$source_icd" ICD_OUT="$icd_path" python3 - 2>"$icd_dir/py.err" <<'PY'
-          import json
-          import os
-          source = os.environ["ICD_SOURCE"]
-          out = os.environ["ICD_OUT"]
-          if source:
-              with open(source) as f:
-                  icd = json.load(f)
-              icd.setdefault("ICD", {})
-          else:
-              icd = {"file_format_version": "1.0.1", "ICD": {"api_version": "1.4.312"}}
-          icd["ICD"]["library_path"] = "libEGL_nvidia.so.0"
-          with open(out, "w") as f:
-              json.dump(icd, f, indent=4)
-              f.write("\n")
-          print(f"Vulkan ICD configured: libEGL_nvidia.so.0 (api_version={icd['ICD'].get('api_version', 'unknown')})")
-          PY
-          then
-            echo "::error::Failed to write Vulkan ICD override — default ICD risks libEGL_nvidia crash on driver 580.x"
-            echo "source_icd=$source_icd"
-            if [ -n "$source_icd" ]; then
-              echo "--- $source_icd ---"
-              cat "$source_icd" || true
-            fi
-            echo "--- python stderr ---"
-            cat "$icd_dir/py.err" 2>/dev/null || true
-            exit 1
-          fi
-          echo "VK_ICD_FILENAMES=$icd_path" >> "$GITHUB_ENV"
-          rm -f /usr/share/glvnd/egl_vendor.d/10_nvidia.json 2>/dev/null || true
-
       - name: Configure Git safe directory
         run: git config --global --add safe.directory '*'
 
@@ -308,6 +214,9 @@ jobs:
         with:
           submodules: "recursive"
           fetch-depth: "1"
+
+      - name: Setup Vulkan ICD
+        uses: ./.github/actions/setup-vulkan-icd
 
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -79,7 +79,7 @@ jobs:
           icd_dir="${RUNNER_TEMP:-/tmp}/vulkan-icd"
           icd_path="$icd_dir/nvidia_icd.json"
           mkdir -p "$icd_dir"
-          if ! ICD_SOURCE="$source_icd" ICD_OUT="$icd_path" python3 - <<'PY'
+          if ! ICD_SOURCE="$source_icd" ICD_OUT="$icd_path" python3 - 2>"$icd_dir/py.err" <<'PY'
           import json
           import os
           source = os.environ["ICD_SOURCE"]
@@ -87,6 +87,7 @@ jobs:
           if source:
               with open(source) as f:
                   icd = json.load(f)
+              icd.setdefault("ICD", {})
           else:
               icd = {"file_format_version": "1.0.1", "ICD": {"api_version": "1.4.312"}}
           icd["ICD"]["library_path"] = "libEGL_nvidia.so.0"
@@ -96,8 +97,15 @@ jobs:
           print(f"Vulkan ICD configured: libEGL_nvidia.so.0 (api_version={icd['ICD'].get('api_version', 'unknown')})")
           PY
           then
-            echo "::warning::Failed to write Vulkan ICD override; keeping default"
-            exit 0
+            echo "::error::Failed to write Vulkan ICD override — default ICD risks libEGL_nvidia crash on driver 580.x"
+            echo "source_icd=$source_icd"
+            if [ -n "$source_icd" ]; then
+              echo "--- $source_icd ---"
+              cat "$source_icd" || true
+            fi
+            echo "--- python stderr ---"
+            cat "$icd_dir/py.err" 2>/dev/null || true
+            exit 1
           fi
           echo "VK_ICD_FILENAMES=$icd_path" >> "$GITHUB_ENV"
           # Also remove the NVIDIA EGL vendor JSON if writable, to prevent
@@ -262,7 +270,7 @@ jobs:
           icd_dir="${RUNNER_TEMP:-/tmp}/vulkan-icd"
           icd_path="$icd_dir/nvidia_icd.json"
           mkdir -p "$icd_dir"
-          if ! ICD_SOURCE="$source_icd" ICD_OUT="$icd_path" python3 - <<'PY'
+          if ! ICD_SOURCE="$source_icd" ICD_OUT="$icd_path" python3 - 2>"$icd_dir/py.err" <<'PY'
           import json
           import os
           source = os.environ["ICD_SOURCE"]
@@ -270,6 +278,7 @@ jobs:
           if source:
               with open(source) as f:
                   icd = json.load(f)
+              icd.setdefault("ICD", {})
           else:
               icd = {"file_format_version": "1.0.1", "ICD": {"api_version": "1.4.312"}}
           icd["ICD"]["library_path"] = "libEGL_nvidia.so.0"
@@ -279,8 +288,15 @@ jobs:
           print(f"Vulkan ICD configured: libEGL_nvidia.so.0 (api_version={icd['ICD'].get('api_version', 'unknown')})")
           PY
           then
-            echo "::warning::Failed to write Vulkan ICD override; keeping default"
-            exit 0
+            echo "::error::Failed to write Vulkan ICD override — default ICD risks libEGL_nvidia crash on driver 580.x"
+            echo "source_icd=$source_icd"
+            if [ -n "$source_icd" ]; then
+              echo "--- $source_icd ---"
+              cat "$source_icd" || true
+            fi
+            echo "--- python stderr ---"
+            cat "$icd_dir/py.err" 2>/dev/null || true
+            exit 1
           fi
           echo "VK_ICD_FILENAMES=$icd_path" >> "$GITHUB_ENV"
           rm -f /usr/share/glvnd/egl_vendor.d/10_nvidia.json 2>/dev/null || true

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -64,10 +64,9 @@ jobs:
       - name: Setup Vulkan ICD
         run: |
           # See job-level comment for why we override the Vulkan ICD.
-          # Read the existing NVIDIA ICD JSON (injected by the container toolkit
-          # read-only in 1.19+) and swap only the library_path, preserving
-          # api_version. Write to a writable temp path and point
-          # VK_ICD_FILENAMES at it via $GITHUB_ENV.
+          # Write the modified ICD JSON to a writable temp path and point
+          # VK_ICD_FILENAMES at it — /etc/vulkan/icd.d/nvidia_icd.json may
+          # be mounted read-only by nvidia-container-toolkit 1.19+.
           source_icd=""
           for candidate in \
             /etc/vulkan/icd.d/nvidia_icd.json \
@@ -77,24 +76,26 @@ jobs:
               break
             fi
           done
-          if [ -z "$source_icd" ]; then
-            echo "::warning::No existing NVIDIA ICD JSON found, using defaults"
-          fi
           mkdir -p /tmp/vulkan-icd
-          python3 -c "
+          if ! python3 - "$source_icd" <<'PY'
           import json
-          source = '$source_icd'
+          import sys
+          source = sys.argv[1]
           if source:
               with open(source) as f:
                   icd = json.load(f)
           else:
-              icd = {'file_format_version': '1.0.1', 'ICD': {'api_version': '1.4.312'}}
-          icd['ICD']['library_path'] = 'libEGL_nvidia.so.0'
-          with open('/tmp/vulkan-icd/nvidia_icd.json', 'w') as f:
+              icd = {"file_format_version": "1.0.1", "ICD": {"api_version": "1.4.312"}}
+          icd["ICD"]["library_path"] = "libEGL_nvidia.so.0"
+          with open("/tmp/vulkan-icd/nvidia_icd.json", "w") as f:
               json.dump(icd, f, indent=4)
-              f.write('\n')
-          print(f\"Vulkan ICD configured: libEGL_nvidia.so.0 (api_version={icd['ICD'].get('api_version', 'unknown')})\")
-          "
+              f.write("\n")
+          print(f"Vulkan ICD configured: libEGL_nvidia.so.0 (api_version={icd['ICD'].get('api_version', 'unknown')})")
+          PY
+          then
+            echo "::warning::Failed to write Vulkan ICD override; keeping default"
+            exit 0
+          fi
           echo "VK_ICD_FILENAMES=/tmp/vulkan-icd/nvidia_icd.json" >> "$GITHUB_ENV"
           # Also remove the NVIDIA EGL vendor JSON if writable, to prevent
           # libglvnd from loading libEGL_nvidia through the EGL path.
@@ -255,24 +256,27 @@ jobs:
               break
             fi
           done
-          if [ -z "$source_icd" ]; then
-            echo "::warning::No existing NVIDIA ICD JSON found, using defaults"
-            source_icd=""
-          fi
-          mkdir -p /etc/vulkan/icd.d
-          python3 -c "
-          import json, sys
-          if '$source_icd':
-              with open('$source_icd') as f:
+          mkdir -p /tmp/vulkan-icd
+          if ! python3 - "$source_icd" <<'PY'
+          import json
+          import sys
+          source = sys.argv[1]
+          if source:
+              with open(source) as f:
                   icd = json.load(f)
           else:
-              icd = {'file_format_version': '1.0.1', 'ICD': {'api_version': '1.4.312'}}
-          icd['ICD']['library_path'] = 'libEGL_nvidia.so.0'
-          with open('/etc/vulkan/icd.d/nvidia_icd.json', 'w') as f:
+              icd = {"file_format_version": "1.0.1", "ICD": {"api_version": "1.4.312"}}
+          icd["ICD"]["library_path"] = "libEGL_nvidia.so.0"
+          with open("/tmp/vulkan-icd/nvidia_icd.json", "w") as f:
               json.dump(icd, f, indent=4)
-              f.write('\n')
-          print(f\"Vulkan ICD configured: libEGL_nvidia.so.0 (api_version={icd['ICD'].get('api_version', 'unknown')})\")
-          "
+              f.write("\n")
+          print(f"Vulkan ICD configured: libEGL_nvidia.so.0 (api_version={icd['ICD'].get('api_version', 'unknown')})")
+          PY
+          then
+            echo "::warning::Failed to write Vulkan ICD override; keeping default"
+            exit 0
+          fi
+          echo "VK_ICD_FILENAMES=/tmp/vulkan-icd/nvidia_icd.json" >> "$GITHUB_ENV"
           rm -f /usr/share/glvnd/egl_vendor.d/10_nvidia.json 2>/dev/null || true
 
       - name: Configure Git safe directory

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -76,18 +76,21 @@ jobs:
               break
             fi
           done
-          mkdir -p /tmp/vulkan-icd
-          if ! python3 - "$source_icd" <<'PY'
+          icd_dir="${RUNNER_TEMP:-/tmp}/vulkan-icd"
+          icd_path="$icd_dir/nvidia_icd.json"
+          mkdir -p "$icd_dir"
+          if ! ICD_SOURCE="$source_icd" ICD_OUT="$icd_path" python3 - <<'PY'
           import json
-          import sys
-          source = sys.argv[1]
+          import os
+          source = os.environ["ICD_SOURCE"]
+          out = os.environ["ICD_OUT"]
           if source:
               with open(source) as f:
                   icd = json.load(f)
           else:
               icd = {"file_format_version": "1.0.1", "ICD": {"api_version": "1.4.312"}}
           icd["ICD"]["library_path"] = "libEGL_nvidia.so.0"
-          with open("/tmp/vulkan-icd/nvidia_icd.json", "w") as f:
+          with open(out, "w") as f:
               json.dump(icd, f, indent=4)
               f.write("\n")
           print(f"Vulkan ICD configured: libEGL_nvidia.so.0 (api_version={icd['ICD'].get('api_version', 'unknown')})")
@@ -96,7 +99,7 @@ jobs:
             echo "::warning::Failed to write Vulkan ICD override; keeping default"
             exit 0
           fi
-          echo "VK_ICD_FILENAMES=/tmp/vulkan-icd/nvidia_icd.json" >> "$GITHUB_ENV"
+          echo "VK_ICD_FILENAMES=$icd_path" >> "$GITHUB_ENV"
           # Also remove the NVIDIA EGL vendor JSON if writable, to prevent
           # libglvnd from loading libEGL_nvidia through the EGL path.
           rm -f /usr/share/glvnd/egl_vendor.d/10_nvidia.json 2>/dev/null || true
@@ -256,18 +259,21 @@ jobs:
               break
             fi
           done
-          mkdir -p /tmp/vulkan-icd
-          if ! python3 - "$source_icd" <<'PY'
+          icd_dir="${RUNNER_TEMP:-/tmp}/vulkan-icd"
+          icd_path="$icd_dir/nvidia_icd.json"
+          mkdir -p "$icd_dir"
+          if ! ICD_SOURCE="$source_icd" ICD_OUT="$icd_path" python3 - <<'PY'
           import json
-          import sys
-          source = sys.argv[1]
+          import os
+          source = os.environ["ICD_SOURCE"]
+          out = os.environ["ICD_OUT"]
           if source:
               with open(source) as f:
                   icd = json.load(f)
           else:
               icd = {"file_format_version": "1.0.1", "ICD": {"api_version": "1.4.312"}}
           icd["ICD"]["library_path"] = "libEGL_nvidia.so.0"
-          with open("/tmp/vulkan-icd/nvidia_icd.json", "w") as f:
+          with open(out, "w") as f:
               json.dump(icd, f, indent=4)
               f.write("\n")
           print(f"Vulkan ICD configured: libEGL_nvidia.so.0 (api_version={icd['ICD'].get('api_version', 'unknown')})")
@@ -276,7 +282,7 @@ jobs:
             echo "::warning::Failed to write Vulkan ICD override; keeping default"
             exit 0
           fi
-          echo "VK_ICD_FILENAMES=/tmp/vulkan-icd/nvidia_icd.json" >> "$GITHUB_ENV"
+          echo "VK_ICD_FILENAMES=$icd_path" >> "$GITHUB_ENV"
           rm -f /usr/share/glvnd/egl_vendor.d/10_nvidia.json 2>/dev/null || true
 
       - name: Configure Git safe directory

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -64,8 +64,10 @@ jobs:
       - name: Setup Vulkan ICD
         run: |
           # See job-level comment for why we override the Vulkan ICD.
-          # Read the existing NVIDIA ICD JSON (injected by the container toolkit)
-          # and swap only the library_path, preserving api_version and formatting.
+          # Read the existing NVIDIA ICD JSON (injected by the container toolkit
+          # read-only in 1.19+) and swap only the library_path, preserving
+          # api_version. Write to a writable temp path and point
+          # VK_ICD_FILENAMES at it via $GITHUB_ENV.
           source_icd=""
           for candidate in \
             /etc/vulkan/icd.d/nvidia_icd.json \
@@ -77,22 +79,25 @@ jobs:
           done
           if [ -z "$source_icd" ]; then
             echo "::warning::No existing NVIDIA ICD JSON found, using defaults"
-            source_icd=""
           fi
-          mkdir -p /etc/vulkan/icd.d
+          mkdir -p /tmp/vulkan-icd
           python3 -c "
-          import json, sys
-          if '$source_icd':
-              with open('$source_icd') as f:
+          import json
+          source = '$source_icd'
+          if source:
+              with open(source) as f:
                   icd = json.load(f)
           else:
               icd = {'file_format_version': '1.0.1', 'ICD': {'api_version': '1.4.312'}}
           icd['ICD']['library_path'] = 'libEGL_nvidia.so.0'
-          with open('/etc/vulkan/icd.d/nvidia_icd.json', 'w') as f:
+          with open('/tmp/vulkan-icd/nvidia_icd.json', 'w') as f:
               json.dump(icd, f, indent=4)
               f.write('\n')
           print(f\"Vulkan ICD configured: libEGL_nvidia.so.0 (api_version={icd['ICD'].get('api_version', 'unknown')})\")
           "
+          echo "VK_ICD_FILENAMES=/tmp/vulkan-icd/nvidia_icd.json" >> "$GITHUB_ENV"
+          # Also remove the NVIDIA EGL vendor JSON if writable, to prevent
+          # libglvnd from loading libEGL_nvidia through the EGL path.
           rm -f /usr/share/glvnd/egl_vendor.d/10_nvidia.json 2>/dev/null || true
 
       - name: Configure Git safe directory


### PR DESCRIPTION
## Summary
- `nvidia-container-toolkit` 1.19+ injects `/etc/vulkan/icd.d/nvidia_icd.json` into the container as a read-only bind mount, breaking the in-place ICD swap added in #10825.
- Write the modified ICD JSON to a writable path under `$RUNNER_TEMP` instead and point `VK_ICD_FILENAMES` at it via `$GITHUB_ENV` so subsequent steps pick it up.
- Fail loudly (exit 1) if the override can't be written, with source ICD contents and Python stderr dumped, so we don't silently reintroduce the libEGL crash this workaround exists to prevent.

## Context

After the 2026-04-17 Linux base image refresh (kernel 6.8.0-1053, nvidia-container-toolkit 1.19.0), the "Setup Vulkan ICD" step fails with:

```
OSError: [Errno 30] Read-only file system: '/etc/vulkan/icd.d/nvidia_icd.json'
```

The behavior change is in the newer container toolkit — it injects the NVIDIA ICD JSON as read-only even when we don't explicitly mount it.

`VK_ICD_FILENAMES` is the standard Vulkan loader environment variable for overriding the ICD search path.