### PR TITLE
Add Metal neural cooperative matrix support

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -15574,7 +15574,7 @@ uint WaveMaskCountBits(WaveMask mask, bool value)
 // It seems this can only mean the active threads are the "threads the program flow would lead to". This implies a lockstep
 // "straight SIMD" style interpretation. That being the case this op on HLSL is just a memory barrier without any Sync.
 
-[require(cuda_glsl_hlsl_spirv, memorybarrier)]
+[require(cuda_glsl_hlsl_metal_spirv, memorybarrier)]
 void AllMemoryBarrierWithWaveMaskSync(WaveMask mask)
 {
     __target_switch
@@ -15587,6 +15587,9 @@ void AllMemoryBarrierWithWaveMaskSync(WaveMask mask)
     case spirv:
         __subgroupBarrier();
         return;
+    case metal:
+        // Metal simdgroup_barrier always syncs all 32 lanes; mask is ignored.
+        __intrinsic_asm "simdgroup_barrier(metal::mem_flags::mem_device | metal::mem_flags::mem_threadgroup)";
     }
 }
 
@@ -15606,7 +15609,7 @@ void AllMemoryBarrierWithWaveMaskSync(WaveMask mask)
 // aspect of HLSL seems to make everything in lock step - but that's not quite so, it only has to apparently be that way as far as the programmers
 // model appears - divergence could perhaps potentially still happen.
 
-[require(cuda_glsl_hlsl_spirv, memorybarrier)]
+[require(cuda_glsl_hlsl_metal_spirv, memorybarrier)]
 void GroupMemoryBarrierWithWaveMaskSync(WaveMask mask)
 {
     __target_switch
@@ -15619,10 +15622,13 @@ void GroupMemoryBarrierWithWaveMaskSync(WaveMask mask)
     case spirv:
         __subgroupBarrier();
         return;
+    case metal:
+        // Metal simdgroup_barrier always syncs all 32 lanes; mask is ignored.
+        __intrinsic_asm "simdgroup_barrier(metal::mem_flags::mem_threadgroup)";
     }
 }
 
-[require(cuda_glsl_hlsl_spirv, memorybarrier)]
+[require(cuda_glsl_hlsl_metal_spirv, memorybarrier)]
 void AllMemoryBarrierWithWaveSync()
 {
     __target_switch
@@ -15635,10 +15641,12 @@ void AllMemoryBarrierWithWaveSync()
     case spirv:
         __subgroupBarrier();
         return;
+    case metal:
+        __intrinsic_asm "simdgroup_barrier(metal::mem_flags::mem_device | metal::mem_flags::mem_threadgroup)";
     }
 }
 
-[require(cuda_glsl_hlsl_spirv, memorybarrier)]
+[require(cuda_glsl_hlsl_metal_spirv, memorybarrier)]
 void GroupMemoryBarrierWithWaveSync()
 {
     __target_switch
@@ -15651,6 +15659,8 @@ void GroupMemoryBarrierWithWaveSync()
     case spirv:
         __subgroupBarrier();
         return;
+    case metal:
+        __intrinsic_asm "simdgroup_barrier(metal::mem_flags::mem_threadgroup)";
     }
 }
 
@@ -28383,10 +28393,13 @@ struct CoopMat
             else
                 __intrinsic_asm "$0.Store<Slang_CUDA_WMMA::ColMajor>(($1)->m_data + $2, $3)";
         case metal:
+            // This overload indexes the groupshared array in U elements. Metal's
+            // simdgroup_store writes through a T*, so offset in U first, then
+            // cast; only the row/column stride needs conversion to T elements.
             if (matrixLayout == CoopMatMatrixLayout.RowMajor)
-                __intrinsic_asm "simdgroup_store($0, (threadgroup $[0]*)(&((*($1))[0])) + $2, (ulong)$3)", T;
+                __intrinsic_asm "simdgroup_store($0, (threadgroup $[0]*)(&((*($1))[0]) + $2), (ulong)($3 * (sizeof($[1]) / sizeof($[0]))))", T, U;
             else
-                __intrinsic_asm "simdgroup_store($0, (threadgroup $[0]*)(&((*($1))[0])) + $2, (ulong)$3, ulong2(0), true)", T;
+                __intrinsic_asm "simdgroup_store($0, (threadgroup $[0]*)(&((*($1))[0]) + $2), (ulong)($3 * (sizeof($[1]) / sizeof($[0]))), ulong2(0), true)", T, U;
         }
     }
 
@@ -28412,9 +28425,9 @@ struct CoopMat
                 __intrinsic_asm "$0.Store<Slang_CUDA_WMMA::ColMajor>(($1), $2)";
         case metal:
             if (matrixLayout == CoopMatMatrixLayout.RowMajor)
-                __intrinsic_asm "simdgroup_store($0, (threadgroup $[0]*)($1), (ulong)$2)", T;
+                __intrinsic_asm "simdgroup_store($0, (threadgroup $[0]*)($1), (ulong)($2 * (sizeof($[1]) / sizeof($[0]))))", T, U;
             else
-                __intrinsic_asm "simdgroup_store($0, (threadgroup $[0]*)($1), (ulong)$2, ulong2(0), true)", T;
+                __intrinsic_asm "simdgroup_store($0, (threadgroup $[0]*)($1), (ulong)($2 * (sizeof($[1]) / sizeof($[0]))), ulong2(0), true)", T, U;
         }
     }
 
@@ -28666,10 +28679,13 @@ $}
             else
                 __intrinsic_asm "$TR::Load<Slang_CUDA_WMMA::ColMajor>(($0)->m_data + $1, $2)";
         case metal:
+            // This overload indexes the groupshared array in U elements. Metal's
+            // simdgroup_load reads through a T*, so offset in U first, then cast;
+            // only the row/column stride needs conversion to T elements.
             if (matrixLayout == CoopMatMatrixLayout.RowMajor)
-                __intrinsic_asm "_slang_simdgroup_load<$TR>((const threadgroup $[0]*)(&((*($0))[0])) + $1, (ulong)$2)", T;
+                __intrinsic_asm "_slang_simdgroup_load<$TR>((const threadgroup $[0]*)(&((*($0))[0]) + $1), (ulong)($2 * (sizeof($[1]) / sizeof($[0]))))", T, U;
             else
-                __intrinsic_asm "_slang_simdgroup_load_transpose<$TR>((const threadgroup $[0]*)(&((*($0))[0])) + $1, (ulong)$2)", T;
+                __intrinsic_asm "_slang_simdgroup_load_transpose<$TR>((const threadgroup $[0]*)(&((*($0))[0]) + $1), (ulong)($2 * (sizeof($[1]) / sizeof($[0]))))", T, U;
         }
     }
 
@@ -28695,9 +28711,9 @@ $}
                 __intrinsic_asm "$TR::Load<Slang_CUDA_WMMA::ColMajor>($0, $1)";
         case metal:
             if (matrixLayout == CoopMatMatrixLayout.RowMajor)
-                __intrinsic_asm "_slang_simdgroup_load<$TR>((const threadgroup $[0]*)($0), (ulong)$1)", T;
+                __intrinsic_asm "_slang_simdgroup_load<$TR>((const threadgroup $[0]*)($0), (ulong)($1 * (sizeof($[1]) / sizeof($[0]))))", T, U;
             else
-                __intrinsic_asm "_slang_simdgroup_load_transpose<$TR>((const threadgroup $[0]*)($0), (ulong)$1)", T;
+                __intrinsic_asm "_slang_simdgroup_load_transpose<$TR>((const threadgroup $[0]*)($0), (ulong)($1 * (sizeof($[1]) / sizeof($[0]))))", T, U;
         }
     }
 

--- a/source/standard-modules/neural/accelerate-vector-coopmat.slang
+++ b/source/standard-modules/neural/accelerate-vector-coopmat.slang
@@ -14,9 +14,9 @@ implementing neural;
 #define PERF_OPA_ACTIVE 1
 #endif
 
-// Cooperative matrix is only supported by CUDA and SPIR-V
+// Cooperative matrix is supported by CUDA, Metal, and SPIR-V here.
 // WaveTangledVector is a vector type that emulates the Cooperative Vector type by using Cooperative Matrix feature which is
-// supported by CUDA and SPIR-V.
+// supported by CUDA, Metal, and SPIR-V.
 [require(cuda_metal_spirv, cooperative_matrix, subgroup_basic)]
 public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int SubgroupSize, int SubgroupCount> : IVector<T>
     where T : __BuiltinFloatingPointType
@@ -190,7 +190,7 @@ public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int Sub
     [ForceInline]
     [HasTrivialForwardDerivative]
     [BackwardDerivative(linearTransformBwd)]
-    [require(cuda_spirv)]
+    [require(cuda_metal_spirv)]
     public OutputVector linearTransform<Address, Layout, OutputVector>(
         Address weightAddress)
             where Address : IPointerLikeAddress<T>
@@ -204,6 +204,8 @@ public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int Sub
             return no_diff linearTransformOnTarget<Address, Layout, OutputVector, TargetEnum.CUDA, false>(weightAddress, none);
         case spirv:
             return no_diff linearTransformOnTarget<Address, Layout, OutputVector, TargetEnum.SPIR_V, false>(weightAddress, none);
+        case metal:
+            return no_diff linearTransformOnTarget<Address, Layout, OutputVector, TargetEnum.Metal, false>(weightAddress, none);
         }
     }
 
@@ -226,13 +228,15 @@ public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int Sub
             linearTransformBwdOnTarget<Address, Layout, OutputVector, TargetEnum.CUDA, false>(dthis, dWeightAddress, biasAddress, doutput);
         case spirv:
             linearTransformBwdOnTarget<Address, Layout, OutputVector, TargetEnum.SPIR_V, false>(dthis, dWeightAddress, biasAddress, doutput);
+        case metal:
+            linearTransformBwdOnTarget<Address, Layout, OutputVector, TargetEnum.Metal, false>(dthis, dWeightAddress, biasAddress, doutput);
         }
     }
 
     [ForceInline]
     [HasTrivialForwardDerivative]
     [BackwardDerivative(linearTransformBwd)]
-    [require(cuda_spirv)]
+    [require(cuda_metal_spirv)]
     public OutputVector linearTransform<Address, Layout, OutputVector>(
         Address weightAddress, Address biasAddress)
             where Address : IPointerLikeAddress<T>
@@ -246,6 +250,8 @@ public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int Sub
             return no_diff linearTransformOnTarget<Address, Layout, OutputVector, TargetEnum.CUDA, true>(weightAddress, biasAddress);
         case spirv:
             return no_diff linearTransformOnTarget<Address, Layout, OutputVector, TargetEnum.SPIR_V, true>(weightAddress, biasAddress);
+        case metal:
+            return no_diff linearTransformOnTarget<Address, Layout, OutputVector, TargetEnum.Metal, true>(weightAddress, biasAddress);
         }
     }
 
@@ -268,6 +274,8 @@ public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int Sub
             linearTransformBwdOnTarget<Address, Layout, OutputVector, TargetEnum.CUDA, true>(dthis, dWeightAddress, dBiasAddress, doutput);
         case spirv:
             linearTransformBwdOnTarget<Address, Layout, OutputVector, TargetEnum.SPIR_V, true>(dthis, dWeightAddress, dBiasAddress, doutput);
+        case metal:
+            linearTransformBwdOnTarget<Address, Layout, OutputVector, TargetEnum.Metal, true>(dthis, dWeightAddress, dBiasAddress, doutput);
         }
     }
 }

--- a/source/standard-modules/neural/accelerate-vector-coopmat.slang
+++ b/source/standard-modules/neural/accelerate-vector-coopmat.slang
@@ -17,7 +17,8 @@ implementing neural;
 // Cooperative matrix is only supported by CUDA and SPIR-V
 // WaveTangledVector is a vector type that emulates the Cooperative Vector type by using Cooperative Matrix feature which is
 // supported by CUDA and SPIR-V.
-[require(cooperative_matrix, subgroup_basic, cuda_spirv)]
+// [require(cooperative_matrix, subgroup_basic, cuda_metal_spirv)]
+[require(cuda_metal_spirv, cooperative_matrix, subgroup_basic)]
 public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int SubgroupSize, int SubgroupCount> : IVector<T>
     where T : __BuiltinFloatingPointType
     where T.Differential == T
@@ -36,8 +37,10 @@ public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int Sub
     internal T[Uint4AlignedInputSize] data;
     public int getCount() { return N; }
 
+    [ForceInline]
     public __init() { data = {}; }
 
+    [ForceInline]
     public __init(T value)
     {
         for (int i = 0; i < N; i++)
@@ -45,6 +48,7 @@ public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int Sub
         cleanPaddingData();
     }
 
+    [ForceInline]
     public __init(T[Size] inData)
     {
         for (int i = 0; i < N; i++)
@@ -52,13 +56,16 @@ public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int Sub
         cleanPaddingData();
     }
 
+    [ForceInline]
     internal __init(T[Uint4AlignedInputSize] inData)
     {
         this.data = inData;
     }
 
+    [ForceInline]
     public __init(This other) { this.data = other.data; }
 
+    [ForceInline]
     public __init<InputArray : IArray<T>>(InputArray inData)
     {
         for (int i = 0; i < N; i++)

--- a/source/standard-modules/neural/accelerate-vector-coopmat.slang
+++ b/source/standard-modules/neural/accelerate-vector-coopmat.slang
@@ -17,7 +17,6 @@ implementing neural;
 // Cooperative matrix is only supported by CUDA and SPIR-V
 // WaveTangledVector is a vector type that emulates the Cooperative Vector type by using Cooperative Matrix feature which is
 // supported by CUDA and SPIR-V.
-// [require(cooperative_matrix, subgroup_basic, cuda_metal_spirv)]
 [require(cuda_metal_spirv, cooperative_matrix, subgroup_basic)]
 public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int SubgroupSize, int SubgroupCount> : IVector<T>
     where T : __BuiltinFloatingPointType
@@ -38,11 +37,12 @@ public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int Sub
     public int getCount() { return N; }
 
     [ForceInline]
-    public __init() { data = {}; }
+    public __init() {}
 
     [ForceInline]
     public __init(T value)
     {
+        [ForceUnroll]
         for (int i = 0; i < N; i++)
             this.data[i] = value;
         cleanPaddingData();
@@ -51,6 +51,7 @@ public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int Sub
     [ForceInline]
     public __init(T[Size] inData)
     {
+        [ForceUnroll]
         for (int i = 0; i < N; i++)
             this.data[i] = inData[i];
         cleanPaddingData();
@@ -68,6 +69,7 @@ public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int Sub
     [ForceInline]
     public __init<InputArray : IArray<T>>(InputArray inData)
     {
+        [ForceUnroll]
         for (int i = 0; i < N; i++)
             this.data[i] = inData[i];
         cleanPaddingData();
@@ -79,6 +81,7 @@ public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int Sub
     {
         const int elementCountPerUint4 = sizeof(uint4) / sizeof(DTypeMatC);
         const int alignedSize = ((N + (elementCountPerUint4 - 1)) / elementCountPerUint4) * elementCountPerUint4;
+        [ForceUnroll]
         for (int i = N; i < alignedSize; i++)
             this.data[i] = T(0.0f);
     }

--- a/source/standard-modules/neural/accelerate-vector-coopmat.slang
+++ b/source/standard-modules/neural/accelerate-vector-coopmat.slang
@@ -37,7 +37,10 @@ public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int Sub
     public int getCount() { return N; }
 
     [ForceInline]
-    public __init() {}
+    public __init()
+    {
+        cleanPaddingData();
+    }
 
     [ForceInline]
     public __init(T value)
@@ -61,6 +64,7 @@ public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int Sub
     internal __init(T[Uint4AlignedInputSize] inData)
     {
         this.data = inData;
+        cleanPaddingData();
     }
 
     [ForceInline]

--- a/source/standard-modules/neural/activations.slang
+++ b/source/standard-modules/neural/activations.slang
@@ -11,6 +11,7 @@ public struct IdentityActivation<T> : IActivation<T>
 {
     public __init() {}
 
+    [ForceInline]
     [NoDiffThis]
     [Differentiable]
     public Vector eval<Vector>(Vector input)

--- a/source/standard-modules/neural/iactivation.slang
+++ b/source/standard-modules/neural/iactivation.slang
@@ -21,6 +21,7 @@ public interface IActivation<T>
     /// Apply activation function element-wise.
     /// @param input Input vector.
     /// @return Output vector with activation applied.
+    [ForceInline]
     [NoDiffThis]
     [Differentiable]
     public Vector eval<Vector>(Vector input)

--- a/source/standard-modules/neural/mma-linear-layout-help.slang
+++ b/source/standard-modules/neural/mma-linear-layout-help.slang
@@ -27,6 +27,8 @@ internal uint getWaveId()
                 OpCapability GroupNonUniform;
                 result:$$uint = OpLoad builtin(SubgroupId:uint);
             };
+    case metal:
+        return WaveGetWaveIndex();
     }
 }
 
@@ -47,6 +49,8 @@ public int getWaveCount()
             uint3 workGroupSize = WorkgroupSize();
             int subGroupSize = WaveGetLaneCount();
             return (workGroupSize.x * workGroupSize.y * workGroupSize.z) / subGroupSize;
+        case metal:
+            return int(WaveGetNumWaves());
         }
     default:
         // We need this because WorkgroupSize() call requires compute stage only.

--- a/source/standard-modules/neural/mma-linear-layout-help.slang
+++ b/source/standard-modules/neural/mma-linear-layout-help.slang
@@ -4,6 +4,7 @@ public enum TargetEnum : uint32_t
 {
     CUDA = 0,
     SPIR_V = 1,
+    Metal = 2,
 }
 
 public enum ExecutionMode : uint32_t

--- a/source/standard-modules/neural/mma-tiled-cuda.slang
+++ b/source/standard-modules/neural/mma-tiled-cuda.slang
@@ -239,7 +239,7 @@ internal struct TiledMMACuda<T, int InputSize, int OutputSize, int SubgroupSize,
     {
         WeightMatrix w;
         w.loadWeightRaw<T, Address>(weightAddress);
-        result = matMul<T, N, K, M>(inputMat, w);
+        result = matMul<half, T, N, K, M>(inputMat, w);
     }
 
     // =========================================================================
@@ -267,7 +267,7 @@ internal struct TiledMMACuda<T, int InputSize, int OutputSize, int SubgroupSize,
         let wT = w.transpose();
 
         // MMA: result(N, K) = dOut(N, M) × W^T(M, K)
-        result = matMul<T, N, M, K>(dOut, wT);
+        result = matMul<half, T, N, M, K>(dOut, wT);
     }
 
     // =========================================================================
@@ -328,7 +328,7 @@ internal struct TiledMMACuda<T, int InputSize, int OutputSize, int SubgroupSize,
         }
 
         // MMA: C(M×K) = A(M×32) × B(32×K)
-        OPResult matC = matMul<T, M, N, K>(dOutT, inputB);
+        OPResult matC = matMul<half, T, M, N, K>(dOutT, inputB);
 
         // Cross-warp reduction
         if (SubgroupCount > 1)

--- a/source/standard-modules/neural/mma-tiled-cuda.slang
+++ b/source/standard-modules/neural/mma-tiled-cuda.slang
@@ -239,7 +239,7 @@ internal struct TiledMMACuda<T, int InputSize, int OutputSize, int SubgroupSize,
     {
         WeightMatrix w;
         w.loadWeightRaw<T, Address>(weightAddress);
-        result = matMul<half, T, N, K, M>(inputMat, w);
+        result = matMul<T, N, K, M>(inputMat, w);
     }
 
     // =========================================================================
@@ -267,7 +267,7 @@ internal struct TiledMMACuda<T, int InputSize, int OutputSize, int SubgroupSize,
         let wT = w.transpose();
 
         // MMA: result(N, K) = dOut(N, M) × W^T(M, K)
-        result = matMul<half, T, N, M, K>(dOut, wT);
+        result = matMul<T, N, M, K>(dOut, wT);
     }
 
     // =========================================================================
@@ -328,7 +328,7 @@ internal struct TiledMMACuda<T, int InputSize, int OutputSize, int SubgroupSize,
         }
 
         // MMA: C(M×K) = A(M×32) × B(32×K)
-        OPResult matC = matMul<half, T, M, N, K>(dOutT, inputB);
+        OPResult matC = matMul<T, M, N, K>(dOutT, inputB);
 
         // Cross-warp reduction
         if (SubgroupCount > 1)

--- a/source/standard-modules/neural/mma-tiled-layout-helper.slang
+++ b/source/standard-modules/neural/mma-tiled-layout-helper.slang
@@ -42,7 +42,7 @@ internal struct TiledMMAHelper<T, int InputSize, int OutputSize, int SubgroupSiz
     [require(cooperative_matrix, subgroup_basic, cuda_spirv)]
     internal static WaveTangledVector<T, ShMemSize, OutputSize, SubgroupSize, SubgroupCount>
     forward<Address, bool Bias = false>(
-        WaveTangledVector<T, ShMemSize, InputSize, SubgroupSize, SubgroupCount> input,
+        __constref WaveTangledVector<T, ShMemSize, InputSize, SubgroupSize, SubgroupCount> input,
         Address weightAddress,
         Optional<Address> biasAddress)
         where Address : IPointerLikeAddress<T>

--- a/source/standard-modules/neural/mma-tiled-layout-helper.slang
+++ b/source/standard-modules/neural/mma-tiled-layout-helper.slang
@@ -3,6 +3,7 @@
 // Routes forward and backward to backend-specific implementations:
 //   CUDA:   TiledMMACuda / MMAHelperNew (WaveMatrix register ops)
 //   Vulkan: TiledMMAVulkan (WaveMatrix + shmem, CoopMat.Load)
+//   Metal:  TiledMMAMetal (8x8 simdgroup_matrix, row-major weights)
 //
 // InputSize and OutputSize must be tile-aligned (multiples of 16).
 // Callers with arbitrary sizes should pad via PadToTile before instantiation.
@@ -32,14 +33,15 @@ internal struct TiledMMAHelper<T, int InputSize, int OutputSize, int SubgroupSiz
     static const int K = BaseMMA.K;
 
     // =========================================================================
-    // Forward MMA: dispatches to CUDA or Vulkan backend.
+    // Forward MMA: dispatches to CUDA, Vulkan, or Metal backend.
     //
     // CUDA:   TiledMMACuda.forward (MMAHelperNew, register-based, zero shmem)
     // Vulkan: TiledMMAVulkan.forward (WaveMatrix + shmem, CoopMat.Load)
+    // Metal:  TiledMMAMetal.forward (8x8 simdgroup_matrix + shmem staging)
     // =========================================================================
 
     [ForceInline]
-    [require(cooperative_matrix, subgroup_basic, cuda_spirv)]
+    [require(cooperative_matrix, subgroup_basic, cuda_metal_spirv)]
     internal static WaveTangledVector<T, ShMemSize, OutputSize, SubgroupSize, SubgroupCount>
     forward<Address, bool Bias = false>(
         __constref WaveTangledVector<T, ShMemSize, InputSize, SubgroupSize, SubgroupCount> input,
@@ -57,18 +59,23 @@ internal struct TiledMMAHelper<T, int InputSize, int OutputSize, int SubgroupSiz
             typealias Vulkan = TiledMMAVulkan<T, InputSize, OutputSize, SubgroupSize, Target, ShMemSize, TransposeA, SubgroupCount>;
             return Vulkan.forward<Address, Bias>(
                 input, weightAddress, biasAddress);
+        case metal:
+            typealias Metal = TiledMMAMetal<T, InputSize, OutputSize, SubgroupSize, Target, ShMemSize, TransposeA, SubgroupCount>;
+            return Metal.forward<Address, Bias>(
+                input, weightAddress, biasAddress);
         }
     }
 
     // =========================================================================
-    // Unified backward: dispatches to CUDA or Vulkan backend.
+    // Unified backward: dispatches to CUDA, Vulkan, or Metal backend.
     //
     // CUDA:   TiledMMACuda (WaveMatrix register ops, shuffles, ChangeMajor)
     // Vulkan: TiledMMAVulkan (WaveMatrix + shmem, CoopMat.Load, no register transforms)
+    // Metal:  TiledMMAMetal (mmaTranspose + biasReduce + direct outer-product)
     // =========================================================================
 
     [ForceInline]
-    [require(cooperative_matrix, subgroup_basic, cuda_spirv)]
+    [require(cooperative_matrix, subgroup_basic, cuda_metal_spirv)]
     internal static WaveTangledVector<T.Differential, ShMemSize, InputSize, SubgroupSize, SubgroupCount>
     backward<Address, OutputVector, bool Bias = true>(
         WaveTangledVector<T, ShMemSize, InputSize, SubgroupSize, SubgroupCount> input,
@@ -95,6 +102,10 @@ internal struct TiledMMAHelper<T, int InputSize, int OutputSize, int SubgroupSiz
         case spirv:
             typealias Vulkan = TiledMMAVulkan<T, InputSize, OutputSize, SubgroupSize, Target, ShMemSize, TransposeA, SubgroupCount>;
             return Vulkan.backward<Address, Bias>(
+                input, dOutConcrete, weightAddress, weightGradConcrete, biasGradConcrete);
+        case metal:
+            typealias Metal = TiledMMAMetal<T, InputSize, OutputSize, SubgroupSize, Target, ShMemSize, TransposeA, SubgroupCount>;
+            return Metal.backward<Address, Bias>(
                 input, dOutConcrete, weightAddress, weightGradConcrete, biasGradConcrete);
         }
     }

--- a/source/standard-modules/neural/mma-tiled-layout-helper.slang
+++ b/source/standard-modules/neural/mma-tiled-layout-helper.slang
@@ -5,8 +5,8 @@
 //   Vulkan: TiledMMAVulkan (WaveMatrix + shmem, CoopMat.Load)
 //   Metal:  TiledMMAMetal (8x8 simdgroup_matrix, row-major weights)
 //
-// InputSize and OutputSize must be tile-aligned (multiples of 16).
-// Callers with arbitrary sizes should pad via PadToTile before instantiation.
+// InputSize and OutputSize must be target-tile-aligned:
+// 16 elements for CUDA/Vulkan and 8 elements for Metal.
 implementing neural;
 
 

