### PR TITLE
Shader coverage: boolean coverage mode (-trace-coverage-boolean)

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -321,7 +321,7 @@ Instrument the shader with per-branch-arm coverage counters for if/else, loop-co
 
 <a id="trace-coverage-boolean"></a>
 ### -trace-coverage-boolean
-Record boolean coverage instead of exact execution counts: each counter slot is set to 1 (via a plain non-atomic store) the first time its entry executes, rather than atomically incremented per execution. This removes all atomic contention, so coverage is dramatically faster and avoids the GPU watchdog timeouts that heavy per-execution counting can trigger, at the cost of exact counts (the counter is 0 or non-zero). Off by default. Ignored when no coverage mode is enabled. 
+Record boolean coverage instead of exact execution counts: each counter slot is written with 1 (via a plain non-atomic store) whenever its entry executes, rather than atomically incremented per execution. This removes all atomic contention, so coverage is dramatically faster and avoids the GPU watchdog timeouts that heavy per-execution counting can trigger, at the cost of exact counts (the counter is 0 or non-zero). Off by default. Ignored when no coverage mode is enabled. 
 
 
 <a id="trace-coverage-binding"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -319,9 +319,9 @@ Instrument the shader with per-function-entry coverage counters. Shares the synt
 Instrument the shader with per-branch-arm coverage counters for if/else, loop-condition, switch case/default arms, and switch no-match default paths. Expression-level short-circuit and ternary branches are not instrumented by this mode yet. Shares the synthesized `__slang_coverage` buffer and coverage metadata path. 
 
 
-<a id="trace-coverage-hit-miss"></a>
-### -trace-coverage-hit-miss
-Record hit/miss coverage instead of exact execution counts: each counter slot is set to 1 (via a plain non-atomic store) the first time its entry executes, rather than atomically incremented per execution. This removes all atomic contention, so coverage is dramatically faster and avoids the GPU watchdog timeouts that heavy per-execution counting can trigger, at the cost of exact counts (the counter is 0 or non-zero). Off by default. Ignored when no coverage mode is enabled. 
+<a id="trace-coverage-boolean"></a>
+### -trace-coverage-boolean
+Record boolean coverage instead of exact execution counts: each counter slot is set to 1 (via a plain non-atomic store) the first time its entry executes, rather than atomically incremented per execution. This removes all atomic contention, so coverage is dramatically faster and avoids the GPU watchdog timeouts that heavy per-execution counting can trigger, at the cost of exact counts (the counter is 0 or non-zero). Off by default. Ignored when no coverage mode is enabled. 
 
 
 <a id="trace-coverage-binding"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -319,6 +319,11 @@ Instrument the shader with per-function-entry coverage counters. Shares the synt
 Instrument the shader with per-branch-arm coverage counters for if/else, loop-condition, switch case/default arms, and switch no-match default paths. Expression-level short-circuit and ternary branches are not instrumented by this mode yet. Shares the synthesized `__slang_coverage` buffer and coverage metadata path. 
 
 
+<a id="trace-coverage-hit-miss"></a>
+### -trace-coverage-hit-miss
+Record hit/miss coverage instead of exact execution counts: each counter slot is set to 1 (via a plain non-atomic store) the first time its entry executes, rather than atomically incremented per execution. This removes all atomic contention, so coverage is dramatically faster and avoids the GPU watchdog timeouts that heavy per-execution counting can trigger, at the cost of exact counts (the counter is 0 or non-zero). Off by default. Ignored when no coverage mode is enabled. 
+
+
 <a id="trace-coverage-binding"></a>
 ### -trace-coverage-binding
 

--- a/docs/design/shader-coverage-host-interface.md
+++ b/docs/design/shader-coverage-host-interface.md
@@ -243,10 +243,10 @@ creation is rejected and no counters are written:
   capability) and `shaderBufferInt64Atomics` (`VK_KHR_shader_atomic_int64`,
   core in Vulkan 1.2). The 64-bit path emits SPIR-V 1.5, so the instance
   must target Vulkan 1.2 (a 1.1 instance, max SPIR-V 1.3, rejects it).
-  Note that some drivers (e.g. NVIDIA) report `shaderBufferInt64Atomics`
-  only through the standalone `VkPhysicalDeviceShaderAtomicInt64Features`
-  struct and return 0 for the same bit in the aggregated
-  `VkPhysicalDeviceVulkan12Features`; query the standalone struct.
+  Query `shaderBufferInt64Atomics` via `VkPhysicalDeviceShaderAtomicInt64Features`
+  in the `vkGetPhysicalDeviceFeatures2` pNext chain — this is the canonical
+  struct for this feature and is the reliable path regardless of what the
+  aggregated `VkPhysicalDeviceVulkan12Features` reports.
   Integrated GPUs frequently expose a compute queue but not
   `shaderBufferInt64Atomics`, so a host that enumerates devices should
   select one that advertises the feature (or fall back to

--- a/docs/design/shader-coverage.md
+++ b/docs/design/shader-coverage.md
@@ -478,7 +478,7 @@ direct counters, shared counters, derived counter expressions, or
 counterless metadata entries represented through tail-extended fields
 or a derived metadata interface. `CoverageCounterMode` currently defines `Count` (exact execution counts
 via atomic add, the default) and `Boolean` (hit/not-hit via a plain
-non-atomic store of 1, selected by `-trace-coverage-hit-miss`).
+non-atomic store of 1, selected by `-trace-coverage-boolean`).
 Warp/group-aggregated and other modes may be appended in future
 extensions. LCOV remains a
 compatibility export (`DA:`, `FN/FNDA:`, `BRDA:`), not the only

--- a/docs/design/shader-coverage.md
+++ b/docs/design/shader-coverage.md
@@ -476,10 +476,11 @@ source ranges, function names, and branch site/arm ids live on
 the size of the runtime counter buffer. Region entries may later use
 direct counters, shared counters, derived counter expressions, or
 counterless metadata entries represented through tail-extended fields
