### PR TITLE
Print formatting help without arguments

### DIFF
--- a/extras/formatting.sh
+++ b/extras/formatting.sh
@@ -21,11 +21,12 @@ show_help() {
   cat <<EOF
 $me: Format or check formatting of files in this repo
 
-Usage: $me [--check-only] [--no-version-check] [--source <path>] [--cpp] [--yaml] [--md] [--sh] [--cmake] [--since <rev>] [-- file1 file2 ...]
+Usage: $me [--check-only] [--no-version-check] [--modified] [--source <path>] [--cpp] [--yaml] [--md] [--sh] [--cmake] [--since <rev>] [-- file1 file2 ...]
 
 Options:
     --check-only       Check formatting without modifying files
     --no-version-check Skip version compatibility checks
+    --modified         Only format files modified from HEAD
     --source          Path to source directory to format (defaults to parent of script directory)
     --cpp             Format only C++ files
     --yaml            Format only YAML/JSON files

--- a/extras/formatting.sh
+++ b/extras/formatting.sh
@@ -111,7 +111,7 @@ done
 # Detect macOS and set appropriate binary names
 if [[ "$(uname)" == "Darwin" ]]; then
   # On macOS, check for GNU versions
-  # grep and xargs use g-prefix, diff is installed as /opt/homebrew/bin/diff
+  # grep and xargs use g-prefix, diff is installed in a Homebrew prefix
   missing_tools=()
 
   if ! command -v ggrep &>/dev/null; then
@@ -122,7 +122,11 @@ if [[ "$(uname)" == "Darwin" ]]; then
     missing_tools+=("findutils")
   fi
 
-  if ! command -v /opt/homebrew/bin/diff &>/dev/null; then
+  if command -v /opt/homebrew/bin/diff &>/dev/null; then
+    DIFF_BIN="/opt/homebrew/bin/diff"
+  elif command -v /usr/local/bin/diff &>/dev/null; then
+    DIFF_BIN="/usr/local/bin/diff"
+  else
     missing_tools+=("diffutils")
   fi
 
@@ -135,7 +139,6 @@ if [[ "$(uname)" == "Darwin" ]]; then
 
   GREP_BIN="ggrep"
   XARGS_BIN="gxargs"
-  DIFF_BIN="/opt/homebrew/bin/diff"
 else
   # On other systems, use standard binaries
   GREP_BIN="grep"

--- a/extras/formatting.sh
+++ b/extras/formatting.sh
@@ -16,58 +16,12 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 source_dir="$(dirname "$script_dir")"
 since_rev=""
 
-# Detect macOS and set appropriate binary names
-if [[ "$(uname)" == "Darwin" ]]; then
-  # On macOS, check for GNU versions
-  # grep and xargs use g-prefix, diff is installed as /opt/homebrew/bin/diff
-  missing_tools=()
-
-  if ! command -v ggrep &>/dev/null; then
-    missing_tools+=("grep")
-  fi
-
-  if ! command -v gxargs &>/dev/null; then
-    missing_tools+=("findutils")
-  fi
-
-  if ! command -v /opt/homebrew/bin/diff &>/dev/null; then
-    missing_tools+=("diffutils")
-  fi
-
-  if [ ${#missing_tools[@]} -gt 0 ]; then
-    echo "Error: GNU versions of grep, xargs, and diff are required on macOS." >&2
-    echo "Please install them using Homebrew:" >&2
-    echo "  brew install ${missing_tools[*]}" >&2
-    exit 1
-  fi
-
-  GREP_BIN="ggrep"
-  XARGS_BIN="gxargs"
-  DIFF_BIN="/opt/homebrew/bin/diff"
-else
-  # On other systems, use standard binaries
-  GREP_BIN="grep"
-  XARGS_BIN="xargs"
-  DIFF_BIN="diff"
-fi
-
-check_only=0
-no_version_check=0
-modified_files=0
-run_cpp=0
-run_yaml=0
-run_markdown=0
-run_sh=0
-run_cmake=0
-run_all=1
-explicit_files=()
-
 show_help() {
   me=$(basename "$0")
   cat <<EOF
 $me: Format or check formatting of files in this repo
 
-Usage: $me [--check-only] [--no-version-check] [--source <path>] [--cpp] [--yaml] [--md] [--sh] [--cmake] [-- file1 file2 ...]
+Usage: $me [--check-only] [--no-version-check] [--source <path>] [--cpp] [--yaml] [--md] [--sh] [--cmake] [--since <rev>] [-- file1 file2 ...]
 
 Options:
     --check-only       Check formatting without modifying files
@@ -80,8 +34,27 @@ Options:
     --cmake           Format only CMake files
     --since <rev>     Only format files since Git revision <rev>
     -- file1 file2    Format only the specified files (auto-detects file types)
+
+Examples:
+    $me --since master
 EOF
 }
+
+if [ "$#" -eq 0 ]; then
+  show_help
+  exit 0
+fi
+
+check_only=0
+no_version_check=0
+modified_files=0
+run_cpp=0
+run_yaml=0
+run_markdown=0
+run_sh=0
+run_cmake=0
+run_all=1
+explicit_files=()
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
@@ -133,6 +106,41 @@ while [[ "$#" -gt 0 ]]; do
   esac
   shift
 done
+
+# Detect macOS and set appropriate binary names
+if [[ "$(uname)" == "Darwin" ]]; then
+  # On macOS, check for GNU versions
+  # grep and xargs use g-prefix, diff is installed as /opt/homebrew/bin/diff
+  missing_tools=()
+
+  if ! command -v ggrep &>/dev/null; then
+    missing_tools+=("grep")
+  fi
+
+  if ! command -v gxargs &>/dev/null; then
+    missing_tools+=("findutils")
+  fi
+
+  if ! command -v /opt/homebrew/bin/diff &>/dev/null; then
+    missing_tools+=("diffutils")
+  fi
+
+  if [ ${#missing_tools[@]} -gt 0 ]; then
+    echo "Error: GNU versions of grep, xargs, and diff are required on macOS." >&2
+    echo "Please install them using Homebrew:" >&2
+    echo "  brew install ${missing_tools[*]}" >&2
+    exit 1
+  fi
+
+  GREP_BIN="ggrep"
+  XARGS_BIN="gxargs"
+  DIFF_BIN="/opt/homebrew/bin/diff"
+else
+  # On other systems, use standard binaries
+  GREP_BIN="grep"
+  XARGS_BIN="xargs"
+  DIFF_BIN="diff"
+fi
 
 cd "$source_dir" || exit 1
 


### PR DESCRIPTION
LLMs kept having problem with the formatting script.
This modifies the script to print a help message when the script is ran without any command-line arguments; rather than formatting the entire project.