--- a/source/standard-modules/neural/mma-tiled-metal.slang
+++ b/source/standard-modules/neural/mma-tiled-metal.slang
@@ -1,0 +1,711 @@
+// TiledMMAMetal: Metal backend for tiled MMA using 8x8 simdgroup_matrix
+// tiles (matching Metal's hardware MMA size).
+//
+// Weight memory layout
+// --------------------
+// Despite the `Tiled*` family name, this Metal backend expects the weight
+// matrix W to be a plain M × K **row-major** buffer in memory (stride = K),
+// NOT the tile-grid layout used by `TiledMMACuda` / `TiledMMAVulkan`.
+// A-tiles are issued as `simdgroup_matrix_8x8_load` with
+// `extents=[K, 8], strides=[1, K]`, i.e. the standard wide-row pattern.
+//
+// The earlier perf investigation on Apple M4 showed that
+// the canonical tile-grid pattern (`extents=[8, 8], strides=[1, 8]`)
+// defeats the GPU's prefetch reuse after each per-k threadgroup-memory
+// write, costing 8–14% at half and 1–6% at float. A re-measurement after
+// the ForceUnroll MMA + barrier-after-load + packed-uint4 shmem-write
+// changes showed the half gap has mostly collapsed (0–3%), but float
+// still pays 1–16% for the tile-grid layout at large sizes, so row-major
+// remains the default for this backend.
+//
+// Callers that pack weights for mixed CUDA/Vulkan/Metal deployment should
+// therefore keep a separate row-major packing for the Metal path (or
+// equivalently, transpose from tile-grid to row-major on upload).
+implementing neural;
+
+
+static const int MetalTile = 8;
+
+internal typealias MetalMatrixA<T: __BuiltinFloatingPointType, int Rows, int Cols> = WaveMatrix<T, linalg.CoopMatMatrixUse.MatrixA, Rows, Cols>;
+internal typealias MetalMatrixB<T: __BuiltinFloatingPointType, int Rows, int Cols> = WaveMatrix<T, linalg.CoopMatMatrixUse.MatrixB, Rows, Cols>;
+internal typealias MetalMatrixC<T: __BuiltinFloatingPointType, int Rows, int Cols> = WaveMatrix<T, linalg.CoopMatMatrixUse.MatrixAccumulator, Rows, Cols>;
+
+
+[require(cooperative_matrix)]
+internal struct TiledMMAMetal<T, int InputSize, int OutputSize, int SubgroupSize, TargetEnum Target, ShMemSize: ISharedMemorySize, bool TransposeA, int SubgroupCount>
+    where T : __BuiltinFloatingPointType
+    where T.Differential == T
+{
+    typealias ShMemPool = SharedMemoryPool<ShMemSize>;
+    typealias BaseMMA = MMAHelper<T, InputSize, OutputSize, SubgroupSize, Target, ShMemSize, TransposeA, SubgroupCount>;
+    typealias CMShape = BaseMMA.CMShape;
+
+    static const int M = OutputSize;
+    static const int K = InputSize;
+    static const int N = SubgroupSize;
+
+    static const int NTileRows = (M + MetalTile - 1) / MetalTile;
+    static const int NTileCols = (K + MetalTile - 1) / MetalTile;
+    static const int TileSizeInElements = MetalTile * MetalTile;
+
+    [ForceInline]
+    static int tileElementOffset(int tileRow, int tileCol)
+    {
+        return (tileRow * NTileCols + tileCol) * TileSizeInElements;
+    }
+
+    // =========================================================================
+    // Forward: result = W(M,K) × input(K,N)
+    //
+    // Blocked outer-product form (K outermost, M blocked with M_BLOCK=2).
+    // Keeps ~13 simdgroup matrices live to avoid register spills on Apple Silicon.
+    //
+    // Metal: no hybrid precision -- A, B, C all use the same type T.
+    // Uses WaveMatrix methods: loadWeightTiled, fromVectorViaShMem, matMad.
+    // =========================================================================
+
+    static const int M_BLOCK = 2;
+
+    // Struct-scope shared state for forward / mmaTranspose. Both functions
+    // reuse the same K-loop via `mmaAccumulateMgGroup`, and both rely on the
+    // same per-warp shmem layout and 8x8 CoopMat types. Keeping these at
+    // struct scope (rather than duplicated as function-local constants) means
+    // the helper(s) can access them directly.
+    static const int TILES_N_ = N / MetalTile;
+    static const int ElemsPerUint4_ = sizeof(uint4) / sizeof(T);
+    static const int TileWidthUint4_ = (MetalTile + ElemsPerUint4_ - 1) / ElemsPerUint4_;
+    static const int ShmemPerWarpUint4_ = 32 * TileWidthUint4_;
+
+    typealias AMatrix = linalg.CoopMat<T, MemoryScope.Subgroup, MetalTile, MetalTile, linalg.CoopMatMatrixUse.MatrixA>;
+    typealias BMatrix = linalg.CoopMat<T, MemoryScope.Subgroup, MetalTile, MetalTile, linalg.CoopMatMatrixUse.MatrixB>;
+    typealias CMatrix = linalg.CoopMat<T, MemoryScope.Subgroup, MetalTile, MetalTile, linalg.CoopMatMatrixUse.MatrixAccumulator>;
+
+    // =========================================================================
+    // packInputTileToShmem
+    //
+    // Pack a tile-wide (MetalTile = 8) slice of the input WTV into the
+    // current warp's shmem region, in the layout expected by
+    // `BMatrix.Load<ColumnMajor, uint4>`.
+    //
+    // - For half:  1 uint4 = 8 halfs = 1 tile, so one uint4 store per lane.
+    //              The WTV's `Uint4AlignedInputSize` already guarantees
+    //              at least 1-uint4 (= 1 tile) of storage past the logical
+    //              `InputSize`, so a full-tile read is always in-bounds
+    //              and no bounds check is needed.
+    // - For float: 1 uint4 = 4 floats = half a tile, so two uint4 stores
+    //              per lane. The WTV's storage is 1-uint4 aligned for
+    //              float (= half a tile), so if `InputSize` is not a
+    //              multiple of MetalTile, the last k-iteration's read
+    //              would exceed the caller's logical input.
+    //
+    // The float path uses a single per-tile branch
+    // (`srcStart + MetalTile <= InputSize`) to pick between:
+    //   - Fast path: both uint4 stores unchecked. Taken for every tile
+    //     when `InputSize` is tile-aligned (the compile-time constant
+    //     `InputSize % MetalTile == 0` short-circuits the condition, so
+    //     the slow path is dead-code-eliminated), and for all but the
+    //     last partial tile otherwise.
+    //   - Slow path: per-element bounds check, zero-pad OOB slots so
+    //     the MMA's last partial tile sees zeros rather than
+    //     uninitialized storage. Runs at most once per `forward` call.
+    // =========================================================================
+
+    [ForceInline]
+    internal static void packInputTileToShmem<int SrcSize>(
+        __constref WaveTangledVector<T, ShMemSize, SrcSize, SubgroupSize, SubgroupCount> input,
+        int srcStart,
+        uint shMemDstUint4)
+    {
+        if (sizeof(T) == sizeof(half))
+        {
+            let u0 = bit_cast<uint2>(half4(
+                __realCast<half>(input.data[srcStart + 0]),
+                __realCast<half>(input.data[srcStart + 1]),
+                __realCast<half>(input.data[srcStart + 2]),
+                __realCast<half>(input.data[srcStart + 3])));
+            let u1 = bit_cast<uint2>(half4(
+                __realCast<half>(input.data[srcStart + 4]),
+                __realCast<half>(input.data[srcStart + 5]),
+                __realCast<half>(input.data[srcStart + 6]),
+                __realCast<half>(input.data[srcStart + 7])));
+            ShMemPool.data[shMemDstUint4] = uint4(u0.x, u0.y, u1.x, u1.y);
+        }
+        else if (SrcSize % MetalTile == 0 || srcStart + MetalTile <= SrcSize)
+        {
+            // Fast path. Taken when either:
+            //   (a) `SrcSize` is tile-aligned, so no contract iteration can
+            //       exceed it (compile-time-foldable), or
+            //   (b) this tile is fully in-bounds (runtime check, true for
+            //       every iteration except the last partial one).
+            ShMemPool.data[shMemDstUint4 + 0] = uint4(
+                bit_cast<uint>(input.data[srcStart + 0]),
+                bit_cast<uint>(input.data[srcStart + 1]),
+                bit_cast<uint>(input.data[srcStart + 2]),
+                bit_cast<uint>(input.data[srcStart + 3]));
+            ShMemPool.data[shMemDstUint4 + 1] = uint4(
+                bit_cast<uint>(input.data[srcStart + 4]),
+                bit_cast<uint>(input.data[srcStart + 5]),
+                bit_cast<uint>(input.data[srcStart + 6]),
+                bit_cast<uint>(input.data[srcStart + 7]));
+        }
+        else
+        {
+            // Slow path: float's last partial tile on a non-tile-aligned
+            // `SrcSize`. Per-element bounds check, zero OOB slots so the
+            // MMA accumulator sees zeros rather than uninitialized storage.
+            let e0 = (srcStart + 0 < SrcSize) ? bit_cast<uint>(input.data[srcStart + 0]) : 0u;
+            let e1 = (srcStart + 1 < SrcSize) ? bit_cast<uint>(input.data[srcStart + 1]) : 0u;
+            let e2 = (srcStart + 2 < SrcSize) ? bit_cast<uint>(input.data[srcStart + 2]) : 0u;
+            let e3 = (srcStart + 3 < SrcSize) ? bit_cast<uint>(input.data[srcStart + 3]) : 0u;
+            let e4 = (srcStart + 4 < SrcSize) ? bit_cast<uint>(input.data[srcStart + 4]) : 0u;
+            let e5 = (srcStart + 5 < SrcSize) ? bit_cast<uint>(input.data[srcStart + 5]) : 0u;
+            let e6 = (srcStart + 6 < SrcSize) ? bit_cast<uint>(input.data[srcStart + 6]) : 0u;
+            let e7 = (srcStart + 7 < SrcSize) ? bit_cast<uint>(input.data[srcStart + 7]) : 0u;
+            ShMemPool.data[shMemDstUint4 + 0] = uint4(e0, e1, e2, e3);
+            ShMemPool.data[shMemDstUint4 + 1] = uint4(e4, e5, e6, e7);
+        }
+    }
+
+    // =========================================================================
+    // mmaAccumulateMgGroup
+    //
+    // Compute one M_BLOCK-wide tile group of the output:
+    //   acc[mb][n] = sum over contract tiles of A_tile × B_tile
+    // where the A tiles come from the weight matrix W (possibly transposed),
+    // and the B tiles come from `input` packed into shmem tile-by-tile.
+    //
+    // Template parameters:
+    //   `ContractSize`  — length of `input` in elements; equals the contract
+    //                     dimension of the MMA (K for forward, M for
+    //                     mmaTranspose).
+    //   `DoTransposeA`  — false: A is the W[m, k] row-major tile (forward).
+    //                     true:  A is the W^T[k, m] = W[m, k] viewed as
+    //                            column-major (mmaTranspose / backward).
+    //
+    // The weight matrix W is stored in memory as OutputSize × InputSize
+    // row-major, so the underlying stride is always `K = InputSize`,
+    // regardless of whether we are loading W or W^T.
+    //
+    // This helper is the shared core of `forward` and `mmaTranspose`.
+    // =========================================================================
+
+    [ForceInline]
+    [require(cooperative_matrix, subgroup_basic)]
+    internal static void mmaAccumulateMgGroup<Address, int ContractSize, bool DoTransposeA>(
+        __constref WaveTangledVector<T, ShMemSize, ContractSize, SubgroupSize, SubgroupCount> input,
+        Address weightAddress,
+        int outerGroup,
+        inout CMatrix acc[M_BLOCK][TILES_N_],
+        uint perWarpBase,
+        uint lane)
+        where Address : IPointerLikeAddress<T>
+    {
+        static const int TILES_C = (ContractSize + MetalTile - 1) / MetalTile;
+
+        for (int mb = 0; mb < M_BLOCK; mb++)
+            for (int n = 0; n < TILES_N_; n++)
+                acc[mb][n].fill(T(0));
+
+        // Contract loop is NOT unrolled. Tried [ForceUnroll]: helped half
+        // slightly (~1%) but caused 16-27% regression at float for
+        // ContractSize=128 — fully inlining 16 iterations exceeds the GPU's
+        // instruction window / register budget. Code-size grows ~3x.
+        for (int c = 0; c < TILES_C; c++)
+        {
+            // Each lane packs its MetalTile-element slice of `input.data`
+            // into `TileWidthUint4_` uint4 stores in shmem. See
+            // `packInputTileToShmem`'s doc block for the bounds-check
+            // rationale for float with non-tile-aligned `ContractSize`.
+            packInputTileToShmem<ContractSize>(
+                input,
+                c * MetalTile,
+                perWarpBase + lane * uint(TileWidthUint4_));
+            GroupMemoryBarrierWithWaveSync();
+
+            BMatrix matB[TILES_N_];
+            [ForceUnroll]
+            for (int n = 0; n < TILES_N_; n++)
+            {
+                uint tileOffsetUint4 = perWarpBase + uint(n * MetalTile * TileWidthUint4_);
+                matB[n] = BMatrix.Load<linalg.CoopMatMatrixLayout.ColumnMajor, uint4>(
+                    ShMemPool.data, tileOffsetUint4, uint(TileWidthUint4_));
+            }
+            // Post-load barrier mirrors fromVectorViaShMem's structure
+            // (write -> barrier -> load -> barrier). Empirically, placing
+            // the barrier here (instead of post-MMA) lets the GPU schedule
+            // MMA more efficiently and is ~5% faster at half on M4.
+            GroupMemoryBarrierWithWaveSync();
+
+            [ForceUnroll]
+            for (int mb = 0; mb < M_BLOCK; mb++)
+            {
+                int outerTile = outerGroup * M_BLOCK + mb;
+
+                AMatrix matA;
+                if (DoTransposeA)
+                {
+                    // W^T[outerTile*8+r, c*8+col] = W[c*8+col, outerTile*8+r].
+                    // Base address = c*8*K + outerTile*8 (row c*8 of W);
+                    // ColumnMajor load with stride=K produces the transposed
+                    // 8x8 block as MatrixA.
+                    matA = loadCoopMat<T, Address, MetalTile, MetalTile,
+                        linalg.CoopMatMatrixUse.MatrixA,
+                        linalg.CoopMatMatrixLayout.ColumnMajor>(
+                        weightAddress,
+                        uint(c * MetalTile * K + outerTile * MetalTile),
+                        uint(K));
+                }
+                else
+                {
+                    // W[outerTile*8+r, c*8+col].
+                    // Base address = outerTile*8*K + c*8; RowMajor stride=K.
+                    matA = loadCoopMat<T, Address, MetalTile, MetalTile,
+                        linalg.CoopMatMatrixUse.MatrixA,
+                        linalg.CoopMatMatrixLayout.RowMajor>(
+                        weightAddress,
+                        uint(outerTile * MetalTile * K + c * MetalTile),
+                        uint(K));
+                }
+
+                [ForceUnroll]
+                for (int n = 0; n < TILES_N_; n++)
+                    acc[mb][n] = linalg.coopMatMulAdd<T, false>(matA, matB[n], acc[mb][n]);
+            }
+        }
+    }
+
+    // =========================================================================
+    // writebackMgGroup
+    //
+    // Flush an M_BLOCK-wide tile group of accumulator back out to a
+    // WaveTangledVector via shmem. For each of the M_BLOCK A-rows:
+    //   1. simdgroup_store every `TILES_N_` accumulator into a shared
+    //      8 rows × (TILES_N_ * MetalTile = N) strip of shmem (row-major).
+    //   2. Each lane reads its column from the strip into output.data[...].
+    // The shmem region is shared with the B preload used by
+    // `mmaAccumulateMgGroup` — safe because by writeback the B-data is dead.
+    // =========================================================================
+
+    [ForceInline]
+    [require(cooperative_matrix, subgroup_basic)]
+    internal static void writebackMgGroup<int OutputN>(
+        inout WaveTangledVector<T, ShMemSize, OutputN, SubgroupSize, SubgroupCount> output,
+        __constref CMatrix acc[M_BLOCK][TILES_N_],
+        int outerGroup,
+        Ptr<T, Access::ReadWrite, AddressSpace::GroupShared> shmemPtr,
+        uint lane)
+    {
+        [ForceUnroll]
+        for (int mb = 0; mb < M_BLOCK; mb++)
+        {
+            int outerTile = outerGroup * M_BLOCK + mb;
+
+            [ForceUnroll]
+            for (int n = 0; n < TILES_N_; n++)
+                acc[mb][n].Store<linalg.CoopMatMatrixLayout.RowMajor>(shmemPtr + n * MetalTile, uint(N));
+
+            GroupMemoryBarrierWithWaveSync();
+
+            [ForceUnroll]
+            for (int i = 0; i < MetalTile; i++)
+                output.data[outerTile * MetalTile + i] = shmemPtr[i * N + int(lane)];
+
+            GroupMemoryBarrierWithWaveSync();
+        }
+    }
+
+    // =========================================================================
+    // Forward: result(M) = W(M,K) × input(K)
+    //
+    // Direct CoopMat implementation with a per-warp, uint4-packed shmem
+    // layout. Outer loop tiles the M dimension into `M_GROUPS_` groups of
+    // `M_BLOCK` rows each; the inner contract loop (over K) is handled by
+    // `mmaAccumulateMgGroup`, and writeback by `writebackMgGroup`.
+    // =========================================================================
+
+    [ForceInline]
+    [require(cooperative_matrix, subgroup_basic)]
+    internal static WaveTangledVector<T, ShMemSize, OutputSize, SubgroupSize, SubgroupCount>
+    forward<Address, bool Bias = false>(
+        __constref WaveTangledVector<T, ShMemSize, InputSize, SubgroupSize, SubgroupCount> input,
+        Address weightAddress,
+        Optional<Address> biasAddress)
+        where Address : IPointerLikeAddress<T>
+    {
+        typealias OutputVec = WaveTangledVector<T, ShMemSize, OutputSize, SubgroupSize, SubgroupCount>;
+
+        OutputVec output;
+
+        static const int TILES_M_ = (M + MetalTile - 1) / MetalTile;
+        static const int M_GROUPS_ = TILES_M_ / M_BLOCK;
+
+        uint lane = WaveGetLaneIndex();
+        uint warpId = WaveGetWaveIndex();
+        uint perWarpBase = warpId * uint(ShmemPerWarpUint4_);
+
+        Ptr<T, Access::ReadWrite, AddressSpace::GroupShared> shmemPtr =
+            bit_cast<Ptr<T, Access::ReadWrite, AddressSpace::GroupShared>>(
+                __getAddress(ShMemPool.data[perWarpBase]));
+
+        for (int mg = 0; mg < M_GROUPS_; mg++)
+        {
+            CMatrix acc[M_BLOCK][TILES_N_];
+            mmaAccumulateMgGroup<Address, InputSize, false>(
+                input, weightAddress, mg, acc, perWarpBase, lane);
+            writebackMgGroup<OutputSize>(output, acc, mg, shmemPtr, lane);
+        }
+
+        if (Bias)
+        {
+            for (int i = 0; i < M; i++)
+                output.data[i] = output.data[i] + biasAddress.value[uint(i)];
+        }
+
+        return output;
+    }
+
+    // =========================================================================
+    // mmaTranspose: result(K) = W^T(K, M) × input(M)
+    //
+    // Used in the backward path to compute dInput = W^T × dOut, where the
+    // original forward was output = W × input. The input here is M-sized
+    // (forward's output space) and the result is K-sized (forward's input
+    // space).
+    //
+    // The weight matrix W is stored in memory as M×K row-major; loading
+    // the transposed W^T tiles is done by `mmaAccumulateMgGroup` with
+    // `DoTransposeA=true` (ColumnMajor load with stride=K over swapped
+    // row/col offsets). The outer loop tiles the K dimension into
+    // `K_GROUPS_` groups of `M_BLOCK` rows each; contract is over M.
+    // =========================================================================
+
+    [ForceInline]
+    [require(cooperative_matrix, subgroup_basic)]
+    internal static WaveTangledVector<T, ShMemSize, InputSize, SubgroupSize, SubgroupCount>
+    mmaTranspose<Address>(
+        __constref WaveTangledVector<T, ShMemSize, OutputSize, SubgroupSize, SubgroupCount> input,
+        Address weightAddress)
+        where Address : IPointerLikeAddress<T>
+    {
+        typealias ResultVec = WaveTangledVector<T, ShMemSize, InputSize, SubgroupSize, SubgroupCount>;
+
+        ResultVec output;
+
+        static const int TILES_K_ = (K + MetalTile - 1) / MetalTile;
+        static const int K_GROUPS_ = TILES_K_ / M_BLOCK;
+
+        uint lane = WaveGetLaneIndex();
+        uint warpId = WaveGetWaveIndex();
+        uint perWarpBase = warpId * uint(ShmemPerWarpUint4_);
+
+        Ptr<T, Access::ReadWrite, AddressSpace::GroupShared> shmemPtr =
+            bit_cast<Ptr<T, Access::ReadWrite, AddressSpace::GroupShared>>(
+                __getAddress(ShMemPool.data[perWarpBase]));
+
+        for (int kg = 0; kg < K_GROUPS_; kg++)
+        {
+            CMatrix acc[M_BLOCK][TILES_N_];
+            mmaAccumulateMgGroup<Address, OutputSize, true>(
+                input, weightAddress, kg, acc, perWarpBase, lane);
+            writebackMgGroup<InputSize>(output, acc, kg, shmemPtr, lane);
+        }
+
+        return output;
+    }
+
+    // =========================================================================
+    // Bias reduce: dBias += sum(dOut) across lanes.
+    //
+    // Prototype Metal implementation using the simple wave-reduce strategy:
+    // each warp reduces one output element across its lanes, writes the per-warp
+    // partial into shmem, then warp 0 lane 0 reduces those partials and atomicAdds
+    // to the global bias buffer. This mirrors the benchmark's "wave shmem" path.
+    // =========================================================================
+
+    [ForceInline]
+    [require(metal, subgroup_basic)]
+    internal static void sumReduceRows<U, Address, InArrayType>(
+        uint sharedMemoryOffset,
+        __constref WaveTangledVector<U, ShMemSize, OutputSize, SubgroupSize, SubgroupCount> dOut,
+        in int subgroupId,
+        Address biasAddress)
+        where U : __BuiltinFloatingPointType
+        where U.Differential == U
+        where Address : IPointerLikeAddress<U>
+    {
+        uint lane = WaveGetLaneIndex();
+
+        Ptr<U, Access::ReadWrite, AddressSpace::GroupShared> shmemPtr =
+            bit_cast<Ptr<U, Access::ReadWrite, AddressSpace::GroupShared>>(
+                __getAddress(ShMemPool.data[sharedMemoryOffset]));
+
+        [ForceUnroll]
+        for (int i = 0; i < OutputSize; i++)
+        {
+            U reduced = WaveActiveSum(dOut.data[i]);
+            if (lane == 0)
+                shmemPtr[subgroupId] = reduced;
+            GroupMemoryBarrierWithGroupSync();
+
+            if (subgroupId == 0 && lane == 0)
+            {
+                U total = U(0);
+                [ForceUnroll]
+                for (int w = 0; w < SubgroupCount; w++)
+                    total += shmemPtr[w];
+                biasAddress.atomicAdd(uint(i), total);
+            }
+            GroupMemoryBarrierWithGroupSync();
+        }
+    }
+
+    // // =========================================================================
+    // // Bias reduce: dBias += sum(dOut) across lanes via MMA with all-ones B
+    // // =========================================================================
+
+    // [ForceInline]
+    // [require(cooperative_matrix, subgroup_basic)]
+    // internal static void biasReduce<Address>(
+    //     MetalMatrixA<M, N> dOutA,
+    //     int subgroupId,
+    //     Address biasGradAddress,
+    //     uint shBase)
+    //     where Address : IPointerLikeAddress<T>
+    // {
+    //     typealias TileB = linalg.CoopMat<half, MemoryScope.Subgroup, MetalTile, MetalTile, linalg.CoopMatMatrixUse.MatrixB>;
+    //     typealias TileC = linalg.CoopMat<T, MemoryScope.Subgroup, MetalTile, MetalTile, linalg.CoopMatMatrixUse.MatrixAccumulator>;
+
+    //     const uint laneId = WaveGetLaneIndex();
+    //     const int subgroupCount = SubgroupCount;
+
+    //     static const int NOutputTiles = (M + MetalTile - 1) / MetalTile;
+    //     static const int NLaneTiles = (N + MetalTile - 1) / MetalTile;
+
+    //     TileB matOnes;
+    //     matOnes.fill(half(1));
+
+    //     // Shmem layout: tile store area + cross-warp reduction area
+    //     static const int TileStoreSize = MetalTile * MetalTile;
+    //     uint tempBase = shBase + uint(subgroupId) * uint(TileStoreSize);
+    //     uint crossWarpBase = shBase + uint(subgroupCount) * uint(TileStoreSize);
+
+    //     [ForceUnroll]
+    //     for (int ot = 0; ot < NOutputTiles; ot++)
+    //     {
+    //         TileC matC;
+    //         matC.fill(T(0));
+
+    //         [ForceUnroll]
+    //         for (int g = 0; g < NLaneTiles; g++)
+    //         {
+    //             int aIdx = dOutA.tileIdx(ot, g);
+    //             matC = linalg.coopMatMulAdd<T, false, half, half, T,
+    //                 MemoryScope.Subgroup, MetalTile, MetalTile, MetalTile>(dOutA.tiles[aIdx], matOnes, matC);
+    //         }
+
+    //         // Store tile to shmem, extract column 0, cross-warp reduce
+    //         Ptr<T, Access::ReadWrite, AddressSpace::GroupShared> tilePtr =
+    //             __getAddress(ShMemPool.data[tempBase]);
+    //         matC.Store<linalg.CoopMatMatrixLayout.RowMajor>(tilePtr, uint(MetalTile));
+
+    //         if (laneId < uint(MetalTile))
+    //         {
+    //             // Column 0 of 8x8 tile: element at row=laneId, col=0
+    //             T val = ShMemPool.smemLoad<T>(tempBase, int(laneId) * MetalTile);
+    //             ShMemPool.smemStore(crossWarpBase, subgroupId * M + ot * MetalTile + int(laneId), val);
+    //         }
+    //     }
+
+    //     GroupMemoryBarrierWithGroupSync();
+
+    //     BaseMMA.crossWarpReduceAndAtomicWrite<T, Address, M, M / 2>(
+    //         crossWarpBase, subgroupId, subgroupCount, biasGradAddress);
+    // }
+
+    // // =========================================================================
+    // // Outer product: dW(M,K) += dOut(M,N) × input^T(N,K)
+    // // =========================================================================
+
+    // [ForceInline]
+    // [require(cooperative_matrix, subgroup_basic)]
+    // internal static void outerProductAccumulate<Address, int InputVecSize>(
+    //     MetalMatrixA<M, N> dOutA,
+    //     T inputArr[InputVecSize],
+    //     Address weightGradAddress,
+    //     uint shBase)
+    //     where Address : IPointerLikeAddress<T>
+    // {
+    //     const uint subgroupIndex = getWaveId();
+
+    //     static const int HalvesPerUint4 = sizeof(uint4) / sizeof(half);
+    //     static const int TileWidthUint4 = MetalTile / HalvesPerUint4;
+    //     static const int ShmemPerWarp = N * TileWidthUint4;
+    //     uint perWarpBase = shBase + subgroupIndex * uint(ShmemPerWarp);
+
+    //     MetalMatrixB<N, K> inputB;
+    //     inputB.fromVectorViaShMem<ShMemSize, T, InputVecSize, true>(inputArr, perWarpBase);
+
+    //     GroupMemoryBarrierWithWaveSync();
+
+    //     typealias OPResult = MetalMatrixC<T, M, K>;
+    //     OPResult dW = matMul(dOutA, inputB);
+
+    //     // Cross-warp reduction
+    //     if (SubgroupCount > 1)
+    //     {
+    //         static const int OPTileStride = OPResult.TileStride;
+    //         static const int OPTotalTiles = OPResult.TileCount;
+
+    //         for (int s = 1; s < SubgroupCount; s <<= 1)
+    //         {
+    //             uint subgroupOffset = (subgroupIndex / uint(s << 1)) * uint(OPTotalTiles * OPTileStride);
+    //             uint base = shBase + subgroupOffset;
+
+    //             if (subgroupIndex % uint(s << 1) == uint(s))
+    //                 dW.storeRaw<ShMemSize>(base);
+
+    //             GroupMemoryBarrierWithGroupSync();
+
+    //             if (subgroupIndex % uint(s << 1) == 0)
+    //             {
+    //                 if (subgroupIndex + uint(s) < uint(SubgroupCount))
+    //                 {
+    //                     OPResult other;
+    //                     other.loadRaw<ShMemSize>(base);
+    //                     dW = dW.add(other);
+    //                 }
+    //             }
+
+    //             GroupMemoryBarrierWithGroupSync();
+    //         }
+    //     }
+
+    //     // Store dW tiles to global via shmem + atomicAdd
+    //     if (subgroupIndex == 0)
+    //     {
+    //         static const linalg.CoopMatMatrixLayout RowMajor = linalg.CoopMatMatrixLayout.RowMajor;
+
+    //         [ForceUnroll]
+    //         for (uint i = 0; i < NTileRows; i++)
+    //         {
+    //             [ForceUnroll]
+    //             for (uint j = 0; j < NTileCols; j++)
+    //             {
+    //                 int tileIdx = int(j) * NTileRows + int(i);
+    //                 Ptr<T, Access::ReadWrite, AddressSpace::GroupShared> tilePtr =
+    //                     __getAddress(ShMemPool.data[shBase + uint(j) * uint(MetalTile)]);
+    //                 dW.tiles[tileIdx].Store<RowMajor>(tilePtr, uint(MetalTile));
+    //             }
+    //             GroupMemoryBarrierWithWaveSync();
+
+    //             storeTileRowToGlobal<T, Address>(shBase, int(i), weightGradAddress);
+    //         }
+    //     }
+
+    //     GroupMemoryBarrierWithGroupSync();
+    // }
+
+    // // =========================================================================
+    // // Backward: orchestrates mmaTranspose + biasReduce + outerProductAccumulate
+    // // =========================================================================
+
+    // [ForceInline]
+    // [require(cooperative_matrix, subgroup_basic)]
+    // internal static WaveTangledVector<T.Differential, ShMemSize, InputSize, SubgroupSize, SubgroupCount>
+    // backward<Address, bool Bias = true>(
+    //     WaveTangledVector<T, ShMemSize, InputSize, SubgroupSize, SubgroupCount> input,
+    //     WaveTangledVector<T, ShMemSize, OutputSize, SubgroupSize, SubgroupCount> dOut,
+    //     Address weightAddress,
+    //     Address weightGradAddress,
+    //     Address biasGradAddress)
+    //     where Address : IPointerLikeAddress<T>
+    // {
+    //     uint shBase = 0u;
+
+    //     typealias OutputVec = WaveTangledVector<T, ShMemSize, OutputSize, SubgroupSize, SubgroupCount>;
+    //     typealias InputVecT = WaveTangledVector<T, ShMemSize, InputSize, SubgroupSize, SubgroupCount>;
+    //     static const int PaddedM = OutputVec.Uint4AlignedInputSize;
+    //     static const int PaddedK = InputVecT.Uint4AlignedInputSize;
+
+    //     static const int HalvesPerUint4 = sizeof(uint4) / sizeof(half);
+    //     static const int TileWidthUint4 = MetalTile / HalvesPerUint4;
+    //     static const int ShmemPerWarp = N * TileWidthUint4;
+    //     uint perWarpBase = shBase + uint(getWaveId()) * uint(ShmemPerWarp);
+
+    //     MetalMatrixB<M, N> dOutB;
+    //     dOutB.fromVectorViaShMem<ShMemSize, T, PaddedM, false>(dOut.data, perWarpBase);
+
+    //     MetalMatrixA<M, N> dOutA;
+    //     dOutA.fromVectorViaShMem<ShMemSize, T, PaddedM, false>(dOut.data, perWarpBase);
+
+    //     // 1. Transpose MMA: dInput = W^T × dOut
+    //     typealias InputVecDiff = WaveTangledVector<T, ShMemSize, K, N, SubgroupCount>;
+    //     InputVecDiff dInput;
+    //     mmaTranspose<Address, InputVecDiff.Uint4AlignedInputSize>(dOutB, weightAddress, dInput.data, shBase);
+
+    //     GroupMemoryBarrierWithGroupSync();
+
+    //     // 2. Bias reduce
+    //     if (Bias)
+    //         biasReduce<Address>(dOutA, int(getWaveId()), biasGradAddress, shBase);
+
+    //     GroupMemoryBarrierWithGroupSync();
+
+    //     // 3. Outer product accumulate
+    //     outerProductAccumulate<Address, PaddedK>(dOutA, input.data, weightGradAddress, shBase);
+
+    //     return bit_cast<WaveTangledVector<T.Differential, ShMemSize, InputSize, SubgroupSize, SubgroupCount>>(dInput);
+    // }
+
+    // // Store one row of tiles from shmem to global using atomicAdd.
+    // [ForceInline]
+    // [require(cooperative_matrix, subgroup_basic)]
+    // internal static void storeTileRowToGlobal<U, Address>(
+    //     uint sharedMemoryOffset,
+    //     int tileRow,
+    //     Address weightAddress)
+    //         where U : __BuiltinFloatingPointType
+    //         where U.Differential == U
+    //         where Address : IPointerLikeAddress<U>
+    // {
+    //     const uint laneId = WaveGetLaneIndex();
+
+    //     static const int TotalElemsPerRow = NTileCols * TileSizeInElements;
+    //     static const int ItersPerLane = (TotalElemsPerRow + N - 1) / N;
+
+    //     if (sizeof(U) == 2)
+    //     {
+    //         static const int H2PerTile = TileSizeInElements / 2;
+    //         static const int TotalH2PerRow = NTileCols * H2PerTile;
+    //         static const int H2ItersPerLane = (TotalH2PerRow + N - 1) / N;
+
+    //         [ForceUnroll]
+    //         for (uint k = 0; k < H2ItersPerLane; k++)
+    //         {
+    //             int h2Idx = int(laneId) + int(k) * N;
+    //             int tileCol = h2Idx / H2PerTile;
+    //             int localH2 = h2Idx % H2PerTile;
+    //             int elemOffset = tileElementOffset(tileRow, tileCol) + localH2 * 2;
+
+    //             vector<U, 2> h2 = ShMemPool.smemLoad<vector<U, 2>>(sharedMemoryOffset, h2Idx);
+    //             let addr = weightAddress.getOffset(elemOffset);
+    //             addr.atomicAdd(0, h2);
+    //         }
+    //     }
+    //     else if (sizeof(U) == 4)
+    //     {
+    //         [ForceUnroll]
+    //         for (uint k = 0; k < ItersPerLane; k++)
+    //         {
+    //             int elemIdx = int(laneId) + int(k) * N;
+    //             int tileCol = elemIdx / TileSizeInElements;
+    //             int localElem = elemIdx % TileSizeInElements;
+    //             int elemOffset = tileElementOffset(tileRow, tileCol) + localElem;
+    //             int shmemIdx = tileCol * TileSizeInElements + localElem;
+
+    //             U val = ShMemPool.smemLoad<U>(sharedMemoryOffset, shmemIdx);
+    //             weightAddress.atomicAdd(uint(elemOffset), val);
+    //         }
+    //     }
+    // }
+}

--- a/source/standard-modules/neural/mma-tiled-metal.slang
+++ b/source/standard-modules/neural/mma-tiled-metal.slang
@@ -414,6 +414,46 @@ internal struct TiledMMAMetal<T, int InputSize, int OutputSize, int SubgroupSize
     }
 
     // =========================================================================
+    // Backward: compute dInput, accumulate dBias and dWeight.
+    //
+    //   1. dInput = W^T * dOut via `mmaTranspose`
+    //   2. dBias += sum_lanes(dOut) via `sumReduceRows`
+    //   3. dWeight += dOut * input^T via `outerProductAccumulate`
+    //
+    // All three phases reuse ShMemPool.data. Full-group barriers between phases
+    // make the reuse explicit because bias/outer-product communicate across
+    // warps through threadgroup memory.
+    // =========================================================================
+
+    [ForceInline]
+    [require(metal, cooperative_matrix, subgroup_basic)]
+    internal static WaveTangledVector<T.Differential, ShMemSize, InputSize, SubgroupSize, SubgroupCount>
+    backward<Address, bool Bias = true>(
+        WaveTangledVector<T, ShMemSize, InputSize, SubgroupSize, SubgroupCount> input,
+        WaveTangledVector<T, ShMemSize, OutputSize, SubgroupSize, SubgroupCount> dOut,
+        Address weightAddress,
+        Address weightGradAddress,
+        Address biasGradAddress)
+        where Address : IPointerLikeAddress<T>
+    {
+        let dInput = mmaTranspose<Address>(dOut, weightAddress);
+
+        GroupMemoryBarrierWithGroupSync();
+
+        if (Bias)
+        {
+            sumReduceRows<T, Address, WaveTangledVector<T, ShMemSize, OutputSize, SubgroupSize, SubgroupCount>>(
+                0u, dOut, int(getWaveId()), biasGradAddress);
+        }
+
+        GroupMemoryBarrierWithGroupSync();
+
+        outerProductAccumulate<T, Address>(dOut, input, weightGradAddress);
+
+        return bit_cast<WaveTangledVector<T.Differential, ShMemSize, InputSize, SubgroupSize, SubgroupCount>>(dInput);
+    }
+
+    // =========================================================================
     // Outer product accumulate: weightGrad(M,K) += sum_lanes(dOut(M) * input(K)^T)
     //
     // This is the standard-module version of the benchmark's "Slang CoopMat

--- a/source/standard-modules/neural/mma-tiled-metal.slang
+++ b/source/standard-modules/neural/mma-tiled-metal.slang
@@ -414,6 +414,159 @@ internal struct TiledMMAMetal<T, int InputSize, int OutputSize, int SubgroupSize
     }
 
     // =========================================================================
