### PR TITLE
Prevent accidental backward-compatibility breaks in slang.h

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,39 @@ int foo = undefined;
 - **Adding a built-in function**: Add to appropriate module in `prelude/`
 - **Adding a new target**: Implement new emitter in `source/slang/slang-emit-*.cpp`
 
+### Modifying Public Headers (`include/`)
+
+All files under `include/` are public API. Changes must preserve binary (ABI) and source
+compatibility for callers compiled against older versions of the header.
+
+#### Enums
+
+- **Never insert a new enumerator in the middle of an existing enum.** Insertion shifts all
+  subsequent integer values, silently breaking any caller that stores or compares the value.
+- **Always append** new enumerators immediately before the terminal count/sentinel member
+  (e.g. `CountOf`, `Count`, `NUM_*`), assigning an explicit integer value (the next sequential
+  integer after the preceding enumerator).
+- **Removed enumerators**: rename to `REMOVED_<Name>` and keep the original integer value.
+  Never reuse or reclaim a retired integer.
+
+#### Virtual tables (COM interfaces)
+
+Slang's public interfaces (`ISession`, `IModule`, `IComponentType`, etc.) are COM-style
+vtables declared with `virtual` methods in `include/slang.h`. The vtable layout is fixed by
+declaration order. Violating these rules corrupts the vtable and causes silent crashes or
+wrong-method dispatch for any caller compiled against an older header.
+
+- **Never reorder virtual methods** within an interface.
+- **Never change a virtual method's signature** (return type, parameter types, calling
+  convention, or `SLANG_MCALL` decoration).
+- **Never insert a new virtual method** in the middle of an interface — append only, at the
+  end of the interface before the closing brace.
+- **Never remove a virtual method** — replace its body with a stub that returns
+  `SLANG_E_NOT_IMPLEMENTED` and keep the declaration in place.
+- Avoid extending an existing public COM interface in place when clients may implement or
+  query it by UUID. Prefer adding a new derived/versioned interface with its own UUID, while
+  keeping the original interface declaration and UUID supported for existing callers.
+
 ### Debugging tools
 
 #### IR Dump (`-dump-ir`)

--- a/docs/user-guide/08-compiling.md
+++ b/docs/user-guide/08-compiling.md
@@ -1028,6 +1028,24 @@ meanings of their `CompilerOptionValue` encodings.
 | GenerateWholeProgram | When set will emit target code for the entire program instead of for a specific entry point. `intValue0` specifies a bool value for the setting. |
 | UseUpToDateBinaryModule | When set will only load precompiled modules if it is up-to-date with its source. `intValue0` specifies a bool value for the setting. |
 | ValidateUniformity | When set will perform [uniformity analysis](a1-05-uniformity.md).|
+| SPIRVResourceHeapStride | Specifies the byte stride for the resource descriptor heap when generating SPIR-V with `spvDescriptorHeapEXT`. `intValue0` encodes the stride in bytes; use 0 to let the driver compute the stride via `OpConstantSizeOfEXT`. |
+| SPIRVSamplerHeapStride | Specifies the byte stride for the sampler descriptor heap when generating SPIR-V with `spvDescriptorHeapEXT`. `intValue0` encodes the stride in bytes; use 0 to let the driver compute the stride via `OpConstantSizeOfEXT`. |
+| ForceDXLayout | When set forces the compiler to use DirectX-compatible (HLSL register packing) rules when laying out buffer struct fields during code generation. `intValue0` specifies a bool value for the setting. |
+| ForceCLayout | When set forces the compiler to use C struct layout rules (natural alignment, no HLSL/GLSL padding) when laying out buffer struct fields during code generation. `intValue0` specifies a bool value for the setting. |
+| DenormalModeFp16 | Specifies how 16-bit floating-point denormal values are handled. `intValue0` encodes a value from the `SlangFpDenormalMode` enum. |
+| DenormalModeFp32 | Specifies how 32-bit floating-point denormal values are handled. `intValue0` encodes a value from the `SlangFpDenormalMode` enum. |
+| DenormalModeFp64 | Specifies how 64-bit floating-point denormal values are handled. `intValue0` encodes a value from the `SlangFpDenormalMode` enum. |
+| UseMSVCStyleBitfieldPacking | When set uses MSVC-compatible bitfield packing rules instead of the default GLSL/Vulkan rules. `intValue0` specifies a bool value for the setting. |
+
+### Compiler Option ABI Stability
+
+Each `CompilerOptionName` enumerator has an explicit integer value in `include/slang.h`. You
+can safely pass option names through the `CompilerOptionEntry` API and rely on them remaining
+consistent across Slang releases.
+
+New options are assigned explicit integer values above the current `CountOf` sentinel; existing
+values are never changed. Deprecated options are retained as numbered placeholders to prevent
+renumbering of subsequent members.
 
 ## Debugging
 

--- a/include/slang.h
+++ b/include/slang.h
@@ -576,12 +576,13 @@ typedef uint32_t SlangSizeT;
     enum SlangSeverity : SlangSeverityIntegral
     {
         SLANG_SEVERITY_DISABLED = 0, /**< A message that is disabled, filtered out. */
-        SLANG_SEVERITY_NOTE,         /**< An informative message. */
-        SLANG_SEVERITY_WARNING,      /**< A warning, which indicates a possible problem. */
-        SLANG_SEVERITY_ERROR,        /**< An error, indicating that compilation failed. */
-        SLANG_SEVERITY_FATAL,    /**< An unrecoverable error, which forced compilation to abort. */
-        SLANG_SEVERITY_INTERNAL, /**< An internal error, indicating a logic error in the compiler.
-                                  */
+        SLANG_SEVERITY_NOTE = 1,     /**< An informative message. */
+        SLANG_SEVERITY_WARNING = 2,  /**< A warning, which indicates a possible problem. */
+        SLANG_SEVERITY_ERROR = 3,    /**< An error, indicating that compilation failed. */
+        SLANG_SEVERITY_FATAL = 4, /**< An unrecoverable error, which forced compilation to abort. */
+        SLANG_SEVERITY_INTERNAL =
+            5, /**< An internal error, indicating a logic error in the compiler.
+                */
     };
 
     typedef int SlangDiagnosticFlags;
@@ -595,10 +596,10 @@ typedef uint32_t SlangSizeT;
     enum SlangBindableResourceType : SlangBindableResourceIntegral
     {
         SLANG_NON_BINDABLE = 0,
-        SLANG_TEXTURE,
-        SLANG_SAMPLER,
-        SLANG_UNIFORM_BUFFER,
-        SLANG_STORAGE_BUFFER,
+        SLANG_TEXTURE = 1,
+        SLANG_SAMPLER = 2,
+        SLANG_UNIFORM_BUFFER = 3,
+        SLANG_STORAGE_BUFFER = 4,
     };
 
     /* NOTE! To keep binary compatibility care is needed with this enum!
@@ -612,47 +613,47 @@ typedef uint32_t SlangSizeT;
     typedef int SlangCompileTargetIntegral;
     enum SlangCompileTarget : SlangCompileTargetIntegral
     {
-        SLANG_TARGET_UNKNOWN,
-        SLANG_TARGET_NONE,
-        SLANG_GLSL,
-        SLANG_GLSL_VULKAN_DEPRECATED,          //< deprecated and removed: just use `SLANG_GLSL`.
-        SLANG_GLSL_VULKAN_ONE_DESC_DEPRECATED, //< deprecated and removed.
-        SLANG_HLSL,
-        SLANG_SPIRV,
-        SLANG_SPIRV_ASM,
-        SLANG_DXBC,
-        SLANG_DXBC_ASM,
-        SLANG_DXIL,
-        SLANG_DXIL_ASM,
-        SLANG_C_SOURCE,              ///< The C language
-        SLANG_CPP_SOURCE,            ///< C++ code for shader kernels.
-        SLANG_HOST_EXECUTABLE,       ///< Standalone binary executable (for hosting CPU/OS)
-        SLANG_SHADER_SHARED_LIBRARY, ///< A shared library/Dll for shader kernels (for hosting
-                                     ///< CPU/OS)
-        SLANG_SHADER_HOST_CALLABLE,  ///< A CPU target that makes the compiled shader code available
-                                     ///< to be run immediately
-        SLANG_CUDA_SOURCE,           ///< Cuda source
-        SLANG_PTX,                   ///< PTX
-        SLANG_CUDA_OBJECT_CODE,      ///< Object code that contains CUDA functions.
-        SLANG_OBJECT_CODE,     ///< Object code that can be used for later linking (kernel/shader)
-        SLANG_HOST_CPP_SOURCE, ///< C++ code for host library or executable.
-        SLANG_HOST_HOST_CALLABLE,  ///< Host callable host code (ie non kernel/shader)
-        SLANG_CPP_PYTORCH_BINDING, ///< C++ PyTorch binding code.
-        SLANG_METAL,               ///< Metal shading language
-        SLANG_METAL_LIB,           ///< Metal library
-        SLANG_METAL_LIB_ASM,       ///< Metal library assembly
-        SLANG_HOST_SHARED_LIBRARY, ///< A shared library/Dll for host code (for hosting CPU/OS)
-        SLANG_WGSL,                ///< WebGPU shading language
-        SLANG_WGSL_SPIRV_ASM,      ///< SPIR-V assembly via WebGPU shading language
-        SLANG_WGSL_SPIRV,          ///< SPIR-V via WebGPU shading language
+        SLANG_TARGET_UNKNOWN = 0,
+        SLANG_TARGET_NONE = 1,
+        SLANG_GLSL = 2,
+        SLANG_GLSL_VULKAN_DEPRECATED = 3, //< deprecated and removed: just use `SLANG_GLSL`.
+        SLANG_GLSL_VULKAN_ONE_DESC_DEPRECATED = 4, //< deprecated and removed.
+        SLANG_HLSL = 5,
+        SLANG_SPIRV = 6,
+        SLANG_SPIRV_ASM = 7,
+        SLANG_DXBC = 8,
+        SLANG_DXBC_ASM = 9,
+        SLANG_DXIL = 10,
+        SLANG_DXIL_ASM = 11,
+        SLANG_C_SOURCE = 12,              ///< The C language
+        SLANG_CPP_SOURCE = 13,            ///< C++ code for shader kernels.
+        SLANG_HOST_EXECUTABLE = 14,       ///< Standalone binary executable (for hosting CPU/OS)
+        SLANG_SHADER_SHARED_LIBRARY = 15, ///< A shared library/Dll for shader kernels (for hosting
+                                          ///< CPU/OS)
+        SLANG_SHADER_HOST_CALLABLE = 16,  ///< A CPU target that makes the compiled shader code
+                                          ///< available to be run immediately
+        SLANG_CUDA_SOURCE = 17,           ///< Cuda source
+        SLANG_PTX = 18,                   ///< PTX
+        SLANG_CUDA_OBJECT_CODE = 19,      ///< Object code that contains CUDA functions.
+        SLANG_OBJECT_CODE = 20, ///< Object code that can be used for later linking (kernel/shader)
+        SLANG_HOST_CPP_SOURCE = 21,     ///< C++ code for host library or executable.
+        SLANG_HOST_HOST_CALLABLE = 22,  ///< Host callable host code (ie non kernel/shader)
+        SLANG_CPP_PYTORCH_BINDING = 23, ///< C++ PyTorch binding code.
+        SLANG_METAL = 24,               ///< Metal shading language
+        SLANG_METAL_LIB = 25,           ///< Metal library
+        SLANG_METAL_LIB_ASM = 26,       ///< Metal library assembly
+        SLANG_HOST_SHARED_LIBRARY = 27, ///< A shared library/Dll for host code (for hosting CPU/OS)
+        SLANG_WGSL = 28,                ///< WebGPU shading language
+        SLANG_WGSL_SPIRV_ASM = 29,      ///< SPIR-V assembly via WebGPU shading language
+        SLANG_WGSL_SPIRV = 30,          ///< SPIR-V via WebGPU shading language
 
-        SLANG_HOST_VM,     ///< Bytecode that can be interpreted by the Slang VM
-        SLANG_CPP_HEADER,  ///< C++ header for shader kernels.
-        SLANG_CUDA_HEADER, ///< Cuda header
+        SLANG_HOST_VM = 31,     ///< Bytecode that can be interpreted by the Slang VM
+        SLANG_CPP_HEADER = 32,  ///< C++ header for shader kernels.
+        SLANG_CUDA_HEADER = 33, ///< Cuda header
 
-        SLANG_HOST_OBJECT_CODE, ///< Host object code
-        SLANG_HOST_LLVM_IR,     ///< Host LLVM IR assembly
-        SLANG_SHADER_LLVM_IR,   ///< Host LLVM IR assembly (kernel/shader)
+        SLANG_HOST_OBJECT_CODE = 34, ///< Host object code
+        SLANG_HOST_LLVM_IR = 35,     ///< Host LLVM IR assembly
+        SLANG_SHADER_LLVM_IR = 36,   ///< Host LLVM IR assembly (kernel/shader)
 
         SLANG_TARGET_COUNT_OF,
     };
@@ -664,32 +665,32 @@ typedef uint32_t SlangSizeT;
     enum SlangContainerFormat : SlangContainerFormatIntegral
     {
         /* Don't generate a container. */
-        SLANG_CONTAINER_FORMAT_NONE,
+        SLANG_CONTAINER_FORMAT_NONE = 0,
 
         /* Generate a container in the `.slang-module` format,
         which includes reflection information, compiled kernels, etc. */
