### PR TITLE
DEBUG: capture core dumps on Linux test jobs (do not merge)

### DIFF
--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -60,6 +60,61 @@ jobs:
           echo "=== Disk space after cleanup ==="
           df -h /host_root || true
 
+      # TEMPORARY: gather AVX-512 detection ground truth on this build
+      # runner. The test runner runs the same probe; comparing the two tells
+      # us whether the build host and test host see the same CPU features.
+      # If clang on the build host detects AVX-512 but the test host doesn't
+      # support it, that explains the SIGILL in #11062.
+      # Remove once #11062 is fixed.
+      - name: CPUID / AVX-512 probe (build runner)
+        run: |
+          echo "::group::Build runner identity"
+          uname -a
+          if [ -r /proc/sys/kernel/random/boot_id ]; then
+            printf 'boot_id=%s\n' "$(cat /proc/sys/kernel/random/boot_id)"
+          fi
+          echo "::endgroup::"
+
+          echo "::group::AVX-512 family flags reported in /proc/cpuinfo"
+          grep -oE 'avx512[a-z0-9]*' /proc/cpuinfo | sort -u || echo "(none)"
+          echo "::endgroup::"
+
+          echo "::group::CPUID leaf 7, sub 0 (raw)"
+          cat >/tmp/cpuid.c <<'EOF'
+          #include <stdio.h>
+          #include <stdint.h>
+          static void cpuid_count(uint32_t leaf, uint32_t sub,
+                                  uint32_t *a, uint32_t *b,
+                                  uint32_t *c, uint32_t *d) {
+              __asm__ volatile("cpuid"
+                  : "=a"(*a), "=b"(*b), "=c"(*c), "=d"(*d)
+                  : "a"(leaf), "c"(sub));
+          }
+          int main(void) {
+              uint32_t a, b, c, d;
+              cpuid_count(7, 0, &a, &b, &c, &d);
+              printf("EAX=0x%08x EBX=0x%08x ECX=0x%08x EDX=0x%08x\n", a, b, c, d);
+              printf("  AVX-512F   (EBX bit 16): %s\n", (b & (1u<<16)) ? "yes" : "no");
+              printf("  AVX-512DQ  (EBX bit 17): %s\n", (b & (1u<<17)) ? "yes" : "no");
+              printf("  AVX-512CD  (EBX bit 28): %s\n", (b & (1u<<28)) ? "yes" : "no");
+              printf("  AVX-512BW  (EBX bit 30): %s\n", (b & (1u<<30)) ? "yes" : "no");
+              printf("  AVX-512VL  (EBX bit 31): %s\n", (b & (1u<<31)) ? "yes" : "no");
+              return 0;
+          }
+          EOF
+          cc -O0 -o /tmp/cpuid /tmp/cpuid.c && /tmp/cpuid || echo "(cpuid probe failed)"
+          echo "::endgroup::"
+
+          echo "::group::clang sees this CPU as"
+          if command -v clang >/dev/null 2>&1; then
+            clang --version | head -1
+            clang -E -x c /dev/null -march=native -### 2>&1 \
+              | tr ' ' '\n' \
+              | grep -E '^-(target-cpu|target-feature|march|mcpu)' \
+              | sort -u || true
+          fi
+          echo "::endgroup::"
+
       - name: Configure Git safe directory
         run: git config --global --add safe.directory '*'
 

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -75,8 +75,27 @@ jobs:
           config: ${{ inputs.config }}
           artifact-suffix: ${{ inputs.artifact-suffix }}
 
+      # TEMPORARY: enable core-dump capture on Linux to investigate the
+      # SIGILL in slang-test on the linux-cpu job (seen 2026-05-04 PR #10977
+      # and 2026-05-05 PR #11053, both crashing right after
+      # tests/autodiff/global-param-hoisting.slang.1 (vk)). Remove once root-caused.
+      - name: Enable core dumps (Linux)
+        if: inputs.os == 'linux'
+        shell: bash
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/cores"
+          # Override Ubuntu's default apport pipe so cores land as plain files.
+          sudo sysctl -w kernel.core_pattern="$GITHUB_WORKSPACE/cores/core.%e.%p"
+          sudo sysctl -w kernel.core_uses_pid=1
+          ulimit -c unlimited
+          # Make sure gdb is installed for the post-run extraction step.
+          sudo apt-get install -y --no-install-recommends gdb
+
       - name: Test Slang
         run: |
