### PR TITLE
Use variadic layer sizes for neural shared memory

### DIFF
--- a/source/standard-modules/neural/shared-memory-pool.slang
+++ b/source/standard-modules/neural/shared-memory-pool.slang
@@ -363,8 +363,14 @@ internal struct SharedMemoryUsage<T, TargetEnum Target, ExecutionMode ExeMode, i
     static const int SharedMemSizeInVectorMatC = SharedMemSizeInVectorMatB * sizeof(T) / sizeof(half);
 }
 
-public struct SharedMemorySize0<T, TargetEnum Target, ExecutionMode ExeMode, int SubgroupSize, int SubgroupCount, int InputSize, int OutputSize>
-                    : ISharedMemorySize
+internal struct SharedMemorySizeForLayer<
+    T,
+    TargetEnum Target,
+    ExecutionMode ExeMode,
+    int SubgroupSize,
+    int SubgroupCount,
+    int InputSize,
+    int OutputSize>
     where T : __BuiltinFloatingPointType
     where T.Differential == T
 {
@@ -407,193 +413,80 @@ public struct SharedMemorySize0<T, TargetEnum Target, ExecutionMode ExeMode, int
         (SubgroupCount * SubgroupSize * HeightInVecB_SR + SubgroupCount * TileStrideVec_SR * CMShape.ROW_C) * sizeof(uint4)
         + ((SubgroupCount * MPadded_SR * sizeof(T) + sizeof(uint4) - 1) / sizeof(uint4)) * sizeof(uint4);
 
-    public static const uint Bytes = Max(Max(Max(BytesForMMA, BytesForOuterProductStore), BytesForCrossWarpReduction), BytesForSumReduceRows);
+    static const uint Bytes = Max(Max(Max(BytesForMMA, BytesForOuterProductStore),
+                                          BytesForCrossWarpReduction),
+                                                BytesForSumReduceRows);
 }
 
-// The following code is a macro-based implementation of the shared memory size calculation.
-// It is used to calculate the shared memory size for a given number of hidden layers.
-// The challenge here is that the size of the shared memory has to be compile time constant, however
-// slang doesn't really have const_expr function. So the only way to get the compile time constant
-// is to use meta programming to generate the code that can be evaluated at compile time.
-// Here the algorithm is very simple where we just use divide and conquer to calculate the shared memory size.
-// Firstly, we define the base case `SharedMemorySize0` that give an input and output of a layer, we calculate the shared memory size for this layer.
-// Then we can define larger number of layers by using the divide and conquer strategy. The reason to use Macro here
-// is just to reduce the mount of code that we need to write. But under the hood, the macro will be expanded to:
-// `SharedMemorySize1` to `SharedMemorySize15`.
+internal interface ISharedMemorySizePackNode
+{
+    static const uint Bytes;
+}
 
-// Take an example:
-// ```
-// DEFINE_SHMEM_SIZE(3, 1, 1, PARAM_3, ARG_3_L, ARG_3_R)
-// ```
-// This will be expanded to:
-// ```
-// public struct SharedMemorySize3<T, TargetEnum Target, ExecutionMode ExeMode, int SubgroupSize, int SubgroupCount, uint S0, uint S1, uint S2, uint S3> SHMEM_WHERE {
-//     internal static const uint a = SharedMemorySize1<T, Target, ExeMode, SubgroupSize, SubgroupCount, S0, S1, S2>.Bytes;
-//     internal static const uint b = SharedMemorySize1<T, Target, ExeMode, SubgroupSize, SubgroupCount, S2, S3, S4>.Bytes;
-//     public static const uint Bytes = Max(a, b);
-// }
-// ```
-// Where `LN` and `RN` determine how we divide input sequence of layers into two parts.
+internal struct SharedMemorySizePackEnd : ISharedMemorySizePackNode
+{
+    static const uint Bytes = 0;
+}
 
