### PR TITLE
Fix synthesized methods with return or parameter types that need witness params

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -6707,6 +6707,10 @@ GenericDecl* SemanticsVisitor::synthesizeGenericSignatureForRequirementWitness(
     // This will create a substitution of the synthesized parameters for the
     // original parameters.
     //
+    // We'll also need to invalidate cached default substitution args, because
+    // we've changed the generic decl after the last time
+    // getDefaultSubstitutionArgs was called.
+    synGenericDecl->_cachedArgsForDefaultSubstitution.clear();
     auto defaultArgs = getDefaultSubstitutionArgs(m_astBuilder, this, synGenericDecl);
     DeclRef<CallableDecl> requiredFuncDeclRef =
         m_astBuilder->getGenericAppDeclRef(requiredMemberDeclRef, defaultArgs.getArrayView())

--- a/tests/bugs/gh-10900.slang
+++ b/tests/bugs/gh-10900.slang
@@ -1,0 +1,22 @@
+//DIAGNOSTIC_TEST:SIMPLE:
+interface IBar
+{
+}
+
+struct Thingy<T: IBar>
+{
+}
+
+interface IFoo
+{
+    [mutating]
+    Thingy<T> foo<T: IBar>();
+}
+
+struct Foo: IFoo
+{
+    Thingy<T> foo<T: IBar>()
+    {
+        return Thingy<T>();
+    }
+}


### PR DESCRIPTION
Fixes #10900. `synthesizeGenericSignatureForRequirementWitness` was reusing cached default substitution args, which were computed prior to adding constraints to the synthesized generic decl.

[There are only two hard things in computer science...](https://martinfowler.com/bliki/TwoHardThings.html)