### PR TITLE
ci-analytics: track GitHub-hosted runner usage against the 20-runner cap

### DIFF
--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -26,6 +26,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from ci_visualization import page_template, chart_section, DOWNLOAD_JS
 from ci_hosted_runner_usage import (
     DEFAULT_HOSTED_RUNNER_CAP,
+    HOSTED_LABEL_PREFIXES,
     sample_hosted_runner_usage,
 )
 
@@ -643,7 +644,7 @@ def _build_hosted_runner_chart(snapshots):
     }
 
 
-HOSTED_LABEL_ORDER = ("ubuntu-", "macos-", "windows-")
+HOSTED_LABEL_ORDER = HOSTED_LABEL_PREFIXES
 
 HOSTED_LABEL_PALETTE = {
     "ubuntu-": "#0d6efd",

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -668,7 +668,7 @@ def _hosted_label_palette(labels):
         if prefix is None:
             palette[lbl] = "#6c757d"
             continue
-        base = HOSTED_LABEL_PALETTE[prefix]
+        base = HOSTED_LABEL_PALETTE.get(prefix, "#6c757d")
         idx = counts_per_prefix.get(prefix, 0)
         counts_per_prefix[prefix] = idx + 1
         palette[lbl] = base if idx == 0 else _lighten_hex(base, _shade_factor(idx))

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -621,7 +621,9 @@ def _build_hosted_runner_chart(snapshots):
     total_series = []
     for s in snapshots:
         usage = s.get("hosted_runner_usage")
-        if not usage:
+        # Partial samples are known undercounts; plot them as gaps so a
+        # transient Actions API failure doesn't render as a fake dip.
+        if not usage or usage.get("partial"):
             for lbl in sorted_labels:
                 label_series[lbl].append(None)
             queued_series.append(None)
@@ -1023,11 +1025,18 @@ def render_hosted_runner_usage(hosted_runner_usage):
     in_use = in_progress.get("total", 0)
     queued_total = queued.get("total", 0)
     pct = (in_use / cap * 100) if cap else 0
+    partial = hosted_runner_usage.get("partial", False)
 
     # Severity thresholds match shader-slang/slang#11142:
     #   warn  at >=80% of cap
     #   alarm at  100% of cap with queued > 0
-    if in_use >= cap and queued_total > 0:
+    # A partial sample is a known undercount; show PARTIAL instead of
+    # OK/HIGH/AT CAP so the dashboard doesn't reassure operators with a
+    # false-healthy banner during an Actions API failure.
+    if partial:
+        banner_fg, banner_bg = "#6c757d", "#e2e3e5"
+        banner_label = "PARTIAL"
+    elif in_use >= cap and queued_total > 0:
         banner_fg, banner_bg = "#dc3545", "#f8d7da"
         banner_label = "AT CAP"
     elif in_use >= 0.8 * cap:
@@ -1044,6 +1053,13 @@ def render_hosted_runner_usage(hosted_runner_usage):
   &nbsp;&nbsp;<span style="color:#6c757d">queued jobs: {queued_total}</span>
 </div>
 """
+    if partial:
+        html += (
+            '<p style="color:#6c757d;margin-top:-8px">'
+            "Sample is partial and may undercount usage "
+            "(GitHub Actions API failure during collection)."
+            "</p>\n"
+        )
 
     def _render_table(rows, name_key, name_header):
         out = f'<table><tr><th>{name_header}</th><th>Jobs</th></tr>\n'

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -1334,6 +1334,15 @@ def main():
         in_use = hosted_runner_usage["in_progress"]["total"]
         queued = hosted_runner_usage["queued"]["total"]
         print(f"  Hosted runners in use: {in_use}/{cap}, queued: {queued}")
+        if hosted_runner_usage.get("partial"):
+            fetch_errs = hosted_runner_usage.get("fetch_errors", 0)
+            list_errs = hosted_runner_usage.get("list_errors", [])
+            print(
+                f"  Warning: hosted-runner sample is partial "
+                f"(fetch_errors={fetch_errs}, list_errors={len(list_errs)}); "
+                f"counts above may undercount real usage.",
+                file=sys.stderr,
+            )
     except Exception as e:  # noqa: BLE001 — sampler must never break the health run
         print(f"  Warning: hosted-runner sampler failed: {e}", file=sys.stderr)
         hosted_runner_usage = None

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -24,6 +24,10 @@ from datetime import datetime, timezone, timedelta
 # Import the page template from ci_visualization
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from ci_visualization import page_template, chart_section, DOWNLOAD_JS
+from ci_hosted_runner_usage import (
+    DEFAULT_HOSTED_RUNNER_CAP,
+    sample_hosted_runner_usage,
+)
 
 
 DEFAULT_REPO = "shader-slang/slang"
@@ -372,9 +376,9 @@ def fetch_merge_queue_status(repo):
     return {"recent": recent, "summary": counts}
 
 
-def record_snapshot(queue_data, output_dir, gpu_quota=None, mq_data=None):
+def record_snapshot(queue_data, output_dir, gpu_quota=None, mq_data=None, hosted_runner_usage=None):
     """Append a runner status snapshot to the JSONL time-series file."""
-    if not queue_data and not gpu_quota:
+    if not queue_data and not gpu_quota and not hosted_runner_usage:
         return
 
     now = datetime.now(timezone.utc)
@@ -421,6 +425,9 @@ def record_snapshot(queue_data, output_dir, gpu_quota=None, mq_data=None):
     # Merge queue summary
     if mq_data:
         snapshot["merge_queue"] = mq_data.get("summary", {})
+
+    if hosted_runner_usage:
+        snapshot["hosted_runner_usage"] = hosted_runner_usage
 
     # Append to JSONL file (kept indefinitely, ~55KB/day)
     os.makedirs(output_dir, exist_ok=True)
@@ -576,6 +583,104 @@ def _build_gpu_quota_charts(snapshots):
     return charts
 
 
+def _build_hosted_runner_chart(snapshots):
+    """Build hosted-runner usage chart data, stacked by hosted label.
+
+    Returns None if no snapshot carries hosted_runner_usage data — the
+    field was added later and older snapshots won't have it. Older
+    snapshots are rendered as gaps (None) so the chart starts on the
+    first data point.
+    """
+    has_data = any(s.get("hosted_runner_usage") for s in snapshots)
+    if not has_data:
+        return None
+
+    # Collect every label observed across the window so the stacked
+    # series stay consistent.
+    labels_seen = set()
+    cap = DEFAULT_HOSTED_RUNNER_CAP
+    for s in snapshots:
+        usage = s.get("hosted_runner_usage") or {}
+        if usage.get("cap"):
+            cap = usage["cap"]
+        for row in usage.get("in_progress", {}).get("by_label", []):
+            labels_seen.add(row["label"])
+
+    # Stable ordering: ubuntu first, then macos, then windows, then alpha.
+    def _label_sort_key(lbl):
+        for i, prefix in enumerate(HOSTED_LABEL_ORDER):
+            if lbl.startswith(prefix):
+                return (i, lbl)
+        return (len(HOSTED_LABEL_ORDER), lbl)
+
+    sorted_labels = sorted(labels_seen, key=_label_sort_key)
+
+    label_series = {lbl: [] for lbl in sorted_labels}
+    queued_series = []
+    total_series = []
+    for s in snapshots:
+        usage = s.get("hosted_runner_usage")
+        if not usage:
+            for lbl in sorted_labels:
+                label_series[lbl].append(None)
+            queued_series.append(None)
+            total_series.append(None)
+            continue
+        by_label = {row["label"]: row["count"] for row in usage.get("in_progress", {}).get("by_label", [])}
+        for lbl in sorted_labels:
+            label_series[lbl].append(by_label.get(lbl, 0))
+        queued_series.append(usage.get("queued", {}).get("total", 0))
+        total_series.append(usage.get("in_progress", {}).get("total", 0))
+
+    palette = _hosted_label_palette(sorted_labels)
+    return {
+        "cap": cap,
+        "labels": sorted_labels,
+        "label_series": label_series,
+        "queued_series": queued_series,
+        "total_series": total_series,
+        "palette": palette,
+    }
+
+
+HOSTED_LABEL_ORDER = ("ubuntu-", "macos-", "windows-")
+
+HOSTED_LABEL_PALETTE = {
+    "ubuntu-": "#0d6efd",
+    "macos-": "#6f42c1",
+    "windows-": "#28a745",
+}
+
+
+def _hosted_label_palette(labels):
+    """Assign a stable color per hosted label based on its pool prefix.
+
+    Variant labels under the same pool (ubuntu-latest vs. ubuntu-22.04)
+    get shaded variants so they're distinguishable but visibly related.
+    """
+    palette = {}
+    counts_per_prefix = {}
+    for lbl in labels:
+        prefix = next((p for p in HOSTED_LABEL_ORDER if lbl.startswith(p)), None)
+        if prefix is None:
+            palette[lbl] = "#6c757d"
+            continue
+        base = HOSTED_LABEL_PALETTE[prefix]
+        idx = counts_per_prefix.get(prefix, 0)
+        counts_per_prefix[prefix] = idx + 1
+        # First variant gets the base color; subsequent variants get a
+        # lighter alpha-suffix encoded as an HSL-ish offset by appending
+        # an "AA" alpha hint. Chart.js will use the borderColor as-is.
+        palette[lbl] = base if idx == 0 else f"{base}{_alpha_suffix(idx)}"
+    return palette
+
+
+def _alpha_suffix(idx):
+    """Return a 2-hex-digit alpha suffix that decreases with idx."""
+    alphas = ["", "BB", "88", "55", "33"]
+    return alphas[idx] if idx < len(alphas) else "33"
+
+
 def build_history_chart(snapshots):
     """Build Chart.js HTML for 24h runner load history."""
     if not snapshots:
@@ -603,6 +708,10 @@ def build_history_chart(snapshots):
 
     gpu_quota_charts = _build_gpu_quota_charts(snapshots)
 
+    # Hosted-runner usage over time, with the per-org concurrency cap
+    # plotted as a horizontal limit line.
+    hosted_runner_chart = _build_hosted_runner_chart(snapshots)
+
     # Merge queue cumulative success/failure from snapshots
     # Each snapshot records the running 24h totals; we just plot them over time.
     mq_success_data = [s.get("merge_queue", {}).get("success", 0) for s in snapshots]
@@ -627,6 +736,13 @@ def build_history_chart(snapshots):
     if has_mq_snapshots:
         charts_html += chart_section("mqHistory", "Merge Queue Checks (24h rolling)",
             "Rolling 24-hour count of merge queue CI check outcomes, sampled every 15 minutes.")
+    if hosted_runner_chart:
+        charts_html += chart_section(
+            "hostedRunnerHistory",
+            "GitHub-Hosted Runner Usage vs. Cap",
+            "Hosted runners in use (stacked by label) and queued hosted-runner jobs, "
+            "sampled every 15 minutes. Dashed line shows the per-org concurrency cap.",
+        )
 
     return f"""
 <div class="chart-section">
@@ -650,6 +766,8 @@ const allJobsQueued = {json.dumps(queued_data)};
 const allJobsRunning = {json.dumps(running_data)};
 
 const gpuQuotaCharts = {json.dumps(gpu_quota_charts)};
+
+const hostedRunnerChart = {json.dumps(hosted_runner_chart)};
 
 const mqSuccessData = {json.dumps(mq_success_data)};
 const mqFailureData = {json.dumps(mq_failure_data)};
@@ -783,6 +901,66 @@ function buildCharts(hours) {{
     }});
   }}
 
