### PR TITLE
Add must-init (definite assignment) warning for conditionally initialized variables

### DIFF
--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -4575,6 +4575,20 @@ warning(
 )
 
 warning(
+    "possibly-using-uninitialized-variable",
+    41035,
+    "possible use of uninitialized variable",
+    span { loc = "location", message = "variable '~varName' may be uninitialized on some paths; it is only conditionally assigned" }
+)
+
+warning(
+    "possibly-using-uninitialized-value",
+    41036,
+    "possible use of uninitialized value",
+    span { loc = "location", message = "value of type '~typeName' may be uninitialized on some paths; it is only conditionally assigned" }
+)
+
+warning(
     "using-uninitialized-global-variable",
     41017,
     "use of uninitialized global variable",

--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -357,6 +357,281 @@ static void cancelLoads(
     }
 }
 
+// If `block` ends in an `ifElse` whose condition is one of `block`'s own parameters
+// (a phi), and the value that parameter receives along the edge from `fromPred` is a
+// boolean constant, then only one of the two branches is feasible when arriving from
+// `fromPred`. Returns the block that is *not* taken (the infeasible successor), or
+// null if both successors remain feasible.
+//
+// This captures the short-circuit `&&`/`||` lowering: the merge block of `a && b`
+// carries a phi that is the literal `false` along the "a is false" edge, so a later
+// branch on that phi cannot take its true-side from that edge. Without this, the
+// flat CFG admits an infeasible store-free path through the merge, producing a false
+// "possibly uninitialized" warning for patterns like `f(out x) && use(x)`.
+static IRBlock* getInfeasibleBranchFromPredecessor(IRBlock* block, IRBlock* fromPred)
+{
+    auto ifElse = as<IRIfElse>(block->getTerminator());
+    if (!ifElse)
+        return nullptr;
+
+    auto cond = ifElse->getCondition();
+    auto condParam = as<IRParam>(cond);
+    if (!condParam || condParam->getParent() != block)
+        return nullptr;
+
+    // Find the index of this parameter among the block's parameters.
+    UInt paramIndex = 0;
+    bool found = false;
+    for (auto p : block->getParams())
+    {
+        if (p == condParam)
+        {
+            found = true;
+            break;
+        }
+        paramIndex++;
+    }
+    if (!found)
+        return nullptr;
+
+    // Get the branch argument supplied for that parameter along the edge from
+    // `fromPred`.
+    auto branch = as<IRUnconditionalBranch>(fromPred->getTerminator());
+    if (!branch || paramIndex >= branch->getArgCount())
+        return nullptr;
+
+    auto argVal = as<IRBoolLit>(branch->getArg(paramIndex));
+    if (!argVal)
+        return nullptr;
+
+    // A constant condition makes the opposite branch infeasible from this edge.
+    return argVal->getValue() ? ifElse->getFalseBlock() : ifElse->getTrueBlock();
+}
+
+// Remove all loads that are "definitely assigned": every control-flow path from
+// the function entry to the load passes through at least one store.
+//
+// A load is kept (a must-init violation) only when there exists a path from entry
+// to the load that does not pass through any store first — i.e. the variable can
+// be read while still uninitialized on at least one path.
+//
+// This is the standard definite-assignment property. We compute it directly with a
+// forward CFG walk from entry that is blocked by store-containing blocks, rather
+// than using simple dominance. Dominance is too strict: "the load is dominated by
+// some single store" misses the common-and-safe case where different paths are
+// guarded by different stores, producing false positives on patterns like
+// short-circuit `&&` chains (`f(out x) && use(x)`), where the only way to reach the
+// use is through the store, but no individual store-block dominates the use-block
+// because the join block has a store-free predecessor whose path never reaches the
+// use.
+static void cancelLoadsByDefiniteAssignment(
+    IRGlobalValueWithCode* func,
+    const List<IRInst*>& stores,
+    List<IRInst*>& loads)
+{
+    if (loads.getCount() == 0)
+        return;
+
+    // Map each store to the block that contains it.
+    //
+    // `collectInstructionByUsage` records most stores as the storing instruction, but
+    // for the `StoreParent` case (e.g. inline SPIRV-asm operands) it records the
+    // *containing block* itself as the "store". Such a block is treated as initializing
+    // the variable somewhere within it, matching the block-reachability granularity the
+    // may-init analysis already uses. We track those separately as `wholeBlockStores`
+    // so that every load in them counts as definitely assigned.
+    HashSet<IRBlock*> blocksWithStore;
+    HashSet<IRBlock*> wholeBlockStores;
+    HashSet<IRInst*> storeSet;
+    for (auto store : stores)
+    {
+        if (auto storeBlock = as<IRBlock>(store))
+        {
+            blocksWithStore.add(storeBlock);
+            wholeBlockStores.add(storeBlock);
+        }
+        else if (auto block = as<IRBlock>(store->getParent()))
+        {
+            blocksWithStore.add(block);
+            storeSet.add(store);
+        }
+    }
+
+    // For blocks that contain both a store and a load, the relative order matters:
+    // a load that appears before any store in the same block is reachable while
+    // uninitialized (along the store-free entry path into the block), whereas a load
+    // after a store in the same block is definitely assigned by that store.
+    //
+    // Precompute, for each load, whether a store precedes it within its own block.
+    HashSet<IRInst*> loadHasPriorStoreInBlock;
+    for (auto load : loads)
+    {
+        auto block = as<IRBlock>(load->getParent());
+        if (!block)
+            continue;
+        // A whole-block (StoreParent) store covers the entire block, so any load in it
+        // is considered definitely assigned.
+        if (wholeBlockStores.contains(block))
+        {
+            loadHasPriorStoreInBlock.add(load);
+            continue;
+        }
+        if (!blocksWithStore.contains(block))
+            continue;
+        for (auto inst = block->getFirstInst(); inst; inst = inst->getNextInst())
+        {
+            if (inst == load)
+                break;
+            if (storeSet.contains(inst))
+            {
+                loadHasPriorStoreInBlock.add(load);
+                break;
+            }
+        }
+    }
+
+    // Loop relaxation: element-wise initialization inside a loop is extremely common
+    // (e.g. `[ForceUnroll] for (i) result[i] = ...;` filling an array/vector before
+    // use). Such a store does not strictly dominate the post-loop use — the loop could
+    // run zero times — but in practice these loops have constant trip counts >= 1, so
+    // treating the zero-trip path as leaving the variable uninitialized produces noisy
+    // false positives (this is what previously forced large parts of the core module
+    // and many tests to disable the warning).
+    //
+    // To suppress those while still catching genuine first-iteration reads (the #10658
+    // motivating bug, where the use appears *inside* the loop before any store), we
+    // treat a loop whose body contains a store as initializing the variable by the time
+    // control reaches the loop-exit (break) block: that break block is never marked
+    // clean-reachable. The break block is the loop's reconvergence point, so every path
+    // that reaches it first goes through the loop; excluding it does not hide store-free
+    // paths that bypass the loop entirely. Clean state still flows into the loop body, so
+    // uses that precede the store inside the body are still reported.
+    HashSet<IRBlock*> suppressedBreakBlocks;
+    for (auto block : func->getBlocks())
+    {
+        auto loop = as<IRLoop>(block->getTerminator());
+        if (!loop)
+            continue;
+        auto breakBlock = loop->getBreakBlock();
+
+        // Collect the loop body: blocks reachable from the loop target without passing
+        // through the break block. If any of them contains a store, treat the loop as
+        // initializing the variable by the time control reaches the break block.
+        //
+        // This is deliberately conservative toward *fewer* false positives. Loops that
+        // fill a variable element-by-element (e.g. `[ForceUnroll] for (i) result[i] =
+        // ...;`, including nested loops over compile-time-constant bounds) are extremely
+        // common and safe in practice, but the store is not guaranteed to dominate the
+        // post-loop use under a purely structural analysis (the loop "might" run zero
+        // times, or an inner loop might). Distinguishing those from a genuine
+        // conditionally-initialized-in-a-loop bug would require trip-count reasoning, so
+        // we accept the rare missed in-loop conditional-store case rather than warn on
+        // the pervasive element-wise pattern. Uses that occur *inside* the loop before
+        // the store are still reported, since clean state still flows into the body.
+        HashSet<IRBlock*> bodyVisited;
+        List<IRBlock*> bodyWork;
+        bodyVisited.add(breakBlock); // sentinel: never traverse past the break block
+        if (auto target = loop->getTargetBlock())
+        {
+            if (bodyVisited.add(target))
+                bodyWork.add(target);
+        }
+        bool bodyHasStore = false;
+        while (bodyWork.getCount())
+        {
+            auto b = bodyWork.getLast();
+            bodyWork.removeLast();
+            if (blocksWithStore.contains(b))
+            {
+                bodyHasStore = true;
+                break;
+            }
+            for (auto succ : b->getSuccessors())
+            {
+                if (bodyVisited.add(succ))
+                    bodyWork.add(succ);
+            }
+        }
+        if (bodyHasStore)
+            suppressedBreakBlocks.add(breakBlock);
+    }
+
+    // Forward CFG reachability from entry, treating any block that contains a store
+    // as a barrier: we can enter such a block "clean" (still uninitialized) but its
+    // successors are reached only after the store has executed, so they are not
+    // propagated as clean.
+    //
+    // The set of "clean-reachable" blocks is exactly the set of blocks reachable
+    // from entry along a path with no preceding store (subject to the loop relaxation
+    // above, and pruning of short-circuit-infeasible edges below).
+    //
+    // We propagate over CFG edges rather than blocks so that, when entering a block,
+    // we know which predecessor we came from and can prune outgoing edges that are
+    // statically infeasible due to short-circuit `&&`/`||` constant-phi conditions
+    // (see getInfeasibleBranchFromPredecessor). A block is clean-reachable if some
+    // clean, feasible edge enters it (the entry block is clean by definition).
+    //
+    // The worklist holds (predecessor, block) edges. `predecessor` is null for the
+    // synthetic entry edge.
+    HashSet<IRBlock*> cleanReachable;
+    HashSet<KeyValuePair<IRBlock*, IRBlock*>> visitedEdges;
+    List<KeyValuePair<IRBlock*, IRBlock*>> worklist;
+
+    auto enqueueEdge = [&](IRBlock* pred, IRBlock* succ)
+    {
+        // Don't mark a loop's break block clean when the loop body initializes the
+        // variable: by the time control reconverges at the break block, the loop has
+        // run at least once and performed the store.
+        if (suppressedBreakBlocks.contains(succ))
+            return;
+        KeyValuePair<IRBlock*, IRBlock*> edge(pred, succ);
+        if (visitedEdges.add(edge))
+        {
+            cleanReachable.add(succ);
+            worklist.add(edge);
+        }
+    };
+
+    if (auto entry = func->getFirstBlock())
+        enqueueEdge(nullptr, entry);
+
+    while (worklist.getCount())
+    {
+        auto edge = worklist.getLast();
+        worklist.removeLast();
+        IRBlock* pred = edge.key;
+        IRBlock* block = edge.value;
+
+        // A store in this block blocks propagation to its successors.
+        if (blocksWithStore.contains(block))
+            continue;
+
+        // Prune the outgoing branch that is infeasible given the predecessor we
+        // arrived from (short-circuit constant-phi correlation).
+        IRBlock* infeasibleSucc = pred ? getInfeasibleBranchFromPredecessor(block, pred) : nullptr;
+
+        for (auto succ : block->getSuccessors())
+        {
+            if (succ == infeasibleSucc)
+                continue;
+            enqueueEdge(block, succ);
+        }
+    }
+
+    // A load is a violation iff its block is clean-reachable and no store precedes
+    // it within that block.
+    for (Index i = 0; i < loads.getCount();)
+    {
+        auto block = as<IRBlock>(loads[i]->getParent());
+        bool definitelyAssigned = !block || !cleanReachable.contains(block) ||
+                                  loadHasPriorStoreInBlock.contains(loads[i]);
+        if (definitelyAssigned)
+            loads.fastRemoveAt(i);
+        else
+            i++;
+    }
+}
+
 static void collectAliasableLoadStores(IRInst* inst, List<IRInst*>& stores, List<IRInst*>& loads)
 {
     auto addresses = getAliasableInstructions(inst);
@@ -395,17 +670,97 @@ static List<IRInst*> getUnresolvedParamLoads(
     return loads;
 }
 
-static List<IRInst*> getUnresolvedVariableLoads(ReachabilityContext& reachability, IRInst* inst)
+// The two disjoint classes of uninitialized-use violations for a single variable,
+// computed from one shared collection pass over its aliasable loads/stores.
+struct UninitializedUseLoads
 {
-    // Partition instructions
+    // Loads with NO store reaching them at all (the may-init violations, 41016/41033).
+    List<IRInst*> mayInit;
+
+    // Loads that some store reaches (so not may-init) but for which a store-free path
+    // from the function entry can still reach the load — i.e. the variable is only
+    // conditionally initialized (the must-init / definite-assignment violations,
+    // 41035/41036).
+    List<IRInst*> mustInit;
+};
+
+static UninitializedUseLoads getUninitializedUseLoads(
+    ReachabilityContext& reachability,
+    IRGlobalValueWithCode* func,
+    IRInst* inst)
+{
+    // Collect the aliasable loads/stores once and derive both violation sets from it.
     List<IRInst*> stores;
-    List<IRInst*> loads;
+    List<IRInst*> allLoads;
+    collectAliasableLoadStores(inst, stores, allLoads);
 
-    collectAliasableLoadStores(inst, stores, loads);
+    UninitializedUseLoads result;
 
-    cancelLoads(reachability, stores, loads);
+    // May-init violations: loads not reachable from any store.
+    result.mayInit = allLoads;
+    cancelLoads(reachability, stores, result.mayInit);
 
-    return loads;
+    // Must-init only adds information when there is at least one store (otherwise every
+    // load is already a may-init violation) and at least one load.
+    if (stores.getCount() == 0 || allLoads.getCount() == 0)
+        return result;
+
+    HashSet<IRInst*> mayInitSet;
+    for (auto load : result.mayInit)
+        mayInitSet.add(load);
+
+    result.mustInit = allLoads;
+    cancelLoadsByDefiniteAssignment(func, stores, result.mustInit);
+
+    // Keep the two sets disjoint: drop loads already reported as may-init violations.
+    for (Index i = 0; i < result.mustInit.getCount();)
+    {
+        if (mayInitSet.contains(result.mustInit[i]))
+            result.mustInit.fastRemoveAt(i);
+        else
+            i++;
+    }
+
+    return result;
+}
+
+// Emit an uninitialized-use diagnostic at each load location. The named-variable form
+// (`TVarDiag`, carrying `varName`) is used when `inst` has a user-visible name; the
+// typed-value form (`TValDiag`, carrying `typeName`) is used otherwise (e.g. poison ops
+// and other compiler-synthesized intermediates). This is shared by the may-init
+// (41016/41033) and must-init (41035/41036) paths, which differ only in the diagnostic
+// pair they pass.
+template<typename TVarDiag, typename TValDiag>
+static void diagnoseUninitializedUses(
+    DiagnosticSink* sink,
+    IRInst* inst,
+    IRType* type,
+    const List<IRInst*>& loads)
+{
+    bool hasName = inst->findDecoration<IRNameHintDecoration>() != nullptr ||
+                   inst->findDecoration<IRLinkageDecoration>() != nullptr;
+
+    for (auto load : loads)
+    {
+        if (hasName)
+        {
+            StringBuilder varNameSb;
+            printDiagnosticArg(varNameSb, inst);
+            sink->diagnose(TVarDiag{
+                .varName = varNameSb.produceString(),
+                .location = load->sourceLoc,
+            });
+        }
+        else
+        {
+            StringBuilder typeNameSb;
+            printDiagnosticArg(typeNameSb, type);
+            sink->diagnose(TValDiag{
+                .typeName = typeNameSb.produceString(),
+                .location = load->sourceLoc,
+            });
+        }
+    }
 }
 
 static bool isInstStoredInto(ReachabilityContext& reachability, IRInst* reference, IRInst* inst)
@@ -638,33 +993,20 @@ static void checkUninitializedValues(IRFunc* func, DiagnosticSink* sink)
             if (canIgnoreType(type, nullptr))
                 continue;
 
-            auto loads = getUnresolvedVariableLoads(reachability, inst);
-            for (auto load : loads)
-            {
-                // Check if we have a meaningful name for the variable
-                bool hasName = inst->findDecoration<IRNameHintDecoration>() != nullptr ||
-                               inst->findDecoration<IRLinkageDecoration>() != nullptr;
+            // Collect both may-init and must-init violations from a single shared
+            // load/store collection pass.
+            auto useLoads = getUninitializedUseLoads(reachability, func, inst);
 
-                if (hasName)
-                {
-                    StringBuilder varNameSb;
-                    printDiagnosticArg(varNameSb, inst);
-                    sink->diagnose(Diagnostics::UsingUninitializedVariable{
-                        .varName = varNameSb.produceString(),
-                        .location = load->sourceLoc,
-                    });
-                }
-                else
-                {
-                    // For poison ops and other unnamed instructions, show type instead
-                    StringBuilder typeNameSb;
-                    printDiagnosticArg(typeNameSb, type);
-                    sink->diagnose(Diagnostics::UsingUninitializedValue{
-                        .typeName = typeNameSb.produceString(),
-                        .location = load->sourceLoc,
-                    });
-                }
-            }
+            // May-init: the variable is read on a path where no store reaches it at all.
+            diagnoseUninitializedUses<
+                Diagnostics::UsingUninitializedVariable,
+                Diagnostics::UsingUninitializedValue>(sink, inst, type, useLoads.mayInit);
+
+            // Must-init: some store reaches the use, but a store-free path from entry can
+            // still reach it — the variable is only conditionally initialized.
+            diagnoseUninitializedUses<
+                Diagnostics::PossiblyUsingUninitializedVariable,
+                Diagnostics::PossiblyUsingUninitializedValue>(sink, inst, type, useLoads.mustInit);
         }
     }
 