-// TODO: We shouldn't need such sophisticated meta-programming to achieve this once we have const_expr function
-//       or we can provide more advanced variadic generic parameters support such as First(...)/Rest(...), so that
-//       we can define the SharedMemorySize as variadic generic struct instead of these pre-defined generics.
-//
-// We note that this implementation is not the most efficient way to calculate the shared memory size, because
-// we can first find out the max layer size, and then do the remaining calculation. But since this computation is
-// not done at run time, so we don't need to worry about the performance, and we can reuse other data structure we
-// already have, so it's easiest way to implement this.
-
-
-#define UNPACK(...) __VA_ARGS__
-
-// 2. Define your helper macros
-#define SHMEM_WHERE where T : __BuiltinFloatingPointType where T.Differential == T
-#define SHMEM_BASE T, Target, ExeMode, SubgroupSize, SubgroupCount
-
-// 3. The Core Macro - note the removed spaces around UNPACK
-#define DEFINE_SHMEM_SIZE(N, LN, RN, ARGS, L_VALS, R_VALS)                                                                           \
-    public struct SharedMemorySize##N<T, TargetEnum Target, ExecutionMode ExeMode, int SubgroupSize, int SubgroupCount, UNPACK ARGS> \
-         : ISharedMemorySize                                                                                                         \
-        SHMEM_WHERE                                                                                                                  \
-    {                                                                                                                                \
-        internal static const uint a = SharedMemorySize##LN<SHMEM_BASE, UNPACK L_VALS>.Bytes;                                        \
-        internal static const uint b = SharedMemorySize##RN<SHMEM_BASE, UNPACK R_VALS>.Bytes;                                        \
-        public static const uint Bytes = Max(a, b);                                                                                  \
-    }
-
-#define PARAM_1 (uint S0, uint S1, uint S2)
-#define ARG_1 (S0, S1, S2)
-#define ARG_1_L (S0, S1)
-#define ARG_1_R (S1, S2)
-
-#define PARAM_2 (UNPACK PARAM_1, uint S3)
-#define ARG_2 (UNPACK ARG_1, S3)
-#define ARG_2_L (S0, S1, S2)
-#define ARG_2_R (S2, S3)
-
-#define PARAM_3 (UNPACK PARAM_2, uint S4)
-#define ARG_3 (UNPACK ARG_2, S4)
-#define ARG_3_L (S0, S1, S2)
-#define ARG_3_R (S2, S3, S4)
-
-DEFINE_SHMEM_SIZE(1, 0, 0, PARAM_1, ARG_1_L, ARG_1_R)
-DEFINE_SHMEM_SIZE(2, 1, 0, PARAM_2, ARG_2_L, ARG_2_R)
-DEFINE_SHMEM_SIZE(3, 1, 1, PARAM_3, ARG_3_L, ARG_3_R)
-
-// from 4 to 7
-#define PARAM_4 (UNPACK PARAM_3, uint S5)
-#define ARG_4 (UNPACK ARG_3, S5)
-#define ARG_4_R (S4, S5)
-
-#define PARAM_5 (UNPACK PARAM_4, uint S6)
-#define ARG_5 (UNPACK ARG_4, S6)
-#define ARG_5_R (UNPACK ARG_4_R, S6)
-
-#define PARAM_6 (UNPACK PARAM_5, uint S7)
-#define ARG_6 (S0, S1, S2, S3, S4, S5, S6, S7)
-#define ARG_6_R (UNPACK ARG_5_R, S7)
-
-#define PARAM_7 (UNPACK PARAM_6, uint S8)
-#define ARG_7 (UNPACK ARG_6, S8)
-#define ARG_7_R (UNPACK ARG_6_R, S8)
-
-DEFINE_SHMEM_SIZE(4, 3, 0, PARAM_4, ARG_3, ARG_4_R)
-DEFINE_SHMEM_SIZE(5, 3, 1, PARAM_5, ARG_3, ARG_5_R)
-DEFINE_SHMEM_SIZE(6, 3, 2, PARAM_6, ARG_3, ARG_6_R)
-DEFINE_SHMEM_SIZE(7, 3, 3, PARAM_7, ARG_3, ARG_7_R)
-
-// from 8 to 15
-#define PARAM_8 (UNPACK PARAM_7, uint S9)
-#define ARG_8 (UNPACK ARG_7, S9)
-#define ARG_8_R (S8, S9)
-
-#define PARAM_9 (UNPACK PARAM_8, uint S10)
-#define ARG_9 (UNPACK ARG_8, S10)
-#define ARG_9_R (UNPACK ARG_8_R, S10)
-
-#define PARAM_10 (UNPACK PARAM_9, uint S11)
-#define ARG_10 (UNPACK ARG_9, S11)
-#define ARG_10_R (UNPACK ARG_9_R, S11)
-
-#define PARAM_11 (UNPACK PARAM_10, uint S12)
-#define ARG_11 (UNPACK ARG_10, S12)
-#define ARG_11_R (UNPACK ARG_10_R, S12)
-
-#define PARAM_12 (UNPACK PARAM_11, uint S13)
-#define ARG_12 (UNPACK ARG_11, S13)
-#define ARG_12_R (UNPACK ARG_11_R, S13)
-
-#define PARAM_13 (UNPACK PARAM_12, uint S14)
-#define ARG_13 (UNPACK ARG_12, S14)
-#define ARG_13_R (UNPACK ARG_12_R, S14)
-
-#define PARAM_14 (UNPACK PARAM_13, uint S15)
-#define ARG_14 (UNPACK ARG_13, S15)
-#define ARG_14_R (UNPACK ARG_13_R, S15)
-
-#define PARAM_15 (UNPACK PARAM_14, uint S16)
-#define ARG_15 (UNPACK ARG_14, S16)
-#define ARG_15_R (UNPACK ARG_14_R, S16)
-
-DEFINE_SHMEM_SIZE(8,  7, 0, PARAM_8,  ARG_7, ARG_8_R)
-DEFINE_SHMEM_SIZE(9,  7, 1, PARAM_9,  ARG_7, ARG_9_R)
-DEFINE_SHMEM_SIZE(10, 7, 2, PARAM_10, ARG_7, ARG_10_R)
-DEFINE_SHMEM_SIZE(11, 7, 3, PARAM_11, ARG_7, ARG_11_R)
-DEFINE_SHMEM_SIZE(12, 7, 4, PARAM_12, ARG_7, ARG_12_R)
-DEFINE_SHMEM_SIZE(13, 7, 5, PARAM_13, ARG_7, ARG_13_R)
-DEFINE_SHMEM_SIZE(14, 7, 6, PARAM_14, ARG_7, ARG_14_R)
-DEFINE_SHMEM_SIZE(15, 7, 7, PARAM_15, ARG_7, ARG_15_R)
-
-// Slang doesn't support generic overloading, so we cannot provide the one generic with different number of parameters.
-public struct SharedMemorySize<T, TargetEnum Target, ExecutionMode ExeMode, int SubgroupSize, int SubgroupCount>
+internal struct SharedMemorySizePackNode<
+    T,
+    TargetEnum Target,
+    ExecutionMode ExeMode,
+    int SubgroupSize,
+    int SubgroupCount,
+    int CurrentLayerSize,
+    int NextLayerSize,
+    let each RestLayerSize : int>
+    : ISharedMemorySizePackNode
     where T : __BuiltinFloatingPointType
     where T.Differential == T
 {
-    #define STRIP_PARENS(x) STRIP_PARENS_I x
-    #define STRIP_PARENS_I(...) __VA_ARGS__
+    internal static const uint Current =
+        SharedMemorySizeForLayer<
+            T,
+            Target,
+            ExeMode,
+            SubgroupSize,
+            SubgroupCount,
+            CurrentLayerSize,
+            NextLayerSize>.Bytes;
+    typealias Tail = __packBranch(
+        RestLayerSize,
+        SharedMemorySizePackEnd,
+        SharedMemorySizePackNode<
+            T,
+            Target,
+            ExeMode,
+            SubgroupSize,
+            SubgroupCount,
+            NextLayerSize,
+            __first(RestLayerSize),
+            __trimFirst(RestLayerSize)>);
 
-    public typealias OfLayer1<uint S0, uint S1> = SharedMemorySize0<T, Target, ExeMode, SubgroupSize, SubgroupCount, S0, S1>;
-    public typealias OfLayer2<STRIP_PARENS(PARAM_1)>   = SharedMemorySize1<T, Target, ExeMode, SubgroupSize, SubgroupCount, STRIP_PARENS(ARG_1)>;
-    public typealias OfLayer3<STRIP_PARENS(PARAM_2)>   = SharedMemorySize2<T, Target, ExeMode, SubgroupSize, SubgroupCount, STRIP_PARENS(ARG_2)>;
-    public typealias OfLayer4<STRIP_PARENS(PARAM_3)>   = SharedMemorySize3<T, Target, ExeMode, SubgroupSize, SubgroupCount, STRIP_PARENS(ARG_3)>;
-    public typealias OfLayer5<STRIP_PARENS(PARAM_4)>   = SharedMemorySize4<T, Target, ExeMode, SubgroupSize, SubgroupCount, STRIP_PARENS(ARG_4)>;
-    public typealias OfLayer6<STRIP_PARENS(PARAM_5)>   = SharedMemorySize5<T, Target, ExeMode, SubgroupSize, SubgroupCount, STRIP_PARENS(ARG_5)>;
-    public typealias OfLayer7<STRIP_PARENS(PARAM_6)>   = SharedMemorySize6<T, Target, ExeMode, SubgroupSize, SubgroupCount, STRIP_PARENS(ARG_6)>;
-    public typealias OfLayer8<STRIP_PARENS(PARAM_7)>   = SharedMemorySize7<T, Target, ExeMode, SubgroupSize, SubgroupCount, STRIP_PARENS(ARG_7)>;
-    public typealias OfLayer9<STRIP_PARENS(PARAM_8)>   = SharedMemorySize8<T, Target, ExeMode, SubgroupSize, SubgroupCount, STRIP_PARENS(ARG_8)>;
-    public typealias OfLayer10<STRIP_PARENS(PARAM_9)>   = SharedMemorySize9<T, Target, ExeMode, SubgroupSize, SubgroupCount, STRIP_PARENS(ARG_9)>;
-    public typealias OfLayer11<STRIP_PARENS(PARAM_10)> = SharedMemorySize10<T, Target, ExeMode, SubgroupSize, SubgroupCount, STRIP_PARENS(ARG_10)>;
-    public typealias OfLayer12<STRIP_PARENS(PARAM_11)> = SharedMemorySize11<T, Target, ExeMode, SubgroupSize, SubgroupCount, STRIP_PARENS(ARG_11)>;
-    public typealias OfLayer13<STRIP_PARENS(PARAM_12)> = SharedMemorySize12<T, Target, ExeMode, SubgroupSize, SubgroupCount, STRIP_PARENS(ARG_12)>;
-    public typealias OfLayer14<STRIP_PARENS(PARAM_13)> = SharedMemorySize13<T, Target, ExeMode, SubgroupSize, SubgroupCount, STRIP_PARENS(ARG_13)>;
-    public typealias OfLayer15<STRIP_PARENS(PARAM_14)> = SharedMemorySize14<T, Target, ExeMode, SubgroupSize, SubgroupCount, STRIP_PARENS(ARG_14)>;
-    public typealias OfLayer16<STRIP_PARENS(PARAM_15)> = SharedMemorySize15<T, Target, ExeMode, SubgroupSize, SubgroupCount, STRIP_PARENS(ARG_15)>;
+    static const uint Bytes = Max(Current, Tail.Bytes);
 }
 
