### PR TITLE
Remove deprecated SPIRV-Tools optimizer passes

### DIFF
--- a/source/slang-glslang/slang-glslang.cpp
+++ b/source/slang-glslang/slang-glslang.cpp
@@ -264,8 +264,6 @@ static int glslang_optimizeSPIRV(
         return 0;
     }
 
-    const auto debugInfoType = request.debugInfoType;
-
     spvtools::Optimizer optimizer(targetEnv);
 
     auto messageConsumer = [&](spv_message_level_t level,
@@ -287,15 +285,6 @@ static int glslang_optimizeSPIRV(
         outDiags.push_back(diag);
     };
     optimizer.SetMessageConsumer(messageConsumer);
-
-    // If debug info is being generated at Minimal level or above, propagate
-    // line information into all SPIR-V instructions. This avoids loss of
-    // information when instructions are deleted or moved. Later, remove
-    // redundant information to minimize final SPRIR-V size.
-    if (debugInfoType != SLANG_DEBUG_INFO_LEVEL_NONE)
-    {
-        optimizer.RegisterPass(spvtools::CreatePropagateLineInfoPass());
-    }
 
     spvtools::OptimizerOptions spvOptOptions;
 
@@ -507,11 +496,6 @@ static int glslang_optimizeSPIRV(
 
             break;
         }
-    }
-
-    if (debugInfoType != SLANG_DEBUG_INFO_LEVEL_NONE)
-    {
-        optimizer.RegisterPass(spvtools::CreateRedundantLineInfoElimPass());
     }
 
     spvOptOptions.set_run_validator(false); // Don't run the validator by default


### PR DESCRIPTION
## Summary of the problem from the end user perspective

slang-glslang still registered SPIRV-Tools line-info optimizer passes that are now deprecated and may be removed. This left the build depending on obsolete optimizer APIs.

## Root cause

The optimizer setup registered `CreatePropagateLineInfoPass` before optimization when debug info was enabled, then registered `CreateRedundantLineInfoElimPass` afterward. SPIRV-Tools now documents both pass factories as [deprecated empty passes](https://github.com/KhronosGroup/SPIRV-Tools/blob/main/include/spirv-tools/optimizer.hpp#L561-L571).

## Solution in this PR

Remove both pass registrations and the now-unused `debugInfoType` local. No replacement pass is needed because the deprecated SPIRV-Tools passes are empty.

### Notes to the reviewers; where to focus on

Focus on `glslang_optimizeSPIRV` in `source/slang-glslang/slang-glslang.cpp`. I also checked SPIRV-Tools deprecation markers and found no other deprecated functions called by Slang; the remaining Slang use of `SPV_ENV_WEBGPU_0` is a deprecated target enum alias, not a function.