### PR TITLE
Fix SPIR-V layout-sensitive type memoization

### DIFF
--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -4451,6 +4451,10 @@ __generic<T : __BuiltinType>
     }
 }
 
+// Typed pointer to an image texel used by image atomic spirv_asm snippets.
+internal typealias __ImagePtr<T> =
+    Ptr<T, Access::ReadWrite, (AddressSpace)$((uint64_t)AddressSpace::Image)>;
+
 ${
 {
     struct ImageTypeInfo
@@ -4667,8 +4671,7 @@ $}
                 return spirv_asm
                 {
                     OpCapability ImageQuery;
-                    %ptrType = OpTypePointer Image $$$(targetType.type);
-                    %ptr:%ptrType = OpImageTexelPointer $imageP $P $sample;
+                    %ptr:$$__ImagePtr<$(targetType.type)> = OpImageTexelPointer $imageP $P $sample;
                     result:$$$(targetType.type) = OpAtomic$(targetType.SPVTypePrefix)Add$(targetType.SPVAtomicSuffix) %ptr Device None $data
                 };
             }
@@ -4690,8 +4693,7 @@ $}
                 return spirv_asm
                 {
                     OpCapability ImageQuery;
-                    %ptrType = OpTypePointer Image $$$(targetType.type);
-                    %ptr:%ptrType = OpImageTexelPointer $imageP $P $sample;
+                    %ptr:$$__ImagePtr<$(targetType.type)> = OpImageTexelPointer $imageP $P $sample;
                     result:$$$(targetType.type) = OpAtomicExchange %ptr Device Relaxed $data
                 };
             }
@@ -4713,8 +4715,7 @@ $}
                 return spirv_asm
                 {
                     OpCapability ImageQuery;
-                    %ptrType = OpTypePointer Image $$$(targetType.type);
-                    %ptr:%ptrType = OpImageTexelPointer $imageP $P $sample;
+                    %ptr:$$__ImagePtr<$(targetType.type)> = OpImageTexelPointer $imageP $P $sample;
                     result:$$$(targetType.type) = OpAtomic$(targetType.SPVSubTypePrefix)Min$(targetType.SPVAtomicSuffix) %ptr Device Relaxed $data
                 };
             }
@@ -4736,8 +4737,7 @@ $}
                 return spirv_asm
                 {
                     OpCapability ImageQuery;
-                    %ptrType = OpTypePointer Image $$$(targetType.type);
-                    %ptr:%ptrType = OpImageTexelPointer $imageP $P $sample;
+                    %ptr:$$__ImagePtr<$(targetType.type)> = OpImageTexelPointer $imageP $P $sample;
                     result:$$$(targetType.type) = OpAtomic$(targetType.SPVSubTypePrefix)Max$(targetType.SPVAtomicSuffix) %ptr Device Relaxed $data
                 };
             }
@@ -4762,8 +4762,7 @@ $}
                 return spirv_asm
                 {
                     OpCapability ImageQuery;
-                    %ptrType = OpTypePointer Image $$$(targetType.type);
-                    %ptr:%ptrType = OpImageTexelPointer $imageP $P $sample;
+                    %ptr:$$__ImagePtr<$(targetType.type)> = OpImageTexelPointer $imageP $P $sample;
                     result:$$$(targetType.type) = OpAtomicAnd %ptr Device Relaxed $data
                 };
             }
@@ -4784,8 +4783,7 @@ $}
                 return spirv_asm
                 {
                     OpCapability ImageQuery;
-                    %ptrType = OpTypePointer Image $$$(targetType.type);
-                    %ptr:%ptrType = OpImageTexelPointer $imageP $P $sample;
+                    %ptr:$$__ImagePtr<$(targetType.type)> = OpImageTexelPointer $imageP $P $sample;
                     result:$$$(targetType.type) = OpAtomicOr %ptr Device Relaxed $data
                 };
             }
@@ -4807,8 +4805,7 @@ $}
                 return spirv_asm
                 {
                     OpCapability ImageQuery;
-                    %ptrType = OpTypePointer Image $$$(targetType.type);
-                    %ptr:%ptrType = OpImageTexelPointer $imageP $P $sample;
+                    %ptr:$$__ImagePtr<$(targetType.type)> = OpImageTexelPointer $imageP $P $sample;
                     result:$$$(targetType.type) = OpAtomicXor %ptr Device Relaxed $data
                 };
             }
@@ -4829,8 +4826,7 @@ $}
                 return spirv_asm
                 {
                     OpCapability ImageQuery;
-                    %ptrType = OpTypePointer Image $$$(targetType.type);
-                    %ptr:%ptrType = OpImageTexelPointer $imageP $P $sample;
+                    %ptr:$$__ImagePtr<$(targetType.type)> = OpImageTexelPointer $imageP $P $sample;
                     result:$$$(targetType.type) = OpAtomicCompareExchange %ptr Device Relaxed Relaxed $data $compare
                 };
             }

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -5752,12 +5752,20 @@ __intrinsic_op($(kIROp_GetUntypedBufferPtr))
 Ptr<uint[]> __getByteAddressBufferPtr(RWByteAddressBuffer buffer);
 
 __intrinsic_op($(kIROp_GetStructuredBufferPtr))
-[require(cpp_cuda, structuredbuffer)]
+[require(cpp_cuda_spirv, structuredbuffer)]
 LayoutPtr<T[], L> __getStructuredBufferPtr<T, L:IBufferDataLayout>(StructuredBuffer<T, L> buffer);
 
 __intrinsic_op($(kIROp_GetStructuredBufferPtr))
-[require(cpp_cuda, structuredbuffer)]
+[require(cpp_cuda_spirv, structuredbuffer)]
 LayoutPtr<T[], L> __getStructuredBufferPtr<T, L:IBufferDataLayout>(RWStructuredBuffer<T, L> buffer);