-#if 0
-
-// We should implement First/Rest syntax to something like this.
-interface IVal {
-    static const int Value;
-}
-SharedMemorySize<int In, each Val:IVal HiddenSize, int OutputSize>
-{
-    static const uint SharedMemSizeInBytes =
-        max(SharedMemorySize<In, First HiddenSize>, SharedMemorySize<each Rest HiddenSize, OutputSize>);
-}
-
-// Slang doesn't support generic overloading, therefore we cannot provide the pre-defined generics that adds different number of HiddenSize.
-
-public struct SharedMemorySize<T, TargetEnum Target, ExecutionMode ExeMode, int SubgroupSize, int SubgroupCount, int InputSize, int HiddenSize, int OutputSize>
+public struct SharedMemorySize<
+    T,
+    TargetEnum Target,
+    ExecutionMode ExeMode,
+    int SubgroupSize,
+    int SubgroupCount,
+    int FirstLayerSize,
+    int SecondLayerSize,
+    let each RestLayerSize : int>
+    : ISharedMemorySize
     where T : __BuiltinFloatingPointType
     where T.Differential == T
 {
-    typealias ShMemInfo = SharedMemoryUsage<T, Target, ExeMode, InputSize, OutputSize, SubgroupSize>;
-
-    // Notice that in the actual implementation, we always reuse shared memory for Tile B and Tile C because they are always used at
-    // different stages of the computation, and they have the same size.
-    static const uint SharedMemSizeInBytes =
-        (ShMemInfo.SharedMemSizeInVectorMatA + (ShMemInfo.SharedMemSizeInVectorMatB) * SubgroupCount) * sizeof(uint4);
+    public static const uint Bytes =
+        SharedMemorySizePackNode<
+            T,
+            Target,
+            ExeMode,
+            SubgroupSize,
+            SubgroupCount,
+            FirstLayerSize,
+            SecondLayerSize,
+            RestLayerSize>.Bytes;
 }
