### PR TITLE
ci: track GPU quota by accelerator type

### DIFF
--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -112,7 +112,10 @@ def load_gpu_quota_metrics():
     if not isinstance(config, dict):
         return _default_gpu_quota_metrics("root must be an object")
 
-    configured_metrics = config.get("gpu_quota_metrics", [])
+    if "gpu_quota_metrics" not in config:
+        return _default_gpu_quota_metrics()
+
+    configured_metrics = config["gpu_quota_metrics"]
     if not isinstance(configured_metrics, list):
         return _default_gpu_quota_metrics("gpu_quota_metrics must be a list")
 
@@ -138,7 +141,7 @@ def load_gpu_quota_metrics():
             "name": name,
             "regions": list(dict.fromkeys(regions)),
         })
-    return metrics or _default_gpu_quota_metrics()
+    return metrics
 
 
 def fetch_gpu_quota(metrics=None):

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -200,8 +200,15 @@ def fetch_gpu_quota(metrics=None):
             metric = q.get("metric")
             if metric not in wanted_metrics:
                 continue
-            usage = int(q.get("usage", 0))
-            limit = int(q.get("limit", 0))
+            try:
+                usage = int(q.get("usage", 0))
+                limit = int(q.get("limit", 0))
+            except (TypeError, ValueError):
+                print(
+                    f"Warning: invalid quota values for {metric} in {region}",
+                    file=sys.stderr,
+                )
+                continue
             bucket = by_metric[metric]
             bucket["regions"][region] = {"usage": usage, "limit": limit}
             bucket["usage"] += usage

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -91,6 +91,15 @@ def _copy_gpu_quota_metrics(metrics):
     ]
 
 
+def _default_gpu_quota_metrics(reason=None):
+    if reason:
+        print(
+            f"Warning: invalid gpu_quota_metrics in runner_config.json: {reason}; using defaults",
+            file=sys.stderr,
+        )
+    return _copy_gpu_quota_metrics(DEFAULT_GPU_QUOTA_METRICS)
+
+
 def load_gpu_quota_metrics():
     """Load GPU quota metrics from runner_config.json."""
     config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "runner_config.json")
@@ -98,20 +107,38 @@ def load_gpu_quota_metrics():
         with open(config_path, "r", encoding="utf-8") as f:
             config = json.load(f)
     except (OSError, json.JSONDecodeError):
-        return _copy_gpu_quota_metrics(DEFAULT_GPU_QUOTA_METRICS)
+        return _default_gpu_quota_metrics()
+
+    if not isinstance(config, dict):
+        return _default_gpu_quota_metrics("root must be an object")
+
+    configured_metrics = config.get("gpu_quota_metrics", [])
+    if not isinstance(configured_metrics, list):
+        return _default_gpu_quota_metrics("gpu_quota_metrics must be a list")
 
     metrics = []
-    for entry in config.get("gpu_quota_metrics", []):
+    for index, entry in enumerate(configured_metrics):
+        if not isinstance(entry, dict):
+            return _default_gpu_quota_metrics(f"entry {index} must be an object")
         metric = entry.get("metric")
         regions = entry.get("regions", [])
-        if not metric or not regions:
-            continue
+        name = entry.get("name", metric)
+        if not isinstance(metric, str) or not metric:
+            return _default_gpu_quota_metrics(f"entry {index} metric must be a non-empty string")
+        if not isinstance(name, str) or not name:
+            return _default_gpu_quota_metrics(f"entry {index} name must be a non-empty string")
+        if (
+            not isinstance(regions, list)
+            or not regions
+            or any(not isinstance(region, str) or not region for region in regions)
+        ):
+            return _default_gpu_quota_metrics(f"entry {index} regions must be a non-empty string list")
         metrics.append({
             "metric": metric,
-            "name": entry.get("name", metric),
+            "name": name,
             "regions": list(dict.fromkeys(regions)),
         })
-    return metrics or _copy_gpu_quota_metrics(DEFAULT_GPU_QUOTA_METRICS)
+    return metrics or _default_gpu_quota_metrics()
 
 
 def fetch_gpu_quota(metrics=None):
