### PR TITLE
Fix default ctor synthesis for later member types

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -3144,6 +3144,8 @@ static Expr* constructDefaultConstructorForType(
     {
         if (auto structDecl = as<StructDecl>(declRefType->getDeclRef().getDecl()))
         {
+            if (!structDecl->checkState.isBeingChecked())
+                visitor->ensureDecl(structDecl, DeclCheckState::AttributesChecked);
             defaultCtor = _getDefaultCtor(structDecl);
         }
     }

--- a/tests/initializer-list/default-init-later-member-explicit-ctor.slang
+++ b/tests/initializer-list/default-init-later-member-explicit-ctor.slang
@@ -1,0 +1,39 @@
+//TEST:SIMPLE: -stage compute -entry main
+
+struct ExplicitDefault
+{
+    int value;
+
+    __init(int value = 0)
+    {
+        this.value = value;
+    }
+}
+
+struct UsesLaterType
+{
+    LaterType later;
+}
+
+struct LaterType
+{
+    ExplicitDefault leaf;
+}
+
+struct Outer
+{
+    UsesLaterType data;
+}
+
+void init(inout Outer o)
+{
+    o = {};
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main()
+{
+    Outer o;
+    init(o);
+}

--- a/tests/initializer-list/default-init-later-member-explicit-ctor.slang
+++ b/tests/initializer-list/default-init-later-member-explicit-ctor.slang
@@ -1,4 +1,5 @@
-//TEST:SIMPLE: -stage compute -entry main
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUFFER):-shaderobj -vk
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=BUFFER):-shaderobj
 
 struct ExplicitDefault
 {
@@ -25,6 +26,9 @@ struct Outer
     UsesLaterType data;
 }
 
+//TEST_INPUT:ubuffer(data=[1], stride=4):out,name=outputBuffer
+RWStructuredBuffer<int> outputBuffer;
+
 void init(inout Outer o)
 {
     o = {};
@@ -32,8 +36,11 @@ void init(inout Outer o)
 
 [shader("compute")]
 [numthreads(1, 1, 1)]
-void main()
+void computeMain()
 {
     Outer o;
     init(o);
+
+    // BUFFER: 0
+    outputBuffer[0] = o.data.later.leaf.value;
 }


### PR DESCRIPTION
Fixes #11095

## Summary of the problem from the end user perspective

Default-initializing a struct with `{}` could fail with `not enough arguments to call` when one member's struct type was declared later in the file and transitively contained a type with an explicit default constructor.

### Minimal repro shader; if applicable

```slang
struct ExplicitDefault { __init(int value = 0) {} }
struct UsesLaterType { LaterType later; }
struct LaterType { ExplicitDefault leaf; }
struct Outer { UsesLaterType data; }
void init(inout Outer o) { o = {}; }
```

## Root cause

`constructDefaultConstructorForType` queried `_getDefaultCtor` for member struct types before ensuring those declarations had reached `AttributesChecked`, so synthesized constructors might not exist yet.

## Solution in this PR

Advance member struct declarations to `AttributesChecked` before looking up their default constructors, matching the existing synthesized constructor invocation path.

### Notes to the reviewers; where to focus on

The implementation change is the two-line guard before `_getDefaultCtor`; the new initializer-list regression covers the declaration-order dependency with an explicit default constructor leaf.