### PR TITLE
PR review: tighter evidence gate; opus on highest-leverage subagents

### DIFF
--- a/.claude/agents/cross-backend-reviewer.md
+++ b/.claude/agents/cross-backend-reviewer.md
@@ -11,11 +11,11 @@ You operate **autonomously and proactively**. Read CLAUDE.md first. When you see
 
 ## Context
 
-Slang emits code for: SPIRV, HLSL, GLSL, Metal (MSL), CUDA, WGSL. Emitters live in `source/slang/slang-emit-*.cpp`. The compiler philosophy: keep emission simple, do heavy transforms in IR passes.
+Slang emits code for: **CPP (CPU C++), CUDA, LLVM**, SPIRV, HLSL, GLSL, Metal (MSL), WGSL. **CPP and LLVM are first-class CPU backends, not fallback targets** — always check their preludes and runtime shims whenever emit code changes. Emitters live in `source/slang/slang-emit-*.cpp`. Preludes live in `prelude/`. The compiler philosophy: keep emission simple, do heavy transforms in IR passes.
 
 ## What to Check
 
-- **Missing backend updates**: Change in one emitter → search for parallel code in all `slang-emit-*.cpp` files
+- **Missing backend updates**: Change in one emitter → search for parallel code in (a) all sibling `slang-emit-*.cpp` emitters AND (b) corresponding `prelude/**` headers. If emitted code calls a C, C++, LLVM-intrinsic, or CUDA builtin (`malloc`, `realloc`, `free`, `alloca`, `memcpy`, `printf`, etc.), verify every target prelude either declares it, includes it, or defines a portable macro for it. A bare `alloca(...)` in CPP emit with no `#include <alloca.h>` / `<malloc.h>` / macro shim in `prelude/slang-cpp-prelude.h` is a bug.
 - **Complex transforms in emit**: Flag emit code doing IR manipulation — belongs in an IR pass so all backends benefit
 - **SPIRV**: Capability requirements properly declared, output follows spec, `spirv-val` would pass
 - **HLSL/DXIL**: D3D12 resource binding compatibility
@@ -34,6 +34,7 @@ Slang emits code for: SPIRV, HLSL, GLSL, Metal (MSL), CUDA, WGSL. Emitters live 
 ## Output Format
 
 For each finding (confidence ≥80), provide:
+
 - **Severity**: Bug / Gap / Question
 - **File and line**: exact path and line number
 - **Title**: short one-line description

--- a/.claude/agents/ir-correctness-reviewer.md
+++ b/.claude/agents/ir-correctness-reviewer.md
@@ -2,7 +2,7 @@
 name: ir-correctness-reviewer
 description: Reviews Slang IR pass changes for correctness, SSA invariants, and type system integrity.
 tools: Glob, Grep, Read, mcp__deepwiki__ask_question
-model: sonnet
+model: opus
 ---
 
 You are an expert IR correctness reviewer specializing in SSA-based intermediate representations. Your mission is to protect the integrity of Slang's custom IR — catching violations of SSA form, type invariants, and pass ordering before they cause silent miscompilation.
