### PR TITLE
ci-slang-coverage: enable agentic suite with -expected-failure-list

### DIFF
--- a/.github/workflows/ci-slang-coverage.yml
+++ b/.github/workflows/ci-slang-coverage.yml
@@ -272,16 +272,17 @@ jobs:
 
           # --with-synthesis runs a second pass with -only-synthesized to
           # exercise backend emit paths without a GPU.
-          # `run-coverage.sh` also supports `--with-agentic-tests`, which
-          # rolls the doc-anchored bundles under docs/generated/tests/
-          # into the merged coverage report. We deliberately do NOT pass
-          # it here yet — the suite is still being stabilized under
-          # ci-agentic-tests-nightly.yml; flip the switch once the
-          # nightly is green steady-state.
+          # --with-agentic-tests rolls the doc-anchored bundles under
+          # docs/generated/tests/ into the merged coverage report.
+          # run-coverage.sh passes -expected-failure-list pointing at
+          # docs/generated/tests/_meta/expected-failures.txt, so the
+          # agentic pass uses the same gate as ci-agentic-tests-nightly
+          # (only unexpected failures surface, and they're tolerated
+          # here so coverage data is collected either way).
           # Retry once on failure to handle intermittent test failures.
-          if ! ./tools/coverage/run-coverage.sh --with-synthesis "${test_args[@]}"; then
+          if ! ./tools/coverage/run-coverage.sh --with-synthesis --with-agentic-tests "${test_args[@]}"; then
             echo "::warning::First coverage run failed. Retrying..."
-            ./tools/coverage/run-coverage.sh --with-synthesis "${test_args[@]}"
+            ./tools/coverage/run-coverage.sh --with-synthesis --with-agentic-tests "${test_args[@]}"
           fi
 
       - name: Run Tests with Coverage (Windows)

--- a/docs/generated/tests/_meta/agentic-coverage-excludes.txt
+++ b/docs/generated/tests/_meta/agentic-coverage-excludes.txt
@@ -24,11 +24,30 @@
 # documenting the symptom and how it was identified (CI run URL +
 # the last-printed test before the crash), so a future maintainer
 # can verify whether the underlying issue is still present.
+#
+# Staleness signal
+# ----------------
+# Unlike `-expected-failure-list`, `-exclude-prefix` has no
+# "passing tests that are expected to fail" reporter, so entries
+# here can rot silently once the underlying crash is fixed. To
+# audit the list periodically:
+#   1. Compile slang with coverage instrumentation locally.
+#   2. Remove an entry below and run
+#      `./tools/coverage/run-coverage.sh --with-agentic-tests`
+#      (or trigger the coverage workflow on a branch with the
+#      entry removed).
+#   3. If the run completes without a SIGSEGV in slang-test, the
+#      underlying crash has been fixed — drop the entry for real.
+# A green ci-agentic-tests-nightly run on the same test is a
+# necessary but NOT sufficient condition: the nightly uses an
+# uninstrumented binary, and the crash here is
+# coverage-instrumentation-specific.
 
 # Run 26813684019 (sequential reproducer with -server-count 1):
 # SIGSEGV in slang-test immediately after
-# ir-reference/metadata/type-layout-base.slang passes. Already a
-# known Linux failure on the uninstrumented nightly (Cluster C in
-# expected-failures.txt); coverage instrumentation escalates that
-# failure into a SIGSEGV inside the slang-test orchestrator.
+# ir-reference/metadata/type-layout-base.slang passes. The same
+# test is already listed in expected-failures.txt (it fails on the
+# uninstrumented Linux nightly); coverage instrumentation
+# escalates that failure into a SIGSEGV inside the slang-test
+# orchestrator, which kills the rest of the suite.
 docs/generated/tests/ir-reference/metadata/unorm-attr-on-buffer-element.slang

