### PR TITLE
Document principled problem-solving methodology and required PR description format

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,6 +52,30 @@ Add the "pr: breaking" label to your PR if you are introducing public API change
 or you are introducing changes to the Slang language that will cause the compiler to error out on existing Slang code.
 It is rare for a PR to be a breaking change.
 
+## Problem-solving methodology
+
+Follow the principled path, not the minimal-edit-distance path: fix root causes (usually upstream
+in an IR pass, lowering, or the AST/IR representation), not symptoms in emit/codegen. Question every
+change — if you cannot name a test that fails without it, it probably should not exist. Do not mask
+malformed AST/IR with guards or special cases; make the representation correct so consumers stay
+simple. When data is conceptually an unordered key→value set (e.g. witness-table / interface
+requirement entries), address it by role/key, never by position/index. Keep a scratch log
+throughout the task recording the problem, how issues cascade (one fix exposing the next), the fix
+for each and why it is principled (with a code trace), and rejected alternatives; distill that log
+into the PR description.
+
+## PR description format
+
+Write every PR description in this four-part format:
+
+1. **Motivation** — the problem, with a concrete example / motivating test case.
+2. **Proposed solution** — the approach and why it is principled.
+3. **Change summary** — the files/areas touched and what each does.
+4. **Process report** — explain every change with a logical reason. For a change addressing a
+   cascading issue, describe the issue (with its motivating test case) and justify the fix with a
+   code trace (the exact functions/insts involved), explaining why it is necessary and principled
+   rather than a workaround.
+
 ## Debugging
 
 If you encounter a bug related to a problematic instruction, it is often useful to trace the location where the instruction is created.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,7 +58,10 @@ Follow the principled path, not the minimal-edit-distance path: fix root causes 
 in an IR pass, lowering, or the AST/IR representation), not symptoms in emit/codegen. Question every
 change — if you cannot name a test that fails without it, it probably should not exist. Do not mask
 malformed AST/IR with guards or special cases; make the representation correct so consumers stay
