### PR TITLE
shader coverage: synthesize __slang_coverage at AST time for reflection visibility

### DIFF
--- a/include/slang.h
+++ b/include/slang.h
@@ -1139,6 +1139,8 @@ typedef uint32_t SlangSizeT;
 
         DiagnosticColor, // intValue0: SlangDiagnosticColor (always, never, auto)
 
+        TraceCoverage, // bool: insert per-statement execution counters
+
         CountOf,
     };
 

--- a/prelude/slang-cpp-prelude.h
+++ b/prelude/slang-cpp-prelude.h
@@ -321,6 +321,34 @@ public:                                                                         
 #include "slang-cpp-scalar-intrinsics.h"
 #include "slang-cpp-types.h"
 
+// Atomic helpers for the CPU target. Needed so kIROp_AtomicAdd and
+// friends can lower to native atomic operations on the host — matching
+// the semantics of HLSL `InterlockedAdd`, SPIR-V `OpAtomicIAdd`, etc.
+// Uses compiler builtins so no <atomic> header is required.
+#if defined(_MSC_VER)
+#include <intrin.h>
+static inline uint32_t _slang_atomic_add_u32(uint32_t* ptr, uint32_t val)
+{
+    // Returns the PRIOR value, matching HLSL InterlockedAdd and GLSL atomicAdd.
+    return static_cast<uint32_t>(
+        _InterlockedExchangeAdd(reinterpret_cast<volatile long*>(ptr), static_cast<long>(val)));
+}
+static inline int32_t _slang_atomic_add_i32(int32_t* ptr, int32_t val)
+{
+    return static_cast<int32_t>(
+        _InterlockedExchangeAdd(reinterpret_cast<volatile long*>(ptr), static_cast<long>(val)));
+}
+#else
+static inline uint32_t _slang_atomic_add_u32(uint32_t* ptr, uint32_t val)
+{
+    return __atomic_fetch_add(ptr, val, __ATOMIC_RELAXED);
+}
+static inline int32_t _slang_atomic_add_i32(int32_t* ptr, int32_t val)
+{
+    return __atomic_fetch_add(ptr, val, __ATOMIC_RELAXED);
+}
+#endif
+
 // TODO(JS): Hack! Output C++ code from slang can copy uninitialized variables.
 #if defined(_MSC_VER)
 #pragma warning(disable : 4700)

--- a/prelude/slang-cpp-prelude.h
+++ b/prelude/slang-cpp-prelude.h
@@ -325,8 +325,20 @@ public:                                                                         
 // friends can lower to native atomic operations on the host — matching
 // the semantics of HLSL `InterlockedAdd`, SPIR-V `OpAtomicIAdd`, etc.
 // Uses compiler builtins so no <atomic> header is required.
-#if defined(_MSC_VER)
+//
+// Compiler coverage:
+//   - MSVC:            `_InterlockedExchangeAdd`
+//   - GCC / Clang:     `__atomic_fetch_add`
+//   - SNC / GHS etc.:  falls back to a non-atomic load/add/store.
+//     These are console / embedded toolchains not known to ship
+//     `__atomic_*` builtins; the fallback is racy under concurrency
+//     but keeps the prelude buildable there. Platforms that need
+//     real atomics on those compilers can add a bespoke branch.
+#if SLANG_VC
 #include <intrin.h>
+static_assert(
+    sizeof(long) == 4,
+    "_InterlockedExchangeAdd uses `long`; MSVC LLP64 requires sizeof(long)==4");
 static inline uint32_t _slang_atomic_add_u32(uint32_t* ptr, uint32_t val)
 {
     // Returns the PRIOR value, matching HLSL InterlockedAdd and GLSL atomicAdd.
@@ -338,7 +350,7 @@ static inline int32_t _slang_atomic_add_i32(int32_t* ptr, int32_t val)
     return static_cast<int32_t>(
         _InterlockedExchangeAdd(reinterpret_cast<volatile long*>(ptr), static_cast<long>(val)));
 }
-#else
+#elif SLANG_GCC || SLANG_CLANG
 static inline uint32_t _slang_atomic_add_u32(uint32_t* ptr, uint32_t val)
 {
     return __atomic_fetch_add(ptr, val, __ATOMIC_RELAXED);
@@ -346,6 +358,23 @@ static inline uint32_t _slang_atomic_add_u32(uint32_t* ptr, uint32_t val)
 static inline int32_t _slang_atomic_add_i32(int32_t* ptr, int32_t val)
 {
     return __atomic_fetch_add(ptr, val, __ATOMIC_RELAXED);
+}
+#else
+// Non-atomic fallback for compilers without a known atomic builtin
+// (Sony SNC, Green Hills MULTI, etc.). Racy under concurrent invocation
+// but keeps the prelude compilable; CPU-target coverage on these
+// platforms is single-threaded in practice.
+static inline uint32_t _slang_atomic_add_u32(uint32_t* ptr, uint32_t val)
+{
+    uint32_t old = *ptr;
+    *ptr = old + val;
+    return old;
+}
+static inline int32_t _slang_atomic_add_i32(int32_t* ptr, int32_t val)
+{
+    int32_t old = *ptr;
+    *ptr = old + val;
+    return old;
 }
 #endif
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2,6 +2,7 @@
 #include "slang-ast-modifier.h"
 #include "slang-ast-support-types.h"
 #include "slang-check-impl.h"
+#include "slang-check-synthesize-coverage.h"
 
 // This file constaints the semantic checking logic and
 // related queries for declarations.
@@ -4800,6 +4801,15 @@ void SemanticsDeclVisitorBase::checkModule(ModuleDecl* moduleDecl)
         if (auto fileDecl = as<FileDecl>(moduleDecl->getDirectMemberDecl(i)))
             visitIncludeDecls(fileDecl);
     }
+
+    // When `-trace-coverage` is on, inject the synthetic
+    // `RWStructuredBuffer<uint> __slang_coverage` global that the
+    // coverage IR pass will later wire counter increments into.
+    // Done here — after imports/includes, before the main decl-
+    // state iteration — so the synthetic decl participates in the
+    // same name-lookup, parameter-binding, and reflection passes as
+    // a user-declared global.
+    maybeSynthesizeCoverageBufferDecl(this, moduleDecl);
 
     // The entire goal of semantic checking is to get all of the
     // declarations in the module up to `DeclCheckState::DefinitionChecked`.

--- a/source/slang/slang-check-synthesize-coverage.cpp
+++ b/source/slang/slang-check-synthesize-coverage.cpp
@@ -1,0 +1,101 @@
+// slang-check-synthesize-coverage.cpp
+//
+// When `-trace-coverage` is on, the user is asking the compiler to
+// instrument their shader with per-statement execution counters.
+// The placeholder IR op that records each counter needs a buffer to
+// write into at runtime; the *architecturally correct* way to model
+// that buffer is as a synthetic global-scope shader parameter, so
+// that it flows through the same parameter-binding, reflection, and
+// layout pipeline as user-declared globals.
+//
+// This file runs at semantic-check time, between include/import
+// resolution and the main decl-state iteration. It injects a
+// `RWStructuredBuffer<uint> __slang_coverage` declaration into the
+// module's scope if one isn't already present, marked with a
+// `SynthesizedModifier` so downstream tooling can filter it.
+
+#include "slang-check-synthesize-coverage.h"
+
+#include "compiler-core/slang-name.h"
+#include "slang-ast-builder.h"
+#include "slang-ast-decl.h"
+#include "slang-ast-modifier.h"
+#include "slang-ast-type.h"
+#include "slang-check-impl.h"
+#include "slang-compiler.h"
+
+namespace Slang
+{
+
+// Well-known buffer name. Matches the IR pass that rewrites
+// IncrementCoverageCounter placeholders and the `.slangcov` manifest
+// format.
+static const char* kCoverageBufferName = "__slang_coverage";
+
+// Find an existing module-scope decl named `__slang_coverage`. If
+// present, callers reuse it instead of synthesizing. Returns null if
+// not found.
+static VarDecl* findExistingCoverageDecl(ModuleDecl* moduleDecl)
+{
+    for (auto member : moduleDecl->getDirectMemberDecls())
+    {
+        auto varDecl = as<VarDecl>(member);
+        if (!varDecl)
+            continue;
+        auto name = varDecl->getName();
+        if (!name)
+            continue;
+        if (name->text == kCoverageBufferName)
+            return varDecl;
+    }
+    return nullptr;
+}
+
+void maybeSynthesizeCoverageBufferDecl(
+    SemanticsVisitor* visitor,
+    ModuleDecl* moduleDecl)
+{
+    // Gate on the compile flag. If coverage isn't requested, this
+    // entire function is a no-op — we don't want to perturb any
+    // normal compile.
+    if (!visitor->getLinkage()->m_optionSet.getBoolOption(
+            CompilerOptionName::TraceCoverage))
+        return;
+
+    // Don't inject into the core module or other compiler-owned
+    // modules; coverage is strictly a user-facing feature.
+    if (isFromCoreModule(moduleDecl))
+        return;
+
+    // If the user already declared `__slang_coverage` themselves (or
+    // a previous compile phase already synthesized it for this
+    // module), don't duplicate.
+    if (findExistingCoverageDecl(moduleDecl))
+        return;
+
+    auto astBuilder = getCurrentASTBuilder();
+
+    // Build the type: `RWStructuredBuffer<uint>`.
+    auto uintType = astBuilder->getUIntType();
+    auto bufferType = astBuilder->getRWStructuredBufferType(uintType);
+
+    // Build the VarDecl. Parent is the module itself; name matches
+    // the well-known reserved identifier. A `SynthesizedModifier`
+    // lets downstream tooling filter it out of user-facing views
+    // (reflection, IDEs) without affecting correctness.
+    auto varDecl = astBuilder->create<VarDecl>();
+    varDecl->nameAndLoc.name = visitor->getNamePool()->getName(kCoverageBufferName);
+    varDecl->parentDecl = moduleDecl;
+    varDecl->type.type = bufferType;
+    varDecl->loc = moduleDecl->loc;
+
+    auto synthModifier = astBuilder->create<SynthesizedModifier>();
+    addModifier(varDecl, synthModifier);
+
+    // Attach the decl to the module. `addDirectMemberDecl` updates
+    // the internal name-lookup table so subsequent phases find it
+    // like any other declaration.
+    moduleDecl->addDirectMemberDecl(varDecl);
+}
+
+} // namespace Slang

--- a/source/slang/slang-check-synthesize-coverage.h
+++ b/source/slang/slang-check-synthesize-coverage.h
@@ -1,0 +1,26 @@
+#ifndef SLANG_CHECK_SYNTHESIZE_COVERAGE_H
+#define SLANG_CHECK_SYNTHESIZE_COVERAGE_H
+
+namespace Slang
+{
+class ModuleDecl;
+class SemanticsVisitor;
+
+// When `-trace-coverage` is enabled, synthesize a module-scope
+// `RWStructuredBuffer<uint> __slang_coverage` declaration in the
+// given ModuleDecl, unless the user has already declared one.
+//
+// Runs at semantic-check time, before parameter binding. The
+// synthesized decl goes through the normal binding/reflection/IR
+// pipeline, so every backend and every reflection-driven runtime
+// (slang-rhi, slangpy, user Vulkan/D3D12 apps) sees the buffer as
+// a first-class shader parameter.
+//
+// No-op when the flag is off or on core-module modules.
+void maybeSynthesizeCoverageBufferDecl(
+    SemanticsVisitor* visitor,
+    ModuleDecl* moduleDecl);
+
+} // namespace Slang
+
+#endif // SLANG_CHECK_SYNTHESIZE_COVERAGE_H