-or a derived metadata interface. `CoverageCounterMode` currently
-defines only `Count`; additional counter interpretations such as
-binary hit/not-hit and warp/group-aggregated modes should be appended
-when a concrete mode is implemented. LCOV remains a
+or a derived metadata interface. `CoverageCounterMode` currently defines `Count` (exact execution counts
+via atomic add, the default) and `Boolean` (hit/not-hit via a plain
+non-atomic store of 1, selected by `-trace-coverage-hit-miss`).
+Warp/group-aggregated and other modes may be appended in future
+extensions. LCOV remains a
 compatibility export (`DA:`, `FN/FNDA:`, `BRDA:`), not the only
 internal coverage model.
 

--- a/include/slang.h
+++ b/include/slang.h
@@ -1197,8 +1197,8 @@ typedef uint32_t SlangSizeT;
                  //   within any practical run. The corresponding CLI flag
                  //   `-trace-coverage-counter-width <bits>` takes a bit count (32/64)
                  //   and stores the matching byte width here.
-        TraceCoverageHitMiss =
-            152, // bool: record hit/miss (CoverageCounterMode::Boolean) instead of exact
+        TraceCoverageBoolean =
+            152, // bool: record boolean coverage (CoverageCounterMode::Boolean) instead of exact
                  //   execution counts. Each counter is written with a plain non-atomic store
                  //   of `1`, eliminating atomic contention (much faster, and avoids the GPU
                  //   watchdog timeouts heavy coverage can trigger) at the cost of exact
@@ -4631,11 +4631,11 @@ enum class CoverageCounterMode : uint32_t
     /// The counter holds the number of times the entry executed
     /// (atomic add per execution).
     Count = 0,
-    /// The counter is a hit/miss flag: `0` if the entry never executed,
+    /// The counter is a boolean flag: `0` if the entry never executed,
     /// non-zero if it executed at least once. Written with a plain
     /// (non-atomic) store of `1`, so it carries no execution count but
     /// avoids all atomic contention. Selected by
-    /// `-trace-coverage-hit-miss`.
+    /// `-trace-coverage-boolean`.
     Boolean = 1,
 };
 

--- a/include/slang.h
+++ b/include/slang.h
@@ -1197,6 +1197,12 @@ typedef uint32_t SlangSizeT;
                  //   within any practical run. The corresponding CLI flag
                  //   `-trace-coverage-counter-width <bits>` takes a bit count (32/64)
                  //   and stores the matching byte width here.
+        TraceCoverageHitMiss =
+            152, // bool: record hit/miss (CoverageCounterMode::Boolean) instead of exact
+                 //   execution counts. Each counter is written with a plain non-atomic store
+                 //   of `1`, eliminating atomic contention (much faster, and avoids the GPU
+                 //   watchdog timeouts heavy coverage can trigger) at the cost of exact
+                 //   counts. Off by default.
 
         CountOf,
     };
@@ -4622,7 +4628,15 @@ enum class CoverageEntryKind : uint32_t
 
 enum class CoverageCounterMode : uint32_t
 {
+    /// The counter holds the number of times the entry executed
+    /// (atomic add per execution).
     Count = 0,
+    /// The counter is a hit/miss flag: `0` if the entry never executed,
+    /// non-zero if it executed at least once. Written with a plain
+    /// (non-atomic) store of `1`, so it carries no execution count but
+    /// avoids all atomic contention. Selected by
+    /// `-trace-coverage-hit-miss`.
+    Boolean = 1,
 };
 
 enum class CoverageBranchArmKind : uint32_t

--- a/source/slang/slang-api.cpp
+++ b/source/slang/slang-api.cpp
@@ -1165,6 +1165,8 @@ static const char* _getCoverageCounterModeName(slang::CoverageCounterMode mode)
     {
     case slang::CoverageCounterMode::Count:
         return "count";
+    case slang::CoverageCounterMode::Boolean:
+        return "boolean";
     default:
         return "unknown";
     }

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -1106,6 +1106,14 @@ Result linkAndOptimizeIR(
             });
             return SLANG_FAIL;
         }
+        // Opt-in hit/miss mode (off by default): record whether each entry
+        // executed (non-atomic store of 1) instead of an exact count.
+        bool coverageHitMiss = false;
+        if (auto values = opts.options.tryGetValue(CompilerOptionName::TraceCoverageHitMiss))
+        {
+            if (values->getCount() > 0)
+                coverageHitMiss = (*values)[0].intValue != 0;
+        }
         SLANG_PASS(
             instrumentCoverage,
             sink,
@@ -1115,6 +1123,7 @@ Result linkAndOptimizeIR(
             reservedSpaces.getBuffer(),
             (int)reservedSpaces.getCount(),
             counterByteWidth,
+            coverageHitMiss,
             targetRequest,
             outLinkedIR.globalScopeVarLayout,
             *metadata);

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -1106,13 +1106,13 @@ Result linkAndOptimizeIR(
             });
             return SLANG_FAIL;
         }
-        // Opt-in hit/miss mode (off by default): record whether each entry
+        // Opt-in boolean mode (off by default): record whether each entry
         // executed (non-atomic store of 1) instead of an exact count.
