### PR TITLE
Detect enumerator overflow in enum declarations

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -11592,11 +11592,17 @@ void SemanticsDeclBodyVisitor::visitEnumDecl(EnumDecl* decl)
 
     auto isEnumFlags = decl->hasModifier<FlagsAttribute>();
 
-    // Resolve the underlying integer kind once, so we can range-check the
-    // implicit tag advancement against the user-declared tag type.
-    BaseType tagBaseType = BaseType::Int;
+    // Resolve the underlying integer kind
+    BaseType tagBaseType;
     if (auto basicTagType = as<BasicExpressionType>(unwrapModifiedType(tagType)))
         tagBaseType = basicTagType->getBaseType();
+    else
+    {
+        getSink()->diagnose(Diagnostics::Unexpected{
+            .message = "Unexpected enumeration tag type",
+            .location = decl->getNameLoc()});
+        return;
+    }
 
     // Check the enum cases in order.
     for (auto caseDecl : decl->getMembersOfType<EnumCaseDecl>())

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -11508,10 +11508,7 @@ void SemanticsDeclBasesVisitor::visitEnumDecl(EnumDecl* decl)
 }
 
 // Increments an enumerator value and returns true if there was a wrap-around
-static bool _incrementEnumerator(
-    IntegerLiteralValue& value,
-    BaseType baseType,
-    bool isFlags)
+static bool _incrementEnumerator(IntegerLiteralValue& value, BaseType baseType, bool isFlags)
 {
     const BaseTypeInfo& info = BaseTypeInfo::getInfo(baseType);
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -11507,6 +11507,81 @@ void SemanticsDeclBasesVisitor::visitEnumDecl(EnumDecl* decl)
     }
 }
 
