### PR TITLE
ci: retry smoke check when required GPU APIs are not detected

### DIFF
--- a/.github/actions/common-test-setup/action.yml
+++ b/.github/actions/common-test-setup/action.yml
@@ -102,8 +102,14 @@ runs:
         # Retry on either a non-zero exit or a missing required API; on final
         # failure, the captured output is printed below.
         for attempt in 1 2 3; do
-          smokeResult=$("$bin_dir/slang-test" "tests/render/check-backend-support-on-ci.slang" 2>&1)
-          smokeStatus=$?
+          # Guard the assignment in `if` so that under `bash -e` (the GitHub
+          # Actions default) a non-zero exit from slang-test does not abort
+          # the step before we get a chance to retry.
+          if smokeResult=$("$bin_dir/slang-test" "tests/render/check-backend-support-on-ci.slang" 2>&1); then
+            smokeStatus=0
+          else
+            smokeStatus=$?
+          fi
           if [ "$smokeStatus" -eq 0 ] && all_required_apis_supported "$smokeResult"; then
             break
           fi

--- a/.github/actions/common-test-setup/action.yml
+++ b/.github/actions/common-test-setup/action.yml
@@ -98,8 +98,9 @@ runs:
           return 0
         }
 
-        # Capture the output of slang-test while also displaying it.
-        # Retry on either a non-zero exit or a missing required API.
+        # Capture the output of slang-test for inspection after the loop.
+        # Retry on either a non-zero exit or a missing required API; on final
+        # failure, the captured output is printed below.
         for attempt in 1 2 3; do
           smokeResult=$("$bin_dir/slang-test" "tests/render/check-backend-support-on-ci.slang" 2>&1)
           smokeStatus=$?
@@ -148,9 +149,10 @@ runs:
           done
         }
 
-        # Platform-specific API checks - fail if APIs are not available
+        # Platform-specific API checks - fail if APIs are not available.
+        # The required_apis array above is the single source of truth.
         if [[ "${{ inputs.os }}" == "macos" ]]; then
-          check_api_support "mtl,metal"
+          check_api_support "${required_apis[@]}"
 
           # Structured environment dump (matches Linux print-env-info format)
           echo "ENV_INFO_START"
@@ -167,7 +169,7 @@ runs:
           echo "os=macos"
           echo "ENV_INFO_END"
         elif [[ "${{ inputs.os }}" == "windows" ]]; then
-          check_api_support "vk,vulkan" "dx12,d3d12" "dx11,d3d11" "cuda"
+          check_api_support "${required_apis[@]}"
 
           echo "Printing CUDA compiler version: ..."
           nvcc --version || (echo "ERROR: CUDA compiler (nvcc) not available on Windows" && exit 1)

--- a/.github/actions/common-test-setup/action.yml
+++ b/.github/actions/common-test-setup/action.yml
@@ -76,20 +76,53 @@ runs:
       shell: bash
       run: |
         echo "Checking supported backends"
-        # Capture the output of slang-test while also displaying it
-        # Add retry logic for intermittent failures
-        for attempt in 1 2 3; do
-          if smokeResult=$("$bin_dir/slang-test" "tests/render/check-backend-support-on-ci.slang" 2>&1); then
-            break
-          else
-            echo "⚠️  Attempt $attempt failed, retrying..."
-            if [ $attempt -eq 3 ]; then
-              echo "❌ ERROR: slang-test failed to run after 3 attempts"
-              echo "Output: $smokeResult"
-              exit 1
+
+        # Per-OS list of APIs the smoke check must report as Supported. If any
+        # are missing we retry — device startup (e.g. Metal on the macOS VM)
+        # occasionally fails on the first try and recovers on a retry.
+        required_apis=()
+        if [[ "${{ inputs.os }}" == "macos" ]]; then
+          required_apis=("mtl,metal")
+        elif [[ "${{ inputs.os }}" == "windows" ]]; then
+          required_apis=("vk,vulkan" "dx12,d3d12" "dx11,d3d11" "cuda")
+        fi
+
+        # Returns 0 if every required API appears as "<api>: Supported" in the smoke output.
+        all_required_apis_supported() {
+          local out=$1
+          for api in "${required_apis[@]}"; do
+            if ! echo "$out" | grep -qi "${api}: Supported"; then
+              return 1
             fi
-            sleep 2
+          done
+          return 0
+        }
+
+        # Capture the output of slang-test while also displaying it.
+        # Retry on either a non-zero exit or a missing required API.
+        for attempt in 1 2 3; do
+          smokeResult=$("$bin_dir/slang-test" "tests/render/check-backend-support-on-ci.slang" 2>&1)
+          smokeStatus=$?
+          if [ "$smokeStatus" -eq 0 ] && all_required_apis_supported "$smokeResult"; then
+            break
           fi
+          if [ "$smokeStatus" -ne 0 ]; then
+            echo "⚠️  Attempt $attempt: slang-test exited with status $smokeStatus, retrying..."
+          else
+            missing=()
+            for api in "${required_apis[@]}"; do
+              if ! echo "$smokeResult" | grep -qi "${api}: Supported"; then
+                missing+=("$api")
+              fi
+            done
+            echo "⚠️  Attempt $attempt: required API(s) not detected: ${missing[*]}, retrying..."
+          fi
+          if [ "$attempt" -eq 3 ]; then
+            echo "❌ ERROR: smoke check failed after 3 attempts"
+            echo "Output: $smokeResult"
+            exit 1
+          fi
+          sleep 2
         done
         supportedBackends="$(echo "$smokeResult" | grep 'Supported backends: ')"
         echo "$smokeResult"


### PR DESCRIPTION
## Summary
- The macOS smoke check in `common-test-setup` occasionally reports `Check mtl,metal: Not Supported` when `render-test -mtl -only-startup` fails to bring up the paravirtual Metal device on the GitHub-hosted runner. Example: https://github.com/shader-slang/slang/actions/runs/25035391068/job/73347418880 — all four macOS test jobs in that run aborted at the smoke step with `❌ mtl,metal API support not detected`, while runs immediately before and after on master succeeded and exercised Metal normally.
- The existing retry only triggered on a non-zero exit from `slang-test`, so a successful run that happened to miss Metal on the first attempt aborted the job immediately.
- This PR extends the retry loop to also retry when `slang-test` exits 0 but the platform-required APIs are not all reported as Supported. Required APIs are declared per-OS (macOS: `mtl,metal`; Windows: vk/dx12/dx11/cuda) so the loop only re-runs when there's something concrete to wait on.
- The loop still bails after 3 attempts, so persistent missing APIs (a real regression) still hard-fail the job.