### PR TITLE
chore: ignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ vkd3d-proton.cache.write
 
 # Claude local settings, memory, and worktrees
 /.claude/settings.local.json
+/.claude/scheduled_tasks.lock
 /.claude/worktrees/
 /issue-*/plan.*.md
 /issue-*/review-guide.md


### PR DESCRIPTION
## Summary
- Adds `/.claude/scheduled_tasks.lock` to `.gitignore` so the lock file written by Claude Code's scheduled-tasks runtime isn't tracked.