### PR TITLE
ci_health: detach Queued series from hosted-runner in-use stack

### DIFF
--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -947,6 +947,7 @@ function buildCharts(hours) {{
       backgroundColor: 'rgba(255,193,7,0.0)',
       fill: false,
       tension: 0.3,
+      stack: 'queued',
     }});
     hostedDatasets.push({{
       label: 'Cap (' + hostedRunnerChart.cap + ')',


### PR DESCRIPTION
## Summary

The Queued line dataset in the hosted-runner chart on `ci_health.html` shared the stacked y-axis (`stacked: true`) with the per-label in-use datasets. Chart.js stacks any dataset that doesn't opt out, so the Queued series was being piled on top of the in-use total — visually pushing the chart above the 20-runner cap whenever `queued > 0`, even though the numeric banner and tooltip remained correct.

Give the Queued dataset its own `stack: 'queued'` so it renders as an independent line.