### PR TITLE
Fix crash when ConstantBuffer<T>.Handle is used with spvDescriptorHeapEXT (#11037)

### DIFF
--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -2610,11 +2610,14 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 auto elementType = constantBufferType->getElementType();
                 SLANG_ASSERT(as<IRStructType>(elementType));
                 builder.addDecorationIfNotExist(elementType, kIROp_SPIRVBlockDecoration);
+                auto dataLayout = constantBufferType->getDataLayout();
+                if (!dataLayout)
+                    dataLayout = builder.getDefaultBufferLayoutType();
                 t->replaceUsesWith(builder.getPtrType(
                     elementType,
                     AccessQualifier::Immutable,
                     AddressSpace::Uniform,
-                    constantBufferType->getDataLayout()));
+                    dataLayout));
             }
         }
         for (auto t : textureFootprintTypes)

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -24,6 +24,7 @@
 #include "slang-ir-specialize-address-space.h"
 #include "slang-ir-util.h"
 #include "slang-ir-validate.h"
+#include "slang-ir-wrap-cbuffer-element.h"
 #include "slang-ir.h"
 #include "slang-legalize-types.h"
 #include "slang-rich-diagnostics.h"
@@ -2601,6 +2602,40 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             t->replaceUsesWith(lowered);
         }
 
+        // Translate ConstantBuffer<T> types used in the descriptor heap path.
+        // When ConstantBuffer<T>.Handle is accessed with spvDescriptorHeapEXT, the
+        // SPIRVLoadDescriptorFromHeap instruction has result type ConstantBuffer<T>.
+        // The SPIRV emit code expects buffer result types to be lowered to pointers,
+        // so replace ConstantBuffer<T> with Ptr<T, Uniform> here. Non-struct element
+        // types are wrapped earlier by wrapCBufferElementsForSPIRV, matching the
+        // treatment for traditionally-bound constant buffers.
+        // Note: ParameterBlock<T> is intentionally excluded because it does not conform
+        // to IOpaqueDescriptor and therefore cannot appear as a DescriptorHandle argument.
+        {
+            List<IRUniformParameterGroupType*> cbufferTypesToProcess;
+            for (auto globalInst : m_module->getGlobalInsts())
+            {
+                if (!as<IRConstantBufferType>(globalInst))
+                    continue;
+                auto t = as<IRUniformParameterGroupType>(globalInst);
+                if (t->hasUses())
+                    cbufferTypesToProcess.add(t);
+            }
+            for (auto t : cbufferTypesToProcess)
+            {
+                IRBuilder builder(m_sharedContext->m_irModule);
+                builder.setInsertBefore(t);
+                auto elementType = t->getElementType();
+                SLANG_ASSERT(as<IRStructType>(elementType));
+                builder.addDecorationIfNotExist(elementType, kIROp_SPIRVBlockDecoration);
+                t->replaceUsesWith(builder.getPtrType(
+                    elementType,
+                    AccessQualifier::ReadWrite,
+                    AddressSpace::Uniform,
+                    t->getDataLayout()));
+            }
+        }
+
         // If older than spirv 1.4, we need more legalization steps due to lack of opcodes.
         if (!m_sharedContext->isSpirv14OrLater())
         {
@@ -2715,6 +2750,21 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         }
     }
 };
+
+class SPIRVWrapCBufferElementPolicy : public WrapCBufferElementPolicy
+{
+public:
+    bool shouldWrapBufferElementInStruct(IRParameterGroupType* cbufferType) override
+    {
+        return !as<IRStructType>(cbufferType->getElementType());
+    }
+};
+
+static void wrapCBufferElementsForSPIRV(IRModule* module)
+{
+    SPIRVWrapCBufferElementPolicy policy = {};
+    wrapCBufferElements(module, &policy);
+}
 
 SpvSnippet* SPIRVEmitSharedContext::getParsedSpvSnippet(IRTargetIntrinsicDecoration* intrinsic)
 {
@@ -2981,6 +3031,7 @@ void legalizeIRForSPIRV(
     CodeGenContext* codeGenContext)
 {
     SLANG_UNUSED(entryPoints);
+    wrapCBufferElementsForSPIRV(module);
     legalizeSPIRV(context, module, codeGenContext);
     simplifyIRForSpirvLegalization(context->m_targetProgram, codeGenContext->getSink(), module);
 

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -2607,7 +2607,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                     getStorageBufferAddressSpace(),
                     structuredBufferType->getDataLayout()));
             }
-            else if (auto constantBufferType = as<IRUniformParameterGroupType>(t))
+            else if (auto constantBufferType = as<IRConstantBufferType>(t))
             {
                 auto elementType = constantBufferType->getElementType();
                 SLANG_ASSERT(as<IRStructType>(elementType));

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -238,6 +238,9 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             parameterGroupType->getOp(),
             (UInt)bufferTypeOperands.getCount(),
             bufferTypeOperands.getArrayView().getBuffer()));
+        auto rules = getTypeLayoutRuleForBuffer(m_sharedContext->m_targetProgram, newCbType);
+        IRSizeAndAlignment sizeAlignment;
+        getSizeAndAlignment(m_sharedContext->m_targetRequest, rules, structType, &sizeAlignment);
         return WrappedCBufferElementInfo{structType, key, newCbType};
     }
 
@@ -276,15 +279,6 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         auto wrapped = createWrappedConstantBufferElementType(parameterGroupType);
         cbParamInst->setFullType(wrapped.parameterGroupType);
         replaceUsesWithWrappedConstantBufferElement(cbParamInst, wrapped.key, innerType);
-        auto rules = getTypeLayoutRuleForBuffer(
-            m_sharedContext->m_targetProgram,
-            cbParamInst->getDataType());
-        IRSizeAndAlignment sizeAlignment;
-        getSizeAndAlignment(
-            m_sharedContext->m_targetRequest,
-            rules,
-            wrapped.structType,
-            &sizeAlignment);
         return wrapped.structType;
     }
 
@@ -314,9 +308,6 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                     if (user->getFullType() == constantBufferType)
                         instsToUnwrap.add(user);
                 });