+    // Outer product accumulate: weightGrad(M,K) += sum_lanes(dOut(M) * input(K)^T)
+    //
+    // This is the standard-module version of the benchmark's "Slang CoopMat
+    // direct" path. Each warp stages two 8-row dOut tiles and two 8-column input
+    // tiles into threadgroup memory, uses CoopMat MMA to sum across the 32 lanes,
+    // then each warp atomic-adds its own accumulator tile to global memory.
+    // =========================================================================
+
+    [ForceInline]
+    [require(metal, cooperative_matrix, subgroup_basic)]
+    internal static void outerProductAccumulate<U, Address>(
+        __constref WaveTangledVector<U, ShMemSize, OutputSize, SubgroupSize, SubgroupCount> inputVectorA,
+        __constref WaveTangledVector<U, ShMemSize, InputSize, SubgroupSize, SubgroupCount> inputVectorB,
+        Address weightAddress)
+        where U : __BuiltinFloatingPointType
+        where U.Differential == U
+        where Address : IPointerLikeAddress<U>
+    {
+        typealias OPAAMatrix = linalg.CoopMat<U, MemoryScope.Subgroup, MetalTile, MetalTile, linalg.CoopMatMatrixUse.MatrixA>;
+        typealias OPABMatrix = linalg.CoopMat<U, MemoryScope.Subgroup, MetalTile, MetalTile, linalg.CoopMatMatrixUse.MatrixB>;
+        typealias OPACMatrix = linalg.CoopMat<U, MemoryScope.Subgroup, MetalTile, MetalTile, linalg.CoopMatMatrixUse.MatrixAccumulator>;
+
+        static const int OPA_N_BLOCK = 2;
+        static const int TILES_M_ = OutputSize / MetalTile;
+        static const int TILES_K_ = InputSize / MetalTile;
+        static const int TILES_LANE_ = SubgroupSize / MetalTile;
+
+        static const int StageAElemsPerWarp = M_BLOCK * MetalTile * SubgroupSize;
+        static const int StageBElemsPerWarp = OPA_N_BLOCK * MetalTile * SubgroupSize;
+        static const int AccumElemsPerWarp = MetalTile * MetalTile;
+        static const int PerWarpElems = StageAElemsPerWarp + StageBElemsPerWarp + AccumElemsPerWarp;
+
+        uint lane = WaveGetLaneIndex();
+        uint warpId = WaveGetWaveIndex();
+        uint perWarpBase = warpId * uint(PerWarpElems);
+        uint stageABase = perWarpBase;
+        uint stageBBase = stageABase + uint(StageAElemsPerWarp);
+        uint accumBase = stageBBase + uint(StageBElemsPerWarp);
+
+        Ptr<U, Access::ReadWrite, AddressSpace::GroupShared> shmemPtr =
+            bit_cast<Ptr<U, Access::ReadWrite, AddressSpace::GroupShared>>(
+                __getAddress(ShMemPool.data[0]));
+
+        for (int mg = 0; mg < TILES_M_ / M_BLOCK; mg++)
+        {
+            for (int kg = 0; kg < TILES_K_ / OPA_N_BLOCK; kg++)
+            {
+                [ForceUnroll]
+                for (int mb = 0; mb < M_BLOCK; mb++)
+                {
+                    int m = mg * M_BLOCK + mb;
+                    [ForceUnroll]
+                    for (int row = 0; row < MetalTile; row++)
+                    {
+                        shmemPtr[stageABase + uint(mb * MetalTile * SubgroupSize + row * SubgroupSize) + lane] =
+                            inputVectorA.data[m * MetalTile + row];
+                    }
+                }
+
+                [ForceUnroll]
+                for (int kb = 0; kb < OPA_N_BLOCK; kb++)
+                {
+                    int kTile = kg * OPA_N_BLOCK + kb;
+                    [ForceUnroll]
+                    for (int col = 0; col < MetalTile; col++)
+                    {
+                        shmemPtr[stageBBase + uint(kb * MetalTile * SubgroupSize + col * SubgroupSize) + lane] =
+                            inputVectorB.data[kTile * MetalTile + col];
+                    }
+                }
+                GroupMemoryBarrierWithGroupSync();
+
+                OPACMatrix acc[M_BLOCK][OPA_N_BLOCK];
+                [ForceUnroll]
+                for (int mb = 0; mb < M_BLOCK; mb++)
+                    [ForceUnroll]
+                    for (int kb = 0; kb < OPA_N_BLOCK; kb++)
+                        acc[mb][kb].fill(U(0));
+
+                [ForceUnroll]
+                for (int laneTile = 0; laneTile < TILES_LANE_; laneTile++)
+                {
+                    OPAAMatrix matA[M_BLOCK];
+                    [ForceUnroll]
+                    for (int mb = 0; mb < M_BLOCK; mb++)
+                    {
+                        matA[mb] = OPAAMatrix.Load<linalg.CoopMatMatrixLayout.RowMajor>(
+                            shmemPtr + int(stageABase) + mb * MetalTile * SubgroupSize + laneTile * MetalTile,
+                            uint(SubgroupSize));
+                    }
+
+                    OPABMatrix matB[OPA_N_BLOCK];
+                    [ForceUnroll]
+                    for (int kb = 0; kb < OPA_N_BLOCK; kb++)
+                    {
+                        matB[kb] = OPABMatrix.Load<linalg.CoopMatMatrixLayout.ColumnMajor>(
+                            shmemPtr + int(stageBBase) + kb * MetalTile * SubgroupSize + laneTile * MetalTile,
+                            uint(SubgroupSize));
+                    }
+
+                    [ForceUnroll]
+                    for (int mb = 0; mb < M_BLOCK; mb++)
+                        [ForceUnroll]
+                        for (int kb = 0; kb < OPA_N_BLOCK; kb++)
+                            acc[mb][kb] = linalg.coopMatMulAdd<U, false>(matA[mb], matB[kb], acc[mb][kb]);
+                }
+
+                [ForceUnroll]
+                for (int mb = 0; mb < M_BLOCK; mb++)
+                {
+                    int m = mg * M_BLOCK + mb;
+                    [ForceUnroll]
+                    for (int kb = 0; kb < OPA_N_BLOCK; kb++)
+                    {
+                        int kTile = kg * OPA_N_BLOCK + kb;
+                        acc[mb][kb].Store<linalg.CoopMatMatrixLayout.RowMajor>(
+                            shmemPtr + int(accumBase), uint(MetalTile));
+                        GroupMemoryBarrierWithGroupSync();
+
+                        if (sizeof(U) == sizeof(half))
+                        {
+                            for (uint idx = lane; idx < uint(MetalTile * MetalTile / 2); idx += uint(SubgroupSize))
+                            {
+                                uint i = idx / uint(MetalTile / 2);
+                                uint j = idx % uint(MetalTile / 2);
+                                uint r = uint(m * MetalTile) + i;
+                                uint c = uint(kTile * MetalTile) + j * 2;
+                                weightAddress.atomicAdd(
+                                    r * uint(InputSize) + c,
+                                    vector<U, 2>(
+                                        shmemPtr[accumBase + i * uint(MetalTile) + j * 2],
+                                        shmemPtr[accumBase + i * uint(MetalTile) + j * 2 + 1]));
+                            }
+                        }
+                        else
+                        {
+                            for (uint idx = lane; idx < uint(MetalTile * MetalTile); idx += uint(SubgroupSize))
+                            {
+                                uint r = uint(m * MetalTile) + idx / uint(MetalTile);
+                                uint c = uint(kTile * MetalTile) + idx % uint(MetalTile);
+                                weightAddress.atomicAdd(
+                                    r * uint(InputSize) + c,
+                                    shmemPtr[accumBase + idx]);
+                            }
+                        }
+                        GroupMemoryBarrierWithGroupSync();
+                    }
+                }
+            }
+        }
+    }
+
+    // =========================================================================
     // Bias reduce: dBias += sum(dOut) across lanes.
     //
     // Prototype Metal implementation using the simple wave-reduce strategy:
@@ -459,253 +612,4 @@ internal struct TiledMMAMetal<T, int InputSize, int OutputSize, int SubgroupSize
         }
     }
 
-    // // =========================================================================
-    // // Bias reduce: dBias += sum(dOut) across lanes via MMA with all-ones B
-    // // =========================================================================
-
-    // [ForceInline]
-    // [require(cooperative_matrix, subgroup_basic)]
-    // internal static void biasReduce<Address>(
-    //     MetalMatrixA<M, N> dOutA,
-    //     int subgroupId,
-    //     Address biasGradAddress,
-    //     uint shBase)
-    //     where Address : IPointerLikeAddress<T>
-    // {
-    //     typealias TileB = linalg.CoopMat<half, MemoryScope.Subgroup, MetalTile, MetalTile, linalg.CoopMatMatrixUse.MatrixB>;
-    //     typealias TileC = linalg.CoopMat<T, MemoryScope.Subgroup, MetalTile, MetalTile, linalg.CoopMatMatrixUse.MatrixAccumulator>;
-
-    //     const uint laneId = WaveGetLaneIndex();
-    //     const int subgroupCount = SubgroupCount;
-
-    //     static const int NOutputTiles = (M + MetalTile - 1) / MetalTile;
-    //     static const int NLaneTiles = (N + MetalTile - 1) / MetalTile;
-
-    //     TileB matOnes;
-    //     matOnes.fill(half(1));
-
-    //     // Shmem layout: tile store area + cross-warp reduction area
-    //     static const int TileStoreSize = MetalTile * MetalTile;
-    //     uint tempBase = shBase + uint(subgroupId) * uint(TileStoreSize);
-    //     uint crossWarpBase = shBase + uint(subgroupCount) * uint(TileStoreSize);
-
-    //     [ForceUnroll]
-    //     for (int ot = 0; ot < NOutputTiles; ot++)
-    //     {
-    //         TileC matC;
-    //         matC.fill(T(0));
-
-    //         [ForceUnroll]
-    //         for (int g = 0; g < NLaneTiles; g++)
-    //         {
-    //             int aIdx = dOutA.tileIdx(ot, g);
-    //             matC = linalg.coopMatMulAdd<T, false, half, half, T,
-    //                 MemoryScope.Subgroup, MetalTile, MetalTile, MetalTile>(dOutA.tiles[aIdx], matOnes, matC);
-    //         }
-
-    //         // Store tile to shmem, extract column 0, cross-warp reduce
-    //         Ptr<T, Access::ReadWrite, AddressSpace::GroupShared> tilePtr =
-    //             __getAddress(ShMemPool.data[tempBase]);
-    //         matC.Store<linalg.CoopMatMatrixLayout.RowMajor>(tilePtr, uint(MetalTile));
-
-    //         if (laneId < uint(MetalTile))
-    //         {
-    //             // Column 0 of 8x8 tile: element at row=laneId, col=0
-    //             T val = ShMemPool.smemLoad<T>(tempBase, int(laneId) * MetalTile);
-    //             ShMemPool.smemStore(crossWarpBase, subgroupId * M + ot * MetalTile + int(laneId), val);
-    //         }
-    //     }
-
-    //     GroupMemoryBarrierWithGroupSync();
-
-    //     BaseMMA.crossWarpReduceAndAtomicWrite<T, Address, M, M / 2>(
-    //         crossWarpBase, subgroupId, subgroupCount, biasGradAddress);
-    // }
-
-    // // =========================================================================
-    // // Outer product: dW(M,K) += dOut(M,N) × input^T(N,K)
-    // // =========================================================================
-
-    // [ForceInline]
-    // [require(cooperative_matrix, subgroup_basic)]
-    // internal static void outerProductAccumulate<Address, int InputVecSize>(
-    //     MetalMatrixA<M, N> dOutA,
-    //     T inputArr[InputVecSize],
-    //     Address weightGradAddress,
-    //     uint shBase)
-    //     where Address : IPointerLikeAddress<T>
-    // {
-    //     const uint subgroupIndex = getWaveId();
-
-    //     static const int HalvesPerUint4 = sizeof(uint4) / sizeof(half);
-    //     static const int TileWidthUint4 = MetalTile / HalvesPerUint4;
-    //     static const int ShmemPerWarp = N * TileWidthUint4;
-    //     uint perWarpBase = shBase + subgroupIndex * uint(ShmemPerWarp);
-
-    //     MetalMatrixB<N, K> inputB;
-    //     inputB.fromVectorViaShMem<ShMemSize, T, InputVecSize, true>(inputArr, perWarpBase);
-
-    //     GroupMemoryBarrierWithWaveSync();
-
-    //     typealias OPResult = MetalMatrixC<T, M, K>;
-    //     OPResult dW = matMul(dOutA, inputB);
-
-    //     // Cross-warp reduction
-    //     if (SubgroupCount > 1)
-    //     {
-    //         static const int OPTileStride = OPResult.TileStride;
-    //         static const int OPTotalTiles = OPResult.TileCount;
-
-    //         for (int s = 1; s < SubgroupCount; s <<= 1)
-    //         {
-    //             uint subgroupOffset = (subgroupIndex / uint(s << 1)) * uint(OPTotalTiles * OPTileStride);
-    //             uint base = shBase + subgroupOffset;
-
-    //             if (subgroupIndex % uint(s << 1) == uint(s))
-    //                 dW.storeRaw<ShMemSize>(base);
-
-    //             GroupMemoryBarrierWithGroupSync();
-
-    //             if (subgroupIndex % uint(s << 1) == 0)
-    //             {
-    //                 if (subgroupIndex + uint(s) < uint(SubgroupCount))
-    //                 {
-    //                     OPResult other;
-    //                     other.loadRaw<ShMemSize>(base);
-    //                     dW = dW.add(other);
-    //                 }
-    //             }
-
-    //             GroupMemoryBarrierWithGroupSync();
-    //         }
-    //     }
-
-    //     // Store dW tiles to global via shmem + atomicAdd
-    //     if (subgroupIndex == 0)
-    //     {
-    //         static const linalg.CoopMatMatrixLayout RowMajor = linalg.CoopMatMatrixLayout.RowMajor;
-
-    //         [ForceUnroll]
-    //         for (uint i = 0; i < NTileRows; i++)
-    //         {
-    //             [ForceUnroll]
-    //             for (uint j = 0; j < NTileCols; j++)
-    //             {
-    //                 int tileIdx = int(j) * NTileRows + int(i);
-    //                 Ptr<T, Access::ReadWrite, AddressSpace::GroupShared> tilePtr =
-    //                     __getAddress(ShMemPool.data[shBase + uint(j) * uint(MetalTile)]);
-    //                 dW.tiles[tileIdx].Store<RowMajor>(tilePtr, uint(MetalTile));
-    //             }
-    //             GroupMemoryBarrierWithWaveSync();
-
-    //             storeTileRowToGlobal<T, Address>(shBase, int(i), weightGradAddress);
-    //         }
-    //     }
-
-    //     GroupMemoryBarrierWithGroupSync();
-    // }
-
-    // // =========================================================================
-    // // Backward: orchestrates mmaTranspose + biasReduce + outerProductAccumulate
-    // // =========================================================================
-
-    // [ForceInline]
-    // [require(cooperative_matrix, subgroup_basic)]
-    // internal static WaveTangledVector<T.Differential, ShMemSize, InputSize, SubgroupSize, SubgroupCount>
-    // backward<Address, bool Bias = true>(
-    //     WaveTangledVector<T, ShMemSize, InputSize, SubgroupSize, SubgroupCount> input,
-    //     WaveTangledVector<T, ShMemSize, OutputSize, SubgroupSize, SubgroupCount> dOut,
-    //     Address weightAddress,
-    //     Address weightGradAddress,
-    //     Address biasGradAddress)
-    //     where Address : IPointerLikeAddress<T>
-    // {
-    //     uint shBase = 0u;
-
-    //     typealias OutputVec = WaveTangledVector<T, ShMemSize, OutputSize, SubgroupSize, SubgroupCount>;
-    //     typealias InputVecT = WaveTangledVector<T, ShMemSize, InputSize, SubgroupSize, SubgroupCount>;
-    //     static const int PaddedM = OutputVec.Uint4AlignedInputSize;
-    //     static const int PaddedK = InputVecT.Uint4AlignedInputSize;
-
-    //     static const int HalvesPerUint4 = sizeof(uint4) / sizeof(half);
-    //     static const int TileWidthUint4 = MetalTile / HalvesPerUint4;
-    //     static const int ShmemPerWarp = N * TileWidthUint4;
-    //     uint perWarpBase = shBase + uint(getWaveId()) * uint(ShmemPerWarp);
-
-    //     MetalMatrixB<M, N> dOutB;
-    //     dOutB.fromVectorViaShMem<ShMemSize, T, PaddedM, false>(dOut.data, perWarpBase);
-
-    //     MetalMatrixA<M, N> dOutA;
-    //     dOutA.fromVectorViaShMem<ShMemSize, T, PaddedM, false>(dOut.data, perWarpBase);
-
-    //     // 1. Transpose MMA: dInput = W^T × dOut
-    //     typealias InputVecDiff = WaveTangledVector<T, ShMemSize, K, N, SubgroupCount>;
-    //     InputVecDiff dInput;
-    //     mmaTranspose<Address, InputVecDiff.Uint4AlignedInputSize>(dOutB, weightAddress, dInput.data, shBase);
-
-    //     GroupMemoryBarrierWithGroupSync();
-
-    //     // 2. Bias reduce
-    //     if (Bias)
-    //         biasReduce<Address>(dOutA, int(getWaveId()), biasGradAddress, shBase);
-
-    //     GroupMemoryBarrierWithGroupSync();
-
-    //     // 3. Outer product accumulate
-    //     outerProductAccumulate<Address, PaddedK>(dOutA, input.data, weightGradAddress, shBase);
-
-    //     return bit_cast<WaveTangledVector<T.Differential, ShMemSize, InputSize, SubgroupSize, SubgroupCount>>(dInput);
-    // }
-
-    // // Store one row of tiles from shmem to global using atomicAdd.
-    // [ForceInline]
-    // [require(cooperative_matrix, subgroup_basic)]
-    // internal static void storeTileRowToGlobal<U, Address>(
-    //     uint sharedMemoryOffset,
-    //     int tileRow,
-    //     Address weightAddress)
-    //         where U : __BuiltinFloatingPointType
-    //         where U.Differential == U
-    //         where Address : IPointerLikeAddress<U>
-    // {
-    //     const uint laneId = WaveGetLaneIndex();
-
-    //     static const int TotalElemsPerRow = NTileCols * TileSizeInElements;
-    //     static const int ItersPerLane = (TotalElemsPerRow + N - 1) / N;
-
-    //     if (sizeof(U) == 2)
-    //     {
-    //         static const int H2PerTile = TileSizeInElements / 2;
-    //         static const int TotalH2PerRow = NTileCols * H2PerTile;
-    //         static const int H2ItersPerLane = (TotalH2PerRow + N - 1) / N;
-
-    //         [ForceUnroll]
-    //         for (uint k = 0; k < H2ItersPerLane; k++)
-    //         {
-    //             int h2Idx = int(laneId) + int(k) * N;
-    //             int tileCol = h2Idx / H2PerTile;
-    //             int localH2 = h2Idx % H2PerTile;
-    //             int elemOffset = tileElementOffset(tileRow, tileCol) + localH2 * 2;
-
-    //             vector<U, 2> h2 = ShMemPool.smemLoad<vector<U, 2>>(sharedMemoryOffset, h2Idx);
-    //             let addr = weightAddress.getOffset(elemOffset);
-    //             addr.atomicAdd(0, h2);
-    //         }
-    //     }
-    //     else if (sizeof(U) == 4)
-    //     {
-    //         [ForceUnroll]
-    //         for (uint k = 0; k < ItersPerLane; k++)
-    //         {
-    //             int elemIdx = int(laneId) + int(k) * N;
-    //             int tileCol = elemIdx / TileSizeInElements;
-    //             int localElem = elemIdx % TileSizeInElements;
-    //             int elemOffset = tileElementOffset(tileRow, tileCol) + localElem;
-    //             int shmemIdx = tileCol * TileSizeInElements + localElem;
-
-    //             U val = ShMemPool.smemLoad<U>(sharedMemoryOffset, shmemIdx);
-    //             weightAddress.atomicAdd(uint(elemOffset), val);
-    //         }
-    //     }
-    // }
 }

--- a/source/standard-modules/neural/mma-tiled-metal.slang
+++ b/source/standard-modules/neural/mma-tiled-metal.slang
@@ -90,27 +90,11 @@ internal struct TiledMMAMetal<T, int InputSize, int OutputSize, int SubgroupSize
     // current warp's shmem region, in the layout expected by
     // `BMatrix.Load<ColumnMajor, uint4>`.
     //
-    // - For half:  1 uint4 = 8 halfs = 1 tile, so one uint4 store per lane.
-    //              The WTV's `Uint4AlignedInputSize` already guarantees
-    //              at least 1-uint4 (= 1 tile) of storage past the logical
-    //              `InputSize`, so a full-tile read is always in-bounds
-    //              and no bounds check is needed.
-    // - For float: 1 uint4 = 4 floats = half a tile, so two uint4 stores
-    //              per lane. The WTV's storage is 1-uint4 aligned for
-    //              float (= half a tile), so if `InputSize` is not a
-    //              multiple of MetalTile, the last k-iteration's read
-    //              would exceed the caller's logical input.
-    //
-    // The float path uses a single per-tile branch
-    // (`srcStart + MetalTile <= InputSize`) to pick between:
-    //   - Fast path: both uint4 stores unchecked. Taken for every tile
-    //     when `InputSize` is tile-aligned (the compile-time constant
-    //     `InputSize % MetalTile == 0` short-circuits the condition, so
-    //     the slow path is dead-code-eliminated), and for all but the
-    //     last partial tile otherwise.
-    //   - Slow path: per-element bounds check, zero-pad OOB slots so
-    //     the MMA's last partial tile sees zeros rather than
-    //     uninitialized storage. Runs at most once per `forward` call.
+    // The WTV's `Uint4AlignedInputSize` uses half-style uint4 alignment,
+    // so storage is rounded up to a full MetalTile (= 8) elements even for
+    // float vectors. WaveTangledVector keeps padding zeroed, which lets every
+    // contract tile read a full 8-element slice without per-element bounds
+    // checks. For half this is one uint4 store per lane; for float it is two.
     // =========================================================================
 
     [ForceInline]
@@ -133,13 +117,8 @@ internal struct TiledMMAMetal<T, int InputSize, int OutputSize, int SubgroupSize
                 __realCast<half>(input.data[srcStart + 7])));
             ShMemPool.data[shMemDstUint4] = uint4(u0.x, u0.y, u1.x, u1.y);
         }
-        else if (SrcSize % MetalTile == 0 || srcStart + MetalTile <= SrcSize)
+        else
         {
-            // Fast path. Taken when either:
-            //   (a) `SrcSize` is tile-aligned, so no contract iteration can
-            //       exceed it (compile-time-foldable), or
-            //   (b) this tile is fully in-bounds (runtime check, true for
-            //       every iteration except the last partial one).
             ShMemPool.data[shMemDstUint4 + 0] = uint4(
                 bit_cast<uint>(input.data[srcStart + 0]),
                 bit_cast<uint>(input.data[srcStart + 1]),
@@ -150,22 +129,6 @@ internal struct TiledMMAMetal<T, int InputSize, int OutputSize, int SubgroupSize
                 bit_cast<uint>(input.data[srcStart + 5]),
                 bit_cast<uint>(input.data[srcStart + 6]),
                 bit_cast<uint>(input.data[srcStart + 7]));
-        }
-        else
-        {
-            // Slow path: float's last partial tile on a non-tile-aligned
-            // `SrcSize`. Per-element bounds check, zero OOB slots so the
-            // MMA accumulator sees zeros rather than uninitialized storage.
-            let e0 = (srcStart + 0 < SrcSize) ? bit_cast<uint>(input.data[srcStart + 0]) : 0u;
-            let e1 = (srcStart + 1 < SrcSize) ? bit_cast<uint>(input.data[srcStart + 1]) : 0u;
-            let e2 = (srcStart + 2 < SrcSize) ? bit_cast<uint>(input.data[srcStart + 2]) : 0u;
-            let e3 = (srcStart + 3 < SrcSize) ? bit_cast<uint>(input.data[srcStart + 3]) : 0u;
-            let e4 = (srcStart + 4 < SrcSize) ? bit_cast<uint>(input.data[srcStart + 4]) : 0u;
-            let e5 = (srcStart + 5 < SrcSize) ? bit_cast<uint>(input.data[srcStart + 5]) : 0u;
-            let e6 = (srcStart + 6 < SrcSize) ? bit_cast<uint>(input.data[srcStart + 6]) : 0u;
-            let e7 = (srcStart + 7 < SrcSize) ? bit_cast<uint>(input.data[srcStart + 7]) : 0u;
-            ShMemPool.data[shMemDstUint4 + 0] = uint4(e0, e1, e2, e3);
-            ShMemPool.data[shMemDstUint4 + 1] = uint4(e4, e5, e6, e7);
         }
     }
 
@@ -215,10 +178,8 @@ internal struct TiledMMAMetal<T, int InputSize, int OutputSize, int SubgroupSize
         // instruction window / register budget. Code-size grows ~3x.
         for (int c = 0; c < TILES_C; c++)
         {
-            // Each lane packs its MetalTile-element slice of `input.data`
-            // into `TileWidthUint4_` uint4 stores in shmem. See
-            // `packInputTileToShmem`'s doc block for the bounds-check
-            // rationale for float with non-tile-aligned `ContractSize`.
+            // Each lane packs its padded MetalTile-element slice of
+            // `input.data` into `TileWidthUint4_` uint4 stores in shmem.
             packInputTileToShmem<ContractSize>(
                 input,
                 c * MetalTile,
@@ -364,6 +325,7 @@ internal struct TiledMMAMetal<T, int InputSize, int OutputSize, int SubgroupSize
                 output.data[i] = output.data[i] + biasAddress.value[uint(i)];
         }
 
+        output.cleanPaddingData();
         return output;
     }
 
@@ -413,6 +375,7 @@ internal struct TiledMMAMetal<T, int InputSize, int OutputSize, int SubgroupSize
             writebackMgGroup<InputSize>(output, acc, kg, shmemPtr, lane);
         }
 
+        output.cleanPaddingData();
         return output;
     }
 

--- a/source/standard-modules/neural/mma-tiled-metal.slang
+++ b/source/standard-modules/neural/mma-tiled-metal.slang
@@ -57,14 +57,17 @@ internal struct TiledMMAMetal<T, int InputSize, int OutputSize, int SubgroupSize
     // =========================================================================
     // Forward: result = W(M,K) × input(K,N)
     //
-    // Blocked outer-product form (K outermost, M blocked with M_BLOCK=2).
+    // Blocked outer-product form (K outermost, M blocked with M_BLOCK rows).
     // Keeps ~13 simdgroup matrices live to avoid register spills on Apple Silicon.
     //
     // Metal: no hybrid precision -- A, B, C all use the same type T.
     // Uses WaveMatrix methods: loadWeightTiled, fromVectorViaShMem, matMad.
     // =========================================================================
 
-    static const int M_BLOCK = 2;
+    // Use the two-tile row block on the common 16-aligned path. Fall back to a
+    // single 8x8 tile block when either dimension has an odd tile count so
+    // target-native 8-aligned Metal sizes do not drop the final tile.
+    static const int M_BLOCK = ((NTileRows % 2 == 0) && (NTileCols % 2 == 0)) ? 2 : 1;
 
     // Struct-scope shared state for forward / mmaTranspose. Both functions
     // reuse the same K-loop via `mmaAccumulateMgGroup`, and both rely on the
@@ -449,6 +452,7 @@ internal struct TiledMMAMetal<T, int InputSize, int OutputSize, int SubgroupSize
         GroupMemoryBarrierWithGroupSync();
 
         outerProductAccumulate<T, Address>(dOut, input, weightGradAddress);
+        AllMemoryBarrierWithGroupSync();
 
         return bit_cast<WaveTangledVector<T.Differential, ShMemSize, InputSize, SubgroupSize, SubgroupCount>>(dInput);
     }
@@ -476,9 +480,9 @@ internal struct TiledMMAMetal<T, int InputSize, int OutputSize, int SubgroupSize
         typealias OPABMatrix = linalg.CoopMat<U, MemoryScope.Subgroup, MetalTile, MetalTile, linalg.CoopMatMatrixUse.MatrixB>;
         typealias OPACMatrix = linalg.CoopMat<U, MemoryScope.Subgroup, MetalTile, MetalTile, linalg.CoopMatMatrixUse.MatrixAccumulator>;
 
-        static const int OPA_N_BLOCK = 2;
         static const int TILES_M_ = OutputSize / MetalTile;
         static const int TILES_K_ = InputSize / MetalTile;
+        static const int OPA_N_BLOCK = (TILES_K_ % 2 == 0) ? 2 : 1;
         static const int TILES_LANE_ = SubgroupSize / MetalTile;
 
         static const int StageAElemsPerWarp = M_BLOCK * MetalTile * SubgroupSize;

--- a/source/standard-modules/neural/mma-tiled-metal.slang
+++ b/source/standard-modules/neural/mma-tiled-metal.slang
@@ -480,8 +480,8 @@ internal struct TiledMMAMetal<T, int InputSize, int OutputSize, int SubgroupSize
         typealias OPABMatrix = linalg.CoopMat<U, MemoryScope.Subgroup, MetalTile, MetalTile, linalg.CoopMatMatrixUse.MatrixB>;
         typealias OPACMatrix = linalg.CoopMat<U, MemoryScope.Subgroup, MetalTile, MetalTile, linalg.CoopMatMatrixUse.MatrixAccumulator>;
 
-        static const int TILES_M_ = OutputSize / MetalTile;
-        static const int TILES_K_ = InputSize / MetalTile;
+        static const int TILES_M_ = (OutputSize + MetalTile - 1) / MetalTile;
+        static const int TILES_K_ = (InputSize + MetalTile - 1) / MetalTile;
         static const int OPA_N_BLOCK = (TILES_K_ % 2 == 0) ? 2 : 1;
         static const int TILES_LANE_ = SubgroupSize / MetalTile;
 

--- a/source/standard-modules/neural/mma-tiled-vulkan.slang
+++ b/source/standard-modules/neural/mma-tiled-vulkan.slang
@@ -70,7 +70,7 @@ internal struct TiledMMAVulkan<T, int InputSize, int OutputSize, int SubgroupSiz
         inputB.fromVectorViaShMem<ShMemSize, T, InputVec.Uint4AlignedInputSize, false>(input.data, perWarpBase);
 
         // MMA: result(M, N) = W(M, K) × input(K, N)
-        MatrixC<T, M, N> resultMat = matMul<T, M, K, N>(wA, inputB);
+        MatrixC<T, M, N> resultMat = matMul<half, T, M, K, N>(wA, inputB);
 
         // Extract output vector
         typealias OutputVec = WaveTangledVector<T, ShMemSize, OutputSize, SubgroupSize, SubgroupCount>;
@@ -107,7 +107,7 @@ internal struct TiledMMAVulkan<T, int InputSize, int OutputSize, int SubgroupSiz
         wA.loadWeightTiled<T, Address, true>(weightAddress);
 
         // MMA: result(K, N) = W^T(K, M) × input(M, N)
-        MatrixC<T, K, N> resultMat = matMul<T, K, M, N>(wA, inputB);
+        MatrixC<T, K, N> resultMat = matMul<half, T, K, M, N>(wA, inputB);
 
         resultMat.toVectorViaShMem<ShMemSize, ResultVecSize, false>(resultArr, shBase);
     }
@@ -234,7 +234,7 @@ internal struct TiledMMAVulkan<T, int InputSize, int OutputSize, int SubgroupSiz
 
         // MMA: dW(M, K) = dOut^T(M, N) × input(N, K)
         typealias OPResult = MatrixC<T, M, K>;
-        OPResult dW = matMul<T, M, N, K>(dOutA, inputB);
+        OPResult dW = matMul<half, T, M, N, K>(dOutA, inputB);
 
         // Cross-warp reduction via storeRaw/loadRaw/add (portable)
         if (SubgroupCount > 1)

--- a/source/standard-modules/neural/mma-tiled-vulkan.slang
+++ b/source/standard-modules/neural/mma-tiled-vulkan.slang
@@ -70,7 +70,7 @@ internal struct TiledMMAVulkan<T, int InputSize, int OutputSize, int SubgroupSiz
         inputB.fromVectorViaShMem<ShMemSize, T, InputVec.Uint4AlignedInputSize, false>(input.data, perWarpBase);
 
         // MMA: result(M, N) = W(M, K) × input(K, N)
-        MatrixC<T, M, N> resultMat = matMul<half, T, M, K, N>(wA, inputB);
+        MatrixC<T, M, N> resultMat = matMul<T, M, K, N>(wA, inputB);
 
         // Extract output vector
         typealias OutputVec = WaveTangledVector<T, ShMemSize, OutputSize, SubgroupSize, SubgroupCount>;
@@ -107,7 +107,7 @@ internal struct TiledMMAVulkan<T, int InputSize, int OutputSize, int SubgroupSiz
         wA.loadWeightTiled<T, Address, true>(weightAddress);
 
         // MMA: result(K, N) = W^T(K, M) × input(M, N)
-        MatrixC<T, K, N> resultMat = matMul<half, T, K, M, N>(wA, inputB);
+        MatrixC<T, K, N> resultMat = matMul<T, K, M, N>(wA, inputB);
 
         resultMat.toVectorViaShMem<ShMemSize, ResultVecSize, false>(resultArr, shBase);
     }
@@ -234,7 +234,7 @@ internal struct TiledMMAVulkan<T, int InputSize, int OutputSize, int SubgroupSiz
 
         // MMA: dW(M, K) = dOut^T(M, N) × input(N, K)
         typealias OPResult = MatrixC<T, M, K>;
-        OPResult dW = matMul<half, T, M, N, K>(dOutA, inputB);
+        OPResult dW = matMul<T, M, N, K>(dOutA, inputB);
 
         // Cross-warp reduction via storeRaw/loadRaw/add (portable)
         if (SubgroupCount > 1)

--- a/source/standard-modules/neural/mma-tiled-vulkan.slang
+++ b/source/standard-modules/neural/mma-tiled-vulkan.slang
@@ -343,6 +343,7 @@ internal struct TiledMMAVulkan<T, int InputSize, int OutputSize, int SubgroupSiz
 
         // 3. Outer product: dW += dOut ⊗ input — reuses dOutA
         outerProductAccumulate<Address, PaddedK>(dOutA, input.data, weightGradAddress, shBase);
+        AllMemoryBarrierWithGroupSync();
 
         return bit_cast<WaveTangledVector<T.Differential, ShMemSize, InputSize, SubgroupSize, SubgroupCount>>(dInput);
     }

--- a/source/standard-modules/neural/neural.slang
+++ b/source/standard-modules/neural/neural.slang
@@ -30,6 +30,7 @@ __include "WaveMatrix";
 __include "mma-linear-layout-help";
 __include "mma-tiled-cuda";
 __include "mma-tiled-vulkan";
+__include "mma-tiled-metal";
 __include "mma-tiled-layout-helper";
 __include "vectorized-reader";
 __include "shared-memory-pool";

--- a/source/standard-modules/neural/shared-memory-pool.slang
+++ b/source/standard-modules/neural/shared-memory-pool.slang
@@ -381,8 +381,19 @@ internal struct SharedMemorySizeForLayer<
     // With MMAHelperNew (CUDA + OptimalLayout), forward and backward MMA
     // use zero shmem (LoadRaw + FromLocal). This term only applies to
     // the legacy shmem-based MMAHelper/TiledMMAHelper paths (non-CUDA).
-    static const uint BytesForMMA =
-        (ShMemInfo.SharedMemSizeInVectorMatA + (ShMemInfo.SharedMemSizeInVectorMatC) * SubgroupCount) * sizeof(uint4);
+    //
+    // Metal: on-demand per-k fromVectorViaShMem for both half and float.
+    // Shmem per warp = SubgroupSize * TileWidthUint4 (in uint4 units).
+    // Half: 8 halfs / 8 per uint4 = 1 uint4 per lane.
+    // Float: 8 floats / 4 per uint4 = 2 uint4s per lane (stored as bit_cast, not converted to half).
+    static const int MetalTile_ = 8;
+    static const int MetalElemsPerUint4_ = sizeof(uint4) / sizeof(T);
+    static const int MetalTileWidthUint4_ = (MetalTile_ + MetalElemsPerUint4_ - 1) / MetalElemsPerUint4_;
+    static const uint MetalBytes =
+        uint(SubgroupCount) * uint(SubgroupSize * MetalTileWidthUint4_) * sizeof(uint4);
+    static const uint BytesForMMA = (Target == TargetEnum.Metal)
+        ? MetalBytes
+        : (ShMemInfo.SharedMemSizeInVectorMatA + (ShMemInfo.SharedMemSizeInVectorMatC) * SubgroupCount) * sizeof(uint4);
 
     // Cross-warp butterfly reduction for outer product.
     // The first butterfly pass has G/2 warps storing simultaneously, each
@@ -413,7 +424,7 @@ internal struct SharedMemorySizeForLayer<
         (SubgroupCount * SubgroupSize * HeightInVecB_SR + SubgroupCount * TileStrideVec_SR * CMShape.ROW_C) * sizeof(uint4)
         + ((SubgroupCount * MPadded_SR * sizeof(T) + sizeof(uint4) - 1) / sizeof(uint4)) * sizeof(uint4);
 
