### PR TITLE
Add BigQuery CI telemetry: schema, ingester, and ci-telemetry.yml ingest job

### DIFF
--- a/.github/workflows/check-python-core.yml
+++ b/.github/workflows/check-python-core.yml
@@ -34,7 +34,7 @@ jobs:
               echo "FAIL: $f"
               failed=1
             fi
-          done < <(find extras -type f -name '*.py' -print0)
+          done < <(find extras -type f -name '*.py' -not -path 'extras/ci/analytics/*' -print0)
           exit $failed
 
       - name: Check for non-stdlib imports
@@ -44,6 +44,13 @@ jobs:
           from pathlib import Path
 
           stdlib = sys.stdlib_module_names
+
+          # Paths under extras/ that are exempted from the core-python rule.
+          # extras/ci/analytics/ is the BigQuery ingester (PyYAML, etc.). It's
+          # only invoked from .github/workflows/ci-telemetry.yml, which
+          # pip-installs its own deps. No other CI step shells out to those
+          # scripts, so the 'no third-party deps' invariant doesn't apply.
+          EXEMPT_PREFIXES = ('extras/ci/analytics/',)
 
           # Collect all .py stems and package dirs under extras/ so that
           # cross-directory project-local imports are recognized.
@@ -56,6 +63,8 @@ jobs:
 
           errors = []
           for filepath in sorted(extras.rglob('*.py')):
+              if any(str(filepath).startswith(prefix) for prefix in EXEMPT_PREFIXES):
+                  continue
               with open(filepath) as f:
                   tree = ast.parse(f.read(), str(filepath))
               def check_module(top, desc):

--- a/.github/workflows/ci-telemetry.yml
+++ b/.github/workflows/ci-telemetry.yml
@@ -85,12 +85,14 @@ jobs:
     if: |
       (github.event_name == 'workflow_run' || github.event_name == 'workflow_dispatch')
       && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-    # Serialize ingests for the same (run_id, run_attempt) to avoid the rare
-    # workflow_run ↔ workflow_dispatch race on the same target, and to cap
-    # MERGE retry storms when many workflows complete simultaneously.
-    # Different targets stay parallel because the group key includes the run
-    # id + attempt; cancel-in-progress is false because the loader's
-    # idempotency model means a duplicate ingest is safe to let finish.
+    # Serialize ingests of the same (run_id, run_attempt). This avoids the
+    # rare workflow_run ↔ workflow_dispatch race on the same target and the
+    # gh-ui-double-click case. It does NOT cap global ingest fan-out — that's
+    # GitHub's per-repo job concurrency cap, not this knob — but the loader's
+    # MERGE conflict retry already handles concurrent ingests of different
+    # targets cleanly. cancel-in-progress is false because the loader's
+    # idempotency model means a duplicate ingest is safe to let finish, and
+    # mid-flight cancellation would skip the staging-table cleanup.
     concurrency:
       group: ci-telemetry-ingest-${{ github.event.workflow_run.id || inputs.run_id }}-${{ github.event.workflow_run.run_attempt || inputs.run_attempt }}
       cancel-in-progress: false
@@ -147,20 +149,24 @@ jobs:
             run_id="${DISPATCH_RUN_ID}"
             run_attempt="${DISPATCH_RUN_ATTEMPT}"
           fi
-          # Defensive validation: both must be positive integers (run IDs
-          # and attempt numbers are always >= 1 in GitHub Actions).
-          # ci_bq_ingest treats them as ints, but reject early so the failure
-          # surfaces here rather than mid-ingest.
+          # Defensive validation: both must be positive integers in their
+          # canonical form (no leading zeros). Run IDs and attempt numbers
+          # are always >= 1 in GitHub Actions. Canonical form matters here
+          # because the value flows into the concurrency group key
+          # `ci-telemetry-ingest-<run>-<attempt>`: an operator typing
+          # `026149...` would target the same numeric run as the matching
+          # workflow_run but fail to share the same concurrency group.
+          # Ingester idempotency would absorb the duplicate, but cleaner
+          # to reject at the boundary.
           #
-          # Two-stage check per field:
-          #   1. case-glob: must be non-empty and all digits. Cheap and
-          #      catches injection-shaped input before reaching `test`.
-          #   2. POSIX arithmetic test: must be > 0. Handles "0", "00",
-          #      "000" etc. which the case-glob alone would accept.
+          # Three-stage check per field:
+          #   1. case-glob: non-empty, all digits, no leading zero.
+          #   2. POSIX arithmetic test: must be > 0 (belt-and-suspenders,
+          #      and catches the literal "0" the glob does accept).
           for var in run_id run_attempt; do
             eval "val=\$$var"
             case "$val" in
-              ''|*[!0-9]*) echo "::error::invalid $var: $val"; exit 1 ;;
+              ''|*[!0-9]*|0?*) echo "::error::invalid $var: $val"; exit 1 ;;
             esac
             if [ "$val" -le 0 ]; then
               echo "::error::$var must be positive, got: $val"

--- a/.github/workflows/ci-telemetry.yml
+++ b/.github/workflows/ci-telemetry.yml
@@ -72,20 +72,24 @@ jobs:
     # workflow_run fires for every completed run of the listed workflows;
     # workflow_dispatch is the manual escape hatch. Both modes share the
     # same ingest path.
-    if: github.event_name == 'workflow_run' || github.event_name == 'workflow_dispatch'
+    #
+    # Default-branch guard: workflow_dispatch lets the operator choose a
+    # ref, and the chosen ref's copy of this YAML is what executes. Without
+    # this guard, anyone with write access could push a branch that modifies
+    # ci-telemetry.yml and dispatch from there to impersonate the ingest SA.
+    # The WIF binding's workflow_ref condition is the IAM-layer defense; this
+    # is the workflow-layer defense. github.ref is the workflow file's ref,
+    # not the triggering run's ref, so this correctly rejects manual runs
+    # from non-default branches.
+    if: |
+      (github.event_name == 'workflow_run' || github.event_name == 'workflow_dispatch')
+      && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
       actions: read
       id-token: write # for google-github-actions/auth (OIDC → WIF → ingest SA)
-
-    env:
-      # The ingester reads this to authenticate to the GitHub API. Inside
-      # workflow_run, GITHUB_TOKEN is auto-scoped to the base repo with
-      # actions:read; reads of run/job/artifact data for the triggering run
-      # are allowed even when that run came from a fork PR.
-      GH_TOKEN: ${{ github.token }}
 
     steps:
       - name: Checkout (master, NEVER the triggering ref)
@@ -133,19 +137,26 @@ jobs:
             run_id="${DISPATCH_RUN_ID}"
             run_attempt="${DISPATCH_RUN_ATTEMPT}"
           fi
-          # Defensive validation: both must be positive integers. ci_bq_ingest
-          # treats them as ints, but reject early so the failure surfaces here
-          # rather than mid-ingest.
+          # Defensive validation: both must be positive integers (run IDs
+          # and attempt numbers are always >= 1 in GitHub Actions).
+          # ci_bq_ingest treats them as ints, but reject early so the failure
+          # surfaces here rather than mid-ingest.
           case "$run_id" in
-            ''|*[!0-9]*) echo "::error::invalid run_id: $run_id"; exit 1 ;;
+            ''|0|*[!0-9]*) echo "::error::invalid run_id: $run_id"; exit 1 ;;
           esac
           case "$run_attempt" in
-            ''|*[!0-9]*) echo "::error::invalid run_attempt: $run_attempt"; exit 1 ;;
+            ''|0|*[!0-9]*) echo "::error::invalid run_attempt: $run_attempt"; exit 1 ;;
           esac
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
           echo "run_attempt=$run_attempt" >> "$GITHUB_OUTPUT"
 
       - name: Ingest
+        # GH_TOKEN is scoped to this single step. The ingester uses it to
+        # call the GitHub API (run/jobs/artifacts endpoints). It's the
+        # only step that touches gh; checkout uses its own
+        # persist-credentials toggle, and the gcloud auth path is separate.
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           python extras/ci/analytics/ci_bq_ingest.py \
             --run-id "${{ steps.target.outputs.run_id }}" \

--- a/.github/workflows/ci-telemetry.yml
+++ b/.github/workflows/ci-telemetry.yml
@@ -64,11 +64,12 @@ on:
         type: string
 
 permissions:
-  contents: read
-  actions: read
+  contents: read # actions/checkout reads the default branch
+  actions: read # ingester needs the runs/jobs/artifacts API endpoints
 
 jobs:
   ingest:
+    name: Ingest one (run_id, run_attempt) into slang_ci
     # workflow_run fires for every completed run of the listed workflows;
     # workflow_dispatch is the manual escape hatch. Both modes share the
     # same ingest path.
@@ -84,11 +85,20 @@ jobs:
     if: |
       (github.event_name == 'workflow_run' || github.event_name == 'workflow_dispatch')
       && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    # Serialize ingests for the same (run_id, run_attempt) to avoid the rare
+    # workflow_run ↔ workflow_dispatch race on the same target, and to cap
+    # MERGE retry storms when many workflows complete simultaneously.
+    # Different targets stay parallel because the group key includes the run
+    # id + attempt; cancel-in-progress is false because the loader's
+    # idempotency model means a duplicate ingest is safe to let finish.
+    concurrency:
+      group: ci-telemetry-ingest-${{ github.event.workflow_run.id || inputs.run_id }}-${{ github.event.workflow_run.run_attempt || inputs.run_attempt }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      contents: read
-      actions: read
+      contents: read # actions/checkout
+      actions: read # GitHub API access for runs/jobs/artifacts
       id-token: write # for google-github-actions/auth (OIDC → WIF → ingest SA)
 
     steps:

--- a/.github/workflows/ci-telemetry.yml
+++ b/.github/workflows/ci-telemetry.yml
@@ -141,12 +141,22 @@ jobs:
           # and attempt numbers are always >= 1 in GitHub Actions).
           # ci_bq_ingest treats them as ints, but reject early so the failure
           # surfaces here rather than mid-ingest.
-          case "$run_id" in
-            ''|0|*[!0-9]*) echo "::error::invalid run_id: $run_id"; exit 1 ;;
-          esac
-          case "$run_attempt" in
-            ''|0|*[!0-9]*) echo "::error::invalid run_attempt: $run_attempt"; exit 1 ;;
-          esac
+          #
+          # Two-stage check per field:
+          #   1. case-glob: must be non-empty and all digits. Cheap and
+          #      catches injection-shaped input before reaching `test`.
+          #   2. POSIX arithmetic test: must be > 0. Handles "0", "00",
+          #      "000" etc. which the case-glob alone would accept.
+          for var in run_id run_attempt; do
+            eval "val=\$$var"
+            case "$val" in
+              ''|*[!0-9]*) echo "::error::invalid $var: $val"; exit 1 ;;
+            esac
+            if [ "$val" -le 0 ]; then
+              echo "::error::$var must be positive, got: $val"
+              exit 1
+            fi
+          done
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
           echo "run_attempt=$run_attempt" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci-telemetry.yml
+++ b/.github/workflows/ci-telemetry.yml
@@ -1,0 +1,154 @@
+# BigQuery CI telemetry ingester.
+#
+# Fires on completion of in-scope workflows, ingests the run + its jobs +
+# steps into per-attempt staging tables in slang-runners:slang_ci_staging,
+# then atomically MERGEs the staged data into the live slang_ci dataset.
+#
+# Design notes are in slang-ci-docs:plans/bigquery-reporting.md. The two
+# things worth recalling here:
+#
+# - This workflow ONLY runs from the default branch. workflow_run gives it
+#   elevated privileges (secrets + writable GITHUB_TOKEN) even when the
+#   triggering run was a fork PR, so the workflow's contents — and every
+#   action it pulls in — are the entire trust boundary.
+# - Each action is therefore pinned to a commit SHA, not a tag.
+#
+# This commit lands the `ingest` job only. The `publish-snapshot` job (and
+# the hourly schedule trigger) follow in a separate commit once at least
+# one snapshot query exists to publish.
+
+name: CI Telemetry
+
+on:
+  workflow_run:
+    workflows:
+      # Tier 1 (parse_graph) — kept in sync with PARSE_GRAPH_WORKFLOWS in
+      # extras/ci/analytics/_bq_ingest_lib.py.
+      - CI
+      - CMake Options
+      - Falcor Tests
+      - Falcor Compiler Perf-Test
+      - RTX Remix Shaders (Nightly)
+      - Sascha Willems Vulkan Shaders (Nightly)
+      - VK-GL-CTS Nightly
+      # Tier 2 (record_only) — housekeeping workflows that consume hosted-
+      # runner slots and are worth tracking for the quota-exhaustion chart.
+      # Add liberally: Tier 2 is cheap (no YAML fetch, no artifact downloads).
+      - Verify PR Labels
+      - Check Formatting (comment /format to auto-fix)
+      - Check Table of Contents (comment /regenerate-toc to auto-fix)
+      - Check Command Line Reference (comment /regenerate-cmdline-ref to auto-fix)
+      - Check Container Image Consistency
+      - Check SPIRV Generated Files
+      - Check Python Scripts (Core Python Only)
+      - Compile Regression-Test
+      - Format
+      - Nightly Sanitizer
+      - Coverage (Nightly)
+      - MDL Benchmark
+      - Populate sccache
+    types: [completed]
+  # Manual dispatch for ingesting a specific historical run without waiting
+  # for a real workflow_run event. Lets us validate the WIF auth path on
+  # master before any real ingest hits.
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Triggering CI run ID to ingest
+        required: true
+        type: string
+      run_attempt:
+        description: Triggering CI run attempt (1, 2, …)
+        required: true
+        default: "1"
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  ingest:
+    # workflow_run fires for every completed run of the listed workflows;
+    # workflow_dispatch is the manual escape hatch. Both modes share the
+    # same ingest path.
+    if: github.event_name == 'workflow_run' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: read
+      id-token: write # for google-github-actions/auth (OIDC → WIF → ingest SA)
+
+    env:
+      # The ingester reads this to authenticate to the GitHub API. Inside
+      # workflow_run, GITHUB_TOKEN is auto-scoped to the base repo with
+      # actions:read; reads of run/job/artifact data for the triggering run
+      # are allowed even when that run came from a fork PR.
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout (master, NEVER the triggering ref)
+        # workflow_run defaults to checking out the default branch, but
+        # being explicit about ref guards against future refactors that
+        # accidentally point at the triggering run's head_sha.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Python deps
+        run: python -m pip install --no-deps pyyaml==6.0.2
+
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider
+          service_account: slang-ci-ingest@slang-runners.iam.gserviceaccount.com
+
+      - name: Set up gcloud (provides bq)
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+        with:
+          project_id: slang-runners
+
+      - name: Resolve target run from event payload
+        id: target
+        env:
+          # Avoid passing event payload through shell expansion.
+          WF_RUN_ID: ${{ github.event.workflow_run.id }}
+          WF_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          DISPATCH_RUN_ID: ${{ inputs.run_id }}
+          DISPATCH_RUN_ATTEMPT: ${{ inputs.run_attempt }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            run_id="${WF_RUN_ID}"
+            run_attempt="${WF_RUN_ATTEMPT}"
+          else
+            run_id="${DISPATCH_RUN_ID}"
+            run_attempt="${DISPATCH_RUN_ATTEMPT}"
+          fi
+          # Defensive validation: both must be positive integers. ci_bq_ingest
+          # treats them as ints, but reject early so the failure surfaces here
+          # rather than mid-ingest.
+          case "$run_id" in
+            ''|*[!0-9]*) echo "::error::invalid run_id: $run_id"; exit 1 ;;
+          esac
+          case "$run_attempt" in
+            ''|*[!0-9]*) echo "::error::invalid run_attempt: $run_attempt"; exit 1 ;;
+          esac
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          echo "run_attempt=$run_attempt" >> "$GITHUB_OUTPUT"
+
+      - name: Ingest
+        run: |
+          python extras/ci/analytics/ci_bq_ingest.py \
+            --run-id "${{ steps.target.outputs.run_id }}" \
+            --run-attempt "${{ steps.target.outputs.run_attempt }}" \
+            --validate \
+            --load-to-bq

