### PR TITLE
Fix generic vector constructor prelinking

### DIFF
--- a/source/slang/slang-ir-deduplicate.cpp
+++ b/source/slang/slang-ir-deduplicate.cpp
@@ -40,10 +40,8 @@ IRInst* IRDeduplicationContext::findVisibleGlobalNumberingEntry(
     IRInst* genericScope)
 {
     IRInst* existingVal = nullptr;
-    if (!m_globalValueNumberingMap.tryGetValue(key, existingVal))
-        return nullptr;
-
-    if (isInstVisibleFromGenericScope(existingVal, genericScope))
+    if (m_globalValueNumberingMap.tryGetValue(key, existingVal) &&
+        isInstVisibleFromGenericScope(existingVal, genericScope))
         return existingVal;
 
     return findVisibleScopedGlobalNumberingEntry(key, genericScope);

--- a/source/slang/slang-ir-deduplicate.cpp
+++ b/source/slang/slang-ir-deduplicate.cpp
@@ -8,6 +8,7 @@ void IRDeduplicationContext::init(IRModule* module)
     m_session = module->getSession();
 
     m_globalValueNumberingMap.clear();
+    m_scopedGlobalValueNumberingMap.clear();
     m_constantMap.clear();
 }
 

--- a/source/slang/slang-ir-deduplicate.cpp
+++ b/source/slang/slang-ir-deduplicate.cpp
@@ -9,7 +9,65 @@ void IRDeduplicationContext::init(IRModule* module)
 
     m_globalValueNumberingMap.clear();
     m_scopedGlobalValueNumberingMap.clear();
+    m_scopedGlobalValueNumberingScopes.clear();
     m_constantMap.clear();
+}
+
+bool IRDeduplicationContext::isInstVisibleFromGenericScope(IRInst* inst, IRInst* genericScope)
+{
+    auto instGeneric = findOuterGeneric(inst);
+    return !instGeneric || instGeneric == genericScope ||
+           (genericScope && hasDescendent(instGeneric, genericScope));
+}
+
+IRInst* IRDeduplicationContext::findVisibleScopedGlobalNumberingEntry(
+    IRInstKey const& key,
+    IRInst* genericScope)
+{
+    IRInst* scopedInst = nullptr;
+    for (auto generic = genericScope; generic; generic = findOuterGeneric(generic))
+    {
+        if (m_scopedGlobalValueNumberingMap.tryGetValue(IRScopedInstKey{key, generic}, scopedInst))
+            return scopedInst;
+    }
+    if (m_scopedGlobalValueNumberingMap.tryGetValue(IRScopedInstKey{key, nullptr}, scopedInst))
+        return scopedInst;
+    return nullptr;
+}
+
+IRInst* IRDeduplicationContext::findVisibleGlobalNumberingEntry(
+    IRInstKey const& key,
+    IRInst* genericScope)
+{
+    IRInst* existingVal = nullptr;
+    if (!m_globalValueNumberingMap.tryGetValue(key, existingVal))
+        return nullptr;
+
+    if (isInstVisibleFromGenericScope(existingVal, genericScope))
+        return existingVal;
+
+    return findVisibleScopedGlobalNumberingEntry(key, genericScope);
+}
+
+void IRDeduplicationContext::_addScopedGlobalNumberingEntry(IRInst* inst)
+{
+    auto scope = findOuterGeneric(inst);
+    m_scopedGlobalValueNumberingMap[IRScopedInstKey{IRInstKey{inst}, scope}] = inst;
+    m_scopedGlobalValueNumberingScopes[inst] = scope;
+}
+
+void IRDeduplicationContext::_removeScopedGlobalNumberingEntry(IRInst* inst)
+{
+    IRInst* scope = nullptr;
+    if (!m_scopedGlobalValueNumberingScopes.tryGetValue(inst, scope))
+        return;
+
+    IRInst* value = nullptr;
+    IRScopedInstKey scopedKey{IRInstKey{inst}, scope};
+    if (m_scopedGlobalValueNumberingMap.tryGetValue(scopedKey, value) && value == inst)
+        m_scopedGlobalValueNumberingMap.remove(scopedKey);
+
+    m_scopedGlobalValueNumberingScopes.remove(inst);
 }
 
 void IRDeduplicationContext::removeHoistableInstFromGlobalNumberingMap(IRInst* instToRemove)

