### PR TITLE
Enable unused-variable warning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,26 @@ cmake --build --preset debug >/dev/null 2>&1 || cmake --build --preset debug
 
 **Run `./extras/formatting.sh` before committing changes.** PRs must conform to the project's coding style. Use `./extras/formatting.sh --check-only` to verify without modifying files.
 
+### Suppressing Unused Variable Warnings
+
+When a variable declared in an `if` condition is unused inside the body (the condition exists only for its type-check side-effect), use the **C++17 if-init-statement** pattern instead of `SLANG_UNUSED`:
+
+```cpp
+// Preferred: C++17 if-init pattern
+if (auto foo = as<IRFoo>(inst); foo)
+{
+    // foo not needed in body — the type check is the point
+}
+
+// Avoid: SLANG_UNUSED inside the body
+if (auto foo = as<IRFoo>(inst))
+{
+    SLANG_UNUSED(foo);
+}
+```
+
+For variables that are set but never read outside an `if` (e.g., a plain local variable), use `SLANG_UNUSED(var)` with a comment explaining why.
+
 ### PR Workflow
 
 1. **Format your code**: Run `./extras/formatting.sh` before committing

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -112,9 +112,6 @@ function(set_default_compile_options target)
             -Wno-invalid-offsetof
             -Wno-newline-eof
             -Wno-return-std-move
-            # Allow unused variables with a pattern of `if (auto v = as<...>(...))`.
-            # This pattern is very common in Slang code base.
-            -Wno-unused-but-set-variable
             # Allowed warnings:
             # If a function returns an address/reference to a local, we want it to
             # produce an error, because it probably means something very bad.

--- a/examples/autodiff-texture/main.cpp
+++ b/examples/autodiff-texture/main.cpp
@@ -372,8 +372,7 @@ struct AutoDiffTexture : public WindowedAppBase
         }
 
         int mipCount = 1 + Math::Log2Ceil(Math::Max(textureWidth, textureHeight));
-        SubresourceData initialData = {};
-        initialData.data = gLearningTexture =
+        gLearningTexture =
             createRenderTargetTexture(Format::RGBA32Float, textureWidth, textureHeight, mipCount);
         gLearningTextureSRV = createSRV(gLearningTexture);
         for (int i = 0; i < mipCount; i++)
@@ -518,8 +517,6 @@ struct AutoDiffTexture : public WindowedAppBase
 
     virtual void renderFrame(ITexture* texture) override
     {
-        static uint32_t frameCount = 0;
-        frameCount++;
         auto transformMatrix = getTransformMatrix();
         renderReferenceImage(transformMatrix);
 

--- a/examples/model-viewer/main.cpp
+++ b/examples/model-viewer/main.cpp
@@ -878,7 +878,8 @@ struct ModelViewer : WindowedAppBase
         view = glm::translate(view, -cameraPosition);
 
         glm::mat4x4 viewProjection = projection * view;
-        auto deviceInfo = gDevice->getInfo();
+        gDevice->getInfo();
+
         // Use identity matrix for correction
         static const float kIdentity[] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
         glm::mat4x4 correctionMatrix;

--- a/examples/triangle/main.cpp
+++ b/examples/triangle/main.cpp
@@ -343,7 +343,7 @@ struct HelloWorld : public WindowedAppBase
         // basis, even though the data that is loaded does not change
         // per-frame (we always use an identity matrix).
         //
-        auto deviceInfo = gDevice->getInfo();
+        gDevice->getInfo();
 
         // We know that `rootObject` is a root shader object created
         // from our program, and that it is set up to hold values for

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -384,7 +384,7 @@ public:
                 break;
             }
         }
-        else if (auto directDeclRef = as<DirectDeclRef>(parent.declRefBase))
+        else if (auto directDeclRef = as<DirectDeclRef>(parent.declRefBase); directDeclRef)
         {
             return makeDeclRef(memberDecl);
         }

--- a/source/slang/slang-ast-print.cpp
+++ b/source/slang/slang-ast-print.cpp
@@ -84,7 +84,7 @@ void ASTPrinter::addExpr(Expr* expr)
 
     auto& sb = m_builder;
 
-    if (const auto incompleteExpr = as<IncompleteExpr>(expr))
+    if (const auto incompleteExpr = as<IncompleteExpr>(expr); incompleteExpr)
     {
         sb << "<incomplete>";
     }
@@ -296,7 +296,7 @@ void ASTPrinter::addExpr(Expr* expr)
     {
         if (const auto operatorExpr = as<OperatorExpr>(invokeExpr))
         {
-            if (const auto infixExpr = as<InfixExpr>(operatorExpr))
+            if (const auto infixExpr = as<InfixExpr>(operatorExpr); infixExpr)
             {
                 // Binary operator
                 if (invokeExpr->arguments.getCount() == 2)
@@ -317,7 +317,7 @@ void ASTPrinter::addExpr(Expr* expr)
                     return;
                 }
             }
-            else if (const auto prefixExpr = as<PrefixExpr>(operatorExpr))
+            else if (const auto prefixExpr = as<PrefixExpr>(operatorExpr); prefixExpr)
             {
                 // Prefix operator
                 if (operatorExpr->functionExpr && as<VarExpr>(operatorExpr->functionExpr) &&
@@ -336,7 +336,7 @@ void ASTPrinter::addExpr(Expr* expr)
                 }
                 return;
             }
-            else if (const auto postfixExpr = as<PostfixExpr>(operatorExpr))
+            else if (const auto postfixExpr = as<PostfixExpr>(operatorExpr); postfixExpr)
             {
                 // Postfix operator
                 if (invokeExpr->arguments.getCount() > 0)
@@ -355,7 +355,7 @@ void ASTPrinter::addExpr(Expr* expr)
                 }
                 return;
             }
-            else if (const auto selectExpr = as<SelectExpr>(operatorExpr))
+            else if (const auto selectExpr = as<SelectExpr>(operatorExpr); selectExpr)
             {
                 // Ternary operator: cond ? ifTrue : ifFalse
                 if (invokeExpr->arguments.getCount() == 3)
@@ -818,19 +818,23 @@ void ASTPrinter::addExpr(Expr* expr)
     }
     else if (const auto higherOrderInvokeExpr = as<HigherOrderInvokeExpr>(expr))
     {
-        if (const auto primalSubstituteExpr = as<PrimalSubstituteExpr>(higherOrderInvokeExpr))
+        if (const auto primalSubstituteExpr = as<PrimalSubstituteExpr>(higherOrderInvokeExpr);
+            primalSubstituteExpr)
         {
             sb << "__primal(";
         }
-        else if (const auto forwardDiffExpr = as<ForwardDifferentiateExpr>(higherOrderInvokeExpr))
+        else if (const auto forwardDiffExpr = as<ForwardDifferentiateExpr>(higherOrderInvokeExpr);
+                 forwardDiffExpr)
         {
             sb << "__fwd_diff(";
         }
-        else if (const auto backwardDiffExpr = as<BackwardDifferentiateExpr>(higherOrderInvokeExpr))
+        else if (const auto backwardDiffExpr = as<BackwardDifferentiateExpr>(higherOrderInvokeExpr);
+                 backwardDiffExpr)
         {
             sb << "__bwd_diff(";
         }
-        else if (const auto dispatchKernelExpr = as<DispatchKernelExpr>(higherOrderInvokeExpr))
+        else if (const auto dispatchKernelExpr = as<DispatchKernelExpr>(higherOrderInvokeExpr);
+                 dispatchKernelExpr)
         {
             sb << "__dispatch_kernel(";
         }
@@ -1165,7 +1169,7 @@ void ASTPrinter::addExpr(Expr* expr)
             addExpr(tryExpr->base);
         }
     }
-    else if (const auto defaultConstructExpr = as<DefaultConstructExpr>(expr))
+    else if (const auto defaultConstructExpr = as<DefaultConstructExpr>(expr); defaultConstructExpr)
     {
         sb << "default(";
         addType(expr->type);
@@ -1670,7 +1674,7 @@ void ASTPrinter::addDeclKindPrefix(Decl* decl)
             m_builder << " ";
         }
     }
-    else if (const auto propertyDecl = as<PropertyDecl>(decl))
+    else if (const auto propertyDecl = as<PropertyDecl>(decl); propertyDecl)
     {
         m_builder << "property ";
     }
@@ -1698,11 +1702,11 @@ void ASTPrinter::addDeclKindPrefix(Decl* decl)
             m_builder << " ";
         }
     }
-    else if (const auto assocType = as<AssocTypeDecl>(decl))
+    else if (const auto assocType = as<AssocTypeDecl>(decl); assocType)
     {
         m_builder << "associatedtype ";
     }
-    else if (const auto attribute = as<AttributeDecl>(decl))
+    else if (const auto attribute = as<AttributeDecl>(decl); attribute)
     {
         m_builder << "attribute ";
     }

--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -1887,7 +1887,7 @@ IntVal* PolynomialIntVal::mul(ASTBuilder* astBuilder, IntVal* op0, IntVal* op1)
     }
     else if (auto val0 = as<IntVal>(op0))
     {
-        if (auto poly1 = as<PolynomialIntVal>(op1); poly1)
+        if (const auto poly1 = as<PolynomialIntVal>(op1); poly1)
         {
             return mul(astBuilder, op1, op0);
         }

--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -234,15 +234,15 @@ Val* maybeSubstituteGenericParam(Val* paramVal, Decl* paramDecl, SubstitutionSet
             (*ioDiff)++;
             return args[argIndex];
         }
-        else if (const auto typeParam = as<GenericTypeParamDeclBase>(m))
+        else if (const auto typeParam = as<GenericTypeParamDeclBase>(m); typeParam)
         {
             argIndex++;
         }
-        else if (const auto valPackParam = as<GenericValuePackParamDecl>(m))
+        else if (const auto valPackParam = as<GenericValuePackParamDecl>(m); valPackParam)
         {
             argIndex++;
         }
-        else if (const auto valParam = as<GenericValueParamDecl>(m))
+        else if (const auto valParam = as<GenericValueParamDecl>(m); valParam)
         {
             argIndex++;
         }
@@ -1887,7 +1887,7 @@ IntVal* PolynomialIntVal::mul(ASTBuilder* astBuilder, IntVal* op0, IntVal* op1)
     }
     else if (auto val0 = as<IntVal>(op0))
     {
-        if (const auto poly1 = as<PolynomialIntVal>(op1))
+        if (auto poly1 = as<PolynomialIntVal>(op1); poly1)
         {
             return mul(astBuilder, op1, op0);
         }

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -540,7 +540,7 @@ public:
         }
         else
         {
-            if (const auto thatGenParam = as<DeclRefIntVal>(other.getParam()))
+            if (const auto thatGenParam = as<DeclRefIntVal>(other.getParam()); thatGenParam)
             {
                 return false;
             }

--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -1146,9 +1146,9 @@ bool SemanticsVisitor::TryUnifyVals(
         }
     }
 