--- a/docs/generated/tests/_meta/agentic-coverage-excludes.txt
+++ b/docs/generated/tests/_meta/agentic-coverage-excludes.txt
@@ -1,0 +1,34 @@
+# agentic-coverage-excludes.txt — paths skipped in the coverage agentic pass
+#
+# `tools/coverage/run-coverage.sh` reads this file and appends one
+# `-exclude-prefix` flag to the agentic slang-test invocation for each
+# entry. The agentic pass under coverage instrumentation can SIGSEGV
+# inside slang-test on certain tests; the orchestrator dies and takes
+# the tail of the suite down with it, so we exclude those tests up
+# front to keep the rest of the suite running and producing coverage.
+#
+# This file is NOT consulted by ci-agentic-tests-nightly.yml — those
+# tests still run in the nightly against the uninstrumented binary,
+# where they bucket as `failed(expected)` via expected-failures.txt
+# where appropriate. The exclude is purely a coverage-stability hack.
+#
+# Format
+# ------
+# One path per line. Lines starting with `#` and blank lines are
+# ignored. Comments after `#` on a path line are also stripped. Each
+# entry is passed verbatim to slang-test's `-exclude-prefix` flag,
+# which is a path-prefix filter — listing a directory excludes
+# everything under it.
+#
+# Each entry SHOULD be accompanied by a `#` comment block above it
+# documenting the symptom and how it was identified (CI run URL +
+# the last-printed test before the crash), so a future maintainer
+# can verify whether the underlying issue is still present.
+
+# Run 26813684019 (sequential reproducer with -server-count 1):
+# SIGSEGV in slang-test immediately after
+# ir-reference/metadata/type-layout-base.slang passes. Already a
+# known Linux failure on the uninstrumented nightly (Cluster C in
+# expected-failures.txt); coverage instrumentation escalates that
+# failure into a SIGSEGV inside the slang-test orchestrator.
+docs/generated/tests/ir-reference/metadata/unorm-attr-on-buffer-element.slang

--- a/tools/coverage/run-coverage.sh
+++ b/tools/coverage/run-coverage.sh
@@ -151,12 +151,21 @@ else
       "-test-dir" "docs/generated/tests"
       "-expected-failure-list" "docs/generated/tests/_meta/expected-failures.txt"
     )
-    # Inherit server-count from the main pass when in use.
+    # Inherit a few flags from the main pass:
+    #   -use-test-server / -server-count: match the main-pass
+    #     parallelism so the test-server pool is reused.
+    #   -synthesizedTestApi: the macOS coverage step disables
+    #     `-llvm`-synthesized variants via this flag (see
+    #     ci-slang-coverage.yml; coverage instrumentation crashes
+    #     in those tests). Forward it so the agentic pass on macOS
+    #     skips the same variants instead of replaying the crash.
     for ((i = 0; i < ${#TEST_ARGS[@]}; i++)); do
       if [[ "${TEST_ARGS[i]}" == "-use-test-server" ]]; then
         AGENTIC_TEST_ARGS+=("-use-test-server")
       elif [[ "${TEST_ARGS[i]}" == "-server-count" ]]; then
         AGENTIC_TEST_ARGS+=("-server-count" "${TEST_ARGS[i + 1]}")
+      elif [[ "${TEST_ARGS[i]}" == "-synthesizedTestApi" ]]; then
+        AGENTIC_TEST_ARGS+=("-synthesizedTestApi" "${TEST_ARGS[i + 1]}")
       fi
     done
     AGENTIC_EXIT=0

--- a/tools/coverage/run-coverage.sh
+++ b/tools/coverage/run-coverage.sh
@@ -168,12 +168,20 @@ else
     # Walk TEST_ARGS one token at a time and classify each:
     #   - Agentic-overridden value-taking flags (-test-dir,
     #     -expected-failure-list, -server-count): skip flag + value.
-    #   - Other known value-taking flags: inherit flag + value.
-    #   - Lone option flags ("-*"): inherit as-is.
+    #   - Known no-value option flags (used in the coverage workflow's
+    #     test_args): inherit as a lone token.
+    #   - Any other "-*" flag: assume it takes a value and inherit
+    #     flag + value. Default-to-two-arg is the safer policy: if a
+    #     future maintainer adds e.g. `-capability spirv_1_5` to the
+    #     workflow's test_args, the value is preserved instead of
+    #     being silently dropped as a "bare positional." If a new
+    #     no-value flag is ever added to test_args, add it to the
+    #     explicit no-value case above so the next token isn't
+    #     swallowed as a phantom value.
     #   - Bare positional tokens (test selectors): drop. The agentic
     #     pass runs over its own -test-dir; inheriting positionals
     #     from the main pass would silently narrow the agentic run.
-    #     CI doesn't pass bare positionals here today, so this only
+    #     CI doesn't pass bare positionals here today; this only
     #     guards local-dev `run-coverage.sh --with-agentic-tests foo`.
     i=0
     while [ "$i" -lt "${#TEST_ARGS[@]}" ]; do
@@ -182,13 +190,18 @@ else
       -test-dir | -expected-failure-list | -server-count)
         i=$((i + 2))
         ;;
-      -enable-debug-layers | -synthesizedTestApi)
-        AGENTIC_TEST_ARGS+=("$arg" "${TEST_ARGS[i + 1]}")
-        i=$((i + 2))
-        ;;
-      -*)
+      -use-test-server | -skip-reference-image-generation | -show-adapter-info | -only-synthesized)
         AGENTIC_TEST_ARGS+=("$arg")
         i=$((i + 1))
