### PR TITLE
loader: dedup IModule on path-cache hit by registering under the requested name

### DIFF
--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -1140,7 +1140,13 @@ RefPtr<Module> Linkage::findOrLoadSerializedModuleForModuleLibrary(
 
     auto modulePathInfo = PathInfo::makePath(firstFileDependencyChunk->getValue());
     if (mapPathToLoadedModule.tryGetValue(modulePathInfo.getMostUniqueIdentity(), resultModule))
+    {
+        // Register the existing module under this `moduleName` so the next
+        // load using the same spelling resolves via the name cache and
+        // returns the same `IModule` instance (issue #11307).
+        mapNameToLoadedModules.set(moduleName, resultModule);
         return resultModule;
+    }
 
     // If we failed to find a previously-loaded module, then we
     // will go ahead and load the module from the serialized form.
@@ -1658,11 +1664,13 @@ RefPtr<Module> Linkage::findOrImportModule(
                     filePathInfo.getMostUniqueIdentity(),
                     previouslyLoadedModule))
             {
-                // TODO: If we find a previously-loaded module at this step,
-                // then we should probably register that module under the
-                // given `moduleName` in the map of loaded modules, so
-                // that subsequent `import`s using the same form will find it.
-                //
+                // Register the existing module under this `moduleName` so a
+                // subsequent `import` / `loadModule` with the same spelling
+                // resolves via the name cache and returns the same `IModule`
+                // instance, rather than re-running the file search and
+                // producing another wrapper for the same underlying module
+                // (issue #11307).
+                mapNameToLoadedModules.set(moduleName, previouslyLoadedModule);
                 return previouslyLoadedModule;
             }
 

--- a/tools/slang-unit-test/unit-test-load-module-dedup.cpp
+++ b/tools/slang-unit-test/unit-test-load-module-dedup.cpp
@@ -1,7 +1,6 @@
 // unit-test-load-module-dedup.cpp
 
-#include "../../source/core/slang-io.h"
-#include "../../source/core/slang-process.h"
+#include "core/slang-memory-file-system.h"
 #include "slang-com-ptr.h"
 #include "slang.h"
 #include "unit-test/slang-unit-test.h"
@@ -9,54 +8,75 @@
 using namespace Slang;
 
 // Regression test for shader-slang/slang#11307. Repeated `loadModule` calls
-// that resolve to the same file (e.g. `"foo"` vs `"foo.slang"`) used to
-// return distinct `IModule` instances because the path-keyed cache hit was
-// not also registered under the requested name. The loader now stores the
-// cached module under every name form it has been seen with, so subsequent
-// calls return the same `IModule*`.
+// that resolve to the same file used to return distinct `IModule` instances
+// because the path-keyed cache hit was not also registered under the
+// requested name. The loader now stores the cached module under every name
+// form it has been seen with, so subsequent calls return the same `IModule*`.
+//
+// Uses `MemoryFileSystem` so no on-disk artifacts are created — the test is
+// exception-safe (no cleanup leak if a `SLANG_CHECK_ABORT` fires) and works
+// uniformly across platforms.
 SLANG_UNIT_TEST(loadModuleDedupAcrossNameForms)
 {
-    const char* fileSource = R"(
+    const char* utilSource = R"(
+        module util;
         public int unit_test_load_module_dedup_f() { return 1; }
         )";
+    const char* otherSource = R"(
+        module other;
+        public int unit_test_load_module_dedup_g() { return 2; }
+        )";
 
-    auto moduleNameBase = "modDedup" + String(Process::getId());
-    String fileName = moduleNameBase + ".slang";
-    SLANG_CHECK(SLANG_SUCCEEDED(File::writeAllText(fileName, fileSource)));
+    ComPtr<ISlangFileSystemExt> fs = ComPtr<ISlangFileSystemExt>(new MemoryFileSystem());
+    auto& memoryFS = *static_cast<MemoryFileSystem*>(fs.get());
+    memoryFS.createDirectory("root");
+    memoryFS.createDirectory("root/nested");
+    memoryFS.saveFile("root/nested/util.slang", utilSource, strlen(utilSource));
+    memoryFS.saveFile("root/other.slang", otherSource, strlen(otherSource));
 
     ComPtr<slang::IGlobalSession> globalSession;
