### PR TITLE
Write deps file when output is stdout

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -62,31 +62,9 @@ The space between - D and &lt;name&gt; is optional. If no &lt;value&gt; is speci
 
 Save the source file dependency list in a file. 
 
-The file uses Makefile dependency syntax: &lt;target&gt;: &lt;dep1&gt; &lt;dep2&gt; ... 
+Uses Makefile dependency syntax: &lt;output&gt;: &lt;dep&gt; &lt;dep...&gt; 
 
-Each compiled output produces one line where [&lt;target&gt;](#target-1) is the output file path. 
-
-When no [-o](#o) flag is given for a target (output goes to stdout), - is used as the 
-
-Make target placeholder, following the Unix convention where - denotes stdin/stdout. 
-
-This keeps the depfile syntactically valid so tools that only care about the 
-
-dependency list still work. Build systems that match on the target name will not 
-
-find a rule for -; pass [-o](#o) explicitly or filter out -: lines if needed. 
-
-Slang uses - rather than the input filename (GCC -MD style) because the output 
-
-format is not derived from the input name. 
-
-When some targets have an explicit [-o](#o) path and others do not, each target gets its 
-
-own depfile line; named targets produce &lt;path&gt;: &lt;deps&gt; and unnamed ones produce 
-
--: &lt;deps&gt;. When several targets all lack [-o](#o), only one -: &lt;deps&gt; line is written; 
-
-a deduplication guard suppresses the redundant identical lines. 
+When no [-o](#o) is given, - is used as the make target (output goes to stdout). 
 
 
 <a id="entry"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1,5 +1,3 @@
-Compiling core module on debug build, this can take a while.
-Compiling core module took 54.00 seconds.
 # Slang Command Line Options
 
 *Usage:*

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -62,14 +62,6 @@ The space between - D and &lt;name&gt; is optional. If no &lt;value&gt; is speci
 
 Save the source file dependency list in a file.
 
-The file uses Makefile dependency syntax: `<target>: <dep1> <dep2> ...`. Each compiled output produces one line, where `<target>` is the output file path and `<dep1> <dep2> ...` are the source files read during compilation.
-
-**Stdout output (`-` sentinel):** When no `-o` flag is given for a target (output goes to stdout), `-` is used as the Make target placeholder. This follows the Unix convention where `-` denotes stdin/stdout and keeps the depfile syntactically valid so tools that only care about the dependency list (right of `:`) still work. Build systems that do match on the target name will not find a rule for `-`; they should either always pass `-o` or filter out `-:` lines. This is intentional: Slang does not fall back to the input filename (GCC `-MD` style) because the output format is not derived from the input name.
-
-**Mixed `-o` presence:** When some targets have an explicit `-o` path and others do not, each target gets its own depfile line — named targets produce `<path>: <deps>` and unnamed ones produce `-: <deps>`. The dependency list is identical for all lines in a single invocation since all targets share the same source inputs.
-
-**Multiple stdout-bound targets:** When several targets all lack a `-o` flag, only one `-: <deps>` line is written. A deduplication guard suppresses the redundant identical lines that would otherwise appear.
-
 
 <a id="entry"></a>
 ### -entry

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -62,7 +62,13 @@ The space between - D and &lt;name&gt; is optional. If no &lt;value&gt; is speci
 
 Save the source file dependency list in a file.
 
-The file uses Makefile dependency syntax: `<target>: <dep1> <dep2> ...`. When no output file is specified via `-o` (output goes to stdout), `-` is used as the make target placeholder — following the Unix convention where `-` denotes stdin/stdout.
+The file uses Makefile dependency syntax: `<target>: <dep1> <dep2> ...`. Each compiled output produces one line, where `<target>` is the output file path and `<dep1> <dep2> ...` are the source files read during compilation.
+
+**Stdout output (`-` sentinel):** When no `-o` flag is given for a target (output goes to stdout), `-` is used as the Make target placeholder. This follows the Unix convention where `-` denotes stdin/stdout and keeps the depfile syntactically valid so tools that only care about the dependency list (right of `:`) still work. Build systems that do match on the target name will not find a rule for `-`; they should either always pass `-o` or filter out `-:` lines. This is intentional: Slang does not fall back to the input filename (GCC `-MD` style) because the output format is not derived from the input name.
+
+**Mixed `-o` presence:** When some targets have an explicit `-o` path and others do not, each target gets its own depfile line — named targets produce `<path>: <deps>` and unnamed ones produce `-: <deps>`. The dependency list is identical for all lines in a single invocation since all targets share the same source inputs.
+
+**Multiple stdout-bound targets:** When several targets all lack a `-o` flag, only one `-: <deps>` line is written. A deduplication guard suppresses the redundant identical lines that would otherwise appear.
 
 
 <a id="entry"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -60,7 +60,9 @@ The space between - D and &lt;name&gt; is optional. If no &lt;value&gt; is speci
 
 **-depfile &lt;path&gt;**
 
-Save the source file dependency list in a file. 
+Save the source file dependency list in a file.
+
+The file uses Makefile dependency syntax: `<target>: <dep1> <dep2> ...`. When no output file is specified via `-o` (output goes to stdout), `-` is used as the make target placeholder — following the Unix convention where `-` denotes stdin/stdout.
 
 
 <a id="entry"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1,3 +1,5 @@
+Compiling core module on debug build, this can take a while.
+Compiling core module took 54.00 seconds.
 # Slang Command Line Options
 
 *Usage:*
@@ -60,7 +62,33 @@ The space between - D and &lt;name&gt; is optional. If no &lt;value&gt; is speci
 
 **-depfile &lt;path&gt;**
 
-Save the source file dependency list in a file.
+Save the source file dependency list in a file. 
+
+The file uses Makefile dependency syntax: &lt;target&gt;: &lt;dep1&gt; &lt;dep2&gt; ... 
+
+Each compiled output produces one line where [&lt;target&gt;](#target-1) is the output file path. 
+
+When no [-o](#o) flag is given for a target (output goes to stdout), - is used as the 
+
+Make target placeholder, following the Unix convention where - denotes stdin/stdout. 
+
+This keeps the depfile syntactically valid so tools that only care about the 
+
+dependency list still work. Build systems that match on the target name will not 
+
+find a rule for -; pass [-o](#o) explicitly or filter out -: lines if needed. 
+
+Slang uses - rather than the input filename (GCC -MD style) because the output 
+
+format is not derived from the input name. 
+
+When some targets have an explicit [-o](#o) path and others do not, each target gets its 
+
+own depfile line; named targets produce &lt;path&gt;: &lt;deps&gt; and unnamed ones produce 
+
+-: &lt;deps&gt;. When several targets all lack [-o](#o), only one -: &lt;deps&gt; line is written; 
+
+a deduplication guard suppresses the redundant identical lines. 
 
 
 <a id="entry"></a>

--- a/source/slang/slang-emit-dependency-file.cpp
+++ b/source/slang/slang-emit-dependency-file.cpp
@@ -40,14 +40,24 @@ static void _escapeDependencyString(const char* string, StringBuilder& outBuilde
 
 // Writes a line to the file stream, formatted like this:
 //   <output-file>: <dependency-file> <dependency-file...>
+//
+// When outputPath is empty (output going to stdout), "-" is used as the target placeholder.
+// writtenStdoutSentinel guards against emitting duplicate "-: ..." lines when multiple
+// targets or entry points share the same empty output path (e.g. two -target flags with no -o).
 static void _writeDependencyStatement(
     Stream& stream,
     EndToEndCompileRequest* compileRequest,
-    const String& outputPath)
+    const String& outputPath,
+    bool& writtenStdoutSentinel)
 {
     StringBuilder builder;
     if (outputPath.getLength() == 0)
-    {        
+    {
+        // No output file — output goes to stdout. Emit the sentinel only once even if
+        // called multiple times (once per target/entry-point) with an empty path.
+        if (writtenStdoutSentinel)
+            return;
+        writtenStdoutSentinel = true;
         _writeString(stream, "-");
     }
     else
@@ -84,6 +94,8 @@ SlangResult writeDependencyFile(EndToEndCompileRequest* compileRequest)
     auto linkage = compileRequest->getLinkage();
     auto program = compileRequest->getSpecializedGlobalAndEntryPointsComponentType();
 
+    bool writtenStdoutSentinel = false;
+
     // Iterate over all the targets and their outputs
     for (const auto& targetReq : linkage->targets)
     {
@@ -96,7 +108,8 @@ SlangResult writeDependencyFile(EndToEndCompileRequest* compileRequest)
                 _writeDependencyStatement(
                     stream,
                     compileRequest,
-                    targetInfo->wholeTargetOutputPath);
+                    targetInfo->wholeTargetOutputPath,
+                    writtenStdoutSentinel);
             }
         }
         else
@@ -110,7 +123,11 @@ SlangResult writeDependencyFile(EndToEndCompileRequest* compileRequest)
                     String outputPath;
                     if (targetInfo->entryPointOutputPaths.tryGetValue(entryPointIndex, outputPath))
                     {
-                        _writeDependencyStatement(stream, compileRequest, outputPath);
+                        _writeDependencyStatement(
+                            stream,
+                            compileRequest,
+                            outputPath,
+                            writtenStdoutSentinel);
                     }
                 }
             }
@@ -121,7 +138,11 @@ SlangResult writeDependencyFile(EndToEndCompileRequest* compileRequest)
     // we need to do their dependencies separately.
     if (compileRequest->m_containerFormat == ContainerFormat::SlangModule)
     {
-        _writeDependencyStatement(stream, compileRequest, compileRequest->m_containerOutputPath);
+        _writeDependencyStatement(
+            stream,
+            compileRequest,
+            compileRequest->m_containerOutputPath,
+            writtenStdoutSentinel);
     }
 
     return SLANG_OK;

--- a/source/slang/slang-emit-dependency-file.cpp
+++ b/source/slang/slang-emit-dependency-file.cpp
@@ -46,9 +46,11 @@ static void _escapeDependencyString(const char* string, StringBuilder& outBuilde
 // syntactically valid so tools that only care about the dependency list (right of ":") still work.
 //
 // writtenStdoutSentinel deduplicates the "-: ..." line when this function is called more than
-// once with an empty path (e.g. if a future code path creates TargetInfo entries with empty
-// wholeTargetOutputPath for multiple targets). Without the guard each such call would emit an
-// identical "-: <deps>" line, producing a depfile that make tolerates but that is misleading.
+// once with an empty path. This happens today when a SlangModule-container compile runs without
+// an explicit container output path: the whole-target call site emits the "-: <deps>" line,
+// then the SlangModule branch in writeDependencyFile would emit an identical line — the guard
+// suppresses the duplicate. The same suppression covers any future call site that also passes
+// an empty path.
 static void _writeDependencyStatement(
     Stream& stream,
     EndToEndCompileRequest* compileRequest,

--- a/source/slang/slang-emit-dependency-file.cpp
+++ b/source/slang/slang-emit-dependency-file.cpp
@@ -44,15 +44,23 @@ static void _escapeDependencyString(const char* string, StringBuilder& outBuilde
 // When outputPath is empty (output going to stdout), "-" is used as the make target placeholder.
 // This follows the Unix convention where "-" denotes stdin/stdout, and keeps the depfile
 // syntactically valid so tools that only care about the dependency list (right of ":") still work.
+//
+// writtenStdoutSentinel deduplicates the "-: ..." line when this function is called more than
+// once with an empty path (e.g. if a future code path creates TargetInfo entries with empty
+// wholeTargetOutputPath for multiple targets). Without the guard each such call would emit an
+// identical "-: <deps>" line, producing a depfile that make tolerates but that is misleading.
 static void _writeDependencyStatement(
     Stream& stream,
     EndToEndCompileRequest* compileRequest,
-    const String& outputPath)
+    const String& outputPath,
+    bool& writtenStdoutSentinel)
 {
     StringBuilder builder;
     if (outputPath.getLength() == 0)
     {
-        // No output file — output goes to stdout; use "-" as the make target.
+        if (writtenStdoutSentinel)
+            return;
+        writtenStdoutSentinel = true;
         _writeString(stream, "-");
     }
     else
@@ -89,6 +97,8 @@ SlangResult writeDependencyFile(EndToEndCompileRequest* compileRequest)
     auto linkage = compileRequest->getLinkage();
     auto program = compileRequest->getSpecializedGlobalAndEntryPointsComponentType();
 
+    bool writtenStdoutSentinel = false;
+
     // Iterate over all the targets and their outputs
     for (const auto& targetReq : linkage->targets)
     {
@@ -101,7 +111,8 @@ SlangResult writeDependencyFile(EndToEndCompileRequest* compileRequest)
                 _writeDependencyStatement(
                     stream,
                     compileRequest,
-                    targetInfo->wholeTargetOutputPath);
+                    targetInfo->wholeTargetOutputPath,
+                    writtenStdoutSentinel);
             }
         }
         else
@@ -115,7 +126,11 @@ SlangResult writeDependencyFile(EndToEndCompileRequest* compileRequest)
                     String outputPath;
                     if (targetInfo->entryPointOutputPaths.tryGetValue(entryPointIndex, outputPath))
                     {
-                        _writeDependencyStatement(stream, compileRequest, outputPath);
+                        _writeDependencyStatement(
+                            stream,
+                            compileRequest,
+                            outputPath,
+                            writtenStdoutSentinel);
                     }
                 }
             }
@@ -126,7 +141,11 @@ SlangResult writeDependencyFile(EndToEndCompileRequest* compileRequest)
     // we need to do their dependencies separately.
     if (compileRequest->m_containerFormat == ContainerFormat::SlangModule)
     {
-        _writeDependencyStatement(stream, compileRequest, compileRequest->m_containerOutputPath);
+        _writeDependencyStatement(
+            stream,
+            compileRequest,
+            compileRequest->m_containerOutputPath,
+            writtenStdoutSentinel);
     }
 
     return SLANG_OK;

--- a/source/slang/slang-emit-dependency-file.cpp
+++ b/source/slang/slang-emit-dependency-file.cpp
@@ -41,23 +41,18 @@ static void _escapeDependencyString(const char* string, StringBuilder& outBuilde
 // Writes a line to the file stream, formatted like this:
 //   <output-file>: <dependency-file> <dependency-file...>
 //
-// When outputPath is empty (output going to stdout), "-" is used as the target placeholder.
-// writtenStdoutSentinel guards against emitting duplicate "-: ..." lines when multiple
-// targets or entry points share the same empty output path (e.g. two -target flags with no -o).
+// When outputPath is empty (output going to stdout), "-" is used as the make target placeholder.
+// This follows the Unix convention where "-" denotes stdin/stdout, and keeps the depfile
+// syntactically valid so tools that only care about the dependency list (right of ":") still work.
 static void _writeDependencyStatement(
     Stream& stream,
     EndToEndCompileRequest* compileRequest,
-    const String& outputPath,
-    bool& writtenStdoutSentinel)
+    const String& outputPath)
 {
     StringBuilder builder;
     if (outputPath.getLength() == 0)
     {
-        // No output file — output goes to stdout. Emit the sentinel only once even if
-        // called multiple times (once per target/entry-point) with an empty path.
-        if (writtenStdoutSentinel)
-            return;
-        writtenStdoutSentinel = true;
+        // No output file — output goes to stdout; use "-" as the make target.
         _writeString(stream, "-");
     }
     else
@@ -94,8 +89,6 @@ SlangResult writeDependencyFile(EndToEndCompileRequest* compileRequest)
     auto linkage = compileRequest->getLinkage();
     auto program = compileRequest->getSpecializedGlobalAndEntryPointsComponentType();
 
-    bool writtenStdoutSentinel = false;
-
     // Iterate over all the targets and their outputs
     for (const auto& targetReq : linkage->targets)
     {
@@ -108,8 +101,7 @@ SlangResult writeDependencyFile(EndToEndCompileRequest* compileRequest)
                 _writeDependencyStatement(
                     stream,
                     compileRequest,
-                    targetInfo->wholeTargetOutputPath,
-                    writtenStdoutSentinel);
+                    targetInfo->wholeTargetOutputPath);
             }
         }
         else
@@ -123,11 +115,7 @@ SlangResult writeDependencyFile(EndToEndCompileRequest* compileRequest)
                     String outputPath;
                     if (targetInfo->entryPointOutputPaths.tryGetValue(entryPointIndex, outputPath))
                     {
-                        _writeDependencyStatement(
-                            stream,
-                            compileRequest,
-                            outputPath,
-                            writtenStdoutSentinel);
+                        _writeDependencyStatement(stream, compileRequest, outputPath);
                     }
                 }
             }
@@ -138,11 +126,7 @@ SlangResult writeDependencyFile(EndToEndCompileRequest* compileRequest)
     // we need to do their dependencies separately.
     if (compileRequest->m_containerFormat == ContainerFormat::SlangModule)
     {
-        _writeDependencyStatement(
-            stream,
-            compileRequest,
-            compileRequest->m_containerOutputPath,
-            writtenStdoutSentinel);
+        _writeDependencyStatement(stream, compileRequest, compileRequest->m_containerOutputPath);
     }
 
     return SLANG_OK;

--- a/source/slang/slang-emit-dependency-file.cpp
+++ b/source/slang/slang-emit-dependency-file.cpp
@@ -38,19 +38,9 @@ static void _escapeDependencyString(const char* string, StringBuilder& outBuilde
     }
 }
 
-// Writes a line to the file stream, formatted like this:
-//   <output-file>: <dependency-file> <dependency-file...>
-//
-// When outputPath is empty (output going to stdout), "-" is used as the make target placeholder.
-// This follows the Unix convention where "-" denotes stdin/stdout, and keeps the depfile
-// syntactically valid so tools that only care about the dependency list (right of ":") still work.
-//
-// writtenStdoutSentinel deduplicates the "-: ..." line when this function is called more than
-// once with an empty path. This happens today when a SlangModule-container compile runs without
-// an explicit container output path: the whole-target call site emits the "-: <deps>" line,
-// then the SlangModule branch in writeDependencyFile would emit an identical line — the guard
-// suppresses the duplicate. The same suppression covers any future call site that also passes
-// an empty path.
+// Writes a "<output-file>: <dep> <dep...>" line to the stream.
+// When outputPath is empty (output to stdout), "-" is used as the make target placeholder.
+// writtenStdoutSentinel prevents duplicate "-: ..." lines across multiple call sites.
 static void _writeDependencyStatement(
     Stream& stream,
     EndToEndCompileRequest* compileRequest,

--- a/source/slang/slang-emit-dependency-file.cpp
+++ b/source/slang/slang-emit-dependency-file.cpp
@@ -45,12 +45,17 @@ static void _writeDependencyStatement(
     EndToEndCompileRequest* compileRequest,
     const String& outputPath)
 {
-    if (outputPath.getLength() == 0)
-        return;
-
     StringBuilder builder;
-    _escapeDependencyString(outputPath.begin(), builder);
-    _writeString(stream, builder.begin());
+    if (outputPath.getLength() == 0)
+    {        
+        _writeString(stream, "-");
+    }
+    else
+    {
+        _escapeDependencyString(outputPath.begin(), builder);
+        _writeString(stream, builder.begin());
+        builder.clear();
+    }
     _writeString(stream, ": ");
 
     int dependencyCount = compileRequest->getDependencyFileCount();

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -460,7 +460,20 @@ void initCommandOptions(CommandOptions& options)
         {OptionKind::DepFile,
          "-depfile",
          "-depfile <path>",
-         "Save the source file dependency list in a file."},
+         "Save the source file dependency list in a file.\n"
+         "The file uses Makefile dependency syntax: <target>: <dep1> <dep2> ...\n"
+         "Each compiled output produces one line where <target> is the output file path.\n"
+         "When no -o flag is given for a target (output goes to stdout), - is used as the\n"
+         "Make target placeholder, following the Unix convention where - denotes stdin/stdout.\n"
+         "This keeps the depfile syntactically valid so tools that only care about the\n"
+         "dependency list still work. Build systems that match on the target name will not\n"
+         "find a rule for -; pass -o explicitly or filter out -: lines if needed.\n"
+         "Slang uses - rather than the input filename (GCC -MD style) because the output\n"
+         "format is not derived from the input name.\n"
+         "When some targets have an explicit -o path and others do not, each target gets its\n"
+         "own depfile line; named targets produce <path>: <deps> and unnamed ones produce\n"
+         "-: <deps>. When several targets all lack -o, only one -: <deps> line is written;\n"
+         "a deduplication guard suppresses the redundant identical lines."},
         {OptionKind::EntryPointName,
          "-entry",
          "-entry <name>",

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -461,19 +461,8 @@ void initCommandOptions(CommandOptions& options)
          "-depfile",
          "-depfile <path>",
          "Save the source file dependency list in a file.\n"
-         "The file uses Makefile dependency syntax: <target>: <dep1> <dep2> ...\n"
-         "Each compiled output produces one line where <target> is the output file path.\n"
-         "When no -o flag is given for a target (output goes to stdout), - is used as the\n"
-         "Make target placeholder, following the Unix convention where - denotes stdin/stdout.\n"
-         "This keeps the depfile syntactically valid so tools that only care about the\n"
-         "dependency list still work. Build systems that match on the target name will not\n"
-         "find a rule for -; pass -o explicitly or filter out -: lines if needed.\n"
-         "Slang uses - rather than the input filename (GCC -MD style) because the output\n"
-         "format is not derived from the input name.\n"
-         "When some targets have an explicit -o path and others do not, each target gets its\n"
-         "own depfile line; named targets produce <path>: <deps> and unnamed ones produce\n"
-         "-: <deps>. When several targets all lack -o, only one -: <deps> line is written;\n"
-         "a deduplication guard suppresses the redundant identical lines."},
+         "Uses Makefile dependency syntax: <output>: <dep> <dep...>\n"
+         "When no -o is given, - is used as the make target (output goes to stdout)."},
         {OptionKind::EntryPointName,
          "-entry",
          "-entry <name>",

--- a/tools/slang-unit-test/unit-test-depfile.cpp
+++ b/tools/slang-unit-test/unit-test-depfile.cpp
@@ -7,11 +7,13 @@
 
 using namespace Slang;
 
+/// Returns true if `text` contains the substring `expected`.
 static bool _contains(const String& text, const char* expected)
 {
     return text.getUnownedSlice().indexOf(UnownedStringSlice(expected)) >= 0;
 }
 
+/// RAII wrapper that deletes a temporary file on destruction.
 struct TempFile
 {
     String path;
@@ -23,12 +25,14 @@ struct TempFile
     }
 };
 
+/// Creates a temporary file and stores its path in `out`.
 static SlangResult _makeTempFile(const char* prefix, TempFile& out)
 {
     SLANG_RETURN_ON_FAIL(File::generateTemporary(UnownedStringSlice(prefix), out.path));
     return SLANG_OK;
 }
 
+/// Runs slangc with the given arguments and captures stdout/stderr into `outResult`.
 static SlangResult _runSlangc(
     UnitTestContext* context,
     const List<String>& args,

--- a/tools/slang-unit-test/unit-test-depfile.cpp
+++ b/tools/slang-unit-test/unit-test-depfile.cpp
@@ -151,6 +151,9 @@ SLANG_UNIT_TEST(DepfileOutput)
             depContent.startsWith("-: "),
             "depfile target line must start with '-: ' (stdout sentinel + space)");
         SLANG_CHECK_MSG(
+            !_contains(depContent, "\n-:"),
+            "depfile must contain only one '-:' sentinel line");
+        SLANG_CHECK_MSG(
             _contains(depContent, Path::getFileName(slangPath).getBuffer()),
             "depfile missing input file dependency");
     }
@@ -309,5 +312,69 @@ SLANG_UNIT_TEST(DepfileOutput)
         SLANG_CHECK_MSG(
             !depContent.startsWith("-:") && !_contains(depContent, "\n-:"),
             "depfile must not contain '-:' sentinel for whole-program output");
+    }
+
+    // --- Test 5: per-entry-point output path branch (-emit-spirv-via-glsl) ---
+    //
+    // The per-entry-point branch in writeDependencyFile (the else arm that iterates
+    // entryPointOutputPaths) is only reached for SPIRV when -emit-spirv-via-glsl is
+    // specified; the default SPIRV path (shouldEmitSPIRVDirectly() == true) sets
+    // SLANG_TARGET_FLAG_GENERATE_WHOLE_PROGRAM and routes through wholeTargetOutputPath
+    // instead.  Tests 1-4 therefore all exercise the whole-program branch; this test
+    // covers the per-entry-point branch by forcing via-GLSL lowering.
+    {
+        TempFile inputBase;
+        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-viaglsl-in", inputBase)));
+        const String slangPath = inputBase.path + ".slang";
+        SLANG_CHECK(SLANG_SUCCEEDED(
+            File::writeAllText(slangPath, "[shader(\"compute\")] void main() {}\n")));
+        TempFile slangGuard;
+        slangGuard.path = slangPath;
+
+        TempFile outputBase;
+        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-viaglsl-out", outputBase)));
+        const String spvPath = outputBase.path + ".spv";
+        TempFile spvGuard;
+        spvGuard.path = spvPath;
+
+        TempFile depFile;
+        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-viaglsl-dep", depFile)));
+
+        List<String> args;
+        args.add("-lang");
+        args.add("slang");
+        args.add("-target");
+        args.add("spirv");
+        args.add("-emit-spirv-via-glsl");
+        args.add("-entry");
+        args.add("main");
+        args.add("-stage");
+        args.add("compute");
+        args.add("-o");
+        args.add(spvPath);
+        args.add("-depfile");
+        args.add(depFile.path);
+        args.add(slangPath);
+
+        ExecuteResult result;
+        SLANG_CHECK(SLANG_SUCCEEDED(_runSlangc(unitTestContext, args, result)));
+        if (result.resultCode != 0)
+            getTestReporter()->message(TestMessageType::Info, result.standardError.getBuffer());
+        SLANG_CHECK(result.resultCode == 0);
+
+        String depContent;
+        SLANG_CHECK(SLANG_SUCCEEDED(File::readAllText(depFile.path, depContent)));
+        getTestReporter()->message(TestMessageType::Info, depContent.getBuffer());
+
+        // Per-entry-point output: the depfile target is the .spv file, not "-:".
+        SLANG_CHECK_MSG(
+            _contains(depContent, Path::getFileName(spvPath).getBuffer()),
+            "depfile missing per-entry-point output path target");
+        SLANG_CHECK_MSG(
+            _contains(depContent, Path::getFileName(slangPath).getBuffer()),
+            "depfile missing input file dependency");
+        SLANG_CHECK_MSG(
+            !depContent.startsWith("-:") && !_contains(depContent, "\n-:"),
+            "depfile must not contain '-:' sentinel for named per-entry-point output");
     }
 }

--- a/tools/slang-unit-test/unit-test-depfile.cpp
+++ b/tools/slang-unit-test/unit-test-depfile.cpp
@@ -2,10 +2,10 @@
 // Tests for -depfile output, covering both file-output and stdout-output (no -o) cases,
 // plus a dedup guard test exercising the writtenStdoutSentinel branch.
 
-#include "../../source/core/slang-io.h"
-#include "../../source/core/slang-process-util.h"
-#include "../../source/slang/slang-compiler-api.h"
-#include "../../source/slang/slang-internal.h"
+#include "core/slang-io.h"
+#include "core/slang-process-util.h"
+#include "slang/slang-compiler-api.h"
+#include "slang/slang-internal.h"
 #include "unit-test/slang-unit-test.h"
 
 using namespace Slang;

--- a/tools/slang-unit-test/unit-test-depfile.cpp
+++ b/tools/slang-unit-test/unit-test-depfile.cpp
@@ -5,6 +5,7 @@
 #include "core/slang-io.h"
 #include "core/slang-process-util.h"
 #include "slang/slang-compiler-api.h"
+#include "slang/slang-emit-dependency-file.h"
 #include "slang/slang-internal.h"
 #include "unit-test/slang-unit-test.h"
 
@@ -14,6 +15,20 @@ using namespace Slang;
 static bool _contains(const String& text, const char* expected)
 {
     return text.getUnownedSlice().indexOf(UnownedStringSlice(expected)) >= 0;
+}
+
+/// Returns the number of non-overlapping occurrences of `needle` in `text`.
+static int _countOccurrences(const String& text, const char* needle)
+{
+    int count = 0;
+    Index needleLen = Index(strlen(needle));
+    Index pos = text.indexOf(needle, 0);
+    while (pos >= 0)
+    {
+        ++count;
+        pos = text.indexOf(needle, pos + needleLen);
+    }
+    return count;
 }
 
 /// RAII wrapper that deletes a temporary file on destruction.
@@ -441,5 +456,71 @@ SLANG_UNIT_TEST(DepfileOutput)
         SLANG_CHECK_MSG(
             _contains(depContent, Path::getFileName(slangPath).getBuffer()),
             "depfile missing input file dependency");
+    }
+
+    // --- Test 7: multi-target dedup — writtenStdoutSentinel fires across successive targets ---
+    //
+    // writeDependencyFile iterates over linkage->targets. When two targets both have an
+    // empty wholeTargetOutputPath, _writeDependencyStatement is called twice with an empty
+    // path. The guard must suppress the second emission so the depfile contains exactly one
+    // "-:" occurrence.
+    //
+    // This scenario cannot be triggered via CLI (auto-rawOutput requires a single target),
+    // so we set up the condition in-process: parse args with two targets so that
+    // linkage->targets is populated, then manually insert TargetInfo entries with empty
+    // wholeTargetOutputPath and call writeDependencyFile directly.
+    {
+        TempFile depFile;
+        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-multitgt-dep", depFile)));
+
+        {
+            SlangCompileRequest* request =
+                spCreateCompileRequest((SlangSession*)unitTestContext->slangGlobalSession);
+            SLANG_CHECK(request != nullptr);
+
+            spSetCommandLineCompilerMode(request);
+
+            auto* endToEnd = asInternal(request);
+
+            // Parse with two targets so linkage->targets has two entries.
+            // No -o is given; auto-rawOutput does not fire for multi-target invocations
+            // so m_targetInfos stays empty — we populate it manually below.
+            const char* parseArgs[] = {"-target", "spirv", "-target", "hlsl"};
+            SLANG_CHECK(SLANG_SUCCEEDED(
+                spProcessCommandLineArguments(request, parseArgs, SLANG_COUNT_OF(parseArgs))));
+
+            // Manually insert a TargetInfo with empty wholeTargetOutputPath for each target,
+            // and enable GenerateWholeProgram so writeDependencyFile takes the whole-target
+            // branch (which reads wholeTargetOutputPath).
+            auto* linkage = endToEnd->getLinkage();
+            for (auto& targetRef : linkage->targets)
+            {
+                TargetRequest* targetReq = targetRef.Ptr();
+                RefPtr<EndToEndCompileRequest::TargetInfo> info =
+                    new EndToEndCompileRequest::TargetInfo();
+                info->wholeTargetOutputPath = "";
+                endToEnd->m_targetInfos[targetReq] = info;
+                endToEnd->getTargetOptionSet(targetReq)
+                    .set(CompilerOptionName::GenerateWholeProgram, true);
+            }
+
+            endToEnd->m_dependencyOutputPath = depFile.path;
+
+            // Call writeDependencyFile directly — no compilation needed; we only want to
+            // verify the dedup guard fires when both targets have an empty output path.
+            SLANG_CHECK(SLANG_SUCCEEDED(writeDependencyFile(endToEnd)));
+
+            spDestroyCompileRequest(request);
+        }
+
+        String depContent;
+        SLANG_CHECK(SLANG_SUCCEEDED(File::readAllText(depFile.path, depContent)));
+        getTestReporter()->message(TestMessageType::Info, depContent.getBuffer());
+
+        // The dedup guard must have suppressed the second empty-path call: exactly one "-:"
+        // in the output, not two.
+        SLANG_CHECK_MSG(
+            _countOccurrences(depContent, "-:") == 1,
+            "dedup guard failed: depfile must contain exactly one '-:' sentinel");
     }
 }

