### PR TITLE
ci: suppress `glslang_disassembleSPIRV` alloc-dealloc-mismatch in nightly sanitizer

### DIFF
--- a/cmake/expected-sanitizer-findings.txt
+++ b/cmake/expected-sanitizer-findings.txt
@@ -45,3 +45,12 @@ LEAK: _maybeBeginMacroInvocation
 Slang::List<Slang::TypeLayout::ResourceInfo, Slang::StandardAllocator>::begin()
 slang-reflection-api.cpp:1384
 slang-type-layout.h:772
+
+# #10988: alloc-dealloc-mismatch in glslang_disassembleSPIRV.
+# String allocated with `new char[len]` in
+# glslang_disassembleSPIRVWithResult is freed with scalar `delete` in
+# glslang_disassembleSPIRV. The buggy free is reachable only from the
+# SPIR-V validation-failure branch in slang-emit.cpp, so it stayed
+# dormant from 2025-09-30 (PR #8526) until 2026-04-29, when a newly
+# added test on master produced invalid SPIR-V and walked into it.
+in glslang_disassembleSPIRV


### PR DESCRIPTION
## Summary
- Add an entry to `cmake/expected-sanitizer-findings.txt` to suppress
  the AddressSanitizer `alloc-dealloc-mismatch` in
  `glslang_disassembleSPIRV` so the master nightly sanitizer is not
  blocked while the underlying bug is fixed.

## Motivation
The 2026-04-29 master nightly sanitizer failed with:

```
SUMMARY: AddressSanitizer: alloc-dealloc-mismatch
  source/slang-glslang/slang-glslang.cpp:247:5 in glslang_disassembleSPIRV
```

`new char[len]` at `source/slang-glslang/slang-glslang.cpp:223` is
freed with scalar `delete` at line 247. The mismatch was introduced in
#8526 (2025-09-30) but stayed dormant for ~7 months because the
buggy `delete` is only reachable from the SPIR-V validation-failure
branch in `source/slang/slang-emit.cpp:2939`. It was unmasked when the
2026-04-28 master commit (#10823) added new `-target spirv` tests, at
least one of which produces SPIR-V that fails validation.

Tracked in #10988. The fix and the unrelated SPIR-V codegen issue
unmasked here are out of scope for this PR — this change only unblocks
the nightly while those are addressed.

## Technical Details
The pattern `in glslang_disassembleSPIRV` is matched as a fixed
substring against the `SUMMARY:` line by the existing classifier in
`.github/workflows/ci-slang-sanitizer.yml`. The match deliberately
omits line numbers (the file's header comments call out that line
numbers are fragile) and intentionally also covers
`glslang_disassembleSPIRVWithResult`, which shares the same root cause.

The expected-findings file already produces a stale-pattern warning
when an entry stops matching, so once #10988 is fixed and this entry
is removed, the warning will fire if a regression silently brings the
finding back.

## Test Plan
- [ ] Re-run nightly sanitizer (`workflow_dispatch` on
  `ci-nightly-sanitizer.yml`) and confirm:
  - The `alloc-dealloc-mismatch` SUMMARY is now classified as
    "Expected" rather than "PR-related".
  - The job exits 0.
- [ ] Confirm the existing `LEAK:` and TypeLayout UAF entries continue
  to match (no new stale-pattern warnings introduced).