-        SLANG_CONTAINER_FORMAT_SLANG_MODULE,
+        SLANG_CONTAINER_FORMAT_SLANG_MODULE = 1,
     };
 
     typedef int SlangPassThroughIntegral;
     enum SlangPassThrough : SlangPassThroughIntegral
     {
-        SLANG_PASS_THROUGH_NONE,
-        SLANG_PASS_THROUGH_FXC,
-        SLANG_PASS_THROUGH_DXC,
-        SLANG_PASS_THROUGH_GLSLANG,
-        SLANG_PASS_THROUGH_SPIRV_DIS,
-        SLANG_PASS_THROUGH_CLANG,         ///< Clang C/C++ compiler
-        SLANG_PASS_THROUGH_VISUAL_STUDIO, ///< Visual studio C/C++ compiler
-        SLANG_PASS_THROUGH_GCC,           ///< GCC C/C++ compiler
-        SLANG_PASS_THROUGH_GENERIC_C_CPP, ///< Generic C or C++ compiler, which is decided by the
-                                          ///< source type
-        SLANG_PASS_THROUGH_NVRTC,         ///< NVRTC Cuda compiler
-        SLANG_PASS_THROUGH_LLVM,          ///< LLVM 'compiler' - includes LLVM and Clang
-        SLANG_PASS_THROUGH_SPIRV_OPT,     ///< SPIRV-opt
-        SLANG_PASS_THROUGH_METAL,         ///< Metal compiler
-        SLANG_PASS_THROUGH_TINT,          ///< Tint WGSL compiler
-        SLANG_PASS_THROUGH_SPIRV_LINK,    ///< SPIRV-link
+        SLANG_PASS_THROUGH_NONE = 0,
+        SLANG_PASS_THROUGH_FXC = 1,
+        SLANG_PASS_THROUGH_DXC = 2,
+        SLANG_PASS_THROUGH_GLSLANG = 3,
+        SLANG_PASS_THROUGH_SPIRV_DIS = 4,
+        SLANG_PASS_THROUGH_CLANG = 5,         ///< Clang C/C++ compiler
+        SLANG_PASS_THROUGH_VISUAL_STUDIO = 6, ///< Visual studio C/C++ compiler
+        SLANG_PASS_THROUGH_GCC = 7,           ///< GCC C/C++ compiler
+        SLANG_PASS_THROUGH_GENERIC_C_CPP = 8, ///< Generic C or C++ compiler, which is decided by
+                                              ///< the source type
+        SLANG_PASS_THROUGH_NVRTC = 9,         ///< NVRTC Cuda compiler
+        SLANG_PASS_THROUGH_LLVM = 10,         ///< LLVM 'compiler' - includes LLVM and Clang
+        SLANG_PASS_THROUGH_SPIRV_OPT = 11,    ///< SPIRV-opt
+        SLANG_PASS_THROUGH_METAL = 12,        ///< Metal compiler
+        SLANG_PASS_THROUGH_TINT = 13,         ///< Tint WGSL compiler
+        SLANG_PASS_THROUGH_SPIRV_LINK = 14,   ///< SPIRV-link
         SLANG_PASS_THROUGH_COUNT_OF,
     };
 
@@ -697,11 +698,11 @@ typedef uint32_t SlangSizeT;
     typedef int SlangArchiveTypeIntegral;
     enum SlangArchiveType : SlangArchiveTypeIntegral
     {
-        SLANG_ARCHIVE_TYPE_UNDEFINED,
-        SLANG_ARCHIVE_TYPE_ZIP,
-        SLANG_ARCHIVE_TYPE_RIFF, ///< Riff container with no compression
-        SLANG_ARCHIVE_TYPE_RIFF_DEFLATE,
-        SLANG_ARCHIVE_TYPE_RIFF_LZ4,
+        SLANG_ARCHIVE_TYPE_UNDEFINED = 0,
+        SLANG_ARCHIVE_TYPE_ZIP = 1,
+        SLANG_ARCHIVE_TYPE_RIFF = 2, ///< Riff container with no compression
+        SLANG_ARCHIVE_TYPE_RIFF_DEFLATE = 3,
+        SLANG_ARCHIVE_TYPE_RIFF_LZ4 = 4,
         SLANG_ARCHIVE_TYPE_COUNT_OF,
     };
 
@@ -762,8 +763,8 @@ typedef uint32_t SlangSizeT;
     enum SlangFloatingPointMode : SlangFloatingPointModeIntegral
     {
         SLANG_FLOATING_POINT_MODE_DEFAULT = 0,
-        SLANG_FLOATING_POINT_MODE_FAST,
-        SLANG_FLOATING_POINT_MODE_PRECISE,
+        SLANG_FLOATING_POINT_MODE_FAST = 1,
+        SLANG_FLOATING_POINT_MODE_PRECISE = 2,
     };
 
     /*!
@@ -773,8 +774,8 @@ typedef uint32_t SlangSizeT;
     enum SlangFpDenormalMode : SlangFpDenormalModeIntegral
     {
         SLANG_FP_DENORM_MODE_ANY = 0,
-        SLANG_FP_DENORM_MODE_PRESERVE,
-        SLANG_FP_DENORM_MODE_FTZ,
+        SLANG_FP_DENORM_MODE_PRESERVE = 1,
+        SLANG_FP_DENORM_MODE_FTZ = 2,
     };
 
     /*!
@@ -785,35 +786,35 @@ typedef uint32_t SlangSizeT;
     {
         SLANG_LINE_DIRECTIVE_MODE_DEFAULT =
             0,                              /**< Default behavior: pick behavior base on target. */
-        SLANG_LINE_DIRECTIVE_MODE_NONE,     /**< Don't emit line directives at all. */
-        SLANG_LINE_DIRECTIVE_MODE_STANDARD, /**< Emit standard C-style `#line` directives. */
-        SLANG_LINE_DIRECTIVE_MODE_GLSL, /**< Emit GLSL-style directives with file *number* instead
-                                           of name */
-        SLANG_LINE_DIRECTIVE_MODE_SOURCE_MAP, /**< Use a source map to track line mappings (ie no
-                                                 #line will appear in emitting source) */
+        SLANG_LINE_DIRECTIVE_MODE_NONE = 1, /**< Don't emit line directives at all. */
+        SLANG_LINE_DIRECTIVE_MODE_STANDARD = 2,   /**< Emit standard C-style `#line` directives. */
+        SLANG_LINE_DIRECTIVE_MODE_GLSL = 3,       /**< Emit GLSL-style directives with file *number*
+                                                       instead of name */
+        SLANG_LINE_DIRECTIVE_MODE_SOURCE_MAP = 4, /**< Use a source map to track line mappings (ie
+                                                     no #line will appear in emitting source) */
     };
 
     typedef int SlangSourceLanguageIntegral;
     enum SlangSourceLanguage : SlangSourceLanguageIntegral
     {
-        SLANG_SOURCE_LANGUAGE_UNKNOWN,
-        SLANG_SOURCE_LANGUAGE_SLANG,
-        SLANG_SOURCE_LANGUAGE_HLSL,
-        SLANG_SOURCE_LANGUAGE_GLSL,
-        SLANG_SOURCE_LANGUAGE_C,
-        SLANG_SOURCE_LANGUAGE_CPP,
-        SLANG_SOURCE_LANGUAGE_CUDA,
-        SLANG_SOURCE_LANGUAGE_SPIRV,
-        SLANG_SOURCE_LANGUAGE_METAL,
-        SLANG_SOURCE_LANGUAGE_WGSL,
-        SLANG_SOURCE_LANGUAGE_LLVM,
+        SLANG_SOURCE_LANGUAGE_UNKNOWN = 0,
+        SLANG_SOURCE_LANGUAGE_SLANG = 1,
+        SLANG_SOURCE_LANGUAGE_HLSL = 2,
+        SLANG_SOURCE_LANGUAGE_GLSL = 3,
+        SLANG_SOURCE_LANGUAGE_C = 4,
+        SLANG_SOURCE_LANGUAGE_CPP = 5,
+        SLANG_SOURCE_LANGUAGE_CUDA = 6,
+        SLANG_SOURCE_LANGUAGE_SPIRV = 7,
+        SLANG_SOURCE_LANGUAGE_METAL = 8,
+        SLANG_SOURCE_LANGUAGE_WGSL = 9,
+        SLANG_SOURCE_LANGUAGE_LLVM = 10,
         SLANG_SOURCE_LANGUAGE_COUNT_OF,
     };
 
     typedef unsigned int SlangProfileIDIntegral;
     enum SlangProfileID : SlangProfileIDIntegral
     {
-        SLANG_PROFILE_UNKNOWN,
+        SLANG_PROFILE_UNKNOWN = 0,
     };
 
 
