### PR TITLE
Guard serialized IR flat table reads

### DIFF
--- a/source/slang/slang-serialize-ir.cpp
+++ b/source/slang/slang-serialize-ir.cpp
@@ -619,8 +619,11 @@ static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serialize
             SLANG_RELEASE_ASSERT(len >= 0);
             SLANG_RELEASE_ASSERT(uint64_t(len) <= uint64_t(UINT32_MAX));
 
-            minSizeInBytes = offsetof(IRConstant, value) +
-                             offsetof(IRConstant::StringValue, chars) + size_t(len);
+            const size_t headerSize =
+                offsetof(IRConstant, value) + offsetof(IRConstant::StringValue, chars);
+            SLANG_RELEASE_ASSERT(size_t(len) <= size_t(-1) - headerSize);
+
+            minSizeInBytes = headerSize + size_t(len);
             break;
         }
         }

--- a/source/slang/slang-serialize-ir.cpp
+++ b/source/slang/slang-serialize-ir.cpp
@@ -572,6 +572,9 @@ static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serialize
 
     const auto operandIndicesCount = flat.operandIndices.getCount();
 
+    SLANG_RELEASE_ASSERT(flat.childCounts.getCount() == numInsts);
+    SLANG_RELEASE_ASSERT(sourceLocs.getCount() == numInsts);
+
     instsList.setCount(numInsts + 1);
     // nullptr instructions are represented as `-1`. We can save ourselves a
     // branch by just making that index valid.
@@ -610,10 +613,16 @@ static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serialize
         // About 5% of instructions in the core module are strings!
         case kIROp_StringLit:
         case kIROp_BlobLit:
+        {
+            SLANG_RELEASE_ASSERT(stringLengthIndex < flat.stringLengths.getCount());
+            const auto len = flat.stringLengths[stringLengthIndex++];
+            SLANG_RELEASE_ASSERT(len >= 0);
+            SLANG_RELEASE_ASSERT(uint64_t(len) <= uint64_t(UINT32_MAX));
+
             minSizeInBytes = offsetof(IRConstant, value) +
-                             offsetof(IRConstant::StringValue, chars) +
-                             flat.stringLengths[stringLengthIndex++];
+                             offsetof(IRConstant::StringValue, chars) + size_t(len);
             break;
+        }
         }
         insts[instIndex] = module->_allocateInst(op, a.operandCount, minSizeInBytes);
     }
@@ -632,6 +641,8 @@ static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serialize
     };
     const auto go = [&](auto& go, IRInst* parent) -> IRInst*
     {
+        SLANG_RELEASE_ASSERT(instIndex < numInsts);
+
         const auto thisInstIndex = instIndex++;
         IRInst* inst = insts[thisInstIndex];
 
@@ -649,25 +660,47 @@ static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serialize
             break;
         case kIROp_BoolLit:
         case kIROp_IntLit:
-            cast<IRConstant>(inst)->value.intVal =
-                bitCast<IRIntegerValue>(flat.literals[litIndex++]);
+        {
+            SLANG_RELEASE_ASSERT(litIndex < flat.literals.getCount());
+            const auto bits = flat.literals[litIndex++];
+            cast<IRConstant>(inst)->value.intVal = bitCast<IRIntegerValue>(bits);
             break;
+        }
         case kIROp_FloatLit:
-            cast<IRConstant>(inst)->value.floatVal = bitCast<double>(flat.literals[litIndex++]);
+        {
+            SLANG_RELEASE_ASSERT(litIndex < flat.literals.getCount());
+            const auto bits = flat.literals[litIndex++];
+            cast<IRConstant>(inst)->value.floatVal = bitCast<double>(bits);
             break;
+        }
         case kIROp_PtrLit:
+        {
+            SLANG_RELEASE_ASSERT(litIndex < flat.literals.getCount());
+            const auto bits = flat.literals[litIndex++];
             // Keep the compiler happy on 32 bit builds
-            cast<IRConstant>(inst)->value.ptrVal = (void*)(uintptr_t(flat.literals[litIndex++]));
+            cast<IRConstant>(inst)->value.ptrVal = (void*)(uintptr_t(bits));
             break;
+        }
         case kIROp_StringLit:
         case kIROp_BlobLit:
+        {
             const auto c = cast<IRConstant>(inst);
+            SLANG_RELEASE_ASSERT(stringLengthIndex < flat.stringLengths.getCount());
             const auto len = flat.stringLengths[stringLengthIndex++];
+            SLANG_RELEASE_ASSERT(len >= 0);
+            SLANG_RELEASE_ASSERT(uint64_t(len) <= uint64_t(UINT32_MAX));
+
+            const auto stringCharsCount = flat.stringChars.getCount();
+            SLANG_RELEASE_ASSERT(stringDataIndex <= stringCharsCount);
+            SLANG_RELEASE_ASSERT(len <= stringCharsCount - stringDataIndex);
+
             char* const dstChars = c->value.stringVal.chars;
             c->value.stringVal.numChars = uint32_t(len);
-            memcpy(dstChars, flat.stringChars.begin() + stringDataIndex, len);
+            if (len != 0)
+                memcpy(dstChars, flat.stringChars.begin() + stringDataIndex, size_t(len));
             stringDataIndex += len;
             break;
+        }
         }
 
         // Read in children, and fix up pointers
