### PR TITLE
Fix false positives from _CrtDumpMemoryLeaks in MSVC Debug

### DIFF
--- a/source/slang-record-replay/replay-context.cpp
+++ b/source/slang-record-replay/replay-context.cpp
@@ -124,27 +124,37 @@ DataMismatchException::DataMismatchException(size_t offset, size_t size)
 // ReplayContext construction and low-level helpers
 // =============================================================================
 
-// Tracks the singleton in get() once it has been constructed, so that tryGet()
-// can observe construction from other threads without racing against a
-// concurrent get() call. Guarded by s_contextMutex to match the thread-safety
-// contract documented on get().
+// Singleton pointer and its mutex. Using heap allocation instead of a
+// function-local static so that destroySingleton() can fully release the
+// instance (including its STL container internals) before _CrtDumpMemoryLeaks()
+// runs in wmain(), preventing false leak reports in MSVC Debug builds when
+// CMAKE_MSVC_RUNTIME_LIBRARY is the default MultiThreadedDebugDLL (/MDd).
 static std::mutex s_contextMutex;
 static ReplayContext* s_contextInstance = nullptr;
 
 ReplayContext& ReplayContext::get()
 {
-    static ReplayContext s_instance;
-    {
-        std::lock_guard<std::mutex> lock(s_contextMutex);
-        s_contextInstance = &s_instance;
-    }
-    return s_instance;
+    std::lock_guard<std::mutex> lock(s_contextMutex);
+    if (!s_contextInstance)
+        s_contextInstance = new ReplayContext();
+    return *s_contextInstance;
 }
 
 ReplayContext* ReplayContext::tryGet()
 {
     std::lock_guard<std::mutex> lock(s_contextMutex);
     return s_contextInstance;
+}
+
+void ReplayContext::destroySingleton()
+{
+    ReplayContext* toDelete;
+    {
+        std::lock_guard<std::mutex> lock(s_contextMutex);
+        toDelete = s_contextInstance;
+        s_contextInstance = nullptr;
+    }
+    delete toDelete;
 }
 
 ReplayContext::ReplayContext()

--- a/source/slang-record-replay/replay-context.h
+++ b/source/slang-record-replay/replay-context.h
@@ -216,14 +216,13 @@ public:
 
     /// Return the singleton if it has already been constructed, or nullptr.
     /// Thread-safe - uses a mutex to synchronize with get().
-    /// Use this in cleanup paths (e.g. slang_shutdown) to avoid constructing
+    /// Use this in cleanup paths to avoid constructing
     /// the singleton just to tear it down.
     SLANG_API static ReplayContext* tryGet();
 
-    /// Destroy the singleton and release all its heap allocations.
-    /// Called from slang_shutdown() so that _CrtDumpMemoryLeaks() does not
-    /// report the STL debug-proxy allocations owned by the singleton's
-    /// Dictionary members as leaks in MSVC Debug builds.
+    /// Return the singleton if it has already been constructed, or nullptr.
+    /// Thread-safe - uses a mutex to synchronize with get().
+    /// Use this to check whether the singleton exists without constructing it.
     SLANG_API static void destroySingleton();
 
     /// Create an idle context.

--- a/source/slang-record-replay/replay-context.h
+++ b/source/slang-record-replay/replay-context.h
@@ -220,6 +220,12 @@ public:
     /// the singleton just to tear it down.
     SLANG_API static ReplayContext* tryGet();
 
+    /// Destroy the singleton and release all its heap allocations.
+    /// Called from slang_shutdown() so that _CrtDumpMemoryLeaks() does not
+    /// report the STL debug-proxy allocations owned by the singleton's
+    /// Dictionary members as leaks in MSVC Debug builds.
+    SLANG_API static void destroySingleton();
+
     /// Create an idle context.
     /// Will switch to Record mode if SLANG_RECORD_LAYER=1 is set.
     SLANG_API ReplayContext();

--- a/source/slang-record-replay/replay-context.h
+++ b/source/slang-record-replay/replay-context.h
@@ -216,13 +216,14 @@ public:
 
     /// Return the singleton if it has already been constructed, or nullptr.
     /// Thread-safe - uses a mutex to synchronize with get().
-    /// Use this in cleanup paths to avoid constructing
+    /// Use this in cleanup paths (e.g. slang_shutdown) to avoid constructing
     /// the singleton just to tear it down.
     SLANG_API static ReplayContext* tryGet();
 
-    /// Return the singleton if it has already been constructed, or nullptr.
-    /// Thread-safe - uses a mutex to synchronize with get().
-    /// Use this to check whether the singleton exists without constructing it.
+    /// Destroy the singleton instance if it exists, freeing all resources.
+    /// Thread-safe - uses a mutex to synchronize with get() and tryGet().
+    /// Safe to call when no singleton exists (no-op). After this call,
+    /// get() will lazily re-create a fresh instance if called again.
     SLANG_API static void destroySingleton();
 
     /// Create an idle context.

--- a/source/slang/slang-api.cpp
+++ b/source/slang/slang-api.cpp
@@ -283,8 +283,7 @@ SLANG_API void slang_shutdown()
     Slang::SPIRVCoreGrammarInfo::freeEmbeddedGrammerInfo();
     Slang::RttiInfo::deallocateAll();
     Slang::freeCapabilityDefs();
-    if (auto replayContext = SlangRecord::ReplayContext::tryGet())
-        replayContext->resetHandlers();
+    SlangRecord::ReplayContext::destroySingleton();
 }
 
 SLANG_API void slang_enableRecordLayer(bool enable)

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -43,6 +43,8 @@
 #include "slang-tag-version.h"
 #include "slang-type-layout.h"
 