-#endif

--- a/tests/bugs/neural-autodiff-constexpr-crash-full.slang
+++ b/tests/bugs/neural-autodiff-constexpr-crash-full.slang
@@ -29,8 +29,17 @@ static const int WARPS_PER_BLOCK = WT_WAVE_WARPS;
 static const float LEAKY_ALPHA = 0.01f;
 
 typealias Storage = TorchTensorViewAddress<half>;
-typealias ShMemSize = SharedMemorySize<half, TargetEnum.CUDA, ExecutionMode.Training, SubgroupSize, WARPS_PER_BLOCK>;
-typealias ShMemSizeLayer = ShMemSize.OfLayer4<IN_DIM, HIDDEN_DIM, HIDDEN_DIM, HIDDEN_DIM, OUT_DIM>;
+typealias ShMemSizeLayer = SharedMemorySize<
+    half,
+    TargetEnum.CUDA,
+    ExecutionMode.Training,
+    SubgroupSize,
+    WARPS_PER_BLOCK,
+    IN_DIM,
+    HIDDEN_DIM,
+    HIDDEN_DIM,
+    HIDDEN_DIM,
+    OUT_DIM>;
 typealias InVec = WaveTangledVector<half, ShMemSizeLayer, IN_DIM, SubgroupSize, WARPS_PER_BLOCK>;
 typealias HidVec = WaveTangledVector<half, ShMemSizeLayer, HIDDEN_DIM, SubgroupSize, WARPS_PER_BLOCK>;
 typealias OutVec = WaveTangledVector<half, ShMemSizeLayer, OUT_DIM, SubgroupSize, WARPS_PER_BLOCK>;

