### PR TITLE
Handle descriptor heap byte address buffers

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -26997,6 +26997,9 @@ struct DescriptorHandle<T:IOpaqueDescriptor> : IComparable
     __intrinsic_op($(kIROp_CastUInt2ToDescriptorHandle))
     __init(uint2 handleValue);
 
+    // Under spvDescriptorHeapEXT, a scalar handle is a resource-heap index.
+    // Keep this distinct from the uint64_t constructors used by CUDA and
+    // spvBindlessTextureNV so integer literals do not select the wrong layout.
     [ForceInline]
     [require(spvDescriptorHeapEXT, descriptor_handle)]
     __init(uint handleValue)

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -26997,6 +26997,20 @@ struct DescriptorHandle<T:IOpaqueDescriptor> : IComparable
     __intrinsic_op($(kIROp_CastUInt2ToDescriptorHandle))
     __init(uint2 handleValue);
 
+    [ForceInline]
+    [require(spvDescriptorHeapEXT, descriptor_handle)]
+    __init(uint handleValue)
+    {
+        return DescriptorHandle<T>(uint2(handleValue, 0));
+    }
+
+    [ForceInline]
+    [require(spvDescriptorHeapEXT, descriptor_handle)]
+    __init(int handleValue)
+    {
+        return DescriptorHandle<T>(uint(handleValue));
+    }
+
     /// Constructor for uint64_t handles
     [ForceInline]
     [require(spvBindlessTextureNV, descriptor_handle)]

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -26997,23 +26997,6 @@ struct DescriptorHandle<T:IOpaqueDescriptor> : IComparable
     __intrinsic_op($(kIROp_CastUInt2ToDescriptorHandle))
     __init(uint2 handleValue);
 
-    // Under spvDescriptorHeapEXT, a scalar handle is a resource-heap index.
-    // Keep this distinct from the uint64_t constructors used by CUDA and
-    // spvBindlessTextureNV so integer literals do not select the wrong layout.
-    [ForceInline]
-    [require(spvDescriptorHeapEXT, descriptor_handle)]
-    __init(uint handleValue)
-    {
-        return DescriptorHandle<T>(uint2(handleValue, 0));
-    }
-
-    [ForceInline]
-    [require(spvDescriptorHeapEXT, descriptor_handle)]
-    __init(int handleValue)
-    {
-        return DescriptorHandle<T>(uint(handleValue));
-    }
-
     /// Constructor for uint64_t handles
     [ForceInline]
     [require(spvBindlessTextureNV, descriptor_handle)]

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -979,6 +979,21 @@ struct ByteAddressBufferLegalizationContext
                 loadDescriptor->getHeap(),
                 loadDescriptor->getIndex());
         }
+        else if (auto resourceDescriptor = as<IRLoadResourceDescriptorFromHeap>(byteAddressBuffer))
+        {
+            auto structuredBufferType = getEquivalentStructuredBufferParamType(
+                elementType,
+                resourceDescriptor->getDataType());
+            if (!structuredBufferType)
+                return nullptr;
+
+            auto index = resourceDescriptor->getIndex();
+            return m_builder.emitIntrinsicInst(
+                structuredBufferType,
+                kIROp_LoadResourceDescriptorFromHeap,
+                1,
+                &index);
+        }
 
         if (byteAddressBuffer->getOp() == kIROp_GetElement)
         {

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -969,6 +969,9 @@ struct ByteAddressBufferLegalizationContext
         }
         else if (auto loadDescriptor = as<IRSPIRVLoadDescriptorFromHeap>(byteAddressBuffer))
         {
+            // Under spvDescriptorHeapEXT, DescriptorHandle<T> dereferences lower to a heap load.
+            // Reinterpret that heap-sourced ByteAddressBuffer as the equivalent StructuredBuffer
+            // before replacing byte-address loads/stores with structured-buffer operations.
             auto structuredBufferType =
                 getEquivalentStructuredBufferParamType(elementType, loadDescriptor->getDataType());
             if (!structuredBufferType)

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -967,6 +967,18 @@ struct ByteAddressBufferLegalizationContext
                 1,
                 &arg);
         }
