### PR TITLE
ci: preserve scale set across scaler restarts to fix runner orphaning

### DIFF
--- a/extras/scaler/cmd/scaler/main.go
+++ b/extras/scaler/cmd/scaler/main.go
@@ -304,14 +304,6 @@ func run(ctx context.Context, cfg config, logger *slog.Logger) error {
 		ScaleSetID: ss.ID,
 	})
 
-	// Clean up scale set on exit
-	defer func() {
-		logger.Info("deleting scale set", "id", ss.ID)
-		if err := ssClient.DeleteRunnerScaleSet(context.WithoutCancel(ctx), ss.ID); err != nil {
-			logger.Error("failed to delete scale set", "error", err)
-		}
-	}()
-
 	// Runner name prefix
 	vmPrefix := cfg.gcpVMPrefix
 	if vmPrefix == "" {
@@ -369,6 +361,29 @@ func run(ctx context.Context, cfg config, logger *slog.Logger) error {
 		minRunners:     cfg.minRunners,
 		vmPrefix:       vmPrefix,
 	}
+
+	// Clean up scale set on exit, except after a graceful drain. A scaler
+	// that exits via drain mode (SIGUSR1, --session-max-age, or systemctl
+	// reload) is being restarted, not decommissioned — preserving the scale
+	// set lets the next instance reuse the same ID via GetRunnerScaleSet
+	// above, so any in-flight runners keep their JIT registration valid.
+	// Deleting the scale set under a live runner orphans it in a
+	// "Registration not found" retry loop (#11067).
+	//
+	// This defer is declared before defer gcpScaler.shutdown(...) below so
+	// that LIFO ordering runs shutdown first; isDraining() then reflects
+	// the post-shutdown state.
+	defer func() {
+		if gcpScaler.isDraining() {
+			logger.Info("preserving scale set for next scaler instance",
+				"id", ss.ID, "active_vms", vmManager.ActiveCount())
+			return
+		}
+		logger.Info("deleting scale set", "id", ss.ID)
+		if err := ssClient.DeleteRunnerScaleSet(context.WithoutCancel(ctx), ss.ID); err != nil {
+			logger.Error("failed to delete scale set", "error", err)
+		}
+	}()
 
 	// SIGUSR1 enters drain mode: stop accepting new jobs, wait for running
 	// jobs to finish. This enables seamless binary updates:

--- a/extras/scaler/cmd/scaler/main_test.go
+++ b/extras/scaler/cmd/scaler/main_test.go
@@ -49,3 +49,25 @@ func TestValidateSessionMaxAgeNegative(t *testing.T) {
 		t.Fatal("validateSessionMaxAge should fail for negative durations")
 	}
 }
+
+// TestDrainStateTransitions verifies the scaler's drain flag is initially
+// false and toggles via setDraining. The scale-set-preservation defer in
+// run() keys off this state to decide whether to delete the scale set on
+// exit (#11067): preserve when draining, delete otherwise.
+func TestDrainStateTransitions(t *testing.T) {
+	s := &gcpRunnerScaler{}
+
+	if s.isDraining() {
+		t.Fatal("new scaler should not be draining")
+	}
+
+	s.setDraining(true)
+	if !s.isDraining() {
+		t.Fatal("setDraining(true) should make isDraining() true")
+	}
+
+	s.setDraining(false)
+	if s.isDraining() {
+		t.Fatal("setDraining(false) should make isDraining() false")
+	}
+}

--- a/extras/scaler/deploy/update-scaler.sh
+++ b/extras/scaler/deploy/update-scaler.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Update the scaler binary on the host VM
+# Update the scaler binary on the host VM.
 #
 # Use this after rebuilding the scaler binary to deploy a new version.
 #
@@ -7,6 +7,10 @@
 #   cd extras/scaler
 #   GOOS=linux GOARCH=amd64 go build -o scaler-linux ./cmd/scaler
 #   ./deploy/update-scaler.sh
+#
+# Environment overrides:
+#   DRAIN_TIMEOUT_SECONDS  Per-service drain wait (default 300, i.e. 5 min).
+#                          Set to 0 to skip drain and force-stop (orphan risk).
 
 set -euo pipefail
 
@@ -18,6 +22,7 @@ PROJECT="slang-runners"
 ZONE="us-west1-a"
 VM_NAME="gpu-scaler-host"
 BINARY="${SCALER_DIR}/scaler-linux"
+DRAIN_TIMEOUT_SECONDS="${DRAIN_TIMEOUT_SECONDS:-300}"
 
 if [ ! -f "${BINARY}" ]; then
   echo "ERROR: Binary not found at ${BINARY}"
@@ -32,22 +37,67 @@ echo "Uploading binary..."
 gcloud compute scp "${BINARY}" "${VM_NAME}:/tmp/scaler" \
   --zone="${ZONE}" --project="${PROJECT}"
 
-echo "Stopping services, replacing binary, restarting..."
+echo "Draining and stopping services, replacing binary, restarting..."
 # Keep the service list synchronized between the stop block and the restart loop.
 # scaler-linux-sm80plus was added in PR #10967 (2026-04-29) but was missing from
 # this script, so deployments silently left the SM80Plus tier on the old binary
 # until manually restarted.
 SCALER_SERVICES="scaler-windows scaler-linux scaler-linux-sm80plus scaler-windows-build"
