### PR TITLE
Fix coop vector autodiff gradient accumulation

### DIFF
--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -3086,15 +3086,18 @@ struct ForwardDiffTranslationContext
             // Same fast-path as emitDZeroOfDiffInstType: bypass the synthesized
             // dzero witness for CoopVec/CoopMat self-differential opaque types,
             // which degenerate to uninitialized values.
-            if (as<IRCoopVectorType>(diffType) || as<IRCoopMatrixType>(diffType))
+            if (isSelfDifferentialOpaqueType((IRType*)diffType))
             {
-                // Mirror the reverse-mode specialization-ordering invariant.
+                // Guard: CoopVec requires a concrete element count; fall through
+                // to the witness method for non-literal counts.
                 if (auto coopVec = as<IRCoopVectorType>(diffType))
-                    SLANG_ASSERT(as<IRIntLit>(coopVec->getElementCount()));
+                    if (!as<IRIntLit>(coopVec->getElementCount()))
+                        goto witnessLookup;
                 auto result = builder->emitDefaultConstruct((IRType*)diffType);
                 builder->markInstAsDifferential(result, primalType);
                 return result;
             }
+            witnessLookup:
 
             auto zeroMethod = diffTypeContext.getZeroMethodForType(builder, originalType);
             SLANG_RELEASE_ASSERT(zeroMethod);

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -3083,6 +3083,16 @@ struct ForwardDiffTranslationContext
                 return result;
             }
 
+            // Same fast-path as emitDZeroOfDiffInstType: bypass the synthesized
+            // dzero witness for CoopVec/CoopMat self-differential opaque types,
+            // which degenerate to uninitialized values.
+            if (as<IRCoopVectorType>(diffType) || as<IRCoopMatrixType>(diffType))
+            {
+                auto result = builder->emitDefaultConstruct((IRType*)diffType);
+                builder->markInstAsDifferential(result, primalType);
+                return result;
+            }
+
             auto zeroMethod = diffTypeContext.getZeroMethodForType(builder, originalType);
             SLANG_RELEASE_ASSERT(zeroMethod);
 

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -3088,6 +3088,9 @@ struct ForwardDiffTranslationContext
             // which degenerate to uninitialized values.
             if (as<IRCoopVectorType>(diffType) || as<IRCoopMatrixType>(diffType))
             {
+                // Mirror the reverse-mode specialization-ordering invariant.
+                if (auto coopVec = as<IRCoopVectorType>(diffType))
+                    SLANG_ASSERT(as<IRIntLit>(coopVec->getElementCount()));
                 auto result = builder->emitDefaultConstruct((IRType*)diffType);
                 builder->markInstAsDifferential(result, primalType);
                 return result;

--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -3097,7 +3097,7 @@ struct ForwardDiffTranslationContext
                 builder->markInstAsDifferential(result, primalType);
                 return result;
             }
-            witnessLookup:
+        witnessLookup:
 
             auto zeroMethod = diffTypeContext.getZeroMethodForType(builder, originalType);
             SLANG_RELEASE_ASSERT(zeroMethod);

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -570,6 +570,14 @@ IRInst* DifferentiableTypeConformanceContext::buildDifferentiablePairWitness(
     return table;
 }
 
+// CoopVec/CoopMat are self-differential opaque types with no recursable fields;
+// synthesized dadd/dzero helpers degenerate to uninitialized values for them.
+// emitDefaultConstruct also has a dedicated fast-path for both (slang-ir.cpp).
+static bool isSelfDifferentialOpaqueType(IRType* type)
+{
+    return as<IRCoopVectorType>(type) || as<IRCoopMatrixType>(type);
+}
+
 IRInst* DifferentiableTypeConformanceContext::emitDAddOfDiffInstType(
     IRBuilder* builder,
     IRType* primalType,
@@ -591,11 +599,8 @@ IRInst* DifferentiableTypeConformanceContext::emitDAddOfDiffInstType(
         SLANG_UNEXPECTED("unexpected associated type during transposition");
     }
 
-    // CoopVec/CoopMat are self-differential opaque types with no recursable fields;
-    // synthesized dadd helpers degenerate to uninitialized values. Emit a primitive
-    // add directly and bypass the witness-table lookup.
     auto diffType = (IRType*)this->getDifferentialForType(primalType);
-    if (as<IRCoopVectorType>(diffType) || as<IRCoopMatrixType>(diffType))
+    if (isSelfDifferentialOpaqueType(diffType))
     {
         return builder->emitAdd(diffType, op1, op2);
     }
@@ -652,13 +657,13 @@ IRInst* DifferentiableTypeConformanceContext::emitDZeroOfDiffInstType(
             zeroElements.getBuffer());
     }
 