-        bool coverageHitMiss = false;
-        if (auto values = opts.options.tryGetValue(CompilerOptionName::TraceCoverageHitMiss))
+        bool coverageBoolean = false;
+        if (auto values = opts.options.tryGetValue(CompilerOptionName::TraceCoverageBoolean))
         {
             if (values->getCount() > 0)
-                coverageHitMiss = (*values)[0].intValue != 0;
+                coverageBoolean = (*values)[0].intValue != 0;
         }
         SLANG_PASS(
             instrumentCoverage,
@@ -1123,7 +1123,7 @@ Result linkAndOptimizeIR(
             reservedSpaces.getBuffer(),
             (int)reservedSpaces.getCount(),
             counterByteWidth,
-            coverageHitMiss,
+            coverageBoolean,
             targetRequest,
             outLinkedIR.globalScopeVarLayout,
             *metadata);

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -950,11 +950,11 @@ struct CoverageInstrumenter
     IRType* counterElementType;
     IRType* counterElementPtrType;
     IRType* intType;
-    // Caller opted in to hit/miss recording (`-trace-coverage-hit-miss`): each
+    // Caller opted in to boolean recording (`-trace-coverage-boolean`): each
     // counter is written with a plain non-atomic store of 1 instead of an
     // atomic add, recording whether the entry executed (0 / non-zero) rather
     // than an exact count.
-    bool hitMiss = false;
+    bool booleanMode = false;
     List<BranchSiteRemap> branchSiteRemaps;
     uint32_t nextBranchSiteID = 1;
 
@@ -963,8 +963,8 @@ struct CoverageInstrumenter
         IRGlobalParam* buf,
         SourceManager* sm,
         ArtifactPostEmitMetadata& md,
-        bool hitMiss)
-        : module(m), coverageBuffer(buf), sourceManager(sm), outMetadata(md), hitMiss(hitMiss)
+        bool booleanMode)
+        : module(m), coverageBuffer(buf), sourceManager(sm), outMetadata(md), booleanMode(booleanMode)
     {
         IRBuilder tmpBuilder(module);
         // The unchecked `cast` is safe: this instrumenter only ever runs
@@ -1004,7 +1004,7 @@ struct CoverageInstrumenter
     {
         entry.counterIndex = (uint32_t)slot;
         entry.counterMode =
-            hitMiss ? slang::CoverageCounterMode::Boolean : slang::CoverageCounterMode::Count;
+            booleanMode ? slang::CoverageCounterMode::Boolean : slang::CoverageCounterMode::Count;
         resolveHumaneLoc(sourceManager, markerOp, entry.file, entry.line, entry.startColumn);
 
         switch (markerOp->getOp())
@@ -1053,7 +1053,7 @@ struct CoverageInstrumenter
             2,
             getElemArgs);
 
-        if (hitMiss)
+        if (booleanMode)
         {
             // Hit/miss recording: a plain, non-atomic store of `1`. Every
             // lane that reaches this marker writes the same value, so
@@ -1066,7 +1066,7 @@ struct CoverageInstrumenter
             // guaranteed single-copy atomic unless shaderBufferInt64Atomics
             // is enabled. In practice the host already requires that feature
             // for 64-bit coverage, which implies single-copy atomic plain
-            // stores on all known drivers. If exact hit-miss semantics under
+            // stores on all known drivers. If exact boolean semantics under
             // 64-bit are required, prefer 32-bit counters
             // (`-trace-coverage-counter-width 32`).
             //
@@ -1297,7 +1297,7 @@ void instrumentCoverage(
     const int* reservedSpaces,
     int reservedSpaceCount,
     int counterByteWidth,
-    bool hitMiss,
+    bool booleanMode,
     TargetRequest* targetRequest,
     IRVarLayout*& globalScopeVarLayout,
     ArtifactPostEmitMetadata& outMetadata)
@@ -1454,7 +1454,7 @@ void instrumentCoverage(
         buffer,
         sink ? sink->getSourceManager() : nullptr,
         outMetadata,
-        hitMiss);
+        booleanMode);
     instrumenter.run(markerOps);
 }
 

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -964,7 +964,11 @@ struct CoverageInstrumenter
         SourceManager* sm,
         ArtifactPostEmitMetadata& md,
         bool booleanMode)