+        else if (auto loadDescriptor = as<IRSPIRVLoadDescriptorFromHeap>(byteAddressBuffer))
+        {
+            auto structuredBufferType =
+                getEquivalentStructuredBufferParamType(elementType, loadDescriptor->getDataType());
+            if (!structuredBufferType)
+                return nullptr;
+
+            return m_builder.emitLoadDescriptorFromHeap(
+                structuredBufferType,
+                loadDescriptor->getHeap(),
+                loadDescriptor->getIndex());
+        }
 
         if (byteAddressBuffer->getOp() == kIROp_GetElement)
         {

--- a/source/slang/slang-ir-byte-address-legalize.cpp
+++ b/source/slang/slang-ir-byte-address-legalize.cpp
@@ -969,9 +969,6 @@ struct ByteAddressBufferLegalizationContext
         }
         else if (auto loadDescriptor = as<IRSPIRVLoadDescriptorFromHeap>(byteAddressBuffer))
         {
-            // Under spvDescriptorHeapEXT, DescriptorHandle<T> dereferences lower to a heap load.
-            // Reinterpret that heap-sourced ByteAddressBuffer as the equivalent StructuredBuffer
-            // before replacing byte-address loads/stores with structured-buffer operations.
             auto structuredBufferType =
                 getEquivalentStructuredBufferParamType(elementType, loadDescriptor->getDataType());
             if (!structuredBufferType)

--- a/tests/spirv/descriptor-heap-byte-address-buffer.slang
+++ b/tests/spirv/descriptor-heap-byte-address-buffer.slang
@@ -19,38 +19,27 @@
 //TEST_INPUT:ubuffer(data=[0 0], stride=4):out,name=output
 RWStructuredBuffer<uint> output;
 
-//TEST_INPUT: set runtimeReadOnlyBuffer = ubuffer(data=[4 99], stride=4)
-uniform ByteAddressBuffer.Handle runtimeReadOnlyBuffer;
+//TEST_INPUT: set readOnlyBuffer = ubuffer(data=[4 99], stride=4)
+uniform ByteAddressBuffer.Handle readOnlyBuffer;
 
-//TEST_INPUT: set runtimeReadWriteBuffer = ubuffer(data=[0 0], stride=4)
-uniform RWByteAddressBuffer.Handle runtimeReadWriteBuffer;
+//TEST_INPUT: set readWriteBuffer = ubuffer(data=[0 0], stride=4)
+uniform RWByteAddressBuffer.Handle readWriteBuffer;
+
+uniform RasterizerOrderedByteAddressBuffer.Handle rasterOrderedBuffer;
 
 [numthreads(1, 1, 1)]
 void computeMain()
 {
-#if defined(RUNTIME)
-    let value0 = runtimeReadOnlyBuffer.Load<uint>(0);
-    runtimeReadWriteBuffer.Store<uint>(4, value0 * 2);
+    let value0 = readOnlyBuffer.Load<uint>(0);
+    readWriteBuffer.Store<uint>(4, value0 * 2);
 
     output[0] = value0;
-    output[1] = runtimeReadWriteBuffer.Load<uint>(4);
-#else
-    let readOnlyBuffer = DescriptorHandle<ByteAddressBuffer>(0);
-    let readWriteBuffer = DescriptorHandle<RWByteAddressBuffer>(uint(1));
-
-    let value0 = readOnlyBuffer.Load<uint>(0);
-    readWriteBuffer.Store<uint>(4, value0 + 1);
-    let value1 = readWriteBuffer.Load<uint>(4);
-    output[0] = value1;
-#endif
+    output[1] = readWriteBuffer.Load<uint>(4);
 }
 
 [shader("fragment")]
 float4 fragmentMain() : SV_Target
 {
-    let rasterOrderedBuffer =
-        DescriptorHandle<RasterizerOrderedByteAddressBuffer>(uint(2));
-
     rasterOrderedBuffer.Store<uint>(8, 1);
     return float4(rasterOrderedBuffer.Load<uint>(8), 0, 0, 1);
 }

--- a/tests/spirv/descriptor-heap-byte-address-buffer.slang
+++ b/tests/spirv/descriptor-heap-byte-address-buffer.slang
@@ -1,0 +1,36 @@
+// Regression test for descriptor-heap sourced ByteAddressBuffer values.
+// Byte-address-buffer legalization must rewrite the heap load to an equivalent
+// structured-buffer heap load before SPIR-V emission.
+
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -capability spvDescriptorHeapEXT -emit-spirv-directly
+//TEST:SIMPLE(filecheck=ROV): -target spirv-asm -entry fragmentMain -stage fragment -capability spvDescriptorHeapEXT -emit-spirv-directly
+
+// CHECK: OpCapability DescriptorHeapEXT
+// CHECK: OpUntypedAccessChainKHR
+
+// ROV: OpCapability DescriptorHeapEXT
+// ROV: OpUntypedAccessChainKHR
+
+RWStructuredBuffer<uint> output;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    let readOnlyBuffer = DescriptorHandle<ByteAddressBuffer>(0);
+    let readWriteBuffer = DescriptorHandle<RWByteAddressBuffer>(uint(1));
+
+    let value0 = readOnlyBuffer.Load<uint>(0);
+    readWriteBuffer.Store<uint>(4, value0 + 1);
+    let value1 = readWriteBuffer.Load<uint>(4);
+    output[0] = value1;
+}
+
+[shader("fragment")]
+float4 fragmentMain() : SV_Target
+{
+    let rasterOrderedBuffer =
+        DescriptorHandle<RasterizerOrderedByteAddressBuffer>(uint(2));
+
+    rasterOrderedBuffer.Store<uint>(8, 1);
+    return float4(rasterOrderedBuffer.Load<uint>(8), 0, 0, 1);
+}

