### PR TITLE
Check [require] capabilities on user-defined derivative functions

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -19587,6 +19587,30 @@ void SemanticsDeclCapabilityVisitor::visitContainerDecl(ContainerDecl* decl)
     decl->inferredCapabilityRequirements = getDeclaredCapabilitySet(decl).freeze(getASTBuilder());
 }
 
+// A `[ForwardDerivative(fn)]` / `[BackwardDerivative(fn)]` attribute references a
+// user-defined derivative function `fn` that is not part of the decorated function's
+// body, so its capability requirements would otherwise be ignored. Resolve the
+// referenced function decl from the (already checked) attribute `funcExpr` so the
+// caller can propagate its capability requirements onto the primal function.
+static FunctionDeclBase* _getUserDefinedDerivativeFuncDecl(UserDefinedDerivativeAttribute* attr)
+{
+    Expr* expr = attr->funcExpr;
+    // The derivative reference may be wrapped in generic-application or
+    // higher-order-invoke nodes; dig down to the underlying decl reference.
+    for (;;)
+    {
+        if (auto genericApp = as<GenericAppExpr>(expr))
+            expr = genericApp->functionExpr;
+        else if (auto higherOrder = as<HigherOrderInvokeExpr>(expr))
+            expr = higherOrder->baseFunction;
+        else
+            break;
+    }
+    if (auto declRefExpr = as<DeclRefExpr>(expr))
+        return as<FunctionDeclBase>(declRefExpr->declRef.getDecl());
+    return nullptr;
+}
+
 void SemanticsDeclCapabilityVisitor::visitFunctionDeclBase(FunctionDeclBase* funcDecl)
 {
     setParentFuncOfVisitor(funcDecl);
@@ -19618,6 +19642,33 @@ void SemanticsDeclCapabilityVisitor::visitFunctionDeclBase(FunctionDeclBase* fun
         { _propagateRequirement(this, mutableFuncDeclCapSet, funcDecl, node, nodeCaps, refLoc); },
         [this, funcDecl](DiagnosticCategory category)
         { _propagateSeeDefinitionOf(this, funcDecl, category); });
+
+    // A user-defined forward/backward derivative function is invoked when this
+    // function is differentiated, so its capability requirements must also be
+    // reflected on this function. These references live on attributes rather than
+    // in the function body, so propagate them explicitly here.
+    for (auto attr : funcDecl->getModifiersOfType<UserDefinedDerivativeAttribute>())
+    {
+        if (auto derivativeFuncDecl = _getUserDefinedDerivativeFuncDecl(attr))
+        {
+            ensureDecl(derivativeFuncDecl, DeclCheckState::CapabilityChecked);
+            // Point the provenance note at the referenced derivative function
+            // inside the attribute (e.g. the 'foo' in [BackwardDerivative(foo)])
+            // rather than the whole attribute, since that is what the user needs
+            // to fix. Fall back to the attribute location if the reference has
+            // no valid location.
+            SourceLoc refLoc = attr->funcExpr ? attr->funcExpr->loc : SourceLoc();
+            if (!refLoc.isValid())
+                refLoc = attr->loc;
+            _propagateRequirement(
+                this,
+                mutableFuncDeclCapSet,
+                funcDecl,
+                derivativeFuncDecl,
+                derivativeFuncDecl->inferredCapabilityRequirements,
+                refLoc);
+        }
+    }
 
     // non-static function join's capabilities with parent
     // to become a superset of the parent.

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -2443,7 +2443,7 @@ warning(
     "special-type-member-leaks-from-parameter-group",
     31107,
     "This member cannot be included in the same binding as some other parts of this struct, and will be moved into another parameter binding slot.",
-    span { loc = "member:IRInst", message = "This member will leak into a separate binding slot." }
+    span { loc = "location", message = "This member will leak into a separate binding slot." }
 )
 
 err(

--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -534,10 +534,19 @@ static void checkConstructor(IRFunc* func, ReachabilityContext& reachability, Di
             printDiagnosticArg(fieldNameSb, field->getKey());
             if (synthesized)
             {
+                // The field key's source location can be empty (e.g. when the
+                // struct definition comes from a linked module). Fall back to
+                // the struct type's location and then the constructor function
+                // so the warning always points somewhere meaningful.
+                SourceLoc loc = field->getKey()->sourceLoc;
+                if (!loc.isValid())
+                    loc = stype->sourceLoc;
+                if (!loc.isValid())
+                    loc = func->sourceLoc;
                 sink->diagnose(Diagnostics::FieldNotDefaultInitialized{
                     .typeName = typeNameSb.produceString(),
                     .fieldName = fieldNameSb.produceString(),
-                    .location = field->getKey()->sourceLoc,
+                    .location = loc,
                 });
             }
             else

--- a/source/slang/slang-legalize-types.cpp
+++ b/source/slang/slang-legalize-types.cpp
@@ -1237,8 +1237,14 @@ LegalType legalizeTypeImpl(TypeLegalizationContext* context, IRType* type)
             if (legalElementType.flavor == LegalType::Flavor::pair &&
                 as<IRConstantBufferType>(type))
             {
-                context->m_sink->diagnose(Diagnostics::SpecialTypeLeaksFromParameterGroup{
-                    .location = findFirstUseLoc(type)});
+                // The parameter group type's source location can be empty
+                // (e.g. when it comes from a linked module). Fall back to the
+                // location of the first use so the warning always points
+                // somewhere meaningful.
+                SourceLoc groupLoc = findFirstUseLoc(type);
+
+                context->m_sink->diagnose(
+                    Diagnostics::SpecialTypeLeaksFromParameterGroup{.location = groupLoc});
 
                 // indicate which elements cannot be part of the parameter group
                 auto& specialType = legalElementType.getPair()->specialType;
@@ -1247,9 +1253,15 @@ LegalType legalizeTypeImpl(TypeLegalizationContext* context, IRType* type)
                     auto specialTuple = specialType.getTuple();
                     for (auto specialElement : specialTuple->elements)
                     {
+                        // The member key's location may be empty; fall back to
+                        // the parameter group location computed above.
+                        SourceLoc memberLoc =
+                            specialElement.key ? specialElement.key->sourceLoc : SourceLoc();
+                        if (!memberLoc.isValid())
+                            memberLoc = groupLoc;
                         context->m_sink->diagnose(
                             Diagnostics::SpecialTypeMemberLeaksFromParameterGroup{
-                                .member = specialElement.key});
+                                .location = memberLoc});
                     }
                 }
             }

