### PR TITLE
ci: harden Linux scaler startup

### DIFF
--- a/extras/scaler/deploy/scaler-linux.service
+++ b/extras/scaler/deploy/scaler-linux.service
@@ -18,7 +18,8 @@ ExecStart=/opt/scaler/scaler \
     --gcp-project=slang-runners \
     --gcp-zones=us-east1-c,us-east1-d,us-central1-a,us-west1-a \
     --gcp-instance-template=linux-gpu-runner \
-    --platform=linux
+    --platform=linux \
+    --session-max-age=2h
 
 EnvironmentFile=/opt/scaler/scaler.env
 

--- a/extras/scaler/internal/gcp/manager.go
+++ b/extras/scaler/internal/gcp/manager.go
@@ -578,8 +578,17 @@ func (m *Manager) listTerminatedVMNames(ctx context.Context, zone string) ([]str
 	return m.listVMNamesByFilter(ctx, zone, cleanupFilter(m.config.VMPrefix))
 }
 
-func prefixFilter(vmPrefix string) string {
-	return fmt.Sprintf("name=%s-*", vmPrefix)
+func liveFilter(vmPrefix string) string {
+	return fmt.Sprintf("name=%s-* AND (status=PROVISIONING OR status=STAGING OR status=RUNNING)", vmPrefix)
+}
+
+func isLiveStatus(status string) bool {
+	switch status {
+	case "PROVISIONING", "STAGING", "RUNNING":
+		return true
+	default:
+		return false
+	}
 }
 
 func (m *Manager) listLiveVMNames(ctx context.Context, zone string) ([]string, error) {
@@ -593,7 +602,7 @@ func (m *Manager) listLiveVMNames(ctx context.Context, zone string) ([]string, e
 	req := &computepb.ListInstancesRequest{
 		Project: m.config.Project,
 		Zone:    zone,
-		Filter:  proto.String(prefixFilter(m.config.VMPrefix)),
+		Filter:  proto.String(liveFilter(m.config.VMPrefix)),
 	}
 
 	it := m.instancesClient.List(ctx, req)
@@ -606,8 +615,7 @@ func (m *Manager) listLiveVMNames(ctx context.Context, zone string) ([]string, e
 		if err != nil {
 			return names, err
 		}
-		switch instance.GetStatus() {
-		case "PROVISIONING", "STAGING", "RUNNING":
+		if isLiveStatus(instance.GetStatus()) {
 			names = append(names, instance.GetName())
 		}
 	}

--- a/extras/scaler/internal/gcp/manager.go
+++ b/extras/scaler/internal/gcp/manager.go
@@ -688,10 +688,13 @@ func (m *Manager) reconcileTrackedVMs(ctx context.Context) {
 		return
 	}
 
-	// Snapshot tracked VMs grouped by zone
-	zoneVMs := make(map[string][]string) // zone -> []runnerName
+	// Snapshot tracked VMs grouped by zone. Eviction must only consider this
+	// snapshot; new VMs can be added while the GCP list calls are in flight.
+	zoneVMs := make(map[string]struct{})
+	snapshot := make(map[string]vmInfo, len(m.vms))
 	for runnerName, vm := range m.vms {
-		zoneVMs[vm.zone] = append(zoneVMs[vm.zone], runnerName)
+		snapshot[runnerName] = *vm
+		zoneVMs[vm.zone] = struct{}{}
 	}
 	m.mu.Unlock()
 
@@ -716,12 +719,19 @@ func (m *Manager) reconcileTrackedVMs(ctx context.Context) {
 	// Skip VMs in zones where the list call failed.
 	m.mu.Lock()
 	evicted := 0
-	for runnerName, vm := range m.vms {
-		if failedZones[vm.zone] {
+	for runnerName, snap := range snapshot {
+		current, ok := m.vms[runnerName]
+		if !ok {
 			continue
 		}
-		if !liveVMs[vm.vmName] {
-			slog.Info("reconcile: removing stale tracked VM", "runner", runnerName, "vm", vm.vmName, "zone", vm.zone)
+		if current.vmName != snap.vmName || current.zone != snap.zone {
+			continue
+		}
+		if failedZones[snap.zone] {
+			continue
+		}
+		if !liveVMs[snap.vmName] {
+			slog.Info("reconcile: removing stale tracked VM", "runner", runnerName, "vm", snap.vmName, "zone", snap.zone)
 			delete(m.vms, runnerName)
 			evicted++
 		}

--- a/extras/scaler/internal/gcp/manager.go
+++ b/extras/scaler/internal/gcp/manager.go
@@ -63,6 +63,7 @@ type Manager struct {
 	cancelCleanup   context.CancelFunc
 	cleanupPass     func(context.Context)
 	listTerminated  func(context.Context, string) ([]string, error)
+	listLive        func(context.Context, string) ([]string, error)
 	deleteVMFunc    func(context.Context, string, string) error
 	selectZonesFunc func(context.Context) ([]zoneCandidate, error)
 	insertVMFunc    func(context.Context, *computepb.InsertInstanceRequest) error
@@ -577,15 +578,40 @@ func (m *Manager) listTerminatedVMNames(ctx context.Context, zone string) ([]str
 	return m.listVMNamesByFilter(ctx, zone, cleanupFilter(m.config.VMPrefix))
 }
 
-func runningFilter(vmPrefix string) string {
-	return fmt.Sprintf("name=%s-* AND status=RUNNING", vmPrefix)
+func prefixFilter(vmPrefix string) string {
+	return fmt.Sprintf("name=%s-*", vmPrefix)
 }
 
-func (m *Manager) listRunningVMNames(ctx context.Context, zone string) ([]string, error) {
+func (m *Manager) listLiveVMNames(ctx context.Context, zone string) ([]string, error) {
+	if m.listLive != nil {
+		return m.listLive(ctx, zone)
+	}
 	if m.instancesClient == nil {
 		return nil, nil
 	}
-	return m.listVMNamesByFilter(ctx, zone, runningFilter(m.config.VMPrefix))
+
+	req := &computepb.ListInstancesRequest{
+		Project: m.config.Project,
+		Zone:    zone,
+		Filter:  proto.String(prefixFilter(m.config.VMPrefix)),
+	}
+
+	it := m.instancesClient.List(ctx, req)
+	var names []string
+	for {
+		instance, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return names, err
+		}
+		switch instance.GetStatus() {
+		case "PROVISIONING", "STAGING", "RUNNING":
+			names = append(names, instance.GetName())
+		}
+	}
+	return names, nil
 }
 
 func (m *Manager) deleteVMForCleanup(ctx context.Context, vmName, zone string) error {
@@ -633,18 +659,18 @@ func (m *Manager) doCleanupTerminatedVMs(ctx context.Context) {
 
 	slog.Info("terminated VM cleanup pass completed", "terminated_vms_deleted", deletedCount)
 
-	// Reconcile: remove tracked VMs that no longer exist as RUNNING instances.
+	// Reconcile: remove tracked VMs that no longer exist as live instances.
 	// This prevents ActiveCount() from drifting above reality, which would
 	// cause the scaler to stop creating new VMs.
 	m.reconcileTrackedVMs(ctx)
 }
 
 // reconcileTrackedVMs checks all tracked VMs against actual GCP instance state
-// and removes entries for VMs that are no longer RUNNING. This prevents the
-// in-memory tracker from drifting when VMs terminate outside the scaler's
-// control (e.g., via shutdown in the startup script).
+// and removes entries for VMs that are no longer live. Freshly created VMs can
+// remain in PROVISIONING or STAGING long enough for cleanup to run, so those
+// states must stay tracked just like RUNNING instances.
 func (m *Manager) reconcileTrackedVMs(ctx context.Context) {
-	if m.instancesClient == nil {
+	if m.instancesClient == nil && m.listLive == nil {
 		return // No GCP client (test mode), skip reconciliation
 	}
 
@@ -661,24 +687,24 @@ func (m *Manager) reconcileTrackedVMs(ctx context.Context) {
 	}
 	m.mu.Unlock()
 
-	// Collect all RUNNING VM names across zones
-	runningVMs := make(map[string]bool)
+	// Collect all live VM names across zones.
+	liveVMs := make(map[string]bool)
 	failedZones := make(map[string]bool)
 	for zone := range zoneVMs {
 		listCtx, cancel := context.WithTimeout(ctx, cleanupZoneScanTimeout)
-		names, err := m.listRunningVMNames(listCtx, zone)
+		names, err := m.listLiveVMNames(listCtx, zone)
 		cancel()
 		if err != nil {
-			slog.Warn("reconcile: failed to list running VMs", "zone", zone, "error", err)
+			slog.Warn("reconcile: failed to list live VMs", "zone", zone, "error", err)
 			failedZones[zone] = true
 			continue
 		}
 		for _, name := range names {
-			runningVMs[name] = true
+			liveVMs[name] = true
 		}
 	}
 
-	// Remove tracked entries whose VMs are no longer RUNNING.
+	// Remove tracked entries whose VMs are no longer live.
 	// Skip VMs in zones where the list call failed.
 	m.mu.Lock()
 	evicted := 0
@@ -686,7 +712,7 @@ func (m *Manager) reconcileTrackedVMs(ctx context.Context) {
 		if failedZones[vm.zone] {
 			continue
 		}
-		if !runningVMs[vm.vmName] {
+		if !liveVMs[vm.vmName] {
 			slog.Info("reconcile: removing stale tracked VM", "runner", runnerName, "vm", vm.vmName, "zone", vm.zone)
 			delete(m.vms, runnerName)
 			evicted++

--- a/extras/scaler/internal/gcp/manager.go
+++ b/extras/scaler/internal/gcp/manager.go
@@ -579,12 +579,12 @@ func (m *Manager) listTerminatedVMNames(ctx context.Context, zone string) ([]str
 }
 
 func liveFilter(vmPrefix string) string {
-	return fmt.Sprintf("name=%s-* AND (status=PROVISIONING OR status=STAGING OR status=RUNNING)", vmPrefix)
+	return fmt.Sprintf("name=%s-* AND (status=PROVISIONING OR status=STAGING OR status=RUNNING OR status=REPAIRING)", vmPrefix)
 }
 
 func isLiveStatus(status string) bool {
 	switch status {
-	case "PROVISIONING", "STAGING", "RUNNING":
+	case "PROVISIONING", "STAGING", "RUNNING", "REPAIRING":
 		return true
 	default:
 		return false

--- a/extras/scaler/internal/gcp/manager_test.go
+++ b/extras/scaler/internal/gcp/manager_test.go
@@ -19,6 +19,31 @@ func TestCleanupFilter(t *testing.T) {
 	}
 }
 
+func TestLiveFilter(t *testing.T) {
+	got := liveFilter("linux-test")
+	want := "name=linux-test-* AND (status=PROVISIONING OR status=STAGING OR status=RUNNING)"
+	if got != want {
+		t.Fatalf("liveFilter() = %q, want %q", got, want)
+	}
+}
+
+func TestIsLiveStatus(t *testing.T) {
+	tests := map[string]bool{
+		"PROVISIONING": true,
+		"STAGING":      true,
+		"RUNNING":      true,
+		"STOPPING":     false,
+		"TERMINATED":   false,
+		"":             false,
+	}
+
+	for status, want := range tests {
+		if got := isLiveStatus(status); got != want {
+			t.Fatalf("isLiveStatus(%q) = %v, want %v", status, got, want)
+		}
+	}
+}
+
 func TestRemoveTrackedVMByVMName(t *testing.T) {
 	m := &Manager{
 		vms: map[string]*vmInfo{

--- a/extras/scaler/internal/gcp/manager_test.go
+++ b/extras/scaler/internal/gcp/manager_test.go
@@ -283,6 +283,29 @@ func TestReconcileKeepsTrackedVMsWhenListFails(t *testing.T) {
 	}
 }
 
+func TestReconcileDoesNotEvictVMAddedAfterSnapshot(t *testing.T) {
+	m := &Manager{
+		vms: map[string]*vmInfo{
+			"runner-a": {vmName: "linux-test-a", zone: "us-east1-c"},
+		},
+	}
+	m.listLive = func(_ context.Context, _ string) ([]string, error) {
+		m.mu.Lock()
+		m.vms["runner-b"] = &vmInfo{vmName: "linux-test-b", zone: "us-east1-c"}
+		m.mu.Unlock()
+		return nil, nil
+	}
+
+	m.reconcileTrackedVMs(context.Background())
+
+	if _, ok := m.vms["runner-a"]; ok {
+		t.Fatalf("runner-a should be removed when snapshot VM is no longer live")
+	}
+	if _, ok := m.vms["runner-b"]; !ok {
+		t.Fatalf("runner-b should remain because it was added after the snapshot")
+	}
+}
+
 func TestSelectZoneErrorsOnEmptyCandidates(t *testing.T) {
 	m := &Manager{}
 	m.selectZonesFunc = func(context.Context) ([]zoneCandidate, error) {

--- a/extras/scaler/internal/gcp/manager_test.go
+++ b/extras/scaler/internal/gcp/manager_test.go
@@ -204,6 +204,60 @@ func TestDoCleanupTerminatedVMsDeletesPartialListResultsOnError(t *testing.T) {
 	}
 }
 
+func TestReconcileKeepsLiveTrackedVMs(t *testing.T) {
+	m := &Manager{
+		vms: map[string]*vmInfo{
+			"runner-a": {vmName: "linux-test-a", zone: "us-east1-c"},
+		},
+	}
+	m.listLive = func(_ context.Context, zone string) ([]string, error) {
+		if zone != "us-east1-c" {
+			t.Fatalf("zone = %q, want us-east1-c", zone)
+		}
+		return []string{"linux-test-a"}, nil
+	}
+
+	m.reconcileTrackedVMs(context.Background())
+
+	if _, ok := m.vms["runner-a"]; !ok {
+		t.Fatalf("runner-a should remain while VM is live")
+	}
+}
+
+func TestReconcileEvictsMissingTrackedVMs(t *testing.T) {
+	m := &Manager{
+		vms: map[string]*vmInfo{
+			"runner-a": {vmName: "linux-test-a", zone: "us-east1-c"},
+		},
+	}
+	m.listLive = func(_ context.Context, _ string) ([]string, error) {
+		return nil, nil
+	}
+
+	m.reconcileTrackedVMs(context.Background())
+
+	if _, ok := m.vms["runner-a"]; ok {
+		t.Fatalf("runner-a should be removed when VM is no longer live")
+	}
+}
+
+func TestReconcileKeepsTrackedVMsWhenListFails(t *testing.T) {
+	m := &Manager{
+		vms: map[string]*vmInfo{
+			"runner-a": {vmName: "linux-test-a", zone: "us-east1-c"},
+		},
+	}
+	m.listLive = func(_ context.Context, _ string) ([]string, error) {
+		return nil, errors.New("list failed")
+	}
+
+	m.reconcileTrackedVMs(context.Background())
+
+	if _, ok := m.vms["runner-a"]; !ok {
+		t.Fatalf("runner-a should remain when live VM listing fails")
+	}
+}
+
 func TestSelectZoneErrorsOnEmptyCandidates(t *testing.T) {
 	m := &Manager{}
 	m.selectZonesFunc = func(context.Context) ([]zoneCandidate, error) {

--- a/extras/scaler/internal/gcp/manager_test.go
+++ b/extras/scaler/internal/gcp/manager_test.go
@@ -21,7 +21,7 @@ func TestCleanupFilter(t *testing.T) {
 
 func TestLiveFilter(t *testing.T) {
 	got := liveFilter("linux-test")
-	want := "name=linux-test-* AND (status=PROVISIONING OR status=STAGING OR status=RUNNING)"
+	want := "name=linux-test-* AND (status=PROVISIONING OR status=STAGING OR status=RUNNING OR status=REPAIRING)"
 	if got != want {
 		t.Fatalf("liveFilter() = %q, want %q", got, want)
 	}
@@ -32,6 +32,7 @@ func TestIsLiveStatus(t *testing.T) {
 		"PROVISIONING": true,
 		"STAGING":      true,
 		"RUNNING":      true,
+		"REPAIRING":    true,
 		"STOPPING":     false,
 		"TERMINATED":   false,
 		"":             false,

--- a/extras/scaler/internal/gcp/startup.sh
+++ b/extras/scaler/internal/gcp/startup.sh
@@ -15,6 +15,7 @@
 set -euo pipefail
 
 RUNNER_VERSION="2.334.0"
+RUNNER_SHA256="048024cd2c848eb6f14d5646d56c13a4def2ae7ee3ad12122bee960c56f3d271"
 
 # Find the runner directory and its owner
 RUNNER_DIR=""
@@ -51,6 +52,15 @@ log "=== Linux GPU Runner Startup ==="
 log "Runner directory: $RUNNER_DIR"
 log "Runner user: $RUNNER_USER"
 
+fail_update_and_shutdown() {
+  log "ERROR: $1"
+  if [ -n "${runner_archive:-}" ]; then
+    rm -f "$runner_archive" || true
+  fi
+  shutdown -h now
+  exit 1
+}
+
 # Step 0: Remove any pre-existing runner service from the base image.
 log "Removing pre-existing runner service (if any)..."
 if systemctl list-units --type=service --all 2>/dev/null | grep -q "actions.runner"; then
@@ -84,22 +94,34 @@ log "Current Actions runner version: $current_runner_version"
 
 if [ "$current_runner_version" != "$RUNNER_VERSION" ]; then
   log "Updating Actions runner to v${RUNNER_VERSION}..."
-  runner_archive="$(mktemp /tmp/actions-runner.XXXXXX.tar.gz)"
+  if ! runner_archive="$(mktemp /tmp/actions-runner.XXXXXX.tar.gz)"; then
+    fail_update_and_shutdown "Failed to create temporary Actions runner archive"
+  fi
   runner_url="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
 
-  if curl -fsSL --retry 3 --connect-timeout 10 --max-time 120 "$runner_url" -o "$runner_archive"; then
-    chown "$RUNNER_USER":"$RUNNER_USER" "$runner_archive"
-    sudo -u "$RUNNER_USER" tar xzf "$runner_archive" -C "$RUNNER_DIR"
-    rm -f "$runner_archive"
-  else
-    log "ERROR: Failed to download Actions runner v${RUNNER_VERSION}"
-    rm -f "$runner_archive"
-    shutdown -h now
-    exit 1
+  if ! curl -fsSL --retry 3 --connect-timeout 10 --max-time 120 "$runner_url" -o "$runner_archive"; then
+    fail_update_and_shutdown "Failed to download Actions runner v${RUNNER_VERSION}"
   fi
+
+  if ! printf '%s  %s\n' "$RUNNER_SHA256" "$runner_archive" | sha256sum -c - >/dev/null 2>&1; then
+    fail_update_and_shutdown "Actions runner v${RUNNER_VERSION} checksum verification failed"
+  fi
+
+  if ! chown "$RUNNER_USER":"$RUNNER_USER" "$runner_archive"; then
+    fail_update_and_shutdown "Failed to change owner for Actions runner v${RUNNER_VERSION} archive"
+  fi
+
+  if ! sudo -u "$RUNNER_USER" tar xzf "$runner_archive" -C "$RUNNER_DIR"; then
+    fail_update_and_shutdown "Failed to extract Actions runner v${RUNNER_VERSION}"
+  fi
+  rm -f "$runner_archive" || true
+  runner_archive=""
 
   updated_runner_version="$(runner_version || true)"
   log "Actions runner version after update: ${updated_runner_version:-unknown}"
+  if [ "${updated_runner_version:-}" != "$RUNNER_VERSION" ]; then
+    fail_update_and_shutdown "Runner version mismatch after update (expected ${RUNNER_VERSION}, got ${updated_runner_version:-unknown})"
+  fi
 fi
 
 # Step 0.5: Ensure NVIDIA GPU devices are initialized.

--- a/extras/scaler/internal/gcp/startup.sh
+++ b/extras/scaler/internal/gcp/startup.sh
@@ -7,11 +7,14 @@
 #
 # Steps:
 # 1. Removes any pre-existing runner service from the base image
-# 2. Reads the JIT config from GCP instance metadata
-# 3. Starts the GitHub Actions runner as the correct user
-# 4. Shuts down the VM when the job completes
+# 2. Updates the preinstalled GitHub Actions runner if it is stale
+# 3. Reads the JIT config from GCP instance metadata
+# 4. Starts the GitHub Actions runner as the correct user
+# 5. Shuts down the VM when the job completes
 
 set -euo pipefail
+
+RUNNER_VERSION="2.334.0"
 
 # Find the runner directory and its owner
 RUNNER_DIR=""
@@ -66,6 +69,38 @@ for f in .runner .credentials .credentials_rsaparams .runner_migrated; do
     log "  Removed $f"
   fi
 done
+
+runner_version() {
+  if [ -x "$RUNNER_DIR/bin/Runner.Listener" ]; then
+    sudo -u "$RUNNER_USER" "$RUNNER_DIR/bin/Runner.Listener" --version 2>/dev/null | head -n 1 | tr -d '\r'
+  fi
+}
+
+current_runner_version="$(runner_version || true)"
+if [ -z "$current_runner_version" ]; then
+  current_runner_version="unknown"
+fi
+log "Current Actions runner version: $current_runner_version"
+
+if [ "$current_runner_version" != "$RUNNER_VERSION" ]; then
+  log "Updating Actions runner to v${RUNNER_VERSION}..."
+  runner_archive="$(mktemp /tmp/actions-runner.XXXXXX.tar.gz)"
+  runner_url="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+
+  if curl -fsSL --retry 3 --connect-timeout 10 --max-time 120 "$runner_url" -o "$runner_archive"; then
+    chown "$RUNNER_USER":"$RUNNER_USER" "$runner_archive"
+    sudo -u "$RUNNER_USER" tar xzf "$runner_archive" -C "$RUNNER_DIR"
+    rm -f "$runner_archive"
+  else
+    log "ERROR: Failed to download Actions runner v${RUNNER_VERSION}"
+    rm -f "$runner_archive"
+    shutdown -h now
+    exit 1
+  fi
+
+  updated_runner_version="$(runner_version || true)"
+  log "Actions runner version after update: ${updated_runner_version:-unknown}"
+fi
 
 # Step 0.5: Ensure NVIDIA GPU devices are initialized.
 # On fresh boot, the kernel module may not be loaded yet. Running nvidia-smi


### PR DESCRIPTION
## Summary
- keep PROVISIONING/STAGING runner VMs tracked during scaler reconciliation
- add session max age to the regular Linux scaler service
- update stale Linux Actions runners to v2.334.0 before JIT registration

## Live validation
- deployed the functional fix to gpu-scaler-host on 2026-04-29
- observed post-deploy Linux runners update from v2.331.0 to v2.334.0, connect to GitHub, and start jobs
- observed SM80Plus runners online and busy after the redeploy

## Tests
- bash -n extras/scaler/internal/gcp/startup.sh
- go test ./... -count=1
- GOOS=linux GOARCH=amd64 go build -o scaler-linux ./cmd/scaler