-    static const uint Bytes = Max(Max(Max(BytesForMMA, BytesForOuterProductStore),
+    public static const uint Bytes = Max(Max(Max(BytesForMMA, BytesForOuterProductStore),
                                           BytesForCrossWarpReduction),
                                                 BytesForSumReduceRows);
 }

--- a/source/standard-modules/neural/shared-memory-pool.slang
+++ b/source/standard-modules/neural/shared-memory-pool.slang
@@ -382,17 +382,32 @@ internal struct SharedMemorySizeForLayer<
     // use zero shmem (LoadRaw + FromLocal). This term only applies to
     // the legacy shmem-based MMAHelper/TiledMMAHelper paths (non-CUDA).
     //
-    // Metal: on-demand per-k fromVectorViaShMem for both half and float.
-    // Shmem per warp = SubgroupSize * TileWidthUint4 (in uint4 units).
-    // Half: 8 halfs / 8 per uint4 = 1 uint4 per lane.
-    // Float: 8 floats / 4 per uint4 = 2 uint4s per lane (stored as bit_cast, not converted to half).
+    // Metal forward/backward transpose: on-demand per-k fromVectorViaShMem for
+    // both half and float. Shmem per warp = SubgroupSize * TileWidthUint4 (in
+    // uint4 units). Half: 8 halfs / 8 per uint4 = 1 uint4 per lane. Float:
+    // 8 floats / 4 per uint4 = 2 uint4s per lane (stored as bit_cast, not
+    // converted to half).
     static const int MetalTile_ = 8;
     static const int MetalElemsPerUint4_ = sizeof(uint4) / sizeof(T);
     static const int MetalTileWidthUint4_ = (MetalTile_ + MetalElemsPerUint4_ - 1) / MetalElemsPerUint4_;
-    static const uint MetalBytes =
+    static const uint MetalBytesForMMA =
         uint(SubgroupCount) * uint(SubgroupSize * MetalTileWidthUint4_) * sizeof(uint4);
+
+    // Metal outer-product backward stages two 8-row dOut tiles, two 8-column
+    // input tiles, and one 8x8 accumulator tile per warp in T-typed shmem.
+    static const int MetalOPMBlock_ = 2;
+    static const int MetalOPNBlock_ = 2;
+    static const int MetalOPStageAElemsPerWarp_ = MetalOPMBlock_ * MetalTile_ * SubgroupSize;
+    static const int MetalOPStageBElemsPerWarp_ = MetalOPNBlock_ * MetalTile_ * SubgroupSize;
+    static const int MetalOPAccumElemsPerWarp_ = MetalTile_ * MetalTile_;
+    static const uint MetalBytesForOuterProduct =
+        !ShMemInfo.IsTraining ? 0 :
+        uint(SubgroupCount) *
+            uint(MetalOPStageAElemsPerWarp_ + MetalOPStageBElemsPerWarp_ + MetalOPAccumElemsPerWarp_) *
+            sizeof(T);
+
     static const uint BytesForMMA = (Target == TargetEnum.Metal)
-        ? MetalBytes
+        ? Max(MetalBytesForMMA, MetalBytesForOuterProduct)
         : (ShMemInfo.SharedMemSizeInVectorMatA + (ShMemInfo.SharedMemSizeInVectorMatC) * SubgroupCount) * sizeof(uint4);
 
     // Cross-warp butterfly reduction for outer product.

--- a/source/standard-modules/neural/shared-memory-pool.slang
+++ b/source/standard-modules/neural/shared-memory-pool.slang
@@ -439,7 +439,7 @@ internal struct SharedMemorySizeForLayer<
         (SubgroupCount * SubgroupSize * HeightInVecB_SR + SubgroupCount * TileStrideVec_SR * CMShape.ROW_C) * sizeof(uint4)
         + ((SubgroupCount * MPadded_SR * sizeof(T) + sizeof(uint4) - 1) / sizeof(uint4)) * sizeof(uint4);
 
-    public static const uint Bytes = Max(Max(Max(BytesForMMA, BytesForOuterProductStore),
+    static const uint Bytes = Max(Max(Max(BytesForMMA, BytesForOuterProductStore),
                                           BytesForCrossWarpReduction),
                                                 BytesForSumReduceRows);
 }

--- a/source/standard-modules/neural/unit-test/unittest-bias-reduce.slang
+++ b/source/standard-modules/neural/unit-test/unittest-bias-reduce.slang
@@ -8,11 +8,12 @@ void testBiasSumReduceImpl<
         DType : __BuiltinFloatingPointType,
         int InputSize,
         int OutputSize,
+        int InArraySize,
         ShMemSize : ISharedMemorySize,
         TargetEnum Target,
         int SubgroupCount>
     (uint tid,
-     DType[OutputSize] dOut,
+     __constref DType[InArraySize] dOut,
      RWStructuredBuffer<DType>.Handle biasBuffer)
         where DType.Differential == DType
 {
@@ -30,6 +31,27 @@ void testBiasSumReduceImpl<
     MMA.sumReduceRows<DType, Address, DType[OutSize]>(0, dOutVector, subgroupId, biasAddress);
 }
 
+void testBiasSumReduceMetalImpl<
+        DType : __BuiltinFloatingPointType,
+        int InputSize,
+        int OutputSize,
+        ShMemSize : ISharedMemorySize,
+        int SubgroupCount>
+    (uint tid,
+     __constref WaveTangledVector<DType, ShMemSize, OutputSize, 32, SubgroupCount> dOut,
+     RWStructuredBuffer<DType>.Handle biasBuffer)
+        where DType.Differential == DType
+{
+    typealias Address = BindlessAddress<DType>;
+    Address biasAddress = Address(biasBuffer);
+
+    typealias MMA = TiledMMAMetal<DType, InputSize, OutputSize, 32, TargetEnum.Metal, ShMemSize, false, SubgroupCount>;
+
+    uint subgroupId = tid / 32;
+    MMA.sumReduceRows<DType, Address, WaveTangledVector<DType, ShMemSize, OutputSize, 32, SubgroupCount>>(
+        0, dOut, subgroupId, biasAddress);
+}
+
 public void testBiasSumReduce<
         DType : __BuiltinFloatingPointType,
         int InputSize,
@@ -37,16 +59,23 @@ public void testBiasSumReduce<
         ShMemSize : ISharedMemorySize,
         int SubgroupCount>
     (uint tid,
-     DType[OutputSize] dOut,
+     __constref WaveTangledVector<DType, ShMemSize, OutputSize, 32, SubgroupCount> dOut,
      RWStructuredBuffer<DType>.Handle biasBuffer)
         where DType.Differential == DType
 {
+    typealias DOutVec = WaveTangledVector<DType, ShMemSize, OutputSize, 32, SubgroupCount>;
+
     __target_switch
     {
     case cuda:
-        testBiasSumReduceImpl<DType, InputSize, OutputSize, ShMemSize, TargetEnum.CUDA, SubgroupCount>(tid, dOut, biasBuffer);
+        testBiasSumReduceImpl<DType, InputSize, OutputSize, DOutVec.Uint4AlignedInputSize, ShMemSize, TargetEnum.CUDA, SubgroupCount>(
+            tid, dOut.data, biasBuffer);
     case spirv:
-        testBiasSumReduceImpl<DType, InputSize, OutputSize, ShMemSize, TargetEnum.SPIR_V, SubgroupCount>(tid, dOut, biasBuffer);
+        testBiasSumReduceImpl<DType, InputSize, OutputSize, DOutVec.Uint4AlignedInputSize, ShMemSize, TargetEnum.SPIR_V, SubgroupCount>(
+            tid, dOut.data, biasBuffer);
+    case metal:
+        testBiasSumReduceMetalImpl<DType, InputSize, OutputSize, ShMemSize, SubgroupCount>(
+            tid, dOut, biasBuffer);
     }
 }
 

--- a/source/standard-modules/neural/unit-test/unittest-mat-vec-mul.slang
+++ b/source/standard-modules/neural/unit-test/unittest-mat-vec-mul.slang
@@ -84,7 +84,8 @@ public DType[TransposeA ? InputSize : OutputSize]
 // with PadToTile for dimensions.
 // ---------------------------------------------------------------------------
 
-DType[TransposeA ? InputSize : OutputSize]
+[ForceInline]
+WaveTangledVector<DType, ShMemSize, TransposeA ? PaddedInputSize : PaddedOutputSize, 32, SubgroupCount>
     testTiledMatVecMulImpl<
         DType : __BuiltinFloatingPointType,
         int InputSize,
@@ -97,7 +98,7 @@ DType[TransposeA ? InputSize : OutputSize]
         bool Bias,
         int SubgroupCount,
         bool TransposeA>
-    (DType[InArraySize] inputData,
+    (__constref WaveTangledVector<DType, ShMemSize, InArraySize, 32, SubgroupCount> inputData,
      RWStructuredBuffer<DType>.Handle weightBuffer,
      Optional<RWStructuredBuffer<DType>.Handle> biasBuffer)
         where DType.Differential == DType
@@ -105,17 +106,18 @@ DType[TransposeA ? InputSize : OutputSize]
     typealias Address = BindlessAddress<DType>;
     Address address = Address(weightBuffer);
 
-    static const int K = PaddedInputSize;
-    static const int M = PaddedOutputSize;
     static const int N = 32;
     const int ResultSize = TransposeA ? InputSize : OutputSize;
+    typealias OutputVec = WaveTangledVector<DType, ShMemSize, TransposeA ? PaddedInputSize : PaddedOutputSize, N, SubgroupCount>;
 
     if (TransposeA)
     {
+        static const int K = PaddedInputSize;
+        static const int M = InArraySize;
         // mmaTranspose: input has M elements, result has K elements
         //   CUDA:   result(N,K) = input(N,M) × W^T(M,K)
         //   Vulkan: result(K,N) = W^T(K,M) × input(M,N)
-        DType output[ResultSize];
+        OutputVec output = OutputVec(DType(0));
 
         __target_switch
         {
@@ -125,10 +127,8 @@ DType[TransposeA ? InputSize : OutputSize]
 
             Cuda.DOutMatrix inputMat;
             half inputHalf[M];
-            for (int i = 0; i < InArraySize; i++)
+            for (int i = 0; i < M; i++)
                 inputHalf[i] = __realCast<half>(inputData[i]);
-            for (int i = InArraySize; i < M; i++)
-                inputHalf[i] = half(0);
             let inputPacked = bit_cast<uint[M / 2]>(inputHalf);
             inputMat.fromArrayPacked<M / 2>(inputPacked);
 
@@ -147,10 +147,8 @@ DType[TransposeA ? InputSize : OutputSize]
             typealias Vulkan = TiledMMAVulkan<DType, K, M, N, TargetEnum.SPIR_V, ShMemSize, TransposeA, SubgroupCount>;
 
             DType inputArr[M];
-            for (int i = 0; i < InArraySize; i++)
+            for (int i = 0; i < M; i++)
                 inputArr[i] = inputData[i];
-            for (int i = InArraySize; i < M; i++)
-                inputArr[i] = DType(0);
 
             // Per-warp shmem offset. With tile-row-at-a-time, each warp needs
             // 32 × max(TILE/HalvesPerUint4, TILE/ElemPerUint4_T) uint4 per group.
@@ -167,31 +165,33 @@ DType[TransposeA ? InputSize : OutputSize]
             for (int i = 0; i < ResultSize; i++)
                 output[i] = resultArr[i];
         }
+        case metal:
+        {
+            typealias Metal = TiledMMAMetal<DType, K, M, N, TargetEnum.Metal, ShMemSize, TransposeA, SubgroupCount>;
+
+            let resultVec = Metal.mmaTranspose<Address>(inputData, address);
+            output = bit_cast<OutputVec>(resultVec);
+        }
         }
         return output;
     }
     else
     {
+        static const int K = InArraySize;
+        static const int M = PaddedOutputSize;
         // mma (forward): input has K elements, result has M elements
         typealias MMA = TiledMMAHelper<DType, K, M, N, Target, ShMemSize, TransposeA, SubgroupCount>;
-        typealias InputVec = WaveTangledVector<DType, ShMemSize, K, N, SubgroupCount>;
-
-        InputVec inputVec = InputVec(DType(0));
-        for (int i = 0; i < InArraySize; i++)
-            inputVec[i] = inputData[i];
 
         let resultVec = Bias
-            ? MMA.forward<Address, true>(inputVec, address, Address(biasBuffer.value))
-            : MMA.forward<Address, false>(inputVec, address, none);
+            ? MMA.forward<Address, true>(inputData, address, Address(biasBuffer.value))
+            : MMA.forward<Address, false>(inputData, address, none);
 
-        DType output[ResultSize];
-        for (int i = 0; i < ResultSize; i++)
-            output[i] = resultVec[i];
-        return output;
+        return bit_cast<OutputVec>(resultVec);
     }
 }
 
-public DType[TransposeA ? InputSize : OutputSize]
+[ForceInline]
+public WaveTangledVector<DType, ShMemSize, TransposeA ? PaddedInputSize : PaddedOutputSize, 32, SubgroupCount>
     testTiledMatVecMul<
         DType : __BuiltinFloatingPointType,
         int InputSize,
@@ -203,7 +203,7 @@ public DType[TransposeA ? InputSize : OutputSize]
         bool Bias,
         int SubgroupCount,
         bool TransposeA>
-    (DType[InArraySize] inputData,
+    (__constref WaveTangledVector<DType, ShMemSize, InArraySize, 32, SubgroupCount> inputData,
      RWStructuredBuffer<DType>.Handle weightBuffer,
      Optional<RWStructuredBuffer<DType>.Handle> biasBuffer)
         where DType.Differential == DType
@@ -214,6 +214,8 @@ public DType[TransposeA ? InputSize : OutputSize]
         return testTiledMatVecMulImpl<DType, InputSize, OutputSize, InArraySize, PaddedInputSize, PaddedOutputSize, ShMemSize, TargetEnum.CUDA, Bias, SubgroupCount, TransposeA>(inputData, weightBuffer, biasBuffer);
     case spirv:
         return testTiledMatVecMulImpl<DType, InputSize, OutputSize, InArraySize, PaddedInputSize, PaddedOutputSize, ShMemSize, TargetEnum.SPIR_V, Bias, SubgroupCount, TransposeA>(inputData, weightBuffer, biasBuffer);
+    case metal:
+        return testTiledMatVecMulImpl<DType, InputSize, OutputSize, InArraySize, PaddedInputSize, PaddedOutputSize, ShMemSize, TargetEnum.Metal, Bias, SubgroupCount, TransposeA>(inputData, weightBuffer, biasBuffer);
     }
 }
 

--- a/source/standard-modules/neural/unit-test/unittest-mma-backward.slang
+++ b/source/standard-modules/neural/unit-test/unittest-mma-backward.slang
@@ -7,6 +7,7 @@ namespace neural_unittest
 // Full backward pass using TiledMMAHelper.backward() dispatcher:
 //   CUDA:   TiledMMACuda (WaveMatrix register ops)
 //   Vulkan: TiledMMAVulkan (WaveMatrix + shmem)
+//   Metal:  TiledMMAMetal (8x8 simdgroup_matrix + shmem)
 //
 // InputSize and OutputSize must be multiples of 16 (tiled layout requirement).
 
@@ -66,6 +67,9 @@ public DType[InputSize]
             inputData, dOutData, weightBuffer, weightGradBuffer, biasGradBuffer);
     case spirv:
         return testTiledBackwardImpl<DType, InputSize, OutputSize, ShMemSize, TargetEnum.SPIR_V, SubgroupCount>(
+            inputData, dOutData, weightBuffer, weightGradBuffer, biasGradBuffer);
+    case metal:
+        return testTiledBackwardImpl<DType, InputSize, OutputSize, ShMemSize, TargetEnum.Metal, SubgroupCount>(
             inputData, dOutData, weightBuffer, weightGradBuffer, biasGradBuffer);
     }
 }

--- a/source/standard-modules/neural/unit-test/unittest-outerproduct-reduce.slang
+++ b/source/standard-modules/neural/unit-test/unittest-outerproduct-reduce.slang
@@ -73,14 +73,15 @@ public void testOuterProductAccumulate<
 // Callers with arbitrary sizes should pad via PadToTile before calling.
 // ---------------------------------------------------------------------------
 
+[ForceInline]
 public void testOuterProductAccumulateTiled<
         DType : __BuiltinFloatingPointType,
         int InputSize,
         int OutputSize,
         ShMemSize : ISharedMemorySize,
         int SubgroupCount>
-    (DType[InputSize] inputData,
-     DType[OutputSize] dOutData,
+    (__constref WaveTangledVector<DType, ShMemSize, InputSize, 32, SubgroupCount> inputVector,
+     __constref WaveTangledVector<DType, ShMemSize, OutputSize, 32, SubgroupCount> dOutVector,
      RWStructuredBuffer<DType>.Handle outputBuffer)
         where DType.Differential == DType
 {
@@ -101,7 +102,7 @@ public void testOuterProductAccumulateTiled<
         {
             half h[OutputSize];
             for (int i = 0; i < OutputSize; i++)
-                h[i] = __realCast<half>(dOutData[i]);
+                h[i] = __realCast<half>(dOutVector.data[i]);
             let packed = bit_cast<uint[PackedSizeOut]>(h);
             dOutMat.fromArrayPacked<PackedSizeOut>(packed);
         }
@@ -110,7 +111,7 @@ public void testOuterProductAccumulateTiled<
         {
             half h[InputSize];
             for (int i = 0; i < InputSize; i++)
-                h[i] = __realCast<half>(inputData[i]);
+                h[i] = __realCast<half>(inputVector.data[i]);
             let packed = bit_cast<uint[PackedSizeIn]>(h);
             inputMat.fromArrayPacked<PackedSizeIn>(packed);
         }
@@ -129,16 +130,21 @@ public void testOuterProductAccumulateTiled<
 
         DType dOutArr[OutputSize];
         for (int i = 0; i < OutputSize; i++)
-            dOutArr[i] = dOutData[i];
+            dOutArr[i] = dOutVector.data[i];
 
         MatrixA<OutputSize, N> dOutA;
         dOutA.fromVectorViaShMem<ShMemSize, DType, OutputSize, false>(dOutArr, perWarpBase);
 
         DType inputArr[InputSize];
         for (int i = 0; i < InputSize; i++)
-            inputArr[i] = inputData[i];
+            inputArr[i] = inputVector.data[i];
 
         Vulkan.outerProductAccumulate<Address, InputSize>(dOutA, inputArr, address, 0u);
+    }
+    case metal:
+    {
+        typealias Metal = TiledMMAMetal<DType, InputSize, OutputSize, N, TargetEnum.Metal, ShMemSize, false, SubgroupCount>;
+        Metal.outerProductAccumulate<DType, Address>(dOutVector, inputVector, address);
     }
     default:
         static_assert(false, "Unsupported target");

--- a/tests/neural/basic-coopmat-vector-tiled-layout-test.slang
+++ b/tests/neural/basic-coopmat-vector-tiled-layout-test.slang
@@ -41,31 +41,27 @@ RWStructuredBuffer<uint> testResult;
 
 // Tiled layout weight buffer: 258 elements (one 16x16 tile + 2 bias).
 // Use stride=4 so the buffer is large enough for both half (258*2=516B) and float (258*4=1032B).
-//TEST_INPUT: set parametersPtr = ubuffer(stride=4, count=258)
 //TEST_INPUT: set buffers.parameters = ubuffer(stride=4, count=258)
 
 // Tiled layout dW buffer (same layout as parameters).
-//TEST_INPUT: set dParametersPtr = ubuffer(stride=4, count=258)
 //TEST_INPUT: set buffers.dParameters = ubuffer(stride=4, count=258)
-
-uniform ElementType* parametersPtr;
-uniform ElementType* dParametersPtr;
 
 struct TestBuffers
 {
+#if TEST_POINTER
+    ElementType* parameters;
+    ElementType* dParameters;
+#else
     RWStructuredBuffer<ElementType>.Handle parameters;
     RWStructuredBuffer<ElementType>.Handle dParameters;
+#endif
 }
 
 ParameterBlock<TestBuffers> buffers;
 
 #if TEST_POINTER
-    #define parameters parametersPtr
-    #define dParameters dParametersPtr
     typealias Address = PointerAddress<ElementType>;
 #else
-    #define parameters buffers.parameters
-    #define dParameters buffers.dParameters
     typealias Address = BindlessAddress<ElementType>;
 #endif
 
@@ -95,16 +91,16 @@ void setupParameters(uint tid)
     if (tid == 0)
     {
         for (int i = 0; i < 258; i++)
-            parameters[i] = ElementType(0.0);
+            buffers.parameters[i] = ElementType(0.0);
 
         for (int col = 0; col < InputSize; col++)
-            parameters[tiledWeightOffset(0, col)] = ElementType(col + 1);
+            buffers.parameters[tiledWeightOffset(0, col)] = ElementType(col + 1);
 
         for (int col = 0; col < InputSize; col++)
-            parameters[tiledWeightOffset(1, col)] = ElementType(InputSize + col + 1);
+            buffers.parameters[tiledWeightOffset(1, col)] = ElementType(InputSize + col + 1);
 
-        parameters[256] = ElementType(9);
-        parameters[257] = ElementType(10);
+        buffers.parameters[256] = ElementType(9);
+        buffers.parameters[257] = ElementType(10);
     }
 
 }
@@ -114,7 +110,7 @@ void cleanupDParameters(uint tid)
     if (tid == 0)
     {
         for (int i = 0; i < 258; i++)
-            dParameters[i] = ElementType(0.0);
+            buffers.dParameters[i] = ElementType(0.0);
     }
 }
 
@@ -127,7 +123,7 @@ void ForwardTestWithoutBias(int tid, int resIndex)
     ElementType[InputSize] inputData = { ElementType(1.0), ElementType(2.0), ElementType(3.0), ElementType(4.0) };
     InVectorType input = InVectorType(inputData);
 
-    Address weightAddress = Address(parameters);
+    Address weightAddress = Address(buffers.parameters);
 
     let outputVec = input.linearTransform<Address, OptimalLayout, OutVectorType>(weightAddress);
 
@@ -152,7 +148,7 @@ void ForwardTestWithBias(int tid, int resIndex)
     ElementType[InputSize] inputData = { ElementType(1.0), ElementType(2.0), ElementType(3.0), ElementType(4.0) };
     InVectorType input = InVectorType(inputData);
 
-    Address weightAddress = Address(parameters);
+    Address weightAddress = Address(buffers.parameters);
     Address biasAddress = weightAddress.getOffset(256);
 
     let outputVec = input.linearTransform<Address, OptimalLayout, OutVectorType>(weightAddress, biasAddress);
@@ -198,8 +194,8 @@ void BackwardTestWithoutBias(int tid, int resIndex)
     ElementType[InputSize] inputData = { ElementType(1.0), ElementType(2.0), ElementType(3.0), ElementType(4.0) };
     InVectorType input = InVectorType(inputData);
 
-    Address weightAddress = Address(parameters);
-    Address dWeightAddress = Address(dParameters);
+    Address weightAddress = Address(buffers.parameters);
+    Address dWeightAddress = Address(buffers.dParameters);
 
     let outputVec = MatVecMul<InVectorType, OutVectorType>(input, weightAddress);
 
@@ -213,7 +209,6 @@ void BackwardTestWithoutBias(int tid, int resIndex)
 
     // Backward: dInput = W^T * dOutput = [[1,5],[2,6],[3,7],[4,8]] * [1,1] = [6, 8, 10, 12]
     bwd_diff(MatVecMul<InVectorType, OutVectorType>)(dPair, weightDiffPair, dRes);
-    AllMemoryBarrierWithGroupSync();
 
     isPassed = isPassed &&
         equals(dPair.d[0], ElementType(6.0)) && equals(dPair.d[1], ElementType(8.0)) &&
@@ -222,10 +217,10 @@ void BackwardTestWithoutBias(int tid, int resIndex)
     // dW = dOutput * input^T = [[1],[1]] * [1,2,3,4] = [[1,2,3,4],[1,2,3,4]]
     // Accumulated across 32 threads: 32x.
     isPassed = isPassed &&
-        equals(dParameters[tiledDWeightOffset(0, 0)], ElementType(32.0)) && equals(dParameters[tiledDWeightOffset(0, 1)], ElementType(64.0)) &&
-        equals(dParameters[tiledDWeightOffset(0, 2)], ElementType(96.0)) && equals(dParameters[tiledDWeightOffset(0, 3)], ElementType(128.0)) &&
-        equals(dParameters[tiledDWeightOffset(1, 0)], ElementType(32.0)) && equals(dParameters[tiledDWeightOffset(1, 1)], ElementType(64.0)) &&
-        equals(dParameters[tiledDWeightOffset(1, 2)], ElementType(96.0)) && equals(dParameters[tiledDWeightOffset(1, 3)], ElementType(128.0));
+        equals(buffers.dParameters[tiledDWeightOffset(0, 0)], ElementType(32.0)) && equals(buffers.dParameters[tiledDWeightOffset(0, 1)], ElementType(64.0)) &&
+        equals(buffers.dParameters[tiledDWeightOffset(0, 2)], ElementType(96.0)) && equals(buffers.dParameters[tiledDWeightOffset(0, 3)], ElementType(128.0)) &&
+        equals(buffers.dParameters[tiledDWeightOffset(1, 0)], ElementType(32.0)) && equals(buffers.dParameters[tiledDWeightOffset(1, 1)], ElementType(64.0)) &&
+        equals(buffers.dParameters[tiledDWeightOffset(1, 2)], ElementType(96.0)) && equals(buffers.dParameters[tiledDWeightOffset(1, 3)], ElementType(128.0));
 
     isPassed = WaveActiveAllTrue(isPassed);
     if (tid == 0)
@@ -243,9 +238,9 @@ void BackwardTestWithBias(int tid, int resIndex)
     ElementType[InputSize] inputData = { ElementType(1.0), ElementType(2.0), ElementType(3.0), ElementType(4.0) };
     InVectorType input = InVectorType(inputData);
 
-    Address weightAddress = Address(parameters);
+    Address weightAddress = Address(buffers.parameters);
     Address biasAddress = weightAddress.getOffset(256);
-    Address dWeightAddress = Address(dParameters);
+    Address dWeightAddress = Address(buffers.dParameters);
     Address dBiasAddress = dWeightAddress.getOffset(256);
 
     let outputVec = MatVecMulAdd<InVectorType, OutVectorType>(input, weightAddress, biasAddress);
@@ -261,7 +256,6 @@ void BackwardTestWithBias(int tid, int resIndex)
 
     // Backward: dInput = W^T * dOutput = [6, 8, 10, 12]
     bwd_diff(MatVecMulAdd<InVectorType, OutVectorType>)(dPair, weightDiffPair, biasDiffPair, dOutput);
-    AllMemoryBarrierWithGroupSync();
 
     isPassed = isPassed &&
         equals(dPair.d[0], ElementType(6.0)) && equals(dPair.d[1], ElementType(8.0)) &&
@@ -269,14 +263,14 @@ void BackwardTestWithBias(int tid, int resIndex)
 
     // dW: same as BackwardTestWithoutBias.
     isPassed = isPassed &&
-        equals(dParameters[tiledDWeightOffset(0, 0)], ElementType(32.0)) && equals(dParameters[tiledDWeightOffset(0, 1)], ElementType(64.0)) &&
-        equals(dParameters[tiledDWeightOffset(0, 2)], ElementType(96.0)) && equals(dParameters[tiledDWeightOffset(0, 3)], ElementType(128.0)) &&
-        equals(dParameters[tiledDWeightOffset(1, 0)], ElementType(32.0)) && equals(dParameters[tiledDWeightOffset(1, 1)], ElementType(64.0)) &&
-        equals(dParameters[tiledDWeightOffset(1, 2)], ElementType(96.0)) && equals(dParameters[tiledDWeightOffset(1, 3)], ElementType(128.0));
+        equals(buffers.dParameters[tiledDWeightOffset(0, 0)], ElementType(32.0)) && equals(buffers.dParameters[tiledDWeightOffset(0, 1)], ElementType(64.0)) &&
+        equals(buffers.dParameters[tiledDWeightOffset(0, 2)], ElementType(96.0)) && equals(buffers.dParameters[tiledDWeightOffset(0, 3)], ElementType(128.0)) &&
+        equals(buffers.dParameters[tiledDWeightOffset(1, 0)], ElementType(32.0)) && equals(buffers.dParameters[tiledDWeightOffset(1, 1)], ElementType(64.0)) &&
+        equals(buffers.dParameters[tiledDWeightOffset(1, 2)], ElementType(96.0)) && equals(buffers.dParameters[tiledDWeightOffset(1, 3)], ElementType(128.0));
 
     // dBias = dOutput accumulated across 32 threads = [32, 32]
     isPassed = isPassed &&
-        equals(dParameters[256], ElementType(32.0)) && equals(dParameters[257], ElementType(32.0));
+        equals(buffers.dParameters[256], ElementType(32.0)) && equals(buffers.dParameters[257], ElementType(32.0));
 
     isPassed = WaveActiveAllTrue(isPassed);
     if (tid == 0)

--- a/tests/neural/basic-coopmat-vector-tiled-layout-test.slang
+++ b/tests/neural/basic-coopmat-vector-tiled-layout-test.slang
@@ -10,9 +10,16 @@
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_POINTER=1
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=1 -xslang -DTEST_POINTER=1
 
+// Metal tests — bindless address path.
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -output-using-type -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_POINTER=0 -xslang -DTEST_METAL=1
+
 #pragma warning(disable: 41017)
 import slang.neural;
 import common;
+
+#ifndef TEST_METAL
+#define TEST_METAL 0
+#endif
 
 #if TEST_HALF
 typealias ElementType = half;
@@ -32,24 +39,33 @@ RWStructuredBuffer<uint> testResult;
 //
 // Bias = {9, 10} stored separately at offset 256.
 
-// Float source for parameter initialization
-//TEST_INPUT: set parametersFloat = ubuffer(data=[1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0], stride=4)
-uniform RWStructuredBuffer<float> parametersFloat;
-
 // Tiled layout weight buffer: 258 elements (one 16x16 tile + 2 bias).
 // Use stride=4 so the buffer is large enough for both half (258*2=516B) and float (258*4=1032B).
-//TEST_INPUT: set parameters = ubuffer(stride=4, count=258)
+//TEST_INPUT: set parametersPtr = ubuffer(stride=4, count=258)
+//TEST_INPUT: set buffers.parameters = ubuffer(stride=4, count=258)
 
 // Tiled layout dW buffer (same layout as parameters).
-//TEST_INPUT: set dParameters = ubuffer(stride=4, count=258)
+//TEST_INPUT: set dParametersPtr = ubuffer(stride=4, count=258)
+//TEST_INPUT: set buffers.dParameters = ubuffer(stride=4, count=258)
+
+uniform ElementType* parametersPtr;
+uniform ElementType* dParametersPtr;
+
+struct TestBuffers
+{
+    RWStructuredBuffer<ElementType>.Handle parameters;
+    RWStructuredBuffer<ElementType>.Handle dParameters;
+}
+
+ParameterBlock<TestBuffers> buffers;
 
 #if TEST_POINTER
-    uniform ElementType* parameters;
-    uniform ElementType* dParameters;
+    #define parameters parametersPtr
+    #define dParameters dParametersPtr
     typealias Address = PointerAddress<ElementType>;
 #else
-    uniform RWStructuredBuffer<ElementType>.Handle parameters;
-    uniform RWStructuredBuffer<ElementType>.Handle dParameters;
+    #define parameters buffers.parameters
+    #define dParameters buffers.dParameters
     typealias Address = BindlessAddress<ElementType>;
 #endif
 
@@ -59,9 +75,15 @@ static const int BatchSize = 32;
 static const int SubgroupSize = 32;
 static const int workgroupCount = BatchSize / SubgroupSize;
 
+#if TEST_METAL
+#define TEST_TARGET TargetEnum.Metal
+#else
+#define TEST_TARGET TargetEnum.CUDA
+#endif
+
 typealias ShMemSizeLayer1 = SharedMemorySize<
     ElementType,
-    TargetEnum.CUDA,
+    TEST_TARGET,
     ExecutionMode.Training,
     SubgroupSize,
     workgroupCount,
@@ -76,14 +98,15 @@ void setupParameters(uint tid)
             parameters[i] = ElementType(0.0);
 
         for (int col = 0; col < InputSize; col++)
-            parameters[tiledWeightOffset(0, col)] = ElementType(parametersFloat[col]);
+            parameters[tiledWeightOffset(0, col)] = ElementType(col + 1);
 
         for (int col = 0; col < InputSize; col++)
-            parameters[tiledWeightOffset(1, col)] = ElementType(parametersFloat[InputSize + col]);
+            parameters[tiledWeightOffset(1, col)] = ElementType(InputSize + col + 1);
 
-        parameters[256] = ElementType(parametersFloat[8]);
-        parameters[257] = ElementType(parametersFloat[9]);
+        parameters[256] = ElementType(9);
+        parameters[257] = ElementType(10);
     }
+
 }
 
 void cleanupDParameters(uint tid)
@@ -116,9 +139,6 @@ void ForwardTestWithoutBias(int tid, int resIndex)
     isPassed = WaveActiveAllTrue(isPassed);
     if (tid == 0)
     {
-        if (!isPassed)
-            printf("ForwardTestWithoutBias FAIL: got [%f, %f], expected [30, 70]\n",
-                float(outputVec[0]), float(outputVec[1]));
         testResult[resIndex] = isPassed ? 1 : 0;
     }
 }
@@ -144,9 +164,6 @@ void ForwardTestWithBias(int tid, int resIndex)
     isPassed = WaveActiveAllTrue(isPassed);
     if (tid == 0)
     {
-        if (!isPassed)
-            printf("ForwardTestWithBias FAIL: got [%f, %f], expected [39, 80]\n",
-                float(outputVec[0]), float(outputVec[1]));
         testResult[resIndex] = isPassed ? 1 : 0;
     }
 }