+  // Hosted-runner usage stacked by label, with the cap as a dashed line.
+  const hostedCanvas = document.getElementById('hostedRunnerHistory_canvas');
+  if (hostedCanvas && hostedRunnerChart) {{
+    const hostedDatasets = [];
+    for (const lbl of hostedRunnerChart.labels) {{
+      const color = hostedRunnerChart.palette[lbl] || '#6c757d';
+      hostedDatasets.push({{
+        label: lbl,
+        data: sliceLast(hostedRunnerChart.label_series[lbl] || [], n),
+        borderColor: color,
+        backgroundColor: color + '55',
+        fill: 'stack',
+        stack: 'in_use',
+        tension: 0.3,
+      }});
+    }}
+    hostedDatasets.push({{
+      label: 'Queued',
+      data: sliceLast(hostedRunnerChart.queued_series, n),
+      borderColor: '#ffc107',
+      borderDash: [2, 2],
+      backgroundColor: 'rgba(255,193,7,0.0)',
+      fill: false,
+      tension: 0.3,
+    }});
+    hostedDatasets.push({{
+      label: 'Cap (' + hostedRunnerChart.cap + ')',
+      data: Array(labels.length).fill(hostedRunnerChart.cap),
+      borderColor: '#dc3545',
+      borderDash: [6, 3],
+      borderWidth: 2,
+      pointRadius: 0,
+      fill: false,
+    }});
+    charts.hostedRunner = new Chart(hostedCanvas.getContext('2d'), {{
+      type: 'line',
+      data: {{ labels: displayLabels, datasets: hostedDatasets }},
+      options: {{
+        responsive: true,
+        scales: {{
+          y: {{ min: 0, stacked: true, title: {{ display: true, text: 'Hosted Runners' }} }}
+        }},
+        plugins: {{
+          tooltip: {{
+            callbacks: {{
+              afterBody: function(items) {{
+                const idx = items[0].dataIndex;
+                const total = (hostedRunnerChart.total_series || [])[
+                  (hostedRunnerChart.total_series || []).length - n + idx
+                ];
+                if (total == null) return '';
+                return 'Total in use: ' + total + ' / ' + hostedRunnerChart.cap;
+              }}
+            }}
+          }}
+        }}
+      }}
+    }});
+  }}
+
   // Merge queue checks over time
   const mqCanvas = document.getElementById('mqHistory_canvas');
   if (mqCanvas && hasMqSnapshots) {{
@@ -814,7 +992,60 @@ buildCharts(24);
 """
 
 
-def generate_health_html(queue_data, failures, output_dir, mq_data=None):
+def render_hosted_runner_usage(hosted_runner_usage):
+    """Render the GitHub-hosted runner quota section."""
+    if not hosted_runner_usage:
+        return "<p>Hosted-runner usage unavailable.</p>"
+
+    cap = hosted_runner_usage.get("cap", DEFAULT_HOSTED_RUNNER_CAP)
+    in_progress = hosted_runner_usage.get("in_progress", {})
+    queued = hosted_runner_usage.get("queued", {})
+    in_use = in_progress.get("total", 0)
+    queued_total = queued.get("total", 0)
+    pct = (in_use / cap * 100) if cap else 0
+
+    # Severity thresholds match shader-slang/slang#11142:
+    #   warn  at >=80% of cap
+    #   alarm at  100% of cap with queued > 0
+    if in_use >= cap and queued_total > 0:
+        banner_fg, banner_bg = "#dc3545", "#f8d7da"
+        banner_label = "AT CAP"
+    elif in_use >= 0.8 * cap:
+        banner_fg, banner_bg = "#fd7e14", "#fff3cd"
+        banner_label = "HIGH"
+    else:
+        banner_fg, banner_bg = "#198754", "#d1e7dd"
+        banner_label = "OK"
+
+    html = f"""
+<div style="border-left:4px solid {banner_fg};background:{banner_bg};padding:12px 18px;margin-bottom:14px;border-radius:4px">
+  <span style="background:{banner_fg};color:white;padding:2px 8px;border-radius:3px;font-size:0.8em">{banner_label}</span>
+  <strong style="margin-left:8px">{in_use} / {cap} hosted runners in use ({pct:.0f}%)</strong>
+  &nbsp;&nbsp;<span style="color:#6c757d">queued jobs: {queued_total}</span>
+</div>
+"""
+
+    def _render_table(rows, name_key, name_header):
+        out = f'<table><tr><th>{name_header}</th><th>Jobs</th></tr>\n'
+        for row in rows:
+            out += f"<tr><td>{_esc(row[name_key])}</td><td>{row['count']}</td></tr>\n"
+        out += "</table>\n"
+        return out
+
+    if in_progress.get("by_workflow"):
+        html += "<h3>In Use by Workflow</h3>\n"
+        html += _render_table(in_progress["by_workflow"], "name", "Workflow")
+    if in_progress.get("by_label"):
+        html += "<h3>In Use by Label</h3>\n"
+        html += _render_table(in_progress["by_label"], "label", "Hosted Label")
+    if queued.get("by_workflow"):
+        html += "<h3>Queued by Workflow</h3>\n"
+        html += _render_table(queued["by_workflow"], "name", "Workflow")
+
+    return html
+
+
+def generate_health_html(queue_data, failures, output_dir, mq_data=None, hosted_runner_usage=None):
     """Generate health.html from live data."""
     now = datetime.now(timezone.utc)
     fetched_at = now.strftime("%Y-%m-%d %H:%M UTC")
@@ -1009,12 +1240,17 @@ def generate_health_html(queue_data, failures, output_dir, mq_data=None):
     snapshots = load_snapshots(output_dir, hours=24)
     history_html = build_history_chart(snapshots)
 
+    hosted_runner_html = render_hosted_runner_usage(hosted_runner_usage)
+
     body = f"""
 <h1>CI System Health</h1>
 <p style="color:#6c757d">Last updated: {fetched_at}</p>
 
 <h2>Queue Status</h2>
 {queue_html}
+
+<h2>GitHub-Hosted Runner Quota</h2>
+{hosted_runner_html}
 
 <h2>Merge Queue</h2>
 {mq_html}
@@ -1055,14 +1291,37 @@ def main():
     else:
         print("  Merge queue data unavailable")
 
+    print("Sampling GitHub-hosted runner usage...")
+    try:
+        hosted_runner_usage = sample_hosted_runner_usage(args.repo)
+        cap = hosted_runner_usage["cap"]
+        in_use = hosted_runner_usage["in_progress"]["total"]
+        queued = hosted_runner_usage["queued"]["total"]
+        print(f"  Hosted runners in use: {in_use}/{cap}, queued: {queued}")
+    except Exception as e:  # noqa: BLE001 — sampler must never break the health run
+        print(f"  Warning: hosted-runner sampler failed: {e}", file=sys.stderr)
+        hosted_runner_usage = None
+
     print("Recording snapshot...")
-    record_snapshot(queue_data, args.output, gpu_quota=gpu_quota, mq_data=mq_data)
+    record_snapshot(
+        queue_data,
+        args.output,
+        gpu_quota=gpu_quota,
+        mq_data=mq_data,
+        hosted_runner_usage=hosted_runner_usage,
+    )
 
     print("Fetching recent CI failures...")
     failures = fetch_recent_failures(args.repo)
 
     print(f"Generating health.html in {args.output}/...")
-    generate_health_html(queue_data, failures, args.output, mq_data=mq_data)
+    generate_health_html(
+        queue_data,
+        failures,
+        args.output,
+        mq_data=mq_data,
+        hosted_runner_usage=hosted_runner_usage,
+    )
 
     print("Done.")
 

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -378,7 +378,7 @@ def fetch_merge_queue_status(repo):
 
 def record_snapshot(queue_data, output_dir, gpu_quota=None, mq_data=None, hosted_runner_usage=None):
     """Append a runner status snapshot to the JSONL time-series file."""
-    if not queue_data and not gpu_quota and not hosted_runner_usage:
+    if not queue_data and not gpu_quota and not mq_data and not hosted_runner_usage:
         return
 
     now = datetime.now(timezone.utc)
@@ -656,7 +656,9 @@ def _hosted_label_palette(labels):
     """Assign a stable color per hosted label based on its pool prefix.
 
     Variant labels under the same pool (ubuntu-latest vs. ubuntu-22.04)
-    get shaded variants so they're distinguishable but visibly related.
+    get progressively lighter shades of the same base color so they're
+    distinguishable but visibly related. The returned colors are always
+    6-digit `#RRGGBB` — alpha is applied at use time by the chart code.
     """
     palette = {}
     counts_per_prefix = {}
@@ -668,17 +670,34 @@ def _hosted_label_palette(labels):
         base = HOSTED_LABEL_PALETTE[prefix]
         idx = counts_per_prefix.get(prefix, 0)
         counts_per_prefix[prefix] = idx + 1
-        # First variant gets the base color; subsequent variants get a
-        # lighter alpha-suffix encoded as an HSL-ish offset by appending
-        # an "AA" alpha hint. Chart.js will use the borderColor as-is.
-        palette[lbl] = base if idx == 0 else f"{base}{_alpha_suffix(idx)}"
+        palette[lbl] = base if idx == 0 else _lighten_hex(base, _shade_factor(idx))
     return palette
 
 
-def _alpha_suffix(idx):
-    """Return a 2-hex-digit alpha suffix that decreases with idx."""
-    alphas = ["", "BB", "88", "55", "33"]
-    return alphas[idx] if idx < len(alphas) else "33"
+def _shade_factor(idx):
+    """Return a 0..1 lightening factor that grows with idx (max ~0.8)."""
+    factors = [0.0, 0.30, 0.50, 0.65, 0.78]
+    return factors[idx] if idx < len(factors) else 0.85
+
+
+def _lighten_hex(color, factor):
+    """Lighten a `#RRGGBB` color toward white by `factor` in [0,1].
+
+    Returns a `#RRGGBB` string. Invalid input is returned unchanged.
+    """
+    if not (isinstance(color, str) and len(color) == 7 and color.startswith("#")):
+        return color
+    try:
+        r = int(color[1:3], 16)
+        g = int(color[3:5], 16)
+        b = int(color[5:7], 16)
+    except ValueError:
+        return color
+    factor = max(0.0, min(1.0, factor))
+    r = int(r + (255 - r) * factor)
+    g = int(g + (255 - g) * factor)
+    b = int(b + (255 - b) * factor)
+    return f"#{r:02x}{g:02x}{b:02x}"
 
 
 def build_history_chart(snapshots):
@@ -948,9 +967,9 @@ function buildCharts(hours) {{
             callbacks: {{
               afterBody: function(items) {{
                 const idx = items[0].dataIndex;
-                const total = (hostedRunnerChart.total_series || [])[
-                  (hostedRunnerChart.total_series || []).length - n + idx
-                ];
+                const total = sliceLast(
+                  hostedRunnerChart.total_series || [], n
+                )[idx];
                 if (total == null) return '';
                 return 'Total in use: ' + total + ' / ' + hostedRunnerChart.cap;
               }}

--- a/extras/ci/analytics/ci_hosted_runner_usage.py
+++ b/extras/ci/analytics/ci_hosted_runner_usage.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""
+Hosted-runner quota sampler.
+
+Samples in-progress and queued GitHub-hosted runner jobs for a repo and
+returns a structured snapshot suitable for the health dashboard.
+
+The Slang org runs on the public-repo 20-concurrent-runner cap, shared
+across every hosted-runner label (ubuntu-*, macos-*, windows-*, etc.).
+When usage approaches the cap, gating jobs starve and the merge queue
+stalls. See shader-slang/slang#11142 for background.
+
+CLI usage:
+    python3 ci_hosted_runner_usage.py
+    python3 ci_hosted_runner_usage.py --repo shader-slang/slang --cap 20
+"""
+
+import argparse
+import json
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+from gh_api import gh_api_list
+
+DEFAULT_REPO = "shader-slang/slang"
+
+# The Slang org runs on the standard public-repo concurrent-runner cap
+# of 20 hosted runners shared across all labels. The cap is per-org,
+# not per-label.
+DEFAULT_HOSTED_RUNNER_CAP = 20
+
+HOSTED_LABEL_PREFIXES = ("ubuntu-", "macos-", "windows-")
+
+
+def is_hosted_label(label):
+    """Return True if `label` is a GitHub-hosted-runner label.
+
+    GitHub-hosted images all start with one of `ubuntu-`, `macos-`,
+    `windows-`. Self-hosted runners carry the `self-hosted` label and
+    use NVIDIA-specific labels (`SM80Plus`, `GCP-T4`, etc.).
+    """
+    if not isinstance(label, str):
+        return False
+    return label.startswith(HOSTED_LABEL_PREFIXES)
+
+
+def classify_hosted_label(labels):
+    """Pick the canonical hosted label from a job's labels list.
+
+    Returns the first hosted label or None if no hosted label is
+    present. The convention `runs-on: [foo]` produces a single-element
+    list in practice, but matrix jobs and array syntax can produce
+    multiple labels.
+    """
+    if not labels:
+        return None
+    # `self-hosted` rules out hosted runners regardless of other labels.
+    if any(l == "self-hosted" for l in labels if isinstance(l, str)):
+        return None
+    for label in labels:
+        if is_hosted_label(label):
+            return label
+    return None
+
+
+def fetch_in_progress_runs(repo):
+    """Fetch all in-progress workflow runs."""
+    runs, err = gh_api_list(
+        f"repos/{repo}/actions/runs?status=in_progress&per_page=100",
+        "workflow_runs",
+    )
+    if err:
+        print(f"Warning: failed to fetch in-progress runs: {err}", file=sys.stderr)
+        return []
+    return runs or []
+
+
+def fetch_jobs_for_run(repo, run_id):
+    """Fetch all jobs for a run. Returns (jobs, error)."""
+    jobs, err = gh_api_list(
+        f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100",
+        "jobs",
+    )
+    if err:
+        return [], err
+    return (jobs if isinstance(jobs, list) else []), None
+
+
+def fetch_queued_jobs(repo):
+    """Fetch queued workflow runs as a stand-in for queued hosted-runner jobs.
+
+    GitHub's REST API has no `?status=queued&jobs` shortcut, so we list
+    queued runs and then expand each run to its queued jobs. We classify
+    by hosted-runner label using the job's `labels` field.
+    """
+    runs, err = gh_api_list(
+        f"repos/{repo}/actions/runs?status=queued&per_page=100",
+        "workflow_runs",
+    )
+    if err:
+        print(f"Warning: failed to fetch queued runs: {err}", file=sys.stderr)
+        return []
+    return runs or []
+
+
+def collect_hosted_jobs(repo, runs, status_filter):
+    """Expand workflow runs to their hosted-runner jobs at `status_filter`.
+
+    `status_filter` is e.g. `"in_progress"` or `"queued"`. Returns a
+    list of dicts with keys: workflow_name, job_name, hosted_label.
+    """
+    results = []
+    if not runs:
+        return results
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = {
+            executor.submit(fetch_jobs_for_run, repo, run["id"]): run
+            for run in runs
+        }
+        for future in as_completed(futures):
+            run = futures[future]
+            jobs, err = future.result()
+            if err:
+                continue
+            for job in jobs:
+                if job.get("status") != status_filter:
+                    continue
+                hosted_label = classify_hosted_label(job.get("labels", []))
+                if not hosted_label:
+                    continue
+                results.append({
+                    "workflow_name": run.get("name", ""),
+                    "job_name": job.get("name", ""),
+                    "hosted_label": hosted_label,
+                })
+    return results
+
+
+def summarize(jobs):
+    """Group hosted-runner jobs by workflow and by label.
+
+    Returns dict with:
+        total: int
+        by_workflow: sorted list of {name, count}
+        by_label: sorted list of {label, count}
+    """
+    by_workflow = {}
+    by_label = {}
+    for j in jobs:
+        wf = j["workflow_name"] or "(unknown)"
+        lbl = j["hosted_label"]
+        by_workflow[wf] = by_workflow.get(wf, 0) + 1
+        by_label[lbl] = by_label.get(lbl, 0) + 1
+    return {
+        "total": len(jobs),
+        "by_workflow": sorted(
+            ({"name": k, "count": v} for k, v in by_workflow.items()),
+            key=lambda x: (-x["count"], x["name"]),
+        ),
+        "by_label": sorted(
+            ({"label": k, "count": v} for k, v in by_label.items()),
+            key=lambda x: (-x["count"], x["label"]),
+        ),
+    }
+
+
+def sample_hosted_runner_usage(repo, cap=DEFAULT_HOSTED_RUNNER_CAP):
+    """Sample current hosted-runner usage for `repo`.
+
+    Returns a dict suitable for embedding in the health snapshot:
+        {
+            "cap": 20,
+            "in_progress": { total, by_workflow, by_label },
+            "queued":      { total, by_workflow, by_label },
+        }
+    """
+    in_progress_runs = fetch_in_progress_runs(repo)
+    queued_runs = fetch_queued_jobs(repo)
+
+    in_progress_jobs = collect_hosted_jobs(repo, in_progress_runs, "in_progress")
+    queued_jobs = collect_hosted_jobs(repo, queued_runs, "queued")
+
+    return {
+        "cap": cap,
+        "in_progress": summarize(in_progress_jobs),
+        "queued": summarize(queued_jobs),
+    }
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Sample GitHub-hosted runner usage for a repo, broken down "
+            "by workflow and label. Aimed at detecting impending "
+            "20-runner-cap exhaustion before it stalls the merge queue."
+        )
+    )
+    parser.add_argument(
+        "--repo",
+        default=DEFAULT_REPO,
+        help=f"Repository (default: {DEFAULT_REPO})",
+    )
+    parser.add_argument(
+        "--cap",
+        type=int,
+        default=DEFAULT_HOSTED_RUNNER_CAP,
+        help=(
+            f"Hosted-runner concurrency cap to report against "
+            f"(default: {DEFAULT_HOSTED_RUNNER_CAP}, the standard public-repo limit)"
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the raw JSON snapshot instead of a human-readable summary.",
+    )
+    return parser.parse_args()
+
+
+def format_summary(snapshot):
+    """Render a one-screen human-readable summary."""
+    cap = snapshot["cap"]
+    in_use = snapshot["in_progress"]["total"]
+    queued = snapshot["queued"]["total"]
+    pct = (in_use / cap * 100) if cap else 0
+
+    lines = []
+    lines.append(
+        f"Hosted runners in use: {in_use} / {cap} ({pct:.0f}%)   "
+        f"queued: {queued}"
+    )
+    lines.append("")
+    if snapshot["in_progress"]["by_label"]:
+        lines.append("In use by label:")
+        for row in snapshot["in_progress"]["by_label"]:
+            lines.append(f"  {row['count']:>3}  {row['label']}")
+        lines.append("")
+    if snapshot["in_progress"]["by_workflow"]:
+        lines.append("In use by workflow (top 5):")
+        for row in snapshot["in_progress"]["by_workflow"][:5]:
+            lines.append(f"  {row['count']:>3}  {row['name']}")
+        lines.append("")
+    if snapshot["queued"]["by_workflow"]:
+        lines.append("Queued by workflow (top 5):")
+        for row in snapshot["queued"]["by_workflow"][:5]:
+            lines.append(f"  {row['count']:>3}  {row['name']}")
+    return "\n".join(lines)
+
+
+def main():
+    args = parse_args()
+    snapshot = sample_hosted_runner_usage(args.repo, cap=args.cap)
+    if args.json:
+        json.dump(snapshot, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        print(format_summary(snapshot))
+
+
+if __name__ == "__main__":
+    main()

--- a/extras/ci/analytics/ci_hosted_runner_usage.py
+++ b/extras/ci/analytics/ci_hosted_runner_usage.py
@@ -66,15 +66,15 @@ def classify_hosted_label(labels):
 
 
 def fetch_in_progress_runs(repo):
-    """Fetch all in-progress workflow runs."""
+    """Fetch all in-progress workflow runs. Returns `(runs, error)`."""
     runs, err = gh_api_list(
         f"repos/{repo}/actions/runs?status=in_progress&per_page=100",
         "workflow_runs",
     )
     if err:
         print(f"Warning: failed to fetch in-progress runs: {err}", file=sys.stderr)
-        return []
-    return runs or []
+        return [], err
+    return runs or [], None
 
 
 def fetch_jobs_for_run(repo, run_id):
@@ -88,12 +88,12 @@ def fetch_jobs_for_run(repo, run_id):
     return (jobs if isinstance(jobs, list) else []), None
 
 
-def fetch_queued_jobs(repo):
-    """Fetch queued workflow runs as a stand-in for queued hosted-runner jobs.
+def fetch_queued_runs(repo):
+    """Fetch workflow runs whose top-level status is `queued`.
 
-    GitHub's REST API has no `?status=queued&jobs` shortcut, so we list
-    queued runs and then expand each run to its queued jobs. We classify
-    by hosted-runner label using the job's `labels` field.
+    GitHub's REST API has no `?status=queued&jobs` shortcut, so callers
+    list queued runs here and then expand each run to its queued jobs.
+    Returns `(runs, error)`.
     """
     runs, err = gh_api_list(
         f"repos/{repo}/actions/runs?status=queued&per_page=100",
@@ -101,8 +101,8 @@ def fetch_queued_jobs(repo):
     )
     if err:
         print(f"Warning: failed to fetch queued runs: {err}", file=sys.stderr)
-        return []
-    return runs or []
+        return [], err
+    return runs or [], None
 
 
 def collect_hosted_jobs(repo, runs, status_filter):
@@ -200,20 +200,20 @@ def sample_hosted_runner_usage(repo, cap=DEFAULT_HOSTED_RUNNER_CAP):
             "queued":      { total, by_workflow, by_label },
         }
     """
-    in_progress_runs = fetch_in_progress_runs(repo)
-    queued_runs = fetch_queued_jobs(repo)
+    in_progress_runs, ip_list_err = fetch_in_progress_runs(repo)
+    queued_runs, q_list_err = fetch_queued_runs(repo)
 
     # A workflow run's top-level status doesn't dictate its jobs' statuses.
     # An `in_progress` run can carry jobs that are still `queued`, waiting
     # for a hosted runner — exactly the cap-exhaustion case we need to
     # detect. So scan jobs from both run sets for both job statuses, then
-    # dedupe by (run_id, job_id) in case a run transitions between the
-    # two list endpoints during sampling.
+    # dedupe by run id in case a run transitions between the two list
+    # endpoints during sampling.
     seen = set()
     deduped_runs = []
     for run in list(in_progress_runs) + list(queued_runs):
         rid = run.get("id")
-        if rid in seen:
+        if rid is None or rid in seen:
             continue
         seen.add(rid)
         deduped_runs.append(run)
@@ -229,9 +229,18 @@ def sample_hosted_runner_usage(repo, cap=DEFAULT_HOSTED_RUNNER_CAP):
         "in_progress": summarize(in_progress_jobs),
         "queued": summarize(queued_jobs),
     }
-    if fetch_errors:
+    # Mark partial if either the per-run job fetches or the top-level
+    # run listings failed. A listing failure is more dangerous: it
+    # erases an entire status's contribution rather than one run's,
+    # so a transient 5xx on `?status=queued` must not look healthy.
+    if fetch_errors or ip_list_err or q_list_err:
         result["partial"] = True
+    if fetch_errors:
         result["fetch_errors"] = fetch_errors
+    if ip_list_err or q_list_err:
+        result["list_errors"] = [
+            e for e in (ip_list_err, q_list_err) if e
+        ]
     return result
 
 

--- a/extras/ci/analytics/ci_hosted_runner_usage.py
+++ b/extras/ci/analytics/ci_hosted_runner_usage.py
@@ -109,11 +109,19 @@ def collect_hosted_jobs(repo, runs, status_filter):
     """Expand workflow runs to their hosted-runner jobs at `status_filter`.
 
     `status_filter` is e.g. `"in_progress"` or `"queued"`. Returns a
-    list of dicts with keys: workflow_name, job_name, hosted_label.
+    tuple `(results, error_count)`: `results` is a list of dicts with
+    keys workflow_name/job_name/hosted_label; `error_count` is the
+    number of runs whose jobs API call failed and whose hosted-runner
+    usage is therefore *missing* from `results`.
+
+    A non-zero `error_count` means the sample undercounts real usage.
+    Callers should surface this so a quota-exhaustion incident isn't
+    masked by a transient GitHub API hiccup.
     """
     results = []
+    error_count = 0
     if not runs:
-        return results
+        return results, error_count
 
     with ThreadPoolExecutor(max_workers=8) as executor:
         futures = {
@@ -124,6 +132,11 @@ def collect_hosted_jobs(repo, runs, status_filter):
             run = futures[future]
             jobs, err = future.result()
             if err:
+                print(
+                    f"Warning: failed to fetch jobs for run {run.get('id')}: {err}",
+                    file=sys.stderr,
+                )
+                error_count += 1
                 continue
             for job in jobs:
                 if job.get("status") != status_filter:
@@ -136,7 +149,7 @@ def collect_hosted_jobs(repo, runs, status_filter):
                     "job_name": job.get("name", ""),
                     "hosted_label": hosted_label,
                 })
-    return results
+    return results, error_count
 
 
 def summarize(jobs):
@@ -180,14 +193,21 @@ def sample_hosted_runner_usage(repo, cap=DEFAULT_HOSTED_RUNNER_CAP):
     in_progress_runs = fetch_in_progress_runs(repo)
     queued_runs = fetch_queued_jobs(repo)
 
-    in_progress_jobs = collect_hosted_jobs(repo, in_progress_runs, "in_progress")
-    queued_jobs = collect_hosted_jobs(repo, queued_runs, "queued")
+    in_progress_jobs, in_progress_errors = collect_hosted_jobs(
+        repo, in_progress_runs, "in_progress"
+    )
+    queued_jobs, queued_errors = collect_hosted_jobs(repo, queued_runs, "queued")
 
-    return {
+    fetch_errors = in_progress_errors + queued_errors
+    result = {
         "cap": cap,
         "in_progress": summarize(in_progress_jobs),
         "queued": summarize(queued_jobs),
     }
+    if fetch_errors:
+        result["partial"] = True
+        result["fetch_errors"] = fetch_errors
+    return result
 
 
 def parse_args():

--- a/extras/ci/analytics/ci_hosted_runner_usage.py
+++ b/extras/ci/analytics/ci_hosted_runner_usage.py
@@ -106,18 +106,26 @@ def fetch_queued_jobs(repo):
 
 
 def collect_hosted_jobs(repo, runs, status_filter):
-    """Expand workflow runs to their hosted-runner jobs at `status_filter`.
+    """Expand workflow runs to their hosted-runner jobs.
 
-    `status_filter` is e.g. `"in_progress"` or `"queued"`. Returns a
-    tuple `(results, error_count)`: `results` is a list of dicts with
-    keys workflow_name/job_name/hosted_label; `error_count` is the
-    number of runs whose jobs API call failed and whose hosted-runner
-    usage is therefore *missing* from `results`.
+    `status_filter` is a single status string (e.g. `"in_progress"`) or
+    an iterable of statuses (e.g. `("in_progress", "queued")`). The
+    *job* status is what's matched — not the workflow run's top-level
+    status, since an `in_progress` run can contain `queued` jobs that
+    are stuck waiting for a hosted runner (the textbook cap-exhaustion
+    shape).
 
-    A non-zero `error_count` means the sample undercounts real usage.
-    Callers should surface this so a quota-exhaustion incident isn't
-    masked by a transient GitHub API hiccup.
+    Returns a tuple `(results, error_count)`. Each result dict has
+    keys: workflow_name, job_name, hosted_label, status. `error_count`
+    is the number of runs whose jobs API call failed and whose
+    hosted-runner usage is therefore *missing* from `results`. A
+    non-zero `error_count` means the sample undercounts real usage.
     """
+    if isinstance(status_filter, str):
+        wanted = {status_filter}
+    else:
+        wanted = set(status_filter)
+
     results = []
     error_count = 0
     if not runs:
@@ -139,7 +147,8 @@ def collect_hosted_jobs(repo, runs, status_filter):
                 error_count += 1
                 continue
             for job in jobs:
-                if job.get("status") != status_filter:
+                status = job.get("status")
+                if status not in wanted:
                     continue
                 hosted_label = classify_hosted_label(job.get("labels", []))
                 if not hosted_label:
@@ -148,6 +157,7 @@ def collect_hosted_jobs(repo, runs, status_filter):
                     "workflow_name": run.get("name", ""),
                     "job_name": job.get("name", ""),
                     "hosted_label": hosted_label,
+                    "status": status,
                 })
     return results, error_count
 
@@ -193,12 +203,27 @@ def sample_hosted_runner_usage(repo, cap=DEFAULT_HOSTED_RUNNER_CAP):
     in_progress_runs = fetch_in_progress_runs(repo)
     queued_runs = fetch_queued_jobs(repo)
 
-    in_progress_jobs, in_progress_errors = collect_hosted_jobs(
-        repo, in_progress_runs, "in_progress"
-    )
-    queued_jobs, queued_errors = collect_hosted_jobs(repo, queued_runs, "queued")
+    # A workflow run's top-level status doesn't dictate its jobs' statuses.
+    # An `in_progress` run can carry jobs that are still `queued`, waiting
+    # for a hosted runner — exactly the cap-exhaustion case we need to
+    # detect. So scan jobs from both run sets for both job statuses, then
+    # dedupe by (run_id, job_id) in case a run transitions between the
+    # two list endpoints during sampling.
+    seen = set()
+    deduped_runs = []
+    for run in list(in_progress_runs) + list(queued_runs):
+        rid = run.get("id")
+        if rid in seen:
+            continue
+        seen.add(rid)
+        deduped_runs.append(run)
 
-    fetch_errors = in_progress_errors + queued_errors
+    all_jobs, fetch_errors = collect_hosted_jobs(
+        repo, deduped_runs, ("in_progress", "queued")
+    )
+    in_progress_jobs = [j for j in all_jobs if j["status"] == "in_progress"]
+    queued_jobs = [j for j in all_jobs if j["status"] == "queued"]
+
     result = {
         "cap": cap,
         "in_progress": summarize(in_progress_jobs),

--- a/extras/ci/analytics/ci_hosted_runner_usage.py
+++ b/extras/ci/analytics/ci_hosted_runner_usage.py
@@ -286,6 +286,14 @@ def format_summary(snapshot):
         f"Hosted runners in use: {in_use} / {cap} ({pct:.0f}%)   "
         f"queued: {queued}"
     )
+    if snapshot.get("partial"):
+        lines.append(
+            "WARNING: sample is partial and may undercount hosted-runner usage."
+        )
+        if snapshot.get("fetch_errors"):
+            lines.append(f"  job fetch failures: {snapshot['fetch_errors']}")
+        for err in snapshot.get("list_errors", []):
+            lines.append(f"  list failure: {err}")
     lines.append("")
     if snapshot["in_progress"]["by_label"]:
         lines.append("In use by label:")

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -1242,6 +1242,25 @@ class TestHostedRunnerUsage(unittest.TestCase):
         self.assertEqual(snap["queued"]["total"], 0)
         self.assertIn("HTTP 502 listing in_progress runs", snap.get("list_errors", []))
 
+    def test_format_summary_surfaces_partial(self):
+        """`--json` and the human-readable summary must carry the same
+        degraded signal — the text mode previously printed `0 / cap`
+        without any indication the sample was undercounted.
+        """
+        snapshot = {
+            "cap": 20,
+            "in_progress": {"total": 0, "by_workflow": [], "by_label": []},
+            "queued": {"total": 0, "by_workflow": [], "by_label": []},
+            "partial": True,
+            "fetch_errors": 2,
+            "list_errors": ["HTTP 502 listing in_progress runs"],
+        }
+        out = ci_hosted_runner_usage.format_summary(snapshot)
+        self.assertIn("WARNING", out)
+        self.assertIn("partial", out.lower())
+        self.assertIn("job fetch failures: 2", out)
+        self.assertIn("HTTP 502 listing in_progress runs", out)
+
     def test_sample_dedupe_skips_runs_with_missing_id(self):
         """Don't collapse multiple `id: None` runs into one entry."""
 
@@ -1418,6 +1437,19 @@ class TestHostedRunnerRender(unittest.TestCase):
         html = ci_health.render_hosted_runner_usage(None)
         self.assertIn("unavailable", html.lower())
 
+    def test_render_banner_partial_overrides_severity(self):
+        """A partial sample is a known undercount — render PARTIAL
+        instead of computing OK/HIGH/AT CAP from numbers we know are
+        low. Otherwise the dashboard reads false-healthy during an
+        Actions API failure.
+        """
+        snap = self._snapshot(in_use=2, queued=0)
+        snap["partial"] = True
+        html = ci_health.render_hosted_runner_usage(snap)
+        self.assertIn("PARTIAL", html)
+        self.assertNotIn("OK", html)
+        self.assertIn("partial", html.lower())
+
     def test_build_hosted_runner_chart_none_when_no_data(self):
         snapshots = [{"timestamp": "2026-05-13T10:00:00Z"}]
         self.assertIsNone(ci_health._build_hosted_runner_chart(snapshots))
@@ -1466,6 +1498,43 @@ class TestHostedRunnerRender(unittest.TestCase):
         self.assertEqual(chart["label_series"]["windows-latest"], [0, 2])
         self.assertEqual(chart["queued_series"], [2, 0])
         self.assertEqual(chart["total_series"], [4, 6])
+
+    def test_build_hosted_runner_chart_partial_renders_as_gap(self):
+        """A partial sample is a known undercount; the history chart
+        must plot None (a gap) rather than the false-low number.
+        """
+        snapshots = [
+            {
+                "timestamp": "2026-05-13T10:00:00Z",
+                "hosted_runner_usage": {
+                    "cap": 20,
+                    "in_progress": {
+                        "total": 5,
+                        "by_label": [{"label": "ubuntu-latest", "count": 5}],
+                        "by_workflow": [],
+                    },
+                    "queued": {"total": 0, "by_workflow": [], "by_label": []},
+                },
+            },
+            {
+                "timestamp": "2026-05-13T10:15:00Z",
+                "hosted_runner_usage": {
+                    "cap": 20,
+                    "partial": True,
+                    "in_progress": {
+                        "total": 0,
+                        "by_label": [],
+                        "by_workflow": [],
+                    },
+                    "queued": {"total": 0, "by_workflow": [], "by_label": []},
+                },
+            },
+        ]
+        chart = ci_health._build_hosted_runner_chart(snapshots)
+        self.assertIsNotNone(chart)
+        self.assertEqual(chart["total_series"], [5, None])
+        self.assertEqual(chart["queued_series"], [0, None])
+        self.assertEqual(chart["label_series"]["ubuntu-latest"], [5, None])
 
     def test_build_hosted_runner_chart_marks_missing_snapshots_as_gap(self):
         # Older snapshots without the new field should be rendered as

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -14,6 +14,7 @@ if ANALYTICS_DIR not in sys.path:
     sys.path.insert(0, ANALYTICS_DIR)
 
 import ci_health
+import ci_hosted_runner_usage
 import ci_job_collector
 import ci_status
 import ci_visualization
@@ -995,6 +996,305 @@ class TestMonthlySplit(unittest.TestCase):
 
             self.assertEqual({j["id"] for j in feb_data}, {1})
             self.assertEqual({j["id"] for j in mar_data}, {2, 3})
+
+
+class TestHostedRunnerUsage(unittest.TestCase):
+    def test_classify_hosted_label_picks_first_hosted(self):
+        self.assertEqual(
+            ci_hosted_runner_usage.classify_hosted_label(["ubuntu-latest"]),
+            "ubuntu-latest",
+        )
+        self.assertEqual(
+            ci_hosted_runner_usage.classify_hosted_label(
+                ["ubuntu-22.04", "x64"]
+            ),
+            "ubuntu-22.04",
+        )
+
+    def test_classify_hosted_label_rejects_self_hosted(self):
+        # Self-hosted runners often carry an `ubuntu-*` *image* label too,
+        # but the `self-hosted` marker disqualifies them from the cap.
+        self.assertIsNone(
+            ci_hosted_runner_usage.classify_hosted_label(
+                ["self-hosted", "Linux", "SM80Plus"]
+            )
+        )
+        self.assertIsNone(
+            ci_hosted_runner_usage.classify_hosted_label(
+                ["self-hosted", "ubuntu-22.04"]
+            )
+        )
+
+    def test_classify_hosted_label_returns_none_for_no_hosted(self):
+        self.assertIsNone(ci_hosted_runner_usage.classify_hosted_label([]))
+        self.assertIsNone(ci_hosted_runner_usage.classify_hosted_label(["custom"]))
+
+    def test_classify_hosted_label_recognizes_all_three_pools(self):
+        for label in ("ubuntu-24.04-arm", "macos-latest", "windows-2022"):
+            self.assertEqual(
+                ci_hosted_runner_usage.classify_hosted_label([label]), label
+            )
+
+    def test_summarize_groups_and_sorts(self):
+        jobs = [
+            {"workflow_name": "CI", "job_name": "filter", "hosted_label": "ubuntu-latest"},
+            {"workflow_name": "CI", "job_name": "label", "hosted_label": "ubuntu-latest"},
+            {"workflow_name": "CMake Options", "job_name": "m1", "hosted_label": "ubuntu-22.04"},
+            {"workflow_name": "CI", "job_name": "mac", "hosted_label": "macos-latest"},
+        ]
+        s = ci_hosted_runner_usage.summarize(jobs)
+        self.assertEqual(s["total"], 4)
+        # Sorted by count desc, then name asc.
+        self.assertEqual(s["by_workflow"][0], {"name": "CI", "count": 3})
+        self.assertEqual(s["by_workflow"][1], {"name": "CMake Options", "count": 1})
+        self.assertEqual(s["by_label"][0], {"label": "ubuntu-latest", "count": 2})
+
+    def test_summarize_handles_empty(self):
+        s = ci_hosted_runner_usage.summarize([])
+        self.assertEqual(s, {"total": 0, "by_workflow": [], "by_label": []})
+
+    def test_collect_hosted_jobs_filters_status_and_self_hosted(self):
+        run = {"id": 1, "name": "CI"}
+
+        def fake_fetch(repo, run_id):
+            return (
+                [
+                    # hosted, in_progress — kept
+                    {"status": "in_progress", "labels": ["ubuntu-latest"], "name": "a"},
+                    # hosted, queued — filtered out by status_filter
+                    {"status": "queued", "labels": ["ubuntu-latest"], "name": "b"},
+                    # self-hosted — filtered out by classifier
+                    {"status": "in_progress", "labels": ["self-hosted", "Linux", "GPU"], "name": "c"},
+                    # hosted windows, in_progress — kept
+                    {"status": "in_progress", "labels": ["windows-latest"], "name": "d"},
+                ],
+                None,
+            )
+
+        with mock.patch.object(
+            ci_hosted_runner_usage, "fetch_jobs_for_run", side_effect=fake_fetch
+        ):
+            jobs = ci_hosted_runner_usage.collect_hosted_jobs(
+                "shader-slang/slang", [run], "in_progress"
+            )
+        self.assertEqual(len(jobs), 2)
+        labels = sorted(j["hosted_label"] for j in jobs)
+        self.assertEqual(labels, ["ubuntu-latest", "windows-latest"])
+        for j in jobs:
+            self.assertEqual(j["workflow_name"], "CI")
+
+    def test_sample_hosted_runner_usage_shape(self):
+        in_progress_run = {"id": 10, "name": "CI"}
+        queued_run = {"id": 11, "name": "CMake Options"}
+
+        def fake_in_progress(repo):
+            return [in_progress_run]
+
+        def fake_queued(repo):
+            return [queued_run]
+
+        def fake_jobs(repo, run_id):
+            if run_id == 10:
+                return (
+                    [
+                        {"status": "in_progress", "labels": ["ubuntu-latest"], "name": "filter"},
+                        {"status": "in_progress", "labels": ["self-hosted", "Linux", "GPU"], "name": "gpu"},
+                    ],
+                    None,
+                )
+            if run_id == 11:
+                return (
+                    [
+                        {"status": "queued", "labels": ["ubuntu-latest"], "name": "matrix-0"},
+                        {"status": "queued", "labels": ["ubuntu-latest"], "name": "matrix-1"},
+                    ],
+                    None,
+                )
+            return ([], None)
+
+        with mock.patch.object(
+            ci_hosted_runner_usage, "fetch_in_progress_runs", side_effect=fake_in_progress
+        ), mock.patch.object(
+            ci_hosted_runner_usage, "fetch_queued_jobs", side_effect=fake_queued
+        ), mock.patch.object(
+            ci_hosted_runner_usage, "fetch_jobs_for_run", side_effect=fake_jobs
+        ):
+            snap = ci_hosted_runner_usage.sample_hosted_runner_usage(
+                "shader-slang/slang", cap=20
+            )
+
+        self.assertEqual(snap["cap"], 20)
+        self.assertEqual(snap["in_progress"]["total"], 1)
+        self.assertEqual(snap["in_progress"]["by_label"], [{"label": "ubuntu-latest", "count": 1}])
+        self.assertEqual(snap["queued"]["total"], 2)
+        self.assertEqual(snap["queued"]["by_workflow"], [{"name": "CMake Options", "count": 2}])
+
+
+class TestHostedRunnerRender(unittest.TestCase):
+    def _snapshot(self, in_use, cap=20, queued=0, by_workflow=None):
+        return {
+            "cap": cap,
+            "in_progress": {
+                "total": in_use,
+                "by_workflow": by_workflow or [],
+                "by_label": [],
+            },
+            "queued": {"total": queued, "by_workflow": [], "by_label": []},
+        }
+
+    def test_render_banner_ok_under_threshold(self):
+        html = ci_health.render_hosted_runner_usage(self._snapshot(in_use=10))
+        self.assertIn("OK", html)
+        self.assertIn("10 / 20", html)
+
+    def test_render_banner_high_at_or_above_80pct(self):
+        html = ci_health.render_hosted_runner_usage(self._snapshot(in_use=16))
+        self.assertIn("HIGH", html)
+
+    def test_render_banner_at_cap_with_queue_is_alarm(self):
+        html = ci_health.render_hosted_runner_usage(
+            self._snapshot(in_use=20, queued=5)
+        )
+        self.assertIn("AT CAP", html)
+
+    def test_render_banner_at_cap_with_no_queue_is_high_not_alarm(self):
+        # 100% in-use is uncomfortable but not the smoking-gun signature
+        # of starvation — that's 100% with backlog queued behind.
+        html = ci_health.render_hosted_runner_usage(self._snapshot(in_use=20))
+        self.assertIn("HIGH", html)
+        self.assertNotIn("AT CAP", html)
+
+    def test_render_handles_missing_snapshot(self):
+        html = ci_health.render_hosted_runner_usage(None)
+        self.assertIn("unavailable", html.lower())
+
+    def test_build_hosted_runner_chart_none_when_no_data(self):
+        snapshots = [{"timestamp": "2026-05-13T10:00:00Z"}]
+        self.assertIsNone(ci_health._build_hosted_runner_chart(snapshots))
+
+    def test_build_hosted_runner_chart_stacks_by_label(self):
+        snapshots = [
+            {
+                "timestamp": "2026-05-13T10:00:00Z",
+                "hosted_runner_usage": {
+                    "cap": 20,
+                    "in_progress": {
+                        "total": 4,
+                        "by_label": [
+                            {"label": "ubuntu-latest", "count": 3},
+                            {"label": "macos-latest", "count": 1},
+                        ],
+                        "by_workflow": [],
+                    },
+                    "queued": {"total": 2, "by_workflow": [], "by_label": []},
+                },
+            },
+            {
+                "timestamp": "2026-05-13T10:15:00Z",
+                "hosted_runner_usage": {
+                    "cap": 20,
+                    "in_progress": {
+                        "total": 6,
+                        "by_label": [
+                            {"label": "ubuntu-latest", "count": 4},
+                            {"label": "windows-latest", "count": 2},
+                        ],
+                        "by_workflow": [],
+                    },
+                    "queued": {"total": 0, "by_workflow": [], "by_label": []},
+                },
+            },
+        ]
+        chart = ci_health._build_hosted_runner_chart(snapshots)
+        self.assertIsNotNone(chart)
+        # Ordering: ubuntu, then macos, then windows.
+        self.assertEqual(chart["labels"], ["ubuntu-latest", "macos-latest", "windows-latest"])
+        self.assertEqual(chart["cap"], 20)
+        # macos absent in the 2nd snapshot collapses to 0, not None.
+        self.assertEqual(chart["label_series"]["ubuntu-latest"], [3, 4])
+        self.assertEqual(chart["label_series"]["macos-latest"], [1, 0])
+        self.assertEqual(chart["label_series"]["windows-latest"], [0, 2])
+        self.assertEqual(chart["queued_series"], [2, 0])
+        self.assertEqual(chart["total_series"], [4, 6])
+
+    def test_build_hosted_runner_chart_marks_missing_snapshots_as_gap(self):
+        # Older snapshots without the new field should be rendered as
+        # None gaps so the chart begins on the first real data point.
+        snapshots = [
+            {"timestamp": "2026-05-13T09:00:00Z"},
+            {
+                "timestamp": "2026-05-13T09:15:00Z",
+                "hosted_runner_usage": {
+                    "cap": 20,
+                    "in_progress": {
+                        "total": 1,
+                        "by_label": [{"label": "ubuntu-latest", "count": 1}],
+                        "by_workflow": [],
+                    },
+                    "queued": {"total": 0, "by_workflow": [], "by_label": []},
+                },
+            },
+        ]
+        chart = ci_health._build_hosted_runner_chart(snapshots)
+        self.assertEqual(chart["label_series"]["ubuntu-latest"], [None, 1])
+        self.assertEqual(chart["queued_series"], [None, 0])
+        self.assertEqual(chart["total_series"], [None, 1])
+
+    def test_build_history_chart_includes_hosted_runner_section_when_data_present(self):
+        snapshots = [
+            {
+                "timestamp": "2026-05-13T10:00:00Z",
+                "jobs_queued": 0,
+                "jobs_running": 0,
+                "runs_queued": 0,
+                "runs_in_progress": 0,
+                "runner_groups": {},
+                "hosted_runner_usage": {
+                    "cap": 20,
+                    "in_progress": {
+                        "total": 1,
+                        "by_label": [{"label": "ubuntu-latest", "count": 1}],
+                        "by_workflow": [],
+                    },
+                    "queued": {"total": 0, "by_workflow": [], "by_label": []},
+                },
+            }
+        ]
+        html = ci_health.build_history_chart(snapshots)
+        self.assertIn("hostedRunnerHistory", html)
+        self.assertIn("GitHub-Hosted Runner Usage", html)
+
+    def test_build_history_chart_omits_hosted_runner_section_when_no_data(self):
+        snapshots = [
+            {
+                "timestamp": "2026-05-13T10:00:00Z",
+                "jobs_queued": 0,
+                "jobs_running": 0,
+                "runs_queued": 0,
+                "runs_in_progress": 0,
+                "runner_groups": {},
+            }
+        ]
+        html = ci_health.build_history_chart(snapshots)
+        # The <canvas id="hostedRunnerHistory_canvas"> is what gates the
+        # client-side chart render. When no hosted-runner data exists,
+        # the section header must be absent so the canvas isn't emitted.
+        self.assertNotIn('id="hostedRunnerHistory_canvas"', html)
+        self.assertNotIn("GitHub-Hosted Runner Usage", html)
+
+    def test_record_snapshot_persists_hosted_runner_usage(self):
+        usage = {
+            "cap": 20,
+            "in_progress": {"total": 7, "by_workflow": [], "by_label": []},
+            "queued": {"total": 0, "by_workflow": [], "by_label": []},
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            ci_health.record_snapshot(
+                {"summary": {}}, tmp, hosted_runner_usage=usage
+            )
+            with open(os.path.join(tmp, ci_health.SNAPSHOTS_FILE), encoding="utf-8") as f:
+                snapshot = json.loads(f.readline())
+        self.assertEqual(snapshot["hosted_runner_usage"], usage)
 
 
 if __name__ == "__main__":

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -1115,12 +1115,12 @@ class TestHostedRunnerUsage(unittest.TestCase):
         in_progress_run = {"id": 42, "name": "CI"}
 
         def fake_in_progress(repo):
-            return [in_progress_run]
+            return [in_progress_run], None
 
         def fake_queued(repo):
             # No workflow runs have top-level status=queued yet —
             # the queueing is happening *inside* an in_progress run.
-            return []
+            return [], None
 
         def fake_jobs(repo, run_id):
             assert run_id == 42
@@ -1136,7 +1136,7 @@ class TestHostedRunnerUsage(unittest.TestCase):
         with mock.patch.object(
             ci_hosted_runner_usage, "fetch_in_progress_runs", side_effect=fake_in_progress
         ), mock.patch.object(
-            ci_hosted_runner_usage, "fetch_queued_jobs", side_effect=fake_queued
+            ci_hosted_runner_usage, "fetch_queued_runs", side_effect=fake_queued
         ), mock.patch.object(
             ci_hosted_runner_usage, "fetch_jobs_for_run", side_effect=fake_jobs
         ):
@@ -1157,10 +1157,10 @@ class TestHostedRunnerUsage(unittest.TestCase):
         run = {"id": 7, "name": "CI"}
 
         def fake_in_progress(repo):
-            return [run]
+            return [run], None
 
         def fake_queued(repo):
-            return [run]
+            return [run], None
 
         call_count = {"n": 0}
 
@@ -1174,7 +1174,7 @@ class TestHostedRunnerUsage(unittest.TestCase):
         with mock.patch.object(
             ci_hosted_runner_usage, "fetch_in_progress_runs", side_effect=fake_in_progress
         ), mock.patch.object(
-            ci_hosted_runner_usage, "fetch_queued_jobs", side_effect=fake_queued
+            ci_hosted_runner_usage, "fetch_queued_runs", side_effect=fake_queued
         ), mock.patch.object(
             ci_hosted_runner_usage, "fetch_jobs_for_run", side_effect=fake_jobs
         ):
@@ -1189,10 +1189,10 @@ class TestHostedRunnerUsage(unittest.TestCase):
         run = {"id": 99, "name": "CI"}
 
         def fake_in_progress(repo):
-            return [run]
+            return [run], None
 
         def fake_queued(repo):
-            return []
+            return [], None
 
         def fake_jobs(repo, run_id):
             return (None, "HTTP 500")
@@ -1200,7 +1200,7 @@ class TestHostedRunnerUsage(unittest.TestCase):
         with mock.patch.object(
             ci_hosted_runner_usage, "fetch_in_progress_runs", side_effect=fake_in_progress
         ), mock.patch.object(
-            ci_hosted_runner_usage, "fetch_queued_jobs", side_effect=fake_queued
+            ci_hosted_runner_usage, "fetch_queued_runs", side_effect=fake_queued
         ), mock.patch.object(
             ci_hosted_runner_usage, "fetch_jobs_for_run", side_effect=fake_jobs
         ):
@@ -1211,15 +1211,77 @@ class TestHostedRunnerUsage(unittest.TestCase):
         self.assertTrue(snap.get("partial"))
         self.assertEqual(snap.get("fetch_errors"), 1)
 
+    def test_sample_marks_partial_on_listing_endpoint_failure(self):
+        """A 5xx on the runs-listing endpoint must surface as partial,
+        not as a false-healthy zero. Otherwise a transient API error
+        masks the very incident this sampler exists to detect.
+        """
+
+        def fake_in_progress(repo):
+            return [], "HTTP 502 listing in_progress runs"
+
+        def fake_queued(repo):
+            return [], None
+
+        def fake_jobs(repo, run_id):
+            return ([], None)
+
+        with mock.patch.object(
+            ci_hosted_runner_usage, "fetch_in_progress_runs", side_effect=fake_in_progress
+        ), mock.patch.object(
+            ci_hosted_runner_usage, "fetch_queued_runs", side_effect=fake_queued
+        ), mock.patch.object(
+            ci_hosted_runner_usage, "fetch_jobs_for_run", side_effect=fake_jobs
+        ):
+            snap = ci_hosted_runner_usage.sample_hosted_runner_usage(
+                "shader-slang/slang", cap=20
+            )
+
+        self.assertTrue(snap.get("partial"))
+        self.assertEqual(snap["in_progress"]["total"], 0)
+        self.assertEqual(snap["queued"]["total"], 0)
+        self.assertIn("HTTP 502 listing in_progress runs", snap.get("list_errors", []))
+
+    def test_sample_dedupe_skips_runs_with_missing_id(self):
+        """Don't collapse multiple `id: None` runs into one entry."""
+
+        def fake_in_progress(repo):
+            return [{"name": "broken-1"}, {"name": "broken-2"}], None
+
+        def fake_queued(repo):
+            return [], None
+
+        call_count = {"n": 0}
+
+        def fake_jobs(repo, run_id):
+            call_count["n"] += 1
+            return ([], None)
+
+        with mock.patch.object(
+            ci_hosted_runner_usage, "fetch_in_progress_runs", side_effect=fake_in_progress
+        ), mock.patch.object(
+            ci_hosted_runner_usage, "fetch_queued_runs", side_effect=fake_queued
+        ), mock.patch.object(
+            ci_hosted_runner_usage, "fetch_jobs_for_run", side_effect=fake_jobs
+        ):
+            snap = ci_hosted_runner_usage.sample_hosted_runner_usage(
+                "shader-slang/slang", cap=20
+            )
+
+        # Both malformed runs must be dropped (not merged into a single
+        # None-id entry and dispatched to fetch_jobs_for_run).
+        self.assertEqual(call_count["n"], 0)
+        self.assertEqual(snap["in_progress"]["total"], 0)
+
     def test_sample_hosted_runner_usage_shape(self):
         in_progress_run = {"id": 10, "name": "CI"}
         queued_run = {"id": 11, "name": "CMake Options"}
 
         def fake_in_progress(repo):
-            return [in_progress_run]
+            return [in_progress_run], None
 
         def fake_queued(repo):
-            return [queued_run]
+            return [queued_run], None
 
         def fake_jobs(repo, run_id):
             if run_id == 10:
@@ -1243,7 +1305,7 @@ class TestHostedRunnerUsage(unittest.TestCase):
         with mock.patch.object(
             ci_hosted_runner_usage, "fetch_in_progress_runs", side_effect=fake_in_progress
         ), mock.patch.object(
-            ci_hosted_runner_usage, "fetch_queued_jobs", side_effect=fake_queued
+            ci_hosted_runner_usage, "fetch_queued_runs", side_effect=fake_queued
         ), mock.patch.object(
             ci_hosted_runner_usage, "fetch_jobs_for_run", side_effect=fake_jobs
         ):
@@ -1293,6 +1355,22 @@ class TestHostedLabelPalette(unittest.TestCase):
                 self._is_six_digit_hex(color),
                 msg=f"{lbl!r} → {color!r} is not a 6-digit #RRGGBB",
             )
+
+    def test_palette_handles_unknown_prefix_without_keyerror(self):
+        """If HOSTED_LABEL_PREFIXES gains a new entry not mirrored in
+        HOSTED_LABEL_PALETTE, palette construction must fall back to a
+        neutral color rather than raising KeyError mid-snapshot."""
+        original = ci_hosted_runner_usage.HOSTED_LABEL_PREFIXES
+        with mock.patch.object(
+            ci_health,
+            "HOSTED_LABEL_ORDER",
+            original + ("freebsd-",),
+        ):
+            palette = ci_health._hosted_label_palette(["freebsd-14"])
+        self.assertTrue(
+            self._is_six_digit_hex(palette["freebsd-14"]),
+            msg=f"unknown-prefix label got invalid color {palette['freebsd-14']!r}",
+        )
 
     def test_variants_under_same_pool_get_distinct_colors(self):
         palette = ci_health._hosted_label_palette(

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -1074,14 +1074,62 @@ class TestHostedRunnerUsage(unittest.TestCase):
         with mock.patch.object(
             ci_hosted_runner_usage, "fetch_jobs_for_run", side_effect=fake_fetch
         ):
-            jobs = ci_hosted_runner_usage.collect_hosted_jobs(
+            jobs, errors = ci_hosted_runner_usage.collect_hosted_jobs(
                 "shader-slang/slang", [run], "in_progress"
             )
         self.assertEqual(len(jobs), 2)
+        self.assertEqual(errors, 0)
         labels = sorted(j["hosted_label"] for j in jobs)
         self.assertEqual(labels, ["ubuntu-latest", "windows-latest"])
         for j in jobs:
             self.assertEqual(j["workflow_name"], "CI")
+
+    def test_collect_hosted_jobs_counts_fetch_errors(self):
+        """Fetch failures must be surfaced, not silently undercounted."""
+        runs = [{"id": 1, "name": "CI"}, {"id": 2, "name": "CI"}]
+
+        def fake_fetch(repo, run_id):
+            if run_id == 1:
+                return (
+                    [{"status": "in_progress", "labels": ["ubuntu-latest"], "name": "a"}],
+                    None,
+                )
+            return (None, "HTTP 502")
+
+        with mock.patch.object(
+            ci_hosted_runner_usage, "fetch_jobs_for_run", side_effect=fake_fetch
+        ):
+            jobs, errors = ci_hosted_runner_usage.collect_hosted_jobs(
+                "shader-slang/slang", runs, "in_progress"
+            )
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(errors, 1)
+
+    def test_sample_hosted_runner_usage_marks_partial_on_errors(self):
+        run = {"id": 99, "name": "CI"}
+
+        def fake_in_progress(repo):
+            return [run]
+
+        def fake_queued(repo):
+            return []
+
+        def fake_jobs(repo, run_id):
+            return (None, "HTTP 500")
+
+        with mock.patch.object(
+            ci_hosted_runner_usage, "fetch_in_progress_runs", side_effect=fake_in_progress
+        ), mock.patch.object(
+            ci_hosted_runner_usage, "fetch_queued_jobs", side_effect=fake_queued
+        ), mock.patch.object(
+            ci_hosted_runner_usage, "fetch_jobs_for_run", side_effect=fake_jobs
+        ):
+            snap = ci_hosted_runner_usage.sample_hosted_runner_usage(
+                "shader-slang/slang", cap=20
+            )
+
+        self.assertTrue(snap.get("partial"))
+        self.assertEqual(snap.get("fetch_errors"), 1)
 
     def test_sample_hosted_runner_usage_shape(self):
         in_progress_run = {"id": 10, "name": "CI"}
@@ -1128,6 +1176,50 @@ class TestHostedRunnerUsage(unittest.TestCase):
         self.assertEqual(snap["in_progress"]["by_label"], [{"label": "ubuntu-latest", "count": 1}])
         self.assertEqual(snap["queued"]["total"], 2)
         self.assertEqual(snap["queued"]["by_workflow"], [{"name": "CMake Options", "count": 2}])
+
+
+class TestHostedLabelPalette(unittest.TestCase):
+    """Regression: variants must yield valid 6-digit `#RRGGBB` colors.
+
+    The original implementation appended an alpha suffix (`"BB"`), then
+    the chart code appended another `"55"` for the background fill,
+    producing invalid 10-digit hex like `#0d6efdBB55`.
+    """
+
+    def _is_six_digit_hex(self, color):
+        return (
+            isinstance(color, str)
+            and len(color) == 7
+            and color.startswith("#")
+            and all(c in "0123456789abcdefABCDEF" for c in color[1:])
+        )
+
+    def test_palette_returns_six_digit_hex_for_all_variants(self):
+        labels = [
+            "ubuntu-latest",
+            "ubuntu-22.04",
+            "ubuntu-24.04",
+            "ubuntu-24.04-arm",
+            "ubuntu-22.04-arm",
+            "windows-latest",
+            "windows-2022",
+            "macos-latest",
+            "macos-13",
+            "self-hosted-fallback",
+        ]
+        palette = ci_health._hosted_label_palette(labels)
+        for lbl, color in palette.items():
+            self.assertTrue(
+                self._is_six_digit_hex(color),
+                msg=f"{lbl!r} → {color!r} is not a 6-digit #RRGGBB",
+            )
+
+    def test_variants_under_same_pool_get_distinct_colors(self):
+        palette = ci_health._hosted_label_palette(
+            ["ubuntu-latest", "ubuntu-22.04", "ubuntu-24.04"]
+        )
+        colors = list(palette.values())
+        self.assertEqual(len(set(colors)), 3)
 
 
 class TestHostedRunnerRender(unittest.TestCase):

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -1105,6 +1105,86 @@ class TestHostedRunnerUsage(unittest.TestCase):
         self.assertEqual(len(jobs), 1)
         self.assertEqual(errors, 1)
 
+    def test_sample_counts_queued_jobs_inside_in_progress_runs(self):
+        """A run whose top-level status is `in_progress` can still carry
+        `queued` jobs waiting on a hosted runner. That is exactly the
+        cap-exhaustion leading edge we need to surface — make sure those
+        queued jobs land in the snapshot's `queued` bucket and not in
+        the void.
+        """
+        in_progress_run = {"id": 42, "name": "CI"}
+
+        def fake_in_progress(repo):
+            return [in_progress_run]
+
+        def fake_queued(repo):
+            # No workflow runs have top-level status=queued yet —
+            # the queueing is happening *inside* an in_progress run.
+            return []
+
+        def fake_jobs(repo, run_id):
+            assert run_id == 42
+            return (
+                [
+                    {"status": "in_progress", "labels": ["ubuntu-latest"], "name": "early"},
+                    {"status": "queued", "labels": ["ubuntu-latest"], "name": "stuck-1"},
+                    {"status": "queued", "labels": ["windows-latest"], "name": "stuck-2"},
+                ],
+                None,
+            )
+
+        with mock.patch.object(
+            ci_hosted_runner_usage, "fetch_in_progress_runs", side_effect=fake_in_progress
+        ), mock.patch.object(
+            ci_hosted_runner_usage, "fetch_queued_jobs", side_effect=fake_queued
+        ), mock.patch.object(
+            ci_hosted_runner_usage, "fetch_jobs_for_run", side_effect=fake_jobs
+        ):
+            snap = ci_hosted_runner_usage.sample_hosted_runner_usage(
+                "shader-slang/slang", cap=20
+            )
+
+        self.assertEqual(snap["in_progress"]["total"], 1)
+        self.assertEqual(snap["queued"]["total"], 2)
+        queued_labels = {x["label"]: x["count"] for x in snap["queued"]["by_label"]}
+        self.assertEqual(queued_labels, {"ubuntu-latest": 1, "windows-latest": 1})
+
+    def test_sample_dedupes_runs_listed_in_both_endpoints(self):
+        """A run transitioning queued -> in_progress can appear in both
+        list endpoints during sampling. Its jobs must not be counted
+        twice.
+        """
+        run = {"id": 7, "name": "CI"}
+
+        def fake_in_progress(repo):
+            return [run]
+
+        def fake_queued(repo):
+            return [run]
+
+        call_count = {"n": 0}
+
+        def fake_jobs(repo, run_id):
+            call_count["n"] += 1
+            return (
+                [{"status": "in_progress", "labels": ["ubuntu-latest"], "name": "a"}],
+                None,
+            )
+
+        with mock.patch.object(
+            ci_hosted_runner_usage, "fetch_in_progress_runs", side_effect=fake_in_progress
+        ), mock.patch.object(
+            ci_hosted_runner_usage, "fetch_queued_jobs", side_effect=fake_queued
+        ), mock.patch.object(
+            ci_hosted_runner_usage, "fetch_jobs_for_run", side_effect=fake_jobs
+        ):
+            snap = ci_hosted_runner_usage.sample_hosted_runner_usage(
+                "shader-slang/slang", cap=20
+            )
+
+        self.assertEqual(call_count["n"], 1)
+        self.assertEqual(snap["in_progress"]["total"], 1)
+
     def test_sample_hosted_runner_usage_marks_partial_on_errors(self):
         run = {"id": 99, "name": "CI"}
 


### PR DESCRIPTION
## Summary

Implements #11142: surfaces GitHub-hosted runner usage on the CI Health dashboard so a 20-cap exhaustion incident becomes a quantitative signal *before* it becomes a multi-hour repo-wide stall (as happened 5/11–5/13).

- New \`ci_hosted_runner_usage.py\` sampler polls in-progress and queued workflow runs and classifies hosted-runner jobs by label (\`ubuntu-*\` / \`macos-*\` / \`windows-*\`) and workflow. Self-hosted runners are vetoed by the \`self-hosted\` label.
- \`ci_health.py\` runs the sampler each refresh, persists \`hosted_runner_usage\` into the JSONL snapshot, and renders a new "GitHub-Hosted Runner Quota" section: tri-state banner (OK / HIGH at ≥80% / AT CAP at 100% + queue>0, matching thresholds in #11142), tables by workflow and by label, and a stacked-by-label history chart with the 20-cap line.

## Scope

Covers every workflow in \`shader-slang/slang\` (CI, CMake Options, Claude PR Review, Check Table of Contents, ...) — the per-org 20-runner cap is shared across all of them. **Cross-repo accounting** (slangpy, slang-rhi, etc., which draw from the same per-org cap) is deferred; will file a follow-up issue.

## Out of scope

- Historical statistics page chart: \`generate_statistics\` filters to \`workflow_name == \"CI\"\` and the daily collector is invoked with \`--workflow CI\`, so historical data is CI-only. Adding a hosted-runner chart there would either be misleading (if computed from CI-only data) or break existing-chart comparability (if we dropped the workflow filter mid-stream). Deferred to a follow-up.
Fixes #11142