### PR TITLE
Use VS 2026 for CMake options workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,7 +41,6 @@ jobs:
       (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'claude') ||
       contains(github.event.comment.body || github.event.review.body || github.event.issue.body || '', '@claude')
 
-    # Defaults to the self-hosted Windows GPU runner used by Claude automation.
     runs-on: ${{ fromJSON(vars.CLAUDE_RUNNER || '["Windows", "self-hosted", "GCP-T4"]') }}
     timeout-minutes: 360
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,8 +42,6 @@ jobs:
       contains(github.event.comment.body || github.event.review.body || github.event.issue.body || '', '@claude')
 
     # Defaults to the self-hosted Windows GPU runner used by Claude automation.
-    # Repositories can override the exact label set with CLAUDE_RUNNER; Windows
-    # runners selected here must provide VS 2026 for the setup commands below.
     runs-on: ${{ fromJSON(vars.CLAUDE_RUNNER || '["Windows", "self-hosted", "GCP-T4"]') }}
     timeout-minutes: 360
 
@@ -193,8 +191,8 @@ jobs:
               echo "Claude can build on-demand if needed via cmake commands."
             elif [ "${RUNNER_OS}" = "Windows" ]; then
               echo "Setting up Windows environment..."
-              cmake.exe --preset vs2026 --fresh -DSLANG_IGNORE_ABORT_MSG=ON
-              cmake.exe --build --preset vs2026-debug >/dev/null 2>&1 || cmake.exe --build --preset vs2026-debug
+              cmake.exe --preset vs2022 --fresh -DSLANG_IGNORE_ABORT_MSG=ON
+              cmake.exe --build --preset vs2022-debug >/dev/null 2>&1 || cmake.exe --build --preset vs2022-debug
             else
               echo "Setting up Linux environment..."
               cmake --preset default -DSLANG_SLANG_LLVM_BINARY_URL=https://github.com/shader-slang/slang/releases/download/v2025.6.1/slang-2026.1.2-linux-x86_64.zip --fresh

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,6 +41,9 @@ jobs:
       (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'claude') ||
       contains(github.event.comment.body || github.event.review.body || github.event.issue.body || '', '@claude')
 
+    # Defaults to the self-hosted Windows GPU runner used by Claude automation.
+    # Repositories can override the exact label set with CLAUDE_RUNNER; Windows
+    # runners selected here must provide VS 2026 for the setup commands below.
     runs-on: ${{ fromJSON(vars.CLAUDE_RUNNER || '["Windows", "self-hosted", "GCP-T4"]') }}
     timeout-minutes: 360
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -190,8 +190,8 @@ jobs:
               echo "Claude can build on-demand if needed via cmake commands."
             elif [ "${RUNNER_OS}" = "Windows" ]; then
               echo "Setting up Windows environment..."
-              cmake.exe --preset vs2022 --fresh -DSLANG_IGNORE_ABORT_MSG=ON
-              cmake.exe --build --preset vs2022-debug >/dev/null 2>&1 || cmake.exe --build --preset vs2022-debug
+              cmake.exe --preset vs2026 --fresh -DSLANG_IGNORE_ABORT_MSG=ON
+              cmake.exe --build --preset vs2026-debug >/dev/null 2>&1 || cmake.exe --build --preset vs2026-debug
             else
               echo "Setting up Linux environment..."
               cmake --preset default -DSLANG_SLANG_LLVM_BINARY_URL=https://github.com/shader-slang/slang/releases/download/v2025.6.1/slang-2026.1.2-linux-x86_64.zip --fresh

--- a/.github/workflows/cmake-options.yml
+++ b/.github/workflows/cmake-options.yml
@@ -91,6 +91,9 @@ jobs:
       runs-on: '["windows-latest"]'
       arch: "amd64_arm64"
 
+  # windows-vs2019-debug: disabled — windows-2019 runner is being retired (June 2025)
+  # windows-vs2019-release: disabled — windows-2019 runner is being retired (June 2025)
+
   windows-vs2022-debug:
     uses: ./.github/workflows/cmake-options-build.yml
     with:

--- a/.github/workflows/cmake-options.yml
+++ b/.github/workflows/cmake-options.yml
@@ -78,7 +78,7 @@ jobs:
       compiler: cl
       platform: aarch64
       config: debug
-      runs-on: '["windows-2025-vs2026"]'
+      runs-on: '["windows-2025"]'
       arch: "amd64_arm64"
 
   windows-aarch64-release:
@@ -88,7 +88,7 @@ jobs:
       compiler: cl
       platform: aarch64
       config: release
-      runs-on: '["windows-2025-vs2026"]'
+      runs-on: '["windows-2025"]'
       arch: "amd64_arm64"
 
   # windows-vs2019-debug: disabled — windows-2019 runner is being retired (June 2025)

--- a/.github/workflows/cmake-options.yml
+++ b/.github/workflows/cmake-options.yml
@@ -91,8 +91,25 @@ jobs:
       runs-on: '["windows-latest"]'
       arch: "amd64_arm64"
 