--- a/tools/slang-unit-test/unit-test-depfile.cpp
+++ b/tools/slang-unit-test/unit-test-depfile.cpp
@@ -377,4 +377,69 @@ SLANG_UNIT_TEST(DepfileOutput)
             !depContent.startsWith("-:") && !_contains(depContent, "\n-:"),
             "depfile must not contain '-:' sentinel for named per-entry-point output");
     }
+
+    // --- Test 6: multi-entry-point per-entry-point path, no -o — exactly one "-:" line ---
+    //
+    // With two entry points, no -o, and -emit-spirv-via-glsl (which routes through the
+    // per-entry-point branch of writeDependencyFile), only the last entry point gets an empty
+    // path in entryPointOutputPaths (auto-rawOutput targets the last -entry). The loop
+    // therefore calls _writeDependencyStatement once with an empty path, producing exactly
+    // one "-: <deps>" line. A regression that, for example, reset writtenStdoutSentinel
+    // between entry points would still produce only one line here (since there is only one
+    // call), but this test pins down the correct single-sentinel shape for the most common
+    // multi-entry-point / no-output CLI invocation.
+    {
+        TempFile inputBase;
+        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-multi-ep-in", inputBase)));
+        const String slangPath = inputBase.path + ".slang";
+        SLANG_CHECK(SLANG_SUCCEEDED(File::writeAllText(
+            slangPath,
+            "[shader(\"compute\")] void main1() {}\n"
+            "[shader(\"compute\")] void main2() {}\n")));
+        TempFile slangGuard;
+        slangGuard.path = slangPath;
+
+        TempFile depFile;
+        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-multi-ep-dep", depFile)));
+
+        List<String> args;
+        args.add("-lang");
+        args.add("slang");
+        args.add("-target");
+        args.add("spirv");
+        args.add("-emit-spirv-via-glsl");
+        args.add("-entry");
+        args.add("main1");
+        args.add("-stage");
+        args.add("compute");
+        args.add("-entry");
+        args.add("main2");
+        args.add("-stage");
+        args.add("compute");
+        // Deliberately no -o — output goes to stdout.
+        args.add("-depfile");
+        args.add(depFile.path);
+        args.add(slangPath);
+
+        ExecuteResult result;
+        SLANG_CHECK(SLANG_SUCCEEDED(_runSlangc(unitTestContext, args, result)));
+        if (result.resultCode != 0)
+            getTestReporter()->message(TestMessageType::Info, result.standardError.getBuffer());
+        SLANG_CHECK(result.resultCode == 0);
+
+        String depContent;
+        SLANG_CHECK(SLANG_SUCCEEDED(File::readAllText(depFile.path, depContent)));
+        getTestReporter()->message(TestMessageType::Info, depContent.getBuffer());
+
+        // Exactly one "-: <deps>" line — not zero, not two.
+        SLANG_CHECK_MSG(
+            depContent.startsWith("-: "),
+            "depfile must start with '-: ' sentinel for multi-entry stdout output");
+        SLANG_CHECK_MSG(
+            !_contains(depContent, "\n-:"),
+            "depfile must not contain a second '-:' sentinel line");
+        SLANG_CHECK_MSG(
+            _contains(depContent, Path::getFileName(slangPath).getBuffer()),
+            "depfile missing input file dependency");
+    }
 }

