### PR TITLE
Print constructor names as 'TypeName.init' in diagnostics instead of '$init'

### DIFF
--- a/source/slang/slang-rich-diagnostics.cpp
+++ b/source/slang/slang-rich-diagnostics.cpp
@@ -57,6 +57,15 @@ UnownedStringSlice nameToPrintableString(Name* name)
     return name ? name->text.getUnownedSlice() : UnownedStringSlice{"<unknown name>"};
 }
 
+String declToPrintableString(Decl* decl)
+{
+    if (!decl)
+        return "<unknown decl>";
+    StringBuilder sb;
+    printDiagnosticArg(sb, decl);
+    return sb.produceString();
+}
+
 String typeToPrintableString(Type* type)
 {
     return type ? type->toString() : "<unknown type>";
@@ -263,7 +272,7 @@ String declVisibilityToPrintableString(DeclVisibility visibility)
 %           elseif ptype == "qualtype" then
           qualTypeToPrintableString($(base_expr))
 %           elseif ptype == "decl" then
-          nameToPrintableString($(base_expr)->getName())
+          declToPrintableString($(base_expr))
 %           elseif ptype == "modifier" then
           modifierToPrintableString($(base_expr))
 %           elseif ptype == "irinst" then

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -152,6 +152,38 @@ void printDiagnosticArg(StringBuilder& sb, Decl* decl)
 {
     if (!decl)
         return;
+    // Unwrap GenericDecl to check for constructors inside.
+    auto innerDecl = maybeGetInner(decl);
+    if (as<ConstructorDecl>(innerDecl))
+    {
+        // Print constructors as "TypeName.init" instead of the internal "$init" name.
+        // Walk up through parent chain, skipping GenericDecl wrappers, to find the
+        // containing type declaration.
+        for (auto parent = decl->parentDecl; parent; parent = parent->parentDecl)
+        {
+            if (as<GenericDecl>(parent))
+                continue;
+            if (parent->getName() && parent->getName()->text.getLength())
+            {
+                sb << getText(parent->getName()) << ".";
+            }
+            else if (auto extDecl = as<ExtensionDecl>(parent))
+            {
+                // ExtensionDecl has no name; recover the type name from targetType.
+                if (auto declRefType = as<DeclRefType>(extDecl->targetType.type))
+                {
+                    auto typeDecl = declRefType->getDeclRef().getDecl();
+                    if (typeDecl && typeDecl->getName() && typeDecl->getName()->text.getLength())
+                    {
+                        sb << getText(typeDecl->getName()) << ".";
+                    }
+                }
+            }
+            break;
+        }
+        sb << "init";
+        return;
+    }
     if (decl->getName() && decl->getName()->text.getLength())
         sb << getText(decl->getName());
     else

--- a/tests/diagnostics/capability-constructor-diagnostic-generic.slang
+++ b/tests/diagnostics/capability-constructor-diagnostic-generic.slang
@@ -1,0 +1,40 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):
+// non-exhaustive: cascading notes for visibility errors
+
+// Test that visibility diagnostics for constructors in various declaration
+// shapes print "TypeName.init" instead of the internal "$init" name.
+// Regression test for https://github.com/shader-slang/slang/issues/10955
+
+struct IS
+{
+}
+
+// Generic struct with synthesized constructor referencing less-visible type.
+public struct GenericStruct<T>
+//CHECK:      ^^^^^^^^^^^^^ 'GenericStruct.init' references less visible type 'IS'.
+{
+    public IS member;
+//CHECK:      ^^^^^^ references less visible type
+}
+
+// Non-generic struct with a generic constructor referencing less-visible type.
+public struct PlainStruct
+{
+    public __init<T>(IS v)
+//CHECK:   ^^^^^^ 'PlainStruct.init' references less visible type 'IS'.
+    {
+    }
+}
+
+// Constructor declared inside an extension.
+struct ExtTarget
+{
+}
+
+extension ExtTarget
+{
+    public __init(IS v)
+//CHECK:   ^^^^^^ 'ExtTarget.init' references less visible type
+    {
+    }
+}

--- a/tests/diagnostics/capability-constructor-diagnostic.slang
+++ b/tests/diagnostics/capability-constructor-diagnostic.slang
@@ -1,0 +1,34 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive): -target spirv -emit-spirv-directly -entry main -stage compute
+// non-exhaustive: cascading notes for capability errors
+
+// Test that capability diagnostics for constructors print "TypeName.init"
+// instead of the internal "$init" name.
+// Regression test for https://github.com/shader-slang/slang/issues/10955
+
+struct MyType
+{
+    int value;
+
+    [require(hlsl)]
+    __init(int v)
+    {
+        value = v;
+    }
+}
+
+void caller()
+{
+    // Non-generic constructor: should show "MyType.init".
+    let t = MyType(42);
+}
+
+[numthreads(1, 1, 1)]
+void main()
+/*CHECK:
+     ^^^^ unavailable features in entry point
+*/
+{
+    caller();
+}
+//CHECK: see using of 'MyType.init'
+//CHECK: see definition of 'MyType.init'

--- a/tests/diagnostics/visibility.slang
+++ b/tests/diagnostics/visibility.slang
@@ -23,7 +23,7 @@ public IS f() {}
 
 public struct PS
 //CHECK:      ^^ references less visible type
-//CHECK:      ^^ '$init' references less visible type 'IS'.
+//CHECK:      ^^ 'PS.init' references less visible type 'IS'.
 {
     // Error: public member of internal type
     public IS ii;


### PR DESCRIPTION
## Summary

Fixes #10955

When capability requirements on constructors were not satisfied (e.g. a `[require(hlsl)]` constructor called in a SPIR-V target), diagnostics would show the internal name `$init` which was confusing to users. For example:

```
note: see using of '$init'
```

Now constructors are printed as `TypeName.init`:

```
note: see using of 'MyType.init'
```

### Changes

- **`printDiagnosticArg(Decl*)`** in `slang-syntax.cpp`: Detect `ConstructorDecl` (unwrapping `GenericDecl` if needed) and print `ParentTypeName.init` instead of the raw `$init` name.
- **`declToPrintableString()`** in `slang-rich-diagnostics.cpp`: New helper that delegates to `printDiagnosticArg` for constructor-aware formatting. The FIDDLE template now uses this instead of `nameToPrintableString(decl->getName())` for `decl`-typed parameters.
- Updated `tests/diagnostics/visibility.slang` expectation from `$init` to `PS.init`.
- Added regression test `tests/diagnostics/capability-constructor-diagnostic.slang`.

## Test plan

- [x] New test `tests/diagnostics/capability-constructor-diagnostic.slang` verifies `MyType.init` appears in diagnostics
- [x] Updated `tests/diagnostics/visibility.slang` passes with new naming
- [x] All 484 diagnostic tests pass
- [x] All 86 capability tests pass
- [x] All 1635 language-feature tests pass
- [x] All 352 unit tests pass