-  # windows-vs2019-debug: disabled — windows-2019 runner is being retired (June 2025)
-  # windows-vs2019-release: disabled — windows-2019 runner is being retired (June 2025)
+  windows-vs2022-debug:
+    uses: ./.github/workflows/cmake-options-build.yml
+    with:
+      os: windows
+      compiler: cl
+      platform: x86_64
+      config: debug
+      runs-on: '["windows-2025"]'
+      buildtool: "Visual Studio 17 2022"
+
+  windows-vs2022-release:
+    uses: ./.github/workflows/cmake-options-build.yml
+    with:
+      os: windows
+      compiler: cl
+      platform: x86_64
+      config: release
+      runs-on: '["windows-2025"]'
+      buildtool: "Visual Studio 17 2022"
 
   windows-vs2026-debug:
     uses: ./.github/workflows/cmake-options-build.yml
@@ -125,6 +142,8 @@ jobs:
         macos-release,
         windows-aarch64-debug,
         windows-aarch64-release,
+        windows-vs2022-debug,
+        windows-vs2022-release,
         windows-vs2026-debug,
         windows-vs2026-release,
       ]

--- a/.github/workflows/cmake-options.yml
+++ b/.github/workflows/cmake-options.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   linux-debug:
     uses: ./.github/workflows/cmake-options-build-container.yml
@@ -75,7 +78,7 @@ jobs:
       compiler: cl
       platform: aarch64
       config: debug
-      runs-on: '["windows-latest"]'
+      runs-on: '["windows-2025-vs2026"]'
       arch: "amd64_arm64"
 
   windows-aarch64-release:
@@ -85,34 +88,31 @@ jobs:
       compiler: cl
       platform: aarch64
       config: release
-      runs-on: '["windows-latest"]'
+      runs-on: '["windows-2025-vs2026"]'
       arch: "amd64_arm64"
 
   # windows-vs2019-debug: disabled — windows-2019 runner is being retired (June 2025)
   # windows-vs2019-release: disabled — windows-2019 runner is being retired (June 2025)
 
-  windows-vs2022-debug:
+  windows-vs2026-debug:
     uses: ./.github/workflows/cmake-options-build.yml
     with:
       os: windows
       compiler: cl
       platform: x86_64
       config: debug
-      runs-on: '["windows-2022"]'
-      buildtool: "Visual Studio 17 2022"
+      runs-on: '["windows-2025-vs2026"]'
+      buildtool: "Visual Studio 18 2026"
 
-  windows-vs2022-release:
+  windows-vs2026-release:
     uses: ./.github/workflows/cmake-options-build.yml
     with:
       os: windows
       compiler: cl
       platform: x86_64
       config: release
-      runs-on: '["windows-2022"]'
-      buildtool: "Visual Studio 17 2022"
-
-  # windows-vs2026-debug: disabled — VS 2026 not yet available on GitHub-hosted runners
-  # windows-vs2026-release: disabled — VS 2026 not yet available on GitHub-hosted runners
+      runs-on: '["windows-2025-vs2026"]'
+      buildtool: "Visual Studio 18 2026"
 
   check-cmake:
     needs:
@@ -125,8 +125,8 @@ jobs:
         macos-release,
         windows-aarch64-debug,
         windows-aarch64-release,
-        windows-vs2022-debug,
-        windows-vs2022-release,
+        windows-vs2026-debug,
+        windows-vs2026-release,
       ]
     runs-on: ubuntu-latest
     if: always()

--- a/.github/workflows/cmake-options.yml
+++ b/.github/workflows/cmake-options.yml
@@ -78,7 +78,7 @@ jobs:
       compiler: cl
       platform: aarch64
       config: debug
-      runs-on: '["windows-2025"]'
+      runs-on: '["windows-latest"]'
       arch: "amd64_arm64"
 
   windows-aarch64-release:
@@ -88,7 +88,7 @@ jobs:
       compiler: cl
       platform: aarch64
       config: release
-      runs-on: '["windows-2025"]'
+      runs-on: '["windows-latest"]'
       arch: "amd64_arm64"
 
   # windows-vs2019-debug: disabled — windows-2019 runner is being retired (June 2025)


### PR DESCRIPTION
Fixes #11133

## Summary of the problem from the end user perspective

The CMake Options workflow did not explicitly cover the Windows x64 Visual Studio 2026 generator configuration while preserving the existing Visual Studio 2022 coverage.

## Root cause

The workflow only had one Windows x64 Visual Studio generator family at a time, so moving to VS 2026 removed the explicit VS 2022 generator jobs. The Windows AArch64 jobs use their existing `windows-latest` runner selection, and the Claude setup workflow runs on a self-hosted Windows runner, so those paths do not need VS 2026 runner/preset changes.

## Solution in this PR

Keep Windows x64 VS 2022 debug and release generator jobs on `windows-2025` with `Visual Studio 17 2022`, add Windows x64 VS 2026 debug and release generator jobs on `windows-2025-vs2026` with `Visual Studio 18 2026`, and update `check-cmake` to depend on all four VS generator jobs. Leave the Windows AArch64 jobs on `windows-latest` and the self-hosted Claude setup workflow on its existing VS 2022 presets.

### Reference data

- https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-VS2026-Readme.md
- https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md

### Notes to the reviewers; where to focus on

Review the Windows x64 generator jobs in `.github/workflows/cmake-options.yml`, especially the `windows-2025` / `Visual Studio 17 2022` VS 2022 jobs, the `windows-2025-vs2026` / `Visual Studio 18 2026` VS 2026 jobs, and the updated `check-cmake` dependency list.