+
+__intrinsic_op($(kIROp_RWStructuredBufferGetElementPtr))
+[require(spirv, structuredbuffer)]
+LayoutPtr<T, L> __getStructuredBufferElementPtr<T, L:IBufferDataLayout>(StructuredBuffer<T, L> buffer, uint element);
+
+__intrinsic_op($(kIROp_RWStructuredBufferGetElementPtr))
+[require(spirv, structuredbuffer)]
+LayoutPtr<T, L> __getStructuredBufferElementPtr<T, L:IBufferDataLayout>(RWStructuredBuffer<T, L> buffer, uint element);
 
 /**
 Represents an opaque handle to a read-only structured buffer allocated in global memory.
@@ -20768,8 +20776,7 @@ float3 HitTriangleVertexPosition(uint index)
                 OpCapability RayTracingPositionFetchKHR;
                 OpExtension "SPV_KHR_ray_tracing";
                 OpExtension "SPV_KHR_ray_tracing_position_fetch";
-                %_ptr_Input_v3float = OpTypePointer Input $$float3;
-                %addr : %_ptr_Input_v3float = OpAccessChain builtin(HitTriangleVertexPositionsKHR:float3[3]) $index;
+                %addr : $$Ptr<float3, Access::Read, AddressSpace::VaryingInput> = OpAccessChain builtin(HitTriangleVertexPositionsKHR:float3[3]) $index;
                 result:$$float3 = OpLoad %addr;
             };
     }
@@ -28009,27 +28016,27 @@ struct CoopMat
     ///        or multiple of 4 for float element type. (i.e., multiple of 16 bytes in both cases)
     [require(cuda_metal_spirv, cooperative_matrix)]
     void Store<
-        let matrixLayout : CoopMatMatrixLayout
-    >(RWStructuredBuffer<T> buffer, uint element, uint stride)
+        let matrixLayout : CoopMatMatrixLayout,
+        L : IBufferDataLayout = DefaultDataLayout
+    >(RWStructuredBuffer<T, L> buffer, uint element, uint stride)
     {
         __store<matrixLayout>(buffer, element, stride);
     }
 
     [require(cuda_metal_spirv, cooperative_matrix)]
-    internal void __store<
-        let matrixLayout : CoopMatMatrixLayout
-    >(RWStructuredBuffer<T> buffer, uint element, uint stride)
+    void __store<
+        let matrixLayout : CoopMatMatrixLayout,
+        L : IBufferDataLayout
+    >(RWStructuredBuffer<T, L> buffer, uint element, uint stride)
     {
-        let zero = 0;
-        let alignment = 16U;
         __target_switch
         {
         case spirv:
+            let pointer = __getStructuredBufferElementPtr<T, L>(buffer, element);
+            let alignment = 16U;
             spirv_asm
             {
-                %storagePointerType = OpTypePointer StorageBuffer $$T;
-                %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
-                OpCooperativeMatrixStoreKHR %pointer $this $matrixLayout $stride Aligned !alignment;
+                OpCooperativeMatrixStoreKHR $pointer $this $matrixLayout $stride Aligned !alignment;
             };
         case cuda:
             if (matrixLayout == CoopMatMatrixLayout.RowMajor)
@@ -28115,12 +28122,11 @@ struct CoopMat
         __target_switch
         {
         case spirv:
+            let pointer = __getAddress(data[element]);
             let alignment = 16U;
             spirv_asm
             {
-                %workgroupPointerType = OpTypePointer Workgroup $$T;
-                %pointer:%workgroupPointerType = OpAccessChain &data $element;
-                OpCooperativeMatrixStoreKHR %pointer $this $matrixLayout $stride Aligned !alignment;
+                OpCooperativeMatrixStoreKHR $pointer $this $matrixLayout $stride Aligned !alignment;
             };
         case cuda:
             if (matrixLayout == CoopMatMatrixLayout.RowMajor)
@@ -28180,12 +28186,11 @@ struct CoopMat
         __target_switch
         {
         case spirv:
+            let pointer = __getAddress(data[element]);
             let alignment = 16U;
             spirv_asm
             {
-                %workgroupPointerType = OpTypePointer Workgroup $$U;
-                %pointer:%workgroupPointerType = OpAccessChain &data $element;
-                OpCooperativeMatrixStoreKHR %pointer $this $matrixLayout $stride Aligned !alignment;
+                OpCooperativeMatrixStoreKHR $pointer $this $matrixLayout $stride Aligned !alignment;
             };
         case cuda:
             if (matrixLayout == CoopMatMatrixLayout.RowMajor)
@@ -28247,11 +28252,10 @@ struct CoopMat
     >(__ref groupshared vector<U, L>[V] data, uint element, uint stride)
     {
         let alignment = 16U;
+        let pointer = __getAddress(data[element]);
         spirv_asm
         {
-            %workgroupPointerType = OpTypePointer Workgroup $$vector<U, L>;
-            %pointer:%workgroupPointerType = OpAccessChain &data $element;
-            OpCooperativeMatrixStoreKHR %pointer $this $matrixLayout $stride Aligned !alignment;
+            OpCooperativeMatrixStoreKHR $pointer $this $matrixLayout $stride Aligned !alignment;
         };
     }
 
@@ -28289,22 +28293,21 @@ $}
     [__NoSideEffect]
     [require(cuda_metal_spirv, cooperative_matrix)]
     static This Load<
-        let matrixLayout : CoopMatMatrixLayout
+        let matrixLayout : CoopMatMatrixLayout,
+        L : IBufferDataLayout = DefaultDataLayout
     >(
-        $(RW)StructuredBuffer<T> buffer,
+        $(RW)StructuredBuffer<T, L> buffer,
         uint element,
         uint stride)
     {
-        let zero = 0;
         let alignment = 16U;
         __target_switch
         {
         case spirv:
+            let pointer = __getStructuredBufferElementPtr<T, L>(buffer, element);
             return spirv_asm
             {
-                %storagePointerType = OpTypePointer StorageBuffer $$T;
-                %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
-                result:$$CoopMat<T, S, M, N, R> = OpCooperativeMatrixLoadKHR %pointer $matrixLayout $stride Aligned !alignment;
+                result:$$CoopMat<T, S, M, N, R> = OpCooperativeMatrixLoadKHR $pointer $matrixLayout $stride Aligned !alignment;
             };
         case cuda:
             if (matrixLayout == CoopMatMatrixLayout.RowMajor)
@@ -28401,12 +28404,11 @@ $}
         __target_switch
         {
         case spirv:
+            let pointer = __getAddress(data[element]);
             let alignment = 16U;
             return spirv_asm
             {
-                %workgroupPointerType = OpTypePointer Workgroup $$T;
-                %pointer:%workgroupPointerType = OpAccessChain &data $element;
-                result:$$CoopMat<T, S, M, N, R> = OpCooperativeMatrixLoadKHR %pointer $matrixLayout $stride Aligned !alignment;
+                result:$$CoopMat<T, S, M, N, R> = OpCooperativeMatrixLoadKHR $pointer $matrixLayout $stride Aligned !alignment;
             };
         case cuda:
             if (matrixLayout == CoopMatMatrixLayout.RowMajor)
@@ -28467,12 +28469,11 @@ $}
         __target_switch
         {
         case spirv:
+            let pointer = __getAddress(data[element]);
             let alignment = 16U;
             return spirv_asm
             {
-                %workgroupPointerType = OpTypePointer Workgroup $$U;
-                %pointer:%workgroupPointerType = OpAccessChain &data $element;
-                result:$$CoopMat<T, S, M, N, R> = OpCooperativeMatrixLoadKHR %pointer $matrixLayout $stride Aligned !alignment;
+                result:$$CoopMat<T, S, M, N, R> = OpCooperativeMatrixLoadKHR $pointer $matrixLayout $stride Aligned !alignment;
             };
         case cuda:
             if (matrixLayout == CoopMatMatrixLayout.RowMajor)
@@ -28535,11 +28536,10 @@ $}
     >(__constref groupshared vector<U, L>[V] data, uint element, uint stride)
     {
         let alignment = 16U;
+        let pointer = __getAddress(data[element]);
         return spirv_asm
         {
-            %workgroupPointerType = OpTypePointer Workgroup $$vector<U, L>;
-            %pointer:%workgroupPointerType = OpAccessChain &data $element;
-            result:$$CoopMat<T, S, M, N, R> = OpCooperativeMatrixLoadKHR %pointer $matrixLayout $stride Aligned !alignment;
+            result:$$CoopMat<T, S, M, N, R> = OpCooperativeMatrixLoadKHR $pointer $matrixLayout $stride Aligned !alignment;
         };
     }
 
@@ -28690,9 +28690,10 @@ $}
     [require(cooperative_matrix_tensor_addressing)]
     static This Load<
         let Dim : uint32_t,
-        let ClampMode : CoopMatClampMode
+        let ClampMode : CoopMatClampMode,
+        L : IBufferDataLayout = DefaultDataLayout
     >(
-        $(RW)StructuredBuffer<T> buffer,
+        $(RW)StructuredBuffer<T, L> buffer,
         uint element,
         TensorLayout<Dim, ClampMode> tensorLayout)
     {
@@ -28702,14 +28703,15 @@ $}
     [require(cooperative_matrix_tensor_addressing)]
     static This __loadLayout<
         let Dim : uint32_t,
-        let ClampMode : CoopMatClampMode
+        let ClampMode : CoopMatClampMode,
+        L : IBufferDataLayout
     >(
-        $(RW)StructuredBuffer<T> buffer,
+        $(RW)StructuredBuffer<T, L> buffer,
         uint element,
         TensorLayout<Dim, ClampMode> tensorLayout)
     {
-        let zero = 0;
         let alignment = 16U;
+        let pointer = __getStructuredBufferElementPtr<T, L>(buffer, element);
 
         // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
         This ret;
@@ -28717,9 +28719,7 @@ $}
         {
             OpCapability CooperativeMatrixTensorAddressingNV;
             OpExtension "SPV_NV_cooperative_matrix2";
-            %storagePointerType = OpTypePointer StorageBuffer $$T;
-            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
-            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment None;
+            result:$$This = OpCooperativeMatrixLoadTensorNV $pointer $ret $tensorLayout Aligned !alignment None;
         };
     }
 
@@ -28745,9 +28745,10 @@ $}
         let ClampMode : CoopMatClampMode,
         let DimView : uint32_t,
         let HasDimensions : bool
-        $(tensorViewTypes)
+        $(tensorViewTypes),
+        L : IBufferDataLayout = DefaultDataLayout
     >(
-        $(RW)StructuredBuffer<T> buffer,
+        $(RW)StructuredBuffer<T, L> buffer,
         uint element,
         TensorLayout<Dim, ClampMode> tensorLayout,
         TensorView<DimView, HasDimensions $(tensorViewParams) > tensorView)
@@ -28761,15 +28762,16 @@ $}
         let ClampMode : CoopMatClampMode,
         let DimView : uint32_t,
         let HasDimensions : bool
-        $(tensorViewTypes)
+        $(tensorViewTypes),
+        L : IBufferDataLayout
     >(
-        $(RW)StructuredBuffer<T> buffer,
+        $(RW)StructuredBuffer<T, L> buffer,
         uint element,
         TensorLayout<Dim, ClampMode> tensorLayout,
         TensorView<DimView, HasDimensions $(tensorViewParams) > tensorView)
     {
-        let zero = 0;
         let alignment = 16U;
+        let pointer = __getStructuredBufferElementPtr<T, L>(buffer, element);
 
         // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
         This ret;
@@ -28777,9 +28779,7 @@ $}
         {
             OpCapability CooperativeMatrixTensorAddressingNV;
             OpExtension "SPV_NV_cooperative_matrix2";
-            %storagePointerType = OpTypePointer StorageBuffer $$T;
-            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
-            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment TensorView $tensorView;
+            result:$$This = OpCooperativeMatrixLoadTensorNV $pointer $ret $tensorLayout Aligned !alignment TensorView $tensorView;
         };
     }
 
@@ -28801,9 +28801,10 @@ $}
     static This Load<
         U,
         let Dim : uint32_t,
-        let ClampMode : CoopMatClampMode
+        let ClampMode : CoopMatClampMode,
+        L : IBufferDataLayout = DefaultDataLayout
     >(
-        $(RW)StructuredBuffer<T> buffer,
+        $(RW)StructuredBuffer<T, L> buffer,
         uint element,
         TensorLayout<Dim, ClampMode> tensorLayout,
         functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
@@ -28815,15 +28816,16 @@ $}
     static This __loadLayoutDecode<
         U,
         let Dim : uint32_t,
-        let ClampMode : CoopMatClampMode
+        let ClampMode : CoopMatClampMode,
+        L : IBufferDataLayout
     >(
-        $(RW)StructuredBuffer<T> buffer,
+        $(RW)StructuredBuffer<T, L> buffer,
         uint element,
         TensorLayout<Dim, ClampMode> tensorLayout,
         functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
     {
-        let zero = 0;
         let alignment = 16U;
+        let pointer = __getStructuredBufferElementPtr<T, L>(buffer, element);
 
         // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
         This ret;
@@ -28831,9 +28833,7 @@ $}
         {
             OpCapability CooperativeMatrixBlockLoadsNV;
             OpExtension "SPV_NV_cooperative_matrix2";
-            %storagePointerType = OpTypePointer StorageBuffer $$T;
-            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
-            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment DecodeFunc $decodeFunc;
+            result:$$This = OpCooperativeMatrixLoadTensorNV $pointer $ret $tensorLayout Aligned !alignment DecodeFunc $decodeFunc;
         };
     }
 
@@ -28862,9 +28862,10 @@ $}
         let ClampMode : CoopMatClampMode,
         let DimView : uint32_t,
         let HasDimensions : bool
-        $(tensorViewTypes)
+        $(tensorViewTypes),
+        L : IBufferDataLayout = DefaultDataLayout
     >(
-        $(RW)StructuredBuffer<T> buffer,
+        $(RW)StructuredBuffer<T, L> buffer,
         uint element,
         TensorLayout<Dim, ClampMode> tensorLayout,
         TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView,
@@ -28880,16 +28881,17 @@ $}
         let ClampMode : CoopMatClampMode,
         let DimView : uint32_t,
         let HasDimensions : bool
-        $(tensorViewTypes)
+        $(tensorViewTypes),
+        L : IBufferDataLayout
     >(
-        $(RW)StructuredBuffer<T> buffer,
+        $(RW)StructuredBuffer<T, L> buffer,
         uint element,
         TensorLayout<Dim, ClampMode> tensorLayout,
         TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView,
         functype(U*, uint32_t[Dim], uint32_t[Dim]) -> T decodeFunc)
     {
-        let zero = 0;
         let alignment = 16U;
+        let pointer = __getStructuredBufferElementPtr<T, L>(buffer, element);
 
         // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpCooperativeMatrixLoadTensorNV
         This ret;
@@ -28898,9 +28900,7 @@ $}
             OpCapability CooperativeMatrixTensorAddressingNV;
             OpCapability CooperativeMatrixBlockLoadsNV;
             OpExtension "SPV_NV_cooperative_matrix2";
-            %storagePointerType = OpTypePointer StorageBuffer $$T;
-            %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
-            result:$$This = OpCooperativeMatrixLoadTensorNV %pointer $ret $tensorLayout Aligned !alignment TensorView|DecodeFunc $tensorView $decodeFunc;
+            result:$$This = OpCooperativeMatrixLoadTensorNV $pointer $ret $tensorLayout Aligned !alignment TensorView|DecodeFunc $tensorView $decodeFunc;
         };
     }
 
@@ -28923,14 +28923,15 @@ $}
     [require(cooperative_matrix_tensor_addressing)]
     void Store<
         let Dim : uint32_t,
-        let ClampMode : CoopMatClampMode
+        let ClampMode : CoopMatClampMode,
+        L : IBufferDataLayout = DefaultDataLayout
     >(
-        RWStructuredBuffer<T> buffer,
+        RWStructuredBuffer<T, L> buffer,
         uint element,
         TensorLayout<Dim, ClampMode> tensorLayout)
     {
-        let zero = 0;
         let alignment = 16U;
+        let pointer = __getStructuredBufferElementPtr<T, L>(buffer, element);
 
         __target_switch
         {
@@ -28939,9 +28940,7 @@ $}
             {
                 OpCapability CooperativeMatrixTensorAddressingNV;
                 OpExtension "SPV_NV_cooperative_matrix2";
-                %storagePointerType = OpTypePointer StorageBuffer $$T;
-                %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
-                OpCooperativeMatrixStoreTensorNV %pointer $this $tensorLayout Aligned !alignment None;
+                OpCooperativeMatrixStoreTensorNV $pointer $this $tensorLayout Aligned !alignment None;
             };
         }
     }
@@ -28991,15 +28990,16 @@ $}
         let ClampMode : CoopMatClampMode,
         let DimView : uint32_t,
         let HasDimensions : bool
-        $(tensorViewTypes)
+        $(tensorViewTypes),
+        L : IBufferDataLayout = DefaultDataLayout
     >(
-        RWStructuredBuffer<T> buffer,
+        RWStructuredBuffer<T, L> buffer,
         uint element,
         TensorLayout<Dim, ClampMode> tensorLayout,
         TensorView<DimView, HasDimensions $(tensorViewParams)> tensorView)
     {
-        let zero = 0;
         let alignment = 16U;
+        let pointer = __getStructuredBufferElementPtr<T, L>(buffer, element);
 
         __target_switch
         {
@@ -29008,9 +29008,7 @@ $}
             {
                 OpCapability CooperativeMatrixTensorAddressingNV;
                 OpExtension "SPV_NV_cooperative_matrix2";
-                %storagePointerType = OpTypePointer StorageBuffer $$T;
-                %pointer:%storagePointerType = OpAccessChain $buffer $zero $element;
-                OpCooperativeMatrixStoreTensorNV %pointer $this $tensorLayout Aligned !alignment TensorView $tensorView;
+                OpCooperativeMatrixStoreTensorNV $pointer $this $tensorLayout Aligned !alignment TensorView $tensorView;
             };
         }
     }
@@ -29150,6 +29148,7 @@ CoopMat<T, S, M, N, R> coopMatLoad<
 /// @param N The number of columns in the matrix fragment.
 /// @param R The matrix use specifier (MatrixA, MatrixB, or MatrixAccumulator).
 /// @param matrixLayout The memory layout (RowMajor or ColMajor) of the data in the buffer.
+/// @param L The data layout of the StructuredBuffer.
 /// @param buffer The StructuredBuffer to load from.
 /// @param element The starting element index in the buffer.
 /// @param stride The stride in elements between consecutive rows or columns.
@@ -29162,9 +29161,10 @@ CoopMat<T, S, M, N, R> coopMatLoad<
     let M : int,
     let N : int,
     let R : CoopMatMatrixUse,
-    let matrixLayout : CoopMatMatrixLayout
+    let matrixLayout : CoopMatMatrixLayout,
+    L : IBufferDataLayout = DefaultDataLayout
 >(
-    StructuredBuffer<T> buffer,
+    StructuredBuffer<T, L> buffer,
     uint element,
     uint stride)
 {
@@ -29179,6 +29179,7 @@ CoopMat<T, S, M, N, R> coopMatLoad<
 /// @param N The number of columns in the matrix fragment.
 /// @param R The matrix use specifier (MatrixA, MatrixB, or MatrixAccumulator).
 /// @param matrixLayout The memory layout (RowMajor or ColMajor) of the data in the buffer.
+/// @param L The data layout of the RWStructuredBuffer.
 /// @param buffer The RWStructuredBuffer to load from.
 /// @param element The starting element index in the buffer.
 /// @param stride The stride in elements between consecutive rows or columns.
@@ -29191,9 +29192,10 @@ CoopMat<T, S, M, N, R> coopMatLoad<
     let M : int,
     let N : int,
     let R : CoopMatMatrixUse,
-    let matrixLayout : CoopMatMatrixLayout
+    let matrixLayout : CoopMatMatrixLayout,
+    L : IBufferDataLayout = DefaultDataLayout
 >(
-    RWStructuredBuffer<T> buffer,
+    RWStructuredBuffer<T, L> buffer,
     uint element,
     uint stride)
 {
@@ -30019,19 +30021,17 @@ struct CoopVec<T : __BuiltinArithmeticType, let N : int> : IArray<T>, IArithmeti
     }
 
     [require(cooperative_vector)]
-    void store(RWStructuredBuffer<T> buffer, int32_t byteOffset16ByteAligned = 0)
+    void store<L : IBufferDataLayout = DefaultDataLayout>(RWStructuredBuffer<T, L> buffer, int32_t byteOffset16ByteAligned = 0)
     {
         __target_switch
         {
         case spirv:
-            let zero = 0;
+            let pointer = __getStructuredBufferPtr<T, L>(buffer);
             spirv_asm
             {
-                %runtimeArrayType = OpTypeRuntimeArray $$T;
-                %storagePointerType = OpTypePointer StorageBuffer %runtimeArrayType;
-                %pointer:%storagePointerType = OpAccessChain $buffer $zero;
-                OpCooperativeVectorStoreNV %pointer $byteOffset16ByteAligned $this None;
+                OpCooperativeVectorStoreNV $pointer $byteOffset16ByteAligned $this None;
             };
+            return;
         default:
             for(int i = 0; i < N; ++i)
                 buffer[i + __byteToElemOffset<T>(byteOffset16ByteAligned)] = this[i];
@@ -30168,18 +30168,15 @@ struct CoopVec<T : __BuiltinArithmeticType, let N : int> : IArray<T>, IArithmeti
 
     [__NoSideEffect]
     [require(cooperative_vector)]
-    static CoopVec<T, N> load(StructuredBuffer<T> buffer, int32_t byteOffset16ByteAligned = 0)
+    static CoopVec<T, N> load<L : IBufferDataLayout = DefaultDataLayout>(StructuredBuffer<T, L> buffer, int32_t byteOffset16ByteAligned = 0)
     {
         __target_switch
         {
         case spirv:
-            let zero = 0;
+            let pointer = __getStructuredBufferPtr<T, L>(buffer);
             return spirv_asm
             {
-                %runtimeArrayType = OpTypeRuntimeArray $$T;
-                %storagePointerType = OpTypePointer StorageBuffer %runtimeArrayType;
-                %pointer:%storagePointerType = OpAccessChain $buffer $zero;
-                result:$$CoopVec<T, N> = OpCooperativeVectorLoadNV %pointer $byteOffset16ByteAligned None;
+                result:$$CoopVec<T, N> = OpCooperativeVectorLoadNV $pointer $byteOffset16ByteAligned None;
             };
         default:
             var vec = CoopVec<T, N>();
@@ -30192,18 +30189,15 @@ struct CoopVec<T : __BuiltinArithmeticType, let N : int> : IArray<T>, IArithmeti
 
     [__NoSideEffect]
     [require(cooperative_vector)]
-    static CoopVec<T, N> load(RWStructuredBuffer<T> buffer, int32_t byteOffset16ByteAligned = 0)
+    static CoopVec<T, N> load<L : IBufferDataLayout = DefaultDataLayout>(RWStructuredBuffer<T, L> buffer, int32_t byteOffset16ByteAligned = 0)
     {
         __target_switch
         {
         case spirv:
-            let zero = 0;
+            let pointer = __getStructuredBufferPtr<T, L>(buffer);
             return spirv_asm
             {
-                %runtimeArrayType = OpTypeRuntimeArray $$T;
-                %storagePointerType = OpTypePointer StorageBuffer %runtimeArrayType;
-                %pointer:%storagePointerType = OpAccessChain $buffer $zero;
-                result:$$CoopVec<T, N> = OpCooperativeVectorLoadNV %pointer $byteOffset16ByteAligned None;
+                result:$$CoopVec<T, N> = OpCooperativeVectorLoadNV $pointer $byteOffset16ByteAligned None;
             };
         default:
             var vec = CoopVec<T, N>();
@@ -31387,14 +31381,14 @@ CoopVec<T, N> coopVecLoad<let N : int, T : __BuiltinArithmeticType>(RWByteAddres
 
 [ForceInline]
 [require(cooperative_vector)]
-CoopVec<T, N> coopVecLoad<let N : int, T : __BuiltinArithmeticType>(StructuredBuffer<T> buffer, int32_t byteOffset16ByteAligned = 0)
+CoopVec<T, N> coopVecLoad<let N : int, T : __BuiltinArithmeticType, L : IBufferDataLayout = DefaultDataLayout>(StructuredBuffer<T, L> buffer, int32_t byteOffset16ByteAligned = 0)
 {
     return CoopVec<T, N>.load(buffer, byteOffset16ByteAligned);
 }
 
 [ForceInline]
 [require(cooperative_vector)]
-CoopVec<T, N> coopVecLoad<let N : int, T : __BuiltinArithmeticType>(RWStructuredBuffer<T> buffer, int32_t byteOffset16ByteAligned = 0)
+CoopVec<T, N> coopVecLoad<let N : int, T : __BuiltinArithmeticType, L : IBufferDataLayout = DefaultDataLayout>(RWStructuredBuffer<T, L> buffer, int32_t byteOffset16ByteAligned = 0)
 {
     return CoopVec<T, N>.load(buffer, byteOffset16ByteAligned);
 }
@@ -32881,9 +32875,7 @@ struct DispatchNodeInputRecord
         case spirv:
             return spirv_asm
             {
-                %in_payload_t = OpTypeNodePayloadArrayAMDX $$T;
-                %in_payload_ptr_t = OpTypePointer NodePayloadAMDX %in_payload_t;
-                %var = OpVariable %in_payload_ptr_t NodePayloadAMDX;
+                %var : $$NodePayloadPtr<T> = OpVariable NodePayloadAMDX;
                 result : $$NodePayloadPtr<T> = OpAccessChain %var $index;
             };
         }

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -8241,7 +8241,8 @@ Expr* SemanticsExprVisitor::visitSPIRVAsmExpr(SPIRVAsmExpr* expr)
     {
         // It's not automatically a failure to not have info, we just won't
         // be able to deduce types for operands
-        const auto opInfo = spirvInfo->opInfos.lookup(SpvOp(inst.opcode.knownValue));
+        const auto opcode = SpvOp(inst.opcode.knownValue);
+        const auto opInfo = spirvInfo->opInfos.lookup(opcode);
 
         if (opInfo && opInfo->numOperandTypes == 0 && inst.operands.getCount())
         {
@@ -8438,6 +8439,14 @@ Expr* SemanticsExprVisitor::visitSPIRVAsmExpr(SPIRVAsmExpr* expr)
             };
 
             check(check, inst.operands[operandIndex]);
+        }
+
+        if (opcode == SpvOpTypeArray || opcode == SpvOpTypeRuntimeArray ||
+            opcode == SpvOpTypePointer)
+        {
+            getSink()->diagnose(Diagnostics::SpirvLayoutSensitiveTypeInAsm{
+                .opcode = inst.opcode.token.getContent(),
+                .location = inst.opcode.token.loc});
         }
     }
 

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -1039,6 +1039,13 @@ err(
     span { loc = "location", message = "cannot use a stage name in '__target_switch', use '__stage_switch' for stage-specific code." }
 )
 
+warning(
+    "spirv-layout-sensitive-type-in-asm",
+    29116,
+    "layout-sensitive SPIR-V type declaration in spirv_asm",
+    span { loc = "location", message = "layout-sensitive SPIR-V type declaration '~opcode' in spirv_asm may not preserve Slang data-layout information; form layout-sensitive pointers/values with Slang types or expressions and pass them into spirv_asm instead" }
+)
+
 
 -- Load semantic checking diagnostics (part 1)
 -- (inlined from slang-diagnostics-semantic-checking-1.lua)

--- a/source/slang/slang-emit-spirv-ops.h
+++ b/source/slang/slang-emit-spirv-ops.h
@@ -342,11 +342,12 @@ SpvInst* emitOpTypeArray(IRInst* inst, const T1& elementType, const T2& length)
 {
     static_assert(isSingular<T1>);
     static_assert(isSingular<T2>);
-    return emitInst(
+    return emitInstMemoizedWithExtraKeyData(
         getSection(SpvLogicalSectionID::ConstantsAndTypes),
         inst,
         SpvOpTypeArray,
         kResultID,
+        getArrayTypeExtraKeyData(inst),
         elementType,
         length);
 }
@@ -356,11 +357,12 @@ template<typename T>
 SpvInst* emitOpTypeRuntimeArray(IRInst* inst, const T& elementType)
 {
     static_assert(isSingular<T>);
-    return emitInstMemoized(
+    return emitInstMemoizedWithExtraKeyData(
         getSection(SpvLogicalSectionID::ConstantsAndTypes),
         inst,
         SpvOpTypeRuntimeArray,
         kResultID,
+        getArrayTypeExtraKeyData(inst),
         elementType);
 }
 
@@ -395,11 +397,12 @@ template<typename T>
 SpvInst* emitOpTypePointer(IRInst* inst, SpvStorageClass storageClass, const T& type)
 {
     static_assert(isSingular<T>);
-    return emitInstMemoized(
+    return emitInstMemoizedWithExtraKeyData(
         getSection(SpvLogicalSectionID::ConstantsAndTypes),
         inst,
         SpvOpTypePointer,
         kResultID,
+        getPointerTypeExtraKeyData(inst, storageClass),
         storageClass,
         type);
 }

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -7,6 +7,7 @@
 #include "slang-ir-entry-point-decorations.h"
 #include "slang-ir-insts.h"
 #include "slang-ir-layout.h"
+#include "slang-ir-lower-buffer-element-type.h"
 #include "slang-ir-redundancy-removal.h"
 #include "slang-ir-spirv-legalize.h"
 #include "slang-ir-spirv-snippet.h"
@@ -1358,6 +1359,46 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         ResultIDToken resultId,
         const OperandEmitFunc& f)
     {
+        return emitInstMemoizedCustomOperandFuncWithExtraKeyData(
+            parent,
+            irInst,
+            opcode,
+            resultId,
+            f,
+            List<SpvWord>());
+    }
+
+    template<typename... Operands>
+    SpvInst* emitInstMemoizedWithExtraKeyData(
+        SpvInstParent* parent,
+        IRInst* irInst,
+        SpvOp opcode,
+        // We take the resultId here explicitly here to make sure we don't try
+        // and memoize its value.
+        ResultIDToken resultId,
+        List<SpvWord>&& extraKeyData,
+        const Operands&... ops)
+    {
+        return emitInstMemoizedCustomOperandFuncWithExtraKeyData(
+            parent,
+            irInst,
+            opcode,
+            resultId,
+            [&]() { (emitOperand(ops), ...); },
+            std::move(extraKeyData));
+    }
+
+    template<typename OperandEmitFunc>
+    SpvInst* emitInstMemoizedCustomOperandFuncWithExtraKeyData(
+        SpvInstParent* parent,
+        IRInst* irInst,
+        SpvOp opcode,
+        // We take the resultId here explicitly here to make sure we don't try
+        // and memoize its value.
+        ResultIDToken resultId,
+        const OperandEmitFunc& f,
+        List<SpvWord>&& extraKeyData)
+    {
         List<SpvWord> ourOperands;
         {
             auto scopePeek = OperandMemoizeScope(this);
@@ -1367,13 +1408,14 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             ourOperands = std::move(m_operandStack);
         }
 
-        // Hash the whole global stack and opcode
-        SpvTypeInstKey key;
-        key.words.add(opcode);
-        key.words.addRange(ourOperands);
+        // Hash the opcode, encoded operands, and any caller-provided key data.
+        SpvInstKey key;
+        key.instWords.add(opcode);
+        key.instWords.addRange(ourOperands);
+        key.extraKeyData = std::move(extraKeyData);
 
         // If we have seen this before, return the memoized instruction
-        if (SpvInst** memoized = m_spvTypeInsts.tryGetValue(key))
+        if (SpvInst** memoized = m_memoizedSpvInsts.tryGetValue(key))
         {
             // There could be another different slang IR inst that translates to
             // the same spir-v inst.
@@ -1389,7 +1431,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         // Otherwise, we can construct our instruction and record the result
         InstConstructScope scopeInst(this, opcode, irInst);
         SpvInst* spvInst = scopeInst;
-        m_spvTypeInsts[key] = spvInst;
+        m_memoizedSpvInsts[key] = spvInst;
 
         // Emit our operands, this time with the resultId too
         emitOperand(resultId);
@@ -1415,19 +1457,19 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             ourOperands = std::move(m_operandStack);
         }
 
-        // Hash the whole global stack and opcode
-        SpvTypeInstKey key;
-        key.words.add(opcode);
-        key.words.addRange(ourOperands);
+        // Hash the opcode and encoded operands.
+        SpvInstKey key;
+        key.instWords.add(opcode);
+        key.instWords.addRange(ourOperands);
 
         // If we have seen this before, return the memoized instruction
-        if (SpvInst** memoized = m_spvTypeInsts.tryGetValue(key))
+        if (SpvInst** memoized = m_memoizedSpvInsts.tryGetValue(key))
             return *memoized;
 
         // Otherwise, we can construct our instruction and record the result
         InstConstructScope scopeInst(this, opcode, irInst);
         SpvInst* spvInst = scopeInst;
-        m_spvTypeInsts[key] = spvInst;
+        m_memoizedSpvInsts[key] = spvInst;
 
         m_operandStack.addRange(ourOperands);
 
@@ -1817,20 +1859,196 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         return m_extensionInsts.containsKey(name);
     }
 
-    struct SpvTypeInstKey
+    struct SpvInstKey
     {
-        List<SpvWord> words;
-        bool operator==(const SpvTypeInstKey& other) const { return words == other.words; }
+        List<SpvWord> instWords;
+        List<SpvWord> extraKeyData;
+        bool operator==(const SpvInstKey& other) const
+        {
+            return instWords == other.instWords && extraKeyData == other.extraKeyData;
+        }
         const static bool kHasUniformHash = true;
         auto getHashCode() const
         {
-            return Slang::getHashCode(
-                reinterpret_cast<const char*>(words.getBuffer()),
-                words.getCount() * sizeof(SpvWord));
+            const auto instWordsHash = Slang::getHashCode(
+                reinterpret_cast<const char*>(instWords.getBuffer()),
+                instWords.getCount() * sizeof(SpvWord));
+            const auto extraKeyDataHash = Slang::getHashCode(
+                reinterpret_cast<const char*>(extraKeyData.getBuffer()),
+                extraKeyData.getCount() * sizeof(SpvWord));
+            return combineHash(instWordsHash, extraKeyDataHash);
         }
     };
 
-    Dictionary<SpvTypeInstKey, SpvInst*> m_spvTypeInsts;
+    Dictionary<SpvInstKey, SpvInst*> m_memoizedSpvInsts;
+
+    // `IRSizeAndAlignmentDecoration` currently serves two purposes: it caches
+    // the result of layout queries on a type, and it is also the closest signal
+    // we have for which concrete layout should drive SPIR-V layout emission.
+    // That conflicts when multiple layout rules have been queried for the same
+    // type; for example, debug-info emission can ask for Natural layout on a type
+    // originally laid out as Std430. Prefer the non-Natural rule here so layout
+    // emission and layout-sensitive memoization use the same heuristic.
+    // TODO: Attach an explicit "primary layout" marker during
+    // `lowerBufferElementTypeToStorageType`. See #10964.
+    bool tryGetPreferredSizeAndAlignmentLayoutRuleName(
+        IRType* type,
+        IRTypeLayoutRuleName* outLayoutRuleName)
+    {
+        if (!type)
+            return false;
+
+        IRTypeLayoutRuleName result = IRTypeLayoutRuleName::Natural;
+        bool foundLayout = false;
+        for (auto decor : type->getDecorations())
+        {
+            if (auto sizeDecor = as<IRSizeAndAlignmentDecoration>(decor))
+            {
+                foundLayout = true;
+                auto name = sizeDecor->getLayoutName();
+                if (name != IRTypeLayoutRuleName::Natural)
+                {
+                    *outLayoutRuleName = name;
+                    return true;
+                }
+                result = name;
+            }
+        }
+
+        if (!foundLayout)
+            return false;
+
+        *outLayoutRuleName = result;
+        return true;
+    }
+
+    IRTypeLayoutRules* getPointerArrayStrideLayoutRule(IRPtrTypeBase* ptrType, IRType* valueType)
+    {
+        if (ptrType->getDataLayout())
+            return getTypeLayoutRuleForBuffer(m_targetProgram, ptrType);
+
+        IRTypeLayoutRuleName layoutRuleName;
+        if (tryGetPreferredSizeAndAlignmentLayoutRuleName(valueType, &layoutRuleName) &&
+            layoutRuleName != IRTypeLayoutRuleName::Natural)
+            return IRTypeLayoutRules::get(layoutRuleName);
+
+        return getTypeLayoutRuleForBuffer(m_targetProgram, ptrType);
+    }
+
+    IRIntegerValue getArrayElementStrideValue(IRArrayTypeBase* arrayType, IRTypeLayoutRules* rule)
+    {
+        auto elementType = arrayType->getElementType();
+        if (isIROpaqueType(elementType) || !shouldEmitArrayStride(elementType))
+            return 0;
+
+        if (auto strideInst = arrayType->getArrayStride())
+            return getIntVal(strideInst);
+
+        IRSizeAndAlignment elementSizeAndAlignment;
+        getSizeAndAlignment(m_targetRequest, rule, elementType, &elementSizeAndAlignment);
+
+        if (elementSizeAndAlignment.size == IRSizeAndAlignment::kIndeterminateSize)
+            return IRSizeAndAlignment::kIndeterminateSize;
+
+        elementSizeAndAlignment = rule->alignCompositeElement(elementSizeAndAlignment);
+        return elementSizeAndAlignment.getStride();
+    }
+
+    IRIntegerValue getPointerArrayStrideValue(IRPtrTypeBase* ptrType, SpvStorageClass storageClass)
+    {
+        if (!ptrType)
+            return 0;
+
+        if (storageClass != SpvStorageClassPhysicalStorageBuffer &&
+            storageClass != SpvStorageClassStorageBuffer)
+            return 0;
+
+        auto valueType = ptrType->getValueType();
+        auto rule = getPointerArrayStrideLayoutRule(ptrType, valueType);
+
+        if (auto arrayType = as<IRUnsizedArrayType>(valueType))
+            return getArrayElementStrideValue(arrayType, rule);
+
+        IRSizeAndAlignment sizeAndAlignment;
+        getSizeAndAlignment(m_targetRequest, rule, valueType, &sizeAndAlignment);
+
+        if (sizeAndAlignment.size == IRSizeAndAlignment::kIndeterminateSize)
+            return IRSizeAndAlignment::kIndeterminateSize;
+
+        return rule->alignCompositeElement(sizeAndAlignment).getStride();
+    }
+
+    IRIntegerValue getArrayStrideValue(IRInst* inst)
+    {
+        if (auto arrayType = as<IRArrayTypeBase>(inst))
+        {
+            auto elementType = arrayType->getElementType();
+            if (isIROpaqueType(elementType) || !shouldEmitArrayStride(elementType))
+                return 0;
+
+            if (auto strideInst = arrayType->getArrayStride())
+                return getIntVal(strideInst);
+
+            if (arrayType->getOp() == kIROp_UnsizedArrayType)
+            {
+                IRTypeLayoutRuleName layoutRuleName = IRTypeLayoutRuleName::Natural;
+                tryGetPreferredSizeAndAlignmentLayoutRuleName(elementType, &layoutRuleName);
+                return getArrayElementStrideValue(
+                    arrayType,
+                    IRTypeLayoutRules::get(layoutRuleName));
+            }
+
+            return 0;
+        }
+
+        if (auto ptrType = as<IRPtrTypeBase>(inst))
+        {
+            return getPointerArrayStrideValue(ptrType, getSpvStorageClass(ptrType));
+        }
+
+        return 0;
+    }
+
+    // Returns 0 when no ArrayStride decoration should be emitted.
+    SpvWord getArrayStrideDecorationValue(IRInst* inst)
+    {
+        auto stride = getArrayStrideValue(inst);
+
+        if (stride == IRSizeAndAlignment::kIndeterminateSize)
+        {
+            // Any unsized data type (e.g. struct or array) will have size of
+            // kIndeterminateSize, in such case the stride is invalid, so we have to
+            // provide a non-zero value to pass the spirv validator.
+            return 0xFFFF;
+        }
+
+        // TODO: Diagnose strides outside the 32-bit SPIR-V ArrayStride literal range.
+
+        return SpvWord(uint32_t(stride));
+    }
+
+    void addArrayStrideExtraKeyData(List<SpvWord>& extraKeyData, IRIntegerValue stride)
+    {
+        uint64_t strideValue = uint64_t(stride);
+        extraKeyData.add(SpvWord(strideValue & 0xffffffff));
+        extraKeyData.add(SpvWord((strideValue >> 32) & 0xffffffff));
+    }
+
+    List<SpvWord> getPointerTypeExtraKeyData(IRInst* inst, SpvStorageClass storageClass)
+    {
+        List<SpvWord> extraKeyData;
+        addArrayStrideExtraKeyData(
+            extraKeyData,
+            getPointerArrayStrideValue(as<IRPtrTypeBase>(inst), storageClass));
+        return extraKeyData;
+    }
+
+    List<SpvWord> getArrayTypeExtraKeyData(IRInst* inst)
+    {
+        List<SpvWord> extraKeyData;
+        addArrayStrideExtraKeyData(extraKeyData, getArrayStrideValue(inst));
+        return extraKeyData;
+    }
 
     bool shouldEmitSPIRVReflectionInfo()
     {
@@ -2174,7 +2392,9 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 else if (storageClass == SpvStorageClassNodePayloadAMDX)
                 {
                     auto spvValueType = ensureInst(valueType);
-                    auto spvNodePayloadType = emitOpTypeNodePayloadArray(inst, spvValueType);
+                    // The IR instruction maps to the pointer type below. This wrapper is only
+                    // the pointee type required by SPIR-V, so do not register it for the IR inst.
+                    auto spvNodePayloadType = emitOpTypeNodePayloadArray(nullptr, spvValueType);
                     valueTypeId = getID(spvNodePayloadType);
                 }
                 else
@@ -2198,33 +2418,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 {
                     if (m_decoratedSpvInsts.add(getID(resultSpvType)))
                     {
-                        IRSizeAndAlignment sizeAndAlignment;
-                        uint32_t stride;
-
-                        if (auto layout = valueType->findDecoration<IRSizeAndAlignmentDecoration>())
-                        {
-                            auto rule = IRTypeLayoutRules::get(layout->getLayoutName());
-                            getSizeAndAlignment(
-                                m_targetRequest,
-                                rule,
-                                valueType,
-                                &sizeAndAlignment);
-                        }
-                        else
-                        {
-                            getNaturalSizeAndAlignment(
-                                m_targetRequest,
-                                valueType,
-                                &sizeAndAlignment);
-                        }
-                        uint64_t valueSize = sizeAndAlignment.size;
-
-                        // Any unsized data type (e.g. struct or array) will have size of
-                        // kIndeterminateSize, in such case the stride is invalid, so we have to
-                        // provide a non-zero value to pass the spirv validator.
-                        stride = (valueSize >= (uint64_t)sizeAndAlignment.kIndeterminateSize)
-                                     ? 0xFFFF
-                                     : (uint32_t)sizeAndAlignment.getStride();
+                        auto stride = getArrayStrideDecorationValue(ptrType);
                         if (stride != 0)
                         {
                             emitOpDecorateArrayStride(
@@ -2445,43 +2639,19 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                         ? emitOpTypeArray(inst, elementType, irArrayType->getElementCount())
                         : emitOpTypeRuntimeArray(inst, elementType);
                 // Arrays of opaque types should not emit a stride
-                if (!isIROpaqueType(elementType) &&
-                    shouldEmitArrayStride(irArrayType->getElementType()))
+                auto stride = getArrayStrideDecorationValue(irArrayType);
+                if (stride != 0)
                 {
-                    auto stride = 0;
-                    // If the array type has no stride, it indicates that this array type is only
-                    // used in Private or Function storage class (aka. thread-local or function
-                    // scope variable), in that case SPIRV doesn't allow to decorate the array
-                    // stride.
-                    //
-                    // The only exception is if the array type is unsized, because unsized array
-                    // also has no stride operand, however unsized array can not be used in Private
-                    // or Function, so we are safe to just decorate the stride for unsized array by
-                    // calculating the natural stride.
-                    if (auto strideInst = irArrayType->getArrayStride())
-                    {
-                        stride = (int)getIntVal(strideInst);
-                    }
-                    else if (inst->getOp() == kIROp_UnsizedArrayType)
-                    {
-                        IRSizeAndAlignment sizeAndAlignment;
-                        getNaturalSizeAndAlignment(m_targetRequest, elementType, &sizeAndAlignment);
-                        stride = (int)sizeAndAlignment.getStride();
-                    }
-
-                    if (stride != 0)
-                    {
-                        emitInstMemoizedNoResultIDCustomOperandFunc(
-                            getSection(SpvLogicalSectionID::Annotations),
-                            nullptr,
-                            SpvOpDecorate,
-                            [&]()
-                            {
-                                emitOperand(arrayType);
-                                emitOperand(SpvLiteralInteger::from32(SpvDecorationArrayStride));
-                                emitOperand(SpvLiteralInteger::from32(stride));
-                            });
-                    }
+                    emitInstMemoizedNoResultIDCustomOperandFunc(
+                        getSection(SpvLogicalSectionID::Annotations),
+                        nullptr,
+                        SpvOpDecorate,
+                        [&]()
+                        {
+                            emitOperand(arrayType);
+                            emitOperand(SpvLiteralInteger::from32(SpvDecorationArrayStride));
+                            emitOperand(SpvLiteralInteger::from32(stride));
+                        });
                 }
                 return arrayType;
             }
@@ -6387,30 +6557,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
          * assigned the same Offset.
          *
          *****/
