### PR TITLE
Fix slang-test launching problem on WSL

### DIFF
--- a/source/core/slang-test-tool-util.cpp
+++ b/source/core/slang-test-tool-util.cpp
@@ -110,16 +110,28 @@ static SlangResult _addCUDAPrelude(const String& rootPath, slang::IGlobalSession
     return SLANG_OK;
 }
 
-// Gets the canonical path for exePath, falling back to /proc/self/exe on Linux
-// when exePath is just a bare command name (e.g., when invoked via PATH).
+// Gets the canonical path for exePath, falling back to the operating system's executable path
+// when exePath is just a bare command name. This happens when invoked via PATH on Linux, and also
+// when a Windows .exe is launched directly through WSL interop.
 static SlangResult _getCanonicalOrExecutablePath(const char* exePath, String& outPath)
 {
-    if (SLANG_SUCCEEDED(Path::getCanonical(exePath, outPath)))
+    if (exePath && Path::hasPath(UnownedStringSlice(exePath)) &&
+        SLANG_SUCCEEDED(Path::getCanonical(exePath, outPath)))
     {
+        // argv[0] already contains enough path information to resolve directly.
+        // Examples:
+        // - "./build/Debug/bin/slang-test" on Linux.
+        // - ".\\build\\Debug\\bin\\slang-test.exe" from cmd.exe.
+        // - "D:\\repo\\build\\Debug\\bin\\slang-test.exe".
         return SLANG_OK;
     }
-    // On Linux, when invoked via PATH, argv[0] is just the bare command name
-    // and realpath() fails. Fall back to /proc/self/exe.
+
+    // argv[0] is missing, only a file name, or could not be canonicalized. Ask the OS for the
+    // actual executable path instead.
+    // Examples:
+    // - "slang-test" when invoked via PATH on Linux.
+    // - "slang-test.exe" when launched directly from WSL as ./build/Debug/bin/slang-test.exe.
+    // - A stale symlink or otherwise non-resolvable path-like argv[0].
     outPath = Path::getExecutablePath();
     if (outPath.getLength() == 0)
     {

--- a/source/core/slang-test-tool-util.cpp
+++ b/source/core/slang-test-tool-util.cpp
@@ -116,7 +116,7 @@ static SlangResult _addCUDAPrelude(const String& rootPath, slang::IGlobalSession
 static SlangResult _getCanonicalOrExecutablePath(const char* exePath, String& outPath)
 {
     if (exePath && Path::hasPath(UnownedStringSlice(exePath)) &&
-        SLANG_SUCCEEDED(Path::getCanonical(exePath, outPath)))
+        SLANG_SUCCEEDED(Path::getCanonical(exePath, outPath)) && File::exists(outPath))
     {
         // argv[0] already contains enough path information to resolve directly.
         // Examples:

--- a/source/core/slang-test-tool-util.cpp
+++ b/source/core/slang-test-tool-util.cpp
@@ -130,7 +130,8 @@ static SlangResult _getCanonicalOrExecutablePath(const char* exePath, String& ou
     // actual executable path instead.
     // Examples:
     // - "slang-test" when invoked via PATH on Linux.
-    // - "slang-test.exe" when launched directly from WSL as ./build/Debug/bin/slang-test.exe.
+    // - "slang-test.exe" when WSL interop strips path information from argv[0]
+    //   (e.g., the user invoked it from WSL with the bin dir on PATH).
     // - A stale symlink or otherwise non-resolvable path-like argv[0].
     outPath = Path::getExecutablePath();
     if (outPath.getLength() == 0)

--- a/tools/slang-unit-test/unit-test-path.cpp
+++ b/tools/slang-unit-test/unit-test-path.cpp
@@ -57,4 +57,20 @@ SLANG_UNIT_TEST(path)
 
         SLANG_CHECK(Path::hasRelativeElement("a:\\what\\..\\.\\..\\is\\.\\..\\this\\.\\"));
     }
+
+    // hasPath: returns true only when the path contains at least one separator.
+    // These cases matter for _getCanonicalOrExecutablePath: bare names must
+    // fall through to the OS-fallback branch even if realpath() would succeed
+    // against cwd.
+    {
+        // Bare names — no separator, no path context.
+        SLANG_CHECK(Path::hasPath(UnownedStringSlice("slang-test")) == false);
+        SLANG_CHECK(Path::hasPath(UnownedStringSlice("slang-test.exe")) == false);
+        SLANG_CHECK(Path::hasPath(UnownedStringSlice("")) == false);
+
+        // Names with explicit path context.
+        SLANG_CHECK(Path::hasPath(UnownedStringSlice("./slang-test")));
+        SLANG_CHECK(Path::hasPath(UnownedStringSlice("/usr/bin/slang-test")));
+        SLANG_CHECK(Path::hasPath(UnownedStringSlice("D:\\foo\\slang-test.exe")));
+    }
 }

--- a/tools/slang-unit-test/unit-test-test-tool-util.cpp
+++ b/tools/slang-unit-test/unit-test-test-tool-util.cpp
@@ -31,9 +31,14 @@ SLANG_UNIT_TEST(testToolUtilBareArgv0)
     SLANG_CHECK(SLANG_SUCCEEDED(TestToolUtil::getExeDirectoryPath("", emptyResult)));
     SLANG_CHECK(emptyResult == Path::getParentDirectory(Path::getExecutablePath()));
 
-    // Path-like but unresolvable — hasPath() == true, getCanonical fails, must fall through.
+#if !SLANG_WINDOWS_FAMILY
+    // Path-like but unresolvable on POSIX — hasPath() == true, realpath() fails for a
+    // non-existent path, so the function must fall through to Path::getExecutablePath().
+    // On Windows _wfullpath() does not validate existence, so this branch cannot be
+    // triggered with a simple missing path there.
     String missingResult;
     SLANG_CHECK(SLANG_SUCCEEDED(
         TestToolUtil::getExeDirectoryPath("/nonexistent/dir/slang-test", missingResult)));
     SLANG_CHECK(missingResult == Path::getParentDirectory(Path::getExecutablePath()));
+#endif
 }

--- a/tools/slang-unit-test/unit-test-test-tool-util.cpp
+++ b/tools/slang-unit-test/unit-test-test-tool-util.cpp
@@ -43,4 +43,13 @@ SLANG_UNIT_TEST(testToolUtilBareArgv0)
         TestToolUtil::getExeDirectoryPath("/nonexistent/dir/slang-test", missingResult)));
     SLANG_CHECK(missingResult.getLength() > 0);
     SLANG_CHECK(missingResult == Path::getParentDirectory(Path::getExecutablePath()));