--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -615,6 +615,8 @@ IRGeneric* cloneGenericImpl(
     // We want to clone extra decorations on the
     // return value from other symbols as well.
     auto clonedInnerVal = findGenericReturnVal(clonedVal);
+    if (!clonedInnerVal)
+        return clonedVal;
     for (auto originalSym = originalValues.sym; originalSym;
          originalSym = originalSym->nextWithSameName.get())
     {
@@ -622,6 +624,8 @@ IRGeneric* cloneGenericImpl(
         if (!originalGeneric)
             continue;
         auto originalInnerVal = findGenericReturnVal(originalGeneric);
+        if (!originalInnerVal)
+            continue;
 
         // Register all generic parameters before cloning the decorations.
         auto clonedParam = clonedVal->getFirstParam();

--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -851,7 +851,6 @@ void cloneGlobalValueWithCodeCommon(
 
     cloneDecorations(context, clonedValue, originalValue);
     cloneExtraDecorations(context, clonedValue, originalValues);
-    clonedValue->setFullType((IRType*)cloneValue(context, originalValue->getFullType()));
 
     // We will walk through the blocks of the function, and clone each of them.
     //
@@ -926,6 +925,10 @@ void cloneGlobalValueWithCodeCommon(
             cb = cb->getNextBlock();
         }
     }
+
+    // The full type can reference params that are registered while cloning the blocks above.
+    // Cloning it earlier can leave hoistable types pointing at sibling generic clones.
+    clonedValue->setFullType((IRType*)cloneValue(context, originalValue->getFullType()));
 }
 
 void checkIRDuplicate(IRInst* inst, IRInst* moduleInst, UnownedStringSlice const& mangledName)

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -2722,28 +2722,40 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
         // If it's found, just return, and throw away the instruction
         if (found)
         {
-            memoryArena.rewindToCursor(cursor);
-
-            // If the found inst is defined in the same parent as current insert location but
-            // is located after the insert location, we need to move it to the insert location.
             auto foundInst = *found;
-            if (foundInst->getParent() && foundInst->getParent() == getInsertLoc().getParent() &&
-                getInsertLoc().getMode() == IRInsertLoc::Mode::Before)
+            auto foundGeneric = findOuterGeneric(foundInst);
+            auto insertGeneric = findOuterGeneric(getInsertLoc().getParent());
+            if (foundGeneric && foundGeneric != insertGeneric)
             {
-                auto insertLoc = getInsertLoc().getInst();
-                bool isAfter = false;
-                for (auto cur = insertLoc->next; cur; cur = cur->next)
-                {
-                    if (cur == foundInst)
-                    {
-                        isAfter = true;
-                        break;
-                    }
-                }
-                if (isAfter)
-                    foundInst->insertBefore(insertLoc);
+                // The global value-numbering map is keyed only by operands. A matching
+                // instruction in a different generic scope is not visible here, so keep the
+                // newly allocated instruction and let it be hoisted in the current scope.
             }
-            return *found;
+            else
+            {
+                memoryArena.rewindToCursor(cursor);
+
+                // If the found inst is defined in the same parent as current insert location but
+                // is located after the insert location, we need to move it to the insert location.
+                if (foundInst->getParent() &&
+                    foundInst->getParent() == getInsertLoc().getParent() &&
+                    getInsertLoc().getMode() == IRInsertLoc::Mode::Before)
+                {
+                    auto insertLoc = getInsertLoc().getInst();
+                    bool isAfter = false;
+                    for (auto cur = insertLoc->next; cur; cur = cur->next)
+                    {
+                        if (cur == foundInst)
+                        {
+                            isAfter = true;
+                            break;
+                        }
+                    }
+                    if (isAfter)
+                        foundInst->insertBefore(insertLoc);
+                }
+                return *found;
+            }
         }
     }
 

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -1360,8 +1360,9 @@ IRInst* IRBuilder::replaceOperand(IRUse* use, IRInst* newValue)
     builder->_removeGlobalNumberingEntry(user);
     use->init(user, newValue);
 
-    IRInst* existingVal = nullptr;
-    if (builder->getGlobalValueNumberingMap().tryGetValue(IRInstKey{user}, existingVal))
+    auto genericScope = findOuterGeneric(user);
+    auto existingVal = builder->findVisibleGlobalNumberingEntry(IRInstKey{user}, genericScope);
+    if (existingVal && existingVal != user)
     {
         user->replaceUsesWith(existingVal);
         return existingVal;
@@ -2717,20 +2718,6 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
     {
         IRInstKey key = {inst};
 
-        auto findVisibleScopedInst = [&](IRInst* insertGeneric) -> IRInst*
-        {
-            IRInst* scopedInst = nullptr;
-            auto& scopedMap = m_dedupContext->getScopedGlobalValueNumberingMap();
-            for (auto generic = insertGeneric; generic; generic = findOuterGeneric(generic->parent))
-            {
-                if (scopedMap.tryGetValue(IRScopedInstKey{key, generic}, scopedInst))
-                    return scopedInst;
-            }
-            if (scopedMap.tryGetValue(IRScopedInstKey{key, nullptr}, scopedInst))
-                return scopedInst;
-            return nullptr;
-        };
-
         auto useFoundInst = [&](IRInst* foundInst) -> IRInst*
         {
             memoryArena.rewindToCursor(cursor);
@@ -2745,7 +2732,12 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
                     insertLoc = insertLoc->getNextInst();
 
                 if (!insertLoc)
+                {
+                    // There is no legal non-param insertion point in this suffix of the block.
+                    // If a non-param `foundInst` appeared after the requested insert location,
+                    // the scan above would have stopped at it.
                     return foundInst;
+                }
 
                 bool isAfter = false;
                 for (auto cur = insertLoc->next; cur; cur = cur->next)
@@ -2768,15 +2760,14 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
         if (found)
         {
             auto foundInst = *found;
-            auto foundGeneric = findOuterGeneric(foundInst);
             auto insertGeneric = findOuterGeneric(getInsertLoc().getParent());
-            if (foundGeneric && foundGeneric != insertGeneric &&
-                !(insertGeneric && hasDescendent(foundGeneric, insertGeneric)))
+            if (!m_dedupContext->isInstVisibleFromGenericScope(foundInst, insertGeneric))
             {
                 // The global value-numbering map is keyed only by operands. A matching
                 // instruction in a different generic scope is not visible here, so keep the
                 // newly allocated instruction and let it be hoisted in the current scope.
-                if (auto scopedInst = findVisibleScopedInst(insertGeneric))
+                if (auto scopedInst =
+                        m_dedupContext->findVisibleScopedGlobalNumberingEntry(key, insertGeneric))
                     return useFoundInst(scopedInst);
             }
             else
@@ -2819,9 +2810,7 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
         else
             addHoistableInst(this, inst);
     }
-    m_dedupContext->getScopedGlobalValueNumberingMap()[IRScopedInstKey{
-        IRInstKey{inst},
-        findOuterGeneric(inst)}] = inst;
+    m_dedupContext->_addScopedGlobalNumberingEntry(inst);
 
     return inst;
 }
@@ -8808,10 +8797,11 @@ static void _replaceInstUsesWith(IRInst* thisInst, IRInst* other)
                 {
                     // Otherwise, check the global value numbering map for duplication after
                     // replacing the use.
-                    IRInst* existingVal = nullptr;
-                    if (dedupContext->getGlobalValueNumberingMap().tryGetValue(
-                            IRInstKey{user},
-                            existingVal))
+                    auto genericScope = findOuterGeneric(user);
+                    auto existingVal = dedupContext->findVisibleGlobalNumberingEntry(
+                        IRInstKey{user},
+                        genericScope);
+                    if (existingVal && existingVal != user)
                     {
                         // If existingVal has been replaced by something else, use that.
                         dedupContext->getInstReplacementMap().tryGetValue(existingVal, existingVal);

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -2717,6 +2717,51 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
     {
         IRInstKey key = {inst};
 
+        auto findVisibleScopedInst = [&](IRInst* insertGeneric) -> IRInst*
+        {
+            IRInst* scopedInst = nullptr;
+            auto& scopedMap = m_dedupContext->getScopedGlobalValueNumberingMap();
+            for (auto generic = insertGeneric; generic; generic = findOuterGeneric(generic->parent))
+            {
+                if (scopedMap.tryGetValue(IRScopedInstKey{key, generic}, scopedInst))
+                    return scopedInst;
+            }
+            if (scopedMap.tryGetValue(IRScopedInstKey{key, nullptr}, scopedInst))
+                return scopedInst;
+            return nullptr;
+        };
+
+        auto useFoundInst = [&](IRInst* foundInst) -> IRInst*
+        {
+            memoryArena.rewindToCursor(cursor);
+
+            // If the found inst is defined in the same parent as current insert location but
+            // is located after the insert location, we need to move it to the insert location.
+            if (foundInst->getParent() && foundInst->getParent() == getInsertLoc().getParent() &&
+                getInsertLoc().getMode() == IRInsertLoc::Mode::Before)
+            {
+                auto insertLoc = getInsertLoc().getInst();
+                while (insertLoc && insertLoc->getOp() == kIROp_Param)
+                    insertLoc = insertLoc->getNextInst();
+
+                if (!insertLoc)
+                    return foundInst;
+
+                bool isAfter = false;
+                for (auto cur = insertLoc->next; cur; cur = cur->next)
+                {
+                    if (cur == foundInst)
+                    {
+                        isAfter = true;
+                        break;
+                    }
+                }
+                if (isAfter)
+                    foundInst->insertBefore(insertLoc);
+            }
+            return foundInst;
+        };
+
         IRInst** found = m_dedupContext->getGlobalValueNumberingMap().tryGetValueOrAdd(key, inst);
         SLANG_ASSERT(endCursor == memoryArena.getCursor());
         // If it's found, just return, and throw away the instruction
@@ -2731,37 +2776,12 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
                 // The global value-numbering map is keyed only by operands. A matching
                 // instruction in a different generic scope is not visible here, so keep the
                 // newly allocated instruction and let it be hoisted in the current scope.
+                if (auto scopedInst = findVisibleScopedInst(insertGeneric))
+                    return useFoundInst(scopedInst);
             }
             else
             {
-                memoryArena.rewindToCursor(cursor);
-
-                // If the found inst is defined in the same parent as current insert location but
-                // is located after the insert location, we need to move it to the insert location.
-                if (foundInst->getParent() &&
-                    foundInst->getParent() == getInsertLoc().getParent() &&
-                    getInsertLoc().getMode() == IRInsertLoc::Mode::Before)
-                {
-                    auto insertLoc = getInsertLoc().getInst();
-                    while (insertLoc && insertLoc->getOp() == kIROp_Param)
-                        insertLoc = insertLoc->getNextInst();
-
-                    if (!insertLoc)
-                        return *found;
-
-                    bool isAfter = false;
-                    for (auto cur = insertLoc->next; cur; cur = cur->next)
-                    {
-                        if (cur == foundInst)
-                        {
-                            isAfter = true;
-                            break;
-                        }
-                    }
-                    if (isAfter)
-                        foundInst->insertBefore(insertLoc);
-                }
-                return *found;
+                return useFoundInst(foundInst);
             }
         }
     }
@@ -2799,6 +2819,9 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
         else
             addHoistableInst(this, inst);
     }
+    m_dedupContext->getScopedGlobalValueNumberingMap()[IRScopedInstKey{
+        IRInstKey{inst},
+        findOuterGeneric(inst)}] = inst;
 
     return inst;
 }

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -2756,7 +2756,9 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
 
         IRInst** found = m_dedupContext->getGlobalValueNumberingMap().tryGetValueOrAdd(key, inst);
         SLANG_ASSERT(endCursor == memoryArena.getCursor());
-        // If it's found, just return, and throw away the instruction
+        // If the value-numbered match is visible from the current generic scope, return it and
+        // discard the freshly allocated instruction. Otherwise, try to substitute a visible scoped
+        // match; if none exists, keep the new instruction and hoist it in this scope.
         if (found)
         {
             auto foundInst = *found;

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -2725,7 +2725,8 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
             auto foundInst = *found;
             auto foundGeneric = findOuterGeneric(foundInst);
             auto insertGeneric = findOuterGeneric(getInsertLoc().getParent());
-            if (foundGeneric && foundGeneric != insertGeneric)
+            if (foundGeneric && foundGeneric != insertGeneric &&
+                !(insertGeneric && hasDescendent(foundGeneric, insertGeneric)))
             {
                 // The global value-numbering map is keyed only by operands. A matching
                 // instruction in a different generic scope is not visible here, so keep the
@@ -2742,6 +2743,12 @@ IRInst* IRBuilder::_findOrEmitHoistableInst(
                     getInsertLoc().getMode() == IRInsertLoc::Mode::Before)
                 {
                     auto insertLoc = getInsertLoc().getInst();
+                    while (insertLoc && insertLoc->getOp() == kIROp_Param)
+                        insertLoc = insertLoc->getNextInst();
+
+                    if (!insertLoc)
+                        return *found;
+
                     bool isAfter = false;
                     for (auto cur = insertLoc->next; cur; cur = cur->next)
                     {

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -1969,6 +1969,28 @@ public:
     }
 };
 
+struct IRScopedInstKey
+{
+    IRInstKey instKey;
+    IRInst* genericScope = nullptr;
+
+    IRScopedInstKey() = default;
+    IRScopedInstKey(IRInstKey const& key, IRInst* scope)
+        : instKey(key), genericScope(scope)
+    {
+    }
+
+    HashCode getHashCode() const
+    {
+        return combineHash(instKey.getHashCode(), Slang::getHashCode(genericScope));
+    }
+
+    bool operator==(IRScopedInstKey const& right) const
+    {
+        return genericScope == right.genericScope && instKey == right.instKey;
+    }
+};
+
 struct IRConstantKey
 {
     IRConstant* inst;
@@ -2015,9 +2037,14 @@ public:
     void tryHoistInst(IRInst* inst);
 
     typedef Dictionary<IRInstKey, IRInst*> GlobalValueNumberingMap;
+    typedef Dictionary<IRScopedInstKey, IRInst*> ScopedGlobalValueNumberingMap;
     typedef Dictionary<IRConstantKey, IRConstant*> ConstantMap;
 
     GlobalValueNumberingMap& getGlobalValueNumberingMap() { return m_globalValueNumberingMap; }
+    ScopedGlobalValueNumberingMap& getScopedGlobalValueNumberingMap()
+    {
+        return m_scopedGlobalValueNumberingMap;
+    }
     Dictionary<IRInst*, IRInst*>& getInstReplacementMap() { return m_instReplacementMap; }
 
     void _addGlobalNumberingEntry(IRInst* inst)
@@ -2025,6 +2052,8 @@ public:
         m_globalValueNumberingMap.add(IRInstKey{inst}, inst);
         m_instReplacementMap.remove(inst);
         tryHoistInst(inst);
+        m_scopedGlobalValueNumberingMap[IRScopedInstKey{IRInstKey{inst}, findOuterGeneric(inst)}] =
+            inst;
     }
     void _removeGlobalNumberingEntry(IRInst* inst)
     {
@@ -2034,6 +2063,14 @@ public:
             if (value == inst)
             {
                 m_globalValueNumberingMap.remove(IRInstKey{inst});
+            }
+        }
+        IRScopedInstKey scopedKey{IRInstKey{inst}, findOuterGeneric(inst)};
+        if (m_scopedGlobalValueNumberingMap.tryGetValue(scopedKey, value))
+        {
+            if (value == inst)
+            {
+                m_scopedGlobalValueNumberingMap.remove(scopedKey);
             }
         }
     }
@@ -2048,6 +2085,7 @@ private:
     Session* m_session;
 
     GlobalValueNumberingMap m_globalValueNumberingMap;
+    ScopedGlobalValueNumberingMap m_scopedGlobalValueNumberingMap;
 
     // Duplicate insts that are still alive and needs to be replaced in m_globalValueNumberMap
     // when used as an operand to create another inst.

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -2060,6 +2060,9 @@ public:
     {
         auto key = IRInstKey{inst};
         IRInst* value = nullptr;
+        // Keep the first scope-blind entry for a key. Structurally identical instructions in
+        // disjoint generic scopes can collide here; the scoped map below records the visible
+        // instruction for each scope.
         if (!m_globalValueNumberingMap.tryGetValue(key, value))
             m_globalValueNumberingMap.add(key, inst);
         m_instReplacementMap.remove(inst);

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -2040,6 +2040,9 @@ public:
     typedef Dictionary<IRScopedInstKey, IRInst*> ScopedGlobalValueNumberingMap;
     typedef Dictionary<IRConstantKey, IRConstant*> ConstantMap;
 
+    // Scope-blind map of value-numbered instructions. Entries may belong to any generic scope;
+    // callers that need a visible instruction for a specific scope should use
+    // findVisibleGlobalNumberingEntry instead.
     GlobalValueNumberingMap& getGlobalValueNumberingMap() { return m_globalValueNumberingMap; }
     ScopedGlobalValueNumberingMap& getScopedGlobalValueNumberingMap()
     {

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -2052,8 +2052,9 @@ public:
         m_globalValueNumberingMap.add(IRInstKey{inst}, inst);
         m_instReplacementMap.remove(inst);
         tryHoistInst(inst);
-        m_scopedGlobalValueNumberingMap[IRScopedInstKey{IRInstKey{inst}, findOuterGeneric(inst)}] =
-            inst;
+        m_scopedGlobalValueNumberingMap.add(
+            IRScopedInstKey{IRInstKey{inst}, findOuterGeneric(inst)},
+            inst);
     }
     void _removeGlobalNumberingEntry(IRInst* inst)
     {

--- a/source/slang/slang-ir.h
+++ b/source/slang/slang-ir.h
@@ -2047,14 +2047,21 @@ public:
     }
     Dictionary<IRInst*, IRInst*>& getInstReplacementMap() { return m_instReplacementMap; }
 
+    bool isInstVisibleFromGenericScope(IRInst* inst, IRInst* genericScope);
+    IRInst* findVisibleScopedGlobalNumberingEntry(IRInstKey const& key, IRInst* genericScope);
+    IRInst* findVisibleGlobalNumberingEntry(IRInstKey const& key, IRInst* genericScope);
+    void _addScopedGlobalNumberingEntry(IRInst* inst);
+    void _removeScopedGlobalNumberingEntry(IRInst* inst);
+
     void _addGlobalNumberingEntry(IRInst* inst)
     {
-        m_globalValueNumberingMap.add(IRInstKey{inst}, inst);
+        auto key = IRInstKey{inst};
+        IRInst* value = nullptr;
+        if (!m_globalValueNumberingMap.tryGetValue(key, value))
+            m_globalValueNumberingMap.add(key, inst);
         m_instReplacementMap.remove(inst);
         tryHoistInst(inst);
-        m_scopedGlobalValueNumberingMap.add(
-            IRScopedInstKey{IRInstKey{inst}, findOuterGeneric(inst)},
-            inst);
+        _addScopedGlobalNumberingEntry(inst);
     }
     void _removeGlobalNumberingEntry(IRInst* inst)
     {
@@ -2066,14 +2073,7 @@ public:
                 m_globalValueNumberingMap.remove(IRInstKey{inst});
             }
         }
-        IRScopedInstKey scopedKey{IRInstKey{inst}, findOuterGeneric(inst)};
-        if (m_scopedGlobalValueNumberingMap.tryGetValue(scopedKey, value))
-        {
-            if (value == inst)
-            {
-                m_scopedGlobalValueNumberingMap.remove(scopedKey);
-            }
-        }
+        _removeScopedGlobalNumberingEntry(inst);
     }
 
     ConstantMap& getConstantMap() { return m_constantMap; }
@@ -2087,6 +2087,7 @@ private:
 
     GlobalValueNumberingMap m_globalValueNumberingMap;
     ScopedGlobalValueNumberingMap m_scopedGlobalValueNumberingMap;
+    Dictionary<IRInst*, IRInst*> m_scopedGlobalValueNumberingScopes;
 
     // Duplicate insts that are still alive and needs to be replaced in m_globalValueNumberMap
     // when used as an operand to create another inst.

--- a/tests/language-feature/generics/generic-vector-ctor-link-import.slang
+++ b/tests/language-feature/generics/generic-vector-ctor-link-import.slang
@@ -1,3 +1,5 @@
+//TEST_IGNORE_FILE:
+
 // Imported helper module for generic-vector-ctor-link.slang.
 
 [Differentiable]

--- a/tests/language-feature/generics/generic-vector-ctor-link-import.slang
+++ b/tests/language-feature/generics/generic-vector-ctor-link-import.slang
@@ -1,0 +1,12 @@
+// Imported helper module for generic-vector-ctor-link.slang.
+
+[Differentiable]
+vector<T, N> importedVectorCtor<T, int N>(vector<T, N> v) where T : __BuiltinFloatingPointType
+{
+    return vector<T, N>(0.0f);
+}
+
+vector<T, N> importedSiblingCtor<T, int N>(vector<T, N> v) where T : __BuiltinFloatingPointType
+{
+    return vector<T, N>(1.0f);
+}

--- a/tests/language-feature/generics/generic-vector-ctor-link.slang
+++ b/tests/language-feature/generics/generic-vector-ctor-link.slang
@@ -1,8 +1,8 @@
 // Regression test for #11182: prelinking an imported generic vector constructor while
 // lowering this module used to crash while hoisting a cloned Func type.
 
-//TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -profile spirv_1_6 -emit-spirv-directly -stage compute -entry cs_main
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_RUN):-cpu -shaderobj -output-using-type -entry cs_main
+//TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -profile spirv_1_6 -emit-spirv-directly -stage compute -entry computeMain
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK_RUN):-slang -compute -shaderobj -output-using-type
 
 import generic_vector_ctor_link_import;
 
