### PR TITLE
Limit replay stream array decoding

### DIFF
--- a/source/slang-record-replay/replay-stream-decoder.cpp
+++ b/source/slang-record-replay/replay-stream-decoder.cpp
@@ -10,6 +10,50 @@ namespace SlangRecord
 using Slang::String;
 using Slang::StringBuilder;
 
+namespace
+{
+
+static const int kMaxReplayDecodeNestingDepth = 64;
+static const uint64_t kMaxReplayDecodeArrayElementCount = 1000000;
+static const uint64_t kMaxDisplayedArrayElementCount = 100;
+
+void checkReplayDecodeNestingDepth(int recursionDepth)
+{
+    if (recursionDepth > kMaxReplayDecodeNestingDepth)
+        throw Slang::Exception("Maximum replay decode nesting depth exceeded");
+}
+
+void validateReplayDecodeArrayElementCount(ReplayStream& stream, uint64_t count)
+{
+    if (count > kMaxReplayDecodeArrayElementCount)
+        throw Slang::Exception("Array element count exceeds decoder limit");
+
+    size_t position = stream.getPosition();
+    size_t size = stream.getSize();
+    uint64_t remainingBytes = position < size ? uint64_t(size - position) : 0;
+
+    // Each serialized array element has at least a one-byte TypeId. Reject impossible counts
+    // before recursively walking the array.
+    if (count > remainingBytes)
+        throw Slang::Exception("Array element count exceeds remaining stream bytes");
+}
+
+uint64_t readReplayDecodeArrayElementCount(ReplayStream& stream)
+{
+    uint8_t countTypeValue;
+    stream.read(&countTypeValue, sizeof(countTypeValue));
+    TypeId countType = static_cast<TypeId>(countTypeValue);
+    if (countType != TypeId::UInt64)
+        throw Slang::Exception("Array element count has invalid type");
+
+    uint64_t count;
+    stream.read(&count, sizeof(count));
+    validateReplayDecodeArrayElementCount(stream, count);
+    return count;
+}
+
+} // namespace
+
 // =============================================================================
 // Public Static API - Full Stream Decoding
 // =============================================================================
