### PR TITLE
ci/coverage-nightly: cut over to in-tree renderer; add Windows + merged rows to landing page

### DIFF
--- a/.github/workflows/ci-slang-coverage.yml
+++ b/.github/workflows/ci-slang-coverage.yml
@@ -30,10 +30,6 @@ on:
         required: false
         type: string
         default: ""
-      deploy-pages:
-        required: false
-        type: boolean
-        default: false
       pr-comment:
         required: false
         type: boolean
@@ -74,7 +70,7 @@ jobs:
         with:
           min-disk-gb: "10"
 
-      - name: Install OpenCppCoverage and ReportGenerator (Windows)
+      - name: Install OpenCppCoverage (Windows)
         if: inputs.os == 'windows'
         shell: pwsh
         run: |
@@ -86,24 +82,6 @@ jobs:
           $occ = "C:\Program Files\OpenCppCoverage\OpenCppCoverage.exe"
           if (-not (Test-Path $occ)) { throw "OpenCppCoverage.exe missing at $occ" }
           Write-Host "OpenCppCoverage installed: $occ"
-
-          # ReportGenerator via dotnet tool -- used by run-coverage-windows.ps1
-          # to render the Cobertura XML as HTML (full + slangc-only variants).
-          # OCC's own HTML is line-level only and markedly less polished than
-          # llvm-cov's HTML on Linux/macOS; ReportGenerator's output is close
-          # to parity.
-          #
-          # Pin the version to match local testing (parallel to the OCC pin
-          # above). Without --version, `dotnet tool install` grabs the latest
-          # NuGet release at workflow execution time, so a breaking change in
-          # ReportGenerator could fail the nightly with no diff in this repo.
-          dotnet tool install -g dotnet-reportgenerator-globaltool --version 5.5.6
-          if ($LASTEXITCODE -ne 0) { throw "dotnet tool install reportgenerator exited $LASTEXITCODE" }
-          $toolsDir = Join-Path $env:USERPROFILE '.dotnet\tools'
-          Add-Content -Path $env:GITHUB_PATH -Value $toolsDir
-          $rg = Join-Path $toolsDir 'reportgenerator.exe'
-          if (-not (Test-Path $rg)) { throw "reportgenerator.exe missing at $rg" }
-          Write-Host "ReportGenerator installed: $rg"
 
       - name: Install Clang 18 and LLVM Tools
         if: inputs.compiler == 'clang-18' && inputs.os == 'linux' && inputs.container == ''
@@ -221,13 +199,12 @@ jobs:
       - name: Run Tests with Coverage (Linux/macOS)
         if: inputs.os != 'windows'
         run: |
-          # Generate HTML, LCOV, and llvm-cov JSON formats. The JSON
-          # export carries regions natively and is the preferred input
-          # to slang-coverage-html for the LLVM-coverage path.
-          export COVERAGE_HTML=1
+          # Generate LCOV and llvm-cov JSON formats only. The new
+          # in-tree renderer (tools/coverage-html/) renders HTML
+          # downstream from these in coverage-nightly.yml, so we no
+          # longer need run-coverage.sh to produce llvm-cov HTML here.
           export COVERAGE_LCOV=1
           export COVERAGE_JSON=1
-          export COVERAGE_HTML_DIR="$PWD/coverage-html"
           export COVERAGE_LCOV_FILE="$PWD/coverage.lcov"
           export COVERAGE_JSON_FILE="$PWD/coverage.json"
 
@@ -270,11 +247,11 @@ jobs:
         shell: pwsh
         env:
           COVERAGE_LCOV: "1"
-          COVERAGE_HTML: "1"
-          # Use repo-root paths so the artifact upload step (OS-agnostic) finds
-          # the expected layout.
+          # Use a repo-root path so the artifact upload step (OS-agnostic)
+          # finds the expected layout. HTML is no longer generated here;
+          # the new in-tree renderer (tools/coverage-html/) renders HTML
+          # downstream from the LCOV in coverage-nightly.yml.
           COVERAGE_LCOV_FILE: "coverage.lcov"
-          COVERAGE_HTML_DIR: "coverage-html"
           # Match regular CI's SPIRV validation settings.
           SLANG_RUN_SPIRV_VALIDATION: "1"
           SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN: "1"
@@ -540,103 +517,22 @@ jobs:
           Get-Content 'coverage-summary.json' | Write-Host
 
       - name: Upload Coverage Artifacts for Merging
-        if: ${{ !inputs.deploy-pages }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ inputs.os }}-${{ inputs.platform }}
-          # coverage-html-slangc/ and libslang.* are Linux/macOS-only; the
-          # Cobertura XML and slangc LCOV are Windows-only;
+          # libslang.* and the Cobertura XML are Linux/macOS-only;
           # coverage-report*.txt are Linux/macOS-only (llvm-cov report
-          # text, not produced from OpenCppCoverage).
-          # upload-artifact silently skips missing paths, so one path
-          # list works for all OSes.
+          # text, not produced from OpenCppCoverage). upload-artifact
+          # silently skips missing paths, so one path list works for
+          # all OSes.
           path: |
             coverage-summary.json
             coverage-report.txt
             coverage-report-slangc.txt
-            coverage-html/
-            coverage-html-slangc/
-            coverage-slangc.lcov
             build/${{ inputs.config }}/coverage-data/slang-test.profdata
             build/${{ inputs.config }}/lib/libslang.*
             build/coverage-data/full.cobertura.xml
           retention-days: 7
