### PR TITLE
Warn when vertex shader output lacks SV_Position (E38052)

### DIFF
--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -6,6 +6,7 @@
 // enumerating specialization parameters, and validating
 // attempts to specialize shader code.
 
+#include "../core/slang-char-util.h"
 #include "../core/slang-type-text-util.h"
 #include "slang-lookup.h"
 #include "slang-parameter-binding.h"
@@ -1130,6 +1131,120 @@ bool doStructFieldsHaveSemantic(Type* type)
     return doStructFieldsHaveSemanticImpl(type, seenTypes);
 }
 
+// Returns the base portion of a semantic name with any trailing decimal
+// digits stripped, so that e.g. `SV_Position`, `SV_Position0` and
+// `SV_Position1` all yield `SV_Position`. HLSL semantics are
+// indexed by an optional integer suffix and the index isn't relevant
+// for "is the semantic present" questions.
+static UnownedStringSlice _semanticBaseName(UnownedStringSlice name)
+{
+    auto end = name.end();
+    while (end != name.begin() && CharUtil::isDigit(end[-1]))
+        --end;
+    return UnownedStringSlice(name.begin(), end);
+}
+
+// Returns true if `decl` has a semantic whose base name (any trailing
+// decimal index dropped) matches `baseName`, case-insensitively. `decl`
+// may be null, in which case false is returned.
+static bool _declHasSemantic(Decl* decl, UnownedStringSlice baseName)
+{
+    if (!decl)
+        return false;
+    if (auto semantic = decl->findModifier<HLSLSimpleSemantic>())
+    {
+        if (_semanticBaseName(semantic->name.getContent()).caseInsensitiveEquals(baseName))
+            return true;
+    }
+    return false;
+}
+
+// Returns true if any declaration reachable from `type` (transitively
+// through structs, arrays, conditional/wrapper types, modified types
+// and stream/mesh output wrappers) carries a semantic whose base name
+// matches `baseName`.
+//
+// A recursion depth bound is enforced alongside `seenTypes`: generic
+// instantiations can produce a fresh `Type*` at each level and would
+// otherwise recurse unboundedly.
+static bool _typeHasSemanticImpl(
+    ASTBuilder* astBuilder,
+    Type* type,
+    UnownedStringSlice baseName,
+    HashSet<Type*>& seenTypes,
+    UInt recursionDepth = 0)
+{
+    if (recursionDepth >= kMaxTypeNestingDepth)
+        return false;
+    if (!type)
+        return false;
+    type = unwrapConditionalType(type);
+    if (!type)
+        return false;
+    if (seenTypes.contains(type))
+        return false;
+    seenTypes.add(type);
+
+    const auto next = recursionDepth + 1;
+
+    if (auto modType = as<ModifiedType>(type))
+        return _typeHasSemanticImpl(astBuilder, modType->getBase(), baseName, seenTypes, next);
+
+    if (auto arrayType = as<ArrayExpressionType>(type))
+        return _typeHasSemanticImpl(
+            astBuilder,
+            arrayType->getElementType(),
+            baseName,
+            seenTypes,
+            next);
+    if (auto streamType = as<HLSLStreamOutputType>(type))
+        return _typeHasSemanticImpl(
+            astBuilder,
+            streamType->getElementType(),
+            baseName,
+            seenTypes,
+            next);
+    if (auto meshOutputType = as<MeshOutputType>(type))
+        return _typeHasSemanticImpl(
+            astBuilder,
+            meshOutputType->getElementType(),
+            baseName,
+            seenTypes,
+            next);
+
+    auto declRefType = as<DeclRefType>(type);
+    if (!declRefType)
+        return false;
+    auto structDeclRef = declRefType->getDeclRef().as<StructDecl>();
+    if (!structDeclRef)
+        return false;
+
+    for (auto fieldDeclRef : getFields(astBuilder, structDeclRef, MemberFilterStyle::Instance))
+    {
+        auto fieldDecl = fieldDeclRef.getDecl();
+        if (_declHasSemantic(fieldDecl, baseName))
+            return true;
+        auto fieldType = getType(astBuilder, fieldDeclRef);
+        if (_typeHasSemanticImpl(astBuilder, fieldType, baseName, seenTypes, next))
+            return true;
+    }
+    return false;
+}
+
+// Convenience wrapper: check whether `decl` (and the type it carries)
+// transitively expose a semantic whose base name matches `baseName`.
+static bool _outputDeclHasSemantic(
+    ASTBuilder* astBuilder,
+    Decl* decl,
+    Type* type,
+    UnownedStringSlice baseName)
+{
+    if (_declHasSemantic(decl, baseName))
+        return true;
+    HashSet<Type*> seenTypes;
+    return _typeHasSemanticImpl(astBuilder, type, baseName, seenTypes);
+}
+
 
 // Validate that an entry point function conforms to any additional
 // constraints based on the stage (and profile?) it specifies.
