### PR TITLE
docs: add Code Style and Review Conventions to instruction files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,6 +67,28 @@ throughout the task recording the problem, how issues cascade (one fix exposing 
 for each and why it is principled (with a code trace), and rejected alternatives; distill that log
 into the PR description.
 
+## Code Style and Review Conventions
+
+Recurring review feedback distilled into rules — following them avoids review round-trips. (These
+govern how code reads and is structured; the Problem-Solving Methodology above governs what to
+change.)
+
+- **Comment functions as complete sentences: what, then why.** Say what the function does first;
+  then, if non-obvious, why it exists. Include a concrete example for non-trivial behavior; avoid
+  terse fragment/bullet-only function comments.
+- **Reuse before you write; then extract.** Before adding a helper, check shared headers
+  (`slang-ast-type.h`, `slang-ir-util.h`, the `*-util.h` files) for an existing one (e.g.
+  `isDeclRefTypeOf<T>`). When the logic is genuinely new, extract it into a named, documented helper
+  with an intention-revealing name instead of an inline lambda or long inline block.
+- **Keep one source of truth; delete dead code.** Map/classify a thing in exactly one place, and
+  remove any branch or fallback that a refactor makes unreachable.
+- **One canonical representation per value; assert the invariant.** Don't add a second AST/IR/`Val`
+  form for a value that already has one (it breaks `equals`/identity and deduplication); when an
+  invariant guarantees a form is never produced for some inputs, `SLANG_ASSERT` it at the
+  construction site.
+- **Fail loudly on out-of-contract input.** When a helper is only valid for a restricted set of
+  inputs, `SLANG_RELEASE_ASSERT` outside that set rather than silently returning a default.
+
 ## PR Description Format
 
 Write every PR description in this five-part format:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,19 @@ Conventions:
 - Use `SLANG_`-prefixed `SCREAMING_SNAKE_CASE` for macros.
 - Prefer comments that explain why code exists.
 
+Review conventions (recurring review feedback — following them avoids review round-trips):
+
+- Comment functions in complete sentences: what it does first, then why if non-obvious; include a
+  concrete example for non-trivial logic.
+- Reuse before you write: check shared headers (`slang-ast-type.h`, `slang-ir-util.h`, the `*-util.h`
+  files) for an existing helper (e.g. `isDeclRefTypeOf<T>`) before adding one. When the logic is
+  genuinely new, extract it into a named, documented helper rather than an inline lambda/long block.
+- Keep one source of truth for a mapping or classification, and delete any branch/fallback a refactor
+  makes unreachable.
+- Don't create a second AST/IR/`Val` representation of a value that already has one (it breaks
+  `equals`/dedup); `SLANG_ASSERT` such invariants at the construction site.
+- `SLANG_RELEASE_ASSERT` on out-of-contract input instead of silently returning a default.
+
 ## Shell Scripts
 
 Scripts under `extras/` (and other repository shell scripts) must run on bash 3.2, the version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ change.)
   why. For non-trivial behavior, include a concrete example. Avoid terse fragment- or bullet-only
   comments on a function. For instance, `substituteElementOfCompositeType` should read like _"Return
   `target` with its element type replaced by `newElementType`, preserving shape: scalar →
-  newElementType, vector<T,N> → vector<newElementType,N>, matrix<T,R,C> → matrix<newElementType,R,C>."_
+  newElementType, `vector<T,N>` → `vector<newElementType,N>`, `matrix<T,R,C>` → `matrix<newElementType,R,C>`."_
   — not _"element coerce target"_.
 
 - **Reuse before you write; then extract non-trivial logic into a named, documented helper.** Before

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,46 @@ representation that is robust by construction, even when that means a larger rew
   PR description below. (Keep the log out of the commit — it feeds the PR body, it is not a repo
   artifact.)
 
