### PR TITLE
Fix SPIR-V void pointer array stride

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1935,6 +1935,21 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         return getTypeLayoutRuleForBuffer(m_targetProgram, ptrType);
     }
 
+    // SPIR-V pointer types require a concrete pointee. Emit IR void* as uint*
+    // for OpTypePointer emission and pointer-stride computation, while leaving
+    // the source IR type intact so emitDebugType reports the original void* in
+    // debug info.
+    IRType* getSpvPointerValueType(IRPtrTypeBase* ptrType)
+    {
+        auto valueType = ptrType->getValueType();
+        if (as<IRVoidType>(valueType))
+        {
+            IRBuilder builder(m_irModule);
+            return builder.getUIntType();
+        }
+        return valueType;
+    }
+
     IRIntegerValue getArrayElementStrideValue(IRArrayTypeBase* arrayType, IRTypeLayoutRules* rule)
     {
         auto elementType = arrayType->getElementType();
@@ -1963,7 +1978,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             storageClass != SpvStorageClassStorageBuffer)
             return 0;
 
-        auto valueType = ptrType->getValueType();
+        auto valueType = getSpvPointerValueType(ptrType);
         auto rule = getPointerArrayStrideLayoutRule(ptrType, valueType);
 
         if (auto arrayType = as<IRUnsizedArrayType>(valueType))
@@ -2368,7 +2383,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     break;
                 }
 
-                auto valueType = ptrType->getValueType();
+                auto valueType = getSpvPointerValueType(ptrType);
 
                 // Check for 8/16-bit storage capabilities when emitting pointer types
                 requireCapabilitiesForType(valueType, storageClass);
@@ -2378,14 +2393,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     (!m_mapIRInstToSpvInst.containsKey(valueType) && as<IRStructType>(valueType) &&
                      storageClass == SpvStorageClassPhysicalStorageBuffer);
                 SpvId valueTypeId;
-                if (as<IRVoidType>(valueType))
-                {
-                    // Emit void* as uint*.
-                    IRBuilder builder(valueType);
-                    builder.setInsertBefore(valueType);
-                    valueTypeId = getID(ensureInst(builder.getUIntType()));
-                }
-                else if (useForwardDeclaration)
+                if (useForwardDeclaration)
                 {
                     valueTypeId = getIRInstSpvID(valueType);
                 }

--- a/tests/spirv/void-ptr-array-stride.slang
+++ b/tests/spirv/void-ptr-array-stride.slang
@@ -1,0 +1,32 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -emit-spirv-directly -entry main -stage compute
+//TEST:SIMPLE(filecheck=DEBUG):-target spirv-asm -emit-spirv-directly -entry main -stage compute -g2 -O0
+
+// Check that void* in PhysicalStorageBuffer is emitted as uint* with
+// ArrayStride 4 (required by OpPtrAccessChain), and that debug info still
+// describes the original source-level void*.
+
+// CHECK-DAG: OpDecorate %[[PTR:_ptr_PhysicalStorageBuffer_uint[A-Za-z0-9_]*]] ArrayStride 4
+// CHECK-DAG: %uint = OpTypeInt 32 0
+// CHECK-DAG: %[[PTR]] = OpTypePointer PhysicalStorageBuffer %uint
+// CHECK: OpPtrAccessChain %[[PTR]]
+
+// DEBUG-DAG: %[[VOID_STR:[A-Za-z_0-9]+]] = OpString "void"
+// DEBUG-DAG: %[[P_STR:[A-Za-z_0-9]+]] = OpString "p"
+// DEBUG-DAG: %[[VOID_TYPE:[A-Za-z_0-9]+]] = OpExtInst %void %{{[A-Za-z_0-9]+}} DebugTypeBasic %[[VOID_STR]] %uint_0 %uint_0
+// DEBUG-DAG: %[[VOID_PTR_TYPE:[A-Za-z_0-9]+]] = OpExtInst %void %{{[A-Za-z_0-9]+}} DebugTypePointer %[[VOID_TYPE]]
+// DEBUG-DAG: OpExtInst %void %{{[A-Za-z_0-9]+}} DebugTypeMember %[[P_STR]] %[[VOID_PTR_TYPE]]
+
+cbuffer Params
+{
+    void* p;
+    uint i;
+}
+
+RWStructuredBuffer<uint> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    void* q = p + i;
+    outputBuffer[0] = reinterpret<uint64_t>(q) != 0;
+}


### PR DESCRIPTION
SPIR-V represents IR void* pointer types as uint* because OpTypePointer requires a concrete pointee, but pointer layout still derived ArrayStride from the original void pointee. That could leave PhysicalStorageBuffer uint* pointer types without the required ArrayStride 4 decoration when used by OpPtrAccessChain.

Use a single effective SPIR-V pointee type in the emitter for OpTypePointer emission, pointer ArrayStride calculation, and pointer type memoization. Keep the source IR type unchanged so debug info still describes the original void*.

* Treat void pointees as uint only at SPIR-V pointer emission and layout sites.

* Add coverage for ArrayStride 4 on lowered void* pointers and for debug info preserving source-level void*.

Fixes #11109