### PR TITLE
ci: add CPU-only tier and trim CPU-capable tests from T4 jobs

### DIFF
--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -101,8 +101,13 @@ jobs:
           export SLANG_RUN_SPIRV_VALIDATION=1
           export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1
 
+          # Run only tests that exercise a GPU API; backend-agnostic tests
+          # (SIMPLE, DIAGNOSTIC, compile-only, CPU, LLVM) are covered by the
+          # separate CPU-only tier and don't need the T4 runner.
           slang_test_args=(
             "-category" "full"
+            "-api" "vk+cuda+dx11+dx12+mtl+wgpu"
+            "-api-only"
             "-expected-failure-list" "tests/expected-failure-github.txt"
             "-expected-failure-list" "tests/expected-failure-linux.txt"
             "-expected-failure-list" "tests/expected-failure-linux-gpu.txt"

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -101,13 +101,14 @@ jobs:
           export SLANG_RUN_SPIRV_VALIDATION=1
           export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1
 
-          # Run only tests that exercise a GPU API; backend-agnostic tests
-          # (SIMPLE, DIAGNOSTIC, compile-only, CPU, LLVM) are covered by the
-          # separate CPU-only tier and don't need the T4 runner.
+          # Restrict to GPU APIs so (cpu) / (llvm) tests are skipped — the
+          # CPU-only tier covers those. Intentionally NOT using -api-only:
+          # no-API tests (COMPILE directives in multi-step compile→dispatch
+          # sequences, SIMPLE/DIAGNOSTIC tests that validate SPIR-V emission)
+          # still need to run on the GPU tier for correctness.
           slang_test_args=(
             "-category" "full"
             "-api" "vk+cuda+dx11+dx12+mtl+wgpu"
-            "-api-only"
             "-expected-failure-list" "tests/expected-failure-github.txt"
             "-expected-failure-list" "tests/expected-failure-linux.txt"
             "-expected-failure-list" "tests/expected-failure-linux-gpu.txt"

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -39,6 +39,16 @@ on:
         type: string
         default: ""
         description: "Optional suffix for artifact name (e.g., '-cuda')"
+      cpu-only:
+        required: false
+        type: boolean
+        default: false
+        description: "Restrict slang-test to CPU and LLVM backends via -api cpu+llvm"
+      gpu-api-only:
+        required: false
+        type: boolean
+        default: false
+        description: "Restrict slang-test to GPU APIs (vk+cuda+dx11+dx12+mtl+wgpu) and skip no-API tests — used on GPU runners to avoid redundant CPU-capable test work"
 
 jobs:
   test-slang:
@@ -62,10 +72,12 @@ jobs:
 
       - name: Test Slang
         run: |
-          export SLANG_RUN_SPIRV_VALIDATION=1
-          export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1
-          if [ "${{ inputs.enable-debug-layers }}" == "true" ]; then
-            export VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation
+          if [[ "${{ inputs.cpu-only }}" != "true" ]]; then
+            export SLANG_RUN_SPIRV_VALIDATION=1
+            export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1
+            if [ "${{ inputs.enable-debug-layers }}" == "true" ]; then
+              export VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation
+            fi
           fi
           # Build common slang-test arguments
           slang_test_args=(
@@ -75,6 +87,19 @@ jobs:
             "-show-adapter-info"
             "-enable-debug-layers" "${{ inputs.enable-debug-layers }}"
           )
+
+          # Restrict to CPU / LLVM backends; tests requiring any GPU API get
+          # ignored by the test filter rather than run-and-failed.
+          if [[ "${{ inputs.cpu-only }}" == "true" ]]; then
+            slang_test_args+=("-api" "cpu+llvm")
+          fi
+
+          # Restrict to GPU APIs; no-API tests (SIMPLE/DIAGNOSTIC/compile-only)
+          # are covered by the CPU-only tier and skipped here to save GPU time.
+          if [[ "${{ inputs.gpu-api-only }}" == "true" ]]; then
+            slang_test_args+=("-api" "vk+cuda+dx11+dx12+mtl+wgpu")
+            slang_test_args+=("-api-only")
+          fi
 
           # Add test server arguments only if server count > 1
           if [ "${{ inputs.server-count }}" -gt 1 ]; then

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -101,11 +101,12 @@ jobs:
             slang_test_args+=("-api" "cpu+llvm")
           fi
 
-          # Restrict to GPU APIs; no-API tests (SIMPLE/DIAGNOSTIC/compile-only)
-          # are covered by the CPU-only tier and skipped here to save GPU time.
+          # Restrict to GPU APIs so (cpu) / (llvm) tests are skipped — the
+          # CPU-only tier covers those. Intentionally NOT using -api-only:
+          # COMPILE directives in multi-step compile→dispatch tests have
+          # requiredFlags==0 and would be skipped, breaking the dispatch.
           if [[ "${{ inputs.gpu-api-only }}" == "true" ]]; then
             slang_test_args+=("-api" "vk+cuda+dx11+dx12+mtl+wgpu")
-            slang_test_args+=("-api-only")
           fi
 
           # Add test server arguments only if server count > 1

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -48,7 +48,7 @@ on:
         required: false
         type: boolean
         default: false
-        description: "Restrict slang-test to GPU APIs (vk+cuda+dx11+dx12+mtl+wgpu) and skip no-API tests — used on GPU runners to avoid redundant CPU-capable test work"
+        description: "Restrict slang-test to GPU APIs (vk+cuda+dx11+dx12+mtl+wgpu) while retaining no-API tests needed by multi-step workflows"
 
 jobs:
   test-slang:
@@ -73,7 +73,7 @@ jobs:
       - name: Test Slang
         run: |
           # Fail fast on mutually exclusive inputs — both would accumulate
-          # -api flags and -api-only would then wipe CPU/LLVM too.
+          # -api filters and produce an empty test partition.
           if [[ "${{ inputs.cpu-only }}" == "true" && "${{ inputs.gpu-api-only }}" == "true" ]]; then
             echo "::error::cpu-only and gpu-api-only are mutually exclusive"
             exit 1
@@ -101,8 +101,8 @@ jobs:
             slang_test_args+=("-api" "cpu+llvm")
           fi
 
-          # Restrict to GPU APIs so (cpu) / (llvm) tests are skipped — the
-          # CPU-only tier covers those. Intentionally NOT using -api-only:
+          # Restrict to GPU APIs so (cpu) / (llvm) tests are skipped. Intentionally
+          # NOT using -api-only: no-API tests still need to run because
           # COMPILE directives in multi-step compile→dispatch tests have
           # requiredFlags==0 and would be skipped, breaking the dispatch.
           if [[ "${{ inputs.gpu-api-only }}" == "true" ]]; then

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -72,12 +72,19 @@ jobs:
 
       - name: Test Slang
         run: |
-          if [[ "${{ inputs.cpu-only }}" != "true" ]]; then
-            export SLANG_RUN_SPIRV_VALIDATION=1
-            export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1
-            if [ "${{ inputs.enable-debug-layers }}" == "true" ]; then
-              export VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation
-            fi
+          # Fail fast on mutually exclusive inputs — both would accumulate
+          # -api flags and -api-only would then wipe CPU/LLVM too.
+          if [[ "${{ inputs.cpu-only }}" == "true" && "${{ inputs.gpu-api-only }}" == "true" ]]; then
+            echo "::error::cpu-only and gpu-api-only are mutually exclusive"
+            exit 1
+          fi
+
+          # SPIR-V emission / validation don't need a GPU — keep on all tiers.
+          export SLANG_RUN_SPIRV_VALIDATION=1
+          export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1
+          # Vulkan runtime validation needs a Vulkan device; skip on CPU tier.
+          if [[ "${{ inputs.cpu-only }}" != "true" && "${{ inputs.enable-debug-layers }}" == "true" ]]; then
+            export VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation
           fi
           # Build common slang-test arguments
           slang_test_args=(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,9 @@ jobs:
       test-category: full
       full-gpu-tests: false
       cpu-only: true
+      # GitHub-hosted ubuntu-24.04 has 4 vCPUs; match test-server count
+      # to avoid IPC timeouts / JSON RPC failures on compute (cpu) tests.
+      server-count: 4
 
   # macOS tests
   test-macos-debug-clang-aarch64:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,25 @@ jobs:
       config: release
       server-count: 4
 
+  # Linux x86_64 CPU-only tests (GitHub-hosted; no GPU).
+  # Runs the -category full suite filtered to CPU and LLVM backends via
+  # -api cpu+llvm, so GPU-targeted test variants are ignored rather than run.
+  # Catches frontend / IR / diagnostic regressions on cheap hardware and
+  # complements the GPU-runner jobs.
+  test-linux-release-gcc-x86_64-cpu:
+    needs: [filter, build-linux-release-gcc-x86_64]
+    if: needs.filter.outputs.should-run == 'true'
+    uses: ./.github/workflows/ci-slang-test.yml
+    with:
+      os: linux
+      compiler: gcc
+      platform: x86_64
+      config: release
+      runs-on: '["ubuntu-24.04"]'
+      test-category: full
+      full-gpu-tests: false
+      cpu-only: true
+
   # macOS tests
   test-macos-debug-clang-aarch64:
     needs: [filter, build-macos-debug-clang-aarch64]
@@ -225,7 +244,9 @@ jobs:
       test-category: smoke
       full-gpu-tests: false
 
-  # Windows GPU tests (self-hosted)
+  # Windows GPU tests (self-hosted).
+  # gpu-api-only skips no-API / CPU / LLVM tests — the CPU-only tier
+  # covers those.
   test-windows-debug-cl-x86_64-gpu:
     needs: [filter, build-windows-debug-cl-x86_64-gpu]
     if: needs.filter.outputs.should-run == 'true'
@@ -238,6 +259,7 @@ jobs:
       runs-on: '["Windows", "self-hosted", "GCP-T4"]'
       test-category: full
       full-gpu-tests: true
+      gpu-api-only: true
 
   test-windows-release-cl-x86_64-gpu:
     needs: [filter, build-windows-release-cl-x86_64-gpu]
@@ -251,6 +273,7 @@ jobs:
       runs-on: '["Windows", "self-hosted", "GCP-T4"]'
       test-category: full
       full-gpu-tests: true
+      gpu-api-only: true
 
   # MaterialX Integration Tests (Windows only for initial validation)
   test-materialx-windows-release:
@@ -272,6 +295,7 @@ jobs:
         test-macos-release-clang-aarch64,
         test-macos-debug-clang-aarch64,
         test-linux-release-gcc-x86_64,
+        test-linux-release-gcc-x86_64-cpu,
         test-linux-debug-gcc-x86_64,
         test-linux-release-gcc-aarch64,
         test-linux-debug-gcc-aarch64,
@@ -289,6 +313,7 @@ jobs:
           echo "macOS Release ARM64: ${{ needs.test-macos-release-clang-aarch64.result }}"
           echo "macOS Debug ARM64: ${{ needs.test-macos-debug-clang-aarch64.result }}"
           echo "Linux Release x64: ${{ needs.test-linux-release-gcc-x86_64.result }}"
+          echo "Linux Release x64 CPU: ${{ needs.test-linux-release-gcc-x86_64-cpu.result }}"
           echo "Linux Debug x64: ${{ needs.test-linux-debug-gcc-x86_64.result }}"
           echo "Linux Release ARM64: ${{ needs.test-linux-release-gcc-aarch64.result }}"
           echo "Linux Debug ARM64: ${{ needs.test-linux-debug-gcc-aarch64.result }}"
@@ -301,6 +326,7 @@ jobs:
              [[ "${{ needs.test-macos-release-clang-aarch64.result }}" == "failure" ]] || \
              [[ "${{ needs.test-macos-debug-clang-aarch64.result }}" == "failure" ]] || \
              [[ "${{ needs.test-linux-release-gcc-x86_64.result }}" == "failure" ]] || \
+             [[ "${{ needs.test-linux-release-gcc-x86_64-cpu.result }}" == "failure" ]] || \
              [[ "${{ needs.test-linux-debug-gcc-x86_64.result }}" == "failure" ]] || \
              [[ "${{ needs.test-linux-release-gcc-aarch64.result }}" == "failure" ]] || \
              [[ "${{ needs.test-linux-debug-gcc-aarch64.result }}" == "failure" ]] || \
@@ -311,6 +337,7 @@ jobs:
              [[ "${{ needs.test-macos-release-clang-aarch64.result }}" == "cancelled" ]] || \
              [[ "${{ needs.test-macos-debug-clang-aarch64.result }}" == "cancelled" ]] || \
              [[ "${{ needs.test-linux-release-gcc-x86_64.result }}" == "cancelled" ]] || \
+             [[ "${{ needs.test-linux-release-gcc-x86_64-cpu.result }}" == "cancelled" ]] || \
              [[ "${{ needs.test-linux-debug-gcc-x86_64.result }}" == "cancelled" ]] || \
              [[ "${{ needs.test-linux-release-gcc-aarch64.result }}" == "cancelled" ]] || \
              [[ "${{ needs.test-linux-debug-gcc-aarch64.result }}" == "cancelled" ]] || \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,9 +247,7 @@ jobs:
       test-category: smoke
       full-gpu-tests: false
 
-  # Windows GPU tests (self-hosted).
-  # gpu-api-only skips no-API / CPU / LLVM tests — the CPU-only tier
-  # covers those.
+  # Windows GPU tests (self-hosted)
   test-windows-debug-cl-x86_64-gpu:
     needs: [filter, build-windows-debug-cl-x86_64-gpu]
     if: needs.filter.outputs.should-run == 'true'
@@ -262,7 +260,6 @@ jobs:
       runs-on: '["Windows", "self-hosted", "GCP-T4"]'
       test-category: full
       full-gpu-tests: true
-      gpu-api-only: true
 
   test-windows-release-cl-x86_64-gpu:
     needs: [filter, build-windows-release-cl-x86_64-gpu]
@@ -276,7 +273,6 @@ jobs:
       runs-on: '["Windows", "self-hosted", "GCP-T4"]'
       test-category: full
       full-gpu-tests: true
-      gpu-api-only: true
 
   # MaterialX Integration Tests (Windows only for initial validation)
   test-materialx-windows-release:

--- a/tests/expected-failure-no-gpu.txt
+++ b/tests/expected-failure-no-gpu.txt
@@ -33,3 +33,6 @@ gfx-unit-test-tool/precompiledModuleVulkan.internal
 gfx-unit-test-tool/rootShaderParameterVulkan.internal
 gfx-unit-test-tool/samplerArrayVulkan.internal
 gfx-unit-test-tool/uint16BufferTestVulkan.internal
+
+# CPU gfx smoke imports the gfx module, which is not available on no-GPU hosted runners
+tests/cpu-program/gfx-smoke.slang (cpu)


### PR DESCRIPTION
## Summary

Phase 4a of the multi-tier GPU CI plan ([#7331](https://github.com/shader-slang/slang/issues/7331)).

This PR adds a new CPU-only Linux x86_64 test job and trims CPU/LLVM-targeted tests from the Linux T4 GPU container job. The intent is to move cheap, non-GPU coverage onto GitHub-hosted CPU runners while keeping the existing GPU tiers responsible for GPU API coverage.

Two cooperating changes:

**New CPU tier** - `test-linux-release-gcc-x86_64-cpu`:

- GitHub-hosted `ubuntu-24.04`, uses the existing `build-linux-release-gcc-x86_64` build artifact (no rebuild)
- Runs `slang-test -category full -api cpu+llvm`, so tests requiring a GPU API (vk/cuda/dx11/dx12/mtl/wgpu) are ignored by the test filter rather than attempted
- Uses `server-count: 4` to match the 4-vCPU hosted runner and avoid test-server oversubscription
- `check-ci` aggregation includes it

**Linux T4 trim** - `test-linux-release-gcc-x86_64` container workflow:

```bash
-api vk+cuda+dx11+dx12+mtl+wgpu
```

This skips `(cpu)` and `(llvm)` test variants on the Linux T4 runner. It intentionally does **not** pass `-api-only`: no-API tests still run on the GPU tier because some COMPILE/SIMPLE/DIAGNOSTIC cases are part of multi-step GPU workflows or validate GPU-relevant SPIR-V emission.

**Windows T4 jobs are unchanged in this PR.** An earlier attempt to apply `gpu-api-only: true` to Windows exposed WGPU synthesized render test coverage issues, so Windows trimming is deferred to a follow-up. The reusable `gpu-api-only` workflow input remains as plumbing for that future work, but no current caller enables it.

## Data driving this change

Phase 2 baseline audit ran `slang-test -category full` inside the `slang-linux-gpu-ci:v1.5.1` container on an ephemeral CPU-only GCP VM (same `linux-gpu-runner` disk image as production T4 runners, no GPU attached). Results:

| Bucket | Count | Nature |
|--------|------:|--------|
| Passed | 4530 | Either CPU-compatible or compile-only |
| Ignored | 5146 | GPU-requiring |
| Failed | 10 | 8 container/OptiX issues + 2 diagnostic drift - not CPU-specific, all reproduced identically on the L4 trial in Phase 3 |

That's about **66% of what the T4 runner runs today** that can be covered on cheaper CPU hardware. This PR takes the safe first slice: add the CPU tier and trim CPU/LLVM variants from the Linux T4 job, while leaving no-API GPU-adjacent coverage and Windows GPU jobs intact.

## Why this is safe

- **Purely additive for the CPU tier** - new job, existing build artifacts
- **Linux T4 trim is reversible** - a single YAML revert restores original behavior
- **No source code changes** - workflow YAML and expected-failure list only
- **No broad `-api-only` filtering** - no-API tests continue to run where needed for multi-step GPU workflows
- **Windows GPU jobs unchanged** - avoids the WGPU synthesized render test fallout seen during review
- **Unchanged jobs stay unchanged** - macOS, ARM64, Windows GPU jobs, and the "Test Slang via glsl" step on Linux container do not enable CPU-only or GPU-api-only filtering

## Risks

- Linux T4 still runs no-API tests, so the wall-time saving is smaller than the theoretical 66% CPU-capable bucket. This is intentional until COMPILE/no-API classification is precise enough for broader filtering.
- `gpu-api-only` is currently defined but unused by callers. It is kept as future plumbing for Windows or other reusable-workflow GPU jobs once no-API coverage gaps are resolved.
- `enabledApis &= availableApis` means the `-api` list gracefully drops unavailable APIs (e.g. `dx11/dx12/mtl` on Linux). No platform-specific branching is needed in the container workflow.

## Test plan

- [x] `test-linux-release-gcc-x86_64-cpu` job completes green on `ubuntu-24.04` with no GPU
- [x] `test-linux-release-gcc-x86_64` (T4 container) stays green with `-api vk+cuda+dx11+dx12+mtl+wgpu` and no `-api-only`
- [x] `test-windows-release-cl-x86_64-gpu` and `test-windows-debug-cl-x86_64-gpu` stay green with their existing unfiltered configuration
- [x] `check-ci` aggregates the new CPU job correctly

## Context

Part of [#7331](https://github.com/shader-slang/slang/issues/7331) - Phase 4a. Phase 4b will add a narrow SM80Plus capability tier on L4 / Blackwell for tests that actually require Ampere-or-newer hardware.
