### PR TITLE
Fix forward-mode autodiff crash for no_diff scalar in generic vector construct

### DIFF
--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -694,21 +694,23 @@ struct ForwardDiffTranslationContext
                 }
             }
 
-            // If all diff operands are VoidType (non-differentiable), the
-            // differential of the construct is also void — don't create a
-            // construct with mismatched types.
-            bool allVoid = true;
-            for (auto op : diffOperands)
+            // If all diff operands are VoidLit (all operands are non-differentiable),
+            // the differential of the entire construct is also non-differentiable.
+            // Return nullptr instead of creating a construct with VoidLit operands
+            // that would have mismatched types (e.g. MakeVectorFromScalar(void_constant)
+            // with a float3 result type).
             {
-                if (op->getOp() != kIROp_VoidLit)
+                bool allVoid = true;
+                for (auto op : diffOperands)
                 {
-                    allVoid = false;
-                    break;
+                    if (op->getOp() != kIROp_VoidLit)
+                    {
+                        allVoid = false;
+                        break;
+                    }
                 }
-            }
-            if (allVoid)
-            {
-                return InstPair(primalConstruct, nullptr);
+                if (allVoid)
+                    return InstPair(primalConstruct, nullptr);
             }
 
             return InstPair(

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -694,6 +694,23 @@ struct ForwardDiffTranslationContext
                 }
             }
 
