### PR TITLE
Exec model tests v2

### DIFF
--- a/tests/diagnostics/execution-model/entry-point-no-stage.slang
+++ b/tests/diagnostics/execution-model/entry-point-no-stage.slang
@@ -1,0 +1,7 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target hlsl -entry main
+
+//CHECK: E38007
+void main() {}
+/*CHECK:
+     ^^^^ no stage specified for entry point
+*/

--- a/tests/diagnostics/execution-model/invalid-dispatch-thread-id-type.slang
+++ b/tests/diagnostics/execution-model/invalid-dispatch-thread-id-type.slang
@@ -1,0 +1,18 @@
+// Test that wrong types for SV_DispatchThreadID produce error E38024.
+// computeMain1: float3 (wrong element type)
+// computeMain2: uint4 (wrong dimension)
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target hlsl -stage compute -entry computeMain1
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK2):-target hlsl -stage compute -entry computeMain2
+
+[numthreads(1,1,1)]
+void computeMain1(float3 tid : SV_DispatchThreadID)
+//CHECK:                 ^^^ invalid SV_DispatchThreadID type
+//CHECK:                 ^^^ parameter with SV_DispatchThreadID must be either scalar or vector (1 to 3) of uint/int but is vector<float,3>
+{}
+
+[numthreads(1,1,1)]
+void computeMain2(uint4 tid : SV_DispatchThreadID)
+//CHECK2:               ^^^ invalid SV_DispatchThreadID type
+//CHECK2:               ^^^ parameter with SV_DispatchThreadID must be either scalar or vector (1 to 3) of uint/int but is vector<uint,4>
+{}

--- a/tests/diagnostics/execution-model/invalid-wave-size.slang
+++ b/tests/diagnostics/execution-model/invalid-wave-size.slang
@@ -1,0 +1,11 @@
+// Test that [WaveSize(3)] produces error E31103 (must be power of 2 between 4-128).
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target hlsl -stage compute -entry computeMain
+
+[WaveSize(3)]
+/*CHECK:
+ ^^^^^^^^ invalid 'WaveSize' value
+ ^^^^^^^^ expected a power of 2 between 4 and 128, inclusive, in 'WaveSize' attribute, got '3'
+*/
+[numthreads(1,1,1)]
+void computeMain() {}

--- a/tests/diagnostics/execution-model/non-positive-numthreads.slang
+++ b/tests/diagnostics/execution-model/non-positive-numthreads.slang
@@ -1,0 +1,10 @@
+// Test that [numthreads(0,1,1)] produces error E31102.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target hlsl -stage compute -entry computeMain
+
+[numthreads(0,1,1)]
+/*CHECK:
+ ^^^^^^^^^^ invalid 'numthreads' value
+ ^^^^^^^^^^ expected a positive integer in 'numthreads' attribute, got '0'
+*/
+void computeMain() {}

--- a/tests/diagnostics/execution-model/numthreads-negative-value.slang
+++ b/tests/diagnostics/execution-model/numthreads-negative-value.slang
@@ -1,0 +1,10 @@
+// Test that [numthreads(-1,1,1)] produces error E31102.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target hlsl -stage compute -entry computeMain
+
+[numthreads(-1,1,1)]
+/*CHECK:
+ ^^^^^^^^^^ invalid 'numthreads' value
+ ^^^^^^^^^^ expected a positive integer in 'numthreads' attribute, got '-1'
+*/
+void computeMain() {}

--- a/tests/diagnostics/execution-model/spec-constant-numthreads.slang
+++ b/tests/diagnostics/execution-model/spec-constant-numthreads.slang
@@ -1,0 +1,11 @@
+// Test that specialization constants in numthreads produce an error on non-SPIRV targets.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK, non-exhaustive):-target hlsl -entry main
+
+[[vk::constant_id(0)]] const int X = 4;
+[numthreads(X, 1, 1)]
+/*CHECK:
+ ^^^^^^^^^^ Specialization constants are not supported in the 'numthreads' attribute
+*/
+[shader("compute")]
+void main() {}

--- a/tests/diagnostics/execution-model/stage-dependency-incompatible.slang
+++ b/tests/diagnostics/execution-model/stage-dependency-incompatible.slang
@@ -1,0 +1,14 @@
+// Test that using a compute-only system value in a fragment shader
+// produces a stage-incompatible diagnostic.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target hlsl -entry fragMain
+
+//CHECK: E30702
+[shader("fragment")]
+float4 fragMain(uint3 gid : SV_GroupID) : SV_Target
+{
+    return float4(float(gid.x), 0.0, 0.0, 1.0);
+}
+/*CHECK:
+                      ^^^
+*/

