### PR TITLE
ci: respect prior author verdicts in Claude PR review

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -102,9 +102,14 @@ jobs:
                     nodes {
                       id
                       isResolved
-                      comments(first: 1) {
+                      isOutdated
+                      path
+                      line
+                      comments(first: 30) {
                         nodes {
                           author { login }
+                          body
+                          createdAt
                         }
                       }
                     }
@@ -146,23 +151,72 @@ jobs:
               }
             }
 
-            // 2. Resolve all Claude-authored unresolved review threads
+            // 2. Harvest prior Claude review threads + maintainer replies, THEN
+            //    resolve only the threads nobody engaged with.
+            //
+            //    Threads that a human replied to carry maintainer verdicts
+            //    ("won't fix", "by design", "unfixable", "no such target", ...).
+            //    We must NOT bury those: they are written to
+            //    tmp/prior-review-threads.json so the next review can suppress
+            //    findings that were already adjudicated (see REVIEW.md Rule 7),
+            //    and left UNRESOLVED so the verdict stays visible in the PR.
+            const fs = require('fs');
+            const priorVerdicts = [];
             const claudeThreads = pr.reviewThreads.nodes.filter(t =>
-              !t.isResolved &&
               t.comments.nodes.length > 0 &&
               CLAUDE_LOGINS.includes(t.comments.nodes[0].author?.login)
             );
             for (const thread of claudeThreads) {
-              try {
-                await github.graphql(`mutation($threadId: ID!) {
-                  resolveReviewThread(input: { threadId: $threadId }) {
-                    thread { isResolved }
-                  }
-                }`, { threadId: thread.id });
-                resolved++;
-              } catch (e) {
-                core.warning(`Could not resolve thread ${thread.id}: ${e.message}`);
+              const finding = thread.comments.nodes[0];
+              const humanReplies = thread.comments.nodes
+                .slice(1)
+                .filter(c => !CLAUDE_LOGINS.includes(c.author?.login));
+
+              priorVerdicts.push({
+                path: thread.path,
+                line: thread.line,
+                resolved: thread.isResolved,
+                // outdated == GitHub re-anchored the thread because its line
+                // changed. Rule 7 treats an outdated verdict as STALE and
+                // re-evaluates the finding instead of suppressing it.
+                outdated: thread.isOutdated,
+                finding: finding.body,
+                humanReplies: humanReplies.map(c => ({
+                  user: c.author?.login,
+                  body: c.body,
+                })),
+              });
+
+              // Only auto-resolve threads NOBODY engaged with. Leaving
+              // human-replied threads alone keeps the maintainer's response
+              // visible and breaks the "re-posts the same finding every push"
+              // busywork loop.
+              if (humanReplies.length === 0 && !thread.isResolved) {
+                try {
+                  await github.graphql(`mutation($threadId: ID!) {
+                    resolveReviewThread(input: { threadId: $threadId }) {
+                      thread { isResolved }
+                    }
+                  }`, { threadId: thread.id });
+                  resolved++;
+                } catch (e) {
+                  core.warning(`Could not resolve thread ${thread.id}: ${e.message}`);
+                }
               }
+            }
+
+            // Hand the prior verdicts to the review step (same workspace).
+            // Best-effort: if this write fails, REVIEW.md Rule 7 treats a missing
+            // file as "no prior verdicts" and the review proceeds normally.
+            try {
+              fs.mkdirSync('tmp', { recursive: true });
+              fs.writeFileSync(
+                'tmp/prior-review-threads.json',
+                JSON.stringify(priorVerdicts, null, 2)
+              );
+              core.info(`Wrote ${priorVerdicts.length} prior thread(s) to tmp/prior-review-threads.json`);
+            } catch (e) {
+              core.warning(`Could not write prior-review-threads.json: ${e.message}`);
             }
 
             // 3. Minimize all bot issue comments (tracking/progress comments)
@@ -213,9 +267,14 @@ jobs:
             However, the PR branch is NOT checked out — to see what the PR actually changes, you MUST
             use `gh pr diff` or GitHub MCP tools. Do NOT assume local files reflect the PR's changes.
 
-            NOTE: Any previous Claude reviews on this PR have been automatically minimized
-            and their threads resolved. You are posting a fresh, self-contained review.
-            Do NOT reference previous reviews — just review the PR as it currently stands.
+            NOTE: Previous Claude review *summaries* on this PR have been minimized, and
+            prior Claude threads that nobody replied to have been resolved. But threads
+            where a maintainer REPLIED are left intact — those replies are maintainer
+            verdicts. The prior threads and replies are saved to
+            `tmp/prior-review-threads.json`. Before posting any finding, apply REVIEW.md
+            Rule 7: do NOT re-post a finding a maintainer has already declined, deferred,
+            or explained. You are still posting one fresh, self-contained review — just do
+            not repeat already-adjudicated findings.
 
           # Execution strategy: dispatch 6 background Agent calls for parallel review.
           # REVIEW.md contains the review protocol (format, tone, severity badges).
@@ -258,6 +317,104 @@ jobs:
             mcp__github__add_issue_comment,
             mcp__github_inline_comment__create_inline_comment,
             mcp__deepwiki__ask_question
+
+      # Safety net: enforce REVIEW.md Rule 7 mechanically. The review step is *asked*
+      # (not forced) to suppress findings a maintainer already adjudicated. This step
+      # minimizes any freshly-posted Gap/Question comment that recurs a still-valid
+      # (non-outdated) human-engaged prior thread at the same location.
+      # 🔴 Bugs are NEVER auto-minimized — a real bug must stay visible even if it recurs.
+      - name: Suppress re-posted adjudicated findings
+        if: always()
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const prNumber = context.payload.pull_request?.number
+              || parseInt('${{ github.event.inputs.pr_number }}' || '0');
+            if (!prNumber) return;
+
+            // Prior verdicts harvested by the cleanup step (same workspace).
+            let priors = [];
+            try {
+              priors = JSON.parse(fs.readFileSync('tmp/prior-review-threads.json', 'utf8'));
+            } catch (e) {
+              core.info('No prior-review-threads.json; nothing to enforce.');
+              return;
+            }
+            // Only act on threads a human engaged with, on code that has NOT changed
+            // since (outdated === false). A stale verdict must not suppress a fresh finding.
+            const declined = priors.filter(p =>
+              Array.isArray(p.humanReplies) && p.humanReplies.length > 0 && !p.outdated
+            );
+            if (declined.length === 0) {
+              core.info('No still-valid human-engaged prior verdicts; nothing to enforce.');
+              return;
+            }
+
+            const CLAUDE_LOGINS = ['claude', 'github-actions'];
+            // Compare the first line of two findings, stripped of markdown/emoji.
+            const norm = s => (s || '').split('\n')[0]
+              .replace(/[*_`#>:\-]/g, ' ')
+              .replace(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/gu, ' ')
+              .toLowerCase().replace(/\s+/g, ' ').trim();
+            const words = s => new Set(norm(s).split(' ').filter(w => w.length > 3));
+            const jaccard = (a, b) => {
+              const A = words(a), B = words(b);
+              if (!A.size || !B.size) return 0;
+              let inter = 0; for (const w of A) if (B.has(w)) inter++;
+              return inter / (A.size + B.size - inter);
+            };
+
+            const query = `query($owner:String!,$repo:String!,$pr:Int!){
+              repository(owner:$owner,name:$repo){ pullRequest(number:$pr){
+                reviewThreads(last:100){ nodes {
+                  id isResolved path line
+                  comments(first:5){ nodes { id author{login} body isMinimized } }
+                }}}}}`;
+            const res = await github.graphql(query, {
+              owner: context.repo.owner, repo: context.repo.repo, pr: prNumber
+            });
+            const threads = res.repository.pullRequest.reviewThreads.nodes;
+
+            let suppressed = 0;
+            for (const t of threads) {
+              if (t.isResolved) continue;
+              const c = t.comments.nodes[0];
+              if (!c || c.isMinimized) continue;
+              if (!CLAUDE_LOGINS.includes(c.author?.login)) continue;
+              // Never auto-minimize a real bug — highest-value signal stays visible.
+              if (/🔴/.test(c.body || '')) continue;
+              // Skip threads a human already replied to (the prior, kept-visible one).
+              const hasHuman = t.comments.nodes.some(
+                x => !CLAUDE_LOGINS.includes(x.author?.login)
+              );
+              if (hasHuman) continue;
+
+              const match = declined.find(p => {
+                if (p.path !== t.path) return false;
+                const lineClose = p.line != null && t.line != null
+                  && Math.abs(p.line - t.line) <= 10;
+                const titleClose = jaccard(p.finding, c.body) >= 0.6;
+                return lineClose || titleClose;
+              });
+              if (!match) continue;
+
+              try {
+                await github.graphql(`mutation($id:ID!,$cl:ReportedContentClassifiers!){
+                  minimizeComment(input:{subjectId:$id,classifier:$cl}){ minimizedComment{ isMinimized } }
+                }`, { id: c.id, cl: 'OUTDATED' });
+                await github.graphql(`mutation($t:ID!){
+                  resolveReviewThread(input:{threadId:$t}){ thread{ isResolved } }
+                }`, { t: t.id });
+                suppressed++;
+                core.warning(`Rule 7: suppressed re-posted finding on ${t.path}:${t.line} `
+                  + `(matched prior verdict by @${match.humanReplies[0]?.user})`);
+              } catch (e) {
+                core.warning(`Could not suppress thread ${t.id}: ${e.message}`);
+              }
+            }
+            core.info(`Rule 7 enforcement: suppressed ${suppressed} re-posted finding(s).`);
 
       # Safety net: dismiss any APPROVE or REQUEST_CHANGES reviews from bot accounts.
       # Claude is instructed to use COMMENT only, but prompt-level constraints are not

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -80,6 +80,8 @@ Wait for all 6 background agents to complete. You will be automatically notified
 
 Once ALL 6 have returned findings, build the editorial table below, **fill every column for every Keep row**, and post only Keep rows.
 
+If `tmp/prior-review-threads.json` exists, read it first — it lists prior Claude findings on this PR and any maintainer replies. Apply Rule 7 below before keeping anything.
+
 | Source agent | file:line | Severity | Confidence | Evidence / verification quote | User-visible impact | Keep / Drop |
 
 Rules (applied in order, before any posting):
@@ -98,6 +100,16 @@ Rules (applied in order, before any posting):
 5. **Dedup + bundling:** Merge duplicates across teammates. Group closely related consistency nits (missing `static`/`override`/`public`, docstring polish) into one comment; do not post low-impact maintainability items as separate inline threads.
 
 6. **CI-enforced drops:** Drop formatting/style issues (`./extras/formatting.sh`) and anything already caught by existing CI.
+
+7. **Respect prior maintainer verdicts — but only while they are still valid.** If `tmp/prior-review-threads.json` exists, match each candidate finding against prior threads on the same `path` (±8 lines, or the same symbol/function if code moved). Suppress a candidate **only when ALL of these hold**:
+   - a prior thread raised an equivalent claim, **and**
+   - a non-Claude author replied **declining, deferring, or explaining** it ("won't fix", "by design", "intentional", "unfixable", "no such target", "the diagnostic test is exhaustive", …), **and**
+   - **the verdict is still valid for the current code** — i.e. the code the verdict was about has NOT materially changed since the reply. Treat the verdict as **stale (do not suppress, re-evaluate normally)** if any of:
+     - the prior thread is marked `outdated: true` in the JSON (its anchored line changed), **or**
+     - the current `tmp/pr-diff.patch` touches the lines/symbol the verdict was about, **or**
+     - the finding now rests on different evidence than the prior thread addressed.
+
+   When suppressing, mark the row **Drop** with `Suppressed: prior verdict by @user` in the table. **Exception:** keep a 🔴 Bug whose evidence quote shows a concrete wrong output the reply did not actually rebut — state why the reply does not cover it. A prior thread with **no** human reply never suppresses (the point may have been missed); re-surface it at most once. A missing JSON file means "no prior verdicts" — proceed normally.
 
 A finding that fails any rule above is marked Drop in the table. Do not post Drop rows. Do not post findings that were not in the table.
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -109,7 +109,7 @@ Rules (applied in order, before any posting):
      - the current `tmp/pr-diff.patch` touches the lines/symbol the verdict was about, **or**
      - the finding now rests on different evidence than the prior thread addressed.
 
-   When suppressing, mark the row **Drop** with `Suppressed: prior verdict by @user` in the table. **Exception:** keep a 🔴 Bug whose evidence quote shows a concrete wrong output the reply did not actually rebut — state why the reply does not cover it. A prior thread with **no** human reply never suppresses (the point may have been missed); re-surface it at most once. A missing JSON file means "no prior verdicts" — proceed normally.
+   When suppressing, mark the row **Drop** with `Suppressed: prior verdict by @user` in the table, and add the finding to the folded **Suppressed** section of the review body (see Review Body Format) — one row with its location, a one-line description, and a short paraphrase of the maintainer's reply. This keeps suppression transparent without re-posting the inline comment. **Exception:** keep a 🔴 Bug whose evidence quote shows a concrete wrong output the reply did not actually rebut — state why the reply does not cover it. A prior thread with **no** human reply never suppresses (the point may have been missed); re-surface it at most once. A missing JSON file means "no prior verdicts" — proceed normally.
 
 A finding that fails any rule above is marked Drop in the table. Do not post Drop rows. Do not post findings that were not in the table.
 
@@ -207,9 +207,18 @@ The review body is the SUMMARY. The detailed analysis goes in inline comments. U
 | 🔵 Question | `file:line` | <one-line description — detail is in the inline comment> |
 
 </details>
+
+<details>
+<summary>Suppressed (K) — findings a maintainer already addressed on this PR; not re-posted</summary>
+
+| Location | Finding | Maintainer verdict |
+|----------|---------|--------------------|
+| `file:line` | <one-line description of the dropped finding> | @user: <short paraphrase of their reply> |
+
+</details>
 ```
 
-Omit the Findings section if there are 0 findings. Changes Overview is ALWAYS included.
+Omit the Findings section if there are 0 findings. Omit the Suppressed section if nothing was suppressed under Rule 7. Changes Overview is ALWAYS included.
 
 ### Severity badges:
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -101,15 +101,26 @@ Rules (applied in order, before any posting):
 
 6. **CI-enforced drops:** Drop formatting/style issues (`./extras/formatting.sh`) and anything already caught by existing CI.
 
-7. **Respect prior maintainer verdicts — but only while they are still valid.** If `tmp/prior-review-threads.json` exists, match each candidate finding against prior threads on the same `path` (±8 lines, or the same symbol/function if code moved). Suppress a candidate **only when ALL of these hold**:
-   - a prior thread raised an equivalent claim, **and**
-   - a non-Claude author replied **declining, deferring, or explaining** it ("won't fix", "by design", "intentional", "unfixable", "no such target", "the diagnostic test is exhaustive", …), **and**
-   - **the verdict is still valid for the current code** — i.e. the code the verdict was about has NOT materially changed since the reply. Treat the verdict as **stale (do not suppress, re-evaluate normally)** if any of:
-     - the prior thread is marked `outdated: true` in the JSON (its anchored line changed), **or**
-     - the current `tmp/pr-diff.patch` touches the lines/symbol the verdict was about, **or**
-     - the finding now rests on different evidence than the prior thread addressed.
+7. **Don't re-post a finding the maintainer already dismissed.** The cleanup step writes prior findings to `tmp/prior-review-threads.json` (no file → skip this rule). Each entry has this shape:
 
-   When suppressing, mark the row **Drop** with `Suppressed: prior verdict by @user` in the table, and add the finding to the folded **Suppressed** section of the review body (see Review Body Format) — one row with its location, a one-line description, and a short paraphrase of the maintainer's reply. This keeps suppression transparent without re-posting the inline comment. **Exception:** keep a 🔴 Bug whose evidence quote shows a concrete wrong output the reply did not actually rebut — state why the reply does not cover it. A prior thread with **no** human reply never suppresses (the point may have been missed); re-surface it at most once. A missing JSON file means "no prior verdicts" — proceed normally.
+   ```json
+   {
+     "path": "tests/.../foo.slang",
+     "line": 99,
+     "outdated": false,
+     "finding": "<the bot's earlier comment text>",
+     "humanReplies": [
+       { "user": "<maintainer>", "body": "<maintainer's reply>" }
+     ]
+   }
+   ```
+
+   `outdated` is `true` when newer commits changed those lines since the reply (GitHub re-anchored the thread). DROP a candidate finding when **ALL** of these hold:
+   - a prior entry made the same point on the same code (same `path`, within ±8 lines), **and**
+   - its `humanReplies` is non-empty and a maintainer dismissed or explained it ("won't fix", "by design", "no such target", "the diagnostic test is exhaustive", …), **and**
+   - that entry has **`"outdated": false`**. If `"outdated": true`, the verdict is stale (the code changed since the reply) — re-review the finding normally instead.
+
+   Always KEEP a 🔴 Bug whose evidence shows a concrete wrong result the reply did not address. If `humanReplies` is empty, nobody responded — you may post the finding once. When you drop a finding here, mark the row **Drop** with `Suppressed: prior verdict by @<user>` and list it in the folded **Suppressed** section of the review body (see Review Body Format).
 
 A finding that fails any rule above is marked Drop in the table. Do not post Drop rows. Do not post findings that were not in the table.
 


### PR DESCRIPTION
## Problem

The Claude PR-review workflow re-derives findings from scratch on **every push**. The cleanup step resolves all of its own prior threads (burying any maintainer reply), and the prompt explicitly tells the model *"Do NOT reference previous reviews."* As a result, findings a maintainer has already **declined / deferred / explained** get re-posted on every `synchronize` — pure busywork.

Concrete example (PR #11357): a maintainer replied to several review threads ("This test should not have any warnings", "we don't have targets with 32-bit pointers", …). On the next push those same Gap/Question findings would be regenerated and re-posted, while the conversation that resolved them was hidden.

## Change

Make the review **resolution-aware** without losing real bugs:

1. **Harvest before resolve.** The cleanup step now collects every prior Claude thread + its maintainer replies into `tmp/prior-review-threads.json` (including each thread's `isOutdated` flag), and only auto-resolves threads **nobody replied to**. Human-engaged threads stay visible.
2. **REVIEW.md Rule 7 (advisory).** Drop a candidate finding when an equivalent prior finding was adjudicated by a maintainer **and the verdict is still valid** — i.e. the code hasn't changed since. A stale verdict (outdated thread, or the current diff touches those lines) does **not** suppress; it is re-evaluated. A 🔴 Bug with new evidence the reply didn't rebut is never silenced.
3. **Enforcing post-filter step.** Mirroring the existing `Dismiss unauthorized bot approvals` safety net (prompt rules aren't binding), a new step minimizes any freshly-posted **Gap/Question** comment that recurs a still-valid, human-engaged prior thread. **🔴 Bugs are never auto-minimized.**

## Validation

Ran the harvest + matcher logic **read-only** against live PR #11357 data (no mutations, no Docker):

- Suppresses the two findings the maintainer flagged as noise (the over-broad `CHK-NOT` gap, the 32-bit-host question).
- Keeps all 8 🔴 Bugs, including the real `+2147483648` over-warn bug the maintainer said still needs fixing.
- Correctly treats two replies as **stale** (`outdated`) because the code changed after the verdict — so they do not suppress.

## Notes

- This is a CI/workflow + protocol change only; no compiler code touched.
- Limitation: the *mechanical* filter only sees replies on the current PR, so a finding declined in a previous PR (with no reply on this one) isn't mechanically suppressed — the advisory Rule 7 is the only layer that could catch that.

pr: non-breaking