### PR TITLE
Tighten CI Git trust and sccache setup

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -31,13 +31,20 @@ runs:
         tar xz -f /tmp/sccache.tar.gz
         rm /tmp/sccache.tar.gz
 
-        # Try with sudo if available, otherwise install directly (for containers running as root)
-        if command -v sudo &> /dev/null; then
+        # Prefer a system install when available, but support non-root containers.
+        if command -v sudo &> /dev/null && sudo -n true 2>/dev/null; then
           sudo mv sccache-v0.7.4-${SCCACHE_ARCH}/sccache /usr/local/bin/
           sudo chmod +x /usr/local/bin/sccache
-        else
+        elif [ -w /usr/local/bin ]; then
           mv sccache-v0.7.4-${SCCACHE_ARCH}/sccache /usr/local/bin/
           chmod +x /usr/local/bin/sccache
+        else
+          install_dir="${RUNNER_TEMP:-/tmp}/sccache-bin"
+          mkdir -p "$install_dir"
+          mv sccache-v0.7.4-${SCCACHE_ARCH}/sccache "$install_dir/"
+          chmod +x "$install_dir/sccache"
+          echo "$install_dir" >> "$GITHUB_PATH"
+          export PATH="$install_dir:$PATH"
         fi
 
         sccache --version

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -18,18 +18,22 @@ runs:
         ARCH=$(uname -m)
         if [[ "$ARCH" == "x86_64" ]]; then
           SCCACHE_ARCH="x86_64-unknown-linux-musl"
+          SCCACHE_SHA256="42612b161343e8b74d1feac6418c1286e036854983e7a16d567cfde3c74a8baf"
         elif [[ "$ARCH" == "aarch64" ]]; then
           SCCACHE_ARCH="aarch64-unknown-linux-musl"
+          SCCACHE_SHA256="f491b6080da49547622d2a3ea388232293a1a0bb99acb53557dad7c34608b8d9"
         else
           echo "Unsupported architecture: $ARCH"
           exit 1
         fi
 
         echo "Installing sccache for $ARCH ($SCCACHE_ARCH)"
-        curl -fL --retry 3 --retry-delay 5 -o /tmp/sccache.tar.gz \
+        sccache_archive="/tmp/sccache.tar.gz"
+        curl -fL --retry 3 --retry-delay 5 -o "$sccache_archive" \
           https://github.com/mozilla/sccache/releases/download/v0.7.4/sccache-v0.7.4-${SCCACHE_ARCH}.tar.gz
-        tar xz -f /tmp/sccache.tar.gz
-        rm /tmp/sccache.tar.gz
+        printf '%s  %s\n' "$SCCACHE_SHA256" "$sccache_archive" | sha256sum -c -
+        tar xz -f "$sccache_archive"
+        rm "$sccache_archive"
         sccache_dir="sccache-v0.7.4-${SCCACHE_ARCH}"
 
         # Prefer a system install when available, but support non-root containers.
@@ -79,6 +83,11 @@ runs:
           # Use .zip release to avoid tar path issues on Windows
           $zipFile = Join-Path $env:RUNNER_TEMP "sccache.zip"
           curl.exe -fL --retry 3 --retry-delay 5 -o $zipFile https://github.com/mozilla/sccache/releases/download/v0.7.4/sccache-v0.7.4-x86_64-pc-windows-msvc.zip
+          $expectedHash = "1b9809836e2e3e24a27cc447e5d801fab9486ebf31c8597e77461c1764b2d72b"
+          $actualHash = (Get-FileHash -Path $zipFile -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualHash -ne $expectedHash) {
+            throw "sccache archive SHA-256 mismatch: expected $expectedHash, got $actualHash"
+          }
           Expand-Archive -Path $zipFile -DestinationPath $env:RUNNER_TEMP -Force
           Move-Item (Join-Path $env:RUNNER_TEMP "sccache-v0.7.4-x86_64-pc-windows-msvc\sccache.exe") (Join-Path $installDir "sccache.exe")
           $installDir | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -30,22 +30,24 @@ runs:
           https://github.com/mozilla/sccache/releases/download/v0.7.4/sccache-v0.7.4-${SCCACHE_ARCH}.tar.gz
         tar xz -f /tmp/sccache.tar.gz
         rm /tmp/sccache.tar.gz
