### PR TITLE
ci: disable test server for CPU-only tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,9 +201,9 @@ jobs:
       test-category: full
       full-gpu-tests: false
       cpu-only: true
-      # GitHub-hosted ubuntu-24.04 has 4 vCPUs; match test-server count
-      # to avoid IPC timeouts / JSON RPC failures on compute (cpu) tests.
-      server-count: 4
+      # Keep the CPU-only tier off the persistent test-server while we
+      # investigate intermittent JSON RPC failures on GitHub-hosted runners.
+      server-count: 1
 
   # macOS tests
   test-macos-debug-clang-aarch64:


### PR DESCRIPTION
## Summary
- Set the CPU-only Linux CI tier to server-count: 1 so it runs without the persistent test-server path.
- Keep full cpu+llvm test coverage while avoiding the intermittent JSON-RPC server-lane failures seen after CPU testing was split out.

## Notes
- This is intended as a mitigation, not the root-cause fix.
- Follow-up diagnostics/stress work should continue to capture why the test-server lane sometimes dies on GitHub-hosted ubuntu-24.04.

## Validation
- git diff --check