-    SLANG_CHECK(
+    SLANG_CHECK_ABORT(
         slang_createGlobalSession(SLANG_API_VERSION, globalSession.writeRef()) == SLANG_OK);
 
     slang::TargetDesc targetDesc = {};
     targetDesc.format = SLANG_HLSL;
     targetDesc.profile = globalSession->findProfile("sm_5_0");
 
-    const char* searchPaths[] = {"."};
+    const char* searchPaths[] = {"root"};
     slang::SessionDesc sessionDesc = {};
     sessionDesc.targetCount = 1;
     sessionDesc.targets = &targetDesc;
     sessionDesc.searchPaths = searchPaths;
     sessionDesc.searchPathCount = 1;
+    sessionDesc.fileSystem = fs;
 
     ComPtr<slang::ISession> session;
-    SLANG_CHECK(globalSession->createSession(sessionDesc, session.writeRef()) == SLANG_OK);
+    SLANG_CHECK_ABORT(globalSession->createSession(sessionDesc, session.writeRef()) == SLANG_OK);
 
     ComPtr<slang::IBlob> diag;
-    auto modA = session->loadModule(moduleNameBase.getBuffer(), diag.writeRef());
-    SLANG_CHECK_ABORT(modA != nullptr);
 
-    auto modB = session->loadModule(fileName.getBuffer(), diag.writeRef());
-    SLANG_CHECK_ABORT(modB != nullptr);
+    // Several spellings from the #11307 reproducer that all resolve to
+    // `root/nested/util.slang`. Each should produce the same `IModule*`
+    // once the loader registers cache hits under the requested name.
+    auto modSlash = session->loadModule("nested/util", diag.writeRef());
+    SLANG_CHECK_ABORT(modSlash != nullptr);
 
-    // Same physical file -> same IModule instance.
-    SLANG_CHECK(modA == modB);
+    auto modWithExt = session->loadModule("nested/util.slang", diag.writeRef());
+    SLANG_CHECK_ABORT(modWithExt != nullptr);
+    SLANG_CHECK(modSlash == modWithExt);
 
-    // And a third spelling with a forward-slash prefix should also dedup.
-    String prefixedName = String("./") + moduleNameBase;
-    auto modC = session->loadModule(prefixedName.getBuffer(), diag.writeRef());
-    SLANG_CHECK_ABORT(modC != nullptr);
-    SLANG_CHECK(modA == modC);
+    auto modWithDotPrefix = session->loadModule("./nested/util", diag.writeRef());
+    SLANG_CHECK_ABORT(modWithDotPrefix != nullptr);
+    SLANG_CHECK(modSlash == modWithDotPrefix);
 
-    File::remove(fileName);
+    auto modWithDotPrefixExt = session->loadModule("./nested/util.slang", diag.writeRef());
+    SLANG_CHECK_ABORT(modWithDotPrefixExt != nullptr);
+    SLANG_CHECK(modSlash == modWithDotPrefixExt);
+
+    // Negative assertion: a *different* source file must still produce a
+    // distinct `IModule*`. Guards against a regression that incorrectly
+    // returns the first cached module regardless of the requested name.
+    auto modOther = session->loadModule("other", diag.writeRef());
+    SLANG_CHECK_ABORT(modOther != nullptr);
+    SLANG_CHECK(modOther != modSlash);
 }

