### PR TITLE
linalg: fix implementation of cooperative vector VectorAccumulate

### DIFF
--- a/source/slang/slang-emit-hlsl-prelude.cpp
+++ b/source/slang/slang-emit-hlsl-prelude.cpp
@@ -109,13 +109,7 @@ void __slang_linalg_OuterProductAccumulate(
 template<typename ElTy, uint N, typename BufTy>
 void __slang_linalg_VectorAccumulate(vector<ElTy, N> inputVec, BufTy buffer, uint offset)
 {
-    // No dx::linalg wrapper for cooperative-vector reduce-sum yet; approximate with per-lane load/add/store
-    for (uint i = 0; i < N; ++i)
-    {
-        uint byteOffset = offset + i * uint(sizeof(ElTy));
-        ElTy cur = buffer.template Load<ElTy>(byteOffset);
-        buffer.template Store<ElTy>(byteOffset, cur + inputVec[i]);
-    }
+    dx::linalg::InterlockedAccumulate(buffer, inputVec, offset);
 }
 )";
 

--- a/source/slang/slang-emit-hlsl-prelude.cpp
+++ b/source/slang/slang-emit-hlsl-prelude.cpp
@@ -109,7 +109,7 @@ void __slang_linalg_OuterProductAccumulate(
 template<typename ElTy, uint N, typename BufTy>
 void __slang_linalg_VectorAccumulate(vector<ElTy, N> inputVec, BufTy buffer, uint offset)
 {
-    dx::linalg::InterlockedAccumulate(buffer, inputVec, offset);
+    dx::linalg::VectorAccumulate(inputVec, buffer, offset);
 }
 )";
 

--- a/tests/cooperative-vector/reduce-sum-accumulate-sm610.slang
+++ b/tests/cooperative-vector/reduce-sum-accumulate-sm610.slang
@@ -1,5 +1,6 @@
 // SM6.10 behavioral test for cooperative-vector reduce-sum accumulate.
-// Disabled until GPU CI runners support cs_6_10 / DXC SM6.10.
+// TODO: enable when GPU CI runners gain cs_6_10 / DXC SM6.10 support
+//       (requires DXC >= v1.9.2602 and dx::linalg::VectorAccumulate in dx/linalg.h).
 // Multi-threaded: 8 lanes each accumulate [1,1,1,1] into the same byte offset.
 // Atomic reduce-sum yields output[i]=8; a non-atomic load/add/store loop would
 // produce a smaller value due to lost updates under thread contention.

--- a/tests/cooperative-vector/reduce-sum-accumulate-sm610.slang
+++ b/tests/cooperative-vector/reduce-sum-accumulate-sm610.slang
@@ -1,12 +1,15 @@
 // SM6.10 behavioral test for cooperative-vector reduce-sum accumulate.
 // Disabled until GPU CI runners support cs_6_10 / DXC SM6.10.
+// Multi-threaded: 8 lanes each accumulate [1,1,1,1] into the same byte offset.
+// Atomic reduce-sum yields output[i]=8; a non-atomic load/add/store loop would
+// produce a smaller value due to lost updates under thread contention.
 //DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_10 -Xdxc -Vd
 
 // CHECK: type: half
-// CHECK-NEXT: 112.000000
-// CHECK-NEXT: 2.00
-// CHECK-NEXT: 3.00
-// CHECK-NEXT: 4.0
+// CHECK-NEXT: 8.0
+// CHECK-NEXT: 8.0
+// CHECK-NEXT: 8.0
+// CHECK-NEXT: 8.0
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 ], stride=2):out,name=outputBuffer
 RWStructuredBuffer<half> outputBuffer;
@@ -14,14 +17,12 @@ RWStructuredBuffer<half> outputBuffer;
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=2),name=output
 RWByteAddressBuffer output;
 
-[numthreads(1, 1, 1)]
-void computeMain()
+[numthreads(8, 1, 1)]
+void computeMain(uint groupIndex : SV_GroupIndex)
 {
     CoopVec<half, 4> vecA;
     for(int i = 0; i < vecA.getCount(); ++i)
-        vecA[i] = half(i+1);
-
-    output.Store(0, half(111));
+        vecA[i] = half(1);
 
     coopVecReduceSumAccumulate(
         vecA,
@@ -29,6 +30,11 @@ void computeMain()
         0,
     );
 
-    for(int i = 0; i < vecA.getCount(); ++i)
-        outputBuffer[i] = output.Load<half>(i * 2);
+    AllMemoryBarrierWithGroupSync();
+
+    if (groupIndex == 0)
+    {
+        for(int i = 0; i < vecA.getCount(); ++i)
+            outputBuffer[i] = output.Load<half>(i * 2);
+    }
 }