--- a/tests/diagnostics/uninitialized-local-variables.slang
+++ b/tests/diagnostics/uninitialized-local-variables.slang
@@ -2,7 +2,11 @@
 
 float f(float) { return 1; }
 
-// Should not warn here (unconditionalBranch)
+// k0 and k1 are only conditionally assigned (inside if).
+// Note: this case is optimized away by constexpr propagation before
+// the uninit check runs, so no warning is produced at IR level.
+// The must-init warning (41035) catches this pattern when the variable
+// survives optimization (e.g. structs, out params).
 float3 unconditional(int mode)
 {
     float k0;

--- a/tests/diagnostics/uninitialized-must-init.slang
+++ b/tests/diagnostics/uninitialized-must-init.slang
@@ -1,0 +1,146 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHK): -target spirv -entry computeMain
+
+// Test must-init (definite assignment) warning 41035.
+// These cases involve variables that are conditionally initialized —
+// some control flow path has a store, but not all paths do.
+//
+// Note: simple scalar variables with conditional stores may be optimized
+// away (dead-code eliminated or folded) before the uninit check runs.
+// Tests here use structs, out params, or other patterns that survive
+// optimization.
+
+struct Data
+{
+    float value;
+};
+
+// Struct with conditional field init — survives optimization
+float struct_conditional(bool b)
+{
+    Data d;
+    if (b)
+        d.value = 1.0;
+    return d.value;
+//CHK: E41035
+//CHK: variable 'd' may be uninitialized on some paths
+}
+
+// Out parameter in conditional path
+void set_val(out int v) { v = 42; }
+
+int out_param_conditional(bool b)
+{
+    int x;
+    if (b)
+        set_val(x);
+    return x;
+//CHK: E41035
+//CHK: variable 'x' may be uninitialized on some paths
+}
+
+// Conditional via out param, only one variable
+int out_param_conditional_only(bool b)
+{
+    int y;
+    if (b)
+        set_val(y);
+    return y;
+//CHK: E41035
+//CHK: variable 'y' may be uninitialized on some paths
+}
+
+// Loop-initialized variable: should NOT warn
+// (store is unconditional within the loop body)
+void loop_init_no_warn()
+{
+    Data d;
+    for (int i = 0; i < 4; i++)
+        d.value = float(i);
+    float x = d.value;
+}
+
+// Struct unconditionally initialized: should NOT warn
+float struct_unconditional()
+{
+    Data d;
+    d.value = 1.0;
+    return d.value;
+}
+
+// Switch fallthrough: variable initialized in case 0 but used in case 1
+// which can be entered directly without going through case 0.
+// Regression test for https://github.com/shader-slang/slang/issues/9601
+float switch_fallthrough(int val)
+{
+    Data d;
+    switch (val)
+    {
+    case 0:
+        d.value = 100.0;
+        // falls through to case 1
+    case 1:
+        return d.value;
+//CHK: E41035
+//CHK: variable 'd' may be uninitialized on some paths
+    default:
+        break;
+    }
+    return -1;
+}
+
+bool init_out(out int v) { v = 1; return true; }
+
+// Short-circuit '&&': 'x' is initialized in the first operand and only used in
+// the second, which is reached only when the first ran. The '&&' lowering creates
+// a merge block whose phi carries a constant 'false' on the short-circuit edge, so
+// the flat CFG admits an infeasible store-free path to the use. The must-init
+// analysis prunes that edge (getInfeasibleBranchFromPredecessor) and must NOT warn.
+int short_circuit_and_no_warn()
+{
+    int x;
+    if (init_out(x) && x > 0)
+        return x;
+    return 0;
+}
+
+// Short-circuit '||': same idea via the negated-first-operand edge. Must NOT warn.
+int short_circuit_or_no_warn()
+{
+    int x;
+    if (!init_out(x) || x > 0)
+        return x;
+    return 0;
+}
+
+// Element-wise array fill in a loop, then read: should NOT warn. Exercises a
+// different CFG topology (array element stores) than the single struct-field
+// loop_init_no_warn case above.
+float array_loop_fill_no_warn()
+{
+    float arr[4];
+    [ForceUnroll] for (int i = 0; i < 4; i++)
+        arr[i] = float(i);
+    float s = 0;
+    [ForceUnroll] for (int i = 0; i < 4; i++)
+        s += arr[i];
+    return s;
+}
+
+// while-loop initialization: should NOT warn. Exercises a while-loop CFG shape.
+float while_loop_init_no_warn()
+{
+    Data d;
+    int i = 0;
+    while (i < 4)
+    {
+        d.value = float(i);
+        i++;
+    }
+    return d.value;
+}
+
+[Shader("compute")]
+[NumThreads(4, 1, 1)]
+void computeMain(int3 dispatchThreadID : SV_DispatchThreadID)
+{
+}