-    if (auto fstWit = as<TypeCoercionWitness>(fst); fstWit)
+    if (const auto fstWit = as<TypeCoercionWitness>(fst); fstWit)
     {
-        if (auto sndWit = as<TypeCoercionWitness>(snd); sndWit)
+        if (const auto sndWit = as<TypeCoercionWitness>(snd); sndWit)
         {
             // Ignore unification for coercion constraints for now,
             // they will be checked later anyway.
@@ -1849,10 +1849,10 @@ bool SemanticsVisitor::TryUnifyTypes(
 
     // An error type can unify with anything, just so we avoid cascading errors.
 
-    if (const auto fstErrorType = as<ErrorType>(fst))
+    if (const auto fstErrorType = as<ErrorType>(fst); fstErrorType)
         return true;
 
-    if (const auto sndErrorType = as<ErrorType>(snd))
+    if (const auto sndErrorType = as<ErrorType>(snd); sndErrorType)
         return true;
 
     // If one or the other of the types is a conjunction `X & Y`,

--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -1146,9 +1146,9 @@ bool SemanticsVisitor::TryUnifyVals(
         }
     }
 
-    if (const auto fstWit = as<TypeCoercionWitness>(fst); fstWit)
+    if (auto fstWit = as<TypeCoercionWitness>(fst); fstWit)
     {
-        if (const auto sndWit = as<TypeCoercionWitness>(snd); sndWit)
+        if (auto sndWit = as<TypeCoercionWitness>(snd); sndWit)
         {
             // Ignore unification for coercion constraints for now,
             // they will be checked later anyway.

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -11492,9 +11492,9 @@ void SemanticsDeclBodyVisitor::visitFunctionDeclBase(FunctionDeclBase* decl)
     }
 
     decl->body = maybeParseStmt(decl->body, newContext);
-    if (const auto body = decl->body; body)
+    if (const auto body = decl->body)
     {
-        checkStmt(decl->body, newContext);
+        checkStmt(body, newContext);
     }
 }
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2267,7 +2267,7 @@ void SemanticsDeclHeaderVisitor::checkExtensionExternVarAttribute(
     VarDeclBase* varDecl,
     ExtensionExternVarModifier* extensionExternMemberModifier)
 {
-    if (const auto parentExtension = as<ExtensionDecl>(varDecl->parentDecl))
+    if (const auto parentExtension = as<ExtensionDecl>(varDecl->parentDecl); parentExtension)
     {
         if (auto originalVarDecl = extensionExternMemberModifier->originalDecl.as<VarDeclBase>())
         {
@@ -2750,7 +2750,7 @@ void SemanticsDeclHeaderVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
         }
     }
 
-    if (const auto interfaceDecl = as<InterfaceDecl>(varDecl->parentDecl))
+    if (const auto interfaceDecl = as<InterfaceDecl>(varDecl->parentDecl); interfaceDecl)
     {
         if (auto basicType = as<BasicExpressionType>(varDecl->getType()))
         {
@@ -10110,7 +10110,7 @@ bool SemanticsVisitor::checkConformance(
                             Diagnostics::InterfaceInheritingComMustBeCom{.decl = inheritanceDecl});
                     }
                 }
-                else if (const auto structDecl = as<StructDecl>(subTypeDecl))
+                else if (const auto structDecl = as<StructDecl>(subTypeDecl); structDecl)
                 {
                     getSink()->diagnose(
                         Diagnostics::StructCannotImplementComInterface{.decl = inheritanceDecl});
@@ -10251,12 +10251,12 @@ void SemanticsVisitor::checkAggTypeConformance(AggTypeDecl* decl)
     // confirm that the type actually provides whatever
     // those clauses require.
 
-    if (const auto interfaceDecl = as<InterfaceDecl>(decl))
+    if (const auto interfaceDecl = as<InterfaceDecl>(decl); interfaceDecl)
     {
         // Don't check that an interface conforms to the
         // things it inherits from.
     }
-    else if (const auto assocTypeDecl = as<AssocTypeDecl>(decl))
+    else if (const auto assocTypeDecl = as<AssocTypeDecl>(decl); assocTypeDecl)
     {
         // Don't check that an associated type decl conforms to the
         // things it inherits from.
@@ -10593,7 +10593,7 @@ void SemanticsDeclBasesVisitor::visitInterfaceDecl(InterfaceDecl* decl)
         // It is possible that there was an error in checking the base type
         // expression, and in such a case we shouldn't emit a cascading error.
         //
-        if (const auto baseErrorType = as<ErrorType>(baseType))
+        if (const auto baseErrorType = as<ErrorType>(baseType); baseErrorType)
         {
             continue;
         }
@@ -10667,6 +10667,7 @@ void SemanticsDeclBasesVisitor::visitCallableDecl(CallableDecl* decl)
     for (auto inheritanceDecl : decl->getMembersOfType<InheritanceDecl>())
     {
         inheritanceClauseCounter++;
+        SLANG_UNUSED(inheritanceClauseCounter);
 
         ensureDecl(inheritanceDecl, DeclCheckState::CanUseBaseOfInheritanceDecl);
         auto baseType = inheritanceDecl->base.type;
@@ -10674,7 +10675,7 @@ void SemanticsDeclBasesVisitor::visitCallableDecl(CallableDecl* decl)
         // It is possible that there was an error in checking the base type
         // expression, and in such a case we shouldn't emit a cascading error.
         //
-        if (const auto baseErrorType = as<ErrorType>(baseType))
+        if (const auto baseErrorType = as<ErrorType>(baseType); baseErrorType)
         {
             continue;
         }
@@ -10741,7 +10742,7 @@ void SemanticsDeclBasesVisitor::visitStructDecl(StructDecl* decl)
         // It is possible that there was an error in checking the base type
         // expression, and in such a case we shouldn't emit a cascading error.
         //
-        if (const auto baseErrorType = as<ErrorType>(baseType))
+        if (const auto baseErrorType = as<ErrorType>(baseType); baseErrorType)
         {
             continue;
         }
@@ -10858,7 +10859,7 @@ void SemanticsDeclBasesVisitor::visitClassDecl(ClassDecl* decl)
         // It is possible that there was an error in checking the base type
         // expression, and in such a case we shouldn't emit a cascading error.
         //
-        if (const auto baseErrorType = as<ErrorType>(baseType))
+        if (const auto baseErrorType = as<ErrorType>(baseType); baseErrorType)
         {
             continue;
         }
@@ -11074,7 +11075,7 @@ void SemanticsDeclBasesVisitor::visitEnumDecl(EnumDecl* decl)
         // It is possible that there was an error in checking the base type
         // expression, and in such a case we shouldn't emit a cascading error.
         //
-        if (const auto baseErrorType = as<ErrorType>(baseType))
+        if (const auto baseErrorType = as<ErrorType>(baseType); baseErrorType)
         {
             continue;
         }
@@ -11491,7 +11492,7 @@ void SemanticsDeclBodyVisitor::visitFunctionDeclBase(FunctionDeclBase* decl)
     }
 
     decl->body = maybeParseStmt(decl->body, newContext);
-    if (const auto body = decl->body)
+    if (const auto body = decl->body; body)
     {
         checkStmt(decl->body, newContext);
     }
@@ -14296,7 +14297,7 @@ void SemanticsDeclBasesVisitor::visitExtensionDecl(ExtensionDecl* decl)
         // It is possible that there was an error in checking the base type
         // expression, and in such a case we shouldn't emit a cascading error.
         //
-        if (const auto baseErrorType = as<ErrorType>(baseType))
+        if (const auto baseErrorType = as<ErrorType>(baseType); baseErrorType)
         {
             continue;
         }

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2105,9 +2105,9 @@ Expr* SemanticsVisitor::_CheckTerm(Expr* term)
     {
         binding->type = type;
 
-        if (const auto body = binding->body; body)
+        if (const auto body = binding->body)
         {
-            binding = as<LetExpr>(binding->body);
+            binding = as<LetExpr>(body);
             SLANG_ASSERT(binding);
             continue;
         }

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2105,7 +2105,7 @@ Expr* SemanticsVisitor::_CheckTerm(Expr* term)
     {
         binding->type = type;
 
-        if (const auto body = binding->body)
+        if (const auto body = binding->body; body)
         {
             binding = as<LetExpr>(binding->body);
             SLANG_ASSERT(binding);
@@ -2135,7 +2135,7 @@ bool SemanticsVisitor::IsErrorExpr(Expr* expr)
 {
     // TODO: we may want other cases here...
 
-    if (const auto errorType = as<ErrorType>(expr->type))
+    if (const auto errorType = as<ErrorType>(expr->type); errorType)
         return true;
 
     return false;
@@ -7660,7 +7660,7 @@ Expr* SemanticsExprVisitor::visitMemberExpr(MemberExpr* expr)
     {
         return _lookupStaticMember(expr, expr->baseExpression);
     }
-    else if (const auto typeType = as<TypeType>(baseType))
+    else if (const auto typeType = as<TypeType>(baseType); typeType)
     {
         return _lookupStaticMember(expr, expr->baseExpression);
     }
@@ -7740,11 +7740,11 @@ Expr* SemanticsExprVisitor::visitThisExpr(ThisExpr* expr)
     {
         auto containerDecl = scope->containerDecl;
 
-        if (const auto ctorDecl = as<ConstructorDecl>(containerDecl))
+        if (const auto ctorDecl = as<ConstructorDecl>(containerDecl); ctorDecl)
         {
             expr->type.isLeftValue = true;
         }
-        else if (const auto setterDecl = as<SetterDecl>(containerDecl))
+        else if (const auto setterDecl = as<SetterDecl>(containerDecl); setterDecl)
         {
             expr->type.isLeftValue = true;
         }
@@ -8010,17 +8010,17 @@ Val* SemanticsExprVisitor::checkTypeModifier(Modifier* modifier, Type* type)
 {
     SLANG_UNUSED(type);
 
-    if (const auto unormModifier = as<UNormModifier>(modifier))
+    if (const auto unormModifier = as<UNormModifier>(modifier); unormModifier)
     {
         // TODO: validate that `type` is either `float` or a vector of `float`s
         return m_astBuilder->getUNormModifierVal();
     }
-    else if (const auto snormModifier = as<SNormModifier>(modifier))
+    else if (const auto snormModifier = as<SNormModifier>(modifier); snormModifier)
     {
         // TODO: validate that `type` is either `float` or a vector of `float`s
         return m_astBuilder->getSNormModifierVal();
     }
-    else if (const auto noDiffModifier = as<NoDiffModifier>(modifier))
+    else if (const auto noDiffModifier = as<NoDiffModifier>(modifier); noDiffModifier)
     {
         return m_astBuilder->getNoDiffModifierVal();
     }

--- a/source/slang/slang-check-modifier.cpp
+++ b/source/slang/slang-check-modifier.cpp
@@ -814,7 +814,7 @@ Modifier* SemanticsVisitor::validateAttribute(
             addModifier(attr->attributeDecl, targetModifier);
         }
     }
-    else if (const auto unrollAttr = as<UnrollAttribute>(attr))
+    else if (const auto unrollAttr = as<UnrollAttribute>(attr); unrollAttr)
     {
         // Check has an argument. We need this because default behavior is to give an error
         // if an attribute has arguments, but not handled explicitly (and the default param will
@@ -848,7 +848,7 @@ Modifier* SemanticsVisitor::validateAttribute(
             maxItersAttrs->value = checkLinkTimeConstantIntVal(attr->args[0]);
         }
     }
-    else if (const auto userDefAttr = as<UserDefinedAttribute>(attr))
+    else if (const auto userDefAttr = as<UserDefinedAttribute>(attr); userDefAttr)
     {
         // check arguments against attribute parameters defined in attribClassDecl
         Index paramIndex = 0;
@@ -1090,7 +1090,8 @@ Modifier* SemanticsVisitor::validateAttribute(
             return nullptr;
         }
     }
-    else if (const auto derivativeMemberAttr = as<DerivativeMemberAttribute>(attr))
+    else if (const auto derivativeMemberAttr = as<DerivativeMemberAttribute>(attr);
+             derivativeMemberAttr)
     {
         auto varDecl = as<VarDeclBase>(attrTarget);
         if (!varDecl)
@@ -1328,7 +1329,7 @@ AttributeBase* SemanticsVisitor::checkAttribute(
         {
             // We didn't have enough arguments for the
             // number of parameters declared.
-            if (const auto defaultArg = paramDecl->initExpr)
+            if (const auto defaultArg = paramDecl->initExpr; defaultArg)
             {
                 // The attribute declaration provided a default,
                 // so we should use that.
@@ -1853,7 +1854,7 @@ Modifier* SemanticsVisitor::checkModifier(
         }
     }
 
-    if (const auto externModifier = as<ExternModifier>(m))
+    if (const auto externModifier = as<ExternModifier>(m); externModifier)
     {
         if (auto varDecl = as<VarDeclBase>(syntaxNode))
         {

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -230,7 +230,7 @@ bool SemanticsVisitor::TryCheckOverloadCandidateFixity(
 
     auto decl = candidate.item.declRef.getDecl();
 
-    if (const auto prefixExpr = as<PrefixExpr>(expr))
+    if (const auto prefixExpr = as<PrefixExpr>(expr); prefixExpr)
     {
         if (decl->hasModifier<PrefixModifier>())
             return true;
@@ -243,7 +243,7 @@ bool SemanticsVisitor::TryCheckOverloadCandidateFixity(
 
         return false;
     }
-    else if (const auto postfixExpr = as<PostfixExpr>(expr))
+    else if (const auto postfixExpr = as<PostfixExpr>(expr); postfixExpr)
     {
         if (decl->hasModifier<PostfixModifier>())
             return true;

--- a/source/slang/slang-check-type.cpp
+++ b/source/slang/slang-check-type.cpp
@@ -116,11 +116,11 @@ Expr* SemanticsVisitor::ExpectATypeRepr(Expr* expr)
         expr = resolveOverloadedExpr(overloadedExpr, LookupMask::type);
     }
 
-    if (const auto typeType = as<TypeType>(expr->type))
+    if (const auto typeType = as<TypeType>(expr->type); typeType)
     {
         return expr;
     }
-    else if (const auto errorType = as<ErrorType>(expr->type))
+    else if (const auto errorType = as<ErrorType>(expr->type); errorType)
     {
         return expr;
     }
@@ -195,7 +195,7 @@ Val* SemanticsVisitor::ExtractGenericArgVal(
     {
         return typeType->getType();
     }
-    else if (const auto errorType = as<ErrorType>(exp->type))
+    else if (const auto errorType = as<ErrorType>(exp->type); errorType)
     {
         return exp->type.type;
     }
@@ -526,7 +526,7 @@ bool SemanticsVisitor::ValuesAreEqual(IntVal* left, IntVal* right)
         {
             return leftVar->getDeclRef().equals(rightVar->getDeclRef());
         }
-        else if (const auto rightPoly = as<PolynomialIntVal>(right))
+        else if (const auto rightPoly = as<PolynomialIntVal>(right); rightPoly)
         {
             return right->equals(leftVar);
         }

--- a/source/slang/slang-doc-ast.cpp
+++ b/source/slang/slang-doc-ast.cpp
@@ -13,15 +13,15 @@ namespace Slang
 {
     typedef Extractor::SearchStyle SearchStyle;
 
-    if (const auto enumCaseDecl = as<EnumCaseDecl>(decl))
+    if (const auto enumCaseDecl = as<EnumCaseDecl>(decl); enumCaseDecl)
     {
         return SearchStyle::EnumCase;
     }
-    if (const auto paramDecl = as<ParamDecl>(decl))
+    if (const auto paramDecl = as<ParamDecl>(decl); paramDecl)
     {
         return SearchStyle::Param;
     }
-    else if (const auto callableDecl = as<CallableDecl>(decl))
+    else if (const auto callableDecl = as<CallableDecl>(decl); callableDecl)
     {
         return SearchStyle::Function;
     }

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -996,8 +996,8 @@ void CPPSourceEmitter::emitSimpleFuncImpl(IRFunc* func)
     }
     // We start by emitting the result type and function name.
     //
-    if (IREntryPointDecoration* const entryPointDecor =
-            func->findDecoration<IREntryPointDecoration>())
+    if (IREntryPointDecoration* entryPointDecor = func->findDecoration<IREntryPointDecoration>();
+        entryPointDecor)
     {
         // Note: we currently emit multiple functions to represent an entry point
         // on CPU/CUDA, and these all bottleneck through the actual `IRFunc`

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -996,7 +996,8 @@ void CPPSourceEmitter::emitSimpleFuncImpl(IRFunc* func)
     }
     // We start by emitting the result type and function name.
     //
-    if (IREntryPointDecoration* const entryPointDecor = func->findDecoration<IREntryPointDecoration>();
+    if (IREntryPointDecoration* const entryPointDecor =
+            func->findDecoration<IREntryPointDecoration>();
         entryPointDecor)
     {
         // Note: we currently emit multiple functions to represent an entry point

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -996,7 +996,7 @@ void CPPSourceEmitter::emitSimpleFuncImpl(IRFunc* func)
     }
     // We start by emitting the result type and function name.
     //
-    if (IREntryPointDecoration* entryPointDecor = func->findDecoration<IREntryPointDecoration>();
+    if (IREntryPointDecoration* const entryPointDecor = func->findDecoration<IREntryPointDecoration>();
         entryPointDecor)
     {
         // Note: we currently emit multiple functions to represent an entry point

--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -1043,7 +1043,7 @@ bool CUDASourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
                 m_writer->emit(")");
                 return true;
             }
-            else if (const auto matrixType = as<IRMatrixType>(inst->getDataType()))
+            else if (const auto matrixType = as<IRMatrixType>(inst->getDataType()); matrixType)
             {
                 m_writer->emit("make");
                 emitType(inst->getDataType());

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -2438,7 +2438,7 @@ bool GLSLSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOu
     case kIROp_Not:
         {
             IRInst* operand = inst->getOperand(0);
-            if (const auto vectorType = as<IRVectorType>(operand->getDataType()))
+            if (const auto vectorType = as<IRVectorType>(operand->getDataType()); vectorType)
             {
                 EmitOpInfo outerPrec = inOuterPrec;
                 bool needClose = false;
@@ -3557,7 +3557,8 @@ void GLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
         _emitGLSLSubpassInputType(subpassType);
         return;
     }
-    else if (const auto structuredBufferType = as<IRHLSLStructuredBufferTypeBase>(type))
+    else if (const auto structuredBufferType = as<IRHLSLStructuredBufferTypeBase>(type);
+             structuredBufferType)
     {
         // TODO: We desugar global variables with structured-buffer type into GLSL
         // `buffer` declarations, but we don't currently handle structured-buffer types

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -1980,7 +1980,8 @@ void HLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
 
         return;
     }
-    else if (const auto untypedBufferType = as<IRUntypedBufferResourceType>(type))
+    else if (const auto untypedBufferType = as<IRUntypedBufferResourceType>(type);
+             untypedBufferType)
     {
         switch (type->getOp())
         {
@@ -2179,7 +2180,8 @@ void HLSLSourceEmitter::emitPostKeywordTypeAttributesImpl(IRInst* inst)
 
     if (enablePAQs)
     {
-        if (const auto payloadDecoration = inst->findDecoration<IRRayPayloadDecoration>())
+        if (const auto payloadDecoration = inst->findDecoration<IRRayPayloadDecoration>();
+            payloadDecoration)
         {
             m_writer->emit("[raypayload] ");
         }
@@ -2383,7 +2385,7 @@ void HLSLSourceEmitter::emitFrontMatterImpl(TargetRequest*)
 
 void HLSLSourceEmitter::emitGlobalInstImpl(IRInst* inst)
 {
-    if (const auto nvapiDecor = inst->findDecoration<IRNVAPIMagicDecoration>())
+    if (const auto nvapiDecor = inst->findDecoration<IRNVAPIMagicDecoration>(); nvapiDecor)
     {
         // When emitting one of the "magic" NVAPI declarations,
         // we will wrap it in a preprocessor conditional that

--- a/source/slang/slang-emit-metal.cpp
+++ b/source/slang/slang-emit-metal.cpp
@@ -1375,7 +1375,8 @@ void MetalSourceEmitter::emitSimpleTypeImpl(IRType* type)
         m_writer->emit(" device*");
         return;
     }
-    else if (const auto untypedBufferType = as<IRUntypedBufferResourceType>(type))
+    else if (const auto untypedBufferType = as<IRUntypedBufferResourceType>(type);
+             untypedBufferType)
     {
         switch (type->getOp())
         {

--- a/source/slang/slang-entry-point.cpp
+++ b/source/slang/slang-entry-point.cpp
@@ -95,7 +95,7 @@ Index EntryPoint::getRequirementCount()
     // "dummy" entry points we create for pass-through
     // compilation will not have an associated module.
     //
-    if (const auto module = getModule())
+    if (const auto module = getModule(); module)
     {
         return 1;
     }
@@ -149,7 +149,7 @@ List<Module*> const& EntryPoint::getModuleDependencies()
 
 List<SourceFile*> const& EntryPoint::getFileDependencies()
 {
-    if (const auto module = getModule())
+    if (const auto module = getModule(); module)
         return getModule()->getFileDependencies();
 
     static List<SourceFile*> empty;

--- a/source/slang/slang-entry-point.cpp
+++ b/source/slang/slang-entry-point.cpp
@@ -149,8 +149,8 @@ List<Module*> const& EntryPoint::getModuleDependencies()
 
 List<SourceFile*> const& EntryPoint::getFileDependencies()
 {
-    if (const auto module = getModule(); module)
-        return getModule()->getFileDependencies();
+    if (const auto module = getModule())
+        return module->getFileDependencies();
 
     static List<SourceFile*> empty;
     return empty;

--- a/source/slang/slang-global-session.cpp
+++ b/source/slang/slang-global-session.cpp
@@ -1034,7 +1034,7 @@ SlangPassThrough Session::getDownstreamCompilerForTransition(
          source == CodeGenTarget::CPPHeader))
     {
         // We prefer LLVM if it's available
-        if (const auto llvm = getOrLoadDownstreamCompiler(PassThroughMode::LLVM, nullptr))
+        if (const auto llvm = getOrLoadDownstreamCompiler(PassThroughMode::LLVM, nullptr); llvm)
         {
             return SLANG_PASS_THROUGH_LLVM;
         }

--- a/source/slang/slang-intrinsic-expand.cpp
+++ b/source/slang/slang-intrinsic-expand.cpp
@@ -573,7 +573,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
             elementType = dropNormAttributes(elementType);
 
             SLANG_ASSERT(elementType);
-            if (const auto basicType = as<IRBasicType>(elementType))
+            if (const auto basicType = as<IRBasicType>(elementType); basicType)
             {
                 // A scalar result is expected
 
@@ -596,7 +596,7 @@ const char* IntrinsicExpandContext::_emitSpecial(const char* cursor)
                     m_writer->emit(swiz[elementCount]);
                 }
             }
-            else if (const auto attrType = as<IRAttributedType>(elementType))
+            else if (const auto attrType = as<IRAttributedType>(elementType); attrType)
             {
                 SLANG_UNEXPECTED("unhandled attributed type in intrinsic definition");
             }

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -324,7 +324,7 @@ struct ForwardDiffTranslationContext
     {
         auto primalVal = maybeCloneForPrimalInst(builder, origInst);
 
-        if (IRType* diffType = differentiateType(builder, origInst->getFullType()); diffType)
+        if (IRType* const diffType = differentiateType(builder, origInst->getFullType()); diffType)
         {
             auto dzero = getDifferentialZeroOfType(builder, origInst->getFullType());
             if (dzero)

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -324,7 +324,7 @@ struct ForwardDiffTranslationContext
     {
         auto primalVal = maybeCloneForPrimalInst(builder, origInst);
 
-        if (IRType* const diffType = differentiateType(builder, origInst->getFullType()))
+        if (IRType* diffType = differentiateType(builder, origInst->getFullType()); diffType)
         {
             auto dzero = getDifferentialZeroOfType(builder, origInst->getFullType());
             if (dzero)
@@ -681,7 +681,8 @@ struct ForwardDiffTranslationContext
                 else
                 {
                     auto operandDataType = origConstruct->getOperand(ii)->getDataType();
-                    if (const auto diffOperandType = differentiateType(builder, operandDataType))
+                    if (const auto diffOperandType = differentiateType(builder, operandDataType);
+                        diffOperandType)
                     {
                         operandDataType =
                             (IRType*)findOrTranslatePrimalInst(builder, operandDataType);
@@ -1736,7 +1737,7 @@ struct ForwardDiffTranslationContext
                 diffAccessChain.add(key);
             }
         }
-        if (const auto diffType = differentiateType(builder, originalInst->getDataType()))
+        if (const auto diffType = differentiateType(builder, originalInst->getDataType()); diffType)
         {
             auto diffBase = findOrTranslateDiffInst(builder, origBase);
             if (!diffBase)
@@ -2134,7 +2135,7 @@ struct ForwardDiffTranslationContext
         List<IRParam*> params;
         for (auto param : firstBlock->getParams())
         {
-            if (const auto ptrType = as<IROutParamTypeBase>(param->getDataType()))
+            if (const auto ptrType = as<IROutParamTypeBase>(param->getDataType()); ptrType)
             {
                 params.add(param);
             }

--- a/source/slang/slang-ir-autodiff-pairs.cpp
+++ b/source/slang/slang-ir-autodiff-pairs.cpp
@@ -100,7 +100,8 @@ struct DifferentialPairTypeBuilder
             {
                 auto genericType = findInnerMostGenericReturnVal(
                     as<IRGeneric>(ptrInnerSpecializedType->getBase()));
-                if (const auto genericBasePairStructType = as<IRStructType>(genericType))
+                if (const auto genericBasePairStructType = as<IRStructType>(genericType);
+                    genericBasePairStructType)
                 {
                     return as<IRFieldAddress>(builder->emitFieldAddress(
                         builder->getPtrType((IRType*)findSpecializationForParam(

--- a/source/slang/slang-ir-autodiff-primal-hoist.cpp
+++ b/source/slang/slang-ir-autodiff-primal-hoist.cpp
@@ -2748,7 +2748,8 @@ static bool shouldStoreInst(IRInst* inst)
 
 static bool shouldStoreVar(IRVar* var)
 {
-    if (const auto typeDecor = var->findDecoration<IRBackwardDerivativePrimalContextDecoration>())
+    if (const auto typeDecor = var->findDecoration<IRBackwardDerivativePrimalContextDecoration>();
+        typeDecor)
     {
         // If we are specializing a callee's intermediate context with types that can't be stored,
         // we can't store the entire context.

--- a/source/slang/slang-ir-autodiff-transpose.cpp
+++ b/source/slang/slang-ir-autodiff-transpose.cpp
@@ -529,7 +529,7 @@ struct DiffTransposePass
         {
             return RegionEntryPoint(revBlockMap[currentBlock], branchInst->getTargetBlock(), false);
         }
-        else if (const auto returnInst = as<IRReturn>(currentBlock->getTerminator()))
+        else if (const auto returnInst = as<IRReturn>(currentBlock->getTerminator()); returnInst)
         {
             return RegionEntryPoint(revBlockMap[currentBlock], nullptr, true);
         }
@@ -1793,7 +1793,7 @@ struct DiffTransposePass
         {
             auto argOperand = fwdMakeMatrix->getOperand(ii);
             IRInst* gradAtIndex = nullptr;
-            if (const auto vecType = as<IRVectorType>(argOperand->getDataType()))
+            if (const auto vecType = as<IRVectorType>(argOperand->getDataType()); vecType)
             {
                 gradAtIndex = builder->emitElementExtract(
                     argOperand->getDataType(),

--- a/source/slang/slang-ir-autodiff-unzip.cpp
+++ b/source/slang/slang-ir-autodiff-unzip.cpp
@@ -72,16 +72,11 @@ struct UnzippingContext
             }
         }
 
-        IRBlock* firstPrimalBlock = nullptr;
-
         // Emit an empty primal block for every mixed block.
         for (auto block : mixedBlocks)
         {
             IRBlock* primalBlock = builder->emitBlock();
             primalMap[block] = primalBlock;
-
-            if (block == firstBlock)
-                firstPrimalBlock = primalBlock;
         }
 
         // Emit an empty differential block for every mixed block.
@@ -141,9 +136,6 @@ struct UnzippingContext
                         (IndexedRegion*)indexRegionMap->map[block]);
             }
         }
-
-        // Swap the first block's occurences out for the first primal block.
-        // firstBlock->replaceUsesWith(firstPrimalBlock);
 
         RefPtr<BlockSplitInfo> splitInfo = new BlockSplitInfo();
 

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -1112,6 +1112,7 @@ bool finalizeAutoDiffPass(IRModule* module, TargetProgram* target)
     // IRMakeDifferentialPair with an IRMakeStruct.
     //
     modified |= processPairTypes(&autodiffContext);
+    SLANG_UNUSED(modified);
 
     removeDetachInsts(module);
 

--- a/source/slang/slang-ir-check-differentiability.cpp
+++ b/source/slang/slang-ir-check-differentiability.cpp
@@ -315,6 +315,9 @@ public:
                 hasDiffValueType = true;
         }
 
+        // TODO: PR #9808 (Sai Praveen Bangaru) - hasDiffValueType is computed but never used
+        // to gate the diagnostic. The comment above suggests it should be part of the condition.
+        SLANG_UNUSED(hasDiffValueType);
         return hasDiffPtrOutput;
     }
 

--- a/source/slang/slang-ir-constexpr.cpp
+++ b/source/slang/slang-ir-constexpr.cpp
@@ -39,7 +39,7 @@ bool isConstExpr(IRType* fullType)
     if (auto rateQualifiedType = as<IRRateQualifiedType>(fullType))
     {
         auto rate = rateQualifiedType->getRate();
-        if (const auto constExprRate = as<IRConstExprRate>(rate))
+        if (const auto constExprRate = as<IRConstExprRate>(rate); constExprRate)
             return true;
     }
 

--- a/source/slang/slang-ir-dce.cpp
+++ b/source/slang/slang-ir-dce.cpp
@@ -559,6 +559,9 @@ bool shouldInstBeLiveIfParentIsLive(IRInst* inst, IRDeadCodeEliminationOptions o
         {
             innerInst = findInnerMostGenericReturnVal(genInst);
         }
+        // TODO: PR #9808 (Sai Praveen Bangaru) removed the loop over innerInst->getDecorations()
+        // that set shouldKeptAliveIfImported, leaving innerInst unused.
+        SLANG_UNUSED(innerInst);
         for (auto decor : inst->getDecorations())
         {
             switch (decor->getOp())

--- a/source/slang/slang-ir-defer-buffer-load.cpp
+++ b/source/slang/slang-ir-defer-buffer-load.cpp
@@ -38,7 +38,7 @@ static bool isCompositeTypeContainingArrays(IRType* type)
     {
         for (auto field : structType->getFields())
         {
-            if (const auto arrayType = as<IRArrayTypeBase>(field->getFieldType()))
+            if (const auto arrayType = as<IRArrayTypeBase>(field->getFieldType()); arrayType)
             {
                 return true;
             }

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -3361,7 +3361,7 @@ static void replaceAllUsesOfMeshOutputValWithLegalizedVal(
                 auto replacementSrcVal = dereferenceVal(builder, replacement);
                 replaceAllUsesOfMeshOutputValWithLegalizedVal(context, load, replacementSrcVal);
             }
-            else if (const auto swiz = as<IRSwizzledStore>(user))
+            else if (const auto swiz = as<IRSwizzledStore>(user); swiz)
             {
                 SLANG_UNEXPECTED("Swizzled store to a non-address ScalarizedVal");
             }
@@ -4082,7 +4082,7 @@ void legalizeEntryPointParameterForGLSL(
     {
         valueType = paramPtrType->getValueType();
     }
-    if (const auto gsStreamType = as<IRHLSLStreamOutputType>(valueType))
+    if (const auto gsStreamType = as<IRHLSLStreamOutputType>(valueType); gsStreamType)
     {
         // An output stream type like `TriangleStream<Foo>` should
         // more or less translate into `out Foo` (plus scalarization).
@@ -4231,7 +4231,7 @@ void legalizeEntryPointParameterForGLSL(
         auto localVariable = builder->emitVar(valueType);
         auto localVal = ScalarizedVal::address(localVariable);
 
-        if (const auto inOutType = as<IRBorrowInOutParamType>(paramType))
+        if (const auto inOutType = as<IRBorrowInOutParamType>(paramType); inOutType)
         {
             // In the `in out` case we need to declare two
             // sets of global variables: one for the `in`

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -621,7 +621,7 @@ protected:
         builder.addSimpleDecoration<IRTempCallArgVarDecoration>(localVar);
         auto localVal = LegalizedVaryingVal::makeAddress(localVar);
 
-        if (const auto inOutType = as<IRBorrowInOutParamType>(paramPtrType))
+        if (const auto inOutType = as<IRBorrowInOutParamType>(paramPtrType); inOutType)
         {
             // If the parameter was an `inout` and not just an `out`
             // parameter, we will create one more more legal `in`
@@ -1868,7 +1868,7 @@ struct CUDAEntryPointVaryingParamLegalizeContext : EntryPointVaryingParamLegaliz
                 elementVals.getCount(),
                 elementVals.getBuffer());
         }
-        else if (const auto basicType = as<IRBasicType>(typeToFetch))
+        else if (const auto basicType = as<IRBasicType>(typeToFetch); basicType)
         {
             IRIntegerValue idx = ioBaseAttributeIndex;
             auto idxInst = builder->getIntValue(builder->getIntType(), idx);

--- a/source/slang/slang-ir-marshal-native-call.cpp
+++ b/source/slang/slang-ir-marshal-native-call.cpp
@@ -249,7 +249,7 @@ IRFunc* NativeCallMarshallingContext::generateDLLExportWrapperFunc(
     }
     auto originalReturnType = originalFunc->getResultType();
     auto callInst = builder.emitCallInst(originalReturnType, originalFunc, args);
-    if (const auto resultType = as<IRResultType>(originalReturnType))
+    if (const auto resultType = as<IRResultType>(originalReturnType); resultType)
     {
         auto isResultError = builder.emitIsResultError(callInst);
         IRBlock* trueBlock = nullptr;

--- a/source/slang/slang-ir-peephole.cpp
+++ b/source/slang/slang-ir-peephole.cpp
@@ -1061,7 +1061,7 @@ struct PeepholeContext : InstPassBase
                         }
                     }
                 }
-                else if (const auto structKey = as<IRStructKey>(key))
+                else if (const auto structKey = as<IRStructKey>(key); structKey)
                 {
                     auto oldVal = inst->getOperand(0);
                     if (oldVal->getOp() == kIROp_MakeStruct)

--- a/source/slang/slang-ir-redundancy-removal.cpp
+++ b/source/slang/slang-ir-redundancy-removal.cpp
@@ -488,7 +488,7 @@ bool tryRemoveRedundantStore(IRGlobalValueWithCode* func, IRStoreBase* store)
 
     // A store can be removed if it stores into a local variable
     // that has no other uses than store.
-    if (const auto varInst = as<IRVar>(rootVar))
+    if (const auto varInst = as<IRVar>(rootVar); varInst)
     {
         bool hasNonStoreUse = false;
         // If the entire access chain doesn't non-store use, we can safely remove it.

--- a/source/slang/slang-ir-sccp.cpp
+++ b/source/slang/slang-ir-sccp.cpp
@@ -1258,7 +1258,7 @@ struct SCCPContext
         // since abstract interpretation of them should cause blocks to
         // be marked as executed, etc.
         //
-        if (const auto terminator = as<IRTerminatorInst>(inst))
+        if (const auto terminator = as<IRTerminatorInst>(inst); terminator)
         {
             if (auto unconditionalBranch = as<IRUnconditionalBranch>(inst))
             {

--- a/source/slang/slang-ir-specialize-buffer-load-arg.cpp
+++ b/source/slang/slang-ir-specialize-buffer-load-arg.cpp
@@ -113,7 +113,7 @@ struct FuncBufferLoadSpecializationCondition : FunctionCallSpecializeCondition
         // 2. A user pointer or bindless resource handle that can be passed to the callee as
         //    ordinary argument.
         //
-        if (const auto argGlobalParam = as<IRGlobalParam>(a))
+        if (const auto argGlobalParam = as<IRGlobalParam>(a); argGlobalParam)
         {
             return true;
         }

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -1891,7 +1891,8 @@ struct SpecializationContext
                     // A subscript operation on mutable buffers returns a ptr type instead of a
                     // value type. We need to make sure the pointer-ness is preserved correctly.
                     auto innerResultType = elementType;
-                    if (const auto ptrResultType = as<IRPtrType>(inst->getDataType()))
+                    if (const auto ptrResultType = as<IRPtrType>(inst->getDataType());
+                        ptrResultType)
                     {
                         innerResultType = builder.getPtrType(elementType);
                     }

--- a/source/slang/slang-ir-ssa.cpp
+++ b/source/slang/slang-ir-ssa.cpp
@@ -1145,7 +1145,7 @@ void collectInstsToRemove(ConstructSSAContext* context, IRBlock* block)
         case kIROp_FieldAddress:
             {
                 auto ptrArg = ii->getOperand(0);
-                if (const auto var = asPromotableVarAccessChain(context, ptrArg))
+                if (const auto var = asPromotableVarAccessChain(context, ptrArg); var)
                 {
                     context->instsToRemove.add(ii);
                 }

--- a/source/slang/slang-ir-translate.cpp
+++ b/source/slang/slang-ir-translate.cpp
@@ -333,9 +333,6 @@ IRInst* _resolveInstRec(TranslationContext* ctx, IRInst* inst)
     if (as<IRParam>(inst))
         return inst;
 
-    List<IRInst*> operands;
-    bool changed = false;
-
     IRBuilder builder(ctx->getModule());
     IRWeakUse* instRef = builder.getWeakUse(inst);
 
@@ -343,9 +340,7 @@ IRInst* _resolveInstRec(TranslationContext* ctx, IRInst* inst)
     for (UInt i = 0; i < inst->getOperandCount(); ++i)
     {
         auto operand = inst->getOperand(i);
-        auto resolvedOperand = ctx->resolveInst(operand);
-        if (resolvedOperand != operand)
-            changed = true;
+        ctx->resolveInst(operand);
     }
 
     // Extract effective inst post-resolution. (the inst may have changed).

--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -817,7 +817,9 @@ bool isIntrinsic(IRInst* inst)
     //
     if (auto existentialSpecializedFunc = as<IRSpecializeExistentialsInFunc>(inst);
         existentialSpecializedFunc)
+    {
         return false;
+    }
 
     if (!func)
         return false;
@@ -6929,7 +6931,7 @@ struct TypeFlowSpecializationContext
 
     bool specializeMakeDifferentialPair(IRInst* context, IRMakeDifferentialPair* inst)
     {
-        if (auto tupleType = as<IRTupleType>(tryGetInfo(context, inst)); tupleType)
+        if (const auto tupleType = as<IRTupleType>(tryGetInfo(context, inst)); tupleType)
         {
             IRBuilder builder(inst);
             builder.setInsertBefore(inst);

--- a/source/slang/slang-ir-typeflow-specialize.cpp
+++ b/source/slang/slang-ir-typeflow-specialize.cpp
@@ -817,9 +817,7 @@ bool isIntrinsic(IRInst* inst)
     //
     if (auto existentialSpecializedFunc = as<IRSpecializeExistentialsInFunc>(inst);
         existentialSpecializedFunc)
-    {
         return false;
-    }
 
     if (!func)
         return false;
@@ -6931,7 +6929,7 @@ struct TypeFlowSpecializationContext
 
     bool specializeMakeDifferentialPair(IRInst* context, IRMakeDifferentialPair* inst)
     {
-        if (const auto tupleType = as<IRTupleType>(tryGetInfo(context, inst)); tupleType)
+        if (auto tupleType = as<IRTupleType>(tryGetInfo(context, inst)); tupleType)
         {
             IRBuilder builder(inst);
             builder.setInsertBefore(inst);

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -1730,7 +1730,7 @@ IRInst* getInstInBlock(IRInst* inst)
 {
     SLANG_RELEASE_ASSERT(inst);
 
-    if (const auto block = as<IRBlock>(inst->getParent()))
+    if (const auto block = as<IRBlock>(inst->getParent()); block)
         return inst;
 
     return getInstInBlock(inst->getParent());

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -3221,7 +3221,7 @@ IRCompilerDictionaryEntry* IRBuilder::fetchCompilerDictionaryEntry(
 
 void IRBuilder::setCompilerDictionaryEntryValue(IRCompilerDictionaryEntry* entry, IRInst* valueInst)
 {
-    if (const auto existingVal = entry->getValue(); existingVal)
+    if (auto existingVal = entry->getValue(); existingVal)
     {
         // Invalid.
         SLANG_UNEXPECTED("Translation entry already exists");
@@ -3252,7 +3252,7 @@ void IRBuilder::addCompilerDictionaryEntry(
     }
 
     auto entry = _getCompilerDictionaryEntry(keyVals);
-    if (const auto existingVal = entry->getValue(); existingVal)
+    if (auto existingVal = entry->getValue(); existingVal)
     {
         // Invalid.
         SLANG_UNEXPECTED("Translation entry already exists");

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -1312,7 +1312,7 @@ IRBlock* IRInsertLoc::getBlock() const
 IRInst* IRInsertLoc::getFunc() const
 {
     auto pp = getParent();
-    if (const auto block = as<IRBlock>(pp))
+    if (const auto block = as<IRBlock>(pp); block)
     {
         pp = pp->getParent();
     }
@@ -3221,7 +3221,7 @@ IRCompilerDictionaryEntry* IRBuilder::fetchCompilerDictionaryEntry(
 
 void IRBuilder::setCompilerDictionaryEntryValue(IRCompilerDictionaryEntry* entry, IRInst* valueInst)
 {
-    if (auto existingVal = entry->getValue(); existingVal)
+    if (const auto existingVal = entry->getValue(); existingVal)
     {
         // Invalid.
         SLANG_UNEXPECTED("Translation entry already exists");
@@ -3252,7 +3252,7 @@ void IRBuilder::addCompilerDictionaryEntry(
     }
 
     auto entry = _getCompilerDictionaryEntry(keyVals);
-    if (auto existingVal = entry->getValue(); existingVal)
+    if (const auto existingVal = entry->getValue(); existingVal)
     {
         // Invalid.
         SLANG_UNEXPECTED("Translation entry already exists");

--- a/source/slang/slang-language-server-ast-lookup.cpp
+++ b/source/slang/slang-language-server-ast-lookup.cpp
@@ -244,7 +244,7 @@ public:
             if (expr->declRef.getDecl()->hasModifier<ImplicitConversionModifier>())
                 return false;
             Int declLength = 0;
-            if (const auto ctorDecl = as<ConstructorDecl>(expr->declRef.getDecl()))
+            if (const auto ctorDecl = as<ConstructorDecl>(expr->declRef.getDecl()); ctorDecl)
             {
                 auto humaneLoc =
                     context->sourceManager->getHumaneLoc(expr->loc, SourceLocType::Actual);
@@ -881,7 +881,7 @@ bool _findAstNodeImpl(ASTLookupContext& context, SyntaxNode* node)
         if (auto container = as<ContainerDecl>(node))
         {
             bool shouldInspectChildren = true;
-            if (const auto genericDecl = as<GenericDecl>(node))
+            if (const auto genericDecl = as<GenericDecl>(node); genericDecl)
             {
             }
             else if (container->closingSourceLoc.getRaw() >= container->loc.getRaw())

--- a/source/slang/slang-language-server-document-symbols.cpp
+++ b/source/slang/slang-language-server-document-symbols.cpp
@@ -206,7 +206,7 @@ static void _getDocumentSymbolsImpl(
                     sym.selectionRange.end = sym.range.end;
                 }
             }
-            if (const auto childContainerDecl = as<ContainerDecl>(child))
+            if (const auto childContainerDecl = as<ContainerDecl>(child); childContainerDecl)
             {
                 // Recurse
                 bool shouldRecurse = true;

--- a/source/slang/slang-language-server.cpp
+++ b/source/slang/slang-language-server.cpp
@@ -921,7 +921,7 @@ LanguageServerResult<LanguageServerProtocol::Hover> LanguageServerCore::hover(
             sb << "\n```\n";
             fillLoc(expr->loc);
         }
-        if (const auto higherOrderExpr = as<HigherOrderInvokeExpr>(expr))
+        if (const auto higherOrderExpr = as<HigherOrderInvokeExpr>(expr); higherOrderExpr)
         {
             String documentation;
             String signature = getExprDeclSignature(expr, &documentation, nullptr);

--- a/source/slang/slang-legalize-types.cpp
+++ b/source/slang/slang-legalize-types.cpp
@@ -168,27 +168,28 @@ bool isResourceType(IRType* type)
         type = arrayType->getElementType();
     }
 
-    if (const auto resourceTypeBase = as<IRResourceTypeBase>(type))
+    if (const auto resourceTypeBase = as<IRResourceTypeBase>(type); resourceTypeBase)
     {
         return true;
     }
-    else if (const auto builtinGenericType = as<IRBuiltinGenericType>(type))
+    else if (const auto builtinGenericType = as<IRBuiltinGenericType>(type); builtinGenericType)
     {
         return true;
     }
-    else if (const auto pointerLikeType = as<IRPointerLikeType>(type))
+    else if (const auto pointerLikeType = as<IRPointerLikeType>(type); pointerLikeType)
     {
         return true;
     }
-    else if (const auto samplerType = as<IRSamplerStateTypeBase>(type))
+    else if (const auto samplerType = as<IRSamplerStateTypeBase>(type); samplerType)
     {
         return true;
     }
-    else if (const auto subpassInputType = as<IRSubpassInputType>(type))
+    else if (const auto subpassInputType = as<IRSubpassInputType>(type); subpassInputType)
     {
         return true;
     }
-    else if (const auto untypedBufferType = as<IRUntypedBufferResourceType>(type))
+    else if (const auto untypedBufferType = as<IRUntypedBufferResourceType>(type);
+             untypedBufferType)
     {
         return true;
     }

--- a/source/slang/slang-lookup.cpp
+++ b/source/slang/slang-lookup.cpp
@@ -53,36 +53,36 @@ bool DeclPassesLookupMask(Decl* decl, LookupMask mask)
         }
     }
     // type declarations
-    if (const auto aggTypeDecl = as<AggTypeDecl>(decl))
+    if (const auto aggTypeDecl = as<AggTypeDecl>(decl); aggTypeDecl)
     {
         return int(mask) & int(LookupMask::type);
     }
-    else if (const auto simpleTypeDecl = as<SimpleTypeDecl>(decl))
+    else if (const auto simpleTypeDecl = as<SimpleTypeDecl>(decl); simpleTypeDecl)
     {
         return int(mask) & int(LookupMask::type);
     }
     // function declarations
-    else if (const auto funcDecl = as<FunctionDeclBase>(decl))
+    else if (const auto funcDecl = as<FunctionDeclBase>(decl); funcDecl)
     {
         return (int(mask) & int(LookupMask::Function)) != 0;
     }
     // attribute declaration
-    else if (const auto attrDecl = as<AttributeDecl>(decl))
+    else if (const auto attrDecl = as<AttributeDecl>(decl); attrDecl)
     {
         return (int(mask) & int(LookupMask::Attribute)) != 0;
     }
     // syntax declaration
-    else if (const auto syntaxDecl = as<SyntaxDecl>(decl))
+    else if (const auto syntaxDecl = as<SyntaxDecl>(decl); syntaxDecl)
     {
         return (int(mask) & int(LookupMask::SyntaxDecl)) != 0;
     }
-    else if (const auto fileDecl = as<FileDecl>(decl))
+    else if (const auto fileDecl = as<FileDecl>(decl); fileDecl)
     {
         // FileDecls should never be discovered via name lookups.
         return false;
     }
     // semantic declaration
-    else if (const auto semanticDecl = as<SemanticDecl>(decl))
+    else if (const auto semanticDecl = as<SemanticDecl>(decl); semanticDecl)
     {
         return (int(mask) & int(LookupMask::Semantic)) != 0;
     }

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -1500,7 +1500,7 @@ static String getNameForNameHint(IRGenContext* context, Decl* decl)
         return String();
 
 
-    if (const auto varDecl = as<VarDeclBase>(decl))
+    if (const auto varDecl = as<VarDeclBase>(decl); varDecl)
     {
         // For an ordinary local variable, global variable,
         // parameter, or field, we will just use the name
@@ -1584,20 +1584,20 @@ static void addNameHint(IRGenContext* context, IRInst* inst, char const* text)
 
 bool shouldDeclBeTreatedAsInterfaceRequirement(Decl* requirementDecl)
 {
-    if (const auto funcDecl = as<CallableDecl>(requirementDecl))
+    if (const auto funcDecl = as<CallableDecl>(requirementDecl); funcDecl)
     {
         // Subscript decl itself won't have a witness table entry.
         // But its accessors will.
-        if (const auto subscriptDecl = as<SubscriptDecl>(requirementDecl))
+        if (const auto subscriptDecl = as<SubscriptDecl>(requirementDecl); subscriptDecl)
             return false;
     }
-    else if (const auto assocTypeDecl = as<AssocTypeDecl>(requirementDecl))
+    else if (const auto assocTypeDecl = as<AssocTypeDecl>(requirementDecl); assocTypeDecl)
     {
     }
-    else if (const auto typeConstraint = as<TypeConstraintDecl>(requirementDecl))
+    else if (const auto typeConstraint = as<TypeConstraintDecl>(requirementDecl); typeConstraint)
     {
     }
-    else if (const auto varDecl = as<VarDeclBase>(requirementDecl))
+    else if (const auto varDecl = as<VarDeclBase>(requirementDecl); varDecl)
     {
     }
     else if (as<AccessorDecl>(requirementDecl))
@@ -4761,7 +4761,8 @@ struct ExprLoweringContext
         // In such a case we should be careful to not statically
         // resolve things.
         //
-        if (auto callableDecl = as<CallableDecl>(declRefExpr->declRef.getDecl()))
+        if (const auto callableDecl = as<CallableDecl>(declRefExpr->declRef.getDecl());
+            callableDecl)
         {
             // Okay, the declaration is directly callable, so we can continue.
 
@@ -4818,7 +4819,7 @@ struct ExprLoweringContext
                     continue;
                 }
             }
-            else if (auto andType = as<AndType>(e->type))
+            else if (const auto andType = as<AndType>(e->type); andType)
             {
                 // TODO: We might eventually need to tell the difference
                 // between conjunctions of interfaces and conjunctions
@@ -6230,7 +6231,7 @@ struct ExprLoweringVisitorBase : public ExprVisitor<Derived, LoweredValInfo>
         type = getOriginalTypeFromModifiedType(type);
 
         auto irType = lowerType(context, type);
-        if (auto basicType = as<BasicExpressionType>(type))
+        if (const auto basicType = as<BasicExpressionType>(type); basicType)
         {
             return getSimpleDefaultVal(irType);
         }
@@ -6256,7 +6257,7 @@ struct ExprLoweringVisitorBase : public ExprVisitor<Derived, LoweredValInfo>
             return LoweredValInfo::simple(
                 getBuilder()->emitMakeArrayFromElement(irType, irDefaultElement));
         }
-        else if (auto ptrType = as<PtrType>(type))
+        else if (const auto ptrType = as<PtrType>(type); ptrType)
         {
             return LoweredValInfo::simple(getBuilder()->getNullPtrValue(irType));
         }
@@ -6270,7 +6271,7 @@ struct ExprLoweringVisitorBase : public ExprVisitor<Derived, LoweredValInfo>
             return LoweredValInfo::simple(
                 getBuilder()->emitMakeTuple(irType, args.getCount(), args.getBuffer()));
         }
-        else if (auto resourceType = as<ResourceType>(type))
+        else if (const auto resourceType = as<ResourceType>(type); resourceType)
         {
             // A resource type does not have a default value, so we defensively assign poison value.
             // In practice, we should never get here. If the value remains unassigned after all of
@@ -8426,11 +8427,11 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
                 }
             }
         }
-        else if (const auto caseStmt = as<CaseStmt>(stmt))
+        else if (const auto caseStmt = as<CaseStmt>(stmt); caseStmt)
         {
             return true;
         }
-        else if (const auto defaultStmt = as<DefaultStmt>(stmt))
+        else if (const auto defaultStmt = as<DefaultStmt>(stmt); defaultStmt)
         {
             // A 'default:' is a kind of case.
             return true;
@@ -8483,16 +8484,6 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
             //
             // TODO: figure out something cleaner.
 
-            // Actually, one gotcha is that if we ever allow non-constant
-            // expressions here (or anything that requires instructions
-            // to be emitted to yield its value), then those instructions
-            // need to go into an appropriate block.
-
-            IRGenContext subContext = *context;
-            IRBuilder subBuilder = *getBuilder();
-            subBuilder.setInsertInto(info->initialBlock);
-            subContext.irBuilder = &subBuilder;
-
             auto constVal = as<ConstantIntVal>(caseStmt->exprVal);
             SLANG_ASSERT(constVal);
             auto caseType = lowerType(context, constVal->getType());
@@ -8507,7 +8498,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
             info->cases.add(caseVal);
             info->cases.add(label);
         }
-        else if (const auto defaultStmt = as<DefaultStmt>(stmt))
+        else if (const auto defaultStmt = as<DefaultStmt>(stmt); defaultStmt)
         {
             auto label = getLabelForCase(info);
 
@@ -8516,7 +8507,7 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
 
             info->defaultLabel = label;
         }
-        else if (const auto emptyStmt = as<EmptyStmt>(stmt))
+        else if (const auto emptyStmt = as<EmptyStmt>(stmt); emptyStmt)
         {
             // Special-case empty statements so they don't
             // mess up our "trivial fall-through" optimization.
@@ -9830,7 +9821,8 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             // generic associated types.
 
 
-            if (const auto interfaceDecl = as<InterfaceDecl>(assocTypeDecl->parentDecl))
+            if (const auto interfaceDecl = as<InterfaceDecl>(assocTypeDecl->parentDecl);
+                interfaceDecl)
             {
                 // Okay, this seems to be an interface rquirement, and
                 // we should lower it as such.
@@ -9845,7 +9837,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         {
             // TODO: needs more work for generic functions.
 
-            if (const auto interfaceDecl = as<InterfaceDecl>(funcDecl->parentDecl))
+            if (const auto interfaceDecl = as<InterfaceDecl>(funcDecl->parentDecl); interfaceDecl)
             {
                 // Okay, this seems to be an interface requirement, and
                 // we should lower it as such.
@@ -9855,7 +9847,8 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             SLANG_ASSERT("unexpected type constraint inside a function");
         }
 
-        if (const auto globalGenericParamDecl = as<GlobalGenericParamDecl>(decl->parentDecl))
+        if (const auto globalGenericParamDecl = as<GlobalGenericParamDecl>(decl->parentDecl);
+            globalGenericParamDecl)
         {
             // This is a constraint on a global generic type parameters,
             // and so it should lower as a parameter of its own.
@@ -10212,7 +10205,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // table, because it represents something the
         // interface requires, and not what it provides.
         //
-        if (const auto parentInterfaceDecl = as<InterfaceDecl>(parentDecl))
+        if (const auto parentInterfaceDecl = as<InterfaceDecl>(parentDecl); parentInterfaceDecl)
         {
             return LoweredValInfo::simple(getInterfaceRequirementKey(inheritanceDecl));
         }
@@ -10499,7 +10492,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         }
         if (auto extDecl = as<ExtensionDecl>(parent))
         {
-            if (const auto declRefType = as<DeclRefType>(extDecl->targetType.type))
+            if (const auto declRefType = as<DeclRefType>(extDecl->targetType.type); declRefType)
             {
                 return true;
             }
@@ -11357,7 +11350,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         {
             subBuilder->addAnyValueSizeDecoration(irInterface, anyValueSizeAttr->size);
         }
-        if (const auto specializeAttr = decl->findModifier<SpecializeAttribute>())
+        if (const auto specializeAttr = decl->findModifier<SpecializeAttribute>(); specializeAttr)
         {
             subBuilder->addSpecializeDecoration(irInterface);
         }
@@ -11367,7 +11360,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                 irInterface,
                 comInterfaceAttr->guid.getUnownedSlice());
         }
-        if (const auto builtinAttr = decl->findModifier<BuiltinAttribute>())
+        if (const auto builtinAttr = decl->findModifier<BuiltinAttribute>(); builtinAttr)
         {
             subBuilder->addBuiltinDecoration(irInterface);
         }
@@ -11598,7 +11591,8 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         addLinkageDecoration(context, irAggType, decl);
 
 
-        if (const auto rayPayloadAttribute = decl->findModifier<RayPayloadAttribute>())
+        if (const auto rayPayloadAttribute = decl->findModifier<RayPayloadAttribute>();
+            rayPayloadAttribute)
         {
             subBuilder->addDecoration(irAggType, kIROp_RayPayloadDecoration);
         }
@@ -12389,7 +12383,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                 scrutinee);
         }
 
-        if (const auto nvapiMod = decl->findModifier<NVAPIMagicModifier>())
+        if (const auto nvapiMod = decl->findModifier<NVAPIMagicModifier>(); nvapiMod)
         {
             builder->addNVAPIMagicDecoration(irInst, decl->getName()->text.getUnownedSlice());
         }
@@ -12567,7 +12561,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         // have a name, but its parent should.
         //
         Decl* declForName = decl;
-        if (const auto accessorDecl = as<AccessorDecl>(decl))
+        if (const auto accessorDecl = as<AccessorDecl>(decl); accessorDecl)
             declForName = decl->parentDecl;
 
         definition.append(getText(declForName->getName()));

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -4761,7 +4761,7 @@ struct ExprLoweringContext
         // In such a case we should be careful to not statically
         // resolve things.
         //
-        if (const auto callableDecl = as<CallableDecl>(declRefExpr->declRef.getDecl());
+        if (auto callableDecl = as<CallableDecl>(declRefExpr->declRef.getDecl());
             callableDecl)
         {
             // Okay, the declaration is directly callable, so we can continue.
@@ -4819,7 +4819,7 @@ struct ExprLoweringContext
                     continue;
                 }
             }
-            else if (const auto andType = as<AndType>(e->type); andType)
+            else if (auto andType = as<AndType>(e->type); andType)
             {
                 // TODO: We might eventually need to tell the difference
                 // between conjunctions of interfaces and conjunctions
@@ -6231,7 +6231,7 @@ struct ExprLoweringVisitorBase : public ExprVisitor<Derived, LoweredValInfo>
         type = getOriginalTypeFromModifiedType(type);
 
         auto irType = lowerType(context, type);
-        if (const auto basicType = as<BasicExpressionType>(type); basicType)
+        if (auto basicType = as<BasicExpressionType>(type); basicType)
         {
             return getSimpleDefaultVal(irType);
         }
@@ -6257,7 +6257,7 @@ struct ExprLoweringVisitorBase : public ExprVisitor<Derived, LoweredValInfo>
             return LoweredValInfo::simple(
                 getBuilder()->emitMakeArrayFromElement(irType, irDefaultElement));
         }
-        else if (const auto ptrType = as<PtrType>(type); ptrType)
+        else if (auto ptrType = as<PtrType>(type); ptrType)
         {
             return LoweredValInfo::simple(getBuilder()->getNullPtrValue(irType));
         }
@@ -6271,7 +6271,7 @@ struct ExprLoweringVisitorBase : public ExprVisitor<Derived, LoweredValInfo>
             return LoweredValInfo::simple(
                 getBuilder()->emitMakeTuple(irType, args.getCount(), args.getBuffer()));
         }
-        else if (const auto resourceType = as<ResourceType>(type); resourceType)
+        else if (auto resourceType = as<ResourceType>(type); resourceType)
         {
             // A resource type does not have a default value, so we defensively assign poison value.
             // In practice, we should never get here. If the value remains unassigned after all of

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -4761,8 +4761,7 @@ struct ExprLoweringContext
         // In such a case we should be careful to not statically
         // resolve things.
         //
-        if (auto callableDecl = as<CallableDecl>(declRefExpr->declRef.getDecl());
-            callableDecl)
+        if (auto callableDecl = as<CallableDecl>(declRefExpr->declRef.getDecl()); callableDecl)
         {
             // Okay, the declaration is directly callable, so we can continue.
 

--- a/source/slang/slang-mangle.cpp
+++ b/source/slang/slang-mangle.cpp
@@ -241,11 +241,11 @@ void emitType(ManglingContext* context, Type* type)
         emitRaw(context, "t");
         emitQualifiedName(context, thisType->getInterfaceDeclRef(), true);
     }
-    else if (const auto errorType = dynamicCast<ErrorType>(type))
+    else if (const auto errorType = dynamicCast<ErrorType>(type); errorType)
     {
         emitRaw(context, "E");
     }
-    else if (const auto bottomType = dynamicCast<BottomType>(type))
+    else if (const auto bottomType = dynamicCast<BottomType>(type); bottomType)
     {
         emitRaw(context, "B");
     }
@@ -343,7 +343,7 @@ void emitVal(ManglingContext* context, Val* val)
     {
         emitType(context, type);
     }
-    else if (const auto witness = dynamicCast<Witness>(val))
+    else if (const auto witness = dynamicCast<Witness>(val); witness)
     {
         // We don't emit witnesses as part of a mangled
         // name, because the way that the front-end

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -2324,19 +2324,19 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
             return arrayTypeLayout;
         }
         // Ignore a bunch of types that don't make sense here...
-        else if (const auto subpassType = as<SubpassInputType>(type))
+        else if (const auto subpassType = as<SubpassInputType>(type); subpassType)
         {
             return nullptr;
         }
-        else if (const auto textureType = as<TextureType>(type))
+        else if (const auto textureType = as<TextureType>(type); textureType)
         {
             return nullptr;
         }
-        else if (const auto samplerStateType = as<SamplerStateType>(type))
+        else if (const auto samplerStateType = as<SamplerStateType>(type); samplerStateType)
         {
             return nullptr;
         }
-        else if (const auto constantBufferType = as<ConstantBufferType>(type))
+        else if (const auto constantBufferType = as<ConstantBufferType>(type); constantBufferType)
         {
             return nullptr;
         }
@@ -2623,7 +2623,7 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
         }
 
         // If we ran into an error in checking the user's code, then skip this parameter
-        else if (const auto errorType = as<ErrorType>(type))
+        else if (const auto errorType = as<ErrorType>(type); errorType)
         {
             return nullptr;
         }

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -7981,7 +7981,7 @@ static bool _isCast(Parser* parser, Expr* expr)
             // want the interpretation of something in parentheses to be determined by something
             // as common as + or - whitespace.
 
-            if (const auto staticMemberExpr = dynamicCast<StaticMemberExpr>(expr))
+            if (const auto staticMemberExpr = dynamicCast<StaticMemberExpr>(expr); staticMemberExpr)
             {
                 // Apply the heuristic:
                 TokenReader::ParsingCursor cursor = parser->tokenReader.getCursor();

--- a/source/slang/slang-reflection-api.cpp
+++ b/source/slang/slang-reflection-api.cpp
@@ -414,23 +414,23 @@ SLANG_API SlangTypeKind spReflectionType_GetKind(SlangReflectionType* inType)
     {
         return SLANG_TYPE_KIND_SCALAR;
     }
-    else if (const auto vectorType = as<VectorExpressionType>(type))
+    else if (const auto vectorType = as<VectorExpressionType>(type); vectorType)
     {
         return SLANG_TYPE_KIND_VECTOR;
     }
-    else if (const auto matrixType = as<MatrixExpressionType>(type))
+    else if (const auto matrixType = as<MatrixExpressionType>(type); matrixType)
     {
         return SLANG_TYPE_KIND_MATRIX;
     }
-    else if (const auto parameterBlockType = as<ParameterBlockType>(type))
+    else if (const auto parameterBlockType = as<ParameterBlockType>(type); parameterBlockType)
     {
         return SLANG_TYPE_KIND_PARAMETER_BLOCK;
     }
-    else if (const auto constantBufferType = as<ConstantBufferType>(type))
+    else if (const auto constantBufferType = as<ConstantBufferType>(type); constantBufferType)
     {
         return SLANG_TYPE_KIND_CONSTANT_BUFFER;
     }
-    else if (const auto streamOutputType = as<HLSLStreamOutputType>(type))
+    else if (const auto streamOutputType = as<HLSLStreamOutputType>(type); streamOutputType)
     {
         return SLANG_TYPE_KIND_OUTPUT_STREAM;
     }
@@ -446,27 +446,27 @@ SLANG_API SlangTypeKind spReflectionType_GetKind(SlangReflectionType* inType)
     {
         return SLANG_TYPE_KIND_SHADER_STORAGE_BUFFER;
     }
-    else if (const auto samplerStateType = as<SamplerStateType>(type))
+    else if (const auto samplerStateType = as<SamplerStateType>(type); samplerStateType)
     {
         return SLANG_TYPE_KIND_SAMPLER_STATE;
     }
-    else if (const auto textureType = as<TextureTypeBase>(type))
+    else if (const auto textureType = as<TextureTypeBase>(type); textureType)
     {
         return SLANG_TYPE_KIND_RESOURCE;
     }
-    else if (const auto subpassInputType = as<SubpassInputType>(type))
+    else if (const auto subpassInputType = as<SubpassInputType>(type); subpassInputType)
     {
         return SLANG_TYPE_KIND_RESOURCE;
     }
-    else if (const auto feedbackType = as<FeedbackType>(type))
+    else if (const auto feedbackType = as<FeedbackType>(type); feedbackType)
     {
         return SLANG_TYPE_KIND_FEEDBACK;
     }
-    else if (const auto ptrType = as<PtrType>(type))
+    else if (const auto ptrType = as<PtrType>(type); ptrType)
     {
         return SLANG_TYPE_KIND_POINTER;
     }
-    else if (const auto dynamicResourceType = as<DynamicResourceType>(type))
+    else if (const auto dynamicResourceType = as<DynamicResourceType>(type); dynamicResourceType)
     {
         return SLANG_TYPE_KIND_DYNAMIC_RESOURCE;
     }
@@ -490,7 +490,7 @@ SLANG_API SlangTypeKind spReflectionType_GetKind(SlangReflectionType* inType)
     CASE(GLSLShaderStorageBufferType);
 #undef CASE
 
-    else if (const auto arrayType = as<ArrayExpressionType>(type))
+    else if (const auto arrayType = as<ArrayExpressionType>(type); arrayType)
     {
         return SLANG_TYPE_KIND_ARRAY;
     }
@@ -519,11 +519,11 @@ SLANG_API SlangTypeKind spReflectionType_GetKind(SlangReflectionType* inType)
             return SLANG_TYPE_KIND_ENUM;
         }
     }
-    else if (const auto specializedType = as<ExistentialSpecializedType>(type))
+    else if (const auto specializedType = as<ExistentialSpecializedType>(type); specializedType)
     {
         return SLANG_TYPE_KIND_SPECIALIZED;
     }
-    else if (const auto errorType = as<ErrorType>(type))
+    else if (const auto errorType = as<ErrorType>(type); errorType)
     {
         // This means we saw a type we didn't understand in the user's code
         return SLANG_TYPE_KIND_NONE;
@@ -690,7 +690,7 @@ SLANG_API unsigned int spReflectionType_GetRowCount(SlangReflectionType* inType)
     {
         return (unsigned int)getIntVal(matrixType->getRowCount());
     }
-    else if (const auto vectorType = as<VectorExpressionType>(type))
+    else if (const auto vectorType = as<VectorExpressionType>(type); vectorType)
     {
         return 1;
     }
@@ -1847,7 +1847,8 @@ SlangBindingType _calcResourceBindingType(Type* type)
             return SlangBindingType(SLANG_BINDING_TYPE_TYPED_BUFFER | mutableFlag);
         }
     }
-    else if (const auto structuredBufferType = as<HLSLStructuredBufferTypeBase>(type))
+    else if (const auto structuredBufferType = as<HLSLStructuredBufferTypeBase>(type);
+             structuredBufferType)
     {
         if (as<HLSLStructuredBufferType>(type))
         {
@@ -1862,7 +1863,7 @@ SlangBindingType _calcResourceBindingType(Type* type)
     {
         return SLANG_BINDING_TYPE_RAY_TRACING_ACCELERATION_STRUCTURE;
     }
-    else if (const auto untypedBufferType = as<UntypedBufferResourceType>(type))
+    else if (const auto untypedBufferType = as<UntypedBufferResourceType>(type); untypedBufferType)
     {
         if (as<HLSLByteAddressBufferType>(type))
         {

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -3048,7 +3048,7 @@ static LayoutSize GetElementCount(IntVal* val)
             return LayoutSize::infinite();
         return LayoutSize(LayoutSize::RawValue(constantVal->getValue()));
     }
-    else if (const auto varRefVal = as<DeclRefIntVal>(val))
+    else if (const auto varRefVal = as<DeclRefIntVal>(val); varRefVal)
     {
         // TODO: We want to treat the case where the number of
         // elements in an array depends on a generic parameter
@@ -3060,7 +3060,7 @@ static LayoutSize GetElementCount(IntVal* val)
         //
         return LayoutSize::invalid();
     }
-    else if (const auto polyIntVal = as<PolynomialIntVal>(val))
+    else if (const auto polyIntVal = as<PolynomialIntVal>(val); polyIntVal)
     {
         return LayoutSize::invalid();
     }
@@ -3621,7 +3621,8 @@ RefPtr<TypeLayout> applyOffsetToTypeLayout(
     bool anyHit = false;
     for (auto oldResInfo : oldTypeLayout->resourceInfos)
     {
-        if (const auto offsetResInfo = offsetVarLayout->FindResourceInfo(oldResInfo.kind))
+        if (const auto offsetResInfo = offsetVarLayout->FindResourceInfo(oldResInfo.kind);
+            offsetResInfo)
         {
             anyHit = true;
             break;
@@ -3717,7 +3718,8 @@ IRTypeLayout* applyOffsetToTypeLayout(
     for (auto oldResInfo : oldTypeLayout->getSizeAttrs())
     {
         if (const auto offsetResInfo =
-                offsetVarLayout->findOffsetAttr(oldResInfo->getResourceKind()))
+                offsetVarLayout->findOffsetAttr(oldResInfo->getResourceKind());
+            offsetResInfo)
         {
             anyHit = true;
             break;
@@ -5775,8 +5777,9 @@ static TypeLayoutResult _createTypeLayout(TypeLayoutContext& context, Type* type
                 // If the field has an explicit offset, then we will
                 // use that to place it.
                 //
-                if (const auto packOffsetModifier =
-                        field.getDecl()->findModifier<HLSLPackOffsetSemantic>())
+                if (auto packOffsetModifier =
+                        field.getDecl()->findModifier<HLSLPackOffsetSemantic>();
+                    packOffsetModifier)
                 {
                     TypeLayoutResult fieldResult = _createTypeLayout(
                         context,
@@ -5789,8 +5792,9 @@ static TypeLayoutResult _createTypeLayout(TypeLayoutContext& context, Type* type
             for (auto field :
                  getFields(context.astBuilder, structDeclRef, MemberFilterStyle::Instance))
             {
-                if (const auto packOffsetModifier =
-                        field.getDecl()->findModifier<HLSLPackOffsetSemantic>())
+                if (auto packOffsetModifier =
+                        field.getDecl()->findModifier<HLSLPackOffsetSemantic>();
+                    packOffsetModifier)
                     continue;
 
                 // The fields of a `struct` type may include existential (interface)
@@ -6053,6 +6057,9 @@ static TypeLayoutResult _createTypeLayout(TypeLayoutContext& context, Type* type
                         break;
                     }
                 }
+                // TODO: PR #1612 (Theresa Foley) - fits is computed but never used.
+                // The intended use was to branch on fits to select storage strategy.
+                SLANG_UNUSED(fits);
             }
             // Interface type occupies a uniform slot for the fixed size storage, with alignment of
             // 4 bytes.

--- a/tools/gfx/vulkan/vk-command-encoder.cpp
+++ b/tools/gfx/vulkan/vk-command-encoder.cpp
@@ -488,6 +488,8 @@ void ResourceCommandEncoder::uploadTextureData(
         dstData += uploadBufferOffset;
         uint8_t* dstDataStart;
         dstDataStart = dstData;
+        // TODO: PR #2244 (lucy96chen) - dstDataStart is set but never used.
+        SLANG_UNUSED(dstDataStart);
 
         Offset dstSubresourceOffset = 0;
         for (GfxIndex i = 0; i < subResourceRange.layerCount; ++i)

--- a/tools/gfx/vulkan/vk-device.cpp
+++ b/tools/gfx/vulkan/vk-device.cpp
@@ -1762,6 +1762,8 @@ Result DeviceImpl::createTextureResource(
             m_api.vkMapMemory(m_device, uploadBuffer.m_memory, 0, bufferSize, 0, (void**)&dstData);
             uint8_t* dstDataStart;
             dstDataStart = dstData;
+            // TODO: PR #2244 (lucy96chen) - dstDataStart is set but never used.
+            SLANG_UNUSED(dstDataStart);
 
             Offset dstSubresourceOffset = 0;
             for (int i = 0; i < arraySize; ++i)

--- a/tools/platform/apple/cocoa-window.mm
+++ b/tools/platform/apple/cocoa-window.mm
@@ -299,6 +299,7 @@ static KeyCode getKeyCode(NSUInteger keyCode)
         deltaX *= 0.1;
         deltaY *= 0.1;
     }
+    SLANG_UNUSED(deltaX);
 
     int delta = (int)deltaY;
 

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -1308,6 +1308,8 @@ void RenderTestApp::setProjectionMatrix(IShaderObject* rootObject)
     float kIdentity[16] =
         {1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f};
     auto info = m_device->getInfo();
+    // TODO: PR #7303 (Simon Kallweit) - info is set but never used.
+    SLANG_UNUSED(info);
     ShaderCursor(rootObject)
         .getField("Uniforms")
         .getDereferenced()

--- a/tools/slang-capability-generator/capability-generator-main.cpp
+++ b/tools/slang-capability-generator/capability-generator-main.cpp
@@ -282,7 +282,7 @@ public:
             for (auto keyAtom : sharedKeyAtomsInCanonicalSet_stage)
                 this->keyAtomsPresent.add(keyAtom);
         }
-        if (const auto base = this->getAbstractBase(); base)
+        if (auto base = this->getAbstractBase(); base)
             keyAtomsPresent.add(this);
     }
 };

--- a/tools/slang-capability-generator/capability-generator-main.cpp
+++ b/tools/slang-capability-generator/capability-generator-main.cpp
@@ -272,6 +272,9 @@ public:
                 }
                 keyAtomsFound.clear();
             }
+            // TODO: PR #4237 (ArielG-NV) - alreadySetStage is set but never read.
+            // Line 249 uses !alreadySetTarget instead of !alreadySetStage, which is likely a bug.
+            SLANG_UNUSED(alreadySetStage);
 
             // add all shared key atoms
             for (auto keyAtom : sharedKeyAtomsInCanonicalSet_target)
@@ -279,7 +282,7 @@ public:
             for (auto keyAtom : sharedKeyAtomsInCanonicalSet_stage)
                 this->keyAtomsPresent.add(keyAtom);
         }
-        if (auto base = this->getAbstractBase())
+        if (const auto base = this->getAbstractBase(); base)
             keyAtomsPresent.add(this);
     }
 };

--- a/tools/slang-cpp-parser/parser.cpp
+++ b/tools/slang-cpp-parser/parser.cpp
@@ -659,6 +659,8 @@ SlangResult Parser::_maybeParseNode(Node::Kind kind)
     }
 
     const Token braceToken = m_reader.advanceToken();
+    // TODO: PR #2159 (jsmall-nvidia) - braceToken is set but never used.
+    SLANG_UNUSED(braceToken);
 
     // Push the class scope
     return pushScope(node);

--- a/tools/slang-fiddle/slang-fiddle-scrape.cpp
+++ b/tools/slang-fiddle/slang-fiddle-scrape.cpp
@@ -1063,7 +1063,7 @@ private:
         {
             checkMemberDecls(namespaceDecl);
         }
-        else if (const auto varDecl = as<VarDecl>(decl); varDecl)
+        else if (auto varDecl = as<VarDecl>(decl); varDecl)
         {
             // Note: for now we aren't trying to check the type
             // or the initial-value expression of a field.

--- a/tools/slang-fiddle/slang-fiddle-scrape.cpp
+++ b/tools/slang-fiddle/slang-fiddle-scrape.cpp
@@ -1063,7 +1063,7 @@ private:
         {
             checkMemberDecls(namespaceDecl);
         }
-        else if (auto varDecl = as<VarDecl>(decl))
+        else if (const auto varDecl = as<VarDecl>(decl); varDecl)
         {
             // Note: for now we aren't trying to check the type
             // or the initial-value expression of a field.

--- a/tools/slang-reflection-test/slang-reflection-test-main.cpp
+++ b/tools/slang-reflection-test/slang-reflection-test-main.cpp
@@ -65,10 +65,6 @@ innerMain(Slang::StdWriters* stdWriters, SlangSession* session, int argc, const 
         spSetWriter(request, channel, stdWriters->getWriter(channel));
     }
 
-    char const* appName = "slang-reflection-test";
-    if (argc > 0)
-        appName = argv[0];
-
     SlangResult res = performCompilationAndReflection(request, argc, argv);
 
     spDestroyCompileRequest(request);

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1425,7 +1425,6 @@ static SlangResult _extractRenderTestRequirements(
     }
 
     // The native language for the API
-    SlangSourceLanguage nativeLanguage = SLANG_SOURCE_LANGUAGE_UNKNOWN;
     SlangCompileTarget target = SLANG_TARGET_NONE;
     SlangPassThrough passThru = SLANG_PASS_THROUGH_NONE;
 
@@ -1433,12 +1432,10 @@ static SlangResult _extractRenderTestRequirements(
     {
     case RenderApiType::D3D11:
         target = SLANG_DXBC;
-        nativeLanguage = SLANG_SOURCE_LANGUAGE_HLSL;
         passThru = SLANG_PASS_THROUGH_FXC;
         break;
     case RenderApiType::D3D12:
         target = SLANG_DXIL;
-        nativeLanguage = SLANG_SOURCE_LANGUAGE_HLSL;
         passThru = SLANG_PASS_THROUGH_DXC;
         if (useDxbc)
         {
@@ -1448,40 +1445,32 @@ static SlangResult _extractRenderTestRequirements(
         break;
     case RenderApiType::Vulkan:
         target = SLANG_SPIRV;
-        nativeLanguage = SLANG_SOURCE_LANGUAGE_GLSL;
         passThru = SLANG_PASS_THROUGH_GLSLANG;
         break;
     case RenderApiType::Metal:
         target = SLANG_METAL_LIB;
-        nativeLanguage = SLANG_SOURCE_LANGUAGE_METAL;
         passThru = SLANG_PASS_THROUGH_METAL;
         break;
     case RenderApiType::CPU:
         target = SLANG_SHADER_HOST_CALLABLE;
-        nativeLanguage = SLANG_SOURCE_LANGUAGE_CPP;
         passThru = SLANG_PASS_THROUGH_GENERIC_C_CPP;
         break;
     case RenderApiType::CUDA:
         target = SLANG_PTX;
-        nativeLanguage = SLANG_SOURCE_LANGUAGE_CUDA;
         passThru = SLANG_PASS_THROUGH_NVRTC;
         break;
     case RenderApiType::WebGPU:
         target = SLANG_WGSL;
-        nativeLanguage = SLANG_SOURCE_LANGUAGE_WGSL;
         passThru = SLANG_PASS_THROUGH_TINT;
         break;
     case RenderApiType::LLVM:
         target = SLANG_SHADER_HOST_CALLABLE;
-        nativeLanguage = SLANG_SOURCE_LANGUAGE_LLVM;
         passThru = SLANG_PASS_THROUGH_NONE;
         break;
     }
 
-    SlangSourceLanguage sourceLanguage = nativeLanguage;
     if (!usePassthru)
     {
-        sourceLanguage = SLANG_SOURCE_LANGUAGE_SLANG;
         passThru = SLANG_PASS_THROUGH_NONE;
     }
 

--- a/tools/slang-unit-test/unit-test-memory-arena.cpp
+++ b/tools/slang-unit-test/unit-test-memory-arena.cpp
@@ -136,7 +136,6 @@ SLANG_UNIT_TEST(memoryArena)
     }
 
     {
-        int count = 0;
         const size_t blockSize = 1024;
 
         for (TestMode mode = TestMode(0); int(mode) < int(TestMode::eCount);
@@ -151,8 +150,6 @@ SLANG_UNIT_TEST(memoryArena)
 
             for (int i = 0; i < 10000; i++)
             {
-                count++;
-
                 const int var = randGen.nextInt32() & 0x3ff;
                 if (var < 3 && blocks.getCount() > 0)
                 {


### PR DESCRIPTION
This PR re-enables the unused-variable warnings for Clang and GCC.
Because it turned out to be useful.

The current warnings are silenced with SLANG_UNUSED.
They need to be properly addressed later.

The Slang code pattern of `if (auto v = as<YY>(inst))` will trigger the unused-variable warning.
We could silence it with SLANG_UNUSED but we will use the pattern of `if (auto v = as<YY>(inst); v)` which is C++17 syntax without a macro-magic.