### PR TITLE
Open existential through ModifiedType in member lookup

### DIFF
--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -187,9 +187,15 @@ Expr* SemanticsVisitor::openExistential(Expr* expr, DeclRef<InterfaceDecl> inter
         expr,
         [&](DeclRef<VarDeclBase> varDeclRef)
         {
+            // The interface type stored on the `ExtractExistentialType` should
+            // be the bare interface, not a `ModifiedType` wrapping it (e.g. the
+            // `no_diff` modifier that `[Differentiable]` adds to non-
+            // differentiable return types). Otherwise downstream consumers that
+            // look at the cached "original interface type" by `DeclRefType`
+            // would not recognize it as an interface.
             ExtractExistentialType* openedType = m_astBuilder->getOrCreate<ExtractExistentialType>(
                 varDeclRef,
-                expr->type.type,
+                unwrapModifiedType(expr->type.type),
                 interfaceDeclRef);
 
             ExtractExistentialValueExpr* openedValue =
@@ -232,7 +238,13 @@ Expr* SemanticsVisitor::openExistential(Expr* expr, DeclRef<InterfaceDecl> inter
 ///
 Expr* SemanticsVisitor::maybeOpenExistential(Expr* expr)
 {
-    auto exprType = expr->type.type;
+    // Look through `ModifiedType` (e.g. an interface return wrapped in
+    // `no_diff` by the `[Differentiable]` checker) so the interface check
+    // below succeeds. If we miss this, member lookup never produces an
+    // `ExtractExistentialValueExpr`, the IR never emits the standard
+    // existential-dispatch idiom, and a raw `this_type(...)` leaks all the
+    // way to codegen.
+    auto exprType = unwrapModifiedType(expr->type.type);
 
     if (auto declRefType = as<DeclRefType>(exprType))
     {

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -6737,7 +6737,8 @@ Expr* SemanticsExprVisitor::visitIsTypeExpr(IsTypeExpr* expr)
     auto valueType = expr->value->type.type;
     if (auto typeType = as<TypeType>(valueType))
         valueType = typeType->getType();
-    valueType = unwrapModifiedType(valueType);
+    auto unwrappedValueType = unwrapModifiedType(valueType);
+    auto valueInterfaceType = isInterfaceType(unwrappedValueType) ? unwrappedValueType : valueType;
 
     // If value is a subtype of `type`, then this expr is always true.
     auto witness = isSubtype(valueType, expr->typeExpr.type, IsSubTypeOptions::None);
@@ -6768,11 +6769,12 @@ Expr* SemanticsExprVisitor::visitIsTypeExpr(IsTypeExpr* expr)
     // subtype witness for runtime checks.
 
     expr->value = maybeOpenExistential(originalVal);
-    expr->witnessArg = witness ? witness : tryGetSubtypeWitness(expr->typeExpr.type, valueType);
+    expr->witnessArg =
+        witness ? witness : tryGetSubtypeWitness(expr->typeExpr.type, valueInterfaceType);
     if (expr->witnessArg)
     {
         // For now we can only support the scenario where `expr->value` is an interface type.
-        if (!optionalWitness && !isInterfaceType(valueType))
+        if (!optionalWitness && !isInterfaceType(valueInterfaceType))
         {
             getSink()->diagnose(Diagnostics::IsOperatorValueMustBeInterfaceType{.expr = expr});
         }
@@ -6785,8 +6787,8 @@ Expr* SemanticsExprVisitor::visitIsTypeExpr(IsTypeExpr* expr)
     // Note: _isTypeParametric only handles DeclRefType-based types (incl. recursive generic args).
     // Builtin composite types like arrays or vectors with embedded generic params are not checked,
     // but these are unlikely to appear in `is`/`as` expressions in practice.
-    if (!as<ErrorType>(valueType) && !as<ErrorType>(expr->typeExpr.type) &&
-        !isInterfaceType(valueType) && !_isTypeParametric(valueType) &&
+    if (!as<ErrorType>(valueInterfaceType) && !as<ErrorType>(expr->typeExpr.type) &&
+        !isInterfaceType(valueInterfaceType) && !_isTypeParametric(valueInterfaceType) &&
         !_isTypeParametric(expr->typeExpr.type))
     {
         getSink()->diagnose(Diagnostics::IsAsOnUnrelatedConcreteTypes{.expr = expr});
@@ -6809,7 +6811,9 @@ Expr* SemanticsExprVisitor::visitAsTypeExpr(AsTypeExpr* expr)
     }
 
     expr->value = CheckTerm(expr->value);
-    auto valueType = unwrapModifiedType(expr->value->type.type);
+    auto valueType = expr->value->type.type;
+    auto unwrappedValueType = unwrapModifiedType(valueType);
+    auto valueInterfaceType = isInterfaceType(unwrappedValueType) ? unwrappedValueType : valueType;
 
     // Reject `expr as OpaqueType` (and structs containing opaque fields) because
     // Optional<T> cannot wrap resource/opaque types.
@@ -6839,11 +6843,11 @@ Expr* SemanticsExprVisitor::visitAsTypeExpr(AsTypeExpr* expr)
 
     // If target type is an interface type, we will obtain the witness here for
     // runtime casting.
-    expr->witnessArg = tryGetSubtypeWitness(typeExpr.type, valueType);
+    expr->witnessArg = tryGetSubtypeWitness(typeExpr.type, valueInterfaceType);
     if (expr->witnessArg)
     {
         // For now we can only support the scenario where `expr->value` is an interface type.
-        if (!isInterfaceType(valueType))
+        if (!isInterfaceType(valueInterfaceType))
         {
             getSink()->diagnose(Diagnostics::IsOperatorValueMustBeInterfaceType{.expr = expr});
         }
@@ -6854,8 +6858,9 @@ Expr* SemanticsExprVisitor::visitAsTypeExpr(AsTypeExpr* expr)
     // If we reach here with no witness and both the value type and target type are concrete
     // (not generic type parameters, associated types, or ThisType), the `as` cast always
     // fails and the user is using `as` incorrectly on unrelated concrete types.
-    if (!as<ErrorType>(valueType) && !as<ErrorType>(typeExpr.type) && !isInterfaceType(valueType) &&
-        !_isTypeParametric(valueType) && !_isTypeParametric(typeExpr.type))
+    if (!as<ErrorType>(valueInterfaceType) && !as<ErrorType>(typeExpr.type) &&
+        !isInterfaceType(valueInterfaceType) && !_isTypeParametric(valueInterfaceType) &&
+        !_isTypeParametric(typeExpr.type))
     {
         getSink()->diagnose(Diagnostics::IsAsOnUnrelatedConcreteTypes{.expr = expr});
     }

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -6737,6 +6737,7 @@ Expr* SemanticsExprVisitor::visitIsTypeExpr(IsTypeExpr* expr)
     auto valueType = expr->value->type.type;
     if (auto typeType = as<TypeType>(valueType))
         valueType = typeType->getType();
+    valueType = unwrapModifiedType(valueType);
 
     // If value is a subtype of `type`, then this expr is always true.
     auto witness = isSubtype(valueType, expr->typeExpr.type, IsSubTypeOptions::None);
@@ -6771,7 +6772,7 @@ Expr* SemanticsExprVisitor::visitIsTypeExpr(IsTypeExpr* expr)
     if (expr->witnessArg)
     {
         // For now we can only support the scenario where `expr->value` is an interface type.
-        if (!optionalWitness && !isInterfaceType(originalVal->type))
+        if (!optionalWitness && !isInterfaceType(valueType))
         {
             getSink()->diagnose(Diagnostics::IsOperatorValueMustBeInterfaceType{.expr = expr});
         }
@@ -6808,6 +6809,7 @@ Expr* SemanticsExprVisitor::visitAsTypeExpr(AsTypeExpr* expr)
     }
 
     expr->value = CheckTerm(expr->value);
+    auto valueType = unwrapModifiedType(expr->value->type.type);
 
     // Reject `expr as OpaqueType` (and structs containing opaque fields) because
     // Optional<T> cannot wrap resource/opaque types.
@@ -6823,7 +6825,7 @@ Expr* SemanticsExprVisitor::visitAsTypeExpr(AsTypeExpr* expr)
     expr->type = optType;
 
     // If value is a subtype of `type`, then this expr is equivalent to a CastToSuperTypeExpr.
-    if (auto witness = tryGetSubtypeWitness(expr->value->type.type, typeExpr.type))
+    if (auto witness = tryGetSubtypeWitness(valueType, typeExpr.type))
     {
         auto castToSuperType = createCastToSuperTypeExpr(typeExpr.type, expr->value, witness);
         auto makeOptional = m_astBuilder->create<MakeOptionalExpr>();
@@ -6837,11 +6839,11 @@ Expr* SemanticsExprVisitor::visitAsTypeExpr(AsTypeExpr* expr)
 
     // If target type is an interface type, we will obtain the witness here for
     // runtime casting.
-    expr->witnessArg = tryGetSubtypeWitness(typeExpr.type, expr->value->type.type);
+    expr->witnessArg = tryGetSubtypeWitness(typeExpr.type, valueType);
     if (expr->witnessArg)
     {
         // For now we can only support the scenario where `expr->value` is an interface type.
-        if (!isInterfaceType(expr->value->type.type))
+        if (!isInterfaceType(valueType))
         {
             getSink()->diagnose(Diagnostics::IsOperatorValueMustBeInterfaceType{.expr = expr});
         }
@@ -6852,10 +6854,8 @@ Expr* SemanticsExprVisitor::visitAsTypeExpr(AsTypeExpr* expr)
     // If we reach here with no witness and both the value type and target type are concrete
     // (not generic type parameters, associated types, or ThisType), the `as` cast always
     // fails and the user is using `as` incorrectly on unrelated concrete types.
-    auto asValueType = expr->value->type.type;
-    if (!as<ErrorType>(asValueType) && !as<ErrorType>(typeExpr.type) &&
-        !isInterfaceType(asValueType) && !_isTypeParametric(asValueType) &&
-        !_isTypeParametric(typeExpr.type))
+    if (!as<ErrorType>(valueType) && !as<ErrorType>(typeExpr.type) && !isInterfaceType(valueType) &&
+        !_isTypeParametric(valueType) && !_isTypeParametric(typeExpr.type))
     {
         getSink()->diagnose(Diagnostics::IsAsOnUnrelatedConcreteTypes{.expr = expr});
     }

--- a/tests/autodiff/differentiable-interface-return.slang
+++ b/tests/autodiff/differentiable-interface-return.slang
@@ -10,32 +10,37 @@
 
 //TEST:SIMPLE(filecheck=CHECK_HLSL): -target hlsl -stage compute -entry main
 //TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv-asm -stage compute -entry main
+//TEST:INTERPRET(filecheck=CHECK_INTERP): -entry interpretMain
 
-// The fix should ensure neither `this_type` (the unresolved IR placeholder)
-// nor the interface dispatcher key escapes into the emitted HLSL.
+// The fix should ensure `this_type` (the unresolved IR placeholder) does not
+// escape into the emitted HLSL.
 // CHECK_HLSL-NOT: this_type
-// CHECK_HLSL-NOT: IMaterialInstance_collect_properties
 // CHECK_HLSL: void main(
 // CHECK_HLSL-NOT: this_type
-// CHECK_HLSL-NOT: IMaterialInstance_collect_properties
 // CHECK_HLSL: return;
 // A trailing negative block after the final positive `CHECK_HLSL` extends
-// the scope to end-of-input, so an out-of-line dispatcher emitted after
-// `main` (e.g. via a future regression) still fails the test.
+// the scope to end-of-input, so a future regression emitted after `main`
+// still fails the test.
 // CHECK_HLSL-NOT: this_type
-// CHECK_HLSL-NOT: IMaterialInstance_collect_properties
 
 // SPIR-V should compile successfully (no ICE) and emit the dispatch chain
-// fully constant-folded into a store of `(1, 2, 3)` into `out_buf`. Pinning
-// the composite + store catches silent miscompilation that an
-// `OpEntryPoint`-only check would miss (e.g. a future regression that
-// produces a clean module but folds the call away to undef).
+// fully constant-folded into observable stores. Pinning the composites +
+// stores catches silent miscompilation that an `OpEntryPoint`-only check
+// would miss (e.g. a future regression that produces a clean module but
+// folds the call away to undef).
 // CHECK_SPV: OpEntryPoint
 // CHECK_SPV-DAG: %[[F1:[A-Za-z0-9_]+]] = OpConstant %float 1
 // CHECK_SPV-DAG: %[[F2:[A-Za-z0-9_]+]] = OpConstant %float 2
 // CHECK_SPV-DAG: %[[F3:[A-Za-z0-9_]+]] = OpConstant %float 3
-// CHECK_SPV-DAG: %[[V:[A-Za-z0-9_]+]] = OpConstantComposite %v3float %[[F1]] %[[F2]] %[[F3]]
-// CHECK_SPV: OpStore {{.*}} %[[V]]
+// CHECK_SPV-DAG: %[[V123:[A-Za-z0-9_]+]] = OpConstantComposite %v3float %[[F1]] %[[F2]] %[[F3]]
+// CHECK_SPV-DAG: %[[V111:[A-Za-z0-9_]+]] = OpConstantComposite %v3float %[[F1]] %[[F1]] %[[F1]]
+// CHECK_SPV: OpStore {{.*}} %[[V123]]
+// CHECK_SPV: OpStore {{.*}} %[[V123]]
+// CHECK_SPV: OpStore {{.*}} %[[V111]]
+
+// CHECK_INTERP: matched=1
+// CHECK_INTERP: cast=1 2 3
+// CHECK_INTERP: member=1 2 3
 
 public struct SurfaceInteraction { public float3 pos; }
 public struct MaterialProperties { public float3 albedo; }
@@ -78,6 +83,20 @@ float3 cast_my_inst(SurfaceInteraction si)
 
 RWStructuredBuffer<float3> out_buf;
 
+void interpretMain()
+{
+    SurfaceInteraction si;
+    si.pos = float3(1, 2, 3);
+
+    bool matched = is_my_inst(si);
+    float3 castResult = cast_my_inst(si);
+    float3 memberResult = get_inst(si).collect_properties(si).albedo;
+
+    printf("matched=%d\n", (int)matched);
+    printf("cast=%.0f %.0f %.0f\n", castResult.x, castResult.y, castResult.z);
+    printf("member=%.0f %.0f %.0f\n", memberResult.x, memberResult.y, memberResult.z);
+}
+
 [shader("compute")]
 [numthreads(1,1,1)]
 void main()
@@ -86,5 +105,9 @@ void main()
     si.pos = float3(1, 2, 3);
     bool matched = is_my_inst(si);
     float3 castResult = cast_my_inst(si);
-    out_buf[0] = matched ? get_inst(si).collect_properties(si).albedo : castResult;
+    float3 memberResult = get_inst(si).collect_properties(si).albedo;
+
+    out_buf[0] = memberResult;
+    out_buf[1] = castResult;
+    out_buf[2] = matched ? float3(1, 1, 1) : float3(0);
 }

--- a/tests/autodiff/differentiable-interface-return.slang
+++ b/tests/autodiff/differentiable-interface-return.slang
@@ -16,6 +16,9 @@
 // CHECK_HLSL-NOT: this_type
 // CHECK_HLSL-NOT: IMaterialInstance_collect_properties
 // CHECK_HLSL: void main(
+// CHECK_HLSL-NOT: this_type
+// CHECK_HLSL-NOT: IMaterialInstance_collect_properties
+// CHECK_HLSL: return;
 
 // SPIR-V should compile successfully (no ICE) and produce an entry point.
 // CHECK_SPV: OpEntryPoint

--- a/tests/autodiff/differentiable-interface-return.slang
+++ b/tests/autodiff/differentiable-interface-return.slang
@@ -19,6 +19,11 @@
 // CHECK_HLSL-NOT: this_type
 // CHECK_HLSL-NOT: IMaterialInstance_collect_properties
 // CHECK_HLSL: return;
+// A trailing negative block after the final positive `CHECK_HLSL` extends
+// the scope to end-of-input, so an out-of-line dispatcher emitted after
+// `main` (e.g. via a future regression) still fails the test.
+// CHECK_HLSL-NOT: this_type
+// CHECK_HLSL-NOT: IMaterialInstance_collect_properties
 
 // SPIR-V should compile successfully (no ICE) and produce an entry point.
 // CHECK_SPV: OpEntryPoint

--- a/tests/autodiff/differentiable-interface-return.slang
+++ b/tests/autodiff/differentiable-interface-return.slang
@@ -61,6 +61,21 @@ IMaterialInstance get_inst(SurfaceInteraction si)
     return MyInst();
 }
 
+// These helpers exercise the same modified-interface return type through
+// `is`/`as`, not just through member lookup.
+bool is_my_inst(SurfaceInteraction si)
+{
+    return get_inst(si) is MyInst;
+}
+
+float3 cast_my_inst(SurfaceInteraction si)
+{
+    let castResult = get_inst(si) as MyInst;
+    if (castResult.hasValue)
+        return castResult.value.collect_properties(si).albedo;
+    return float3(0);
+}
+
 RWStructuredBuffer<float3> out_buf;
 
 [shader("compute")]

--- a/tests/autodiff/differentiable-interface-return.slang
+++ b/tests/autodiff/differentiable-interface-return.slang
@@ -84,5 +84,7 @@ void main()
 {
     SurfaceInteraction si;
     si.pos = float3(1, 2, 3);
-    out_buf[0] = get_inst(si).collect_properties(si).albedo;
+    bool matched = is_my_inst(si);
+    float3 castResult = cast_my_inst(si);
+    out_buf[0] = matched ? get_inst(si).collect_properties(si).albedo : castResult;
 }

--- a/tests/autodiff/differentiable-interface-return.slang
+++ b/tests/autodiff/differentiable-interface-return.slang
@@ -25,8 +25,17 @@
 // CHECK_HLSL-NOT: this_type
 // CHECK_HLSL-NOT: IMaterialInstance_collect_properties
 
-// SPIR-V should compile successfully (no ICE) and produce an entry point.
+// SPIR-V should compile successfully (no ICE) and emit the dispatch chain
+// fully constant-folded into a store of `(1, 2, 3)` into `out_buf`. Pinning
+// the composite + store catches silent miscompilation that an
+// `OpEntryPoint`-only check would miss (e.g. a future regression that
+// produces a clean module but folds the call away to undef).
 // CHECK_SPV: OpEntryPoint
+// CHECK_SPV-DAG: %[[F1:[A-Za-z0-9_]+]] = OpConstant %float 1
+// CHECK_SPV-DAG: %[[F2:[A-Za-z0-9_]+]] = OpConstant %float 2
+// CHECK_SPV-DAG: %[[F3:[A-Za-z0-9_]+]] = OpConstant %float 3
+// CHECK_SPV-DAG: %[[V:[A-Za-z0-9_]+]] = OpConstantComposite %v3float %[[F1]] %[[F2]] %[[F3]]
+// CHECK_SPV: OpStore {{.*}} %[[V]]
 
 public struct SurfaceInteraction { public float3 pos; }
 public struct MaterialProperties { public float3 albedo; }

--- a/tests/autodiff/differentiable-interface-return.slang
+++ b/tests/autodiff/differentiable-interface-return.slang
@@ -1,0 +1,56 @@
+// Regression test for https://github.com/shader-slang/slang/issues/11272.
+//
+// A `[Differentiable]` function that returns an interface (existential) type
+// wraps the return type with a `no_diff` modifier. The semantic checker's
+// `maybeOpenExistential` must look through that modifier so the existential
+// is opened and the lowered IR contains the standard
+// `extractExistential*` + `lookupWitness` dispatch idiom. Without that,
+// `this_type(...)` leaks all the way to codegen — invalid HLSL on
+// `-target hlsl` and an ICE on `-target spirv`.
+
+//TEST:SIMPLE(filecheck=CHECK_HLSL): -target hlsl -stage compute -entry main
+//TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv-asm -stage compute -entry main
+
+// The fix should ensure neither `this_type` (the unresolved IR placeholder)
+// nor the interface dispatcher key escapes into the emitted HLSL.
+// CHECK_HLSL-NOT: this_type
+// CHECK_HLSL-NOT: IMaterialInstance_collect_properties
+// CHECK_HLSL: void main(
+
+// SPIR-V should compile successfully (no ICE) and produce an entry point.
+// CHECK_SPV: OpEntryPoint
+
+public struct SurfaceInteraction { public float3 pos; }
+public struct MaterialProperties { public float3 albedo; }
+
+public interface IMaterialInstance
+{
+    MaterialProperties collect_properties(SurfaceInteraction si);
+}
+
+struct MyInst : IMaterialInstance
+{
+    MaterialProperties collect_properties(SurfaceInteraction si)
+    {
+        MaterialProperties p;
+        p.albedo = si.pos;
+        return p;
+    }
+}
+
+[Differentiable]
+IMaterialInstance get_inst(SurfaceInteraction si)
+{
+    return MyInst();
+}
+
+RWStructuredBuffer<float3> out_buf;
+
+[shader("compute")]
+[numthreads(1,1,1)]
+void main()
+{
+    SurfaceInteraction si;
+    si.pos = float3(1, 2, 3);
+    out_buf[0] = get_inst(si).collect_properties(si).albedo;
+}


### PR DESCRIPTION
## Summary

Fixes #11272.

A `[Differentiable]` function returning an interface (existential) type wraps the
return type in `ModifiedType(IFace, NoDiffModifierVal)`. The semantic checker was
only treating bare interface `DeclRefType`s as existentials in the relevant call
paths, so the modified interface type could pass through unopened. With no
`ExtractExistentialValueExpr` inserted, lowering emitted a direct call to the
interface dispatcher instead of the standard `extractExistential*` +
`lookupWitness` idiom. That let `this_type(...)` leak into emitted HLSL and
SPIR-V codegen.

## Root cause

The `[Differentiable]` checker wraps non-differentiable return types in
`ModifiedType(returnType, NoDiffModifierVal)`. Interfaces are not differentiable
by default, so a `[Differentiable]` function returning an interface ends up with
`ModifiedType(IFace, NoDiff)` as its return type.

At a call site such as `get_inst(si).collect_properties(si)`,
`maybeOpenExistential` failed its bare-interface check, so member lookup proceeded
against the unopened interface. The same modified-interface invariant also
affected nearby `is`/`as` runtime type checks.

## Fix

- Unwrap `ModifiedType` before the interface check in `maybeOpenExistential`.
- Use the unwrapped type when constructing the `ExtractExistentialType` inside
  `openExistential`, so downstream consumers see the bare original interface
  type.
- Apply the same unwrapping in `is`/`as` semantic checks so modified interface
  returns are handled consistently for member lookup, runtime type tests, and
  runtime casts.

## Alternatives considered

- Skip wrapping interface return types in the autodiff checker: risky, because
  the `NoDiff` annotation is consumed by the autodiff pass and dropping it for
  interfaces could silently misclassify functions elsewhere.
- Broaden `isInterfaceType` globally: wider blast radius. This PR keeps the
  unwrapping local to the modified-interface paths that need it.
- Add an IR-pass workaround to rewrite direct dispatcher calls: fixes a symptom
  too late and would re-break on future type modifiers.

## Test plan

- New regression test `tests/autodiff/differentiable-interface-return.slang`:
  - HLSL FileCheck asserts no `this_type` leak and checks for the normal
    existential extract/witness-dispatch pattern.
  - SPIR-V asm FileCheck asserts independent stores for the member lookup,
    runtime cast, and runtime type-test paths.
  - INTERPRET coverage prints the member lookup, `as`, and `is` results
    separately so the three modified-interface paths are not only compile-time
    checks.
- Local verification:
  - `build/Debug/bin/slang-test tests/autodiff/differentiable-interface-return.slang`
    - 3/3 passed