+        ;;
+      -*)
+        if [ "$((i + 1))" -lt "${#TEST_ARGS[@]}" ]; then
+          AGENTIC_TEST_ARGS+=("$arg" "${TEST_ARGS[i + 1]}")
+          i=$((i + 2))
+        else
+          AGENTIC_TEST_ARGS+=("$arg")
+          i=$((i + 1))
+        fi
         ;;
       *)
         i=$((i + 1))

--- a/tools/coverage/run-coverage.sh
+++ b/tools/coverage/run-coverage.sh
@@ -153,14 +153,19 @@ else
     # needs suppression, the entry must include the `.N` suffix —
     # there is no canonicalization on this path.
     # Build the agentic invocation: start with the agentic-specific
-    # overrides (test-dir and expected-failure-list — those are what
-    # differ from the main pass), then inherit every other flag from
-    # the main pass's TEST_ARGS so settings like -use-test-server,
-    # -server-count, -synthesizedTestApi, -skip-reference-image-
-    # generation, -enable-debug-layers, etc. apply uniformly. This
-    # keeps the agentic pass running in the same slang-test mode as
-    # the main pass; the only differences are which tests run and
-    # which list of failures to expect.
+    # overrides (test-dir and expected-failure-list — those are
+    # what differ from the main pass), then inherit every other
+    # flag from the main pass's TEST_ARGS so settings like
+    # -use-test-server, -synthesizedTestApi,
+    # -skip-reference-image-generation, -enable-debug-layers, etc.
+    # apply uniformly. -server-count is also overridden, but in a
+    # dedicated block further down (the value gets forced to 1 for
+    # sequential execution under coverage instrumentation; see the
+    # comment at the `AGENTIC_TEST_ARGS+=("-server-count" "1")`
+    # line for the rationale). This keeps the agentic pass running
+    # in the same slang-test mode as the main pass; the only
+    # differences are which tests run, which list of failures to
+    # expect, and forced sequential execution.
     AGENTIC_TEST_ARGS=(
       "-test-dir" "docs/generated/tests"
       "-expected-failure-list" "docs/generated/tests/_meta/expected-failures.txt"

--- a/tools/coverage/run-coverage.sh
+++ b/tools/coverage/run-coverage.sh
@@ -167,7 +167,7 @@ else
     )
     # Walk TEST_ARGS one token at a time and classify each:
     #   - Agentic-overridden value-taking flags (-test-dir,