@@ -675,7 +708,9 @@ static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serialize
         IRInst* prev = nullptr;
         IRInst* first = nullptr;
         IRInst* last = nullptr;
-        for (Int64 i = 0; i < flat.childCounts[thisInstIndex]; ++i)
+        const auto childCount = flat.childCounts[thisInstIndex];
+        SLANG_RELEASE_ASSERT(childCount >= 0);
+        for (Int64 i = 0; i < childCount; ++i)
         {
             auto c = go(go, inst);
             if (i == 0)
@@ -694,6 +729,8 @@ static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serialize
         return inst;
     };
     const auto moduleInst = go(go, nullptr);
+    SLANG_RELEASE_ASSERT(instIndex == numInsts);
+    SLANG_RELEASE_ASSERT(as<IRModuleInst>(moduleInst));
     return cast<IRModuleInst>(moduleInst);
 }
 

--- a/source/slang/slang-serialize-ir.cpp
+++ b/source/slang/slang-serialize-ir.cpp
@@ -548,6 +548,9 @@ static T deserialize1(const IRReadSerializer& serializer, const Fossil::AnyValRe
 
 static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serializer, IRModule* module)
 {
+    // Bound recursive child traversal so malformed flat tables cannot exhaust the host stack.
+    static const Int64 kMaxIRDeserializeDepth = 4096;
+
     IRSerialReadContext& readContext = *serializer.getContext();
 #if DIRECT_FROM_FOSSIL
     const auto flatPtr = as<Fossilized<FlatInstTable>>(serializer.getImpl()->readValPtr());
@@ -572,6 +575,8 @@ static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serialize
 
     const auto operandIndicesCount = flat.operandIndices.getCount();
 
+    // These relationships are serialized IR invariants; stop before rebuilding pointers from
+    // inconsistent flat tables.
     SLANG_RELEASE_ASSERT(flat.childCounts.getCount() == numInsts);
     SLANG_RELEASE_ASSERT(sourceLocs.getCount() == numInsts);
 
@@ -642,8 +647,9 @@ static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serialize
         SLANG_RELEASE_ASSERT(index >= -1 && index < numInsts);
         return insts[index];
     };
-    const auto go = [&](auto& go, IRInst* parent) -> IRInst*
+    const auto go = [&](auto& go, IRInst* parent, Int64 depth) -> IRInst*
     {
+        SLANG_RELEASE_ASSERT(depth < kMaxIRDeserializeDepth);
         SLANG_RELEASE_ASSERT(instIndex < numInsts);
 
         const auto thisInstIndex = instIndex++;
@@ -715,7 +721,7 @@ static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serialize
         SLANG_RELEASE_ASSERT(childCount >= 0);
         for (Int64 i = 0; i < childCount; ++i)
         {
-            auto c = go(go, inst);
+            auto c = go(go, inst, depth + 1);
             if (i == 0)
                 first = c;
             last = c;
@@ -731,8 +737,12 @@ static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serialize
 
         return inst;
     };
-    const auto moduleInst = go(go, nullptr);
+    const auto moduleInst = go(go, nullptr, 0);
     SLANG_RELEASE_ASSERT(instIndex == numInsts);
+    SLANG_RELEASE_ASSERT(litIndex == flat.literals.getCount());
+    SLANG_RELEASE_ASSERT(operandIndex == operandIndicesCount);
+    SLANG_RELEASE_ASSERT(stringLengthIndex == flat.stringLengths.getCount());
+    SLANG_RELEASE_ASSERT(stringDataIndex == flat.stringChars.getCount());
     SLANG_RELEASE_ASSERT(as<IRModuleInst>(moduleInst));
     return cast<IRModuleInst>(moduleInst);
 }

