### PR TITLE
Fix unaligned byte-address descriptor loads

### DIFF
--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -243,6 +243,10 @@ struct ByteAddressBufferLegalizationContext
     // Returns true if a vectorized load or store of `alignmentVal` bytes at
     // `baseOffset + immediateOffset` is known to be sufficiently aligned.
     //
+    // As a side effect, this emits `ByteAddressBufferUnaligned` for a dynamic
+    // base offset when an explicit nonzero alignment is known but insufficient
+    // for `alignmentVal`.
+    //
     // Keep the dynamic base offset and constant nested-field offset separate:
     // a synthesized add is not an integer literal, so pre-summing them would
     // hide constant immediate-offset misalignment from this check.
@@ -623,6 +627,9 @@ struct ByteAddressBufferLegalizationContext
         }
         else if (auto basicType = as<IRBasicType>(type))
         {
+            // Only split misaligned 8-byte scalar loads for targets that translate
+            // byte-address buffers into typed structured buffers. Targets that keep
+            // byte-address-buffer operations use the simple/lowerBasicTypeOps paths.
             if (m_options.translateToStructuredBufferOps)
             {
                 IRSizeAndAlignment sizeAlignment;
@@ -1520,6 +1527,8 @@ struct ByteAddressBufferLegalizationContext
         }
         else if (auto basicType = as<IRBasicType>(type))
         {
+            // Match the load path: this split is only needed when byte-address buffers
+            // are translated into typed structured buffers.
             if (m_options.translateToStructuredBufferOps)
             {
                 IRSizeAndAlignment sizeAlignment;

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -240,16 +240,19 @@ struct ByteAddressBufferLegalizationContext
         return false;
     }
 
-    // Helper function to check if the alignment value passed is
-    // divisible by the offset at which the resource is indexed into
-    // in order to ensure if the load or store can be vectorized.
-    bool isAligned(IRInst* offset, IRInst* unknownOffsetAlignment, IRIntegerValue alignmentVal)
+    // Helper function to check if the offset at which the resource is indexed into
+    // is aligned enough to allow a vectorized load or store.
+    bool isAligned(
+        IRInst* baseOffset,
+        IRIntegerValue immediateOffset,
+        IRInst* unknownOffsetAlignment,
+        IRIntegerValue alignmentVal)
     {
-        if (auto baseOffsetVal = as<IRIntLit>(offset))
+        if (auto baseOffsetVal = as<IRIntLit>(baseOffset))
         {
             // If the offset is a constant known at compile time, simply check if it aligned to
             // the elementsize of the underlying resource.
-            return (baseOffsetVal->getValue() % alignmentVal) == 0;
+            return ((baseOffsetVal->getValue() + immediateOffset) % alignmentVal) == 0;
         }
         else if (auto alignInst = as<IRIntLit>(unknownOffsetAlignment))
         {
@@ -262,6 +265,9 @@ struct ByteAddressBufferLegalizationContext
             if (!alignInst->getValue())
                 return false;
 
+            if ((immediateOffset % alignmentVal) != 0)
+                return false;
+
             if ((alignInst->getValue() % alignmentVal) == 0)
             {
                 return true;
@@ -269,10 +275,35 @@ struct ByteAddressBufferLegalizationContext
             m_sink->diagnose(Diagnostics::ByteAddressBufferUnaligned{
                 .alignment = alignInst->getValue(),
                 .elementSize = alignmentVal,
-                .location = offset->sourceLoc,
+                .location = baseOffset->sourceLoc,
             });
         }
         return false;
+    }
+
+    IRType* getDescriptorHandleStorageType()
+    {
+        if (!m_options.translateToStructuredBufferOps)
+            return nullptr;
+
+        if (m_target->getTargetCaps().implies(CapabilityAtom::spvBindlessTextureNV))
+            return m_builder.getUInt64Type();
+
+        return m_builder.getVectorType(m_builder.getUIntType(), 2);
+    }
+
+    IROp getCastDescriptorHandleToStorageOp()
+    {
+        return m_target->getTargetCaps().implies(CapabilityAtom::spvBindlessTextureNV)
+                   ? kIROp_CastDescriptorHandleToUInt64
+                   : kIROp_CastDescriptorHandleToUInt2;
+    }
+
+    IROp getCastStorageToDescriptorHandleOp()
+    {
+        return m_target->getTargetCaps().implies(CapabilityAtom::spvBindlessTextureNV)
+                   ? kIROp_CastUInt64ToDescriptorHandle
+                   : kIROp_CastUInt2ToDescriptorHandle;
     }
 
     SlangResult getOffset(TargetProgram* target, IRStructField* field, IRIntegerValue* outOffset)
@@ -408,10 +439,7 @@ struct ByteAddressBufferLegalizationContext
                     &elementLayout));
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
-                if (!isAligned(
-                        emitOffsetAddIfNeeded(baseOffset, immediateOffset),
-                        alignment,
-                        alignmentVal))
+                if (!isAligned(baseOffset, immediateOffset, alignment, alignmentVal))
                 {
                     return emitLegalSequenceLoad(
                         type,
@@ -427,6 +455,22 @@ struct ByteAddressBufferLegalizationContext
                 {
                     return emitSimpleLoad(type, buffer, baseOffset, immediateOffset);
                 }
+            }
+        }
+        else if (auto descriptorHandleType = as<IRDescriptorHandleType>(type))
+        {
+            if (auto storageType = getDescriptorHandleStorageType())
+            {
+                auto storageVal =
+                    emitLegalLoad(storageType, buffer, baseOffset, immediateOffset, alignment);
+                if (!storageVal)
+                    return nullptr;
+                IRInst* args[] = {storageVal};
+                return m_builder.emitIntrinsicInst(
+                    descriptorHandleType,
+                    getCastStorageToDescriptorHandleOp(),
+                    1,
+                    args);
             }
         }
         else if (auto matType = as<IRMatrixType>(type))
@@ -507,10 +551,7 @@ struct ByteAddressBufferLegalizationContext
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
                 if (m_options.scalarizeVectorLoadStore ||
-                    !isAligned(
-                        emitOffsetAddIfNeeded(baseOffset, immediateOffset),
-                        alignment,
-                        alignmentVal))
+                    !isAligned(baseOffset, immediateOffset, alignment, alignmentVal))
                 {
                     return emitLegalSequenceLoad(
                         type,
@@ -1280,10 +1321,7 @@ struct ByteAddressBufferLegalizationContext
                     &elementLayout));
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
-                if (!isAligned(
-                        emitOffsetAddIfNeeded(baseOffset, immediateOffset),
-                        alignment,
-                        alignmentVal))
+                if (!isAligned(baseOffset, immediateOffset, alignment, alignmentVal))
                 {
                     return emitLegalSequenceStore(
                         buffer,
@@ -1303,6 +1341,25 @@ struct ByteAddressBufferLegalizationContext
                         immediateOffset,
                         value);
                 }
