### PR TITLE
Limit zip uncompressed file size to mitigate decompression bombs

### DIFF
--- a/source/core/slang-archive-file-system.h
+++ b/source/core/slang-archive-file-system.h
@@ -6,6 +6,8 @@
 #include "slang-compression-system.h"
 
 // Override at build time to allow larger individual entries in archive-backed file systems.
+// This cap is per loaded entry. Callers that load many entries should enforce their own
+// aggregate uncompressed-byte and entry-count budgets.
 // SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE is kept as a compatibility alias.
 #ifndef SLANG_ARCHIVE_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE
 #ifdef SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE

--- a/source/core/slang-archive-file-system.h
+++ b/source/core/slang-archive-file-system.h
@@ -5,8 +5,33 @@
 #include "slang-com-ptr.h"
 #include "slang-compression-system.h"
 
+// Override at build time to allow larger individual entries in archive-backed file systems.
+// SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE is kept as a compatibility alias.
+#ifndef SLANG_ARCHIVE_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE
+#ifdef SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE
+#define SLANG_ARCHIVE_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE \
+    SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE
+#else
+#define SLANG_ARCHIVE_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE (256ull * 1024ull * 1024ull)
+#endif
+#endif
+
+#ifndef SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE
+#define SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE \
+    SLANG_ARCHIVE_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE
+#endif
+
 namespace Slang
 {
+
+static const UInt64 kMaxArchiveFileUncompressedSize =
+    UInt64(SLANG_ARCHIVE_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE);
+
+static inline bool isArchiveFileUncompressedSizeInBounds(UInt64 size)
+{
+    const UInt64 maxTerminatedAllocationSize = UInt64(~size_t(0) - 1);
+    return size <= kMaxArchiveFileUncompressedSize && size <= maxTerminatedAllocationSize;
+}
 
 class IArchiveFileSystem : public ISlangCastable
 {

--- a/source/core/slang-blob.h
+++ b/source/core/slang-blob.h
@@ -146,8 +146,17 @@ public:
     /// Allocate size including a 0 byte at `size`.
     void* allocateTerminated(size_t size)
     {
-        SLANG_ASSUME(size != std::numeric_limits<size_t>::max());
+        if (size == std::numeric_limits<size_t>::max())
+        {
+            return nullptr;
+        }
+
         uint8_t* data = (uint8_t*)allocate(size + 1);
+        if (!data)
+        {
+            return nullptr;
+        }
+
         data[size] = 0;
         m_sizeInBytes = size;
         return data;

--- a/source/core/slang-blob.h
+++ b/source/core/slang-blob.h
@@ -148,12 +148,17 @@ public:
     {
         if (size == std::numeric_limits<size_t>::max())
         {
+            deallocate();
             return nullptr;
         }
 
         uint8_t* data = (uint8_t*)allocate(size + 1);
         if (!data)
         {
+            // allocate() updates m_sizeInBytes/m_capacityInBytes even when
+            // ::malloc returns nullptr — reset to a fully deallocated state
+            // so callers don't see inconsistent sizes alongside a null buffer.
+            deallocate();
             return nullptr;
         }
 

--- a/source/core/slang-blob.h
+++ b/source/core/slang-blob.h
@@ -305,6 +305,10 @@ public:
         ComPtr<ISlangBlob>& outBlob)
     {
         outBlob.setNull();
+        if (size > 0 && !inData)
+        {
+            return SLANG_E_INVALID_ARG;
+        }
 
         RawBlob* blob = new RawBlob;
         if (!blob->init(inData, size))

--- a/source/core/slang-blob.h
+++ b/source/core/slang-blob.h
@@ -8,6 +8,7 @@
 #include "slang-string.h"
 #include "slang.h"
 
+#include <limits>
 #include <stdarg.h>
 
 namespace Slang
@@ -286,26 +287,50 @@ public:
     }
 
     /// Create a blob that will retain (a copy of) raw data.
+    /// Returns null if allocation fails.
     static inline ComPtr<ISlangBlob> create(void const* inData, size_t size)
     {
-        return ComPtr<ISlangBlob>(new RawBlob(inData, size));
+        ComPtr<ISlangBlob> blob;
+        if (SLANG_FAILED(tryCreate(inData, size, blob)))
+        {
+            return nullptr;
+        }
+        return blob;
+    }
+
+    /// Create a blob that will retain (a copy of) raw data.
+    static inline SlangResult tryCreate(
+        void const* inData,
+        size_t size,
+        ComPtr<ISlangBlob>& outBlob)
+    {
+        outBlob.setNull();
+
+        RawBlob* blob = new RawBlob;
+        if (!blob->init(inData, size))
+        {
+            delete blob;
+            return SLANG_E_OUT_OF_MEMORY;
+        }
+
+        outBlob = ComPtr<ISlangBlob>(blob);
+        return SLANG_OK;
     }
 
 protected:
-    // Ctor
-    // NOTE! Takes a copy of the input data
-    RawBlob(const void* data, size_t size)
+    bool init(const void* data, size_t size)
     {
         void* dst = m_data.allocateTerminated(size);
         if (!dst)
         {
-            return;
+            return false;
         }
 
         if (size > 0)
         {
             memcpy(dst, data, size);
         }
+        return true;
     }
 
     void* getObject(const Guid& guid);

--- a/source/core/slang-blob.h
+++ b/source/core/slang-blob.h
@@ -156,7 +156,7 @@ public:
         if (!data)
         {
             // allocate() updates m_sizeInBytes/m_capacityInBytes even when
-            // ::malloc returns nullptr — reset to a fully deallocated state
+            // ::malloc returns nullptr; reset to a fully deallocated state
             // so callers don't see inconsistent sizes alongside a null buffer.
             deallocate();
             return nullptr;
@@ -296,10 +296,15 @@ protected:
     // NOTE! Takes a copy of the input data
     RawBlob(const void* data, size_t size)
     {
-        m_data.allocateTerminated(size);
+        void* dst = m_data.allocateTerminated(size);
+        if (!dst)
+        {
+            return;
+        }
+
         if (size > 0)
         {
-            memcpy(m_data.getData(), data, size);
+            memcpy(dst, data, size);
         }
     }
 

--- a/source/core/slang-blob.h
+++ b/source/core/slang-blob.h
@@ -304,9 +304,9 @@ public:
         size_t size,
         ComPtr<ISlangBlob>& outBlob)
     {
-        outBlob.setNull();
         if (size > 0 && !inData)
         {
+            outBlob.setNull();
             return SLANG_E_INVALID_ARG;
         }
 
@@ -314,6 +314,7 @@ public:
         if (!blob->init(inData, size))
         {
             delete blob;
+            outBlob.setNull();
             return SLANG_E_OUT_OF_MEMORY;
         }
 

--- a/source/core/slang-memory-file-system.cpp
+++ b/source/core/slang-memory-file-system.cpp
@@ -190,7 +190,8 @@ SlangResult MemoryFileSystem::saveFile(const char* path, const void* data, size_
 {
     Entry* entry;
     SLANG_RETURN_ON_FAIL(_requireFile(path, &entry));
-    auto contents = RawBlob::create(data, size);
+    ComPtr<ISlangBlob> contents;
+    SLANG_RETURN_ON_FAIL(RawBlob::tryCreate(data, size, contents));
     entry->setContents(size, contents);
     return SLANG_OK;
 }

--- a/source/core/slang-riff-file-system.cpp
+++ b/source/core/slang-riff-file-system.cpp
@@ -56,6 +56,10 @@ SlangResult RiffFileSystem::loadFile(char const* path, ISlangBlob** outBlob)
         // Okay lets decompress into a blob
         ScopedAllocation alloc;
         void* dst = alloc.allocateTerminated(entry->m_uncompressedSizeInBytes);
+        if (!dst)
+        {
+            return SLANG_E_OUT_OF_MEMORY;
+        }
         SLANG_RETURN_ON_FAIL(m_compressionSystem->decompress(
             contents->getBufferPointer(),
             contents->getBufferSize(),

--- a/source/core/slang-riff-file-system.cpp
+++ b/source/core/slang-riff-file-system.cpp
@@ -54,6 +54,11 @@ SlangResult RiffFileSystem::loadFile(char const* path, ISlangBlob** outBlob)
     if (m_compressionSystem)
     {
         // Okay lets decompress into a blob
+        if (!isArchiveFileUncompressedSizeInBounds(UInt64(entry->m_uncompressedSizeInBytes)))
+        {
+            return SLANG_E_OUT_OF_MEMORY;
+        }
+
         ScopedAllocation alloc;
         void* dst = alloc.allocateTerminated(entry->m_uncompressedSizeInBytes);
         if (!dst)
@@ -95,7 +100,7 @@ SlangResult RiffFileSystem::saveFile(const char* path, const void* data, size_t 
     else
     {
         // Just store the data directly.
-        contents = RawBlob::create(data, size);
+        SLANG_RETURN_ON_FAIL(RawBlob::tryCreate(data, size, contents));
     }
     entry->setContents(size, contents);
     return SLANG_OK;
@@ -211,8 +216,10 @@ SlangResult RiffFileSystem::loadArchive(const void* archive, size_t archiveSizeI
                     }
 
                     // Get the compressed data
-                    dstEntry.m_contents =
-                        RawBlob::create(reader.getRemainingData(), srcEntry.compressedSize);
+                    SLANG_RETURN_ON_FAIL(RawBlob::tryCreate(
+                        reader.getRemainingData(),
+                        srcEntry.compressedSize,
+                        dstEntry.m_contents));
                     break;
                 }
             case SLANG_PATH_TYPE_DIRECTORY:

--- a/source/core/slang-zip-file-system.cpp
+++ b/source/core/slang-zip-file-system.cpp
@@ -10,14 +10,10 @@
 #include "slang-string-util.h"
 #include "slang-uint-set.h"
 
-#include <limits>
 #include <miniz.h>
 
 namespace Slang
 {
-
-static const mz_uint64 kMaxZipFileUncompressedSize =
-    mz_uint64(SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE);
 
 class ZipFileSystemImpl : public ComBaseObject,
                           public ISlangMutableFileSystem,
@@ -491,8 +487,7 @@ SlangResult ZipFileSystemImpl::loadFile(char const* path, ISlangBlob** outBlob)
         return SLANG_E_NOT_FOUND;
     }
 
-    if (fileStat.m_uncomp_size > kMaxZipFileUncompressedSize ||
-        fileStat.m_uncomp_size > mz_uint64(std::numeric_limits<size_t>::max() - 1))
+    if (!isArchiveFileUncompressedSizeInBounds(UInt64(fileStat.m_uncomp_size)))
     {
         return SLANG_E_OUT_OF_MEMORY;
     }
@@ -827,7 +822,8 @@ SlangResult ZipFileSystemImpl::storeArchive(bool blobOwnsContent, ISlangBlob** o
     if (blobOwnsContent)
     {
         // Takes a copy
-        blob = RawBlob::create(m_data.getData(), Index(m_data.getSizeInBytes()));
+        SLANG_RETURN_ON_FAIL(
+            RawBlob::tryCreate(m_data.getData(), Index(m_data.getSizeInBytes()), blob));
     }
     else
     {

--- a/source/core/slang-zip-file-system.cpp
+++ b/source/core/slang-zip-file-system.cpp
@@ -10,9 +10,8 @@
 #include "slang-string-util.h"
 #include "slang-uint-set.h"
 
-#include <miniz.h>
-
 #include <limits>
+#include <miniz.h>
 
 namespace Slang
 {

--- a/source/core/slang-zip-file-system.cpp
+++ b/source/core/slang-zip-file-system.cpp
@@ -12,8 +12,13 @@
 
 #include <miniz.h>
 
+#include <limits>
+
 namespace Slang
 {
+
+static const mz_uint64 kMaxZipFileUncompressedSize =
+    mz_uint64(SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE);
 
 class ZipFileSystemImpl : public ComBaseObject,
                           public ISlangMutableFileSystem,
@@ -485,6 +490,12 @@ SlangResult ZipFileSystemImpl::loadFile(char const* path, ISlangBlob** outBlob)
     if (!mz_zip_reader_file_stat(&m_archive, index, &fileStat) || fileStat.m_is_directory)
     {
         return SLANG_E_NOT_FOUND;
+    }
+
+    if (fileStat.m_uncomp_size > kMaxZipFileUncompressedSize ||
+        fileStat.m_uncomp_size > mz_uint64(std::numeric_limits<size_t>::max() - 1))
+    {
+        return SLANG_E_OUT_OF_MEMORY;
     }
 
     ScopedAllocation alloc;

--- a/source/core/slang-zip-file-system.h
+++ b/source/core/slang-zip-file-system.h
@@ -4,11 +4,6 @@
 #include "slang-archive-file-system.h"
 #include "slang-basic.h"
 
-// Override at build time to allow larger individual entries.
-#ifndef SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE
-#define SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE (256ull * 1024ull * 1024ull)
-#endif
-
 namespace Slang
 {
 

--- a/source/core/slang-zip-file-system.h
+++ b/source/core/slang-zip-file-system.h
@@ -4,6 +4,11 @@
 #include "slang-archive-file-system.h"
 #include "slang-basic.h"
 
+// Override at build time to allow larger individual entries.
+#ifndef SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE
+#define SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE (256ull * 1024ull * 1024ull)
+#endif
+
 namespace Slang
 {
 

--- a/tools/slang-unit-test/unit-test-file-system.cpp
+++ b/tools/slang-unit-test/unit-test-file-system.cpp
@@ -391,7 +391,13 @@ static SlangResult _createFileSystem(
     return outFileSystem ? SLANG_OK : SLANG_FAIL;
 }
 
-#if SLANG_ARCHIVE_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE < 0xffffffffull
+// The ZIP and RIFF patchers below write legacy 32-bit uncompressed-size fields. If the
+// configured cap cannot be exceeded with those fields, the end-to-end rejection tests report
+// as ignored instead of silently passing.
+#define SLANG_CAN_PATCH_ARCHIVE_BOMB_SIZE \
+    (SLANG_ARCHIVE_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE < 0xffffffffull)
+
+#if SLANG_CAN_PATCH_ARCHIVE_BOMB_SIZE
 static uint32_t _readUInt32LE(const uint8_t* data)
 {
     return uint32_t(data[0]) | (uint32_t(data[1]) << 8) | (uint32_t(data[2]) << 16) |
@@ -571,6 +577,9 @@ static SlangResult _testArchiveUncompressedSizeBounds()
                                         ? kMaxArchiveFileUncompressedSize
                                         : maxTerminatedAllocationSize;
 
+    // Keep the exact-cap check at the predicate level. An end-to-end success case at the
+    // default cap would allocate the full cap-sized output buffer, while patching a small
+    // archive's metadata to the cap is not a valid positive decompression fixture.
     SLANG_CHECK(isArchiveFileUncompressedSizeInBounds(effectiveMaxSize));
     SLANG_CHECK(!isArchiveFileUncompressedSizeInBounds(effectiveMaxSize + 1));
     return SLANG_OK;
@@ -592,16 +601,20 @@ static SlangResult _testScopedAllocationRejectsMaxTerminatedSize()
     SLANG_CHECK(!blob);
 
     const char replacementContents[] = "replacement";
-    SLANG_RETURN_ON_FAIL(RawBlob::tryCreate(
-        replacementContents,
-        sizeof(replacementContents) - 1,
-        blob));
     SLANG_RETURN_ON_FAIL(
-        RawBlob::tryCreate(blob->getBufferPointer(), blob->getBufferSize(), blob));
+        RawBlob::tryCreate(replacementContents, sizeof(replacementContents) - 1, blob));
+    SLANG_RETURN_ON_FAIL(RawBlob::tryCreate(blob->getBufferPointer(), blob->getBufferSize(), blob));
     SLANG_CHECK(blob->getBufferSize() == sizeof(replacementContents) - 1);
     SLANG_CHECK(
         ::memcmp(blob->getBufferPointer(), replacementContents, blob->getBufferSize()) == 0);
 
+    return SLANG_OK;
+}
+
+static SlangResult _testMemoryFileSystemRejectsNullNonEmptySave()
+{
+    ComPtr<ISlangMutableFileSystem> fileSystem(new MemoryFileSystem);
+    SLANG_CHECK(fileSystem->saveFile("foo", nullptr, 1) == SLANG_E_INVALID_ARG);
     return SLANG_OK;
 }
 
@@ -795,7 +808,7 @@ SLANG_UNIT_TEST(fileSystem)
 
 SLANG_UNIT_TEST(zipRejectsOversizedUncompressedEntry)
 {
-#if SLANG_ARCHIVE_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE < 0xffffffffull
+#if SLANG_CAN_PATCH_ARCHIVE_BOMB_SIZE
     SLANG_CHECK(SLANG_SUCCEEDED(_testZipRejectsOversizedUncompressedEntry()));
 #else
     SLANG_IGNORE_TEST;
@@ -804,7 +817,7 @@ SLANG_UNIT_TEST(zipRejectsOversizedUncompressedEntry)
 
 SLANG_UNIT_TEST(riffRejectsOversizedUncompressedEntry)
 {
-#if SLANG_ARCHIVE_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE < 0xffffffffull
+#if SLANG_CAN_PATCH_ARCHIVE_BOMB_SIZE
     SLANG_CHECK(SLANG_SUCCEEDED(_testRiffRejectsOversizedUncompressedEntry()));
 #else
     SLANG_IGNORE_TEST;
@@ -819,4 +832,9 @@ SLANG_UNIT_TEST(archiveUncompressedSizeBounds)
 SLANG_UNIT_TEST(scopedAllocationRejectsMaxTerminatedSize)
 {
     SLANG_CHECK(SLANG_SUCCEEDED(_testScopedAllocationRejectsMaxTerminatedSize()));
+}
+
+SLANG_UNIT_TEST(memoryFileSystemRejectsNullNonEmptySave)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_testMemoryFileSystemRejectsNullNonEmptySave()));
 }

--- a/tools/slang-unit-test/unit-test-file-system.cpp
+++ b/tools/slang-unit-test/unit-test-file-system.cpp
@@ -408,8 +408,8 @@ static SlangResult _setZipEntryUncompressedSize(List<uint8_t>& archiveData, uint
     static const uint32_t kLocalFileHeaderSignature = 0x04034b50;
     static const uint32_t kCentralDirectoryHeaderSignature = 0x02014b50;
 
-    bool foundLocalHeader = false;
-    bool foundCentralDirectoryHeader = false;
+    Index localHeaderCount = 0;
+    Index centralDirectoryHeaderCount = 0;
 
     uint8_t* data = archiveData.getBuffer();
     const Index count = archiveData.getCount();
@@ -424,16 +424,16 @@ static SlangResult _setZipEntryUncompressedSize(List<uint8_t>& archiveData, uint
         if (signature == kLocalFileHeaderSignature && i + 26 <= count)
         {
             _writeUInt32LE(data + i + 22, size);
-            foundLocalHeader = true;
+            ++localHeaderCount;
         }
         else if (signature == kCentralDirectoryHeaderSignature && i + 28 <= count)
         {
             _writeUInt32LE(data + i + 24, size);
-            foundCentralDirectoryHeader = true;
+            ++centralDirectoryHeaderCount;
         }
     }
 
-    return foundLocalHeader && foundCentralDirectoryHeader ? SLANG_OK : SLANG_FAIL;
+    return localHeaderCount == 1 && centralDirectoryHeaderCount == 1 ? SLANG_OK : SLANG_FAIL;
 }
 
 static SlangResult _testZipRejectsOversizedUncompressedEntry()

--- a/tools/slang-unit-test/unit-test-file-system.cpp
+++ b/tools/slang-unit-test/unit-test-file-system.cpp
@@ -1,7 +1,7 @@
 // unit-test-file-system.cpp
 
-#include "../../source/core/slang-castable.h"
 #include "../../source/core/slang-blob.h"
+#include "../../source/core/slang-castable.h"
 #include "../../source/core/slang-deflate-compression-system.h"
 #include "../../source/core/slang-file-system.h"
 #include "../../source/core/slang-io.h"
@@ -441,9 +441,8 @@ static SlangResult _setZipEntryUncompressedSize(List<uint8_t>& archiveData, uint
 
 static SlangResult _setRiffEntryUncompressedSize(List<uint8_t>& archiveData, uint32_t size)
 {
-    auto rootList = RIFF::RootChunk::getFromBlob(
-        archiveData.getBuffer(),
-        size_t(archiveData.getCount()));
+    auto rootList =
+        RIFF::RootChunk::getFromBlob(archiveData.getBuffer(), size_t(archiveData.getCount()));
     if (!rootList || rootList->getType() != RiffFileSystemBinary::kContainerFourCC)
     {
         return SLANG_FAIL;

--- a/tools/slang-unit-test/unit-test-file-system.cpp
+++ b/tools/slang-unit-test/unit-test-file-system.cpp
@@ -388,6 +388,100 @@ static SlangResult _createFileSystem(
     return outFileSystem ? SLANG_OK : SLANG_FAIL;
 }
 
+#if SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE < 0xffffffffull
+static uint32_t _readUInt32LE(const uint8_t* data)
+{
+    return uint32_t(data[0]) | (uint32_t(data[1]) << 8) | (uint32_t(data[2]) << 16) |
+           (uint32_t(data[3]) << 24);
+}
+
+static void _writeUInt32LE(uint8_t* data, uint32_t value)
+{
+    data[0] = uint8_t(value);
+    data[1] = uint8_t(value >> 8);
+    data[2] = uint8_t(value >> 16);
+    data[3] = uint8_t(value >> 24);
+}
+
+static SlangResult _setZipEntryUncompressedSize(List<uint8_t>& archiveData, uint32_t size)
+{
+    static const uint32_t kLocalFileHeaderSignature = 0x04034b50;
+    static const uint32_t kCentralDirectoryHeaderSignature = 0x02014b50;
+
+    bool foundLocalHeader = false;
+    bool foundCentralDirectoryHeader = false;
+
+    uint8_t* data = archiveData.getBuffer();
+    const Index count = archiveData.getCount();
+    if (count < 4)
+    {
+        return SLANG_FAIL;
+    }
+
+    for (Index i = 0; i <= count - 4; ++i)
+    {
+        const uint32_t signature = _readUInt32LE(data + i);
+        if (signature == kLocalFileHeaderSignature && i + 26 <= count)
+        {
+            _writeUInt32LE(data + i + 22, size);
+            foundLocalHeader = true;
+        }
+        else if (signature == kCentralDirectoryHeaderSignature && i + 28 <= count)
+        {
+            _writeUInt32LE(data + i + 24, size);
+            foundCentralDirectoryHeader = true;
+        }
+    }
+
+    return foundLocalHeader && foundCentralDirectoryHeader ? SLANG_OK : SLANG_FAIL;
+}
+
+static SlangResult _testZipRejectsOversizedUncompressedEntry()
+{
+    ComPtr<ISlangMutableFileSystem> fileSystem;
+    SLANG_RETURN_ON_FAIL(ZipFileSystem::create(fileSystem));
+
+    const char contents[] = "small";
+    SLANG_RETURN_ON_FAIL(fileSystem->saveFile("bomb.txt", contents, sizeof(contents) - 1));
+
+    IArchiveFileSystem* archiveFileSystem = as<IArchiveFileSystem>(fileSystem);
+    if (!archiveFileSystem)
+    {
+        return SLANG_FAIL;
+    }
+
+    ComPtr<ISlangBlob> archiveBlob;
+    SLANG_RETURN_ON_FAIL(archiveFileSystem->storeArchive(false, archiveBlob.writeRef()));
+
+    List<uint8_t> archiveData;
+    archiveData.setCount(Index(archiveBlob->getBufferSize()));
+    ::memcpy(
+        archiveData.getBuffer(),
+        archiveBlob->getBufferPointer(),
+        archiveBlob->getBufferSize());
+
+    const uint32_t oversizedUncompressedSize =
+        uint32_t(SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE + 1);
+    SLANG_RETURN_ON_FAIL(_setZipEntryUncompressedSize(archiveData, oversizedUncompressedSize));
+
+    ComPtr<ISlangFileSystemExt> loadedFileSystem;
+    SLANG_RETURN_ON_FAIL(loadArchiveFileSystem(
+        archiveData.getBuffer(),
+        size_t(archiveData.getCount()),
+        loadedFileSystem));
+
+    SlangPathType pathType;
+    SLANG_RETURN_ON_FAIL(loadedFileSystem->getPathType("bomb.txt", &pathType));
+    SLANG_CHECK(pathType == SLANG_PATH_TYPE_FILE);
+
+    ComPtr<ISlangBlob> blob;
+    SLANG_CHECK(
+        loadedFileSystem->loadFile("bomb.txt", blob.writeRef()) == SLANG_E_OUT_OF_MEMORY);
+
+    return SLANG_OK;
+}
+#endif
+
 static SlangResult _testImplicitDirectory(FileSystemType type)
 {
     ComPtr<ISlangMutableFileSystem> fileSystem;
@@ -574,4 +668,11 @@ SLANG_UNIT_TEST(fileSystem)
             SLANG_CHECK(SLANG_SUCCEEDED(_testImplicitDirectory(type)));
         }
     }
+}
+
+SLANG_UNIT_TEST(zipRejectsOversizedUncompressedEntry)
+{
+#if SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE < 0xffffffffull
+    SLANG_CHECK(SLANG_SUCCEEDED(_testZipRejectsOversizedUncompressedEntry()));
+#endif
 }

--- a/tools/slang-unit-test/unit-test-file-system.cpp
+++ b/tools/slang-unit-test/unit-test-file-system.cpp
@@ -475,8 +475,7 @@ static SlangResult _testZipRejectsOversizedUncompressedEntry()
     SLANG_CHECK(pathType == SLANG_PATH_TYPE_FILE);
 
     ComPtr<ISlangBlob> blob;
-    SLANG_CHECK(
-        loadedFileSystem->loadFile("bomb.txt", blob.writeRef()) == SLANG_E_OUT_OF_MEMORY);
+    SLANG_CHECK(loadedFileSystem->loadFile("bomb.txt", blob.writeRef()) == SLANG_E_OUT_OF_MEMORY);
 
     return SLANG_OK;
 }

--- a/tools/slang-unit-test/unit-test-file-system.cpp
+++ b/tools/slang-unit-test/unit-test-file-system.cpp
@@ -1,6 +1,7 @@
 // unit-test-file-system.cpp
 
 #include "../../source/core/slang-castable.h"
+#include "../../source/core/slang-blob.h"
 #include "../../source/core/slang-deflate-compression-system.h"
 #include "../../source/core/slang-file-system.h"
 #include "../../source/core/slang-io.h"
@@ -9,6 +10,8 @@
 #include "../../source/core/slang-riff-file-system.h"
 #include "../../source/core/slang-zip-file-system.h"
 #include "unit-test/slang-unit-test.h"
+
+#include <limits>
 
 using namespace Slang;
 
@@ -388,7 +391,7 @@ static SlangResult _createFileSystem(
     return outFileSystem ? SLANG_OK : SLANG_FAIL;
 }
 
-#if SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE < 0xffffffffull
+#if SLANG_ARCHIVE_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE < 0xffffffffull
 static uint32_t _readUInt32LE(const uint8_t* data)
 {
     return uint32_t(data[0]) | (uint32_t(data[1]) << 8) | (uint32_t(data[2]) << 16) |
@@ -436,6 +439,43 @@ static SlangResult _setZipEntryUncompressedSize(List<uint8_t>& archiveData, uint
     return localHeaderCount == 1 && centralDirectoryHeaderCount == 1 ? SLANG_OK : SLANG_FAIL;
 }
 
+static SlangResult _setRiffEntryUncompressedSize(List<uint8_t>& archiveData, uint32_t size)
+{
+    auto rootList = RIFF::RootChunk::getFromBlob(
+        archiveData.getBuffer(),
+        size_t(archiveData.getCount()));
+    if (!rootList || rootList->getType() != RiffFileSystemBinary::kContainerFourCC)
+    {
+        return SLANG_FAIL;
+    }
+
+    Index entryCount = 0;
+    for (auto chunk : rootList->getChildren())
+    {
+        auto dataChunk = as<RIFF::DataChunk>(chunk);
+        if (!dataChunk || dataChunk->getType() != RiffFileSystemBinary::kEntryFourCC)
+        {
+            continue;
+        }
+
+        if (dataChunk->getPayloadSize() < sizeof(RiffFileSystemBinary::Entry))
+        {
+            return SLANG_FAIL;
+        }
+
+        RiffFileSystemBinary::Entry entry;
+        dataChunk->writePayloadInto(entry);
+        entry.uncompressedSize = size;
+        ::memcpy(
+            const_cast<void*>(dataChunk->getPayload()),
+            &entry,
+            sizeof(RiffFileSystemBinary::Entry));
+        ++entryCount;
+    }
+
+    return entryCount == 1 ? SLANG_OK : SLANG_FAIL;
+}
+
 static SlangResult _testZipRejectsOversizedUncompressedEntry()
 {
     ComPtr<ISlangMutableFileSystem> fileSystem;
@@ -461,7 +501,7 @@ static SlangResult _testZipRejectsOversizedUncompressedEntry()
         archiveBlob->getBufferSize());
 
     const uint32_t oversizedUncompressedSize =
-        uint32_t(SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE + 1);
+        uint32_t(SLANG_ARCHIVE_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE + 1);
     SLANG_RETURN_ON_FAIL(_setZipEntryUncompressedSize(archiveData, oversizedUncompressedSize));
 
     ComPtr<ISlangFileSystemExt> loadedFileSystem;
@@ -479,7 +519,78 @@ static SlangResult _testZipRejectsOversizedUncompressedEntry()
 
     return SLANG_OK;
 }
+
+static SlangResult _testRiffRejectsOversizedUncompressedEntry()
+{
+    ComPtr<ISlangMutableFileSystem> fileSystem(
+        new RiffFileSystem(DeflateCompressionSystem::getSingleton()));
+
+    const char contents[] = "small";
+    SLANG_RETURN_ON_FAIL(fileSystem->saveFile("bomb.txt", contents, sizeof(contents) - 1));
+
+    IArchiveFileSystem* archiveFileSystem = as<IArchiveFileSystem>(fileSystem);
+    if (!archiveFileSystem)
+    {
+        return SLANG_FAIL;
+    }
+
+    ComPtr<ISlangBlob> archiveBlob;
+    SLANG_RETURN_ON_FAIL(archiveFileSystem->storeArchive(false, archiveBlob.writeRef()));
+
+    List<uint8_t> archiveData;
+    archiveData.setCount(Index(archiveBlob->getBufferSize()));
+    ::memcpy(
+        archiveData.getBuffer(),
+        archiveBlob->getBufferPointer(),
+        archiveBlob->getBufferSize());
+
+    const uint32_t oversizedUncompressedSize =
+        uint32_t(SLANG_ARCHIVE_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE + 1);
+    SLANG_RETURN_ON_FAIL(_setRiffEntryUncompressedSize(archiveData, oversizedUncompressedSize));
+
+    ComPtr<ISlangFileSystemExt> loadedFileSystem;
+    SLANG_RETURN_ON_FAIL(loadArchiveFileSystem(
+        archiveData.getBuffer(),
+        size_t(archiveData.getCount()),
+        loadedFileSystem));
+
+    SlangPathType pathType;
+    SLANG_RETURN_ON_FAIL(loadedFileSystem->getPathType("bomb.txt", &pathType));
+    SLANG_CHECK(pathType == SLANG_PATH_TYPE_FILE);
+
+    ComPtr<ISlangBlob> blob;
+    SLANG_CHECK(loadedFileSystem->loadFile("bomb.txt", blob.writeRef()) == SLANG_E_OUT_OF_MEMORY);
+
+    return SLANG_OK;
+}
 #endif
+
+static SlangResult _testArchiveUncompressedSizeBounds()
+{
+    const UInt64 maxTerminatedAllocationSize = UInt64(~size_t(0) - 1);
+    const UInt64 effectiveMaxSize = kMaxArchiveFileUncompressedSize < maxTerminatedAllocationSize
+                                        ? kMaxArchiveFileUncompressedSize
+                                        : maxTerminatedAllocationSize;
+
+    SLANG_CHECK(isArchiveFileUncompressedSizeInBounds(effectiveMaxSize));
+    SLANG_CHECK(!isArchiveFileUncompressedSizeInBounds(effectiveMaxSize + 1));
+    return SLANG_OK;
+}
+
+static SlangResult _testScopedAllocationRejectsMaxTerminatedSize()
+{
+    ScopedAllocation alloc;
+    SLANG_CHECK(!alloc.allocateTerminated(std::numeric_limits<size_t>::max()));
+    SLANG_CHECK(alloc.getData() == nullptr);
+    SLANG_CHECK(alloc.getSizeInBytes() == 0);
+    SLANG_CHECK(alloc.getCapacityInBytes() == 0);
+
+    const char contents[] = "small";
+    ComPtr<ISlangBlob> blob = RawBlob::create(contents, std::numeric_limits<size_t>::max());
+    SLANG_CHECK(!blob);
+
+    return SLANG_OK;
+}
 
 static SlangResult _testImplicitDirectory(FileSystemType type)
 {
@@ -671,7 +782,28 @@ SLANG_UNIT_TEST(fileSystem)
 
 SLANG_UNIT_TEST(zipRejectsOversizedUncompressedEntry)
 {
-#if SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE < 0xffffffffull
+#if SLANG_ARCHIVE_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE < 0xffffffffull
     SLANG_CHECK(SLANG_SUCCEEDED(_testZipRejectsOversizedUncompressedEntry()));
+#else
+    SLANG_IGNORE_TEST;
 #endif
+}
+
+SLANG_UNIT_TEST(riffRejectsOversizedUncompressedEntry)
+{
+#if SLANG_ARCHIVE_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE < 0xffffffffull
+    SLANG_CHECK(SLANG_SUCCEEDED(_testRiffRejectsOversizedUncompressedEntry()));
+#else
+    SLANG_IGNORE_TEST;
+#endif
+}
+
+SLANG_UNIT_TEST(archiveUncompressedSizeBounds)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_testArchiveUncompressedSizeBounds()));
+}
+
+SLANG_UNIT_TEST(scopedAllocationRejectsMaxTerminatedSize)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_testScopedAllocationRejectsMaxTerminatedSize()));
 }

--- a/tools/slang-unit-test/unit-test-file-system.cpp
+++ b/tools/slang-unit-test/unit-test-file-system.cpp
@@ -588,6 +588,9 @@ static SlangResult _testScopedAllocationRejectsMaxTerminatedSize()
     ComPtr<ISlangBlob> blob = RawBlob::create(contents, std::numeric_limits<size_t>::max());
     SLANG_CHECK(!blob);
 
+    SLANG_CHECK(RawBlob::tryCreate(nullptr, 1, blob) == SLANG_E_INVALID_ARG);
+    SLANG_CHECK(!blob);
+
     return SLANG_OK;
 }
 

--- a/tools/slang-unit-test/unit-test-file-system.cpp
+++ b/tools/slang-unit-test/unit-test-file-system.cpp
@@ -591,6 +591,17 @@ static SlangResult _testScopedAllocationRejectsMaxTerminatedSize()
     SLANG_CHECK(RawBlob::tryCreate(nullptr, 1, blob) == SLANG_E_INVALID_ARG);
     SLANG_CHECK(!blob);
 
+    const char replacementContents[] = "replacement";
+    SLANG_RETURN_ON_FAIL(RawBlob::tryCreate(
+        replacementContents,
+        sizeof(replacementContents) - 1,
+        blob));
+    SLANG_RETURN_ON_FAIL(
+        RawBlob::tryCreate(blob->getBufferPointer(), blob->getBufferSize(), blob));
+    SLANG_CHECK(blob->getBufferSize() == sizeof(replacementContents) - 1);
+    SLANG_CHECK(
+        ::memcmp(blob->getBufferPointer(), replacementContents, blob->getBufferSize()) == 0);
+
     return SLANG_OK;
 }
 


### PR DESCRIPTION
## TLDR
Vulnerability found on the following lines:
```
if (!alloc.allocateTerminated(size_t(fileStat.m_uncomp_size)))
```
In `ZipFileSystemImpl::loadFile`, the uncompressed size from the ZIP archive metadata (`fileStat.m_uncomp_size`) is used directly to allocate memory via `alloc.allocateTerminated(size_t(fileStat.m_uncomp_size))` without any upper bound check. A maliciously crafted ZIP archive could claim an extremely large uncompressed size (e.g., multiple gigabytes), causing the application to attempt a massive memory allocation. This is a classic zip bomb vector. While `allocateTerminated` will return false on allocation failure, the attempt itself can cause system-wide memory pressure or OOM conditions.

## Summary

Mitigate decompression-bomb risk in archive-backed file systems by capping the uncompressed size of any individual archived entry. Entries reporting an uncompressed size above the cap are rejected with `SLANG_E_OUT_OF_MEMORY` instead of being allocated and decompressed.

## Details

- Added file-system-agnostic macro `SLANG_ARCHIVE_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE` in `source/core/slang-archive-file-system.h` (default 256 MiB), overridable at build time for callers that legitimately need larger entries.
- Kept `SLANG_ZIP_FILE_SYSTEM_MAX_UNCOMPRESSED_FILE_SIZE` as a compatibility alias for existing build-time overrides.
- `ZipFileSystemImpl::loadFile` and `RiffFileSystem::loadFile` now validate the reported uncompressed size against both the archive cap and the largest safely terminated `size_t` allocation before allocating.
- Replaced `SLANG_ASSUME` in `ScopedAllocation::allocateTerminated` with a real runtime overflow check, and made every failure path call `deallocate()` so callers never observe non-zero `m_sizeInBytes`/`m_capacityInBytes` alongside a null `m_data`.
- `RawBlob::create` now returns null when `tryCreate` fails; `RawBlob::tryCreate` rejects null non-empty input with `SLANG_E_INVALID_ARG`, preserves the previous output blob until a replacement blob is initialized, and propagates allocation failure as `SLANG_E_OUT_OF_MEMORY` for result-returning core file-system callers.
- The ZIP test helper now only succeeds when exactly one local header and one central-directory header are patched.

## Test plan

- Added ZIP and RIFF oversized-entry unit helpers in `tools/slang-unit-test/unit-test-file-system.cpp` that patch archive metadata above the cap and verify `loadFile` returns `SLANG_E_OUT_OF_MEMORY`.
- Added `archiveUncompressedSizeBounds` coverage for the exact effective cap boundary and `cap + 1` rejection without allocating a cap-sized file.
- Added `scopedAllocationRejectsMaxTerminatedSize` coverage for the `SIZE_MAX` terminated-allocation failure invariant, nullable `RawBlob::create` behavior, `RawBlob::tryCreate(nullptr, nonZeroSize)` returning `SLANG_E_INVALID_ARG`, and the self-copy case where the input pointer comes from the output blob being replaced.
- Added `memoryFileSystemRejectsNullNonEmptySave` coverage for `MemoryFileSystem::saveFile("foo", nullptr, 1)` returning `SLANG_E_INVALID_ARG`.
- `git diff --check` passed locally.
- `./extras/formatting.sh --check-only --cpp -- source/core/slang-archive-file-system.h tools/slang-unit-test/unit-test-file-system.cpp` passed locally.
- Direct `-fsyntax-only` compilation with generated Ninja flags passed for `slang-riff-file-system.cpp`, `slang-zip-file-system.cpp`, `slang-memory-file-system.cpp`, `slang-blob.cpp`, and `unit-test-file-system.cpp`.
- A serial `cmake --build --preset debug --target slang-unit-test --parallel 1` rebuilt the edited core files and linked `Debug/lib/libcore.a` and `Debug/lib/libcompiler-core.a`; I stopped it after it expanded into a broad compiler rebuild from the shared header change.
