### PR TITLE
Fix child and decoration transfer loop in type legalization

### DIFF
--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -2395,10 +2395,8 @@ static LegalVal legalizeInst(IRTypeLegalizationContext* context, IRInst* inst)
             inst->replaceUsesWith(newInst);
             inst->removeFromParent();
             context->replacedInstructions.add(inst);
-            for (auto child : inst->getDecorationsAndChildren())
-            {
+            while (auto child = inst->getFirstDecorationOrChild())
                 child->insertAtEnd(newInst);
-            }
             return LegalVal::simple(newInst);
         }
         return LegalVal::simple(inst);


### PR DESCRIPTION
This loop modifies the same list that it is currently iterating over, as `insertAtEnd` also calls `removeFromParent`. This causes it to sometimes miss valid entries, only copying some decorations and children instead of all of them.

This bug is exceptionally difficult to surface with end-to-end tests; the case I found also requires #10608 to be merged AND using the LLVM emitter. But in the IR, the problem is visible as dropping decorations:

Before `lowerEmptyTypes` (`%Bar` has a field with an empty struct type):
```
[SizeAndAlignment(0 : Int, 8 : Int64, 4 : Int)]
[SizeAndAlignment(7 : Int, 8 : Int64, 4 : Int)]
struct %Baz     : Type
{
        [Offset(0 : Int, 0 : Int)]
        [Offset(7 : Int, 0 : Int)]
        field(%a, Int)
        [Offset(0 : Int, 4 : Int)]
        [Offset(7 : Int, 4 : Int)]
        field(%b, %Bar)
}
```
After:
```
[SizeAndAlignment(0 : Int, 8 : Int64, 4 : Int)]
[SizeAndAlignment(7 : Int, 8 : Int64, 4 : Int)]
struct %Baz     : Type
{
        [Offset(0 : Int, 0 : Int)]
        [Offset(7 : Int, 0 : Int)]
        field(%a, Int)
        [Offset(0 : Int, 4 : Int)]
        field(%b, %Bar)
}
```
Here, `%Bar` got legalized to not contain the empty field anymore, and the field using it, `%Baz.%b`, got replaced. The decorations were also supposed to get copied over, but the second `Offset` decoration is silently dropped due to this bug.

This in turn makes `getOffset` queries to fail if the layout rule is 7 (LLVM), as the cached `SizeAndAlignment` decoration causes `getSizeAndAlignment` to not re-calculate `Offset` decorations to all of the fields. Then, `getOffset` fails out, because it neither had a cached offset for `%b` nor did `getSizeAndAlignment` add it like expected.