+            }
+        }
+        else if (auto descriptorHandleType = as<IRDescriptorHandleType>(type))
+        {
+            if (auto storageType = getDescriptorHandleStorageType())
+            {
+                IRInst* args[] = {value};
+                auto storageVal = m_builder.emitIntrinsicInst(
+                    storageType,
+                    getCastDescriptorHandleToStorageOp(),
+                    1,
+                    args);
+                return emitLegalStore(
+                    storageType,
+                    buffer,
+                    baseOffset,
+                    immediateOffset,
+                    alignment,
+                    storageVal);
             }
         }
         else if (auto matType = as<IRMatrixType>(type))
@@ -1374,10 +1431,7 @@ struct ByteAddressBufferLegalizationContext
                 IRIntegerValue elementStride = elementLayout.getStride();
                 auto alignmentVal = elementStride * elementCountInst->getValue();
                 if (m_options.scalarizeVectorLoadStore ||
-                    !isAligned(
-                        emitOffsetAddIfNeeded(baseOffset, immediateOffset),
-                        alignment,
-                        alignmentVal))
+                    !isAligned(baseOffset, immediateOffset, alignment, alignmentVal))
                 {
                     return emitLegalSequenceStore(
                         buffer,

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -242,14 +242,6 @@ struct ByteAddressBufferLegalizationContext
 
     // Returns true if a vectorized load or store of `alignmentVal` bytes at
     // `baseOffset + immediateOffset` is known to be sufficiently aligned.
-    //
-    // As a side effect, this emits `ByteAddressBufferUnaligned` for a dynamic
-    // base offset when an explicit nonzero alignment is known but insufficient
-    // for `alignmentVal`.
-    //
-    // Keep the dynamic base offset and constant nested-field offset separate:
-    // a synthesized add is not an integer literal, so pre-summing them would
-    // hide constant immediate-offset misalignment from this check.
     bool isAligned(
         IRInst* baseOffset,
         IRIntegerValue immediateOffset,
@@ -638,7 +630,12 @@ struct ByteAddressBufferLegalizationContext
                 if (sizeAlignment.size == 8 &&
                     !isAligned(baseOffset, immediateOffset, alignment, sizeAlignment.getStride()))
                 {
-                    return emitLegal64BitLoad(type, buffer, baseOffset, immediateOffset, alignment);
+                    return emitLegalUnaligned64BitLoadFromTwoUInts(
+                        type,
+                        buffer,
+                        baseOffset,
+                        immediateOffset,
+                        alignment);
                 }
             }
 
@@ -718,7 +715,7 @@ struct ByteAddressBufferLegalizationContext
             .emitIntrinsicInst(type, op, elementVals.getCount(), elementVals.getBuffer());
     }
 
-    IRInst* emitLegal64BitLoad(
+    IRInst* emitLegalUnaligned64BitLoadFromTwoUInts(
         IRType* type,
         IRInst* buffer,
         IRInst* baseOffset,
@@ -1536,7 +1533,7 @@ struct ByteAddressBufferLegalizationContext
                 if (sizeAlignment.size == 8 &&
                     !isAligned(baseOffset, immediateOffset, alignment, sizeAlignment.getStride()))
                 {
-                    return emitLegal64BitStore(
+                    return emitLegalUnaligned64BitStoreAsTwoUInts(
                         buffer,
                         baseOffset,
                         immediateOffset,
@@ -1563,7 +1560,7 @@ struct ByteAddressBufferLegalizationContext
         return emitSimpleStore(type, buffer, baseOffset, immediateOffset, value);
     }
 
-    Result emitLegal64BitStore(
+    Result emitLegalUnaligned64BitStoreAsTwoUInts(
         IRInst* buffer,
         IRInst* baseOffset,
         IRIntegerValue immediateOffset,

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -1346,7 +1346,7 @@ struct ByteAddressBufferLegalizationContext
                 }
             }
         }
-        else if (auto descriptorHandleType = as<IRDescriptorHandleType>(type))
+        else if (as<IRDescriptorHandleType>(type))
         {
             if (auto storageType = getDescriptorHandleStorageType())
             {

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -240,8 +240,12 @@ struct ByteAddressBufferLegalizationContext
         return false;
     }
 
-    // Helper function to check if the offset at which the resource is indexed into
-    // is aligned enough to allow a vectorized load or store.
+    // Returns true if a vectorized load or store of `alignmentVal` bytes at
+    // `baseOffset + immediateOffset` is known to be sufficiently aligned.
+    //
+    // Keep the dynamic base offset and constant nested-field offset separate:
+    // a synthesized add is not an integer literal, so pre-summing them would
+    // hide constant immediate-offset misalignment from this check.
     bool isAligned(
         IRInst* baseOffset,
         IRIntegerValue immediateOffset,
@@ -619,6 +623,18 @@ struct ByteAddressBufferLegalizationContext
         }
         else if (auto basicType = as<IRBasicType>(type))
         {
+            if (m_options.translateToStructuredBufferOps)
+            {
+                IRSizeAndAlignment sizeAlignment;
+                SLANG_RETURN_NULL_ON_FAIL(
+                    getNaturalSizeAndAlignment(m_target, type, &sizeAlignment));
+                if (sizeAlignment.size == 8 &&
+                    !isAligned(baseOffset, immediateOffset, alignment, sizeAlignment.getStride()))
+                {
+                    return emitLegal64BitLoad(type, buffer, baseOffset, immediateOffset, alignment);
+                }
+            }
+
             // Most basic scalar types can be handled directly on targets,
             // but as described above for vectors, the D3D11/DXBC target
             // only support loading `uint` values, so we need to emulate
@@ -693,6 +709,34 @@ struct ByteAddressBufferLegalizationContext
         //
         return m_builder
             .emitIntrinsicInst(type, op, elementVals.getCount(), elementVals.getBuffer());
+    }
+
+    IRInst* emitLegal64BitLoad(
+        IRType* type,
+        IRInst* buffer,
+        IRInst* baseOffset,
+        IRIntegerValue immediateOffset,
+        IRInst* alignment)
+    {
+        auto uintType = m_builder.getUIntType();
+        auto uint64Type = m_builder.getUInt64Type();
+
+        auto loLoad = emitLegalLoad(uintType, buffer, baseOffset, immediateOffset, alignment);
+        if (!loLoad)
+            return nullptr;
+
+        auto hiLoad = emitLegalLoad(uintType, buffer, baseOffset, immediateOffset + 4, alignment);
+        if (!hiLoad)
+            return nullptr;
+
+        auto lo64 = m_builder.emitCast(uint64Type, loLoad);
+        auto hi64 = m_builder.emitCast(uint64Type, hiLoad);
+        auto shift = m_builder.emitShl(
+            uint64Type,
+            hi64,
+            m_builder.getIntValue(uint64Type, 32));
+        auto fullValue = m_builder.emitBitOr(uint64Type, lo64, shift);
+        return m_builder.emitBitCast(type, fullValue);
     }
 
     // All of the loading operations above eventually bottom out at `emitSimpleLoad`,
@@ -1479,6 +1523,17 @@ struct ByteAddressBufferLegalizationContext
         }
         else if (auto basicType = as<IRBasicType>(type))
         {
+            if (m_options.translateToStructuredBufferOps)
+            {
+                IRSizeAndAlignment sizeAlignment;
+                SLANG_RETURN_ON_FAIL(getNaturalSizeAndAlignment(m_target, type, &sizeAlignment));
+                if (sizeAlignment.size == 8 &&
+                    !isAligned(baseOffset, immediateOffset, alignment, sizeAlignment.getStride()))
+                {
+                    return emitLegal64BitStore(buffer, baseOffset, immediateOffset, alignment, value);
+                }
+            }
+
             if (m_options.useBitCastFromUInt)
             {
                 if (auto unsignedType = getSameSizeUIntType(basicType))
@@ -1495,6 +1550,32 @@ struct ByteAddressBufferLegalizationContext
         }
 
         return emitSimpleStore(type, buffer, baseOffset, immediateOffset, value);
+    }
+
+    Result emitLegal64BitStore(
+        IRInst* buffer,
+        IRInst* baseOffset,
+        IRIntegerValue immediateOffset,
+        IRInst* alignment,
+        IRInst* value)
+    {
+        auto uintType = m_builder.getUIntType();
+        auto uint64Type = m_builder.getUInt64Type();
+
+        auto uint64Val = m_builder.emitBitCast(uint64Type, value);
+        auto loVal = m_builder.emitCast(uintType, uint64Val);
+        auto hiVal = m_builder.emitCast(
+            uintType,
+            m_builder.emitShr(
+                uint64Type,
+                uint64Val,
+                m_builder.getIntValue(uint64Type, 32)));
+
+        SLANG_RETURN_ON_FAIL(
+            emitLegalStore(uintType, buffer, baseOffset, immediateOffset, alignment, loVal));
+        SLANG_RETURN_ON_FAIL(
+            emitLegalStore(uintType, buffer, baseOffset, immediateOffset + 4, alignment, hiVal));
+        return SLANG_OK;
     }
 
     Result emitSimpleStore(

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -731,10 +731,7 @@ struct ByteAddressBufferLegalizationContext
 
         auto lo64 = m_builder.emitCast(uint64Type, loLoad);
         auto hi64 = m_builder.emitCast(uint64Type, hiLoad);
-        auto shift = m_builder.emitShl(
-            uint64Type,
-            hi64,
-            m_builder.getIntValue(uint64Type, 32));
+        auto shift = m_builder.emitShl(uint64Type, hi64, m_builder.getIntValue(uint64Type, 32));
         auto fullValue = m_builder.emitBitOr(uint64Type, lo64, shift);
         return m_builder.emitBitCast(type, fullValue);
     }
@@ -1530,7 +1527,12 @@ struct ByteAddressBufferLegalizationContext
                 if (sizeAlignment.size == 8 &&
                     !isAligned(baseOffset, immediateOffset, alignment, sizeAlignment.getStride()))
                 {
-                    return emitLegal64BitStore(buffer, baseOffset, immediateOffset, alignment, value);
+                    return emitLegal64BitStore(
+                        buffer,
+                        baseOffset,
+                        immediateOffset,
+                        alignment,
+                        value);
                 }
             }
 
@@ -1566,10 +1568,7 @@ struct ByteAddressBufferLegalizationContext
         auto loVal = m_builder.emitCast(uintType, uint64Val);
         auto hiVal = m_builder.emitCast(
             uintType,
-            m_builder.emitShr(
-                uint64Type,
-                uint64Val,
-                m_builder.getIntValue(uint64Type, 32)));
+            m_builder.emitShr(uint64Type, uint64Val, m_builder.getIntValue(uint64Type, 32)));
 
         SLANG_RETURN_ON_FAIL(
             emitLegalStore(uintType, buffer, baseOffset, immediateOffset, alignment, loVal));

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -248,6 +248,9 @@ struct ByteAddressBufferLegalizationContext
         IRInst* unknownOffsetAlignment,
         IRIntegerValue alignmentVal)
     {
+        if (alignmentVal <= 0)
+            return false;
+
         if (auto baseOffsetVal = as<IRIntLit>(baseOffset))
         {
             // If the offset is a constant known at compile time, simply check if it aligned to

--- a/tests/bugs/gh-9931.slang
+++ b/tests/bugs/gh-9931.slang
@@ -1,0 +1,46 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -bindless-space-index 2 -O0
+
+// CHECK-DAG: %[[UINT:[A-Za-z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[V2UINT:[A-Za-z0-9_]+]] = OpTypeVector %[[UINT]] 2
+// CHECK-NOT: OpTypeRuntimeArray %[[V2UINT]]
+// CHECK-NOT: OpTypePointer StorageBuffer %[[V2UINT]]
+// CHECK: OpCompositeConstruct %[[V2UINT]]
+
+struct VectorStruct
+{
+    uint flags;
+    uint2 data;
+};
+
+struct HandleStruct
+{
+    uint flags;
+    DescriptorHandle<Texture2D<float4>> handle;
+};
+
+[[vk::binding(0, 0)]]
+ByteAddressBuffer inputBuffer;
+
+[[vk::binding(1, 0)]]
+RWStructuredBuffer<uint> outputBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    VectorStruct v = inputBuffer.Load<VectorStruct>(0);
+    HandleStruct h = inputBuffer.Load<HandleStruct>(0);
+    HandleStruct hAligned = inputBuffer.LoadAligned<HandleStruct>(0, 8);
+
+    uint2 handleBits = reinterpret<uint2>(h.handle);
+    uint2 alignedHandleBits = reinterpret<uint2>(hAligned.handle);
+
+    outputBuffer[0] = v.flags;
+    outputBuffer[1] = v.data.x;
+    outputBuffer[2] = v.data.y;
+    outputBuffer[3] = h.flags;
+    outputBuffer[4] = handleBits.x;
+    outputBuffer[5] = handleBits.y;
+    outputBuffer[6] = alignedHandleBits.x;
+    outputBuffer[7] = alignedHandleBits.y;
+}

--- a/tests/bugs/gh-9931.slang
+++ b/tests/bugs/gh-9931.slang
@@ -1,11 +1,18 @@
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -bindless-space-index 2 -O0
+//TEST:SIMPLE(filecheck=CHECK_NV): -target spirv-asm -entry computeMainNV -stage compute -bindless-space-index 2 -capability spvBindlessTextureNV -DNV_HANDLE -O0
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=RESULT): -vk -compute -shaderobj -xslang -bindless-space-index -xslang 2
 
 // CHECK-DAG: %[[UINT:[A-Za-z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[V2UINT:[A-Za-z0-9_]+]] = OpTypeVector %[[UINT]] 2
 // CHECK-NOT: OpTypeRuntimeArray %[[V2UINT]]
 // CHECK-NOT: OpTypePointer StorageBuffer %[[V2UINT]]
+// CHECK-NOT: OpStore %_ptr_StorageBuffer_v2uint
 // CHECK: OpCompositeConstruct %[[V2UINT]]
+
+// CHECK_NV-DAG: %[[ULONG:[A-Za-z0-9_]+]] = OpTypeInt 64 0
+// CHECK_NV-NOT: OpTypeRuntimeArray %[[ULONG]]
+// CHECK_NV-NOT: OpTypePointer StorageBuffer %[[ULONG]]
+// CHECK_NV: OpBitwiseOr %[[ULONG]]
 
 struct VectorStruct
 {
@@ -24,19 +31,48 @@ struct HandleStruct
 ByteAddressBuffer inputBuffer;
 
 [[vk::binding(1, 0)]]
-//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
+
+[[vk::binding(2, 0)]]
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputByteBuffer
+RWByteAddressBuffer outputByteBuffer;
+
+#if defined(NV_HANDLE)
 
 [shader("compute")]
 [numthreads(1, 1, 1)]
-void computeMain()
+void computeMainNV()
+{
+    DescriptorHandle<Texture2D<float4>> h =
+        inputBuffer.Load<DescriptorHandle<Texture2D<float4>>>(4);
+    outputByteBuffer.Store<DescriptorHandle<Texture2D<float4>>>(4, h, 8);
+
+    uint64_t handleBits = (uint64_t)h;
+
+    outputBuffer[0] = uint(handleBits);
+    outputBuffer[1] = uint(handleBits >> 32);
+    outputBuffer[2] = outputByteBuffer.Load<uint>(4);
+    outputBuffer[3] = outputByteBuffer.Load<uint>(8);
+}
+
+#else
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     VectorStruct v = inputBuffer.Load<VectorStruct>(0);
     HandleStruct h = inputBuffer.Load<HandleStruct>(0);
     HandleStruct hAligned = inputBuffer.LoadAligned<HandleStruct>(0, 8);
+    uint dynamicOffset = dispatchThreadID.x;
+    HandleStruct hDynamic = inputBuffer.LoadAligned<HandleStruct>(dynamicOffset, 8);
+
+    outputByteBuffer.Store<HandleStruct>(dynamicOffset, h, 8);
 
     uint2 handleBits = reinterpret<uint2>(h.handle);
     uint2 alignedHandleBits = reinterpret<uint2>(hAligned.handle);
+    uint2 dynamicHandleBits = reinterpret<uint2>(hDynamic.handle);
 
     outputBuffer[0] = v.flags;
     outputBuffer[1] = v.data.x;
@@ -46,7 +82,15 @@ void computeMain()
     outputBuffer[5] = handleBits.y;
     outputBuffer[6] = alignedHandleBits.x;
     outputBuffer[7] = alignedHandleBits.y;
+    outputBuffer[8] = hDynamic.flags;
+    outputBuffer[9] = dynamicHandleBits.x;
+    outputBuffer[10] = dynamicHandleBits.y;
+    outputBuffer[11] = outputByteBuffer.Load<uint>(0);
+    outputBuffer[12] = outputByteBuffer.Load<uint>(4);
+    outputBuffer[13] = outputByteBuffer.Load<uint>(8);
 }
+
+#endif
 
 // RESULT: 0
 // RESULT-NEXT: 1
@@ -54,5 +98,11 @@ void computeMain()
 // RESULT-NEXT: 0
 // RESULT-NEXT: 1
 // RESULT-NEXT: 2
+// RESULT-NEXT: 1
+// RESULT-NEXT: 2
+// RESULT-NEXT: 0
+// RESULT-NEXT: 1
+// RESULT-NEXT: 2
+// RESULT-NEXT: 0
 // RESULT-NEXT: 1
 // RESULT-NEXT: 2

--- a/tests/bugs/gh-9931.slang
+++ b/tests/bugs/gh-9931.slang
@@ -1,4 +1,5 @@
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -bindless-space-index 2 -O0
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=RESULT): -vk -compute -shaderobj -xslang -bindless-space-index -xslang 2
 
 // CHECK-DAG: %[[UINT:[A-Za-z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[V2UINT:[A-Za-z0-9_]+]] = OpTypeVector %[[UINT]] 2
