### PR TITLE
[draft] Bump DXC to v1.10.2605.2 (preview)

### DIFF
--- a/cmake/FetchDXC.cmake
+++ b/cmake/FetchDXC.cmake
@@ -19,12 +19,12 @@ include(FetchContent)
 if(NOT DEFINED SLANG_DXC_BINARY_URL)
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         set(SLANG_DXC_BINARY_URL
-            "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.9.2602/dxc_2026_02_20.zip"
+            "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.10.2605.2/dxc_preview_2026_04_22.zip"
         )
     elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
             set(SLANG_DXC_BINARY_URL
-                "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.9.2602/linux_dxc_2026_02_20.x86_64.tar.gz"
+                "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.10.2605.2/linux_dxc_preview_2026_04_22.x86_64.tar.gz"
             )
         endif()
     endif()


### PR DESCRIPTION
Draft fix for #11002.

## Summary

Bumps the prebuilt DXC URLs in `cmake/FetchDXC.cmake` from v1.9.2602 to v1.10.2605.2 — the first DXC release with Shader Model 6.10 / `dx::linalg` HLSL support. Re-enabling the cooperative-vector / cooperative-matrix `DISABLE_TEST` directives (~60 files under `tests/cooperative-{vector,matrix}/`) is deferred to a follow-up issue so this PR stays a focused infra bump.

## Changes

- `cmake/FetchDXC.cmake:22, 27`: switch Windows + Linux x86_64 release URLs to v1.10.2605.2 with the new `_preview_` asset names (`dxc_preview_2026_04_22.zip` / `linux_dxc_preview_2026_04_22.x86_64.tar.gz`).

`external/slang-rhi/CMakeLists.txt:158` is intentionally NOT touched — when slang-rhi is built as a submodule it sees `dxc_POPULATED=TRUE` from this file's `FetchContent_MakeAvailable(dxc)` and skips its own download. A separate mirror PR against `shader-slang/slang-rhi` is the right place for standalone slang-rhi builds.

## Test plan

- [x] `cmake --preset default` resolves and downloads `linux_dxc_preview_2026_04_22.x86_64.tar.gz` cleanly (DXC URL is valid).
- [ ] Slang Linux x86_64 + Windows x64 builds in CI.
- [ ] `slang-test` linalg-touching subset (Linux GPU container + Windows GPU runner) — expect new `dx::linalg` paths to start working once the follow-up enables the disabled tests.

## Known risk: GLIBC

v1.10.2605.2's prebuilt Linux libs (`libdxcompiler.so`, `libdxil.so`) are built against **GLIBC ≥ 2.38**. Slang CI's standard Linux jobs run on `ubuntu-22.04` (GLIBC 2.35); only `ubuntu-24.04` (GLIBC 2.39) and the `slang-linux-gpu-ci` container reliably satisfy this. Expect DXIL-loading failures on the `ubuntu-22.04` runners until either (a) those jobs are moved to `ubuntu-24.04`, or (b) `slang-linux-gpu-ci`'s base image already covers the GLIBC requirement and only the host-runner jobs need to migrate. CI is the authoritative signal here.

Local verification of slangc was blocked by an unrelated sandbox env issue (X11 dev headers absent for slang-rhi vulkan build, plus disk pressure causing `cc1plus: Bus error` mid-link). The CMake configure succeeds and the new asset URLs are reachable; downstream link/test verification depends on CI.

## Follow-up

A separate issue will track flipping the ~60 `//DISABLE_TEST` directives in `tests/cooperative-{vector,matrix}/` once this PR lands and CI confirms DXC v1.10.2605.2 loads on the runner matrix.