### PR TITLE
Fix spurious GL_EXT_texture_shadow_lod requirement for baseline shadow LOD types

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1715,6 +1715,7 @@ A capability describes an optional feature that a target may or may not support.
 * `texture_querylod` 
 * `texture_querylevels` 
 * `texture_shadowlod` 
+* `texture_shadowlod_ext` 
 * `texture_shadowgrad` 
 * `atomic_glsl_float1` 
 * `atomic_glsl_float2` 

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -1504,7 +1504,14 @@ Compound Capabilities
 > New in HLSL SM6.8 but existed in older GLSL and SPIRV targets.
 
 `texture_shadowlod`
-> Capabilities required to query shadow texture lod info
+> Capabilities required for shadow texture LOD sampling on types
+> natively supported by GLSL 1.50 (sampler1DShadow, sampler1DArrayShadow,
+> sampler2DShadow).
+
+`texture_shadowlod_ext`
+> Capabilities required for shadow texture LOD sampling on types
+> that need GL_EXT_texture_shadow_lod (sampler2DArrayShadow, samplerCubeShadow,
+> samplerCubeArrayShadow).
 
 `texture_size`
 > Capabilities required to query texture sample info

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -2455,7 +2455,7 @@ public vector<T.Element,4> textureLod(_Texture<
 }
 
 [ForceInline]
-[require(glsl_hlsl_spirv, texture_shadowlod)]
+[require(glsl_hlsl_spirv, texture_sm_4_1)]
 public float textureLod(sampler2DShadow sampler, vec3 p, float lod)
 {
     __target_switch
@@ -2473,13 +2473,16 @@ public float textureLod(sampler2DShadow sampler, vec3 p, float lod)
     }
 }
 
+__glsl_extension(GL_EXT_texture_shadow_lod)
 [ForceInline]
