### PR TITLE
Terminate test server when parent exits

### DIFF
--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -228,6 +228,8 @@ SlangResult TestContext::_createJSONRPCConnection(RefPtr<JSONRPCConnection>& out
     {
         CommandLine cmdLine;
         cmdLine.setExecutableLocation(ExecutableLocation(exeDirectoryPath, "test-server"));
+        cmdLine.addArg("-parent-pid");
+        cmdLine.addArg(String(Process::getId()));
 
         SLANG_RETURN_ON_FAIL(Process::create(
             cmdLine,

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -231,6 +231,19 @@ SlangResult TestContext::_createJSONRPCConnection(RefPtr<JSONRPCConnection>& out
         cmdLine.addArg("-parent-pid");
         cmdLine.addArg(String(Process::getId()));
 
+#if defined(_WIN32)
+        // Hidden integration-test hook. stdout is the JSON-RPC channel, so the test-server parent
+        // monitor test uses a named event instead of emitting a sentinel line.
+        StringBuilder parentMonitorReadyEventName;
+        if (SLANG_SUCCEEDED(PlatformUtil::getEnvironmentVariable(
+                UnownedStringSlice::fromLiteral("SLANG_TEST_PARENT_MONITOR_READY_EVENT"),
+                parentMonitorReadyEventName)))
+        {
+            cmdLine.addArg("-parent-monitor-ready-event");
+            cmdLine.addArg(parentMonitorReadyEventName.produceString());
+        }
+#endif
+
         SLANG_RETURN_ON_FAIL(Process::create(
             cmdLine,
             Process::Flag::AttachDebugger | Process::Flag::DisableStdErrRedirection,

--- a/tools/slang-unit-test/unit-test-process.cpp
+++ b/tools/slang-unit-test/unit-test-process.cpp
@@ -177,6 +177,15 @@ struct ScopedWinEnvironmentVariable
     }
 };
 
+static void _terminateWindowsProcessAndWait(HANDLE process)
+{
+    if (process)
+    {
+        TerminateProcess(process, 0);
+        WaitForSingleObject(process, INFINITE);
+    }
+}
+
 static SlangResult _createWindowsProcess(const CommandLine& cmdLine, PROCESS_INFORMATION& out)
 {
     STARTUPINFOW startupInfo;
@@ -216,7 +225,10 @@ static SlangResult _createWindowsProcess(const CommandLine& cmdLine, PROCESS_INF
     return success ? SLANG_OK : SLANG_FAIL;
 }
 
-static SlangResult _expectTestServerTerminates(UnitTestContext* context, const List<String>& args)
+static SlangResult _expectTestServerTerminates(
+    UnitTestContext* context,
+    const List<String>& args,
+    int32_t expectedReturnCode)
 {
     CommandLine serverCmdLine;
     serverCmdLine.setExecutableLocation(
@@ -234,6 +246,10 @@ static SlangResult _expectTestServerTerminates(UnitTestContext* context, const L
         testServerProcess->kill(-1);
         return SLANG_FAIL;
     }
+    if (testServerProcess->getReturnValue() != expectedReturnCode)
+    {
+        return SLANG_FAIL;
+    }
 
     return SLANG_OK;
 }
@@ -244,34 +260,34 @@ static SlangResult _parentMonitorFailureModeTests(UnitTestContext* context)
         List<String> args;
         args.add("-parent-pid");
         args.add("abc");
-        SLANG_RETURN_ON_FAIL(_expectTestServerTerminates(context, args));
+        SLANG_RETURN_ON_FAIL(_expectTestServerTerminates(context, args, 1));
     }
 
     {
         List<String> args;
         args.add("-parent-pid");
         args.add("0");
-        SLANG_RETURN_ON_FAIL(_expectTestServerTerminates(context, args));
+        SLANG_RETURN_ON_FAIL(_expectTestServerTerminates(context, args, 1));
     }
 
     {
         List<String> args;
         args.add("-parent-pid");
         args.add("4294967296");
-        SLANG_RETURN_ON_FAIL(_expectTestServerTerminates(context, args));
+        SLANG_RETURN_ON_FAIL(_expectTestServerTerminates(context, args, 1));
     }
 
     {
         List<String> args;
         args.add("-parent-pid");
         args.add(String(uint32_t(MAXDWORD)));
-        SLANG_RETURN_ON_FAIL(_expectTestServerTerminates(context, args));
+        SLANG_RETURN_ON_FAIL(_expectTestServerTerminates(context, args, 1));
     }
 
     {
         List<String> args;
         args.add("-parent-pid");
-        SLANG_RETURN_ON_FAIL(_expectTestServerTerminates(context, args));
+        SLANG_RETURN_ON_FAIL(_expectTestServerTerminates(context, args, 1));
     }
 
     // Without -parent-pid, test-server should keep its normal RPC wait behavior.
@@ -294,21 +310,33 @@ static SlangResult _parentMonitorFailureModeTests(UnitTestContext* context)
     return SLANG_OK;
 }
 
-static String _makeParentMonitorReadyEventName()
+static String _makeParentMonitorEventName(const char* label)
 {
     StringBuilder builder;
-    builder << "Local\\SlangParentMonitorReady-" << Process::getId() << "-"
+    builder << "Local\\SlangParentMonitor-" << label << "-" << Process::getId() << "-"
             << Process::getClockTick();
     return builder.produceString();
 }
 
-static SlangResult _parentMonitorHappyPathTest(UnitTestContext* context)
+static String _makeParentMonitorReadyEventName()
 {
+    return _makeParentMonitorEventName("ready");
+}
+
+static SlangResult _parentMonitorParentExitTest(UnitTestContext* context, bool terminateParent)
+{
+    String parentExitEventName = _makeParentMonitorEventName("parent-exit");
+    OSString parentExitEventOSName = parentExitEventName.toWString();
+    ScopedWinHandle parentExitEvent(
+        CreateEventW(nullptr, TRUE, FALSE, parentExitEventOSName.begin()));
+    if (!parentExitEvent.isValid())
+        return SLANG_FAIL;
+
     CommandLine parentCmdLine;
     parentCmdLine.setExecutableLocation(
         ExecutableLocation(context->executableDirectory, "test-process"));
-    parentCmdLine.addArg("sleep");
-    parentCmdLine.addArg("30000");
+    parentCmdLine.addArg("wait-event");
+    parentCmdLine.addArg(parentExitEventName);
 
     PROCESS_INFORMATION parentProcessInfo;
     SLANG_RETURN_ON_FAIL(_createWindowsProcess(parentCmdLine, parentProcessInfo));
@@ -318,10 +346,9 @@ static SlangResult _parentMonitorHappyPathTest(UnitTestContext* context)
     String readyEventName = _makeParentMonitorReadyEventName();
     OSString readyEventOSName = readyEventName.toWString();
     ScopedWinHandle readyEvent(CreateEventW(nullptr, TRUE, FALSE, readyEventOSName.begin()));
-    if (!readyEvent.handle)
+    if (!readyEvent.isValid())
     {
-        TerminateProcess(parentProcess.handle, 0);
-        WaitForSingleObject(parentProcess.handle, INFINITE);
+        _terminateWindowsProcessAndWait(parentProcess.handle);
         return SLANG_FAIL;
     }
 
@@ -340,32 +367,49 @@ static SlangResult _parentMonitorHappyPathTest(UnitTestContext* context)
         testServerProcess);
     if (SLANG_FAILED(createServerResult))
     {
-        TerminateProcess(parentProcess.handle, 0);
-        WaitForSingleObject(parentProcess.handle, INFINITE);
+        _terminateWindowsProcessAndWait(parentProcess.handle);
         return createServerResult;
     }
 
     if (testServerProcess->isTerminated())
     {
-        TerminateProcess(parentProcess.handle, 0);
-        WaitForSingleObject(parentProcess.handle, INFINITE);
+        _terminateWindowsProcessAndWait(parentProcess.handle);
         return SLANG_FAIL;
     }
 
     if (WaitForSingleObject(readyEvent.handle, 5 * 1000) != WAIT_OBJECT_0 ||
         testServerProcess->isTerminated())
     {
-        TerminateProcess(parentProcess.handle, 0);
-        WaitForSingleObject(parentProcess.handle, INFINITE);
+        _terminateWindowsProcessAndWait(parentProcess.handle);
         return SLANG_FAIL;
     }
 
-    TerminateProcess(parentProcess.handle, 0);
-    WaitForSingleObject(parentProcess.handle, INFINITE);
+    if (terminateParent)
+    {
+        TerminateProcess(parentProcess.handle, 0);
+    }
+    else
+    {
+        if (!SetEvent(parentExitEvent.handle))
+        {
+            _terminateWindowsProcessAndWait(parentProcess.handle);
+            return SLANG_FAIL;
+        }
+    }
+
+    if (WaitForSingleObject(parentProcess.handle, 5 * 1000) != WAIT_OBJECT_0)
+    {
+        _terminateWindowsProcessAndWait(parentProcess.handle);
+        return SLANG_FAIL;
+    }
 
     if (!testServerProcess->waitForTermination(5 * 1000))
     {
         testServerProcess->kill(-1);
+        return SLANG_FAIL;
+    }
+    if (testServerProcess->getReturnValue() != 0)
+    {
         return SLANG_FAIL;
     }
 
@@ -374,7 +418,8 @@ static SlangResult _parentMonitorHappyPathTest(UnitTestContext* context)
 
 static SlangResult _parentMonitorTest(UnitTestContext* context)
 {
-    SLANG_RETURN_ON_FAIL(_parentMonitorHappyPathTest(context));
+    SLANG_RETURN_ON_FAIL(_parentMonitorParentExitTest(context, true));
+    SLANG_RETURN_ON_FAIL(_parentMonitorParentExitTest(context, false));
     SLANG_RETURN_ON_FAIL(_parentMonitorFailureModeTests(context));
     return SLANG_OK;
 }
@@ -394,7 +439,7 @@ static SlangResult _findChildTestServerProcessIds(DWORD parentProcessId, List<DW
     do
     {
         if (entry.th32ParentProcessID == parentProcessId &&
-            wcscmp(entry.szExeFile, L"test-server.exe") == 0)
+            _wcsicmp(entry.szExeFile, L"test-server.exe") == 0)
         {
             outProcessIds.add(entry.th32ProcessID);
         }

--- a/tools/slang-unit-test/unit-test-process.cpp
+++ b/tools/slang-unit-test/unit-test-process.cpp
@@ -7,6 +7,10 @@
 #include "../../source/core/slang-string-util.h"
 #include "unit-test/slang-unit-test.h"
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 using namespace Slang;
 
 static SlangResult _createProcess(
@@ -118,6 +122,107 @@ static SlangResult _httpCrashTest(UnitTestContext* context)
     return SLANG_OK;
 }
 
+#if defined(_WIN32)
+struct ScopedWinHandle
+{
+    HANDLE handle = nullptr;
+
+    ScopedWinHandle() {}
+    explicit ScopedWinHandle(HANDLE inHandle)
+        : handle(inHandle)
+    {
+    }
+    ~ScopedWinHandle()
+    {
+        if (handle)
+        {
+            CloseHandle(handle);
+        }
+    }
+};
+
+static SlangResult _createWindowsProcess(const CommandLine& cmdLine, PROCESS_INFORMATION& out)
+{
+    STARTUPINFOW startupInfo;
+    ZeroMemory(&startupInfo, sizeof(startupInfo));
+    startupInfo.cb = sizeof(startupInfo);
+
+    String cmdString = cmdLine.toString();
+    OSString cmdStringBuffer = cmdString.toWString();
+
+    OSString pathBuffer;
+    LPCWSTR path = nullptr;
+    if (cmdLine.m_executableLocation.m_type == ExecutableLocation::Type::Path)
+    {
+        pathBuffer = cmdLine.m_executableLocation.m_pathOrName.toWString();
+        path = pathBuffer.begin();
+    }
+
+    ZeroMemory(&out, sizeof(out));
+    BOOL success = CreateProcessW(
+        path,
+        (LPWSTR)cmdStringBuffer.begin(),
+        nullptr,
+        nullptr,
+        FALSE,
+        CREATE_NO_WINDOW,
+        nullptr,
+        nullptr,
+        &startupInfo,
+        &out);
+
+    return success ? SLANG_OK : SLANG_FAIL;
+}
+
+static SlangResult _parentMonitorTest(UnitTestContext* context)
+{
+    CommandLine parentCmdLine;
+    parentCmdLine.setExecutableLocation(
+        ExecutableLocation(context->executableDirectory, "test-process"));
+    parentCmdLine.addArg("sleep");
+    parentCmdLine.addArg("30000");
+
+    PROCESS_INFORMATION parentProcessInfo;
+    SLANG_RETURN_ON_FAIL(_createWindowsProcess(parentCmdLine, parentProcessInfo));
+    ScopedWinHandle parentProcess(parentProcessInfo.hProcess);
+    ScopedWinHandle parentThread(parentProcessInfo.hThread);
+
+    CommandLine serverCmdLine;
+    serverCmdLine.setExecutableLocation(
+        ExecutableLocation(context->executableDirectory, "test-server"));
+    serverCmdLine.addArg("-parent-pid");
+    serverCmdLine.addArg(String(uint32_t(parentProcessInfo.dwProcessId)));
+
+    RefPtr<Process> testServerProcess;
+    SlangResult createServerResult = Process::create(
+        serverCmdLine,
+        Process::Flag::AttachDebugger | Process::Flag::DisableStdErrRedirection,
+        testServerProcess);
+    if (SLANG_FAILED(createServerResult))
+    {
+        TerminateProcess(parentProcess.handle, 0);
+        return createServerResult;
+    }
+
+    if (testServerProcess->isTerminated())
+    {
+        TerminateProcess(parentProcess.handle, 0);
+        return SLANG_FAIL;
+    }
+
+    TerminateProcess(parentProcess.handle, 0);
+    WaitForSingleObject(parentProcess.handle, INFINITE);
+
+    if (!testServerProcess->waitForTermination(5 * 1000))
+    {
+        testServerProcess->kill(-1);
+        return SLANG_FAIL;
+    }
+
+    return SLANG_OK;
+}
+#endif
+
 static SlangResult _countTest(UnitTestContext* context, Index size, Index crashIndex = -1)
 {
     /* Here we are trying to test what happens if the server produces a large amount of data, and
@@ -224,4 +329,7 @@ SLANG_UNIT_TEST(CommandLineProcess)
     SLANG_CHECK(SLANG_SUCCEEDED(_reflectTest(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_httpReflectTest(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_httpCrashTest(unitTestContext)));
+#if defined(_WIN32)
+    SLANG_CHECK(SLANG_SUCCEEDED(_parentMonitorTest(unitTestContext)));
+#endif
 }

--- a/tools/slang-unit-test/unit-test-process.cpp
+++ b/tools/slang-unit-test/unit-test-process.cpp
@@ -223,6 +223,12 @@ static SlangResult _parentMonitorTest(UnitTestContext* context)
     // Give test-server time to open the parent handle. The fail-closed path is also acceptable,
     // but the normal monitor-thread path is what this regression test is meant to exercise.
     Process::sleepCurrentThread(250);
+    if (testServerProcess->isTerminated())
+    {
+        TerminateProcess(parentProcess.handle, 0);
+        WaitForSingleObject(parentProcess.handle, INFINITE);
+        return SLANG_FAIL;
+    }
 
     TerminateProcess(parentProcess.handle, 0);
     WaitForSingleObject(parentProcess.handle, INFINITE);

--- a/tools/slang-unit-test/unit-test-process.cpp
+++ b/tools/slang-unit-test/unit-test-process.cpp
@@ -2,13 +2,18 @@
 
 #include "../../source/core/slang-http.h"
 #include "../../source/core/slang-io.h"
+#include "../../source/core/slang-platform.h"
 #include "../../source/core/slang-process-util.h"
 #include "../../source/core/slang-random-generator.h"
 #include "../../source/core/slang-string-util.h"
 #include "unit-test/slang-unit-test.h"
 
 #if defined(_WIN32)
+#include <wchar.h>
 #include <windows.h>
+// clang-format off
+#include <tlhelp32.h>
+// clang-format on
 #endif
 
 using namespace Slang;
@@ -134,11 +139,40 @@ struct ScopedWinHandle
     }
     ScopedWinHandle(const ScopedWinHandle&) = delete;
     ScopedWinHandle& operator=(const ScopedWinHandle&) = delete;
+    bool isValid() const { return handle && handle != INVALID_HANDLE_VALUE; }
     ~ScopedWinHandle()
     {
-        if (handle)
+        if (isValid())
         {
             CloseHandle(handle);
+        }
+    }
+};
+
+struct ScopedWinEnvironmentVariable
+{
+    const char* name = nullptr;
+    String oldValue;
+    bool hadOldValue = false;
+    bool isSet = false;
+
+    ScopedWinEnvironmentVariable(const char* inName, const String& value)
+        : name(inName)
+    {
+        StringBuilder oldValueBuilder;
+        hadOldValue = SLANG_SUCCEEDED(
+            PlatformUtil::getEnvironmentVariable(UnownedStringSlice(name), oldValueBuilder));
+        oldValue = oldValueBuilder.produceString();
+        isSet = SetEnvironmentVariableA(name, value.getBuffer()) != 0;
+    }
+
+    ScopedWinEnvironmentVariable(const ScopedWinEnvironmentVariable&) = delete;
+    ScopedWinEnvironmentVariable& operator=(const ScopedWinEnvironmentVariable&) = delete;
+    ~ScopedWinEnvironmentVariable()
+    {
+        if (name && isSet)
+        {
+            SetEnvironmentVariableA(name, hadOldValue ? oldValue.getBuffer() : nullptr);
         }
     }
 };
@@ -344,6 +378,120 @@ static SlangResult _parentMonitorTest(UnitTestContext* context)
     SLANG_RETURN_ON_FAIL(_parentMonitorFailureModeTests(context));
     return SLANG_OK;
 }
+
+static SlangResult _findChildTestServerProcessIds(DWORD parentProcessId, List<DWORD>& outProcessIds)
+{
+    ScopedWinHandle snapshot(CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0));
+    if (!snapshot.isValid())
+        return SLANG_FAIL;
+
+    PROCESSENTRY32W entry;
+    ZeroMemory(&entry, sizeof(entry));
+    entry.dwSize = sizeof(entry);
+    if (!Process32FirstW(snapshot.handle, &entry))
+        return SLANG_FAIL;
+
+    do
+    {
+        if (entry.th32ParentProcessID == parentProcessId &&
+            wcscmp(entry.szExeFile, L"test-server.exe") == 0)
+        {
+            outProcessIds.add(entry.th32ProcessID);
+        }
+    } while (Process32NextW(snapshot.handle, &entry));
+
+    return SLANG_OK;
+}
+
+static void _closeWindowsHandles(List<HANDLE>& handles)
+{
+    for (HANDLE handle : handles)
+    {
+        if (handle)
+        {
+            CloseHandle(handle);
+        }
+    }
+    handles.clear();
+}
+
+static SlangResult _testServerParentMonitorIntegrationTest(UnitTestContext* context)
+{
+    String readyEventName = _makeParentMonitorReadyEventName();
+    OSString readyEventOSName = readyEventName.toWString();
+    ScopedWinHandle readyEvent(CreateEventW(nullptr, TRUE, FALSE, readyEventOSName.begin()));
+    if (!readyEvent.isValid())
+        return SLANG_FAIL;
+
+    CommandLine slangTestCmdLine;
+    slangTestCmdLine.setExecutableLocation(
+        ExecutableLocation(context->executableDirectory, "slang-test"));
+    slangTestCmdLine.addArg("-use-test-server");
+    slangTestCmdLine.addArg("-server-count");
+    slangTestCmdLine.addArg("1");
+    slangTestCmdLine.addArg("slang-unit-test-tool/CommandLineProcess");
+
+    PROCESS_INFORMATION slangTestProcessInfo;
+    {
+        ScopedWinEnvironmentVariable readyEventEnv(
+            "SLANG_TEST_PARENT_MONITOR_READY_EVENT",
+            readyEventName);
+        if (!readyEventEnv.isSet)
+            return SLANG_FAIL;
+
+        SLANG_RETURN_ON_FAIL(_createWindowsProcess(slangTestCmdLine, slangTestProcessInfo));
+    }
+
+    ScopedWinHandle slangTestProcess(slangTestProcessInfo.hProcess);
+    ScopedWinHandle slangTestThread(slangTestProcessInfo.hThread);
+    List<HANDLE> testServerHandles;
+    SlangResult result = SLANG_OK;
+
+    if (WaitForSingleObject(readyEvent.handle, 30 * 1000) != WAIT_OBJECT_0)
+    {
+        result = SLANG_FAIL;
+    }
+
+    if (SLANG_SUCCEEDED(result))
+    {
+        List<DWORD> testServerProcessIds;
+        result =
+            _findChildTestServerProcessIds(slangTestProcessInfo.dwProcessId, testServerProcessIds);
+        if (SLANG_SUCCEEDED(result) && testServerProcessIds.getCount() == 0)
+        {
+            result = SLANG_FAIL;
+        }
+
+        for (DWORD processId : testServerProcessIds)
+        {
+            HANDLE process = OpenProcess(SYNCHRONIZE | PROCESS_TERMINATE, FALSE, processId);
+            if (!process)
+            {
+                result = SLANG_FAIL;
+                break;
+            }
+            testServerHandles.add(process);
+        }
+    }
+
+    TerminateProcess(slangTestProcess.handle, 0);
+    WaitForSingleObject(slangTestProcess.handle, INFINITE);
+
+    if (SLANG_SUCCEEDED(result))
+    {
+        for (HANDLE testServerHandle : testServerHandles)
+        {
+            if (WaitForSingleObject(testServerHandle, 5 * 1000) != WAIT_OBJECT_0)
+            {
+                TerminateProcess(testServerHandle, 0);
+                result = SLANG_FAIL;
+            }
+        }
+    }
+
+    _closeWindowsHandles(testServerHandles);
+    return result;
+}
 #endif
 
 static SlangResult _countTest(UnitTestContext* context, Index size, Index crashIndex = -1)
@@ -456,3 +604,10 @@ SLANG_UNIT_TEST(CommandLineProcess)
     SLANG_CHECK(SLANG_SUCCEEDED(_parentMonitorTest(unitTestContext)));
 #endif
 }
+
+#if defined(_WIN32)
+SLANG_UNIT_TEST(TestServerParentMonitorIntegration)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_testServerParentMonitorIntegrationTest(unitTestContext)));
+}
+#endif

--- a/tools/slang-unit-test/unit-test-process.cpp
+++ b/tools/slang-unit-test/unit-test-process.cpp
@@ -132,6 +132,8 @@ struct ScopedWinHandle
         : handle(inHandle)
     {
     }
+    ScopedWinHandle(const ScopedWinHandle&) = delete;
+    ScopedWinHandle& operator=(const ScopedWinHandle&) = delete;
     ~ScopedWinHandle()
     {
         if (handle)
@@ -149,6 +151,12 @@ static SlangResult _createWindowsProcess(const CommandLine& cmdLine, PROCESS_INF
 
     String cmdString = cmdLine.toString();
     OSString cmdStringBuffer = cmdString.toWString();
+    List<wchar_t> mutableCmdString;
+    for (const wchar_t* cursor = cmdStringBuffer.begin(); cursor != cmdStringBuffer.end(); ++cursor)
+    {
+        mutableCmdString.add(*cursor);
+    }
+    mutableCmdString.add(0);
 
     OSString pathBuffer;
     LPCWSTR path = nullptr;
@@ -161,7 +169,7 @@ static SlangResult _createWindowsProcess(const CommandLine& cmdLine, PROCESS_INF
     ZeroMemory(&out, sizeof(out));
     BOOL success = CreateProcessW(
         path,
-        (LPWSTR)cmdStringBuffer.begin(),
+        mutableCmdString.getBuffer(),
         nullptr,
         nullptr,
         FALSE,
@@ -201,14 +209,20 @@ static SlangResult _parentMonitorTest(UnitTestContext* context)
     if (SLANG_FAILED(createServerResult))
     {
         TerminateProcess(parentProcess.handle, 0);
+        WaitForSingleObject(parentProcess.handle, INFINITE);
         return createServerResult;
     }
 
     if (testServerProcess->isTerminated())
     {
         TerminateProcess(parentProcess.handle, 0);
+        WaitForSingleObject(parentProcess.handle, INFINITE);
         return SLANG_FAIL;
     }
+
+    // Give test-server time to open the parent handle. The fail-closed path is also acceptable,
+    // but the normal monitor-thread path is what this regression test is meant to exercise.
+    Process::sleepCurrentThread(250);
 
     TerminateProcess(parentProcess.handle, 0);
     WaitForSingleObject(parentProcess.handle, INFINITE);

--- a/tools/slang-unit-test/unit-test-process.cpp
+++ b/tools/slang-unit-test/unit-test-process.cpp
@@ -182,7 +182,93 @@ static SlangResult _createWindowsProcess(const CommandLine& cmdLine, PROCESS_INF
     return success ? SLANG_OK : SLANG_FAIL;
 }
 
-static SlangResult _parentMonitorTest(UnitTestContext* context)
+static SlangResult _expectTestServerTerminates(UnitTestContext* context, const List<String>& args)
+{
+    CommandLine serverCmdLine;
+    serverCmdLine.setExecutableLocation(
+        ExecutableLocation(context->executableDirectory, "test-server"));
+    serverCmdLine.m_args.addRange(args.getBuffer(), args.getCount());
+
+    RefPtr<Process> testServerProcess;
+    SLANG_RETURN_ON_FAIL(Process::create(
+        serverCmdLine,
+        Process::Flag::AttachDebugger | Process::Flag::DisableStdErrRedirection,
+        testServerProcess));
+
+    if (!testServerProcess->waitForTermination(5 * 1000))
+    {
+        testServerProcess->kill(-1);
+        return SLANG_FAIL;
+    }
+
+    return SLANG_OK;
+}
+
+static SlangResult _parentMonitorFailureModeTests(UnitTestContext* context)
+{
+    {
+        List<String> args;
+        args.add("-parent-pid");
+        args.add("abc");
+        SLANG_RETURN_ON_FAIL(_expectTestServerTerminates(context, args));
+    }
+
+    {
+        List<String> args;
+        args.add("-parent-pid");
+        args.add("0");
+        SLANG_RETURN_ON_FAIL(_expectTestServerTerminates(context, args));
+    }
+
+    {
+        List<String> args;
+        args.add("-parent-pid");
+        args.add("4294967296");
+        SLANG_RETURN_ON_FAIL(_expectTestServerTerminates(context, args));
+    }
+
+    {
+        List<String> args;
+        args.add("-parent-pid");
+        args.add(String(uint32_t(MAXDWORD)));
+        SLANG_RETURN_ON_FAIL(_expectTestServerTerminates(context, args));
+    }
+
+    {
+        List<String> args;
+        args.add("-parent-pid");
+        SLANG_RETURN_ON_FAIL(_expectTestServerTerminates(context, args));
+    }
+
+    // Without -parent-pid, test-server should keep its normal RPC wait behavior.
+    CommandLine serverCmdLine;
+    serverCmdLine.setExecutableLocation(
+        ExecutableLocation(context->executableDirectory, "test-server"));
+
+    RefPtr<Process> testServerProcess;
+    SLANG_RETURN_ON_FAIL(Process::create(
+        serverCmdLine,
+        Process::Flag::AttachDebugger | Process::Flag::DisableStdErrRedirection,
+        testServerProcess));
+
+    if (testServerProcess->waitForTermination(500))
+    {
+        return SLANG_FAIL;
+    }
+    testServerProcess->kill(0);
+
+    return SLANG_OK;
+}
+
+static String _makeParentMonitorReadyEventName()
+{
+    StringBuilder builder;
+    builder << "Local\\SlangParentMonitorReady-" << Process::getId() << "-"
+            << Process::getClockTick();
+    return builder.produceString();
+}
+
+static SlangResult _parentMonitorHappyPathTest(UnitTestContext* context)
 {
     CommandLine parentCmdLine;
     parentCmdLine.setExecutableLocation(
@@ -195,11 +281,23 @@ static SlangResult _parentMonitorTest(UnitTestContext* context)
     ScopedWinHandle parentProcess(parentProcessInfo.hProcess);
     ScopedWinHandle parentThread(parentProcessInfo.hThread);
 
+    String readyEventName = _makeParentMonitorReadyEventName();
+    OSString readyEventOSName = readyEventName.toWString();
+    ScopedWinHandle readyEvent(CreateEventW(nullptr, TRUE, FALSE, readyEventOSName.begin()));
+    if (!readyEvent.handle)
+    {
+        TerminateProcess(parentProcess.handle, 0);
+        WaitForSingleObject(parentProcess.handle, INFINITE);
+        return SLANG_FAIL;
+    }
+
     CommandLine serverCmdLine;
     serverCmdLine.setExecutableLocation(
         ExecutableLocation(context->executableDirectory, "test-server"));
     serverCmdLine.addArg("-parent-pid");
     serverCmdLine.addArg(String(uint32_t(parentProcessInfo.dwProcessId)));
+    serverCmdLine.addArg("-parent-monitor-ready-event");
+    serverCmdLine.addArg(readyEventName);
 
     RefPtr<Process> testServerProcess;
     SlangResult createServerResult = Process::create(
@@ -220,10 +318,8 @@ static SlangResult _parentMonitorTest(UnitTestContext* context)
         return SLANG_FAIL;
     }
 
-    // Give test-server time to open the parent handle. The fail-closed path is also acceptable,
-    // but the normal monitor-thread path is what this regression test is meant to exercise.
-    Process::sleepCurrentThread(250);
-    if (testServerProcess->isTerminated())
+    if (WaitForSingleObject(readyEvent.handle, 5 * 1000) != WAIT_OBJECT_0 ||
+        testServerProcess->isTerminated())
     {
         TerminateProcess(parentProcess.handle, 0);
         WaitForSingleObject(parentProcess.handle, INFINITE);
@@ -239,6 +335,13 @@ static SlangResult _parentMonitorTest(UnitTestContext* context)
         return SLANG_FAIL;
     }
 
+    return SLANG_OK;
+}
+
+static SlangResult _parentMonitorTest(UnitTestContext* context)
+{
+    SLANG_RETURN_ON_FAIL(_parentMonitorHappyPathTest(context));
+    SLANG_RETURN_ON_FAIL(_parentMonitorFailureModeTests(context));
     return SLANG_OK;
 }
 #endif

--- a/tools/test-process/test-process-main.cpp
+++ b/tools/test-process/test-process-main.cpp
@@ -178,6 +178,22 @@ static SlangResult _httpCrash()
     return SLANG_FAIL;
 }
 
+static SlangResult _sleep(int argc, const char* const* argv)
+{
+    Int timeInMs = 30 * 1000;
+    if (argc > 2)
+    {
+        SLANG_RETURN_ON_FAIL(StringUtil::parseInt(UnownedStringSlice(argv[2]), timeInMs));
+        if (timeInMs < 0 || timeInMs > 60 * 1000)
+        {
+            return SLANG_FAIL;
+        }
+    }
+
+    Process::sleepCurrentThread(timeInMs);
+    return SLANG_OK;
+}
+
 static SlangResult execute(int argc, const char* const* argv)
 {
     if (argc < 2)
@@ -202,6 +218,10 @@ static SlangResult execute(int argc, const char* const* argv)
     else if (toolName == "http-crash")
     {
         return _httpCrash();
+    }
+    else if (toolName == "sleep")
+    {
+        return _sleep(argc, argv);
     }
     return SLANG_E_NOT_AVAILABLE;
 }

--- a/tools/test-process/test-process-main.cpp
+++ b/tools/test-process/test-process-main.cpp
@@ -12,6 +12,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 namespace TestProcess
 {
 using namespace Slang;
@@ -184,7 +188,7 @@ static SlangResult _sleep(int argc, const char* const* argv)
     if (argc > 2)
     {
         SLANG_RETURN_ON_FAIL(StringUtil::parseInt(UnownedStringSlice(argv[2]), timeInMs));
-        if (timeInMs < 0 || timeInMs > 60 * 1000)
+        if (timeInMs < 0)
         {
             return SLANG_FAIL;
         }
@@ -193,6 +197,29 @@ static SlangResult _sleep(int argc, const char* const* argv)
     Process::sleepCurrentThread(timeInMs);
     return SLANG_OK;
 }
+
+#if defined(_WIN32)
+static SlangResult _waitEvent(int argc, const char* const* argv)
+{
+    if (argc < 3)
+    {
+        return SLANG_FAIL;
+    }
+
+    OSString eventName = String(argv[2]).toWString();
+    HANDLE event = OpenEventW(SYNCHRONIZE, FALSE, eventName.begin());
+    if (!event)
+    {
+        return SLANG_FAIL;
+    }
+
+    // Keep the helper bounded so a missed test signal cannot leave a child process around
+    // indefinitely.
+    DWORD waitResult = WaitForSingleObject(event, 60 * 1000);
+    CloseHandle(event);
+    return waitResult == WAIT_OBJECT_0 ? SLANG_OK : SLANG_FAIL;
+}
+#endif
 
 static SlangResult execute(int argc, const char* const* argv)
 {
@@ -223,6 +250,12 @@ static SlangResult execute(int argc, const char* const* argv)
     {
         return _sleep(argc, argv);
     }
+#if defined(_WIN32)
+    else if (toolName == "wait-event")
+    {
+        return _waitEvent(argc, argv);
+    }
+#endif
     return SLANG_E_NOT_AVAILABLE;
 }
 

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -36,6 +36,9 @@ namespace TestServer
 using namespace Slang;
 
 #if defined(_WIN32)
+// This monitor is Windows-only because issue #10109 is specifically about orphaned test-server
+// processes holding DLLs open after slang-test crashes. Unix platforms do not prevent loaded
+// shared libraries from being replaced in the same way.
 static DWORD WINAPI _parentMonitorThreadProc(void* data)
 {
     HANDLE parentProcess = (HANDLE)data;
@@ -44,6 +47,8 @@ static DWORD WINAPI _parentMonitorThreadProc(void* data)
 
     if (waitResult == WAIT_OBJECT_0)
     {
+        // The RPC peer is gone, so graceful shutdown cannot be coordinated. Exit hard to release
+        // DLL file handles promptly; Windows will reclaim the process resources.
         TerminateProcess(GetCurrentProcess(), 0);
     }
 
@@ -52,13 +57,13 @@ static DWORD WINAPI _parentMonitorThreadProc(void* data)
 
 static void _startParentMonitor(DWORD parentProcessId)
 {
+    // Keep this scoped to test-server instead of changing shared process-launch plumbing. The PID
+    // is captured immediately before spawning this process and consumed during init, so the reuse
+    // window is tiny; if we cannot open it at all, avoid leaving an unmonitored orphan.
     HANDLE parentProcess = OpenProcess(SYNCHRONIZE, FALSE, parentProcessId);
     if (!parentProcess)
     {
-        if (GetLastError() == ERROR_INVALID_PARAMETER)
-        {
-            TerminateProcess(GetCurrentProcess(), 0);
-        }
+        TerminateProcess(GetCurrentProcess(), 0);
         return;
     }
 

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -26,6 +26,8 @@
 #endif
 
 #if defined(_WIN32)
+#include <windows.h>
+
 #include <slang-rhi/agility-sdk.h>
 SLANG_RHI_EXPORT_AGILITY_SDK
 #endif
@@ -33,6 +35,61 @@ SLANG_RHI_EXPORT_AGILITY_SDK
 namespace TestServer
 {
 using namespace Slang;
+
+#if defined(_WIN32)
+static DWORD WINAPI _parentMonitorThreadProc(void* data)
+{
+    HANDLE parentProcess = (HANDLE)data;
+    DWORD waitResult = WaitForSingleObject(parentProcess, INFINITE);
+    CloseHandle(parentProcess);
+
+    if (waitResult == WAIT_OBJECT_0)
+    {
+        TerminateProcess(GetCurrentProcess(), 0);
+    }
+
+    return 0;
+}
+
+static void _startParentMonitor(DWORD parentProcessId)
+{
+    HANDLE parentProcess = OpenProcess(SYNCHRONIZE, FALSE, parentProcessId);
+    if (!parentProcess)
+    {
+        if (GetLastError() == ERROR_INVALID_PARAMETER)
+        {
+            TerminateProcess(GetCurrentProcess(), 0);
+        }
+        return;
+    }
+
+    HANDLE thread = CreateThread(nullptr, 0, _parentMonitorThreadProc, parentProcess, 0, nullptr);
+    if (!thread)
+    {
+        CloseHandle(parentProcess);
+        return;
+    }
+    CloseHandle(thread);
+}
+
+static void _startParentMonitorFromArgs(int argc, const char* const* argv)
+{
+    for (int i = 1; i + 1 < argc; ++i)
+    {
+        if (strcmp(argv[i], "-parent-pid") != 0)
+            continue;
+
+        Int parentProcessId = 0;
+        if (SLANG_SUCCEEDED(
+                StringUtil::parseInt(UnownedStringSlice(argv[i + 1]), parentProcessId)) &&
+            parentProcessId > 0)
+        {
+            _startParentMonitor(DWORD(parentProcessId));
+        }
+        return;
+    }
+}
+#endif
 
 class TestReporter : public ITestReporter
 {
@@ -194,6 +251,10 @@ SlangResult innerMain(
 SlangResult TestServer::init(int argc, const char* const* argv)
 {
     m_exePath = argv[0];
+
+#if defined(_WIN32)
+    _startParentMonitorFromArgs(argc, argv);
+#endif
 
 #if SLANG_IGNORE_ABORT_MSG && defined(_MSC_VER)
     // Suppress the modal abort() dialog in unattended/LLM-driven builds.

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -71,6 +71,7 @@ static void _startParentMonitor(DWORD parentProcessId)
     if (!thread)
     {
         CloseHandle(parentProcess);
+        TerminateProcess(GetCurrentProcess(), 0);
         return;
     }
     CloseHandle(thread);

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -36,6 +36,8 @@ namespace TestServer
 using namespace Slang;
 
 #if defined(_WIN32)
+static const UINT kParentMonitorFailedExitCode = 1;
+
 // This monitor is Windows-only because issue #10109 is specifically about orphaned test-server
 // processes holding DLLs open after slang-test crashes. Unix platforms do not prevent loaded
 // shared libraries from being replaced in the same way.
@@ -71,13 +73,15 @@ static void _signalParentMonitorReady(const char* readyEventName)
 
 static void _startParentMonitor(DWORD parentProcessId, const char* readyEventName)
 {
-    // Keep this scoped to test-server instead of changing shared process-launch plumbing. The PID
-    // is captured immediately before spawning this process and consumed during init, so the reuse
-    // window is tiny; if we cannot open it at all, avoid leaving an unmonitored orphan.
+    // Keep this scoped to test-server instead of changing shared process-launch plumbing. A
+    // duplicated inheritable parent handle would remove PID reuse entirely, but Process::create
+    // does not currently expose selective handle inheritance. The PID is captured immediately
+    // before spawning this process and consumed during init, so the reuse window is tiny; if we
+    // cannot open it at all, avoid leaving an unmonitored orphan.
     HANDLE parentProcess = OpenProcess(SYNCHRONIZE, FALSE, parentProcessId);
     if (!parentProcess)
     {
-        TerminateProcess(GetCurrentProcess(), 0);
+        TerminateProcess(GetCurrentProcess(), kParentMonitorFailedExitCode);
         return;
     }
 
@@ -85,7 +89,7 @@ static void _startParentMonitor(DWORD parentProcessId, const char* readyEventNam
     if (!thread)
     {
         CloseHandle(parentProcess);
-        TerminateProcess(GetCurrentProcess(), 0);
+        TerminateProcess(GetCurrentProcess(), kParentMonitorFailedExitCode);
         return;
     }
     CloseHandle(thread);
@@ -130,7 +134,7 @@ static void _startParentMonitorFromArgs(int argc, const char* const* argv)
         return;
     }
 
-    TerminateProcess(GetCurrentProcess(), 0);
+    TerminateProcess(GetCurrentProcess(), kParentMonitorFailedExitCode);
 }
 #endif
 

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -55,7 +55,21 @@ static DWORD WINAPI _parentMonitorThreadProc(void* data)
     return 0;
 }
 
-static void _startParentMonitor(DWORD parentProcessId)
+static void _signalParentMonitorReady(const char* readyEventName)
+{
+    if (!readyEventName || !readyEventName[0])
+        return;
+
+    OSString readyEventNameString = String(readyEventName).toWString();
+    HANDLE readyEvent = OpenEventW(EVENT_MODIFY_STATE, FALSE, readyEventNameString.begin());
+    if (readyEvent)
+    {
+        SetEvent(readyEvent);
+        CloseHandle(readyEvent);
+    }
+}
+
+static void _startParentMonitor(DWORD parentProcessId, const char* readyEventName)
 {
     // Keep this scoped to test-server instead of changing shared process-launch plumbing. The PID
     // is captured immediately before spawning this process and consumed during init, so the reuse
@@ -75,27 +89,48 @@ static void _startParentMonitor(DWORD parentProcessId)
         return;
     }
     CloseHandle(thread);
+    _signalParentMonitorReady(readyEventName);
 }
 
 static void _startParentMonitorFromArgs(int argc, const char* const* argv)
 {
-    for (int i = 1; i + 1 < argc; ++i)
+    bool hasParentProcessId = false;
+    const char* parentProcessIdArg = nullptr;
+    const char* readyEventName = nullptr;
+
+    for (int i = 1; i < argc; ++i)
     {
-        if (strcmp(argv[i], "-parent-pid") != 0)
-            continue;
-
-        Int parentProcessId = 0;
-        if (SLANG_SUCCEEDED(
-                StringUtil::parseInt(UnownedStringSlice(argv[i + 1]), parentProcessId)) &&
-            parentProcessId > 0 && parentProcessId <= Int(MAXDWORD))
+        if (strcmp(argv[i], "-parent-pid") == 0)
         {
-            _startParentMonitor(DWORD(parentProcessId));
-            return;
+            hasParentProcessId = true;
+            if (i + 1 >= argc)
+                break;
+            parentProcessIdArg = argv[++i];
+            continue;
         }
+        if (strcmp(argv[i], "-parent-monitor-ready-event") == 0)
+        {
+            if (i + 1 >= argc)
+                break;
+            readyEventName = argv[++i];
+            continue;
+        }
+    }
 
-        TerminateProcess(GetCurrentProcess(), 0);
+    if (!hasParentProcessId)
+        return;
+
+    Int parentProcessId = 0;
+    if (parentProcessIdArg &&
+        SLANG_SUCCEEDED(
+            StringUtil::parseInt(UnownedStringSlice(parentProcessIdArg), parentProcessId)) &&
+        parentProcessId > 0 && parentProcessId <= Int(MAXDWORD))
+    {
+        _startParentMonitor(DWORD(parentProcessId), readyEventName);
         return;
     }
+
+    TerminateProcess(GetCurrentProcess(), 0);
 }
 #endif
 

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -26,9 +26,8 @@
 #endif
 
 #if defined(_WIN32)
-#include <windows.h>
-
 #include <slang-rhi/agility-sdk.h>
+#include <windows.h>
 SLANG_RHI_EXPORT_AGILITY_SDK
 #endif
 
@@ -82,7 +81,7 @@ static void _startParentMonitorFromArgs(int argc, const char* const* argv)
         Int parentProcessId = 0;
         if (SLANG_SUCCEEDED(
                 StringUtil::parseInt(UnownedStringSlice(argv[i + 1]), parentProcessId)) &&
-            parentProcessId > 0)
+            parentProcessId > 0 && parentProcessId <= Int(MAXDWORD))
         {
             _startParentMonitor(DWORD(parentProcessId));
         }

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -90,7 +90,10 @@ static void _startParentMonitorFromArgs(int argc, const char* const* argv)
             parentProcessId > 0 && parentProcessId <= Int(MAXDWORD))
         {
             _startParentMonitor(DWORD(parentProcessId));
+            return;
         }
+
+        TerminateProcess(GetCurrentProcess(), 0);
         return;
     }
 }


### PR DESCRIPTION
Fixes #10109.

## Summary
- pass the slang-test parent PID to test-server instances
- on Windows, have test-server monitor the parent process and terminate itself when the parent exits

## Context
This implementation is meant to be robust under the following case:
1. slang-test is running as a CI task on a Windows machine.
2. test-server is somehow stuck in the middle of testing due to an unexpected problem.
3. slang-test is killed by the gitlab runner; because the user requested to cancel or it hit the timeout limit.
4. test-server still lingers while holding the Slang-compiler.dll file handle.
5. gitlab runner cannot delete the build directory for the next CI test.