+// Increments an enumerator value and returns true if there was a wrap-around
+static bool _incrementEnumerator(
+    IntegerLiteralValue& value,
+    BaseType baseType,
+    bool isFlags)
+{
+    const BaseTypeInfo& info = BaseTypeInfo::getInfo(baseType);
+
+    // calculate the mask of significant bits for the type
+    uint64_t mask;
+    unsigned significantBits;
+
+    if (baseType == BaseType::Bool)
+    {
+        significantBits = 1U;
+    }
+    else
+    {
+        // generic numeric types
+        significantBits = (8U * info.sizeInBytes);
+    }
+
+    mask = std::numeric_limits<uint64_t>::max();
+    mask >>= 64U - significantBits;
+
+    if (isFlags)
+    {
+        // zero increments to 1, never overflows
+        if (value == 0)
+        {
+            value = 1;
+            return false;
+        }
+
+        // now shift left and detect overflow (note: correctness requires C++20)
+        value = (value << 1) & mask;
+        if (value == 0)
+        {
+            value = 1;
+            return true;
+        }
+
+        return false;
+    }
+    else
+    {
+        // detect overflow
+        if (info.flags & BaseTypeInfo::Flag::Signed)
+        {
+            unsigned excessBits = 64U - significantBits;
+            int64_t currentValue = value;
+
+            // do sign extension (note: correctness requires C++20)
+            currentValue <<= excessBits;
+            currentValue >>= excessBits;
+
+            // increment and do sign extension (note: correctness requires C++20)
+            int64_t nextValue = static_cast<uint64_t>(currentValue) + 1;
+            nextValue <<= excessBits;
+            nextValue >>= excessBits;
+
+            value = nextValue;
+            return currentValue > nextValue;
+        }
+        else
+        {
+            const uint64_t currentValue = static_cast<uint64_t>(value) & mask;
+            const uint64_t nextValue = (currentValue + 1U) & mask;
+
+            value = nextValue;
+            return currentValue > nextValue;
+        }
+    }
+}
+
 void SemanticsDeclBodyVisitor::visitEnumDecl(EnumDecl* decl)
 {
     SLANG_OUTER_SCOPE_CONTEXT_DECL_RAII(this, decl);
@@ -11519,6 +11594,12 @@ void SemanticsDeclBodyVisitor::visitEnumDecl(EnumDecl* decl)
         return;
 
     auto isEnumFlags = decl->hasModifier<FlagsAttribute>();
+
+    // Resolve the underlying integer kind once, so we can range-check the
+    // implicit tag advancement against the user-declared tag type.
+    BaseType tagBaseType = BaseType::Int;
+    if (auto basicTagType = as<BasicExpressionType>(unwrapModifiedType(tagType)))
+        tagBaseType = basicTagType->getBaseType();
 
     // Check the enum cases in order.
     for (auto caseDecl : decl->getMembersOfType<EnumCaseDecl>())
@@ -11540,6 +11621,7 @@ void SemanticsDeclBodyVisitor::visitEnumDecl(EnumDecl* decl)
     // For any enum case that didn't provide an explicit
     // tag value, derived an appropriate tag value.
     IntegerLiteralValue defaultTag = isEnumFlags ? 1 : 0;
+    bool defaultTagWrappedAround = false;
     for (auto caseDecl : decl->getMembersOfType<EnumCaseDecl>())
     {
         if (auto explicitTagValExpr = caseDecl->tagExpr)
@@ -11575,7 +11657,17 @@ void SemanticsDeclBodyVisitor::visitEnumDecl(EnumDecl* decl)
         else
         {
             // This tag has no initializer, so it should use
-            // the default tag value we are tracking.
+            // the default tag value we are tracking. If the implicit
+            // counter wrapped around past the underlying tag type's
+            // range on the previous step, this is the case that ends
+            // up consuming the wrapped value, so warn here.
+            if (defaultTagWrappedAround)
+            {
+                getSink()->diagnose(Diagnostics::EnumCaseImplicitTagValueOverflow{
+                    .tagType = tagType,
+                    .decl = caseDecl});
+            }
+
             IntegerLiteralExpr* tagValExpr = m_astBuilder->create<IntegerLiteralExpr>();
             tagValExpr->loc = caseDecl->loc;
             tagValExpr->type = QualType(tagType);
@@ -11584,18 +11676,8 @@ void SemanticsDeclBodyVisitor::visitEnumDecl(EnumDecl* decl)
             caseDecl->tagVal = m_astBuilder->getIntVal(enumType, defaultTag);
         }
 
-        // Default tag for the next case will be one more than
-        // for the most recent case.
-        //
-        if (!isEnumFlags)
-            defaultTag++;
-        else
-        {
-            if (defaultTag == 0)
-                defaultTag = 1;
-            else
-                defaultTag <<= 1;
-        }
+        // compute the next default tag value with the info whether it overflowed
+        defaultTagWrappedAround = _incrementEnumerator(defaultTag, tagBaseType, isEnumFlags);
     }
 }
 

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -2828,6 +2828,16 @@ err(
     span { loc = "expr:Expr", message = "unexpected form for 'enum' tag value expression" }
 )
 