-[require(glsl_hlsl_spirv, texture_shadowlod)]
+[require(glsl_hlsl_spirv, texture_shadowlod_ext)]
 public float textureLod(sampler2DArrayShadow sampler, vec4 p, float lod)
 {
     __target_switch
     {
-    case glsl: __intrinsic_asm "textureLod";
+    case glsl:
+        __requireCapability(GL_EXT_texture_shadow_lod);
+        __intrinsic_asm "textureLod";
     case spirv:
     {
         float compareValue = p.w;
@@ -2492,22 +2495,38 @@ public float textureLod(sampler2DArrayShadow sampler, vec4 p, float lod)
     }
 }
 
+__glsl_extension(GL_EXT_texture_shadow_lod)
 [ForceInline]
-[require(glsl_hlsl_spirv, texture_shadowlod)]
+[require(glsl_hlsl_spirv, texture_shadowlod_ext)]
 public float textureLod(samplerCubeShadow sampler, vec4 p, float lod)
 {
-    return sampler.SampleCmpLevel(p.xyz, p.w, lod);
+    __target_switch
+    {
+    case glsl:
+        __requireCapability(GL_EXT_texture_shadow_lod);
+        return sampler.SampleCmpLevel(p.xyz, p.w, lod);
+    default:
+        return sampler.SampleCmpLevel(p.xyz, p.w, lod);
+    }
 }
 
+__glsl_extension(GL_EXT_texture_shadow_lod)
 [ForceInline]
-[require(glsl_hlsl_spirv, texture_shadowlod)]
+[require(glsl_hlsl_spirv, texture_shadowlod_ext)]
 public float textureLod(samplerCubeArrayShadow sampler, vec4 p, float compareValue, float lod)
 {
-    return sampler.SampleCmpLevel(p, compareValue, lod);
+    __target_switch
+    {
+    case glsl:
+        __requireCapability(GL_EXT_texture_shadow_lod);
+        return sampler.SampleCmpLevel(p, compareValue, lod);
+    default:
+        return sampler.SampleCmpLevel(p, compareValue, lod);
+    }
 }
 
 [ForceInline]
-[require(glsl_hlsl_spirv, texture_shadowlod)]
+[require(glsl_hlsl_spirv, texture_sm_4_1)]
 public float textureLod(sampler1DShadow sampler, vec3 p, float lod)
 {
     __target_switch
@@ -2526,7 +2545,7 @@ public float textureLod(sampler1DShadow sampler, vec3 p, float lod)
 }
 
 [ForceInline]
-[require(glsl_hlsl_spirv, texture_shadowlod)]
+[require(glsl_hlsl_spirv, texture_sm_4_1)]
 public float textureLod(sampler1DArrayShadow sampler, vec3 p, float lod)
 {
     __target_switch
@@ -3194,7 +3213,7 @@ public vector<T.Element,4> textureLodOffset(_Texture<
 }
 
 [ForceInline]
-[require(glsl_hlsl_spirv, texture_shadowlod)]
+[require(glsl_hlsl_spirv, texture_sm_4_1)]
 public float textureLodOffset(sampler1DShadow sampler, vec3 p, float lod, constexpr int offset)
 {
     __target_switch
@@ -3214,7 +3233,7 @@ public float textureLodOffset(sampler1DShadow sampler, vec3 p, float lod, conste
 }
 
 [ForceInline]
-[require(glsl_hlsl_spirv, texture_shadowlod)]
+[require(glsl_hlsl_spirv, texture_sm_4_1)]
 public float textureLodOffset(sampler2DShadow sampler, vec3 p, float lod, constexpr ivec2 offset)
 {
     __target_switch
@@ -3234,7 +3253,7 @@ public float textureLodOffset(sampler2DShadow sampler, vec3 p, float lod, conste
 }
 
 [ForceInline]
-[require(glsl_hlsl_spirv, texture_shadowlod)]
+[require(glsl_hlsl_spirv, texture_sm_4_1)]
 public float textureLodOffset(sampler1DArrayShadow sampler, vec3 p, float lod, constexpr int offset)
 {
     __target_switch

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -919,9 +919,17 @@ float __glsl_shadow_lod_texture_level_cube_array_shadow<TSampler, TCoord>(TSampl
     }
 }
 
-__glsl_extension(GL_EXT_texture_shadow_lod)
-[require(glsl, texture_shadowlod)]
-float __glsl_texture_level_offset<TSampler, TCoord, TOffset>(TSampler s, TCoord value, float level, constexpr TOffset offset)
+[require(glsl, texture_sm_4_1)]
+float __glsl150_texture_level_offset<TSampler, TCoord, TOffset>(TSampler s, TCoord value, float level, constexpr TOffset offset)
+{
+    __target_switch
+    {
+    case glsl: __intrinsic_asm "textureLodOffset($0, $1, $2, $3)";
+    }
+}
+
+[require(glsl, texture_sm_4_1)]
+float __glsl150_texture_level_offset_1d_shadow<TSampler, TCoord, TOffset>(TSampler s, TCoord value, float level, constexpr TOffset offset)
 {
     __target_switch
     {
@@ -930,12 +938,14 @@ float __glsl_texture_level_offset<TSampler, TCoord, TOffset>(TSampler s, TCoord 
 }
 
 __glsl_extension(GL_EXT_texture_shadow_lod)
-[require(glsl, texture_shadowlod)]
-float __glsl_texture_level_offset_1d_shadow<TSampler, TCoord, TOffset>(TSampler s, TCoord value, float level, constexpr TOffset offset)
+[require(glsl, texture_sm_4_1)]
+float __glsl_shadow_lod_texture_level_offset<TSampler, TCoord, TOffset>(TSampler s, TCoord value, float level, constexpr TOffset offset)
 {
     __target_switch
     {
-    case glsl: __intrinsic_asm "textureLodOffset($0, $1, $2, $3)";
+    case glsl:
+        __requireCapability(GL_EXT_texture_shadow_lod);
+        __intrinsic_asm "textureLodOffset($0, $1, $2, $3)";
     }
 }
 
@@ -1029,9 +1039,17 @@ float __glsl_shadow_lod_texture_level_cube_array_shadow<TTexture, TCoord>(TTextu
     }
 }
 
-__glsl_extension(GL_EXT_texture_shadow_lod)
-[require(glsl, texture_shadowlod)]
-float __glsl_texture_level_offset<TTexture, TCoord, TOffset>(TTexture t,SamplerComparisonState s, TCoord value, float level, constexpr TOffset offset)
+[require(glsl, texture_sm_4_1)]
+float __glsl150_texture_level_offset<TTexture, TCoord, TOffset>(TTexture t,SamplerComparisonState s, TCoord value, float level, constexpr TOffset offset)
+{
+    __target_switch
+    {
+    case glsl: __intrinsic_asm "textureLodOffset($p, $2, $3, $4)";
+    }
+}
+
+[require(glsl, texture_sm_4_1)]
+float __glsl150_texture_level_offset_1d_shadow<TTexture, TCoord, TOffset>(TTexture t,SamplerComparisonState s, TCoord value, float level, constexpr TOffset offset)
 {
     __target_switch
     {
@@ -1040,12 +1058,14 @@ float __glsl_texture_level_offset<TTexture, TCoord, TOffset>(TTexture t,SamplerC
 }
 
 __glsl_extension(GL_EXT_texture_shadow_lod)
-[require(glsl, texture_shadowlod)]
-float __glsl_texture_level_offset_1d_shadow<TTexture, TCoord, TOffset>(TTexture t,SamplerComparisonState s, TCoord value, float level, constexpr TOffset offset)
+[require(glsl, texture_sm_4_1)]
+float __glsl_shadow_lod_texture_level_offset<TTexture, TCoord, TOffset>(TTexture t,SamplerComparisonState s, TCoord value, float level, constexpr TOffset offset)
 {
     __target_switch
     {
-    case glsl: __intrinsic_asm "textureLodOffset($p, $2, $3, $4)";
+    case glsl:
+        __requireCapability(GL_EXT_texture_shadow_lod);
+        __intrinsic_asm "textureLodOffset($p, $2, $3, $4)";
     }
 }
 
@@ -1700,19 +1720,38 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,1,format>
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv, texture_sm_4_1)]
     float SampleCmpLevel(vector<float, Shape.dimensions+isArray> location, float compareValue, float level, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
         {
         case glsl:
-            if (Shape.dimensions == 1 && isArray == 0)
+            // Note: the baseline requirement texture_sm_4_1 corresponds to GLSL 1.50, which covers the following variants:
+            // - float textureLodOffset(sampler1DShadow sampler, vec3 P, float lod, int offset)
+            // - float textureLodOffset(sampler1DArrayShadow sampler, vec3 P, float lod, int offset)
+            // - float textureLodOffset(sampler2DShadow sampler, vec3 P, float lod, ivec2 offset)
+            //
+            // GL_EXT_texture_shadow_lod adds the following variant:
+            // - float textureLodOffset(sampler2DArrayShadow sampler, vec4 P, float lod, ivec2 offset)
+
+            if (Shape.dimensions == 1)
             {
-                return __glsl_texture_level_offset_1d_shadow(this, __makeVector(__makeVector(location,0.0), compareValue), level, offset);
+                if (isArray == 0)
+                    return __glsl150_texture_level_offset_1d_shadow(this, __makeVector(__makeVector(location,0.0), compareValue), level, offset);
+                else
+                    return __glsl150_texture_level_offset(this, __makeVector(location, compareValue), level, offset);
+            }
+            else if (Shape.dimensions == 2)
+            {
+                if (isArray == 0)
+                    return __glsl150_texture_level_offset(this, __makeVector(location, compareValue), level, offset);
+                else
+                    return __glsl_shadow_lod_texture_level_offset(this, __makeVector(location, compareValue), level, offset);
             }
             else
             {
-                return __glsl_texture_level_offset(this, __makeVector(location, compareValue), level, offset);
+                static_assert(Shape.dimensions != 3, "_Texture::SampleCmpLevel with offset: cube shadow types do not support textureLodOffset in GLSL");
+                return 0.0;
             }
         case hlsl:
             static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>
@@ -3068,19 +3107,38 @@ extension _Texture<T,Shape,isArray,isMS,sampleCount,0,isShadow,0,format>
 
     [__readNone]
     [ForceInline]
-    [require(glsl_hlsl_metal_spirv, texture_shadowlod)]
+    [require(glsl_hlsl_metal_spirv, texture_sm_4_1)]
     float SampleCmpLevel(SamplerComparisonState s, vector<float, Shape.dimensions+isArray> location, float compareValue, float level, constexpr vector<int, Shape.planeDimensions> offset)
     {
         __target_switch
         {
         case glsl:
-            if (Shape.dimensions == 1 && isArray == 0)
+            // Note: the baseline requirement texture_sm_4_1 corresponds to GLSL 1.50, which covers the following variants:
+            // - float textureLodOffset(sampler1DShadow sampler, vec3 P, float lod, int offset)
+            // - float textureLodOffset(sampler1DArrayShadow sampler, vec3 P, float lod, int offset)
+            // - float textureLodOffset(sampler2DShadow sampler, vec3 P, float lod, ivec2 offset)
+            //
+            // GL_EXT_texture_shadow_lod adds the following variant:
+            // - float textureLodOffset(sampler2DArrayShadow sampler, vec4 P, float lod, ivec2 offset)
+
+            if (Shape.dimensions == 1)
             {
-                return __glsl_texture_level_offset_1d_shadow(this, s, __makeVector(__makeVector(location,0.0),compareValue), level, offset);
+                if (isArray == 0)
+                    return __glsl150_texture_level_offset_1d_shadow(this, s, __makeVector(__makeVector(location,0.0),compareValue), level, offset);
+                else
+                    return __glsl150_texture_level_offset(this, s, __makeVector(location, compareValue), level, offset);
+            }
+            else if (Shape.dimensions == 2)
+            {
+                if (isArray == 0)
+                    return __glsl150_texture_level_offset(this, s, __makeVector(location,compareValue), level, offset);
+                else
+                    return __glsl_shadow_lod_texture_level_offset(this, s, __makeVector(location, compareValue), level, offset);
             }
             else
             {
-                return __glsl_texture_level_offset(this, s, __makeVector(location,compareValue), level, offset);
+                static_assert(Shape.dimensions != 3, "_Texture::SampleCmpLevel with offset: cube shadow types do not support textureLodOffset in GLSL");
+                return 0.0;
             }
         case hlsl:
             static_assert(T is float || T is vector<float,2> || T is vector<float,3> || T is vector<float,4>

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -2355,9 +2355,16 @@ alias texture_querylod = texture_sm_4_1 | GL_EXT_texture_query_lod;
 /// Capabilities required to query texture level info
 /// [Compound]
 alias texture_querylevels = texture_sm_4_1 | GL_ARB_texture_query_levels;
-/// Capabilities required to query shadow texture lod info
+/// Capabilities required for shadow texture LOD sampling on types
+/// natively supported by GLSL 1.50 (sampler1DShadow, sampler1DArrayShadow,
+/// sampler2DShadow).
 /// [Compound]
 alias texture_shadowlod = texture_sm_4_1;
+/// Capabilities required for shadow texture LOD sampling on types
+/// that need GL_EXT_texture_shadow_lod (sampler2DArrayShadow, samplerCubeShadow,
+/// samplerCubeArrayShadow).
+/// [Compound]
+alias texture_shadowlod_ext = texture_sm_4_1 | GL_EXT_texture_shadow_lod;
 /// Capabilities required for shadow texture sampling with bias and gradients.
 /// New in HLSL SM6.8 but existed in older GLSL and SPIRV targets.
 /// [Compound]

--- a/tests/hlsl-intrinsic/texture-shadow-lod-no-ext.slang
+++ b/tests/hlsl-intrinsic/texture-shadow-lod-no-ext.slang
@@ -1,0 +1,26 @@
+//TEST:SIMPLE(filecheck=CHECK): -target glsl -profile glsl_460 -entry fragMain -stage fragment
+
+// Test that shadow LOD sampling on sampler types natively supported by GLSL 1.50
+// does not require GL_EXT_texture_shadow_lod (issue #9074).
+
+// CHECK-NOT: GL_EXT_texture_shadow_lod
+
+Sampler2DShadow sampler2d;
+Sampler1DShadow sampler1d;
+Sampler1DArrayShadow sampler1dArray;
+
+[shader("fragment")]
+float4 fragMain() : SV_Target
+{
+    // These should use baseline GLSL textureLod, no extension required.
+    float r0 = sampler2d.SampleCmpLevel(float2(0, 0), 0.5, 0.0);
+    float r1 = sampler1d.SampleCmpLevel(0.0, 0.5, 0.0);
+    float r2 = sampler1dArray.SampleCmpLevel(float2(0, 0), 0.5, 0.0);
+
+    // textureLodOffset variants should also not require the extension.
+    float r3 = sampler2d.SampleCmpLevel(float2(0, 0), 0.5, 0.0, int2(1, 0));
+    float r4 = sampler1d.SampleCmpLevel(0.0, 0.5, 0.0, 1);
+    float r5 = sampler1dArray.SampleCmpLevel(float2(0, 0), 0.5, 0.0, 1);
+
+    return float4(r0 + r1 + r2, r3 + r4 + r5, 0.0, 1.0);
+}


### PR DESCRIPTION
## Summary

Fixes #9074

Shadow LOD sampling (`textureLod`/`textureLodOffset`) on `sampler1DShadow`, `sampler1DArrayShadow`, and `sampler2DShadow` is natively supported in GLSL 1.50 and does not require the `GL_EXT_texture_shadow_lod` extension. Only `sampler2DArrayShadow`, `samplerCubeShadow`, and `samplerCubeArrayShadow` need the extension.

This PR fixes several places where the extension was incorrectly required for baseline types:

- **`SampleCmpLevel` with offset** (combined sampler path): Added dispatch logic matching the no-offset variant to route baseline types to new `__glsl150_texture_level_offset` helpers without extension, and extension-requiring types to a new `__glsl_shadow_lod_texture_level_offset` helper
- **GLSL `textureLod` overloads**: Use `texture_sm_4_1` for baseline types (`sampler1DShadow`, `sampler1DArrayShadow`, `sampler2DShadow`); use new `texture_shadowlod_ext` capability for extension-requiring types (`sampler2DArrayShadow`, `samplerCubeShadow`, `samplerCubeArrayShadow`)
- **GLSL `textureLodOffset` shadow overloads**: Use `texture_sm_4_1` instead of `texture_shadowlod`
- **New `texture_shadowlod_ext` capability**: Combines `texture_sm_4_1` with `GL_EXT_texture_shadow_lod` for types that genuinely need the extension

## Test plan

- [x] New regression test `tests/hlsl-intrinsic/texture-shadow-lod-no-ext.slang` verifies no `GL_EXT_texture_shadow_lod` pragma is emitted for baseline shadow types (both with and without offset)
- [x] Existing `tests/hlsl-intrinsic/texture-lod-shadow.slang` still passes (Texture2DArray with extension)
- [x] All hlsl-intrinsic tests pass (446/446)
- [x] All glsl-intrinsic tests pass (243/243)
- [x] All cross-compile tests pass (63/63)
- [x] Manual verification: `sampler2DArrayShadow` and `samplerCubeShadow` still correctly emit the extension