@@ -120,7 +147,7 @@ def fetch_gpu_quota(metrics=None):
     Returns a dict with a 'by_metric' breakdown plus legacy T4 'usage',
     'limit', and 'regions' fields, or None if gcloud is unavailable.
     """
-    metric_configs = metrics or load_gpu_quota_metrics()
+    metric_configs = load_gpu_quota_metrics() if metrics is None else metrics
     if not metric_configs:
         return None
 

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -28,10 +28,34 @@ from ci_visualization import page_template, chart_section, DOWNLOAD_JS
 
 DEFAULT_REPO = "shader-slang/slang"
 
-# GCP T4 GPU quota configuration
+# GCP GPU quota configuration
 GPU_QUOTA_PROJECT = "slang-runners"
-GPU_QUOTA_REGIONS = ["us-central1", "us-east1", "us-west1"]
 GPU_QUOTA_METRIC = "NVIDIA_T4_GPUS"
+GPU_QUOTA_REGIONS = ["us-central1", "us-east1", "us-west1"]
+DEFAULT_GPU_QUOTA_METRICS = [
+    {
+        "metric": GPU_QUOTA_METRIC,
+        "name": "T4",
+        "regions": GPU_QUOTA_REGIONS,
+    },
+    {
+        "metric": "NVIDIA_L4_GPUS",
+        "name": "L4",
+        "regions": ["us-central1", "us-east1", "us-west1", "us-west4", "europe-west1"],
+    },
+]
+GCP_VM_GROUPS = [
+    "Linux GPU (GCP)",
+    "Linux SM80Plus GPU (GCP)",
+    "Windows Build (GCP)",
+    "Windows GPU (GCP)",
+]
+GCP_VM_PALETTE = {
+    "Linux GPU (GCP)": "#0d6efd",
+    "Linux SM80Plus GPU (GCP)": "#6f42c1",
+    "Windows Build (GCP)": "#fd7e14",
+    "Windows GPU (GCP)": "#28a745",
+}
 
 
 def _esc(s):
@@ -56,17 +80,65 @@ SNAPSHOTS_FILE = "health_snapshots.jsonl"
 CHARTJS_CDN = "https://cdn.jsdelivr.net/npm/chart.js"
 
 
-def fetch_gpu_quota():
-    """Fetch T4 GPU usage and limits from GCP across all configured regions.
+def _copy_gpu_quota_metrics(metrics):
+    return [
+        {
+            "metric": m["metric"],
+            "name": m.get("name", m["metric"]),
+            "regions": list(m.get("regions", [])),
+        }
+        for m in metrics
+    ]
 
-    Returns a dict with 'usage', 'limit', and per-region breakdown,
-    or None if gcloud is unavailable.
+
+def load_gpu_quota_metrics():
+    """Load GPU quota metrics from runner_config.json."""
+    config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "runner_config.json")
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return _copy_gpu_quota_metrics(DEFAULT_GPU_QUOTA_METRICS)
+
+    metrics = []
+    for entry in config.get("gpu_quota_metrics", []):
+        metric = entry.get("metric")
+        regions = entry.get("regions", [])
+        if not metric or not regions:
+            continue
+        metrics.append({
+            "metric": metric,
+            "name": entry.get("name", metric),
+            "regions": list(dict.fromkeys(regions)),
+        })
+    return metrics or _copy_gpu_quota_metrics(DEFAULT_GPU_QUOTA_METRICS)
+
+
+def fetch_gpu_quota(metrics=None):
+    """Fetch GPU usage and limits from GCP across configured regions.
+
+    Returns a dict with a 'by_metric' breakdown plus legacy T4 'usage',
+    'limit', and 'regions' fields, or None if gcloud is unavailable.
     """
-    total_usage = 0
-    total_limit = 0
-    regions = {}
+    metric_configs = metrics or load_gpu_quota_metrics()
+    if not metric_configs:
+        return None
 
