### PR TITLE
Fix IRFuncType param accessors for attributed function types

### DIFF
--- a/source/slang/slang-ir-cleanup-void.cpp
+++ b/source/slang/slang-ir-cleanup-void.cpp
@@ -209,24 +209,35 @@ struct CleanUpVoidContext
         case kIROp_FuncType:
             {
                 auto funcType = as<IRFuncType>(inst);
-                List<IRInst*> newOperands;
-                for (UInt i = 1; i < funcType->getOperandCount(); i++)
+                // Walk only the actual parameter types (the
+                // `IRFuncType` accessors skip a trailing `IRAttr`
+                // operand such as `IRFuncThrowTypeAttr` that
+                // attributed function types carry). Reading raw
+                // operands here would mistake the attribute for a
+                // parameter and rebuild the type without it.
+                List<IRType*> newParamTypes;
+                for (auto paramType : funcType->getParamTypes())
                 {
-                    auto operand = funcType->getOperand(i);
-                    if (operand->getOp() == kIROp_VoidType)
+                    if (paramType->getOp() == kIROp_VoidType)
                     {
                         continue;
                     }
-                    newOperands.add(operand);
+                    newParamTypes.add(paramType);
                 }
-                if (newOperands.getCount() != (Index)funcType->getParamCount())
+                if (newParamTypes.getCount() != (Index)funcType->getParamCount())
                 {
                     IRBuilder builder(module);
                     builder.setInsertBefore(funcType);
-                    auto newFuncType = builder.getFuncType(
-                        newOperands.getCount(),
-                        (IRType**)newOperands.getBuffer(),
-                        funcType->getResultType());
+                    auto attr = funcType->getAttr();
+                    auto newFuncType = attr ? builder.getFuncType(
+                                                  newParamTypes.getCount(),
+                                                  newParamTypes.getBuffer(),
+                                                  funcType->getResultType(),
+                                                  attr)
+                                            : builder.getFuncType(
+                                                  newParamTypes.getCount(),
+                                                  newParamTypes.getBuffer(),
+                                                  funcType->getResultType());
                     if (newFuncType != funcType)
                     {
                         funcType->replaceUsesWith(newFuncType);

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -2980,6 +2980,44 @@ IRFuncType* IRBuilder::getFuncType(
     return (IRFuncType*)createIntrinsicInst(nullptr, kIROp_FuncType, 3, counts, lists);
 }
 
+UInt IRFuncType::getParamCount()
+{
+    // A well-formed `IRFuncType` always has at least the result-type
+    // operand at index 0; the zero-operand check is purely defensive
+    // for malformed or partially-constructed IR.
+    auto count = getOperandCount();
+    if (count == 0)
+        return 0;
+    UInt n = count - 1;
+    if (n > 0 && as<IRAttr>(getOperand(count - 1)))
+        --n;
+    return n;
+}
+
+IRType* IRFuncType::getParamType(UInt index)
+{
+    // Bounds-checked against the (attribute-stripped) parameter count
+    // so attributed function types don't accidentally expose a trailing
+    // attribute as if it were a parameter.
+    SLANG_ASSERT(index < getParamCount());
+    return (IRType*)getOperand(1 + index);
+}
+
+IROperandList<IRType> IRFuncType::getParamTypes()
+{
+    IRUse* end = getOperands() + getOperandCount();
+    if (end != getOperands() + 1 && as<IRAttr>((end - 1)->get()))
+        --end;
+    return IROperandList<IRType>(getOperands() + 1, end);
+}
+
+IRAttr* IRFuncType::getAttr()
+{
+    if (getOperandCount() == 0)
+        return nullptr;
+    return as<IRAttr>(getOperand(getOperandCount() - 1));
+}
+
 IRType* IRBuilder::getBindExistentialsType(
     IRInst* baseType,
     UInt slotArgCount,

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1623,12 +1623,24 @@ FIDDLE()
 struct IRFuncType : IRType
 {
     FIDDLE(leafInst())
-    UInt getParamCount() { return getOperandCount() - 1; }
-    IRType* getParamType(UInt index) { return (IRType*)getOperand(1 + index); }
-    IROperandList<IRType> getParamTypes()
-    {
-        return IROperandList<IRType>(getOperands() + 1, getOperands() + getOperandCount());
-    }
+    // Operand layout:
+    //   [0]                   : result type
+    //   [1 .. paramEnd)       : parameter types
+    //   [paramEnd]            : optional trailing attribute (e.g.
+    //                           `IRFuncThrowTypeAttr`), distinguished
+    //                           from a parameter type by deriving from
+    //                           `IRAttr` rather than `IRType`.
+    //
+    // The accessors below skip the trailing attribute (if any) so that
+    // `getParamCount()` / `getParamType()` / `getParamTypes()` only
+    // expose actual parameter types. They are defined out-of-line in
+    // slang-ir.cpp because they need the full `IRAttr` definition.
+    UInt getParamCount();
+    IRType* getParamType(UInt index);
+    IROperandList<IRType> getParamTypes();
+    // Returns the trailing attribute (e.g. an `IRFuncThrowTypeAttr`) if
+    // one was attached when the type was created, or null otherwise.
+    IRAttr* getAttr();
 };
 
 FIDDLE()

--- a/tests/language-feature/error-handling/throws-with-params.slang
+++ b/tests/language-feature/error-handling/throws-with-params.slang
@@ -1,0 +1,43 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -cpu -shaderobj
+
+// Regression test for #8742.
+//
+// `IRFuncType::getParamCount()` used to return an inflated count for
+// throwing functions (one extra for the trailing
+// `IRFuncThrowTypeAttr` operand). This in turn confused
+// `slang-ir-cleanup-void` into rebuilding the `IRFuncType` and losing
+// its throw attribute, corrupting the function signature for any
+// throwing function with at least one parameter.
+//
+// Compiling and running such a function exercises both the parameter
+// accessor and the void-cleanup pass; if either is wrong, this test
+// either fails to compile or computes the wrong answer.
+
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
+enum MyError
+{
+    Fail
+};
+
+int addOrThrow(int a, int b) throws MyError
+{
+    if (a < 0)
+        throw MyError.Fail;
+    return a + b;
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    do
+    {
+        // CHECK: 7
+        outputBuffer[0] = try addOrThrow(3, 4);
+    }
+    catch
+    {
+        outputBuffer[0] = -1;
+    }
+}


### PR DESCRIPTION
## Summary

`IRBuilder::getFuncType(paramCount, paramTypes, resultType, attribute)`
appends an `IRAttr*` to the operand list as a trailing operand. This is
used today to attach an `IRFuncThrowTypeAttr` to the type of a
throwing function (`source/slang/slang-lower-to-ir.cpp:4531`).

However, `IRFuncType::getParamCount()` and `getParamTypes()` did not
account for this trailing operand, so on attributed function types
they returned an inflated count and `getParamType(last)` would yield
the attribute as if it were another parameter type. The issue notes
this is the latent footgun that prompted the report.

Update the accessors to skip a trailing operand if it derives from
`IRAttr` (already a distinct base from `IRType`, so the runtime check
is unambiguous), and add an explicit `getAttr()` accessor for callers
that *do* want the attribute. The accessor bodies move to
`slang-ir.cpp` since they need the full `IRAttr` definition that lives
in `slang-ir-insts.h`.

Fixes #8742

## Test plan

- Full `tests/diagnostics`, `tests/glsl`, `tests/hlsl`, `tests/spirv`
  suites pass (1633 tests, 0 regressions).
- `tests/autodiff` (heavy IR-level use of function types via
  forward/backward differentiation) passes (511 tests).
- `tests/language-feature/error-handling` (the only place that
  currently hits the `IRAttr*` overload, via throwing functions)
  passes (23 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)