+          # Inherit unlimited core size for any child processes (slang-test,
+          # test-servers, etc.). No-op on non-Linux runners.
+          ulimit -c unlimited || true
           # Fail fast on mutually exclusive inputs — both would accumulate
           # -api filters and produce an empty test partition.
           if [[ "${{ inputs.cpu-only }}" == "true" && "${{ inputs.gpu-api-only }}" == "true" ]]; then
@@ -175,6 +194,49 @@ jobs:
             via_glsl_args+=("-skip-list" "tests/skip-list-gpu-t4.txt")
           fi
           "$bin_dir/slang-test" "${via_glsl_args[@]}"
+
+      # TEMPORARY: extract gdb backtraces from any cores produced above and
+      # upload both backtraces and raw cores as artifacts. Paired with
+      # "Enable core dumps (Linux)". Remove once the SIGILL is root-caused.
+      - name: Capture core dumps (Linux)
+        if: always() && inputs.os == 'linux'
+        shell: bash
+        run: |
+          shopt -s nullglob
+          cores=("$GITHUB_WORKSPACE/cores"/core.*)
+          if [ "${#cores[@]}" -eq 0 ]; then
+            echo "No core dumps captured."
+            exit 0
+          fi
+          echo "Captured ${#cores[@]} core dump(s):"
+          ls -lh "${cores[@]}"
+          mkdir -p "$GITHUB_WORKSPACE/cores/backtraces"
+          for c in "${cores[@]}"; do
+            name=$(basename "$c")
+            # Pull the executable name out of core.<exe>.<pid>.
+            exe_name=${name#core.}
+            exe_name=${exe_name%.*}
+            exe_path="$bin_dir/$exe_name"
+            if [ ! -x "$exe_path" ]; then
+              # Fall back to whatever gdb finds in the core itself.
+              exe_path=""
+            fi
+            bt_file="$GITHUB_WORKSPACE/cores/backtraces/$name.bt.txt"
+            echo "=== Backtrace for $name (exe=$exe_path) ===" | tee "$bt_file"
+            gdb -batch \
+              -ex "set pagination off" \
+              -ex "thread apply all bt full" \
+              ${exe_path:+"$exe_path"} "$c" 2>&1 | tee -a "$bt_file" || true
+          done
+
+      - name: Upload core dumps and backtraces
+        if: always() && inputs.os == 'linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: cores-${{ inputs.os }}-${{ inputs.platform }}-${{ inputs.compiler }}-${{ inputs.config }}${{ inputs.artifact-suffix }}
+          path: cores/
+          if-no-files-found: ignore
+          retention-days: 7
 
   # Run slang-rhi tests when:
   # 1. full-gpu-tests is enabled AND

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -233,6 +233,14 @@ jobs:
           # Inherit unlimited core size for any child processes (slang-test,
           # test-servers, etc.). No-op on non-Linux runners.
           ulimit -c unlimited || true
+          # TEMPORARY: have slang-llvm dump every JIT module's IR so we can
+          # inspect per-function `target-features` attributes for the SIGILL
+          # investigation in #11062. Remove with the rest of the debug
+          # machinery once root-caused.
+          if [[ "${{ inputs.os }}" == "linux" ]]; then
+            mkdir -p "$GITHUB_WORKSPACE/llvm-ir"
+            export SLANG_LLVM_DUMP_IR_DIR="$GITHUB_WORKSPACE/llvm-ir"
+          fi
           # Fail fast on mutually exclusive inputs — both would accumulate
           # -api filters and produce an empty test partition.
           if [[ "${{ inputs.cpu-only }}" == "true" && "${{ inputs.gpu-api-only }}" == "true" ]]; then
@@ -388,6 +396,44 @@ jobs:
         with:
           name: cores-${{ inputs.os }}-${{ inputs.platform }}-${{ inputs.compiler }}-${{ inputs.config }}${{ inputs.artifact-suffix }}
           path: cores/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      # TEMPORARY: also upload the dumped LLVM IR so we can grep for
+      # `target-features` attributes (#11062). Remove with the rest of the
+      # debug machinery.
+      - name: Filter and upload LLVM IR dumps
+        if: always() && inputs.os == 'linux'
+        shell: bash
+        run: |
+          if [ ! -d "$GITHUB_WORKSPACE/llvm-ir" ]; then
+            echo "No LLVM IR dump directory; nothing to do."
+            exit 0
+          fi
+          echo "::group::IR file count and total size"
+          count=$(find "$GITHUB_WORKSPACE/llvm-ir" -name 'slang-llvm-*.ll' | wc -l)
+          echo "files: $count"
+          du -sh "$GITHUB_WORKSPACE/llvm-ir" 2>/dev/null || true
+          echo "::endgroup::"
+          echo "::group::AVX-512 feature mentions across all dumped IR"
+          grep -lE 'avx512[a-z0-9]*' "$GITHUB_WORKSPACE/llvm-ir"/*.ll 2>/dev/null \
+            | head -10 || echo "(none — IR has no AVX-512 attributes)"
+          echo "::endgroup::"
+          echo "::group::Sample target-features attributes (first match per file, up to 5)"
+          for f in "$GITHUB_WORKSPACE"/llvm-ir/*.ll; do
+            [ -f "$f" ] || continue
+            line=$(grep -m1 'target-features' "$f" | head -c 400 || true)
+            if [ -n "$line" ]; then
+              printf '%s:\n  %s\n' "$(basename "$f")" "$line"
+            fi
+          done | head -50
+          echo "::endgroup::"
+      - name: Upload LLVM IR dumps
+        if: always() && inputs.os == 'linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: llvm-ir-${{ inputs.os }}-${{ inputs.platform }}-${{ inputs.compiler }}-${{ inputs.config }}${{ inputs.artifact-suffix }}
+          path: llvm-ir/
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -188,8 +188,12 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Execute kmovd %eax, %k1 in a child"
-          # The exact instruction we observed crashing in the cores. Run in
-          # a forked child so SIGILL doesn't terminate the whole job.
+          # The exact instruction we observed crashing in the cores. Use the
+          # raw VEX encoding via .byte so this assembles even on toolchains
+          # that don't have AVX-512 enabled by default (system gcc on
+          # GitHub-hosted ubuntu often won't accept "%k1" without -mavx512f).
+          # Run in a forked child so SIGILL doesn't terminate the whole job.
+          # `kmovd %eax, %k1` -> C5 FB 92 C8 (verified with llvm-mc)
           cat >/tmp/avx512.c <<'EOF'
           #include <stdio.h>
           #include <stdlib.h>
@@ -199,7 +203,7 @@ jobs:
               pid_t p = fork();
               if (p < 0) { perror("fork"); return 2; }
               if (p == 0) {
-                  __asm__ volatile("kmovd %%eax, %%k1" : : : "k1");
+                  __asm__ volatile(".byte 0xc5,0xfb,0x92,0xc8"); /* kmovd %eax, %k1 */
                   fputs("kmovd executed cleanly\n", stdout);
                   fflush(stdout);
                   _exit(0);
@@ -220,8 +224,7 @@ jobs:
               return 3;
           }
           EOF
