### PR TITLE
Fetch git tags in CI build workflow

### DIFF
--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
-          fetch-depth: "2"
+          fetch-depth: "0"
           fetch-tags: true
 
       # Restore sccache local cache from master

--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -65,6 +65,7 @@ jobs:
         with:
           submodules: "recursive"
           fetch-depth: "2"
+          fetch-tags: true
 
       # Restore sccache local cache from master
       - name: Restore sccache cache

--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
-          fetch-depth: "0"
+          fetch-depth: "250"
           fetch-tags: true
 
       # Restore sccache local cache from master


### PR DESCRIPTION
Without tags, git describe in cmake/GitVersion.cmake fails and it fails to download the right Slang release package. Without the slang release package, we cannot use the prebuilt slang-llvm.dll.

This PR fetchs git-tags on ci build machines so that it can use the right slang-llvm.dll from the prebuilt release package.