### PR TITLE
Defensively gate AVX-512 in slang-llvm JIT TargetMachine

### DIFF
--- a/source/slang-llvm/slang-llvm.cpp
+++ b/source/slang-llvm/slang-llvm.cpp
@@ -1002,7 +1002,10 @@ SlangResult LLVMDownstreamCompiler::compile(
                     JITTargetMachineBuilder::detectHost();
                 if (expectJTMB)
                 {
-                    if (expectJTMB->getTargetTriple().isX86_64() && !_hostSupportsAVX512())
+                    // Use getArch() comparison rather than Triple::isX86_64() —
+                    // the latter is only available in newer LLVM headers (>= 22).
+                    if (expectJTMB->getTargetTriple().getArch() == llvm::Triple::x86_64 &&
+                        !_hostSupportsAVX512())
                     {
                         // Cover every AVX-512 family feature LLVM exposes for
                         // x86_64. LLVM's subtarget table generally implies the

--- a/source/slang-llvm/slang-llvm.cpp
+++ b/source/slang-llvm/slang-llvm.cpp
@@ -1028,6 +1028,13 @@ SlangResult LLVMDownstreamCompiler::compile(
                             "-avx512vp2intersect",
                             "-avx512fp16",
                             "-avx512bf16",
+                            // Knights Landing (KNL) — Xeon Phi only.
+                            "-avx512er",
+                            "-avx512pf",
+                            // Knights Mill (KNM) — Xeon Phi only. LLVM uses
+                            // the underscore spelling for these two.
+                            "-avx512_4fmaps",
+                            "-avx512_4vnniw",
                         });
                     }
                     jitBuilder.setJITTargetMachineBuilder(std::move(*expectJTMB));

--- a/source/slang-llvm/slang-llvm.cpp
+++ b/source/slang-llvm/slang-llvm.cpp
@@ -41,6 +41,7 @@
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
+#include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
 #include "llvm/IR/LLVMContext.h"
@@ -79,6 +80,12 @@
 // For memset_pattern functions
 // https://www.unix.com/man-page/osx/3/memset_pattern16/
 #include <string.h>
+#endif
+
+// For __cpuidex / _xgetbv used by the AVX-512 host-feature probe below.
+// On GCC/Clang the inline-asm fallback is used instead.
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
+#include <intrin.h>
 #endif
 
 #if SLANG_WINDOWS_FAMILY
@@ -172,6 +179,83 @@ public:
 
     Desc m_desc;
 };
+
+// Defensive AVX-512 detection on x86_64. Returns true iff the running CPU is
+// confirmed to support AVX-512F at the OS-XSAVE level (CPUID leaf 7 EBX bit
+// 16 set AND XCR0 bits 5/6/7 all set, matching the standard AVX-512
+// detection sequence).
+//
+// We do this in addition to LLVM's `JITTargetMachineBuilder::detectHost()`
+// because LLVM's host detection can pick a CPU model name (e.g. derived from
+// brand string or family) whose subtarget table enables AVX-512 features
+// even when the runtime CPU does not. When the JIT then lowers IR to machine
+// code, late codegen passes can emit AVX-512 instructions based on the
+// TargetMachine subtarget rather than per-function `target-features` attrs.
+// This causes SIGILL on hosts where AVX-512 is genuinely absent
+// (https://github.com/shader-slang/slang/issues/11062). Calling this helper
+// before configuring the JIT lets us subtract the AVX-512 family from the
+// detected features only when the host can't safely run them.
+static bool _hostSupportsAVX512()
+{
+#if defined(__x86_64__) || defined(_M_X64)
+    // CPUID leaf 1, ECX bit 27 = OSXSAVE (OS supports XSAVE/xgetbv). Must hold
+    // before executing xgetbv at all.
+    uint32_t ecx1 = 0;
+#if defined(_MSC_VER)
+    {
+        int regs1[4] = {0, 0, 0, 0};
+        __cpuidex(regs1, 1, 0);
+        ecx1 = (uint32_t)regs1[2];
+    }
+#else
+    {
+        uint32_t eax = 0, ebx = 0, edx = 0;
+        __asm__ volatile("cpuid" : "=a"(eax), "=b"(ebx), "=c"(ecx1), "=d"(edx) : "a"(1u), "c"(0u));
+        (void)eax;
+        (void)ebx;
+        (void)edx;
+    }
+#endif
+    if ((ecx1 & (1u << 27)) == 0)
+        return false;
+
+    // XCR0 bits 5/6/7 (opmask, ZMM_Hi256, Hi16_ZMM) must all be set for the
+    // OS to have enabled AVX-512 register state in XSAVE.
+    uint64_t xcr0 = 0;
+#if defined(_MSC_VER)
+    xcr0 = _xgetbv(0);
+#else
+    {
+        uint32_t xa = 0, xd = 0;
+        __asm__ volatile("xgetbv" : "=a"(xa), "=d"(xd) : "c"(0u));
+        xcr0 = ((uint64_t)xd << 32) | xa;
+    }
+#endif
+    if ((xcr0 & 0xe0ull) != 0xe0ull)
+        return false;
+
+    // CPUID leaf 7, sub-leaf 0: EBX bit 16 = AVX-512F.
+    uint32_t ebx7 = 0;
+#if defined(_MSC_VER)
+    {
+        int regs7[4] = {0, 0, 0, 0};
+        __cpuidex(regs7, 7, 0);
+        ebx7 = (uint32_t)regs7[1];
+    }
+#else
+    {
+        uint32_t eax = 0, ecx = 0, edx = 0;
+        __asm__ volatile("cpuid" : "=a"(eax), "=b"(ebx7), "=c"(ecx), "=d"(edx) : "a"(7u), "c"(0u));
+        (void)eax;
+        (void)ecx;
+        (void)edx;
+    }
+#endif
+    return (ebx7 & (1u << 16)) != 0;
+#else
+    return false;
+#endif
+}
 
 static void _ensureSufficientStack() {}
 