-
-      - name: Checkout Coverage Reports Repository
-        if: ${{ inputs.deploy-pages }}
-        uses: actions/checkout@v4
-        with:
-          repository: "shader-slang/slang-coverage-reports"
-          path: "coverage-repo"
-          token: ${{ secrets.SLANG_COVERAGE_REPORTS_PAT }}
-
-      - name: Deploy Coverage to Separate Repository
-        if: ${{ inputs.deploy-pages }}
-        run: |
-          # Get current date and short commit hash
-          REPORT_DATE=$(date -u +"%Y-%m-%d")
-          COMMIT_SHORT=$(git rev-parse --short HEAD)
-          FULL_COMMIT=$(git rev-parse HEAD)
-          REPORT_DIR="reports/history/${REPORT_DATE}-${COMMIT_SHORT}"
-
-          cd coverage-repo
-
-          # Configure git
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Create directory structure
-          mkdir -p "${REPORT_DIR}"
-          mkdir -p reports/latest
-
-          # Copy coverage HTML to historical location
-          cp -r ../coverage-html/* "${REPORT_DIR}/"
-
-          # Copy slangc compiler-only HTML report if it exists
-          if [[ -d ../coverage-html-slangc ]]; then
-            mkdir -p "${REPORT_DIR}/slangc"
-            cp -r ../coverage-html-slangc/* "${REPORT_DIR}/slangc/"
-          fi
-
-          # Copy coverage summary JSON if it exists
-          if [[ -f ../coverage-summary.json ]]; then
-            cp ../coverage-summary.json "${REPORT_DIR}/"
-          fi
-
-          # Update latest (replace entire directory)
-          rm -rf reports/latest/*
-          cp -r ../coverage-html/* reports/latest/
-
-          # Copy slangc report to latest
-          if [[ -d ../coverage-html-slangc ]]; then
-            mkdir -p reports/latest/slangc
-            cp -r ../coverage-html-slangc/* reports/latest/slangc/
-          fi
-
-          # Copy coverage summary to latest
-          if [[ -f ../coverage-summary.json ]]; then
-            cp ../coverage-summary.json reports/latest/
-          fi
-
-          # Generate historical index
-          bash ../tools/coverage/generate-history-index.sh reports/history
-
-          # Generate main landing page
-          bash ../tools/coverage/generate-landing-page.sh reports
-
-          # Commit and push if there are changes
-          git add reports/
-          if ! git diff --cached --quiet; then
-            TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
-            git commit -m "Add coverage report for ${REPORT_DATE} (${COMMIT_SHORT})" \
-                       -m "Generated from shader-slang/slang@${FULL_COMMIT}" \
-                       -m "Date: ${TIMESTAMP}"
-
-            git push origin main
-            echo "Coverage report deployed successfully"
-          else
-            echo "No changes to coverage report"
-          fi
 
       - name: Report Coverage in PR
         if: ${{ inputs.pr-comment }}

--- a/.github/workflows/ci-slang-coverage.yml
+++ b/.github/workflows/ci-slang-coverage.yml
@@ -310,6 +310,14 @@ jobs:
       - name: Generate Coverage Summary (Linux/macOS)
         id: coverage-summary
         if: inputs.os != 'windows'
+        env:
+          # Read inputs.os / inputs.platform from env so the unquoted
+          # heredoc below does not embed the workflow expressions
+          # verbatim. Today's callers pass fixed values, but reading from
+          # env keeps this reusable workflow safe if a future caller
+          # passes a value containing `$(...)`. Matches the Windows step.
+          INPUT_OS: ${{ inputs.os }}
+          INPUT_PLATFORM: ${{ inputs.platform }}
         run: |
           # Ensure git works in container (ownership check)
           git config --global --add safe.directory "$PWD"
@@ -420,8 +428,8 @@ jobs:
           {
             "date": "${REPORT_DATE}",
             "commit": "${COMMIT_SHORT}",
-            "platform": "${{ inputs.os }}",
-            "platform_detail": "${{ inputs.os }}-${{ inputs.platform }}",
+            "platform": "${INPUT_OS}",
+            "platform_detail": "${INPUT_OS}-${INPUT_PLATFORM}",
             "line_coverage": "${line_pct}",
             "lines_hit": ${lines_hit},
             "lines_found": ${lines_total},
@@ -468,7 +476,13 @@ jobs:
 
           [xml]$cob = Get-Content -LiteralPath $xmlPath
           $c = $cob.coverage
-          $line_pct = [math]::Round([double]$c.'line-rate' * 100, 2)
+          # Format percents as fixed-2 invariant-culture strings so the
+          # written JSON matches the Linux/macOS `75.71%` shape verbatim.
+          # PowerShell's default double-to-string would render 0.548 as
+          # `54.8` and 0.75 as `75`, breaking schema parity with the
+          # llvm-cov-formatted values on Linux/macOS.
+          $invariant = [System.Globalization.CultureInfo]::InvariantCulture
+          $line_pct = ([math]::Round([double]$c.'line-rate' * 100, 2)).ToString("F2", $invariant)
           $lines_hit = [int]$c.'lines-covered'
           $lines_total = [int]$c.'lines-valid'
 
@@ -481,7 +495,9 @@ jobs:
                   elseif ($line.StartsWith('LH:')) { $slangc_hit += [int]$line.Substring(3) }
               }
           }
-          $slangc_pct = if ($slangc_total -gt 0) { [math]::Round($slangc_hit / $slangc_total * 100, 2) } else { 0 }
+          $slangc_pct = if ($slangc_total -gt 0) {
+              ([math]::Round($slangc_hit / $slangc_total * 100, 2)).ToString("F2", $invariant)
+          } else { "0.00" }
 
           "coverage=$line_pct" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding ascii
 
@@ -529,11 +545,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ inputs.os }}-${{ inputs.platform }}
-          # libslang.* and the Cobertura XML are Linux/macOS-only;
-          # coverage-report*.txt are Linux/macOS-only (llvm-cov report
-          # text, not produced from OpenCppCoverage). upload-artifact
-          # silently skips missing paths, so one path list works for
-          # all OSes.
+          # libslang.* is Linux/macOS-only; full.cobertura.xml is
+          # Windows-only (OpenCppCoverage output -- llvm-cov does not
+          # emit Cobertura); coverage-report*.txt are Linux/macOS-only
+          # (llvm-cov report text, not produced from OpenCppCoverage).
+          # upload-artifact silently skips missing paths, so one path
+          # list works for all OSes.
           path: |
             coverage-summary.json
             coverage-report.txt

--- a/.github/workflows/ci-slang-coverage.yml
+++ b/.github/workflows/ci-slang-coverage.yml
@@ -447,6 +447,12 @@ jobs:
         id: coverage-summary-windows
         if: inputs.os == 'windows'
         shell: pwsh
+        env:
+          # Read inputs.platform from env so the pwsh script does not embed
+          # the workflow expression verbatim. Today's callers pass fixed
+          # values, but reading from env keeps this reusable workflow safe
+          # if a future caller passes a value containing `$(...)`.
+          INPUT_PLATFORM: ${{ inputs.platform }}
         run: |
           # OpenCppCoverage has already produced the Cobertura XML via
           # run-coverage-windows.ps1. Parse it for the JSON summary used by
@@ -506,7 +512,7 @@ jobs:
               date = $reportDate
               commit = $commitShort
               platform = 'windows'
-              platform_detail = "windows-${{ inputs.platform }}"
+              platform_detail = "windows-$env:INPUT_PLATFORM"
               line_coverage = "$line_pct%"
               lines_hit = $lines_hit
               lines_found = $lines_total

--- a/.github/workflows/ci-slang-coverage.yml
+++ b/.github/workflows/ci-slang-coverage.yml
@@ -495,8 +495,11 @@ jobs:
           ) -join "`n"
           $summary | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
-          # coverage-summary.json for historical tracking. Schema mirrors the
-          # Linux/macOS output but omits region/function/branch fields.
+          # coverage-summary.json for historical tracking. Schema mirrors
+          # the Linux/macOS output but omits region/function/branch
+          # fields. Percent strings keep the trailing `%` to match the
+          # Linux/macOS shape (which interpolates llvm-cov's own
+          # `75.71%`-style output verbatim).
           $commitShort = (git rev-parse --short HEAD).Trim()
           $reportDate = (Get-Date -AsUTC).ToString('yyyy-MM-dd')
           $json = [ordered]@{
@@ -504,10 +507,10 @@ jobs:
               commit = $commitShort
               platform = 'windows'
               platform_detail = "windows-${{ inputs.platform }}"
-              line_coverage = "$line_pct"
+              line_coverage = "$line_pct%"
               lines_hit = $lines_hit
               lines_found = $lines_total
-              slangc_line_coverage = "$slangc_pct"
+              slangc_line_coverage = "$slangc_pct%"
               slangc_lines_hit = $slangc_hit
               slangc_lines_found = $slangc_total
               _version = 2

--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -27,7 +27,6 @@ jobs:
       runs-on: '["ubuntu-22.04"]'
       container: ghcr.io/shader-slang/slang-linux-clang-ci:v1.0.1
       build-llvm: true
-      deploy-pages: false
       server-count: 1
     secrets: inherit
 
@@ -40,7 +39,6 @@ jobs:
       config: relwithdebinfo
       runs-on: '["macos-latest"]'
       build-llvm: true
-      deploy-pages: false
       server-count: 1
     secrets: inherit
 
@@ -53,7 +51,6 @@ jobs:
       config: relwithdebinfo
       runs-on: '["windows-latest"]'
       build-llvm: true
-      deploy-pages: false
       server-count: 1
     secrets: inherit
 
@@ -124,12 +121,11 @@ jobs:
           echo "Organized coverage data:"
           ls -R coverage-reports/
 
-      - name: Render with slang-coverage-html (new renderer)
-        # Produces a merged cross-OS report and per-OS reports rendered with
-        # the new in-tree renderer (tools/coverage-html/slang-coverage-html.py).
-        # Runs alongside the existing per-OS HTML reports so output can be
-        # compared. Persists the merged LCOV + auth-summary so a future diff
-        # job can compare two runs without re-merging from scratch.
+      - name: Render with slang-coverage-html
+        # Produces a merged cross-OS report and per-OS reports rendered
+        # with the in-tree renderer (tools/coverage-html/slang-coverage-html.py).
+        # Persists the merged LCOV + auth-summary so a future diff job
+        # can compare two runs without re-merging from scratch.
         run: |
           set -euo pipefail
 
@@ -175,7 +171,7 @@ jobs:
           [ -f "$ART/coverage-macos-aarch64/coverage-report-slangc.txt" ] && AUTH_SLANGC+=( --auth-summary "$ART/coverage-macos-aarch64/coverage-report-slangc.txt" )
 
           if [ ${#INPUTS[@]} -eq 0 ]; then
-            echo "::warning::No per-OS LCOV artifacts found; skipping new-renderer reports."
+            echo "::warning::No per-OS LCOV artifacts found; skipping rendered reports."
             exit 0
           fi
 
@@ -224,7 +220,7 @@ jobs:
             --title "Slang merged slangc coverage (Linux + macOS + Windows)" \
             --output-dir coverage-reports/merged/slangc/html
 
-          # ----- Per-OS reports (new renderer, side-by-side with existing) -----
+          # ----- Per-OS reports -----
           # Path-normalize each per-OS LCOV via the merger in single-input
           # mode so --source-root resolves source files cleanly.
           render_per_os() {
@@ -245,14 +241,14 @@ jobs:
             [ -f "$report" ] && auth=( --auth-summary "$report" )
             python3 "$RENDERER" "$dest/full/coverage.lcov" "${auth[@]}" \
               --source-root . \
-              --title "Slang $os coverage (new renderer)" \
+              --title "Slang $os coverage" \
               --output-dir "$dest/full/html"
 
             auth=()
             [ -f "$report_slangc" ] && auth=( --auth-summary "$report_slangc" )
             python3 "$SLANG_RENDER" "$dest/full/coverage.lcov" "${auth[@]}" \
               --source-root . \
-              --title "Slang $os slangc coverage (new renderer)" \
+              --title "Slang $os slangc coverage" \
               --output-dir "$dest/slangc/html"
           }
           shopt -s nullglob
@@ -292,9 +288,8 @@ jobs:
           cat coverage-reports/combined-summary.json
 
       - name: Upload Merged Coverage Reports
-        # Lets feature-branch dispatches inspect the merged + new-renderer
-        # output without writing to slang-coverage-reports. Always uploads
-        # so we can compare the new and existing renderers across runs.
+        # Lets feature-branch dispatches inspect the rendered output
+        # without writing to slang-coverage-reports. Always uploads.
         uses: actions/upload-artifact@v4
         with:
           name: coverage-reports-merged
@@ -327,49 +322,26 @@ jobs:
           mkdir -p "${REPORT_DIR}"/{linux,macos,windows}
           mkdir -p reports/latest/{linux,macos,windows}
 
-          # Copy Linux coverage
-          cp -r ../coverage-reports/linux/coverage-html/* "${REPORT_DIR}/linux/"
-          cp ../coverage-reports/linux/coverage-summary.json "${REPORT_DIR}/linux/"
-          if [ -d "../coverage-reports/linux/coverage-html-slangc" ]; then
-            mkdir -p "${REPORT_DIR}/linux/slangc"
-            cp -r ../coverage-reports/linux/coverage-html-slangc/* "${REPORT_DIR}/linux/slangc/"
-          fi
-
-          # Copy macOS coverage
-          cp -r ../coverage-reports/macos/coverage-html/* "${REPORT_DIR}/macos/"
-          cp ../coverage-reports/macos/coverage-summary.json "${REPORT_DIR}/macos/"
-          if [ -d "../coverage-reports/macos/coverage-html-slangc" ]; then
-            mkdir -p "${REPORT_DIR}/macos/slangc"
-            cp -r ../coverage-reports/macos/coverage-html-slangc/* "${REPORT_DIR}/macos/slangc/"
-          fi
-
-          # Copy Windows coverage. No coverage-html-slangc/ on Windows -- the
-          # full HTML report is the only browseable view; slangc totals come
-          # from coverage-slangc.lcov which we stash next to the summary.
-          if [ -d "../coverage-reports/windows/coverage-html" ]; then
-            cp -r ../coverage-reports/windows/coverage-html/* "${REPORT_DIR}/windows/"
-            cp ../coverage-reports/windows/coverage-summary.json "${REPORT_DIR}/windows/"
-            if [ -f "../coverage-reports/windows/coverage-slangc.lcov" ]; then
-              cp ../coverage-reports/windows/coverage-slangc.lcov "${REPORT_DIR}/windows/"
+          # Per-OS reports come from the in-tree renderer
+          # (tools/coverage-html/). The full/ render is the primary
+          # per-OS landing page; slangc/ is the compiler-only filtered
+          # view. Same shape for all three platforms.
+          for os in linux macos windows; do
+            src_root="../coverage-reports/$os"
+            if [ -d "$src_root/new-html/full/html" ]; then
+              cp -r "$src_root/new-html/full/html"/* "${REPORT_DIR}/$os/"
             fi
-          fi
+            if [ -d "$src_root/new-html/slangc/html" ]; then
+              mkdir -p "${REPORT_DIR}/$os/slangc"
+              cp -r "$src_root/new-html/slangc/html"/* "${REPORT_DIR}/$os/slangc/"
+            fi
+            if [ -f "$src_root/coverage-summary.json" ]; then
+              cp "$src_root/coverage-summary.json" "${REPORT_DIR}/$os/"
+            fi
+          done
 
           # Copy combined summary
           cp ../coverage-reports/combined-summary.json "${REPORT_DIR}/"
-
-          # Copy new-renderer reports (rendered alongside the existing
-          # llvm-cov / ReportGenerator HTML so the two outputs can be
-          # compared visually). Best-effort: skip silently when missing.
-          for os in linux macos windows; do
-            for view in full slangc; do
-              src="../coverage-reports/$os/new-html/$view/html"
-              dest="${REPORT_DIR}/$os/new/$view"
-              if [ -d "$src" ]; then
-                mkdir -p "$dest"
-                cp -r "$src"/* "$dest/"
-              fi
-            done
-          done
 
           # Merged cross-OS report (single canonical view that rolls up all
           # three platforms). The merged LCOV + auth-summary are persisted
@@ -388,41 +360,24 @@ jobs:
             cp ../coverage-reports/merged/slangc/coverage-report.txt "${REPORT_DIR}/merged/slangc/" 2>/dev/null || true
           fi
 
-          # Update latest
+          # Update latest. Same per-OS structure as the history archive
+          # above, sourcing from the in-tree renderer.
           rm -rf reports/latest/{linux,macos,windows}/*
           rm -rf reports/latest/merged
-          cp -r ../coverage-reports/linux/coverage-html/* reports/latest/linux/
-          cp ../coverage-reports/linux/coverage-summary.json reports/latest/linux/
-          if [ -d "../coverage-reports/linux/coverage-html-slangc" ]; then
-            mkdir -p reports/latest/linux/slangc
-            cp -r ../coverage-reports/linux/coverage-html-slangc/* reports/latest/linux/slangc/
-          fi
-          cp -r ../coverage-reports/macos/coverage-html/* reports/latest/macos/
-          cp ../coverage-reports/macos/coverage-summary.json reports/latest/macos/
-          if [ -d "../coverage-reports/macos/coverage-html-slangc" ]; then
-            mkdir -p reports/latest/macos/slangc
-            cp -r ../coverage-reports/macos/coverage-html-slangc/* reports/latest/macos/slangc/
-          fi
-          if [ -d "../coverage-reports/windows/coverage-html" ]; then
-            cp -r ../coverage-reports/windows/coverage-html/* reports/latest/windows/
-            cp ../coverage-reports/windows/coverage-summary.json reports/latest/windows/
-            if [ -f "../coverage-reports/windows/coverage-slangc.lcov" ]; then
-              cp ../coverage-reports/windows/coverage-slangc.lcov reports/latest/windows/
-            fi
-          fi
-          cp ../coverage-reports/combined-summary.json reports/latest/
-
-          # Mirror the new-renderer reports into reports/latest/.
           for os in linux macos windows; do
-            for view in full slangc; do
-              src="../coverage-reports/$os/new-html/$view/html"
-              dest="reports/latest/$os/new/$view"
-              if [ -d "$src" ]; then
-                mkdir -p "$dest"
-                cp -r "$src"/* "$dest/"
-              fi
-            done
+            src_root="../coverage-reports/$os"
+            if [ -d "$src_root/new-html/full/html" ]; then
+              cp -r "$src_root/new-html/full/html"/* "reports/latest/$os/"
+            fi
+            if [ -d "$src_root/new-html/slangc/html" ]; then
+              mkdir -p "reports/latest/$os/slangc"
+              cp -r "$src_root/new-html/slangc/html"/* "reports/latest/$os/slangc/"
+            fi
+            if [ -f "$src_root/coverage-summary.json" ]; then
+              cp "$src_root/coverage-summary.json" "reports/latest/$os/"
+            fi
           done
+          cp ../coverage-reports/combined-summary.json reports/latest/
           if [ -d ../coverage-reports/merged/full/html ]; then
             mkdir -p reports/latest/merged/full
             cp -r ../coverage-reports/merged/full/html/* reports/latest/merged/full/

--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -377,6 +377,14 @@ jobs:
             cp ../coverage-reports/merged/slangc/coverage.lcov "${REPORT_DIR}/merged/slangc/" || true
             cp ../coverage-reports/merged/slangc/coverage-report.txt "${REPORT_DIR}/merged/slangc/" 2>/dev/null || true
           fi
+          # Publish the merged coverage-summary.json alongside the HTML.
+          # generate-landing-page.sh reads reports/latest/merged/coverage-summary.json
+          # to populate the cross-OS Merged row and headline badge -- if
+          # this copy is missing the row never renders.
+          if [ -f ../coverage-reports/merged/coverage-summary.json ]; then
+            mkdir -p "${REPORT_DIR}/merged"
+            cp ../coverage-reports/merged/coverage-summary.json "${REPORT_DIR}/merged/"
+          fi
 
           # Update latest. Same per-OS structure as the history archive
           # above, sourcing from the in-tree renderer.
@@ -407,6 +415,10 @@ jobs:
             cp -r ../coverage-reports/merged/slangc/html/* reports/latest/merged/slangc/
             cp ../coverage-reports/merged/slangc/coverage.lcov reports/latest/merged/slangc/ || true
             cp ../coverage-reports/merged/slangc/coverage-report.txt reports/latest/merged/slangc/ 2>/dev/null || true
+          fi
+          if [ -f ../coverage-reports/merged/coverage-summary.json ]; then
+            mkdir -p reports/latest/merged
+            cp ../coverage-reports/merged/coverage-summary.json reports/latest/merged/
           fi
 
           # Cleanup old reports (keep last 7 days + monthly snapshots)

--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -381,7 +381,13 @@ jobs:
           # generate-landing-page.sh reads reports/latest/merged/coverage-summary.json
           # to populate the cross-OS Merged row and headline badge -- if
           # this copy is missing the row never renders.
-          if [ -f ../coverage-reports/merged/coverage-summary.json ]; then
+          #
+          # Only publish when the Windows summary is also present:
+          # otherwise a Windows-failure night would still ship a "Merged"
+          # row claiming cross-OS coverage that is actually
+          # Linux+macOS-only -- silently downgrading the public dashboard.
+          if [ -f ../coverage-reports/merged/coverage-summary.json ] && \
+             [ -f ../coverage-reports/windows/coverage-summary.json ]; then
             mkdir -p "${REPORT_DIR}/merged"
             cp ../coverage-reports/merged/coverage-summary.json "${REPORT_DIR}/merged/"
           fi
@@ -416,7 +422,9 @@ jobs:
             cp ../coverage-reports/merged/slangc/coverage.lcov reports/latest/merged/slangc/ || true
             cp ../coverage-reports/merged/slangc/coverage-report.txt reports/latest/merged/slangc/ 2>/dev/null || true
           fi
-          if [ -f ../coverage-reports/merged/coverage-summary.json ]; then
+          # Same Windows-presence guard as above (history archive).
+          if [ -f ../coverage-reports/merged/coverage-summary.json ] && \
+             [ -f ../coverage-reports/windows/coverage-summary.json ]; then
             mkdir -p reports/latest/merged
             cp ../coverage-reports/merged/coverage-summary.json reports/latest/merged/
           fi

--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -179,6 +179,14 @@ jobs:
             exit 0
           fi
 
+          # Restrict reports to files under source/. Top-level, build/,
+          # external/, include/ and tools/ files are not what readers of
+          # the Slang coverage report are looking for; the slangc-only
+          # path already filters them via slang_filters.py, and we apply
+          # the same restriction to the full-library view here for
+          # consistency.
+          INCLUDE_SOURCE=( --filter-include-regex '^source/' )
+
           # ----- Merged full-library report -----
           mkdir -p coverage-reports/merged/full
           MERGED_FULL_LCOV=coverage-reports/merged/full/coverage.lcov
@@ -186,7 +194,7 @@ jobs:
           AUTH_OUT_FULL=()
           [ ${#AUTH_FULL[@]} -gt 0 ] && AUTH_OUT_FULL=( --auth-summary-out "$MERGED_FULL_REPORT" )
 
-          python3 "$MERGER" "${INPUTS[@]}" "${STRIP[@]}" \
+          python3 "$MERGER" "${INPUTS[@]}" "${STRIP[@]}" "${INCLUDE_SOURCE[@]}" \
             "${AUTH_FULL[@]}" "${AUTH_OUT_FULL[@]}" \
             -o "$MERGED_FULL_LCOV"
 
@@ -205,7 +213,7 @@ jobs:
           AUTH_OUT_SLANGC=()
           [ ${#AUTH_SLANGC[@]} -gt 0 ] && AUTH_OUT_SLANGC=( --auth-summary-out "$MERGED_SLANGC_REPORT" )
 
-          python3 "$SLANG_MERGE" "${INPUTS[@]}" \
+          python3 "$SLANG_MERGE" "${INPUTS[@]}" "${INCLUDE_SOURCE[@]}" \
             "${AUTH_SLANGC[@]}" "${AUTH_OUT_SLANGC[@]}" \
             -o "$MERGED_SLANGC_LCOV"
 
@@ -230,7 +238,8 @@ jobs:
 
             mkdir -p "$dest/full" "$dest/slangc"
 
-            python3 "$MERGER" "$gz" "${STRIP[@]}" -o "$dest/full/coverage.lcov"
+            python3 "$MERGER" "$gz" "${STRIP[@]}" "${INCLUDE_SOURCE[@]}" \
+              -o "$dest/full/coverage.lcov"
 
             local auth=()
             [ -f "$report" ] && auth=( --auth-summary "$report" )

--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -84,39 +84,24 @@ jobs:
 
       - name: Organize Coverage Data
         run: |
-          # Create organized structure
+          # Stage the per-OS summary JSON next to where the renderer step
+          # below expects it. The renderer reads its primary inputs (LCOV
+          # + auth-summary text) directly from the coverage-artifacts/
+          # layout downloaded above; here we only need to mirror the
+          # per-OS coverage-summary.json into coverage-reports/<os>/ for
+          # the landing-page generator.
           mkdir -p coverage-reports/{linux,macos,windows}
-
-          # Extract Linux coverage
-          if [ -d "coverage-artifacts/coverage-linux-x86_64" ]; then
-            cp coverage-artifacts/coverage-linux-x86_64/coverage-summary.json coverage-reports/linux/
-            cp -r coverage-artifacts/coverage-linux-x86_64/coverage-html coverage-reports/linux/
-            if [ -d "coverage-artifacts/coverage-linux-x86_64/coverage-html-slangc" ]; then
-              cp -r coverage-artifacts/coverage-linux-x86_64/coverage-html-slangc coverage-reports/linux/
+          for os_artifact in coverage-linux-x86_64 coverage-macos-aarch64 coverage-windows-x86_64; do
+            case "$os_artifact" in
+              coverage-linux-*)   os=linux   ;;
+              coverage-macos-*)   os=macos   ;;
+              coverage-windows-*) os=windows ;;
+            esac
+            src=coverage-artifacts/$os_artifact/coverage-summary.json
+            if [ -f "$src" ]; then
+              cp "$src" coverage-reports/$os/
             fi
-          fi
-
-          # Extract macOS coverage
-          if [ -d "coverage-artifacts/coverage-macos-aarch64" ]; then
-            cp coverage-artifacts/coverage-macos-aarch64/coverage-summary.json coverage-reports/macos/
-            cp -r coverage-artifacts/coverage-macos-aarch64/coverage-html coverage-reports/macos/
-            if [ -d "coverage-artifacts/coverage-macos-aarch64/coverage-html-slangc" ]; then
-              cp -r coverage-artifacts/coverage-macos-aarch64/coverage-html-slangc coverage-reports/macos/
-            fi
-          fi
-
-          # Extract Windows coverage. OpenCppCoverage does not produce a
-          # slangc-only HTML report on Windows (would require a second test
-          # pass with --excluded_sources baked in, doubling test-run time);
-          # the slangc LCOV is still captured and its totals flow through
-          # the JSON summary.
-          if [ -d "coverage-artifacts/coverage-windows-x86_64" ]; then
-            cp coverage-artifacts/coverage-windows-x86_64/coverage-summary.json coverage-reports/windows/
-            cp -r coverage-artifacts/coverage-windows-x86_64/coverage-html coverage-reports/windows/
-            if [ -f "coverage-artifacts/coverage-windows-x86_64/coverage-slangc.lcov" ]; then
-              cp coverage-artifacts/coverage-windows-x86_64/coverage-slangc.lcov coverage-reports/windows/
-            fi
-          fi
+          done
 
           echo "Organized coverage data:"
           ls -R coverage-reports/
@@ -285,6 +270,12 @@ jobs:
                       #          <branches> <missed_b> <b_cov>
                       p = line.split()
                       if len(p) < 13:
+                          print(
+                              f"merged-summary: malformed TOTAL line in {path} "
+                              f"({len(p)} fields, expected >=13). Merged row "
+                              f"will be omitted from the landing page.",
+                              file=sys.stderr,
+                          )
                           return None
                       def n(s):
                           try: return int(s)
@@ -309,6 +300,11 @@ jobs:
                           "branches_hit": b_tot - b_miss,
                           "branches_found": b_tot,
                       }
+              print(
+                  f"merged-summary: no TOTAL line in {path}. Merged row "
+                  f"will be omitted from the landing page.",
+                  file=sys.stderr,
+              )
               return None
 
           out = {
@@ -331,6 +327,23 @@ jobs:
 
           echo "Renderer outputs:"
           find coverage-reports -maxdepth 6 -name index.html -printf '  %p\n' | sort
+
+          # Fail loudly if no per-OS full HTML survived the render. The
+          # deploy step below copies $os/new-html/full/html/* into
+          # reports/latest/$os/; if those dirs are all empty we would
+          # otherwise silently commit blank per-OS landing pages.
+          rendered_any=false
+          for os in linux macos windows; do
+            if [ -f "coverage-reports/$os/new-html/full/html/index.html" ]; then
+              rendered_any=true
+              break
+            fi
+          done
+          if [ "$rendered_any" != "true" ]; then
+            echo "::error::No per-OS full HTML was produced by the renderer." >&2
+            echo "::error::Refusing to continue -- the deploy step would otherwise replace reports/latest/<os>/ with empty directories." >&2
+            exit 1
+          fi
 
       - name: Combine Platform Summaries
         run: |

--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -257,7 +257,79 @@ jobs:
           render_per_os windows windows-x86_64
           shopt -u nullglob
 
-          echo "New-renderer outputs:"
+          # Synthesize a single merged coverage-summary.json that the
+          # landing-page generator can read alongside the per-OS ones.
+          # Data comes from the auth-summary text files just written by
+          # the merger; both full and slangc are folded into one JSON
+          # to mirror the per-OS schema.
+          REPORT_DATE=$(date -u +"%Y-%m-%d")
+          COMMIT_SHORT=$(git rev-parse --short HEAD)
+          MERGED_FULL_TXT=coverage-reports/merged/full/coverage-report.txt
+          MERGED_SLANGC_TXT=coverage-reports/merged/slangc/coverage-report.txt
+          if [ -f "$MERGED_FULL_TXT" ]; then
+            python3 - "$MERGED_FULL_TXT" "$MERGED_SLANGC_TXT" "$REPORT_DATE" "$COMMIT_SHORT" <<'PY' > coverage-reports/merged/coverage-summary.json
+          import json, os, sys
+
+          full_txt, slangc_txt, date, commit = sys.argv[1:5]
+
+          def parse_total(path):
+              if not path or not os.path.isfile(path):
+                  return None
+              with open(path) as f:
+                  for line in f:
+                      if not line.startswith("TOTAL"):
+                          continue
+                      # Columns: TOTAL <regions> <missed_r> <r_cov>
+                      #          <functions> <missed_f> <f_cov>
+                      #          <lines> <missed_l> <l_cov>
+                      #          <branches> <missed_b> <b_cov>
+                      p = line.split()
+                      if len(p) < 13:
+                          return None
+                      def n(s):
+                          try: return int(s)
+                          except ValueError: return 0
+                      def pct(s):
+                          return s.rstrip("%") if s.endswith("%") else ""
+                      r_tot, r_miss = n(p[1]), n(p[2])
+                      f_tot, f_miss = n(p[4]), n(p[5])
+                      l_tot, l_miss = n(p[7]), n(p[8])
+                      b_tot, b_miss = n(p[10]), n(p[11])
+                      return {
+                          "region_coverage": pct(p[3]),
+                          "regions_hit": r_tot - r_miss,
+                          "regions_found": r_tot,
+                          "function_coverage": pct(p[6]),
+                          "functions_hit": f_tot - f_miss,
+                          "functions_found": f_tot,
+                          "line_coverage": pct(p[9]),
+                          "lines_hit": l_tot - l_miss,
+                          "lines_found": l_tot,
+                          "branch_coverage": pct(p[12]),
+                          "branches_hit": b_tot - b_miss,
+                          "branches_found": b_tot,
+                      }
+              return None
+
+          out = {
+              "date": date,
+              "commit": commit,
+              "platform": "merged",
+              "platform_detail": "linux+macos+windows",
+          }
+          full = parse_total(full_txt)
+          if full:
+              out.update(full)
+          slangc = parse_total(slangc_txt)
+          if slangc:
+              out.update({"slangc_" + k: v for k, v in slangc.items()})
+          out["_version"] = 2
+          json.dump(out, sys.stdout, indent=2)
+          PY
+            echo "Wrote coverage-reports/merged/coverage-summary.json"
+          fi
+
+          echo "Renderer outputs:"
           find coverage-reports -maxdepth 6 -name index.html -printf '  %p\n' | sort
 
       - name: Combine Platform Summaries

--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -242,86 +242,19 @@ jobs:
           render_per_os windows windows-x86_64
           shopt -u nullglob
 
-          # Synthesize a single merged coverage-summary.json that the
-          # landing-page generator can read alongside the per-OS ones.
-          # Data comes from the auth-summary text files just written by
-          # the merger; both full and slangc are folded into one JSON
-          # to mirror the per-OS schema.
+          # Synthesize the merged coverage-summary.json so the
+          # landing-page generator can read it alongside the per-OS
+          # ones. Parser + schema live in tools/coverage/merge_summary.py
+          # (tested in tools/coverage/tests/test_merge_summary.py).
           REPORT_DATE=$(date -u +"%Y-%m-%d")
           COMMIT_SHORT=$(git rev-parse --short HEAD)
           MERGED_FULL_TXT=coverage-reports/merged/full/coverage-report.txt
           MERGED_SLANGC_TXT=coverage-reports/merged/slangc/coverage-report.txt
           if [ -f "$MERGED_FULL_TXT" ]; then
-            python3 - "$MERGED_FULL_TXT" "$MERGED_SLANGC_TXT" "$REPORT_DATE" "$COMMIT_SHORT" <<'PY' > coverage-reports/merged/coverage-summary.json
-          import json, os, sys
-
-          full_txt, slangc_txt, date, commit = sys.argv[1:5]
-
-          def parse_total(path):
-              if not path or not os.path.isfile(path):
-                  return None
-              with open(path) as f:
-                  for line in f:
-                      if not line.startswith("TOTAL"):
-                          continue
-                      # Columns: TOTAL <regions> <missed_r> <r_cov>
-                      #          <functions> <missed_f> <f_cov>
-                      #          <lines> <missed_l> <l_cov>
-                      #          <branches> <missed_b> <b_cov>
-                      p = line.split()
-                      if len(p) < 13:
-                          print(
-                              f"merged-summary: malformed TOTAL line in {path} "
-                              f"({len(p)} fields, expected >=13). Merged row "
-                              f"will be omitted from the landing page.",
-                              file=sys.stderr,
-                          )
-                          return None
-                      def n(s):
-                          try: return int(s)
-                          except ValueError: return 0
-                      def pct(s):
-                          return s.rstrip("%") if s.endswith("%") else ""
-                      r_tot, r_miss = n(p[1]), n(p[2])
-                      f_tot, f_miss = n(p[4]), n(p[5])
-                      l_tot, l_miss = n(p[7]), n(p[8])
-                      b_tot, b_miss = n(p[10]), n(p[11])
-                      return {
-                          "region_coverage": pct(p[3]),
-                          "regions_hit": r_tot - r_miss,
-                          "regions_found": r_tot,
-                          "function_coverage": pct(p[6]),
-                          "functions_hit": f_tot - f_miss,
-                          "functions_found": f_tot,
-                          "line_coverage": pct(p[9]),
-                          "lines_hit": l_tot - l_miss,
-                          "lines_found": l_tot,
-                          "branch_coverage": pct(p[12]),
-                          "branches_hit": b_tot - b_miss,
-                          "branches_found": b_tot,
-                      }
-              print(
-                  f"merged-summary: no TOTAL line in {path}. Merged row "
-                  f"will be omitted from the landing page.",
-                  file=sys.stderr,
-              )
-              return None
-
-          out = {
-              "date": date,
-              "commit": commit,
-              "platform": "merged",
-              "platform_detail": "linux+macos+windows",
-          }
-          full = parse_total(full_txt)
-          if full:
-              out.update(full)
-          slangc = parse_total(slangc_txt)
-          if slangc:
-              out.update({"slangc_" + k: v for k, v in slangc.items()})
-          out["_version"] = 2
-          json.dump(out, sys.stdout, indent=2)
-          PY
+            python3 tools/coverage/merge_summary.py \
+              "$MERGED_FULL_TXT" "$MERGED_SLANGC_TXT" \
+              "$REPORT_DATE" "$COMMIT_SHORT" \
+              > coverage-reports/merged/coverage-summary.json
             echo "Wrote coverage-reports/merged/coverage-summary.json"
           fi
 

--- a/tools/coverage/generate-landing-page.sh
+++ b/tools/coverage/generate-landing-page.sh
@@ -84,9 +84,13 @@ if [[ -f "$COMBINED_SUMMARY" ]]; then
   # Check which platforms are available
   LINUX_SUMMARY="${REPORTS_DIR}/latest/linux/coverage-summary.json"
   MACOS_SUMMARY="${REPORTS_DIR}/latest/macos/coverage-summary.json"
+  WINDOWS_SUMMARY="${REPORTS_DIR}/latest/windows/coverage-summary.json"
+  MERGED_SUMMARY="${REPORTS_DIR}/latest/merged/coverage-summary.json"
 
   HAS_LINUX=false
   HAS_MACOS=false
+  HAS_WINDOWS=false
+  HAS_MERGED=false
 
   if [[ -f "$LINUX_SUMMARY" ]]; then
     HAS_LINUX=true
@@ -148,8 +152,58 @@ if [[ -f "$COMBINED_SUMMARY" ]]; then
     MACOS_SLANGC_BRANCHES_FOUND=$(get_json_number "slangc_branches_found" "$MACOS_SUMMARY")
   fi
 
-  # Use Linux coverage for the main badge (most comprehensive usually)
-  if [[ "$HAS_LINUX" == "true" ]]; then
+  # Windows summary schema is leaner (OpenCppCoverage produces line metrics
+  # only; no region / function / branch). slangc_* is similarly line-only.
+  if [[ -f "$WINDOWS_SUMMARY" ]]; then
+    HAS_WINDOWS=true
+    WINDOWS_LINE_COV=$(get_json_value "line_coverage" "$WINDOWS_SUMMARY")
+    WINDOWS_LINES_HIT=$(get_json_number "lines_hit" "$WINDOWS_SUMMARY")
+    WINDOWS_LINES_FOUND=$(get_json_number "lines_found" "$WINDOWS_SUMMARY")
+
+    WINDOWS_SLANGC_LINE_COV=$(get_json_value "slangc_line_coverage" "$WINDOWS_SUMMARY")
+    WINDOWS_SLANGC_LINES_HIT=$(get_json_number "slangc_lines_hit" "$WINDOWS_SUMMARY")
+    WINDOWS_SLANGC_LINES_FOUND=$(get_json_number "slangc_lines_found" "$WINDOWS_SUMMARY")
+  fi
+
+  # Merged summary is synthesized by coverage-nightly.yml from the cross-OS
+  # auth-summary text files. Same field shape as the per-OS Linux/macOS
+  # summaries, except regions are empty (the merger doesn't compute regions
+  # across platforms).
+  if [[ -f "$MERGED_SUMMARY" ]]; then
+    HAS_MERGED=true
+    MERGED_LINE_COV=$(get_json_value "line_coverage" "$MERGED_SUMMARY")
+    MERGED_LINES_HIT=$(get_json_number "lines_hit" "$MERGED_SUMMARY")
+    MERGED_LINES_FOUND=$(get_json_number "lines_found" "$MERGED_SUMMARY")
+    MERGED_REGION_COV=$(get_json_value "region_coverage" "$MERGED_SUMMARY")
+    MERGED_REGIONS_HIT=$(get_json_number "regions_hit" "$MERGED_SUMMARY")
+    MERGED_REGIONS_FOUND=$(get_json_number "regions_found" "$MERGED_SUMMARY")
+    MERGED_FUNCTION_COV=$(get_json_value "function_coverage" "$MERGED_SUMMARY")
+    MERGED_FUNCTIONS_HIT=$(get_json_number "functions_hit" "$MERGED_SUMMARY")
+    MERGED_FUNCTIONS_FOUND=$(get_json_number "functions_found" "$MERGED_SUMMARY")
+    MERGED_BRANCH_COV=$(get_json_value "branch_coverage" "$MERGED_SUMMARY")
+    MERGED_BRANCHES_HIT=$(get_json_number "branches_hit" "$MERGED_SUMMARY")
+    MERGED_BRANCHES_FOUND=$(get_json_number "branches_found" "$MERGED_SUMMARY")
+
+    MERGED_SLANGC_LINE_COV=$(get_json_value "slangc_line_coverage" "$MERGED_SUMMARY")
+    MERGED_SLANGC_LINES_HIT=$(get_json_number "slangc_lines_hit" "$MERGED_SUMMARY")
+    MERGED_SLANGC_LINES_FOUND=$(get_json_number "slangc_lines_found" "$MERGED_SUMMARY")
+    MERGED_SLANGC_REGION_COV=$(get_json_value "slangc_region_coverage" "$MERGED_SUMMARY")
+    MERGED_SLANGC_REGIONS_HIT=$(get_json_number "slangc_regions_hit" "$MERGED_SUMMARY")
+    MERGED_SLANGC_REGIONS_FOUND=$(get_json_number "slangc_regions_found" "$MERGED_SUMMARY")
+    MERGED_SLANGC_FUNCTION_COV=$(get_json_value "slangc_function_coverage" "$MERGED_SUMMARY")
+    MERGED_SLANGC_FUNCTIONS_HIT=$(get_json_number "slangc_functions_hit" "$MERGED_SUMMARY")
+    MERGED_SLANGC_FUNCTIONS_FOUND=$(get_json_number "slangc_functions_found" "$MERGED_SUMMARY")
+    MERGED_SLANGC_BRANCH_COV=$(get_json_value "slangc_branch_coverage" "$MERGED_SUMMARY")
+    MERGED_SLANGC_BRANCHES_HIT=$(get_json_number "slangc_branches_hit" "$MERGED_SUMMARY")
+    MERGED_SLANGC_BRANCHES_FOUND=$(get_json_number "slangc_branches_found" "$MERGED_SUMMARY")
+  fi
+
+  # Headline badge uses the merged cross-OS number when available
+  # (most comprehensive view), falling back to per-OS otherwise.
+  if [[ "$HAS_MERGED" == "true" ]]; then
+    LINE_COV="$MERGED_LINE_COV"
+    LINE_COLOR=$(get_badge_color "$LINE_COV")
+  elif [[ "$HAS_LINUX" == "true" ]]; then
     LINE_COV="$LINUX_LINE_COV"
     LINE_COLOR=$(get_badge_color "$LINE_COV")
   elif [[ "$HAS_MACOS" == "true" ]]; then
@@ -437,6 +491,26 @@ if [[ "$HAS_DATA" == "true" ]]; then
                 <tbody>
 EOF
 
+    if [[ "$HAS_MERGED" == "true" ]]; then
+      merged_line_class=$(get_badge_color "$MERGED_LINE_COV" | sed 's/#27ae60/cov-good/; s/#f39c12/cov-medium/; s/#e74c3c/cov-low/')
+      merged_function_class=$(get_badge_color "$MERGED_FUNCTION_COV" | sed 's/#27ae60/cov-good/; s/#f39c12/cov-medium/; s/#e74c3c/cov-low/')
+      merged_branch_class=$(get_badge_color "$MERGED_BRANCH_COV" | sed 's/#27ae60/cov-good/; s/#f39c12/cov-medium/; s/#e74c3c/cov-low/')
+
+      # Regions column is intentionally n/a: the cross-OS merger
+      # doesn't produce a region count (each OS reports regions
+      # differently and they can't be combined sensibly).
+      cat >>"${OUTPUT_FILE}" <<EOF
+                    <tr style="border-bottom: 1px solid #ddd; background: #f8f9fa;">
+                        <td style="padding: 15px;"><strong>🧩 Merged (cross-OS)</strong></td>
+                        <td style="padding: 15px; text-align: center;"><span class="${merged_line_class}">${MERGED_LINE_COV}%</span><br><small>${MERGED_LINES_HIT}/${MERGED_LINES_FOUND}</small></td>
+                        <td style="padding: 15px; text-align: center; color: #95a5a6;">n/a</td>
+                        <td style="padding: 15px; text-align: center;"><span class="${merged_function_class}">${MERGED_FUNCTION_COV}%</span><br><small>${MERGED_FUNCTIONS_HIT}/${MERGED_FUNCTIONS_FOUND}</small></td>
+                        <td style="padding: 15px; text-align: center;"><span class="${merged_branch_class}">${MERGED_BRANCH_COV}%</span><br><small>${MERGED_BRANCHES_HIT}/${MERGED_BRANCHES_FOUND}</small></td>
+                        <td style="padding: 15px; text-align: center;"><a href="${LINK_PREFIX}latest/merged/full/index.html" style="color: #667eea;">View</a></td>
+                    </tr>
+EOF
+    fi
+
     if [[ "$HAS_LINUX" == "true" ]]; then
       # Get color classes for each metric
       linux_line_class=$(get_badge_color "$LINUX_LINE_COV" | sed 's/#27ae60/cov-good/; s/#f39c12/cov-medium/; s/#e74c3c/cov-low/')
@@ -487,6 +561,23 @@ EOF
 EOF
     fi
 
+    if [[ "$HAS_WINDOWS" == "true" ]]; then
+      # OpenCppCoverage only produces line metrics on Windows, so
+      # region / function / branch columns are n/a here.
+      windows_line_class=$(get_badge_color "$WINDOWS_LINE_COV" | sed 's/#27ae60/cov-good/; s/#f39c12/cov-medium/; s/#e74c3c/cov-low/')
+
+      cat >>"${OUTPUT_FILE}" <<EOF
+                    <tr style="border-bottom: 1px solid #ddd;">
+                        <td style="padding: 15px;"><strong>🪟 Windows (x86_64)</strong></td>
+                        <td style="padding: 15px; text-align: center;"><span class="${windows_line_class}">${WINDOWS_LINE_COV}%</span><br><small>${WINDOWS_LINES_HIT}/${WINDOWS_LINES_FOUND}</small></td>
+                        <td style="padding: 15px; text-align: center; color: #95a5a6;">n/a</td>
+                        <td style="padding: 15px; text-align: center; color: #95a5a6;">n/a</td>
+                        <td style="padding: 15px; text-align: center; color: #95a5a6;">n/a</td>
+                        <td style="padding: 15px; text-align: center;"><a href="${LINK_PREFIX}latest/windows/index.html" style="color: #667eea;">View</a></td>
+                    </tr>
+EOF
+    fi
+
     cat >>"${OUTPUT_FILE}" <<EOF
                 </tbody>
             </table>
@@ -498,6 +589,12 @@ EOF
       HAS_SLANGC=true
     fi
     if [[ "$HAS_MACOS" == "true" && -n "$MACOS_SLANGC_LINE_COV" ]]; then
+      HAS_SLANGC=true
+    fi
+    if [[ "$HAS_WINDOWS" == "true" && -n "$WINDOWS_SLANGC_LINE_COV" ]]; then
+      HAS_SLANGC=true
+    fi
+    if [[ "$HAS_MERGED" == "true" && -n "$MERGED_SLANGC_LINE_COV" ]]; then
       HAS_SLANGC=true
     fi
 
@@ -522,6 +619,23 @@ EOF
                 </thead>
                 <tbody>
 EOF
+
+      if [[ "$HAS_MERGED" == "true" && -n "$MERGED_SLANGC_LINE_COV" ]]; then
+        merged_sl_line_class=$(get_badge_color "$MERGED_SLANGC_LINE_COV" | sed 's/#27ae60/cov-good/; s/#f39c12/cov-medium/; s/#e74c3c/cov-low/')
+        merged_sl_function_class=$(get_badge_color "$MERGED_SLANGC_FUNCTION_COV" | sed 's/#27ae60/cov-good/; s/#f39c12/cov-medium/; s/#e74c3c/cov-low/')
+        merged_sl_branch_class=$(get_badge_color "$MERGED_SLANGC_BRANCH_COV" | sed 's/#27ae60/cov-good/; s/#f39c12/cov-medium/; s/#e74c3c/cov-low/')
+
+        cat >>"${OUTPUT_FILE}" <<EOF
+                    <tr style="border-bottom: 1px solid #ddd; background: #f8f9fa;">
+                        <td style="padding: 15px;"><strong>🧩 Merged (cross-OS)</strong></td>
+                        <td style="padding: 15px; text-align: center;"><span class="${merged_sl_line_class}">${MERGED_SLANGC_LINE_COV}%</span><br><small>${MERGED_SLANGC_LINES_HIT}/${MERGED_SLANGC_LINES_FOUND}</small></td>
+                        <td style="padding: 15px; text-align: center; color: #95a5a6;">n/a</td>
+                        <td style="padding: 15px; text-align: center;"><span class="${merged_sl_function_class}">${MERGED_SLANGC_FUNCTION_COV}%</span><br><small>${MERGED_SLANGC_FUNCTIONS_HIT}/${MERGED_SLANGC_FUNCTIONS_FOUND}</small></td>
+                        <td style="padding: 15px; text-align: center;"><span class="${merged_sl_branch_class}">${MERGED_SLANGC_BRANCH_COV}%</span><br><small>${MERGED_SLANGC_BRANCHES_HIT}/${MERGED_SLANGC_BRANCHES_FOUND}</small></td>
+                        <td style="padding: 15px; text-align: center;"><a href="${LINK_PREFIX}latest/merged/slangc/index.html" style="color: #667eea;">View</a></td>
+                    </tr>
+EOF
+      fi
 
       if [[ "$HAS_LINUX" == "true" && -n "$LINUX_SLANGC_LINE_COV" ]]; then
         linux_sl_line_class=$(get_badge_color "$LINUX_SLANGC_LINE_COV" | sed 's/#27ae60/cov-good/; s/#f39c12/cov-medium/; s/#e74c3c/cov-low/')
@@ -555,6 +669,21 @@ EOF
                         <td style="padding: 15px; text-align: center;"><span class="${macos_sl_function_class}">${MACOS_SLANGC_FUNCTION_COV}</span><br><small>${MACOS_SLANGC_FUNCTIONS_HIT}/${MACOS_SLANGC_FUNCTIONS_FOUND}</small></td>
                         <td style="padding: 15px; text-align: center;"><span class="${macos_sl_branch_class}">${MACOS_SLANGC_BRANCH_COV}</span><br><small>${MACOS_SLANGC_BRANCHES_HIT}/${MACOS_SLANGC_BRANCHES_FOUND}</small></td>
                         <td style="padding: 15px; text-align: center;"><a href="${LINK_PREFIX}latest/macos/slangc/index.html" style="color: #667eea;">View</a></td>
+                    </tr>
+EOF
+      fi
+
+      if [[ "$HAS_WINDOWS" == "true" && -n "$WINDOWS_SLANGC_LINE_COV" ]]; then
+        windows_sl_line_class=$(get_badge_color "$WINDOWS_SLANGC_LINE_COV" | sed 's/#27ae60/cov-good/; s/#f39c12/cov-medium/; s/#e74c3c/cov-low/')
+
+        cat >>"${OUTPUT_FILE}" <<EOF
+                    <tr style="border-bottom: 1px solid #ddd;">
+                        <td style="padding: 15px;"><strong>🪟 Windows (x86_64)</strong></td>
+                        <td style="padding: 15px; text-align: center;"><span class="${windows_sl_line_class}">${WINDOWS_SLANGC_LINE_COV}%</span><br><small>${WINDOWS_SLANGC_LINES_HIT}/${WINDOWS_SLANGC_LINES_FOUND}</small></td>
+                        <td style="padding: 15px; text-align: center; color: #95a5a6;">n/a</td>
+                        <td style="padding: 15px; text-align: center; color: #95a5a6;">n/a</td>
+                        <td style="padding: 15px; text-align: center; color: #95a5a6;">n/a</td>
+                        <td style="padding: 15px; text-align: center;"><a href="${LINK_PREFIX}latest/windows/slangc/index.html" style="color: #667eea;">View</a></td>
                     </tr>
 EOF
       fi

--- a/tools/coverage/generate-landing-page.sh
+++ b/tools/coverage/generate-landing-page.sh
@@ -200,7 +200,9 @@ if [[ -f "$COMBINED_SUMMARY" ]]; then
 
   # Headline badge uses the merged cross-OS number when available
   # (most comprehensive view), falling back to per-OS otherwise.
-  if [[ "$HAS_MERGED" == "true" ]]; then
+  # -n "$MERGED_LINE_COV" guards against the merged JSON existing but
+  # being incomplete (parse_total returned None).
+  if [[ "$HAS_MERGED" == "true" && -n "$MERGED_LINE_COV" ]]; then
     LINE_COV="$MERGED_LINE_COV"
     LINE_COLOR=$(get_badge_color "$LINE_COV")
   elif [[ "$HAS_LINUX" == "true" ]]; then
@@ -491,7 +493,10 @@ if [[ "$HAS_DATA" == "true" ]]; then
                 <tbody>
 EOF
 
-    if [[ "$HAS_MERGED" == "true" ]]; then
+    # Guard on -n "$MERGED_LINE_COV" too: HAS_MERGED only signals that
+    # coverage-summary.json exists, not that parse_total succeeded in
+    # writing coverage fields into it. Matches the slangc Merged row.
+    if [[ "$HAS_MERGED" == "true" && -n "$MERGED_LINE_COV" ]]; then
       merged_line_class=$(get_badge_color "$MERGED_LINE_COV" | sed 's/#27ae60/cov-good/; s/#f39c12/cov-medium/; s/#e74c3c/cov-low/')
       merged_function_class=$(get_badge_color "$MERGED_FUNCTION_COV" | sed 's/#27ae60/cov-good/; s/#f39c12/cov-medium/; s/#e74c3c/cov-low/')
       merged_branch_class=$(get_badge_color "$MERGED_BRANCH_COV" | sed 's/#27ae60/cov-good/; s/#f39c12/cov-medium/; s/#e74c3c/cov-low/')

--- a/tools/coverage/generate-landing-page.sh
+++ b/tools/coverage/generate-landing-page.sh
@@ -507,10 +507,10 @@ EOF
       cat >>"${OUTPUT_FILE}" <<EOF
                     <tr style="border-bottom: 1px solid #ddd; background: #f8f9fa;">
                         <td style="padding: 15px;"><strong>🧩 Merged (cross-OS)</strong></td>
-                        <td style="padding: 15px; text-align: center;"><span class="${merged_line_class}">${MERGED_LINE_COV}%</span><br><small>${MERGED_LINES_HIT}/${MERGED_LINES_FOUND}</small></td>
+                        <td style="padding: 15px; text-align: center;"><span class="${merged_line_class}">${MERGED_LINE_COV}</span><br><small>${MERGED_LINES_HIT}/${MERGED_LINES_FOUND}</small></td>
                         <td style="padding: 15px; text-align: center; color: #95a5a6;">n/a</td>
-                        <td style="padding: 15px; text-align: center;"><span class="${merged_function_class}">${MERGED_FUNCTION_COV}%</span><br><small>${MERGED_FUNCTIONS_HIT}/${MERGED_FUNCTIONS_FOUND}</small></td>
-                        <td style="padding: 15px; text-align: center;"><span class="${merged_branch_class}">${MERGED_BRANCH_COV}%</span><br><small>${MERGED_BRANCHES_HIT}/${MERGED_BRANCHES_FOUND}</small></td>
+                        <td style="padding: 15px; text-align: center;"><span class="${merged_function_class}">${MERGED_FUNCTION_COV}</span><br><small>${MERGED_FUNCTIONS_HIT}/${MERGED_FUNCTIONS_FOUND}</small></td>
+                        <td style="padding: 15px; text-align: center;"><span class="${merged_branch_class}">${MERGED_BRANCH_COV}</span><br><small>${MERGED_BRANCHES_HIT}/${MERGED_BRANCHES_FOUND}</small></td>
                         <td style="padding: 15px; text-align: center;"><a href="${LINK_PREFIX}latest/merged/full/index.html" style="color: #667eea;">View</a></td>
                     </tr>
 EOF
@@ -574,7 +574,7 @@ EOF
       cat >>"${OUTPUT_FILE}" <<EOF
                     <tr style="border-bottom: 1px solid #ddd;">
                         <td style="padding: 15px;"><strong>🪟 Windows (x86_64)</strong></td>
-                        <td style="padding: 15px; text-align: center;"><span class="${windows_line_class}">${WINDOWS_LINE_COV}%</span><br><small>${WINDOWS_LINES_HIT}/${WINDOWS_LINES_FOUND}</small></td>
+                        <td style="padding: 15px; text-align: center;"><span class="${windows_line_class}">${WINDOWS_LINE_COV}</span><br><small>${WINDOWS_LINES_HIT}/${WINDOWS_LINES_FOUND}</small></td>
                         <td style="padding: 15px; text-align: center; color: #95a5a6;">n/a</td>
                         <td style="padding: 15px; text-align: center; color: #95a5a6;">n/a</td>
                         <td style="padding: 15px; text-align: center; color: #95a5a6;">n/a</td>
@@ -633,10 +633,10 @@ EOF
         cat >>"${OUTPUT_FILE}" <<EOF
                     <tr style="border-bottom: 1px solid #ddd; background: #f8f9fa;">
                         <td style="padding: 15px;"><strong>🧩 Merged (cross-OS)</strong></td>
-                        <td style="padding: 15px; text-align: center;"><span class="${merged_sl_line_class}">${MERGED_SLANGC_LINE_COV}%</span><br><small>${MERGED_SLANGC_LINES_HIT}/${MERGED_SLANGC_LINES_FOUND}</small></td>
+                        <td style="padding: 15px; text-align: center;"><span class="${merged_sl_line_class}">${MERGED_SLANGC_LINE_COV}</span><br><small>${MERGED_SLANGC_LINES_HIT}/${MERGED_SLANGC_LINES_FOUND}</small></td>
                         <td style="padding: 15px; text-align: center; color: #95a5a6;">n/a</td>
-                        <td style="padding: 15px; text-align: center;"><span class="${merged_sl_function_class}">${MERGED_SLANGC_FUNCTION_COV}%</span><br><small>${MERGED_SLANGC_FUNCTIONS_HIT}/${MERGED_SLANGC_FUNCTIONS_FOUND}</small></td>
-                        <td style="padding: 15px; text-align: center;"><span class="${merged_sl_branch_class}">${MERGED_SLANGC_BRANCH_COV}%</span><br><small>${MERGED_SLANGC_BRANCHES_HIT}/${MERGED_SLANGC_BRANCHES_FOUND}</small></td>
+                        <td style="padding: 15px; text-align: center;"><span class="${merged_sl_function_class}">${MERGED_SLANGC_FUNCTION_COV}</span><br><small>${MERGED_SLANGC_FUNCTIONS_HIT}/${MERGED_SLANGC_FUNCTIONS_FOUND}</small></td>
+                        <td style="padding: 15px; text-align: center;"><span class="${merged_sl_branch_class}">${MERGED_SLANGC_BRANCH_COV}</span><br><small>${MERGED_SLANGC_BRANCHES_HIT}/${MERGED_SLANGC_BRANCHES_FOUND}</small></td>
                         <td style="padding: 15px; text-align: center;"><a href="${LINK_PREFIX}latest/merged/slangc/index.html" style="color: #667eea;">View</a></td>
                     </tr>
 EOF
@@ -684,7 +684,7 @@ EOF
         cat >>"${OUTPUT_FILE}" <<EOF
                     <tr style="border-bottom: 1px solid #ddd;">
                         <td style="padding: 15px;"><strong>🪟 Windows (x86_64)</strong></td>
-                        <td style="padding: 15px; text-align: center;"><span class="${windows_sl_line_class}">${WINDOWS_SLANGC_LINE_COV}%</span><br><small>${WINDOWS_SLANGC_LINES_HIT}/${WINDOWS_SLANGC_LINES_FOUND}</small></td>
+                        <td style="padding: 15px; text-align: center;"><span class="${windows_sl_line_class}">${WINDOWS_SLANGC_LINE_COV}</span><br><small>${WINDOWS_SLANGC_LINES_HIT}/${WINDOWS_SLANGC_LINES_FOUND}</small></td>
                         <td style="padding: 15px; text-align: center; color: #95a5a6;">n/a</td>
                         <td style="padding: 15px; text-align: center; color: #95a5a6;">n/a</td>
                         <td style="padding: 15px; text-align: center; color: #95a5a6;">n/a</td>

--- a/tools/coverage/merge_summary.py
+++ b/tools/coverage/merge_summary.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Synthesize the merged ``coverage-summary.json`` from the auth-summary
+text files written by ``slang-coverage-merge.py --auth-summary-out``.
+
+Same JSON schema as the per-OS ``coverage-summary.json`` files produced
+by ``ci-slang-coverage.yml`` so the landing-page generator can read all
+four summaries (linux / macos / windows / merged) with one set of
+``get_json_value`` helpers. Percent fields keep their trailing ``%`` to
+match the per-OS files.
+
+Used by the renderer step in ``.github/workflows/coverage-nightly.yml``:
+
+    python3 tools/coverage/merge_summary.py \\
+        coverage-reports/merged/full/coverage-report.txt \\
+        coverage-reports/merged/slangc/coverage-report.txt \\
+        "$(date -u +%Y-%m-%d)" "$(git rev-parse --short HEAD)" \\
+        > coverage-reports/merged/coverage-summary.json
+
+Stand-alone Python so it can be unit-tested at
+``tools/coverage/tests/test_merge_summary.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any, Dict, Optional
+
+
+def _int(s: str) -> int:
+    """Parse a column value; treat ``-`` and unparseable strings as 0."""
+    try:
+        return int(s)
+    except ValueError:
+        return 0
+
+
+def _pct(s: str) -> str:
+    """Return a percent string verbatim if it ends with ``%``, otherwise
+    the empty string. ``llvm-cov report`` emits ``-`` in the Cover column
+    when the metric is unmeasured (zero total regions, etc.); we surface
+    that as an empty string so the landing-page generator treats it the
+    same as missing data."""
+    return s if s.endswith("%") else ""
+
+
+def parse_total(path: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Parse the TOTAL line of an llvm-cov-style report text file.
+
+    Returns a dict matching the per-OS coverage-summary.json field shape
+    (region/function/line/branch coverage, hit/found counts) or ``None``
+    if the file is missing, has no TOTAL line, or has a malformed TOTAL.
+    Failure reasons are logged to stderr so a future column-layout change
+    in ``write_llvm_cov_report`` surfaces in the workflow logs.
+
+    Column layout (whitespace-separated, 13 fields incl. leading TOTAL):
+
+        TOTAL  <regions> <missed_r> <r_cov>
+               <functions> <missed_f> <f_cov>
+               <lines> <missed_l> <l_cov>
+               <branches> <missed_b> <b_cov>
+    """
+    if not path or not os.path.isfile(path):
+        return None
+    with open(path) as f:
+        for line in f:
+            if not line.startswith("TOTAL"):
+                continue
+            p = line.split()
+            if len(p) < 13:
+                print(
+                    f"merge_summary: malformed TOTAL line in {path} "
+                    f"({len(p)} fields, expected >=13). Merged row will "
+                    f"be omitted from the landing page.",
+                    file=sys.stderr,
+                )
+                return None
+            r_tot, r_miss = _int(p[1]), _int(p[2])
+            f_tot, f_miss = _int(p[4]), _int(p[5])
+            l_tot, l_miss = _int(p[7]), _int(p[8])
+            b_tot, b_miss = _int(p[10]), _int(p[11])
+            return {
+                "region_coverage": _pct(p[3]),
+                "regions_hit": r_tot - r_miss,
+                "regions_found": r_tot,
+                "function_coverage": _pct(p[6]),
+                "functions_hit": f_tot - f_miss,
+                "functions_found": f_tot,
+                "line_coverage": _pct(p[9]),
+                "lines_hit": l_tot - l_miss,
+                "lines_found": l_tot,
+                "branch_coverage": _pct(p[12]),
+                "branches_hit": b_tot - b_miss,
+                "branches_found": b_tot,
+            }
+    print(
+        f"merge_summary: no TOTAL line in {path}. Merged row will be "
+        f"omitted from the landing page.",
+        file=sys.stderr,
+    )
+    return None
+
+
+def build_summary(
+    full_txt: Optional[str],
+    slangc_txt: Optional[str],
+    date: str,
+    commit: str,
+) -> Dict[str, Any]:
+    """Combine the full and slangc TOTAL parses into one summary dict.
+
+    The slangc fields are prefixed ``slangc_`` to match the per-OS
+    schema. The dict always carries ``date`` / ``commit`` / ``platform``
+    / ``platform_detail`` / ``_version`` metadata; coverage fields are
+    present only when ``parse_total`` succeeds for the corresponding
+    input."""
+    out: Dict[str, Any] = {
+        "date": date,
+        "commit": commit,
+        "platform": "merged",
+        "platform_detail": "linux+macos+windows",
+    }
+    full = parse_total(full_txt)
+    if full:
+        out.update(full)
+    slangc = parse_total(slangc_txt)
+    if slangc:
+        out.update({"slangc_" + k: v for k, v in slangc.items()})
+    out["_version"] = 2
+    return out
+
+
+def main(argv: Optional[list] = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) != 4:
+        print(
+            "usage: merge_summary.py FULL_TXT SLANGC_TXT DATE COMMIT",
+            file=sys.stderr,
+        )
+        return 2
+    full_txt, slangc_txt, date, commit = args
+    summary = build_summary(full_txt, slangc_txt, date, commit)
+    json.dump(summary, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/coverage/merge_summary.py
+++ b/tools/coverage/merge_summary.py
@@ -28,14 +28,6 @@ import sys
 from typing import Any, Dict, Optional
 
 
-def _int(s: str) -> int:
-    """Parse a column value; treat ``-`` and unparseable strings as 0."""
-    try:
-        return int(s)
-    except ValueError:
-        return 0
-
-
 def _pct(s: str) -> str:
     """Return a percent string verbatim if it ends with ``%``, otherwise
     the empty string. ``llvm-cov report`` emits ``-`` in the Cover column
@@ -76,10 +68,23 @@ def parse_total(path: Optional[str]) -> Optional[Dict[str, Any]]:
                     file=sys.stderr,
                 )
                 return None
-            r_tot, r_miss = _int(p[1]), _int(p[2])
-            f_tot, f_miss = _int(p[4]), _int(p[5])
-            l_tot, l_miss = _int(p[7]), _int(p[8])
-            b_tot, b_miss = _int(p[10]), _int(p[11])
+            # Count columns are integer hit/miss totals -- llvm-cov never
+            # emits ``-`` here (only in the percent columns). A non-integer
+            # in these slots means the report layout has drifted and we
+            # cannot trust any of the derived counts, so omit the row
+            # rather than publish misleading metrics.
+            try:
+                r_tot, r_miss = int(p[1]), int(p[2])
+                f_tot, f_miss = int(p[4]), int(p[5])
+                l_tot, l_miss = int(p[7]), int(p[8])
+                b_tot, b_miss = int(p[10]), int(p[11])
+            except ValueError:
+                print(
+                    f"merge_summary: non-integer TOTAL counts in {path}. "
+                    f"Merged row will be omitted from the landing page.",
+                    file=sys.stderr,
+                )
+                return None
             return {
                 "region_coverage": _pct(p[3]),
                 "regions_hit": r_tot - r_miss,

--- a/tools/coverage/tests/test_merge_summary.py
+++ b/tools/coverage/tests/test_merge_summary.py
@@ -108,6 +108,19 @@ class ParseTotalTests(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_non_integer_count_column_returns_none(self):
+        """Count columns are always integers in llvm-cov's output. A
+        non-integer there means the column layout has drifted; the row
+        must be omitted rather than silently coerced to 0 (which would
+        publish misleading merged metrics)."""
+        path = write_tmp(
+            "TOTAL  BOGUS  10  90.00%  20  5  75.00%  500  50  90.00%  200  20  90.00%\n"
+        )
+        try:
+            self.assertIsNone(merge_summary.parse_total(path))
+        finally:
+            os.unlink(path)
+
 
 class BuildSummaryTests(unittest.TestCase):
     """build_summary combines full + slangc parses with metadata."""

--- a/tools/coverage/tests/test_merge_summary.py
+++ b/tools/coverage/tests/test_merge_summary.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Tests for tools/coverage/merge_summary.py.
+
+The module parses ``llvm-cov report``-style TOTAL lines into a JSON
+summary that drives the "Merged (cross-OS)" row on the landing page.
+The parser is column-positional and brittle against future llvm-cov
+column-layout changes, so the tests pin the contract:
+
+- A valid TOTAL line maps to the right fields with `%` preserved.
+- Malformed TOTAL (too few columns) and missing TOTAL both return
+  None with an informative stderr message.
+- An unmeasured metric (``-`` instead of a percent) decodes as empty
+  string, matching how the landing page treats missing data.
+- The combined full + slangc invocation produces the schema the
+  landing-page generator expects.
+
+Run from repo root:
+
+    python3 -m unittest discover -s tools/coverage/tests -v
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SLANG_TOOL_DIR = os.path.abspath(os.path.join(HERE, os.pardir))
+MERGE_SUMMARY = os.path.join(SLANG_TOOL_DIR, "merge_summary.py")
+
+sys.path.insert(0, SLANG_TOOL_DIR)
+import merge_summary  # noqa: E402
+
+
+VALID_TOTAL = (
+    "Filename ...\n"
+    "----\n"
+    "source/foo.cpp  100  10  90.00%  20  5  75.00%  500  50  90.00%  200  20  90.00%\n"
+    "----\n"
+    "TOTAL           160  36  77.50%  44  11  75.00%  325  91  72.00%  130  34  73.85%\n"
+)
+
+
+def write_tmp(content: str) -> str:
+    fd, path = tempfile.mkstemp(suffix=".txt")
+    with os.fdopen(fd, "w") as f:
+        f.write(content)
+    return path
+
+
+class ParseTotalTests(unittest.TestCase):
+    """Unit-level coverage of parse_total."""
+
+    def test_valid_total_preserves_percent_suffix(self):
+        path = write_tmp(VALID_TOTAL)
+        try:
+            r = merge_summary.parse_total(path)
+            self.assertIsNotNone(r)
+            self.assertEqual(r["line_coverage"], "72.00%")
+            self.assertEqual(r["region_coverage"], "77.50%")
+            self.assertEqual(r["function_coverage"], "75.00%")
+            self.assertEqual(r["branch_coverage"], "73.85%")
+            self.assertEqual(r["lines_hit"], 325 - 91)
+            self.assertEqual(r["lines_found"], 325)
+            self.assertEqual(r["regions_hit"], 160 - 36)
+            self.assertEqual(r["functions_hit"], 44 - 11)
+            self.assertEqual(r["branches_hit"], 130 - 34)
+        finally:
+            os.unlink(path)
+
+    def test_missing_file_returns_none(self):
+        self.assertIsNone(merge_summary.parse_total("/no/such/file"))
+
+    def test_none_path_returns_none(self):
+        self.assertIsNone(merge_summary.parse_total(None))
+
+    def test_no_total_line_returns_none(self):
+        path = write_tmp("Filename ...\nsome/file.cpp 1 0 100.00% ...\n")
+        try:
+            self.assertIsNone(merge_summary.parse_total(path))
+        finally:
+            os.unlink(path)
+
+    def test_short_total_returns_none(self):
+        path = write_tmp("TOTAL 1 2 3\n")
+        try:
+            self.assertIsNone(merge_summary.parse_total(path))
+        finally:
+            os.unlink(path)
+
+    def test_dash_cover_decodes_as_empty(self):
+        """llvm-cov emits ``-`` when a metric has zero total. The
+        landing page should treat that the same as missing data."""
+        path = write_tmp(
+            "TOTAL  0  0  -  44  11  75.00%  325  91  72.00%  130  34  73.85%\n"
+        )
+        try:
+            r = merge_summary.parse_total(path)
+            self.assertIsNotNone(r)
+            self.assertEqual(r["region_coverage"], "")
+            self.assertEqual(r["regions_hit"], 0)
+            self.assertEqual(r["regions_found"], 0)
+            # Other metrics still parse normally.
+            self.assertEqual(r["line_coverage"], "72.00%")
+        finally:
+            os.unlink(path)
+
+
+class BuildSummaryTests(unittest.TestCase):
+    """build_summary combines full + slangc parses with metadata."""
+
+    def test_full_only(self):
+        full = write_tmp(VALID_TOTAL)
+        try:
+            s = merge_summary.build_summary(full, None, "2026-05-22", "abc1234")
+            self.assertEqual(s["platform"], "merged")
+            self.assertEqual(s["platform_detail"], "linux+macos+windows")
+            self.assertEqual(s["date"], "2026-05-22")
+            self.assertEqual(s["commit"], "abc1234")
+            self.assertEqual(s["_version"], 2)
+            self.assertEqual(s["line_coverage"], "72.00%")
+            self.assertNotIn("slangc_line_coverage", s)
+        finally:
+            os.unlink(full)
+
+    def test_full_plus_slangc(self):
+        full = write_tmp(VALID_TOTAL)
+        slangc = write_tmp(
+            "TOTAL  100  20  80.00%  20  5  75.00%  200  20  90.00%  100  10  90.00%\n"
+        )
+        try:
+            s = merge_summary.build_summary(full, slangc, "2026-05-22", "abc")
+            self.assertEqual(s["line_coverage"], "72.00%")
+            self.assertEqual(s["slangc_line_coverage"], "90.00%")
+            self.assertEqual(s["slangc_lines_hit"], 180)
+            self.assertEqual(s["slangc_lines_found"], 200)
+        finally:
+            os.unlink(full)
+            os.unlink(slangc)
+
+    def test_full_missing_yields_metadata_only(self):
+        """When parse_total returns None for full, the summary still
+        contains the metadata fields the landing-page generator reads.
+        The landing-page guard then suppresses the row because
+        line_coverage is absent."""
+        s = merge_summary.build_summary(
+            "/no/such/file", None, "2026-05-22", "abc"
+        )
+        self.assertEqual(set(s.keys()), {
+            "date", "commit", "platform", "platform_detail", "_version",
+        })
+
+    def test_malformed_full_still_includes_slangc(self):
+        """A partial signal is better than dropping everything: if the
+        slangc parse succeeds but the full parse fails, slangc fields
+        are still emitted."""
+        slangc = write_tmp(VALID_TOTAL)
+        try:
+            s = merge_summary.build_summary(
+                "/no/such/file", slangc, "2026-05-22", "abc"
+            )
+            self.assertNotIn("line_coverage", s)
+            self.assertIn("slangc_line_coverage", s)
+        finally:
+            os.unlink(slangc)
+
+
+class CliTests(unittest.TestCase):
+    """End-to-end via the script's argv interface, matching how the
+    workflow invokes it."""
+
+    def test_cli_emits_json_with_percent_preserved(self):
+        full = write_tmp(VALID_TOTAL)
+        slangc = write_tmp(VALID_TOTAL)
+        try:
+            out = subprocess.check_output(
+                [sys.executable, MERGE_SUMMARY, full, slangc, "2026-05-22", "abc"],
+                text=True,
+            )
+            parsed = json.loads(out)
+            self.assertEqual(parsed["line_coverage"], "72.00%")
+            self.assertEqual(parsed["slangc_line_coverage"], "72.00%")
+            self.assertEqual(parsed["_version"], 2)
+            self.assertEqual(parsed["platform"], "merged")
+        finally:
+            os.unlink(full)
+            os.unlink(slangc)
+
+    def test_cli_wrong_argc_exits_nonzero(self):
+        result = subprocess.run(
+            [sys.executable, MERGE_SUMMARY, "only", "one"],
+            capture_output=True, text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("usage:", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Three related changes to the nightly coverage pipeline, stacked as three commits on this branch:

1. **Restrict reports to `source/`.** The merged + per-OS reports rendered by the in-tree renderer ([`tools/coverage-html/`](../tree/master/tools/coverage-html/)) previously surfaced files under `build/`, `external/`, `include/`, `source/`, and `tools/`. Apply `--filter-include-regex '^source/'` at the merge step so the full-library view is restricted to the Slang library implementation, matching what the slangc-only view already filters via `slang_filters.py`.
2. **Cut over from llvm-cov / ReportGenerator HTML to the in-tree renderer.** PR #10973 added the in-tree renderer alongside the previous llvm-cov (Linux/macOS) and ReportGenerator (Windows) HTML so the two outputs could be compared. After 30+ nightlies in parallel the new renderer is ready to take over. This commit removes the old generation paths and routes `reports/latest/<os>/index.html` (the primary per-OS landing page) at the in-tree renderer.
3. **Add Windows and Merged rows to the landing page.** The front-door table at https://shader-slang.org/slang-coverage-reports/ previously showed only Linux and macOS. Add a Merged (cross-OS) row at the top of both tables (Coverage by Platform and Compiler Pipeline Coverage) and a Windows row at the bottom.

## What changed

### `ci-slang-coverage.yml`
- Drop `COVERAGE_HTML` / `COVERAGE_HTML_DIR` env vars from both Linux/macOS and Windows test steps. LCOV and llvm-cov JSON are still produced; HTML generation moves downstream.
- Drop the ReportGenerator install on Windows (dotnet tool) — only consumer was Windows HTML generation, which is gone. Saves ~30 s per nightly.
- Drop `coverage-html/`, `coverage-html-slangc/`, and `coverage-slangc.lcov` from the artifact upload paths. The slangc-only HTML for Windows is now produced by the in-tree renderer's slangc view.
- Drop the dead per-OS deploy block and the unused `deploy-pages` input — only ever ran when `deploy-pages: true`, which no caller passes.

### `coverage-nightly.yml`
- Restrict full-library merger + per-OS merger calls with `--filter-include-regex '^source/'` (commit 1).
- Deploy step now sources `reports/latest/<os>/` and `reports/history/.../<os>/` from the renderer's `new-html/{full,slangc}/html/` outputs. The three OS-specific blocks plus the `/new/` mirror loops collapse to one unified `for os in linux macos windows` loop — Windows is no longer a special case.
- Drop the `deploy-pages: false` lines from the three per-OS call sites.
- Add a step in the renderer block that synthesizes `coverage-reports/merged/coverage-summary.json` from the cross-OS auth-summary text files. Same JSON schema as the per-OS summaries.

### `tools/coverage/generate-landing-page.sh`
- Read `latest/windows/coverage-summary.json` and the new `latest/merged/coverage-summary.json`.
- Render a Merged (cross-OS) row at the top of both tables, and a Windows row at the bottom.
- Use the merged line coverage as the headline badge when available, falling back to Linux → macOS as before.
- Region cells are n/a on the Merged row (cross-OS merger doesn't combine regions) and on the Windows row (OpenCppCoverage only produces line metrics).

## Local validation

End-to-end test of the landing-page generator with synthetic summaries mirroring the live numbers:

| View | Lines | Regions | Functions | Branches |
|---|---:|---:|---:|---:|
| Merged (cross-OS) | 76.53% (282 889/369 625) | n/a | 72.65% | 69.80% |
| Linux (x86_64) | 75.71% | 51.41% | 70.37% | 68.92% |
| macOS (aarch64) | 75.10% | 50.63% | 64.19% | 68.18% |
| Windows (x86_64) | 54.80% (7 203/13 144) | n/a | n/a | n/a |

Source-only filter against the published merged LCOV (`reports/latest/merged/full/coverage.lcov`):

```
INPUT:  642 files; top-level dirs: build, external, include, source, tools
OUTPUT: 579 files; top-level dirs: source
slang-coverage-merge: filter dropped 63
```

## Notes / known limitations

- Historical archives under `reports/history/<date>-<sha>/` keep their original renderer's HTML — only new archive entries from this point on are produced by the in-tree renderer. URL shape (e.g. `reports/latest/linux/index.html`) is unchanged, so any external links continue to resolve.
- The Merged row's regions column is intentionally n/a: each OS's region count comes from a different instrumentation toolchain (llvm-cov regions on Linux/macOS, OpenCppCoverage Cobertura on Windows) and can't be sensibly cross-summed.

## Test plan

- [ ] `workflow_dispatch` on this branch produces a `coverage-reports-merged` artifact whose merged and per-OS rendered HTML contain only files under `source/`.
- [ ] After merge to master, the next nightly publishes `reports/latest/<os>/index.html` from the in-tree renderer (visible by inspecting HTML head / styling).
- [ ] After merge, the landing page at https://shader-slang.org/slang-coverage-reports/ shows the new Merged and Windows rows in both tables, with the numbers from the latest nightly.
- [ ] No regression in `reports/latest/<os>/slangc/index.html` (the compiler-only view); slangc HTML now exists for Windows too.