### PR TITLE
Fix and test infinite recursion in LLVM debug data emission

### DIFF
--- a/source/slang-llvm/slang-llvm-builder.cpp
+++ b/source/slang-llvm/slang-llvm-builder.cpp
@@ -366,6 +366,8 @@ public:
         int line) override;
     SLANG_NO_THROW LLVMDebugNode* SLANG_MCALL
     getDebugForwardDeclareType(CharSlice name, LLVMDebugNode* file, int line) override;
+    SLANG_NO_THROW void SLANG_MCALL
+    replaceDebugForwardDeclareType(LLVMDebugNode* replace, LLVMDebugNode* with) override;
     SLANG_NO_THROW LLVMDebugNode* SLANG_MCALL
     getDebugFunctionType(LLVMDebugNode* returnType, Slice<LLVMDebugNode*> paramTypes) override;
     SLANG_NO_THROW LLVMDebugNode* SLANG_MCALL getDebugFunction(
@@ -721,16 +723,16 @@ void LLVMBuilder::finalize()
     // llvmModule->print(rso, nullptr);
     // printf("%s\n", out.c_str());
 
+    // Debug info must be finalized before verifyModule, as otherwise the
+    // unresolved debug nodes can cause verification errors.
+    if (options.debugLevel != SLANG_DEBUG_INFO_LEVEL_NONE)
+        llvmDebugBuilder->finalize();
+
     llvm::verifyModule(*llvmModule, &llvm::errs());
 
     // O0 is separately handled inside `optimize()`; we need to call it in
     // any case to make sure that `ForceInline` functions get inlined.
     optimize();
-
-    if (options.debugLevel != SLANG_DEBUG_INFO_LEVEL_NONE)
-    {
-        llvmDebugBuilder->finalize();
-    }
 }
 
 void LLVMBuilder::emitGlobalLLVMIR(const std::string& textIR)
@@ -1811,12 +1813,18 @@ LLVMDebugNode* LLVMBuilder::getDebugForwardDeclareType(
         file = compileUnit->getFile();
     llvm::DIFile* llvmFile = llvm::cast<llvm::DIFile>(file);
 
-    return llvmDebugBuilder->createForwardDecl(
+    return llvmDebugBuilder->createReplaceableCompositeType(
         llvm::dwarf::DW_TAG_structure_type,
         charSliceToLLVM(name),
         llvmFile,
         llvmFile,
         line);
+}
+
+void LLVMBuilder::replaceDebugForwardDeclareType(LLVMDebugNode* replace, LLVMDebugNode* with)
+{
+    llvm::TempMDNode fwdDecl(replace);
+    llvmDebugBuilder->replaceTemporary(std::move(fwdDecl), with);
 }
 
 LLVMDebugNode* LLVMBuilder::getDebugFunctionType(

--- a/source/slang-llvm/slang-llvm-builder.cpp
+++ b/source/slang-llvm/slang-llvm-builder.cpp
@@ -365,6 +365,8 @@ public:
         LLVMDebugNode* file,
         int line) override;
     SLANG_NO_THROW LLVMDebugNode* SLANG_MCALL
+    getDebugForwardDeclareType(CharSlice name, LLVMDebugNode* file, int line) override;
+    SLANG_NO_THROW LLVMDebugNode* SLANG_MCALL
     getDebugFunctionType(LLVMDebugNode* returnType, Slice<LLVMDebugNode*> paramTypes) override;
     SLANG_NO_THROW LLVMDebugNode* SLANG_MCALL getDebugFunction(
         LLVMDebugNode* funcType,
@@ -1800,6 +1802,20 @@ LLVMDebugNode* LLVMBuilder::getDebugStructType(
         fieldTypes);
 }
 
+LLVMDebugNode* LLVMBuilder::getDebugForwardDeclareType(CharSlice name, LLVMDebugNode* file, int line)
+{
+    if (!file)
+        file = compileUnit->getFile();
+    llvm::DIFile* llvmFile = llvm::cast<llvm::DIFile>(file);
+
+    return llvmDebugBuilder->createForwardDecl(
+        llvm::dwarf::DW_TAG_structure_type,
+        charSliceToLLVM(name),
+        llvmFile,
+        llvmFile,
+        line);
+}
+
 LLVMDebugNode* LLVMBuilder::getDebugFunctionType(
     LLVMDebugNode* returnType,
     Slice<LLVMDebugNode*> paramTypes)
@@ -2349,7 +2365,7 @@ SlangResult LLVMBuilder::generateJITLibrary(IArtifact** outArtifact)
 
 } // namespace slang_llvm
 
