### PR TITLE
Fix #line directive showing wrong source line in diagnostics

### DIFF
--- a/source/compiler-core/slang-rich-diagnostics-render.cpp
+++ b/source/compiler-core/slang-rich-diagnostics-render.cpp
@@ -311,9 +311,16 @@ private:
                 if (view)
                 {
                     line.sourceAvailable = true;
+                    // Retrieve the source line using the *physical* line index
+                    // (derived from the raw SourceLoc offset), not the humane line
+                    // number. The humane line may have been remapped by a #line
+                    // directive and would index the wrong line in the file.
+                    auto physicalOffset = view->getRange().getOffset(span.startLoc);
+                    auto physicalLineIndex =
+                        view->getSourceFile()->calcLineIndexFromOffset(physicalOffset);
                     // Get the line content and trim end-of-line characters and trailing whitespace
                     UnownedStringSlice rawLine = StringUtil::trimEndOfLine(
-                        view->getSourceFile()->getLineAtIndex(span.line - 1));
+                        view->getSourceFile()->getLineAtIndex(physicalLineIndex));
                     // Trim trailing whitespace but preserve leading whitespace (indentation)
                     line.content = UnownedStringSlice(rawLine.begin(), rawLine.trim().end());
                 }
@@ -783,8 +790,10 @@ String renderDiagnosticMachineReadable(
             SourceView* view = sm->findSourceView(span.range.begin);
             if (view)
             {
-                UnownedStringSlice rawLine = StringUtil::trimEndOfLine(
-                    view->getSourceFile()->getLineAtIndex(beginLoc.line - 1));
+                auto offset = view->getRange().getOffset(span.range.begin);
+                auto lineIdx = view->getSourceFile()->calcLineIndexFromOffset(offset);
+                UnownedStringSlice rawLine =
+                    StringUtil::trimEndOfLine(view->getSourceFile()->getLineAtIndex(lineIdx));
                 UnownedStringSlice lineContent =
                     UnownedStringSlice(rawLine.begin(), rawLine.trim().end());
                 if (lineContent.getLength() > 0 && beginLoc.column > 0 &&

--- a/source/compiler-core/slang-rich-diagnostics-render.cpp
+++ b/source/compiler-core/slang-rich-diagnostics-render.cpp
@@ -311,16 +311,13 @@ private:
                 if (view)
                 {
                     line.sourceAvailable = true;
-                    // Retrieve the source line using the *physical* line index
-                    // (derived from the raw SourceLoc offset), not the humane line
-                    // number. The humane line may have been remapped by a #line
-                    // directive and would index the wrong line in the file.
-                    auto physicalOffset = view->getRange().getOffset(span.startLoc);
-                    auto physicalLineIndex =
-                        view->getSourceFile()->calcLineIndexFromOffset(physicalOffset);
+                    // Use the *actual* (non-remapped) line so that a #line
+                    // directive doesn't cause us to display the wrong source.
+                    auto actualLine =
+                        view->getHumaneLoc(span.startLoc, SourceLocType::Actual).line;
                     // Get the line content and trim end-of-line characters and trailing whitespace
                     UnownedStringSlice rawLine = StringUtil::trimEndOfLine(
-                        view->getSourceFile()->getLineAtIndex(physicalLineIndex));
+                        view->getSourceFile()->getLineAtIndex(actualLine - 1));
                     // Trim trailing whitespace but preserve leading whitespace (indentation)
                     line.content = UnownedStringSlice(rawLine.begin(), rawLine.trim().end());
                 }
@@ -790,10 +787,10 @@ String renderDiagnosticMachineReadable(
             SourceView* view = sm->findSourceView(span.range.begin);
             if (view)
             {
-                auto offset = view->getRange().getOffset(span.range.begin);
-                auto lineIdx = view->getSourceFile()->calcLineIndexFromOffset(offset);
+                auto actualLine =
+                    view->getHumaneLoc(span.range.begin, SourceLocType::Actual).line;
                 UnownedStringSlice rawLine =
-                    StringUtil::trimEndOfLine(view->getSourceFile()->getLineAtIndex(lineIdx));
+                    StringUtil::trimEndOfLine(view->getSourceFile()->getLineAtIndex(actualLine - 1));
                 UnownedStringSlice lineContent =
                     UnownedStringSlice(rawLine.begin(), rawLine.trim().end());
                 if (lineContent.getLength() > 0 && beginLoc.column > 0 &&

--- a/source/compiler-core/slang-rich-diagnostics-render.cpp
+++ b/source/compiler-core/slang-rich-diagnostics-render.cpp
@@ -313,8 +313,7 @@ private:
                     line.sourceAvailable = true;
                     // Use the *actual* (non-remapped) line so that a #line
                     // directive doesn't cause us to display the wrong source.
-                    auto actualLine =
-                        view->getHumaneLoc(span.startLoc, SourceLocType::Actual).line;
+                    auto actualLine = view->getHumaneLoc(span.startLoc, SourceLocType::Actual).line;
                     // Get the line content and trim end-of-line characters and trailing whitespace
                     UnownedStringSlice rawLine = StringUtil::trimEndOfLine(
                         view->getSourceFile()->getLineAtIndex(actualLine - 1));
@@ -787,10 +786,9 @@ String renderDiagnosticMachineReadable(
             SourceView* view = sm->findSourceView(span.range.begin);
             if (view)
             {
-                auto actualLine =
-                    view->getHumaneLoc(span.range.begin, SourceLocType::Actual).line;
-                UnownedStringSlice rawLine =
-                    StringUtil::trimEndOfLine(view->getSourceFile()->getLineAtIndex(actualLine - 1));
+                auto actualLine = view->getHumaneLoc(span.range.begin, SourceLocType::Actual).line;
+                UnownedStringSlice rawLine = StringUtil::trimEndOfLine(
+                    view->getSourceFile()->getLineAtIndex(actualLine - 1));
                 UnownedStringSlice lineContent =
                     UnownedStringSlice(rawLine.begin(), rawLine.trim().end());
                 if (lineContent.getLength() > 0 && beginLoc.column > 0 &&

--- a/tests/diagnostics/line-directive-display.slang
+++ b/tests/diagnostics/line-directive-display.slang
@@ -1,0 +1,25 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):-target spirv -no-codegen
+
+// Regression test for #10837.
+//
+// When a `#line` directive remaps line numbers, the diagnostic renderer
+// used to show the wrong source line (using the remapped line number
+// to index into the physical file). Verify the correct source line is
+// displayed — it should show the line containing `undeclaredIdentifier`,
+// not the padding struct field at physical line 3.
+
+struct Padding {
+    uint a;
+    uint b;
+};
+
+#line 1
+void test()
+{
+    int x = undeclaredIdentifier;
+}
+
+// The displayed source line must be the actual error line, not a
+// padding struct field from the physical file.
+// CHECK: undeclaredIdentifier
+// CHECK: undefined identifier

--- a/tests/diagnostics/line-directive-display.slang
+++ b/tests/diagnostics/line-directive-display.slang
@@ -22,4 +22,5 @@ void test()
 // The displayed source line must be the actual error line, not a
 // padding struct field from the physical file.
 // CHECK: undeclaredIdentifier
+// CHECK-NOT: uint b
 // CHECK: undefined identifier

--- a/tests/literate/diagnostic-line-number.slang.md
+++ b/tests/literate/diagnostic-line-number.slang.md
@@ -9,7 +9,7 @@ report the correct line number from the original Markdown file.
 void foo()
 {
     int x = undefinedVar;
-//CHECK:    ^ undefined identifier
-//CHECK:    ^ undefined identifier 'undefinedVar'.
+//CHECK:    ^^^^^^^^^^^^ undefined identifier
+//CHECK:    ^^^^^^^^^^^^ undefined identifier 'undefinedVar'.
 }
 ```


### PR DESCRIPTION
## Summary
- When a `#line` directive remaps line numbers, the diagnostic renderer used the remapped line number to index into the physical source file, displaying the wrong source line
- For example, `#line 1` resets numbering so an error on remapped line 8 would show physical line 8 (`};`) instead of the actual source line (`color = float4(...)`)
- Fixes both the rich-diagnostic and machine-readable rendering paths to compute the physical line index from the raw `SourceLoc` offset

Fixes #10837

## Test plan
- [x] `tests/diagnostics/line-directive-display.slang` — verifies the rendered source line contains the actual error token, not a line from the padding struct
- [x] Manually verified all four crash variants from the issue report

🤖 Generated with [Claude Code](https://claude.com/claude-code)