### PR TITLE
ci: install clang-18 toolchain in LLVM cache workflows

### DIFF
--- a/.github/workflows/build-missing-llvm-caches.yml
+++ b/.github/workflows/build-missing-llvm-caches.yml
@@ -109,6 +109,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ninja-build
 
+          # Install versioned clang toolchain if requested (e.g. clang-18);
+          # GitHub-hosted ubuntu-22.04 images only ship clang-14 by default.
+          compiler="${{ matrix.compiler }}"
+          if [[ "$compiler" == clang-* ]]; then
+            sudo apt-get install -y "$compiler" "${compiler/clang/clang++}"
+          fi
+
           # Set compiler
           CC=${{ matrix.compiler }}
           CXX=${{ matrix.compiler }}

--- a/.github/workflows/populate-llvm-cache.yml
+++ b/.github/workflows/populate-llvm-cache.yml
@@ -46,6 +46,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ninja-build
 
+          # Install versioned clang toolchain if requested (e.g. clang-18);
+          # GitHub-hosted ubuntu-22.04 images only ship clang-14 by default.
+          compiler="${{ inputs.compiler }}"
+          if [[ "$compiler" == clang-* ]]; then
+            sudo apt-get install -y "$compiler" "${compiler/clang/clang++}"
+          fi
+
           # Set compiler
           CC=${{ inputs.compiler }}
           CXX=${{ inputs.compiler }}


### PR DESCRIPTION
## Summary

The weekly `Build Missing LLVM Caches` workflow has been consistently failing on the `linux:clang-18:x86_64:ubuntu-22.04` matrix entry — most recently [run 25976712683](https://github.com/shader-slang/slang/actions/runs/25976712683) — with:

```
CMake Error: Could not find compiler set in environment variable CC: clang-18.
```

GitHub-hosted `ubuntu-22.04` images ship only `clang-14`; the "Setup dependencies (Linux)" step installed `ninja-build` and then set `CC=clang-18` without ever installing it. (`ci-slang-coverage.yml` already works around this by `apt-get install`-ing `clang-18` explicitly.)

This adds a conditional install of the versioned clang toolchain (mirroring the existing `clang`→`clang++` parameter expansion) in both `build-missing-llvm-caches.yml` (scheduled) and `populate-llvm-cache.yml` (manual dispatch — same latent bug).

Scoped to those two workflows; `common-setup` is not touched because its other consumers either don't pass `clang-18` or run in a container that already has it.