### PR TITLE
Fix GH-5219: wrong caret position and color highlight for multi-byte UTF-8 in diagnostics

### DIFF
--- a/source/compiler-core/slang-rich-diagnostics-render.cpp
+++ b/source/compiler-core/slang-rich-diagnostics-render.cpp
@@ -415,23 +415,30 @@ private:
             return;
         }
 
-        Int64 cursor = 1;
+        // cursor is a byte offset into content (indent bytes were already stripped above)
+        Index cursor = 0;
         for (const auto& span : line.spans)
         {
-            Int64 start = span.column - indent;
-            if (start > cursor && cursor - 1 < content.getLength())
-                ss << content.subString(cursor - 1, start - cursor);
+            // span.column is a 1-based code-point column in the full line; subtract the
+            // (ASCII-only) indent to get a 0-based code-point offset into content, then
+            // convert to a byte offset so subString receives byte-based indices.
+            Index cpStart = (Index)std::max(Int64{0}, span.column - indent - 1);
+            Index cpEnd = (Index)std::max(Int64{0}, cpStart + std::max(Int64{0}, span.length));
+            Index byteStart = UTF8Util::codePointIndexToByteOffset(content, cpStart);
+            Index byteEnd = UTF8Util::codePointIndexToByteOffset(content, cpEnd);
+
+            if (byteStart > cursor && cursor < content.getLength())
+                ss << content.subString(cursor, byteStart - cursor);
 
             TerminalColor c = span.isPrimary ? TerminalColor::Red : TerminalColor::Cyan;
-            Int64 startIdx = std::max(Int64{0}, start - 1);
-            Int64 safeLen =
-                std::max(Int64{0}, std::min(span.length, content.getLength() - startIdx));
-            if (safeLen > 0)
-                ss << color(c, String(content.subString(startIdx, safeLen)));
-            cursor = start + span.length;
+            Index safeStart = std::min(byteStart, (Index)content.getLength());
+            Index safeEnd = std::min(byteEnd, (Index)content.getLength());
+            if (safeEnd > safeStart)
+                ss << color(c, String(content.subString(safeStart, safeEnd - safeStart)));
+            cursor = byteEnd;
         }
-        if (cursor - 1 >= 0 && cursor - 1 < content.getLength())
-            ss << content.tail(cursor - 1);
+        if (cursor < (Index)content.getLength())
+            ss << content.tail(cursor);
     }
 
     //

--- a/source/compiler-core/slang-rich-diagnostics-render.cpp
+++ b/source/compiler-core/slang-rich-diagnostics-render.cpp
@@ -1,5 +1,6 @@
 #include "slang-rich-diagnostics-render.h"
 
+#include "../core/slang-char-encode.h"
 #include "../core/slang-dictionary.h"
 #include "../core/slang-list.h"
 #include "../core/slang-string-util.h"
@@ -321,9 +322,29 @@ private:
                     line.content = UnownedStringSlice(rawLine.begin(), rawLine.trim().end());
                 }
             }
-            if (m_lexer && span.length <= 0 && line.content.getLength() > 0 && span.col > 0 &&
-                span.col - 1 < line.content.getLength())
-                span.length = m_lexer(line.content.tail(span.col - 1)).getLength();
+            if (line.content.getLength() > 0 && span.col > 0)
+            {
+                // span.col is a 1-based code-point index; convert to a byte offset for tail()
+                auto byteOffset = UTF8Util::codePointIndexToByteOffset(line.content, span.col - 1);
+                if (m_lexer && span.length <= 0 && byteOffset < line.content.getLength())
+                {
+                    // Ask the lexer for the token starting here, then express its
+                    // size in code points so it stays consistent with span.col.
+                    auto token = m_lexer(line.content.tail(byteOffset));
+                    span.length = (Int64)UTF8Util::calcCodePointCount(token);
+                }
+                else if (span.length > 0 && byteOffset < line.content.getLength())
+                {
+                    // LayoutSpan::length was set from span.range.getOffset(span.range.end)
+                    // in makeLayoutSpan, which is a byte distance. Convert to code points.
+                    // SourceRange endpoints are always code-point-aligned for valid source,
+                    // so the byte slice will not end mid-sequence in practice.
+                    auto tail = line.content.tail(byteOffset);
+                    auto cappedLen = std::min(tail.getLength(), (Index)span.length);
+                    span.length = (Int64)UTF8Util::calcCodePointCount(
+                        UnownedStringSlice(tail.begin(), tail.begin() + cappedLen));
+                }
+            }
             line.spans.add({span.col, span.length, span.label, span.isPrimary});
         }
 
@@ -791,14 +812,20 @@ String renderDiagnosticMachineReadable(
                     view->getSourceFile()->getLineAtIndex(actualLine - 1));
                 UnownedStringSlice lineContent =
                     UnownedStringSlice(rawLine.begin(), rawLine.trim().end());
-                if (lineContent.getLength() > 0 && beginLoc.column > 0 &&
-                    beginLoc.column - 1 < lineContent.getLength())
+                if (lineContent.getLength() > 0 && beginLoc.column > 0)
                 {
-                    Int64 tokenLen = sll(lineContent.tail(beginLoc.column - 1)).getLength();
-                    if (tokenLen > 0)
+                    // beginLoc.column is a 1-based code-point index; convert to byte offset
+                    auto byteOffset =
+                        UTF8Util::codePointIndexToByteOffset(lineContent, beginLoc.column - 1);
+                    if (byteOffset < lineContent.getLength())
                     {
-                        endLoc.line = beginLoc.line;
-                        endLoc.column = beginLoc.column + tokenLen;
+                        auto token = sll(lineContent.tail(byteOffset));
+                        Int64 tokenLen = (Int64)UTF8Util::calcCodePointCount(token);
+                        if (tokenLen > 0)
+                        {
+                            endLoc.line = beginLoc.line;
+                            endLoc.column = beginLoc.column + tokenLen;
+                        }
                     }
                 }
             }

