### PR TITLE
ci/rtx-remix-nightly: drop ngx_sdk_dlfg from packman pull

### DIFF
--- a/.github/workflows/compile-rtx-remix-shaders-nightly.yml
+++ b/.github/workflows/compile-rtx-remix-shaders-nightly.yml
@@ -122,18 +122,23 @@ jobs:
             packman-
           enableCrossOsArchive: false
 
-      # Drop packman entries we can't fetch (and don't need for
-      # shader compilation) before invoking packman pull. Currently:
+      # Pin packman entries we can't fetch back to a public-CDN
+      # version before invoking packman pull. Currently:
       #
-      #   - ngx_sdk_dlfg: published to NVGTL (NVIDIA-internal remote)
-      #     from v4 onward and requires NVM_GTLAPI_TOKEN. It's used
-      #     by dxvk-remix's C++ code only -- no shader includes any
-      #     header under external/ngx_sdk_dlfg/, so omitting it has
-      #     no effect on build_shaders_only.ps1.
+      #   - rtx-remix-ngx_sdk_dlfg v4 is published only to NVIDIA's
+      #     internal NVGTL packman remote (which requires
+      #     NVM_GTLAPI_TOKEN). v3 is still on the public CloudFront
+      #     CDN. The DLFG SDK is consumed by dxvk-remix's C++ code
+      #     only -- no shader includes any header under
+      #     external/ngx_sdk_dlfg/ -- but meson resolves
+      #     include_directories('../../external/ngx_sdk_dlfg/include')
+      #     during configure even for build_shaders_only.ps1, so the
+      #     directory has to exist. Pinning to v3 gives meson the
+      #     directory it wants without needing the NVGTL token.
       #
       # If a future package needs the same treatment, extend the
       # python regex below.
-      - name: Strip non-shader / NVGTL-only packman entries
+      - name: Pin NVGTL-only packman entries to public-CDN versions
         shell: bash
         run: |
           set -euo pipefail
@@ -144,19 +149,23 @@ jobs:
           import sys
           path = sys.argv[1]
           src = open(path).read()
-          # Remove the <dependency name="ngx_sdk_dlfg" ...>...</dependency>
-          # block. The XML uses tabs+spaces for indent, so anchor on the
-          # opening tag and consume through the matching closing tag.
+          # Rewrite the version attribute inside the
+          # <package name="rtx-remix-ngx_sdk_dlfg" version="N" />
+          # element from any value to "3". The version attribute is
+          # the only thing on that line that needs rewriting; the
+          # surrounding <dependency> wrapper stays intact.
           pattern = re.compile(
-              r'\s*<dependency\s+name="ngx_sdk_dlfg"[^>]*>.*?</dependency>',
-              re.DOTALL,
+              r'(<package\s+name="rtx-remix-ngx_sdk_dlfg"\s+version=")[^"]*(")'
           )
-          new, n = pattern.subn("", src)
+          new, n = pattern.subn(r"\g<1>3\g<2>", src)
           if n != 1:
-              sys.exit(f"expected exactly 1 ngx_sdk_dlfg dependency, found {n}")
+              sys.exit(
+                  f"expected exactly 1 rtx-remix-ngx_sdk_dlfg package "
+                  f"entry, found {n}"
+              )
           open(path, "w").write(new)
           PY
-          echo "Patched $xml: removed ngx_sdk_dlfg dependency."
+          echo "Patched $xml: pinned rtx-remix-ngx_sdk_dlfg to v3 (public CDN)."
 
       # Download shader compilation tools via packman
       # First run: ~2-5 min (downloads ~340MB)

--- a/.github/workflows/compile-rtx-remix-shaders-nightly.yml
+++ b/.github/workflows/compile-rtx-remix-shaders-nightly.yml
@@ -122,6 +122,42 @@ jobs:
             packman-
           enableCrossOsArchive: false
 