+
+    // Positive case: a real existing path must take the canonicalization-success
+    // branch, not the OS fallback. This pins the hasPath + File::exists guard.
+    const String selfPath = Path::getExecutablePath();
+    String existingResult;
+    SLANG_CHECK(SLANG_SUCCEEDED(
+        TestToolUtil::getExeDirectoryPath(selfPath.getBuffer(), existingResult)));
+    SLANG_CHECK(existingResult.getLength() > 0);
+    SLANG_CHECK(existingResult == Path::getParentDirectory(selfPath));
 }

--- a/tools/slang-unit-test/unit-test-test-tool-util.cpp
+++ b/tools/slang-unit-test/unit-test-test-tool-util.cpp
@@ -13,32 +13,34 @@ SLANG_UNIT_TEST(testToolUtilBareArgv0)
     // A bare name with no path separator should use the OS-provided exe path.
     String bareResult;
     SLANG_CHECK(SLANG_SUCCEEDED(TestToolUtil::getExeDirectoryPath("slang-test", bareResult)));
+    SLANG_CHECK(bareResult.getLength() > 0);
     SLANG_CHECK(bareResult == Path::getParentDirectory(Path::getExecutablePath()));
 
     // Same for a Windows-style bare name.
     String bareExeResult;
     SLANG_CHECK(
         SLANG_SUCCEEDED(TestToolUtil::getExeDirectoryPath("slang-test.exe", bareExeResult)));
+    SLANG_CHECK(bareExeResult.getLength() > 0);
     SLANG_CHECK(bareExeResult == Path::getParentDirectory(Path::getExecutablePath()));
 
     // nullptr argv[0] — exercises the new null guard in _getCanonicalOrExecutablePath.
     String nullResult;
     SLANG_CHECK(SLANG_SUCCEEDED(TestToolUtil::getExeDirectoryPath(nullptr, nullResult)));
+    SLANG_CHECK(nullResult.getLength() > 0);
     SLANG_CHECK(nullResult == Path::getParentDirectory(Path::getExecutablePath()));
 
     // Empty string — hasPath("") == false, must fall through to OS fallback.
     String emptyResult;
     SLANG_CHECK(SLANG_SUCCEEDED(TestToolUtil::getExeDirectoryPath("", emptyResult)));
+    SLANG_CHECK(emptyResult.getLength() > 0);
     SLANG_CHECK(emptyResult == Path::getParentDirectory(Path::getExecutablePath()));
 
-#if !SLANG_WINDOWS_FAMILY
-    // Path-like but unresolvable on POSIX — hasPath() == true, realpath() fails for a
-    // non-existent path, so the function must fall through to Path::getExecutablePath().
-    // On Windows _wfullpath() does not validate existence, so this branch cannot be
-    // triggered with a simple missing path there.
+    // Path-like but unresolvable — hasPath() == true, getCanonical succeeds but
+    // File::exists() fails, so the function must fall through to getExecutablePath().
+    // With the File::exists() guard, this works on both POSIX and Windows.
     String missingResult;
     SLANG_CHECK(SLANG_SUCCEEDED(
         TestToolUtil::getExeDirectoryPath("/nonexistent/dir/slang-test", missingResult)));