-        // TODO: `IRSizeAndAlignmentDecoration` currently serves two purposes: it caches the
-        // result of layout queries on a type (any query simply attaches the decoration), and it is
-        // used here to decide which layout rule should be applied when emitting the struct.  That
-        // conflicts when multiple layout rules have been queried for the same struct -- in
-        // particular, debug-info emission asks for Natural layout on types that were originally
-        // laid out as Std430, which leaves both decorations on the struct and a plain
-        // `findDecoration` call would return whichever was attached first.  We prefer the
-        // non-Natural rule here as a heuristic, but the real fix is to either stop reusing the
-        // caching decoration as a layout-selection signal or to attach an explicit "primary
-        // layout" marker during `lowerBufferElementTypeToStorageType`.  See #10964.
         IRTypeLayoutRuleName layoutRuleName = IRTypeLayoutRuleName::Natural;
-        for (auto decor : structType->getDecorations())
-        {
-            if (auto sizeDecor = as<IRSizeAndAlignmentDecoration>(decor))
-            {
-                auto name = sizeDecor->getLayoutName();
-                if (name != IRTypeLayoutRuleName::Natural)
-                {
-                    layoutRuleName = name;
-                    break;
-                }
-                layoutRuleName = name;
-            }
-        }
+        tryGetPreferredSizeAndAlignmentLayoutRuleName(structType, &layoutRuleName);
         int32_t id = 0;
         bool isPhysicalType = isPhysicalCompositeType(structType);
         for (auto field : structType->getFields())