-extern "C" SLANG_DLL_EXPORT SlangResult createLLVMBuilder_V2(
+extern "C" SLANG_DLL_EXPORT SlangResult createLLVMBuilder_V3(
     const SlangUUID& intfGuid,
     Slang::ILLVMBuilder** out,
     Slang::LLVMBuilderOptions options,

--- a/source/slang-llvm/slang-llvm-builder.cpp
+++ b/source/slang-llvm/slang-llvm-builder.cpp
@@ -1802,7 +1802,10 @@ LLVMDebugNode* LLVMBuilder::getDebugStructType(
         fieldTypes);
 }
 
-LLVMDebugNode* LLVMBuilder::getDebugForwardDeclareType(CharSlice name, LLVMDebugNode* file, int line)
+LLVMDebugNode* LLVMBuilder::getDebugForwardDeclareType(
+    CharSlice name,
+    LLVMDebugNode* file,
+    int line)
 {
     if (!file)
         file = compileUnit->getFile();

--- a/source/slang-llvm/slang-llvm-builder.h
+++ b/source/slang-llvm/slang-llvm-builder.h
@@ -329,6 +329,8 @@ public:
 
     virtual SLANG_NO_THROW LLVMDebugNode* SLANG_MCALL
     getDebugForwardDeclareType(CharSlice name, LLVMDebugNode* file, int line) = 0;
+    virtual SLANG_NO_THROW void SLANG_MCALL
+    replaceDebugForwardDeclareType(LLVMDebugNode* replace, LLVMDebugNode* with) = 0;
 
     virtual SLANG_NO_THROW LLVMDebugNode* SLANG_MCALL
     getDebugFunctionType(LLVMDebugNode* returnType, Slice<LLVMDebugNode*> paramTypes) = 0;

--- a/source/slang-llvm/slang-llvm-builder.h
+++ b/source/slang-llvm/slang-llvm-builder.h
@@ -326,6 +326,10 @@ public:
         int64_t alignment,
         LLVMDebugNode* file,
         int line) = 0;
+
+    virtual SLANG_NO_THROW LLVMDebugNode* SLANG_MCALL
+    getDebugForwardDeclareType(CharSlice name, LLVMDebugNode* file, int line) = 0;
+
     virtual SLANG_NO_THROW LLVMDebugNode* SLANG_MCALL
     getDebugFunctionType(LLVMDebugNode* returnType, Slice<LLVMDebugNode*> paramTypes) = 0;
     virtual SLANG_NO_THROW LLVMDebugNode* SLANG_MCALL getDebugFunction(

--- a/source/slang/slang-emit-llvm.cpp
+++ b/source/slang/slang-emit-llvm.cpp
@@ -330,6 +330,14 @@ public:
             auto& types = debugTypeMap[rules];
             if (types.containsKey(type))
                 return types.getValue(type);
+
+            // Placeholder; we need this to break infinite recursion with
+            // self-referential structs. This does unfortunately mean that we
+            // can e.g. lose the type of a pointer in those cases.
+            //
+            // TODO: Is there something we could do better here with LLVM's
+            // debug data builder?
+            types[type] = builder->getDebugVoidType();
         }
 
         LLVMDebugNode* llvmType = nullptr;

--- a/source/slang/slang-emit-llvm.cpp
+++ b/source/slang/slang-emit-llvm.cpp
@@ -2881,7 +2881,7 @@ struct LLVMEmitter
         // Some debug types may have been left as forward declared if they
         // were self-referential (e.g., struct containing a pointer to itself).
         // We have to resolve these last.
-        for (auto[fwdDecl, concrete] : types->forwardDeclaredDebugTypes)
+        for (auto [fwdDecl, concrete] : types->forwardDeclaredDebugTypes)
             builder->replaceDebugForwardDeclareType(fwdDecl, concrete);
     }
 };

