### PR TITLE
Clamp SPIR-V debug line columns to debug source

### DIFF
--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -470,6 +470,13 @@ struct IRGenEnv
     IRGenEnv* outer = nullptr;
 };
 
+struct DebugSourceLineColumnCache
+{
+    bool isInitialized = false;
+    bool hasEmbeddedSourceText = false;
+    List<IRIntegerValue> lineMaxColumns;
+};
+
 struct SharedIRGenContext
 {
 
@@ -498,6 +505,7 @@ struct SharedIRGenContext
 
     Dictionary<SourceFile*, IRInst*> mapSourceFileToDebugSourceInst;
     Dictionary<String, IRInst*> mapSourcePathToDebugSourceInst;
+    Dictionary<IRInst*, DebugSourceLineColumnCache> mapDebugSourceToLineColumnCache;
 
     Dictionary<IntVal*, IRInst*> mapSpecConstValToIRInst;
 
@@ -8966,55 +8974,77 @@ IRInst* getOrEmitDebugSource(IRGenContext* context, SourceLoc loc)
     return debugSourceInst;
 }
 
-static bool _getDebugSourceLine(
-    IRInst* debugSourceInst,
-    IRIntegerValue oneBasedLine,
-    UnownedStringSlice& outLine)
+static DebugSourceLineColumnCache _buildDebugSourceLineColumnCache(IRInst* debugSourceInst)
 {
+    DebugSourceLineColumnCache cache;
+    cache.isInitialized = true;
+
     auto debugSource = as<IRDebugSource>(debugSourceInst);
-    if (!debugSource || oneBasedLine <= 0)
-        return false;
+    if (!debugSource)
+        return cache;
 
     auto source = as<IRStringLit>(debugSource->getSource());
     if (!source)
-        return false;
+        return cache;
 
     UnownedStringSlice remaining = source->getStringSlice();
     if (remaining.getLength() == 0)
-        return false;
+        return cache;
 
+    cache.hasEmbeddedSourceText = true;
     UnownedStringSlice line;
-    for (IRIntegerValue lineCounter = 1; lineCounter <= oneBasedLine; ++lineCounter)
+    while (StringUtil::extractLine(remaining, line))
     {
-        if (!StringUtil::extractLine(remaining, line))
-            return false;
+        // HumaneSourceLoc columns are code-point based when SourceFile has contents, so keep the
+        // cached SPIR-V validation bound in the same units.
+        cache.lineMaxColumns.add(IRIntegerValue(UTF8Util::calcCodePointCount(line) + 1));
     }
 
-    outLine = line;
+    return cache;
+}
+
+static bool _tryGetDebugSourceLineMaxColumn(
+    IRGenContext* context,
+    IRInst* debugSourceInst,
+    IRIntegerValue oneBasedLine,
+    IRIntegerValue& outMaxColumn)
+{
+    auto& cache = context->shared->mapDebugSourceToLineColumnCache[debugSourceInst];
+    if (!cache.isInitialized)
+        cache = _buildDebugSourceLineColumnCache(debugSourceInst);
+
+    if (!cache.hasEmbeddedSourceText)
+        return false;
+
+    // SPIRV-Tools validates DebugLine columns against the embedded DebugSource text. The maximum
+    // accepted column is one past the final code point on the source line. If the line is outside
+    // the embedded text, clamp to column 1 as the only defensible column for an absent line.
+    if (oneBasedLine <= 0)
+    {
+        outMaxColumn = 1;
+        return true;
+    }
+
+    const auto lineIndex = Index(oneBasedLine - 1);
+    if (lineIndex >= 0 && lineIndex < cache.lineMaxColumns.getCount())
+    {
+        outMaxColumn = cache.lineMaxColumns[lineIndex];
+        return true;
+    }
+
+    outMaxColumn = 1;
     return true;
 }
 