@@ -19,9 +20,11 @@ struct HandleStruct
 };
 
 [[vk::binding(0, 0)]]
+//TEST_INPUT:ubuffer(data=[0 1 2 3 4 5 6 7], stride=4):name=inputBuffer
 ByteAddressBuffer inputBuffer;
 
 [[vk::binding(1, 0)]]
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
 
 [shader("compute")]
@@ -44,3 +47,12 @@ void computeMain()
     outputBuffer[6] = alignedHandleBits.x;
     outputBuffer[7] = alignedHandleBits.y;
 }
+
+// RESULT: 0
+// RESULT-NEXT: 1
+// RESULT-NEXT: 2
+// RESULT-NEXT: 0
+// RESULT-NEXT: 1
+// RESULT-NEXT: 2
+// RESULT-NEXT: 1
+// RESULT-NEXT: 2

--- a/tests/bugs/gh-9931.slang
+++ b/tests/bugs/gh-9931.slang
@@ -4,10 +4,14 @@
 
 // CHECK-DAG: %[[UINT:[A-Za-z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[V2UINT:[A-Za-z0-9_]+]] = OpTypeVector %[[UINT]] 2
+// CHECK-DAG: %[[ULONG:[A-Za-z0-9_]+]] = OpTypeInt 64 0
 // CHECK-NOT: OpTypeRuntimeArray %[[V2UINT]]
 // CHECK-NOT: OpTypePointer StorageBuffer %[[V2UINT]]
 // CHECK-NOT: OpStore %_ptr_StorageBuffer_v2uint