-        : module(m), coverageBuffer(buf), sourceManager(sm), outMetadata(md), booleanMode(booleanMode)
+        : module(m)
+        , coverageBuffer(buf)
+        , sourceManager(sm)
+        , outMetadata(md)
+        , booleanMode(booleanMode)
     {
         IRBuilder tmpBuilder(module);
         // The unchecked `cast` is safe: this instrumenter only ever runs

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -1055,16 +1055,25 @@ struct CoverageInstrumenter
 
         if (hitMiss)
         {
-            // Hit/miss recording: a plain, non-atomic store of `1`. Every lane
-            // that reaches this marker writes the same value, so the concurrent
-            // writes are a benign race — the slot ends up `1` iff the entry
-            // executed at least once. The store being non-atomic is the whole
-            // point: a *relaxed atomic* store would be memory-model-clean but
-            // still serializes on the hot counter address — measured just as
-            // slow as the atomic-add counting path (~15x slower than this plain
-            // store), defeating the purpose. The trade-off vs `Count` mode is
-            // that no exact execution count is recorded
-            // (`CoverageCounterMode::Boolean`).
+            // Hit/miss recording: a plain, non-atomic store of `1`. Every
+            // lane that reaches this marker writes the same value, so
+            // concurrent same-value writes are a benign race for 32-bit
+            // counters — 32-bit StorageBuffer stores are single-copy atomic
+            // under the Vulkan memory model, so a reader always observes a
+            // complete 0 or 1 and the slot is 1 iff the entry executed.
+            //
+            // For 64-bit counters: a 64-bit StorageBuffer store is not
+            // guaranteed single-copy atomic unless shaderBufferInt64Atomics
+            // is enabled. In practice the host already requires that feature
+            // for 64-bit coverage, which implies single-copy atomic plain
+            // stores on all known drivers. If exact hit-miss semantics under
+            // 64-bit are required, prefer 32-bit counters
+            // (`-trace-coverage-counter-width 32`).
+            //
+            // Non-atomic is the whole point: a relaxed atomic store still
+            // serializes on the hot counter address (measured ~15x slower),
+            // defeating the purpose. Trade-off: no exact execution count
+            // (`CoverageCounterMode::Boolean`, not `Count`).
             builder.emitStore(slotPtr, builder.getIntValue(counterElementType, 1));
         }
         else

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -950,6 +950,11 @@ struct CoverageInstrumenter
     IRType* counterElementType;
     IRType* counterElementPtrType;
     IRType* intType;
+    // Caller opted in to hit/miss recording (`-trace-coverage-hit-miss`): each
+    // counter is written with a plain non-atomic store of 1 instead of an
+    // atomic add, recording whether the entry executed (0 / non-zero) rather
+    // than an exact count.
+    bool hitMiss = false;
     List<BranchSiteRemap> branchSiteRemaps;
     uint32_t nextBranchSiteID = 1;
 
@@ -957,8 +962,9 @@ struct CoverageInstrumenter
         IRModule* m,
         IRGlobalParam* buf,
         SourceManager* sm,
-        ArtifactPostEmitMetadata& md)
-        : module(m), coverageBuffer(buf), sourceManager(sm), outMetadata(md)
+        ArtifactPostEmitMetadata& md,
+        bool hitMiss)
+        : module(m), coverageBuffer(buf), sourceManager(sm), outMetadata(md), hitMiss(hitMiss)
     {
         IRBuilder tmpBuilder(module);
         // The unchecked `cast` is safe: this instrumenter only ever runs
@@ -997,7 +1003,8 @@ struct CoverageInstrumenter
     void populateEntryForMarker(IRInst* markerOp, UInt slot, CoverageTracingEntry& entry)
     {
         entry.counterIndex = (uint32_t)slot;
-        entry.counterMode = slang::CoverageCounterMode::Count;
+        entry.counterMode =
+            hitMiss ? slang::CoverageCounterMode::Boolean : slang::CoverageCounterMode::Count;
         resolveHumaneLoc(sourceManager, markerOp, entry.file, entry.line, entry.startColumn);
 
         switch (markerOp->getOp())
@@ -1046,19 +1053,36 @@ struct CoverageInstrumenter
             2,
             getElemArgs);
 
-        // Emit `AtomicAdd(slotPtr, 1, relaxed)` — lowered by each
-        // backend emitter to its native atomic-increment idiom
-        // (InterlockedAdd on HLSL, atomicAdd on GLSL, OpAtomicIAdd on
-        // SPIR-V, etc.). The immediate and the result type are typed
-        // against `counterElementType` (uint or uint64), so the same
-        // lowering path produces a 64-bit `OpAtomicIAdd` /
-        // `atomicAdd(ulonglong*)` when the buffer is wide.
-        IRInst* atomicArgs[] = {
-            slotPtr,
-            builder.getIntValue(counterElementType, 1),
-            builder.getIntValue(intType, (IRIntegerValue)kIRMemoryOrder_Relaxed),
-        };
-        builder.emitIntrinsicInst(counterElementType, kIROp_AtomicAdd, 3, atomicArgs);
+        if (hitMiss)
+        {
+            // Hit/miss recording: a plain, non-atomic store of `1`. Every lane
+            // that reaches this marker writes the same value, so the concurrent
+            // writes are a benign race — the slot ends up `1` iff the entry
+            // executed at least once. The store being non-atomic is the whole
+            // point: a *relaxed atomic* store would be memory-model-clean but
+            // still serializes on the hot counter address — measured just as
+            // slow as the atomic-add counting path (~15x slower than this plain
+            // store), defeating the purpose. The trade-off vs `Count` mode is
+            // that no exact execution count is recorded
+            // (`CoverageCounterMode::Boolean`).
+            builder.emitStore(slotPtr, builder.getIntValue(counterElementType, 1));
+        }
+        else
+        {
+            // Emit `AtomicAdd(slotPtr, 1, relaxed)` — lowered by each
+            // backend emitter to its native atomic-increment idiom
+            // (InterlockedAdd on HLSL, atomicAdd on GLSL, OpAtomicIAdd on
+            // SPIR-V, etc.). The immediate and the result type are typed
+            // against `counterElementType` (uint or uint64), so the same
+            // lowering path produces a 64-bit `OpAtomicIAdd` /
+            // `atomicAdd(ulonglong*)` when the buffer is wide.
+            IRInst* atomicArgs[] = {
+                slotPtr,
+                builder.getIntValue(counterElementType, 1),
+                builder.getIntValue(intType, (IRIntegerValue)kIRMemoryOrder_Relaxed),
+            };
+            builder.emitIntrinsicInst(counterElementType, kIROp_AtomicAdd, 3, atomicArgs);
+        }
 
         // The marker op has void return type and, by construction, no uses.
         // Catch a future IR transform that takes a use of it before we reach
@@ -1264,6 +1288,7 @@ void instrumentCoverage(
     const int* reservedSpaces,
     int reservedSpaceCount,
     int counterByteWidth,
+    bool hitMiss,
     TargetRequest* targetRequest,
     IRVarLayout*& globalScopeVarLayout,
     ArtifactPostEmitMetadata& outMetadata)
@@ -1419,7 +1444,8 @@ void instrumentCoverage(
         module,
         buffer,
         sink ? sink->getSourceManager() : nullptr,
-        outMetadata);
+        outMetadata,
+        hitMiss);
     instrumenter.run(markerOps);
 }
 

--- a/source/slang/slang-ir-coverage-instrument.h
+++ b/source/slang/slang-ir-coverage-instrument.h
@@ -65,7 +65,7 @@ static constexpr int kDefaultCoverageCounterByteWidth = 8;
 // buffer is synthesized, and `outMetadata` and `globalScopeVarLayout`
 // are left untouched.
 //
