### PR TITLE
Add [NoDiscard] attribute

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -701,7 +701,7 @@ interface IForwardDifferentiable<FType> where __hasDiffTypeInfo(FType)
 {
     __builtin_requirement($( (int)BuiltinRequirementKind::ForwardDerivativeFunc))
     [MaybeDifferentiable]
-    static __associatedfunc FwdDiffFuncType<FType> fwd_diff; // -> fwd_diff 
+    static __associatedfunc FwdDiffFuncType<FType> fwd_diff; // -> fwd_diff
 };
 
 // Core library interfaces:
@@ -718,10 +718,10 @@ __magic_type(BwdDiffFuncInterfaceType)
 [__FunctionInterface]
 interface IBackwardDifferentiable<FType> where __hasDiffTypeInfo(FType)
 {
-    __builtin_requirement($( (int)BuiltinRequirementKind::BwdCallableContextType)) 
+    __builtin_requirement($( (int)BuiltinRequirementKind::BwdCallableContextType))
     associatedtype BwdCallable : IBwdCallable<FType>; // -> intermediate_context_type
 
-    __builtin_requirement($( (int)BuiltinRequirementKind::MinimalContextType)) 
+    __builtin_requirement($( (int)BuiltinRequirementKind::MinimalContextType))
     associatedtype MinimalContext; // -> minimal_context_type
 
     __builtin_requirement($( (int)BuiltinRequirementKind::BwdApplyFunc))
@@ -1322,7 +1322,7 @@ $}
         {
             return a + b;
         }
-        
+
 ${
         break;
     }
@@ -2455,7 +2455,7 @@ extension matrix<T,N,M,L> : IFloat
     [__unsafeForceInlineEarly]
     __implicit_conversion($(kConversionCost_ScalarToMatrix))
     __init(float v) { this = matrix<T,N,M>(T(v)); }
-    
+
     /// Initialize a matrix where all elements have the same scalar `value`.
     [OverloadRank(-1)]
     [Differentiable]
@@ -4524,6 +4524,28 @@ attribute_syntax [mutating] : MutatingAttribute;
 ///
 __attributeTarget(AccessorDecl)
 attribute_syntax [nonmutating] : NonmutatingAttribute;
+
+/// Marks a function whose return value should not be discarded. When a call to a
+/// function marked with `[nodiscard]` is used as a statement and its result is
+/// ignored, the compiler emits a warning.
+/// @remarks
+/// This is useful for functions that look like they mutate the object they are called
+/// on, but instead return a result. For example, a member function `Load` that returns
+/// the loaded value rather than mutating `this`:
+/// ```
+/// struct MyType
+/// {
+///    [nodiscard]
+///    MyType load() { ... }
+/// }
+/// MyType t;
+/// t.load(); // warning: result of '[nodiscard]' function is discarded.
+/// let loaded = t.load(); // OK
+/// ```
+/// The C++ spelling `[[nodiscard]]` is also accepted.
+///
+__attributeTarget(FunctionDeclBase)
+attribute_syntax [nodiscard] : NoDiscardAttribute;
 
 /// @internal
 /// Marks a member function to make `this` argument passed by const reference.

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -4542,7 +4542,6 @@ attribute_syntax [nonmutating] : NonmutatingAttribute;
 /// t.load(); // warning: result of '[nodiscard]' function is discarded.
 /// let loaded = t.load(); // OK
 /// ```
-/// The C++ spelling `[[nodiscard]]` is also accepted.
 ///
 __attributeTarget(FunctionDeclBase)
 attribute_syntax [nodiscard] : NoDiscardAttribute;

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -4530,7 +4530,7 @@ attribute_syntax [nonmutating] : NonmutatingAttribute;
 /// discarded — an expression statement, or a `for` loop's side-effect expression,
 /// including through transparent wrappers (parentheses, casts) and pass-through
 /// operands (comma, ternary arms, the right-hand side of `&&`/`||`) — the compiler
-/// emits a warning.
+/// emits an error.
 /// @remarks
 /// This is useful for functions that look like they mutate the object they are called
 /// on, but instead return a result. For example, a member function `load` that returns
@@ -4542,7 +4542,7 @@ attribute_syntax [nonmutating] : NonmutatingAttribute;
 ///    MyType load() { ... }
 /// }
 /// MyType t;
-/// t.load(); // warning: result of '[nodiscard]' function is discarded.
+/// t.load(); // error: result of '[nodiscard]' function is discarded.
 /// let loaded = t.load(); // OK
 /// ```
 ///

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -4526,8 +4526,11 @@ __attributeTarget(AccessorDecl)
 attribute_syntax [nonmutating] : NonmutatingAttribute;
 
 /// Marks a function whose return value should not be discarded. When a call to a
-/// function marked with `[nodiscard]` is used as a statement and its result is
-/// ignored, the compiler emits a warning.
+/// function marked with `[nodiscard]` is made in a context where its result is
+/// discarded — an expression statement, or a `for` loop's side-effect expression,
+/// including through transparent wrappers (parentheses, casts) and pass-through
+/// operands (comma, ternary arms, the right-hand side of `&&`/`||`) — the compiler
+/// emits a warning.
 /// @remarks
 /// This is useful for functions that look like they mutate the object they are called
 /// on, but instead return a result. For example, a member function `load` that returns

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -4530,7 +4530,7 @@ attribute_syntax [nonmutating] : NonmutatingAttribute;
 /// ignored, the compiler emits a warning.
 /// @remarks
 /// This is useful for functions that look like they mutate the object they are called
-/// on, but instead return a result. For example, a member function `Load` that returns
+/// on, but instead return a result. For example, a member function `load` that returns
 /// the loaded value rather than mutating `this`:
 /// ```
 /// struct MyType

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -4526,11 +4526,11 @@ __attributeTarget(AccessorDecl)
 attribute_syntax [nonmutating] : NonmutatingAttribute;
 
 /// Marks a function whose return value should not be discarded. When a call to a
-/// function marked with `[nodiscard]` is made in a context where its result is
+/// function marked with `[NoDiscard]` is made in a context where its result is
 /// discarded — an expression statement, or a `for` loop's side-effect expression,
-/// including through transparent wrappers (parentheses, casts) and pass-through
-/// operands (comma, ternary arms, the right-hand side of `&&`/`||`) — the compiler
-/// emits an error. Applying `[nodiscard]` to a function that returns `void` is itself an
+/// including through transparent wrappers (parentheses) and pass-through operands
+/// (comma, ternary arms, the right-hand side of `&&`/`||`) — the compiler emits an
+/// error. Applying `[NoDiscard]` to a function that returns `void` is itself an
 /// error, reported at the declaration, since such a function has no result to discard.
 /// @remarks
 /// This is useful for functions that look like they mutate the object they are called
@@ -4539,16 +4539,16 @@ attribute_syntax [nonmutating] : NonmutatingAttribute;
 /// ```
 /// struct MyType
 /// {
-///    [nodiscard]
+///    [NoDiscard]
 ///    MyType load() { ... }
 /// }
 /// MyType t;
-/// t.load(); // error: result of '[nodiscard]' function is discarded.
+/// t.load(); // error: result of '[NoDiscard]' function is discarded.
 /// let loaded = t.load(); // OK
 /// ```
 ///
 __attributeTarget(FunctionDeclBase)
-attribute_syntax [nodiscard] : NoDiscardAttribute;
+attribute_syntax [NoDiscard] : NoDiscardAttribute;
 
 /// @internal
 /// Marks a member function to make `this` argument passed by const reference.

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -4530,7 +4530,8 @@ attribute_syntax [nonmutating] : NonmutatingAttribute;
 /// discarded — an expression statement, or a `for` loop's side-effect expression,
 /// including through transparent wrappers (parentheses, casts) and pass-through
 /// operands (comma, ternary arms, the right-hand side of `&&`/`||`) — the compiler
-/// emits an error.
+/// emits an error. Applying `[nodiscard]` to a function that returns `void` is itself an
+/// error, reported at the declaration, since such a function has no result to discard.
 /// @remarks
 /// This is useful for functions that look like they mutate the object they are called
 /// on, but instead return a result. For example, a member function `load` that returns

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -1385,6 +1385,17 @@ class NonmutatingAttribute : public Attribute
     FIDDLE(...)
 };
 
+// A `[nodiscard]` attribute, which indicates that the result of a
+// function call should not be discarded. When a call to a function
+// marked with this attribute is used as a statement (its result is
+// ignored), the compiler emits a warning.
+//
+FIDDLE()
+class NoDiscardAttribute : public Attribute
+{
+    FIDDLE(...)
+};
+
 // A `[constref]` attribute, which indicates that the `this` parameter of
 // a member function should be passed by const reference.
 //

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -1390,7 +1390,7 @@ class NonmutatingAttribute : public Attribute
 // marked with this attribute is made in a context where its result is
 // discarded — an expression statement, or a `for` loop's side-effect
 // expression, including through transparent wrappers and pass-through
-// operands — the compiler emits a warning.
+// operands — the compiler emits an error.
 //
 FIDDLE()
 class NoDiscardAttribute : public Attribute

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -1387,8 +1387,10 @@ class NonmutatingAttribute : public Attribute
 
 // A `[nodiscard]` attribute, which indicates that the result of a
 // function call should not be discarded. When a call to a function