--- a/source/slang/slang-ir-lower-buffer-element-type.cpp
+++ b/source/slang/slang-ir-lower-buffer-element-type.cpp
@@ -703,7 +703,7 @@ struct LoweredElementTypeContext
                     loweredInnerTypeInfo.loweredType,
                     arrayType->getElementCount(),
                     needExplicitLayout ? builder.getIntValue(
-                                             builder.getIntType(),
+                                             builder.getUIntType(),
                                              elementSizeAlignment.getStride())
                                        : nullptr);
                 builder.createStructField(loweredType, structKey, innerArrayType);
@@ -729,7 +729,7 @@ struct LoweredElementTypeContext
                     loweredInnerTypeInfo.loweredType,
                     nullptr,
                     needExplicitLayout ? builder.getIntValue(
-                                             builder.getIntType(),
+                                             builder.getUIntType(),
                                              elementSizeAlignment.getStride())
                                        : nullptr);
                 maybeAddPhysicalTypeDecoration(builder, innerArrayType, config);
@@ -2389,6 +2389,12 @@ IRTypeLayoutRuleName getTypeLayoutRuleNameForBuffer(TargetProgram* target, IRTyp
                                                      : kIROp_DefaultBufferLayoutType;
 
         IRTypeLayoutRuleName defaultRule = IRTypeLayoutRuleName::Natural;
+        // SPIR-V storage-buffer pointers inherit the same std430 default as
+        // GLSLShaderStorageBuffer when no explicit data layout is attached, so stride
+        // computations match the ArrayStride decorations emitted later.
+        if (target->shouldEmitSPIRVDirectly() &&
+            ptrType->getAddressSpace() == AddressSpace::StorageBuffer)
+            defaultRule = IRTypeLayoutRuleName::Std430;
         if (isCPUTargetViaLLVM(targetReq))
             defaultRule = IRTypeLayoutRuleName::LLVM;
 
@@ -2683,7 +2689,7 @@ struct DefaultBufferElementTypeLoweringPolicy : BufferElementTypeLoweringPolicy
                 vectorType,
                 isColMajor ? matrixType->getColumnCount() : matrixType->getRowCount(),
                 needExplicitLayout
-                    ? builder.getIntValue(builder.getIntType(), elementSizeAlignment.getStride())
+                    ? builder.getIntValue(builder.getUIntType(), elementSizeAlignment.getStride())
                     : nullptr);
             builder.createStructField(loweredType, structKey, arrayType);
 

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -135,7 +135,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
 
         const auto arrayType = builder.getUnsizedArrayType(
             inst->getElementType(),
-            builder.getIntValue(builder.getIntType(), elementSize.getStride()));
+            builder.getIntValue(builder.getUIntType(), elementSize.getStride()));
         const auto structType = builder.createStructType();
         builder.addPhysicalTypeDecoration(structType);
         const auto arrayKey = builder.createStructKey();