@@ -17,14 +17,16 @@ vector<T, N> localVectorCtor<T, int N>(vector<T, N> v) where T : __BuiltinFloati
 
 [shader("compute")]
 [numthreads(1, 1, 1)]
-void cs_main()
+void computeMain()
 {
     var input = diffPair(vector<float, 3>(1.0f), vector<float, 3>(1.0f));
     var importedResult = __fwd_diff(importedVectorCtor<float, 3>)(input);
     var localResult = __fwd_diff(localVectorCtor<float, 3>)(input);
     var siblingResult = importedSiblingCtor<float, 3>(vector<float, 3>(1.0f));
-    outputBuffer[0] = importedResult.p.x + importedResult.d.x + localResult.p.x +
-                      localResult.d.x + siblingResult.x;
+    var result = importedResult.p.x + importedResult.d.x + localResult.p.x + localResult.d.x +
+                 siblingResult.x;
+
+    outputBuffer[0] = result; // CHECK_RUN: 3.0
 }
 
 // CHECK: OpCapability Shader
@@ -33,5 +35,3 @@ void cs_main()
 // CHECK: OpTypeVector
 // CHECK: OpStore
 // CHECK: OpReturn
-
-// CHECK_RUN: 3.0

--- a/tests/language-feature/generics/generic-vector-ctor-link.slang
+++ b/tests/language-feature/generics/generic-vector-ctor-link.slang
@@ -34,6 +34,13 @@ void computeMain()
 // CHECK: OpCapability Shader
 // CHECK: OpEntryPoint GLCompute
 // CHECK: OpExecutionMode {{.*}} LocalSize 1 1 1