+        sccache_dir="sccache-v0.7.4-${SCCACHE_ARCH}"
 
         # Prefer a system install when available, but support non-root containers.
         if command -v sudo &> /dev/null && sudo -n true 2>/dev/null; then
-          sudo mv sccache-v0.7.4-${SCCACHE_ARCH}/sccache /usr/local/bin/
+          sudo mv "$sccache_dir/sccache" /usr/local/bin/
           sudo chmod +x /usr/local/bin/sccache
         elif [ -w /usr/local/bin ]; then
-          mv sccache-v0.7.4-${SCCACHE_ARCH}/sccache /usr/local/bin/
+          mv "$sccache_dir/sccache" /usr/local/bin/
           chmod +x /usr/local/bin/sccache
         else
           install_dir="${RUNNER_TEMP:-/tmp}/sccache-bin"
           mkdir -p "$install_dir"
-          mv sccache-v0.7.4-${SCCACHE_ARCH}/sccache "$install_dir/"
+          mv "$sccache_dir/sccache" "$install_dir/"
           chmod +x "$install_dir/sccache"
           echo "$install_dir" >> "$GITHUB_PATH"
           export PATH="$install_dir:$PATH"
         fi
+        rm -rf "$sccache_dir"
 
         sccache --version
 

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -44,7 +44,11 @@ runs:
           mv "$sccache_dir/sccache" /usr/local/bin/
           chmod +x /usr/local/bin/sccache
         else
-          install_parent="${RUNNER_TEMP:-/tmp}"
+          if [[ -n "${RUNNER_TEMP:-}" && -d "$RUNNER_TEMP" && -w "$RUNNER_TEMP" ]]; then
+            install_parent="$RUNNER_TEMP"
+          else
+            install_parent="/tmp"
+          fi
           mkdir -p "$install_parent"
           install_dir=$(mktemp -d "$install_parent/sccache-bin.XXXXXX")
           mv "$sccache_dir/sccache" "$install_dir/"

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -40,8 +40,9 @@ runs:
           mv "$sccache_dir/sccache" /usr/local/bin/
           chmod +x /usr/local/bin/sccache
         else
-          install_dir="${RUNNER_TEMP:-/tmp}/sccache-bin"
-          mkdir -p "$install_dir"
+          install_parent="${RUNNER_TEMP:-/tmp}"
+          mkdir -p "$install_parent"
+          install_dir=$(mktemp -d "$install_parent/sccache-bin.XXXXXX")
           mv "$sccache_dir/sccache" "$install_dir/"
           chmod +x "$install_dir/sccache"
           echo "$install_dir" >> "$GITHUB_PATH"

--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -21,9 +21,9 @@ jobs:
       packages: read # Required to pull container from ghcr.io
     container:
       image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.6.1
-      # Current callers use GitHub-hosted Ubuntu, where the mounted workspace is
-      # writable by UID/GID 1001. The published image has no named non-root user.
-      options: --user 1001:1001
+      # The disk cleanup step below removes host runner directories, so this job
+      # keeps the host-root bind mount and root user intentionally.
+      options: --user root -v /:/host_root
 
     env:
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
@@ -33,8 +33,38 @@ jobs:
         shell: bash
 
     steps:
+      - name: Free disk space on host
+        run: |
+          echo "=== Disk space before cleanup ==="
+          df -h /host_root || true
+          # Remove large pre-installed software from the GitHub runner host.
+          # NOTE: Do NOT remove /opt/hostedtoolcache - it is used by GitHub
+          # Actions (e.g. setup-gcloud) for tool caching and removal breaks steps.
+          for dir in \
+            /host_root/usr/share/dotnet \
+            /host_root/usr/local/lib/android \
+            /host_root/opt/ghc \
+            /host_root/usr/local/.ghcup \
+            /host_root/usr/share/swift \
+            /host_root/usr/local/share/powershell \
+            /host_root/usr/local/share/chromium \
+            /host_root/usr/local/share/boost \
+            /host_root/opt/microsoft/msedge \
+            /host_root/opt/google/chrome \
+            /host_root/usr/local/lib/heroku \
+          ; do
+            if [ -d "$dir" ]; then
+              size=$(du -sh "$dir" 2>/dev/null | cut -f1 || echo "unknown")
+              echo "Removing $dir ($size)..."
+              rm -rf "$dir" || true
+            fi
+          done
+          echo "=== Disk space after cleanup ==="
+          df -h /host_root || true
+
       - name: Configure Git safe directory
         run: |