-    for region in GPU_QUOTA_REGIONS:
+    by_metric = {
+        config["metric"]: {
+            "name": config.get("name", config["metric"]),
+            "usage": 0,
+            "limit": 0,
+            "regions": {},
+        }
+        for config in metric_configs
+    }
+    metrics_by_region = {}
+    for config in metric_configs:
+        for region in config.get("regions", []):
+            metrics_by_region.setdefault(region, set()).add(config["metric"])
+
+    for region in metrics_by_region:
         cmd = [
             "gcloud", "compute", "regions", "describe", region,
             "--project", GPU_QUOTA_PROJECT,
@@ -93,18 +165,61 @@ def fetch_gpu_quota():
             print(f"Warning: invalid GPU quota JSON for {region}", file=sys.stderr)
             continue
 
+        wanted_metrics = metrics_by_region[region]
         for q in data.get("quotas", []):
-            if q.get("metric") == GPU_QUOTA_METRIC:
-                usage = int(q.get("usage", 0))
-                limit = int(q.get("limit", 0))
-                regions[region] = {"usage": usage, "limit": limit}
-                total_usage += usage
-                total_limit += limit
-                break
+            metric = q.get("metric")
+            if metric not in wanted_metrics:
+                continue
+            usage = int(q.get("usage", 0))
+            limit = int(q.get("limit", 0))
+            bucket = by_metric[metric]
+            bucket["regions"][region] = {"usage": usage, "limit": limit}
+            bucket["usage"] += usage
+            bucket["limit"] += limit
 
-    if not regions:
+    by_metric = {
+        metric: quota
+        for metric, quota in by_metric.items()
+        if quota["regions"]
+    }
+    if not by_metric:
         return None
-    return {"usage": total_usage, "limit": total_limit, "regions": regions}
+
+    result = {"by_metric": by_metric}
+    legacy = by_metric.get(GPU_QUOTA_METRIC)
+    if legacy:
+        result.update({
+            "usage": legacy["usage"],
+            "limit": legacy["limit"],
+            "regions": legacy["regions"],
+        })
+    return result
+
+
+def _sum_region_quota(regions, key):
+    return sum(region.get(key, 0) for region in regions.values())
+
+
+def _normalize_gpu_quota_by_metric(gpu_quota):
+    """Normalize current and legacy quota payloads into a metric-keyed map."""
+    if not gpu_quota:
+        return {}
+
+    by_metric = gpu_quota.get("by_metric")
+    if isinstance(by_metric, dict) and by_metric:
+        return by_metric
+
+    legacy_regions = gpu_quota.get("regions", {})
+    if not legacy_regions:
+        return {}
+    return {
+        gpu_quota.get("metric", GPU_QUOTA_METRIC): {
+            "name": gpu_quota.get("name", "T4"),
+            "usage": gpu_quota.get("usage", _sum_region_quota(legacy_regions, "usage")),
+            "limit": gpu_quota.get("limit", _sum_region_quota(legacy_regions, "limit")),
+            "regions": legacy_regions,
+        }
+    }
 
 
 def parse_args():
@@ -259,7 +374,12 @@ def record_snapshot(queue_data, output_dir, gpu_quota=None, mq_data=None):
 
     # GPU quota per region
     if gpu_quota:
-        snapshot["gpu_quota"] = gpu_quota.get("regions", {})
+        by_metric = _normalize_gpu_quota_by_metric(gpu_quota)
+        if by_metric:
+            snapshot["gpu_quota_by_metric"] = by_metric
+            legacy = by_metric.get(GPU_QUOTA_METRIC)
+            if legacy:
+                snapshot["gpu_quota"] = legacy.get("regions", {})
 
     # Merge queue summary
     if mq_data:
@@ -334,6 +454,91 @@ def _region_palette(regions):
     return {r: _REGION_COLORS[i % len(_REGION_COLORS)] for i, r in enumerate(regions)}
 
 
+def _gpu_quota_chart_id(metric):
+    if metric == GPU_QUOTA_METRIC:
+        return "gpuQuota"
+    suffix = "".join(ch if ch.isalnum() else "_" for ch in metric)
+    return f"gpuQuota_{suffix}"
+
+
+def _snapshot_gpu_quota_by_metric(snapshot):
+    by_metric = snapshot.get("gpu_quota_by_metric")
+    if isinstance(by_metric, dict) and by_metric:
+        return by_metric
+
+    legacy_regions = snapshot.get("gpu_quota", {})
+    if legacy_regions:
+        return {
+            GPU_QUOTA_METRIC: {
+                "name": "T4",
+                "usage": _sum_region_quota(legacy_regions, "usage"),
+                "limit": _sum_region_quota(legacy_regions, "limit"),
+                "regions": legacy_regions,
+            }
+        }
+    return {}
+
+
+def _quota_metric_display_order(snapshots):
+    ordered = []
+    seen = set()
+    for config in load_gpu_quota_metrics():
+        metric = config["metric"]
+        if metric not in seen:
+            ordered.append(metric)
+            seen.add(metric)
+    for snapshot in snapshots:
+        for metric in _snapshot_gpu_quota_by_metric(snapshot):
+            if metric not in seen:
+                ordered.append(metric)
+                seen.add(metric)
+    return ordered
+
+
+def _build_gpu_quota_charts(snapshots):
+    charts = []
+    for metric in _quota_metric_display_order(snapshots):
+        metric_snapshots = [
+            _snapshot_gpu_quota_by_metric(snapshot).get(metric, {})
+            for snapshot in snapshots
+        ]
+        regions = sorted({
+            region
+            for quota in metric_snapshots
+            for region in quota.get("regions", {})
+        })
+        if not regions:
+            continue
+
+        region_series = {
+            region: [
+                quota.get("regions", {}).get(region, {}).get("usage", 0)
+                for quota in metric_snapshots
+            ]
+            for region in regions
+        }
+        quota_limit = 0
+        name = metric
+        for quota in reversed(metric_snapshots):
+            if quota.get("regions"):
+                name = quota.get("name", metric)
+                quota_limit = sum(
+                    region.get("limit", 0)
+                    for region in quota.get("regions", {}).values()
+                )
+                break
+
+        charts.append({
+            "id": _gpu_quota_chart_id(metric),
+            "metric": metric,
+            "name": name,
+            "regionData": region_series,
+            "limit": quota_limit,
+            "regionColors": _region_palette(regions),
+        })
+    return charts
+
+
 def build_history_chart(snapshots):
     """Build Chart.js HTML for 24h runner load history."""
     if not snapshots:
@@ -342,19 +547,9 @@ def build_history_chart(snapshots):
     snapshots = _deduplicate_snapshots(snapshots)
     timestamps = [_round_time(s["timestamp"][11:16]) for s in snapshots]
 
-    # Only show GCP VM groups (Linux GPU and Windows GPU), exclude scaler host and test runners
-    gcp_vm_groups = [
-        "Linux GPU (GCP)",
-        "Linux SM80Plus GPU (GCP)",
-        "Windows Build (GCP)",
-        "Windows GPU (GCP)",
-    ]
-    palette = {
-        "Linux GPU (GCP)": "#0d6efd",
-        "Linux SM80Plus GPU (GCP)": "#6f42c1",
-        "Windows Build (GCP)": "#fd7e14",
-        "Windows GPU (GCP)": "#28a745",
-    }
+    # Only show GCP VM groups, exclude scaler host and test runners
+    gcp_vm_groups = GCP_VM_GROUPS
+    palette = GCP_VM_PALETTE
 
     # Queue depth over time
     queued_data = [s.get("jobs_queued", 0) for s in snapshots]
@@ -369,26 +564,7 @@ def build_history_chart(snapshots):
     for g in gcp_vm_groups:
         group_series[g] = [s.get("runner_groups", {}).get(g, {}).get("total", 0) for s in snapshots]
 
-    # GPU quota per region (discover regions dynamically from snapshot data)
-    gpu_regions = sorted({
-        region
-        for s in snapshots
-        for region in s.get("gpu_quota", {})
-    })
-    gpu_region_series = {}
-    for region in gpu_regions:
-        gpu_region_series[region] = [
-            s.get("gpu_quota", {}).get(region, {}).get("usage", 0)
-            for s in snapshots
-        ]
-    # Total quota limit (use latest snapshot that has quota data)
-    gpu_quota_limit = 0
-    for s in reversed(snapshots):
-        quota = s.get("gpu_quota", {})
-        if quota:
-            gpu_quota_limit = sum(r.get("limit", 0) for r in quota.values())
-            break
-    has_gpu_quota = bool(gpu_regions)
+    gpu_quota_charts = _build_gpu_quota_charts(snapshots)
 
     # Merge queue cumulative success/failure from snapshots
     # Each snapshot records the running 24h totals; we just plot them over time.
@@ -404,9 +580,13 @@ def build_history_chart(snapshots):
         + chart_section("queueHistory", "Job Queue Depth",
             "Individual jobs waiting in queue vs. actively running on runners.")
     )
