### PR TITLE
Fix command line reference regeneration setup

### DIFF
--- a/.github/workflows/regenerate-cmdline-ref.yml
+++ b/.github/workflows/regenerate-cmdline-ref.yml
@@ -17,6 +17,14 @@ jobs:
       github.event.client_payload.pull_request.base.repo.full_name == 'shader-slang/slang'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout target branch
+        uses: actions/checkout@v4
+        with:
+          repository: shader-slang/slang
+          ref: ${{ github.event.client_payload.pull_request.base.ref }}
+          submodules: "recursive"
+          persist-credentials: false
+
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
@@ -26,22 +34,13 @@ jobs:
           submodules: "recursive"
           persist-credentials: false
 
-      - name: Checkout target branch
-        uses: actions/checkout@v4
-        with:
-          repository: shader-slang/slang
-          ref: ${{ github.event.client_payload.pull_request.base.ref }}
-          path: target-branch
-          submodules: "recursive"
-          persist-credentials: false
-
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libx11-dev
 
       - name: Setup
-        uses: ./target-branch/.github/actions/common-setup
+        uses: ./.github/actions/common-setup
         with:
           os: linux
           compiler: gcc


### PR DESCRIPTION
Fixed the workflow pathing issue in .github/workflows/regenerate-cmdline-ref.yml:20.

The failing job was dying in Setup because common-setup was loaded from ./target-branch/..., but its nested local action lookup still resolved ./.github/actions/check-disk-space from the workspace root. I changed the workflow to checkout the trusted target branch at the workspace root, checkout the PR branch into pr-branch, and use ./.github/actions/common-setup.