### PR TITLE
Diagnose Windows slang-test RPC timeouts

### DIFF
--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -53,7 +53,7 @@ on:
 jobs:
   test-slang:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.os == 'windows' && inputs.config == 'debug' && github.event_name == 'pull_request' && 90 || 60 }}
     defaults:
       run:
         shell: bash
@@ -137,6 +137,36 @@ jobs:
 
           # Execute slang-test with all arguments
           "$bin_dir/slang-test" "${slang_test_args[@]}"
+
+      - name: Stress Windows RPC unit tests
+        # Temporary diagnostic loop for intermittent Windows test-server JSON RPC failures.
+        if: inputs.os == 'windows' && inputs.config == 'debug' && github.event_name == 'pull_request'
+        run: |
+          export SLANG_TEST_DIAGNOSTICS=rpc,timing,timing-phases
+          export SLANG_RUN_SPIRV_VALIDATION=1
+          export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1
+
+          stress_args=(
+            "slang-unit-test-tool/comHostCallable.internal"
+            "slang-unit-test-tool/compileBenchmark.internal"
+            "slang-unit-test-tool/parallelGenericEntryPointCompile.internal"
+            "-category" "full"
+            "-expected-failure-list" "tests/expected-failure-github.txt"
+            "-skip-reference-image-generation"
+            "-show-adapter-info"
+            "-enable-debug-layers" "${{ inputs.enable-debug-layers }}"
+            "-disable-retries"
+          )
+
+          if [ "${{ inputs.server-count }}" -gt 1 ]; then
+            stress_args+=("-use-test-server")
+            stress_args+=("-server-count" "${{ inputs.server-count }}")
+          fi
+
+          for attempt in 1 2 3 4 5; do
+            echo "Windows RPC stress iteration $attempt"
+            "$bin_dir/slang-test" "${stress_args[@]}"
+          done
       - name: Run Slang examples
         # Run examples on release for pull requests, and not on merge_group, to reduce CI load.
         if: inputs.full-gpu-tests && inputs.config == 'release' && github.event_name == 'pull_request'

--- a/source/compiler-core/slang-json-rpc-connection.h
+++ b/source/compiler-core/slang-json-rpc-connection.h
@@ -159,6 +159,10 @@ public:
     /// If we have an JSON-RPC message m_jsonRoot the root.
     bool hasMessage() const { return m_jsonRoot.isValid(); }
 
+    bool hasProcess() const { return m_process != nullptr; }
+    bool isProcessTerminated() { return m_process && m_process->isTerminated(); }
+    int32_t getProcessReturnValue() const { return m_process ? m_process->getReturnValue() : 0; }
+
     /// If there is a message returns kind of JSON RPC message
     JSONRPCMessageType getMessageType();
 

--- a/source/core/slang-test-diagnostics.h
+++ b/source/core/slang-test-diagnostics.h
@@ -1,0 +1,70 @@
+// slang-test-diagnostics.h
+#ifndef SLANG_TEST_DIAGNOSTICS_H
+#define SLANG_TEST_DIAGNOSTICS_H
+
+#include <stdlib.h>
+#include <string.h>
+
+namespace Slang
+{
+
+inline bool isTestDiagnosticTokenEnabled(const char* diagnostics, const char* category)
+{
+    if (!diagnostics || !category)
+        return false;
+
+    if (strcmp(diagnostics, "all") == 0 || strcmp(diagnostics, "1") == 0)
+        return true;
+
+    const size_t categoryLength = strlen(category);
+    const char* cursor = diagnostics;
+    while (*cursor)
+    {
+        while (*cursor == ' ' || *cursor == '\t' || *cursor == ',')
+            cursor++;
+
+        const char* end = cursor;
+        while (*end && *end != ',')
+            end++;
+
+        const char* tokenEnd = end;
+        while (tokenEnd > cursor && (tokenEnd[-1] == ' ' || tokenEnd[-1] == '\t'))
+            tokenEnd--;
+
+        if (size_t(tokenEnd - cursor) == categoryLength &&
+            strncmp(cursor, category, categoryLength) == 0)
+        {
+            return true;
+        }
+
+        cursor = end;
+    }
+
+    return false;
+}
+
+inline bool isTestDiagnosticEnabled(const char* category)
+{
+#ifdef _WIN32
+    static const char* diagnostics = []() -> const char*
+    {
+        static char buffer[256];
+        char* value = nullptr;
+        size_t valueLength = 0;
+        if (_dupenv_s(&value, &valueLength, "SLANG_TEST_DIAGNOSTICS") == 0 && value)
+        {
+            strncpy_s(buffer, sizeof(buffer), value, _TRUNCATE);
+            free(value);
+            return buffer;
+        }
+        return nullptr;
+    }();
+#else
+    static const char* diagnostics = getenv("SLANG_TEST_DIAGNOSTICS");
+#endif
+    return isTestDiagnosticTokenEnabled(diagnostics, category);
+}
+
+} // namespace Slang
+
+#endif // SLANG_TEST_DIAGNOSTICS_H

