### PR TITLE
Build slang as static lib for emscripten/wasm

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,6 +24,7 @@
       "binaryDir": "${sourceDir}/build.em",
       "cacheVariables": {
         "SLANG_SLANG_LLVM_FLAVOR": "DISABLE",
+        "SLANG_LIB_TYPE": "STATIC",
         "SLANG_ENABLE_AFTERMATH": "OFF",
         "SLANG_ENABLE_CUDA": "OFF",
         "SLANG_ENABLE_GFX": "OFF",


### PR DESCRIPTION
## Problem

The `build-linux-release-gcc-wasm / build` CI job started failing on 2026-06-04 with undefined-symbol errors at the wasm link step:

```
error: undefined symbol: _ZN5Slang16WorkspaceVersion15getOrLoadModuleENS_6StringE
error: undefined symbol: _ZN5Slang18LanguageServerCore10completionE...
error: undefined symbol: _ZN5Slang9Workspace17getCurrentVersionEv
```

## Root cause

CI installs emscripten via unpinned `emsdk install latest`, which now resolves to **emscripten 6.0.0** (released 2026-06-04). Its changelog notes:

> The `FAKE_DYLIBS` setting is now disabled by default. This means that `-shared` will produce real dynamic libraries by default (`-sSIDE_MODULE` is implied).

`SLANG_LIB_TYPE` defaults to `SHARED`, and the `emscripten` preset did not override it, so the wasm build links `slang` as `libslang-compiler.so`. The `slang-wasm` bindings reference internal C++ symbols (`LanguageServerCore::*`, `Workspace::getCurrentVersion`, `WorkspaceVersion::getOrLoadModule`) that have hidden visibility and are not part of the `SLANG_API` public surface. Pre-6.0.0, `FAKE_DYLIBS` made the `.so` behave like a static archive so those internals were pulled in; in 6.0.0 the `.so` is a real side module that only exports default-visibility symbols, so they become undefined at link.

This was confirmed by comparing two runs from the same day, both on emsdk 6.0.0: a tree that linked `libslang-compiler.a` (STATIC) succeeded, while trees linking `libslang-compiler.so` (SHARED) failed.

## Fix

Set `SLANG_LIB_TYPE=STATIC` in the `emscripten` preset so the slang library is linked as a static archive. This covers both `ci-slang-build.yml` and `release.yml`, which configure with `--preset emscripten`.

## Testing

Verified by CI (no local emsdk available). A same-day run that linked slang statically under emscripten 6.0.0 produced `slang-wasm.js` successfully.