### PR TITLE
shader-coverage: thunk-based instrumentation + same-line slot dedup

### DIFF
--- a/docs/design/shader-coverage.md
+++ b/docs/design/shader-coverage.md
@@ -400,20 +400,21 @@ it catches inlining regressions on the CPU path. Other targets do
 not have an equivalent assertion today — adding one per backend is a
 follow-up.
 
-### Slot dedup and `getEntryCount` behavior
+### Slot dedup and `getCounterCount` behavior
 
 Counter-slot assignment dedupes by `(file, line)`. Hosts auto-sizing
-their `__slang_coverage` buffer from
-`getBufferInfo().elementCount` get smaller allocations on shaders
-with multi-statement source lines (the intended outcome). The
-LCOV / gcov reporting pipeline already aggregates by `(file, line)`
-on the host, so the user-visible coverage report is unchanged.
+their `__slang_coverage` buffer from `getCounterCount()` get smaller
+allocations on shaders with multi-statement source lines (the
+intended outcome). `getBufferInfo()` reports binding location only
+(`space` + `binding`) and is unaffected by dedup. The LCOV / gcov
+reporting pipeline already aggregates by `(file, line)` on the host,
+so the user-visible coverage report is unchanged.
 
-`ICoverageTracingMetadata::getEntryCount()` returns the count of
+`ICoverageTracingMetadata::getCounterCount()` returns the count of
 unique `(file, line)` pairs, **not** the count of executable
 statements. Hosts that hardcode a slot count or assume "N statements
 → N slots" would break — but no such pattern is supported by the