+
+# Drain-then-stop sequence (#11067):
+#   1. systemctl reload sends SIGUSR1 -> scaler enters drain mode, stops
+#      accepting new jobs, exits cleanly when active_vms == 0.
+#   2. Wait up to DRAIN_TIMEOUT_SECONDS for the service to deactivate.
+#   3. If still active (long-running job, hung scaler): fall back to
+#      systemctl stop. The new binary's scale-set-preserving defer means
+#      runners orphan ONLY in this fallback path, not on every deploy.
+#
+# Restart=always in the unit files would auto-restart the scaler after a
+# clean drain exit. We therefore explicitly `systemctl stop` after drain to
+# keep the old binary down until the swap-and-start step below.
 gcloud compute ssh "${VM_NAME}" --zone="${ZONE}" --project="${PROJECT}" --command="
-    sudo systemctl stop ${SCALER_SERVICES} 2>/dev/null || true
+    set -u
+    SERVICES='${SCALER_SERVICES}'
+    DRAIN_TIMEOUT='${DRAIN_TIMEOUT_SECONDS}'
+    for svc in \$SERVICES; do
+        if ! sudo systemctl is-active --quiet \"\$svc\"; then
+            echo \"  \$svc: already inactive, skipping drain\"
+            continue
+        fi
+        if [ \"\$DRAIN_TIMEOUT\" -eq 0 ]; then
+            echo \"  \$svc: DRAIN_TIMEOUT_SECONDS=0, force-stopping (orphan risk)\"
+            sudo systemctl stop \"\$svc\" || true
+            continue
+        fi
+        echo \"  \$svc: requesting drain (timeout \${DRAIN_TIMEOUT}s)\"
+        sudo systemctl reload \"\$svc\" || true
+        elapsed=0
+        while [ \"\$elapsed\" -lt \"\$DRAIN_TIMEOUT\" ]; do
+            if ! sudo systemctl is-active --quiet \"\$svc\"; then
+                break
+            fi
+            sleep 5
+            elapsed=\$((elapsed + 5))
+        done
+        if sudo systemctl is-active --quiet \"\$svc\"; then
+            echo \"  \$svc: drain timeout after \${elapsed}s, force-stopping (orphan risk)\"
+        else
+            echo \"  \$svc: drained cleanly after \${elapsed}s\"
+        fi
+        # systemctl stop is idempotent; needed even after a clean drain to
+        # block Restart=always from bringing the old binary back up.
+        sudo systemctl stop \"\$svc\" || true
+    done
+
     sudo mv /tmp/scaler /opt/scaler/scaler
     sudo chmod 755 /opt/scaler/scaler
     sudo chown scaler:scaler /opt/scaler/scaler
+
     failed=0
-    for svc in ${SCALER_SERVICES}; do
-        if sudo systemctl is-enabled \$svc 2>/dev/null | grep -q enabled; then
-            sudo systemctl start \$svc
-            if sudo systemctl is-active \$svc >/dev/null 2>&1; then
+    for svc in \$SERVICES; do
+        if sudo systemctl is-enabled \"\$svc\" 2>/dev/null | grep -q enabled; then
+            sudo systemctl start \"\$svc\"
+            if sudo systemctl is-active --quiet \"\$svc\"; then
                 echo \"  \$svc: active\"
             else
                 echo \"  \$svc: FAILED TO START\"


### PR DESCRIPTION
## Summary

Fixes the deploy-time runner-orphaning bug documented in #11067. When the scaler exits, it currently deletes its GitHub Actions scale set unconditionally. Any VM still authenticated against that scale set — an in-flight job, a runner preserved by drain mode, or one alive across a `--session-max-age` restart — loses its registration credential and gets stuck in a `"Registration not found"` retry loop. Such runners appear in GitHub as `online` with empty labels and `os=unknown`, never self-terminate, and accumulate as orphans that fill `active_vms` and block new VM creation. This morning we hit it again: 7 orphans accumulated overnight, blocking 28 queued CI runs (oldest 14h old) until manual cleanup.

The fix is split across three small changes:

1. **`cmd/scaler/main.go`** — skip `DeleteRunnerScaleSet` when `isDraining()` at exit time. The scale set is meant to outlive a single scaler process; `GetRunnerScaleSet()` at startup already reuses an existing one, so the new instance picks up the same ID and live runners stay valid. The defer is moved past `gcpScaler` initialization so `isDraining()` is in scope, and ordered before `defer gcpScaler.shutdown()` so LIFO runs shutdown first and the drain decision is final by the time we check.

2. **`deploy/update-scaler.sh`** — replace unconditional `systemctl stop` with `systemctl reload` (SIGUSR1 → drain) plus a wait loop bounded by `DRAIN_TIMEOUT_SECONDS` (default 300; override to `0` for emergency force-stop). Followed by an explicit `systemctl stop` to keep `Restart=always` from bringing the old binary back up before the binary swap.

3. **`cmd/scaler/main_test.go`** — cover the `setDraining`/`isDraining` state transitions that the new defer keys off.

After this lands, `update-scaler.sh` deploys and the existing `--session-max-age=2h` cycle both stop creating orphans. SIGKILL/OOM remains a manual-cleanup edge case (see "Out of scope" below).

## Out of scope (follow-up)

The upstream `actions/scaleset` v0.1.0 client exposes no list-runners-in-scale-set API, so an automatic orphan-reconciliation pass would need direct GitHub REST integration. I'll file that as a separate issue. The combination of changes here eliminates the two paths that have actually orphaned runners in production.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` — all pass
- [x] new `TestDrainStateTransitions` passes
- [x] `shellcheck deploy/update-scaler.sh` clean
- [x] `gofmt` clean
- [ ] Real-world test: deploy the new binary while a CI job is mid-run, verify the in-flight VM survives the restart and the same scale-set ID is logged before/after

Fixes #11067