-    #     -expected-failure-list): skip flag + value.
+    #     -expected-failure-list, -server-count): skip flag + value.
     #   - Other known value-taking flags: inherit flag + value.
     #   - Lone option flags ("-*"): inherit as-is.
     #   - Bare positional tokens (test selectors): drop. The agentic
@@ -179,10 +179,10 @@ else
     while [ "$i" -lt "${#TEST_ARGS[@]}" ]; do
       arg="${TEST_ARGS[i]}"
       case "$arg" in
-      -test-dir | -expected-failure-list)
+      -test-dir | -expected-failure-list | -server-count)
         i=$((i + 2))
         ;;
-      -enable-debug-layers | -synthesizedTestApi | -server-count)
+      -enable-debug-layers | -synthesizedTestApi)
         AGENTIC_TEST_ARGS+=("$arg" "${TEST_ARGS[i + 1]}")
         i=$((i + 2))
         ;;
@@ -195,6 +195,15 @@ else
         ;;
       esac
     done
+    # Force sequential execution for the agentic pass under coverage.
+    # On Linux coverage we hit a deterministic SIGSEGV in slang-test
+    # (see run 26810699621) that kills the orchestrator and loses the
+    # tail of the suite. With -server-count 1 the crashing test is
+    # unambiguously the last one printed before the segfault, so we
+    # can identify it and exclude it (or fix it) on the next iter.
+    # Sequential adds wall time but is once-a-day and coverage data
+    # quality > runner-minute savings.
+    AGENTIC_TEST_ARGS+=("-server-count" "1")
     # Retry once on crash (exit > 128 = killed by signal). The suite
     # is long (~2680 bundles); a single SIGSEGV in slang-test mid-run
     # loses the rest of the pass and produces minimal coverage uplift.

--- a/tools/coverage/run-coverage.sh
+++ b/tools/coverage/run-coverage.sh
@@ -197,13 +197,32 @@ else
     done
     # Force sequential execution for the agentic pass under coverage.
     # On Linux coverage we hit a deterministic SIGSEGV in slang-test
-    # (see run 26810699621) that kills the orchestrator and loses the
-    # tail of the suite. With -server-count 1 the crashing test is
-    # unambiguously the last one printed before the segfault, so we
-    # can identify it and exclude it (or fix it) on the next iter.
-    # Sequential adds wall time but is once-a-day and coverage data
-    # quality > runner-minute savings.
+    # (runs 26810699621, 26813684019) that kills the orchestrator and
+    # loses the tail of the suite. With -server-count 1 the crashing
+    # test is unambiguously the last one printed before the segfault,
+    # so we can identify it and add it to AGENTIC_COVERAGE_EXCLUDES
+    # (below). Once the list is stable we may flip back to parallel.
+    # Sequential adds wall time on Linux coverage but the workflow
+    # runs once a day; data quality > runner-minute savings.
     AGENTIC_TEST_ARGS+=("-server-count" "1")
+
+    # Tests that crash slang-test under coverage instrumentation. The
+    # orchestrator dies (SIGSEGV) on these and takes the rest of the
+    # suite down, so they're excluded from the coverage agentic pass
+    # via -exclude-prefix. They still run in ci-agentic-tests-nightly
+    # where the binary has no coverage instrumentation and the
+    # failures just bucket as expected-fail.
+    AGENTIC_COVERAGE_EXCLUDES=(
+      # Run 26813684019 (sequential reproducer): crashes immediately
+      # after metadata/type-layout-base.slang passes. Already a known
+      # Linux failure on the uninstrumented nightly (Cluster C in
+      # docs/generated/tests/_meta/expected-failures.txt); coverage
+      # instrumentation escalates the failure to SIGSEGV.
+      "docs/generated/tests/ir-reference/metadata/unorm-attr-on-buffer-element.slang"
+    )
+    for excl in "${AGENTIC_COVERAGE_EXCLUDES[@]}"; do
+      AGENTIC_TEST_ARGS+=("-exclude-prefix" "$excl")
+    done
     # Retry once on crash (exit > 128 = killed by signal). The suite
     # is long (~2680 bundles); a single SIGSEGV in slang-test mid-run
     # loses the rest of the pass and produces minimal coverage uplift.

