### PR TITLE
Support user-defined texture types on LLVM

### DIFF
--- a/docs/llvm-target.md
+++ b/docs/llvm-target.md
@@ -110,10 +110,10 @@ export T.TexelElement llvmTextureLoad<T:ITexture>(
 {
     if (T is RWTexture2D<float4>)
     {
-        CPUTextureType* type = bitcast<MyCPUTextureType*>(T);
+        MyCPUTextureType* type = bit_cast<MyCPUTextureType*>(tex);
         float4 texel = loadFromMyTextureType(type, int2(location[0], location[1]), levelOrSampleIndex);
         // This cast is a no-op, but necessary due to how generic type-checking operates.
-        return (el as T.TexelElement).value;
+        return (texel as T.TexelElement).value;
     }
     return {};
 }

--- a/docs/llvm-target.md
+++ b/docs/llvm-target.md
@@ -73,9 +73,10 @@ will follow those layout rules.
 ### Special type memory layouts
 
 * `StructuredBuffer` and `ByteAddressBuffer` are stored as `{ Type* data; intptr_t size; }`,
-where `size` is the number of elements in `data`.
+  where `size` is the number of elements in `data`.
 
-* `Texture` and `SamplerState` types are stored as opaque pointers.
+* `Texture` and `SamplerState` types are stored as opaque pointers. Combined
+  image samplers (`Sampler2D` etc.) are `{ void* texture; void* sampler; }`.
 
 * Vectors are passed as LLVM vector types; there's no direct equivalent in standard C or C++.
 

--- a/docs/llvm-target.md
+++ b/docs/llvm-target.md
@@ -70,14 +70,64 @@ If you specify a different layout with flags like `-fvk-use-c-layout` or
 `-fvk-use-scalar-layout`, all structure and array types on the stack and heap
 will follow those layout rules.
 
-### Types and resources
+### Special type memory layouts
 
 * `StructuredBuffer` and `ByteAddressBuffer` are stored as `{ Type* data; intptr_t size; }`,
 where `size` is the number of elements in `data`.
 
+* `Texture` and `SamplerState` types are stored as opaque pointers.
+
 * Vectors are passed as LLVM vector types; there's no direct equivalent in standard C or C++.
 
 * Matrix types are lowered into arrays of vectors. Column and row major matrices are supported as normal.
+
+### Textures
+
+In the LLVM target, texture types are fully user-defined and user-implemented,
+but they still use the familiar `RWTexture2D<T>`, `Texture2D<T>`, etc. types and
+their member functions.
+
+The core module treats these types as opaque pointers. It never attempts to
+dereference them in any way, so you can define them as anything as long as it's
+pointer-sized (like `uint2` on a 64-bit target). It is possible to use `bit_cast`
+to convert the texture and sampler types to whatever concrete type.
+
+The core module forward-declares all texture operations, for example:
+
+```slang
+extern T.TexelElement llvmTextureLoad<T:ITexture>(T tex, vector<int, T.coordDimensions> location, int levelOrSampleIndex);
+```
+
+Which the user must then implement if they wish to use the related functionality:
+
+```slang
+// Must be defined in a user module before compiling to IR or object code.
+export T.TexelElement llvmTextureLoad<T:ITexture>(
+    T tex,
+    vector<int, T.coordDimensions> location,
+    int levelOrSampleIndex)
+{
+    if (T is RWTexture2D<float4>)
+    {
+        CPUTextureType* type = bitcast<MyCPUTextureType*>(T);
+        float4 texel = loadFromMyTextureType(type, int2(location[0], location[1]), levelOrSampleIndex);
+        // This cast is a no-op, but necessary due to how generic type-checking operates.
+        return (el as T.TexelElement).value;
+    }
+    return {};
+}
+```
+
+[Check out all `llvmTexture*` functions from the docs](https://docs.shader-slang.org/en/latest/search.html?q=llvmTexture)
+to see what you need to implement to get all texture functionality. You can get
+away with only implementing the functions you need. You can use the `ITexture`
+interface to observe at compile time what kind of texture is being used.
+
+Note that this doesn't mean that you'd actually have to write your texture
+sampling functionality in Slang (although you can if you want to). You can use
+these `llvmTexture*` functions as routers that just call the relevant external
+C functions, forwarding the opaque texture pointers to them. This way, you don't
+need your concrete texture type to be available to Slang at all.
 
 ### Aggregate parameters
 
@@ -100,7 +150,7 @@ In other words, aggregate parameters are turned into pointers and aggregate
 return values are turned into an additional pointer-typed parameter at the end
 of the parameter list.
 
-### C foreign functions
+### FFI / C foreign functions
 
 Due to the aggregate parameter passing limitation of LLVM, calling arbitrary C
 functions from Slang is complicated, and a hypothetical binding generator would
@@ -153,11 +203,10 @@ implement in LLVM. Support for them may be added later.
 
 ### Missing types
 
-* No texture or sampler types.
 * No acceleration structures.
 
-These are missing due to limitation of scope for the initial implementation,
-and may be added later.
+These are missing due to limitation of scope for the implementation, and may be
+added soon.
 
 ## Gotchas
 

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -1120,14 +1120,26 @@ Compound Capabilities
 `cpp_glsl_hlsl_metal_spirv`
 > CPP, GLSL, HLSL, Metal, and SPIRV code-gen targets
 
+`cpp_glsl_hlsl_metal_spirv_llvm`
+> CPP, GLSL, HLSL, Metal, SPIRV, and LLVM code-gen targets
+
 `cpp_glsl_hlsl_metal_spirv_wgsl`
 > CPP, GLSL, HLSL, Metal, SPIRV and WGSL code-gen targets
+
+`cpp_glsl_hlsl_metal_spirv_wgsl_llvm`
+> CPP, GLSL, HLSL, Metal, SPIRV, WGSL and LLVM code-gen targets
 
 `cpp_glsl_hlsl_spirv`
 > CPP, GLSL, HLSL, and SPIRV code-gen targets
 
+`cpp_glsl_hlsl_spirv_llvm`
+> CPP, GLSL, HLSL, SPIRV, and LLVM code-gen targets
+
 `cpp_glsl_hlsl_spirv_wgsl`
 > CPP, GLSL, HLSL, SPIRV and WGSL code-gen targets
+
+`cpp_glsl_hlsl_spirv_wgsl_llvm`
+> CPP, GLSL, HLSL, SPIRV, WGSL, and LLVM code-gen targets
 
 `cpp_hlsl`
 > CPP, and HLSL code-gen targets
@@ -1143,6 +1155,9 @@ Compound Capabilities
 
 `cuda_glsl_hlsl_metal_spirv_wgsl`
 > CUDA, GLSL, HLSL, Metal, SPIRV and WGSL code-gen targets
+
+`cuda_glsl_hlsl_metal_spirv_wgsl_llvm`
+> CUDA, GLSL, HLSL, Metal, SPIRV, WGSL and LLVM code-gen targets
 
 `cuda_glsl_hlsl_spirv`
 > CUDA, GLSL, HLSL, and SPIRV code-gen targets
@@ -1204,8 +1219,14 @@ Compound Capabilities
 `glsl_hlsl_metal_spirv`
 > GLSL, HLSL, Metal, and SPIRV code-gen targets
 
+`glsl_hlsl_metal_spirv_llvm`
+> GLSL, HLSL, Metal, SPIRV, and LLVM code-gen targets
+
 `glsl_hlsl_metal_spirv_wgsl`
 > GLSL, HLSL, Metal, SPIRV and WGSL code-gen targets
+
+`glsl_hlsl_metal_spirv_wgsl_llvm`
+> GLSL, HLSL, Metal, SPIRV, WGSL, and LLVM code-gen targets
 
 `glsl_hlsl_spirv`
 > GLSL, HLSL, and SPIRV code-gen targets
@@ -1230,6 +1251,9 @@ Compound Capabilities
 
 `hlsl_spirv`
 > HLSL, and SPIRV code-gen targets
+
+`hlsl_spirv_llvm`
+> HLSL, SPIRV and LLVM code-gen targets
 
 `image_loadstore`
 > (GLSL/SPIRV) Capabilities required to use image load/image store operations

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -3658,7 +3658,7 @@ public vector<T.Element,4> textureGradOffset(_Texture<
         0, // isShadow
         1, // isCombined
         format
-    > sampler, vector<float,Shape.dimensions+isArray> p, vector<float,Shape.dimensions> dPdx, vector<float,Shape.dimensions> dPdy, constexpr vector<int,Shape.dimensions> offset)
+    > sampler, vector<float,Shape.dimensions+isArray> p, vector<float,Shape.dimensions> dPdx, vector<float,Shape.dimensions> dPdy, constexpr vector<int,Shape.planeDimensions> offset)
 {
     return __vectorReshape2<T.Element,4>(sampler.SampleGrad(p, dPdx, dPdy, offset));
 }

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -631,7 +631,6 @@ interface ITexture
     static const bool isMultisample;
     static const int multisampleCount;
     static const int accessMode;
-    static const bool isDepthTexture;
     static const bool isShadowTexture;
     static const bool isCombinedTextureSampler;
     static const int storageFormat;
@@ -817,8 +816,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,access,isShadow,isCombined,f
     static const bool isMultisample = isMS == 1;
     static const int multisampleCount = sampleCount;
     static const int accessMode = access;
-    static const bool isDepthTexture = isCombined == 0 && isShadow == 1;
-    static const bool isShadowTexture = isCombined == 1 && isShadow == 1;
+    static const bool isShadowTexture = isShadow == 1;
     static const bool isCombinedTextureSampler = isCombined == 1;
     static const int storageFormat = format;
     static const int coordDimensions = Shape.dimensions + isArray;

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -1158,7 +1158,11 @@ void __wgsl_check_texture_type_texel_offset()
 extern T.TexelElement llvmTextureLoad<T:ITexture>(
     T tex,
     vector<int, T.coordDimensions> location,
-    int levelOrSampleIndex);
+    int levelOrSampleIndex)
+{
+    static_assert(false, "You need to export an implementation for llvmTextureLoad to use Load() on LLVM targets!");
+    return {};
+}
 
 /// Declaration of texel writing functionality for the LLVM target, allowing the
 /// user to define this texture operation. This function always writes to LOD