@@ -196,6 +213,7 @@ void BackwardTestWithoutBias(int tid, int resIndex)
 
     // Backward: dInput = W^T * dOutput = [[1,5],[2,6],[3,7],[4,8]] * [1,1] = [6, 8, 10, 12]
     bwd_diff(MatVecMul<InVectorType, OutVectorType>)(dPair, weightDiffPair, dRes);
+    AllMemoryBarrierWithGroupSync();
 
     isPassed = isPassed &&
         equals(dPair.d[0], ElementType(6.0)) && equals(dPair.d[1], ElementType(8.0)) &&
@@ -212,8 +230,6 @@ void BackwardTestWithoutBias(int tid, int resIndex)
     isPassed = WaveActiveAllTrue(isPassed);
     if (tid == 0)
     {
-        if (!isPassed)
-            printf("BackwardTestWithoutBias FAIL\n");
         testResult[resIndex] = isPassed ? 1 : 0;
     }
 }
@@ -245,6 +261,7 @@ void BackwardTestWithBias(int tid, int resIndex)
 
     // Backward: dInput = W^T * dOutput = [6, 8, 10, 12]
     bwd_diff(MatVecMulAdd<InVectorType, OutVectorType>)(dPair, weightDiffPair, biasDiffPair, dOutput);
+    AllMemoryBarrierWithGroupSync();
 
     isPassed = isPassed &&
         equals(dPair.d[0], ElementType(6.0)) && equals(dPair.d[1], ElementType(8.0)) &&
@@ -264,32 +281,38 @@ void BackwardTestWithBias(int tid, int resIndex)
     isPassed = WaveActiveAllTrue(isPassed);
     if (tid == 0)
     {
-        if (!isPassed)
-            printf("BackwardTestWithBias FAIL\n");
         testResult[resIndex] = isPassed ? 1 : 0;
     }
 }
 
 [shader("compute")]
 [numthreads(BatchSize, 1, 1)]
-void computeMain(uint tid : SV_DispatchThreadID)
+void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
 {
+    if (gid.x != 0)
+        return;
+
+    uint lane = WaveGetLaneIndex();
+    uint wave = WaveGetWaveIndex();
+    if (lane >= uint(SubgroupSize) || wave >= uint(workgroupCount))
+        return;
+
     setupParameters(tid);
     AllMemoryBarrierWithGroupSync();
 
     ForwardTestWithoutBias(tid, 0);
-    // BUFFER: 1
+    // BUFFER: {{^}}1{{$}}
 
     ForwardTestWithBias(tid, 1);
-    // BUFFER-NEXT: 1
+    // BUFFER-NEXT: {{^}}1{{$}}
 
     cleanupDParameters(tid);
     AllMemoryBarrierWithGroupSync();
     BackwardTestWithoutBias(tid, 2);
-    // BUFFER-NEXT: 1
+    // BUFFER-NEXT: {{^}}1{{$}}
 
     cleanupDParameters(tid);
     AllMemoryBarrierWithGroupSync();
     BackwardTestWithBias(tid, 3);
-    // BUFFER-NEXT: 1
+    // BUFFER-NEXT: {{^}}1{{$}}
 }

--- a/tests/neural/basic-coopmat-vector-tiled-layout-test.slang
+++ b/tests/neural/basic-coopmat-vector-tiled-layout-test.slang
@@ -281,16 +281,8 @@ void BackwardTestWithBias(int tid, int resIndex)
 
 [shader("compute")]
 [numthreads(BatchSize, 1, 1)]
-void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
+void computeMain(uint tid : SV_GroupIndex)
 {
-    if (gid.x != 0)
-        return;
-
-    uint lane = WaveGetLaneIndex();
-    uint wave = WaveGetWaveIndex();
-    if (lane >= uint(SubgroupSize) || wave >= uint(workgroupCount))
-        return;
-
     setupParameters(tid);
     AllMemoryBarrierWithGroupSync();
 

--- a/tests/neural/basic-coopmat-vector-tiled-layout-test.slang
+++ b/tests/neural/basic-coopmat-vector-tiled-layout-test.slang
@@ -94,10 +94,10 @@ void setupParameters(uint tid)
             buffers.parameters[i] = ElementType(0.0);
 
         for (int col = 0; col < InputSize; col++)
-            buffers.parameters[tiledWeightOffset(0, col)] = ElementType(col + 1);
+            buffers.parameters[tiledWeightOffset<InputSize>(0, col)] = ElementType(col + 1);
 
         for (int col = 0; col < InputSize; col++)
-            buffers.parameters[tiledWeightOffset(1, col)] = ElementType(InputSize + col + 1);
+            buffers.parameters[tiledWeightOffset<InputSize>(1, col)] = ElementType(InputSize + col + 1);
 
         buffers.parameters[256] = ElementType(9);
         buffers.parameters[257] = ElementType(10);
@@ -217,10 +217,10 @@ void BackwardTestWithoutBias(int tid, int resIndex)
     // dW = dOutput * input^T = [[1],[1]] * [1,2,3,4] = [[1,2,3,4],[1,2,3,4]]
     // Accumulated across 32 threads: 32x.
     isPassed = isPassed &&
-        equals(buffers.dParameters[tiledDWeightOffset(0, 0)], ElementType(32.0)) && equals(buffers.dParameters[tiledDWeightOffset(0, 1)], ElementType(64.0)) &&
-        equals(buffers.dParameters[tiledDWeightOffset(0, 2)], ElementType(96.0)) && equals(buffers.dParameters[tiledDWeightOffset(0, 3)], ElementType(128.0)) &&
-        equals(buffers.dParameters[tiledDWeightOffset(1, 0)], ElementType(32.0)) && equals(buffers.dParameters[tiledDWeightOffset(1, 1)], ElementType(64.0)) &&
-        equals(buffers.dParameters[tiledDWeightOffset(1, 2)], ElementType(96.0)) && equals(buffers.dParameters[tiledDWeightOffset(1, 3)], ElementType(128.0));
+        equals(buffers.dParameters[tiledDWeightOffset<InputSize>(0, 0)], ElementType(32.0)) && equals(buffers.dParameters[tiledDWeightOffset<InputSize>(0, 1)], ElementType(64.0)) &&
+        equals(buffers.dParameters[tiledDWeightOffset<InputSize>(0, 2)], ElementType(96.0)) && equals(buffers.dParameters[tiledDWeightOffset<InputSize>(0, 3)], ElementType(128.0)) &&
+        equals(buffers.dParameters[tiledDWeightOffset<InputSize>(1, 0)], ElementType(32.0)) && equals(buffers.dParameters[tiledDWeightOffset<InputSize>(1, 1)], ElementType(64.0)) &&
+        equals(buffers.dParameters[tiledDWeightOffset<InputSize>(1, 2)], ElementType(96.0)) && equals(buffers.dParameters[tiledDWeightOffset<InputSize>(1, 3)], ElementType(128.0));
 
     isPassed = WaveActiveAllTrue(isPassed);
     if (tid == 0)
@@ -263,10 +263,10 @@ void BackwardTestWithBias(int tid, int resIndex)
 
     // dW: same as BackwardTestWithoutBias.
     isPassed = isPassed &&
-        equals(buffers.dParameters[tiledDWeightOffset(0, 0)], ElementType(32.0)) && equals(buffers.dParameters[tiledDWeightOffset(0, 1)], ElementType(64.0)) &&
-        equals(buffers.dParameters[tiledDWeightOffset(0, 2)], ElementType(96.0)) && equals(buffers.dParameters[tiledDWeightOffset(0, 3)], ElementType(128.0)) &&
-        equals(buffers.dParameters[tiledDWeightOffset(1, 0)], ElementType(32.0)) && equals(buffers.dParameters[tiledDWeightOffset(1, 1)], ElementType(64.0)) &&
-        equals(buffers.dParameters[tiledDWeightOffset(1, 2)], ElementType(96.0)) && equals(buffers.dParameters[tiledDWeightOffset(1, 3)], ElementType(128.0));
+        equals(buffers.dParameters[tiledDWeightOffset<InputSize>(0, 0)], ElementType(32.0)) && equals(buffers.dParameters[tiledDWeightOffset<InputSize>(0, 1)], ElementType(64.0)) &&
+        equals(buffers.dParameters[tiledDWeightOffset<InputSize>(0, 2)], ElementType(96.0)) && equals(buffers.dParameters[tiledDWeightOffset<InputSize>(0, 3)], ElementType(128.0)) &&
+        equals(buffers.dParameters[tiledDWeightOffset<InputSize>(1, 0)], ElementType(32.0)) && equals(buffers.dParameters[tiledDWeightOffset<InputSize>(1, 1)], ElementType(64.0)) &&
+        equals(buffers.dParameters[tiledDWeightOffset<InputSize>(1, 2)], ElementType(96.0)) && equals(buffers.dParameters[tiledDWeightOffset<InputSize>(1, 3)], ElementType(128.0));
 
     // dBias = dOutput accumulated across 32 threads = [32, 32]
     isPassed = isPassed &&

--- a/tests/neural/bias-sum-reduce.slang
+++ b/tests/neural/bias-sum-reduce.slang
@@ -1,9 +1,10 @@
 
 // On Vulkan, we can only test float type for now because atomicAdd is not supported for half on our CI machine.
+//TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -output-using-type -xslang -experimental-feature -xslang -DUNIT_TEST -xslang -DTEST_HALF=0
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=0
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -xslang -experimental-feature -xslang -DTEST_HALF=0
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -xslang -experimental-feature -xslang -DTEST_HALF=1
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -xslang -experimental-feature -xslang -DUNIT_TEST -xslang -DTEST_HALF=0
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -xslang -experimental-feature -xslang -DUNIT_TEST -xslang -DTEST_HALF=1
 import slang.neural;
 #pragma warning(disable: 41017)
 
@@ -37,9 +38,11 @@ typealias Layer1 = SharedMemorySize<
 
 void test<int OutputSize>(uint tid, uint resIndex)
 {
-    DType dOut[OutputSize];
+    typealias DOutVec = WaveTangledVector<DType, Layer1, OutputSize, SubgroupSize, workgroupCount>;
+    DType dOutData[OutputSize];
     for (int i = 0; i < OutputSize; i++)
-        dOut[i] = DType((i + 1) * 0.0078125);
+        dOutData[i] = DType((i + 1) * 0.0078125);
+    DOutVec dOut = DOutVec(dOutData);
 
     neural_unittest.testBiasSumReduce<DType, InputSize, OutputSize, Layer1, workgroupCount>(tid, dOut, outputBuffer);
 

--- a/tests/neural/common.slang
+++ b/tests/neural/common.slang
@@ -118,6 +118,17 @@ public int tiledWeightOffset(int row, int col)
     {
     case cuda:  return rowMajorToNativeMatB(col, row);
     case spirv: return row * 16 + col;
+    case metal: return row * 16 + col;
+    }
+}
+
+public int tiledWeightOffset<int RowStride>(int row, int col)
+{
+    __target_switch
+    {
+    case cuda:  return rowMajorToNativeMatB(col, row);
+    case spirv: return row * 16 + col;
+    case metal: return row * RowStride + col;
     }
 }
 
@@ -131,6 +142,17 @@ public int tiledDWeightOffset(int row, int col)
     {
     case cuda:  return rowMajorToNativeMatC(row, col);
     case spirv: return row * 16 + col;
+    case metal: return row * 16 + col;
+    }
+}
+
+public int tiledDWeightOffset<int RowStride>(int row, int col)
+{
+    __target_switch
+    {
+    case cuda:  return rowMajorToNativeMatC(row, col);
+    case spirv: return row * 16 + col;
+    case metal: return row * RowStride + col;
     }
 }
 
@@ -198,6 +220,8 @@ public void convertTiledToNativeB<T, int PaddedRows, int PaddedCols, int Workgro
         AllMemoryBarrierWithGroupSync();
     }
     case spirv:
+        break;
+    case metal:
         break;
     }
 }
@@ -289,6 +313,8 @@ public void convertNativeToRowMajorTiled<T, int PaddedRows, int PaddedCols, int 
     }
     case spirv:
         break;
+    case metal:
+        break;
     }
 }
 
@@ -368,6 +394,18 @@ public void fillTransposeWeightTiled<T, int Rows, int Cols, int WorkgroupSize, b
             }
         }
     }
+    case metal:
+    {
+        static const int NumRowIters = (Rows + WorkgroupSize - 1) / WorkgroupSize;
+        for (int iter = 0; iter < NumRowIters; iter++)
+        {
+            int row = iter * WorkgroupSize + tid;
+            if (row >= Rows) break;
+            int scaleFactor = (row % 3 == 0) ? -1 : ((row % 3 == 1) ? 0 : 1);
+            for (int col = 0; col < Cols; col++)
+                buffer[row * PaddedCols + col] = T(scaleFactor * (col + 1));
+        }
+    }
     }
 }
 
@@ -416,7 +454,7 @@ public void fillForwardWeightTiled<T, int InputSize, int OutputSize, int Workgro
         AllMemoryBarrierWithGroupSync();
         convertTiledToNativeB<T, PaddedK, PaddedM, WorkgroupSize>(tid, buffer);
     }
-    default:
+    case spirv:
     {
         static const int TotalElements = PaddedK * PaddedM;
         static const int NumClearIters = (TotalElements + WorkgroupSize - 1) / WorkgroupSize;
@@ -443,6 +481,28 @@ public void fillForwardWeightTiled<T, int InputSize, int OutputSize, int Workgro
                 int offset = (tileRow * NTileCols + tileCol) * (TileSize * TileSize) + localRow * TileSize + localCol;
                 buffer[offset] = fillValue;
             }
+        }
+        AllMemoryBarrierWithGroupSync();
+    }
+    case metal:
+    {
+        static const int TotalElements = PaddedK * PaddedM;
+        static const int NumClearIters = (TotalElements + WorkgroupSize - 1) / WorkgroupSize;
+        for (int iter = 0; iter < NumClearIters; iter++)
+        {
+            int idx = iter * WorkgroupSize + tid;
+            if (idx < TotalElements)
+                buffer[idx] = T(0);
+        }
+        AllMemoryBarrierWithGroupSync();
+
+        static const int NumRowIters = (OutputSize + WorkgroupSize - 1) / WorkgroupSize;
+        for (int iter = 0; iter < NumRowIters; iter++)
+        {
+            int row = iter * WorkgroupSize + tid;
+            if (row >= OutputSize) break;
+            for (int col = 0; col < InputSize; col++)
+                buffer[row * PaddedK + col] = fillValue;
         }
         AllMemoryBarrierWithGroupSync();
     }

--- a/tests/neural/common.slang
+++ b/tests/neural/common.slang
@@ -159,7 +159,7 @@ public int tiledDWeightOffset<int RowStride>(int row, int col)
 // Convert a row-major 16x16 tile to MatB native register layout.
 // MatB packs vertically: same column (gid), adjacent rows (tid*2, tid*2+1).
 public void convertTileRowMajorToNativeB<T>(
-    uint tid, int srcTileOffset, int dstOffset,
+    uint tid, int tileOffset,
     RWStructuredBuffer<T>.Handle buffer)
     where T : __BuiltinFloatingPointType
 {
@@ -168,16 +168,18 @@ public void convertTileRowMajorToNativeB<T>(
     int tidLocal = int(tid) & 3;
 
     T b[8];
-    b[0] = buffer[srcTileOffset + (tidLocal*2)   * S + gid];
-    b[1] = buffer[srcTileOffset + (tidLocal*2+1) * S + gid];
-    b[2] = buffer[srcTileOffset + (tidLocal*2+8) * S + gid];
-    b[3] = buffer[srcTileOffset + (tidLocal*2+9) * S + gid];
-    b[4] = buffer[srcTileOffset + (tidLocal*2)   * S + gid + 8];
-    b[5] = buffer[srcTileOffset + (tidLocal*2+1) * S + gid + 8];
-    b[6] = buffer[srcTileOffset + (tidLocal*2+8) * S + gid + 8];
-    b[7] = buffer[srcTileOffset + (tidLocal*2+9) * S + gid + 8];
+    b[0] = buffer[tileOffset + (tidLocal*2)   * S + gid];
+    b[1] = buffer[tileOffset + (tidLocal*2+1) * S + gid];
+    b[2] = buffer[tileOffset + (tidLocal*2+8) * S + gid];
+    b[3] = buffer[tileOffset + (tidLocal*2+9) * S + gid];
+    b[4] = buffer[tileOffset + (tidLocal*2)   * S + gid + 8];
+    b[5] = buffer[tileOffset + (tidLocal*2+1) * S + gid + 8];
+    b[6] = buffer[tileOffset + (tidLocal*2+8) * S + gid + 8];
+    b[7] = buffer[tileOffset + (tidLocal*2+9) * S + gid + 8];
 
-    int nativeBase = dstOffset + int(tid) * 8;
+    AllMemoryBarrierWithWaveSync();
+
+    int nativeBase = tileOffset + int(tid) * 8;
     [ForceUnroll]
     for (int i = 0; i < 8; i++)
         buffer[nativeBase + i] = b[i];
@@ -185,7 +187,8 @@ public void convertTileRowMajorToNativeB<T>(
 
 // Convert all tiles in a PaddedRows x PaddedCols tiled matrix from
 // row-major tiled layout to native MatB register layout (CUDA only).
-// Uses TempOffset = PaddedRows*PaddedCols as scratch space in the same buffer.
+// The first warp converts each tile in-place, using registers to hold all
+// source elements before writing the native layout back over the tile.
 public void convertTiledToNativeB<T, int PaddedRows, int PaddedCols, int WorkgroupSize>(
     uint tid, RWStructuredBuffer<T>.Handle buffer)
     where T : __BuiltinFloatingPointType
@@ -199,23 +202,11 @@ public void convertTiledToNativeB<T, int PaddedRows, int PaddedCols, int Workgro
         static const int NTileCols = PaddedCols / TileSize;
         static const int TotalTiles = NTileRows * NTileCols;
         static const int TileElements = TileSize * TileSize;
-        static const int TotalElements = PaddedRows * PaddedCols;
-        static const int TempOffset = TotalElements;
 
         if (tid < 32)
         {
             for (int t = 0; t < TotalTiles; t++)
-                convertTileRowMajorToNativeB<T>(tid, t * TileElements, TempOffset + t * TileElements, buffer);
-        }
-        AllMemoryBarrierWithGroupSync();
-
-        static const int CopyIters = (TotalElements + WorkgroupSize - 1) / WorkgroupSize;
-        [ForceUnroll]
-        for (int iter = 0; iter < CopyIters; iter++)
-        {
-            int index = iter * WorkgroupSize + tid;
-            if (index < TotalElements)
-                buffer[index] = buffer[TempOffset + index];
+                convertTileRowMajorToNativeB<T>(tid, t * TileElements, buffer);
         }
         AllMemoryBarrierWithGroupSync();
     }

--- a/tests/neural/common.slang
+++ b/tests/neural/common.slang
@@ -121,27 +121,28 @@ int rowMajorToNativeMatB(int row, int col)
 // row = output dimension (M), col = input dimension (K).
 // CUDA weight is MatB<K, M> — native layout indexed as (K_row, M_col).
 // Vulkan weight is MatA<M, K> — row-major indexed as (M_row, K_col).
-public int tiledWeightOffset(int row, int col)
+// Metal weight is row-major with the supplied row stride.
+public int tiledWeightOffset<int RowStride>(int row, int col)
 {
     __target_switch
     {
     case cuda:  return rowMajorToNativeMatB(col, row);
     case spirv: return row * 16 + col;
-    case metal: return row * 16 + col;
+    case metal: return row * RowStride + col;
     }
 }
 
 // Offset for element (row, col) in the dWeight buffer's tiled layout.
 // On CUDA: native MatC fragment layout (from storeRaw + atomicAdd).
 // On Vulkan: row-major within each 16×16 tile (from storeTileRowToGlobal).
-// Single-tile version (row, col both < 16).
-public int tiledDWeightOffset(int row, int col)
+// On Metal: row-major with the supplied row stride.
+public int tiledDWeightOffset<int RowStride>(int row, int col)
 {
     __target_switch
     {
     case cuda:  return rowMajorToNativeMatC(row, col);
     case spirv: return row * 16 + col;
-    case metal: return row * 16 + col;
+    case metal: return row * RowStride + col;
     }
 }
 

--- a/tests/neural/common.slang
+++ b/tests/neural/common.slang
@@ -1,5 +1,6 @@
 #pragma warning(disable: 41017)
 
+import slang.neural;
 
 public bool equals<T>(T a, T b) where T : __BuiltinFloatingPointType
 {
@@ -70,6 +71,14 @@ public bool collectResults<int BatchSize>(uint tid, bool perThreadResult)
 public struct PadToTile<int Size>
 {
     public static const int Value = ((Size + 15) / 16) * 16;
+}
+
+// Pad a size up to the target-native tiled MMA alignment used by the tests.
+public struct PadToTargetTile<int Size, TargetEnum Target>
+{
+    public static const int Value = (Target == TargetEnum.Metal)
+        ? ((Size + 7) / 8) * 8
+        : PadToTile<Size>.Value;
 }
 
 public void setBufferOneValue<int Size, int WorkgroupSize, T>(uint tid, RWStructuredBuffer<T> buffer, T value)
@@ -497,5 +506,101 @@ public void fillForwardWeightTiled<T, int InputSize, int OutputSize, int Workgro
         }
         AllMemoryBarrierWithGroupSync();
     }
+    }
+}
+
+void identityWeightMatrixTiledMetal<T, int InputSize, int WorkgroupSize, bool Clear>(
+    uint tid, RWStructuredBuffer<T>.Handle buffer)
+    where T : __BuiltinFloatingPointType
+{
+    static const int PaddedSize = PadToTargetTile<InputSize, TargetEnum.Metal>.Value;
+    static const int TotalElements = PaddedSize * PaddedSize;
+    static const int NumClearIters = (TotalElements + WorkgroupSize - 1) / WorkgroupSize;
+
+    for (int iter = 0; iter < NumClearIters; iter++)
+    {
+        int index = iter * WorkgroupSize + tid;
+        if (index < TotalElements)
+            buffer[index] = T(0);
+    }
+
+    if (Clear)
+        return;
+
+    AllMemoryBarrierWithGroupSync();
+
+    static const int NumRowIters = (InputSize + WorkgroupSize - 1) / WorkgroupSize;
+    for (int iter = 0; iter < NumRowIters; iter++)
+    {
+        int row = iter * WorkgroupSize + tid;
+        if (row >= InputSize)
+            break;
+
+        for (int col = 0; col < InputSize; col++)
+            buffer[row * PaddedSize + col] = T(1.0f / float(InputSize));
+    }
+
+    AllMemoryBarrierWithGroupSync();
+}
+
+void identityWeightMatrixTiledNative<T, int InputSize, int WorkgroupSize, bool Clear, TargetEnum Target>(
+    uint tid, RWStructuredBuffer<T>.Handle buffer)
+    where T : __BuiltinFloatingPointType
+{
+    static const int TileSize = 16;
+    static const int PaddedSize = PadToTargetTile<InputSize, Target>.Value;
+    static const int NTileCols = PaddedSize / TileSize;
+    static const int TotalElements = PaddedSize * PaddedSize;
+    static const int NumClearIters = (TotalElements + WorkgroupSize - 1) / WorkgroupSize;
+
+    for (int iter = 0; iter < NumClearIters; iter++)
+    {
+        int index = iter * WorkgroupSize + tid;
+        if (index < TotalElements)
+            buffer[index] = T(0);
+    }
+
+    if (Clear)
+        return;
+
+    AllMemoryBarrierWithGroupSync();
+
+    static const int NumDiagIters = (InputSize + WorkgroupSize - 1) / WorkgroupSize;
+    for (int iter = 0; iter < NumDiagIters; iter++)
+    {
+        int row = iter * WorkgroupSize + tid;
+        if (row >= InputSize)
+            break;
+
+        int tileRow = row / TileSize;
+        int tileCol = row / TileSize;
+        int localRow = row % TileSize;
+        int localCol = row % TileSize;
+        int tileIndex = tileRow * NTileCols + tileCol;
+        int offset = tileIndex * TileSize * TileSize + localRow * TileSize + localCol;
+        buffer[offset] = T(1);
+    }
+
+    AllMemoryBarrierWithGroupSync();
+    convertTiledToNativeB<T, PaddedSize, PaddedSize, WorkgroupSize>(tid, buffer);
+}
+
+// Initialize the forward weight matrix used by tiled mat-vec tests.
+//
+// CUDA/Vulkan use a 16x16 tiled layout. Metal uses row-major weights with an
+// 8-element alignment. The Metal test data is dense 1/InputSize rows so that
+// constant input vectors still produce the original expected value.
+public void identityWeightMatrixTiled<T, int InputSize, int WorkgroupSize, bool Clear>(
+    uint tid, RWStructuredBuffer<T>.Handle buffer)
+    where T : __BuiltinFloatingPointType
+{
+    __target_switch
+    {
+    case cuda:
+        identityWeightMatrixTiledNative<T, InputSize, WorkgroupSize, Clear, TargetEnum.CUDA>(tid, buffer);
+    case spirv:
+        identityWeightMatrixTiledNative<T, InputSize, WorkgroupSize, Clear, TargetEnum.SPIR_V>(tid, buffer);
+    case metal:
+        identityWeightMatrixTiledMetal<T, InputSize, WorkgroupSize, Clear>(tid, buffer);
     }
 }

--- a/tests/neural/common.slang
+++ b/tests/neural/common.slang
@@ -529,15 +529,14 @@ void identityWeightMatrixTiledMetal<T, int InputSize, int WorkgroupSize, bool Cl
 
     AllMemoryBarrierWithGroupSync();
 
-    static const int NumRowIters = (InputSize + WorkgroupSize - 1) / WorkgroupSize;
-    for (int iter = 0; iter < NumRowIters; iter++)
+    static const int NumDiagIters = (InputSize + WorkgroupSize - 1) / WorkgroupSize;
+    for (int iter = 0; iter < NumDiagIters; iter++)
     {
         int row = iter * WorkgroupSize + tid;
         if (row >= InputSize)
             break;
 
-        for (int col = 0; col < InputSize; col++)
-            buffer[row * PaddedSize + col] = T(1.0f / float(InputSize));
+        buffer[row * PaddedSize + row] = T(1);
     }
 
     AllMemoryBarrierWithGroupSync();
@@ -588,8 +587,7 @@ void identityWeightMatrixTiledNative<T, int InputSize, int WorkgroupSize, bool C
 // Initialize the forward weight matrix used by tiled mat-vec tests.
 //
 // CUDA/Vulkan use a 16x16 tiled layout. Metal uses row-major weights with an
-// 8-element alignment. The Metal test data is dense 1/InputSize rows so that
-// constant input vectors still produce the original expected value.
+// 8-element alignment.
 public void identityWeightMatrixTiled<T, int InputSize, int WorkgroupSize, bool Clear>(
     uint tid, RWStructuredBuffer<T>.Handle buffer)
     where T : __BuiltinFloatingPointType

--- a/tests/neural/common.slang
+++ b/tests/neural/common.slang
@@ -131,16 +131,6 @@ public int tiledWeightOffset(int row, int col)
     }
 }
 
-public int tiledWeightOffset<int RowStride>(int row, int col)
-{
-    __target_switch
-    {
-    case cuda:  return rowMajorToNativeMatB(col, row);
-    case spirv: return row * 16 + col;
-    case metal: return row * RowStride + col;
-    }
-}
-
 // Offset for element (row, col) in the dWeight buffer's tiled layout.
 // On CUDA: native MatC fragment layout (from storeRaw + atomicAdd).
 // On Vulkan: row-major within each 16×16 tile (from storeTileRowToGlobal).
@@ -152,16 +142,6 @@ public int tiledDWeightOffset(int row, int col)
     case cuda:  return rowMajorToNativeMatC(row, col);
     case spirv: return row * 16 + col;
     case metal: return row * 16 + col;
-    }
-}
-
-public int tiledDWeightOffset<int RowStride>(int row, int col)
-{
-    __target_switch
-    {
-    case cuda:  return rowMajorToNativeMatC(row, col);
-    case spirv: return row * 16 + col;
-    case metal: return row * RowStride + col;
     }
 }
 

--- a/tests/neural/fflayer-wavetangled-vector-tiled-test.slang
+++ b/tests/neural/fflayer-wavetangled-vector-tiled-test.slang
@@ -5,10 +5,15 @@
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_POINTER=0 -xslang -DWARP_COUNT=1 -emit-spirv-directly
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0 -xslang -experimental-feature -xslang -DTEST_POINTER=0 -xslang -DWARP_COUNT=1
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0 -xslang -experimental-feature -xslang -DTEST_POINTER=1 -xslang -DWARP_COUNT=1
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -output-using-type -xslang -experimental-feature -xslang -DTEST_POINTER=0 -xslang -DWARP_COUNT=1 -xslang -DTEST_METAL=1
 
 #pragma warning(disable: 41017)
 import slang.neural;
 import common;
+
+#ifndef TEST_METAL
+#define TEST_METAL 0
+#endif
 
 #ifndef WARP_COUNT
 #define WARP_COUNT 1
@@ -20,11 +25,10 @@ import common;
 
 typealias ElementType = float;
 
-//TEST_INPUT: set parametersFloat = ubuffer(data=[1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0], stride=4)
-uniform RWStructuredBuffer<float>.Handle parametersFloat;
-
-//TEST_INPUT: set parameters = ubuffer(stride=4, count=258)
-//TEST_INPUT: set dParameters = ubuffer(stride=4, count=258)
+//TEST_INPUT: set parametersPtr = ubuffer(stride=4, count=258)
+//TEST_INPUT: set dParametersPtr = ubuffer(stride=4, count=258)
+//TEST_INPUT: set buffers.parameters = ubuffer(stride=4, count=258)
+//TEST_INPUT: set buffers.dParameters = ubuffer(stride=4, count=258)
 
 static const int BiasOffset = 256;
 static const int ParamBufferSize = 258;
@@ -33,13 +37,24 @@ typealias Layout = OptimalLayout;
 //TEST_INPUT: ubuffer(data=[0 0 0], stride=4):out,name=testResult
 RWStructuredBuffer<uint> testResult;
 
+uniform ElementType* parametersPtr;
+uniform ElementType* dParametersPtr;
+
+struct TestBuffers
+{
+    RWStructuredBuffer<ElementType>.Handle parameters;
+    RWStructuredBuffer<ElementType>.Handle dParameters;
+}
+
+ParameterBlock<TestBuffers> buffers;
+
 #if TEST_POINTER
-    uniform ElementType* parameters;
-    uniform ElementType* dParameters;
+    #define parameters parametersPtr
+    #define dParameters dParametersPtr
     typealias Address = PointerAddress<ElementType>;
 #else
-    uniform RWStructuredBuffer<ElementType>.Handle parameters;
-    uniform RWStructuredBuffer<ElementType>.Handle dParameters;
+    #define parameters buffers.parameters
+    #define dParameters buffers.dParameters
     typealias Address = BindlessAddress<ElementType>;
 #endif
 
@@ -49,9 +64,15 @@ static const int SubgroupSize = 32;
 static const int WarpCount = WARP_COUNT;
 static const int BatchSize = WarpCount * SubgroupSize;
 
+#if TEST_METAL
+#define TEST_TARGET TargetEnum.Metal
+#else
+#define TEST_TARGET TargetEnum.CUDA
+#endif
+
 typealias ShMemSizeLayer1 = SharedMemorySize<
     ElementType,
-    TargetEnum.CUDA,
+    TEST_TARGET,
     ExecutionMode.Training,
     SubgroupSize,
     WarpCount,
@@ -105,6 +126,7 @@ void testFFLayerBackward(int tid, int resIndex)
     let dOutput = OutVec(1.0);
 
     bwd_diff(computeLayerOutput)(paramAddrPair, inputPair, layer, dOutput);
+    AllMemoryBarrierWithGroupSync();
 
     // dInput = W^T * dOutput = [6, 8, 10, 12]
     bool isPassed = true;
@@ -168,31 +190,39 @@ void setupParameters(uint tid)
             parameters[i] = ElementType(0.0);
 
         for (int col = 0; col < InputSize; col++)
-            parameters[tiledWeightOffset(0, col)] = ElementType(parametersFloat[col]);
+            parameters[tiledWeightOffset(0, col)] = ElementType(col + 1);
 
         for (int col = 0; col < InputSize; col++)
-            parameters[tiledWeightOffset(1, col)] = ElementType(parametersFloat[InputSize + col]);
+            parameters[tiledWeightOffset(1, col)] = ElementType(InputSize + col + 1);
 
-        parameters[256] = ElementType(parametersFloat[8]);
-        parameters[257] = ElementType(parametersFloat[9]);
+        parameters[256] = ElementType(9);
+        parameters[257] = ElementType(10);
     }
 }
 
 [shader("compute")]
 [numthreads(BatchSize, 1, 1)]
-void computeMain(uint tid : SV_DispatchThreadID)
+void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
 {
+    if (gid.x != 0)
+        return;
+
+    uint lane = WaveGetLaneIndex();
+    uint wave = WaveGetWaveIndex();
+    if (lane >= uint(SubgroupSize) || wave >= uint(WarpCount))
+        return;
+
     setupParameters(tid);
     AllMemoryBarrierWithGroupSync();
 
     testFFLayerParameterCount(tid, 0);
-    // BUFFER: 1
+    // BUFFER: {{^}}1{{$}}
 
     testFFLayerForward(tid, 1);
-    // BUFFER: 1
+    // BUFFER-NEXT: {{^}}1{{$}}
 
     cleanupDParameters(tid);
     AllMemoryBarrierWithGroupSync();
     testFFLayerBackward(tid, 2);
-    // BUFFER: 1
+    // BUFFER-NEXT: {{^}}1{{$}}
 }