--- a/tests/diagnostics/execution-model/stage-incompatible-in-param.slang
+++ b/tests/diagnostics/execution-model/stage-incompatible-in-param.slang
@@ -1,0 +1,9 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target hlsl -entry main
+
+struct Payload { float3 data; };
+[shader("callable")]
+void main(in Payload data) {}
+//CHECK:             ^^^^ stage does not support in parameters
+//CHECK:             ^^^^ the 'callable' stage does not support `in` entry point parameters
+//CHECK:             ^^^^ stage does not support in parameters
+//CHECK:             ^^^^ the 'callable' stage does not support `in` entry point parameters

--- a/tests/diagnostics/execution-model/stage-incompatible-out-param.slang
+++ b/tests/diagnostics/execution-model/stage-incompatible-out-param.slang
@@ -1,0 +1,10 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target hlsl -entry main
+
+//CHECK: E41018
+//CHECK: E39017
+[shader("intersection")]
+void main(out float3 x : MY_SEMANTIC) {}
+/*CHECK:
+                                       ^ returning without initializing out parameter
+                     ^ the 'intersection' stage does not support `out` or `inout` entry point parameters
+*/

--- a/tests/diagnostics/execution-model/sv-invalid-direction.slang
+++ b/tests/diagnostics/execution-model/sv-invalid-direction.slang
@@ -1,0 +1,9 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target hlsl -entry vertMain
+
+//CHECK: E30702
+struct VOut { uint vid : SV_VertexID; float4 pos : SV_Position; };
+/*CHECK:
+                   ^^^
+*/
+[shader("vertex")]
+VOut vertMain() { VOut o; o.vid = 0; o.pos = float4(0); return o; }

--- a/tests/diagnostics/execution-model/unknown-stage-name-attribute.slang
+++ b/tests/diagnostics/execution-model/unknown-stage-name-attribute.slang
@@ -1,0 +1,8 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):
+
+[shader("invalid")]
+/*CHECK:
+ ^^^^^^ unknown capability
+ ^^^^^^ unknown capability name 'invalid'.
+*/
+void main() {}

--- a/tests/language-feature/execution-model/compute-numthreads-functional.slang
+++ b/tests/language-feature/execution-model/compute-numthreads-functional.slang
@@ -1,0 +1,22 @@
+// Test [numthreads(2,3,1)] dispatch with 6 threads.
+// Each thread writes tid.x*10+tid.y to outputBuffer[groupIndex].
+// Verifies correct thread ID assignment and group index linearization.
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0], stride=4):out,name outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(2, 3, 1)]
+void computeMain(uint3 tid : SV_GroupThreadID, uint groupIndex : SV_GroupIndex)
+{
+    outputBuffer[groupIndex] = int(tid.x) * 10 + int(tid.y);
+}
+
+// CHECK: 0
+// CHECK: 10
+// CHECK: 1
+// CHECK: 11
+// CHECK: 2
+// CHECK: 12

--- a/tests/language-feature/execution-model/compute-system-values-comprehensive.slang
+++ b/tests/language-feature/execution-model/compute-system-values-comprehensive.slang
@@ -1,0 +1,47 @@
+// Comprehensive test of compute shader system values.
+// [numthreads(2,2,1)] with 4 threads. Each thread writes 4 values:
+//   [groupIndex*4+0] = dispatchThreadId encoded as x*100+y*10+z
+//   [groupIndex*4+1] = groupThreadId encoded as x*100+y*10+z
+//   [groupIndex*4+2] = groupId.x + groupId.y + groupId.z
+//   [groupIndex*4+3] = groupIndex
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(2, 2, 1)]
+void computeMain(
+    uint3 dispatchId : SV_DispatchThreadID,
+    uint3 groupThreadId : SV_GroupThreadID,
+    uint3 groupId : SV_GroupID,
+    uint groupIndex : SV_GroupIndex)
+{
+    int base = int(groupIndex) * 4;
+    outputBuffer[base + 0] = int(dispatchId.x) * 100 + int(dispatchId.y) * 10 + int(dispatchId.z);
+    outputBuffer[base + 1] = int(groupThreadId.x) * 100 + int(groupThreadId.y) * 10 + int(groupThreadId.z);
+    outputBuffer[base + 2] = int(groupId.x) + int(groupId.y) + int(groupId.z);
+    outputBuffer[base + 3] = int(groupIndex);
+}
+
+// groupIndex=0: tid=(0,0,0), groupId=(0,0,0)
+// CHECK: 0
+// CHECK: 0
+// CHECK: 0
+// CHECK: 0
+// groupIndex=1: tid=(1,0,0), groupId=(0,0,0)
+// CHECK: 100
+// CHECK: 100
+// CHECK: 0
+// CHECK: 1
+// groupIndex=2: tid=(0,1,0), groupId=(0,0,0)
+// CHECK: 10
+// CHECK: 10
+// CHECK: 0
+// CHECK: 2
+// groupIndex=3: tid=(1,1,0), groupId=(0,0,0)
+// CHECK: 110
+// CHECK: 110
+// CHECK: 0
+// CHECK: 3