--- a/tests/bugs/link-time-constant-array-size-lib.slang
+++ b/tests/bugs/link-time-constant-array-size-lib.slang
@@ -1,1 +1,1 @@
-export static const int N = 1597463007;
+export static const int N = 1024;

--- a/tests/bugs/link-time-constant-array-size-main.slang
+++ b/tests/bugs/link-time-constant-array-size-main.slang
@@ -2,6 +2,8 @@
 //TEST:COMPILE: tests/bugs/link-time-constant-array-size-main.slang -o tests/bugs/link-time-constant-array-size-main.slang-module
 //TEST:SIMPLE(filecheck=SPIRV): -r tests/bugs/link-time-constant-array-size-main.slang-module -r tests/bugs/link-time-constant-array-size-lib.slang-module -target spirv -o out.spv -stage compute -entry computeMain
 
+// Check that linked constant array sizes still lower into SPIR-V.
+
 extern static const int N;
 
 // SPIRV: warning[E31010]
@@ -14,9 +16,9 @@ ParameterBlock<S> p;
 [numthreads(1, 1, 1)]
 void computeMain()
 {
-    // check that we multiply by our special number
-    // SPIRV: [[fisqr:%[a-zA-Z0-9_]+]] = OpConstant %int 1597463007
-    // SPIRV: {{%[0-9]+}} = OpIMul %int {{%[0-9]+}} [[fisqr]]
+    // check that we multiply by our linked constant
+    // SPIRV: [[arraySize:%[a-zA-Z0-9_]+]] = OpConstant %int 1024
+    // SPIRV: OpIMul %int {{.*}}[[arraySize]]{{.*}}
     for(int i = 0; i < N; ++i)
         b[0].xs[i] = p.xs[i] * N;
 }