-    // CoopVec/CoopMat are self-differential opaque types with no recursable fields;
-    // synthesized dzero helpers degenerate to uninitialized values. Emit a primitive
-    // default-construct directly and bypass the witness-table lookup.
-    // Specialization runs before this pass (slang-emit.cpp: specializeModule before
-    // finalizeAutoDiffPass), so CoopVec element counts are always IRIntLit here.
+    // When reached from finalizeAutoDiffPass, specializeModule has already run
+    // (slang-emit.cpp:1237 < 1248), so CoopVec element counts are IRIntLit and
+    // emitDefaultConstruct produces a real zero. Callers from earlier autodiff
+    // passes must ensure specialization has completed before CoopVec/CoopMat
+    // types can appear as differentials.
     auto diffType = (IRType*)this->getDifferentialForType(primalType);
-    if (as<IRCoopVectorType>(diffType) || as<IRCoopMatrixType>(diffType))
+    if (isSelfDifferentialOpaqueType(diffType))
     {
         return builder->emitDefaultConstruct(diffType);
     }

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -657,21 +657,18 @@ IRInst* DifferentiableTypeConformanceContext::emitDZeroOfDiffInstType(
             zeroElements.getBuffer());
     }
 
-    // When reached from finalizeAutoDiffPass, specializeModule has already run,
-    // so CoopVec element counts are IRIntLit and emitDefaultConstruct produces
-    // a real zero. Callers from earlier autodiff passes must ensure
-    // specialization has completed before CoopVec/CoopMat types can appear
-    // as differentials.
+    // emitDefaultConstruct handles both types:
+    // - CoopVec: iterates element constructors when getElementCount() is IRIntLit;
+    //   falls through to a generic DefaultConstruct if the count is non-literal.
+    // - CoopMat: unconditionally calls emitMakeCoopMatrixFromScalar (no dimension check).
+    // Debug-assert the expected IRIntLit precondition for CoopVec so pipeline ordering
+    // violations surface early; CoopMat needs no assert since emitDefaultConstruct
+    // handles it unconditionally.
     auto diffType = (IRType*)this->getDifferentialForType(primalType);
     if (isSelfDifferentialOpaqueType(diffType))
     {
-        // Assert the specialization precondition: all dimension operands must be
-        // concrete IRIntLit so emitDefaultConstruct produces a real zero, not OpUndef.
-        // Use SLANG_RELEASE_ASSERT so violations surface in release builds too.
         if (auto coopVec = as<IRCoopVectorType>(diffType))
-            SLANG_RELEASE_ASSERT(as<IRIntLit>(coopVec->getElementCount()));
-        else if (auto coopMat = as<IRCoopMatrixType>(diffType))
-            SLANG_RELEASE_ASSERT(as<IRIntLit>(coopMat->getRowCount()) && as<IRIntLit>(coopMat->getColumnCount()));
+            SLANG_ASSERT(as<IRIntLit>(coopVec->getElementCount()));
         return builder->emitDefaultConstruct(diffType);
     }
 

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -665,10 +665,15 @@ IRInst* DifferentiableTypeConformanceContext::emitDZeroOfDiffInstType(
     auto diffType = (IRType*)this->getDifferentialForType(primalType);
     if (isSelfDifferentialOpaqueType(diffType))
     {
-        // Assert the specialization precondition: CoopVec element counts must be
-        // concrete so emitDefaultConstruct produces a real zero, not OpUndef.
+        // Assert the specialization precondition: all dimension operands must be
+        // concrete IRIntLit so emitDefaultConstruct produces a real zero, not OpUndef.
+        // Use SLANG_RELEASE_ASSERT so violations surface in release builds too.
         if (auto coopVec = as<IRCoopVectorType>(diffType))
-            SLANG_ASSERT(as<IRIntLit>(coopVec->getElementCount()));
+            SLANG_RELEASE_ASSERT(as<IRIntLit>(coopVec->getElementCount()));
+        else if (auto coopMat = as<IRCoopMatrixType>(diffType))
+            SLANG_RELEASE_ASSERT(
+                as<IRIntLit>(coopMat->getRowCount()) &&
+                as<IRIntLit>(coopMat->getColumnCount()));
         return builder->emitDefaultConstruct(diffType);
     }
 

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -591,13 +591,19 @@ IRInst* DifferentiableTypeConformanceContext::emitDAddOfDiffInstType(
         SLANG_UNEXPECTED("unexpected associated type during transposition");
     }
 
+    auto diffType = (IRType*)this->getDifferentialForType(primalType);
+    if (as<IRCoopVectorType>(diffType))
+    {
+        return builder->emitAdd(diffType, op1, op2);
+    }
+
     auto addMethod = this->getAddMethodForType(builder, primalType);
 
     // Should exist.
     SLANG_ASSERT(addMethod);
 
     return builder->emitCallInst(
-        (IRType*)this->getDifferentialForType(primalType),
+        diffType,
         addMethod,
         List<IRInst*>(op1, op2));
 }