--- a/source/slang/slang-serialize-ir.cpp
+++ b/source/slang/slang-serialize-ir.cpp
@@ -549,7 +549,8 @@ static T deserialize1(const IRReadSerializer& serializer, const Fossil::AnyValRe
 static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serializer, IRModule* module)
 {
     // Bound recursive child traversal so malformed flat tables cannot exhaust the host stack.
-    static const Int64 kMaxIRDeserializeDepth = 4096;
+    // Keep this well below typical 1 MiB debug-thread stacks, even with unoptimized frames.
+    static const Int64 kMaxIRDeserializeDepth = 512;
 
     IRSerialReadContext& readContext = *serializer.getContext();
 #if DIRECT_FROM_FOSSIL

--- a/source/slang/slang-serialize-ir.cpp
+++ b/source/slang/slang-serialize-ir.cpp
@@ -548,10 +548,6 @@ static T deserialize1(const IRReadSerializer& serializer, const Fossil::AnyValRe
 
 static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serializer, IRModule* module)
 {
-    // Bound recursive child traversal so malformed flat tables cannot exhaust the host stack.
-    // Keep this well below typical 1 MiB debug-thread stacks, even with unoptimized frames.
-    static const Int64 kMaxIRDeserializeDepth = 512;
-
     IRSerialReadContext& readContext = *serializer.getContext();
 #if DIRECT_FROM_FOSSIL
     const auto flatPtr = as<Fossilized<FlatInstTable>>(serializer.getImpl()->readValPtr());
@@ -650,7 +646,7 @@ static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serialize
     };
     const auto go = [&](auto& go, IRInst* parent, Int64 depth) -> IRInst*
     {
-        SLANG_RELEASE_ASSERT(depth < kMaxIRDeserializeDepth);
+        SLANG_RELEASE_ASSERT(depth < kMaxIRSerializationDepth);
         SLANG_RELEASE_ASSERT(instIndex < numInsts);
 
         const auto thisInstIndex = instIndex++;
@@ -740,10 +736,15 @@ static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serialize
     };
     const auto moduleInst = go(go, nullptr, 0);
     SLANG_RELEASE_ASSERT(instIndex == numInsts);
-    SLANG_RELEASE_ASSERT(litIndex == flat.literals.getCount());
     SLANG_RELEASE_ASSERT(operandIndex == operandIndicesCount);
-    SLANG_RELEASE_ASSERT(stringLengthIndex == flat.stringLengths.getCount());
-    SLANG_RELEASE_ASSERT(stringDataIndex == flat.stringChars.getCount());
+    // Unknown future opcodes intentionally become a recoverable read failure later.
+    // This reader cannot know whether those opcodes consume literal or string payloads.
+    if (!readContext._foundUnrecognizedInstructions)
+    {
+        SLANG_RELEASE_ASSERT(litIndex == flat.literals.getCount());
+        SLANG_RELEASE_ASSERT(stringLengthIndex == flat.stringLengths.getCount());
+        SLANG_RELEASE_ASSERT(stringDataIndex == flat.stringChars.getCount());
+    }
     SLANG_RELEASE_ASSERT(as<IRModuleInst>(moduleInst));
     return cast<IRModuleInst>(moduleInst);
 }

--- a/source/slang/slang-serialize-ir.cpp
+++ b/source/slang/slang-serialize-ir.cpp
@@ -613,19 +613,19 @@ static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serialize
         // About 5% of instructions in the core module are strings!
         case kIROp_StringLit:
         case kIROp_BlobLit:
