### PR TITLE
slang-test: Reorder init for disabled LLVM backend

### DIFF
--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -5841,6 +5841,11 @@ SlangResult innerMain(int argc, char** argv)
             SLANG_CPP_SOURCE,
             SLANG_SHADER_HOST_CALLABLE);
 
+        if (hasLlvm)
+        {
+            SLANG_RETURN_ON_FAIL(context.locateLLVMFileCheck());
+        }
+
         if (hasLlvm && hostCallableCompiler == SLANG_PASS_THROUGH_LLVM && SLANG_PROCESSOR_X86)
         {
             // TODO(JS)

--- a/tools/slang-test/test-context.cpp
+++ b/tools/slang-test/test-context.cpp
@@ -92,7 +92,7 @@ TestReporter* TestContext::getTestReporter()
     return m_reporters[slangTestThreadIndex];
 }
 
-SlangResult TestContext::locateFileCheck()
+SlangResult TestContext::locateLLVMFileCheck()
 {
     DefaultSharedLibraryLoader* loader = DefaultSharedLibraryLoader::getSingleton();
 
@@ -121,8 +121,6 @@ Result TestContext::init(const char* inExePath)
     exePath = inExePath;
     SLANG_RETURN_ON_FAIL(TestToolUtil::getExeDirectoryPath(inExePath, exeDirectoryPath));
     SLANG_RETURN_ON_FAIL(TestToolUtil::getDllDirectoryPath(inExePath, dllDirectoryPath));
-
-    SLANG_RETURN_ON_FAIL(locateFileCheck());
 
     return SLANG_OK;
 }

--- a/tools/slang-test/test-context.h
+++ b/tools/slang-test/test-context.h
@@ -205,10 +205,12 @@ public:
 
     Slang::IFileCheck* getFileCheck() { return m_fileCheck; };
 
+    /// Invoke after it has been determined that the LLVM render target is enabled
+    SlangResult locateLLVMFileCheck();
+
 protected:
     SlangResult _createJSONRPCConnection(Slang::RefPtr<Slang::JSONRPCConnection>& out);
 
-    SlangResult locateFileCheck();
 
     struct SharedLibraryTool
     {


### PR DESCRIPTION
Fix the case when the LLVM backend has been disabled from the build. TestContext::locateFileCheck() would fail on

    loader->loadSharedLibrary("slang-llvm", ...)

because slang-llvm is nowhere to be found. To gracefully support this case, rename TestContext::locateFileCheck() ->
TestContext::locateLLVMFileCheck() and invoke it only after we have determined that we have LLVM.

Fixes #11390