### PR TITLE
Warn when the same variable is passed to aliased out/inout parameters

### DIFF
--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -3908,6 +3908,161 @@ static Expr* convertHigherOrderExprToLookup(
     }
 }
 
+// Peel implicit casts and parentheses from an expression.
+static Expr* _peelCastsAndParens(Expr* expr)
+{
+    for (;;)
+    {
+        if (!expr)
+            return nullptr;
+        // Peel any single-argument TypeCastExpr: this covers
+        // ImplicitCastExpr, OutImplicitCastExpr, InOutImplicitCastExpr,
+        // and LValueImplicitCastExpr which wrap the original argument
+        // during overload resolution for out/inout coercion.
+        if (auto castExpr = as<TypeCastExpr>(expr))
+        {
+            if (castExpr->arguments.getCount() == 1)
+            {
+                expr = castExpr->arguments[0];
+                continue;
+            }
+        }
+        if (auto parenExpr = as<ParenExpr>(expr))
+        {
+            expr = parenExpr->base;
+            continue;
+        }
+        return expr;
+    }
+}
+
+// Check whether two expressions refer to the same storage location by
+// comparing their structure in lockstep. Handles bare variable
+// references, member accesses (s.x == s.x, but not s.x == s.y), and
+// subscripts with matching constant indices (arr[0] == arr[0], but not
+// arr[0] == arr[1]). Returns false for anything it can't prove equal.
+static bool _exprsDefinitelyAlias(Expr* a, Expr* b)
+{
+    a = _peelCastsAndParens(a);
+    b = _peelCastsAndParens(b);
+    if (!a || !b)
+        return false;
+
+    // Same declaration reference.
+    if (auto aDeclRef = as<DeclRefExpr>(a))
+    {
+        auto bDeclRef = as<DeclRefExpr>(b);
+        return bDeclRef && aDeclRef->declRef.getDecl() == bDeclRef->declRef.getDecl();
+    }
+
+    // Same member of the same base: s.x vs s.x.
+    if (auto aMember = as<MemberExpr>(a))
+    {
+        auto bMember = as<MemberExpr>(b);
+        if (!bMember)
+            return false;
+        if (aMember->declRef.getDecl() != bMember->declRef.getDecl())
+            return false;
+        return _exprsDefinitelyAlias(aMember->baseExpression, bMember->baseExpression);
+    }
+
+    // Same element of the same base: arr[0] vs arr[0].
+    if (auto aIndex = as<IndexExpr>(a))
+    {
+        auto bIndex = as<IndexExpr>(b);
+        if (!bIndex)
+            return false;
+        if (aIndex->indexExprs.getCount() != 1 || bIndex->indexExprs.getCount() != 1)
+            return false;
+        // Only compare constant integer indices; dynamic indices are
+        // conservatively treated as non-aliasing (may be different).
+        auto aLit = as<IntegerLiteralExpr>(aIndex->indexExprs[0]);
+        auto bLit = as<IntegerLiteralExpr>(bIndex->indexExprs[0]);
+        if (!aLit || !bLit || aLit->value != bLit->value)
+            return false;
+        return _exprsDefinitelyAlias(aIndex->baseExpression, bIndex->baseExpression);
+    }
+
+    return false;
+}
+
+static bool _isOutInOutOrRefParam(FuncType* funcType, Index paramIndex)
+{
+    auto paramType = funcType->getParamTypeWithModeWrapper(paramIndex);
+    return as<OutParamTypeBase>(paramType) || as<RefParamType>(paramType);
+}
+
+static const char* _getDirectionString(FuncType* funcType, Index paramIndex)
+{
+    auto paramType = funcType->getParamTypeWithModeWrapper(paramIndex);
+    if (as<OutParamType>(paramType))
+        return "out";
+    if (as<BorrowInOutParamType>(paramType))
+        return "inout";
+    if (as<RefParamType>(paramType))
+        return "ref";
+    return "in";
+}
+
+void SemanticsVisitor::_checkAliasedOutArguments(
+    InvokeExpr* invoke,
+    FuncType* funcType,
+    FunctionDeclBase* funcDeclBase)
+{
+    // Operator expressions (compound assignments like `a += a`, prefix/postfix
+    // `++a`, etc.) desugar into function calls with `inout` parameters but have
+    // well-defined semantics even when the operand appears on both sides.
+    // Skip the aliasing check for those.
+    if (as<OperatorExpr>(invoke))
+        return;
+
+    Index argCount = invoke->arguments.getCount();
+    Index paramCount = funcType->getParamCount();
+    Index checkCount = Math::Min(argCount, paramCount);
+
+    // For each pair of arguments, check if they refer to the same storage
+    // and at least one parameter is out/inout/ref. We compare expressions
+    // structurally: bare variables (a == a), member accesses (s.x == s.x
+    // but not s.x == s.y), and constant-index subscripts (arr[0] == arr[0]
+    // but not arr[0] == arr[1]).
+    for (Index i = 0; i < checkCount; ++i)
+    {
+        bool iIsOut = _isOutInOutOrRefParam(funcType, i);
+
+        for (Index j = i + 1; j < checkCount; ++j)
+        {
+            // At least one of the two must be out/inout/ref.
+            bool jIsOut = _isOutInOutOrRefParam(funcType, j);
+            if (!iIsOut && !jIsOut)
+                continue;
+
+            if (!_exprsDefinitelyAlias(invoke->arguments[i], invoke->arguments[j]))
+                continue;
+
+            // Both arguments refer to the same variable and at least
+            // one is out/inout/ref. Put the out/inout/ref parameter
+            // first in the diagnostic for clarity.
+            Index first = iIsOut ? i : j;
+            Index second = iIsOut ? j : i;
+
+            Name* paramNameFirst = nullptr;
+            Name* paramNameSecond = nullptr;
+            if (funcDeclBase && funcDeclBase->getParameters().getCount() > first)
+                paramNameFirst = funcDeclBase->getParameters()[first]->getName();
+            if (funcDeclBase && funcDeclBase->getParameters().getCount() > second)
+                paramNameSecond = funcDeclBase->getParameters()[second]->getName();
+
+            getSink()->diagnose(Diagnostics::PotentiallyAliasedOutParameter{
+                .direction1 = _getDirectionString(funcType, first),
+                .param1 = paramNameFirst,
+                .direction2 = _getDirectionString(funcType, second),
+                .param2 = paramNameSecond,
+                .firstArg = invoke->arguments[first]});
+            break; // One warning per outer index i is enough.
+        }
+    }
+}
+
 Expr* SemanticsVisitor::CheckInvokeExprWithCheckedOperands(InvokeExpr* expr)
 {
     auto rs = ResolveInvoke(expr);
@@ -4139,6 +4294,12 @@ Expr* SemanticsVisitor::CheckInvokeExprWithCheckedOperands(InvokeExpr* expr)
                     }
                 }
             }