--- a/tests/bugs/neural-autodiff-constexpr-crash.slang
+++ b/tests/bugs/neural-autodiff-constexpr-crash.slang
@@ -19,8 +19,17 @@ import slang.neural;
 static const int SubgroupSize = 32;
 static const int WARPS = 4;
 
-typealias ShMemSize = SharedMemorySize<half, TargetEnum.CUDA, ExecutionMode.Training, SubgroupSize, WARPS>;
-typealias ShMemSizeLayer = ShMemSize.OfLayer4<2, 128, 128, 128, 3>;
+typealias ShMemSizeLayer = SharedMemorySize<
+    half,
+    TargetEnum.CUDA,
+    ExecutionMode.Training,
+    SubgroupSize,
+    WARPS,
+    2,
+    128,
+    128,
+    128,
+    3>;
 typealias InVec = WaveTangledVector<half, ShMemSizeLayer, 2, SubgroupSize, WARPS>;
 typealias HidVec = WaveTangledVector<half, ShMemSizeLayer, 128, SubgroupSize, WARPS>;
 typealias OutVec = WaveTangledVector<half, ShMemSizeLayer, 3, SubgroupSize, WARPS>;

--- a/tests/neural/activation-coopmat-vector-test.slang
+++ b/tests/neural/activation-coopmat-vector-test.slang
@@ -17,9 +17,15 @@ static const int VecSize = 3;
 static const int SubgroupSize = 32;
 static const int BatchSize = 32;
 
-typealias ShMemSize = SharedMemorySize<ElementType, TargetEnum.CUDA, ExecutionMode.Inference, SubgroupSize, BatchSize / SubgroupSize>;
 // Use a dummy layer size for shared memory calculation (we only need minimal shared memory for activations)
-typealias ShMemSizeLayer = ShMemSize.OfLayer1<VecSize, VecSize>;
+typealias ShMemSizeLayer = SharedMemorySize<
+    ElementType,
+    TargetEnum.CUDA,
+    ExecutionMode.Inference,
+    SubgroupSize,
+    BatchSize / SubgroupSize,
+    VecSize,
+    VecSize>;
 typealias Vec3 = WaveTangledVector<ElementType, ShMemSizeLayer, VecSize, SubgroupSize, 1>;
 
 // Helper: check if two floats are approximately equal

