### PR TITLE
Use slang-build skill in agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,11 @@ Examples:
 Do not infer WSL build commands from generic Linux instructions. Follow the platform detection,
 host-tool selection, CMake preset choice, and clean-build steps defined by the skill.
 
-After building, run tests from the repository root using the generated `slang-test` binary:
+After building, run tests from the repository root using the generated `slang-test` binary in
+the directory for the selected configuration:
 - `build/Debug/bin/slang-test`: run the Debug test suite.
+- `build/RelWithDebInfo/bin/slang-test -use-test-server -server-count 8`: run optimized
+  tests with symbols in parallel using test servers.
 - `build/Release/bin/slang-test -use-test-server -server-count 8`: run Release tests in
   parallel using test servers.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,14 +19,18 @@ Key directories:
 
 ## Build, Test, and Development Commands
 
-- `cmake --preset default`: configure the default Ninja Multi-Config build in `build/`.
-- `cmake --build --preset debug`: build the Debug configuration.
-- `cmake --build --preset releaseWithDebugInfo`: build an optimized configuration with symbols.
-- `cmake --workflow --preset release`: configure, build, and package a release build.
-- `build/Debug/bin/slang-test`: run the test suite from the repository root.
-- `build/Release/bin/slang-test -use-test-server -server-count 8`: run tests in parallel
-  using test servers.
-- `cmake --preset vs2026`: preferred Windows configuration preset for Visual Studio 2026.
+Slang build setup is platform-specific, especially under WSL. For compiler builds, use the
+`slang-build` skill from the `shader-slang/slang-skills` repository instead of following
+hard-coded commands in this file.
+
+Examples:
+- `/slang-build build debug`: build the Debug configuration.
+- `/slang-build rebuild debug`: discard the existing build directory and rebuild Debug.
+- `/slang-build configure releasewithdebug`: configure an optimized build with symbols.
+- `/slang-build clean`: rename and remove the existing build directory.
+
+Do not infer WSL build commands from generic Linux instructions. Follow the platform detection,
+host-tool selection, CMake preset choice, and clean-build steps defined by the skill.
 
 ## Coding Style & Naming Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,11 +20,15 @@ Key directories:
 ## Build, Test, and Development Commands
 
 Slang build setup is platform-specific, especially under WSL. For compiler builds, use the
-`slang-build` skill from the `shader-slang/slang-skills` repository instead of following
-hard-coded commands in this file.
+`slang-build` skill from `skills/slang-build` in the `shader-slang/slang-skills` repository
+instead of following hard-coded commands in this file.
+
+If the skill is unavailable because skills cannot be installed or network access is limited, use
+`docs/building.md` as the fallback build reference.
 
 Examples:
 - `/slang-build build debug`: build the Debug configuration.
+- `/slang-build build release`: build the Release configuration.
 - `/slang-build rebuild debug`: discard the existing build directory and rebuild Debug.
 - `/slang-build configure releasewithdebug`: configure an optimized build with symbols.
 - `/slang-build clean`: rename and remove the existing build directory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,13 @@ Examples:
 Do not infer WSL build commands from generic Linux instructions. Follow the platform detection,
 host-tool selection, CMake preset choice, and clean-build steps defined by the skill.
 
+After building, run tests from the repository root using the generated `slang-test` binary:
+- `build/Debug/bin/slang-test`: run the Debug test suite.
+- `build/Release/bin/slang-test -use-test-server -server-count 8`: run Release tests in
+  parallel using test servers.
+
+On Windows-hosted builds, use the `.exe` suffix if that is the generated binary name.
+
 ## Coding Style & Naming Conventions
 
 Formatting:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,6 @@ If the skill is unavailable because skills cannot be installed or network access
 
 Examples:
 - `/slang-build build debug`: build the Debug configuration.
-- `/slang-build build release`: build the Release configuration.
 - `/slang-build rebuild debug`: discard the existing build directory and rebuild Debug.
 - `/slang-build configure releasewithdebug`: configure an optimized build with symbols.
 - `/slang-build clean`: rename and remove the existing build directory.


### PR DESCRIPTION
Summary:
- Delegate Slang compiler build setup in AGENTS.md to the slang-build skill.
- Keep stable slang-test invocation examples, including Debug, RelWithDebInfo, and Release paths.
- Add docs/building.md as a fallback when skills are unavailable.