### PR TITLE
Fix associated types of extern struct used as varying entry-point parameters

### DIFF
--- a/docs/user-guide/10-link-time-specialization.md
+++ b/docs/user-guide/10-link-time-specialization.md
@@ -229,6 +229,27 @@ when creating the session. When this option is set, the compiler will verify the
 from source if it is not up-to-date.
 
 
+## Associated types of `extern struct` in varying parameters
+
+Using an `associatedtype` of an `extern struct` directly as an entry-point varying parameter
+(a parameter or return type that carries an HLSL semantic such as `SV_Position`, `POSITION`,
+`SV_Target`, etc.) is supported for GLSL, SPIRV, and HLSL targets.
+
+For example, the following pattern works correctly across all targets:
+
+```csharp
+interface IObject
+{
+    associatedtype VertexInput;
+    associatedtype VertexOutput;
+}
+
+export struct Object : IObject = MyObject;
+
+[shader("vertex")]
+Object.VertexOutput VSMain(Object.VertexInput input) { ... }
+```
+
 ## Additional Remarks
 
 Link-time specialization is Slang's answer to compile-time performance and modularity issues associated with preprocessor

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -2120,7 +2120,15 @@ ScalarizedVal createGLSLGlobalVaryingsImpl(
         // and generate a variable for each of them.
 
         auto structTypeLayout = as<IRStructTypeLayout>(typeLayout);
-        SLANG_ASSERT(structTypeLayout);
+        if (!structTypeLayout)
+        {
+            // A concrete IRStructType reached this path without a matching IRStructTypeLayout.
+            // This indicates a layout/type mismatch, typically from an unresolved link-time type.
+            SLANG_UNEXPECTED(
+                "IRStructType has no matching IRStructTypeLayout in createGLSLGlobalVaryingsImpl; "
+                "check lookupExternDeclRefType for unhandled associated-type patterns");
+            return ScalarizedVal();
+        }
         RefPtr<ScalarizedTupleValImpl> tupleValImpl = new ScalarizedTupleValImpl();
 
         // Since we are going to recurse into struct fields,

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -6457,6 +6457,83 @@ Type* TypeLayoutContext::lookupExternDeclRefType(DeclRefType* declRefType)
         }
     }
 