--- a/source/core/windows/slang-win-process.cpp
+++ b/source/core/windows/slang-win-process.cpp
@@ -94,6 +94,54 @@ private:
     HANDLE m_handle;
 };
 
+class WinProcThreadAttributeList
+{
+public:
+    SlangResult init(DWORD attributeCount)
+    {
+        SIZE_T attributeListSize = 0;
+        ::InitializeProcThreadAttributeList(nullptr, attributeCount, 0, &attributeListSize);
+        if (attributeListSize == 0)
+        {
+            return SLANG_FAIL;
+        }
+
+        m_attributeList =
+            (LPPROC_THREAD_ATTRIBUTE_LIST)::HeapAlloc(::GetProcessHeap(), 0, attributeListSize);
+        if (!m_attributeList)
+        {
+            return SLANG_FAIL;
+        }
+
+        SLANG_RETURN_FAIL_ON_FALSE(::InitializeProcThreadAttributeList(
+            m_attributeList,
+            attributeCount,
+            0,
+            &attributeListSize));
+
+        m_isInitialized = true;
+        return SLANG_OK;
+    }
+
+    LPPROC_THREAD_ATTRIBUTE_LIST get() const { return m_attributeList; }
+
+    ~WinProcThreadAttributeList()
+    {
+        if (m_attributeList)
+        {
+            if (m_isInitialized)
+            {
+                ::DeleteProcThreadAttributeList(m_attributeList);
+            }
+            ::HeapFree(::GetProcessHeap(), 0, m_attributeList);
+        }
+    }
+
+private:
+    LPPROC_THREAD_ATTRIBUTE_LIST m_attributeList = nullptr;
+    bool m_isInitialized = false;
+};
+
 /* A simple Stream implementation of a File HANDLE (or Pipe). Note that currently does not allow
  * getPosition/seek/atEnd */
 class WinPipeStream : public Stream
@@ -516,14 +564,35 @@ void WinProcess::kill(int32_t returnCode)
                 DUPLICATE_SAME_ACCESS));
         }
 
-        // TODO: switch to proper wide-character versions of these...
-        STARTUPINFOW startupInfo;
+        STARTUPINFOEXW startupInfo;
         ZeroMemory(&startupInfo, sizeof(startupInfo));
-        startupInfo.cb = sizeof(startupInfo);
-        startupInfo.hStdError = childStdErrWrite;
-        startupInfo.hStdOutput = childStdOutWrite;
-        startupInfo.hStdInput = childStdInRead;
-        startupInfo.dwFlags = STARTF_USESTDHANDLES;
+        startupInfo.StartupInfo.cb = sizeof(startupInfo);
+        startupInfo.StartupInfo.hStdError = childStdErrWrite;
+        startupInfo.StartupInfo.hStdOutput = childStdOutWrite;
+        startupInfo.StartupInfo.hStdInput = childStdInRead;
+        startupInfo.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+
+        // Avoid inheriting unrelated pipe handles from concurrent Process::create calls.
+        HANDLE inheritedHandles[3];
+        DWORD inheritedHandleCount = 0;
+        inheritedHandles[inheritedHandleCount++] = childStdOutWrite;
+        inheritedHandles[inheritedHandleCount++] = childStdInRead;
+        if (childStdErrWrite)
+        {
+            inheritedHandles[inheritedHandleCount++] = childStdErrWrite;
+        }
+
+        WinProcThreadAttributeList attributeList;
+        SLANG_RETURN_ON_FAIL(attributeList.init(1));
+        startupInfo.lpAttributeList = attributeList.get();
+        SLANG_RETURN_FAIL_ON_FALSE(::UpdateProcThreadAttribute(
+            startupInfo.lpAttributeList,
+            0,
+            PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+            inheritedHandles,
+            sizeof(HANDLE) * inheritedHandleCount,
+            nullptr,
+            nullptr));
 
         OSString pathBuffer;
         LPCWSTR path = nullptr;