-
-            if (!instsToUnwrap.getCount())
-                continue;
 
             auto innerType = constantBufferType->getElementType();
             auto wrapped = createWrappedConstantBufferElementType(constantBufferType);

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -212,6 +212,8 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
     {
     }
 
+    // Creates the wrapper struct and matching parameter-group type for a non-struct constant
+    // buffer element, preserving layout operands and caching the wrapper layout decorations.
     WrappedCBufferElementInfo createWrappedConstantBufferElementType(
         IRParameterGroupType* parameterGroupType)
     {
@@ -244,6 +246,8 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         return WrappedCBufferElementInfo{structType, key, newCbType};
     }
 
+    // Rewrites value users of a constant-buffer value to read through the single field of the
+    // synthesized wrapper struct.
     void replaceUsesWithWrappedConstantBufferElement(
         IRInst* cbParamInst,
         IRStructKey* key,
@@ -270,8 +274,9 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             });
     }
 
-    // Wraps the element type of a constant buffer or parameter block in a struct if it is not
-    // already a struct, returns the newly created struct type.
+    // Wraps the element type of a constant buffer or parameter block in a struct. This mutates
+    // cbParamInst in place by changing its full type to the wrapped parameter-group type and
+    // rewriting existing value uses to field addresses. Returns the wrapper struct type.
     IRType* wrapConstantBufferElement(IRInst* cbParamInst)
     {
         auto parameterGroupType = as<IRParameterGroupType>(cbParamInst->getDataType());
@@ -282,6 +287,9 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         return wrapped.structType;
     }
 
+    // Wraps used non-struct IRConstantBufferType globals before SPIR-V type translation. This
+    // handles descriptor-handle operands that refer to the type directly rather than going
+    // through processGlobalParam.
     void wrapRemainingConstantBufferElementTypes()
     {
         List<IRConstantBufferType*> constantBufferTypes;

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -455,6 +455,8 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 auto uniformParamGroupType = as<IRUniformParameterGroupType>(innerType);
                 innerType = uniformParamGroupType->getElementType();
                 dataLayout = uniformParamGroupType->getDataLayout();
+                if (!dataLayout)
+                    dataLayout = builder.getDefaultBufferLayoutType();
                 if (addressSpace == AddressSpace::ThreadLocal)
                     addressSpace = AddressSpace::Uniform;
                 // Constant buffer is already treated like a pointer type, and

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -24,7 +24,6 @@
 #include "slang-ir-specialize-address-space.h"
 #include "slang-ir-util.h"
 #include "slang-ir-validate.h"
-#include "slang-ir-wrap-cbuffer-element.h"
 #include "slang-ir.h"
 #include "slang-legalize-types.h"
 #include "slang-rich-diagnostics.h"
@@ -35,8 +34,6 @@ namespace Slang
 //
 // Legalization of IR for direct SPIRV emit.
 //
-
-static void wrapCBufferElementsForSPIRV(IRModule* module);
 
 struct SPIRVLegalizationContext : public SourceEmitterBase
 {
@@ -55,6 +52,13 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         IRArrayTypeBase* runtimeArrayType;
     };
     Dictionary<IRType*, LoweredStructuredBufferTypeInfo> m_loweredStructuredBufferTypes;
+
+    struct WrappedCBufferElementInfo
+    {
+        IRStructType* structType;
+        IRStructKey* key;
+        IRParameterGroupType* parameterGroupType;
+    };
 
     IRInst* lowerTextureFootprintType(IRInst* footprintType)
     {
@@ -208,13 +212,12 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
     {
     }
 
-    // Wraps the element type of a constant buffer or parameter block in a struct if it is not
-    // already a struct, returns the newly created struct type.
-    IRType* wrapConstantBufferElement(IRInst* cbParamInst)
+    WrappedCBufferElementInfo createWrappedConstantBufferElementType(
+        IRParameterGroupType* parameterGroupType)
     {
-        auto innerType = as<IRParameterGroupType>(cbParamInst->getDataType())->getElementType();
-        IRBuilder builder(cbParamInst);
-        builder.setInsertBefore(cbParamInst);
+        auto innerType = parameterGroupType->getElementType();
+        IRBuilder builder(parameterGroupType);
+        builder.setInsertBefore(parameterGroupType);
         auto structType = builder.createStructType();
         builder.addPhysicalTypeDecoration(structType);
         addToWorkList(structType);
@@ -225,14 +228,25 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         builder.addNameHintDecoration(structType, sb.produceString().getUnownedSlice());
         auto key = builder.createStructKey();
         builder.createStructField(structType, key, innerType);
-        builder.setInsertBefore(cbParamInst);
-        auto newCbType = builder.getType(cbParamInst->getDataType()->getOp(), structType);
-        cbParamInst->setFullType(newCbType);
-        auto rules = getTypeLayoutRuleForBuffer(
-            m_sharedContext->m_targetProgram,
-            cbParamInst->getDataType());
-        IRSizeAndAlignment sizeAlignment;
-        getSizeAndAlignment(m_sharedContext->m_targetRequest, rules, structType, &sizeAlignment);
+
+        List<IRInst*> bufferTypeOperands;
+        bufferTypeOperands.add(structType);
+        for (UInt i = 1; i < parameterGroupType->getOperandCount(); i++)
+            bufferTypeOperands.add(parameterGroupType->getOperand(i));
+
+        auto newCbType = as<IRParameterGroupType>(builder.getType(
+            parameterGroupType->getOp(),
+            (UInt)bufferTypeOperands.getCount(),
+            bufferTypeOperands.getArrayView().getBuffer()));
+        return WrappedCBufferElementInfo{structType, key, newCbType};
+    }
+
+    void replaceUsesWithWrappedConstantBufferElement(
+        IRInst* cbParamInst,
+        IRStructKey* key,
+        IRType* innerType)
+    {
+        IRBuilder builder(cbParamInst);
         traverseUses(
             cbParamInst,
             [&](IRUse* use)
@@ -251,7 +265,67 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                     key);
                 use->set(addr);
             });
-        return structType;
+    }
+
+    // Wraps the element type of a constant buffer or parameter block in a struct if it is not
+    // already a struct, returns the newly created struct type.
+    IRType* wrapConstantBufferElement(IRInst* cbParamInst)
+    {
+        auto parameterGroupType = as<IRParameterGroupType>(cbParamInst->getDataType());
+        auto innerType = parameterGroupType->getElementType();
+        auto wrapped = createWrappedConstantBufferElementType(parameterGroupType);
+        cbParamInst->setFullType(wrapped.parameterGroupType);
+        replaceUsesWithWrappedConstantBufferElement(cbParamInst, wrapped.key, innerType);
+        auto rules = getTypeLayoutRuleForBuffer(
+            m_sharedContext->m_targetProgram,
+            cbParamInst->getDataType());
+        IRSizeAndAlignment sizeAlignment;
+        getSizeAndAlignment(
+            m_sharedContext->m_targetRequest,
+            rules,
+            wrapped.structType,
+            &sizeAlignment);
+        return wrapped.structType;
+    }
+
+    void wrapRemainingConstantBufferElementTypes()
+    {
+        List<IRConstantBufferType*> constantBufferTypes;
+        for (auto globalInst : m_module->getGlobalInsts())
+        {
+            auto constantBufferType = as<IRConstantBufferType>(globalInst);
+            if (!constantBufferType)
+                continue;
+            if (!constantBufferType->hasUses())
+                continue;
+            if (as<IRStructType>(constantBufferType->getElementType()))
+                continue;
+            constantBufferTypes.add(constantBufferType);
+        }
+
+        for (auto constantBufferType : constantBufferTypes)
+        {
+            List<IRInst*> instsToUnwrap;
+            traverseUses(
+                constantBufferType,
+                [&](IRUse* use)
+                {
+                    auto user = use->getUser();
+                    if (user->getFullType() == constantBufferType)
+                        instsToUnwrap.add(user);
+                });
+
+            if (!instsToUnwrap.getCount())
+                continue;
+
+            auto innerType = constantBufferType->getElementType();
+            auto wrapped = createWrappedConstantBufferElementType(constantBufferType);
+            constantBufferType->replaceUsesWith(wrapped.parameterGroupType);
+            for (auto inst : instsToUnwrap)
+            {
+                replaceUsesWithWrappedConstantBufferElement(inst, wrapped.key, innerType);
+            }
+        }
     }
 
     static void insertLoadAtLatestLocation(
@@ -2566,7 +2640,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         for (auto inst : m_instsToRemove)
             inst->removeAndDeallocate();
 
-        wrapCBufferElementsForSPIRV(m_module);
+        wrapRemainingConstantBufferElementTypes();
 
         // Translate types.
         List<IRType*> instsToProcess;
@@ -2744,22 +2818,6 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         }
     }
 };
