### PR TITLE
Add implicit Optional<T>->Optional<U> coercion when T is coercible to U

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,6 +266,26 @@ Use the `/repro-remix` skill or see `extras/repro-remix.md`.
 - The enum values starting with `kIROp_` are defined in a generated file, `build/source/slang/fiddle/slang-ir-insts-enum.h.fiddle`
 - `FIDDLE()` and `FIDDLE(...)` statements in AST node declarations indicate that additional source is generated and included from `build/source/slang/fiddle`, providing static type system and reflection metadata, visitor support, and serialization support.
 
+### Adding a new AST expression node
+
+When adding a new `Expr` subclass (e.g. `FooExpr`) to `source/slang/slang-ast-expr.h`:
+
+1. Declare with `FIDDLE()` / `FIDDLE(...)` macros (required for code generation).
+2. Register in the visitor dispatch table in `source/slang/slang-check-impl.h` — find the block of `CASE(MakeOptionalExpr)` macros and add `CASE(FooExpr)`.
+3. Add `visitFooExpr` to `ExprVisitor` in `source/slang/slang-visitor.h` (follow the pattern of any nearby visitor).
+4. Add IR lowering (`visitFooExpr`) in `source/slang/slang-lower-to-ir.cpp`.
+5. Add a type-checking visitor stub in `source/slang/slang-check-decl.cpp`.
+6. Add an AST-iterator stub in `source/slang/slang-ast-iterator.h`.
+7. Add an LSP-lookup stub in `source/slang/slang-language-server-ast-lookup.cpp`.
+8. Optionally add a pretty-printer case in `source/slang/slang-ast-print.cpp`.
+9. After all edits, do a full build — the FIDDLE system regenerates dispatch glue automatically.
+
+### Type coercion system
+
+The coercion entry point is `SemanticsVisitor::_coerce()` in `source/slang/slang-check-conversion.cpp`. It follows a two-phase pattern: when `outToExpr == nullptr` it is a cost-probe (just compute `*outCost`); when `outToExpr != nullptr` it also constructs the AST expression. Always gate expression construction behind `if (outToExpr)`. Coercion costs are `ConversionCost` enum values defined in `source/slang/slang-ast-support-types.h`. The standard library `__implicit_conversion` attribute (in `source/slang/core.meta.slang`) is how user-visible implicit constructors expose themselves to the coercion system.
+
+**Synthetic VarDecl pattern for deferred inner conversions**: When a coercion expression needs to reference a value that only exists at IR lowering time (e.g., an extracted inner value from a conditional branch), create a synthetic `VarDecl` in the AST as a placeholder, build the inner conversion expression referencing that VarDecl, and store both in the AST node. In `visitXxxExpr` in `slang-lower-to-ir.cpp`, emit the IR value and call `context->setValue(syntheticVarDecl, LoweredValInfo::simple(irValue))` before lowering the inner expression — `emitDeclRef` / `visitVarExpr` uses `findLoweredDecl()` (walking `env->mapDeclToValue`) to resolve it.
+
 ### Git commit message
 
 - Don't mention Claude on the commit message