+    // Handle associated types accessed through an extern struct, e.g. `Object.VertexOutput`
+    // where `extern struct Object : IObject = MyObject`. AssocTypeDecl itself is not marked
+    // extern, so the existing check above doesn't apply.
+    else if (auto lookupDeclRef = as<LookupDeclRef>(declRef.declRefBase))
+    {
+        if (auto lookupSourceDeclRefType = as<DeclRefType>(lookupDeclRef->getLookupSource()))
+        {
+            auto resolvedSource = lookupExternDeclRefType(lookupSourceDeclRefType);
+            if (resolvedSource != lookupSourceDeclRefType)
+            {
+                // Primary path: witnessTable is null on aliased extern structs; use witnessVal.
+                auto tryViaWitnessVal = [&]() -> Type*
+                {
+                    auto witness = lookupDeclRef->getWitness();
+                    if (!witness)
+                        return nullptr;
+                    auto declaredWitness = as<DeclaredSubtypeWitness>(witness);
+                    if (!declaredWitness)
+                        return nullptr;
+                    auto inheritanceDeclRef = declaredWitness->getDeclRef().as<InheritanceDecl>();
+                    if (!inheritanceDeclRef)
+                        return nullptr;
+                    auto concreteWitness =
+                        as<SubtypeWitness>(inheritanceDeclRef.getDecl()->witnessVal);
+                    if (!concreteWitness)
+                        return nullptr;
+                    RequirementWitness reqWitness =
+                        tryLookUpRequirementWitness(astBuilder, concreteWitness, decl);
+                    if (reqWitness.getFlavor() == RequirementWitness::Flavor::declRef)
+                        return DeclRefType::create(astBuilder, reqWitness.getDeclRef());
+                    if (reqWitness.getFlavor() == RequirementWitness::Flavor::val)
+                    {
+                        if (auto t = as<Type>(reqWitness.getVal()))
+                            return t;
+                    }
+                    return nullptr;
+                };
+
+                if (auto resolved = tryViaWitnessVal())
+                    return resolved;
+
+                // Fallback: iterate the concrete type's InheritanceDecls directly.
+                if (auto resolvedDeclRefType = as<DeclRefType>(resolvedSource))
+                {
+                    if (auto resolvedAggDeclRef =
+                            resolvedDeclRefType->getDeclRef().as<AggTypeDecl>())
+                    {
+                        auto supDecl =
+                            lookupDeclRef->getWitness() ? lookupDeclRef->getSupDecl() : nullptr;
+                        auto interfaceDecl = as<InterfaceDecl>(supDecl);
+                        for (auto inheritanceDeclRef :
+                             getMembersOfType<InheritanceDecl>(astBuilder, resolvedAggDeclRef))
+                        {
+                            auto supType = getSup(astBuilder, inheritanceDeclRef);
+                            auto supInterfaceRef = isDeclRefTypeOf<InterfaceDecl>(supType);
+                            if (!supInterfaceRef)
+                                continue;
+                            if (interfaceDecl && supInterfaceRef.getDecl() != interfaceDecl)
+                                continue;
+                            auto concreteWitness = astBuilder->getDeclaredSubtypeWitness(
+                                resolvedSource, supType, inheritanceDeclRef);
+                            RequirementWitness reqWitness =
+                                tryLookUpRequirementWitness(astBuilder, concreteWitness, decl);
+                            if (reqWitness.getFlavor() == RequirementWitness::Flavor::declRef)
+                                return DeclRefType::create(astBuilder, reqWitness.getDeclRef());
+                            if (reqWitness.getFlavor() == RequirementWitness::Flavor::val)
+                            {
+                                if (auto t = as<Type>(reqWitness.getVal()))
+                                    return t;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // If the type is an alias of another type, then we should create the type layout
     // from the aliased type instead.
     if (auto aggTypeDeclRef = isDeclRefTypeOf<AggTypeDecl>(resultType))

--- a/tests/bugs/gh-8957-glsl.slang
+++ b/tests/bugs/gh-8957-glsl.slang
@@ -1,0 +1,38 @@
+//TEST:SIMPLE(filecheck=CHECK): -target glsl -stage vertex -entry VSMain
+
+// Regression test: issue #8957 (GLSL variant)
+// Exercises createGLSLGlobalVaryingsImpl with extern struct associated types.
+
+interface IObject
+{
+    associatedtype VertexInput;
+    associatedtype VertexOutput;
+}
+
+struct MyVertexInput
+{
+    [[vk::location(0)]] float3 position;
+}
+
+struct MyVertexOutput
+{
+    float4 position : SV_Position;
+}
+
+struct MyObject : IObject
+{
+    typedef MyVertexInput VertexInput;
+    typedef MyVertexOutput VertexOutput;
+}
+
+export struct Object : IObject = MyObject;
+
+[shader("vertex")]
+Object.VertexOutput VSMain(Object.VertexInput input)
+{
+    Object.VertexOutput output;
+    return output;
+}
+
+//CHECK: void main()
+//CHECK: gl_Position

--- a/tests/bugs/gh-8957.slang
+++ b/tests/bugs/gh-8957.slang
@@ -1,0 +1,42 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -stage vertex -entry VSMain
+
+// Regression test: issue #8957
+// Associated type of link-time extern struct used as varying entry-point parameter/return type.
+
+interface IObjectVertexInput {}
+interface IObjectVertexOutput {}
+
+interface IObject
+{
+    associatedtype VertexInput : IObjectVertexInput;
+    associatedtype VertexOutput : IObjectVertexOutput;
+}
+
+struct MyObjectVertexInput : IObjectVertexInput
+{
+    [[vk::location(0)]] float3 position;
+}
+
+struct MyObjectVertexOutput : IObjectVertexOutput
+{
+    float4 position : SV_Position;
+}
+
+struct MyObject : IObject
+{
+    typedef MyObjectVertexInput VertexInput;
+    typedef MyObjectVertexOutput VertexOutput;
+}
+
+export struct Object : IObject = MyObject;
+
+[shader("vertex")]
+Object.VertexOutput VSMain(Object.VertexInput input)
+{
+    Object.VertexOutput output;
+    return output;
+}
+
+//CHECK: OpEntryPoint Vertex %VSMain
+//CHECK: OpName %MyObjectVertexOutput "MyObjectVertexOutput"
+//CHECK: OpDecorate %gl_Position BuiltIn Position


### PR DESCRIPTION
**Problem**: Writing a vertex shader whose input or output type is an `associatedtype` of an `extern struct` (e.g. `Object.VertexInput`) crashed the compiler during SPIR-V or GLSL code generation.

**Root cause**: When the compiler computed the memory layout for such a parameter, it failed to recognise that `Object.VertexInput` belongs to a link-time-specialized struct and left the layout unresolved. Later, the code generator expected a full struct layout but received an empty one, triggering an assertion.

**Fix**: The layout resolver now follows the full lookup chain — `Object` → its concrete substitute `MyObject` → `MyObject::VertexInput` — so the correct struct layout is produced before code generation runs.

**Technical details (for reviewers)**:
`TypeLayoutContext::lookupExternDeclRefType` checked `ExternAttribute` on the directly-referenced decl. For `Object.VertexOutput` that decl is `AssocTypeDecl "VertexOutput"` inside `IObject`, which is not extern itself.

The fix adds a `LookupDeclRef` branch: recursively resolve the lookup source (`Object` → `MyObject`), follow `InheritanceDecl::witnessVal` for the concrete conformance witness, then call `tryLookUpRequirementWitness` to obtain the concrete type. A fallback iterates `InheritanceDecl`s for cases where `witnessVal` is not a `DeclaredSubtypeWitness`. The hard assert in `createGLSLGlobalVaryingsImpl` is also softened to `SLANG_UNEXPECTED`.

Fixes #8957