-
-class SPIRVWrapCBufferElementPolicy : public WrapCBufferElementPolicy
-{
-public:
-    bool shouldWrapBufferElementInStruct(IRParameterGroupType* cbufferType) override
-    {
-        return as<IRConstantBufferType>(cbufferType) &&
-               !as<IRStructType>(cbufferType->getElementType());
-    }
-};
-
-static void wrapCBufferElementsForSPIRV(IRModule* module)
-{
-    SPIRVWrapCBufferElementPolicy policy = {};
-    wrapCBufferElements(module, &policy);
-}
 
 SpvSnippet* SPIRVEmitSharedContext::getParsedSpvSnippet(IRTargetIntrinsicDecoration* intrinsic)
 {

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -2612,7 +2612,7 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 builder.addDecorationIfNotExist(elementType, kIROp_SPIRVBlockDecoration);
                 t->replaceUsesWith(builder.getPtrType(
                     elementType,
-                    AccessQualifier::ReadWrite,
+                    AccessQualifier::Immutable,
                     AddressSpace::Uniform,
                     constantBufferType->getDataLayout()));
             }

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -274,9 +274,9 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             });
     }
 
-    // Wraps the element type of a constant buffer or parameter block in a struct. This mutates
-    // cbParamInst in place by changing its full type to the wrapped parameter-group type and
-    // rewriting existing value uses to field addresses. Returns the wrapper struct type.
+    // Wraps the element type of a non-array constant buffer or parameter block in a struct. This
+    // mutates cbParamInst in place by changing its full type to the wrapped parameter-group type
+    // and rewriting existing value uses to field addresses. Returns the wrapper struct type.
     IRType* wrapConstantBufferElement(IRInst* cbParamInst)
     {
         auto parameterGroupType = as<IRParameterGroupType>(cbParamInst->getDataType());
@@ -523,6 +523,8 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             IRType* dataLayout = builder.getDefaultBufferLayoutType();
             auto cbufferType = as<IRConstantBufferType>(innerType);
             auto paramBlockType = as<IRParameterBlockType>(innerType);
+            IRStructKey* wrappedArrayElementKey = nullptr;
+            IRType* wrappedArrayElementType = nullptr;
             if (cbufferType || paramBlockType)
             {
                 auto uniformParamGroupType = as<IRUniformParameterGroupType>(innerType);
@@ -541,7 +543,18 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                 // a struct.
                 if (!as<IRStructType>(innerType))
                 {
-                    innerType = wrapConstantBufferElement(inst);
+                    if (arrayType)
+                    {
+                        wrappedArrayElementType = innerType;
+                        auto wrapped =
+                            createWrappedConstantBufferElementType(uniformParamGroupType);
+                        innerType = wrapped.structType;
+                        wrappedArrayElementKey = wrapped.key;
+                    }
+                    else
+                    {
+                        innerType = wrapConstantBufferElement(inst);
+                    }
                 }
                 builder.addDecorationIfNotExist(innerType, kIROp_SPIRVBlockDecoration);
 
@@ -663,7 +676,19 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
                                     dataLayout),
                                 inst,
                                 getElement->getIndex());
