### PR TITLE
Fix #8279: diagnose static const global initialized from cbuffer/tbuffer member

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -3210,6 +3210,80 @@ static Decl* findLegacyBwdDiffFunc(SemanticsVisitor* visitor, ExtensionDecl* ext
 
 void validateStructuredBufferElementType(SemanticsVisitor* visitor, VarDeclBase* varDecl);
 
+/// Returns true if `expr` contains a reference to a global shader parameter
+/// (e.g. a cbuffer/tbuffer member), which is a runtime value and cannot be
+/// used to initialise a compile-time `static const` global variable.
+static bool _initExprContainsShaderParamRef(Expr* expr)
+{
+    if (!expr)
+        return false;
+    // Don't recurse into already-errored sub-expressions.
+    if (as<ErrorType>(expr->type.type))
+        return false;
+
+    // Member access (e.g. `cbuf.member`): check the base object.
+    if (auto memberExpr = as<MemberExpr>(expr))
+        return _initExprContainsShaderParamRef(memberExpr->baseExpression);
+
+    // Pointer dereference: ConstantBuffer<T> members are accessed via a deref of the
+    // cbuffer variable (e.g. `(*Options).Value`), so recurse into the operand.
+    if (auto derefExpr = as<DerefExpr>(expr))
+        return _initExprContainsShaderParamRef(derefExpr->base);
+
+    // Built-in casts (rank promotion, matrix layout change) wrap the source expression
+    // in a BuiltinCastExpr that is NOT a subclass of InvokeExpr, so handle it explicitly.
+    if (auto builtinCastExpr = as<BuiltinCastExpr>(expr))
+        return _initExprContainsShaderParamRef(builtinCastExpr->base);
+
+    // Swizzle expressions (e.g. `cbuf.Vec.xy`, `cbuf.Mat._m00_m01`): check the base.
+    if (auto swizzleExpr = as<SwizzleExpr>(expr))
+        return _initExprContainsShaderParamRef(swizzleExpr->base);
+    if (auto matSwizzleExpr = as<MatrixSwizzleExpr>(expr))
+        return _initExprContainsShaderParamRef(matSwizzleExpr->base);
+
+    // Subscript / element access (e.g. `cbuf.Arr[i]`, `cbuf.Vec[0]`): check the base.
+    if (auto indexExpr = as<IndexExpr>(expr))
+        return _initExprContainsShaderParamRef(indexExpr->baseExpression);
+
+    // Direct declaration reference.
+    if (auto declRefExpr = as<DeclRefExpr>(expr))
+    {
+        if (auto varDecl = as<VarDeclBase>(declRefExpr->declRef.getDecl()))
+        {
+            // References to other `static const` globals are compile-time constants.
+            if (varDecl->hasModifier<HLSLStaticModifier>() && varDecl->hasModifier<ConstModifier>())
+                return false;
+            // Only flag global shader parameters that are cbuffer/tbuffer bindings
+            // (ConstantBufferType / TextureBufferType).  General resource globals
+            // (RWStructuredBuffer, Texture2D, etc.) may validly alias into a
+            // static const variable via type-legalization and must not be rejected.
+            if (isGlobalShaderParameter(varDecl))
+            {
+                if (as<UniformParameterGroupType>(varDecl->type.type))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    // Function calls and built-in operators: check all arguments.
+    if (auto invokeExpr = as<InvokeExpr>(expr))
+    {
+        if (_initExprContainsShaderParamRef(invokeExpr->functionExpr))
+            return true;
+        for (auto arg : invokeExpr->arguments)
+            if (_initExprContainsShaderParamRef(arg))
+                return true;
+        return false;
+    }
+
+    // Parenthesised expressions.
+    if (auto parenExpr = as<ParenExpr>(expr))
+        return _initExprContainsShaderParamRef(parenExpr->base);
+
+    return false;
+}
+
 void SemanticsDeclBodyVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
 {
     DiagnoseIsAllowedInitExpr(varDecl, getSink());
@@ -3243,6 +3317,14 @@ void SemanticsDeclBodyVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
 
         initExpr = coerce(CoercionSite::Initializer, varDecl->type.Ptr(), initExpr, getSink());
         varDecl->initExpr = initExpr;
+
+        // A `static const` global variable must be initialised from a compile-time
+        // constant; cbuffer/tbuffer members are runtime values and cannot be used here.
+        if (isStaticConst && isGlobalDecl(varDecl) && _initExprContainsShaderParamRef(initExpr))
+        {
+            getSink()->diagnose(
+                Diagnostics::StaticConstGlobalCannotUseRuntimeValue{.decl = varDecl});
+        }
 
         // We need to ensure that any variable doesn't introduce
         // a constant with a circular definition.

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -2813,6 +2813,13 @@ err(
 )
 
 err(
+    "static-const-global-cannot-use-runtime-value",
+    30305,
+    "static const global cannot be initialized from a runtime value",
+    span { loc = "decl:Decl", message = "'~decl' is a 'static const' global and cannot be initialized from a runtime value such as a cbuffer or tbuffer member." }
+)
+
+err(
     "type-cannot-conform-to-both-value-and-pointer-diff-interfaces",
     30311,
     "type cannot conform to both value and pointer differentiation interfaces",

--- a/tests/diagnostics/static-const-from-cbuffer.slang
+++ b/tests/diagnostics/static-const-from-cbuffer.slang
@@ -1,0 +1,81 @@
+// Test that a `static const` global initialized from a cbuffer member produces a
+// diagnostic on all targets, rather than crashing (spirv) or silently succeeding
+// (glsl/hlsl).
+// Regression test for https://github.com/shader-slang/slang/issues/8279
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target spirv
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target glsl
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target hlsl
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK_NEG): -target spirv -DNEGATIVE
+
+#ifndef NEGATIVE
+
+enum Status
+{
+    Active = 1
+}
+
+cbuffer Options
+{
+    float Value;
+    float3 Vec;
+    float Arr[4];
+    Status StatusValue;
+}
+
+// CHECK: error[E30305]
+static const float VALUE = Value;
+
+// Arithmetic on a cbuffer member should also be caught (InvokeExpr).
+// CHECK: error[E30305]
+static const float VALUE2 = Value * 2.0;
+
+// tbuffer member reference should also be caught.
+tbuffer TOptions
+{
+    float TValue;
+}
+
+// CHECK: error[E30305]
+static const float TVALUE = TValue;
+
+// Enum-to-underlying-type coercion uses BuiltinCastExpr (not InvokeExpr) — must be caught.
+// CHECK: error[E30305]
+static const int STATUS_ACTIVE = StatusValue;
+
+// Swizzle on a cbuffer member (SwizzleExpr) must be caught.
+// CHECK: error[E30305]
+static const float2 XY = Vec.xy;
+
+// Array/vector subscript on a cbuffer member (IndexExpr) must be caught.
+// CHECK: error[E30305]
+static const float ELEM = Arr[0];
+// CHECK: error[E30305]
+static const float VELEM = Vec[1];
+
+RWStructuredBuffer<float> OutData;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void ComputeMain(uint3 thread_id : SV_DispatchThreadID)
+{
+    OutData[thread_id.x] = thread_id.y + VALUE;
+}
+
+#else
+
+// Negative: static const initialized from a literal or another static const is fine.
+// CHECK_NEG-NOT: error[E30305]
+
+static const float PI = 3.14159;
+static const float TAU = PI * 2.0;
+
+RWStructuredBuffer<float> OutData;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void ComputeMain(uint3 thread_id : SV_DispatchThreadID)
+{
+    OutData[thread_id.x] = TAU;
+}
+
+#endif


### PR DESCRIPTION
Previously, initializing a `static const` global from a cbuffer or tbuffer member caused a crash on SPIRV and silently emitted incorrect code on GLSL and HLSL. This adds diagnostic E30305 that fires in the semantic analysis phase (SemanticsDeclBodyVisitor::checkVarDeclCommon) when this pattern is detected.

The check walks the checked, coerced init expression with a recursive helper _initExprContainsShaderParamRef. The walk handles all expression types that can appear in a static const initializer containing a cbuffer/tbuffer ref:

- MemberExpr: struct field access (the common case)
- DerefExpr: ConstantBuffer<T> transparent access desugars to MemberExpr(DerefExpr(DeclRefExpr(cbuf_var)), field)
- DeclRefExpr: base case — calls isGlobalShaderParameter()
- InvokeExpr: arithmetic operators, function calls, implicit/explicit casts (TypeCastExpr, ImplicitCastExpr, SelectExpr etc. are all InvokeExpr subclasses)
- BuiltinCastExpr: enum-to-underlying-type and matrix layout conversions (NOT an InvokeExpr subclass — requires explicit handling)
- SwizzleExpr / MatrixSwizzleExpr: vector/matrix swizzle access
- IndexExpr: array element and vector element subscript
- ParenExpr: parenthesized expressions

Diagnostic code is 30305 (30304 was already used by is-as-on-unrelated-concrete-types).