@@ -1560,6 +1675,57 @@ void validateEntryPoint(EntryPoint* entryPoint, DiagnosticSink* sink)
             ctx.targets = targets.getArrayView();
             ctx.stage = stage;
             validateVaryingType(ctx, param->getType());
+        }
+    }
+
+    // For vertex shaders, warn when an output has been declared but none
+    // of them carry the `SV_Position` semantic. This is almost always a
+    // bug: the rasterizer needs an output position from the last
+    // vertex-processing stage. Cases where the vertex shader is
+    // intentionally producing no position (e.g. it feeds a
+    // tessellation/geometry/mesh stage that supplies SV_Position itself,
+    // or rasterizer-discard / transform feedback is in use) are rare;
+    // users who hit this can add the semantic to a vertex output, or
+    // silence the warning explicitly.
+    //
+    // We deliberately skip the check when the entry point declares no
+    // outputs at all (void return type, no `out`/`inout` parameters).
+    // GLSL-style entry points write `gl_Position` via a global rather
+    // than as a returned member, so we cannot tell whether SV_Position
+    // is missing just by looking at the signature.
+    if (stage == Stage::Vertex)
+    {
+        auto astBuilder = linkage->getASTBuilder();
+        const auto svPosition = UnownedStringSlice::fromLiteral("sv_position");
+
+        auto returnBasicType = as<BasicExpressionType>(returnType);
+        bool returnIsVoid = returnBasicType && returnBasicType->getBaseType() == BaseType::Void;
+        bool hasOutputs = returnType && !returnIsVoid;
+        bool hasSvPosition =
+            _outputDeclHasSemantic(astBuilder, entryPointFuncDecl, returnType, svPosition);
+
+        if (!hasSvPosition)
+        {
+            for (const auto& param : entryPointFuncDecl->getParameters())
+            {
+                // Only outputs (or in/out) of the entry point can carry
+                // SV_Position for the rasterizer.
+                if (!param->hasModifier<OutModifier>() && !param->hasModifier<InOutModifier>())
+                    continue;
+                hasOutputs = true;
+                if (_outputDeclHasSemantic(astBuilder, param, param->getType(), svPosition))
+                {
+                    hasSvPosition = true;
+                    break;
+                }
+            }
+        }
+
+        if (hasOutputs && !hasSvPosition)
+        {
+            sink->diagnose(Diagnostics::VertexShaderMissingSvPosition{
+                .entryPoint = entryPointName,
+                .location = entryPointFuncDecl->loc});
         }
     }
 

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -4012,6 +4012,13 @@ err(
     span { loc = "location", message = "type '~type:Type' cannot be used as ~direction ~context of entry point '~entryPoint:Name' when targeting ~target because ~reason" }
 )
 
+warning(
+    "vertex-shader-missing-sv-position",
+    38052,
+    "vertex shader '~entryPoint:Name' has no output with the 'SV_Position' system value semantic",
+    span { loc = "location", message = "vertex shader '~entryPoint:Name' has no output with the 'SV_Position' system value semantic; the rasterizer will not receive valid vertex positions (add 'SV_Position' to a vertex output, or suppress with -warnings-disable 38052)" }
+)
+
 --
 -- 382xx: module imports
 --

--- a/tests/bugs/gh-3087-multi-entry-point.slang
+++ b/tests/bugs/gh-3087-multi-entry-point.slang
@@ -25,6 +25,7 @@ struct VIn
 
 struct VSOutput
 {
+    float4 pos : SV_Position;
     uint instanceID : SV_InstanceID;
 	float4 color : COLOR;
 };
