### PR TITLE
Fix constexpr variable declarations as compile-time constants (#10940)

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2789,7 +2789,8 @@ void SemanticsDeclHeaderVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
             }
         }
         if (!varDecl->findModifier<ConstExprModifier>() &&
-            (!varDecl->findModifier<HLSLStaticModifier>() || !varDecl->findModifier<ConstModifier>()))
+            (!varDecl->findModifier<HLSLStaticModifier>() ||
+             !varDecl->findModifier<ConstModifier>()))
         {
             getSink()->diagnose(
                 Diagnostics::ValueRequirementMustBeCompileTimeConst{.decl = varDecl});
@@ -3261,7 +3262,8 @@ static bool _initExprIsRuntimeValue(Expr* expr)
         if (auto varDecl = as<VarDeclBase>(declRefExpr->declRef.getDecl()))
         {
             // References to static const or constexpr globals are fine — compile-time constants.
-            if ((varDecl->hasModifier<HLSLStaticModifier>() && varDecl->hasModifier<ConstModifier>()) ||
+            if ((varDecl->hasModifier<HLSLStaticModifier>() &&
+                 varDecl->hasModifier<ConstModifier>()) ||
                 varDecl->hasModifier<ConstExprModifier>())
                 return false;
             // Any other global variable (including plain `static float foo`) is mutable.

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -1535,6 +1535,10 @@ bool isGlobalShaderParameter(VarDeclBase* decl)
         if (as<HLSLStaticModifier>(modifier))
             return false;
 
+        // A `constexpr` variable is a compile-time constant, not a shader parameter.
+        if (as<ConstExprModifier>(modifier))
+            return false;
+
         // While not normally allowed, out variables are not constant
         // parameters, this can happen for example in GLSL mode
         if (as<OutModifier>(modifier))
@@ -1594,6 +1598,11 @@ QualType getTypeForDeclRef(
 
         bool isLValue = true;
         if (varDeclRef.getDecl()->findModifier<ConstModifier>())
+            isLValue = false;
+        // `constexpr` on a variable declaration (not a parameter) is immutable.
+        // On parameters it means "must be compile-time constant at the call site",
+        // but the parameter itself is still an lvalue inside the function.
+        if (!varDeclRef.is<ParamDecl>() && varDeclRef.getDecl()->findModifier<ConstExprModifier>())
             isLValue = false;
 
         // Global-scope shader parameters should not be writable,
@@ -2779,7 +2788,8 @@ void SemanticsDeclHeaderVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
                 break;
             }
         }
-        if (!varDecl->findModifier<HLSLStaticModifier>() || !varDecl->findModifier<ConstModifier>())
+        if (!varDecl->findModifier<ConstExprModifier>() &&
+            (!varDecl->findModifier<HLSLStaticModifier>() || !varDecl->findModifier<ConstModifier>()))
         {
             getSink()->diagnose(
                 Diagnostics::ValueRequirementMustBeCompileTimeConst{.decl = varDecl});
@@ -3250,8 +3260,9 @@ static bool _initExprIsRuntimeValue(Expr* expr)
     {
         if (auto varDecl = as<VarDeclBase>(declRefExpr->declRef.getDecl()))
         {
-            // References to static const globals are fine — compile-time constants.
-            if (varDecl->hasModifier<HLSLStaticModifier>() && varDecl->hasModifier<ConstModifier>())
+            // References to static const or constexpr globals are fine — compile-time constants.
+            if ((varDecl->hasModifier<HLSLStaticModifier>() && varDecl->hasModifier<ConstModifier>()) ||
+                varDecl->hasModifier<ConstExprModifier>())
                 return false;
             // Any other global variable (including plain `static float foo`) is mutable.
             if (isGlobalDecl(varDecl))
@@ -3329,9 +3340,10 @@ void SemanticsDeclBodyVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
 
     if (auto initExpr = varDecl->initExpr)
     {
-        // Disable the short-circuiting for static const variable init expression
+        // Disable the short-circuiting for static const or constexpr variable init expression
         bool isStaticConst =
-            varDecl->hasModifier<HLSLStaticModifier>() && varDecl->hasModifier<ConstModifier>();
+            (varDecl->hasModifier<HLSLStaticModifier>() && varDecl->hasModifier<ConstModifier>()) ||
+            varDecl->hasModifier<ConstExprModifier>();
 
         auto subVisitor =
             isStaticConst ? SemanticsVisitor(disableShortCircuitLogicalExpr()) : *this;

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2689,7 +2689,8 @@ void SemanticsDeclHeaderVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
         if (as<BasicExpressionType>(varDecl->type.type))
         {
             auto parentDecl = getParentDecl(varDecl);
-            if (varDecl->findModifier<ConstModifier>() &&
+            if ((varDecl->findModifier<ConstModifier>() ||
+                 varDecl->findModifier<ConstExprModifier>()) &&
                 (as<NamespaceDeclBase>(parentDecl) || as<FileDecl>(parentDecl) ||
                  varDecl->findModifier<HLSLStaticModifier>()))
             {
@@ -3564,6 +3565,7 @@ void SemanticsDeclBodyVisitor::checkVarDeclCommon(VarDeclBase* varDecl)
 
         bool isOpaque = (((int)varTypeTags & (int)TypeTag::Opaque) != 0);
         if (isOpaque && isGlobalDecl(varDecl) && !varDecl->hasModifier<ConstModifier>() &&
+            !varDecl->hasModifier<ConstExprModifier>() &&
             varDecl->hasModifier<HLSLStaticModifier>())
         {
             // Opaque type global variable must be const.

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -2682,7 +2682,8 @@ IntVal* SemanticsVisitor::tryConstantFoldDeclRef(
         return nullptr;
 
     // In HLSL, `const` is used to mark compile-time constant expressions.
-    if (!decl->hasModifier<ConstModifier>())
+    // `constexpr` carries `ConstExprModifier` and is also a compile-time constant.
+    if (!decl->hasModifier<ConstModifier>() && !decl->hasModifier<ConstExprModifier>())
         return nullptr;
 
     // The values of specialization constants aren't known at compile time even

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -3147,9 +3147,10 @@ IntVal* SemanticsVisitor::tryFoldIndexExpr(
     auto arrayType = as<ArrayExpressionType>(type);
     if (!arrayType)
         return nullptr;
-    if (!varDecl->hasModifier<ConstModifier>())
+    if (!varDecl->hasModifier<ConstModifier>() && !varDecl->hasModifier<ConstExprModifier>())
         return nullptr;
-    if (isGlobalDecl(varDecl) && !varDecl->hasModifier<HLSLStaticModifier>())
+    if (isGlobalDecl(varDecl) && !varDecl->hasModifier<HLSLStaticModifier>() &&
+        !varDecl->hasModifier<ConstExprModifier>())
         return nullptr;
     if (!varDecl->initExpr)
         return nullptr;

--- a/source/slang/slang-language-server.cpp
+++ b/source/slang/slang-language-server.cpp
@@ -404,7 +404,9 @@ String getDeclSignatureString(DeclRef<Decl> declRef, WorkspaceVersion* version)
         };
         if (auto varDecl = as<VarDeclBase>(declRef.getDecl()))
         {
-            if (!varDecl->findModifier<ConstModifier>() && !as<LetDecl>(declRef.getDecl()))
+            if (!varDecl->findModifier<ConstModifier>() &&
+                !varDecl->findModifier<ConstExprModifier>() &&
+                !as<LetDecl>(declRef.getDecl()))
                 return printer.getString();
             printInitExpr(getModule(varDecl), varDecl->type, varDecl->initExpr);
         }

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -10786,8 +10786,8 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
     LoweredValInfo lowerConstantDeclCommon(VarDeclBase* decl)
     {
-        // It's constant, so shoul dhave this modifier
-        SLANG_ASSERT(decl->hasModifier<ConstModifier>());
+        // It's constant, so should have either `const` or `constexpr`.
+        SLANG_ASSERT(decl->hasModifier<ConstModifier>() || decl->hasModifier<ConstExprModifier>());
 
         NestedContext nested(this);
         auto subBuilder = nested.getBuilder();
@@ -10903,9 +10903,9 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             return lowerGlobalShaderParam(decl);
         }
 
-        // A `static const` global is actually a compile-time constant.
+        // A `static const` global or any `constexpr` global is a compile-time constant.
         //
-        if (decl->hasModifier<HLSLStaticModifier>() && decl->hasModifier<ConstModifier>())
+        if (isConstExprVar(decl))
         {
             return lowerGlobalConstantDecl(decl);
         }
@@ -10979,8 +10979,8 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
 
     LoweredValInfo lowerFunctionStaticVarDecl(VarDeclBase* decl)
     {
-        // We know the variable is `static`, but it might also be `const.
-        if (decl->hasModifier<ConstModifier>())
+        // We know the variable is `static`, but it might also be `const` or `constexpr`.
+        if (decl->hasModifier<ConstModifier>() || decl->hasModifier<ConstExprModifier>())
             return lowerFunctionStaticConstVarDecl(decl);
 
         // A function-scope `static` variable is effectively a global,

--- a/tests/language-feature/constexpr/constexpr-array-index-fold.slang
+++ b/tests/language-feature/constexpr/constexpr-array-index-fold.slang
@@ -1,0 +1,20 @@
+// Test that array indexing into a `constexpr` array is constant-folded,
+// so array elements can be used as generic arguments and array sizes.
+// Tests the tryFoldIndexExpr path for ConstExprModifier.
+
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<uint> outputBuffer;
+
+constexpr uint sizes[3] = { 2, 3, 4 };
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // Use an array element as a compile-time generic argument.
+    vector<uint, sizes[1]> v = { 10, 20, 30 };
+    outputBuffer[0] = v[2];
+}
+
+// CHECK: 30

--- a/tests/language-feature/constexpr/constexpr-as-compile-time-const.slang
+++ b/tests/language-feature/constexpr/constexpr-as-compile-time-const.slang
@@ -1,0 +1,24 @@
+// Test that `constexpr` variables are recognized as compile-time constants,
+// matching the behaviour of `static const`. Regression test for issue #10940.
+
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<uint> outputBuffer;
+
+static constexpr uint N = 4;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // Use constexpr as a generic argument (the original repro).
+    vector<uint, N> v = { 1, 2, 3, 4 };
+
+    uint sum = 0;
+    for (uint i = 0; i < N; i++)
+        sum += v[i];
+
+    outputBuffer[0] = sum;
+}
+
+// CHECK: 10

--- a/tests/language-feature/constexpr/constexpr-bare-global.slang
+++ b/tests/language-feature/constexpr/constexpr-bare-global.slang
@@ -1,0 +1,18 @@
+// Test that a bare `constexpr` global (no `static`) is treated as a
+// compile-time constant, not a shader parameter.
+
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<uint> outputBuffer;
+
+constexpr uint N = 3;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    vector<uint, N> v = { 10, 20, 30 };
+    outputBuffer[0] = v[2];
+}
+
+// CHECK: 30

--- a/tests/language-feature/constexpr/constexpr-function-static.slang
+++ b/tests/language-feature/constexpr/constexpr-function-static.slang
@@ -1,0 +1,17 @@
+// Test that function-local `static constexpr` variables are recognized as
+// compile-time constants and can be used as generic arguments.
+
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<uint> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    static constexpr uint N = 3;
+    vector<uint, N> v = { 5, 6, 7 };
+    outputBuffer[0] = v[0] + v[1] + v[2];
+}
+
+// CHECK: 18

--- a/tests/language-feature/constexpr/constexpr-not-lvalue.slang
+++ b/tests/language-feature/constexpr/constexpr-not-lvalue.slang
@@ -1,0 +1,16 @@
+// Test that `constexpr` variables are not lvalues and cannot be assigned to.
+// Regression test for the lvalue rule in slang-check-decl.cpp.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):
+
+constexpr int x = 5;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    constexpr int y = 10;
+    //CHECK: left of '=' is not an l-value
+    x = 6;
+    //CHECK: left of '=' is not an l-value
+    y = 11;
+}

--- a/tests/language-feature/constexpr/constexpr-user-generic.slang
+++ b/tests/language-feature/constexpr/constexpr-user-generic.slang
@@ -1,0 +1,25 @@
+// Test that `constexpr` variables can be used as arguments to user-defined
+// generic types, exercising the constant-folding path in the semantic checker.
+
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<uint> outputBuffer;
+
+static constexpr uint N = 2;
+
+struct Pair<let Count : uint>
+{
+    uint data[Count];
+};
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    Pair<N> p;
+    p.data[0] = 100;
+    p.data[1] = 200;
+    outputBuffer[0] = p.data[0] + p.data[1];
+}
+
+// CHECK: 300


### PR DESCRIPTION
`constexpr` variables were not recognized as compile-time constants because the constant-folding gate in `tryConstantFoldDeclRef` only checked for `ConstModifier` (`const`), not `ConstExprModifier` (`constexpr`). Six additional sites that gate on `ConstModifier` were also missed.

Changes:
- slang-check-expr.cpp: accept ConstExprModifier in tryConstantFoldDeclRef
- slang-check-decl.cpp: exclude constexpr from isGlobalShaderParameter; mark constexpr variable declarations non-lvalue; recognize constexpr in _initExprIsRuntimeValue and isStaticConst; accept constexpr in interface value requirement validation
- slang-lower-to-ir.cpp: route constexpr globals and static-constexpr locals to constant-lowering paths

Adds four regression tests covering static constexpr globals, bare constexpr globals, function-local static constexpr, and constexpr as a user-defined generic argument.

Fixes #10940.