### PR TITLE
Fix unused variable warnings on Linux

### DIFF
--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -1146,9 +1146,9 @@ bool SemanticsVisitor::TryUnifyVals(
         }
     }
 
-    if (auto fstWit = as<TypeCoercionWitness>(fst))
+    if (auto fstWit = as<TypeCoercionWitness>(fst); fstWit)
     {
-        if (auto sndWit = as<TypeCoercionWitness>(snd))
+        if (auto sndWit = as<TypeCoercionWitness>(snd); sndWit)
         {
             // Ignore unification for coercion constraints for now,
             // they will be checked later anyway.

--- a/source/slang/slang-ir-autodiff-rev.cpp
+++ b/source/slang/slang-ir-autodiff-rev.cpp
@@ -775,7 +775,8 @@ IRInst* maybeTranslateLegacyBackwardDerivative(
         {
             // inout diff-pair or in diff-ptr-pair
             if (auto bwdDiffParamPtrType =
-                    as<IRPtrTypeBase>(bwdDiffFuncType->getParamType(bwdDiffParamIdx)))
+                    as<IRPtrTypeBase>(bwdDiffFuncType->getParamType(bwdDiffParamIdx));
+                bwdDiffParamPtrType)
             {
                 if (auto applyParamPtrType = as<IRPtrTypeBase>(applyParamType))
                 {

--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -815,7 +815,8 @@ bool isIntrinsic(IRInst* inst)
     // an intrinsic function, so this automatically implies
     // that this is not an intrinsic.
     //
-    if (auto existentialSpecializedFunc = as<IRSpecializeExistentialsInFunc>(inst))
+    if (auto existentialSpecializedFunc = as<IRSpecializeExistentialsInFunc>(inst);
+        existentialSpecializedFunc)
         return false;
 
     if (!func)
@@ -6928,7 +6929,7 @@ struct TypeFlowSpecializationContext
 
     bool specializeMakeDifferentialPair(IRInst* context, IRMakeDifferentialPair* inst)
     {
-        if (auto tupleType = as<IRTupleType>(tryGetInfo(context, inst)))
+        if (auto tupleType = as<IRTupleType>(tryGetInfo(context, inst)); tupleType)
         {
             IRBuilder builder(inst);
             builder.setInsertBefore(inst);

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3221,7 +3221,7 @@ IRCompilerDictionaryEntry* IRBuilder::fetchCompilerDictionaryEntry(
 
 void IRBuilder::setCompilerDictionaryEntryValue(IRCompilerDictionaryEntry* entry, IRInst* valueInst)
 {
-    if (auto existingVal = entry->getValue())
+    if (auto existingVal = entry->getValue(); existingVal)
     {
         // Invalid.
         SLANG_UNEXPECTED("Translation entry already exists");
@@ -3252,7 +3252,7 @@ void IRBuilder::addCompilerDictionaryEntry(
     }
 
     auto entry = _getCompilerDictionaryEntry(keyVals);
-    if (auto existingVal = entry->getValue())
+    if (auto existingVal = entry->getValue(); existingVal)
     {
         // Invalid.
         SLANG_UNEXPECTED("Translation entry already exists");


### PR DESCRIPTION
This PR resolves the unused variable warnings on Linux with the new C++17 syntax if-init-statement pattern

This will allow us to use `-DCMAKE_COMPILE_WARNING_AS_ERROR=ON` on Linux.