--- a/tools/slang-unit-test/unit-test-depfile.cpp
+++ b/tools/slang-unit-test/unit-test-depfile.cpp
@@ -1,12 +1,8 @@
 // unit-test-depfile.cpp
-// Tests for -depfile output, covering both file-output and stdout-output (no -o) cases,
-// plus a dedup guard test exercising the writtenStdoutSentinel branch.
+// Tests for -depfile output.
 
 #include "core/slang-io.h"
 #include "core/slang-process-util.h"
-#include "slang/slang-compiler-api.h"
-#include "slang/slang-emit-dependency-file.h"
-#include "slang/slang-internal.h"
 #include "unit-test/slang-unit-test.h"
 
 using namespace Slang;
@@ -15,20 +11,6 @@ using namespace Slang;
 static bool _contains(const String& text, const char* expected)
 {
     return text.getUnownedSlice().indexOf(UnownedStringSlice(expected)) >= 0;
-}
-
-/// Returns the number of non-overlapping occurrences of `needle` in `text`.
-static int _countOccurrences(const String& text, const char* needle)
-{
-    int count = 0;
-    Index needleLen = Index(strlen(needle));
-    Index pos = text.indexOf(needle, 0);
-    while (pos >= 0)
-    {
-        ++count;
-        pos = text.indexOf(needle, pos + needleLen);
-    }
-    return count;
 }
 
 /// RAII wrapper that deletes a temporary file on destruction.