--- a/tests/language-feature/execution-model/cross-stage-vertex-fragment-emission.slang
+++ b/tests/language-feature/execution-model/cross-stage-vertex-fragment-emission.slang
@@ -1,0 +1,31 @@
+// Test cross-stage vertex/fragment emission with shared interpolant semantics.
+
+//TEST:SIMPLE(filecheck=CHECK_VERT): -target hlsl -entry vertMain -stage vertex
+//TEST:SIMPLE(filecheck=CHECK_FRAG): -target hlsl -entry fragMain -stage fragment
+
+struct VsOut
+{
+    float4 pos : SV_Position;
+    float4 color : COLOR;
+    float2 uv : TEXCOORD;
+};
+
+// CHECK_VERT: SV_Position
+// CHECK_VERT: COLOR
+// CHECK_VERT: TEXCOORD
+[shader("vertex")]
+VsOut vertMain(uint vid : SV_VertexID)
+{
+    VsOut o;
+    o.pos = float4(float(vid), 0.0, 0.0, 1.0);
+    o.color = float4(1.0, 0.0, 0.0, 1.0);
+    o.uv = float2(float(vid), 0.0);
+    return o;
+}
+
+// CHECK_FRAG: SV_TARGET
+[shader("fragment")]
+float4 fragMain(float4 color : COLOR, float2 uv : TEXCOORD) : SV_Target
+{
+    return color * float4(uv, 0.0, 1.0);
+}

--- a/tests/language-feature/execution-model/discard-fragment-emission.slang
+++ b/tests/language-feature/execution-model/discard-fragment-emission.slang
@@ -1,0 +1,17 @@
+// Test that `discard` emits correctly across HLSL, GLSL, and SPIR-V targets.
+
+//TEST:SIMPLE(filecheck=CHECK_HLSL): -target hlsl -stage fragment -entry fragMain
+//TEST:SIMPLE(filecheck=CHECK_GLSL): -target glsl -stage fragment -entry fragMain
+//TEST:SIMPLE(filecheck=CHECK_SPIRV): -target spirv-asm -stage fragment -entry fragMain -emit-spirv-directly -profile spirv_1_6
+
+[shader("fragment")]
+float4 fragMain(float4 color : COLOR) : SV_Target
+{
+    if (color.r < 0.5)
+        discard;
+    return color;
+}
+
+// CHECK_HLSL: discard
+// CHECK_GLSL: discard
+// CHECK_SPIRV: OpDemoteToHelperInvocation

--- a/tests/language-feature/execution-model/early-return-wave-op-functional.slang
+++ b/tests/language-feature/execution-model/early-return-wave-op-functional.slang
@@ -1,0 +1,23 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -shaderobj -output-using-type
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0], stride=4)
+
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    int idx = int(tid.x);
+    if (idx == 0)
+    {
+        outputBuffer[idx] = -1;
+        return;
+    }
+    int minVal = WaveActiveMin(idx);
+    outputBuffer[idx] = minVal;
+}
+
+// CHECK: -1
+// CHECK: 1
+// CHECK: 1
+// CHECK: 1