+          # RUNNER_TEMP is GitHub Actions' job-local temporary directory.
           if [[ -n "${RUNNER_TEMP:-}" && -d "$RUNNER_TEMP" && -w "$RUNNER_TEMP" ]]; then
             git_config_dir="$RUNNER_TEMP"
           else

--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -21,47 +21,22 @@ jobs:
       packages: read # Required to pull container from ghcr.io
     container:
       image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.6.1
-      options: --user root -v /:/host_root
+      options: --user 1001:1001
 
     env:
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
+      GIT_CONFIG_GLOBAL: /tmp/gitconfig
+      HOME: /tmp/github-home
 
     defaults:
       run:
         shell: bash
 
     steps:
-      - name: Free disk space on host
-        run: |
-          echo "=== Disk space before cleanup ==="
-          df -h /host_root || true
-          # Remove large pre-installed software from the GitHub runner host.
-          # NOTE: Do NOT remove /opt/hostedtoolcache - it is used by GitHub
-          # Actions (e.g. setup-gcloud) for tool caching and removal breaks steps.
-          for dir in \
-            /host_root/usr/share/dotnet \
-            /host_root/usr/local/lib/android \
-            /host_root/opt/ghc \
-            /host_root/usr/local/.ghcup \
-            /host_root/usr/share/swift \
-            /host_root/usr/local/share/powershell \
-            /host_root/usr/local/share/chromium \
-            /host_root/usr/local/share/boost \
-            /host_root/opt/microsoft/msedge \
-            /host_root/opt/google/chrome \
-            /host_root/usr/local/lib/heroku \
-          ; do
-            if [ -d "$dir" ]; then
-              size=$(du -sh "$dir" 2>/dev/null | cut -f1 || echo "unknown")
-              echo "Removing $dir ($size)..."
-              rm -rf "$dir" || true
-            fi
-          done
-          echo "=== Disk space after cleanup ==="
-          df -h /host_root || true
-
       - name: Configure Git safe directory
-        run: git config --global --add safe.directory '*'
+        run: |
+          mkdir -p "$HOME"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -21,12 +21,14 @@ jobs:
       packages: read # Required to pull container from ghcr.io
     container:
       image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.6.1
+      # Current callers use GitHub-hosted Ubuntu, where the mounted workspace is
+      # writable by UID/GID 1001. The published image has no named non-root user.
       options: --user 1001:1001
 
     env:
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
+      # Store Git's global config in writable /tmp for the numeric non-root user.
       GIT_CONFIG_GLOBAL: /tmp/gitconfig
-      HOME: /tmp/github-home
 
     defaults:
       run:
@@ -34,9 +36,7 @@ jobs:
 
     steps:
       - name: Configure Git safe directory
-        run: |
-          mkdir -p "$HOME"
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -62,6 +62,11 @@ jobs:
           echo "=== Disk space after cleanup ==="
           df -h /host_root || true
 
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+          fetch-depth: "2"
+
       - name: Configure Git safe directory
         run: |
           # RUNNER_TEMP is GitHub Actions' job-local temporary directory.
@@ -73,11 +78,6 @@ jobs:
           git_config_global="$git_config_dir/gitconfig"
           echo "GIT_CONFIG_GLOBAL=$git_config_global" >> "$GITHUB_ENV"
           GIT_CONFIG_GLOBAL="$git_config_global" git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-          fetch-depth: "2"
 
       - name: Check disk space
         uses: ./.github/actions/check-disk-space

--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -27,8 +27,6 @@ jobs:
 
     env:
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
-      # Store Git's global config in writable /tmp for the numeric non-root user.
-      GIT_CONFIG_GLOBAL: /tmp/gitconfig
 
     defaults:
       run:
@@ -36,7 +34,15 @@ jobs:
 
     steps:
       - name: Configure Git safe directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: |
+          if [[ -n "${RUNNER_TEMP:-}" && -d "$RUNNER_TEMP" && -w "$RUNNER_TEMP" ]]; then
+            git_config_dir="$RUNNER_TEMP"
+          else
+            git_config_dir="/tmp"
+          fi
+          git_config_global="$git_config_dir/gitconfig"
+          echo "GIT_CONFIG_GLOBAL=$git_config_global" >> "$GITHUB_ENV"
+          GIT_CONFIG_GLOBAL="$git_config_global" git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -62,8 +62,9 @@ jobs:
           echo "=== Disk space after cleanup ==="
           df -h /host_root || true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          persist-credentials: false
           submodules: "recursive"
           fetch-depth: "2"
 

