### PR TITLE
Fix Linux coverage no-GPU runner failures

### DIFF
--- a/.github/workflows/ci-slang-coverage.yml
+++ b/.github/workflows/ci-slang-coverage.yml
@@ -235,6 +235,13 @@ jobs:
           export SLANG_RUN_SPIRV_VALIDATION=1
           export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1
 
+          # Match regular CPU-only CI's #11062 mitigation. Linux coverage runs
+          # CPU/LLVM and synthesized LLVM test paths on GitHub-hosted runners,
+          # so it can hit the same slang-llvm JIT AVX-512 SIGILL.
+          if [[ "${{ inputs.os }}" == "linux" ]]; then
+            export SLANG_DISABLE_AVX512=1
+          fi
+
           # Build slang-test arguments (same as regular CI)
           test_args=(
             "-expected-failure-list" "tests/expected-failure-github.txt"

--- a/tests/expected-failure-no-gpu.txt
+++ b/tests/expected-failure-no-gpu.txt
@@ -7,6 +7,7 @@ slang-unit-test-tool/replayRecord_gpu_printing.internal
 
 # CUDA tests require a GPU
 slang-unit-test-tool/cudaCodeGenBug.internal
+gfx-unit-test-tool/neuralSlangNetworkConverterCUDA.internal
 
 # Vulkan gfx-unit-tests require a Vulkan-capable GPU
 gfx-unit-test-tool/bufferBarrierVulkan.internal


### PR DESCRIPTION
## Summary

Linux coverage runs on GitHub-hosted no-GPU runners, but they execute a broader test set than normal CPU-only CI. This PR fixes two Linux coverage-only failures exposed by that setup:

- Export `SLANG_DISABLE_AVX512=1` for Linux coverage test runs. The recent nightly failure in https://github.com/shader-slang/slang/actions/runs/26733106828/job/78780859217 matches the old #11062 failure signature: `slang-test` exits with SIGILL immediately after the autodiff LLVM test sequence around `getter-setter` / `global-param-hoisting`. Regular CPU-only CI already uses this mitigation.
- Add `gfx-unit-test-tool/neuralSlangNetworkConverterCUDA.internal` to `tests/expected-failure-no-gpu.txt`. The test requires a CUDA-capable GPU/driver and fails on the Linux coverage runner with `rhiCudaDriverApiInit(): could not find symbol "cuGetErrorString"` before it can cleanly skip itself.

This is intentionally separate from #11332, which fixes the macOS coverage replay exception issue.

## Testing

- `git diff --check -- .github/workflows/ci-slang-coverage.yml tests/expected-failure-no-gpu.txt`
