### PR TITLE
Diagnose constant passed to inout/out parameter instead of ICE

### DIFF
--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -3987,7 +3987,16 @@ Expr* SemanticsVisitor::CheckInvokeExprWithCheckedOperands(InvokeExpr* expr)
                             //
                             // An argument can be made that transformation shouldn't apply to
                             // the ref scenario in general.
-                            if (implicitCastExpr && as<OutParamTypeBase>(paramType) &&
+                            // Only fall back to the implicit-cast-as-lvalue
+                            // mechanism if the inner expression is itself an
+                            // l-value: writing back the result of the call only
+                            // makes sense if we have somewhere to write back to.
+                            // Without this check, passing a literal (e.g.
+                            // `foo(0)` for `inout uint`) would survive the
+                            // front end and ICE during IR lowering.
+                            if (implicitCastExpr && implicitCastExpr->arguments.getCount() == 1 &&
+                                as<OutParamTypeBase>(paramType) &&
+                                implicitCastExpr->arguments[0]->type.isLeftValue &&
                                 _canLValueCoerce(
                                     implicitCastExpr->arguments[0]->type,
                                     implicitCastExpr->type))
@@ -4066,7 +4075,7 @@ Expr* SemanticsVisitor::CheckInvokeExprWithCheckedOperands(InvokeExpr* expr)
                                     .arg = argExpr});
 
 
-                                if (implicitCastExpr)
+                                if (implicitCastExpr && implicitCastExpr->arguments.getCount() == 1)
                                 {
                                     // Try and determine reason for failure
                                     if (as<RefParamType>(paramType))

--- a/tests/compute/inout-implicit-cast.slang
+++ b/tests/compute/inout-implicit-cast.slang
@@ -1,0 +1,23 @@
+//TEST:INTERPRET(filecheck=CHECK):
+
+// Companion to tests/diagnostics/inout-constant-arg.slang.
+// Exercises the *positive* path of the implicit-cast-as-lvalue
+// mechanism that #9700's fix tightens: when the argument really is an
+// l-value of a coercible-but-different integer type, the call should
+// still compile and the back-and-forth conversion should round-trip.
+
+void inc(inout uint x) { x = x + 1; }
+void writeFive(out uint x) { x = 5; }
+
+void main()
+{
+    int a = 1;
+    inc(a); // inout: implicit-cast-as-lvalue: int <-> uint, a is an lvalue
+    //CHECK: a=2
+    printf("a=%d\n", a);
+
+    int b = 0;
+    writeFive(b); // out: same coercion path on the write-back direction
+    //CHECK: b=5
+    printf("b=%d\n", b);
+}

--- a/tests/diagnostics/inout-constant-arg.slang
+++ b/tests/diagnostics/inout-constant-arg.slang
@@ -1,0 +1,44 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=diag):
+
+// Regression test for #9700.
+//
+// Passing a literal constant as an `inout` (or `out`) argument used to
+// ICE during IR lowering ("unimplemented: assignment") because the
+// front-end's implicit-cast-as-lvalue mechanism was applied even when
+// the underlying argument expression was not an l-value. We now reject
+// both shapes with an ordinary `argument must be l-value` diagnostic.
+
+float useInout(inout uint seed)
+{
+    seed += 1;
+    return float(seed);
+}
+
+void useOut(out uint seed)
+{
+    seed = 0;
+}
+
+int returnInt() { return 7; }
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main()
+{
+    // Literal r-value
+    float bar = useInout(0);
+//diag:                  ^ argument must be l-value
+//diag:                  ^ argument passed to parameter '0' must be l-value.
+//diag:                  ^ argument was implicitly cast from 'int' to 'uint', and Slang does not support using an implicit cast as an l-value for this usage
+    useOut(0);
+//diag:    ^ argument must be l-value
+//diag:    ^ argument passed to parameter '0' must be l-value.
+//diag:    ^ argument was implicitly cast from 'int' to 'uint', and Slang does not support using an implicit cast as an l-value for this usage
+
+    // Non-literal r-value (function call result) — same rule should
+    // catch it: the inner expression is not an l-value either.
+    float baz = useInout(returnInt());
+//diag:                           ^ argument must be l-value
+//diag:                           ^ argument passed to parameter '0' must be l-value.
+//diag:                           ^ argument was implicitly cast from 'int' to 'uint', and Slang does not support using an implicit cast as an l-value for this usage
+}


### PR DESCRIPTION
## Summary

Compiling code that passes an r-value (e.g. a literal `0`) for an
`inout`/`out` parameter triggered an internal error during IR lowering:

```
error 99999: Slang::InternalError: unimplemented: assignment
```

The front-end's *implicit-cast-as-lvalue* mechanism (used to allow
e.g. `int a; foo(a)` to call `foo(inout uint)`) was applied even when
the inner expression of the cast was not itself an l-value, so things
like `foo(0)` survived into the IR pass that tries to write back to the
original argument.

Add the missing l-value check on the inner expression and let the
existing `argument-expected-lvalue` (E30047) diagnostic fire instead.

Fixes #9700

## Test plan

- New regression test `tests/diagnostics/inout-constant-arg.slang`
  exercises the original repro and pins the diagnostic
- `tests/diagnostics`, `tests/autodiff`, and `tests/compute` suites all
  pass (1330+ tests, 0 regressions)
- The valid case (l-value of a different but coercible type, e.g.
  `int a; foo(a)` for `foo(inout uint)`) still compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)