--- a/tools/coverage/run-coverage.sh
+++ b/tools/coverage/run-coverage.sh
@@ -142,7 +142,15 @@ else
   if [[ "$WITH_AGENTIC_TESTS" == "true" ]]; then
     echo
     echo "Running agentic test suite (docs/generated/tests/) for coverage..."
-    AGENTIC_TEST_ARGS=("-test-dir" "docs/generated/tests")
+    # Use the agentic suite's own expected-failure list (matches what
+    # ci-agentic-tests-nightly.yml passes). slang-test reclassifies
+    # listed failures as `failed(expected)` and exits 0 when only
+    # those occur, so this call only fails on UNEXPECTED failures —
+    # the same gate the nightly enforces.
+    AGENTIC_TEST_ARGS=(
+      "-test-dir" "docs/generated/tests"
+      "-expected-failure-list" "docs/generated/tests/_meta/expected-failures.txt"
+    )
     # Inherit server-count from the main pass when in use.
     for ((i = 0; i < ${#TEST_ARGS[@]}; i++)); do
       if [[ "${TEST_ARGS[i]}" == "-use-test-server" ]]; then
@@ -156,7 +164,7 @@ else
     if [ "$AGENTIC_EXIT" -gt 128 ]; then
       echo "Warning: agentic-test pass crashed (signal $((AGENTIC_EXIT - 128)))"
     elif [ "$AGENTIC_EXIT" -ne 0 ]; then
-      echo "Note: agentic-test pass had test failures (exit code $AGENTIC_EXIT). Coverage data still collected."
+      echo "Note: agentic-test pass had unexpected test failures (exit code $AGENTIC_EXIT). Coverage data still collected; see ci-agentic-tests-nightly.yml for the authoritative pass/fail gate."
     fi
   fi
 

--- a/tools/coverage/run-coverage.sh
+++ b/tools/coverage/run-coverage.sh
@@ -206,23 +206,24 @@ else
     # runs once a day; data quality > runner-minute savings.
     AGENTIC_TEST_ARGS+=("-server-count" "1")
 
-    # Tests that crash slang-test under coverage instrumentation. The
-    # orchestrator dies (SIGSEGV) on these and takes the rest of the
-    # suite down, so they're excluded from the coverage agentic pass
-    # via -exclude-prefix. They still run in ci-agentic-tests-nightly
-    # where the binary has no coverage instrumentation and the
-    # failures just bucket as expected-fail.
-    AGENTIC_COVERAGE_EXCLUDES=(
-      # Run 26813684019 (sequential reproducer): crashes immediately
-      # after metadata/type-layout-base.slang passes. Already a known
-      # Linux failure on the uninstrumented nightly (Cluster C in
-      # docs/generated/tests/_meta/expected-failures.txt); coverage
-      # instrumentation escalates the failure to SIGSEGV.
-      "docs/generated/tests/ir-reference/metadata/unorm-attr-on-buffer-element.slang"
-    )
-    for excl in "${AGENTIC_COVERAGE_EXCLUDES[@]}"; do
-      AGENTIC_TEST_ARGS+=("-exclude-prefix" "$excl")
-    done
+    # Read coverage-only exclude list from
+    # docs/generated/tests/_meta/agentic-coverage-excludes.txt and add
+    # one -exclude-prefix flag per entry. These are tests that crash
+    # slang-test under coverage instrumentation (the orchestrator dies
+    # SIGSEGV and loses the tail of the suite); they still run in
+    # ci-agentic-tests-nightly against the uninstrumented binary.
+    AGENTIC_COVERAGE_EXCLUDES_FILE="$REPO_ROOT/docs/generated/tests/_meta/agentic-coverage-excludes.txt"
+    if [ -f "$AGENTIC_COVERAGE_EXCLUDES_FILE" ]; then
+      while IFS= read -r line || [ -n "$line" ]; do
+        # Strip trailing comment, then trim whitespace.
+        line="${line%%#*}"
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        if [ -n "$line" ]; then
+          AGENTIC_TEST_ARGS+=("-exclude-prefix" "$line")
+        fi
+      done <"$AGENTIC_COVERAGE_EXCLUDES_FILE"
+    fi
     # Retry once on crash (exit > 128 = killed by signal). The suite
     # is long (~2680 bundles); a single SIGSEGV in slang-test mid-run
     # loses the rest of the pass and produces minimal coverage uplift.

--- a/tools/coverage/run-coverage.sh
+++ b/tools/coverage/run-coverage.sh
@@ -147,26 +147,31 @@ else
     # listed failures as `failed(expected)` and exits 0 when only
     # those occur, so this call only fails on UNEXPECTED failures —
     # the same gate the nightly enforces.
+    # Build the agentic invocation: start with the agentic-specific
+    # overrides (test-dir and expected-failure-list — those are what
+    # differ from the main pass), then inherit every other flag from
+    # the main pass's TEST_ARGS so settings like -use-test-server,
+    # -server-count, -synthesizedTestApi, -skip-reference-image-
+    # generation, -enable-debug-layers, etc. apply uniformly. This
+    # keeps the agentic pass running in the same slang-test mode as
+    # the main pass; the only differences are which tests run and
+    # which list of failures to expect.
     AGENTIC_TEST_ARGS=(
       "-test-dir" "docs/generated/tests"
       "-expected-failure-list" "docs/generated/tests/_meta/expected-failures.txt"
     )
-    # Inherit a few flags from the main pass:
-    #   -use-test-server / -server-count: match the main-pass
-    #     parallelism so the test-server pool is reused.
-    #   -synthesizedTestApi: the macOS coverage step disables
-    #     `-llvm`-synthesized variants via this flag (see
-    #     ci-slang-coverage.yml; coverage instrumentation crashes
-    #     in those tests). Forward it so the agentic pass on macOS
-    #     skips the same variants instead of replaying the crash.
-    for ((i = 0; i < ${#TEST_ARGS[@]}; i++)); do
-      if [[ "${TEST_ARGS[i]}" == "-use-test-server" ]]; then
-        AGENTIC_TEST_ARGS+=("-use-test-server")
-      elif [[ "${TEST_ARGS[i]}" == "-server-count" ]]; then
-        AGENTIC_TEST_ARGS+=("-server-count" "${TEST_ARGS[i + 1]}")
-      elif [[ "${TEST_ARGS[i]}" == "-synthesizedTestApi" ]]; then
-        AGENTIC_TEST_ARGS+=("-synthesizedTestApi" "${TEST_ARGS[i + 1]}")
-      fi
+    i=0
+    while [ "$i" -lt "${#TEST_ARGS[@]}" ]; do
+      arg="${TEST_ARGS[i]}"
+      case "$arg" in
+      -test-dir | -expected-failure-list)
+        # Skip the flag and its value — agentic overrides these.
+        i=$((i + 2))
+        continue
+        ;;
+      esac
+      AGENTIC_TEST_ARGS+=("$arg")
+      i=$((i + 1))
     done
     # Retry once on crash (exit > 128 = killed by signal). The suite
     # is long (~2680 bundles); a single SIGSEGV in slang-test mid-run

--- a/tools/coverage/run-coverage.sh
+++ b/tools/coverage/run-coverage.sh
@@ -165,18 +165,35 @@ else
       "-test-dir" "docs/generated/tests"
       "-expected-failure-list" "docs/generated/tests/_meta/expected-failures.txt"
     )
+    # Walk TEST_ARGS one token at a time and classify each:
+    #   - Agentic-overridden value-taking flags (-test-dir,
+    #     -expected-failure-list): skip flag + value.
+    #   - Other known value-taking flags: inherit flag + value.
+    #   - Lone option flags ("-*"): inherit as-is.
+    #   - Bare positional tokens (test selectors): drop. The agentic
+    #     pass runs over its own -test-dir; inheriting positionals
+    #     from the main pass would silently narrow the agentic run.
+    #     CI doesn't pass bare positionals here today, so this only
+    #     guards local-dev `run-coverage.sh --with-agentic-tests foo`.
     i=0
     while [ "$i" -lt "${#TEST_ARGS[@]}" ]; do
       arg="${TEST_ARGS[i]}"
       case "$arg" in
       -test-dir | -expected-failure-list)
-        # Skip the flag and its value — agentic overrides these.
         i=$((i + 2))
-        continue
+        ;;
+      -enable-debug-layers | -synthesizedTestApi | -server-count)
+        AGENTIC_TEST_ARGS+=("$arg" "${TEST_ARGS[i + 1]}")
+        i=$((i + 2))
+        ;;
+      -*)
+        AGENTIC_TEST_ARGS+=("$arg")
+        i=$((i + 1))
+        ;;
+      *)
+        i=$((i + 1))
         ;;
       esac