--- a/tests/neural/basic-coopmat-vector-test.slang
+++ b/tests/neural/basic-coopmat-vector-test.slang
@@ -52,8 +52,14 @@ static const int BatchSize = 32;
 static const int SubgroupSize = 32;
 static const int workgroupCount = BatchSize / SubgroupSize;
 
-typealias ShMemSize = SharedMemorySize<ElementType, TargetEnum.CUDA, ExecutionMode.Training, SubgroupSize, workgroupCount>;
-typealias ShMemSizeLayer1 = ShMemSize.OfLayer1<InputSize, OutputSize>;
+typealias ShMemSizeLayer1 = SharedMemorySize<
+    ElementType,
+    TargetEnum.CUDA,
+    ExecutionMode.Training,
+    SubgroupSize,
+    workgroupCount,
+    InputSize,
+    OutputSize>;
 
 typealias SPtr<T> = Ptr<T, Access::ReadWrite, AddressSpace::GroupShared>;
 

--- a/tests/neural/basic-coopmat-vector-tiled-layout-test.slang
+++ b/tests/neural/basic-coopmat-vector-tiled-layout-test.slang
@@ -59,8 +59,14 @@ static const int BatchSize = 32;
 static const int SubgroupSize = 32;
 static const int workgroupCount = BatchSize / SubgroupSize;
 
