### PR TITLE
Enable default DXC source builds on macOS

### DIFF
--- a/.github/cmake-options-matrix.json
+++ b/.github/cmake-options-matrix.json
@@ -2,6 +2,11 @@
   "include": [
     {
       "option": "SLANG_DXC_BUILD_FROM_SOURCE",
+      "value": "ON",
+      "windows_only": "true"
+    },
+    {
+      "option": "SLANG_DXC_BUILD_FROM_SOURCE",
       "value": "OFF"
     },
     { "option": "SLANG_EMBED_CORE_MODULE_SOURCE" },

--- a/.github/cmake-options-matrix.json
+++ b/.github/cmake-options-matrix.json
@@ -2,11 +2,6 @@
   "include": [
     {
       "option": "SLANG_DXC_BUILD_FROM_SOURCE",
-      "value": "ON",
-      "windows_only": "true"
-    },
-    {
-      "option": "SLANG_DXC_BUILD_FROM_SOURCE",
       "value": "OFF"
     },
     { "option": "SLANG_EMBED_CORE_MODULE_SOURCE" },

--- a/.github/cmake-options-matrix.json
+++ b/.github/cmake-options-matrix.json
@@ -2,7 +2,7 @@
   "include": [
     {
       "option": "SLANG_DXC_BUILD_FROM_SOURCE",
-      "value": "ON"
+      "value": "OFF"
     },
     { "option": "SLANG_EMBED_CORE_MODULE_SOURCE" },
     { "option": "SLANG_EMBED_CORE_MODULE" },

--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -191,6 +191,13 @@ jobs:
               exit 1
             fi
 
+            cmake_ci_defines=()
+            if [[ "${{ inputs.os }}" == "macos" ]]; then
+              # Keep macOS CI from spending time on DXC source builds. DXC
+              # coverage is already exercised on other CI platforms.
+              cmake_ci_defines+=("-DSLANG_DXC_BUILD_FROM_SOURCE=OFF")
+            fi
+
             if [[ "${{ inputs.os }}" =~ "windows" && "${{ inputs.config }}" == "debug" ]]; then
               # Doing a debug build will try to link against a release built llvm, this
               # is a problem on Windows, so make slang-llvm in release build and use
@@ -204,6 +211,7 @@ jobs:
                 "-DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }}" \
                 -DSLANG_IGNORE_ABORT_MSG=ON \
                 -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=ON \
+                "${cmake_ci_defines[@]}" \
                 "${cmake_launcher_defines[@]}"
               cmake --workflow --preset "${{ inputs.config }}"
             elif [[ "${{ inputs.build-llvm }}" = "false" ]]; then
@@ -213,6 +221,7 @@ jobs:
                 -DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }} \
                 -DSLANG_IGNORE_ABORT_MSG=ON \
                 -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=ON \
+                "${cmake_ci_defines[@]}" \
                 "${cmake_launcher_defines[@]}"
               cmake --workflow --preset "${{ inputs.config }}"
             else
@@ -223,6 +232,7 @@ jobs:
                 -DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }} \
                 -DSLANG_IGNORE_ABORT_MSG=ON \
                 -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=ON \
+                "${cmake_ci_defines[@]}" \
                 "${cmake_launcher_defines[@]}"
               cmake --workflow --preset "${{ inputs.config }}"
             fi

--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -46,6 +46,9 @@ jobs:
 
     env:
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
+      # Keep macOS CI from spending time on DXC source builds. DXC coverage is
+      # already exercised on other CI platforms.
+      SLANG_CI_EXTRA_CMAKE_FLAGS: ${{ inputs.os == 'macos' && '-DSLANG_DXC_BUILD_FROM_SOURCE=OFF' || '' }}
 
     defaults:
       run:
@@ -191,13 +194,6 @@ jobs:
               exit 1
             fi
 
