### PR TITLE
Package CMark in wasm release libs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,6 +291,7 @@ jobs:
             cp build.em/Release/lib/*.a "${base_libs}/lib/" 2>/dev/null || echo "No .a files in lib/"
             cp build.em/external/lz4/build/cmake/Release/liblz4.a "${base_libs}/lib/" 2>/dev/null || true
             cp build.em/external/miniz/Release/libminiz.a "${base_libs}/lib/" 2>/dev/null || true
+            cp build.em/external/cmark/src/libcmark-gfm.a "${base_libs}/lib/"
             cp build.em/Release/include/*.h "${base_libs}/include/"
             (cd "${base_libs}" && zip -r "../${base_libs}.zip" .)
             echo "SLANG_WASM_LIBS_ARCHIVE=${base_libs}.zip" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- include the Swift CMark static archive in the wasm static libs release package
- fail the wasm packaging step if the expected CMark archive is missing from the Emscripten build

## Context
Slang v2026.05 added .slang.md support and introduced a static dependency from libslang-compiler.a to libcmark-gfm.a. The wasm libs package still only copied the older dependency set, so downstream static consumers can fail to link with unresolved cmark_* symbols.

## Testing
- YAML parse check: ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- git diff --check
