### PR TITLE
Fix neural module not built when SLANG_EMBED_CORE_MODULE=OFF

### DIFF
--- a/source/standard-modules/neural/CMakeLists.txt
+++ b/source/standard-modules/neural/CMakeLists.txt
@@ -96,15 +96,9 @@ add_custom_command(
 )
 
 # Create a target to ensure the neural module is built.
-# When SLANG_EMBED_CORE_MODULE=OFF the compiler runs slang-bootstrap from source and currently
-# crashes (exit 0xC0000005) when processing neural.slang's CoopMat/spirv_asm code. Exclude the
-# module from the default ALL build in that configuration so development builds with
-# SLANG_EMBED_CORE_MODULE=OFF do not fail. The target can still be built explicitly.
-if(SLANG_EMBED_CORE_MODULE)
-    add_custom_target(slang-neural-module ALL DEPENDS ${neural_module_file})
-else()
-    add_custom_target(slang-neural-module DEPENDS ${neural_module_file})
-endif()
+# The prelinkIR crashes that previously blocked SLANG_EMBED_CORE_MODULE=OFF builds
+# are fixed (PRs #10835, #10847). Build the neural module unconditionally.
+add_custom_target(slang-neural-module ALL DEPENDS ${neural_module_file})
 set_target_properties(slang-neural-module PROPERTIES FOLDER generated)
 
 # Install the neural directory to the configured location in the release package

--- a/tests/neural/neural-import-smoke.slang
+++ b/tests/neural/neural-import-smoke.slang
@@ -1,0 +1,9 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -entry main -stage compute -experimental-feature
+
+import slang.neural;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main() {}
+
+// CHECK: OpEntryPoint

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -284,13 +284,7 @@ if(SLANG_ENABLE_TESTS AND SLANG_ENABLE_SLANG_RHI)
         FOLDER test
         DEBUG_DIR ${slang_SOURCE_DIR}
     )
-    # Only depend on slang-neural-module when SLANG_EMBED_CORE_MODULE=ON.
-    # With SLANG_EMBED_CORE_MODULE=OFF, building the neural module crashes
-    # (slang-bootstrap exits 0xC0000005 when processing neural.slang), so we
-    # exclude the dependency to keep development builds with EMBED=OFF working.
-    if(SLANG_EMBED_CORE_MODULE)
-        add_dependencies(slang-test slang-neural-module)
-    endif()
+    add_dependencies(slang-test slang-neural-module)
 
     set_property(
         DIRECTORY ${slang_SOURCE_DIR}


### PR DESCRIPTION
Fixes https://github.com/shader-slang/slang/issues/11015

With `-DSLANG_EMBED_CORE_MODULE=OFF`, `import slang.neural;` fails with `E00001: cannot open file 'slang/neural.slang'` because the CMake guards added in PR #10840 excluded `slang-neural-module` from the default `ALL` build in that configuration, so `neural.slang-module` was never compiled.

The crash that motivated those guards (`slang-bootstrap` exiting `0xC0000005` while processing `neural.slang`) was fixed one day earlier by PRs #10835 and #10847, which restructured `prelinkIR` in `slang-ir-link.cpp` to strip linkage decorations before `replaceUsesWith` and defer `removeAndDeallocate` until all uses are patched. The workaround was committed in parallel and landed after the root-cause fix.

Remove the two `if(SLANG_EMBED_CORE_MODULE)` guards so that `slang-neural-module` is always in the `ALL` build and `slang-test` always depends on it. Only the stale Problem 3 guards are removed; the correct parts of PR #10840 (Problem 1: slangc/glsl-module guard, Problem 2: Windows DLL pre-copy, the slang-bootstrap compiler selection for EMBED=OFF) are untouched.

Add a compile-only SPIRV smoke test (`tests/neural/neural-import-smoke.slang`) that verifies the full import-parse-link-emit pipeline succeeds without a GPU. This test fails with `E00001` if the module binary is absent from the build output and with `E00104` if the `-experimental-feature` flag is dropped, catching both failure modes in any CI environment where `slang-neural-module` is included in the build.