### PR TITLE
Enable KHR barycentric features during Vulkan device init

### DIFF
--- a/tools/gfx/vulkan/vk-api.h
+++ b/tools/gfx/vulkan/vk-api.h
@@ -301,6 +301,10 @@ struct VulkanExtendedFeatureProperties
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR fragmentShadingRateFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR};
 
+    // Fragment shader barycentric features
+    VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR fragmentShaderBarycentricFeatures = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR};
+
     // Vulkan 1.2 features.
     VkPhysicalDeviceVulkan12Features vulkan12Features = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES};

--- a/tools/gfx/vulkan/vk-device.cpp
+++ b/tools/gfx/vulkan/vk-device.cpp
@@ -544,6 +544,10 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
         extendedFeatures.fragmentShadingRateFeatures.pNext = deviceFeatures2.pNext;
         deviceFeatures2.pNext = &extendedFeatures.fragmentShadingRateFeatures;
 
+        // fragment shader barycentric features
+        extendedFeatures.fragmentShaderBarycentricFeatures.pNext = deviceFeatures2.pNext;
+        deviceFeatures2.pNext = &extendedFeatures.fragmentShaderBarycentricFeatures;
+
         // raytracing validation features
         extendedFeatures.rayTracingValidationFeatures.pNext = deviceFeatures2.pNext;
         deviceFeatures2.pNext = &extendedFeatures.rayTracingValidationFeatures;
@@ -851,11 +855,29 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             deviceExtensions.add(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
             m_features.add("push-descriptor");
         }
-        if (extensionNames.contains(VK_NV_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME))
+
+        const bool khrFragmentBarycentrics =
+            extensionNames.contains(VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME) &&
+            extendedFeatures.fragmentShaderBarycentricFeatures.fragmentShaderBarycentric == VK_TRUE;
+        const bool nvFragmentBarycentrics =
+            extensionNames.contains(VK_NV_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
+        if (khrFragmentBarycentrics || nvFragmentBarycentrics)
         {
-            deviceExtensions.add(VK_NV_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
             m_features.add("barycentrics");
         }
+
+        if (khrFragmentBarycentrics)
+        {
+            deviceExtensions.add(VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
+            extendedFeatures.fragmentShaderBarycentricFeatures.pNext =
+                (void*)deviceCreateInfo.pNext;
+            deviceCreateInfo.pNext = &extendedFeatures.fragmentShaderBarycentricFeatures;
+        }
+        if (nvFragmentBarycentrics)
+        {
+            deviceExtensions.add(VK_NV_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
+        }
+
         if (extensionNames.contains(VK_NV_SHADER_SUBGROUP_PARTITIONED_EXTENSION_NAME))
         {
             deviceExtensions.add(VK_NV_SHADER_SUBGROUP_PARTITIONED_EXTENSION_NAME);


### PR DESCRIPTION
# Summary

I was trying to test some barycentric code on Falcor and the RHI was reporting that my gpu doesn't support barycentric rendering. I'm testing on linux using an RX 5700 XT graphics card. my card does not list the NV extension: https://vulkan.gpuinfo.org/displayreport.php?id=47720. 

# Test plan

- [ ] validate changes against falcor with a shader that requires barycentric support.