### PR TITLE
Resolve dependent default generic arguments

### DIFF
--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -988,158 +988,321 @@ DeclRef<Decl> SemanticsVisitor::trySolveConstraintSystem(
         return substDeclRef;
     };
 
-    DeclRef<Decl*> substDeclRef;
+    struct SubstitutableGenericArg
+    {
+        GenericDecl* genericDecl = nullptr;
+        Index argIndex = 0;
+    };
+
+    ShortList<SubstitutableGenericArg, 4> substitutableGenericArgs;
     for (auto _genericDecl : genericDecls)
-        for (auto constraintDecl : _genericDecl->getDirectMemberDecls())
+    {
+        Index argIndex = _genericDecl == genericDecls[0] ? knownGenericArgs.getCount() : 0;
+        for (auto member : _genericDecl->getDirectMemberDecls())
         {
-            if (auto genericTypeConstraintDecl = as<GenericTypeConstraintDecl>(constraintDecl))
+            if (auto typeParam = as<GenericTypeParamDeclBase>(member))
             {
-                auto constraintDeclRef =
-                    getSubstDeclRef(constraintDecl).as<GenericTypeConstraintDecl>();
+                SLANG_ASSERT(typeParam->parameterIndex != -1);
+                if (typeParam->parameterIndex < knownGenericArgCount)
+                    continue;
 
-                // Extract the (substituted) sub- and super-type from the constraint.
-                auto sub = getSub(m_astBuilder, constraintDeclRef);
-                auto sup = getSup(m_astBuilder, constraintDeclRef);
-
-                // Mark sub type as constrained.
-                if (auto subDeclRefType = as<DeclRefType>(constraintDeclRef.getDecl()->sub.type))
-                    constrainedGenericParams.add(subDeclRefType->getDeclRef().getDecl());
-                else if (auto subEachType = as<EachType>(constraintDeclRef.getDecl()->sub.type))
+                if (!as<GenericTypePackParamDecl>(typeParam) &&
+                    typeParam->parameterIndex < solvedArgs[_genericDecl].getCount() &&
+                    solvedArgs[_genericDecl][typeParam->parameterIndex].priority ==
+                        ConstraintPriority::Default)
                 {
-                    if (auto elementDeclRefType = subEachType->getElementDeclRefType())
+                    substitutableGenericArgs.add(SubstitutableGenericArg{_genericDecl, argIndex});
+                }
+                argIndex++;
+            }
+            else if (auto valPackParam = as<GenericValuePackParamDecl>(member))
+            {
+                SLANG_ASSERT(valPackParam->parameterIndex != -1);
+                if (valPackParam->parameterIndex < knownGenericArgCount)
+                    continue;
+
+                argIndex++;
+            }
+            else if (auto valParam = as<GenericValueParamDecl>(member))
+            {
+                SLANG_ASSERT(valParam->parameterIndex != -1);
+                if (valParam->parameterIndex < knownGenericArgCount)
+                    continue;
+
+                if (valParam->parameterIndex < solvedArgs[_genericDecl].getCount() &&
+                    solvedArgs[_genericDecl][valParam->parameterIndex].priority ==
+                        ConstraintPriority::Default)
+                {
+                    substitutableGenericArgs.add(SubstitutableGenericArg{_genericDecl, argIndex});
+                }
+                argIndex++;
+            }
+        }
+    }
+
+    Dictionary<Decl*, Count> ordinaryArgCounts;
+    for (auto _genericDecl : genericDecls)
+        ordinaryArgCounts[_genericDecl] = args[_genericDecl].getCount();
+
+    auto substituteDefaultArgs = [&]() -> bool
+    {
+        auto fullSubst = SubstitutionSet(getSubstDeclRef(genericDeclRef.getDecl()->inner));
+        bool changed = false;
+
+        for (auto defaultArg : substitutableGenericArgs)
+        {
+            auto& genericArgs = args[defaultArg.genericDecl];
+            if (defaultArg.argIndex >= genericArgs.getCount())
+                continue;
+
+            auto oldArg = genericArgs[defaultArg.argIndex];
+            int diff = 0;
+            auto substArg = oldArg->substituteImpl(m_astBuilder, fullSubst, &diff);
+            if (auto substArgType = as<Type>(substArg))
+                substArg = substArgType->getCanonicalType();
+            if (!oldArg->equals(substArg))
+            {
+                genericArgs[defaultArg.argIndex] = substArg;
+                changed = true;
+            }
+        }
+
+        return changed;
+    };
+
+    auto appendImplicitWitnessArgs = [&](ConversionCost& ioWitnessCost, bool& ioChanged) -> bool
+    {
+        for (auto _genericDecl : genericDecls)
+            for (auto constraintDecl : _genericDecl->getDirectMemberDecls())
+            {
+                ioChanged |= substituteDefaultArgs();
+
+                if (auto genericTypeConstraintDecl = as<GenericTypeConstraintDecl>(constraintDecl))
+                {
+                    auto constraintDeclRef =
+                        getSubstDeclRef(constraintDecl).as<GenericTypeConstraintDecl>();
+
+                    // Extract the (substituted) sub- and super-type from the constraint.
+                    auto sub = getSub(m_astBuilder, constraintDeclRef);
+                    auto sup = getSup(m_astBuilder, constraintDeclRef);
+
+                    // Mark sub type as constrained.
+                    if (auto subDeclRefType =
+                            as<DeclRefType>(constraintDeclRef.getDecl()->sub.type))
+                        constrainedGenericParams.add(subDeclRefType->getDeclRef().getDecl());
+                    else if (auto subEachType = as<EachType>(constraintDeclRef.getDecl()->sub.type))
                     {
-                        constrainedGenericParams.add(elementDeclRefType->getDeclRef().getDecl());
+                        if (auto elementDeclRefType = subEachType->getElementDeclRefType())
+                        {
+                            constrainedGenericParams.add(
+                                elementDeclRefType->getDeclRef().getDecl());
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+
+                    if (sub->equals(sup) && isDeclRefTypeOf<InterfaceDecl>(sup))
+                    {
+                        // We are trying to use an interface type itself to conform to the
+                        // type constraint. We can reach this case when the user code does
+                        // not provide an explicit type parameter to specialize a generic
+                        // and the type parameter cannot be inferred from any arguments.
+                        // In this case, we should fail the constraint check.
+                        return false;
+                    }
+
+                    // Search for a witness that shows the constraint is satisfied.
+                    SubtypeWitness* subTypeWitness = nullptr;
+                    if (sub == system->subTypeForAdditionalWitnesses)
+                    {
+                        // If we are trying to find the subtype info for a type whose inheritance
+                        // info is being calculated, use what we have already known about the type.
+                        system->additionalSubtypeWitnesses->tryGetValue(sup, subTypeWitness);
                     }
                     else
                     {
-                        return DeclRef<Decl>();
+                        // The general case is to initiate a subtype query.
+                        subTypeWitness = isSubtype(
+                            sub,
+                            sup,
+                            system->additionalSubtypeWitnesses ? IsSubTypeOptions::NoCaching
+                                                               : IsSubTypeOptions::None);
                     }
-                }
 
-                if (sub->equals(sup) && isDeclRefTypeOf<InterfaceDecl>(sup))
-                {
-                    // We are trying to use an interface type itself to conform to the
-                    // type constraint. We can reach this case when the user code does
-                    // not provide an explicit type parameter to specialize a generic
-                    // and the type parameter cannot be inferred from any arguments.
-                    // In this case, we should fail the constraint check.
-                    return DeclRef<Decl>();
-                }
+                    if (genericTypeConstraintDecl->isEqualityConstraint)
+                    {
+                        // If constraint is an equality constraint, we need to make sure
+                        // the witness is equality witness.
+                        if (!isTypeEqualityWitness(subTypeWitness))
+                            subTypeWitness = nullptr;
+                    }
 
-                // Search for a witness that shows the constraint is satisfied.
-                SubtypeWitness* subTypeWitness = nullptr;
-                if (sub == system->subTypeForAdditionalWitnesses)
-                {
-                    // If we are trying to find the subtype info for a type whose inheritance info
-                    // is being calculated, use what we have already known about the type.
-                    system->additionalSubtypeWitnesses->tryGetValue(sup, subTypeWitness);
-                }
-                else
-                {
-                    // The general case is to initiate a subtype query.
-                    subTypeWitness = isSubtype(
-                        sub,
-                        sup,
-                        system->additionalSubtypeWitnesses ? IsSubTypeOptions::NoCaching
-                                                           : IsSubTypeOptions::None);
-                }
+                    bool witnessIsOptional = isWitnessUncheckedOptional(subTypeWitness);
+                    bool constraintIsOptional =
+                        constraintDecl->hasModifier<OptionalConstraintModifier>();
 
-                if (genericTypeConstraintDecl->isEqualityConstraint)
-                {
-                    // If constraint is an equality constraint, we need to make sure
-                    // the witness is equality witness.
-                    if (!isTypeEqualityWitness(subTypeWitness))
-                        subTypeWitness = nullptr;
-                }
+                    if (subTypeWitness && (!witnessIsOptional || constraintIsOptional))
+                    {
+                        // We found a witness, so it will become an (implicit) argument.
+                        args[_genericDecl].add(subTypeWitness);
+                        ioWitnessCost += subTypeWitness->getOverloadResolutionCost();
+                        ioChanged |= substituteDefaultArgs();
+                    }
+                    else if (!subTypeWitness && constraintIsOptional)
+                    {
+                        // Optional witness failed to resolve; not an error.
+                        auto noneWitness = m_astBuilder->getOrCreate<NoneWitness>();
+                        args[_genericDecl].add(noneWitness);
+                        ioWitnessCost += kConversionCost_FailedOptionalConstraint;
+                        ioChanged |= substituteDefaultArgs();
+                    }
+                    else
+                    {
+                        // No witness was found, so the inference will now fail.
+                        //
+                        // TODO: Ideally we should print an error message in
+                        // this case, to let the user know why things failed.
+                        return false;
+                    }
 
-                bool witnessIsOptional = isWitnessUncheckedOptional(subTypeWitness);
-                bool constraintIsOptional =
-                    constraintDecl->hasModifier<OptionalConstraintModifier>();
+                    // TODO: We may need to mark some constrains in our constraint
+                    // system as being solved now, as a result of the witness we found.
+                }
+                else if (
+                    auto typeCoercionConstraintDecl =
+                        as<TypeCoercionConstraintDecl>(constraintDecl))
+                {
+                    if (!addTypeCoercionWitnessToArgs(
+                            getASTBuilder(),
+                            this,
+                            typeCoercionConstraintDecl,
+                            genericDeclRef,
+                            nullptr,
+                            &constrainedGenericParams,
+                            args[_genericDecl],
+                            false))
+                    {
+                        return false;
+                    }
+                    ioChanged |= substituteDefaultArgs();
+                }
+                else if (
+                    auto nonEmptyConstraintDecl = as<NonEmptyPackConstraintDecl>(constraintDecl))
+                {
+                    Decl* constrainedPackDecl = nullptr;
+                    if (auto declRefExpr = as<DeclRefExpr>(nonEmptyConstraintDecl->packExpr))
+                    {
+                        constrainedPackDecl = getDeclRef(m_astBuilder, declRefExpr).getDecl();
+                    }
 
-                if (subTypeWitness && (!witnessIsOptional || constraintIsOptional))
-                {
-                    // We found a witness, so it will become an (implicit) argument.
-                    args[_genericDecl].add(subTypeWitness);
-                    outBaseCost += subTypeWitness->getOverloadResolutionCost();
-                }
-                else if (!subTypeWitness && constraintIsOptional)
-                {
-                    // Optional witness failed to resolve; not an error.
-                    auto noneWitness = m_astBuilder->getOrCreate<NoneWitness>();
-                    args[_genericDecl].add(noneWitness);
-                    outBaseCost += kConversionCost_FailedOptionalConstraint;
-                }
-                else
-                {
-                    // No witness was found, so the inference will now fail.
-                    //
-                    // TODO: Ideally we should print an error message in
-                    // this case, to let the user know why things failed.
-                    return DeclRef<Decl>();
-                }
+                    Val* constrainedArg = nullptr;
+                    if (auto typePackDecl = as<GenericTypePackParamDecl>(constrainedPackDecl))
+                    {
+                        if (typePackDecl->parameterIndex < args[_genericDecl].getCount())
+                            constrainedArg = args[_genericDecl][typePackDecl->parameterIndex];
+                    }
+                    else if (
+                        auto valuePackDecl = as<GenericValuePackParamDecl>(constrainedPackDecl))
+                    {
+                        if (valuePackDecl->parameterIndex < args[_genericDecl].getCount())
+                            constrainedArg = args[_genericDecl][valuePackDecl->parameterIndex];
+                    }
 
-                // TODO: We may need to mark some constrains in our constraint
-                // system as being solved now, as a result of the witness we found.
-            }
-            else if (
-                auto typeCoercionConstraintDecl = as<TypeCoercionConstraintDecl>(constraintDecl))
-            {
-                if (!addTypeCoercionWitnessToArgs(
-                        getASTBuilder(),
-                        this,
-                        typeCoercionConstraintDecl,
-                        genericDeclRef,
-                        nullptr,
-                        &constrainedGenericParams,
-                        args[_genericDecl],
-                        false))
-                {
-                    return DeclRef<Decl>();
-                }
-            }
-            else if (auto nonEmptyConstraintDecl = as<NonEmptyPackConstraintDecl>(constraintDecl))
-            {
-                Decl* constrainedPackDecl = nullptr;
-                if (auto declRefExpr = as<DeclRefExpr>(nonEmptyConstraintDecl->packExpr))
-                {
-                    constrainedPackDecl = getDeclRef(m_astBuilder, declRefExpr).getDecl();
-                }
+                    if (!constrainedArg || !isKnownNonEmptyPack(constrainedArg))
+                        return false;
 
-                Val* constrainedArg = nullptr;
-                if (auto typePackDecl = as<GenericTypePackParamDecl>(constrainedPackDecl))
-                {
-                    if (typePackDecl->parameterIndex < args[_genericDecl].getCount())
-                        constrainedArg = args[_genericDecl][typePackDecl->parameterIndex];
+                    args[_genericDecl].add(m_astBuilder->getNonEmptyPackWitness(constrainedArg));
+                    ioChanged |= substituteDefaultArgs();
                 }
-                else if (auto valuePackDecl = as<GenericValuePackParamDecl>(constrainedPackDecl))
+                else if (
+                    auto hasDiffTypeInfoConstraintDecl =
+                        as<HasDiffTypeInfoConstraintDecl>(constraintDecl))
                 {
-                    if (valuePackDecl->parameterIndex < args[_genericDecl].getCount())
-                        constrainedArg = args[_genericDecl][valuePackDecl->parameterIndex];
-                }
-
-                if (!constrainedArg || !isKnownNonEmptyPack(constrainedArg))
-                    return DeclRef<Decl>();
-
-                args[_genericDecl].add(m_astBuilder->getNonEmptyPackWitness(constrainedArg));
-            }
-            else if (
-                auto hasDiffTypeInfoConstraintDecl =
-                    as<HasDiffTypeInfoConstraintDecl>(constraintDecl))
-            {
-                if (!addHasDiffTypeInfoWitnessToArgs(
-                        getASTBuilder(),
-                        this,
-                        hasDiffTypeInfoConstraintDecl,
-                        genericDeclRef,
-                        nullptr,
-                        &constrainedGenericParams,
-                        args[_genericDecl],
-                        false))
-                {
-                    return DeclRef<Decl>();
+                    if (!addHasDiffTypeInfoWitnessToArgs(
+                            getASTBuilder(),
+                            this,
+                            hasDiffTypeInfoConstraintDecl,
+                            genericDeclRef,
+                            nullptr,
+                            &constrainedGenericParams,
+                            args[_genericDecl],
+                            false))
+                    {
+                        return false;
+                    }
+                    ioChanged |= substituteDefaultArgs();
                 }
             }
+
+        return true;
+    };
+
+    // Default generic arguments can depend on earlier generic arguments, and those
+    // dependencies can be chained through associated types or associated constants:
+    //
+    //     func<T : IFoo, U : IBar = T.Bar, W : IBaz = U.Baz>()
+    //
+    // For a call like `func<ConcreteFoo>()`, solving initially gives us values like
+    // `U = ConcreteFoo.Bar` and `W = U.Baz`. Reducing `ConcreteFoo.Bar` to its real
+    // associated type can make `U = ConcreteBar`, and only another pass can then reduce
+    // `W = U.Baz` to `ConcreteBar.Baz`.
+    //
+    // The reduction needs implicit witnesses: the substitution logic for `ConcreteFoo.Bar`
+    // discovers the concrete associated type through the `ConcreteFoo : IFoo` witness. Witnesses
+    // are also allowed to depend on earlier defaults, as with the `U : IBar` witness needed to
+    // resolve `U.Baz`.
+    //
+    // We therefore resolve implicit witnesses and default ordinary arguments as a fixed point,
+    // and we run default-argument reduction during the same walk that discovers witnesses. After
+    // a pass appends the `T : IFoo` witness, the next constraint can see `U = ConcreteBar`
+    // instead of `U = T.Bar`; after it appends the `U : IBar` witness, the next constraint can
+    // similarly see `W = ConcreteBaz` instead of `W = U.Baz`.
+    //
+    // Each pass starts from the current ordinary arguments, appends temporary witnesses, and uses
+    // the resulting full substitution to reduce default arguments. If a default changes, those
+    // temporary witnesses are discarded and the next pass recomputes witnesses for the updated
+    // ordinary arguments. When a pass makes no default changes, the witnesses appended in that
+    // pass are for the final ordinary argument list and can be kept.
+    //
+    // Only arguments whose winning solver constraint still has default priority are rewritten.
+    // Required or inferred arguments are deliberate choices made by overload resolution and
+    // argument matching; substituting them here can change identity-sensitive values such as
+    // inferred function/operator types even when their printed type text looks the same.
+    //
+    // The number of default argument slots is a conservative iteration bound. In practice each
+    // pass substitutes through the latest full generic application and either makes progress
+    // along a dependency chain (`T.Bar` -> `ConcreteBar`, then `U.Baz` -> `ConcreteBaz`) or stops.
+    Count maxPassCount = substitutableGenericArgs.getCount() + 1;
+    if (maxPassCount < 1)
+        maxPassCount = 1;
+
+    bool solvedImplicitArgs = false;
+    ConversionCost finalWitnessCost = kConversionCost_None;
+    for (Index pass = 0; pass < maxPassCount; pass++)
+    {
+        for (auto _genericDecl : genericDecls)
+        {
+            args[_genericDecl].setCount(ordinaryArgCounts[_genericDecl]);
         }
+
+        bool passChanged = substituteDefaultArgs();
+        ConversionCost passWitnessCost = kConversionCost_None;
+        if (!appendImplicitWitnessArgs(passWitnessCost, passChanged))
+            return DeclRef<Decl>();
+
+        passChanged |= substituteDefaultArgs();
+        if (!passChanged)
+        {
+            solvedImplicitArgs = true;
+            finalWitnessCost = passWitnessCost;
+            break;
+        }
+    }
+
+    if (!solvedImplicitArgs)
+        return DeclRef<Decl>();
 
     // Make sure we haven't constructed any spurious constraints
     // that we aren't able to satisfy:
@@ -1162,7 +1325,7 @@ DeclRef<Decl> SemanticsVisitor::trySolveConstraintSystem(
     // Add the accumulated type promotion cost from constraint solving.
     // This includes costs from promoting types to satisfy interface constraints
     // (e.g., int -> float to satisfy __BuiltinFloatingPointType).
-    outBaseCost += system->typePromotionCost;
+    outBaseCost += system->typePromotionCost + finalWitnessCost;
 
     DeclRef<Decl> substGenericDeclRef = getSubstDeclRef(genericDeclRef.getDecl()->inner);
     return substGenericDeclRef;

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -339,6 +339,7 @@ bool SemanticsVisitor::TryCheckGenericOverloadCandidateTypes(
     // appropriate forms.
     //
     List<Val*> checkedArgs;
+    Index firstDefaultArgIndex = -1;
 
     // Rather than bail out as soon as we hit a problem,
     // we are going to process *all* of the parameters of the
@@ -422,6 +423,8 @@ bool SemanticsVisitor::TryCheckGenericOverloadCandidateTypes(
                         maybeReportGeneralError();
                         return false;
                     }
+                    if (firstDefaultArgIndex < 0)
+                        firstDefaultArgIndex = checkedArgs.getCount();
                     checkedArgs.add(substType);
                     continue;
                 }
@@ -496,6 +499,8 @@ bool SemanticsVisitor::TryCheckGenericOverloadCandidateTypes(
                         maybeReportGeneralError();
                         return false;
                     }
+                    if (firstDefaultArgIndex < 0)
+                        firstDefaultArgIndex = checkedArgs.getCount();
                     checkedArgs.add(defaultVal);
                     continue;
                 }
@@ -681,6 +686,29 @@ bool SemanticsVisitor::TryCheckGenericOverloadCandidateTypes(
         {
             continue;
         }
+    }
+
+    if (firstDefaultArgIndex >= 0)
+    {
+        ShortList<Val*> knownGenericArgs;
+        for (Index ii = 0; ii < firstDefaultArgIndex; ii++)
+            knownGenericArgs.add(checkedArgs[ii]);
+
+        ConstraintSystem constraints;
+        ConversionCost solverCost = kConversionCost_None;
+        auto solvedDeclRef = trySolveConstraintSystem(
+            &constraints,
+            genericDeclRef,
+            knownGenericArgs.getArrayView().arrayView,
+            solverCost);
+        if (!solvedDeclRef)
+        {
+            maybeReportGeneralError();
+            return false;
+        }
+        candidate.conversionCostSum += solverCost;
+        candidate.subst = SubstitutionSet(solvedDeclRef);
+        return success;
     }
 
     auto genSubst = m_astBuilder->getGenericAppDeclRef(genericDeclRef, checkedArgs.getArrayView());
@@ -1087,6 +1115,13 @@ bool SemanticsVisitor::TryCheckOverloadCandidateConstraints(
     // handy, so that we can construct a substitution list.
     auto substArgs = tryGetGenericArguments(candidate.subst, genericDeclRef.getDecl());
     SLANG_ASSERT(substArgs.getCount());
+
+    Count ordinaryParamCount =
+        genericDeclRef.getDecl()->getMembersOfType<GenericTypeParamDeclBase>().getCount() +
+        genericDeclRef.getDecl()->getMembersOfType<GenericValueParamDecl>().getCount() +
+        genericDeclRef.getDecl()->getMembersOfType<GenericValuePackParamDecl>().getCount();
+    if (substArgs.getCount() > ordinaryParamCount)
+        return true;
 
     ShortList<Val*> newArgs;
     for (auto arg : substArgs)

--- a/tests/bugs/associated-type-default-constraint.slang
+++ b/tests/bugs/associated-type-default-constraint.slang
@@ -1,0 +1,66 @@
+//TEST:SIMPLE: -target hlsl
+
+// Regression test for default generic type arguments that are associated types
+// with their own interface constraints.
+
+interface IData
+{
+}
+
+interface IElement
+{
+    associatedtype DataType : IData;
+}
+
+struct FloatData : IData
+{
+}
+
+struct FloatElement : IElement
+{
+    typealias DataType = FloatData;
+}
+
+__generic<T : IElement, U : IData = T.DataType>
+U getDefaultAssociatedType()
+{
+    return U();
+}
+
+FloatData gFunctionValue = getDefaultAssociatedType<FloatElement>();
+
+interface IBaz
+{
+}
+
+interface IBar
+{
+    associatedtype BazType : IBaz;
+}
+
+interface IFoo
+{
+    associatedtype BarType : IBar;
+}
+
+struct ConcreteBaz : IBaz
+{
+}
+
+struct ConcreteBar : IBar
+{
+    typealias BazType = ConcreteBaz;
+}
+
+struct ConcreteFoo : IFoo
+{
+    typealias BarType = ConcreteBar;
+}
+
+__generic<T : IFoo, U : IBar = T.BarType, W : IBaz = U.BazType>
+W getChainedDefaultAssociatedType()
+{
+    return W();
+}
+
+ConcreteBaz gChainedFunctionValue = getChainedDefaultAssociatedType<ConcreteFoo>();

--- a/tests/bugs/generic-typealias-associated-type-default.slang
+++ b/tests/bugs/generic-typealias-associated-type-default.slang
@@ -1,0 +1,35 @@
+//TEST:SIMPLE: -target hlsl
+
+// Regression test for generic type aliases whose default type argument is an
+// associated type that has its own interface constraint.
+
+interface IData
+{
+}
+
+interface IElement
+{
+    associatedtype DataType : IData;
+}
+
+struct Box<T : IData>
+{
+}
+
+typealias DefaultedBox<T : IElement, U : IData = T.DataType> = Box<U>;
+
+struct UsesDefault<T : IElement>
+{
+    DefaultedBox<T> value;
+}
+
+struct FloatData : IData
+{
+}
+
+struct FloatElement : IElement
+{
+    typealias DataType = FloatData;
+}
+
+UsesDefault<FloatElement> gValue;

--- a/tests/bugs/generic-value-default-member.slang
+++ b/tests/bugs/generic-value-default-member.slang
@@ -1,0 +1,22 @@
+//TEST:SIMPLE: -target hlsl
+
+// Regression test for lowering a default generic value argument that depends
+// on a static member of a constrained type parameter.
+
+interface I
+{
+    static const int f;
+}
+
+struct S<T, let f : int>
+{
+}
+
+typealias X<T : I, let f : int = T.f> = S<T, f>;
+
+struct A : I
+{
+    static const int f = 1;
+}
+
+X<A> x;


### PR DESCRIPTION
## Summary
- route generic applications with omitted defaults through the constraint solver so defaults can be resolved with witness-aware substitutions
- iteratively reduce default-priority generic arguments inside the solver after implicit witnesses are available
- add regressions for associated type defaults, chained associated type defaults, type aliases, and static value defaults

## Tests
- `cmake --build --preset debug --target slangc slang-test`
- `build\Debug\bin\slang-test.exe tests\bugs\associated-type-default-constraint.slang tests\bugs\generic-typealias-associated-type-default.slang tests\bugs\generic-value-default-member.slang tests\language-feature\generics\pack-branch-mlp.slang tests\bugs\gh-6331.slang tests\bugs\gh-9803.slang -bindir build\Debug\bin -disable-retries`

Note: `vs2026-dev` configure currently wedges in CMake/MSBuild compiler-id detection in this fresh worktree, so validation used the Ninja `default` preset under the VS2026 `vcvarsall` environment.