### PR TITLE
Drive fiddle from a stamp file to fix incremental rebuilds

### DIFF
--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -27,12 +27,28 @@ list(
 )
 list(TRANSFORM SLANG_FIDDLE_OUTPUTS PREPEND "${SLANG_FIDDLE_OUTPUT_DIR}/")
 
+#
+# slang-fiddle is a many-input / many-output generator that uses
+# `writeAllTextIfChanged()` to avoid touching outputs whose content has
+# not changed. CMake's add_custom_command(OUTPUT …) treats every listed
+# output as an up-to-date marker: if any single output is older than the
+# command's dependencies, it re-runs the command. Because fiddle leaves
+# unchanged outputs alone, those output mtimes stay older than the
+# generator binary itself, so CMake re-runs fiddle on every build, and
+# downstream link steps re-link.
+#
+# Drive the rule from a stamp file we touch unconditionally; list the
+# generated source files via BYPRODUCTS so dependants still see them
+# but their (stale) mtimes are not used as up-to-date markers.
+set(SLANG_FIDDLE_STAMP "${SLANG_FIDDLE_OUTPUT_DIR}/.fiddle.stamp")
 add_custom_command(
-    OUTPUT ${SLANG_FIDDLE_OUTPUTS}
+    OUTPUT ${SLANG_FIDDLE_STAMP}
+    BYPRODUCTS ${SLANG_FIDDLE_OUTPUTS}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${SLANG_FIDDLE_OUTPUT_DIR}
     COMMAND
         slang-fiddle -i "${SLANG_FIDDLE_INPUT_DIR}/" -o
         "${SLANG_FIDDLE_OUTPUT_DIR}/" ${SLANG_FIDDLE_INPUT_FILE_NAMES}
+    COMMAND ${CMAKE_COMMAND} -E touch ${SLANG_FIDDLE_STAMP}
     DEPENDS ${SLANG_FIDDLE_INPUTS} ${SLANG_FIDDLE_LUA_INPUTS} slang-fiddle
     WORKING_DIRECTORY ${slang_SOURCE_DIR}
     VERBATIM
@@ -41,7 +57,7 @@ add_library(
     slang-fiddle-output
     INTERFACE
     EXCLUDE_FROM_ALL
-    ${SLANG_FIDDLE_OUTPUTS}
+    ${SLANG_FIDDLE_STAMP}
 )
 set_target_properties(slang-fiddle-output PROPERTIES FOLDER generated)
 target_include_directories(


### PR DESCRIPTION
## Summary

Best-effort fix for #9722. As reported, incremental \`cmake --build\`
sometimes re-runs slang-fiddle even when nothing has changed, which in
turn re-links a number of downstream binaries.

\`slang-fiddle\` is a many-input/many-output generator that uses
\`writeAllTextIfChanged()\` to avoid touching outputs whose content has
not changed. CMake's \`add_custom_command(OUTPUT …)\` treats every listed
output as an up-to-date marker: if any single output is older than the
command's dependencies, it re-runs the command. Because fiddle leaves
unchanged outputs alone, those output mtimes stay older than the
generator binary itself, so CMake re-runs fiddle on every build, and
downstream link steps re-link.

The standard CMake fix is a stamp file: write a single sentinel that
we touch unconditionally, and use that as the rule's output. The
generated source files are listed via \`BYPRODUCTS\` so dependants still
see them, but their (stale) mtimes are not used as up-to-date markers.

I could not directly reproduce the regression on tip-of-master, which
matches the reporter's note that the symptom is transitive (depends on
which inputs were touched and in what order). The change is still the
right shape per CMake guidance and fixes the situation we know breaks.

@pknowles — does this match what you were trying in your earlier
experiments?

Fixes #9722

## Test plan

- Initial \`cmake --build --preset debug --target slangc\` builds and
  runs fiddle as expected
- Subsequent \`cmake --build --preset debug --target slang\` is a no-op
  (no fiddle invocation, no relinks)
- All-target build still completes successfully

This only touches the fiddle rule; the capability- and
lookup-table-generators have the same many-output shape and would
benefit from the same treatment, but I've kept this PR minimal so the
fix can land in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)