--- a/tests/cooperative-vector/reduce-sum-accumulate-sm610.slang
+++ b/tests/cooperative-vector/reduce-sum-accumulate-sm610.slang
@@ -1,0 +1,37 @@
+// SM6.10 behavioral test for cooperative-vector reduce-sum accumulate.
+// Disabled until GPU CI runners support cs_6_10 / DXC SM6.10.
+//DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_10 -Xslang... -Xdxc -Vd -X.
+
+// CHECK: type: half
+// CHECK-NEXT: 112.000000
+// CHECK-NEXT: 2.00
+// CHECK-NEXT: 3.00
+// CHECK-NEXT: 4.0
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 ], stride=2):out,name=outputBuffer
+RWStructuredBuffer<half> outputBuffer;
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4),name=inputA
+ByteAddressBuffer inputA;
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4),name=output
+RWByteAddressBuffer output;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    CoopVec<half, 4> vecA;
+    for(int i = 0; i < vecA.getCount(); ++i)
+        vecA[i] = half(i+1);
+
+    output.Store(0, half(111));
+
+    coopVecReduceSumAccumulate(
+        vecA,
+        output,
+        0,
+    );
+
+    for(int i = 0; i < vecA.getCount(); ++i)
+        outputBuffer[i] = output.Load<half>(i * 2);
+}

--- a/tests/cooperative-vector/reduce-sum-accumulate-sm610.slang
+++ b/tests/cooperative-vector/reduce-sum-accumulate-sm610.slang
@@ -1,6 +1,6 @@
 // SM6.10 behavioral test for cooperative-vector reduce-sum accumulate.
 // Disabled until GPU CI runners support cs_6_10 / DXC SM6.10.
-//DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_10 -Xslang... -Xdxc -Vd -X.
+//DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -render-feature cooperative-vector -dx12-experimental -output-using-type -profile cs_6_10 -Xdxc -Vd
 
 // CHECK: type: half
 // CHECK-NEXT: 112.000000
@@ -11,10 +11,7 @@
 //TEST_INPUT:ubuffer(data=[0 0 0 0 ], stride=2):out,name=outputBuffer
 RWStructuredBuffer<half> outputBuffer;
 
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4),name=inputA
-ByteAddressBuffer inputA;
-
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4),name=output
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=2),name=output
 RWByteAddressBuffer output;
 
 [numthreads(1, 1, 1)]

--- a/tests/cooperative-vector/training-hlsl-codegen.slang
+++ b/tests/cooperative-vector/training-hlsl-codegen.slang
@@ -19,7 +19,7 @@
 // CHECK610: void __slang_linalg_VectorAccumulate(
 // CHECK610-NOT: byteOffset = offset + i *
 // CHECK610-NOT: i * uint(sizeof(ElTy))
-// CHECK610: dx::linalg::VectorAccumulate(
+// CHECK610: dx::linalg::VectorAccumulate(inputVec, buffer, offset);
 // CHECK610: }
 
 RWByteAddressBuffer outerProductOutput;

--- a/tests/cooperative-vector/training-hlsl-codegen.slang
+++ b/tests/cooperative-vector/training-hlsl-codegen.slang
@@ -16,9 +16,11 @@
 // CHECK610-NOT: ComponentTypeTraits<ElTy>
 // CHECK610-NOT: buffer.template Load<ElTy>
 // CHECK610-NOT: buffer.template Store<ElTy>
-// CHECK610-NOT: byteOffset = offset + i *
 // CHECK610: void __slang_linalg_VectorAccumulate(
+// CHECK610-NOT: byteOffset = offset + i *
+// CHECK610-NOT: i * uint(sizeof(ElTy))
 // CHECK610: dx::linalg::VectorAccumulate(
+// CHECK610: }
 
 RWByteAddressBuffer outerProductOutput;
 RWByteAddressBuffer reduceSumOutput;

--- a/tests/cooperative-vector/training-hlsl-codegen.slang
+++ b/tests/cooperative-vector/training-hlsl-codegen.slang
@@ -10,7 +10,7 @@
 
 // CHECK610-DAG: dx::linalg::OuterProduct<
 // CHECK610-DAG: acc.InterlockedAccumulate(matBuf, matOff);
-// CHECK610-DAG: dx::linalg::InterlockedAccumulate(buffer, inputVec, offset);
+// CHECK610-DAG: dx::linalg::VectorAccumulate(inputVec, buffer, offset);
 // CHECK610-DAG: __slang_linalg_OuterProductAccumulate<
 // CHECK610-DAG: __slang_linalg_VectorAccumulate<
 // CHECK610-NOT: OuterProduct<MatDT, dx::linalg::MatrixScope::Thread>