--- a/tests/spirv/descriptor-heap-byte-address-buffer.slang
+++ b/tests/spirv/descriptor-heap-byte-address-buffer.slang
@@ -71,6 +71,8 @@ void computeMain()
 [numthreads(1, 1, 1)]
 void hlslMain()
 {
+    // Public HLSL ByteAddressBuffer APIs emit native methods, so this entry
+    // directly exercises equivalent-structured-buffer descriptor-heap lowering.
     let readOnlyStructured = __getEquivalentStructuredBuffer<uint>(readOnlyBuffer);
     let readWriteStructured = __getEquivalentStructuredBuffer<uint>(readWriteBuffer);
 

--- a/tests/spirv/descriptor-heap-byte-address-buffer.slang
+++ b/tests/spirv/descriptor-heap-byte-address-buffer.slang
@@ -11,10 +11,22 @@
 // RUNTIME-NEXT: 8
 
 // CHECK: OpCapability DescriptorHeapEXT
-// CHECK: OpUntypedAccessChainKHR
+// CHECK-NOT: ByteAddressBuffer
+// CHECK: %StructuredBuffer = OpTypeStruct %_runtimearr_uint
+// CHECK: %_ptr_StorageBuffer_StructuredBuffer = OpTypePointer StorageBuffer %StructuredBuffer
+// CHECK: %RWStructuredBuffer = OpTypeStruct %_runtimearr_uint
+// CHECK: %_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
+// CHECK: OpBufferPointerEXT %_ptr_StorageBuffer_StructuredBuffer
+// CHECK: OpAccessChain %_ptr_StorageBuffer_uint
+// CHECK: OpBufferPointerEXT %_ptr_StorageBuffer_RWStructuredBuffer
+// CHECK: OpAccessChain %_ptr_StorageBuffer_uint
 
 // ROV: OpCapability DescriptorHeapEXT
-// ROV: OpUntypedAccessChainKHR
+// ROV-NOT: ByteAddressBuffer
+// ROV: %RasterizerOrderedStructuredBuffer = OpTypeStruct %_runtimearr_uint
+// ROV: %_ptr_StorageBuffer_RasterizerOrderedStructuredBuffer = OpTypePointer StorageBuffer %RasterizerOrderedStructuredBuffer
+// ROV: OpBufferPointerEXT %_ptr_StorageBuffer_RasterizerOrderedStructuredBuffer
+// ROV: OpAccessChain %_ptr_StorageBuffer_uint
 
 //TEST_INPUT:ubuffer(data=[0 0], stride=4):out,name=output
 RWStructuredBuffer<uint> output;
@@ -25,6 +37,7 @@ uniform ByteAddressBuffer.Handle readOnlyBuffer;
 //TEST_INPUT: set readWriteBuffer = ubuffer(data=[0 0], stride=4)
 uniform RWByteAddressBuffer.Handle readWriteBuffer;
 
+//TEST_INPUT: set rasterOrderedBuffer = ubuffer(data=[0 0 0], stride=4)
 uniform RasterizerOrderedByteAddressBuffer.Handle rasterOrderedBuffer;
 
 [numthreads(1, 1, 1)]

--- a/tests/spirv/descriptor-heap-byte-address-buffer.slang
+++ b/tests/spirv/descriptor-heap-byte-address-buffer.slang
@@ -2,8 +2,13 @@
 // Byte-address-buffer legalization must rewrite the heap load to an equivalent
 // structured-buffer heap load before SPIR-V emission.
 
+//TEST:COMPARE_COMPUTE(filecheck-buffer=RUNTIME): -vk -shaderobj -output-using-type -render-feature bindless -emit-spirv-directly -Xslang -DRUNTIME
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -capability spvDescriptorHeapEXT -emit-spirv-directly
 //TEST:SIMPLE(filecheck=ROV): -target spirv-asm -entry fragmentMain -stage fragment -capability spvDescriptorHeapEXT -emit-spirv-directly
+
+// RUNTIME: type: uint
+// RUNTIME-NEXT: 4
+// RUNTIME-NEXT: 8
 
 // CHECK: OpCapability DescriptorHeapEXT
 // CHECK: OpUntypedAccessChainKHR
@@ -11,11 +16,25 @@
 // ROV: OpCapability DescriptorHeapEXT
 // ROV: OpUntypedAccessChainKHR
 
+//TEST_INPUT:ubuffer(data=[0 0], stride=4):out,name=output
 RWStructuredBuffer<uint> output;
+
+//TEST_INPUT: set runtimeReadOnlyBuffer = ubuffer(data=[4 99], stride=4)
+uniform ByteAddressBuffer.Handle runtimeReadOnlyBuffer;
+
+//TEST_INPUT: set runtimeReadWriteBuffer = ubuffer(data=[0 0], stride=4)
+uniform RWByteAddressBuffer.Handle runtimeReadWriteBuffer;
 
 [numthreads(1, 1, 1)]
 void computeMain()
 {
+#if defined(RUNTIME)
+    let value0 = runtimeReadOnlyBuffer.Load<uint>(0);
+    runtimeReadWriteBuffer.Store<uint>(4, value0 * 2);
+
+    output[0] = value0;
+    output[1] = runtimeReadWriteBuffer.Load<uint>(4);
+#else
     let readOnlyBuffer = DescriptorHandle<ByteAddressBuffer>(0);
     let readWriteBuffer = DescriptorHandle<RWByteAddressBuffer>(uint(1));
 
@@ -23,6 +42,7 @@ void computeMain()
     readWriteBuffer.Store<uint>(4, value0 + 1);
     let value1 = readWriteBuffer.Load<uint>(4);
     output[0] = value1;
+#endif
 }
 
 [shader("fragment")]

--- a/tests/spirv/descriptor-heap-byte-address-buffer.slang
+++ b/tests/spirv/descriptor-heap-byte-address-buffer.slang
@@ -38,6 +38,8 @@
 
 // HLSL: StructuredBuffer<uint >{{.*}}ResourceDescriptorHeap[
 // HLSL: RWStructuredBuffer<uint >{{.*}}ResourceDescriptorHeap[
+// HLSL: [int(1)] = 7U
+// HLSL: InterlockedAdd
 // HLSL-NOT: asStructuredBuffer
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=output
@@ -78,6 +80,11 @@ void hlslMain()
 
     output[0] = readOnlyStructured[0];
     output[1] = readWriteStructured[0];
+    readWriteStructured[1] = 7;
+
+    uint original = 0;
+    InterlockedAdd(readWriteStructured[2], 5, original);
+    output[2] = original;
 }
 
 [shader("fragment")]