-            cmake_ci_defines=()
-            if [[ "${{ inputs.os }}" == "macos" ]]; then
-              # Keep macOS CI from spending time on DXC source builds. DXC
-              # coverage is already exercised on other CI platforms.
-              cmake_ci_defines+=("-DSLANG_DXC_BUILD_FROM_SOURCE=OFF")
-            fi
-
             if [[ "${{ inputs.os }}" =~ "windows" && "${{ inputs.config }}" == "debug" ]]; then
               # Doing a debug build will try to link against a release built llvm, this
               # is a problem on Windows, so make slang-llvm in release build and use
@@ -211,7 +207,7 @@ jobs:
                 "-DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }}" \
                 -DSLANG_IGNORE_ABORT_MSG=ON \
                 -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=ON \
-                "${cmake_ci_defines[@]}" \
+                $SLANG_CI_EXTRA_CMAKE_FLAGS \
                 "${cmake_launcher_defines[@]}"
               cmake --workflow --preset "${{ inputs.config }}"
             elif [[ "${{ inputs.build-llvm }}" = "false" ]]; then
@@ -221,7 +217,7 @@ jobs:
                 -DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }} \
                 -DSLANG_IGNORE_ABORT_MSG=ON \
                 -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=ON \
-                "${cmake_ci_defines[@]}" \
+                $SLANG_CI_EXTRA_CMAKE_FLAGS \
                 "${cmake_launcher_defines[@]}"
               cmake --workflow --preset "${{ inputs.config }}"
             else
@@ -232,7 +228,7 @@ jobs:
                 -DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }} \
                 -DSLANG_IGNORE_ABORT_MSG=ON \
                 -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=ON \
-                "${cmake_ci_defines[@]}" \
+                $SLANG_CI_EXTRA_CMAKE_FLAGS \
                 "${cmake_launcher_defines[@]}"
               cmake --workflow --preset "${{ inputs.config }}"
             fi

--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -46,9 +46,8 @@ jobs:
 
     env:
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
-      # Keep macOS CI from spending time on DXC source builds. DXC coverage is
-      # already exercised on other CI platforms.
-      SLANG_CI_EXTRA_CMAKE_FLAGS: ${{ inputs.os == 'macos' && '-DSLANG_DXC_BUILD_FROM_SOURCE=OFF' || '' }}
+      # Keep macOS CI from spending time on DXC source builds.
+      SLANG_CI_DXC_BUILD_FROM_SOURCE: ${{ inputs.os == 'macos' && '-DSLANG_DXC_BUILD_FROM_SOURCE=OFF' || '' }}
 
     defaults:
       run:
@@ -207,7 +206,7 @@ jobs:
                 "-DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }}" \
                 -DSLANG_IGNORE_ABORT_MSG=ON \
                 -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=ON \
-                $SLANG_CI_EXTRA_CMAKE_FLAGS \
+                $SLANG_CI_DXC_BUILD_FROM_SOURCE \
                 "${cmake_launcher_defines[@]}"
               cmake --workflow --preset "${{ inputs.config }}"
             elif [[ "${{ inputs.build-llvm }}" = "false" ]]; then
@@ -217,7 +216,7 @@ jobs:
                 -DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }} \
                 -DSLANG_IGNORE_ABORT_MSG=ON \
                 -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=ON \
-                $SLANG_CI_EXTRA_CMAKE_FLAGS \
+                $SLANG_CI_DXC_BUILD_FROM_SOURCE \
                 "${cmake_launcher_defines[@]}"
               cmake --workflow --preset "${{ inputs.config }}"
             else
@@ -228,7 +227,7 @@ jobs:
                 -DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }} \
                 -DSLANG_IGNORE_ABORT_MSG=ON \
                 -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=ON \
-                $SLANG_CI_EXTRA_CMAKE_FLAGS \
+                $SLANG_CI_DXC_BUILD_FROM_SOURCE \
                 "${cmake_launcher_defines[@]}"
               cmake --workflow --preset "${{ inputs.config }}"
             fi

--- a/.github/workflows/cmake-options-build.yml
+++ b/.github/workflows/cmake-options-build.yml
@@ -151,6 +151,13 @@ jobs:
             generators_path="-DSLANG_GENERATORS_PATH=build-platform-generators/bin"
           fi
 
