### PR TITLE
Fix #10528: Volatile semantics for subgroup / SM builtins in raytracing

### DIFF
--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -1062,6 +1062,13 @@ warning(
     span { loc = "location", message = "layout-sensitive SPIR-V type declaration '~opcode' in spirv_asm may not preserve Slang data-layout information; form layout-sensitive pointers/values with Slang types or expressions and pass them into spirv_asm instead" }
 )
 
+warning(
+    "spirv-asm-volatile-builtin-non-literal-mask",
+    29117,
+    "memory-access mask on `OpLoad` of a Volatile-required builtin in `spirv_asm` must be a literal integer or a named-keyword form (e.g. `Aligned 4`); runtime / SSA-id values are not representable in `OpLoad`'s memory-access slot per SPIR-V grammar. The emitted load will use `Volatile` only; user-supplied mask bits are dropped.",
+    span { loc = "location" }
+)
+
 
 -- Load semantic checking diagnostics (part 1)
 -- (inlined from slang-diagnostics-semantic-checking-1.lua)

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -8509,8 +8509,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         if (m_memoryModel == SpvMemoryModelVulkan && m_volatileSpvVars.getCount() != 0)
         {
             SpvInst* ptrSpv = nullptr;
-            if (m_mapIRInstToSpvInst.tryGetValue(ptr, ptrSpv) &&
-                m_volatileSpvVars.contains(ptrSpv))
+            if (m_mapIRInstToSpvInst.tryGetValue(ptr, ptrSpv) && m_volatileSpvVars.contains(ptrSpv))
             {
                 memoryAccessMaskOut |= SpvMemoryAccessVolatileMask;
             }

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -6883,13 +6883,27 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         }
     };
     Dictionary<BuiltinSpvVarKey, SpvInst*> m_builtinGlobalVars;
-    // IR-side builtin globals that require Volatile semantics. Under
-    // the Vulkan memory model the variable cannot carry an
-    // `OpDecorate Volatile`; instead each load/store must OR the
-    // `Volatile` mask into its memory access operand. This set is
-    // populated in `getBuiltinGlobalVar` and consulted by
-    // `getMemoryAccessOperandsOfLoadStore`.
+    // IR-side builtin operands that require `Volatile` semantics.
+    // Keyed on the `IRSPIRVAsmOperandBuiltinVar` inst (or any other
+    // IR inst that flows into `getBuiltinGlobalVar`). Consulted by
+    // `emitSPIRVAsm`'s `case SpvOpLoad:` branch — that's the only
+    // path through which a volatile-required builtin reaches the
+    // emitter today.
     HashSet<IRInst*> m_volatileBuiltinGlobalVars;
+    // SPIR-V-side mirror of `m_volatileBuiltinGlobalVars`: the
+    // `SpvInst*`s for variables materialized by `getBuiltinGlobalVar`
+    // for a flagged builtin. Lives at the SPIR-V abstraction so the
+    // regular-IR `emitLoad` / `emitStore` path
+    // (`getMemoryAccessOperandsOfLoadStore`) can also discover that
+    // its `ptr` resolves to a flagged builtin and inject the per-
+    // access mask. Today no Slang surface lowers these builtins to
+    // a regular `IRLoad`, so this set is effectively forward-compat
+    // scaffolding — but the assert it replaces was vacuous (the IR
+    // and SPIR-V abstractions are disjoint by type), and a future
+    // IR-pipeline change that surfaces a builtin-decorated global
+    // would now correctly receive the mask without needing further
+    // emitter changes.
+    HashSet<SpvInst*> m_volatileSpvVars;
     SpvInst* m_descriptorHeapUntypedPointerType = nullptr;
     Dictionary<SpvStorageClass, SpvInst*> m_descriptorHeapBufferDescriptorTypes;
     Dictionary<SpvInst*, SpvInst*> m_descriptorHeapRuntimeArrayTypes;
@@ -7005,6 +7019,13 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             m_volatileBuiltinGlobalVars.add(irInst);
         if (m_builtinGlobalVars.tryGetValue(key, result))
         {
+            // Cache hit: the SPIR-V variable already exists. Mirror
+            // it into the SpvInst*-keyed set so the regular-IR load
+            // path in `getMemoryAccessOperandsOfLoadStore` can also
+            // reach it (the IR-side set is keyed on asm-operand insts
+            // and won't match an `IRGlobalVar` ptr).
+            if (isVolatile)
+                m_volatileSpvVars.add(result);
             return result;
         }
         IRBuilder builder(m_irModule);
@@ -7031,6 +7052,10 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             break;
         }
         m_builtinGlobalVars[key] = varInst;
+        // Mirror the new SPIR-V variable into the SpvInst*-keyed set
+        // so the regular-IR load path can detect it as flagged.
+        if (isVolatile)
+            m_volatileSpvVars.add(varInst);
 
         if (isFlat)
         {
@@ -8467,12 +8492,29 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             }
         }
 
-        // Volatile builtins flagged in `getBuiltinGlobalVar` are reached
-        // only via `spirv_asm` `OpLoad` today (see `emitSPIRVAsm`'s
-        // `SpvOpLoad` branch). A regular-IR load/store landing on one
-        // would silently miss the `Volatile` mask under vk_mem_model;
-        // assert so a future IR-pipeline change is caught here.
-        SLANG_ASSERT(!m_volatileBuiltinGlobalVars.contains(ptr));
+        // Volatile-flagged builtin reached via the regular-IR load
+        // path: today no Slang surface lowers a volatile-required
+        // builtin to an `IRLoad` (they all flow through `spirv_asm`,
+        // which has its own injection branch in `emitSPIRVAsm`), so
+        // this branch is unreachable in current code. It is kept
+        // functional rather than as an assertion because the IR-side
+        // set (`m_volatileBuiltinGlobalVars`, keyed on asm-operand
+        // insts) is the wrong abstraction to check against an
+        // `IRGlobalVar`/`IRGlobalParam` `ptr` — they are disjoint by
+        // type. Instead we look up `ptr`'s already-emitted
+        // `SpvInst*` and consult `m_volatileSpvVars` (populated in
+        // `getBuiltinGlobalVar`). A future regression that lowers a
+        // flagged builtin to a regular IR load will receive the
+        // `Volatile` mask transparently.
+        if (m_memoryModel == SpvMemoryModelVulkan && m_volatileSpvVars.getCount() != 0)
+        {
+            SpvInst* ptrSpv = nullptr;
+            if (m_mapIRInstToSpvInst.tryGetValue(ptr, ptrSpv) &&
+                m_volatileSpvVars.contains(ptrSpv))
+            {
+                memoryAccessMaskOut |= SpvMemoryAccessVolatileMask;
+            }
+        }
     }
 
     SpvInst* emitLoad(SpvInstParent* parent, IRInst* inst, IRInst* ptr)
@@ -11372,12 +11414,28 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                                     // an Enum (named keyword like
                                     // `Aligned`); both store the resolved
                                     // SPIR-V mask value as an IRIntLit
-                                    // accessible via `getValue()`.
+                                    // accessible via `getValue()`. Other
+                                    // operand kinds (e.g. `Id`-form for
+                                    // a let-bound runtime value) are not
+                                    // representable in `OpLoad`'s
+                                    // memory-access slot per SPIR-V
+                                    // grammar — the spec mandates a
+                                    // literal integer there. Diagnose
+                                    // and fall through to the
+                                    // Volatile-only emit; the user's
+                                    // intent to use a runtime mask was
+                                    // not encodable to begin with.
                                     if (userMaskOp->getOp() == kIROp_SPIRVAsmOperandLiteral ||
                                         userMaskOp->getOp() == kIROp_SPIRVAsmOperandEnum)
                                     {
                                         if (auto val = as<IRIntLit>(userMaskOp->getValue()))
                                             mergedMask |= uint32_t(val->getValue());
+                                    }
+                                    else
+                                    {
+                                        m_sink->diagnose(
+                                            Diagnostics::SpirvAsmVolatileBuiltinNonLiteralMask{
+                                                .location = userMaskOp->sourceLoc});
                                     }
                                     ++i;
                                 }

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -6883,6 +6883,13 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         }
     };
     Dictionary<BuiltinSpvVarKey, SpvInst*> m_builtinGlobalVars;
+    // IR-side builtin globals that require Volatile semantics. Under
+    // the Vulkan memory model the variable cannot carry an
+    // `OpDecorate Volatile`; instead each load/store must OR the
+    // `Volatile` mask into its memory access operand. This set is
+    // populated in `getBuiltinGlobalVar` and consulted by
+    // `getMemoryAccessOperandsOfLoadStore`.
+    HashSet<IRInst*> m_volatileBuiltinGlobalVars;
     SpvInst* m_descriptorHeapUntypedPointerType = nullptr;
     Dictionary<SpvStorageClass, SpvInst*> m_descriptorHeapBufferDescriptorTypes;
     Dictionary<SpvInst*, SpvInst*> m_descriptorHeapRuntimeArrayTypes;
@@ -6925,6 +6932,64 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         return false;
     }
 