--- a/tests/spirv/descriptor-heap-byte-address-buffer.slang
+++ b/tests/spirv/descriptor-heap-byte-address-buffer.slang
@@ -4,8 +4,8 @@
 
 //TEST:COMPARE_COMPUTE(filecheck-buffer=RUNTIME): -vk -shaderobj -output-using-type -render-feature bindless -emit-spirv-directly -Xslang -DRUNTIME
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -capability spvDescriptorHeapEXT -emit-spirv-directly
-//TEST:SIMPLE(filecheck=ROV): -target spirv-asm -entry fragmentMain -stage fragment -capability spvDescriptorHeapEXT -emit-spirv-directly
-//TEST:SIMPLE(filecheck=HLSL): -target hlsl -entry hlslMain -profile cs_6_6
+//TEST:SIMPLE(filecheck=FRAG): -target spirv-asm -entry fragmentMain -stage fragment -capability spvDescriptorHeapEXT -emit-spirv-directly
+//TEST:SIMPLE(filecheck=DXIL): -target dxil -entry hlslMain -profile cs_6_6
 
 // RUNTIME: type: uint
 // RUNTIME-NEXT: 4
@@ -29,18 +29,14 @@
 // CHECK: OpAccessChain %_ptr_StorageBuffer_uint
 // CHECK: OpAtomicIAdd
 