@@ -1175,7 +1179,10 @@ extern void llvmTextureStore<T:ITexture>(
     T tex,
     vector<int, T.coordDimensions> location,
     T.TexelElement newValue,
-    int sampleIndex);
+    int sampleIndex)
+{
+    static_assert(false, "You need to export an implementation for llvmTextureStore to use Store() on LLVM targets!");
+}
 
 
 /// Declaration of texture dimension querying functionality for the LLVM target,
@@ -1200,7 +1207,17 @@ extern void llvmTextureGetDimensions<T:ITexture>(
     out int elements,
     out int depth,
     out int numberOfLevels,
-    out int numberOfSamples);
+    out int numberOfSamples)
+{
+    static_assert(false, "You need to export an implementation for llvmTextureGetDimensions to use GetDimensions() on LLVM targets!");
+    // Silence the warning about these being uninitialized.
+    width = 0;
+    height = 0;
+    elements = 0;
+    depth = 0;
+    numberOfLevels = 0;
+    numberOfSamples = 0;
+}
 
 /// Declaration of texture sampling functionality for the LLVM target,
 /// allowing the user to define this texture operation. This variant takes an
@@ -1221,7 +1238,11 @@ extern T.TexelElement llvmTextureSampleLevel<T:ITexture>(
     SamplerState sam,
     vector<float, T.coordDimensions> location,
     float level,
-    vector<int, T.offsetDimensions> offset);
+    vector<int, T.offsetDimensions> offset)
+{
+    static_assert(false, "You need to export an implementation for llvmTextureSampleLevel to use SampleLevel*() on LLVM targets!");
+    return {};
+}
 
 /// Declaration of texture sampling functionality for the LLVM target,
 /// allowing the user to define this texture operation. This variant takes
@@ -1249,7 +1270,11 @@ extern T.TexelElement llvmTextureSampleGrad<T:ITexture>(
     vector<float, T.gradDimensions> gradY,
     vector<int, T.offsetDimensions> offset,
     float bias,
-    float lodClamp);
+    float lodClamp)
+{
+    static_assert(false, "You need to export an implementation for llvmTextureSampleGrad to use Sample*() on LLVM targets!");
+    return {};
+}
 
 /// Declaration of texture compare sampling functionality for the LLVM target,
 /// allowing the user to define this texture operation. This variant takes an
@@ -1272,7 +1297,11 @@ extern float llvmTextureSampleCmpLevel<T:ITexture>(
     vector<float, T.coordDimensions> location,
     float compareValue,
     float level,
-    vector<int, T.offsetDimensions> offset);
+    vector<int, T.offsetDimensions> offset)
+{
+    static_assert(false, "You need to export an implementation for llvmTextureSampleCmpLevel to use SampleCmpLevel*() on LLVM targets!");
+    return 0.0;
+}
 
 /// Declaration of texture compare functionality for the LLVM target,
 /// allowing the user to define this texture operation. This variant takes
@@ -1302,7 +1331,11 @@ extern float llvmTextureSampleCmpGrad<T:ITexture>(
     vector<float, T.gradDimensions> gradY,
     vector<int, T.offsetDimensions> offset,
     float bias,
-    float lodClamp);
+    float lodClamp)
+{
+    static_assert(false, "You need to export an implementation for llvmTextureSampleCmpGrad to use SampleCmp*() on LLVM targets!");
+    return 0.0;
+}
 
 /// Declaration of texture gather functionality for the LLVM target,
 /// allowing the user to define this texture operation.
@@ -1321,7 +1354,11 @@ extern vector<T.TexelElement.Element, 4> llvmTextureGather<T:ITexture, let Chann
     T tex,
     SamplerState sam,
     vector<float, T.coordDimensions> location,
-    vector<int, T.offsetDimensions> offset);
+    vector<int, T.offsetDimensions> offset)
+{
+    static_assert(false, "You need to export an implementation for llvmTextureGather to use Gather*() on LLVM targets!");
+    return {};
+}
 
 /// Declaration of texture gather functionality for the LLVM target,
 /// allowing the user to define this texture operation.
@@ -1342,7 +1379,11 @@ extern vector<T.TexelElement.Element, 4> llvmTextureGatherCmp<T:ITexture, let Ch
     SamplerComparisonState sam,
     vector<float, T.coordDimensions> location,
     T.TexelElement.Element compareValue,
-    vector<int, T.offsetDimensions> offset);
+    vector<int, T.offsetDimensions> offset)
+{
+    static_assert(false, "You need to export an implementation for llvmTextureGatherCmp to use GatherCmp*() on LLVM targets!");
+    return {};
+}
 
 //@public:
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -618,6 +618,28 @@ extension vector<int64_t,2>:ITexelElement
     __intrinsic_op($(kIROp_MakeVectorFromScalar)) __init(Element x);
 }
 
+
+//@public:
+// All texture types implement this interface.
+[sealed]
+[builtin]
+interface ITexture
+{
+    associatedtype TexelElement : ITexelElement;
+    associatedtype TextureShape : __ITextureShape;
+    static const bool isArrayTexture;
+    static const bool isMultisample;
+    static const int multisampleCount;
+    static const int accessMode;
+    static const bool isDepthTexture;
+    static const bool isShadowTexture;
+    static const bool isCombinedTextureSampler;
+    static const int storageFormat;
+    static const int coordDimensions;
+    static const int gradDimensions;
+    static const int offsetDimensions;
+}
+
 //@public:
 /// A parameterized type that represents all flavors of texture types supported by the Slang language.
 /// Please note that this type is not intended to be used directly in user code, and not all combinations
@@ -786,6 +808,26 @@ struct _Texture<T:ITexelElement, Shape: __ITextureShape, let isArray:int, let is
 }
 
 //@hidden:
+__generic<T:ITexelElement, Shape: __ITextureShape, let isArray:int, let isMS:int, let sampleCount:int, let access:int, let isShadow:int, let isCombined:int, let format:int>
+extension _Texture<T,Shape,isArray,isMS,sampleCount,access,isShadow,isCombined,format> : ITexture
+{
+    typealias TexelElement = T;
+    typealias TextureShape = Shape;
+    typealias CoordType = vector<float, Shape.dimensions + isArray>;
+    typealias GradientType = vector<float, Shape.dimensions>;
+    typealias OffsetType = vector<int, Shape.planeDimensions>;
+    static const bool isArrayTexture = isArray == 1;
+    static const bool isMultisample = isMS == 1;
+    static const int multisampleCount = sampleCount;
+    static const int accessMode = access;
+    static const bool isDepthTexture = isCombined == 0 && isShadow == 1;
+    static const bool isShadowTexture = isCombined == 1 && isShadow == 1;
+    static const bool isCombinedTextureSampler = isCombined == 1;
+    static const int storageFormat = format;
+    static const int coordDimensions = Shape.dimensions + isArray;
+    static const int gradDimensions = Shape.dimensions;
+    static const int offsetDimensions = Shape.planeDimensions;
+}
 
 // Returns true when the stage supports implicit derivatives on the
 // target. This must match with capability `implicit_derivatives_sampling`.
@@ -1103,6 +1145,206 @@ void __wgsl_check_texture_type_texel_offset()
 }
 
 //@public:
+/// Declaration of texel reading functionality for the LLVM target, allowing the
+/// user to define this texture operation.
+///
+/// @param T Texture type.
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param location Texel coordinate. If this is an array texture, the last coordinate is the array index.
+/// @param levelOrSampleIndex If `T.isMultisample`, this is the sample index. Otherwise, it is the LOD level.
+/// @return The fetched texel.
+[ForceInline]
+[require(llvm)]
+extern T.TexelElement llvmTextureLoad<T:ITexture>(
+    T tex,
+    vector<int, T.coordDimensions> location,
+    int levelOrSampleIndex);
+
+/// Declaration of texel writing functionality for the LLVM target, allowing the
+/// user to define this texture operation. This function always writes to LOD
+/// level 0.
+///
+/// @param T Texture type.
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param location Texel coordinate. If this is an array texture, the last coordinate is the array index.
+/// @param newValue New value to write to the texel.
+/// @param sampleIndex Sample index in multisample textures. Ignore it if `!T.isMultisample`.
+[ForceInline]
+[require(llvm)]
+extern void llvmTextureStore<T:ITexture>(
+    T tex,
+    vector<int, T.coordDimensions> location,
+    T.TexelElement newValue,
+    int sampleIndex);
+
+
+/// Declaration of texture dimension querying functionality for the LLVM target,
+/// allowing the user to define this texture operation.
+///
+/// @param T Texture type.
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param mipLevel The LOD level to query the sizes for.
+/// @param width Width of the texture, in texels.
+/// @param height Height of the texture, in texels. Unused if the texture is 1D.
+/// @param elements Number of array elements in the texture. Unused if the texture is not an array.
+/// @param depth Depth of the texture. Unused if the texture is not 3D.
+/// @param numberOfLevels Number of LOD levels in the texture.
+/// @param numberOfSamples Number of Multisample samples in the texture.
+[ForceInline]
+[require(llvm)]
+extern void llvmTextureGetDimensions<T:ITexture>(
+    T tex,
+    int mipLevel,
+    out int width,
+    out int height,
+    out int elements,
+    out int depth,
+    out int numberOfLevels,
+    out int numberOfSamples);
+
+/// Declaration of texture sampling functionality for the LLVM target,
+/// allowing the user to define this texture operation. This variant takes an
+/// explicit LOD level.
+///
+/// @param T Texture type.
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param sam Sampler that can be converted into an arbitrary pointer type with `bit_cast`.
+///            May be a null pointer if `T.isCombinedTextureSampler`.
+/// @param location Texture coordinate. If this is an array texture, the last coordinate is the array index.
+/// @param level The LOD level to sample from.
+/// @param offset An integer offset applied to the resolved texel coordinates.
+/// @return The sampled texel value.
+[ForceInline]
+[require(llvm)]
+extern T.TexelElement llvmTextureSampleLevel<T:ITexture>(
+    T tex,
+    SamplerState sam,
+    vector<float, T.coordDimensions> location,
+    float level,
+    vector<int, T.offsetDimensions> offset);
+
+/// Declaration of texture sampling functionality for the LLVM target,
+/// allowing the user to define this texture operation. This variant takes
+/// texture coordinate gradients, allowing for anisotropic filtering and
+/// automatic LOD level computation.
+///
+/// @param T Texture type.
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param sam Sampler that can be converted into an arbitrary pointer type with `bit_cast`.
+///            May be a null pointer if `T.isCombinedTextureSampler`.
+/// @param location Texture coordinate. If this is an array texture, the last coordinate is the array index.
+/// @param gradX Texture gradient on the X axis
+/// @param gradY Texture gradient on the Y axis
+/// @param offset An integer offset applied to the resolved texel coordinates.
+/// @param bias LOD bias, added to the selected LOD level.
+/// @param lodClamp The selected LOD level must be greater than or equal to this value.
+/// @return The sampled texel value.
+[ForceInline]
+[require(llvm)]
+extern T.TexelElement llvmTextureSampleGrad<T:ITexture>(
+    T tex,
+    SamplerState sam,
+    vector<float, T.coordDimensions> location,
+    vector<float, T.gradDimensions> gradX,
+    vector<float, T.gradDimensions> gradY,
+    vector<int, T.offsetDimensions> offset,
+    float bias,
+    float lodClamp);
+
+/// Declaration of texture compare sampling functionality for the LLVM target,
+/// allowing the user to define this texture operation. This variant takes an
+/// explicit LOD level.
+///
+/// @param T Texture type.
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param sam Sampler that can be converted into an arbitrary pointer type with `bit_cast`.
+///            May be a null pointer if `T.isCombinedTextureSampler`.
+/// @param location Texture coordinate. If this is an array texture, the last coordinate is the array index.
+/// @param compareValue The value to compare to.
+/// @param level The LOD level to sample from.
+/// @param offset An integer offset applied to the resolved texel coordinates.
+/// @return A value between 0 and 1.
+[ForceInline]
+[require(llvm)]
+extern float llvmTextureSampleCmpLevel<T:ITexture>(
+    T tex,
+    SamplerComparisonState sam,
+    vector<float, T.coordDimensions> location,
+    float compareValue,
+    float level,
+    vector<int, T.offsetDimensions> offset);
+
+/// Declaration of texture compare functionality for the LLVM target,
+/// allowing the user to define this texture operation. This variant takes
+/// texture coordinate gradients, allowing for anisotropic filtering and
+/// automatic LOD level computation.
+///
+/// @param T Texture type.
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param sam Sampler that can be converted into an arbitrary pointer type with `bit_cast`.
+///            May be a null pointer if `T.isCombinedTextureSampler`.
+/// @param location Texture coordinate. If this is an array texture, the last coordinate is the array index.
+/// @param compareValue The value to compare to.
+/// @param gradX Texture gradient on the X axis
+/// @param gradY Texture gradient on the Y axis
+/// @param offset An integer offset applied to the resolved texel coordinates.
+/// @param bias LOD bias, added to the selected LOD level.
+/// @param lodClamp The selected LOD level must be greater than or equal to this value.
+/// @return A value between 0 and 1.
+[ForceInline]
+[require(llvm)]
+extern float llvmTextureSampleCmpGrad<T:ITexture>(
+    T tex,
+    SamplerComparisonState sam,
+    vector<float, T.coordDimensions> location,
+    float compareValue,
+    vector<float, T.gradDimensions> gradX,
+    vector<float, T.gradDimensions> gradY,
+    vector<int, T.offsetDimensions> offset,
+    float bias,
+    float lodClamp);
+
+/// Declaration of texture gather functionality for the LLVM target,
+/// allowing the user to define this texture operation.
+///
+/// @param T Texture type.
+/// @param Channel Channel index to gather from.
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param sam Sampler that can be converted into an arbitrary pointer type with `bit_cast`.
+///            May be a null pointer if `T.isCombinedTextureSampler`.
+/// @param location Texture coordinate. If this is an array texture, the last coordinate is the array index.
+/// @param offset An integer offset applied to the resolved texel coordinates.
+/// @return The four gathered values.
+[ForceInline]
+[require(llvm)]
+extern vector<T.TexelElement.Element, 4> llvmTextureGather<T:ITexture, let Channel:int>(
+    T tex,
+    SamplerState sam,
+    vector<float, T.coordDimensions> location,
+    vector<int, T.offsetDimensions> offset);
+
+/// Declaration of texture gather functionality for the LLVM target,
+/// allowing the user to define this texture operation.
+///
+/// @param T Texture type.
+/// @param Channel Channel index to gather from.
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param sam Sampler that can be converted into an arbitrary pointer type with `bit_cast`.
+///            May be a null pointer if `T.isCombinedTextureSampler`.
+/// @param location Texture coordinate. If this is an array texture, the last coordinate is the array index.
+/// @param compareValue The value to compare to.
+/// @param offset An integer offset applied to the resolved texel coordinates.
+/// @return The four gathered values, between 0 and 1.
+[ForceInline]
+[require(llvm)]
+extern vector<T.TexelElement.Element, 4> llvmTextureGatherCmp<T:ITexture, let Channel:int>(
+    T tex,
+    SamplerComparisonState sam,
+    vector<float, T.coordDimensions> location,
+    T.TexelElement.Element compareValue,
+    vector<int, T.offsetDimensions> offset);
+
+//@public:
 
 __generic<T:ITexelElement, Shape: __ITextureShape, let isArray:int, let isMS:int, let sampleCount:int, let isShadow:int, let format:int>
 extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
@@ -1210,7 +1452,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     ///@see `SampleBias`, `SampleLevel`, `SampleLevelZero`, `SampleGrad`, `SampleCmp`, `SampleCmpLevelZero`, `SampleCmpLevel`, `SampleCmpBias`, `SampleCmpGrad`.
     [__readNone]
     [ForceInline]
-    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
+    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0_fragment)]
     T Sample(vector<float, Shape.dimensions+isArray> location)
     {
         __requireComputeDerivative();
@@ -1223,6 +1465,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 return __getTexture().Sample(__getSampler(), location);
             case cpp:
             case metal:
+            case llvm:
                 return __getTexture().Sample(__getSampler(), location);
             case glsl:
                 __intrinsic_asm "$ctexture($0, $1)$z";
@@ -1268,7 +1511,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0_fragment)]
     T Sample(vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __requireComputeDerivative();
@@ -1281,6 +1524,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 return __getTexture().Sample(__getSampler(), location, offset);
             case cpp:
             case metal:
+            case llvm:
                 return __getTexture().Sample(__getSampler(), location, offset);
             case glsl:
                 __intrinsic_asm "$ctextureOffsetClampARB($0, $1, $2)$z";
@@ -1299,7 +1543,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     [__readNone]
     [ForceInline]
     __glsl_extension(GL_ARB_sparse_texture_clamp)
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_clamp_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv_llvm, texture_sm_4_1_clamp_fragment)]
     T Sample(vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset, float clamp)
     {
         __requireComputeDerivative();
@@ -1312,6 +1556,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 return __getTexture().Sample(__getSampler(), location, offset, clamp);
             case cpp:
             case metal:
+            case llvm:
                 return __getTexture().Sample(__getSampler(), location, offset, clamp);
             case glsl:
                 __intrinsic_asm "$ctextureOffsetClampARB($0, $1, $2, $3)$z";
@@ -1359,7 +1604,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0_fragment)]
     T SampleBias(vector<float, Shape.dimensions+isArray> location, float bias)
     {
         __requireComputeDerivative();
@@ -1372,6 +1617,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 return __getTexture().SampleBias(__getSampler(), location, bias);
             case cpp:
             case metal:
+            case llvm:
                 return __getTexture().SampleBias(__getSampler(), location, bias);
             case glsl:
                 __intrinsic_asm "$ctexture($0, $1, $2)$z";
@@ -1389,7 +1635,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0_fragment)]
     T SampleBias(vector<float, Shape.dimensions+isArray> location, float bias, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __requireComputeDerivative();
@@ -1402,6 +1648,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 return __getTexture().SampleBias(__getSampler(), location, bias, offset);
             case cpp:
             case metal:
+            case llvm:
                 return __getTexture().SampleBias(__getSampler(), location, bias, offset);
             case glsl:
                 __intrinsic_asm "$ctextureOffset($0, $1, $3, $2)$z";
@@ -1447,7 +1694,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_wgsl_llvm, texture_shadowlod)]
     float SampleCmp(vector<float, Shape.dimensions+isArray> location, float compareValue)
     {
         __requireComputeDerivative();
@@ -1472,6 +1719,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 , "HLSL supports only float and half type textures");
             return __getTexture().SampleCmp(__getComparisonSampler(), location, compareValue);
         case metal:
+        case llvm:
             return __getTexture().SampleCmp(__getComparisonSampler(), location, compareValue);
         case spirv:
             return spirv_asm