@@ -827,29 +828,29 @@ typedef uint32_t SlangSizeT;
     enum SlangMatrixLayoutMode : SlangMatrixLayoutModeIntegral
     {
         SLANG_MATRIX_LAYOUT_MODE_UNKNOWN = 0,
-        SLANG_MATRIX_LAYOUT_ROW_MAJOR,
-        SLANG_MATRIX_LAYOUT_COLUMN_MAJOR,
+        SLANG_MATRIX_LAYOUT_ROW_MAJOR = 1,
+        SLANG_MATRIX_LAYOUT_COLUMN_MAJOR = 2,
     };
 
     typedef SlangUInt32 SlangStageIntegral;
     enum SlangStage : SlangStageIntegral
     {
-        SLANG_STAGE_NONE,
-        SLANG_STAGE_VERTEX,
-        SLANG_STAGE_HULL,
-        SLANG_STAGE_DOMAIN,
-        SLANG_STAGE_GEOMETRY,
-        SLANG_STAGE_FRAGMENT,
-        SLANG_STAGE_COMPUTE,
-        SLANG_STAGE_RAY_GENERATION,
-        SLANG_STAGE_INTERSECTION,
-        SLANG_STAGE_ANY_HIT,
-        SLANG_STAGE_CLOSEST_HIT,
-        SLANG_STAGE_MISS,
-        SLANG_STAGE_CALLABLE,
-        SLANG_STAGE_MESH,
-        SLANG_STAGE_AMPLIFICATION,
-        SLANG_STAGE_DISPATCH,
+        SLANG_STAGE_NONE = 0,
+        SLANG_STAGE_VERTEX = 1,
+        SLANG_STAGE_HULL = 2,
+        SLANG_STAGE_DOMAIN = 3,
+        SLANG_STAGE_GEOMETRY = 4,
+        SLANG_STAGE_FRAGMENT = 5,
+        SLANG_STAGE_COMPUTE = 6,
+        SLANG_STAGE_RAY_GENERATION = 7,
+        SLANG_STAGE_INTERSECTION = 8,
+        SLANG_STAGE_ANY_HIT = 9,
+        SLANG_STAGE_CLOSEST_HIT = 10,
+        SLANG_STAGE_MISS = 11,
+        SLANG_STAGE_CALLABLE = 12,
+        SLANG_STAGE_MESH = 13,
+        SLANG_STAGE_AMPLIFICATION = 14,
+        SLANG_STAGE_DISPATCH = 15,
         //
         SLANG_STAGE_COUNT,
 
@@ -860,45 +861,45 @@ typedef uint32_t SlangSizeT;
     typedef SlangUInt32 SlangCooperativeMatrixUseIntegral;
     enum SlangCooperativeMatrixUse : SlangCooperativeMatrixUseIntegral
     {
-        SLANG_COOPERATIVE_MATRIX_USE_A,
-        SLANG_COOPERATIVE_MATRIX_USE_B,
-        SLANG_COOPERATIVE_MATRIX_USE_ACCUMULATOR,
+        SLANG_COOPERATIVE_MATRIX_USE_A = 0,
+        SLANG_COOPERATIVE_MATRIX_USE_B = 1,
+        SLANG_COOPERATIVE_MATRIX_USE_ACCUMULATOR = 2,
     };
 
     typedef SlangUInt32 SlangCooperativeVectorMatrixLayoutIntegral;
     enum SlangCooperativeVectorMatrixLayout : SlangCooperativeVectorMatrixLayoutIntegral
     {
-        SLANG_COOPERATIVE_VECTOR_MATRIX_LAYOUT_ROW_MAJOR,
-        SLANG_COOPERATIVE_VECTOR_MATRIX_LAYOUT_COLUMN_MAJOR,
-        SLANG_COOPERATIVE_VECTOR_MATRIX_LAYOUT_INFERENCING_OPTIMAL,
-        SLANG_COOPERATIVE_VECTOR_MATRIX_LAYOUT_TRAINING_OPTIMAL,
+        SLANG_COOPERATIVE_VECTOR_MATRIX_LAYOUT_ROW_MAJOR = 0,
+        SLANG_COOPERATIVE_VECTOR_MATRIX_LAYOUT_COLUMN_MAJOR = 1,
+        SLANG_COOPERATIVE_VECTOR_MATRIX_LAYOUT_INFERENCING_OPTIMAL = 2,
+        SLANG_COOPERATIVE_VECTOR_MATRIX_LAYOUT_TRAINING_OPTIMAL = 3,
     };
 
     typedef SlangUInt32 SlangDebugInfoLevelIntegral;
     enum SlangDebugInfoLevel : SlangDebugInfoLevelIntegral
     {
-        SLANG_DEBUG_INFO_LEVEL_NONE = 0, /**< Don't emit debug information at all. */
-        SLANG_DEBUG_INFO_LEVEL_MINIMAL,  /**< Emit as little debug information as possible, while
-                                            still supporting stack trackers. */
-        SLANG_DEBUG_INFO_LEVEL_STANDARD, /**< Emit whatever is the standard level of debug
-                                            information for each target. */
-        SLANG_DEBUG_INFO_LEVEL_MAXIMAL,  /**< Emit as much debug information as possible for each
-                                            target. */
+        SLANG_DEBUG_INFO_LEVEL_NONE = 0,     /**< Don't emit debug information at all. */
+        SLANG_DEBUG_INFO_LEVEL_MINIMAL = 1,  /**< Emit as little debug information as possible,
+                                                  while still supporting stack trackers. */
+        SLANG_DEBUG_INFO_LEVEL_STANDARD = 2, /**< Emit whatever is the standard level of debug
+                                                  information for each target. */
+        SLANG_DEBUG_INFO_LEVEL_MAXIMAL = 3,  /**< Emit as much debug information as possible for
+                                                  each target. */
     };
 
     /* Describes the debugging information format produced during a compilation. */
     typedef SlangUInt32 SlangDebugInfoFormatIntegral;
     enum SlangDebugInfoFormat : SlangDebugInfoFormatIntegral
     {
-        SLANG_DEBUG_INFO_FORMAT_DEFAULT, ///< Use the default debugging format for the target
-        SLANG_DEBUG_INFO_FORMAT_C7,  ///< CodeView C7 format (typically means debugging information
-                                     ///< is embedded in the binary)
-        SLANG_DEBUG_INFO_FORMAT_PDB, ///< Program database
+        SLANG_DEBUG_INFO_FORMAT_DEFAULT = 0, ///< Use the default debugging format for the target
+        SLANG_DEBUG_INFO_FORMAT_C7 = 1,      ///< CodeView C7 format (typically means debugging
+                                             ///< information is embedded in the binary)
+        SLANG_DEBUG_INFO_FORMAT_PDB = 2,     ///< Program database
 
-        SLANG_DEBUG_INFO_FORMAT_STABS, ///< Stabs
-        SLANG_DEBUG_INFO_FORMAT_COFF,  ///< COFF debug info
-        SLANG_DEBUG_INFO_FORMAT_DWARF, ///< DWARF debug info (we may want to support specifying the
-                                       ///< version)
+        SLANG_DEBUG_INFO_FORMAT_STABS = 3, ///< Stabs
+        SLANG_DEBUG_INFO_FORMAT_COFF = 4,  ///< COFF debug info
+        SLANG_DEBUG_INFO_FORMAT_DWARF = 5, ///< DWARF debug info (we may want to support specifying
+                                           ///< the version)
 
         SLANG_DEBUG_INFO_FORMAT_COUNT_OF,
     };
@@ -906,246 +907,261 @@ typedef uint32_t SlangSizeT;
     typedef SlangUInt32 SlangOptimizationLevelIntegral;
     enum SlangOptimizationLevel : SlangOptimizationLevelIntegral
     {
-        SLANG_OPTIMIZATION_LEVEL_NONE = 0, /**< Don't optimize at all. */
-        SLANG_OPTIMIZATION_LEVEL_DEFAULT,  /**< Default optimization level: balance code quality and
-                                              compilation time. */
-        SLANG_OPTIMIZATION_LEVEL_HIGH,     /**< Optimize aggressively. */
-        SLANG_OPTIMIZATION_LEVEL_MAXIMAL, /**< Include optimizations that may take a very long time,
-                                             or may involve severe space-vs-speed tradeoffs */
+        SLANG_OPTIMIZATION_LEVEL_NONE = 0,    /**< Don't optimize at all. */
+        SLANG_OPTIMIZATION_LEVEL_DEFAULT = 1, /**< Default optimization level: balance code quality
+                                                   and compilation time. */
+        SLANG_OPTIMIZATION_LEVEL_HIGH = 2,    /**< Optimize aggressively. */
+        SLANG_OPTIMIZATION_LEVEL_MAXIMAL = 3, /**< Include optimizations that may take a very long
+                                                   time, or may involve severe space-vs-speed
+                                                   tradeoffs */
     };
 
     enum SlangEmitSpirvMethod
     {
         SLANG_EMIT_SPIRV_DEFAULT = 0,
-        SLANG_EMIT_SPIRV_VIA_GLSL,
-        SLANG_EMIT_SPIRV_DIRECTLY,
+        SLANG_EMIT_SPIRV_VIA_GLSL = 1,
+        SLANG_EMIT_SPIRV_DIRECTLY = 2,
     };
 
     enum SlangEmitCPUMethod
     {
         SLANG_EMIT_CPU_DEFAULT = 0,
-        SLANG_EMIT_CPU_VIA_CPP,
-        SLANG_EMIT_CPU_VIA_LLVM,
+        SLANG_EMIT_CPU_VIA_CPP = 1,
+        SLANG_EMIT_CPU_VIA_LLVM = 2,
     };
 
     enum SlangDiagnosticColor
     {
-        SLANG_DIAGNOSTIC_COLOR_AUTO = 0, // Use color if output sink is a tty
-        SLANG_DIAGNOSTIC_COLOR_ALWAYS,   // Always use color
-        SLANG_DIAGNOSTIC_COLOR_NEVER,    // Never use color
+        SLANG_DIAGNOSTIC_COLOR_AUTO = 0,   // Use color if output sink is a tty
+        SLANG_DIAGNOSTIC_COLOR_ALWAYS = 1, // Always use color
+        SLANG_DIAGNOSTIC_COLOR_NEVER = 2,  // Never use color
     };
 
     // All compiler option names supported by Slang.
+    //
+    // IMPORTANT: ABI STABILITY POLICY FOR CompilerOptionName
+    //
+    // Every enumerator has an explicit integer value. Rules:
+    //   1. NEVER insert a new enumerator in the middle of the list.
+    //   2. NEVER remove an enumerator; rename to REMOVED_<Name> and keep the value.
+    //   3. NEVER reuse an integer value from a removed/deprecated entry.
+    //   4. NEW entries MUST be appended immediately before CountOf, assigning the next
+    //      sequential integer (equal to the preceding enumerator's value + 1).
+    //
+    // Violation of these rules silently breaks binary compatibility for any caller
+    // compiled against an older version of this header.
     namespace slang
     {
     enum class CompilerOptionName
     {
-        MacroDefine, // stringValue0: macro name;  stringValue1: macro value
-        DepFile,
-        EntryPointName,
-        Specialize,
-        Help,
-        HelpStyle,
-        Include, // stringValue: additional include path.
-        Language,
-        MatrixLayoutColumn,         // bool
-        MatrixLayoutRow,            // bool
-        ZeroInitialize,             // bool
-        IgnoreCapabilities,         // bool
-        RestrictiveCapabilityCheck, // bool
-        ModuleName,                 // stringValue0: module name.
-        Output,
-        Profile, // intValue0: profile
-        Stage,   // intValue0: stage
-        Target,  // intValue0: CodeGenTarget
-        Version,
-        WarningsAsErrors, // stringValue0: "all" or comma separated list of warning codes or names.
-        DisableWarnings,  // stringValue0: comma separated list of warning codes or names.
-        EnableWarning,    // stringValue0: warning code or name.
-        DisableWarning,   // stringValue0: warning code or name.
-        DumpWarningDiagnostics,
-        InputFilesRemain,
-        EmitIr,                        // bool
-        ReportDownstreamTime,          // bool
-        ReportPerfBenchmark,           // bool
-        ReportCheckpointIntermediates, // bool
-        SkipSPIRVValidation,           // bool
-        SourceEmbedStyle,
-        SourceEmbedName,
-        SourceEmbedLanguage,
-        DisableShortCircuit,            // bool
-        MinimumSlangOptimization,       // bool
-        DisableNonEssentialValidations, // bool
-        DisableSourceMap,               // bool
-        UnscopedEnum,                   // bool
-        PreserveParameters, // bool: preserve all resource parameters in the output code.
+        MacroDefine = 0, // stringValue0: macro name;  stringValue1: macro value
+        DepFile = 1,
+        EntryPointName = 2,
+        Specialize = 3,
+        Help = 4,
+        HelpStyle = 5,
+        Include = 6, // stringValue: additional include path.
+        Language = 7,
+        MatrixLayoutColumn = 8,          // bool
+        MatrixLayoutRow = 9,             // bool
+        ZeroInitialize = 10,             // bool
+        IgnoreCapabilities = 11,         // bool
+        RestrictiveCapabilityCheck = 12, // bool
+        ModuleName = 13,                 // stringValue0: module name.
+        Output = 14,
+        Profile = 15, // intValue0: profile
+        Stage = 16,   // intValue0: stage
+        Target = 17,  // intValue0: CodeGenTarget
+        Version = 18,
+        WarningsAsErrors = 19, // stringValue0: "all" or comma-separated list of
+                               // warning codes or names.
+        DisableWarnings = 20,  // stringValue0: comma separated list of warning codes or names.
+        EnableWarning = 21,    // stringValue0: warning code or name.
+        DisableWarning = 22,   // stringValue0: warning code or name.
+        DumpWarningDiagnostics = 23,
+        InputFilesRemain = 24,
+        EmitIr = 25,                        // bool
+        ReportDownstreamTime = 26,          // bool
+        ReportPerfBenchmark = 27,           // bool
+        ReportCheckpointIntermediates = 28, // bool
+        SkipSPIRVValidation = 29,           // bool
+        SourceEmbedStyle = 30,
+        SourceEmbedName = 31,
+        SourceEmbedLanguage = 32,
+        DisableShortCircuit = 33,            // bool
+        MinimumSlangOptimization = 34,       // bool
+        DisableNonEssentialValidations = 35, // bool
+        DisableSourceMap = 36,               // bool
+        UnscopedEnum = 37,                   // bool
+        PreserveParameters = 38, // bool: preserve all resource parameters in the output code.
+
         // Target
+        Capability = 39,                // intValue0: CapabilityName
+        DefaultImageFormatUnknown = 40, // bool
+        DisableDynamicDispatch = 41,    // bool
+        DisableSpecialization = 42,     // bool
+        FloatingPointMode = 43,         // intValue0: FloatingPointMode
+        DebugInformation = 44,          // intValue0: DebugInfoLevel
+        LineDirectiveMode = 45,
+        Optimization = 46, // intValue0: OptimizationLevel
+        Obfuscate = 47,    // bool
 
-        Capability,                // intValue0: CapabilityName
-        DefaultImageFormatUnknown, // bool
-        DisableDynamicDispatch,    // bool
-        DisableSpecialization,     // bool
-        FloatingPointMode,         // intValue0: FloatingPointMode
-        DebugInformation,          // intValue0: DebugInfoLevel
-        LineDirectiveMode,
-        Optimization, // intValue0: OptimizationLevel
-        Obfuscate,    // bool
+        VulkanBindShift = 48,      // intValue0 (higher 8 bits): kind; intValue0(lower bits): set;
+                                   // intValue1: shift
+        VulkanBindGlobals = 49,    // intValue0: index; intValue1: set
+        VulkanInvertY = 50,        // bool
+        VulkanUseDxPositionW = 51, // bool
+        VulkanUseEntryPointName = 52, // bool
+        VulkanUseGLLayout = 53,       // bool
+        VulkanEmitReflection = 54,    // bool
 
-        VulkanBindShift, // intValue0 (higher 8 bits): kind; intValue0(lower bits): set; intValue1:
-                         // shift
-        VulkanBindGlobals,       // intValue0: index; intValue1: set
-        VulkanInvertY,           // bool
-        VulkanUseDxPositionW,    // bool
-        VulkanUseEntryPointName, // bool
-        VulkanUseGLLayout,       // bool
-        VulkanEmitReflection,    // bool
+        GLSLForceScalarLayout = 55,   // bool
+        EnableEffectAnnotations = 56, // bool
 
-        GLSLForceScalarLayout,   // bool
-        EnableEffectAnnotations, // bool
-
-        EmitSpirvViaGLSL,     // bool (will be deprecated)
-        EmitSpirvDirectly,    // bool (will be deprecated)
-        SPIRVCoreGrammarJSON, // stringValue0: json path
-        IncompleteLibrary,    // bool, when set, will not issue an error when the linked program has
-                              // unresolved extern function symbols.
+        EmitSpirvViaGLSL = 57,     // bool (will be deprecated)
+        EmitSpirvDirectly = 58,    // bool (will be deprecated)
+        SPIRVCoreGrammarJSON = 59, // stringValue0: json path
+        IncompleteLibrary = 60, // bool, when set, will not issue an error when the linked program
+                                // has unresolved extern function symbols.
 
         // Downstream
-
-        CompilerPath,
-        DefaultDownstreamCompiler,
-        DownstreamArgs, // stringValue0: downstream compiler name. stringValue1: argument list, one
-                        // per line.
-        PassThrough,
+        CompilerPath = 61,
+        DefaultDownstreamCompiler = 62,
+        DownstreamArgs = 63, // stringValue0: downstream compiler name. stringValue1: argument list,
+                             // one per line.
+        PassThrough = 64,
 
         // Repro
-
-        DumpRepro,
-        DumpReproOnError,
-        ExtractRepro,
-        LoadRepro,
-        LoadReproDirectory,
-        ReproFallbackDirectory,
+        DumpRepro = 65,
+        DumpReproOnError = 66,
+        ExtractRepro = 67,
+        LoadRepro = 68,
+        LoadReproDirectory = 69,
+        ReproFallbackDirectory = 70,
 
         // Debugging
-
-        DumpAst,
-        DumpIntermediatePrefix,
-        DumpIntermediates, // bool
-        DumpIr,            // bool
-        DumpIrIds,
-        PreprocessorOutput,
-        OutputIncludes,
-        ReproFileSystem,
-        REMOVED_SerialIR, // deprecated and removed
-        SkipCodeGen,      // bool
-        ValidateIr,       // bool
-        VerbosePaths,
-        VerifyDebugSerialIr,
-        NoCodeGen, // Not used.
+        DumpAst = 71,
+        DumpIntermediatePrefix = 72,
+        DumpIntermediates = 73, // bool
+        DumpIr = 74,            // bool
+        DumpIrIds = 75,
+        PreprocessorOutput = 76,
+        OutputIncludes = 77,
+        ReproFileSystem = 78,
+        REMOVED_SerialIR = 79, // deprecated and removed; value must never be reused
+        SkipCodeGen = 80,      // bool
+        ValidateIr = 81,       // bool
+        VerbosePaths = 82,
+        VerifyDebugSerialIr = 83,
+        NoCodeGen = 84, // Not used.
 
         // Experimental
-
-        FileSystem,
-        Heterogeneous,
-        NoMangle,
-        NoHLSLBinding,
-        NoHLSLPackConstantBufferElements,
-        ValidateUniformity,
-        AllowGLSL,
-        EnableExperimentalPasses,
-        BindlessSpaceIndex, // int
-        SPIRVResourceHeapStride,
-        SPIRVSamplerHeapStride,
+        FileSystem = 85,
+        Heterogeneous = 86,
+        NoMangle = 87,
+        NoHLSLBinding = 88,
+        NoHLSLPackConstantBufferElements = 89,
+        ValidateUniformity = 90,
+        AllowGLSL = 91,
+        EnableExperimentalPasses = 92,
+        BindlessSpaceIndex = 93,      // int
+        SPIRVResourceHeapStride = 94, // int: byte stride for SPIRV resource descriptor heap
+        SPIRVSamplerHeapStride = 95,  // int: byte stride for SPIRV sampler descriptor heap
 
         // Internal
+        ArchiveType = 96,
+        CompileCoreModule = 97,
+        Doc = 98,
 
-        ArchiveType,
-        CompileCoreModule,
-        Doc,
+        IrCompression = 99, // deprecated; value must never be reused
 
-        IrCompression, //< deprecated
+        LoadCoreModule = 100,
+        ReferenceModule = 101,
+        SaveCoreModule = 102,
+        SaveCoreModuleBinSource = 103,
+        TrackLiveness = 104,
+        LoopInversion = 105, // bool, enable loop inversion optimization
 
-        LoadCoreModule,
-        ReferenceModule,
-        SaveCoreModule,
-        SaveCoreModuleBinSource,
-        TrackLiveness,
-        LoopInversion, // bool, enable loop inversion optimization
+        ParameterBlocksUseRegisterSpaces = 106,  // Deprecated; value must never be reused
+        LanguageVersion = 107,                   // intValue0: SlangLanguageVersion
+        TypeConformance = 108,                   // stringValue0: type conformance to link; format:
+                                                 // "<TypeName>:<IInterfaceName>[=<sequentialId>]",
+                                                 // e.g. "Impl:IFoo=3" or "Impl:IFoo".
+        EnableExperimentalDynamicDispatch = 109, // bool, experimental
+        EmitReflectionJSON = 110,                // bool
 
-        ParameterBlocksUseRegisterSpaces, // Deprecated
-        LanguageVersion,                  // intValue0: SlangLanguageVersion
-        TypeConformance, // stringValue0: additional type conformance to link, in the format of
-                         // "<TypeName>:<IInterfaceName>[=<sequentialId>]", for example
-                         // "Impl:IFoo=3" or "Impl:IFoo".
-        EnableExperimentalDynamicDispatch, // bool, experimental
-        EmitReflectionJSON,                // bool
+        CountOfParsableOptions = 111, // historical sentinel; value must not be reused
 
-        CountOfParsableOptions,
+        // Options added after the original set. Most have CLI flags; a few are
+        // API-only (marked below). All future additions belong after DiagnosticColor,
+        // immediately before CountOf.
+        DebugInformationFormat = 112,  // intValue0: DebugInfoFormat (derived from -g; no direct CLI
+                                       // flag)
+        VulkanBindShiftAll = 113,      // intValue0: kind; intValue1: shift (derived from
+                                       // -fvk-x-shift; no direct CLI flag)
+        GenerateWholeProgram = 114,    // bool
+        UseUpToDateBinaryModule = 115, // bool, when set, will only load precompiled modules
+                                       // if up-to-date with source. (API-only; no direct CLI flag)
+        EmbedDownstreamIR = 116,       // bool
+        ForceDXLayout = 117,           // bool
 
-        // Used in parsed options only.
-        DebugInformationFormat,  // intValue0: DebugInfoFormat
-        VulkanBindShiftAll,      // intValue0: kind; intValue1: shift
-        GenerateWholeProgram,    // bool
-        UseUpToDateBinaryModule, // bool, when set, will only load
-                                 // precompiled modules if it is up-to-date with its source.
-        EmbedDownstreamIR,       // bool
-        ForceDXLayout,           // bool
-
-        // Add this new option to the end of the list to avoid breaking ABI as much as possible.
         // Setting of EmitSpirvDirectly or EmitSpirvViaGLSL will turn into this option internally.
-        EmitSpirvMethod, // enum SlangEmitSpirvMethod
+        EmitSpirvMethod = 118, // enum SlangEmitSpirvMethod (derived; no direct CLI flag)
 
-        SaveGLSLModuleBinSource,
+        SaveGLSLModuleBinSource = 119,
 
-        SkipDownstreamLinking, // bool, experimental
-        DumpModule,
+        SkipDownstreamLinking = 120, // bool, experimental (API-only; no direct CLI flag)
+        DumpModule = 121,
 
-        GetModuleInfo,              // Print serialized module version and name
-        GetSupportedModuleVersions, // Print the min and max module versions this compiler supports
+        GetModuleInfo = 122,              // Print serialized module version and name
+        GetSupportedModuleVersions = 123, // Print the min and max module versions this compiler
+                                          // supports
 
-        EmitSeparateDebug, // bool
+        EmitSeparateDebug = 124, // bool
 
         // Floating point denormal handling modes
-        DenormalModeFp16,
-        DenormalModeFp32,
-        DenormalModeFp64,
+        DenormalModeFp16 = 125,
+        DenormalModeFp32 = 126,
+        DenormalModeFp64 = 127,
 
         // Bitfield options
-        UseMSVCStyleBitfieldPacking, // bool
+        UseMSVCStyleBitfieldPacking = 128, // bool
 
-        ForceCLayout, // bool
+        ForceCLayout = 129, // bool
 
-        ExperimentalFeature, // bool, enable experimental features
+        ExperimentalFeature = 130, // bool, enable experimental features
 
-        ReportDetailedPerfBenchmark, // bool, reports detailed compiler performance benchmark
-                                     // results
-        ValidateIRDetailed,          // bool, enable detailed IR validation
-        DumpIRBefore,                // string, pass name to dump IR before
-        DumpIRAfter,                 // string, pass name to dump IR after
+        ReportDetailedPerfBenchmark = 131, // bool, reports detailed compiler performance benchmark
+                                           // results
+        ValidateIRDetailed = 132,          // bool, enable detailed IR validation
+        DumpIRBefore = 133,                // string, pass name to dump IR before
+        DumpIRAfter = 134,                 // string, pass name to dump IR after
 
-        EmitCPUMethod,    // enum SlangEmitCPUMethod
-        EmitCPUViaCPP,    // bool
-        EmitCPUViaLLVM,   // bool
-        LLVMTargetTriple, // string
-        LLVMCPU,          // string
-        LLVMFeatures,     // string
+        EmitCPUMethod = 135,    // enum SlangEmitCPUMethod (derived; no direct CLI flag)
+        EmitCPUViaCPP = 136,    // bool
+        EmitCPUViaLLVM = 137,   // bool
+        LLVMTargetTriple = 138, // string
+        LLVMCPU = 139,          // string
+        LLVMFeatures = 140,     // string
 
-        EnableRichDiagnostics, // bool, enable the experimental rich diagnostics
+        EnableRichDiagnostics = 141, // bool, enable the experimental rich diagnostics
 
-        ReportDynamicDispatchSites, // bool
+        ReportDynamicDispatchSites = 142, // bool
 
-        EnableMachineReadableDiagnostics, // bool, enable machine-readable diagnostic output
-                                          // (implies EnableRichDiagnostics)
+        EnableMachineReadableDiagnostics = 143, // bool, enable machine-readable diagnostic output
+                                                // (implies EnableRichDiagnostics)
 
-        DiagnosticColor, // intValue0: SlangDiagnosticColor (always, never, auto)
+        DiagnosticColor = 144, // intValue0: SlangDiagnosticColor (always, never, auto)
+
+        // Add new options HERE, immediately before CountOf.
 
         CountOf,
     };
 
     enum class CompilerOptionValueKind
     {
-        Int,
-        String
+        Int = 0,
+        String = 1,
     };
 
     struct CompilerOptionValue
@@ -1553,8 +1569,8 @@ public:                                                              \
     typedef unsigned int SlangPathTypeIntegral;
     enum SlangPathType : SlangPathTypeIntegral
     {
-        SLANG_PATH_TYPE_DIRECTORY, /**< Path specified specifies a directory. */
-        SLANG_PATH_TYPE_FILE,      /**< Path specified is to a file. */
+        SLANG_PATH_TYPE_DIRECTORY = 0, /**< Path specified specifies a directory. */
+        SLANG_PATH_TYPE_FILE = 1,      /**< Path specified is to a file. */
     };
 
     /* Callback to enumerate the contents of of a directory in a ISlangFileSystemExt.
@@ -1566,10 +1582,10 @@ public:                                                              \
     /* Determines how paths map to files on the OS file system */
     enum class OSPathKind : uint8_t
     {
-        None,            ///< Paths do not map to the file system
-        Direct,          ///< Paths map directly to the file system
-        OperatingSystem, ///< Only paths gained via PathKind::OperatingSystem map to the operating
-                         ///< system file system
+        None = 0,            ///< Paths do not map to the file system
+        Direct = 1,          ///< Paths map directly to the file system
+        OperatingSystem = 2, ///< Only paths gained via PathKind::OperatingSystem map to the
+                             ///< operating system file system
     };
 
     /* Used to determine what kind of path is required from an input path */
@@ -1578,7 +1594,7 @@ public:                                                              \
         /// Given a path, returns a simplified version of that path.
         /// This typically means removing '..' and/or '.' from the path.
         /// A simplified path must point to the same object as the original.
-        Simplified,
+        Simplified = 0,
 
         /// Given a path, returns a 'canonical path' to the item.
         /// This may be the operating system 'canonical path' that is the unique path to the item.
@@ -1589,7 +1605,7 @@ public:                                                              \
         /// If the item the path specifies doesn't exist, the canonical path may not be returnable
         /// or be a path simplification.
         /// Not all file systems support canonical paths.
-        Canonical,
+        Canonical = 1,
 
         /// Given a path returns a path such that it is suitable to be displayed to the user.
         ///
@@ -1597,10 +1613,10 @@ public:                                                              \
         /// container as well as the path to the specific file.
         ///
         /// NOTE! The display path won't necessarily work on the file system to access the item
-        Display,
+        Display = 2,
 
         /// Get the path to the item on the *operating system* file system, if available.
-        OperatingSystem,
+        OperatingSystem = 3,
 
         CountOf,
     };
@@ -1780,17 +1796,17 @@ public:                                                              \
     typedef unsigned int SlangWriterChannelIntegral;
     enum SlangWriterChannel : SlangWriterChannelIntegral
     {
-        SLANG_WRITER_CHANNEL_DIAGNOSTIC,
-        SLANG_WRITER_CHANNEL_STD_OUTPUT,
-        SLANG_WRITER_CHANNEL_STD_ERROR,
+        SLANG_WRITER_CHANNEL_DIAGNOSTIC = 0,
+        SLANG_WRITER_CHANNEL_STD_OUTPUT = 1,
+        SLANG_WRITER_CHANNEL_STD_ERROR = 2,
         SLANG_WRITER_CHANNEL_COUNT_OF,
     };
 
     typedef unsigned int SlangWriterModeIntegral;
     enum SlangWriterMode : SlangWriterModeIntegral
     {
-        SLANG_WRITER_MODE_TEXT,
-        SLANG_WRITER_MODE_BINARY,
+        SLANG_WRITER_MODE_TEXT = 0,
+        SLANG_WRITER_MODE_BINARY = 1,
     };
 
     /** A stream typically of text, used for outputting diagnostic as well as other information.
@@ -1939,66 +1955,66 @@ public:                                                              \
     typedef unsigned int SlangTypeKindIntegral;
     enum SlangTypeKind : SlangTypeKindIntegral
     {
-        SLANG_TYPE_KIND_NONE,
-        SLANG_TYPE_KIND_STRUCT,
-        SLANG_TYPE_KIND_ARRAY,
-        SLANG_TYPE_KIND_MATRIX,
-        SLANG_TYPE_KIND_VECTOR,
-        SLANG_TYPE_KIND_SCALAR,
-        SLANG_TYPE_KIND_CONSTANT_BUFFER,
-        SLANG_TYPE_KIND_RESOURCE,
-        SLANG_TYPE_KIND_SAMPLER_STATE,
-        SLANG_TYPE_KIND_TEXTURE_BUFFER,
-        SLANG_TYPE_KIND_SHADER_STORAGE_BUFFER,
-        SLANG_TYPE_KIND_PARAMETER_BLOCK,
-        SLANG_TYPE_KIND_GENERIC_TYPE_PARAMETER,
-        SLANG_TYPE_KIND_INTERFACE,
-        SLANG_TYPE_KIND_OUTPUT_STREAM,
-        SLANG_TYPE_KIND_MESH_OUTPUT,
-        SLANG_TYPE_KIND_SPECIALIZED,
-        SLANG_TYPE_KIND_FEEDBACK,
-        SLANG_TYPE_KIND_POINTER,
-        SLANG_TYPE_KIND_DYNAMIC_RESOURCE,
-        SLANG_TYPE_KIND_ENUM,
+        SLANG_TYPE_KIND_NONE = 0,
+        SLANG_TYPE_KIND_STRUCT = 1,
+        SLANG_TYPE_KIND_ARRAY = 2,
+        SLANG_TYPE_KIND_MATRIX = 3,
+        SLANG_TYPE_KIND_VECTOR = 4,
+        SLANG_TYPE_KIND_SCALAR = 5,
+        SLANG_TYPE_KIND_CONSTANT_BUFFER = 6,
+        SLANG_TYPE_KIND_RESOURCE = 7,
+        SLANG_TYPE_KIND_SAMPLER_STATE = 8,
+        SLANG_TYPE_KIND_TEXTURE_BUFFER = 9,
+        SLANG_TYPE_KIND_SHADER_STORAGE_BUFFER = 10,
+        SLANG_TYPE_KIND_PARAMETER_BLOCK = 11,
+        SLANG_TYPE_KIND_GENERIC_TYPE_PARAMETER = 12,
+        SLANG_TYPE_KIND_INTERFACE = 13,
+        SLANG_TYPE_KIND_OUTPUT_STREAM = 14,
+        SLANG_TYPE_KIND_MESH_OUTPUT = 15,
+        SLANG_TYPE_KIND_SPECIALIZED = 16,
+        SLANG_TYPE_KIND_FEEDBACK = 17,
+        SLANG_TYPE_KIND_POINTER = 18,
+        SLANG_TYPE_KIND_DYNAMIC_RESOURCE = 19,
+        SLANG_TYPE_KIND_ENUM = 20,
         SLANG_TYPE_KIND_COUNT,
     };
 
     typedef unsigned int SlangScalarTypeIntegral;
     enum SlangScalarType : SlangScalarTypeIntegral
     {
-        SLANG_SCALAR_TYPE_NONE,
-        SLANG_SCALAR_TYPE_VOID,
-        SLANG_SCALAR_TYPE_BOOL,
-        SLANG_SCALAR_TYPE_INT32,
-        SLANG_SCALAR_TYPE_UINT32,
-        SLANG_SCALAR_TYPE_INT64,
-        SLANG_SCALAR_TYPE_UINT64,
-        SLANG_SCALAR_TYPE_FLOAT16,
-        SLANG_SCALAR_TYPE_FLOAT32,
-        SLANG_SCALAR_TYPE_FLOAT64,
-        SLANG_SCALAR_TYPE_INT8,
-        SLANG_SCALAR_TYPE_UINT8,
-        SLANG_SCALAR_TYPE_INT16,
-        SLANG_SCALAR_TYPE_UINT16,
-        SLANG_SCALAR_TYPE_INTPTR,
-        SLANG_SCALAR_TYPE_UINTPTR,
-        SLANG_SCALAR_TYPE_BFLOAT16,
-        SLANG_SCALAR_TYPE_FLOAT_E4M3,
-        SLANG_SCALAR_TYPE_FLOAT_E5M2,
+        SLANG_SCALAR_TYPE_NONE = 0,
+        SLANG_SCALAR_TYPE_VOID = 1,
+        SLANG_SCALAR_TYPE_BOOL = 2,
+        SLANG_SCALAR_TYPE_INT32 = 3,
+        SLANG_SCALAR_TYPE_UINT32 = 4,
+        SLANG_SCALAR_TYPE_INT64 = 5,
+        SLANG_SCALAR_TYPE_UINT64 = 6,
+        SLANG_SCALAR_TYPE_FLOAT16 = 7,
+        SLANG_SCALAR_TYPE_FLOAT32 = 8,
+        SLANG_SCALAR_TYPE_FLOAT64 = 9,
+        SLANG_SCALAR_TYPE_INT8 = 10,
+        SLANG_SCALAR_TYPE_UINT8 = 11,
+        SLANG_SCALAR_TYPE_INT16 = 12,
+        SLANG_SCALAR_TYPE_UINT16 = 13,
+        SLANG_SCALAR_TYPE_INTPTR = 14,
+        SLANG_SCALAR_TYPE_UINTPTR = 15,
+        SLANG_SCALAR_TYPE_BFLOAT16 = 16,
+        SLANG_SCALAR_TYPE_FLOAT_E4M3 = 17,
+        SLANG_SCALAR_TYPE_FLOAT_E5M2 = 18,
     };
 
     // abstract decl reflection
     typedef unsigned int SlangDeclKindIntegral;
     enum SlangDeclKind : SlangDeclKindIntegral
     {
-        SLANG_DECL_KIND_UNSUPPORTED_FOR_REFLECTION,
-        SLANG_DECL_KIND_STRUCT,
-        SLANG_DECL_KIND_FUNC,
-        SLANG_DECL_KIND_MODULE,
-        SLANG_DECL_KIND_GENERIC,
-        SLANG_DECL_KIND_VARIABLE,
-        SLANG_DECL_KIND_NAMESPACE,
-        SLANG_DECL_KIND_ENUM,
+        SLANG_DECL_KIND_UNSUPPORTED_FOR_REFLECTION = 0,
+        SLANG_DECL_KIND_STRUCT = 1,
+        SLANG_DECL_KIND_FUNC = 2,
+        SLANG_DECL_KIND_MODULE = 3,
+        SLANG_DECL_KIND_GENERIC = 4,
+        SLANG_DECL_KIND_VARIABLE = 5,
+        SLANG_DECL_KIND_NAMESPACE = 6,
+        SLANG_DECL_KIND_ENUM = 7,
     };
 
 #ifndef SLANG_RESOURCE_SHAPE
@@ -2043,46 +2059,46 @@ public:                                                              \
     typedef unsigned int SlangResourceAccessIntegral;
     enum SlangResourceAccess : SlangResourceAccessIntegral
     {
-        SLANG_RESOURCE_ACCESS_NONE,
-        SLANG_RESOURCE_ACCESS_READ,
-        SLANG_RESOURCE_ACCESS_READ_WRITE,
-        SLANG_RESOURCE_ACCESS_RASTER_ORDERED,
-        SLANG_RESOURCE_ACCESS_APPEND,
-        SLANG_RESOURCE_ACCESS_CONSUME,
-        SLANG_RESOURCE_ACCESS_WRITE,
-        SLANG_RESOURCE_ACCESS_FEEDBACK,
+        SLANG_RESOURCE_ACCESS_NONE = 0,
+        SLANG_RESOURCE_ACCESS_READ = 1,
+        SLANG_RESOURCE_ACCESS_READ_WRITE = 2,
+        SLANG_RESOURCE_ACCESS_RASTER_ORDERED = 3,
+        SLANG_RESOURCE_ACCESS_APPEND = 4,
+        SLANG_RESOURCE_ACCESS_CONSUME = 5,
+        SLANG_RESOURCE_ACCESS_WRITE = 6,
+        SLANG_RESOURCE_ACCESS_FEEDBACK = 7,
         SLANG_RESOURCE_ACCESS_UNKNOWN = 0x7FFFFFFF,
     };
 
     typedef unsigned int SlangParameterCategoryIntegral;
     enum SlangParameterCategory : SlangParameterCategoryIntegral
     {
-        SLANG_PARAMETER_CATEGORY_NONE,
-        SLANG_PARAMETER_CATEGORY_MIXED,
-        SLANG_PARAMETER_CATEGORY_CONSTANT_BUFFER,
-        SLANG_PARAMETER_CATEGORY_SHADER_RESOURCE,
-        SLANG_PARAMETER_CATEGORY_UNORDERED_ACCESS,
-        SLANG_PARAMETER_CATEGORY_VARYING_INPUT,
-        SLANG_PARAMETER_CATEGORY_VARYING_OUTPUT,
-        SLANG_PARAMETER_CATEGORY_SAMPLER_STATE,
-        SLANG_PARAMETER_CATEGORY_UNIFORM,
-        SLANG_PARAMETER_CATEGORY_DESCRIPTOR_TABLE_SLOT,
-        SLANG_PARAMETER_CATEGORY_SPECIALIZATION_CONSTANT,
-        SLANG_PARAMETER_CATEGORY_PUSH_CONSTANT_BUFFER,
+        SLANG_PARAMETER_CATEGORY_NONE = 0,
+        SLANG_PARAMETER_CATEGORY_MIXED = 1,
+        SLANG_PARAMETER_CATEGORY_CONSTANT_BUFFER = 2,
+        SLANG_PARAMETER_CATEGORY_SHADER_RESOURCE = 3,
+        SLANG_PARAMETER_CATEGORY_UNORDERED_ACCESS = 4,
+        SLANG_PARAMETER_CATEGORY_VARYING_INPUT = 5,
+        SLANG_PARAMETER_CATEGORY_VARYING_OUTPUT = 6,
+        SLANG_PARAMETER_CATEGORY_SAMPLER_STATE = 7,
+        SLANG_PARAMETER_CATEGORY_UNIFORM = 8,
+        SLANG_PARAMETER_CATEGORY_DESCRIPTOR_TABLE_SLOT = 9,
+        SLANG_PARAMETER_CATEGORY_SPECIALIZATION_CONSTANT = 10,
+        SLANG_PARAMETER_CATEGORY_PUSH_CONSTANT_BUFFER = 11,
 
         // HLSL register `space`, Vulkan GLSL `set`
-        SLANG_PARAMETER_CATEGORY_REGISTER_SPACE,
+        SLANG_PARAMETER_CATEGORY_REGISTER_SPACE = 12,
 
         // TODO: Ellie, Both APIs treat mesh outputs as more or less varying output,
         // Does it deserve to be represented here??
 
         // A parameter whose type is to be specialized by a global generic type argument
-        SLANG_PARAMETER_CATEGORY_GENERIC,
+        SLANG_PARAMETER_CATEGORY_GENERIC = 13,
 
-        SLANG_PARAMETER_CATEGORY_RAY_PAYLOAD,
-        SLANG_PARAMETER_CATEGORY_HIT_ATTRIBUTES,
-        SLANG_PARAMETER_CATEGORY_CALLABLE_PAYLOAD,
-        SLANG_PARAMETER_CATEGORY_SHADER_RECORD,
+        SLANG_PARAMETER_CATEGORY_RAY_PAYLOAD = 14,
+        SLANG_PARAMETER_CATEGORY_HIT_ATTRIBUTES = 15,
+        SLANG_PARAMETER_CATEGORY_CALLABLE_PAYLOAD = 16,
+        SLANG_PARAMETER_CATEGORY_SHADER_RECORD = 17,
 
         // An existential type parameter represents a "hole" that
         // needs to be filled with a concrete type to enable
@@ -2102,7 +2118,7 @@ public:                                                              \
         // we need to have a *single* concrete type for all the array
         // elements to be able to generate specialized code.
         //
-        SLANG_PARAMETER_CATEGORY_EXISTENTIAL_TYPE_PARAM,
+        SLANG_PARAMETER_CATEGORY_EXISTENTIAL_TYPE_PARAM = 18,
 
         // An existential object parameter represents a value
         // that needs to be passed in to provide data for some
@@ -2121,22 +2137,22 @@ public:                                                              \
         // element). This is consistent with the number of interface-type
         // "objects" that are being passed through to the shader.
         //
-        SLANG_PARAMETER_CATEGORY_EXISTENTIAL_OBJECT_PARAM,
+        SLANG_PARAMETER_CATEGORY_EXISTENTIAL_OBJECT_PARAM = 19,
 
         // The register space offset for the sub-elements that occupies register spaces.
-        SLANG_PARAMETER_CATEGORY_SUB_ELEMENT_REGISTER_SPACE,
+        SLANG_PARAMETER_CATEGORY_SUB_ELEMENT_REGISTER_SPACE = 20,
 
         // The input_attachment_index subpass occupancy tracker
-        SLANG_PARAMETER_CATEGORY_SUBPASS,
+        SLANG_PARAMETER_CATEGORY_SUBPASS = 21,
 
         // Metal tier-1 argument buffer element [[id]].
-        SLANG_PARAMETER_CATEGORY_METAL_ARGUMENT_BUFFER_ELEMENT,
+        SLANG_PARAMETER_CATEGORY_METAL_ARGUMENT_BUFFER_ELEMENT = 22,
 
         // Metal [[attribute]] inputs.
-        SLANG_PARAMETER_CATEGORY_METAL_ATTRIBUTE,
+        SLANG_PARAMETER_CATEGORY_METAL_ATTRIBUTE = 23,
 
         // Metal [[payload]] inputs
-        SLANG_PARAMETER_CATEGORY_METAL_PAYLOAD,
+        SLANG_PARAMETER_CATEGORY_METAL_PAYLOAD = 24,
 
         //
         SLANG_PARAMETER_CATEGORY_COUNT,
@@ -2180,22 +2196,22 @@ public:                                                              \
     {
         SLANG_BINDING_TYPE_UNKNOWN = 0,
 
-        SLANG_BINDING_TYPE_SAMPLER,
-        SLANG_BINDING_TYPE_TEXTURE,
-        SLANG_BINDING_TYPE_CONSTANT_BUFFER,
-        SLANG_BINDING_TYPE_PARAMETER_BLOCK,
-        SLANG_BINDING_TYPE_TYPED_BUFFER,
-        SLANG_BINDING_TYPE_RAW_BUFFER,
-        SLANG_BINDING_TYPE_COMBINED_TEXTURE_SAMPLER,
-        SLANG_BINDING_TYPE_INPUT_RENDER_TARGET,
-        SLANG_BINDING_TYPE_INLINE_UNIFORM_DATA,
-        SLANG_BINDING_TYPE_RAY_TRACING_ACCELERATION_STRUCTURE,
+        SLANG_BINDING_TYPE_SAMPLER = 1,
+        SLANG_BINDING_TYPE_TEXTURE = 2,
+        SLANG_BINDING_TYPE_CONSTANT_BUFFER = 3,
+        SLANG_BINDING_TYPE_PARAMETER_BLOCK = 4,
+        SLANG_BINDING_TYPE_TYPED_BUFFER = 5,
+        SLANG_BINDING_TYPE_RAW_BUFFER = 6,
+        SLANG_BINDING_TYPE_COMBINED_TEXTURE_SAMPLER = 7,
+        SLANG_BINDING_TYPE_INPUT_RENDER_TARGET = 8,
+        SLANG_BINDING_TYPE_INLINE_UNIFORM_DATA = 9,
+        SLANG_BINDING_TYPE_RAY_TRACING_ACCELERATION_STRUCTURE = 10,
 
-        SLANG_BINDING_TYPE_VARYING_INPUT,
-        SLANG_BINDING_TYPE_VARYING_OUTPUT,
+        SLANG_BINDING_TYPE_VARYING_INPUT = 11,
+        SLANG_BINDING_TYPE_VARYING_OUTPUT = 12,
 
-        SLANG_BINDING_TYPE_EXISTENTIAL_VALUE,
-        SLANG_BINDING_TYPE_PUSH_CONSTANT,
+        SLANG_BINDING_TYPE_EXISTENTIAL_VALUE = 13,
+        SLANG_BINDING_TYPE_PUSH_CONSTANT = 14,
 
         SLANG_BINDING_TYPE_MUTABLE_FLAG = 0x100,
 
@@ -2213,26 +2229,26 @@ public:                                                              \
     typedef SlangUInt32 SlangLayoutRulesIntegral;
     enum SlangLayoutRules : SlangLayoutRulesIntegral
     {
-        SLANG_LAYOUT_RULES_DEFAULT,
-        SLANG_LAYOUT_RULES_METAL_ARGUMENT_BUFFER_TIER_2,
-        SLANG_LAYOUT_RULES_DEFAULT_STRUCTURED_BUFFER,
-        SLANG_LAYOUT_RULES_DEFAULT_CONSTANT_BUFFER,
+        SLANG_LAYOUT_RULES_DEFAULT = 0,
+        SLANG_LAYOUT_RULES_METAL_ARGUMENT_BUFFER_TIER_2 = 1,
+        SLANG_LAYOUT_RULES_DEFAULT_STRUCTURED_BUFFER = 2,
+        SLANG_LAYOUT_RULES_DEFAULT_CONSTANT_BUFFER = 3,
     };
 
     typedef SlangUInt32 SlangModifierIDIntegral;
     enum SlangModifierID : SlangModifierIDIntegral
     {
-        SLANG_MODIFIER_SHARED,
-        SLANG_MODIFIER_NO_DIFF,
-        SLANG_MODIFIER_STATIC,
-        SLANG_MODIFIER_CONST,
-        SLANG_MODIFIER_EXPORT,
-        SLANG_MODIFIER_EXTERN,
-        SLANG_MODIFIER_DIFFERENTIABLE,
-        SLANG_MODIFIER_MUTATING,
-        SLANG_MODIFIER_IN,
-        SLANG_MODIFIER_OUT,
-        SLANG_MODIFIER_INOUT
+        SLANG_MODIFIER_SHARED = 0,
+        SLANG_MODIFIER_NO_DIFF = 1,
+        SLANG_MODIFIER_STATIC = 2,
+        SLANG_MODIFIER_CONST = 3,
+        SLANG_MODIFIER_EXPORT = 4,
+        SLANG_MODIFIER_EXTERN = 5,
+        SLANG_MODIFIER_DIFFERENTIABLE = 6,
+        SLANG_MODIFIER_MUTATING = 7,
+        SLANG_MODIFIER_IN = 8,
+        SLANG_MODIFIER_OUT = 9,
+        SLANG_MODIFIER_INOUT = 10,
     };
 
     typedef SlangUInt32 SlangImageFormatIntegral;
@@ -3842,8 +3858,8 @@ struct TargetDesc;
 
 enum class BuiltinModuleName
 {
-    Core,
-    GLSL
+    Core = 0,
+    GLSL = 1,
 };
 
 /** A global session for interaction with the Slang library.
@@ -4210,11 +4226,11 @@ struct SessionDesc
 
 enum class ContainerType
 {
-    None,
-    UnsizedArray,
-    StructuredBuffer,
-    ConstantBuffer,
-    ParameterBlock
+    None = 0,
+    UnsizedArray = 1,
+    StructuredBuffer = 2,
+    ConstantBuffer = 3,
+    ParameterBlock = 4,
 };
 
 struct SourceLocation
@@ -4925,9 +4941,9 @@ struct SpecializationArg
 {
     enum class Kind : int32_t
     {
-        Unknown, /**< An invalid specialization argument. */
-        Type,    /**< Specialize to a type. */
-        Expr,    /**< An expression representing a type or value */
+        Unknown = 0, /**< An invalid specialization argument. */
+        Type = 1,    /**< Specialize to a type. */
+        Expr = 2,    /**< An expression representing a type or value */
     };
 
     /** The kind of specialization argument. */