--- a/tests/cooperative-vector/training-hlsl-codegen.slang
+++ b/tests/cooperative-vector/training-hlsl-codegen.slang
@@ -10,17 +10,14 @@
 
 // CHECK610-DAG: dx::linalg::OuterProduct<
 // CHECK610-DAG: acc.InterlockedAccumulate(matBuf, matOff);
+// CHECK610-DAG: void __slang_linalg_VectorAccumulate(
+// CHECK610-DAG: dx::linalg::VectorAccumulate(inputVec, buffer, offset);
 // CHECK610-DAG: __slang_linalg_OuterProductAccumulate<
 // CHECK610-DAG: __slang_linalg_VectorAccumulate<
 // CHECK610-NOT: OuterProduct<MatDT, dx::linalg::MatrixScope::Thread>
 // CHECK610-NOT: ComponentTypeTraits<ElTy>
 // CHECK610-NOT: buffer.template Load<ElTy>
 // CHECK610-NOT: buffer.template Store<ElTy>
-// CHECK610: void __slang_linalg_VectorAccumulate(
-// CHECK610-NOT: byteOffset = offset + i *
-// CHECK610-NOT: i * uint(sizeof(ElTy))
-// CHECK610: dx::linalg::VectorAccumulate(inputVec, buffer, offset);
-// CHECK610: }
 
 RWByteAddressBuffer outerProductOutput;
 RWByteAddressBuffer reduceSumOutput;

--- a/tests/cooperative-vector/training-hlsl-codegen.slang
+++ b/tests/cooperative-vector/training-hlsl-codegen.slang
@@ -10,13 +10,15 @@
 
 // CHECK610-DAG: dx::linalg::OuterProduct<
 // CHECK610-DAG: acc.InterlockedAccumulate(matBuf, matOff);
-// CHECK610-DAG: dx::linalg::VectorAccumulate(inputVec, buffer, offset);
 // CHECK610-DAG: __slang_linalg_OuterProductAccumulate<
 // CHECK610-DAG: __slang_linalg_VectorAccumulate<
 // CHECK610-NOT: OuterProduct<MatDT, dx::linalg::MatrixScope::Thread>
 // CHECK610-NOT: ComponentTypeTraits<ElTy>
 // CHECK610-NOT: buffer.template Load<ElTy>
 // CHECK610-NOT: buffer.template Store<ElTy>
+// CHECK610-NOT: byteOffset = offset + i *
+// CHECK610: void __slang_linalg_VectorAccumulate(
+// CHECK610: dx::linalg::VectorAccumulate(
 
 RWByteAddressBuffer outerProductOutput;
 RWByteAddressBuffer reduceSumOutput;

--- a/tests/cooperative-vector/training-hlsl-codegen.slang
+++ b/tests/cooperative-vector/training-hlsl-codegen.slang
@@ -9,12 +9,14 @@
 // CHECK609-DAG: __slang_linalg_VectorAccumulate<
 
 // CHECK610-DAG: dx::linalg::OuterProduct<
-// CHECK610-DAG: InterlockedAccumulate(
+// CHECK610-DAG: acc.InterlockedAccumulate(matBuf, matOff);
+// CHECK610-DAG: dx::linalg::InterlockedAccumulate(buffer, inputVec, offset);
 // CHECK610-DAG: __slang_linalg_OuterProductAccumulate<
 // CHECK610-DAG: __slang_linalg_VectorAccumulate<
 // CHECK610-NOT: OuterProduct<MatDT, dx::linalg::MatrixScope::Thread>
-// CHECK610-NOT: InterlockedAccumulate(matBuf, matOff, uint(sizeof
 // CHECK610-NOT: ComponentTypeTraits<ElTy>
+// CHECK610-NOT: buffer.template Load<ElTy>
+// CHECK610-NOT: buffer.template Store<ElTy>
 
 RWByteAddressBuffer outerProductOutput;
 RWByteAddressBuffer reduceSumOutput;


### PR DESCRIPTION
## Summary

- `__slang_linalg_VectorAccumulate` in the HLSL SM6.10 prelude was implemented as a manual per-lane load/add/store loop, which is incorrect — it lacks the interlocked/atomic semantics required for cooperative vector reduction across threads.
- Replace the loop with a direct call to `dx::linalg::VectorAccumulate(inputVec, buffer, offset)`, the free function defined in DXC's `dx/linalg.h` (distinct from the `.InterlockedAccumulate()` method on `Matrix<..., MatrixUse::Accumulator>` used in `OuterProductAccumulate`).
- Update the `cs_6_10` codegen test to anchor the check to the function body and add `NOT` assertions to reject the old load/store loop patterns.

Fixes https://github.com/shader-slang/slang/issues/10742

🤖 Generated with [Claude Code](https://claude.com/claude-code)