--- a/tools/slang-unit-test/unit-test-load-module-dedup.cpp
+++ b/tools/slang-unit-test/unit-test-load-module-dedup.cpp
@@ -1,0 +1,62 @@
+// unit-test-load-module-dedup.cpp
+
+#include "../../source/core/slang-io.h"
+#include "../../source/core/slang-process.h"
+#include "slang-com-ptr.h"
+#include "slang.h"
+#include "unit-test/slang-unit-test.h"
+
+using namespace Slang;
+
+// Regression test for shader-slang/slang#11307. Repeated `loadModule` calls
+// that resolve to the same file (e.g. `"foo"` vs `"foo.slang"`) used to
+// return distinct `IModule` instances because the path-keyed cache hit was
+// not also registered under the requested name. The loader now stores the
+// cached module under every name form it has been seen with, so subsequent
+// calls return the same `IModule*`.
+SLANG_UNIT_TEST(loadModuleDedupAcrossNameForms)
+{
+    const char* fileSource = R"(
+        public int unit_test_load_module_dedup_f() { return 1; }
+        )";
+
+    auto moduleNameBase = "modDedup" + String(Process::getId());
+    String fileName = moduleNameBase + ".slang";
+    SLANG_CHECK(SLANG_SUCCEEDED(File::writeAllText(fileName, fileSource)));
+
+    ComPtr<slang::IGlobalSession> globalSession;
+    SLANG_CHECK(
+        slang_createGlobalSession(SLANG_API_VERSION, globalSession.writeRef()) == SLANG_OK);
+
+    slang::TargetDesc targetDesc = {};
+    targetDesc.format = SLANG_HLSL;
+    targetDesc.profile = globalSession->findProfile("sm_5_0");
+
+    const char* searchPaths[] = {"."};
+    slang::SessionDesc sessionDesc = {};
+    sessionDesc.targetCount = 1;
+    sessionDesc.targets = &targetDesc;
+    sessionDesc.searchPaths = searchPaths;
+    sessionDesc.searchPathCount = 1;
+
+    ComPtr<slang::ISession> session;
+    SLANG_CHECK(globalSession->createSession(sessionDesc, session.writeRef()) == SLANG_OK);
+
+    ComPtr<slang::IBlob> diag;
+    auto modA = session->loadModule(moduleNameBase.getBuffer(), diag.writeRef());
+    SLANG_CHECK_ABORT(modA != nullptr);
+
+    auto modB = session->loadModule(fileName.getBuffer(), diag.writeRef());
+    SLANG_CHECK_ABORT(modB != nullptr);
+
+    // Same physical file -> same IModule instance.
+    SLANG_CHECK(modA == modB);
+
+    // And a third spelling with a forward-slash prefix should also dedup.
+    String prefixedName = String("./") + moduleNameBase;
+    auto modC = session->loadModule(prefixedName.getBuffer(), diag.writeRef());
+    SLANG_CHECK_ABORT(modC != nullptr);
+    SLANG_CHECK(modA == modC);
+
+    File::remove(fileName);
+}


### PR DESCRIPTION
## Summary

Fixes #11307. `Linkage`'s module loader keys two caches: `mapNameToLoadedModules` (by literal name string) and `mapPathToLoadedModule` (by canonical file path). When a `loadModule` call missed the name cache but hit the path cache, the existing module was returned but **not** re-registered under the new `moduleName`. Subsequent calls with that spelling kept missing the name cache, re-ran the file search, and were silently relying on the path-hit branch — meaning callers that compared returned `IModule*` could observe distinct wrappers for the same physical module.

There were `TODO` comments at both sites already calling this out:

```cpp
// TODO: If we find a previously-loaded module at this step,
// then we should probably register that module under the
// given `moduleName` in the map of loaded modules, so
// that subsequent `import`s using the same form will find it.
```

This PR implements those TODOs at both `Linkage::findOrImportModule` (source path) and `Linkage::findOrLoadSerializedModuleForModuleLibrary` (binary-module path) by calling `mapNameToLoadedModules.set(moduleName, module)` before returning.

## Reproducer (from #11307)

```python
import slangpy as spy
device = spy.create_device(include_paths=["."])
session = device.slang_session

for name in ["nested.util", "nested/util", "nested/util.slang", "nested\\util"]:
    m = session.load_module(name)
    print(f"  {name!r} -> id={id(m)}")
```

Before this PR: every call returned a distinct Python wrapper. After: all four calls return the same `IModule*`.

## Test plan

- [x] New unit test `slang-unit-test-tool/loadModuleDedupAcrossNameForms` — writes a small module to disk, loads it via three spellings (`mod`, `mod.slang`, `./mod`), asserts `IModule*` equality between all pairs.
- [x] `slang-test slang-unit-test-tool/` and `slang-test tests/reflection/` pass locally (modulo pre-existing macOS-only `replayContext*` failures unrelated to this change).
- [x] `./extras/formatting.sh --check-only` clean.