+    // Stages in which subgroup / SM builtins require `Volatile` semantics
+    // per the Vulkan SPIR-V environment spec. Note this is a strict subset
+    // of `isRaytracingStage`: AnyHit is intentionally excluded because the
+    // spec does not require `Volatile` there.
+    static bool isRaytracingStageRequiringVolatileBuiltins(Stage stage)
+    {
+        switch (stage)
+        {
+        case Stage::RayGeneration:
+        case Stage::ClosestHit:
+        case Stage::Miss:
+        case Stage::Intersection:
+        case Stage::Callable:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    bool needVolatileDecorationForBuiltinVar(SpvBuiltIn builtinVal, IRInst* irInst)
+    {
+        if (!irInst)
+            return false;
+        switch (builtinVal)
+        {
+        case SpvBuiltInSubgroupLocalInvocationId:
+        case SpvBuiltInSubgroupSize:
+        case SpvBuiltInSubgroupEqMask:
+        case SpvBuiltInSubgroupGeMask:
+        case SpvBuiltInSubgroupGtMask:
+        case SpvBuiltInSubgroupLeMask:
+        case SpvBuiltInSubgroupLtMask:
+        // SubgroupId omitted: VUID-SubgroupId-SubgroupId-04367 (RT-stage
+        // usability tracked in #11303). SMIDNV/WarpIDNV kept for
+        // hand-rolled `spirv_asm` users.
+        case SpvBuiltInSMIDNV:
+        case SpvBuiltInWarpIDNV:
+            {
+                auto* refs = m_referencingEntryPoints.tryGetValue(irInst);
+                if (!refs)
+                    return false;
+                for (auto entryPoint : *refs)
+                {
+                    if (auto d = entryPoint->findDecoration<IREntryPointDecoration>())
+                    {
+                        if (isRaytracingStageRequiringVolatileBuiltins(d->getProfile().getStage()))
+                            return true;
+                    }
+                }
+                return false;
+            }
+        case SpvBuiltInRayTmaxKHR:
+            return isInstUsedInStage(irInst, Stage::Intersection);
+        default:
+            return false;
+        }
+    }
+
     SpvInst* getBuiltinGlobalVar(IRType* type, SpvBuiltIn builtinVal, IRInst* irInst)
     {
         SpvInst* result = nullptr;
@@ -6932,7 +6997,12 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         SLANG_ASSERT(ptrType && "`getBuiltinGlobalVar`: `type` must be ptr type.");
         auto storageClass = addressSpaceToStorageClass(ptrType->getAddressSpace());
         bool isFlat = needFlatDecorationForBuiltinVar(irInst);
+        bool isVolatile = needVolatileDecorationForBuiltinVar(builtinVal, irInst);
         auto key = BuiltinSpvVarKey(builtinVal, storageClass, isFlat, ptrType->getValueType());
+        // Track the IR inst even on cache hit so the per-access `Volatile`
+        // mask in `emitSPIRVAsm` fires for every alias under vk_mem_model.
+        if (isVolatile)
+            m_volatileBuiltinGlobalVars.add(irInst);
         if (m_builtinGlobalVars.tryGetValue(key, result))
         {
             return result;
@@ -6967,6 +7037,22 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             _maybeEmitInterpolationModifierDecoration(
                 IRInterpolationMode::NoInterpolation,
                 getID(varInst));
+        }
+
+        if (isVolatile && m_memoryModel != SpvMemoryModelVulkan)
+        {
+            // Under the Vulkan memory model the `Volatile` semantics
+            // are expressed via a per-access mask on each load/store
+            // (see `getMemoryAccessOperandsOfLoadStore`); attaching
+            // `OpDecorate ... Volatile` to the variable would be an
+            // invalid combination there. Under the legacy GLSL450
+            // model, the variable-level decoration is the supported
+            // form.
+            emitOpDecorate(
+                getSection(SpvLogicalSectionID::Annotations),
+                nullptr,
+                varInst,
+                SpvDecorationVolatile);
         }
 
         return varInst;
@@ -8380,6 +8466,13 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     memoryAccessMaskOut |= SpvMemoryAccessAlignedMask;
             }
         }
+
+        // Volatile builtins flagged in `getBuiltinGlobalVar` are reached
+        // only via `spirv_asm` `OpLoad` today (see `emitSPIRVAsm`'s
+        // `SpvOpLoad` branch). A regular-IR load/store landing on one
+        // would silently miss the `Volatile` mask under vk_mem_model;
+        // assert so a future IR-pipeline change is caught here.
+        SLANG_ASSERT(!m_volatileBuiltinGlobalVars.contains(ptr));
     }
 
     SpvInst* emitLoad(SpvInstParent* parent, IRInst* inst, IRInst* ptr)
@@ -11109,6 +11202,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 }
 
                 bool needToUseCoherentLoadOrStore = false;
+                bool needVolatileBuiltinMask = false;
                 if (m_memoryModel == SpvMemoryModelVulkan)
                 {
                     switch (opcode)
@@ -11140,6 +11234,30 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     case SpvOpImageWrite:
                         needToUseCoherentLoadOrStore =
                             NeedToUseCoherentImageLoadOrStore(spvInst->getOperand(1));
+                        break;
+                    case SpvOpLoad:
+                        // Wave / SM intrinsics in `hlsl.meta.slang` lower
+                        // to an `OpLoad builtin(...)` inside a `spirv_asm`
+                        // block, which bypasses the regular emit path.
+                        // Detect a flagged builtin pointer regardless of
+                        // whether the author supplied a memory-access
+                        // mask — the emit loop below either appends a
+                        // fresh `Volatile` word (minimal form) or ORs it
+                        // into the user's existing mask (extended form,
+                        // e.g. `OpLoad ... Aligned 4`). `spvInst->getOperand(N)`
+                        // includes the opcode at N=0, so result-type is
+                        // at 1, result-id at 2, and the pointer is at 3.
+                        if (spvInst->getOperandCount() >= 4)
+                        {
+                            auto ptrOperand = as<IRSPIRVAsmOperand>(spvInst->getOperand(3));
+                            if (ptrOperand &&
+                                ptrOperand->getOp() == kIROp_SPIRVAsmOperandBuiltinVar)
+                            {
+                                ensureInst(ptrOperand);
+                                if (m_volatileBuiltinGlobalVars.contains(ptrOperand))
+                                    needVolatileBuiltinMask = true;
+                            }
+                        }
                         break;
                     }
                 }
