### PR TITLE
ci: add hosted CPU stress workflow

### DIFF
--- a/.github/workflows/ci-cpu-stress.yml
+++ b/.github/workflows/ci-cpu-stress.yml
@@ -56,3 +56,4 @@ jobs:
       cpu-only: true
       server-count: ${{ inputs.server-count }}
       test-log-artifact: cpu-stress-${{ inputs.config }}-server${{ inputs.server-count }}-${{ matrix.iteration }}
+      collect-core-dumps: true

--- a/.github/workflows/ci-cpu-stress.yml
+++ b/.github/workflows/ci-cpu-stress.yml
@@ -1,0 +1,58 @@
+name: CI CPU Stress
+
+on:
+  workflow_dispatch:
+    inputs:
+      config:
+        description: "Build/test configuration"
+        required: true
+        type: choice
+        default: release
+        options:
+          - release
+          - debug
+      test-category:
+        description: "slang-test category"
+        required: true
+        type: choice
+        default: full
+        options:
+          - full
+          - smoke
+      server-count:
+        description: "test-server process count; 4 matches the current ubuntu-24.04 CPU CI tier"
+        required: true
+        type: number
+        default: 4
+      iterations:
+        description: "JSON array of iteration labels; each entry runs on a fresh GitHub-hosted ubuntu-24.04 runner"
+        required: true
+        type: string
+        default: '["01","02","03","04"]'
+
+jobs:
+  build-linux-gcc-x86_64:
+    uses: ./.github/workflows/ci-slang-build-container.yml
+    with:
+      config: ${{ inputs.config }}
+      runs-on: '["ubuntu-22.04"]'
+
+  stress-linux-gcc-x86_64-cpu:
+    needs: [build-linux-gcc-x86_64]
+    name: cpu stress ${{ matrix.iteration }} / ${{ inputs.config }} / server-count ${{ inputs.server-count }}
+    strategy:
+      fail-fast: false
+      matrix:
+        iteration: ${{ fromJSON(inputs.iterations) }}
+    uses: ./.github/workflows/ci-slang-test.yml
+    with:
+      os: linux
+      compiler: gcc
+      platform: x86_64
+      config: ${{ inputs.config }}
+      runs-on: '["ubuntu-24.04"]'
+      test-category: ${{ inputs.test-category }}
+      full-gpu-tests: false
+      cpu-only: true
+      server-count: ${{ inputs.server-count }}
+      test-log-artifact: cpu-stress-${{ inputs.config }}-server${{ inputs.server-count }}-${{ matrix.iteration }}

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -49,6 +49,11 @@ on:
         type: boolean
         default: false
         description: "Restrict slang-test to GPU APIs (vk+cuda+dx11+dx12+mtl+wgpu) while retaining no-API tests needed by multi-step workflows"
+      test-log-artifact:
+        required: false
+        type: string
+        default: ""
+        description: "Optional artifact name for captured slang-test output and summary"
 
 jobs:
   test-slang:
@@ -69,6 +74,20 @@ jobs:
           platform: ${{ inputs.platform }}
           config: ${{ inputs.config }}
           artifact-suffix: ${{ inputs.artifact-suffix }}