-          cc -O0 -o /tmp/avx512 /tmp/avx512.c
-          /tmp/avx512
+          cc -O0 -o /tmp/avx512 /tmp/avx512.c && /tmp/avx512 || true
           echo "kmovd probe exit code: $?"
           echo "::endgroup::"
 

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -91,6 +91,140 @@ jobs:
           # Make sure gdb is installed for the post-run extraction step.
           sudo apt-get install -y --no-install-recommends gdb
 
+      # TEMPORARY: gather AVX-512 detection ground truth on each Linux test
+      # runner so we can validate the hypothesis behind #11062 (slang-llvm JIT
+      # emits AVX-512 because LLVM reports the CPU supports it, then the
+      # instruction faults at execution). Confirms which of these is happening:
+      #   (a) CPUID reports AVX-512 + XCR0 has bits 5-7 + kmovd runs cleanly
+      #       → falsifies hypothesis, points at IR/JIT-attribute leakage
+      #   (b) CPUID reports AVX-512 but XCR0 lacks bits 5-7
+      #       → OS XSAVE problem
+      #   (c) CPUID reports AVX-512, XCR0 fine, kmovd still SIGILLs
+      #       → hypervisor passthrough / instruction-mask discrepancy
+      # Remove once #11062 is fixed and verified.
+      - name: CPUID / AVX-512 probe (Linux)
+        if: inputs.os == 'linux'
+        shell: bash
+        run: |
+          echo "::group::Runner identity"
+          uname -a
+          # boot_id is unique per host boot — proxy for "same physical host".
+          if [ -r /proc/sys/kernel/random/boot_id ]; then
+            printf 'boot_id=%s\n' "$(cat /proc/sys/kernel/random/boot_id)"
+          fi
+          echo "::endgroup::"
+
+          echo "::group::/proc/cpuinfo (first processor entry)"
+          awk '/^processor/{n++} n==2{exit} {print}' /proc/cpuinfo
+          echo "::endgroup::"
+
+          echo "::group::AVX-512 family flags reported in /proc/cpuinfo"
+          grep -oE 'avx512[a-z0-9]*' /proc/cpuinfo | sort -u || echo "(none)"
+          echo "::endgroup::"
+
+          echo "::group::clang -march=native (LLVM-style detection)"
+          if command -v clang >/dev/null 2>&1; then
+            clang --version | head -1
+            # Print only the cc1 invocation line; that contains all
+            # -target-cpu and -target-feature flags clang would set.
+            clang -E -x c /dev/null -march=native -### 2>&1 \
+              | tr ' ' '\n' \
+              | grep -E '^-(target-cpu|target-feature|march|mcpu)' \
+              | sort -u || true
+          else
+            echo "(clang not on PATH)"
+          fi
+          echo "::endgroup::"
+
+          echo "::group::CPUID leaf 7, sub 0 (raw)"
+          cat >/tmp/cpuid.c <<'EOF'
+          #include <stdio.h>
+          #include <stdint.h>
+          static void cpuid_count(uint32_t leaf, uint32_t sub,
+                                  uint32_t *a, uint32_t *b,
+                                  uint32_t *c, uint32_t *d) {
+              __asm__ volatile("cpuid"
+                  : "=a"(*a), "=b"(*b), "=c"(*c), "=d"(*d)
+                  : "a"(leaf), "c"(sub));
+          }
+          int main(void) {
+              uint32_t a, b, c, d;
+              cpuid_count(7, 0, &a, &b, &c, &d);
+              printf("EAX=0x%08x EBX=0x%08x ECX=0x%08x EDX=0x%08x\n", a, b, c, d);
+              printf("  AVX-512F   (EBX bit 16): %s\n", (b & (1u<<16)) ? "yes" : "no");
+              printf("  AVX-512DQ  (EBX bit 17): %s\n", (b & (1u<<17)) ? "yes" : "no");
+              printf("  AVX-512CD  (EBX bit 28): %s\n", (b & (1u<<28)) ? "yes" : "no");
+              printf("  AVX-512BW  (EBX bit 30): %s\n", (b & (1u<<30)) ? "yes" : "no");
+              printf("  AVX-512VL  (EBX bit 31): %s\n", (b & (1u<<31)) ? "yes" : "no");
+              printf("  AVX-512VBMI(ECX bit  1): %s\n", (c & (1u<< 1)) ? "yes" : "no");
+              printf("  AVX-512VNNI(ECX bit 11): %s\n", (c & (1u<<11)) ? "yes" : "no");
+              return 0;
+          }
+          EOF
+          cc -O0 -o /tmp/cpuid /tmp/cpuid.c && /tmp/cpuid || echo "(cpuid probe failed)"
+          echo "::endgroup::"
+
+          echo "::group::OS XSAVE state (XCR0)"
+          # AVX-512 also requires the OS to enable XSAVE for opmask + ZMM regs
+          # (XCR0 bits 5, 6, 7). If those are clear, AVX-512 instructions
+          # raise #UD even on supporting hardware.
+          cat >/tmp/xcr0.c <<'EOF'
+          #include <stdio.h>
+          #include <stdint.h>
+          int main(void) {
+              uint32_t a, d;
+              __asm__ volatile("xgetbv" : "=a"(a), "=d"(d) : "c"(0));
+              uint64_t xcr0 = ((uint64_t)d << 32) | a;
+              printf("XCR0=0x%016llx\n", (unsigned long long)xcr0);
+              printf("  X87/SSE  (bits 0-1): %s\n", (xcr0 & 0x3) == 0x3 ? "on" : "off");
+              printf("  AVX      (bit 2):    %s\n", (xcr0 & (1ull<<2)) ? "on" : "off");
+              printf("  opmask   (bit 5):    %s\n", (xcr0 & (1ull<<5)) ? "on" : "off");
+              printf("  ZMM_Hi256(bit 6):    %s\n", (xcr0 & (1ull<<6)) ? "on" : "off");
+              printf("  Hi16_ZMM (bit 7):    %s\n", (xcr0 & (1ull<<7)) ? "on" : "off");
+              return 0;
+          }
+          EOF
+          cc -O0 -o /tmp/xcr0 /tmp/xcr0.c && /tmp/xcr0 || echo "(xcr0 probe failed)"
+          echo "::endgroup::"
+
+          echo "::group::Execute kmovd %eax, %k1 in a child"
+          # The exact instruction we observed crashing in the cores. Run in
+          # a forked child so SIGILL doesn't terminate the whole job.
+          cat >/tmp/avx512.c <<'EOF'
+          #include <stdio.h>
+          #include <stdlib.h>
+          #include <unistd.h>
+          #include <sys/wait.h>
+          int main(void) {
+              pid_t p = fork();
+              if (p < 0) { perror("fork"); return 2; }
+              if (p == 0) {
+                  __asm__ volatile("kmovd %%eax, %%k1" : : : "k1");
+                  fputs("kmovd executed cleanly\n", stdout);
+                  fflush(stdout);
+                  _exit(0);
+              }
+              int s = 0;
+              waitpid(p, &s, 0);
+              if (WIFEXITED(s)) {
+                  printf("child exited normally, status=%d\n", WEXITSTATUS(s));
+                  return 0;
+              }
+              if (WIFSIGNALED(s)) {
+                  int sig = WTERMSIG(s);
+                  printf("child killed by signal %d (%s)\n", sig,
+                         sig == 4 ? "SIGILL" : sig == 11 ? "SIGSEGV" : "other");
+                  return 132;
+              }
+              printf("child finished in unexpected state, raw=0x%x\n", s);
+              return 3;
+          }
+          EOF
+          cc -O0 -o /tmp/avx512 /tmp/avx512.c
+          /tmp/avx512
+          echo "kmovd probe exit code: $?"
+          echo "::endgroup::"
+
       - name: Test Slang
         run: |
           # Inherit unlimited core size for any child processes (slang-test,

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -203,9 +203,16 @@ jobs:
         shell: bash
         run: |
           shopt -s nullglob