-        {
-            SLANG_RELEASE_ASSERT(stringLengthIndex < flat.stringLengths.getCount());
-            const auto len = flat.stringLengths[stringLengthIndex++];
-            SLANG_RELEASE_ASSERT(len >= 0);
-            SLANG_RELEASE_ASSERT(uint64_t(len) <= uint64_t(UINT32_MAX));
+            {
+                SLANG_RELEASE_ASSERT(stringLengthIndex < flat.stringLengths.getCount());
+                const auto len = flat.stringLengths[stringLengthIndex++];
+                SLANG_RELEASE_ASSERT(len >= 0);
+                SLANG_RELEASE_ASSERT(uint64_t(len) <= uint64_t(UINT32_MAX));
 
-            const size_t headerSize =
-                offsetof(IRConstant, value) + offsetof(IRConstant::StringValue, chars);
-            SLANG_RELEASE_ASSERT(size_t(len) <= size_t(-1) - headerSize);
+                const size_t headerSize =
+                    offsetof(IRConstant, value) + offsetof(IRConstant::StringValue, chars);
+                SLANG_RELEASE_ASSERT(size_t(len) <= size_t(-1) - headerSize);
 
-            minSizeInBytes = headerSize + size_t(len);
-            break;
-        }
+                minSizeInBytes = headerSize + size_t(len);
+                break;
+            }
         }
         insts[instIndex] = module->_allocateInst(op, a.operandCount, minSizeInBytes);
     }
@@ -663,47 +663,47 @@ static IRModuleInst* deserializeFromFlatModule(const IRReadSerializer& serialize
             break;
         case kIROp_BoolLit:
         case kIROp_IntLit:
-        {
-            SLANG_RELEASE_ASSERT(litIndex < flat.literals.getCount());
-            const auto bits = flat.literals[litIndex++];
-            cast<IRConstant>(inst)->value.intVal = bitCast<IRIntegerValue>(bits);
-            break;
-        }
+            {
+                SLANG_RELEASE_ASSERT(litIndex < flat.literals.getCount());
+                const auto bits = flat.literals[litIndex++];
+                cast<IRConstant>(inst)->value.intVal = bitCast<IRIntegerValue>(bits);
+                break;
+            }
         case kIROp_FloatLit:
-        {
-            SLANG_RELEASE_ASSERT(litIndex < flat.literals.getCount());
-            const auto bits = flat.literals[litIndex++];
-            cast<IRConstant>(inst)->value.floatVal = bitCast<double>(bits);
-            break;
-        }
+            {
+                SLANG_RELEASE_ASSERT(litIndex < flat.literals.getCount());
+                const auto bits = flat.literals[litIndex++];
+                cast<IRConstant>(inst)->value.floatVal = bitCast<double>(bits);
+                break;
+            }
         case kIROp_PtrLit:
-        {
-            SLANG_RELEASE_ASSERT(litIndex < flat.literals.getCount());
-            const auto bits = flat.literals[litIndex++];
-            // Keep the compiler happy on 32 bit builds
-            cast<IRConstant>(inst)->value.ptrVal = (void*)(uintptr_t(bits));
-            break;
-        }
+            {
+                SLANG_RELEASE_ASSERT(litIndex < flat.literals.getCount());
+                const auto bits = flat.literals[litIndex++];
+                // Keep the compiler happy on 32 bit builds
+                cast<IRConstant>(inst)->value.ptrVal = (void*)(uintptr_t(bits));
+                break;
+            }
         case kIROp_StringLit:
         case kIROp_BlobLit:
-        {
-            const auto c = cast<IRConstant>(inst);
-            SLANG_RELEASE_ASSERT(stringLengthIndex < flat.stringLengths.getCount());
-            const auto len = flat.stringLengths[stringLengthIndex++];
-            SLANG_RELEASE_ASSERT(len >= 0);
-            SLANG_RELEASE_ASSERT(uint64_t(len) <= uint64_t(UINT32_MAX));
+            {
+                const auto c = cast<IRConstant>(inst);
+                SLANG_RELEASE_ASSERT(stringLengthIndex < flat.stringLengths.getCount());
+                const auto len = flat.stringLengths[stringLengthIndex++];
+                SLANG_RELEASE_ASSERT(len >= 0);
+                SLANG_RELEASE_ASSERT(uint64_t(len) <= uint64_t(UINT32_MAX));
 
-            const auto stringCharsCount = flat.stringChars.getCount();
-            SLANG_RELEASE_ASSERT(stringDataIndex <= stringCharsCount);
-            SLANG_RELEASE_ASSERT(len <= stringCharsCount - stringDataIndex);
+                const auto stringCharsCount = flat.stringChars.getCount();
+                SLANG_RELEASE_ASSERT(stringDataIndex <= stringCharsCount);
+                SLANG_RELEASE_ASSERT(len <= stringCharsCount - stringDataIndex);
 
-            char* const dstChars = c->value.stringVal.chars;
-            c->value.stringVal.numChars = uint32_t(len);
-            if (len != 0)
-                memcpy(dstChars, flat.stringChars.begin() + stringDataIndex, size_t(len));
-            stringDataIndex += len;
-            break;
-        }
+                char* const dstChars = c->value.stringVal.chars;
+                c->value.stringVal.numChars = uint32_t(len);
+                if (len != 0)
+                    memcpy(dstChars, flat.stringChars.begin() + stringDataIndex, size_t(len));
+                stringDataIndex += len;
+                break;
+            }
         }
 
         // Read in children, and fix up pointers

