### PR TITLE
Fix VM printf string literal operands

### DIFF
--- a/source/slang/slang-vm-inst-impl.cpp
+++ b/source/slang/slang-vm-inst-impl.cpp
@@ -1037,11 +1037,9 @@ void printHandler(IByteCodeRunner* inCtx, VMExecInstHeader* inst, void* userData
     for (uint32_t i = 1; i < inst->operandCount; ++i)
     {
         auto& arg = inst->getOperand(i);
-        auto argSize =
-            arg.section == (uint8_t**)&ctx->m_stringLitsPtr ? sizeof(const char*) : arg.size;
         List<uint8_t> data;
-        data.setCount(argSize);
-        memcpy(data.getBuffer(), arg.getPtr(), argSize);
+        data.setCount(arg.size);
+        memcpy(data.getBuffer(), arg.getPtr(), arg.size);
         args.add(data);
     }
     for (auto& arg : args)

--- a/source/slang/slang-vm-inst-impl.cpp
+++ b/source/slang/slang-vm-inst-impl.cpp
@@ -1037,9 +1037,11 @@ void printHandler(IByteCodeRunner* inCtx, VMExecInstHeader* inst, void* userData
     for (uint32_t i = 1; i < inst->operandCount; ++i)
     {
         auto& arg = inst->getOperand(i);
+        auto argSize =
+            arg.section == (uint8_t**)&ctx->m_stringLitsPtr ? sizeof(const char*) : arg.size;
         List<uint8_t> data;
-        data.setCount(arg.size);
-        memcpy(data.getBuffer(), arg.getPtr(), arg.size);
+        data.setCount(argSize);
+        memcpy(data.getBuffer(), arg.getPtr(), argSize);
         args.add(data);
     }
     for (auto& arg : args)

--- a/source/slang/slang-vm.cpp
+++ b/source/slang/slang-vm.cpp
@@ -418,8 +418,9 @@ SlangResult ByteCodeInterpreter::prepareModuleForExecution()
                     execOpernad.section = (uint8_t**)&m_currentWorkingSet;
                     break;
                 case kSlangByteCodeSectionStrings:
-                    execOpernad.section = (uint8_t**)&m_stringLitsPtr;
+                    execOpernad.section = reinterpret_cast<uint8_t**>(&m_stringLitsPtr);
                     execOpernad.offset *= sizeof(const char*);
+                    execOpernad.size = sizeof(const char*);
                     break;
                 case kSlangByteCodeSectionImmediate:
                 case kSlangByteCodeSectionFuncs:

--- a/tests/byte-code/printf-string-literal.slang
+++ b/tests/byte-code/printf-string-literal.slang
@@ -1,0 +1,23 @@
+//TEST:INTERPRET(filecheck=BC): -disasm
+//TEST:INTERPRET(filecheck=CHECK):
+
+int main()
+{
+    String stringValue = "string";
+    NativeString nativeStringValue = "native";
+    bool condition = true;
+
+    // CHECK: literal
+    printf("%s\n", "literal");
+    // CHECK: string
+    printf("%s\n", stringValue);
+    // CHECK: native
+    printf("%s\n", nativeStringValue);
+    // CHECK: T
+    printf("%s\n", condition ? "T" : "F");
+
+    return 0;
+}
+
+// BC: func main
+// BC: print


### PR DESCRIPTION
Fixes #11399

## Summary of the problem from the end user perspective

`slangi` crashed when `%s` formatting received a string literal or a value initialized from a string literal. This blocked simple patterns such as printing conditional text.

### Minimal repro shader; if applicable

```slang
void main()
{
    printf("%s\n", "T");
}
```

## Root cause

VM string literals are emitted as string-section operands with a serialized size of zero. Runtime relocation converted the string-table index into a byte offset in the string-literal pointer table, but left the executable operand size unchanged.

## Solution in this PR

Normalize relocated string-section operands to `sizeof(const char*)`, so runtime handlers can use the operand's size consistently. Add byte-code coverage for `%s` with a literal, `String`, `NativeString`, and a string-literal ternary, including the disassembly path.

### Notes to the reviewers; where to focus on

The bytecode format is unchanged. The runtime relocation fix mirrors the existing VM validation logic, which already treats string-section reads as pointer-sized.

## Related PRs in the past

- shader-slang/slang#11398 fixed the sibling BoolLit issue that exposed this path.
- shader-slang/slang#11309 added VM operand bounds validation in the same subsystem.
