### PR TITLE
Fix CMark wasm release package path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,7 +291,7 @@ jobs:
             cp build.em/Release/lib/*.a "${base_libs}/lib/" 2>/dev/null || echo "No .a files in lib/"
             cp build.em/external/lz4/build/cmake/Release/liblz4.a "${base_libs}/lib/" 2>/dev/null || true
             cp build.em/external/miniz/Release/libminiz.a "${base_libs}/lib/" 2>/dev/null || true
-            cp build.em/external/cmark/src/libcmark-gfm.a "${base_libs}/lib/"
+            cp build.em/external/cmark/src/Release/libcmark-gfm.a "${base_libs}/lib/"
             cp build.em/Release/include/*.h "${base_libs}/include/"
             (cd "${base_libs}" && zip -r "../${base_libs}.zip" .)
             echo "SLANG_WASM_LIBS_ARCHIVE=${base_libs}.zip" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Fixes the release workflow failure introduced by packaging libcmark-gfm.a from the wrong path. The Emscripten build uses the multi-config output directory, so the archive is produced at build.em/external/cmark/src/Release/libcmark-gfm.a.\n\nValidation:\n- git diff --check -- .github/workflows/release.yml\n- YAML parse for .github/workflows/release.yml