+### Code Style and Review Conventions
+
+Recurring review feedback distilled into rules — following them avoids review round-trips. (These
+govern how code reads and is structured; the Problem-Solving Methodology above governs _what_ to
+change.)
+
+- **Write function comments as complete sentences: what, then why.** State what the function does
+  first; then, if the reason it exists isn't obvious from that description, add a brief summary of
+  why. For non-trivial behavior, include a concrete example. Avoid terse fragment- or bullet-only
+  comments on a function. For instance, `substituteElementOfCompositeType` should read like _"Return
+  `target` with its element type replaced by `newElementType`, preserving shape: scalar →
+  newElementType, vector<T,N> → vector<newElementType,N>, matrix<T,R,C> → matrix<newElementType,R,C>."_
+  — not _"element coerce target"_.
+
+- **Reuse before you write; then extract non-trivial logic into a named, documented helper.** Before
+  writing a new helper, search for an existing one — what you need is often already provided by a
+  shared header (the AST/IR helpers in `slang-ast-type.h`, `slang-ir-util.h`, and the various
+  `*-util.h` files). For example, to test whether a type is a `DeclRefType` of a particular
+  declaration, use the existing `isDeclRefTypeOf<T>(type)` rather than re-deriving it. When the
+  logic genuinely is new, don't bury a multi-step computation in an inline lambda or a long inline
+  block: give it an intention-revealing name (`coerceOperandsOfBuiltinBinaryExpr`,
+  `substituteElementOfCompositeType`, `unifyBaseType`) and a doc comment, so the caller stays
+  readable and the helper is reusable.
+
+- **Keep one source of truth; delete dead code after a refactor.** Map or classify a given thing in
+  exactly one place — e.g. the operator-name → operation-kind mapping lives only in
+  `getBuiltinOperationKindFromString`, not re-implemented at call sites. When a change makes a
+  branch, fallback, or helper unreachable, remove it rather than leaving it as dead code.
+
+- **One canonical representation per value; assert the invariant.** Don't introduce a second
+  AST/IR/`Val` representation for something that already has one — multiple forms of the same logical
+  value break `equals`/identity checks and deduplication. When an invariant guarantees a
+  representation is never produced for certain inputs (e.g. `+`/`-`/`*` are always a
+  `PolynomialIntVal`, never a `BuiltinOperationIntVal`), `SLANG_ASSERT` it at the construction site
+  so a violation is caught rather than silently producing a divergent form.
+
+- **Fail loudly on out-of-contract input.** When a helper is only valid for a restricted set of
+  inputs, `SLANG_RELEASE_ASSERT` on anything outside that set instead of silently returning a default
+  — e.g. `substituteElementOfCompositeType` asserts its operand is a builtin scalar/vector/matrix.
+
 ### PR Workflow
 
 1. **Format your code**: Run `./extras/formatting.sh` before committing


### PR DESCRIPTION
## Motivation

Recurring code-review feedback on recent PRs kept hitting the same few points (comment quality, factoring out helpers, reusing existing helpers, avoiding duplicate value representations, asserting invariants). Writing those down as explicit conventions should reduce review round-trips.

## Change

Adds a **"Code Style and Review Conventions"** section to the three instruction docs (`CLAUDE.md` canonical, `AGENTS.md`, `.github/copilot-instructions.md`) with five rules distilled from review feedback:

- **Comment functions in complete sentences: what, then why**, with a concrete example for non-trivial logic.
- **Reuse before you write**: check shared headers (`slang-ast-type.h`, `slang-ir-util.h`, the `*-util.h` files) for an existing helper (e.g. `isDeclRefTypeOf<T>`) before adding one; extract genuinely-new non-trivial logic into a named, documented helper.
- **Keep one source of truth; delete dead code** after a refactor makes a branch unreachable.
- **One canonical representation per value; assert the invariant** (multiple forms of the same value break `equals`/dedup).
- **Fail loudly on out-of-contract input** (`SLANG_RELEASE_ASSERT`) instead of silently returning a default.

Docs-only; no code changes.
