### PR TITLE
[WIP] Fix autodiff constexpr shader failures

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -5093,6 +5093,14 @@ bool SemanticsVisitor::doesSignatureMatchRequirement(
         auto requirementWitness = RequirementWitness(satisfyingMemberDeclRef);
         witnessTable->m_requirementDictionary[requiredMemberDeclRef.getDecl()] = requirementWitness;
 
+        List<Decl*> speculativeConstraintWitnesses;
+        for (auto constraintDeclRef :
+             getMembersOfType<GenericTypeConstraintDecl>(m_astBuilder, requiredMemberDeclRef))
+        {
+            if (!witnessTable->m_requirementDictionary.containsKey(constraintDeclRef.getDecl()))
+                speculativeConstraintWitnesses.add(constraintDeclRef.getDecl());
+        }
+
         // We need to check that the satisfying member has the same constraints as the requirement.
         auto satisfyingFuncAsType = DeclRefType::create(m_astBuilder, satisfyingMemberDeclRef);
         bool conformance = doesTypeSatisfyConstraintRequirements(
@@ -5103,6 +5111,8 @@ bool SemanticsVisitor::doesSignatureMatchRequirement(
         if (!conformance)
         {
             witnessTable->m_requirementDictionary.remove(requiredMemberDeclRef.getDecl());
+            for (auto constraintDecl : speculativeConstraintWitnesses)
+                witnessTable->m_requirementDictionary.remove(constraintDecl);
             return false;
         }
     }

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -5284,6 +5284,14 @@ bool SemanticsVisitor::doesSignatureMatchRequirement(
         auto requirementWitness = RequirementWitness(satisfyingMemberDeclRef);
         witnessTable->m_requirementDictionary[requiredMemberDeclRef.getDecl()] = requirementWitness;
 
+        List<Decl*> speculativeConstraintWitnesses;
+        for (auto constraintDeclRef :
+             getMembersOfType<GenericTypeConstraintDecl>(m_astBuilder, requiredMemberDeclRef))
+        {
+            if (!witnessTable->m_requirementDictionary.containsKey(constraintDeclRef.getDecl()))
+                speculativeConstraintWitnesses.add(constraintDeclRef.getDecl());
+        }
+
         // We need to check that the satisfying member has the same constraints as the requirement.
         bool conformance =
             doesTypeSatisfyConstraintRequirements(requiredMemberDeclRef, witnessTable);
@@ -5291,6 +5299,8 @@ bool SemanticsVisitor::doesSignatureMatchRequirement(
         if (!conformance)
         {
             witnessTable->m_requirementDictionary.remove(requiredMemberDeclRef.getDecl());
+            for (auto constraintDecl : speculativeConstraintWitnesses)
+                witnessTable->m_requirementDictionary.remove(constraintDecl);
             return false;
         }
     }

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -5284,6 +5284,12 @@ bool SemanticsVisitor::doesSignatureMatchRequirement(
         auto requirementWitness = RequirementWitness(satisfyingMemberDeclRef);
         witnessTable->m_requirementDictionary[requiredMemberDeclRef.getDecl()] = requirementWitness;
 
+        // doesTypeSatisfyConstraintRequirements adds witnesses for direct
+        // GenericTypeConstraintDecl children of requiredMemberDeclRef. Track the
+        // ones missing before the speculative check so a failed direct match does
+        // not leave partial constraint witnesses for a later synthesized wrapper.
+        // Existing entries are intentionally left alone; WitnessTable::add asserts
+        // rather than overwriting them.
         List<Decl*> speculativeConstraintWitnesses;
         for (auto constraintDeclRef :
              getMembersOfType<GenericTypeConstraintDecl>(m_astBuilder, requiredMemberDeclRef))

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -35,6 +35,7 @@
 #include "slang-ir-collect-global-uniforms.h"
 #include "slang-ir-com-interface.h"
 #include "slang-ir-composite-reg-to-mem.h"
+#include "slang-ir-constexpr.h"
 #include "slang-ir-cuda-immutable-load.h"
 #include "slang-ir-dce.h"
 #include "slang-ir-defer-buffer-load.h"
@@ -107,6 +108,7 @@
 #include "slang-ir-specialize-address-space.h"
 #include "slang-ir-specialize-arrays.h"
 #include "slang-ir-specialize-buffer-load-arg.h"
+#include "slang-ir-specialize-function-call.h"
 #include "slang-ir-specialize-matrix-layout.h"
 #include "slang-ir-specialize-resources.h"
 #include "slang-ir-specialize-stage-switch.h"
@@ -886,6 +888,44 @@ void removeWeakUseInsts(IRModule* module)
     }
 }
 
+static bool isLiteralConstExprArg(IRInst* arg)
+{
+    switch (arg->getOp())
+    {
+    case kIROp_BoolLit:
+    case kIROp_FloatLit:
+    case kIROp_IntLit:
+    case kIROp_PtrLit:
+    case kIROp_StringLit:
+    case kIROp_VoidLit:
+        return true;
+    default:
+        return false;
+    }
+}
+
+struct ConstExprFunctionCallSpecializeCondition : FunctionCallSpecializeCondition
+{
+    virtual bool doesParamWantSpecialization(IRParam* param, IRInst* arg, IRCall* callInst) override
+    {
+        SLANG_UNUSED(arg);
+        SLANG_UNUSED(callInst);
+        return isConstExprRateQualifiedType(param->getFullType());
+    }
+
+    virtual bool isParamSuitableForSpecialization(IRParam* param, IRInst* arg) override
+    {
+        SLANG_UNUSED(param);
+        return isLiteralConstExprArg(arg);
+    }
+};
+
+static bool specializeConstExprFunctionCalls(IRModule* module, CodeGenContext* codeGenContext)
+{
+    ConstExprFunctionCallSpecializeCondition condition;
+    return specializeFunctionCalls(codeGenContext, module, &condition);
+}
+
 Result linkAndOptimizeIR(
     CodeGenContext* codeGenContext,
     LinkingAndOptimizationOptions const& options,
@@ -1196,6 +1236,14 @@ Result linkAndOptimizeIR(
     }
 
     SLANG_PASS(finalizeAutoDiffPass, targetProgram);
+    SLANG_PASS(propagateConstExpr, sink);
+    if (sink->getErrorCount() != 0)
+        return SLANG_FAIL;
+
+    SLANG_PASS(specializeConstExprFunctionCalls, codeGenContext);
+    if (sink->getErrorCount() != 0)
+        return SLANG_FAIL;
+
     if (requiredLoweringPassSet.matrixSwizzleStore)
         SLANG_PASS(lowerMatrixSwizzleStores);
     SLANG_PASS(eliminateDeadCode, deadCodeEliminationOptions);

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -35,6 +35,8 @@
 #include "slang-ir-collect-global-uniforms.h"
 #include "slang-ir-com-interface.h"
 #include "slang-ir-coverage-instrument.h"
+#include "slang-ir-composite-reg-to-mem.h"
+#include "slang-ir-constexpr.h"
 #include "slang-ir-cuda-immutable-load.h"
 #include "slang-ir-dce.h"
 #include "slang-ir-defer-buffer-load.h"
@@ -107,6 +109,7 @@
 #include "slang-ir-specialize-address-space.h"
 #include "slang-ir-specialize-arrays.h"
 #include "slang-ir-specialize-buffer-load-arg.h"
+#include "slang-ir-specialize-function-call.h"
 #include "slang-ir-specialize-matrix-layout.h"
 #include "slang-ir-specialize-resources.h"
 #include "slang-ir-specialize-stage-switch.h"
@@ -892,6 +895,44 @@ void removeWeakUseInsts(IRModule* module)
     }
 }
 
+static bool isLiteralConstExprArg(IRInst* arg)
+{
+    switch (arg->getOp())
+    {
+    case kIROp_BoolLit:
+    case kIROp_FloatLit:
+    case kIROp_IntLit:
+    case kIROp_PtrLit:
+    case kIROp_StringLit:
+    case kIROp_VoidLit:
+        return true;
+    default:
+        return false;
+    }
+}
+
+struct ConstExprFunctionCallSpecializeCondition : FunctionCallSpecializeCondition
+{
+    virtual bool doesParamWantSpecialization(IRParam* param, IRInst* arg, IRCall* callInst) override
+    {
+        SLANG_UNUSED(arg);
+        SLANG_UNUSED(callInst);
+        return isConstExprRateQualifiedType(param->getFullType());
+    }
+
+    virtual bool isParamSuitableForSpecialization(IRParam* param, IRInst* arg) override
+    {
+        SLANG_UNUSED(param);
+        return isLiteralConstExprArg(arg);
+    }
+};
+
+static bool specializeConstExprFunctionCalls(IRModule* module, CodeGenContext* codeGenContext)
+{
+    ConstExprFunctionCallSpecializeCondition condition;
+    return specializeFunctionCalls(codeGenContext, module, &condition);
+}
+
 Result linkAndOptimizeIR(
     CodeGenContext* codeGenContext,
     LinkingAndOptimizationOptions const& options,
@@ -1323,6 +1364,14 @@ Result linkAndOptimizeIR(
     }
 
     SLANG_PASS(finalizeAutoDiffPass, targetProgram);
+    SLANG_PASS(propagateConstExpr, sink);
+    if (sink->getErrorCount() != 0)
+        return SLANG_FAIL;
+
+    SLANG_PASS(specializeConstExprFunctionCalls, codeGenContext);
+    if (sink->getErrorCount() != 0)
+        return SLANG_FAIL;
+
     if (requiredLoweringPassSet.matrixSwizzleStore)
         SLANG_PASS(lowerMatrixSwizzleStores);
     SLANG_PASS(eliminateDeadCode, deadCodeEliminationOptions);

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -35,7 +35,6 @@
 #include "slang-ir-collect-global-uniforms.h"
 #include "slang-ir-com-interface.h"
 #include "slang-ir-coverage-instrument.h"
-#include "slang-ir-composite-reg-to-mem.h"
 #include "slang-ir-constexpr.h"
 #include "slang-ir-cuda-immutable-load.h"
 #include "slang-ir-dce.h"

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -127,6 +127,7 @@
 #include "slang-ir-typeflow-specialize.h"
 #include "slang-ir-undo-param-copy.h"
 #include "slang-ir-uniformity.h"
+#include "slang-ir-util.h"
 #include "slang-ir-user-type-hint.h"
 #include "slang-ir-validate.h"
 #include "slang-ir-variable-scope-correction.h"
@@ -895,22 +896,6 @@ void removeWeakUseInsts(IRModule* module)
     }
 }
 