--- a/tools/slang-unit-test/unit-test-vtable-stability.cpp
+++ b/tools/slang-unit-test/unit-test-vtable-stability.cpp
@@ -1,0 +1,1603 @@
+// unit-test-vtable-stability.cpp
+//
+// Verifies that the vtable slot layout of every COM interface declared in
+// include/slang.h has not changed.  Each test creates a concrete probe object
+// that records which override was called, then dispatches through a specific
+// raw vtable slot and asserts the expected method fired.
+//
+// If a virtual method is inserted in the middle of an interface the slot
+// indices of all subsequent methods shift by one, causing a different probe
+// method to fire and the corresponding SLANG_CHECK to fail.
+//
+// Calling convention note: on all platforms Slang targets, virtual dispatch
+// passes `this` in the first register and further args in subsequent registers.
+// The probe overrides never read their arguments, so calling with no args
+// (beyond `this`) is safe regardless of the declared parameter list.
+
+#include "slang.h"
+#include "unit-test/slang-unit-test.h"
+
+using namespace slang;
+
+// ---------------------------------------------------------------------------
+// Helper: call vtable slot `slot` on `obj`, passing only `this`.
+// ---------------------------------------------------------------------------
+static void callSlot(void* obj, int slot)
+{
+    void** vtbl = *reinterpret_cast<void***>(obj);
+    reinterpret_cast<void(SLANG_MCALL*)(void*)>(vtbl[slot])(obj);
+}
+
+// ---------------------------------------------------------------------------
+// ISlangUnknown  (3 slots: 0-2)
+// ---------------------------------------------------------------------------
+struct ISlangUnknownProbe : ISlangUnknown
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+};
+
+SLANG_UNIT_TEST(vtableISlangUnknown)
+{
+    ISlangUnknownProbe p;
+    callSlot(&p, 0);
+    SLANG_CHECK(p.lastSlot == 0); // queryInterface
+    callSlot(&p, 1);
+    SLANG_CHECK(p.lastSlot == 1); // addRef
+    callSlot(&p, 2);
+    SLANG_CHECK(p.lastSlot == 2); // release
+}
+
+// ---------------------------------------------------------------------------
+// ISlangCastable : ISlangUnknown  (own slot 3)
+// ---------------------------------------------------------------------------
+struct ISlangCastableProbe : ISlangCastable
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW void* SLANG_MCALL castAs(const SlangUUID&) SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return nullptr;
+    }
+};
+
+SLANG_UNIT_TEST(vtableISlangCastable)
+{
+    ISlangCastableProbe p;
+    callSlot(&p, 0);
+    SLANG_CHECK(p.lastSlot == 0); // queryInterface
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // castAs
+}
+
+// ---------------------------------------------------------------------------
+// ISlangClonable : ISlangCastable  (own slot 4)
+// ---------------------------------------------------------------------------
+struct ISlangClonableProbe : ISlangClonable
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW void* SLANG_MCALL castAs(const SlangUUID&) SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return nullptr;
+    }
+    SLANG_NO_THROW void* SLANG_MCALL clone(const SlangUUID&) SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return nullptr;
+    }
+};
+
+SLANG_UNIT_TEST(vtableISlangClonable)
+{
+    ISlangClonableProbe p;
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // castAs
+    callSlot(&p, 4);
+    SLANG_CHECK(p.lastSlot == 4); // clone
+}
+
+// ---------------------------------------------------------------------------
+// ISlangBlob : ISlangUnknown  (own slots 3-4)
+// ---------------------------------------------------------------------------
+struct ISlangBlobProbe : ISlangBlob
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW void const* SLANG_MCALL getBufferPointer() SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return nullptr;
+    }
+    SLANG_NO_THROW size_t SLANG_MCALL getBufferSize() SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return 0;
+    }
+};
+
+SLANG_UNIT_TEST(vtableISlangBlob)
+{
+    ISlangBlobProbe p;
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // getBufferPointer
+    callSlot(&p, 4);
+    SLANG_CHECK(p.lastSlot == 4); // getBufferSize
+}
+
+// ---------------------------------------------------------------------------
+// ISlangFileSystem : ISlangCastable  (own slot 4)
+// ---------------------------------------------------------------------------
+struct ISlangFileSystemProbe : ISlangFileSystem
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW void* SLANG_MCALL castAs(const SlangUUID&) SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return nullptr;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL loadFile(char const*, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return SLANG_OK;
+    }
+};
+
+SLANG_UNIT_TEST(vtableISlangFileSystem)
+{
+    ISlangFileSystemProbe p;
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // castAs
+    callSlot(&p, 4);
+    SLANG_CHECK(p.lastSlot == 4); // loadFile
+}
+
+// ---------------------------------------------------------------------------
+// ISlangSharedLibrary_Dep1 : ISlangUnknown  (own slot 3)
+// ---------------------------------------------------------------------------
+struct ISlangSharedLibraryDep1Probe : ISlangSharedLibrary_Dep1
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW void* SLANG_MCALL findSymbolAddressByName(char const*) SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return nullptr;
+    }
+};
+
+SLANG_UNIT_TEST(vtableISlangSharedLibraryDep1)
+{
+    ISlangSharedLibraryDep1Probe p;
+    callSlot(&p, 2);
+    SLANG_CHECK(p.lastSlot == 2); // release
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // findSymbolAddressByName
+}
+
+// ---------------------------------------------------------------------------
+// ISlangSharedLibrary : ISlangCastable  (own slot 4)
+// ---------------------------------------------------------------------------
+struct ISlangSharedLibraryProbe : ISlangSharedLibrary
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW void* SLANG_MCALL castAs(const SlangUUID&) SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return nullptr;
+    }
+    SLANG_NO_THROW void* SLANG_MCALL findSymbolAddressByName(char const*) SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return nullptr;
+    }
+};
+
+SLANG_UNIT_TEST(vtableISlangSharedLibrary)
+{
+    ISlangSharedLibraryProbe p;
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // castAs
+    callSlot(&p, 4);
+    SLANG_CHECK(p.lastSlot == 4); // findSymbolAddressByName
+}
+
+// ---------------------------------------------------------------------------
+// ISlangSharedLibraryLoader : ISlangUnknown  (own slot 3)
+// ---------------------------------------------------------------------------
+struct ISlangSharedLibraryLoaderProbe : ISlangSharedLibraryLoader
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL loadSharedLibrary(const char*, ISlangSharedLibrary**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return SLANG_OK;
+    }
+};
+
+SLANG_UNIT_TEST(vtableISlangSharedLibraryLoader)
+{
+    ISlangSharedLibraryLoaderProbe p;
+    callSlot(&p, 2);
+    SLANG_CHECK(p.lastSlot == 2); // release
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // loadSharedLibrary
+}
+
+// ---------------------------------------------------------------------------
+// ISlangFileSystemExt : ISlangFileSystem  (own slots 5-11)
+// ---------------------------------------------------------------------------
+struct ISlangFileSystemExtProbe : ISlangFileSystemExt
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW void* SLANG_MCALL castAs(const SlangUUID&) SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return nullptr;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL loadFile(char const*, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getFileUniqueIdentity(const char*, ISlangBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 5;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    calcCombinedPath(SlangPathType, const char*, const char*, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 6;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getPathType(const char*, SlangPathType*) SLANG_OVERRIDE
+    {
+        lastSlot = 7;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getPath(PathKind, const char*, ISlangBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 8;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW void SLANG_MCALL clearCache() SLANG_OVERRIDE { lastSlot = 9; }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    enumeratePathContents(const char*, FileSystemContentsCallBack, void*) SLANG_OVERRIDE
+    {
+        lastSlot = 10;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW OSPathKind SLANG_MCALL getOSPathKind() SLANG_OVERRIDE
+    {
+        lastSlot = 11;
+        return OSPathKind::None;
+    }
+};
+
+SLANG_UNIT_TEST(vtableISlangFileSystemExt)
+{
+    ISlangFileSystemExtProbe p;
+    callSlot(&p, 4);
+    SLANG_CHECK(p.lastSlot == 4); // loadFile
+    callSlot(&p, 5);
+    SLANG_CHECK(p.lastSlot == 5); // getFileUniqueIdentity
+    callSlot(&p, 6);
+    SLANG_CHECK(p.lastSlot == 6); // calcCombinedPath
+    callSlot(&p, 7);
+    SLANG_CHECK(p.lastSlot == 7); // getPathType
+    callSlot(&p, 8);
+    SLANG_CHECK(p.lastSlot == 8); // getPath
+    callSlot(&p, 9);
+    SLANG_CHECK(p.lastSlot == 9); // clearCache
+    callSlot(&p, 10);
+    SLANG_CHECK(p.lastSlot == 10); // enumeratePathContents
+    callSlot(&p, 11);
+    SLANG_CHECK(p.lastSlot == 11); // getOSPathKind
+}
+
+// ---------------------------------------------------------------------------
+// ISlangMutableFileSystem : ISlangFileSystemExt  (own slots 12-15)
+// ---------------------------------------------------------------------------
+struct ISlangMutableFileSystemProbe : ISlangMutableFileSystem
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW void* SLANG_MCALL castAs(const SlangUUID&) SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return nullptr;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL loadFile(char const*, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getFileUniqueIdentity(const char*, ISlangBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 5;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    calcCombinedPath(SlangPathType, const char*, const char*, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 6;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getPathType(const char*, SlangPathType*) SLANG_OVERRIDE
+    {
+        lastSlot = 7;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getPath(PathKind, const char*, ISlangBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 8;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW void SLANG_MCALL clearCache() SLANG_OVERRIDE { lastSlot = 9; }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    enumeratePathContents(const char*, FileSystemContentsCallBack, void*) SLANG_OVERRIDE
+    {
+        lastSlot = 10;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW OSPathKind SLANG_MCALL getOSPathKind() SLANG_OVERRIDE
+    {
+        lastSlot = 11;
+        return OSPathKind::None;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL saveFile(const char*, const void*, size_t) SLANG_OVERRIDE
+    {
+        lastSlot = 12;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL saveFileBlob(const char*, ISlangBlob*) SLANG_OVERRIDE
+    {
+        lastSlot = 13;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL remove(const char*) SLANG_OVERRIDE
+    {
+        lastSlot = 14;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL createDirectory(const char*) SLANG_OVERRIDE
+    {
+        lastSlot = 15;
+        return SLANG_OK;
+    }
+};
+
+SLANG_UNIT_TEST(vtableISlangMutableFileSystem)
+{
+    ISlangMutableFileSystemProbe p;
+    callSlot(&p, 11);
+    SLANG_CHECK(p.lastSlot == 11); // getOSPathKind
+    callSlot(&p, 12);
+    SLANG_CHECK(p.lastSlot == 12); // saveFile
+    callSlot(&p, 13);
+    SLANG_CHECK(p.lastSlot == 13); // saveFileBlob
+    callSlot(&p, 14);
+    SLANG_CHECK(p.lastSlot == 14); // remove
+    callSlot(&p, 15);
+    SLANG_CHECK(p.lastSlot == 15); // createDirectory
+}
+
+// ---------------------------------------------------------------------------
+// ISlangWriter : ISlangUnknown  (own slots 3-8)
+// ---------------------------------------------------------------------------
+struct ISlangWriterProbe : ISlangWriter
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW char* SLANG_MCALL beginAppendBuffer(size_t) SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return nullptr;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL endAppendBuffer(char*, size_t) SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL write(const char*, size_t) SLANG_OVERRIDE
+    {
+        lastSlot = 5;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW void SLANG_MCALL flush() SLANG_OVERRIDE { lastSlot = 6; }
+    SLANG_NO_THROW SlangBool SLANG_MCALL isConsole() SLANG_OVERRIDE
+    {
+        lastSlot = 7;
+        return 0;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL setMode(SlangWriterMode) SLANG_OVERRIDE
+    {
+        lastSlot = 8;
+        return SLANG_OK;
+    }
+};
+
+SLANG_UNIT_TEST(vtableISlangWriter)
+{
+    ISlangWriterProbe p;
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // beginAppendBuffer
+    callSlot(&p, 4);
+    SLANG_CHECK(p.lastSlot == 4); // endAppendBuffer
+    callSlot(&p, 5);
+    SLANG_CHECK(p.lastSlot == 5); // write
+    callSlot(&p, 6);
+    SLANG_CHECK(p.lastSlot == 6); // flush
+    callSlot(&p, 7);
+    SLANG_CHECK(p.lastSlot == 7); // isConsole
+    callSlot(&p, 8);
+    SLANG_CHECK(p.lastSlot == 8); // setMode
+}
+
+// ---------------------------------------------------------------------------
+// ISlangProfiler : ISlangUnknown  (own slots 3-6)
+// ---------------------------------------------------------------------------
+struct ISlangProfilerProbe : ISlangProfiler
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW size_t SLANG_MCALL getEntryCount() SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return 0;
+    }
+    SLANG_NO_THROW const char* SLANG_MCALL getEntryName(uint32_t) SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return nullptr;
+    }
+    SLANG_NO_THROW long SLANG_MCALL getEntryTimeMS(uint32_t) SLANG_OVERRIDE
+    {
+        lastSlot = 5;
+        return 0;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL getEntryInvocationTimes(uint32_t) SLANG_OVERRIDE
+    {
+        lastSlot = 6;
+        return 0;
+    }
+};
+
+SLANG_UNIT_TEST(vtableISlangProfiler)
+{
+    ISlangProfilerProbe p;
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // getEntryCount
+    callSlot(&p, 4);
+    SLANG_CHECK(p.lastSlot == 4); // getEntryName
+    callSlot(&p, 5);
+    SLANG_CHECK(p.lastSlot == 5); // getEntryTimeMS
+    callSlot(&p, 6);
+    SLANG_CHECK(p.lastSlot == 6); // getEntryInvocationTimes
+}
+
+// ---------------------------------------------------------------------------
+// IGlobalSession : ISlangUnknown  (own slots 3-31)
+// ---------------------------------------------------------------------------
+struct IGlobalSessionProbe : IGlobalSession
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL createSession(SessionDesc const&, ISession**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangProfileID SLANG_MCALL findProfile(char const*) SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return SLANG_PROFILE_UNKNOWN;
+    }
+    SLANG_NO_THROW void SLANG_MCALL setDownstreamCompilerPath(SlangPassThrough, char const*)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 5;
+    }
+    SLANG_NO_THROW void SLANG_MCALL setDownstreamCompilerPrelude(SlangPassThrough, const char*)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 6;
+    }
+    SLANG_NO_THROW void SLANG_MCALL getDownstreamCompilerPrelude(SlangPassThrough, ISlangBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 7;
+    }
+    SLANG_NO_THROW const char* SLANG_MCALL getBuildTagString() SLANG_OVERRIDE
+    {
+        lastSlot = 8;
+        return nullptr;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    setDefaultDownstreamCompiler(SlangSourceLanguage, SlangPassThrough) SLANG_OVERRIDE
+    {
+        lastSlot = 9;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangPassThrough SLANG_MCALL getDefaultDownstreamCompiler(SlangSourceLanguage)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 10;
+        return SLANG_PASS_THROUGH_NONE;
+    }
+    SLANG_NO_THROW void SLANG_MCALL setLanguagePrelude(SlangSourceLanguage, const char*)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 11;
+    }
+    SLANG_NO_THROW void SLANG_MCALL getLanguagePrelude(SlangSourceLanguage, ISlangBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 12;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL createCompileRequest(ICompileRequest**) SLANG_OVERRIDE
+    {
+        lastSlot = 13;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW void SLANG_MCALL addBuiltins(char const*, char const*) SLANG_OVERRIDE
+    {
+        lastSlot = 14;
+    }
+    SLANG_NO_THROW void SLANG_MCALL setSharedLibraryLoader(ISlangSharedLibraryLoader*)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 15;
+    }
+    SLANG_NO_THROW ISlangSharedLibraryLoader* SLANG_MCALL getSharedLibraryLoader() SLANG_OVERRIDE
+    {
+        lastSlot = 16;
+        return nullptr;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL checkCompileTargetSupport(SlangCompileTarget)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 17;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL checkPassThroughSupport(SlangPassThrough) SLANG_OVERRIDE
+    {
+        lastSlot = 18;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL compileCoreModule(CompileCoreModuleFlags) SLANG_OVERRIDE
+    {
+        lastSlot = 19;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL loadCoreModule(const void*, size_t) SLANG_OVERRIDE
+    {
+        lastSlot = 20;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL saveCoreModule(SlangArchiveType, ISlangBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 21;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangCapabilityID SLANG_MCALL findCapability(char const*) SLANG_OVERRIDE
+    {
+        lastSlot = 22;
+        return SLANG_CAPABILITY_UNKNOWN;
+    }
+    SLANG_NO_THROW void SLANG_MCALL setDownstreamCompilerForTransition(
+        SlangCompileTarget,
+        SlangCompileTarget,
+        SlangPassThrough) SLANG_OVERRIDE
+    {
+        lastSlot = 23;
+    }
+    SLANG_NO_THROW SlangPassThrough SLANG_MCALL
+    getDownstreamCompilerForTransition(SlangCompileTarget, SlangCompileTarget) SLANG_OVERRIDE
+    {
+        lastSlot = 24;
+        return SLANG_PASS_THROUGH_NONE;
+    }
+    SLANG_NO_THROW void SLANG_MCALL getCompilerElapsedTime(double*, double*) SLANG_OVERRIDE
+    {
+        lastSlot = 25;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL setSPIRVCoreGrammar(char const*) SLANG_OVERRIDE
+    {
+        lastSlot = 26;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    parseCommandLineArguments(int, const char* const*, SessionDesc*, ISlangUnknown**) SLANG_OVERRIDE
+    {
+        lastSlot = 27;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getSessionDescDigest(SessionDesc*, ISlangBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 28;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    compileBuiltinModule(BuiltinModuleName, CompileCoreModuleFlags) SLANG_OVERRIDE
+    {
+        lastSlot = 29;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL loadBuiltinModule(BuiltinModuleName, const void*, size_t)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 30;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    saveBuiltinModule(BuiltinModuleName, SlangArchiveType, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 31;
+        return SLANG_OK;
+    }
+};
+
+SLANG_UNIT_TEST(vtableIGlobalSession)
+{
+    IGlobalSessionProbe p;
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // createSession
+    callSlot(&p, 4);
+    SLANG_CHECK(p.lastSlot == 4); // findProfile
+    callSlot(&p, 8);
+    SLANG_CHECK(p.lastSlot == 8); // getBuildTagString
+    callSlot(&p, 13);
+    SLANG_CHECK(p.lastSlot == 13); // createCompileRequest (deprecated)
+    callSlot(&p, 16);
+    SLANG_CHECK(p.lastSlot == 16); // getSharedLibraryLoader
+    callSlot(&p, 22);
+    SLANG_CHECK(p.lastSlot == 22); // findCapability
+    callSlot(&p, 26);
+    SLANG_CHECK(p.lastSlot == 26); // setSPIRVCoreGrammar
+    callSlot(&p, 31);
+    SLANG_CHECK(p.lastSlot == 31); // saveBuiltinModule
+}
+
+// ---------------------------------------------------------------------------
+// IMetadata : ISlangCastable  (own slots 4-5)
+// ---------------------------------------------------------------------------
+struct IMetadataProbe : IMetadata
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW void* SLANG_MCALL castAs(const SlangUUID&) SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return nullptr;
+    }
+    SlangResult SLANG_MCALL
+    isParameterLocationUsed(SlangParameterCategory, SlangUInt, SlangUInt, bool&) SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW const char* SLANG_MCALL getDebugBuildIdentifier() SLANG_OVERRIDE
+    {
+        lastSlot = 5;
+        return nullptr;
+    }
+};
+
+SLANG_UNIT_TEST(vtableIMetadata)
+{
+    IMetadataProbe p;
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // castAs
+    callSlot(&p, 4);
+    SLANG_CHECK(p.lastSlot == 4); // isParameterLocationUsed
+    callSlot(&p, 5);
+    SLANG_CHECK(p.lastSlot == 5); // getDebugBuildIdentifier
+}
+
+// ---------------------------------------------------------------------------
+// ICompileResult : ISlangCastable  (own slots 4-6)
+// ---------------------------------------------------------------------------
+struct ICompileResultProbe : ICompileResult
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW void* SLANG_MCALL castAs(const SlangUUID&) SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return nullptr;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL getItemCount() SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return 0;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getItemData(uint32_t, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 5;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getMetadata(IMetadata**) SLANG_OVERRIDE
+    {
+        lastSlot = 6;
+        return SLANG_OK;
+    }
+};
+
+SLANG_UNIT_TEST(vtableICompileResult)
+{
+    ICompileResultProbe p;
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // castAs
+    callSlot(&p, 4);
+    SLANG_CHECK(p.lastSlot == 4); // getItemCount
+    callSlot(&p, 5);
+    SLANG_CHECK(p.lastSlot == 5); // getItemData
+    callSlot(&p, 6);
+    SLANG_CHECK(p.lastSlot == 6); // getMetadata
+}
+
+// ---------------------------------------------------------------------------
+// IComponentType : ISlangUnknown  (own slots 3-16)
+// ---------------------------------------------------------------------------
+struct IComponentTypeProbe : IComponentType
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW ISession* SLANG_MCALL getSession() SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return nullptr;
+    }
+    SLANG_NO_THROW ProgramLayout* SLANG_MCALL getLayout(SlangInt, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return nullptr;
+    }
+    SLANG_NO_THROW SlangInt SLANG_MCALL getSpecializationParamCount() SLANG_OVERRIDE
+    {
+        lastSlot = 5;
+        return 0;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getEntryPointCode(SlangInt, SlangInt, IBlob**, IBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 6;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    getResultAsFileSystem(SlangInt, SlangInt, ISlangMutableFileSystem**) SLANG_OVERRIDE
+    {
+        lastSlot = 7;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW void SLANG_MCALL getEntryPointHash(SlangInt, SlangInt, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 8;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    specialize(SpecializationArg const*, SlangInt, IComponentType**, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 9;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL link(IComponentType**, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 10;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    getEntryPointHostCallable(int, int, ISlangSharedLibrary**, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 11;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL renameEntryPoint(const char*, IComponentType**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 12;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    linkWithOptions(IComponentType**, uint32_t, CompilerOptionEntry const*, ISlangBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 13;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getTargetCode(SlangInt, IBlob**, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 14;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getTargetMetadata(SlangInt, IMetadata**, IBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 15;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    getEntryPointMetadata(SlangInt, SlangInt, IMetadata**, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 16;
+        return SLANG_OK;
+    }
+};
+
+SLANG_UNIT_TEST(vtableIComponentType)
+{
+    IComponentTypeProbe p;
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // getSession
+    callSlot(&p, 5);
+    SLANG_CHECK(p.lastSlot == 5); // getSpecializationParamCount
+    callSlot(&p, 8);
+    SLANG_CHECK(p.lastSlot == 8); // getEntryPointHash
+    callSlot(&p, 10);
+    SLANG_CHECK(p.lastSlot == 10); // link
+    callSlot(&p, 13);
+    SLANG_CHECK(p.lastSlot == 13); // linkWithOptions
+    callSlot(&p, 16);
+    SLANG_CHECK(p.lastSlot == 16); // getEntryPointMetadata
+}
+
+// ---------------------------------------------------------------------------
+// IEntryPoint : IComponentType  (own slot 17)
+// ---------------------------------------------------------------------------
+struct IEntryPointProbe : IEntryPoint
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW ISession* SLANG_MCALL getSession() SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return nullptr;
+    }
+    SLANG_NO_THROW ProgramLayout* SLANG_MCALL getLayout(SlangInt, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return nullptr;
+    }
+    SLANG_NO_THROW SlangInt SLANG_MCALL getSpecializationParamCount() SLANG_OVERRIDE
+    {
+        lastSlot = 5;
+        return 0;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getEntryPointCode(SlangInt, SlangInt, IBlob**, IBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 6;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    getResultAsFileSystem(SlangInt, SlangInt, ISlangMutableFileSystem**) SLANG_OVERRIDE
+    {
+        lastSlot = 7;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW void SLANG_MCALL getEntryPointHash(SlangInt, SlangInt, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 8;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    specialize(SpecializationArg const*, SlangInt, IComponentType**, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 9;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL link(IComponentType**, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 10;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    getEntryPointHostCallable(int, int, ISlangSharedLibrary**, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 11;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL renameEntryPoint(const char*, IComponentType**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 12;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    linkWithOptions(IComponentType**, uint32_t, CompilerOptionEntry const*, ISlangBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 13;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getTargetCode(SlangInt, IBlob**, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 14;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getTargetMetadata(SlangInt, IMetadata**, IBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 15;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    getEntryPointMetadata(SlangInt, SlangInt, IMetadata**, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 16;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW FunctionReflection* SLANG_MCALL getFunctionReflection() SLANG_OVERRIDE
+    {
+        lastSlot = 17;
+        return nullptr;
+    }
+};
+
+SLANG_UNIT_TEST(vtableIEntryPoint)
+{
+    IEntryPointProbe p;
+    callSlot(&p, 16);
+    SLANG_CHECK(p.lastSlot == 16); // getEntryPointMetadata
+    callSlot(&p, 17);
+    SLANG_CHECK(p.lastSlot == 17); // getFunctionReflection
+}
+
+// ---------------------------------------------------------------------------
+// IComponentType2 : ISlangUnknown  (own slots 3-5)
+// ---------------------------------------------------------------------------
+struct IComponentType2Probe : IComponentType2
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    getTargetCompileResult(SlangInt, ICompileResult**, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    getEntryPointCompileResult(SlangInt, SlangInt, ICompileResult**, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    getTargetHostCallable(int, ISlangSharedLibrary**, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 5;
+        return SLANG_OK;
+    }
+};
+
+SLANG_UNIT_TEST(vtableIComponentType2)
+{
+    IComponentType2Probe p;
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // getTargetCompileResult
+    callSlot(&p, 4);
+    SLANG_CHECK(p.lastSlot == 4); // getEntryPointCompileResult
+    callSlot(&p, 5);
+    SLANG_CHECK(p.lastSlot == 5); // getTargetHostCallable
+}
+
+// ---------------------------------------------------------------------------
+// ISession : ISlangUnknown  (own slots 3-23)
+// ---------------------------------------------------------------------------
+struct ISessionProbe : ISession
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW IGlobalSession* SLANG_MCALL getGlobalSession() SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return nullptr;
+    }
+    SLANG_NO_THROW IModule* SLANG_MCALL loadModule(const char*, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return nullptr;
+    }
+    SLANG_NO_THROW IModule* SLANG_MCALL
+    loadModuleFromSource(const char*, const char*, IBlob*, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 5;
+        return nullptr;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    createCompositeComponentType(IComponentType* const*, SlangInt, IComponentType**, ISlangBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 6;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW TypeReflection* SLANG_MCALL
+    specializeType(TypeReflection*, SpecializationArg const*, SlangInt, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 7;
+        return nullptr;
+    }
+    SLANG_NO_THROW TypeLayoutReflection* SLANG_MCALL
+    getTypeLayout(TypeReflection*, SlangInt, LayoutRules, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 8;
+        return nullptr;
+    }
+    SLANG_NO_THROW TypeReflection* SLANG_MCALL
+    getContainerType(TypeReflection*, ContainerType, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 9;
+        return nullptr;
+    }
+    SLANG_NO_THROW TypeReflection* SLANG_MCALL getDynamicType() SLANG_OVERRIDE
+    {
+        lastSlot = 10;
+        return nullptr;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getTypeRTTIMangledName(TypeReflection*, ISlangBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 11;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getTypeConformanceWitnessMangledName(
+        TypeReflection*,
+        TypeReflection*,
+        ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 12;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getTypeConformanceWitnessSequentialID(
+        TypeReflection*,
+        TypeReflection*,
+        uint32_t*) SLANG_OVERRIDE
+    {
+        lastSlot = 13;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL createCompileRequest(SlangCompileRequest**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 14;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL createTypeConformanceComponentType(
+        TypeReflection*,
+        TypeReflection*,
+        ITypeConformance**,
+        SlangInt,
+        ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 15;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW IModule* SLANG_MCALL
+    loadModuleFromIRBlob(const char*, const char*, IBlob*, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 16;
+        return nullptr;
+    }
+    SLANG_NO_THROW SlangInt SLANG_MCALL getLoadedModuleCount() SLANG_OVERRIDE
+    {
+        lastSlot = 17;
+        return 0;
+    }
+    SLANG_NO_THROW IModule* SLANG_MCALL getLoadedModule(SlangInt) SLANG_OVERRIDE
+    {
+        lastSlot = 18;
+        return nullptr;
+    }
+    SLANG_NO_THROW bool SLANG_MCALL isBinaryModuleUpToDate(const char*, IBlob*) SLANG_OVERRIDE
+    {
+        lastSlot = 19;
+        return false;
+    }
+    SLANG_NO_THROW IModule* SLANG_MCALL
+    loadModuleFromSourceString(const char*, const char*, const char*, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 20;
+        return nullptr;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    getDynamicObjectRTTIBytes(TypeReflection*, TypeReflection*, uint32_t*, uint32_t) SLANG_OVERRIDE
+    {
+        lastSlot = 21;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    loadModuleInfoFromIRBlob(IBlob*, SlangInt&, const char*&, const char*&) SLANG_OVERRIDE
+    {
+        lastSlot = 22;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getDeclSourceLocation(DeclReflection*, SourceLocation*)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 23;
+        return SLANG_OK;
+    }
+};
+
+SLANG_UNIT_TEST(vtableISession)
+{
+    ISessionProbe p;
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // getGlobalSession
+    callSlot(&p, 10);
+    SLANG_CHECK(p.lastSlot == 10); // getDynamicType
+    callSlot(&p, 14);
+    SLANG_CHECK(p.lastSlot == 14); // createCompileRequest
+    callSlot(&p, 17);
+    SLANG_CHECK(p.lastSlot == 17); // getLoadedModuleCount
+    callSlot(&p, 23);
+    SLANG_CHECK(p.lastSlot == 23); // getDeclSourceLocation
+}
+
+// ---------------------------------------------------------------------------
+// IModule : IComponentType  (own slots 17-29)
+// ---------------------------------------------------------------------------
+struct IModuleProbe : IModule
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW ISession* SLANG_MCALL getSession() SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return nullptr;
+    }
+    SLANG_NO_THROW ProgramLayout* SLANG_MCALL getLayout(SlangInt, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return nullptr;
+    }
+    SLANG_NO_THROW SlangInt SLANG_MCALL getSpecializationParamCount() SLANG_OVERRIDE
+    {
+        lastSlot = 5;
+        return 0;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getEntryPointCode(SlangInt, SlangInt, IBlob**, IBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 6;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    getResultAsFileSystem(SlangInt, SlangInt, ISlangMutableFileSystem**) SLANG_OVERRIDE
+    {
+        lastSlot = 7;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW void SLANG_MCALL getEntryPointHash(SlangInt, SlangInt, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 8;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    specialize(SpecializationArg const*, SlangInt, IComponentType**, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 9;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL link(IComponentType**, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 10;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    getEntryPointHostCallable(int, int, ISlangSharedLibrary**, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 11;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL renameEntryPoint(const char*, IComponentType**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 12;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    linkWithOptions(IComponentType**, uint32_t, CompilerOptionEntry const*, ISlangBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 13;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getTargetCode(SlangInt, IBlob**, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 14;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getTargetMetadata(SlangInt, IMetadata**, IBlob**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 15;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    getEntryPointMetadata(SlangInt, SlangInt, IMetadata**, IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 16;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL findEntryPointByName(char const*, IEntryPoint**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 17;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangInt32 SLANG_MCALL getDefinedEntryPointCount() SLANG_OVERRIDE
+    {
+        lastSlot = 18;
+        return 0;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getDefinedEntryPoint(SlangInt32, IEntryPoint**)
+        SLANG_OVERRIDE
+    {
+        lastSlot = 19;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL serialize(ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 20;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL writeToFile(char const*) SLANG_OVERRIDE
+    {
+        lastSlot = 21;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW const char* SLANG_MCALL getName() SLANG_OVERRIDE
+    {
+        lastSlot = 22;
+        return nullptr;
+    }
+    SLANG_NO_THROW const char* SLANG_MCALL getFilePath() SLANG_OVERRIDE
+    {
+        lastSlot = 23;
+        return nullptr;
+    }
+    SLANG_NO_THROW const char* SLANG_MCALL getUniqueIdentity() SLANG_OVERRIDE
+    {
+        lastSlot = 24;
+        return nullptr;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL
+    findAndCheckEntryPoint(char const*, SlangStage, IEntryPoint**, ISlangBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 25;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangInt32 SLANG_MCALL getDependencyFileCount() SLANG_OVERRIDE
+    {
+        lastSlot = 26;
+        return 0;
+    }
+    SLANG_NO_THROW char const* SLANG_MCALL getDependencyFilePath(SlangInt32) SLANG_OVERRIDE
+    {
+        lastSlot = 27;
+        return nullptr;
+    }
+    SLANG_NO_THROW DeclReflection* SLANG_MCALL getModuleReflection() SLANG_OVERRIDE
+    {
+        lastSlot = 28;
+        return nullptr;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL disassemble(IBlob**) SLANG_OVERRIDE
+    {
+        lastSlot = 29;
+        return SLANG_OK;
+    }
+};
+
+SLANG_UNIT_TEST(vtableIModule)
+{
+    IModuleProbe p;
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // getSession (inherited from IComponentType)
+    callSlot(&p, 16);
+    SLANG_CHECK(p.lastSlot == 16); // getEntryPointMetadata (last IComponentType slot)
+    callSlot(&p, 17);
+    SLANG_CHECK(p.lastSlot == 17); // findEntryPointByName
+    callSlot(&p, 22);
+    SLANG_CHECK(p.lastSlot == 22); // getName
+    callSlot(&p, 23);
+    SLANG_CHECK(p.lastSlot == 23); // getFilePath
+    callSlot(&p, 24);
+    SLANG_CHECK(p.lastSlot == 24); // getUniqueIdentity
+    callSlot(&p, 29);
+    SLANG_CHECK(p.lastSlot == 29); // disassemble
+}

--- a/tools/slang-unit-test/unit-test-vtable-stability.cpp
+++ b/tools/slang-unit-test/unit-test-vtable-stability.cpp
@@ -9,15 +9,23 @@
 // indices of all subsequent methods shift by one, causing a different probe
 // method to fire and the corresponding SLANG_CHECK to fail.
 //
-// Calling convention note: on all platforms Slang targets, virtual dispatch
-// passes `this` in the first register and further args in subsequent registers.
-// The probe overrides never read their arguments, so calling with no args
-// (beyond `this`) is safe regardless of the declared parameter list.
+// Calling convention note: callSlot() casts every vtable entry to
+// void(SLANG_MCALL*)(void*) and calls it with only `this`. The actual methods
+// have varying signatures; calling through a mismatched pointer is undefined
+// behavior per [expr.call]. On all 64-bit ABIs Slang targets (x86_64, ARM64)
+// this is benign: `this` lands in the first integer register, remaining
+// argument registers hold garbage that the probe overrides never read, and the
+// caller handles stack cleanup (no __stdcall callee-cleanup mismatch). On
+// 32-bit x86 with __stdcall the callee would clean the stack for its declared
+// parameters, corrupting the stack when called with fewer arguments, so the
+// entire test is guarded by SLANG_PTR_IS_64.
 
 #include "slang.h"
 #include "unit-test/slang-unit-test.h"
 
 using namespace slang;
+
+#if SLANG_PTR_IS_64
 
 // ---------------------------------------------------------------------------
 // Helper: call vtable slot `slot` on `obj`, passing only `this`.
@@ -1601,3 +1609,93 @@ SLANG_UNIT_TEST(vtableIModule)
     callSlot(&p, 29);
     SLANG_CHECK(p.lastSlot == 29); // disassemble
 }
+
+// ---------------------------------------------------------------------------
+// IByteCodeRunner : ISlangUnknown  (own slots 3-13)
+// ---------------------------------------------------------------------------
+struct IByteCodeRunnerProbe : IByteCodeRunner
+{
+    int lastSlot = -1;
+    SLANG_NO_THROW SlangResult SLANG_MCALL queryInterface(SlangUUID const&, void**) SLANG_OVERRIDE
+    {
+        lastSlot = 0;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL addRef() SLANG_OVERRIDE
+    {
+        lastSlot = 1;
+        return 1;
+    }
+    SLANG_NO_THROW uint32_t SLANG_MCALL release() SLANG_OVERRIDE
+    {
+        lastSlot = 2;
+        return 1;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL loadModule(IBlob*) SLANG_OVERRIDE
+    {
+        lastSlot = 3;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL selectFunctionByIndex(uint32_t) SLANG_OVERRIDE
+    {
+        lastSlot = 4;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW int SLANG_MCALL findFunctionByName(const char*) SLANG_OVERRIDE
+    {
+        lastSlot = 5;
+        return -1;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL getFunctionInfo(uint32_t, ByteCodeFuncInfo*) SLANG_OVERRIDE
+    {
+        lastSlot = 6;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW void* SLANG_MCALL getCurrentWorkingSet() SLANG_OVERRIDE
+    {
+        lastSlot = 7;
+        return nullptr;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL execute(void*, size_t) SLANG_OVERRIDE
+    {
+        lastSlot = 8;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW void SLANG_MCALL getErrorString(IBlob**) SLANG_OVERRIDE { lastSlot = 9; }
+    SLANG_NO_THROW void* SLANG_MCALL getReturnValue(size_t*) SLANG_OVERRIDE
+    {
+        lastSlot = 10;
+        return nullptr;
+    }
+    SLANG_NO_THROW void SLANG_MCALL setExtInstHandlerUserData(void*) SLANG_OVERRIDE
+    {
+        lastSlot = 11;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL registerExtCall(const char*, VMExtFunction) SLANG_OVERRIDE
+    {
+        lastSlot = 12;
+        return SLANG_OK;
+    }
+    SLANG_NO_THROW SlangResult SLANG_MCALL setPrintCallback(VMPrintFunc, void*) SLANG_OVERRIDE
+    {
+        lastSlot = 13;
+        return SLANG_OK;
+    }
+};
+
+SLANG_UNIT_TEST(vtableIByteCodeRunner)
+{
+    IByteCodeRunnerProbe p;
+    callSlot(&p, 3);
+    SLANG_CHECK(p.lastSlot == 3); // loadModule
+    callSlot(&p, 5);
+    SLANG_CHECK(p.lastSlot == 5); // findFunctionByName
+    callSlot(&p, 7);
+    SLANG_CHECK(p.lastSlot == 7); // getCurrentWorkingSet
+    callSlot(&p, 10);
+    SLANG_CHECK(p.lastSlot == 10); // getReturnValue
+    callSlot(&p, 13);
+    SLANG_CHECK(p.lastSlot == 13); // setPrintCallback
+}
+
+#endif // SLANG_PTR_IS_64

--- a/tools/slang-unit-test/unit-test-vtable-stability.cpp
+++ b/tools/slang-unit-test/unit-test-vtable-stability.cpp
@@ -1646,7 +1646,8 @@ struct IByteCodeRunnerProbe : IByteCodeRunner
         lastSlot = 5;
         return -1;
     }
-    SLANG_NO_THROW SlangResult SLANG_MCALL getFunctionInfo(uint32_t, ByteCodeFuncInfo*) SLANG_OVERRIDE
+    SLANG_NO_THROW SlangResult SLANG_MCALL getFunctionInfo(uint32_t, ByteCodeFuncInfo*)
+        SLANG_OVERRIDE
     {
         lastSlot = 6;
         return SLANG_OK;
@@ -1671,7 +1672,8 @@ struct IByteCodeRunnerProbe : IByteCodeRunner
     {
         lastSlot = 11;
     }
-    SLANG_NO_THROW SlangResult SLANG_MCALL registerExtCall(const char*, VMExtFunction) SLANG_OVERRIDE
+    SLANG_NO_THROW SlangResult SLANG_MCALL registerExtCall(const char*, VMExtFunction)
+        SLANG_OVERRIDE
     {
         lastSlot = 12;
         return SLANG_OK;


### PR DESCRIPTION
This PR assigned explicit integer values to all enums to make it obvious when the backward-compatibility will be broken.
It avoid implicit value shift when a new enum is inserted in the middle.

This PR also adds vtable slot stability tests for all COM interfaces in slang.h.
If the order of the member functions changes in the interface, the unit-tests will fail.

This PR also updates CLAUDE.md and documents to avoid unwanted backward-compatibility breaks.

Fixes https://github.com/shader-slang/slang/issues/10800