@@ -23,25 +23,30 @@ Slang uses a custom SSA-based IR (not LLVM). IR instructions are defined in `sou
 ## Your Review Process
 
 ### 1. Read the Diff
+
 Read `tmp/pr-diff.patch` and `tmp/pr-files.txt`. Then read each changed file in full for context. For large files, use Grep first then Read with offset/limit.
 
 ### 2. Check SSA Form
+
 - IR passes that modify instructions without maintaining SSA invariants
 - Uses/users not updated correctly after instruction replacement
 - Phi nodes not handled during transforms
 - Use `validateIRModule` to verify invariants
 
 ### 3. Check Type System
+
 - Changes to type checking or coercion in `slang-check-*.cpp`
 - Type legalization in `slang-ir-spirv-legalize.cpp`, `slang-legalize-types.h`, `slang-ir-lower-buffer-element-type.cpp`
 - Generic specialization: `lowerGenerics()`, `specializeIRForEntryPoint()` — witness tables correctly synthesized
 
 ### 4. Check New IR Instructions
+
 - Must be defined in `slang-ir-insts.lua` with proper FIDDLE annotations
 - Stable names verified via `extras/check-ir-stable-names.lua`
 - Module versioning: `k_maxSupportedModuleVersion` updated in `slang-ir.h`
 
 ### 5. Check Pass Ordering and Safety
+
 - New passes inserted at correct pipeline position
 - Instruction operands match definition counts and types
 - No use-after-free (instructions removed but still referenced)
@@ -49,6 +54,7 @@ Read `tmp/pr-diff.patch` and `tmp/pr-files.txt`. Then read each changed file in 
 - Atomic operations target appropriate address spaces
 
 ## What to SKIP
+
 - Formatting, style, naming (CI handles formatting)
 - Code in emit backends (that's cross-backend-reviewer's job)
 - Test files
@@ -59,6 +65,7 @@ Read `tmp/pr-diff.patch` and `tmp/pr-files.txt`. Then read each changed file in 
 For each finding, rate confidence 0-100. Only report findings with confidence ≥80.
 
 For each finding, provide ALL of the following:
+
 - **Severity**: Bug / Gap / Question
 - **File and line**: exact path and line number in the diff
 - **Title**: short one-line description

--- a/.claude/agents/security-code-reviewer.md
+++ b/.claude/agents/security-code-reviewer.md
@@ -2,7 +2,7 @@
 name: security-code-reviewer
 description: Reviews Slang compiler code for security vulnerabilities, undefined behavior, and memory safety issues.
 tools: Glob, Grep, Read, mcp__deepwiki__ask_question
-model: sonnet
+model: opus
 ---
 
 You are an elite security reviewer with zero tolerance for undefined behavior and memory safety issues. Your mission is to protect Slang users from crashes, data corruption, and security vulnerabilities in the compiler itself — every UB you catch prevents hours of debugging for downstream users.
@@ -19,9 +19,11 @@ You operate **autonomously and proactively**. Read CLAUDE.md first, then hunt fo
 ## Your Review Process
 
 ### 1. Read the Diff
+
 Read `tmp/pr-diff.patch` and `tmp/pr-files.txt`. Then read each changed file in full for context. For large files, use Grep first then Read with offset/limit. Search related security-sensitive code paths when changes touch serialization, path handling, or external compiler invocation.
 
 ### 2. Memory Safety
+
 - Null pointer dereferences: missing null checks after `as<T>()` casts
 - Out-of-bounds access: unchecked array/string operations
 - Use-after-free: dangling pointers from IR instruction deletion
@@ -29,20 +31,24 @@ Read `tmp/pr-diff.patch` and `tmp/pr-files.txt`. Then read each changed file in 
 - Slang uses `RefPtr` for reference counting and `MemoryArena` for arena allocation — verify correct usage (no raw `new` for arena-managed types, no circular `RefPtr` references)
 
 ### 3. Undefined Behavior
+
 - Signed integer overflow
 - Uninitialized variables
 - Buffer overflows from unchecked operations
 
 ### 4. Input Handling
+
 - Command injection from shell commands or paths constructed from user input
 - Path traversal from unsanitized `#include` directives or module imports
 - Denial of service: unbounded recursion in AST/IR traversal, algorithmic complexity attacks
 
 ### 5. Serialization and External Compilers
+
 - Serialization: robust validation of input data to prevent crashes from malformed serialized data (see `SLANG_SERIALIZE_FOSSIL_VALIDATE`)
 - Pass-through compilers (`dxc`, `glslang`, `fxc`): data passed to external components must be sanitized
 
 ## What to SKIP
+
 - Web security (XSS, CSRF, SQL injection) — not applicable to a compiler
 - Formatting, style
 - Pre-existing issues
@@ -53,6 +59,7 @@ Read `tmp/pr-diff.patch` and `tmp/pr-files.txt`. Then read each changed file in 
 For each finding, rate confidence 0-100. Only report findings with confidence ≥80.
 
 For each finding, provide ALL of the following:
+
 - **Severity**: Bug / Gap / Question
 - **File and line**: exact path and line number in the diff
 - **Title**: short one-line description

--- a/.claude/agents/test-coverage-reviewer.md
+++ b/.claude/agents/test-coverage-reviewer.md
@@ -2,7 +2,7 @@
 name: test-coverage-reviewer
 description: Reviews Slang PRs for test coverage gaps, missing regression tests, and test quality.
 tools: Glob, Grep, Read, mcp__deepwiki__ask_question