+// CHECK-NOT: OpTypeRuntimeArray %[[ULONG]]
+// CHECK-NOT: OpTypePointer StorageBuffer %[[ULONG]]
 // CHECK: OpCompositeConstruct %[[V2UINT]]
+// CHECK: OpBitwiseOr %[[ULONG]]
 
 // CHECK_NV-DAG: %[[ULONG:[A-Za-z0-9_]+]] = OpTypeInt 64 0
 // CHECK_NV-NOT: OpTypeRuntimeArray %[[ULONG]]
@@ -31,11 +35,11 @@ struct HandleStruct
 ByteAddressBuffer inputBuffer;
 
 [[vk::binding(1, 0)]]
-//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
 
 [[vk::binding(2, 0)]]
-//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=outputByteBuffer
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name=outputByteBuffer
 RWByteAddressBuffer outputByteBuffer;
 
 #if defined(NV_HANDLE)
@@ -67,8 +71,10 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     HandleStruct hAligned = inputBuffer.LoadAligned<HandleStruct>(0, 8);
     uint dynamicOffset = dispatchThreadID.x;
     HandleStruct hDynamic = inputBuffer.LoadAligned<HandleStruct>(dynamicOffset, 8);
+    uint64_t u64 = inputBuffer.Load<uint64_t>(4);
 
     outputByteBuffer.Store<HandleStruct>(dynamicOffset, h, 8);