-// ROV: OpCapability DescriptorHeapEXT
-// ROV-NOT: ByteAddressBuffer
-// ROV: %RasterizerOrderedStructuredBuffer = OpTypeStruct %_runtimearr_uint
-// ROV: %_ptr_StorageBuffer_RasterizerOrderedStructuredBuffer = OpTypePointer StorageBuffer %RasterizerOrderedStructuredBuffer
-// ROV: OpBufferPointerEXT %_ptr_StorageBuffer_RasterizerOrderedStructuredBuffer
-// ROV: OpAccessChain %_ptr_StorageBuffer_uint
+// FRAG: OpCapability DescriptorHeapEXT
+// FRAG-NOT: ByteAddressBuffer
+// FRAG: %RasterizerOrderedStructuredBuffer = OpTypeStruct %_runtimearr_uint
+// FRAG: %_ptr_StorageBuffer_RasterizerOrderedStructuredBuffer = OpTypePointer StorageBuffer %RasterizerOrderedStructuredBuffer
+// FRAG: OpBufferPointerEXT %_ptr_StorageBuffer_RasterizerOrderedStructuredBuffer
+// FRAG: OpAccessChain %_ptr_StorageBuffer_uint
 
-// HLSL: StructuredBuffer<uint >{{.*}}ResourceDescriptorHeap[
-// HLSL: RWStructuredBuffer<uint >{{.*}}ResourceDescriptorHeap[
-// HLSL: [int(1)] = 7U
-// HLSL: InterlockedAdd
-// HLSL-NOT: asStructuredBuffer
+// DXIL: result code = 0
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=output
 RWStructuredBuffer<uint> output;

--- a/tests/spirv/descriptor-heap-byte-address-buffer.slang
+++ b/tests/spirv/descriptor-heap-byte-address-buffer.slang
@@ -1,25 +1,33 @@
 // Regression test for descriptor-heap sourced ByteAddressBuffer values.