-// `hitMiss` opts in to hit/miss recording (`CoverageCounterMode::Boolean`):
+// `booleanMode` opts in to boolean recording (`CoverageCounterMode::Boolean`):
 // each counter is written with a plain non-atomic store of `1` instead of
 // an atomic add, so it records whether the entry executed (0 / non-zero)
 // rather than an exact count. This removes all atomic contention. Off by
@@ -79,7 +79,7 @@ void instrumentCoverage(
     const int* reservedSpaces,
     int reservedSpaceCount,
     int counterByteWidth,
-    bool hitMiss,
+    bool booleanMode,
     TargetRequest* targetRequest,
     IRVarLayout*& globalScopeVarLayout,
     ArtifactPostEmitMetadata& outMetadata);

--- a/source/slang/slang-ir-coverage-instrument.h
+++ b/source/slang/slang-ir-coverage-instrument.h
@@ -64,6 +64,12 @@ static constexpr int kDefaultCoverageCounterByteWidth = 8;
 // from cached modules are dropped so the backend never sees them, no
 // buffer is synthesized, and `outMetadata` and `globalScopeVarLayout`
 // are left untouched.
+//
+// `hitMiss` opts in to hit/miss recording (`CoverageCounterMode::Boolean`):
+// each counter is written with a plain non-atomic store of `1` instead of
+// an atomic add, so it records whether the entry executed (0 / non-zero)
+// rather than an exact count. This removes all atomic contention. Off by
+// default.
 void instrumentCoverage(
     IRModule* module,
     DiagnosticSink* sink,
@@ -73,6 +79,7 @@ void instrumentCoverage(
     const int* reservedSpaces,
     int reservedSpaceCount,
     int counterByteWidth,
+    bool hitMiss,
     TargetRequest* targetRequest,
     IRVarLayout*& globalScopeVarLayout,
     ArtifactPostEmitMetadata& outMetadata);

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -636,7 +636,7 @@ void initCommandOptions(CommandOptions& options)
          "-trace-coverage-boolean",
          nullptr,
          "Record boolean coverage instead of exact execution counts: each counter slot "
-         "is set to 1 (via a plain non-atomic store) the first time its entry executes, "
+         "is written with 1 (via a plain non-atomic store) whenever its entry executes, "
          "rather than atomically incremented per execution. This removes all atomic "
          "contention, so coverage is dramatically faster and avoids the GPU watchdog "
          "timeouts that heavy per-execution counting can trigger, at the cost of exact "

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -632,6 +632,16 @@ void initCommandOptions(CommandOptions& options)
          "default paths. Expression-level short-circuit and ternary branches are "
          "not instrumented by this mode yet. "
          "Shares the synthesized `__slang_coverage` buffer and coverage metadata path."},
+        {OptionKind::TraceCoverageHitMiss,
+         "-trace-coverage-hit-miss",
+         nullptr,
+         "Record hit/miss coverage instead of exact execution counts: each counter slot "
+         "is set to 1 (via a plain non-atomic store) the first time its entry executes, "
+         "rather than atomically incremented per execution. This removes all atomic "
+         "contention, so coverage is dramatically faster and avoids the GPU watchdog "
+         "timeouts that heavy per-execution counting can trigger, at the cost of exact "
+         "counts (the counter is 0 or non-zero). Off by default. Ignored when no coverage "
+         "mode is enabled."},
         {OptionKind::TraceCoverageBinding,
          "-trace-coverage-binding",
          "-trace-coverage-binding <index> <space>",
@@ -2607,6 +2617,7 @@ SlangResult OptionsParser::_parse(int argc, char const* const* argv)
         case OptionKind::TraceCoverage:
         case OptionKind::TraceFunctionCoverage:
         case OptionKind::TraceBranchCoverage:
+        case OptionKind::TraceCoverageHitMiss:
         case OptionKind::SkipSPIRVValidation:
         case OptionKind::DisableSpecialization:
         case OptionKind::DisableDynamicDispatch:

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -632,10 +632,10 @@ void initCommandOptions(CommandOptions& options)
          "default paths. Expression-level short-circuit and ternary branches are "
          "not instrumented by this mode yet. "
          "Shares the synthesized `__slang_coverage` buffer and coverage metadata path."},