-// marked with this attribute is used as a statement (its result is
-// ignored), the compiler emits a warning.
+// marked with this attribute is made in a context where its result is
+// discarded — an expression statement, or a `for` loop's side-effect
+// expression, including through transparent wrappers and pass-through
+// operands — the compiler emits a warning.
 //
 FIDDLE()
 class NoDiscardAttribute : public Attribute

--- a/source/slang/slang-ast-modifier.h
+++ b/source/slang/slang-ast-modifier.h
@@ -1385,12 +1385,12 @@ class NonmutatingAttribute : public Attribute
     FIDDLE(...)
 };
 
-// A `[nodiscard]` attribute, which indicates that the result of a
+// A `[NoDiscard]` attribute, which indicates that the result of a
 // function call should not be discarded. When a call to a function
 // marked with this attribute is made in a context where its result is
 // discarded — an expression statement, or a `for` loop's side-effect
-// expression, including through transparent wrappers and pass-through
-// operands — the compiler emits an error.
+// expression, including through parentheses and pass-through operands —
+// the compiler emits an error.
 //
 FIDDLE()
 class NoDiscardAttribute : public Attribute

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -14847,13 +14847,13 @@ void SemanticsDeclHeaderVisitor::checkCallableDeclCommon(CallableDecl* decl)
         }
     }
 
-    // `[nodiscard]` is meaningless on a function with no result to discard, so reject it
+    // `[NoDiscard]` is meaningless on a function with no result to discard, so reject it
     // on a `void`-returning function.
     if (decl->findModifier<NoDiscardAttribute>())
     {
         if (decl->returnType.type && decl->returnType.type->equals(m_astBuilder->getVoidType()))
         {
-            getSink()->diagnose(Diagnostics::NodiscardOnVoidFunction{.decl = decl});
+            getSink()->diagnose(Diagnostics::NoDiscardOnVoidFunction{.decl = decl});
         }
     }
 

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -14847,6 +14847,16 @@ void SemanticsDeclHeaderVisitor::checkCallableDeclCommon(CallableDecl* decl)
         }
     }
 
+    // `[nodiscard]` is meaningless on a function with no result to discard, so reject it
+    // on a `void`-returning function.
+    if (decl->findModifier<NoDiscardAttribute>())
+    {
+        if (decl->returnType.type && decl->returnType.type->equals(m_astBuilder->getVoidType()))
+        {
+            getSink()->diagnose(Diagnostics::NodiscardOnVoidFunction{.decl = decl});
+        }
+    }
+
     checkInterfaceRequirement(decl);
     checkVisibility(decl);
 }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -3848,6 +3848,11 @@ struct SemanticsStmtVisitor : public SemanticsVisitor, StmtVisitor<SemanticsStmt
 
     void visitRequireCapabilityStmt(RequireCapabilityStmt* stmt);
 
+    // If `expr` is the discarded result of a call to a `[nodiscard]` function,
+    // emit a warning. Used for any context where an expression's result is
+    // ignored (an expression statement, or a `for` loop's side-effect expression).
+    void maybeDiagnoseDiscardedNodiscardResult(Expr* expr);
+
     // Try to infer the max number of iterations the loop will run.
     void tryInferLoopMaxIterations(ForStmt* stmt);
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -3848,10 +3848,10 @@ struct SemanticsStmtVisitor : public SemanticsVisitor, StmtVisitor<SemanticsStmt
 
     void visitRequireCapabilityStmt(RequireCapabilityStmt* stmt);
 
-    // If `expr` is the discarded result of a call to a `[nodiscard]` function,
+    // If `expr` is the discarded result of a call to a `[NoDiscard]` function,
     // emit an error. Used for any context where an expression's result is
     // ignored (an expression statement, or a `for` loop's side-effect expression).
-    void maybeDiagnoseDiscardedNodiscardResult(Expr* expr);
+    void maybeDiagnoseDiscardedNoDiscardResult(Expr* expr);
 
     // Try to infer the max number of iterations the loop will run.
     void tryInferLoopMaxIterations(ForStmt* stmt);

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -3849,7 +3849,7 @@ struct SemanticsStmtVisitor : public SemanticsVisitor, StmtVisitor<SemanticsStmt
     void visitRequireCapabilityStmt(RequireCapabilityStmt* stmt);
 
     // If `expr` is the discarded result of a call to a `[nodiscard]` function,
-    // emit a warning. Used for any context where an expression's result is
+    // emit an error. Used for any context where an expression's result is
     // ignored (an expression statement, or a `for` loop's side-effect expression).
     void maybeDiagnoseDiscardedNodiscardResult(Expr* expr);
 

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -720,8 +720,11 @@ void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
     if (!invokeExpr)
         return;
 
-    // A `void`-returning function has no result to discard, so `[nodiscard]` on it never
-    // warns (matching C++ behavior).
+    // `[nodiscard]` on a `void`-returning function is already rejected at the declaration
+    // (see `NodiscardOnVoidFunction` in `checkCallableDeclCommon`). That diagnostic is an
+    // error but not fatal, so checking continues and calls to such a function still reach
+    // here; this guard suppresses an additional, nonsensical "result is discarded" warning
+    // at every call site on top of the declaration error.
     if (invokeExpr->type.type && invokeExpr->type.type->equals(m_astBuilder->getVoidType()))
         return;
 

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -700,9 +700,24 @@ void SemanticsStmtVisitor::visitExpressionStmt(ExpressionStmt* stmt)
 void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
 {
     // Peel transparent wrappers that don't change whether the result is discarded: a call
-    // wrapped in parentheses (e.g. `(t.load());`) still discards its result.
-    while (auto paren = as<ParenExpr>(expr))
-        expr = paren->base;
+    // wrapped in parentheses (`(t.load());`) or a cast (`(uint)t.load();`) still discards the
+    // call's result. A cast is a `TypeCastExpr`, which derives from `InvokeExpr`, so it must be
+    // peeled before the `InvokeExpr` check below; otherwise that check would inspect the cast's
+    // conversion decl instead of the underlying call.
+    for (;;)
+    {
+        if (auto paren = as<ParenExpr>(expr))
+        {
+            expr = paren->base;
+            continue;
+        }
+        if (auto cast = as<TypeCastExpr>(expr); cast && cast->arguments.getCount() >= 1)
+        {
+            expr = cast->arguments[0];
+            continue;
+        }
+        break;
+    }
 
     // A comma operator in a discarded context discards each of its operands, so recurse
     // into them (e.g. `for (int i = 0; i < n; t.load(), i++)` discards `t.load()`).
@@ -719,9 +734,13 @@ void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
         }
     }
 
-    // A ternary `?:` discards the result of whichever arm is selected, so recurse into both
-    // arms (e.g. `cond ? t.load() : t.compute();`). The condition is `arguments[0]`; it is
-    // consumed to choose an arm rather than discarded, so only the two arms are checked.
+    // A ternary `?:` and a short-circuiting `&&`/`||` both yield a chosen operand's result
+    // verbatim, so discarding the whole expression discards that operand's result. Recurse into
+    // the operands that can become the result:
+    //   - both arms of a ternary (`arguments[1]`/`arguments[2]`; the condition `arguments[0]` is
+    //     consumed to choose an arm, not passed through), and
+    //   - the right-hand operand of `&&`/`||` (`arguments[1]`; the left operand is consumed to
+    //     decide whether the right is evaluated, not passed through).
     if (auto select = as<SelectExpr>(expr))
     {
         if (select->arguments.getCount() == 3)
@@ -729,6 +748,12 @@ void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
             maybeDiagnoseDiscardedNodiscardResult(select->arguments[1]);
             maybeDiagnoseDiscardedNodiscardResult(select->arguments[2]);
         }
+        return;
+    }
+    if (auto shortCircuit = as<LogicOperatorShortCircuitExpr>(expr))
+    {
+        if (shortCircuit->arguments.getCount() == 2)
+            maybeDiagnoseDiscardedNodiscardResult(shortCircuit->arguments[1]);
         return;
     }
 

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -690,6 +690,24 @@ void SemanticsStmtVisitor::visitExpressionStmt(ExpressionStmt* stmt)
     }
     if (isDanglingEquality)
         getSink()->diagnose(Diagnostics::DanglingEqualityExpr{.expr = stmt->expression});
+
+    // If the discarded expression is a call to a function marked `[nodiscard]`, warn that
+    // the result is being ignored.
+    if (auto invokeExpr = as<InvokeExpr>(stmt->expression))
+    {
+        if (auto funcDeclRefExpr = as<DeclRefExpr>(invokeExpr->functionExpr))
+        {
+            if (auto calleeDecl = funcDeclRefExpr->declRef.getDecl())
+            {
+                if (calleeDecl->findModifier<NoDiscardAttribute>())
+                {
+                    getSink()->diagnose(Diagnostics::DiscardedNodiscardResult{
+                        .name = calleeDecl->getName(),
+                        .expr = invokeExpr});
+                }
+            }
+        }
+    }
 }
 
 void SemanticsStmtVisitor::visitRequireCapabilityStmt(RequireCapabilityStmt*)

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -297,7 +297,7 @@ void SemanticsStmtVisitor::visitForStmt(ForStmt* stmt)
         stmt->sideEffectExpression = subExprVisitor.CheckExpr(stmt->sideEffectExpression);
 
         // A `for` loop's side-effect expression also discards its result.
