### PR TITLE
Avoid mesh line mode for isoline tessellation

### DIFF
--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -4898,6 +4898,13 @@ err(
 )
 
 err(
+    "invalid-stage-output-topology",
+    50061,
+    "invalid output topology",
+    span { loc = "location", message = "Invalid output topology '~topology' for stage '~stage', must be one of: ~validTopologies" }
+)
+
+err(
     "no-type-conformances-found-for-interface",
     50100,
     "no type conformances found",

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -6343,11 +6343,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     }
                 }
 
-                if (shouldEmitExecutionMode)
-                {
-                    SLANG_ASSERT(m != SpvExecutionModeMax);
+                if (shouldEmitExecutionMode && m != SpvExecutionModeMax)
                     requireSPIRVExecutionMode(decoration, dstID, m);
-                }
             }
             break;
 

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -6312,6 +6312,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 const auto topologyType = OutputTopologyType(o->getTopologyType());
 
                 SpvExecutionMode m = SpvExecutionModeMax;
+                bool shouldEmitExecutionMode = true;
                 if (entryPointDecor)
                 {
                     switch (entryPointDecor->getProfile().getStage())
@@ -6326,6 +6327,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                             m = SpvExecutionModePointMode;
                         // OutputTopologyType::Line is represented by the Isolines execution mode
                         // emitted for the domain decoration.
+                        else if (topologyType == OutputTopologyType::Line)
+                            shouldEmitExecutionMode = false;
                         break;
                     case Stage::Mesh:
                         if (topologyType == OutputTopologyType::Triangle)
@@ -6340,8 +6343,11 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     }
                 }
 
-                if (m != SpvExecutionModeMax)
+                if (shouldEmitExecutionMode)
+                {
+                    SLANG_ASSERT(m != SpvExecutionModeMax);
                     requireSPIRVExecutionMode(decoration, dstID, m);
+                }
             }
             break;
 

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -6324,21 +6324,24 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                             m = SpvExecutionModeVertexOrderCcw;
                         else if (topologyType == OutputTopologyType::Point)
                             m = SpvExecutionModePointMode;
+                        // OutputTopologyType::Line is represented by the Isolines execution mode
+                        // emitted for the domain decoration.
+                        break;
+                    case Stage::Mesh:
+                        if (topologyType == OutputTopologyType::Triangle)
+                            m = SpvExecutionModeOutputTrianglesEXT;
+                        else if (topologyType == OutputTopologyType::Line)
+                            m = SpvExecutionModeOutputLinesEXT;
+                        else if (topologyType == OutputTopologyType::Point)
+                            m = SpvExecutionModeOutputPoints;
+                        break;
+                    default:
                         break;
                     }
                 }
-                if (m == SpvExecutionModeMax)
-                {
-                    if (topologyType == OutputTopologyType::Triangle)
-                        m = SpvExecutionModeOutputTrianglesEXT;
-                    else if (topologyType == OutputTopologyType::Line)
-                        m = SpvExecutionModeOutputLinesEXT;
-                    else if (topologyType == OutputTopologyType::Point)
-                        m = SpvExecutionModeOutputPoints;
-                }
 
-                SLANG_ASSERT(m != SpvExecutionModeMax);
-                requireSPIRVExecutionMode(decoration, dstID, m);
+                if (m != SpvExecutionModeMax)
+                    requireSPIRVExecutionMode(decoration, dstID, m);
             }
             break;
 

--- a/source/slang/slang-ir-entry-point-decorations.cpp
+++ b/source/slang/slang-ir-entry-point-decorations.cpp
@@ -8,6 +8,7 @@
 #include "slang-ir-insts.h"
 #include "slang-ir.h"
 #include "slang-options.h"
+#include "slang-profile.h"
 #include "slang-rich-diagnostics.h"
 
 namespace Slang
