### PR TITLE
Workaround SPIRV-Tools MergeReturnPass UAF with debug info (#11146)

### DIFF
--- a/source/slang-glslang/slang-glslang.cpp
+++ b/source/slang-glslang/slang-glslang.cpp
@@ -297,6 +297,17 @@ static int glslang_optimizeSPIRV(
         optimizer.RegisterPass(spvtools::CreatePropagateLineInfoPass());
     }
 
+    // shader-slang/slang#11146: MergeReturnPass has a use-after-free in
+    // SPIRV-Tools' DefUseManager that fires when NonSemantic.Shader.DebugInfo
+    // instructions are attached to the rewritten terminator. The pass
+    // re-analyzes the terminator's dbg_line_insts, which are pointers into a
+    // std::vector buffer that may have been invalidated by an earlier pass.
+    // We skip MergeReturnPass (and the InlineExhaustivePass that depends on
+    // it -- see comment in the DEFAULT case below) whenever debug info is
+    // enabled, until the upstream UAF is fixed. Remove this workaround once
+    // the SPIRV-Tools fix lands and the submodule is bumped.
+    const bool skipMergeReturnPass = (debugInfoType != SLANG_DEBUG_INFO_LEVEL_NONE);
+
     spvtools::OptimizerOptions spvOptOptions;
 
     // To compile some large shaders the default is not enough.
@@ -346,8 +357,11 @@ static int glslang_optimizeSPIRV(
             optimizer.RegisterPass(spvtools::CreateWrapOpKillPass());     // 1
             optimizer.RegisterPass(spvtools::CreateDeadBranchElimPass()); // 2
 
-            optimizer.RegisterPass(spvtools::CreateMergeReturnPass());
-            optimizer.RegisterPass(spvtools::CreateInlineExhaustivePass());
+            if (!skipMergeReturnPass)
+            {
+                optimizer.RegisterPass(spvtools::CreateMergeReturnPass());
+                optimizer.RegisterPass(spvtools::CreateInlineExhaustivePass());
+            }
 
             optimizer.RegisterPass(spvtools::CreateEliminateDeadFunctionsPass()); // 3
 
@@ -401,8 +415,11 @@ static int glslang_optimizeSPIRV(
             // size
             optimizer.RegisterPass(spvtools::CreateWrapOpKillPass());
             optimizer.RegisterPass(spvtools::CreateDeadBranchElimPass()); // 15
-            optimizer.RegisterPass(spvtools::CreateMergeReturnPass());
-            optimizer.RegisterPass(spvtools::CreateInlineExhaustivePass());
+            if (!skipMergeReturnPass)
+            {
+                optimizer.RegisterPass(spvtools::CreateMergeReturnPass());
+                optimizer.RegisterPass(spvtools::CreateInlineExhaustivePass());
+            }
             optimizer.RegisterPass(spvtools::CreateEliminateDeadFunctionsPass()); // 9
             optimizer.RegisterPass(spvtools::CreatePrivateToLocalPass());
             // optimizer.RegisterPass(spvtools::CreateScalarReplacementPass(0));   // 12
@@ -449,8 +466,11 @@ static int glslang_optimizeSPIRV(
 
             optimizer.RegisterPass(spvtools::CreateWrapOpKillPass());
             optimizer.RegisterPass(spvtools::CreateDeadBranchElimPass());
-            optimizer.RegisterPass(spvtools::CreateMergeReturnPass());
-            optimizer.RegisterPass(spvtools::CreateInlineExhaustivePass());
+            if (!skipMergeReturnPass)
+            {
+                optimizer.RegisterPass(spvtools::CreateMergeReturnPass());
+                optimizer.RegisterPass(spvtools::CreateInlineExhaustivePass());
+            }
             optimizer.RegisterPass(spvtools::CreateEliminateDeadFunctionsPass());
             optimizer.RegisterPass(spvtools::CreateAggressiveDCEPass());
             optimizer.RegisterPass(spvtools::CreatePrivateToLocalPass());


### PR DESCRIPTION
## Summary

Skip `CreateMergeReturnPass` (and the dependent `CreateInlineExhaustivePass`) in `glslang_optimizeSPIRV` whenever debug info is requested, until the underlying SPIRV-Tools UAF is fixed upstream.

Fixes #11146.

## Background

When `NonSemantic.Shader.DebugInfo.100` instructions are present in the SPIR-V handed to the optimizer, `MergeReturnPass::BranchToBlock` triggers a use-after-free in `spvtools::opt::analysis::DefUseManager`:

```
DefUseManager::AnalyzeInstDefUse(<OpBranch terminator>)        def_use_manager.cpp:71
  -> AnalyzeInstDefUse(<OpExtInst NSDI from dbg_line_insts>)   def_use_manager.cpp:67
  -> AnalyzeInstDef -> ClearInst -> EraseUseRecordsOfOperandIds
  -> std::set::erase -> UserEntryLess -> Instruction::unique_id()  // asserts unique_id_ != 0
```

`Instruction::dbg_line_insts_` is `std::vector<Instruction>` (instruction.h:643), and `AnalyzeInstDefUse` registers pointers into that vector's buffer as long-lived keys in the def-use map. Any subsequent vector mutation invalidates those pointers; the next set lookup walks the comparator over freed memory.

Upstream has patched several specific NSDI cases (KhronosGroup/SPIRV-Tools#6217 for ADCE, #6420, #6555, #6635, etc.) but not done the structural ownership fix.

## Deterministic repro

The crash is deterministic for `(shader × optimization level × debug-info level)`. It looked flaky in CI only because most test inputs miss the combination. Reproduces on macOS without a GPU:

```bash
./build/Debug/bin/slangc \
    tests/metal/groupshared-threadlocal-same-parameter.slang \
    -target spirv -stage compute -entry computeMain \
    -emit-spirv-via-glsl -O1 -g \
    -o out.spv
# Assertion failed: (unique_id_ != 0), function unique_id, file instruction.h, line 251.
```

Crashes at `-O1`/`-O2`/`-O3` with `-g`. Clean at `-O0` or without `-g`. The direct emit path (`-emit-spirv-directly`) also funnels through `glslang_optimizeSPIRV` (via `SLANG_PASS_THROUGH_SPIRV_OPT`) and hits the same crash.

In CI this manifested as `JSON RPC failure: waitForResult()` from a SIGABRT'd test-server. Backtrace captured by #11069 — two cores in run 26175916650 (gh-readonly-queue/master/pr-11167) share the identical Thread 1 stack and the same `target=276`.

## The change

`source/slang-glslang/slang-glslang.cpp` registers `CreateMergeReturnPass` at three live sites (DEFAULT, HIGH, MAXIMAL). Each registration is paired with `CreateInlineExhaustivePass`, which depends on MergeReturn (per the comment at line 321). This PR adds:

```cpp
const bool skipMergeReturnPass = (debugInfoType != SLANG_DEBUG_INFO_LEVEL_NONE);
```

…and guards all three `MergeReturnPass`/`InlineExhaustivePass` pairs. With debug info disabled, the pipeline is unchanged. With debug info enabled, we pay a small optimization-quality cost (no inlining, no return merging) in exchange for not crashing.

This follows the file's existing precedent of disabling specific spirv-opt passes that "cause serious problem on some drivers" (see commented-out `CreateIfConversionPass`, `CreateBlockMergePass` and others at lines 361-362 and 408-431).

## Verification

- All five previously-crashing configurations on `tests/metal/groupshared-threadlocal-same-parameter.slang` and `tests/compute/spirv-array-texel-pointer-atomic.slang` now exit cleanly (`-O1/-O2/-O3 × -g`, both via-glsl and direct paths).
- 5/5 patched runs of the via-glsl repro are clean; baseline still crashes.
- `SLANG_RUN_SPIRV_VALIDATION=1` passes on the patched output.
- No-`-g` codegen is byte-identical (same passes registered).

## Follow-up

This is a workaround, not the fix. Plan:

1. File a SPIRV-Tools upstream issue with the deterministic repro and a proposed structural fix (either skip embedded `dbg_line_insts_` registration in `AnalyzeInstDefUse`, or move `dbg_line_insts_` to stable storage).
2. After upstream lands a fix and we roll the SPIRV-Tools submodule, **revert this workaround**.

## PR labels

`pr: non-breaking` — workaround in downstream-compiler pipeline; no public API or language behavior changes.