--- a/tests/neural/fflayer-wavetangled-vector-tiled-test.slang
+++ b/tests/neural/fflayer-wavetangled-vector-tiled-test.slang
@@ -133,14 +133,14 @@ void testFFLayerBackward(int tid, int resIndex)
     // dW accumulated across BatchSize threads.
     // dW = BatchSize * [[1,2,3,4],[1,2,3,4]]
     ElementType scale = ElementType(BatchSize);
-    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset(0, 0)], scale * ElementType(1.0));
-    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset(0, 1)], scale * ElementType(2.0));
-    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset(0, 2)], scale * ElementType(3.0));
-    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset(0, 3)], scale * ElementType(4.0));
-    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset(1, 0)], scale * ElementType(1.0));
-    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset(1, 1)], scale * ElementType(2.0));
-    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset(1, 2)], scale * ElementType(3.0));
-    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset(1, 3)], scale * ElementType(4.0));
+    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset<InputSize>(0, 0)], scale * ElementType(1.0));
+    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset<InputSize>(0, 1)], scale * ElementType(2.0));
+    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset<InputSize>(0, 2)], scale * ElementType(3.0));
+    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset<InputSize>(0, 3)], scale * ElementType(4.0));
+    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset<InputSize>(1, 0)], scale * ElementType(1.0));
+    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset<InputSize>(1, 1)], scale * ElementType(2.0));
+    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset<InputSize>(1, 2)], scale * ElementType(3.0));
+    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset<InputSize>(1, 3)], scale * ElementType(4.0));
 
     // dBias = [BatchSize, BatchSize]
     isPassed = isPassed && equals(buffers.dParameters[BiasOffset], scale);
@@ -185,10 +185,10 @@ void setupParameters(uint tid)
             buffers.parameters[i] = ElementType(0.0);
 
         for (int col = 0; col < InputSize; col++)
-            buffers.parameters[tiledWeightOffset(0, col)] = ElementType(col + 1);
+            buffers.parameters[tiledWeightOffset<InputSize>(0, col)] = ElementType(col + 1);
 
         for (int col = 0; col < InputSize; col++)
-            buffers.parameters[tiledWeightOffset(1, col)] = ElementType(InputSize + col + 1);
+            buffers.parameters[tiledWeightOffset<InputSize>(1, col)] = ElementType(InputSize + col + 1);
 
         buffers.parameters[256] = ElementType(9);
         buffers.parameters[257] = ElementType(10);

--- a/tests/neural/fflayer-wavetangled-vector-tiled-test.slang
+++ b/tests/neural/fflayer-wavetangled-vector-tiled-test.slang
@@ -25,8 +25,6 @@ import common;
 
 typealias ElementType = float;
 
-//TEST_INPUT: set parametersPtr = ubuffer(stride=4, count=258)
-//TEST_INPUT: set dParametersPtr = ubuffer(stride=4, count=258)
 //TEST_INPUT: set buffers.parameters = ubuffer(stride=4, count=258)
 //TEST_INPUT: set buffers.dParameters = ubuffer(stride=4, count=258)
 
@@ -37,24 +35,22 @@ typealias Layout = OptimalLayout;
 //TEST_INPUT: ubuffer(data=[0 0 0], stride=4):out,name=testResult
 RWStructuredBuffer<uint> testResult;
 
-uniform ElementType* parametersPtr;
-uniform ElementType* dParametersPtr;
-
 struct TestBuffers
 {
+#if TEST_POINTER
+    ElementType* parameters;
+    ElementType* dParameters;
+#else
     RWStructuredBuffer<ElementType>.Handle parameters;
     RWStructuredBuffer<ElementType>.Handle dParameters;
+#endif
 }
 
 ParameterBlock<TestBuffers> buffers;
 
 #if TEST_POINTER
-    #define parameters parametersPtr
-    #define dParameters dParametersPtr
     typealias Address = PointerAddress<ElementType>;
 #else
-    #define parameters buffers.parameters
-    #define dParameters buffers.dParameters
     typealias Address = BindlessAddress<ElementType>;
 #endif
 
@@ -96,7 +92,7 @@ void testFFLayerForward(int tid, int resIndex)
     ElementType[InputSize] inputData = { ElementType(1.0), ElementType(2.0), ElementType(3.0), ElementType(4.0) };
     InVec input = InVec(inputData);
 
-    let baseAddr = Address(parameters);
+    let baseAddr = Address(buffers.parameters);
     let layer = Layer();
 
     let output = layer.eval<Address>(input, baseAddr);
@@ -117,8 +113,8 @@ void testFFLayerBackward(int tid, int resIndex)
     ElementType[InputSize] inputData = { ElementType(1.0), ElementType(2.0), ElementType(3.0), ElementType(4.0) };
     InVec input = InVec(inputData);
 
-    let baseAddr = Address(parameters);
-    let dBaseAddr = Address(dParameters);
+    let baseAddr = Address(buffers.parameters);
+    let dBaseAddr = Address(buffers.dParameters);
     let layer = Layer();
 
     var paramAddrPair = DifferentialPtrPair<Address>(baseAddr, dBaseAddr);
@@ -126,7 +122,6 @@ void testFFLayerBackward(int tid, int resIndex)
     let dOutput = OutVec(1.0);
 
     bwd_diff(computeLayerOutput)(paramAddrPair, inputPair, layer, dOutput);
-    AllMemoryBarrierWithGroupSync();
 
     // dInput = W^T * dOutput = [6, 8, 10, 12]
     bool isPassed = true;
@@ -138,18 +133,18 @@ void testFFLayerBackward(int tid, int resIndex)
     // dW accumulated across BatchSize threads.
     // dW = BatchSize * [[1,2,3,4],[1,2,3,4]]
     ElementType scale = ElementType(BatchSize);
-    isPassed = isPassed && equals(dParameters[tiledDWeightOffset(0, 0)], scale * ElementType(1.0));
-    isPassed = isPassed && equals(dParameters[tiledDWeightOffset(0, 1)], scale * ElementType(2.0));
-    isPassed = isPassed && equals(dParameters[tiledDWeightOffset(0, 2)], scale * ElementType(3.0));
-    isPassed = isPassed && equals(dParameters[tiledDWeightOffset(0, 3)], scale * ElementType(4.0));
-    isPassed = isPassed && equals(dParameters[tiledDWeightOffset(1, 0)], scale * ElementType(1.0));
-    isPassed = isPassed && equals(dParameters[tiledDWeightOffset(1, 1)], scale * ElementType(2.0));
-    isPassed = isPassed && equals(dParameters[tiledDWeightOffset(1, 2)], scale * ElementType(3.0));
-    isPassed = isPassed && equals(dParameters[tiledDWeightOffset(1, 3)], scale * ElementType(4.0));
+    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset(0, 0)], scale * ElementType(1.0));
+    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset(0, 1)], scale * ElementType(2.0));
+    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset(0, 2)], scale * ElementType(3.0));
+    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset(0, 3)], scale * ElementType(4.0));
+    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset(1, 0)], scale * ElementType(1.0));
+    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset(1, 1)], scale * ElementType(2.0));
+    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset(1, 2)], scale * ElementType(3.0));
+    isPassed = isPassed && equals(buffers.dParameters[tiledDWeightOffset(1, 3)], scale * ElementType(4.0));
 
     // dBias = [BatchSize, BatchSize]
-    isPassed = isPassed && equals(dParameters[BiasOffset], scale);
-    isPassed = isPassed && equals(dParameters[BiasOffset + 1], scale);
+    isPassed = isPassed && equals(buffers.dParameters[BiasOffset], scale);
+    isPassed = isPassed && equals(buffers.dParameters[BiasOffset + 1], scale);
 
     isPassed = WaveActiveAllTrue(isPassed);
     if (tid == 0)
@@ -178,7 +173,7 @@ void cleanupDParameters(uint tid)
     if (tid == 0)
     {
         for (int i = 0; i < ParamBufferSize; i++)
-            dParameters[i] = ElementType(0.0);
+            buffers.dParameters[i] = ElementType(0.0);
     }
 }
 
@@ -187,31 +182,23 @@ void setupParameters(uint tid)
     if (tid == 0)
     {
         for (int i = 0; i < ParamBufferSize; i++)
-            parameters[i] = ElementType(0.0);
+            buffers.parameters[i] = ElementType(0.0);
 
         for (int col = 0; col < InputSize; col++)
-            parameters[tiledWeightOffset(0, col)] = ElementType(col + 1);
+            buffers.parameters[tiledWeightOffset(0, col)] = ElementType(col + 1);
 
         for (int col = 0; col < InputSize; col++)
-            parameters[tiledWeightOffset(1, col)] = ElementType(InputSize + col + 1);
+            buffers.parameters[tiledWeightOffset(1, col)] = ElementType(InputSize + col + 1);
 
-        parameters[256] = ElementType(9);
-        parameters[257] = ElementType(10);
+        buffers.parameters[256] = ElementType(9);
+        buffers.parameters[257] = ElementType(10);
     }
 }
 
 [shader("compute")]
 [numthreads(BatchSize, 1, 1)]
-void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
+void computeMain(uint tid : SV_GroupIndex)
 {
-    if (gid.x != 0)
-        return;
-
-    uint lane = WaveGetLaneIndex();
-    uint wave = WaveGetWaveIndex();
-    if (lane >= uint(SubgroupSize) || wave >= uint(WarpCount))
-        return;
-
     setupParameters(tid);
     AllMemoryBarrierWithGroupSync();
 

--- a/tests/neural/mma-tiled-backward-test.slang
+++ b/tests/neural/mma-tiled-backward-test.slang
@@ -2,6 +2,7 @@
 // VK half disabled: backward pass uses half atomics for bias/weight gradient accumulation,
 // which requires VK_EXT_shader_atomic_float16 not available on our test GPUs.
 // DISABLED-TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=1
+//TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0 -xslang -experimental-feature -xslang -DTEST_HALF=0
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0 -xslang -experimental-feature -xslang -DTEST_HALF=1
 
@@ -15,18 +16,21 @@ typealias DType = half;
 typealias DType = float;
 #endif
 
+struct TestBuffers
+{
+    RWStructuredBuffer<DType>.Handle weightBuffer;
+    RWStructuredBuffer<DType>.Handle weightGradBuffer;
+    RWStructuredBuffer<DType>.Handle biasGradBuffer;
+}
+
 // Weight matrix in tiled layout (read by transpose MMA)
 // 2x size needed: convertTiledToNativeB uses the second half as scratch space.
-// TEST_INPUT: set weightBuffer = ubuffer(stride=4, count=8192)
-uniform RWStructuredBuffer<DType>.Handle weightBuffer;
-
+// TEST_INPUT: set buffers.weightBuffer = ubuffer(stride=4, count=8192)
 // Weight gradient (written by outer product)
-// TEST_INPUT: set weightGradBuffer = ubuffer(stride=4, count=4096)
-uniform RWStructuredBuffer<DType>.Handle weightGradBuffer;
-
+// TEST_INPUT: set buffers.weightGradBuffer = ubuffer(stride=4, count=4096)
 // Bias gradient (written by bias reduce)
-// TEST_INPUT: set biasGradBuffer = ubuffer(stride=4, count=64)
-uniform RWStructuredBuffer<DType>.Handle biasGradBuffer;
+// TEST_INPUT: set buffers.biasGradBuffer = ubuffer(stride=4, count=64)
+ParameterBlock<TestBuffers> buffers;
 
 // TEST_INPUT:ubuffer(stride=4, count=3):out, name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
@@ -47,7 +51,7 @@ void clearWeightBuffer<int PaddedSize>(uint tid)
     {
         int index = iter * BatchSize + tid;
         if (index < TotalElements)
-            weightBuffer[index] = DType(0);
+            buffers.weightBuffer[index] = DType(0);
     }
 }
 
@@ -61,7 +65,7 @@ void clearGradBuffers<int PaddedSize>(uint tid)
     {
         int index = iter * BatchSize + tid;
         if (index < TotalElements)
-            weightGradBuffer[index] = DType(0);
+            buffers.weightGradBuffer[index] = DType(0);
     }
 
     static const int BiasIters = (PaddedSize + BatchSize - 1) / BatchSize;
@@ -70,12 +74,14 @@ void clearGradBuffers<int PaddedSize>(uint tid)
     {
         int index = iter * BatchSize + tid;
         if (index < PaddedSize)
-            biasGradBuffer[index] = DType(0);
+            buffers.biasGradBuffer[index] = DType(0);
     }
 }
 
-// Write identity matrix in tiled layout.
-// On CUDA, also converts from row-major tiled to native fragment layout.
+// Write identity matrix in the layout expected by the active backend.
+// CUDA/Vulkan use row-major 16x16 tiled layout. CUDA then converts that
+// temporary row-major tiled data to native fragment layout. Metal uses plain
+// row-major weights.
 void identityWeightTiled<int Size, int PaddedSize>(uint tid)
 {
     static const int TileSize = 16;
@@ -84,25 +90,44 @@ void identityWeightTiled<int Size, int PaddedSize>(uint tid)
     clearWeightBuffer<PaddedSize>(tid);
     AllMemoryBarrierWithGroupSync();
 
-    static const int NumDiagIters = (Size + BatchSize - 1) / BatchSize;
-    [ForceUnroll]
-    for (int iter = 0; iter < NumDiagIters; iter++)
+    __target_switch
     {
-        int row = iter * BatchSize + tid;
-        if (row >= Size)
-            break;
-        int tileRow = row / TileSize;
-        int tileCol = row / TileSize;
-        int localRow = row % TileSize;
-        int localCol = row % TileSize;
-        int tileIndex = tileRow * NTileCols + tileCol;
-        int offset = tileIndex * TileSize * TileSize + localRow * TileSize + localCol;
-        weightBuffer[offset] = DType(1);
-    }
-    AllMemoryBarrierWithGroupSync();
+    case metal:
+        {
+            static const int NumDiagIters = (Size + BatchSize - 1) / BatchSize;
+            [ForceUnroll]
+            for (int iter = 0; iter < NumDiagIters; iter++)
+            {
+                int row = iter * BatchSize + tid;
+                if (row >= Size)
+                    break;
+                buffers.weightBuffer[row * PaddedSize + row] = DType(1);
+            }
+            AllMemoryBarrierWithGroupSync();
+        }
+    default:
+        {
+            static const int NumDiagIters = (Size + BatchSize - 1) / BatchSize;
+            [ForceUnroll]
+            for (int iter = 0; iter < NumDiagIters; iter++)
+            {
+                int row = iter * BatchSize + tid;
+                if (row >= Size)
+                    break;
+                int tileRow = row / TileSize;
+                int tileCol = row / TileSize;
+                int localRow = row % TileSize;
+                int localCol = row % TileSize;
+                int tileIndex = tileRow * NTileCols + tileCol;
+                int offset = tileIndex * TileSize * TileSize + localRow * TileSize + localCol;
+                buffers.weightBuffer[offset] = DType(1);
+            }
+            AllMemoryBarrierWithGroupSync();
 
-    convertTiledToNativeB<DType, PaddedSize, PaddedSize, BatchSize>(tid, weightBuffer);
-    AllMemoryBarrierWithGroupSync();
+            convertTiledToNativeB<DType, PaddedSize, PaddedSize, BatchSize>(tid, buffers.weightBuffer);
+            AllMemoryBarrierWithGroupSync();
+        }
+    }
 }
 
 void test<int Size>(uint tid, int resIndex)
@@ -122,7 +147,7 @@ void test<int Size>(uint tid, int resIndex)
 
     // W = identity → dInput = W^T * dOut = dOut
     let dInput = neural_unittest.testTiledBackward<DType, Size, Size, TestShMemSize, 1>(
-        inputData, dOutData, weightBuffer, weightGradBuffer, biasGradBuffer);
+        inputData, dOutData, buffers.weightBuffer, buffers.weightGradBuffer, buffers.biasGradBuffer);
 
     bool res = true;
     for (int i = 0; i < Size; i++)
@@ -142,8 +167,11 @@ void test<int Size>(uint tid, int resIndex)
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_DispatchThreadID)
+void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
 {
+    if (gid.x != 0)
+        return;
+
     // 16x16
     {
         identityWeightTiled<16, 16>(tid);
@@ -162,7 +190,7 @@ void computeMain(uint tid : SV_DispatchThreadID)
         test<64>(tid, 2);
     }
 
-    // BUFFER: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
+    // BUFFER: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
 }