--- a/source/slang/slang-serialize-ir.h
+++ b/source/slang/slang-serialize-ir.h
@@ -39,13 +39,19 @@ void writeSerializedModuleIR(
 // of the stream to make deserialization slightly faster
 const bool kReorderInstructionsForSerialization = true;
 
+// Recursive IR tree traversal is used on both write and read. This matches the
+// existing IR specialization depth budget and is shared so round-trips stay symmetric.
+const Int64 kMaxIRSerializationDepth = 512;
+
 // We expose this function here as it's used by the verifyIRSerialize function in
 // slang-serialize-container.cpp
 template<typename Func>
 static void traverseInstsInSerializationOrder(IRInst* moduleInst, Func&& processInst)
 {
-    const auto go = [&](auto& go, IRInst* inst) -> void
+    const auto go = [&](auto& go, IRInst* inst, Int64 depth) -> void
     {
+        SLANG_RELEASE_ASSERT(depth < kMaxIRSerializationDepth);
+
         // Process the current instruction
         processInst(inst);
 
@@ -76,27 +82,27 @@ static void traverseInstsInSerializationOrder(IRInst* moduleInst, Func&& process
                 }
                 else
                 {
-                    go(go, c);
+                    go(go, c, depth + 1);
                 }
             }
             for (const auto c : lits)
             {
-                go(go, c);
+                go(go, c, depth + 1);
             }
             for (const auto c : strings)
             {
-                go(go, c);
+                go(go, c, depth + 1);
             }
         }
         else
         {
             for (const auto c : inst->m_decorationsAndChildren)
             {
-                go(go, c);
+                go(go, c, depth + 1);
             }
         }
     };
-    go(go, moduleInst);
+    go(go, moduleInst, 0);
 }
 
 } // namespace Slang


### PR DESCRIPTION
## TL;DR

Security vulnerability was reported on the following lines:
```
flat.stringLengths[stringLengthIndex++];
bitCast<IRIntegerValue>(flat.literals[litIndex++]);
memcpy(dstChars, flat.stringChars.begin() + stringDataIndex, len);
```
This PR adds `SLANG_RELEASE_ASSERT` guards to error out loudly on unexpected values.

## Summary of the problem from the end user perspective

A malformed precompiled `.slang-module` could contain more string/blob or literal instructions than entries in the serialized payload tables. Loading that module in release builds could read past the end of those tables.

## Root cause

`deserializeFromFlatModule` advanced payload indices and read from `flat.stringLengths`, `flat.literals`, and `flat.stringChars` without release-mode bounds checks. The allocation pass also needed to guard the computed string/blob constant size against `size_t` overflow.

## Solution in this PR

Add `SLANG_RELEASE_ASSERT` guards before consuming serialized string lengths, literal values, and string character data. The deserializer also asserts related flattened instruction table bounds, guards the string/blob allocation-size calculation before allocating each instruction, caps recursive child traversal depth, and checks that the operand, literal, string-length, and string-data tables are fully consumed after rebuilding the module tree. The depth cap is shared by the writer and reader so serialization does not emit modules this reader rejects solely because of the cap. Final literal/string payload-table consumption is enforced only when the reader did not see an unrecognized future opcode, because that path already reports `SLANG_FAIL` and the older reader cannot know the opcode's payload shape.

### Notes to the reviewers; where to focus on

The important paths are the allocation pass for string/blob constants, the payload population pass for literals and strings, and the final traversal invariants in `deserializeFromFlatModule`. The checks are placed immediately before each indexed access, allocation-size calculation, `memcpy` source calculation, recursive child traversal, or final table-consumption assertion.

## Reviewer Directives (maintained by agent)

- [LLM CodeRabbit] Do not enforce final literal/string payload-table consumption after an unrecognized future opcode has already been detected; let that path reach the existing `SLANG_FAIL` handling instead. (https://github.com/shader-slang/slang/pull/11514#pullrequestreview-4454710532)
