### PR TITLE
Support coherent descriptor handles

### DIFF
--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -868,6 +868,11 @@ Val* ASTBuilder::getNoDiffModifierVal()
     return getOrCreate<NoDiffModifierVal>();
 }
 
+Val* ASTBuilder::getGloballyCoherentModifierVal()
+{
+    return getOrCreate<GloballyCoherentModifierVal>();
+}
+
 UIntSetVal* ASTBuilder::getUIntSetVal(const UIntSet& uintSet)
 {
     // Convert UIntSet buffer to list of ConstantIntVals

--- a/source/slang/slang-ast-builder.h
+++ b/source/slang/slang-ast-builder.h
@@ -670,6 +670,7 @@ public:
     Val* getUNormModifierVal();
     Val* getSNormModifierVal();
     Val* getNoDiffModifierVal();
+    Val* getGloballyCoherentModifierVal();
 
     /// Create a UIntSetVal from a UIntSet
     UIntSetVal* getUIntSetVal(const UIntSet& uintSet);

--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -1486,6 +1486,23 @@ Val* NoDiffModifierVal::_substituteImplOverride(
     return this;
 }
 
+// GloballyCoherentModifierVal
+void GloballyCoherentModifierVal::_toTextOverride(StringBuilder& out)
+{
+    out.append("globallycoherent");
+}
+
+Val* GloballyCoherentModifierVal::_substituteImplOverride(
+    ASTBuilder* astBuilder,
+    SubstitutionSet subst,
+    int* ioDiff)
+{
+    SLANG_UNUSED(astBuilder);
+    SLANG_UNUSED(subst);
+    SLANG_UNUSED(ioDiff);
+    return this;
+}
+
 // PolynomialIntVal
 
 void PolynomialIntVal::_toTextOverride(StringBuilder& out)

--- a/source/slang/slang-ast-val.h
+++ b/source/slang/slang-ast-val.h
@@ -1164,6 +1164,14 @@ class NoDiffModifierVal : public TypeModifierVal
     Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
 };
 
+FIDDLE()
+class GloballyCoherentModifierVal : public TypeModifierVal
+{
+    FIDDLE(...)
+    void _toTextOverride(StringBuilder& out);
+    Val* _substituteImplOverride(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff);
+};
+
 /// Represents the result of differentiating a function.
 FIDDLE()
 class DifferentiateVal : public Val

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -8569,6 +8569,10 @@ Val* SemanticsExprVisitor::checkTypeModifier(Modifier* modifier, Type* type)
     {
         return m_astBuilder->getNoDiffModifierVal();
     }