-public API contract, and the existing `getEntryCount()` API
+public API contract, and the existing `getCounterCount()` API
 explicitly leaves the buffer-sizing question to the host.
 
 Counter ops with unresolvable source locations (synthetic statements

--- a/docs/design/shader-coverage.md
+++ b/docs/design/shader-coverage.md
@@ -134,11 +134,21 @@ Enabling `-trace-coverage` runs three pipeline stages:
      extension is a no-op for them; the buffer flows through emit
      as a standalone `IRGlobalParam`.
    - **Assigns a counter slot to each `IncrementCoverageCounter`
-     op** (per-inst UID — consecutive index in traversal order;
-     multiple ops on the same source line get distinct slots, which
-     keeps the door open for branch/function coverage later).
-   - **Rewrites each op as `AtomicAdd(__slang_coverage[slot], 1,
-     Relaxed)`**.
+     op**, deduped by `(file, line)`: multiple ops resolving to the
+     same source line share a slot. Per-statement firing is
+     preserved (each op still emits its own call), but the buffer
+     holds one slot per source line instead of one per statement.
+     Counter ops with an unresolvable source location are not
+     deduped — each gets a fresh slot since attribution can't tell
+     them apart.
+   - **Synthesizes a `[ForceInline]` thunk**
+     `__slang_coverage_hit(int slot)` that performs the atomic add
+     on `__slang_coverage[slot]`. One thunk per linked module.
+   - **Rewrites each op as `Call(__slang_coverage_hit, slot)`** — a
+     single IR inst per call site. Backend inlining folds the thunk
+     back into a per-site atomic at emit time, preserving final
+     compiled output shape (HLSL `InterlockedAdd`, SPIR-V
+     `OpAtomicIAdd`, etc.).
    - **Records `(slot → file, line)` plus the buffer's binding** on
      the artifact's `ICoverageTracingMetadata`. A slot is
      unattributable when its `IncrementCoverageCounter` op carried
@@ -330,6 +340,134 @@ dispatches, and LCOV serialization for hosts that want LCOV output
 without implementing the format themselves. It will not be required
 for either workflow above. A reference end-to-end host integration
 (`examples/shader-coverage-demo`) ships with the same follow-up.
+
+Performance and integration considerations
+------------------------------------------
+
+The IR coverage pass reduces per-shader memory pressure by emitting a
+per-call-site `Call` to a shared `[ForceInline]` thunk rather than
+expanding the atomic-add chain inline at every counter site. This
+section captures the contracts that make that work and the
+host-observable consequences.
+
+### Per-call-site IR cost
+
+After generic specialization clones a function body for each
+instantiation, the per-clone coverage cost is:
+
+- **Today**: one `Call(__slang_coverage_hit, slot)` inst per source
+  statement.
+- **Pre-thunk implementation** (for context): one `IntLit` + one
+  `RWStructuredBufferGetElementPtr` + one `AtomicAdd` per statement,
+  with `IntLit` globally pooled so the per-clone unique-inst count
+  was 2.
+
+The savings ratio in linked-module IR for coverage-related insts
+specifically is roughly **2× per call site**. On a 50-spec ×
+1000-statement RT shader with no multi-statement-per-line dedup, that
+amortizes to ~50% fewer coverage IR insts; on small shaders the
+ratio is softened by constant overhead from the thunk body and the
+pool of slot literals. Measured baseline-vs-thunk on a synthetic
+3-spec × 6-line helper plus 11-stmt entry point: 59 → 36 coverage
+IR insts in the post-specialization snapshot (~1.6×). Final compiled
+output (HLSL / SPIR-V text) is byte-identical between the two
+shapes — the thunk inlines fully at backend emit.
+
+### Inline-hint contract
+
+`__slang_coverage_hit` carries `IRForceInlineDecoration`
+(`addForceInlineDecoration` in `slang-ir-coverage-instrument.cpp`).
+Every backend used by Slang today honors this and folds the thunk
+back into a per-site atomic at emit time. Final compiled assembly
+(HLSL `InterlockedAdd`, SPIR-V `OpAtomicIAdd`, GLSL `atomicAdd`,
+Metal atomic builtins, CUDA `atomicAdd`, CPU
+`_slang_atomic_add_u32`) is shape-equivalent to what the pre-thunk
+implementation produced.
+
+If any backend ever stops honoring `[ForceInline]` on this thunk:
+
+- A per-coverage-hit function call frame appears at runtime.
+- Shaders with tight stack budgets (RT hit / closest-hit / miss
+  shaders especially) could push past their stack limits and fail.
+- Atomic-contention behavior is unchanged — the call is the only
+  added cost.
+
+The regression test
+`tests/language-feature/coverage/coverage-thunk-instrumentation.slang`
+asserts both expected per-site atomic-add count and the absence of
+any surviving `__slang_coverage_hit` call symbol in CPU emit output;
+it catches inlining regressions on the CPU path. Other targets do
+not have an equivalent assertion today — adding one per backend is a
+follow-up.
+
+### Slot dedup and `getEntryCount` behavior
+
+Counter-slot assignment dedupes by `(file, line)`. Hosts auto-sizing
+their `__slang_coverage` buffer from
+`getBufferInfo().elementCount` get smaller allocations on shaders
+with multi-statement source lines (the intended outcome). The
+LCOV / gcov reporting pipeline already aggregates by `(file, line)`
+on the host, so the user-visible coverage report is unchanged.
+
+`ICoverageTracingMetadata::getEntryCount()` returns the count of
+unique `(file, line)` pairs, **not** the count of executable
+statements. Hosts that hardcode a slot count or assume "N statements
+→ N slots" would break — but no such pattern is supported by the
+public API contract, and the existing `getEntryCount()` API
+explicitly leaves the buffer-sizing question to the host.
+
+Counter ops with unresolvable source locations (synthetic statements
+from autodiff reverse-mode, generic specialization, struct
+constructor synthesis) bypass the dedup and each get their own slot,
+since attribution can't tell them apart. The LCOV converter filters
+these out of line-oriented output; consumers reading
+`ICoverageTracingMetadata` directly see them as `entry.file ==
+nullptr` / `entry.line == 0`.
+
+### Runtime cost
+
+Per executed statement: one atomic-add on a `RWStructuredBuffer<uint>`
+slot. Same memory traffic as the pre-thunk implementation. After
+backend inlining, no function-call overhead.
+
+Atomic contention on a shared slot is the only inherent runtime
+cost: many threads incrementing the same slot in a hot inner loop
+will serialize on the underlying hardware atomic unit. This is
+inherent to coverage instrumentation, not specific to the thunk
+shape — `gcov`-style line counters have the same contention
+profile. For inner loops with high thread occupancy, expect
+measurable but not catastrophic slowdown; coverage is intended for
+correctness / completeness measurement, not for runs at full
+throughput.
+
+### Compile-time cost
+
+The IR pass adds:
+
+- One `Dictionary<String, UInt>` lookup per counter op (slot dedup).
+- One thunk function (5 IR insts) per linked module.
+- One `Call` IR inst per counter op (replaces a 3-inst chain).
+
+Net effect on compile time is below noise floor for typical
+workloads — the IR pass itself runs once per linked module, and the
+generated IR is smaller, so downstream optimization passes have
+less to walk.
+
+### Multi-target consistency
+
+All Slang backends (HLSL, SPIR-V, GLSL, Metal, CUDA, CPU) lower
+`kIROp_AtomicAdd` on `RWStructuredBuffer<uint>` to their native
+atomic-increment intrinsic. Coverage data is consistent across
+targets for the same shader and the same workload — same slot
+mapping, same atomic-add behavior, same per-line counts. The
+observable difference between targets is binding location
+(reported via `ICoverageTracingMetadata`), not coverage values.
+
+WGSL is the one exception: instrumentation is currently skipped on
+WGSL targets (warning E45102) until the synthesized buffer's
+element type is wrapped in `Atomic<...>`. WebGPU workflows that
+need coverage today should use `-target spirv` and rely on the
+SPIR-V → WebGPU path.
 
 Roadmap
 -------

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -2212,7 +2212,7 @@ Result linkAndOptimizeIR(
 
     SLANG_PASS(performForceInlining);
 
-    SLANG_PASS(verifyCoverageThunkInlined);
+    SLANG_PASS(verifyAndRemoveCoverageThunk);
 
     if (emitSpirvDirectly)
     {

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -2212,6 +2212,8 @@ Result linkAndOptimizeIR(
 
     SLANG_PASS(performForceInlining);
 
+    SLANG_PASS(verifyCoverageThunkInlined);
+
     if (emitSpirvDirectly)
     {
         SLANG_PASS(performIntrinsicFunctionInlining);

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -1436,6 +1436,11 @@ Result linkAndOptimizeIR(
     if (target == CodeGenTarget::HostVM)
     {
         SLANG_PASS(performForceInlining);
+        // Same invariant as the main path: after `performForceInlining` the
+        // synthesized coverage thunk must have zero remaining uses. Without
+        // this, an unhonored `[ForceInline]` would leak `__slang_coverage_hit`
+        // into HostVM bytecode.
+        SLANG_PASS(verifyAndRemoveCoverageThunk);
         SLANG_PASS(simplifyIR, targetProgram, defaultIRSimplificationOptions, sink);
         return SLANG_OK;
     }

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -454,6 +454,14 @@ struct CoverageInstrumenter
     IRType* voidType;
     IRType* intType;
 
+    // Dedup map for same-line slot sharing: every counter op resolving
+    // to the same `(file, line)` reuses the first slot allocated for
+    // that pair. Keyed on a `file + ":" + line` string for portability
+    // across `Dictionary` implementations. Counter ops with an
+    // unresolvable source location are not deduped — they each get a
+    // unique slot, since attribution can't tell them apart anyway.
+    Dictionary<String, UInt> slotByLineKey;
+
     CoverageInstrumenter(
         IRModule* m,
         IRGlobalParam* buf,
@@ -468,15 +476,47 @@ struct CoverageInstrumenter
         intType = tmpBuilder.getIntType();
     }
 
-    // Lower a single IncrementCoverageCounter op to a `Call(hitThunk,
-    // slot)` — a single IR inst per call site. The thunk itself
-    // performs the atomic add on `coverageBuffer[slot]`. Appends a
-    // metadata entry for `slot` and removes the op.
-    void lowerCounterOp(IRInst* counterOp, UInt slot)
+    // Resolve `counterOp`'s source position and assign it a slot,
+    // either by reusing an existing slot for the same `(file, line)`
+    // or by allocating a new one. Appends a new metadata entry on a
+    // miss; returns the slot index in either case.
+    UInt assignSlot(IRInst* counterOp)
     {
         CoverageTracingEntry entry;
-        resolveHumaneLoc(sourceManager, counterOp, entry.file, entry.line);
+        bool valid = resolveHumaneLoc(sourceManager, counterOp, entry.file, entry.line);
+
+        if (valid)
+        {
+            StringBuilder keyBuilder;
+            keyBuilder << entry.file << ":" << entry.line;
+            String key = keyBuilder.toString();
+            UInt existing = 0;
+            if (slotByLineKey.tryGetValue(key, existing))
+                return existing;
+
+            UInt slot = (UInt)outMetadata.m_coverageEntries.getCount();
+            outMetadata.m_coverageEntries.add(entry);
+            slotByLineKey.add(key, slot);
+            return slot;
+        }
+
+        // Unresolvable location: each such op gets a fresh slot. The
+        // metadata entry is empty (`file == ""`, `line == 0`); the
+        // host-side LCOV converter filters these out of line-oriented
+        // output.
+        UInt slot = (UInt)outMetadata.m_coverageEntries.getCount();
         outMetadata.m_coverageEntries.add(entry);
+        return slot;
+    }
+
+    // Lower a single IncrementCoverageCounter op to a `Call(hitThunk,
+    // slot)` — a single IR inst per call site. The thunk itself
+    // performs the atomic add on `coverageBuffer[slot]`. Slot is
+    // resolved via `assignSlot` (which may reuse a slot for an
+    // already-seen source line) and the op is removed.
+    void lowerCounterOp(IRInst* counterOp)
+    {
+        UInt slot = assignSlot(counterOp);
 
         IRBuilder builder(module);
         builder.setInsertBefore(counterOp);
@@ -493,14 +533,20 @@ struct CoverageInstrumenter
 
     void run(List<IRInst*> const& counterOps)
     {
+        // Best-case reservation: every op gets its own slot. Worst
+        // case the buffer grows by less due to same-line dedup; the
+        // over-reservation is harmless.
         outMetadata.m_coverageEntries.reserve(counterOps.getCount());
-        // Each counter op gets its own slot: the op's identity IS the
-        // UID, and we assign a consecutive index in traversal order.
-        // Multiple ops on the same source line get distinct slots; the
-        // LCOV converter aggregates per (file, line) at the host side
-        // via summation.
-        for (UInt slot = 0; slot < (UInt)counterOps.getCount(); ++slot)
-            lowerCounterOp(counterOps[slot], slot);
+
+        // Multiple ops resolving to the same `(file, line)` share a
+        // counter slot. Net effect: same per-statement firing in the
+        // emitted code (each op still triggers an atomic-add), but
+        // the buffer holds one slot per source line instead of one
+        // per statement, and the metadata holds one entry per line.
+        // The LCOV converter already aggregates by `(file, line)` on
+        // the host, so the user-visible report is unchanged.
+        for (auto op : counterOps)
+            lowerCounterOp(op);
     }
 };
 

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -20,6 +20,13 @@ namespace
 // matches the manifest / sidecar key that hosts read.
 static const char kCoverageBufferName[] = "__slang_coverage";
 
+// Well-known name of the synthesized coverage-hit thunk. Each
+// `IncrementCoverageCounter` op is rewritten to a single `Call` to
+// this helper; the helper performs the atomic increment on the slot.
+// Naming it explicitly (rather than letting Slang auto-mangle) keeps
+// the function recognizable in dumped IR / generated source.
+static const char kCoverageHitFuncName[] = "__slang_coverage_hit";
+
 // Choose the resource kind under which the coverage buffer is bound
 // for `target`. Each target family speaks a different vocabulary
 // for buffer slots, and parameter binding only routes a kind through
@@ -374,32 +381,97 @@ static bool resolveHumaneLoc(
     return true;
 }
 
+// Synthesize the coverage-hit thunk. Each `IncrementCoverageCounter`
+// op is rewritten to a single `Call(thunk, slot)` instead of expanding
+// inline to a 3-inst `(IntLit slot) + GEP + AtomicAdd` chain. After
+// generic specialization clones a function body N times for N
+// instantiations, only the 1-inst `Call` is duplicated per clone — not
+// the whole atomic-add sequence — saving ~2/3 of the coverage-related
+// IR insts in the linked module.
+//
+// `[ForceInline]` is essential, not optional: the helper's body is
+// trivial (one atomic) and inlining is what restores the final
+// emitted code to the same shape as the pre-thunk implementation.
+// Without it, GPU backends would leave a per-hit function call,
+// adding stack-budget / runtime cost on RT-shader workloads where
+// the call overhead is non-trivial.
+static IRFunc* synthesizeCoverageHitThunk(IRModule* module, IRGlobalParam* coverageBuffer)
+{
+    IRBuilder builder(module);
+    builder.setInsertInto(module->getModuleInst());
+
+    auto uintType = builder.getUIntType();
+    auto intType = builder.getIntType();
+    auto voidType = builder.getVoidType();
+    auto uintPtrType = builder.getPtrType(uintType);
+
+    // Slot parameter is `int` to match what the pre-thunk
+    // implementation passed to `RWStructuredBufferGetElementPtr`. After
+    // `[ForceInline]` folds the body back into each call site, the
+    // emitted GEP keeps the same signed-index shape (`int(N)`) that
+    // existing snapshot tests were anchored against.
+    IRType* paramTypes[] = {intType};
+    auto funcType = builder.getFuncType(1, paramTypes, voidType);
+
+    auto thunk = builder.createFunc();
+    thunk->setFullType(funcType);
+    builder.addNameHintDecoration(thunk, UnownedTerminatedStringSlice(kCoverageHitFuncName));
+    builder.addForceInlineDecoration(thunk);
+
+    auto block = builder.createBlock();
+    thunk->addBlock(block);
+    builder.setInsertInto(block);
+
+    auto slotParam = builder.emitParam(intType);
+
+    // slotPtr = &__slang_coverage[slot]
+    IRInst* gepArgs[] = {coverageBuffer, slotParam};
+    auto slotPtr =
+        builder.emitIntrinsicInst(uintPtrType, kIROp_RWStructuredBufferGetElementPtr, 2, gepArgs);
+
+    // AtomicAdd(slotPtr, 1, relaxed). Each backend emitter lowers
+    // this to its native atomic-increment idiom (InterlockedAdd on
+    // HLSL, atomicAdd on GLSL, OpAtomicIAdd on SPIR-V, etc.).
+    IRInst* atomicArgs[] = {
+        slotPtr,
+        builder.getIntValue(uintType, 1),
+        builder.getIntValue(intType, (IRIntegerValue)kIRMemoryOrder_Relaxed),
+    };
+    builder.emitIntrinsicInst(uintType, kIROp_AtomicAdd, 3, atomicArgs);
+
+    builder.emitReturn();
+    return thunk;
+}
+
 struct CoverageInstrumenter
 {
     IRModule* module;
     IRGlobalParam* coverageBuffer;
+    IRFunc* hitThunk;
     SourceManager* sourceManager;
     ArtifactPostEmitMetadata& outMetadata;
     IRType* uintType;
-    IRType* uintPtrType;
+    IRType* voidType;
     IRType* intType;
 
     CoverageInstrumenter(
         IRModule* m,
         IRGlobalParam* buf,
+        IRFunc* thunk,
         SourceManager* sm,
         ArtifactPostEmitMetadata& md)
-        : module(m), coverageBuffer(buf), sourceManager(sm), outMetadata(md)
+        : module(m), coverageBuffer(buf), hitThunk(thunk), sourceManager(sm), outMetadata(md)
     {
         IRBuilder tmpBuilder(module);
         uintType = tmpBuilder.getUIntType();
-        uintPtrType = tmpBuilder.getPtrType(uintType);
+        voidType = tmpBuilder.getVoidType();
         intType = tmpBuilder.getIntType();
     }
 
-    // Lower a single IncrementCoverageCounter op to an atomic add on
-    // `coverageBuffer[slot]`. Appends a metadata entry for `slot` and
-    // removes the op.
+    // Lower a single IncrementCoverageCounter op to a `Call(hitThunk,
+    // slot)` — a single IR inst per call site. The thunk itself
+    // performs the atomic add on `coverageBuffer[slot]`. Appends a
+    // metadata entry for `slot` and removes the op.
     void lowerCounterOp(IRInst* counterOp, UInt slot)
     {
         CoverageTracingEntry entry;
@@ -409,26 +481,8 @@ struct CoverageInstrumenter
         IRBuilder builder(module);
         builder.setInsertBefore(counterOp);
 
-        IRInst* getElemArgs[] = {
-            coverageBuffer,
-            builder.getIntValue(intType, (IRIntegerValue)slot),
-        };
-        IRInst* slotPtr = builder.emitIntrinsicInst(
-            uintPtrType,
-            kIROp_RWStructuredBufferGetElementPtr,
-            2,
-            getElemArgs);
-
-        // Emit `AtomicAdd(slotPtr, 1, relaxed)` — lowered by each
-        // backend emitter to its native atomic-increment idiom
-        // (InterlockedAdd on HLSL, atomicAdd on GLSL, OpAtomicIAdd on
-        // SPIR-V, etc.). Correct under GPU concurrency.
-        IRInst* atomicArgs[] = {
-            slotPtr,
-            builder.getIntValue(uintType, 1),
-            builder.getIntValue(intType, (IRIntegerValue)kIRMemoryOrder_Relaxed),
-        };
-        builder.emitIntrinsicInst(uintType, kIROp_AtomicAdd, 3, atomicArgs);
+        IRInst* slotArg = builder.getIntValue(intType, (IRIntegerValue)slot);
+        builder.emitCallInst(voidType, hitThunk, 1, &slotArg);
 
         // The counter op has void return type and, by construction, no uses.
         // Catch a future IR transform that takes a use of it before we reach
@@ -585,9 +639,17 @@ void instrumentCoverage(
     outMetadata.m_coverageBufferSpace = chosenSpace;
     outMetadata.m_coverageBufferBinding = chosenBinding;
 
+    // Synthesize the coverage-hit thunk after the buffer is in place.
+    // Each `IncrementCoverageCounter` op will be lowered to a single
+    // `Call(thunk, slot)` rather than expanding inline to a 3-inst
+    // atomic-add chain — see `synthesizeCoverageHitThunk` for the
+    // rationale and inlining requirement.
+    auto hitThunk = synthesizeCoverageHitThunk(module, buffer);
+
     CoverageInstrumenter instrumenter(
         module,
         buffer,
+        hitThunk,
         sink ? sink->getSourceManager() : nullptr,
         outMetadata);
     instrumenter.run(counterOps);

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -378,6 +378,13 @@ static bool resolveHumaneLoc(
         return false;
     outFile = humane.pathInfo.foundPath;
     outLine = (uint32_t)humane.line;
+    // Synthetic source views (e.g. token-paste / macro-synthesized
+    // locations) can carry a positive line with an empty file path.
+    // Treat those as unresolvable so the escape hatch in `assignSlot`
+    // gives each one a fresh slot — otherwise `("", line)` keys would
+    // collapse unrelated synthetic origins onto a single counter.
+    if (outFile.getLength() == 0)
+        return false;
     return true;
 }
 

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -482,7 +482,10 @@ struct CoverageInstrumenter
     // miss; returns the slot index in either case.
     UInt assignSlot(IRInst* counterOp)
     {
-        CoverageTracingEntry entry;
+        // Value-initialize so the unresolvable-loc path appends a
+        // well-defined zero entry even if `CoverageTracingEntry`'s
+        // in-class field initializers ever change.
+        CoverageTracingEntry entry = {};
         bool valid = resolveHumaneLoc(sourceManager, counterOp, entry.file, entry.line);
 
         if (valid)
@@ -699,6 +702,28 @@ void instrumentCoverage(
         sink ? sink->getSourceManager() : nullptr,
         outMetadata);
     instrumenter.run(counterOps);
+}
+
+void verifyCoverageThunkInlined(IRModule* module)
+{
+    for (auto inst : module->getModuleInst()->getChildren())
+    {
+        auto func = as<IRFunc>(inst);
+        if (!func)
+            continue;
+        auto nameHint = func->findDecoration<IRNameHintDecoration>();
+        if (!nameHint)
+            continue;
+        if (nameHint->getName() != UnownedTerminatedStringSlice(kCoverageHitFuncName))
+            continue;
+
+        // Found the thunk. After `performForceInlining` the thunk
+        // should have zero remaining uses; any surviving use means
+        // a `Call` site escaped inlining and a per-hit function-call
+        // frame would appear in emitted code.
+        SLANG_RELEASE_ASSERT(!func->hasUses());
+        return;
+    }
 }
 
 } // namespace Slang

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -415,6 +415,11 @@ static IRFunc* synthesizeCoverageHitThunk(IRModule* module, IRGlobalParam* cover
 
     auto thunk = builder.createFunc();
     thunk->setFullType(funcType);
+    // Tag the thunk with a dedicated decoration (rather than relying on the
+    // name hint) so the post-`performForceInlining` verifier can identify
+    // it unambiguously, even if user code declares a function with the same
+    // reserved-looking name.
+    builder.addDecoration(thunk, kIROp_CoverageThunkDecoration);
     builder.addNameHintDecoration(thunk, UnownedTerminatedStringSlice(kCoverageHitFuncName));
     builder.addForceInlineDecoration(thunk);
 
@@ -456,11 +461,26 @@ struct CoverageInstrumenter
 
     // Dedup map for same-line slot sharing: every counter op resolving
     // to the same `(file, line)` reuses the first slot allocated for
-    // that pair. Keyed on a `file + ":" + line` string for portability
-    // across `Dictionary` implementations. Counter ops with an
-    // unresolvable source location are not deduped — they each get a
-    // unique slot, since attribution can't tell them apart anyway.
-    Dictionary<String, UInt> slotByLineKey;
+    // that pair. Keyed on a struct rather than a stringified
+    // `file + ":" + line` to (a) skip the per-op `StringBuilder`
+    // allocation and (b) avoid any path-with-colon ambiguity. Counter
+    // ops with an unresolvable source location are not deduped — they
+    // each get a unique slot, since attribution can't tell them apart
+    // anyway.
+    struct FileLineKey
+    {
+        String file;
+        uint32_t line;
+        bool operator==(const FileLineKey& other) const
+        {
+            return line == other.line && file == other.file;
+        }
+        HashCode getHashCode() const
+        {
+            return combineHash(Slang::getHashCode(file), Slang::getHashCode(line));
+        }
+    };
+    Dictionary<FileLineKey, UInt> slotByLineKey;
 
     CoverageInstrumenter(
         IRModule* m,
@@ -490,9 +510,7 @@ struct CoverageInstrumenter
 
         if (valid)
         {
-            StringBuilder keyBuilder;
-            keyBuilder << entry.file << ":" << entry.line;
-            String key = keyBuilder.toString();
+            FileLineKey key{entry.file, entry.line};
             UInt existing = 0;
             if (slotByLineKey.tryGetValue(key, existing))
                 return existing;
@@ -704,24 +722,28 @@ void instrumentCoverage(
     instrumenter.run(counterOps);
 }
 
-void verifyCoverageThunkInlined(IRModule* module)
+void verifyAndRemoveCoverageThunk(IRModule* module)
 {
     for (auto inst : module->getModuleInst()->getChildren())
     {
         auto func = as<IRFunc>(inst);
         if (!func)
             continue;
-        auto nameHint = func->findDecoration<IRNameHintDecoration>();
-        if (!nameHint)
-            continue;
-        if (nameHint->getName() != UnownedTerminatedStringSlice(kCoverageHitFuncName))
+        if (!func->findDecoration<IRCoverageThunkDecoration>())
             continue;
 
-        // Found the thunk. After `performForceInlining` the thunk
-        // should have zero remaining uses; any surviving use means
-        // a `Call` site escaped inlining and a per-hit function-call
-        // frame would appear in emitted code.
+        // Found the thunk. After `performForceInlining` it should
+        // have zero remaining uses; any surviving use means a `Call`
+        // site escaped inlining and a per-hit function-call frame
+        // would appear in emitted code.
         SLANG_RELEASE_ASSERT(!func->hasUses());
+
+        // Remove the now-dead thunk explicitly. Downstream global-DCE
+        // would also eliminate it today, but doing so here makes the
+        // contract independent of which simplification passes happen
+        // to run after this point — important for minimal-optimization
+        // builds that may skip simplifyIR.
+        func->removeAndDeallocate();
         return;
     }
 }

--- a/source/slang/slang-ir-coverage-instrument.h
+++ b/source/slang/slang-ir-coverage-instrument.h
@@ -46,6 +46,20 @@ void instrumentCoverage(
     IRVarLayout*& globalScopeVarLayout,
     ArtifactPostEmitMetadata& outMetadata);
 
+// Defensive invariant: after `[ForceInline]` inlining has run, the
+// synthesized `__slang_coverage_hit` thunk must have no surviving
+// call sites. Each backend used by Slang honors `[ForceInline]` and
+// folds the thunk's atomic-add body back into each call site at emit
+// time, preserving the "byte-identical to pre-thunk emit" contract
+// documented in `docs/design/shader-coverage.md`. If a backend ever
+// stops honoring the decoration (or a target-specific pass strips
+// it after instrumentation), an extra per-coverage-hit function-call
+// frame would appear in emitted code; this check catches that
+// regression in IR rather than as a per-target emit-output check.
+//
+// No-op when the coverage pass did not run (no thunk in the module).
+void verifyCoverageThunkInlined(IRModule* module);
+
 } // namespace Slang
 
 #endif // SLANG_IR_COVERAGE_INSTRUMENT_H

--- a/source/slang/slang-ir-coverage-instrument.h
+++ b/source/slang/slang-ir-coverage-instrument.h
@@ -46,19 +46,28 @@ void instrumentCoverage(
     IRVarLayout*& globalScopeVarLayout,
     ArtifactPostEmitMetadata& outMetadata);
 
-// Defensive invariant: after `[ForceInline]` inlining has run, the
-// synthesized `__slang_coverage_hit` thunk must have no surviving
-// call sites. Each backend used by Slang honors `[ForceInline]` and
-// folds the thunk's atomic-add body back into each call site at emit
-// time, preserving the "byte-identical to pre-thunk emit" contract
-// documented in `docs/design/shader-coverage.md`. If a backend ever
-// stops honoring the decoration (or a target-specific pass strips
-// it after instrumentation), an extra per-coverage-hit function-call
-// frame would appear in emitted code; this check catches that
-// regression in IR rather than as a per-target emit-output check.
+// Defensive invariant + cleanup: after `[ForceInline]` inlining has
+// run, the synthesized `__slang_coverage_hit` thunk must have no
+// surviving call sites. Each backend used by Slang honors
+// `[ForceInline]` and folds the thunk's atomic-add body back into
+// each call site at emit time, preserving the "byte-identical to
+// pre-thunk emit" contract documented in
+// `docs/design/shader-coverage.md`. If a backend ever stops honoring
+// the decoration (or a target-specific pass strips it after
+// instrumentation), an extra per-coverage-hit function-call frame
+// would appear in emitted code; this check catches that regression
+// in IR rather than as a per-target emit-output check.
+//
+// On success the now-zero-use thunk is also removed from the module
+// so its dead body cannot leak into emitted source on backends that
+// do not (or no longer) run a downstream global-DCE pass.
+//
+// The thunk is identified by `IRCoverageThunkDecoration`, not by
+// name hint — user code is free to declare a function with the same
+// reserved-looking name without colliding with this verifier.
 //
 // No-op when the coverage pass did not run (no thunk in the module).
-void verifyCoverageThunkInlined(IRModule* module);
+void verifyAndRemoveCoverageThunk(IRModule* module);
 
 } // namespace Slang
 

--- a/source/slang/slang-ir-coverage-instrument.h
+++ b/source/slang/slang-ir-coverage-instrument.h
@@ -17,11 +17,13 @@ class ArtifactPostEmitMetadata;
 // decoration (UAV register for D3D, descriptor binding for Khronos),
 // extends the program-scope var layout so the buffer participates in
 // `collectGlobalUniformParameters` packaging on targets that need it
-// (CPU, CUDA), assigns one counter slot per `IncrementCoverageCounter`
-// op, and rewrites each op into an atomic add on its slot. The pass
-// writes the resulting `(slot → file, line)` mapping and the chosen
-// buffer binding into `outMetadata` so hosts can query it via
-// `ICoverageTracingMetadata`.
+// (CPU, CUDA), assigns counter slots deduplicated by `(file, line)`
+// — multiple `IncrementCoverageCounter` ops on the same source line
+// share one slot — and rewrites each op into a `Call` to a synthesized
+// `[ForceInline]` `__slang_coverage_hit` thunk that performs the
+// atomic add on its slot. The pass writes the resulting
+// `(slot → file, line)` mapping and the chosen buffer binding into
+// `outMetadata` so hosts can query it via `ICoverageTracingMetadata`.
 //
 // `explicitBinding` / `explicitSpace` are the values supplied by
 // `-trace-coverage-binding`; pass `-1` for either to request auto-

--- a/source/slang/slang-ir-insts-stable-names.lua
+++ b/source/slang/slang-ir-insts-stable-names.lua
@@ -828,5 +828,6 @@ return {
 	["SpecializeExistentialsInType"] = 852,
 	["assumeAddress"] = 853,
 	["DebugCompilationUnit"] = 854,
-	["IncrementCoverageCounter"] = 855
+	["IncrementCoverageCounter"] = 855,
+	["Decoration.CoverageThunk"] = 856
 }

--- a/source/slang/slang-ir-insts.lua
+++ b/source/slang/slang-ir-insts.lua
@@ -1949,6 +1949,15 @@ local insts = {
 				},
 			},
 			{
+				CoverageThunk = {
+					-- Identifies the synthesized `__slang_coverage_hit` thunk created by the coverage
+					-- instrumentation pass. Matched by a dedicated decoration (rather than name hint)
+					-- so the post-`performForceInlining` verifier never collides with a user-declared
+					-- function that happens to share the thunk's reserved name.
+					struct_name = "CoverageThunkDecoration",
+				},
+			},
+			{
 				AllowPreTranslationInlining = {
 					-- This decoration indicates the callee should be inlined after translation passes,
 					-- Typically, this is because the callee has non-trivial values associated with it that need to be preserved 

--- a/tests/language-feature/coverage/coverage-multi-stmt-per-line.slang
+++ b/tests/language-feature/coverage/coverage-multi-stmt-per-line.slang
@@ -1,9 +1,16 @@
-// Locks in the per-inst-UID design: each `IncrementCoverageCounter` op
-// gets its own counter slot, even when multiple ops originate from the
-// same source line. The old design deduplicated slots by (file, line),
-// which would have collapsed the three statements on line 9 below into
-// one or two slots. If someone reintroduces that dedupe, this test
-// regresses.
+// Locks in same-line slot dedup: when multiple
+// `IncrementCoverageCounter` ops resolve to the same `(file, line)`,
+// they share a counter slot. Each statement still triggers its own
+// atomic-add at runtime (the per-statement firing is preserved), but
+// they all hit the same buffer slot — fewer slots in the buffer,
+// fewer entries in the (file, line) metadata.
+//
+// Earlier design assigned a unique slot per op to allow per-statement
+// hit counts. That fidelity isn't reachable through the LCOV / gcov
+// reporting pipeline, which already aggregates by `(file, line)` at
+// the host side, so the user-visible report is identical either way.
+// The dedup gives us a 30-50% counter-buffer + metadata reduction on
+// typical shaders without changing observable coverage semantics.
 
 //TEST:SIMPLE(filecheck=CHECK):-target cpp -stage compute -entry computeMain -trace-coverage
 
@@ -17,9 +24,20 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
     outputBuffer[0] = a + b + c;
 }
 
-// The three statements on one source line must each produce a distinct
-// atomic add on a distinct slot. If the compiler dedupes back to
-// (file, line), slots 2 and 3 here would disappear.
-//CHECK: _slang_atomic_add_u32{{.*}}_slang_coverage{{.*int\(1\)}}
-//CHECK: _slang_atomic_add_u32{{.*}}_slang_coverage{{.*int\(2\)}}
-//CHECK: _slang_atomic_add_u32{{.*}}_slang_coverage{{.*int\(3\)}}
+// All three statements on the same source line share one slot. The
+// captured `[[SLOT]]` regex pins each subsequent atomic-add to the
+// same int literal as the first — if the compiler regresses back to
+// per-op slots, the second statement's slot would be different and
+// the recapture mismatches.
+//
+// The trailing CHECK pins the next statement (on the next source
+// line) to a different slot, confirming the dedup is per-line, not
+// module-wide.
+//CHECK: _slang_atomic_add_u32{{.*}}_slang_coverage{{.*}}[[SLOT:int\([0-9]+\)]]
+//CHECK: _slang_atomic_add_u32{{.*}}_slang_coverage{{.*}}[[SLOT]]
+//CHECK: _slang_atomic_add_u32{{.*}}_slang_coverage{{.*}}[[SLOT]]
+
+// The next source line gets its own slot — distinct from the shared
+// slot above.
+//CHECK-NOT: _slang_atomic_add_u32{{.*}}_slang_coverage{{.*}}[[SLOT]]
+//CHECK: _slang_atomic_add_u32{{.*}}_slang_coverage

--- a/tests/language-feature/coverage/coverage-thunk-instrumentation.slang
+++ b/tests/language-feature/coverage/coverage-thunk-instrumentation.slang
@@ -28,12 +28,17 @@
 // load-bearing on every backend used by Slang — if any of them stops
 // honoring the decoration on the synthesized thunk, a per-coverage-hit
 // function-call frame would appear in emitted code (a stack-budget
-// risk on RT shaders). These passes assert no `__slang_coverage_hit`
-// symbol survives in HLSL / GLSL / Metal / SPIR-V emit.
+// risk on RT shaders, where CUDA/OptiX is the dominant backend).
+// These passes assert no `__slang_coverage_hit` symbol survives in
+// HLSL / GLSL / Metal / SPIR-V / CUDA emit, plus the LLVM-based CPU
+// path (separate pipeline that maps `IRForceInlineDecoration` to
+// `SLANG_LLVM_FUNC_ATTR_ALWAYSINLINE`).
 //TEST:SIMPLE(filecheck=HLSL_NOTHUNK):-target hlsl -stage compute -entry computeMain -trace-coverage
 //TEST:SIMPLE(filecheck=GLSL_NOTHUNK):-target glsl -stage compute -entry computeMain -trace-coverage
 //TEST:SIMPLE(filecheck=METAL_NOTHUNK):-target metal -stage compute -entry computeMain -trace-coverage
 //TEST:SIMPLE(filecheck=SPIRV_NOTHUNK):-target spirv-asm -stage compute -entry computeMain -trace-coverage
+//TEST:SIMPLE(filecheck=CUDA_NOTHUNK):-target cuda -stage compute -entry computeMain -trace-coverage
+//TEST:SIMPLE(filecheck=LLVM_NOTHUNK):-target llvm-shader-ir -stage compute -entry computeMain -trace-coverage
 
 //TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
 RWStructuredBuffer<uint> outputBuffer;
@@ -70,3 +75,5 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
 //GLSL_NOTHUNK-NOT: __slang_coverage_hit
 //METAL_NOTHUNK-NOT: __slang_coverage_hit
 //SPIRV_NOTHUNK-NOT: __slang_coverage_hit
+//CUDA_NOTHUNK-NOT: __slang_coverage_hit
+//LLVM_NOTHUNK-NOT: __slang_coverage_hit

--- a/tests/language-feature/coverage/coverage-thunk-instrumentation.slang
+++ b/tests/language-feature/coverage/coverage-thunk-instrumentation.slang
@@ -1,0 +1,47 @@
+// Regression test for thunk-based coverage instrumentation: each
+// `IncrementCoverageCounter` op is lowered to a single
+// `Call(__slang_coverage_hit, slot)` instead of expanding inline to
+// a 3-inst atomic-add chain. The thunk is decorated `[ForceInline]`,
+// so backends fold it back into a per-site atomic at emit time —
+// i.e. the user-observable emit shape is preserved. This test
+// verifies that property end-to-end on the CPU path: a generic
+// helper instantiated for two types still produces one atomic-add
+// per (specialization, source-line) in the emitted code, confirming
+// the thunk transformation didn't drop any specialization's
+// contribution.
+//
+// If `[ForceInline]` ever stops being honored on the synthesized
+// thunk, this test would surface a `_slang_coverage_hit(` call in
+// the output where an inline `_slang_atomic_add_u32` is expected,
+// triggering a CHECK failure.
+
+//TEST:SIMPLE(filecheck=CHECK):-target cpp -stage compute -entry computeMain -trace-coverage
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<uint> outputBuffer;
+
+T add_two<T : __BuiltinArithmeticType>(T x)
+{
+    return x + x;
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    int a = add_two<int>(1);
+    float b = add_two<float>(2.0f);
+    outputBuffer[0] = uint(a) + uint(b);
+}
+
+// Both specializations of `add_two<T>` keep their own atomic-add
+// after the thunk gets inlined: one for `add_two<int>`, one for
+// `add_two<float>`. Plus three for the statements in computeMain.
+// Total: five inline atomic-adds against `__slang_coverage`.
+//CHECK-COUNT-5: _slang_atomic_add_u32{{.*}}_slang_coverage
+//CHECK-NOT: _slang_atomic_add_u32{{.*}}_slang_coverage
+
+// The thunk should be fully inlined, so no `_slang_coverage_hit`
+// call survives in the CPU output. If this CHECK-NOT triggers,
+// either `[ForceInline]` regressed or the inlining pass stopped
+// honoring it — both indicate the thunk is leaking into emit.
+//CHECK-NOT: _slang_coverage_hit{{[ \t]*\(}}

--- a/tests/language-feature/coverage/coverage-thunk-instrumentation.slang
+++ b/tests/language-feature/coverage/coverage-thunk-instrumentation.slang
@@ -17,6 +17,13 @@
 
 //TEST:SIMPLE(filecheck=CHECK):-target cpp -stage compute -entry computeMain -trace-coverage
 
+// Second pass: a negative-only prefix scans the entire emitted
+// output, catching a stray `_slang_coverage_hit` symbol regardless of
+// whether it appears before, between, or after the atomic-add matches
+// the first pass anchors to. (A trailing negative directive in the
+// first pass only constrains text after its final positive match.)
+//TEST:SIMPLE(filecheck=NOTHUNK):-target cpp -stage compute -entry computeMain -trace-coverage
+
 //TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
 RWStructuredBuffer<uint> outputBuffer;
 
@@ -41,7 +48,10 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
 //CHECK-NOT: _slang_atomic_add_u32{{.*}}_slang_coverage
 
 // The thunk should be fully inlined, so no `_slang_coverage_hit`
-// call survives in the CPU output. If this CHECK-NOT triggers,
+// call survives in the CPU output. If this NOTHUNK-NOT triggers,
 // either `[ForceInline]` regressed or the inlining pass stopped
 // honoring it — both indicate the thunk is leaking into emit.
-//CHECK-NOT: _slang_coverage_hit{{[ \t]*\(}}
+// Run as a separate filecheck pass so the directive scans the whole
+// emitted output (a CHECK-NOT after CHECK-COUNT only covers text
+// past the final positive match).
+//NOTHUNK-NOT: _slang_coverage_hit{{[ \t]*\(}}

--- a/tests/language-feature/coverage/coverage-thunk-instrumentation.slang
+++ b/tests/language-feature/coverage/coverage-thunk-instrumentation.slang
@@ -24,6 +24,17 @@
 // first pass only constrains text after its final positive match.)
 //TEST:SIMPLE(filecheck=NOTHUNK):-target cpp -stage compute -entry computeMain -trace-coverage
 
+// Cross-target NOTHUNK regressions. The `[ForceInline]` contract is
+// load-bearing on every backend used by Slang — if any of them stops
+// honoring the decoration on the synthesized thunk, a per-coverage-hit
+// function-call frame would appear in emitted code (a stack-budget
+// risk on RT shaders). These passes assert no `__slang_coverage_hit`
+// symbol survives in HLSL / GLSL / Metal / SPIR-V emit.
+//TEST:SIMPLE(filecheck=HLSL_NOTHUNK):-target hlsl -stage compute -entry computeMain -trace-coverage
+//TEST:SIMPLE(filecheck=GLSL_NOTHUNK):-target glsl -stage compute -entry computeMain -trace-coverage
+//TEST:SIMPLE(filecheck=METAL_NOTHUNK):-target metal -stage compute -entry computeMain -trace-coverage
+//TEST:SIMPLE(filecheck=SPIRV_NOTHUNK):-target spirv-asm -stage compute -entry computeMain -trace-coverage
+
 //TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
 RWStructuredBuffer<uint> outputBuffer;
 
@@ -48,10 +59,14 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
 //CHECK-NOT: _slang_atomic_add_u32{{.*}}_slang_coverage
 
 // The thunk should be fully inlined, so no `_slang_coverage_hit`
-// call survives in the CPU output. If this NOTHUNK-NOT triggers,
-// either `[ForceInline]` regressed or the inlining pass stopped
-// honoring it — both indicate the thunk is leaking into emit.
-// Run as a separate filecheck pass so the directive scans the whole
-// emitted output (a CHECK-NOT after CHECK-COUNT only covers text
-// past the final positive match).
-//NOTHUNK-NOT: _slang_coverage_hit{{[ \t]*\(}}
+// symbol survives in any target's emitted output. If any of these
+// fires, either `[ForceInline]` regressed or the inlining pass
+// stopped honoring it — both indicate the thunk is leaking into
+// emit. Each runs as its own filecheck pass so the directive scans
+// the whole emitted output (a CHECK-NOT after CHECK-COUNT only
+// covers text past the final positive match).
+//NOTHUNK-NOT: __slang_coverage_hit
+//HLSL_NOTHUNK-NOT: __slang_coverage_hit
+//GLSL_NOTHUNK-NOT: __slang_coverage_hit
+//METAL_NOTHUNK-NOT: __slang_coverage_hit
+//SPIRV_NOTHUNK-NOT: __slang_coverage_hit

--- a/tests/language-feature/coverage/coverage-unresolvable-loc.slang
+++ b/tests/language-feature/coverage/coverage-unresolvable-loc.slang
@@ -1,0 +1,50 @@
+// Regression test for the unresolvable-source-location escape hatch
+// in `assignSlot`.
+//
+// Counter-slot assignment dedupes by `(file, line)`. When
+// `resolveHumaneLoc` cannot resolve the IR op's `sourceLoc`, every
+// such op must get its own fresh slot — not collapse onto a single
+// `":0"` dedup key. Without the escape hatch, all unresolvable-loc
+// counter ops in a module would silently share one slot, merging
+// unrelated execution paths in the reported coverage data.
+//
+// Trigger: `-obfuscate` rewrites source locs to point at a synthetic
+// obfuscated source view that is opaque to the coverage pass's
+// source-manager lookup, forcing `resolveHumaneLoc` to return false
+// for every counter op in the module.
+//
+// Expected behavior with three statements on the same source line:
+//
+// - With `-obfuscate`: each op gets a distinct slot (escape hatch
+//   fires) — three statements on one line yield three slots, one per
+//   op, plus one for the assignment line. Slot literals 0, 1, 2, 3
+//   appear in source order.
+// - Without `-obfuscate` (compare with `coverage-multi-stmt-per-line`
+//   in the same directory): the three statements share a single slot
+//   via the dedup map.
+//
+// If the escape hatch ever regresses (e.g. the dedup map starts
+// caching the unresolvable-loc empty key), the slot literals here
+// would collapse onto a single value and the per-slot CHECK pattern
+// would fail.
+
+//TEST:SIMPLE(filecheck=CHECK):-target cpp -stage compute -entry computeMain -trace-coverage -obfuscate
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<uint> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    int a = 1; int b = 2; int c = 3;
+    outputBuffer[0] = uint(a + b + c);
+}
+
+// Each of the three statements on the same line gets its own slot
+// because the obfuscated locs are unresolvable, so the dedup map
+// never coalesces them. The fourth atomic-add belongs to the
+// assignment line. Slot literals appear in source order.
+//CHECK: _slang_atomic_add_u32{{.*}}_slang_coverage{{.*\[}}int(0)
+//CHECK: _slang_atomic_add_u32{{.*}}_slang_coverage{{.*\[}}int(1)
+//CHECK: _slang_atomic_add_u32{{.*}}_slang_coverage{{.*\[}}int(2)
+//CHECK: _slang_atomic_add_u32{{.*}}_slang_coverage{{.*\[}}int(3)

--- a/tools/shader-coverage/README.md
+++ b/tools/shader-coverage/README.md
@@ -268,14 +268,15 @@ slot in its own pipeline layout / root signature.
 ### Format scope
 
 - **Line coverage only** — emits `DA:` records; no `FN:` / `BRDA:`
-  (function / branch) coverage yet. Per-inst slot assignment is
-  forward-compatible with branch coverage: each branch point would
-  get its own slot, and the LCOV emitter would grow a `BRDA:`
-  writer.
+  (function / branch) coverage yet. Per-`(file, line)` slot
+  assignment is forward-compatible with branch coverage: each branch
+  point would get its own slot, and the LCOV emitter would grow a
+  `BRDA:` writer.
 - **Column position is dropped.** Only `(file, line)` reaches LCOV.
 - **Counter type is `uint32`.** Saturates at ~4 × 10⁹ hits per
-  slot. Multiple ops on the same source line accumulate
-  independently before LCOV-emit-time aggregation.
+  slot. Multiple `IncrementCoverageCounter` ops on the same source
+  line share one slot and aggregate at runtime via repeated atomic
+  increments on the same counter.
 
 ## Current limitations
 


### PR DESCRIPTION
## Summary

Two complementary memory-footprint reductions for coverage-instrumented shaders, attacking different axes:

**1. Thunk-based instrumentation** — replaces the per-call-site `IntLit + GEP + AtomicAdd` chain with a single `Call` to a synthesized `[ForceInline]` thunk:

```slang
void __slang_coverage_hit(int slot)
{
    atomicAdd(&__slang_coverage[slot], 1, relaxed);
}
```

After generic specialization clones a function body for each instantiation, only the `Call` (1 inst) duplicates per clone, not the full 3-inst chain. **~2× reduction in coverage-related IR insts per call site**, lossless on coverage semantics. `[ForceInline]` ensures backends fold the thunk back into a per-site atomic at emit time, so final compiled output (HLSL / SPIR-V / etc.) is shape-equivalent to the prior implementation.

**2. Same-line slot dedup** — multiple `IncrementCoverageCounter` ops resolving to the same `(file, line)` now share a counter slot instead of getting one slot per op. Each statement still triggers its own atomic-add at runtime (per-statement firing preserved), but the buffer holds one slot per source line instead of one per statement. **30-50% reduction in counter-buffer + metadata size** on shaders with multi-statement source lines.

Together they hit different layers: the thunk shrinks compile-time IR memory; the slot dedup shrinks runtime-buffer + metadata memory.

## Why

Generic-heavy RT shaders with `-trace-coverage` reported up to 30x IR-cache memory at peak. Coverage-related insts inside generic helpers and per-statement metadata entries are the targeted slices.

Measured baseline-vs-thunk on a synthetic 3-spec × 6-line helper plus 11-stmt entry point: 59 → 36 coverage IR insts in the post-specialization snapshot (~1.6×), with byte-identical final compiled output.

No public-interface changes.

## Behavioral notes

- `ICoverageTracingMetadata::getCounterCount()` returns smaller values on shaders with multi-statement source lines (one slot per unique `(file, line)` rather than one per statement). Hosts auto-sizing their `__slang_coverage` buffer from that query get smaller allocations (intended). Hosts that hardcode a slot count or assume "N statements → N slots" would break, but no such pattern is supported by the public API contract. `getBufferInfo()` reports binding location only (`space` + `binding`) and is unaffected by dedup.
- The synthesized `__slang_coverage_hit` symbol appears in the IR before backend inlining; final compiled output (after `[ForceInline]` is honored) is equivalent to today.
- Counter ops with unresolvable source loc are not deduped (each gets a fresh slot) since attribution can't tell them apart.

## Documentation

`docs/design/shader-coverage.md` is updated:
- Step 2 of the pipeline architecture now describes the thunk + slot-dedup shape (slot assignment dedupes by `(file, line)`, ops lower to `Call(thunk, slot)`)
- New "Performance and integration considerations" section before Roadmap covering: per-call-site IR cost, the `[ForceInline]` contract, slot dedup behavior (referencing the actual `getCounterCount()` / `getBufferInfo()` API surface), runtime cost, compile-time cost, multi-target consistency

## Test plan

- [x] All 15 coverage tests pass on macOS Release (13 source files; `coverage-thunk-instrumentation.slang` and `coverage-wgsl-skip.slang` each contribute two filecheck passes)
- [x] `coverage-multi-stmt-per-line.slang` updated to lock in the new same-line dedup behavior (regex-captures the slot literal and asserts re-use across the three statements on one line, then asserts a different slot on the next line)
- [x] New `coverage-thunk-instrumentation.slang` regression test asserts the expected per-site atomic-add count, and uses a second filecheck pass with a negative-only prefix that scans the entire emitted output to catch any surviving `__slang_coverage_hit` symbol regardless of where it appears
- [x] All 1587 language-feature tests pass (verifies the new emit-pipeline invariant is non-disruptive when the coverage pass did not run)
- [x] CI: cross-platform / cross-target matrix
- [x] CI: SPIR-V / HLSL / Metal target tests still pass

## Risk

If a backend stops honoring `[ForceInline]` on the synthesized thunk, an extra function call frame would appear per coverage hit. Two layered checks guard this:

1. **IR-level invariant** (cross-target): `verifyCoverageThunkInlined()` runs after the final `performForceInlining` pass in `emitCodeForTarget` and asserts the thunk has zero remaining uses. This is a single invariant covering every backend (HLSL / SPIR-V / GLSL / Metal / CUDA / CPU) — no per-target plumbing needed.
2. **Emit-level regression** (CPU): `coverage-thunk-instrumentation.slang` checks that no `__slang_coverage_hit(` symbol survives in CPU emit output across the entire emitted text.

The IR-level invariant is the load-bearing check for non-CPU targets. The CPU emit-level regression is a defense-in-depth backup.