--- a/tests/neural/mma-tiled-backward-test.slang
+++ b/tests/neural/mma-tiled-backward-test.slang
@@ -101,11 +101,8 @@ void test<int Size>(uint tid, int resIndex)
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
+void computeMain(uint tid : SV_GroupIndex)
 {
-    if (gid.x != 0)
-        return;
-
     // 16x16
     {
         identityWeightMatrixTiled<DType, 16, BatchSize, false>(tid, buffers.weightBuffer);

--- a/tests/neural/mma-tiled-backward-test.slang
+++ b/tests/neural/mma-tiled-backward-test.slang
@@ -41,20 +41,6 @@ public struct TestShMemSize : ISharedMemorySize {
     public static const uint Bytes = 1024 * sizeof(uint4);
 }
 
-void clearWeightBuffer<int PaddedSize>(uint tid)
-{
-    static const int TotalElements = PaddedSize * PaddedSize;
-    static const int NumIters = (TotalElements + BatchSize - 1) / BatchSize;
-
-    [ForceUnroll]
-    for (int iter = 0; iter < NumIters; iter++)
-    {
-        int index = iter * BatchSize + tid;
-        if (index < TotalElements)
-            buffers.weightBuffer[index] = DType(0);
-    }
-}
-
 void clearGradBuffers<int PaddedSize>(uint tid)
 {
     static const int TotalElements = PaddedSize * PaddedSize;
@@ -75,58 +61,6 @@ void clearGradBuffers<int PaddedSize>(uint tid)
         int index = iter * BatchSize + tid;
         if (index < PaddedSize)
             buffers.biasGradBuffer[index] = DType(0);
-    }
-}
-
-// Write identity matrix in the layout expected by the active backend.
-// CUDA/Vulkan use row-major 16x16 tiled layout. CUDA then converts that
-// temporary row-major tiled data to native fragment layout. Metal uses plain
-// row-major weights.
-void identityWeightTiled<int Size, int PaddedSize>(uint tid)
-{
-    static const int TileSize = 16;
-    static const int NTileCols = PaddedSize / TileSize;
-
-    clearWeightBuffer<PaddedSize>(tid);
-    AllMemoryBarrierWithGroupSync();
-
-    __target_switch
-    {
-    case metal:
-        {
-            static const int NumDiagIters = (Size + BatchSize - 1) / BatchSize;
-            [ForceUnroll]
-            for (int iter = 0; iter < NumDiagIters; iter++)
-            {
-                int row = iter * BatchSize + tid;
-                if (row >= Size)
-                    break;
-                buffers.weightBuffer[row * PaddedSize + row] = DType(1);
-            }
-            AllMemoryBarrierWithGroupSync();
-        }
-    default:
-        {
-            static const int NumDiagIters = (Size + BatchSize - 1) / BatchSize;
-            [ForceUnroll]
-            for (int iter = 0; iter < NumDiagIters; iter++)
-            {
-                int row = iter * BatchSize + tid;
-                if (row >= Size)
-                    break;
-                int tileRow = row / TileSize;
-                int tileCol = row / TileSize;
-                int localRow = row % TileSize;
-                int localCol = row % TileSize;
-                int tileIndex = tileRow * NTileCols + tileCol;
-                int offset = tileIndex * TileSize * TileSize + localRow * TileSize + localCol;
-                buffers.weightBuffer[offset] = DType(1);
-            }
-            AllMemoryBarrierWithGroupSync();
-
-            convertTiledToNativeB<DType, PaddedSize, PaddedSize, BatchSize>(tid, buffers.weightBuffer);
-            AllMemoryBarrierWithGroupSync();
-        }
     }
 }
 
@@ -174,19 +108,19 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
 
     // 16x16
     {
-        identityWeightTiled<16, 16>(tid);
+        identityWeightMatrixTiled<DType, 16, BatchSize, false>(tid, buffers.weightBuffer);
         test<16>(tid, 0);
     }
 
     // 32x32
     {
-        identityWeightTiled<32, 32>(tid);
+        identityWeightMatrixTiled<DType, 32, BatchSize, false>(tid, buffers.weightBuffer);
         test<32>(tid, 1);
     }
 
     // 64x64
     {
-        identityWeightTiled<64, 64>(tid);
+        identityWeightMatrixTiled<DType, 64, BatchSize, false>(tid, buffers.weightBuffer);
         test<64>(tid, 2);
     }
 

--- a/tests/neural/mma-tiled-layout-test-multi-warps-arbitrary-size.slang
+++ b/tests/neural/mma-tiled-layout-test-multi-warps-arbitrary-size.slang
@@ -3,6 +3,11 @@
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=1
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=1 -xslang -DTEST_BIAS=1
 
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=0
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=1 -xslang -DTEST_BIAS=0
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=1
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=1 -xslang -DTEST_BIAS=1
+
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=0
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=1 -xslang -DTEST_BIAS=0
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=1
@@ -18,11 +23,15 @@ typealias DType = half;
 typealias DType = float;
 #endif
 
-// TEST_INPUT: set weightBuffer = ubuffer(stride=4, count=4096)
-uniform RWStructuredBuffer<DType>.Handle weightBuffer;
+struct TestBuffers
+{
+    RWStructuredBuffer<DType>.Handle weightBuffer;
+    RWStructuredBuffer<DType>.Handle biasBuffer;
+}
 
-// TEST_INPUT: set biasBuffer = ubuffer(data=[0], stride=4, count=64)
-uniform RWStructuredBuffer<DType>.Handle biasBuffer;
+// TEST_INPUT: set buffers.weightBuffer = ubuffer(stride=4, count=4096)
+// TEST_INPUT: set buffers.biasBuffer = ubuffer(data=[0], stride=4, count=64)
+ParameterBlock<TestBuffers> buffers;
 
 // TEST_INPUT:ubuffer(stride=4, count=5):out, name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
@@ -38,24 +47,26 @@ static const uint OffsetB = 256;
 
 void fillWeightMatrixTiled<int InputSize, int OutputSize>(uint tid)
 {
-    fillForwardWeightTiled<DType, InputSize, OutputSize, BatchSize>(tid, weightBuffer, DType(0.125f));
+    fillForwardWeightTiled<DType, InputSize, OutputSize, BatchSize>(tid, buffers.weightBuffer, DType(0.125f));
 }
 
-void test<int InputSize, int OutputSize>(uint tid, int resIndex)
+bool test<int InputSize, int OutputSize>(uint tid)
 {
     static const int PaddedInputSize = PadToTile<InputSize>.Value;
     static const int PaddedOutputSize = PadToTile<OutputSize>.Value;
 
-    DType inputData[InputSize];
+    typealias InputVec = WaveTangledVector<DType, TestShMemSize, PaddedInputSize, SubgroupSize, 2>;
+    InputVec inputData = InputVec(DType(0));
+    DType inputValue = DType(WaveGetLaneIndex() + 1 + tid / 32);
     for (int i = 0; i < InputSize; i++)
-        inputData[i] = DType(tid + 1);
+        inputData[i] = inputValue;
 
 #if TEST_BIAS
-    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, InputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, true, 2, false>(
-        inputData, weightBuffer, Optional<RWStructuredBuffer<DType>.Handle>(biasBuffer));
+    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, PaddedInputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, true, 2, false>(
+        inputData, buffers.weightBuffer, Optional<RWStructuredBuffer<DType>.Handle>(buffers.biasBuffer));
 #else
-    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, InputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, false, 2, false>(
-        inputData, weightBuffer, none);
+    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, PaddedInputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, false, 2, false>(
+        inputData, buffers.weightBuffer, none);
 #endif
 
     bool res = true;
@@ -63,37 +74,36 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
     {
         DType scaleFactor = DType(0.125f);
 #if !TEST_BIAS
-        DType expected = DType((tid + 1) * InputSize) * scaleFactor;
+        DType expected = inputValue * DType(InputSize) * scaleFactor;
 #else
-        DType expected = DType((tid + 1) * InputSize) * scaleFactor + DType(i);
+        DType expected = inputValue * DType(InputSize) * scaleFactor + DType(i);
 #endif
         if (!equals(output[i], expected))
         {
-            if (tid == 0)
-                printf("FAIL resIndex=%d i=%d expected=%f got=%f\n", resIndex, i, float(expected), float(output[i]));
             res = false;
             break;
         }
     }
 
-    bool finalResult = collectResults<BatchSize>(tid, res);
-    if (tid == 0)
-    {
-        outputBuffer[resIndex] = finalResult ? 1 : 0;
-    }
+    return collectResults<BatchSize>(tid, res);
 }
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_DispatchThreadID)
+void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
 {
-    initBias<DType, 64, BatchSize>(tid, biasBuffer);
+    if (gid.x != 0)
+        return;
+
+    initBias<DType, 64, BatchSize>(tid, buffers.biasBuffer);
 
     // 3x5 (padded to 16x16)
     {
         fillWeightMatrixTiled<3, 5>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<3, 5>(tid, 0);
+        bool result = test<3, 5>(tid);
+        if (tid == 0)
+            outputBuffer[0] = result ? 1 : 0;
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -101,7 +111,9 @@ void computeMain(uint tid : SV_DispatchThreadID)
     {
         fillWeightMatrixTiled<11, 18>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<11, 18>(tid, 1);
+        bool result = test<11, 18>(tid);
+        if (tid == 0)
+            outputBuffer[1] = result ? 1 : 0;
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -109,7 +121,9 @@ void computeMain(uint tid : SV_DispatchThreadID)
     {
         fillWeightMatrixTiled<23, 9>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<23, 9>(tid, 2);
+        bool result = test<23, 9>(tid);
+        if (tid == 0)
+            outputBuffer[2] = result ? 1 : 0;
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -117,7 +131,9 @@ void computeMain(uint tid : SV_DispatchThreadID)
     {
         fillWeightMatrixTiled<35, 3>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<35, 3>(tid, 3);
+        bool result = test<35, 3>(tid);
+        if (tid == 0)
+            outputBuffer[3] = result ? 1 : 0;
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -125,11 +141,13 @@ void computeMain(uint tid : SV_DispatchThreadID)
     {
         fillWeightMatrixTiled<17, 64>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<17, 64>(tid, 4);
+        bool result = test<17, 64>(tid);
+        if (tid == 0)
+            outputBuffer[4] = result ? 1 : 0;
     }
-    // BUFFER: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
+    // BUFFER: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
 }

--- a/tests/neural/mma-tiled-layout-test-multi-warps-arbitrary-size.slang
+++ b/tests/neural/mma-tiled-layout-test-multi-warps-arbitrary-size.slang
@@ -50,7 +50,7 @@ void fillWeightMatrixTiled<int InputSize, int OutputSize>(uint tid)
     fillForwardWeightTiled<DType, InputSize, OutputSize, BatchSize>(tid, buffers.weightBuffer, DType(0.125f));
 }
 
-bool test<int InputSize, int OutputSize>(uint tid)
+void test<int InputSize, int OutputSize>(uint tid, int resIndex)
 {
     static const int PaddedInputSize = PadToTile<InputSize>.Value;
     static const int PaddedOutputSize = PadToTile<OutputSize>.Value;
@@ -85,7 +85,11 @@ bool test<int InputSize, int OutputSize>(uint tid)
         }
     }
 
-    return collectResults<BatchSize>(tid, res);
+    bool finalResult = collectResults<BatchSize>(tid, res);
+    if (tid == 0)
+    {
+        outputBuffer[resIndex] = finalResult ? 1 : 0;
+    }
 }
 
 [numthreads(BatchSize, 1, 1)]
@@ -101,9 +105,7 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
     {
         fillWeightMatrixTiled<3, 5>(tid);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<3, 5>(tid);
-        if (tid == 0)
-            outputBuffer[0] = result ? 1 : 0;
+        test<3, 5>(tid, 0);
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -111,9 +113,7 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
     {
         fillWeightMatrixTiled<11, 18>(tid);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<11, 18>(tid);
-        if (tid == 0)
-            outputBuffer[1] = result ? 1 : 0;
+        test<11, 18>(tid, 1);
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -121,9 +121,7 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
     {
         fillWeightMatrixTiled<23, 9>(tid);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<23, 9>(tid);
-        if (tid == 0)
-            outputBuffer[2] = result ? 1 : 0;
+        test<23, 9>(tid, 2);
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -131,9 +129,7 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
     {
         fillWeightMatrixTiled<35, 3>(tid);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<35, 3>(tid);
-        if (tid == 0)
-            outputBuffer[3] = result ? 1 : 0;
+        test<35, 3>(tid, 3);
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -141,9 +137,7 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
     {
         fillWeightMatrixTiled<17, 64>(tid);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<17, 64>(tid);
-        if (tid == 0)
-            outputBuffer[4] = result ? 1 : 0;
+        test<17, 64>(tid, 4);
     }
     // BUFFER: {{^}}1{{$}}
     // BUFFER-NEXT: {{^}}1{{$}}

--- a/tests/neural/mma-tiled-layout-test-multi-warps-arbitrary-size.slang
+++ b/tests/neural/mma-tiled-layout-test-multi-warps-arbitrary-size.slang
@@ -94,11 +94,8 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
+void computeMain(uint tid : SV_GroupIndex)
 {
-    if (gid.x != 0)
-        return;
-
     initBias<DType, 64, BatchSize>(tid, buffers.biasBuffer);
 
     // 3x5 (padded to 16x16)

--- a/tests/neural/mma-tiled-layout-test-multi-warps.slang
+++ b/tests/neural/mma-tiled-layout-test-multi-warps.slang
@@ -3,6 +3,11 @@
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=1
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=1 -xslang -DTEST_BIAS=1
 
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=0
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=1 -xslang -DTEST_BIAS=0
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=1
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=1 -xslang -DTEST_BIAS=1
+
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=0
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=1 -xslang -DTEST_BIAS=0
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=1
@@ -18,11 +23,15 @@ typealias DType = half;
 typealias DType = float;
 #endif
 
-// TEST_INPUT: set weightBuffer = ubuffer(data=[0], stride=4, count=4096)
-uniform RWStructuredBuffer<DType>.Handle weightBuffer;
+struct TestBuffers
+{
+    RWStructuredBuffer<DType>.Handle weightBuffer;
+    RWStructuredBuffer<DType>.Handle biasBuffer;
+}
 
-// TEST_INPUT: set biasBuffer = ubuffer(data=[0], stride=4, count=64)
-uniform RWStructuredBuffer<DType>.Handle biasBuffer;
+// TEST_INPUT: set buffers.weightBuffer = ubuffer(data=[0], stride=4, count=4096)
+// TEST_INPUT: set buffers.biasBuffer = ubuffer(data=[0], stride=4, count=64)
+ParameterBlock<TestBuffers> buffers;
 
 // TEST_INPUT:ubuffer(stride=4, count=5):out, name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
@@ -46,7 +55,7 @@ void clearWeightBuffer<int PaddedSize>(uint tid)
     {
         int index = iter * BatchSize + tid;
         if (index < TotalElements)
-            weightBuffer[index] = DType(0);
+            buffers.weightBuffer[index] = DType(0);
     }
 }
 
@@ -71,51 +80,63 @@ void identityWeightMatrixTiled<int InputSize, int PaddedSize, bool Clear>(uint t
     clearWeightBuffer<PaddedSize>(tid);
     AllMemoryBarrierWithGroupSync();
 
-    static const int NumDiagIters = (InputSize + BatchSize - 1) / BatchSize;
-
-    for (int iter = 0; iter < NumDiagIters; iter++)
+    __target_switch
     {
-        int row = iter * BatchSize + tid;
-        if (row >= InputSize)
-            break;
+    case metal:
+        {
+            fillForwardWeightTiled<DType, InputSize, InputSize, BatchSize>(
+                tid, buffers.weightBuffer, DType(1.0f / float(InputSize)));
+        }
+    default:
+        {
+            static const int NumDiagIters = (InputSize + BatchSize - 1) / BatchSize;
+            for (int iter = 0; iter < NumDiagIters; iter++)
+            {
+                int row = iter * BatchSize + tid;
+                if (row >= InputSize)
+                    break;
 
-        int tileRow = row / TileSize;
-        int tileCol = row / TileSize;
-        int localRow = row % TileSize;
-        int localCol = row % TileSize;
-        int tileIndex = tileRow * NTileCols + tileCol;
-        int offset = tileIndex * TileSize * TileSize + localRow * TileSize + localCol;
-        weightBuffer[offset] = DType(1);
+                int tileRow = row / TileSize;
+                int tileCol = row / TileSize;
+                int localRow = row % TileSize;
+                int localCol = row % TileSize;
+                int tileIndex = tileRow * NTileCols + tileCol;
+                int offset = tileIndex * TileSize * TileSize + localRow * TileSize + localCol;
+                buffers.weightBuffer[offset] = DType(1);
+            }
+
+            AllMemoryBarrierWithGroupSync();
+            convertTiledToNativeB<DType, PaddedSize, PaddedSize, BatchSize>(tid, buffers.weightBuffer);
+        }
     }
-
-    AllMemoryBarrierWithGroupSync();
-    convertTiledToNativeB<DType, PaddedSize, PaddedSize, BatchSize>(tid, weightBuffer);
 }
 
-void test<int InputSize, int OutputSize>(uint tid, int resIndex)
+bool test<int InputSize, int OutputSize>(uint tid)
 {
     static const int PaddedInputSize = PadToTile<InputSize>.Value;
     static const int PaddedOutputSize = PadToTile<OutputSize>.Value;
 
-    DType inputData[InputSize];
+    typealias InputVec = WaveTangledVector<DType, TestShMemSize, PaddedInputSize, SubgroupSize, 2>;
+    InputVec inputData = InputVec(DType(0));
+    DType inputValue = DType(WaveGetLaneIndex() + 1 + tid / 32);
     for (int i = 0; i < InputSize; i++)
-        inputData[i] = DType(tid + 1);
+        inputData[i] = inputValue;
 
 #if TEST_BIAS
-    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, InputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, true, 2, false>(
-        inputData, weightBuffer, Optional<RWStructuredBuffer<DType>.Handle>(biasBuffer));
+    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, PaddedInputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, true, 2, false>(
+        inputData, buffers.weightBuffer, Optional<RWStructuredBuffer<DType>.Handle>(buffers.biasBuffer));
 #else
-    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, InputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, false, 2, false>(
-        inputData, weightBuffer, none);
+    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, PaddedInputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, false, 2, false>(
+        inputData, buffers.weightBuffer, none);
 #endif
 
     bool res = true;
     for (int i = 0; i < OutputSize; i++)
     {
 #if !TEST_BIAS
-        DType expected = DType(tid + 1);
+        DType expected = inputValue;
 #else
-        DType expected = DType(tid + 1) + DType(i);
+        DType expected = inputValue + DType(i);
 #endif
         if (!equals(output[i], expected))
         {
@@ -124,26 +145,25 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
         }
     }
 
-    bool finalResult = collectResults<BatchSize>(tid, res);
-    if (tid == 0)
-    {
-        outputBuffer[resIndex] = finalResult ? 1 : 0;
-    }
+    return collectResults<BatchSize>(tid, res);
 }
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_DispatchThreadID)
+void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
 {
-    initBias<DType, 64, BatchSize>(tid, biasBuffer);
+    if (gid.x != 0)
+        return;
+
+    initBias<DType, 64, BatchSize>(tid, buffers.biasBuffer);
 
     // 4x4 (padded to 16x16)
     {
         identityWeightMatrixTiled<4, 16, false>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<4, 4>(tid, 0);
-        AllMemoryBarrierWithGroupSync();
-        identityWeightMatrixTiled<4, 16, true>(tid);
+        bool result = test<4, 4>(tid);
+        if (tid == 0)
+            outputBuffer[0] = result ? 1 : 0;
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -151,9 +171,9 @@ void computeMain(uint tid : SV_DispatchThreadID)
     {
         identityWeightMatrixTiled<8, 16, false>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<8, 8>(tid, 1);
-        AllMemoryBarrierWithGroupSync();
-        identityWeightMatrixTiled<8, 16, true>(tid);
+        bool result = test<8, 8>(tid);
+        if (tid == 0)
+            outputBuffer[1] = result ? 1 : 0;
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -161,9 +181,9 @@ void computeMain(uint tid : SV_DispatchThreadID)
     {
         identityWeightMatrixTiled<16, 16, false>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<16, 16>(tid, 2);
-        AllMemoryBarrierWithGroupSync();
-        identityWeightMatrixTiled<16, 16, true>(tid);
+        bool result = test<16, 16>(tid);
+        if (tid == 0)
+            outputBuffer[2] = result ? 1 : 0;
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -171,9 +191,9 @@ void computeMain(uint tid : SV_DispatchThreadID)
     {
         identityWeightMatrixTiled<32, 32, false>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<32, 32>(tid, 3);
-        AllMemoryBarrierWithGroupSync();
-        identityWeightMatrixTiled<32, 32, true>(tid);
+        bool result = test<32, 32>(tid);
+        if (tid == 0)
+            outputBuffer[3] = result ? 1 : 0;
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -181,12 +201,14 @@ void computeMain(uint tid : SV_DispatchThreadID)
     {
         identityWeightMatrixTiled<64, 64, false>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<64, 64>(tid, 4);
+        bool result = test<64, 64>(tid);
+        if (tid == 0)
+            outputBuffer[4] = result ? 1 : 0;
     }
 
-    // BUFFER: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
+    // BUFFER: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
 }

--- a/tests/neural/mma-tiled-layout-test-multi-warps.slang
+++ b/tests/neural/mma-tiled-layout-test-multi-warps.slang
@@ -45,7 +45,7 @@ public struct TestShMemSize : ISharedMemorySize {
 static const uint OffsetA = 0;
 static const uint OffsetB = 256;
 
-bool testImpl<int InputSize, int OutputSize, TargetEnum Target>(uint tid)
+void testImpl<int InputSize, int OutputSize, TargetEnum Target>(uint tid, int resIndex)
 {
     static const int PaddedInputSize = PadToTargetTile<InputSize, Target>.Value;
     static const int PaddedOutputSize = PadToTargetTile<OutputSize, Target>.Value;
@@ -79,38 +79,38 @@ bool testImpl<int InputSize, int OutputSize, TargetEnum Target>(uint tid)
         }
     }
 
-    return collectResults<BatchSize>(tid, res);
+    bool finalResult = collectResults<BatchSize>(tid, res);
+    if (tid == 0)
+        outputBuffer[resIndex] = finalResult ? 1 : 0;
 }
 
-bool test<int InputSize, int OutputSize>(uint tid)
+void test<int InputSize, int OutputSize>(uint tid, int resIndex)
 {
     __target_switch
     {
     case cuda:
-        return testImpl<InputSize, OutputSize, TargetEnum.CUDA>(tid);
+        testImpl<InputSize, OutputSize, TargetEnum.CUDA>(tid, resIndex);
+        return;
     case spirv:
-        return testImpl<InputSize, OutputSize, TargetEnum.SPIR_V>(tid);
+        testImpl<InputSize, OutputSize, TargetEnum.SPIR_V>(tid, resIndex);
+        return;
     case metal:
-        return testImpl<InputSize, OutputSize, TargetEnum.Metal>(tid);
+        testImpl<InputSize, OutputSize, TargetEnum.Metal>(tid, resIndex);
+        return;
     }
 }
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
+void computeMain(uint tid : SV_GroupIndex)
 {
-    if (gid.x != 0)
-        return;
-
     initBias<DType, 64, BatchSize>(tid, buffers.biasBuffer);
 
     // 4x4 (target-padded)
     {
         identityWeightMatrixTiled<DType, 4, BatchSize, false>(tid, buffers.weightBuffer);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<4, 4>(tid);
-        if (tid == 0)
-            outputBuffer[0] = result ? 1 : 0;
+        test<4, 4>(tid, 0);
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -118,9 +118,7 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
     {
         identityWeightMatrixTiled<DType, 8, BatchSize, false>(tid, buffers.weightBuffer);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<8, 8>(tid);
-        if (tid == 0)
-            outputBuffer[1] = result ? 1 : 0;
+        test<8, 8>(tid, 1);
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -128,9 +126,7 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
     {
         identityWeightMatrixTiled<DType, 16, BatchSize, false>(tid, buffers.weightBuffer);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<16, 16>(tid);
-        if (tid == 0)
-            outputBuffer[2] = result ? 1 : 0;
+        test<16, 16>(tid, 2);
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -138,9 +134,7 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
     {
         identityWeightMatrixTiled<DType, 32, BatchSize, false>(tid, buffers.weightBuffer);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<32, 32>(tid);
-        if (tid == 0)
-            outputBuffer[3] = result ? 1 : 0;
+        test<32, 32>(tid, 3);
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -148,9 +142,7 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
     {
         identityWeightMatrixTiled<DType, 64, BatchSize, false>(tid, buffers.weightBuffer);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<64, 64>(tid);
-        if (tid == 0)
-            outputBuffer[4] = result ? 1 : 0;
+        test<64, 64>(tid, 4);
     }
 
     // BUFFER: {{^}}1{{$}}

--- a/tests/neural/mma-tiled-layout-test-multi-warps.slang
+++ b/tests/neural/mma-tiled-layout-test-multi-warps.slang
@@ -45,76 +45,10 @@ public struct TestShMemSize : ISharedMemorySize {
 static const uint OffsetA = 0;
 static const uint OffsetB = 256;
 
-// Clear the weight buffer region used by a PaddedSize x PaddedSize tiled matrix.
-void clearWeightBuffer<int PaddedSize>(uint tid)
+bool testImpl<int InputSize, int OutputSize, TargetEnum Target>(uint tid)
 {
-    static const int TotalElements = PaddedSize * PaddedSize;
-    static const int NumIters = (TotalElements + BatchSize - 1) / BatchSize;
-
-    for (int iter = 0; iter < NumIters; iter++)
-    {
-        int index = iter * BatchSize + tid;
-        if (index < TotalElements)
-            buffers.weightBuffer[index] = DType(0);
-    }
-}
-
-// Write an identity matrix in tiled layout.
-// Tiled layout addressing for element (row, col):
-//   tileRow   = row / 16
-//   tileCol   = col / 16
-//   NTileCols = PaddedSize / 16
-//   tileIndex = tileRow * NTileCols + tileCol
-//   offset    = tileIndex * 256 + (row % 16) * 16 + (col % 16)
-void identityWeightMatrixTiled<int InputSize, int PaddedSize, bool Clear>(uint tid)
-{
-    static const int TileSize = 16;
-    static const int NTileCols = PaddedSize / TileSize;
-
-    if (Clear)
-    {
-        clearWeightBuffer<PaddedSize>(tid);
-        return;
-    }
-
-    clearWeightBuffer<PaddedSize>(tid);
-    AllMemoryBarrierWithGroupSync();
-
-    __target_switch
-    {
-    case metal:
-        {
-            fillForwardWeightTiled<DType, InputSize, InputSize, BatchSize>(
-                tid, buffers.weightBuffer, DType(1.0f / float(InputSize)));
-        }
-    default:
-        {
-            static const int NumDiagIters = (InputSize + BatchSize - 1) / BatchSize;
-            for (int iter = 0; iter < NumDiagIters; iter++)
-            {
-                int row = iter * BatchSize + tid;
-                if (row >= InputSize)
-                    break;
-
-                int tileRow = row / TileSize;
-                int tileCol = row / TileSize;
-                int localRow = row % TileSize;
-                int localCol = row % TileSize;
-                int tileIndex = tileRow * NTileCols + tileCol;
-                int offset = tileIndex * TileSize * TileSize + localRow * TileSize + localCol;
-                buffers.weightBuffer[offset] = DType(1);
-            }
-
-            AllMemoryBarrierWithGroupSync();
-            convertTiledToNativeB<DType, PaddedSize, PaddedSize, BatchSize>(tid, buffers.weightBuffer);
-        }
-    }
-}
-
-bool test<int InputSize, int OutputSize>(uint tid)
-{
-    static const int PaddedInputSize = PadToTile<InputSize>.Value;
-    static const int PaddedOutputSize = PadToTile<OutputSize>.Value;
+    static const int PaddedInputSize = PadToTargetTile<InputSize, Target>.Value;
+    static const int PaddedOutputSize = PadToTargetTile<OutputSize, Target>.Value;
 
     typealias InputVec = WaveTangledVector<DType, TestShMemSize, PaddedInputSize, SubgroupSize, 2>;
     InputVec inputData = InputVec(DType(0));
@@ -148,6 +82,19 @@ bool test<int InputSize, int OutputSize>(uint tid)
     return collectResults<BatchSize>(tid, res);
 }
 
+bool test<int InputSize, int OutputSize>(uint tid)
+{
+    __target_switch
+    {
+    case cuda:
+        return testImpl<InputSize, OutputSize, TargetEnum.CUDA>(tid);
+    case spirv:
+        return testImpl<InputSize, OutputSize, TargetEnum.SPIR_V>(tid);
+    case metal:
+        return testImpl<InputSize, OutputSize, TargetEnum.Metal>(tid);
+    }
+}
+
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
 void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
@@ -157,9 +104,9 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
 
     initBias<DType, 64, BatchSize>(tid, buffers.biasBuffer);
 
-    // 4x4 (padded to 16x16)
+    // 4x4 (target-padded)
     {
-        identityWeightMatrixTiled<4, 16, false>(tid);
+        identityWeightMatrixTiled<DType, 4, BatchSize, false>(tid, buffers.weightBuffer);
         AllMemoryBarrierWithGroupSync();
         bool result = test<4, 4>(tid);
         if (tid == 0)
@@ -167,9 +114,9 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
         AllMemoryBarrierWithGroupSync();
     }
 
-    // 8x8 (padded to 16x16)
+    // 8x8 (target-padded)
     {
-        identityWeightMatrixTiled<8, 16, false>(tid);
+        identityWeightMatrixTiled<DType, 8, BatchSize, false>(tid, buffers.weightBuffer);
         AllMemoryBarrierWithGroupSync();
         bool result = test<8, 8>(tid);
         if (tid == 0)
@@ -177,9 +124,9 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
         AllMemoryBarrierWithGroupSync();
     }
 
-    // 16x16 (already aligned)
+    // 16x16 (target-padded)
     {
-        identityWeightMatrixTiled<16, 16, false>(tid);
+        identityWeightMatrixTiled<DType, 16, BatchSize, false>(tid, buffers.weightBuffer);
         AllMemoryBarrierWithGroupSync();
         bool result = test<16, 16>(tid);
         if (tid == 0)
@@ -187,9 +134,9 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
         AllMemoryBarrierWithGroupSync();
     }
 
-    // 32x32 (already aligned)
+    // 32x32 (target-padded)
     {
-        identityWeightMatrixTiled<32, 32, false>(tid);
+        identityWeightMatrixTiled<DType, 32, BatchSize, false>(tid, buffers.weightBuffer);
         AllMemoryBarrierWithGroupSync();
         bool result = test<32, 32>(tid);
         if (tid == 0)
@@ -197,9 +144,9 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
         AllMemoryBarrierWithGroupSync();
     }
 
-    // 64x64 (already aligned)
+    // 64x64 (target-padded)
     {
-        identityWeightMatrixTiled<64, 64, false>(tid);
+        identityWeightMatrixTiled<DType, 64, BatchSize, false>(tid, buffers.weightBuffer);
         AllMemoryBarrierWithGroupSync();
         bool result = test<64, 64>(tid);
         if (tid == 0)

--- a/tests/neural/mma-tiled-layout-test-single-warp-arbitrary-size.slang
+++ b/tests/neural/mma-tiled-layout-test-single-warp-arbitrary-size.slang
@@ -3,6 +3,11 @@
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=1
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=1 -xslang -DTEST_BIAS=1
 
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=0
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=1 -xslang -DTEST_BIAS=0
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=1
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=1 -xslang -DTEST_BIAS=1
+
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=0
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=1 -xslang -DTEST_BIAS=0
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=1
@@ -19,11 +24,15 @@ typealias DType = half;
 typealias DType = float;
 #endif
 
-// TEST_INPUT: set weightBuffer = ubuffer(data=[0], stride=4, count=4096)
-uniform RWStructuredBuffer<DType>.Handle weightBuffer;
+struct TestBuffers
+{
+    RWStructuredBuffer<DType>.Handle weightBuffer;
+    RWStructuredBuffer<DType>.Handle biasBuffer;
+}
 
-// TEST_INPUT: set biasBuffer = ubuffer(data=[0], stride=4, count=64)
-uniform RWStructuredBuffer<DType>.Handle biasBuffer;
+// TEST_INPUT: set buffers.weightBuffer = ubuffer(data=[0], stride=4, count=4096)
+// TEST_INPUT: set buffers.biasBuffer = ubuffer(data=[0], stride=4, count=64)
+ParameterBlock<TestBuffers> buffers;
 
 // TEST_INPUT:ubuffer(stride=4, count=5):out, name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
@@ -39,24 +48,25 @@ static const uint OffsetB = 256;
 
 void fillWeightMatrixTiled<int InputSize, int OutputSize>(uint tid)
 {
-    fillForwardWeightTiled<DType, InputSize, OutputSize, BatchSize>(tid, weightBuffer, DType(0.5));
+    fillForwardWeightTiled<DType, InputSize, OutputSize, BatchSize>(tid, buffers.weightBuffer, DType(0.5));
 }
 
-void test<int InputSize, int OutputSize>(uint tid, int resIndex)
+bool test<int InputSize, int OutputSize>(uint tid)
 {
     static const int PaddedInputSize = PadToTile<InputSize>.Value;
     static const int PaddedOutputSize = PadToTile<OutputSize>.Value;
 
-    DType inputData[InputSize];
+    typealias InputVec = WaveTangledVector<DType, TestShMemSize, PaddedInputSize, SubgroupSize, 1>;
+    InputVec inputData = InputVec(DType(0));
     for (int i = 0; i < InputSize; i++)
         inputData[i] = DType(tid + 1);
 
 #if TEST_BIAS
-    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, InputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, true, 1, false>(
-        inputData, weightBuffer, Optional<RWStructuredBuffer<DType>.Handle>(biasBuffer));
+    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, PaddedInputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, true, 1, false>(
+        inputData, buffers.weightBuffer, Optional<RWStructuredBuffer<DType>.Handle>(buffers.biasBuffer));
 #else
-    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, InputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, false, 1, false>(
-        inputData, weightBuffer, none);
+    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, PaddedInputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, false, 1, false>(
+        inputData, buffers.weightBuffer, none);
 #endif
 
     bool res = true;
@@ -71,62 +81,71 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
 #endif
             if (!equals(output[i], expected))
             {
-                if (tid == 0)
-                    printf("FAIL resIndex=%d i=%d expected=%f got=%f\n", resIndex, i, float(expected), float(output[i]));
                 res = false;
                 break;
             }
         }
     }
 
-    res = WaveActiveAllTrue(res);
-    if (tid == 0)
-        outputBuffer[resIndex] = res ? 1 : 0;
+    return WaveActiveAllTrue(res);
 }
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_DispatchThreadID)
+void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
 {
-    initBias<DType, 64, BatchSize>(tid, biasBuffer);
+    if (gid.x != 0)
+        return;
+
+    initBias<DType, 64, BatchSize>(tid, buffers.biasBuffer);
 
     // 3x5 (InputSize=3, OutputSize=5, padded to 16x16)
     {
         fillWeightMatrixTiled<3, 5>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<3, 5>(tid, 0);
+        bool result = test<3, 5>(tid);
+        if (tid == 0)
+            outputBuffer[0] = result ? 1 : 0;
     }
 
     // 11x18 (padded to 16x32)
     {
         fillWeightMatrixTiled<11, 18>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<11, 18>(tid, 1);
+        bool result = test<11, 18>(tid);
+        if (tid == 0)
+            outputBuffer[1] = result ? 1 : 0;
     }
 
     // 23x9 (padded to 32x16)
     {
         fillWeightMatrixTiled<23, 9>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<23, 9>(tid, 2);
+        bool result = test<23, 9>(tid);
+        if (tid == 0)
+            outputBuffer[2] = result ? 1 : 0;
     }
 
     // 35x3 (padded to 48x16)
     {
         fillWeightMatrixTiled<35, 3>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<35, 3>(tid, 3);
+        bool result = test<35, 3>(tid);
+        if (tid == 0)
+            outputBuffer[3] = result ? 1 : 0;
     }
 
     // 17x64 (padded to 32x64)
     {
         fillWeightMatrixTiled<17, 64>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<17, 64>(tid, 4);
+        bool result = test<17, 64>(tid);
+        if (tid == 0)
+            outputBuffer[4] = result ? 1 : 0;
     }
-    // BUFFER: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
+    // BUFFER: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
 }

--- a/tests/neural/mma-tiled-layout-test-single-warp-arbitrary-size.slang
+++ b/tests/neural/mma-tiled-layout-test-single-warp-arbitrary-size.slang
@@ -51,7 +51,7 @@ void fillWeightMatrixTiled<int InputSize, int OutputSize>(uint tid)
     fillForwardWeightTiled<DType, InputSize, OutputSize, BatchSize>(tid, buffers.weightBuffer, DType(0.5));
 }
 
-bool test<int InputSize, int OutputSize>(uint tid)
+void test<int InputSize, int OutputSize>(uint tid, int resIndex)
 {
     static const int PaddedInputSize = PadToTile<InputSize>.Value;
     static const int PaddedOutputSize = PadToTile<OutputSize>.Value;
@@ -87,61 +87,50 @@ bool test<int InputSize, int OutputSize>(uint tid)
         }
     }
 
-    return WaveActiveAllTrue(res);
+    res = WaveActiveAllTrue(res);
+    if (tid == 0)
+        outputBuffer[resIndex] = res ? 1 : 0;
 }
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
+void computeMain(uint tid : SV_GroupIndex)
 {
-    if (gid.x != 0)
-        return;
-
     initBias<DType, 64, BatchSize>(tid, buffers.biasBuffer);
 
     // 3x5 (InputSize=3, OutputSize=5, padded to 16x16)
     {
         fillWeightMatrixTiled<3, 5>(tid);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<3, 5>(tid);
-        if (tid == 0)
-            outputBuffer[0] = result ? 1 : 0;
+        test<3, 5>(tid, 0);
     }
 
     // 11x18 (padded to 16x32)
     {
         fillWeightMatrixTiled<11, 18>(tid);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<11, 18>(tid);
-        if (tid == 0)
-            outputBuffer[1] = result ? 1 : 0;
+        test<11, 18>(tid, 1);
     }
 
     // 23x9 (padded to 32x16)
     {
         fillWeightMatrixTiled<23, 9>(tid);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<23, 9>(tid);
-        if (tid == 0)
-            outputBuffer[2] = result ? 1 : 0;
+        test<23, 9>(tid, 2);
     }
 
     // 35x3 (padded to 48x16)
     {
         fillWeightMatrixTiled<35, 3>(tid);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<35, 3>(tid);
-        if (tid == 0)
-            outputBuffer[3] = result ? 1 : 0;
+        test<35, 3>(tid, 3);
     }
 
     // 17x64 (padded to 32x64)
     {
         fillWeightMatrixTiled<17, 64>(tid);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<17, 64>(tid);
-        if (tid == 0)
-            outputBuffer[4] = result ? 1 : 0;
+        test<17, 64>(tid, 4);
     }
     // BUFFER: {{^}}1{{$}}
     // BUFFER-NEXT: {{^}}1{{$}}

--- a/tests/neural/mma-tiled-layout-test-single-warp.slang
+++ b/tests/neural/mma-tiled-layout-test-single-warp.slang
@@ -3,6 +3,11 @@
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=1
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=1 -xslang -DTEST_BIAS=1
 
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=0
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=1 -xslang -DTEST_BIAS=0
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=1
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=1 -xslang -DTEST_BIAS=1
+
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=0
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=1 -xslang -DTEST_BIAS=0
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_BIAS=1
@@ -19,11 +24,15 @@ typealias DType = half;
 typealias DType = float;
 #endif
 
-// TEST_INPUT: set inputBuffer = ubuffer(stride=4, count=8192)
-uniform RWStructuredBuffer<DType>.Handle inputBuffer;
+struct TestBuffers
+{
+    RWStructuredBuffer<DType>.Handle inputBuffer;
+    RWStructuredBuffer<DType>.Handle biasBuffer;
+}
 
-// TEST_INPUT: set biasBuffer = ubuffer(stride=4, count=64)
-uniform RWStructuredBuffer<DType>.Handle biasBuffer;
+// TEST_INPUT: set buffers.inputBuffer = ubuffer(stride=4, count=8192)
+// TEST_INPUT: set buffers.biasBuffer = ubuffer(stride=4, count=64)
+ParameterBlock<TestBuffers> buffers;
 
 // TEST_INPUT:ubuffer(stride=4, count=5):out, name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
@@ -48,7 +57,7 @@ void clearWeightBuffer<int PaddedSize>(uint tid)
     {
         int index = iter * BatchSize + tid;
         if (index < TotalElements)
-            inputBuffer[index] = DType(0);
+            buffers.inputBuffer[index] = DType(0);
     }
 }
 
@@ -76,43 +85,54 @@ void identityWeightMatrixTiled<int InputSize, int PaddedSize>(uint tid, bool cle
     clearWeightBuffer<PaddedSize>(tid);
     AllMemoryBarrierWithGroupSync();
 
-    static const int NumDiagIters = (InputSize + BatchSize - 1) / BatchSize;
-
-    [ForceUnroll]
-    for (int iter = 0; iter < NumDiagIters; iter++)
+    __target_switch
     {
-        int row = iter * BatchSize + tid;
-        if (row >= InputSize)
-            break;
+    case metal:
+        {
+            fillForwardWeightTiled<DType, InputSize, InputSize, BatchSize>(
+                tid, buffers.inputBuffer, DType(1.0f / float(InputSize)));
+        }
+    default:
+        {
+            static const int NumDiagIters = (InputSize + BatchSize - 1) / BatchSize;
+            [ForceUnroll]
+            for (int iter = 0; iter < NumDiagIters; iter++)
+            {
+                int row = iter * BatchSize + tid;
+                if (row >= InputSize)
+                    break;
 
-        int tileRow = row / TileSize;
-        int tileCol = row / TileSize;
-        int localRow = row % TileSize;
-        int localCol = row % TileSize;
-        int tileIndex = tileRow * NTileCols + tileCol;
-        int offset = tileIndex * TileSize * TileSize + localRow * TileSize + localCol;
-        inputBuffer[offset] = DType(1);
+                int tileRow = row / TileSize;
+                int tileCol = row / TileSize;
+                int localRow = row % TileSize;
+                int localCol = row % TileSize;
+                int tileIndex = tileRow * NTileCols + tileCol;
+                int offset = tileIndex * TileSize * TileSize + localRow * TileSize + localCol;
+                buffers.inputBuffer[offset] = DType(1);
+            }
+
+            AllMemoryBarrierWithGroupSync();
+            convertTiledToNativeB<DType, PaddedSize, PaddedSize, BatchSize>(tid, buffers.inputBuffer);
+        }
     }
-
-    AllMemoryBarrierWithGroupSync();
-    convertTiledToNativeB<DType, PaddedSize, PaddedSize, BatchSize>(tid, inputBuffer);
 }
 
-void test<int InputSize, int OutputSize>(uint tid, int resIndex)
+bool test<int InputSize, int OutputSize>(uint tid)
 {
     static const int PaddedInputSize = PadToTile<InputSize>.Value;
     static const int PaddedOutputSize = PadToTile<OutputSize>.Value;
 
-    DType inputData[InputSize];
+    typealias InputVec = WaveTangledVector<DType, TestShMemSize, PaddedInputSize, SubgroupSize, 1>;
+    InputVec inputData = InputVec(DType(0));
     for (int i = 0; i < InputSize; i++)
         inputData[i] = DType(tid + 1);
 
 #if TEST_BIAS
-    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, InputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, true, 1, false>(
-        inputData, inputBuffer, Optional<RWStructuredBuffer<DType>.Handle>(biasBuffer));
+    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, PaddedInputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, true, 1, false>(
+        inputData, buffers.inputBuffer, Optional<RWStructuredBuffer<DType>.Handle>(buffers.biasBuffer));
 #else
-    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, InputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, false, 1, false>(
-        inputData, inputBuffer, none);
+    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, PaddedInputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, false, 1, false>(
+        inputData, buffers.inputBuffer, none);
 #endif
 
     bool res = true;
@@ -130,23 +150,25 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
         }
     }
 
-    res = WaveActiveAllTrue(res);
-    if (tid == 0)
-        outputBuffer[resIndex] = res ? 1 : 0;
+    return WaveActiveAllTrue(res);
 }
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_DispatchThreadID)
+void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
 {
-    initBias<DType, 64, BatchSize>(tid, biasBuffer);
+    if (gid.x != 0)
+        return;
+
+    initBias<DType, 64, BatchSize>(tid, buffers.biasBuffer);
 
     // 4x4 (padded to 16x16)
     {
         identityWeightMatrixTiled<4, 16>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<4, 4>(tid, 0);
-        identityWeightMatrixTiled<4, 16>(tid, true);
+        bool result = test<4, 4>(tid);
+        if (tid == 0)
+            outputBuffer[0] = result ? 1 : 0;
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -154,8 +176,9 @@ void computeMain(uint tid : SV_DispatchThreadID)
     {
         identityWeightMatrixTiled<8, 16>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<8, 8>(tid, 1);
-        identityWeightMatrixTiled<8, 16>(tid, true);
+        bool result = test<8, 8>(tid);
+        if (tid == 0)
+            outputBuffer[1] = result ? 1 : 0;
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -163,8 +186,9 @@ void computeMain(uint tid : SV_DispatchThreadID)
     {
         identityWeightMatrixTiled<16, 16>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<16, 16>(tid, 2);
-        identityWeightMatrixTiled<16, 16>(tid, true);
+        bool result = test<16, 16>(tid);
+        if (tid == 0)
+            outputBuffer[2] = result ? 1 : 0;
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -172,8 +196,9 @@ void computeMain(uint tid : SV_DispatchThreadID)
     {
         identityWeightMatrixTiled<32, 32>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<32, 32>(tid, 3);
-        identityWeightMatrixTiled<32, 32>(tid, true);
+        bool result = test<32, 32>(tid);
+        if (tid == 0)
+            outputBuffer[3] = result ? 1 : 0;
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -181,15 +206,16 @@ void computeMain(uint tid : SV_DispatchThreadID)
     {
         identityWeightMatrixTiled<64, 64>(tid);
         AllMemoryBarrierWithGroupSync();
-        test<64, 64>(tid, 4);
-        identityWeightMatrixTiled<64, 64>(tid, true);
+        bool result = test<64, 64>(tid);
+        if (tid == 0)
+            outputBuffer[4] = result ? 1 : 0;
         AllMemoryBarrierWithGroupSync();
     }
 
-    // BUFFER: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
+    // BUFFER: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
 }
 //

--- a/tests/neural/mma-tiled-layout-test-single-warp.slang
+++ b/tests/neural/mma-tiled-layout-test-single-warp.slang
@@ -46,7 +46,7 @@ public struct TestShMemSize : ISharedMemorySize {
 static const uint OffsetA = 0;
 static const uint OffsetB = 256;
 
-bool testImpl<int InputSize, int OutputSize, TargetEnum Target>(uint tid)
+void testImpl<int InputSize, int OutputSize, TargetEnum Target>(uint tid, int resIndex)
 {
     static const int PaddedInputSize = PadToTargetTile<InputSize, Target>.Value;
     static const int PaddedOutputSize = PadToTargetTile<OutputSize, Target>.Value;
@@ -79,38 +79,38 @@ bool testImpl<int InputSize, int OutputSize, TargetEnum Target>(uint tid)
         }
     }
 
-    return WaveActiveAllTrue(res);
+    res = WaveActiveAllTrue(res);
+    if (tid == 0)
+        outputBuffer[resIndex] = res ? 1 : 0;
 }
 
-bool test<int InputSize, int OutputSize>(uint tid)
+void test<int InputSize, int OutputSize>(uint tid, int resIndex)
 {
     __target_switch
     {
     case cuda:
-        return testImpl<InputSize, OutputSize, TargetEnum.CUDA>(tid);
+        testImpl<InputSize, OutputSize, TargetEnum.CUDA>(tid, resIndex);
+        return;
     case spirv:
-        return testImpl<InputSize, OutputSize, TargetEnum.SPIR_V>(tid);
+        testImpl<InputSize, OutputSize, TargetEnum.SPIR_V>(tid, resIndex);
+        return;
     case metal:
-        return testImpl<InputSize, OutputSize, TargetEnum.Metal>(tid);
+        testImpl<InputSize, OutputSize, TargetEnum.Metal>(tid, resIndex);
+        return;
     }
 }
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
+void computeMain(uint tid : SV_GroupIndex)
 {
-    if (gid.x != 0)
-        return;
-
     initBias<DType, 64, BatchSize>(tid, buffers.biasBuffer);
 
     // 4x4 (target-padded)
     {
         identityWeightMatrixTiled<DType, 4, BatchSize, false>(tid, buffers.inputBuffer);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<4, 4>(tid);
-        if (tid == 0)
-            outputBuffer[0] = result ? 1 : 0;
+        test<4, 4>(tid, 0);
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -118,9 +118,7 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
     {
         identityWeightMatrixTiled<DType, 8, BatchSize, false>(tid, buffers.inputBuffer);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<8, 8>(tid);
-        if (tid == 0)
-            outputBuffer[1] = result ? 1 : 0;
+        test<8, 8>(tid, 1);
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -128,9 +126,7 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
     {
         identityWeightMatrixTiled<DType, 16, BatchSize, false>(tid, buffers.inputBuffer);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<16, 16>(tid);
-        if (tid == 0)
-            outputBuffer[2] = result ? 1 : 0;
+        test<16, 16>(tid, 2);
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -138,9 +134,7 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
     {
         identityWeightMatrixTiled<DType, 32, BatchSize, false>(tid, buffers.inputBuffer);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<32, 32>(tid);
-        if (tid == 0)
-            outputBuffer[3] = result ? 1 : 0;
+        test<32, 32>(tid, 3);
         AllMemoryBarrierWithGroupSync();
     }
 
@@ -148,9 +142,7 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
     {
         identityWeightMatrixTiled<DType, 64, BatchSize, false>(tid, buffers.inputBuffer);
         AllMemoryBarrierWithGroupSync();
-        bool result = test<64, 64>(tid);
-        if (tid == 0)
-            outputBuffer[4] = result ? 1 : 0;
+        test<64, 64>(tid, 4);
         AllMemoryBarrierWithGroupSync();
     }
 

--- a/tests/neural/mma-tiled-layout-test-single-warp.slang
+++ b/tests/neural/mma-tiled-layout-test-single-warp.slang
@@ -46,81 +46,10 @@ public struct TestShMemSize : ISharedMemorySize {
 static const uint OffsetA = 0;
 static const uint OffsetB = 256;
 
-// Clear the weight buffer region used by a PaddedSize x PaddedSize tiled matrix.
-void clearWeightBuffer<int PaddedSize>(uint tid)
+bool testImpl<int InputSize, int OutputSize, TargetEnum Target>(uint tid)
 {
-    static const int TotalElements = PaddedSize * PaddedSize;
-    static const int NumIters = (TotalElements + BatchSize - 1) / BatchSize;
-
-    [ForceUnroll]
-    for (int iter = 0; iter < NumIters; iter++)
-    {
-        int index = iter * BatchSize + tid;
-        if (index < TotalElements)
-            buffers.inputBuffer[index] = DType(0);
-    }
-}
-
-// Write an identity matrix in tiled layout.
-// The weight matrix is PaddedSize x PaddedSize (both multiples of 16),
-// but only the top-left InputSize x InputSize has the identity.
-//
-// Tiled layout addressing for element (row, col):
-//   tileRow   = row / 16
-//   tileCol   = col / 16
-//   NTileCols = PaddedSize / 16
-//   tileIndex = tileRow * NTileCols + tileCol
-//   offset    = tileIndex * 256 + (row % 16) * 16 + (col % 16)
-void identityWeightMatrixTiled<int InputSize, int PaddedSize>(uint tid, bool clear = false)
-{
-    static const int TileSize = 16;
-    static const int NTileCols = PaddedSize / TileSize;
-
-    if (clear)
-    {
-        clearWeightBuffer<PaddedSize>(tid);
-        return;
-    }
-
-    clearWeightBuffer<PaddedSize>(tid);
-    AllMemoryBarrierWithGroupSync();
-
-    __target_switch
-    {
-    case metal:
-        {
-            fillForwardWeightTiled<DType, InputSize, InputSize, BatchSize>(
-                tid, buffers.inputBuffer, DType(1.0f / float(InputSize)));
-        }
-    default:
-        {
-            static const int NumDiagIters = (InputSize + BatchSize - 1) / BatchSize;
-            [ForceUnroll]
-            for (int iter = 0; iter < NumDiagIters; iter++)
-            {
-                int row = iter * BatchSize + tid;
-                if (row >= InputSize)
-                    break;
-
-                int tileRow = row / TileSize;
-                int tileCol = row / TileSize;
-                int localRow = row % TileSize;
-                int localCol = row % TileSize;
-                int tileIndex = tileRow * NTileCols + tileCol;
-                int offset = tileIndex * TileSize * TileSize + localRow * TileSize + localCol;
-                buffers.inputBuffer[offset] = DType(1);
-            }
-
-            AllMemoryBarrierWithGroupSync();
-            convertTiledToNativeB<DType, PaddedSize, PaddedSize, BatchSize>(tid, buffers.inputBuffer);
-        }
-    }
-}
-
-bool test<int InputSize, int OutputSize>(uint tid)
-{
-    static const int PaddedInputSize = PadToTile<InputSize>.Value;
-    static const int PaddedOutputSize = PadToTile<OutputSize>.Value;
+    static const int PaddedInputSize = PadToTargetTile<InputSize, Target>.Value;
+    static const int PaddedOutputSize = PadToTargetTile<OutputSize, Target>.Value;
 
     typealias InputVec = WaveTangledVector<DType, TestShMemSize, PaddedInputSize, SubgroupSize, 1>;
     InputVec inputData = InputVec(DType(0));
@@ -153,6 +82,19 @@ bool test<int InputSize, int OutputSize>(uint tid)
     return WaveActiveAllTrue(res);
 }
 
+bool test<int InputSize, int OutputSize>(uint tid)
+{
+    __target_switch
+    {
+    case cuda:
+        return testImpl<InputSize, OutputSize, TargetEnum.CUDA>(tid);
+    case spirv:
+        return testImpl<InputSize, OutputSize, TargetEnum.SPIR_V>(tid);
+    case metal:
+        return testImpl<InputSize, OutputSize, TargetEnum.Metal>(tid);
+    }
+}
+
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
 void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
@@ -162,9 +104,9 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
 
     initBias<DType, 64, BatchSize>(tid, buffers.biasBuffer);
 
-    // 4x4 (padded to 16x16)
+    // 4x4 (target-padded)
     {
-        identityWeightMatrixTiled<4, 16>(tid);
+        identityWeightMatrixTiled<DType, 4, BatchSize, false>(tid, buffers.inputBuffer);
         AllMemoryBarrierWithGroupSync();
         bool result = test<4, 4>(tid);
         if (tid == 0)
@@ -172,9 +114,9 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
         AllMemoryBarrierWithGroupSync();
     }
 
-    // 8x8 (padded to 16x16)
+    // 8x8 (target-padded)
     {
-        identityWeightMatrixTiled<8, 16>(tid);
+        identityWeightMatrixTiled<DType, 8, BatchSize, false>(tid, buffers.inputBuffer);
         AllMemoryBarrierWithGroupSync();
         bool result = test<8, 8>(tid);
         if (tid == 0)
@@ -182,9 +124,9 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
         AllMemoryBarrierWithGroupSync();
     }
 
-    // 16x16 (already aligned)
+    // 16x16 (target-padded)
     {
-        identityWeightMatrixTiled<16, 16>(tid);
+        identityWeightMatrixTiled<DType, 16, BatchSize, false>(tid, buffers.inputBuffer);
         AllMemoryBarrierWithGroupSync();
         bool result = test<16, 16>(tid);
         if (tid == 0)
@@ -192,9 +134,9 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
         AllMemoryBarrierWithGroupSync();
     }
 
-    // 32x32 (already aligned)
+    // 32x32 (target-padded)
     {
-        identityWeightMatrixTiled<32, 32>(tid);
+        identityWeightMatrixTiled<DType, 32, BatchSize, false>(tid, buffers.inputBuffer);
         AllMemoryBarrierWithGroupSync();
         bool result = test<32, 32>(tid);
         if (tid == 0)
@@ -202,9 +144,9 @@ void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
         AllMemoryBarrierWithGroupSync();
     }
 
-    // 64x64 (already aligned)
+    // 64x64 (target-padded)
     {
-        identityWeightMatrixTiled<64, 64>(tid);
+        identityWeightMatrixTiled<DType, 64, BatchSize, false>(tid, buffers.inputBuffer);
         AllMemoryBarrierWithGroupSync();
         bool result = test<64, 64>(tid);
         if (tid == 0)

--- a/tests/neural/mma-tiled-layout-test-transpose-multi-warps-arbitrary-size.slang
+++ b/tests/neural/mma-tiled-layout-test-transpose-multi-warps-arbitrary-size.slang
@@ -4,6 +4,9 @@
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=0
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=1
 
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=1
+
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=0
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=1
 
@@ -42,19 +45,20 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
     static const int PaddedInputSize = PadToTile<InputSize>.Value;
     static const int PaddedOutputSize = PadToTile<OutputSize>.Value;
 
-    DType inputData[OutputSize];
+    typealias InputVec = WaveTangledVector<DType, TestShMemSize, PaddedOutputSize, SubgroupSize, 2>;
+    InputVec inputData = InputVec(DType(0));
+    DType inputValue = DType(WaveGetLaneIndex() + 1 + tid / 32);
     for (int i = 0; i < OutputSize; i++)
-        inputData[i] = DType(tid + 1);
+        inputData[i] = inputValue;
 
-    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, OutputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, false, 2, true>(
+    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, PaddedOutputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, false, 2, true>(
         inputData, inputBuffer, none);
 
     bool res = true;
     int scaleFactor = (OutputSize % 3 == 0) ? 0 : -1;
     for (int i = 0; i < InputSize; i++)
     {
-        int intVal = (i + 1) * (tid + 1);
-        DType expected = DType(scaleFactor) * DType(intVal);
+        DType expected = DType(scaleFactor) * DType(i + 1) * inputValue;
         if (!equals(output[i], expected))
         {
             res = false;
@@ -69,8 +73,11 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_DispatchThreadID)
+void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
 {
+    if (gid.x != 0)
+        return;
+
     {
         fillWeightMatrixTiled<3, 5, 16, 16, false>(tid);
         AllMemoryBarrierWithGroupSync();
@@ -101,9 +108,9 @@ void computeMain(uint tid : SV_DispatchThreadID)
         test<17, 64>(tid, 4);
     }
 
-    // BUFFER: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
+    // BUFFER: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
 }

--- a/tests/neural/mma-tiled-layout-test-transpose-multi-warps-arbitrary-size.slang
+++ b/tests/neural/mma-tiled-layout-test-transpose-multi-warps-arbitrary-size.slang
@@ -73,11 +73,8 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
+void computeMain(uint tid : SV_GroupIndex)
 {
-    if (gid.x != 0)
-        return;
-
     {
         fillWeightMatrixTiled<3, 5, 16, 16, false>(tid);
         AllMemoryBarrierWithGroupSync();

--- a/tests/neural/mma-tiled-layout-test-transpose-multi-warps.slang
+++ b/tests/neural/mma-tiled-layout-test-transpose-multi-warps.slang
@@ -4,6 +4,9 @@
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=0
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=1
 
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=1
+
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=0
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=1
 
@@ -42,11 +45,12 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
     static const int PaddedInputSize = PadToTile<InputSize>.Value;
     static const int PaddedOutputSize = PadToTile<OutputSize>.Value;
 
-    DType inputData[OutputSize];
+    typealias InputVec = WaveTangledVector<DType, TestShMemSize, PaddedOutputSize, SubgroupSize, 2>;
+    InputVec inputData = InputVec(DType(0));
     for (int i = 0; i < OutputSize; i++)
         inputData[i] = DType(tid + 1);
 
-    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, OutputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, false, 2, true>(
+    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, PaddedOutputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, false, 2, true>(
         inputData, inputBuffer, none);
 
     bool res = true;
@@ -69,8 +73,11 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_DispatchThreadID)
+void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
 {
+    if (gid.x != 0)
+        return;
+
     {
         fillWeightMatrixTiled<16, 16, 16, 16, false>(tid);
         AllMemoryBarrierWithGroupSync();
@@ -95,7 +102,7 @@ void computeMain(uint tid : SV_DispatchThreadID)
         AllMemoryBarrierWithGroupSync();
     }
 
-    // BUFFER: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
+    // BUFFER: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
 }

--- a/tests/neural/mma-tiled-layout-test-transpose-multi-warps.slang
+++ b/tests/neural/mma-tiled-layout-test-transpose-multi-warps.slang
@@ -73,11 +73,8 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
+void computeMain(uint tid : SV_GroupIndex)
 {
-    if (gid.x != 0)
-        return;
-
     {
         fillWeightMatrixTiled<16, 16, 16, 16, false>(tid);
         AllMemoryBarrierWithGroupSync();

--- a/tests/neural/mma-tiled-layout-test-transpose-single-warp-arbitrary-size.slang
+++ b/tests/neural/mma-tiled-layout-test-transpose-single-warp-arbitrary-size.slang
@@ -4,6 +4,9 @@
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=0
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=1
 
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=1
+
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=0
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=1
 
@@ -42,11 +45,12 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
     static const int PaddedInputSize = PadToTile<InputSize>.Value;
     static const int PaddedOutputSize = PadToTile<OutputSize>.Value;
 
-    DType inputData[OutputSize];
+    typealias InputVec = WaveTangledVector<DType, TestShMemSize, PaddedOutputSize, SubgroupSize, 1>;
+    InputVec inputData = InputVec(DType(0));
     for (int i = 0; i < OutputSize; i++)
         inputData[i] = DType(tid + 1);
 
-    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, OutputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, false, 1, true>(
+    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, PaddedOutputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, false, 1, true>(
         inputData, inputBuffer, none);
 
     bool res = true;
@@ -68,8 +72,11 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_DispatchThreadID)
+void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
 {
+    if (gid.x != 0)
+        return;
+
     {
         fillWeightMatrixTiled<3, 5, 16, 16, false>(tid);
         AllMemoryBarrierWithGroupSync();
@@ -110,9 +117,9 @@ void computeMain(uint tid : SV_DispatchThreadID)
         AllMemoryBarrierWithGroupSync();
     }
 
-    // BUFFER: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
+    // BUFFER: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
 }

--- a/tests/neural/mma-tiled-layout-test-transpose-single-warp-arbitrary-size.slang
+++ b/tests/neural/mma-tiled-layout-test-transpose-single-warp-arbitrary-size.slang
@@ -72,11 +72,8 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
+void computeMain(uint tid : SV_GroupIndex)
 {
-    if (gid.x != 0)
-        return;
-
     {
         fillWeightMatrixTiled<3, 5, 16, 16, false>(tid);
         AllMemoryBarrierWithGroupSync();

--- a/tests/neural/mma-tiled-layout-test-transpose-single-warp.slang
+++ b/tests/neural/mma-tiled-layout-test-transpose-single-warp.slang
@@ -5,6 +5,9 @@
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=0
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=1
 
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=1
+
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=0
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_8_0  -xslang -experimental-feature -xslang -DTEST_HALF=1
 
@@ -43,11 +46,12 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
     static const int PaddedInputSize = PadToTile<InputSize>.Value;
     static const int PaddedOutputSize = PadToTile<OutputSize>.Value;
 
-    DType inputData[OutputSize];
+    typealias InputVec = WaveTangledVector<DType, TestShMemSize, PaddedOutputSize, SubgroupSize, 1>;
+    InputVec inputData = InputVec(DType(0));
     for (int i = 0; i < OutputSize; i++)
         inputData[i] = DType(tid + 1);
 
-    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, OutputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, false, 1, true>(
+    let output = neural_unittest.testTiledMatVecMul<DType, InputSize, OutputSize, PaddedOutputSize, PaddedInputSize, PaddedOutputSize, TestShMemSize, false, 1, true>(
         inputData, inputBuffer, none);
 
     bool res = true;
@@ -69,8 +73,11 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_DispatchThreadID)
+void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
 {
+    if (gid.x != 0)
+        return;
+
     {
         fillWeightMatrixTiled<16, 16, 16, 16, false>(tid);
         AllMemoryBarrierWithGroupSync();
@@ -95,7 +102,7 @@ void computeMain(uint tid : SV_DispatchThreadID)
         AllMemoryBarrierWithGroupSync();
     }
 
-    // BUFFER: 1
-    // BUFFER-NEXT: 1
-    // BUFFER-NEXT: 1
+    // BUFFER: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
+    // BUFFER-NEXT: {{^}}1{{$}}
 }

--- a/tests/neural/mma-tiled-layout-test-transpose-single-warp.slang
+++ b/tests/neural/mma-tiled-layout-test-transpose-single-warp.slang
@@ -73,11 +73,8 @@ void test<int InputSize, int OutputSize>(uint tid, int resIndex)
 
 [numthreads(BatchSize, 1, 1)]
 [shader("compute")]
-void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
+void computeMain(uint tid : SV_GroupIndex)
 {
-    if (gid.x != 0)
-        return;
-
     {
         fillWeightMatrixTiled<16, 16, 16, 16, false>(tid);
         AllMemoryBarrierWithGroupSync();

--- a/tests/neural/outerproduct-accumulate-tiled-test-arbitrary-size.slang
+++ b/tests/neural/outerproduct-accumulate-tiled-test-arbitrary-size.slang
@@ -5,6 +5,8 @@
 
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=0
 
+//TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_METAL=1
+
 //TEST:SIMPLE(filecheck=SPV): -target spirv -entry computeMain -stage compute -DTEST_HALF=1 -experimental-feature
 
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -xslang -experimental-feature -xslang -DTEST_HALF=0
@@ -13,6 +15,10 @@
 #pragma warning(disable: 41017)
 import slang.neural;
 import common;
+
+#ifndef TEST_METAL
+#define TEST_METAL 0
+#endif
 
 // TEST_INPUT: ubuffer(data=[0 0 0 0], stride=4, count=4):out, name=resultBuffer
 RWStructuredBuffer<uint> resultBuffer;
@@ -38,7 +44,11 @@ static const int TotalShMemSizeA = ShMemSizeA * workgroupCount;
 static const int TotalShMemSizeB = ShMemSizeB * workgroupCount * (sizeof(DType) / sizeof(half));
 
 public struct TestShMemSize : ISharedMemorySize {
+#if TEST_METAL
+    public static const uint Bytes = 32768;
+#else
     public static const uint Bytes = (TotalShMemSizeA + TotalShMemSizeB) * sizeof(uint4);
+#endif
 }
 
 static const int TileSize = 16;
@@ -71,7 +81,15 @@ void test<int InputSize, int OutputSize>(uint tid, uint resIndex)
 
     neural_unittest.testOuterProductAccumulateTiled<DType, PaddedInputSize, PaddedOutputSize, TestShMemSize, workgroupCount>(inputData, dOutData, outputBuffer);
 
-    convertNativeToRowMajorTiled<DType, PaddedOutputSize, PaddedInputSize, WorkgroupSize>(tid, outputBuffer);
+    __target_switch
+    {
+    case cuda:
+        convertNativeToRowMajorTiled<DType, PaddedOutputSize, PaddedInputSize, WorkgroupSize>(tid, outputBuffer);
+    case spirv:
+        convertNativeToRowMajorTiled<DType, PaddedOutputSize, PaddedInputSize, WorkgroupSize>(tid, outputBuffer);
+    case metal:
+        {}
+    }
 
     int subgroupIndex = tid / SubgroupSize;
     if (subgroupIndex != 0)
@@ -98,11 +116,19 @@ void test<int InputSize, int OutputSize>(uint tid, uint resIndex)
         for (int j = 0; j < InputSize; j++)
         {
             DType expected = DType(startVal * scaleFactor * (j + 1));
-            DType actual = outputBuffer[tiledOffset<NTileCols>(rowIdx, j)];
+            DType actual;
+            __target_switch
+            {
+            case cuda:
+                actual = outputBuffer[tiledOffset<NTileCols>(rowIdx, j)];
+            case spirv:
+                actual = outputBuffer[tiledOffset<NTileCols>(rowIdx, j)];
+            case metal:
+                actual = outputBuffer[rowIdx * PaddedInputSize + j];
+            }
             if (abs(expected - actual) > errorThreshold)
             {
                 res = false;
-                printf("tid: %d, rowIdx: %d, j: %d, expected: %.4f, actual: %.4f\n", tid, rowIdx, j, float(expected), float(actual));
                 break;
             }
         }
@@ -121,15 +147,18 @@ void clearTiledBuffer<int PaddedSize, int WorkgroupSize>(uint tid)
 
 [shader("compute")]
 [numthreads(WorkgroupSize, 1, 1)]
-void computeMain(uint tid : SV_DispatchThreadID)
+void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
 {
+    if (gid.x != 0)
+        return;
+
     // 3x15 → padded to 16x16
     {
         clearTiledBuffer<16, WorkgroupSize>(tid);
         test<3, 15>(tid, 0);
         AllMemoryBarrierWithGroupSync();
     }
-    // BUFFER: 1
+    // BUFFER: {{^}}1{{$}}
 
     // 20x30 → padded to 32x32
     {
@@ -137,7 +166,7 @@ void computeMain(uint tid : SV_DispatchThreadID)
         test<20, 30>(tid, 1);
         AllMemoryBarrierWithGroupSync();
     }
-    // BUFFER-NEXT: 1
+    // BUFFER-NEXT: {{^}}1{{$}}
 
     // 49x17 → padded to 64x32
     {
@@ -145,7 +174,7 @@ void computeMain(uint tid : SV_DispatchThreadID)
         test<49, 17>(tid, 2);
         AllMemoryBarrierWithGroupSync();
     }
-    // BUFFER-NEXT: 1
+    // BUFFER-NEXT: {{^}}1{{$}}
 
     // 33x9 → padded to 48x16
     {
@@ -153,7 +182,7 @@ void computeMain(uint tid : SV_DispatchThreadID)
         test<33, 9>(tid, 3);
         AllMemoryBarrierWithGroupSync();
     }
-    // BUFFER-NEXT: 1
+    // BUFFER-NEXT: {{^}}1{{$}}
 }
 
 //SPV: OpEntryPoint

--- a/tests/neural/outerproduct-accumulate-tiled-test-arbitrary-size.slang
+++ b/tests/neural/outerproduct-accumulate-tiled-test-arbitrary-size.slang
@@ -58,10 +58,14 @@ void test<int InputSize, int OutputSize>(uint tid, uint resIndex)
     static const int PaddedOutputSize = PadToTile<OutputSize>.Value;
 
     float sf = 1.0f / float(WorkgroupSize);
-    DType inputData[PaddedInputSize];
+    typealias InputVec = WaveTangledVector<DType, TestShMemSize, PaddedInputSize, SubgroupSize, workgroupCount>;
+    typealias DOutVec = WaveTangledVector<DType, TestShMemSize, PaddedOutputSize, SubgroupSize, workgroupCount>;
+
+    InputVec inputData;
     for (int i = 0; i < PaddedInputSize; i++)
         inputData[i] = DType((i + 1) * (tid + 1) * sf);
-    DType dOutData[PaddedOutputSize];
+
+    DOutVec dOutData;
     for (int i = 0; i < PaddedOutputSize; i++)
         dOutData[i] = DType((PaddedOutputSize - i) * sf);
 

--- a/tests/neural/outerproduct-accumulate-tiled-test-arbitrary-size.slang
+++ b/tests/neural/outerproduct-accumulate-tiled-test-arbitrary-size.slang
@@ -147,11 +147,8 @@ void clearTiledBuffer<int PaddedSize, int WorkgroupSize>(uint tid)
 
 [shader("compute")]
 [numthreads(WorkgroupSize, 1, 1)]
-void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
+void computeMain(uint tid : SV_GroupIndex)
 {
-    if (gid.x != 0)
-        return;
-
     // 3x15 → padded to 16x16
     {
         clearTiledBuffer<16, WorkgroupSize>(tid);

--- a/tests/neural/outerproduct-accumulate-tiled-test.slang
+++ b/tests/neural/outerproduct-accumulate-tiled-test.slang
@@ -8,9 +8,9 @@
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=32
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=64
 
-// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=16
-// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=32
-// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=64
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=16 -xslang -DTEST_METAL=1
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=32 -xslang -DTEST_METAL=1
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=64 -xslang -DTEST_METAL=1
 
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=16
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=32
@@ -23,6 +23,10 @@
 #pragma warning(disable: 41017)
 import slang.neural;
 import common;
+
+#ifndef TEST_METAL
+#define TEST_METAL 0
+#endif
 
 // TEST_INPUT: ubuffer(data=[0], stride=4, count=1):out, name=resultBuffer
 RWStructuredBuffer<uint> resultBuffer;
@@ -48,7 +52,11 @@ static const int TotalShMemSizeA = ShMemSizeA * workgroupCount;
 static const int TotalShMemSizeB = ShMemSizeB * workgroupCount * sizeof(DType)/sizeof(half);
 
 public struct TestShMemSize : ISharedMemorySize {
+#if TEST_METAL
+    public static const uint Bytes = 32768;
+#else
     public static const uint Bytes = (TotalShMemSizeA + TotalShMemSizeB) * sizeof(uint4);
+#endif
 }
 
 static const int TileSize = 16;
@@ -138,9 +146,12 @@ void test<int InputSize, int OutputSize>(uint tid, uint resIndex)
 
 [shader("compute")]
 [numthreads(WorkgroupSize, 1, 1)]
-void computeMain(uint tid : SV_DispatchThreadID)
+void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
 {
+    if (gid.x != 0)
+        return;
+
     setBufferOneValue<TEST_SIZE * TEST_SIZE, WorkgroupSize>(tid, outputBuffer, DType(0.0f));
     test<TEST_SIZE, TEST_SIZE>(tid, 0);
-    // BUFFER: 1
+    // BUFFER: {{^}}1{{$}}
 }

--- a/tests/neural/outerproduct-accumulate-tiled-test.slang
+++ b/tests/neural/outerproduct-accumulate-tiled-test.slang
@@ -1,11 +1,16 @@
 
-// Tiled-layout outerProductAccumulate test (TiledMMAHelper path).
-// Result is stored in 16x16 tiled layout instead of linear row-major.
+// Tiled outerProductAccumulate test (TiledMMAHelper path).
+// CUDA/Vulkan store in 16x16 tiled layout and are converted before checking.
+// Metal stores the row-major layout used by TiledMMAMetal.
 // Sizes must be multiples of 16.
 
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=16
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=32
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=64
+
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=16
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=32
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -xslang -experimental-feature -output-using-type -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=64
 
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=16
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -xslang -experimental-feature -xslang -DTEST_HALF=0 -xslang -DTEST_SIZE=32
@@ -60,16 +65,28 @@ int tiledOffset<int NTileCols>(int row, int col)
 void test<int InputSize, int OutputSize>(uint tid, uint resIndex)
 {
     float sf = 1.0f / float(WorkgroupSize);
-    DType inputData[InputSize];
+    typealias InputVec = WaveTangledVector<DType, TestShMemSize, InputSize, SubgroupSize, workgroupCount>;
+    typealias DOutVec = WaveTangledVector<DType, TestShMemSize, OutputSize, SubgroupSize, workgroupCount>;
+
+    InputVec inputData;
     for (int i = 0; i < InputSize; i++)
         inputData[i] = DType((i + 1) * (tid + 1) * sf);
-    DType dOutData[OutputSize];
+
+    DOutVec dOutData;
     for (int i = 0; i < OutputSize; i++)
         dOutData[i] = DType((OutputSize - i) * sf);
 
     neural_unittest.testOuterProductAccumulateTiled<DType, InputSize, OutputSize, TestShMemSize, workgroupCount>(inputData, dOutData, outputBuffer);
 
-    convertNativeToRowMajorTiled<DType, OutputSize, InputSize, WorkgroupSize>(tid, outputBuffer);
+    __target_switch
+    {
+    case cuda:
+        convertNativeToRowMajorTiled<DType, OutputSize, InputSize, WorkgroupSize>(tid, outputBuffer);
+    case spirv:
+        convertNativeToRowMajorTiled<DType, OutputSize, InputSize, WorkgroupSize>(tid, outputBuffer);
+    case metal:
+        {}
+    }
 
     int subgroupIndex = tid / SubgroupSize;
     if (subgroupIndex != 0)
@@ -96,7 +113,16 @@ void test<int InputSize, int OutputSize>(uint tid, uint resIndex)
         for (int j = 0; j < InputSize; j++)
         {
             DType expected = DType(startVal * scaleFactor * (j + 1));
-            DType actual = outputBuffer[tiledOffset<NTileCols>(rowIdx, j)];
+            DType actual;
+            __target_switch
+            {
+            case cuda:
+                actual = outputBuffer[tiledOffset<NTileCols>(rowIdx, j)];
+            case spirv:
+                actual = outputBuffer[tiledOffset<NTileCols>(rowIdx, j)];
+            case metal:
+                actual = outputBuffer[rowIdx * InputSize + j];
+            }
             if (abs(expected - actual) > errorThreshold)
             {
                 res = false;

--- a/tests/neural/outerproduct-accumulate-tiled-test.slang
+++ b/tests/neural/outerproduct-accumulate-tiled-test.slang
@@ -146,11 +146,8 @@ void test<int InputSize, int OutputSize>(uint tid, uint resIndex)
 
 [shader("compute")]
 [numthreads(WorkgroupSize, 1, 1)]
-void computeMain(uint tid : SV_GroupIndex, uint3 gid : SV_GroupID)
+void computeMain(uint tid : SV_GroupIndex)
 {
-    if (gid.x != 0)
-        return;
-
     setBufferOneValue<TEST_SIZE * TEST_SIZE, WorkgroupSize>(tid, outputBuffer, DType(0.0f));
     test<TEST_SIZE, TEST_SIZE>(tid, 0);
     // BUFFER: {{^}}1{{$}}

--- a/tests/neural/shared-memory-size.slang
+++ b/tests/neural/shared-memory-size.slang
@@ -1,5 +1,7 @@
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=0
 // TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly -xslang -DTEST_HALF=1
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -output-using-type -xslang -experimental-feature -xslang -DTEST_HALF=0
+// TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-mtl -compute -shaderobj -output-using-type -xslang -experimental-feature -xslang -DTEST_HALF=1
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=0
 // TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -capability cuda_sm_7_0  -xslang -experimental-feature -xslang -DTEST_HALF=1
 
@@ -28,7 +30,7 @@ static const int SubgroupSize = 32;
 // This verify function uses naive implementation to calculate the shared memory size at run time.
 // It just calculate the shared memory size for a single layer, and store the result in the result array.
 // Then we will find the maximum value in the result array.
-void computeOneLayer<ExecutionMode Mode, T, U, Arr:IRWArray<uint>>(T inputSize, U outputSize, inout uint index, out Arr result)
+void computeOneLayer<TargetEnum Target, ExecutionMode Mode, T, U, Arr:IRWArray<uint>>(T inputSize, U outputSize, inout uint index, out Arr result)
     where T == uint
     where U == uint
 {
@@ -49,7 +51,24 @@ void computeOneLayer<ExecutionMode Mode, T, U, Arr:IRWArray<uint>>(T inputSize, 
                 coopMatShape * (max(alignedN, alignedK)) * sizeof(half);
 
     const int tileCSize = tileBSize * sizeof(DType) / sizeof(half);
-    const int bytesForMMA = tileASize + tileCSize * subgroupCount;
+    const int bytesForMMAOtherTargets = tileASize + tileCSize * subgroupCount;
+
+    const int metalTile = 8;
+    const int metalElemsPerUint4 = sizeof(uint4) / sizeof(DType);
+    const int metalTileWidthUint4 = (metalTile + metalElemsPerUint4 - 1) / metalElemsPerUint4;
+    const int metalBytesForMMA = subgroupCount * SubgroupSize * metalTileWidthUint4 * sizeof(uint4);
+
+    const int metalOPMBlock = 2;
+    const int metalOPNBlock = 2;
+    const int metalOPStageAElemsPerWarp = metalOPMBlock * metalTile * SubgroupSize;
+    const int metalOPStageBElemsPerWarp = metalOPNBlock * metalTile * SubgroupSize;
+    const int metalOPAccumElemsPerWarp = metalTile * metalTile;
+    const int metalBytesForOuterProduct = !isTraining ? 0 :
+        subgroupCount * (metalOPStageAElemsPerWarp + metalOPStageBElemsPerWarp + metalOPAccumElemsPerWarp) * sizeof(DType);
+
+    const int bytesForMMA = (Target == TargetEnum.Metal) ?
+        max(metalBytesForMMA, metalBytesForOuterProduct) :
+        bytesForMMAOtherTargets;
 
     // Term 2: BytesForCrossWarpReduction — butterfly outer product reduction
     const int nTileRows = (int(outputSize) + coopMatShape - 1) / coopMatShape;
@@ -76,13 +95,13 @@ void computeOneLayer<ExecutionMode Mode, T, U, Arr:IRWArray<uint>>(T inputSize, 
 }
 
 
-uint verifySize<ExecutionMode Mode, each T, each U>(expand each T a, expand each U b)
+uint verifySize<TargetEnum Target, ExecutionMode Mode, each T, each U>(expand each T a, expand each U b)
     where T == uint
     where U == uint
 {
     uint index = 0;
     uint resBuffer[countof(T)];
-    expand computeOneLayer<Mode>(each a, each b, index, resBuffer);
+    expand computeOneLayer<Target, Mode>(each a, each b, index, resBuffer);
 
     int maxSize = 0;
 
@@ -179,7 +198,7 @@ uint verifySize<ExecutionMode Mode, each T, each U>(expand each T a, expand each
 
 #define RunTestForTarget(TARGET, N) \
 do { \
-    uint expectedValue = verifySize<ExecutionMode.Inference>(TEST_CASE_##N##_PAIR_1, TEST_CASE_##N##_PAIR_2); \
+    uint expectedValue = verifySize<TARGET, ExecutionMode.Inference>(TEST_CASE_##N##_PAIR_1, TEST_CASE_##N##_PAIR_2); \
     uint actualValue = SharedMemorySize< \
         DType, TARGET, ExecutionMode.Inference, SubgroupSize, BatchSize / SubgroupSize, \
         TEST_CASE_##N>.Bytes; \
@@ -187,7 +206,7 @@ do { \
     actualValue = SharedMemorySize< \
         DType, TARGET, ExecutionMode.Training, SubgroupSize, BatchSize / SubgroupSize, \
         TEST_CASE_##N>.Bytes; \
-    expectedValue = verifySize<ExecutionMode.Training>(TEST_CASE_##N##_PAIR_1, TEST_CASE_##N##_PAIR_2); \
+    expectedValue = verifySize<TARGET, ExecutionMode.Training>(TEST_CASE_##N##_PAIR_1, TEST_CASE_##N##_PAIR_2); \
     isCorrect = isCorrect && (expectedValue == actualValue); \
     outputBuffer[N-1] = isCorrect ? 1U : 0U; \
 } while (false)
@@ -212,6 +231,7 @@ do { \
     RunTestForTarget(TARGET, 16); \
 } while (false)
 
+
 [numthreads(1, 1, 1)]
 [shader("compute")]
 void computeMain(uint tid: SV_DispatchThreadID)
@@ -222,6 +242,8 @@ void computeMain(uint tid: SV_DispatchThreadID)
         RunAllTestsForTarget(TargetEnum.CUDA);
     case spirv:
         RunAllTestsForTarget(TargetEnum.SPIR_V);
+    case metal:
+        RunAllTestsForTarget(TargetEnum.Metal);
     }
 
     // BUFFER: 1


### PR DESCRIPTION
Close #10965.

## Summary

This PR adds Metal support for the neural cooperative-matrix tiled path.

Key pieces:

- add `WaveGetWaveIndex` / `SV_WaveIndex` support needed by the Metal neural path
- add Metal tiled MMA implementation and wiring for `WaveTangledVector`
- add Metal tiled outer-product accumulate and bias reduction coverage
- fix tiled MatB conversion scratch indexing
- expand Metal neural test coverage for shared memory sizing, tiled layout, MMA backward, outer-product accumulate, and FFLayer tiled paths

## Testing

Added/updated Metal compute tests under `tests/neural`, including:

- `shared-memory-size.slang`
- `bias-sum-reduce.slang`
- `outerproduct-accumulate-tiled-test*.slang`
- `mma-tiled-layout-test*.slang`
- `mma-tiled-backward-test.slang`
- `basic-coopmat-vector-tiled-layout-test.slang`
- `fflayer-wavetangled-vector-tiled-test.slang`

Also added compiler coverage for the default-init stripping case:

- `tests/bugs/legalize-defuse-no-zero-init.slang`

Local note: this branch was rebased onto current `upstream/master` before opening the PR.


This PR depends on following fixes:
https://github.com/shader-slang/slang/issues/11193 (functionality blocker)
https://github.com/shader-slang/slang/pull/11011 (correctness blocker)
https://github.com/shader-slang/slang/issues/11085 (performance blocker)
https://github.com/shader-slang/slang/pull/11073 (testing blocker, has WAR)
https://github.com/shader-slang/slang/pull/11103 (correctness blocker)