--- a/tests/language-feature/execution-model/groupshared-barrier-functional.slang
+++ b/tests/language-feature/execution-model/groupshared-barrier-functional.slang
@@ -1,0 +1,23 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -shaderobj -output-using-type
+//TEST:SIMPLE(filecheck=EMIT): -target hlsl -stage compute -entry computeMain
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0], stride=4)
+
+RWStructuredBuffer<int> outputBuffer;
+groupshared int sharedData[4];
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID, uint idx : SV_GroupIndex)
+{
+    sharedData[idx] = int(idx) * 10;
+    GroupMemoryBarrierWithGroupSync();
+    int neighborIdx = (int(idx) + 1) % 4;
+    outputBuffer[idx] = sharedData[neighborIdx];
+}
+
+// EMIT: groupshared
+// EMIT: GroupMemoryBarrierWithGroupSync
+
+// CHECK: 10
+// CHECK: 20
+// CHECK: 30
+// CHECK: 0

--- a/tests/language-feature/execution-model/groupshared-barrier-spirv-emission.slang
+++ b/tests/language-feature/execution-model/groupshared-barrier-spirv-emission.slang
@@ -1,0 +1,19 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -stage compute -entry computeMain
+
+groupshared float sharedArray[64];
+RWStructuredBuffer<float> output;
+
+[numthreads(64, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID, uint idx : SV_GroupIndex)
+{
+    sharedArray[idx] = float(idx);
+    // CHECK: Workgroup
+    // CHECK: OpControlBarrier
+    GroupMemoryBarrierWithGroupSync();
+    uint neighbor = (idx + 1u) % 64u;
+    float val = sharedArray[neighbor];
+    // CHECK: OpMemoryBarrier
+    GroupMemoryBarrier();
+    // Access shared memory after barrier to prevent dead-code elimination
+    output[idx] = val + sharedArray[idx];
+}

--- a/tests/language-feature/execution-model/groupshared-multi-barrier-functional.slang
+++ b/tests/language-feature/execution-model/groupshared-multi-barrier-functional.slang
@@ -1,0 +1,29 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -shaderobj -output-using-type
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0], stride=4)
+
+RWStructuredBuffer<int> outputBuffer;
+groupshared int sharedData[4];
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID, uint idx : SV_GroupIndex)
+{
+    // Round 1: write idx*10, read neighbor
+    sharedData[idx] = int(idx) * 10;
+    GroupMemoryBarrierWithGroupSync();
+    int round1 = sharedData[(int(idx) + 1) % 4];
+
+    // Round 2: write round1*2, read neighbor
+    GroupMemoryBarrierWithGroupSync();
+    sharedData[idx] = round1 * 2;
+    GroupMemoryBarrierWithGroupSync();
+    outputBuffer[idx] = sharedData[(int(idx) + 1) % 4];
+}
+
+// Round 1 reads: thread[0]=10, thread[1]=20, thread[2]=30, thread[3]=0
+// Round 2 writes: thread[0]=20, thread[1]=40, thread[2]=60, thread[3]=0
+// Round 2 reads neighbor: thread[0]=40, thread[1]=60, thread[2]=0, thread[3]=20
+
+// CHECK: 40
+// CHECK: 60
+// CHECK: 0
+// CHECK: 20

--- a/tests/language-feature/execution-model/loop-break-wave-op-functional.slang
+++ b/tests/language-feature/execution-model/loop-break-wave-op-functional.slang
@@ -1,0 +1,27 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -shaderobj -output-using-type
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0], stride=4)
+
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    int idx = int(tid.x);
+    int result = 0;
+    for (int i = 0; i < 4; ++i)
+    {
+        int activeCount = int(WaveActiveCountBits(true));
+        if (i == idx)
+        {
+            result = activeCount;
+            break;
+        }
+    }
+    outputBuffer[idx] = result;
+}
+
+// CHECK: 4
+// CHECK: 3
+// CHECK: 2
+// CHECK: 1

--- a/tests/language-feature/execution-model/loop-divergence-reconvergence-emission.slang
+++ b/tests/language-feature/execution-model/loop-divergence-reconvergence-emission.slang
@@ -1,0 +1,23 @@
+//TEST:SIMPLE(filecheck=CHECK_HLSL): -target hlsl -stage compute -entry computeMain
+//TEST:SIMPLE(filecheck=CHECK_GLSL): -target glsl -stage compute -entry computeMain
+
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    int idx = int(tid.x);
+    int acc = 0;
+    int limit = 5 + (idx & 1);
+    for (int i = 0; i < limit; ++i)
+    {
+        acc += i;
+    }
+    outputBuffer[idx] = WaveActiveSum(acc);
+}
+
+// CHECK_HLSL: for
+// CHECK_HLSL: WaveActiveSum
+
+// CHECK_GLSL: for
+// CHECK_GLSL: subgroupAdd

