### PR TITLE
Demote 38032 ('no_diff' on differentiable call) to warning

### DIFF
--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -3917,7 +3917,7 @@ err(
     span { loc = "expr:Expr", message = "'no_diff' can only be used to decorate a call or a subscript operation" }
 )
 
-err(
+warning(
     "use-of-no-diff-on-differentiable-func",
     38032,
     "'no_diff' on differentiable function has no meaning",


### PR DESCRIPTION
## Summary

Demote diagnostic 38032 (`use-of-no-diff-on-differentiable-func`) from error to warning.

The original issue reporter pointed out that this error makes iterating
on differentiable code awkward — most other diagnostics about
differentiability are warnings already, so flagging an unnecessary
`no_diff` annotation as a hard error is inconsistent and gets in the way.

Note: the diagnostic is presently defined but not actually wired up
anywhere in the semantic checker (see the `DISABLE_DIAGNOSTIC_TEST` in
`tests/diagnostics/autodiff-no-diff-on-differentiable-func.slang`). This
PR only adjusts the severity for when the diagnostic is eventually
emitted; wiring it up is tracked separately.

Fixes #8045

## Test plan

- Existing autodiff diagnostic tests still pass
- The disabled test for the diagnostic remains disabled; once the
  diagnostic is wired up it can be re-enabled with the new severity

🤖 Generated with [Claude Code](https://claude.com/claude-code)