### PR TITLE
Emit visibility-mismatch note when synthesized ctor argument count fails

### DIFF
--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -917,6 +917,33 @@ bool SemanticsVisitor::createInvokeExprForSynthesizedCtor(
             getSink()->diagnoseRaw(
                 Severity::Error,
                 static_cast<char const*>(blob->getBufferPointer()));
+
+            // When the synthesized constructor has fewer parameters than
+            // members because some members are less visible than the struct
+            // itself, the user gets "too many arguments" without
+            // understanding why certain members were excluded from the
+            // constructor. Emit a note naming each non-public member so
+            // they know what to fix (issue #11005).
+            //
+            // Use the same criteria as `collectInitializableMembers`:
+            // instance members whose visibility is strictly less than the
+            // struct's are excluded from the synthesized ctor.
+            DeclVisibility structVis = getDeclVisibility(structDecl);
+            for (auto varDecl : structDecl->getMembersOfType<VarDeclBase>())
+            {
+                if (varDecl->hasModifier<HLSLStaticModifier>())
+                    continue;
+                DeclVisibility memberVis = getDeclVisibility(varDecl);
+                if (memberVis < structVis)
+                {
+                    diagnoseOnce(Diagnostics::InitializerListMemberVisibilityMismatch{
+                        .memberVis = memberVis,
+                        .type = toType,
+                        .structVis = structVis,
+                        .member = varDecl});
+                }
+            }
+
             return false;
         }
     }

--- a/tests/initializer-list/struct-visibility-diagnostic-1.slang
+++ b/tests/initializer-list/struct-visibility-diagnostic-1.slang
@@ -3,6 +3,7 @@
 public struct Visibility
 {
   internal int x;
+//CHECK:       ^ member 'x' is internal, but 'Visibility' is public
   public int y = 0;
   // Mixed visibility: internal x != public struct.
   // A synthesized public constructor is created for the public member only: __init(int y = 0).

--- a/tests/initializer-list/struct-visibility-diagnostic-4.slang
+++ b/tests/initializer-list/struct-visibility-diagnostic-4.slang
@@ -3,6 +3,7 @@
 public struct Visibility
 {
   internal int x = 1;
+//CHECK:       ^ member 'x' is internal, but 'Visibility' is public
   public int y = 5;
   // Mixed visibility: internal x != public struct.
   // A synthesized public constructor is created for the public member only: __init(int y = 5).


### PR DESCRIPTION
## Summary
- When a public struct has mixed-visibility members (e.g. some internal, some public), the synthesized constructor only accepts the public members. If a user tries to initialize the struct with an initializer list that has arguments for all members, they get "too many arguments" without any indication of why some members were excluded.
- Now emit the existing E30516 note for each member whose visibility doesn't match the struct's, so users understand which members are excluded and why.
- Updated existing diagnostic tests to verify the new note appears.

## Test plan
- [x] `tests/initializer-list/struct-visibility-diagnostic-1.slang` passes with updated CHECK annotations
- [x] `tests/initializer-list/struct-visibility-diagnostic-4.slang` passes with updated CHECK annotations
- [x] `tests/initializer-list/non-public-member-note.slang` still passes (no regressions)
- [x] `tests/initializer-list/struct-visibility-diagnostic-2.slang` still passes
- [x] `tests/initializer-list/struct-visibility-diagnostic-3.slang` still passes

Fixes #11005