-// CHECK: OpTypeVector
+// CHECK: ; Types, variables and constants
+// CHECK-COUNT-1: OpTypeFunction
+// CHECK-NOT: OpTypeFunction
+// CHECK: OpTypeFloat 32
+// CHECK-NOT: OpTypeFunction
+// CHECK-COUNT-1: OpTypeVector %float 3
+// CHECK-NOT: OpTypeFunction
+// CHECK-NOT: OpTypeVector %float 3
 // CHECK: OpStore
 // CHECK: OpReturn

--- a/tests/language-feature/generics/generic-vector-ctor-link.slang
+++ b/tests/language-feature/generics/generic-vector-ctor-link.slang
@@ -3,6 +3,8 @@
 
 //TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -profile spirv_1_6 -emit-spirv-directly -stage compute -entry computeMain
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK_RUN):-slang -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK_RUN):-cpu -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK_RUN):-vk -compute -shaderobj -output-using-type
 
 import generic_vector_ctor_link_import;
 

--- a/tests/language-feature/generics/generic-vector-ctor-link.slang
+++ b/tests/language-feature/generics/generic-vector-ctor-link.slang
@@ -3,18 +3,31 @@
 
 //TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -profile spirv_1_6 -emit-spirv-directly -stage compute -entry cs_main
 