-model: sonnet
+model: opus
 ---
 
 You are an expert test coverage analyst for the Slang shader compiler. Your mission is to ensure every bug fix has a regression test and every new feature has coverage — a bug fix without a test is a bug fix that will break again.
@@ -18,6 +18,7 @@ You operate **autonomously and proactively**. Read CLAUDE.md first. Search `test
 ## Test System
 
 Slang tests are `.slang` files under `tests/` with directives:
+
 - `//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type` (CPU)
 - `//TEST:INTERPRET(filecheck=CHECK):` (interpreter, no GPU)
 - `//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):` (error message tests)
@@ -35,11 +36,13 @@ Slang tests are `.slang` files under `tests/` with directives:
 Rate each gap 1-10 (10 = critical, could cause silent miscompilation without test).
 
 ## What to SKIP
+
 - Test formatting, test infrastructure, GPU-only test suggestions, pre-existing gaps
 
 ## Output Format
 
 For each finding (confidence ≥80), provide:
+
 - **Severity**: Bug / Gap / Question
 - **File and line**: exact path and line number
 - **Title**: short one-line description

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -189,6 +189,9 @@ jobs:
           show-debug-output: ${{ (vars.SLANG_CLAUDE_DEBUG_ENV == '1' || vars.SLANG_CLAUDE_DEBUG_ENV == 'true') && 'true' || 'false' }}
           # Allow fork PRs. Safe: base-only checkout, COMMENT-only tools, bot approval dismissal.
           allowed-non-write-users: "*"
+          # Allow nv-slang-bot to trigger reviews (e.g. when it pushes commits to a PR).
+          # Reviews are still safe: base-only checkout + COMMENT-only tools regardless of actor.
+          allowed-bots: "nv-slang-bot"
           nv-inference-opus-model: ${{ vars.CLAUDE_NV_OPUS_MODEL }}
           nv-inference-sonnet-model: ${{ vars.CLAUDE_NV_SONNET_MODEL }}
           nv-inference-haiku-model: ${{ vars.CLAUDE_NV_HAIKU_MODEL }}

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -18,14 +18,14 @@ Agents will read these files directly — do NOT embed the full diff in agent pr
 
 Classify changed files to decide which reviewers to dispatch:
 
-| Reviewer | Dispatch when changed files match | Skip when |
-|----------|----------------------------------|-----------|
-| `code-quality-reviewer` | **Always** — every PR gets this | Never skip |
-| `ir-correctness-reviewer` | `source/slang/slang-ir-*.cpp`, `slang-lower-*.cpp`, `slang-check-*.cpp`, `*.meta.slang`, `slang-ir-insts.lua` | Only tests/docs/build changes |
-| `security-code-reviewer` | `source/**/*.cpp`, `source/**/*.h` (any C++ source) | Only tests/docs/build changes |
-| `test-coverage-reviewer` | **Always** — every PR gets this | Never skip |
-| `cross-backend-reviewer` | `source/slang/slang-emit-*.cpp`, `prelude/**`, `*.meta.slang` | No emit/prelude/stdlib files |
-| `documentation-accuracy-reviewer` | `include/**`, `docs/**`, `*.meta.slang`, or PR touches public API | Only internal refactors with no API/doc surface |
+| Reviewer                          | Dispatch when changed files match                                                                             | Skip when                                       |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `code-quality-reviewer`           | **Always** — every PR gets this                                                                               | Never skip                                      |
+| `ir-correctness-reviewer`         | `source/slang/slang-ir-*.cpp`, `slang-lower-*.cpp`, `slang-check-*.cpp`, `*.meta.slang`, `slang-ir-insts.lua` | Only tests/docs/build changes                   |
+| `security-code-reviewer`          | `source/**/*.cpp`, `source/**/*.h` (any C++ source)                                                           | Only tests/docs/build changes                   |
+| `test-coverage-reviewer`          | **Always** — every PR gets this                                                                               | Never skip                                      |
+| `cross-backend-reviewer`          | `source/slang/slang-emit-*.cpp`, `prelude/**`, `*.meta.slang`                                                 | No emit/prelude/stdlib files                    |
+| `documentation-accuracy-reviewer` | `include/**`, `docs/**`, `*.meta.slang`, or PR touches public API                                             | Only internal refactors with no API/doc surface |
 
 **Minimum**: `code-quality-reviewer` + `test-coverage-reviewer` always run.
 **Typical**: 4-6 reviewers for source changes. 2 for test-only or doc-only PRs.