-      AGENTIC_TEST_ARGS+=("$arg")
-      i=$((i + 1))
     done
     # Retry once on crash (exit > 128 = killed by signal). The suite
     # is long (~2680 bundles); a single SIGSEGV in slang-test mid-run

--- a/tools/coverage/run-coverage.sh
+++ b/tools/coverage/run-coverage.sh
@@ -142,11 +142,16 @@ else
   if [[ "$WITH_AGENTIC_TESTS" == "true" ]]; then
     echo
     echo "Running agentic test suite (docs/generated/tests/) for coverage..."
-    # Use the agentic suite's own expected-failure list (matches what
-    # ci-agentic-tests-nightly.yml passes). slang-test reclassifies
-    # listed failures as `failed(expected)` and exits 0 when only
-    # those occur, so this call only fails on UNEXPECTED failures —
-    # the same gate the nightly enforces.
+    # Use the agentic suite's own expected-failure list.
+    # `slang-test -expected-failure-list` does EXACT-STRING matching:
+    # listed paths get reclassified to `failed(expected)` (slang-test's
+    # TestResult::ExpectedFail), the run exits 0 when only those
+    # occur, and any entry that has started passing is reported under
+    # "passing tests that are expected to fail" so it can be removed.
+    # Caveat: multi-//TEST tests are named per sub-test
+    # (`foo.slang`, `foo.slang.1`, …), so if a specific sub-test
+    # needs suppression, the entry must include the `.N` suffix —
+    # there is no canonicalization on this path.
     # Build the agentic invocation: start with the agentic-specific
     # overrides (test-dir and expected-failure-list — those are what
     # differ from the main pass), then inherit every other flag from
