### PR TITLE
Fix cooperative matrix diagnostic code collision

### DIFF
--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -5175,7 +5175,7 @@ err(
 
 err(
     "cooperative-matrix-invalid-mma-type-combination",
-    50000,
+    50002,
     "invalid type combination for cooperative matrix multiply-add",
     span { loc = "location", message = "Invalid (A, B, C, D) element-type combination for cooperative matrix multiply-add: A='~aType', B='~bType', C='~cType', D='~dType'. The CUDA backend requires A and B to share the same element type and the accumulator family to match the input family (half -> half/float, bfloat16 -> float, int8/uint8 -> int, FloatE4M3/FloatE5M2 -> half/float)." }
 )

--- a/tests/cooperative-matrix/cuda-coop-mat-diagnostics.slang
+++ b/tests/cooperative-matrix/cuda-coop-mat-diagnostics.slang
@@ -26,9 +26,9 @@
 
 // CHECK_TYPE: error 50000: unsupported element type for cooperative matrix
 
-// CHECK_SHAPE: error 50000: invalid shape for cooperative matrix
+// CHECK_SHAPE: error 50001: invalid shape for cooperative matrix
 
-// CHECK_COMBO: error 50000: invalid type combination for cooperative matrix multiply-add
+// CHECK_COMBO: error 50002: invalid type combination for cooperative matrix multiply-add
 
 using namespace linalg;
 


### PR DESCRIPTION
## Summary
- Assign a unique diagnostic code (`50002`) to `cooperative-matrix-invalid-mma-type-combination` so duplicate-code validation passes.
- Update cooperative matrix diagnostic test expectations for invalid shape (`50001`) and invalid MMA type combination (`50002`).

## Test plan
- `cmake --build --preset release --target slang-test`
- `./build/Release/bin/slang-test tests/cooperative-matrix/ -use-test-server -server-count 8`


Made with [Cursor](https://cursor.com)