### PR TITLE
Suppress nightly sanitizer TypeLayout UAF findings pending #10893

### DIFF
--- a/cmake/expected-sanitizer-findings.txt
+++ b/cmake/expected-sanitizer-findings.txt
@@ -35,3 +35,13 @@
 # Leak from _maybeBeginMacroInvocation() and type layout objects
 # created during compilation.
 LEAK: _maybeBeginMacroInvocation
+
+# #10893: Use-after-free of TypeLayoutReflection in slang-rhi
+# ShaderObjectLayout cache during render-test CPU compute tests.
+# All three SUMMARY lines below cascade from a single dangling vptr
+# dereference in TypeLayout::FindResourceInfo / List::begin(). UBSan
+# SUMMARY lines only carry file:line -- update line numbers if the
+# surrounding code shifts, or remove entries when #10893 is fixed.
+Slang::List<Slang::TypeLayout::ResourceInfo, Slang::StandardAllocator>::begin()
+slang-reflection-api.cpp:1384
+slang-type-layout.h:772


### PR DESCRIPTION
## Summary

The nightly sanitizer run at `master` commit [72dfd8b9c](https://github.com/shader-slang/slang/actions/runs/24709719289) surfaced a use-after-free on `slang::TypeLayoutReflection*` during `render-test` CPU compute comparisons, producing three cascading SUMMARY lines from a single dangling vptr dereference in `TypeLayout::FindResourceInfo` / `List::begin()`. The underlying bug is in `slang-rhi`'s `ShaderObjectLayout` cache, which is keyed by raw `TypeLayoutReflection*` and thus returns false cache hits when the slang session is released and the pointer is recycled.

Filed as #10893 with full root-cause analysis and fix options. Until that lands, this PR suppresses the three findings via `cmake/expected-sanitizer-findings.txt` so the nightly sanitizer job is unblocked.

## Why three patterns

The three SUMMARY lines come from one crash site, but the matcher in `ci-slang-sanitizer.yml` classifies a log file as "expected" only when *every* SUMMARY line in it matches some pattern. All three must be listed.

## Pattern stability

- `Slang::List<Slang::TypeLayout::ResourceInfo, Slang::StandardAllocator>::begin()` matches the ASan SUMMARY on function signature — stable.
- UBSan SUMMARY carries file:line only, so the UBSan entries use `slang-reflection-api.cpp:1384` and `slang-type-layout.h:772`. The header comment flags them as fragile under code motion. When #10893 is fixed, all three entries are removed — if the file drifts first, the stale-pattern warning will call it out.

## Test plan

- [ ] Re-run the nightly sanitizer workflow (`workflow_dispatch` on `master` after merge) and confirm the three findings are reclassified as "Expected findings" and the job exits green.
- [ ] Confirm the stale-pattern warning fires once #10893 is fixed, prompting cleanup.