+    SLANG_CHECK(missingResult.getLength() > 0);
     SLANG_CHECK(missingResult == Path::getParentDirectory(Path::getExecutablePath()));
-#endif
 }

--- a/tools/slang-unit-test/unit-test-test-tool-util.cpp
+++ b/tools/slang-unit-test/unit-test-test-tool-util.cpp
@@ -48,8 +48,8 @@ SLANG_UNIT_TEST(testToolUtilBareArgv0)
     // branch, not the OS fallback. This pins the hasPath + File::exists guard.
     const String selfPath = Path::getExecutablePath();
     String existingResult;
-    SLANG_CHECK(SLANG_SUCCEEDED(
-        TestToolUtil::getExeDirectoryPath(selfPath.getBuffer(), existingResult)));
+    SLANG_CHECK(
+        SLANG_SUCCEEDED(TestToolUtil::getExeDirectoryPath(selfPath.getBuffer(), existingResult)));
     SLANG_CHECK(existingResult.getLength() > 0);
     SLANG_CHECK(existingResult == Path::getParentDirectory(selfPath));
 }

--- a/tools/slang-unit-test/unit-test-test-tool-util.cpp
+++ b/tools/slang-unit-test/unit-test-test-tool-util.cpp
@@ -1,0 +1,23 @@
+// unit-test-test-tool-util.cpp
+
+#include "../../source/core/slang-io.h"
+#include "../../source/core/slang-test-tool-util.h"
+#include "unit-test/slang-unit-test.h"
+
+using namespace Slang;
+
+// Verify that getExeDirectoryPath falls back to Path::getExecutablePath() for
+// bare names (no separators), matching the fix in PR #11212.
+SLANG_UNIT_TEST(testToolUtilBareArgv0)
+{
+    // A bare name with no path separator should use the OS-provided exe path.
+    String bareResult;
+    SLANG_CHECK(SLANG_SUCCEEDED(TestToolUtil::getExeDirectoryPath("slang-test", bareResult)));
+    SLANG_CHECK(bareResult == Path::getParentDirectory(Path::getExecutablePath()));
+
+    // Same for a Windows-style bare name.
+    String bareExeResult;
+    SLANG_CHECK(
+        SLANG_SUCCEEDED(TestToolUtil::getExeDirectoryPath("slang-test.exe", bareExeResult)));
+    SLANG_CHECK(bareExeResult == Path::getParentDirectory(Path::getExecutablePath()));
+}

--- a/tools/slang-unit-test/unit-test-test-tool-util.cpp
+++ b/tools/slang-unit-test/unit-test-test-tool-util.cpp
@@ -20,4 +20,20 @@ SLANG_UNIT_TEST(testToolUtilBareArgv0)
     SLANG_CHECK(
         SLANG_SUCCEEDED(TestToolUtil::getExeDirectoryPath("slang-test.exe", bareExeResult)));
     SLANG_CHECK(bareExeResult == Path::getParentDirectory(Path::getExecutablePath()));
+
+    // nullptr argv[0] — exercises the new null guard in _getCanonicalOrExecutablePath.
+    String nullResult;
+    SLANG_CHECK(SLANG_SUCCEEDED(TestToolUtil::getExeDirectoryPath(nullptr, nullResult)));
+    SLANG_CHECK(nullResult == Path::getParentDirectory(Path::getExecutablePath()));
+
+    // Empty string — hasPath("") == false, must fall through to OS fallback.
+    String emptyResult;
+    SLANG_CHECK(SLANG_SUCCEEDED(TestToolUtil::getExeDirectoryPath("", emptyResult)));
+    SLANG_CHECK(emptyResult == Path::getParentDirectory(Path::getExecutablePath()));
+
+    // Path-like but unresolvable — hasPath() == true, getCanonical fails, must fall through.
+    String missingResult;
+    SLANG_CHECK(SLANG_SUCCEEDED(
+        TestToolUtil::getExeDirectoryPath("/nonexistent/dir/slang-test", missingResult)));
+    SLANG_CHECK(missingResult == Path::getParentDirectory(Path::getExecutablePath()));
 }


### PR DESCRIPTION
## Problem

When `slang-test` is launched with a bare executable name (no path component in `argv[0]`), the test tool was unable to resolve the path to co-located helper executables. This caused child process launches to time out because the helper could not be found relative to the test runner's location.

## Fix

Resolve the actual executable path at startup using platform APIs (`GetModuleFileNameW` on Windows, `/proc/self/exe` on Linux, `_NSGetExecutablePath` on macOS) instead of relying on the raw `argv[0]` string, which may be a bare name with no directory component when invoked from `PATH`.

Fixes #7981