### PR TITLE
Fix #10525: Incorrect use of NonUniform in SPIR-V

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -6287,6 +6287,49 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 ensureExtensionDeclarationBeforeSpv15(toSlice("SPV_EXT_descriptor_indexing"));
 
                 requireSPIRVCapability(SpvCapabilityShaderNonUniform);
+                // In addition to ShaderNonUniform, descriptor-array indexing requires a
+                // resource-class-specific capability (cf. glslang's
+                // TranslateNonUniformDecoration and SPV_EXT_descriptor_indexing).
+                // requireNonUniformIndexingCapability();
+                IRInst* parentInst = decoration->getParent();
+                if (parentInst)
+                {
+                    IRType* type = parentInst->getDataType();
+                    if (auto ptrType = as<IRPtrTypeBase>(type))
+                    {
+                        switch (ptrType->getAddressSpace())
+                        {
+                        case AddressSpace::StorageBuffer:
+                            requireSPIRVCapability(
+                                SpvCapabilityStorageBufferArrayNonUniformIndexing);
+                            return;
+                        case AddressSpace::Uniform:
+                            requireSPIRVCapability(
+                                SpvCapabilityUniformBufferArrayNonUniformIndexing);
+                            return;
+                        default:
+                            // Textures live in UniformConstant; unwrap and classify by texture type
+                            // below.
+                            type = ptrType->getValueType();
+                            break;
+                        }
+                    }
+                    while (auto arrayType = as<IRArrayTypeBase>(type))
+                        type = arrayType->getElementType();
+                    if (auto texType = as<IRTextureTypeBase>(type))
+                    {
+                        bool isReadWrite = texType->getAccess() != SLANG_RESOURCE_ACCESS_READ;
+                        if (texType->GetBaseShape() == SLANG_TEXTURE_BUFFER)
+                            requireSPIRVCapability(
+                                isReadWrite
+                                    ? SpvCapabilityStorageTexelBufferArrayNonUniformIndexing
+                                    : SpvCapabilityUniformTexelBufferArrayNonUniformIndexing);
+                        else
+                            requireSPIRVCapability(
+                                isReadWrite ? SpvCapabilityStorageImageArrayNonUniformIndexing
+                                            : SpvCapabilitySampledImageArrayNonUniformIndexing);
+                    }
+                }
                 emitOpDecorate(
                     getSection(SpvLogicalSectionID::Annotations),
                     decoration,

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -456,6 +456,8 @@ template<typename T>
 constexpr bool isSingular = !isPlural<T>;
 
 
+
+
 // Now that we've defined the intermediate data structures we will
 // use to represent SPIR-V code during emission, we will move on
 // to defining the main context type that will drive SPIR-V
@@ -4652,6 +4654,52 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         return emitOpBitcast(parent, inst, inst->getDataType(), vec);
     }
 
