### PR TITLE
Adjust slang-test RPC timeout

### DIFF
--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -21,12 +21,36 @@ static std::atomic<int> s_consecutiveFailures{0};
 
 TestContext::TestContext()
 {
-    /// if we are testing on arm, debug, we may want to increase the connection timeout
+    /// If we are testing on arm, debug, we may want to increase the connection timeout.
 #if (SLANG_PROCESSOR_ARM || SLANG_PROCESSOR_ARM_64) && defined(_DEBUG)
     // 10 mins(!). This seems to be the order of time needed for timeout on a CI ARM test system on
     // debug
     connectionTimeOutInMs = 1000 * 60 * 10;
+#elif SLANG_WINDOWS_FAMILY && defined(_DEBUG)
+    // Windows debug CI can spend more than two minutes in individual test-server requests.
+    connectionTimeOutInMs = 1000 * 60 * 5;
 #endif
+
+    StringBuilder rpcTimeoutEnvValue;
+    if (SLANG_SUCCEEDED(PlatformUtil::getEnvironmentVariable(
+            UnownedStringSlice::fromLiteral("SLANG_TEST_RPC_TIMEOUT_MS"),
+            rpcTimeoutEnvValue)))
+    {
+        Int rpcTimeoutInMs = 0;
+        if (SLANG_SUCCEEDED(
+                StringUtil::parseInt(rpcTimeoutEnvValue.getUnownedSlice(), rpcTimeoutInMs)) &&
+            rpcTimeoutInMs > 0)
+        {
+            connectionTimeOutInMs = rpcTimeoutInMs;
+        }
+        else
+        {
+            fprintf(
+                stderr,
+                "warning: ignoring invalid SLANG_TEST_RPC_TIMEOUT_MS value '%s'\n",
+                rpcTimeoutEnvValue.getBuffer());
+        }
+    }
 }
 
 void TestContext::setThreadIndex(int index)

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -18,6 +18,7 @@ thread_local int slangTestThreadIndex = 0;
 // When GPU driver crashes, all threads fail simultaneously so this triggers quickly.
 static constexpr int kConsecutiveFailureAbortThreshold = 32;
 static std::atomic<int> s_consecutiveFailures{0};
+static constexpr Int kMaxRPCConnectionTimeoutInMs = 24 * 60 * 60 * 1000;
 
 TestContext::TestContext()
 {
@@ -36,19 +37,21 @@ TestContext::TestContext()
             UnownedStringSlice::fromLiteral("SLANG_TEST_RPC_TIMEOUT_MS"),
             rpcTimeoutEnvValue)))
     {
-        Int rpcTimeoutInMs = 0;
+        Int64 rpcTimeoutInMs = 0;
         if (SLANG_SUCCEEDED(
-                StringUtil::parseInt(rpcTimeoutEnvValue.getUnownedSlice(), rpcTimeoutInMs)) &&
-            rpcTimeoutInMs > 0)
+                StringUtil::parseInt64(rpcTimeoutEnvValue.getUnownedSlice(), rpcTimeoutInMs)) &&
+            rpcTimeoutInMs > 0 && rpcTimeoutInMs <= kMaxRPCConnectionTimeoutInMs)
         {
-            connectionTimeOutInMs = rpcTimeoutInMs;
+            connectionTimeOutInMs = Int(rpcTimeoutInMs);
         }
         else
         {
-            fprintf(
-                stderr,
-                "warning: ignoring invalid SLANG_TEST_RPC_TIMEOUT_MS value '%s'\n",
-                rpcTimeoutEnvValue.getBuffer());
+            String maxTimeoutInMs = String(kMaxRPCConnectionTimeoutInMs);
+            StdWriters::getError().print(
+                "warning: ignoring invalid SLANG_TEST_RPC_TIMEOUT_MS value '%s' "
+                "(expected 1..%s milliseconds)\n",
+                rpcTimeoutEnvValue.getBuffer(),
+                maxTimeoutInMs.getBuffer());
         }
     }
 }

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -172,7 +172,8 @@ public:
     /// TODO(JS): We could split the core module compilation from other actions, and have timeout
     /// specific for that. To do this we could have a 'compileCoreModule' RPC method.
     ///
-    /// Current default is 120 seconds.
+    /// Current default is 120 seconds. Windows debug builds default to 300 seconds, and ARM debug
+    /// builds default to 600 seconds. SLANG_TEST_RPC_TIMEOUT_MS can override the default.
     Slang::Int connectionTimeOutInMs = 120 * 1000;
 
     void setThreadIndex(int index);

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -162,7 +162,7 @@ public:
     Slang::String dllDirectoryPath;
     Slang::String exePath;
 
-    /// Timeout time for communication over connection.
+    /// Timeout time for communication over connection, in milliseconds.
     /// NOTE! If the timeout is hit, the connection will be destroyed, and then recreated.
     /// To test it, compile the core module, if it takes too much time, the core module will be
     /// repeatedly compiled and each time fail.
@@ -173,7 +173,8 @@ public:
     /// specific for that. To do this we could have a 'compileCoreModule' RPC method.
     ///
     /// Current default is 120 seconds. Windows debug builds default to 300 seconds, and ARM debug
-    /// builds default to 600 seconds. SLANG_TEST_RPC_TIMEOUT_MS can override the default.
+    /// builds default to 600 seconds. SLANG_TEST_RPC_TIMEOUT_MS can override the default with a
+    /// value in milliseconds.
     Slang::Int connectionTimeOutInMs = 120 * 1000;
 
     void setThreadIndex(int index);

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -174,7 +174,7 @@ public:
     ///
     /// Current default is 120 seconds. Windows debug builds default to 300 seconds, and ARM debug
     /// builds default to 600 seconds. SLANG_TEST_RPC_TIMEOUT_MS can override the default with a
-    /// value in milliseconds.
+    /// value in the range 1..86400000 milliseconds.
     Slang::Int connectionTimeOutInMs = 120 * 1000;
 
     void setThreadIndex(int index);


### PR DESCRIPTION
This adds a runtime override for the slang-test JSON RPC wait timeout via SLANG_TEST_RPC_TIMEOUT_MS and raises the Windows debug default from 120s to 300s. ARM debug keeps the existing 600s timeout.\n\nThe Windows RPC diagnostics showed test-server requests entering the unit-test body and then exceeding the current 120s client wait, so this gives Windows debug CI more headroom while keeping a knob for follow-up experiments.