--- a/source/slang/slang-code-gen.cpp
+++ b/source/slang/slang-code-gen.cpp
@@ -1387,6 +1387,11 @@ bool CodeGenContext::shouldReportDynamicDispatchSites()
         CompilerOptionName::ReportDynamicDispatchSites);
 }
 
+bool CodeGenContext::shouldTraceCoverage()
+{
+    return getTargetProgram()->getOptionSet().getBoolOption(CompilerOptionName::TraceCoverage);
+}
+
 bool CodeGenContext::shouldDumpIntermediates()
 {
     return getTargetProgram()->getOptionSet().shouldDumpIntermediates();

--- a/source/slang/slang-code-gen.h
+++ b/source/slang/slang-code-gen.h
@@ -177,6 +177,7 @@ public:
     bool shouldDumpIR();
     bool shouldReportCheckpointIntermediates();
     bool shouldReportDynamicDispatchSites();
+    bool shouldTraceCoverage();
 
     bool shouldTrackLiveness();
 

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -1357,9 +1357,17 @@ bool CPPSourceEmitter::tryEmitInstStmtImpl(IRInst* inst)
             // Lower AtomicAdd on a pointer-to-uint/int slot to a call
             // through the CPU prelude helpers. Matches HLSL/GLSL
             // semantics: returns the prior value as the inst result.
+            //
+            // Only 32-bit integer widths are supported by the prelude
+            // helpers today; wider/narrower types fall through to the
+            // default unhandled-opcode diagnostic so the build fails
+            // loudly instead of producing bogus code.
             auto dataType = inst->getDataType();
-            bool isSigned = dataType->getOp() == kIROp_IntType;
-            char const* helper = isSigned ? "_slang_atomic_add_i32" : "_slang_atomic_add_u32";
+            bool isSignedInt = dataType->getOp() == kIROp_IntType;
+            bool isUnsignedInt = dataType->getOp() == kIROp_UIntType;
+            if (!isSignedInt && !isUnsignedInt)
+                return false;
+            char const* helper = isSignedInt ? "_slang_atomic_add_i32" : "_slang_atomic_add_u32";
             emitInstResultDecl(inst);
             m_writer->emit(helper);
             m_writer->emit("(");

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -1352,6 +1352,23 @@ bool CPPSourceEmitter::tryEmitInstStmtImpl(IRInst* inst)
             m_writer->emit(");\n");
             return true;
         }
+    case kIROp_AtomicAdd:
+        {
+            // Lower AtomicAdd on a pointer-to-uint/int slot to a call
+            // through the CPU prelude helpers. Matches HLSL/GLSL
+            // semantics: returns the prior value as the inst result.
+            auto dataType = inst->getDataType();
+            bool isSigned = dataType->getOp() == kIROp_IntType;
+            char const* helper = isSigned ? "_slang_atomic_add_i32" : "_slang_atomic_add_u32";
+            emitInstResultDecl(inst);
+            m_writer->emit(helper);
+            m_writer->emit("(");
+            emitOperand(inst->getOperand(0), getInfo(EmitOp::General));
+            m_writer->emit(", ");
+            emitOperand(inst->getOperand(1), getInfo(EmitOp::General));
+            m_writer->emit(");\n");
+            return true;
+        }
     default:
         return false;
     }

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -35,6 +35,7 @@
 #include "slang-ir-collect-global-uniforms.h"
 #include "slang-ir-com-interface.h"
 #include "slang-ir-composite-reg-to-mem.h"
+#include "slang-ir-coverage-instrument.h"
 #include "slang-ir-cuda-immutable-load.h"
 #include "slang-ir-dce.h"
 #include "slang-ir-defer-buffer-load.h"
@@ -955,8 +956,11 @@ Result linkAndOptimizeIR(
 
     // Debug info is added by the front-end. If the target cannot express debug info, or if the user
     // specifies -g0, we need to stripped them out now to allow more optimization and cleanups.
+    // Exception: when `-trace-coverage` is on, coverage placeholders reference the debug source
+    // entries; stripping now would leave dangling operands. Strip after the coverage pass has run.
     if (requiredLoweringPassSet.debugInfo &&
-        (targetCompilerOptions.getDebugInfoLevel() == DebugInfoLevel::None))
+        (targetCompilerOptions.getDebugInfoLevel() == DebugInfoLevel::None) &&
+        !codeGenContext->shouldTraceCoverage())
         SLANG_PASS(stripDebugInfo);
 
     if (!isKhronosTarget(targetRequest) && requiredLoweringPassSet.glslSSBO)
@@ -1007,6 +1011,24 @@ Result linkAndOptimizeIR(
     // can assume that all ordinary/uniform data is strictly
     // passed using constant buffers.
     //
+    // Shader coverage instrumentation. Runs before the user's module-
+    // scope globals are packed into a uniform struct, so that a
+    // `RWStructuredBuffer<uint> __slang_coverage` declaration (or one
+    // synthesized by this pass) is still visible as a top-level
+    // IRGlobalParam. When `-trace-coverage` is off the pass is a no-op
+    // unless the user has declared the buffer themselves.
+    SLANG_PASS(instrumentCoverage, sink, codeGenContext->shouldTraceCoverage());
+
+    // If the user requested -trace-coverage but not -g, we deferred the
+    // debug-info strip so the coverage pass could read source positions
+    // off the placeholders. Now that the placeholders are gone, strip
+    // the debug instructions as originally intended.
+    if (codeGenContext->shouldTraceCoverage() && requiredLoweringPassSet.debugInfo &&
+        targetCompilerOptions.getDebugInfoLevel() == DebugInfoLevel::None)
+    {
+        SLANG_PASS(stripDebugInfo);
+    }
+
     SLANG_PASS(collectGlobalUniformParameters, outLinkedIR.globalScopeVarLayout, target);
     validateIRModuleIfEnabled(codeGenContext, irModule);
 

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -255,11 +255,9 @@ struct CoverageInstrumenter
             if (layout.binding >= 0)
                 fprintf(f, ",\n    \"binding\": %lld", (long long)layout.binding);
             if (layout.descriptorSet >= 0)
-                fprintf(f, ",\n    \"descriptor_set\": %lld",
-                        (long long)layout.descriptorSet);
+                fprintf(f, ",\n    \"descriptor_set\": %lld", (long long)layout.descriptorSet);
             if (layout.uavRegister >= 0)
-                fprintf(f, ",\n    \"uav_register\": %lld",
-                        (long long)layout.uavRegister);
+                fprintf(f, ",\n    \"uav_register\": %lld", (long long)layout.uavRegister);
         }
         fprintf(f, "\n  },\n");
 