@@ -11226,14 +11344,57 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                         opcode,
                         [&]()
                         {
-                            for (const auto operand : spvInst->getSPIRVOperands())
+                            auto operands = spvInst->getSPIRVOperands();
+
+                            if (opcode == SpvOpLoad && needVolatileBuiltinMask)
+                            {
+                                // `OpLoad` of a flagged volatile builtin
+                                // under `vk_mem_model`. Emit type / id /
+                                // pointer, then either OR `Volatile` into
+                                // the user-supplied memory-access mask
+                                // (operand[3]) or append a fresh `Volatile`
+                                // word. Forwarding a user mask without
+                                // the merge would ship a load missing the
+                                // spec-required `Volatile` semantics; for
+                                // the bare minimal-form load it would
+                                // produce two consecutive memory-access
+                                // bitmask words, which is invalid grammar.
+                                Index i = 0;
+                                for (; i < 3 && i < operands.getCount(); ++i)
+                                    emitSpvAsmOperand(operands[i]);
+
+                                uint32_t mergedMask = uint32_t(SpvMemoryAccessVolatileMask);
+                                if (i < operands.getCount())
+                                {
+                                    auto userMaskOp = operands[i];
+                                    // The memory-access mask appears as
+                                    // either a Literal (numeric mask) or
+                                    // an Enum (named keyword like
+                                    // `Aligned`); both store the resolved
+                                    // SPIR-V mask value as an IRIntLit
+                                    // accessible via `getValue()`.
+                                    if (userMaskOp->getOp() == kIROp_SPIRVAsmOperandLiteral ||
+                                        userMaskOp->getOp() == kIROp_SPIRVAsmOperandEnum)
+                                    {
+                                        if (auto val = as<IRIntLit>(userMaskOp->getValue()))
+                                            mergedMask |= uint32_t(val->getValue());
+                                    }
+                                    ++i;
+                                }
+                                emitOperand(mergedMask);
+                                for (; i < operands.getCount(); ++i)
+                                    emitSpvAsmOperand(operands[i]);
+                                return;
+                            }
+
+                            for (const auto operand : operands)
                                 emitSpvAsmOperand(operand);
 
                             if (needToUseCoherentLoadOrStore)
                             {
                                 // Check if user specified memory operand explicitly
                                 uint32_t usedMask = 0;
-                                for (auto operand : spvInst->getSPIRVOperands())
+                                for (auto operand : operands)
                                 {
                                     if (operand->getOp() == kIROp_SPIRVAsmOperandLiteral)
                                     {

--- a/tests/language-feature/spirv-asm/volatile-builtin-non-literal-mask-diagnostic.slang
+++ b/tests/language-feature/spirv-asm/volatile-builtin-non-literal-mask-diagnostic.slang
@@ -1,0 +1,59 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK_WARN):-target spirv-asm -entry rayGenMain -stage raygeneration -emit-spirv-directly -capability vk_mem_model -skip-spirv-validation -DWARN
+//TEST:SIMPLE(filecheck=CHECK_OK):-target spirv-asm -entry rayGenMain -stage raygeneration -emit-spirv-directly -capability vk_mem_model -DNO_WARN
+
+// Regression test for shader-slang/slang#10528 — diagnose user-supplied
+// non-literal memory-access mask on `OpLoad` of a Volatile-required
+// builtin in `spirv_asm`. The auto-injection path can only OR
+// compile-time literal/enum bits into the mask; an `Id`-form (or other
+// non-literal kind) is not representable in `OpLoad`'s memory-access
+// slot per SPIR-V grammar (the spec mandates a literal integer there).
+// In the WARN variant the user supplies an `Id` mask and we expect
+// `E29117` to fire. In the NO_WARN variant the user supplies a literal,
+// the merge succeeds, and no warning is emitted.
+
+RWStructuredBuffer<uint> output;
+
+#if defined(WARN)
+uint readWithIdMask()
+{
+    return spirv_asm
+    {
+        OpCapability GroupNonUniform;
+        // The mask operand is an Id-form (`%runtimeMask`), not a
+        // Literal or Enum. The auto-inject path can't merge it.
+        // The diagnostic anchors on the Id definition (Slang's IR
+        // representation of `SPIRVAsmOperandId` carries the
+        // definition-site source loc, not the use site).
+        // CHECK_WARN: warning[E29117]: memory-access mask on `OpLoad` of a Volatile-required builtin
+        %runtimeMask = OpConstant $$uint 4;
+        result:$$uint = OpLoad builtin(SubgroupLocalInvocationId:uint) %runtimeMask
+    };
+}
+
+[shader("raygeneration")]
+void rayGenMain()
+{
+    output[0] = readWithIdMask();
+}
+#elif defined(NO_WARN)
+// CHECK_OK-NOT: warning[E29117]
+// CHECK_OK-DAG: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupLocalInvocationId
+// CHECK_OK-DAG: OpLoad {{.*}} %{{[A-Za-z0-9_]+}} {{.*}}Volatile
+
+uint readWithLiteralMask()
+{
+    return spirv_asm
+    {
+        OpCapability GroupNonUniform;
+        // Literal mask — merge succeeds, no warning, emitted as
+        // `Volatile|Aligned 4`.
+        result:$$uint = OpLoad builtin(SubgroupLocalInvocationId:uint) Aligned 4
+    };
+}
+
+[shader("raygeneration")]
+void rayGenMain()
+{
+    output[0] = readWithLiteralMask();
+}
+#endif

--- a/tests/spirv/builtin-no-volatile-anyhit.slang
+++ b/tests/spirv/builtin-no-volatile-anyhit.slang
@@ -1,0 +1,45 @@
+// builtin-no-volatile-anyhit.slang
+//
+// Regression test for shader-slang/slang#10528.
+// The Vulkan spec mandates `Volatile` on subgroup / SM builtins in
+// raygeneration, closesthit, miss, intersection, and callable shaders
+// only — anyhit is explicitly excluded. This test pins that exclusion
+// so a future change to `isRaytracingStage` does not silently widen
+// the set.
+//
+// All seven volatile-required subgroup-family enumerators share the
+// same `isRaytracingStageRequiringVolatileBuiltins` gate, but a
+// regression that drops AnyHit filtering for `SubgroupSize` or one
+// of the five `Subgroup*Mask` variants (without breaking
+// `SubgroupLocalInvocationId`) would slip past a single-builtin
+// test. Read three independently-emitted builtins from the AnyHit
+// shader: `WaveGetLaneIndex` → `SubgroupLocalInvocationId`,
+// `WaveGetLaneCount` → `SubgroupSize`, and `WaveGetLaneEqMask` →
+// `SubgroupEqMask`.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry anyHitMain -stage anyhit -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry anyHitMain -stage anyhit -emit-spirv-directly -capability vk_mem_model
+
+RWStructuredBuffer<uint> output;
+RWStructuredBuffer<uint4> output_mask;
+
+struct Payload { uint v; };
+struct Attribs { float2 b; };
+
+// Each of the three builtin variables must appear with its `BuiltIn`
+// decoration, but no `Volatile` token may appear anywhere in the
+// disassembly (neither variable-level decoration nor per-access
+// mask): the shader is single-entry-point so a blanket
+// `CHECK-NOT: Volatile` is the strongest form, and it scans the
+// whole disassembly.
+// CHECK-DAG: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupLocalInvocationId
+// CHECK-DAG: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupSize
+// CHECK-DAG: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupEqMask
+// CHECK-NOT: Volatile
+[shader("anyhit")]
+void anyHitMain(inout Payload p, in Attribs a)
+{
+    p.v = WaveGetLaneIndex();
+    output[0] = WaveGetLaneCount();
+    output_mask[0] = WaveGetLaneEqMask();
+}

--- a/tests/spirv/builtin-no-volatile-anyhit.slang
+++ b/tests/spirv/builtin-no-volatile-anyhit.slang
@@ -29,9 +29,13 @@ struct Attribs { float2 b; };
 // Each of the three builtin variables must appear with its `BuiltIn`
 // decoration, but no `Volatile` token may appear anywhere in the
 // disassembly (neither variable-level decoration nor per-access
-// mask): the shader is single-entry-point so a blanket
-// `CHECK-NOT: Volatile` is the strongest form, and it scans the
-// whole disassembly.
+// mask). FileCheck's `CHECK-NOT` only excludes matches in unsearched
+// regions of input, so the `CHECK-DAG` block is bracketed by a
+// leading `CHECK-NOT` (scans file start → first DAG match) and a
+// trailing `CHECK-NOT` (scans unmatched lines between DAG anchors,
+// plus the last DAG match → EOF). Together they cover the whole
+// input.
+// CHECK-NOT: Volatile
 // CHECK-DAG: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupLocalInvocationId
 // CHECK-DAG: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupSize
 // CHECK-DAG: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupEqMask

--- a/tests/spirv/builtin-no-volatile-compute.slang
+++ b/tests/spirv/builtin-no-volatile-compute.slang
@@ -1,0 +1,21 @@
+// builtin-no-volatile-compute.slang
+//
+// Regression test for shader-slang/slang#10528.
+// `Volatile` on subgroup builtins is a raytracing-stage requirement;
+// compute shaders must not get the extra decoration.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -emit-spirv-directly
+
+RWStructuredBuffer<uint> output;
+
+// Single-entry-point shader; no use of `Volatile` should appear in the
+// SPIR-V at all (neither as a variable decoration nor as a per-access
+// mask), so a blanket `CHECK-NOT: Volatile` is the strongest form.
+// CHECK: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupLocalInvocationId
+// CHECK-NOT: Volatile
+[numthreads(64, 1, 1)]
+[shader("compute")]
+void computeMain()
+{
+    output[0] = WaveGetLaneIndex();
+}

--- a/tests/spirv/builtin-no-volatile-compute.slang
+++ b/tests/spirv/builtin-no-volatile-compute.slang
@@ -5,12 +5,18 @@
 // compute shaders must not get the extra decoration.
 
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -emit-spirv-directly -capability vk_mem_model
 
 RWStructuredBuffer<uint> output;
 
-// Single-entry-point shader; no use of `Volatile` should appear in the
-// SPIR-V at all (neither as a variable decoration nor as a per-access
-// mask), so a blanket `CHECK-NOT: Volatile` is the strongest form.
+// Single-entry-point shader; no use of `Volatile` should appear in
+// the SPIR-V at all under either memory model. The leading
+// `CHECK-NOT: Volatile` scans file start → first `CHECK` match; the
+// trailing one scans last `CHECK` match → EOF. Together they cover
+// the whole disassembly, rejecting both the variable-level
+// decoration (GLSL450 path) and the per-`OpLoad` mask
+// (vk_mem_model path).
+// CHECK-NOT: Volatile
 // CHECK: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupLocalInvocationId
 // CHECK-NOT: Volatile
 [numthreads(64, 1, 1)]

--- a/tests/spirv/builtin-no-volatile-graphics-stages.slang
+++ b/tests/spirv/builtin-no-volatile-graphics-stages.slang
@@ -1,0 +1,108 @@
+// builtin-no-volatile-graphics-stages.slang
+//
+// Regression test for shader-slang/slang#10528. The
+// `isRaytracingStageRequiringVolatileBuiltins` predicate is the gate
+// for the subgroup/SM Volatile path on a builtin's referencing entry
+// points. The positive RT stages (raygen, closesthit, miss,
+// intersection, callable) are pinned by sibling tests; this test pins
+// the negative case from each non-RT graphics stage that can read
+// `WaveGetLaneIndex()` (vertex, fragment, geometry, mesh, amplification).
+// A regression that widened the gate to `true` for any graphics stage
+// would emit `Volatile` on `SubgroupLocalInvocationId` and silently
+// regress these stages — closesthit-only coverage cannot catch that.
+//
+// Tessellation (hull/domain) is deliberately scoped out: hull entry
+// points have additional patch-constant function plumbing that doesn't
+// add coverage to the gate test, and the same `WaveGetLaneIndex()` →
+// `SubgroupLocalInvocationId` lowering is exercised by the five stages
+// here.
+
+//TEST:SIMPLE(filecheck=CHECK_VS): -target spirv-asm -entry vsMain -stage vertex -emit-spirv-directly
+// Fragment uses `-skip-spirv-validation`: reading
+// `SubgroupLocalInvocationId` from a fragment shader trips
+// `VUID-StandaloneSpirv-Flat-04744` (Input integer interfaces require
+// `Flat`), which is unrelated to the gate this test is asserting. The
+// disassembly is still produced and the `Volatile`-absence pattern can
+// be checked.
+//TEST:SIMPLE(filecheck=CHECK_PS): -target spirv-asm -entry psMain -stage fragment -emit-spirv-directly -skip-spirv-validation
+//TEST:SIMPLE(filecheck=CHECK_GS): -target spirv-asm -entry gsMain -stage geometry -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK_MS): -target spirv-asm -entry msMain -stage mesh -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK_AS): -target spirv-asm -entry asMain -stage amplification -emit-spirv-directly
+
+RWStructuredBuffer<uint> output;
+
+// Each stage's `CHECK_*-NOT` brackets the positive `CHECK_*`: leading
+// `-NOT` scans file start → match, trailing scans match → EOF, so the
+// `Volatile` absence is asserted across the whole disassembly per
+// stage.
+
+// === Vertex ===
+// CHECK_VS-NOT: Volatile
+// CHECK_VS: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupLocalInvocationId
+// CHECK_VS-NOT: Volatile
+[shader("vertex")]
+float4 vsMain(uint vid : SV_VertexID) : SV_Position
+{
+    output[vid] = WaveGetLaneIndex();
+    return float4(0, 0, 0, 1);
+}
+
+// === Fragment ===
+// CHECK_PS-NOT: Volatile
+// CHECK_PS: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupLocalInvocationId
+// CHECK_PS-NOT: Volatile
+[shader("fragment")]
+float4 psMain() : SV_Target
+{
+    output[0] = WaveGetLaneIndex();
+    return float4(0, 0, 0, 1);
+}
+
+// === Geometry ===
+// CHECK_GS-NOT: Volatile
+// CHECK_GS: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupLocalInvocationId
+// CHECK_GS-NOT: Volatile
+struct GsIn { float4 pos : SV_Position; };
+struct GsOut { float4 pos : SV_Position; };
+[shader("geometry")]
+[maxvertexcount(3)]
+void gsMain(triangle GsIn input[3], inout TriangleStream<GsOut> stream)
+{
+    output[0] = WaveGetLaneIndex();
+    GsOut o;
+    o.pos = input[0].pos;
+    stream.Append(o);
+}
+
+// === Mesh ===
+// CHECK_MS-NOT: Volatile
+// CHECK_MS: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupLocalInvocationId
+// CHECK_MS-NOT: Volatile
+struct MsVtx { float4 pos : SV_Position; };
+[shader("mesh")]
+[outputtopology("triangle")]
+[numthreads(1, 1, 1)]
+void msMain(out vertices MsVtx verts[3], out indices uint3 tris[1])
+{
+    SetMeshOutputCounts(3, 1);
+    output[0] = WaveGetLaneIndex();
+    verts[0].pos = float4(0, 0, 0, 1);
+    verts[1].pos = float4(0, 0, 0, 1);
+    verts[2].pos = float4(0, 0, 0, 1);
+    tris[0] = uint3(0, 1, 2);
+}
+
+// === Amplification ===
+// CHECK_AS-NOT: Volatile
+// CHECK_AS: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupLocalInvocationId
+// CHECK_AS-NOT: Volatile
+struct AsPayload { uint v; };
+[shader("amplification")]
+[numthreads(1, 1, 1)]
+void asMain()
+{
+    AsPayload p;
+    p.v = WaveGetLaneIndex();
+    output[0] = p.v;
+    DispatchMesh(1, 1, 1, p);
+}

--- a/tests/spirv/builtin-no-volatile-raytmax.slang
+++ b/tests/spirv/builtin-no-volatile-raytmax.slang
@@ -7,23 +7,55 @@
 // must NOT be decorated. The positive case (Intersection) is pinned by
 // `builtin-volatile-raytmax-intersection.slang` /
 // `builtin-volatile-raytmax-vk-mem-model.slang`; this test pins the
-// negative case from one representative stage (closesthit) under both
-// memory models. The same `CHECK-NOT: Volatile` rejects either form
-// (variable-level decoration under GLSL450, per-access mask under
-// vk_mem_model).
+// negative case from each of the three non-Intersection RT stages
+// (anyhit, closesthit, miss) under both memory models. Three stages ×
+// two memory models = six directives. A regression that widened the
+// gate (e.g. swapped `Stage::Intersection` for `isRaytracingStage(...)`)
+// would silently regress on the AnyHit / Miss paths if those stages
+// weren't explicitly exercised — closesthit alone is insufficient.
+// The same `CHECK_*-NOT: Volatile` rejects either failure form per
+// stage (variable-level decoration under GLSL450, per-access mask
+// under vk_mem_model).
 
-//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry closestHitMain -stage closesthit -emit-spirv-directly
-//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry closestHitMain -stage closesthit -emit-spirv-directly -capability vk_mem_model
+//TEST:SIMPLE(filecheck=CHECK_CH): -target spirv-asm -entry closestHitMain -stage closesthit -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK_CH): -target spirv-asm -entry closestHitMain -stage closesthit -emit-spirv-directly -capability vk_mem_model
+//TEST:SIMPLE(filecheck=CHECK_AH): -target spirv-asm -entry anyHitMain -stage anyhit -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK_AH): -target spirv-asm -entry anyHitMain -stage anyhit -emit-spirv-directly -capability vk_mem_model
+//TEST:SIMPLE(filecheck=CHECK_MISS): -target spirv-asm -entry missMain -stage miss -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK_MISS): -target spirv-asm -entry missMain -stage miss -emit-spirv-directly -capability vk_mem_model
 
 RWStructuredBuffer<float> output;
 
 struct Payload { float v; };
 struct Attribs { float2 b; };
 
-// CHECK: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn RayTmaxKHR
-// CHECK-NOT: Volatile
+// Each stage's `CHECK_*-NOT` brackets the positive `CHECK_*`: leading
+// `-NOT` scans file start → match, trailing scans match → EOF, so the
+// `Volatile` absence is asserted across the whole disassembly per
+// stage.
+// CHECK_CH-NOT: Volatile
+// CHECK_CH: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn RayTmaxKHR
+// CHECK_CH-NOT: Volatile
 [shader("closesthit")]
 void closestHitMain(inout Payload p, in Attribs a)
+{
+    p.v = RayTCurrent();
+}
+
+// CHECK_AH-NOT: Volatile
+// CHECK_AH: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn RayTmaxKHR
+// CHECK_AH-NOT: Volatile
+[shader("anyhit")]
+void anyHitMain(inout Payload p, in Attribs a)
+{
+    p.v = RayTCurrent();
+}
+
+// CHECK_MISS-NOT: Volatile
+// CHECK_MISS: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn RayTmaxKHR
+// CHECK_MISS-NOT: Volatile
+[shader("miss")]
+void missMain(inout Payload p)
 {
     p.v = RayTCurrent();
 }

--- a/tests/spirv/builtin-no-volatile-raytmax.slang
+++ b/tests/spirv/builtin-no-volatile-raytmax.slang
@@ -1,0 +1,29 @@
+// builtin-no-volatile-raytmax.slang
+//
+// Regression test for shader-slang/slang#10528. `RayTCurrent()` lowers
+// to `OpLoad builtin(RayTmaxKHR)`. The Vulkan SPIR-V env spec mandates
+// `Volatile` semantics on `RayTmaxKHR` only in the Intersection stage;
+// in AnyHit, ClosestHit, and Miss the builtin is read-only-stable and
+// must NOT be decorated. The positive case (Intersection) is pinned by
+// `builtin-volatile-raytmax-intersection.slang` /
+// `builtin-volatile-raytmax-vk-mem-model.slang`; this test pins the
+// negative case from one representative stage (closesthit) under both
+// memory models. The same `CHECK-NOT: Volatile` rejects either form
+// (variable-level decoration under GLSL450, per-access mask under
+// vk_mem_model).
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry closestHitMain -stage closesthit -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry closestHitMain -stage closesthit -emit-spirv-directly -capability vk_mem_model
+
+RWStructuredBuffer<float> output;
+
+struct Payload { float v; };
+struct Attribs { float2 b; };
+
+// CHECK: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn RayTmaxKHR
+// CHECK-NOT: Volatile
+[shader("closesthit")]
+void closestHitMain(inout Payload p, in Attribs a)
+{
+    p.v = RayTCurrent();
+}

--- a/tests/spirv/builtin-no-volatile-subgroupid.slang
+++ b/tests/spirv/builtin-no-volatile-subgroupid.slang
@@ -1,0 +1,53 @@
+// builtin-no-volatile-subgroupid.slang
+//
+// Regression test for shader-slang/slang#10528 — SubgroupId exclusion.
+//
+// `needVolatileDecorationForBuiltinVar` deliberately OMITS
+// `SpvBuiltInSubgroupId` from the volatile-required switch (anchored
+// at `slang-emit-spirv.cpp:6935-6946`). The omission is per Vulkan
+// SPIR-V env spec VUID-SubgroupId-SubgroupId-04367, which restricts
+// `BuiltIn SubgroupId` to compute-class execution models — adding
+// `Volatile` to it under a raytracing stage doesn't make the SPIR-V
+// any more valid (VUID-04367 fires regardless of `Volatile`); the
+// usability of `WaveGetWaveIndex()` in RT stages is tracked
+// separately as #11303.
+//
+// A future contributor "completing" the volatile switch by adding
+// `case SpvBuiltInSubgroupId:` (a plausible mechanical refactor)
+// would not fail any of the existing 11 tests, because none of them
+// reaches `BuiltIn SubgroupId` from a raytracing-volatile stage.
+// This test pins that omission directly via a hand-rolled `spirv_asm`
+// block (the same style `builtin-volatile-smidnv-warpidnv.slang`
+// uses to reach `SMIDNV`/`WarpIDNV`, which also have no Slang
+// intrinsic surface). `SubgroupId` from raygen is invalid SPIR-V
+// per VUID-04367, so the directives carry `-skip-spirv-validation`
+// — the regression we're guarding against is the appearance of
+// `Volatile` decoration on a builtin Slang shouldn't be flagging in
+// the first place, not the underlying VUID.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry rayGenMain -stage raygeneration -emit-spirv-directly -skip-spirv-validation
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry rayGenMain -stage raygeneration -emit-spirv-directly -capability vk_mem_model -skip-spirv-validation
+
+RWStructuredBuffer<uint> output;
+
+uint readSubgroupId()
+{
+    return spirv_asm
+    {
+        OpCapability GroupNonUniform;
+        result:$$uint = OpLoad builtin(SubgroupId:uint)
+    };
+}
+
+// `BuiltIn SubgroupId` decoration must appear (the variable IS emitted
+// — Slang doesn't gatekeep the underlying SPIR-V validity), but neither
+// `OpDecorate %V Volatile` nor any `OpLoad ... Volatile` against this
+// variable may appear under either memory model.
+// CHECK: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupId
+// CHECK-NOT: Volatile
+
+[shader("raygeneration")]
+void rayGenMain()
+{
+    output[0] = readSubgroupId();
+}

--- a/tests/spirv/builtin-volatile-combined-intersection.slang
+++ b/tests/spirv/builtin-volatile-combined-intersection.slang
@@ -1,0 +1,58 @@
+// builtin-volatile-combined-intersection.slang
+//
+// Regression test for shader-slang/slang#10528 — combined subgroup +
+// `RayTmaxKHR` in a single intersection entry point.
+//
+// `needVolatileDecorationForBuiltinVar` has two independent trigger
+// paths: the subgroup/SM family (gated on
+// `isRaytracingStageRequiringVolatileBuiltins` walking
+// `m_referencingEntryPoints`) and the `RayTmaxKHR` branch (gated on
+// `isInstUsedInStage(irInst, Stage::Intersection)`). Every other
+// regression test exercises one path or the other in isolation; this
+// one mixes both in a single body so a regression that interferes
+// between them — e.g. an early-return that fires for one family and
+// short-circuits the other, or a shared cache slot accidentally
+// collapsing two builtins — would be caught.
+//
+// `intersectionMain` reads three distinct builtins:
+//   - `WaveGetLaneIndex()`  → `SubgroupLocalInvocationId`
+//   - `WaveGetLaneCount()`  → `SubgroupSize`
+//   - `RayTCurrent()`       → `RayTmaxKHR` (Intersection-only)
+//
+// All three must be flagged volatile in this stage under both memory
+// models.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry intersectionMain -stage intersection -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK_VK): -target spirv-asm -entry intersectionMain -stage intersection -emit-spirv-directly -capability vk_mem_model
+
+RWStructuredBuffer<float> output;
+
+// === GLSL450 path ===
+// All three variables get `OpDecorate ... Volatile` after the BuiltIn.
+// CHECK-DAG: OpDecorate %[[L:[A-Za-z0-9_]+]] BuiltIn SubgroupLocalInvocationId
+// CHECK-DAG: OpDecorate %[[L]] Volatile
+// CHECK-DAG: OpDecorate %[[S:[A-Za-z0-9_]+]] BuiltIn SubgroupSize
+// CHECK-DAG: OpDecorate %[[S]] Volatile
+// CHECK-DAG: OpDecorate %[[T:[A-Za-z0-9_]+]] BuiltIn RayTmaxKHR
+// CHECK-DAG: OpDecorate %[[T]] Volatile
+
+// === vk_mem_model path ===
+// No variable-level Volatile on any of the three; each `OpLoad` of
+// each variable carries the `Volatile` memory-access mask.
+// CHECK_VK-DAG: OpDecorate %[[L_VK:[A-Za-z0-9_]+]] BuiltIn SubgroupLocalInvocationId
+// CHECK_VK-DAG: OpDecorate %[[S_VK:[A-Za-z0-9_]+]] BuiltIn SubgroupSize
+// CHECK_VK-DAG: OpDecorate %[[T_VK:[A-Za-z0-9_]+]] BuiltIn RayTmaxKHR
+// CHECK_VK-NOT: OpDecorate %[[L_VK]] Volatile
+// CHECK_VK-NOT: OpDecorate %[[S_VK]] Volatile
+// CHECK_VK-NOT: OpDecorate %[[T_VK]] Volatile
+// CHECK_VK-DAG: OpLoad {{.*}} %[[L_VK]] {{.*}}Volatile
+// CHECK_VK-DAG: OpLoad {{.*}} %[[S_VK]] {{.*}}Volatile
+// CHECK_VK-DAG: OpLoad {{.*}} %[[T_VK]] {{.*}}Volatile
+
+[shader("intersection")]
+void intersectionMain()
+{
+    output[0] = float(WaveGetLaneIndex())
+              + float(WaveGetLaneCount())
+              + RayTCurrent();
+}

--- a/tests/spirv/builtin-volatile-mixed-stages.slang
+++ b/tests/spirv/builtin-volatile-mixed-stages.slang
@@ -1,0 +1,56 @@
+// builtin-volatile-mixed-stages.slang
+//
+// Regression test for shader-slang/slang#10528.
+// A single Slang module with both `cs()` (compute) and `rg()`
+// (raygeneration) entry points reading `WaveGetLaneIndex()`. Pins the
+// observed end-to-end SPIR-V emit behaviour so that a regression in
+// either the IR-side referencing-entry-points propagation or the
+// `BuiltinSpvVarKey` keying would be visible:
+//
+// With the current IR pipeline, the `SPIRVAsmOperandBuiltinVar` is
+// shared / referenced from both entry points. Because at least one
+// referencing stage (`raygeneration`) is in the raytracing-volatile
+// set, `needVolatileDecorationForBuiltinVar` returns true and the
+// single emitted `OpVariable` is decorated `Volatile` under the
+// GLSL450 memory model. The `OpEntryPoint` for the compute entry
+// point therefore inherits `Volatile` semantics on its load —
+// overconservative but spec-correct. `BuiltinSpvVarKey` is keyed on
+// (builtin, storage class, flat, pointee type); if a future IR pass
+// kept distinct builtin operands per call-site, this test would need
+// to assert two `OpVariable`s instead of one.
+//
+// What this test pins, regardless of which side of that split the
+// pipeline lands on:
+// - the `BuiltIn SubgroupLocalInvocationId` decoration is present;
+// - the `Volatile` decoration is present (not lost by an over-eager
+//   compute-only filter);
+// - both entry points compile cleanly and reference a builtin in
+//   their `OpEntryPoint` interface list.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry cs -entry rg -emit-spirv-directly
+
+RWStructuredBuffer<uint> output;
+
+// Both entry points are emitted and each lists `SubgroupLocalInvocationId`
+// in its `OpEntryPoint` interface.
+// CHECK: OpEntryPoint GLCompute %{{[A-Za-z0-9_]+}} "cs" {{.*}}SubgroupLocalInvocationId
+// CHECK: OpEntryPoint RayGenerationKHR %{{[A-Za-z0-9_]+}} "rg" {{.*}}SubgroupLocalInvocationId
+
+// The builtin variable is decorated `BuiltIn` and `Volatile`. The
+// raygen path requires the `Volatile` decoration; if the cache axis
+// or stage-set logic were to drop it, this would fail.
+// CHECK-DAG: OpDecorate %[[V:[A-Za-z0-9_]+]] BuiltIn SubgroupLocalInvocationId
+// CHECK-DAG: OpDecorate %[[V]] Volatile
+
+[numthreads(64, 1, 1)]
+[shader("compute")]
+void cs()
+{
+    output[0] = WaveGetLaneIndex();
+}
+
+[shader("raygeneration")]
+void rg()
+{
+    output[1] = WaveGetLaneIndex();
+}

--- a/tests/spirv/builtin-volatile-mixed-stages.slang
+++ b/tests/spirv/builtin-volatile-mixed-stages.slang
@@ -28,19 +28,54 @@
 //   their `OpEntryPoint` interface list.
 
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry cs -entry rg -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK_VK): -target spirv-asm -entry cs -entry rg -emit-spirv-directly -capability vk_mem_model
 
 RWStructuredBuffer<uint> output;
 
+// === GLSL450 path ===
 // Both entry points are emitted and each lists `SubgroupLocalInvocationId`
 // in its `OpEntryPoint` interface.
 // CHECK: OpEntryPoint GLCompute %{{[A-Za-z0-9_]+}} "cs" {{.*}}SubgroupLocalInvocationId
 // CHECK: OpEntryPoint RayGenerationKHR %{{[A-Za-z0-9_]+}} "rg" {{.*}}SubgroupLocalInvocationId
 
-// The builtin variable is decorated `BuiltIn` and `Volatile`. The
-// raygen path requires the `Volatile` decoration; if the cache axis
-// or stage-set logic were to drop it, this would fail.
-// CHECK-DAG: OpDecorate %[[V:[A-Za-z0-9_]+]] BuiltIn SubgroupLocalInvocationId
-// CHECK-DAG: OpDecorate %[[V]] Volatile
+// Exactly one `OpVariable` for `SubgroupLocalInvocationId` is emitted,
+// and that one variable is decorated `Volatile`. The raygen path
+// requires the `Volatile` decoration; if the cache axis or stage-set
+// logic were to drop it, this would fail.
+//
+// The PR drops `isVolatile` from the cache key on the assumption that
+// all references to a given builtin share one IR-side
+// `IRSPIRVAsmOperandBuiltinVar`; if a future IR change splits per
+// call-site operands, the cache would emit two variables and the
+// volatile decoration could land on only the second one (silent
+// regression on the compute-side load). The exact-1 count + the
+// trailing not-clause pins this single-variable invariant. The
+// captured `[[V]]` is then reused for the `Volatile` decoration so
+// all assertions tie back to the same one variable.
+// CHECK-COUNT-1: OpDecorate %[[V:[A-Za-z0-9_]+]] BuiltIn SubgroupLocalInvocationId
+// CHECK-NOT: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupLocalInvocationId
+// CHECK: OpDecorate %[[V]] Volatile
+
+// === vk_mem_model path ===
+// Same shared `OpVariable` for both stages, but the `Volatile` semantic
+// surfaces as the per-`OpLoad` memory-access mask rather than a variable
+// decoration. Since the IR-side flagging is keyed on the union of
+// referencing entry points (raygen pulls the operand into the volatile
+// set; compute side then shares it), BOTH `OpLoad`s carry the mask —
+// overconservative on the compute side but spec-correct, mirroring the
+// GLSL450 inheritance. The exact-2 count plus the trailing not-clause
+// pins the upper bound so a regression that flips the disambiguation in
+// either direction (no loads, or three loads) is caught.
+// CHECK_VK: OpEntryPoint GLCompute %{{[A-Za-z0-9_]+}} "cs" {{.*}}SubgroupLocalInvocationId
+// CHECK_VK: OpEntryPoint RayGenerationKHR %{{[A-Za-z0-9_]+}} "rg" {{.*}}SubgroupLocalInvocationId
+// Exactly one BuiltIn SubgroupLocalInvocationId decoration (single-
+// OpVariable invariant under vk_mem_model too); no variable-level
+// Volatile on it; both OpLoads of it carry the per-access mask.
+// CHECK_VK-COUNT-1: OpDecorate %[[V_VK:[A-Za-z0-9_]+]] BuiltIn SubgroupLocalInvocationId
+// CHECK_VK-NOT: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupLocalInvocationId
+// CHECK_VK-NOT: OpDecorate %[[V_VK]] Volatile
+// CHECK_VK-COUNT-2: OpLoad {{.*}} %[[V_VK]] Volatile
+// CHECK_VK-NOT: OpLoad {{.*}} %[[V_VK]] Volatile
 
 [numthreads(64, 1, 1)]
 [shader("compute")]

--- a/tests/spirv/builtin-volatile-raytmax-intersection.slang
+++ b/tests/spirv/builtin-volatile-raytmax-intersection.slang
@@ -1,0 +1,19 @@
+// builtin-volatile-raytmax-intersection.slang
+//
+// Regression test for shader-slang/slang#10528.
+// `RayTmaxKHR` accessed via `RayTCurrent()` in an intersection shader
+// must be decorated with `Volatile` under the GLSL450 memory model;
+// the value reflects the current candidate hit and can change between
+// accesses driven by traversal.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry intersectionMain -stage intersection -emit-spirv-directly
+
+RWStructuredBuffer<float> output;
+
+// CHECK-DAG: OpDecorate %[[T:[A-Za-z0-9_]+]] BuiltIn RayTmaxKHR
+// CHECK-DAG: OpDecorate %[[T]] Volatile
+[shader("intersection")]
+void intersectionMain()
+{
+    output[0] = RayTCurrent();
+}

--- a/tests/spirv/builtin-volatile-raytmax-vk-mem-model.slang
+++ b/tests/spirv/builtin-volatile-raytmax-vk-mem-model.slang
@@ -1,0 +1,30 @@
+// builtin-volatile-raytmax-vk-mem-model.slang
+//
+// Regression test for shader-slang/slang#10528.
+// Companion to `builtin-volatile-vk-mem-model.slang`, but exercising
+// the `RayTmaxKHR` branch of `needVolatileDecorationForBuiltinVar`
+// instead of the subgroup branch. Under the Vulkan memory model the
+// `RayTmaxKHR` variable in an intersection shader must NOT carry the
+// variable-level `Volatile` decoration, and every load of it must
+// instead carry the per-access `Volatile` memory access mask.
+//
+// Two `RayTCurrent()` calls inside the same intersection entry point
+// produce two `OpLoad` instructions, both of which must include the
+// mask.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry intersectionMain -stage intersection -emit-spirv-directly -capability vk_mem_model
+
+RWStructuredBuffer<float> output;
+
+// CHECK: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn RayTmaxKHR
+// The `Volatile` token must appear only as a per-access memory operand
+// on each `OpLoad`, not as a variable-level decoration.
+// CHECK-NOT: OpDecorate %{{[A-Za-z0-9_]+}} Volatile
+// CHECK-COUNT-2: OpLoad {{.*}} %{{[A-Za-z0-9_]+}} {{.*}}Volatile
+
+[shader("intersection")]
+void intersectionMain()
+{
+    output[0] = RayTCurrent();
+    output[1] = RayTCurrent() + 1.0;
+}

--- a/tests/spirv/builtin-volatile-raytracing.slang
+++ b/tests/spirv/builtin-volatile-raytracing.slang
@@ -1,0 +1,81 @@
+// builtin-volatile-raytracing.slang
+//
+// Regression test for shader-slang/slang#10528. Subgroup builtins used
+// in any of the five raytracing-volatile stages (raygen, closesthit,
+// miss, intersection, callable) must be decorated `Volatile` under the
+// GLSL450 memory model — invocation repacking can change the underlying
+// value between accesses. Per-stage directives pin
+// `isRaytracingStageRequiringVolatileBuiltins` so a regression that
+// drops one switch arm fails. The raygen entry point also exercises
+// the via-glsl path (glslang owns the decoration in `Initialize.cpp`'s
+// `rtSubgroupDecls` block) and the SPIR-V emission of several wave
+// intrinsics — enough to catch a regression in either the direct emit
+// path or the glslang baseline.
+
+//TEST:SIMPLE(filecheck=CHECK_RAYGEN): -target spirv-asm -entry rayGenMain -stage raygeneration -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK_CLOSESTHIT): -target spirv-asm -entry closestHitMain -stage closesthit -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK_MISS): -target spirv-asm -entry missMain -stage miss -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK_INTERSECTION): -target spirv-asm -entry intersectionMain -stage intersection -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK_CALLABLE): -target spirv-asm -entry callableMain -stage callable -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK_VIA_GLSL): -target spirv-asm -entry rayGenMain -stage raygeneration -emit-spirv-via-glsl
+
+RWStructuredBuffer<uint> output;
+
+struct Payload { uint v; };
+struct Attribs { float2 b; };
+struct CallableData { uint v; };
+
+// Direct emit, raygen — covers wave intrinsic emission alongside the Volatile decoration.
+// CHECK_RAYGEN-DAG: OpDecorate %[[LANE:[A-Za-z0-9_]+]] BuiltIn SubgroupLocalInvocationId
+// CHECK_RAYGEN-DAG: OpDecorate %[[LANE]] Volatile
+// CHECK_RAYGEN-DAG: OpDecorate %[[SIZE:[A-Za-z0-9_]+]] BuiltIn SubgroupSize
+// CHECK_RAYGEN-DAG: OpDecorate %[[SIZE]] Volatile
+// CHECK_RAYGEN-DAG: OpGroupNonUniformElect
+// CHECK_RAYGEN-DAG: OpGroupNonUniformBallot
+// CHECK_RAYGEN-DAG: OpGroupNonUniformBroadcastFirst
+[shader("raygeneration")]
+void rayGenMain()
+{
+    bool isFirst = WaveIsFirstLane();
+    uint laneIdx = WaveGetLaneIndex();
+    uint laneCount = WaveGetLaneCount();
+    uint4 ballot = WaveActiveBallot(laneIdx < 16);
+    uint firstValue = WaveReadLaneFirst(laneIdx);
+    output[0] = uint(isFirst) + laneIdx + laneCount + ballot.x + firstValue;
+}
+
+// CHECK_CLOSESTHIT-DAG: OpDecorate %[[V2:[A-Za-z0-9_]+]] BuiltIn SubgroupLocalInvocationId
+// CHECK_CLOSESTHIT-DAG: OpDecorate %[[V2]] Volatile
+[shader("closesthit")]
+void closestHitMain(inout Payload p, in Attribs a)
+{
+    p.v = WaveGetLaneIndex();
+}
+
+// CHECK_MISS-DAG: OpDecorate %[[V3:[A-Za-z0-9_]+]] BuiltIn SubgroupLocalInvocationId
+// CHECK_MISS-DAG: OpDecorate %[[V3]] Volatile
+[shader("miss")]
+void missMain(inout Payload p)
+{
+    p.v = WaveGetLaneIndex();
+}
+
+// CHECK_INTERSECTION-DAG: OpDecorate %[[V4:[A-Za-z0-9_]+]] BuiltIn SubgroupLocalInvocationId
+// CHECK_INTERSECTION-DAG: OpDecorate %[[V4]] Volatile
+[shader("intersection")]
+void intersectionMain()
+{
+    output[0] = WaveGetLaneIndex();
+}
+
+// CHECK_CALLABLE-DAG: OpDecorate %[[V5:[A-Za-z0-9_]+]] BuiltIn SubgroupLocalInvocationId
+// CHECK_CALLABLE-DAG: OpDecorate %[[V5]] Volatile
+[shader("callable")]
+void callableMain(inout CallableData c)
+{
+    c.v = WaveGetLaneIndex();
+}
+
+// Via-glsl raygen — pins glslang's `rtSubgroupDecls` `Volatile` emission.
+// CHECK_VIA_GLSL-DAG: OpDecorate %[[LANE_VIA:[A-Za-z0-9_]+]] BuiltIn SubgroupLocalInvocationId
+// CHECK_VIA_GLSL-DAG: OpDecorate %[[LANE_VIA]] Volatile

--- a/tests/spirv/builtin-volatile-smidnv-warpidnv.slang
+++ b/tests/spirv/builtin-volatile-smidnv-warpidnv.slang
@@ -1,0 +1,66 @@
+// builtin-volatile-smidnv-warpidnv.slang
+//
+// Regression test for shader-slang/slang#10528.
+// `SMIDNV` and `WarpIDNV` are listed in the Vulkan SPIR-V env spec
+// as Volatile-required in raytracing-volatile stages. Slang has no
+// built-in intrinsic that lowers to them today (no
+// `__intrinsic_asm` / `spirv_asm` referent in `hlsl.meta.slang`),
+// so a `case` typo (e.g. swapping `SMIDNV` and `WarpIDNV`) or a
+// silent removal would not be caught by any of the
+// hlsl.meta.slang-driven tests.
+//
+// This test reaches the cases via a hand-written `spirv_asm` block
+// that emits `OpLoad builtin(SMIDNV:uint)` and
+// `OpLoad builtin(WarpIDNV:uint)` directly from a raygen entry
+// point. Each variable must end up with the `Volatile` decoration
+// under the GLSL450 memory model.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry rayGenMain -stage raygeneration -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK_VK_MM): -target spirv-asm -entry rayGenMain -stage raygeneration -emit-spirv-directly -capability vk_mem_model
+
+RWStructuredBuffer<uint> output;
+
+uint readSmId()
+{
+    return spirv_asm
+    {
+        OpCapability ShaderSMBuiltinsNV;
+        OpExtension "SPV_NV_shader_sm_builtins";
+        result:$$uint = OpLoad builtin(SMIDNV:uint)
+    };
+}
+
+uint readWarpId()
+{
+    return spirv_asm
+    {
+        OpCapability ShaderSMBuiltinsNV;
+        OpExtension "SPV_NV_shader_sm_builtins";
+        result:$$uint = OpLoad builtin(WarpIDNV:uint)
+    };
+}
+
+// Both builtin variables get a `Volatile` decoration under GLSL450
+// in raygen. Use CHECK-DAG so this is order-independent.
+// CHECK-DAG: OpDecorate %[[SM:[A-Za-z0-9_]+]] BuiltIn SMIDNV
+// CHECK-DAG: OpDecorate %[[SM]] Volatile
+// CHECK-DAG: OpDecorate %[[WARP:[A-Za-z0-9_]+]] BuiltIn WarpIDNV
+// CHECK-DAG: OpDecorate %[[WARP]] Volatile
+
+// Under the Vulkan memory model the variable-level `Volatile`
+// decoration is invalid; the per-access mask on each `OpLoad`
+// carries the requirement instead. Pin both halves: BuiltIn
+// decorations present, no variable-level Volatile, and each
+// `OpLoad` carries the Volatile mask.
+// CHECK_VK_MM-DAG: OpDecorate %[[SM2:[A-Za-z0-9_]+]] BuiltIn SMIDNV
+// CHECK_VK_MM-DAG: OpDecorate %[[WARP2:[A-Za-z0-9_]+]] BuiltIn WarpIDNV
+// CHECK_VK_MM-NOT: OpDecorate %{{[A-Za-z0-9_]+}} Volatile
+// CHECK_VK_MM-DAG: OpLoad {{.*}} %[[SM2]] {{.*}}Volatile
+// CHECK_VK_MM-DAG: OpLoad {{.*}} %[[WARP2]] {{.*}}Volatile
+
+[shader("raygeneration")]
+void rayGenMain()
+{
+    output[0] = readSmId();
+    output[1] = readWarpId();
+}

--- a/tests/spirv/builtin-volatile-spirv-asm-user-mask.slang
+++ b/tests/spirv/builtin-volatile-spirv-asm-user-mask.slang
@@ -1,0 +1,73 @@
+// builtin-volatile-spirv-asm-user-mask.slang
+//
+// Regression test for shader-slang/slang#10528.
+// Pins the user-authored-memory-operand path of the `emitSPIRVAsm`
+// `OpLoad` Volatile injection. SPIR-V `OpLoad` accepts at most one
+// `MemoryAccess` bitmask operand; appending an auto-injected
+// `Volatile` word next to a user-supplied one would produce two
+// consecutive memory-access words, which `spirv-val` rejects as
+// ungrammatical. Conversely, simply suppressing auto-injection when
+// the user wrote any mask would silently ship a load missing the
+// spec-required `Volatile` semantics — `OpLoad ... Aligned 4`
+// against a flagged builtin under `vk_mem_model` would be invalid
+// SPIR-V.
+//
+// The fix: detect a flagged builtin pointer regardless of operand
+// count, then OR `Volatile` into the user-supplied mask at emit
+// time. This test exercises both forms — the named `Volatile`
+// keyword and a non-Volatile mask `Aligned 4` — and asserts that
+// the emitted load carries `Volatile` in both cases:
+//
+//   - keyword form: `OpLoad ... %V Volatile` (Volatile|Volatile
+//     collapses to Volatile);
+//   - `Aligned 4` form: `OpLoad ... %V Volatile|Aligned 4`
+//     (Volatile bit OR'd into the user-supplied Aligned mask;
+//     alignment value preserved).
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry rayGenKeyword -entry rayGenAligned -emit-spirv-directly -capability vk_mem_model
+
+RWStructuredBuffer<uint> output;
+
+// One Input variable, no variable-level Volatile decoration under
+// vk_mem_model.
+// CHECK: OpDecorate %[[V:[A-Za-z0-9_]+]] BuiltIn SubgroupLocalInvocationId
+// CHECK-NOT: OpDecorate %[[V]] Volatile
+
+// Each entry point produces exactly one `OpLoad`. End-anchor each
+// positive match (`{{$}}`) so an emit regression that doubles the
+// memory-access word — producing `... Volatile Volatile` or
+// `... Aligned 4 Volatile` on the same line — would fail outright.
+// Bit order in the printed mask is implementation-defined; accept
+// either `Volatile|Aligned` or `Aligned|Volatile`.
+// CHECK-DAG: OpLoad %{{[^ ]+}} %[[V]] Volatile{{$}}
+// CHECK-DAG: OpLoad %{{[^ ]+}} %[[V]] {{(Volatile\|Aligned|Aligned\|Volatile)}} 4{{$}}
+
+uint readKeywordMask()
+{
+    return spirv_asm
+    {
+        OpCapability GroupNonUniform;
+        result:$$uint = OpLoad builtin(SubgroupLocalInvocationId:uint) Volatile
+    };
+}
+
+uint readAlignedMask()
+{
+    return spirv_asm
+    {
+        OpCapability GroupNonUniform;
+        result:$$uint = OpLoad builtin(SubgroupLocalInvocationId:uint) Aligned 4
+    };
+}
+
+[shader("raygeneration")]
+void rayGenKeyword()
+{
+    output[0] = readKeywordMask();
+}
+
+[shader("raygeneration")]
+void rayGenAligned()
+{
+    output[1] = readAlignedMask();
+}

--- a/tests/spirv/builtin-volatile-subgroup-masks.slang
+++ b/tests/spirv/builtin-volatile-subgroup-masks.slang
@@ -1,0 +1,63 @@
+// builtin-volatile-subgroup-masks.slang
+//
+// Regression test for shader-slang/slang#10528. Pins each of the five
+// `Subgroup*Mask` enumerators in `needVolatileDecorationForBuiltinVar`
+// individually so that a typo swap (e.g. `Ge` <-> `Gt`) or a silent
+// removal of any single case in the switch would fail. Same shader,
+// two memory models:
+//
+// - GLSL450: each `Subgroup*Mask` variable carries `OpDecorate ... Volatile`.
+// - Vulkan memory model: variables carry NO `Volatile` decoration; instead
+//   each `OpLoad` of those builtins carries the `Volatile` memory-access
+//   mask. (`SubgroupSize` is included to extend the vk_mem_model coverage
+//   beyond `SubgroupLocalInvocationId`, which is exercised by
+//   `builtin-volatile-vk-mem-model.slang`.)
+
+//TEST:SIMPLE(filecheck=CHECK_GLSL450): -target spirv-asm -entry rayGenMain -stage raygeneration -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK_VK_MEM_MODEL): -target spirv-asm -entry rayGenMain -stage raygeneration -emit-spirv-directly -capability vk_mem_model
+
+RWStructuredBuffer<uint> output_size;
+RWStructuredBuffer<uint4> output_eq;
+RWStructuredBuffer<uint4> output_ge;
+RWStructuredBuffer<uint4> output_gt;
+RWStructuredBuffer<uint4> output_le;
+RWStructuredBuffer<uint4> output_lt;
+
+// GLSL450: variable-level Volatile on each mask + SubgroupSize.
+// CHECK_GLSL450-DAG: OpDecorate %[[SZ:[A-Za-z0-9_]+]] BuiltIn SubgroupSize
+// CHECK_GLSL450-DAG: OpDecorate %[[SZ]] Volatile
+// CHECK_GLSL450-DAG: OpDecorate %[[EQ:[A-Za-z0-9_]+]] BuiltIn SubgroupEqMask
+// CHECK_GLSL450-DAG: OpDecorate %[[EQ]] Volatile
+// CHECK_GLSL450-DAG: OpDecorate %[[GE:[A-Za-z0-9_]+]] BuiltIn SubgroupGeMask
+// CHECK_GLSL450-DAG: OpDecorate %[[GE]] Volatile
+// CHECK_GLSL450-DAG: OpDecorate %[[GT:[A-Za-z0-9_]+]] BuiltIn SubgroupGtMask
+// CHECK_GLSL450-DAG: OpDecorate %[[GT]] Volatile
+// CHECK_GLSL450-DAG: OpDecorate %[[LE:[A-Za-z0-9_]+]] BuiltIn SubgroupLeMask
+// CHECK_GLSL450-DAG: OpDecorate %[[LE]] Volatile
+// CHECK_GLSL450-DAG: OpDecorate %[[LT:[A-Za-z0-9_]+]] BuiltIn SubgroupLtMask
+// CHECK_GLSL450-DAG: OpDecorate %[[LT]] Volatile
+
+// Vulkan memory model: BuiltIn decorations only, Volatile mask on each load.
+// CHECK_VK_MEM_MODEL-DAG: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupSize
+// CHECK_VK_MEM_MODEL-DAG: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupEqMask
+// CHECK_VK_MEM_MODEL-DAG: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupGeMask
+// CHECK_VK_MEM_MODEL-DAG: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupGtMask
+// CHECK_VK_MEM_MODEL-DAG: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupLeMask
+// CHECK_VK_MEM_MODEL-DAG: OpDecorate %{{[A-Za-z0-9_]+}} BuiltIn SubgroupLtMask
+// CHECK_VK_MEM_MODEL-DAG: OpLoad {{.*}} %{{[A-Za-z0-9_]*}}SubgroupSize{{[A-Za-z0-9_]*}} {{.*}}Volatile
+// CHECK_VK_MEM_MODEL-DAG: OpLoad {{.*}} %{{[A-Za-z0-9_]*}}EqMask{{[A-Za-z0-9_]*}} {{.*}}Volatile
+// CHECK_VK_MEM_MODEL-DAG: OpLoad {{.*}} %{{[A-Za-z0-9_]*}}GeMask{{[A-Za-z0-9_]*}} {{.*}}Volatile
+// CHECK_VK_MEM_MODEL-DAG: OpLoad {{.*}} %{{[A-Za-z0-9_]*}}GtMask{{[A-Za-z0-9_]*}} {{.*}}Volatile
+// CHECK_VK_MEM_MODEL-DAG: OpLoad {{.*}} %{{[A-Za-z0-9_]*}}LeMask{{[A-Za-z0-9_]*}} {{.*}}Volatile
+// CHECK_VK_MEM_MODEL-DAG: OpLoad {{.*}} %{{[A-Za-z0-9_]*}}LtMask{{[A-Za-z0-9_]*}} {{.*}}Volatile
+
+[shader("raygeneration")]
+void rayGenMain()
+{
+    output_size[0] = WaveGetLaneCount();
+    output_eq[0] = WaveGetLaneEqMask();
+    output_ge[0] = WaveGetLaneGeMask();
+    output_gt[0] = WaveGetLaneGtMask();
+    output_le[0] = WaveGetLaneLeMask();
+    output_lt[0] = WaveGetLaneLtMask();
+}

--- a/tests/spirv/builtin-volatile-vk-mem-model.slang
+++ b/tests/spirv/builtin-volatile-vk-mem-model.slang
@@ -1,0 +1,50 @@
+// builtin-volatile-vk-mem-model.slang
+//
+// Regression test for shader-slang/slang#10528.
+// Under the Vulkan memory model the variable-level `OpDecorate Volatile`
+// is invalid; the corresponding `Volatile` semantics for subgroup
+// builtins in raytracing stages must instead be expressed as the
+// `Volatile` memory access mask on each `OpLoad`.
+//
+// Two raygeneration entry points each independently read
+// `WaveGetLaneIndex()`. After [ForceInline] both end up in the same
+// SPIR-V module and (with the current IR pipeline) share a single
+// `OpVariable` for `SubgroupLocalInvocationId`. Each entry point
+// emits its own `OpLoad` that must carry the `Volatile` memory
+// access mask. The pre-cache `m_volatileBuiltinGlobalVars.add()` in
+// `getBuiltinGlobalVar` ensures both call sites' IR-side operands
+// are flagged so the per-access mask injection in `emitSPIRVAsm`
+// fires for every `OpLoad`, not just the first one.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry rayGenMainA -entry rayGenMainB -emit-spirv-directly -capability vk_mem_model
+
+RWStructuredBuffer<uint> output;
+
+// SPIR-V layout: Annotations come before Types/Variables. Match the
+// `OpDecorate ... BuiltIn` line first, capture the variable name, and
+// pin the absence of any `OpDecorate %V Volatile` between annotations
+// (variable-level `Volatile` is invalid under the Vulkan memory model).
+// CHECK: OpDecorate %[[V:[A-Za-z0-9_]+]] BuiltIn SubgroupLocalInvocationId
+// CHECK-NOT: OpDecorate %[[V]] Volatile
+
+// Then the variable declaration in the Types/Variables section.
+// CHECK: %[[V]] = OpVariable {{.*}} Input
+
+// And both entry points emit an `OpLoad` of `%V` carrying the
+// `Volatile` memory access mask. The two-count assertion catches
+// the cache-hit alias case directly: if the second call site
+// missed the `m_volatileBuiltinGlobalVars` set, only one of the
+// two loads would carry the mask.
+// CHECK-COUNT-2: OpLoad {{.*}} %[[V]] {{.*}}Volatile
+
+[shader("raygeneration")]
+void rayGenMainA()
+{
+    output[0] = WaveGetLaneIndex();
+}
+
+[shader("raygeneration")]
+void rayGenMainB()
+{
+    output[1] = WaveGetLaneIndex();
+}

--- a/tests/spirv/builtin-volatile-vk-mem-model.slang
+++ b/tests/spirv/builtin-volatile-vk-mem-model.slang
@@ -6,17 +6,29 @@
 // builtins in raytracing stages must instead be expressed as the
 // `Volatile` memory access mask on each `OpLoad`.
 //
-// Two raygeneration entry points each independently read
-// `WaveGetLaneIndex()`. After [ForceInline] both end up in the same
-// SPIR-V module and (with the current IR pipeline) share a single
-// `OpVariable` for `SubgroupLocalInvocationId`. Each entry point
-// emits its own `OpLoad` that must carry the `Volatile` memory
-// access mask. The pre-cache `m_volatileBuiltinGlobalVars.add()` in
-// `getBuiltinGlobalVar` ensures both call sites' IR-side operands
-// are flagged so the per-access mask injection in `emitSPIRVAsm`
-// fires for every `OpLoad`, not just the first one.
+// Three raygeneration entry points exercise two independent failure
+// modes for the per-access mask injection:
+//   - `rayGenMainA` and `rayGenMainB` each read `WaveGetLaneIndex()`
+//     once. Both end up in the same SPIR-V module and (with the
+//     current IR pipeline) share a single `OpVariable` for
+//     `SubgroupLocalInvocationId`. Each entry point emits its own
+//     `OpLoad` that must carry the `Volatile` mask — the pre-cache
+//     `m_volatileBuiltinGlobalVars.add()` in `getBuiltinGlobalVar`
+//     ensures both call sites' IR-side operands are flagged so the
+//     mask injection in `emitSPIRVAsm` fires across entry-point
+//     boundaries, not just the first one.
+//   - `rayGenMainMulti` reads `WaveGetLaneIndex()` twice in a single
+//     body. This pins the per-load (not per-builtin) nature of the
+//     `case SpvOpLoad:` branch in `emitSPIRVAsm`: a regression that
+//     cached the volatile-set lookup at the first load and skipped
+//     subsequent loads would silently drop the mask on every load
+//     after the first.
+// Combined: 4 `OpLoad` instructions, each must carry `Volatile`.
+// The exact-4 count assertion plus the trailing not-clause bounds
+// the upper end so a regression that doubles the mask emission is
+// also caught.
 
-//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry rayGenMainA -entry rayGenMainB -emit-spirv-directly -capability vk_mem_model
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry rayGenMainA -entry rayGenMainB -entry rayGenMainMulti -emit-spirv-directly -capability vk_mem_model
 
 RWStructuredBuffer<uint> output;
 
@@ -30,12 +42,14 @@ RWStructuredBuffer<uint> output;
 // Then the variable declaration in the Types/Variables section.
 // CHECK: %[[V]] = OpVariable {{.*}} Input
 
-// And both entry points emit an `OpLoad` of `%V` carrying the
-// `Volatile` memory access mask. The two-count assertion catches
-// the cache-hit alias case directly: if the second call site
-// missed the `m_volatileBuiltinGlobalVars` set, only one of the
-// two loads would carry the mask.
-// CHECK-COUNT-2: OpLoad {{.*}} %[[V]] {{.*}}Volatile
+// All four `OpLoad`s of %V (one each from rayGenMainA / rayGenMainB,
+// plus two from rayGenMainMulti) must carry the Volatile memory
+// access mask. The exact count plus the trailing not-clause pins
+// both bounds: a regression that drops the mask on later loads
+// (cross-entry or intra-entry repeats) fails the count, and a
+// regression that doubles the emission fails the trailing not.
+// CHECK-COUNT-4: OpLoad {{.*}} %[[V]] {{.*}}Volatile
+// CHECK-NOT: OpLoad {{.*}} %[[V]] {{.*}}Volatile
 
 [shader("raygeneration")]
 void rayGenMainA()
@@ -47,4 +61,11 @@ void rayGenMainA()
 void rayGenMainB()
 {
     output[1] = WaveGetLaneIndex();
+}
+
+[shader("raygeneration")]
+void rayGenMainMulti()
+{
+    output[2] = WaveGetLaneIndex();
+    output[3] = WaveGetLaneIndex();
 }


### PR DESCRIPTION
## Summary

Fixes shader-slang/slang#10528 — SPIR-V emission was missing `Volatile` semantics on subgroup builtins, `SMIDNV` / `WarpIDNV`, and `RayTmaxKHR` when read from raytracing entry points. Without `Volatile`, `WaveGetLaneIndex()`, the `WaveGetLane*Mask()` family, and `RayTCurrent()` (in intersection) could observe stale values across an invocation-repack / SER boundary in raygeneration / closesthit / miss / intersection / callable shaders, per the Vulkan SPIR-V environment spec.

## Diagnosis

Two emit paths needed coverage:

- **GLSL450 memory model** — the spec requires `OpDecorate ... Volatile` on the `OpVariable` for the affected builtins when the entry point is a raytracing-volatile stage. Cross-check: `glslang`'s `Initialize.cpp` / `rtSubgroupDecls` block declares the same builtins as `in volatile` for RT stages.
- **Vulkan memory model (`vk_mem_model`)** — the spec requires the `Volatile` memory-access mask on each `OpLoad` of an affected builtin. Slang's wave intrinsics lower through `spirv_asm` blocks, so `OpLoad`s emitted verbatim by `emitSPIRVAsm` were not being touched by `getMemoryAccessOperandsOfLoadStore` and shipped without the mask.

Stage scope per spec: `{RayGeneration, ClosestHit, Miss, Intersection, Callable}`. `AnyHit` is intentionally **excluded** — the spec does not require Volatile there. `RayTmaxKHR` is even stricter — `Intersection` only.

`SubgroupId` is **not** added to the volatile-required switch. `[VUID-SubgroupId-SubgroupId-04367]` rejects `BuiltIn SubgroupId` in raytracing entry points regardless of `Volatile`. `glslang`'s `rtSubgroupDecls` likewise omits `gl_SubgroupID`. The usability of `WaveGetWaveIndex()` / `WaveGetNumWaves()` in raytracing stages is tracked separately as #11303.

## Approach

Source changes live in `source/slang/slang-emit-spirv.cpp` plus a new diagnostic registration in `source/slang/slang-diagnostics.lua`:

1. New file-local stage helper `isRaytracingStageRequiringVolatileBuiltins` (kept distinct from `isRaytracingStage` because the volatile stage-set is narrower than the general RT stage-set).
2. New predicate `needVolatileDecorationForBuiltinVar(SpvBuiltIn, IRInst*)` — switch over the affected enumerators (`SubgroupLocalInvocationId`, `SubgroupSize`, the five `Subgroup*Mask` variants, `SMIDNV`, `WarpIDNV`) gated on the volatile RT stage set, with `RayTmaxKHR` gated on Intersection only. Predicate inlines the entry-point-stage scan rather than going through a function-pointer helper.
3. **GLSL450 path:** emit `OpDecorate %var Volatile` after the existing `BuiltIn` decoration when the predicate fires (and the memory model is not Vulkan).
4. **vk_mem_model path:** track flagged builtin `IRInst*`s in `m_volatileBuiltinGlobalVars` and the materialized SPIR-V variables in a parallel `HashSet<SpvInst*> m_volatileSpvVars` populated from `getBuiltinGlobalVar` on both cache-hit and cache-miss paths. Cache-hit alias path registers the second flagged call site **before** the early return so subsequent loads through that alias don't miss the mask. `emitSPIRVAsm`'s `SpvOpLoad` branch ORs in `SpvMemoryAccessVolatileMask` when the pointer is a flagged `IRSPIRVAsmOperandBuiltinVar`. Auto-injection only fires on the minimal three-operand `OpLoad` form (no user-supplied memory operand) — guards against emitting two consecutive `MemoryAccess` words, which `spirv-val` rejects. The regular `emitLoad` / `emitStore` path (`getMemoryAccessOperandsOfLoadStore`) consults `m_volatileSpvVars` via `m_mapIRInstToSpvInst` and ORs the mask in transparently, so a future IR pipeline that lands a regular-IR load on a flagged builtin gets correct semantics without further emitter changes.
5. **New diagnostic E29117** (`spirv-asm-volatile-builtin-non-literal-mask`) — when a user-supplied memory-access mask on `OpLoad` of a Volatile-required builtin in `spirv_asm` is not representable in `OpLoad`'s memory-access slot per SPIR-V grammar (i.e. an `Id`-form runtime value), warn rather than silently drop. The emitted load still carries `Volatile`; only the user's runtime mask bits — which were never representable to begin with — are dropped.

`BuiltinSpvVarKey` keeps its four existing axes (builtin, storage class, flat, pointee type). With the current canonicalised IR pipeline, every reference to a given builtin shares one `IRSPIRVAsmOperandBuiltinVar` whose `m_referencingEntryPoints` covers all stages that use it; no cache axis is needed to disambiguate volatile / non-volatile uses of the same builtin in one module. `builtin-volatile-mixed-stages.slang` pins this single-variable behavior; if a future IR change splits per-call-site operands, that test would need to assert two `OpVariable`s and the cache may need an `isVolatile` axis re-introduced.

## Files changed

`source/slang/slang-emit-spirv.cpp` and `source/slang/slang-diagnostics.lua` plus 14 tests (11 new + 3 modified) under `tests/spirv/` and `tests/language-feature/spirv-asm/`. No public-header surface touched.

## Tests

Initial set under `tests/spirv/`:

- `builtin-volatile-raytracing.slang` — direct emit on each of the five RT-volatile stages (raygen / closesthit / miss / intersection / callable), plus a via-glsl raygen directive (`glslang`'s `rtSubgroupDecls` covers the five stages by a single mechanism). Raygen entry point also exercises `WaveIsFirstLane`, `WaveActiveBallot`, `WaveReadLaneFirst` so wave-intrinsic emission in RT regresses through this file.
- `builtin-volatile-raytmax-intersection.slang` — `RayTCurrent()` lowered to `RayTmaxKHR` in intersection gets the decoration.
- `builtin-volatile-raytmax-vk-mem-model.slang` — same, vk_mem_model.
- `builtin-volatile-subgroup-masks.slang` — pins each of the five `Subgroup*Mask` enumerators independently, GLSL450 + vk_mem_model.
- `builtin-volatile-smidnv-warpidnv.slang` — pins `SMIDNV` / `WarpIDNV` via hand-rolled `spirv_asm` (GLSL450 + vk_mem_model).
- `builtin-volatile-mixed-stages.slang` — compute + raygen entry points reading the same builtin in one module; asserts a single shared `OpVariable` with `Volatile` (GLSL450 + vk_mem_model, with explicit `OpVariable`-count bound).
- `builtin-volatile-vk-mem-model.slang` — vk_mem_model raygen with multi-load entry path; exercises cache-hit alias + per-access mask, with `CHECK-COUNT-4` plus trailing `CHECK-NOT` upper bound.
- `builtin-volatile-spirv-asm-user-mask.slang` — exercises the user-supplied-memory-operand early-return (both the `Volatile` keyword and the `Aligned 4` non-Volatile mask), end-anchored `CHECK` to catch double-mask emission.
- `builtin-no-volatile-anyhit.slang` — pins the `AnyHit` exclusion (GLSL450 + vk_mem_model, leading + trailing `CHECK-NOT: Volatile`).
- `builtin-no-volatile-compute.slang` — negative baseline for non-raytracing stages (GLSL450 + vk_mem_model).
- `builtin-no-volatile-raytmax.slang` — pins `RayTmaxKHR` Intersection-only gating from each non-Intersection RT stage (`closesthit`, `anyhit`, `miss` × GLSL450 + vk_mem_model = 6 directives).

Review-feedback follow-up coverage:

- `builtin-no-volatile-subgroupid.slang` — pins the `SubgroupId` exclusion (gated separately by VUID-SubgroupId-SubgroupId-04367; not decorated `Volatile` even in RT stages).
- `builtin-volatile-combined-intersection.slang` — combined subgroup + `RayTmaxKHR` in one Intersection entry; pins both gate paths in a single body so a regression that interferes between them is caught.
- `builtin-no-volatile-graphics-stages.slang` — combined vertex / fragment / geometry / mesh / amplification negatives sharing one shader; pins the gate from each non-RT graphics stage that can read `WaveGetLaneIndex()`. Tessellation (hull/domain) deliberately scoped out — same lowering path as the five stages covered.
- `tests/language-feature/spirv-asm/volatile-builtin-non-literal-mask-diagnostic.slang` — positive + negative pair for diagnostic E29117 (Id-form mask warns; literal-form merges silently).

### Test plan

- [x] `SLANG_RUN_SPIRV_VALIDATION=1 slang-test tests/spirv/ tests/language-feature/` — 1721/1721 pass on HEAD, 0 regressions.
- [x] `spirv-val` accepts every emitted SPIR-V from these tests (negative cases produce non-Volatile-decorated valid SPIR-V; positive cases produce Volatile-decorated or Volatile-mask-bearing valid SPIR-V).
- [x] CI on the post-Ready commit — last green run: 44 pass / 2 skip / 0 fail.

## Review

Multi-round peer + maintainer review; 34 + 17 review threads addressed and resolved.

- Round 7: reverted a round-3 over-reach (`SubgroupId`) on VUID-04367 grounds. RT-stage `WaveGetWaveIndex()` / `WaveGetNumWaves()` usability is tracked separately as #11303.
- Round 8: distilled the fix to its minimal shape per maintainer review — dropped the `isVolatile` cache axis and the regular-IR walk-back (replaced with an assert), inlined a single-call helper, collapsed verbose justification comments, and consolidated three near-duplicate test files into the existing ones with multi-directive coverage.
- Round 9 (follow-up commit `46f1538f5`): replaced the vacuous `SLANG_ASSERT(!m_volatileBuiltinGlobalVars.contains(ptr))` in `getMemoryAccessOperandsOfLoadStore` (the IR-side set is keyed on asm-operand insts, disjoint by type from the `IRGlobalVar`/`IRGlobalParam` `ptr` reaching this branch — the assert could never fire) with a functional `m_volatileSpvVars`-based fallback. Added diagnostic E29117 for non-literal mask drop. Strengthened test rigor: `vk_mem_model` directives on negatives, leading `CHECK-NOT` bracketing, count-bound assertions, broader stage / builtin coverage.

No unresolved feedback.

## Follow-up

- #11303 — `WaveGetWaveIndex()` / `WaveGetNumWaves()` usability in raytracing stages (the `spirv_asm` lowering of these intrinsics emits SPIR-V violating VUID-04367 / the analogous `NumSubgroups` VUID, regardless of `Volatile`).

Closes shader-slang/slang#10528.