-static bool isLiteralConstExprArg(IRInst* arg)
-{
-    switch (arg->getOp())
-    {
-    case kIROp_BoolLit:
-    case kIROp_FloatLit:
-    case kIROp_IntLit:
-    case kIROp_PtrLit:
-    case kIROp_StringLit:
-    case kIROp_VoidLit:
-        return true;
-    default:
-        return false;
-    }
-}
-
 struct ConstExprFunctionCallSpecializeCondition : FunctionCallSpecializeCondition
 {
     virtual bool doesParamWantSpecialization(IRParam* param, IRInst* arg, IRCall* callInst) override
@@ -923,7 +908,7 @@ struct ConstExprFunctionCallSpecializeCondition : FunctionCallSpecializeConditio
     virtual bool isParamSuitableForSpecialization(IRParam* param, IRInst* arg) override
     {
         SLANG_UNUSED(param);
-        return isLiteralConstExprArg(arg);
+        return isLiteralValue(arg);
     }
 };
 

--- a/source/slang/slang-ir-autodiff-rev.cpp
+++ b/source/slang/slang-ir-autodiff-rev.cpp
@@ -273,10 +273,20 @@ struct BackwardDiffTranslationContext
 
         propagateParamTypes.add((IRType*)intermediateType);
 
+        ShortList<IRParam*, 8> targetFuncParams;
+        for (auto param = targetFunc->getFirstParam(); param; param = param->getNextParam())
+            targetFuncParams.add(param);
+
         for (UInt i = 0; i < targetFunc->getParamCount(); i++)
         {
-            const auto& [direction, paramType] =
-                splitParameterDirectionAndType(targetFunc->getParamType(i));
+            auto targetParamType = targetFunc->getParamType(i);
+            if (Index(i) < targetFuncParams.getCount() &&
+                isConstExprRateQualifiedType(targetFuncParams[i]->getFullType()))
+            {
+                targetParamType = targetFuncParams[i]->getFullType();
+            }
+
+            const auto& [direction, paramType] = splitParameterDirectionAndType(targetParamType);
             auto diffValueParamType = (IRType*)diffTypeContext.tryGetAssociationOfKind(
                 paramType,
                 AnnotationKind::DifferentialType);
@@ -286,6 +296,8 @@ struct BackwardDiffTranslationContext
                     builder,
                     transposeDirection(direction),
                     diffValueParamType));