+    outputByteBuffer.Store<uint64_t>(20, u64);
 
     uint2 handleBits = reinterpret<uint2>(h.handle);
     uint2 alignedHandleBits = reinterpret<uint2>(hAligned.handle);
@@ -88,6 +94,10 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     outputBuffer[11] = outputByteBuffer.Load<uint>(0);
     outputBuffer[12] = outputByteBuffer.Load<uint>(4);
     outputBuffer[13] = outputByteBuffer.Load<uint>(8);
+    outputBuffer[14] = uint(u64);
+    outputBuffer[15] = uint(u64 >> 32);
+    outputBuffer[16] = outputByteBuffer.Load<uint>(20);
+    outputBuffer[17] = outputByteBuffer.Load<uint>(24);
 }
 
 #endif
@@ -104,5 +114,9 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 // RESULT-NEXT: 1
 // RESULT-NEXT: 2
 // RESULT-NEXT: 0
+// RESULT-NEXT: 1
+// RESULT-NEXT: 2
+// RESULT-NEXT: 1
+// RESULT-NEXT: 2
 // RESULT-NEXT: 1
 // RESULT-NEXT: 2

--- a/tests/compute/byte-address-buffer-align-error.slang
+++ b/tests/compute/byte-address-buffer-align-error.slang
@@ -16,10 +16,12 @@ struct Block {
 [numthreads(1,1,1)]
 void computeMain(uint3 threadId : SV_DispatchThreadID)
 {
+    uint address = threadId.x;
+
     // CHECK: error[E41300]: invalid byte address buffer alignment
     // CHECK: error[E41300]: invalid byte address buffer alignment
-    buffer.Store<Block>(0, buffer.LoadAligned<Block>(1, 5));
-    buffer.Store<Block>(1, buffer.Load<Block>(0), 3);
+    buffer.Store<Block>(address, buffer.LoadAligned<Block>(address, 5));
+    buffer.Store<Block>(address, buffer.Load<Block>(address), 3);
 
 }
 

--- a/tests/compute/byte-address-buffer-align-error.slang
+++ b/tests/compute/byte-address-buffer-align-error.slang
@@ -5,6 +5,7 @@
 //TEST:SIMPLE(filecheck=CHECK):-target spirv -entry computeMain -stage compute
 //TEST:SIMPLE(filecheck=CHECK):-target spirv -emit-spirv-directly -entry computeMain -stage compute
 //TEST:SIMPLE(filecheck=CHECK):-target cuda -entry computeMain -stage compute
+//DIAGNOSTIC_TEST:SIMPLE(diag=LOC,non-exhaustive):-target spirv -entry computeMain -stage compute
 
 // Confirm compilation of `(RW)ByteAddressBuffer` with aligned load / stores to wider data types.
 
@@ -16,12 +17,11 @@ struct Block {
 [numthreads(1,1,1)]
 void computeMain(uint3 threadId : SV_DispatchThreadID)
 {
-    uint address = threadId.x;
-
     // CHECK: error[E41300]: invalid byte address buffer alignment
     // CHECK: error[E41300]: invalid byte address buffer alignment
-    buffer.Store<Block>(address, buffer.LoadAligned<Block>(address, 5));
-    buffer.Store<Block>(address, buffer.Load<Block>(address), 3);
+    buffer.Store<Block>(threadId.x, buffer.LoadAligned<Block>(threadId.x, 5));
+//LOC:                                                                 ^ invalid byte address buffer alignment
+    buffer.Store<Block>(threadId.x, buffer.Load<Block>(threadId.x), 3);
+//LOC:                           ^ invalid byte address buffer alignment
 
 }
-

--- a/tests/compute/byte-address-buffer-array.slang
+++ b/tests/compute/byte-address-buffer-array.slang
@@ -27,7 +27,11 @@ void computeMain(uint3 threadId : SV_DispatchThreadID)
     // CHECK2: float {{.*}} = (buffer_0).Load<float >(12U);
     // CHECK2: float {{.*}} = (buffer_0).Load<float >(16U);
     // CHECK2: float4 {{.*}} = float4({{.*}}, {{.*}}, {{.*}}, {{.*}});
-    // CHECK2: float4 {{.*}} = (buffer_0).Load<float4 >(20U);
+    // CHECK2: float {{.*}} = (buffer_0).Load<float >(20U);
+    // CHECK2: float {{.*}} = (buffer_0).Load<float >(24U);
+    // CHECK2: float {{.*}} = (buffer_0).Load<float >(28U);
+    // CHECK2: float {{.*}} = (buffer_0).Load<float >(32U);
+    // CHECK2: float4 {{.*}} = float4({{.*}}, {{.*}}, {{.*}}, {{.*}});
     // CHECK2: buffer_0.Store(16U,{{.*}});
     // CHECK2: buffer_0.Store(32U,{{.*}});
 


### PR DESCRIPTION
Fixes #9931

## Summary of the problem from the end user perspective

`ByteAddressBuffer.Load<T>()` could read the wrong data for `uint2` or `DescriptorHandle<T>` fields placed at offsets that are only 4-byte aligned when emitting SPIR-V.

### Minimal repro shader; if applicable

```slang
struct S
{
    uint flags;
    DescriptorHandle<Texture2D<float4>> handle;
};

ByteAddressBuffer inputBuffer;
S value = inputBuffer.Load<S>(0);
```

## Root cause

The SPIR-V byte-address-buffer legalization translated descriptor handles as opaque leaf values, so they could become `v2uint` structured-buffer loads even when the field offset was not 8-byte aligned. The vector alignment helper also ignored constant nested field offsets when checking whether a wide vector load was valid.

## Solution in this PR

Descriptor handles now legalize through their concrete storage representation before structured-buffer translation, using `uint2` for ordinary SPIR-V and `uint64` for `spvBindlessTextureNV`. The alignment check now includes both the dynamic base offset and the immediate nested offset before allowing vectorized load/store lowering.

### Notes to the reviewers; where to focus on

The key changes are in byte-address-buffer load/store legalization: descriptor-handle load/store recursion and the updated `isAligned` helper. The new `gh-9931` regression checks that unaligned `uint2` and descriptor-handle fields are reconstructed from scalar `uint` storage-buffer loads instead of introducing a storage-buffer `v2uint` alias.

## Reviewer Directives (maintained by agent)

- Human reviewer @jkwak-work requested a COMPARE_COMPUTE regression test for this PR; keep that runtime coverage in tests/bugs/gh-9931.slang. See https://github.com/jkwak-work/slang/pull/228#discussion_r3341912783.
- [LLM github-actions] Keep the misaligned 8-byte scalar split scoped to byte-address-buffer-to-structured-buffer translation; targets that keep byte-address-buffer operations use the simple/lowerBasicTypeOps paths. (https://github.com/shader-slang/slang/pull/11430#discussion_r3343672011)