@@ -1485,7 +1733,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_wgsl_llvm, texture_shadowlod)]
     float SampleCmpLevelZero(vector<float, Shape.dimensions+isArray> location, float compareValue)
     {
         __target_switch
@@ -1525,7 +1773,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_wgsl_llvm, texture_shadowlod)]
     float SampleCmp(vector<float, Shape.dimensions+isArray> location, float compareValue, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __requireComputeDerivative();
@@ -1546,6 +1794,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 , "HLSL supports only float and half type textures");
             return __getTexture().SampleCmp(__getComparisonSampler(), location, compareValue, offset);
         case metal:
+        case llvm:
             return __getTexture().SampleCmp(__getComparisonSampler(), location, compareValue, offset);
         case spirv:
             return spirv_asm
@@ -1589,7 +1838,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_wgsl_llvm, texture_shadowlod)]
     float SampleCmpLevelZero(vector<float, Shape.dimensions+isArray> location, float compareValue, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -1641,7 +1890,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv, texture_sm_4_1)]
+    [require(glsl_hlsl_metal_spirv_llvm, texture_sm_4_1)]
     float SampleCmpLevel(vector<float, Shape.dimensions+isArray> location, float compareValue, float level)
     {
         __target_switch
@@ -1689,6 +1938,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 , "HLSL supports only float and half type textures");
             return __getTexture().SampleCmpLevel(__getComparisonSampler(), location, compareValue, level);
         case metal:
+        case llvm:
             return __getTexture().SampleCmpLevel(__getComparisonSampler(), location, compareValue, level);
         case spirv:
             return spirv_asm
@@ -1700,7 +1950,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_llvm, texture_shadowlod)]
     float SampleCmpLevel(vector<float, Shape.dimensions+isArray> location, float compareValue, float level, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -1720,6 +1970,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 , "HLSL supports only float and half type textures");
             return __getTexture().SampleCmpLevel(__getComparisonSampler(), location, compareValue, level, offset);
         case metal:
+        case llvm:
             return __getTexture().SampleCmpLevel(__getComparisonSampler(), location, compareValue, level, offset);
         case spirv:
             return spirv_asm
@@ -1758,7 +2009,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(hlsl_spirv, texture_shadowgrad)]
+    [require(hlsl_spirv_llvm, texture_shadowgrad)]
     float SampleCmpGrad(vector<float, Shape.dimensions+isArray> location, float compareValue, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY)
     {
         static_assert(!(Shape is __ShapeCube && isArray != 0), "SampleCmpGrad is not supported for TextureCubeArray");
@@ -1774,12 +2025,14 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
             {
                 result:$$float = OpImageSampleDrefExplicitLod $this $location $compareValue Grad $gradX $gradY;
             };
+        case llvm:
+            return __getTexture().SampleCmpGrad(__getComparisonSampler(), location, compareValue, gradX, gradY);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(hlsl_spirv, texture_shadowgrad)]
+    [require(hlsl_spirv_llvm, texture_shadowgrad)]
     float SampleCmpGrad(vector<float, Shape.dimensions+isArray> location, float compareValue, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.planeDimensions> offset)
     {
         static_assert(!(Shape is __ShapeCube && isArray != 0), "SampleCmpGrad is not supported for TextureCubeArray");
@@ -1796,6 +2049,8 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
             {
                 result:$$float = OpImageSampleDrefExplicitLod $this $location $compareValue Grad|ConstOffset $gradX $gradY $offset;
             };
+        case llvm:
+            return __getTexture().SampleCmpGrad(__getComparisonSampler(), location, compareValue, gradX, gradY, offset);
         }
     }
 
@@ -1830,7 +2085,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(hlsl_spirv, texture_shadowgrad)]
+    [require(hlsl_spirv_llvm, texture_shadowgrad)]
     float SampleCmpBias(vector<float, Shape.dimensions+isArray> location, float compareValue, float bias)
     {
         __requireComputeDerivative();
@@ -1846,12 +2101,14 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
             {
                 result:$$float = OpImageSampleDrefImplicitLod $this $location $compareValue Bias $bias;
             };
+        case llvm:
+            return __getTexture().SampleCmpBias(__getComparisonSampler(), location, compareValue, bias);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(hlsl_spirv, texture_shadowgrad)]
+    [require(hlsl_spirv_llvm, texture_shadowgrad)]
     float SampleCmpBias(vector<float, Shape.dimensions+isArray> location, float compareValue, float bias, constexpr vector<int, Shape.planeDimensions> offset)
     {
         static_assert(!(Shape is __ShapeCube), "SampleCmpBias with offset is not supported for TextureCube or TextureCubeArray");
@@ -1868,6 +2125,8 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
             {
                 result:$$float = OpImageSampleDrefImplicitLod $this $location $compareValue Bias|ConstOffset $bias $offset;
             };
+        case llvm:
+            return __getTexture().SampleCmpBias(__getComparisonSampler(), location, compareValue, bias, offset);
         }
     }
 
@@ -1902,7 +2161,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0)]
     T SampleGrad(vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY)
     {
         __target_switch
@@ -1914,6 +2173,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY);
             case cpp:
             case metal:
+            case llvm:
                 return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY);
             case glsl:
                 __intrinsic_asm "$ctextureGrad($0, $1, $2, $3)$z";
@@ -1930,8 +2190,8 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
-    T SampleGrad(vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.dimensions> offset)
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0)]
+    T SampleGrad(vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
         {
@@ -1942,6 +2202,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY, offset);
             case cpp:
             case metal:
+            case llvm:
                 return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY, offset);
             case glsl:
                 __intrinsic_asm "$ctextureGradOffset($0, $1, $2, $3, $4)$z";
@@ -1959,8 +2220,8 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     [__readNone]
     [ForceInline]
     __glsl_extension(GL_ARB_sparse_texture_clamp)
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_1_clamp_fragment)]
-    T SampleGrad(vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.dimensions> offset, float lodClamp)
+    [require(cpp_glsl_hlsl_metal_spirv_llvm, texture_sm_4_1_clamp_fragment)]
+    T SampleGrad(vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.planeDimensions> offset, float lodClamp)
     {
         __target_switch
         {
@@ -1971,6 +2232,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY, offset, lodClamp);
             case cpp:
             case metal:
+            case llvm:
                 return __getTexture().SampleGrad(__getSampler(), location, gradX, gradY, offset, lodClamp);
             case glsl:
             __intrinsic_asm "$ctextureGradOffsetClampARB($0, $1, $2, $3, $4, $5)$z";
@@ -1987,7 +2249,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     [__readNone]
     [ForceInline]
     [require(hlsl_spirv, sm_5_0)]
-    T SampleGrad(vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.dimensions> offset, float lodClamp, out uint status)
+    T SampleGrad(vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.planeDimensions> offset, float lodClamp, out uint status)
     {
         __target_switch
         {
@@ -2015,7 +2277,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
+    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0)]
     T SampleLevel(vector<float, Shape.dimensions+isArray> location, float level)
     {
         __target_switch
@@ -2027,6 +2289,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 return __getTexture().SampleLevel(__getSampler(), location, level);
             case cpp:
             case metal:
+            case llvm:
                 return __getTexture().SampleLevel(__getSampler(), location, level);
             case glsl:
                 __intrinsic_asm "$ctextureLod($0, $1, $2)$z";
@@ -2074,7 +2337,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0)]
     T SampleLevel(vector<float, Shape.dimensions+isArray> location, float level, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -2086,6 +2349,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
                 return __getTexture().SampleLevel(__getSampler(), location, level, offset);
             case cpp:
             case metal:
+            case llvm:
                 return __getTexture().SampleLevel(__getSampler(), location, level, offset);
             case glsl:
                 __intrinsic_asm "$ctextureLodOffset($0, $1, $2, $3)$z";
@@ -2148,7 +2412,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
     ///@see `Sample`, `SampleBias`, `SampleLevel`, `SampleGrad`, `SampleCmp`, `SampleCmpLevelZero`, `SampleCmpLevel`, `GL_NV_compute_shader_derivatives`.
     [__readNone]
     [ForceInline]
-    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
+    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0)]
     T SampleLevelZero(vector<float, Shape.dimensions+isArray> location)
     {
         __target_switch
@@ -2167,7 +2431,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0)]
     T SampleLevelZero(vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -2393,7 +2657,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
     //@public:
     [__readNone]
     [ForceInline]
-    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
+    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0_fragment)]
     T Sample(SamplerState s, vector<float, Shape.dimensions+isArray> location)
     {
         __requireComputeDerivative();
@@ -2490,13 +2754,24 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     }
                 }
                 __intrinsic_asm "textureSample($0, $1, $2)$z";
+            case llvm:
+                // TODO: This should ideally use ddx & ddy for the gradients,
+                // but we can't implement those yet in the current state of the
+                // LLVM emitter. Which is why they're hardcoded as zero here :/
+                return llvmTextureSampleGrad(
+                    this, s, location, 
+                    vector<float, Shape.dimensions>(0.0),
+                    vector<float, Shape.dimensions>(0.0),
+                    vector<int, Shape.planeDimensions>(0),
+                    0.0f,
+                    0.0f);
         }
     }
 
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0_fragment)]
     T Sample(SamplerState s, vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __requireComputeDerivative();
@@ -2553,13 +2828,19 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     }
                 }
                 __intrinsic_asm "textureSample($0, $1, $2, $3)$z";
+            case llvm:
+                return llvmTextureSampleGrad(
+                    this, s, location, 
+                    vector<float, Shape.dimensions>(0.0),
+                    vector<float, Shape.dimensions>(0.0),
+                    offset, 0.0f, 0.0f);
         }
     }
 
     [__readNone]
     [ForceInline]
     __glsl_extension(GL_ARB_sparse_texture_clamp)
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv_llvm, texture_sm_4_0_fragment)]
     T Sample(SamplerState s, vector<float, Shape.dimensions+isArray> location, constexpr vector<int, Shape.planeDimensions> offset, float clamp)
     {
         __requireComputeDerivative();
@@ -2602,6 +2883,12 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     %sampled : __sampledType(T) = OpImageSampleImplicitLod %sampledImage $location None|ConstOffset|MinLod $offset $clamp;
                     __truncate $$T result __sampledType(T) %sampled;
                 };