+warning(
+    "enum-case-implicit-tag-value-overflow",
+    32006,
+    "implicit enum case value overflows underlying tag type",
+    span {
+        loc = "decl:Decl",
+        message = "implicit value for enum case '~decl' overflows tag type '~tagType:Type' and wraps around",
+    }
+)
+
 -- 303xx: interfaces and associated types
 
 err(

--- a/tests/bugs/11043-enum-constant-wraparound.slang
+++ b/tests/bugs/11043-enum-constant-wraparound.slang
@@ -1,0 +1,167 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -stage compute -entry main -target spirv
+
+enum TestEnumBool : bool
+{
+    Value1 = true,
+    Value2,
+/*CHECK:
+    ^^^^^^ warning E32006
+    ^^^^^^ overflows tag type 'bool' and wraps around
+*/
+    Value3,
+}
+
+enum TestEnumS8 : int8_t
+{
+    Value1 = 127,
+    Value2,
+/*CHECK:
+    ^^^^^^ warning E32006
+    ^^^^^^ overflows tag type 'int8_t' and wraps around
+*/
+    Value3,
+}
+
+enum TestEnumS8_NoWrapAround : int8_t
+{
+    Value1 = 127,
+    Value2 = -128, // no wraparound diagnostics here
+    Value3,
+}
+
+enum TestEnumU8 : uint8_t
+{
+    Value1 = 255U,
+    Value2,
+/*CHECK:
+    ^^^^^^ warning E32006
+    ^^^^^^ overflows tag type 'uint8_t' and wraps around
+*/
+    Value3,
+}
+
+enum TestEnumS16 : int16_t
+{
+    Value1 = 32767,
+    Value2,
+/*CHECK:
+    ^^^^^^ warning E32006
+    ^^^^^^ overflows tag type 'int16_t' and wraps around
+*/
+    Value3,
+}
+
+enum TestEnumU16 : uint16_t
+{
+    Value1 = 65535U,
+    Value2,
+/*CHECK:
+    ^^^^^^ warning E32006
+    ^^^^^^ overflows tag type 'uint16_t' and wraps around
+*/
+    Value3,
+}
+
+enum TestEnumDefault
+{
+    Value1 = 2147483647,
+    Value2,
+/*CHECK:
+    ^^^^^^ warning E32006
+    ^^^^^^ overflows tag type 'int' and wraps around
+*/
+    Value3,
+}
+
+enum TestEnumS32 : int32_t
+{
+    Value1 = 2147483647,
+    Value2,
+/*CHECK:
+    ^^^^^^ warning E32006
+    ^^^^^^ overflows tag type 'int' and wraps around
+*/
+    Value3,
+}
+
+enum TestEnumU32 : uint32_t
+{
+    Value1 = 4294967295U,
+    Value2,
+/*CHECK:
+    ^^^^^^ warning E32006
+    ^^^^^^ overflows tag type 'uint' and wraps around
+*/
+    Value3,
+}
+
+enum TestEnumS64 : int64_t
+{
+    Value1 = 9223372036854775807,
+    Value2,
+/*CHECK:
+    ^^^^^^ warning E32006
+    ^^^^^^ overflows tag type 'int64_t' and wraps around
+*/
+    Value3,
+}
+
+enum TestEnumU64 : uint64_t
+{
+    Value1 = 18446744073709551615ULL,
+    Value2,
+/*CHECK:
+    ^^^^^^ warning E32006
+    ^^^^^^ overflows tag type 'uint64_t' and wraps around
+*/
+    Value3,
+}
+
+[numthreads(1,1,1)]
+void main()
+{
+    // TestEnumBool wraparound verification
+    static_assert(TestEnumBool.Value1, "Value before wraparound");
+    static_assert(!TestEnumBool.Value2, "Value after wraparound");
+    static_assert(TestEnumBool.Value3, "Value after wraparound + 1");
+
+    // TestEnumS8 wraparound verification
+    static_assert(TestEnumS8.Value1 == 127, "Value before wraparound");
+    static_assert(TestEnumS8.Value2 == -128, "Value after wraparound");
+    static_assert(TestEnumS8.Value3 == -127, "Value after wraparound + 1");
+
+    // TestEnumS16 wraparound verification
+    static_assert(TestEnumS16.Value1 == 32767, "Value before wraparound");
+    static_assert(TestEnumS16.Value2 == -32768, "Value after wraparound");
+    static_assert(TestEnumS16.Value3 == -32767, "Value after wraparound + 1");
+
+    // TestEnumS32 wraparound verification
+    static_assert(TestEnumS32.Value1 == 2147483647, "Value before wraparound");
+    static_assert(TestEnumS32.Value2 == -2147483648, "Value after wraparound");
+    static_assert(TestEnumS32.Value3 == -2147483647, "Value after wraparound + 1");
+
+    // TestEnumS64 wraparound verification
+    static_assert(TestEnumS64.Value1 == 9223372036854775807LL, "Value before wraparound");
+    static_assert(TestEnumS64.Value2 == -9223372036854775808LL, "Value after wraparound");
+    static_assert(TestEnumS64.Value3 == -9223372036854775807LL, "Value after wraparound + 1");
+
+    // TestEnumU8 wraparound verification
+    static_assert(TestEnumU8.Value1 == 255, "Value before wraparound");
+    static_assert(TestEnumU8.Value2 == 0, "Value after wraparound");
+    static_assert(TestEnumU8.Value3 == 1, "Value after wraparound + 1");
+
+    // TestEnumU16 wraparound verification
+    static_assert(TestEnumU16.Value1 == 65535, "Value before wraparound");
+    static_assert(TestEnumU16.Value2 == 0, "Value after wraparound");
+    static_assert(TestEnumU16.Value3 == 1, "Value after wraparound + 1");
+
+    // TestEnumU32 wraparound verification
+    static_assert(TestEnumU32.Value1 == 4294967295, "Value before wraparound");
+    static_assert(TestEnumU32.Value2 == 0, "Value after wraparound");
+    static_assert(TestEnumU32.Value3 == 1, "Value after wraparound + 1");
+
+    // TestEnumU64 wraparound verification
+    static_assert(TestEnumU64.Value1 == 18446744073709551615ULL, "Value before wraparound");
+    static_assert(TestEnumU64.Value2 == 0ULL, "Value after wraparound");
+    static_assert(TestEnumU64.Value3 == 1ULL, "Value after wraparound + 1");
+}

--- a/tests/bugs/11043-enum-constant-wraparound.slang
+++ b/tests/bugs/11043-enum-constant-wraparound.slang
@@ -1,4 +1,5 @@
 //DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -stage compute -entry main -target spirv
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK_WARNING_DISABLED): -stage compute -entry main -target spirv -warnings-disable 32006
 
 enum TestEnumBool : bool
 {

--- a/tests/bugs/11043-enum-flag-wraparound.slang
+++ b/tests/bugs/11043-enum-flag-wraparound.slang
@@ -1,0 +1,157 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -stage compute -entry main -target spirv
+
+[Flags]
+enum TestEnumS8 : int8_t
+{
+    Bit6 = 0x40,
+    Bit7,
+    Bit0_Wraparound,
+/*CHECK:
+    ^^^^^^^^^^^^^^^ implicit enum case value overflows underlying tag type
+    ^^^^^^^^^^^^^^^ implicit value for enum case 'Bit0_Wraparound' overflows tag type 'int8_t' and wraps around
+*/
+    Bit1_Wraparound,
+}
+
+[Flags]
+enum TestEnumS8_NoWrapAround : int8_t
+{
+    Bit6 = 0x40,
+    Bit7,
+    Bit0_Reset = 0, // no wraparound diagnostics here
+}
+
+[Flags]
+enum TestEnumS16 : int16_t
+{
+    Bit14 = 0x4000,
+    Bit15,
+    Bit0_Wraparound,
+/*CHECK:
+    ^^^^^^^^^^^^^^^ implicit enum case value overflows underlying tag type
+    ^^^^^^^^^^^^^^^ implicit value for enum case 'Bit0_Wraparound' overflows tag type 'int16_t' and wraps around
+*/
+    Bit1_Wraparound,
+}
+
+[Flags]
+enum TestEnumS32 : int32_t
+{
+    Bit30 = 0x40000000,
+    Bit31,
+    Bit0_Wraparound,
+/*CHECK:
+    ^^^^^^^^^^^^^^^ implicit enum case value overflows underlying tag type
+    ^^^^^^^^^^^^^^^ implicit value for enum case 'Bit0_Wraparound' overflows tag type 'int' and wraps around
+*/
+    Bit1_Wraparound,
+}
+
+[Flags]
+enum TestEnumS64 : int64_t
+{
+    Bit62 = 0x4000000000000000,
+    Bit63,
+    Bit0_Wraparound,
+/*CHECK:
+    ^^^^^^^^^^^^^^^ implicit enum case value overflows underlying tag type
+    ^^^^^^^^^^^^^^^ implicit value for enum case 'Bit0_Wraparound' overflows tag type 'int64_t' and wraps around
+*/
+    Bit1_Wraparound,
+}
+
+[Flags]
+enum TestEnumU8 : uint8_t
+{
+    Bit6 = 0x40,
+    Bit7,
+    Bit0_Wraparound,
+/*CHECK:
+    ^^^^^^^^^^^^^^^ implicit enum case value overflows underlying tag type
+    ^^^^^^^^^^^^^^^ implicit value for enum case 'Bit0_Wraparound' overflows tag type 'uint8_t' and wraps around
+*/
+    Bit1_Wraparound,
+}
+
+[Flags]
+enum TestEnumU16 : uint16_t
+{
+    Bit14 = 0x4000,
+    Bit15,
+    Bit0_Wraparound,
+/*CHECK:
+    ^^^^^^^^^^^^^^^ implicit enum case value overflows underlying tag type
+    ^^^^^^^^^^^^^^^ implicit value for enum case 'Bit0_Wraparound' overflows tag type 'uint16_t' and wraps around
+*/
+    Bit1_Wraparound,
+}
+
+[Flags]
+enum TestEnumU32 : uint32_t
+{
+    Bit30 = 0x40000000,
+    Bit31,
+    Bit0_Wraparound,
+/*CHECK:
+    ^^^^^^^^^^^^^^^ implicit enum case value overflows underlying tag type
+    ^^^^^^^^^^^^^^^ implicit value for enum case 'Bit0_Wraparound' overflows tag type 'uint' and wraps around
+*/
+    Bit1_Wraparound,
+}
+
+[Flags]
+enum TestEnumU64 : uint64_t
+{
+    Bit62 = 0x4000000000000000,
+    Bit63,
+    Bit0_Wraparound,
+/*CHECK:
+    ^^^^^^^^^^^^^^^ implicit enum case value overflows underlying tag type
+    ^^^^^^^^^^^^^^^ implicit value for enum case 'Bit0_Wraparound' overflows tag type 'uint64_t' and wraps around
+*/
+    Bit1_Wraparound,
+}
+
+[numthreads(1,1,1)]
+void main()
+{
+    // TestEnumS8 verification
+    static_assert(TestEnumS8.Bit7 == 0x80, "Flag before wraparound");
+    static_assert(TestEnumS8.Bit0_Wraparound == 0x01, "Flag after wraparound");
+    static_assert(TestEnumS8.Bit1_Wraparound == 0x02, "Flag after wraparound + 1");
+
+    // TestEnumS16 verification
+    static_assert(TestEnumS16.Bit15 == 0x8000, "Flag before wraparound");
+    static_assert(TestEnumS16.Bit0_Wraparound == 0x01, "Flag after wraparound");
+    static_assert(TestEnumS16.Bit1_Wraparound == 0x02, "Flag after wraparound + 1");
+
+    // TestEnumS32 verification
+    static_assert(TestEnumS32.Bit31 == 0x80000000, "Flag before wraparound");
+    static_assert(TestEnumS32.Bit0_Wraparound == 0x01, "Flag after wraparound");
+    static_assert(TestEnumS32.Bit1_Wraparound == 0x02, "Flag after wraparound + 1");
+
+    // TestEnumS64 verification
+    static_assert(TestEnumS64.Bit63 == 0x8000000000000000LL, "Flag before wraparound");
+    static_assert(TestEnumS64.Bit0_Wraparound == 0x01, "Flag after wraparound");
+    static_assert(TestEnumS64.Bit1_Wraparound == 0x02, "Flag after wraparound + 1");
+
+    // TestEnumU8 verification
+    static_assert(TestEnumU8.Bit7 == 0x80, "Flag before wraparound");
+    static_assert(TestEnumU8.Bit0_Wraparound == 0x01, "Flag after wraparound");
+    static_assert(TestEnumU8.Bit1_Wraparound == 0x02, "Flag after wraparound + 1");
+
+    // TestEnumU16 verification
+    static_assert(TestEnumU16.Bit15 == 0x8000, "Flag before wraparound");
+    static_assert(TestEnumU16.Bit0_Wraparound == 0x01, "Flag after wraparound");
+    static_assert(TestEnumU16.Bit1_Wraparound == 0x02, "Flag after wraparound + 1");
+
+    // TestEnumU32 verification
+    static_assert(TestEnumU32.Bit31 == 0x80000000, "Flag before wraparound");
+    static_assert(TestEnumU32.Bit0_Wraparound == 0x01, "Flag after wraparound");
+    static_assert(TestEnumU32.Bit1_Wraparound == 0x02, "Flag after wraparound + 1");
+
+    // TestEnumU64 verification
+    static_assert(TestEnumU64.Bit63 == 0x8000000000000000LL, "Flag before wraparound");
+    static_assert(TestEnumU64.Bit0_Wraparound == 0x01, "Flag after wraparound");
+    static_assert(TestEnumU64.Bit1_Wraparound == 0x02, "Flag after wraparound + 1");
+}


### PR DESCRIPTION
Diagnose an enumerator overflow as a warning. Add also targeted testing for diagnostics and overflow behavior.

Fixes #11043