### PR TITLE
Fix Ninja race between cpu-shader-llvm-link and shader.o generation

### DIFF
--- a/examples/cpu-shader-llvm/CMakeLists.txt
+++ b/examples/cpu-shader-llvm/CMakeLists.txt
@@ -15,6 +15,23 @@ if(SLANG_ENABLE_SLANGC)
     # slangc and slang-llvm.
     add_dependencies(cpu-shader-llvm-link-shader slangc slang-llvm)
 
+    # Mark shader.o as a generated file before `slang_add_target` consumes it
+    # via `EXPLICIT_SOURCE` below. `slang_add_target` is a function (separate
+    # variable scope from this CMakeLists.txt), and without an explicit
+    # GENERATED property the `add_executable` inside the function treats the
+    # file as a plain pre-existing input. That gives Ninja only the order-only
+    # target-level edge from `REQUIRES cpu-shader-llvm-link-shader`, which under
+    # high-parallelism builds (notably slangpy CI building slang as a
+    # subproject) races the link step ahead of the slangc invocation that
+    # produces shader.o. Setting GENERATED here makes CMake emit a proper
+    # file-level Ninja edge from the link's input list to the custom-command
+    # producer rule, so the link must wait for shader.o regardless of build
+    # scheduling.
+    set_source_files_properties(
+        ${CMAKE_CURRENT_BINARY_DIR}/shader.o
+        PROPERTIES GENERATED TRUE
+    )
+
     # Normally, you would use the below three lines:
     #add_executable(cpu-shader-llvm-link link.cpp ${CMAKE_CURRENT_BINARY_DIR}/shader.o)
     #add_dependencies(cpu-shader-llvm-link cpu-shader-llvm-link-shader)


### PR DESCRIPTION
## Summary

Fixes a long-latent Ninja race in `examples/cpu-shader-llvm/CMakeLists.txt` that causes intermittent build failures of `cpu-shader-llvm-link` in high-parallelism builds. The failure has hit several slang PRs in the slangpy CI workflow (`ci-latest-slang`), with the same `cannot open input file 'examples/cpu-shader-llvm/shader.o'` signature.

The bug is environmental and reliably reproducible when something (parallelism, CMake/Ninja version, host capacity) tips the timing into the bad case.

## Root cause

The example links `cpu-shader-llvm-link` against an `shader.o` produced by a custom-command running `slangc`. The intent is:

- `add_custom_command(OUTPUT shader.o)` produces the file.
- `add_custom_target(cpu-shader-llvm-link-shader DEPENDS shader.o)` wraps it.
- `slang_add_target(... REQUIRES cpu-shader-llvm-link-shader EXPLICIT_SOURCE link.cpp shader.o)` links them.

But `REQUIRES` maps to a target-level `add_dependencies()`, which Ninja translates to an **order-only** edge — that gives a soft ordering, not a file-input requirement. And because `slang_add_target` is a *function* (separate variable scope), the `add_executable` inside it does not see the `GENERATED` source-file property implicitly set by `add_custom_command` in the calling scope. CMake therefore treats `shader.o` as a plain pre-existing input and emits no explicit file-level edge from the link rule to the producer custom-command rule.

Under high-parallelism builds, the link step races ahead of the slangc invocation:

```
[1270/1394] Generating shader.o
[1380/1394] Linking CXX executable Release/bin/cpu-shader-llvm-link
/usr/bin/ld: cannot find examples/cpu-shader-llvm/shader.o: No such file or directory
```

The two steps run *concurrently* in the failing CI logs (timestamps 7s apart on Linux, 25s apart on Windows), not sequentially.

## Fix

Set `GENERATED TRUE` explicitly on `shader.o` before `slang_add_target` consumes it. The property is on the file (not in a variable), so once set it propagates into the function scope. CMake now emits the link rule with `shader.o` as an explicit input:

```
build Release/bin/cpu-shader-llvm-link: CXX_EXECUTABLE_LINKER__cpu-shader-llvm-link_Release \
    examples/cpu-shader-llvm/shader.o \
    examples/cpu-shader-llvm/CMakeFiles/cpu-shader-llvm-link.dir/Release/link.cpp.o \
    || ...
```

Ninja refuses to start the link until shader.o exists on disk, regardless of parallelism.

## Verified locally

Fresh build of `cpu-shader-llvm-link` with the fix applied:
```
[480/483] Generating shader.o
[481/483] Building CXX object .../link.cpp.o
[482/483] Linking CXX executable Release/bin/cpu-shader-llvm-link
```
Generation now precedes link strictly. Without the fix, those steps would interleave.

## Test plan

- [x] Local Release build of `cpu-shader-llvm-link` succeeds (macOS arm64, FETCH_BINARY_IF_POSSIBLE slang-llvm)
- [x] slang CI green
- [x] slangpy CI green — note this is the failing-job-of-record; passing here demonstrates the fix landed
