### PR TITLE
Fix SM6.10 outer product prelude for updated dx/linalg.h ComponentTypeTraits

### DIFF
--- a/source/slang/slang-emit-hlsl-prelude.cpp
+++ b/source/slang/slang-emit-hlsl-prelude.cpp
@@ -103,13 +103,12 @@ void __slang_linalg_OuterProductAccumulate(
 {
     using AccTy = dx::linalg::Matrix<
         MatDT,
-        MatM * dx::linalg::__detail::ComponentTypeTraits<ElTy>::ElementsPerScalar,
-        MatN * dx::linalg::__detail::ComponentTypeTraits<ElTy>::ElementsPerScalar,
+        MatM,
+        MatN,
         dx::linalg::MatrixUse::Accumulator,
         dx::linalg::MatrixScope::Thread>;
-    AccTy acc =
-        dx::linalg::OuterProduct<MatDT, dx::linalg::MatrixScope::Thread>(a, b);
-    acc.InterlockedAccumulate(matBuf, matOff, uint(sizeof(ElTy)));
+    AccTy acc = dx::linalg::OuterProduct<MatDT>(a, b);
+    acc.InterlockedAccumulate(matBuf, matOff);
 }
 
 template<typename ElTy, uint N, typename BufTy>

--- a/source/slang/slang-emit-hlsl-prelude.cpp
+++ b/source/slang/slang-emit-hlsl-prelude.cpp
@@ -79,10 +79,7 @@ vector<OutElTy, MatM> __slang_linalg_MulAdd(
     MatTy mat = MatTy::template Load<LoadLayout>(matBuf, matOff, matStr);
     using BiasVecTy = vector<BiasElTy, BiasVecDim>;
     BiasVecTy biasVec = biasBuf.template Load<BiasVecTy>(biasOff);
-    return dx::linalg::MultiplyAdd<OutElTy>(
-        mat,
-        dx::linalg::MakeInterpretedVector<InputDT>(input),
-        biasVec);
+    return dx::linalg::MultiplyAdd<OutElTy>(mat, input, biasVec);
 }
 
 template<

--- a/source/slang/slang-emit-hlsl-prelude.cpp
+++ b/source/slang/slang-emit-hlsl-prelude.cpp
@@ -46,9 +46,7 @@ vector<OutElTy, MatM> __slang_linalg_Mul(
         dx::linalg::MatrixUse::A,
         dx::linalg::MatrixScope::Thread>;
     MatTy mat = MatTy::template Load<LoadLayout>(matBuf, matOff, matStr);
-    return dx::linalg::Multiply<OutElTy>(
-        mat,
-        dx::linalg::MakeInterpretedVector<InputDT>(input));
+    return dx::linalg::Multiply<OutElTy>(mat, input);
 }
 
 template<

--- a/tests/cooperative-vector/matrix-mul-hlsl-codegen.slang
+++ b/tests/cooperative-vector/matrix-mul-hlsl-codegen.slang
@@ -9,6 +9,7 @@
 
 // CHECK610: dx::linalg::Multiply<
 // CHECK610: dx::linalg::MultiplyAdd<
+// CHECK610-NOT: MakeInterpretedVector
 
 RWStructuredBuffer<int32_t> outputBuffer;
 ByteAddressBuffer input;

--- a/tests/cooperative-vector/training-hlsl-codegen.slang
+++ b/tests/cooperative-vector/training-hlsl-codegen.slang
@@ -12,6 +12,9 @@
 // CHECK610-DAG: InterlockedAccumulate(
 // CHECK610-DAG: __slang_linalg_OuterProductAccumulate<
 // CHECK610-DAG: __slang_linalg_VectorAccumulate<
+// CHECK610-NOT: OuterProduct<MatDT, dx::linalg::MatrixScope::Thread>
+// CHECK610-NOT: InterlockedAccumulate(matBuf, matOff, uint(sizeof
+// CHECK610-NOT: ComponentTypeTraits<ElTy>
 
 RWByteAddressBuffer outerProductOutput;
 RWByteAddressBuffer reduceSumOutput;


### PR DESCRIPTION
The dx/linalg.h header changed ComponentTypeTraits to be templated on ComponentEnum instead of a C++ type, and OuterProduct no longer takes MatrixScope as a template parameter (hardcoded to Thread). Update the SM6.10 __slang_linalg_OuterProductAccumulate prelude accordingly:
- Use vector dimensions directly for AccTy instead of multiplying by ComponentTypeTraits<ElTy>::ElementsPerScalar
- Remove MatrixScope::Thread from OuterProduct explicit template args
- Drop the stride argument from InterlockedAccumulate (Thread-scope version hardcodes layout/stride internally)