--- a/tests/language-feature/execution-model/loop-divergence-reconvergence-functional.slang
+++ b/tests/language-feature/execution-model/loop-divergence-reconvergence-functional.slang
@@ -1,0 +1,28 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -shaderobj -output-using-type
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0], stride=4)
+
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    int idx = int(tid.x);
+    int acc = 0;
+    int limit = 5 + (idx & 1);
+    for (int i = 0; i < limit; ++i)
+    {
+        acc += i;
+    }
+    // Thread 0: loops 5 times, acc=0+1+2+3+4=10
+    // Thread 1: loops 6 times, acc=0+1+2+3+4+5=15
+    // Thread 2: loops 5 times, acc=10
+    // Thread 3: loops 6 times, acc=15
+    // Sum = 10+15+10+15 = 50
+    outputBuffer[idx] = WaveActiveSum(acc);
+}
+
+// CHECK: 50
+// CHECK: 50
+// CHECK: 50
+// CHECK: 50

--- a/tests/language-feature/execution-model/multiple-entry-points-stages.slang
+++ b/tests/language-feature/execution-model/multiple-entry-points-stages.slang
@@ -1,0 +1,42 @@
+// Test multiple entry points across vertex, fragment, and compute stages
+// sharing a common utility function.
+
+//TEST:SIMPLE(filecheck=CHECK_VERT): -target hlsl -entry vertMain -stage vertex
+//TEST:SIMPLE(filecheck=CHECK_FRAG): -target hlsl -entry fragMain -stage fragment
+//TEST:SIMPLE(filecheck=CHECK_COMP): -target hlsl -entry compMain -stage compute
+
+float brighten(float v) { return saturate(v * 2.0); }
+
+struct VsOut
+{
+    float4 pos : SV_Position;
+    float brightness : BRIGHTNESS;
+};
+
+// CHECK_VERT: SV_Position
+// CHECK_VERT: BRIGHTNESS
+[shader("vertex")]
+VsOut vertMain(uint vid : SV_VertexID)
+{
+    VsOut o;
+    o.pos = float4(float(vid), 0.0, 0.0, 1.0);
+    o.brightness = brighten(float(vid) / 3.0);
+    return o;
+}
+
+// CHECK_FRAG: SV_TARGET
+[shader("fragment")]
+float4 fragMain(float brightness : BRIGHTNESS) : SV_Target
+{
+    return float4(brightness, brightness, brightness, 1.0);
+}
+
+RWStructuredBuffer<float> buffer;
+
+// CHECK_COMP: numthreads(64
+[shader("compute")]
+[numthreads(64,1,1)]
+void compMain(uint3 tid : SV_DispatchThreadID)
+{
+    buffer[tid.x] = brighten(float(tid.x) / 64.0);
+}

--- a/tests/language-feature/execution-model/nested-divergence-functional.slang
+++ b/tests/language-feature/execution-model/nested-divergence-functional.slang
@@ -1,0 +1,39 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -shaderobj -output-using-type
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0], stride=4)
+
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    int idx = int(tid.x);
+    int result = 0;
+    if ((idx & 1) == 0)
+    {
+        // Even threads {0, 2}
+        int outerSum = WaveActiveSum(idx); // 0+2=2
+        if (idx == 0)
+        {
+            int innerSum = WaveActiveSum(idx); // just 0
+            result = innerSum + outerSum * 100; // 0 + 200 = 200
+        }
+        else
+        {
+            int innerSum = WaveActiveSum(idx); // just 2
+            result = innerSum + outerSum * 100; // 2 + 200 = 202
+        }
+    }
+    else
+    {
+        // Odd threads {1, 3}
+        int oddSum = WaveActiveSum(idx); // 1+3=4
+        result = oddSum + oddSum * 100; // 4 + 400 = 404
+    }
+    outputBuffer[idx] = result;
+}
+
+// CHECK: 200
+// CHECK: 404
+// CHECK: 202
+// CHECK: 404