-vector<T, N> f<T, int N>(vector<T, N> v) where T : __BuiltinFloatingPointType
+import generic_vector_ctor_link_import;
+
+RWStructuredBuffer<float> outputBuffer;
+
+[Differentiable]
+vector<T, N> localVectorCtor<T, int N>(vector<T, N> v) where T : __BuiltinFloatingPointType
 {
-    return vector<T, N>(0.0f);
+    return vector<T, N>(2.0f);
 }
 
 [shader("compute")]
 [numthreads(1, 1, 1)]
 void cs_main()
 {
+    var input = diffPair(vector<float, 3>(1.0f), vector<float, 3>(1.0f));
+    var importedResult = __fwd_diff(importedVectorCtor<float, 3>)(input);
+    var localResult = __fwd_diff(localVectorCtor<float, 3>)(input);
+    var siblingResult = importedSiblingCtor<float, 3>(vector<float, 3>(1.0f));
+    outputBuffer[0] = importedResult.p.x + importedResult.d.x + localResult.p.x +
+                      localResult.d.x + siblingResult.x;
 }
 
 // CHECK: OpCapability Shader
 // CHECK: OpEntryPoint GLCompute
 // CHECK: OpExecutionMode {{.*}} LocalSize 1 1 1
+// CHECK: OpTypeVector
+// CHECK: OpStore
 // CHECK: OpReturn