+          cmake_ci_defines=()
+          if [[ "${{ inputs.os }}" == "macos" ]]; then
+            # Keep macOS option sweeps from building DXC from source. The
+            # SLANG_DXC_BUILD_FROM_SOURCE matrix entry still tests OFF.
+            cmake_ci_defines+=("-DSLANG_DXC_BUILD_FROM_SOURCE=OFF")
+          fi
+
           # SLANG_USE_SCCACHE=OFF prevents the env-var auto-activation path in
           # CMakeLists.txt from silently enabling sccache and polluting the
           # shared cache with objects built under non-default CMake options.
@@ -162,6 +169,7 @@ jobs:
               -DSLANG_USE_SCCACHE=OFF \
               -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
               $generators_path \
+              "${cmake_ci_defines[@]}" \
               "-D${option}=${value}" \
               ${{ matrix.extra_cmake_flags || '' }}
           else
@@ -170,6 +178,7 @@ jobs:
               -DSLANG_USE_SCCACHE=OFF \
               -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
               $generators_path \
+              "${cmake_ci_defines[@]}" \
               "-D${option}=${value}" \
               ${{ matrix.extra_cmake_flags || '' }}
           fi

--- a/.github/workflows/cmake-options-build.yml
+++ b/.github/workflows/cmake-options-build.yml
@@ -72,7 +72,7 @@ jobs:
     env:
       # Keep macOS option sweeps from building DXC from source. The
       # SLANG_DXC_BUILD_FROM_SOURCE matrix entry still tests OFF.