--- a/docs/language-reference/types-optional.md
+++ b/docs/language-reference/types-optional.md
@@ -1,0 +1,135 @@
+# Optional Types
+
+An `Optional<T>` value either holds a value of type `T` or holds no value.
+The absence of a value is represented by the `none` literal.
+
+## Declaration Syntax {#syntax}
+
+```slang
+Optional<T> varName;             // default-initialized to none
+Optional<T> varName = expr;      // initialized with a value of type T
+Optional<T> varName = none;      // explicitly initialized to none
+```
+
+### Parameters
+
+- `T` is the value type. `T` may be any Slang type including interface types and generics.
+
+## Members {#members}
+
+| Member | Type | Description |
+|---|---|---|
+| `hasValue` | `bool` | `true` when the optional holds a value; `false` when it is `none`. |
+| `value` | `T` | The held value. Accessing `value` when `hasValue` is `false` is undefined behavior. |
+
+## The `none` Literal {#none}
+
+The built-in keyword `none` represents the absent value.
+`none` is implicitly convertible to any `Optional<T>`.
+
+```slang
+Optional<int> a = none;    // no value
+bool absent = !a.hasValue; // true
+```
+
+## Implicit Coercions {#coercions}
+
+Three implicit coercions are defined for `Optional<T>`:
+
+### Value to Optional
+
+Any value of type `T` is implicitly convertible to `Optional<T>`.
+The resulting optional holds the value and `hasValue` is `true`.
+
+```slang
+int x = 42;
+Optional<int> opt = x;   // opt.hasValue == true, opt.value == 42
+```
+
+This applies in function call arguments, return statements, and initializers.
+
+### `none` to Optional
+
+`none` is implicitly convertible to any `Optional<T>` with `hasValue == false`.
+
+```slang
+Optional<float> f = none;  // f.hasValue == false
+```
+
+### Optional to Optional coercion {#optional-coercion}
+
+`Optional<T>` is implicitly convertible to `Optional<U>` when `T` is implicitly
+convertible to `U`. The coercion preserves the `hasValue` state: if the source is
+`none`, the result is `none`; if the source holds a value, the inner value is
+converted from `T` to `U` and the result holds that converted value.
+
+```slang
+Optional<int>   src = 7;
+Optional<float> dst = src;  // dst.hasValue == true, dst.value == 7.0
+
+Optional<int>   empty = none;
+Optional<float> emptyF = empty;  // emptyF.hasValue == false
+```
+
+This applies to all coercible inner types, including numeric promotions and
+concrete-to-interface upcasts:
+
+```slang
+interface IShape { int area(); }
+struct Square : IShape { int side; int area() { return side * side; } }
+
+Optional<Square>  sq = Square{ 3 };
+Optional<IShape>  sh = sq;  // sh.hasValue == true, sh.value.area() == 9
+```
+
+## Comparison with `none` {#comparison}
+
+An `Optional<T>` value may be compared to `none` using `==` and `!=`:
+
+```slang
+Optional<int> opt = 5;
+if (opt != none)
+    printf("%d\n", opt.value);  // prints 5
+```
+
+This is equivalent to testing `opt.hasValue`.
+
+## `if (let ...)` Syntax {#if-let}
+
+The `if (let name = expr)` syntax unwraps an `Optional<T>` in a single step.
+The body executes only when `expr` has a value; inside the body, `name` is
+bound to the unwrapped value of type `T`.
+
+```slang
+Optional<int> getVal() { ... }
+
+void example()
+{
+    if (let x = getVal())
+    {
+        // x has type int here
+        printf("%d\n", x);
+    }
+}
+```
+
+## Memory Layout {#layout}
+
+`Optional<T>` is lowered to a struct with two fields:
+
+```slang
+struct Optional<T> { T value; bool hasValue; }
+```
+
+The layout follows the same rules as a struct with those two members. The
+`value` field is always present in memory regardless of `hasValue`; reading
+`value` when `hasValue` is `false` is undefined behavior.
+
+> 📝 **Remark:** The layout is target-specific and subject to standard struct
+> alignment rules. Do not rely on a specific byte layout for serialization.
+
+## Restrictions {#restrictions}
+
+- `Optional<T>` cannot be used as the element type of a resource (e.g.,
+  `StructuredBuffer<Optional<T>>` is not supported).
+- Accessing `.value` when `.hasValue` is `false` is undefined behavior.

--- a/docs/language-reference/types.md
+++ b/docs/language-reference/types.md
@@ -6,6 +6,7 @@ Slang types:
 * [Structures](types-struct.md) and [Classes](types-class.md)
   * [Extensions](types-extension.md)
 * [Array Types](types-array.md)
+* [Optional Types](types-optional.md)
 * [Pointers](types-pointer.md)
 * [Interfaces](types-interface.md)
 * [Special Types](types-special.md)

--- a/source/slang/slang-ast-expr.h
+++ b/source/slang/slang-ast-expr.h
@@ -607,6 +607,29 @@ class MakeOptionalExpr : public Expr
     FIDDLE() Expr* typeExpr = nullptr;
 };
 
