### PR TITLE
Fix return value storage scope for textual backends

### DIFF
--- a/source/slang/slang-ir-lower-buffer-element-type.cpp
+++ b/source/slang/slang-ir-lower-buffer-element-type.cpp
@@ -1749,14 +1749,8 @@ struct LoweredElementTypeContext
                     // derived from some other base address. We will let
                     // the later part of the pass to systematically propagate
                     // the cast through them.
-                    switch (user->getOp())
-                    {
-                    case kIROp_FieldAddress:
-                    case kIROp_GetElementPtr:
-                    case kIROp_GetOffsetPtr:
-                    case kIROp_RWStructuredBufferGetElementPtr:
+                    if (isAddressInst(user))
                         return;
-                    }
                     auto ptrVal = use->getUser();
                     setInsertAfterOrdinaryInst(&builder, ptrVal);
                     builder.replaceOperand(use, loweredBufferType);

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -26,6 +26,20 @@ bool isUserPointerType(IRInst* type)
     return ptrType->getAddressSpace() == AddressSpace::UserPointer;
 }
 
+bool isAddressInst(IRInst* inst)
+{
+    switch (inst->getOp())
+    {
+    case kIROp_FieldAddress:
+    case kIROp_GetElementPtr:
+    case kIROp_GetOffsetPtr:
+    case kIROp_RWStructuredBufferGetElementPtr:
+        return true;
+    default:
+        return false;
+    }
+}
+
 IRType* getVectorElementType(IRType* type)
 {
     if (auto vectorType = as<IRVectorType>(type))

--- a/source/slang/slang-ir-util.h
+++ b/source/slang/slang-ir-util.h
@@ -120,6 +120,9 @@ bool isPointerOfType(IRInst* ptrType, IROp opCode);
 
 bool isUserPointerType(IRInst* type);
 
+// True if inst produces a derived address from another base address.
+bool isAddressInst(IRInst* inst);
+
 // Builds a dictionary that maps from requirement key to requirement value for `interfaceType`.
 Dictionary<IRInst*, IRInst*> buildInterfaceRequirementDict(IRInterfaceType* interfaceType);
 

--- a/source/slang/slang-ir-variable-scope-correction.cpp
+++ b/source/slang/slang-ir-variable-scope-correction.cpp
@@ -35,7 +35,6 @@ struct VariableScopeCorrectionContext
     void _processUnstorableInst(IRInst* inst, const List<IRUse*>& outOfScopeUser);
 
     bool _isStorableType(IRType* inst);
-    bool _isAddressInst(IRInst* inst);
     bool _isOutOfScopeUse(
         IRInst* inst,
         IRDominatorTree* domTree,
@@ -185,7 +184,7 @@ void VariableScopeCorrectionContext::_processInstruction(
         return;
     }
 
-    if (!_isAddressInst(originInst) && _isStorableType(originInst->getDataType()))
+    if (!isAddressInst(originInst) && _isStorableType(originInst->getDataType()))
     {
         _processStorableInst(instAfterParam, originInst, outOfScopeUses);
     }
@@ -272,20 +271,6 @@ bool VariableScopeCorrectionContext::_isStorableType(IRType* type)
         }
     case kIROp_UnsizedArrayType:
         return false;
-    default:
-        return false;
-    }
-}
-
-bool VariableScopeCorrectionContext::_isAddressInst(IRInst* inst)
-{
-    switch (inst->getOp())
-    {
-    case kIROp_FieldAddress:
-    case kIROp_GetElementPtr:
-    case kIROp_GetOffsetPtr:
-    case kIROp_RWStructuredBufferGetElementPtr:
-        return true;
     default:
         return false;
     }

--- a/source/slang/slang-ir-variable-scope-correction.cpp
+++ b/source/slang/slang-ir-variable-scope-correction.cpp
@@ -107,13 +107,6 @@ void VariableScopeCorrectionContext::_processFunction(IRFunc* funcInst)
         {
             for (auto inst : block->getChildren())
             {
-                List<IRInst*> instList;
-                // Don't process the variable declaration instruction because the code is not
-                // emitted for them unless there is a use.
-                if (inst->getOp() == kIROp_Var)
-                {
-                    continue;
-                }
                 workList.add(inst);
             }
         }
@@ -178,6 +171,15 @@ void VariableScopeCorrectionContext::_processInstruction(
     if (outOfScopeUses.getCount() == 0)
         return;
 
+    // A var represents storage, so cloning it would create fresh uninitialized
+    // storage at the use site. Hoist the declaration instead, preserving the
+    // stores that define its value.
+    if (auto var = as<IRVar>(originInst))
+    {
+        var->insertBefore(instAfterParam);
+        return;
+    }
+
     if (_isStorableType(originInst->getDataType()))
     {
         _processStorableInst(instAfterParam, originInst, outOfScopeUses);
@@ -227,14 +229,13 @@ void VariableScopeCorrectionContext::_processUnstorableInst(
     IRInst* inst,
     const List<IRUse*>& outOfScopeUsers)
 {
-    IRCloneEnv cloneEnv;
-    auto clonedInst = cloneInst(&cloneEnv, &m_builder, inst);
-
     for (auto user : outOfScopeUsers)
     {
         // duplicate the invisible instruction and insert it right before the use site,
         // then replace the operand with the duplicated instruction
-        clonedInst->insertBefore(user->getUser());
+        IRCloneEnv cloneEnv;
+        m_builder.setInsertBefore(user->getUser());
+        auto clonedInst = cloneInst(&cloneEnv, &m_builder, inst);
         m_builder.replaceOperand(user, clonedInst);
     }
 }
@@ -242,6 +243,9 @@ void VariableScopeCorrectionContext::_processUnstorableInst(
 bool VariableScopeCorrectionContext::_isStorableType(IRType* type)
 {
     if (!type)
+        return false;
+
+    if (as<IRPtrTypeBase>(type))
         return false;
 
     // C/CPP/CUDA can store any type.

--- a/source/slang/slang-ir-variable-scope-correction.cpp
+++ b/source/slang/slang-ir-variable-scope-correction.cpp
@@ -35,6 +35,7 @@ struct VariableScopeCorrectionContext
     void _processUnstorableInst(IRInst* inst, const List<IRUse*>& outOfScopeUser);
 
     bool _isStorableType(IRType* inst);
+    bool _isAddressInst(IRInst* inst);
     bool _isOutOfScopeUse(
         IRInst* inst,
         IRDominatorTree* domTree,
@@ -112,7 +113,11 @@ void VariableScopeCorrectionContext::_processFunction(IRFunc* funcInst)
         }
     }
 
-    auto instAfterParam = funcInst->getFirstBlock()->getFirstOrdinaryInst();
+    auto entryBlock = funcInst->getFirstBlock();
+    auto instAfterParam = entryBlock->getFirstOrdinaryInst();
+    if (!instAfterParam)
+        instAfterParam = entryBlock->getTerminator();
+    SLANG_ASSERT(instAfterParam);
 
     for (Index i = 0; i < workList.getCount(); i++)
     {
@@ -180,7 +185,7 @@ void VariableScopeCorrectionContext::_processInstruction(
         return;
     }
 
-    if (_isStorableType(originInst->getDataType()))
+    if (!_isAddressInst(originInst) && _isStorableType(originInst->getDataType()))
     {
         _processStorableInst(instAfterParam, originInst, outOfScopeUses);
     }
@@ -245,9 +250,6 @@ bool VariableScopeCorrectionContext::_isStorableType(IRType* type)
     if (!type)
         return false;
 
-    if (as<IRPtrTypeBase>(type))
-        return false;
-
     // C/CPP/CUDA can store any type.
     if (isCPUTarget(m_targetReq) || isCUDATarget(m_targetReq))
         return true;
@@ -270,6 +272,20 @@ bool VariableScopeCorrectionContext::_isStorableType(IRType* type)
         }
     case kIROp_UnsizedArrayType:
         return false;
+    default:
+        return false;
+    }
+}
+
+bool VariableScopeCorrectionContext::_isAddressInst(IRInst* inst)
+{
+    switch (inst->getOp())
+    {
+    case kIROp_FieldAddress:
+    case kIROp_GetElementPtr:
+    case kIROp_GetOffsetPtr:
+    case kIROp_RWStructuredBufferGetElementPtr:
+        return true;
     default:
         return false;
     }

--- a/tests/bugs/metal-return-value-lost.slang
+++ b/tests/bugs/metal-return-value-lost.slang
@@ -8,6 +8,14 @@
 //TEST:SIMPLE(filecheck=CPP):   -target cpp -entry computeMain -stage compute
 //TEST:SIMPLE(filecheck=WGSL):  -target wgsl -entry computeMain -stage compute
 
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-d3d12 -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cpu -compute -shaderobj -output-using-type
+//TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-metal -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-wgsl -compute -shaderobj -output-using-type
+
+//TEST_INPUT: ubuffer(data=[0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
 
 struct Vec
@@ -47,27 +55,34 @@ void computeMain(uint tid : SV_GroupIndex)
         outputBuffer[0] = passed ? 1 : 0;
 }
 
+// BUFFER: 1
+
 // METAL: thread Vec_0 [[RET:_S[0-9]+]];
+// METAL: for(;;)
 // METAL: (&[[RET]])->data_0 = (&output_0)->data_0;
 // METAL: if(((&[[RET]])->data_0[int(0)]) == 30.0)
 // METAL: passed_0 = ((&[[RET]])->data_0[int(1)]) == 70.0;
 
 // HLSL: Vec_0 [[RET:_S[0-9]+]];
+// HLSL: for(;;)
 // HLSL: [[RET]].data_0 = output_0.data_0;
 // HLSL: if(([[RET]].data_0[int(0)]) == 30.0f)
 // HLSL: passed_0 = ([[RET]].data_0[int(1)]) == 70.0f;
 
 // CUDA: Vec_0 [[RET:_S[0-9]+]];
+// CUDA: for(;;)
 // CUDA: (&[[RET]])->data_0 = (&output_0)->data_0;
 // CUDA: if(((&[[RET]])->data_0[int(0)]) == 30.0f)
 // CUDA: passed_0 = ((&[[RET]])->data_0[int(1)]) == 70.0f;
 
 // CPP: Vec_0 [[RET:_S[0-9]+]];
+// CPP: for(;;)
 // CPP: (&[[RET]])->data_0 = (&output_0)->data_0;
 // CPP: if(((&[[RET]])->data_0[int(0)]) == 30.0f)
 // CPP: passed_0 = ((&[[RET]])->data_0[int(1)]) == 70.0f;
 
 // WGSL: var [[RET:_S[0-9]+]] : Vec_0;
+// WGSL: for(;;)
 // WGSL: [[RET]].data_0 = output_0.data_0;
 // WGSL: if(([[RET]].data_0[i32(0)]) == 30.0f)
 // WGSL: passed_0 = ([[RET]].data_0[i32(1)]) == 70.0f;

--- a/tests/bugs/metal-return-value-lost.slang
+++ b/tests/bugs/metal-return-value-lost.slang
@@ -1,0 +1,73 @@
+// Regression coverage for textual backends referencing synthesized return-value
+// storage outside of its declaring scope.
+// https://github.com/shader-slang/slang/issues/11102
+
+//TEST:SIMPLE(filecheck=METAL): -target metal -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=HLSL):  -target hlsl -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=CUDA):  -target cuda -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=CPP):   -target cpp -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=WGSL):  -target wgsl -entry computeMain -stage compute
+
+RWStructuredBuffer<uint> outputBuffer;
+
+struct Vec
+{
+    float data[5];
+
+    [ForceInline]
+    __init(float[5] values)
+    {
+        data = values;
+    }
+
+}
+
+[ForceInline]
+Vec make()
+{
+    Vec output;
+
+    for (int mg = 0; mg < 1; mg++)
+    {
+        output.data[0] = 30.0f;
+        output.data[1] = 70.0f;
+    }
+
+    return Vec(output.data);
+}
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(uint tid : SV_GroupIndex)
+{
+    let output = make();
+
+    bool passed = output.data[0] == 30.0f && output.data[1] == 70.0f;
+    if (tid == 0)
+        outputBuffer[0] = passed ? 1 : 0;
+}
+
+// METAL: thread Vec_0 [[RET:_S[0-9]+]];
+// METAL: (&[[RET]])->data_0 = (&output_0)->data_0;
+// METAL: if(((&[[RET]])->data_0[int(0)]) == 30.0)
+// METAL: passed_0 = ((&[[RET]])->data_0[int(1)]) == 70.0;
+
+// HLSL: Vec_0 [[RET:_S[0-9]+]];
+// HLSL: [[RET]].data_0 = output_0.data_0;
+// HLSL: if(([[RET]].data_0[int(0)]) == 30.0f)
+// HLSL: passed_0 = ([[RET]].data_0[int(1)]) == 70.0f;
+
+// CUDA: Vec_0 [[RET:_S[0-9]+]];
+// CUDA: (&[[RET]])->data_0 = (&output_0)->data_0;
+// CUDA: if(((&[[RET]])->data_0[int(0)]) == 30.0f)
+// CUDA: passed_0 = ((&[[RET]])->data_0[int(1)]) == 70.0f;
+
+// CPP: Vec_0 [[RET:_S[0-9]+]];
+// CPP: (&[[RET]])->data_0 = (&output_0)->data_0;
+// CPP: if(((&[[RET]])->data_0[int(0)]) == 30.0f)
+// CPP: passed_0 = ((&[[RET]])->data_0[int(1)]) == 70.0f;
+
+// WGSL: var [[RET:_S[0-9]+]] : Vec_0;
+// WGSL: [[RET]].data_0 = output_0.data_0;
+// WGSL: if(([[RET]].data_0[i32(0)]) == 30.0f)
+// WGSL: passed_0 = ([[RET]].data_0[i32(1)]) == 70.0f;


### PR DESCRIPTION
Fixes https://github.com/shader-slang/slang/issues/11102.

This fixes the final variable-scope correction pass for textual backends when synthesized return-value storage is declared inside a loop region but used after the loop.

Root cause:
- The scope-correction pass skipped `IRVar` instructions, so storage created for a synthesized return value could remain in the loop body even when address expressions derived from that storage were used after the loop.
- Metal/HLSL/WGSL then cloned the storage at the out-of-scope use site, producing a fresh synthesized local that was referenced before declaration and never received the returned data.
- CUDA/C++ treated the address projection as storable, so the pass preserved a pointer to loop-local storage and used that pointer after the block lifetime ended.

Changes:
- allow `IRVar` instructions to participate in scope correction, and hoist the storage declaration when it has out-of-scope uses
- clone address-producing projections such as `get_field_addr`/`getElementPtr` at the use site instead of materializing their pointer value
- keep non-address pointer values on the normal storable path, avoiding duplicated pointer-returning producers
- add a fallback insertion point when the entry block has no ordinary instruction before its terminator
- clone non-storable instructions per out-of-scope use so multiple uses do not move the same clone around
- add compile-time checks plus runtime compute coverage for the affected target families

Investigation notes:
- This is present on upstream `master`, so it is not caused by PR #11011.
- On `master`, Metal/HLSL/WGSL can reference a synthesized local before declaration.
- On `master`, CUDA/C++ preserve a pointer to block-local return-value storage and then use it after scope exit.
- SPIR-V direct emission did not show this issue.

Verification:
- `cmake --build --preset release --parallel 10 --target slangc slang-test`
- `build/Release/bin/slang-test tests/bugs/metal-return-value-lost.slang`