@@ -547,7 +616,7 @@ void WinProcess::kill(int32_t returnCode)
 
         // https://docs.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
 
-        DWORD createFlags = CREATE_NO_WINDOW;
+        DWORD createFlags = CREATE_NO_WINDOW | EXTENDED_STARTUPINFO_PRESENT;
 
         if (flags & Process::Flag::AttachDebugger)
         {
@@ -575,7 +644,7 @@ void WinProcess::kill(int32_t returnCode)
             createFlags,
             nullptr, // TODO: allow specifying environment variables?
             nullptr,
-            &startupInfo,
+            &startupInfo.StartupInfo,
             &processInfo);
 
         if (!success)

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1148,6 +1148,29 @@ Result spawnAndWaitProxy(
     return res;
 }
 
+static Int64 _getElapsedTimeInMs(uint64_t startTick)
+{
+    const uint64_t elapsedTicks = Process::getClockTick() - startTick;
+    return Int64((elapsedTicks * 1000) / Process::getClockFrequency());
+}
+
+static String _getRPCServerStatus(JSONRPCConnection* rpcConnection)
+{
+    if (!rpcConnection->hasProcess())
+    {
+        return String("none");
+    }
+
+    if (rpcConnection->isProcessTerminated())
+    {
+        StringBuilder builder;
+        builder << "terminated, exitCode=" << rpcConnection->getProcessReturnValue();
+        return builder.produceString();
+    }
+
+    return String("running");
+}
+
 static Result _executeRPC(
     TestContext* context,
     SpawnType spawnType,
@@ -1184,18 +1207,25 @@ static Result _executeRPC(
     }
 
     // Wait for the result
+    const uint64_t waitStartTick = Process::getClockTick();
     if (SLANG_FAILED(rpcConnection->waitForResult(context->connectionTimeOutInMs)))
     {
+        String serverStatus = _getRPCServerStatus(rpcConnection);
         context->getTestReporter()->messageFormat(
             TestMessageType::RunError,
-            "JSON RPC failure: waitForResult()");
+            "JSON RPC failure: waitForResult() after %lld ms (timeout=%lld ms, server=%s)",
+            (long long)_getElapsedTimeInMs(waitStartTick),
+            (long long)context->connectionTimeOutInMs,
+            serverStatus.getBuffer());
     }
 
     if (!rpcConnection->hasMessage())
     {
+        String serverStatus = _getRPCServerStatus(rpcConnection);
         context->getTestReporter()->messageFormat(
             TestMessageType::RunError,
-            "JSON RPC failure: hasMessage()");
+            "JSON RPC failure: hasMessage() (server=%s)",
+            serverStatus.getBuffer());
 
         // We can assume somethings gone wrong. So lets kill the connection and fail.
         context->destroyRPCConnection();
@@ -1228,6 +1258,8 @@ static Result _executeRPC(
     outRes.standardError = exeRes.stdError;
     outRes.standardOutput = exeRes.stdOut;
     outRes.debugLayer = exeRes.debugLayer;
+
+    context->drainTestServerStderr();
 
     return SLANG_OK;
 }

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -5,6 +5,7 @@
 #include "../../source/core/slang-io.h"
 #include "../../source/core/slang-shared-library.h"
 #include "../../source/core/slang-string-util.h"
+#include "../../source/core/slang-test-diagnostics.h"
 #include "../../source/core/slang-test-tool-util.h"
 
 #include <stdio.h>
