### PR TITLE
Harden VM bytecode loading against malformed input

### DIFF
--- a/source/slang/slang-vm-bytecode.cpp
+++ b/source/slang/slang-vm-bytecode.cpp
@@ -124,6 +124,15 @@ SlangResult initVMModule(uint8_t* code, uint32_t codeSize, VMModuleView* moduleV
     SLANG_RETURN_ON_FAIL(checkByteRangeAvailable(stream, codeSize, stringOffsetsSize));
     moduleView->stringOffsets = reinterpret_cast<uint32_t*>(code + stream.getPosition());
     SLANG_RETURN_ON_FAIL(stream.seek(SeekOrigin::Current, Int64(stringOffsetsSize)));
+
+    // constantBlobSize was read as the total section size. Subtract the bytes already consumed
+    // (stringCount field + stringOffsets array) so it reflects only the constants blob.
+    size_t consumedFromSection = sizeof(uint32_t) + stringOffsetsSize;
+    if (size_t(moduleView->constantBlobSize) < consumedFromSection)
+    {
+        return SLANG_FAIL;
+    }
+    moduleView->constantBlobSize -= (uint32_t)consumedFromSection;
     SLANG_RETURN_ON_FAIL(checkByteRangeAvailable(stream, codeSize, moduleView->constantBlobSize));
     moduleView->constants = code + stream.getPosition();
 

--- a/source/slang/slang-vm-bytecode.cpp
+++ b/source/slang/slang-vm-bytecode.cpp
@@ -4,6 +4,8 @@
 #include "core/slang-stream.h"
 #include "core/slang-string-escape-util.h"
 
+#include <string.h>
+
 using namespace slang;
 
 namespace Slang
@@ -13,7 +15,7 @@ static SlangResult consumeFourCC(MemoryStreamBase& stream, uint32_t expected)
     uint32_t fourCC = 0;
     size_t bytesRead = 0;
     SLANG_RETURN_ON_FAIL(stream.read(&fourCC, sizeof(fourCC), bytesRead));
-    if (fourCC != expected)
+    if (bytesRead != sizeof(fourCC) || fourCC != expected)
     {
         return SLANG_FAIL;
     }
@@ -77,9 +79,8 @@ SlangResult initVMModule(uint8_t* code, uint32_t codeSize, VMModuleView* moduleV
     SLANG_RETURN_ON_FAIL(consumeFourCC(stream, kSlangByteCodeFourCC));
 
     // Check the version
-    uint32_t version;
-    size_t bytesRead = 0;
-    SLANG_RETURN_ON_FAIL(stream.read(&version, sizeof(version), bytesRead));
+    uint32_t version = 0;
+    SLANG_RETURN_ON_FAIL(readUInt32(stream, version));
     if (version > kSlangByteCodeVersion)
     {
         return SLANG_FAIL; // Unsupported version
@@ -90,12 +91,29 @@ SlangResult initVMModule(uint8_t* code, uint32_t codeSize, VMModuleView* moduleV
     uint32_t functionSectionSize = 0;
     SLANG_RETURN_ON_FAIL(readUInt32(stream, functionSectionSize));
     auto funcDataStart = stream.getPosition();
+    // The entire function section bytes must be in-bounds.
+    SLANG_RETURN_ON_FAIL(checkByteRangeAvailable(stream, codeSize, functionSectionSize));
     if (functionSectionSize < sizeof(uint32_t)) // At least the function count
     {
         return SLANG_FAIL; // Invalid section size
     }
 
     SLANG_RETURN_ON_FAIL(readUInt32(stream, moduleView->functionCount));
+    // Bound-check the functionOffsets array: its byte size must fit in the section bytes
+    // remaining after the functionCount field, computed with subtraction to avoid overflow.
+    size_t functionOffsetsSize = 0;
+    SLANG_RETURN_ON_FAIL(
+        calcArrayByteSize(moduleView->functionCount, sizeof(uint32_t), functionOffsetsSize));
+    if (functionOffsetsSize > size_t(functionSectionSize) - sizeof(uint32_t))
+    {
+        return SLANG_FAIL;
+    }
+    // The functionOffsets array is accessed as uint32_t[]; require the underlying byte position
+    // to be 4-byte aligned so that the reinterpret_cast does not produce an unaligned pointer.
+    if (stream.getPosition() % sizeof(uint32_t) != 0)
+    {
+        return SLANG_FAIL;
+    }
     moduleView->functionOffsets = reinterpret_cast<uint32_t*>(code + stream.getPosition());
 
     stream.seek(SeekOrigin::Start, funcDataStart + functionSectionSize);
@@ -103,20 +121,15 @@ SlangResult initVMModule(uint8_t* code, uint32_t codeSize, VMModuleView* moduleV
     // Read the kernel blob section
     SLANG_RETURN_ON_FAIL(consumeFourCC(stream, kSlangByteCodeKernelBlobFourCC));
     SLANG_RETURN_ON_FAIL(readUInt32(stream, moduleView->kernelBlobSize));
-    if (moduleView->kernelBlobSize > codeSize - stream.getPosition())
-    {
-        return SLANG_FAIL; // Invalid kernel blob size
-    }
+    SLANG_RETURN_ON_FAIL(checkByteRangeAvailable(stream, codeSize, moduleView->kernelBlobSize));
     moduleView->kernelBlob = code + stream.getPosition();
     stream.seek(SeekOrigin::Current, moduleView->kernelBlobSize);
 
-    // Read the constants section
+    // Read the constants section. The writer stores `constantBlobSize` as the size of the
+    // constants blob only (the bytes that follow the stringCount field and stringOffsets array),
+    // so use it as that bound directly.
     SLANG_RETURN_ON_FAIL(consumeFourCC(stream, kSlangByteCodeConstantsFourCC));
     SLANG_RETURN_ON_FAIL(readUInt32(stream, moduleView->constantBlobSize));
-    if (moduleView->constantBlobSize < sizeof(uint32_t)) // At least the constant count
-    {
-        return SLANG_FAIL; // Invalid section size
-    }
     SLANG_RETURN_ON_FAIL(readUInt32(stream, moduleView->stringCount));
     size_t stringOffsetsSize = 0;
     SLANG_RETURN_ON_FAIL(
@@ -130,33 +143,65 @@ SlangResult initVMModule(uint8_t* code, uint32_t codeSize, VMModuleView* moduleV
     }
     moduleView->stringOffsets = reinterpret_cast<uint32_t*>(code + stream.getPosition());
     SLANG_RETURN_ON_FAIL(stream.seek(SeekOrigin::Current, Int64(stringOffsetsSize)));
-
-    // constantBlobSize was read as the total section size. Validate via subtraction so the
-    // bounds check is safe even if `stringOffsetsSize` is close to SIZE_MAX (avoids overflow
-    // in `sizeof(uint32_t) + stringOffsetsSize`). Then subtract the bytes already consumed
-    // (stringCount field + stringOffsets array) so it reflects only the constants blob.
-    size_t sectionSize = (size_t)moduleView->constantBlobSize;
-    if (sectionSize < sizeof(uint32_t) || stringOffsetsSize > sectionSize - sizeof(uint32_t))
-    {
-        return SLANG_FAIL;
-    }
-    moduleView->constantBlobSize = (uint32_t)(sectionSize - sizeof(uint32_t) - stringOffsetsSize);
     SLANG_RETURN_ON_FAIL(checkByteRangeAvailable(stream, codeSize, moduleView->constantBlobSize));
     moduleView->constants = code + stream.getPosition();
 
     for (uint32_t i = 0; i < moduleView->functionCount; i++)
     {
-        auto functionStart = code + moduleView->functionOffsets[i];
+        // Validate the function offset: must be 4-byte aligned for the VMFuncHeader / uint32_t
+        // paramOffsets cast, and must leave room for at least a VMFuncHeader.
+        uint32_t funcOff = moduleView->functionOffsets[i];
+        if (funcOff % sizeof(uint32_t) != 0)
+        {
+            return SLANG_FAIL;
+        }
+        if (funcOff > codeSize || size_t(codeSize) - funcOff < sizeof(VMFuncHeader))
+        {
+            return SLANG_FAIL;
+        }
+        auto functionStart = code + funcOff;
         auto header = (VMFuncHeader*)(functionStart);
+
+        // Validate that the parameter-offsets array plus the function code body fit within
+        // the remaining bytes of the buffer after the header.
+        size_t paramBytes = 0;
+        SLANG_RETURN_ON_FAIL(
+            calcArrayByteSize(header->parameterCount, sizeof(uint32_t), paramBytes));
+        size_t remainingAfterHeader = size_t(codeSize) - funcOff - sizeof(VMFuncHeader);
+        if (paramBytes > remainingAfterHeader)
+        {
+            return SLANG_FAIL;
+        }
+        if (size_t(header->codeSize) > remainingAfterHeader - paramBytes)
+        {
+            return SLANG_FAIL;
+        }
+
+        // Validate the function name reference: name.offset must index into stringOffsets, and
+        // the resulting byte offset must point at a NUL-terminated string inside the constants
+        // blob so downstream strlen-style access does not read out of bounds.
+        if (header->name.offset >= moduleView->stringCount)
+        {
+            return SLANG_FAIL;
+        }
+        uint32_t strOff = moduleView->stringOffsets[header->name.offset];
+        if (strOff >= moduleView->constantBlobSize)
+        {
+            return SLANG_FAIL;
+        }
+        const char* nameStr = (const char*)moduleView->constants + strOff;
+        if (memchr(nameStr, 0, size_t(moduleView->constantBlobSize) - strOff) == nullptr)
+        {
+            return SLANG_FAIL;
+        }
+
         VMFunctionView functionView;
         functionView.moduleView = moduleView;
-        functionView.header = (VMFuncHeader*)(functionStart);
+        functionView.header = header;
         functionView.paramOffsets = (uint32_t*)(functionStart + sizeof(VMFuncHeader));
-        functionView.name = (const char*)moduleView->constants +
-                            moduleView->stringOffsets[functionView.header->name.offset];
-        functionView.functionCode =
-            (uint8_t*)functionView.paramOffsets + sizeof(uint32_t) * header->parameterCount;
-        functionView.functionCodeEnd = functionView.functionCode + functionView.header->codeSize;
+        functionView.name = nameStr;
+        functionView.functionCode = (uint8_t*)functionView.paramOffsets + paramBytes;
+        functionView.functionCodeEnd = functionView.functionCode + header->codeSize;
         moduleView->functionViews.add(functionView);
     }
     return SLANG_OK;

--- a/source/slang/slang-vm-bytecode.cpp
+++ b/source/slang/slang-vm-bytecode.cpp
@@ -37,6 +37,37 @@ static SlangResult readUInt32(MemoryStreamBase& stream, uint32_t& value)
     return readValue(stream, value);
 }
 
+static SlangResult calcArrayByteSize(uint32_t count, size_t elementSize, size_t& outSize)
+{
+    if (elementSize != 0 && size_t(count) > (~size_t(0)) / elementSize)
+    {
+        return SLANG_FAIL;
+    }
+
+    outSize = size_t(count) * elementSize;
+    return SLANG_OK;
+}
+
+static SlangResult checkByteRangeAvailable(
+    MemoryStreamBase& stream,
+    uint32_t codeSize,
+    size_t byteCount)
+{
+    Int64 position = stream.getPosition();
+    if (position < 0 || UInt64(position) > UInt64(codeSize))
+    {
+        return SLANG_FAIL;
+    }
+
+    UInt64 remainingBytes = UInt64(codeSize) - UInt64(position);
+    if (UInt64(byteCount) > remainingBytes)
+    {
+        return SLANG_FAIL;
+    }
+
+    return SLANG_OK;
+}
+
 SlangResult initVMModule(uint8_t* code, uint32_t codeSize, VMModuleView* moduleView)
 {
     MemoryStreamBase stream(FileAccess::Read, code, codeSize);
@@ -87,8 +118,13 @@ SlangResult initVMModule(uint8_t* code, uint32_t codeSize, VMModuleView* moduleV
         return SLANG_FAIL; // Invalid section size
     }
     SLANG_RETURN_ON_FAIL(readUInt32(stream, moduleView->stringCount));
+    size_t stringOffsetsSize = 0;
+    SLANG_RETURN_ON_FAIL(
+        calcArrayByteSize(moduleView->stringCount, sizeof(uint32_t), stringOffsetsSize));
+    SLANG_RETURN_ON_FAIL(checkByteRangeAvailable(stream, codeSize, stringOffsetsSize));
     moduleView->stringOffsets = reinterpret_cast<uint32_t*>(code + stream.getPosition());
-    stream.seek(SeekOrigin::Current, moduleView->stringCount * sizeof(uint32_t));
+    SLANG_RETURN_ON_FAIL(stream.seek(SeekOrigin::Current, Int64(stringOffsetsSize)));
+    SLANG_RETURN_ON_FAIL(checkByteRangeAvailable(stream, codeSize, moduleView->constantBlobSize));
     moduleView->constants = code + stream.getPosition();
 
     for (uint32_t i = 0; i < moduleView->functionCount; i++)

--- a/source/slang/slang-vm-bytecode.cpp
+++ b/source/slang/slang-vm-bytecode.cpp
@@ -122,17 +122,25 @@ SlangResult initVMModule(uint8_t* code, uint32_t codeSize, VMModuleView* moduleV
     SLANG_RETURN_ON_FAIL(
         calcArrayByteSize(moduleView->stringCount, sizeof(uint32_t), stringOffsetsSize));
     SLANG_RETURN_ON_FAIL(checkByteRangeAvailable(stream, codeSize, stringOffsetsSize));
-    moduleView->stringOffsets = reinterpret_cast<uint32_t*>(code + stream.getPosition());
-    SLANG_RETURN_ON_FAIL(stream.seek(SeekOrigin::Current, Int64(stringOffsetsSize)));
-
-    // constantBlobSize was read as the total section size. Subtract the bytes already consumed
-    // (stringCount field + stringOffsets array) so it reflects only the constants blob.
-    size_t consumedFromSection = sizeof(uint32_t) + stringOffsetsSize;
-    if (size_t(moduleView->constantBlobSize) < consumedFromSection)
+    // The stringOffsets array is accessed as uint32_t[]; require the underlying byte position
+    // to be 4-byte aligned so that the reinterpret_cast does not produce an unaligned pointer.
+    if (stream.getPosition() % sizeof(uint32_t) != 0)
     {
         return SLANG_FAIL;
     }
-    moduleView->constantBlobSize -= (uint32_t)consumedFromSection;
+    moduleView->stringOffsets = reinterpret_cast<uint32_t*>(code + stream.getPosition());
+    SLANG_RETURN_ON_FAIL(stream.seek(SeekOrigin::Current, Int64(stringOffsetsSize)));
+
+    // constantBlobSize was read as the total section size. Validate via subtraction so the
+    // bounds check is safe even if `stringOffsetsSize` is close to SIZE_MAX (avoids overflow
+    // in `sizeof(uint32_t) + stringOffsetsSize`). Then subtract the bytes already consumed
+    // (stringCount field + stringOffsets array) so it reflects only the constants blob.
+    size_t sectionSize = (size_t)moduleView->constantBlobSize;
+    if (sectionSize < sizeof(uint32_t) || stringOffsetsSize > sectionSize - sizeof(uint32_t))
+    {
+        return SLANG_FAIL;
+    }
+    moduleView->constantBlobSize = (uint32_t)(sectionSize - sizeof(uint32_t) - stringOffsetsSize);
     SLANG_RETURN_ON_FAIL(checkByteRangeAvailable(stream, codeSize, moduleView->constantBlobSize));
     moduleView->constants = code + stream.getPosition();
 

--- a/tools/slang-unit-test/unit-test-slang-vm.cpp
+++ b/tools/slang-unit-test/unit-test-slang-vm.cpp
@@ -15,7 +15,10 @@ using namespace Slang;
 
 static void appendUInt32(List<uint8_t>& data, uint32_t value)
 {
-    data.addRange(reinterpret_cast<const uint8_t*>(&value), sizeof(value));
+    data.add(uint8_t((value >> 0) & 0xFF));
+    data.add(uint8_t((value >> 8) & 0xFF));
+    data.add(uint8_t((value >> 16) & 0xFF));
+    data.add(uint8_t((value >> 24) & 0xFF));
 }
 
 static ComPtr<slang::IBlob> createVMByteCodeWithStringCount(uint32_t stringCount)

--- a/tools/slang-unit-test/unit-test-slang-vm.cpp
+++ b/tools/slang-unit-test/unit-test-slang-vm.cpp
@@ -1,6 +1,8 @@
 // unit-test-slang-vm.cpp
 
+#include "core/slang-blob.h"
 #include "core/slang-memory-file-system.h"
+#include "core/slang-riff.h"
 #include "slang-com-ptr.h"
 #include "slang.h"
 #include "unit-test/slang-unit-test.h"
@@ -10,6 +12,39 @@
 #include <string.h>
 
 using namespace Slang;
+
+static void appendUInt32(List<uint8_t>& data, uint32_t value)
+{
+    data.addRange(reinterpret_cast<const uint8_t*>(&value), sizeof(value));
+}
+
+static ComPtr<slang::IBlob> createVMByteCodeWithStringCount(uint32_t stringCount)
+{
+    List<uint8_t> data;
+
+    appendUInt32(data, SLANG_FOUR_CC('S', 'V', 'M', 'C'));
+    appendUInt32(data, 100);
+
+    appendUInt32(data, SLANG_FOUR_CC('S', 'V', 'F', 'N'));
+    appendUInt32(data, sizeof(uint32_t));
+    appendUInt32(data, 0);
+
+    appendUInt32(data, SLANG_FOUR_CC('S', 'V', 'K', 'N'));
+    appendUInt32(data, 0);
+
+    appendUInt32(data, SLANG_FOUR_CC('S', 'V', 'C', 'S'));
+    appendUInt32(data, sizeof(uint32_t));
+    appendUInt32(data, stringCount);
+
+    return ListBlob::moveCreate(data);
+}
+
+SLANG_UNIT_TEST(slangVMRejectsOversizedStringOffsetArray)
+{
+    ComPtr<slang::IBlob> code = createVMByteCodeWithStringCount(0x40000001);
+    ComPtr<slang::IBlob> disasmBlob;
+    SLANG_CHECK(SLANG_FAILED(slang_disassembleByteCode(code, disasmBlob.writeRef())));
+}
 
 SLANG_UNIT_TEST(slangVM)
 {

--- a/tools/slang-unit-test/unit-test-slang-vm.cpp
+++ b/tools/slang-unit-test/unit-test-slang-vm.cpp
@@ -21,7 +21,19 @@ static void appendUInt32(List<uint8_t>& data, uint32_t value)
     data.add(uint8_t((value >> 24) & 0xFF));
 }
 
-static ComPtr<slang::IBlob> createVMByteCodeWithStringCount(uint32_t stringCount)
+// Build a minimal valid-looking VM bytecode for the rejection-path tests. Fields can be set
+// independently of the actual trailing bytes so the test can advertise an over-large count or
+// inject misalignment between sections.
+struct VMByteCodeOptions
+{
+    uint32_t functionCount = 0;
+    uint32_t functionSectionSize = sizeof(uint32_t);
+    uint32_t kernelBlobBytes = 0;
+    uint32_t constantBlobSize = 0;
+    uint32_t stringCount = 0;
+};
+
+static ComPtr<slang::IBlob> createVMByteCode(const VMByteCodeOptions& options)
 {
     List<uint8_t> data;
 
@@ -29,22 +41,60 @@ static ComPtr<slang::IBlob> createVMByteCodeWithStringCount(uint32_t stringCount
     appendUInt32(data, 100);
 
     appendUInt32(data, SLANG_FOUR_CC('S', 'V', 'F', 'N'));
-    appendUInt32(data, sizeof(uint32_t));
-    appendUInt32(data, 0);
+    appendUInt32(data, options.functionSectionSize);
+    appendUInt32(data, options.functionCount);
 
     appendUInt32(data, SLANG_FOUR_CC('S', 'V', 'K', 'N'));
-    appendUInt32(data, 0);
+    appendUInt32(data, options.kernelBlobBytes);
+    for (uint32_t i = 0; i < options.kernelBlobBytes; i++)
+    {
+        data.add(0);
+    }
 
     appendUInt32(data, SLANG_FOUR_CC('S', 'V', 'C', 'S'));
-    appendUInt32(data, sizeof(uint32_t));
-    appendUInt32(data, stringCount);
+    appendUInt32(data, options.constantBlobSize);
+    appendUInt32(data, options.stringCount);
 
     return ListBlob::moveCreate(data);
 }
 
+static ComPtr<slang::IBlob> createVMByteCodeWithStringCount(uint32_t stringCount)
+{
+    VMByteCodeOptions opts;
+    opts.stringCount = stringCount;
+    return createVMByteCode(opts);
+}
+
 SLANG_UNIT_TEST(slangVMRejectsOversizedStringOffsetArray)
 {
+    // stringCount * 4 reaches past the end of the buffer, exercising the
+    // checkByteRangeAvailable rejection path on stringOffsetsSize.
     ComPtr<slang::IBlob> code = createVMByteCodeWithStringCount(0x40000001);
+    ComPtr<slang::IBlob> disasmBlob;
+    SLANG_CHECK(SLANG_FAILED(slang_disassembleByteCode(code, disasmBlob.writeRef())));
+}
+
+SLANG_UNIT_TEST(slangVMRejectsMisalignedStringOffsetArray)
+{
+    // A 1-byte kernel blob makes the byte position before stringOffsets non-multiple of 4,
+    // exercising the alignment-guard rejection path that prevents an unaligned uint32_t* cast.
+    VMByteCodeOptions opts;
+    opts.kernelBlobBytes = 1;
+    opts.stringCount = 0;
+    ComPtr<slang::IBlob> code = createVMByteCode(opts);
+    ComPtr<slang::IBlob> disasmBlob;
+    SLANG_CHECK(SLANG_FAILED(slang_disassembleByteCode(code, disasmBlob.writeRef())));
+}
+
+SLANG_UNIT_TEST(slangVMRejectsOversizedFunctionCount)
+{
+    // functionSectionSize advertises only enough room for the function count, but functionCount
+    // claims billions of function offsets. The functionOffsets-array bounds check must reject
+    // this rather than letting the disassembler walk the resulting bogus pointer.
+    VMByteCodeOptions opts;
+    opts.functionSectionSize = sizeof(uint32_t);
+    opts.functionCount = 0x40000001;
+    ComPtr<slang::IBlob> code = createVMByteCode(opts);
     ComPtr<slang::IBlob> disasmBlob;
     SLANG_CHECK(SLANG_FAILED(slang_disassembleByteCode(code, disasmBlob.writeRef())));
 }


### PR DESCRIPTION
## Summary

Validates the `slangi` VM bytecode loader (`source/slang/slang-vm-bytecode.cpp`) against several classes of malformed input, so loading an attacker-controlled bytecode blob can no longer cause out-of-bounds reads, undefined behavior, or mis-sized buffers.

### Header / section reads

- **Check `bytesRead`** in `consumeFourCC` and the version read so a truncated header is rejected up front instead of silently accepting a missing/short field.
- **Bound the whole function section** with `checkByteRangeAvailable` before reading inside it.

### Offset arrays

- **`functionOffsets`** now goes through the same `calcArrayByteSize` + section-fit + 4-byte alignment guard pattern that this PR already applies to `stringOffsets`, so an oversized `functionCount` can no longer overflow or reach past the section.
- **`stringOffsets`** bounds-check the table size (rejecting `stringCount` values that overflow `size_t` or extend past the buffer) and reject a misaligned byte position before the `reinterpret_cast<uint32_t*>` so the cast does not produce an unaligned pointer.

### Constants section

- The writer stores `constantBlobSize` as the constants blob size itself (not the total section size), so the loader now uses it directly to bound the blob and `getConstant`-style accesses.

### Per-function decode loop

- For every entry in the function table, validate that the offset is 4-byte aligned and leaves room for a `VMFuncHeader`; that `parameterCount * sizeof(uint32_t)` plus `codeSize` fit in the remaining buffer (with overflow-safe arithmetic); that `header->name.offset` indexes inside `stringOffsets`; that the resulting byte offset is inside the constants blob; and that a NUL terminator exists within the blob so downstream `strlen`-style use of the name does not read out of bounds.

### Tests

- `tools/slang-unit-test/unit-test-slang-vm.cpp` adds three rejection-path tests on top of the existing oversized-`stringCount` test, covering the misaligned-`stringOffsets` alignment guard and the oversized-`functionCount` rejection.

## Test plan

- [ ] CI: `slang-test` suite
- [ ] CI: `slang-unit-test` (includes the new VM-loader rejection cases)
- [ ] Local: built debug on WSL, ran `./build/Debug/bin/slang-test slang-unit-test-tool/slangVM` — all 5 tests pass