+    // In addition to ShaderNonUniform, descriptor-array indexing requires a
+    // resource-class-specific capability (cf. glslang's TranslateNonUniformDecoration
+    // and SPV_EXT_descriptor_indexing). Given the instruction a NonUniform decoration
+    // is attached to, classify it by resource class and return the matching capability
+    // via `outCapability`, or `false` if no resource-class-specific capability applies.
+    SpvCapability getNonUniformDescriptorIndexingCapability(IRInst* decoratedInst)
+    {
+        if (!decoratedInst)
+            return SpvCapabilityMax;
+
+        IRType* type = decoratedInst->getDataType();
+        if (auto ptrType = as<IRPtrTypeBase>(type))
+        {
+            switch (ptrType->getAddressSpace())
+            {
+            case AddressSpace::StorageBuffer:
+                return SpvCapabilityStorageBufferArrayNonUniformIndexing;
+            case AddressSpace::Uniform:
+                return SpvCapabilityUniformBufferArrayNonUniformIndexing;
+            default:
+                // Textures live in UniformConstant; unwrap and classify by texture type below.
+                type = ptrType->getValueType();
+                break;
+            }
+        }
+
+        while (auto arrayType = as<IRArrayTypeBase>(type))
+            type = arrayType->getElementType();
+
+        if (auto texType = as<IRTextureTypeBase>(type))
+        {
+            // Mirror ensureTextureType(): NONE and READ are sampled (read-only); everything
+            // else (WRITE, READ_WRITE, RASTER_ORDERED) is a storage image/texel buffer.
+            bool isReadWrite = texType->getAccess() != SLANG_RESOURCE_ACCESS_NONE &&
+                               texType->getAccess() != SLANG_RESOURCE_ACCESS_READ;
+            if (texType->GetBaseShape() == SLANG_TEXTURE_BUFFER)
+                return isReadWrite ? SpvCapabilityStorageTexelBufferArrayNonUniformIndexing
+                                   : SpvCapabilityUniformTexelBufferArrayNonUniformIndexing;
+            else
+                return isReadWrite ? SpvCapabilityStorageImageArrayNonUniformIndexing
+                                   : SpvCapabilitySampledImageArrayNonUniformIndexing;
+        }
+
+        return SpvCapabilityMax;
+    }
+
     bool isAtomicableAddressSpace(IRInst* type)
     {
         auto ptrType = as<IRPtrTypeBase>(type);
@@ -6287,48 +6335,10 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 ensureExtensionDeclarationBeforeSpv15(toSlice("SPV_EXT_descriptor_indexing"));
 
                 requireSPIRVCapability(SpvCapabilityShaderNonUniform);
-                // In addition to ShaderNonUniform, descriptor-array indexing requires a
-                // resource-class-specific capability (cf. glslang's
-                // TranslateNonUniformDecoration and SPV_EXT_descriptor_indexing).
-                // requireNonUniformIndexingCapability();
-                IRInst* parentInst = decoration->getParent();
-                if (parentInst)
+                SpvCapability indexingCapability = getNonUniformDescriptorIndexingCapability(decoration->getParent());
+                if (indexingCapability != SpvCapabilityMax)
                 {
-                    IRType* type = parentInst->getDataType();
-                    if (auto ptrType = as<IRPtrTypeBase>(type))
-                    {
-                        switch (ptrType->getAddressSpace())
-                        {
-                        case AddressSpace::StorageBuffer:
-                            requireSPIRVCapability(
-                                SpvCapabilityStorageBufferArrayNonUniformIndexing);
-                            return;
-                        case AddressSpace::Uniform:
-                            requireSPIRVCapability(
-                                SpvCapabilityUniformBufferArrayNonUniformIndexing);
-                            return;
-                        default:
-                            // Textures live in UniformConstant; unwrap and classify by texture type
-                            // below.
-                            type = ptrType->getValueType();
-                            break;
-                        }
-                    }
-                    while (auto arrayType = as<IRArrayTypeBase>(type))
-                        type = arrayType->getElementType();
-                    if (auto texType = as<IRTextureTypeBase>(type))
-                    {
-                        bool isReadWrite = texType->getAccess() != SLANG_RESOURCE_ACCESS_READ;
-                        if (texType->GetBaseShape() == SLANG_TEXTURE_BUFFER)
-                            requireSPIRVCapability(
-                                isReadWrite
-                                    ? SpvCapabilityStorageTexelBufferArrayNonUniformIndexing
-                                    : SpvCapabilityUniformTexelBufferArrayNonUniformIndexing);
-                        else
-                            requireSPIRVCapability(
-                                isReadWrite ? SpvCapabilityStorageImageArrayNonUniformIndexing
-                                            : SpvCapabilitySampledImageArrayNonUniformIndexing);
-                    }
+                    requireSPIRVCapability(indexingCapability);
                 }
                 emitOpDecorate(
                     getSection(SpvLogicalSectionID::Annotations),

--- a/source/slang/slang-ir-float-non-uniform-resource-index.cpp
+++ b/source/slang/slang-ir-float-non-uniform-resource-index.cpp
@@ -171,7 +171,15 @@ void processNonUniformResourceIndex(
         // getElementPtr (and loads of those).
         auto operand = inst->getOperand(0);
         auto type = operand->getDataType();
-        if (isResourceType(type) || isPointerToResourceType(type))
+        // `isPointerToResourceType` recognizes StorageBuffer-class pointers (e.g.
+        // `RWStructuredBuffer[]`), but a `ConstantBuffer<T>[]` element access lowers to a pointer
+        // into the `Uniform` address space whose pointee is a plain layout struct, which is not a
+        // resource type. Treat that as a descriptor access as well so the NonUniform decoration
+        // still reaches the index operand of the access chain.
+        bool isUniformBufferPtr = false;
+        if (auto ptrType = as<IRPtrTypeBase>(type))
+            isUniformBufferPtr = ptrType->getAddressSpace() == AddressSpace::Uniform;
+        if (isResourceType(type) || isPointerToResourceType(type) || isUniformBufferPtr)
         {
             IRBuilder builder(operand);
             auto decorate = [&](IRInst* value)

--- a/source/slang/slang-ir-spirv-legalize.cpp
+++ b/source/slang/slang-ir-spirv-legalize.cpp
@@ -2131,6 +2131,33 @@ struct SPIRVLegalizationContext : public SourceEmitterBase
             {
                 for (auto inst : block->getChildren())
                 {
+                     // VUID-RuntimeSpirv-NonUniform-06274 If an instruction loads from or stores to a resource 
+                     // (including atomics and image instructions) and the resource descriptor being accessed is not 
+                     // dynamically uniform, then the operand corresponding to that resource (e.g. the pointer or sampled image operand) 
+                     // must be decorated with NonUniform
+                     if (auto load = as<IRLoad>(inst))
+                     {
+                         auto ptr = load->getPtr();
+                         switch (ptr->getOp())
+                         {
+                         case kIROp_GetElement:
+                         case kIROp_GetElementPtr:
+                         case kIROp_RWStructuredBufferGetElementPtr:
+                             if (isResourceType(load->getDataType()) &&
+                                 ptr->findDecoration<IRSPIRVNonUniformResourceDecoration>() &&
+                                 !load->findDecoration<IRSPIRVNonUniformResourceDecoration>())
+                             {
+                                 IRBuilder builder(load);
+                                 builder.setInsertBefore(load);
+                                 builder.addSPIRVNonUniformResourceDecoration(load);
+                             }
+                             break;
+                         default:
+                             break;
+                         }
+                         continue;
+                     }
+
                     IRInst* indexOperand = nullptr;
                     switch (inst->getOp())
                     {

--- a/tests/spirv/nonuniform-resource-index.slang
+++ b/tests/spirv/nonuniform-resource-index.slang
@@ -1,22 +1,10 @@
-// Coverage for `NonUniformResourceIndex` across descriptor-array resource
-// classes when emitting SPIR-V directly.
-//
-// Two things must be correct for each class (cf. glslang's
-// `array[nonuniformEXT(i)]`, and the Vulkan/SPV_EXT_descriptor_indexing spec):
-//
-//   1. NonUniform decoration reaches the operand the access actually consumes:
-//        - sampled/storage images & texel buffers: the OpLoad of the descriptor
-//          that feeds OpSampledImage / OpImageFetch / OpImageWrite;
-//        - uniform/storage buffers: the OpAccessChain into the buffer.
-//   2. The matching type-specific capability is declared (not just
-//      ShaderNonUniform): SampledImage / StorageImage / StorageBuffer /
-//      UniformBuffer / UniformTexelBuffer / StorageTexelBuffer
-//      ArrayNonUniformIndexing.
-//
-// Status when authored (slang ~v2026.9.1-39): the decorations are present for
-// every class EXCEPT ConstantBuffer[] (where NonUniformResourceIndex is dropped
-// entirely), and NONE of the type-specific capabilities are emitted -- slang
-// emits only ShaderNonUniform. These checks pin the fix.
+// nonuniform-resource-index.slang
+
+// Check that `NonUniformResourceIndex` on a descriptor array emits, for each
+// resource class, (1) the NonUniform decoration on the operand the access
+// consumes (the descriptor OpLoad for images/texel buffers, the OpAccessChain
+// for uniform/storage buffers) and (2) the matching type-specific
+// *ArrayNonUniformIndexing capability, alongside the base ShaderNonUniform.
 
 //TEST:SIMPLE(filecheck=COMBINED):-target spirv -entry combinedSampler -stage fragment -emit-spirv-directly
 //TEST:SIMPLE(filecheck=SAMPLED):-target spirv -entry sampledImage -stage fragment -emit-spirv-directly
@@ -30,8 +18,7 @@
 // --- combined sampler array (Sampler2D[] + .Sample) -----------------------
 // Exact form of https://github.com/shader-slang/slang/issues/10930: the
 // NonUniform decoration must reach the descriptor OpLoad consumed by
-// OpImageSampleImplicitLod. (Decoration landed already; the capability is the
-// remaining gap.)
+// OpImageSampleImplicitLod.
 //
 Sampler2D gCombined[];
 
@@ -93,7 +80,6 @@ void storageBuffer(uint3 t : SV_DispatchThreadID)
 
 //
 // --- uniform buffer array (ConstantBuffer[]) ------------------------------
-// Currently broken twice over: no NonUniform decoration AND no capability.
 //
 struct Foo { float4 v; };
 ConstantBuffer<Foo> gCB[];

--- a/tests/spirv/nonuniform-resource-index.slang
+++ b/tests/spirv/nonuniform-resource-index.slang
@@ -1,0 +1,142 @@
+// Coverage for `NonUniformResourceIndex` across descriptor-array resource
+// classes when emitting SPIR-V directly.
+//
+// Two things must be correct for each class (cf. glslang's
+// `array[nonuniformEXT(i)]`, and the Vulkan/SPV_EXT_descriptor_indexing spec):
+//
+//   1. NonUniform decoration reaches the operand the access actually consumes:
+//        - sampled/storage images & texel buffers: the OpLoad of the descriptor
+//          that feeds OpSampledImage / OpImageFetch / OpImageWrite;
+//        - uniform/storage buffers: the OpAccessChain into the buffer.
+//   2. The matching type-specific capability is declared (not just
+//      ShaderNonUniform): SampledImage / StorageImage / StorageBuffer /
+//      UniformBuffer / UniformTexelBuffer / StorageTexelBuffer
+//      ArrayNonUniformIndexing.
+//
+// Status when authored (slang ~v2026.9.1-39): the decorations are present for
+// every class EXCEPT ConstantBuffer[] (where NonUniformResourceIndex is dropped
+// entirely), and NONE of the type-specific capabilities are emitted -- slang
+// emits only ShaderNonUniform. These checks pin the fix.
+
+//TEST:SIMPLE(filecheck=COMBINED):-target spirv -entry combinedSampler -stage fragment -emit-spirv-directly
+//TEST:SIMPLE(filecheck=SAMPLED):-target spirv -entry sampledImage -stage fragment -emit-spirv-directly
+//TEST:SIMPLE(filecheck=STOREIMG):-target spirv -entry storageImage -stage compute -emit-spirv-directly
+//TEST:SIMPLE(filecheck=STOREBUF):-target spirv -entry storageBuffer -stage compute -emit-spirv-directly
+//TEST:SIMPLE(filecheck=UNIFBUF):-target spirv -entry uniformBuffer -stage compute -emit-spirv-directly
+//TEST:SIMPLE(filecheck=UNIFTEX):-target spirv -entry uniformTexelBuffer -stage compute -emit-spirv-directly
+//TEST:SIMPLE(filecheck=STORETEX):-target spirv -entry storageTexelBuffer -stage compute -emit-spirv-directly
+
+//
+// --- combined sampler array (Sampler2D[] + .Sample) -----------------------
+// Exact form of https://github.com/shader-slang/slang/issues/10930: the
+// NonUniform decoration must reach the descriptor OpLoad consumed by
+// OpImageSampleImplicitLod. (Decoration landed already; the capability is the
+// remaining gap.)
+//
+Sampler2D gCombined[];
+
+// COMBINED: OpCapability SampledImageArrayNonUniformIndexing
+// COMBINED: OpAccessChain {{.*}} %gCombined {{.*}}; NonUniform
+// COMBINED: [[IMG:%[0-9a-zA-Z_]+]] = OpLoad {{.*}}; NonUniform
+// COMBINED: OpImageSampleImplicitLod {{.*}} [[IMG]]
+[shader("fragment")]
+float4 combinedSampler(float2 uv : UV, uint i : I) : SV_Target
+{
+    return gCombined[NonUniformResourceIndex(i)].Sample(uv);
+}
+
+//
+// --- sampled image array (Texture2D[] + separate SamplerState) ------------
+//
+Texture2D gTex[];
+SamplerState gSamp;
+
+// SAMPLED: OpCapability SampledImageArrayNonUniformIndexing
+// SAMPLED: OpAccessChain {{.*}} %gTex {{.*}}; NonUniform
+// SAMPLED: [[IMG:%[0-9a-zA-Z_]+]] = OpLoad {{.*}}; NonUniform
+// SAMPLED: OpSampledImage {{.*}} [[IMG]]
+[shader("fragment")]
+float4 sampledImage(uint i : I) : SV_Target
+{
+    return gTex[NonUniformResourceIndex(i)].SampleLevel(gSamp, float2(0, 0), 0);
+}
+
+//
+// --- storage image array (RWTexture2D[]) ----------------------------------
+//
+RWTexture2D<float4> gRWTex[];
+
+// STOREIMG: OpCapability StorageImageArrayNonUniformIndexing
+// STOREIMG: OpAccessChain {{.*}} %gRWTex {{.*}}; NonUniform
+// STOREIMG: [[IMG:%[0-9a-zA-Z_]+]] = OpLoad {{.*}}; NonUniform
+// STOREIMG: OpImageWrite [[IMG]]
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void storageImage(uint3 t : SV_DispatchThreadID)
+{
+    gRWTex[NonUniformResourceIndex(t.x)][uint2(0, 0)] = float4(1, 0, 0, 0);
+}
+
+//
+// --- storage buffer array (RWStructuredBuffer[]) --------------------------
+//
+RWStructuredBuffer<float4> gSB[];
+
+// STOREBUF: OpCapability StorageBufferArrayNonUniformIndexing
+// STOREBUF: OpAccessChain {{.*}} %gSB {{.*}}; NonUniform
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void storageBuffer(uint3 t : SV_DispatchThreadID)
+{
+    gSB[NonUniformResourceIndex(t.x)][0] = float4(2, 0, 0, 0);
+}
+
+//
+// --- uniform buffer array (ConstantBuffer[]) ------------------------------
+// Currently broken twice over: no NonUniform decoration AND no capability.
+//
+struct Foo { float4 v; };
+ConstantBuffer<Foo> gCB[];
+RWStructuredBuffer<float4> gOutCB;
+
+// UNIFBUF: OpCapability UniformBufferArrayNonUniformIndexing
+// UNIFBUF: OpAccessChain {{.*}} %gCB {{.*}}; NonUniform
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void uniformBuffer(uint3 t : SV_DispatchThreadID)
+{
+    gOutCB[0] = gCB[NonUniformResourceIndex(t.x)].v;
+}
+
+//
+// --- uniform texel buffer array (Buffer<T>[]) -----------------------------
+//
+Buffer<float4> gTB[];
+RWStructuredBuffer<float4> gOutTB;
+
+// UNIFTEX: OpCapability UniformTexelBufferArrayNonUniformIndexing
+// UNIFTEX: OpAccessChain {{.*}} %gTB {{.*}}; NonUniform
+// UNIFTEX: [[IMG:%[0-9a-zA-Z_]+]] = OpLoad {{.*}}; NonUniform
+// UNIFTEX: OpImageFetch {{.*}} [[IMG]]
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void uniformTexelBuffer(uint3 t : SV_DispatchThreadID)
+{
+    gOutTB[0] = gTB[NonUniformResourceIndex(t.x)].Load(0);
+}
+
+//
+// --- storage texel buffer array (RWBuffer<T>[]) ---------------------------
+//
+RWBuffer<float4> gRWB[];
+
+// STORETEX: OpCapability StorageTexelBufferArrayNonUniformIndexing
+// STORETEX: OpAccessChain {{.*}} %gRWB {{.*}}; NonUniform
+// STORETEX: [[IMG:%[0-9a-zA-Z_]+]] = OpLoad {{.*}}; NonUniform
+// STORETEX: OpImageWrite [[IMG]]
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void storageTexelBuffer(uint3 t : SV_DispatchThreadID)
+{
+    gRWB[NonUniformResourceIndex(t.x)][0] = float4(3, 0, 0, 0);
+}


### PR DESCRIPTION
While working on a personal project, I encountered visual artifacts (texel border bleeding) caused by non-uniform access errors. This was observed on an AMD Radeon RX 7800 XT using the radv Mesa driver.

This addresses the same underlying problem reported in #10525 and #10930, which triggers the following Vulkan validation error:

```
VUID-RuntimeSpirv-NonUniform-06274
If an instruction loads from or stores to a resource (including atomics and image instructions) and the resource descriptor being accessed is not dynamically uniform, then the operand corresponding to that resource (e.g. the pointer or sampled image operand) must be decorated with NonUniform
```

## Test

Added `tests/spirv/nonuniform-resource-index.slang`, covering the descriptor-array resource classes above with `-emit-spirv-directly`. Each variant FileCheck-pins both requirements: (1) the type-specific `*ArrayNonUniformIndexing` capability is declared, and (2) the `NonUniform` decoration reaches the operand the access consumes — the `OpAccessChain` for uniform/storage buffers, and the descriptor `OpLoad` feeding `OpSampledImage` / `OpImageFetch` / `OpImageWrite` for images and texel buffers.

I also ran this against my current project to see if the artifacts were resolved: 
before: 
<img width="183" height="176" alt="image" src="https://github.com/user-attachments/assets/e7df3890-3c95-4c77-a320-db112bdef3e4" />

after:
<img width="373" height="323" alt="image" src="https://github.com/user-attachments/assets/63f55091-20e0-44e9-8a62-536d448e7d2f" />


