### PR TITLE
ci: add apt.llvm.org repo for versioned clang install

### DIFF
--- a/.github/workflows/build-missing-llvm-caches.yml
+++ b/.github/workflows/build-missing-llvm-caches.yml
@@ -110,9 +110,16 @@ jobs:
           sudo apt-get install -y ninja-build
 
           # Install versioned clang toolchain if requested (e.g. clang-18);
-          # GitHub-hosted ubuntu-22.04 images only ship clang-14 by default.
+          # GitHub-hosted ubuntu-22.04 images only ship clang-14 by default,
+          # so add the upstream apt.llvm.org repo for newer versions.
           compiler="${{ matrix.compiler }}"
-          if [[ "$compiler" == clang-* ]]; then
+          if [[ "$compiler" =~ ^clang-([0-9]+)$ ]]; then
+            clang_version="${BASH_REMATCH[1]}"
+            curl -fsSL --retry 3 --retry-delay 5 -o /tmp/llvm-snapshot.gpg.key https://apt.llvm.org/llvm-snapshot.gpg.key
+            sudo apt-key add /tmp/llvm-snapshot.gpg.key
+            rm /tmp/llvm-snapshot.gpg.key
+            sudo add-apt-repository -y "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${clang_version} main"
+            sudo apt-get update
             sudo apt-get install -y "$compiler" "${compiler/clang/clang++}"
           fi
 

--- a/.github/workflows/populate-llvm-cache.yml
+++ b/.github/workflows/populate-llvm-cache.yml
@@ -47,9 +47,16 @@ jobs:
           sudo apt-get install -y ninja-build
 
           # Install versioned clang toolchain if requested (e.g. clang-18);
-          # GitHub-hosted ubuntu-22.04 images only ship clang-14 by default.
+          # GitHub-hosted ubuntu-22.04 images only ship clang-14 by default,
+          # so add the upstream apt.llvm.org repo for newer versions.
           compiler="${{ inputs.compiler }}"
-          if [[ "$compiler" == clang-* ]]; then
+          if [[ "$compiler" =~ ^clang-([0-9]+)$ ]]; then
+            clang_version="${BASH_REMATCH[1]}"
+            curl -fsSL --retry 3 --retry-delay 5 -o /tmp/llvm-snapshot.gpg.key https://apt.llvm.org/llvm-snapshot.gpg.key
+            sudo apt-key add /tmp/llvm-snapshot.gpg.key
+            rm /tmp/llvm-snapshot.gpg.key
+            sudo add-apt-repository -y "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${clang_version} main"
+            sudo apt-get update
             sudo apt-get install -y "$compiler" "${compiler/clang/clang++}"
           fi
 


### PR DESCRIPTION
## Summary

Follow-up to #11186. That PR added `apt-get install -y clang-N clang++-N` to the LLVM cache workflows so the linux/clang-18 row would have a compiler, but ubuntu-22.04 only ships clang-14 by default. Without the upstream LLVM apt repo the install fails:

```
E: Package 'clang-18' has no installation candidate
```

(failing run: https://github.com/shader-slang/slang/actions/runs/26032071732, job 76520398964).

This change mirrors the setup already used by `ci-slang-coverage.yml`: when the compiler matches `^clang-([0-9]+)$`, add the LLVM GPG key and the versioned `apt.llvm.org/jammy/llvm-toolchain-jammy-${version}` repo before installing.

Applied identically to both `build-missing-llvm-caches.yml` (matrix.compiler) and `populate-llvm-cache.yml` (inputs.compiler).