+            case llvm:
+                return llvmTextureSampleGrad(
+                    this, s, location, 
+                    vector<float, Shape.dimensions>(0.0),
+                    vector<float, Shape.dimensions>(0.0),
+                    offset, 0.0f, clamp);
         }
     }
 
@@ -2640,7 +2927,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0_fragment)]
     T SampleBias(SamplerState s, vector<float, Shape.dimensions+isArray> location, float bias)
     {
         __requireComputeDerivative();
@@ -2701,12 +2988,19 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     }
                 }
                 __intrinsic_asm "textureSampleBias($0, $1, $2, $3)$z";
+            case llvm:
+                return llvmTextureSampleGrad(
+                    this, s, location, 
+                    vector<float, Shape.dimensions>(0.0),
+                    vector<float, Shape.dimensions>(0.0),
+                    vector<int, Shape.planeDimensions>(0),
+                    bias, 0.0f);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0_fragment)]
     T SampleBias(SamplerState s, vector<float, Shape.dimensions+isArray> location, float bias, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __requireComputeDerivative();
@@ -2762,6 +3056,12 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     }
                 }
                 __intrinsic_asm "textureSampleBias($0, $1, $2, $3, $4)$z";
+            case llvm:
+                return llvmTextureSampleGrad(
+                    this, s, location, 
+                    vector<float, Shape.dimensions>(0.0),
+                    vector<float, Shape.dimensions>(0.0),
+                    offset, bias, 0.0f);
         }
     }
 
@@ -2798,7 +3098,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_wgsl_llvm, texture_shadowlod)]
     float SampleCmp(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue)
     {
         __requireComputeDerivative();
@@ -2846,12 +3146,18 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 }
             }
             __intrinsic_asm "textureSampleCompare($0, $1, $2, $3)";
+        case llvm:
+            return llvmTextureSampleCmpGrad(
+                this, s, location, compareValue,
+                vector<float, Shape.dimensions>(0.0),
+                vector<float, Shape.dimensions>(0.0),
+                vector<int, Shape.planeDimensions>(0), 0.0f, 0.0f);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_wgsl_llvm, texture_shadowlod)]
     float SampleCmpLevelZero(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue)
     {
         __target_switch
@@ -2884,7 +3190,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_wgsl_llvm, texture_shadowlod)]
     float SampleCmp(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __requireComputeDerivative();
@@ -2926,6 +3232,12 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 }
             }
             __intrinsic_asm "textureSampleCompare($0, $1, $2, $3, $4)";
+        case llvm:
+            return llvmTextureSampleCmpGrad(
+                this, s, location, compareValue,
+                vector<float, Shape.dimensions>(0.0),
+                vector<float, Shape.dimensions>(0.0),
+                offset, 0.0f, 0.0f);
         }
     }
 
@@ -2961,7 +3273,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv_wgsl, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_wgsl_llvm, texture_shadowlod)]
     float SampleCmpLevelZero(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -3009,7 +3321,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_llvm, texture_shadowlod)]
     float SampleCmpLevel(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue, float level)
     {
         __target_switch
@@ -3063,12 +3375,16 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
                 result:$$float = OpImageSampleDrefExplicitLod %sampledImage $location $compareValue Lod $level;
             };
+        case llvm:
+            return llvmTextureSampleCmpLevel(
+                this, s, location, compareValue, level,
+                vector<int, Shape.planeDimensions>(0));
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv_llvm, texture_shadowlod)]
     float SampleCmpLevel(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue, float level, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -3095,6 +3411,8 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
                 result:$$float = OpImageSampleDrefExplicitLod %sampledImage $location $compareValue Lod|ConstOffset $level $offset;
             };
+        case llvm:
+            return llvmTextureSampleCmpLevel(this, s, location, compareValue, level, offset);
         }
     }
 
@@ -3128,7 +3446,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(hlsl_spirv, texture_shadowgrad)]
+    [require(hlsl_spirv_llvm, texture_shadowgrad)]
     float SampleCmpGrad(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY)
     {
         static_assert(!(Shape is __ShapeCube && isArray != 0), "SampleCmpGrad is not supported for TextureCubeArray");
@@ -3145,12 +3463,16 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
                 result:$$float = OpImageSampleDrefExplicitLod %sampledImage $location $compareValue Grad $gradX $gradY;
             };
+        case llvm:
+            return llvmTextureSampleCmpGrad(
+                this, s, location, compareValue, gradX, gradY,
+                vector<int, Shape.planeDimensions>(0), 0.0f, 0.0f);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(hlsl_spirv, texture_shadowgrad)]
+    [require(hlsl_spirv_llvm, texture_shadowgrad)]
     float SampleCmpGrad(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.planeDimensions> offset)
     {
         static_assert(!(Shape is __ShapeCube && isArray != 0), "SampleCmpGrad is not supported for TextureCubeArray");
@@ -3168,6 +3490,8 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
                 result:$$float = OpImageSampleDrefExplicitLod %sampledImage $location $compareValue Grad|ConstOffset $gradX $gradY $offset;
             };
+        case llvm:
+            return llvmTextureSampleCmpGrad(this, s, location, compareValue, gradX, gradY, offset, 0.0f, 0.0f);
         }
     }
 
@@ -3203,7 +3527,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(hlsl_spirv, texture_shadowgrad)]
+    [require(hlsl_spirv_llvm, texture_shadowgrad)]
     float SampleCmpBias(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue, float bias)
     {
         __requireComputeDerivative();
@@ -3220,12 +3544,19 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
                 result:$$float = OpImageSampleDrefImplicitLod %sampledImage $location $compareValue Bias $bias;
             };
+        case llvm:
+            return llvmTextureSampleCmpGrad(
+                this, s, location, compareValue,
+                vector<float, Shape.dimensions>(0.0),
+                vector<float, Shape.dimensions>(0.0),
+                vector<int, Shape.planeDimensions>(0),
+                bias, 0.0f);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(hlsl_spirv, texture_shadowgrad)]
+    [require(hlsl_spirv_llvm, texture_shadowgrad)]
     float SampleCmpBias(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue, float bias, constexpr vector<int, Shape.planeDimensions> offset)
     {
         static_assert(!(Shape is __ShapeCube), "SampleCmpBias with offset is not supported for TextureCube or TextureCubeArray");
@@ -3243,6 +3574,12 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                 %sampledImage : __sampledImageType(this) = OpSampledImage $this $s;
                 result:$$float = OpImageSampleDrefImplicitLod %sampledImage $location $compareValue Bias|ConstOffset $bias $offset;
             };
+        case llvm:
+            return llvmTextureSampleCmpGrad(
+                this, s, location, compareValue,
+                vector<float, Shape.dimensions>(0.0),
+                vector<float, Shape.dimensions>(0.0),
+                offset, bias, 0.0f);
         }
     }
 
@@ -3278,7 +3615,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0)]
     T SampleGrad(SamplerState s, vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY)
     {
         __target_switch
@@ -3340,13 +3677,15 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     }
                 }
                 __intrinsic_asm "textureSampleGrad($0, $1, $2, $3, $4)$z";
+            case llvm:
+                return llvmTextureSampleGrad(this, s, location, gradX, gradY, vector<int, Shape.planeDimensions>(0), 0.0f, 0.0f);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
-    T SampleGrad(SamplerState s, vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.dimensions> offset)
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0)]
+    T SampleGrad(SamplerState s, vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
         {
@@ -3402,14 +3741,16 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     }
                 }
                 __intrinsic_asm "textureSampleGrad($0, $1, $2, $3, $4, $5)$z";
+            case llvm:
+                return llvmTextureSampleGrad(this, s, location, gradX, gradY, offset, 0.0f, 0.0f);
         }
     }
 
     [__readNone]
     [ForceInline]
     __glsl_extension(GL_ARB_sparse_texture_clamp)
-    [require(cpp_glsl_hlsl_metal_spirv, texture_sm_4_0)]
-    T SampleGrad(SamplerState s, vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.dimensions> offset, float lodClamp)
+    [require(cpp_glsl_hlsl_metal_spirv_llvm, texture_sm_4_0)]
+    T SampleGrad(SamplerState s, vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.planeDimensions> offset, float lodClamp)
     {
         __target_switch
         {
@@ -3451,13 +3792,15 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     %sampled : __sampledType(T) = OpImageSampleExplicitLod %sampledImage $location None|Grad|ConstOffset|MinLod $gradX $gradY $offset $lodClamp;
                     __truncate $$T result __sampledType(T) %sampled;
                 };
+            case llvm:
+                return llvmTextureSampleGrad(this, s, location, gradX, gradY, offset, 0.0f, lodClamp);
         }
     }
 
     [__readNone]
     [ForceInline]
     [require(hlsl_spirv, sm_5_0)]
-    T SampleGrad(SamplerState s, vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.dimensions> offset, float lodClamp, out uint status)
+    T SampleGrad(SamplerState s, vector<float, Shape.dimensions+isArray> location, vector<float, Shape.dimensions> gradX, vector<float, Shape.dimensions> gradY, constexpr vector<int, Shape.planeDimensions> offset, float lodClamp, out uint status)
     {
         __target_switch
         {
@@ -3486,7 +3829,7 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
+    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0)]
     T SampleLevel(SamplerState s, vector<float, Shape.dimensions+isArray> location, float level)
     {
         __target_switch
@@ -3581,12 +3924,14 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     }
                 }
                 __intrinsic_asm "textureSampleLevel($0, $1, $2, $3)$z";