@@ -37,6 +38,7 @@ void TestContext::setThreadIndex(int index)
 void TestContext::setMaxTestRunnerThreadCount(int count)
 {
     m_jsonRpcConnections.setCount(count);
+    m_testServerStderrStreams.setCount(count);
     m_testRequirements.setCount(count);
     m_reporters.setCount(count);
     for (auto& reporter : m_reporters)
@@ -197,22 +199,31 @@ DownstreamCompilerSet* TestContext::getCompilerSet()
 SlangResult TestContext::_createJSONRPCConnection(RefPtr<JSONRPCConnection>& out)
 {
     RefPtr<Process> process;
+    const bool captureTestServerStderr = isTestDiagnosticEnabled("rpc") ||
+                                         isTestDiagnosticEnabled("timing") ||
+                                         isTestDiagnosticEnabled("timing-phases");
 
     {
         CommandLine cmdLine;
         cmdLine.setExecutableLocation(ExecutableLocation(exeDirectoryPath, "test-server"));
 
-        SLANG_RETURN_ON_FAIL(Process::create(
-            cmdLine,
-            Process::Flag::AttachDebugger | Process::Flag::DisableStdErrRedirection,
-            process));
+        Process::Flags flags = Process::Flag::AttachDebugger;
+        if (!captureTestServerStderr)
+        {
+            flags |= Process::Flag::DisableStdErrRedirection;
+        }
+
+        SLANG_RETURN_ON_FAIL(Process::create(cmdLine, flags, process));
     }
 
     Stream* writeStream = process->getStream(StdStreamType::In);
     RefPtr<BufferedReadStream> readStream(
         new BufferedReadStream(process->getStream(StdStreamType::Out)));
-    RefPtr<BufferedReadStream> readErrStream(
-        new BufferedReadStream(process->getStream(StdStreamType::ErrorOut)));
+    RefPtr<BufferedReadStream> readErrStream;
+    if (Stream* stderrStream = process->getStream(StdStreamType::ErrorOut))
+    {
+        readErrStream = new BufferedReadStream(stderrStream);
+    }
 
     RefPtr<HTTPPacketConnection> connection = new HTTPPacketConnection(readStream, writeStream);
     RefPtr<JSONRPCConnection> rpcConnection = new JSONRPCConnection;
@@ -221,6 +232,7 @@ SlangResult TestContext::_createJSONRPCConnection(RefPtr<JSONRPCConnection>& out
         rpcConnection->init(connection, JSONRPCConnection::CallStyle::Default, process));
 
     out = rpcConnection;
+    m_testServerStderrStreams[slangTestThreadIndex] = readErrStream;
 
     return SLANG_OK;
 }
@@ -256,9 +268,44 @@ void TestContext::destroyRPCConnection()
 {
     if (m_jsonRpcConnections[slangTestThreadIndex])
     {
+        drainTestServerStderr();
+
         m_jsonRpcConnections[slangTestThreadIndex]->disconnect();
         m_jsonRpcConnections[slangTestThreadIndex].setNull();
+
+        drainTestServerStderr();
+        m_testServerStderrStreams[slangTestThreadIndex].setNull();
     }
+}
+
+void TestContext::drainTestServerStderr()
+{
+    drainTestServerStderr(slangTestThreadIndex);
+}
+
+void TestContext::drainTestServerStderr(Index threadIndex)
+{
+    if (threadIndex < 0 || threadIndex >= m_testServerStderrStreams.getCount())
+        return;
+
+    auto& stderrStream = m_testServerStderrStreams[threadIndex];
+    if (!stderrStream)
+        return;
+
+    List<uint8_t> buffer;
+    buffer.setCount(4096);
+
+    while (!stderrStream->isEnd())
+    {
+        size_t bytesRead = 0;
+        SlangResult res = stderrStream->read(buffer.getBuffer(), buffer.getCount(), bytesRead);
+
+        if (SLANG_FAILED(res) || bytesRead == 0)
+            break;
+
+        fwrite(buffer.getBuffer(), 1, bytesRead, stderr);
+    }
+    fflush(stderr);
 }
 
 Slang::JSONRPCConnection* TestContext::getOrCreateJSONRPCConnection()

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -142,6 +142,10 @@ public:
     Slang::JSONRPCConnection* getOrCreateJSONRPCConnection();
     void destroyRPCConnection();
 
+    /// Drain and print any stderr output from test-server processes.
+    void drainTestServerStderr();
+    void drainTestServerStderr(Slang::Index threadIndex);
+
     /// Ctor
     TestContext();
     /// Dtor
@@ -216,6 +220,7 @@ protected:
     };
 
     Slang::List<Slang::RefPtr<Slang::JSONRPCConnection>> m_jsonRpcConnections;
+    Slang::List<Slang::RefPtr<Slang::BufferedReadStream>> m_testServerStderrStreams;
     Slang::List<TestReporter*> m_reporters;
     Slang::List<TestRequirements*> m_testRequirements = nullptr;
 

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -8,6 +8,7 @@
 #include "../../source/core/slang-shared-library.h"
 #include "../../source/core/slang-string-util.h"
 #include "../../source/core/slang-string.h"
