### PR TITLE
Add SLANG_USE_SYSTEM_DXC option for system-installed DXC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,18 @@ advanced_option(
     "Build using system glslang library"
     OFF
 )
+
+# Highest-precedence DXC acquisition path; see docs/building.md
+# (#dxc-acquisition). Hidden unless SLANG_ENABLE_DXIL=ON.
+cmake_dependent_option(
+    SLANG_USE_SYSTEM_DXC
+    "Build using system DXC instead of fetching or building it"
+    OFF
+    "SLANG_ENABLE_DXIL"
+    OFF
+)
+mark_as_advanced(SLANG_USE_SYSTEM_DXC)
+
 if(WIN32)
     set(SLANG_ENABLE_SPIRV_TOOLS_MIMALLOC_DEFAULT ON)
 else()
@@ -598,7 +610,11 @@ if(${SLANG_USE_SYSTEM_GLSLANG})
 endif()
 
 if(SLANG_ENABLE_DXIL)
-    include(FetchDXC)
+    if(SLANG_USE_SYSTEM_DXC)
+        include(SystemDXC)
+    else()
+        include(FetchDXC)
+    endif()
 endif()
 
 add_subdirectory(external)

--- a/cmake/DXCMetadata.cmake
+++ b/cmake/DXCMetadata.cmake
@@ -1,0 +1,33 @@
+# DXC release metadata shared by FetchDXC.cmake (download / source build)
+# and FindDXC.cmake (system-DXC version check).
+#
+# To upgrade DXC:
+#   1. Pick a release tag from
+#      https://github.com/microsoft/DirectXShaderCompiler/releases.
+#   2. Set SLANG_DXC_VERSION_TAG to that tag.
+#   3. Set SLANG_DXC_RELEASE_DATE to the date used in the asset names
+#      (dxc_<YYYY_MM_DD>.zip and linux_dxc_<YYYY_MM_DD>.x86_64.tar.gz).
+#   4. Resolve the tag to the source commit (peeled hash for annotated tags):
+#      git ls-remote https://github.com/microsoft/DirectXShaderCompiler.git \
+#          "refs/tags/<tag>" "refs/tags/<tag>^{}"
+#   5. Update the hashes:
+#      sha256sum dxc_<YYYY_MM_DD>.zip linux_dxc_<YYYY_MM_DD>.x86_64.tar.gz
+#   6. Keep external/slang-rhi/CMakeLists.txt's SLANG_RHI_DXC_URL in sync
+#      with SLANG_DXC_WINDOWS_URL below.
+
+set(SLANG_DXC_VERSION_TAG "v1.9.2602")
+set(SLANG_DXC_EXPECTED_GIT_COMMIT "21d28f727ad395b59394815ef76012e432f7e4e5")
+set(SLANG_DXC_RELEASE_DATE "2026_02_20")
+set(SLANG_DXC_WINDOWS_SHA256
+    "a1e89031421cf3c1fca6627766ab3020ca4f962ac7e2caa7fab2b33a8436151e"
+)
+set(SLANG_DXC_LINUX_SHA256
+    "a1d3e3b5e1c5685b3eb27d5e8890e41d87df45def05112a2d6f1a63a931f7d60"
+)
+
+set(SLANG_DXC_WINDOWS_URL
+    "https://github.com/microsoft/DirectXShaderCompiler/releases/download/${SLANG_DXC_VERSION_TAG}/dxc_${SLANG_DXC_RELEASE_DATE}.zip"
+)
+set(SLANG_DXC_LINUX_URL
+    "https://github.com/microsoft/DirectXShaderCompiler/releases/download/${SLANG_DXC_VERSION_TAG}/linux_dxc_${SLANG_DXC_RELEASE_DATE}.x86_64.tar.gz"
+)

--- a/cmake/FetchDXC.cmake
+++ b/cmake/FetchDXC.cmake
@@ -29,32 +29,13 @@
 #   library_subdir   - Destination for Unix shared libraries (e.g. "lib")
 
 include(FetchContent)
+include(DXCMetadata)
 