-simple. When data is conceptually an unordered key→value set (e.g. witness-table / interface
+simple. For any code that handles a particular shape of input (AST node, IR inst, witness, type),
+always ask whether that shape is itself correct and principled or whether its upstream producer
+should be fixed instead — fix the producer when the shape is wrong — and record the answer in the
+PR description. When data is conceptually an unordered key→value set (e.g. witness-table / interface
 requirement entries), address it by role/key, never by position/index. Keep a scratch log
 throughout the task recording the problem, how issues cascade (one fix exposing the next), the fix
 for each and why it is principled (with a code trace), and rejected alternatives; distill that log
@@ -78,7 +81,10 @@ Write every PR description in this five-part format:
 5. **Process report** — explain every change with a logical reason. For a change addressing a
    cascading issue, describe the issue (with its motivating test case) and justify the fix with a
    code trace (the exact functions/insts involved), explaining why it is necessary and principled
-   rather than a workaround.
+   rather than a workaround. For any change that handles, guards, or special-cases a particular
+   input shape, the report must answer the input-shape check from the methodology — is that shape
+   correct and principled, or should its producer have been fixed instead? — so a reviewer can
+   confirm the fix sits at the right layer.
 
 Write for a reviewer without the full context in their head: ground each abstract claim in a
 concrete example, and wire explanations to the source (function name and file, or `file.cpp:line`).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,12 +47,12 @@ You can also use `./extras/formatting.sh --check-only` to verify formatting with
 
 ## Labeling your PR
 
-All PRs needs to be labeled as either "pr: non-breaking" or "pr: breaking".
-Add the "pr: breaking" label to your PR if you are introducing public API changes that breaks ABI compabibility,
+All PRs needs to be labeled as either "pr: non-breaking" or "pr: breaking change".
+Add the "pr: breaking change" label to your PR if you are introducing public API changes that breaks ABI compabibility,
 or you are introducing changes to the Slang language that will cause the compiler to error out on existing Slang code.
 It is rare for a PR to be a breaking change.
 
-## Problem-solving methodology
+## Problem-Solving Methodology
 
 Follow the principled path, not the minimal-edit-distance path: fix root causes (usually upstream
 in an IR pass, lowering, or the AST/IR representation), not symptoms in emit/codegen. Question every
@@ -64,17 +64,24 @@ throughout the task recording the problem, how issues cascade (one fix exposing 
 for each and why it is principled (with a code trace), and rejected alternatives; distill that log
 into the PR description.
 
-## PR description format
+## PR Description Format
 
-Write every PR description in this four-part format:
+Write every PR description in this five-part format:
 
 1. **Motivation** — the problem, with a concrete example / motivating test case.
 2. **Proposed solution** — the approach and why it is principled.
 3. **Change summary** — the files/areas touched and what each does.
-4. **Process report** — explain every change with a logical reason. For a change addressing a
+4. **Concepts and vocabulary** — a short glossary between the change summary and the process report.
+   Restate only the codebase-specific or subtle terms the report relies on (e.g. witness, facet,
+   the fixpoint solver, a non-obvious distinction the fix hinges on), as a reminder. Do not explain
+   basic, well-known concepts (interface, associated type) — assume them.
+5. **Process report** — explain every change with a logical reason. For a change addressing a
    cascading issue, describe the issue (with its motivating test case) and justify the fix with a
    code trace (the exact functions/insts involved), explaining why it is necessary and principled
    rather than a workaround.
+
+Write for a reviewer without the full context in their head: ground each abstract claim in a
+concrete example, and wire explanations to the source (function name and file, or `file.cpp:line`).
 
 ## Debugging
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Slang is a shading-language compiler and runtime implemented primarily in C++20 
 CMake.
 
 Key directories:
+
 - `source/`: core implementation, including `source/slang/`, `source/core/`,
   `source/compiler-core/`, and tools like `source/slangc/`.
 - `include/`: public API headers.
@@ -24,6 +25,7 @@ harnesses should still consult those `SKILL.md` files when a user asks for the w
 describe.
 
 Review-related skills:
+
 - `slang-review-clarity-workflow`: coordinate the end-to-end clarity review workflow.
 - `slang-review-clarity`: generate high-level clarity and explainability review candidates.
 - `slang-review-fine-grained-clarity`: generate line-by-line name/comment/type/function
@@ -65,6 +67,7 @@ If the skill is unavailable because skills cannot be installed or network access
 `docs/building.md` as the fallback build reference.
 
 Examples:
+
 - `/slang-build build debug`: build the Debug configuration.
 - `/slang-build rebuild debug`: discard the existing build directory and rebuild Debug.
 - `/slang-build configure releasewithdebug`: configure an optimized build with symbols.
@@ -75,6 +78,7 @@ host-tool selection, CMake preset choice, and clean-build steps defined by the s
 
 After building, run tests from the repository root using the generated `slang-test` binary in
 the directory for the selected configuration:
+
 - `build/Debug/bin/slang-test`: run the Debug test suite.
 - `build/RelWithDebInfo/bin/slang-test -use-test-server -server-count 8`: run optimized
   tests with symbols in parallel using test servers.
@@ -106,12 +110,14 @@ reasons (e.g., a security fix or feature addition touching many lines).
 ## Coding Style & Naming Conventions
 
 Formatting:
+
 - Use four-space indentation for C, C++, headers, and Slang files.
 - Run `./extras/formatting.sh` before committing to apply rules from `.clang-format`
   and `.editorconfig`.
 - Follow Allman braces, a 100-column limit, left-aligned pointers, and final newlines.
 
 Conventions:
+
 - Follow `docs/design/coding-conventions.md`.
 - Avoid STL containers, iostreams, RTTI, and exceptions for ordinary errors.
 - Use `UpperCamelCase` for types and `lowerCamelCase` for values.
@@ -123,12 +129,30 @@ Conventions:
 Add tests near related coverage in `tests/`.
 
 Slang tests:
+
 - Use leading directives such as `//TEST(smoke):SIMPLE:`.
 - Use `//DISABLE_TEST` only with a clear reason.
 - For targeted runs, pass a prefix, for example
   `build/Debug/bin/slang-test tests/diagnostics/my-test`.
 
 Unit tests live under `tools/slang-unit-test` and typically use `SLANG_UNIT_TEST(name)`.
+
+## Problem-Solving Methodology
+
+Follow the principled path, not the minimal-edit-distance path.
+
+- Fix root causes, not symptoms. A bug surfacing in emit/codegen is usually caused upstream (an IR
+  pass, lowering, type legalization, specialization, or the AST/IR representation). Trace it there.
+- Question every change. If you cannot name a test that fails without a change, it probably should
+  not exist. Ask whether the problem is telling you the direction/representation is flawed.
+- Do not mask. A guard, null-check, or special case that papers over malformed AST/IR/witness-table
+  data is a band-aid hiding a representation bug. Make the representation correct so consumers stay
+  simple.
+- Address conceptually unordered key→value data (witness-table / interface requirement entries) by
+  role/key, never by position/index.
+- Keep a working log throughout the task: the problem and a motivating example, how issues cascade
+  (one fix exposing the next), the fix chosen for each and why it is principled (with a code trace),
+  and rejected alternatives. Distill this log into the PR description; do not commit it.
 
 ## Commit & Pull Request Guidelines
 
@@ -139,3 +163,13 @@ Unit tests live under `tools/slang-unit-test` and typically use `SLANG_UNIT_TEST
 - Human contributors should sign the CLA when prompted.
 - For formatting failures, run installed hooks from `./extras/install-git-hooks.sh` or
   request the format bot with `/format`.
+
+Write the PR description in this four-part format:
+
+1. **Motivation** — the problem, with a concrete example / motivating test case.
+2. **Proposed solution** — the approach and why it is principled.
+3. **Change summary** — the files/areas touched and what each does.
+4. **Process report** — explain every change with a logical reason. For a change addressing a
+   cascading issue, describe the issue (with its motivating test case) and justify the fix with a
+   code trace (the exact functions/insts involved), explaining why it is necessary and principled
+   rather than a workaround.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,12 +164,19 @@ Follow the principled path, not the minimal-edit-distance path.
 - For formatting failures, run installed hooks from `./extras/install-git-hooks.sh` or
   request the format bot with `/format`.
 
-Write the PR description in this four-part format:
+Write the PR description in this five-part format:
 
 1. **Motivation** — the problem, with a concrete example / motivating test case.
 2. **Proposed solution** — the approach and why it is principled.
 3. **Change summary** — the files/areas touched and what each does.
-4. **Process report** — explain every change with a logical reason. For a change addressing a
+4. **Concepts and vocabulary** — a short glossary between the change summary and the process report.
+   Restate only the codebase-specific or subtle terms the report relies on (e.g. witness, facet,
+   the fixpoint solver, a non-obvious distinction the fix hinges on), as a reminder. Do not explain
+   basic, well-known concepts (interface, associated type) — assume them.
+5. **Process report** — explain every change with a logical reason. For a change addressing a
    cascading issue, describe the issue (with its motivating test case) and justify the fix with a
    code trace (the exact functions/insts involved), explaining why it is necessary and principled
    rather than a workaround.
+
+Write for a reviewer without the full context in their head: ground each abstract claim in a
+concrete example, and wire explanations to the source (function name and file, or `file.cpp:line`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,10 @@ Follow the principled path, not the minimal-edit-distance path.
 - Do not mask. A guard, null-check, or special case that papers over malformed AST/IR/witness-table
   data is a band-aid hiding a representation bug. Make the representation correct so consumers stay
   simple.
+- Interrogate the input shape. For any code that handles a particular shape of input (AST node, IR
+  inst, witness, type, ...), always ask: is that shape itself correct and principled, or should the
+  upstream producer be fixed instead? Fix the producer when the shape is wrong; handle it here only
+  when the shape is genuinely valid input. Record the answer in the PR description (Process report).
 - Address conceptually unordered key→value data (witness-table / interface requirement entries) by
   role/key, never by position/index.
 - Keep a working log throughout the task: the problem and a motivating example, how issues cascade
@@ -176,7 +180,10 @@ Write the PR description in this five-part format:
 5. **Process report** — explain every change with a logical reason. For a change addressing a
    cascading issue, describe the issue (with its motivating test case) and justify the fix with a
    code trace (the exact functions/insts involved), explaining why it is necessary and principled
-   rather than a workaround.
+   rather than a workaround. For any change that handles, guards, or special-cases a particular
+   input shape, the report must answer the input-shape check from the methodology — is that shape
+   correct and principled, or should its producer have been fixed instead? — so a reviewer can
+   confirm the fix sits at the right layer.
 
 Write for a reviewer without the full context in their head: ground each abstract claim in a
 concrete example, and wire explanations to the source (function name and file, or `file.cpp:line`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,11 +89,47 @@ if (auto foo = as<IRFoo>(inst))
 
 For variables that are set but never read outside an `if` (e.g., a plain local variable), use `SLANG_UNUSED(var)` with a comment explaining why.
 
+### Problem-Solving Methodology
+
+Follow the **principled path**, not the minimal-edit-distance path. The goal is a correct
+representation that is robust by construction, even when that means a larger rework.
+
+- **Fix root causes, not symptoms.** When a bug appears in emit/codegen, the cause is usually
+  upstream (an IR pass, type legalization, specialization, lowering, or the AST/IR representation
+  itself). Trace it there and fix it there.
+- **Question every change.** Before keeping a change, answer: _Why is this change necessary? What
+  test fails without it? Is this the right fix, or is the problem telling me the
+  direction/representation is flawed?_ If you cannot name a test that fails without a change, the
+  change probably should not exist.
+- **Do not mask.** A guard, null-check, or special case that papers over a malformed
+  AST/IR/witness-table is a band-aid that hides a representation bug. A guard that is never hit
+  under correct input is dead code. Prefer making the representation correct so consumers stay
+  simple.
+- **Prefer correct representation over edit distance.** If two surface forms _should_ be
+  equivalent, model them identically. If a consumer reads data by position/index/identity when the
+  data is conceptually an unordered key→value set (e.g. witness-table / interface requirement
+  entries), make the access by role/key, not by position.
+- **Keep a working log/report.** Maintain a scratch markdown document throughout the task that
+  records: the problem and a motivating example, road-blockers encountered, how issues **cascade**
+  (one fix exposing the next), the fix chosen for each and _why it is principled_ (with a concrete
+  code trace), and alternatives that were rejected and why. This log is what you distill into the
+  PR description below. (Keep the log out of the commit — it feeds the PR body, it is not a repo
+  artifact.)
+
 ### PR Workflow
 
 1. **Format your code**: Run `./extras/formatting.sh` before committing
 2. **Label your PR**: Use "pr: non-breaking" (default) or "pr: breaking" (for ABI/language breaking changes)
 3. **Include tests**: Add regression tests as `.slang` files under `tests/`
+4. **Write the PR description in this required four-part format:**
+   1. **Motivation** — the problem being solved, with a concrete example / motivating test case.
+   2. **Proposed solution** — the approach, and why it is the principled one.
+   3. **Change summary** — a table or list of the files/areas touched and what each does.
+   4. **Process report** — explain _every_ change with a logical reason. For a change that
+      addresses a **cascading** issue, describe the issue (with its motivating test case) and
+      justify why the fix is correct with a **code trace** (the exact functions/insts involved),
+      not just a description. State explicitly why each change is necessary and principled rather
+      than a workaround.
 
 ### Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,15 +121,24 @@ representation that is robust by construction, even when that means a larger rew
 1. **Format your code**: Run `./extras/formatting.sh` before committing
 2. **Label your PR**: Use "pr: non-breaking" (default) or "pr: breaking" (for ABI/language breaking changes)
 3. **Include tests**: Add regression tests as `.slang` files under `tests/`
-4. **Write the PR description in this required four-part format:**
+4. **Write the PR description in this required five-part format:**
    1. **Motivation** — the problem being solved, with a concrete example / motivating test case.
    2. **Proposed solution** — the approach, and why it is the principled one.
    3. **Change summary** — a table or list of the files/areas touched and what each does.
-   4. **Process report** — explain _every_ change with a logical reason. For a change that
+   4. **Concepts and vocabulary** — a short glossary, placed between the change summary and the
+      process report. Restate only the _codebase-specific or subtle_ terms the report relies on, as
+      a reminder for the reviewer (e.g. witness / `getSub`, facet / `getInheritanceInfo`, the
+      fixpoint solver, or a non-obvious distinction the fix hinges on). Do **not** explain basic,
+      well-known concepts (e.g. interface, associated type) — assume them.
+   5. **Process report** — explain _every_ change with a logical reason. For a change that
       addresses a **cascading** issue, describe the issue (with its motivating test case) and
       justify why the fix is correct with a **code trace** (the exact functions/insts involved),
       not just a description. State explicitly why each change is necessary and principled rather
       than a workaround.
+
+   Write for a reviewer who does not have the full context in their head: ground each abstract claim
+   in a concrete example, and wire explanations to the source — name the function and file (or
+   `file.cpp:line`) — so the reader can navigate from prose to code without searching.
 
 ### Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ representation that is robust by construction, even when that means a larger rew
 ### PR Workflow
 
 1. **Format your code**: Run `./extras/formatting.sh` before committing
-2. **Label your PR**: Use "pr: non-breaking" (default) or "pr: breaking" (for ABI/language breaking changes)
+2. **Label your PR**: Use "pr: non-breaking" (default) or "pr: breaking change" (for ABI/language breaking changes)
 3. **Include tests**: Add regression tests as `.slang` files under `tests/`
 4. **Write the PR description in this required five-part format:**
    1. **Motivation** — the problem being solved, with a concrete example / motivating test case.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,12 @@ representation that is robust by construction, even when that means a larger rew
   AST/IR/witness-table is a band-aid that hides a representation bug. A guard that is never hit
   under correct input is dead code. Prefer making the representation correct so consumers stay
   simple.
+- **Interrogate the input shape.** Whenever you write or change code that handles a particular
+  shape of input — an AST node, IR inst, witness, type, etc. — always ask: _is that input shape
+  itself correct and principled, or should the upstream producer of it be fixed instead?_ If the
+  shape is wrong or accidental, fix the producer; handle it here only when the shape is genuinely
+  valid input. This is the routine double-check that root-causing was done at the right layer, and
+  its answer is required in the PR description (see the Process report below).
 - **Prefer correct representation over edit distance.** If two surface forms _should_ be
   equivalent, model them identically. If a consumer reads data by position/index/identity when the
   data is conceptually an unordered key→value set (e.g. witness-table / interface requirement
@@ -134,7 +140,10 @@ representation that is robust by construction, even when that means a larger rew
       addresses a **cascading** issue, describe the issue (with its motivating test case) and
       justify why the fix is correct with a **code trace** (the exact functions/insts involved),
       not just a description. State explicitly why each change is necessary and principled rather
-      than a workaround.
+      than a workaround. For any change that handles, guards, or special-cases a particular input
+      shape, the report **must** answer the input-shape check from the methodology — _is that shape
+      correct and principled, or should its producer have been fixed instead?_ — so a reviewer can
+      confirm the fix sits at the right layer.
 
    Write for a reviewer who does not have the full context in their head: ground each abstract claim
    in a concrete example, and wire explanations to the source — name the function and file (or


### PR DESCRIPTION
## 1. Motivation

Recent agent-driven work converged on a way of working that produced robust fixes and reviewable
PRs: chase root causes instead of patching symptoms, justify every change, keep a running log of how
issues cascade, and write the PR description in a consistent, detailed format. That process was not
written down anywhere, so future agents (and contributors) had no canonical reference and the PR
description quality/format varied.

Concrete example of the target style: the four-part description in
[#11368](https://github.com/shader-slang/slang/pull/11368) (motivation → proposed solution → change
summary → a process report that explains every change and the cascade of fixes with code traces).
We want that to be the default, not a one-off.

## 2. Proposed solution

Codify the methodology and the required PR-description format in the repository's instruction files
so every agent picks them up automatically:

- **`CLAUDE.md`** is the canonical source — add a "Problem-Solving Methodology" subsection and
  extend "PR Workflow" with the required four-part description format.
- **`.github/copilot-instructions.md`** is what Copilot-style agents read — mirror the same two
  pieces of guidance there.
- **`AGENTS.md`** is the harness-agnostic guidelines file (Codex and other agents) — mirror the
  methodology and the four-part PR format there too, so coverage is uniform across all agents.

The guidance is principles, not new tooling: follow the principled path; fix root causes upstream
(IR passes, lowering, representation) rather than masking in emit; question whether each change is
necessary (name the failing test); never paper over malformed AST/IR with guards; address unordered
key→value data (witness-table / interface requirement entries) by role, not position; and keep a
working log that is distilled into the PR body.

## 3. Change summary

| File | Change |
|---|---|
| `CLAUDE.md` | New "### Problem-Solving Methodology" subsection; "### PR Workflow" extended with the required four-part PR-description format (motivation w/ test, proposed solution, change summary, process report with code traces). |
| `.github/copilot-instructions.md` | Mirrored "## Problem-solving methodology" and "## PR description format" sections (Copilot agents read this file, not `CLAUDE.md`). |
| `AGENTS.md` | Mirrored "## Problem-Solving Methodology" section and the four-part PR-description format under "## Commit & Pull Request Guidelines" (harness-agnostic guidelines read by Codex and other agents). |

Docs only — no code, no behavior change.

## 4. Process report

- **Add the methodology subsection to `CLAUDE.md`.** Necessary because the canonical instruction
  file had build/format/test/PR-label guidance but nothing on _how_ to approach a problem; agents
  had no instruction to prefer root-cause fixes over symptom patches or to avoid masking. Placed
  next to "PR Workflow" so it is read alongside the rest of the contribution workflow.
- **Extend "PR Workflow" with the four-part description format.** Necessary so PR descriptions are
  consistent and reviewable; the "process report" item specifically requires explaining cascading
  issues with code traces, which is what made the example PR auditable.
- **Mirror both into `.github/copilot-instructions.md` and `AGENTS.md`.** Necessary because
  different harnesses read different instruction files — Copilot reads the copilot file, and Codex
  and other agents read `AGENTS.md`; without mirroring, those agents would not receive the guidance.
  Kept concise in each (they are intentionally terser) while `CLAUDE.md` carries the fuller version,
  consistent with their existing relationship.

There is no code cascade to trace here (documentation-only). The content itself is the distillation
of the working log from #11368, per the methodology it describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