-        maybeDiagnoseDiscardedNodiscardResult(stmt->sideEffectExpression);
+        maybeDiagnoseDiscardedNoDiscardResult(stmt->sideEffectExpression);
     }
     subContext.checkStmt(stmt->statement);
 
@@ -694,29 +694,16 @@ void SemanticsStmtVisitor::visitExpressionStmt(ExpressionStmt* stmt)
     if (isDanglingEquality)
         getSink()->diagnose(Diagnostics::DanglingEqualityExpr{.expr = stmt->expression});
 
-    maybeDiagnoseDiscardedNodiscardResult(stmt->expression);
+    maybeDiagnoseDiscardedNoDiscardResult(stmt->expression);
 }
 
-void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
+void SemanticsStmtVisitor::maybeDiagnoseDiscardedNoDiscardResult(Expr* expr)
 {
     // Peel transparent wrappers that don't change whether the result is discarded: a call
-    // wrapped in parentheses (`(t.load());`) or a cast (`(uint)t.load();`) still discards the
-    // call's result. A cast is a `TypeCastExpr`, which derives from `InvokeExpr`, so it must be
-    // peeled before the `InvokeExpr` check below; otherwise that check would inspect the cast's
-    // conversion decl instead of the underlying call.
-    for (;;)
+    // wrapped in parentheses (`(t.load());`) still discards the call's result.
+    while (auto paren = as<ParenExpr>(expr))
     {
-        if (auto paren = as<ParenExpr>(expr))
-        {
-            expr = paren->base;
-            continue;
-        }
-        if (auto cast = as<TypeCastExpr>(expr); cast && cast->arguments.getCount() >= 1)
-        {
-            expr = cast->arguments[0];
-            continue;
-        }
-        break;
+        expr = paren->base;
     }
 
     // A comma operator in a discarded context discards each of its operands, so recurse
@@ -725,10 +712,10 @@ void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
     {
         if (auto func = as<VarExpr>(operatorExpr->functionExpr))
         {
-            if (func->name && func->name->text == ",")
+            if (getText(func->name) == ",")
             {
                 for (auto arg : operatorExpr->arguments)
-                    maybeDiagnoseDiscardedNodiscardResult(arg);
+                    maybeDiagnoseDiscardedNoDiscardResult(arg);
                 return;
             }
         }
@@ -745,26 +732,26 @@ void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
     {
         if (select->arguments.getCount() == 3)
         {
-            maybeDiagnoseDiscardedNodiscardResult(select->arguments[1]);
-            maybeDiagnoseDiscardedNodiscardResult(select->arguments[2]);
+            maybeDiagnoseDiscardedNoDiscardResult(select->arguments[1]);
+            maybeDiagnoseDiscardedNoDiscardResult(select->arguments[2]);
         }
         return;
     }
     if (auto shortCircuit = as<LogicOperatorShortCircuitExpr>(expr))
     {
         if (shortCircuit->arguments.getCount() == 2)
-            maybeDiagnoseDiscardedNodiscardResult(shortCircuit->arguments[1]);
+            maybeDiagnoseDiscardedNoDiscardResult(shortCircuit->arguments[1]);
         return;
     }
 
-    // If the discarded expression is a call to a function marked `[nodiscard]`, report that
+    // If the discarded expression is a call to a function marked `[NoDiscard]`, report that
     // the result is being ignored.
     auto invokeExpr = as<InvokeExpr>(expr);
     if (!invokeExpr)
         return;
 
-    // `[nodiscard]` on a `void`-returning function is already rejected at the declaration
-    // (see `NodiscardOnVoidFunction` in `checkCallableDeclCommon`). That diagnostic is an
+    // `[NoDiscard]` on a `void`-returning function is already rejected at the declaration
+    // (see `NoDiscardOnVoidFunction` in `checkCallableDeclCommon`). That diagnostic is an
     // error but not fatal, so checking continues and calls to such a function still reach
     // here; this guard suppresses an additional, nonsensical "result is discarded" error
     // at every call site on top of the declaration error.
@@ -779,9 +766,13 @@ void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
     if (!calleeDecl)
         return;
 
+    // Bare discarded construction is intentionally outside this diagnostic.
+    if (as<ConstructorDecl>(calleeDecl))
+        return;
+
     if (calleeDecl->findModifier<NoDiscardAttribute>())
     {
-        getSink()->diagnose(Diagnostics::DiscardedNodiscardResult{
+        getSink()->diagnose(Diagnostics::DiscardedNoDiscardResult{
             .name = calleeDecl->getName(),
             .expr = invokeExpr});
     }

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -699,6 +699,11 @@ void SemanticsStmtVisitor::visitExpressionStmt(ExpressionStmt* stmt)
 
 void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
 {
+    // Peel transparent wrappers that don't change whether the result is discarded: a call
+    // wrapped in parentheses (e.g. `(t.load());`) still discards its result.
+    while (auto paren = as<ParenExpr>(expr))
+        expr = paren->base;
+
     // A comma operator in a discarded context discards each of its operands, so recurse
     // into them (e.g. `for (int i = 0; i < n; t.load(), i++)` discards `t.load()`).
     if (auto operatorExpr = as<OperatorExpr>(expr))
@@ -712,6 +717,19 @@ void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
                 return;
             }
         }
+    }
+
+    // A ternary `?:` discards the result of whichever arm is selected, so recurse into both
+    // arms (e.g. `cond ? t.load() : t.compute();`). The condition is `arguments[0]`; it is
+    // consumed to choose an arm rather than discarded, so only the two arms are checked.
+    if (auto select = as<SelectExpr>(expr))
+    {
+        if (select->arguments.getCount() == 3)
+        {
+            maybeDiagnoseDiscardedNodiscardResult(select->arguments[1]);
+            maybeDiagnoseDiscardedNodiscardResult(select->arguments[2]);
+        }
+        return;
     }
 
     // If the discarded expression is a call to a function marked `[nodiscard]`, warn that

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -699,6 +699,21 @@ void SemanticsStmtVisitor::visitExpressionStmt(ExpressionStmt* stmt)
 
 void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
 {
+    // A comma operator in a discarded context discards each of its operands, so recurse
+    // into them (e.g. `for (int i = 0; i < n; t.load(), i++)` discards `t.load()`).
+    if (auto operatorExpr = as<OperatorExpr>(expr))
+    {
+        if (auto func = as<VarExpr>(operatorExpr->functionExpr))
+        {
+            if (func->name && func->name->text == ",")
+            {
+                for (auto arg : operatorExpr->arguments)
+                    maybeDiagnoseDiscardedNodiscardResult(arg);
+                return;
+            }
+        }
+    }
+
     // If the discarded expression is a call to a function marked `[nodiscard]`, warn that
     // the result is being ignored.
     auto invokeExpr = as<InvokeExpr>(expr);

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -757,7 +757,7 @@ void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
         return;
     }
 
-    // If the discarded expression is a call to a function marked `[nodiscard]`, warn that
+    // If the discarded expression is a call to a function marked `[nodiscard]`, report that
     // the result is being ignored.
     auto invokeExpr = as<InvokeExpr>(expr);
     if (!invokeExpr)
@@ -766,7 +766,7 @@ void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
     // `[nodiscard]` on a `void`-returning function is already rejected at the declaration
     // (see `NodiscardOnVoidFunction` in `checkCallableDeclCommon`). That diagnostic is an
     // error but not fatal, so checking continues and calls to such a function still reach
-    // here; this guard suppresses an additional, nonsensical "result is discarded" warning
+    // here; this guard suppresses an additional, nonsensical "result is discarded" error
     // at every call site on top of the declaration error.
     if (invokeExpr->type.type && invokeExpr->type.type->equals(m_astBuilder->getVoidType()))
         return;

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -295,6 +295,9 @@ void SemanticsStmtVisitor::visitForStmt(ForStmt* stmt)
         SemanticsContext sideEffectContext = withInForLoopSideEffect();
         SemanticsExprVisitor subExprVisitor(sideEffectContext);
         stmt->sideEffectExpression = subExprVisitor.CheckExpr(stmt->sideEffectExpression);
+
+        // A `for` loop's side-effect expression also discards its result.
+        maybeDiagnoseDiscardedNodiscardResult(stmt->sideEffectExpression);
     }
     subContext.checkStmt(stmt->statement);
 
@@ -691,22 +694,35 @@ void SemanticsStmtVisitor::visitExpressionStmt(ExpressionStmt* stmt)
     if (isDanglingEquality)
         getSink()->diagnose(Diagnostics::DanglingEqualityExpr{.expr = stmt->expression});
 
+    maybeDiagnoseDiscardedNodiscardResult(stmt->expression);
+}
+
+void SemanticsStmtVisitor::maybeDiagnoseDiscardedNodiscardResult(Expr* expr)
+{
     // If the discarded expression is a call to a function marked `[nodiscard]`, warn that
     // the result is being ignored.
-    if (auto invokeExpr = as<InvokeExpr>(stmt->expression))
+    auto invokeExpr = as<InvokeExpr>(expr);
+    if (!invokeExpr)
+        return;
+
+    // A `void`-returning function has no result to discard, so `[nodiscard]` on it never
+    // warns (matching C++ behavior).
+    if (invokeExpr->type.type && invokeExpr->type.type->equals(m_astBuilder->getVoidType()))
+        return;
+
+    auto funcDeclRefExpr = as<DeclRefExpr>(invokeExpr->functionExpr);
+    if (!funcDeclRefExpr)
+        return;
+
+    auto calleeDecl = funcDeclRefExpr->declRef.getDecl();
+    if (!calleeDecl)
+        return;
+
+    if (calleeDecl->findModifier<NoDiscardAttribute>())
     {
-        if (auto funcDeclRefExpr = as<DeclRefExpr>(invokeExpr->functionExpr))
-        {
-            if (auto calleeDecl = funcDeclRefExpr->declRef.getDecl())
-            {
-                if (calleeDecl->findModifier<NoDiscardAttribute>())
-                {
-                    getSink()->diagnose(Diagnostics::DiscardedNodiscardResult{
-                        .name = calleeDecl->getName(),
-                        .expr = invokeExpr});
-                }
-            }
-        }
+        getSink()->diagnose(Diagnostics::DiscardedNodiscardResult{
+            .name = calleeDecl->getName(),
+            .expr = invokeExpr});
     }
 }
 

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -1301,6 +1301,13 @@ warning(
 )
 
 err(
+    "nodiscard-on-void-function",
+    30069,
+    "'[nodiscard]' applied to a function returning 'void'",
+    span { loc = "decl:Decl", message = "'[nodiscard]' has no effect on a function that returns 'void'." }
+)
+
+err(
     "expected-a-type",
     30060,
     "expected a type",

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -1293,6 +1293,13 @@ warning(
     span { loc = "expr:Expr", message = "result of '==' not used, did you intend '='?" }
 )
 
+warning(
+    "discarded-nodiscard-result",
+    30059,
+    "result of '[nodiscard]' function is discarded",
+    span { loc = "expr:Expr", message = "the result of calling '~name:Name' is discarded; this function is marked '[nodiscard]'." }
+)
+
 err(
     "expected-a-type",
     30060,

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -1294,17 +1294,17 @@ warning(
 )
 
 err(
-    "discarded-nodiscard-result",
+    "discarded-no-discard-result",
     30059,
-    "result of '[nodiscard]' function is discarded",
-    span { loc = "expr:Expr", message = "the result of calling '~name:Name' is discarded; this function is marked '[nodiscard]'." }
+    "result of '[NoDiscard]' function is discarded",
+    span { loc = "expr:Expr", message = "the result of calling '~name:Name' is discarded; this function is marked '[NoDiscard]'." }
 )
 
 err(
-    "nodiscard-on-void-function",
+    "no-discard-on-void-function",
     30069,
-    "'[nodiscard]' applied to a function returning 'void'",
-    span { loc = "decl:Decl", message = "'[nodiscard]' is not allowed on a function that returns 'void'; there is no result to discard." }
+    "'[NoDiscard]' applied to a function returning 'void'",
+    span { loc = "decl:Decl", message = "'[NoDiscard]' is not allowed on a function that returns 'void'; there is no result to discard." }
 )
 
 err(

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -1293,7 +1293,7 @@ warning(
     span { loc = "expr:Expr", message = "result of '==' not used, did you intend '='?" }
 )
 
-warning(
+err(
     "discarded-nodiscard-result",
     30059,
     "result of '[nodiscard]' function is discarded",

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -1304,7 +1304,7 @@ err(
     "nodiscard-on-void-function",
     30069,
     "'[nodiscard]' applied to a function returning 'void'",
-    span { loc = "decl:Decl", message = "'[nodiscard]' has no effect on a function that returns 'void'." }
+    span { loc = "decl:Decl", message = "'[nodiscard]' is not allowed on a function that returns 'void'; there is no result to discard." }
 )
 
 err(

--- a/tests/diagnostics/nodiscard-void.slang
+++ b/tests/diagnostics/nodiscard-void.slang
@@ -1,4 +1,4 @@
-//DIAGNOSTIC_TEST:SIMPLE(diag=diag):
+//DIAGNOSTIC_TEST:SIMPLE(diag=DIAG):
 
 // `[nodiscard]` on a function that returns `void` has no result to discard,
 // so it is rejected at the declaration with an error.
@@ -9,7 +9,7 @@ struct MyType
 
     [nodiscard]
     void touch() {}
-/*diag:
+/*DIAG:
          ^^^^^ '[nodiscard]' applied to a function returning 'void'
          ^^^^^ '[nodiscard]' has no effect on a function that returns 'void'.
 */
@@ -17,7 +17,7 @@ struct MyType
 
 [nodiscard]
 void freeVoid() {}
-/*diag:
+/*DIAG:
      ^^^^^^^^ '[nodiscard]' applied to a function returning 'void'
      ^^^^^^^^ '[nodiscard]' has no effect on a function that returns 'void'.
 */

--- a/tests/diagnostics/nodiscard-void.slang
+++ b/tests/diagnostics/nodiscard-void.slang
@@ -1,0 +1,30 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=diag):
+
+// `[nodiscard]` on a function that returns `void` has no result to discard,
+// so it is rejected at the declaration with an error.
+
+struct MyType
+{
+    int val;
+
+    [nodiscard]
+    void touch() {}
+/*diag:
+         ^^^^^ '[nodiscard]' applied to a function returning 'void'
+         ^^^^^ '[nodiscard]' has no effect on a function that returns 'void'.
+*/
+}
+
+[nodiscard]
+void freeVoid() {}
+/*diag:
+     ^^^^^^^^ '[nodiscard]' applied to a function returning 'void'
+     ^^^^^^^^ '[nodiscard]' has no effect on a function that returns 'void'.
+*/
+
+[numthreads(1, 1, 1)]
+void main(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    MyType t;
+    t.val = 0;
+}

--- a/tests/diagnostics/nodiscard-void.slang
+++ b/tests/diagnostics/nodiscard-void.slang
@@ -27,4 +27,10 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     MyType t;
     t.val = 0;
+
+    // Calling a `[nodiscard]` void function adds no discard error at the call site: only the
+    // declaration error above fires. The call-site guard in `maybeDiagnoseDiscardedNodiscardResult`
+    // returns early for a `void` result, so these lines are intentionally un-annotated.
+    t.touch();
+    freeVoid();
 }

--- a/tests/diagnostics/nodiscard-void.slang
+++ b/tests/diagnostics/nodiscard-void.slang
@@ -1,25 +1,25 @@
 //DIAGNOSTIC_TEST:SIMPLE(diag=DIAG):
 
-// `[nodiscard]` on a function that returns `void` has no result to discard,
+// `[NoDiscard]` on a function that returns `void` has no result to discard,
 // so it is rejected at the declaration with an error.
 
 struct MyType
 {
     int val;
 
-    [nodiscard]
+    [NoDiscard]
     void touch() {}
 /*DIAG:
-         ^^^^^ '[nodiscard]' applied to a function returning 'void'
-         ^^^^^ '[nodiscard]' is not allowed on a function that returns 'void'; there is no result to discard.
+         ^^^^^ '[NoDiscard]' applied to a function returning 'void'
+         ^^^^^ '[NoDiscard]' is not allowed on a function that returns 'void'; there is no result to discard.
 */
 }
 
-[nodiscard]
+[NoDiscard]
 void freeVoid() {}
 /*DIAG:
-     ^^^^^^^^ '[nodiscard]' applied to a function returning 'void'
-     ^^^^^^^^ '[nodiscard]' is not allowed on a function that returns 'void'; there is no result to discard.
+     ^^^^^^^^ '[NoDiscard]' applied to a function returning 'void'
+     ^^^^^^^^ '[NoDiscard]' is not allowed on a function that returns 'void'; there is no result to discard.
 */
 
 [numthreads(1, 1, 1)]
@@ -28,8 +28,8 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     MyType t;
     t.val = 0;
 
-    // Calling a `[nodiscard]` void function adds no discard error at the call site: only the
-    // declaration error above fires. The call-site guard in `maybeDiagnoseDiscardedNodiscardResult`
+    // Calling a `[NoDiscard]` void function adds no discard error at the call site: only the
+    // declaration error above fires. The call-site guard in `maybeDiagnoseDiscardedNoDiscardResult`
     // returns early for a `void` result, so these lines are intentionally un-annotated.
     t.touch();
     freeVoid();

--- a/tests/diagnostics/nodiscard-void.slang
+++ b/tests/diagnostics/nodiscard-void.slang
@@ -11,7 +11,7 @@ struct MyType
     void touch() {}
 /*DIAG:
          ^^^^^ '[nodiscard]' applied to a function returning 'void'
-         ^^^^^ '[nodiscard]' has no effect on a function that returns 'void'.
+         ^^^^^ '[nodiscard]' is not allowed on a function that returns 'void'; there is no result to discard.
 */
 }
 
@@ -19,7 +19,7 @@ struct MyType
 void freeVoid() {}
 /*DIAG:
      ^^^^^^^^ '[nodiscard]' applied to a function returning 'void'
-     ^^^^^^^^ '[nodiscard]' has no effect on a function that returns 'void'.
+     ^^^^^^^^ '[nodiscard]' is not allowed on a function that returns 'void'; there is no result to discard.
 */
 
 [numthreads(1, 1, 1)]

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -13,11 +13,6 @@ struct MyType
     [nodiscard]
     int compute() { return val * 2; }
 
-    // `[nodiscard]` on a `void` function has no result to discard, so discarding
-    // a call to it never warns.
-    [nodiscard]
-    void touch() {}
-
     int regular() { return val; }
 }
 
@@ -66,9 +61,6 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
 */
     {
     }
-
-    // `[nodiscard]` on a `void` function does not warn even when discarded.
-    t.touch();
 
     // Storing the result is fine, no warning.
     let loaded = t.load();

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -10,9 +10,13 @@ struct MyType
     [nodiscard]
     MyType load() { MyType r; r.val = 42; return r; }
 
-    // The C++ `[[nodiscard]]` spelling is also accepted.
-    [[nodiscard]]
+    [nodiscard]
     int compute() { return val * 2; }
+
+    // `[nodiscard]` on a `void` function has no result to discard, so discarding
+    // a call to it never warns.
+    [nodiscard]
+    void touch() {}
 
     int regular() { return val; }
 }
@@ -43,6 +47,19 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
             ^ result of '[nodiscard]' function is discarded
             ^ the result of calling 'freeFunc' is discarded; this function is marked '[nodiscard]'.
 */
+
+    // The result is discarded in a `for` loop's side-effect expression too.
+    for (int i = 0; i < 1; t.load())
+/*diag:
+                                 ^ result of '[nodiscard]' function is discarded
+                                 ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
+*/
+    {
+        i++;
+    }
+
+    // `[nodiscard]` on a `void` function does not warn even when discarded.
+    t.touch();
 
     // Storing the result is fine, no warning.
     let loaded = t.load();

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -1,4 +1,4 @@
-//DIAGNOSTIC_TEST:SIMPLE(diag=diag):
+//DIAGNOSTIC_TEST:SIMPLE(diag=DIAG):
 
 // Test the `[nodiscard]` attribute: calling a function marked `[nodiscard]`
 // and discarding its result produces a warning.
@@ -26,26 +26,26 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     t.val = 0;
 
     t.load(); // warn
-/*diag:
+/*DIAG:
           ^ result of '[nodiscard]' function is discarded
           ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
 */
 
     t.compute(); // warn
-/*diag:
+/*DIAG:
              ^ result of '[nodiscard]' function is discarded
              ^ the result of calling 'compute' is discarded; this function is marked '[nodiscard]'.
 */
 
     freeFunc(); // warn
-/*diag:
+/*DIAG:
             ^ result of '[nodiscard]' function is discarded
             ^ the result of calling 'freeFunc' is discarded; this function is marked '[nodiscard]'.
 */
 
     // The result is discarded in a `for` loop's side-effect expression too.
     for (int i = 0; i < 1; t.load())
-/*diag:
+/*DIAG:
                                  ^ result of '[nodiscard]' function is discarded
                                  ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
 */
@@ -55,7 +55,7 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
 
     // The result is also discarded in a comma operand of a `for` loop side effect.
     for (int j = 0; j < 1; t.load(), j++)
-/*diag:
+/*DIAG:
                                  ^ result of '[nodiscard]' function is discarded
                                  ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
 */

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -58,6 +58,15 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
         i++;
     }
 