+
+            // Check for potentially aliased out/inout/ref arguments.
+            // If two arguments refer to the same root variable and at
+            // least one of them is out/inout/ref, the behavior is
+            // undefined (issue #10699).
+            _checkAliasedOutArguments(invoke, funcType, funcDeclBase);
 
             if (!IsErrorExpr(invoke))
             {

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -3231,6 +3231,10 @@ public:
 
 
     void compareMemoryQualifierOfParamToArgument(ParamDecl* paramIn, Expr* argIn);
+    void _checkAliasedOutArguments(
+        InvokeExpr* invoke,
+        FuncType* funcType,
+        FunctionDeclBase* funcDeclBase);
     Expr* CheckInvokeExprWithCheckedOperands(InvokeExpr* expr);
     // Get the type to use when referencing a declaration
     QualType GetTypeForDeclRef(DeclRef<Decl> declRef, SourceLoc loc);

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -1211,6 +1211,13 @@ standalone_note(
     span { loc = "expr:Expr" }
 )
 
+warning(
+    "potentially-aliased-out-parameter",
+    30051,
+    "potentially aliased argument to 'out'/'inout'/'ref' parameter",
+    span { loc = "firstArg:Expr", message = "argument for '~direction1' parameter '~param1:Name' may alias argument for '~direction2' parameter '~param2:Name'; passing the same value to both may produce unexpected results" }
+)
+
 err(
     "mutating-method-on-immutable-value",
     30050,

--- a/tests/diagnostics/aliased-out-inout-parameter.slang
+++ b/tests/diagnostics/aliased-out-inout-parameter.slang
@@ -1,0 +1,107 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):
+
+// Test that passing the same variable to multiple out/inout/ref parameters
+// produces a warning about potential aliasing (issue #10699).
+
+void addConsumeTwoValues(
+    inout int i1, inout int i2, inout int o)
+{
+    o += i1;
+    i1 = -1;
+    o += i2;
+    i2 = -1;
+}
+
+void twoOut(out int a, out int b)
+{
+    a = 1;
+    b = 2;
+}
+
+void inAndInout(int a, inout int b)
+{
+    b += a;
+}
+
+void twoRef(__ref int a, __ref int b)
+{
+    int t = a; a = b; b = t;
+}
+
+struct S { int x; int y; }
+
+void twoInoutInt(inout int a, inout int b)
+{
+    a += b; b -= a;
+}
+
+void twoInoutUint(inout uint a, inout uint b)
+{
+    a += b; b -= a;
+}
+
+void readBoth(int a, int b) {}
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    int a = 0;
+    int b = 1;
+
+    // Positive: same variable to two inout params.
+    addConsumeTwoValues(a, b, a);
+//CHECK:                ^ potentially aliased argument to 'out'/'inout'/'ref' parameter
+//CHECK:                ^ argument for 'inout' parameter 'i1' may alias argument for 'inout' parameter 'o'; passing the same value to both may produce unexpected results
+
+    // Positive: same variable to two out params.
+    twoOut(a, a);
+//CHECK:   ^ potentially aliased argument to 'out'/'inout'/'ref' parameter
+//CHECK:   ^ argument for 'out' parameter 'a' may alias argument for 'out' parameter 'b'; passing the same value to both may produce unexpected results
+
+    // Positive: same variable to in and inout params.
+    inAndInout(a, a);
+//CHECK:          ^ potentially aliased argument to 'out'/'inout'/'ref' parameter
+//CHECK:          ^ argument for 'inout' parameter 'b' may alias argument for 'in' parameter 'a'; passing the same value to both may produce unexpected results
+
+    // Positive: same variable to two ref params.
+    twoRef(a, a);
+//CHECK:   ^ potentially aliased argument to 'out'/'inout'/'ref' parameter
+//CHECK:   ^ argument for 'ref' parameter 'a' may alias argument for 'ref' parameter 'b'; passing the same value to both may produce unexpected results
+
+    // Positive: identical struct field to two inout params.
+    S s;
+    twoInoutInt(s.x, s.x);
+//CHECK:          ^ potentially aliased argument to 'out'/'inout'/'ref' parameter
+//CHECK:          ^ passing the same value to both may produce unexpected results
+
+    // Positive: identical array element to two inout params.
+    int arr[4];
+    twoInoutInt(arr[0], arr[0]);
+//CHECK:           ^ potentially aliased argument to 'out'/'inout'/'ref' parameter
+//CHECK:           ^ passing the same value to both may produce unexpected results
+
+    // Positive: coerced inout argument (exercises TypeCastExpr peeling).
+    twoInoutUint(a, a);
+//CHECK:         ^ potentially aliased argument to 'out'/'inout'/'ref' parameter
+//CHECK:         ^ passing the same value to both may produce unexpected results
+
+    // Negative: distinct variables — no warning expected.
+    twoOut(a, b);
+//CHECK-NOT: potentially aliased
+
+    // Negative: two in params — no warning expected.
+    readBoth(a, a);
+//CHECK-NOT: potentially aliased
+
+    // Negative: distinct struct fields — no warning expected.
+    twoInoutInt(s.x, s.y);
+//CHECK-NOT: potentially aliased
+
+    // Negative: distinct array elements — no warning expected.
+    twoInoutInt(arr[0], arr[1]);
+//CHECK-NOT: potentially aliased
+
+    // Negative: compound assignment operator (a += a is well-defined).
+    a += a;
+//CHECK-NOT: potentially aliased
+}


### PR DESCRIPTION
## Summary
- When the same variable (or a variable that shares the same root declaration through member access or subscript) is passed to two parameters where at least one is `out`/`inout`/`ref`, the behavior is undefined because different backends implement different copy-in/copy-out semantics.
- Add a compile-time warning (W30051) that detects simple cases of this aliasing by comparing the root declarations of argument expressions.
- The check covers three scenarios: both parameters are `out`/`inout`, one is `out`/`inout` and the other is `in`, and `ref` parameters.
- This is a conservative check — it only flags cases where both arguments trace back to the exact same declaration. It does not attempt full alias analysis through pointers or complex indirection.

## Test plan
- [x] New test `tests/diagnostics/aliased-out-inout-parameter.slang` verifies warnings for:
  - Same variable passed to two `inout` parameters
  - Same variable passed to two `out` parameters
  - Same variable passed to `in` and `inout` parameters

Fixes #10699