-        {OptionKind::TraceCoverageHitMiss,
-         "-trace-coverage-hit-miss",
+        {OptionKind::TraceCoverageBoolean,
+         "-trace-coverage-boolean",
          nullptr,
-         "Record hit/miss coverage instead of exact execution counts: each counter slot "
+         "Record boolean coverage instead of exact execution counts: each counter slot "
          "is set to 1 (via a plain non-atomic store) the first time its entry executes, "
          "rather than atomically incremented per execution. This removes all atomic "
          "contention, so coverage is dramatically faster and avoids the GPU watchdog "
@@ -2617,7 +2617,7 @@ SlangResult OptionsParser::_parse(int argc, char const* const* argv)
         case OptionKind::TraceCoverage:
         case OptionKind::TraceFunctionCoverage:
         case OptionKind::TraceBranchCoverage:
-        case OptionKind::TraceCoverageHitMiss:
+        case OptionKind::TraceCoverageBoolean:
         case OptionKind::SkipSPIRVValidation:
         case OptionKind::DisableSpecialization:
         case OptionKind::DisableDynamicDispatch:

--- a/tests/language-feature/coverage/coverage-boolean-spirv.slang
+++ b/tests/language-feature/coverage/coverage-boolean-spirv.slang
@@ -1,6 +1,6 @@
-// Verifies hit/miss coverage mode (`-trace-coverage-hit-miss`, #11509).
+// Verifies boolean coverage mode (`-trace-coverage-boolean`, #11509).
 //
-// In hit/miss mode each coverage counter is written with a plain non-atomic
+// In boolean mode each coverage counter is written with a plain non-atomic
 // store of 1 (CoverageCounterMode::Boolean) instead of an atomic add, so it
 // records whether an entry executed (0 / non-zero) rather than an exact count.
 // This removes all atomic contention. Off by default — the default count mode
@@ -10,7 +10,7 @@
 //TEST:SIMPLE(filecheck=COUNT):-target spirv-asm -stage compute -entry computeMain -trace-coverage -trace-branch-coverage
 
 // Hit/miss mode: no atomics at all.
-//TEST:SIMPLE(filecheck=HITMISS):-target spirv-asm -stage compute -entry computeMain -trace-coverage -trace-branch-coverage -trace-coverage-hit-miss
+//TEST:SIMPLE(filecheck=HITMISS):-target spirv-asm -stage compute -entry computeMain -trace-coverage -trace-branch-coverage -trace-coverage-boolean
 
 //TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
 RWStructuredBuffer<uint> outputBuffer;

--- a/tests/language-feature/coverage/coverage-boolean-spirv.slang
+++ b/tests/language-feature/coverage/coverage-boolean-spirv.slang
@@ -9,8 +9,10 @@
 // Default (count) mode: coverage uses atomic adds.
 //TEST:SIMPLE(filecheck=COUNT):-target spirv-asm -stage compute -entry computeMain -trace-coverage -trace-branch-coverage
 
-// Hit/miss mode: no atomics at all.
-//TEST:SIMPLE(filecheck=HITMISS):-target spirv-asm -stage compute -entry computeMain -trace-coverage -trace-branch-coverage -trace-coverage-boolean
+// Boolean mode: 32-bit counters, no atomics.
+// Pin counter width to 32-bit so the stored constant is %uint_1 (not %ulong_1
+// which the 64-bit default would produce), making the HITMISS check below exact.
+//TEST:SIMPLE(filecheck=HITMISS):-target spirv-asm -stage compute -entry computeMain -trace-coverage -trace-branch-coverage -trace-coverage-boolean -trace-coverage-counter-width 32
 
 //TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
 RWStructuredBuffer<uint> outputBuffer;

--- a/tests/language-feature/coverage/coverage-boolean-spirv.slang
+++ b/tests/language-feature/coverage/coverage-boolean-spirv.slang
@@ -18,18 +18,22 @@ RWStructuredBuffer<uint> outputBuffer;
 [numthreads(64, 1, 1)]
 void computeMain(uint3 tid : SV_DispatchThreadID)
 {
+    // Use output values 2 and 3 (not 1) so the only OpStore of the constant 1
+    // in the SPIR-V is the coverage counter write, making the HITMISS check
+    // below unambiguous.
     if ((tid.x & 1u) == 0u)
-        outputBuffer[tid.x] = 1;
-    else
         outputBuffer[tid.x] = 2;
+    else
+        outputBuffer[tid.x] = 3;
 }
 
 // Count mode increments counters atomically.
 //COUNT: OpAtomicIAdd
 
-// Hit/miss mode emits a plain store of 1 (not an atomic add).
-// The positive OpStore check ensures the instrumentation actually ran and
-// emitted something — preventing the NOT check from passing vacuously if
-// the instrumentation were silently dropped.
-//HITMISS: OpStore
+// Boolean mode emits a plain store of 1 (not an atomic add). The coverage
+// variable is named __slang_coverage; checking OpName ensures the variable
+// is present and OpStore %uint_1 is unambiguous because the shader writes
+// 2 and 3 to outputBuffer, not 1.
+//HITMISS: OpName {{.*}} "__slang_coverage"
+//HITMISS: OpStore {{.*}} %uint_1
 //HITMISS-NOT: OpAtomicIAdd

--- a/tests/language-feature/coverage/coverage-hit-miss-spirv.slang
+++ b/tests/language-feature/coverage/coverage-hit-miss-spirv.slang
@@ -1,0 +1,31 @@
+// Verifies hit/miss coverage mode (`-trace-coverage-hit-miss`, #11509).
+//
+// In hit/miss mode each coverage counter is written with a plain non-atomic
+// store of 1 (CoverageCounterMode::Boolean) instead of an atomic add, so it
+// records whether an entry executed (0 / non-zero) rather than an exact count.
+// This removes all atomic contention. Off by default — the default count mode
+// still uses atomic adds (asserted by the COUNT run below).
+
+// Default (count) mode: coverage uses atomic adds.
+//TEST:SIMPLE(filecheck=COUNT):-target spirv-asm -stage compute -entry computeMain -trace-coverage -trace-branch-coverage
+
+// Hit/miss mode: no atomics at all.
+//TEST:SIMPLE(filecheck=HITMISS):-target spirv-asm -stage compute -entry computeMain -trace-coverage -trace-branch-coverage -trace-coverage-hit-miss
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<uint> outputBuffer;
+
+[numthreads(64, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    if ((tid.x & 1u) == 0u)
+        outputBuffer[tid.x] = 1;
+    else
+        outputBuffer[tid.x] = 2;
+}
+
+// Count mode increments counters atomically.
+//COUNT: OpAtomicIAdd
+
+// Hit/miss mode must not emit any atomic add for the counters.
+//HITMISS-NOT: OpAtomicIAdd

--- a/tests/language-feature/coverage/coverage-hit-miss-spirv.slang
+++ b/tests/language-feature/coverage/coverage-hit-miss-spirv.slang
@@ -27,5 +27,9 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
 // Count mode increments counters atomically.
 //COUNT: OpAtomicIAdd
 
-// Hit/miss mode must not emit any atomic add for the counters.
+// Hit/miss mode emits a plain store of 1 (not an atomic add).
+// The positive OpStore check ensures the instrumentation actually ran and
+// emitted something — preventing the NOT check from passing vacuously if
+// the instrumentation were silently dropped.
+//HITMISS: OpStore
 //HITMISS-NOT: OpAtomicIAdd

--- a/tools/slang-unit-test/unit-test-coverage-tracing-metadata.cpp
+++ b/tools/slang-unit-test/unit-test-coverage-tracing-metadata.cpp
@@ -2567,12 +2567,12 @@ SLANG_UNIT_TEST(coverageTracingInvalidCounterWidthFailsCodegen)
     SLANG_CHECK(code64.indexOf(toSlice("_slang_atomic_add_u32((")) == -1);
 }
 
-// Verify that compiling with `-trace-coverage-hit-miss` produces
+// Verify that compiling with `-trace-coverage-boolean` produces
 // `CoverageCounterMode::Boolean` in the metadata for every entry, and
 // that the manifest serializes it as "boolean" rather than "unknown".
 // This is a regression test for the case where _getCoverageCounterModeName
 // lacked a case for Boolean and silently returned "unknown".
-SLANG_UNIT_TEST(coverageTracingHitMissCounterMode)
+SLANG_UNIT_TEST(coverageTracingBooleanCounterMode)
 {
     const char* shaderSource = R"(
         RWStructuredBuffer<uint> outputBuffer;
@@ -2599,7 +2599,7 @@ SLANG_UNIT_TEST(coverageTracingHitMissCounterMode)
     options[0].name = slang::CompilerOptionName::TraceCoverage;
     options[0].value.kind = slang::CompilerOptionValueKind::Int;
     options[0].value.intValue0 = 1;
-    options[1].name = slang::CompilerOptionName::TraceCoverageHitMiss;
+    options[1].name = slang::CompilerOptionName::TraceCoverageBoolean;
     options[1].value.kind = slang::CompilerOptionValueKind::Int;
     options[1].value.intValue0 = 1;
 
@@ -2614,8 +2614,8 @@ SLANG_UNIT_TEST(coverageTracingHitMissCounterMode)
 
     ComPtr<slang::IBlob> diagnostics;
     ComPtr<slang::IModule> module(session->loadModuleFromSourceString(
-        "hitMissTest",
-        "hitMissTest.slang",
+        "booleanTest",
+        "booleanTest.slang",
         shaderSource,
         diagnostics.writeRef()));
     SLANG_CHECK(module != nullptr);
@@ -2641,7 +2641,7 @@ SLANG_UNIT_TEST(coverageTracingHitMissCounterMode)
         slang::ICoverageTracingMetadata::getTypeGuid());
     SLANG_CHECK(coverage != nullptr);
 
-    // Every entry produced in hit-miss mode must carry Boolean mode.
+    // Every entry produced in boolean mode must carry Boolean mode.
     uint32_t count = coverage->getEntryCount();
     SLANG_CHECK(count > 0);
     for (uint32_t i = 0; i < count; ++i)

--- a/tools/slang-unit-test/unit-test-coverage-tracing-metadata.cpp
+++ b/tools/slang-unit-test/unit-test-coverage-tracing-metadata.cpp
@@ -2566,3 +2566,96 @@ SLANG_UNIT_TEST(coverageTracingInvalidCounterWidthFailsCodegen)
     SLANG_CHECK(code64.indexOf(toSlice("_slang_atomic_add_u64((")) != -1);
     SLANG_CHECK(code64.indexOf(toSlice("_slang_atomic_add_u32((")) == -1);
 }
+
+// Verify that compiling with `-trace-coverage-hit-miss` produces
+// `CoverageCounterMode::Boolean` in the metadata for every entry, and
+// that the manifest serializes it as "boolean" rather than "unknown".
+// This is a regression test for the case where _getCoverageCounterModeName
+// lacked a case for Boolean and silently returned "unknown".
+SLANG_UNIT_TEST(coverageTracingHitMissCounterMode)
+{
+    const char* shaderSource = R"(
+        RWStructuredBuffer<uint> outputBuffer;
+
+        [shader("compute")]
+        [numthreads(1, 1, 1)]
+        void computeMain(uint3 tid : SV_DispatchThreadID)
+        {
+            if (tid.x > 0)
+                outputBuffer[0] = tid.x;
+            else
+                outputBuffer[0] = 0;
+        }
+    )";
+
+    ComPtr<slang::IGlobalSession> globalSession;
+    SLANG_CHECK(slang_createGlobalSession(SLANG_API_VERSION, globalSession.writeRef()) == SLANG_OK);
+
+    slang::TargetDesc targetDesc = {};
+    targetDesc.format = SLANG_SPIRV;
+    targetDesc.profile = globalSession->findProfile("spirv_1_5");
+
+    slang::CompilerOptionEntry options[2] = {};
+    options[0].name = slang::CompilerOptionName::TraceCoverage;
+    options[0].value.kind = slang::CompilerOptionValueKind::Int;
+    options[0].value.intValue0 = 1;
+    options[1].name = slang::CompilerOptionName::TraceCoverageHitMiss;
+    options[1].value.kind = slang::CompilerOptionValueKind::Int;
+    options[1].value.intValue0 = 1;
+
+    slang::SessionDesc sessionDesc = {};
+    sessionDesc.targetCount = 1;
+    sessionDesc.targets = &targetDesc;
+    sessionDesc.compilerOptionEntries = options;
+    sessionDesc.compilerOptionEntryCount = SLANG_COUNT_OF(options);
+
+    ComPtr<slang::ISession> session;
+    SLANG_CHECK(globalSession->createSession(sessionDesc, session.writeRef()) == SLANG_OK);
+
+    ComPtr<slang::IBlob> diagnostics;
+    ComPtr<slang::IModule> module(session->loadModuleFromSourceString(
+        "hitMissTest",
+        "hitMissTest.slang",
+        shaderSource,
+        diagnostics.writeRef()));
+    SLANG_CHECK(module != nullptr);
+
+    ComPtr<slang::IEntryPoint> entryPoint;
+    SLANG_CHECK(module->findEntryPointByName("computeMain", entryPoint.writeRef()) == SLANG_OK);
+
+    slang::IComponentType* parts[] = {module, entryPoint};
+    ComPtr<slang::IComponentType> composed;
+    SLANG_CHECK(
+        session->createCompositeComponentType(parts, 2, composed.writeRef(), nullptr) == SLANG_OK);
+
+    ComPtr<slang::IComponentType> linked;
+    SLANG_CHECK(composed->link(linked.writeRef(), nullptr) == SLANG_OK);
+
+    ComPtr<slang::IBlob> code;
+    SLANG_CHECK(linked->getEntryPointCode(0, 0, code.writeRef(), nullptr) == SLANG_OK);
+
+    ComPtr<slang::IMetadata> metadata;
+    SLANG_CHECK(linked->getEntryPointMetadata(0, 0, metadata.writeRef(), nullptr) == SLANG_OK);
+
+    auto* coverage = (slang::ICoverageTracingMetadata*)metadata->castAs(
+        slang::ICoverageTracingMetadata::getTypeGuid());
+    SLANG_CHECK(coverage != nullptr);
+
+    // Every entry produced in hit-miss mode must carry Boolean mode.
+    uint32_t count = coverage->getEntryCount();
+    SLANG_CHECK(count > 0);
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        slang::CoverageEntryInfo entry = {};
+        SLANG_CHECK(coverage->getEntryInfo(i, &entry) == SLANG_OK);
+        SLANG_CHECK(entry.counterMode == slang::CoverageCounterMode::Boolean);
+    }
+
+    // The manifest must serialize Boolean as "boolean", not "unknown".
+    ComPtr<ISlangBlob> manifestBlob;
+    SLANG_CHECK(slang_writeCoverageManifestJson(coverage, manifestBlob.writeRef()) == SLANG_OK);
+    UnownedStringSlice manifestText(
+        (const char*)manifestBlob->getBufferPointer(), manifestBlob->getBufferSize());
+    SLANG_CHECK(manifestText.indexOf(toSlice("\"boolean\"")) != -1);
+    SLANG_CHECK(manifestText.indexOf(toSlice("\"unknown\"")) == -1);
+}