--- a/tests/cooperative-matrix/layout-structuredbuffer-tensor.slang
+++ b/tests/cooperative-matrix/layout-structuredbuffer-tensor.slang
@@ -1,0 +1,53 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -emit-spirv-directly -entry computeMain -stage compute -capability cooperative_matrix_tensor_addressing
+
+// Check that tensor-layout cooperative matrix StructuredBuffer overloads preserve
+// the StructuredBuffer data layout on the element pointer used by load/store.
+
+// CHECK-DAG: OpDecorate %[[PTR_140:[A-Za-z0-9_]+]] ArrayStride 16
+// CHECK-DAG: OpDecorate %[[PTR_430:[A-Za-z0-9_]+]] ArrayStride 4
+// CHECK-DAG: %[[COOP_MAT:[A-Za-z0-9_]+]] = OpTypeCooperativeMatrixKHR %float
+// CHECK-DAG: %[[PTR_140]] = OpTypePointer StorageBuffer %float
+// CHECK-DAG: %[[PTR_430]] = OpTypePointer StorageBuffer %float
+// CHECK: %[[INPUT_140:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_140]] %input140 %int_0 %uint_0
+// CHECK: %[[MAT_140:[A-Za-z0-9_]+]] = OpCooperativeMatrixLoadTensorNV %[[COOP_MAT]] %[[INPUT_140]]
+// CHECK: OpStore %{{[A-Za-z0-9_]+}} %[[MAT_140]]
+// CHECK: %[[MAT_COPY_140:[A-Za-z0-9_]+]] = OpLoad %[[COOP_MAT]]
+// CHECK: OpStore %{{[A-Za-z0-9_]+}} %[[MAT_COPY_140]]
+// CHECK: %[[STORE_MAT_140:[A-Za-z0-9_]+]] = OpLoad %[[COOP_MAT]]
+// CHECK: %[[OUTPUT_140:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_140]] %output140 %int_0 %uint_0
+// CHECK: OpCooperativeMatrixStoreTensorNV %[[OUTPUT_140]] %[[STORE_MAT_140]]
+// CHECK: %[[INPUT_430:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_430]] %input430 %int_0 %uint_0
+// CHECK: %[[MAT_430:[A-Za-z0-9_]+]] = OpCooperativeMatrixLoadTensorNV %[[COOP_MAT]] %[[INPUT_430]]
+// CHECK: OpStore %{{[A-Za-z0-9_]+}} %[[MAT_430]]
+// CHECK: %[[MAT_COPY_430:[A-Za-z0-9_]+]] = OpLoad %[[COOP_MAT]]
+// CHECK: OpStore %{{[A-Za-z0-9_]+}} %[[MAT_COPY_430]]
+// CHECK: %[[STORE_MAT_430:[A-Za-z0-9_]+]] = OpLoad %[[COOP_MAT]]
+// CHECK: %[[OUTPUT_430:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_430]] %output430 %int_0 %uint_0
+// CHECK: OpCooperativeMatrixStoreTensorNV %[[OUTPUT_430]] %[[STORE_MAT_430]]
+
+// The scalar float element type has the same size in both layouts, but the
+// StructuredBuffer element stride differs: std140 rounds up to 16, std430 stays at 4.
+
+using namespace linalg;
+
+StructuredBuffer<float, Std140DataLayout> input140;
+RWStructuredBuffer<float, Std140DataLayout> output140;
+
+StructuredBuffer<float, Std430DataLayout> input430;
+RWStructuredBuffer<float, Std430DataLayout> output430;
+
+typealias CoopMatType = CoopMat<float, MemoryScope.Subgroup, 16, 16, CoopMatMatrixUse.MatrixAccumulator>;
+
+[numthreads(32, 1, 1)]
+void computeMain()
+{
+    TensorLayout<2, CoopMatClampMode.Undefined> tensorLayout;
+    let tensorLayout1 = tensorLayout.Dimension(16, 16);
+    let tensorLayout2 = tensorLayout1.Stride(16, 1);
+
+    let a = CoopMatType.Load(input140, 0, tensorLayout2);
+    a.Store(output140, 0, tensorLayout2);
+
+    let b = CoopMatType.Load(input430, 0, tensorLayout2);
+    b.Store(output430, 0, tensorLayout2);
+}

--- a/tests/cooperative-matrix/layout-structuredbuffer.slang
+++ b/tests/cooperative-matrix/layout-structuredbuffer.slang
@@ -1,0 +1,43 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -emit-spirv-directly -entry computeMain -stage compute -capability cooperative_matrix
+
+// Check that cooperative matrix StructuredBuffer overloads preserve the
+// StructuredBuffer data layout on the element pointer used by load/store.
+
+// CHECK-DAG: OpDecorate %[[PTR_140:[A-Za-z0-9_]+]] ArrayStride 16
+// CHECK-DAG: OpDecorate %[[PTR_430:[A-Za-z0-9_]+]] ArrayStride 4
+// CHECK-DAG: %[[COOP_MAT:[A-Za-z0-9_]+]] = OpTypeCooperativeMatrixKHR %float
+// CHECK-DAG: %[[PTR_140]] = OpTypePointer StorageBuffer %float
+// CHECK-DAG: %[[PTR_430]] = OpTypePointer StorageBuffer %float
+// CHECK: %[[INPUT_140:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_140]] %input140 %int_0 %uint_0
+// CHECK: %[[MAT_140:[A-Za-z0-9_]+]] = OpCooperativeMatrixLoadKHR %[[COOP_MAT]] %[[INPUT_140]]
+// CHECK: %[[OUTPUT_140:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_140]] %output140 %int_0 %uint_0
+// CHECK: OpCooperativeMatrixStoreKHR %[[OUTPUT_140]] %[[MAT_140]]
+// CHECK: %[[INPUT_430:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_430]] %input430 %int_0 %uint_0
+// CHECK: %[[MAT_430:[A-Za-z0-9_]+]] = OpCooperativeMatrixLoadKHR %[[COOP_MAT]] %[[INPUT_430]]
+// CHECK: %[[OUTPUT_430:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_430]] %output430 %int_0 %uint_0
+// CHECK: OpCooperativeMatrixStoreKHR %[[OUTPUT_430]] %[[MAT_430]]
+
+// The scalar float element type has the same size in both layouts, but the
+// StructuredBuffer element stride differs: std140 rounds up to 16, std430 stays at 4.
+
+using namespace linalg;
+
+StructuredBuffer<float, Std140DataLayout> input140;
+RWStructuredBuffer<float, Std140DataLayout> output140;
+
+StructuredBuffer<float, Std430DataLayout> input430;
+RWStructuredBuffer<float, Std430DataLayout> output430;
+
+typealias CoopMatType = CoopMat<float, MemoryScope.Subgroup, 16, 16, CoopMatMatrixUse.MatrixAccumulator>;
+
+[numthreads(32, 1, 1)]
+void computeMain()
+{
+    let stride = 16;
+
+    let a = CoopMatType.Load<CoopMatMatrixLayout.RowMajor>(input140, 0, stride);
+    a.Store<CoopMatMatrixLayout.RowMajor>(output140, 0, stride);
+
+    let b = CoopMatType.Load<CoopMatMatrixLayout.RowMajor>(input430, 0, stride);
+    b.Store<CoopMatMatrixLayout.RowMajor>(output430, 0, stride);
+}