-    if has_gpu_quota:
-        charts_html += chart_section("gpuQuota", "T4 GPU Usage vs. Quota",
-            "T4 GPUs in use per GCP region, stacked. Dashed line shows total quota limit.")
+    for quota_chart in gpu_quota_charts:
+        charts_html += chart_section(
+            quota_chart["id"],
+            f"{quota_chart['name']} GPU Usage vs. Quota",
+            f"{quota_chart['name']} GPUs in use per GCP region, stacked. "
+            "Dashed line shows total quota limit.",
+        )
     if has_mq_snapshots:
         charts_html += chart_section("mqHistory", "Merge Queue Checks (24h rolling)",
             "Rolling 24-hour count of merge queue CI check outcomes, sampled every 15 minutes.")
@@ -432,9 +612,7 @@ const allRunsQueued = {json.dumps(runs_queued)};
 const allJobsQueued = {json.dumps(queued_data)};
 const allJobsRunning = {json.dumps(running_data)};
 
-const gpuRegionData = {json.dumps(gpu_region_series)};
-const gpuQuotaLimit = {gpu_quota_limit};
-const gpuRegionColors = {json.dumps(_region_palette(gpu_regions))};
+const gpuQuotaCharts = {json.dumps(gpu_quota_charts)};
 
 const mqSuccessData = {json.dumps(mq_success_data)};
 const mqFailureData = {json.dumps(mq_failure_data)};