--- a/tools/slang-unit-test/unit-test-coverage-tracing-metadata.cpp
+++ b/tools/slang-unit-test/unit-test-coverage-tracing-metadata.cpp
@@ -2655,7 +2655,8 @@ SLANG_UNIT_TEST(coverageTracingBooleanCounterMode)
     ComPtr<ISlangBlob> manifestBlob;
     SLANG_CHECK(slang_writeCoverageManifestJson(coverage, manifestBlob.writeRef()) == SLANG_OK);
     UnownedStringSlice manifestText(
-        (const char*)manifestBlob->getBufferPointer(), manifestBlob->getBufferSize());
+        (const char*)manifestBlob->getBufferPointer(),
+        manifestBlob->getBufferSize());
     SLANG_CHECK(manifestText.indexOf(toSlice("\"boolean\"")) != -1);
     SLANG_CHECK(manifestText.indexOf(toSlice("\"unknown\"")) == -1);
 }


### PR DESCRIPTION
## Summary

Adds **boolean coverage mode** (`-trace-coverage-boolean` /
`CompilerOptionName::TraceCoverageBoolean`, `CoverageCounterMode::Boolean`):
each coverage counter is written with a **plain non-atomic store of 1** instead
of an atomic add, recording whether an entry executed (0 / non-zero) rather than
an exact execution count.