--- a/source/slang/slang-emit-llvm.cpp
+++ b/source/slang/slang-emit-llvm.cpp
@@ -168,6 +168,8 @@ private:
     Dictionary<IRTypeLayoutRules*, Dictionary<IRType*, LLVMDebugNode*>> debugTypeMap;
 
 public:
+    Dictionary<LLVMDebugNode*, LLVMDebugNode*> forwardDeclaredDebugTypes;
+
     LLVMTypeTranslator(
         ILLVMBuilder* builder,
         TargetRequest* targetReq,
@@ -456,14 +458,15 @@ public:
                 CharSlice linkageName, prettyName;
                 maybeGetName(&linkageName, &prettyName, type);
 
+                LLVMDebugNode* forwardDeclaredType = nullptr;
                 {
                     // We forward-declare the type itself initially, so that
                     // self-referential structs get some useful debug data as
-                    // well. Because LLVM's debug metadata must not contain
-                    // cycles, there's not really anything we could do better
-                    // here.
+                    // well. These get replaced later with the final type.
                     auto& types = debugTypeMap[rules];
-                    types[type] = builder->getDebugForwardDeclareType(prettyName, file, line);
+                    forwardDeclaredType =
+                        builder->getDebugForwardDeclareType(prettyName, file, line);
+                    types[type] = forwardDeclaredType;
                 }
 
                 List<LLVMDebugNode*> types;
@@ -479,12 +482,12 @@ public:
                     IRIntegerValue offset = getOffset(field, rules);
 
                     IRStructKey* key = field->getKey();
-                    CharSlice linkageName, prettyName;
-                    maybeGetName(&linkageName, &prettyName, key);
+                    CharSlice fieldLinkageName, fieldPrettyName;
+                    maybeGetName(&fieldLinkageName, &fieldPrettyName, key);
 
                     types.add(builder->getDebugStructField(
                         debugType,
-                        prettyName,
+                        fieldPrettyName,
                         offset,
                         fieldSizeAndAlignment.size,
                         fieldSizeAndAlignment.alignment,
@@ -500,6 +503,7 @@ public:
                     sizeAndAlignment.alignment,
                     file,
                     line);
+                forwardDeclaredDebugTypes[forwardDeclaredType] = llvmType;
             }
             break;
 
@@ -699,13 +703,13 @@ struct LLVMEmitter
             return SLANG_FAIL;
         }
 
-        using BuilderFuncV2 = SlangResult (*)(
+        using BuilderFuncV3 = SlangResult (*)(
             const SlangUUID& intfGuid,
             Slang::ILLVMBuilder** out,
             Slang::LLVMBuilderOptions options,
             Slang::IArtifact** outErrorArtifact);
 
-        auto builderFunc = (BuilderFuncV2)library->findFuncByName("createLLVMBuilder_V3");
+        auto builderFunc = (BuilderFuncV3)library->findFuncByName("createLLVMBuilder_V3");
         if (!builderFunc)
             return SLANG_FAIL;
 
@@ -2873,6 +2877,12 @@ struct LLVMEmitter
         emitGlobalDeclarations(irModule);
         emitGlobalFunctions(irModule);
         emitGlobalInstructionCtor();
+
+        // Some debug types may have been left as forward declared if they
+        // were self-referential (e.g., struct containing a pointer to itself).
+        // We have to resolve these last.
+        for (auto[fwdDecl, concrete] : types->forwardDeclaredDebugTypes)
+            builder->replaceDebugForwardDeclareType(fwdDecl, concrete);
     }
 };
 