@@ -267,9 +265,7 @@ struct CoverageInstrumenter
         for (Index i = 0; i < orderedKeys.getCount(); ++i)
         {
             auto const& key = orderedKeys[i];
-            fprintf(f, "%s\n    {\"index\": %lld, \"file\": \"",
-                    i == 0 ? "" : ",",
-                    (long long)i);
+            fprintf(f, "%s\n    {\"index\": %lld, \"file\": \"", i == 0 ? "" : ",", (long long)i);
             for (auto c : key.file)
             {
                 if (c == '\\' || c == '"')
@@ -298,16 +294,13 @@ static IRGlobalParam* synthesizeCoverageBuffer(IRModule* module)
 
     auto uintType = builder.getUIntType();
     IRInst* elemOperand = uintType;
-    auto bufferType = (IRType*)
-        builder.getType(kIROp_HLSLRWStructuredBufferType, 1, &elemOperand);
+    auto bufferType = (IRType*)builder.getType(kIROp_HLSLRWStructuredBufferType, 1, &elemOperand);
 
     auto param = builder.createGlobalParam(bufferType);
     builder.addNameHintDecoration(param, UnownedStringSlice(kCoverageBufferName));
 
     IRTypeLayout::Builder typeLayoutBuilder(&builder);
-    typeLayoutBuilder.addResourceUsage(
-        LayoutResourceKind::DescriptorTableSlot,
-        LayoutSize(1));
+    typeLayoutBuilder.addResourceUsage(LayoutResourceKind::DescriptorTableSlot, LayoutSize(1));
     auto typeLayout = typeLayoutBuilder.build();
 
     IRVarLayout::Builder varLayoutBuilder(&builder, typeLayout);
@@ -360,19 +353,13 @@ void instrumentCoverage(IRModule* module, DiagnosticSink* /*sink*/, bool enabled
 
     // Always announce the counter count on stderr — the host needs
     // this to allocate the counter buffer at the right size.
-    fprintf(
-        stderr,
-        "slang-coverage-info: counters=%lld\n",
-        (long long)instrumenter.counterCount());
+    fprintf(stderr, "slang-coverage-info: counters=%lld\n", (long long)instrumenter.counterCount());
 
     if (auto path = getenv("SLANG_COVERAGE_MANIFEST_PATH"))
     {
         if (!instrumenter.writeJsonManifest(path))
         {
-            fprintf(
-                stderr,
-                "slang-coverage-info: failed to write manifest to '%s'\n",
-                path);
+            fprintf(stderr, "slang-coverage-info: failed to write manifest to '%s'\n", path);
         }
         else
         {

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -321,11 +321,45 @@ struct CoverageInstrumenter
         {
             auto const& key = orderedKeys[i];
             fprintf(f, "%s\n    {\"index\": %lld, \"file\": \"", i == 0 ? "" : ",", (long long)i);
+            // JSON requires escaping backslash, double-quote, and all
+            // control characters (U+0000..U+001F). Source file paths can
+            // come from user `#line` directives or synthetic locations
+            // and may legally contain tabs, newlines, etc. — emit
+            // specific escape sequences where defined and `\uXXXX`
+            // elsewhere to keep the manifest parseable.
             for (auto c : key.file)
             {
-                if (c == '\\' || c == '"')
-                    fputc('\\', f);
-                fputc(c, f);
+                unsigned char uc = (unsigned char)c;
+                switch (uc)
+                {
+                case '\\':
+                    fputs("\\\\", f);
+                    break;
+                case '"':
+                    fputs("\\\"", f);
+                    break;
+                case '\b':
+                    fputs("\\b", f);
+                    break;
+                case '\f':
+                    fputs("\\f", f);
+                    break;
+                case '\n':
+                    fputs("\\n", f);
+                    break;
+                case '\r':
+                    fputs("\\r", f);
+                    break;
+                case '\t':
+                    fputs("\\t", f);
+                    break;
+                default:
+                    if (uc < 0x20)
+                        fprintf(f, "\\u%04x", (unsigned)uc);
+                    else
+                        fputc((int)uc, f);
+                    break;
+                }
             }
             fprintf(f, "\", \"line\": %lld}", (long long)key.line);
         }

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -12,14 +12,13 @@ namespace Slang
 namespace
 {
 
+// The coverage buffer is synthesized as a global-scope `VarDecl` at
+// AST-check time by `maybeSynthesizeCoverageBufferDecl` (see
+// slang-check-synthesize-coverage.cpp). By the time this IR pass
+// runs, the buffer is a normal `IRGlobalParam` indistinguishable
+// from a user-declared one; this pass only locates it by name and
+// rewrites `IncrementCoverageCounter` placeholders against it.
 static const char kCoverageBufferName[] = "__slang_coverage";
-
-// Reserved register space + binding for the synthesized coverage
-// buffer. Chosen to sit high enough that it is unlikely to collide
-// with user resources. Will become configurable once the feature
-// moves out of prototype status.
-static const UInt kCoverageReservedSpace = 31;
-static const UInt kCoverageReservedBinding = 0;
 
 // Key that identifies a counter slot in the host-facing manifest:
 // one slot per (file, line) pair. Multiple placeholder UIDs that
@@ -92,34 +91,6 @@ static IRGlobalParam* findCoverageBuffer(IRModule* module, DiagnosticSink* sink)
     return nullptr;
 }
 
-// Return true if any existing module-scope global parameter already
-// occupies the reserved `(space, binding)` we would assign to the
-// synthesized coverage buffer. Used to diagnose before synthesis
-// rather than aliasing a user resource silently.
-static bool hasResourceAtReservedBinding(IRModule* module)
-{
-    for (auto inst : module->getGlobalInsts())
-    {
-        auto param = as<IRGlobalParam>(inst);
-        if (!param)
-            continue;
-        auto layoutDecor = param->findDecoration<IRLayoutDecoration>();
-        if (!layoutDecor)
-            continue;
-        auto varLayout = as<IRVarLayout>(layoutDecor->getLayout());
-        if (!varLayout)
-            continue;
-        auto spaceAttr = varLayout->findOffsetAttr(LayoutResourceKind::RegisterSpace);
-        auto bindingAttr = varLayout->findOffsetAttr(LayoutResourceKind::DescriptorTableSlot);
-        if (!spaceAttr || !bindingAttr)
-            continue;
-        if ((UInt)spaceAttr->getOffset() == kCoverageReservedSpace &&
-            (UInt)bindingAttr->getOffset() == kCoverageReservedBinding)
-            return true;
-    }
-    return false;
-}
-
 // Collect every IncrementCoverageCounter placeholder in the module
 // across all functions. The pass is designed to be a simple, O(n)
 // linear sweep — placeholders are opaque to the optimizer so if any
@@ -153,13 +124,12 @@ struct CoverageInstrumenter
     IRType* uintType;
     IRType* uintPtrType;
     IRType* intType;
-    bool isSynthesized;
 
     Dictionary<CoverageKey, UInt, CoverageKeyHasher> keyToIndex;
     List<CoverageKey> orderedKeys;
 
-    CoverageInstrumenter(IRModule* m, IRGlobalParam* buf, bool synthesized)
-        : module(m), coverageBuffer(buf), isSynthesized(synthesized)
+    CoverageInstrumenter(IRModule* m, IRGlobalParam* buf)
+        : module(m), coverageBuffer(buf)
     {
         IRBuilder tmpBuilder(module);
         uintType = tmpBuilder.getUIntType();
@@ -297,12 +267,16 @@ struct CoverageInstrumenter
         fprintf(f, "  \"version\": 1,\n");
         fprintf(f, "  \"counters\": %lld,\n", (long long)orderedKeys.getCount());
 
+        // The coverage buffer is always reflection-visible:
+        // AST-synthesized when `-trace-coverage` is on, or user-
+        // declared by the shader itself. The binding reported below
+        // is whatever the parameter-binding pass assigned; hosts
+        // use this to bind the counter UAV at runtime.
         auto layout = readLayout();
         fprintf(f, "  \"buffer\": {\n");
         fprintf(f, "    \"name\": \"%s\",\n", kCoverageBufferName);
         fprintf(f, "    \"element_type\": \"uint32\",\n");
-        fprintf(f, "    \"element_stride\": 4,\n");
-        fprintf(f, "    \"synthesized\": %s", isSynthesized ? "true" : "false");
+        fprintf(f, "    \"element_stride\": 4");
         if (layout.hasLayout)
         {
             if (layout.space >= 0)
@@ -372,50 +346,6 @@ struct CoverageInstrumenter
     Index counterCount() const { return orderedKeys.getCount(); }
 };
 
-// Synthesize an implicit `RWStructuredBuffer<uint> __slang_coverage`
-// global parameter with a reserved layout. Follows the pattern in
-// `lowerDynamicResourceHeap` — we manually build an IRTypeLayout /
-// IRVarLayout so the buffer survives later uniform-collection passes.
-// Emits a warning if any existing user resource already occupies the
-// reserved binding; synthesis proceeds anyway but aliasing risk is
-// documented to the user.
-static IRGlobalParam* synthesizeCoverageBuffer(IRModule* module, DiagnosticSink* sink)
-{
-    if (hasResourceAtReservedBinding(module) && sink)
-    {
-        sink->diagnoseRaw(
-            Severity::Warning,
-            UnownedStringSlice("-trace-coverage: an existing resource occupies the reserved "
-                               "binding (space=31, binding=0); coverage buffer may alias it. "
-                               "Declare `RWStructuredBuffer<uint> __slang_coverage` explicitly "
-                               "at a conflict-free binding to avoid this."));
-    }
-
-    IRBuilder builder(module);
-    builder.setInsertInto(module->getModuleInst());
-
-    auto uintType = builder.getUIntType();
-    IRInst* elemOperand = uintType;
-    auto bufferType = (IRType*)builder.getType(kIROp_HLSLRWStructuredBufferType, 1, &elemOperand);
-
-    auto param = builder.createGlobalParam(bufferType);
-    builder.addNameHintDecoration(param, UnownedStringSlice(kCoverageBufferName));
-
-    IRTypeLayout::Builder typeLayoutBuilder(&builder);
-    typeLayoutBuilder.addResourceUsage(LayoutResourceKind::DescriptorTableSlot, LayoutSize(1));
-    auto typeLayout = typeLayoutBuilder.build();
-
-    IRVarLayout::Builder varLayoutBuilder(&builder, typeLayout);
-    varLayoutBuilder.findOrAddResourceInfo(LayoutResourceKind::RegisterSpace)->offset =
-        kCoverageReservedSpace;
-    varLayoutBuilder.findOrAddResourceInfo(LayoutResourceKind::DescriptorTableSlot)->offset =
-        kCoverageReservedBinding;
-    auto varLayout = varLayoutBuilder.build();
-    builder.addLayoutDecoration(param, varLayout);
-
-    return param;
-}
-
 // Strip any leftover IncrementCoverageCounter placeholders from the
 // module. Called when the pass is a no-op (neither flag nor user
 // buffer) so the backend emitter never sees the opaque op.
@@ -441,17 +371,19 @@ void instrumentCoverage(IRModule* module, DiagnosticSink* sink, bool enabled)
         return;
     }
 
-    // Flag is on. Reuse a user-declared buffer if present and well-
-    // typed; otherwise synthesize one.
+    // Flag is on. The AST synthesizer (see
+    // slang-check-synthesize-coverage.cpp) has already injected the
+    // `__slang_coverage` decl unless the user declared it themselves,
+    // so `findCoverageBuffer` always returns a valid buffer at this
+    // point. If it doesn't, some earlier phase has failed; bail.
     auto buffer = findCoverageBuffer(module, sink);
-    bool synthesized = false;
     if (!buffer)
     {
-        buffer = synthesizeCoverageBuffer(module, sink);
-        synthesized = true;
+        stripPlaceholders(module);
+        return;
     }
 
-    CoverageInstrumenter instrumenter(module, buffer, synthesized);
+    CoverageInstrumenter instrumenter(module, buffer);
     instrumenter.run();
 
     // Always announce the counter count on stderr — the host needs

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -1,5 +1,6 @@
 #include "slang-ir-coverage-instrument.h"
 
+#include "compiler-core/slang-diagnostic-sink.h"
 #include "slang-ir-insts.h"
 #include "slang-ir.h"
 
@@ -43,10 +44,13 @@ struct CoverageKeyHasher
     }
 };
 
-// Locate the module-scope RWStructuredBuffer<uint> named
-// `__slang_coverage`, if any. Returns nullptr when the user has not
-// declared the buffer themselves.
-static IRGlobalParam* findCoverageBuffer(IRModule* module)
+// Locate the module-scope `RWStructuredBuffer<uint> __slang_coverage`
+// declared by the user, if any. Returns nullptr when no such buffer
+// exists. If a buffer with the reserved name is present but has the
+// wrong type (not a `RWStructuredBuffer<uint>`), that is a user error:
+// diagnose via `sink` and treat it as absent so the pass is a no-op
+// rather than generating invalid IR.
+static IRGlobalParam* findCoverageBuffer(IRModule* module, DiagnosticSink* sink)
 {
     for (auto inst : module->getGlobalInsts())
     {
@@ -58,11 +62,62 @@ static IRGlobalParam* findCoverageBuffer(IRModule* module)
             continue;
         if (nameHint->getName() != UnownedStringSlice(kCoverageBufferName))
             continue;
-        if (!as<IRHLSLRWStructuredBufferType>(param->getDataType()))
-            continue;
+        auto bufferType = as<IRHLSLRWStructuredBufferType>(param->getDataType());
+        if (!bufferType)
+        {
+            if (sink)
+                sink->diagnoseRaw(
+                    Severity::Warning,
+                    UnownedStringSlice("'__slang_coverage' is reserved for -trace-coverage; "
+                                       "declaration must be 'RWStructuredBuffer<uint>'. "
+                                       "Ignoring and synthesizing the coverage buffer."));
+            return nullptr;
+        }
+        // Validate the element type is specifically `uint`. Anything
+        // else (float, int, struct) would produce bad IR once we emit
+        // atomic-add on the slot pointer.
+        auto elementType = as<IRBasicType>(bufferType->getElementType());
+        if (!elementType || elementType->getBaseType() != BaseType::UInt)
+        {
+            if (sink)
+                sink->diagnoseRaw(
+                    Severity::Warning,
+                    UnownedStringSlice("'__slang_coverage' element type must be 'uint' for "
+                                       "-trace-coverage. Ignoring and synthesizing the "
+                                       "coverage buffer."));
+            return nullptr;
+        }
         return param;
     }
     return nullptr;
+}
+
+// Return true if any existing module-scope global parameter already
+// occupies the reserved `(space, binding)` we would assign to the
+// synthesized coverage buffer. Used to diagnose before synthesis
+// rather than aliasing a user resource silently.
+static bool hasResourceAtReservedBinding(IRModule* module)
+{
+    for (auto inst : module->getGlobalInsts())
+    {
+        auto param = as<IRGlobalParam>(inst);
+        if (!param)
+            continue;
+        auto layoutDecor = param->findDecoration<IRLayoutDecoration>();
+        if (!layoutDecor)
+            continue;
+        auto varLayout = as<IRVarLayout>(layoutDecor->getLayout());
+        if (!varLayout)
+            continue;
+        auto spaceAttr = varLayout->findOffsetAttr(LayoutResourceKind::RegisterSpace);
+        auto bindingAttr = varLayout->findOffsetAttr(LayoutResourceKind::DescriptorTableSlot);
+        if (!spaceAttr || !bindingAttr)
+            continue;
+        if ((UInt)spaceAttr->getOffset() == kCoverageReservedSpace &&
+            (UInt)bindingAttr->getOffset() == kCoverageReservedBinding)
+            return true;
+    }
+    return false;
 }
 
 // Collect every IncrementCoverageCounter placeholder in the module
@@ -287,8 +342,21 @@ struct CoverageInstrumenter
 // global parameter with a reserved layout. Follows the pattern in
 // `lowerDynamicResourceHeap` — we manually build an IRTypeLayout /
 // IRVarLayout so the buffer survives later uniform-collection passes.
-static IRGlobalParam* synthesizeCoverageBuffer(IRModule* module)
+// Emits a warning if any existing user resource already occupies the
+// reserved binding; synthesis proceeds anyway but aliasing risk is
+// documented to the user.
+static IRGlobalParam* synthesizeCoverageBuffer(IRModule* module, DiagnosticSink* sink)
 {
+    if (hasResourceAtReservedBinding(module) && sink)
+    {
+        sink->diagnoseRaw(
+            Severity::Warning,
+            UnownedStringSlice("-trace-coverage: an existing resource occupies the reserved "
+                               "binding (space=31, binding=0); coverage buffer may alias it. "
+                               "Declare `RWStructuredBuffer<uint> __slang_coverage` explicitly "
+                               "at a conflict-free binding to avoid this."));
+    }
+
     IRBuilder builder(module);
     builder.setInsertInto(module->getModuleInst());
 
@@ -327,24 +395,25 @@ static void stripPlaceholders(IRModule* module)
 
 } // anonymous namespace
 
-void instrumentCoverage(IRModule* module, DiagnosticSink* /*sink*/, bool enabled)
+void instrumentCoverage(IRModule* module, DiagnosticSink* sink, bool enabled)
 {
-    auto buffer = findCoverageBuffer(module);
-    bool synthesized = false;
-
-    // With the flag off and no user buffer: any placeholders that got
-    // emitted (shouldn't normally happen) are dropped and we return.
-    if (!enabled && !buffer)
+    // With the flag off: guarantee a true no-op. Any placeholders that
+    // might have made it in via a stale cached module are dropped so
+    // the backend emitter never sees them, but we do not print any
+    // info messages or write a manifest.
+    if (!enabled)
     {
         stripPlaceholders(module);
         return;
     }
 
-    // With the flag on, synthesize the buffer when the user didn't
-    // supply one themselves.
-    if (enabled && !buffer)
+    // Flag is on. Reuse a user-declared buffer if present and well-
+    // typed; otherwise synthesize one.
+    auto buffer = findCoverageBuffer(module, sink);
+    bool synthesized = false;
+    if (!buffer)
     {
-        buffer = synthesizeCoverageBuffer(module);
+        buffer = synthesizeCoverageBuffer(module, sink);
         synthesized = true;
     }
 

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -1,0 +1,387 @@
+#include "slang-ir-coverage-instrument.h"
+
+#include "slang-ir-insts.h"
+#include "slang-ir.h"
+
+#include <cstdio>
+
+namespace Slang
+{
+
+namespace
+{
+
+static const char kCoverageBufferName[] = "__slang_coverage";
+
+// Reserved register space + binding for the synthesized coverage
+// buffer. Chosen to sit high enough that it is unlikely to collide
+// with user resources. Will become configurable once the feature
+// moves out of prototype status.
+static const UInt kCoverageReservedSpace = 31;
+static const UInt kCoverageReservedBinding = 0;
+
+// Key that identifies a counter slot in the host-facing manifest:
+// one slot per (file, line) pair. Multiple placeholder UIDs that
+// share the same (file, line) alias onto the same slot so that LCOV
+// output matches gcov semantics.
+struct CoverageKey
+{
+    UnownedStringSlice file;
+    IRIntegerValue line;
+
+    bool operator==(CoverageKey const& other) const
+    {
+        return file == other.file && line == other.line;
+    }
+};
+
+struct CoverageKeyHasher
+{
+    HashCode operator()(CoverageKey const& key) const
+    {
+        return combineHash(getHashCode(key.file), getHashCode(key.line));
+    }
+};
+
+// Locate the module-scope RWStructuredBuffer<uint> named
+// `__slang_coverage`, if any. Returns nullptr when the user has not
+// declared the buffer themselves.
+static IRGlobalParam* findCoverageBuffer(IRModule* module)
+{
+    for (auto inst : module->getGlobalInsts())
+    {
+        auto param = as<IRGlobalParam>(inst);
+        if (!param)
+            continue;
+        auto nameHint = param->findDecoration<IRNameHintDecoration>();
+        if (!nameHint)
+            continue;
+        if (nameHint->getName() != UnownedStringSlice(kCoverageBufferName))
+            continue;
+        if (!as<IRHLSLRWStructuredBufferType>(param->getDataType()))
+            continue;
+        return param;
+    }
+    return nullptr;
+}
+
+// Collect every IncrementCoverageCounter placeholder in the module
+// across all functions. The pass is designed to be a simple, O(n)
+// linear sweep — placeholders are opaque to the optimizer so if any
+// survived they're all still present at this point.
+static void collectPlaceholders(IRModule* module, List<IRInst*>& out)
+{
+    auto visitFunc = [&](IRFunc* func)
+    {
+        for (auto block : func->getBlocks())
+            for (auto inst = block->getFirstInst(); inst; inst = inst->getNextInst())
+                if (inst->getOp() == kIROp_IncrementCoverageCounter)
+                    out.add(inst);
+    };
+
+    for (auto inst : module->getGlobalInsts())
+    {
+        if (auto func = as<IRFunc>(inst))
+            visitFunc(func);
+        else if (auto generic = as<IRGeneric>(inst))
+        {
+            if (auto inner = as<IRFunc>(findGenericReturnVal(generic)))
+                visitFunc(inner);
+        }
+    }
+}
+
+struct CoverageInstrumenter
+{
+    IRModule* module;
+    IRGlobalParam* coverageBuffer;
+    IRType* uintType;
+    IRType* uintPtrType;
+    IRType* intType;
+    bool isSynthesized;
+
+    Dictionary<CoverageKey, UInt, CoverageKeyHasher> keyToIndex;
+    List<CoverageKey> orderedKeys;
+
+    CoverageInstrumenter(IRModule* m, IRGlobalParam* buf, bool synthesized)
+        : module(m), coverageBuffer(buf), isSynthesized(synthesized)
+    {
+        IRBuilder tmpBuilder(module);
+        uintType = tmpBuilder.getUIntType();
+        uintPtrType = tmpBuilder.getPtrType(uintType);
+        intType = tmpBuilder.getIntType();
+    }
+
+    struct BufferLayoutInfo
+    {
+        bool hasLayout = false;
+        IRIntegerValue space = -1;
+        IRIntegerValue binding = -1;
+        IRIntegerValue descriptorSet = -1;
+        IRIntegerValue uavRegister = -1;
+    };
+
+    BufferLayoutInfo readLayout() const
+    {
+        BufferLayoutInfo info;
+        auto layoutDecor = coverageBuffer->findDecoration<IRLayoutDecoration>();
+        if (!layoutDecor)
+            return info;
+        auto varLayout = as<IRVarLayout>(layoutDecor->getLayout());
+        if (!varLayout)
+            return info;
+        info.hasLayout = true;
+        if (auto a = varLayout->findOffsetAttr(LayoutResourceKind::RegisterSpace))
+            info.space = (IRIntegerValue)a->getOffset();
+        if (auto a = varLayout->findOffsetAttr(LayoutResourceKind::DescriptorTableSlot))
+        {
+            info.binding = (IRIntegerValue)a->getOffset();
+            info.descriptorSet = info.space;
+        }
+        if (auto a = varLayout->findOffsetAttr(LayoutResourceKind::UnorderedAccess))
+            info.uavRegister = (IRIntegerValue)a->getOffset();
+        return info;
+    }
+
+    UInt getOrAssignCounter(CoverageKey const& key)
+    {
+        UInt idx = 0;
+        if (keyToIndex.tryGetValue(key, idx))
+            return idx;
+        idx = (UInt)orderedKeys.getCount();
+        keyToIndex[key] = idx;
+        orderedKeys.add(key);
+        return idx;
+    }
+
+    // Replace an IncrementCoverageCounter placeholder with the actual
+    // counter write on `coverageBuffer[counterIdx]`.
+    void lowerPlaceholder(IRInst* placeholder)
+    {
+        auto loc = placeholder->findDecoration<IRDebugLocationDecoration>();
+        if (!loc)
+        {
+            placeholder->removeAndDeallocate();
+            return;
+        }
+        auto debugSource = as<IRDebugSource>(loc->getSource());
+        if (!debugSource)
+        {
+            placeholder->removeAndDeallocate();
+            return;
+        }
+        auto fileLit = as<IRStringLit>(debugSource->getFileName());
+        if (!fileLit)
+        {
+            placeholder->removeAndDeallocate();
+            return;
+        }
+
+        CoverageKey key;
+        key.file = fileLit->getStringSlice();
+        key.line = getIntVal(loc->getLine());
+        UInt counterIdx = getOrAssignCounter(key);
+
+        IRBuilder builder(module);
+        builder.setInsertBefore(placeholder);
+
+        IRInst* getElemArgs[] = {
+            coverageBuffer,
+            builder.getIntValue(intType, (IRIntegerValue)counterIdx),
+        };
+        IRInst* slotPtr = builder.emitIntrinsicInst(
+            uintPtrType,
+            kIROp_RWStructuredBufferGetElementPtr,
+            2,
+            getElemArgs);
+
+        // Emit `AtomicAdd(slotPtr, 1, relaxed)` — lowered by each
+        // backend emitter to its native atomic-increment idiom
+        // (InterlockedAdd on HLSL, atomicAdd on GLSL, OpAtomicIAdd on
+        // SPIR-V, etc.). Correct under GPU concurrency.
+        IRInst* atomicArgs[] = {
+            slotPtr,
+            builder.getIntValue(uintType, 1),
+            builder.getIntValue(intType, (IRIntegerValue)kIRMemoryOrder_Relaxed),
+        };
+        builder.emitIntrinsicInst(uintType, kIROp_AtomicAdd, 3, atomicArgs);
+
+        placeholder->removeAndDeallocate();
+    }
+
+    void run()
+    {
+        List<IRInst*> placeholders;
+        collectPlaceholders(module, placeholders);
+        for (auto ph : placeholders)
+            lowerPlaceholder(ph);
+    }
+
+    void printStderrManifest()
+    {
+        for (Index i = 0; i < orderedKeys.getCount(); ++i)
+        {
+            auto const& key = orderedKeys[i];
+            fprintf(
+                stderr,
+                "slang-coverage-manifest: %u,%.*s,%lld\n",
+                (unsigned)i,
+                (int)key.file.getLength(),
+                key.file.begin(),
+                (long long)key.line);
+        }
+    }
+
+    // Write a minimal JSON manifest describing the counter layout.
+    bool writeJsonManifest(char const* path)
+    {
+        FILE* f = fopen(path, "w");
+        if (!f)
+            return false;
+        fprintf(f, "{\n");
+        fprintf(f, "  \"version\": 1,\n");
+        fprintf(f, "  \"counters\": %lld,\n", (long long)orderedKeys.getCount());
+
+        auto layout = readLayout();
+        fprintf(f, "  \"buffer\": {\n");
+        fprintf(f, "    \"name\": \"%s\",\n", kCoverageBufferName);
+        fprintf(f, "    \"element_type\": \"uint32\",\n");
+        fprintf(f, "    \"element_stride\": 4,\n");
+        fprintf(f, "    \"synthesized\": %s", isSynthesized ? "true" : "false");
+        if (layout.hasLayout)
+        {
+            if (layout.space >= 0)
+                fprintf(f, ",\n    \"space\": %lld", (long long)layout.space);
+            if (layout.binding >= 0)
+                fprintf(f, ",\n    \"binding\": %lld", (long long)layout.binding);
+            if (layout.descriptorSet >= 0)
+                fprintf(f, ",\n    \"descriptor_set\": %lld",
+                        (long long)layout.descriptorSet);
+            if (layout.uavRegister >= 0)
+                fprintf(f, ",\n    \"uav_register\": %lld",
+                        (long long)layout.uavRegister);
+        }
+        fprintf(f, "\n  },\n");
+
+        fprintf(f, "  \"entries\": [");
+        for (Index i = 0; i < orderedKeys.getCount(); ++i)
+        {
+            auto const& key = orderedKeys[i];
+            fprintf(f, "%s\n    {\"index\": %lld, \"file\": \"",
+                    i == 0 ? "" : ",",
+                    (long long)i);
+            for (auto c : key.file)
+            {
+                if (c == '\\' || c == '"')
+                    fputc('\\', f);
+                fputc(c, f);
+            }
+            fprintf(f, "\", \"line\": %lld}", (long long)key.line);
+        }
+        fprintf(f, "\n  ]\n");
+        fprintf(f, "}\n");
+        fclose(f);
+        return true;
+    }
+
+    Index counterCount() const { return orderedKeys.getCount(); }
+};
+
+// Synthesize an implicit `RWStructuredBuffer<uint> __slang_coverage`
+// global parameter with a reserved layout. Follows the pattern in
+// `lowerDynamicResourceHeap` — we manually build an IRTypeLayout /
+// IRVarLayout so the buffer survives later uniform-collection passes.
+static IRGlobalParam* synthesizeCoverageBuffer(IRModule* module)
+{
+    IRBuilder builder(module);
+    builder.setInsertInto(module->getModuleInst());
+
+    auto uintType = builder.getUIntType();
+    IRInst* elemOperand = uintType;
+    auto bufferType = (IRType*)
+        builder.getType(kIROp_HLSLRWStructuredBufferType, 1, &elemOperand);
+
+    auto param = builder.createGlobalParam(bufferType);
+    builder.addNameHintDecoration(param, UnownedStringSlice(kCoverageBufferName));
+
+    IRTypeLayout::Builder typeLayoutBuilder(&builder);
+    typeLayoutBuilder.addResourceUsage(
+        LayoutResourceKind::DescriptorTableSlot,
+        LayoutSize(1));
+    auto typeLayout = typeLayoutBuilder.build();
+
+    IRVarLayout::Builder varLayoutBuilder(&builder, typeLayout);
+    varLayoutBuilder.findOrAddResourceInfo(LayoutResourceKind::RegisterSpace)->offset =
+        kCoverageReservedSpace;
+    varLayoutBuilder.findOrAddResourceInfo(LayoutResourceKind::DescriptorTableSlot)->offset =
+        kCoverageReservedBinding;
+    auto varLayout = varLayoutBuilder.build();
+    builder.addLayoutDecoration(param, varLayout);
+
+    return param;
+}
+
+// Strip any leftover IncrementCoverageCounter placeholders from the
+// module. Called when the pass is a no-op (neither flag nor user
+// buffer) so the backend emitter never sees the opaque op.
+static void stripPlaceholders(IRModule* module)
+{
+    List<IRInst*> placeholders;
+    collectPlaceholders(module, placeholders);
+    for (auto ph : placeholders)
+        ph->removeAndDeallocate();
+}
+
+} // anonymous namespace
+
+void instrumentCoverage(IRModule* module, DiagnosticSink* /*sink*/, bool enabled)
+{
+    auto buffer = findCoverageBuffer(module);
+    bool synthesized = false;
+
+    // With the flag off and no user buffer: any placeholders that got
+    // emitted (shouldn't normally happen) are dropped and we return.
+    if (!enabled && !buffer)
+    {
+        stripPlaceholders(module);
+        return;
+    }
+
+    // With the flag on, synthesize the buffer when the user didn't
+    // supply one themselves.
+    if (enabled && !buffer)
+    {
+        buffer = synthesizeCoverageBuffer(module);
+        synthesized = true;
+    }
+
+    CoverageInstrumenter instrumenter(module, buffer, synthesized);
+    instrumenter.run();
+
+    // Always announce the counter count on stderr — the host needs
+    // this to allocate the counter buffer at the right size.
+    fprintf(
+        stderr,
+        "slang-coverage-info: counters=%lld\n",
+        (long long)instrumenter.counterCount());
+
+    if (auto path = getenv("SLANG_COVERAGE_MANIFEST_PATH"))
+    {
+        if (!instrumenter.writeJsonManifest(path))
+        {
+            fprintf(
+                stderr,
+                "slang-coverage-info: failed to write manifest to '%s'\n",
+                path);
+        }
+        else
+        {
+            fprintf(stderr, "slang-coverage-info: manifest written to '%s'\n", path);
+        }
+    }
+
+    if (getenv("SLANG_COVERAGE_DUMP_MANIFEST"))
+        instrumenter.printStderrManifest();
+}
+
+} // namespace Slang

--- a/source/slang/slang-ir-coverage-instrument.h
+++ b/source/slang/slang-ir-coverage-instrument.h
@@ -1,0 +1,31 @@
+#ifndef SLANG_IR_COVERAGE_INSTRUMENT_H
+#define SLANG_IR_COVERAGE_INSTRUMENT_H
+
+namespace Slang
+{
+struct IRModule;
+class DiagnosticSink;
+
+// Prototype shader coverage instrumentation pass.
+//
+// When `enabled` is true, the pass ensures there is a module-scope
+// `RWStructuredBuffer<uint> __slang_coverage` — either one declared by
+// the user or a synthesized one bound at a reserved space/binding.
+// For every basic block whose first source-bearing instruction has an
+// IRDebugLine or IRDebugLocationDecoration, the pass injects an
+// increment into a counter slot indexed by a deduplicated (file, line)
+// key.
+//
+// When `enabled` is false the pass still preserves the pre-existing
+// zero-config contract: if the user has declared `__slang_coverage`
+// explicitly, instrument it; otherwise no-op.
+//
+// A counter->source manifest is printed to stderr when the
+// `SLANG_COVERAGE_DUMP_MANIFEST` environment variable is set, in the
+// form:
+//     slang-coverage-manifest: <index>,<file>,<line>
+void instrumentCoverage(IRModule* module, DiagnosticSink* sink, bool enabled);
+
+} // namespace Slang
+
+#endif // SLANG_IR_COVERAGE_INSTRUMENT_H

--- a/source/slang/slang-ir-insts-stable-names.lua
+++ b/source/slang/slang-ir-insts-stable-names.lua
@@ -825,5 +825,6 @@ return {
 	["Type.Conditional"] = 849,
 	["getConditionalValue"] = 850,
 	["makeConditionalValue"] = 851,
-  ["SpecializeExistentialsInType"] = 852
+	["SpecializeExistentialsInType"] = 852,
+	["IncrementCoverageCounter"] = 853,
 }

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -3499,6 +3499,10 @@ $(type_info.return_type) $(type_info.method_name)(
         IRInst* col,
         IRInst* argIndex = nullptr);
     IRInst* emitDebugValue(IRInst* debugVar, IRInst* debugValue);
+    // Emit an IncrementCoverageCounter(uid) placeholder. The coverage
+    // instrumentation IR pass later rewrites each occurrence into an
+    // atomic add on a synthesized counter buffer indexed by `uid`.
+    IRInst* emitIncrementCoverageCounter(IRIntegerValue uid);
     IRInst* emitDebugInlinedAt(
         IRInst* line,
         IRInst* col,

--- a/source/slang/slang-ir-insts.lua
+++ b/source/slang/slang-ir-insts.lua
@@ -1096,6 +1096,14 @@ local insts = {
 			{ atomicDec = { operands = { { "ptr" } } } },
 		},
 	},
+	-- Placeholder emitted at AST lowering when `-trace-coverage` is on.
+	-- A single integer `uid` identifies the statement the placeholder
+	-- was produced for. The coverage-instrument IR pass later rewrites
+	-- each occurrence into an atomic add on a synthesized counter
+	-- buffer, indexed by uid, and harvests the uid -> SourceLoc mapping
+	-- for the compile manifest. Inherent side-effect semantics keep the
+	-- optimizer from deleting or hoisting the placeholder.
+	{ IncrementCoverageCounter = { operands = { { "uid" } } } },
 	-- Produced and removed during backward auto-diff pass as a temporary placeholder representing the
 	-- currently accumulated derivative to pass to some dOut argument in a nested call.
 	{ LoadReverseGradient = { operands = { { "value" } } } },

--- a/source/slang/slang-ir-insts.lua
+++ b/source/slang/slang-ir-insts.lua
@@ -1097,12 +1097,14 @@ local insts = {
 		},
 	},
 	-- Placeholder emitted at AST lowering when `-trace-coverage` is on.
-	-- A single integer `uid` identifies the statement the placeholder
-	-- was produced for. The coverage-instrument IR pass later rewrites
-	-- each occurrence into an atomic add on a synthesized counter
-	-- buffer, indexed by uid, and harvests the uid -> SourceLoc mapping
-	-- for the compile manifest. Inherent side-effect semantics keep the
-	-- optimizer from deleting or hoisting the placeholder.
+	-- The integer `uid` identifies the statement the placeholder was
+	-- produced for, and the instruction carries an
+	-- IRDebugLocationDecoration with its (file, line). The
+	-- coverage-instrument IR pass later rewrites each occurrence into
+	-- an atomic add on a synthesized counter buffer; the counter index
+	-- is assigned by deduplicating (file, line) keys, so multiple UIDs
+	-- on the same line share a slot. Inherent side-effect semantics
+	-- keep the optimizer from deleting or hoisting the placeholder.
 	{ IncrementCoverageCounter = { operands = { { "uid" } } } },
 	-- Produced and removed during backward auto-diff pass as a temporary placeholder representing the
 	-- currently accumulated derivative to pass to some dOut argument in a nested call.

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3373,6 +3373,12 @@ IRInst* IRBuilder::emitDebugLine(
         getIntValue(getUIntType(), colEnd)};
     return emitIntrinsicInst(getVoidType(), kIROp_DebugLine, 5, args);
 }
+IRInst* IRBuilder::emitIncrementCoverageCounter(IRIntegerValue uid)
+{
+    IRInst* arg = getIntValue(getUIntType(), uid);
+    return emitIntrinsicInst(getVoidType(), kIROp_IncrementCoverageCounter, 1, &arg);
+}
+
 IRInst* IRBuilder::emitDebugVar(
     IRType* type,
     IRInst* source,

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -614,6 +614,13 @@ struct IRGenContext
 
     DebugInfoLevel debugInfoLevel = DebugInfoLevel::None;
 
+    // Prototype shader-coverage instrumentation. When true, each
+    // lowered statement is preceded by an IncrementCoverageCounter
+    // placeholder whose uid increments from 0. A later IR pass rewrites
+    // the placeholders into counter writes on a synthesized buffer.
+    bool traceCoverage = false;
+    IRIntegerValue nextCoverageUID = 0;
+
     // The element index if we are inside an `expand` expression.
     IRInst* expandIndex = nullptr;
 
@@ -8964,6 +8971,22 @@ void maybeAddDebugLocationDecoration(IRGenContext* context, IRInst* inst)
         ->addDebugLocationDecoration(inst, debugSourceInst, humaneLoc.line, humaneLoc.column);
 }
 
+// Unconditional variant used by the coverage instrumentation path:
+// attaches an IRDebugLocationDecoration even when `-g` is off, because
+// coverage needs the source mapping regardless of user debug settings.
+void addCoverageLocationDecoration(IRGenContext* context, IRInst* inst)
+{
+    IRInst* debugSourceInst = getOrEmitDebugSource(context, inst->sourceLoc);
+    if (!debugSourceInst)
+        return;
+
+    auto sourceManager = context->getLinkage()->getSourceManager();
+    auto humaneLoc = sourceManager->getHumaneLoc(inst->sourceLoc, SourceLocType::Emit);
+
+    context->irBuilder
+        ->addDebugLocationDecoration(inst, debugSourceInst, humaneLoc.line, humaneLoc.column);
+}
+
 void lowerStmt(IRGenContext* context, Stmt* stmt)
 {
     IRBuilderSourceLocRAII sourceLocInfo(context->irBuilder, stmt->loc);
@@ -8974,6 +8997,21 @@ void lowerStmt(IRGenContext* context, Stmt* stmt)
     try
     {
         maybeEmitDebugLine(context, &visitor, stmt, stmt->loc);
+
+        // Emit a coverage-counter placeholder tagged with this
+        // statement's source location, before lowering the statement
+        // itself. The pass in slang-ir-coverage-instrument.cpp later
+        // rewrites these into counter writes. EmptyStmt, blocks, and
+        // other purely structural statements also receive a counter
+        // because they all occupy real source positions — the LCOV
+        // converter aggregates multiple counters per line as needed.
+        if (context->traceCoverage && stmt->loc.isValid() && !as<EmptyStmt>(stmt))
+        {
+            auto counterInst =
+                context->irBuilder->emitIncrementCoverageCounter(context->nextCoverageUID++);
+            addCoverageLocationDecoration(context, counterInst);
+        }
+
         visitor.dispatch(stmt);
     }
     // Don't emit any context message for an explicit `AbortCompilationException`
@@ -14199,6 +14237,8 @@ RefPtr<IRModule> generateIRForTranslationUnit(
 
     context->irBuilder = builder;
     context->debugInfoLevel = compileRequest->getLinkage()->m_optionSet.getDebugInfoLevel();
+    context->traceCoverage =
+        compileRequest->getLinkage()->m_optionSet.getBoolOption(CompilerOptionName::TraceCoverage);
 
     if (translationUnit->getModuleDecl()->findModifier<ExperimentalModuleAttribute>())
     {

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9001,12 +9001,21 @@ void lowerStmt(IRGenContext* context, Stmt* stmt)
         // Emit a coverage-counter placeholder tagged with this
         // statement's source location, before lowering the statement
         // itself. The pass in slang-ir-coverage-instrument.cpp later
-        // rewrites these into counter writes. EmptyStmt, blocks, and
-        // other purely structural statements also receive a counter
-        // because they all occupy real source positions — the LCOV
-        // converter aggregates multiple counters per line as needed.
+        // rewrites these into counter writes.
+        //
+        // Empty statements are skipped because they have no
+        // observable execution; the LCOV converter deduplicates
+        // counters back to `(file, line)` at the IR-pass stage.
+        //
+        // `startBlockIfNeeded` is required because `maybeEmitDebugLine`
+        // may have returned early (e.g. under `-g0`) without opening a
+        // fresh block after a terminator. Without it, a statement that
+        // follows a `break` / `return` could get its coverage counter
+        // inserted into the already-terminated predecessor block,
+        // corrupting the IR.
         if (context->traceCoverage && stmt->loc.isValid() && !as<EmptyStmt>(stmt))
         {
+            visitor.startBlockIfNeeded(stmt);
             auto counterInst =
                 context->irBuilder->emitIncrementCoverageCounter(context->nextCoverageUID++);
             addCoverageLocationDecoration(context, counterInst);

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -539,6 +539,14 @@ void initCommandOptions(CommandOptions& options)
          nullptr,
          "Reports information about checkpoint contexts used for reverse-mode automatic "
          "differentiation."},
+        {OptionKind::TraceCoverage,
+         "-trace-coverage",
+         nullptr,
+         "Prototype: instrument the shader with per-statement execution counters. "
+         "Emits IncrementCoverageCounter placeholders at AST lowering that a later IR "
+         "pass rewrites into counter writes on a synthesized `RWStructuredBuffer<uint> "
+         "__slang_coverage` buffer bound at a reserved space/binding. A sidecar manifest "
+         "(set SLANG_COVERAGE_MANIFEST_PATH) maps counters back to source positions."},
         {OptionKind::ReportDynamicDispatchSites,
          "-report-dynamic-dispatch-sites",
          nullptr,
@@ -2382,6 +2390,7 @@ SlangResult OptionsParser::_parse(int argc, char const* const* argv)
         case OptionKind::ReportPerfBenchmark:
         case OptionKind::ReportCheckpointIntermediates:
         case OptionKind::ReportDynamicDispatchSites:
+        case OptionKind::TraceCoverage:
         case OptionKind::SkipSPIRVValidation:
         case OptionKind::DisableSpecialization:
         case OptionKind::DisableDynamicDispatch:

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -3690,6 +3690,21 @@ SlangResult OptionsParser::_parse(int argc, char const* const* argv)
             }
         }
 
+        // `-trace-coverage` instruments at the Slang IR level and has
+        // no meaning when the user asks for pass-through codegen
+        // (where the downstream compiler sees the original source
+        // directly). Reject the combination rather than silently
+        // producing an uninstrumented shader.
+        if (m_requestImpl->m_passThrough != PassThroughMode::None &&
+            linkage->m_optionSet.getBoolOption(CompilerOptionName::TraceCoverage))
+        {
+            m_sink->diagnoseRaw(
+                Severity::Error,
+                UnownedStringSlice("-trace-coverage cannot be combined with -pass-through; "
+                                   "pass-through bypasses the Slang IR pipeline and cannot "
+                                   "emit coverage instrumentation."));
+        }
+
         // If the user is requesting code generation via pass-through,
         // then any entry points they specify need to have a stage set,
         // because fxc/dxc/glslang don't have a facility for taking

--- a/tests/language-feature/coverage/coverage-basic.slang
+++ b/tests/language-feature/coverage/coverage-basic.slang
@@ -1,0 +1,49 @@
+//TEST:COMPARE_COMPUTE(filecheck-buffer=BUF):-cpu -output-using-type -xslang -trace-coverage
+
+// Verifies that the prototype shader coverage pass activates under
+// `-trace-coverage`. The user also declares their own
+// `RWStructuredBuffer<uint> __slang_coverage`; the compiler binds the
+// synthesized counters to it instead of manufacturing a new buffer.
+//
+// The loop iterates 4 times. Two iterations take the then-branch
+// (i=0, 2) and two take the else-branch (i=1, 3). The `BUF` check is
+// spread across both buffers — outputBuffer first, then __slang_coverage.
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<uint> outputBuffer;
+
+//TEST_INPUT: set __slang_coverage = out ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4)
+RWStructuredBuffer<uint> __slang_coverage;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    uint accum = 0;
+    for (uint i = 0; i < 4; ++i)
+    {
+        if ((i & 1u) == 0u)
+            accum += i;
+        else
+            accum += i * 2u;
+    }
+    outputBuffer[0] = accum;
+    // Kernel result: 0 + 2 + 2 + 6 = 10
+    // BUF: 10
+
+    // Coverage buffer — one counter per (file, line) pair hit.
+    // Under the -trace-coverage placeholder model, each statement
+    // entry increments the slot for its source line; multiple
+    // statements on the same line accumulate.
+    //   counter 0: line 23 (var init + 2 for-init parts) = 3
+    //   counter 1: line 24 (for-header + 2 iteration markers) = 2
+    //   counter 2: line 26 (if check + increment per iteration) = 8
+    //   counter 3: line 27 (then-branch body)              = 2
+    //   counter 4: line 29 (else-branch body)              = 2
+    //   counter 5: line 32 (store to outputBuffer)         = 1
+    // BUF: 3
+    // BUF: 2
+    // BUF: 8
+    // BUF: 2
+    // BUF: 2
+    // BUF: 1
+}

--- a/tests/language-feature/coverage/coverage-no-debug-info.slang
+++ b/tests/language-feature/coverage/coverage-no-debug-info.slang
@@ -1,0 +1,38 @@
+// Regression test for the deferred-stripDebugInfo code path.
+//
+// When `-trace-coverage` is on but `-g` is NOT set, the coverage pass
+// still needs source locations to resolve counter placeholders to
+// (file, line). The normal `stripDebugInfo` pass that runs under
+// `-g0` is deliberately deferred until AFTER the coverage pass has
+// consumed the locations. This test verifies the compile succeeds
+// under -g0 and the resulting C++ still contains counter increments
+// (and not placeholder IR ops).
+
+//TEST:SIMPLE(filecheck=CHECK):-target cpp -stage compute -entry computeMain -trace-coverage
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<uint> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    uint accum = 0;
+    for (uint i = 0; i < 4; ++i)
+    {
+        if ((i & 1u) == 0u)
+            accum += i;
+    }
+    outputBuffer[0] = accum;
+}
+
+// Counter buffer is emitted even without debug info.
+//CHECK: RWStructuredBuffer{{.*}}_slang_coverage
+
+// Counter increment materializes as the CPU prelude atomic helper —
+// this is stronger than just checking a counter-slot reference,
+// because it verifies the full AtomicAdd lowering path runs.
+//CHECK: _slang_atomic_add_u32
+
+// No placeholder IR ops should leak into the emitted C++ — they must
+// all have been rewritten by the coverage pass.
+//CHECK-NOT: IncrementCoverageCounter

--- a/tests/language-feature/coverage/coverage-spirv-atomics.slang
+++ b/tests/language-feature/coverage/coverage-spirv-atomics.slang
@@ -1,0 +1,31 @@
+// Verifies that -trace-coverage on a SPIR-V target emits real
+// OpAtomicIAdd instructions on the synthesized counter buffer. This
+// is the check that shader coverage actually lowers to native atomics
+// on GPU targets (not just the stopgap used during earlier prototypes).
+
+//TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -stage compute -entry computeMain -trace-coverage
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<uint> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    uint accum = 0;
+    for (uint i = 0; i < 4; ++i)
+    {
+        if ((i & 1u) == 0u)
+            accum += i;
+        else
+            accum += i * 2u;
+    }
+    outputBuffer[0] = accum;
+}
+
+// At least one OpAtomicIAdd must appear in the output — this is the
+// native SPIR-V lowering of kIROp_AtomicAdd for our counter increment.
+//CHECK: OpAtomicIAdd
+
+// The synthesized coverage buffer should also show up in the module's
+// debug name table so that a host can discover it via reflection.
+//CHECK: __slang_coverage

--- a/tests/language-feature/coverage/coverage-trace-flag.slang
+++ b/tests/language-feature/coverage/coverage-trace-flag.slang
@@ -25,9 +25,10 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
 // Synthesized coverage buffer should appear in the emitted C++.
 //CHECK: RWStructuredBuffer{{.*}}_slang_coverage
 
-// Each basic block's counter increment materializes as a pointer
-// fetch followed by a non-atomic load-add-store on that slot. At
-// least three distinct counter indices should show up.
-//CHECK: _slang_coverage{{.*int\(0\)}}
-//CHECK: _slang_coverage{{.*int\(1\)}}
-//CHECK: _slang_coverage{{.*int\(2\)}}
+// At least three distinct counter indices should be written to via
+// the CPU-prelude atomic helper. This assertion matches both the
+// slot reference AND the real atomic emission so the test would fail
+// if codegen regressed to a non-atomic load-add-store.
+//CHECK: _slang_atomic_add_u32{{.*}}_slang_coverage{{.*int\(0\)}}
+//CHECK: _slang_atomic_add_u32{{.*}}_slang_coverage{{.*int\(1\)}}
+//CHECK: _slang_atomic_add_u32{{.*}}_slang_coverage{{.*int\(2\)}}

--- a/tests/language-feature/coverage/coverage-trace-flag.slang
+++ b/tests/language-feature/coverage/coverage-trace-flag.slang
@@ -1,0 +1,33 @@
+// Verifies the `-trace-coverage` flag on a shader that does NOT
+// declare `__slang_coverage` itself — the compiler must synthesize
+// the buffer automatically and rewrite the AST-lowering placeholder
+// IncrementCoverageCounter ops into counter writes.
+
+//TEST:SIMPLE(filecheck=CHECK):-target cpp -stage compute -entry computeMain -trace-coverage
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<uint> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    uint accum = 0;
+    for (uint i = 0; i < 4; ++i)
+    {
+        if ((i & 1u) == 0u)
+            accum += i;
+        else
+            accum += i * 2u;
+    }
+    outputBuffer[0] = accum;
+}
+
+// Synthesized coverage buffer should appear in the emitted C++.
+//CHECK: RWStructuredBuffer{{.*}}_slang_coverage
+
+// Each basic block's counter increment materializes as a pointer
+// fetch followed by a non-atomic load-add-store on that slot. At
+// least three distinct counter indices should show up.
+//CHECK: _slang_coverage{{.*int\(0\)}}
+//CHECK: _slang_coverage{{.*int\(1\)}}
+//CHECK: _slang_coverage{{.*int\(2\)}}