--- a/.github/workflows/ci-slang-sanitizer.yml
+++ b/.github/workflows/ci-slang-sanitizer.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Configure Git safe directory
-        run: git config --global --add safe.directory '*'
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -75,7 +75,7 @@ jobs:
           echo "GPU: $output"
 
       - name: Configure Git safe directory
-        run: git config --global --add safe.directory '*'
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - uses: actions/checkout@v4
         with:
@@ -317,7 +317,7 @@ jobs:
           echo "GPU: $output"
 
       - name: Configure Git safe directory
-        run: git config --global --add safe.directory '*'
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cmake-options-build-container.yml
+++ b/.github/workflows/cmake-options-build-container.yml
@@ -49,11 +49,13 @@ jobs:
       packages: read # Required to pull container from ghcr.io
     container:
       image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.6.1
+      # Current callers use GitHub-hosted Ubuntu, where the mounted workspace is
+      # writable by UID/GID 1001. The published image has no named non-root user.
       options: --user 1001:1001
 
     env:
+      # Store Git's global config in writable /tmp for the numeric non-root user.
       GIT_CONFIG_GLOBAL: /tmp/gitconfig
-      HOME: /tmp/github-home
 
     defaults:
       run:
@@ -65,9 +67,7 @@ jobs:
 
     steps:
       - name: Configure Git safe directory
-        run: |
-          mkdir -p "$HOME"
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cmake-options-build-container.yml
+++ b/.github/workflows/cmake-options-build-container.yml
@@ -28,8 +28,9 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          persist-credentials: false
           sparse-checkout: .github/cmake-options-matrix.json
           sparse-checkout-cone-mode: false
       - id: set-matrix
@@ -62,8 +63,9 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
+          persist-credentials: false
           submodules: "recursive"
           fetch-depth: "2"
 

--- a/.github/workflows/cmake-options-build-container.yml
+++ b/.github/workflows/cmake-options-build-container.yml
@@ -64,6 +64,7 @@ jobs:
     steps:
       - name: Configure Git safe directory
         run: |
+          # RUNNER_TEMP is GitHub Actions' job-local temporary directory.
           if [[ -n "${RUNNER_TEMP:-}" && -d "$RUNNER_TEMP" && -w "$RUNNER_TEMP" ]]; then
             git_config_dir="$RUNNER_TEMP"
           else

--- a/.github/workflows/cmake-options-build-container.yml
+++ b/.github/workflows/cmake-options-build-container.yml
@@ -53,10 +53,6 @@ jobs:
       # writable by UID/GID 1001. The published image has no named non-root user.
       options: --user 1001:1001
 
-    env:
-      # Store Git's global config in writable /tmp for the numeric non-root user.
-      GIT_CONFIG_GLOBAL: /tmp/gitconfig
-
     defaults:
       run:
         shell: bash
@@ -67,7 +63,15 @@ jobs:
 
     steps:
       - name: Configure Git safe directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: |
+          if [[ -n "${RUNNER_TEMP:-}" && -d "$RUNNER_TEMP" && -w "$RUNNER_TEMP" ]]; then
+            git_config_dir="$RUNNER_TEMP"
+          else
+            git_config_dir="/tmp"
+          fi
+          git_config_global="$git_config_dir/gitconfig"
+          echo "GIT_CONFIG_GLOBAL=$git_config_global" >> "$GITHUB_ENV"
+          GIT_CONFIG_GLOBAL="$git_config_global" git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cmake-options-build-container.yml
+++ b/.github/workflows/cmake-options-build-container.yml
@@ -49,7 +49,11 @@ jobs:
       packages: read # Required to pull container from ghcr.io
     container:
       image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.6.1
-      options: --user root -v /:/host_root
+      options: --user 1001:1001
+
+    env:
+      GIT_CONFIG_GLOBAL: /tmp/gitconfig
+      HOME: /tmp/github-home
 
     defaults:
       run:
@@ -61,7 +65,9 @@ jobs:
 
     steps:
       - name: Configure Git safe directory