@@ -178,9 +183,13 @@ else
     # loses the rest of the pass and produces minimal coverage uplift.
     # Profraws from the first attempt are kept on disk and accumulate
     # with the retry's so coverage from both runs merges into the
-    # report. Retries only fire on crashes, not on unexpected test
-    # failures (those repeat deterministically and would just waste
-    # runner time).
+    # report.
+    #
+    # Retries only fire on crashes, not on unexpected test failures
+    # (those repeat deterministically and would just waste runner
+    # time). The retry helps *flaky* crashes — for a reproducible
+    # SIGSEGV the second attempt is pure overhead and will crash at
+    # the same point. The 2-attempt cap bounds that cost.
     AGENTIC_MAX_ATTEMPTS=2
     AGENTIC_EXIT=0
     for attempt in $(seq 1 $AGENTIC_MAX_ATTEMPTS); do

--- a/tools/coverage/run-coverage.sh
+++ b/tools/coverage/run-coverage.sh
@@ -168,10 +168,32 @@ else
         AGENTIC_TEST_ARGS+=("-synthesizedTestApi" "${TEST_ARGS[i + 1]}")
       fi
     done
+    # Retry once on crash (exit > 128 = killed by signal). The suite
+    # is long (~2680 bundles); a single SIGSEGV in slang-test mid-run
+    # loses the rest of the pass and produces minimal coverage uplift.
+    # Profraws from the first attempt are kept on disk and accumulate
+    # with the retry's so coverage from both runs merges into the
+    # report. Retries only fire on crashes, not on unexpected test
+    # failures (those repeat deterministically and would just waste
+    # runner time).
+    AGENTIC_MAX_ATTEMPTS=2
     AGENTIC_EXIT=0
