### PR TITLE
Complete DXC cooperative vector revert

### DIFF
--- a/source/slang/slang-emit-hlsl-prelude.cpp
+++ b/source/slang/slang-emit-hlsl-prelude.cpp
@@ -46,10 +46,7 @@ vector<OutElTy, MatM> __slang_linalg_Mul(
         dx::linalg::MatrixUse::A,
         dx::linalg::MatrixScope::Thread>;
     MatTy mat = MatTy::template Load<LoadLayout>(matBuf, matOff, matStr);
-    return dx::linalg::MultiplyAdd<OutElTy>(
-        mat,
-        dx::linalg::MakeInterpretedVector<InputDT>(input),
-        (vector<OutElTy, MatM>)0);
+    return dx::linalg::Multiply<OutElTy>(mat, input);
 }
 
 template<
@@ -82,10 +79,7 @@ vector<OutElTy, MatM> __slang_linalg_MulAdd(
     MatTy mat = MatTy::template Load<LoadLayout>(matBuf, matOff, matStr);
     using BiasVecTy = vector<BiasElTy, BiasVecDim>;
     BiasVecTy biasVec = biasBuf.template Load<BiasVecTy>(biasOff);
-    return dx::linalg::MultiplyAdd<OutElTy>(
-        mat,
-        dx::linalg::MakeInterpretedVector<InputDT>(input),
-        biasVec);
+    return dx::linalg::MultiplyAdd<OutElTy>(mat, input, biasVec);
 }
 
 template<
@@ -115,7 +109,7 @@ void __slang_linalg_OuterProductAccumulate(
 template<typename ElTy, uint N, typename BufTy>
 void __slang_linalg_VectorAccumulate(vector<ElTy, N> inputVec, BufTy buffer, uint offset)
 {
-    dx::linalg::InterlockedAccumulate(inputVec, buffer, offset);
+    dx::linalg::VectorAccumulate(inputVec, buffer, offset);
 }
 )";
 
@@ -390,9 +384,9 @@ __slang_cm_muladd(
         switch (slangValue)
         {
         case SLANG_SCALAR_TYPE_INT8:
-            return UnownedStringSlice(sm610OrAbove ? "I8" : "DATA_TYPE_SINT8_T4_PACKED");
+            return UnownedStringSlice(sm610OrAbove ? "PackedS8x32" : "DATA_TYPE_SINT8_T4_PACKED");
         case SLANG_SCALAR_TYPE_UINT8:
-            return UnownedStringSlice(sm610OrAbove ? "U8" : "DATA_TYPE_UINT8_T4_PACKED");
+            return UnownedStringSlice(sm610OrAbove ? "PackedU8x32" : "DATA_TYPE_UINT8_T4_PACKED");
         default:
             SLANG_UNEXPECTED(
                 "Unsupported packed cooperative vector input interpretation for HLSL emission");


### PR DESCRIPTION
## Summary

Completes the cooperative-vector side of the DXC revert by restoring the SM 6.10 HLSL prelude emitted API calls to match the reverted DXC package and the test expectations restored in #11354.

Fixes the following consistently failing tests in CI:

```
2 failing tests:
---
tests/cooperative-vector/matrix-mul-hlsl-codegen.slang.1
tests/cooperative-vector/training-hlsl-codegen.slang.1
---

```
## Root cause

#11348 updated both the DXC package and the SM 6.10 cooperative-vector HLSL emission for newer dx::linalg APIs. #11353 reverted the unstable DXC package, and #11354 reverted the cooperative-vector test expectations, but the matching implementation changes in source/slang/slang-emit-hlsl-prelude.cpp were left in place.

That left master in a mixed state: old DXC and old FileCheck expectations, but new HLSL prelude output. As a result, unrelated PRs started failing deterministic HLSL codegen tests across Linux, macOS, and Windows.

## Fix

Restore the SM 6.10 cooperative-vector prelude behavior from before #11348:

- emit dx::linalg::Multiply for mat-vec multiply instead of MultiplyAdd with a zero accumulator
- pass the input vector directly to MultiplyAdd instead of wrapping it in MakeInterpretedVector
- emit dx::linalg::VectorAccumulate instead of InterlockedAccumulate
- restore packed input component names to PackedS8x32 / PackedU8x32

No test expectations are changed; the existing tests already describe the reverted behavior.

## Testing

- cmake --build build --config Debug --target slang-test
- build/Debug/bin/slang-test -v tests/cooperative-vector/matrix-mul-hlsl-codegen.slang tests/cooperative-vector/training-hlsl-codegen.slang
- build/Debug/bin/slang-test -v -server-count 1 tests/cooperative-vector/matrix-mul-hlsl-codegen.slang tests/cooperative-vector/training-hlsl-codegen.slang