@@ -143,6 +187,17 @@ void ReplayStreamDecoder::decodeValueFromStream(
     StringBuilder& output,
     int indentLevel)
 {
+    decodeValueFromStream(stream, output, indentLevel, 0);
+}
+
+void ReplayStreamDecoder::decodeValueFromStream(
+    ReplayStream& stream,
+    StringBuilder& output,
+    int indentLevel,
+    int recursionDepth)
+{
+    checkReplayDecodeNestingDepth(recursionDepth);
+
     TypeId type = readTypeId(stream);
 
     switch (type)
@@ -370,26 +425,26 @@ void ReplayStreamDecoder::decodeValueFromStream(
 
     case TypeId::Array:
         {
-            uint64_t count;
-            stream.skip(1); // the type of the count (1B, should be TypeId::UInt64)
-            stream.read(&count, sizeof(count));
+            uint64_t count = readReplayDecodeArrayElementCount(stream);
 
             output << "Array[" << count << "]:";
-            for (uint64_t i = 0; i < count && i < 100; i++)
+            uint64_t displayedCount =
+                count < kMaxDisplayedArrayElementCount ? count : kMaxDisplayedArrayElementCount;
+            for (uint64_t i = 0; i < displayedCount; i++)
             {
                 output << "\n";
                 indent(output, indentLevel + 1);
                 output << "[" << i << "] ";
-                decodeValueFromStream(stream, output, indentLevel + 1);
+                decodeValueFromStream(stream, output, indentLevel + 1, recursionDepth + 1);
             }
-            if (count > 100)
+            if (count > kMaxDisplayedArrayElementCount)
             {
                 output << "\n";
                 indent(output, indentLevel + 1);
-                output << "... (" << (count - 100) << " more elements)";
+                output << "... (" << (count - kMaxDisplayedArrayElementCount) << " more elements)";
                 // Skip remaining elements
-                for (uint64_t i = 100; i < count; ++i)
-                    skipValueInStream(stream);
+                for (uint64_t i = kMaxDisplayedArrayElementCount; i < count; ++i)
+                    skipValueInStream(stream, recursionDepth + 1);
             }
         }
         break;
@@ -479,6 +534,13 @@ void ReplayStreamDecoder::decodeByteRange(
 
 void ReplayStreamDecoder::skipValueInStream(ReplayStream& stream)
 {
+    skipValueInStream(stream, 0);
+}
+
+void ReplayStreamDecoder::skipValueInStream(ReplayStream& stream, int recursionDepth)
+{
+    checkReplayDecodeNestingDepth(recursionDepth);
+
     TypeId type = readTypeId(stream);
 
     switch (type)
@@ -548,11 +610,9 @@ void ReplayStreamDecoder::skipValueInStream(ReplayStream& stream)
 
     case TypeId::Array:
         {
-            uint64_t count;
-            stream.skip(1); // the type of the count (1B, should be TypeId::UInt64)
-            stream.read(&count, sizeof(count));
+            uint64_t count = readReplayDecodeArrayElementCount(stream);
             for (uint64_t i = 0; i < count; i++)
-                skipValueInStream(stream);
+                skipValueInStream(stream, recursionDepth + 1);
         }
         break;
 

--- a/source/slang-record-replay/replay-stream-decoder.cpp
+++ b/source/slang-record-replay/replay-stream-decoder.cpp
@@ -13,20 +13,37 @@ using Slang::StringBuilder;
 namespace
 {
 
+// Nested arrays are legal in replay streams, but decoder recursion still needs a hard
+// ceiling so malformed input cannot exhaust the process stack.
 static const int kMaxReplayDecodeNestingDepth = 64;
+
+// Replay array counts come from the input file. Cap the logical element count so a
+// well-sized but malicious stream cannot make the decoder spend unbounded CPU in
+// decodeValueFromStream or skipValueInStream.
 static const uint64_t kMaxReplayDecodeArrayElementCount = 1000000;
+
+// Keep text dumps useful and bounded: display the first elements, then skip the rest
+// through the same guarded traversal used by ordinary skipping.
 static const uint64_t kMaxDisplayedArrayElementCount = 100;
+
+void reportReplayDecodeError(const char* message)
+{
+    // These checks reject malformed external replay data. Use the decoder's existing
+    // exception path so public dump APIs can catch and print an ERROR line; a
+    // SLANG_RELEASE_ASSERT would turn a bad replay file into a process abort.
+    throw Slang::Exception(message);
+}
 
 void checkReplayDecodeNestingDepth(int recursionDepth)
 {
     if (recursionDepth > kMaxReplayDecodeNestingDepth)
-        throw Slang::Exception("Maximum replay decode nesting depth exceeded");
+        reportReplayDecodeError("Maximum replay decode nesting depth exceeded");
 }
 
 void validateReplayDecodeArrayElementCount(ReplayStream& stream, uint64_t count)
 {
     if (count > kMaxReplayDecodeArrayElementCount)
-        throw Slang::Exception("Array element count exceeds decoder limit");
+        reportReplayDecodeError("Array element count exceeds decoder limit");
 
     size_t position = stream.getPosition();
     size_t size = stream.getSize();
@@ -35,7 +52,7 @@ void validateReplayDecodeArrayElementCount(ReplayStream& stream, uint64_t count)
     // Each serialized array element has at least a one-byte TypeId. Reject impossible counts
     // before recursively walking the array.
     if (count > remainingBytes)
-        throw Slang::Exception("Array element count exceeds remaining stream bytes");
+        reportReplayDecodeError("Array element count exceeds remaining stream bytes");
 }
 
 uint64_t readReplayDecodeArrayElementCount(ReplayStream& stream)
@@ -44,7 +61,7 @@ uint64_t readReplayDecodeArrayElementCount(ReplayStream& stream)
     stream.read(&countTypeValue, sizeof(countTypeValue));
     TypeId countType = static_cast<TypeId>(countTypeValue);
     if (countType != TypeId::UInt64)
-        throw Slang::Exception("Array element count has invalid type");
+        reportReplayDecodeError("Array element count has invalid type");
 
     uint64_t count;
     stream.read(&count, sizeof(count));

--- a/source/slang-record-replay/replay-stream-decoder.cpp
+++ b/source/slang-record-replay/replay-stream-decoder.cpp
@@ -483,7 +483,14 @@ String ReplayStreamDecoder::decodeValueFromBytes(const void* data, size_t size)
 {
     ReplayStream stream(data, size);
     StringBuilder output;
-    decodeValueFromStream(stream, output, 0);
+    try
+    {
+        decodeValueFromStream(stream, output, 0);
+    }
+    catch (const Slang::Exception& e)
+    {
+        output << "ERROR: " << e.Message.getBuffer();
+    }
     return output.produceString();
 }
 

--- a/source/slang-record-replay/replay-stream-decoder.h
+++ b/source/slang-record-replay/replay-stream-decoder.h
@@ -105,6 +105,12 @@ private:
 
     static TypeId peekTypeId(ReplayStream& stream);
     static TypeId readTypeId(ReplayStream& stream);
+    static void decodeValueFromStream(
+        ReplayStream& stream,
+        Slang::StringBuilder& output,
+        int indentLevel,
+        int recursionDepth);
+    static void skipValueInStream(ReplayStream& stream, int recursionDepth);
 
     static void indent(Slang::StringBuilder& output, int level);
     static void appendHexDump(

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -405,6 +405,7 @@ if(SLANG_ENABLE_TESTS AND SLANG_ENABLE_SLANG_RHI)
             SLANG_NO_DEPRECATION
         USE_FEWER_WARNINGS
         LINK_WITH_PRIVATE core compiler-core unit-test slang Threads::Threads
+        INCLUDE_DIRECTORIES_PRIVATE ${slang_SOURCE_DIR}/source
         PRECOMPILE_HEADERS ${SLANG_TOOLS_PCH}
         OUTPUT_NAME slang-unit-test-tool
         FOLDER test/tools

--- a/tools/slang-unit-test/unit-test-replay-stream-decoder.cpp
+++ b/tools/slang-unit-test/unit-test-replay-stream-decoder.cpp
@@ -56,3 +56,52 @@ SLANG_UNIT_TEST(replayStreamDecoderBoundsSkippedArrayDepth)
 
     SLANG_CHECK(containsString(decoded, "Maximum replay decode nesting depth exceeded"));
 }
+
+SLANG_UNIT_TEST(replayStreamDecoderBoundsDecodedArrayDepth)
+{
+    // Nest arrays deeper than kMaxReplayDecodeNestingDepth with count=1 at every
+    // level so traversal stays on the decode path (i < kMaxDisplayedArrayElementCount)
+    // and exercises checkReplayDecodeNestingDepth inside decodeValueFromStream,
+    // complementing the skip-path coverage above.
+    ReplayStream stream;
+    for (int i = 0; i < 70; ++i)
+        writeArrayHeader(stream, 1);
+    writeReplayTypeId(stream, TypeId::Null);
+
+    ReplayStream reader = stream.createReader();
+    String decoded = ReplayStreamDecoder::decode(reader);
+
+    SLANG_CHECK(containsString(decoded, "Maximum replay decode nesting depth exceeded"));
+}
+
+SLANG_UNIT_TEST(replayStreamDecoderRejectsArrayLargerThanStream)
+{
+    // Count fits under the 1M element cap but exceeds the bytes remaining in the
+    // stream, so validateReplayDecodeArrayElementCount must reach the
+    // count > remainingBytes guard. This is the realistic attack: the cap alone
+    // would still let a small-but-too-large count slip through.
+    ReplayStream stream;
+    writeArrayHeader(stream, 500);
+    writeReplayTypeId(stream, TypeId::Null);
+
+    ReplayStream reader = stream.createReader();
+    String decoded = ReplayStreamDecoder::decode(reader);
+
+    SLANG_CHECK(containsString(decoded, "exceeds remaining stream bytes"));
+}
+
+SLANG_UNIT_TEST(replayStreamDecoderRejectsInvalidArrayCountType)
+{
+    // The pre-PR code blindly skipped the count's TypeId byte. The new
+    // readReplayDecodeArrayElementCount rejects anything other than UInt64;
+    // pin that behavior so a future refactor cannot silently weaken it.
+    ReplayStream stream;
+    writeReplayTypeId(stream, TypeId::Array);
+    writeReplayTypeId(stream, TypeId::UInt32);
+    writeUInt64Payload(stream, 0);
+
+    ReplayStream reader = stream.createReader();
+    String decoded = ReplayStreamDecoder::decode(reader);
+
+    SLANG_CHECK(containsString(decoded, "Array element count has invalid type"));
+}

--- a/tools/slang-unit-test/unit-test-replay-stream-decoder.cpp
+++ b/tools/slang-unit-test/unit-test-replay-stream-decoder.cpp
@@ -1,0 +1,58 @@
+#include "../../source/slang-record-replay/replay-stream-decoder.h"
+#include "unit-test/slang-unit-test.h"
+
+#include <cstdint>
+
+using namespace Slang;
+using namespace SlangRecord;
+
+static bool containsString(const String& text, const char* value)
+{
+    return text.indexOf(UnownedStringSlice(value)) != -1;
+}
+
+static void writeReplayTypeId(ReplayStream& stream, TypeId type)
+{
+    uint8_t value = static_cast<uint8_t>(type);
+    stream.write(&value, sizeof(value));
+}
+
+static void writeUInt64Payload(ReplayStream& stream, uint64_t value)
+{
+    stream.write(&value, sizeof(value));
+}
+
+static void writeArrayHeader(ReplayStream& stream, uint64_t count)
+{
+    writeReplayTypeId(stream, TypeId::Array);
+    writeReplayTypeId(stream, TypeId::UInt64);
+    writeUInt64Payload(stream, count);
+}
+
+SLANG_UNIT_TEST(replayStreamDecoderRejectsHugeArrayCount)
+{
+    ReplayStream stream;
+    writeArrayHeader(stream, ~uint64_t(0));
+
+    ReplayStream reader = stream.createReader();
+    String decoded = ReplayStreamDecoder::decode(reader);
+
+    SLANG_CHECK(containsString(decoded, "Array element count exceeds decoder limit"));
+}
+
+SLANG_UNIT_TEST(replayStreamDecoderBoundsSkippedArrayDepth)
+{
+    ReplayStream stream;
+    writeArrayHeader(stream, 101);
+    for (int i = 0; i < 100; ++i)
+        writeReplayTypeId(stream, TypeId::Null);
+
+    for (int i = 0; i < 70; ++i)
+        writeArrayHeader(stream, 1);
+    writeReplayTypeId(stream, TypeId::Null);
+
+    ReplayStream reader = stream.createReader();
+    String decoded = ReplayStreamDecoder::decode(reader);
+
+    SLANG_CHECK(containsString(decoded, "Maximum replay decode nesting depth exceeded"));
+}

--- a/tools/slang-unit-test/unit-test-replay-stream-decoder.cpp
+++ b/tools/slang-unit-test/unit-test-replay-stream-decoder.cpp
@@ -144,6 +144,26 @@ SLANG_UNIT_TEST(replayStreamDecoderRejectsInvalidArrayCountType)
     SLANG_CHECK(containsString(decoded, "Array element count has invalid type"));
 }
 
+SLANG_UNIT_TEST(replayStreamDecoderRejectsHugeArrayCountOnSkipPath)
+{
+    // The decode-path cap test puts the oversized Array[1000001] at top level,
+    // which is decode (not skip). Mirror the depth-on-skip-path pattern: outer
+    // Array[101] forces element 101 through skipValueInStream, where the
+    // nested oversized array trips `count > kMaxReplayDecodeArrayElementCount`.
+    // A regression that splits readReplayDecodeArrayElementCount and weakens
+    // the cap on only the skip path would otherwise sneak by.
+    ReplayStream stream;
+    writeArrayHeader(stream, 101);
+    for (int i = 0; i < 100; ++i)
+        writeReplayTypeId(stream, TypeId::Null);
+    writeArrayHeader(stream, 1000001);
+
+    ReplayStream reader = stream.createReader();
+    String decoded = ReplayStreamDecoder::decode(reader);
+
+    SLANG_CHECK(containsString(decoded, "Array element count exceeds decoder limit"));
+}
+
 SLANG_UNIT_TEST(replayStreamDecoderDecodesValidArray)
 {
     // Happy path: a valid Array of three UInt32 elements must decode cleanly,

--- a/tools/slang-unit-test/unit-test-replay-stream-decoder.cpp
+++ b/tools/slang-unit-test/unit-test-replay-stream-decoder.cpp
@@ -1,4 +1,4 @@
-#include "../../source/slang-record-replay/replay-stream-decoder.h"
+#include "slang-record-replay/replay-stream-decoder.h"
 #include "unit-test/slang-unit-test.h"
 
 #include <cstdint>

--- a/tools/slang-unit-test/unit-test-replay-stream-decoder.cpp
+++ b/tools/slang-unit-test/unit-test-replay-stream-decoder.cpp
@@ -22,6 +22,12 @@ static void writeUInt64Payload(ReplayStream& stream, uint64_t value)
     stream.write(&value, sizeof(value));
 }
 
+static void writeUInt32Value(ReplayStream& stream, uint32_t value)
+{
+    writeReplayTypeId(stream, TypeId::UInt32);
+    stream.write(&value, sizeof(value));
+}
+
 static void writeArrayHeader(ReplayStream& stream, uint64_t count)
 {
     writeReplayTypeId(stream, TypeId::Array);
@@ -31,8 +37,13 @@ static void writeArrayHeader(ReplayStream& stream, uint64_t count)
 
 SLANG_UNIT_TEST(replayStreamDecoderRejectsHugeArrayCount)
 {
+    // Pin the 1,000,000-element cap at the boundary: count = cap + 1 trips the
+    // first guard in validateReplayDecodeArrayElementCount with the cap-specific
+    // error string. A regression that bumps the cap or reorders the cap check
+    // behind the remaining-bytes check would either silence this error string
+    // entirely or change which guard fires first, breaking the test.
     ReplayStream stream;
-    writeArrayHeader(stream, ~uint64_t(0));
+    writeArrayHeader(stream, 1000001);
 
     ReplayStream reader = stream.createReader();
     String decoded = ReplayStreamDecoder::decode(reader);
@@ -42,12 +53,20 @@ SLANG_UNIT_TEST(replayStreamDecoderRejectsHugeArrayCount)
 
 SLANG_UNIT_TEST(replayStreamDecoderBoundsSkippedArrayDepth)
 {
+    // Pin the 64-depth boundary on the skip path. The outer Array[101] places
+    // skipValueInStream calls at depth=1 (since decodeValueFromStream starts at
+    // depth=0). 64 nested Array headers inside the skip-loop payload mean the
+    // recursive skipValueInStream call at depth=65 trips
+    // `recursionDepth > kMaxReplayDecodeNestingDepth` before reading any byte.
+    // Changing the operator from `>` to `>=` (off-by-one regression) would shift
+    // the trip to depth=64 and let this test pass at depth=63 — so any rewrite
+    // of either the constant or the operator breaks this test.
     ReplayStream stream;
     writeArrayHeader(stream, 101);
     for (int i = 0; i < 100; ++i)
         writeReplayTypeId(stream, TypeId::Null);
 
-    for (int i = 0; i < 70; ++i)
+    for (int i = 0; i < 64; ++i)
         writeArrayHeader(stream, 1);
     writeReplayTypeId(stream, TypeId::Null);
 
@@ -59,12 +78,13 @@ SLANG_UNIT_TEST(replayStreamDecoderBoundsSkippedArrayDepth)
 
 SLANG_UNIT_TEST(replayStreamDecoderBoundsDecodedArrayDepth)
 {
-    // Nest arrays deeper than kMaxReplayDecodeNestingDepth with count=1 at every
-    // level so traversal stays on the decode path (i < kMaxDisplayedArrayElementCount)
-    // and exercises checkReplayDecodeNestingDepth inside decodeValueFromStream,
-    // complementing the skip-path coverage above.
+    // Pin the 64-depth boundary on the decode path. decodeValueFromStream
+    // starts at depth=0, so 65 nested Array[1] headers produce a call at
+    // depth=65, which trips `recursionDepth > kMaxReplayDecodeNestingDepth`
+    // before reading. Companion to the at-max-depth happy-path test below
+    // (64 levels must NOT trip the same guard).
     ReplayStream stream;
-    for (int i = 0; i < 70; ++i)
+    for (int i = 0; i < 65; ++i)
         writeArrayHeader(stream, 1);
     writeReplayTypeId(stream, TypeId::Null);
 
@@ -72,6 +92,24 @@ SLANG_UNIT_TEST(replayStreamDecoderBoundsDecodedArrayDepth)
     String decoded = ReplayStreamDecoder::decode(reader);
 
     SLANG_CHECK(containsString(decoded, "Maximum replay decode nesting depth exceeded"));
+}
+
+SLANG_UNIT_TEST(replayStreamDecoderAcceptsArraysAtMaxDepth)
+{
+    // Companion to the boundary test above: 64 nested Array[1] headers reach
+    // exactly depth=64 (`recursionDepth > 64` is false). The decode must
+    // succeed and the depth-exceeded error message must NOT appear. If the
+    // operator were tightened to `>=`, this test would start failing.
+    ReplayStream stream;
+    for (int i = 0; i < 64; ++i)
+        writeArrayHeader(stream, 1);
+    writeReplayTypeId(stream, TypeId::Null);
+
+    ReplayStream reader = stream.createReader();
+    String decoded = ReplayStreamDecoder::decode(reader);
+
+    SLANG_CHECK(!containsString(decoded, "Maximum replay decode nesting depth exceeded"));
+    SLANG_CHECK(!containsString(decoded, "ERROR:"));
 }
 
 SLANG_UNIT_TEST(replayStreamDecoderRejectsArrayLargerThanStream)
@@ -104,4 +142,27 @@ SLANG_UNIT_TEST(replayStreamDecoderRejectsInvalidArrayCountType)
     String decoded = ReplayStreamDecoder::decode(reader);
 
     SLANG_CHECK(containsString(decoded, "Array element count has invalid type"));
+}
+
+SLANG_UNIT_TEST(replayStreamDecoderDecodesValidArray)
+{
+    // Happy path: a valid Array of three UInt32 elements must decode cleanly,
+    // with the element values visible in the output and no error string. This
+    // guards against an over-eager early-throw added to a future bound check
+    // that would silently regress legitimate inputs.
+    ReplayStream stream;
+    writeArrayHeader(stream, 3);
+    writeUInt32Value(stream, 11);
+    writeUInt32Value(stream, 22);
+    writeUInt32Value(stream, 33);
+
+    ReplayStream reader = stream.createReader();
+    String decoded = ReplayStreamDecoder::decode(reader);
+
+    SLANG_CHECK(containsString(decoded, "Array[3]:"));
+    SLANG_CHECK(containsString(decoded, "UInt32: 11"));
+    SLANG_CHECK(containsString(decoded, "UInt32: 22"));
+    SLANG_CHECK(containsString(decoded, "UInt32: 33"));
+    SLANG_CHECK(!containsString(decoded, "ERROR:"));
+    SLANG_CHECK(!containsString(decoded, "exceeds"));
 }


### PR DESCRIPTION
## TLDR
Vulnerability found on the following lines:
```
uint64_t count;
stream.skip(1);
stream.read(&count, sizeof(count));
for (uint64_t i = 0; i < count && i < 100; i++)
for (uint64_t i = 100; i < count; ++i)
    skipValueInStream(stream);
```
In `ReplayStreamDecoder::decodeValueFromStream`, when processing `TypeId::Array`, the code reads a `uint64_t count` from the stream and then recursively calls `decodeValueFromStream` for each element. While there's a display cap of 100 elements, the `skipValueInStream` function is called for remaining elements, and nested arrays can cause deep recursion. More critically, a crafted binary stream could specify a very large count value, causing the decoder to attempt to process billions of elements, leading to excessive CPU consumption (DoS). The `skipValueInStream` for arrays also recursively processes elements without depth limits.

## Summary

The replay-stream decoder previously trusted the array element count and nesting depth read from the stream, making it vulnerable to malformed or malicious streams that could exhaust memory or the stack.

This PR adds three bounds:

- **Element count cap** — reject decoded array counts greater than 1,000,000.
- **Remaining-bytes check** — reject counts that exceed the bytes remaining in the stream (each serialized element is at least a one-byte TypeId, so the count cannot legitimately be larger than the remaining stream length).
- **Recursion depth limit** — cap nested decoding at depth 64 in both `decodeValueFromStream` and `skipValueInStream` to avoid stack exhaustion on deeply nested arrays.

Also validates that the count's `TypeId` is `UInt64` before reading, and replaces magic numbers (`100`) with named constants.

## Test plan

- [ ] CPU unit tests pass (`slang-test slang-unit-test-tool/`)
- [ ] No regressions in existing replay-stream tests