+#include "../../source/core/slang-test-diagnostics.h"
 #include "../../source/core/slang-test-tool-util.h"
 #include "../../source/core/slang-writer.h"
 #include "../render-test/slang-support.h"
@@ -17,6 +18,7 @@
 #include "test-server-diagnostics.h"
 #include "unit-test/slang-unit-test.h"
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -33,6 +35,68 @@ SLANG_RHI_EXPORT_AGILITY_SDK
 namespace TestServer
 {
 using namespace Slang;
+
+static double _getElapsedTimeInMs(uint64_t startTick)
+{
+    const uint64_t elapsedTicks = Process::getClockTick() - startTick;
+    return (double(elapsedTicks) * 1000.0) / double(Process::getClockFrequency());
+}
+
+static bool _isRPCDiagnosticsEnabled()
+{
+    return isTestDiagnosticEnabled("rpc");
+}
+
+static bool _isTimingDiagnosticsEnabled()
+{
+    return isTestDiagnosticEnabled("timing") || isTestDiagnosticEnabled("timing-phases");
+}
+
+static bool _isTimingPhaseDiagnosticsEnabled()
+{
+    return isTestDiagnosticEnabled("timing-phases");
+}
+
+static void _vwriteDiagnostic(const char* prefix, const char* format, va_list args)
+{
+    fprintf(stderr, "%s ", prefix);
+    vfprintf(stderr, format, args);
+    fprintf(stderr, "\n");
+    fflush(stderr);
+}
+
+static void _writeRPCDiagnostic(const char* format, ...)
+{
+    if (!_isRPCDiagnosticsEnabled())
+        return;
+
+    va_list args;
+    va_start(args, format);
+    _vwriteDiagnostic("[TEST-SERVER-RPC]", format, args);
+    va_end(args);
+}
+
+static void _writeTimingDiagnostic(const char* format, ...)
+{
+    if (!_isTimingDiagnosticsEnabled())
+        return;
+
+    va_list args;
+    va_start(args, format);
+    _vwriteDiagnostic("[TEST-SERVER-TIMING]", format, args);
+    va_end(args);
+}
+
+static void _writeTimingPhaseDiagnostic(const char* format, ...)
+{
+    if (!_isTimingPhaseDiagnosticsEnabled())
+        return;
+
+    va_list args;
+    va_start(args, format);
+    _vwriteDiagnostic("[TEST-SERVER-TIMING]", format, args);
+    va_end(args);
+}
 
 class TestReporter : public ITestReporter
 {
@@ -345,8 +409,26 @@ TestServer::InnerMainFunc TestServer::getToolFunction(const String& name, Diagno
 
 SlangResult TestServer::_executeSingle()
 {
+    const uint64_t waitStartTick = Process::getClockTick();
+    _writeRPCDiagnostic("wait begin pid=%u", Process::getId());
+
     // Block waiting for content (or error/closed)
-    SLANG_RETURN_ON_FAIL(m_connection->waitForResult());
+    SlangResult waitResult = m_connection->waitForResult();
+    if (SLANG_FAILED(waitResult))
+    {
+        _writeRPCDiagnostic(
+            "wait failed pid=%u elapsedMs=%.3f result=0x%08x",
+            Process::getId(),
+            _getElapsedTimeInMs(waitStartTick),
+            uint32_t(waitResult));
+        return waitResult;
+    }
+
+    _writeRPCDiagnostic(
+        "wait complete pid=%u elapsedMs=%.3f hasMessage=%s",
+        Process::getId(),
+        _getElapsedTimeInMs(waitStartTick),
+        m_connection->hasMessage() ? "true" : "false");
 
     // If we don't have a message, we can quit for now
     if (!m_connection->hasMessage())
@@ -362,21 +444,53 @@ SlangResult TestServer::_executeSingle()
         {
             JSONRPCCall call;
             SLANG_RETURN_ON_FAIL(m_connection->getRPCOrSendError(&call));
+            String methodName(call.method);
+            _writeRPCDiagnostic(
+                "call received pid=%u method=%s",
+                Process::getId(),
+                methodName.getBuffer());
 
             // Do different things
             if (call.method == TestServerProtocol::QuitArgs::g_methodName)
             {
+                _writeRPCDiagnostic("quit received pid=%u", Process::getId());
                 m_quit = true;
                 return SLANG_OK;
             }
             else if (call.method == TestServerProtocol::ExecuteUnitTestArgs::g_methodName)
             {
-                SLANG_RETURN_ON_FAIL(_executeUnitTest(call));
+                const uint64_t dispatchStartTick = Process::getClockTick();
+                _writeTimingPhaseDiagnostic(
+                    "dispatch begin pid=%u method=%s",
+                    Process::getId(),
+                    methodName.getBuffer());
+
+                SlangResult result = _executeUnitTest(call);
+                _writeTimingDiagnostic(
+                    "dispatch complete pid=%u method=%s elapsedMs=%.3f result=0x%08x",
+                    Process::getId(),
+                    methodName.getBuffer(),
+                    _getElapsedTimeInMs(dispatchStartTick),
+                    uint32_t(result));
+                SLANG_RETURN_ON_FAIL(result);
                 return SLANG_OK;
             }
             else if (call.method == TestServerProtocol::ExecuteToolTestArgs::g_methodName)
             {
-                SLANG_RETURN_ON_FAIL(_executeTool(call));
+                const uint64_t dispatchStartTick = Process::getClockTick();
+                _writeTimingPhaseDiagnostic(
+                    "dispatch begin pid=%u method=%s",
+                    Process::getId(),
+                    methodName.getBuffer());
+
+                SlangResult result = _executeTool(call);
+                _writeTimingDiagnostic(
+                    "dispatch complete pid=%u method=%s elapsedMs=%.3f result=0x%08x",
+                    Process::getId(),
+                    methodName.getBuffer(),
+                    _getElapsedTimeInMs(dispatchStartTick),
+                    uint32_t(result));
+                SLANG_RETURN_ON_FAIL(result);
                 break;
             }
             else
@@ -412,10 +526,17 @@ static Index _findTestIndex(IUnitTestModule* testModule, const String& name)
 
 SlangResult TestServer::_executeUnitTest(const JSONRPCCall& call)
 {
+    const uint64_t totalStartTick = Process::getClockTick();
     auto id = m_connection->getPersistentValue(call.id);
 
     TestServerProtocol::ExecuteUnitTestArgs args;
     SLANG_RETURN_ON_FAIL(m_connection->toNativeArgsOrSendError(call.params, &args, call.id));
+
+    _writeRPCDiagnostic(
+        "unit-test begin pid=%u module=%s test=%s",
+        Process::getId(),
+        args.moduleName.getBuffer(),
+        args.testName.getBuffer());
 
     auto sink = m_connection->getSink();
 
@@ -460,6 +581,12 @@ SlangResult TestServer::_executeUnitTest(const JSONRPCCall& call)
 
     UnitTestFunc testFunc = testModule->getTestFunc(testIndex);
 
+    const uint64_t bodyStartTick = Process::getClockTick();
+    _writeTimingPhaseDiagnostic(
+        "unit-test body begin pid=%u module=%s test=%s",
+        Process::getId(),
+        args.moduleName.getBuffer(),
+        args.testName.getBuffer());
     try
     {
         testFunc(&unitTestContext);
@@ -468,6 +595,14 @@ SlangResult TestServer::_executeUnitTest(const JSONRPCCall& call)
     {
         testReporter.m_failCount++;
     }
+    _writeTimingDiagnostic(
+        "unit-test body complete pid=%u module=%s test=%s elapsedMs=%.3f failures=%lld tests=%lld",
+        Process::getId(),
+        args.moduleName.getBuffer(),
+        args.testName.getBuffer(),
+        _getElapsedTimeInMs(bodyStartTick),
+        (long long)testReporter.m_failCount,
+        (long long)testReporter.m_testCount);
 
     TestServerProtocol::ExecutionResult result;
     result.result = SLANG_OK;
@@ -484,16 +619,46 @@ SlangResult TestServer::_executeUnitTest(const JSONRPCCall& call)
     }
 
     result.returnCode = int32_t(TestToolUtil::getReturnCode(result.result));
-    return m_connection->sendResult(&result, id);
+
+    const uint64_t sendStartTick = Process::getClockTick();
+    _writeRPCDiagnostic(
+        "unit-test send-result begin pid=%u module=%s test=%s returnCode=%d",
+        Process::getId(),
+        args.moduleName.getBuffer(),
+        args.testName.getBuffer(),
+        result.returnCode);
+    SlangResult sendResult = m_connection->sendResult(&result, id);
+    _writeTimingDiagnostic(
+        "unit-test send-result complete pid=%u module=%s test=%s elapsedMs=%.3f result=0x%08x",
+        Process::getId(),
+        args.moduleName.getBuffer(),
+        args.testName.getBuffer(),
+        _getElapsedTimeInMs(sendStartTick),
+        uint32_t(sendResult));
+    _writeRPCDiagnostic(
+        "unit-test complete pid=%u module=%s test=%s elapsedMs=%.3f result=0x%08x",
+        Process::getId(),
+        args.moduleName.getBuffer(),
+        args.testName.getBuffer(),
+        _getElapsedTimeInMs(totalStartTick),
+        uint32_t(sendResult));
+    return sendResult;
 }
 
 SlangResult TestServer::_executeTool(const JSONRPCCall& call)
 {
+    const uint64_t totalStartTick = Process::getClockTick();
     auto id = m_connection->getPersistentValue(call.id);
 
     TestServerProtocol::ExecuteToolTestArgs args;
 
     SLANG_RETURN_ON_FAIL(m_connection->toNativeArgsOrSendError(call.params, &args, id));
+
+    _writeRPCDiagnostic(
+        "tool begin pid=%u tool=%s argc=%lld",
+        Process::getId(),
+        args.toolName.getBuffer(),
+        (long long)args.args.getCount());
 
     auto sink = m_connection->getSink();
 
@@ -542,8 +707,19 @@ SlangResult TestServer::_executeTool(const JSONRPCCall& call)
         stdWriters.setWriter(SLANG_WRITER_CHANNEL_DIAGNOSTIC, stdErrorWriter);
     }
 
+    const uint64_t bodyStartTick = Process::getClockTick();
+    _writeTimingPhaseDiagnostic(
+        "tool body begin pid=%u tool=%s",
+        Process::getId(),
+        args.toolName.getBuffer());
     const SlangResult funcRes =
         func(&stdWriters, session, int(toolArgs.getCount()), toolArgs.begin());
+    _writeTimingDiagnostic(
+        "tool body complete pid=%u tool=%s elapsedMs=%.3f result=0x%08x",
+        Process::getId(),
+        args.toolName.getBuffer(),
+        _getElapsedTimeInMs(bodyStartTick),
+        uint32_t(funcRes));
 
     TestServerProtocol::ExecutionResult result;
     result.result = funcRes;
@@ -552,7 +728,27 @@ SlangResult TestServer::_executeTool(const JSONRPCCall& call)
     result.debugLayer = debugCallback.getString();
 
     result.returnCode = int32_t(TestToolUtil::getReturnCode(result.result));
-    return m_connection->sendResult(&result, id);
+
+    const uint64_t sendStartTick = Process::getClockTick();
+    _writeRPCDiagnostic(
+        "tool send-result begin pid=%u tool=%s returnCode=%d",
+        Process::getId(),
+        args.toolName.getBuffer(),
+        result.returnCode);
+    SlangResult sendResult = m_connection->sendResult(&result, id);
+    _writeTimingDiagnostic(
+        "tool send-result complete pid=%u tool=%s elapsedMs=%.3f result=0x%08x",
+        Process::getId(),
+        args.toolName.getBuffer(),
+        _getElapsedTimeInMs(sendStartTick),
+        uint32_t(sendResult));
+    _writeRPCDiagnostic(
+        "tool complete pid=%u tool=%s elapsedMs=%.3f result=0x%08x",
+        Process::getId(),
+        args.toolName.getBuffer(),
+        _getElapsedTimeInMs(totalStartTick),
+        uint32_t(sendResult));
+    return sendResult;
 }
 
 SlangResult TestServer::execute()


### PR DESCRIPTION
Summary:
- Restrict Windows Process::create handle inheritance to intended stdio handles.
- Add slang-test JSON RPC timeout diagnostics with elapsed time and test-server process state.
- Restore a narrow, env-gated slice of the reverted slang-test diagnostics for test-server RPC/timing traces.
- Temporarily loop the Windows debug RPC-heavy unit tests in PR CI with SLANG_TEST_DIAGNOSTICS=rpc,timing,timing-phases to increase reproduction odds.

Testing:
- git diff --check
- git diff --cached --check
- Parsed .github/workflows/ci-slang-test.yml with Ruby YAML loader

Note: the Windows stress loop and server diagnostics are intentionally temporary for this investigation.