-typealias ShMemSize = SharedMemorySize<ElementType, TargetEnum.CUDA, ExecutionMode.Training, SubgroupSize, workgroupCount>;
-typealias ShMemSizeLayer1 = ShMemSize.OfLayer1<InputSize, OutputSize>;
+typealias ShMemSizeLayer1 = SharedMemorySize<
+    ElementType,
+    TargetEnum.CUDA,
+    ExecutionMode.Training,
+    SubgroupSize,
+    workgroupCount,
+    InputSize,
+    OutputSize>;
 
 void setupParameters(uint tid)
 {

--- a/tests/neural/bias-sum-reduce.slang
+++ b/tests/neural/bias-sum-reduce.slang
@@ -26,8 +26,14 @@ static const int workgroupCount = WorkgroupSize / SubgroupSize;
 static const int InputSize = 8;
 static const int MaxOutputSize = 64;
 
-typealias ShMemSize = SharedMemorySize< DType, TargetEnum.CUDA, ExecutionMode.Training, SubgroupSize, workgroupCount>;
-typealias Layer1 = ShMemSize.OfLayer1<InputSize, MaxOutputSize>;
+typealias Layer1 = SharedMemorySize<
+    DType,
+    TargetEnum.CUDA,
+    ExecutionMode.Training,
+    SubgroupSize,
+    workgroupCount,
+    InputSize,
+    MaxOutputSize>;
 
 void test<int OutputSize>(uint tid, uint resIndex)
 {

--- a/tests/neural/fflayer-wavetangled-vector-test.slang
+++ b/tests/neural/fflayer-wavetangled-vector-test.slang
@@ -71,8 +71,14 @@ static const int SubgroupSize = 32;
 static const int WarpCount = WARP_COUNT;
 static const int BatchSize = WarpCount * SubgroupSize;
 
-typealias ShMemSize = SharedMemorySize<ElementType, TargetEnum.CUDA, ExecutionMode.Training, SubgroupSize, WarpCount>;
-typealias ShMemSizeLayer1 = ShMemSize.OfLayer1<InputSize, OutputSize>;
+typealias ShMemSizeLayer1 = SharedMemorySize<
+    ElementType,
+    TargetEnum.CUDA,
+    ExecutionMode.Training,
+    SubgroupSize,
+    WarpCount,
+    InputSize,
+    OutputSize>;
 typealias InVec = WaveTangledVector<ElementType, ShMemSizeLayer1, InputSize, SubgroupSize, WarpCount>;
 typealias OutVec = WaveTangledVector<ElementType, ShMemSizeLayer1, OutputSize, SubgroupSize, WarpCount>;
 

--- a/tests/neural/fflayer-wavetangled-vector-tiled-test.slang
+++ b/tests/neural/fflayer-wavetangled-vector-tiled-test.slang
@@ -49,8 +49,14 @@ static const int SubgroupSize = 32;
 static const int WarpCount = WARP_COUNT;
 static const int BatchSize = WarpCount * SubgroupSize;
 
-typealias ShMemSize = SharedMemorySize<ElementType, TargetEnum.CUDA, ExecutionMode.Training, SubgroupSize, WarpCount>;
-typealias ShMemSizeLayer1 = ShMemSize.OfLayer1<InputSize, OutputSize>;
+typealias ShMemSizeLayer1 = SharedMemorySize<
+    ElementType,
+    TargetEnum.CUDA,
+    ExecutionMode.Training,
+    SubgroupSize,
+    WarpCount,
+    InputSize,
+    OutputSize>;
 typealias InVec = WaveTangledVector<ElementType, ShMemSizeLayer1, InputSize, SubgroupSize, WarpCount>;
 typealias OutVec = WaveTangledVector<ElementType, ShMemSizeLayer1, OutputSize, SubgroupSize, WarpCount>;
 

--- a/tests/neural/shared-memory-size.slang
+++ b/tests/neural/shared-memory-size.slang
@@ -6,8 +6,8 @@
 // Test that given the layer configuration, thread count, data type, subgroup size, and execution mode, the shared memory required is correctly
 // calculated during compile time.
 
-// SharedMemorySize<DType, TargetEnum, ExecutionMode, SubgroupSize, SubgroupCount>.OfHiddenN<LayerConfiguration>.Bytes
-// is the compile time (or link time) constant that represents the total shared memory needed for launcing the inference kernel or training kernel.
+// SharedMemorySize<DType, TargetEnum, ExecutionMode, SubgroupSize, SubgroupCount, LayerConfiguration>.Bytes
+// is the compile time (or link time) constant that represents the total shared memory needed for launching the inference kernel or training kernel.
 
 import slang.neural;
 #pragma warning(disable: 41017)
@@ -177,17 +177,40 @@ uint verifySize<ExecutionMode Mode, each T, each U>(expand each T a, expand each
 #define TEST_CASE_16_PAIR_1 14U, 3U, 49U, 8U, 37U, 6U, 28U, 11U, 41U, 2U, 33U, 17U, 55U, 9U, 44U, 12U
 #define TEST_CASE_16_PAIR_2 3U, 49U, 8U, 37U, 6U, 28U, 11U, 41U, 2U, 33U, 17U, 55U, 9U, 44U, 12U, 29U
 
-#define RunTest(N) \
+#define RunTestForTarget(TARGET, N) \
 do { \
     uint expectedValue = verifySize<ExecutionMode.Inference>(TEST_CASE_##N##_PAIR_1, TEST_CASE_##N##_PAIR_2); \
-    uint actualValue = SharedMemorySizeInference.OfLayer##N<TEST_CASE_##N>.Bytes; \
+    uint actualValue = SharedMemorySize< \
+        DType, TARGET, ExecutionMode.Inference, SubgroupSize, BatchSize / SubgroupSize, \
+        TEST_CASE_##N>.Bytes; \
     bool isCorrect = expectedValue == actualValue; \
-    actualValue = SharedMemorySizeTraining.OfLayer##N<TEST_CASE_##N>.Bytes; \
+    actualValue = SharedMemorySize< \
+        DType, TARGET, ExecutionMode.Training, SubgroupSize, BatchSize / SubgroupSize, \
+        TEST_CASE_##N>.Bytes; \
     expectedValue = verifySize<ExecutionMode.Training>(TEST_CASE_##N##_PAIR_1, TEST_CASE_##N##_PAIR_2); \
     isCorrect = isCorrect && (expectedValue == actualValue); \
     outputBuffer[N-1] = isCorrect ? 1U : 0U; \
 } while (false)
 
+#define RunAllTestsForTarget(TARGET) \
+do { \
+    RunTestForTarget(TARGET, 1); \
+    RunTestForTarget(TARGET, 2); \
+    RunTestForTarget(TARGET, 3); \
+    RunTestForTarget(TARGET, 4); \
+    RunTestForTarget(TARGET, 5); \
+    RunTestForTarget(TARGET, 6); \
+    RunTestForTarget(TARGET, 7); \
+    RunTestForTarget(TARGET, 8); \
+    RunTestForTarget(TARGET, 9); \
+    RunTestForTarget(TARGET, 10); \
+    RunTestForTarget(TARGET, 11); \
+    RunTestForTarget(TARGET, 12); \
+    RunTestForTarget(TARGET, 13); \
+    RunTestForTarget(TARGET, 14); \
+    RunTestForTarget(TARGET, 15); \
+    RunTestForTarget(TARGET, 16); \
+} while (false)
 
 [numthreads(1, 1, 1)]
 [shader("compute")]
@@ -196,43 +219,9 @@ void computeMain(uint tid: SV_DispatchThreadID)
     __target_switch
     {
     case cuda:
-        typealias SharedMemorySizeInference = SharedMemorySize<DType, TargetEnum.CUDA, ExecutionMode.Inference, SubgroupSize, BatchSize/SubgroupSize>;
-        typealias SharedMemorySizeTraining = SharedMemorySize< DType, TargetEnum.CUDA, ExecutionMode.Training, SubgroupSize, BatchSize/SubgroupSize>;
-        RunTest(1);
-        RunTest(2);
-        RunTest(3);
-        RunTest(4);
-        RunTest(5);
-        RunTest(6);
-        RunTest(7);
-        RunTest(8);
-        RunTest(9);
-        RunTest(10);
-        RunTest(11);
-        RunTest(12);
-        RunTest(13);
-        RunTest(14);
-        RunTest(15);
-        RunTest(16);
+        RunAllTestsForTarget(TargetEnum.CUDA);
     case spirv:
-        typealias SharedMemorySizeInference = SharedMemorySize<DType, TargetEnum.SPIR_V, ExecutionMode.Inference, SubgroupSize, BatchSize/SubgroupSize>;
-        typealias SharedMemorySizeTraining = SharedMemorySize< DType, TargetEnum.SPIR_V, ExecutionMode.Training, SubgroupSize, BatchSize/SubgroupSize>;
-        RunTest(1);
-        RunTest(2);
-        RunTest(3);
-        RunTest(4);
-        RunTest(5);
-        RunTest(6);
-        RunTest(7);
-        RunTest(8);
-        RunTest(9);
-        RunTest(10);
-        RunTest(11);
-        RunTest(12);
-        RunTest(13);
-        RunTest(14);
-        RunTest(15);
-        RunTest(16);
+        RunAllTestsForTarget(TargetEnum.SPIR_V);
     }
 
     // BUFFER: 1

--- a/tests/neural/shared-memory-variadic-min-layer-diagnose.slang
+++ b/tests/neural/shared-memory-variadic-min-layer-diagnose.slang
@@ -1,0 +1,10 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -experimental-feature
+
+import slang.neural;
+
+typealias TooFewLayers =
+    SharedMemorySize<float, TargetEnum.CUDA, ExecutionMode.Inference, 32, 2, 64>;
+/*CHECK:
+    ^^^^^^^^^^^^^^^^ cannot specialize generic
+    ^^^^^^^^^^^^^^^^ cannot specialize generic 'SharedMemorySize' with the provided arguments.
+*/


### PR DESCRIPTION
## Summary
- Replace the macro-generated SharedMemorySize.OfLayerN API with a direct variadic layer-size sequence.
- Keep per-layer shared-memory math internal while exposing SharedMemorySize<..., FirstLayerSize, SecondLayerSize, each RestLayerSize>.Bytes.
- Update neural tests and bug repros to use the new API.
- Add a diagnostic test for fewer than two layer sizes.

Closes #11253

## Testing
- cmake --build build --config Release --target slang-neural-module --parallel 8
- build/Release/bin/slang-test tests/neural/shared-memory-size.slang tests/neural/shared-memory-variadic-min-layer-diagnose.slang
- build/Release/bin/slang-test tests/neural/activation-coopmat-vector-test.slang tests/neural/basic-coopmat-vector-test.slang tests/neural/basic-coopmat-vector-tiled-layout-test.slang tests/neural/fflayer-wavetangled-vector-test.slang tests/neural/fflayer-wavetangled-vector-tiled-test.slang tests/neural/bias-sum-reduce.slang tests/bugs/neural-autodiff-constexpr-crash.slang tests/bugs/neural-autodiff-constexpr-crash-full.slang