### PR TITLE
Wire REVIEW.md into CodeRabbit and mark it agent-facing

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -212,4 +212,10 @@ chat:
   art: false
 
 knowledge_base:
-  opt_out: true
+  opt_out: false
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "REVIEW.md"
+      - "CLAUDE.md"
+      - "AGENTS.md"

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,5 +1,7 @@
 # PR Review Protocol
 
+> For AI review agents (Claude GitHub Actions + CodeRabbit), not humans.
+
 Follow this protocol. Do NOT skip steps. Do NOT write a free-form review. Do NOT post a review without dispatching all 6 teammates first.
 
 ## Step 1: Fetch the PR diff and save to file


### PR DESCRIPTION
## What

Two small changes around `REVIEW.md`, the PR-review protocol:

1. **Mark `REVIEW.md` as agent-facing.** Added a one-line note at the top making it explicit the document is guidance for AI review agents (Claude GitHub Actions + CodeRabbit), not humans.
2. **Wire `REVIEW.md` into CodeRabbit.** Connected it via `knowledge_base.code_guidelines.filePatterns` so CodeRabbit scans it and applies it as review criteria. Also lists `CLAUDE.md` and `AGENTS.md`.

## Why the `opt_out` flip

`code_guidelines` lives under `knowledge_base`, which was fully disabled by `opt_out: true`. To wire `REVIEW.md` into CodeRabbit via `knowledge_base.code_guidelines`, the knowledge base must be enabled — so `opt_out` is changed from `true` to `false`. Note this means CodeRabbit will retain knowledge-base data (guidelines, learnings).

## Diff

- `.coderabbit.yaml` — `opt_out: false` + `code_guidelines` block
- `REVIEW.md` — one-line audience note