+          # Drop known-benign cores from intentional unit-test crashes (test-process
+          # exercises subprocess management; gfx-smoke fails to load a GPU driver
+          # on the GitHub-hosted runner). Keeps the artifact lean so the slang-test
+          # cores we actually care about are easy to find.
+          for benign in test-process gfx-smoke; do
+            rm -f "$GITHUB_WORKSPACE/cores/core.$benign".*
+          done
           cores=("$GITHUB_WORKSPACE/cores"/core.*)
           if [ "${#cores[@]}" -eq 0 ]; then
-            echo "No core dumps captured."
+            echo "No interesting core dumps captured."
             exit 0
           fi
           echo "Captured ${#cores[@]} core dump(s):"
@@ -223,9 +230,18 @@ jobs:
             fi
             bt_file="$GITHUB_WORKSPACE/cores/backtraces/$name.bt.txt"
             echo "=== Backtrace for $name (exe=$exe_path) ===" | tee "$bt_file"
+            # Run a richer gdb inspection: registers, faulting instruction,
+            # disassembly around $pc, shared-library map (so we can correlate
+            # the faulting RIP to a JITed mmap region), and process mappings.
             gdb -batch \
               -ex "set pagination off" \
+              -ex "set print pretty on" \
               -ex "thread apply all bt full" \