--- a/tests/language-feature/execution-model/numthreads-3d-linearization.slang
+++ b/tests/language-feature/execution-model/numthreads-3d-linearization.slang
@@ -1,0 +1,25 @@
+// Test 3D thread group linearization with [numthreads(2,2,2)].
+// Each thread writes its SV_GroupIndex to outputBuffer[groupIndex].
+// Verifies linearization formula: groupIndex = x + y*Nx + z*Nx*Ny
+// where Nx=2, Ny=2, giving groupIndex = x + y*2 + z*4.
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(2, 2, 2)]
+void computeMain(uint groupIndex : SV_GroupIndex)
+{
+    outputBuffer[groupIndex] = int(groupIndex);
+}
+
+// CHECK: 0
+// CHECK: 1
+// CHECK: 2
+// CHECK: 3
+// CHECK: 4
+// CHECK: 5
+// CHECK: 6
+// CHECK: 7

--- a/tests/language-feature/execution-model/shader-attribute-stages.slang
+++ b/tests/language-feature/execution-model/shader-attribute-stages.slang
@@ -1,0 +1,36 @@
+// Test that [shader()] attributes correctly select entry points for different stages.
+
+//TEST:SIMPLE(filecheck=CHECK_CS): -target hlsl -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=CHECK_VS): -target hlsl -entry vertMain -stage vertex
+//TEST:SIMPLE(filecheck=CHECK_FS): -target hlsl -entry fragMain -stage fragment
+
+RWStructuredBuffer<float> outputBuffer;
+
+// CHECK_CS: numthreads(64
+[shader("compute")]
+[numthreads(64,1,1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    outputBuffer[tid.x] = float(tid.x);
+}
+
+struct VertexOut
+{
+    float4 pos : SV_Position;
+};
+
+// CHECK_VS: SV_Position
+[shader("vertex")]
+VertexOut vertMain(uint vid : SV_VertexID)
+{
+    VertexOut o;
+    o.pos = float4(float(vid), 0.0, 0.0, 1.0);
+    return o;
+}
+
+// CHECK_FS: SV_TARGET
+[shader("fragment")]
+float4 fragMain(float4 pos : SV_Position) : SV_Target
+{
+    return float4(pos.x, pos.y, 0.0, 1.0);
+}

--- a/tests/language-feature/execution-model/wave-ballot-verify-functional.slang
+++ b/tests/language-feature/execution-model/wave-ballot-verify-functional.slang
@@ -1,0 +1,26 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -shaderobj -output-using-type
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0 0 0 0 0], stride=4)
+
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    int idx = int(tid.x);
+    bool isEven = (idx & 1) == 0;
+    uint4 ballot = WaveActiveBallot(isEven);
+    int count = int(WaveActiveCountBits(isEven));
+    outputBuffer[idx * 2] = int(ballot.x);
+    outputBuffer[idx * 2 + 1] = count;
+}
+
+// ballot.x = 0x5 = 5 for all threads, count = 2
+// CHECK: 5
+// CHECK: 2
+// CHECK: 5
+// CHECK: 2
+// CHECK: 5
+// CHECK: 2
+// CHECK: 5
+// CHECK: 2

--- a/tests/language-feature/execution-model/wave-divergent-if-emission.slang
+++ b/tests/language-feature/execution-model/wave-divergent-if-emission.slang
@@ -1,0 +1,25 @@
+//TEST:SIMPLE(filecheck=CHECK_HLSL): -target hlsl -stage compute -entry computeMain
+//TEST:SIMPLE(filecheck=CHECK_GLSL): -target glsl -stage compute -entry computeMain
+
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    int idx = int(tid.x);
+    int branchMin = 0;
+    if ((idx & 1) == 0)
+        branchMin = WaveActiveMin(idx);
+    else
+        branchMin = WaveActiveMin(idx);
+    int total = WaveActiveSum(branchMin);
+    outputBuffer[idx] = total;
+}
+
+// CHECK_HLSL: WaveActiveMin
+// CHECK_HLSL: WaveActiveMin
+// CHECK_HLSL: WaveActiveSum
+
+// CHECK_GLSL: subgroupMin
+// CHECK_GLSL: subgroupMin
+// CHECK_GLSL: subgroupAdd

--- a/tests/language-feature/execution-model/wave-divergent-if-functional.slang
+++ b/tests/language-feature/execution-model/wave-divergent-if-functional.slang
@@ -1,0 +1,23 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -shaderobj -output-using-type
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0], stride=4)
+
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    int idx = int(tid.x);
+    int branchMin = 0;
+    if ((idx & 1) == 0)
+        branchMin = WaveActiveMin(idx);
+    else
+        branchMin = WaveActiveMin(idx);
+    int total = WaveActiveSum(branchMin);
+    outputBuffer[idx] = total;
+}
+
+// CHECK: 2
+// CHECK: 2
+// CHECK: 2
+// CHECK: 2