-    "$SLANG_TEST" "${AGENTIC_TEST_ARGS[@]}" || AGENTIC_EXIT=$?
+    for attempt in $(seq 1 $AGENTIC_MAX_ATTEMPTS); do
+      if [ "$attempt" -gt 1 ]; then
+        echo "Retrying agentic-test pass (attempt $attempt of $AGENTIC_MAX_ATTEMPTS)..."
+      fi
+      AGENTIC_EXIT=0
+      "$SLANG_TEST" "${AGENTIC_TEST_ARGS[@]}" || AGENTIC_EXIT=$?
+      if [ "$AGENTIC_EXIT" -le 128 ]; then
+        # Not a crash — passed, or had expected/unexpected failures.
+        # Don't retry; those don't change on a re-run.
+        break
+      fi
+      echo "Warning: agentic-test pass crashed (signal $((AGENTIC_EXIT - 128))) on attempt $attempt of $AGENTIC_MAX_ATTEMPTS"
+    done
+
     if [ "$AGENTIC_EXIT" -gt 128 ]; then
-      echo "Warning: agentic-test pass crashed (signal $((AGENTIC_EXIT - 128)))"
+      echo "Warning: agentic-test pass crashed on all $AGENTIC_MAX_ATTEMPTS attempts (signal $((AGENTIC_EXIT - 128))). Partial coverage data still collected."
     elif [ "$AGENTIC_EXIT" -ne 0 ]; then
       echo "Note: agentic-test pass had unexpected test failures (exit code $AGENTIC_EXIT). Coverage data still collected; see ci-agentic-tests-nightly.yml for the authoritative pass/fail gate."
     fi


### PR DESCRIPTION
## Summary

Enable the doc-anchored agentic test suite (`docs/generated/tests/`) in the Linux/macOS coverage workflow so its coverage signal rolls into the merged report.

- **`.github/workflows/ci-slang-coverage.yml`** — passes `--with-agentic-tests` to `run-coverage.sh` in both the initial and retry calls of the Linux/macOS coverage step. Comment refreshed to describe the new behavior.

- **`tools/coverage/run-coverage.sh`** — the existing `--with-agentic-tests` path now builds `AGENTIC_TEST_ARGS` with `-expected-failure-list docs/generated/tests/_meta/expected-failures.txt`, matching the gate `ci-agentic-tests-nightly.yml` uses. slang-test reclassifies listed failures as `failed(expected)` and exits 0 unless an unexpected failure occurs. The existing tolerance (`|| AGENTIC_EXIT=$?` + warning) is kept so coverage data is collected even on unexpected failures — the nightly remains the authoritative pass/fail gate; this step is here for the coverage signal.

Windows coverage path is left untouched (it's already tight against its 240-min timeout).

## Coordination

This references `docs/generated/tests/_meta/expected-failures.txt`. PR #11414 (agentic nightly fixes) is in flight and adds 13 entries to that file. Once #11414 merges, this PR's runs automatically pick up the full list — no rebase required.

## Test plan

- [x] `prettier --check` on the workflow file — clean.
- [x] `shfmt` on `run-coverage.sh` — clean.
- [x] After merge: confirm the next Linux/macOS coverage-nightly leg uplifts agentic-suite line/region coverage in the merged report.