-// Byte-address-buffer legalization must rewrite the heap load to an equivalent
-// structured-buffer heap load before SPIR-V emission.
+// Byte-address-buffer legalization must rewrite heap loads to equivalent
+// structured-buffer heap loads before target emission.
 
 //TEST:COMPARE_COMPUTE(filecheck-buffer=RUNTIME): -vk -shaderobj -output-using-type -render-feature bindless -emit-spirv-directly -Xslang -DRUNTIME
 //TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry computeMain -stage compute -capability spvDescriptorHeapEXT -emit-spirv-directly
 //TEST:SIMPLE(filecheck=ROV): -target spirv-asm -entry fragmentMain -stage fragment -capability spvDescriptorHeapEXT -emit-spirv-directly
+//TEST:SIMPLE(filecheck=HLSL): -target hlsl -entry hlslMain -profile cs_6_6
 
 // RUNTIME: type: uint
 // RUNTIME-NEXT: 4
 // RUNTIME-NEXT: 8
+// RUNTIME-NEXT: 0
+// RUNTIME-NEXT: 5
 
 // CHECK: OpCapability DescriptorHeapEXT
 // CHECK-NOT: ByteAddressBuffer
-// CHECK: %StructuredBuffer = OpTypeStruct %_runtimearr_uint
+// CHECK: %v4uint = OpTypeVector %uint 4
+// CHECK: %_runtimearr_v4uint = OpTypeRuntimeArray %v4uint
+// CHECK: %StructuredBuffer = OpTypeStruct %_runtimearr_v4uint
 // CHECK: %_ptr_StorageBuffer_StructuredBuffer = OpTypePointer StorageBuffer %StructuredBuffer
+// CHECK: %_ptr_StorageBuffer_v4uint = OpTypePointer StorageBuffer %v4uint
 // CHECK: %RWStructuredBuffer = OpTypeStruct %_runtimearr_uint
 // CHECK: %_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
 // CHECK: OpBufferPointerEXT %_ptr_StorageBuffer_StructuredBuffer
-// CHECK: OpAccessChain %_ptr_StorageBuffer_uint
+// CHECK: OpAccessChain %_ptr_StorageBuffer_v4uint
+// CHECK: OpLoad %v4uint
 // CHECK: OpBufferPointerEXT %_ptr_StorageBuffer_RWStructuredBuffer
 // CHECK: OpAccessChain %_ptr_StorageBuffer_uint
+// CHECK: OpAtomicIAdd
 
 // ROV: OpCapability DescriptorHeapEXT
 // ROV-NOT: ByteAddressBuffer
@@ -28,13 +36,17 @@
 // ROV: OpBufferPointerEXT %_ptr_StorageBuffer_RasterizerOrderedStructuredBuffer
 // ROV: OpAccessChain %_ptr_StorageBuffer_uint
 
-//TEST_INPUT:ubuffer(data=[0 0], stride=4):out,name=output
+// HLSL: StructuredBuffer<uint >{{.*}}ResourceDescriptorHeap[
+// HLSL: RWStructuredBuffer<uint >{{.*}}ResourceDescriptorHeap[
+// HLSL-NOT: asStructuredBuffer
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=output
 RWStructuredBuffer<uint> output;
 
-//TEST_INPUT: set readOnlyBuffer = ubuffer(data=[4 99], stride=4)
+//TEST_INPUT: set readOnlyBuffer = ubuffer(data=[4 5 6 7], stride=4)
 uniform ByteAddressBuffer.Handle readOnlyBuffer;
 
-//TEST_INPUT: set readWriteBuffer = ubuffer(data=[0 0], stride=4)
+//TEST_INPUT: set readWriteBuffer = ubuffer(data=[0 0 0 0], stride=4)
 uniform RWByteAddressBuffer.Handle readWriteBuffer;
 
 //TEST_INPUT: set rasterOrderedBuffer = ubuffer(data=[0 0 0], stride=4)
