### PR TITLE
ci: skip Claude PR review for draft PRs

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -31,10 +31,12 @@ permissions:
 
 jobs:
   review:
-    # Skip bot PRs and Claude's own branches (loop prevention)
+    # Skip draft PRs, bot PRs, and Claude's own branches (loop prevention)
+    # Drafts will trigger automatically on `ready_for_review` (see types: above)
     # workflow_dispatch bypasses these checks (manual trigger = intentional)
     if: |
       github.event_name == 'workflow_dispatch' || (
+        github.event.pull_request.draft == false &&
         !contains(github.event.pull_request.user.login, '[bot]') &&
         !startsWith(github.event.pull_request.head.ref, 'claude/')
       )


### PR DESCRIPTION
Restore the `draft == false` gate that was accidentally removed in #10257 ("Skip CI for draft PRs"). The trigger already includes `ready_for_review`, so the review will fire automatically when a draft is marked ready.