+              -ex "info registers" \
+              -ex "x/i \$pc" \
+              -ex "x/16i \$pc-32" \
+              -ex "info sharedlibrary" \
+              -ex "maintenance info sections" \
               ${exe_path:+"$exe_path"} "$c" 2>&1 | tee -a "$bt_file" || true
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.filter.outputs.should-run }}
+      cpu-only-debug: ${{ steps.filter.outputs.cpu-only-debug }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,10 +46,22 @@ jobs:
           fi
           echo "should-run=$shouldRun" >> $GITHUB_OUTPUT
 
+          # TEMPORARY: on the ci/debug-slang-test-sigill branch only, run a
+          # minimal subset of jobs (linux-release build + linux-cpu test) so
+          # we can iterate cheaply on the SIGILL repro. Drop this when the
+          # debug PR is closed.
+          headRef='${{ github.head_ref }}'
+          refName='${{ github.ref_name }}'
+          if [[ "$headRef" == "ci/debug-slang-test-sigill" || "$refName" == "ci/debug-slang-test-sigill" ]]; then
+            echo "cpu-only-debug=true" >> $GITHUB_OUTPUT
+          else
+            echo "cpu-only-debug=false" >> $GITHUB_OUTPUT
+          fi
+
   # Linux builds (containerized builds on GitHub-hosted runners)
   build-linux-debug-gcc-x86_64:
     needs: [filter]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-build-container.yml
     with:
       config: debug
@@ -64,7 +77,7 @@ jobs:
 
   build-linux-release-gcc-wasm:
     needs: [filter]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-build.yml
     with:
       os: linux
@@ -76,7 +89,7 @@ jobs:
   # Sanitizer build+test (blocking via check-ci, runs on every PR)
   sanitizer-linux-clang-x86_64:
     needs: [filter]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-sanitizer.yml
     with:
       runs-on: '["ubuntu-22.04"]'
@@ -84,7 +97,7 @@ jobs:
   # macOS builds
   build-macos-debug-clang-aarch64:
     needs: [filter]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-build.yml
     with:
       os: macos
@@ -95,7 +108,7 @@ jobs:
 
   build-macos-release-clang-aarch64:
     needs: [filter]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-build.yml
     with:
       os: macos
@@ -107,7 +120,7 @@ jobs:
   # Linux ARM64 builds (GitHub-hosted)
   build-linux-debug-gcc-aarch64:
     needs: [filter]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-build.yml
     with:
       os: linux
@@ -119,7 +132,7 @@ jobs:
 
   build-linux-release-gcc-aarch64:
     needs: [filter]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-build.yml
     with:
       os: linux
@@ -132,7 +145,7 @@ jobs:
   # Windows builds (self-hosted)
   build-windows-debug-cl-x86_64-gpu:
     needs: [filter]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-build.yml
     with:
       os: windows
@@ -143,7 +156,7 @@ jobs:
 
   build-windows-release-cl-x86_64-gpu:
     needs: [filter]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-build.yml
     with:
       os: windows
@@ -155,7 +168,7 @@ jobs:
   # Linux tests (self-hosted GPU runner, containerized)
   test-linux-debug-gcc-x86_64:
     needs: [filter, build-linux-debug-gcc-x86_64]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-test-container.yml
     with:
       config: debug
@@ -163,7 +176,7 @@ jobs:
 
   test-linux-release-gcc-x86_64:
     needs: [filter, build-linux-release-gcc-x86_64]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-test-container.yml
     with:
       config: release
@@ -174,7 +187,7 @@ jobs:
   # execute after CUDA coopmat moves to Ampere-only mma.sync PTX.
   test-linux-release-gcc-x86_64-sm80:
     needs: [filter, build-linux-release-gcc-x86_64]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-test-container.yml
     with:
       config: release
@@ -208,7 +221,7 @@ jobs:
   # macOS tests
   test-macos-debug-clang-aarch64:
     needs: [filter, build-macos-debug-clang-aarch64]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-test.yml
     with:
       os: macos
@@ -222,7 +235,7 @@ jobs:
 
   test-macos-release-clang-aarch64:
     needs: [filter, build-macos-release-clang-aarch64]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-test.yml
     with:
       os: macos
@@ -237,7 +250,7 @@ jobs:
   # Linux ARM64 tests (GitHub-hosted, CPU only)
   test-linux-debug-gcc-aarch64:
     needs: [filter, build-linux-debug-gcc-aarch64]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-test.yml
     with:
       os: linux
@@ -250,7 +263,7 @@ jobs:
 
   test-linux-release-gcc-aarch64:
     needs: [filter, build-linux-release-gcc-aarch64]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-test.yml
     with:
       os: linux
@@ -264,7 +277,7 @@ jobs:
   # Windows GPU tests (self-hosted)
   test-windows-debug-cl-x86_64-gpu:
     needs: [filter, build-windows-debug-cl-x86_64-gpu]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-test.yml
     with:
       os: windows
@@ -278,7 +291,7 @@ jobs:
 
   test-windows-release-cl-x86_64-gpu:
     needs: [filter, build-windows-release-cl-x86_64-gpu]
-    if: needs.filter.outputs.should-run == 'true'
+    if: needs.filter.outputs.should-run == 'true' && needs.filter.outputs.cpu-only-debug != 'true'
     uses: ./.github/workflows/ci-slang-test.yml
     with:
       os: windows

--- a/source/slang-llvm/slang-llvm.cpp
+++ b/source/slang-llvm/slang-llvm.cpp
@@ -64,6 +64,7 @@
 #include <core/slang-shared-library.h>
 #include <core/slang-string-util.h>
 #include <core/slang-string.h>
+#include <optional>
 #include <stdio.h>
 
 // We want to make math functions available to the JIT
@@ -883,6 +884,26 @@ SlangResult LLVMDownstreamCompiler::compile(
             // Get the module produced by the action
             module = codeGenAction->takeModule();
             break;
+        }
+    }
+
+    // TEMPORARY: dump LLVM IR pre-JIT when SLANG_LLVM_DUMP_IR_DIR is set so
+    // we can inspect per-function `target-features` attributes (#11062).
+    // Writes <dir>/slang-llvm-<pid>-<seq>.ll. Remove with the rest of the
+    // SIGILL debug machinery.
+    if (module)
+    {
+        std::optional<std::string> dumpDir = llvm::sys::Process::GetEnv("SLANG_LLVM_DUMP_IR_DIR");
+        if (dumpDir.has_value() && !dumpDir->empty())
+        {
+            static unsigned dumpSeq = 0;
+            std::string path = *dumpDir + "/slang-llvm-" +
+                               std::to_string(llvm::sys::Process::getProcessId()) + "-" +
+                               std::to_string(dumpSeq++) + ".ll";
+            std::error_code ec;
+            llvm::raw_fd_ostream out(path, ec);
+            if (!ec)
+                module->print(out, nullptr);
         }
     }
 