--- a/tests/cooperative-vector/layout-structuredbuffer.slang
+++ b/tests/cooperative-vector/layout-structuredbuffer.slang
@@ -1,0 +1,40 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -emit-spirv-directly -entry computeMain -stage compute -capability cooperative_vector
+
+// Check that cooperative vector StructuredBuffer overloads preserve distinct
+// std140/std430 ArrayStride decorations for runtime arrays and pointers.
+
+// CHECK-DAG: OpDecorate %[[ARRAY_140:[A-Za-z0-9_]+]] ArrayStride 16
+// CHECK-DAG: OpDecorate %[[ARRAY_430:[A-Za-z0-9_]+]] ArrayStride 4
+// CHECK-DAG: OpDecorate %[[PTR_ARRAY_140:[A-Za-z0-9_]+]] ArrayStride 16
+// CHECK-DAG: OpDecorate %[[PTR_ARRAY_430:[A-Za-z0-9_]+]] ArrayStride 4
+// CHECK-DAG: %[[COOP_VEC:[A-Za-z0-9_]+]] = OpTypeVectorIdEXT %float %int_4
+// CHECK-DAG: %[[ARRAY_140]] = OpTypeRuntimeArray %float
+// CHECK-DAG: %[[ARRAY_430]] = OpTypeRuntimeArray %float
+// CHECK-DAG: %[[PTR_ARRAY_140]] = OpTypePointer StorageBuffer %[[ARRAY_140]]
+// CHECK-DAG: %[[PTR_ARRAY_430]] = OpTypePointer StorageBuffer %[[ARRAY_430]]
+// CHECK: %[[INPUT_140:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_ARRAY_140]] %input140 %int_0
+// CHECK: %[[VAL_140:[A-Za-z0-9_]+]] = OpCooperativeVectorLoadNV %[[COOP_VEC]] %[[INPUT_140]] %int_0 None
+// CHECK: %[[STORE_VAL_140:[A-Za-z0-9_]+]] = OpLoad %[[COOP_VEC]]
+// CHECK: %[[INPUT_430:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_ARRAY_430]] %input430 %int_0
+// CHECK: %[[VAL_430:[A-Za-z0-9_]+]] = OpCooperativeVectorLoadNV %[[COOP_VEC]] %[[INPUT_430]] %int_0 None
+// CHECK: %[[STORE_VAL_430:[A-Za-z0-9_]+]] = OpLoad %[[COOP_VEC]]
+// CHECK: %[[OUTPUT_140:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_ARRAY_140]] %output140 %int_0
+// CHECK: OpCooperativeVectorStoreNV %[[OUTPUT_140]] %int_0 %[[STORE_VAL_140]] None
+// CHECK: %[[OUTPUT_430:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_ARRAY_430]] %output430 %int_0
+// CHECK: OpCooperativeVectorStoreNV %[[OUTPUT_430]] %int_0 %[[STORE_VAL_430]] None
+
+StructuredBuffer<float, Std140DataLayout> input140;
+RWStructuredBuffer<float, Std140DataLayout> output140;
+
+StructuredBuffer<float, Std430DataLayout> input430;
+RWStructuredBuffer<float, Std430DataLayout> output430;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    let a = coopVecLoad<4, float>(input140, 0);
+    let b = coopVecLoad<4, float>(input430, 0);
+
+    a.store(output140, 0);
+    b.store(output430, 0);
+}

--- a/tests/language-feature/spirv-asm/layout-sensitive-type-diagnostic.slang
+++ b/tests/language-feature/spirv-asm/layout-sensitive-type-diagnostic.slang
@@ -1,0 +1,47 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK_WARN):-target spirv-asm -entry computeMain -stage compute -DWARN
+//TEST:SIMPLE(filecheck=CHECK_OK):-target spirv-asm -entry computeMain -stage compute -DNO_WARN
+
+// Check that direct layout-sensitive OpType declarations in spirv_asm warn,
+// while using Slang-typed pointer operands does not.
+
+#if defined(WARN)
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    let value = spirv_asm
+    {
+        %arraySize = OpConstant $$uint 4;
+        // CHECK_WARN: warning[E29116]: layout-sensitive SPIR-V type declaration in spirv_asm
+        // CHECK_WARN: layout-sensitive-type-diagnostic.slang:[[# @LINE+2]]:
+        // CHECK_WARN: layout-sensitive SPIR-V type declaration 'OpTypeArray' in spirv_asm may not preserve Slang data-layout information
+        %array = OpTypeArray $$float %arraySize;
+        // CHECK_WARN: warning[E29116]: layout-sensitive SPIR-V type declaration in spirv_asm
+        // CHECK_WARN: layout-sensitive-type-diagnostic.slang:[[# @LINE+2]]:
+        // CHECK_WARN: layout-sensitive SPIR-V type declaration 'OpTypeRuntimeArray' in spirv_asm may not preserve Slang data-layout information
+        %runtimeArray = OpTypeRuntimeArray $$float;
+        // CHECK_WARN: warning[E29116]: layout-sensitive SPIR-V type declaration in spirv_asm
+        // CHECK_WARN: layout-sensitive-type-diagnostic.slang:[[# @LINE+2]]:
+        // CHECK_WARN: layout-sensitive SPIR-V type declaration 'OpTypePointer' in spirv_asm may not preserve Slang data-layout information
+        %pointer = OpTypePointer StorageBuffer %runtimeArray;
+        result:$$uint = OpConstant 1;
+    };
+}
+#elif defined(NO_WARN)
+// CHECK_OK-NOT: layout-sensitive SPIR-V type declaration
+// CHECK_OK: OpAccessChain
+// CHECK_OK-NOT: layout-sensitive SPIR-V type declaration
+
+RWStructuredBuffer<uint, Std430DataLayout> buffer;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    let pointer = __getStructuredBufferElementPtr(buffer, 0);
+    let value = spirv_asm
+    {
+        %unused = OpTypeBool;
+        result:$$uint = OpLoad $pointer;
+    };
+    buffer[0] = value;
+}
+#endif

--- a/tests/spirv/atomic-image-access.slang
+++ b/tests/spirv/atomic-image-access.slang
@@ -13,12 +13,28 @@ RWStructuredBuffer<uint> resultBuffer;
 [vk::image_format("r32ui")]
 RWTexture2D<uint> tex;
 
+// CHECK-DAG: %[[UINT:[A-Za-z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[IMAGE_PTR:[A-Za-z0-9_]+]] = OpTypePointer Image %[[UINT]]
+// CHECK-DAG: %[[ONE:[A-Za-z0-9_]+]] = OpConstant %[[UINT]] 1
+// CHECK-DAG: %[[TWO:[A-Za-z0-9_]+]] = OpConstant %[[UINT]] 2
+
 [numthreads(1,1,1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
-    // CHECK: OpImageTexelPointer
+    // CHECK: %[[ADD_PTR_0:[A-Za-z0-9_]+]] = OpImageTexelPointer %[[IMAGE_PTR]]
+    // CHECK: OpAtomicIAdd %[[UINT]] %[[ADD_PTR_0]] {{.*}} {{.*}} %[[ONE]]
     InterlockedAdd(tex[uint2(0, 0)], 1);
+
     uint oldVal;
-    InterlockedAdd(tex[uint2(0, 0)], 1, oldVal);
+    // CHECK: %[[ADD_PTR_1:[A-Za-z0-9_]+]] = OpImageTexelPointer %[[IMAGE_PTR]]
+    // CHECK: OpAtomicIAdd %[[UINT]] %[[ADD_PTR_1]] {{.*}} {{.*}} %[[ONE]]
+    InterlockedAdd(tex[uint2(1, 0)], 1, oldVal);
+
+    uint compareOldVal;
+    // CHECK: %[[COMPARE_PTR:[A-Za-z0-9_]+]] = OpImageTexelPointer %[[IMAGE_PTR]]
+    // CHECK: OpAtomicCompareExchange %[[UINT]] %[[COMPARE_PTR]] {{.*}} {{.*}} {{.*}} %[[TWO]] %[[ONE]]
+    InterlockedCompareExchange(tex[uint2(0, 0)], 1, 2, compareOldVal);
+
     resultBuffer[0] = oldVal;
+    resultBuffer[1] = compareOldVal;
 }

--- a/tests/spirv/get-buffer-element-ptr.slang
+++ b/tests/spirv/get-buffer-element-ptr.slang
@@ -1,0 +1,40 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry computeMain -stage compute -emit-spirv-directly
+
+// Check that structured-buffer element pointers preserve layout-derived
+// ArrayStride decorations, including the default StructuredBuffer layout.
+
+// CHECK-DAG: OpDecorate %[[PTR_140:_ptr_StorageBuffer_float[A-Za-z0-9_]*]] ArrayStride 16
+// CHECK-DAG: OpDecorate %[[PTR_430:_ptr_StorageBuffer_float[A-Za-z0-9_]*]] ArrayStride 4
+// CHECK-DAG: OpDecorate %[[PTR_DEFAULT:_ptr_StorageBuffer_v3float[A-Za-z0-9_]*]] ArrayStride 16
+// CHECK-DAG: %[[V3:[A-Za-z0-9_]+]] = OpTypeVector %float 3
+// CHECK-DAG: %[[PTR_140]] = OpTypePointer StorageBuffer %float
+// CHECK-DAG: %[[PTR_430]] = OpTypePointer StorageBuffer %float
+// CHECK-DAG: %[[PTR_DEFAULT]] = OpTypePointer StorageBuffer %[[V3]]
+// CHECK: OpPtrAccessChain %[[PTR_140]]
+// CHECK: OpPtrAccessChain %[[PTR_430]]
+// CHECK: OpPtrAccessChain %[[PTR_DEFAULT]]
+
+StructuredBuffer<float, Std140DataLayout> input140;
+StructuredBuffer<float, Std430DataLayout> input430;
+StructuredBuffer<float3> inputDefault;
+RWStructuredBuffer<float> output;
+
+float readNext<L:IBufferDataLayout>(StructuredBuffer<float, L> buffer)
+{
+    let pointer = __getStructuredBufferElementPtr(buffer, 0);
+    return pointer[1];
+}
+
+float readDefaultNext(StructuredBuffer<float3> buffer)
+{
+    let pointer = __getStructuredBufferElementPtr(buffer, 0);
+    return pointer[1].x;
+}
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    output[0] = readNext(input140);
+    output[1] = readNext(input430);
+    output[2] = readDefaultNext(inputDefault);
+}