--- a/tests/diagnostics/parameter-group-special-type-leak-location-cross-module.slang
+++ b/tests/diagnostics/parameter-group-special-type-leak-location-cross-module.slang
@@ -1,0 +1,41 @@
+// Cross-module regression test for https://github.com/shader-slang/slang/issues/11395
+//
+// When the struct wrapped in a `ConstantBuffer<>` comes from a *precompiled*
+// module, the member/field keys lose their source locations. This exercises
+// the source-location fallback chains added for E31106 / E31107: the member
+// location (E31107) falls back to the parameter-group location, and the group
+// location (E31106) falls back to the first-use location. Without those
+// fallbacks the warnings would be emitted with no source location at all
+// (the original bug).
+//
+// Precompile the helper to a module, then compile this file referencing it.
+
+//TEST:COMPILE: tests/diagnostics/parameter-group-special-type-leak-location-helper.slang -o tests/diagnostics/parameter-group-special-type-leak-location-helper.slang-module
+//TEST:SIMPLE(filecheck=CHECK): -r tests/diagnostics/parameter-group-special-type-leak-location-helper.slang-module -target spirv -entry computeMain -stage compute -o out.spv
+
+import "parameter-group-special-type-leak-location-helper";
+
+// The group-level warning (E31106) must carry a valid source location. The
+// parameter-group type comes from the precompiled module, so the location
+// falls back to the first use, which is the `cb` declaration below.
+//CHECK: warning{{.*}}E31106
+//CHECK-NEXT: parameter-group-special-type-leak-location-cross-module.slang:23:
+ConstantBuffer<Mixed> cb;
+
+RWStructuredBuffer<float4> buf;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    buf[0] = cb.color;
+}
+
+// Each leaking member emits E31107. Because the member keys come from the
+// precompiled module (no source loc), the location falls back to the parameter
+// group location above. The important regression check is that a valid
+// location is present at all, rather than the location-less warnings in #11395.
+//CHECK: warning{{.*}}E31107
+//CHECK-NEXT: parameter-group-special-type-leak-location-cross-module.slang:23:
+//CHECK: warning{{.*}}E31107
+//CHECK-NEXT: parameter-group-special-type-leak-location-cross-module.slang:23:

