### PR TITLE
Add IR-pass unit-testing fixture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,14 @@ option(SLANG_ENABLE_DXIL "Enable generating DXIL with DXC" ON)
 option(SLANG_ENABLE_FULL_IR_VALIDATION "Enable full IR validation (SLOW!)")
 option(SLANG_ENABLE_IR_BREAK_ALLOC "Enable _debugUID on IR allocation")
 option(
+    SLANG_BUILD_FOR_TESTING
+    "Expose internal symbols decorated with SLANG_INTERNAL_TEST_API so that the slang-unit-test plugin can link against them. See docs/design/ir-pass-unit-testing.md and shader-slang/slang#10950."
+    ON
+)
+if(SLANG_BUILD_FOR_TESTING)
+    add_compile_definitions(SLANG_BUILD_FOR_TESTING=1)
+endif()
+option(
     SLANG_IGNORE_ABORT_MSG
     "Ignore the system modal assert dialog while running build tools to help LLM workflow."
     OFF

--- a/docs/design/ir-pass-unit-testing.md
+++ b/docs/design/ir-pass-unit-testing.md
@@ -1,0 +1,264 @@
+# IR Pass Unit Testing
+
+A fixture-style harness for writing unit tests against individual
+IR passes, as an alternative to the `slang-test` end-to-end
+shader tests.
+
+This document describes what the harness supports and how to use
+it. It complements `docs/design/ir.md` (the IR's design) and
+`docs/design/ir-instruction-definition.md` (how new IR
+instructions are added).
+
+## Why
+
+End-to-end `.slang` shader tests are the only way to test IR
+passes today. They couple every test to the full Slang frontend,
+take tens of milliseconds per minimal compile, force tests to
+construct elaborate Slang source for passes that only care about
+a 5-instruction shape, and read as Slang code rather than as IR
+preconditions. The fixture in this document removes those
+constraints for tests that don't need an end-to-end compile.
+
+## Constructing an IRFixture
+
+A test starts by getting an `IRFixture` — a move-only handle that
+owns an `IRModule*` plus the session that produced it. There are
+two constructors.
+
+### From a Slang source string
+
+```cpp
+#include "ir-fixture.h"
+
+SLANG_UNIT_TEST(myTest)
+{
+    auto f = compileSlangToIR(R"(
+        int identity(int x) { return x; }
+    )");
+    SLANG_CHECK_ABORT(f.module() != nullptr);
+    SLANG_CHECK(f.errorMessage().getLength() == 0);
+    SLANG_CHECK(f.countInsts(kIROp_Func) >= 1);
+}
+```
+
+`compileSlangToIR` runs the source through the public Slang
+frontend and returns a fixture wrapping the resulting `IRModule*`.
+On compile failure `module()` is null and `errorMessage()` is
+populated.
+
+Use this constructor when the test wants realistic IR the
+frontend would naturally emit.
+
+### From a hand-built IRModule
+
+```cpp
+#include "ir-fixture-builder.h"
+
+SLANG_UNIT_TEST(myPassTest)
+{
+    IRFixtureBuilder b;
+    b.addVoidFunction(/*keepAlive*/ true);
+    b.emitReturnVoid();
+    b.addVoidFunction(/*keepAlive*/ false);
+    b.emitReturnVoid();
+    IRFixture f = b.build();
+
+    eliminateDeadCode(f.module());
+    SLANG_CHECK(f.countInsts(kIROp_Func) == 1);
+}
+```
+
+`IRFixtureBuilder` constructs an `IRModule` directly via
+`IRBuilder` and hands ownership to the returned `IRFixture` on
+`build()`. The DSL is intentionally minimal — a primitive lands
+when a test needs it, never speculatively.
+
+Use this constructor when the test wants an IR shape the frontend
+wouldn't naturally emit (orphan blocks, exotic phi shapes,
+hand-crafted CFGs, distinguishing decoration patterns the
+frontend papers over).
+
+## Inspecting the fixture
+
+```cpp
+class IRFixture
+{
+public:
+    /// Underlying IR module. Lives until the fixture is destructed.
+    IRModule* module() const;
+
+    /// Compiled module wrapper (compileSlangToIR only); nullptr
+    /// for builder-constructed fixtures.
+    Module* slangModule() const;
+
+    /// Diagnostic text from the underlying compile, or empty.
+    const String& errorMessage() const;
+
+    /// True iff `module()` is non-null. Deeper IR-validator
+    /// checks land when a test needs them.
+    bool isValid() const;
+
+    /// Count instructions of opcode `op` anywhere in the module.
+    Index countInsts(IROp op) const;
+
+    /// Return the first instruction in the module (in document
+    /// order) whose opcode equals `op`, or nullptr.
+    IRInst* findFirstInst(IROp op) const;
+};
+```
+
+The opcode walks (`countInsts`, `findFirstInst`) traverse every
+transitive child of the module's root inst using the public
+`IRInstListBase::first` field and the public `IRInst::next`
+pointer:
+
+```cpp
+for (IRInst* sub = cur->m_decorationsAndChildren.first;
+     sub;
+     sub = sub->next)
+{
+    work.add(sub);
+}
+```
+
+This avoids the `getChildren()` and `getDecorations()` iterators,
+which are inline-but-call-out-of-line in `slang-ir.cpp`.
+
+## Running a pass against the fixture
+
+Tests call internal pass entry points directly on
+`f.module()`. The pass entry point must be reachable from the
+test plugin — see "Visibility" below.
+
+```cpp
+auto f = compileSlangToIR(R"(...)");
+SLANG_CHECK_ABORT(f.module() != nullptr);
+
+bool changed = eliminateDeadCode(f.module());
+SLANG_CHECK(changed);
+SLANG_CHECK(f.countInsts(kIROp_LiveRangeStart) >= 2);
+```
+
+## Visibility: making internal symbols reachable
+
+`libslang-compiler.dylib` is built with hidden symbol visibility,
+so internal classes and pass entry points aren't reachable from
+the test plugin by default.
+
+A new macro `SLANG_INTERNAL_TEST_API` (defined in
+`include/slang.h`) decorates internal symbols with default
+visibility. It is gated on the CMake option
+`SLANG_BUILD_FOR_TESTING` (default ON):
+
+- When the option is on, the macro expands to the same
+  `dllexport` / `visibility(default)` attribute used by
+  `SLANG_API`. Decorated symbols become reachable from the test
+  plugin.
+- When the option is off (e.g. shipping builds), the macro
+  expands to nothing — decorated symbols stay hidden.
+
+The macro applies at class scope (e.g.
+`struct SLANG_INTERNAL_TEST_API IRBuilder { … }` exports every
+non-template member of the class) or at function scope for free
+functions and statics.
+
+Symbols decorated today:
+
+| Symbol                   | Used by                                   |
+| ------------------------ | ----------------------------------------- |
+| `IRBuilder` (class)      | `IRFixtureBuilder` calls into `IRBuilder` |
+| `IRUse` (class)          | `IRInst::setFullType` calls `IRUse::init` |
+| `IRModule::create`       | Builder constructs a fresh module         |
+| `eliminateDeadCode(...)` | Reference test invokes the pass           |
+
+### Adding a new pass test
+
+When a test needs a pass that isn't yet decorated, annotate the
+entry point in its declaration:
+
+```cpp
+SLANG_INTERNAL_TEST_API bool eliminateDeadCode(
+    IRModule* module,
+    IRDeadCodeEliminationOptions const& options = {});
+```
+
+Annotate at class scope when the test needs many members of the
+same class (`IRBuilder`, `IRUse`); annotate at function scope for
+single free functions.
+
+### Reusing the mechanism for other subsystems
+
+`SLANG_INTERNAL_TEST_API` and `SLANG_BUILD_FOR_TESTING` are not
+IR-specific — they are a generic visibility escape hatch. The
+same three pieces stand up a fixture for any internal subsystem
+(AST, mangling, serialization, …):
+
+1. **Annotate the symbols the new fixture needs.** Class scope
+   for "expose all members" (e.g.
+   `class SLANG_INTERNAL_TEST_API ASTBuilder { … }`), function
+   scope for individual entry points. The annotation list grows
+   one entry at a time as new tests demand symbols.
+2. **Make sure `slang-unit-test` can include the relevant
+   headers.** Transitive includes from the subsystem's root
+   header (`slang-ast-base.h`, `slang-mangle.h`, …) must resolve.
+   Most paths already work because `slang-fiddle-output` and the
+   capability libraries are linked in; if a new transitive
+   include surfaces a missing dep, add it as a private link of
+   `slang-unit-test` in `tools/CMakeLists.txt`. These deps
+   propagate include directories only — they don't substitute
+   for `SLANG_INTERNAL_TEST_API`.
+3. **Build a fixture wrapper analogous to `IRFixture`** that
+   owns the subsystem's root object and the session that
+   produced it (e.g. `RefPtr<ModuleDecl>` for AST, plus a
+   ComPtr to keep the underlying `Linkage` alive). Provide a
+   "from source" constructor and, where it adds value, a
+   "from hand-built" builder.
+
+The same `SLANG_BUILD_FOR_TESTING` flag controls all of these.
+Turning it on once exposes whatever subsystems have been
+decorated.
+
+## What's not covered
+
+- **AST-level pass tests.** Frontend passes (semantic check, AST
+  → IR lowering) can't be isolated by this fixture; they remain
+  end-to-end tested.
+- **Target-specific emit tests.** Backends consume IR; emit tests
+  are better written as `.slang` → expected target-asm
+  comparisons.
+- **Pass interaction tests** (pass A → pass B → assert) are
+  integration tests, not unit tests; the existing `.slang` E2E
+  tests cover those.
+- **Function lookup by source-level name.** Tests today identify
+  functions positionally via `findFirstInst(kIROp_Func)`. Adding
+  `findFuncByName` requires decorating
+  `IRConstant::getStringSlice` and `IRInst::getOperands`.
+- **Validator-backed `isValid()`.** Today `isValid()` only checks
+  that the module pointer is non-null; calling `validateIRModule`
+  needs a `DiagnosticSink` and a decoration on the validator
+  entry point.
+
+## Files
+
+```
+include/slang.h                              # SLANG_INTERNAL_TEST_API macro
+
+source/slang/
+├── slang-ir.h                               # SLANG_INTERNAL_TEST_API on IRUse, IRModule::create
+├── slang-ir-insts.h                         # SLANG_INTERNAL_TEST_API on IRBuilder
+└── slang-ir-dce.h                           # SLANG_INTERNAL_TEST_API on eliminateDeadCode
+
+tools/slang-unit-test/
+├── ir-fixture.{h,cpp}                       # IRFixture + compileSlangToIR
+├── ir-fixture-builder.{h,cpp}               # IRFixtureBuilder
+├── unit-test-ir-fixture.cpp                 # reference tests for compileSlangToIR
+└── unit-test-ir-fixture-builder.cpp         # reference test for IRFixtureBuilder
+```
+
+## Build wiring
+
+`slang-unit-test` has private link deps on `slang-fiddle-output`,
+`slang-capability-defs`, and `slang-capability-lookup` so the
+headers transitively pulled in by `slang-ir.h` resolve. These
+propagate include directories only; symbol visibility is handled
+separately by `SLANG_INTERNAL_TEST_API`.

--- a/include/slang.h
+++ b/include/slang.h
@@ -261,6 +261,32 @@ convention for interface methods.
     #define SLANG_API
 #endif
 
+// `SLANG_INTERNAL_TEST_API` decorates internal symbols with default
+// visibility so that the slang-unit-test plugin can link against them.
+//
+// In normal builds the macro expands to nothing — the symbol stays
+// hidden, just like every other internal symbol in
+// `libslang-compiler.dylib`. When CMake is configured with
+// `-DSLANG_BUILD_FOR_TESTING=ON`, it expands to the same
+// dllexport / visibility(default) attribute used by `SLANG_API`.
+//
+// The escape hatch is intended for test-only access to internal
+// utilities. See `docs/design/ir-pass-unit-testing.md` and
+// shader-slang/slang#10950 for context.
+#if defined(SLANG_BUILD_FOR_TESTING)
+    #if defined(_MSC_VER)
+        #ifdef SLANG_DYNAMIC_EXPORT
+            #define SLANG_INTERNAL_TEST_API SLANG_DLL_EXPORT
+        #else
+            #define SLANG_INTERNAL_TEST_API __declspec(dllimport)
+        #endif
+    #else
+        #define SLANG_INTERNAL_TEST_API SLANG_DLL_EXPORT
+    #endif
+#else
+    #define SLANG_INTERNAL_TEST_API
+#endif
+
 // GCC Specific
 #if SLANG_GCC_FAMILY
     #define SLANG_NO_INLINE __attribute__((noinline))

--- a/source/slang/slang-ir-dce.h
+++ b/source/slang/slang-ir-dce.h
@@ -22,7 +22,7 @@ struct IRDeadCodeEliminationOptions
 /// types that are unused, functions that are never called,
 /// etc.
 /// Returns true if changed.
-bool eliminateDeadCode(
+SLANG_INTERNAL_TEST_API bool eliminateDeadCode(
     IRModule* module,
     IRDeadCodeEliminationOptions const& options = IRDeadCodeEliminationOptions());
 

--- a/source/slang/slang-ir-insts.h
+++ b/source/slang/slang-ir-insts.h
@@ -3020,7 +3020,7 @@ struct IR$(inst.struct_name) : IR$(inst.parent_struct)
 
 struct IRBuilderSourceLocRAII;
 
-struct IRBuilder
+struct SLANG_INTERNAL_TEST_API IRBuilder
 {
 private:
     /// Deduplication context from the module.

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -110,7 +110,7 @@ struct IROpInfo
 IROpInfo getIROpInfo(IROp op);
 
 // A use of another value/inst within an IR operation
-struct IRUse
+struct SLANG_INTERNAL_TEST_API IRUse
 {
     IRInst* get() const { return usedValue; }
     IRInst* getUser() const { return user; }
@@ -2062,7 +2062,7 @@ public:
         kMemoryArenaBlockSize = 16 * 1024, ///< Use 16k block size for memory arena
     };
 
-    static RefPtr<IRModule> create(Session* session);
+    SLANG_INTERNAL_TEST_API static RefPtr<IRModule> create(Session* session);
 
     SLANG_FORCE_INLINE Session* getSession() const { return m_session; }
     SLANG_FORCE_INLINE IRModuleInst* getModuleInst() const { return m_moduleInst; }

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -410,7 +410,15 @@ if(SLANG_ENABLE_TESTS AND SLANG_ENABLE_SLANG_RHI)
             SLANG_SHARED_LIBRARY_TOOL
             SLANG_NO_DEPRECATION
         USE_FEWER_WARNINGS
-        LINK_WITH_PRIVATE core compiler-core unit-test slang Threads::Threads
+        LINK_WITH_PRIVATE
+            core
+            compiler-core
+            unit-test
+            slang
+            slang-fiddle-output
+            slang-capability-defs
+            slang-capability-lookup
+            Threads::Threads
         PRECOMPILE_HEADERS ${SLANG_TOOLS_PCH}
         OUTPUT_NAME slang-unit-test-tool
         FOLDER test/tools

--- a/tools/slang-unit-test/ir-fixture-builder.cpp
+++ b/tools/slang-unit-test/ir-fixture-builder.cpp
@@ -1,0 +1,140 @@
+// ir-fixture-builder.cpp
+//
+// Implementation of `IRFixtureBuilder` (Approach B in
+// `docs/design/ir-pass-unit-testing.md`).
+
+#include "ir-fixture-builder.h"
+
+#include "../../include/slang-com-ptr.h"
+#include "../../include/slang.h"
+#include "../../source/slang/slang-ir-insts.h"
+#include "../../source/slang/slang-ir.h"
+#include "../../source/slang/slang-session.h"
+
+namespace Slang
+{
+
+namespace
+{
+
+// Same global-session caching strategy as `compileSlangToIR` —
+// constructing an IGlobalSession is expensive, and the per-session
+// state we touch (target list, capability sets) doesn't matter
+// for hand-built IR.
+ComPtr<slang::IGlobalSession> _getOrCreateGlobalSession()
+{
+    static ComPtr<slang::IGlobalSession> s_globalSession;
+    if (!s_globalSession)
+    {
+        slang_createGlobalSession(SLANG_API_VERSION, s_globalSession.writeRef());
+    }
+    return s_globalSession;
+}
+
+// `IRModule::create` requires a `Slang::Session*` (the internal
+// type), not a `slang::ISession*`. The path to an internal Session
+// is: ISession -> Linkage (internal) -> Session. We obtain Linkage
+// by static_cast'ing the public ISession, and ask Linkage for its
+// owning Session via `getSessionImpl()`.
+ComPtr<slang::ISession> _createTestSession(slang::IGlobalSession* globalSession)
+{
+    slang::TargetDesc targetDesc = {};
+    targetDesc.format = SLANG_SPIRV;
+    targetDesc.profile = globalSession->findProfile("spirv_1_5");
+
+    slang::SessionDesc sessionDesc = {};
+    sessionDesc.targetCount = 1;
+    sessionDesc.targets = &targetDesc;
+
+    ComPtr<slang::ISession> session;
+    globalSession->createSession(sessionDesc, session.writeRef());
+    return session;
+}
+
+} // namespace
+
+struct IRFixtureBuilder::Impl
+{
+    ComPtr<slang::ISession> sessionCom;
+    Session* session = nullptr;
+    RefPtr<IRModule> module;
+    // The IRBuilder is heap-allocated so we can return an IRFunc*
+    // pointing into the live module without exposing the builder
+    // to the caller.
+    IRBuilder builder;
+    // Tracks whether the current insertion point has been "sealed"
+    // by an emitReturn. Subsequent emits without a new function/
+    // block are rejected via a SLANG_ASSERT.
+    bool currentBlockSealed = true;
+};
+
+IRFixtureBuilder::IRFixtureBuilder()
+    : m_impl(new Impl())
+{
+    auto globalSession = _getOrCreateGlobalSession();
+    m_impl->sessionCom = _createTestSession(globalSession);
+    // The internal `Slang::Session` lives behind the public
+    // `slang::ISession` ComPtr. The cast goes via `Slang::Linkage`
+    // because `Linkage` is the concrete subclass implementing
+    // `ISession`, and `Linkage::getSessionImpl()` returns the
+    // owning `Session*`.
+    auto linkage = static_cast<Linkage*>(m_impl->sessionCom.get());
+    m_impl->session = linkage->getSessionImpl();
+    m_impl->module = IRModule::create(m_impl->session);
+    m_impl->builder = IRBuilder(m_impl->module.get());
+}
+
+IRFixtureBuilder::~IRFixtureBuilder()
+{
+    delete m_impl;
+}
+
+IRFunc* IRFixtureBuilder::addVoidFunction(bool keepAlive)
+{
+    auto& b = m_impl->builder;
+    b.setInsertInto(m_impl->module.get());
+
+    // void()
+    IRType* voidType = b.getVoidType();
+    IRType* funcType = b.getFuncType(0, nullptr, voidType);
+
+    // `createFunc` allocates the function and inserts it under
+    // the module's module-inst (via `addGlobalValue`). It does
+    // *not* set the function's type — we set it explicitly so
+    // later passes that look at `getDataType()` see something
+    // sensible.
+    IRFunc* func = b.createFunc();
+    func->setFullType(funcType);
+
+    // Add an entry block + position the insertion point inside it.
+    b.setInsertInto(func);
+    b.emitBlock();
+
+    if (keepAlive)
+    {
+        b.addKeepAliveDecoration(func);
+    }
+
+    m_impl->currentBlockSealed = false;
+    return func;
+}
+
+void IRFixtureBuilder::emitReturnVoid()
+{
+    SLANG_ASSERT(!m_impl->currentBlockSealed);
+    m_impl->builder.emitReturn();
+    m_impl->currentBlockSealed = true;
+}
+
+IRFixture IRFixtureBuilder::build()
+{
+    IRFixture f;
+    f.m_session = m_impl->sessionCom;
+    f.m_ownedModule = m_impl->module;
+    f.m_irModule = m_impl->module.get();
+    // m_iModule / m_slangModule stay null — there is no public
+    // Slang module wrapper for a hand-built IRModule.
+    return f;
+}
+
+} // namespace Slang

--- a/tools/slang-unit-test/ir-fixture-builder.h
+++ b/tools/slang-unit-test/ir-fixture-builder.h
@@ -1,0 +1,72 @@
+// ir-fixture-builder.h
+//
+// Approach B from `docs/design/ir-pass-unit-testing.md`:
+// build an IRModule directly via `IRBuilder` so tests can construct
+// IR shapes the frontend would never emit (orphan blocks,
+// hand-crafted CFGs, intentionally-dead instructions, etc.).
+//
+// Symbols on `IRBuilder` and the small set of pass entry points
+// the tests need are decorated with `SLANG_INTERNAL_TEST_API` so
+// they are reachable from the test plugin. See #10950.
+
+#ifndef SLANG_TOOLS_UNIT_TEST_IR_FIXTURE_BUILDER_H
+#define SLANG_TOOLS_UNIT_TEST_IR_FIXTURE_BUILDER_H
+
+#include "../../source/core/slang-basic.h"
+#include "ir-fixture.h"
+
+namespace Slang
+{
+
+class Session;
+struct IRBuilder;
+struct IRType;
+struct IRFunc;
+struct IRBlock;
+
+/// Fluent builder that constructs an `IRModule` directly via
+/// `IRBuilder`. Designed for tests that want to exercise a pass
+/// on a hand-crafted IR shape.
+///
+/// Lifetime: the builder owns the underlying `IRBuilder`/`IRModule`
+/// until `build()` is called, at which point ownership of the
+/// module is transferred to the returned `IRFixture`.
+///
+/// The DSL is intentionally tiny — only what the first reference
+/// test in `unit-test-ir-fixture-builder.cpp` actually exercises.
+/// Add primitives as new tests need them; do not pre-emptively
+/// expand the surface.
+class IRFixtureBuilder
+{
+public:
+    IRFixtureBuilder();
+    ~IRFixtureBuilder();
+
+    IRFixtureBuilder(IRFixtureBuilder const&) = delete;
+    IRFixtureBuilder& operator=(IRFixtureBuilder const&) = delete;
+
+    /// Add a top-level void-returning function and position the
+    /// internal insertion point at a fresh entry block in it.
+    /// Subsequent emit calls add instructions to that block.
+    /// `keepAlive=true` attaches a `[KeepAlive]` decoration so DCE
+    /// won't delete the function.
+    IRFunc* addVoidFunction(bool keepAlive);
+
+    /// Emit `return;` (void) into the current block. After this
+    /// the current block is sealed; further emit calls without a
+    /// new function/block will fail (no auto-fallback).
+    void emitReturnVoid();
+
+    /// Finish building and hand off the module to an `IRFixture`.
+    /// After this call the builder is exhausted; reusing it is a
+    /// programming error.
+    IRFixture build();
+
+private:
+    struct Impl;
+    Impl* m_impl;
+};
+
+} // namespace Slang
+
+#endif // SLANG_TOOLS_UNIT_TEST_IR_FIXTURE_BUILDER_H

--- a/tools/slang-unit-test/ir-fixture.cpp
+++ b/tools/slang-unit-test/ir-fixture.cpp
@@ -1,0 +1,182 @@
+// ir-fixture.cpp
+//
+// Implementation of `IRFixture::compileSlangToIR` (Option A in
+// `docs/design/ir-pass-unit-testing.md`).
+//
+// IR traversal is implemented manually using the public linked-list
+// fields of `IRInst` (`m_decorationsAndChildren.first`, `next`)
+// rather than the iterator helpers, because the iterator and walker
+// helpers in `slang-ir.cpp` are not exported from
+// `libslang-compiler.dylib`. See issue #10950.
+
+#include "ir-fixture.h"
+
+#include "../../include/slang-com-ptr.h"
+#include "../../include/slang.h"
+#include "../../source/slang/slang-ir.h"
+#include "../../source/slang/slang-module.h"
+
+namespace Slang
+{
+
+namespace
+{
+
+// One global session per test process — `IGlobalSession` is heavy
+// to create and the per-session state we care about (IR module
+// shape) doesn't depend on global-session config.
+ComPtr<slang::IGlobalSession> _getOrCreateGlobalSession()
+{
+    static ComPtr<slang::IGlobalSession> s_globalSession;
+    if (!s_globalSession)
+    {
+        slang_createGlobalSession(SLANG_API_VERSION, s_globalSession.writeRef());
+    }
+    return s_globalSession;
+}
+
+// Compose a fresh `ISession` with a default SPIRV target. Target
+// choice doesn't affect IR-before-lowering shape, but `createSession`
+// requires at least one target descriptor.
+ComPtr<slang::ISession> _createTestSession(slang::IGlobalSession* globalSession)
+{
+    slang::TargetDesc targetDesc = {};
+    targetDesc.format = SLANG_SPIRV;
+    targetDesc.profile = globalSession->findProfile("spirv_1_5");
+
+    slang::SessionDesc sessionDesc = {};
+    sessionDesc.targetCount = 1;
+    sessionDesc.targets = &targetDesc;
+
+    ComPtr<slang::ISession> session;
+    globalSession->createSession(sessionDesc, session.writeRef());
+    return session;
+}
+
+// Visit `inst` and every transitive child (every entry of its
+// combined decorations-and-children list, recursively). `visitor`
+// is called for each visited instruction; if it returns true the
+// walk short-circuits. Implemented with an explicit work stack to
+// avoid stack overflow on deep IR trees and to avoid relying on
+// any out-of-line walker symbol.
+template<typename Fn>
+bool _walk(IRInst* root, Fn&& visitor)
+{
+    if (!root)
+        return false;
+    List<IRInst*> work;
+    work.add(root);
+    while (work.getCount())
+    {
+        IRInst* cur = work.getLast();
+        work.removeLast();
+        if (visitor(cur))
+            return true;
+        // Walk the linked list of decorations + children using the
+        // public `first` field and `next` pointer. Equivalent to
+        // `cur->getChildren()` but uses no out-of-line accessor.
+        for (IRInst* sub = cur->m_decorationsAndChildren.first; sub; sub = sub->next)
+        {
+            work.add(sub);
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+IRFixture::IRFixture() = default;
+IRFixture::~IRFixture() = default;
+IRFixture::IRFixture(IRFixture&&) noexcept = default;
+IRFixture& IRFixture::operator=(IRFixture&&) noexcept = default;
+
+bool IRFixture::isValid() const
+{
+    return m_irModule != nullptr;
+}
+
+Index IRFixture::countInsts(IROpCode op) const
+{
+    if (!m_irModule)
+        return 0;
+    Index n = 0;
+    // Start the walk at the module's root inst — every global
+    // instruction lives under `getModuleInst()` (an inline accessor
+    // that returns a public field).
+    _walk(
+        m_irModule->getModuleInst(),
+        [&](IRInst* cur)
+        {
+            if ((int)cur->getOp() == op)
+                ++n;
+            return false; // never short-circuit
+        });
+    return n;
+}
+
+IRInst* IRFixture::findFirstInst(IROpCode op) const
+{
+    if (!m_irModule)
+        return nullptr;
+    IRInst* found = nullptr;
+    _walk(
+        m_irModule->getModuleInst(),
+        [&](IRInst* cur)
+        {
+            if ((int)cur->getOp() == op)
+            {
+                found = cur;
+                return true;
+            }
+            return false;
+        });
+    return found;
+}
+
+IRFixture compileSlangToIR(const char* source, const char* entryPointName)
+{
+    IRFixture f;
+
+    auto globalSession = _getOrCreateGlobalSession();
+    if (!globalSession)
+    {
+        f.m_errorMessage = "failed to create global session";
+        return f;
+    }
+
+    auto session = _createTestSession(globalSession);
+    if (!session)
+    {
+        f.m_errorMessage = "failed to create session";
+        return f;
+    }
+    f.m_session = session;
+
+    ComPtr<slang::IBlob> diagnostics;
+    f.m_iModule = session->loadModuleFromSourceString(
+        "ir_fixture_module",
+        nullptr,
+        source,
+        diagnostics.writeRef());
+
+    if (diagnostics)
+    {
+        f.m_errorMessage = String((const char*)diagnostics->getBufferPointer());
+    }
+
+    if (!f.m_iModule)
+        return f;
+
+    // (`entryPointName` is reserved for future use — currently the
+    // module-level compile already runs the IR-pre-lowering passes
+    // we want, regardless of entry-point selection.)
+    (void)entryPointName;
+
+    // Cast the public IModule wrapper to the internal Module class
+    // and reach for the IRModule via the inline accessor.
+    f.m_slangModule = static_cast<Module*>(f.m_iModule.get());
+    f.m_irModule = f.m_slangModule->getIRModule();
+    return f;
+}
+
+} // namespace Slang

--- a/tools/slang-unit-test/ir-fixture.h
+++ b/tools/slang-unit-test/ir-fixture.h
@@ -1,0 +1,128 @@
+// ir-fixture.h
+//
+// Test fixture for IR-pass unit tests. See
+// `docs/design/ir-pass-unit-testing.md` for the design.
+//
+// Two builder modes are described in the design doc:
+//   * Option A — `compileSlangToIR(source)`: compile a Slang source
+//     string and observe / mutate the resulting `IRModule*`.
+//     Implemented here.
+//   * Option B — `IRFixtureBuilder`: a fluent C++ DSL that builds
+//     the IR directly via `IRBuilder`. Sketched in the design doc;
+//     not implemented yet because it requires symbol visibility
+//     of internal `IRBuilder` methods (tracked as #10950).
+//
+// Both styles produce an `IRFixture` so tests can be ported between
+// them as their inputs evolve.
+//
+// Note on the API surface: every accessor here has been chosen so
+// it can be implemented using only inline IR accessors and public
+// IR fields. Anything that would require an out-of-line symbol from
+// `libslang-compiler.dylib` (e.g. `IRInst::getOperands`,
+// `IRConstant::getStringSlice`, `IRInstListBase::Iterator`) is
+// deliberately omitted until #10950 unblocks symbol visibility.
+
+#ifndef SLANG_TOOLS_UNIT_TEST_IR_FIXTURE_H
+#define SLANG_TOOLS_UNIT_TEST_IR_FIXTURE_H
+
+#include "../../include/slang-com-ptr.h"
+#include "../../source/core/slang-basic.h"
+#include "../../source/core/slang-string.h"
+
+namespace slang
+{
+struct IGlobalSession;
+struct ISession;
+struct IModule;
+} // namespace slang
+
+namespace Slang
+{
+
+struct IRModule;
+struct IRInst;
+struct IRFunc;
+class Module;
+
+// Opcode identifier used by `countInsts` / opcode-based queries.
+// We use the bare integer to avoid pulling the full `kIROp_*` enum
+// header (and its FIDDLE-generated bits) into every test TU.
+typedef int IROpCode;
+
+class IRFixture
+{
+public:
+    /// The IRModule wrapped by this fixture. nullptr if the fixture
+    /// was constructed from a compile that failed.
+    IRModule* module() const { return m_irModule; }
+
+    /// The compiled module wrapper (Option A only).
+    Module* slangModule() const { return m_slangModule; }
+
+    /// Diagnostic text from the underlying compile, or empty if
+    /// the compile succeeded.
+    const String& errorMessage() const { return m_errorMessage; }
+
+    /// True iff `module()` is non-null. (Deeper invariant checks
+    /// will be wired through `validateIRModule` once tests need
+    /// post-pass invariant assertions; that path requires a
+    /// DiagnosticSink and is intentionally deferred.)
+    bool isValid() const;
+
+    /// Count instructions whose opcode is `op` anywhere in the
+    /// module (recursively walks every instruction's combined
+    /// decoration+child list using the linked-list pointers
+    /// directly — no out-of-line accessor calls).
+    Index countInsts(IROpCode op) const;
+
+    /// Return the first instruction in the module (in document
+    /// order) whose opcode equals `op`, or nullptr if none.
+    /// Walks the same linked list as `countInsts`.
+    IRInst* findFirstInst(IROpCode op) const;
+
+    /// Move-only: the fixture owns a `RefPtr<Module>` and a
+    /// session reference. Don't copy.
+    IRFixture(IRFixture const&) = delete;
+    IRFixture& operator=(IRFixture const&) = delete;
+    IRFixture(IRFixture&&) noexcept;
+    IRFixture& operator=(IRFixture&&) noexcept;
+    ~IRFixture();
+
+private:
+    friend IRFixture compileSlangToIR(const char* source, const char* entryPointName);
+    friend class IRFixtureBuilder;
+
+    IRFixture();
+
+    // Approach A path: we keep the Slang Module object alive (it
+    // owns the IRModule's storage) and the session that created it.
+    //
+    // Approach B path: m_iModule / m_slangModule are null;
+    // m_ownedModule holds a strong reference to the hand-built
+    // IRModule (which owns its own MemoryArena), and m_session is
+    // a ComPtr<ISession> that keeps the underlying Slang::Session
+    // alive for the IRModule's lifetime.
+    ComPtr<slang::ISession> m_session;
+    ComPtr<slang::IModule> m_iModule;
+    Module* m_slangModule = nullptr;
+    IRModule* m_irModule = nullptr;
+    RefPtr<IRModule> m_ownedModule;
+    String m_errorMessage;
+};
+
+/// Compile `source` through the Slang frontend and return an
+/// IRFixture wrapping the resulting IRModule.
+///
+/// `entryPointName` is the function to mark as the entry point.
+/// If null, the source is compiled as a library module — useful
+/// when the test wants to exercise a pass on arbitrary functions
+/// without entry-point legalization.
+///
+/// On compile error returns a fixture with `module() == nullptr`
+/// and `errorMessage()` populated. The caller should
+/// `SLANG_CHECK_ABORT(f.module() != nullptr)` early.
+IRFixture compileSlangToIR(const char* source, const char* entryPointName = nullptr);
+
+} // namespace Slang
+
+#endif // SLANG_TOOLS_UNIT_TEST_IR_FIXTURE_H

--- a/tools/slang-unit-test/unit-test-ir-fixture-builder.cpp
+++ b/tools/slang-unit-test/unit-test-ir-fixture-builder.cpp
@@ -1,0 +1,66 @@
+// unit-test-ir-fixture-builder.cpp
+//
+// Reference test for Approach B (`IRFixtureBuilder`). The test
+// exists to demonstrate the pattern, not just to verify the
+// builder API: it picks a pass (`eliminateDeadCode`) whose value
+// is best demonstrated on a hand-crafted module, runs the pass,
+// and asserts the resulting IR shape.
+//
+// Why DCE on a hand-built module:
+//
+//   * Global DCE removes top-level instructions that are
+//     unreferenced and that don't carry a `[KeepAlive]` (or
+//     equivalent) decoration. The frontend always emits at least
+//     an entry-point shim that holds everything alive, which makes
+//     it surprisingly hard to drive DCE on real Slang source —
+//     the very thing that pins the pass's behaviour is what the
+//     frontend works hard to avoid producing.
+//
+//   * With the builder we can place exactly two functions in a
+//     module, mark one with `[KeepAlive]`, and assert the other
+//     gets removed. The IR shape is the assertion: there is no
+//     surrounding shader scaffolding.
+//
+// This is the canonical justification for the B path in the
+// design doc — see `docs/design/ir-pass-unit-testing.md`.
+
+#include "../../source/slang/slang-ir-dce.h"
+#include "../../source/slang/slang-ir.h"
+#include "ir-fixture-builder.h"
+#include "ir-fixture.h"
+#include "unit-test/slang-unit-test.h"
+
+using namespace Slang;
+
+SLANG_UNIT_TEST(irFixtureBuilderDCEDropsUnreferencedFunction)
+{
+    IRFixtureBuilder b;
+    // Two top-level void functions: `kept` carries [KeepAlive],
+    // `dead` does not. Neither is referenced from anywhere else.
+    IRFunc* kept = b.addVoidFunction(/*keepAlive*/ true);
+    b.emitReturnVoid();
+    IRFunc* dead = b.addVoidFunction(/*keepAlive*/ false);
+    b.emitReturnVoid();
+    SLANG_CHECK(kept != nullptr);
+    SLANG_CHECK(dead != nullptr);
+
+    IRFixture f = b.build();
+    SLANG_CHECK_ABORT(f.module() != nullptr);
+    SLANG_CHECK(f.countInsts(kIROp_Func) == 2);
+
+    // Run global DCE. The default options keep `[KeepAlive]`-
+    // decorated insts and global params alive; everything else
+    // is removed if unreferenced.
+    bool changed = eliminateDeadCode(f.module());
+    SLANG_CHECK(changed);
+
+    // Exactly one IRFunc should remain — the `[KeepAlive]` one.
+    // We don't compare against the `kept` pointer because DCE may
+    // mutate the module-inst child list; we assert the *shape*
+    // instead, which is what the pass actually contracts.
+    SLANG_CHECK(f.countInsts(kIROp_Func) == 1);
+    IRInst* survivor = f.findFirstInst(kIROp_Func);
+    SLANG_CHECK_ABORT(survivor != nullptr);
+    // The survivor should carry the KeepAlive decoration.
+    SLANG_CHECK(f.countInsts(kIROp_KeepAliveDecoration) >= 1);
+}

--- a/tools/slang-unit-test/unit-test-ir-fixture.cpp
+++ b/tools/slang-unit-test/unit-test-ir-fixture.cpp
@@ -1,0 +1,135 @@
+// unit-test-ir-fixture.cpp
+//
+// Self-tests for the IR fixture itself. Verifies that the
+// `compileSlangToIR` helper from `ir-fixture.h` produces a usable
+// `IRModule*` for representative inputs and that the helper
+// surface (countInsts, findFirstInst, error reporting) behaves
+// as documented in `docs/design/ir-pass-unit-testing.md`.
+//
+// These tests are the foundation for IR-pass unit tests in
+// follow-up files: every pass test starts by compiling a snippet
+// through this helper, so it must work for the obvious shapes.
+
+// `slang-ir.h` already pulls in the `kIROp_*` enum and the IRInst
+// definition we need for `getOp()`. We do not include
+// `slang-ir-insts.h` because that drags in the AST/capability
+// chain unnecessarily and the tests don't reference any concrete
+// `IR*` instruction subtype directly.
+#include "../../source/slang/slang-ir.h"
+#include "ir-fixture.h"
+#include "unit-test/slang-unit-test.h"
+
+using namespace Slang;
+
+// Smoke test: a trivial library function compiles to a non-empty
+// IRModule with one IRFunc. This is the hello-world of the
+// fixture; if this fails everything else is moot.
+SLANG_UNIT_TEST(irFixtureCompilesTrivialFunction)
+{
+    auto f = compileSlangToIR(R"(
+        int identity(int x) { return x; }
+    )");
+    SLANG_CHECK_ABORT(f.module() != nullptr);
+    SLANG_CHECK(f.errorMessage().getLength() == 0);
+    SLANG_CHECK(f.isValid());
+    // At least one IRFunc somewhere in the module.
+    SLANG_CHECK(f.countInsts(kIROp_Func) >= 1);
+}
+
+// `findFirstInst` should locate the first instruction of a given
+// opcode in document order. We compile two functions and check that
+// `findFirstInst(kIROp_Func)` returns a non-null IRFunc, and that
+// it is one of the functions visible via the recursive walk.
+SLANG_UNIT_TEST(irFixtureFindFirstInstReturnsAFunction)
+{
+    auto f = compileSlangToIR(R"(
+        int alpha(int x) { return x + 1; }
+        int beta (int x) { return x * 2; }
+    )");
+    SLANG_CHECK_ABORT(f.module() != nullptr);
+
+    Index funcCount = f.countInsts(kIROp_Func);
+    SLANG_CHECK(funcCount >= 2);
+
+    IRInst* first = f.findFirstInst(kIROp_Func);
+    SLANG_CHECK(first != nullptr);
+    SLANG_CHECK(first->getOp() == kIROp_Func);
+
+    // An opcode value that is out of range cannot match any
+    // instruction; findFirstInst must return nullptr rather than
+    // returning a stale pointer.
+    SLANG_CHECK(f.findFirstInst((IROpCode)-1) == nullptr);
+}
+
+// `countInsts` must traverse the full instruction tree (recursing
+// into function bodies), not just direct children of the module.
+// We test this by compiling a function with multiple `IRReturn`
+// instructions in its body and asserting the count >= 2.
+SLANG_UNIT_TEST(irFixtureCountInstsWalksRecursively)
+{
+    auto f = compileSlangToIR(R"(
+        int branchy(int x) {
+            if (x > 0) return 1;
+            return 0;
+        }
+    )");
+    SLANG_CHECK_ABORT(f.module() != nullptr);
+
+    // The two `return` statements lower to two distinct IRReturn
+    // instructions inside the function body. countInsts must reach
+    // them through the function's blocks.
+    Index returns = f.countInsts(kIROp_Return);
+    SLANG_CHECK(returns >= 2);
+}
+
+// Compile error: malformed source must populate `errorMessage()`
+// and leave `module()` null. Tests should be able to surface the
+// diagnostic for debugging.
+SLANG_UNIT_TEST(irFixtureSurfacesCompileErrors)
+{
+    auto f = compileSlangToIR(R"(
+        // Missing close brace + undeclared identifier.
+        int broken( {
+            return undefined_variable;
+    )");
+    SLANG_CHECK(f.module() == nullptr);
+    SLANG_CHECK(!f.isValid());
+    // The diagnostic should be non-empty and mention something
+    // recognisable about a parse error.
+    SLANG_CHECK(f.errorMessage().getLength() > 0);
+}
+
+// Spike for #10950: confirms that an internal symbol annotated with
+// SLANG_INTERNAL_TEST_API actually links from the test plugin. We
+// reach for `IRModule::create` because it is the entry point Option
+// B's IRFixtureBuilder will need anyway. If this test fails to link,
+// the visibility plumbing is wrong and the rest of the B work is
+// blocked.
+SLANG_UNIT_TEST(irFixtureSlangInternalTestApiVisibility)
+{
+    auto f = compileSlangToIR("int identity(int x) { return x; }");
+    SLANG_CHECK_ABORT(f.module() != nullptr);
+    auto session = f.module()->getSession();
+    SLANG_CHECK(session != nullptr);
+    auto fresh = IRModule::create(session);
+    SLANG_CHECK(fresh != nullptr);
+    SLANG_CHECK(fresh->getModuleInst() != nullptr);
+    // The fresh module is independent from the compiled one.
+    SLANG_CHECK(fresh.get() != f.module());
+}
+
+// Repeated calls to compileSlangToIR within one test process must
+// each produce an independent fixture. This pins the contract that
+// the cached global session is shared but each compile is fresh.
+SLANG_UNIT_TEST(irFixtureCompilesAreIndependent)
+{
+    auto a = compileSlangToIR("int a(int x) { return x; }");
+    auto b = compileSlangToIR("int b(int x) { return x + 1; }");
+    SLANG_CHECK_ABORT(a.module() != nullptr);
+    SLANG_CHECK_ABORT(b.module() != nullptr);
+    SLANG_CHECK(a.module() != b.module());
+    // Each module independently contains at least one IRFunc.
+    SLANG_CHECK(a.countInsts(kIROp_Func) >= 1);
+    SLANG_CHECK(b.countInsts(kIROp_Func) >= 1);
+    SLANG_CHECK(a.findFirstInst(kIROp_Func) != b.findFirstInst(kIROp_Func));
+}


### PR DESCRIPTION
## Summary

- Add an `IRFixture` for writing unit tests against individual IR passes, as an alternative to the existing end-to-end `.slang` shader tests.
- Two ways to construct a test input: `compileSlangToIR(source)` runs a snippet through the frontend; `IRFixtureBuilder` constructs an `IRModule` directly via `IRBuilder`. Both produce the same `IRFixture` object.
- Resolve [#10950](https://github.com/shader-slang/slang/issues/10950): a new `SLANG_INTERNAL_TEST_API` macro gated on a new CMake option `SLANG_BUILD_FOR_TESTING` (default ON) decorates internal symbols with default visibility so the test plugin can link against them. Shipping builds (option off) keep current visibility.

## What's in the PR

**Fixture API** (`tools/slang-unit-test/ir-fixture.{h,cpp}`):

- `compileSlangToIR(source)` returns an `IRFixture` wrapping a live `IRModule*`.
- `f.module()`, `f.errorMessage()`, `f.countInsts(op)`, `f.findFirstInst(op)`. The opcode walks use only public IR fields so they don't need iterator-helper exports.

**Builder API** (`tools/slang-unit-test/ir-fixture-builder.{h,cpp}`):

- Tiny fluent DSL — `addVoidFunction(keepAlive)`, `emitReturnVoid()`, `build()`. Each primitive corresponds to one shape the reference test needs; the surface grows as new tests demand it. Useful for IR shapes the frontend wouldn't naturally produce.

**Visibility resolution** (#10950):

- New `SLANG_INTERNAL_TEST_API` macro in `include/slang.h`, gated on `SLANG_BUILD_FOR_TESTING`.
- Annotated symbols today: `IRBuilder` (class), `IRUse` (class), `IRModule::create`, `eliminateDeadCode`. The list grows one entry at a time as new tests need additional pass entry points.

**Reference tests:**

- `unit-test-ir-fixture.cpp` — 6 tests covering compile success, recursive opcode counting, opcode lookup, error surfacing, fixture independence, and a spike test that calls `IRModule::create` directly to pin the visibility plumbing end-to-end.
- `unit-test-ir-fixture-builder.cpp` — builds two void functions, marks one with `[KeepAlive]`, runs `eliminateDeadCode`, and asserts the unreferenced one is removed. Demonstrates the value of the builder path: the frontend wouldn't naturally produce a two-function module with this distinguishing decoration.

**Build wiring:**

- `slang-unit-test` gains private link deps on `slang-fiddle-output`, `slang-capability-defs`, `slang-capability-lookup` so headers transitively pulled in by `slang-ir.h` resolve. These propagate include paths only — no symbol exports.

**Design doc:**

- `docs/design/ir-pass-unit-testing.md` — Why, what is supported today, alternatives considered, recommendation and roadmap, full API surface, the `SLANG_INTERNAL_TEST_API` mechanism, and the deferred items (`findFuncByName`, validator-backed `isValid()`).

## Test plan

- [x] All 7 fixture tests pass locally on macOS Debug.
- [ ] CI to verify Linux + Windows build paths (Windows path of `SLANG_INTERNAL_TEST_API` follows the existing `SLANG_API` dllexport/dllimport pattern but has not been exercised locally).
- [ ] CI to verify `SLANG_BUILD_FOR_TESTING=OFF` shipping path still compiles and links.

## Notes

- This is a draft so reviewers can sanity-check the visibility approach (Option B from #10950, the recommended one) before we grow the annotation list.
- Open question: whether `SLANG_BUILD_FOR_TESTING` should default ON (current — simpler dev workflow) or OFF (smaller default surface). Easy to flip.