### PR TITLE
ci: include scaler-linux-sm80plus in update-scaler.sh

### DIFF
--- a/extras/scaler/deploy/update-scaler.sh
+++ b/extras/scaler/deploy/update-scaler.sh
@@ -33,13 +33,18 @@ gcloud compute scp "${BINARY}" "${VM_NAME}:/tmp/scaler" \
   --zone="${ZONE}" --project="${PROJECT}"
 
 echo "Stopping services, replacing binary, restarting..."
+# Keep the service list synchronized between the stop block and the restart loop.
+# scaler-linux-sm80plus was added in PR #10967 (2026-04-29) but was missing from
+# this script, so deployments silently left the SM80Plus tier on the old binary
+# until manually restarted.
+SCALER_SERVICES="scaler-windows scaler-linux scaler-linux-sm80plus scaler-windows-build"
 gcloud compute ssh "${VM_NAME}" --zone="${ZONE}" --project="${PROJECT}" --command="
-    sudo systemctl stop scaler-windows scaler-linux scaler-windows-build 2>/dev/null || true
+    sudo systemctl stop ${SCALER_SERVICES} 2>/dev/null || true
     sudo mv /tmp/scaler /opt/scaler/scaler
     sudo chmod 755 /opt/scaler/scaler
     sudo chown scaler:scaler /opt/scaler/scaler
     failed=0
-    for svc in scaler-windows scaler-linux scaler-windows-build; do
+    for svc in ${SCALER_SERVICES}; do
         if sudo systemctl is-enabled \$svc 2>/dev/null | grep -q enabled; then
             sudo systemctl start \$svc
             if sudo systemctl is-active \$svc >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

[PR #10967](https://github.com/shader-slang/slang/pull/10967) (2026-04-29) added the `scaler-linux-sm80plus` service, but `extras/scaler/deploy/update-scaler.sh` was not updated. Every subsequent binary deployment silently left the SM80Plus tier on the previous binary until someone remembered to restart it manually — exactly the kind of drift that caused (or rather, would cause) the next deployment to surprise us.

This change centralizes the service list in a single `SCALER_SERVICES` variable used by both the stop block and the restart loop, so they cannot drift again.

Validated:
- `shellcheck` clean.
- `bash -n` syntax check passes.
- `git diff` shows the change is one-line equivalent in two places (now substituting from a shared variable) plus the new variable + explanatory comment.

Sequencing note: this is a prerequisite for the next scaler binary deployment that includes [PR #11041](https://github.com/shader-slang/slang/pull/11041) (the stray-runner-install wipe). With both merged, `update-scaler.sh` will deploy the new safety net to the SM80Plus tier alongside the other three.