+            case llvm:
+                return llvmTextureSampleLevel(this, s, location, level, vector<int, Shape.planeDimensions>(0));
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_0)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_0)]
     T SampleLevel(SamplerState s, vector<float, Shape.dimensions+isArray> location, float level, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -3643,6 +3988,8 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
                     }
                 }
                 __intrinsic_asm "textureSampleLevel($0, $1, $2, $3, $4)$z";
+            case llvm:
+                return llvmTextureSampleLevel(this, s, location, level, offset);
         }
     }
 
@@ -4190,7 +4537,7 @@ ${
         const char* componentArg = (isShadow ? "" : componentArgString[componentId]);
 $}
     [ForceInline]
-    [require(cuda_glsl_hlsl_metal_spirv_wgsl, texture_gather)]
+    [require(cuda_glsl_hlsl_metal_spirv_wgsl_llvm, texture_gather)]
     vector<T.Element,4> Gather$(compareFunc)$(componentFunc)(
         $(samplerParam)
         vector<float, Shape.dimensions+isArray> location
@@ -4216,6 +4563,8 @@ $}
             static_assert(Shape.flavor == $(SLANG_TEXTURE_2D) || Shape.flavor == $(SLANG_TEXTURE_CUBE),
                 "Gather is supported only for 2D and 3D textures");
             return __texture_gather$(compareFunc)(this $(samplerArg), location $(compareArg) $(componentArg));
+        case llvm:
+            return llvmTextureGather$(compareFunc)<This $(componentArgString[componentId])>(this $(getSampler), location $(compareArg), vector<int, Shape.planeDimensions>(0));
         }
     }
 
@@ -4237,7 +4586,7 @@ $}
     }
 
     [ForceInline]
-    [require(cuda_glsl_hlsl_metal_spirv_wgsl, texture_gather)]
+    [require(cuda_glsl_hlsl_metal_spirv_wgsl_llvm, texture_gather)]
     vector<T.Element,4> Gather$(compareFunc)$(componentFunc)(
         $(samplerParam)
         vector<float, Shape.dimensions+isArray> location
@@ -4265,6 +4614,8 @@ $}
             static_assert(Shape.flavor == $(SLANG_TEXTURE_2D) || Shape.flavor == $(SLANG_TEXTURE_CUBE),
                 "Gather is supported only for 2D and 3D textures");
             return __texture_gather$(compareFunc)_offset(this $(samplerArg), location $(compareArg), offset $(componentArg));
+        case llvm:
+            return llvmTextureGather$(compareFunc)<This $(componentArgString[componentId])>(this $(getSampler), location $(compareArg), offset);
         }
     }
 
@@ -4354,7 +4705,7 @@ extension _Texture<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,format>
 //@public:
     [__readNone]
     [ForceInline]
-    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1_samplerless)]
+    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_1_samplerless)]
     T Load(vector<int, Shape.dimensions+isArray+1> location)
     {
         __target_switch
@@ -4501,12 +4852,17 @@ extension _Texture<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,format>
                 __intrinsic_asm "<invalid intrinsic: unimplemented shape>";
             }
             return __default<T>();
+        case llvm:
+            const int lodLoc = Shape.dimensions+isArray;
+            let coord = __vectorReshape<Shape.dimensions+isArray>(location);
+            let lod = location[lodLoc];
+            return llvmTextureLoad(this, coord, lod);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_samplerless)]
+    [require(cpp_glsl_hlsl_spirv_llvm, texture_sm_4_1_samplerless)]
     T Load(vector<int, Shape.dimensions+isArray+1> location, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -4539,6 +4895,13 @@ extension _Texture<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,format>
                         __truncate $$T result __sampledType(T) %sampled;
                     };
                 }
+        case llvm:
+            const int lodLoc = Shape.dimensions+isArray;
+            let coord =
+                __vectorReshape<Shape.dimensions+isArray>(location) +
+                __vectorReshape<Shape.dimensions+isArray>(offset);
+            let lod = location[lodLoc];
+            return llvmTextureLoad(this, coord, lod);
         }
     }
 
@@ -4595,7 +4958,7 @@ extension _Texture<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,format>
     {
         [__readNone]
         [ForceInline]
-        [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1_samplerless)]
+        [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_1_samplerless)]
         get
         {
             __target_switch
@@ -4605,6 +4968,7 @@ extension _Texture<T,Shape,isArray,0,sampleCount,0,isShadow,isCombined,format>
                     __intrinsic_asm ".operator[]";
                 case metal:
                 case cuda:
+                case llvm:
                     return Load(__makeVector(location, 0));
                 case glsl:
                     if (isCombined == 0)
@@ -4647,7 +5011,7 @@ extension _Texture<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,format>
 //@public:
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1_samplerless)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_1_samplerless)]
     T Load(vector<int, Shape.dimensions+isArray> location, int sampleIndex)
     {
         __target_switch
@@ -4709,12 +5073,14 @@ extension _Texture<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,format>
                 __wgsl_check_texture_type<T, Shape, isArray, isMS, sampleCount, access, isShadow, isCombined, format>();
 
                 __intrinsic_asm "textureLoad($0, $1, $2)$z";
+            case llvm:
+                return llvmTextureLoad(this, location, sampleIndex);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv_wgsl, texture_sm_4_1_samplerless)]
+    [require(cpp_glsl_hlsl_spirv_wgsl_llvm, texture_sm_4_1_samplerless)]
     T Load(vector<int, Shape.dimensions + isArray + 1> locationAndSampleIndex)
     {
         return Load(__vectorReshape<Shape.dimensions + isArray>(locationAndSampleIndex), locationAndSampleIndex[Shape.dimensions + isArray]);
@@ -4722,7 +5088,7 @@ extension _Texture<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_samplerless)]
+    [require(cpp_glsl_hlsl_spirv_llvm, texture_sm_4_1_samplerless)]
     T Load(vector<int, Shape.dimensions+isArray> location, int sampleIndex, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
@@ -4752,6 +5118,9 @@ extension _Texture<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,format>
                         __truncate $$T result __sampledType(T) %sampled;
                     };
                 }
+            case llvm:
+                let coord = location + __vectorReshape<Shape.dimensions+isArray>(offset);
+                return llvmTextureLoad(this, coord, sampleIndex);
         }
     }
 
@@ -4805,7 +5174,7 @@ extension _Texture<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,format>
     {
         [__readNone]
         [ForceInline]
-        [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1_samplerless)]
+        [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_1_samplerless)]
         get
         {
             __target_switch
@@ -4816,6 +5185,7 @@ extension _Texture<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,format>
                 case metal:
                 case spirv:
                 case wgsl:
+                case llvm:
                     return Load(location, 0);
                 case glsl:
                     if (isCombined == 0)
@@ -4828,7 +5198,7 @@ extension _Texture<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,format>
     {
         [__readNone]
         [ForceInline]
-        [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1_samplerless)]
+        [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_1_samplerless)]
         get
         {
             __target_switch
@@ -4839,6 +5209,7 @@ extension _Texture<T,Shape,isArray,1,sampleCount,0,isShadow,isCombined,format>
                 case metal:
                 case spirv:
                 case wgsl:
+                case llvm:
                     return Load(location, sampleIndex);
                 case glsl:
                     if (isCombined == 0)
@@ -4873,7 +5244,7 @@ extension _Texture<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,format>
     $}
     [__readNone]
     [ForceInline]
-    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1)]
+    [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_1)]
     T Load(vector<int, Shape.dimensions+isArray> location)
     {
         __target_switch
@@ -4998,12 +5369,14 @@ extension _Texture<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,format>
                     }
                 }
                 __intrinsic_asm "textureLoad($0, $1)$z";
+            case llvm:
+                return llvmTextureLoad(this, location, 0);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1)]
+    [require(cpp_glsl_hlsl_spirv_llvm, texture_sm_4_1)]
     T Load(vector<int, Shape.dimensions+isArray> location, vector<int, Shape.dimensions+isArray> offset)
     {
         __target_switch
@@ -5019,6 +5392,9 @@ extension _Texture<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,format>
                     %sampled:__sampledType(T) = OpImageRead $this $location ConstOffset $offset;
                     __truncate $$T result __sampledType(T) %sampled;
                 };
+            case llvm:
+                let coord = location + offset;
+                return llvmTextureLoad(this, coord, 0);
         }
     }
 
@@ -5146,6 +5522,8 @@ extension _Texture<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,format>
             if (T is float2) __intrinsic_asm "textureStore($0, $1, vec4<f32>($2, 0, 1))";
             if (T is float3) __intrinsic_asm "textureStore($0, $1, vec4<f32>($2, 1))";
             __intrinsic_asm "textureStore($0, $1, $2)";
+        case llvm:
+            llvmTextureStore(this, location, newValue, 0);
         }
     }
 
@@ -5157,7 +5535,7 @@ extension _Texture<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,format>
     {
         [__readNone]
         [ForceInline]
-        [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1)]
+        [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_1)]
         get
         {
             __target_switch
@@ -5170,13 +5548,14 @@ extension _Texture<T,Shape,isArray,0,sampleCount,$(access),isShadow, 0,format>
                 case cuda:
                 case metal:
                 case wgsl:
+                case llvm:
                     return Load(location);
             }
         }
 
         [nonmutating]
         [ForceInline]
-        [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1)]
+        [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_1)]
         set(T newValue)
         {
             Store(location, newValue);
@@ -5211,7 +5590,7 @@ extension _Texture<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,format>
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_metal_spirv_wgsl, texture_sm_4_1_compute_fragment)]
+    [require(cpp_glsl_hlsl_metal_spirv_wgsl_llvm, texture_sm_4_1_compute_fragment)]
     T Load(vector<int, Shape.dimensions+isArray> location, int sampleIndex)
     {
         __target_switch
@@ -5259,12 +5638,14 @@ extension _Texture<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,format>
                 __wgsl_check_texture_type<T, Shape, isArray, isMS, sampleCount, $(access), isShadow, isCombined, format>();
 
                 __intrinsic_asm "textureLoad($0, $1, $2)$z";
+            case llvm:
+                return llvmTextureLoad(this, location, sampleIndex);
         }
     }
 
     [__readNone]
     [ForceInline]