All lanes that reach a marker write the same value, so the concurrent stores are
a benign race — the slot ends up `1` iff the entry executed at least once. This
removes **all atomic contention**, which is the dominant cost of coverage on hot
loops. The host always reads the coverage buffer after the dispatch completes
behind a Vulkan pipeline barrier, which guarantees visibility regardless of
store atomicity.

**Off by default**; the existing `Count` mode (atomic add, exact counts) is
unchanged.

## Motivation

Coverage instrumentation atomically increments a counter per execution. In
shaders with hot loops, every thread hammers the same few slots and the atomics
serialize. Measured on the `shader-coverage-image-pipeline` demo (1080p
bilateral filter) on an NVIDIA RTX A3000:

| Mode | Render time | Atomics |
| --- | --- | --- |
| no coverage | ~12 ms | — |
| count (default) | ~334 ms (~28×) | yes |
| **boolean** | **~22 ms (~1.8×)** | **none** |

~15× faster than count mode, coverage results identical (covered-or-not is
exactly what boolean mode preserves). At ~22 ms/config the 48-config exhaustive
sweep is ~1 s total, so it also keeps heavy sweeps well under the GPU watchdog
timeout (TDR) that per-execution counting can trigger.

## Changes

- `CoverageCounterMode::Boolean` (ABI-safe enum append) + the
  `-trace-coverage-boolean` flag / option (bool, default off).
- The coverage pass emits a store instead of `AtomicAdd` in boolean mode;
  entries report the mode via the existing `CoverageEntryInfo.counterMode`.
- `_getCoverageCounterModeName` updated to serialize `Boolean` as
  `"boolean"` in the JSON manifest (was `"unknown"`).
- Regression test `coverage-boolean-spirv.slang` with positive `OpName`
  + `OpStore` checks and a `NOT: OpAtomicIAdd` guard.
- Unit test `coverageTracingBooleanCounterMode` asserting the mode
  round-trips through `ICoverageTracingMetadata` and the manifest.
- Demos updated: `--coverage-mode=boolean` flag, README descriptions of
  the boolean vs count trade-off.

## Notes

- **Caveat:** boolean mode loses exact execution counts — it is a *mode*,
  with `Count` kept for when counts matter.
- The non-atomic store is safe for coverage readback: the host always reads
  after dispatch behind a Vulkan pipeline barrier, which makes all prior
  shader writes available regardless of atomicity.

## Stack relationship

Stacks on #11451 (64-bit counters, now merged).