@@ -43,11 +55,27 @@ uniform RasterizerOrderedByteAddressBuffer.Handle rasterOrderedBuffer;
 [numthreads(1, 1, 1)]
 void computeMain()
 {
-    let value0 = readOnlyBuffer.Load<uint>(0);
+    let vectorValue = readOnlyBuffer.Load<uint4>(0);
+    let value0 = vectorValue.x;
     readWriteBuffer.Store<uint>(4, value0 * 2);
+
+    uint original = 0;
+    readWriteBuffer.InterlockedAdd(0, vectorValue.y, original);
 
     output[0] = value0;
     output[1] = readWriteBuffer.Load<uint>(4);
+    output[2] = original;
+    output[3] = readWriteBuffer.Load<uint>(0);
+}
+
+[numthreads(1, 1, 1)]
+void hlslMain()
+{
+    let readOnlyStructured = __getEquivalentStructuredBuffer<uint>(readOnlyBuffer);
+    let readWriteStructured = __getEquivalentStructuredBuffer<uint>(readWriteBuffer);
+
+    output[0] = readOnlyStructured[0];
+    output[1] = readWriteStructured[0];
 }
 
 [shader("fragment")]


### PR DESCRIPTION
Fixes #10440
Fixes #10979

## Summary of the problem from the end user perspective

SPIR-V compilation could fail when a descriptor-heap-sourced `ByteAddressBuffer` handle was used through byte-address load/store operations. The same legalization gap affected writable and rasterizer-ordered byte-address buffer handles, and the generic HLSL descriptor-heap lowering path needed the same equivalent structured-buffer rewrite.

### Minimal repro shader; if applicable

```slang
RWStructuredBuffer<uint> output;
uniform ByteAddressBuffer.Handle readOnlyBuffer;

[numthreads(1, 1, 1)]
void computeMain()
{
    output[0] = readOnlyBuffer.Load<uint>(0);
}
```

## Root cause

Byte-address-buffer legalization rewrites raw buffer loads and stores to equivalent structured-buffer operations, but it did not recognize descriptor-heap resource loads as buffer sources. As a result, descriptor-heap byte-address buffers were not retyped before later SPIR-V emission, and the generic `IRLoadResourceDescriptorFromHeap` path could still fall back to an invalid `.asStructuredBuffer<T>()` emission shape.

## Solution in this PR

Handle descriptor-heap resource loads in byte-address-buffer legalization by re-emitting the same heap/index lookup with the equivalent structured-buffer type. Add regression coverage for read-only, read-write, and rasterizer-ordered byte-address buffers, including a Vulkan runtime comparison path that sources descriptor handles from uniform inputs, a wide-vector load, an atomic operation, and DXIL compilation coverage for generic equivalent structured-buffer heap loads.

### Notes to the reviewers; where to focus on

The legalization change preserves the original descriptor heap and index while changing only the loaded resource type used by the byte-address-buffer rewrite. The test intentionally uses `ByteAddressBuffer.Handle`, `RWByteAddressBuffer.Handle`, and `RasterizerOrderedByteAddressBuffer.Handle` uniforms rather than static descriptor indices.

## Reviewer Directives (maintained by agent)

- [human @jkwak-work] Do not add `spvDescriptorHeapEXT` scalar `DescriptorHandle<T>` constructors for static descriptor-heap values; descriptor-heap handle values in this PR should come from uniform input. (https://github.com/jkwak-work/slang/pull/230#discussion_r3342868372)
- [human @jkwak-work] Keep the source change minimal and do not add explanatory comments around the `IRSPIRVLoadDescriptorFromHeap` case solely to answer review questions. (https://github.com/jkwak-work/slang/pull/230#discussion_r3342878376)
- [human @jkwak-work] Prefer end-user APIs in tests; if this PR keeps direct internal `__getEquivalentStructuredBuffer` calls, keep a test comment explaining the targeted generic descriptor-heap lowering coverage. (https://github.com/shader-slang/slang/pull/11431#discussion_r3343778670)
- [human @jkwak-work] Validate the generic equivalent-structured-buffer path with a DXIL target test rather than an emitted-HLSL-only test, and use `FRAG` as the fragment FileCheck prefix. (https://github.com/shader-slang/slang/pull/11431#discussion_r3344805569, https://github.com/shader-slang/slang/pull/11431#discussion_r3344806399)