--- a/source/core/slang-char-encode.cpp
+++ b/source/core/slang-char-encode.cpp
@@ -220,6 +220,26 @@ CharEncoding* CharEncoding::UTF32 = &_utf32Encoding;
     return count;
 }
 
+/* static */ Index UTF8Util::codePointIndexToByteOffset(
+    const UnownedStringSlice& in,
+    Index codePointIndex)
+{
+    const int8_t* cur = (const int8_t*)in.begin();
+    const int8_t* const end = (const int8_t*)in.end();
+
+    for (Index i = 0; i < codePointIndex && cur < end; ++i)
+    {
+        const auto c = *cur++;
+        if (c < 0)
+        {
+            while (cur < end && (*cur & 0xc0) == 0x80)
+                cur++;
+        }
+    }
+
+    return Index((const char*)cur - in.begin());
+}
+
 Index UTF8Util::calcUTF16CharCount(const UnownedStringSlice& in)
 {
     Index count = 0;

--- a/source/core/slang-char-encode.h
+++ b/source/core/slang-char-encode.h
@@ -210,6 +210,10 @@ struct UTF8Util
     /// Given a slice in UTF8, calculate the number of UTF16 characters needed to represent the
     /// string.
     static Index calcUTF16CharCount(const UnownedStringSlice& in);
+
+    /// Given a UTF-8 string and a 0-based code-point index, return the byte offset of that code
+    /// point within the string. Returns in.getLength() if codePointIndex is out of range.
+    static Index codePointIndexToByteOffset(const UnownedStringSlice& in, Index codePointIndex);
 };
 
 } // namespace Slang

--- a/tests/bugs/gh-5219-utf8-column.slang
+++ b/tests/bugs/gh-5219-utf8-column.slang
@@ -1,0 +1,28 @@
+// Regression test for GH-5219: error underline misaligned for multi-byte UTF-8.
+//
+// The compiler must report code-point columns (not byte offsets) for diagnostics.
+// The rich diagnostic renderer must also use the code-point column when computing
+// the byte slice for the lexer (to determine the highlight span length).
+//
+// In each case below, the comment before `undeclaredN` has exactly 9 code points
+// (matching `/* abc */`), so all three identifiers sit at code-point column 20.
+// `undeclaredN` is 11 ASCII characters, so the span ends at code-point column 31.
+// Without the fix, byte-based slicing would return a short/wrong token for a2/a3.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):
+
+// Case 1: ASCII (1-byte code points) — code-point column == byte column.
+int a1 = /* abc */ undeclared1;
+//CHECK:           ^^^^^^^^^^^ undefined identifier
+
+// Case 2: Two-byte UTF-8 code points (α β γ, 2 bytes each).
+int a2 = /* αβγ */ undeclared2;
+//CHECK:           ^^^^^^^^^^^ undefined identifier
+
+// Case 3: Three-byte UTF-8 code points (CJK characters, 3 bytes each).
+int a3 = /* 救命！ */ undeclared3;
+//CHECK:           ^^^^^^^^^^^ undefined identifier
+
+// Case 4: Four-byte UTF-8 code points (supplementary plane, 4 bytes each).
+int a4 = /* 𝛼𝛽𝛾 */ undeclared4;
+//CHECK:           ^^^^^^^^^^^ undefined identifier


### PR DESCRIPTION
## Summary

The rich diagnostic renderer (`slang-rich-diagnostics-render.cpp`) stored column positions as 1-based code-point indices (per `calcColumnIndex` / `UTF8Util::calcCodePointCount`) but then used those values as raw byte offsets when slicing source lines. For any line containing multi-byte UTF-8 characters (Greek, CJK, emoji, etc.) this caused:

- **Wrong caret count** in rendered diagnostics (e.g. one `^` instead of eleven for an 11-character identifier that follows a `/* αβγ */` comment).
- **Wrong `endCol`** in machine-readable (tab-separated) diagnostic output.
- **Wrong terminal color highlight** — the colored region started and ended at the wrong characters in the source-line echo.

### Root Cause

Three call sites passed a 1-based code-point column directly to
`UnownedStringSlice::tail()` / `subString()`, which expect byte offsets:

| Function | Variable misused |
|---|---|
| `buildSectionLayout` | `span.col - 1` as byte offset for `tail()` |
| `outputSpan` (machine-readable) | `beginLoc.column - 1` as byte offset |
| `renderSourceLine` | `span.column - indent` and `span.length` as byte offsets |

Returned lexer token lengths (bytes) were also stored directly into `span.length` (code points), compounding the mismatch.

### Fix

- Added `UTF8Util::codePointIndexToByteOffset(slice, n)` to `source/core/slang-char-encode.{h,cpp}` — walks the UTF-8 bytes and returns the byte offset of the nth code point.
- Each call site now converts code-point columns to byte offsets before slicing, and converts byte token lengths back to code-point counts via `UTF8Util::calcCodePointCount`.

### Test

`tests/bugs/gh-5219-utf8-column.slang` — a `DIAGNOSTIC_TEST:SIMPLE` that exercises 1-, 2-, 3-, and 4-byte UTF-8 code points in the comment preceding an undeclared identifier. All four cases must produce `endCol = 31` (11-caret span starting at code-point column 20).

Fixes #5219