--- a/tools/shader-coverage/README.md
+++ b/tools/shader-coverage/README.md
@@ -1,0 +1,246 @@
+# Shader Coverage Instrumentation
+
+A gcov-style coverage facility for shaders compiled by Slang. Instruments
+a `.slang` shader so that each executed source line increments a
+counter at runtime; the counter buffer is read back by the host and
+converted to LCOV `.info` for rendering by `genhtml`, Codecov, VS
+Code Coverage Gutters, or any other LCOV consumer.
+
+Not to be confused with `tools/coverage/`, which measures C++ coverage
+of the Slang compiler itself.
+
+---
+
+## Compiler-side flow
+
+Enable with `-trace-coverage` on the `slangc` CLI.
+
+1. **AST lowering** (`source/slang/slang-lower-to-ir.cpp`). Before each
+   statement is lowered to IR, the front-end emits an
+   `IncrementCoverageCounter(uid)` IR placeholder, tagged with an
+   `IRDebugLocationDecoration` carrying the statement's source
+   position. UIDs increment monotonically from zero.
+2. **IR pass** (`source/slang/slang-ir-coverage-instrument.cpp`).
+   Before the user's module-scope globals are collected into a uniform
+   struct, the pass:
+   - Synthesizes an implicit `RWStructuredBuffer<uint> __slang_coverage`
+     at a reserved register binding (space 31, binding 0) — unless the
+     user already declared a buffer with that exact name, in which case
+     it reuses theirs.
+   - Walks every `IncrementCoverageCounter` placeholder, reads its
+     attached source location, dedupes into a `(file, line) → counter
+     index` map, and rewrites each placeholder as
+     `AtomicAdd(__slang_coverage[counterIdx], 1, Relaxed)`.
+   - Writes a JSON manifest (when `SLANG_COVERAGE_MANIFEST_PATH` is
+     set) and prints a `slang-coverage-info: counters=<N>` line to
+     stderr so the host knows the buffer size.
+3. **Emission.** Each backend already handles `kIROp_AtomicAdd` on
+   `RWStructuredBuffer<uint>`:
+   - HLSL/DXIL → `InterlockedAdd`
+   - SPIR-V → `OpAtomicIAdd`
+   - GLSL → `atomicAdd`
+   - Metal → Metal atomic builtins
+   - WGSL → `atomicAdd`
+   - CUDA → `atomicAdd`
+   - CPU → `_slang_atomic_add_u32` prelude helper (GCC/Clang
+     `__atomic_fetch_add`, MSVC `_InterlockedExchangeAdd`)
+
+Because `IncrementCoverageCounter` defaults to side-effectful in the
+DCE analysis, placeholders survive optimizations untouched. Debug
+info is usually stripped early when the user hasn't asked for `-g`;
+when `-trace-coverage` is on, that strip is deferred until after our
+pass has read the source locations off the placeholders.
+
+---
+
+## Runtime flow
+
+```
+┌─────────────────┐  -trace-coverage      ┌──────────────────────┐
+│  shader.slang   │ ────────────────────► │  target code + sidecar
+└─────────────────┘                       │  shader.slangcov      │
+                                          └──────────────────────┘
+                                                   │
+                                    bind coverage  │
+                                    buffer, run    ▼
+                               ┌─────────────────────────────────┐
+                               │ Host program                    │
+                               │  · uint32 counters[N]           │
+                               │  · dispatch                     │
+                               │  · read UAV back                │
+                               └─────────────────────────────────┘
+                                                   │
+                                                   ▼
+                  slang-coverage-to-lcov.py  ┌─────────────┐
+                                             │ shader.lcov │
+                                             └─────────────┘
+                                                   │
+                                                   ▼
+                                    genhtml, Codecov, VS Code, ...
+```
+
+### Quick start
+
+```bash
+# 1. Compile with coverage on.
+SLANG_COVERAGE_MANIFEST_PATH=build/shader.slangcov \
+slangc shader.slang \
+    -target spirv \
+    -stage compute -entry main \
+    -trace-coverage \
+    -o build/shader.spv
+# stderr: `slang-coverage-info: counters=<N>`
+
+# 2. Allocate a uint32[N] buffer on the host.  Bind it at the
+#    register/binding found in `shader.slangcov` → "buffer".  Dispatch.
+#    After dispatch, read the UAV back to `build/shader.buffer.bin`.
+
+# 3. Convert and render.
+python3 tools/shader-coverage/slang-coverage-to-lcov.py \
+    --manifest build/shader.slangcov \
+    --counters build/shader.buffer.bin \
+    --output   build/shader.lcov
+genhtml build/shader.lcov -o build/shader-cov-html/
+```
+
+---
+
+## Flag and environment reference
+
+| Interface | Effect |
+|---|---|
+| `-trace-coverage` (CLI) | Enables the feature. Emits placeholders during lowering; synthesizes the buffer (if not user-declared); rewrites placeholders to atomic increments. |
+| `SLANG_COVERAGE_MANIFEST_PATH` (env) | Writes a JSON sidecar at the given path describing each counter's source location and the buffer's binding. Unset → no sidecar. |
+| `SLANG_COVERAGE_DUMP_MANIFEST` (env) | When set to any value, also prints `slang-coverage-manifest: <index>,<file>,<line>` lines to stderr. |
+| stderr `slang-coverage-info: counters=<N>` | Always printed when `-trace-coverage` is active. Tells the host the counter-buffer size. |
+
+---
+
+## Sidecar format (`.slangcov`)
+
+Plain JSON, version 1:
+
+```json
+{
+  "version": 1,
+  "counters": 6,
+  "buffer": {
+    "name": "__slang_coverage",
+    "element_type": "uint32",
+    "element_stride": 4,
+    "synthesized": true,
+    "space": 31,
+    "binding": 0,
+    "descriptor_set": 31
+  },
+  "entries": [
+    { "index": 0, "file": "shader.slang", "line": 21 },
+    { "index": 1, "file": "shader.slang", "line": 22 },
+    { "index": 2, "file": "shader.slang", "line": 24 },
+    { "index": 3, "file": "shader.slang", "line": 25 },
+    { "index": 4, "file": "shader.slang", "line": 27 },
+    { "index": 5, "file": "shader.slang", "line": 29 }
+  ]
+}
+```
+
+- `counters` — length of the flat `uint32` counter buffer.
+- `buffer.space` / `buffer.binding` — Vulkan-style descriptor set +
+  binding (populated when the pass has SPIR-V-shaped layout info).
+- `buffer.uav_register` — HLSL-style `u<N>` register (populated for
+  D3D12).
+- `buffer.synthesized` — `true` when Slang created the buffer,
+  `false` when the user declared it in the shader.
+- `entries` — one per counter, in index order. Multiple entries may
+  share the same `(file, line)` when several statements live on one
+  source line; their hits are summed at the LCOV conversion step.
+
+## Counter buffer format
+
+`uint32_t counters[N]` — flat little-endian array. No header, no
+version prefix. `N` is the `counters` field from the sidecar.
+
+---
+
+## The converter — `slang-coverage-to-lcov.py`
+
+```
+--manifest <file.slangcov>       (required)
+--counters <file.bin>            Binary uint32 little-endian
+  OR
+--counters-text <file-or-'->     Whitespace-separated decimal ints
+                                  ('-' reads stdin)
+--output <file.lcov>             Default: stdout
+--test-name <name>               Default: 'slang_coverage' (LCOV
+                                 disallows hyphens in test names)
+```
+
+Binary mode is the normal path after a real GPU dispatch. Text mode
+is a convenience for testing — pipe `slang-test` buffer output
+directly in:
+
+```bash
+./build/Debug/bin/slang-test tests/my-coverage-test.slang 2>&1 \
+  | awk '/^type: uint32_t/{p=1; next} p && /^[0-9]+$/{print}' \
+  | python3 tools/shader-coverage/slang-coverage-to-lcov.py \
+      --manifest build/test.slangcov \
+      --counters-text - \
+      --output build/test.lcov
+```
+
+---
+
+## Example output
+
+For a small compute shader with a 4-iteration loop containing an
+if/else:
+
+```
+TN:slang_coverage
+SF:tests/language-feature/coverage/coverage-basic.slang
+DA:21,3
+DA:22,2
+DA:24,8
+DA:25,2
+DA:27,2
+DA:29,1
+end_of_record
+```
+
+`lcov --summary` reports `lines: 100.0% (6 of 6 lines)`; `genhtml`
+produces a per-line-annotated report in the usual gcov style.
+
+Each counter is the number of times a statement on that line was
+entered, summed across all shader invocations that ran. Because
+multiple statements on the same source line share a counter slot
+(dedupe by `(file, line)`), the displayed hit count may exceed the
+number of invocations.
+
+---
+
+## Current scope
+
+- Line coverage only — emits `DA:` records; no `FN:` / `BRDA:`
+  (function / branch) coverage yet.
+- Column position from the placeholder's debug decoration is dropped
+  when the sidecar is written; only `(file, line)` reaches LCOV.
+- Counter type is `uint32`; will saturate at 4 × 10⁹ hits.
+- Manifest delivery is via file sidecar + stderr; no embedded-compiler
+  API for querying UID → source location yet.
+- Sidecar path must be supplied via `SLANG_COVERAGE_MANIFEST_PATH`;
+  deriving it from `-o` automatically is a natural follow-up.
+
+---
+
+## Related files in the Slang tree
+
+| Path | Role |
+|---|---|
+| `source/slang/slang-ir-coverage-instrument.{h,cpp}` | The IR pass — synthesizes buffer, rewrites placeholders, writes manifest |
+| `source/slang/slang-ir-insts.lua` | Declares `IncrementCoverageCounter(uid)` IR op |
+| `source/slang/slang-lower-to-ir.cpp` | Emits placeholders during AST lowering |
+| `source/slang/slang-emit.cpp` | Integrates the pass into the pipeline |
+| `source/slang/slang-options.cpp` | Registers `-trace-coverage` CLI flag |
+| `prelude/slang-cpp-prelude.h` | CPU-target atomic helpers (`_slang_atomic_add_u32/i32`) |
+| `source/slang/slang-emit-cpp.cpp` | CPU emitter's handling of `kIROp_AtomicAdd` |
+| `tests/language-feature/coverage/` | End-to-end tests |