+            else if (isConstExprRateQualifiedType(targetParamType))
+                propagateParamTypes.add(targetParamType);
             else
                 propagateParamTypes.add(builder->getVoidType());
         }
@@ -386,6 +398,17 @@ IRInst* maybeTranslateLegacyToNewBackwardDerivative(
 
     auto primalFuncType = cast<IRFuncType>(primalFunc->getDataType());
 
+    // Pull up a list of primal params, so we can use their original parameter
+    // modifiers for naming, location tagging, and constexpr propagation. The
+    // specialized function type can lose the rate qualification even though the
+    // resolved function parameter still carries it.
+    ShortList<IRParam*, 8> primalFuncParams;
+    auto funcForNames = as<IRFunc>(getResolvedInstForDecorations(primalFunc));
+    for (auto param : funcForNames->getParams())
+    {
+        primalFuncParams.add(param);
+    }
+
     List<IRInst*> applyForBwdFuncTypeParams;
     applyForBwdFuncTypeParams.add(primalFunc->getDataType());
     applyForBwdFuncTypeParams.add(minimalContextType);
@@ -407,6 +430,28 @@ IRInst* maybeTranslateLegacyToNewBackwardDerivative(
             kIROp_BwdCallableFuncType,
             bwdPropFuncTypeParams.getCount(),
             bwdPropFuncTypeParams.getBuffer())));