+#include <cinttypes>
+#include <cstdio>
 #include <sys/stat.h>
 
 // Used to print exception type names in internal-compiler-error messages
@@ -58,9 +60,16 @@ const char* getBuildTagString()
         // If the tag is unknown, then we will try to get the timestamp of the shared library
         // and use that as the version string, so that we can at least return something
         // that uniquely identifies the build.
-        static String timeStampString =
-            String(SharedLibraryUtils::getSharedLibraryTimestamp((void*)spCreateSession));
-        return timeStampString.getBuffer();
+        //
+        // Use a static char buffer (BSS) instead of a heap String so MSVC
+        // _CrtDumpMemoryLeaks() at exit does not false-report that allocation.
+        static char timeStampBuffer[32] = {};
+        if (timeStampBuffer[0] == '\0')
+        {
+            uint64_t ts = SharedLibraryUtils::getSharedLibraryTimestamp((void*)spCreateSession);
+            snprintf(timeStampBuffer, sizeof(timeStampBuffer), "%" PRIu64, ts);
+        }
+        return timeStampBuffer;
     }
     return SLANG_TAG_VERSION;
 }

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -45,6 +45,7 @@
 
 #include <cinttypes>
 #include <cstdio>
+#include <mutex>
 #include <sys/stat.h>
 
 // Used to print exception type names in internal-compiler-error messages

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -64,11 +64,12 @@ const char* getBuildTagString()
         // Use a static char buffer (BSS) instead of a heap String so MSVC
         // _CrtDumpMemoryLeaks() at exit does not false-report that allocation.
         static char timeStampBuffer[32] = {};
-        if (timeStampBuffer[0] == '\0')
+        static std::once_flag initFlag;
+        std::call_once(initFlag, []()
         {
             uint64_t ts = SharedLibraryUtils::getSharedLibraryTimestamp((void*)spCreateSession);
             snprintf(timeStampBuffer, sizeof(timeStampBuffer), "%" PRIu64, ts);
-        }
+        });
         return timeStampBuffer;
     }
     return SLANG_TAG_VERSION;

--- a/source/slang/slang.cpp
+++ b/source/slang/slang.cpp
@@ -66,11 +66,13 @@ const char* getBuildTagString()
         // _CrtDumpMemoryLeaks() at exit does not false-report that allocation.
         static char timeStampBuffer[32] = {};
         static std::once_flag initFlag;
-        std::call_once(initFlag, []()
-        {
-            uint64_t ts = SharedLibraryUtils::getSharedLibraryTimestamp((void*)spCreateSession);
-            snprintf(timeStampBuffer, sizeof(timeStampBuffer), "%" PRIu64, ts);
-        });
+        std::call_once(
+            initFlag,
+            []()
+            {
+                uint64_t ts = SharedLibraryUtils::getSharedLibraryTimestamp((void*)spCreateSession);
+                snprintf(timeStampBuffer, sizeof(timeStampBuffer), "%" PRIu64, ts);
+            });
         return timeStampBuffer;
     }
     return SLANG_TAG_VERSION;

--- a/tools/slang-unit-test/unit-test-replay-shutdown-leak.cpp
+++ b/tools/slang-unit-test/unit-test-replay-shutdown-leak.cpp
@@ -53,3 +53,16 @@ SLANG_UNIT_TEST(replayTryGetSkipsConstruction)
     SLANG_CHECK(ptr != nullptr);
     SLANG_CHECK(ptr == &ReplayContext::get());
 }
+
+// Make sure the singleton is released after destroySingleton().
+SLANG_UNIT_TEST(replayContextDestroyedByShutdown)
+{
+    REPLAY_TEST;
+    SLANG_UNUSED(unitTestContext);
+
+    SLANG_CHECK(ReplayContext::get() != nullptr);
+
+    // Simulate what slang_shutdown() now does
+    ReplayContext::destroySingleton();
+    SLANG_CHECK(ReplayContext::tryGet() == nullptr);
+}

--- a/tools/slang-unit-test/unit-test-replay-shutdown-leak.cpp
+++ b/tools/slang-unit-test/unit-test-replay-shutdown-leak.cpp
@@ -61,6 +61,7 @@ SLANG_UNIT_TEST(replayContextDestroyedByShutdown)
     SLANG_UNUSED(unitTestContext);
 
     ReplayContext::get();
+    SLANG_CHECK(ReplayContext::tryGet() != nullptr);
 
     // Simulate what slang_shutdown() now does
     ReplayContext::destroySingleton();

--- a/tools/slang-unit-test/unit-test-replay-shutdown-leak.cpp
+++ b/tools/slang-unit-test/unit-test-replay-shutdown-leak.cpp
@@ -60,7 +60,7 @@ SLANG_UNIT_TEST(replayContextDestroyedByShutdown)
     REPLAY_TEST;
     SLANG_UNUSED(unitTestContext);
 
-    SLANG_CHECK(ReplayContext::get() != nullptr);
+    ReplayContext::get();
 
     // Simulate what slang_shutdown() now does
     ReplayContext::destroySingleton();


### PR DESCRIPTION
Tear down the ReplayContext singleton in slang_shutdown() so its state is freed before the CRT memory dump runs, instead of only resetting handlers on a function-local static that is never destroyed.

For unknown SLANG_TAG_VERSION, format the shared-library timestamp with snprintf into a static char buffer instead of a heap-allocated String, and keep the same PRIu64 formatting as elsewhere in the codebase.

Fixes #10904