### PR TITLE
ci/slang-coverage: dump llvm-cov report text as artifact

### DIFF
--- a/.github/workflows/ci-slang-coverage.yml
+++ b/.github/workflows/ci-slang-coverage.yml
@@ -346,6 +346,20 @@ jobs:
           # Generate slangc compiler-only coverage report
           SLANGC_REPORT_OUTPUT=$($LLVM_COV report "$LIBSLANG" -instr-profile="$COVERAGE_DIR/slang-test.profdata" "${SLANGC_IGNORE_ARGS[@]}" 2>/dev/null || echo "")
 
+          # Persist the report text as artifacts. Downstream tools
+          # (merger / renderer with --auth-summary) need llvm-cov's
+          # authoritative per-file totals to match the published
+          # per-platform numbers — the LCOV alone has more BRDA / FN
+          # records than llvm-cov report counts post-collapse, so we
+          # can't reconstruct those totals from the LCOV side. Tiny
+          # files (~100-200 KB per OS, plain text), zero extra runtime.
+          if [[ -n "$REPORT_OUTPUT" ]]; then
+            echo "$REPORT_OUTPUT" > coverage-report.txt
+          fi
+          if [[ -n "$SLANGC_REPORT_OUTPUT" ]]; then
+            echo "$SLANGC_REPORT_OUTPUT" > coverage-report-slangc.txt
+          fi
+
           if [[ -n "$REPORT_OUTPUT" ]]; then
             TOTALS_LINE=$(echo "$REPORT_OUTPUT" | grep "^TOTAL" | head -1)
 
@@ -515,10 +529,15 @@ jobs:
         with:
           name: coverage-${{ inputs.os }}-${{ inputs.platform }}
           # coverage-html-slangc/ and libslang.* are Linux/macOS-only; the
-          # Cobertura XML and slangc LCOV are Windows-only. upload-artifact
-          # silently skips missing paths, so one path list works for all OSes.
+          # Cobertura XML and slangc LCOV are Windows-only;
+          # coverage-report*.txt are Linux/macOS-only (llvm-cov report
+          # text, not produced from OpenCppCoverage).
+          # upload-artifact silently skips missing paths, so one path
+          # list works for all OSes.
           path: |
             coverage-summary.json
+            coverage-report.txt
+            coverage-report-slangc.txt
             coverage-html/
             coverage-html-slangc/
             coverage-slangc.lcov


### PR DESCRIPTION
## Summary

Persists the `llvm-cov report` output we already capture (for
`coverage-summary.json`'s percentages) to two text files in the
per-OS coverage artifact:

- `coverage-report.txt` — full library, `llvm-cov report` TOTAL + per-file rows
- `coverage-report-slangc.txt` — same shape, slangc-filtered

Linux/macOS only. Windows uses OpenCppCoverage (no llvm-cov in the loop), and `actions/upload-artifact@v4` silently skips missing paths, so one path list works for all OSes.

## Why

Companion change for [#10948](https://github.com/shader-slang/slang/pull/10948) (the new `tools/coverage-html/` toolchain). The merger / renderer there consume the LCOV produced by `llvm-cov export -format=lcov`, which emits more `BRDA` / `FN` records than `llvm-cov report` counts (post-export, the report tool collapses some). The collapse can't be reproduced from the LCOV alone, so the merger's branch-coverage numbers run ~8 pp below what's published on <https://shader-slang.org/slang-coverage-reports/> for Linux/macOS.

A planned consumer-side flag — `--auth-summary <file>` on `slang-coverage-merge` / `slang-coverage-html` — will read this report text and use its per-file totals as the source of truth, closing the gap exactly. Landing this CI artifact change first lets us iterate on that consumer side against real artifacts before [#10948](https://github.com/shader-slang/slang/pull/10948) merges.

## Cost

- Zero extra `llvm-cov` invocations (we just persist the stdout we were already capturing).
- ~100–200 KB extra artifact per OS (plain text).
- ~0 ms extra runtime.

## Test plan

- [ ] Trigger `coverage-nightly.yml` manually on this branch (`workflow_dispatch`) and verify the new files appear in the `coverage-{linux,macos}-*` artifacts.
- [ ] Confirm the Windows artifact is unchanged (the new files are missing, which is expected).
- [ ] Confirm `coverage-summary.json`, `coverage-html/`, and the existing per-OS LCOV are unchanged.