@@ -109,15 +91,12 @@ SLANG_UNIT_TEST(DepfileOutput)
         SLANG_CHECK(SLANG_SUCCEEDED(File::readAllText(depFile.path, depContent)));
         getTestReporter()->message(TestMessageType::Info, depContent.getBuffer());
 
-        // Depfile escapes ':' and '\', but bare filenames are unescaped.
-        // Extract just the filename component to search for in the depfile content.
         SLANG_CHECK_MSG(
             _contains(depContent, Path::getFileName(spvPath).getBuffer()),
             "depfile missing output path target");
         SLANG_CHECK_MSG(
             _contains(depContent, Path::getFileName(slangPath).getBuffer()),
             "depfile missing input file dependency");
-        // Negative: a non-stdout compile must not emit the "-:" sentinel.
         SLANG_CHECK_MSG(
             !depContent.startsWith("-:") && !_contains(depContent, "\n-:"),
             "depfile must not contain '-:' sentinel when -o is specified");
@@ -160,367 +139,12 @@ SLANG_UNIT_TEST(DepfileOutput)
         SLANG_CHECK(SLANG_SUCCEEDED(File::readAllText(depFile.path, depContent)));
         getTestReporter()->message(TestMessageType::Info, depContent.getBuffer());
 
-        // Without -o the target must be "-" (stdout sentinel), anchored at line start,
-        // followed by a colon, a space, and the dependency — all on the same line.
+        // Without -o the target must be "-" (stdout sentinel).
         SLANG_CHECK_MSG(
             depContent.startsWith("-: "),
             "depfile target line must start with '-: ' (stdout sentinel + space)");
         SLANG_CHECK_MSG(
-            !_contains(depContent, "\n-:"),
-            "depfile must contain only one '-:' sentinel line");
-        SLANG_CHECK_MSG(
             _contains(depContent, Path::getFileName(slangPath).getBuffer()),
             "depfile missing input file dependency");
