### PR TITLE
Guard URI percent decoding bounds

### DIFF
--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -1299,7 +1299,7 @@ URI URI::fromLocalFilePath(UnownedStringSlice path)
         else
         {
             char buffer[32];
-            int length = intToAscii(buffer, (unsigned char)ch, 16, 2);
+            int length = intToAscii(buffer, int((unsigned char)ch), 16, 2);
             sb << "%" << UnownedStringSlice(buffer, length);
         }
     }

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -1244,19 +1244,20 @@ String URI::getPath() const
     for (Index i = startIndex; i < endIndex;)
     {
         auto ch = uri[i];
-        if (ch == '%' && i + 2 < endIndex && CharUtil::isHexDigit(uri[i + 1]) &&
-            CharUtil::isHexDigit(uri[i + 2]))
+        if (ch == '%' && i + 2 < endIndex)
         {
-            Int charVal = CharUtil::getHexDigitValue(uri[i + 1]) * 16 +
-                          CharUtil::getHexDigitValue(uri[i + 2]);
-            sb.appendChar((char)charVal);
-            i += 3;
+            Int highDigit = CharUtil::getHexDigitValue(uri[i + 1]);
+            Int lowDigit = CharUtil::getHexDigitValue(uri[i + 2]);
+            if (highDigit >= 0 && lowDigit >= 0)
+            {
+                sb.appendChar((char)(highDigit * 16 + lowDigit));
+                i += 3;
+                continue;
+            }
         }
-        else
-        {
-            sb.appendChar(uri[i]);
-            i++;
-        }
+
+        sb.appendChar(uri[i]);
+        i++;
     }
     return sb.produceString();
 }