-# DXC release metadata.
-#
-# To upgrade DXC:
-#   1. Pick a release tag from
-#      https://github.com/microsoft/DirectXShaderCompiler/releases.
-#   2. Set _dxc_version_tag to that tag.
-#   3. Set _dxc_release_date to the date used in the release asset names:
-#      dxc_<YYYY_MM_DD>.zip and linux_dxc_<YYYY_MM_DD>.x86_64.tar.gz.
-#   4. Resolve the release tag to the source commit used by source builds:
-#      git ls-remote https://github.com/microsoft/DirectXShaderCompiler.git \
-#          "refs/tags/<tag>" "refs/tags/<tag>^{}"
-#      For an annotated tag, use the peeled ^{} hash. Otherwise use the tag hash.
-#   5. Download the Windows zip and Linux tarball, then update the hashes with:
-#      sha256sum dxc_<YYYY_MM_DD>.zip linux_dxc_<YYYY_MM_DD>.x86_64.tar.gz
-#   6. Keep external/slang-rhi/CMakeLists.txt's SLANG_RHI_DXC_URL in sync with
-#      the Windows DXC URL below.
-set(_dxc_version_tag "v1.9.2602")
-set(_dxc_expected_git_commit "21d28f727ad395b59394815ef76012e432f7e4e5")
-set(_dxc_release_date "2026_02_20")
-set(_dxc_windows_sha256
-    "a1e89031421cf3c1fca6627766ab3020ca4f962ac7e2caa7fab2b33a8436151e"
-)
-set(_dxc_linux_sha256
-    "a1d3e3b5e1c5685b3eb27d5e8890e41d87df45def05112a2d6f1a63a931f7d60"
-)
+# Local aliases keep the rest of this file readable.
+set(_dxc_version_tag "${SLANG_DXC_VERSION_TAG}")
+set(_dxc_expected_git_commit "${SLANG_DXC_EXPECTED_GIT_COMMIT}")
+set(_dxc_windows_sha256 "${SLANG_DXC_WINDOWS_SHA256}")
+set(_dxc_linux_sha256 "${SLANG_DXC_LINUX_SHA256}")
 set(_dxc_windows_url_hash "SHA256=${_dxc_windows_sha256}")
 set(_dxc_linux_url_hash "SHA256=${_dxc_linux_sha256}")
 