+/// Represents an implicit coercion from Optional<T> to Optional<U>
+/// where T is implicitly coercible to U.
+///
+/// During IR lowering, this emits an if-else guarded by optionalHasValue:
+///   - true branch:  getOptionalValue(valueArg) -> coerce to U -> makeOptionalValue
+///   - false branch: makeOptionalNone
+///
+/// `innerVarDecl` is a synthetic VarDecl of type T. During IR lowering,
+/// `context->setValue(innerVarDecl, extractedInnerValue)` is called before
+/// lowering `innerCoercedExpr`, so that VarExpr references to innerVarDecl
+/// resolve to the extracted inner value.
+FIDDLE()
+class CastOptionalExpr : public Expr
+{
+    FIDDLE(...)
+    /// The source Optional<T> expression.
+    FIDDLE() Expr* valueArg = nullptr;
+    /// Synthetic placeholder VarDecl of type T (inner type of source Optional).
+    FIDDLE() VarDecl* innerVarDecl = nullptr;
+    /// Coercion expression from T to U, built referencing innerVarDecl.
+    FIDDLE() Expr* innerCoercedExpr = nullptr;
+};
+
 /// A cast of a value to the same type, with different modifiers.
 ///
 /// The type being cast to is stored as this expression's `type`.

--- a/source/slang/slang-ast-iterator.h
+++ b/source/slang/slang-ast-iterator.h
@@ -319,6 +319,12 @@ struct ASTIterator
             dispatchIfNotNull(expr->value);
             dispatchIfNotNull(expr->typeExpr);
         }
+        void visitCastOptionalExpr(CastOptionalExpr* expr)
+        {
+            iterator->maybeDispatchCallback(expr);
+            dispatchIfNotNull(expr->valueArg);
+            dispatchIfNotNull(expr->innerCoercedExpr);
+        }
         void visitPartiallyAppliedGenericExpr(PartiallyAppliedGenericExpr* expr)
         {
             dispatchIfNotNull(expr->originalExpr);

--- a/source/slang/slang-ast-print.cpp
+++ b/source/slang/slang-ast-print.cpp
@@ -685,6 +685,12 @@ void ASTPrinter::addExpr(Expr* expr)
         }
         sb << ")";
     }
+    else if (const auto castOptionalExpr = as<CastOptionalExpr>(expr))
+    {
+        sb << "CastOptional(";
+        addExpr(castOptionalExpr->valueArg);
+        sb << ")";
+    }
     else if (const auto makeOptionalExpr = as<MakeOptionalExpr>(expr))
     {
         if (makeOptionalExpr->value)

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -1971,6 +1971,79 @@ bool SemanticsVisitor::_coerce(
         return true;
     }
 
+    // Optional<T> can be implicitly cast to Optional<U> when T is coercible to U.
+    if (auto fromOptType = as<OptionalType>(fromType))
+    {
+        if (auto toOptType = as<OptionalType>(toType))
+        {
+            Type* fromInner = fromOptType->getValueType();
+            Type* toInner = toOptType->getValueType();
+
+            if (!fromInner->equals(toInner))
+            {
+                // Create a synthetic VarDecl of type fromInner as a placeholder for the
+                // extracted inner value. We build innerVarExpr here (even in cost-probe mode)
+                // because the inner _coerce call needs a properly-typed fromExpr; passing
+                // nullptr would risk a null-deref in the ExplicitRefType path.
+                auto innerVarDecl = getASTBuilder()->create<VarDecl>();
+                innerVarDecl->nameAndLoc.name = getName("__optInner");
+                innerVarDecl->type.type = fromInner;
+
+                auto innerVarExpr = getASTBuilder()->create<VarExpr>();
+                innerVarExpr->type = QualType(fromInner);
+                innerVarExpr->loc = fromExpr ? fromExpr->loc : SourceLoc();
+                innerVarExpr->declRef = makeDeclRef(innerVarDecl);
+
+                // Cost probe: suppress diagnostics on failure.
+                ConversionCost innerCost = kConversionCost_None;
+                bool innerCoercible = _coerce(
+                    site,
+                    toInner,
+                    nullptr,
+                    QualType(fromInner),
+                    innerVarExpr,
+                    nullptr,
+                    &innerCost,
+                    nullptr);
+
+                if (innerCoercible)
+                {
+                    if (outCost)
+                    {
+                        // +1 so that Optional<T>->Optional<U> (with T!=U) costs more than an
+                        // exact Optional<T>->Optional<T> match (cost 0), while still ranking
+                        // below any direct non-Optional conversion.
+                        *outCost = innerCost + 1;
+                    }
+                    if (outToExpr)
+                    {
+                        Expr* innerCoercedExpr = nullptr;
+                        bool ok = _coerce(
+                            site,
+                            toInner,
+                            &innerCoercedExpr,
+                            QualType(fromInner),
+                            innerVarExpr,
+                            sink,
+                            nullptr,
+                            nullptr);
+                        SLANG_ASSERT(ok && innerCoercedExpr);
+
+                        auto castExpr = getASTBuilder()->create<CastOptionalExpr>();
+                        castExpr->loc = fromExpr->loc;
+                        castExpr->type = QualType(toType);
+                        castExpr->checked = true;
+                        castExpr->valueArg = fromExpr;
+                        castExpr->innerVarDecl = innerVarDecl;
+                        castExpr->innerCoercedExpr = innerCoercedExpr;
+                        *outToExpr = castExpr;
+                    }
+                    return true;
+                }
+            }
+        }
+    }
+
     // A enum type can be converted into its underlying tag type.
     if (auto enumDecl = isEnumType(fromType))
     {

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1158,6 +1158,12 @@ struct SemanticsDeclReferenceVisitor : public SemanticsDeclVisitorBase,
         dispatchIfNotNull(expr->value);
         dispatchIfNotNull(expr->typeExpr);
     }
+    void visitCastOptionalExpr(CastOptionalExpr* expr)
+    {
+        dispatchIfNotNull(expr->valueArg);
+        // innerVarDecl is synthetic; innerCoercedExpr references it
+        dispatchIfNotNull(expr->innerCoercedExpr);
+    }
     void visitPartiallyAppliedGenericExpr(PartiallyAppliedGenericExpr*) { return; }
     void visitSPIRVAsmExpr(SPIRVAsmExpr*) { return; }
     void visitModifiedTypeExpr(ModifiedTypeExpr* expr) { dispatchIfNotNull(expr->base.type); }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -3403,6 +3403,7 @@ public:
     CASE(ExtractExistentialValueExpr)
     CASE(OpenRefExpr)
     CASE(MakeOptionalExpr)
+    CASE(CastOptionalExpr)
     CASE(PartiallyAppliedGenericExpr)
     CASE(PackExpr)
 #undef CASE

--- a/source/slang/slang-language-server-ast-lookup.cpp
+++ b/source/slang/slang-language-server-ast-lookup.cpp
@@ -488,6 +488,12 @@ public:
             return true;
         return dispatchIfNotNull(expr->value);
     }
