### PR TITLE
Add severity comment to generated rich diagnostic structs

### DIFF
--- a/source/slang/slang-rich-diagnostics.h
+++ b/source/slang/slang-rich-diagnostics.h
@@ -35,6 +35,7 @@ Index getRichDiagnosticsInfoCount();
 % local diagnostics = lua_module.getDiagnostics()
 % for _, diagnostic in ipairs(diagnostics) do
 %     local class_name = lua_module.toPascalCase(diagnostic.name)
+// $(diagnostic.severity): $(diagnostic.name) ($(diagnostic.code))
 struct $(class_name)
 {
 %     -- Direct parameters (non-variadic or shared)


### PR DESCRIPTION
## Summary
- Adds a severity/name/code comment above each generated struct in `slang-rich-diagnostics.h.fiddle`, e.g. `// error: cannot-open-file (1)` or `// warning: separate-debug-info-unsupported-for-target (18)`
- Makes it easy to see at a glance whether a `Diagnostics::Foo` struct is an error, warning, etc. without having to look up the definition in `slang-diagnostics.lua`

Closes #11122

## Test plan
- All diagnostic tests pass
- Generated output verified to contain correct severity annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)