-static IRIntegerValue _getDebugSourceLineMaxColumn(
-    IRInst* debugSourceInst,
-    IRIntegerValue oneBasedLine)
-{
-    UnownedStringSlice line;
-    if (!_getDebugSourceLine(debugSourceInst, oneBasedLine, line))
-        return 0;
-
-    // SPIRV-Tools validates DebugLine columns against the embedded DebugSource text, with the
-    // maximum accepted column being one past the final character on the source line.
-    return IRIntegerValue(UTF8Util::calcCodePointCount(line) + 1);
-}
-
 static void _clampDebugLineColumns(
+    IRGenContext* context,
     IRInst* debugSourceInst,
     IRIntegerValue line,
     IRIntegerValue& colStart,
     IRIntegerValue& colEnd)
 {
-    const IRIntegerValue maxColumn = _getDebugSourceLineMaxColumn(debugSourceInst, line);
-    if (maxColumn <= 0)
+    IRIntegerValue maxColumn = 0;
+    if (!_tryGetDebugSourceLineMaxColumn(context, debugSourceInst, line, maxColumn))
         return;
 
     if (colStart < 1)
@@ -9028,18 +9058,32 @@ static void _clampDebugLineColumns(
         colEnd = maxColumn;
 }
 
+static IRIntegerValue _clampDebugColumn(
+    IRGenContext* context,
+    IRInst* debugSourceInst,
+    IRIntegerValue line,
+    IRIntegerValue column)
+{
+    IRIntegerValue maxColumn = 0;
+    if (!_tryGetDebugSourceLineMaxColumn(context, debugSourceInst, line, maxColumn))
+        return column;
+
+    if (column < 1)
+        return 1;
+    if (column > maxColumn)
+        return maxColumn;
+    return column;
+}
+
 static HumaneSourceLoc _getDebugHumaneLoc(
-    SourceManager* sourceManager,
+    IRGenContext* context,
     IRInst* debugSourceInst,
     SourceLoc loc)
 {
+    auto sourceManager = context->getLinkage()->getSourceManager();
     auto humaneLoc = sourceManager->getHumaneLoc(loc, SourceLocType::Emit);
-
-    IRIntegerValue colStart = humaneLoc.column;
-    IRIntegerValue colEnd = colStart;
-    _clampDebugLineColumns(debugSourceInst, humaneLoc.line, colStart, colEnd);
-    humaneLoc.column = colStart;
-
+    humaneLoc.column =
+        _clampDebugColumn(context, debugSourceInst, humaneLoc.line, humaneLoc.column);
     return humaneLoc;
 }
 
@@ -9067,10 +9111,10 @@ void maybeEmitDebugLine(
         return;
 
     auto sourceManager = context->getLinkage()->getSourceManager();
-    auto humaneLoc = _getDebugHumaneLoc(sourceManager, debugSourceInst, loc);
+    auto humaneLoc = sourceManager->getHumaneLoc(loc, SourceLocType::Emit);
     IRIntegerValue colStart = humaneLoc.column;
     IRIntegerValue colEnd = humaneLoc.column + 1;
-    _clampDebugLineColumns(debugSourceInst, humaneLoc.line, colStart, colEnd);
+    _clampDebugLineColumns(context, debugSourceInst, humaneLoc.line, colStart, colEnd);
 
     if (visitor)
         visitor->startBlockIfNeeded(stmt);
@@ -9088,8 +9132,7 @@ void maybeAddDebugLocationDecoration(IRGenContext* context, IRInst* inst)
     if (!debugSourceInst)
         return;
 
-    auto sourceManager = context->getLinkage()->getSourceManager();
-    auto humaneLoc = _getDebugHumaneLoc(sourceManager, debugSourceInst, inst->sourceLoc);
+    auto humaneLoc = _getDebugHumaneLoc(context, debugSourceInst, inst->sourceLoc);
 
     context->irBuilder
         ->addDebugLocationDecoration(inst, debugSourceInst, humaneLoc.line, humaneLoc.column);
@@ -11043,10 +11086,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                     IRInst* debugSourceInst = getOrEmitDebugSource(context, decl->loc);
                     if (debugSourceInst)
                     {
-                        auto humaneLoc = _getDebugHumaneLoc(
-                            context->getLinkage()->getSourceManager(),
-                            debugSourceInst,
-                            decl->loc);
+                        auto humaneLoc = _getDebugHumaneLoc(context, debugSourceInst, decl->loc);
                         auto debugVar = builder->emitDebugVar(
                             varType,
                             debugSourceInst,

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9074,12 +9074,8 @@ void maybeEmitDebugLine(
 
     if (visitor)
         visitor->startBlockIfNeeded(stmt);
-    context->irBuilder->emitDebugLine(
-        debugSourceInst,
-        humaneLoc.line,
-        humaneLoc.line,
-        colStart,
-        colEnd);
+    context->irBuilder
+        ->emitDebugLine(debugSourceInst, humaneLoc.line, humaneLoc.line, colStart, colEnd);
 }
 
 void maybeAddDebugLocationDecoration(IRGenContext* context, IRInst* inst)

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -1,6 +1,7 @@
 // lower.cpp
 #include "slang-lower-to-ir.h"
 
+#include "../core/slang-char-encode.h"
 #include "../core/slang-char-util.h"
 #include "../core/slang-hash.h"
 #include "../core/slang-performance-profiler.h"
@@ -8965,6 +8966,83 @@ IRInst* getOrEmitDebugSource(IRGenContext* context, SourceLoc loc)
     return debugSourceInst;
 }
 
+static bool _getDebugSourceLine(
+    IRInst* debugSourceInst,
+    IRIntegerValue oneBasedLine,
+    UnownedStringSlice& outLine)
+{
+    auto debugSource = as<IRDebugSource>(debugSourceInst);
+    if (!debugSource || oneBasedLine <= 0)
+        return false;
+
+    auto source = as<IRStringLit>(debugSource->getSource());
+    if (!source)
+        return false;
+
+    UnownedStringSlice remaining = source->getStringSlice();
+    if (remaining.getLength() == 0)
+        return false;
+
+    UnownedStringSlice line;
+    for (IRIntegerValue lineCounter = 1; lineCounter <= oneBasedLine; ++lineCounter)
+    {
+        if (!StringUtil::extractLine(remaining, line))
+            return false;
+    }
+
+    outLine = line;
+    return true;
+}
+
+static IRIntegerValue _getDebugSourceLineMaxColumn(
+    IRInst* debugSourceInst,
+    IRIntegerValue oneBasedLine)
+{
+    UnownedStringSlice line;
+    if (!_getDebugSourceLine(debugSourceInst, oneBasedLine, line))
+        return 0;
+
+    // SPIRV-Tools validates DebugLine columns against the embedded DebugSource text, with the
+    // maximum accepted column being one past the final character on the source line.
+    return IRIntegerValue(UTF8Util::calcCodePointCount(line) + 1);
+}
+
+static void _clampDebugLineColumns(
+    IRInst* debugSourceInst,
+    IRIntegerValue line,
+    IRIntegerValue& colStart,
+    IRIntegerValue& colEnd)
+{
+    const IRIntegerValue maxColumn = _getDebugSourceLineMaxColumn(debugSourceInst, line);
+    if (maxColumn <= 0)
+        return;
+
+    if (colStart < 1)
+        colStart = 1;
+    if (colStart > maxColumn)
+        colStart = maxColumn;
+
+    if (colEnd < colStart)
+        colEnd = colStart;
+    if (colEnd > maxColumn)
+        colEnd = maxColumn;
+}
+
+static HumaneSourceLoc _getDebugHumaneLoc(
+    SourceManager* sourceManager,
+    IRInst* debugSourceInst,
+    SourceLoc loc)
+{
+    auto humaneLoc = sourceManager->getHumaneLoc(loc, SourceLocType::Emit);
+
+    IRIntegerValue colStart = humaneLoc.column;
+    IRIntegerValue colEnd = colStart;
+    _clampDebugLineColumns(debugSourceInst, humaneLoc.line, colStart, colEnd);
+    humaneLoc.column = colStart;
+
+    return humaneLoc;
+}
+
 void maybeEmitDebugLine(
     IRGenContext* context,
     StmtLoweringVisitor* visitor,
@@ -8989,7 +9067,10 @@ void maybeEmitDebugLine(
         return;
 
     auto sourceManager = context->getLinkage()->getSourceManager();
-    auto humaneLoc = sourceManager->getHumaneLoc(loc, SourceLocType::Emit);
+    auto humaneLoc = _getDebugHumaneLoc(sourceManager, debugSourceInst, loc);
+    IRIntegerValue colStart = humaneLoc.column;
+    IRIntegerValue colEnd = humaneLoc.column + 1;
+    _clampDebugLineColumns(debugSourceInst, humaneLoc.line, colStart, colEnd);
 
     if (visitor)
         visitor->startBlockIfNeeded(stmt);
@@ -8997,8 +9078,8 @@ void maybeEmitDebugLine(
         debugSourceInst,
         humaneLoc.line,
         humaneLoc.line,
-        humaneLoc.column,
-        humaneLoc.column + 1);
+        colStart,
+        colEnd);
 }
 
 void maybeAddDebugLocationDecoration(IRGenContext* context, IRInst* inst)
@@ -9012,7 +9093,7 @@ void maybeAddDebugLocationDecoration(IRGenContext* context, IRInst* inst)
         return;
 
     auto sourceManager = context->getLinkage()->getSourceManager();
-    auto humaneLoc = sourceManager->getHumaneLoc(inst->sourceLoc, SourceLocType::Emit);
+    auto humaneLoc = _getDebugHumaneLoc(sourceManager, debugSourceInst, inst->sourceLoc);
 
     context->irBuilder
         ->addDebugLocationDecoration(inst, debugSourceInst, humaneLoc.line, humaneLoc.column);
@@ -10962,14 +11043,14 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                 {
                     // Create a debug variable for this let declaration
                     auto builder = context->irBuilder;
-                    auto humaneLoc = context->getLinkage()->getSourceManager()->getHumaneLoc(
-                        decl->loc,
-                        SourceLocType::Emit);
-
                     // Find the debug source for this file
                     IRInst* debugSourceInst = getOrEmitDebugSource(context, decl->loc);
                     if (debugSourceInst)
                     {
+                        auto humaneLoc = _getDebugHumaneLoc(
+                            context->getLinkage()->getSourceManager(),
+                            debugSourceInst,
+                            decl->loc);
                         auto debugVar = builder->emitDebugVar(
                             varType,
                             debugSourceInst,

--- a/tests/spirv/debug-line-column-clamp-original.slang
+++ b/tests/spirv/debug-line-column-clamp-original.slang
@@ -1,0 +1,15 @@
+RWStructuredBuffer<float> outputBuffer;
+
+float helper(float value)
+{
+	{
+		return value;
+	}
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main()
+{
+	outputBuffer[0] = helper(1.0);
+}

--- a/tests/spirv/debug-line-column-clamp.slang
+++ b/tests/spirv/debug-line-column-clamp.slang
@@ -1,0 +1,24 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -g2 -O0 -emit-spirv-directly -entry main -stage compute
+// Verifies DebugLine columns are clamped to the embedded DebugSource text when #line maps
+// space-indented generated source back to a tab-indented source file.
+
+//CHECK-DAG: [[ORIGINAL_FILE:%[0-9]+]] = OpString "tests/spirv/debug-line-column-clamp-original.slang"
+//CHECK-DAG: [[ORIGINAL_SOURCE:%[0-9]+]] = {{.*}} DebugSource [[ORIGINAL_FILE]]
+//CHECK: DebugLine [[ORIGINAL_SOURCE]] %uint_5 %uint_5 %uint_3 %uint_3
+
+#line 1 "tests/spirv/debug-line-column-clamp-original.slang"
+RWStructuredBuffer<float> outputBuffer;
+
+float helper(float value)
+{
+    {
+    return value;
+    }
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main()
+{
+    outputBuffer[0] = helper(1.0);
+}

--- a/tests/spirv/debug-line-column-clamp.slang
+++ b/tests/spirv/debug-line-column-clamp.slang
@@ -4,6 +4,9 @@
 
 //CHECK-DAG: [[ORIGINAL_FILE:%[0-9]+]] = OpString "tests/spirv/debug-line-column-clamp-original.slang"
 //CHECK-DAG: [[ORIGINAL_SOURCE:%[0-9]+]] = {{.*}} DebugSource [[ORIGINAL_FILE]]
+// Original line 5 is "\t{" (one tab followed by one brace), so column 3 is the
+// one-past-the-line column. The generated line below is "    {" (four spaces
+// followed by one brace), so its column 5 source location must clamp to 3.
 //CHECK: DebugLine [[ORIGINAL_SOURCE]] %uint_5 %uint_5 %uint_3 %uint_3
 
 #line 1 "tests/spirv/debug-line-column-clamp-original.slang"


### PR DESCRIPTION
## Summary

- Clamp SPIR-V debug line columns to the embedded `DebugSource` text when available.
- Cache the per-line column bounds for each `DebugSource`, so lowering does not rescan large embedded source text for every debug location.
- Apply the same clamped source location to debug location decorations and direct `let` debug variables.
- Add a regression test for `#line` mapping from a space-indented generated source to a tab-indented source file.

Fixes #11064.

## Root Cause

When Slang lowers source locations for SPIR-V debug info, `SourceLocType::Emit` applies `#line` file/line remapping but keeps the column from the actual parsed/generated source file.

That means a generated/preprocessed input line that is indented with four spaces:

```slang
    }
```

can be mapped by `#line` to an original source line whose embedded `DebugSource` text is indented with three tab characters:

```slang
			}
```

In other words, the first snippet is `SPACE SPACE SPACE SPACE }`, while the second snippet is `TAB TAB TAB }`.

Slang then emitted a `DebugLine` column range based on the generated/source-view column, for example column `5` to `6`. SPIRV-Tools validates the `DebugLine` operands against the embedded mapped `DebugSource` text. In the tab-indented original line, the validator sees a shorter raw source line, so the generated end column can be past the line length and validation fails.

## Why This Fix Works

The SPIR-V `DebugLine` record references a specific `DebugSource`, so the valid column range is ultimately bounded by the text embedded in that `DebugSource`. This PR clamps emitted debug columns to the maximum column accepted for the referenced embedded source line whenever source text is available.

The clamp uses code-point counts, matching `SourceFile::calcColumnIndex()` when source content is available, and caches those one-past-the-line bounds per `DebugSource`. If an embedded source exists but a requested line is outside that text, the clamp defensively uses column `1`; if no embedded source text is available, the previous behavior is preserved.

For the failing case, the invalid range:

```text
DebugLine ... %uint_244 %uint_244 %uint_5 %uint_6
```

is emitted as a valid clamped range against the mapped tab-indented source:

```text
DebugLine ... %uint_244 %uint_244 %uint_5 %uint_5
```

## Testing

- `cmake --build build --target slangc`
- `build/Debug/bin/slang-test tests/spirv/debug-line-column-clamp.slang tests/spirv/debug-info-line-function.slang tests/spirv/debug-info-line-variable.slang tests/spirv/debug-info.slang`
- Verified the original shader command output validates with latest SPIRV-Tools `spirv-val`.
