### PR TITLE
Handle global descriptor handle casts in SPIR-V

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -2828,6 +2828,16 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             return emitMakeMatrixFromScalar(
                 getSection(SpvLogicalSectionID::ConstantsAndTypes),
                 inst);
+        case kIROp_CastDescriptorHandleToUInt2:
+        case kIROp_CastUInt2ToDescriptorHandle:
+        case kIROp_CastUInt64ToDescriptorHandle:
+        case kIROp_CastDescriptorHandleToUInt64:
+        case kIROp_GlobalValueRef:
+            {
+                auto inner = ensureInst(inst->getOperand(0));
+                registerInst(inst, inner);
+                return inner;
+            }
         case kIROp_GlobalParam:
             return emitGlobalParam(as<IRGlobalParam>(inst));
         case kIROp_GlobalVar:

--- a/tests/bugs/gh-9916.slang
+++ b/tests/bugs/gh-9916.slang
@@ -1,9 +1,15 @@
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -stage fragment -entry fragmentMain
+//TEST:SIMPLE(filecheck=CHECK_BINDLESS): -target spirv-asm -stage fragment -entry fragmentMain -capability spvBindlessTextureNV -DUSE_BINDLESS_NV
 
 // A global DescriptorHandle constant lowers to a module-scope descriptor-handle
 // representation cast. SPIR-V emission should treat that cast as transparent.
 static const DescriptorHandle<SamplerState> kSampler =
     DescriptorHandle<SamplerState>(uint2(0, 0));
+
+#ifdef USE_BINDLESS_NV
+static const DescriptorHandle<Texture2D<float4>> kTexture =
+    DescriptorHandle<Texture2D<float4>>(uint64_t(0));
+#endif
 
 struct FragmentInput
 {
@@ -21,7 +27,15 @@ struct Args
 [shader("fragment")]
 float4 fragmentMain(FragmentInput input) : SV_Target
 {
+#ifdef USE_BINDLESS_NV
+    return kTexture.Sample(kSampler, input.uv);
+#else
     return args.texture.Sample(kSampler, input.uv);
+#endif
 }
 
 // CHECK: OpImageSampleImplicitLod
+
+// CHECK_BINDLESS: OpCapability BindlessTextureNV
+// CHECK_BINDLESS: OpConvertUToSampledImageNV
+// CHECK_BINDLESS: OpImageSampleImplicitLod

--- a/tests/bugs/gh-9916.slang
+++ b/tests/bugs/gh-9916.slang
@@ -1,0 +1,27 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -stage fragment -entry fragmentMain
+
+// A global DescriptorHandle constant lowers to a module-scope descriptor-handle
+// representation cast. SPIR-V emission should treat that cast as transparent.
+static const DescriptorHandle<SamplerState> kSampler =
+    DescriptorHandle<SamplerState>(uint2(0, 0));
+
+struct FragmentInput
+{
+    float4 position : SV_Position;
+    float2 uv : TEXCOORD0;
+};
+
+struct Args
+{
+    DescriptorHandle<Texture2D<float4>> texture;
+};
+
+[[vk::push_constant]] uniform Args args;
+
+[shader("fragment")]
+float4 fragmentMain(FragmentInput input) : SV_Target
+{
+    return args.texture.Sample(kSampler, input.uv);
+}
+
+// CHECK: OpImageSampleImplicitLod

--- a/tests/bugs/gh-9916.slang
+++ b/tests/bugs/gh-9916.slang
@@ -4,11 +4,13 @@
 // A global DescriptorHandle constant lowers to a module-scope descriptor-handle
 // representation cast. SPIR-V emission should treat that cast as transparent.
 static const DescriptorHandle<SamplerState> kSampler =
-    DescriptorHandle<SamplerState>(uint2(0, 0));
+    DescriptorHandle<SamplerState>(uint2(3, 4));
+static const uint2 kSamplerBits = (uint2)kSampler;
 
 #ifdef USE_BINDLESS_NV
 static const DescriptorHandle<Texture2D<float4>> kTexture =
-    DescriptorHandle<Texture2D<float4>>(uint64_t(0));
+    DescriptorHandle<Texture2D<float4>>(uint64_t(5));
+static const uint64_t kTextureBits = (uint64_t)kTexture;
 #endif
 
 struct FragmentInput
@@ -28,14 +30,18 @@ struct Args
 float4 fragmentMain(FragmentInput input) : SV_Target
 {
 #ifdef USE_BINDLESS_NV
-    return kTexture.Sample(kSampler, input.uv);
+    float2 uv = input.uv + float2(float(uint(kTextureBits)), 0.0) * 0.000001;
+    return kTexture.Sample(kSampler, uv);
 #else
-    return args.texture.Sample(kSampler, input.uv);
+    float2 uv = input.uv + float2(float(kSamplerBits.x), float(kSamplerBits.y)) * 0.000001;
+    return args.texture.Sample(kSampler, uv);
 #endif
 }
 
+// CHECK: OpConstantComposite
 // CHECK: OpImageSampleImplicitLod
 
 // CHECK_BINDLESS: OpCapability BindlessTextureNV
+// CHECK_BINDLESS: OpConstant %ulong 5
 // CHECK_BINDLESS: OpConvertUToSampledImageNV
 // CHECK_BINDLESS: OpImageSampleImplicitLod

--- a/tests/bugs/gh-9916.slang
+++ b/tests/bugs/gh-9916.slang
@@ -38,7 +38,9 @@ float4 fragmentMain(FragmentInput input) : SV_Target
 #endif
 }
 
-// CHECK: OpConstantComposite
+// CHECK-DAG: %[[F3:[A-Za-z0-9_]+]] = OpConstant %float {{3\.000[0-9]*e-06}}
+// CHECK-DAG: %[[F4:[A-Za-z0-9_]+]] = OpConstant %float {{3\.999[0-9]*e-06}}
+// CHECK-DAG: OpConstantComposite %v2float %[[F3]] %[[F4]]
 // CHECK: OpImageSampleImplicitLod
 
 // CHECK_BINDLESS: OpCapability BindlessTextureNV


### PR DESCRIPTION
Fixes #9916

## Summary of the problem from the end user perspective

Declaring a `DescriptorHandle<SamplerState>` as a top-level static constant caused SPIR-V compilation to abort. The same handle worked when declared as a function-local constant.

### Minimal repro shader; if applicable

```slang
static const DescriptorHandle<SamplerState> kSampler =
    DescriptorHandle<SamplerState>(uint2(0, 0));

float4 fragmentMain(FragmentInput input) : SV_Target
{
    return args.texture.Sample(kSampler, input.uv);
}
```

## Root cause

Function-scope SPIR-V emission already treated descriptor-handle representation casts as transparent. Module-scope emission did not, so a global `CastUInt2ToDescriptorHandle` reached the unhandled global instruction path.

## Solution in this PR

The SPIR-V global emitter now forwards descriptor-handle representation casts to their operand, matching the existing local instruction behavior. Regression coverage exercises the default `uint2` global sampler handle path, the `spvBindlessTextureNV` `uint64_t` global texture handle path, and module-scope reverse casts back to `uint2`/`uint64_t`.

### Notes to the reviewers; where to focus on

The code change is intentionally limited to the global `ensureInst` switch in the SPIR-V emitter. The tests exercise the issue shape and check that default and bindless SPIR-V sampling emission complete while preserving non-zero global handle constants.

## Related PRs in the past

shader-slang/slang#9870 was mentioned while triaging this issue, but this PR handles the remaining module-scope cast path directly.