-    }
-
-    // --- Test 3: in-process dedup — writtenStdoutSentinel prevents a second "-:" line ---
-    //
-    // The writtenStdoutSentinel guard in _writeDependencyStatement is designed to
-    // de-duplicate "-:" lines when writeDependencyFile is called with multiple
-    // output paths that are all empty (stdout). This scenario arises when a SPIRV
-    // entry-point output (empty path, from auto-rawOutput) co-exists with a
-    // SlangModule container format whose output path is also empty. The guard must
-    // ensure the depfile contains exactly one "-:" sentinel line, not two.
-    //
-    // This combination cannot be triggered through the slangc CLI (the auto-rawOutput
-    // path only fires for single-target invocations, and the SlangModule container
-    // output path is always set when specified on the command line), so we exercise
-    // it in-process by setting the internal fields directly.
-    {
-        TempFile inputBase;
-        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-dedup-in", inputBase)));
-        const String slangPath = inputBase.path + ".slang";
-        SLANG_CHECK(SLANG_SUCCEEDED(
-            File::writeAllText(slangPath, "[shader(\"compute\")] void main() {}\n")));
-        TempFile slangGuard;
-        slangGuard.path = slangPath;
-
-        TempFile depFile;
-        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-dedup-dep", depFile)));
-
-        {
-            SlangCompileRequest* request =
-                spCreateCompileRequest((SlangSession*)unitTestContext->slangGlobalSession);
-            SLANG_CHECK(request != nullptr);
-
-            spSetCommandLineCompilerMode(request);
-
-            // Directly access the internal request to pre-configure fields that
-            // cannot be set via CLI:
-            //   m_containerFormat = SlangModule  → triggers a second call to
-            //     _writeDependencyStatement with an empty container output path,
-            //     exercising the writtenStdoutSentinel dedup guard.
-            //   m_dependencyOutputPath            → path for the depfile to write.
-            auto* endToEnd = asInternal(request);
-            endToEnd->m_containerFormat = ContainerFormat::SlangModule;
-            endToEnd->m_dependencyOutputPath = depFile.path;
-
-            const char* slangPathCStr = slangPath.begin();
-            const char* parseArgs[] = {
-                "-lang",
-                "slang",
-                "-target",
-                "spirv",
-                "-entry",
-                "main",
-                "-stage",
-                "compute",
-                slangPathCStr,
-            };
-            // Parse arguments (sets up targets and entry points, but does not compile).
-            const SlangResult parseRes =
-                spProcessCommandLineArguments(request, parseArgs, SLANG_COUNT_OF(parseArgs));
-            if (SLANG_FAILED(parseRes))
-                getTestReporter()->message(
-                    TestMessageType::Info,
-                    spGetDiagnosticOutput(request));
-            SLANG_CHECK(SLANG_SUCCEEDED(parseRes));
-
-            // Compile: generates SPIRV code, then writes the depfile via writeDependencyFile.
-            // The SPIRV entry-point output path (empty, from auto-rawOutput) triggers the
-            // first "-:" sentinel. The SlangModule container path (also empty) triggers the
-            // second call, which the writtenStdoutSentinel guard suppresses.
-            const SlangResult compileRes = spCompile(request);
-            if (SLANG_FAILED(compileRes))
-                getTestReporter()->message(
-                    TestMessageType::Info,
-                    spGetDiagnosticOutput(request));
-            SLANG_CHECK(SLANG_SUCCEEDED(compileRes));
-
-            spDestroyCompileRequest(request);
-        }
-
-        String depContent;
-        SLANG_CHECK(SLANG_SUCCEEDED(File::readAllText(depFile.path, depContent)));
-        getTestReporter()->message(TestMessageType::Info, depContent.getBuffer());
-
-        // The dedup guard must have fired: the depfile must start with "-:" (one sentinel
-        // was written) but must NOT contain a second "\n-:" line (the guard suppressed it).
-        SLANG_CHECK_MSG(
-            depContent.startsWith("-:"),
-            "depfile must contain '-:' stdout sentinel");
-        SLANG_CHECK_MSG(
-            !_contains(depContent, "\n-:"),
-            "dedup guard failed: depfile must not contain a second '-:' sentinel line");
-        SLANG_CHECK_MSG(
-            _contains(depContent, Path::getFileName(slangPath).getBuffer()),
-            "depfile missing input file dependency");
-    }
-
-    // --- Test 4: whole-program output path branch (-emit-spirv-directly) ---
-    //
-    // When -emit-spirv-directly is active, SPIRV compilation sets isWholeProgram=true
-    // and routes through targetInfo->wholeTargetOutputPath in writeDependencyFile
-    // (the GenerateWholeProgram branch, lines 105-116), which is not exercised by
-    // Tests 1-3 (those all take the per-entry-point path).
-    {
-        TempFile inputBase;
-        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-wp-in", inputBase)));
-        const String slangPath = inputBase.path + ".slang";
-        SLANG_CHECK(SLANG_SUCCEEDED(
-            File::writeAllText(slangPath, "[shader(\"compute\")] void main() {}\n")));
-        TempFile slangGuard;
-        slangGuard.path = slangPath;
-
-        TempFile outputBase;
-        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-wp-out", outputBase)));
-        const String spvPath = outputBase.path + ".spv";
-        TempFile spvGuard;
-        spvGuard.path = spvPath;
-
-        TempFile depFile;
-        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-wp-dep", depFile)));
-
-        List<String> args;
-        args.add("-lang");
-        args.add("slang");
-        args.add("-target");
-        args.add("spirv");
-        args.add("-emit-spirv-directly");
-        args.add("-entry");
-        args.add("main");
-        args.add("-stage");
-        args.add("compute");
-        args.add("-o");
-        args.add(spvPath);
-        args.add("-depfile");
-        args.add(depFile.path);
-        args.add(slangPath);
-
-        ExecuteResult result;
-        SLANG_CHECK(SLANG_SUCCEEDED(_runSlangc(unitTestContext, args, result)));
-        if (result.resultCode != 0)
-            getTestReporter()->message(TestMessageType::Info, result.standardError.getBuffer());
-        SLANG_CHECK(result.resultCode == 0);
-
-        String depContent;
-        SLANG_CHECK(SLANG_SUCCEEDED(File::readAllText(depFile.path, depContent)));
-        getTestReporter()->message(TestMessageType::Info, depContent.getBuffer());
-
-        // Whole-program output: the depfile target is the .spv file, not "-:".
-        SLANG_CHECK_MSG(
-            _contains(depContent, Path::getFileName(spvPath).getBuffer()),
-            "depfile missing whole-program output path target");
-        SLANG_CHECK_MSG(
-            _contains(depContent, Path::getFileName(slangPath).getBuffer()),
-            "depfile missing input file dependency");
-        SLANG_CHECK_MSG(
-            !depContent.startsWith("-:") && !_contains(depContent, "\n-:"),
-            "depfile must not contain '-:' sentinel for whole-program output");
-    }
-
-    // --- Test 5: per-entry-point output path branch (-emit-spirv-via-glsl) ---
-    //
-    // The per-entry-point branch in writeDependencyFile (the else arm that iterates
-    // entryPointOutputPaths) is only reached for SPIRV when -emit-spirv-via-glsl is
-    // specified; the default SPIRV path (shouldEmitSPIRVDirectly() == true) sets
-    // SLANG_TARGET_FLAG_GENERATE_WHOLE_PROGRAM and routes through wholeTargetOutputPath
-    // instead.  Tests 1-4 therefore all exercise the whole-program branch; this test
-    // covers the per-entry-point branch by forcing via-GLSL lowering.
-    {
-        TempFile inputBase;
-        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-viaglsl-in", inputBase)));
-        const String slangPath = inputBase.path + ".slang";
-        SLANG_CHECK(SLANG_SUCCEEDED(
-            File::writeAllText(slangPath, "[shader(\"compute\")] void main() {}\n")));
-        TempFile slangGuard;
-        slangGuard.path = slangPath;
-
-        TempFile outputBase;
-        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-viaglsl-out", outputBase)));
-        const String spvPath = outputBase.path + ".spv";
-        TempFile spvGuard;
-        spvGuard.path = spvPath;
-
-        TempFile depFile;
-        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-viaglsl-dep", depFile)));
-
-        List<String> args;
-        args.add("-lang");
-        args.add("slang");
-        args.add("-target");
-        args.add("spirv");
-        args.add("-emit-spirv-via-glsl");
-        args.add("-entry");
-        args.add("main");
-        args.add("-stage");
-        args.add("compute");
-        args.add("-o");
-        args.add(spvPath);
-        args.add("-depfile");
-        args.add(depFile.path);
-        args.add(slangPath);
-
-        ExecuteResult result;
-        SLANG_CHECK(SLANG_SUCCEEDED(_runSlangc(unitTestContext, args, result)));
-        if (result.resultCode != 0)
-            getTestReporter()->message(TestMessageType::Info, result.standardError.getBuffer());
-        SLANG_CHECK(result.resultCode == 0);
-
-        String depContent;
-        SLANG_CHECK(SLANG_SUCCEEDED(File::readAllText(depFile.path, depContent)));
-        getTestReporter()->message(TestMessageType::Info, depContent.getBuffer());
-
-        // Per-entry-point output: the depfile target is the .spv file, not "-:".
-        SLANG_CHECK_MSG(
-            _contains(depContent, Path::getFileName(spvPath).getBuffer()),
-            "depfile missing per-entry-point output path target");
-        SLANG_CHECK_MSG(
-            _contains(depContent, Path::getFileName(slangPath).getBuffer()),
-            "depfile missing input file dependency");
-        SLANG_CHECK_MSG(
-            !depContent.startsWith("-:") && !_contains(depContent, "\n-:"),
-            "depfile must not contain '-:' sentinel for named per-entry-point output");
-    }
-
-    // --- Test 6: multi-entry-point per-entry-point path, no -o — exactly one "-:" line ---
-    //
-    // With two entry points, no -o, and -emit-spirv-via-glsl (which routes through the
-    // per-entry-point branch of writeDependencyFile), only the last entry point gets an empty
-    // path in entryPointOutputPaths (auto-rawOutput targets the last -entry). The loop
-    // therefore calls _writeDependencyStatement once with an empty path, producing exactly
-    // one "-: <deps>" line. A regression that, for example, reset writtenStdoutSentinel
-    // between entry points would still produce only one line here (since there is only one
-    // call), but this test pins down the correct single-sentinel shape for the most common
-    // multi-entry-point / no-output CLI invocation.
-    {
-        TempFile inputBase;
-        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-multi-ep-in", inputBase)));
-        const String slangPath = inputBase.path + ".slang";
-        SLANG_CHECK(SLANG_SUCCEEDED(File::writeAllText(
-            slangPath,
-            "[shader(\"compute\")] void main1() {}\n"
-            "[shader(\"compute\")] void main2() {}\n")));
-        TempFile slangGuard;
-        slangGuard.path = slangPath;
-
-        TempFile depFile;
-        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-multi-ep-dep", depFile)));
-
-        List<String> args;
-        args.add("-lang");
-        args.add("slang");
-        args.add("-target");
-        args.add("spirv");
-        args.add("-emit-spirv-via-glsl");
-        args.add("-entry");
-        args.add("main1");
-        args.add("-stage");
-        args.add("compute");
-        args.add("-entry");
-        args.add("main2");
-        args.add("-stage");
-        args.add("compute");
-        // Deliberately no -o — output goes to stdout.
-        args.add("-depfile");
-        args.add(depFile.path);
-        args.add(slangPath);
-
-        ExecuteResult result;
-        SLANG_CHECK(SLANG_SUCCEEDED(_runSlangc(unitTestContext, args, result)));
-        if (result.resultCode != 0)
-            getTestReporter()->message(TestMessageType::Info, result.standardError.getBuffer());
-        SLANG_CHECK(result.resultCode == 0);
-
-        String depContent;
-        SLANG_CHECK(SLANG_SUCCEEDED(File::readAllText(depFile.path, depContent)));
-        getTestReporter()->message(TestMessageType::Info, depContent.getBuffer());
-
-        // Exactly one "-: <deps>" line — not zero, not two.
-        SLANG_CHECK_MSG(
-            depContent.startsWith("-: "),
-            "depfile must start with '-: ' sentinel for multi-entry stdout output");
-        SLANG_CHECK_MSG(
-            !_contains(depContent, "\n-:"),
-            "depfile must not contain a second '-:' sentinel line");
-        SLANG_CHECK_MSG(
-            _contains(depContent, Path::getFileName(slangPath).getBuffer()),
-            "depfile missing input file dependency");
-    }
-
-    // --- Test 7: multi-target dedup — writtenStdoutSentinel fires across successive targets ---
-    //
-    // writeDependencyFile iterates over linkage->targets. When two targets both have an
-    // empty wholeTargetOutputPath, _writeDependencyStatement is called twice with an empty
-    // path. The guard must suppress the second emission so the depfile contains exactly one
-    // "-:" occurrence.
-    //
-    // This scenario cannot be triggered via CLI (auto-rawOutput requires a single target),
-    // so we set up the condition in-process: parse args with two targets so that
-    // linkage->targets is populated, then manually insert TargetInfo entries with empty
-    // wholeTargetOutputPath and call writeDependencyFile directly.
-    {
-        TempFile depFile;
-        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-multitgt-dep", depFile)));
-
-        {
-            SlangCompileRequest* request =
-                spCreateCompileRequest((SlangSession*)unitTestContext->slangGlobalSession);
-            SLANG_CHECK(request != nullptr);
-
-            spSetCommandLineCompilerMode(request);
-
-            auto* endToEnd = asInternal(request);
-
-            // Parse with two targets so linkage->targets has two entries.
-            // No -o is given; auto-rawOutput does not fire for multi-target invocations
-            // so m_targetInfos stays empty — we populate it manually below.
-            const char* parseArgs[] = {"-target", "spirv", "-target", "hlsl"};
-            SLANG_CHECK(SLANG_SUCCEEDED(
-                spProcessCommandLineArguments(request, parseArgs, SLANG_COUNT_OF(parseArgs))));
-
-            // Manually insert a TargetInfo with empty wholeTargetOutputPath for each target,
-            // and enable GenerateWholeProgram so writeDependencyFile takes the whole-target
-            // branch (which reads wholeTargetOutputPath).
-            auto* linkage = endToEnd->getLinkage();
-            for (auto& targetRef : linkage->targets)
-            {
-                TargetRequest* targetReq = targetRef.Ptr();
-                RefPtr<EndToEndCompileRequest::TargetInfo> info =
-                    new EndToEndCompileRequest::TargetInfo();
-                info->wholeTargetOutputPath = "";
-                endToEnd->m_targetInfos[targetReq] = info;
-                endToEnd->getTargetOptionSet(targetReq)
-                    .set(CompilerOptionName::GenerateWholeProgram, true);
-            }
-
-            endToEnd->m_dependencyOutputPath = depFile.path;
-
-            // Call writeDependencyFile directly — no compilation needed; we only want to
-            // verify the dedup guard fires when both targets have an empty output path.
-            SLANG_CHECK(SLANG_SUCCEEDED(writeDependencyFile(endToEnd)));
-
-            spDestroyCompileRequest(request);
-        }
-
-        String depContent;
-        SLANG_CHECK(SLANG_SUCCEEDED(File::readAllText(depFile.path, depContent)));
-        getTestReporter()->message(TestMessageType::Info, depContent.getBuffer());
-
-        // The dedup guard must have suppressed the second empty-path call: exactly one "-:"
-        // in the output, not two.
-        SLANG_CHECK_MSG(
-            _countOccurrences(depContent, "-:") == 1,
-            "dedup guard failed: depfile must contain exactly one '-:' sentinel");
     }
 }