-                            user->replaceUsesWith(newAddr);
+                            IRInst* replacementAddr = newAddr;
+                            if (wrappedArrayElementKey)
+                            {
+                                replacementAddr = builder.emitFieldAddress(
+                                    builder.getPtrType(
+                                        wrappedArrayElementType,
+                                        AccessQualifier::Read,
+                                        addressSpace,
+                                        dataLayout),
+                                    newAddr,
+                                    wrappedArrayElementKey);
+                            }
+                            user->replaceUsesWith(replacementAddr);
                             user->removeAndDeallocate();
                             return;
                         }

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -36,6 +36,8 @@ namespace Slang
 // Legalization of IR for direct SPIRV emit.
 //
 
+static void wrapCBufferElementsForSPIRV(IRModule* module);
+
 struct SPIRVLegalizationContext : public SourceEmitterBase
 {
     SPIRVEmitSharedContext* m_sharedContext;
@@ -2562,8 +2564,10 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         for (auto inst : m_instsToRemove)
             inst->removeAndDeallocate();
 
+        wrapCBufferElementsForSPIRV(m_module);
+
         // Translate types.
-        List<IRHLSLStructuredBufferTypeBase*> instsToProcess;
+        List<IRType*> instsToProcess;
         List<IRInst*> textureFootprintTypes;
 
         for (auto globalInst : m_module->getGlobalInsts())
@@ -2572,6 +2576,11 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             {
                 instsToProcess.add(t);
             }
+            else if (auto constantBufferType = as<IRConstantBufferType>(globalInst))
+            {
+                if (constantBufferType->hasUses())
+                    instsToProcess.add(constantBufferType);
+            }
             else if (globalInst->getOp() == kIROp_TextureFootprintType)
             {
                 textureFootprintTypes.add(globalInst);
@@ -2579,20 +2588,34 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
         }
         for (auto t : instsToProcess)
         {
-            auto lowered = lowerStructuredBufferType(t);
-
-            AccessQualifier accessQualifier = AccessQualifier::ReadWrite;
-            if (as<IRHLSLStructuredBufferType>(t))
-                accessQualifier = AccessQualifier::Immutable;
-
             IRBuilder builder(t);
 
             builder.setInsertBefore(t);
-            t->replaceUsesWith(builder.getPtrType(
-                lowered.structType,
-                accessQualifier,
-                getStorageBufferAddressSpace(),
-                t->getDataLayout()));
+            if (auto structuredBufferType = as<IRHLSLStructuredBufferTypeBase>(t))
+            {
+                auto lowered = lowerStructuredBufferType(structuredBufferType);
+
+                AccessQualifier accessQualifier = AccessQualifier::ReadWrite;
+                if (as<IRHLSLStructuredBufferType>(t))
+                    accessQualifier = AccessQualifier::Immutable;
+
+                t->replaceUsesWith(builder.getPtrType(
+                    lowered.structType,
+                    accessQualifier,
+                    getStorageBufferAddressSpace(),
+                    structuredBufferType->getDataLayout()));
+            }
+            else if (auto constantBufferType = as<IRUniformParameterGroupType>(t))
+            {
+                auto elementType = constantBufferType->getElementType();
+                SLANG_ASSERT(as<IRStructType>(elementType));
+                builder.addDecorationIfNotExist(elementType, kIROp_SPIRVBlockDecoration);
+                t->replaceUsesWith(builder.getPtrType(
+                    elementType,
+                    AccessQualifier::ReadWrite,
+                    AddressSpace::Uniform,
+                    constantBufferType->getDataLayout()));
+            }
         }
         for (auto t : textureFootprintTypes)
         {
@@ -2600,40 +2623,6 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             IRBuilder builder(t);
             builder.setInsertBefore(t);
             t->replaceUsesWith(lowered);
-        }
-
-        // Translate ConstantBuffer<T> types used in the descriptor heap path.
-        // When ConstantBuffer<T>.Handle is accessed with spvDescriptorHeapEXT, the
-        // SPIRVLoadDescriptorFromHeap instruction has result type ConstantBuffer<T>.
-        // The SPIRV emit code expects buffer result types to be lowered to pointers,
-        // so replace ConstantBuffer<T> with Ptr<T, Uniform> here. Non-struct element
-        // types are wrapped earlier by wrapCBufferElementsForSPIRV, matching the
-        // treatment for traditionally-bound constant buffers.
-        // Note: ParameterBlock<T> is intentionally excluded because it does not conform
-        // to IOpaqueDescriptor and therefore cannot appear as a DescriptorHandle argument.
-        {
-            List<IRUniformParameterGroupType*> cbufferTypesToProcess;
-            for (auto globalInst : m_module->getGlobalInsts())
-            {
-                if (!as<IRConstantBufferType>(globalInst))
-                    continue;
-                auto t = as<IRUniformParameterGroupType>(globalInst);
-                if (t->hasUses())
-                    cbufferTypesToProcess.add(t);
-            }
-            for (auto t : cbufferTypesToProcess)
-            {
-                IRBuilder builder(m_sharedContext->m_irModule);
-                builder.setInsertBefore(t);
-                auto elementType = t->getElementType();
-                SLANG_ASSERT(as<IRStructType>(elementType));
-                builder.addDecorationIfNotExist(elementType, kIROp_SPIRVBlockDecoration);
-                t->replaceUsesWith(builder.getPtrType(
-                    elementType,
-                    AccessQualifier::ReadWrite,
-                    AddressSpace::Uniform,
-                    t->getDataLayout()));
-            }
         }
 
         // If older than spirv 1.4, we need more legalization steps due to lack of opcodes.
@@ -2756,7 +2745,8 @@ class SPIRVWrapCBufferElementPolicy : public WrapCBufferElementPolicy
 public:
     bool shouldWrapBufferElementInStruct(IRParameterGroupType* cbufferType) override
     {
-        return !as<IRStructType>(cbufferType->getElementType());
+        return as<IRConstantBufferType>(cbufferType) &&
+               !as<IRStructType>(cbufferType->getElementType());
     }
 };
 
