### PR TITLE
Diagnose non-float matrix element types in SPIR-V entry-point varyings

### DIFF
--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -917,6 +917,30 @@ static bool _matchInvalidIndicesElementType(Type* type)
     return true;
 }
 
+static bool _matchMatrixWithNonFloatElementType(Type* type)
+{
+    // SPIR-V's `OpTypeMatrix` requires column vectors to have a floating-point
+    // scalar component type (half/float/double). Matrices with integer or bool
+    // element types are legalized to arrays in IR, but that legalization does
+    // not produce valid SPIR-V when the matrix appears in an interface block
+    // (entry-point varyings). Diagnose them up front (issue #9451).
+    auto matType = as<MatrixExpressionType>(type);
+    if (!matType)
+        return false;
+    auto elemType = as<BasicExpressionType>(matType->getElementType());
+    if (!elemType)
+        return false;
+    switch (elemType->getBaseType())
+    {
+    case BaseType::Half:
+    case BaseType::Float:
+    case BaseType::Double:
+        return false; // valid floating-point element types
+    default:
+        return true; // integer, bool, etc. — not valid for SPIR-V matrices
+    }
+}
+
 static bool _matchMatrixWithOutOfRangeDimensions(Type* type)
 {
     // Row and column counts outside the 1..4 range break downstream codegen
@@ -994,6 +1018,16 @@ static const EntryPointVaryingTypeRule kEntryPointVaryingTypeRules[] = {
     // practice; only diagnose where the failure actually occurs.
     {_matchVectorBoolType,
      "vector<bool> is not a valid SPIR-V varying type for this stage",
+     isSPIRV,
+     _isInterfaceBlockVaryingStage},
+
+    // `matrix<T, R, C>` where T is not a floating-point type (half/float/double)
+    // generates invalid SPIR-V because `OpTypeMatrix` requires floating-point
+    // column vectors. Integer and bool matrices are legalized to arrays in IR
+    // but that legalization does not cover interface-block varyings (issue #9451).
+    {_matchMatrixWithNonFloatElementType,
+     "matrix element type must be a floating-point type (half, float, or double) for "
+     "SPIR-V entry-point varyings",
      isSPIRV,
      _isInterfaceBlockVaryingStage},
 

--- a/tests/diagnostics/entry-point-matrix-non-float-spirv.slang
+++ b/tests/diagnostics/entry-point-matrix-non-float-spirv.slang
@@ -1,0 +1,19 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):-target spirv -entry mainParam -stage vertex
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK2,non-exhaustive):-target spirv -entry mainReturn -stage vertex
+
+// Test that non-float matrix element types are diagnosed on SPIR-V targets
+// when used as entry-point varying parameters or return types (issue #9451).
+
+[shader("vertex")]
+void mainParam(matrix<uint64_t> a)
+//CHECK:                        ^ type 'matrix<uint64_t,4,4>' cannot be used as input parameter 'a' of entry point 'mainParam' when targeting spirv because matrix element type must be a floating-point type (half, float, or double) for SPIR-V entry-point varyings
+{
+    unused(a);
+}
+
+[shader("vertex")]
+matrix<uint64_t> mainReturn()
+//CHECK2:        ^^^^^^^^^^ type 'matrix<uint64_t,4,4>' cannot be used as output return type of entry point 'mainReturn' when targeting spirv because matrix element type must be a floating-point type (half, float, or double) for SPIR-V entry-point varyings
+{
+    return {};
+}


### PR DESCRIPTION
## Summary
- SPIR-V's `OpTypeMatrix` requires column vectors to have a floating-point scalar component type (half/float/double). When `matrix<uint64_t>` or other non-float matrix types were used as entry-point varying parameters or return types, the compiler silently generated invalid SPIR-V.
- Add an entry-point varying type validation rule that rejects matrices with non-float element types on SPIR-V targets for interface-block varying stages (vertex, fragment, geometry, hull, domain, mesh).
- Follows the existing pattern established by the `vector<bool>` rule for SPIR-V targets.

## Test plan
- [x] New test `tests/diagnostics/entry-point-matrix-non-float-spirv.slang` verifies the diagnostic fires for `matrix<uint64_t>` as a vertex shader parameter
- [x] Verified `matrix<float>` still compiles without errors on SPIR-V targets
- [x] Verified the return-type case also produces the diagnostic

Fixes #9451