--- a/tools/slang-unit-test/unit-test-depfile.cpp
+++ b/tools/slang-unit-test/unit-test-depfile.cpp
@@ -1,0 +1,143 @@
+// unit-test-depfile.cpp
+// Tests for -depfile output, covering both file-output and stdout-output (no -o) cases.
+
+#include "../../source/core/slang-io.h"
+#include "../../source/core/slang-process-util.h"
+#include "unit-test/slang-unit-test.h"
+
+using namespace Slang;
+
+static bool _contains(const String& text, const char* expected)
+{
+    return text.getUnownedSlice().indexOf(UnownedStringSlice(expected)) >= 0;
+}
+
+struct TempFile
+{
+    String path;
+
+    ~TempFile()
+    {
+        if (path.getLength())
+            File::remove(path);
+    }
+};
+
+static SlangResult _makeTempFile(const char* prefix, TempFile& out)
+{
+    SLANG_RETURN_ON_FAIL(File::generateTemporary(UnownedStringSlice(prefix), out.path));
+    return SLANG_OK;
+}
+
+static SlangResult _runSlangc(
+    UnitTestContext* context,
+    const List<String>& args,
+    ExecuteResult& outResult)
+{
+    CommandLine cmdLine;
+    cmdLine.setExecutableLocation(ExecutableLocation(context->executableDirectory, "slangc"));
+    for (const auto& arg : args)
+        cmdLine.addArg(arg);
+    return ProcessUtil::execute(cmdLine, outResult);
+}
+
+SLANG_UNIT_TEST(DepfileOutput)
+{
+    // --- Test 1: depfile with -o ---
+    {
+        TempFile inputBase;
+        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-in", inputBase)));
+        const String slangPath = inputBase.path + ".slang";
+        SLANG_CHECK(SLANG_SUCCEEDED(
+            File::writeAllText(slangPath, "[shader(\"compute\")] void main() {}\n")));
+        TempFile slangGuard;
+        slangGuard.path = slangPath;
+
+        TempFile outputBase;
+        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-out", outputBase)));
+        const String spvPath = outputBase.path + ".spv";
+        TempFile spvGuard;
+        spvGuard.path = spvPath;
+
+        TempFile depFile;
+        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-dep", depFile)));
+
+        List<String> args;
+        args.add("-lang");
+        args.add("slang");
+        args.add("-target");
+        args.add("spirv");
+        args.add("-entry");
+        args.add("main");
+        args.add("-stage");
+        args.add("compute");
+        args.add("-o");
+        args.add(spvPath);
+        args.add("-depfile");
+        args.add(depFile.path);
+        args.add(slangPath);
+
+        ExecuteResult result;
+        SLANG_CHECK(SLANG_SUCCEEDED(_runSlangc(unitTestContext, args, result)));
+        if (result.resultCode != 0)
+            getTestReporter()->message(TestMessageType::Info, result.standardError.getBuffer());
+        SLANG_CHECK(result.resultCode == 0);
+
+        String depContent;
+        SLANG_CHECK(SLANG_SUCCEEDED(File::readAllText(depFile.path, depContent)));
+        getTestReporter()->message(TestMessageType::Info, depContent.getBuffer());
+
+        // Depfile escapes ':' and '\', but bare filenames are unescaped.
+        // Extract just the filename component to search for in the depfile content.
+        SLANG_CHECK_MSG(
+            _contains(depContent, Path::getFileName(spvPath).getBuffer()),
+            "depfile missing output path target");
+        SLANG_CHECK_MSG(
+            _contains(depContent, Path::getFileName(slangPath).getBuffer()),
+            "depfile missing input file dependency");
+    }
+
+    // --- Test 2: depfile without -o (output to stdout) ---
+    {
+        TempFile inputBase;
+        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-stdout-in", inputBase)));
+        const String slangPath = inputBase.path + ".slang";
+        SLANG_CHECK(SLANG_SUCCEEDED(
+            File::writeAllText(slangPath, "[shader(\"compute\")] void main() {}\n")));
+        TempFile slangGuard;
+        slangGuard.path = slangPath;
+
+        TempFile depFile;
+        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-stdout-dep", depFile)));
+
+        List<String> args;
+        args.add("-lang");
+        args.add("slang");
+        args.add("-target");
+        args.add("spirv");
+        args.add("-entry");
+        args.add("main");
+        args.add("-stage");
+        args.add("compute");
+        // Deliberately no -o — output goes to stdout.
+        args.add("-depfile");
+        args.add(depFile.path);
+        args.add(slangPath);
+
+        ExecuteResult result;
+        SLANG_CHECK(SLANG_SUCCEEDED(_runSlangc(unitTestContext, args, result)));
+        if (result.resultCode != 0)
+            getTestReporter()->message(TestMessageType::Info, result.standardError.getBuffer());
+        SLANG_CHECK(result.resultCode == 0);
+
+        String depContent;
+        SLANG_CHECK(SLANG_SUCCEEDED(File::readAllText(depFile.path, depContent)));
+        getTestReporter()->message(TestMessageType::Info, depContent.getBuffer());
+
+        // Without -o the target must be "-" (stdout sentinel).
+        SLANG_CHECK_MSG(_contains(depContent, "-:"), "depfile missing '-:' stdout target");
+        SLANG_CHECK_MSG(
+            _contains(depContent, Path::getFileName(slangPath).getBuffer()),
+            "depfile missing input file dependency");
+    }
+}