@@ -903,6 +987,51 @@ SlangResult LLVMDownstreamCompiler::compile(
                 // Create the JIT
 
                 LLJITBuilder jitBuilder;
+
+                // Defensive AVX-512 gating on x86_64. LLVM's JITTargetMachineBuilder
+                // host detection can leave AVX-512 features enabled on CPUs where
+                // those instructions actually fault at runtime (e.g. AMD EPYC 7763
+                // on GitHub-hosted runners, where CPUID reports no AVX-512 yet
+                // late LLVM codegen passes still emit kmov / vmovss-with-mask).
+                // Build the JTMB explicitly, then if our own CPUID/XCR0 probe says
+                // AVX-512 is not safely usable, subtract the family from the
+                // detected features. AVX2/BMI2/etc remain untouched, so AVX-512-
+                // capable hosts still get the full AVX-512 feature set.
+                // See https://github.com/shader-slang/slang/issues/11062.
+                Expected<JITTargetMachineBuilder> expectJTMB =
+                    JITTargetMachineBuilder::detectHost();
+                if (expectJTMB)
+                {
+                    if (expectJTMB->getTargetTriple().isX86_64() && !_hostSupportsAVX512())
+                    {
+                        // Cover every AVX-512 family feature LLVM exposes for
+                        // x86_64. LLVM's subtarget table generally implies the
+                        // base feature (avx512f) for the higher extensions, so
+                        // disabling -avx512f alone usually suffices, but we
+                        // list the family explicitly to be defensive against
+                        // version-specific implication tables.
+                        expectJTMB->addFeatures({
+                            "-avx512f",
+                            "-avx512cd",
+                            "-avx512dq",
+                            "-avx512bw",
+                            "-avx512vl",
+                            "-avx512vbmi",
+                            "-avx512vbmi2",
+                            "-avx512vnni",
+                            "-avx512bitalg",
+                            "-avx512vpopcntdq",
+                            "-avx512ifma",
+                            "-avx512vp2intersect",
+                            "-avx512fp16",
+                            "-avx512bf16",
+                        });
+                    }
+                    jitBuilder.setJITTargetMachineBuilder(std::move(*expectJTMB));
+                }
+                // If detectHost() failed, fall through and let LLJITBuilder do its
+                // own default detection — preserves prior behaviour on platforms
+                // where this code path can't determine host info.
 
                 Expected<std::unique_ptr<llvm::orc::LLJIT>> expectJit = jitBuilder.create();
                 if (!expectJit)


### PR DESCRIPTION
## Summary

Subtracts the AVX-512 feature family from the slang-llvm JIT's detected host features when the running CPU does not actually support AVX-512 — leaves AVX-512 enabled on capable hosts, only intervenes when LLVM's host detection has misfired.

Fixes #11062.

## Why

`source/slang-llvm/slang-llvm.cpp` creates an `LLJITBuilder` with default host detection. LLVM's [`JITTargetMachineBuilder::detectHost()`](https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h) builds the JIT TargetMachine from `getHostCPUName()` + `getHostCPUFeatures()`. On the GitHub-hosted Linux CPU runners we use, this combination has been reporting AVX-512 as available on AMD EPYC 7763 hosts, where CPUID actually says no AVX-512 — and the JIT then emits `kmov %r,%kN` / masked `vmovss xmm,xmm,xmm{%kN}` into JIT memory, which `#UD`s at execution time.

We've ruled out:

- **clang frontend leak** — IR-dump probe across 120 modules from a real test run shows every function's `target-features` is the x86-64 baseline `+cx8,+mmx,+sse,+sse2,+x87`, no AVX-512. ([comment](https://github.com/shader-slang/slang/issues/11062#issuecomment-4387156524))
- **stale prebuilt LLVM** — disassembly of every static archive that links into `libslang-llvm.so` plus the resulting `.so` from a recent successful master build shows the only AVX-512 in the binary is the BLAKE3 hash function, which dispatches at runtime via `cpuid`+`xgetbv` and correctly falls back on EPYC 7763. ([comment](https://github.com/shader-slang/slang/issues/11062#issuecomment-4387351799))

The remaining path is the JIT's own backend codegen — late LLVM passes consult the `TargetMachine` subtarget rather than per-function `target-features`, and the JIT subtarget is built from LLVM's host detection, which was wrong here.

## What this PR does

1. Adds a small static helper `_hostSupportsAVX512()` that runs the standard AVX-512 detection sequence (CPUID leaf 1 ECX bit 27 OSXSAVE → XCR0 bits 5/6/7 → CPUID leaf 7 EBX bit 16). x86_64-only; on aarch64 / non-x86 it's a no-op returning false.
2. In the `LLJIT` setup path, builds `JITTargetMachineBuilder::detectHost()` explicitly. If the triple is x86_64 *and* our probe says AVX-512 is not safely usable, calls `addFeatures(["-avx512f", "-avx512cd", ..., "-avx512bf16"])` to subtract the entire AVX-512 family from the JIT subtarget. AVX2/BMI2/SSE4 etc. are untouched.
3. Hands the modified JTMB to `LLJITBuilder::setJITTargetMachineBuilder()`. If `detectHost()` itself fails for some reason, falls through to the existing `LLJITBuilder` default — no behaviour change on platforms where this code path can't determine host info.

The probe uses inline `cpuid`/`xgetbv` on GCC/Clang and `__cpuidex`/`_xgetbv` on MSVC — both well-documented platform APIs.

## Behaviour summary

| Host | Before this PR | After this PR |
|---|---|---|
| AVX-512 capable (Ice Lake/Sapphire Rapids/Zen 4 etc.) | AVX-512 codegen, AVX-512 execution | unchanged: AVX-512 codegen, AVX-512 execution |
| Non-AVX-512 host where LLVM detects correctly | no AVX-512 codegen | unchanged: no AVX-512 codegen |
| **Non-AVX-512 host where LLVM detects incorrectly** | **AVX-512 codegen → SIGILL** | **AVX-512 explicitly disabled → fallback codegen** |
| Hypervisor masks AVX-512 mid-run | (rare; would also crash) | safe fallback |
| Non-x86 host | n/a | unchanged: helper is no-op |

So: AVX-512 perf is preserved everywhere it actually works. The fix only kicks in when the existing behaviour would have been a SIGILL.

## Local verification

Built `source/slang-llvm/slang-llvm.cpp.o` against system LLVM 22 (brew) on macOS arm64 with `-Werror`. Object compiles clean. The host-arm64 path of `_hostSupportsAVX512()` is the no-op `#else` branch, so behaviour on the macOS dev box is unchanged.

End-to-end CI verification will happen on this PR — expect the linux-cpu test job's intermittent SIGILL to disappear.