+    // The result is also discarded in a comma operand of a `for` loop side effect.
+    for (int j = 0; j < 1; t.load(), j++)
+/*diag:
+                                 ^ result of '[nodiscard]' function is discarded
+                                 ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
+*/
+    {
+    }
+
     // `[nodiscard]` on a `void` function does not warn even when discarded.
     t.touch();
 

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -19,6 +19,11 @@ struct MyType
 [nodiscard]
 int freeFunc() { return 1; }
 
+void consume(int x) {}
+
+// Returning the result is using it, not discarding it, so no warning.
+int useResult() { return freeFunc(); }
+
 [numthreads(1, 1, 1)]
 void main(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
@@ -68,6 +73,13 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
 
     // A function not marked `[nodiscard]` does not warn even when discarded.
     t.regular();
+
+    // Using the result in a sub-expression is not discarding it, so none of these warn:
+    // as a call argument, ...
+    consume(t.compute());
+    // ... and as an operand of a larger, non-`[nodiscard]` expression whose own result is
+    // then discarded (the `[nodiscard]` call's result is consumed by `+`, not discarded).
+    t.compute() + c;
 
     // Silence unused-variable concerns.
     t.val = loaded.val + c;

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -1,0 +1,56 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=diag):
+
+// Test the `[nodiscard]` attribute: calling a function marked `[nodiscard]`
+// and discarding its result produces a warning.
+
+struct MyType
+{
+    int val;
+
+    [nodiscard]
+    MyType load() { MyType r; r.val = 42; return r; }
+
+    // The C++ `[[nodiscard]]` spelling is also accepted.
+    [[nodiscard]]
+    int compute() { return val * 2; }
+
+    int regular() { return val; }
+}
+
+[nodiscard]
+int freeFunc() { return 1; }
+
+[numthreads(1, 1, 1)]
+void main(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    MyType t;
+    t.val = 0;
+
+    t.load(); // warn
+/*diag:
+          ^ result of '[nodiscard]' function is discarded
+          ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
+*/
+
+    t.compute(); // warn
+/*diag:
+             ^ result of '[nodiscard]' function is discarded
+             ^ the result of calling 'compute' is discarded; this function is marked '[nodiscard]'.
+*/
+
+    freeFunc(); // warn
+/*diag:
+            ^ result of '[nodiscard]' function is discarded
+            ^ the result of calling 'freeFunc' is discarded; this function is marked '[nodiscard]'.
+*/
+
+    // Storing the result is fine, no warning.
+    let loaded = t.load();
+    int c = t.compute();
+
+    // A function not marked `[nodiscard]` does not warn even when discarded.
+    t.regular();
+
+    // Silence unused-variable concerns.
+    t.val = loaded.val + c;
+}

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -24,6 +24,25 @@ void consume(int x) {}
 // Returning the result is using it, not discarding it, so no warning.
 int useResult() { return freeFunc(); }
 