--- a/tests/language-feature/execution-model/wave-intrinsics-emission.slang
+++ b/tests/language-feature/execution-model/wave-intrinsics-emission.slang
@@ -1,0 +1,29 @@
+// Test that wave intrinsics emit correctly to HLSL and GLSL targets.
+
+//TEST:SIMPLE(filecheck=CHECK_HLSL): -target hlsl -stage compute -entry computeMain
+//TEST:SIMPLE(filecheck=CHECK_GLSL): -target glsl -stage compute -entry computeMain
+
+RWStructuredBuffer<uint> outputBuffer;
+
+// CHECK_HLSL: WaveIsFirstLane
+// CHECK_HLSL: WaveGetLaneIndex
+// CHECK_HLSL: WaveGetLaneCount
+// CHECK_HLSL: WaveReadLaneFirst
+
+// CHECK_GLSL: subgroupElect
+// CHECK_GLSL: gl_SubgroupInvocationID
+// CHECK_GLSL: gl_SubgroupSize
+// CHECK_GLSL: subgroupBroadcastFirst
+
+[shader("compute")]
+[numthreads(64,1,1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    uint idx = tid.x;
+    bool isFirst = WaveIsFirstLane();
+    uint laneIdx = WaveGetLaneIndex();
+    uint laneCount = WaveGetLaneCount();
+    float value = float(idx);
+    float firstVal = WaveReadLaneFirst(value);
+    outputBuffer[idx] = isFirst ? laneCount : laneIdx + uint(firstVal);
+}

--- a/tests/language-feature/execution-model/wave-switch-divergence-functional.slang
+++ b/tests/language-feature/execution-model/wave-switch-divergence-functional.slang
@@ -1,0 +1,25 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -shaderobj -output-using-type
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0], stride=4)
+
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    int idx = int(tid.x);
+    int caseValue = 0;
+    switch (idx)
+    {
+    case 0: caseValue = 100; break;
+    case 1: caseValue = 200; break;
+    case 2: caseValue = 300; break;
+    default: caseValue = 400; break;
+    }
+    outputBuffer[idx] = WaveActiveSum(caseValue);
+}
+
+// CHECK: 1000
+// CHECK: 1000
+// CHECK: 1000
+// CHECK: 1000


### PR DESCRIPTION
## Summary

Adds 31 regression tests for the Slang program execution model, covering compute dispatch, groupshared memory, wave divergence/reconvergence, and pipeline stages. No compiler changes — test-only PR.

## Tests added

**`tests/language-feature/execution-model/` (20 functional / emission tests)**

- **Compute dispatch & system values**: `numthreads` linearization (1D/3D), `SV_GroupThreadID`/`SV_GroupIndex`/`SV_DispatchThreadID`.
- **Groupshared & barriers**: functional round-trips, multi-barrier sequences, SPIRV emission check.
- **Wave divergence/reconvergence**: divergent `if`, `switch`, loops with `break`, nested divergence, early return, wave ballot/verify, intrinsic emission.
- **Pipeline stages**: multiple entry points per module, `[shader(...)]` attribute, cross-stage vertex/fragment emission, `discard` in fragment.

Functional tests target CPU and CUDA (GPU-less CI can still run the CPU variant); emission tests target SPIRV/HLSL.

**`tests/diagnostics/execution-model/` (11 diagnostic tests)**

Pins the following error codes on bad execution-model input:

| Code | Covers |
|---|---|
| E31102, E31103 | invalid / non-positive `numthreads` |
| E38024 | spec-constant `numthreads` |
| E30702 | stage-incompatible system value |
| E38007 | invalid direction on system-value parameter |
| E39017, E39018 | stage-incompatible in/out parameters |
| E36105 | entry point missing `[shader(...)]` stage |
| E55205 | unknown stage name, invalid wave size, stage dependency mismatch |

## Test plan

- [x] `./build/Release/bin/slang-test tests/language-feature/execution-model/` passes locally (CPU paths)
- [x] `./build/Release/bin/slang-test tests/diagnostics/execution-model/` passes locally
- [ ] CI: CUDA / Vulkan / HLSL backends for emission tests