@@ -515,13 +693,15 @@ function buildCharts(hours) {{
   }});
 
   // GPU quota (stacked by region + limit line)
-  const gpuCanvas = document.getElementById('gpuQuota_canvas');
-  if (gpuCanvas && Object.keys(gpuRegionData).length > 0) {{
+  for (const quotaChart of gpuQuotaCharts) {{
+    const gpuCanvas = document.getElementById(quotaChart.id + '_canvas');
+    if (!gpuCanvas || Object.keys(quotaChart.regionData).length === 0) continue;
+
     const gpuDatasets = [];
-    for (const [region, color] of Object.entries(gpuRegionColors)) {{
+    for (const [region, color] of Object.entries(quotaChart.regionColors)) {{
       gpuDatasets.push({{
         label: region,
-        data: sliceLast(gpuRegionData[region] || [], n),
+        data: sliceLast(quotaChart.regionData[region] || [], n),
         borderColor: color,
         backgroundColor: color + '55',
         fill: 'stack',
@@ -532,20 +712,20 @@ function buildCharts(hours) {{
     // Quota limit as a dashed line (not stacked)
     gpuDatasets.push({{
       label: 'Quota Limit',
-      data: Array(labels.length).fill(gpuQuotaLimit),
+      data: Array(labels.length).fill(quotaChart.limit),
       borderColor: '#dc3545',
       borderDash: [6, 3],
       borderWidth: 2,
       pointRadius: 0,
       fill: false,
     }});
-    charts.gpu = new Chart(gpuCanvas.getContext('2d'), {{
+    charts[quotaChart.id] = new Chart(gpuCanvas.getContext('2d'), {{
       type: 'line',
       data: {{ labels: displayLabels, datasets: gpuDatasets }},
       options: {{
         responsive: true,
         scales: {{
-          y: {{ min: 0, stacked: true, title: {{ display: true, text: 'T4 GPUs' }} }}
+          y: {{ min: 0, stacked: true, title: {{ display: true, text: quotaChart.name + ' GPUs' }} }}
         }},
         plugins: {{
           tooltip: {{
@@ -553,11 +733,11 @@ function buildCharts(hours) {{
               afterBody: function(items) {{
                 const idx = items[0].dataIndex;
                 let total = 0;
-                for (const region of Object.keys(gpuRegionColors)) {{
+                for (const region of Object.keys(quotaChart.regionColors)) {{
                   const ds = items[0].chart.data.datasets.find(d => d.label === region);
                   if (ds) total += ds.data[idx] || 0;
                 }}
-                return 'Total: ' + total + ' / ' + gpuQuotaLimit;
+                return 'Total: ' + total + ' / ' + quotaChart.limit;
               }}
             }}
           }}
@@ -602,13 +782,8 @@ def generate_health_html(queue_data, failures, output_dir, mq_data=None):
     now = datetime.now(timezone.utc)
     fetched_at = now.strftime("%Y-%m-%d %H:%M UTC")
 
-    # Runner status section — only online GCP GPU runners
-    GCP_GPU_GROUPS = {
-        "Linux GPU (GCP)",
-        "Linux SM80Plus GPU (GCP)",
-        "Windows Build (GCP)",
-        "Windows GPU (GCP)",
-    }
+    # Runner status section — only online GCP VM runners
+    GCP_GPU_GROUPS = set(GCP_VM_GROUPS)
     runners_html = ""
     if queue_data and "self_hosted_runners" in queue_data:
         runners = queue_data["self_hosted_runners"]
@@ -830,7 +1005,8 @@ def main():
     print("Fetching GPU quota...")
     gpu_quota = fetch_gpu_quota()
     if gpu_quota:
-        print(f"  T4 GPUs: {gpu_quota['usage']}/{gpu_quota['limit']} in use")
+        for quota in _normalize_gpu_quota_by_metric(gpu_quota).values():
+            print(f"  {quota.get('name', 'GPU')} GPUs: {quota['usage']}/{quota['limit']} in use")
     else:
         print("  GPU quota unavailable (gcloud not configured or not accessible)")
 

--- a/extras/ci/analytics/runner_config.json
+++ b/extras/ci/analytics/runner_config.json
@@ -133,6 +133,24 @@
       "self_hosted": true
     }
   ],
+  "gpu_quota_metrics": [
+    {
+      "metric": "NVIDIA_T4_GPUS",
+      "name": "T4",
+      "regions": ["us-central1", "us-east1", "us-west1"]
+    },
+    {
+      "metric": "NVIDIA_L4_GPUS",
+      "name": "L4",
+      "regions": [
+        "us-central1",
+        "us-east1",
+        "us-west1",
+        "us-west4",
+        "europe-west1"
+      ]
+    }
+  ],
   "non_production_periods": {
     "runners": {}
   }

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -266,6 +266,36 @@ class TestGpuQuota(unittest.TestCase):
         self.assertEqual(quota["by_metric"]["NVIDIA_L4_GPUS"]["usage"], 5)
         self.assertEqual(quota["by_metric"]["NVIDIA_L4_GPUS"]["limit"], 32)
 
+    def test_fetch_gpu_quota_skips_invalid_numeric_values(self):
+        response = {
+            "quotas": [
+                {"metric": "NVIDIA_T4_GPUS", "usage": "bad", "limit": 8},
+                {"metric": "NVIDIA_L4_GPUS", "usage": 2, "limit": None},
+                {"metric": "NVIDIA_L4_GPUS", "usage": "3", "limit": "16"},
+            ],
+        }
+
+        def fake_run(cmd, **kwargs):
+            return mock.Mock(
+                returncode=0,
+                stdout=json.dumps(response),
+                stderr="",
+            )
+
+        stderr = io.StringIO()
+        with mock.patch("ci_health.subprocess.run", side_effect=fake_run):
+            with contextlib.redirect_stderr(stderr):
+                quota = ci_health.fetch_gpu_quota([
+                    {"metric": "NVIDIA_T4_GPUS", "name": "T4", "regions": ["us-central1"]},
+                    {"metric": "NVIDIA_L4_GPUS", "name": "L4", "regions": ["us-central1"]},
+                ])
+
+        self.assertNotIn("NVIDIA_T4_GPUS", quota["by_metric"])
+        self.assertEqual(quota["by_metric"]["NVIDIA_L4_GPUS"]["usage"], 3)
+        self.assertEqual(quota["by_metric"]["NVIDIA_L4_GPUS"]["limit"], 16)
+        self.assertIn("invalid quota values for NVIDIA_T4_GPUS in us-central1", stderr.getvalue())
+        self.assertIn("invalid quota values for NVIDIA_L4_GPUS in us-central1", stderr.getvalue())
+
     def test_record_snapshot_stores_gpu_quota_per_region(self):
         queue_data = {
             "summary": {"jobs_queued": 0, "jobs_running": 0, "runs_queued": 0, "runs_in_progress": 0},

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -211,6 +211,19 @@ class TestGpuQuota(unittest.TestCase):
                 self.assertIn(warning, stderr.getvalue())
                 self.assertIn("using defaults", stderr.getvalue())
 
+    def test_load_gpu_quota_metrics_distinguishes_missing_from_empty_config(self):
+        with mock.patch("builtins.open", mock.mock_open(read_data=json.dumps({}))):
+            missing_metrics = ci_health.load_gpu_quota_metrics()
+
+        stderr = io.StringIO()
+        with mock.patch("builtins.open", mock.mock_open(read_data=json.dumps({"gpu_quota_metrics": []}))):
+            with contextlib.redirect_stderr(stderr):
+                empty_metrics = ci_health.load_gpu_quota_metrics()
+
+        self.assertEqual(missing_metrics, ci_health.DEFAULT_GPU_QUOTA_METRICS)
+        self.assertEqual(empty_metrics, [])
+        self.assertEqual(stderr.getvalue(), "")
+
     def test_fetch_gpu_quota_honors_explicit_empty_metric_list(self):
         with mock.patch("ci_health.subprocess.run") as run:
             quota = ci_health.fetch_gpu_quota([])

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -190,6 +190,34 @@ class TestRunnerTypeCoverage(unittest.TestCase):
 
 
 class TestGpuQuota(unittest.TestCase):
+    def test_load_gpu_quota_metrics_falls_back_for_malformed_config(self):
+        cases = [
+            (["not", "an", "object"], "root must be an object"),
+            ({"gpu_quota_metrics": {"metric": "NVIDIA_L4_GPUS"}}, "gpu_quota_metrics must be a list"),
+            (
+                {"gpu_quota_metrics": [{"metric": "NVIDIA_L4_GPUS", "regions": "us-central1"}]},
+                "regions must be a non-empty string list",
+            ),
+        ]
+
+        for payload, warning in cases:
+            with self.subTest(payload=payload):
+                stderr = io.StringIO()
+                with mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(payload))):
+                    with contextlib.redirect_stderr(stderr):
+                        metrics = ci_health.load_gpu_quota_metrics()
+
+                self.assertEqual(metrics, ci_health.DEFAULT_GPU_QUOTA_METRICS)
+                self.assertIn(warning, stderr.getvalue())
+                self.assertIn("using defaults", stderr.getvalue())
+
+    def test_fetch_gpu_quota_honors_explicit_empty_metric_list(self):
+        with mock.patch("ci_health.subprocess.run") as run:
+            quota = ci_health.fetch_gpu_quota([])
+
+        self.assertIsNone(quota)
+        run.assert_not_called()
+
     def test_fetch_gpu_quota_fetches_configured_gpu_metrics(self):
         responses = {
             "us-central1": {
@@ -206,7 +234,7 @@ class TestGpuQuota(unittest.TestCase):
         }
 
         def fake_run(cmd, **kwargs):
-            region = cmd[4]
+            region = cmd[cmd.index("describe") + 1]
             return mock.Mock(
                 returncode=0,
                 stdout=json.dumps(responses[region]),

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -190,6 +190,41 @@ class TestRunnerTypeCoverage(unittest.TestCase):
 
 
 class TestGpuQuota(unittest.TestCase):
+    def test_fetch_gpu_quota_fetches_configured_gpu_metrics(self):
+        responses = {
+            "us-central1": {
+                "quotas": [
+                    {"metric": "NVIDIA_T4_GPUS", "usage": 1, "limit": 8},
+                    {"metric": "NVIDIA_L4_GPUS", "usage": 2, "limit": 16},
+                ],
+            },
+            "us-east1": {
+                "quotas": [
+                    {"metric": "NVIDIA_L4_GPUS", "usage": 3, "limit": 16},
+                ],
+            },
+        }
+
+        def fake_run(cmd, **kwargs):
+            region = cmd[4]
+            return mock.Mock(
+                returncode=0,
+                stdout=json.dumps(responses[region]),
+                stderr="",
+            )
+
+        with mock.patch("ci_health.subprocess.run", side_effect=fake_run):
+            quota = ci_health.fetch_gpu_quota([
+                {"metric": "NVIDIA_T4_GPUS", "name": "T4", "regions": ["us-central1"]},
+                {"metric": "NVIDIA_L4_GPUS", "name": "L4", "regions": ["us-central1", "us-east1"]},
+            ])
+
+        self.assertEqual(quota["usage"], 1)
+        self.assertEqual(quota["limit"], 8)
+        self.assertEqual(quota["by_metric"]["NVIDIA_T4_GPUS"]["regions"]["us-central1"], {"usage": 1, "limit": 8})
+        self.assertEqual(quota["by_metric"]["NVIDIA_L4_GPUS"]["usage"], 5)
+        self.assertEqual(quota["by_metric"]["NVIDIA_L4_GPUS"]["limit"], 32)
+
     def test_record_snapshot_stores_gpu_quota_per_region(self):
         queue_data = {
             "summary": {"jobs_queued": 0, "jobs_running": 0, "runs_queued": 0, "runs_in_progress": 0},
@@ -197,12 +232,26 @@ class TestGpuQuota(unittest.TestCase):
             "queue_by_group": [],
         }
         gpu_quota = {
-            "usage": 18,
-            "limit": 24,
-            "regions": {
-                "us-central1": {"usage": 6, "limit": 8},
-                "us-east1": {"usage": 7, "limit": 8},
-                "us-west1": {"usage": 5, "limit": 8},
+            "by_metric": {
+                "NVIDIA_T4_GPUS": {
+                    "name": "T4",
+                    "usage": 18,
+                    "limit": 24,
+                    "regions": {
+                        "us-central1": {"usage": 6, "limit": 8},
+                        "us-east1": {"usage": 7, "limit": 8},
+                        "us-west1": {"usage": 5, "limit": 8},
+                    },
+                },
+                "NVIDIA_L4_GPUS": {
+                    "name": "L4",
+                    "usage": 2,
+                    "limit": 32,
+                    "regions": {
+                        "us-central1": {"usage": 1, "limit": 16},
+                        "us-east1": {"usage": 1, "limit": 16},
+                    },
+                },
             },
         }
 
@@ -214,8 +263,53 @@ class TestGpuQuota(unittest.TestCase):
         self.assertEqual(snapshot["gpu_quota"]["us-central1"], {"usage": 6, "limit": 8})
         self.assertEqual(snapshot["gpu_quota"]["us-east1"], {"usage": 7, "limit": 8})
         self.assertEqual(snapshot["gpu_quota"]["us-west1"], {"usage": 5, "limit": 8})
+        self.assertEqual(
+            snapshot["gpu_quota_by_metric"]["NVIDIA_L4_GPUS"]["regions"]["us-east1"],
+            {"usage": 1, "limit": 16},
+        )
 
     def test_build_history_chart_includes_gpu_quota_when_present(self):
+        snapshots = [
+            {
+                "timestamp": "2026-03-03T10:00:00Z",
+                "jobs_queued": 0,
+                "jobs_running": 0,
+                "runs_queued": 0,
+                "runs_in_progress": 0,
+                "runner_groups": {},
+                "gpu_quota_by_metric": {
+                    "NVIDIA_T4_GPUS": {
+                        "name": "T4",
+                        "usage": 13,
+                        "limit": 16,
+                        "regions": {
+                            "us-central1": {"usage": 6, "limit": 8},
+                            "us-east1": {"usage": 7, "limit": 8},
+                        },
+                    },
+                    "NVIDIA_L4_GPUS": {
+                        "name": "L4",
+                        "usage": 2,
+                        "limit": 32,
+                        "regions": {
+                            "us-central1": {"usage": 1, "limit": 16},
+                            "us-east1": {"usage": 1, "limit": 16},
+                        },
+                    },
+                },
+            },
+        ]
+
+        html = ci_health.build_history_chart(snapshots)
+        self.assertIn("T4 GPU Usage", html)
+        self.assertIn("L4 GPU Usage", html)
+        self.assertIn("gpuQuota_canvas", html)
+        self.assertIn("gpuQuota_NVIDIA_L4_GPUS_canvas", html)
+        self.assertIn("us-central1", html)
+        self.assertIn("us-east1", html)
+        self.assertIn("Quota Limit", html)
+
+    def test_build_history_chart_supports_legacy_t4_gpu_quota_snapshots(self):
         snapshots = [
             {
                 "timestamp": "2026-03-03T10:00:00Z",
@@ -234,9 +328,6 @@ class TestGpuQuota(unittest.TestCase):
         html = ci_health.build_history_chart(snapshots)
         self.assertIn("T4 GPU Usage", html)
         self.assertIn("gpuQuota_canvas", html)
-        self.assertIn("us-central1", html)
-        self.assertIn("us-east1", html)
-        self.assertIn("Quota Limit", html)
 
     def test_build_history_chart_omits_gpu_quota_section_when_absent(self):
         snapshots = [


### PR DESCRIPTION
## Summary
- add accelerator-specific GPU quota metric configuration for CI analytics
- track T4 and L4 quota separately in the health dashboard
- keep the merged SM80Plus runner group visible in runner history/status views

## Testing
- python3 -m unittest extras.ci.analytics.tests.test_ci_analytics