--- a/tools/slang-unit-test/unit-test-depfile.cpp
+++ b/tools/slang-unit-test/unit-test-depfile.cpp
@@ -99,6 +99,10 @@ SLANG_UNIT_TEST(DepfileOutput)
         SLANG_CHECK_MSG(
             _contains(depContent, Path::getFileName(slangPath).getBuffer()),
             "depfile missing input file dependency");
+        // Negative: a non-stdout compile must not emit the "-:" sentinel.
+        SLANG_CHECK_MSG(
+            !depContent.startsWith("-:") && !_contains(depContent, "\n-:"),
+            "depfile must not contain '-:' sentinel when -o is specified");
     }
 
     // --- Test 2: depfile without -o (output to stdout) ---
@@ -138,10 +142,13 @@ SLANG_UNIT_TEST(DepfileOutput)
         SLANG_CHECK(SLANG_SUCCEEDED(File::readAllText(depFile.path, depContent)));
         getTestReporter()->message(TestMessageType::Info, depContent.getBuffer());
 
-        // Without -o the target must be "-" (stdout sentinel).
-        SLANG_CHECK_MSG(_contains(depContent, "-:"), "depfile missing '-:' stdout target");
+        // Without -o the target must be "-" (stdout sentinel), anchored at line start.
+        SLANG_CHECK_MSG(
+            depContent.startsWith("-:") || _contains(depContent, "\n-:"),
+            "depfile target line must start with '-:' (stdout sentinel)");
         SLANG_CHECK_MSG(
             _contains(depContent, Path::getFileName(slangPath).getBuffer()),
             "depfile missing input file dependency");
     }
+
 }

--- a/tools/slang-unit-test/unit-test-depfile.cpp
+++ b/tools/slang-unit-test/unit-test-depfile.cpp
@@ -1,8 +1,11 @@
 // unit-test-depfile.cpp
-// Tests for -depfile output, covering both file-output and stdout-output (no -o) cases.
+// Tests for -depfile output, covering both file-output and stdout-output (no -o) cases,
+// plus a dedup guard test exercising the writtenStdoutSentinel branch.
 
 #include "../../source/core/slang-io.h"
 #include "../../source/core/slang-process-util.h"