--- a/tests/diagnostics/parameter-group-special-type-leak-location-helper.slang
+++ b/tests/diagnostics/parameter-group-special-type-leak-location-helper.slang
@@ -1,0 +1,18 @@
+// Helper module for parameter-group-special-type-leak-location.slang.
+//
+// `Mixed` mixes ordinary data (float4) with resource types (Texture2D,
+// SamplerState). When wrapped in a `ConstantBuffer<>` at the import site, the
+// resource members "leak" out of the parameter group, triggering E31106 /
+// E31107. Because the struct (and its field keys) are defined in this separate
+// module, their source locations are not available at the point the warning is
+// emitted in the importing module, which exercises the source-location
+// fallback chains.
+
+module "parameter-group-special-type-leak-location-helper";
+
+public struct Mixed
+{
+    public float4 color;
+    public Texture2D tex;
+    public SamplerState samp;
+}

--- a/tests/diagnostics/parameter-group-special-type-leak-location.slang
+++ b/tests/diagnostics/parameter-group-special-type-leak-location.slang
@@ -1,0 +1,28 @@
+// Regression test for https://github.com/shader-slang/slang/issues/11395
+//
+// Warnings E31106 / E31107 (special types leaking out of a parameter group)
+// must carry a source location pointing at the offending member / parameter
+// group, rather than being emitted with no location.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive): -target spirv -entry computeMain
+
+struct Mixed
+{
+    float4 color;
+    Texture2D tex;
+//CHECK:      ^^^ warning E31107
+    SamplerState samp;
+//CHECK:         ^^^^ warning E31107
+}
+
+ConstantBuffer<Mixed> cb;
+//CHECK:              ^^ warning E31106
+
+RWStructuredBuffer<float4> buf;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    buf[0] = cb.color;
+}