@@ -32,6 +33,7 @@ struct VSOutput
 [shader("vertex")]
 VSOutput vmain(VIn vin) {
     VSOutput t;
+    t.pos = float4(0);
     t.instanceID = vin.instanceID;
     t.color = float4(0, 0, 0, 0);
     return t;

--- a/tests/bugs/gh-8512.slang
+++ b/tests/bugs/gh-8512.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -warnings-disable 38052
 // CHECK: OpEntryPoint
 
 __generic <Scalar : __BuiltinFloatingPointType, int Mode>

--- a/tests/bugs/gh-8920-domain-shaders.slang
+++ b/tests/bugs/gh-8920-domain-shaders.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv -g
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -g -warnings-disable 38052
 
 // This is a minimal repro for issue 8920
 

--- a/tests/bugs/gh-9434.slang
+++ b/tests/bugs/gh-9434.slang
@@ -1,5 +1,5 @@
-//TEST:SIMPLE(filecheck=FUNC1): -target spirv -O0 -entry func1
-//TEST:SIMPLE(filecheck=FUNC2): -target spirv -O0 -entry func2
+//TEST:SIMPLE(filecheck=FUNC1): -target spirv -O0 -entry func1 -warnings-disable 38052
+//TEST:SIMPLE(filecheck=FUNC2): -target spirv -O0 -entry func2 -warnings-disable 38052
 
 // FUNC1: OpEntryPoint Vertex %func1 "main" %entryPointParam_func1_value %entryPointParam_func1_hasValue
 // FUNC1-DAG: OpDecorate %entryPointParam_func1_value Location 0

--- a/tests/diagnostics/vertex-missing-sv-position-positive.slang
+++ b/tests/diagnostics/vertex-missing-sv-position-positive.slang
@@ -1,0 +1,75 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=diag): -target spirv
+
+// Regression test for #8753 (positive cases).
+//
+// These vertex shapes should NOT warn:
+//  * Direct return with SV_Position semantic on the function
+//  * Struct return with an SV_Position-tagged field
+//  * `out`-parameter SV_Position
+//  * Indexed semantic (`SV_Position0`)
+//  * Nested struct that contains an SV_Position-tagged field
+//  * Void return with no out parameters (e.g. GLSL-style entry points
+//    that write `gl_Position` via a global)
+
+[shader("vertex")]
+float4 directReturn(uint vid : SV_VertexID) : SV_Position
+{
+    return float4(0, 0, 0, 1);
+}
+
+struct VSOutput
+{
+    float4 pos : SV_Position;
+};
+
+[shader("vertex")]
+VSOutput structReturn(uint vid : SV_VertexID)
+{
+    VSOutput o;
+    o.pos = float4(0, 0, 0, 1);
+    return o;
+}
+
+[shader("vertex")]
+void outParam(uint vid : SV_VertexID, out float4 pos : SV_Position)
+{
+    pos = float4(0, 0, 0, 1);
+}
+
+struct VSOutputIndexed
+{
+    float4 pos : SV_Position0;
+};
+
+[shader("vertex")]
+VSOutputIndexed indexedSemantic(uint vid : SV_VertexID)
+{
+    VSOutputIndexed o;
+    o.pos = float4(0, 0, 0, 1);
+    return o;
+}
+
+struct InnerOut
+{
+    float4 pos : SV_Position;
+};
+
+struct OuterOut
+{
+    float3 color;
+    InnerOut inner;
+};
+
+[shader("vertex")]
+OuterOut nestedStruct(uint vid : SV_VertexID)
+{
+    OuterOut o;
+    o.color = float3(0, 0, 0);
+    o.inner.pos = float4(0, 0, 0, 1);
+    return o;
+}
+
+[shader("vertex")]
+void noOutputs(uint vid : SV_VertexID)
+{
+}