+    else if (as<GloballyCoherentModifier>(modifier))
+    {
+        return m_astBuilder->getGloballyCoherentModifierVal();
+    }
     else if (as<ConstModifier>(modifier))
     {
         getSink()->diagnose(Diagnostics::ConstNotAllowedOnType{.location = modifier->loc});

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -403,9 +403,19 @@ List<IRWitnessTableEntry*> CLikeSourceEmitter::getSortedWitnessTableEntries(
 
 void CLikeSourceEmitter::_emitPrefixTypeAttr(IRAttr* attr)
 {
-    SLANG_UNUSED(attr);
+    if (auto memoryQualifierAttr = as<IRMemoryQualifierSetAttr>(attr))
+    {
+        auto flags = getIntVal(memoryQualifierAttr->getMemoryQualifierBit());
+        if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
+        {
+            getSink()->diagnose(Diagnostics::UnsupportedTargetIntrinsic{
+                .operation = "coherent memory qualifier",
+                .location = findFirstUseLoc(attr)});
+        }
+        return;
+    }
 
-    // By defualt we will not emit any attributes.
+    // By default we will not emit any attributes.
     //
     // TODO: If `const` ever surfaces as a type attribute in our IR,
     // we may need to handle it here.

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -1951,9 +1951,8 @@ void GLSLSourceEmitter::emitImageFormatModifierImpl(IRInst* varDecl, IRType* var
     // - Emit a `format` layout qualifier.
     // - Emit `writeonly` memory qualifier for `WTexture*`.
 
-    if (auto resourceType =
-            as<IRTextureType, IRDynamicCastBehavior::NoUnwrap>(
-                _unwrapArrayAndAttributedType(varType)))
+    if (auto resourceType = as<IRTextureType, IRDynamicCastBehavior::NoUnwrap>(
+            _unwrapArrayAndAttributedType(varType)))
     {
         switch (resourceType->getAccess())
         {

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -261,6 +261,26 @@ IRIntegerValue GLSLSourceEmitter::_getMemoryQualifierTypeAttrFlags(IRType* type)
     return flags;
 }
 
+// Strip array and type-attribute wrappers for GLSL resource classification.
+static IRType* _unwrapArrayAndAttributedType(IRType* type)
+{
+    while (type)
+    {
+        if (auto arrayType = as<IRArrayTypeBase, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            type = arrayType->getElementType();
+            continue;
+        }
+        if (auto attributedType = as<IRAttributedType, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            type = attributedType->getBaseType();
+            continue;
+        }
+        break;
+    }
+    return type;
+}
+
 void GLSLSourceEmitter::_emitMemoryQualifierDecorations(IRInst* varDecl)
 {
     _emitMemoryQualifierFlags(_getMemoryQualifierDecorationFlags(varDecl));
@@ -1894,7 +1914,7 @@ bool GLSLSourceEmitter::tryEmitGlobalParamImpl(IRGlobalParam* varDecl, IRType* v
     //
     if (as<IRUnsizedArrayType>(varType))
     {
-        if (isResourceType(unwrapArray(varType)))
+        if (isResourceType(_unwrapArrayAndAttributedType(varType)))
         {
             _requireGLSLExtension(UnownedStringSlice::fromLiteral("GL_EXT_nonuniform_qualifier"));
         }
@@ -1931,7 +1951,9 @@ void GLSLSourceEmitter::emitImageFormatModifierImpl(IRInst* varDecl, IRType* var
     // - Emit a `format` layout qualifier.
     // - Emit `writeonly` memory qualifier for `WTexture*`.
 
-    if (auto resourceType = as<IRTextureType>(unwrapArray(varType)))
+    if (auto resourceType =
+            as<IRTextureType, IRDynamicCastBehavior::NoUnwrap>(
+                _unwrapArrayAndAttributedType(varType)))
     {
         switch (resourceType->getAccess())
         {

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -201,31 +201,62 @@ void GLSLSourceEmitter::_requireGLSLVersion(int version)
     }
 }
 
+void GLSLSourceEmitter::_emitMemoryQualifierFlags(IRIntegerValue flags)
+{
+    if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
+    {
+        m_writer->emit("coherent ");
+    }
+    if (flags & MemoryQualifierSetModifier::Flags::kVolatile)
+    {
+        m_writer->emit("volatile ");
+    }
+    if (flags & MemoryQualifierSetModifier::Flags::kRestrict)
+    {
+        m_writer->emit("restrict ");
+    }
+    if (flags & MemoryQualifierSetModifier::Flags::kReadOnly)
+    {
+        m_writer->emit("readonly ");
+    }
+    if (flags & MemoryQualifierSetModifier::Flags::kWriteOnly)
+    {
+        m_writer->emit("writeonly ");
+    }
+}
+
 void GLSLSourceEmitter::_emitMemoryQualifierDecorations(IRInst* varDecl)
 {
     if (auto collection = varDecl->findDecoration<IRMemoryQualifierSetDecoration>())
     {
         IRIntegerValue flags = collection->getMemoryQualifierBit();
-        if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
+        _emitMemoryQualifierFlags(flags);
+    }
+}
+
+void GLSLSourceEmitter::_emitMemoryQualifierTypeAttrs(IRType* type)
+{
+    while (type)
+    {
+        if (auto attributedType = as<IRAttributedType, IRDynamicCastBehavior::NoUnwrap>(type))
         {
-            m_writer->emit("coherent ");
+            for (auto attr : attributedType->getAllAttrs())
+            {
+                if (auto memoryQualifierAttr = as<IRMemoryQualifierSetAttr>(attr))
+                {
+                    _emitMemoryQualifierFlags(
+                        getIntVal(memoryQualifierAttr->getMemoryQualifierBit()));
+                }
+            }
+            type = attributedType->getBaseType();
+            continue;
         }
-        if (flags & MemoryQualifierSetModifier::Flags::kVolatile)
+        if (auto arrayType = as<IRArrayTypeBase, IRDynamicCastBehavior::NoUnwrap>(type))
         {
-            m_writer->emit("volatile ");
+            type = arrayType->getElementType();
+            continue;
         }
-        if (flags & MemoryQualifierSetModifier::Flags::kRestrict)
-        {
-            m_writer->emit("restrict ");
-        }
-        if (flags & MemoryQualifierSetModifier::Flags::kReadOnly)
-        {
-            m_writer->emit("readonly ");
-        }
-        if (flags & MemoryQualifierSetModifier::Flags::kWriteOnly)
-        {
-            m_writer->emit("writeonly ");
-        }
+        break;
     }
 }
 
@@ -234,6 +265,22 @@ void GLSLSourceEmitter::emitMemoryQualifiers(IRInst* varDecl)
     _emitMemoryQualifierDecorations(varDecl);
 }
 
+void GLSLSourceEmitter::_emitPrefixTypeAttr(IRAttr* attr)
+{
+    switch (attr->getOp())
+    {
+    default:
+        Super::_emitPrefixTypeAttr(attr);
+        break;
+
+    case kIROp_MemoryQualifierSetAttr:
+        {
+            auto memoryQualifierAttr = cast<IRMemoryQualifierSetAttr>(attr);
+            _emitMemoryQualifierFlags(getIntVal(memoryQualifierAttr->getMemoryQualifierBit()));
+        }
+        break;
+    }
+}
 
 void GLSLSourceEmitter::emitStructFieldAttributes(
     IRStructType* structType,
@@ -314,6 +361,9 @@ void GLSLSourceEmitter::_emitGLSLStructuredBuffer(
     }
 
     m_writer->emit(") ");
+
+    _emitMemoryQualifierDecorations(varDecl);
+    _emitMemoryQualifierTypeAttrs(varDecl->getDataType());
 
     /*
     If the output type is a buffer, and we can determine it is only readonly we can prefix

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -236,49 +236,7 @@ IRIntegerValue GLSLSourceEmitter::_getMemoryQualifierDecorationFlags(IRInst* var
 
 IRIntegerValue GLSLSourceEmitter::_getMemoryQualifierTypeAttrFlags(IRType* type)
 {
-    IRIntegerValue flags = 0;
-    while (type)
-    {
-        if (auto attributedType = as<IRAttributedType, IRDynamicCastBehavior::NoUnwrap>(type))
-        {
-            for (auto attr : attributedType->getAllAttrs())
-            {
-                if (auto memoryQualifierAttr = as<IRMemoryQualifierSetAttr>(attr))
-                {
-                    flags |= getIntVal(memoryQualifierAttr->getMemoryQualifierBit());
-                }
-            }
-            type = attributedType->getBaseType();
-            continue;
-        }
-        if (auto arrayType = as<IRArrayTypeBase, IRDynamicCastBehavior::NoUnwrap>(type))
-        {
-            type = arrayType->getElementType();
-            continue;
-        }
-        break;
-    }
-    return flags;
-}
-
-// Strip array and type-attribute wrappers for GLSL resource classification.
-static IRType* _unwrapArrayAndAttributedType(IRType* type)
-{
-    while (type)
-    {
-        if (auto arrayType = as<IRArrayTypeBase, IRDynamicCastBehavior::NoUnwrap>(type))
-        {
-            type = arrayType->getElementType();
-            continue;
-        }
-        if (auto attributedType = as<IRAttributedType, IRDynamicCastBehavior::NoUnwrap>(type))
-        {
-            type = attributedType->getBaseType();
-            continue;
-        }
-        break;
-    }
-    return type;
+    return getMemoryQualifierSetAttrFlags(type);
 }
 
 void GLSLSourceEmitter::_emitMemoryQualifierDecorations(IRInst* varDecl)
@@ -1914,7 +1872,7 @@ bool GLSLSourceEmitter::tryEmitGlobalParamImpl(IRGlobalParam* varDecl, IRType* v
     //
     if (as<IRUnsizedArrayType>(varType))
     {
-        if (isResourceType(_unwrapArrayAndAttributedType(varType)))
+        if (isResourceType(unwrapAttributedTypeAndArray(varType)))
         {
             _requireGLSLExtension(UnownedStringSlice::fromLiteral("GL_EXT_nonuniform_qualifier"));
         }
@@ -1952,7 +1910,7 @@ void GLSLSourceEmitter::emitImageFormatModifierImpl(IRInst* varDecl, IRType* var
     // - Emit `writeonly` memory qualifier for `WTexture*`.
 
     if (auto resourceType = as<IRTextureType, IRDynamicCastBehavior::NoUnwrap>(
-            _unwrapArrayAndAttributedType(varType)))
+            unwrapAttributedTypeAndArray(varType)))
     {
         switch (resourceType->getAccess())
         {

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -225,17 +225,18 @@ void GLSLSourceEmitter::_emitMemoryQualifierFlags(IRIntegerValue flags)
     }
 }
 
-void GLSLSourceEmitter::_emitMemoryQualifierDecorations(IRInst* varDecl)
+IRIntegerValue GLSLSourceEmitter::_getMemoryQualifierDecorationFlags(IRInst* varDecl)
 {
     if (auto collection = varDecl->findDecoration<IRMemoryQualifierSetDecoration>())
     {
-        IRIntegerValue flags = collection->getMemoryQualifierBit();
-        _emitMemoryQualifierFlags(flags);
+        return collection->getMemoryQualifierBit();
     }
+    return 0;
 }
 
-void GLSLSourceEmitter::_emitMemoryQualifierTypeAttrs(IRType* type)
+IRIntegerValue GLSLSourceEmitter::_getMemoryQualifierTypeAttrFlags(IRType* type)
 {
+    IRIntegerValue flags = 0;
     while (type)
     {
         if (auto attributedType = as<IRAttributedType, IRDynamicCastBehavior::NoUnwrap>(type))
@@ -244,8 +245,7 @@ void GLSLSourceEmitter::_emitMemoryQualifierTypeAttrs(IRType* type)
             {
                 if (auto memoryQualifierAttr = as<IRMemoryQualifierSetAttr>(attr))
                 {
-                    _emitMemoryQualifierFlags(
-                        getIntVal(memoryQualifierAttr->getMemoryQualifierBit()));
+                    flags |= getIntVal(memoryQualifierAttr->getMemoryQualifierBit());
                 }
             }
             type = attributedType->getBaseType();
@@ -258,6 +258,17 @@ void GLSLSourceEmitter::_emitMemoryQualifierTypeAttrs(IRType* type)
         }
         break;
     }
+    return flags;
+}
+
+void GLSLSourceEmitter::_emitMemoryQualifierDecorations(IRInst* varDecl)
+{
+    _emitMemoryQualifierFlags(_getMemoryQualifierDecorationFlags(varDecl));
+}
+
+void GLSLSourceEmitter::_emitMemoryQualifierTypeAttrs(IRType* type)
+{
+    _emitMemoryQualifierFlags(_getMemoryQualifierTypeAttrFlags(type));
 }
 
 void GLSLSourceEmitter::emitMemoryQualifiers(IRInst* varDecl)
@@ -362,8 +373,9 @@ void GLSLSourceEmitter::_emitGLSLStructuredBuffer(
 
     m_writer->emit(") ");
 
-    _emitMemoryQualifierDecorations(varDecl);
-    _emitMemoryQualifierTypeAttrs(varDecl->getDataType());
+    _emitMemoryQualifierFlags(
+        _getMemoryQualifierDecorationFlags(varDecl) |
+        _getMemoryQualifierTypeAttrFlags(varDecl->getDataType()));
 
     /*
     If the output type is a buffer, and we can determine it is only readonly we can prefix

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -266,11 +266,6 @@ void GLSLSourceEmitter::_emitMemoryQualifierDecorations(IRInst* varDecl)
     _emitMemoryQualifierFlags(_getMemoryQualifierDecorationFlags(varDecl));
 }
 
-void GLSLSourceEmitter::_emitMemoryQualifierTypeAttrs(IRType* type)
-{
-    _emitMemoryQualifierFlags(_getMemoryQualifierTypeAttrFlags(type));
-}
-
 void GLSLSourceEmitter::emitMemoryQualifiers(IRInst* varDecl)
 {
     _emitMemoryQualifierDecorations(varDecl);

--- a/source/slang/slang-emit-glsl.h
+++ b/source/slang/slang-emit-glsl.h
@@ -67,6 +67,7 @@ protected:
     virtual void emitParamTypeImpl(IRType* type, String const& name) SLANG_OVERRIDE;
     virtual void emitFuncDecorationImpl(IRDecoration* decoration) SLANG_OVERRIDE;
     virtual void emitGlobalParamDefaultVal(IRGlobalParam* decl) SLANG_OVERRIDE;
+    virtual void _emitPrefixTypeAttr(IRAttr* attr) SLANG_OVERRIDE;
 
     virtual void emitBitfieldExtractImpl(IRInst* inst) SLANG_OVERRIDE;
     virtual void emitBitfieldInsertImpl(IRInst* inst) SLANG_OVERRIDE;
@@ -83,7 +84,9 @@ protected:
     virtual void emitSimpleValueImpl(IRInst* inst) SLANG_OVERRIDE;
     virtual void emitLoopControlDecorationImpl(IRLoopControlDecoration* decl) SLANG_OVERRIDE;
 
+    void _emitMemoryQualifierFlags(IRIntegerValue flags);
     void _emitMemoryQualifierDecorations(IRInst* varDecl);
+    void _emitMemoryQualifierTypeAttrs(IRType* type);
     void _emitGLSLSubpassInputType(IRSubpassInputType* type);
     void _emitGLSLTextureOrTextureSamplerType(IRTextureTypeBase* type, char const* baseName);
     void _emitGLSLStructuredBuffer(

--- a/source/slang/slang-emit-glsl.h
+++ b/source/slang/slang-emit-glsl.h
@@ -84,6 +84,8 @@ protected:
     virtual void emitSimpleValueImpl(IRInst* inst) SLANG_OVERRIDE;
     virtual void emitLoopControlDecorationImpl(IRLoopControlDecoration* decl) SLANG_OVERRIDE;
 
+    IRIntegerValue _getMemoryQualifierDecorationFlags(IRInst* varDecl);
+    IRIntegerValue _getMemoryQualifierTypeAttrFlags(IRType* type);
     void _emitMemoryQualifierFlags(IRIntegerValue flags);
     void _emitMemoryQualifierDecorations(IRInst* varDecl);
     void _emitMemoryQualifierTypeAttrs(IRType* type);

--- a/source/slang/slang-emit-glsl.h
+++ b/source/slang/slang-emit-glsl.h
@@ -88,7 +88,6 @@ protected:
     IRIntegerValue _getMemoryQualifierTypeAttrFlags(IRType* type);
     void _emitMemoryQualifierFlags(IRIntegerValue flags);
     void _emitMemoryQualifierDecorations(IRInst* varDecl);
-    void _emitMemoryQualifierTypeAttrs(IRType* type);
     void _emitGLSLSubpassInputType(IRSubpassInputType* type);
     void _emitGLSLTextureOrTextureSamplerType(IRTextureTypeBase* type, char const* baseName);
     void _emitGLSLStructuredBuffer(

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -2217,6 +2217,14 @@ void HLSLSourceEmitter::_emitPrefixTypeAttr(IRAttr* attr)
     case kIROp_SNormAttr:
         m_writer->emit("snorm ");
         break;
+    case kIROp_MemoryQualifierSetAttr:
+        {
+            auto memoryQualifierAttr = cast<IRMemoryQualifierSetAttr>(attr);
+            IRIntegerValue flags = getIntVal(memoryQualifierAttr->getMemoryQualifierBit());
+            if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
+                m_writer->emit("globallycoherent ");
+        }
+        break;
     }
 }
 

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -16,14 +16,10 @@ static bool _shouldEmitHLSLGloballyCoherentModifier(IRType* type)
 {
     while (type)
     {
-        if (auto attributedType = as<IRAttributedType, IRDynamicCastBehavior::NoUnwrap>(type))
+        auto unwrappedType = unwrapAttributedTypeAndArray(type);
+        if (unwrappedType != type)
         {
-            type = attributedType->getBaseType();
-            continue;
-        }
-        if (auto arrayType = as<IRArrayTypeBase, IRDynamicCastBehavior::NoUnwrap>(type))
-        {
-            type = arrayType->getElementType();
+            type = unwrappedType;
             continue;
         }
         if (auto rateQualifiedType = as<IRRateQualifiedType, IRDynamicCastBehavior::NoUnwrap>(type))

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -11,6 +11,66 @@
 namespace Slang
 {
 
+// Return true when HLSL can legally print `globallycoherent` on this resource declaration.
+static bool _shouldEmitHLSLGloballyCoherentModifier(IRType* type)
+{
+    while (type)
+    {
+        if (auto attributedType = as<IRAttributedType, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            type = attributedType->getBaseType();
+            continue;
+        }
+        if (auto arrayType = as<IRArrayTypeBase, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            type = arrayType->getElementType();
+            continue;
+        }
+        if (auto rateQualifiedType = as<IRRateQualifiedType, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            type = rateQualifiedType->getValueType();
+            continue;
+        }
+        if (auto descriptorHandleType =
+                as<IRDescriptorHandleType, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            type = descriptorHandleType->getResourceType();
+            continue;
+        }
+
+        break;
+    }
+
+    if (!type)
+        return false;
+
+    if (auto resourceType = as<IRResourceTypeBase>(type))
+    {
+        switch (resourceType->getAccess())
+        {
+        case SLANG_RESOURCE_ACCESS_READ_WRITE:
+        case SLANG_RESOURCE_ACCESS_RASTER_ORDERED:
+        case SLANG_RESOURCE_ACCESS_WRITE:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    switch (type->getOp())
+    {
+    case kIROp_HLSLRWStructuredBufferType:
+    case kIROp_HLSLRasterizerOrderedStructuredBufferType:
+    case kIROp_HLSLAppendStructuredBufferType:
+    case kIROp_HLSLConsumeStructuredBufferType:
+    case kIROp_HLSLRWByteAddressBufferType:
+    case kIROp_HLSLRasterizerOrderedByteAddressBufferType:
+        return true;
+    default:
+        return false;
+    }
+}
+
 
 void HLSLSourceEmitter::_emitHLSLDecorationSingleString(
     const char* name,
@@ -1722,6 +1782,32 @@ void HLSLSourceEmitter::emitSimpleTypeAndDeclaratorImpl(IRType* type, Declarator
         }
     }
     Super::emitSimpleTypeAndDeclaratorImpl(type, declarator);
+}
+
+void HLSLSourceEmitter::_emitType(IRType* type, DeclaratorInfo* declarator)
+{
+    if (auto attributedType = as<IRAttributedType>(type))
+    {
+        for (auto attr : attributedType->getAllAttrs())
+        {
+            if (auto memoryQualifierAttr = as<IRMemoryQualifierSetAttr>(attr))
+            {
+                auto flags = getIntVal(memoryQualifierAttr->getMemoryQualifierBit());
+                if ((flags & MemoryQualifierSetModifier::Flags::kCoherent) &&
+                    !_shouldEmitHLSLGloballyCoherentModifier(attributedType->getBaseType()))
+                {
+                    continue;
+                }
+            }
+
+            _emitPrefixTypeAttr(attr);
+        }
+        AttributedDeclaratorInfo attributedDeclarator(declarator, attributedType);
+        _emitType(attributedType->getBaseType(), &attributedDeclarator);
+        return;
+    }
+
+    Super::_emitType(type, declarator);
 }
 
 void HLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)

--- a/source/slang/slang-emit-hlsl.h
+++ b/source/slang/slang-emit-hlsl.h
@@ -109,6 +109,7 @@ protected:
 
     virtual void emitPostKeywordTypeAttributesImpl(IRInst* inst) SLANG_OVERRIDE;
 
+    virtual void _emitType(IRType* type, DeclaratorInfo* declarator) SLANG_OVERRIDE;
     virtual void _emitPrefixTypeAttr(IRAttr* attr) SLANG_OVERRIDE;
 
     // Emit a single `register` semantic, as appropriate for a given resource-type-specific layout

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -7119,7 +7119,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
     SpvStorageClass getDescriptorHeapBufferStorageClass(IRType* valueType)
     {
-        valueType = (IRType*)unwrapAttributedType(valueType);
+        valueType = as<IRType>(unwrapAttributedType(valueType));
         auto ptrType = as<IRPtrTypeBase>(valueType);
         if (!ptrType)
         {
@@ -7204,7 +7204,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
     SpvInst* getDescriptorHeapBaseType(IRType* valueType, bool* outIsBufferResource = nullptr)
     {
-        valueType = (IRType*)unwrapAttributedType(valueType);
+        valueType = as<IRType>(unwrapAttributedType(valueType));
         SpvInst* descriptorElementType = nullptr;
         bool isBufferResource = false;
         switch (valueType->getOp())

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1717,12 +1717,61 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         }
     }
 
+    bool hasCoherentMemoryQualifierDecoration(IRInst* inst)
+    {
+        if (!inst)
+            return false;
+
+        for (auto decoration : inst->getDecorations())
+        {
+            if (auto collection = as<IRMemoryQualifierSetDecoration>(decoration))
+            {
+                IRIntegerValue flags = collection->getMemoryQualifierBit();
+                if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    bool hasCoherentMemoryQualifierAttr(IRInst* type)
+    {
+        while (auto attributedType = as<IRAttributedType>(type))
+        {
+            for (auto attr : attributedType->getAllAttrs())
+            {
+                if (auto collection = as<IRMemoryQualifierSetAttr>(attr))
+                {
+                    IRIntegerValue flags = getIntVal(collection->getMemoryQualifierBit());
+                    if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
+                        return true;
+                }
+            }
+            type = attributedType->getBaseType();
+        }
+        return false;
+    }
+
+    bool hasCoherentMemoryQualifier(IRInst* inst)
+    {
+        if (!inst)
+            return false;
+
+        if (hasCoherentMemoryQualifierDecoration(inst))
+            return true;
+
+        if (hasCoherentMemoryQualifierAttr(inst->getDataType()))
+            return true;
+
+        return hasCoherentMemoryQualifierAttr(inst->getFullType());
+    }
+
     bool NeedToUseCoherentLoadOrStore(IRInst* pointer)
     {
         if (m_memoryModel != SpvMemoryModelVulkan)
             return false;
 
-        auto ptrType = as<IRPtrTypeBase>(pointer->getFullType());
+        auto ptrType = as<IRPtrTypeBase>(unwrapAttributedType(pointer->getFullType()));
         if (!ptrType)
             return false;
 
@@ -1763,19 +1812,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         if (baseObj == nullptr)
             return false;
 
-        for (auto decoration : baseObj->getDecorations())
-        {
-            if (decoration->getOp() == kIROp_MemoryQualifierSetDecoration)
-            {
-                auto collection = as<IRMemoryQualifierSetDecoration>(decoration);
-                IRIntegerValue flags = collection->getMemoryQualifierBit();
-                if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
-                {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return hasCoherentMemoryQualifier(baseObj) ||
+               hasCoherentMemoryQualifierAttr(ptrType->getValueType());
     }
 
     bool NeedToUseCoherentImageLoadOrStore(IRInst* image)
@@ -1783,21 +1821,19 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         if (m_memoryModel != SpvMemoryModelVulkan)
             return false;
 
-        if (auto opLoad = as<IRLoad>(image->getOperand(0)))
+        auto imageValue = image;
+        if (as<IRImageLoad>(image) || as<IRImageStore>(image))
+            imageValue = image->getOperand(0);
+        else if (auto asmOperand = as<IRSPIRVAsmOperand>(image))
+            imageValue = asmOperand->getValue();
+
+        if (hasCoherentMemoryQualifier(imageValue))
+            return true;
+
+        if (auto opLoad = as<IRLoad>(imageValue))
         {
             auto texPtr = opLoad->getPtr();
-            for (auto decoration : texPtr->getDecorations())
-            {
-                if (decoration->getOp() == kIROp_MemoryQualifierSetDecoration)
-                {
-                    auto collection = as<IRMemoryQualifierSetDecoration>(decoration);
-                    IRIntegerValue flags = collection->getMemoryQualifierBit();
-                    if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
-                    {
-                        return true;
-                    }
-                }
-            }
+            return hasCoherentMemoryQualifier(texPtr);
         }
         return false;
     }
@@ -7083,6 +7119,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
     SpvStorageClass getDescriptorHeapBufferStorageClass(IRType* valueType)
     {
+        valueType = (IRType*)unwrapAttributedType(valueType);
         auto ptrType = as<IRPtrTypeBase>(valueType);
         if (!ptrType)
         {
@@ -7167,6 +7204,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
     SpvInst* getDescriptorHeapBaseType(IRType* valueType, bool* outIsBufferResource = nullptr)
     {
+        valueType = (IRType*)unwrapAttributedType(valueType);
         SpvInst* descriptorElementType = nullptr;
         bool isBufferResource = false;
         switch (valueType->getOp())

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1734,9 +1734,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
     {
         if (auto irType = as<IRType, IRDynamicCastBehavior::NoUnwrap>(type))
         {
-            return (
-                getMemoryQualifierSetAttrFlags(irType) &
-                MemoryQualifierSetModifier::Flags::kCoherent) != 0;
+            return (getMemoryQualifierSetAttrFlags(irType) &
+                    MemoryQualifierSetModifier::Flags::kCoherent) != 0;
         }
         return false;
     }

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1732,28 +1732,11 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
     bool hasCoherentMemoryQualifierAttr(IRInst* type)
     {
-        while (type)
+        if (auto irType = as<IRType, IRDynamicCastBehavior::NoUnwrap>(type))
         {
-            if (auto attributedType = as<IRAttributedType, IRDynamicCastBehavior::NoUnwrap>(type))
-            {
-                for (auto attr : attributedType->getAllAttrs())
-                {
-                    if (auto collection = as<IRMemoryQualifierSetAttr>(attr))
-                    {
-                        IRIntegerValue flags = getIntVal(collection->getMemoryQualifierBit());
-                        if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
-                            return true;
-                    }
-                }
-                type = attributedType->getBaseType();
-                continue;
-            }
-            if (auto arrayType = as<IRArrayTypeBase, IRDynamicCastBehavior::NoUnwrap>(type))
-            {
-                type = arrayType->getElementType();
-                continue;
-            }
-            break;
+            return (
+                getMemoryQualifierSetAttrFlags(irType) &
+                MemoryQualifierSetModifier::Flags::kCoherent) != 0;
         }
         return false;
     }

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1722,16 +1722,12 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         if (!inst)
             return false;
 
-        for (auto decoration : inst->getDecorations())
-        {
-            if (auto collection = as<IRMemoryQualifierSetDecoration>(decoration))
-            {
-                IRIntegerValue flags = collection->getMemoryQualifierBit();
-                if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
-                    return true;
-            }
-        }
-        return false;
+        auto collection = inst->findDecoration<IRMemoryQualifierSetDecoration>();
+        if (!collection)
+            return false;
+
+        IRIntegerValue flags = collection->getMemoryQualifierBit();
+        return (flags & MemoryQualifierSetModifier::Flags::kCoherent) != 0;
     }
 
     bool hasCoherentMemoryQualifierAttr(IRInst* type)

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1732,18 +1732,28 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
     bool hasCoherentMemoryQualifierAttr(IRInst* type)
     {
-        while (auto attributedType = as<IRAttributedType>(type))
+        while (type)
         {
-            for (auto attr : attributedType->getAllAttrs())
+            if (auto attributedType = as<IRAttributedType, IRDynamicCastBehavior::NoUnwrap>(type))
             {
-                if (auto collection = as<IRMemoryQualifierSetAttr>(attr))
+                for (auto attr : attributedType->getAllAttrs())
                 {
-                    IRIntegerValue flags = getIntVal(collection->getMemoryQualifierBit());
-                    if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
-                        return true;
+                    if (auto collection = as<IRMemoryQualifierSetAttr>(attr))
+                    {
+                        IRIntegerValue flags = getIntVal(collection->getMemoryQualifierBit());
+                        if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
+                            return true;
+                    }
                 }
+                type = attributedType->getBaseType();
+                continue;
             }
-            type = attributedType->getBaseType();
+            if (auto arrayType = as<IRArrayTypeBase, IRDynamicCastBehavior::NoUnwrap>(type))
+            {
+                type = arrayType->getElementType();
+                continue;
+            }
+            break;
         }
         return false;
     }

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -1751,6 +1751,8 @@ Result linkAndOptimizeIR(
     if (requiredLoweringPassSet.dynamicResourceHeap)
         SLANG_PASS(lowerDynamicResourceHeap, targetProgram, sink);
 
+    SLANG_PASS(checkUnsupportedCoherentMemoryQualifier, targetRequest, sink);
+
     validateIRModuleIfEnabled(codeGenContext, irModule);
 
     // After type legalization and subsequent SSA cleanup we expect

--- a/source/slang/slang-ir-check-unsupported-inst.cpp
+++ b/source/slang/slang-ir-check-unsupported-inst.cpp
@@ -13,20 +13,6 @@ static bool _targetSupportsCoherentMemoryQualifier(TargetRequest* target)
     return target && (isD3DTarget(target) || isKhronosTarget(target));
 }
 
-static bool _hasCoherentMemoryQualifierAttr(IRAttributedType* attributedType)
-{
-    for (auto attr : attributedType->getAllAttrs())
-    {
-        if (auto memoryQualifierAttr = as<IRMemoryQualifierSetAttr>(attr))
-        {
-            auto flags = getIntVal(memoryQualifierAttr->getMemoryQualifierBit());
-            if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
-                return true;
-        }
-    }
-    return false;
-}
-
 static bool _hasCoherentMemoryQualifierDecoration(IRInst* inst)
 {
     if (auto decoration = inst->findDecoration<IRMemoryQualifierSetDecoration>())
@@ -35,21 +21,6 @@ static bool _hasCoherentMemoryQualifierDecoration(IRInst* inst)
         return (flags & MemoryQualifierSetModifier::Flags::kCoherent) != 0;
     }
     return false;
-}
-
-static void _checkCoherentMemoryQualifierTargetSupport(
-    IRAttributedType* attributedType,
-    TargetRequest* target,
-    DiagnosticSink* sink)
-{
-    if (_targetSupportsCoherentMemoryQualifier(target))
-        return;
-    if (!_hasCoherentMemoryQualifierAttr(attributedType))
-        return;
-
-    sink->diagnose(Diagnostics::UnsupportedTargetIntrinsic{
-        .operation = "coherent memory qualifier",
-        .location = findFirstUseLoc(attributedType)});
 }
 
 static void _checkCoherentMemoryQualifierDecorationTargetSupport(
@@ -81,17 +52,21 @@ static void _checkCoherentMemoryQualifierTargetSupport(
         if (!checkedTypes.add(type))
             return;
 
-        if (auto attributedType = as<IRAttributedType, IRDynamicCastBehavior::NoUnwrap>(type))
+        if ((getMemoryQualifierSetAttrFlags(type) & MemoryQualifierSetModifier::Flags::kCoherent) !=
+            0)
         {
-            _checkCoherentMemoryQualifierTargetSupport(attributedType, target, sink);
-            type = attributedType->getBaseType();
+            sink->diagnose(Diagnostics::UnsupportedTargetIntrinsic{
+                .operation = "coherent memory qualifier",
+                .location = findFirstUseLoc(type)});
+        }
+
+        auto unwrappedType = unwrapAttributedTypeAndArray(type);
+        if (unwrappedType != type)
+        {
+            type = unwrappedType;
             continue;
         }
-        if (auto arrayType = as<IRArrayTypeBase, IRDynamicCastBehavior::NoUnwrap>(type))
-        {
-            type = arrayType->getElementType();
-            continue;
-        }
+
         if (auto ptrType = as<IRPtrTypeBase, IRDynamicCastBehavior::NoUnwrap>(type))
         {
             type = ptrType->getValueType();
@@ -100,6 +75,12 @@ static void _checkCoherentMemoryQualifierTargetSupport(
         if (auto rateQualifiedType = as<IRRateQualifiedType, IRDynamicCastBehavior::NoUnwrap>(type))
         {
             type = rateQualifiedType->getValueType();
+            continue;
+        }
+        if (auto descriptorHandleType =
+                as<IRDescriptorHandleType, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            type = descriptorHandleType->getResourceType();
             continue;
         }
         return;

--- a/source/slang/slang-ir-check-unsupported-inst.cpp
+++ b/source/slang/slang-ir-check-unsupported-inst.cpp
@@ -3,9 +3,182 @@
 #include "slang-ir-util.h"
 #include "slang-ir.h"
 #include "slang-rich-diagnostics.h"
+#include "slang-target.h"
 
 namespace Slang
 {
+
+static bool _targetSupportsCoherentMemoryQualifier(TargetRequest* target)
+{
+    return target && (isD3DTarget(target) || isKhronosTarget(target));
+}
+
+static bool _hasCoherentMemoryQualifierAttr(IRAttributedType* attributedType)
+{
+    for (auto attr : attributedType->getAllAttrs())
+    {
+        if (auto memoryQualifierAttr = as<IRMemoryQualifierSetAttr>(attr))
+        {
+            auto flags = getIntVal(memoryQualifierAttr->getMemoryQualifierBit());
+            if (flags & MemoryQualifierSetModifier::Flags::kCoherent)
+                return true;
+        }
+    }
+    return false;
+}
+
+static bool _hasCoherentMemoryQualifierDecoration(IRInst* inst)
+{
+    if (auto decoration = inst->findDecoration<IRMemoryQualifierSetDecoration>())
+    {
+        auto flags = decoration->getMemoryQualifierBit();
+        return (flags & MemoryQualifierSetModifier::Flags::kCoherent) != 0;
+    }
+    return false;
+}
+
+static void _checkCoherentMemoryQualifierTargetSupport(
+    IRAttributedType* attributedType,
+    TargetRequest* target,
+    DiagnosticSink* sink)
+{
+    if (_targetSupportsCoherentMemoryQualifier(target))
+        return;
+    if (!_hasCoherentMemoryQualifierAttr(attributedType))
+        return;
+
+    sink->diagnose(Diagnostics::UnsupportedTargetIntrinsic{
+        .operation = "coherent memory qualifier",
+        .location = findFirstUseLoc(attributedType)});
+}
+
+static void _checkCoherentMemoryQualifierDecorationTargetSupport(
+    IRInst* inst,
+    TargetRequest* target,
+    DiagnosticSink* sink)
+{
+    if (_targetSupportsCoherentMemoryQualifier(target))
+        return;
+    if (!_hasCoherentMemoryQualifierDecoration(inst))
+        return;
+
+    sink->diagnose(Diagnostics::UnsupportedTargetIntrinsic{
+        .operation = "coherent memory qualifier",
+        .location = findFirstUseLoc(inst)});
+}
+
+static void _checkCoherentMemoryQualifierTargetSupport(
+    IRType* type,
+    TargetRequest* target,
+    DiagnosticSink* sink,
+    HashSet<IRInst*>& checkedTypes)
+{
+    if (_targetSupportsCoherentMemoryQualifier(target))
+        return;
+
+    while (type)
+    {
+        if (!checkedTypes.add(type))
+            return;
+
+        if (auto attributedType = as<IRAttributedType, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            _checkCoherentMemoryQualifierTargetSupport(attributedType, target, sink);
+            type = attributedType->getBaseType();
+            continue;
+        }
+        if (auto arrayType = as<IRArrayTypeBase, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            type = arrayType->getElementType();
+            continue;
+        }
+        if (auto ptrType = as<IRPtrTypeBase, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            type = ptrType->getValueType();
+            continue;
+        }
+        if (auto rateQualifiedType = as<IRRateQualifiedType, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            type = rateQualifiedType->getValueType();
+            continue;
+        }
+        return;
+    }
+}
+
+static void _checkCoherentMemoryQualifierTargetSupport(
+    TargetRequest* target,
+    IRFunc* func,
+    DiagnosticSink* sink,
+    HashSet<IRInst*>& checkedTypes)
+{
+    for (auto block : func->getBlocks())
+    {
+        for (auto inst : block->getChildren())
+        {
+            _checkCoherentMemoryQualifierDecorationTargetSupport(inst, target, sink);
+            _checkCoherentMemoryQualifierTargetSupport(
+                inst->getDataType(),
+                target,
+                sink,
+                checkedTypes);
+        }
+    }
+}
+
+void checkUnsupportedCoherentMemoryQualifier(
+    IRModule* module,
+    TargetRequest* target,
+    DiagnosticSink* sink)
+{
+    // Run before source-target legalization can erase coherent decorations or attributed types.
+    HashSet<IRInst*> checkedTypes;
+
+    for (auto globalInst : module->getGlobalInsts())
+    {
+        _checkCoherentMemoryQualifierDecorationTargetSupport(globalInst, target, sink);
+
+        if (auto type = as<IRType, IRDynamicCastBehavior::NoUnwrap>(globalInst))
+        {
+            _checkCoherentMemoryQualifierTargetSupport(type, target, sink, checkedTypes);
+        }
+        else
+        {
+            _checkCoherentMemoryQualifierTargetSupport(
+                globalInst->getDataType(),
+                target,
+                sink,
+                checkedTypes);
+        }
+
+        switch (globalInst->getOp())
+        {
+        case kIROp_Func:
+            _checkCoherentMemoryQualifierTargetSupport(
+                target,
+                as<IRFunc>(globalInst),
+                sink,
+                checkedTypes);
+            break;
+        case kIROp_Generic:
+            {
+                auto generic = as<IRGeneric>(globalInst);
+                auto innerFunc = as<IRFunc>(findGenericReturnVal(generic));
+                if (innerFunc)
+                {
+                    _checkCoherentMemoryQualifierTargetSupport(
+                        target,
+                        innerFunc,
+                        sink,
+                        checkedTypes);
+                }
+                break;
+            }
+        default:
+            break;
+        }
+    }
+}
 
 void checkUnsupportedInst(TargetRequest* target, IRFunc* func, DiagnosticSink* sink)
 {

--- a/source/slang/slang-ir-check-unsupported-inst.h
+++ b/source/slang/slang-ir-check-unsupported-inst.h
@@ -6,5 +6,9 @@ struct IRModule;
 class DiagnosticSink;
 class TargetRequest;
 
+void checkUnsupportedCoherentMemoryQualifier(
+    IRModule* module,
+    TargetRequest* target,
+    DiagnosticSink* sink);
 void checkUnsupportedInst(IRModule* module, TargetRequest* target, DiagnosticSink* sink);
 } // namespace Slang

--- a/source/slang/slang-ir-insts-stable-names.lua
+++ b/source/slang/slang-ir-insts-stable-names.lua
@@ -600,7 +600,7 @@ return {
 	["Attr.unorm"] = 618,
 	["Attr.snorm"] = 619,
 	["Attr.no_diff"] = 620,
-	["Attr.memoryQualifierSet"] = 860,
+	["Attr.memoryQualifierSet"] = 863,
 	["Attr.nonuniform"] = 621,
 	["Attr.Aligned"] = 622,
 	["Attr.SemanticAttr.userSemantic"] = 623,

--- a/source/slang/slang-ir-insts-stable-names.lua
+++ b/source/slang/slang-ir-insts-stable-names.lua
@@ -600,6 +600,7 @@ return {
 	["Attr.unorm"] = 618,
 	["Attr.snorm"] = 619,
 	["Attr.no_diff"] = 620,
+	["Attr.memoryQualifierSet"] = 860,
 	["Attr.nonuniform"] = 621,
 	["Attr.Aligned"] = 622,
 	["Attr.SemanticAttr.userSemantic"] = 623,

--- a/source/slang/slang-ir-insts.lua
+++ b/source/slang/slang-ir-insts.lua
@@ -2737,6 +2737,12 @@ local insts = {
 			},
 			{ no_diff = { struct_name = "NoDiffAttr" } },
 			{
+				memoryQualifierSet = {
+					struct_name = "MemoryQualifierSetAttr",
+					operands = { { "memoryQualifierBit" } },
+				},
+			},
+			{
 				nonuniform = {
 					struct_name = "NonUniformAttr",
 				},

--- a/source/slang/slang-ir-layout.cpp
+++ b/source/slang/slang-ir-layout.cpp
@@ -459,6 +459,12 @@ Result IRTypeLayoutRules::calcSizeAndAlignment(
     case kIROp_AttributedType:
         {
             auto attributedType = cast<IRAttributedType>(type);
+            for (auto attr : attributedType->getAllAttrs())
+            {
+                SLANG_ASSERT(
+                    attr->getOp() == kIROp_NoDiffAttr ||
+                    attr->getOp() == kIROp_MemoryQualifierSetAttr);
+            }
             return getSizeAndAlignment(
                 targetReq,
                 this,

--- a/source/slang/slang-ir-layout.cpp
+++ b/source/slang/slang-ir-layout.cpp
@@ -459,7 +459,6 @@ Result IRTypeLayoutRules::calcSizeAndAlignment(
     case kIROp_AttributedType:
         {
             auto attributedType = cast<IRAttributedType>(type);
-            SLANG_ASSERT(attributedType->getAttr()->getOp() == kIROp_NoDiffAttr);
             return getSizeAndAlignment(
                 targetReq,
                 this,

--- a/source/slang/slang-ir-resolve-texture-format.cpp
+++ b/source/slang/slang-ir-resolve-texture-format.cpp
@@ -5,6 +5,27 @@
 
 namespace Slang
 {
+// Find the texture resource inside parameter wrappers without relying on implicit cast unwrapping.
+static IRTextureTypeBase* getTextureTypeFromParameterType(IRType* type)
+{
+    while (type)
+    {
+        if (auto arrayType = as<IRArrayTypeBase, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            type = arrayType->getElementType();
+            continue;
+        }
+        if (auto attributedType = as<IRAttributedType, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            type = attributedType->getBaseType();
+            continue;
+        }
+        break;
+    }
+    return as<IRTextureTypeBase, IRDynamicCastBehavior::NoUnwrap>(type);
+}
+
+// Rebuild a parameter type with a new image element type while preserving wrapper attributes.
 static IRType* replaceImageElementType(IRInst* originalType, IRInst* newElementType)
 {
     switch (originalType->getOp())
@@ -30,8 +51,24 @@ static IRType* replaceImageElementType(IRInst* originalType, IRInst* newElementT
             return (IRType*)originalType;
         }
 
+    case kIROp_AttributedType:
+        {
+            auto attributedType = cast<IRAttributedType>(originalType);
+            auto newBaseType =
+                replaceImageElementType(attributedType->getBaseType(), newElementType);
+            if (newBaseType != attributedType->getBaseType())
+            {
+                IRBuilder builder(originalType);
+                builder.setInsertBefore(originalType);
+                IRCloneEnv cloneEnv;
+                cloneEnv.mapOldValToNew.add(attributedType->getBaseType(), newBaseType);
+                return (IRType*)cloneInst(&cloneEnv, &builder, originalType);
+            }
+            return (IRType*)originalType;
+        }
+
     default:
-        if (as<IRResourceTypeBase>(originalType))
+        if (as<IRResourceTypeBase, IRDynamicCastBehavior::NoUnwrap>(originalType))
             return (IRType*)newElementType;
         return (IRType*)originalType;
     }
@@ -130,20 +167,9 @@ void resolveTextureFormat(IRModule* module)
 {
     for (auto globalInst : module->getGlobalInsts())
     {
-        if (as<IRTextureTypeBase>(globalInst->getDataType()))
+        if (auto textureType = getTextureTypeFromParameterType(globalInst->getDataType()))
         {
-            resolveTextureFormatForParameter(
-                globalInst,
-                (IRTextureTypeBase*)globalInst->getDataType());
-        }
-        else if (auto arrayType = as<IRArrayTypeBase>(globalInst->getDataType()))
-        {
-            if (as<IRTextureTypeBase>(arrayType->getElementType()))
-            {
-                resolveTextureFormatForParameter(
-                    globalInst,
-                    (IRTextureTypeBase*)arrayType->getElementType());
-            }
+            resolveTextureFormatForParameter(globalInst, textureType);
         }
     }
 }

--- a/source/slang/slang-ir-resolve-texture-format.cpp
+++ b/source/slang/slang-ir-resolve-texture-format.cpp
@@ -2,27 +2,15 @@
 
 #include "slang-ir-clone.h"
 #include "slang-ir-insts.h"
+#include "slang-ir-util.h"
 
 namespace Slang
 {
 // Find the texture resource inside parameter wrappers without relying on implicit cast unwrapping.
 static IRTextureTypeBase* getTextureTypeFromParameterType(IRType* type)
 {
-    while (type)
-    {
-        if (auto arrayType = as<IRArrayTypeBase, IRDynamicCastBehavior::NoUnwrap>(type))
-        {
-            type = arrayType->getElementType();
-            continue;
-        }
-        if (auto attributedType = as<IRAttributedType, IRDynamicCastBehavior::NoUnwrap>(type))
-        {
-            type = attributedType->getBaseType();
-            continue;
-        }
-        break;
-    }
-    return as<IRTextureTypeBase, IRDynamicCastBehavior::NoUnwrap>(type);
+    return as<IRTextureTypeBase, IRDynamicCastBehavior::NoUnwrap>(
+        unwrapAttributedTypeAndArray(type));
 }
 
 // Rebuild a parameter type with a new image element type while preserving wrapper attributes.

--- a/source/slang/slang-ir-util.h
+++ b/source/slang/slang-ir-util.h
@@ -245,6 +245,54 @@ inline IRInst* unwrapAttributedType(IRInst* type)
     }
 }
 
+// Returns `type` with type-attribute and array wrappers stripped without implicit cast unwrapping.
+inline IRType* unwrapAttributedTypeAndArray(IRType* type)
+{
+    while (type)
+    {
+        if (auto attrType = as<IRAttributedType, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            type = attrType->getBaseType();
+            continue;
+        }
+        if (auto arrayType = as<IRArrayTypeBase, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            type = arrayType->getElementType();
+            continue;
+        }
+        break;
+    }
+    return type;
+}
+
+// Returns memory-qualifier attribute flags found while walking attributed and array type wrappers.
+inline IRIntegerValue getMemoryQualifierSetAttrFlags(IRType* type)
+{
+    IRIntegerValue flags = 0;
+    while (type)
+    {
+        if (auto attrType = as<IRAttributedType, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            for (auto attr : attrType->getAllAttrs())
+            {
+                if (auto memoryQualifierAttr = as<IRMemoryQualifierSetAttr>(attr))
+                {
+                    flags |= getIntVal(memoryQualifierAttr->getMemoryQualifierBit());
+                }
+            }
+            type = attrType->getBaseType();
+            continue;
+        }
+        if (auto arrayType = as<IRArrayTypeBase, IRDynamicCastBehavior::NoUnwrap>(type))
+        {
+            type = arrayType->getElementType();
+            continue;
+        }
+        break;
+    }
+    return flags;
+}
+
 // Remove hlsl's 'unorm' and 'snorm' modifiers
 IRType* dropNormAttributes(IRType* const t);
 

--- a/source/slang/slang-legalize-types.cpp
+++ b/source/slang/slang-legalize-types.cpp
@@ -1214,7 +1214,14 @@ LegalType legalizeTypeImpl(TypeLegalizationContext* context, IRType* type)
                     context->getBuilder()->getAttributedType(legalBaseType.getSimple(), attrs));
             }
         default:
-            // Attributes cannot currently wrap decomposed legalized types.
+            // Memory qualifiers affect code generation, so do not silently drop them if an
+            // unsupported type ever decomposes during legalization.
+            for (auto attr : attributedType->getAllAttrs())
+            {
+                if (as<IRMemoryQualifierSetAttr>(attr))
+                    SLANG_UNEXPECTED(
+                        "memory qualifier attributes cannot wrap decomposed legalized types");
+            }
             return legalBaseType;
         }
     }

--- a/source/slang/slang-legalize-types.cpp
+++ b/source/slang/slang-legalize-types.cpp
@@ -1214,13 +1214,20 @@ LegalType legalizeTypeImpl(TypeLegalizationContext* context, IRType* type)
                     context->getBuilder()->getAttributedType(legalBaseType.getSimple(), attrs));
             }
         default:
-            // Memory qualifiers affect code generation, so do not silently drop them if an
-            // unsupported type ever decomposes during legalization.
+            // Decomposed legalized types have no single wrapper where a type attribute can be
+            // preserved. NoDiffAttr has historically been allowed to drop in this case, but
+            // memory qualifiers affect code generation and future attributes should opt in here
+            // explicitly instead of being silently discarded.
             for (auto attr : attributedType->getAllAttrs())
             {
                 if (as<IRMemoryQualifierSetAttr>(attr))
                     SLANG_UNEXPECTED(
                         "memory qualifier attributes cannot wrap decomposed legalized types");
+
+                if (as<IRNoDiffAttr>(attr))
+                    continue;
+
+                SLANG_UNEXPECTED("unsupported attributes cannot wrap decomposed legalized types");
             }
             return legalBaseType;
         }

--- a/source/slang/slang-legalize-types.cpp
+++ b/source/slang/slang-legalize-types.cpp
@@ -1195,7 +1195,30 @@ LegalType legalizeTypeImpl(TypeLegalizationContext* context, IRType* type)
 
     context->builder->setInsertBefore(type);
 
-    if (auto uniformBufferType = as<IRUniformParameterGroupType>(type))
+    if (auto attributedType = as<IRAttributedType>(type))
+    {
+        auto legalBaseType = legalizeType(context, attributedType->getBaseType());
+        switch (legalBaseType.flavor)
+        {
+        case LegalType::Flavor::none:
+            return LegalType();
+        case LegalType::Flavor::simple:
+            {
+                if (legalBaseType.getSimple() == attributedType->getBaseType())
+                    return LegalType::simple(type);
+
+                List<IRAttr*> attrs;
+                for (auto attr : attributedType->getAllAttrs())
+                    attrs.add(attr);
+                return LegalType::simple(
+                    context->getBuilder()->getAttributedType(legalBaseType.getSimple(), attrs));
+            }
+        default:
+            // Attributes cannot currently wrap decomposed legalized types.
+            return legalBaseType;
+        }
+    }
+    else if (auto uniformBufferType = as<IRUniformParameterGroupType>(type))
     {
         // We have one of:
         //

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -2948,6 +2948,9 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
     LoweredValInfo visitGloballyCoherentModifierVal(GloballyCoherentModifierVal* astVal)
     {
         SLANG_UNUSED(astVal);
+        // `coherent` and `globallycoherent` both parse to GloballyCoherentModifier today.
+        // Preserve that existing consolidation for type modifiers: both map to the
+        // device-scope coherent bit used by HLSL/SPIR-V emission.
         IRInst* memoryQualifierBit = getBuilder()->getIntValue(
             getBuilder()->getIntType(),
             MemoryQualifierSetModifier::Flags::kCoherent);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -2945,6 +2945,16 @@ struct ValLoweringVisitor : ValVisitor<ValLoweringVisitor, LoweredValInfo, Lower
         return LoweredValInfo::simple(getBuilder()->getAttr(kIROp_NoDiffAttr));
     }
 
+    LoweredValInfo visitGloballyCoherentModifierVal(GloballyCoherentModifierVal* astVal)
+    {
+        SLANG_UNUSED(astVal);
+        IRInst* memoryQualifierBit = getBuilder()->getIntValue(
+            getBuilder()->getIntType(),
+            MemoryQualifierSetModifier::Flags::kCoherent);
+        return LoweredValInfo::simple(
+            getBuilder()->getAttr(kIROp_MemoryQualifierSetAttr, memoryQualifierBit));
+    }
+
     // We do not expect to encounter the following types in ASTs that have
     // passed front-end semantic checking.
 #define UNEXPECTED_CASE(NAME)        \

--- a/tests/language-feature/descriptor-handle/desc-handle-coherent-buffer.slang
+++ b/tests/language-feature/descriptor-handle/desc-handle-coherent-buffer.slang
@@ -10,10 +10,10 @@
 // SPIRV-NOT: MakePointerAvailable|NonPrivatePointer
 
 // HLSL-COUNT-4: globallycoherent RWStructuredBuffer<uint >  _S
-// HLSL-NOT: globallycoherent
+// HLSL-NOT: globallycoherent RWStructuredBuffer<uint >  _S
 // GLSL emits one resource-heap SSBO declaration shared by both coherent handles.
 // GLSL-COUNT-1: coherent buffer
-// GLSL-NOT: coherent
+// GLSL-NOT: coherent buffer
 
 uniform DescriptorHandle<coherent RWStructuredBuffer<uint>> coherentBuffer;
 uniform DescriptorHandle<globallycoherent RWStructuredBuffer<uint>> globallyCoherentBuffer;

--- a/tests/language-feature/descriptor-handle/desc-handle-coherent-buffer.slang
+++ b/tests/language-feature/descriptor-handle/desc-handle-coherent-buffer.slang
@@ -1,0 +1,17 @@
+//TEST(compute, vulkan):SIMPLE(filecheck=SPIRV): -target spirv-asm -stage compute -entry computeMain -capability spvDescriptorHeapEXT -capability vk_mem_model
+//TEST(compute):SIMPLE(filecheck=HLSL): -target hlsl -profile cs_6_6 -entry computeMain
+
+// SPIRV: OpLoad {{.*}} MakePointerVisible|NonPrivatePointer
+// SPIRV: OpStore {{.*}} MakePointerAvailable|NonPrivatePointer
+
+// HLSL-COUNT-2: globallycoherent RWStructuredBuffer<uint
+
+uniform DescriptorHandle<coherent RWStructuredBuffer<uint>> coherentBuffer;
+uniform DescriptorHandle<globallycoherent RWStructuredBuffer<uint>> globallyCoherentBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    uint index = dispatchThreadID.x;
+    (*coherentBuffer)[index] = (*globallyCoherentBuffer)[index];
+}

--- a/tests/language-feature/descriptor-handle/desc-handle-coherent-buffer.slang
+++ b/tests/language-feature/descriptor-handle/desc-handle-coherent-buffer.slang
@@ -1,17 +1,26 @@
 //TEST(compute, vulkan):SIMPLE(filecheck=SPIRV): -target spirv-asm -stage compute -entry computeMain -capability spvDescriptorHeapEXT -capability vk_mem_model
 //TEST(compute):SIMPLE(filecheck=HLSL): -target hlsl -profile cs_6_6 -entry computeMain
+//TEST(compute):SIMPLE(filecheck=GLSL): -target glsl -entry computeMain -stage compute
 
 // SPIRV: OpLoad {{.*}} MakePointerVisible|NonPrivatePointer
-// SPIRV: OpStore {{.*}} MakePointerAvailable|NonPrivatePointer
+// SPIRV-NEXT: OpStore {{.*}} MakePointerAvailable|NonPrivatePointer
+// SPIRV: OpLoad {{.*}} MakePointerVisible|NonPrivatePointer
+// SPIRV-NEXT: OpStore {{.*}} MakePointerAvailable|NonPrivatePointer
+// SPIRV-NOT: MakePointerVisible|NonPrivatePointer
+// SPIRV-NOT: MakePointerAvailable|NonPrivatePointer
 
-// HLSL-COUNT-2: globallycoherent RWStructuredBuffer<uint
+// HLSL-COUNT-4: globallycoherent RWStructuredBuffer<uint >  _S
+// GLSL-COUNT-1: coherent buffer
 
 uniform DescriptorHandle<coherent RWStructuredBuffer<uint>> coherentBuffer;
 uniform DescriptorHandle<globallycoherent RWStructuredBuffer<uint>> globallyCoherentBuffer;
+uniform DescriptorHandle<RWStructuredBuffer<uint>> plainBuffer;
 
 [numthreads(1, 1, 1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     uint index = dispatchThreadID.x;
     (*coherentBuffer)[index] = (*globallyCoherentBuffer)[index];
+    (*globallyCoherentBuffer)[index + 1] = (*coherentBuffer)[index + 1];
+    (*plainBuffer)[index + 2] = (*plainBuffer)[index + 3];
 }

--- a/tests/language-feature/descriptor-handle/desc-handle-coherent-buffer.slang
+++ b/tests/language-feature/descriptor-handle/desc-handle-coherent-buffer.slang
@@ -10,7 +10,10 @@
 // SPIRV-NOT: MakePointerAvailable|NonPrivatePointer
 
 // HLSL-COUNT-4: globallycoherent RWStructuredBuffer<uint >  _S
+// HLSL-NOT: globallycoherent
+// GLSL emits one resource-heap SSBO declaration shared by both coherent handles.
 // GLSL-COUNT-1: coherent buffer
+// GLSL-NOT: coherent
 
 uniform DescriptorHandle<coherent RWStructuredBuffer<uint>> coherentBuffer;
 uniform DescriptorHandle<globallycoherent RWStructuredBuffer<uint>> globallyCoherentBuffer;

--- a/tests/language-feature/descriptor-handle/desc-handle-coherent-read-only-buffer.slang
+++ b/tests/language-feature/descriptor-handle/desc-handle-coherent-read-only-buffer.slang
@@ -5,11 +5,12 @@
 // SPIRV: OpLoad {{.*}} MakePointerVisible|NonPrivatePointer
 // SPIRV-NOT: MakePointerVisible|NonPrivatePointer
 
-// HLSL-COUNT-1: globallycoherent StructuredBuffer<uint >  _S
+// HLSL-NOT: globallycoherent
+// HLSL: StructuredBuffer<uint >  _S
 // HLSL-NOT: globallycoherent
 // GLSL emits one resource-heap SSBO declaration for the coherent read-only handle.
 // GLSL-COUNT-1: coherent readonly buffer
-// GLSL-NOT: coherent
+// GLSL-NOT: coherent readonly buffer
 
 uniform DescriptorHandle<coherent StructuredBuffer<uint>> coherentReadOnlyBuffer;
 uniform DescriptorHandle<StructuredBuffer<uint>> plainReadOnlyBuffer;

--- a/tests/language-feature/descriptor-handle/desc-handle-coherent-read-only-buffer.slang
+++ b/tests/language-feature/descriptor-handle/desc-handle-coherent-read-only-buffer.slang
@@ -1,0 +1,24 @@
+//TEST(compute, vulkan):SIMPLE(filecheck=SPIRV): -target spirv-asm -stage compute -entry computeMain -capability spvDescriptorHeapEXT -capability vk_mem_model
+//TEST(compute):SIMPLE(filecheck=HLSL): -target hlsl -profile cs_6_6 -entry computeMain
+//TEST(compute):SIMPLE(filecheck=GLSL): -target glsl -entry computeMain -stage compute
+
+// SPIRV: OpLoad {{.*}} MakePointerVisible|NonPrivatePointer
+// SPIRV-NOT: MakePointerVisible|NonPrivatePointer
+
+// HLSL-COUNT-1: globallycoherent StructuredBuffer<uint >  _S
+// HLSL-NOT: globallycoherent
+// GLSL emits one resource-heap SSBO declaration for the coherent read-only handle.
+// GLSL-COUNT-1: coherent readonly buffer
+// GLSL-NOT: coherent
+
+uniform DescriptorHandle<coherent StructuredBuffer<uint>> coherentReadOnlyBuffer;
+uniform DescriptorHandle<StructuredBuffer<uint>> plainReadOnlyBuffer;
+uniform DescriptorHandle<RWStructuredBuffer<uint>> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    uint index = dispatchThreadID.x;
+    (*outputBuffer)[index] =
+        (*coherentReadOnlyBuffer)[index] + (*plainReadOnlyBuffer)[index + 1];
+}

--- a/tests/language-feature/descriptor-handle/desc-handle-coherent-texture.slang
+++ b/tests/language-feature/descriptor-handle/desc-handle-coherent-texture.slang
@@ -1,5 +1,6 @@
 //TEST(compute, vulkan):SIMPLE(filecheck=SPIRV): -target spirv-asm -stage compute -entry computeMain -capability spvDescriptorHeapEXT -capability vk_mem_model
 //TEST(compute):SIMPLE(filecheck=HLSL): -target hlsl -profile cs_6_6 -entry computeMain
+//TEST(compute):SIMPLE(filecheck=GLSL): -target glsl -entry computeMain -stage compute
 
 // SPIRV: OpImageRead {{.*}} MakeTexelVisible|NonPrivateTexel
 // SPIRV-NEXT: OpImageWrite {{.*}} MakeTexelAvailable|NonPrivateTexel
@@ -9,6 +10,10 @@
 // SPIRV-NOT: MakeTexelAvailable|NonPrivateTexel
 
 // HLSL-COUNT-4: globallycoherent RWTexture2D<float4 >  _S
+// HLSL-NOT: globallycoherent
+// GLSL emits one resource-heap image declaration shared by both coherent handles.
+// GLSL-COUNT-1: coherent
+// GLSL-NOT: coherent
 
 uniform DescriptorHandle<coherent RWTexture2D<float4>> coherentTexture;
 uniform DescriptorHandle<globallycoherent RWTexture2D<float4>> globallyCoherentTexture;

--- a/tests/language-feature/descriptor-handle/desc-handle-coherent-texture.slang
+++ b/tests/language-feature/descriptor-handle/desc-handle-coherent-texture.slang
@@ -10,10 +10,10 @@
 // SPIRV-NOT: MakeTexelAvailable|NonPrivateTexel
 
 // HLSL-COUNT-4: globallycoherent RWTexture2D<float4 >  _S
-// HLSL-NOT: globallycoherent
+// HLSL-NOT: globallycoherent RWTexture2D<float4 >  _S
 // GLSL emits one resource-heap image declaration shared by both coherent handles.
-// GLSL-COUNT-1: coherent
-// GLSL-NOT: coherent
+// GLSL-COUNT-1: uniform coherent image2D
+// GLSL-NOT: uniform coherent image2D
 
 uniform DescriptorHandle<coherent RWTexture2D<float4>> coherentTexture;
 uniform DescriptorHandle<globallycoherent RWTexture2D<float4>> globallyCoherentTexture;

--- a/tests/language-feature/descriptor-handle/desc-handle-coherent-texture.slang
+++ b/tests/language-feature/descriptor-handle/desc-handle-coherent-texture.slang
@@ -1,0 +1,17 @@
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv-asm -stage compute -entry computeMain -capability spvDescriptorHeapEXT -capability vk_mem_model
+//TEST:SIMPLE(filecheck=HLSL): -target hlsl -profile cs_6_6 -entry computeMain
+
+// SPIRV: OpImageRead %{{.*}} {{.*}} MakeTexelVisible|NonPrivateTexel %
+// SPIRV: OpImageWrite {{.*}} {{.*}} {{.*}} MakeTexelAvailable|NonPrivateTexel %
+
+// HLSL: globallycoherent RWTexture2D<float4
+
+uniform DescriptorHandle<coherent RWTexture2D<float4>> coherentTexture;
+uniform DescriptorHandle<globallycoherent RWTexture2D<float4>> globallyCoherentTexture;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    uint2 coord = dispatchThreadID.xy;
+    (*coherentTexture)[coord] = (*globallyCoherentTexture)[coord];
+}

--- a/tests/language-feature/descriptor-handle/desc-handle-coherent-texture.slang
+++ b/tests/language-feature/descriptor-handle/desc-handle-coherent-texture.slang
@@ -1,17 +1,24 @@
 //TEST(compute, vulkan):SIMPLE(filecheck=SPIRV): -target spirv-asm -stage compute -entry computeMain -capability spvDescriptorHeapEXT -capability vk_mem_model
 //TEST(compute):SIMPLE(filecheck=HLSL): -target hlsl -profile cs_6_6 -entry computeMain
 
-// SPIRV: OpImageRead %{{.*}} {{.*}} MakeTexelVisible|NonPrivateTexel %
-// SPIRV: OpImageWrite {{.*}} {{.*}} {{.*}} MakeTexelAvailable|NonPrivateTexel %
+// SPIRV: OpImageRead {{.*}} MakeTexelVisible|NonPrivateTexel
+// SPIRV-NEXT: OpImageWrite {{.*}} MakeTexelAvailable|NonPrivateTexel
+// SPIRV: OpImageRead {{.*}} MakeTexelVisible|NonPrivateTexel
+// SPIRV-NEXT: OpImageWrite {{.*}} MakeTexelAvailable|NonPrivateTexel
+// SPIRV-NOT: MakeTexelVisible|NonPrivateTexel
+// SPIRV-NOT: MakeTexelAvailable|NonPrivateTexel
 
-// HLSL-COUNT-2: globallycoherent RWTexture2D<float4
+// HLSL-COUNT-4: globallycoherent RWTexture2D<float4 >  _S
 
 uniform DescriptorHandle<coherent RWTexture2D<float4>> coherentTexture;
 uniform DescriptorHandle<globallycoherent RWTexture2D<float4>> globallyCoherentTexture;
+uniform DescriptorHandle<RWTexture2D<float4>> plainTexture;
 
 [numthreads(1, 1, 1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     uint2 coord = dispatchThreadID.xy;
     (*coherentTexture)[coord] = (*globallyCoherentTexture)[coord];
+    (*globallyCoherentTexture)[coord + uint2(1, 0)] = (*coherentTexture)[coord + uint2(1, 0)];
+    (*plainTexture)[coord + uint2(2, 0)] = (*plainTexture)[coord + uint2(3, 0)];
 }

--- a/tests/language-feature/descriptor-handle/desc-handle-coherent-texture.slang
+++ b/tests/language-feature/descriptor-handle/desc-handle-coherent-texture.slang
@@ -1,10 +1,10 @@
-//TEST:SIMPLE(filecheck=SPIRV): -target spirv-asm -stage compute -entry computeMain -capability spvDescriptorHeapEXT -capability vk_mem_model
-//TEST:SIMPLE(filecheck=HLSL): -target hlsl -profile cs_6_6 -entry computeMain
+//TEST(compute, vulkan):SIMPLE(filecheck=SPIRV): -target spirv-asm -stage compute -entry computeMain -capability spvDescriptorHeapEXT -capability vk_mem_model
+//TEST(compute):SIMPLE(filecheck=HLSL): -target hlsl -profile cs_6_6 -entry computeMain
 
 // SPIRV: OpImageRead %{{.*}} {{.*}} MakeTexelVisible|NonPrivateTexel %
 // SPIRV: OpImageWrite {{.*}} {{.*}} {{.*}} MakeTexelAvailable|NonPrivateTexel %
 
-// HLSL: globallycoherent RWTexture2D<float4
+// HLSL-COUNT-2: globallycoherent RWTexture2D<float4
 
 uniform DescriptorHandle<coherent RWTexture2D<float4>> coherentTexture;
 uniform DescriptorHandle<globallycoherent RWTexture2D<float4>> globallyCoherentTexture;

--- a/tests/language-feature/descriptor-handle/desc-handle-coherent-unsupported-target.slang
+++ b/tests/language-feature/descriptor-handle/desc-handle-coherent-unsupported-target.slang
@@ -3,12 +3,21 @@
 //DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute
 //DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target cpp -entry computeMain -stage compute
 
-// CHECK: error[E55204]: unsupported intrinsic operation
+// CHECK: warning[E41016]: use of uninitialized variable
+// CHECK-COUNT-2: error[E55204]: unsupported intrinsic operation
 
 coherent RWStructuredBuffer<uint> coherentBuffer;
+
+uint useCoherentHandleType(DescriptorHandle<coherent RWStructuredBuffer<uint>> coherentHandle)
+{
+    return 0;
+}
 
 [numthreads(1, 1, 1)]
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
+    // Keep the local handle live so unsupported targets diagnose the type-attribute path.
+    DescriptorHandle<coherent RWStructuredBuffer<uint>> coherentHandle;
+    uint value = useCoherentHandleType(coherentHandle);
     coherentBuffer[dispatchThreadID.x] = 0;
 }

--- a/tests/language-feature/descriptor-handle/desc-handle-coherent-unsupported-target.slang
+++ b/tests/language-feature/descriptor-handle/desc-handle-coherent-unsupported-target.slang
@@ -1,0 +1,14 @@
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target metal -entry computeMain -stage compute
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target wgsl -entry computeMain -stage compute
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK): -target cpp -entry computeMain -stage compute
+
+// CHECK: error[E55204]: unsupported intrinsic operation
+
+coherent RWStructuredBuffer<uint> coherentBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    coherentBuffer[dispatchThreadID.x] = 0;
+}


### PR DESCRIPTION
Fixes #10852

## Motivation

Declaring bindless coherent resource handles such as `DescriptorHandle<coherent RWTexture2D<float4>>` or `DescriptorHandle<coherent RWStructuredBuffer<uint>>` failed during compilation or lost the coherent qualifier during descriptor-handle lowering and target emission.

A minimal repro is:

```slang
uniform DescriptorHandle<coherent RWTexture2D<float4>> coherentTexture;
uniform DescriptorHandle<globallycoherent RWTexture2D<float4>> globallyCoherentTexture;

(*coherentTexture)[coord] = (*globallyCoherentTexture)[coord];
```

Review follow-up also exposed three target-specific edge cases: HLSL emitted invalid `globallycoherent StructuredBuffer` for a read-only SRV, SPIR-V and GLSL did not walk attributed array types consistently, and Metal/WGSL/CUDA/CPP silently dropped coherent qualifiers.

## Proposed Solution

Keep the existing single-bit consolidation where `coherent` and `globallycoherent` both map to the device-scope coherent memory qualifier. Type-level coherent modifiers lower to `IRMemoryQualifierSetAttr`, while declaration-level coherent modifiers remain `IRMemoryQualifierSetDecoration`.

HLSL emission now prints `globallycoherent` only for writable UAV-like resources where HLSL accepts the modifier. SPIR-V and GLSL use shared IR utilities to walk attributed and array resource types so `coherent T[N]` behaves the same as `coherent T`. Non-D3D/non-Khronos targets now diagnose coherent qualifiers before target legalization can erase them. GLSL texture-format resolution also unwraps attributed resource-array element types explicitly and preserves the wrapper when it rewrites image formats.

## Change Summary

- `source/slang/slang-emit-hlsl.*`: filter type-level coherent attributes so read-only HLSL SRVs do not emit invalid `globallycoherent` declarations.
- `source/slang/slang-ir-util.h`, `source/slang/slang-emit-spirv.cpp`, and `source/slang/slang-emit-glsl.cpp`: share explicit no-unwrap walks through attributed and array resource types for coherent detection/classification.
- `source/slang/slang-ir-resolve-texture-format.cpp`: resolve texture formats through attributed array elements without C-casting the wrapper, and preserve attributes when rebuilding the type.
- `source/slang/slang-ir-check-unsupported-inst.*`, `source/slang/slang-emit.cpp`, and `source/slang/slang-emit-c-like.cpp`: diagnose coherent memory qualifiers on unsupported targets instead of silently dropping them.
- `tests/language-feature/descriptor-handle/`: add and tighten coherent descriptor-handle coverage for read-only buffers, textures, SSBO/image declarations, and unsupported targets.

## Concepts and Vocabulary

- Coherent memory qualifier: the single IR memory bit used for both source spellings, `coherent` and `globallycoherent`.
- Declaration decoration: `IRMemoryQualifierSetDecoration` on a value such as a global resource parameter.
- Type attribute: `IRMemoryQualifierSetAttr` inside an `IRAttributedType`, used for modified resource types such as descriptor-handle resource arguments.
- Descriptor heap resource array: the lowered global resource heap array that backs `DescriptorHandle<T>` on bindless targets.

## Reviewer Directives (maintained by agent)

- Keep descriptor-handle coherent regression tests in leading `//TEST(...)` directive form.
- Cover the structured-buffer descriptor-handle path, including SPIR-V pointer memory operands and HLSL `globallycoherent` emission.
- Preserve the existing single-bit consolidation where `coherent` and `globallycoherent` both map to the device-scope coherent memory qualifier.
- Fail fast instead of silently dropping a memory qualifier if an attributed base type ever legalizes to a decomposed non-simple type.
- Do not emit HLSL `globallycoherent` on read-only SRV declarations such as `StructuredBuffer<T>`.
- Keep coherent qualifiers diagnostic-only on targets without a D3D or Khronos memory model mapping.
- [LLM github-actions] Keep attributed-plus-array IR type walks centralized in `slang-ir-util.h` helpers instead of reintroducing per-backend copies. (https://github.com/shader-slang/slang/pull/11460#discussion_r3400603466)
- [LLM github-actions] Keep unsupported-target diagnostics covering both declaration-level coherent decorations and descriptor-handle type-attribute coherent qualifiers. (https://github.com/shader-slang/slang/pull/11460#discussion_r3400602191)
- [human @csyonghe] Do not broaden the current `IRAttributedType`-based globallycoherent mechanism as a general design; a future revamp should encode coherence directly in the corresponding resource type/access representation before adding wider globallycoherent features. (https://github.com/shader-slang/slang/pull/11460#pullrequestreview-4481170319)

## Process Report

The root representation remains target-independent: coherent declaration modifiers lower to `IRMemoryQualifierSetDecoration`, and coherent modified resource types lower to `IRAttributedType(..., IRMemoryQualifierSetAttr)`. That shape is valid because D3D, SPIR-V, and GLSL consume the same semantic bit differently.

For the HLSL SRV issue, `HLSLSourceEmitter::_emitType` previously printed every prefix type attribute on every attributed resource. For `DescriptorHandle<coherent StructuredBuffer<uint>>`, that produced `globallycoherent StructuredBuffer`, which HLSL does not accept. The fix walks through attributed, array, rate-qualified, and descriptor-handle wrappers to the underlying resource and prints `globallycoherent` only for read-write/write/raster-ordered resources or the HLSL writable structured/byte-address buffer ops. The input shape is correct; the HLSL emitter is the right layer to omit a modifier HLSL cannot represent.

For the SPIR-V/GLSL divergence, SPIR-V coherent detection did not mirror GLSL's attributed-array walk. `SPIRVEmitContext::hasCoherentMemoryQualifierAttr` now uses shared no-unwrap helpers from `slang-ir-util.h` to descend through `IRAttributedType` and `IRArrayTypeBase`, so `coherent T[N]` and `T[N]` with an attributed element are handled by role rather than by incidental dynamic-cast unwrapping.

For the GLSL texture crash, `resolveTextureFormat` tested `as<IRTextureTypeBase>(arrayElement)` with implicit unwrapping and then C-cast the original attributed element to `IRTextureTypeBase`. On an attributed coherent image heap this reached texture accessors on the wrapper and asserted. `getTextureTypeFromParameterType` now unwraps arrays/attributes explicitly for classification, and `replaceImageElementType` rebuilds `IRAttributedType` around the rewritten texture type so the coherent attribute remains attached.

For unsupported targets, late source legalization can erase coherent decorations before emission. The new `checkUnsupportedCoherentMemoryQualifier` pass runs after descriptor-handle resource heaps are lowered but before those source-target legalizers, and checks both declaration decorations and type attributes, including the local `DescriptorHandle<coherent RWStructuredBuffer<uint>>` case in the unsupported-target regression test. Non-D3D/non-Khronos targets have no principled coherent memory-model mapping, so they now emit `E55204` instead of silently producing non-coherent Metal/WGSL/CUDA/CPP. A default C-like emitter diagnostic remains as a fallback if an unsupported coherent type attribute reaches source emission.