--- a/tests/neural/shared-memory-size.slang
+++ b/tests/neural/shared-memory-size.slang
@@ -95,6 +95,12 @@ void computeOneLayer<TargetEnum Target, ExecutionMode Mode, T, U, Arr:IRWArray<u
 }
 
 
+// `resBuffer` is fully initialized by the `expand computeOneLayer(...)` call below,
+// which writes one element per pack element via an `out` array parameter. The
+// must-init analysis (41035) cannot track this cross-call indexed initialization and
+// reports a false positive, so it is disabled for this function only.
+#pragma warning(push)
+#pragma warning(disable : 41035)
 uint verifySize<TargetEnum Target, ExecutionMode Mode, each T, each U>(expand each T a, expand each U b)
     where T == uint
     where U == uint
@@ -113,6 +119,7 @@ uint verifySize<TargetEnum Target, ExecutionMode Mode, each T, each U>(expand ea
 
     return maxSize;
 }
+#pragma warning(pop)
 
 // randomly generated layer configurations
 


### PR DESCRIPTION
## Summary

- Adds warning 41035 (`possibly-using-uninitialized-variable`) / 41036 that detects variables read on a control-flow path where they are only **conditionally** initialized.
- The existing may-init analysis (41016) only warns when *no* store can reach a load. The new must-init analysis warns when a **store-free path from the function entry can still reach the load**, i.e. the variable is not definitely assigned on all paths.
- Implemented as a precise **definite-assignment** analysis (a forward CFG walk from entry, blocked by store-containing blocks) rather than simple dominance. Dominance is too strict and produced many false positives.