### PR DESCRIPTION
## Summary

- Temporary diagnostic PR to capture cores + gdb backtraces for the SIGILL we keep seeing in slang-test on the linux-cpu job
- Two recent occurrences both crashed at the same boundary (right after `tests/autodiff/global-param-hoisting.slang.1 (vk)`), so it's a reproducible-ish crash, not random flakiness
- Existing CI logs only show `Illegal instruction (core dumped)` — kernel produces a core but nothing collects it. This PR fixes that, Linux-only

## Related occurrences

- 2026-05-04: PR #10977 merge queue run [25321832084](https://github.com/shader-slang/slang/actions/runs/25321832084) — `test-linux-release-gcc-x86_64-cpu` died with exit 132 after `global-param-hoisting.slang.1 (vk) [ignored]`
- 2026-05-05: PR #11053 merge queue run [25355110955](https://github.com/shader-slang/slang/actions/runs/25355110955) — same job, same boundary

The Windows coverage workflow already skip-lists this test prefix because of the *same* `EXCEPTION_ILLEGAL_INSTRUCTION` symptom (see comment in `.github/workflows/ci-slang-coverage.yml:296-307`), but the regular Linux test workflow doesn't, and we've never gotten a backtrace.

## What this PR does

1. Before `Test Slang` (Linux only): override Ubuntu's default `core_pattern` (which pipes to apport) to a path inside `$GITHUB_WORKSPACE/cores`, raise `ulimit -c`, install `gdb`
2. After all test steps (`if: always()`, Linux only): walk any captured cores, run `gdb -batch -ex "thread apply all bt full"` against each to produce a `.bt.txt`, upload the whole `cores/` directory as an artifact

Artifact name includes os/platform/compiler/config so the matrix axes don't collide.

## Do not merge

This is a debug-only change. Once we get a backtrace and root-cause the crash, this should be reverted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI diagnostics with CPU feature detection probes to identify AVX-512 and CPUID capabilities during builds and tests.
  * Implemented core dump capture and backtrace analysis for Linux test environments to improve debugging of test failures.
  * Added temporary debug workflow path for targeted troubleshooting on specific branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->