-        run: git config --global --add safe.directory '*'
+        run: |
+          mkdir -p "$HOME"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cmake-options-build-container.yml
+++ b/.github/workflows/cmake-options-build-container.yml
@@ -62,6 +62,11 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+          fetch-depth: "2"
+
       - name: Configure Git safe directory
         run: |
           # RUNNER_TEMP is GitHub Actions' job-local temporary directory.
@@ -73,11 +78,6 @@ jobs:
           git_config_global="$git_config_dir/gitconfig"
           echo "GIT_CONFIG_GLOBAL=$git_config_global" >> "$GITHUB_ENV"
           GIT_CONFIG_GLOBAL="$git_config_global" git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-          fetch-depth: "2"
 
       - name: Set environment variables
         run: |

--- a/docker/linux-clang-ci.Dockerfile
+++ b/docker/linux-clang-ci.Dockerfile
@@ -68,8 +68,7 @@ RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.30.0/cmake-3.3
     ln -s /opt/cmake-3.30.0-linux-x86_64/bin/ctest /usr/local/bin/ctest && \
     ln -s /opt/cmake-3.30.0-linux-x86_64/bin/cpack /usr/local/bin/cpack
 
-# Git configuration for container workflows
-RUN git config --global --add safe.directory '*'
+# Container workflows configure Git safe.directory for the mounted workspace.
 
 # Verify installations
 RUN echo "=== Installed Tools ===" && \

--- a/docker/linux-clang-ci.Dockerfile
+++ b/docker/linux-clang-ci.Dockerfile
@@ -68,8 +68,6 @@ RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.30.0/cmake-3.3
     ln -s /opt/cmake-3.30.0-linux-x86_64/bin/ctest /usr/local/bin/ctest && \
     ln -s /opt/cmake-3.30.0-linux-x86_64/bin/cpack /usr/local/bin/cpack
 
-# Container workflows configure Git safe.directory for the mounted workspace.
-
 # Verify installations
 RUN echo "=== Installed Tools ===" && \
     echo "clang: $(clang-18 --version | head -1)" && \

--- a/docker/linux-gpu-ci.Dockerfile
+++ b/docker/linux-gpu-ci.Dockerfile
@@ -94,8 +94,7 @@ RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.30.0/cmake-3.3
 COPY docker/print-env-info.sh /usr/local/bin/print-env-info
 RUN chmod +x /usr/local/bin/print-env-info
 
-# Git configuration for container workflows
-RUN git config --global --add safe.directory '*'
+# Container workflows configure Git safe.directory for the mounted workspace.
 
 # Verify installations
 RUN echo "=== Installed Tools ===" && \

--- a/docker/linux-gpu-ci.Dockerfile
+++ b/docker/linux-gpu-ci.Dockerfile
@@ -94,8 +94,6 @@ RUN wget -q https://github.com/Kitware/CMake/releases/download/v3.30.0/cmake-3.3
 COPY docker/print-env-info.sh /usr/local/bin/print-env-info
 RUN chmod +x /usr/local/bin/print-env-info
 
-# Container workflows configure Git safe.directory for the mounted workspace.
-
 # Verify installations
 RUN echo "=== Installed Tools ===" && \
     echo "curl: $(curl --version | head -1)" && \


### PR DESCRIPTION
## Summary of the problem from the end user perspective
CI container jobs need to trust the checked-out workspace without baking broad global Git trust into container images. The shared sccache setup also needs to work when Linux jobs run without root and should verify downloaded binaries. Container workflow checkouts should also avoid mutable action refs and persisted credentials.

## Root cause
The CI images and workflows used wildcard `safe.directory` configuration, and the sccache installer assumed system write access or reusable temporary paths. The GPU build workflow also depends on host disk cleanup that requires an accepted-risk host-root mount. The affected container workflows still used the mutable `actions/checkout@v4` tag with default credential persistence.

## Solution in this PR
Scope Git `safe.directory` to `$GITHUB_WORKSPACE`, remove the wildcard trust from CI Dockerfiles, and make sccache installation permission-aware with archive SHA-256 checks. Keep the accepted-risk GPU build cleanup while leaving its Git config scoped to the workspace. Pin the container workflow checkout steps to the current v4 commit and disable checkout credential persistence.

### Notes to the reviewers; where to focus on
Review the workflow Git config scoping, the explicit host-cleanup exception in `ci-slang-build-container.yml`, the checkout pinning and credential persistence settings, and the Linux/Windows sccache install paths and checksum handling.