+
+      - name: Configure core dumps
+        if: ${{ inputs.test-log-artifact != '' && inputs.os == 'linux' }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/cores"
+          chmod 700 "${RUNNER_TEMP}/cores"
+
+          # Best effort: GitHub-hosted Linux runners allow sudo here, but keep
+          # diagnostics non-fatal if the host image changes its policy.
+          sudo sysctl -w "kernel.core_pattern=${RUNNER_TEMP}/cores/core.%e.%p.%t" || true
+          sudo sysctl -w "fs.suid_dumpable=2" || true
+
+          echo "core_pattern=$(cat /proc/sys/kernel/core_pattern 2>/dev/null || true)"
+          echo "core_ulimit_before_test=$(ulimit -c || true)"
 
       - name: Test Slang
         run: |
@@ -135,8 +154,90 @@ jobs:
             slang_test_args+=("-skip-list" "tests/skip-list-debug.txt")
           fi
 
-          # Execute slang-test with all arguments
-          "$bin_dir/slang-test" "${slang_test_args[@]}"
+          # Execute slang-test with all arguments. Stress workflows can ask
+          # this reusable workflow to capture the output without changing the
+          # command line that normal CI runs.
+          if [[ -n "${{ inputs.test-log-artifact }}" ]]; then
+            if [[ "${{ inputs.os }}" == "linux" ]]; then
+              ulimit -c unlimited || true
+              echo "core_ulimit_for_test=$(ulimit -c || true)"
+            fi
+            set +e
+            "$bin_dir/slang-test" "${slang_test_args[@]}" 2>&1 | tee "${RUNNER_TEMP}/slang-test.log"
+            slang_test_exit=${PIPESTATUS[0]}
+            set -e
+            exit "$slang_test_exit"
+          else
+            "$bin_dir/slang-test" "${slang_test_args[@]}"
+          fi
+
+      - name: Summarize slang-test log
+        if: ${{ always() && inputs.test-log-artifact != '' }}
+        run: |
+          python3 extras/ci/summarize-slang-test-log.py \
+            "${RUNNER_TEMP}/slang-test.log" \
+            --json "${RUNNER_TEMP}/slang-test-summary.json" \
+            --markdown "${GITHUB_STEP_SUMMARY}"
+
+      - name: Collect slang-test artifacts
+        if: ${{ always() && inputs.test-log-artifact != '' }}
+        run: |
+          artifact_dir="${RUNNER_TEMP}/slang-test-artifacts"
+          mkdir -p "$artifact_dir"
+
+          cp "${RUNNER_TEMP}/slang-test.log" "$artifact_dir/" 2>/dev/null || true
+          cp "${RUNNER_TEMP}/slang-test-summary.json" "$artifact_dir/" 2>/dev/null || true
+
+          {
+            echo "runner_name=${RUNNER_NAME:-unknown}"
+            echo "runner_os=${RUNNER_OS:-unknown}"
+            echo "runner_arch=${RUNNER_ARCH:-unknown}"
+            echo "core_pattern=$(cat /proc/sys/kernel/core_pattern 2>/dev/null || true)"
+            echo "core_ulimit_after_test=$(ulimit -c || true)"
+          } > "$artifact_dir/core-dump-environment.txt"
+
+          core_list="$artifact_dir/core-files.txt"
+          : > "$core_list"
+
+          if [[ "${{ inputs.os }}" == "linux" ]]; then
+            for core_dir in "${RUNNER_TEMP}/cores" "$PWD" /var/lib/systemd/coredump; do
+              if [[ ! -d "$core_dir" ]]; then
+                continue
+              fi
+              if [[ "$core_dir" == "/var/lib/systemd/coredump" ]]; then
+                sudo find "$core_dir" -maxdepth 1 -type f -size +0c -print >> "$core_list" 2>/dev/null || true
+              else
+                find "$core_dir" -maxdepth 3 -type f \( -name 'core' -o -name 'core.*' -o -name '*.core' \) -size +0c -print >> "$core_list" 2>/dev/null || true
+              fi
+            done
+            sort -u "$core_list" -o "$core_list"
+
+            if [[ -s "$core_list" ]]; then
+              core_stage="$artifact_dir/cores"
+              mkdir -p "$core_stage"
+              while IFS= read -r core_file; do
+                core_name="$(basename "$core_file")"
+                cp "$core_file" "$core_stage/$core_name" 2>/dev/null || sudo cp "$core_file" "$core_stage/$core_name" || true
+                sudo chown "$USER" "$core_stage/$core_name" 2>/dev/null || true
+              done < "$core_list"
+
+              if find "$core_stage" -type f -size +0c -print -quit | grep -q .; then
+                tar -czf "$artifact_dir/core-files.tar.gz" -C "$core_stage" .
+                rm -rf "$core_stage"
+              fi
+            fi
+          fi
+
+          find "$artifact_dir" -maxdepth 2 -type f -print | sort
+
+      - name: Upload slang-test artifacts
+        if: ${{ always() && inputs.test-log-artifact != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.test-log-artifact }}
+          path: ${{ runner.temp }}/slang-test-artifacts
+          retention-days: 7
+          if-no-files-found: warn
       - name: Run Slang examples
         # Run examples on release for pull requests, and not on merge_group, to reduce CI load.
         if: inputs.full-gpu-tests && inputs.config == 'release' && github.event_name == 'pull_request'

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -54,6 +54,11 @@ on:
         type: string
         default: ""
         description: "Optional artifact name for captured slang-test output and summary"
+      collect-core-dumps:
+        required: false
+        type: boolean
+        default: false
+        description: "Collect Linux core dumps into the test artifact; intended for explicit stress/debug workflows"
 
 jobs:
   test-slang:
@@ -76,7 +81,7 @@ jobs:
           artifact-suffix: ${{ inputs.artifact-suffix }}
 
       - name: Configure core dumps
-        if: ${{ inputs.test-log-artifact != '' && inputs.os == 'linux' }}
+        if: ${{ inputs.test-log-artifact != '' && inputs.collect-core-dumps && inputs.os == 'linux' }}
         run: |
           mkdir -p "${RUNNER_TEMP}/cores"
           chmod 700 "${RUNNER_TEMP}/cores"
@@ -158,12 +163,17 @@ jobs:
           # this reusable workflow to capture the output without changing the
           # command line that normal CI runs.
           if [[ -n "${{ inputs.test-log-artifact }}" ]]; then
-            if [[ "${{ inputs.os }}" == "linux" ]]; then
+            if [[ "${{ inputs.collect-core-dumps }}" == "true" && "${{ inputs.os }}" == "linux" ]]; then
               ulimit -c unlimited || true
               echo "core_ulimit_for_test=$(ulimit -c || true)"
             fi
             set +e
-            "$bin_dir/slang-test" "${slang_test_args[@]}" 2>&1 | tee "${RUNNER_TEMP}/slang-test.log"
+            env \
+              -u ACTIONS_ID_TOKEN_REQUEST_TOKEN \
+              -u ACTIONS_RUNTIME_TOKEN \
+              -u GH_TOKEN \
+              -u GITHUB_TOKEN \
+              "$bin_dir/slang-test" "${slang_test_args[@]}" 2>&1 | tee "${RUNNER_TEMP}/slang-test.log"
             slang_test_exit=${PIPESTATUS[0]}
             set -e
             exit "$slang_test_exit"
@@ -188,28 +198,22 @@ jobs:
           cp "${RUNNER_TEMP}/slang-test.log" "$artifact_dir/" 2>/dev/null || true
           cp "${RUNNER_TEMP}/slang-test-summary.json" "$artifact_dir/" 2>/dev/null || true
 
-          {
-            echo "runner_name=${RUNNER_NAME:-unknown}"
-            echo "runner_os=${RUNNER_OS:-unknown}"
-            echo "runner_arch=${RUNNER_ARCH:-unknown}"
-            echo "core_pattern=$(cat /proc/sys/kernel/core_pattern 2>/dev/null || true)"
-            echo "core_ulimit_after_test=$(ulimit -c || true)"
-          } > "$artifact_dir/core-dump-environment.txt"
+          if [[ "${{ inputs.collect-core-dumps }}" == "true" && "${{ inputs.os }}" == "linux" ]]; then
+            {
+              echo "runner_name=${RUNNER_NAME:-unknown}"
+              echo "runner_os=${RUNNER_OS:-unknown}"
+              echo "runner_arch=${RUNNER_ARCH:-unknown}"
+              echo "core_pattern=$(cat /proc/sys/kernel/core_pattern 2>/dev/null || true)"
+              echo "core_ulimit_after_test=$(ulimit -c || true)"
+            } > "$artifact_dir/core-dump-environment.txt"
 
-          core_list="$artifact_dir/core-files.txt"
-          : > "$core_list"
+            core_list="$artifact_dir/core-files.txt"
+            : > "$core_list"
 
-          if [[ "${{ inputs.os }}" == "linux" ]]; then
-            for core_dir in "${RUNNER_TEMP}/cores" "$PWD" /var/lib/systemd/coredump; do
-              if [[ ! -d "$core_dir" ]]; then
-                continue
-              fi
-              if [[ "$core_dir" == "/var/lib/systemd/coredump" ]]; then
-                sudo find "$core_dir" -maxdepth 1 -type f -size +0c -print >> "$core_list" 2>/dev/null || true
-              else
-                find "$core_dir" -maxdepth 3 -type f \( -name 'core' -o -name 'core.*' -o -name '*.core' \) -size +0c -print >> "$core_list" 2>/dev/null || true
-              fi
-            done
+            core_dir="${RUNNER_TEMP}/cores"
+            if [[ -d "$core_dir" ]]; then
+              find "$core_dir" -maxdepth 3 -type f \( -name 'core' -o -name 'core.*' -o -name '*.core' \) -size +0c -print >> "$core_list" 2>/dev/null || true
+            fi
             sort -u "$core_list" -o "$core_list"
 
             if [[ -s "$core_list" ]]; then
@@ -217,11 +221,13 @@ jobs:
               mkdir -p "$core_stage"
               while IFS= read -r core_file; do
                 core_name="$(basename "$core_file")"
-                cp "$core_file" "$core_stage/$core_name" 2>/dev/null || sudo cp "$core_file" "$core_stage/$core_name" || true
-                sudo chown "$USER" "$core_stage/$core_name" 2>/dev/null || true
+                core_hash="$(printf '%s' "$core_file" | sha256sum | cut -d' ' -f1)"
+                staged_core="$core_stage/${core_hash}-${core_name}"
+                cp "$core_file" "$staged_core" 2>/dev/null || sudo cp "$core_file" "$staged_core" || true
+                sudo chown "$USER" "$staged_core" 2>/dev/null || true
               done < "$core_list"
 
-              if find "$core_stage" -type f -size +0c -print -quit | grep -q .; then
+              if [[ -n "$(find "$core_stage" -type f -size +0c -print -quit)" ]]; then
                 tar -czf "$artifact_dir/core-files.tar.gz" -C "$core_stage" .
                 rm -rf "$core_stage"
               fi

--- a/extras/ci/summarize-slang-test-log.py
+++ b/extras/ci/summarize-slang-test-log.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Summarize slang-test output for stress and CI diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+def summarize_log(text: str) -> dict:
+    failed_tests = re.findall(r"FAILED test: '([^']+)'", text)
+    json_rpc_lines = re.findall(r"JSON RPC failure: ([^\r\n]+)", text)
+    summary_matches = list(
+        re.finditer(
+            r"(?P<percent>\d+)% of tests passed "
+            r"\((?P<passed>\d+)/(?P<total>\d+)\), "
+            r"(?P<ignored>\d+) tests ignored"
+            r"(?:, (?P<expected_failed>\d+) tests failed expectedly)?",
+            text,
+        )
+    )
+    summary_match = summary_matches[-1] if summary_matches else None
+
+    summary = {
+        "failed_test_count": len(failed_tests),
+        "failed_tests": failed_tests,
+        "json_rpc_failure_count": len(json_rpc_lines),
+        "json_rpc_wait_for_result_count": sum(
+            1 for line in json_rpc_lines if "waitForResult()" in line
+        ),
+        "json_rpc_has_message_count": sum(
+            1 for line in json_rpc_lines if "hasMessage()" in line
+        ),
+        "too_many_failed_tests": "Too many failed tests" in text,
+        "stopped_after_consecutive_failures": (
+            "Stopped scheduling new tests after too many consecutive failures" in text
+        ),
+        "pass_percent": None,
+        "passed_tests": None,
+        "total_tests": None,
+        "ignored_tests": None,
+        "expected_failed_tests": None,
+    }
+
+    if summary_match:
+        summary.update(
+            {
+                "pass_percent": int(summary_match.group("percent")),
+                "passed_tests": int(summary_match.group("passed")),
+                "total_tests": int(summary_match.group("total")),
+                "ignored_tests": int(summary_match.group("ignored")),
+                "expected_failed_tests": int(
+                    summary_match.group("expected_failed") or 0
+                ),
+            }
+        )
+
+    return summary
+
+
+def write_markdown(path: Path, summary: dict) -> None:
+    failed_tests = summary["failed_tests"]
+    lines = [
+        "## slang-test summary",
+        "",
+        f"- Failed tests: {summary['failed_test_count']}",
+        f"- JSON RPC failures: {summary['json_rpc_failure_count']}",
+        f"- JSON RPC waitForResult: {summary['json_rpc_wait_for_result_count']}",
+        f"- JSON RPC hasMessage: {summary['json_rpc_has_message_count']}",
+        f"- Too many failed tests: {summary['too_many_failed_tests']}",
+        f"- Stopped after consecutive failures: {summary['stopped_after_consecutive_failures']}",
+    ]
+
+    if summary["total_tests"] is not None:
+        lines.extend(
+            [
+                f"- Passed tests: {summary['passed_tests']} / {summary['total_tests']}",
+                f"- Ignored tests: {summary['ignored_tests']}",
+                f"- Expected failed tests: {summary['expected_failed_tests']}",
+            ]
+        )
+
+    if failed_tests:
+        lines.extend(["", "### Failed Tests", ""])
+        lines.extend(f"- `{test}`" for test in failed_tests[:100])
+        if len(failed_tests) > 100:
+            lines.append(f"- ... {len(failed_tests) - 100} more")
+
+    with path.open("a", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+        f.write("\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", type=Path)
+    parser.add_argument("--json", type=Path, required=True)
+    parser.add_argument("--markdown", type=Path)
+    args = parser.parse_args()
+
+    if args.log.exists():
+        text = args.log.read_text(encoding="utf-8", errors="replace")
+    else:
+        text = ""
+
+    summary = summarize_log(text)
+    args.json.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    if args.markdown:
+        write_markdown(args.markdown, summary)
+
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a manual CI CPU Stress workflow that builds once and fans out CPU-only test iterations on GitHub-hosted ubuntu-24.04 runners
- let the reusable ci-slang-test workflow optionally capture slang-test logs, JSON summaries, and core dump artifacts without changing normal CI behavior
- add a slang-test log summarizer for failed-test and JSON-RPC failure counts

## Validation
- python3 -m py_compile extras/ci/summarize-slang-test-log.py
- python3 -c "import yaml, pathlib; [yaml.safe_load(pathlib.Path(p).read_text()) for p in ['.github/workflows/ci-slang-test.yml','.github/workflows/ci-cpu-stress.yml']]; print('yaml ok')"
- git diff --check HEAD~1 HEAD
- verified the summarizer reports the saved CPU incident as 78 failed tests and 156 JSON-RPC failures