+            // If all diff operands are VoidType (non-differentiable), the
+            // differential of the construct is also void — don't create a
+            // construct with mismatched types.
+            bool allVoid = true;
+            for (auto op : diffOperands)
+            {
+                if (op->getOp() != kIROp_VoidLit)
+                {
+                    allVoid = false;
+                    break;
+                }
+            }
+            if (allVoid)
+            {
+                return InstPair(primalConstruct, nullptr);
+            }
+
             return InstPair(
                 primalConstruct,
                 builder->emitIntrinsicInst(

--- a/tests/autodiff/fwd-no-diff-in-generic-construct-variants.slang
+++ b/tests/autodiff/fwd-no-diff-in-generic-construct-variants.slang
@@ -1,0 +1,99 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
+
+// Test that forward-mode autodiff correctly handles all-void-operand constructs
+// in generic functions: MakeVectorFromScalar, MakeMatrixFromScalar,
+// MakeMatrix (from vectors), and MakeArrayFromElement.
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+interface IModel : IDifferentiable {
+    [Differentiable]
+    float eval(float x);
+}
+
+struct SimpleModel : IModel {
+    float scale;
+    [Differentiable]
+    float eval(float x) { return scale * x; }
+}
+
+// --- MakeVectorFromScalar: lerp(float3, float3, no_diff float) ---
+[Differentiable]
+float3 test_vector_from_scalar<M : IModel>(M m, float3 a, float3 b, no_diff float t) {
+    return lerp(a, b, t) * m.eval(1.0);
+}
+
+// --- MakeMatrixFromScalar: float3x3(no_diff float) ---
+[Differentiable]
+float test_matrix_from_scalar<M : IModel>(M m, float3 v, no_diff float s) {
+    float3x3 mat = float3x3(s);
+    float3 r = mul(mat, v);
+    return m.eval(r.x);
+}
+
+// --- MakeMatrix from no_diff row vectors ---
+[Differentiable]
+float test_matrix_from_vector<M : IModel>(M m, float3 v, no_diff float3 row) {
+    float3x3 mat = float3x3(row, row, row);
+    float3 r = mul(mat, v);
+    return m.eval(r.x);
+}
+
+// --- MakeArrayFromElement: array from no_diff element ---
+[Differentiable]
+float test_array_from_element<M : IModel>(M m, float x, no_diff float y) {
+    float arr[3] = { y, y, y };
+    return m.eval(x + arr[0]);
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    SimpleModel m;
+    m.scale = 2.0;
+
+    // test_vector_from_scalar: lerp((1,1,1), (3,3,3), 0.5) = (2,2,2), *2 = (4,4,4)
+    // d/da with da=(1,1,1): d_lerp = 0.5*(1,1,1), *2 = (1,1,1)
+    {
+        DifferentialPair<SimpleModel> dpm = diffPair(m, SimpleModel.dzero());
+        DifferentialPair<float3> dpa = diffPair(float3(1,1,1), float3(1,1,1));
+        DifferentialPair<float3> dpb = diffPair(float3(3,3,3), float3(0,0,0));
+        var r = __fwd_diff(test_vector_from_scalar)(dpm, dpa, dpb, 0.5);
+        outputBuffer[0] = r.p.x; // CHECK: 4.0
+        outputBuffer[1] = r.d.x; // CHECK: 1.0
+    }
+
+    // test_matrix_from_scalar: float3x3(0.5) fills all 9 elements with 0.5
+    // mul(mat, (1,1,1)) = (1.5,1.5,1.5), r.x = 1.5, eval = 2*1.5 = 3.0
+    // d/dv with dv=(1,0,0): mul(mat,dv) = (0.5,0.5,0.5), d(r.x) = 0.5, d(eval) = 2*0.5 = 1.0
+    {
+        DifferentialPair<SimpleModel> dpm = diffPair(m, SimpleModel.dzero());
+        DifferentialPair<float3> dpv = diffPair(float3(1,1,1), float3(1,0,0));
+        var r = __fwd_diff(test_matrix_from_scalar)(dpm, dpv, 0.5);
+        outputBuffer[2] = r.p;   // CHECK: 3.0
+        outputBuffer[3] = r.d;   // CHECK: 1.0
+    }
+
+    // test_matrix_from_vector: mat with all rows = (1,0,0), mul(mat, (1,2,3)) = (1,1,1)
+    // eval = 2*1 = 2.0, d/dv with dv=(1,0,0): d(mul) = (1,1,1), d(eval) = 2*1 = 2.0
+    {
+        DifferentialPair<SimpleModel> dpm = diffPair(m, SimpleModel.dzero());
+        DifferentialPair<float3> dpv = diffPair(float3(1,2,3), float3(1,0,0));
+        var r = __fwd_diff(test_matrix_from_vector)(dpm, dpv, float3(1,0,0));
+        outputBuffer[4] = r.p;   // CHECK: 2.0
+        outputBuffer[5] = r.d;   // CHECK: 2.0
+    }
+
+    // test_array_from_element: arr = {1, 1, 1}, eval(x + arr[0]) = eval(2+1) = 2*3 = 6.0
+    // d/dx with dx=1: d(eval) = 2*1 = 2.0
+    {
+        DifferentialPair<SimpleModel> dpm = diffPair(m, SimpleModel.dzero());
+        DifferentialPair<float> dpx = diffPair(2.0, 1.0);
+        var r = __fwd_diff(test_array_from_element)(dpm, dpx, 1.0);
+        outputBuffer[6] = r.p;   // CHECK: 6.0
+        outputBuffer[7] = r.d;   // CHECK: 2.0
+    }
+}

--- a/tests/autodiff/fwd-no-diff-scalar-in-generic-vector-construct.slang
+++ b/tests/autodiff/fwd-no-diff-scalar-in-generic-vector-construct.slang
@@ -1,16 +1,17 @@
-//TEST:SIMPLE(filecheck=CUDA): -target cuda -line-directive-mode none
-//TEST:SIMPLE(filecheck=HLSL): -target hlsl -line-directive-mode none -DEXCLUDE_CUDA_KERNEL
-//TEST:SIMPLE(filecheck=SPV): -target spirv-asm -emit-spirv-directly -line-directive-mode none -DEXCLUDE_CUDA_KERNEL
-//TEST:SIMPLE(filecheck=METAL): -target metal -line-directive-mode none -DEXCLUDE_CUDA_KERNEL
-//TEST:SIMPLE(filecheck=WGSL): -target wgsl -line-directive-mode none -DEXCLUDE_CUDA_KERNEL
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
 
 // Test that forward-mode autodiff correctly handles a no_diff scalar parameter
 // used in a vector construction (via lerp(float3, float3, float)) inside a
 // generic function with IDifferentiable interface constraints.
 //
 // Previously this crashed with "unexpected IR opcode during code emit" because
-// the forward-mode pass emitted void_constant (RTTIType) instead of a zero
-// literal for the differential of the no_diff parameter.
+// the forward-mode pass emitted void_constant (RTTIType) instead of returning
+// nullptr for the all-void construct differential.
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
 
 interface IA : IDifferentiable {
     [Differentiable]
@@ -28,34 +29,23 @@ float3 my_func<A : IA>(A a, float3 x, float3 y, no_diff float alpha) {
     return a.f(lerp(x, y, alpha));
 }
 
-// CUDA-DAG: __global__ void __kernel__kern
-// HLSL: computeMain
-// SPV: OpEntryPoint
-// METAL: computeMain
-// WGSL: computeMain
-
-RWStructuredBuffer<float> buffer;
-
-[shader("compute")]
-[numthreads(1,1,1)]
-void computeMain(uint tid : SV_DispatchThreadID)
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     SA a;
     a.s = 2.0;
-    float v = buffer[tid];
-    float3 r = my_func(a, float3(v,v,v), float3(v+1,v+1,v+1), 0.5);
-    buffer[tid] = r.x;
-}
 
-#ifndef EXCLUDE_CUDA_KERNEL
-[CUDAKernel]
-[Differentiable]
-[AutoPyBindCUDA]
-void kern(DiffTensorView io) {
-    uint tid = cudaBlockIdx().x * cudaBlockDim().x + cudaThreadIdx().x;
-    SA a; a.s = 2.0;
-    float v = io.loadOnce(uint2(tid, 0));
-    float3 r = my_func(a, float3(v,v,v), float3(v+1,v+1,v+1), 0.5);
-    io.storeOnce(uint2(tid, 0), r.x);
+    // fwd_diff of my_func with dx=(1,1,1), dy=(0,0,0)
+    // lerp(x, y, 0.5) = (2,2,2), a.f(v) = 2*v = (4,4,4)
+    // d/dx lerp = (1-alpha)*dx = 0.5*(1,1,1), d(a.f) = 2*0.5 = (1,1,1)
+    DifferentialPair<float3> dpx = diffPair(float3(1, 1, 1), float3(1, 1, 1));
+    DifferentialPair<float3> dpy = diffPair(float3(3, 3, 3), float3(0, 0, 0));
+    DifferentialPair<SA> dpa = diffPair(a, SA.dzero());
+
+    DifferentialPair<float3> result = __fwd_diff(my_func)(dpa, dpx, dpy, 0.5);
+
+    outputBuffer[0] = result.p.x; // CHECK: 4.0
+    outputBuffer[1] = result.d.x; // CHECK: 1.0
+    outputBuffer[2] = result.d.y; // CHECK: 1.0
+    outputBuffer[3] = result.d.z; // CHECK: 1.0
 }
-#endif

--- a/tests/autodiff/fwd-no-diff-scalar-in-generic-vector-construct.slang
+++ b/tests/autodiff/fwd-no-diff-scalar-in-generic-vector-construct.slang
@@ -1,0 +1,61 @@
+//TEST:SIMPLE(filecheck=CUDA): -target cuda -line-directive-mode none
+//TEST:SIMPLE(filecheck=HLSL): -target hlsl -line-directive-mode none -DEXCLUDE_CUDA_KERNEL
+//TEST:SIMPLE(filecheck=SPV): -target spirv-asm -emit-spirv-directly -line-directive-mode none -DEXCLUDE_CUDA_KERNEL
+//TEST:SIMPLE(filecheck=METAL): -target metal -line-directive-mode none -DEXCLUDE_CUDA_KERNEL
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -line-directive-mode none -DEXCLUDE_CUDA_KERNEL
+
+// Test that forward-mode autodiff correctly handles a no_diff scalar parameter
+// used in a vector construction (via lerp(float3, float3, float)) inside a
+// generic function with IDifferentiable interface constraints.
+//
+// Previously this crashed with "unexpected IR opcode during code emit" because
+// the forward-mode pass emitted void_constant (RTTIType) instead of a zero
+// literal for the differential of the no_diff parameter.
+
+interface IA : IDifferentiable {
+    [Differentiable]
+    float3 f(float3 x);
+}
+
+struct SA : IA {
+    float s;
+    [Differentiable]
+    float3 f(float3 x) { return s * x; }
+}
+
+[Differentiable]
+float3 my_func<A : IA>(A a, float3 x, float3 y, no_diff float alpha) {
+    return a.f(lerp(x, y, alpha));
+}
+
+// CUDA-DAG: __global__ void __kernel__kern
+// HLSL: computeMain
+// SPV: OpEntryPoint
+// METAL: computeMain
+// WGSL: computeMain
+
+RWStructuredBuffer<float> buffer;
+
+[shader("compute")]
+[numthreads(1,1,1)]
+void computeMain(uint tid : SV_DispatchThreadID)
+{
+    SA a;
+    a.s = 2.0;
+    float v = buffer[tid];
+    float3 r = my_func(a, float3(v,v,v), float3(v+1,v+1,v+1), 0.5);
+    buffer[tid] = r.x;
+}
+
+#ifndef EXCLUDE_CUDA_KERNEL
+[CUDAKernel]
+[Differentiable]
+[AutoPyBindCUDA]
+void kern(DiffTensorView io) {
+    uint tid = cudaBlockIdx().x * cudaBlockDim().x + cudaThreadIdx().x;
+    SA a; a.s = 2.0;
+    float v = io.loadOnce(uint2(tid, 0));
+    float3 r = my_func(a, float3(v,v,v), float3(v+1,v+1,v+1), 0.5);
+    io.storeOnce(uint2(tid, 0), r.x);
+}
+#endif


### PR DESCRIPTION
## Summary
- Fix a crash (`unexpected IR opcode during code emit`, `kIROp_RTTIType`) in forward-mode autodiff when a `[Differentiable]` generic function has `no_diff` parameters used in construct instructions (`MakeVectorFromScalar`, `MakeMatrixFromScalar`, `MakeArrayFromElement`, etc.).
- In `translateConstruct()`, when all diff operands are `VoidLit` (all operands are non-differentiable), the code now returns `nullptr` for the differential instead of creating a construct with mismatched types (e.g., `MakeVectorFromScalar(void_constant)` with a `float3` result type).
- The backward-mode pass is not affected because it uses gradient accumulation and never constructs explicit zero differentials.
- A follow-up issue #10888 tracks the proper fix via `NoDiffCastExpr` coercion, which would also handle the mixed-operand case (`MakeVector(diff, VoidLit, VoidLit)`).

Close #10882

## Test plan
- [x] `tests/autodiff/fwd-no-diff-scalar-in-generic-vector-construct.slang` — compute test verifying forward-diff output values for `MakeVectorFromScalar` with `no_diff` alpha in a generic function. Runs on vk, cuda, llvm.
- [x] `tests/autodiff/fwd-no-diff-in-generic-construct-variants.slang` — compute tests covering `MakeMatrixFromScalar`, `MakeMatrix` from `no_diff` row vectors, and `MakeArrayFromElement`. Runs on vk, cuda, llvm.