+    bool visitCastOptionalExpr(CastOptionalExpr* expr)
+    {
+        if (dispatchIfNotNull(expr->valueArg))
+            return true;
+        return dispatchIfNotNull(expr->innerCoercedExpr);
+    }
     bool visitPartiallyAppliedGenericExpr(PartiallyAppliedGenericExpr* expr)
     {
         return dispatchIfNotNull(expr->originalExpr);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -6582,6 +6582,54 @@ struct ExprLoweringVisitorBase : public ExprVisitor<Derived, LoweredValInfo>
         }
     }
 
+    LoweredValInfo visitCastOptionalExpr(CastOptionalExpr* expr)
+    {
+        auto builder = getBuilder();
+
+        auto srcOpt = lowerRValueExpr(context, expr->valueArg);
+        auto srcOptIR = getSimpleVal(context, srcOpt);
+
+        auto toOptType = lowerType(context, expr->type);
+        SLANG_RELEASE_ASSERT(toOptType->getOp() == kIROp_OptionalType);
+
+        auto var = builder->emitVar(toOptType);
+
+        auto hasValue = builder->emitOptionalHasValue(srcOptIR);
+
+        IRBlock* trueBlock;
+        IRBlock* falseBlock;
+        IRBlock* afterBlock;
+        builder->emitIfElseWithBlocks(hasValue, trueBlock, falseBlock, afterBlock);
+
+        // True branch: extract inner value, coerce to U, wrap in Optional<U>.
+        builder->setInsertInto(trueBlock);
+        {
+            auto extractedInner = builder->emitGetOptionalValue(srcOptIR);
+
+            // Bind the synthetic innerVarDecl so the inner coercion expression resolves it.
+            context->setValue(expr->innerVarDecl, LoweredValInfo::simple(extractedInner));
+
+            auto coercedInner = lowerRValueExpr(context, expr->innerCoercedExpr);
+            auto coercedInnerIR = getSimpleVal(context, coercedInner);
+
+            auto someVal = builder->emitMakeOptionalValue(toOptType, coercedInnerIR);
+            builder->emitStore(var, someVal);
+            builder->emitBranch(afterBlock);
+        }
+
+        // False branch: source is none, propagate none.
+        builder->setInsertInto(falseBlock);
+        {
+            auto noneVal = builder->emitMakeOptionalNone(toOptType);
+            builder->emitStore(var, noneVal);
+            builder->emitBranch(afterBlock);
+        }
+
+        builder->setInsertInto(afterBlock);
+        auto result = builder->emitLoad(var);
+        return LoweredValInfo::simple(result);
+    }
+
     LoweredValInfo visitAggTypeCtorExpr(AggTypeCtorExpr* /*expr*/)
     {
         SLANG_UNIMPLEMENTED_X("codegen for aggregate type constructor expression");

--- a/source/slang/slang-visitor.h
+++ b/source/slang/slang-visitor.h
@@ -349,6 +349,13 @@ struct ModifyingExprVisitor : ExprVisitor<Derived, Expr*>
         e->typeExpr = dispatchIfNotNull(e->typeExpr);
         return e;
     }