-    [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_compute_fragment)]
+    [require(cpp_glsl_hlsl_spirv_llvm, texture_sm_4_1_compute_fragment)]
     T Load(vector<int, Shape.dimensions+isArray> location, int sampleIndex, vector<int, Shape.dimensions+isArray> offset)
     {
         __target_switch
@@ -5280,6 +5661,9 @@ extension _Texture<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,format>
                     %sampled:__sampledType(T) = OpImageRead $this $location ConstOffset|Sample $offset $sampleIndex;
                     __truncate $$T result __sampledType(T) %sampled;
                 };
+            case llvm:
+                let coord = location + offset;
+                return llvmTextureLoad(this, coord, sampleIndex);
         }
     }
 
@@ -5308,7 +5692,7 @@ extension _Texture<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,format>
     {
         [__readNone]
         [ForceInline]
-        [require(cpp_glsl_hlsl_spirv_wgsl, texture_sm_4_1_compute_fragment)]
+        [require(cpp_glsl_hlsl_spirv_wgsl_llvm, texture_sm_4_1_compute_fragment)]
         get
         {
             __target_switch
@@ -5319,13 +5703,14 @@ extension _Texture<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,format>
                 case glsl:
                 case spirv:
                 case wgsl:
+                case llvm:
                     return Load(location, sampleIndex);
             }
         }
 
         [nonmutating]
         [ForceInline]