--- a/extras/ci/analytics/_bq_ingest_lib.py
+++ b/extras/ci/analytics/_bq_ingest_lib.py
@@ -1,0 +1,108 @@
+"""Shared helpers for the BigQuery ingester and workflow parser.
+
+Kept separate from the CLI entry points so workflow_parser.py can be unit-tested
+without importing argparse / GH-API plumbing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from typing import Any
+
+
+def gh_api(path: str) -> dict[str, Any]:
+    """Single GH API call returning parsed JSON."""
+    proc = subprocess.run(
+        ["gh", "api", path],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def gh_api_paginated(path: str, list_key: str) -> list[dict[str, Any]]:
+    """Paginated GH API walk. `path` may already contain a query string.
+
+    Uses `gh api --paginate` which handles Link headers transparently and
+    concatenates the named list field across pages.
+    """
+    sep = "&" if "?" in path else "?"
+    full_path = f"{path}{sep}per_page=100"
+    proc = subprocess.run(
+        ["gh", "api", "--paginate", full_path],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    # --paginate emits one JSON object per page concatenated.
+    out: list[dict[str, Any]] = []
+    decoder = json.JSONDecoder()
+    text = proc.stdout.strip()
+    idx = 0
+    while idx < len(text):
+        obj, end = decoder.raw_decode(text, idx)
+        out.extend(obj.get(list_key, []))
+        idx = end
+        while idx < len(text) and text[idx].isspace():
+            idx += 1
+    return out
+
+
+def sha256_hex(s: str) -> str:
+    return hashlib.sha256(s.encode()).hexdigest()
+
+
+# Row-key formulas — one place to look when chasing schema bugs.
+
+def rk_workflow_run(run_id: int, run_attempt: int) -> str:
+    return sha256_hex(f"workflow_run:{run_id}:{run_attempt}")
+
+
+def rk_concrete(job_id: int) -> str:
+    return sha256_hex(f"concrete:{job_id}")
+
+
+def rk_caller_node(
+    run_id: int,
+    run_attempt: int,
+    caller_workflow_file: str,
+    caller_job_key: str,
+    graph_instance_key: str,
+) -> str:
+    return sha256_hex(
+        f"caller:{run_id}:{run_attempt}:{caller_workflow_file}:"
+        f"{caller_job_key}:{graph_instance_key}"
+    )
+
+
+def rk_direct_node(
+    run_id: int,
+    run_attempt: int,
+    caller_workflow_file: str,
+    caller_job_key: str,
+    graph_instance_key: str,
+) -> str:
+    return sha256_hex(
+        f"direct:{run_id}:{run_attempt}:{caller_workflow_file}:"
+        f"{caller_job_key}:{graph_instance_key}"
+    )
+
+
+def rk_step(job_id: int, step_number: int) -> str:
+    return sha256_hex(f"step:{job_id}:{step_number}")
+
+
+def canonical_matrix_key(matrix: dict[str, Any]) -> str:
+    """Canonical-stringified caller-side matrix tuple — `key=val,key=val`,
+    keys sorted alphabetically, values verbatim. Empty string when no matrix.
+
+    The plan specifies this exact shape so row_keys are stable across ingester
+    runs and across rewrites.
+    """
+    if not matrix:
+        return ""
+    parts = [f"{k}={matrix[k]}" for k in sorted(matrix)]
+    return ",".join(parts)

--- a/extras/ci/analytics/_bq_ingest_lib.py
+++ b/extras/ci/analytics/_bq_ingest_lib.py
@@ -12,6 +12,35 @@ import subprocess
 from typing import Any
 
 
+# Tier 1 (`parse_graph`) workflows: full YAML fetch + graph-node materialization
+# + (eventually) build_stats artifacts. Matched by display `name:` field, not
+# filename — that's what GitHub's `on: workflow_run:` clause uses.
+#
+# Everything else that reaches the ingester is Tier 2 (`record_only`): concrete
+# jobs only, NULL graph columns. The `ci-telemetry.yml` `on: workflow_run:`
+# filter is the union of both tiers; the dispatch happens here.
+#
+# MaterialX Integration Tests is intentionally NOT in Tier 1: it's
+# workflow_call:-only, so it never fires its own workflow_run event. Its jobs
+# arrive transitively via CI's caller_node rows.
+PARSE_GRAPH_WORKFLOWS: frozenset[str] = frozenset({
+    "CI",
+    "CMake Options",
+    "Falcor Tests",
+    "Falcor Compiler Perf-Test",
+    "RTX Remix Shaders (Nightly)",
+    "Sascha Willems Vulkan Shaders (Nightly)",
+    "VK-GL-CTS Nightly",
+})
+
+
+def workflow_tier(workflow_name: str | None) -> str:
+    """Return 'parse_graph' or 'record_only' for a workflow's display name."""
+    if workflow_name in PARSE_GRAPH_WORKFLOWS:
+        return "parse_graph"
+    return "record_only"
+
+
 def gh_api(path: str) -> dict[str, Any]:
     """Single GH API call returning parsed JSON."""
     proc = subprocess.run(

--- a/extras/ci/analytics/bq_loader.py
+++ b/extras/ci/analytics/bq_loader.py
@@ -26,6 +26,7 @@ import json
 import os
 import random
 import re
+import secrets
 import subprocess
 import sys
 import tempfile
@@ -36,6 +37,12 @@ from typing import Any, Iterable
 # Caller-validated suffix shape — anything else risks SQL injection via the
 # `str.format()`-templated MERGE script.
 _SAFE_TOKEN = re.compile(r"^[A-Za-z0-9_]+$")
+
+# The plan's BigQuery project. The MERGE template hardcodes the same name,
+# so making this a parameter would create a footgun (loads in one project,
+# MERGE against another). One constant is the simplest honest expression
+# of "we have exactly one prod project."
+PROJECT = "slang-runners"
 
 
 def staging_suffix(
@@ -72,14 +79,18 @@ def derive_ingester_identity() -> tuple[str, str]:
 
     Inside GitHub Actions, GITHUB_RUN_ID and GITHUB_RUN_ATTEMPT are set; both
     are integers but we keep them as strings since they flow into the staging
-    suffix. For manual CLI invocations, fall back to a `manual<unix_ms>`
-    identity and attempt=1, so simultaneous local runs cannot collide.
+    suffix. For manual CLI invocations, fall back to a hybrid identity
+    `manual<unix_ms>p<pid>r<random_hex>` and attempt=1. The random suffix is
+    what makes two invocations within the same millisecond — same `time()`,
+    same `pid` after a quick fork-exec — still get distinct staging tables.
     """
     run_id = os.environ.get("GITHUB_RUN_ID")
     run_attempt = os.environ.get("GITHUB_RUN_ATTEMPT")
     if run_id and run_attempt:
         return run_id, run_attempt
-    return f"manual{int(time.time() * 1000)}", "1"
+    ms = int(time.time() * 1000)
+    rand_suffix = secrets.token_hex(4)  # 8 hex chars; 32 bits of randomness
+    return f"manual{ms}p{os.getpid()}r{rand_suffix}", "1"
 
 
 # ---------- bq CLI wrappers ----------
@@ -106,33 +117,30 @@ def _bq_run(args: list[str]) -> subprocess.CompletedProcess:
     return proc
 
 
-_schema_cache: dict[tuple[str, str], list[dict[str, Any]]] = {}
+_schema_cache: dict[str, list[dict[str, Any]]] = {}
 
 
-def _live_schema_path(
-    table: str, *, project: str, schema_dir: Path
-) -> Path:
+def _live_schema_path(table: str, *, schema_dir: Path) -> Path:
     """Return a path to a JSON file containing the live table's schema, fit
-    for `bq load --schema=<path>`. Cached per (project, table) within the
-    process so repeated loads in one ingest only hit `bq show` once.
+    for `bq load --schema=<path>`. Cached per table within the process so
+    repeated loads in one ingest only hit `bq show` once.
     """
-    key = (project, table)
-    if key not in _schema_cache:
+    if table not in _schema_cache:
         proc = subprocess.run(
             [
                 "bq",
                 "show",
                 "--format=prettyjson",
                 "--schema",
-                f"{project}:slang_ci.{table}",
+                f"{PROJECT}:slang_ci.{table}",
             ],
             check=True,
             capture_output=True,
             text=True,
         )
-        _schema_cache[key] = json.loads(proc.stdout)
+        _schema_cache[table] = json.loads(proc.stdout)
     schema_path = schema_dir / f"{table}.schema.json"
-    schema_path.write_text(json.dumps(_schema_cache[key]))
+    schema_path.write_text(json.dumps(_schema_cache[table]))
     return schema_path
 
 
@@ -142,7 +150,6 @@ def load_ndjson_to_staging(
     ndjson_path: Path,
     suffix: str,
     schema_dir: Path,
-    project: str = "slang-runners",
 ) -> str:
     """`bq load` an NDJSON file into a new per-attempt staging table.
 
@@ -155,8 +162,8 @@ def load_ndjson_to_staging(
     """
     if not _SAFE_TOKEN.match(table):
         raise ValueError(f"bad table name {table!r}")
-    staging_id = f"{project}:slang_ci_staging.{table}__{suffix}"
-    schema_path = _live_schema_path(table, project=project, schema_dir=schema_dir)
+    staging_id = f"{PROJECT}:slang_ci_staging.{table}__{suffix}"
+    schema_path = _live_schema_path(table, schema_dir=schema_dir)
     # --replace lets retries clobber a leftover staging table from a previous
     # crash; the suffix already encodes attempt identity so this is correct.
     _bq_run(
@@ -172,14 +179,16 @@ def load_ndjson_to_staging(
     return staging_id
 
 
-def drop_staging_tables(suffix: str, *, tables: Iterable[str], project: str = "slang-runners") -> None:
+def drop_staging_tables(suffix: str, *, tables: Iterable[str]) -> None:
     """Drop the per-attempt staging tables, swallowing per-table errors so the
-    cleanup pass always tries every table. Called from a finally: clause.
+    cleanup pass always tries every table. Called from a finally: clause, so
+    it must tolerate the "table never existed because its load failed" case.
+    `bq rm -f` already exits 0 when the table is missing.
     """
     for table in tables:
         if not _SAFE_TOKEN.match(table):
             continue
-        staging_id = f"{project}:slang_ci_staging.{table}__{suffix}"
+        staging_id = f"{PROJECT}:slang_ci_staging.{table}__{suffix}"
         try:
             _bq_run(["rm", "-f", "-t", staging_id])
         except subprocess.CalledProcessError as e:
@@ -209,7 +218,6 @@ def _is_transaction_conflict(stderr: str) -> bool:
 def run_merge_with_retry(
     *,
     sql: str,
-    project: str = "slang-runners",
     max_attempts: int = 7,
 ) -> None:
     """Run the multi-statement MERGE transaction with conflict retry.
@@ -230,7 +238,7 @@ def run_merge_with_retry(
                 "query",
                 "--use_legacy_sql=false",
                 "--project_id",
-                project,
+                PROJECT,
                 "--format=none",
             ],
             input=sql,
@@ -267,7 +275,6 @@ def load_rows_to_bq(
     *,
     src_run_id: int,
     src_run_attempt: int,
-    project: str = "slang-runners",
     merge_template_path: Path | None = None,
 ) -> None:
     """End-to-end: write per-table NDJSON, load into per-attempt staging,
@@ -297,25 +304,29 @@ def load_rows_to_bq(
 
     with tempfile.TemporaryDirectory(prefix="bq-stage-") as tmp:
         tmp_dir = Path(tmp)
-        for table in _PHASE1_TABLES:
-            table_rows = rows.get(table, [])
-            ndjson_path = tmp_dir / f"{table}.ndjson"
-            with ndjson_path.open("w") as f:
-                for r in table_rows:
-                    f.write(json.dumps(r))
-                    f.write("\n")
-            load_ndjson_to_staging(
-                table=table,
-                ndjson_path=ndjson_path,
-                suffix=suffix,
-                schema_dir=tmp_dir,
-                project=project,
-            )
-
+        # try/finally wraps both the staging-load phase and the MERGE phase
+        # so a failure partway through the loads still triggers cleanup.
+        # bq load --replace creates the staging tables as a side effect, so
+        # any table we attempted to load may already exist when we land here.
         try:
-            run_merge_with_retry(sql=sql, project=project)
+            for table in _PHASE1_TABLES:
+                table_rows = rows.get(table, [])
+                ndjson_path = tmp_dir / f"{table}.ndjson"
+                with ndjson_path.open("w") as f:
+                    for r in table_rows:
+                        f.write(json.dumps(r))
+                        f.write("\n")
+                load_ndjson_to_staging(
+                    table=table,
+                    ndjson_path=ndjson_path,
+                    suffix=suffix,
+                    schema_dir=tmp_dir,
+                )
+            run_merge_with_retry(sql=sql)
         finally:
             # Always clean up staging tables — they're disposable and the
             # staging dataset has a 1-day default expiration as a safety net,
-            # but explicit drop keeps things tidy.
-            drop_staging_tables(suffix, tables=_PHASE1_TABLES, project=project)
+            # but explicit drop keeps things tidy. drop_staging_tables
+            # tolerates "table not found" so it's safe to call even when a
+            # load failed before creating a given table.
+            drop_staging_tables(suffix, tables=_PHASE1_TABLES)

--- a/extras/ci/analytics/bq_loader.py
+++ b/extras/ci/analytics/bq_loader.py
@@ -1,0 +1,321 @@
+"""Live BigQuery loader for the Phase 1 ingester.
+
+Loads NDJSON-per-table into per-attempt staging tables, runs an atomic
+multi-statement MERGE script against the live tables, then cleans up.
+
+Naming contract for staging tables:
+
+    slang_ci_staging.<table>__src_<src_run_id>_<src_run_attempt>__ing_<ing_run_id>_<ing_run_attempt>
+
+`src_*` is the triggering CI run identity (the run we are ingesting).
+`ing_*` is this ingester's own identity. In production both come from
+GITHUB_RUN_ID / GITHUB_RUN_ATTEMPT environment variables; for manual CLI
+invocations the ingester identity falls back to "manual" + a unix
+timestamp so simultaneous CLI runs cannot collide.
+
+Why both: a re-run of ci-telemetry.yml against the same CI run gets a
+new ing_* but reuses src_*, so two concurrent ingest jobs cannot share
+staging tables. The live row_keys are deterministic, so the eventual
+MERGE converges to the same final state regardless of which attempt
+wins.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Iterable
+
+# Caller-validated suffix shape — anything else risks SQL injection via the
+# `str.format()`-templated MERGE script.
+_SAFE_TOKEN = re.compile(r"^[A-Za-z0-9_]+$")
+
+
+def staging_suffix(
+    *,
+    src_run_id: int,
+    src_run_attempt: int,
+    ing_run_id: str | int,
+    ing_run_attempt: str | int,
+) -> str:
+    """Build the canonical staging-table suffix.
+
+    Format: `src_<src_run_id>_<src_run_attempt>__ing_<ing_run_id>_<ing_run_attempt>`.
+    Every component is restricted to `[A-Za-z0-9_]+` because the suffix flows
+    into a `str.format()`-templated SQL script.
+    """
+    parts = (
+        "src",
+        str(src_run_id),
+        str(src_run_attempt),
+        "_ing",  # leading underscore yields the `__ing_` double separator
+        str(ing_run_id),
+        str(ing_run_attempt),
+    )
+    suffix = "_".join(parts)
+    if not _SAFE_TOKEN.match(suffix):
+        raise ValueError(
+            f"staging suffix {suffix!r} contains characters outside [A-Za-z0-9_]"
+        )
+    return suffix
+
+
+def derive_ingester_identity() -> tuple[str, str]:
+    """Return (ing_run_id, ing_run_attempt) for the current process.
+
+    Inside GitHub Actions, GITHUB_RUN_ID and GITHUB_RUN_ATTEMPT are set; both
+    are integers but we keep them as strings since they flow into the staging
+    suffix. For manual CLI invocations, fall back to a `manual<unix_ms>`
+    identity and attempt=1, so simultaneous local runs cannot collide.
+    """
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    run_attempt = os.environ.get("GITHUB_RUN_ATTEMPT")
+    if run_id and run_attempt:
+        return run_id, run_attempt
+    return f"manual{int(time.time() * 1000)}", "1"
+
+
+# ---------- bq CLI wrappers ----------
+
+
+def _bq_run(args: list[str]) -> subprocess.CompletedProcess:
+    """Run a `bq` CLI command. The bq CLI is available wherever the gcloud SDK
+    is installed; for production we'll be inside the google-github-actions/auth
+    + setup-gcloud composite, which also installs bq.
+
+    On non-zero exit, surface the captured stderr to the calling process's
+    stderr so failures are debuggable. Without this, bq's error message is
+    swallowed by subprocess.run(check=True) and only the command line appears
+    in the traceback.
+    """
+    proc = subprocess.run(
+        ["bq", *args],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        proc.check_returncode()
+    return proc
+
+
+_schema_cache: dict[tuple[str, str], list[dict[str, Any]]] = {}
+
+
+def _live_schema_path(
+    table: str, *, project: str, schema_dir: Path
+) -> Path:
+    """Return a path to a JSON file containing the live table's schema, fit
+    for `bq load --schema=<path>`. Cached per (project, table) within the
+    process so repeated loads in one ingest only hit `bq show` once.
+    """
+    key = (project, table)
+    if key not in _schema_cache:
+        proc = subprocess.run(
+            [
+                "bq",
+                "show",
+                "--format=prettyjson",
+                "--schema",
+                f"{project}:slang_ci.{table}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        _schema_cache[key] = json.loads(proc.stdout)
+    schema_path = schema_dir / f"{table}.schema.json"
+    schema_path.write_text(json.dumps(_schema_cache[key]))
+    return schema_path
+
+
+def load_ndjson_to_staging(
+    *,
+    table: str,
+    ndjson_path: Path,
+    suffix: str,
+    schema_dir: Path,
+    project: str = "slang-runners",
+) -> str:
+    """`bq load` an NDJSON file into a new per-attempt staging table.
+
+    Returns the fully-qualified staging table identifier.
+
+    Each load passes an explicit `--schema` argument derived from the live
+    table's current schema, so the staging table inherits the same shape.
+    BigQuery cannot infer the schema of an empty NDJSON file, so this is
+    mandatory anyway.
+    """
+    if not _SAFE_TOKEN.match(table):
+        raise ValueError(f"bad table name {table!r}")
+    staging_id = f"{project}:slang_ci_staging.{table}__{suffix}"
+    schema_path = _live_schema_path(table, project=project, schema_dir=schema_dir)
+    # --replace lets retries clobber a leftover staging table from a previous
+    # crash; the suffix already encodes attempt identity so this is correct.
+    _bq_run(
+        [
+            "load",
+            "--source_format=NEWLINE_DELIMITED_JSON",
+            "--replace",
+            f"--schema={schema_path}",
+            staging_id,
+            str(ndjson_path),
+        ]
+    )
+    return staging_id
+
+
+def drop_staging_tables(suffix: str, *, tables: Iterable[str], project: str = "slang-runners") -> None:
+    """Drop the per-attempt staging tables, swallowing per-table errors so the
+    cleanup pass always tries every table. Called from a finally: clause.
+    """
+    for table in tables:
+        if not _SAFE_TOKEN.match(table):
+            continue
+        staging_id = f"{project}:slang_ci_staging.{table}__{suffix}"
+        try:
+            _bq_run(["rm", "-f", "-t", staging_id])
+        except subprocess.CalledProcessError as e:
+            sys.stderr.write(
+                f"warning: failed to drop staging table {staging_id}: {e}\n"
+            )
+
+
+# ---------- Transactional MERGE with retry ----------
+
+
+# BigQuery returns a specific error string for cancelled mutating transactions.
+# We match on substring rather than error code because the bq CLI surfaces the
+# message body in non-zero exit text.
+_TXN_CONFLICT_MARKERS = (
+    "Transaction is aborted",
+    "concurrent update",
+    "Could not serialize access",
+    "TRANSACTION_ABORTED",
+)
+
+
+def _is_transaction_conflict(stderr: str) -> bool:
+    return any(m in stderr for m in _TXN_CONFLICT_MARKERS)
+
+
+def run_merge_with_retry(
+    *,
+    sql: str,
+    project: str = "slang-runners",
+    max_attempts: int = 7,
+) -> None:
+    """Run the multi-statement MERGE transaction with conflict retry.
+
+    Plan retry budget: 7 attempts, sleep `random.uniform(0, 2**attempt)`
+    between attempts 1..6, worst case ~126s of cumulative sleep. After
+    exhaustion the call raises so the GH Actions job fails loudly.
+
+    The SQL is fed through stdin rather than as a positional argument
+    because `bq query` argv-parses any positional containing `=` against
+    its flag list (a runaway suggestion-distance algorithm in absl
+    blows the stack on a multi-statement MERGE).
+    """
+    for attempt in range(1, max_attempts + 1):
+        proc = subprocess.run(
+            [
+                "bq",
+                "query",
+                "--use_legacy_sql=false",
+                "--project_id",
+                project,
+                "--format=none",
+            ],
+            input=sql,
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode == 0:
+            return
+        if attempt < max_attempts and _is_transaction_conflict(proc.stderr):
+            sleep_s = random.uniform(0, 2**attempt)
+            sys.stderr.write(
+                f"MERGE transaction conflict on attempt {attempt}; "
+                f"sleeping {sleep_s:.2f}s and retrying.\n"
+            )
+            time.sleep(sleep_s)
+            continue
+        # Non-conflict error, or budget exhausted on a conflict.
+        sys.stderr.write(proc.stderr)
+        raise subprocess.CalledProcessError(
+            proc.returncode, proc.args, proc.stdout, proc.stderr
+        )
+
+
+# ---------- Top-level loader ----------
+
+
+# Tables this Phase 1 slice ingests. Order matters only for the MERGE SQL
+# template's DECLARE block, not here.
+_PHASE1_TABLES = ("workflow_runs", "jobs", "job_steps")
+
+
+def load_rows_to_bq(
+    rows: dict[str, list[dict[str, Any]]],
+    *,
+    src_run_id: int,
+    src_run_attempt: int,
+    project: str = "slang-runners",
+    merge_template_path: Path | None = None,
+) -> None:
+    """End-to-end: write per-table NDJSON, load into per-attempt staging,
+    run the atomic MERGE with retry, then drop staging tables in a finally
+    clause.
+
+    No-ops on tables with zero rows in `rows` — the MERGE template still
+    references them, so an empty NDJSON file is `bq load`-ed and the
+    MIN/MAX-derived partition predicate degrades to (NULL, NULL), which the
+    MERGE BETWEEN clause correctly evaluates to "no rows match".
+    """
+    ing_run_id, ing_run_attempt = derive_ingester_identity()
+    suffix = staging_suffix(
+        src_run_id=src_run_id,
+        src_run_attempt=src_run_attempt,
+        ing_run_id=ing_run_id,
+        ing_run_attempt=ing_run_attempt,
+    )
+
+    if merge_template_path is None:
+        merge_template_path = (
+            Path(__file__).resolve().parent
+            / "bq_schema"
+            / "merge_live_tables.sql.tmpl"
+        )
+    sql = merge_template_path.read_text().format(staging_suffix=suffix)
+
+    with tempfile.TemporaryDirectory(prefix="bq-stage-") as tmp:
+        tmp_dir = Path(tmp)
+        for table in _PHASE1_TABLES:
+            table_rows = rows.get(table, [])
+            ndjson_path = tmp_dir / f"{table}.ndjson"
+            with ndjson_path.open("w") as f:
+                for r in table_rows:
+                    f.write(json.dumps(r))
+                    f.write("\n")
+            load_ndjson_to_staging(
+                table=table,
+                ndjson_path=ndjson_path,
+                suffix=suffix,
+                schema_dir=tmp_dir,
+                project=project,
+            )
+
+        try:
+            run_merge_with_retry(sql=sql, project=project)
+        finally:
+            # Always clean up staging tables — they're disposable and the
+            # staging dataset has a 1-day default expiration as a safety net,
+            # but explicit drop keeps things tidy.
+            drop_staging_tables(suffix, tables=_PHASE1_TABLES, project=project)

--- a/extras/ci/analytics/bq_loader.py
+++ b/extras/ci/analytics/bq_loader.py
@@ -44,6 +44,14 @@ _SAFE_TOKEN = re.compile(r"^[A-Za-z0-9_]+$")
 # of "we have exactly one prod project."
 PROJECT = "slang-runners"
 
+# Per-subprocess wall-clock cap for `bq` invocations. The job-level
+# `timeout-minutes` in ci-telemetry.yml is the outer bound, but it kills the
+# whole process group, which would skip the finally-cleanup of staging tables.
+# A per-process timeout lets the loader's exception path run (drop_staging),
+# at the cost of failing the ingest on a stalled CLI/network. Override via
+# the BQ_CMD_TIMEOUT_S env var if a particular run needs longer.
+_BQ_CMD_TIMEOUT_S = int(os.environ.get("BQ_CMD_TIMEOUT_S", "600"))
+
 
 def staging_suffix(
     *,
@@ -110,6 +118,7 @@ def _bq_run(args: list[str]) -> subprocess.CompletedProcess:
         ["bq", *args],
         capture_output=True,
         text=True,
+        timeout=_BQ_CMD_TIMEOUT_S,
     )
     if proc.returncode != 0:
         sys.stderr.write(proc.stderr)
@@ -137,6 +146,7 @@ def _live_schema_path(table: str, *, schema_dir: Path) -> Path:
             check=True,
             capture_output=True,
             text=True,
+            timeout=_BQ_CMD_TIMEOUT_S,
         )
         _schema_cache[table] = json.loads(proc.stdout)
     schema_path = schema_dir / f"{table}.schema.json"
@@ -244,6 +254,7 @@ def run_merge_with_retry(
             input=sql,
             capture_output=True,
             text=True,
+            timeout=_BQ_CMD_TIMEOUT_S,
         )
         if proc.returncode == 0:
             return

--- a/extras/ci/analytics/bq_loader.py
+++ b/extras/ci/analytics/bq_loader.py
@@ -201,7 +201,13 @@ def drop_staging_tables(suffix: str, *, tables: Iterable[str]) -> None:
         staging_id = f"{PROJECT}:slang_ci_staging.{table}__{suffix}"
         try:
             _bq_run(["rm", "-f", "-t", staging_id])
-        except subprocess.CalledProcessError as e:
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            # Swallow per-table failures so the loop continues — the goal is
+            # to attempt cleanup of every staging table even if one is stuck.
+            # CalledProcessError handles bq-side errors (auth, permissions);
+            # TimeoutExpired handles a hung bq subprocess after we added the
+            # _BQ_CMD_TIMEOUT_S guard. The staging dataset's 1-day default
+            # expiration sweeps anything we miss.
             sys.stderr.write(
                 f"warning: failed to drop staging table {staging_id}: {e}\n"
             )
@@ -241,6 +247,14 @@ def run_merge_with_retry(
     its flag list (a runaway suggestion-distance algorithm in absl
     blows the stack on a multi-statement MERGE).
     """
+    # Server-side job timeout in ms, matched to the client-side
+    # subprocess timeout so both sides agree. Killing the local `bq`
+    # process does not by itself cancel an already-submitted BigQuery job;
+    # --job_timeout_ms makes the BQ server give up on the query if it
+    # exceeds its own deadline. Cancellation is best-effort per Google's
+    # docs but it bounds the orphan-job blast radius.
+    job_timeout_ms = _BQ_CMD_TIMEOUT_S * 1000
+
     for attempt in range(1, max_attempts + 1):
         proc = subprocess.run(
             [
@@ -249,6 +263,7 @@ def run_merge_with_retry(
                 "--use_legacy_sql=false",
                 "--project_id",
                 PROJECT,
+                f"--job_timeout_ms={job_timeout_ms}",
                 "--format=none",
             ],
             input=sql,

--- a/extras/ci/analytics/bq_schema/build_stats.sql
+++ b/extras/ci/analytics/bq_schema/build_stats.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS `slang-runners.slang_ci.build_stats`
+(
+  row_key STRING NOT NULL,
+  run_id INT64 NOT NULL,
+  run_attempt INT64 NOT NULL,
+  job_id INT64 NOT NULL,
+  matrix_os STRING,
+  matrix_arch STRING,
+  matrix_compiler STRING,
+  matrix_config STRING,
+  cache_hits INT64,
+  cache_misses INT64,
+  cache_hit_rate FLOAT64,
+  compile_requests INT64,
+  run_created_at TIMESTAMP NOT NULL
+)
+PARTITION BY DATE(run_created_at)
+CLUSTER BY run_id, run_attempt;

--- a/extras/ci/analytics/bq_schema/job_steps.sql
+++ b/extras/ci/analytics/bq_schema/job_steps.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS `slang-runners.slang_ci.job_steps`
+(
+  row_key STRING NOT NULL,
+  job_id INT64 NOT NULL,
+  run_id INT64 NOT NULL,
+  run_attempt INT64 NOT NULL,
+  run_created_at TIMESTAMP NOT NULL,
+  step_number INT64 NOT NULL,
+  step_name STRING,
+  conclusion STRING,
+  started_at TIMESTAMP,
+  completed_at TIMESTAMP,
+  duration_seconds FLOAT64
+)
+PARTITION BY DATE(run_created_at)
+CLUSTER BY run_id, run_attempt, job_id;

--- a/extras/ci/analytics/bq_schema/jobs.sql
+++ b/extras/ci/analytics/bq_schema/jobs.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS `slang-runners.slang_ci.jobs`
+(
+  row_key STRING NOT NULL,
+  job_id INT64,
+  run_id INT64 NOT NULL,
+  run_attempt INT64 NOT NULL,
+  name STRING,
+  caller_workflow_file STRING,
+  caller_job_key STRING,
+  called_workflow_file STRING,
+  called_job_key STRING,
+  node_kind STRING NOT NULL,
+  graph_instance_key STRING,
+  needs ARRAY<STRING>,
+  conclusion STRING,
+  started_at TIMESTAMP,
+  completed_at TIMESTAMP,
+  duration_seconds FLOAT64,
+  queue_wait_seconds FLOAT64,
+  runner_name STRING,
+  runner_labels ARRAY<STRING>,
+  job_type STRING,
+  matrix_os STRING,
+  matrix_arch STRING,
+  matrix_compiler STRING,
+  matrix_config STRING,
+  matrix_gpu_tier STRING,
+  run_created_at TIMESTAMP NOT NULL
+)
+PARTITION BY DATE(run_created_at)
+CLUSTER BY run_id, run_attempt, node_kind;

--- a/extras/ci/analytics/bq_schema/merge_live_tables.sql.tmpl
+++ b/extras/ci/analytics/bq_schema/merge_live_tables.sql.tmpl
@@ -1,0 +1,136 @@
+-- Multi-statement transaction MERGE of per-attempt staging tables into the live
+-- slang_ci dataset. All MERGEs commit atomically, so a CI run is either fully
+-- visible or not at all visible.
+--
+-- This file is a `str.format()` template. Placeholders, all caller-validated
+-- against the regex `^[A-Za-z0-9_]+$`:
+--   {staging_suffix}  — e.g. "src_12345_1__ing_67890_1"
+--
+-- The ingester separately declares part_lo / part_hi as TIMESTAMP DEFAULTs
+-- before BEGIN TRANSACTION (BigQuery requires DECLAREs before BEGIN). Each
+-- table's BETWEEN predicate uses its partition column (workflow_runs uses
+-- created_at; the others use run_created_at).
+
+DECLARE wfr_part_lo TIMESTAMP DEFAULT (
+  SELECT MIN(created_at) FROM `slang-runners.slang_ci_staging.workflow_runs__{staging_suffix}`
+);
+DECLARE wfr_part_hi TIMESTAMP DEFAULT (
+  SELECT MAX(created_at) FROM `slang-runners.slang_ci_staging.workflow_runs__{staging_suffix}`
+);
+DECLARE jobs_part_lo TIMESTAMP DEFAULT (
+  SELECT MIN(run_created_at) FROM `slang-runners.slang_ci_staging.jobs__{staging_suffix}`
+);
+DECLARE jobs_part_hi TIMESTAMP DEFAULT (
+  SELECT MAX(run_created_at) FROM `slang-runners.slang_ci_staging.jobs__{staging_suffix}`
+);
+DECLARE steps_part_lo TIMESTAMP DEFAULT (
+  SELECT MIN(run_created_at) FROM `slang-runners.slang_ci_staging.job_steps__{staging_suffix}`
+);
+DECLARE steps_part_hi TIMESTAMP DEFAULT (
+  SELECT MAX(run_created_at) FROM `slang-runners.slang_ci_staging.job_steps__{staging_suffix}`
+);
+
+BEGIN TRANSACTION;
+
+MERGE `slang-runners.slang_ci.workflow_runs` T
+USING `slang-runners.slang_ci_staging.workflow_runs__{staging_suffix}` S
+ON T.row_key = S.row_key
+   AND T.created_at BETWEEN wfr_part_lo AND wfr_part_hi
+WHEN MATCHED THEN UPDATE SET
+  run_id = S.run_id,
+  run_attempt = S.run_attempt,
+  workflow_file = S.workflow_file,
+  workflow_name = S.workflow_name,
+  event = S.event,
+  head_sha = S.head_sha,
+  head_branch = S.head_branch,
+  triggering_actor = S.triggering_actor,
+  parent_run_id = S.parent_run_id,
+  created_at = S.created_at,
+  started_at = S.started_at,
+  completed_at = S.completed_at,
+  conclusion = S.conclusion
+WHEN NOT MATCHED THEN INSERT (
+  row_key, run_id, run_attempt, workflow_file, workflow_name, event,
+  head_sha, head_branch, triggering_actor, parent_run_id,
+  created_at, started_at, completed_at, conclusion
+) VALUES (
+  S.row_key, S.run_id, S.run_attempt, S.workflow_file, S.workflow_name, S.event,
+  S.head_sha, S.head_branch, S.triggering_actor, S.parent_run_id,
+  S.created_at, S.started_at, S.completed_at, S.conclusion
+);
+
+MERGE `slang-runners.slang_ci.jobs` T
+USING `slang-runners.slang_ci_staging.jobs__{staging_suffix}` S
+ON T.row_key = S.row_key
+   AND T.run_created_at BETWEEN jobs_part_lo AND jobs_part_hi
+WHEN MATCHED THEN UPDATE SET
+  job_id = S.job_id,
+  run_id = S.run_id,
+  run_attempt = S.run_attempt,
+  name = S.name,
+  caller_workflow_file = S.caller_workflow_file,
+  caller_job_key = S.caller_job_key,
+  called_workflow_file = S.called_workflow_file,
+  called_job_key = S.called_job_key,
+  node_kind = S.node_kind,
+  graph_instance_key = S.graph_instance_key,
+  needs = S.needs,
+  conclusion = S.conclusion,
+  started_at = S.started_at,
+  completed_at = S.completed_at,
+  duration_seconds = S.duration_seconds,
+  queue_wait_seconds = S.queue_wait_seconds,
+  runner_name = S.runner_name,
+  runner_labels = S.runner_labels,
+  job_type = S.job_type,
+  matrix_os = S.matrix_os,
+  matrix_arch = S.matrix_arch,
+  matrix_compiler = S.matrix_compiler,
+  matrix_config = S.matrix_config,
+  matrix_gpu_tier = S.matrix_gpu_tier,
+  run_created_at = S.run_created_at
+WHEN NOT MATCHED THEN INSERT (
+  row_key, job_id, run_id, run_attempt, name,
+  caller_workflow_file, caller_job_key, called_workflow_file, called_job_key,
+  node_kind, graph_instance_key, needs, conclusion,
+  started_at, completed_at, duration_seconds, queue_wait_seconds,
+  runner_name, runner_labels, job_type,
+  matrix_os, matrix_arch, matrix_compiler, matrix_config, matrix_gpu_tier,
+  run_created_at
+) VALUES (
+  S.row_key, S.job_id, S.run_id, S.run_attempt, S.name,
+  S.caller_workflow_file, S.caller_job_key, S.called_workflow_file, S.called_job_key,
+  S.node_kind, S.graph_instance_key, S.needs, S.conclusion,
+  S.started_at, S.completed_at, S.duration_seconds, S.queue_wait_seconds,
+  S.runner_name, S.runner_labels, S.job_type,
+  S.matrix_os, S.matrix_arch, S.matrix_compiler, S.matrix_config, S.matrix_gpu_tier,
+  S.run_created_at
+);
+
+MERGE `slang-runners.slang_ci.job_steps` T
+USING `slang-runners.slang_ci_staging.job_steps__{staging_suffix}` S
+ON T.row_key = S.row_key
+   AND T.run_created_at BETWEEN steps_part_lo AND steps_part_hi
+WHEN MATCHED THEN UPDATE SET
+  job_id = S.job_id,
+  run_id = S.run_id,
+  run_attempt = S.run_attempt,
+  run_created_at = S.run_created_at,
+  step_number = S.step_number,
+  step_name = S.step_name,
+  conclusion = S.conclusion,
+  started_at = S.started_at,
+  completed_at = S.completed_at,
+  duration_seconds = S.duration_seconds
+WHEN NOT MATCHED THEN INSERT (
+  row_key, job_id, run_id, run_attempt, run_created_at,
+  step_number, step_name, conclusion,
+  started_at, completed_at, duration_seconds
+) VALUES (
+  S.row_key, S.job_id, S.run_id, S.run_attempt, S.run_created_at,
+  S.step_number, S.step_name, S.conclusion,
+  S.started_at, S.completed_at, S.duration_seconds
+);
+
+COMMIT TRANSACTION;

--- a/extras/ci/analytics/bq_schema/scaler_events.sql
+++ b/extras/ci/analytics/bq_schema/scaler_events.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS `slang-runners.slang_ci.scaler_events`
+(
+  row_key STRING NOT NULL,
+  event_id STRING NOT NULL,
+  event_time TIMESTAMP NOT NULL,
+  event_type STRING,
+  vm_name STRING,
+  runner_name STRING,
+  runner_labels ARRAY<STRING>,
+  gpu_type STRING,
+  zone STRING,
+  reason STRING
+)
+PARTITION BY DATE(event_time)
+CLUSTER BY event_type, vm_name;

--- a/extras/ci/analytics/bq_schema/views_latest.sql
+++ b/extras/ci/analytics/bq_schema/views_latest.sql
@@ -1,0 +1,33 @@
+-- Latest-attempt views. Snapshot queries read from these; ad-hoc per-attempt
+-- analysis reads the base tables with explicit (run_id, run_attempt) params.
+
+CREATE OR REPLACE VIEW `slang-runners.slang_ci.workflow_runs_latest` AS
+SELECT * FROM `slang-runners.slang_ci.workflow_runs`
+QUALIFY ROW_NUMBER() OVER (PARTITION BY run_id ORDER BY run_attempt DESC) = 1;
+
+CREATE OR REPLACE VIEW `slang-runners.slang_ci.jobs_latest` AS
+SELECT j.* FROM `slang-runners.slang_ci.jobs` j
+JOIN (
+  SELECT run_id, MAX(run_attempt) AS run_attempt
+  FROM `slang-runners.slang_ci.workflow_runs`
+  GROUP BY run_id
+) latest
+  ON j.run_id = latest.run_id AND j.run_attempt = latest.run_attempt;
+
+CREATE OR REPLACE VIEW `slang-runners.slang_ci.job_steps_latest` AS
+SELECT s.* FROM `slang-runners.slang_ci.job_steps` s
+JOIN (
+  SELECT run_id, MAX(run_attempt) AS run_attempt
+  FROM `slang-runners.slang_ci.workflow_runs`
+  GROUP BY run_id
+) latest
+  ON s.run_id = latest.run_id AND s.run_attempt = latest.run_attempt;
+
+CREATE OR REPLACE VIEW `slang-runners.slang_ci.build_stats_latest` AS
+SELECT b.* FROM `slang-runners.slang_ci.build_stats` b
+JOIN (
+  SELECT run_id, MAX(run_attempt) AS run_attempt
+  FROM `slang-runners.slang_ci.workflow_runs`
+  GROUP BY run_id
+) latest
+  ON b.run_id = latest.run_id AND b.run_attempt = latest.run_attempt;

--- a/extras/ci/analytics/bq_schema/workflow_runs.sql
+++ b/extras/ci/analytics/bq_schema/workflow_runs.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS `slang-runners.slang_ci.workflow_runs`
+(
+  row_key STRING NOT NULL,
+  run_id INT64 NOT NULL,
+  run_attempt INT64 NOT NULL,
+  workflow_file STRING,
+  workflow_name STRING,
+  event STRING,
+  head_sha STRING,
+  head_branch STRING,
+  triggering_actor STRING,
+  parent_run_id INT64,
+  created_at TIMESTAMP NOT NULL,
+  started_at TIMESTAMP,
+  completed_at TIMESTAMP,
+  conclusion STRING
+)
+PARTITION BY DATE(created_at)
+CLUSTER BY run_id, run_attempt;

--- a/extras/ci/analytics/ci_bq_ingest.py
+++ b/extras/ci/analytics/ci_bq_ingest.py
@@ -124,27 +124,28 @@ def resolve_caller_key(
     matrix-tuple reconstruction is future work; for now we strip the suffix
     so the key resolves and leave graph_instance_key empty.)
 
-    Resolution order:
+    Resolution order, tried first with the raw caller_part and again with a
+    matrix-suffix-stripped variant (so a job with both `strategy.matrix` and a
+    custom top-level `name:` still resolves):
       1. Exact YAML-key match — covers no-matrix jobs.
-      2. Strip a trailing ` (v1, v2, ...)` matrix-suffix and retry — covers
-         GH's default name expansion for `strategy.matrix` jobs.
-      3. Match against a declared `name:` field.
-      4. Stripped/lowercased match for workflows that use spaces in names.
+      2. Match against a declared `name:` field.
+      3. Stripped/lowercased match for workflows that use spaces in names.
     """
-    for candidate in (caller_part, strip_matrix_suffix(caller_part)):
+    candidates = [caller_part]
+    stripped = strip_matrix_suffix(caller_part)
+    if stripped != caller_part:
+        candidates.append(stripped)
+
+    for candidate in candidates:
         if candidate in workflow_spec.jobs:
             return candidate, ""
-
-    # Try matching against declared `name:` fields.
-    for job_key, spec in workflow_spec.jobs.items():
-        if spec.name and spec.name == caller_part:
-            return job_key, ""
-
-    # Fallback: stripped match (some workflows use spaces in names).
-    normalized = caller_part.replace(" ", "-").lower()
-    for job_key in workflow_spec.jobs:
-        if job_key.lower() == normalized:
-            return job_key, ""
+        for job_key, spec in workflow_spec.jobs.items():
+            if spec.name and spec.name == candidate:
+                return job_key, ""
+        normalized = candidate.replace(" ", "-").lower()
+        for job_key in workflow_spec.jobs:
+            if job_key.lower() == normalized:
+                return job_key, ""
 
     return None, ""
 

--- a/extras/ci/analytics/ci_bq_ingest.py
+++ b/extras/ci/analytics/ci_bq_ingest.py
@@ -33,6 +33,7 @@ from _bq_ingest_lib import (
     rk_direct_node,
     rk_step,
     rk_workflow_run,
+    workflow_tier,
 )
 from workflow_parser import JobSpec, WorkflowSpec, fetch_workflow_yaml
 
@@ -233,10 +234,93 @@ def aggregate_graph_timing(children: list[dict[str, Any]]) -> dict[str, Any]:
 # ---------- Main ingest ----------
 
 
+def _emit_steps_for_job(
+    out: dict[str, list[dict[str, Any]]],
+    api_job: dict[str, Any],
+    *,
+    run_id: int,
+    run_attempt: int,
+    run_created_at: str | None,
+) -> None:
+    """Append job_steps rows for one API job. Shared by both tiers."""
+    job_id = api_job["id"]
+    for step in api_job.get("steps") or []:
+        step_number = step.get("number")
+        if step_number is None:
+            continue
+        out["job_steps"].append(
+            {
+                "row_key": rk_step(job_id, step_number),
+                "job_id": job_id,
+                "run_id": run_id,
+                "run_attempt": run_attempt,
+                "run_created_at": run_created_at,
+                "step_number": step_number,
+                "step_name": step.get("name"),
+                "conclusion": step.get("conclusion"),
+                "started_at": step.get("started_at"),
+                "completed_at": step.get("completed_at"),
+                "duration_seconds": _duration(step),
+            }
+        )
+
+
+def _tier2_concrete_row(
+    api_job: dict[str, Any],
+    *,
+    run_id: int,
+    run_attempt: int,
+    workflow_file: str | None,
+    run_created_at: str | None,
+) -> dict[str, Any]:
+    """Build a Tier 2 (record_only) concrete_job row. All graph columns NULL.
+
+    Tier 2 workflows don't get their YAML parsed, so we have no caller-side
+    keys, no needs[] edges, and no matrix axes. Querying these rows still
+    works for hosted-runner concurrency and conclusion/duration analytics
+    because workflow_name is joinable through (run_id, run_attempt) on
+    workflow_runs.
+    """
+    return {
+        "row_key": rk_concrete(api_job["id"]),
+        "job_id": api_job["id"],
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+        "name": api_job.get("name"),
+        "caller_workflow_file": workflow_file,
+        "caller_job_key": None,
+        "called_workflow_file": None,
+        "called_job_key": None,
+        "node_kind": "concrete_job",
+        "graph_instance_key": None,
+        "needs": [],
+        "conclusion": api_job.get("conclusion"),
+        "started_at": api_job.get("started_at"),
+        "completed_at": api_job.get("completed_at"),
+        "duration_seconds": _duration(api_job),
+        "queue_wait_seconds": _queue_wait(api_job),
+        "runner_name": api_job.get("runner_name"),
+        "runner_labels": api_job.get("labels") or [],
+        "job_type": None,
+        "matrix_os": None,
+        "matrix_arch": None,
+        "matrix_compiler": None,
+        "matrix_config": None,
+        "matrix_gpu_tier": None,
+        "run_created_at": run_created_at,
+    }
+
+
 def build_rows(
     repo: str, run_id: int, run_attempt: int
-) -> tuple[dict[str, list[dict[str, Any]]], int]:
-    """Return (rows-keyed-by-table-name, api_job_count)."""
+) -> tuple[dict[str, list[dict[str, Any]]], int, str]:
+    """Return (rows-keyed-by-table-name, api_job_count, tier).
+
+    Dispatches on the workflow's display name: Tier 1 (parse_graph) fetches
+    YAML and materializes graph nodes; Tier 2 (record_only) emits concrete
+    rows only with NULL graph columns. See PARSE_GRAPH_WORKFLOWS in
+    _bq_ingest_lib.py for the Tier 1 list.
+    """
     out: dict[str, list[dict[str, Any]]] = defaultdict(list)
 
     # workflow_runs (1 row)
@@ -245,12 +329,35 @@ def build_rows(
     head_sha = wfr_row["head_sha"]
     workflow_file = wfr_row["workflow_file"]
     run_created_at = wfr_row["created_at"]
-
-    # YAML at head_sha (data only).
-    workflow_spec = fetch_workflow_yaml(repo, workflow_file, head_sha)
+    tier = workflow_tier(wfr_row.get("workflow_name"))
 
     # All concrete jobs in the attempt.
     api_jobs = fetch_concrete_jobs(repo, run_id, run_attempt)
+
+    if tier == "record_only":
+        for api_job in api_jobs:
+            out["jobs"].append(
+                _tier2_concrete_row(
+                    api_job,
+                    run_id=run_id,
+                    run_attempt=run_attempt,
+                    workflow_file=workflow_file,
+                    run_created_at=run_created_at,
+                )
+            )
+            _emit_steps_for_job(
+                out,
+                api_job,
+                run_id=run_id,
+                run_attempt=run_attempt,
+                run_created_at=run_created_at,
+            )
+        return out, len(api_jobs), tier
+
+    # Tier 1 path: full graph materialization below.
+
+    # YAML at head_sha (data only).
+    workflow_spec = fetch_workflow_yaml(repo, workflow_file, head_sha)
 
     # Group concrete jobs by caller-side YAML key. Each group becomes one
     # graph-node row (caller_node or direct_node).
@@ -398,27 +505,15 @@ def build_rows(
                 }
             )
 
-            for step in api_job.get("steps") or []:
-                step_number = step.get("number")
-                if step_number is None:
-                    continue
-                out["job_steps"].append(
-                    {
-                        "row_key": rk_step(job_id, step_number),
-                        "job_id": job_id,
-                        "run_id": run_id,
-                        "run_attempt": run_attempt,
-                        "run_created_at": run_created_at,
-                        "step_number": step_number,
-                        "step_name": step.get("name"),
-                        "conclusion": step.get("conclusion"),
-                        "started_at": step.get("started_at"),
-                        "completed_at": step.get("completed_at"),
-                        "duration_seconds": _duration(step),
-                    }
-                )
+            _emit_steps_for_job(
+                out,
+                api_job,
+                run_id=run_id,
+                run_attempt=run_attempt,
+                run_created_at=run_created_at,
+            )
 
-    return out, len(api_jobs)
+    return out, len(api_jobs), tier
 
 
 def _normalize_uses(uses: str | None) -> str | None:
@@ -500,6 +595,7 @@ def validate(
     rows: dict[str, list[dict[str, Any]]],
     *,
     api_job_count: int | None = None,
+    tier: str = "parse_graph",
 ) -> list[str]:
     """Structural sanity checks on emitted rows.
 
@@ -507,6 +603,11 @@ def validate(
     returned for this attempt. We use it to catch the silent-empty-output
     regression where every concrete job goes unresolved → 0 graph rows emit
     → validation passes despite zero useful data.
+
+    `tier` selects the rule set: 'parse_graph' (Tier 1) requires every
+    concrete row to have exactly one needs[] entry pointing at its graph
+    node, while 'record_only' (Tier 2) expects no graph rows at all and
+    empty needs[] on concrete rows.
     """
     errors: list[str] = []
     jobs = rows.get("jobs", [])
@@ -521,8 +622,21 @@ def validate(
             "matrix expansion pattern."
         )
 
+    if tier == "record_only" and graph_row_keys:
+        errors.append(
+            f"Tier 2 (record_only) ingest emitted {len(graph_row_keys)} graph "
+            "rows; expected 0. Tier 2 must not materialize graph nodes."
+        )
+
     for r in jobs:
         if r["node_kind"] == "concrete_job":
+            if tier == "record_only":
+                if r["needs"]:
+                    errors.append(
+                        f"Tier 2 concrete row {r['job_id']} ({r['name']}) has "
+                        f"needs[]={r['needs']}, expected empty list."
+                    )
+                continue
             if not r["needs"]:
                 errors.append(
                     f"concrete row {r['job_id']} ({r['name']}) has empty needs[]"
@@ -594,16 +708,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
-    rows, api_job_count = build_rows(args.repo, args.run_id, args.run_attempt)
+    rows, api_job_count, tier = build_rows(args.repo, args.run_id, args.run_attempt)
 
     if args.validate:
-        errs = validate(rows, api_job_count=api_job_count)
+        errs = validate(rows, api_job_count=api_job_count, tier=tier)
         if errs:
             for e in errs:
                 sys.stderr.write(f"validation error: {e}\n")
             return 1
         sys.stderr.write(
-            f"validation OK: {len(rows.get('workflow_runs', []))} workflow_runs, "
+            f"validation OK [{tier}]: {len(rows.get('workflow_runs', []))} workflow_runs, "
             f"{len(rows.get('jobs', []))} jobs ("
             f"{sum(1 for r in rows.get('jobs', []) if r['node_kind'] != 'concrete_job')} graph, "
             f"{sum(1 for r in rows.get('jobs', []) if r['node_kind'] == 'concrete_job')} concrete), "

--- a/extras/ci/analytics/ci_bq_ingest.py
+++ b/extras/ci/analytics/ci_bq_ingest.py
@@ -86,20 +86,54 @@ def split_concrete_name(name: str) -> tuple[str, str | None]:
     return name.strip(), None
 
 
+def strip_matrix_suffix(caller_part: str) -> str:
+    """Strip a trailing matrix-value tuple from a job name.
+
+    GH expands `strategy.matrix` job names to `<job_key> (<v1>, <v2>, ...)`.
+    The opening ` (` is the canonical separator. We don't try to parse the
+    tuple — the caller-side matrix axes are reconstructed separately from the
+    GH API's `runner_labels`/job metadata.
+
+    GH truncates job names to ~100 chars in the API response, which can drop
+    the closing `)`. We therefore also strip when the trailing suffix is
+    `(...)` (closed) OR ends with the literal truncation marker `...` after
+    an unclosed `(`.
+
+    Examples:
+      'build (windows, release, cl, x86_64)' -> 'build'
+      'build (windows, cl, x86_64, ..., vu...' -> 'build'  (truncated)
+      'build'                                -> 'build'
+      'name (with spaces) (a, b)'            -> 'name (with spaces)'
+    """
+    idx = caller_part.rfind(" (")
+    if idx == -1:
+        return caller_part
+    suffix = caller_part[idx + 2 :]
+    if caller_part.endswith(")") or suffix.endswith("..."):
+        return caller_part[:idx].strip()
+    return caller_part
+
+
 def resolve_caller_key(
     caller_part: str, workflow_spec: WorkflowSpec
 ) -> tuple[str | None, str]:
     """Map the API-reported caller part of a job name back to a YAML job key.
 
     Returns (job_key, graph_instance_key). graph_instance_key is the canonical
-    matrix tuple for the caller-side matrix, or empty string when none.
+    matrix tuple for the caller-side matrix, or empty string when none. (Real
+    matrix-tuple reconstruction is future work; for now we strip the suffix
+    so the key resolves and leave graph_instance_key empty.)
 
-    Best-effort: exact YAML-key match first. If GH expanded a `name:` template
-    we may not be able to recover the matrix tuple without resolving `${{ ... }}`
-    expressions; the plan acknowledges this and treats it as future work.
+    Resolution order:
+      1. Exact YAML-key match — covers no-matrix jobs.
+      2. Strip a trailing ` (v1, v2, ...)` matrix-suffix and retry — covers
+         GH's default name expansion for `strategy.matrix` jobs.
+      3. Match against a declared `name:` field.
+      4. Stripped/lowercased match for workflows that use spaces in names.
     """
-    if caller_part in workflow_spec.jobs:
-        return caller_part, ""
+    for candidate in (caller_part, strip_matrix_suffix(caller_part)):
+        if candidate in workflow_spec.jobs:
+            return candidate, ""
 
     # Try matching against declared `name:` fields.
     for job_key, spec in workflow_spec.jobs.items():
@@ -142,19 +176,40 @@ def fmt_ts(dt: datetime | None) -> str | None:
     return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _child_ran(child: dict[str, Any]) -> bool:
+    """Did this concrete child actually execute?
+
+    The plan says graph-node timing is over "children that actually ran". GH
+    Actions reports skipped jobs with conclusion='skipped' and bogus timing
+    (started_at == completed_at, or in some cases an out-of-order pair that
+    yields a negative duration when subtracted). Excluding them keeps the
+    aggregates honest.
+    """
+    return child.get("conclusion") not in ("skipped", None)
+
+
 def aggregate_graph_timing(children: list[dict[str, Any]]) -> dict[str, Any]:
-    """MIN/MAX over concrete children + critical-path proxy.
+    """MIN/MAX over concrete children that ran + critical-path proxy.
 
     The full critical path requires the called workflow's internal needs[] DAG;
     for this slice we use MAX(child.duration) as a conservative approximation
     (correct when called jobs have no internal needs[], otherwise a lower
     bound). The internal-DAG walk is a follow-up.
     """
-    started = [parse_ts(c.get("started_at")) for c in children]
-    completed = [parse_ts(c.get("completed_at")) for c in children]
+    ran = [c for c in children if _child_ran(c)]
+    if not ran:
+        return {
+            "started_at": None,
+            "completed_at": None,
+            "duration_seconds": None,
+            "queue_wait_seconds": None,
+        }
+
+    started = [parse_ts(c.get("started_at")) for c in ran]
+    completed = [parse_ts(c.get("completed_at")) for c in ran]
     queue_waits = []
     durations = []
-    for c in children:
+    for c in ran:
         cr = parse_ts(c.get("created_at"))
         st = parse_ts(c.get("started_at"))
         cp = parse_ts(c.get("completed_at"))
@@ -179,8 +234,8 @@ def aggregate_graph_timing(children: list[dict[str, Any]]) -> dict[str, Any]:
 
 def build_rows(
     repo: str, run_id: int, run_attempt: int
-) -> dict[str, list[dict[str, Any]]]:
-    """Return rows keyed by destination table name."""
+) -> tuple[dict[str, list[dict[str, Any]]], int]:
+    """Return (rows-keyed-by-table-name, api_job_count)."""
     out: dict[str, list[dict[str, Any]]] = defaultdict(list)
 
     # workflow_runs (1 row)
@@ -214,10 +269,13 @@ def build_rows(
             f"YAML key: {[j.get('name') for j in unresolved][:5]}{'...' if len(unresolved) > 5 else ''}\n"
         )
 
-    # Graph-node rows.
+    # Graph-node rows — one per top-level YAML job, whether or not any
+    # concrete child ran. Per the plan, every top-level YAML job becomes one
+    # logical graph node; jobs whose children never ran still need a row so
+    # downstream needs[] edges resolve.
     graph_node_row_key_by_caller: dict[str, str] = {}
-    for caller_key, children in children_by_caller.items():
-        spec = workflow_spec.jobs[caller_key]
+    for caller_key, spec in workflow_spec.jobs.items():
+        children = children_by_caller.get(caller_key, [])
         gik = ""  # caller-side strategy.matrix not yet supported; empty string per plan
         rk = graph_node_row_key(spec, run_id, run_attempt, workflow_file, gik)
         graph_node_row_key_by_caller[caller_key] = rk
@@ -231,11 +289,23 @@ def build_rows(
             "success": 4,
             None: 5,
         }
-        # Worst child conclusion in the obvious failure ordering.
-        worst = min(
-            (c.get("conclusion") for c in children),
-            key=lambda c: conclusion_priority.get(c, 99),
-        )
+        # Worst child conclusion in the obvious failure ordering, restricted
+        # to children that ran. Three cases for the graph-node conclusion:
+        #   - any child ran     → worst conclusion among ran children
+        #   - all children skipped → "skipped"
+        #   - no children at all  → NULL (job did not produce any concrete
+        #                            row in this attempt — e.g. its caller
+        #                            was filtered out by `if:`)
+        ran_children = [c for c in children if _child_ran(c)]
+        if ran_children:
+            worst = min(
+                (c.get("conclusion") for c in ran_children),
+                key=lambda c: conclusion_priority.get(c, 99),
+            )
+        elif children:
+            worst = "skipped"
+        else:
+            worst = None
 
         out["jobs"].append(
             {
@@ -347,7 +417,7 @@ def build_rows(
                     }
                 )
 
-    return out
+    return out, len(api_jobs)
 
 
 def _normalize_uses(uses: str | None) -> str | None:
@@ -366,18 +436,31 @@ def _normalize_uses(uses: str | None) -> str | None:
 
 
 def _duration(j: dict[str, Any]) -> float | None:
+    """Wall-clock seconds between started_at and completed_at.
+
+    Returns None when either timestamp is missing or for skipped jobs (GH
+    reports nominal timestamps for skipped jobs that often differ by 1 second
+    in the wrong order, yielding a negative duration). Treating these as NULL
+    matches the BigQuery convention for "this job did not run".
+    """
+    if j.get("conclusion") == "skipped":
+        return None
     st = parse_ts(j.get("started_at"))
     cp = parse_ts(j.get("completed_at"))
     if st and cp:
-        return (cp - st).total_seconds()
+        d = (cp - st).total_seconds()
+        return d if d >= 0 else None
     return None
 
 
 def _queue_wait(j: dict[str, Any]) -> float | None:
+    if j.get("conclusion") == "skipped":
+        return None
     cr = parse_ts(j.get("created_at"))
     st = parse_ts(j.get("started_at"))
     if cr and st:
-        return (st - cr).total_seconds()
+        d = (st - cr).total_seconds()
+        return d if d >= 0 else None
     return None
 
 
@@ -412,10 +495,30 @@ def _resolve_matrix_input(spec: JobSpec, key: str) -> str | None:
 # ---------- Validation ----------
 
 
-def validate(rows: dict[str, list[dict[str, Any]]]) -> list[str]:
+def validate(
+    rows: dict[str, list[dict[str, Any]]],
+    *,
+    api_job_count: int | None = None,
+) -> list[str]:
+    """Structural sanity checks on emitted rows.
+
+    `api_job_count`, when provided, is the number of concrete jobs the GH API
+    returned for this attempt. We use it to catch the silent-empty-output
+    regression where every concrete job goes unresolved → 0 graph rows emit
+    → validation passes despite zero useful data.
+    """
     errors: list[str] = []
     jobs = rows.get("jobs", [])
     graph_row_keys = {r["row_key"] for r in jobs if r["node_kind"] != "concrete_job"}
+    concrete_row_count = sum(1 for r in jobs if r["node_kind"] == "concrete_job")
+
+    if api_job_count is not None and api_job_count > 0 and concrete_row_count == 0:
+        errors.append(
+            f"GH API reported {api_job_count} concrete jobs but the ingester "
+            "emitted zero concrete_job rows — likely a caller-key resolution "
+            "regression. Re-check resolve_caller_key for this workflow's "
+            "matrix expansion pattern."
+        )
 
     for r in jobs:
         if r["node_kind"] == "concrete_job":
@@ -490,10 +593,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
-    rows = build_rows(args.repo, args.run_id, args.run_attempt)
+    rows, api_job_count = build_rows(args.repo, args.run_id, args.run_attempt)
 
     if args.validate:
-        errs = validate(rows)
+        errs = validate(rows, api_job_count=api_job_count)
         if errs:
             for e in errs:
                 sys.stderr.write(f"validation error: {e}\n")

--- a/extras/ci/analytics/ci_bq_ingest.py
+++ b/extras/ci/analytics/ci_bq_ingest.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""Phase 1 BigQuery ingester for Slang CI telemetry.
+
+Tier 1 (`parse_graph`) ingest of a single (run_id, run_attempt):
+
+    ci_bq_ingest.py --run-id N --run-attempt M [--repo shader-slang/slang]
+                    [--validate] [--table workflow_runs|jobs|job_steps|all]
+
+Emits NDJSON to stdout, one row per output line, prefixed by `{"_table": "..."}`
+when --table=all so the consumer can sort rows by destination table. Single-table
+modes emit bare rows (suitable for `bq load`).
+
+No BigQuery writes; that's a later slice.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _bq_ingest_lib import (
+    gh_api,
+    gh_api_paginated,
+    rk_caller_node,
+    rk_concrete,
+    rk_direct_node,
+    rk_step,
+    rk_workflow_run,
+)
+from workflow_parser import JobSpec, WorkflowSpec, fetch_workflow_yaml
+
+
+# ---------- API → row builders ----------
+
+
+def build_workflow_run_row(repo: str, run_id: int, run_attempt: int) -> dict[str, Any]:
+    payload = gh_api(f"repos/{repo}/actions/runs/{run_id}/attempts/{run_attempt}")
+    actor = payload.get("triggering_actor") or {}
+    return {
+        "row_key": rk_workflow_run(run_id, run_attempt),
+        "run_id": payload["id"],
+        "run_attempt": payload["run_attempt"],
+        "workflow_file": payload.get("path"),
+        "workflow_name": payload.get("name"),
+        "event": payload.get("event"),
+        "head_sha": payload.get("head_sha"),
+        "head_branch": payload.get("head_branch"),
+        "triggering_actor": actor.get("login"),
+        "parent_run_id": None,
+        "created_at": payload.get("created_at"),
+        "started_at": payload.get("run_started_at"),
+        "completed_at": payload.get("updated_at"),
+        "conclusion": payload.get("conclusion"),
+    }
+
+
+def fetch_concrete_jobs(repo: str, run_id: int, run_attempt: int) -> list[dict[str, Any]]:
+    return gh_api_paginated(
+        f"repos/{repo}/actions/runs/{run_id}/attempts/{run_attempt}/jobs",
+        "jobs",
+    )
+
+
+# ---------- Caller-key parsing ----------
+
+
+def split_concrete_name(name: str) -> tuple[str, str | None]:
+    """Concrete job names from a reusable-workflow caller look like
+    `<caller_job_key> / <called_job_name>`. For direct jobs (no `uses:`) the
+    name is just `<caller_job_key>` (or its `name:` override).
+
+    Returns (caller_part, called_part_or_None). The caller_part still needs to
+    be mapped back to a YAML key — GH may have substituted matrix values into
+    the job's display name.
+    """
+    if " / " in name:
+        head, tail = name.split(" / ", 1)
+        return head.strip(), tail.strip()
+    return name.strip(), None
+
+
+def resolve_caller_key(
+    caller_part: str, workflow_spec: WorkflowSpec
+) -> tuple[str | None, str]:
+    """Map the API-reported caller part of a job name back to a YAML job key.
+
+    Returns (job_key, graph_instance_key). graph_instance_key is the canonical
+    matrix tuple for the caller-side matrix, or empty string when none.
+
+    Best-effort: exact YAML-key match first. If GH expanded a `name:` template
+    we may not be able to recover the matrix tuple without resolving `${{ ... }}`
+    expressions; the plan acknowledges this and treats it as future work.
+    """
+    if caller_part in workflow_spec.jobs:
+        return caller_part, ""
+
+    # Try matching against declared `name:` fields.
+    for job_key, spec in workflow_spec.jobs.items():
+        if spec.name and spec.name == caller_part:
+            return job_key, ""
+
+    # Fallback: stripped match (some workflows use spaces in names).
+    normalized = caller_part.replace(" ", "-").lower()
+    for job_key in workflow_spec.jobs:
+        if job_key.lower() == normalized:
+            return job_key, ""
+
+    return None, ""
+
+
+# ---------- Graph-node materialization ----------
+
+
+def graph_node_kind(spec: JobSpec) -> str:
+    return "caller_node" if spec.is_reusable_call else "direct_node"
+
+
+def graph_node_row_key(
+    spec: JobSpec, run_id: int, run_attempt: int, workflow_file: str, gik: str
+) -> str:
+    if spec.is_reusable_call:
+        return rk_caller_node(run_id, run_attempt, workflow_file, spec.job_key, gik)
+    return rk_direct_node(run_id, run_attempt, workflow_file, spec.job_key, gik)
+
+
+def parse_ts(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def fmt_ts(dt: datetime | None) -> str | None:
+    if dt is None:
+        return None
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def aggregate_graph_timing(children: list[dict[str, Any]]) -> dict[str, Any]:
+    """MIN/MAX over concrete children + critical-path proxy.
+
+    The full critical path requires the called workflow's internal needs[] DAG;
+    for this slice we use MAX(child.duration) as a conservative approximation
+    (correct when called jobs have no internal needs[], otherwise a lower
+    bound). The internal-DAG walk is a follow-up.
+    """
+    started = [parse_ts(c.get("started_at")) for c in children]
+    completed = [parse_ts(c.get("completed_at")) for c in children]
+    queue_waits = []
+    durations = []
+    for c in children:
+        cr = parse_ts(c.get("created_at"))
+        st = parse_ts(c.get("started_at"))
+        cp = parse_ts(c.get("completed_at"))
+        if cr and st:
+            queue_waits.append((st - cr).total_seconds())
+        if st and cp:
+            durations.append((cp - st).total_seconds())
+
+    started_nn = [s for s in started if s is not None]
+    completed_nn = [c for c in completed if c is not None]
+
+    return {
+        "started_at": fmt_ts(min(started_nn)) if started_nn else None,
+        "completed_at": fmt_ts(max(completed_nn)) if completed_nn else None,
+        "duration_seconds": max(durations) if durations else None,
+        "queue_wait_seconds": min(queue_waits) if queue_waits else None,
+    }
+
+
+# ---------- Main ingest ----------
+
+
+def build_rows(
+    repo: str, run_id: int, run_attempt: int
+) -> dict[str, list[dict[str, Any]]]:
+    """Return rows keyed by destination table name."""
+    out: dict[str, list[dict[str, Any]]] = defaultdict(list)
+
+    # workflow_runs (1 row)
+    wfr_row = build_workflow_run_row(repo, run_id, run_attempt)
+    out["workflow_runs"].append(wfr_row)
+    head_sha = wfr_row["head_sha"]
+    workflow_file = wfr_row["workflow_file"]
+    run_created_at = wfr_row["created_at"]
+
+    # YAML at head_sha (data only).
+    workflow_spec = fetch_workflow_yaml(repo, workflow_file, head_sha)
+
+    # All concrete jobs in the attempt.
+    api_jobs = fetch_concrete_jobs(repo, run_id, run_attempt)
+
+    # Group concrete jobs by caller-side YAML key. Each group becomes one
+    # graph-node row (caller_node or direct_node).
+    children_by_caller: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    unresolved: list[dict[str, Any]] = []
+    for api_job in api_jobs:
+        caller_part, _called_part = split_concrete_name(api_job.get("name", ""))
+        caller_key, _gik = resolve_caller_key(caller_part, workflow_spec)
+        if caller_key is None:
+            unresolved.append(api_job)
+            continue
+        children_by_caller[caller_key].append(api_job)
+
+    if unresolved:
+        sys.stderr.write(
+            f"warning: {len(unresolved)} concrete jobs did not resolve to a caller "
+            f"YAML key: {[j.get('name') for j in unresolved][:5]}{'...' if len(unresolved) > 5 else ''}\n"
+        )
+
+    # Graph-node rows.
+    graph_node_row_key_by_caller: dict[str, str] = {}
+    for caller_key, children in children_by_caller.items():
+        spec = workflow_spec.jobs[caller_key]
+        gik = ""  # caller-side strategy.matrix not yet supported; empty string per plan
+        rk = graph_node_row_key(spec, run_id, run_attempt, workflow_file, gik)
+        graph_node_row_key_by_caller[caller_key] = rk
+
+        timing = aggregate_graph_timing(children)
+        conclusion_priority = {
+            "failure": 0,
+            "timed_out": 1,
+            "cancelled": 2,
+            "skipped": 3,
+            "success": 4,
+            None: 5,
+        }
+        # Worst child conclusion in the obvious failure ordering.
+        worst = min(
+            (c.get("conclusion") for c in children),
+            key=lambda c: conclusion_priority.get(c, 99),
+        )
+
+        out["jobs"].append(
+            {
+                "row_key": rk,
+                "job_id": None,
+                "run_id": run_id,
+                "run_attempt": run_attempt,
+                "name": spec.name or caller_key,
+                "caller_workflow_file": workflow_file,
+                "caller_job_key": caller_key,
+                "called_workflow_file": _normalize_uses(spec.uses),
+                "called_job_key": None,
+                "node_kind": graph_node_kind(spec),
+                "graph_instance_key": gik,
+                # needs[] is the row_keys of upstream graph nodes. Fill in
+                # after we know all caller→rk mappings; see fixup pass below.
+                "needs": [],
+                "conclusion": worst,
+                "started_at": timing["started_at"],
+                "completed_at": timing["completed_at"],
+                "duration_seconds": timing["duration_seconds"],
+                "queue_wait_seconds": timing["queue_wait_seconds"],
+                "runner_name": None,
+                "runner_labels": [],
+                "job_type": _classify_job(spec, caller_key),
+                "matrix_os": _resolve_matrix_input(spec, "os"),
+                "matrix_arch": _resolve_matrix_input(spec, "arch"),
+                "matrix_compiler": _resolve_matrix_input(spec, "compiler"),
+                "matrix_config": _resolve_matrix_input(spec, "config"),
+                "matrix_gpu_tier": _resolve_matrix_input(spec, "gpu-tier"),
+                "run_created_at": run_created_at,
+            }
+        )
+
+    # Fixup pass: resolve needs[] for graph nodes (caller-key references → row_key references).
+    for row in out["jobs"]:
+        caller_key = row["caller_job_key"]
+        spec = workflow_spec.jobs.get(caller_key)
+        if spec is None:
+            continue
+        resolved = []
+        for needed_key in spec.needs:
+            target_rk = graph_node_row_key_by_caller.get(needed_key)
+            if target_rk is not None:
+                resolved.append(target_rk)
+            else:
+                sys.stderr.write(
+                    f"warning: needs[] target {needed_key!r} from {caller_key!r} "
+                    f"did not resolve to a graph node\n"
+                )
+        row["needs"] = resolved
+
+    # Concrete-job rows + steps.
+    for caller_key, children in children_by_caller.items():
+        graph_rk = graph_node_row_key_by_caller[caller_key]
+        for api_job in children:
+            job_id = api_job["id"]
+            out["jobs"].append(
+                {
+                    "row_key": rk_concrete(job_id),
+                    "job_id": job_id,
+                    "run_id": run_id,
+                    "run_attempt": run_attempt,
+                    "name": api_job.get("name"),
+                    "caller_workflow_file": workflow_file,
+                    "caller_job_key": caller_key,
+                    "called_workflow_file": _normalize_uses(
+                        workflow_spec.jobs[caller_key].uses
+                    ),
+                    "called_job_key": split_concrete_name(api_job.get("name", ""))[1],
+                    "node_kind": "concrete_job",
+                    # graph_instance_key NULL for concrete rows per the plan
+                    "graph_instance_key": None,
+                    "needs": [graph_rk],
+                    "conclusion": api_job.get("conclusion"),
+                    "started_at": api_job.get("started_at"),
+                    "completed_at": api_job.get("completed_at"),
+                    "duration_seconds": _duration(api_job),
+                    "queue_wait_seconds": _queue_wait(api_job),
+                    "runner_name": api_job.get("runner_name"),
+                    "runner_labels": api_job.get("labels") or [],
+                    "job_type": _classify_job(workflow_spec.jobs[caller_key], caller_key),
+                    "matrix_os": _resolve_matrix_input(workflow_spec.jobs[caller_key], "os"),
+                    "matrix_arch": _resolve_matrix_input(workflow_spec.jobs[caller_key], "arch"),
+                    "matrix_compiler": _resolve_matrix_input(workflow_spec.jobs[caller_key], "compiler"),
+                    "matrix_config": _resolve_matrix_input(workflow_spec.jobs[caller_key], "config"),
+                    "matrix_gpu_tier": _resolve_matrix_input(workflow_spec.jobs[caller_key], "gpu-tier"),
+                    "run_created_at": run_created_at,
+                }
+            )
+
+            for step in api_job.get("steps") or []:
+                step_number = step.get("number")
+                if step_number is None:
+                    continue
+                out["job_steps"].append(
+                    {
+                        "row_key": rk_step(job_id, step_number),
+                        "job_id": job_id,
+                        "run_id": run_id,
+                        "run_attempt": run_attempt,
+                        "run_created_at": run_created_at,
+                        "step_number": step_number,
+                        "step_name": step.get("name"),
+                        "conclusion": step.get("conclusion"),
+                        "started_at": step.get("started_at"),
+                        "completed_at": step.get("completed_at"),
+                        "duration_seconds": _duration(step),
+                    }
+                )
+
+    return out
+
+
+def _normalize_uses(uses: str | None) -> str | None:
+    """Map `uses:` string to a repo-relative workflow path.
+
+    GH Actions `uses:` for a same-repo reusable workflow looks like
+    `./.github/workflows/foo.yml`. Strip the leading `./` to match the
+    `caller_workflow_file` shape (`.github/workflows/ci.yml`). External
+    `owner/repo/.github/...@ref` `uses:` strings are returned as-is.
+    """
+    if uses is None:
+        return None
+    if uses.startswith("./"):
+        return uses[2:]
+    return uses
+
+
+def _duration(j: dict[str, Any]) -> float | None:
+    st = parse_ts(j.get("started_at"))
+    cp = parse_ts(j.get("completed_at"))
+    if st and cp:
+        return (cp - st).total_seconds()
+    return None
+
+
+def _queue_wait(j: dict[str, Any]) -> float | None:
+    cr = parse_ts(j.get("created_at"))
+    st = parse_ts(j.get("started_at"))
+    if cr and st:
+        return (st - cr).total_seconds()
+    return None
+
+
+def _classify_job(spec: JobSpec, caller_key: str) -> str:
+    """Heuristic job_type from caller key / called workflow."""
+    key_text = (spec.uses or caller_key).lower()
+    if "build" in key_text:
+        return "build"
+    if "test" in key_text:
+        return "test"
+    if "report" in key_text or "publish" in key_text:
+        return "report"
+    return "other"
+
+
+def _resolve_matrix_input(spec: JobSpec, key: str) -> str | None:
+    """Best-effort matrix-axis resolution.
+
+    Reads from `with:` inputs (Slang's CI uses this exclusively) when the value
+    is a literal string; expressions like `${{ matrix.config }}` are not
+    resolved here. Returns None if not present or not a literal scalar.
+    """
+    val = spec.with_inputs.get(key)
+    if isinstance(val, (str, int, bool)):
+        s = str(val)
+        if "${{" in s:
+            return None
+        return s
+    return None
+
+
+# ---------- Validation ----------
+
+
+def validate(rows: dict[str, list[dict[str, Any]]]) -> list[str]:
+    errors: list[str] = []
+    jobs = rows.get("jobs", [])
+    graph_row_keys = {r["row_key"] for r in jobs if r["node_kind"] != "concrete_job"}
+
+    for r in jobs:
+        if r["node_kind"] == "concrete_job":
+            if not r["needs"]:
+                errors.append(
+                    f"concrete row {r['job_id']} ({r['name']}) has empty needs[]"
+                )
+            elif len(r["needs"]) != 1:
+                errors.append(
+                    f"concrete row {r['job_id']} ({r['name']}) has needs[]={r['needs']}, "
+                    "expected exactly one element (its graph node)"
+                )
+            elif r["needs"][0] not in graph_row_keys:
+                errors.append(
+                    f"concrete row {r['job_id']} ({r['name']}) needs[] target "
+                    f"{r['needs'][0]} is not a graph-node row_key in this dump"
+                )
+        else:
+            for n in r["needs"]:
+                if n not in graph_row_keys:
+                    errors.append(
+                        f"graph row {r['caller_job_key']} needs[] target {n} "
+                        "is not a graph-node row_key in this dump"
+                    )
+
+            # canonical_matrix_key shape (empty or sorted key=val,key=val)
+            gik = r["graph_instance_key"]
+            if gik:
+                parts = gik.split(",")
+                keys = [p.split("=", 1)[0] for p in parts if "=" in p]
+                if keys != sorted(keys):
+                    errors.append(
+                        f"graph row {r['caller_job_key']} graph_instance_key "
+                        f"{gik!r} is not sorted"
+                    )
+
+    return errors
+
+
+# ---------- CLI ----------
+
+
+def emit(rows: dict[str, list[dict[str, Any]]], table: str) -> None:
+    if table == "all":
+        for tbl in ("workflow_runs", "jobs", "job_steps"):
+            for r in rows.get(tbl, []):
+                sys.stdout.write(json.dumps({"_table": tbl, **r}))
+                sys.stdout.write("\n")
+        return
+    for r in rows.get(table, []):
+        sys.stdout.write(json.dumps(r))
+        sys.stdout.write("\n")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--run-id", type=int, required=True)
+    p.add_argument("--run-attempt", type=int, required=True)
+    p.add_argument("--repo", default="shader-slang/slang")
+    p.add_argument(
+        "--table",
+        choices=("workflow_runs", "jobs", "job_steps", "all"),
+        default="all",
+    )
+    p.add_argument(
+        "--validate",
+        action="store_true",
+        help="Run structural sanity checks; exit non-zero on any error.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    rows = build_rows(args.repo, args.run_id, args.run_attempt)
+
+    if args.validate:
+        errs = validate(rows)
+        if errs:
+            for e in errs:
+                sys.stderr.write(f"validation error: {e}\n")
+            return 1
+        sys.stderr.write(
+            f"validation OK: {len(rows.get('workflow_runs', []))} workflow_runs, "
+            f"{len(rows.get('jobs', []))} jobs ("
+            f"{sum(1 for r in rows.get('jobs', []) if r['node_kind'] != 'concrete_job')} graph, "
+            f"{sum(1 for r in rows.get('jobs', []) if r['node_kind'] == 'concrete_job')} concrete), "
+            f"{len(rows.get('job_steps', []))} job_steps\n"
+        )
+
+    emit(rows, args.table)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/extras/ci/analytics/ci_bq_ingest.py
+++ b/extras/ci/analytics/ci_bq_ingest.py
@@ -35,6 +35,7 @@ from _bq_ingest_lib import (
     rk_workflow_run,
     workflow_tier,
 )
+from bq_loader import load_rows_to_bq
 from workflow_parser import JobSpec, WorkflowSpec, fetch_workflow_yaml
 
 
@@ -732,6 +733,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="Run structural sanity checks; exit non-zero on any error.",
     )
+    p.add_argument(
+        "--load-to-bq",
+        action="store_true",
+        help=(
+            "After building rows (and validating, if --validate is set), load "
+            "them into per-attempt staging tables and atomically MERGE into "
+            "the live slang_ci dataset. Staging tables are dropped on "
+            "success and failure. No-ops --table emission to stdout."
+        ),
+    )
     return p.parse_args(argv)
 
 
@@ -752,6 +763,18 @@ def main(argv: list[str]) -> int:
             f"{sum(1 for r in rows.get('jobs', []) if r['node_kind'] == 'concrete_job')} concrete), "
             f"{len(rows.get('job_steps', []))} job_steps\n"
         )
+
+    if args.load_to_bq:
+        load_rows_to_bq(
+            rows,
+            src_run_id=args.run_id,
+            src_run_attempt=args.run_attempt,
+        )
+        sys.stderr.write(
+            f"loaded run_id={args.run_id} run_attempt={args.run_attempt} "
+            f"into slang-runners:slang_ci\n"
+        )
+        return 0
 
     emit(rows, args.table)
     return 0

--- a/extras/ci/analytics/ci_bq_ingest.py
+++ b/extras/ci/analytics/ci_bq_ingest.py
@@ -270,7 +270,6 @@ def _tier2_concrete_row(
     *,
     run_id: int,
     run_attempt: int,
-    workflow_file: str | None,
     run_created_at: str | None,
 ) -> dict[str, Any]:
     """Build a Tier 2 (record_only) concrete_job row. All graph columns NULL.
@@ -280,6 +279,10 @@ def _tier2_concrete_row(
     works for hosted-runner concurrency and conclusion/duration analytics
     because workflow_name is joinable through (run_id, run_attempt) on
     workflow_runs.
+
+    Per the plan, every graph column is NULL on Tier 2 rows — including
+    caller_workflow_file. Workflow attribution is one JOIN away via
+    workflow_runs.workflow_file. Validation enforces this.
     """
     return {
         "row_key": rk_concrete(api_job["id"]),
@@ -287,7 +290,7 @@ def _tier2_concrete_row(
         "run_id": run_id,
         "run_attempt": run_attempt,
         "name": api_job.get("name"),
-        "caller_workflow_file": workflow_file,
+        "caller_workflow_file": None,
         "caller_job_key": None,
         "called_workflow_file": None,
         "called_job_key": None,
@@ -341,7 +344,6 @@ def build_rows(
                     api_job,
                     run_id=run_id,
                     run_attempt=run_attempt,
-                    workflow_file=workflow_file,
                     run_created_at=run_created_at,
                 )
             )
@@ -628,6 +630,24 @@ def validate(
             "rows; expected 0. Tier 2 must not materialize graph nodes."
         )
 
+    # Per-tier graph-field NULL contract on concrete rows. Tier 2's whole
+    # point is that these fields are unset — leaking a Tier 1-style value
+    # into a Tier 2 row would corrupt the "rows with NULL graph_instance_key
+    # are the lightweight tier" assumption downstream queries can rely on.
+    TIER2_NULL_FIELDS = (
+        "caller_workflow_file",
+        "caller_job_key",
+        "called_workflow_file",
+        "called_job_key",
+        "graph_instance_key",
+        "job_type",
+        "matrix_os",
+        "matrix_arch",
+        "matrix_compiler",
+        "matrix_config",
+        "matrix_gpu_tier",
+    )
+
     for r in jobs:
         if r["node_kind"] == "concrete_job":
             if tier == "record_only":
@@ -635,6 +655,15 @@ def validate(
                     errors.append(
                         f"Tier 2 concrete row {r['job_id']} ({r['name']}) has "
                         f"needs[]={r['needs']}, expected empty list."
+                    )
+                leaked = [
+                    f for f in TIER2_NULL_FIELDS if r.get(f) is not None
+                ]
+                if leaked:
+                    errors.append(
+                        f"Tier 2 concrete row {r['job_id']} ({r['name']}) has "
+                        f"non-NULL graph fields: "
+                        + ", ".join(f"{k}={r[k]!r}" for k in leaked)
                     )
                 continue
             if not r["needs"]:

--- a/extras/ci/analytics/workflow_parser.py
+++ b/extras/ci/analytics/workflow_parser.py
@@ -1,0 +1,149 @@
+"""Workflow YAML parser for BigQuery ingestion.
+
+Extracts only the declared fields the plan whitelists:
+
+    jobs.<key>.name
+    jobs.<key>.needs
+    jobs.<key>.strategy.matrix
+    jobs.<key>.uses
+    jobs.<key>.with
+    on.workflow_call.inputs.*       (called workflow side)
+
+The parser does NOT evaluate `${{ ... }}` expressions. Matrix-axis values that
+contain expressions are recorded as raw strings; the ingester resolves them by
+joining against the concrete child job's API-reported matrix values.
+
+Inputs are fetched as data (never checked out) via gh api contents. The result
+is cached by (workflow_file, head_sha) so the same YAML is not re-fetched per
+attempt.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Any
+
+import yaml
+
+from _bq_ingest_lib import gh_api
+
+
+@dataclass
+class JobSpec:
+    """Parsed top-level YAML job entry."""
+
+    job_key: str
+    name: str | None
+    needs: list[str] = field(default_factory=list)
+    matrix: dict[str, list[Any]] = field(default_factory=dict)
+    uses: str | None = None  # e.g. "./.github/workflows/ci-slang-build.yml"
+    with_inputs: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_reusable_call(self) -> bool:
+        return self.uses is not None
+
+    @property
+    def is_matrix(self) -> bool:
+        return bool(self.matrix)
+
+
+@dataclass
+class WorkflowSpec:
+    """Parsed workflow YAML."""
+
+    workflow_file: str  # e.g. ".github/workflows/ci.yml"
+    name: str | None
+    jobs: dict[str, JobSpec] = field(default_factory=dict)
+    # For called workflows: declared inputs (just names + default values, not types).
+    workflow_call_inputs: dict[str, Any] = field(default_factory=dict)
+
+
+MAX_WORKFLOW_BYTES = 256 * 1024
+MAX_JOBS_PER_WORKFLOW = 1000
+
+
+def _parse_workflow_yaml(raw: str, workflow_file: str) -> WorkflowSpec:
+    if len(raw) > MAX_WORKFLOW_BYTES:
+        raise ValueError(
+            f"workflow {workflow_file} exceeds {MAX_WORKFLOW_BYTES} byte cap"
+        )
+    # yaml.safe_load only — never yaml.load (unsafe).
+    doc = yaml.safe_load(raw) or {}
+
+    spec = WorkflowSpec(workflow_file=workflow_file, name=doc.get("name"))
+
+    # Called-side inputs.
+    on_clause = doc.get("on") or doc.get(True) or {}
+    if isinstance(on_clause, dict):
+        wc = on_clause.get("workflow_call") or {}
+        if isinstance(wc, dict):
+            inputs = wc.get("inputs") or {}
+            if isinstance(inputs, dict):
+                spec.workflow_call_inputs = {
+                    k: (v.get("default") if isinstance(v, dict) else None)
+                    for k, v in inputs.items()
+                }
+
+    jobs = doc.get("jobs") or {}
+    if not isinstance(jobs, dict):
+        return spec
+    if len(jobs) > MAX_JOBS_PER_WORKFLOW:
+        raise ValueError(
+            f"workflow {workflow_file} has {len(jobs)} jobs, cap is "
+            f"{MAX_JOBS_PER_WORKFLOW}"
+        )
+
+    for job_key, body in jobs.items():
+        if not isinstance(body, dict):
+            continue
+        js = JobSpec(job_key=job_key, name=body.get("name"))
+
+        needs = body.get("needs")
+        if isinstance(needs, str):
+            js.needs = [needs]
+        elif isinstance(needs, list):
+            js.needs = [str(n) for n in needs if isinstance(n, (str, int))]
+
+        strategy = body.get("strategy") or {}
+        if isinstance(strategy, dict):
+            matrix = strategy.get("matrix")
+            if isinstance(matrix, dict):
+                # Take only scalar list-axes; ignore include/exclude for the
+                # vertical slice. (Slang's CI uses `with:` for matrix-like
+                # axes today, so this is mostly defensive.)
+                js.matrix = {
+                    k: v
+                    for k, v in matrix.items()
+                    if k not in ("include", "exclude") and isinstance(v, list)
+                }
+
+        uses = body.get("uses")
+        if isinstance(uses, str):
+            js.uses = uses
+
+        with_block = body.get("with")
+        if isinstance(with_block, dict):
+            js.with_inputs = with_block
+
+        spec.jobs[job_key] = js
+
+    return spec
+
+
+@lru_cache(maxsize=64)
+def fetch_workflow_yaml(repo: str, workflow_file: str, head_sha: str) -> WorkflowSpec:
+    """Fetch a workflow file at the given commit as DATA (no checkout) and parse.
+
+    Cached by (workflow_file, head_sha) so the same YAML isn't re-fetched per
+    attempt or per job that references it.
+    """
+    payload = gh_api(f"repos/{repo}/contents/{workflow_file}?ref={head_sha}")
+    if payload.get("encoding") != "base64":
+        raise ValueError(
+            f"unexpected encoding {payload.get('encoding')!r} for {workflow_file}"
+        )
+    raw = base64.b64decode(payload["content"]).decode("utf-8")
+    return _parse_workflow_yaml(raw, workflow_file)

--- a/extras/ci/analytics/workflow_parser.py
+++ b/extras/ci/analytics/workflow_parser.py
@@ -32,14 +32,16 @@ from _bq_ingest_lib import gh_api
 
 @dataclass
 class JobSpec:
-    """Parsed top-level YAML job entry."""
+    """Parsed top-level YAML job entry. All fields are scalar-or-None after
+    parser normalization; nested structures are dropped before this point.
+    """
 
     job_key: str
     name: str | None
     needs: list[str] = field(default_factory=list)
-    matrix: dict[str, list[Any]] = field(default_factory=dict)
+    matrix: dict[str, list[str]] = field(default_factory=dict)
     uses: str | None = None  # e.g. "./.github/workflows/ci-slang-build.yml"
-    with_inputs: dict[str, Any] = field(default_factory=dict)
+    with_inputs: dict[str, str] = field(default_factory=dict)
 
     @property
     def is_reusable_call(self) -> bool:
@@ -57,25 +59,50 @@ class WorkflowSpec:
     workflow_file: str  # e.g. ".github/workflows/ci.yml"
     name: str | None
     jobs: dict[str, JobSpec] = field(default_factory=dict)
-    # For called workflows: declared inputs (just names + default values, not types).
-    workflow_call_inputs: dict[str, Any] = field(default_factory=dict)
+    # For called workflows: declared inputs (name → scalar default or None).
+    workflow_call_inputs: dict[str, str | None] = field(default_factory=dict)
 
 
 MAX_WORKFLOW_BYTES = 256 * 1024
 MAX_JOBS_PER_WORKFLOW = 1000
 
 
+def _safe_str(v: Any) -> str | None:
+    """Return v as a string if it's a scalar type (str/int/bool/float),
+    otherwise None. The plan's whitelist treats every extracted YAML field as
+    a scalar; non-scalars survive `safe_load` (nested dicts, lists, None) and
+    must be rejected before they reach BigQuery.
+    """
+    if isinstance(v, str):
+        return v
+    if isinstance(v, bool):
+        # bool is a subclass of int; check first so we don't lose `true/false`
+        return "true" if v else "false"
+    if isinstance(v, (int, float)):
+        return str(v)
+    return None
+
+
 def _parse_workflow_yaml(raw: str, workflow_file: str) -> WorkflowSpec:
+    # Cap is on the raw (post-decode) string — base64-decoded content can be
+    # much larger than the on-wire payload.
     if len(raw) > MAX_WORKFLOW_BYTES:
         raise ValueError(
-            f"workflow {workflow_file} exceeds {MAX_WORKFLOW_BYTES} byte cap"
+            f"workflow {workflow_file} exceeds {MAX_WORKFLOW_BYTES} byte cap "
+            f"(saw {len(raw)} bytes)"
         )
-    # yaml.safe_load only — never yaml.load (unsafe).
+    # yaml.safe_load only — never yaml.load (unsafe constructors).
     doc = yaml.safe_load(raw) or {}
+    if not isinstance(doc, dict):
+        raise ValueError(
+            f"workflow {workflow_file} top-level is not a mapping "
+            f"(got {type(doc).__name__})"
+        )
 
-    spec = WorkflowSpec(workflow_file=workflow_file, name=doc.get("name"))
+    spec = WorkflowSpec(workflow_file=workflow_file, name=_safe_str(doc.get("name")))
 
-    # Called-side inputs.
+    # Called-side inputs. PyYAML maps the bare `on:` key to Python True; both
+    # spellings show up in the wild depending on the YAML version.
     on_clause = doc.get("on") or doc.get(True) or {}
     if isinstance(on_clause, dict):
         wc = on_clause.get("workflow_call") or {}
@@ -83,8 +110,13 @@ def _parse_workflow_yaml(raw: str, workflow_file: str) -> WorkflowSpec:
             inputs = wc.get("inputs") or {}
             if isinstance(inputs, dict):
                 spec.workflow_call_inputs = {
-                    k: (v.get("default") if isinstance(v, dict) else None)
+                    k: (
+                        _safe_str(v.get("default"))
+                        if isinstance(v, dict)
+                        else _safe_str(v)
+                    )
                     for k, v in inputs.items()
+                    if isinstance(k, str)
                 }
 
     jobs = doc.get("jobs") or {}
@@ -97,28 +129,33 @@ def _parse_workflow_yaml(raw: str, workflow_file: str) -> WorkflowSpec:
         )
 
     for job_key, body in jobs.items():
-        if not isinstance(body, dict):
+        if not isinstance(job_key, str) or not isinstance(body, dict):
             continue
-        js = JobSpec(job_key=job_key, name=body.get("name"))
+        js = JobSpec(job_key=job_key, name=_safe_str(body.get("name")))
 
         needs = body.get("needs")
         if isinstance(needs, str):
             js.needs = [needs]
         elif isinstance(needs, list):
-            js.needs = [str(n) for n in needs if isinstance(n, (str, int))]
+            js.needs = [n for n in (_safe_str(x) for x in needs) if n]
 
         strategy = body.get("strategy") or {}
         if isinstance(strategy, dict):
             matrix = strategy.get("matrix")
             if isinstance(matrix, dict):
-                # Take only scalar list-axes; ignore include/exclude for the
-                # vertical slice. (Slang's CI uses `with:` for matrix-like
-                # axes today, so this is mostly defensive.)
-                js.matrix = {
-                    k: v
-                    for k, v in matrix.items()
-                    if k not in ("include", "exclude") and isinstance(v, list)
-                }
+                # Only scalar list-axes survive; ignore include/exclude (full
+                # matrix expansion is future work) and any axis whose values
+                # are not all scalars.
+                cleaned: dict[str, list[Any]] = {}
+                for k, v in matrix.items():
+                    if not isinstance(k, str) or k in ("include", "exclude"):
+                        continue
+                    if not isinstance(v, list):
+                        continue
+                    scalar_vals = [_safe_str(item) for item in v]
+                    if all(s is not None for s in scalar_vals):
+                        cleaned[k] = scalar_vals
+                js.matrix = cleaned
 
         uses = body.get("uses")
         if isinstance(uses, str):
@@ -126,7 +163,17 @@ def _parse_workflow_yaml(raw: str, workflow_file: str) -> WorkflowSpec:
 
         with_block = body.get("with")
         if isinstance(with_block, dict):
-            js.with_inputs = with_block
+            # Drop non-scalar values; the parser doesn't try to flatten lists
+            # or nested mappings. Values containing `${{ ... }}` expressions
+            # are kept verbatim (resolved later against API job data).
+            cleaned_with: dict[str, str] = {}
+            for k, v in with_block.items():
+                if not isinstance(k, str):
+                    continue
+                s = _safe_str(v)
+                if s is not None:
+                    cleaned_with[k] = s
+            js.with_inputs = cleaned_with
 
         spec.jobs[job_key] = js
 


### PR DESCRIPTION
First half of the BigQuery CI telemetry pipeline planned in [slang-ci-docs:plans/bigquery-reporting.md](https://slang.gitlab-master-pages.nvidia.com/slang-ci-docs/plans/bigquery-reporting/). Ships the schema, the ingester, and the `ci-telemetry.yml` workflow's `ingest` job. The `publish-snapshot` job (and the dashboard JSON publisher) come in a follow-up gated on the first snapshot query existing.

## What this lands

**BigQuery schema** (`extras/ci/analytics/bq_schema/*.sql`)
`workflow_runs`, `jobs`, `job_steps`, `build_stats`, `scaler_events` tables plus `_latest` views. Partitioned on `DATE(...)` of a denormalized timestamp; clustered by `(run_id, run_attempt, ...)`. Already applied to `slang-runners:slang_ci`; the SQL files are checked in for documentation parity and recreation.

**Ingester** (`extras/ci/analytics/{_bq_ingest_lib,workflow_parser,ci_bq_ingest,bq_loader}.py` + `bq_schema/merge_live_tables.sql.tmpl`)
CLI that takes a `(run_id, run_attempt)`, fetches the run skeleton from the GH Actions API, optionally parses the workflow YAML at `head_sha`, materializes the graph-node + concrete-job rows per the schema, then loads them into per-attempt staging tables and atomically MERGEs into the live `slang_ci` dataset with conflict retry.

Two-tier dispatch per the plan:
- **Tier 1 (`parse_graph`)** for `CI`, `CMake Options`, `Falcor Tests`, `Falcor Compiler Perf-Test`, `RTX Remix Shaders (Nightly)`, `Sascha Willems Vulkan Shaders (Nightly)`, `VK-GL-CTS Nightly` — full graph parse, matrix axes, every top-level YAML job becomes a graph node.
- **Tier 2 (`record_only`)** for everything else — concrete-job rows only with NULL graph columns. Powers the planned hosted-runner-concurrency analytics without the cost of parsing housekeeping workflows.

**Workflow** (`.github/workflows/ci-telemetry.yml`)
`workflow_run` (types: `completed`) triggers on the 7 Tier 1 workflows plus 13 representative Tier 2 workflows; `workflow_dispatch` with `run_id` / `run_attempt` inputs as the manual escape hatch. One `ingest` job, OIDC → WIF → `slang-ci-ingest@` SA, runs `ci_bq_ingest.py --validate --load-to-bq`. Default-branch guard so manual dispatch from a non-master ref skips, plus the per-SA WIF binding restricts impersonation to this exact `workflow_ref` on master. All third-party actions pinned to commit SHAs.

## What's tested

The ingester's CLI path is end-to-end tested against five real CI runs:

| Workflow | Tier | Graph | Concrete | Steps |
|---|---|---|---|---|
| CI (merge_group) | parse_graph | 24 | 34 | 392 |
| Falcor Tests | parse_graph | 1 | 1 | 11 |
| CMake Options | parse_graph | 11 | 311 | 3293 |
| VK-GL-CTS Nightly | parse_graph | 1 | 1 | 18 |
| Verify PR Labels | record_only | 0 | 1 | 3 |

Idempotency verified: two consecutive `--load-to-bq` runs against the same `(run_id, run_attempt)` leave row counts unchanged. Test rows deleted afterwards; `slang_ci` is empty pre-merge.

The WIF auth path itself is **not** exercised yet — `workflow_run` only fires for the workflow file as it exists on the default branch, so first prod validation happens after this PR merges. The first post-merge step is a `workflow_dispatch` against a known historical CI run; if WIF auth fails, `gh workflow disable` and a follow-up commit fixes the binding without affecting any other workflow.

Internal review trail: ten Codex review rounds across the ten commits in this branch — each commit went out for review before moving on.

## Deliberately deferred

- `publish-snapshot` job + hourly schedule trigger — needs at least one allow-listed snapshot query plus the cross-repo push credential to [`shader-slang/slang-ci-analytics`](https://github.com/shader-slang/slang-ci-analytics). Lands in a follow-up.
- In-progress polling job (the third `ci-telemetry.yml` job we identified as a prereq for retiring the live-state portion of `ci_health.html`).
- `build_stats` ingest — depends on producer-side `telemetry-job-*` artifact uploads in `ci.yml`, lands once the consumer is proven.
- Phase 2 (`test_results` + xUnit ingest) — gated on #9252.
- Caller-side `strategy.matrix` with proper `graph_instance_key` reconstruction (Slang's CI doesn't exercise it today).
- Critical-path: currently `MAX(child.duration)`, not the full internal-DAG walk. Conservative (lower bound when children run in parallel inside a reusable workflow).

## Cost and surface area

- BigQuery: well within the free tier per the [plan's cost estimate](https://slang.gitlab-master-pages.nvidia.com/slang-ci-docs/plans/bigquery-reporting/#cost-estimate). `slang_ci_staging` has a 1-day default table expiration as a safety net.
- GH Actions: one new workflow (`ci-telemetry.yml`), no changes to `ci.yml` or any reusable workflow.
- Trust boundary: documented in the plan. Producing jobs never see BigQuery credentials; only `ci-telemetry.yml` running from master does, via OIDC WIF.

## Rollback

`gh workflow disable ci-telemetry.yml` stops the ingest immediately. The staging dataset's 1-day expiration sweeps any orphaned tables. Reverting the PR fully removes the schema + ingester; the live `slang_ci` dataset can be dropped manually if desired (`bq rm -r -f slang_ci`).

## References

- [BigQuery reporting plan](https://slang.gitlab-master-pages.nvidia.com/slang-ci-docs/plans/bigquery-reporting/) — full design, including the two-tier model, MERGE pruning, hardening checklist, and cost estimates.
- [Hosted-runner quota analytics](https://slang.gitlab-master-pages.nvidia.com/slang-ci-docs/plans/bigquery-reporting/#hosted-runner-concurrency-by-workflow) — the motivating Tier 2 query, written against the schema in this PR.