### PR TITLE
Require fp8 render feature for CUDA tests

### DIFF
--- a/tests/compute/dynamic-dispatch-substandard-float.slang
+++ b/tests/compute/dynamic-dispatch-substandard-float.slang
@@ -1,6 +1,6 @@
 // Test using interface typed shader parameters with texture typed fields.
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -emit-spirv-directly -render-features fp8
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type -render-features fp8
 
 [anyValueSize(4)]
 interface IFoo

--- a/tests/cooperative-matrix/fp8-cuda-e5m2.slang
+++ b/tests/cooperative-matrix/fp8-cuda-e5m2.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type -capability cuda_sm_8_9
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type -capability cuda_sm_8_9 -render-features fp8
 
 // CUDA fp8 (FloatE5M2) cooperative matrix multiply-add test using the
 // m16n8k16 shape (i.e. CoopMat element shape 16x16, which lowers to 2x

--- a/tests/cooperative-matrix/fp8-cuda-half-acc.slang
+++ b/tests/cooperative-matrix/fp8-cuda-half-acc.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type -capability cuda_sm_8_9
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type -capability cuda_sm_8_9 -render-features fp8
 
 // CUDA fp8 (FloatE4M3) cooperative matrix multiply-add with **half** accumulator
 // and output.  Targets PTX

--- a/tests/cooperative-matrix/fp8-cuda.slang
+++ b/tests/cooperative-matrix/fp8-cuda.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type -capability cuda_sm_8_9
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type -capability cuda_sm_8_9 -render-features fp8
 
 // CUDA fp8 (FloatE4M3) cooperative matrix multiply-add test using the
 // m16n8k16 shape (i.e. CoopMat element shape 16x16, which lowers to 2x

--- a/tests/hlsl-intrinsic/scalar-fp8.slang
+++ b/tests/hlsl-intrinsic/scalar-fp8.slang
@@ -1,5 +1,5 @@
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -emit-spirv-directly -output-using-type -render-features fp8
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -output-using-type -render-features fp8
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/hlsl-intrinsic/substandard-fp-folding.slang
+++ b/tests/hlsl-intrinsic/substandard-fp-folding.slang
@@ -1,7 +1,7 @@
 //TEST:SIMPLE(filecheck=SPV): -target spirv -O0
 
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -emit-spirv-directly -output-using-type -render-features fp8 -xslang -O0
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -output-using-type -render-features fp8
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -193,6 +193,25 @@ static void _outputProfileTime(uint64_t startTicks, uint64_t endTicks)
     out.print("profile-time=%g\n", time);
 }
 
+static rhi::Feature _getFeatureFromName(const UnownedStringSlice& featureName)
+{
+    struct FeatureNameMapEntry
+    {
+        const char* name;
+        rhi::Feature feature;
+    };
+
+#define SLANG_RHI_FEATURES_X(id, name) {name, rhi::Feature::id},
+    static const FeatureNameMapEntry kFeatureNameMap[] = {SLANG_RHI_FEATURES(SLANG_RHI_FEATURES_X)};
+#undef SLANG_RHI_FEATURES_X
+
+    for (auto& entry : kFeatureNameMap)
+        if (featureName == UnownedStringSlice(entry.name))
+            return entry.feature;
+
+    return rhi::Feature::_Count;
+}
+
 class ProgramVars;
 
 struct ShaderOutputPlan
@@ -1885,9 +1904,9 @@ static SlangResult _innerMain(
         else
             desc.slang.targetFlags = 0;
 
-        List<const char*> requiredFeatureList;
+        List<rhi::Feature> requiredFeatureList;
         for (auto& name : options.renderFeatures)
-            requiredFeatureList.add(name.getBuffer());
+            requiredFeatureList.add(_getFeatureFromName(name.getUnownedSlice()));
 
         desc.requiredFeatures = requiredFeatureList.getBuffer();
         desc.requiredFeatureCount = (int)requiredFeatureList.getCount();


### PR DESCRIPTION
## Summary
- require the fp8 render feature for the CUDA fp8 cooperative matrix tests
- update the slang-rhi submodule to shader-slang/slang-rhi#750 so CUDA advertises Float8 only on SM 8.9+

## Testing
- cmake --build --preset debug --target render-test slang-test
- build/Debug/bin/slang-test tests/cooperative-matrix/fp8-cuda.slang tests/cooperative-matrix/fp8-cuda-e5m2.slang tests/cooperative-matrix/fp8-cuda-half-acc.slang
- build/Debug/bin/slang-test tests/neural/mma-tiled-backward-test.slang

Close #11161