+    Expr* visitCastOptionalExpr(CastOptionalExpr* e)
+    {
+        e->valueArg = dispatchIfNotNull(e->valueArg);
+        // innerVarDecl is synthetic — do not dispatch
+        e->innerCoercedExpr = dispatchIfNotNull(e->innerCoercedExpr);
+        return e;
+    }
 
     // --- Existential ---
     // Note: ExtractExistentialValueExpr has originalExpr for language server only (not traversed)

--- a/tests/language-feature/optional/optional-cast-function.slang
+++ b/tests/language-feature/optional/optional-cast-function.slang
@@ -1,0 +1,41 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv
+
+// Regression test for issue #7406: Optional<T> should implicitly coerce to
+// Optional<U> when T is coercible to U in function return position.
+
+interface IFoo
+{
+    int get();
+}
+
+struct FooImpl : IFoo
+{
+    int x;
+    int get() { return x; }
+}
+
+// Concrete -> interface coercion in function return position (the main issue #7406 case)
+Optional<IFoo> castToInterface(Optional<FooImpl> v)
+{
+    return v; // implicit coercion: Optional<FooImpl> -> Optional<IFoo>
+}
+
+// Generic version
+__generic<T : IFoo>
+Optional<IFoo> wrapGeneric(Optional<T> v)
+{
+    return v; // implicit coercion: Optional<T> -> Optional<IFoo>
+}
+
+// Numeric promotion in function return position
+Optional<float> promoteToFloat(Optional<int> v)
+{
+    return v; // implicit coercion: Optional<int> -> Optional<float>
+}
+
+// CHECK-NOT: error[
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+}

--- a/tests/language-feature/optional/optional-cast-generic.slang
+++ b/tests/language-feature/optional/optional-cast-generic.slang
@@ -1,0 +1,40 @@
+//TEST:INTERPRET(filecheck=CHECK):
+
+interface IValue
+{
+    int get();
+}
+
+struct ConcreteValue : IValue
+{
+    int x;
+    int get() { return x; }
+}
+
+// Generic function that returns Optional<IValue> from Optional<T : IValue>
+__generic<T : IValue>
+Optional<IValue> wrap(Optional<T> v)
+{
+    return v; // implicit coercion: Optional<T> -> Optional<IValue>
+}
+
+void main()
+{
+    // Test coercion with a value — function call works for the some case
+    ConcreteValue cv = { 42 };
+    Optional<ConcreteValue> optCv = cv;
+    Optional<IValue> iv = wrap(optCv);
+
+    // CHECK: 42
+    if (iv.hasValue)
+        printf("%d\n", iv.value.get());
+
+    // Test none path inline — avoid the pre-existing interpreter limitation
+    // with Optional<interface> returned from conditional-return functions
+    Optional<ConcreteValue> empty = none;
+    Optional<IValue> emptyIV = empty; // inline implicit coercion
+
+    // CHECK: empty
+    if (!emptyIV.hasValue)
+        printf("empty\n");
+}