+[nodiscard]
+bool check() { return true; }
+
+// `[nodiscard]` is accepted on any `FunctionDeclBase`, so it should also warn when the
+// discarded result comes from a constructor, a user-defined operator, or a generic function.
+struct Widget
+{
+    int v;
+
+    [nodiscard]
+    __init(int x) { v = x; }
+}
+
+[nodiscard]
+Widget operator+(Widget a, Widget b) { return Widget(a.v + b.v); }
+
+[nodiscard]
+T identity<T>(T x) { return x; }
+
 [numthreads(1, 1, 1)]
 void main(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
@@ -84,6 +103,46 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
                                  ^ result of '[nodiscard]' function is discarded
                                  ^ the result of calling 'freeFunc' is discarded; this function is marked '[nodiscard]'.
 */
+
+    // A cast is a transparent wrapper, so a cast-wrapped discarded call still warns.
+    (uint)freeFunc();
+/*DIAG:
+                  ^ result of '[nodiscard]' function is discarded
+                  ^ the result of calling 'freeFunc' is discarded; this function is marked '[nodiscard]'.
+*/
+
+    // Short-circuit `&&`/`||` pass their right operand through as the expression's result, so a
+    // discarded `[nodiscard]` call in that position warns. Storing the result does not warn.
+    bool stored = cond && check();
+    cond && check();
+/*DIAG:
+                 ^ result of '[nodiscard]' function is discarded
+                 ^ the result of calling 'check' is discarded; this function is marked '[nodiscard]'.
+*/
+    cond || check();
+/*DIAG:
+                 ^ result of '[nodiscard]' function is discarded
+                 ^ the result of calling 'check' is discarded; this function is marked '[nodiscard]'.
+*/
+
+    // A discarded user-defined operator result and a discarded generic-function result both warn.
+    Widget w1 = Widget(1);
+    Widget w2 = Widget(2);
+    w1 + w2;
+/*DIAG:
+       ^ result of '[nodiscard]' function is discarded
+       ^ the result of calling '+' is discarded; this function is marked '[nodiscard]'.
+*/
+    identity<int>(3);
+/*DIAG:
+                 ^ result of '[nodiscard]' function is discarded
+                 ^ the result of calling 'identity' is discarded; this function is marked '[nodiscard]'.
+*/
+
+    // A bare discarded constructor call is not flagged: the call resolves through initializer
+    // handling rather than a direct callee `DeclRef`, so `[nodiscard]` on `__init` has no effect
+    // here. (A discarded constructor call is already an obvious no-op.)
+    Widget(7);
 
     // Storing the result is fine, no warning.
     let loaded = t.load();

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -1,7 +1,7 @@
 //DIAGNOSTIC_TEST:SIMPLE(diag=DIAG):
 
 // Test the `[nodiscard]` attribute: calling a function marked `[nodiscard]`
-// and discarding its result produces a warning.
+// and discarding its result produces an error.
 
 struct MyType
 {
@@ -21,13 +21,13 @@ int freeFunc() { return 1; }
 
 void consume(int x) {}
 
-// Returning the result is using it, not discarding it, so no warning.
+// Returning the result is using it, not discarding it, so no error.
 int useResult() { return freeFunc(); }
 
 [nodiscard]
 bool check() { return true; }
 
-// `[nodiscard]` is accepted on any `FunctionDeclBase`, so it should also warn when the
+// `[nodiscard]` is accepted on any `FunctionDeclBase`, so it should also error when the
 // discarded result comes from a constructor, a user-defined operator, or a generic function.
 struct Widget
 {
@@ -57,19 +57,19 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     MyType t;
     t.val = 0;
 
-    t.load(); // warn
+    t.load(); // error
 /*DIAG:
           ^ result of '[nodiscard]' function is discarded
           ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
 */
 
-    t.compute(); // warn
+    t.compute(); // error
 /*DIAG:
              ^ result of '[nodiscard]' function is discarded
              ^ the result of calling 'compute' is discarded; this function is marked '[nodiscard]'.
 */
 
-    freeFunc(); // warn
+    freeFunc(); // error
 /*DIAG:
             ^ result of '[nodiscard]' function is discarded
             ^ the result of calling 'freeFunc' is discarded; this function is marked '[nodiscard]'.
@@ -94,14 +94,14 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     {
     }
 
-    // Parentheses are transparent: a parenthesized discarded call still warns.
+    // Parentheses are transparent: a parenthesized discarded call still errors.
     (t.load());
 /*DIAG:
            ^ result of '[nodiscard]' function is discarded
            ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
 */
 
-    // A ternary discards whichever arm is selected, so both `[nodiscard]` arms warn.
+    // A ternary discards whichever arm is selected, so both `[nodiscard]` arms error.
     // (`?:` itself is deprecated in Slang, hence the extra deprecation diagnostic.)
     bool cond = t.val > 0;
     cond ? t.compute() : freeFunc();
@@ -112,7 +112,7 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
                                  ^ the result of calling 'freeFunc' is discarded; this function is marked '[nodiscard]'.
 */
 
-    // A cast is a transparent wrapper, so a cast-wrapped discarded call still warns.
+    // A cast is a transparent wrapper, so a cast-wrapped discarded call still errors.
     (uint)freeFunc();
 /*DIAG:
                   ^ result of '[nodiscard]' function is discarded
@@ -120,7 +120,7 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
 */
 
     // Short-circuit `&&`/`||` pass their right operand through as the expression's result, so a
-    // discarded `[nodiscard]` call in that position warns. Storing the result does not warn.
+    // discarded `[nodiscard]` call in that position errors. Storing the result does not.
     bool stored = cond && check();
     cond && check();
 /*DIAG:
@@ -133,7 +133,7 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
                  ^ the result of calling 'check' is discarded; this function is marked '[nodiscard]'.
 */
 
-    // A discarded user-defined operator result and a discarded generic-function result both warn.
+    // A discarded user-defined operator result and a discarded generic-function result both error.
     Widget w1 = Widget(1);
     Widget w2 = Widget(2);
     w1 + w2;
@@ -152,25 +152,25 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     // here. (A discarded constructor call is already an obvious no-op.)
     Widget(7);
 
-    // Storing the result is fine, no warning.
+    // Storing the result is fine, no error.
     let loaded = t.load();
     int c = t.compute();
 
-    // A function not marked `[nodiscard]` does not warn even when discarded.
+    // A function not marked `[nodiscard]` does not error even when discarded.
     t.regular();
 
-    // Using the result in a sub-expression is not discarding it, so none of these warn:
+    // Using the result in a sub-expression is not discarding it, so none of these error:
     // as a call argument, ...
     consume(t.compute());
     // ... and as an operand of a larger, non-`[nodiscard]` expression whose own result is
     // then discarded (the `[nodiscard]` call's result is consumed by `+`, not discarded).
     t.compute() + c;
 
-    // The motivating case: a method with an `out` parameter that also returns a value warns when
+    // The motivating case: a method with an `out` parameter that also returns a value errors when
     // the returned value is discarded, but not when it is used.
     OutWidget ow;
     int side;
-    ow.loadWith(side); // warn
+    ow.loadWith(side); // error
 /*DIAG:
                ^ result of '[nodiscard]' function is discarded
                ^ the result of calling 'loadWith' is discarded; this function is marked '[nodiscard]'.
@@ -178,7 +178,7 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     int used = ow.loadWith(side);
 
     // Used as a control-flow predicate, the result is consumed by the condition, not discarded,
-    // so none of these warn.
+    // so none of these error.
     if (check()) {}
     while (check()) break;
     do {} while (check());

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -43,6 +43,14 @@ Widget operator+(Widget a, Widget b) { return Widget(a.v + b.v); }
 [nodiscard]
 T identity<T>(T x) { return x; }
 
+// The motivating use case: a function that has side effects via an `out` parameter but also
+// returns a result the caller is expected to consume (like `linalg::CoopMat::Load`).
+struct OutWidget
+{
+    [nodiscard]
+    int loadWith(out int sideEffect) { sideEffect = 1; return 2; }
+}
+
 [numthreads(1, 1, 1)]
 void main(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
@@ -158,6 +166,24 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     // then discarded (the `[nodiscard]` call's result is consumed by `+`, not discarded).
     t.compute() + c;
 
+    // The motivating case: a method with an `out` parameter that also returns a value warns when
+    // the returned value is discarded, but not when it is used.
+    OutWidget ow;
+    int side;
+    ow.loadWith(side); // warn
+/*DIAG:
+               ^ result of '[nodiscard]' function is discarded
+               ^ the result of calling 'loadWith' is discarded; this function is marked '[nodiscard]'.
+*/
+    int used = ow.loadWith(side);
+
+    // Used as a control-flow predicate, the result is consumed by the condition, not discarded,
+    // so none of these warn.
+    if (check()) {}
+    while (check()) break;
+    do {} while (check());
+    for (int k = 0; check(); k++) break;
+
     // Silence unused-variable concerns.
-    t.val = loaded.val + c;
+    t.val = loaded.val + c + side + used;
 }

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -67,6 +67,24 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     {
     }
 
+    // Parentheses are transparent: a parenthesized discarded call still warns.
+    (t.load());
+/*DIAG:
+           ^ result of '[nodiscard]' function is discarded
+           ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
+*/
+
+    // A ternary discards whichever arm is selected, so both `[nodiscard]` arms warn.
+    // (`?:` itself is deprecated in Slang, hence the extra deprecation diagnostic.)
+    bool cond = t.val > 0;
+    cond ? t.compute() : freeFunc();
+/*DIAG:
+                    ^ result of '[nodiscard]' function is discarded
+                    ^ the result of calling 'compute' is discarded; this function is marked '[nodiscard]'.
+                                 ^ result of '[nodiscard]' function is discarded
+                                 ^ the result of calling 'freeFunc' is discarded; this function is marked '[nodiscard]'.
+*/
+
     // Storing the result is fine, no warning.
     let loaded = t.load();
     int c = t.compute();

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -1,22 +1,22 @@
 //DIAGNOSTIC_TEST:SIMPLE(diag=DIAG):
 
-// Test the `[nodiscard]` attribute: calling a function marked `[nodiscard]`
+// Test the `[NoDiscard]` attribute: calling a function marked `[NoDiscard]`
 // and discarding its result produces an error.
 
 struct MyType
 {
     int val;
 
-    [nodiscard]
+    [NoDiscard]
     MyType load() { MyType r; r.val = 42; return r; }
 
-    [nodiscard]
+    [NoDiscard]
     int compute() { return val * 2; }
 
     int regular() { return val; }
 }
 
-[nodiscard]
+[NoDiscard]
 int freeFunc() { return 1; }
 
 void consume(int x) {}
@@ -24,31 +24,31 @@ void consume(int x) {}
 // Returning the result is using it, not discarding it, so no error.
 int useResult() { return freeFunc(); }
 
-[nodiscard]
+[NoDiscard]
 bool check() { return true; }
 
-// `[nodiscard]` is accepted on any `FunctionDeclBase`. A discarded result from a user-defined
+// `[NoDiscard]` is accepted on any `FunctionDeclBase`. A discarded result from a user-defined
 // operator or a generic function errors; a bare constructor call is a documented exception
 // (see the `Widget(7);` case in `main` below).
 struct Widget
 {
     int v;
 
-    [nodiscard]
+    [NoDiscard]
     __init(int x) { v = x; }
 }
 
-[nodiscard]
+[NoDiscard]
 Widget operator+(Widget a, Widget b) { return Widget(a.v + b.v); }
 
-[nodiscard]
+[NoDiscard]
 T identity<T>(T x) { return x; }
 
 // The motivating use case: a function that has side effects via an `out` parameter but also
 // returns a result the caller is expected to consume (like `linalg::CoopMat::Load`).
 struct OutWidget
 {
-    [nodiscard]
+    [NoDiscard]
     int loadWith(out int sideEffect) { sideEffect = 1; return 2; }
 }
 
@@ -60,27 +60,27 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
 
     t.load(); // error
 /*DIAG:
-          ^ result of '[nodiscard]' function is discarded
-          ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
+          ^ result of '[NoDiscard]' function is discarded
+          ^ the result of calling 'load' is discarded; this function is marked '[NoDiscard]'.
 */
 
     t.compute(); // error
 /*DIAG:
-             ^ result of '[nodiscard]' function is discarded
-             ^ the result of calling 'compute' is discarded; this function is marked '[nodiscard]'.
+             ^ result of '[NoDiscard]' function is discarded
+             ^ the result of calling 'compute' is discarded; this function is marked '[NoDiscard]'.
 */
 
     freeFunc(); // error
 /*DIAG:
-            ^ result of '[nodiscard]' function is discarded
-            ^ the result of calling 'freeFunc' is discarded; this function is marked '[nodiscard]'.
+            ^ result of '[NoDiscard]' function is discarded
+            ^ the result of calling 'freeFunc' is discarded; this function is marked '[NoDiscard]'.
 */
 
     // The result is discarded in a `for` loop's side-effect expression too.
     for (int i = 0; i < 1; t.load())
 /*DIAG:
-                                 ^ result of '[nodiscard]' function is discarded
-                                 ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
+                                 ^ result of '[NoDiscard]' function is discarded
+                                 ^ the result of calling 'load' is discarded; this function is marked '[NoDiscard]'.
 */
     {
         i++;
@@ -89,8 +89,8 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     // The result is also discarded in a comma operand of a `for` loop side effect.
     for (int j = 0; j < 1; t.load(), j++)
 /*DIAG:
-                                 ^ result of '[nodiscard]' function is discarded
-                                 ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
+                                 ^ result of '[NoDiscard]' function is discarded
+                                 ^ the result of calling 'load' is discarded; this function is marked '[NoDiscard]'.
 */
     {
     }
@@ -98,40 +98,36 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     // Parentheses are transparent: a parenthesized discarded call still errors.
     (t.load());
 /*DIAG:
-           ^ result of '[nodiscard]' function is discarded
-           ^ the result of calling 'load' is discarded; this function is marked '[nodiscard]'.
+           ^ result of '[NoDiscard]' function is discarded
+           ^ the result of calling 'load' is discarded; this function is marked '[NoDiscard]'.
 */
 
-    // A ternary discards whichever arm is selected, so both `[nodiscard]` arms error.
+    // A ternary discards whichever arm is selected, so both `[NoDiscard]` arms error.
     // (`?:` itself is deprecated in Slang, hence the extra deprecation diagnostic.)
     bool cond = t.val > 0;
     cond ? t.compute() : freeFunc();
 /*DIAG:
-                    ^ result of '[nodiscard]' function is discarded
-                    ^ the result of calling 'compute' is discarded; this function is marked '[nodiscard]'.
-                                 ^ result of '[nodiscard]' function is discarded
-                                 ^ the result of calling 'freeFunc' is discarded; this function is marked '[nodiscard]'.
+                    ^ result of '[NoDiscard]' function is discarded
+                    ^ the result of calling 'compute' is discarded; this function is marked '[NoDiscard]'.
+                                 ^ result of '[NoDiscard]' function is discarded
+                                 ^ the result of calling 'freeFunc' is discarded; this function is marked '[NoDiscard]'.
 */
 
-    // A cast is a transparent wrapper, so a cast-wrapped discarded call still errors.
+    // A cast is a use of the result, so a cast-wrapped call does not error.
     (uint)freeFunc();
-/*DIAG:
-                  ^ result of '[nodiscard]' function is discarded
-                  ^ the result of calling 'freeFunc' is discarded; this function is marked '[nodiscard]'.
-*/
 
     // Short-circuit `&&`/`||` pass their right operand through as the expression's result, so a
-    // discarded `[nodiscard]` call in that position errors. Storing the result does not.
+    // discarded `[NoDiscard]` call in that position errors. Storing the result does not.
     bool stored = cond && check();
     cond && check();
 /*DIAG:
-                 ^ result of '[nodiscard]' function is discarded
-                 ^ the result of calling 'check' is discarded; this function is marked '[nodiscard]'.
+                 ^ result of '[NoDiscard]' function is discarded
+                 ^ the result of calling 'check' is discarded; this function is marked '[NoDiscard]'.
 */
     cond || check();
 /*DIAG:
-                 ^ result of '[nodiscard]' function is discarded
-                 ^ the result of calling 'check' is discarded; this function is marked '[nodiscard]'.
+                 ^ result of '[NoDiscard]' function is discarded
+                 ^ the result of calling 'check' is discarded; this function is marked '[NoDiscard]'.
 */
 
     // A discarded user-defined operator result and a discarded generic-function result both error.
@@ -139,17 +135,17 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     Widget w2 = Widget(2);
     w1 + w2;
 /*DIAG:
-       ^ result of '[nodiscard]' function is discarded
-       ^ the result of calling '+' is discarded; this function is marked '[nodiscard]'.
+       ^ result of '[NoDiscard]' function is discarded
+       ^ the result of calling '+' is discarded; this function is marked '[NoDiscard]'.
 */
     identity<int>(3);
 /*DIAG:
-                 ^ result of '[nodiscard]' function is discarded
-                 ^ the result of calling 'identity' is discarded; this function is marked '[nodiscard]'.
+                 ^ result of '[NoDiscard]' function is discarded
+                 ^ the result of calling 'identity' is discarded; this function is marked '[NoDiscard]'.
 */
 
     // A bare discarded constructor call is not flagged: the call resolves through initializer
-    // handling rather than a direct callee `DeclRef`, so `[nodiscard]` on `__init` has no effect
+    // handling rather than a direct callee `DeclRef`, so `[NoDiscard]` on `__init` has no effect
     // here. (A discarded constructor call is already an obvious no-op.)
     Widget(7);
 
@@ -157,14 +153,14 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     let loaded = t.load();
     int c = t.compute();
 
-    // A function not marked `[nodiscard]` does not error even when discarded.
+    // A function not marked `[NoDiscard]` does not error even when discarded.
     t.regular();
 
     // Using the result in a sub-expression is not discarding it, so none of these error:
     // as a call argument, ...
     consume(t.compute());
-    // ... and as an operand of a larger, non-`[nodiscard]` expression whose own result is
-    // then discarded (the `[nodiscard]` call's result is consumed by `+`, not discarded).
+    // ... and as an operand of a larger, non-`[NoDiscard]` expression whose own result is
+    // then discarded (the `[NoDiscard]` call's result is consumed by `+`, not discarded).
     t.compute() + c;
 
     // The motivating case: a method with an `out` parameter that also returns a value errors when
@@ -173,8 +169,8 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     int side;
     ow.loadWith(side); // error
 /*DIAG:
-               ^ result of '[nodiscard]' function is discarded
-               ^ the result of calling 'loadWith' is discarded; this function is marked '[nodiscard]'.
+               ^ result of '[NoDiscard]' function is discarded
+               ^ the result of calling 'loadWith' is discarded; this function is marked '[NoDiscard]'.
 */
     int used = ow.loadWith(side);
 

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -112,6 +112,9 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
                                  ^ result of '[NoDiscard]' function is discarded
                                  ^ the result of calling 'freeFunc' is discarded; this function is marked '[NoDiscard]'.
 */
+    // The condition of a ternary is consumed to choose an arm, not discarded, so a
+    // `[NoDiscard]` call in that position does not error.
+    check() ? true : false;
 
     // A cast is a use of the result, so a cast-wrapped call does not error.
     (uint)freeFunc();
@@ -129,6 +132,10 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
                  ^ result of '[NoDiscard]' function is discarded
                  ^ the result of calling 'check' is discarded; this function is marked '[NoDiscard]'.
 */
+    // The left operand is consumed to decide whether the right operand is evaluated, so a
+    // `[NoDiscard]` call on the left does not error.
+    check() && cond;
+    check() || cond;
 
     // A discarded user-defined operator result and a discarded generic-function result both error.
     Widget w1 = Widget(1);

--- a/tests/diagnostics/nodiscard.slang
+++ b/tests/diagnostics/nodiscard.slang
@@ -27,8 +27,9 @@ int useResult() { return freeFunc(); }
 [nodiscard]
 bool check() { return true; }
 
-// `[nodiscard]` is accepted on any `FunctionDeclBase`, so it should also error when the
-// discarded result comes from a constructor, a user-defined operator, or a generic function.
+// `[nodiscard]` is accepted on any `FunctionDeclBase`. A discarded result from a user-defined
+// operator or a generic function errors; a bare constructor call is a documented exception
+// (see the `Widget(7);` case in `main` below).
 struct Widget
 {
     int v;


### PR DESCRIPTION
Fixes #11454

## Motivation

Some Slang member functions look like they mutate the object they are called on but actually return the value the caller needs. The motivating case is a cooperative-matrix-style load such as:

```slang
linalg::CoopMat<...> matA;
matA.Load<...>(...); // The returned value is the loaded matrix value.
```

Without an attribute that marks the return value as significant, discarding that result is accepted silently even when it is likely a bug.

## Proposed solution

Add an opt-in `[NoDiscard]` function attribute for ordinary value-returning callables. When a marked call is evaluated only for side effects and its result is discarded, semantic checking emits E30059. Applying `[NoDiscard]` to a `void`-returning function emits E30069 at the declaration, because a `void` function has no result to preserve.

This is implemented as a frontend semantic check rather than an IR or backend rule: the property belongs to the source callable declaration and the discard decision is visible while checking statement expressions.

## Change summary

- `source/slang/core.meta.slang:4551` declares `attribute_syntax [NoDiscard] : NoDiscardAttribute` on `FunctionDeclBase` and documents the source-level behavior.
- `source/slang/slang-ast-modifier.h:1396` adds the `NoDiscardAttribute` AST modifier node.
- `source/slang/slang-diagnostics.lua:1296` adds E30059 for discarded marked results, and `source/slang/slang-diagnostics.lua:1303` adds E30069 for marking `void`-returning functions.
- `source/slang/slang-check-impl.h:3731` declares `SemanticsStmtVisitor::maybeDiagnoseDiscardedNoDiscardResult`.
- `source/slang/slang-check-stmt.cpp:692` calls the helper for expression statements, and `source/slang/slang-check-stmt.cpp:300` calls it for `for` loop side-effect expressions.
- `source/slang/slang-check-stmt.cpp:695` implements the discard checker: it peels parenthesized calls, recurses through comma operands, both ternary arms, and the right operand of short-circuiting `&&`/`||`, skips `void`-typed invokes and constructor calls, and diagnoses calls whose resolved callee carries `NoDiscardAttribute`.
- `source/slang/slang-check-decl.cpp:14641` rejects `[NoDiscard]` on a `void`-returning callable.
- `tests/diagnostics/nodiscard.slang:61` covers discarded calls, parentheses and pass-through operand cases, user operators, generics, the out-parameter motivating shape, cast-use non-errors, stored-result non-errors, and predicate-use non-errors.
- `tests/diagnostics/nodiscard-void.slang:10` covers the declaration-time `void` rejection and `tests/diagnostics/nodiscard-void.slang:31` documents that those invalid calls do not also produce discard errors.

## Concepts and vocabulary

- Discarded context: a source position where the expression is checked and executed only for side effects, so its final value is ignored. This PR handles expression statements and `for` loop side-effect expressions.
- Transparent wrapper: a parenthesized expression (`ParenExpr`) whose result is just the wrapped call result for the purpose of discard checking.
- Pass-through operand: an operand position whose value can become the value of the enclosing expression, such as comma operands, ternary arms, or the right operand of a short-circuiting boolean expression.
- `FunctionDeclBase`: the declaration family used here so `[NoDiscard]` can apply to free functions, methods, constructors, operators, and generic functions.

## Process report

The attribute target is declared on `FunctionDeclBase` because the feature is about callable results, not storage or type declarations. That target lets the parser and AST represent `[NoDiscard]` uniformly through `NoDiscardAttribute` in `source/slang/slang-ast-modifier.h:1396`, while the actual meaning is enforced where callable declarations and call expressions are already checked.

The declaration-time `void` rejection sits in `SemanticsDeclHeaderVisitor::checkCallableDeclCommon` at `source/slang/slang-check-decl.cpp:14641`, next to other callable return-type validation. This is the right layer because the invalid shape is independent of any call site: a `void` callable cannot ever produce a result that a caller should preserve.

The call-site diagnostic is shared through `SemanticsStmtVisitor::maybeDiagnoseDiscardedNoDiscardResult` at `source/slang/slang-check-stmt.cpp:695`. Both supported discarded contexts call the same helper: `visitExpressionStmt` at `source/slang/slang-check-stmt.cpp:692` and `visitForStmt` at `source/slang/slang-check-stmt.cpp:300`. Keeping one helper avoids diverging behavior between `f();` and `for (...; ...; f())`.

The helper handles only input shapes whose enclosing expression actually discards a callable result. Parentheses are peeled because `(t.load());` still discards the call result. Explicit casts are not peeled: `(uint)freeFunc();` is treated as using the result to form a cast value. Comma operands are all checked because the comma expression discards intermediate operands in a discarded context. Ternary arms are checked because either arm may become the discarded result; the condition is not checked because it is consumed to choose an arm. For short-circuiting `&&` and `||`, only the right operand is checked because the left operand is consumed to decide whether the right operand is evaluated.

The helper also returns early for `void`-typed invokes at `source/slang/slang-check-stmt.cpp:753`. That guards against duplicate diagnostics after E30069: semantic checking can continue after the declaration error, but a call to an invalid `void` `[NoDiscard]` function should not also say that a nonexistent result was discarded. It also skips `ConstructorDecl` calls at `source/slang/slang-check-stmt.cpp:765`, keeping bare discarded construction outside this diagnostic.

The tests encode the motivating behavior and boundaries. `tests/diagnostics/nodiscard.slang:61` starts with direct member and free-function discarded calls, then covers `for` side effects, comma, parentheses, ternary arms, casts as non-errors, short-circuit RHS, operator overloads, generics, constructors as non-errors, and out-parameter methods. `tests/diagnostics/nodiscard.slang:153` and `tests/diagnostics/nodiscard.slang:181` cover non-errors where the result is stored or consumed as a predicate. `tests/diagnostics/nodiscard-void.slang:10` covers declaration-time rejection, while `tests/diagnostics/nodiscard-void.slang:31` protects the no-duplicate-call-site-diagnostic behavior.

This PR is intentionally scoped to the attribute mechanism. It does not annotate standard-library or core-module APIs yet, so it will not newly fail existing cooperative-matrix tests. It also leaves broader follow-ups out of scope, including interface-conformance carry-through, property accessor behavior, `TryExpr` peeling, vector boolean operator shapes, and user-guide documentation.

## Reviewer Directives (maintained by agent)

- [human @jkwak-work] Discarding a `[NoDiscard]` result is an **error** (E30059), not a warning — chosen deliberately; easy to relax to a warning later. ([comment](https://github.com/shader-slang/slang/pull/11520#discussion_r3360226))
- [human @jkwak-work] `[NoDiscard]` on a `void`-returning function is an **error** (E30069), reported at the declaration — chosen over a warning/no-op; easy to relax later. ([comment](https://github.com/jkwak-work/slang/pull/245#discussion_r3356392886))
- [human @jkwak-work] `[NoDiscard]` on a `void`-returning function intentionally does not warn — a `void` call has no result to discard. ([comment](https://github.com/jkwak-work/slang/pull/245#discussion_r3356392886))
- [human @jkwak-work] Do not mention the C++ `[[nodiscard]]` double-bracket spelling in the attribute docs or tests. ([comment](https://github.com/jkwak-work/slang/pull/245#discussion_r3356395692))
- [human @csyonghe] Use the `[NoDiscard]` source spelling/naming convention. ([comment](https://github.com/shader-slang/slang/pull/11520#discussion_r3399542618))
- [human @csyonghe] Do not treat cast-wrapped calls as discarded; a cast is considered a valid use of a `[NoDiscard]` result. ([comment](https://github.com/shader-slang/slang/pull/11520#discussion_r3399560511))
- [LLM gemini-code-assist] The `[NoDiscard]` discard check must cover every discarded-expression context — both `ExpressionStmt::expression` and `ForStmt::sideEffectExpression` — via the shared helper. ([comment](https://github.com/jkwak-work/slang/pull/245#discussion_r3353271943))
- [LLM github-actions] The discard check peels parenthesized calls and recurses into pass-through operands (comma, both ternary arms, the right operand of short-circuiting `&&`/`||`); only the right operand of `&&`/`||` is checked, since the left operand is consumed to decide evaluation. Explicit casts are uses of the result, not transparent wrappers.
- [LLM github-actions] A bare discarded constructor call is intentionally **not** flagged; interface-conformance carry-through is out of scope for this PR.
- [LLM github-actions] `[NoDiscard]` on a property accessor/setter is intentionally a silent no-op for this PR (the decl-level void error does not run for accessors and accessors are not called as a top-level `InvokeExpr`). Narrowing the attribute target or extending the void-check to accessors is out of scope; the attribute targets ordinary value-returning functions/methods.
- [LLM github-actions] Discarded calls wrapped in `TryExpr` (`try foo();` for a `throws` function) are intentionally not flagged in this PR; extending the wrapper-peel loop to `TryExpr` is a reasonable follow-up but wrapper coverage is deliberately held to parentheses here. A vector `&&`/`||` that stays an `InvokeExpr` rather than a `LogicOperatorShortCircuitExpr` is also out of scope for this PR.
- [LLM github-actions] User-guide documentation for `[NoDiscard]` (a `docs/user-guide/03-convenience-features.md` subsection alongside `[mutating]`) is a recommended follow-up, deferred to the PR author; the attribute is documented here via its `core.meta.slang` doc comment.