+      # Drop packman entries we can't fetch (and don't need for
+      # shader compilation) before invoking packman pull. Currently:
+      #
+      #   - ngx_sdk_dlfg: published to NVGTL (NVIDIA-internal remote)
+      #     from v4 onward and requires NVM_GTLAPI_TOKEN. It's used
+      #     by dxvk-remix's C++ code only -- no shader includes any
+      #     header under external/ngx_sdk_dlfg/, so omitting it has
+      #     no effect on build_shaders_only.ps1.
+      #
+      # If a future package needs the same treatment, extend the
+      # python regex below.
+      - name: Strip non-shader / NVGTL-only packman entries
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dxvk-remix
+          xml=packman-external.xml
+          python3 - "$xml" <<'PY'
+          import re
+          import sys
+          path = sys.argv[1]
+          src = open(path).read()
+          # Remove the <dependency name="ngx_sdk_dlfg" ...>...</dependency>
+          # block. The XML uses tabs+spaces for indent, so anchor on the
+          # opening tag and consume through the matching closing tag.
+          pattern = re.compile(
+              r'\s*<dependency\s+name="ngx_sdk_dlfg"[^>]*>.*?</dependency>',
+              re.DOTALL,
+          )
+          new, n = pattern.subn("", src)
+          if n != 1:
+              sys.exit(f"expected exactly 1 ngx_sdk_dlfg dependency, found {n}")
+          open(path, "w").write(new)
+          PY
+          echo "Patched $xml: removed ngx_sdk_dlfg dependency."
+
       # Download shader compilation tools via packman
       # First run: ~2-5 min (downloads ~340MB)
       # Cached run: ~30 seconds


### PR DESCRIPTION
## Summary

The nightly RTX Remix workflow has been red since 2026-05-21 04:27 UTC. dxvk-remix commit [`872d4837`](https://github.com/NVIDIAGameWorks/dxvk-remix/commit/872d4837) bumped `rtx-remix-ngx_sdk_dlfg` from v3 to v4, and v4 was published only to NVIDIA's restricted NVGTL packman remote. The OSS workflow has no credentials for NVGTL — and shouldn't, since pulling token-gated NVIDIA artifacts from a public CI mixes trust boundaries — so `packman pull` errors out on that single package:

```
Package 'rtx-remix-ngx_sdk_dlfg' at version '4' is missing from local storage.
packman(ERROR): The environment variable 'NVM_GTLAPI_TOKEN' must be set to use NVGTL
```

Failure: https://github.com/shader-slang/slang/actions/runs/26205419439/job/77104146977.

## Why pinning to v3 is safe

`rtx-remix-ngx_sdk_dlfg` is the DLSS Frame-Generation SDK, consumed only by dxvk-remix's C++ code — no shader `#include`s it. But we can't drop the entry outright: meson validates every `include_directories(...)` path at configure time, and `src/dxvk/meson.build:440` references `external/ngx_sdk_dlfg/include` unconditionally. v3 (still on the public CDN) ships the same include layout as v4, which is all meson needs.

## What changed

A new step "Pin NVGTL-only packman entries to public-CDN versions" runs between the cache restore and the packman pull. It rewrites `dxvk-remix/packman-external.xml` in-place to change the `rtx-remix-ngx_sdk_dlfg` version attribute from `4` to `3`, and aborts the step if the regex doesn't match exactly once — so a future XML restructure surfaces as an immediate failure instead of silently no-opping.

## Known limitations / follow-ups

This is a quickfix, not a long-term solution. The structural root cause is dxvk-remix's shader-only build path reusing the full C++ configure: an upstream change that conditionalizes DLFG-related `include_directories(...)` on a `shaders_only` option (or factors the shader build into a standalone meson project) would let us delete this patch entirely. Worth filing upstream.

Until then, we're holding the DLFG SDK at v3 on our side. If the v4+ header layout diverges from v3 (e.g., a header dxvk-remix's meson references gets renamed), the pin will break and we'll need to bump or revisit.

## Test plan

- [x] `workflow_dispatch` on this branch reaches the shader-compile step and produces the expected number of `.spv` / `.h` outputs — verified at https://github.com/shader-slang/slang/actions/runs/26210237455.
- [x] The pin step logs `Patched packman-external.xml: pinned rtx-remix-ngx_sdk_dlfg to v3 (public CDN).` and exits 0.
- [x] `packman pull` log shows `rtx-remix-ngx_sdk_dlfg@3` downloaded from cloudfront, no NVGTL reference.