--- a/tools/shader-coverage/README.md
+++ b/tools/shader-coverage/README.md
@@ -151,9 +151,12 @@ Plain JSON, version 1:
   D3D12).
 - `buffer.synthesized` — `true` when Slang created the buffer,
   `false` when the user declared it in the shader.
-- `entries` — one per counter, in index order. Multiple entries may
-  share the same `(file, line)` when several statements live on one
-  source line; their hits are summed at the LCOV conversion step.
+- `entries` — one per deduplicated `(file, line)` counter, in index
+  order. Multiple source statements on one line share a single
+  counter slot, so each `(file, line)` appears at most once. The hit
+  count for a line is the sum of all statements on that line that
+  actually executed, multiplied by the number of invocations that
+  reached each.
 
 ## Counter buffer format
 

--- a/tools/shader-coverage/slang-coverage-to-lcov.py
+++ b/tools/shader-coverage/slang-coverage-to-lcov.py
@@ -4,7 +4,7 @@ Convert a Slang coverage counter buffer + manifest to LCOV .info format.
 
 Pipeline:
     1. Compile a shader with:
-           slangc shader.slang -fcoverage ...
+           slangc shader.slang -trace-coverage ...
        with SLANG_COVERAGE_MANIFEST_PATH=shader.slangcov set in the
        environment.  This produces an instrumented shader plus a JSON
        sidecar describing each counter's (file, line).

