### PR TITLE
Use VS 2026 for CMake options Windows jobs

### DIFF
--- a/.github/workflows/cmake-options.yml
+++ b/.github/workflows/cmake-options.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   linux-debug:
     uses: ./.github/workflows/cmake-options-build-container.yml

--- a/.github/workflows/cmake-options.yml
+++ b/.github/workflows/cmake-options.yml
@@ -75,7 +75,7 @@ jobs:
       compiler: cl
       platform: aarch64
       config: debug
-      runs-on: '["windows-latest"]'
+      runs-on: '["windows-2025-vs2026"]'
       arch: "amd64_arm64"
 
   windows-aarch64-release:
@@ -85,34 +85,31 @@ jobs:
       compiler: cl
       platform: aarch64
       config: release
-      runs-on: '["windows-latest"]'
+      runs-on: '["windows-2025-vs2026"]'
       arch: "amd64_arm64"
 
   # windows-vs2019-debug: disabled — windows-2019 runner is being retired (June 2025)
   # windows-vs2019-release: disabled — windows-2019 runner is being retired (June 2025)
 
-  windows-vs2022-debug:
+  windows-vs2026-debug:
     uses: ./.github/workflows/cmake-options-build.yml
     with:
       os: windows
       compiler: cl
       platform: x86_64
       config: debug
-      runs-on: '["windows-2022"]'
-      buildtool: "Visual Studio 17 2022"
+      runs-on: '["windows-2025-vs2026"]'
+      buildtool: "Visual Studio 18 2026"
 
-  windows-vs2022-release:
+  windows-vs2026-release:
     uses: ./.github/workflows/cmake-options-build.yml
     with:
       os: windows
       compiler: cl
       platform: x86_64
       config: release
-      runs-on: '["windows-2022"]'
-      buildtool: "Visual Studio 17 2022"
-
-  # windows-vs2026-debug: disabled — VS 2026 not yet available on GitHub-hosted runners
-  # windows-vs2026-release: disabled — VS 2026 not yet available on GitHub-hosted runners
+      runs-on: '["windows-2025-vs2026"]'
+      buildtool: "Visual Studio 18 2026"
 
   check-cmake:
     needs:
@@ -125,8 +122,8 @@ jobs:
         macos-release,
         windows-aarch64-debug,
         windows-aarch64-release,
-        windows-vs2022-debug,
-        windows-vs2022-release,
+        windows-vs2026-debug,
+        windows-vs2026-release,
       ]
     runs-on: ubuntu-latest
     if: always()


### PR DESCRIPTION
## Summary
- Move the scheduled CMake Options hosted Windows jobs onto the VS 2026 runner image.
- Replace the VS 2022 generator coverage jobs with Visual Studio 18 2026 jobs.
- Keep the aggregate CMake Options check aligned with the renamed Windows jobs.
- Add read-only workflow permissions for the CMake Options workflow.

## Test Plan
- `cmake.exe --preset vs2026-dev -DSLANG_IGNORE_ABORT_MSG=ON -DSLANG_EMBED_CORE_MODULE=OFF`
- `cmake.exe --build --preset debug --target slangc slang-test`
- `cmake.exe --fresh -G "Visual Studio 18 2026" -B build.cmake-options-vs2026 -DSLANG_SLANG_LLVM_FLAVOR=DISABLE -DSLANG_USE_SCCACHE=OFF -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DSLANG_ENABLE_SLANGI=OFF`
- `build/Debug/bin/slangc.exe -version`
- YAML parse for `.github/workflows/cmake-options.yml`
- `git.exe diff --cached --check`
- `git.exe diff --check`

Fixes shader-slang/slang#11133