@@ -650,13 +656,19 @@ IRInst* DifferentiableTypeConformanceContext::emitDZeroOfDiffInstType(
     // Default case: look up zero method and emit call.
     //
 
+    auto diffType = (IRType*)this->getDifferentialForType(primalType);
+    if (as<IRCoopVectorType>(diffType))
+    {
+        return builder->emitDefaultConstruct(diffType);
+    }
+
     auto zeroMethod = this->getZeroMethodForType(builder, primalType);
 
     // Should exist.
     SLANG_ASSERT(zeroMethod);
 
     return builder->emitCallInst(
-        (IRType*)this->getDifferentialForType(primalType),
+        diffType,
         zeroMethod,
         List<IRInst*>());
 }

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -602,10 +602,7 @@ IRInst* DifferentiableTypeConformanceContext::emitDAddOfDiffInstType(
     // Should exist.
     SLANG_ASSERT(addMethod);
 
-    return builder->emitCallInst(
-        diffType,
-        addMethod,
-        List<IRInst*>(op1, op2));
+    return builder->emitCallInst(diffType, addMethod, List<IRInst*>(op1, op2));
 }
 
 IRInst* DifferentiableTypeConformanceContext::emitDAddForExistentialType(
@@ -667,10 +664,7 @@ IRInst* DifferentiableTypeConformanceContext::emitDZeroOfDiffInstType(
     // Should exist.
     SLANG_ASSERT(zeroMethod);
 
-    return builder->emitCallInst(
-        diffType,
-        zeroMethod,
-        List<IRInst*>());
+    return builder->emitCallInst(diffType, zeroMethod, List<IRInst*>());
 }
 
 

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -655,6 +655,8 @@ IRInst* DifferentiableTypeConformanceContext::emitDZeroOfDiffInstType(
     // CoopVec/CoopMat are self-differential opaque types with no recursable fields;
     // synthesized dzero helpers degenerate to uninitialized values. Emit a primitive
     // default-construct directly and bypass the witness-table lookup.
+    // Specialization runs before this pass (slang-emit.cpp: specializeModule before
+    // finalizeAutoDiffPass), so CoopVec element counts are always IRIntLit here.
     auto diffType = (IRType*)this->getDifferentialForType(primalType);
     if (as<IRCoopVectorType>(diffType) || as<IRCoopMatrixType>(diffType))
     {

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -657,11 +657,11 @@ IRInst* DifferentiableTypeConformanceContext::emitDZeroOfDiffInstType(
             zeroElements.getBuffer());
     }
 
-    // When reached from finalizeAutoDiffPass, specializeModule has already run
-    // (slang-emit.cpp:1237 < 1248), so CoopVec element counts are IRIntLit and
-    // emitDefaultConstruct produces a real zero. Callers from earlier autodiff
-    // passes must ensure specialization has completed before CoopVec/CoopMat
-    // types can appear as differentials.
+    // When reached from finalizeAutoDiffPass, specializeModule has already run,
+    // so CoopVec element counts are IRIntLit and emitDefaultConstruct produces
+    // a real zero. Callers from earlier autodiff passes must ensure
+    // specialization has completed before CoopVec/CoopMat types can appear
+    // as differentials.
     auto diffType = (IRType*)this->getDifferentialForType(primalType);
     if (isSelfDifferentialOpaqueType(diffType))
     {

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -591,6 +591,9 @@ IRInst* DifferentiableTypeConformanceContext::emitDAddOfDiffInstType(
         SLANG_UNEXPECTED("unexpected associated type during transposition");
     }
 
+    // CoopVec/CoopMat are self-differential opaque types with no recursable fields;
+    // synthesized dadd helpers degenerate to uninitialized values. Emit a primitive
+    // add directly and bypass the witness-table lookup.
     auto diffType = (IRType*)this->getDifferentialForType(primalType);
     if (as<IRCoopVectorType>(diffType) || as<IRCoopMatrixType>(diffType))
     {
@@ -649,6 +652,9 @@ IRInst* DifferentiableTypeConformanceContext::emitDZeroOfDiffInstType(
             zeroElements.getBuffer());
     }
 
+    // CoopVec/CoopMat are self-differential opaque types with no recursable fields;
+    // synthesized dzero helpers degenerate to uninitialized values. Emit a primitive
+    // default-construct directly and bypass the witness-table lookup.
     auto diffType = (IRType*)this->getDifferentialForType(primalType);
     if (as<IRCoopVectorType>(diffType) || as<IRCoopMatrixType>(diffType))
     {

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -592,7 +592,7 @@ IRInst* DifferentiableTypeConformanceContext::emitDAddOfDiffInstType(
     }
 
     auto diffType = (IRType*)this->getDifferentialForType(primalType);
-    if (as<IRCoopVectorType>(diffType))
+    if (as<IRCoopVectorType>(diffType) || as<IRCoopMatrixType>(diffType))
     {
         return builder->emitAdd(diffType, op1, op2);
     }
@@ -649,16 +649,13 @@ IRInst* DifferentiableTypeConformanceContext::emitDZeroOfDiffInstType(
             zeroElements.getBuffer());
     }
 
-    //
-    // Default case: look up zero method and emit call.
-    //
-
     auto diffType = (IRType*)this->getDifferentialForType(primalType);
-    if (as<IRCoopVectorType>(diffType))
+    if (as<IRCoopVectorType>(diffType) || as<IRCoopMatrixType>(diffType))
     {
         return builder->emitDefaultConstruct(diffType);
     }
 
+    // Default case: look up zero method and emit call.
     auto zeroMethod = this->getZeroMethodForType(builder, primalType);
 
     // Should exist.

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -671,9 +671,7 @@ IRInst* DifferentiableTypeConformanceContext::emitDZeroOfDiffInstType(
         if (auto coopVec = as<IRCoopVectorType>(diffType))
             SLANG_RELEASE_ASSERT(as<IRIntLit>(coopVec->getElementCount()));
         else if (auto coopMat = as<IRCoopMatrixType>(diffType))
-            SLANG_RELEASE_ASSERT(
-                as<IRIntLit>(coopMat->getRowCount()) &&
-                as<IRIntLit>(coopMat->getColumnCount()));
+            SLANG_RELEASE_ASSERT(as<IRIntLit>(coopMat->getRowCount()) && as<IRIntLit>(coopMat->getColumnCount()));
         return builder->emitDefaultConstruct(diffType);
     }
 

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -570,13 +570,6 @@ IRInst* DifferentiableTypeConformanceContext::buildDifferentiablePairWitness(
     return table;
 }
 
-// CoopVec/CoopMat are self-differential opaque types with no recursable fields;
-// synthesized dadd/dzero helpers degenerate to uninitialized values for them.
-// emitDefaultConstruct also has a dedicated fast-path for both (slang-ir.cpp).
-static bool isSelfDifferentialOpaqueType(IRType* type)
-{
-    return as<IRCoopVectorType>(type) || as<IRCoopMatrixType>(type);
-}
 
 IRInst* DifferentiableTypeConformanceContext::emitDAddOfDiffInstType(
     IRBuilder* builder,
@@ -659,18 +652,22 @@ IRInst* DifferentiableTypeConformanceContext::emitDZeroOfDiffInstType(
 
     // emitDefaultConstruct handles both types:
     // - CoopVec: iterates element constructors when getElementCount() is IRIntLit;
-    //   falls through to a generic DefaultConstruct if the count is non-literal.
+    //   falls through to a generic DefaultConstruct if the count is non-literal
+    //   (which is not guaranteed to produce zero). Guard and fall through to the
+    //   witness method for non-literal counts.
     // - CoopMat: unconditionally calls emitMakeCoopMatrixFromScalar (no dimension check).
-    // Debug-assert the expected IRIntLit precondition for CoopVec so pipeline ordering
-    // violations surface early; CoopMat needs no assert since emitDefaultConstruct
-    // handles it unconditionally.
     auto diffType = (IRType*)this->getDifferentialForType(primalType);
     if (isSelfDifferentialOpaqueType(diffType))
     {
         if (auto coopVec = as<IRCoopVectorType>(diffType))
-            SLANG_ASSERT(as<IRIntLit>(coopVec->getElementCount()));
+        {
+            // Only take the fast-path when the element count is concrete.
+            if (!as<IRIntLit>(coopVec->getElementCount()))
+                goto witnessLookup;
+        }
         return builder->emitDefaultConstruct(diffType);
     }
+witnessLookup:
 
     // Default case: look up zero method and emit call.
     auto zeroMethod = this->getZeroMethodForType(builder, primalType);

--- a/source/slang/slang-ir-autodiff.cpp
+++ b/source/slang/slang-ir-autodiff.cpp
@@ -665,6 +665,10 @@ IRInst* DifferentiableTypeConformanceContext::emitDZeroOfDiffInstType(
     auto diffType = (IRType*)this->getDifferentialForType(primalType);
     if (isSelfDifferentialOpaqueType(diffType))
     {
+        // Assert the specialization precondition: CoopVec element counts must be
+        // concrete so emitDefaultConstruct produces a real zero, not OpUndef.
+        if (auto coopVec = as<IRCoopVectorType>(diffType))
+            SLANG_ASSERT(as<IRIntLit>(coopVec->getElementCount()));
         return builder->emitDefaultConstruct(diffType);
     }
 
@@ -955,6 +959,7 @@ bool canTypeBeStored(IRInst* type)
     case kIROp_FloatType:
     case kIROp_VectorType:
     case kIROp_CoopVectorType:
+    case kIROp_CoopMatrixType:
     case kIROp_MatrixType:
     case kIROp_BackwardDiffIntermediateContextType:
     case kIROp_BackwardDiffMinimalContextType:

--- a/source/slang/slang-ir-autodiff.h
+++ b/source/slang/slang-ir-autodiff.h
@@ -673,4 +673,12 @@ inline bool isMixedDifferentialInst(IRInst* inst)
     return inst->findDecoration<IRMixedDifferentialInstDecoration>();
 }
 
+// CoopVec/CoopMat are self-differential opaque types with no recursable fields;
+// synthesized dadd/dzero helpers degenerate to uninitialized values for them.
+// emitDefaultConstruct already has a dedicated fast-path for both (slang-ir.cpp).
+inline bool isSelfDifferentialOpaqueType(IRType* type)
+{
+    return as<IRCoopVectorType>(type) || as<IRCoopMatrixType>(type);
+}
+
 }; // namespace Slang

--- a/tests/autodiff/coopmat-self-differential-dadd.slang
+++ b/tests/autodiff/coopmat-self-differential-dadd.slang
@@ -59,7 +59,8 @@ void computeMain(uint id: SV_DispatchThreadID)
 }
 
 // CHECK: OpCompositeConstruct
+// CHECK-NOT: OpUndef
 // CHECK: OpFAdd
 // OpFAdd is the key regression guard: the buggy (pre-fix) code emitted OpUndef in
-// place of gradient accumulation instead of a real add, so the absence of OpFAdd
-// on the regressed compiler causes this CHECK to fail.
+// place of gradient accumulation, so the absence of OpFAdd (or its presence with
+// an OpUndef operand) on a regressed compiler causes one of these CHECKs to fail.

--- a/tests/autodiff/coopmat-self-differential-dadd.slang
+++ b/tests/autodiff/coopmat-self-differential-dadd.slang
@@ -1,0 +1,65 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -capability spvCooperativeMatrixKHR
+
+// Mirror of coopvec-self-differential-dadd.slang for IRCoopMatrixType.
+// Verifies that emitDAddOfDiffInstType and emitDZeroOfDiffInstType short-circuit
+// to direct IR ops for CoopMat self-differential types.
+
+using namespace linalg;
+
+// Extension generic params need fully-qualified linalg:: names because 'using
+// namespace' is not visible to the extension parameter scope at this point.
+extension<
+    T : __BuiltinFloatingPointType,
+    let S : MemoryScope,
+    let M : int,
+    let N : int,
+    let R : linalg::CoopMatMatrixUse
+> linalg::CoopMat<T, S, M, N, R> : IDifferentiable
+{
+    typealias Differential = linalg::CoopMat<T, S, M, N, R>;
+};
+
+typealias CoopMatFloat = CoopMat<float, MemoryScope.Subgroup, 16, 16, CoopMatMatrixUse.MatrixAccumulator>;
+
+[Differentiable]
+CoopMatFloat addCM(CoopMatFloat a, CoopMatFloat b)
+{
+    // CoopMat arithmetic is not auto-differentiable, so the primal body is a
+    // placeholder. The custom backward below is what the autodiff pass uses;
+    // it propagates dResult to both inputs, exercising the emitDAdd path for CoopMat.
+    return a;
+}
+
+[BackwardDerivativeOf(addCM)]
+void addCM_Backward(
+    inout DifferentialPair<CoopMatFloat> a,
+    inout DifferentialPair<CoopMatFloat> b,
+    CoopMatFloat.Differential dResult)
+{
+    a = diffPair(a.p, dResult);
+    b = diffPair(b.p, dResult);
+}
+
+[Differentiable]
+CoopMatFloat g(CoopMatFloat x)
+{
+    return addCM(x, x);
+}
+
+RWStructuredBuffer<float> output;
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(uint id: SV_DispatchThreadID)
+{
+    var x = diffPair(CoopMatFloat(2.0f), CoopMatFloat(0.0f));
+    bwd_diff(g)(x, CoopMatFloat(1.0f));
+
+    output[0] = x.d[id];
+}
+
+// CHECK: OpCompositeConstruct
+// CHECK: OpFAdd
+// Verify the short-circuit fired: no synthesized dadd/dzero function is emitted.
+// CHECK-NOT: OpName {{.*}} "{{.*}}dadd{{.*}}"
+// CHECK-NOT: OpName {{.*}} "{{.*}}dzero{{.*}}"

--- a/tests/autodiff/coopmat-self-differential-dadd.slang
+++ b/tests/autodiff/coopmat-self-differential-dadd.slang
@@ -58,9 +58,9 @@ void computeMain(uint id: SV_DispatchThreadID)
     output[0] = x.d[id];
 }
 
+// Anchor checks inside the function body so the global-scope OpUndef emitted for
+// unrelated IR (which precedes OpFunction in the module) is outside the scan window.
+// CHECK-LABEL: %computeMain = OpFunction
 // CHECK: OpCompositeConstruct
 // CHECK-NOT: OpUndef
 // CHECK: OpFAdd
-// OpFAdd is the key regression guard: the buggy (pre-fix) code emitted OpUndef in
-// place of gradient accumulation, so the absence of OpFAdd (or its presence with
-// an OpUndef operand) on a regressed compiler causes one of these CHECKs to fail.

--- a/tests/autodiff/coopmat-self-differential-dadd.slang
+++ b/tests/autodiff/coopmat-self-differential-dadd.slang
@@ -58,9 +58,12 @@ void computeMain(uint id: SV_DispatchThreadID)
     output[0] = x.d[id];
 }
 
-// Anchor checks inside the function body so the global-scope OpUndef emitted for
-// unrelated IR (which precedes OpFunction in the module) is outside the scan window.
+// Anchor all checks inside computeMain so the global-scope OpUndef (emitted before
+// OpFunction in the module) is outside the scan window, and the entire function
+// body is covered.
 // CHECK-LABEL: %computeMain = OpFunction
 // CHECK: OpCompositeConstruct
 // CHECK-NOT: OpUndef
 // CHECK: OpFAdd
+// CHECK-NOT: OpUndef
+// CHECK: OpFunctionEnd

--- a/tests/autodiff/coopmat-self-differential-dadd.slang
+++ b/tests/autodiff/coopmat-self-differential-dadd.slang
@@ -60,6 +60,6 @@ void computeMain(uint id: SV_DispatchThreadID)
 
 // CHECK: OpCompositeConstruct
 // CHECK: OpFAdd
-// Verify the short-circuit fired: no synthesized dadd/dzero function is emitted.
-// CHECK-NOT: OpName {{.*}} "{{.*}}dadd{{.*}}"
-// CHECK-NOT: OpName {{.*}} "{{.*}}dzero{{.*}}"
+// OpFAdd is the key regression guard: the buggy (pre-fix) code emitted OpUndef in
+// place of gradient accumulation instead of a real add, so the absence of OpFAdd
+// on the regressed compiler causes this CHECK to fail.

--- a/tests/autodiff/coopvec-self-differential-dadd.slang
+++ b/tests/autodiff/coopvec-self-differential-dadd.slang
@@ -53,6 +53,7 @@ void computeMain(uint id: SV_DispatchThreadID)
 
 // CHECK: OpCompositeConstructReplicateEXT
 // CHECK: OpFAdd
-// Verify the short-circuit fired: no calls to synthesized dadd/dzero helpers.
-// CHECK-NOT: OpFunctionCall {{.*}}dadd
-// CHECK-NOT: OpFunctionCall {{.*}}dzero
+// Verify the short-circuit fired: no synthesized dadd/dzero function is emitted.
+// (OpFunctionCall references functions by result-id, not name; OpName is reliable.)
+// CHECK-NOT: OpName {{.*}} "{{.*}}dadd{{.*}}"
+// CHECK-NOT: OpName {{.*}} "{{.*}}dzero{{.*}}"

--- a/tests/autodiff/coopvec-self-differential-dadd.slang
+++ b/tests/autodiff/coopvec-self-differential-dadd.slang
@@ -49,3 +49,6 @@ void computeMain(uint id: SV_DispatchThreadID)
 
 // CHECK: OpCompositeConstructReplicateEXT
 // CHECK: OpFAdd
+// Verify the short-circuit fired: no calls to synthesized dadd/dzero helpers.
+// CHECK-NOT: OpFunctionCall {{.*}}dadd
+// CHECK-NOT: OpFunctionCall {{.*}}dzero

--- a/tests/autodiff/coopvec-self-differential-dadd.slang
+++ b/tests/autodiff/coopvec-self-differential-dadd.slang
@@ -16,7 +16,11 @@ void exp_BackwardAutoDiff<T : __BuiltinFloatingPointType, let K : int>(
 [Differentiable]
 CoopVec<float, 2> addCV(CoopVec<float, 2> a, CoopVec<float, 2> b)
 {
-    return a + b;
+    // CoopVec arithmetic is not auto-differentiable, so the primal body is a
+    // placeholder that satisfies the [Differentiable] requirement. The custom
+    // backward below is what the autodiff pass uses; it propagates dResult to
+    // both inputs, exercising the emitDAdd path for CoopVec.
+    return a;
 }
 
 [BackwardDerivativeOf(addCV)]

--- a/tests/autodiff/coopvec-self-differential-dadd.slang
+++ b/tests/autodiff/coopvec-self-differential-dadd.slang
@@ -51,11 +51,9 @@ void computeMain(uint id: SV_DispatchThreadID)
     output[0] = x.d[0];
 }
 
+// Anchor checks inside the function body so the global-scope OpUndef emitted for
+// unrelated IR (which precedes OpFunction in the module) is outside the scan window.
+// CHECK-LABEL: %computeMain = OpFunction
 // CHECK: OpCompositeConstructReplicateEXT
 // CHECK-NOT: OpUndef
 // CHECK: OpFAdd
-// OpFAdd is the key regression guard: the buggy (pre-fix) code emitted OpUndef in
-// place of gradient accumulation, so the absence of OpFAdd (or its presence with
-// an OpUndef operand) on a regressed compiler causes one of these CHECKs to fail.
-// (The global-scope OpUndef from an unrelated IR node appears before the first
-// CHECK match and is therefore outside the CHECK-NOT scan window.)

--- a/tests/autodiff/coopvec-self-differential-dadd.slang
+++ b/tests/autodiff/coopvec-self-differential-dadd.slang
@@ -53,7 +53,6 @@ void computeMain(uint id: SV_DispatchThreadID)
 
 // CHECK: OpCompositeConstructReplicateEXT
 // CHECK: OpFAdd
-// Verify the short-circuit fired: no synthesized dadd/dzero function is emitted.
-// (OpFunctionCall references functions by result-id, not name; OpName is reliable.)
-// CHECK-NOT: OpName {{.*}} "{{.*}}dadd{{.*}}"
-// CHECK-NOT: OpName {{.*}} "{{.*}}dzero{{.*}}"
+// OpFAdd is the key regression guard: the buggy (pre-fix) code emitted OpUndef in
+// place of gradient accumulation instead of a real add, so the absence of OpFAdd
+// on the regressed compiler causes this CHECK to fail.

--- a/tests/autodiff/coopvec-self-differential-dadd.slang
+++ b/tests/autodiff/coopvec-self-differential-dadd.slang
@@ -16,8 +16,7 @@ void exp_BackwardAutoDiff<T : __BuiltinFloatingPointType, let K : int>(
 [Differentiable]
 CoopVec<float, 2> addCV(CoopVec<float, 2> a, CoopVec<float, 2> b)
 {
-    // The custom backward below is what matters; the primal just keeps this test compile-only.
-    return a;
+    return a + b;
 }
 
 [BackwardDerivativeOf(addCV)]

--- a/tests/autodiff/coopvec-self-differential-dadd.slang
+++ b/tests/autodiff/coopvec-self-differential-dadd.slang
@@ -1,0 +1,52 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -capability spvCooperativeVectorNV
+
+extension<T : __BuiltinFloatingPointType, let K : int> CoopVec<T, K> : IDifferentiable
+{
+    typealias Differential = CoopVec<T, K>;
+};
+
+[BackwardDerivativeOf(exp)]
+void exp_BackwardAutoDiff<T : __BuiltinFloatingPointType, let K : int>(
+    inout DifferentialPair<CoopVec<T, K>> p0,
+    CoopVec<T, K>.Differential dResult)
+{
+    p0 = diffPair(p0.p, dResult * exp(p0.p));
+}
+
+[Differentiable]
+CoopVec<float, 2> addCV(CoopVec<float, 2> a, CoopVec<float, 2> b)
+{
+    // The custom backward below is what matters; the primal just keeps this test compile-only.
+    return a;
+}
+
+[BackwardDerivativeOf(addCV)]
+void addCV_BackwardAutoDiff(
+    inout DifferentialPair<CoopVec<float, 2>> a,
+    inout DifferentialPair<CoopVec<float, 2>> b,
+    CoopVec<float, 2>.Differential dResult)
+{
+    a = diffPair(a.p, dResult);
+    b = diffPair(b.p, dResult);
+}
+
+[Differentiable]
+CoopVec<float, 2> f(CoopVec<float, 2> x)
+{
+    return addCV(exp(x), exp(x));
+}
+
+RWStructuredBuffer<float> output;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint id: SV_DispatchThreadID)
+{
+    var x = diffPair(CoopVec<float, 2>(2.0f), CoopVec<float, 2>(0.0f));
+    bwd_diff(f)(x, CoopVec<float, 2>(1.0f));
+
+    output[0] = x.d[0];
+}
+
+// CHECK: OpCompositeConstructReplicateEXT
+// CHECK: OpFAdd

--- a/tests/autodiff/coopvec-self-differential-dadd.slang
+++ b/tests/autodiff/coopvec-self-differential-dadd.slang
@@ -52,7 +52,10 @@ void computeMain(uint id: SV_DispatchThreadID)
 }
 
 // CHECK: OpCompositeConstructReplicateEXT