--- a/tests/diagnostics/vertex-missing-sv-position.slang
+++ b/tests/diagnostics/vertex-missing-sv-position.slang
@@ -1,0 +1,34 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=diag): -target spirv
+
+// Regression test for #8753.
+//
+// A vertex shader that returns a struct with no SV_Position member
+// silently fails to drive the rasterizer; warn the user.
+
+struct VSOutput
+{
+    float4 Pos; // missing SV_Position semantic -- bug
+};
+
+[shader("vertex")]
+VSOutput vertexMain(uint vid : SV_VertexID)
+/*diag:
+         ^^^^^^^^^^ vertex shader 'vertexMain' has no output with the 'SV_Position' system value semantic
+         ^^^^^^^^^^ vertex shader 'vertexMain' has no output with the 'SV_Position' system value semantic; the rasterizer will not receive valid vertex positions (add 'SV_Position' to a vertex output, or suppress with -warnings-disable 38052)
+*/
+{
+    VSOutput output;
+    output.Pos = float4(0, 0, 0, 1);
+    return output;
+}
+
+// Void return + out parameter without SV_Position should also warn.
+[shader("vertex")]
+void outParamMissing(uint vid : SV_VertexID, out float4 color : COLOR)
+/*diag:
+     ^^^^^^^^^^^^^^^ vertex shader 'outParamMissing' has no output with the 'SV_Position' system value semantic
+     ^^^^^^^^^^^^^^^ vertex shader 'outParamMissing' has no output with the 'SV_Position' system value semantic; the rasterizer will not receive valid vertex positions (add 'SV_Position' to a vertex output, or suppress with -warnings-disable 38052)
+*/
+{
+    color = float4(1);
+}

--- a/tests/language-feature/shader-params/entry-point-array-return.slang
+++ b/tests/language-feature/shader-params/entry-point-array-return.slang
@@ -1,9 +1,9 @@
 // Entry points cannot return array types. The compiler should emit
 // a diagnostic error for all array return patterns.
 
-//TEST:SIMPLE(filecheck=SINGLE): -target spirv -O0 -entry singleField
-//TEST:SIMPLE(filecheck=MULTI): -target spirv -O0 -entry multiField
-//TEST:SIMPLE(filecheck=NESTED): -target spirv -O0 -entry nestedArray
+//TEST:SIMPLE(filecheck=SINGLE): -target spirv -O0 -entry singleField -warnings-disable 38052
+//TEST:SIMPLE(filecheck=MULTI): -target spirv -O0 -entry multiField -warnings-disable 38052
+//TEST:SIMPLE(filecheck=NESTED): -target spirv -O0 -entry nestedArray -warnings-disable 38052
 
 struct SingleFieldStruct
 {

--- a/tests/spirv/optional-vertex-output.slang
+++ b/tests/spirv/optional-vertex-output.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -warnings-disable 38052
 
 // Test that we can use Optional<T> or bool types in varying input or outputs.
 

--- a/tests/spirv/pointer-bug-3.slang
+++ b/tests/spirv/pointer-bug-3.slang
@@ -2,7 +2,7 @@
 
 [[vk::push_constant]] float4 *positions;
 [shader("vertex")]
-float4 main()
+float4 main() : SV_Position
 {
     return positions[0];
 }


### PR DESCRIPTION
## Summary

Vertex shaders that do not write to `SV_Position` silently fail to drive
the rasterizer. The reporter spent significant time tracking the bug
down because no tool flagged the missing semantic.

This adds warning **E38052** when a vertex entry point declares one or
more outputs but none of them carry the `SV_Position` semantic. The
walk covers:

- the return type (direct semantic on the function or recursively on
  struct fields, through arrays / stream-output / mesh-output wrappers)
- any `out` / `inout` parameter

To avoid false positives, the warning is **not** emitted when the entry
point declares no outputs at all (void return + no `out`/`inout`
params). That covers GLSL-style entry points that drive `gl_Position`
through a global, as well as transform-feedback / rasterizer-discard
shapes where there's nothing to inspect at the signature level. Users
with valid alternative pipelines (tess/geom/mesh stages providing the
position) can silence the warning with the standard `-w` /
`-warnings-disable 38052` mechanism, or by adding the semantic to a
dummy output.

Per the discussion on the issue (notably @tangent-vector's review), this
is intentionally a *warning* rather than an error: there are valid
shapes (XFB, last-stage-feeds-rasterizer-only) and the compiler does
not have enough pipeline context to tell the difference reliably.

Fixes #8753

## Test plan

- New `tests/diagnostics/vertex-missing-sv-position.slang` reproduces
  the issue's repro and pins the warning.
- New `tests/diagnostics/vertex-missing-sv-position-positive.slang`
  exercises the four shapes that should NOT warn (direct return
  semantic, struct return with semantic, `out` parameter, void/no
  outputs).
- Full `tests/diagnostics`, `tests/glsl`, `tests/hlsl`, `tests/vertex`
  suites pass (1300+ tests, 0 regressions). The two pre-existing
  failures (`tests/cpu-program/gfx-smoke.slang`,
  `tests/dispatcher/smoke.slang`) reproduce on master and are
  unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)