@@ -3031,7 +3021,6 @@ void legalizeIRForSPIRV(
     CodeGenContext* codeGenContext)
 {
     SLANG_UNUSED(entryPoints);
-    wrapCBufferElementsForSPIRV(module);
     legalizeSPIRV(context, module, codeGenContext);
     simplifyIRForSpirvLegalization(context->m_targetProgram, codeGenContext->getSink(), module);
 

--- a/tests/spirv/constant-buffer-array-non-struct.slang
+++ b/tests/spirv/constant-buffer-array-non-struct.slang
@@ -22,5 +22,5 @@ void main(uint3 tid : SV_DispatchThreadID)
 // CHECK: %[[ARRAY:_arr_cbuffer_float_t_int_4]] = OpTypeArray %[[CB]] %int_4
 // CHECK: %[[ARRAY_PTR:_ptr_Uniform__arr_cbuffer_float_t_int_4]] = OpTypePointer Uniform %[[ARRAY]]
 // CHECK: %[[CB_PTR:_ptr_Uniform_cbuffer_float_t]] = OpTypePointer Uniform %[[CB]]
-// CHECK: OpAccessChain %[[CB_PTR]] %inputs
-// CHECK: OpAccessChain %_ptr_Uniform_float
+// CHECK: %[[ELEM_ADDR:[A-Za-z0-9_]+]] = OpAccessChain %[[CB_PTR]] %inputs %[[INDEX:[A-Za-z0-9_]+]]
+// CHECK: OpAccessChain %_ptr_Uniform_float %[[ELEM_ADDR]] %int_0

--- a/tests/spirv/constant-buffer-array-non-struct.slang
+++ b/tests/spirv/constant-buffer-array-non-struct.slang
@@ -1,0 +1,26 @@
+// Regression test: arrays of ConstantBuffer<T> with a non-struct element type
+// should preserve the outer array while wrapping T in a SPIR-V block struct.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main -stage compute -capability spvDescriptorHeapEXT
+
+[[vk::binding(0, 0)]]
+ConstantBuffer<float> inputs[4];
+
+RWStructuredBuffer<float> output;
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID)
+{
+    uint index = tid.x & 3;
+    output[0] = inputs[index];
+}
+
+// CHECK: OpName %[[CB:cbuffer_float_t]] "cbuffer_float_t"
+// CHECK: OpDecorate %[[CB]] Block
+// CHECK: OpMemberDecorate %[[CB]] 0 Offset 0
+// CHECK: %[[ARRAY:_arr_cbuffer_float_t_int_4]] = OpTypeArray %[[CB]] %int_4
+// CHECK: %[[ARRAY_PTR:_ptr_Uniform__arr_cbuffer_float_t_int_4]] = OpTypePointer Uniform %[[ARRAY]]
+// CHECK: %[[CB_PTR:_ptr_Uniform_cbuffer_float_t]] = OpTypePointer Uniform %[[CB]]
+// CHECK: OpAccessChain %[[CB_PTR]] %inputs
+// CHECK: OpAccessChain %_ptr_Uniform_float

--- a/tests/spirv/descriptor-heap-constant-buffer-non-struct.slang
+++ b/tests/spirv/descriptor-heap-constant-buffer-non-struct.slang
@@ -6,6 +6,7 @@
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main2 -stage compute -capability spvDescriptorHeapEXT
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main3 -stage compute -capability spvDescriptorHeapEXT
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main4 -stage compute -capability spvDescriptorHeapEXT
+//TEST:SIMPLE(filecheck=SHARED): -target spirv-asm -entry mainShared -stage compute -capability spvDescriptorHeapEXT
 
 [shader("compute")]
 [NumThreads(1, 1, 1)]
@@ -43,8 +44,23 @@ void main4(
     output[0] = getDescriptorFromHandle(input)[2];
 }
 
+// Use the same ConstantBuffer<T> type twice so the legalization pass has to
+// wrap the type once and rewrite both value users.
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void mainShared(
+    uniform DescriptorHandle<ConstantBuffer<float>> left,
+    uniform DescriptorHandle<ConstantBuffer<float>> right,
+    uniform DescriptorHandle<RWStructuredBuffer<float>> output)
+{
+    output[0] = getDescriptorFromHandle(left) + getDescriptorFromHandle(right);
+}
+
 // The synthesized wrapper must carry Block decoration (required for Uniform storage class).
-// CHECK: OpDecorate {{.*}} Block
+// CHECK: OpDecorate %{{(cbuffer_.*_t|_Array_std140_float4)}} Block
+
+// The synthesized wrapper must carry member layout decoration.
+// CHECK: OpMemberDecorate %{{(cbuffer_.*_t|_Array_std140_float4)}} 0 Offset 0
 
 // The pointer to the uniform block must be in Uniform storage class.
 // CHECK: OpTypePointer Uniform