--- a/source/slang/slang-emit-llvm.cpp
+++ b/source/slang/slang-emit-llvm.cpp
@@ -330,14 +330,6 @@ public:
             auto& types = debugTypeMap[rules];
             if (types.containsKey(type))
                 return types.getValue(type);
-
-            // Placeholder; we need this to break infinite recursion with
-            // self-referential structs. This does unfortunately mean that we
-            // can e.g. lose the type of a pointer in those cases.
-            //
-            // TODO: Is there something we could do better here with LLVM's
-            // debug data builder?
-            types[type] = builder->getDebugVoidType();
         }
 
         LLVMDebugNode* llvmType = nullptr;
@@ -461,6 +453,19 @@ public:
                 int line;
                 findDebugLocation(*instToDebugLLVM, structType, file, line);
 
+                CharSlice linkageName, prettyName;
+                maybeGetName(&linkageName, &prettyName, type);
+
+                {
+                    // We forward-declare the type itself initially, so that
+                    // self-referential structs get some useful debug data as
+                    // well. Because LLVM's debug metadata must not contain
+                    // cycles, there's not really anything we could do better
+                    // here.
+                    auto& types = debugTypeMap[rules];
+                    types[type] = builder->getDebugForwardDeclareType(prettyName, file, line);
+                }
+
                 List<LLVMDebugNode*> types;
                 for (auto field : structType->getFields())
                 {
@@ -486,8 +491,6 @@ public:
                         file,
                         line));
                 }
-                CharSlice linkageName, prettyName;
-                maybeGetName(&linkageName, &prettyName, type);
                 sizeAndAlignment.size = align(sizeAndAlignment.size, sizeAndAlignment.alignment);
 
                 llvmType = builder->getDebugStructType(
@@ -702,7 +705,7 @@ struct LLVMEmitter
             Slang::LLVMBuilderOptions options,
             Slang::IArtifact** outErrorArtifact);
 
-        auto builderFunc = (BuilderFuncV2)library->findFuncByName("createLLVMBuilder_V2");
+        auto builderFunc = (BuilderFuncV2)library->findFuncByName("createLLVMBuilder_V3");
         if (!builderFunc)
             return SLANG_FAIL;
 

--- a/tests/bugs/llvm-debug-data-recursion.slang
+++ b/tests/bugs/llvm-debug-data-recursion.slang
@@ -1,0 +1,20 @@
+// This test just needs to run without crashing.
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK): -llvm -compute -Xslang -O0 -Xslang -g3
+//TEST_INPUT:set outputBuffer = out ubuffer(data=[0 0 0 0], stride=4)
+RWStructuredBuffer<int> outputBuffer;
+
+struct SelfReferential
+{
+    // There used to be a bug in the debug data emission here, where this would
+    // cause infinite recursion inside the LLVM emitter.
+    SelfReferential* self;
+}
+
+[numthreads(1,1,1)]
+void computeMain(uint2 tid : SV_DispatchThreadID)
+{
+    SelfReferential self;
+    self.self = &self;
+    // CHECK: 0
+    outputBuffer[0] = 0;
+}


### PR DESCRIPTION
There's a bug with the debug info in the LLVM emitter, where a struct that references itself (even through a pointer) causes infinite recursion and the compiler crashing.

For example, the following would cause the crash when `-g3` is specified:
```slang
struct SelfReferential
{
    SelfReferential* self;
}
```

This is kind-of a hotfix, because it is blocking me in my own project (but I'm already running my own branch with all of my PRs merged on that one, so no rush to actually merge this.) This simple approach can result in the loss of some type info in debug data when these problematic cycles are formed; there may be a better way that would retain this info, but that would likely require more thorough refactoring.