+// CHECK-NOT: OpUndef
 // CHECK: OpFAdd
 // OpFAdd is the key regression guard: the buggy (pre-fix) code emitted OpUndef in
-// place of gradient accumulation instead of a real add, so the absence of OpFAdd
-// on the regressed compiler causes this CHECK to fail.
+// place of gradient accumulation, so the absence of OpFAdd (or its presence with
+// an OpUndef operand) on a regressed compiler causes one of these CHECKs to fail.
+// (The global-scope OpUndef from an unrelated IR node appears before the first
+// CHECK match and is therefore outside the CHECK-NOT scan window.)

--- a/tests/autodiff/coopvec-self-differential-dadd.slang
+++ b/tests/autodiff/coopvec-self-differential-dadd.slang
@@ -51,9 +51,12 @@ void computeMain(uint id: SV_DispatchThreadID)
     output[0] = x.d[0];
 }
 
-// Anchor checks inside the function body so the global-scope OpUndef emitted for
-// unrelated IR (which precedes OpFunction in the module) is outside the scan window.
+// Anchor all checks inside computeMain so the global-scope OpUndef (emitted before
+// OpFunction in the module) is outside the scan window, and the entire function
+// body is covered.
 // CHECK-LABEL: %computeMain = OpFunction
 // CHECK: OpCompositeConstructReplicateEXT
 // CHECK-NOT: OpUndef
 // CHECK: OpFAdd
+// CHECK-NOT: OpUndef
+// CHECK: OpFunctionEnd


### PR DESCRIPTION
Emit zero and add operations directly for cooperative-vector differential values instead of relying on synthesized IDifferentiable helpers, which can return uninitialized values for fieldless self-differential types and poison reverse-mode gradients.