+
+    {
+        List<IRType*> bwdPropParamTypes;
+        bwdPropParamTypes.add(bwdPropFuncType->getParamType(0));
+        for (UIndex i = 0; i < applyForBwdFuncType->getParamCount(); i++)
+        {
+            auto bwdPropParamType = bwdPropFuncType->getParamType(i + 1);
+            if (Index(i) < primalFuncParams.getCount() &&
+                isConstExprRateQualifiedType(primalFuncParams[i]->getFullType()))
+            {
+                bwdPropParamType = primalFuncParams[i]->getFullType();
+            }
+            bwdPropParamTypes.add(bwdPropParamType);
+        }
+        for (UIndex i = applyForBwdFuncType->getParamCount() + 1;
+             i < bwdPropFuncType->getParamCount();
+             i++)
+        {
+            bwdPropParamTypes.add(bwdPropFuncType->getParamType(i));
+        }
+        bwdPropFuncType = builder.getFuncType(bwdPropParamTypes, builder.getVoidType());
+    }
 
     applyFunc->setFullType(applyForBwdFuncType);
     {
@@ -454,16 +499,6 @@ IRInst* maybeTranslateLegacyToNewBackwardDerivative(
 
     bwdPropFuncBuilder.setInsertBefore(placeholderCall);
 
-    // Pull up a list of primal params, so we can use them for naming &
-    // location tagging.
-    //
-    ShortList<IRParam*, 8> primalFuncParams;
-    auto funcForNames = as<IRFunc>(getResolvedInstForDecorations(primalFunc));
-    for (auto param : funcForNames->getParams())
-    {
-        primalFuncParams.add(param);
-    }
-
     // Jointly emit parameters for the apply and bwd prop functions, while
     // also building the context type.
     //
@@ -480,6 +515,12 @@ IRInst* maybeTranslateLegacyToNewBackwardDerivative(
             bwdPropFuncType->getParamType(idx + 1)); // +1 to skip the context param
         generateName(&builder, primalFuncParams[idx], bwdPropParam, "d_");
         bwdPropParam->sourceLoc = primalFuncParams[idx]->sourceLoc;
+
+        if (isConstExprRateQualifiedType(bwdPropParam->getFullType()))
+        {
+            bwdDiffFuncArgs.add(bwdPropParam);
+            continue;
+        }
 
         if (!as<IROutParamType>(applyForBwdParam->getDataType()))
         {
@@ -730,6 +771,16 @@ IRInst* maybeTranslateLegacyBackwardDerivative(
         auto applyParamType = applyBwdFuncType->getParamType(i);
         auto bwdPropParamType =
             bwdPropFuncType->getParamType(i + 1); // +1 to skip the context param
+
+        if (isConstExprRateQualifiedType(applyParamType) ||
+            isConstExprRateQualifiedType(bwdPropParamType))
+        {
+            applyBwdFuncArgs.add(bwdDiffFuncParams[bwdDiffParamIdx]);
+            rematFuncArgs.add(bwdDiffFuncParams[bwdDiffParamIdx]);
+            bwdPropFuncParams.add(bwdDiffFuncParams[bwdDiffParamIdx]);
+            bwdDiffParamIdx++;
+            continue;
+        }
 
         if (as<IRVoidType>(bwdPropParamType))
         {

--- a/source/slang/slang-ir-autodiff-rev.cpp
+++ b/source/slang/slang-ir-autodiff-rev.cpp
@@ -404,9 +404,12 @@ IRInst* maybeTranslateLegacyToNewBackwardDerivative(
     // resolved function parameter still carries it.
     ShortList<IRParam*, 8> primalFuncParams;
     auto funcForNames = as<IRFunc>(getResolvedInstForDecorations(primalFunc));
-    for (auto param : funcForNames->getParams())
+    if (funcForNames)
     {
-        primalFuncParams.add(param);
+        for (auto param : funcForNames->getParams())
+        {
+            primalFuncParams.add(param);
+        }
     }
 
     List<IRInst*> applyForBwdFuncTypeParams;

--- a/source/slang/slang-ir-autodiff-transpose.cpp
+++ b/source/slang/slang-ir-autodiff-transpose.cpp
@@ -1287,8 +1287,14 @@ struct DiffTransposePass
         // Transpose each argument (skip the first one, which is the context struct)
         for (UIndex ii = 1; ii < fwdCall->getArgCount(); ii++)
         {
-            const auto& [argDirection, argType] =
-                splitParameterDirectionAndType(fwdPropCalleeFuncType->getParamType(ii));
+            auto fwdPropParamType = fwdPropCalleeFuncType->getParamType(ii);
+            if (isConstExprRateQualifiedType(fwdPropParamType))
+            {
+                bwdPropArgs.add(fwdCall->getArg(ii));
+                continue;
+            }
+
+            const auto& [argDirection, argType] = splitParameterDirectionAndType(fwdPropParamType);
             if (as<IRVoidType>(argType))
             {
                 bwdPropArgs.add(builder->getVoidValue());

--- a/source/slang/slang-ir-autodiff-unzip.cpp
+++ b/source/slang/slang-ir-autodiff-unzip.cpp
@@ -402,31 +402,57 @@ struct UnzippingContext
         // func)
         //
 
-        List<IRInst*> propFuncArgs;
-        propFuncArgs.add(fullContextVal);
-        for (UIndex ii = 0; ii < mixedCall->getArgCount(); ii++)
-        {
-            auto arg = mixedCall->getArg(ii);
-            if (isMixedDifferentialInst(arg))
-                propFuncArgs.add(lookupDiffInst(arg));
-            else
-                propFuncArgs.add(diffBuilder->getVoidValue());
-        }
-
         // Build forward-prop func type. This is just the .Differential
         // of each param type & result type.
         //
         List<IRType*> fwdPropFuncParamTypes;
         auto baseFuncType = cast<IRFuncType>(baseFn->getFullType());
+        ShortList<IRParam*, 8> baseFuncParams;
+        if (auto baseFuncForParams =
+                as<IRGlobalValueWithParams>(getResolvedInstForDecorations(baseFn)))
+        {
+            for (auto param : baseFuncForParams->getParams())
+                baseFuncParams.add(param);
+        }
+
+        auto getBaseParamType = [&](UIndex ii) -> IRType*
+        {
+            auto paramType = baseFuncType->getParamType(ii);
+            if (Index(ii) < baseFuncParams.getCount() &&
+                isConstExprRateQualifiedType(baseFuncParams[ii]->getFullType()))
+            {
+                paramType = baseFuncParams[ii]->getFullType();
+            }
+            return paramType;
+        };
+
+        List<IRInst*> propFuncArgs;
+        propFuncArgs.add(fullContextVal);
+        for (UIndex ii = 0; ii < mixedCall->getArgCount(); ii++)
+        {
+            auto arg = mixedCall->getArg(ii);
+            auto paramType = getBaseParamType(ii);
+            if (isMixedDifferentialInst(arg))
+                propFuncArgs.add(lookupDiffInst(arg));
+            else if (isConstExprRateQualifiedType(paramType))
+                propFuncArgs.add(arg);
+            else
+                propFuncArgs.add(diffBuilder->getVoidValue());
+        }
+
         fwdPropFuncParamTypes.add(fullContextVal->getDataType());
         for (UIndex ii = 0; ii < baseFuncType->getParamCount(); ii++)
         {
-            const auto& [paramDirection, paramType] =
-                splitParameterDirectionAndType(baseFuncType->getParamType(ii));
+            auto baseParamType = getBaseParamType(ii);
+            const auto& [paramDirection, paramType] = splitParameterDirectionAndType(baseParamType);
             if (auto diffType = diffTypeContext.tryGetDifferentiableValueType(paramType))
             {
                 fwdPropFuncParamTypes.add(
                     fromDirectionAndType(diffBuilder, paramDirection, (IRType*)diffType));
+            }
+            else if (isConstExprRateQualifiedType(baseParamType))
+            {
+                fwdPropFuncParamTypes.add(baseParamType);
             }
             else
             {

--- a/source/slang/slang-ir-autodiff-unzip.cpp
+++ b/source/slang/slang-ir-autodiff-unzip.cpp
@@ -365,31 +365,57 @@ struct UnzippingContext
         // func)
         //
 
-        List<IRInst*> propFuncArgs;
-        propFuncArgs.add(fullContextVal);
-        for (UIndex ii = 0; ii < mixedCall->getArgCount(); ii++)
-        {
-            auto arg = mixedCall->getArg(ii);
-            if (isMixedDifferentialInst(arg))
-                propFuncArgs.add(lookupDiffInst(arg));
-            else
-                propFuncArgs.add(diffBuilder->getVoidValue());
-        }
-
         // Build forward-prop func type. This is just the .Differential
         // of each param type & result type.
         //
         List<IRType*> fwdPropFuncParamTypes;
         auto baseFuncType = cast<IRFuncType>(baseFn->getFullType());
+        ShortList<IRParam*, 8> baseFuncParams;
+        if (auto baseFuncForParams =
+                as<IRGlobalValueWithParams>(getResolvedInstForDecorations(baseFn)))
+        {
+            for (auto param : baseFuncForParams->getParams())
+                baseFuncParams.add(param);
+        }
+
+        auto getBaseParamType = [&](UIndex ii) -> IRType*
+        {
+            auto paramType = baseFuncType->getParamType(ii);
+            if (Index(ii) < baseFuncParams.getCount() &&
+                isConstExprRateQualifiedType(baseFuncParams[ii]->getFullType()))
+            {
+                paramType = baseFuncParams[ii]->getFullType();
+            }
+            return paramType;
+        };
+
+        List<IRInst*> propFuncArgs;
+        propFuncArgs.add(fullContextVal);
+        for (UIndex ii = 0; ii < mixedCall->getArgCount(); ii++)
+        {
+            auto arg = mixedCall->getArg(ii);
+            auto paramType = getBaseParamType(ii);
+            if (isMixedDifferentialInst(arg))
+                propFuncArgs.add(lookupDiffInst(arg));
+            else if (isConstExprRateQualifiedType(paramType))
+                propFuncArgs.add(arg);
+            else
+                propFuncArgs.add(diffBuilder->getVoidValue());
+        }
+
         fwdPropFuncParamTypes.add(fullContextVal->getDataType());
         for (UIndex ii = 0; ii < baseFuncType->getParamCount(); ii++)
         {
-            const auto& [paramDirection, paramType] =
-                splitParameterDirectionAndType(baseFuncType->getParamType(ii));
+            auto baseParamType = getBaseParamType(ii);
+            const auto& [paramDirection, paramType] = splitParameterDirectionAndType(baseParamType);
             if (auto diffType = diffTypeContext.tryGetDifferentiableValueType(paramType))
             {
                 fwdPropFuncParamTypes.add(
                     fromDirectionAndType(diffBuilder, paramDirection, (IRType*)diffType));
+            }
+            else if (isConstExprRateQualifiedType(baseParamType))
+            {
+                fwdPropFuncParamTypes.add(baseParamType);
             }
             else
             {

--- a/source/slang/slang-ir-autodiff.h
+++ b/source/slang/slang-ir-autodiff.h
@@ -36,6 +36,12 @@ struct DiffInstPair
 
 typedef DiffInstPair<IRInst*, IRInst*> InstPair;
 
+inline bool isConstExprRateQualifiedType(IRType* type)
+{
+    auto rateQualifiedType = as<IRRateQualifiedType>(type);
+    return rateQualifiedType && as<IRConstExprRate>(rateQualifiedType->getRate());
+}
+
 enum class DiffConformanceKind
 {
     Any = 0,  // Perform actions for any conformance (infer from context)
@@ -396,6 +402,10 @@ struct DifferentiableTypeConformanceContext
                             builder,
                             transposeDirection(paramDirection),
                             (IRType*)diffValueType));
+                    }
+                    else if (isConstExprRateQualifiedType(innerFnType->getParamType(i)))
+                    {
+                        paramTypes.add(innerFnType->getParamType(i));
                     }
                     else
                         paramTypes.add(builder->getVoidType());

--- a/source/slang/slang-ir-autodiff.h
+++ b/source/slang/slang-ir-autodiff.h
@@ -36,6 +36,12 @@ struct DiffInstPair
 
 typedef DiffInstPair<IRInst*, IRInst*> InstPair;
 
+inline bool isConstExprRateQualifiedType(IRType* type)
+{
+    auto rateQualifiedType = as<IRRateQualifiedType>(type);
+    return rateQualifiedType && as<IRConstExprRate>(rateQualifiedType->getRate());
+}
+
 enum class DiffConformanceKind
 {
     Any = 0,  // Perform actions for any conformance (infer from context)
@@ -400,6 +406,10 @@ struct DifferentiableTypeConformanceContext
                             builder,
                             transposeDirection(paramDirection),
                             (IRType*)diffValueType));
+                    }
+                    else if (isConstExprRateQualifiedType(innerFnType->getParamType(i)))
+                    {
+                        paramTypes.add(innerFnType->getParamType(i));
                     }
                     else
                         paramTypes.add(builder->getVoidType());

--- a/source/slang/slang-ir-specialize-function-call.cpp
+++ b/source/slang/slang-ir-specialize-function-call.cpp
@@ -10,6 +10,22 @@
 namespace Slang
 {
 
+static bool isLiteralSpecializationArg(IRInst* arg)
+{
+    switch (arg->getOp())
+    {
+    case kIROp_BoolLit:
+    case kIROp_FloatLit:
+    case kIROp_IntLit:
+    case kIROp_PtrLit:
+    case kIROp_StringLit:
+    case kIROp_VoidLit:
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool FunctionCallSpecializeCondition::isParamSuitableForSpecialization(
     IRParam* param,
     IRInst* inArg)
@@ -568,6 +584,10 @@ struct FunctionParameterSpecializationContext
             // Similarly for other global constants
             ioInfo.key.vals.add(globalConstant);
         }
+        else if (isLiteralSpecializationArg(oldArg))
+        {
+            ioInfo.key.vals.add(oldArg);
+        }
         else if (isUserPointerType(oldArg->getDataType()))
         {
             // If the arg is a user pointer, we can pass it as an ordinary argument,
@@ -843,6 +863,10 @@ struct FunctionParameterSpecializationContext
             // As above, the identity of the specialized function is sufficient
             // to resolve the uses
             return globalFunc;
+        }
+        if (isLiteralSpecializationArg(oldArg))
+        {
+            return oldArg;
         }
         else if (isElementAccessInst(oldArg))
         {

--- a/source/slang/slang-ir-specialize-function-call.cpp
+++ b/source/slang/slang-ir-specialize-function-call.cpp
@@ -10,6 +10,22 @@
 namespace Slang
 {
 
+static bool isLiteralSpecializationArg(IRInst* arg)
+{
+    switch (arg->getOp())
+    {
+    case kIROp_BoolLit:
+    case kIROp_FloatLit:
+    case kIROp_IntLit:
+    case kIROp_PtrLit:
+    case kIROp_StringLit:
+    case kIROp_VoidLit:
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool FunctionCallSpecializeCondition::isParamSuitableForSpecialization(
     IRParam* param,
     IRInst* inArg)
@@ -574,6 +590,10 @@ struct FunctionParameterSpecializationContext
             // Similarly for other global constants
             ioInfo.key.vals.add(globalConstant);
         }
+        else if (isLiteralSpecializationArg(oldArg))
+        {
+            ioInfo.key.vals.add(oldArg);
+        }
         else if (isUserPointerType(oldArg->getDataType()))
         {
             // If the arg is a user pointer, we can pass it as an ordinary argument,
@@ -859,6 +879,10 @@ struct FunctionParameterSpecializationContext
             // As above, the identity of the specialized function is sufficient
             // to resolve the uses
             return globalFunc;
+        }
+        if (isLiteralSpecializationArg(oldArg))
+        {
+            return oldArg;
         }
         else if (isElementAccessInst(oldArg))
         {

--- a/source/slang/slang-ir-specialize-function-call.cpp
+++ b/source/slang/slang-ir-specialize-function-call.cpp
@@ -10,22 +10,6 @@
 namespace Slang
 {
 
-static bool isLiteralSpecializationArg(IRInst* arg)
-{
-    switch (arg->getOp())
-    {
-    case kIROp_BoolLit:
-    case kIROp_FloatLit:
-    case kIROp_IntLit:
-    case kIROp_PtrLit:
-    case kIROp_StringLit:
-    case kIROp_VoidLit:
-        return true;
-    default:
-        return false;
-    }
-}
-
 bool FunctionCallSpecializeCondition::isParamSuitableForSpecialization(
     IRParam* param,
     IRInst* inArg)
@@ -590,7 +574,7 @@ struct FunctionParameterSpecializationContext
             // Similarly for other global constants
             ioInfo.key.vals.add(globalConstant);
         }
-        else if (isLiteralSpecializationArg(oldArg))
+        else if (isLiteralValue(oldArg))
         {
             ioInfo.key.vals.add(oldArg);
         }
@@ -880,7 +864,7 @@ struct FunctionParameterSpecializationContext
             // to resolve the uses
             return globalFunc;
         }
-        if (isLiteralSpecializationArg(oldArg))
+        if (isLiteralValue(oldArg))
         {
             return oldArg;
         }

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -1866,6 +1866,22 @@ bool isZero(IRInst* inst)
     }
 }
 
+bool isLiteralValue(IRInst* inst)
+{
+    switch (inst->getOp())
+    {
+    case kIROp_BoolLit:
+    case kIROp_FloatLit:
+    case kIROp_IntLit:
+    case kIROp_PtrLit:
+    case kIROp_StringLit:
+    case kIROp_VoidLit:
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool isOne(IRInst* inst)
 {
     switch (inst->getOp())

--- a/source/slang/slang-ir-util.h
+++ b/source/slang/slang-ir-util.h
@@ -337,6 +337,8 @@ bool isZero(IRInst* inst);
 
 bool isOne(IRInst* inst);
 
+bool isLiteralValue(IRInst* inst);
+
 // Casts inst to IRPtrTypeBase, excluding UserPointer address space.
 IRPtrTypeBase* asRelevantPtrType(IRInst* inst);
 

--- a/tests/autodiff/callable-constraint-witness-rollback.slang
+++ b/tests/autodiff/callable-constraint-witness-rollback.slang
@@ -1,0 +1,39 @@
+//TEST:COMPILE: -target hlsl -profile cs_6_0 -entry computeMain -no-codegen
+
+// A [BackwardDifferentiable] interface method adds callable constraints to
+// the requirement. A direct candidate with only a legacy backward derivative
+// can satisfy the backward constraint but not the forward constraint, so it
+// fails and conformance checking falls back to a synthesized wrapper.
+//
+// The failed direct candidate must not leave partial constraint witnesses in
+// the witness table, or the synthesized wrapper will try to add the same
+// backward constraint witness again.
+
+interface IModule<T : IDifferentiable>
+{
+    [BackwardDifferentiable]
+    T forward(T input);
+}
+
+struct InferenceModule : IModule<float>
+{
+    [BackwardDerivative(forward_bwd)]
+    float forward(float input)
+    {
+        return input;
+    }
+
+    void forward_bwd(inout DifferentialPair<float> input, float dOut)
+    {
+        updateDiff(input, dOut);
+    }
+}
+
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    InferenceModule module;
+    outputBuffer[dispatchThreadID.x] = module.forward(1.0);
+}

--- a/tests/autodiff/callable-constraint-witness-rollback.slang
+++ b/tests/autodiff/callable-constraint-witness-rollback.slang
@@ -1,4 +1,5 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHK): -vk -shaderobj -output-using-type
+//TEST:COMPILE: -target hlsl -profile cs_6_0 -entry computeMain -no-codegen
 
 // A [BackwardDifferentiable] interface method adds callable constraints to
 // the requirement. A direct candidate with only a legacy backward derivative

--- a/tests/autodiff/constexpr-param-bwd-propagate.slang
+++ b/tests/autodiff/constexpr-param-bwd-propagate.slang
@@ -1,0 +1,34 @@
+//TEST:COMPILE: -target hlsl -profile cs_6_0 -entry computeMain -no-codegen
+
+// Regression for constexpr parameters used by generated backward-propagation wrappers.
+// The generated bwd-prop call must preserve the literal Mode argument instead of
+// replacing it with void for being nondifferentiable.
+
+[BackwardDerivative(scale_bwd)]
+float scale(float x, constexpr int mode)
+{
+    static_assert(mode == 2, "mode must remain constexpr");
+    return x * float(mode);
+}
+
+void scale_bwd(inout DifferentialPair<float> x, constexpr int mode, float dOut)
+{
+    static_assert(mode == 2, "mode must remain constexpr");
+    updateDiff(x, dOut * float(mode));
+}
+
+[Differentiable]
+float run<let Mode : int>(float x)
+{
+    return scale(x, Mode);
+}
+
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    var x = diffPair(3.0);
+    __bwd_diff(run<2>)(x, 1.0);
+    outputBuffer[dispatchThreadID.x] = x.d;
+}

--- a/tests/autodiff/constexpr-param-bwd-propagate.slang
+++ b/tests/autodiff/constexpr-param-bwd-propagate.slang
@@ -1,4 +1,8 @@
 //TEST:COMPILE: -target hlsl -profile cs_6_0 -entry computeMain -no-codegen
+//TEST:COMPILE: -target spirv -profile cs_6_0 -entry computeMain -no-codegen
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -shaderobj -output-using-type
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0], stride=4)
 
 // Regression for constexpr parameters used by generated backward-propagation wrappers.
 // The generated bwd-prop call must preserve the literal Mode argument instead of
@@ -23,12 +27,24 @@ float run<let Mode : int>(float x)
     return scale(x, Mode);
 }
 
+[ForwardDifferentiable]
+float scaleForward(float x, constexpr int mode)
+{
+    static_assert(mode == 3, "mode must remain constexpr");
+    return x * float(mode);
+}
+
 RWStructuredBuffer<float> outputBuffer;
 
 [numthreads(1, 1, 1)]
-void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+void computeMain()
 {
     var x = diffPair(3.0);
     __bwd_diff(run<2>)(x, 1.0);
-    outputBuffer[dispatchThreadID.x] = x.d;
+    outputBuffer[0] = x.d;
+    // CHECK: 2.0
+
+    var y = __fwd_diff(scaleForward)(diffPair(4.0, 1.0), 3);
+    outputBuffer[1] = y.d;
+    // CHECK: 3.0
 }


### PR DESCRIPTION
Preserve constexpr parameters through reverse autodiff wrappers and specialize post-autodiff literal constexpr calls before shader validation.

Roll back failed speculative constraint witnesses for duplicate synthesized requirements and add regression tests for both failures, including runtime backward/forward constexpr coverage and SPIR-V compile coverage.