### PR TITLE
Deduplicate SPIR-V annotation instructions

### DIFF
--- a/source/compiler-core/slang-spirv-core-grammar.cpp
+++ b/source/compiler-core/slang-spirv-core-grammar.cpp
@@ -233,6 +233,7 @@ RefPtr<SPIRVCoreGrammarInfo> SPIRVCoreGrammarInfo::loadFromJSON(
         const auto class_ = i.class_ == "Type-Declaration"    ? OpInfo::TypeDeclaration
                             : i.class_ == "Constant-Creation" ? OpInfo::ConstantCreation
                             : i.class_ == "Debug"             ? OpInfo::Debug
+                            : i.class_ == "Annotation"        ? OpInfo::Annotation
                                                               : OpInfo::Other;
 
         const auto resultTypeIndex =

--- a/source/slang/slang-emit-spirv-ops.h
+++ b/source/slang/slang-emit-spirv-ops.h
@@ -707,7 +707,7 @@ SpvInst* emitOpDecorate(
     SpvDecoration decoration)
 {
     static_assert(isSingular<T>);
-    return emitInst(parent, inst, SpvOpDecorate, target, decoration);
+    return emitInstMemoizedNoResultID(parent, inst, SpvOpDecorate, target, decoration);
 }
 
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorate
@@ -719,7 +719,7 @@ SpvInst* emitOpDecorateSpecId(
     const SpvLiteralInteger& specializationConstantID)
 {
     static_assert(isSingular<T>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpDecorate,
@@ -737,7 +737,13 @@ SpvInst* emitOpDecorateArrayStride(
     const SpvLiteralInteger& arrayStride)
 {
     static_assert(isSingular<T>);
-    return emitInst(parent, inst, SpvOpDecorate, target, SpvDecorationArrayStride, arrayStride);
+    return emitInstMemoizedNoResultID(
+        parent,
+        inst,
+        SpvOpDecorate,
+        target,
+        SpvDecorationArrayStride,
+        arrayStride);
 }
 
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorateId
@@ -749,7 +755,7 @@ SpvInst* emitOpDecorateArrayStrideIdEXT(
     const U& arrayStride)
 {
     static_assert(isSingular<T>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpDecorateId,
@@ -768,7 +774,13 @@ SpvInst* emitOpDecorateMatrixStride(
     const SpvLiteralInteger& matrixStride)
 {
     static_assert(isSingular<T>);
-    return emitInst(parent, inst, SpvOpDecorate, target, SpvDecorationMatrixStride, matrixStride);
+    return emitInstMemoizedNoResultID(
+        parent,
+        inst,
+        SpvOpDecorate,
+        target,
+        SpvDecorationMatrixStride,
+        matrixStride);
 }
 
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorate
@@ -780,10 +792,16 @@ SpvInst* emitOpDecorateBuiltIn(
     SpvBuiltIn builtIn)
 {
     static_assert(isSingular<T>);
-    return emitInst(parent, inst, SpvOpDecorate, target, SpvDecorationBuiltIn, builtIn);
+    return emitInstMemoizedNoResultID(
+        parent,
+        inst,
+        SpvOpDecorate,
+        target,
+        SpvDecorationBuiltIn,
+        builtIn);
 }
 
-// https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorate
+// https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpMemberDecorateString
 template<typename T>
 SpvInst* emitOpMemberDecorateString(
     SpvInstParent* parent,
@@ -794,10 +812,17 @@ SpvInst* emitOpMemberDecorateString(
     UnownedStringSlice text)
 {
     static_assert(isSingular<T>);
-    return emitInst(parent, inst, SpvOpMemberDecorateString, target, index, decoration, text);
+    return emitInstMemoizedNoResultID(
+        parent,
+        inst,
+        SpvOpMemberDecorateString,
+        target,
+        index,
+        decoration,
+        text);
 }
 
-// https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorate
+// https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorateString
 template<typename T>
 SpvInst* emitOpDecorateString(
     SpvInstParent* parent,
@@ -807,7 +832,7 @@ SpvInst* emitOpDecorateString(
     UnownedStringSlice text)
 {
     static_assert(isSingular<T>);
-    return emitInst(parent, inst, SpvOpDecorateString, target, decoration, text);
+    return emitInstMemoizedNoResultID(parent, inst, SpvOpDecorateString, target, decoration, text);
 }
 
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorate
@@ -820,7 +845,13 @@ SpvInst* emitOpDecorateUniformId(
 {
     static_assert(isSingular<T1>);
     static_assert(isSingular<T2>);
-    return emitInst(parent, inst, SpvOpDecorate, target, SpvDecorationUniformId, execution);
+    return emitInstMemoizedNoResultID(
+        parent,
+        inst,
+        SpvOpDecorate,
+        target,
+        SpvDecorationUniformId,
+        execution);
 }
 
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorate
@@ -832,7 +863,13 @@ SpvInst* emitOpDecorateLocation(
     const SpvLiteralInteger& location)
 {
     static_assert(isSingular<T>);
-    return emitInst(parent, inst, SpvOpDecorate, target, SpvDecorationLocation, location);
+    return emitInstMemoizedNoResultID(
+        parent,
+        inst,
+        SpvOpDecorate,
+        target,
+        SpvDecorationLocation,
+        location);
 }
 
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorate
@@ -844,7 +881,13 @@ SpvInst* emitOpDecorateComponent(
     const SpvLiteralInteger& component)
 {
     static_assert(isSingular<T>);
-    return emitInst(parent, inst, SpvOpDecorate, target, SpvDecorationComponent, component);
+    return emitInstMemoizedNoResultID(
+        parent,
+        inst,
+        SpvOpDecorate,
+        target,
+        SpvDecorationComponent,
+        component);
 }
 
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorate
@@ -856,7 +899,13 @@ SpvInst* emitOpDecorateIndex(
     const SpvLiteralInteger& index)
 {
     static_assert(isSingular<T>);
-    return emitInst(parent, inst, SpvOpDecorate, target, SpvDecorationIndex, index);
+    return emitInstMemoizedNoResultID(
+        parent,
+        inst,
+        SpvOpDecorate,
+        target,
+        SpvDecorationIndex,
+        index);
 }
 
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorate
@@ -868,7 +917,13 @@ SpvInst* emitOpDecorateBinding(
     const SpvLiteralInteger& bindingPoint)
 {
     static_assert(isSingular<T>);
-    return emitInst(parent, inst, SpvOpDecorate, target, SpvDecorationBinding, bindingPoint);
+    return emitInstMemoizedNoResultID(
+        parent,
+        inst,
+        SpvOpDecorate,
+        target,
+        SpvDecorationBinding,
+        bindingPoint);
 }
 
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorate
@@ -880,7 +935,7 @@ SpvInst* emitOpDecorateInputAttachmentIndex(
     const SpvLiteralInteger& bindingPoint)
 {
     static_assert(isSingular<T>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpDecorate,
@@ -898,7 +953,13 @@ SpvInst* emitOpDecorateDescriptorSet(
     const SpvLiteralInteger& descriptorSet)
 {
     static_assert(isSingular<T>);
-    return emitInst(parent, inst, SpvOpDecorate, target, SpvDecorationDescriptorSet, descriptorSet);
+    return emitInstMemoizedNoResultID(
+        parent,
+        inst,
+        SpvOpDecorate,
+        target,
+        SpvDecorationDescriptorSet,
+        descriptorSet);
 }
 
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorate
@@ -910,7 +971,13 @@ SpvInst* emitOpDecorateOffset(
     const SpvLiteralInteger& byteOffset)
 {
     static_assert(isSingular<T>);
-    return emitInst(parent, inst, SpvOpDecorate, target, SpvDecorationOffset, byteOffset);
+    return emitInstMemoizedNoResultID(
+        parent,
+        inst,
+        SpvOpDecorate,
+        target,
+        SpvDecorationOffset,
+        byteOffset);
 }
 
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorate
@@ -922,7 +989,7 @@ SpvInst* emitOpDecorateFPRoundingMode(
     SpvFPRoundingMode floatingPointRoundingMode)
 {
     static_assert(isSingular<T>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpDecorate,
@@ -931,7 +998,7 @@ SpvInst* emitOpDecorateFPRoundingMode(
         floatingPointRoundingMode);
 }
 
-// https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorate
+// https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorateId
 template<typename T1, typename T2>
 SpvInst* emitOpDecorateCounterBuffer(
     SpvInstParent* parent,
@@ -941,7 +1008,7 @@ SpvInst* emitOpDecorateCounterBuffer(
 {
     static_assert(isSingular<T1>);
     static_assert(isSingular<T2>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpDecorateId,
@@ -959,7 +1026,33 @@ SpvInst* emitOpDecorateUserSemantic(
     const UnownedStringSlice& semantic)
 {
     static_assert(isSingular<T>);
-    return emitInst(parent, inst, SpvOpDecorate, target, SpvDecorationUserSemantic, semantic);
+    return emitInstMemoizedNoResultID(
+        parent,
+        inst,
+        SpvOpDecorate,
+        target,
+        SpvDecorationUserSemantic,
+        semantic);
+}
+
+// https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpDecorate
+template<typename T>
+SpvInst* emitOpDecorateLinkageAttributes(
+    SpvInstParent* parent,
+    IRInst* inst,
+    const T& target,
+    const UnownedStringSlice& name,
+    SpvLinkageType linkageType)
+{
+    static_assert(isSingular<T>);
+    return emitInstMemoizedNoResultID(
+        parent,
+        inst,
+        SpvOpDecorate,
+        target,
+        SpvDecorationLinkageAttributes,
+        name,
+        linkageType);
 }
 
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpMemberDecorate
@@ -972,7 +1065,13 @@ SpvInst* emitOpMemberDecorate(
     SpvDecoration decoration)
 {
     static_assert(isSingular<T>);
-    return emitInst(parent, inst, SpvOpMemberDecorate, structureType, member, decoration);
+    return emitInstMemoizedNoResultID(
+        parent,
+        inst,
+        SpvOpMemberDecorate,
+        structureType,
+        member,
+        decoration);
 }
 
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpMemberDecorate
@@ -985,7 +1084,7 @@ SpvInst* emitOpMemberDecorateSpecId(
     const SpvLiteralInteger& specializationConstantID)
 {
     static_assert(isSingular<T>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpMemberDecorate,
@@ -1005,7 +1104,7 @@ SpvInst* emitOpMemberDecorateArrayStride(
     const SpvLiteralInteger& arrayStride)
 {
     static_assert(isSingular<T>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpMemberDecorate,
@@ -1025,7 +1124,7 @@ SpvInst* emitOpMemberDecorateMatrixStride(
     const SpvLiteralInteger& matrixStride)
 {
     static_assert(isSingular<T>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpMemberDecorate,
@@ -1045,7 +1144,7 @@ SpvInst* emitOpMemberDecorateBuiltIn(
     SpvBuiltIn builtIn)
 {
     static_assert(isSingular<T>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpMemberDecorate,
@@ -1066,7 +1165,7 @@ SpvInst* emitOpMemberDecorateUniformId(
 {
     static_assert(isSingular<T1>);
     static_assert(isSingular<T2>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpMemberDecorate,
@@ -1086,7 +1185,7 @@ SpvInst* emitOpMemberDecorateLocation(
     const SpvLiteralInteger& location)
 {
     static_assert(isSingular<T>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpMemberDecorate,
@@ -1106,7 +1205,7 @@ SpvInst* emitOpMemberDecorateComponent(
     const SpvLiteralInteger& component)
 {
     static_assert(isSingular<T>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpMemberDecorate,
@@ -1126,7 +1225,7 @@ SpvInst* emitOpMemberDecorateIndex(
     const SpvLiteralInteger& index)
 {
     static_assert(isSingular<T>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpMemberDecorate,
@@ -1146,7 +1245,7 @@ SpvInst* emitOpMemberDecorateBinding(
     const SpvLiteralInteger& bindingPoint)
 {
     static_assert(isSingular<T>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpMemberDecorate,
@@ -1166,7 +1265,7 @@ SpvInst* emitOpMemberDecorateDescriptorSet(
     const SpvLiteralInteger& descriptorSet)
 {
     static_assert(isSingular<T>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpMemberDecorate,
@@ -1186,7 +1285,7 @@ SpvInst* emitOpMemberDecorateOffset(
     const SpvLiteralInteger& byteOffset)
 {
     static_assert(isSingular<T>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpMemberDecorate,
@@ -1206,7 +1305,7 @@ SpvInst* emitOpMemberDecorateFPRoundingMode(
     SpvFPRoundingMode floatingPointRoundingMode)
 {
     static_assert(isSingular<T>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpMemberDecorate,
@@ -1227,7 +1326,7 @@ SpvInst* emitOpMemberDecorateCounterBuffer(
 {
     static_assert(isSingular<T1>);
     static_assert(isSingular<T2>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpMemberDecorate,
@@ -1247,7 +1346,7 @@ SpvInst* emitOpMemberDecorateUserSemantic(
     const UnownedStringSlice& semantic)
 {
     static_assert(isSingular<T>);
-    return emitInst(
+    return emitInstMemoizedNoResultID(
         parent,
         inst,
         SpvOpMemberDecorate,

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1464,18 +1464,41 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
         // If we have seen this before, return the memoized instruction
         if (SpvInst** memoized = m_memoizedSpvInsts.tryGetValue(key))
+        {
+            // Different Slang IR instructions can produce the same no-result
+            // SPIR-V instruction, so keep the later IR instruction mapped to
+            // the memoized instruction.
+            if (irInst)
+                m_mapIRInstToSpvInst.addIfNotExists(irInst, *memoized);
             return *memoized;
+        }
 
-        // Otherwise, we can construct our instruction and record the result
+        // Otherwise, construct our instruction and record it in the memoization table.
         InstConstructScope scopeInst(this, opcode, irInst);
         SpvInst* spvInst = scopeInst;
         m_memoizedSpvInsts[key] = spvInst;
 
+        // Replay operands captured by the memoize scope into the live instruction.
         m_operandStack.addRange(ourOperands);
 
         parent->addInst(spvInst);
         return spvInst;
     }
+
+    template<typename... Operands>
+    SpvInst* emitInstMemoizedNoResultID(
+        SpvInstParent* parent,
+        IRInst* irInst,
+        SpvOp opcode,
+        const Operands&... ops)
+    {
+        return emitInstMemoizedNoResultIDCustomOperandFunc(
+            parent,
+            irInst,
+            opcode,
+            [&]() { (emitOperand(ops), ...); });
+    }
+
     //
     // Specific emit funcs
     //
@@ -2642,16 +2665,11 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 auto stride = getArrayStrideDecorationValue(irArrayType);
                 if (stride != 0)
                 {
-                    emitInstMemoizedNoResultIDCustomOperandFunc(
+                    emitOpDecorateArrayStride(
                         getSection(SpvLogicalSectionID::Annotations),
                         nullptr,
-                        SpvOpDecorate,
-                        [&]()
-                        {
-                            emitOperand(arrayType);
-                            emitOperand(SpvLiteralInteger::from32(SpvDecorationArrayStride));
-                            emitOperand(SpvLiteralInteger::from32(stride));
-                        });
+                        arrayType,
+                        SpvLiteralInteger::from32(stride));
                 }
                 return arrayType;
             }
@@ -6467,12 +6485,10 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 requireSPIRVCapability(SpvCapabilityLinkage);
                 auto name =
                     decoration->getParent()->findDecoration<IRExportDecoration>()->getMangledName();
-                emitInst(
+                emitOpDecorateLinkageAttributes(
                     getSection(SpvLogicalSectionID::Annotations),
                     decoration,
-                    SpvOpDecorate,
                     dstID,
-                    SpvDecorationLinkageAttributes,
                     name,
                     SpvLinkageTypeExport);
                 break;
@@ -6482,12 +6498,10 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 requireSPIRVCapability(SpvCapabilityLinkage);
                 auto name =
                     decoration->getParent()->findDecoration<IRExportDecoration>()->getMangledName();
-                emitInst(
+                emitOpDecorateLinkageAttributes(
                     getSection(SpvLogicalSectionID::Annotations),
                     decoration,
-                    SpvOpDecorate,
                     dstID,
-                    SpvDecorationLinkageAttributes,
                     name,
                     SpvLinkageTypeImport);
                 break;
@@ -10695,6 +10709,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 SLANG_ASSERT(info.has_value());
                 switch (info->class_)
                 {
+                case SPIRVCoreGrammarInfo::OpInfo::Annotation:
+                    return getSection(SpvLogicalSectionID::Annotations);
                 case SPIRVCoreGrammarInfo::OpInfo::TypeDeclaration:
                 case SPIRVCoreGrammarInfo::OpInfo::ConstantCreation:
                     return getSection(SpvLogicalSectionID::ConstantsAndTypes);
@@ -10714,12 +10730,6 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     case SpvOpExecutionMode:
                     case SpvOpExecutionModeId:
                         return getSection(SpvLogicalSectionID::ExecutionModes);
-                    case SpvOpDecorate:
-                    case SpvOpDecorateId:
-                    case SpvOpDecorateString:
-                    case SpvOpMemberDecorate:
-                    case SpvOpMemberDecorateString:
-                        return getSection(SpvLogicalSectionID::Annotations);
                     case SpvOpTypeNodePayloadArrayAMDX:
                         return getSection(SpvLogicalSectionID::ConstantsAndTypes);
                     default:
@@ -11065,9 +11075,15 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 const auto opInfo = m_grammarInfo->opInfos.lookup(opcode);
 
                 // TODO: handle resultIdIndex == 1, for constants
-                const bool memoize =
+                const bool memoizeTypeInst =
                     opParent == getSection(SpvLogicalSectionID::ConstantsAndTypes) && opInfo &&
                     opInfo->resultIdIndex == 0;
+                // Only no-result instructions in the annotations section are safe to memoize.
+                // Result-producing annotations like OpDecorationGroup must keep
+                // distinct IDs because later group decorations reference them.
+                const bool memoizeAnnotationInst =
+                    opParent == getSection(SpvLogicalSectionID::Annotations) && opInfo &&
+                    opInfo->resultIdIndex == SPIRVCoreGrammarInfo::OpInfo::kNoResultId;
 
                 // We want the "result instruction" to refer to the top level
                 // block which assumes its value, the others are free to refer
@@ -11076,7 +11092,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 // assigned to result is not necessarily the last instruction
                 const auto assignedInst = isLast ? as<IRInst>(inst) : spvInst;
 
-                if (memoize)
+                if (memoizeTypeInst)
                 {
                     last = emitInstMemoizedCustomOperandFunc(
                         opParent,
@@ -11107,6 +11123,18 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                             cast<IRStringLit>(resOperand->getValue())->getStringSlice();
                         idMap[idName] = last->id;
                     }
+                }
+                else if (memoizeAnnotationInst)
+                {
+                    last = emitInstMemoizedNoResultIDCustomOperandFunc(
+                        opParent,
+                        assignedInst,
+                        opcode,
+                        [&]()
+                        {
+                            for (const auto operand : spvInst->getSPIRVOperands())
+                                emitSpvAsmOperand(operand);
+                        });
                 }
                 else
                 {
@@ -11149,8 +11177,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                                 else
                                     requiredMask |= SpvImageOperandsMakeTexelAvailableMask;
 
-                                // If user specified any of the required masks, we cannot specified
-                                // anymore.
+                                // If the user specified any of the required masks, do not add them
+                                // again.
                                 if (usedMask & requiredMask)
                                     return;
 

--- a/tests/spirv/deduplicate-annotation-preserve-distinct.slang
+++ b/tests/spirv/deduplicate-annotation-preserve-distinct.slang
@@ -1,0 +1,41 @@
+//TEST:SIMPLE(filecheck=CHECK):-emit-spirv-directly -target spirv-asm -entry computeMain -stage compute -O0
+
+// Check that annotation instructions with distinct operands are preserved.
+
+// CHECK: OpName %[[ONE:[A-Za-z0-9_]+]] "one"
+// CHECK: OpName %[[TWO:[A-Za-z0-9_]+]] "two"
+// CHECK: OpName %[[STRUCT:[A-Za-z0-9_]+]] "payloadStruct"
+// CHECK: OpDecorate %[[ONE]] RelaxedPrecision
+// CHECK: OpDecorate %[[TWO]] RelaxedPrecision
+// CHECK: OpDecorateString %[[ONE]] UserSemantic "SEM"
+// CHECK: OpDecorateString %[[ONE]] UserSemantic "SEM_ALT"
+// CHECK: OpDecorateString %[[ONE]] UserTypeGOOGLE "TYPE"
+// CHECK: OpDecorateString %[[TWO]] UserSemantic "SEM"
+// CHECK: OpMemberDecorate %[[STRUCT]] 0 Offset 0
+// CHECK: OpMemberDecorate %[[STRUCT]] 1 Offset 4
+
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    int r = spirv_asm
+    {
+        OpExtension "SPV_GOOGLE_decorate_string";
+        OpExtension "SPV_GOOGLE_user_type";
+        OpConstant $$int %one 1;
+        OpConstant $$int %two 2;
+        %payloadStruct = OpTypeStruct $$int $$int;
+        OpDecorate %payloadStruct Block;
+        OpDecorate %one RelaxedPrecision;
+        OpDecorate %two RelaxedPrecision;
+        OpDecorateString %one UserSemantic "SEM";
+        OpDecorateString %one UserSemantic "SEM_ALT";
+        OpDecorateString %one UserTypeGOOGLE "TYPE";
+        OpDecorateString %two UserSemantic "SEM";
+        OpMemberDecorate %payloadStruct 0 Offset 0;
+        OpMemberDecorate %payloadStruct 1 Offset 4;
+        result : $$int = OpIAdd %one %two;
+    };
+    outputBuffer[0] = r;
+}

--- a/tests/spirv/deduplicate-annotation-resource-binding.slang
+++ b/tests/spirv/deduplicate-annotation-resource-binding.slang
@@ -1,0 +1,30 @@
+//TEST:SIMPLE(filecheck=CHECK):-emit-spirv-directly -target spirv-asm -entry computeMain -stage compute
+
+// Check that the Binding and DescriptorSet decorations emitted from
+// [[vk::binding]] and repeated by spirv_asm appear only once for outputBuffer.
+
+// CHECK: OpName %[[BUFFER:[A-Za-z0-9_]+]] "outputBuffer"
+// CHECK: OpDecorate %[[BUFFER]] Binding 1
+// CHECK-NOT: OpDecorate %[[BUFFER]] Binding 1
+// CHECK: OpDecorate %[[BUFFER]] DescriptorSet 0
+// CHECK-NOT: OpDecorate %[[BUFFER]] Binding 1
+// CHECK-NOT: OpDecorate %[[BUFFER]] DescriptorSet 0
+// CHECK: ; Types, variables and constants
+
+[[vk::binding(1, 0)]]
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    int value = spirv_asm
+    {
+        OpDecorate $outputBuffer Binding 1;
+        OpDecorate $outputBuffer Binding 1;
+        OpDecorate $outputBuffer DescriptorSet 0;
+        OpDecorate $outputBuffer DescriptorSet 0;
+        result : $$int = OpConstant 0;
+    };
+
+    outputBuffer[0] = value;
+}

--- a/tests/spirv/deduplicate-annotation-spirv-asm.slang
+++ b/tests/spirv/deduplicate-annotation-spirv-asm.slang
@@ -1,0 +1,73 @@
+//TEST:SIMPLE(filecheck=CHECK):-emit-spirv-directly -target spirv-asm -entry computeMain -stage compute -capability spvDescriptorHeapEXT -O0
+
+// Check that exact duplicate annotation instructions emitted from spirv_asm
+// appear only once in the final SPIR-V assembly.
+
+// CHECK: OpName %[[SCOPE:[A-Za-z0-9_]+]] "scope"
+// CHECK: OpName %[[ONE:[A-Za-z0-9_]+]] "one"
+// CHECK: OpName %[[FOUR:[A-Za-z0-9_]+]] "four"
+// CHECK: OpName %[[STRUCT:[A-Za-z0-9_]+]] "payloadStruct"
+// CHECK: OpName %[[GROUP:[A-Za-z0-9_]+]] "decorGroup"
+// CHECK: OpName %[[GROUP_B:[A-Za-z0-9_]+]] "decorGroupB"
+// CHECK: %[[GROUP]] = OpDecorationGroup
+// CHECK: %[[GROUP_B]] = OpDecorationGroup
+// CHECK-NOT: OpFunction
+// CHECK: OpDecorate %[[ONE]] RelaxedPrecision
+// CHECK-NOT: OpDecorate %[[ONE]] RelaxedPrecision
+// CHECK: OpDecorateString %[[ONE]] UserSemantic "SEM"
+// CHECK-NOT: OpDecorateString %[[ONE]] UserSemantic "SEM"
+// CHECK: OpDecorateId %[[ONE]] UniformId %[[SCOPE]]
+// CHECK-NOT: OpDecorateId %[[ONE]] UniformId %[[SCOPE]]
+// CHECK: OpMemberDecorateIdEXT %[[STRUCT]] 0 OffsetIdEXT %[[FOUR]]
+// CHECK-NOT: OpMemberDecorateIdEXT %[[STRUCT]] 0 OffsetIdEXT %[[FOUR]]
+// CHECK: OpMemberDecorate %[[STRUCT]] 1 Offset 0
+// CHECK-NOT: OpMemberDecorate %[[STRUCT]] 1 Offset 0
+// CHECK: OpMemberDecorateString %[[STRUCT]] 1 UserSemantic "MEMSEM"
+// CHECK-NOT: OpMemberDecorateString %[[STRUCT]] 1 UserSemantic "MEMSEM"
+// CHECK: OpGroupDecorate %[[GROUP]] %[[ONE]]
+// CHECK-NOT: OpGroupDecorate %[[GROUP]] %[[ONE]]
+// CHECK: OpGroupDecorate %[[GROUP_B]] %[[SCOPE]]
+// CHECK: OpGroupMemberDecorate %[[GROUP]] %[[STRUCT]] 1
+// CHECK-NOT: OpGroupMemberDecorate %[[GROUP]] %[[STRUCT]] 1
+
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    int r = spirv_asm
+    {
+        OpCapability DescriptorHeapEXT;
+        OpExtension "SPV_EXT_descriptor_heap";
+        OpExtension "SPV_GOOGLE_decorate_string";
+        OpConstant $$int %scope 3;
+        OpConstant $$int %one 1;
+        OpConstant $$int %four 4;
+        %bufferType = OpTypeBufferEXT Uniform;
+        %payloadStruct = OpTypeStruct %bufferType $$int;
+        %decorGroup = OpDecorationGroup;
+        %decorGroupB = OpDecorationGroup;
+        OpDecorate %one RelaxedPrecision;
+        OpDecorate %one RelaxedPrecision;
+        OpDecorateString %one UserSemantic "SEM";
+        OpDecorateString %one UserSemantic "SEM";
+        OpDecorateId %one UniformId %scope;
+        OpDecorateId %one UniformId %scope;
+        OpDecorate %payloadStruct Block;
+        OpMemberDecorateIdEXT %payloadStruct 0 OffsetIdEXT %four;
+        OpMemberDecorateIdEXT %payloadStruct 0 OffsetIdEXT %four;
+        OpMemberDecorate %payloadStruct 1 Offset 0;
+        OpMemberDecorate %payloadStruct 1 Offset 0;
+        OpMemberDecorateString %payloadStruct 1 UserSemantic "MEMSEM";
+        OpMemberDecorateString %payloadStruct 1 UserSemantic "MEMSEM";
+        OpDecorate %decorGroup RelaxedPrecision;
+        OpDecorate %decorGroupB RelaxedPrecision;
+        OpGroupDecorate %decorGroup %one;
+        OpGroupDecorate %decorGroup %one;
+        OpGroupDecorate %decorGroupB %scope;
+        OpGroupMemberDecorate %decorGroup %payloadStruct 1;
+        OpGroupMemberDecorate %decorGroup %payloadStruct 1;
+        result : $$int = OpIAdd %one %scope;
+    };
+    outputBuffer[0] = r;
+}


### PR DESCRIPTION
Duplicate SPIR-V annotation instructions could be emitted when decorations were generated through helpers that used plain emitInst or inline spirv_asm. Exact duplicate OpDecorate-style annotations, such as repeated Binding decorations on the same target ID, are rejected by SPIR-V validation.

* Route annotation-class spirv_asm opcodes to the Annotations section.
* Deduplicate no-result annotation instructions using memoized emission keyed by opcode and full operand list.
* Preserve distinct result-producing annotations such as OpDecorationGroup.
* Add coverage for duplicate removal and distinct annotation preservation.

Fixes #11113