### PR TITLE
Fix defer in function with infinite loop

### DIFF
--- a/source/slang/slang-ir-lower-defer.cpp
+++ b/source/slang/slang-ir-lower-defer.cpp
@@ -125,12 +125,13 @@ struct DeferLoweringContext : InstPassBase
 
     void processFunc(IRGlobalValueWithCode* func)
     {
-        // Iterating over `defer` instructions in reverse order allows us to
+        // Iterating over `defer` instructions in postorder (effectively
+        // reverse, as successors occur before predecessors) allows us to
         // expand them in the correct order, including nested `defer`s.
-        List<IRBlock*> reverseBlocks = getPostorder(func);
+        List<IRBlock*> postorderBlocks = getPostorder(func);
         List<IRDefer*> unhandledDefers;
 
-        for (IRBlock* block : reverseBlocks)
+        for (IRBlock* block : postorderBlocks)
         {
             for (auto child = block->getLastChild(); child; child = child->getPrevInst())
             {

--- a/source/slang/slang-ir-lower-defer.cpp
+++ b/source/slang/slang-ir-lower-defer.cpp
@@ -127,8 +127,7 @@ struct DeferLoweringContext : InstPassBase
     {
         // Iterating over `defer` instructions in reverse order allows us to
         // expand them in the correct order, including nested `defer`s.
-        // We also use this to determine scope extents.
-        List<IRBlock*> reverseBlocks = getReversePostorderOnReverseCFG(func);
+        List<IRBlock*> reverseBlocks = getPostorder(func);
         List<IRDefer*> unhandledDefers;
 
         for (IRBlock* block : reverseBlocks)

--- a/tests/bugs/defer-infinite-loop.slang
+++ b/tests/bugs/defer-infinite-loop.slang
@@ -1,0 +1,11 @@
+//DIAGNOSTIC_TEST:SIMPLE:
+// This test just needs to compile without crashing the compiler.
+
+void f()
+{
+    // The problem here is that the deferred block occurs after the for-loop,
+    // and is therefore unreachable. We must generate correct IR even in that
+    // case.
+    defer printf("B");
+    for (;;) {}
+}


### PR DESCRIPTION
See added test for the case that used to fail. If there is an infinite loop in a function with `defer`, the reverse CFG doesn't reach the `defer` instruction and the defer lowering pass doesn't actually lower it, confusing later passes and triggering assertions. Fixed by using just the normal postorder of the CFG.

It's been a bit over a year since #6619 added the defer keyword, so I don't remember exactly why I had used the reverse postorder on the reverse CFG instead of just the postorder. I think that's probably a vestige from an earlier iteration of the PR, which the outdated comment above it also suggests (scope extents are actually determined using an operand of `IRDefer`).

There are already several `defer` tests that test for the order of the deferred blocks. Because those tests pass, I'm pretty confident that switching to the regular postorder won't break anything and fixes this corner case. I'm pretty sure nobody triggered this bug before because it makes zero sense to write infinite loops with no exit paths in GPU code.