@@ -50,9 +51,24 @@ private:
 
     void checkOutputTopologyDecoration(IROutputTopologyDecoration* decoration, Stage stage)
     {
+        const auto outputTopologyType = OutputTopologyType(decoration->getTopologyType());
+        if (stage == Stage::Domain || stage == Stage::Hull)
+        {
+            if (outputTopologyType != OutputTopologyType::Point &&
+                outputTopologyType != OutputTopologyType::Line &&
+                outputTopologyType != OutputTopologyType::TriangleCW &&
+                outputTopologyType != OutputTopologyType::TriangleCCW)
+            {
+                diagnoseInvalidStageOutputTopology(
+                    decoration,
+                    stage,
+                    "'point', 'line', 'triangle_cw', 'triangle_ccw'");
+            }
+            return;
+        }
+
         if (stage == Stage::Mesh)
         {
-            const auto outputTopologyType = OutputTopologyType(decoration->getTopologyType());
             if (isTargetGLSL() || isTargetSPIRV() || isTargetMetal())
             {
                 if (outputTopologyType != OutputTopologyType::Point &&
@@ -77,6 +93,19 @@ private:
                 SLANG_UNEXPECTED("Invalid compilation target for mesh stage");
             }
         }
+    }
+
+    void diagnoseInvalidStageOutputTopology(
+        IROutputTopologyDecoration* decoration,
+        Stage stage,
+        String validTopologies)
+    {
+        auto stageName = getStageName(stage);
+        m_sink->diagnose(Diagnostics::InvalidStageOutputTopology{
+            .topology = String(decoration->getTopology()->getStringSlice()),
+            .stage = String(stageName ? stageName : "unknown"),
+            .validTopologies = validTopologies,
+            .location = decoration->sourceLoc});
     }
 
     void diagnoseInvalidMeshStageOutputTopology(

--- a/tests/diagnostics/tessellation-invalid-output-topology.slang
+++ b/tests/diagnostics/tessellation-invalid-output-topology.slang
@@ -1,4 +1,11 @@
-//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -entry hullMain_triangle -stage hull -target spirv
+//DIAGNOSTIC_TEST:SIMPLE(diag=HULL): -entry hullMain_triangle -stage hull -target hlsl
+//DIAGNOSTIC_TEST:SIMPLE(diag=HULL): -entry hullMain_triangle -stage hull -target spirv
+//DIAGNOSTIC_TEST:SIMPLE(diag=HULL): -entry hullMain_triangle -stage hull -target glsl
+//DIAGNOSTIC_TEST:SIMPLE(diag=HULL): -entry hullMain_triangle -stage hull -target metal
+//DIAGNOSTIC_TEST:SIMPLE(diag=DOMAIN): -entry domainMain_triangle -stage domain -target hlsl
+//DIAGNOSTIC_TEST:SIMPLE(diag=DOMAIN): -entry domainMain_triangle -stage domain -target spirv
+//DIAGNOSTIC_TEST:SIMPLE(diag=DOMAIN): -entry domainMain_triangle -stage domain -target glsl
+//DIAGNOSTIC_TEST:SIMPLE(diag=DOMAIN): -entry domainMain_triangle -stage domain -target metal
 
 struct Out
 {
@@ -24,7 +31,7 @@ PatchConst patchConst()
 [domain("tri")]
 [partitioning("integer")]
 [outputtopology("triangle")]
-/*CHECK:
+/*HULL:
  ^^^^^^^^^^^^^^ invalid output topology
  ^^^^^^^^^^^^^^ Invalid output topology 'triangle' for stage 'hull', must be one of: 'point', 'line', 'triangle_cw', 'triangle_ccw'
 */
@@ -35,4 +42,20 @@ Out hullMain_triangle()
     Out o;
     o.x = 0;
     return o;
+}
+
+[shader("domain")]
+[domain("tri")]
+[outputtopology("triangle")]
+/*DOMAIN:
+ ^^^^^^^^^^^^^^ invalid output topology
+ ^^^^^^^^^^^^^^ Invalid output topology 'triangle' for stage 'domain', must be one of: 'point', 'line', 'triangle_cw', 'triangle_ccw'
+*/
+float4 domainMain_triangle(
+    PatchConst patchConstants,
+    OutputPatch<Out, 3> patch,
+    float3 bary : SV_DomainLocation)
+    : SV_Position
+{
+    return float4(bary.x, bary.y, bary.z, patchConstants.InsideTessFactor);
 }

--- a/tests/diagnostics/tessellation-invalid-output-topology.slang
+++ b/tests/diagnostics/tessellation-invalid-output-topology.slang
@@ -1,0 +1,38 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -entry hullMain_triangle -stage hull -target spirv
+
+struct Out
+{
+    float x;
+};
+
+struct PatchConst
+{
+    float EdgeTessFactor[3] : SV_TessFactor;
+    float InsideTessFactor : SV_InsideTessFactor;
+};
+
+PatchConst patchConst()
+{
+    PatchConst o;
+    o.EdgeTessFactor[0] = 1;
+    o.EdgeTessFactor[1] = 1;
+    o.EdgeTessFactor[2] = 1;
+    o.InsideTessFactor = 1;
+    return o;
+}
+
+[domain("tri")]
+[partitioning("integer")]
+[outputtopology("triangle")]
+/*CHECK:
+ ^^^^^^^^^^^^^^ invalid output topology
+ ^^^^^^^^^^^^^^ Invalid output topology 'triangle' for stage 'hull', must be one of: 'point', 'line', 'triangle_cw', 'triangle_ccw'
+*/
+[outputcontrolpoints(3)]
+[patchconstantfunc("patchConst")]
+Out hullMain_triangle()
+{
+    Out o;
+    o.x = 0;
+    return o;
+}

--- a/tests/spirv/domain-shader-outputtopology.slang
+++ b/tests/spirv/domain-shader-outputtopology.slang
@@ -1,0 +1,29 @@
+//TEST:SIMPLE(filecheck=SPIRV_DOMAIN_TRICW):-target spirv -stage domain -entry domainMain_triangle_cw
+
+// SPIRV_DOMAIN_TRICW-DAG: OpExecutionMode %domainMain_triangle_cw Triangles
+// SPIRV_DOMAIN_TRICW-DAG: OpExecutionMode %domainMain_triangle_cw VertexOrderCw
+
+struct ControlPoint
+{
+    float3 position : POSITION;
+};
+
+struct PatchConst
+{
+    float EdgeTessFactor[3] : SV_TessFactor;
+    float InsideTessFactor : SV_InsideTessFactor;
+};
+
+[shader("domain")]
+[domain("tri")]
+[outputtopology("triangle_cw")]
+float4 domainMain_triangle_cw(
+    PatchConst patchConstants,
+    OutputPatch<ControlPoint, 3> patch,
+    float3 bary : SV_DomainLocation)
+    : SV_Position
+{
+    float3 p =
+        patch[0].position * bary.x + patch[1].position * bary.y + patch[2].position * bary.z;
+    return float4(p, patchConstants.InsideTessFactor);
+}

--- a/tests/spirv/domain-shader-outputtopology.slang
+++ b/tests/spirv/domain-shader-outputtopology.slang
@@ -1,7 +1,12 @@
 //TEST:SIMPLE(filecheck=SPIRV_DOMAIN_TRICW):-target spirv -stage domain -entry domainMain_triangle_cw
+//TEST:SIMPLE(filecheck=SPIRV_DOMAIN_ISOLINE):-target spirv -stage domain -entry domainMain_isoline_line
 
 // SPIRV_DOMAIN_TRICW-DAG: OpExecutionMode %domainMain_triangle_cw Triangles
 // SPIRV_DOMAIN_TRICW-DAG: OpExecutionMode %domainMain_triangle_cw VertexOrderCw
+
+// SPIRV_DOMAIN_ISOLINE-NOT: OutputLinesEXT
+// SPIRV_DOMAIN_ISOLINE: OpExecutionMode %domainMain_isoline_line Isolines
+// SPIRV_DOMAIN_ISOLINE-NOT: OutputLinesEXT
 
 struct ControlPoint
 {
@@ -26,4 +31,22 @@ float4 domainMain_triangle_cw(
     float3 p =
         patch[0].position * bary.x + patch[1].position * bary.y + patch[2].position * bary.z;
     return float4(p, patchConstants.InsideTessFactor);
+}
+
+struct LinePatchConst
+{
+    float EdgeTessFactor[2] : SV_TessFactor;
+};
+
+[shader("domain")]
+[domain("isoline")]
+[outputtopology("line")]
+float4 domainMain_isoline_line(
+    LinePatchConst patchConstants,
+    OutputPatch<ControlPoint, 2> patch,
+    float2 uv : SV_DomainLocation)
+    : SV_Position
+{
+    float3 p = patch[0].position * (1.0 - uv.x) + patch[1].position * uv.x;
+    return float4(p, patchConstants.EdgeTessFactor[0]);
 }

--- a/tests/spirv/hull-shader-outputtopology.slang
+++ b/tests/spirv/hull-shader-outputtopology.slang
@@ -1,10 +1,14 @@
 //TEST:SIMPLE(filecheck=SPIRV_POINT):-target spirv -stage hull -entry hullMain_point
 //TEST:SIMPLE(filecheck=SPIRV_TRICW):-target spirv -stage hull -entry hullMain_triangle_cw
 //TEST:SIMPLE(filecheck=SPIRV_TRICCW):-target spirv -stage hull -entry hullMain_triangle_ccw
+//TEST:SIMPLE(filecheck=SPIRV_LINE):-target spirv -stage hull -entry hullMain_line
 
 // SPIRV_POINT: OpExecutionMode %hullMain_point PointMode
 // SPIRV_TRICW: OpExecutionMode %hullMain_triangle_cw VertexOrderCw
 // SPIRV_TRICCW: OpExecutionMode %hullMain_triangle_ccw VertexOrderCcw
+// SPIRV_LINE-NOT: OutputLinesEXT
+// SPIRV_LINE: OpExecutionMode %hullMain_line Isolines
+// SPIRV_LINE-NOT: OutputLinesEXT
 
 struct Out {
     float x;
@@ -13,6 +17,10 @@ struct Out {
 struct PatchConst {
     float EdgeTessFactor[4] : SV_TessFactor;
     float InsideTessFactor[2] : SV_InsideTessFactor;
+};
+
+struct LinePatchConst {
+    float EdgeTessFactor[2] : SV_TessFactor;
 };
 
 PatchConst patchConst() {
@@ -26,12 +34,30 @@ PatchConst patchConst() {
     return o;
 }
 
+LinePatchConst patchConstLine() {
+    LinePatchConst o;
+    o.EdgeTessFactor[0] = 1;
+    o.EdgeTessFactor[1] = 1;
+    return o;
+}
+
 [domain("quad")]
 [partitioning("integer")]
 [outputtopology("point")]
 [outputcontrolpoints(4)]
 [patchconstantfunc("patchConst")]
 Out hullMain_point() {
+    Out o;
+    o.x = 0;
+    return o;
+}
+
+[domain("isoline")]
+[partitioning("integer")]
+[outputtopology("line")]
+[outputcontrolpoints(2)]
+[patchconstantfunc("patchConstLine")]
+Out hullMain_line() {
     Out o;
     o.x = 0;
     return o;

--- a/tests/spirv/mesh-shader-invert-y.slang
+++ b/tests/spirv/mesh-shader-invert-y.slang
@@ -1,7 +1,11 @@
 //TEST:SIMPLE(filecheck=CHECK): -target spirv -fvk-invert-y
+//TEST:SIMPLE(filecheck=POINT): -target spirv -stage mesh -entry pointMain
 
+// CHECK-DAG: OpExecutionMode %main OutputLinesEXT
 // CHECK: %[[CONST:[0-9]+]] = OpConstantComposite %v4float %float_0 %float_n1 %float_0 %float_0
 // CHECK: OpStore {{.*}} %[[CONST]]
+
+// POINT-DAG: OpExecutionMode %pointMain OutputPoints
 
 struct PS_IN
 {
@@ -21,4 +25,17 @@ void main(
 	SetMeshOutputCounts( 128, 64 );
 
     outputVerts[ 2 * nGroupThreadId ].vPositionPs = float4( 0, 1, 0, 0 );
+}
+
+[ shader("mesh") ]
+[ outputtopology( "point" ) ]
+[ numthreads( 1, 1, 1 ) ]
+void pointMain(
+	out vertices PS_IN outputVerts[ 1 ],
+	out indices uint outputIB[ 1 ] )
+{
+	SetMeshOutputCounts( 1, 1 );
+
+    outputVerts[ 0 ].vPositionPs = float4( 0, 1, 0, 0 );
+    outputIB[ 0 ] = 0;
 }

--- a/tests/spirv/mesh-shader-invert-y.slang
+++ b/tests/spirv/mesh-shader-invert-y.slang
@@ -31,10 +31,10 @@ void main(
 [ outputtopology( "point" ) ]
 [ numthreads( 1, 1, 1 ) ]
 void pointMain(
-	out vertices PS_IN outputVerts[ 1 ],
-	out indices uint outputIB[ 1 ] )
+    out vertices PS_IN outputVerts[ 1 ],
+    out indices uint outputIB[ 1 ] )
 {
-	SetMeshOutputCounts( 1, 1 );
+    SetMeshOutputCounts( 1, 1 );
 
     outputVerts[ 0 ].vPositionPs = float4( 0, 1, 0, 0 );
     outputIB[ 0 ] = 0;


### PR DESCRIPTION
Fixes #11370

## Summary of the problem from the end user perspective

Isoline hull shaders compiled to SPIR-V emitted both the valid `Isolines` execution mode and the mesh-shader-only `OutputLinesEXT` execution mode. The extra mode made `spirv-val` reject the tessellation-control shader.

### Minimal repro shader; if applicable

```hlsl
[domain("isoline")]
[partitioning("integer")]
[outputtopology("line")]
[outputcontrolpoints(2)]
[patchconstantfunc("patchConstLine")]
Out hullMain_line()
{
    return Out(0);
}
```

## Root cause

The SPIR-V `kIROp_OutputTopologyDecoration` handler recognized hull/domain point and triangle topology cases, but `line` fell through to the mesh topology mapping and emitted `OutputLinesEXT`.

## Solution in this PR

Restrict mesh `Output*EXT` execution modes to mesh-stage entry points. For tessellation line topology, emit no extra output-topology execution mode and rely on the existing domain decoration emission of `Isolines`; if no SPIR-V execution mode is selected for a stage/topology pair, the emitter now skips the sentinel value instead of passing it through.

The PR also validates hull/domain `outputtopology` values before SPIR-V emission so invalid bare `triangle` topology is diagnosed instead of reaching an emitter assert. The diagnostic coverage exercises both hull and domain stages across HLSL, SPIR-V, GLSL, and Metal targets, and SPIR-V coverage now includes valid domain entries for both `outputtopology("triangle_cw")` and isoline `outputtopology("line")`.

### Notes to the reviewers; where to focus on

Review the stage switch in `source/slang/slang-emit-spirv.cpp`, the hull/domain topology validation in `source/slang/slang-ir-entry-point-decorations.cpp`, and the new `SPIRV_LINE`, domain-output-topology, mesh-topology, and invalid-topology checks in `tests/`.

## Related PRs in the past

PR #7662 added the comparable tessellation `PointMode` handling in this same emitter block.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed output topology validation and error reporting for Domain and Hull shader stages
  * Corrected SPIR-V execution mode emission when using mesh shaders with point, line, and triangle output topologies
  * Improved compiler diagnostics to clearly identify invalid output topology and stage combinations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->