-        [require(cpp_glsl_hlsl_spirv, texture_sm_4_1_compute_fragment)]
+        [require(cpp_glsl_hlsl_spirv_llvm, texture_sm_4_1_compute_fragment)]
         set(T newValue)
         {
             __target_switch
@@ -5340,6 +5725,8 @@ extension _Texture<T,Shape,isArray,1,sampleCount,$(access),isShadow, 0,format>
                     {
                         OpImageWrite $this $location __convertTexel(newValue) Sample $sampleIndex;
                     };
+                case llvm:
+                    llvmTextureStore(this, location, newValue, sampleIndex);
             }
         }
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -813,9 +813,6 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,access,isShadow,isCombined,f
 {
     typealias TexelElement = T;
     typealias TextureShape = Shape;
-    typealias CoordType = vector<float, Shape.dimensions + isArray>;
-    typealias GradientType = vector<float, Shape.dimensions>;
-    typealias OffsetType = vector<int, Shape.planeDimensions>;
     static const bool isArrayTexture = isArray == 1;
     static const bool isMultisample = isMS == 1;
     static const int multisampleCount = sampleCount;
@@ -1149,7 +1146,7 @@ void __wgsl_check_texture_type_texel_offset()
 /// user to define this texture operation.
 ///
 /// @param T Texture type.
-/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`.
 /// @param location Texel coordinate. If this is an array texture, the last coordinate is the array index.
 /// @param levelOrSampleIndex If `T.isMultisample`, this is the sample index. Otherwise, it is the LOD level.
 /// @return The fetched texel.
@@ -1169,7 +1166,7 @@ extern T.TexelElement llvmTextureLoad<T:ITexture>(
 /// level 0.
 ///
 /// @param T Texture type.
-/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`.
 /// @param location Texel coordinate. If this is an array texture, the last coordinate is the array index.
 /// @param newValue New value to write to the texel.
 /// @param sampleIndex Sample index in multisample textures. Ignore it if `!T.isMultisample`.
@@ -1189,7 +1186,7 @@ extern void llvmTextureStore<T:ITexture>(
 /// allowing the user to define this texture operation.
 ///
 /// @param T Texture type.
-/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`.
 /// @param mipLevel The LOD level to query the sizes for.
 /// @param width Width of the texture, in texels.
 /// @param height Height of the texture, in texels. Unused if the texture is 1D.
@@ -1224,9 +1221,8 @@ extern void llvmTextureGetDimensions<T:ITexture>(
 /// explicit LOD level.
 ///
 /// @param T Texture type.
-/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`.
 /// @param sam Sampler that can be converted into an arbitrary pointer type with `bit_cast`.
-///            May be a null pointer if `T.isCombinedTextureSampler`.
 /// @param location Texture coordinate. If this is an array texture, the last coordinate is the array index.
 /// @param level The LOD level to sample from.
 /// @param offset An integer offset applied to the resolved texel coordinates.
@@ -1250,9 +1246,8 @@ extern T.TexelElement llvmTextureSampleLevel<T:ITexture>(
 /// automatic LOD level computation.
 ///
 /// @param T Texture type.
-/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`.
 /// @param sam Sampler that can be converted into an arbitrary pointer type with `bit_cast`.
-///            May be a null pointer if `T.isCombinedTextureSampler`.
 /// @param location Texture coordinate. If this is an array texture, the last coordinate is the array index.
 /// @param gradX Texture gradient on the X axis
 /// @param gradY Texture gradient on the Y axis
@@ -1281,9 +1276,8 @@ extern T.TexelElement llvmTextureSampleGrad<T:ITexture>(
 /// explicit LOD level.
 ///
 /// @param T Texture type.
-/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`.
 /// @param sam Sampler that can be converted into an arbitrary pointer type with `bit_cast`.
-///            May be a null pointer if `T.isCombinedTextureSampler`.
 /// @param location Texture coordinate. If this is an array texture, the last coordinate is the array index.
 /// @param compareValue The value to compare to.
 /// @param level The LOD level to sample from.
@@ -1309,9 +1303,8 @@ extern float llvmTextureSampleCmpLevel<T:ITexture>(
 /// automatic LOD level computation.
 ///
 /// @param T Texture type.
-/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`.
 /// @param sam Sampler that can be converted into an arbitrary pointer type with `bit_cast`.
-///            May be a null pointer if `T.isCombinedTextureSampler`.
 /// @param location Texture coordinate. If this is an array texture, the last coordinate is the array index.
 /// @param compareValue The value to compare to.
 /// @param gradX Texture gradient on the X axis
@@ -1342,9 +1335,8 @@ extern float llvmTextureSampleCmpGrad<T:ITexture>(
 ///
 /// @param T Texture type.
 /// @param Channel Channel index to gather from.
-/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`.
 /// @param sam Sampler that can be converted into an arbitrary pointer type with `bit_cast`.
-///            May be a null pointer if `T.isCombinedTextureSampler`.
 /// @param location Texture coordinate. If this is an array texture, the last coordinate is the array index.
 /// @param offset An integer offset applied to the resolved texel coordinates.
 /// @return The four gathered values.
@@ -1365,9 +1357,8 @@ extern vector<T.TexelElement.Element, 4> llvmTextureGather<T:ITexture, let Chann
 ///
 /// @param T Texture type.
 /// @param Channel Channel index to gather from.
-/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`
+/// @param tex Texture that can be converted into an arbitrary pointer type with `bit_cast`.
 /// @param sam Sampler that can be converted into an arbitrary pointer type with `bit_cast`.
-///            May be a null pointer if `T.isCombinedTextureSampler`.
 /// @param location Texture coordinate. If this is an array texture, the last coordinate is the array index.
 /// @param compareValue The value to compare to.
 /// @param offset An integer offset applied to the resolved texel coordinates.

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -370,17 +370,33 @@ alias cpp_glsl = cpp | glsl;
 /// [Compound]
 alias cpp_glsl_hlsl_spirv = cpp | glsl | hlsl | spirv;
 
+/// CPP, GLSL, HLSL, SPIRV, and LLVM code-gen targets
+/// [Compound]
+alias cpp_glsl_hlsl_spirv_llvm = cpp | glsl | hlsl | spirv | llvm;
+
 /// CPP, GLSL, HLSL, SPIRV and WGSL code-gen targets
 /// [Compound]
 alias cpp_glsl_hlsl_spirv_wgsl = cpp | glsl | hlsl | spirv | wgsl;
+
+/// CPP, GLSL, HLSL, SPIRV, WGSL, and LLVM code-gen targets
+/// [Compound]
+alias cpp_glsl_hlsl_spirv_wgsl_llvm = cpp | glsl | hlsl | spirv | wgsl | llvm;
 
 /// CPP, GLSL, HLSL, Metal, and SPIRV code-gen targets
 /// [Compound]
 alias cpp_glsl_hlsl_metal_spirv = cpp | glsl | hlsl | metal | spirv;
 
+/// CPP, GLSL, HLSL, Metal, SPIRV, and LLVM code-gen targets
+/// [Compound]
+alias cpp_glsl_hlsl_metal_spirv_llvm = cpp | glsl | hlsl | metal | spirv | llvm;
+
 /// CPP, GLSL, HLSL, Metal, SPIRV and WGSL code-gen targets
 /// [Compound]
 alias cpp_glsl_hlsl_metal_spirv_wgsl = cpp | glsl | hlsl | metal | spirv | wgsl;
+
+/// CPP, GLSL, HLSL, Metal, SPIRV, WGSL and LLVM code-gen targets
+/// [Compound]
+alias cpp_glsl_hlsl_metal_spirv_wgsl_llvm = cpp | glsl | hlsl | metal | spirv | wgsl | llvm;
 
 /// CPP, and HLSL code-gen targets
 /// [Compound]
@@ -413,6 +429,10 @@ alias cuda_glsl_hlsl_metal_spirv = cuda | glsl | hlsl | metal | spirv;
 /// CUDA, GLSL, HLSL, Metal, SPIRV and WGSL code-gen targets
 /// [Compound]
 alias cuda_glsl_hlsl_metal_spirv_wgsl = cuda | glsl | hlsl | metal | spirv | wgsl;
+
+/// CUDA, GLSL, HLSL, Metal, SPIRV, WGSL and LLVM code-gen targets
+/// [Compound]
+alias cuda_glsl_hlsl_metal_spirv_wgsl_llvm = cuda | glsl | hlsl | metal | spirv | wgsl | llvm;
 
 /// CUDA, GLSL, and SPIRV code-gen targets
 /// [Compound]
@@ -450,9 +470,17 @@ alias glsl_hlsl_spirv_wgsl = glsl | hlsl | spirv | wgsl;
 /// [Compound]
 alias glsl_hlsl_metal_spirv = glsl | hlsl | metal | spirv;
 
+/// GLSL, HLSL, Metal, SPIRV, and LLVM code-gen targets
+/// [Compound]
+alias glsl_hlsl_metal_spirv_llvm = glsl | hlsl | metal | spirv | llvm;
+
 /// GLSL, HLSL, Metal, SPIRV and WGSL code-gen targets
 /// [Compound]
 alias glsl_hlsl_metal_spirv_wgsl = glsl | hlsl | metal | spirv | wgsl;
+
+/// GLSL, HLSL, Metal, SPIRV, WGSL, and LLVM code-gen targets
+/// [Compound]
+alias glsl_hlsl_metal_spirv_wgsl_llvm = glsl | hlsl | metal | spirv | wgsl | llvm;
 
 /// GLSL, Metal, and SPIRV code-gen targets
 /// [Compound]
@@ -473,6 +501,10 @@ alias glsl_spirv_wgsl = glsl | spirv | wgsl;
 /// HLSL, and SPIRV code-gen targets
 /// [Compound]
 alias hlsl_spirv = hlsl | spirv;
+
+/// HLSL, SPIRV and LLVM code-gen targets
+/// [Compound]
+alias hlsl_spirv_llvm = hlsl | spirv | llvm;
 
 // stages
 //
@@ -2331,7 +2363,7 @@ alias texture_sm_4_1_clamp_fragment = texture_sm_4_0_fragment | GL_ARB_sparse_te
 alias texture_sm_4_1_vertex_fragment_geometry = texture_sm_4_1;
 /// Capabilities required to use 'vertex/fragment/geometry shader only' texture gather operations
 /// [Compound]
-alias texture_gather = texture_sm_4_1_vertex_fragment_geometry | GL_ARB_texture_gather;
+alias texture_gather = texture_sm_4_1_vertex_fragment_geometry | GL_ARB_texture_gather | llvm;
 /// Capabilities required to query image (RWTexture) sample info
 /// [Compound]
 alias image_samples = texture_sm_4_1_compute_fragment | GL_ARB_shader_texture_image_samples;
@@ -2353,7 +2385,7 @@ alias texture_shadowlod = texture_sm_4_1;
 /// Capabilities required for shadow texture sampling with bias and gradients.
 /// New in HLSL SM6.8 but existed in older GLSL and SPIRV targets.
 /// [Compound]
-alias texture_shadowgrad = _sm_6_8 | _GLSL_150 | spirv_1_0 | GL_EXT_texture_shadow_lod;
+alias texture_shadowgrad = _sm_6_8 | _GLSL_150 | spirv_1_0 | GL_EXT_texture_shadow_lod | llvm;
 
 /// (GLSL/SPIRV) Capabilities required to use GLSL-tier-1 float-atomic operations
 /// [Compound]

--- a/source/slang/slang-core-module-textures.cpp
+++ b/source/slang/slang-core-module-textures.cpp
@@ -72,7 +72,8 @@ void TextureTypeInfo::writeFuncBody(
     const String& spirvRWDefault,
     const String& spirvCombined,
     const String& metal,
-    const String& wgsl)
+    const String& wgsl,
+    const String& llvm)
 {
     BraceScope funcScope{i, sb};
     {
@@ -131,6 +132,11 @@ void TextureTypeInfo::writeFuncBody(
             sb << i << "case wgsl:\n";
             sb << i << "__intrinsic_asm \"" << wgsl << "\";\n";
         }
+        if (llvm.getLength())
+        {
+            sb << i << "case llvm:\n";
+            sb << i << llvm << "\n";
+        }
     }
 }
 
@@ -144,13 +150,14 @@ void TextureTypeInfo::writeFuncWithSig(
     const String& cuda,
     const String& metal,
     const String& wgsl,
+    const String& llvm,
     const ReadNoneMode readNoneMode)
 {
     if (readNoneMode == ReadNoneMode::Always)
         sb << i << "[__readNone]\n";
     sb << i << "[ForceInline]\n";
     sb << i << sig << "\n";
-    writeFuncBody(funcName, glsl, cuda, spirvDefault, spirvRWDefault, spirvCombined, metal, wgsl);
+    writeFuncBody(funcName, glsl, cuda, spirvDefault, spirvRWDefault, spirvCombined, metal, wgsl, llvm);
     sb << "\n";
 }
 
@@ -165,6 +172,7 @@ void TextureTypeInfo::writeFunc(
     const String& cuda,
     const String& metal,
     const String& wgsl,
+    const String& llvm,
     const ReadNoneMode readNoneMode)
 {
     writeFuncWithSig(
@@ -177,6 +185,7 @@ void TextureTypeInfo::writeFunc(
         cuda,
         metal,
         wgsl,
+        llvm,
         readNoneMode);
 }
 
@@ -596,6 +605,36 @@ void TextureTypeInfo::writeGetDimensionFunctions()
                 generateSpirvAsm(spirvRWDefault, true, toSlice("$this"));
             }
 
+            StringBuilder llvm;
+            {
+                llvm << "int w, h, e, d, l, s;\n";
+                llvm << "llvmTextureGetDimensions(this,";
+                llvm << (includeMipInfo ? "mipLevel," : "0,");
+                llvm << "w,h,e,d,l,s);\n";
+                switch (baseShape)
+                {
+                case SLANG_TEXTURE_1D:
+                    llvm << "width = w;\n";
+                    break;
+                case SLANG_TEXTURE_2D:
+                case SLANG_TEXTURE_CUBE:
+                    llvm << "width = w;\n";
+                    llvm << "height = h;\n";
+                    break;
+                case SLANG_TEXTURE_3D:
+                    llvm << "width = w;\n";
+                    llvm << "height = h;\n";
+                    llvm << "depth = d;\n";
+                    break;
+                }
+                if (isArray)
+                    llvm << "elements = e;\n";
+                if (includeMipInfo)
+                    llvm << "numberOfLevels = l;\n";
+                if (isMultisample)
+                    llvm << "sampleCount = s;\n";
+            }
+
             sb << "    __glsl_version(450)\n";
 
             sb << "    [require(cpp";
@@ -610,6 +649,8 @@ void TextureTypeInfo::writeGetDimensionFunctions()
                 sb << "_spirv";
             if (wgsl.getLength())
                 sb << "_wgsl";
+            if (llvm.getLength())
+                sb << "_llvm";
             sb << ", texture_sm_4_1)]\n";
 
             writeFunc(
@@ -623,6 +664,7 @@ void TextureTypeInfo::writeGetDimensionFunctions()
                 cuda.produceString(),
                 metal,
                 wgsl,
+                llvm,
                 ReadNoneMode::Always);
         }
     }

--- a/source/slang/slang-core-module-textures.h
+++ b/source/slang/slang-core-module-textures.h
@@ -72,7 +72,8 @@ public:
         const String& spirvRWDefault,
         const String& spirvCombined,
         const String& metal,
-        const String& wgsl);
+        const String& wgsl,
+        const String& llvm);
     void writeFuncWithSig(
         const char* funcName,
         const String& sig,
@@ -83,6 +84,7 @@ public:
         const String& cuda = String{},
         const String& metal = String{},
         const String& wgsl = String{},
+        const String& llvm = String{},
         const ReadNoneMode readNoneMode = ReadNoneMode::Never);
     void writeFunc(
         const char* returnType,
@@ -95,6 +97,7 @@ public:
         const String& cuda = String{},
         const String& metal = String{},
         const String& wgsl = String{},
+        const String& llvm = String{},
         const ReadNoneMode readNoneMode = ReadNoneMode::Never);
 
     // A pointer to a string representing the current level of indentation


### PR DESCRIPTION
This PR allows users to define the implementations of texture operations on the LLVM target.

# Background

There is no canonical "texture" type on CPU targets, as there is no graphics driver to define what it is. Instead, we defer the definition of what a texture is to the user. This allows the user to use a CPU-side image structure that their engine / framework / whatever already has, and use that directly with Slang, as-is.

To that end, the LLVM target already [lowers textures and other resource types as opaque pointers](https://github.com/shader-slang/slang/pull/10982). This PR then completes this support for textures by allowing the user to define all texture access operations (`Load`, `Store`, `GetDimensions`, `Sample*`, `Gather*`).

# Implementation

The PR just adds a pile of forward-declared `llvmTexture*` functions and wires those to the `Texture*` member functions on the LLVM target. These allow user-defined implementations using the same mechanism as `getDescriptorFromHandle`, where the core module declares these functions as `extern` and the user module must `export` the implementations. The default implementations just issue `static_assert`s that give helpful compile-time error messages when they are used without overriding.

See the updated `docs/llvm-target.md` for some more detail.

This PR also adds a new `ITexture` interface, which is implemented by all textures. It does not have member functions, only associated types and associated values that carry metadata about the texture type. This has the following benefits:

- Communicates texture parameters to the user without having to expose `_Texture`
- Makes it possible to add new generic params to `_Texture` without breaking these user-defined texture implementations
- Keeps the functions cleaner, as only `<T:ITexture>` is needed instead of `<T:ITexelElement, Shape: __ITextureShape, let isArray:int, let isMS:int, let sampleCount:int, let access:int, let isShadow:int, let isCombined:int, let format:int>`

# Meta

I will handle acceleration structures with a similar approach in a separate PR later on.

WIP: mostly just missing tests, but I also want to test-drive this feature in my own codebase to get a feel for the ergonomics of this approach