### PR TITLE
Diagnose assignment to indexed property instead of ICE (#7160)

### DIFF
--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -4475,6 +4475,13 @@ err(
 )
 
 err(
+    "unsupported-assignment-target",
+    40017,
+    "assignment target is not supported",
+    span { loc = "location", message = "this form of assignment is not currently supported; consider assigning to the whole value instead of an individual element" }
+)
+
+err(
     "cannot-unroll-loop",
     40020,
     "loop unrolling failed",

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -10081,7 +10081,21 @@ top:
         break;
 
     default:
-        SLANG_UNIMPLEMENTED_X("assignment");
+        {
+            SourceLoc loc;
+            for (auto locInfo = context->irBuilder->getSourceLocInfo(); locInfo;
+                 locInfo = locInfo->next)
+            {
+                if (locInfo->sourceLoc.getRaw() != 0)
+                {
+                    loc = locInfo->sourceLoc;
+                    break;
+                }
+            }
+            context->getSink()->diagnose(Diagnostics::UnsupportedAssignmentTarget{
+                .location = loc,
+            });
+        }
         break;
     }
 }

--- a/tests/diagnostics/indexed-property-assign.slang
+++ b/tests/diagnostics/indexed-property-assign.slang
@@ -1,0 +1,34 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target spirv -entry computeMain
+
+// Regression test for https://github.com/shader-slang/slang/issues/7160
+// Assigning to an indexed element of an array-returning property should
+// produce a diagnostic instead of crashing with an internal error.
+
+struct Foo
+{
+    float a;
+    float _b[2];
+
+    property float b[2]
+    {
+        get { return _b; }
+        set
+        {
+            _b[0] = newValue[0];
+            _b[1] = newValue[1];
+        }
+    }
+}
+
+RWStructuredBuffer<float> output;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    Foo c;
+    c.b[0] = 1.0;
+//CHECK:   ^ assignment target is not supported
+//CHECK:   ^ this form of assignment is not currently supported; consider assigning to the whole value instead of an individual element
+    output[0] = c.b[0];
+}


### PR DESCRIPTION
## Summary

- Replaces the `SLANG_UNIMPLEMENTED_X("assignment")` internal error with a proper diagnostic (E40017) when attempting to assign to an unsupported l-value form
- The most common trigger is assigning to an indexed element of an array-returning property (e.g. `foo.b[0] = 1.0` where `b` is a `property float b[2]`)
- Adds new diagnostic `unsupported-assignment-target` (40017)

## Test plan

- [x] New test `tests/diagnostics/indexed-property-assign.slang` verifies E40017 is emitted instead of crashing
- [ ] CI passes

Closes #7160