@@ -217,9 +198,7 @@ elseif(
     #
     # All steps are cached via stamp files so subsequent reconfigures are fast.
 
-    set(_dxc_probe_url
-        "https://github.com/microsoft/DirectXShaderCompiler/releases/download/${_dxc_version_tag}/linux_dxc_${_dxc_release_date}.x86_64.tar.gz"
-    )
+    set(_dxc_probe_url "${SLANG_DXC_LINUX_URL}")
     set(_dxc_probe_dir "${CMAKE_BINARY_DIR}/_dxc_probe")
     # Include the version tag in the filename so that bumping _dxc_version_tag
     # invalidates the cached tarball and forces a fresh download rather than
@@ -802,9 +781,7 @@ endif()
 
 if(NOT _dxc_has_custom_binary_url)
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-        set(SLANG_DXC_BINARY_URL
-            "https://github.com/microsoft/DirectXShaderCompiler/releases/download/${_dxc_version_tag}/dxc_${_dxc_release_date}.zip"
-        )
+        set(SLANG_DXC_BINARY_URL "${SLANG_DXC_WINDOWS_URL}")
         set(_dxc_url_hash "${_dxc_windows_url_hash}")
     elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
@@ -814,9 +791,7 @@ if(NOT _dxc_has_custom_binary_url)
             if(DEFINED _dxc_probe_tarball AND EXISTS "${_dxc_probe_tarball}")
                 set(SLANG_DXC_BINARY_URL "file://${_dxc_probe_tarball}")
             else()
-                set(SLANG_DXC_BINARY_URL
-                    "https://github.com/microsoft/DirectXShaderCompiler/releases/download/${_dxc_version_tag}/linux_dxc_${_dxc_release_date}.x86_64.tar.gz"
-                )
+                set(SLANG_DXC_BINARY_URL "${SLANG_DXC_LINUX_URL}")
             endif()
         endif()
     endif()

--- a/cmake/FindDXC.cmake
+++ b/cmake/FindDXC.cmake
@@ -1,0 +1,80 @@
+# Locate an installed DXC for the SLANG_USE_SYSTEM_DXC path. The fetch /
+# source-build path is in FetchDXC.cmake.
+#
+# Set DXC_ROOT or CMAKE_PREFIX_PATH to provide an installation prefix.
+#
+# Output cache variables:
+#   DXC_INCLUDE_DIRS         directory containing dxc/dxcapi.h
+#   DXC_DXCOMPILER_RUNTIME   shared library copied next to Slang binaries
+#   DXC_DXIL_RUNTIME         dxil.dll on Windows; optional shared library
+#                            on Linux and macOS
+#   DXC_DXC_EXECUTABLE       optional, used for best-effort version detection
+#   DXC_VERSION              detected version, or unset
+#
+# Version detection is best-effort: DXC has no compile-time version macro
+# and IDxcVersionInfo is a runtime COM interface. A mismatch against the
+# SLANG_DXC_VERSION_TAG pin is a warning, never fatal -- the user opted
+# into their own DXC and owns compatibility.
+
+include(DXCMetadata)
+include(FindPackageHandleStandardArgs)
+
+find_path(DXC_INCLUDE_DIRS NAMES dxc/dxcapi.h PATH_SUFFIXES include)
+
+# Slang loads DXC dynamically and only stages its runtime shared libraries;
+# import libraries are not build inputs on this path.
+if(WIN32)
+    find_file(DXC_DXCOMPILER_RUNTIME NAMES dxcompiler.dll PATH_SUFFIXES bin)
+    find_file(DXC_DXIL_RUNTIME NAMES dxil.dll PATH_SUFFIXES bin)
+else()
+    # NAMES is the bare name; CMake adds the platform prefix/suffix.
+    find_library(DXC_DXCOMPILER_RUNTIME NAMES dxcompiler PATH_SUFFIXES lib)
+    find_library(DXC_DXIL_RUNTIME NAMES dxil PATH_SUFFIXES lib)
+endif()
+
+find_program(DXC_DXC_EXECUTABLE NAMES dxc)
+
+if(DXC_DXC_EXECUTABLE)
+    execute_process(
+        COMMAND "${DXC_DXC_EXECUTABLE}" --version
+        OUTPUT_VARIABLE _dxc_version_output
+        ERROR_VARIABLE _dxc_version_output
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        TIMEOUT 10
+    )
+    string(
+        REGEX MATCH
+        "[0-9]+\\.[0-9]+\\.[0-9]+"
+        DXC_VERSION
+        "${_dxc_version_output}"
+    )
+    if(DXC_VERSION)
+        string(REGEX REPLACE "^v" "" _dxc_expected "${SLANG_DXC_VERSION_TAG}")
+        if(NOT DXC_VERSION STREQUAL _dxc_expected)
+            message(
+                WARNING
+                "System DXC version ${DXC_VERSION} does not match the "
+                "version Slang is tested against (${_dxc_expected}); "
+                "features that depend on specific DXC behavior may fail."
+            )
+        endif()
+    endif()
+endif()
+
+set(_dxc_required_vars DXC_INCLUDE_DIRS DXC_DXCOMPILER_RUNTIME)
+if(WIN32)
+    list(APPEND _dxc_required_vars DXC_DXIL_RUNTIME)
+endif()
+
+find_package_handle_standard_args(
+    DXC
+    REQUIRED_VARS ${_dxc_required_vars}
+    VERSION_VAR DXC_VERSION
+)
+
+mark_as_advanced(
+    DXC_INCLUDE_DIRS
+    DXC_DXCOMPILER_RUNTIME
+    DXC_DXIL_RUNTIME
+    DXC_DXC_EXECUTABLE
+)

--- a/cmake/SystemDXC.cmake
+++ b/cmake/SystemDXC.cmake
@@ -1,0 +1,85 @@
+# Used when SLANG_USE_SYSTEM_DXC is ON: find an installed DXC and re-emit
+# the copy-dxcompiler / copy-dxil / stage-dxc-headers targets that
+# FetchDXC.cmake exposes, so the rest of the build is oblivious to which
+# acquisition path was taken.
+#
+# Requires runtime_subdir and library_subdir from SlangTarget.cmake.
+
+find_package(DXC REQUIRED)
+
+# Stage DXC HLSL headers (dx/linalg.h) at the same build-tree location
+# FetchDXC uses so `slangc -Xdxc -Ibuild/dxc/include` and test directives
+# resolve identically. A system DXC usually lays them out under
+# <prefix>/include/dxc.
+if(EXISTS "${DXC_INCLUDE_DIRS}/dx/linalg.h")
+    set(_dxc_hlsl_include_dir "${DXC_INCLUDE_DIRS}")
+elseif(EXISTS "${DXC_INCLUDE_DIRS}/hlsl/dx/linalg.h")
+    set(_dxc_hlsl_include_dir "${DXC_INCLUDE_DIRS}/hlsl")
+else()
+    set(_dxc_hlsl_include_dir "")
+endif()
+
+if(_dxc_hlsl_include_dir)
+    set(_dxc_inc_dst "${CMAKE_BINARY_DIR}/dxc/include/dx/linalg.h")
+    add_custom_command(
+        OUTPUT "${_dxc_inc_dst}"
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_directory "${_dxc_hlsl_include_dir}/dx"
+            "${CMAKE_BINARY_DIR}/dxc/include/dx"
+        DEPENDS "${_dxc_hlsl_include_dir}/dx/linalg.h"
+        VERBATIM
+    )
+    add_custom_target(stage-dxc-headers DEPENDS "${_dxc_inc_dst}")
+else()
+    # Same FATAL/WARNING split as FetchDXC's _dxc_stage_hlsl_headers.
+    if(SLANG_ENABLE_TESTS)
+        message(
+            FATAL_ERROR
+            "System DXC at ${DXC_INCLUDE_DIRS} is missing dx/linalg.h, "
+            "which the cooperative-{vector,matrix} tests rely on. Install "
+            "a DXC build that ships the public HLSL headers, or disable "
+            "SLANG_ENABLE_TESTS."
+        )
+    endif()
+    message(
+        WARNING
+        "System DXC at ${DXC_INCLUDE_DIRS} is missing dx/linalg.h; "
+        "DXIL cooperative-{vector,matrix} local builds that pass "
+        "-Xdxc -Ibuild/dxc/include will need an external DXC include path."
+    )
+    add_custom_target(stage-dxc-headers)
+endif()
+set_target_properties(stage-dxc-headers PROPERTIES FOLDER generated)
+
+# Stage runtime libraries next to the binaries with the same destination
+# layout as FetchDXC. dxil is enforced by FindDXC on Windows; elsewhere it
+# is optional, so copy-dxil is only emitted when it was actually found.
+set(_dxc_names dxcompiler)
+set(_dxc_srcs "${DXC_DXCOMPILER_RUNTIME}")
+if(WIN32)
+    set(_dxc_subdir "${runtime_subdir}")
+    list(APPEND _dxc_names dxil)
+    list(APPEND _dxc_srcs "${DXC_DXIL_RUNTIME}")
+else()
+    set(_dxc_subdir "${library_subdir}")
+    if(DXC_DXIL_RUNTIME)
+        list(APPEND _dxc_names dxil)
+        list(APPEND _dxc_srcs "${DXC_DXIL_RUNTIME}")
+    endif()
+endif()
+
+foreach(_dxc_lib _dxc_src IN ZIP_LISTS _dxc_names _dxc_srcs)
+    get_filename_component(_dxc_filename "${_dxc_src}" NAME)
+    set(_dxc_dst
+        "${CMAKE_BINARY_DIR}/$<CONFIG>/${_dxc_subdir}/${_dxc_filename}"
+    )
+    add_custom_command(
+        OUTPUT "${_dxc_dst}"
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_if_different "${_dxc_src}" "${_dxc_dst}"
+        DEPENDS "${_dxc_src}"
+        VERBATIM
+    )
+    add_custom_target(copy-${_dxc_lib} DEPENDS "${_dxc_dst}")
+    set_target_properties(copy-${_dxc_lib} PROPERTIES FOLDER generated)
+endforeach()

--- a/docs/building.md
+++ b/docs/building.md
@@ -292,42 +292,60 @@ works for any given binary.
 
 ### CMake options
 
-| Option                                | Default                       | Description                                                                                                                              |
-| ------------------------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `SLANG_VERSION`                       | Latest `v*` tag               | The project version, detected using git if available                                                                                     |
-| `SLANG_DXC_BINARY_URL`                | Stable DXC release URL        | URL of the prebuilt DXC binary archive to download; overrides the default release URL and skips GLIBC auto-detection on Linux            |
+| Option                                | Default                       | Description                                                                                                                                                                                                                        |
+| ------------------------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SLANG_VERSION`                       | Latest `v*` tag               | The project version, detected using git if available                                                                                                                                                                               |
+| `SLANG_DXC_BINARY_URL`                | Stable DXC release URL        | URL of the prebuilt DXC binary archive to download; overrides the default release URL and skips GLIBC auto-detection on Linux                                                                                                      |
 | `SLANG_DXC_BUILD_FROM_SOURCE`         | Unset                         | `ON`: build DXC from source on Windows, Linux, and macOS; `OFF`: use prebuilt when available; unset: build from source on macOS and auto-select on native Linux x86_64 (see [DXC GLIBC auto-detection](#dxc-glibc-auto-detection)) |
-| `SLANG_EMBED_CORE_MODULE`             | `TRUE`                        | Build slang with an embedded version of the core module                                                                                  |
-| `SLANG_EMBED_CORE_MODULE_SOURCE`      | `TRUE`                        | Embed the core module source in the binary                                                                                               |
-| `SLANG_ENABLE_DXIL`                   | `TRUE`                        | Enable generating DXIL using DXC                                                                                                         |
-| `SLANG_ENABLE_ASAN`                   | `FALSE`                       | Enable ASAN (address sanitizer)                                                                                                          |
-| `SLANG_ENABLE_COVERAGE`               | `FALSE`                       | Enable code coverage instrumentation                                                                                                     |
-| `SLANG_ENABLE_FULL_IR_VALIDATION`     | `FALSE`                       | Enable full IR validation (SLOW!)                                                                                                        |
-| `SLANG_ENABLE_VALIDATION_VM_BYTECODE` | `TRUE`                        | Enable VM bytecode validation in the bytecode interpreter. Disabling skips runtime safety checks for malformed bytecode.                 |
-| `SLANG_ENABLE_IR_BREAK_ALLOC`         | `OFF` (Release), `ON` (Debug) | Enable IR BreakAlloc functionality for debugging.                                                                                        |
-| `SLANG_ENABLE_GFX`                    | `TRUE`                        | Enable gfx targets (**deprecated**)                                                                                                      |
-| `SLANG_ENABLE_SLANGD`                 | `TRUE`                        | Enable language server target                                                                                                            |
-| `SLANG_ENABLE_SLANGC`                 | `TRUE`                        | Enable standalone compiler target                                                                                                        |
-| `SLANG_ENABLE_SLANGI`                 | `TRUE`                        | Enable Slang interpreter target                                                                                                          |
-| `SLANG_ENABLE_SLANGRT`                | `TRUE`                        | Enable runtime target                                                                                                                    |
-| `SLANG_ENABLE_SLANG_GLSLANG`          | `TRUE`                        | Enable glslang dependency and slang-glslang wrapper target                                                                               |
-| `SLANG_ENABLE_SLANG_PROXY`            | `TRUE`                        | Build the legacy `slang.dll` proxy and `libslang` symlink backward-compatibility outputs for `slang-compiler`                           |
-| `SLANG_ENABLE_TESTS`                  | `TRUE`                        | Enable test targets, requires `SLANG_ENABLE_SLANG_RHI`; some tests require other CMake options                                           |
-| `SLANG_ENABLE_EXAMPLES`               | `TRUE`                        | Enable example targets, requires SLANG_ENABLE_SLANG_RHI                                                                                  |
-| `SLANG_ENABLE_REPLAYER`               | `TRUE`                        | Enable slang-replay tool                                                                                                                 |
-| `SLANG_ENABLE_PCH`                    | `TRUE`                        | Enable precompiled headers for faster builds (auto-disabled when using sccache)                                                          |
-| `SLANG_STANDARD_MODULE_DEVELOP_BUILD` | `TRUE`                        | Enable development build for standard modules (enables `UNIT_TEST` macro); disable for release builds                                    |
-| `SLANG_LIB_TYPE`                      | `SHARED`                      | How to build the slang library                                                                                                           |
-| `SLANG_ENABLE_RELEASE_DEBUG_INFO`     | `TRUE`                        | Enable generating debug info for Release configs                                                                                         |
-| `SLANG_ENABLE_RELEASE_LTO`            | `FALSE`                       | Enable LTO for Release builds                                                                                                            |
-| `SLANG_ENABLE_SPLIT_DEBUG_INFO`       | `TRUE`                        | Enable generating split debug info for Debug and RelWithDebInfo configs                                                                  |
-| `SLANG_SLANG_LLVM_FLAVOR`             | `FETCH_BINARY_IF_POSSIBLE`    | How to set up llvm support                                                                                                               |
-| `SLANG_SLANG_LLVM_BINARY_URL`         | System dependent              | URL specifying the location of the slang-llvm prebuilt library                                                                           |
-| `SLANG_USE_SCCACHE`                   | `FALSE`                       | Use sccache as compiler launcher (auto-disables PCH)                                                                                     |
-| `SLANG_GENERATORS_PATH`               | ``                            | Path to an installed `all-generators` target for cross compilation                                                                       |
-| `SLANG_IGNORE_ABORT_MSG`              | `FALSE`                       | Suppress the Windows modal abort dialog at compile time (baked into all built executables; recommended for unattended/LLM-driven builds) |
+| `SLANG_EMBED_CORE_MODULE`             | `TRUE`                        | Build slang with an embedded version of the core module                                                                                                                                                                            |
+| `SLANG_EMBED_CORE_MODULE_SOURCE`      | `TRUE`                        | Embed the core module source in the binary                                                                                                                                                                                         |
+| `SLANG_ENABLE_DXIL`                   | `TRUE`                        | Enable generating DXIL using DXC                                                                                                                                                                                                   |
+| `SLANG_ENABLE_ASAN`                   | `FALSE`                       | Enable ASAN (address sanitizer)                                                                                                                                                                                                    |
+| `SLANG_ENABLE_COVERAGE`               | `FALSE`                       | Enable code coverage instrumentation                                                                                                                                                                                               |
+| `SLANG_ENABLE_FULL_IR_VALIDATION`     | `FALSE`                       | Enable full IR validation (SLOW!)                                                                                                                                                                                                  |
+| `SLANG_ENABLE_VALIDATION_VM_BYTECODE` | `TRUE`                        | Enable VM bytecode validation in the bytecode interpreter. Disabling skips runtime safety checks for malformed bytecode.                                                                                                           |
+| `SLANG_ENABLE_IR_BREAK_ALLOC`         | `OFF` (Release), `ON` (Debug) | Enable IR BreakAlloc functionality for debugging.                                                                                                                                                                                  |
+| `SLANG_ENABLE_GFX`                    | `TRUE`                        | Enable gfx targets (**deprecated**)                                                                                                                                                                                                |
+| `SLANG_ENABLE_SLANGD`                 | `TRUE`                        | Enable language server target                                                                                                                                                                                                      |
+| `SLANG_ENABLE_SLANGC`                 | `TRUE`                        | Enable standalone compiler target                                                                                                                                                                                                  |
+| `SLANG_ENABLE_SLANGI`                 | `TRUE`                        | Enable Slang interpreter target                                                                                                                                                                                                    |
+| `SLANG_ENABLE_SLANGRT`                | `TRUE`                        | Enable runtime target                                                                                                                                                                                                              |
+| `SLANG_ENABLE_SLANG_GLSLANG`          | `TRUE`                        | Enable glslang dependency and slang-glslang wrapper target                                                                                                                                                                         |
+| `SLANG_ENABLE_SLANG_PROXY`            | `TRUE`                        | Build the legacy `slang.dll` proxy and `libslang` symlink backward-compatibility outputs for `slang-compiler`                                                                                                                      |
+| `SLANG_ENABLE_TESTS`                  | `TRUE`                        | Enable test targets, requires `SLANG_ENABLE_SLANG_RHI`; some tests require other CMake options                                                                                                                                     |
+| `SLANG_ENABLE_EXAMPLES`               | `TRUE`                        | Enable example targets, requires SLANG_ENABLE_SLANG_RHI                                                                                                                                                                            |
+| `SLANG_ENABLE_REPLAYER`               | `TRUE`                        | Enable slang-replay tool                                                                                                                                                                                                           |
+| `SLANG_ENABLE_PCH`                    | `TRUE`                        | Enable precompiled headers for faster builds (auto-disabled when using sccache)                                                                                                                                                    |
+| `SLANG_STANDARD_MODULE_DEVELOP_BUILD` | `TRUE`                        | Enable development build for standard modules (enables `UNIT_TEST` macro); disable for release builds                                                                                                                              |
+| `SLANG_LIB_TYPE`                      | `SHARED`                      | How to build the slang library                                                                                                                                                                                                     |
+| `SLANG_ENABLE_RELEASE_DEBUG_INFO`     | `TRUE`                        | Enable generating debug info for Release configs                                                                                                                                                                                   |
+| `SLANG_ENABLE_RELEASE_LTO`            | `FALSE`                       | Enable LTO for Release builds                                                                                                                                                                                                      |
+| `SLANG_ENABLE_SPLIT_DEBUG_INFO`       | `TRUE`                        | Enable generating split debug info for Debug and RelWithDebInfo configs                                                                                                                                                            |
+| `SLANG_SLANG_LLVM_FLAVOR`             | `FETCH_BINARY_IF_POSSIBLE`    | How to set up llvm support                                                                                                                                                                                                         |
+| `SLANG_SLANG_LLVM_BINARY_URL`         | System dependent              | URL specifying the location of the slang-llvm prebuilt library                                                                                                                                                                     |
+| `SLANG_USE_SCCACHE`                   | `FALSE`                       | Use sccache as compiler launcher (auto-disables PCH)                                                                                                                                                                               |
+| `SLANG_GENERATORS_PATH`               | ``                            | Path to an installed `all-generators` target for cross compilation                                                                                                                                                                 |
+| `SLANG_IGNORE_ABORT_MSG`              | `FALSE`                       | Suppress the Windows modal abort dialog at compile time (baked into all built executables; recommended for unattended/LLM-driven builds)                                                                                           |
 
-#### DXC GLIBC auto-detection
+#### DXC acquisition
+
+When `SLANG_ENABLE_DXIL=ON`, DXC is acquired by the first applicable rule:
+
+1. `SLANG_USE_SYSTEM_DXC=ON` — `find_package(DXC)` against an installed
+   DXC. Set the standard `DXC_ROOT` variable to its installation prefix, or
+   add the prefix to `CMAKE_PREFIX_PATH`. The installation must provide
+   `include/dxc/dxcapi.h` and the `dxcompiler` shared library. On Windows,
+   both `bin/dxcompiler.dll` and `bin/dxil.dll` are required. On Linux and
+   macOS, the `dxil` shared library is optional and staged when present. A
+   version mismatch against the pinned tag is a warning, not an error.
+2. `SLANG_DXC_BUILD_FROM_SOURCE=ON` — build the pinned DXC from source.
+3. `SLANG_DXC_BINARY_URL=<url>` — download a custom prebuilt archive.
+4. Otherwise: on macOS, build from source (no Microsoft prebuilt exists);
+   elsewhere download the official Microsoft prebuilt, falling back to
+   source on native Linux x86_64 when GLIBC requirements are not met
+   (see below).
+
+##### DXC GLIBC auto-detection
 
 When `SLANG_DXC_BUILD_FROM_SOURCE` is unset on native Linux x86_64 (and
 `SLANG_DXC_BINARY_URL` is not set), CMake downloads the prebuilt DXC binary at
@@ -343,7 +361,9 @@ so the default configuration builds DXC from source unless
 
 ```mermaid
 flowchart TD
-    Start["Configure DXC support"] --> BuildFromSource{"SLANG_DXC_BUILD_FROM_SOURCE"}
+    Start["Configure DXC support"] --> UseSystem{"SLANG_USE_SYSTEM_DXC"}
+    UseSystem -->|ON| System["find_package(DXC); use installed DXC"]
+    UseSystem -->|OFF| BuildFromSource{"SLANG_DXC_BUILD_FROM_SOURCE"}
     BuildFromSource -->|ON| Source["Build DXC from source"]
     BuildFromSource -->|OFF| Prebuilt["Use a prebuilt binary when available"]
     BuildFromSource -->|unset| CustomUrl{"SLANG_DXC_BINARY_URL set?"}
@@ -389,23 +409,24 @@ error if they can't be found.
 
 ### Advanced options
 
-| Option                              | Default                              | Description                                                                                                                 |
-| ----------------------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
-| `SLANG_ENABLE_DX_ON_VK`             | `FALSE`                              | Enable running the DX11 and DX12 tests on non-WARP Windows platforms via vkd3d-proton, requires system-provided d3d headers |
-| `SLANG_ENABLE_SLANG_RHI`            | `TRUE`                               | Enable building and using [slang-rhi](https://github.com/shader-slang/slang-rhi) for tests                                  |
-| `SLANG_USE_SYSTEM_MINIZ`            | `FALSE`                              | Build using system Miniz library instead of the bundled version in [./external](./external)                                 |
-| `SLANG_USE_SYSTEM_LZ4`              | `FALSE`                              | Build using system LZ4 library instead of the bundled version in [./external](./external)                                   |
-| `SLANG_USE_SYSTEM_VULKAN_HEADERS`   | `FALSE`                              | Build using system Vulkan headers instead of the bundled version in [./external](./external)                                |
-| `SLANG_USE_SYSTEM_SPIRV_HEADERS`    | `FALSE`                              | Build using system SPIR-V headers instead of the bundled version in [./external](./external)                                |
-| `SLANG_USE_SYSTEM_UNORDERED_DENSE`  | `FALSE`                              | Build using system unordered dense instead of the bundled version in [./external](./external)                               |
-| `SLANG_USE_SYSTEM_SPIRV_TOOLS`      | `FALSE`                              | Build using system SPIR-V tools library instead of the bundled version in [./external](./external)                          |
-| `SLANG_USE_SYSTEM_GLSLANG`          | `FALSE`                              | Build using system glslang library instead of the bundled version in [./external](./external)                               |
-| `SLANG_SPIRV_HEADERS_INCLUDE_DIR`   | ``                                   | Use this specific path to SPIR-V headers instead of the bundled version in [./external](./external)                         |
-| `SLANG_ENABLE_SPIRV_TOOLS_MIMALLOC` | `FALSE` (`TRUE` on Windows)          | Enable mimalloc allocator for SPIRV-Tools to improve compilation performance                                                |
-| `SLANG_ENABLE_MIMALLOC`             | `FALSE` (`TRUE` on shared Windows)   | Use mimalloc for Slang-owned allocations                                                                                     |
-| `SLANG_EXCLUDE_DAWN`                | `FALSE` on Windows, `TRUE` elsewhere | Exclude Dawn WebGPU support from the build                                                                                  |
-| `SLANG_EXCLUDE_TINT`                | `FALSE`                              | Exclude slang-tint from the build (only relevant on Windows x64)                                                            |
-| `SLANG_ENABLE_TIME_TRACE`           | `FALSE`                              | Enable Clang time trace profiling for build analysis (Clang only)                                                           |
+| Option                              | Default                              | Description                                                                                                                                                    |
+| ----------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SLANG_ENABLE_DX_ON_VK`             | `FALSE`                              | Enable running the DX11 and DX12 tests on non-WARP Windows platforms via vkd3d-proton, requires system-provided d3d headers                                    |
+| `SLANG_ENABLE_SLANG_RHI`            | `TRUE`                               | Enable building and using [slang-rhi](https://github.com/shader-slang/slang-rhi) for tests                                                                     |
+| `SLANG_USE_SYSTEM_MINIZ`            | `FALSE`                              | Build using system Miniz library instead of the bundled version in [./external](./external)                                                                    |
+| `SLANG_USE_SYSTEM_LZ4`              | `FALSE`                              | Build using system LZ4 library instead of the bundled version in [./external](./external)                                                                      |
+| `SLANG_USE_SYSTEM_VULKAN_HEADERS`   | `FALSE`                              | Build using system Vulkan headers instead of the bundled version in [./external](./external)                                                                   |
+| `SLANG_USE_SYSTEM_SPIRV_HEADERS`    | `FALSE`                              | Build using system SPIR-V headers instead of the bundled version in [./external](./external)                                                                   |
+| `SLANG_USE_SYSTEM_UNORDERED_DENSE`  | `FALSE`                              | Build using system unordered dense instead of the bundled version in [./external](./external)                                                                  |
+| `SLANG_USE_SYSTEM_SPIRV_TOOLS`      | `FALSE`                              | Build using system SPIR-V tools library instead of the bundled version in [./external](./external)                                                             |
+| `SLANG_USE_SYSTEM_GLSLANG`          | `FALSE`                              | Build using system glslang library instead of the bundled version in [./external](./external)                                                                  |
+| `SLANG_USE_SYSTEM_DXC`              | `FALSE`                              | Build using system DXC instead of the fetch / source-build paths in [`cmake/FetchDXC.cmake`](../cmake/FetchDXC.cmake); see [DXC acquisition](#dxc-acquisition) |
+| `SLANG_SPIRV_HEADERS_INCLUDE_DIR`   | ``                                   | Use this specific path to SPIR-V headers instead of the bundled version in [./external](./external)                                                            |
+| `SLANG_ENABLE_SPIRV_TOOLS_MIMALLOC` | `FALSE` (`TRUE` on Windows)          | Enable mimalloc allocator for SPIRV-Tools to improve compilation performance                                                                                   |
+| `SLANG_ENABLE_MIMALLOC`             | `FALSE` (`TRUE` on shared Windows)   | Use mimalloc for Slang-owned allocations                                                                                                                       |
+| `SLANG_EXCLUDE_DAWN`                | `FALSE` on Windows, `TRUE` elsewhere | Exclude Dawn WebGPU support from the build                                                                                                                     |
+| `SLANG_EXCLUDE_TINT`                | `FALSE`                              | Exclude slang-tint from the build (only relevant on Windows x64)                                                                                               |
+| `SLANG_ENABLE_TIME_TRACE`           | `FALSE`                              | Enable Clang time trace profiling for build analysis (Clang only)                                                                                              |
 
 ### LLVM Support
 


### PR DESCRIPTION
Fixes #11441

## Summary of the problem from the end user perspective

The SLANG_USE_SYSTEM_* family (miniz, lz4, vulkan-headers, spirv-headers,
unordered-dense, spirv-tools, glslang) lets the build consume system
copies of each vendored dependency. DXC was the only one without an
opt-out: SLANG_ENABLE_DXIL=ON forced either the Microsoft prebuilt
download or a multi-minute source build (#10935, #11434), even when a
known-good DXC was already installed. This blocked distro packaging
workflows that forbid build-time downloads and CI setups that pre-stage
their own DXC.

## Root cause

cmake/FetchDXC.cmake exposed only the fetch / source-build paths; the
dispatch in CMakeLists.txt was an unconditional include(FetchDXC) when
DXIL was enabled. DXC also ships no upstream CMake package-config file,
so a system-DXC path needed a hand-written Find module rather than a
straight find_package(... CONFIG) like the other SLANG_USE_SYSTEM_*
options.

## Solution in this PR

Introduce SLANG_USE_SYSTEM_DXC, gated by SLANG_ENABLE_DXIL via
cmake_dependent_option so the option only appears when meaningful and
cannot silently survive disabling DXIL.

New modules under cmake/:
- DXCMetadata.cmake: single source of truth for the pinned DXC tag,
  commit, release date, asset SHA256s, and assembled URLs. Included by
  FetchDXC, FindDXC, and StageDXCForCI so version bumps touch one file.
- FindDXC.cmake: find_path + find_library + find_program in the same
  shape as FindNVAPI / FindAftermath. Exposes both linker-facing
  DXC_*_LIBRARY (the .lib on Windows, .so/.dylib elsewhere) and
  loader-facing DXC_*_RUNTIME (the .dll on Windows, same .so/.dylib
  otherwise) so staging copies the correct artifact on each platform.
  dxil is required on Windows only (DXIL signing is Windows-only;
  closed-source dxil is not redistributed elsewhere). Best-effort version
  detection via `dxc --version`; a mismatch against the pinned tag is a
  warning, not fatal.
- SystemDXC.cmake: invoked from the dispatch site when the option is ON.
  Calls find_package(DXC REQUIRED) and re-emits the copy-dxcompiler /
  copy-dxil / stage-dxc-headers custom targets with identical names and
  layout to FetchDXC, so slangc's add_dependencies wiring and
  slang-test's OPTIONAL_REQUIRES at tools/CMakeLists.txt:280 work
  unchanged. Mirrors FetchDXC's FATAL_ERROR-if-SLANG_ENABLE_TESTS,
  WARNING-otherwise policy for the dx/linalg.h headers.
- StageDXCForCI.cmake: cross-platform pure-CMake helper invoked via
  `cmake -P` from the option-matrix CI workflow. Downloads the pinned
  Microsoft prebuilt, verifies the SHA256, extracts via
  file(ARCHIVE_EXTRACT), and (on Windows) flattens the per-arch nesting
  into the layout FindDXC's PATH_SUFFIXES expects.

FetchDXC.cmake: the 6 metadata literals at the top are replaced with
include(DXCMetadata) + local aliases; behaviour is unchanged.

CI: cmake-options-build.yml and cmake-options-build-container.yml gain a
new Pre-configure step mirroring the existing apt_packages pattern.
Two matrix entries (linux_only, windows_only) cover SLANG_USE_SYSTEM_DXC;
macOS is intentionally skipped because Microsoft publishes no macOS
prebuilt.

Acquisition precedence (documented in docs/building.md):

    SLANG_USE_SYSTEM_DXC > SLANG_DXC_BUILD_FROM_SOURCE
        > SLANG_DXC_BINARY_URL > auto-detect/download

## Notes to the reviewers; where to focus on

- cmake/FindDXC.cmake's split between *_LIBRARY and *_RUNTIME: on Windows
  find_library returns the .lib import library, which is the wrong thing
  to copy next to a binary that LoadLibraries the .dll. find_file locates
  the runtime DLL separately. On Unix the two are aliased.
- cmake/SystemDXC.cmake target re-emission: the contract with the rest
  of the build is the custom-target names, not any CMake target objects.
  Verify that copy-dxcompiler / copy-dxil / stage-dxc-headers match
  FetchDXC's behaviour 1:1 so the dispatch is a clean swap.
- Local verification on macOS arm64 against [brew dxc 1.9.2602](https://github.com/Homebrew/homebrew-core/pull/285971): default
  build unaffected; SLANG_USE_SYSTEM_DXC=ON configures cleanly, slangc
  builds, libdxcompiler.dylib is staged at Release/lib/, no _deps/
  appears, the missing-libdxil case degrades to skipping copy-dxil, and
  both expected warnings fire (version mismatch and missing dx/linalg.h
  under SLANG_ENABLE_TESTS=OFF).
- CI: the new Pre-configure step is the standard place for matrix
  entries that need an artifact staged before configure. The option-matrix
  workflow runs on dispatch + weekly cron, so validating this branch
  needs a manual dispatch of "CMake Options".

## Related PRs in the past

- #10935 added the Linux GLIBC-fallback source-build path.
- #11434 extended the source-build path to macOS.
- #11441 (this PR's issue) tracked the design discussion.
