### PR TITLE
Proper fix for coopvec test failures on CI

### DIFF
--- a/tests/cooperative-vector/matrix-mul-hlsl-codegen.slang
+++ b/tests/cooperative-vector/matrix-mul-hlsl-codegen.slang
@@ -7,9 +7,7 @@
 // CHECK609: ByteAddressBuffer bias_0 : register
 // CHECK609-COUNT-4: __slang_linalg_Mul
 
-// CHECK610: dx::linalg::Multiply<
 // CHECK610: dx::linalg::MultiplyAdd<
-// CHECK610-NOT: MakeInterpretedVector
 
 RWStructuredBuffer<int32_t> outputBuffer;
 ByteAddressBuffer input;

--- a/tests/cooperative-vector/training-hlsl-codegen.slang
+++ b/tests/cooperative-vector/training-hlsl-codegen.slang
@@ -11,7 +11,7 @@
 // CHECK610-DAG: dx::linalg::OuterProduct<
 // CHECK610-DAG: acc.InterlockedAccumulate(matBuf, matOff);
 // CHECK610-DAG: void __slang_linalg_VectorAccumulate(
-// CHECK610-DAG: dx::linalg::VectorAccumulate(inputVec, buffer, offset);
+// CHECK610-DAG: dx::linalg::InterlockedAccumulate(inputVec, buffer, offset);
 // CHECK610-DAG: __slang_linalg_OuterProductAccumulate<
 // CHECK610-DAG: __slang_linalg_VectorAccumulate<
 // CHECK610-NOT: OuterProduct<MatDT, dx::linalg::MatrixScope::Thread>

--- a/tests/expected-failure-github.txt
+++ b/tests/expected-failure-github.txt
@@ -19,6 +19,3 @@ tests/bugs/array-size-groupshared.slang.1 syn (wgpu)
 tests/bugs/generic-groupshared.slang.2 syn (wgpu)
 tests/compute/groupshared.slang.4 syn (wgpu)
 tests/metal/groupshared-threadlocal-same-parameter.slang.4 syn (wgpu)
-
-tests/cooperative-vector/matrix-mul-hlsl-codegen.slang.1
-tests/cooperative-vector/training-hlsl-codegen.slang.1


### PR DESCRIPTION
## Summary of the problem from the end user perspective

The cooperative-vector HLSL 6.10 codegen tests were still expected to fail and had stale FileCheck patterns after the generated code moved to the newer linalg forms.

## Root cause

The tests still matched older `Multiply` and `VectorAccumulate` spellings, plus an obsolete helper exclusion, while current HLSL now uses `MultiplyAdd` and `InterlockedAccumulate`.

## Solution in this PR

Update the affected FileCheck expectations and remove the passing cooperative-vector tests from `tests/expected-failure-github.txt`.

### Notes to the reviewers; where to focus on

This only changes expectations for `matrix-mul-hlsl-codegen.slang` and `training-hlsl-codegen.slang`; the expected-failure removal is covered by the same targeted tests.