@@ -1298,7 +1299,7 @@ URI URI::fromLocalFilePath(UnownedStringSlice path)
         else
         {
             char buffer[32];
-            int length = intToAscii(buffer, (int)ch, 16);
+            int length = intToAscii(buffer, (unsigned char)ch, 16, 2);
             sb << "%" << UnownedStringSlice(buffer, length);
         }
     }

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -1244,7 +1244,7 @@ String URI::getPath() const
     for (Index i = startIndex; i < endIndex;)
     {
         auto ch = uri[i];
-        if (ch == '%')
+        if (ch == '%' && i + 2 < endIndex)
         {
             Int charVal = CharUtil::getHexDigitValue(uri[i + 1]) * 16 +
                           CharUtil::getHexDigitValue(uri[i + 2]);

--- a/source/core/slang-io.cpp
+++ b/source/core/slang-io.cpp
@@ -1244,7 +1244,8 @@ String URI::getPath() const
     for (Index i = startIndex; i < endIndex;)
     {
         auto ch = uri[i];
-        if (ch == '%' && i + 2 < endIndex)
+        if (ch == '%' && i + 2 < endIndex && CharUtil::isHexDigit(uri[i + 1]) &&
+            CharUtil::isHexDigit(uri[i + 2]))
         {
             Int charVal = CharUtil::getHexDigitValue(uri[i + 1]) * 16 +
                           CharUtil::getHexDigitValue(uri[i + 2]);

--- a/tools/slang-unit-test/unit-test-io.cpp
+++ b/tools/slang-unit-test/unit-test-io.cpp
@@ -172,4 +172,6 @@ SLANG_UNIT_TEST(uriGetPathPercentDecode)
     SLANG_CHECK(URI::fromString(toSlice("file://path%")).getPath() == "path%");
     SLANG_CHECK(URI::fromString(toSlice("file://path%2")).getPath() == "path%2");
     SLANG_CHECK(URI::fromString(toSlice("file://path%2g")).getPath() == "path%2g");
+    SLANG_CHECK(URI::fromString(toSlice("file://path%2?x=1")).getPath() == "path%2");
+    SLANG_CHECK(URI::fromLocalFilePath(toSlice("path\tname")).getPath() == "path\tname");
 }

--- a/tools/slang-unit-test/unit-test-io.cpp
+++ b/tools/slang-unit-test/unit-test-io.cpp
@@ -165,3 +165,10 @@ SLANG_UNIT_TEST(ioLargeFileExists)
     SLANG_IGNORE_TEST
 #endif
 }
+
+SLANG_UNIT_TEST(uriGetPathPercentDecode)
+{
+    SLANG_CHECK(URI::fromString(toSlice("file://path%20name")).getPath() == "path name");
+    SLANG_CHECK(URI::fromString(toSlice("file://path%")).getPath() == "path%");
+    SLANG_CHECK(URI::fromString(toSlice("file://path%2")).getPath() == "path%2");
+}

--- a/tools/slang-unit-test/unit-test-io.cpp
+++ b/tools/slang-unit-test/unit-test-io.cpp
@@ -171,4 +171,5 @@ SLANG_UNIT_TEST(uriGetPathPercentDecode)
     SLANG_CHECK(URI::fromString(toSlice("file://path%20name")).getPath() == "path name");
     SLANG_CHECK(URI::fromString(toSlice("file://path%")).getPath() == "path%");
     SLANG_CHECK(URI::fromString(toSlice("file://path%2")).getPath() == "path%2");
+    SLANG_CHECK(URI::fromString(toSlice("file://path%2g")).getPath() == "path%2g");
 }

--- a/tools/slang-unit-test/unit-test-io.cpp
+++ b/tools/slang-unit-test/unit-test-io.cpp
@@ -174,6 +174,8 @@ SLANG_UNIT_TEST(uriGetPathPercentDecode)
     SLANG_CHECK(URI::fromString(toSlice("file://path%")).getPath() == "path%");
     SLANG_CHECK(URI::fromString(toSlice("file://path%2")).getPath() == "path%2");
     SLANG_CHECK(URI::fromString(toSlice("file://path%2g")).getPath() == "path%2g");
+    SLANG_CHECK(URI::fromString(toSlice("file://path%g0")).getPath() == "path%g0");
+    SLANG_CHECK(URI::fromString(toSlice("file://path%gg")).getPath() == "path%gg");
     SLANG_CHECK(URI::fromString(toSlice("file://path%2?x=1")).getPath() == "path%2");
     SLANG_CHECK(URI::fromLocalFilePath(toSlice("path\tname")).getPath() == "path\tname");
 

--- a/tools/slang-unit-test/unit-test-io.cpp
+++ b/tools/slang-unit-test/unit-test-io.cpp
@@ -169,9 +169,15 @@ SLANG_UNIT_TEST(ioLargeFileExists)
 SLANG_UNIT_TEST(uriGetPathPercentDecode)
 {
     SLANG_CHECK(URI::fromString(toSlice("file://path%20name")).getPath() == "path name");
+    SLANG_CHECK(URI::fromString(toSlice("file://%20")).getPath() == " ");
+    SLANG_CHECK(URI::fromString(toSlice("file://a%20?x=1")).getPath() == "a ");
     SLANG_CHECK(URI::fromString(toSlice("file://path%")).getPath() == "path%");
     SLANG_CHECK(URI::fromString(toSlice("file://path%2")).getPath() == "path%2");
     SLANG_CHECK(URI::fromString(toSlice("file://path%2g")).getPath() == "path%2g");
     SLANG_CHECK(URI::fromString(toSlice("file://path%2?x=1")).getPath() == "path%2");
     SLANG_CHECK(URI::fromLocalFilePath(toSlice("path\tname")).getPath() == "path\tname");
+
+    const char highBitPath[] = {'h', 'i', (char)0x80, (char)0xff, 0};
+    String highBitRoundTrip = URI::fromLocalFilePath(UnownedStringSlice(highBitPath)).getPath();
+    SLANG_CHECK(highBitRoundTrip.getUnownedSlice() == UnownedStringSlice(highBitPath));
 }


### PR DESCRIPTION
## TL;DR

Security vulnerability was reported on the following line:
```
Int charVal = CharUtil::getHexDigitValue(uri[i + 1]) * 16 + CharUtil::getHexDigitValue(uri[i + 2]);
```
This PR adds bounds and validity checks before percent decoding.

## Summary of the problem from the end user perspective

Malformed file URIs from an IDE client could cause the language server to read beyond the URI string while decoding a trailing percent escape, or decode invalid percent escapes into garbage path characters.

## Root cause

`URI::getPath()` decoded every `%` as a three-character escape without first checking that two valid hex digits remained before the path or query boundary.

## Solution in this PR

Only decode a percent escape when both following characters are still within the URI path and are valid hex digits. Too-short or invalid escapes are preserved literally, and local-file URI encoding now emits two-digit hex escapes so encoder/decoder round trips remain consistent.

### Notes to the reviewers; where to focus on

The implementation change is the added guard in `URI::getPath()` plus two-digit padding in `URI::fromLocalFilePath()`. The unit test covers normal `%20` decoding, `%20` at the exact path boundary, trailing `%`, trailing `%2`, invalid high- and low-hex escapes, a `%2` query-boundary case, single-digit-hex local path round trip, and high-bit local path round trip.
