### PR TITLE
Include identifier name in 'expected a type' diagnostic (#9200)

### DIFF
--- a/source/slang/slang-check-type.cpp
+++ b/source/slang/slang-check-type.cpp
@@ -109,8 +109,25 @@ Type* SemanticsVisitor::getConstantBufferType(Type* elementType, Type* layoutTyp
     return m_astBuilder->getConstantBufferType(elementType, layoutType, witness);
 }
 
+static String _getExprName(Expr* expr)
+{
+    if (auto overloadedExpr = as<OverloadedExpr>(expr))
+    {
+        if (overloadedExpr->name)
+            return String(overloadedExpr->name->text);
+    }
+    if (auto declRefExpr = as<DeclRefExpr>(expr))
+    {
+        if (declRefExpr->name)
+            return String(declRefExpr->name->text);
+    }
+    return String();
+}
+
 Expr* SemanticsVisitor::ExpectATypeRepr(Expr* expr)
 {
+    auto originalExpr = expr;
+
     if (auto overloadedExpr = as<OverloadedExpr>(expr))
     {
         expr = resolveOverloadedExpr(overloadedExpr, LookupMask::type);
@@ -125,9 +142,17 @@ Expr* SemanticsVisitor::ExpectATypeRepr(Expr* expr)
         return expr;
     }
 
-    getSink()->diagnose(Diagnostics::ExpectedAType{
-        .whatWeGot = expr->type.type ? String(expr->type.type->toString()) : String("null"),
-        .expr = expr});
+    auto name = _getExprName(originalExpr);
+    if (name.getLength() == 0)
+        name = _getExprName(expr);
+
+    StringBuilder whatWeGot;
+    whatWeGot << "a '" << (expr->type.type ? expr->type.type->toString() : toSlice("null")) << "'";
+    if (name.getLength())
+        whatWeGot << " for '" << name << "'";
+
+    getSink()->diagnose(
+        Diagnostics::ExpectedAType{.whatWeGot = whatWeGot.produceString(), .expr = expr});
     return CreateErrorExpr(expr);
 }
 
@@ -284,8 +309,13 @@ bool SemanticsVisitor::CoerceToProperTypeImpl(
                 // diagnostic.
 
                 // Get the AST node type info, so we can output a 'got' name
+                auto exprName = _getExprName(originalExpr);
+                StringBuilder whatWeGotStr;
+                whatWeGotStr << "a '" << originalExpr->getClass().getName() << "'";
+                if (exprName.getLength())
+                    whatWeGotStr << " for '" << exprName << "'";
                 diagSink->diagnose(Diagnostics::ExpectedAType{
-                    .whatWeGot = originalExpr->getClass().getName(),
+                    .whatWeGot = whatWeGotStr.produceString(),
                     .expr = originalExpr});
             }
         }

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -1297,7 +1297,7 @@ err(
     "expected-a-type",
     30060,
     "expected a type",
-    span { loc = "expr:Expr", message = "expected a type, got a '~whatWeGot'" }
+    span { loc = "expr:Expr", message = "expected a type, got ~whatWeGot" }
 )
 
 err(

--- a/tests/diagnostics/expected-type-overload-group.slang
+++ b/tests/diagnostics/expected-type-overload-group.slang
@@ -1,0 +1,12 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target spirv
+
+// Regression test for https://github.com/shader-slang/slang/issues/9200
+// When an overload group is used where a type is expected, the diagnostic
+// should include the identifier name to help the user locate the problem.
+
+int MyFunc(int x) { return x; }
+float MyFunc(float x) { return x; }
+
+void test(MyFunc v) {}
+//CHECK:  ^^^^^^ expected a type
+//CHECK:  ^^^^^^ expected a type, got a 'overload group' for 'MyFunc'


### PR DESCRIPTION
## Summary

- Improves the E30060 "expected a type" diagnostic to include the identifier name when an overload group or other non-type expression is used where a type is expected
- Before: `expected a type, got a 'overload group'`
- After: `expected a type, got a 'overload group' for 'MyFunc'`
- Updates both emission sites (`ExpectATypeRepr` and `CoerceToProperTypeImpl`) in `slang-check-type.cpp`

## Test plan

- [x] New test `tests/diagnostics/expected-type-overload-group.slang` verifies the improved message
- [ ] CI passes

Closes #9200