## Precision / false-positive handling

The analysis is deliberately conservative to avoid noise:

- **Short-circuit `&&`/`||`** (`f(out x) && use(x)`): the CFG walk prunes the statically-infeasible branch created by the short-circuit merge phi (a constant `false`/`true` incoming value), so these no longer warn.
- **Element-wise loop initialization** (`[ForceUnroll] for (i) result[i] = ...`, including nested loops): a store inside a loop body suppresses the must-init warning at the loop-exit block, since such loops initialize the variable in practice. Uses *inside* the loop before the store are still reported.
- These two refinements let the entire core module (e.g. `diff.meta.slang`, `hlsl.meta.slang`) and the previously-disabled math tests compile clean with the warning **on by default**.

## Tests

- New `tests/diagnostics/uninitialized-must-init.slang`: struct conditional, out-param conditional, switch fallthrough (#9601); loop-init and unconditional cases verified to *not* warn.
- Removed all `-warnings-disable 41035` from `tests/glsl-intrinsic/intrinsic-basic-{scalar,vector}.slang` and `tests/metal/math-{scalar,vector}.slang` (short-circuit FPs are now fixed).
- `tests/neural/shared-memory-size.slang`: a single remaining FP from `expand` + `out`-array writeback is suppressed with a scoped source-level `#pragma warning(disable: 41035)` and documented, instead of six command-line disables.

Closes #10658
Closes #9601