--- a/tests/spirv/large-array-stride.slang
+++ b/tests/spirv/large-array-stride.slang
@@ -1,0 +1,26 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry computeMain -stage compute -emit-spirv-directly
+
+// Check that explicit layout lowering preserves a large SPIR-V ArrayStride
+// unsigned 32-bit literal instead of interpreting it as a signed integer or
+// truncating it.
+// The large array count is only used to produce a stride larger than the
+// maximum 32-bit signed integer; this test is not intended to cover maximum
+// array element count support.
+
+// CHECK-DAG: OpDecorate %[[PTR:_ptr_StorageBuffer_LargeStride_std430[A-Za-z0-9_]*]] ArrayStride 4294967292
+// CHECK-DAG: OpDecorate %[[RUNTIME:_runtimearr_LargeStride_std430[A-Za-z0-9_]*]] ArrayStride 4294967292
+
+struct LargeStride
+{
+    float a[0x3fffffff];
+};
+
+RWStructuredBuffer<LargeStride> buffer;
+RWStructuredBuffer<float> output;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    output[0] = buffer[0].a[0];
+}

--- a/tests/spirv/structured-buffer-spirv13.slang
+++ b/tests/spirv/structured-buffer-spirv13.slang
@@ -1,0 +1,27 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -profile spirv_1_3 -entry computeMain -stage compute -emit-spirv-directly
+
+// Ordinary StructuredBuffer indexing also lowers through RWStructuredBufferGetElementPtr,
+// but should remain valid before SPIR-V 1.4 because it emits OpAccessChain, not OpPtrAccessChain.
+// SPIR-V 1.3 uses Uniform storage class with BufferBlock decoration.
+
+// CHECK: OpDecorate %[[ARRAY:[A-Za-z0-9_]+]] ArrayStride 16
+// CHECK-DAG: %[[V3:[A-Za-z0-9_]+]] = OpTypeVector %float 3
+// CHECK-DAG: %[[ARRAY]] = OpTypeRuntimeArray %[[V3]]
+// CHECK-DAG: %[[PTR:[A-Za-z0-9_]+]] = OpTypePointer Uniform %[[V3]]
+// CHECK: OpFunction
+// CHECK-NOT: OpPtrAccessChain
+// CHECK: OpAccessChain %[[PTR]]
+// CHECK-NOT: OpPtrAccessChain
+// CHECK: OpAccessChain %[[PTR]]
+// CHECK-NOT: OpPtrAccessChain
+// CHECK: OpFunctionEnd
+
+StructuredBuffer<float3> input;
+RWStructuredBuffer<float3> output;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    uint index = dispatchThreadID.x;
+    output[index] = input[index] + float3(1.0f);
+}

--- a/tests/spirv/type-layout-memoization.slang
+++ b/tests/spirv/type-layout-memoization.slang
@@ -1,0 +1,92 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry computeMain -stage compute -emit-spirv-directly
+
+// Check that SPIR-V type instructions are memoized by both their encoded
+// operands and layout-sensitive decorations emitted separately from the type.
+
+struct FixedArrayData
+{
+    float2 v[2];
+};
+
+struct RuntimeArrayData
+{
+    float f;
+    float2 v[];
+};
+
+struct PointerMatrixData
+{
+    row_major float3x2 m1;
+    column_major float3x2 m2;
+};
+
+GLSLShaderStorageBuffer<FixedArrayData, Std140DataLayout> fixed140;
+GLSLShaderStorageBuffer<FixedArrayData, Std430DataLayout> fixed430;
+
+GLSLShaderStorageBuffer<RuntimeArrayData, Std140DataLayout> runtime140;
+GLSLShaderStorageBuffer<RuntimeArrayData, Std430DataLayout> runtime430;
+
+GLSLShaderStorageBuffer<PointerMatrixData, Std140DataLayout> pointerData;
+
+cbuffer PhysicalPointers
+{
+    LayoutPtr<float2, Std140DataLayout> physical140;
+    LayoutPtr<float2, Std430DataLayout> physical430;
+    LayoutPtr<float2[2], Std140DataLayout> physicalArray140;
+    LayoutPtr<float2[2], Std430DataLayout> physicalArray430;
+}
+
+RWStructuredBuffer<float> outputBuffer;
+
+// OpTypeArray: same element type and length, different ArrayStride decorations.
+// CHECK-DAG: OpDecorate %[[ARRAY_140:_arr_v2float[A-Za-z0-9_]*]] ArrayStride 16
+// CHECK-DAG: OpDecorate %[[ARRAY_430:_arr_v2float[A-Za-z0-9_]*]] ArrayStride 8
+// CHECK-DAG: %[[V2:[A-Za-z0-9_]+]] = OpTypeVector %float 2
+// CHECK-DAG: %[[ARRAY_140]] = OpTypeArray %[[V2]] %{{[A-Za-z0-9_]+}}
+// CHECK-DAG: %[[ARRAY_430]] = OpTypeArray %[[V2]] %{{[A-Za-z0-9_]+}}
+
+// OpTypeRuntimeArray: same element type, different ArrayStride decorations.
+// CHECK-DAG: OpDecorate %[[RUNTIME_140:_runtimearr_v2float[A-Za-z0-9_]*]] ArrayStride 16
+// CHECK-DAG: OpDecorate %[[RUNTIME_430:_runtimearr_v2float[A-Za-z0-9_]*]] ArrayStride 8
+// CHECK-DAG: %[[RUNTIME_140]] = OpTypeRuntimeArray %[[V2]]
+// CHECK-DAG: %[[RUNTIME_430]] = OpTypeRuntimeArray %[[V2]]
+
+// OpTypePointer: same storage class and pointee type, different ArrayStride decorations.
+// CHECK-DAG: OpDecorate %[[M1_PTR:_ptr_StorageBuffer_mat3v2float[A-Za-z0-9_]*]] ArrayStride 48
+// CHECK-DAG: OpDecorate %[[M2_PTR:_ptr_StorageBuffer_mat3v2float[A-Za-z0-9_]*]] ArrayStride 32
+// CHECK-DAG: %[[MATRIX:[A-Za-z0-9_]+]] = OpTypeMatrix %[[V2]] 3
+// CHECK-DAG: %[[M1_PTR]] = OpTypePointer StorageBuffer %[[MATRIX]]
+// CHECK-DAG: %[[M2_PTR]] = OpTypePointer StorageBuffer %[[MATRIX]]
+
+// OpTypePointer PhysicalStorageBuffer: same storage class and pointee type,
+// different ArrayStride decorations.
+// CHECK-DAG: OpDecorate %[[PHYSICAL_140:_ptr_PhysicalStorageBuffer_v2float[A-Za-z0-9_]*]] ArrayStride 16
+// CHECK-DAG: OpDecorate %[[PHYSICAL_430:_ptr_PhysicalStorageBuffer_v2float[A-Za-z0-9_]*]] ArrayStride 8
+// CHECK-DAG: %[[PHYSICAL_140]] = OpTypePointer PhysicalStorageBuffer %[[V2]]
+// CHECK-DAG: %[[PHYSICAL_430]] = OpTypePointer PhysicalStorageBuffer %[[V2]]
+
+// OpTypePointer to a sized array uses the whole array object stride, not the
+// array element stride.
+// CHECK-DAG: OpDecorate %[[PHYSICAL_ARRAY_140:_ptr_PhysicalStorageBuffer__arr_v2float[A-Za-z0-9_]*]] ArrayStride 32
+// CHECK-DAG: OpDecorate %[[PHYSICAL_ARRAY_430:_ptr_PhysicalStorageBuffer__arr_v2float[A-Za-z0-9_]*]] ArrayStride 16
+// CHECK-DAG: %[[PHYSICAL_ARRAY_140]] = OpTypePointer PhysicalStorageBuffer %[[ARRAY_140]]
+// CHECK-DAG: %[[PHYSICAL_ARRAY_430]] = OpTypePointer PhysicalStorageBuffer %[[ARRAY_430]]
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    outputBuffer[0] =
+        fixed140.v[0].x +
+        fixed430.v[0].x +
+        runtime140.f +
+        runtime140.v[0].x +
+        runtime430.f +
+        runtime430.v[0].x +
+        pointerData.m1[0][0] +
+        pointerData.m2[0][0] +
+        physical140[0].x +
+        physical430[0].x +
+        physicalArray140[1][0].x +
+        physicalArray430[1][0].x;
+}


### PR DESCRIPTION
Fix SPIR-V layout-sensitive type memoization

Layout-sensitive SPIR-V type instructions need layout data that is not fully described by their opcode operands. Keep that data in the emitter memoization key and avoid declaring those types directly in internal spirv_asm helpers when Slang typed values can carry the layout instead.

Declaring OpTypeArray, OpTypeRuntimeArray, or OpTypePointer directly in spirv_asm loses the Slang IR layout context, so the emitter cannot reliably reconstruct the ArrayStride identity from the raw SPIR-V operands alone.

* Include ArrayStride data in the memoization key for OpTypeArray, OpTypeRuntimeArray, and OpTypePointer. Compute the stride from the originating IR type instruction and preserve the full IRIntegerValue in the key so indeterminate placeholder values stay distinct from real stride values.

* Store explicit layout strides as unsigned IR integer values to match SPIR-V ArrayStride unsigned 32-bit literal operands. Add large-stride regression coverage and keep the link-time constant array-size test focused on link-time constants.

* Update cooperative matrix/vector StructuredBuffer paths to pass Slang-typed layout pointers into spirv_asm instead of using OpTypePointer or OpTypeRuntimeArray directly.

* Keep DefaultDataLayout defaults on cooperative matrix/vector StructuredBuffer overloads so existing calls do not need to spell the layout parameter explicitly.

* Update other internal helpers, including image atomics, hit-triangle vertex positions, and work-graph NodePayloadAMDX, to use typed pointers instead of local OpTypePointer declarations.

* Fix NodePayloadAMDX wrapper type emission to pass nullptr when emitting OpTypeNodePayloadArrayAMDX.

* Warn when spirv_asm declares layout-sensitive type instructions directly, and add regression tests for the memoization and internal-helper paths.

Fixes #11008