--- a/tools/shader-coverage/slang-coverage-to-lcov.py
+++ b/tools/shader-coverage/slang-coverage-to-lcov.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Convert a Slang coverage counter buffer + manifest to LCOV .info format.
+
+Pipeline:
+    1. Compile a shader with:
+           slangc shader.slang -fcoverage ...
+       with SLANG_COVERAGE_MANIFEST_PATH=shader.slangcov set in the
+       environment.  This produces an instrumented shader plus a JSON
+       sidecar describing each counter's (file, line).
+    2. Dispatch the shader on your runtime of choice, bound to the
+       buffer whose location is recorded in the manifest's `buffer`
+       block (register/space or binding/descriptor_set).
+    3. Read the UAV back to a binary file of little-endian uint32's,
+       one per counter.
+    4. Run this script:
+           slang-coverage-to-lcov.py \\
+               --manifest shader.slangcov \\
+               --counters shader.buffer.bin \\
+               --output shader.lcov
+
+Supported counter input formats:
+    --counters <file>          Binary: uint32 little-endian * N (default)
+    --counters-text <file>     Text: whitespace-separated decimal ints
+    --counters-text -          Text from stdin (handy for piping
+                               slang-test output through `grep | awk`)
+
+The output is standard LCOV .info.  Feed it into:
+    genhtml shader.lcov -o html/
+    # or upload to Codecov, consume in VS Code Coverage Gutters, etc.
+"""
+
+import argparse
+import collections
+import json
+import struct
+import sys
+
+
+def load_counters_binary(path, count):
+    with open(path, "rb") as f:
+        raw = f.read()
+    if len(raw) < count * 4:
+        sys.exit(
+            f"error: counter file '{path}' is {len(raw)} bytes; "
+            f"manifest expects at least {count * 4}"
+        )
+    return list(struct.unpack(f"<{count}I", raw[: count * 4]))
+
+
+def load_counters_text(src, count):
+    data = sys.stdin.read() if src == "-" else open(src).read()
+    values = [int(tok) for tok in data.split() if tok.strip()]
+    if len(values) < count:
+        sys.exit(
+            f"error: found {len(values)} counter values; "
+            f"manifest expects at least {count}"
+        )
+    return values[:count]
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Convert Slang coverage buffer + manifest to LCOV .info."
+    )
+    p.add_argument("--manifest", required=True, help="path to .slangcov JSON")
+    p.add_argument("--counters", help="binary uint32 little-endian counter buffer")
+    p.add_argument(
+        "--counters-text", help="whitespace-separated integers (file or '-' for stdin)"
+    )
+    p.add_argument("--output", default="-", help="output .lcov path (default: stdout)")
+    p.add_argument(
+        "--test-name",
+        default="slang_coverage",
+        help="test-name (TN:) field in LCOV output. LCOV forbids "
+        "hyphens in test names — use underscores or alphanumerics.",
+    )
+    args = p.parse_args()
+
+    if (args.counters is None) == (args.counters_text is None):
+        sys.exit("error: exactly one of --counters or --counters-text is required")
+
+    with open(args.manifest) as f:
+        manifest = json.load(f)
+
+    version = manifest.get("version", 1)
+    if version != 1:
+        sys.exit(f"error: unsupported manifest version {version}")
+
+    total = int(manifest["counters"])
+    if args.counters:
+        counters = load_counters_binary(args.counters, total)
+    else:
+        counters = load_counters_text(args.counters_text, total)
+
+    # Aggregate by (file, line).  The pass already dedupes at
+    # compile time, so normally each (file, line) maps to a single
+    # counter — but accept multiple mappings gracefully by summing.
+    hits_by_line = collections.defaultdict(lambda: collections.defaultdict(int))
+    for entry in manifest["entries"]:
+        idx = entry["index"]
+        if idx >= len(counters):
+            sys.exit(f"error: entry index {idx} exceeds counter buffer size")
+        hits_by_line[entry["file"]][int(entry["line"])] += counters[idx]
+
+    out = sys.stdout if args.output == "-" else open(args.output, "w")
+    out.write(f"TN:{args.test_name}\n")
+    for source in sorted(hits_by_line):
+        out.write(f"SF:{source}\n")
+        for line in sorted(hits_by_line[source]):
+            out.write(f"DA:{line},{hits_by_line[source][line]}\n")
+        out.write("end_of_record\n")
+    if out is not sys.stdout:
+        out.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/shader-coverage/slang-coverage-to-lcov.py
+++ b/tools/shader-coverage/slang-coverage-to-lcov.py
@@ -88,6 +88,8 @@ def main():
         sys.exit(f"error: unsupported manifest version {version}")
 
     total = int(manifest["counters"])
+    if total < 0:
+        sys.exit(f"error: manifest 'counters' must be non-negative, got {total}")
     if args.counters:
         counters = load_counters_binary(args.counters, total)
     else:
@@ -99,8 +101,8 @@ def main():
     hits_by_line = collections.defaultdict(lambda: collections.defaultdict(int))
     for entry in manifest["entries"]:
         idx = entry["index"]
-        if idx >= len(counters):
-            sys.exit(f"error: entry index {idx} exceeds counter buffer size")
+        if idx < 0 or idx >= len(counters):
+            sys.exit(f"error: entry index {idx} out of range [0, {len(counters)})")
         hits_by_line[entry["file"]][int(entry["line"])] += counters[idx]
 
     out = sys.stdout if args.output == "-" else open(args.output, "w")


### PR DESCRIPTION
> ## 📍 What this PR *actually* changes (delta on top of #10886)
>
> GitHub doesn't support cross-fork stacked bases, so the commit list
> below shows all commits from #10886 too. **This PR's own delta is
> just one commit (`2c4dc4e09`) touching 4 files / +159 / -90:**
>
> | File | + / - |
> |---|---|
> | `source/slang/slang-check-synthesize-coverage.cpp` (new) | +101 |
> | `source/slang/slang-check-synthesize-coverage.h` (new) | +26 |
> | `source/slang/slang-check-decl.cpp` | +10 / -0 |
> | `source/slang/slang-ir-coverage-instrument.cpp` | +22 / -90 |
>
> To view just this PR's delta locally:
> ```
> git diff shader-slang/master...jvepsalainen-nv:feature/shader-coverage-ast-synth -- \
>     source/slang/slang-check-synthesize-coverage.* \
>     source/slang/slang-check-decl.cpp \
>     source/slang/slang-ir-coverage-instrument.cpp
> ```

## Summary

Follow-up to #10886. Moves the synthesis of the `__slang_coverage`
buffer from the IR pass to AST-check time, so the buffer becomes a
first-class reflection-visible shader parameter on every backend.

Refs: #10794 (original feature request), #10886 (compile-side PR)

## Why

Slang's reflection / parameter-binding pipeline is built from the
AST **before** any IR pass runs. An IR-level synthesized
`IRGlobalParam` is invisible to reflection, which means host
runtimes (slang-rhi, slangpy, custom Vulkan/D3D12 apps) that resolve
bindings by name cannot find the coverage buffer.

Before this PR: `cursor["__slang_coverage"].isValid()` returned
`false` on every backend. The shader ran with instrumentation but
nobody bound the counter buffer, so the dispatched shader wrote to
an unbound slot and host readback produced garbage or zeros.

After this PR: the coverage buffer is synthesized as an AST-level
`VarDecl` during semantic checking, so every downstream layer
(reflection, layout, target codegen) treats it identically to a
user-declared global. Reflection sees it; parameter binding
assigns it a real descriptor-set slot; the manifest reports the
assigned binding.

## Changes

- New: `source/slang/slang-check-synthesize-coverage.{h,cpp}` —
  one-file synthesis pass hooked into
  `SemanticsDeclVisitorBase::checkModule` after
  import/include resolution and before the main decl-state
  iteration.
- The synthetic `VarDecl` is named `__slang_coverage`, typed
  `RWStructuredBuffer<uint>`, and marked with `SynthesizedModifier`
  so downstream tooling can filter it from user-facing views.
- Removes now-dead IR-time synthesis from
  `slang-ir-coverage-instrument.cpp` (`synthesizeCoverageBuffer`,
  `hasResourceAtReservedBinding`, reserved binding constants).
  The IR pass now only locates the buffer by name and rewrites
  `IncrementCoverageCounter` placeholders into atomic increments.
- Manifest writer continues to emit the buffer's binding info;
  values now reflect the real layout assigned by normal parameter
  binding rather than a hardcoded `31/0` reservation.

## Empirical validation

Post-fix, verified end-to-end on two backends (a third blocked by
an unrelated slang-rhi bug):

| Backend | Status |
|---|---|
| CPU via slang-rhi | ✅ Produces correct counter values and a complete LCOV report — `84.6% (22 of 26 lines)` on the demo shader, with dead-code detection at the intentionally-unreachable branch. |
| Vulkan via slang-rhi (tested on MoltenVK / Apple M4) | ✅ **Byte-identical output to CPU**. `spirv-val` clean; 43 × `OpAtomicIAdd` in the generated SPIR-V; `__slang_coverage` listed in `OpEntryPoint` resource interface. |
| Metal direct | ⚠️ Separate slang-rhi Metal constant-buffer-binding bug — unrelated to coverage, breaks a different code path. |

Existing 4 coverage tests (CPU + SPIR-V emission) still pass.

## Test plan

- [x] Existing `tests/language-feature/coverage/` (4 tests) still pass
- [x] CPU dispatch via the shader-coverage-demo (in #10897) produces `84.6%` coverage, correct dead-code detection
- [x] Vulkan dispatch via MoltenVK produces identical LCOV output
- [x] `spirv-val` clean on instrumented SPIR-V
- [x] Multi-file via `__include` and multi-module via `import` both correctly attribute counters to their source files
- [x] `./extras/formatting.sh` clean

## Follow-ups beyond this PR

See #10897 (library + demo) which depends on this PR and exercises it end-to-end.