### PR TITLE
Verify Vulkan SDK checksum in GPU CI image

### DIFF
--- a/docker/linux-gpu-ci.Dockerfile
+++ b/docker/linux-gpu-ci.Dockerfile
@@ -65,6 +65,7 @@ ENV LD_LIBRARY_PATH="${VULKAN_SDK}/lib:${LD_LIBRARY_PATH}"
 ENV VK_LAYER_PATH="${VULKAN_SDK}/share/vulkan/explicit_layer.d"
 
 RUN wget -q https://sdk.lunarg.com/sdk/download/1.4.341.1/linux/vulkansdk-linux-x86_64-1.4.341.1.tar.xz && \
+    echo "3bf0f762afb6c79bc6a9d9fb5998745ccff928800a29619b501ed9de7fd9789b  vulkansdk-linux-x86_64-1.4.341.1.tar.xz" | sha256sum -c - && \
     tar -xf vulkansdk-linux-x86_64-1.4.341.1.tar.xz && \
     mkdir -p /opt/vulkan-sdk && \
     mv 1.4.341.1 /opt/vulkan-sdk/ && \


### PR DESCRIPTION
Summary:
- Verify the Linux GPU CI Vulkan SDK tarball against LunarG's published SHA256 before extraction.
- Keep the SDK version and install flow unchanged.

Tests:
- git diff --check

Not run:
- Full Docker image build; this would pull/build the large GPU CI image and SDK layers.
