### PR TITLE
Default implicit SPIR-V SER to EXT

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1445,6 +1445,7 @@ A capability describes an optional feature that a target may or may not support.
 * `cpp_glsl_hlsl_metal_spirv_wgsl` 
 * `cpp_hlsl` 
 * `cuda_glsl_hlsl` 
+* `cuda_glsl_nvapi` 
 * `cuda_hlsl_metal_spirv` 
 * `cuda_glsl_hlsl_spirv` 
 * `cuda_glsl_hlsl_spirv_llvm` 

--- a/docs/target-compatibility.md
+++ b/docs/target-compatibility.md
@@ -292,7 +292,13 @@ There is preliminary [Mesh Shader support](https://github.com/shader-slang/slang
 
 More information about [Shader Execution Reordering](shader-execution-reordering.md).
 
-Currently support is available in D3D12 via NVAPI, and for Vulkan via the [GL_NV_shader_invocation_reorder](https://github.com/KhronosGroup/GLSL/blob/master/extensions/nv/GLSL_NV_shader_invocation_reorder.txt) extension.
+Currently support is available in D3D12 via NVAPI. For Vulkan, Slang uses the
+[GL_EXT_shader_invocation_reorder](https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_shader_invocation_reorder.txt)
+extension by default for implicit SPIR-V SER capability upgrades. The
+[GL_NV_shader_invocation_reorder](https://github.com/KhronosGroup/GLSL/blob/master/extensions/nv/GLSL_NV_shader_invocation_reorder.txt)
+path remains available when the NV capability or extension is requested explicitly;
+NV-named GLSL entry points such as `hitObjectIsHitNV` continue to require that NV
+path.
 
 <a id="debug-break"></a>
 

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -1168,6 +1168,9 @@ Compound Capabilities
 `cuda_glsl_metal_spirv_wgsl_llvm`
 > CUDA, GLSL, Metal, SPIRV, WGSL and LLVM code-gen targets
 
+`cuda_glsl_nvapi`
+> CUDA, GLSL, and NVAPI code-gen targets
+
 `cuda_glsl_spirv`
 > CUDA, GLSL, and SPIRV code-gen targets
 

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -1370,7 +1370,8 @@ Compound Capabilities
 
 `ser`
 > Capabilities needed for shader-execution-reordering (all paths)
-> Includes NVIDIA-specific (NV), cross-vendor standard (EXT), DXR 1.3 native, and CUDA paths
+> Defaults SPIR-V/GLSL to the cross-vendor standard EXT path; explicit NV still satisfies this
+> through the NV-to-EXT capability hierarchy. Use ser_nv for APIs that require NV opcodes.
 
 `ser_any_closesthit_intersection_miss`
 > Collection of capabilities for raytracing + shader execution reordering and the shader stages of anyhit, closesthit, intersection, and miss.

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -5860,7 +5860,7 @@ public void hitObjectRecordHitMotionNV(
     {
     case _GL_NV_shader_invocation_reorder_motion:
     {
-        HitObject::__glslMakeMotionHit(
+        HitObject::__glslMakeMotionHitNV(
             hitObject,
             topLevel,
             instanceid,
@@ -5990,7 +5990,7 @@ public void hitObjectRecordHitWithIndexMotionNV(
     {
     case _GL_NV_shader_invocation_reorder_motion:
     {
-        HitObject::__glslMakeMotionHitWithIndex(
+        HitObject::__glslMakeMotionHitWithIndexNV(
             hitObject,
             topLevel,
             instanceid,

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -5676,7 +5676,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public void hitObjectTraceRayNV(
     inout hitObjectNV hitObject,
     accelerationStructureEXT topLevel,
@@ -5708,7 +5708,7 @@ __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 __glsl_extension(GL_NV_ray_tracing_motion_blur)
 [ForceInline]
-[require(glsl_spirv, ser_motion_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_motion_raygen_closesthit_miss)]
 public void hitObjectTraceRayMotionNV(
     inout hitObjectNV hitObject,
     accelerationStructureEXT topLevel,
@@ -5774,7 +5774,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public void hitObjectRecordHitNV(
     inout hitObjectNV hitObject,
     accelerationStructureEXT topLevel,
@@ -5839,7 +5839,7 @@ __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 __glsl_extension(GL_NV_ray_tracing_motion_blur)
 [ForceInline]
-[require(glsl_spirv, ser_motion_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_motion_raygen_closesthit_miss)]
 public void hitObjectRecordHitMotionNV(
     inout hitObjectNV hitObject,
     accelerationStructureEXT topLevel,
@@ -5908,7 +5908,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public void hitObjectRecordHitWithIndexNV(
     inout hitObjectNV hitObject,
     accelerationStructureEXT topLevel,
@@ -5970,7 +5970,7 @@ __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 __glsl_extension(GL_NV_ray_tracing_motion_blur)
 [ForceInline]
-[require(glsl_spirv, ser_motion_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_motion_raygen_closesthit_miss)]
 public void hitObjectRecordHitWithIndexMotionNV(
     inout hitObjectNV hitObject,
     accelerationStructureEXT topLevel,
@@ -6036,7 +6036,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public void hitObjectRecordMissNV(
     inout hitObjectNV hitObject,
     uint sbtRecordIndex,
@@ -6056,7 +6056,7 @@ __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 __glsl_extension(GL_NV_ray_tracing_motion_blur)
 [ForceInline]
-[require(glsl_spirv, ser_motion_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_motion_raygen_closesthit_miss)]
 public void hitObjectRecordMissMotionNV(
     inout hitObjectNV hitObject,
     uint sbtRecordIndex,
@@ -6077,7 +6077,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public void hitObjectRecordEmptyNV(hitObjectNV hitObject)
 {
     hitObject = HitObject::MakeNop();
@@ -6087,7 +6087,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public void hitObjectExecuteShaderNV(
     inout hitObjectNV hitObject,
     constexpr int payload)
@@ -6114,7 +6114,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public bool hitObjectIsEmptyNV(hitObjectNV hitObject)
 {
     return hitObject.IsNop();
@@ -6124,7 +6124,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public bool hitObjectIsMissNV(hitObjectNV hitObject)
 {
     return hitObject.IsMiss();
@@ -6134,7 +6134,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public bool hitObjectIsHitNV(hitObjectNV hitObject)
 {
     return hitObject.IsHit();
@@ -6144,7 +6144,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public float hitObjectGetRayTMinNV(hitObjectNV hitObject)
 {
     return hitObject.GetRayDesc().TMin;
@@ -6154,7 +6154,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public float hitObjectGetRayTMaxNV(hitObjectNV hitObject)
 {
     return hitObject.GetRayDesc().TMax;
@@ -6164,7 +6164,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public vec3 hitObjectGetWorldRayOriginNV(hitObjectNV hitObject)
 {
     return hitObject.GetRayDesc().Origin;
@@ -6174,7 +6174,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public vec3 hitObjectGetWorldRayDirectionNV(hitObjectNV hitObject)
 {
     return hitObject.GetRayDesc().Direction;
@@ -6184,7 +6184,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public vec3 hitObjectGetObjectRayOriginNV(hitObjectNV hitObject)
 {
     return hitObject.GetObjectRayOrigin();
@@ -6194,7 +6194,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public vec3 hitObjectGetObjectRayDirectionNV(hitObjectNV hitObject)
 {
     return hitObject.GetObjectRayDirection();
@@ -6204,7 +6204,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public mat4x3 hitObjectGetObjectToWorldNV(hitObjectNV hitObject)
 {
     return hitObject.GetObjectToWorld();
@@ -6214,7 +6214,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public mat4x3 hitObjectGetWorldToObjectNV(hitObjectNV hitObject)
 {
     return hitObject.GetWorldToObject();
@@ -6224,7 +6224,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public int hitObjectGetInstanceCustomIndexNV(hitObjectNV hitObject)
 {
     return hitObject.GetInstanceID();
@@ -6234,7 +6234,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public int hitObjectGetInstanceIdNV(hitObjectNV hitObject)
 {
     return hitObject.GetInstanceIndex();
@@ -6244,7 +6244,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public int hitObjectGetGeometryIndexNV(hitObjectNV hitObject)
 {
     return hitObject.GetGeometryIndex();
@@ -6254,7 +6254,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public int hitObjectGetPrimitiveIndexNV(hitObjectNV hitObject)
 {
     return hitObject.GetPrimitiveIndex();
@@ -6264,7 +6264,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public uint hitObjectGetHitKindNV(hitObjectNV hitObject)
 {
     return hitObject.GetHitKind();
@@ -6274,7 +6274,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public void hitObjectGetAttributesNV(
     inout hitObjectNV hitObject,
     constexpr int attributeLocation)
@@ -6300,7 +6300,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public uvec2 hitObjectGetShaderRecordBufferHandleNV(hitObjectNV hitObject)
 {
     return hitObject.GetShaderRecordBufferHandle();
@@ -6310,7 +6310,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public uint hitObjectGetShaderBindingTableRecordIndexNV(hitObjectNV hitObject)
 {
     return hitObject.GetShaderTableIndex();
@@ -6320,7 +6320,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen_closesthit_miss)]
+[require(glsl_spirv, ser_nv_raygen_closesthit_miss)]
 public float hitObjectGetCurrentTimeNV(hitObjectNV hitObject)
 {
     return hitObject.GetCurrentTime();
@@ -6330,7 +6330,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen)]
+[require(glsl_spirv, ser_nv_raygen)]
 public void reorderThreadNV(uint hint, uint bits)
 {
     ReorderThread(hint, bits);
@@ -6340,7 +6340,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen)]
+[require(glsl_spirv, ser_nv_raygen)]
 public void reorderThreadNV(hitObjectNV hitObject)
 {
     ReorderThread(hitObject);
@@ -6350,7 +6350,7 @@ __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_shader_invocation_reorder)
 __glsl_extension(GLSL_EXT_buffer_reference_uvec2)
 [ForceInline]
-[require(glsl_spirv, ser_raygen)]
+[require(glsl_spirv, ser_nv_raygen)]
 public void reorderThreadNV(hitObjectNV hitObject, uint hint, uint bits)
 {
     ReorderThread(hitObject, hint, bits);

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -24780,12 +24780,38 @@ struct HitObject
         }
     }
 
-    //  "void hitObjectRecordHitWithIndexMotionNV(hitObjectNV, accelerationStructureEXT,int,int,int,uint,uint,vec3,float,vec3,float,float,int);"
+    // Unsuffixed helper retained for existing HitObject::MakeMotionHit call sites.
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
     __glsl_extension(GL_NV_shader_invocation_reorder)
     [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
     static void __glslMakeMotionHitWithIndex(
+        out HitObject hitObj,
+        RaytracingAccelerationStructure accelerationStructure,
+        int instanceid,
+        int primitiveid,
+        int geometryindex,
+        uint hitKind,
+        uint sbtRecordIndex,
+        float3 origin,
+        float Tmin,
+        float3 direction,
+        float Tmax,
+        float CurrentTime,
+        int attributeLocation)
+    {
+        __target_switch
+        {
+        case _GL_NV_shader_invocation_reorder: __intrinsic_asm "hitObjectRecordHitWithIndexMotionNV";
+        }
+    }
+
+    // NV-specific helper used by public hitObjectRecordHitWithIndexMotionNV.
+    __glsl_extension(GL_EXT_ray_tracing)
+    __glsl_extension(GL_NV_ray_tracing_motion_blur)
+    __glsl_extension(GL_NV_shader_invocation_reorder)
+    [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
+    static void __glslMakeMotionHitWithIndexNV(
         out HitObject hitObj,
         RaytracingAccelerationStructure accelerationStructure,
         int instanceid,
@@ -24832,12 +24858,39 @@ struct HitObject
         }
     }
 
-        // "void hitObjectRecordHitMotionNV(hitObjectNV,accelerationStructureEXT,int,int,int,uint,uint,uint,vec3,float,vec3,float,float,int);"
+    // Unsuffixed helper retained for existing HitObject::MakeMotionHit call sites.
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
     __glsl_extension(GL_NV_shader_invocation_reorder)
     [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
     static void __glslMakeMotionHit(
+        out HitObject hitObj,
+        RaytracingAccelerationStructure accelerationStructure,
+        int instanceid,
+        int primitiveid,
+        int geometryindex,
+        uint hitKind,
+        uint sbtRecordOffset,
+        uint sbtRecordStride,
+        float3 origin,
+        float Tmin,
+        float3 direction,
+        float Tmax,
+        float CurrentTime,
+        int attributeLocation)
+    {
+        __target_switch
+        {
+        case _GL_NV_shader_invocation_reorder: __intrinsic_asm "hitObjectRecordHitMotionNV";
+        }
+    }
+
+    // NV-specific helper used by public hitObjectRecordHitMotionNV.
+    __glsl_extension(GL_EXT_ray_tracing)
+    __glsl_extension(GL_NV_ray_tracing_motion_blur)
+    __glsl_extension(GL_NV_shader_invocation_reorder)
+    [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
+    static void __glslMakeMotionHitNV(
         out HitObject hitObj,
         RaytracingAccelerationStructure accelerationStructure,
         int instanceid,

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -24565,7 +24565,7 @@ struct HitObject
     // "void hitObjectRecordMissMotionNV(hitObjectNV, uint, vec3, float, vec3, float, float);"
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
-    [require(glsl, ser_motion_raygen_closesthit_miss)]
+    [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
     static void __glslMakeMissMotionNV(
         out HitObject hitObj,
         uint MissShaderIndex,
@@ -24784,7 +24784,7 @@ struct HitObject
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
     __glsl_extension(GL_NV_shader_invocation_reorder)
-    [require(glsl, ser_motion_raygen_closesthit_miss)]
+    [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
     static void __glslMakeMotionHitWithIndex(
         out HitObject hitObj,
         RaytracingAccelerationStructure accelerationStructure,
@@ -24836,7 +24836,7 @@ struct HitObject
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
     __glsl_extension(GL_NV_shader_invocation_reorder)
-    [require(glsl, ser_motion_raygen_closesthit_miss)]
+    [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
     static void __glslMakeMotionHit(
         out HitObject hitObj,
         RaytracingAccelerationStructure accelerationStructure,

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -23769,7 +23769,8 @@ struct HitObject
     __glsl_extension(GL_NV_cluster_acceleration_structure)
     __glsl_extension(GL_EXT_ray_tracing)
     [ForceInline]
-    [require(cuda_glsl_spirv, ser_raygen_closesthit_miss)]
+    [require(cuda, ser_raygen_closesthit_miss)]
+    [require(glsl, ser_raygen_closesthit_miss)]
     [require(nvapi, ser_raygen_closesthit_miss)]
     [require(spirv, spvShaderInvocationReorderNV)]
     int GetClusterID()
@@ -23788,18 +23789,12 @@ struct HitObject
                 OpCapability RayTracingClusterAccelerationStructureNV;
                 result:$$int = OpHitObjectGetClusterIdNV &this;
             };
-        case spvShaderInvocationReorderEXT:
-        case spirv:
-            static_assert(
-                false,
-                "HitObject.GetClusterID() requires -capability spvShaderInvocationReorderNV for SPIR-V.");
-            return 0;
         }
     }
 
     [__requiresNVAPI]
     [NonUniformReturn]
-    [require(cuda_hlsl_spirv, raytracing_lss_ho)]
+    [require(cuda_hlsl, raytracing_lss_ho)]
     [require(spirv, spvShaderInvocationReorderNV)]
     float4 GetSpherePositionAndRadius()
     {
@@ -23822,18 +23817,12 @@ struct HitObject
                 %radius:$$float = OpHitObjectGetSphereRadiusNV &this;
                 result:$$float4 = OpCompositeConstruct %position %radius;
             };
-        case spvShaderInvocationReorderEXT:
-        case spirv:
-            static_assert(
-                false,
-                "HitObject.GetSpherePositionAndRadius() requires -capability spvShaderInvocationReorderNV for SPIR-V.");
-            return float4(0.0);
         }
     }
 
     [__requiresNVAPI]
     [NonUniformReturn]
-    [require(cuda_hlsl_spirv, raytracing_lss_ho)]
+    [require(cuda_hlsl, raytracing_lss_ho)]
     [require(spirv, spvShaderInvocationReorderNV)]
     float2x4 GetLssPositionsAndRadii()
     {
@@ -23862,18 +23851,12 @@ struct HitObject
                 %b:$$float4 = OpCompositeConstruct %p1 %r1;
                 result:$$float2x4 = OpCompositeConstruct %a %b;
             };
-        case spvShaderInvocationReorderEXT:
-        case spirv:
-            static_assert(
-                false,
-                "HitObject.GetLssPositionsAndRadii() requires -capability spvShaderInvocationReorderNV for SPIR-V.");
-            return float2x4(0.0);
         }
     }
 
     [__requiresNVAPI]
     [NonUniformReturn]
-    [require(cuda_hlsl_spirv, raytracing_lss_ho)]
+    [require(cuda_hlsl, raytracing_lss_ho)]
     [require(spirv, spvShaderInvocationReorderNV)]
     bool IsSphereHit()
     {
@@ -23893,18 +23876,12 @@ struct HitObject
                 OpCapability RayTracingLinearSweptSpheresGeometryNV;
                 result:$$bool = OpHitObjectIsSphereHitNV &this;
             };
-        case spvShaderInvocationReorderEXT:
-        case spirv:
-            static_assert(
-                false,
-                "HitObject.IsSphereHit() requires -capability spvShaderInvocationReorderNV for SPIR-V.");
-            return false;
         }
     }
 
     [__requiresNVAPI]
     [NonUniformReturn]
-    [require(cuda_hlsl_spirv, raytracing_lss_ho)]
+    [require(cuda_hlsl, raytracing_lss_ho)]
     [require(spirv, spvShaderInvocationReorderNV)]
     bool IsLssHit()
     {
@@ -23924,12 +23901,6 @@ struct HitObject
                 OpCapability RayTracingLinearSweptSpheresGeometryNV;
                 result:$$bool = OpHitObjectIsLSSHitNV &this;
             };
-        case spvShaderInvocationReorderEXT:
-        case spirv:
-            static_assert(
-                false,
-                "HitObject.IsLssHit() requires -capability spvShaderInvocationReorderNV for SPIR-V.");
-            return false;
         }
     }
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -23769,9 +23769,7 @@ struct HitObject
     __glsl_extension(GL_NV_cluster_acceleration_structure)
     __glsl_extension(GL_EXT_ray_tracing)
     [ForceInline]
-    [require(cuda, ser_raygen_closesthit_miss)]
-    [require(glsl, ser_raygen_closesthit_miss)]
-    [require(nvapi, ser_raygen_closesthit_miss)]
+    [require(cuda_glsl_nvapi, ser_raygen_closesthit_miss)]
     [require(spirv, spvShaderInvocationReorderNV)]
     int GetClusterID()
     {

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -22896,7 +22896,7 @@ struct HitObject
             // Save the attributes
             __hitObjectAttributes<attr_t>() = attributes;
 
-            __glslMakeMotionHit(
+            __glslMakeMotionHitNV(
                 __return_val,
                 AccelerationStructure,
                 InstanceIndex,
@@ -23058,7 +23058,7 @@ struct HitObject
             // Save the attributes
             __hitObjectAttributes<attr_t>() = attributes;
 
-            __glslMakeMotionHitWithIndex(
+            __glslMakeMotionHitWithIndexNV(
                 __return_val,
                 AccelerationStructure,
                 InstanceIndex,              ///? Same as instanceid ?
@@ -24780,32 +24780,6 @@ struct HitObject
         }
     }
 
-    // Unsuffixed helper retained for existing HitObject::MakeMotionHit call sites.
-    __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_NV_ray_tracing_motion_blur)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
-    [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
-    static void __glslMakeMotionHitWithIndex(
-        out HitObject hitObj,
-        RaytracingAccelerationStructure accelerationStructure,
-        int instanceid,
-        int primitiveid,
-        int geometryindex,
-        uint hitKind,
-        uint sbtRecordIndex,
-        float3 origin,
-        float Tmin,
-        float3 direction,
-        float Tmax,
-        float CurrentTime,
-        int attributeLocation)
-    {
-        __target_switch
-        {
-        case _GL_NV_shader_invocation_reorder: __intrinsic_asm "hitObjectRecordHitWithIndexMotionNV";
-        }
-    }
-
     // NV-specific helper used by public hitObjectRecordHitWithIndexMotionNV.
     __glsl_extension(GL_EXT_ray_tracing)
     __glsl_extension(GL_NV_ray_tracing_motion_blur)
@@ -24855,33 +24829,6 @@ struct HitObject
         {
         case glsl: // fallback - outer MakeHit routes glsl to EXT variant
         case _GL_NV_shader_invocation_reorder: __intrinsic_asm "hitObjectRecordHitNV";
-        }
-    }
-
-    // Unsuffixed helper retained for existing HitObject::MakeMotionHit call sites.
-    __glsl_extension(GL_EXT_ray_tracing)
-    __glsl_extension(GL_NV_ray_tracing_motion_blur)
-    __glsl_extension(GL_NV_shader_invocation_reorder)
-    [require(glsl, ser_nv_motion_raygen_closesthit_miss)]
-    static void __glslMakeMotionHit(
-        out HitObject hitObj,
-        RaytracingAccelerationStructure accelerationStructure,
-        int instanceid,
-        int primitiveid,
-        int geometryindex,
-        uint hitKind,
-        uint sbtRecordOffset,
-        uint sbtRecordStride,
-        float3 origin,
-        float Tmin,
-        float3 direction,
-        float Tmax,
-        float CurrentTime,
-        int attributeLocation)
-    {
-        __target_switch
-        {
-        case _GL_NV_shader_invocation_reorder: __intrinsic_asm "hitObjectRecordHitMotionNV";
         }
     }
 

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -23771,6 +23771,7 @@ struct HitObject
     [ForceInline]
     [require(cuda_glsl_spirv, ser_raygen_closesthit_miss)]
     [require(nvapi, ser_raygen_closesthit_miss)]
+    [require(spirv, spvShaderInvocationReorderNV)]
     int GetClusterID()
     {
         __target_switch
@@ -23778,19 +23779,28 @@ struct HitObject
         case hlsl_nvapi: __intrinsic_asm ".GetClusterID";
         case glsl: __intrinsic_asm "hitObjectGetClusterIdNV($0)";
         case cuda: __intrinsic_asm "slangOptixHitObjectGetClusterId";
-        case spirv:
+        case spvShaderInvocationReorderNV:
             return spirv_asm
             {
+                OpExtension "SPV_NV_shader_invocation_reorder";
                 OpExtension "SPV_NV_cluster_acceleration_structure";
+                OpCapability ShaderInvocationReorderNV;
                 OpCapability RayTracingClusterAccelerationStructureNV;
                 result:$$int = OpHitObjectGetClusterIdNV &this;
             };
+        case spvShaderInvocationReorderEXT:
+        case spirv:
+            static_assert(
+                false,
+                "HitObject.GetClusterID() requires -capability spvShaderInvocationReorderNV for SPIR-V.");
+            return 0;
         }
     }
 
     [__requiresNVAPI]
     [NonUniformReturn]
     [require(cuda_hlsl_spirv, raytracing_lss_ho)]
+    [require(spirv, spvShaderInvocationReorderNV)]
     float4 GetSpherePositionAndRadius()
     {
         __target_switch
@@ -23800,22 +23810,31 @@ struct HitObject
             {
                 __intrinsic_asm "optixHitObjectGetSpherePositionAndRadius";
             }
-        case spirv:
+        case spvShaderInvocationReorderNV:
             return spirv_asm
             {
+                OpExtension "SPV_NV_shader_invocation_reorder";
                 OpExtension "SPV_NV_linear_swept_spheres";
+                OpCapability ShaderInvocationReorderNV;
                 OpCapability RayTracingLinearSweptSpheresGeometryNV;
                 OpCapability RayTracingSpheresGeometryNV;
                 %position:$$float3 = OpHitObjectGetSpherePositionNV &this;
                 %radius:$$float = OpHitObjectGetSphereRadiusNV &this;
                 result:$$float4 = OpCompositeConstruct %position %radius;
             };
+        case spvShaderInvocationReorderEXT:
+        case spirv:
+            static_assert(
+                false,
+                "HitObject.GetSpherePositionAndRadius() requires -capability spvShaderInvocationReorderNV for SPIR-V.");
+            return float4(0.0);
         }
     }
 
     [__requiresNVAPI]
     [NonUniformReturn]
     [require(cuda_hlsl_spirv, raytracing_lss_ho)]
+    [require(spirv, spvShaderInvocationReorderNV)]
     float2x4 GetLssPositionsAndRadii()
     {
         __target_switch
@@ -23825,10 +23844,12 @@ struct HitObject
             {
                 __intrinsic_asm "optixHitObjectGetLssPositionsAndRadii";
             }
-        case spirv:
+        case spvShaderInvocationReorderNV:
             return spirv_asm
             {
+                OpExtension "SPV_NV_shader_invocation_reorder";
                 OpExtension "SPV_NV_linear_swept_spheres";
+                OpCapability ShaderInvocationReorderNV;
                 OpCapability RayTracingLinearSweptSpheresGeometryNV;
                 OpCapability RayTracingSpheresGeometryNV;
                 %positions:$$float3[2] = OpHitObjectGetLSSPositionsNV &this;
@@ -23841,12 +23862,19 @@ struct HitObject
                 %b:$$float4 = OpCompositeConstruct %p1 %r1;
                 result:$$float2x4 = OpCompositeConstruct %a %b;
             };
+        case spvShaderInvocationReorderEXT:
+        case spirv:
+            static_assert(
+                false,
+                "HitObject.GetLssPositionsAndRadii() requires -capability spvShaderInvocationReorderNV for SPIR-V.");
+            return float2x4(0.0);
         }
     }
 
     [__requiresNVAPI]
     [NonUniformReturn]
     [require(cuda_hlsl_spirv, raytracing_lss_ho)]
+    [require(spirv, spvShaderInvocationReorderNV)]
     bool IsSphereHit()
     {
         __target_switch
@@ -23856,19 +23884,28 @@ struct HitObject
             {
                 __intrinsic_asm "optixHitObjectIsSphereHit";
             }
-        case spirv:
+        case spvShaderInvocationReorderNV:
             return spirv_asm
             {
+                OpExtension "SPV_NV_shader_invocation_reorder";
                 OpExtension "SPV_NV_linear_swept_spheres";
+                OpCapability ShaderInvocationReorderNV;
                 OpCapability RayTracingLinearSweptSpheresGeometryNV;
                 result:$$bool = OpHitObjectIsSphereHitNV &this;
             };
+        case spvShaderInvocationReorderEXT:
+        case spirv:
+            static_assert(
+                false,
+                "HitObject.IsSphereHit() requires -capability spvShaderInvocationReorderNV for SPIR-V.");
+            return false;
         }
     }
 
     [__requiresNVAPI]
     [NonUniformReturn]
     [require(cuda_hlsl_spirv, raytracing_lss_ho)]
+    [require(spirv, spvShaderInvocationReorderNV)]
     bool IsLssHit()
     {
         __target_switch
@@ -23878,13 +23915,21 @@ struct HitObject
             {
                 __intrinsic_asm "optixHitObjectIsLSSHit";
             }
-        case spirv:
+        case spvShaderInvocationReorderNV:
             return spirv_asm
             {
+                OpExtension "SPV_NV_shader_invocation_reorder";
                 OpExtension "SPV_NV_linear_swept_spheres";
+                OpCapability ShaderInvocationReorderNV;
                 OpCapability RayTracingLinearSweptSpheresGeometryNV;
                 result:$$bool = OpHitObjectIsLSSHitNV &this;
             };
+        case spvShaderInvocationReorderEXT:
+        case spirv:
+            static_assert(
+                false,
+                "HitObject.IsLssHit() requires -capability spvShaderInvocationReorderNV for SPIR-V.");
+            return false;
         }
     }
 

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -391,6 +391,10 @@ alias cpp_hlsl = cpp | hlsl;
 /// [Compound]
 alias cuda_glsl_hlsl = cuda | glsl | hlsl;
 
+/// CUDA, GLSL, and NVAPI code-gen targets
+/// [Compound]
+alias cuda_glsl_nvapi = cuda | glsl | hlsl_nvapi;
+
 /// CUDA, HLSL, Metal, and SPIRV code-gen targets
 /// [Compound]
 alias cuda_hlsl_metal_spirv = cuda | hlsl | metal | spirv;

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -1319,9 +1319,10 @@ def ser_hlsl_native : _sm_6_9;
 alias ser_dxr = raytracing + ser_hlsl_native;
 
 /// Capabilities needed for shader-execution-reordering (all paths)
-/// Includes NVIDIA-specific (NV), cross-vendor standard (EXT), DXR 1.3 native, and CUDA paths
+/// Defaults SPIR-V/GLSL to the cross-vendor standard EXT path; explicit NV still satisfies this
+/// through the NV-to-EXT capability hierarchy. Use ser_nv for APIs that require NV opcodes.
 /// [Compound]
-alias ser = raytracing + GL_NV_shader_invocation_reorder | raytracing + GL_EXT_shader_invocation_reorder | ser_nvapi | ser_dxr | cuda;
+alias ser = raytracing + GL_EXT_shader_invocation_reorder | ser_nvapi | ser_dxr | cuda;
 
 /// NVIDIA-specific SER capabilities (excludes cross-vendor EXT)
 /// Includes GL_NV_shader_invocation_reorder (GLSL/SPIRV) and CUDA paths

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1620,7 +1620,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     return SpvStorageClassHitObjectAttributeNV;
                 if (targetCaps.implies(CapabilityAtom::spvShaderInvocationReorderEXT))
                     return SpvStorageClassHitObjectAttributeEXT;
-                return SpvStorageClassHitObjectAttributeNV;
+                return SpvStorageClassHitObjectAttributeEXT;
             }
         case AddressSpace::HitAttribute:
             return SpvStorageClassHitAttributeKHR;
@@ -2734,9 +2734,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         case kIROp_HitObjectType:
             {
                 // Check NV first (more specific) since NV derives from EXT in the
-                // capability hierarchy. If we checked EXT first, it would always
-                // match when NV is specified, causing a type/op mismatch
-                // (OpTypeHitObjectEXT=5313 vs OpTypeHitObjectNV=5281).
+                // capability hierarchy. If no SER capability was explicitly requested,
+                // default to EXT to match capability inference and target-switch fallback.
                 auto targetCaps = m_targetProgram->getTargetReq()->getTargetCaps();
                 if (targetCaps.implies(CapabilityAtom::spvShaderInvocationReorderNV))
                 {
@@ -2755,9 +2754,9 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 else
                 {
                     ensureExtensionDeclaration(
-                        UnownedStringSlice("SPV_NV_shader_invocation_reorder"));
-                    requireSPIRVCapability(SpvCapabilityShaderInvocationReorderNV);
-                    return emitOpTypeHitObject(inst);
+                        UnownedStringSlice("SPV_EXT_shader_invocation_reorder"));
+                    requireSPIRVCapability(SpvCapabilityShaderInvocationReorderEXT);
+                    return emitOpTypeHitObjectEXT(inst);
                 }
             }
 
@@ -6383,8 +6382,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 else
                 {
                     ensureExtensionDeclaration(
-                        UnownedStringSlice("SPV_NV_shader_invocation_reorder"));
-                    requireSPIRVCapability(SpvCapabilityShaderInvocationReorderNV);
+                        UnownedStringSlice("SPV_EXT_shader_invocation_reorder"));
+                    requireSPIRVCapability(SpvCapabilityShaderInvocationReorderEXT);
                 }
                 isRayTracingObject = true;
                 break;

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1618,8 +1618,6 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 auto targetCaps = m_targetProgram->getTargetReq()->getTargetCaps();
                 if (targetCaps.implies(CapabilityAtom::spvShaderInvocationReorderNV))
                     return SpvStorageClassHitObjectAttributeNV;
-                if (targetCaps.implies(CapabilityAtom::spvShaderInvocationReorderEXT))
-                    return SpvStorageClassHitObjectAttributeEXT;
                 return SpvStorageClassHitObjectAttributeEXT;
             }
         case AddressSpace::HitAttribute:

--- a/tests/bugs/gh-11082.slang
+++ b/tests/bugs/gh-11082.slang
@@ -12,8 +12,12 @@
 // IMPLICIT: OpExtension "SPV_EXT_shader_invocation_reorder"
 // IMPLICIT-NOT: OpTypeHitObjectNV
 // IMPLICIT: OpTypeHitObjectEXT
+// IMPLICIT-NOT: HitObjectAttributeNV
+// IMPLICIT: HitObjectAttributeEXT
 // IMPLICIT-NOT: OpHitObjectTraceRayNV
 // IMPLICIT: OpHitObjectTraceRayEXT
+// IMPLICIT-NOT: OpHitObjectGetAttributesNV
+// IMPLICIT: OpHitObjectGetAttributesEXT
 
 // EXT_RESTRICTIVE-NOT: error[E41013]
 // EXT_RESTRICTIVE-NOT: warning[E41012]
@@ -23,8 +27,12 @@
 // EXT_RESTRICTIVE: OpExtension "SPV_EXT_shader_invocation_reorder"
 // EXT_RESTRICTIVE-NOT: OpTypeHitObjectNV
 // EXT_RESTRICTIVE: OpTypeHitObjectEXT
+// EXT_RESTRICTIVE-NOT: HitObjectAttributeNV
+// EXT_RESTRICTIVE: HitObjectAttributeEXT
 // EXT_RESTRICTIVE-NOT: OpHitObjectTraceRayNV
 // EXT_RESTRICTIVE: OpHitObjectTraceRayEXT
+// EXT_RESTRICTIVE-NOT: OpHitObjectGetAttributesNV
+// EXT_RESTRICTIVE: OpHitObjectGetAttributesEXT
 
 RaytracingAccelerationStructure tlas;
 RWTexture2D<float> outImage;
@@ -32,6 +40,11 @@ RWTexture2D<float> outImage;
 struct Payload
 {
     uint foo;
+};
+
+struct Attributes
+{
+    float2 barycentrics;
 };
 
 [shader("raygeneration")]
@@ -47,6 +60,7 @@ void main()
     HitObject hitObj = HitObject::TraceRay(tlas, 0, 0xFF, 0, 0, 0, ray, payload);
     if (hitObj.IsHit())
     {
-        outImage[DispatchRaysIndex().xy] = 1.0f;
+        Attributes attributes = hitObj.GetAttributes<Attributes>();
+        outImage[DispatchRaysIndex().xy] = 1.0f + attributes.barycentrics.x;
     }
 }

--- a/tests/bugs/gh-11082.slang
+++ b/tests/bugs/gh-11082.slang
@@ -1,7 +1,7 @@
 // Test for issue #11082: implicit SER capability upgrades should consistently use EXT.
 
-//TEST:SIMPLE(filecheck=IMPLICIT): -target spirv-asm -emit-spirv-directly -profile spirv_1_6 -entry main -stage raygeneration -line-directive-mode none
-//TEST:SIMPLE(filecheck=EXT_RESTRICTIVE): -target spirv-asm -emit-spirv-directly -profile spirv_1_6 -capability spvShaderInvocationReorderEXT -restrictive-capability-check -entry main -stage raygeneration -line-directive-mode none
+//TEST:SIMPLE(filecheck=IMPLICIT): -target spirv-asm -emit-spirv-directly -profile spirv_1_6 -entry main -stage raygeneration
+//TEST:SIMPLE(filecheck=EXT_RESTRICTIVE): -target spirv-asm -emit-spirv-directly -profile spirv_1_6 -capability spvShaderInvocationReorderEXT -restrictive-capability-check -entry main -stage raygeneration
 
 // IMPLICIT: warning[E41012]
 // IMPLICIT: spvShaderInvocationReorderEXT

--- a/tests/bugs/gh-11082.slang
+++ b/tests/bugs/gh-11082.slang
@@ -1,0 +1,60 @@
+// Test for issue #11082: implicit SER capability upgrades should consistently use EXT.
+
+//TEST:SIMPLE(filecheck=IMPLICIT): -target spirv-asm -emit-spirv-directly -profile spirv_1_6 -entry main -stage raygeneration -line-directive-mode none
+//TEST:SIMPLE(filecheck=EXT_RESTRICTIVE): -target spirv-asm -emit-spirv-directly -profile spirv_1_6 -capability spvShaderInvocationReorderEXT -restrictive-capability-check -entry main -stage raygeneration -line-directive-mode none
+
+// IMPLICIT: warning[E41012]
+// IMPLICIT: spvShaderInvocationReorderEXT
+// IMPLICIT-NOT: spvShaderInvocationReorderNV
+// IMPLICIT-NOT: ShaderInvocationReorderNV
+// IMPLICIT-NOT: SPV_NV_shader_invocation_reorder
+// IMPLICIT: OpCapability ShaderInvocationReorderEXT
+// IMPLICIT: OpExtension "SPV_EXT_shader_invocation_reorder"
+// IMPLICIT-NOT: OpTypeHitObjectNV
+// IMPLICIT: OpTypeHitObjectEXT
+// IMPLICIT-NOT: OpHitObjectTraceRayNV
+// IMPLICIT: OpHitObjectTraceRayEXT
+// IMPLICIT-NOT: ShaderInvocationReorderNV
+// IMPLICIT-NOT: SPV_NV_shader_invocation_reorder
+// IMPLICIT-NOT: OpTypeHitObjectNV
+// IMPLICIT-NOT: OpHitObjectTraceRayNV
+
+// EXT_RESTRICTIVE-NOT: error[E41013]
+// EXT_RESTRICTIVE-NOT: warning[E41012]
+// EXT_RESTRICTIVE-NOT: ShaderInvocationReorderNV
+// EXT_RESTRICTIVE-NOT: SPV_NV_shader_invocation_reorder
+// EXT_RESTRICTIVE: OpCapability ShaderInvocationReorderEXT
+// EXT_RESTRICTIVE: OpExtension "SPV_EXT_shader_invocation_reorder"
+// EXT_RESTRICTIVE-NOT: OpTypeHitObjectNV
+// EXT_RESTRICTIVE: OpTypeHitObjectEXT
+// EXT_RESTRICTIVE-NOT: OpHitObjectTraceRayNV
+// EXT_RESTRICTIVE: OpHitObjectTraceRayEXT
+// EXT_RESTRICTIVE-NOT: ShaderInvocationReorderNV
+// EXT_RESTRICTIVE-NOT: SPV_NV_shader_invocation_reorder
+// EXT_RESTRICTIVE-NOT: OpTypeHitObjectNV
+// EXT_RESTRICTIVE-NOT: OpHitObjectTraceRayNV
+
+RaytracingAccelerationStructure tlas;
+RWTexture2D<float> outImage;
+
+struct Payload
+{
+    uint foo;
+};
+
+[shader("raygeneration")]
+void main()
+{
+    RayDesc ray;
+    ray.Origin = float3(0.0);
+    ray.Direction = float3(1.0);
+    ray.TMin = 0.0;
+    ray.TMax = 1e30;
+
+    Payload payload;
+    HitObject hitObj = HitObject::TraceRay(tlas, 0, 0xFF, 0, 0, 0, ray, payload);
+    if (hitObj.IsHit())
+    {
+        outImage[DispatchRaysIndex().xy] = 1.0f;
+    }
+}

--- a/tests/bugs/gh-11082.slang
+++ b/tests/bugs/gh-11082.slang
@@ -14,10 +14,6 @@
 // IMPLICIT: OpTypeHitObjectEXT
 // IMPLICIT-NOT: OpHitObjectTraceRayNV
 // IMPLICIT: OpHitObjectTraceRayEXT
-// IMPLICIT-NOT: ShaderInvocationReorderNV
-// IMPLICIT-NOT: SPV_NV_shader_invocation_reorder
-// IMPLICIT-NOT: OpTypeHitObjectNV
-// IMPLICIT-NOT: OpHitObjectTraceRayNV
 
 // EXT_RESTRICTIVE-NOT: error[E41013]
 // EXT_RESTRICTIVE-NOT: warning[E41012]
@@ -29,10 +25,6 @@
 // EXT_RESTRICTIVE: OpTypeHitObjectEXT
 // EXT_RESTRICTIVE-NOT: OpHitObjectTraceRayNV
 // EXT_RESTRICTIVE: OpHitObjectTraceRayEXT
-// EXT_RESTRICTIVE-NOT: ShaderInvocationReorderNV
-// EXT_RESTRICTIVE-NOT: SPV_NV_shader_invocation_reorder
-// EXT_RESTRICTIVE-NOT: OpTypeHitObjectNV
-// EXT_RESTRICTIVE-NOT: OpHitObjectTraceRayNV
 
 RaytracingAccelerationStructure tlas;
 RWTexture2D<float> outImage;

--- a/tests/glsl-intrinsic/raytracing/glsl-rayMiss.slang
+++ b/tests/glsl-intrinsic/raytracing/glsl-rayMiss.slang
@@ -13,7 +13,7 @@ buffer MyBlockName
 // CHECK_SPV-DAG: IncomingRayPayload{{NV|KHR}}
 layout(location = 2) rayPayloadInEXT vec4 payload;
 // CHECK_GLSL-DAG: hitObjectAttributeEXT
-// CHECK_SPV-DAG: HitObjectAttributeNV
+// CHECK_SPV-DAG: HitObjectAttributeEXT
 layout(location = 2) hitObjectAttributeNV vec4 attrMain;
 
 bool testVars() {

--- a/tests/glsl-intrinsic/raytracing/ser-nv-wrapper-requires-nv.slang
+++ b/tests/glsl-intrinsic/raytracing/ser-nv-wrapper-requires-nv.slang
@@ -1,0 +1,12 @@
+// NV-named GLSL SER wrappers remain tied to SPV_NV_shader_invocation_reorder.
+
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -allow-glsl -stage raygeneration -entry main -target spirv-assembly -emit-spirv-directly -capability spvShaderInvocationReorderEXT -restrictive-capability-check
+
+// CHECK: error[E41013]
+// CHECK: Missing capabilities are: 'spvShaderInvocationReorderNV'
+
+void main()
+{
+    hitObjectNV hit;
+    bool isHit = hitObjectIsHitNV(hit);
+}

--- a/tests/hlsl-intrinsic/ray-tracing/rt-lss-intrinsics-chit.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-lss-intrinsics-chit.slang
@@ -1,16 +1,18 @@
 //TEST:SIMPLE(filecheck=HLSL): -target hlsl -capability hlsl_nvapi
 //TEST:SIMPLE(filecheck=SPIRV): -target spirv-asm -capability spvShaderInvocationReorderNV
 //DIAGNOSTIC_TEST:SIMPLE(filecheck=NO_NV): -target spirv-asm
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=EXT_ONLY): -target spirv-asm -capability spvShaderInvocationReorderEXT -restrictive-capability-check
 //HLSL: NvRtSphereObjectPositionAndRadius
 //HLSL: NvRtLssObjectPositionsAndRadii
 //HLSL: NvRtIsSphereHit
 //HLSL: NvRtIsLssHit
 
-//NO_NV: error[E41400]: static assertion failed
-//NO_NV: HitObject.GetSpherePositionAndRadius() requires -capability spvShaderInvocationReorderNV
-//NO_NV: HitObject.GetLssPositionsAndRadii() requires -capability spvShaderInvocationReorderNV
-//NO_NV: HitObject.IsSphereHit() requires -capability spvShaderInvocationReorderNV
-//NO_NV: HitObject.IsLssHit() requires -capability spvShaderInvocationReorderNV
+//NO_NV: error[E41011]: __target_switch has no compatible target
+//NO_NV: error[E41011]: __target_switch has no compatible target
+//NO_NV: error[E41011]: __target_switch has no compatible target
+//NO_NV: error[E41011]: __target_switch has no compatible target
+//EXT_ONLY: error[E41013]: entry point uses capabilities not in specified profile
+//EXT_ONLY: Missing capabilities are: 'spvShaderInvocationReorderNV'
 //SPIRV: HitSpherePositionNV
 //SPIRV: HitSphereRadiusNV
 //SPIRV: HitLSSPositionsNV

--- a/tests/hlsl-intrinsic/ray-tracing/rt-lss-intrinsics-chit.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-lss-intrinsics-chit.slang
@@ -8,6 +8,9 @@
 
 //NO_NV: error[E41400]: static assertion failed
 //NO_NV: HitObject.GetSpherePositionAndRadius() requires -capability spvShaderInvocationReorderNV
+//NO_NV: HitObject.GetLssPositionsAndRadii() requires -capability spvShaderInvocationReorderNV
+//NO_NV: HitObject.IsSphereHit() requires -capability spvShaderInvocationReorderNV
+//NO_NV: HitObject.IsLssHit() requires -capability spvShaderInvocationReorderNV
 //SPIRV: HitSpherePositionNV
 //SPIRV: HitSphereRadiusNV
 //SPIRV: HitLSSPositionsNV

--- a/tests/hlsl-intrinsic/ray-tracing/rt-lss-intrinsics-chit.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-lss-intrinsics-chit.slang
@@ -1,5 +1,5 @@
 //TEST:SIMPLE(filecheck=HLSL): -target hlsl -capability hlsl_nvapi
-//TEST:SIMPLE(filecheck=SPIRV): -target spirv-asm
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv-asm -capability spvShaderInvocationReorderNV
 //HLSL: NvRtSphereObjectPositionAndRadius
 //HLSL: NvRtLssObjectPositionsAndRadii
 //HLSL: NvRtIsSphereHit
@@ -35,7 +35,7 @@ void closestHitShaderLss(inout RayPayload payload, in BuiltInTriangleIntersectio
     payload.lssData = GetLssPositionsAndRadii();
     payload.isSphere = IsSphereHit();
     payload.isLss = IsLssHit();
-    
+
     // Test HitObject API functions
     HitObject hitObj;
     float4 sphereData = hitObj.GetSpherePositionAndRadius();

--- a/tests/hlsl-intrinsic/ray-tracing/rt-lss-intrinsics-chit.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-lss-intrinsics-chit.slang
@@ -1,10 +1,13 @@
 //TEST:SIMPLE(filecheck=HLSL): -target hlsl -capability hlsl_nvapi
 //TEST:SIMPLE(filecheck=SPIRV): -target spirv-asm -capability spvShaderInvocationReorderNV
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=NO_NV): -target spirv-asm
 //HLSL: NvRtSphereObjectPositionAndRadius
 //HLSL: NvRtLssObjectPositionsAndRadii
 //HLSL: NvRtIsSphereHit
 //HLSL: NvRtIsLssHit
 
+//NO_NV: error[E41400]: static assertion failed
+//NO_NV: HitObject.GetSpherePositionAndRadius() requires -capability spvShaderInvocationReorderNV
 //SPIRV: HitSpherePositionNV
 //SPIRV: HitSphereRadiusNV
 //SPIRV: HitLSSPositionsNV

--- a/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-make-motion-hit.slang
+++ b/tests/hlsl-intrinsic/shader-execution-reordering/hit-object-make-motion-hit.slang
@@ -1,0 +1,78 @@
+// hit-object-make-motion-hit.slang
+
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv-asm -entry rayGenerationMain -stage raygeneration -emit-spirv-directly -capability spvShaderInvocationReorderMotionNV
+
+// SPIRV-DAG: OpExtension "SPV_NV_ray_tracing_motion_blur"
+// SPIRV-DAG: OpCapability RayTracingMotionBlurNV
+// SPIRV-DAG: OpExtension "SPV_NV_shader_invocation_reorder"
+// SPIRV-DAG: OpCapability ShaderInvocationReorderNV
+
+//TEST_INPUT: set scene = AccelerationStructure
+uniform RaytracingAccelerationStructure scene;
+
+//TEST_INPUT:set outputBuffer = out ubuffer(data=[0, 0, 0, 0], stride=4)
+RWStructuredBuffer<uint> outputBuffer;
+
+struct SomeValues
+{
+    int a;
+    float b;
+};
+
+uint calcValue(HitObject hit)
+{
+    uint r = 0;
+
+    if (hit.IsHit())
+    {
+        SomeValues attrs = hit.GetAttributes<SomeValues>();
+        r += attrs.a;
+    }
+
+    return r;
+}
+
+void rayGenerationMain()
+{
+    int idx = DispatchRaysIndex().x;
+
+    SomeValues attrs = { idx, idx * 2.0f };
+
+    RayDesc ray;
+    ray.Origin = float3(idx, 0, 0);
+    ray.TMin = 0.01f;
+    ray.Direction = float3(0, 1, 0);
+    ray.TMax = 1e4f;
+
+    uint hitKind = 0;
+    uint rayContributionToHitGroupIndex = 0;
+    uint multiplierForGeometryContributionToHitGroupIndex = 4;
+    float currentTime = idx / 4.0f;
+
+    // SPIRV-DAG: OpHitObjectRecordHitMotionNV
+    HitObject computedIndexHit = HitObject::MakeMotionHit(
+        scene,
+        idx,
+        idx * 2,
+        idx * 3,
+        hitKind,
+        rayContributionToHitGroupIndex,
+        multiplierForGeometryContributionToHitGroupIndex,
+        ray,
+        currentTime,
+        attrs);
+
+    // SPIRV-DAG: OpHitObjectRecordHitWithIndexMotionNV
+    HitObject explicitIndexHit = HitObject::MakeMotionHit(
+        0,
+        scene,
+        idx,
+        idx * 2,
+        idx * 3,
+        hitKind,
+        ray,
+        currentTime,
+        attrs);
+
+    outputBuffer[idx] = calcValue(computedIndexHit) + calcValue(explicitIndexHit);
+}


### PR DESCRIPTION
Fixes #11082

## Summary of the problem from the end user perspective

Compiling `HitObject::TraceRay` for direct SPIR-V with a `spirv_1_6` profile implicitly upgraded SER to the NV capability while the generated hit-object trace operation used EXT. Restrictive explicit EXT requests were also rejected as if NV was required.

### Minimal repro shader; if applicable

```hlsl
[shader("raygeneration")]
void main()
{
    Payload payload;
    HitObject hitObj = HitObject::TraceRay(tlas, 0, 0xFF, 0, 0, 0, ray, payload);
    if (hitObj.IsHit())
    {
        outImage[DispatchRaysIndex().xy] = 1.0f;
    }
}
```

## Root cause

The generic `ser` capability still included the NV GL/SPIR-V path, while fallback SPIR-V hit-object emission defaulted to NV when no explicit SER capability was present. Because NV implies EXT, generic requirements could resolve through NV and then mismatch EXT opcode emission.

## Solution in this PR

Make the generic SPIR-V/GLSL SER path default to EXT while preserving explicit NV aliases for NV intrinsics, and make ambiguous SPIR-V hit-object fallback emission use EXT. Add regression coverage for implicit profile upgrade and restrictive explicit EXT.

NV-only LSS/cluster `HitObject` accessors now require `spvShaderInvocationReorderNV` for SPIR-V. User shaders that call those accessors without the explicit NV capability now get a Slang diagnostic instead of malformed mixed EXT/NV SPIR-V.

### Notes to the reviewers; where to focus on

Review `slang-capabilities.capdef` and `slang-emit-spirv.cpp` for the EXT default, and the `ser_nv*` requirement changes that keep NV-named GLSL/HLSL intrinsics on the NV path. The new `gh-11082.slang` test checks that implicit and restrictive EXT emit only EXT hit-object declarations, attribute storage classes, and opcodes. `rt-lss-intrinsics-chit.slang` keeps positive NV coverage and adds a no-NV diagnostic regression for LSS `HitObject` methods.