--- a/tests/diagnostics/require-on-user-defined-derivative.slang
+++ b/tests/diagnostics/require-on-user-defined-derivative.slang
@@ -1,0 +1,109 @@
+// Regression test for https://github.com/shader-slang/slang/issues/8144
+//
+// A `[require(...)]` capability attribute on a user-defined derivative
+// function must be honored: when the primal function (which references the
+// derivative through a `[ForwardDerivative]` / `[BackwardDerivative]`
+// attribute) is used on a target that does not provide the required
+// capability, compilation should fail with E36107. The provenance notes
+// should point at the derivative reference inside the attribute.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive): -target hlsl -entry computeMain -stage compute
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECKFWD,non-exhaustive): -target hlsl -entry computeMainFwd -stage compute
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECKGEN,non-exhaustive): -target hlsl -entry computeMainGen -stage compute
+// Positive counter-test: on a target that DOES provide the `spirv` capability,
+// the same primal must compile with no E36107, proving the propagation only
+// fires when the required capability is actually missing.
+//TEST:SIMPLE(filecheck=CHECKOK): -target spirv-asm -entry computeMain -stage compute
+
+//TEST_INPUT:ubuffer(data=[0], stride=16):out
+RWStructuredBuffer<float> outputBuffer;
+
+// --- Backward-derivative variant ---
+
+[require(spirv)]
+void testABwd(inout DifferentialPair<float> x, float result)
+{
+    x = {x.p, 0};
+}
+
+// The provenance note must point at the derivative reference inside the
+// attribute (the function name), not the whole attribute.
+[BackwardDerivative(testABwd)]
+//CHECK:            ^^^^^^^^ see using of 'testABwd'
+float testA(float x)
+{
+    return x * 2;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+/*CHECK:
+     ^^^^^^^^^^^ error E36107
+*/
+{
+    // Calling the primal pulls in the capability requirements of its
+    // user-defined backward derivative, which requires `spirv` and is therefore
+    // unavailable for the `hlsl` target.
+    outputBuffer[0] = testA(2.0);
+}
+
+// --- Forward-derivative variant (issue #8144 explicitly mentions this case) ---
+
+[require(spirv)]
+DifferentialPair<float> testBFwd(DifferentialPair<float> x)
+{
+    return DifferentialPair<float>(x.p * 2, x.d * 2);
+}
+
+[ForwardDerivative(testBFwd)]
+//CHECKFWD:        ^^^^^^^^ see using of 'testBFwd'
+float testB(float x)
+{
+    return x * 2;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMainFwd(uint3 dispatchThreadID : SV_DispatchThreadID)
+/*CHECKFWD:
+     ^^^^^^^^^^^^^^ error E36107
+*/
+{
+    outputBuffer[0] = testB(2.0);
+}
+
+// --- Generic-derivative variant ---
+//
+// The derivative reference is wrapped in a generic application
+// (`testCBwd<float>`), which exercises the `GenericAppExpr` stripping in
+// `_getUserDefinedDerivativeFuncDecl`. The capability requirement must still be
+// propagated and the provenance note must point at the generic function name.
+
+[require(spirv)]
+void testCBwd<T : __BuiltinFloatingPointType>(inout DifferentialPair<T> x, T.Differential result)
+{
+    x = diffPair(x.p, result);
+}
+
+[BackwardDerivative(testCBwd<float>)]
+//CHECKGEN:         ^^^^^^^^ see using of 'testCBwd'
+float testC(float x)
+{
+    return x * 2;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMainGen(uint3 dispatchThreadID : SV_DispatchThreadID)
+/*CHECKGEN:
+     ^^^^^^^^^^^^^^ error E36107
+*/
+{
+    outputBuffer[0] = testC(2.0);
+}
+
+// On the `spirv` target the requirement is satisfied, so `computeMain`
+// compiles to SPIR-V and no capability error is reported.
+//CHECKOK: OpEntryPoint
+//CHECKOK-NOT: E36107


### PR DESCRIPTION
## Summary

Addresses #8144.

A `[ForwardDerivative(fn)]` / `[BackwardDerivative(fn)]` attribute references a user-defined derivative function that is invoked when the decorated (primal) function is differentiated. Because that reference lives on an attribute rather than in the function body, the derivative's capability requirements (e.g. `[require(spirv)]`) were never propagated to callers. As a result, using the primal on a target that lacks the required capability compiled silently instead of erroring.

- Propagate capability requirements from `[ForwardDerivative(...)]` / `[BackwardDerivative(...)]` referenced functions onto the primal during `SemanticsDeclCapabilityVisitor::visitFunctionDeclBase`, so unsupported targets now fail with `E36107`.
- The provenance note points at the referenced derivative function inside the attribute (using `attr->funcExpr->loc`, falling back to `attr->loc`), so the user is pointed at the function name they need to fix.

## Scope / follow-up

The inverse attribute placement (`[ForwardDerivativeOf]` / `[BackwardDerivativeOf]` on the derivative itself) is **not** covered here — that case involves pass-ordering between the capability visitor and the differential-attributes visitor. It is out of scope for #8144 (whose reproducer uses the attribute-on-primal form) and is tracked separately in #11551.

## Stacking

This PR is stacked on top of #11523 (source-location fix for #11395), so its diff transitively includes that change. The overlapping files (`slang-diagnostics.lua`, `slang-ir-use-uninitialized-values.cpp`, `slang-legalize-types.cpp`, `parameter-group-special-type-leak-location.slang`) belong to #11523 and will disappear from this diff once #11523 merges.

## Test plan

- [x] New test `tests/diagnostics/require-on-user-defined-derivative.slang` exercises both `[BackwardDerivative]` and `[ForwardDerivative]` placements and asserts `E36107` plus the provenance note location.
- [ ] CI passes

Closes #8144