@@ -55,3 +71,10 @@ void main4(
 // Access to the wrapped element must use Uniform storage class, not Function.
 // CHECK-NOT: OpAccessChain %_ptr_Function
 // CHECK: OpAccessChain %_ptr_Uniform
+
+// SHARED-COUNT-1: OpDecorate %cbuffer_float_t Block
+// SHARED: OpMemberDecorate %cbuffer_float_t 0 Offset 0
+// SHARED: OpBufferPointerEXT %_ptr_Uniform_cbuffer_float_t
+// SHARED: OpAccessChain %_ptr_Uniform_float
+// SHARED: OpBufferPointerEXT %_ptr_Uniform_cbuffer_float_t
+// SHARED: OpAccessChain %_ptr_Uniform_float

--- a/tests/spirv/descriptor-heap-constant-buffer-non-struct.slang
+++ b/tests/spirv/descriptor-heap-constant-buffer-non-struct.slang
@@ -1,10 +1,11 @@
 // Regression test: ConstantBuffer<T>.Handle with a non-struct element type and
 // spvDescriptorHeapEXT should compile by wrapping T in a SPIR-V block struct.
-// Tests vector, scalar, and matrix element types.
+// Tests vector, scalar, matrix, and array element types.
 
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main1 -stage compute -capability spvDescriptorHeapEXT
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main2 -stage compute -capability spvDescriptorHeapEXT
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main3 -stage compute -capability spvDescriptorHeapEXT
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main4 -stage compute -capability spvDescriptorHeapEXT
 
 [shader("compute")]
 [NumThreads(1, 1, 1)]
@@ -31,6 +32,15 @@ void main3(
     uniform DescriptorHandle<RWStructuredBuffer<float4x4>> output)
 {
     output[0] = getDescriptorFromHandle(input);
+}
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main4(
+    uniform DescriptorHandle<ConstantBuffer<float[4]>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<float>> output)
+{
+    output[0] = getDescriptorFromHandle(input)[2];
 }
 
 // The synthesized wrapper must carry Block decoration (required for Uniform storage class).

--- a/tests/spirv/descriptor-heap-constant-buffer-non-struct.slang
+++ b/tests/spirv/descriptor-heap-constant-buffer-non-struct.slang
@@ -1,0 +1,47 @@
+// Regression test: ConstantBuffer<T>.Handle with a non-struct element type and
+// spvDescriptorHeapEXT should compile by wrapping T in a SPIR-V block struct.
+// Tests vector, scalar, and matrix element types.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main1 -stage compute -capability spvDescriptorHeapEXT
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main2 -stage compute -capability spvDescriptorHeapEXT
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main3 -stage compute -capability spvDescriptorHeapEXT
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main1(
+    uniform DescriptorHandle<ConstantBuffer<float2>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<float2>> output)
+{
+    output[0] = getDescriptorFromHandle(input);
+}
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main2(
+    uniform DescriptorHandle<ConstantBuffer<float>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<float>> output)
+{
+    output[0] = getDescriptorFromHandle(input);
+}
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main3(
+    uniform DescriptorHandle<ConstantBuffer<float4x4>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<float4x4>> output)
+{
+    output[0] = getDescriptorFromHandle(input);
+}
+
+// The synthesized wrapper must carry Block decoration (required for Uniform storage class).
+// CHECK: OpDecorate {{.*}} Block
+
+// The pointer to the uniform block must be in Uniform storage class.
+// CHECK: OpTypePointer Uniform
+
+// The descriptor-heap access must produce a buffer pointer.
+// CHECK: OpBufferPointerEXT
+
+// Access to the wrapped element must use Uniform storage class, not Function.
+// CHECK-NOT: OpAccessChain %_ptr_Function
+// CHECK: OpAccessChain %_ptr_Uniform

--- a/tests/spirv/descriptor-heap-constant-buffer-non-struct.slang
+++ b/tests/spirv/descriptor-heap-constant-buffer-non-struct.slang
@@ -7,6 +7,7 @@
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main3 -stage compute -capability spvDescriptorHeapEXT
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main4 -stage compute -capability spvDescriptorHeapEXT
 //TEST:SIMPLE(filecheck=SHARED): -target spirv-asm -entry mainShared -stage compute -capability spvDescriptorHeapEXT
+//TEST:SIMPLE(filecheck=HANDLE_ARRAY): -target spirv-asm -entry mainHandleArray -stage compute -capability spvDescriptorHeapEXT
 
 [shader("compute")]
 [NumThreads(1, 1, 1)]
@@ -56,25 +57,54 @@ void mainShared(
     output[0] = getDescriptorFromHandle(left) + getDescriptorFromHandle(right);
 }
 
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void mainHandleArray(
+    uniform ConstantBuffer<float>.Handle inputs[4],
+    uniform DescriptorHandle<RWStructuredBuffer<float>> output,
+    uint3 tid : SV_DispatchThreadID)
+{
+    uint index = tid.x & 3;
+    output[0] = getDescriptorFromHandle(inputs[index]);
+}
+
 // The synthesized wrapper must carry Block decoration (required for Uniform storage class).
-// CHECK: OpDecorate %{{(cbuffer_.*_t|_Array_std140_float4)}} Block
+// CHECK: OpName %[[CB:(cbuffer_[A-Za-z0-9_]+_t|_Array_std140_float4)]]
+// CHECK-NOT: %_ptr_Function_[[CB]]
+// CHECK: OpDecorate %[[CB]] Block
 
 // The synthesized wrapper must carry member layout decoration.
-// CHECK: OpMemberDecorate %{{(cbuffer_.*_t|_Array_std140_float4)}} 0 Offset 0
+// CHECK: OpMemberDecorate %[[CB]] 0 Offset 0
 
 // The pointer to the uniform block must be in Uniform storage class.
-// CHECK: OpTypePointer Uniform
+// CHECK-NOT: %_ptr_Function_[[CB]]
+// CHECK: %[[CB_PTR:_ptr_Uniform_[A-Za-z0-9_]+]] = OpTypePointer Uniform %[[CB]]
 
 // The descriptor-heap access must produce a buffer pointer.
-// CHECK: OpBufferPointerEXT
+// CHECK-NOT: %_ptr_Function_[[CB]]
+// CHECK: OpBufferPointerEXT %[[CB_PTR]]
 
 // Access to the wrapped element must use Uniform storage class, not Function.
-// CHECK-NOT: OpAccessChain %_ptr_Function
 // CHECK: OpAccessChain %_ptr_Uniform
+// CHECK-NOT: %_ptr_Function_[[CB]]
 
-// SHARED-COUNT-1: OpDecorate %cbuffer_float_t Block
-// SHARED: OpMemberDecorate %cbuffer_float_t 0 Offset 0
-// SHARED: OpBufferPointerEXT %_ptr_Uniform_cbuffer_float_t
+// SHARED: OpName %[[CB:cbuffer_float_t]] "cbuffer_float_t"
+// SHARED-NOT: cbuffer_float_t_
+// SHARED: OpDecorate %[[CB]] Block
+// SHARED-NOT: cbuffer_float_t_
+// SHARED: OpMemberDecorate %[[CB]] 0 Offset 0
+// SHARED: %[[CB_PTR:_ptr_Uniform_cbuffer_float_t]] = OpTypePointer Uniform %[[CB]]
+// SHARED-NOT: cbuffer_float_t_
+// SHARED: OpBufferPointerEXT %[[CB_PTR]]
 // SHARED: OpAccessChain %_ptr_Uniform_float
-// SHARED: OpBufferPointerEXT %_ptr_Uniform_cbuffer_float_t
+// SHARED: OpBufferPointerEXT %[[CB_PTR]]
 // SHARED: OpAccessChain %_ptr_Uniform_float
+// SHARED-NOT: cbuffer_float_t_
+
+// HANDLE_ARRAY: OpName %[[CB:cbuffer_float_t]] "cbuffer_float_t"
+// HANDLE_ARRAY: OpDecorate %[[CB]] Block
+// HANDLE_ARRAY: OpMemberDecorate %[[CB]] 0 Offset 0
+// HANDLE_ARRAY: %[[CB_PTR:_ptr_Uniform_cbuffer_float_t]] = OpTypePointer Uniform %[[CB]]
+// HANDLE_ARRAY: OpAccessChain %_ptr_PushConstant__arr_v2uint_int_4
+// HANDLE_ARRAY: OpBufferPointerEXT %[[CB_PTR]]
+// HANDLE_ARRAY: OpAccessChain %_ptr_Uniform_float

--- a/tests/spirv/descriptor-heap-constant-buffer-wrapped-vector.slang
+++ b/tests/spirv/descriptor-heap-constant-buffer-wrapped-vector.slang
@@ -1,0 +1,23 @@
+// Regression test: verifies that an explicitly wrapped element type still compiles
+// successfully and produces correct Uniform-storage-class SPIRV.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main -stage compute -capability spvDescriptorHeapEXT
+
+struct MyConstants {
+    float2 value;
+}
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main(
+    uniform DescriptorHandle<ConstantBuffer<MyConstants>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<float2>> output)
+{
+    output[0] = getDescriptorFromHandle(input).value;
+}
+
+// CHECK: OpDecorate {{.*}}MyConstants{{.*}} Block
+// CHECK: OpTypePointer Uniform
+// CHECK: OpBufferPointerEXT
+// CHECK-NOT: OpAccessChain %_ptr_Function
+// CHECK: OpAccessChain %_ptr_Uniform

--- a/tests/spirv/descriptor-heap-constant-buffer-wrapped-vector.slang
+++ b/tests/spirv/descriptor-heap-constant-buffer-wrapped-vector.slang
@@ -16,8 +16,12 @@ void main(
     output[0] = getDescriptorFromHandle(input).value;
 }
 
-// CHECK: OpDecorate {{.*}}MyConstants{{.*}} Block
-// CHECK: OpTypePointer Uniform
-// CHECK: OpBufferPointerEXT
-// CHECK-NOT: OpAccessChain %_ptr_Function
-// CHECK: OpAccessChain %_ptr_Uniform
+// CHECK: OpName %[[CB:MyConstants_std140]] "MyConstants_std140"
+// CHECK-NOT: %_ptr_Function_[[CB]]
+// CHECK: OpDecorate %[[CB]] Block
+// CHECK-NOT: %_ptr_Function_[[CB]]
+// CHECK: %[[CB_PTR:_ptr_Uniform_MyConstants_std140]] = OpTypePointer Uniform %[[CB]]
+// CHECK-NOT: %_ptr_Function_[[CB]]
+// CHECK: OpBufferPointerEXT %[[CB_PTR]]
+// CHECK: OpAccessChain %_ptr_Uniform_v2float
+// CHECK-NOT: %_ptr_Function_[[CB]]

--- a/tests/spirv/descriptor-heap-constant-buffer.slang
+++ b/tests/spirv/descriptor-heap-constant-buffer.slang
@@ -5,9 +5,14 @@
 // so the SPIRV emitter's getDescriptorHeapBufferStorageClass hit an assertion.
 
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main -stage compute -capability spvDescriptorHeapEXT
+//TEST:SIMPLE(filecheck=SHARED_STRUCT): -target spirv-asm -entry mainSharedStruct -stage compute -capability spvDescriptorHeapEXT
 
 struct Uniforms {
     uint x;
+}
+
+struct SharedUniforms {
+    uint v;
 }
 
 [shader("compute")]
@@ -19,15 +24,38 @@ void main(
     output[0] = getDescriptorFromHandle(input).x;
 }
 
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void mainSharedStruct(
+    uniform DescriptorHandle<ConstantBuffer<SharedUniforms>> input,
+    uniform DescriptorHandle<StructuredBuffer<SharedUniforms>> values,
+    uniform DescriptorHandle<RWStructuredBuffer<uint>> output)
+{
+    output[0] = getDescriptorFromHandle(input).v + getDescriptorFromHandle(values)[0].v;
+}
+
 // The struct must carry Block decoration (required for Uniform storage class).
-// CHECK: OpDecorate {{.*}}Uniforms{{.*}} Block
+// CHECK: OpName %[[CB:Uniforms_std140]] "Uniforms_std140"
+// CHECK-NOT: %_ptr_Function_[[CB]]
+// CHECK: OpDecorate %[[CB]] Block
 
 // The pointer to the uniform block must be in Uniform storage class.
-// CHECK: OpTypePointer Uniform
+// CHECK-NOT: %_ptr_Function_[[CB]]
+// CHECK: %[[CB_PTR:_ptr_Uniform_Uniforms_std140]] = OpTypePointer Uniform %[[CB]]
 
 // The descriptor-heap access must produce a buffer pointer.
-// CHECK: OpBufferPointerEXT
+// CHECK-NOT: %_ptr_Function_[[CB]]
+// CHECK: OpBufferPointerEXT %[[CB_PTR]]
 
 // Field access must use Uniform storage class — not Function.
-// CHECK-NOT: OpAccessChain %_ptr_Function
-// CHECK: OpAccessChain %_ptr_Uniform
+// CHECK: OpAccessChain %_ptr_Uniform_uint
+// CHECK-NOT: %_ptr_Function_[[CB]]
+
+// SHARED_STRUCT: OpName %[[CB:SharedUniforms_std140]] "SharedUniforms_std140"
+// SHARED_STRUCT: OpName %[[SB:SharedUniforms_std430]] "SharedUniforms_std430"
+// SHARED_STRUCT-NOT: OpDecorate %[[SB]] Block
+// SHARED_STRUCT: OpDecorate %[[CB]] Block
+// SHARED_STRUCT: %[[CB_PTR:_ptr_Uniform_SharedUniforms_std140]] = OpTypePointer Uniform %[[CB]]
+// SHARED_STRUCT: %[[SB_PTR:_ptr_StorageBuffer_StructuredBuffer]] = OpTypePointer StorageBuffer %StructuredBuffer
+// SHARED_STRUCT: OpBufferPointerEXT %[[CB_PTR]]
+// SHARED_STRUCT: OpBufferPointerEXT %[[SB_PTR]]

--- a/tests/spirv/descriptor-heap-constant-buffer.slang
+++ b/tests/spirv/descriptor-heap-constant-buffer.slang
@@ -1,0 +1,33 @@
+// Regression test for #11037: segmentation fault (assertion failure) when
+// ConstantBuffer<T>.Handle is used with spvDescriptorHeapEXT.
+//
+// The SPIRV legalize pass was not lowering ConstantBuffer<T> to a Uniform pointer,
+// so the SPIRV emitter's getDescriptorHeapBufferStorageClass hit an assertion.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main -stage compute -capability spvDescriptorHeapEXT
+
+struct Uniforms {
+    uint x;
+}
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main(
+    uniform DescriptorHandle<ConstantBuffer<Uniforms>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<uint>> output)
+{
+    output[0] = getDescriptorFromHandle(input).x;
+}
+
+// The struct must carry Block decoration (required for Uniform storage class).
+// CHECK: OpDecorate {{.*}}Uniforms{{.*}} Block
+
+// The pointer to the uniform block must be in Uniform storage class.
+// CHECK: OpTypePointer Uniform
+
+// The descriptor-heap access must produce a buffer pointer.
+// CHECK: OpBufferPointerEXT
+
+// Field access must use Uniform storage class — not Function.
+// CHECK-NOT: OpAccessChain %_ptr_Function
+// CHECK: OpAccessChain %_ptr_Uniform

--- a/tests/spirv/descriptor-heap-parameter-block-error.slang
+++ b/tests/spirv/descriptor-heap-parameter-block-error.slang
@@ -1,0 +1,18 @@
+// Verify that DescriptorHandle<ParameterBlock<T>> is rejected at the front end
+// because ParameterBlock<T> does not conform to IOpaqueDescriptor.
+// This ensures that if IOpaqueDescriptor conformance rules change, CI catches
+// whether ParameterBlock would then need to be handled in the legalize pass.
+
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target spirv -entry main -stage compute -capability spvDescriptorHeapEXT
+
+struct Uniforms { uint x; }
+
+[shader("compute")]
+[NumThreads(1, 1, 1)]
+void main(
+    // CHECK: error[E38029]
+    uniform DescriptorHandle<ParameterBlock<Uniforms>> input,
+    uniform DescriptorHandle<RWStructuredBuffer<uint>> output)
+{
+    output[0] = getDescriptorFromHandle(input).x;
+}

--- a/tests/spirv/descriptor-heap-parameter-block-error.slang
+++ b/tests/spirv/descriptor-heap-parameter-block-error.slang
@@ -10,7 +10,9 @@ struct Uniforms { uint x; }
 [shader("compute")]
 [NumThreads(1, 1, 1)]
 void main(
-    // CHECK: error[E38029]
+    // CHECK: error[E38029]: type argument doesn't conform to interface
+    // CHECK: type argument 'ParameterBlock<Uniforms>' does not conform
+    // CHECK: required interface 'IOpaqueDescriptor'
     uniform DescriptorHandle<ParameterBlock<Uniforms>> input,
     uniform DescriptorHandle<RWStructuredBuffer<uint>> output)
 {


### PR DESCRIPTION
Fixes #11037

## Summary of the problem from the end user perspective

Using `ConstantBuffer<T>.Handle` with `spvDescriptorHeapEXT` could crash during SPIR-V code generation instead of producing valid descriptor-heap code. The related `ParameterBlock<T>.Handle` case is covered by front-end rejection so it does not reach the same IR lowering path.

### Minimal repro shader; if applicable

```hlsl
struct Uniforms { uint x; }

[shader("compute")]
[NumThreads(1, 1, 1)]
void main(
    uniform DescriptorHandle<ConstantBuffer<Uniforms>> input,
    uniform DescriptorHandle<RWStructuredBuffer<uint>> output)
{
    output[0] = getDescriptorFromHandle(input).x;
}
```

## Root cause

Descriptor-heap access can leave a used `IRConstantBufferType<T>` as the result type of `SPIRVLoadDescriptorFromHeap`. The SPIR-V emitter expects descriptor-heap buffer results to have already been lowered to pointer types, so the remaining constant-buffer type hit an internal assertion.

## Solution in this PR

The SPIR-V legalize pass now wraps non-struct constant-buffer element types before type translation, then lowers remaining used `IRConstantBufferType` globals to `Ptr<T, Uniform>` with the required `Block` decoration. The PR also adds SPIR-V regression coverage for struct, non-struct, and already-wrapped vector constant-buffer elements, plus a `ParameterBlock<T>.Handle` diagnostic test that documents the front-end rejection as load-bearing for this fix.

### Notes to the reviewers; where to focus on

Please focus on the ordering of `wrapCBufferElementsForSPIRV` before SPIR-V type translation, the ConstantBuffer-only lowering path for remaining used global types, and the `ParameterBlock<T>.Handle` test comment that should guide any future change to make `ParameterBlock<T>` descriptor-handle compatible.

## Reviewer Directives (maintained by agent)

- [human @csyonghe] Keep this fix local to `source/slang/slang-ir-spirv-legalize.cpp`; do not pull in the existing `slang-ir-wrap-cbuffer-element` pass in this PR, leaving broader constant-buffer wrapper unification for a follow-up. (https://github.com/shader-slang/slang/pull/11211#discussion_r3283420042)
