### PR TITLE
Fix spurious push constant storage capabilities

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -9661,7 +9661,6 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     visited);
             break;
 
-        case kIROp_PtrType:
         case kIROp_RefParamType:
         case kIROp_BorrowInParamType:
         case kIROp_OutParamType:
@@ -9672,6 +9671,17 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     targets,
                     found,
                     visited);
+            break;
+
+        case kIROp_PtrType:
+            // A pointer's pointee is not stored inline in the outer container;
+            // it lives in whatever storage class the pointer's address space
+            // names.  Do not recurse through pointers when deciding whether
+            // the outer container needs 8/16-bit-storage capabilities --
+            // otherwise a `uint16_t*` BDA argument in a push-constant block
+            // would spuriously require `StoragePushConstant16` (issue #11096).
+            // The pointee's own storage-class requirements are handled when
+            // that storage class is emitted.
             break;
 
         case kIROp_RateQualifiedType:

--- a/tests/spirv/bda-pointer-no-spurious-storage-capability.slang
+++ b/tests/spirv/bda-pointer-no-spurious-storage-capability.slang
@@ -1,0 +1,28 @@
+// Regression for #11096: a `uint16_t*` kernel argument (BDA pointer) bundled
+// into the entry-point push-constant block used to spuriously require
+// `StoragePushConstant16`, because `checkTypeNeedsStorageCapability`
+// recursed through pointer types into their pointee.  The pointee lives
+// in PhysicalStorageBuffer, not the outer container's storage class.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main -stage compute
+
+[shader("compute")]
+[numthreads(512, 1, 1)]
+void main(
+    uint* param1,
+    uint16_t* param2,
+    uniform int iteration,
+    uint3 groupThreadID : SV_GroupThreadID,
+    uint3 groupId : SV_GroupID)
+{
+    param1[groupId.x] = (uint)param2[groupThreadID.x] + iteration;
+}
+
+// The push-constant block contains BDA addresses and a plain int32 only --
+// no inline 16-bit scalars -- so none of the *16 storage capabilities
+// should be required.
+// CHECK-NOT: OpCapability StoragePushConstant16
+// CHECK-NOT: OpCapability UniformAndStorageBuffer16BitAccess
+// CHECK: OpCapability PhysicalStorageBufferAddresses
+// The pointee is a uint16_t, so Int16 is still needed.
+// CHECK: OpCapability Int16

--- a/tests/spirv/push-constant-ptr-no-storage-push-constant8.slang
+++ b/tests/spirv/push-constant-ptr-no-storage-push-constant8.slang
@@ -1,0 +1,24 @@
+// Regression for #10055: a push-constant block containing a pointer to
+// uint8_t should not require StoragePushConstant8. The push constant stores a
+// physical-storage-buffer address; the pointed-to uint8_t lives in that storage
+// class, not inline in the push-constant block.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main -stage compute
+
+struct CSInput
+{
+    uint8_t* output;
+};
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void main(uint DTid: SV_DispatchThreadID, uniform CSInput consts)
+{
+    consts.output[DTid] = 1;
+}
+
+// CHECK-NOT: OpCapability StoragePushConstant8
+// CHECK: OpCapability PhysicalStorageBufferAddresses
+// The pointee is a uint8_t, so Int8 is still needed.
+// CHECK: OpCapability Int8
+// CHECK-NOT: OpCapability StoragePushConstant8


### PR DESCRIPTION
Fixes #10055.

This stops the SPIR-V storage-capability scan from recursing through ordinary pointer types: a pointer's pointee is not stored inline in the surrounding push-constant/uniform/storage-buffer container, so its bit width should not cause capabilities such as `StoragePushConstant8` or `StoragePushConstant16` to be emitted for the outer container.

The change preserves recursion through ref/out/borrowed parameter wrappers, and adds regression coverage for both the `uint8_t*` push-constant case from #10055 and a related BDA pointer-to-`uint16_t` case.

Local validation:
- `cmake --preset default`
- `cmake --build --preset release --target slang-test slangc`
- `./build/Release/bin/slang-test tests/spirv/push-constant-ptr-no-storage-push-constant8.slang tests/spirv/bda-pointer-no-spurious-storage-capability.slang`

Note: reviewers, please @-mention `@thorn-agent` in review comments so I receive notifications for follow-up.