--- a/tests/language-feature/optional/optional-cast-interface.slang
+++ b/tests/language-feature/optional/optional-cast-interface.slang
@@ -1,0 +1,32 @@
+//TEST:INTERPRET(filecheck=CHECK):
+
+interface IShape
+{
+    int area();
+}
+
+struct Square : IShape
+{
+    int side;
+    int area() { return side * side; }
+}
+
+void main()
+{
+    // Coerce Optional<Square> with a value to Optional<IShape>
+    Square sq = { 3 };
+    Optional<Square> optSq = sq;
+    Optional<IShape> sh = optSq; // implicit coercion: Optional<Square> -> Optional<IShape>
+
+    // CHECK: 9
+    if (sh.hasValue)
+        printf("%d\n", sh.value.area());
+
+    // Coerce Optional<Square>(none) to Optional<IShape> — must preserve hasValue=false
+    Optional<Square> noSq = none;
+    Optional<IShape> noSh = noSq; // implicit coercion: Optional<Square>(none) -> Optional<IShape>
+
+    // CHECK: none
+    if (!noSh.hasValue)
+        printf("none\n");
+}

--- a/tests/language-feature/optional/optional-cast-negative.slang
+++ b/tests/language-feature/optional/optional-cast-negative.slang
@@ -1,0 +1,19 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target spirv
+
+interface IFoo
+{
+}
+interface IBar
+{
+}
+
+struct MyFoo : IFoo
+{
+}
+
+Optional<IBar> bad(Optional<MyFoo> v)
+{
+    return v; // should error: MyFoo does not implement IBar
+//CHECK:   ^ type mismatch in expression
+//CHECK:   ^ expected an expression of type 'Optional<IBar>', got 'Optional<MyFoo>'
+}

--- a/tests/language-feature/optional/optional-cast-nested.slang
+++ b/tests/language-feature/optional/optional-cast-nested.slang
@@ -1,0 +1,29 @@
+//TEST:INTERPRET(filecheck=CHECK):
+
+// Test recursive Optional<Optional<T>> -> Optional<Optional<U>> coercion
+
+void main()
+{
+    // Nested some/some: Optional<Optional<int>> -> Optional<Optional<float>>
+    Optional<int> inner = 5;
+    Optional<Optional<int>> nested = inner;
+    Optional<Optional<float>> coerced = nested;
+
+    // CHECK: has-outer
+    if (coerced.hasValue)
+        printf("has-outer\n");
+    // CHECK: has-inner
+    if (coerced.hasValue && coerced.value.hasValue)
+        printf("has-inner\n");
+    // CHECK: 5.0
+    if (coerced.hasValue && coerced.value.hasValue)
+        printf("%.1f\n", coerced.value.value);
+
+    // Outer-none propagates: Optional<Optional<int>>(none) -> Optional<Optional<float>>(none)
+    Optional<Optional<int>> outerNone = none;
+    Optional<Optional<float>> coercedOuterNone = outerNone;
+
+    // CHECK: outer-none
+    if (!coercedOuterNone.hasValue)
+        printf("outer-none\n");
+}

--- a/tests/language-feature/optional/optional-cast-numeric.slang
+++ b/tests/language-feature/optional/optional-cast-numeric.slang
@@ -1,0 +1,23 @@
+//TEST:INTERPRET(filecheck=CHECK):
+
+// Test implicit Optional<int> -> Optional<float> coercion
+
+void main()
+{
+    // Test coercion of some value inline
+    Optional<int> some = 7;
+    Optional<float> f = some; // implicit coercion: Optional<int> -> Optional<float>
+    // CHECK: some
+    if (f.hasValue)
+        printf("some\n");
+    // CHECK: 7.0
+    if (f.hasValue)
+        printf("%.1f\n", f.value);
+
+    // Test coercion of none inline
+    Optional<int> none_val = none;
+    Optional<float> none_f = none_val; // implicit coercion: Optional<int>(none) -> Optional<float>
+    // CHECK: none
+    if (!none_f.hasValue)
+        printf("none\n");
+}


### PR DESCRIPTION
Introduces `CastOptionalExpr`, a new AST expression node that represents an implicit coercion from `Optional<T>` to `Optional<U>`. The coercion is accepted when `T` is implicitly coercible to `U` (e.g., concrete struct to interface, numeric promotion).

The IR lowering emits an if-else block guarded by `optionalHasValue`:
- true branch: extract inner value, coerce to U, wrap in Optional<U>
- false branch: propagate none directly

This correctly handles the `none` case without corrupting `hasValue`.

Fixes issue #7406.