### PR TITLE
agentic suppression: fix post-reorg path drift and re-add flaky test

### DIFF
--- a/docs/generated/tests/_meta/agentic-coverage-excludes.txt
+++ b/docs/generated/tests/_meta/agentic-coverage-excludes.txt
@@ -50,4 +50,11 @@
 # uninstrumented Linux nightly); coverage instrumentation
 # escalates that failure into a SIGSEGV inside the slang-test
 # orchestrator, which kills the rest of the suite.
-docs/generated/tests/ir-reference/metadata/unorm-attr-on-buffer-element.slang
+#
+# Path note: PR #11421 reorganized the agentic suite under
+# `docs/generated/tests/design/...` and `.../conformance/...`. The
+# entry below uses the post-reorg path; the pre-reorg form
+# `docs/generated/tests/ir-reference/...` no longer matches anything
+# and silently disabled the exclude until run 26992984934 reproduced
+# the crash and surfaced the staleness.
+docs/generated/tests/design/ir-reference/metadata/unorm-attr-on-buffer-element.slang

--- a/docs/generated/tests/_meta/expected-failures.txt
+++ b/docs/generated/tests/_meta/expected-failures.txt
@@ -144,3 +144,16 @@ docs/generated/tests/design/cross-cutting/diagnostics-catalog/29106-spirv-instru
 # under the slang-linux-clang-ci container; same `-dump-ir` text-emit
 # class as Cluster C. Test-vs-compiler cause still to be determined.
 docs/generated/tests/design/ir-reference/decorations/struct-with-many-field-decorations.slang
+
+# Re-added after nightly run 26997297493 surfaced this test as FAILED:
+# https://github.com/shader-slang/slang/actions/runs/26997297493
+# (no tracking issue filed yet; pending user triage).
+#
+# This entry was previously listed under Cluster C with a comment noting
+# that the cluster's tests "flip between FAILED and PASS across runs."
+# It was removed after run 26934884546 observed it passing (along with
+# three sibling tests) — a single-pass removal that the cluster's own
+# comment warned against ("let multiple consecutive clean runs drive
+# removal, not a single observed pass"). Re-adding here so the next
+# flip back to FAILED doesn't turn the nightly red again.
+docs/generated/tests/design/ir-reference/resources-and-atomics/rwstructured-buffer-load-negative-index-literal.slang


### PR DESCRIPTION
## Summary

PR #11421 reorganized the agentic test suite under `docs/generated/tests/design/...` and `docs/generated/tests/conformance/...`. `expected-failures.txt` was migrated to the new paths in that PR; the sibling `agentic-coverage-excludes.txt` was not, and one flaky Cluster C entry was removed prematurely. Two recent nightlies had errors.

No source code changes.