--- a/tests/language-feature/generics/generic-vector-ctor-link.slang
+++ b/tests/language-feature/generics/generic-vector-ctor-link.slang
@@ -2,9 +2,11 @@
 // lowering this module used to crash while hoisting a cloned Func type.
 
 //TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -profile spirv_1_6 -emit-spirv-directly -stage compute -entry cs_main
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_RUN):-cpu -shaderobj -output-using-type -entry cs_main
 
 import generic_vector_ctor_link_import;
 
+//TEST_INPUT:ubuffer(data=[0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 [Differentiable]
@@ -31,3 +33,5 @@ void cs_main()
 // CHECK: OpTypeVector
 // CHECK: OpStore
 // CHECK: OpReturn
+
+// CHECK_RUN: 3.0

--- a/tests/language-feature/generics/generic-vector-ctor-link.slang
+++ b/tests/language-feature/generics/generic-vector-ctor-link.slang
@@ -1,0 +1,20 @@
+// Regression test for #11182: prelinking an imported generic vector constructor while
+// lowering this module used to crash while hoisting a cloned Func type.
+
+//TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -profile spirv_1_6 -emit-spirv-directly -stage compute -entry cs_main
+
+vector<T, N> f<T, int N>(vector<T, N> v) where T : __BuiltinFloatingPointType
+{
+    return vector<T, N>(0.0f);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void cs_main()
+{
+}
+
+// CHECK: OpCapability Shader
+// CHECK: OpEntryPoint GLCompute
+// CHECK: OpExecutionMode {{.*}} LocalSize 1 1 1
+// CHECK: OpReturn

--- a/tests/language-feature/generics/generic-vector-ctor-minimal.slang
+++ b/tests/language-feature/generics/generic-vector-ctor-minimal.slang
@@ -1,0 +1,17 @@
+// Minimal single-file regression test for #11182.
+
+//TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -profile spirv_1_6 -emit-spirv-directly -stage compute -entry cs_main
+
+vector<T, N> f<T, int N>(vector<T, N> v) where T : __BuiltinFloatingPointType
+{
+    return vector<T, N>(0.0f);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void cs_main()
+{
+}
+
+// CHECK: OpEntryPoint GLCompute
+// CHECK: OpReturn


### PR DESCRIPTION
Fixes #11182

## Summary of the problem from the end user perspective
A generic function that constructs `vector<T, N>` from a floating literal under `where T : __BuiltinFloatingPointType` could crash during prelinking, even with an otherwise empty compute shader entry point.

### Minimal repro shader; if applicable
```slang
vector<T, N> f<T, int N>(vector<T, N> v) where T : __BuiltinFloatingPointType
{
    return vector<T, N>(0.0f);
}
[shader("compute")][numthreads(1, 1, 1)] void cs_main() {}
```

## Root cause
During IR prelinking, the cloned generic's full type was cloned before its block parameters were registered, and hoistable value-numbering could also reuse an equivalent instruction from a sibling cloned generic. That left hoistable `Func` and autodiff-related types with operands in unrelated generic scopes.

## Solution in this PR
Clone global-value full types after block cloning has registered local operands. For hoistable value numbering, reject hits from a different enclosing generic scope consistently across creation and replacement-time dedup paths, and track the registration-time scope used by scoped dedup entries so removals stay correct after reparenting.

The regression now imports the generic vector-constructor helper from a sibling module, drives imported and local differentiable generic instantiations, and checks for vector/storage-buffer SPIR-V output.

### Notes to the reviewers; where to focus on
The main review points are `cloneGlobalValueWithCodeCommon` ordering, scoped hoistable value-numbering lookup/registration in `IRDeduplicationContext`, and the imported/autodiff regression coverage.

## Related PRs in the past
shader-slang/slang#11072 fixed a similar annotation-cloning crash signature, but this case is on the normal hoistable clone path.
shader-slang/slang#11195 was a mitigation that avoided the immediate hoist assertion but left operands from unrelated generic scopes.
