### PR TITLE
Fix printf in LLVM IR emitter when it is passed structs that are not from MakeStruct

### DIFF
--- a/source/slang/slang-emit-llvm.cpp
+++ b/source/slang/slang-emit-llvm.cpp
@@ -1465,6 +1465,8 @@ struct LLVMEmitter
                 emitDecomposedStructValues(op, f->getFieldType(), args, argIsSigned);
             }
         }
+        else if (as<IRVoidType>(type))
+            return;
         else
         {
             args.add(inst);

--- a/source/slang/slang-emit-llvm.cpp
+++ b/source/slang/slang-emit-llvm.cpp
@@ -1450,6 +1450,46 @@ struct LLVMEmitter
         SLANG_UNIMPLEMENTED_X("Unexpected terminator in global scope!");
     }
 
+    void emitDecomposedStructValues(LLVMInst* inst, IRType* type, List<LLVMInst*>& args, List<bool>& argIsSigned)
+    {
+        if (auto structType = as<IRStructType>(type))
+        {
+            for (IRStructField* f : structType->getFields())
+            {
+                LLVMInst* ptr = emitStructGetElementPtr(inst, f, defaultPointerRules);
+                LLVMInst* op = emitLoad(ptr, f->getFieldType(), defaultPointerRules);
+                emitDecomposedStructValues(op, f->getFieldType(), args, argIsSigned);
+            }
+        }
+        else
+        {
+            args.add(inst);
+            argIsSigned.add(isSignedType(type));
+        }
+    }
+
+    void emitDecomposedStructValues(IRInst* inst, List<LLVMInst*>& args, List<bool>& argIsSigned)
+    {
+        auto type = inst->getDataType();
+        if (auto makeStruct = as<IRMakeStruct>(inst))
+        {
+            // Easy & common case, we can just pick the entries from the
+            // MakeStruct.
+            for (UInt bb = 0; bb < makeStruct->getOperandCount(); ++bb)
+            {
+                auto op = makeStruct->getOperand(bb);
+                emitDecomposedStructValues(op, args, argIsSigned);
+            }
+        }
+        else
+        {
+            // Unfortunate & rare situation where some compiler optimization
+            // hid the MakeStruct behind some load/store/whatever operation.
+            LLVMInst* llvmStruct = findValue(inst);
+            emitDecomposedStructValues(llvmStruct, type, args, argIsSigned);
+        }
+    }
+
     // Caution! This is only for emitting things which are considered
     // instructions in LLVM! It won't work for IRBlocks, IRFuncs & such.
     LLVMInst* emitLLVMInstruction(
@@ -2090,19 +2130,7 @@ struct LLVMEmitter
                 if (inst->getOperandCount() == 2)
                 {
                     auto operand = inst->getOperand(1);
-                    if (auto makeStruct = as<IRMakeStruct>(operand))
-                    {
-                        // Flatten the tuple resulting from the variadic pack.
-                        for (UInt bb = 0; bb < makeStruct->getOperandCount(); ++bb)
-                        {
-                            auto op = makeStruct->getOperand(bb);
-                            op->getDataType();
-                            auto llvmValue = findValue(op);
-
-                            args.add(llvmValue);
-                            argIsSigned.add(isSigned(op));
-                        }
-                    }
+                    emitDecomposedStructValues(operand, args, argIsSigned);
                 }
 
                 llvmInst = builder->emitPrintf(

--- a/source/slang/slang-emit-llvm.cpp
+++ b/source/slang/slang-emit-llvm.cpp
@@ -1450,7 +1450,11 @@ struct LLVMEmitter
         SLANG_UNIMPLEMENTED_X("Unexpected terminator in global scope!");
     }
 
-    void emitDecomposedStructValues(LLVMInst* inst, IRType* type, List<LLVMInst*>& args, List<bool>& argIsSigned)
+    void emitDecomposedStructValues(
+        LLVMInst* inst,
+        IRType* type,
+        List<LLVMInst*>& args,
+        List<bool>& argIsSigned)
     {
         if (auto structType = as<IRStructType>(type))
         {

--- a/tests/llvm/printf.slang
+++ b/tests/llvm/printf.slang
@@ -1,0 +1,15 @@
+//TEST:SIMPLE(filecheck=CHECK): -target llvm-host-ir -emit-cpu-via-llvm -whole-program
+
+export __extern_cpp int main(int argc, Ptr<NativeString> argv)
+{
+    int a = 0;
+    int b = 0;
+    int c = 0;
+
+    for (int i = 0; i < 8; ++i)
+        a++;
+
+    // CHECK: i32 8, i32 0, i32 0)
+    printf("%d, %d, %d\n", a, b, c);
+    return 0;
+}

--- a/tests/llvm/printf.slang
+++ b/tests/llvm/printf.slang
@@ -1,5 +1,17 @@
 //TEST:SIMPLE(filecheck=CHECK): -target llvm-host-ir -emit-cpu-via-llvm -whole-program
 
+struct S2
+{
+    int b;
+    int c;
+};
+
+struct S1
+{
+    int a;
+    S2 s2;
+};
+
 export __extern_cpp int main(int argc, Ptr<NativeString> argv)
 {
     int a = 0;
@@ -11,5 +23,12 @@ export __extern_cpp int main(int argc, Ptr<NativeString> argv)
 
     // CHECK: i32 8, i32 0, i32 0)
     printf("%d, %d, %d\n", a, b, c);
+
+    // The LLVM emitter should deconstruct structs when passing them to printf.
+    S1 s1;
+    s1.a = 1;
+    s1.s2.b = 2;
+    s1.s2.c = 3;
+    printf("%d, %d, %d\n", s1);
     return 0;
 }

--- a/tests/llvm/printf.slang
+++ b/tests/llvm/printf.slang
@@ -29,6 +29,7 @@ export __extern_cpp int main(int argc, Ptr<NativeString> argv)
     s1.a = 1;
     s1.s2.b = 2;
     s1.s2.c = 3;
+    // CHECK: i32 1, i32 2, i32 3)
     printf("%d, %d, %d\n", s1);
     return 0;
 }


### PR DESCRIPTION
Fixes #11157 on the LLVM emitter side. A separate fix is needed for the C++ emitter and is not handled in this PR. The test here is LLVM-specific, because it needs to check IR.

The problem in this case is that while usually the printf parameters are passed as a `MakeStruct` inst, this is apparently no longer always the case. The MakeStruct can get hoisted earlier and turned into some load/store mess.

The approach in this PR is to just allow `printf` with any struct parameter, such that it always decomposes them into individual elements and passes those to `printf`, one-by-one. The `MakeStruct` fast path is preserved, as it generates cleaner LLVM IR.