### PR TITLE
ci: wipe stray actions-runner installs at VM startup

### DIFF
--- a/extras/scaler/internal/gcp/startup.sh
+++ b/extras/scaler/internal/gcp/startup.sh
@@ -17,6 +17,25 @@ set -euo pipefail
 RUNNER_VERSION="2.334.0"
 RUNNER_SHA256="048024cd2c848eb6f14d5646d56c13a4def2ae7ee3ad12122bee960c56f3d271"
 
+# Defense in depth: wipe stray actions-runner installs that may be baked into
+# the base image under user accounts other than the canonical "runner" user.
+# A May 2026 SM80Plus outage was caused by /home/<engineer>/actions-runner/
+# leaking into the snapshot — the runner-detection loop below picked it up
+# and ran the GitHub Actions runner under the engineer's account, registering
+# without labels and blocking the queue. Image hygiene is the canonical fix;
+# this is a runtime safety net so a single bad snapshot can't repeat that.
+for stray in /home/*/actions-runner; do
+  [ -d "$stray" ] || continue
+  case "$stray" in
+  /home/runner/actions-runner) continue ;;
+  esac
+  echo "Wiping stray actions-runner install: $stray"
+  if [ -f "$stray/.runner" ] && [ -x "$stray/svc.sh" ]; then
+    (cd "$stray" && ./svc.sh stop 2>/dev/null && ./svc.sh uninstall 2>/dev/null) || true
+  fi
+  rm -rf "$stray"
+done
+
 # Find the runner directory and its owner
 RUNNER_DIR=""
 RUNNER_USER=""

--- a/extras/scaler/internal/gcp/startup.sh
+++ b/extras/scaler/internal/gcp/startup.sh
@@ -25,13 +25,21 @@ RUNNER_SHA256="048024cd2c848eb6f14d5646d56c13a4def2ae7ee3ad12122bee960c56f3d271"
 # without labels and blocking the queue. Image hygiene is the canonical fix;
 # this is a runtime safety net so a single bad snapshot can't repeat that.
 for stray in /home/*/actions-runner; do
+  # Without `nullglob`, an unmatched glob expands to the literal pattern;
+  # the directory check below skips it.
   [ -d "$stray" ] || continue
   case "$stray" in
   /home/runner/actions-runner) continue ;;
   esac
   echo "Wiping stray actions-runner install: $stray"
+  # Stop and uninstall the runner service if it is registered. Run the two
+  # phases independently — `uninstall` must still be attempted even when
+  # `stop` fails (service not running, partially installed, etc.) so we do
+  # not leave a dangling systemd unit pointing at the directory we are about
+  # to delete.
   if [ -f "$stray/.runner" ] && [ -x "$stray/svc.sh" ]; then
-    (cd "$stray" && ./svc.sh stop 2>/dev/null && ./svc.sh uninstall 2>/dev/null) || true
+    (cd "$stray" && ./svc.sh stop 2>/dev/null) || true
+    (cd "$stray" && ./svc.sh uninstall 2>/dev/null) || true
   fi
   rm -rf "$stray"
 done


### PR DESCRIPTION
## Summary

The Linux startup script (`extras/scaler/internal/gcp/startup.sh`) detects the runner user from `/home/*/actions-runner/` ownership. A May 2026 SM80Plus outage was caused by `/home/<engineer>/actions-runner/` leaking into `linux-gpu-runner-20260417`: every fresh VM bound the GitHub Actions runner to that engineer's account, registered against the SM80Plus scale set without labels, and blocked the queue for ~58h.

Image hygiene is the canonical fix and is in place for the new `linux-gpu-runner-20260504` image (published 2026-05-04). This PR adds a runtime safety net so a single bad future snapshot cannot repeat the outage.

The added loop runs before the existing runner-detection step. On a clean image the loop is a no-op (only `/home/runner/actions-runner/` exists, which is explicitly skipped). On a contaminated image, only the stray installs are wiped — the canonical `/home/runner/actions-runner/` is preserved.

Validated:
- `shellcheck` clean on the new block (existing SC2012 warnings on `ls /dev/...` lines unchanged).
- `bash -n` syntax check passes.
- `go test ./... -count=1` in `extras/scaler` passes both packages.
- `go build ./cmd/scaler` succeeds (startup.sh is `go:embed`-ed).
- Local 3-scenario simulation: clean image → no-op; contaminated + canonical → only stray wiped; stray-only → wiped, falls through to the existing "Cannot find actions-runner directory" error path.

Related: doc updates pushed separately to the slang-ci-docs runbook (`gcp-runner-scaler.md`) covering the post-`dist-upgrade` re-verification of the auto-update lockdown layers and the rewritten Step 3 image-cleanup procedure.