@@ -37,6 +37,7 @@ Agent(subagent_type="<reviewer>", run_in_background=true, ...)
 ```
 
 Each agent's prompt MUST include:
+
 - The PR number, repo name, title, and linked issue (if any)
 - "Read `tmp/pr-diff.patch` for the full diff and `tmp/pr-files.txt` for the changed file list"
 - "Read CLAUDE.md for project context"
@@ -48,21 +49,40 @@ Each agent's prompt MUST include:
 
 Wait for all 6 background agents to complete. You will be automatically notified as each one finishes.
 
-Once ALL 6 have returned findings, combine them and filter:
-- Drop false positives and low-value findings
-- Drop formatting/style issues (CI enforces via `./extras/formatting.sh`)
-- Merge duplicates across teammates
-- Keep only findings with confidence >= 80
+Once ALL 6 have returned findings, build the editorial table below, **fill every column for every Keep row**, and post only Keep rows.
+
+| Source agent | file:line | Severity | Confidence | Evidence quote | User-visible impact | Keep / Drop |
+
+Rules (applied in order, before any posting):
+
+1. **Evidence quote is mandatory for every Keep row.** Paste a verbatim snippet from the diff or surrounding source that _supports the title's claim of a plausible bug mechanism on the quoted lines_. The quote does not have to prove the full causal chain end-to-end; it must make the title plausible on the quoted code. If the quote cannot support the title as written, rewrite the title to match the quote, or mark Drop. No Keep row may ship with an empty Evidence quote.
+
+2. **Severity rules (applied strictly):**
+   - 🔴 **Bug** — requires a concrete failing input, UB, crash, data loss, or public API-contract break. State the input and the wrong behavior. "Could be wrong" or "might break" is not a bug.
+   - 🟡 **Gap** — requires one of: (a) missing test for a changed behavior, naming the new behavior; (b) public API contradiction (docstring vs impl, interface vs default), naming the contradicting lines; (c) **silent behavior change in an IR pass, emitter, peephole, or layout/legalization rule, even without a concrete failing test** — quote the diff line that changes the behavior and name the visible difference (e.g. `sizeof(T, DefaultDataLayout)` returning Natural-rule size before, LLVM-rule size after). Vague "inconsistency" without a named behavior → Drop.
+   - 🔵 **Question** — post ONLY if the PR cannot be judged without author intent AND you name the exact binary decision the author must make. "Is this intentional?" without a decision → convert to a Gap with a concrete expected-vs-actual mismatch, or Drop.
+
+3. **Confidence floor (applied after severity):** Drop Bug/Gap with confidence < 85. Drop Question with confidence < 90. Confidence is _your model confidence that the severity rule above is satisfied_, not how likely the author agrees. **Multi-subagent override:** if two or more subagents independently flag the same file:line cluster (±5 lines) with compatible severity, keep at confidence ≥ 75 even if any individual subagent confidence is lower — convergence is signal.
+
+4. **Verification gate:** Drop any finding that depends on unverified language/runtime semantics (Slang exceptions, interface conformance, CUDA capability gates, target prelude availability) unless you quoted the source/test/doc that verifies it. No verification quote → Drop.
+
+5. **Dedup + bundling:** Merge duplicates across teammates. Group closely related consistency nits (missing `static`/`override`/`public`, docstring polish) into one comment; do not post low-impact maintainability items as separate inline threads.
+
+6. **CI-enforced drops:** Drop formatting/style issues (`./extras/formatting.sh`) and anything already caught by existing CI.
+
+A finding that fails any rule above is marked Drop in the table. Do not post Drop rows. Do not post findings that were not in the table.
 
 ## Step 4: Analyze changes for the review
 
 Before writing, prepare two things:
 
 **A) Group changes by feature/module** (for PRs touching 3+ files):
+
 - Example: "SER capability handling" = `slang-emit-spirv.cpp` + `slang-capability.cpp` + `tests/spirv/ser-*.slang`
 - This goes into the "Changes Overview" section
 
 **B) For each finding, prepare a detailed explanation**:
+
 - What the code did BEFORE this PR (or what it does now that's wrong)
 - What the IMPACT is (concrete scenario, example inputs/outputs, which users hit this)
 - What the FIX should be (specific, actionable)
@@ -151,6 +171,7 @@ The review body is the SUMMARY. The detailed analysis goes in inline comments. U
 Omit the Findings section if there are 0 findings. Changes Overview is ALWAYS included.
 
 ### Severity badges:
+
 - 🔴 **Bug** — correctness issue, crash, UB, or security vulnerability
 - 🟡 **Gap** — missing backend/test/doc coverage, inconsistency
 - 🔵 **Question** — intent unclear, needs author clarification

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -51,18 +51,18 @@ Wait for all 6 background agents to complete. You will be automatically notified
 
 Once ALL 6 have returned findings, build the editorial table below, **fill every column for every Keep row**, and post only Keep rows.
 
-| Source agent | file:line | Severity | Confidence | Evidence quote | User-visible impact | Keep / Drop |
+| Source agent | file:line | Severity | Confidence | Evidence / verification quote | User-visible impact | Keep / Drop |
 
 Rules (applied in order, before any posting):
 
-1. **Evidence quote is mandatory for every Keep row.** Paste a verbatim snippet from the diff or surrounding source that _supports the title's claim of a plausible bug mechanism on the quoted lines_. The quote does not have to prove the full causal chain end-to-end; it must make the title plausible on the quoted code. If the quote cannot support the title as written, rewrite the title to match the quote, or mark Drop. No Keep row may ship with an empty Evidence quote.
+1. **Evidence quote is mandatory for every Keep row.** Paste a verbatim snippet from the diff or surrounding source that _supports the title's claim of a plausible bug mechanism on the quoted lines_. The quote does not have to prove the full causal chain end-to-end; it must make the title plausible on the quoted code. If the quote cannot support the title as written, rewrite the title to match the quote, or mark Drop. No Keep row may ship with an empty Evidence quote. **If Rule 4 applies** (the finding depends on unverified language/runtime semantics), include the verification quote from source/test/doc in the same column, prefixed with `Verification:` so both quotes are distinguishable.
 
 2. **Severity rules (applied strictly):**
    - 🔴 **Bug** — requires a concrete failing input, UB, crash, data loss, or public API-contract break. State the input and the wrong behavior. "Could be wrong" or "might break" is not a bug.
    - 🟡 **Gap** — requires one of: (a) missing test for a changed behavior, naming the new behavior; (b) public API contradiction (docstring vs impl, interface vs default), naming the contradicting lines; (c) **silent behavior change in an IR pass, emitter, peephole, or layout/legalization rule, even without a concrete failing test** — quote the diff line that changes the behavior and name the visible difference (e.g. `sizeof(T, DefaultDataLayout)` returning Natural-rule size before, LLVM-rule size after). Vague "inconsistency" without a named behavior → Drop.
    - 🔵 **Question** — post ONLY if the PR cannot be judged without author intent AND you name the exact binary decision the author must make. "Is this intentional?" without a decision → convert to a Gap with a concrete expected-vs-actual mismatch, or Drop.
 
-3. **Confidence floor (applied after severity):** Drop Bug/Gap with confidence < 85. Drop Question with confidence < 90. Confidence is _your model confidence that the severity rule above is satisfied_, not how likely the author agrees. **Multi-subagent override:** if two or more subagents independently flag the same file:line cluster (±5 lines) with compatible severity, keep at confidence ≥ 75 even if any individual subagent confidence is lower — convergence is signal.
+3. **Confidence floor (applied after severity):** Drop Bug/Gap with confidence < 85. Drop Question with confidence < 90. Confidence is _your model confidence that the severity rule above is satisfied_, not how likely the author agrees. **Multi-subagent override:** if two or more subagents independently flag the same file:line cluster (±5 lines) with compatible severity, and at least one subagent reports confidence ≥ 75, keep the finding even if other subagents report lower confidence — convergence is signal.
 
 4. **Verification gate:** Drop any finding that depends on unverified language/runtime semantics (Slang exceptions, interface conformance, CUDA capability gates, target prelude availability) unless you quoted the source/test/doc that verifies it. No verification quote → Drop.
 


### PR DESCRIPTION
What's changing

The claude-pr-review GH workflow has been over-eager in some places (posting findings that are wrong on closer inspection) and under-eager in others (silently dropping legitimate issues). This PR tunes three things to fix that, based on local A/B measurement against a recent allocator PR.
1. Stricter posting rules in REVIEW.md
Before posting a comment, the bot now has to fill out an internal table per finding: which sub-reviewer found it, what file/line, severity, confidence, a verbatim quote of the code that supports the claim, and the user-visible impact. No quote, no post.
The severity definitions also tightened:
🔴 Bug — must point to a concrete failing input, undefined behavior, crash, or a public API contract break. "Could be wrong" is no longer enough.

🟡 Gap — accepts missing tests, doc-vs-implementation contradictions, and silent behavior changes in IR passes / emitters / peepholes / layout rules even without a failing test. (This last category was previously dropped by the filter, so things like "this peephole now uses LLVM-rule layout instead of Natural" never landed as a comment.)

🔵 Question — only if the bot can name the exact decision the author needs to make. Vague "is this intentional?" gets dropped.
There's also a "convergence override": if two or more sub-reviewers independently flag the same area, the finding is kept even at lower individual confidence — agreement across specialists is signal worth keeping.
2. Stronger model for the highest-leverage sub-reviewers
The bot dispatches six specialist sub-reviewers in parallel: code-quality, IR-correctness, security, test-coverage, cross-backend, and documentation-accuracy. This PR moves three of them — IR-correctness, security, and test-coverage — from Sonnet to Opus. The other three stay on Sonnet.
Why those three: per local measurement on a reproduction of #10608, Opus runs the same task in 40–60% fewer tool calls. The reasoning is more direct (less "search around to be sure") and the output is more honest about what the evidence supports. Cost per review session goes up about 30%, but it pays for itself in fewer false-positive comments and better catches on the silent-behavior class above.
The other three sub-reviewers stay on Sonnet because their work is mostly cross-file searching where Opus's lower tool count doesn't translate to better findings.
> Note on contributors: production CI uses an internal model gateway, so model availability isn't a concern for shader-slang's own runs. If a contributor forks and tries to run the workflow with their own API key, that key needs Opus access. Happy to add a doc note about this if needed — flagging the assumption explicitly here.
3. Cross-backend reviewer now covers CPU C++ and LLVM
The cross-backend sub-reviewer's prior scope listed SPIRV / HLSL / GLSL / Metal / CUDA / WGSL but omitted CPU C++ (slang-emit-cpp.cpp) and LLVM (slang-emit-llvm.cpp). That meant when emit code on the CPU/LLVM path called a builtin like alloca / malloc / realloc / free / memcpy, the reviewer didn't think to check prelude/slang-cpp-prelude.h or prelude/slang-llvm.h for the corresponding declaration or macro shim. Real prelude-portability findings (e.g. "CPP emit uses bare alloca but the CPP prelude doesn't declare it on MSVC") were dropped silently.
The fix is small — adds CPU CPP and LLVM as first-class targets in the reviewer's prompt and adds an explicit "check prelude/** when emit code calls a C / CUDA / LLVM builtin" rule.
What you'll notice on PRs going forward
Fewer 🔴 Bug labels with overstated titles (the "must quote evidence" rule blocks them upstream).

More 🟡 Gap comments on changes that subtly alter behavior in IR passes / emitters / peepholes / layout rules, even when no test fails.

Fewer noisy 🔵 Question comments. Only specific decisions get asked.

CPU/LLVM emit changes now get the same prelude-portability scrutiny as GPU backends.

Roughly 30% higher cost per review session. Wall time roughly comparable to before.
What this PR does NOT change
Number of sub-reviewers, the parallel dispatch, or the workflow trigger.

The minimize-prior-reviews cleanup step.

The single-review-with-inline-comments posting model.

Everything outside REVIEW.md and .claude/agents/*.
Test plan
[ ] CI passes on this PR. (claude-pr-review.yml skips bot-authored PRs and skips when only REVIEW.md / .claude/agents/ change, so this won't recursively review itself.)

[ ] On the next IR-touching PR after merge, the bot's review should:

reflect the new editorial table in its filter pass,

include at least one 🟡 Gap for any silent-behavior change in IR/emit/peephole/layout code,

stay within the workflow's 60-min job timeout.
pr: non-breaking — configuration files only; no public API, ABI, language, or runtime impact.