-      SLANG_CI_EXTRA_CMAKE_FLAGS: ${{ inputs.os == 'macos' && '-DSLANG_DXC_BUILD_FROM_SOURCE=OFF' || '' }}
+      SLANG_CI_DXC_BUILD_FROM_SOURCE: ${{ inputs.os == 'macos' && '-DSLANG_DXC_BUILD_FROM_SOURCE=OFF' || '' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
@@ -166,7 +166,7 @@ jobs:
               -DSLANG_USE_SCCACHE=OFF \
               -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
               $generators_path \
-              $SLANG_CI_EXTRA_CMAKE_FLAGS \
+              $SLANG_CI_DXC_BUILD_FROM_SOURCE \
               "-D${option}=${value}" \
               ${{ matrix.extra_cmake_flags || '' }}
           else
@@ -175,7 +175,7 @@ jobs:
               -DSLANG_USE_SCCACHE=OFF \
               -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
               $generators_path \
-              $SLANG_CI_EXTRA_CMAKE_FLAGS \
+              $SLANG_CI_DXC_BUILD_FROM_SOURCE \
               "-D${option}=${value}" \
               ${{ matrix.extra_cmake_flags || '' }}
           fi

--- a/.github/workflows/cmake-options-build.yml
+++ b/.github/workflows/cmake-options-build.yml
@@ -134,6 +134,7 @@ jobs:
               cmake --preset default --fresh \
                 -DSLANG_SLANG_LLVM_FLAVOR=DISABLE \
                 -DSLANG_USE_SCCACHE=OFF \
+                $SLANG_CI_DXC_BUILD_FROM_SOURCE \
                 -LA 2>/dev/null \
               | grep -E "^${option}:(BOOL|STRING)=" \
               | sed 's/.*=//' \

--- a/.github/workflows/cmake-options-build.yml
+++ b/.github/workflows/cmake-options-build.yml
@@ -69,6 +69,10 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      # Keep macOS option sweeps from building DXC from source. The
+      # SLANG_DXC_BUILD_FROM_SOURCE matrix entry still tests OFF.
+      SLANG_CI_EXTRA_CMAKE_FLAGS: ${{ inputs.os == 'macos' && '-DSLANG_DXC_BUILD_FROM_SOURCE=OFF' || '' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
@@ -151,13 +155,6 @@ jobs:
             generators_path="-DSLANG_GENERATORS_PATH=build-platform-generators/bin"
           fi
 
-          cmake_ci_defines=()
-          if [[ "${{ inputs.os }}" == "macos" ]]; then
-            # Keep macOS option sweeps from building DXC from source. The
-            # SLANG_DXC_BUILD_FROM_SOURCE matrix entry still tests OFF.
-            cmake_ci_defines+=("-DSLANG_DXC_BUILD_FROM_SOURCE=OFF")
-          fi
-
           # SLANG_USE_SCCACHE=OFF prevents the env-var auto-activation path in
           # CMakeLists.txt from silently enabling sccache and polluting the
           # shared cache with objects built under non-default CMake options.
@@ -169,7 +166,7 @@ jobs:
               -DSLANG_USE_SCCACHE=OFF \
               -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
               $generators_path \
-              "${cmake_ci_defines[@]}" \
+              $SLANG_CI_EXTRA_CMAKE_FLAGS \
               "-D${option}=${value}" \
               ${{ matrix.extra_cmake_flags || '' }}
           else
@@ -178,7 +175,7 @@ jobs:
               -DSLANG_USE_SCCACHE=OFF \
               -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
               $generators_path \
-              "${cmake_ci_defines[@]}" \
+              $SLANG_CI_EXTRA_CMAKE_FLAGS \
               "-D${option}=${value}" \
               ${{ matrix.extra_cmake_flags || '' }}
           fi

--- a/cmake/FetchDXC.cmake
+++ b/cmake/FetchDXC.cmake
@@ -17,10 +17,11 @@
 #                                 (optional; skips auto-detection when set)
 #   SLANG_DXC_BUILD_FROM_SOURCE - ON: build from source when supported; OFF:
 #                                 always use prebuilt when available (skips detection);
-#                                 unset: auto-detect on native Linux x86_64 by
-#                                 downloading the prebuilt binary and inspecting
-#                                 the GLIBC requirements of both libdxcompiler.so
-#                                 and libdxil.so
+#                                 unset: build from source on macOS; auto-detect
+#                                 on native Linux x86_64 by downloading the
+#                                 prebuilt binary and inspecting the GLIBC
+#                                 requirements of both libdxcompiler.so and
+#                                 libdxil.so
 #   SLANG_GITHUB_TOKEN          - GitHub token for authenticated downloads (optional)
 #
 # Requires the following variables to be set by the caller (set in SlangTarget.cmake):
@@ -128,6 +129,17 @@ if(SLANG_DXC_BUILD_FROM_SOURCE)
         )
         return()
     endif()
+elseif(
+    NOT DEFINED SLANG_DXC_BUILD_FROM_SOURCE
+    AND CMAKE_SYSTEM_NAME STREQUAL "Darwin"
+    AND NOT DEFINED SLANG_DXC_BINARY_URL
+)
+    message(
+        STATUS
+        "SLANG_DXC_BUILD_FROM_SOURCE is unset on macOS; building DXC from "
+        "source (${_dxc_version_tag})."
+    )
+    set(_dxc_build_from_source ON)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_CROSSCOMPILING)
     if(DEFINED SLANG_DXC_BINARY_URL)
         message(

--- a/cmake/FetchDXC.cmake
+++ b/cmake/FetchDXC.cmake
@@ -511,7 +511,11 @@ if(_dxc_build_from_source)
     # to set LLVM_RUNTIME_OUTPUT_INTDIR and LLVM_LIBRARY_OUTPUT_INTDIR, so for
     # multi-config generators the artifacts land under MinSizeRel. Track these
     # subdirectories so byproducts and copy commands point to the right path.
-    get_property(_dxc_parent_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    get_property(
+        _dxc_parent_is_multi_config
+        GLOBAL
+        PROPERTY GENERATOR_IS_MULTI_CONFIG
+    )
     if(CMAKE_GENERATOR MATCHES "Ninja")
         set(_dxc_generator_args -G Ninja)
         set(_dxc_inner_is_multi_config OFF)

--- a/cmake/FetchDXC.cmake
+++ b/cmake/FetchDXC.cmake
@@ -478,9 +478,7 @@ endif()
 
 if(_dxc_build_from_source)
     set(_dxc_forwarded_config_args "")
-    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-        set(_dxc_forwarded_config_args "")
-    elseif(
+    if(
         CMAKE_SYSTEM_NAME STREQUAL "Linux"
         OR CMAKE_SYSTEM_NAME STREQUAL "Darwin"
     )
@@ -502,7 +500,7 @@ if(_dxc_build_from_source)
                 CMAKE_OSX_SYSROOT
                 CMAKE_OSX_DEPLOYMENT_TARGET
             )
-                if(DEFINED ${_dxc_osx_var})
+                if(DEFINED ${_dxc_osx_var} AND NOT "${${_dxc_osx_var}}" STREQUAL "")
                     set(_dxc_osx_value "${${_dxc_osx_var}}")
                     string(REPLACE ";" "\\;" _dxc_osx_value "${_dxc_osx_value}")
                     list(
@@ -524,10 +522,10 @@ if(_dxc_build_from_source)
     # to set LLVM_RUNTIME_OUTPUT_INTDIR and LLVM_LIBRARY_OUTPUT_INTDIR, so for
     # multi-config generators the artifacts land under MinSizeRel. Track these
     # subdirectories so byproducts and copy commands point to the right path.
+    get_property(_dxc_parent_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
     if(CMAKE_GENERATOR MATCHES "Ninja")
         set(_dxc_generator_args -G Ninja)
-        set(_dxc_dll_subdir "bin")
-        set(_dxc_lib_subdir "lib")
+        set(_dxc_inner_is_multi_config OFF)
     else()
         set(_dxc_generator_args -G "${CMAKE_GENERATOR}")
         if(CMAKE_GENERATOR_PLATFORM)
@@ -536,8 +534,15 @@ if(_dxc_build_from_source)
         if(CMAKE_GENERATOR_TOOLSET)
             list(APPEND _dxc_generator_args -T "${CMAKE_GENERATOR_TOOLSET}")
         endif()
+        set(_dxc_inner_is_multi_config "${_dxc_parent_is_multi_config}")
+    endif()
+
+    if(_dxc_inner_is_multi_config)
         set(_dxc_dll_subdir "MinSizeRel/bin")
         set(_dxc_lib_subdir "MinSizeRel/lib")
+    else()
+        set(_dxc_dll_subdir "bin")
+        set(_dxc_lib_subdir "lib")
     endif()
 
     # Step 1: Clone DXC source at Slang configure time.

--- a/cmake/FetchDXC.cmake
+++ b/cmake/FetchDXC.cmake
@@ -58,6 +58,11 @@ set(_dxc_linux_sha256
 set(_dxc_windows_url_hash "SHA256=${_dxc_windows_sha256}")
 set(_dxc_linux_url_hash "SHA256=${_dxc_linux_sha256}")
 
+set(_dxc_has_custom_binary_url OFF)
+if(DEFINED SLANG_DXC_BINARY_URL AND NOT SLANG_DXC_BINARY_URL STREQUAL "")
+    set(_dxc_has_custom_binary_url ON)
+endif()
+
 function(_dxc_stage_hlsl_headers dxc_root dxc_origin)
     set(_dxc_header_deps "${ARGN}")
 
@@ -132,7 +137,7 @@ if(SLANG_DXC_BUILD_FROM_SOURCE)
 elseif(
     NOT DEFINED SLANG_DXC_BUILD_FROM_SOURCE
     AND CMAKE_SYSTEM_NAME STREQUAL "Darwin"
-    AND NOT DEFINED SLANG_DXC_BINARY_URL
+    AND NOT _dxc_has_custom_binary_url
 )
     message(
         STATUS
@@ -141,7 +146,7 @@ elseif(
     )
     set(_dxc_build_from_source ON)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_CROSSCOMPILING)
-    if(DEFINED SLANG_DXC_BINARY_URL)
+    if(_dxc_has_custom_binary_url)
         message(
             STATUS
             "Cross-compiling for Linux: GLIBC auto-detection is skipped; "
@@ -174,7 +179,7 @@ elseif(
     AND NOT SLANG_DXC_BUILD_FROM_SOURCE
     AND CMAKE_SYSTEM_NAME STREQUAL "Linux"
     AND NOT CMAKE_CROSSCOMPILING
-    AND NOT DEFINED SLANG_DXC_BINARY_URL
+    AND NOT _dxc_has_custom_binary_url
     AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64"
 )
     # User explicitly disabled the source build on x86_64 Linux; skip
@@ -190,7 +195,7 @@ elseif(
 elseif(
     CMAKE_SYSTEM_NAME STREQUAL "Linux"
     AND NOT CMAKE_CROSSCOMPILING
-    AND DEFINED SLANG_DXC_BINARY_URL
+    AND _dxc_has_custom_binary_url
 )
     # User supplied a custom URL; skip GLIBC auto-detection and use it as-is.
     message(
@@ -202,7 +207,7 @@ elseif(
     NOT DEFINED SLANG_DXC_BUILD_FROM_SOURCE
     AND CMAKE_SYSTEM_NAME STREQUAL "Linux"
     AND NOT CMAKE_CROSSCOMPILING
-    AND NOT DEFINED SLANG_DXC_BINARY_URL
+    AND NOT _dxc_has_custom_binary_url
     AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64"
 )
     # Auto-detect: download the prebuilt Linux binary and inspect both
@@ -444,7 +449,7 @@ elseif(
 elseif(
     CMAKE_SYSTEM_NAME STREQUAL "Linux"
     AND NOT CMAKE_CROSSCOMPILING
-    AND NOT DEFINED SLANG_DXC_BINARY_URL
+    AND NOT _dxc_has_custom_binary_url
     AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64"
 )
     # Non-x86_64 Linux: no prebuilt binary is available for this architecture.
@@ -759,7 +764,7 @@ endif()
 # Prebuilt binary download path.
 # ---------------------------------------------------------------------------
 
-if(NOT DEFINED SLANG_DXC_BINARY_URL)
+if(NOT _dxc_has_custom_binary_url)
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         set(SLANG_DXC_BINARY_URL
             "https://github.com/microsoft/DirectXShaderCompiler/releases/download/${_dxc_version_tag}/dxc_${_dxc_release_date}.zip"
@@ -781,7 +786,7 @@ if(NOT DEFINED SLANG_DXC_BINARY_URL)
     endif()
 endif()
 
-if(NOT DEFINED SLANG_DXC_BINARY_URL)
+if(NOT DEFINED SLANG_DXC_BINARY_URL OR SLANG_DXC_BINARY_URL STREQUAL "")
     return()
 endif()
 

--- a/cmake/FetchDXC.cmake
+++ b/cmake/FetchDXC.cmake
@@ -478,39 +478,23 @@ endif()
 
 if(_dxc_build_from_source)
     set(_dxc_forwarded_config_args "")
-    if(
-        CMAKE_SYSTEM_NAME STREQUAL "Linux"
-        OR CMAKE_SYSTEM_NAME STREQUAL "Darwin"
-    )
-        # LLVM_ENABLE_WARNINGS=OFF prevents adding warning flags but does not
-        # actively suppress existing ones. Pass -w via CMAKE_*_FLAGS to silence
-        # all compiler warnings from DXC's source.
-        set(_dxc_c_flags "${CMAKE_C_FLAGS}")
-        set(_dxc_cxx_flags "${CMAKE_CXX_FLAGS}")
-        string(APPEND _dxc_c_flags " -w")
-        string(APPEND _dxc_cxx_flags " -w")
-        set(_dxc_forwarded_config_args
-            "-DCMAKE_C_FLAGS=${_dxc_c_flags}"
-            "-DCMAKE_CXX_FLAGS=${_dxc_cxx_flags}"
+    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        foreach(
+            _dxc_osx_var
+            CMAKE_OSX_ARCHITECTURES
+            CMAKE_OSX_SYSROOT
+            CMAKE_OSX_DEPLOYMENT_TARGET
         )
-        if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-            foreach(
-                _dxc_osx_var
-                CMAKE_OSX_ARCHITECTURES
-                CMAKE_OSX_SYSROOT
-                CMAKE_OSX_DEPLOYMENT_TARGET
-            )
-                if(DEFINED ${_dxc_osx_var} AND NOT "${${_dxc_osx_var}}" STREQUAL "")
-                    set(_dxc_osx_value "${${_dxc_osx_var}}")
-                    string(REPLACE ";" "\\;" _dxc_osx_value "${_dxc_osx_value}")
-                    list(
-                        APPEND
-                        _dxc_forwarded_config_args
-                        "-D${_dxc_osx_var}=${_dxc_osx_value}"
-                    )
-                endif()
-            endforeach()
-        endif()
+            if(DEFINED ${_dxc_osx_var} AND NOT "${${_dxc_osx_var}}" STREQUAL "")
+                set(_dxc_osx_value "${${_dxc_osx_var}}")
+                string(REPLACE ";" "\\;" _dxc_osx_value "${_dxc_osx_value}")
+                list(
+                    APPEND
+                    _dxc_forwarded_config_args
+                    "-D${_dxc_osx_var}=${_dxc_osx_value}"
+                )
+            endif()
+        endforeach()
     endif()
 
     # DXC's build (PredefinedParams.cmake) is designed for a single-config

--- a/docs/building.md
+++ b/docs/building.md
@@ -245,7 +245,7 @@ works for any given binary.
 | ------------------------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `SLANG_VERSION`                       | Latest `v*` tag               | The project version, detected using git if available                                                                                     |
 | `SLANG_DXC_BINARY_URL`                | Stable DXC release URL        | URL of the prebuilt DXC binary archive to download; overrides the default release URL and skips GLIBC auto-detection on Linux            |
-| `SLANG_DXC_BUILD_FROM_SOURCE`         | Unset (auto on native Linux x86_64; otherwise prebuilt when available) | `ON`: build DXC from source on Windows, Linux, and macOS; `OFF`: use prebuilt when available; unset: auto-select on native Linux x86_64, otherwise use prebuilt when available (see [DXC GLIBC auto-detection](#dxc-glibc-auto-detection)) |
+| `SLANG_DXC_BUILD_FROM_SOURCE`         | Unset                         | `ON`: build DXC from source on Windows, Linux, and macOS; `OFF`: use prebuilt when available; unset: build from source on macOS and auto-select on native Linux x86_64 (see [DXC GLIBC auto-detection](#dxc-glibc-auto-detection)) |
 | `SLANG_EMBED_CORE_MODULE`             | `TRUE`                        | Build slang with an embedded version of the core module                                                                                  |
 | `SLANG_EMBED_CORE_MODULE_SOURCE`      | `TRUE`                        | Embed the core module source in the binary                                                                                               |
 | `SLANG_ENABLE_DXIL`                   | `TRUE`                        | Enable generating DXIL using DXC                                                                                                         |
@@ -285,9 +285,9 @@ provides, or if the requirement or system GLIBC version cannot be detected, DXC
 is built from source instead. Successful detection results are cached in stamp
 files so subsequent reconfigures are fast. For example, if a DXC Linux prebuilt
 requires GLIBC 2.38 and the host provides an older GLIBC, CMake selects the
-source-build path. On macOS, Microsoft does not publish a prebuilt DXC package;
-set `-DSLANG_DXC_BUILD_FROM_SOURCE=ON` to build DXC locally. The default macOS
-configuration leaves DXC unavailable to avoid the large clone and build cost.
+source-build path. On macOS, Microsoft does not publish a prebuilt DXC package,
+so the default configuration builds DXC from source unless
+`SLANG_DXC_BINARY_URL` is set to a custom archive.
 
 ```mermaid
 flowchart TD
@@ -296,7 +296,9 @@ flowchart TD
     BuildFromSource -->|OFF| Prebuilt["Use a prebuilt binary when available"]
     BuildFromSource -->|unset| CustomUrl{"SLANG_DXC_BINARY_URL set?"}
     CustomUrl -->|yes| CustomPrebuilt["Use custom prebuilt URL and skip GLIBC detection"]
-    CustomUrl -->|no| NativeLinux{"Native Linux x86_64?"}
+    CustomUrl -->|no| MacOS{"macOS?"}
+    MacOS -->|yes| Source
+    MacOS -->|no| NativeLinux{"Native Linux x86_64?"}
     NativeLinux -->|yes| Probe["Download Linux prebuilt and inspect GLIBC requirements"]
     Probe --> Compatible{"Detected requirements are compatible with host GLIBC?"}
     Compatible -->|yes| LinuxPrebuilt["Use Linux prebuilt binary"]
@@ -311,7 +313,7 @@ flowchart TD
   non-x86_64 Linux and macOS, DXC is unavailable unless `SLANG_DXC_BINARY_URL`
   is set to a custom prebuilt for that architecture/platform.
 - unset on native non-x86_64 Linux (e.g. ARM64): DXC is unavailable because no official prebuilt binary exists; set `ON` to build DXC from source.
-- unset on macOS: DXC is unavailable because no official prebuilt binary exists; set `ON` to build DXC from source.
+- unset on macOS: build DXC from source unless `SLANG_DXC_BINARY_URL` is set to a custom prebuilt.
 - unset while cross-compiling for Linux x86_64: skip GLIBC detection because the target system cannot be probed at configure time.
 
 The source-build path clones DXC plus LLVM/Clang submodules on the first run


### PR DESCRIPTION
Fixes #11438

## Summary of the problem from the end user perspective

macOS Slang developers still had to opt in manually to a source-built DXC even though there is no official macOS prebuilt. That left local DXIL coverage unavailable by default.

## Root cause

`FetchDXC.cmake` only selected source-built DXC automatically for native Linux x86_64 GLIBC fallback. The macOS source-build path existed only behind an explicit `SLANG_DXC_BUILD_FROM_SOURCE=ON`.

## Solution in this PR

Select the DXC source-build path by default on macOS when `SLANG_DXC_BUILD_FROM_SOURCE` is unset and no custom `SLANG_DXC_BINARY_URL` is provided. Keep explicit `OFF` and custom prebuilt URLs working, and stage macOS `.dylib` outputs through the existing DXC copy targets.

### Notes to the reviewers; where to focus on

The main logic is in `cmake/FetchDXC.cmake`: the new Darwin default branch is before Linux GLIBC detection, and the source/prebuilt staging code now uses CMake's shared-library prefix and suffix so macOS `.dylib` artifacts work like Linux `.so` artifacts.

## Related PRs in the past

- #11434 enabled opt-in source-built DXC on macOS.

## Reviewer Directives (maintained by agent)

- [human @jkwak-work] Do not forward parent `CMAKE_C_FLAGS` or `CMAKE_CXX_FLAGS` into the nested DXC CMake configure; Slang build flags may not make sense for DXC. (https://github.com/jkwak-work/slang/pull/238#discussion_r3348994725)
- [human @jkwak-work] Keep the local macOS default as DXC source build enabled, but force `SLANG_DXC_BUILD_FROM_SOURCE=OFF` for macOS CI and cover the explicit OFF path in the CMake-options matrix. (https://github.com/jkwak-work/slang/pull/238#pullrequestreview-4420023318)
- [human @jkwak-work] Use a YAML-defined CI CMake flag variable for the macOS DXC source-build opt-out instead of constructing that flag in shell. (https://github.com/jkwak-work/slang/pull/238#discussion_r3350887440)
- [human @jkwak-work] In the CMake-options matrix, check only explicit `SLANG_DXC_BUILD_FROM_SOURCE=OFF`; do not keep an `ON` entry. (https://github.com/shader-slang/slang/pull/11461#discussion_r3353278943)
- [human @jkwak-work] Use the specific YAML variable name `SLANG_CI_DXC_BUILD_FROM_SOURCE` for the macOS DXC source-build opt-out flag. (https://github.com/shader-slang/slang/pull/11461#discussion_r3353284917)