+#include "../../source/slang/slang-compiler-api.h"
+#include "../../source/slang/slang-internal.h"
 #include "unit-test/slang-unit-test.h"
 
 using namespace Slang;
@@ -142,13 +145,169 @@ SLANG_UNIT_TEST(DepfileOutput)
         SLANG_CHECK(SLANG_SUCCEEDED(File::readAllText(depFile.path, depContent)));
         getTestReporter()->message(TestMessageType::Info, depContent.getBuffer());
 
-        // Without -o the target must be "-" (stdout sentinel), anchored at line start.
+        // Without -o the target must be "-" (stdout sentinel), anchored at line start,
+        // followed by a colon, a space, and the dependency — all on the same line.
         SLANG_CHECK_MSG(
-            depContent.startsWith("-:") || _contains(depContent, "\n-:"),
-            "depfile target line must start with '-:' (stdout sentinel)");
+            depContent.startsWith("-: "),
+            "depfile target line must start with '-: ' (stdout sentinel + space)");
         SLANG_CHECK_MSG(
             _contains(depContent, Path::getFileName(slangPath).getBuffer()),
             "depfile missing input file dependency");
     }
 
+    // --- Test 3: in-process dedup — writtenStdoutSentinel prevents a second "-:" line ---
+    //
+    // The writtenStdoutSentinel guard in _writeDependencyStatement is designed to
+    // de-duplicate "-:" lines when writeDependencyFile is called with multiple
+    // output paths that are all empty (stdout). This scenario arises when a SPIRV
+    // entry-point output (empty path, from auto-rawOutput) co-exists with a
+    // SlangModule container format whose output path is also empty. The guard must
+    // ensure the depfile contains exactly one "-:" sentinel line, not two.
+    //
+    // This combination cannot be triggered through the slangc CLI (the auto-rawOutput
+    // path only fires for single-target invocations, and the SlangModule container
+    // output path is always set when specified on the command line), so we exercise
+    // it in-process by setting the internal fields directly.
+    {
+        TempFile inputBase;
+        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-dedup-in", inputBase)));
+        const String slangPath = inputBase.path + ".slang";
+        SLANG_CHECK(SLANG_SUCCEEDED(
+            File::writeAllText(slangPath, "[shader(\"compute\")] void main() {}\n")));
+        TempFile slangGuard;
+        slangGuard.path = slangPath;
+
+        TempFile depFile;
+        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-dedup-dep", depFile)));
+
+        {
+            SlangCompileRequest* request =
+                spCreateCompileRequest((SlangSession*)unitTestContext->slangGlobalSession);
+            SLANG_CHECK(request != nullptr);
+
+            spSetCommandLineCompilerMode(request);
+
+            // Directly access the internal request to pre-configure fields that
+            // cannot be set via CLI:
+            //   m_containerFormat = SlangModule  → triggers a second call to
+            //     _writeDependencyStatement with an empty container output path,
+            //     exercising the writtenStdoutSentinel dedup guard.
+            //   m_dependencyOutputPath            → path for the depfile to write.
+            auto* endToEnd = asInternal(request);
+            endToEnd->m_containerFormat = ContainerFormat::SlangModule;
+            endToEnd->m_dependencyOutputPath = depFile.path;
+
+            const char* slangPathCStr = slangPath.begin();
+            const char* parseArgs[] = {
+                "-lang",
+                "slang",
+                "-target",
+                "spirv",
+                "-entry",
+                "main",
+                "-stage",
+                "compute",
+                slangPathCStr,
+            };
+            // Parse arguments (sets up targets and entry points, but does not compile).
+            const SlangResult parseRes =
+                spProcessCommandLineArguments(request, parseArgs, SLANG_COUNT_OF(parseArgs));
+            if (SLANG_FAILED(parseRes))
+                getTestReporter()->message(
+                    TestMessageType::Info,
+                    spGetDiagnosticOutput(request));
+            SLANG_CHECK(SLANG_SUCCEEDED(parseRes));
+
+            // Compile: generates SPIRV code, then writes the depfile via writeDependencyFile.
+            // The SPIRV entry-point output path (empty, from auto-rawOutput) triggers the
+            // first "-:" sentinel. The SlangModule container path (also empty) triggers the
+            // second call, which the writtenStdoutSentinel guard suppresses.
+            const SlangResult compileRes = spCompile(request);
+            if (SLANG_FAILED(compileRes))
+                getTestReporter()->message(
+                    TestMessageType::Info,
+                    spGetDiagnosticOutput(request));
+            SLANG_CHECK(SLANG_SUCCEEDED(compileRes));
+
+            spDestroyCompileRequest(request);
+        }
+
+        String depContent;
+        SLANG_CHECK(SLANG_SUCCEEDED(File::readAllText(depFile.path, depContent)));
+        getTestReporter()->message(TestMessageType::Info, depContent.getBuffer());
+
+        // The dedup guard must have fired: the depfile must start with "-:" (one sentinel
+        // was written) but must NOT contain a second "\n-:" line (the guard suppressed it).
+        SLANG_CHECK_MSG(
+            depContent.startsWith("-:"),
+            "depfile must contain '-:' stdout sentinel");
+        SLANG_CHECK_MSG(
+            !_contains(depContent, "\n-:"),
+            "dedup guard failed: depfile must not contain a second '-:' sentinel line");
+        SLANG_CHECK_MSG(
+            _contains(depContent, Path::getFileName(slangPath).getBuffer()),
+            "depfile missing input file dependency");
+    }
+
+    // --- Test 4: whole-program output path branch (-emit-spirv-directly) ---
+    //
+    // When -emit-spirv-directly is active, SPIRV compilation sets isWholeProgram=true
+    // and routes through targetInfo->wholeTargetOutputPath in writeDependencyFile
+    // (the GenerateWholeProgram branch, lines 105-116), which is not exercised by
+    // Tests 1-3 (those all take the per-entry-point path).
+    {
+        TempFile inputBase;
+        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-wp-in", inputBase)));
+        const String slangPath = inputBase.path + ".slang";
+        SLANG_CHECK(SLANG_SUCCEEDED(
+            File::writeAllText(slangPath, "[shader(\"compute\")] void main() {}\n")));
+        TempFile slangGuard;
+        slangGuard.path = slangPath;
+
+        TempFile outputBase;
+        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-wp-out", outputBase)));
+        const String spvPath = outputBase.path + ".spv";
+        TempFile spvGuard;
+        spvGuard.path = spvPath;
+
+        TempFile depFile;
+        SLANG_CHECK(SLANG_SUCCEEDED(_makeTempFile("slangc-df-wp-dep", depFile)));
+
+        List<String> args;
+        args.add("-lang");
+        args.add("slang");
+        args.add("-target");
+        args.add("spirv");
+        args.add("-emit-spirv-directly");
+        args.add("-entry");
+        args.add("main");
+        args.add("-stage");
+        args.add("compute");
+        args.add("-o");
+        args.add(spvPath);
+        args.add("-depfile");
+        args.add(depFile.path);
+        args.add(slangPath);
+
+        ExecuteResult result;
+        SLANG_CHECK(SLANG_SUCCEEDED(_runSlangc(unitTestContext, args, result)));
+        if (result.resultCode != 0)
+            getTestReporter()->message(TestMessageType::Info, result.standardError.getBuffer());
+        SLANG_CHECK(result.resultCode == 0);
+
+        String depContent;
+        SLANG_CHECK(SLANG_SUCCEEDED(File::readAllText(depFile.path, depContent)));
+        getTestReporter()->message(TestMessageType::Info, depContent.getBuffer());
+
+        // Whole-program output: the depfile target is the .spv file, not "-:".
+        SLANG_CHECK_MSG(
+            _contains(depContent, Path::getFileName(spvPath).getBuffer()),
+            "depfile missing whole-program output path target");
+        SLANG_CHECK_MSG(
+            _contains(depContent, Path::getFileName(slangPath).getBuffer()),
+            "depfile missing input file dependency");
+        SLANG_CHECK_MSG(
+            !depContent.startsWith("-:") && !_contains(depContent, "\n-:"),
+            "depfile must not contain '-:' sentinel for whole-program output");
+    }
 }


### PR DESCRIPTION
# Description
When output of the compiler is redirected to an stdout (no option `-o` specified) the compiler skips writing the dependencies file because no output path has been specified. This PR fixes the behavior by adding a `-` target placeholder in the dependencies file when output is directed to stdout.

# Tests
Test 1 — compiles a shader with -o out.spv -depfile out.d. Asserts:
  - The output file name (out.spv) appears as the make target in the depfile
  - The input source file appears as a dependency
  - No -: sentinel (output has a real path, sentinel must not appear)

  Test 2 — compiles the same shader with -depfile out.d but no -o. Asserts:
  - The depfile starts with -:  (the stdout sentinel introduced by this PR)
  - The input source file still appears as a dependency