### PR TITLE
Fast-path builtin coercions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,13 +47,20 @@ You can also use `./extras/formatting.sh --check-only` to verify formatting with
 
 ## Commenting
 
-Write comments for a new reader who understands C++ but not the local subsystem. Good comments
-explain why the code exists, what source of truth or invariant it relies on, and why the code sits
-at this layer.
+Comments are expected, not optional polish. Write them as teaching notes for a reader who knows
+C++ but is new to this subsystem.
 
-- Use precise names for real mechanisms, files, and functions instead of vague shorthand. For
-  example, say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
+- Every new function or helper must have a leading comment explaining what it does and why it
+  exists. For callbacks, overrides, tiny accessors, or functions matching a strong local pattern,
+  the comment can be brief, but do not leave a new function unexplained.
+- Inside a function body, if new or changed logic runs for more than about 10 lines without a
+  comment, stop and ask whether the purpose and control flow are obvious to a new reader. If not,
+  add a comment explaining why that block exists before explaining what it does mechanically.
+- Explain the source of truth, invariant, or existing mechanism the code relies on. For example,
+  say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
   `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.
+- Use existing codebase terminology and names. Do not invent new terms for concepts that already
+  have names in nearby code, generated modules, diagnostics, IR ops, or design docs.
 - Ground abstract rationale in one or two concrete examples, such as `float(int)` or `float3(int)`,
   so the reader can connect the prose to the control flow.
 - When a fast path, guard, or special case preserves existing behavior, say what general path it is

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,13 +55,13 @@ Write comments as teaching notes for a reader who knows C++ but is new to this s
   Brief comments are fine for tiny accessors, callbacks, overrides, or code following an obvious
   local pattern, but do not leave new behavior unexplained.
 - State the implicit contract: assumptions or preconditions, the invariant being maintained, the
-  source of truth or existing mechanism being relied on, and why the code sits at this layer. For
-  example, say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
-  `core.meta.slang` constructors; do not call it a "table" unless there is actually a table. A
+  source of truth or existing mechanism being relied on, and why the code sits at this layer. A
   reviewer should be able to read the comment, inspect the following code, and conclude that the
   code maintains the stated invariant without assuming more than the comment declared.
 - Use existing codebase terminology and names. Do not invent new terms for concepts that already
-  have names in nearby code, generated modules, diagnostics, IR ops, or design docs.
+  have names in nearby code, generated modules, diagnostics, IR ops, or design docs. For example,
+  say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
+  `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.
 - Ground rationale in real examples, not abstract claims. Include a logical code trace when the
   behavior spans components: name the upstream producer and the input form it creates, the local
   step being performed, and the downstream consumer or invariant that expects the result. For

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,8 +61,15 @@ C++ but is new to this subsystem.
   `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.
 - Use existing codebase terminology and names. Do not invent new terms for concepts that already
   have names in nearby code, generated modules, diagnostics, IR ops, or design docs.
-- Ground abstract rationale in one or two concrete examples, such as `float(int)` or `float3(int)`,
-  so the reader can connect the prose to the control flow.
+- Ground rationale in real examples, not abstract claims. Include a logical code trace when the
+  behavior spans components: name the upstream producer and the input form it creates, the local
+  step being performed, and the downstream consumer or invariant that expects the result. For
+  example: "X generates input form A; Y expects invariant B; this block does Z before handing the
+  value to Y." Use actual function, type, file, IR op, or diagnostic names wherever possible. A
+  good trace might say: "`core.meta.slang` exposes `float3(int)` as a generated constructor;
+  `_coerce` recognizes the builtin scalar-to-vector input before overload resolution; this block
+  creates a `BuiltinCastExpr` so `IRBuilder::emitCast` can preserve the expected
+  `MakeVectorFromScalar` IR shape."
 - When a fast path, guard, or special case preserves existing behavior, say what general path it is
   bypassing, why that is safe, and what still falls back to the general path.
 - Keep comments synchronized with nearby control flow. If a new block now runs before the old

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,6 +56,11 @@ C++ but is new to this subsystem.
 - Inside a function body, if new or changed logic runs for more than about 10 lines without a
   comment, stop and ask whether the purpose and control flow are obvious to a new reader. If not,
   add a comment explaining why that block exists before explaining what it does mechanically.
+- For every new function and every dense block, state the assumptions or preconditions it expects
+  and the invariant it is maintaining. Comments should document the implicit contract of the
+  system, not merely restate the code. A reviewer should be able to read the comment, inspect the
+  following code, and conclude that the code maintains the stated invariant without assuming more
+  than the comment declared.
 - Explain the source of truth, invariant, or existing mechanism the code relies on. For example,
   say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
   `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,8 +71,6 @@ Write comments as teaching notes for a reader who knows C++ but is new to this s
   `_coerce` recognizes the builtin scalar-to-vector input before overload resolution; this block
   creates a `BuiltinCastExpr` so `IRBuilder::emitCast` can preserve the expected
   `MakeVectorFromScalar` IR shape."
-- When a fast path, guard, or special case preserves existing behavior, say what general path it is
-  bypassing, why that is safe, and what still falls back to the general path.
 - Keep comments synchronized with nearby control flow. If a new block now runs before the old
   fallback, update the surrounding comments so they describe the order the reader sees in the code.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,6 +45,22 @@ brew install clang-format gersemi prettier shfmt
 
 You can also use `./extras/formatting.sh --check-only` to verify formatting without modifying files.
 
+## Commenting
+
+Write comments for a new reader who understands C++ but not the local subsystem. Good comments
+explain why the code exists, what source of truth or invariant it relies on, and why the code sits
+at this layer.
+
+- Use precise names for real mechanisms, files, and functions instead of vague shorthand. For
+  example, say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
+  `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.
+- Ground abstract rationale in one or two concrete examples, such as `float(int)` or `float3(int)`,
+  so the reader can connect the prose to the control flow.
+- When a fast path, guard, or special case preserves existing behavior, say what general path it is
+  bypassing, why that is safe, and what still falls back to the general path.
+- Keep comments synchronized with nearby control flow. If a new block now runs before the old
+  fallback, update the surrounding comments so they describe the order the reader sees in the code.
+
 ## Labeling your PR
 
 All PRs needs to be labeled as either "pr: non-breaking" or "pr: breaking change".

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,18 +47,15 @@ You can also use `./extras/formatting.sh --check-only` to verify formatting with
 
 ## Commenting
 
-Comments are expected, not optional polish. Write them as teaching notes for a reader who knows
-C++ but is new to this subsystem.
+Write comments as teaching notes for a reader who knows C++ but is new to this subsystem.
 
-- Every new function or helper must have a leading comment explaining what it does and why it
-  exists. For callbacks, overrides, tiny accessors, or functions matching a strong local pattern,
-  the comment can be brief, but do not leave a new function unexplained.
-- Inside a function body, if new or changed logic runs for more than about 10 lines without a
-  comment, stop and ask whether the purpose and control flow are obvious to a new reader. If not,
-  add a comment explaining why that block exists before explaining what it does mechanically.
-- For every new function and every dense block, state the assumptions or preconditions it expects
-  and the invariant it is maintaining. Comments should document the implicit contract of the
-  system, not merely restate the code. A reviewer should be able to read the comment, inspect the
+- Comments are required for new functions/helpers and for dense or non-obvious function-body
+  logic. As a rule of thumb, if new or changed logic runs for more than about 10 lines without a
+  comment, stop and check whether a reader new to this subsystem can still follow its purpose.
+  Brief comments are fine for tiny accessors, callbacks, overrides, or code following an obvious
+  local pattern, but do not leave new behavior unexplained.
+- State the implicit contract: assumptions or preconditions, the invariant being maintained, and
+  why the code sits at this layer. A reviewer should be able to read the comment, inspect the
   following code, and conclude that the code maintains the stated invariant without assuming more
   than the comment declared.
 - Explain the source of truth, invariant, or existing mechanism the code relies on. For example,

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,13 +54,12 @@ Write comments as teaching notes for a reader who knows C++ but is new to this s
   comment, stop and check whether a reader new to this subsystem can still follow its purpose.
   Brief comments are fine for tiny accessors, callbacks, overrides, or code following an obvious
   local pattern, but do not leave new behavior unexplained.
-- State the implicit contract: assumptions or preconditions, the invariant being maintained, and
-  why the code sits at this layer. A reviewer should be able to read the comment, inspect the
-  following code, and conclude that the code maintains the stated invariant without assuming more
-  than the comment declared.
-- Explain the source of truth, invariant, or existing mechanism the code relies on. For example,
-  say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
-  `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.
+- State the implicit contract: assumptions or preconditions, the invariant being maintained, the
+  source of truth or existing mechanism being relied on, and why the code sits at this layer. For
+  example, say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
+  `core.meta.slang` constructors; do not call it a "table" unless there is actually a table. A
+  reviewer should be able to read the comment, inspect the following code, and conclude that the
+  code maintains the stated invariant without assuming more than the comment declared.
 - Use existing codebase terminology and names. Do not invent new terms for concepts that already
   have names in nearby code, generated modules, diagnostics, IR ops, or design docs.
 - Ground rationale in real examples, not abstract claims. Include a logical code trace when the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,8 +147,6 @@ Commenting practice:
   `_coerce` recognizes the builtin scalar-to-vector input before overload resolution; this block
   creates a `BuiltinCastExpr` so `IRBuilder::emitCast` can preserve the expected
   `MakeVectorFromScalar` IR shape."
-- When a fast path, guard, or special case preserves existing behavior, say what general path it is
-  bypassing, why that is safe, and what still falls back to the general path.
 - Keep comments synchronized with nearby control flow. If a new block now runs before the old
   fallback, update the surrounding comments so they describe the order the reader sees in the code.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,17 +125,13 @@ Conventions:
 
 Commenting practice:
 
-- Comments are expected, not optional polish. Write them as teaching notes for a reader who knows
-  C++ but is new to this subsystem.
-- Every new function or helper must have a leading comment explaining what it does and why it
-  exists. For callbacks, overrides, tiny accessors, or functions matching a strong local pattern,
-  the comment can be brief, but do not leave a new function unexplained.
-- Inside a function body, if new or changed logic runs for more than about 10 lines without a
-  comment, stop and ask whether the purpose and control flow are obvious to a new reader. If not,
-  add a comment explaining why that block exists before explaining what it does mechanically.
-- For every new function and every dense block, state the assumptions or preconditions it expects
-  and the invariant it is maintaining. Comments should document the implicit contract of the
-  system, not merely restate the code. A reviewer should be able to read the comment, inspect the
+- Comments are required for new functions/helpers and for dense or non-obvious function-body
+  logic. As a rule of thumb, if new or changed logic runs for more than about 10 lines without a
+  comment, stop and check whether a reader new to this subsystem can still follow its purpose.
+  Brief comments are fine for tiny accessors, callbacks, overrides, or code following an obvious
+  local pattern, but do not leave new behavior unexplained.
+- State the implicit contract: assumptions or preconditions, the invariant being maintained, and
+  why the code sits at this layer. A reviewer should be able to read the comment, inspect the
   following code, and conclude that the code maintains the stated invariant without assuming more
   than the comment declared.
 - Explain the source of truth, invariant, or existing mechanism the code relies on. For example,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,8 +138,15 @@ Commenting practice:
   `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.
 - Use existing codebase terminology and names. Do not invent new terms for concepts that already
   have names in nearby code, generated modules, diagnostics, IR ops, or design docs.
-- Ground abstract rationale in one or two concrete examples, such as `float(int)` or `float3(int)`,
-  so the reader can connect the prose to the control flow.
+- Ground rationale in real examples, not abstract claims. Include a logical code trace when the
+  behavior spans components: name the upstream producer and the input form it creates, the local
+  step being performed, and the downstream consumer or invariant that expects the result. For
+  example: "X generates input form A; Y expects invariant B; this block does Z before handing the
+  value to Y." Use actual function, type, file, IR op, or diagnostic names wherever possible. A
+  good trace might say: "`core.meta.slang` exposes `float3(int)` as a generated constructor;
+  `_coerce` recognizes the builtin scalar-to-vector input before overload resolution; this block
+  creates a `BuiltinCastExpr` so `IRBuilder::emitCast` can preserve the expected
+  `MakeVectorFromScalar` IR shape."
 - When a fast path, guard, or special case preserves existing behavior, say what general path it is
   bypassing, why that is safe, and what still falls back to the general path.
 - Keep comments synchronized with nearby control flow. If a new block now runs before the old

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,11 @@ Commenting practice:
 - Inside a function body, if new or changed logic runs for more than about 10 lines without a
   comment, stop and ask whether the purpose and control flow are obvious to a new reader. If not,
   add a comment explaining why that block exists before explaining what it does mechanically.
+- For every new function and every dense block, state the assumptions or preconditions it expects
+  and the invariant it is maintaining. Comments should document the implicit contract of the
+  system, not merely restate the code. A reviewer should be able to read the comment, inspect the
+  following code, and conclude that the code maintains the stated invariant without assuming more
+  than the comment declared.
 - Explain the source of truth, invariant, or existing mechanism the code relies on. For example,
   say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
   `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,15 +122,22 @@ Conventions:
 - Avoid STL containers, iostreams, RTTI, and exceptions for ordinary errors.
 - Use `UpperCamelCase` for types and `lowerCamelCase` for values.
 - Use `SLANG_`-prefixed `SCREAMING_SNAKE_CASE` for macros.
-- Prefer comments that explain why code exists.
 
 Commenting practice:
 
-- Write comments for a new reader who understands C++ but not the local subsystem. Explain the
-  reason for the code, the source of truth it relies on, and why the code sits at this layer.
-- Use precise names for real mechanisms, files, and functions instead of vague shorthand. For
-  example, say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
+- Comments are expected, not optional polish. Write them as teaching notes for a reader who knows
+  C++ but is new to this subsystem.
+- Every new function or helper must have a leading comment explaining what it does and why it
+  exists. For callbacks, overrides, tiny accessors, or functions matching a strong local pattern,
+  the comment can be brief, but do not leave a new function unexplained.
+- Inside a function body, if new or changed logic runs for more than about 10 lines without a
+  comment, stop and ask whether the purpose and control flow are obvious to a new reader. If not,
+  add a comment explaining why that block exists before explaining what it does mechanically.
+- Explain the source of truth, invariant, or existing mechanism the code relies on. For example,
+  say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
   `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.
+- Use existing codebase terminology and names. Do not invent new terms for concepts that already
+  have names in nearby code, generated modules, diagnostics, IR ops, or design docs.
 - Ground abstract rationale in one or two concrete examples, such as `float(int)` or `float3(int)`,
   so the reader can connect the prose to the control flow.
 - When a fast path, guard, or special case preserves existing behavior, say what general path it is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,13 +131,13 @@ Commenting practice:
   Brief comments are fine for tiny accessors, callbacks, overrides, or code following an obvious
   local pattern, but do not leave new behavior unexplained.
 - State the implicit contract: assumptions or preconditions, the invariant being maintained, the
-  source of truth or existing mechanism being relied on, and why the code sits at this layer. For
-  example, say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
-  `core.meta.slang` constructors; do not call it a "table" unless there is actually a table. A
+  source of truth or existing mechanism being relied on, and why the code sits at this layer. A
   reviewer should be able to read the comment, inspect the following code, and conclude that the
   code maintains the stated invariant without assuming more than the comment declared.
 - Use existing codebase terminology and names. Do not invent new terms for concepts that already
-  have names in nearby code, generated modules, diagnostics, IR ops, or design docs.
+  have names in nearby code, generated modules, diagnostics, IR ops, or design docs. For example,
+  say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
+  `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.
 - Ground rationale in real examples, not abstract claims. Include a logical code trace when the
   behavior spans components: name the upstream producer and the input form it creates, the local
   step being performed, and the downstream consumer or invariant that expects the result. For

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,13 +130,12 @@ Commenting practice:
   comment, stop and check whether a reader new to this subsystem can still follow its purpose.
   Brief comments are fine for tiny accessors, callbacks, overrides, or code following an obvious
   local pattern, but do not leave new behavior unexplained.
-- State the implicit contract: assumptions or preconditions, the invariant being maintained, and
-  why the code sits at this layer. A reviewer should be able to read the comment, inspect the
-  following code, and conclude that the code maintains the stated invariant without assuming more
-  than the comment declared.
-- Explain the source of truth, invariant, or existing mechanism the code relies on. For example,
-  say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
-  `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.
+- State the implicit contract: assumptions or preconditions, the invariant being maintained, the
+  source of truth or existing mechanism being relied on, and why the code sits at this layer. For
+  example, say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
+  `core.meta.slang` constructors; do not call it a "table" unless there is actually a table. A
+  reviewer should be able to read the comment, inspect the following code, and conclude that the
+  code maintains the stated invariant without assuming more than the comment declared.
 - Use existing codebase terminology and names. Do not invent new terms for concepts that already
   have names in nearby code, generated modules, diagnostics, IR ops, or design docs.
 - Ground rationale in real examples, not abstract claims. Include a logical code trace when the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,20 @@ Conventions:
 - Use `SLANG_`-prefixed `SCREAMING_SNAKE_CASE` for macros.
 - Prefer comments that explain why code exists.
 
+Commenting practice:
+
+- Write comments for a new reader who understands C++ but not the local subsystem. Explain the
+  reason for the code, the source of truth it relies on, and why the code sits at this layer.
+- Use precise names for real mechanisms, files, and functions instead of vague shorthand. For
+  example, say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
+  `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.
+- Ground abstract rationale in one or two concrete examples, such as `float(int)` or `float3(int)`,
+  so the reader can connect the prose to the control flow.
+- When a fast path, guard, or special case preserves existing behavior, say what general path it is
+  bypassing, why that is safe, and what still falls back to the general path.
+- Keep comments synchronized with nearby control flow. If a new block now runs before the old
+  fallback, update the surrounding comments so they describe the order the reader sees in the code.
+
 ## Shell Scripts
 
 Scripts under `extras/` (and other repository shell scripts) must run on bash 3.2, the version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,13 +78,12 @@ Write comments as teaching notes for a reader who knows C++ but is new to this s
   comment, stop and check whether a reader new to this subsystem can still follow its purpose.
   Brief comments are fine for tiny accessors, callbacks, overrides, or code following an obvious
   local pattern, but do not leave new behavior unexplained.
-- State the implicit contract: assumptions or preconditions, the invariant being maintained, and
-  why the code sits at this layer. A reviewer should be able to read the comment, inspect the
-  following code, and conclude that the code maintains the stated invariant without assuming more
-  than the comment declared.
-- Explain the source of truth, invariant, or existing mechanism the code relies on. For example,
-  say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
-  `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.
+- State the implicit contract: assumptions or preconditions, the invariant being maintained, the
+  source of truth or existing mechanism being relied on, and why the code sits at this layer. For
+  example, say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
+  `core.meta.slang` constructors; do not call it a "table" unless there is actually a table. A
+  reviewer should be able to read the comment, inspect the following code, and conclude that the
+  code maintains the stated invariant without assuming more than the comment declared.
 - Use existing codebase terminology and names. Do not invent new terms for concepts that already
   have names in nearby code, generated modules, diagnostics, IR ops, or design docs.
 - Ground rationale in real examples, not abstract claims. Include a logical code trace when the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,8 +85,15 @@ C++ but is new to this subsystem.
   `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.
 - Use existing codebase terminology and names. Do not invent new terms for concepts that already
   have names in nearby code, generated modules, diagnostics, IR ops, or design docs.
-- Ground abstract rationale in one or two concrete examples, such as `float(int)` or `float3(int)`,
-  so the reader can connect the prose to the control flow.
+- Ground rationale in real examples, not abstract claims. Include a logical code trace when the
+  behavior spans components: name the upstream producer and the input form it creates, the local
+  step being performed, and the downstream consumer or invariant that expects the result. For
+  example: "X generates input form A; Y expects invariant B; this block does Z before handing the
+  value to Y." Use actual function, type, file, IR op, or diagnostic names wherever possible. A
+  good trace might say: "`core.meta.slang` exposes `float3(int)` as a generated constructor;
+  `_coerce` recognizes the builtin scalar-to-vector input before overload resolution; this block
+  creates a `BuiltinCastExpr` so `IRBuilder::emitCast` can preserve the expected
+  `MakeVectorFromScalar` IR shape."
 - When a fast path, guard, or special case preserves existing behavior, say what general path it is
   bypassing, why that is safe, and what still falls back to the general path.
 - Keep comments synchronized with nearby control flow. If a new block now runs before the old

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,13 +79,13 @@ Write comments as teaching notes for a reader who knows C++ but is new to this s
   Brief comments are fine for tiny accessors, callbacks, overrides, or code following an obvious
   local pattern, but do not leave new behavior unexplained.
 - State the implicit contract: assumptions or preconditions, the invariant being maintained, the
-  source of truth or existing mechanism being relied on, and why the code sits at this layer. For
-  example, say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
-  `core.meta.slang` constructors; do not call it a "table" unless there is actually a table. A
+  source of truth or existing mechanism being relied on, and why the code sits at this layer. A
   reviewer should be able to read the comment, inspect the following code, and conclude that the
   code maintains the stated invariant without assuming more than the comment declared.
 - Use existing codebase terminology and names. Do not invent new terms for concepts that already
-  have names in nearby code, generated modules, diagnostics, IR ops, or design docs.
+  have names in nearby code, generated modules, diagnostics, IR ops, or design docs. For example,
+  say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
+  `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.
 - Ground rationale in real examples, not abstract claims. Include a logical code trace when the
   behavior spans components: name the upstream producer and the input form it creates, the local
   step being performed, and the downstream consumer or invariant that expects the result. For

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,22 @@ cmake --build --preset debug >/dev/null 2>&1 || cmake --build --preset debug
 
 **Run `./extras/formatting.sh` before committing changes.** PRs must conform to the project's coding style. Use `./extras/formatting.sh --check-only` to verify without modifying files.
 
+### Commenting
+
+Write comments for a new reader who understands C++ but not the local subsystem. Good comments
+explain why the code exists, what source of truth or invariant it relies on, and why the code sits
+at this layer.
+
+- Use precise names for real mechanisms, files, and functions instead of vague shorthand. For
+  example, say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
+  `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.
+- Ground abstract rationale in one or two concrete examples, such as `float(int)` or `float3(int)`,
+  so the reader can connect the prose to the control flow.
+- When a fast path, guard, or special case preserves existing behavior, say what general path it is
+  bypassing, why that is safe, and what still falls back to the general path.
+- Keep comments synchronized with nearby control flow. If a new block now runs before the old
+  fallback, update the surrounding comments so they describe the order the reader sees in the code.
+
 ### Suppressing Unused Variable Warnings
 
 When a variable declared in an `if` condition is unused inside the body (the condition exists only for its type-check side-effect), use the **C++17 if-init-statement** pattern instead of `SLANG_UNUSED`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,13 +71,20 @@ cmake --build --preset debug >/dev/null 2>&1 || cmake --build --preset debug
 
 ### Commenting
 
-Write comments for a new reader who understands C++ but not the local subsystem. Good comments
-explain why the code exists, what source of truth or invariant it relies on, and why the code sits
-at this layer.
+Comments are expected, not optional polish. Write them as teaching notes for a reader who knows
+C++ but is new to this subsystem.
 
-- Use precise names for real mechanisms, files, and functions instead of vague shorthand. For
-  example, say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
+- Every new function or helper must have a leading comment explaining what it does and why it
+  exists. For callbacks, overrides, tiny accessors, or functions matching a strong local pattern,
+  the comment can be brief, but do not leave a new function unexplained.
+- Inside a function body, if new or changed logic runs for more than about 10 lines without a
+  comment, stop and ask whether the purpose and control flow are obvious to a new reader. If not,
+  add a comment explaining why that block exists before explaining what it does mechanically.
+- Explain the source of truth, invariant, or existing mechanism the code relies on. For example,
+  say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
   `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.
+- Use existing codebase terminology and names. Do not invent new terms for concepts that already
+  have names in nearby code, generated modules, diagnostics, IR ops, or design docs.
 - Ground abstract rationale in one or two concrete examples, such as `float(int)` or `float3(int)`,
   so the reader can connect the prose to the control flow.
 - When a fast path, guard, or special case preserves existing behavior, say what general path it is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,18 +71,15 @@ cmake --build --preset debug >/dev/null 2>&1 || cmake --build --preset debug
 
 ### Commenting
 
-Comments are expected, not optional polish. Write them as teaching notes for a reader who knows
-C++ but is new to this subsystem.
+Write comments as teaching notes for a reader who knows C++ but is new to this subsystem.
 
-- Every new function or helper must have a leading comment explaining what it does and why it
-  exists. For callbacks, overrides, tiny accessors, or functions matching a strong local pattern,
-  the comment can be brief, but do not leave a new function unexplained.
-- Inside a function body, if new or changed logic runs for more than about 10 lines without a
-  comment, stop and ask whether the purpose and control flow are obvious to a new reader. If not,
-  add a comment explaining why that block exists before explaining what it does mechanically.
-- For every new function and every dense block, state the assumptions or preconditions it expects
-  and the invariant it is maintaining. Comments should document the implicit contract of the
-  system, not merely restate the code. A reviewer should be able to read the comment, inspect the
+- Comments are required for new functions/helpers and for dense or non-obvious function-body
+  logic. As a rule of thumb, if new or changed logic runs for more than about 10 lines without a
+  comment, stop and check whether a reader new to this subsystem can still follow its purpose.
+  Brief comments are fine for tiny accessors, callbacks, overrides, or code following an obvious
+  local pattern, but do not leave new behavior unexplained.
+- State the implicit contract: assumptions or preconditions, the invariant being maintained, and
+  why the code sits at this layer. A reviewer should be able to read the comment, inspect the
   following code, and conclude that the code maintains the stated invariant without assuming more
   than the comment declared.
 - Explain the source of truth, invariant, or existing mechanism the code relies on. For example,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,8 +95,6 @@ Write comments as teaching notes for a reader who knows C++ but is new to this s
   `_coerce` recognizes the builtin scalar-to-vector input before overload resolution; this block
   creates a `BuiltinCastExpr` so `IRBuilder::emitCast` can preserve the expected
   `MakeVectorFromScalar` IR shape."
-- When a fast path, guard, or special case preserves existing behavior, say what general path it is
-  bypassing, why that is safe, and what still falls back to the general path.
 - Keep comments synchronized with nearby control flow. If a new block now runs before the old
   fallback, update the surrounding comments so they describe the order the reader sees in the code.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,11 @@ C++ but is new to this subsystem.
 - Inside a function body, if new or changed logic runs for more than about 10 lines without a
   comment, stop and ask whether the purpose and control flow are obvious to a new reader. If not,
   add a comment explaining why that block exists before explaining what it does mechanically.
+- For every new function and every dense block, state the assumptions or preconditions it expects
+  and the invariant it is maintaining. Comments should document the implicit contract of the
+  system, not merely restate the code. A reviewer should be able to read the comment, inspect the
+  following code, and conclude that the code maintains the stated invariant without assuming more
+  than the comment declared.
 - Explain the source of truth, invariant, or existing mechanism the code relies on. For example,
   say a conversion cost comes from `getBaseTypeConversionCost` and is exposed through
   `core.meta.slang` constructors; do not call it a "table" unless there is actually a table.

--- a/source/slang-core-module/slang-embedded-core-module-source.cpp
+++ b/source/slang-core-module/slang-embedded-core-module-source.cpp
@@ -30,45 +30,15 @@ enum
     ANY_MASK = INT_MASK | FLOAT_MASK | BOOL_MASK,
 };
 
-// We are going to declare initializers that allow for conversion between
-// all of our base types, and we need a way to priotize those conversion
-// by giving them different costs. Rather than maintain a hard-coded table
-// of N^2 costs for N basic types, we are going to try to do things a bit
-// more systematically.
-//
-// Every base type will be given a "kind" and a "rank" for conversion.
-// The kind will classify it as signed/unsigned/float, and the rank will
-// classify it by its logical bit size (with a distinct rank for pointer-sized
-// types that logically sits between 32- and 64-bit types).
-//
-enum BaseTypeConversionKind : uint8_t
-{
-    kBaseTypeConversionKind_Signed,
-    kBaseTypeConversionKind_Unsigned,
-    kBaseTypeConversionKind_Float,
-    kBaseTypeConversionKind_Error,
-};
-enum BaseTypeConversionRank : uint8_t
-{
-    kBaseTypeConversionRank_Bool,
-    kBaseTypeConversionRank_Int8,
-    kBaseTypeConversionRank_Int16,
-    kBaseTypeConversionRank_Int32,
-    kBaseTypeConversionRank_IntPtr,
-    kBaseTypeConversionRank_Int64,
-    kBaseTypeConversionRank_Error,
-};
-
 // Here we declare the table of all our builtin types, so that we can generate all the relevant
-// declarations.
+// declarations. The scalar conversion-cost policy lives in `getBaseTypeConversionCost` so
+// semantic checking and this generator keep one shared ordering.
 //
 struct BaseTypeConversionInfo
 {
     char const* name;
     BaseType tag;
     unsigned flags;
-    BaseTypeConversionKind conversionKind;
-    BaseTypeConversionRank conversionRank;
 };
 // kBaseTypes is only referenced from within the generated *.meta.slang.h includes,
 // which are guarded by SLANG_EMBED_CORE_MODULE_SOURCE.
@@ -76,199 +46,37 @@ struct BaseTypeConversionInfo
 static const BaseTypeConversionInfo kBaseTypes[] = {
     // TODO: `void` really shouldn't be in the `BaseType` enumeration, since it behaves so
     // differently across the board
-    {"void", BaseType::Void, 0, kBaseTypeConversionKind_Error, kBaseTypeConversionRank_Error},
+    {"void", BaseType::Void, 0},
 
-    {"bool",
-     BaseType::Bool,
-     BOOL_MASK,
-     kBaseTypeConversionKind_Unsigned,
-     kBaseTypeConversionRank_Bool},
+    {"bool", BaseType::Bool, BOOL_MASK},
 
-    {"int8_t",
-     BaseType::Int8,
-     SINT_MASK,
-     kBaseTypeConversionKind_Signed,
-     kBaseTypeConversionRank_Int8},
-    {"int16_t",
-     BaseType::Int16,
-     SINT_MASK,
-     kBaseTypeConversionKind_Signed,
-     kBaseTypeConversionRank_Int16},
-    {"int",
-     BaseType::Int,
-     SINT_MASK,
-     kBaseTypeConversionKind_Signed,
-     kBaseTypeConversionRank_Int32},
-    {"int64_t",
-     BaseType::Int64,
-     SINT_MASK,
-     kBaseTypeConversionKind_Signed,
-     kBaseTypeConversionRank_Int64},
-    {"intptr_t",
-     BaseType::IntPtr,
-     SINT_MASK,
-     kBaseTypeConversionKind_Signed,
-     kBaseTypeConversionRank_IntPtr},
+    {"int8_t", BaseType::Int8, SINT_MASK},
+    {"int16_t", BaseType::Int16, SINT_MASK},
+    {"int", BaseType::Int, SINT_MASK},
+    {"int64_t", BaseType::Int64, SINT_MASK},
+    {"intptr_t", BaseType::IntPtr, SINT_MASK},
 
 
-    {"half",
-     BaseType::Half,
-     FLOAT_MASK,
-     kBaseTypeConversionKind_Float,
-     kBaseTypeConversionRank_Int16},
-    {"float",
-     BaseType::Float,
-     FLOAT_MASK,
-     kBaseTypeConversionKind_Float,
-     kBaseTypeConversionRank_Int32},
-    {"double",
-     BaseType::Double,
-     FLOAT_MASK,
-     kBaseTypeConversionKind_Float,
-     kBaseTypeConversionRank_Int64},
+    {"half", BaseType::Half, FLOAT_MASK},
+    {"float", BaseType::Float, FLOAT_MASK},
+    {"double", BaseType::Double, FLOAT_MASK},
 
-    {"uint8_t",
-     BaseType::UInt8,
-     UINT_MASK,
-     kBaseTypeConversionKind_Unsigned,
-     kBaseTypeConversionRank_Int8},
-    {"uint16_t",
-     BaseType::UInt16,
-     UINT_MASK,
-     kBaseTypeConversionKind_Unsigned,
-     kBaseTypeConversionRank_Int16},
-    {"uint",
-     BaseType::UInt,
-     UINT_MASK,
-     kBaseTypeConversionKind_Unsigned,
-     kBaseTypeConversionRank_Int32},
-    {"uint64_t",
-     BaseType::UInt64,
-     UINT_MASK,
-     kBaseTypeConversionKind_Unsigned,
-     kBaseTypeConversionRank_Int64},
-    {"uintptr_t",
-     BaseType::UIntPtr,
-     UINT_MASK,
-     kBaseTypeConversionKind_Unsigned,
-     kBaseTypeConversionRank_IntPtr},
+    {"uint8_t", BaseType::UInt8, UINT_MASK},
+    {"uint16_t", BaseType::UInt16, UINT_MASK},
+    {"uint", BaseType::UInt, UINT_MASK},
+    {"uint64_t", BaseType::UInt64, UINT_MASK},
+    {"uintptr_t", BaseType::UIntPtr, UINT_MASK},
 };
 #endif // SLANG_EMBED_CORE_MODULE_SOURCE
 
-// Given two base types, we need to be able to compute the cost of converting between them.
-ConversionCost getBaseTypeConversionCost(
-    BaseTypeConversionInfo const& toInfo,
-    BaseTypeConversionInfo const& fromInfo)
+IROp getBaseTypeConversionOp(BaseType toType, BaseType fromType)
 {
-    if (toInfo.conversionKind == fromInfo.conversionKind &&
-        toInfo.conversionRank == fromInfo.conversionRank)
-    {
-        // Thse should represent the exact same type.
-        return kConversionCost_None;
-    }
-
-    // Conversions within the same kind are easist to handle
-    if (toInfo.conversionKind == fromInfo.conversionKind)
-    {
-        // If we are converting to a "larger" type, then
-        // we are doing a lossless promotion, and otherwise
-        // we are doing a demotion.
-        if (toInfo.conversionRank > fromInfo.conversionRank)
-            return kConversionCost_RankPromotion;
-        else
-            return kConversionCost_GeneralConversion;
-    }
-    else if (fromInfo.tag == BaseType::Bool && toInfo.tag == BaseType::Int)
-    {
-        return kConversionCost_BoolToInt;
-    }
-
-    // If we are converting from an unsigned integer type to
-    // a signed integer type that is guaranteed to be larger,
-    // then that is also a lossless promotion.
-    //
-    // There is one additional wrinkle here, which is that
-    // a conversion from a 32-bit unsigned integer to a
-    // "pointer-sized" signed integer should be treated
-    // as unsafe, because the pointer size might also be
-    // 32 bits.
-    //
-    // The same basic exemption applied when converting
-    // *from* a pointer-sized unsigned integer.
-    else if (
-        toInfo.conversionKind == kBaseTypeConversionKind_Signed &&
-        fromInfo.conversionKind == kBaseTypeConversionKind_Unsigned &&
-        toInfo.conversionRank > fromInfo.conversionRank &&
-        toInfo.conversionRank != kBaseTypeConversionRank_IntPtr &&
-        fromInfo.conversionRank != kBaseTypeConversionRank_IntPtr)
-    {
-        return kConversionCost_UnsignedToSignedPromotion;
-    }
-    // Same-size unsigned to signed integer conversion.
-    else if (
-        toInfo.conversionKind == kBaseTypeConversionKind_Signed &&
-        fromInfo.conversionKind == kBaseTypeConversionKind_Unsigned &&
-        toInfo.conversionRank == fromInfo.conversionRank &&
-        toInfo.conversionRank != kBaseTypeConversionRank_IntPtr &&
-        fromInfo.conversionRank != kBaseTypeConversionRank_IntPtr)
-    {
-        return kConversionCost_SameSizeUnsignedToSignedConversion;
-    }
-
-    // Conversion from signed to unsigned is always lossy,
-    // but it is preferred over conversions from unsigned
-    // to signed, for same-size types.
-    else if (
-        toInfo.conversionKind == kBaseTypeConversionKind_Unsigned &&
-        fromInfo.conversionKind == kBaseTypeConversionKind_Signed &&
-        toInfo.conversionRank >= fromInfo.conversionRank)
-    {
-        return kConversionCost_SignedToUnsignedConversion;
-    }
-
-    // Conversion from an integer to a floating-point type
-    // is never considered a promotion (even when the value
-    // would fit in the available mantissa bits).
-    // If the destination type is at least 32 bits we consider
-    // this a reasonably good conversion, though.
-    //
-    // Note that this means we do *not* consider implicit
-    // conversion to `half` as a good conversion, even for small
-    // types. This makes sense because we relaly want to prefer
-    // conversion to `float` as the default.
-    else if (
-        toInfo.conversionKind == kBaseTypeConversionKind_Float &&
-        toInfo.conversionRank >= kBaseTypeConversionRank_Int32 &&
-        fromInfo.conversionRank >= kBaseTypeConversionRank_Int8)
-    {
-        return kConversionCost_IntegerToFloatConversion;
-    }
-    else if (
-        toInfo.conversionKind == kBaseTypeConversionKind_Float &&
-        toInfo.conversionRank >= kBaseTypeConversionRank_Int16 &&
-        fromInfo.conversionRank >= kBaseTypeConversionRank_Int8)
-    {
-        return kConversionCost_IntegerToHalfConversion;
-    }
-    // All other cases are considered as "general" conversions,
-    // where we don't consider any one conversion better than
-    // any others.
-    else
-    {
-        return kConversionCost_GeneralConversion;
-    }
-}
-
-IROp getBaseTypeConversionOp(
-    BaseTypeConversionInfo const& toInfo,
-    BaseTypeConversionInfo const& fromInfo)
-{
-    if (toInfo.tag == fromInfo.tag)
+    if (toType == fromType)
         return kIROp_Nop;
 
     IROp intrinsicOpCode = kIROp_Nop;
-    auto toStyle = getTypeStyle(toInfo.tag);
-    auto fromStyle = getTypeStyle(fromInfo.tag);
+    auto toStyle = getTypeStyle(toType);
+    auto fromStyle = getTypeStyle(fromType);
     if (toStyle == kIROp_BoolType)
         toStyle = kIROp_IntType;
     if (fromStyle == kIROp_BoolType)

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -1183,12 +1183,12 @@ ${
         // layer will know it can use these operations for implicit
         // conversion.
         ConversionCost conversionCost = getBaseTypeConversionCost(
-            kBaseTypes[tt],
-            kBaseTypes[ss]);
+            kBaseTypes[tt].tag,
+            kBaseTypes[ss].tag);
 
         IROp intrinsicOpCode = getBaseTypeConversionOp(
-            kBaseTypes[tt],
-            kBaseTypes[ss]);
+            kBaseTypes[tt].tag,
+            kBaseTypes[ss].tag);
 
         BuiltinConversionKind builtinConversionKind = kBuiltinConversion_Unknown;
         if (kBaseTypes[tt].tag == BaseType::Double &&

--- a/source/slang/slang-base-type-info.cpp
+++ b/source/slang/slang-base-type-info.cpp
@@ -1,8 +1,85 @@
 // slang-base-type-info.cpp
 #include "slang-base-type-info.h"
 
+#include "slang-ast-support-types.h"
+
 namespace Slang
 {
+namespace
+{
+// The core module generator emits scalar constructors for every builtin base
+// type. These classes are the single source of truth for ranking those
+// constructor conversions and for semantic-checking fast paths that bypass
+// constructor lookup.
+enum BaseTypeConversionKind : uint8_t
+{
+    kBaseTypeConversionKind_Signed,
+    kBaseTypeConversionKind_Unsigned,
+    kBaseTypeConversionKind_Float,
+    kBaseTypeConversionKind_Error,
+};
+enum BaseTypeConversionRank : uint8_t
+{
+    kBaseTypeConversionRank_Bool,
+    kBaseTypeConversionRank_Int8,
+    kBaseTypeConversionRank_Int16,
+    kBaseTypeConversionRank_Int32,
+    kBaseTypeConversionRank_IntPtr,
+    kBaseTypeConversionRank_Int64,
+    kBaseTypeConversionRank_Error,
+};
+
+struct BaseTypeConversionInfo
+{
+    BaseType tag;
+    BaseTypeConversionKind conversionKind;
+    BaseTypeConversionRank conversionRank;
+};
+
+static BaseTypeConversionInfo _getBaseTypeConversionInfo(BaseType baseType)
+{
+    switch (baseType)
+    {
+    case BaseType::Bool:
+        return {BaseType::Bool, kBaseTypeConversionKind_Unsigned, kBaseTypeConversionRank_Bool};
+
+    case BaseType::Int8:
+        return {BaseType::Int8, kBaseTypeConversionKind_Signed, kBaseTypeConversionRank_Int8};
+    case BaseType::Int16:
+        return {BaseType::Int16, kBaseTypeConversionKind_Signed, kBaseTypeConversionRank_Int16};
+    case BaseType::Int:
+        return {BaseType::Int, kBaseTypeConversionKind_Signed, kBaseTypeConversionRank_Int32};
+    case BaseType::Int64:
+        return {BaseType::Int64, kBaseTypeConversionKind_Signed, kBaseTypeConversionRank_Int64};
+    case BaseType::IntPtr:
+        return {BaseType::IntPtr, kBaseTypeConversionKind_Signed, kBaseTypeConversionRank_IntPtr};
+
+    case BaseType::UInt8:
+        return {BaseType::UInt8, kBaseTypeConversionKind_Unsigned, kBaseTypeConversionRank_Int8};
+    case BaseType::UInt16:
+        return {BaseType::UInt16, kBaseTypeConversionKind_Unsigned, kBaseTypeConversionRank_Int16};
+    case BaseType::UInt:
+        return {BaseType::UInt, kBaseTypeConversionKind_Unsigned, kBaseTypeConversionRank_Int32};
+    case BaseType::UInt64:
+        return {BaseType::UInt64, kBaseTypeConversionKind_Unsigned, kBaseTypeConversionRank_Int64};
+    case BaseType::UIntPtr:
+        return {
+            BaseType::UIntPtr,
+            kBaseTypeConversionKind_Unsigned,
+            kBaseTypeConversionRank_IntPtr};
+
+    case BaseType::Half:
+        return {BaseType::Half, kBaseTypeConversionKind_Float, kBaseTypeConversionRank_Int16};
+    case BaseType::Float:
+        return {BaseType::Float, kBaseTypeConversionKind_Float, kBaseTypeConversionRank_Int32};
+    case BaseType::Double:
+        return {BaseType::Double, kBaseTypeConversionKind_Float, kBaseTypeConversionRank_Int64};
+
+    default:
+        return {baseType, kBaseTypeConversionKind_Error, kBaseTypeConversionRank_Error};
+    }
+}
+} // namespace
 
 /* static */ const BaseTypeInfo BaseTypeInfo::s_info[Index(BaseType::CountOfPrimitives)] = {
     {0, 0, uint8_t(BaseType::Void)},
@@ -89,6 +166,91 @@ namespace Slang
             SLANG_ASSERT(!"Unknown basic type");
             return UnownedStringSlice();
         }
+    }
+}
+
+ConversionCost getBaseTypeConversionCost(BaseType toType, BaseType fromType)
+{
+    auto toInfo = _getBaseTypeConversionInfo(toType);
+    auto fromInfo = _getBaseTypeConversionInfo(fromType);
+    if (toInfo.conversionKind == kBaseTypeConversionKind_Error ||
+        fromInfo.conversionKind == kBaseTypeConversionKind_Error)
+    {
+        return kConversionCost_Impossible;
+    }
+
+    if (toInfo.conversionKind == fromInfo.conversionKind &&
+        toInfo.conversionRank == fromInfo.conversionRank)
+    {
+        // These should represent the exact same type.
+        return kConversionCost_None;
+    }
+
+    // Conversions within the same kind are easiest to handle: widening is a
+    // promotion, while narrowing is the general conversion fallback.
+    if (toInfo.conversionKind == fromInfo.conversionKind)
+    {
+        if (toInfo.conversionRank > fromInfo.conversionRank)
+            return kConversionCost_RankPromotion;
+        else
+            return kConversionCost_GeneralConversion;
+    }
+    else if (fromInfo.tag == BaseType::Bool && toInfo.tag == BaseType::Int)
+    {
+        return kConversionCost_BoolToInt;
+    }
+
+    // An unsigned integer can promote to a signed integer only when the signed
+    // rank is strictly larger and neither side is pointer-sized, because
+    // pointer-sized integer width is target-dependent.
+    else if (
+        toInfo.conversionKind == kBaseTypeConversionKind_Signed &&
+        fromInfo.conversionKind == kBaseTypeConversionKind_Unsigned &&
+        toInfo.conversionRank > fromInfo.conversionRank &&
+        toInfo.conversionRank != kBaseTypeConversionRank_IntPtr &&
+        fromInfo.conversionRank != kBaseTypeConversionRank_IntPtr)
+    {
+        return kConversionCost_UnsignedToSignedPromotion;
+    }
+    else if (
+        toInfo.conversionKind == kBaseTypeConversionKind_Signed &&
+        fromInfo.conversionKind == kBaseTypeConversionKind_Unsigned &&
+        toInfo.conversionRank == fromInfo.conversionRank &&
+        toInfo.conversionRank != kBaseTypeConversionRank_IntPtr &&
+        fromInfo.conversionRank != kBaseTypeConversionRank_IntPtr)
+    {
+        return kConversionCost_SameSizeUnsignedToSignedConversion;
+    }
+
+    // Signed-to-unsigned conversions are lossy, but they are preferred over
+    // same-size unsigned-to-signed conversions.
+    else if (
+        toInfo.conversionKind == kBaseTypeConversionKind_Unsigned &&
+        fromInfo.conversionKind == kBaseTypeConversionKind_Signed &&
+        toInfo.conversionRank >= fromInfo.conversionRank)
+    {
+        return kConversionCost_SignedToUnsignedConversion;
+    }
+
+    // Integer-to-floating conversions are not promotions. We still rank float
+    // and double above half so normal overload resolution prefers `float`.
+    else if (
+        toInfo.conversionKind == kBaseTypeConversionKind_Float &&
+        toInfo.conversionRank >= kBaseTypeConversionRank_Int32 &&
+        fromInfo.conversionRank >= kBaseTypeConversionRank_Int8)
+    {
+        return kConversionCost_IntegerToFloatConversion;
+    }
+    else if (
+        toInfo.conversionKind == kBaseTypeConversionKind_Float &&
+        toInfo.conversionRank >= kBaseTypeConversionRank_Int16 &&
+        fromInfo.conversionRank >= kBaseTypeConversionRank_Int8)
+    {
+        return kConversionCost_IntegerToHalfConversion;
+    }
+    else
+    {
+        return kConversionCost_GeneralConversion;
     }
 }
 

--- a/source/slang/slang-base-type-info.h
+++ b/source/slang/slang-base-type-info.h
@@ -15,6 +15,7 @@
 
 namespace Slang
 {
+typedef unsigned int ConversionCost;
 
 // Information about BaseType that's useful for checking literals
 struct BaseTypeInfo
@@ -46,5 +47,9 @@ struct BaseTypeInfo
 private:
     static const BaseTypeInfo s_info[Index(BaseType::CountOfPrimitives)];
 };
+
+/// Get the implicit conversion cost for the scalar base-type constructors
+/// generated into `core.meta.slang`.
+ConversionCost getBaseTypeConversionCost(BaseType toType, BaseType fromType);
 
 } // namespace Slang

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -2519,13 +2519,15 @@ bool SemanticsVisitor::_coerce(
         return true;
     }
 
-    // The main general-purpose approach for conversion is
-    // using suitable marked initializer ("constructor")
-    // declarations on the target type.
+    // Most implicit conversions are handled by the general constructor lookup path below: find
+    // suitable marked initializer declarations on the target type and run overload resolution.
     //
-    // This is treated as a form of overload resolution,
-    // since we are effectively forming an overloaded
-    // call to one of the initializers in the target type.
+    // Builtin scalar/vector/matrix conversions also exist as generated core-module constructors,
+    // but their accepted shapes and costs come from fixed tables. Re-running lookup and overload
+    // resolution for every `float(int)`, `float3(int)`, or `float2x2(int)` coercion just
+    // rediscovers those tables. When both sides have fully-known builtin shapes, mirror the
+    // generated constructors directly here, then fall through to constructor lookup for anything
+    // not covered so user-defined and less common conversions keep the normal semantics.
 
     BaseType toBase, fromBase;
     IntVal *toRows, *toCols, *fromRows, *fromCols;
@@ -2534,6 +2536,9 @@ bool SemanticsVisitor::_coerce(
     if (getBuiltinCompositeTypeShape(toType, toBase, toRows, toCols, &toLayout) &&
         getBuiltinCompositeTypeShape(fromType.type, fromBase, fromRows, fromCols, &fromLayout))
     {
+        // `getBuiltinCompositeTypeShape` reports scalars as no rows, vectors as rows only, and
+        // matrices as rows plus columns. The flags below make the conversion-cost cases line up
+        // with the constructor families generated in `core.meta.slang`.
         bool toIsScalar = !toRows;
         bool fromIsScalar = !fromRows;
         bool toIsVector = toRows && !toCols;
@@ -2547,6 +2552,9 @@ bool SemanticsVisitor::_coerce(
                          (toIsMatrix && fromIsMatrix && toRows->equals(fromRows) &&
                           toCols->equals(fromCols) && sameLayout);
 
+        // Start at impossible and opt in only when we can name the exact generated constructor
+        // family being mirrored. That keeps this as a performance shortcut, not a new conversion
+        // rule, because unsupported builtin shapes still use the general fallback below.
         ConversionCost builtinCoercionCost = kConversionCost_Impossible;
         bool isScalarFloatToDoubleCoercion = false;
         if (toIsScalar && fromIsScalar)
@@ -2592,6 +2600,9 @@ bool SemanticsVisitor::_coerce(
         }
         else if (fromIsVector && toIsScalar)
         {
+            // The generated vector1-to-scalar constructor is a shape coercion only: extract the
+            // sole element without changing its base type. Other vector-to-scalar forms either
+            // discard lanes or require an element conversion, so leave them to the normal path.
             if (auto constElementCount = as<ConstantIntVal>(fromRows))
             {
                 if (constElementCount->getValue() == 1 && toBase == fromBase)
@@ -2602,7 +2613,9 @@ bool SemanticsVisitor::_coerce(
         {
             // Mirror the scalar matrix constructors in core.meta.slang: same-element
             // splats, integer/float splats to floating-point matrices, and the special
-            // int -> int16_t matrix truncation constructor.
+            // int -> int16_t matrix truncation constructor. Matrix splats are intentionally
+            // narrower than vector splats, so they spell out the supported cases instead of
+            // blindly reusing the scalar base-type conversion table.
             auto toInfo = BaseTypeInfo::getInfo(toBase);
             bool toFloat = (toInfo.flags & BaseTypeInfo::Flag::FloatingPoint) != 0;
             if (toBase == fromBase)
@@ -2634,8 +2647,8 @@ bool SemanticsVisitor::_coerce(
                 *outCost = builtinCoercionCost;
             if (outToExpr)
             {
-                // Represent the chosen builtin conversion directly. IR lowering recreates
-                // the scalar splat and vector1-to-scalar forms that used to be introduced
+                // Represent the chosen builtin conversion directly. `IRBuilder::emitCast`
+                // recreates scalar splats and vector1-to-scalar forms that used to be introduced
                 // through generated core-module constructors.
                 auto castExpr = getASTBuilder()->create<BuiltinCastExpr>();
                 castExpr->type = toType;
@@ -2651,6 +2664,10 @@ bool SemanticsVisitor::_coerce(
         }
     }
 
+    // General fallback: use initializer ("constructor") declarations on the target type. This is
+    // treated as overload resolution because a coercion effectively forms a call to one of the
+    // target type's initializers, including user-defined conversions and builtin constructor shapes
+    // that the direct path above deliberately did not recognize.
     OverloadResolveContext overloadContext;
     overloadContext.disallowNestedConversions = (site != CoercionSite::ExplicitCoercion);
     overloadContext.argCount = 1;

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -2521,15 +2521,17 @@ bool SemanticsVisitor::_coerce(
         return true;
     }
 
-    // Most implicit conversions are handled by the general constructor lookup path below: find
-    // suitable marked initializer declarations on the target type and run overload resolution.
+    // The general conversion path below finds suitable initializer ("constructor") declarations
+    // on the target type and runs overload resolution to pick one.
     //
-    // Builtin scalar/vector/matrix conversions also exist as generated core-module constructors,
-    // but their accepted shapes and costs come from fixed tables. Re-running lookup and overload
-    // resolution for every `float(int)`, `float3(int)`, or `float2x2(int)` coercion just
-    // rediscovers those tables. When both sides have fully-known builtin shapes, mirror the
-    // generated constructors directly here, then fall through to constructor lookup for anything
-    // not covered so user-defined and less common conversions keep the normal semantics.
+    // Builtin scalar/vector/matrix conversions have a simpler source of truth: scalar element
+    // conversion costs come from `getBaseTypeConversionCost`, and `core.meta.slang` exposes those
+    // builtin conversions to user code as meta-programmed constructor declarations. We could let
+    // the general path resolve constructor calls like `float(int)`, `float3(int)`, or
+    // `float2x2(int)` to recover the same answer, but doing so spends a lot of compile time on
+    // lookup and overload resolution for facts the compiler already knows. For better compile-time
+    // performance, handle fully-known builtin conversions directly here and fall back to the
+    // general path for user-defined conversions and builtin shapes this fast path does not cover.
 
     BaseType toBase, fromBase;
     IntVal *toRows, *toCols, *fromRows, *fromCols;

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -1673,6 +1673,138 @@ bool SemanticsVisitor::_coerce(
                 getASTBuilder()->getBuiltinTypeCoercionWitness(fromType, toType);
     };
 
+    auto diagnoseImplicitConversion = [&](ConversionCost cost, bool isScalarFloatToDouble)
+    {
+        if (!outToExpr || site == CoercionSite::ExplicitCoercion || !fromExpr)
+            return;
+
+        bool overflowWarningDetected = false;
+        bool isCoreModule = false;
+        if (auto module = getShared()->getModule())
+            if (auto moduleDecl = module->getModuleDecl())
+                isCoreModule = moduleDecl->hasModifier<FromCoreModuleModifier>();
+
+        // Cache the constant-fold result so both the overflow check and
+        // the UnrecommendedImplicitConversion check can reuse it.
+        ConstantIntVal* cachedFoldedVal = nullptr;
+        bool hasFolded = false;
+        auto getFoldedIntVal = [&]() -> ConstantIntVal*
+        {
+            if (!hasFolded)
+            {
+                cachedFoldedVal = as<ConstantIntVal>(tryFoldIntegerConstantExpression(
+                    fromExpr,
+                    ConstantFoldingKind::CompileTime,
+                    nullptr));
+                hasFolded = true;
+            }
+            return cachedFoldedVal;
+        };
+
+        int maxBitSize = getMaximumTypeBitSize(toType);
+        if (!isCoreModule && maxBitSize > 0 && cost < kConversionCost_Explicit)
+        {
+            if (auto val = getFoldedIntVal())
+            {
+                IntegerLiteralValue v = val->getValue();
+                bool overflow = false;
+                if (v < 0)
+                {
+                    // Two's complement minimum for N bits is -(2^(N-1)).
+                    // For 64-bit targets, any int64_t value fits by definition.
+                    if (maxBitSize < 64)
+                    {
+                        int64_t minValue = -(INT64_C(1) << (maxBitSize - 1));
+                        overflow = v < minValue;
+                    }
+                }
+                else
+                {
+                    // Positive: bit-width comparison to avoid false positives
+                    // on hex bit-pattern idioms like int x = 0xFF030206.
+                    overflow = getIntValueBitSize(v) > maxBitSize;
+                }
+
+                if (overflow)
+                {
+                    // Set even when sink is null so that the
+                    // UnrecommendedImplicitConversion path below is
+                    // consistently suppressed for overflow cases.
+                    overflowWarningDetected = true;
+                    if (sink)
+                    {
+                        sink->diagnose(Diagnostics::IntegerConstantOverflow{
+                            .value = String(val->getValue()),
+                            .toType = toType,
+                            .expr = fromExpr});
+                    }
+                }
+            }
+        }
+
+        if (cost >= kConversionCost_Explicit)
+        {
+            if (sink)
+            {
+                sink->diagnose(Diagnostics::TypeMismatch{
+                    .expectedType = toType,
+                    .actualType = fromType,
+                    .expr = fromExpr});
+                sink->diagnose(Diagnostics::NoteExplicitConversionPossible{
+                    .fromType = fromType.type,
+                    .toType = toType,
+                    .location = fromExpr->loc});
+
+                if (auto fromPtrType = as<PtrType>(fromType.type))
+                {
+                    if (auto toPtrType = as<PtrType>(toType))
+                    {
+                        auto fromVal = fromPtrType->getValueType();
+                        auto toVal = toPtrType->getValueType();
+                        if (!isInterfaceType(fromVal) && isInterfaceType(toVal) &&
+                            tryGetSubtypeWitness(fromVal, toVal))
+                        {
+                            sink->diagnose(Diagnostics::NoteConcreteToInterfacePtrUnsafe{
+                                .from = fromVal,
+                                .to = toVal,
+                                .location = fromExpr->loc});
+                        }
+                    }
+                }
+            }
+        }
+        // For general implicit conversions with high cost, emit a warning
+        // unless the value is a known constant within the target type's
+        // range. Skip if the overflow check already covered this case.
+        else if (cost >= kConversionCost_Default && !overflowWarningDetected)
+        {
+            bool shouldEmitGeneralWarning = true;
+            if (isScalarIntegerType(toType) || isHalfType(toType))
+            {
+                if (auto val = getFoldedIntVal())
+                {
+                    if (isIntValueInRangeOfType(val->getValue(), toType))
+                    {
+                        shouldEmitGeneralWarning = false;
+                    }
+                }
+            }
+            if (shouldEmitGeneralWarning && sink)
+            {
+                sink->diagnose(Diagnostics::UnrecommendedImplicitConversion{
+                    .fromType = fromType.type,
+                    .toType = toType,
+                    .expr = fromExpr});
+            }
+        }
+
+        if (site == CoercionSite::Argument && isScalarFloatToDouble && sink)
+        {
+            if (!as<FloatingPointLiteralExpr>(fromExpr))
+                sink->diagnose(Diagnostics::ImplicitConversionToDouble{.expr = fromExpr});
+        }
+    };
+
 
     // If we are about to try and coerce an overloaded expression,
     // then we should start by trying to resolve the ambiguous reference
@@ -2382,6 +2514,121 @@ bool SemanticsVisitor::_coerce(
     // since we are effectively forming an overloaded
     // call to one of the initializers in the target type.
 
+    BaseType toBase, fromBase;
+    IntVal *toRows, *toCols, *fromRows, *fromCols;
+    IntVal* toLayout = nullptr;
+    IntVal* fromLayout = nullptr;
+    if (getBuiltinCompositeTypeShape(toType, toBase, toRows, toCols, &toLayout) &&
+        getBuiltinCompositeTypeShape(fromType.type, fromBase, fromRows, fromCols, &fromLayout))
+    {
+        bool toIsScalar = !toRows;
+        bool fromIsScalar = !fromRows;
+        bool toIsVector = toRows && !toCols;
+        bool fromIsVector = fromRows && !fromCols;
+        bool toIsMatrix = toRows && toCols;
+        bool fromIsMatrix = fromRows && fromCols;
+        bool sameLayout =
+            toLayout == fromLayout || (toLayout && fromLayout && toLayout->equals(fromLayout));
+        bool sameShape = (toIsScalar && fromIsScalar) ||
+                         (toIsVector && fromIsVector && toRows->equals(fromRows)) ||
+                         (toIsMatrix && fromIsMatrix && toRows->equals(fromRows) &&
+                          toCols->equals(fromCols) && sameLayout);
+
+        ConversionCost builtinCoercionCost = kConversionCost_Impossible;
+        bool isScalarFloatToDoubleCoercion = false;
+        if (toIsScalar && fromIsScalar)
+        {
+            builtinCoercionCost = getBaseTypeConversionCost(toBase, fromBase);
+            if (builtinCoercionCost != kConversionCost_Impossible && isScalarIntegerType(toType))
+            {
+                // Keep integer literal overload ranking identical to the generated scalar
+                // constructors, which prefer in-range literals over ordinary narrowing.
+                if (auto knownVal = as<IntegerLiteralExpr>(fromExpr))
+                {
+                    if (getIntValueBitSize(knownVal->value) <= getMaximumTypeBitSize(toType))
+                    {
+                        bool toTypeIsSigned = isSigned(toType);
+                        bool fromTypeIsSigned = isSigned(knownVal->type);
+                        if (toTypeIsSigned == fromTypeIsSigned)
+                            builtinCoercionCost = kConversionCost_InRangeIntLitConversion;
+                        else if (toTypeIsSigned)
+                            builtinCoercionCost =
+                                kConversionCost_InRangeIntLitUnsignedToSignedConversion;
+                        else
+                            builtinCoercionCost =
+                                kConversionCost_InRangeIntLitSignedToUnsignedConversion;
+                    }
+                }
+            }
+            isScalarFloatToDoubleCoercion =
+                toBase == BaseType::Double && fromBase == BaseType::Float;
+        }
+        else if (toIsVector && fromIsScalar)
+        {
+            // This is the vector<T,N>(T) scalar splat constructor. The element
+            // conversion cost still comes from the shared scalar conversion table.
+            builtinCoercionCost = getBaseTypeConversionCost(toBase, fromBase);
+            if (builtinCoercionCost != kConversionCost_Impossible)
+                builtinCoercionCost += kConversionCost_ScalarToVector;
+        }
+        else if (sameShape)
+        {
+            // Vector/matrix element casts with unchanged shape map to the generated
+            // vector<T,N>(vector<U,N>) and matrix<T,R,C,L>(matrix<U,R,C,L>) constructors.
+            builtinCoercionCost = getBaseTypeConversionCost(toBase, fromBase);
+        }
+        else if (fromIsVector && toIsScalar)
+        {
+            if (auto constElementCount = as<ConstantIntVal>(fromRows))
+            {
+                if (constElementCount->getValue() == 1 && toBase == fromBase)
+                    builtinCoercionCost = kConversionCost_OneVectorToScalar;
+            }
+        }
+        else if (toIsMatrix && fromIsScalar)
+        {
+            // Mirror the scalar matrix constructors in core.meta.slang: same-element
+            // splats, integer/float splats to floating-point matrices, and the special
+            // int -> int16_t matrix truncation constructor.
+            auto toInfo = BaseTypeInfo::getInfo(toBase);
+            bool toFloat = (toInfo.flags & BaseTypeInfo::Flag::FloatingPoint) != 0;
+            if (toBase == fromBase)
+                builtinCoercionCost = kConversionCost_ScalarToMatrix;
+            else if (toFloat && fromBase == BaseType::Int)
+                builtinCoercionCost = kConversionCost_ScalarIntegerToFloatMatrix;
+            else if (toFloat && fromBase == BaseType::Float)
+                builtinCoercionCost = kConversionCost_ScalarToMatrix;
+            else if (toBase == BaseType::Int16 && fromBase == BaseType::Int)
+                builtinCoercionCost = kConversionCost_IntegerTruncate;
+        }
+
+        if (builtinCoercionCost != kConversionCost_Impossible)
+        {
+            diagnoseImplicitConversion(builtinCoercionCost, isScalarFloatToDoubleCoercion);
+
+            if (fromType.isLeftValue)
+                builtinCoercionCost += kConversionCost_LValueCast;
+            if (outCost)
+                *outCost = builtinCoercionCost;
+            if (outToExpr)
+            {
+                // Represent the chosen builtin conversion directly. IR lowering recreates
+                // the scalar splat and vector1-to-scalar forms that used to be introduced
+                // through generated core-module constructors.
+                auto castExpr = getASTBuilder()->create<BuiltinCastExpr>();
+                castExpr->type = toType;
+                if (fromExpr)
+                {
+                    castExpr->loc = fromExpr->loc;
+                    castExpr->base = fromExpr;
+                }
+                *outToExpr = castExpr;
+            }
+            setWitnessOfConversionToBuiltinConversion();
+            return true;
+        }
+    }
+
     OverloadResolveContext overloadContext;
     overloadContext.disallowNestedConversions = (site != CoercionSite::ExplicitCoercion);
     overloadContext.argCount = 1;
@@ -2548,146 +2795,16 @@ bool SemanticsVisitor::_coerce(
             toType,
             fromExpr);
 
-        // If the cost is too high to be usable as an
-        // implicit conversion, then we will report the
-        // conversion as possible (so that an overload involving
-        // this conversion will be selected over one without),
-        // but then emit a diagnostic when actually reifying
-        // the result expression.
-        //
-        if (outToExpr && site != CoercionSite::ExplicitCoercion)
+        bool isScalarFloatToDoubleConversion = false;
+        if (site == CoercionSite::Argument && outToExpr)
         {
-            bool overflowWarningDetected = false;
-            bool isCoreModule = false;
-            if (auto module = getShared()->getModule())
-                if (auto moduleDecl = module->getModuleDecl())
-                    isCoreModule = moduleDecl->hasModifier<FromCoreModuleModifier>();
-
-            // Cache the constant-fold result so both the overflow check and
-            // the UnrecommendedImplicitConversion check can reuse it.
-            ConstantIntVal* cachedFoldedVal = nullptr;
-            bool hasFolded = false;
-            auto getFoldedIntVal = [&]() -> ConstantIntVal*
-            {
-                if (!hasFolded)
-                {
-                    cachedFoldedVal = as<ConstantIntVal>(tryFoldIntegerConstantExpression(
-                        fromExpr,
-                        ConstantFoldingKind::CompileTime,
-                        nullptr));
-                    hasFolded = true;
-                }
-                return cachedFoldedVal;
-            };
-
-            int maxBitSize = getMaximumTypeBitSize(toType);
-            if (!isCoreModule && maxBitSize > 0 && cost < kConversionCost_Explicit)
-            {
-                if (auto val = getFoldedIntVal())
-                {
-                    IntegerLiteralValue v = val->getValue();
-                    bool overflow = false;
-                    if (v < 0)
-                    {
-                        // Two's complement minimum for N bits is -(2^(N-1)).
-                        // For 64-bit targets, any int64_t value fits by definition.
-                        if (maxBitSize < 64)
-                        {
-                            int64_t minValue = -(INT64_C(1) << (maxBitSize - 1));
-                            overflow = v < minValue;
-                        }
-                    }
-                    else
-                    {
-                        // Positive: bit-width comparison to avoid false positives
-                        // on hex bit-pattern idioms like int x = 0xFF030206.
-                        overflow = getIntValueBitSize(v) > maxBitSize;
-                    }
-
-                    if (overflow)
-                    {
-                        // Set even when sink is null so that the
-                        // UnrecommendedImplicitConversion path below is
-                        // consistently suppressed for overflow cases.
-                        overflowWarningDetected = true;
-                        if (sink)
-                        {
-                            sink->diagnose(Diagnostics::IntegerConstantOverflow{
-                                .value = String(val->getValue()),
-                                .toType = toType,
-                                .expr = fromExpr});
-                        }
-                    }
-                }
-            }
-
-            if (cost >= kConversionCost_Explicit)
-            {
-                if (sink)
-                {
-                    sink->diagnose(Diagnostics::TypeMismatch{
-                        .expectedType = toType,
-                        .actualType = fromType,
-                        .expr = fromExpr});
-                    sink->diagnose(Diagnostics::NoteExplicitConversionPossible{
-                        .fromType = fromType.type,
-                        .toType = toType,
-                        .location = fromExpr->loc});
-
-                    if (auto fromPtrType = as<PtrType>(fromType.type))
-                    {
-                        if (auto toPtrType = as<PtrType>(toType))
-                        {
-                            auto fromVal = fromPtrType->getValueType();
-                            auto toVal = toPtrType->getValueType();
-                            if (!isInterfaceType(fromVal) && isInterfaceType(toVal) &&
-                                tryGetSubtypeWitness(fromVal, toVal))
-                            {
-                                sink->diagnose(Diagnostics::NoteConcreteToInterfacePtrUnsafe{
-                                    .from = fromVal,
-                                    .to = toVal,
-                                    .location = fromExpr->loc});
-                            }
-                        }
-                    }
-                }
-            }
-            // For general implicit conversions with high cost, emit a warning
-            // unless the value is a known constant within the target type's
-            // range. Skip if the overflow check already covered this case.
-            else if (cost >= kConversionCost_Default && !overflowWarningDetected)
-            {
-                bool shouldEmitGeneralWarning = true;
-                if (isScalarIntegerType(toType) || isHalfType(toType))
-                {
-                    if (auto val = getFoldedIntVal())
-                    {
-                        if (isIntValueInRangeOfType(val->getValue(), toType))
-                        {
-                            shouldEmitGeneralWarning = false;
-                        }
-                    }
-                }
-                if (shouldEmitGeneralWarning && sink)
-                {
-                    sink->diagnose(Diagnostics::UnrecommendedImplicitConversion{
-                        .fromType = fromType.type,
-                        .toType = toType,
-                        .expr = fromExpr});
-                }
-            }
-
-            if (site == CoercionSite::Argument && sink)
-            {
-                auto builtinConversionKind = getImplicitConversionBuiltinKind(
-                    overloadContext.bestCandidate->item.declRef.getDecl());
-                if (builtinConversionKind == kBuiltinConversion_FloatToDouble)
-                {
-                    if (!as<FloatingPointLiteralExpr>(fromExpr))
-                        sink->diagnose(Diagnostics::ImplicitConversionToDouble{.expr = fromExpr});
-                }
-            }
+            auto builtinConversionKind = getImplicitConversionBuiltinKind(
+                overloadContext.bestCandidate->item.declRef.getDecl());
+            isScalarFloatToDoubleConversion =
+                builtinConversionKind == kBuiltinConversion_FloatToDouble;
         }
+        diagnoseImplicitConversion(cost, isScalarFloatToDoubleConversion);
+
         if (fromType.isLeftValue)
         {
             // If we are implicitly casting the type of an l-value, we need to impose additional

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -1611,14 +1611,16 @@ int getMaximumTypeBitSize(Type* t)
     }
 }
 
-/// Emit diagnostics for an implicit conversion once the caller has decided to build the converted
-/// expression.
+/// Emit diagnostics for an implicit conversion once `_coerce` is building the converted
+/// expression, rather than only checking whether a conversion is possible.
 ///
-/// Conversion-cost probes run while overload resolution is still exploring candidates, so
-/// `shouldDiagnose` mirrors the old `outToExpr != nullptr` check and keeps those probes silent.
+/// `_coerce` is also used by overload resolution to ask "could this candidate convert, and what
+/// would it cost?" Those exploratory calls may examine candidates that will be rejected later, so
+/// they must not produce warnings or errors. Only expression-building calls, represented here by
+/// `isBuildingCoercedExpr`, should report diagnostics.
 static void _diagnoseImplicitConversion(
     SemanticsVisitor* visitor,
-    bool shouldDiagnose,
+    bool isBuildingCoercedExpr,
     CoercionSite site,
     Type* toType,
     QualType fromType,
@@ -1627,7 +1629,7 @@ static void _diagnoseImplicitConversion(
     ConversionCost cost,
     bool isScalarFloatToDouble)
 {
-    if (!shouldDiagnose || site == CoercionSite::ExplicitCoercion || !fromExpr)
+    if (!isBuildingCoercedExpr || site == CoercionSite::ExplicitCoercion || !fromExpr)
         return;
 
     bool overflowWarningDetected = false;

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -1611,6 +1611,151 @@ int getMaximumTypeBitSize(Type* t)
     }
 }
 
+/// Emit diagnostics for an implicit conversion once the caller has decided to build the converted
+/// expression.
+///
+/// Conversion-cost probes run while overload resolution is still exploring candidates, so
+/// `shouldDiagnose` mirrors the old `outToExpr != nullptr` check and keeps those probes silent.
+static void _diagnoseImplicitConversion(
+    SemanticsVisitor* visitor,
+    bool shouldDiagnose,
+    CoercionSite site,
+    Type* toType,
+    QualType fromType,
+    Expr* fromExpr,
+    DiagnosticSink* sink,
+    ConversionCost cost,
+    bool isScalarFloatToDouble)
+{
+    if (!shouldDiagnose || site == CoercionSite::ExplicitCoercion || !fromExpr)
+        return;
+
+    bool overflowWarningDetected = false;
+    bool isCoreModule = false;
+    if (auto module = visitor->getShared()->getModule())
+        if (auto moduleDecl = module->getModuleDecl())
+            isCoreModule = moduleDecl->hasModifier<FromCoreModuleModifier>();
+
+    // Cache the constant-fold result so both the overflow check and
+    // the UnrecommendedImplicitConversion check can reuse it.
+    ConstantIntVal* cachedFoldedVal = nullptr;
+    bool hasFolded = false;
+    auto getFoldedIntVal = [&]() -> ConstantIntVal*
+    {
+        if (!hasFolded)
+        {
+            cachedFoldedVal = as<ConstantIntVal>(visitor->tryFoldIntegerConstantExpression(
+                fromExpr,
+                SemanticsVisitor::ConstantFoldingKind::CompileTime,
+                nullptr));
+            hasFolded = true;
+        }
+        return cachedFoldedVal;
+    };
+
+    int maxBitSize = getMaximumTypeBitSize(toType);
+    if (!isCoreModule && maxBitSize > 0 && cost < kConversionCost_Explicit)
+    {
+        if (auto val = getFoldedIntVal())
+        {
+            IntegerLiteralValue v = val->getValue();
+            bool overflow = false;
+            if (v < 0)
+            {
+                // Two's complement minimum for N bits is -(2^(N-1)).
+                // For 64-bit targets, any int64_t value fits by definition.
+                if (maxBitSize < 64)
+                {
+                    int64_t minValue = -(INT64_C(1) << (maxBitSize - 1));
+                    overflow = v < minValue;
+                }
+            }
+            else
+            {
+                // Positive: bit-width comparison to avoid false positives
+                // on hex bit-pattern idioms like int x = 0xFF030206.
+                overflow = getIntValueBitSize(v) > maxBitSize;
+            }
+
+            if (overflow)
+            {
+                // Set even when sink is null so that the UnrecommendedImplicitConversion
+                // path below is consistently suppressed for overflow cases.
+                overflowWarningDetected = true;
+                if (sink)
+                {
+                    sink->diagnose(Diagnostics::IntegerConstantOverflow{
+                        .value = String(val->getValue()),
+                        .toType = toType,
+                        .expr = fromExpr});
+                }
+            }
+        }
+    }
+
+    if (cost >= kConversionCost_Explicit)
+    {
+        if (sink)
+        {
+            sink->diagnose(Diagnostics::TypeMismatch{
+                .expectedType = toType,
+                .actualType = fromType,
+                .expr = fromExpr});
+            sink->diagnose(Diagnostics::NoteExplicitConversionPossible{
+                .fromType = fromType.type,
+                .toType = toType,
+                .location = fromExpr->loc});
+
+            if (auto fromPtrType = as<PtrType>(fromType.type))
+            {
+                if (auto toPtrType = as<PtrType>(toType))
+                {
+                    auto fromVal = fromPtrType->getValueType();
+                    auto toVal = toPtrType->getValueType();
+                    if (!isInterfaceType(fromVal) && isInterfaceType(toVal) &&
+                        visitor->tryGetSubtypeWitness(fromVal, toVal))
+                    {
+                        sink->diagnose(Diagnostics::NoteConcreteToInterfacePtrUnsafe{
+                            .from = fromVal,
+                            .to = toVal,
+                            .location = fromExpr->loc});
+                    }
+                }
+            }
+        }
+    }
+    // For general implicit conversions with high cost, emit a warning unless the value is a known
+    // constant within the target type's range. Skip if the overflow check already covered this
+    // case.
+    else if (cost >= kConversionCost_Default && !overflowWarningDetected)
+    {
+        bool shouldEmitGeneralWarning = true;
+        if (visitor->isScalarIntegerType(toType) || visitor->isHalfType(toType))
+        {
+            if (auto val = getFoldedIntVal())
+            {
+                if (visitor->isIntValueInRangeOfType(val->getValue(), toType))
+                {
+                    shouldEmitGeneralWarning = false;
+                }
+            }
+        }
+        if (shouldEmitGeneralWarning && sink)
+        {
+            sink->diagnose(Diagnostics::UnrecommendedImplicitConversion{
+                .fromType = fromType.type,
+                .toType = toType,
+                .expr = fromExpr});
+        }
+    }
+
+    if (site == CoercionSite::Argument && isScalarFloatToDouble && sink)
+    {
+        if (!as<FloatingPointLiteralExpr>(fromExpr))
+            sink->diagnose(Diagnostics::ImplicitConversionToDouble{.expr = fromExpr});
+    }
+}
+
 ConversionCost SemanticsVisitor::getImplicitConversionCostWithKnownArg(
     DeclRef<Decl> decl,
     Type* toType,
@@ -1671,138 +1816,6 @@ bool SemanticsVisitor::_coerce(
         if (outWitnessOfConversion)
             *outWitnessOfConversion =
                 getASTBuilder()->getBuiltinTypeCoercionWitness(fromType, toType);
-    };
-
-    auto diagnoseImplicitConversion = [&](ConversionCost cost, bool isScalarFloatToDouble)
-    {
-        if (!outToExpr || site == CoercionSite::ExplicitCoercion || !fromExpr)
-            return;
-
-        bool overflowWarningDetected = false;
-        bool isCoreModule = false;
-        if (auto module = getShared()->getModule())
-            if (auto moduleDecl = module->getModuleDecl())
-                isCoreModule = moduleDecl->hasModifier<FromCoreModuleModifier>();
-
-        // Cache the constant-fold result so both the overflow check and
-        // the UnrecommendedImplicitConversion check can reuse it.
-        ConstantIntVal* cachedFoldedVal = nullptr;
-        bool hasFolded = false;
-        auto getFoldedIntVal = [&]() -> ConstantIntVal*
-        {
-            if (!hasFolded)
-            {
-                cachedFoldedVal = as<ConstantIntVal>(tryFoldIntegerConstantExpression(
-                    fromExpr,
-                    ConstantFoldingKind::CompileTime,
-                    nullptr));
-                hasFolded = true;
-            }
-            return cachedFoldedVal;
-        };
-
-        int maxBitSize = getMaximumTypeBitSize(toType);
-        if (!isCoreModule && maxBitSize > 0 && cost < kConversionCost_Explicit)
-        {
-            if (auto val = getFoldedIntVal())
-            {
-                IntegerLiteralValue v = val->getValue();
-                bool overflow = false;
-                if (v < 0)
-                {
-                    // Two's complement minimum for N bits is -(2^(N-1)).
-                    // For 64-bit targets, any int64_t value fits by definition.
-                    if (maxBitSize < 64)
-                    {
-                        int64_t minValue = -(INT64_C(1) << (maxBitSize - 1));
-                        overflow = v < minValue;
-                    }
-                }
-                else
-                {
-                    // Positive: bit-width comparison to avoid false positives
-                    // on hex bit-pattern idioms like int x = 0xFF030206.
-                    overflow = getIntValueBitSize(v) > maxBitSize;
-                }
-
-                if (overflow)
-                {
-                    // Set even when sink is null so that the
-                    // UnrecommendedImplicitConversion path below is
-                    // consistently suppressed for overflow cases.
-                    overflowWarningDetected = true;
-                    if (sink)
-                    {
-                        sink->diagnose(Diagnostics::IntegerConstantOverflow{
-                            .value = String(val->getValue()),
-                            .toType = toType,
-                            .expr = fromExpr});
-                    }
-                }
-            }
-        }
-
-        if (cost >= kConversionCost_Explicit)
-        {
-            if (sink)
-            {
-                sink->diagnose(Diagnostics::TypeMismatch{
-                    .expectedType = toType,
-                    .actualType = fromType,
-                    .expr = fromExpr});
-                sink->diagnose(Diagnostics::NoteExplicitConversionPossible{
-                    .fromType = fromType.type,
-                    .toType = toType,
-                    .location = fromExpr->loc});
-
-                if (auto fromPtrType = as<PtrType>(fromType.type))
-                {
-                    if (auto toPtrType = as<PtrType>(toType))
-                    {
-                        auto fromVal = fromPtrType->getValueType();
-                        auto toVal = toPtrType->getValueType();
-                        if (!isInterfaceType(fromVal) && isInterfaceType(toVal) &&
-                            tryGetSubtypeWitness(fromVal, toVal))
-                        {
-                            sink->diagnose(Diagnostics::NoteConcreteToInterfacePtrUnsafe{
-                                .from = fromVal,
-                                .to = toVal,
-                                .location = fromExpr->loc});
-                        }
-                    }
-                }
-            }
-        }
-        // For general implicit conversions with high cost, emit a warning
-        // unless the value is a known constant within the target type's
-        // range. Skip if the overflow check already covered this case.
-        else if (cost >= kConversionCost_Default && !overflowWarningDetected)
-        {
-            bool shouldEmitGeneralWarning = true;
-            if (isScalarIntegerType(toType) || isHalfType(toType))
-            {
-                if (auto val = getFoldedIntVal())
-                {
-                    if (isIntValueInRangeOfType(val->getValue(), toType))
-                    {
-                        shouldEmitGeneralWarning = false;
-                    }
-                }
-            }
-            if (shouldEmitGeneralWarning && sink)
-            {
-                sink->diagnose(Diagnostics::UnrecommendedImplicitConversion{
-                    .fromType = fromType.type,
-                    .toType = toType,
-                    .expr = fromExpr});
-            }
-        }
-
-        if (site == CoercionSite::Argument && isScalarFloatToDouble && sink)
-        {
-            if (!as<FloatingPointLiteralExpr>(fromExpr))
-                sink->diagnose(Diagnostics::ImplicitConversionToDouble{.expr = fromExpr});
-        }
     };
 
 
@@ -2604,7 +2617,16 @@ bool SemanticsVisitor::_coerce(
 
         if (builtinCoercionCost != kConversionCost_Impossible)
         {
-            diagnoseImplicitConversion(builtinCoercionCost, isScalarFloatToDoubleCoercion);
+            _diagnoseImplicitConversion(
+                this,
+                outToExpr != nullptr,
+                site,
+                toType,
+                fromType,
+                fromExpr,
+                sink,
+                builtinCoercionCost,
+                isScalarFloatToDoubleCoercion);
 
             if (fromType.isLeftValue)
                 builtinCoercionCost += kConversionCost_LValueCast;
@@ -2803,7 +2825,16 @@ bool SemanticsVisitor::_coerce(
             isScalarFloatToDoubleConversion =
                 builtinConversionKind == kBuiltinConversion_FloatToDouble;
         }
-        diagnoseImplicitConversion(cost, isScalarFloatToDoubleConversion);
+        _diagnoseImplicitConversion(
+            this,
+            outToExpr != nullptr,
+            site,
+            toType,
+            fromType,
+            fromExpr,
+            sink,
+            cost,
+            isScalarFloatToDoubleConversion);
 
         if (fromType.isLeftValue)
         {

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -4436,17 +4436,17 @@ bool SemanticsExprVisitor::isGLSLOperatorScope()
     return getShared()->isGLSLOperatorScope();
 }
 
-// Decompose a builtin numeric type into (base element type, shape). `outRows`/`outCols`
-// describe the shape: both null => scalar, rows set & cols null => vector<rows>, both set =>
-// matrix<rows,cols>. Returns false if `type` is not a builtin scalar/vector/matrix.
-static bool _getBuiltinCompositeTypeShape(
+bool getBuiltinCompositeTypeShape(
     Type* type,
     BaseType& outBase,
     IntVal*& outRows,
-    IntVal*& outCols)
+    IntVal*& outCols,
+    IntVal** outLayout)
 {
     outRows = nullptr;
     outCols = nullptr;
+    if (outLayout)
+        *outLayout = nullptr;
     Type* elementType = type;
     if (auto vecType = as<VectorExpressionType>(type))
     {
@@ -4457,6 +4457,8 @@ static bool _getBuiltinCompositeTypeShape(
     {
         outRows = matType->getRowCount();
         outCols = matType->getColumnCount();
+        if (outLayout)
+            *outLayout = matType->getLayout();
         elementType = matType->getElementType();
     }
     auto basic = as<BasicExpressionType>(elementType);
@@ -4530,7 +4532,7 @@ Type* SemanticsExprVisitor::coerceOperandsOfBuiltinBinaryExpr(
         return nullptr;
     BaseType commonBase;
     IntVal *cRows, *cCols;
-    _getBuiltinCompositeTypeShape(commonType, commonBase, cRows, cCols);
+    getBuiltinCompositeTypeShape(commonType, commonBase, cRows, cCols);
     Type* commonElementType = m_astBuilder->getBuiltinType(commonBase);
 
     // Coerce each operand to its *own* shape with the common element base, converting only the
@@ -4782,9 +4784,9 @@ Type* SemanticsExprVisitor::getBuiltinArithmeticCommonType(Type* left, Type* rig
 {
     BaseType leftBase, rightBase;
     IntVal *leftRows, *leftCols, *rightRows, *rightCols;
-    if (!_getBuiltinCompositeTypeShape(left, leftBase, leftRows, leftCols))
+    if (!getBuiltinCompositeTypeShape(left, leftBase, leftRows, leftCols))
         return nullptr;
-    if (!_getBuiltinCompositeTypeShape(right, rightBase, rightRows, rightCols))
+    if (!getBuiltinCompositeTypeShape(right, rightBase, rightRows, rightCols))
         return nullptr;
 
     // Only well-known numeric base types are handled here; anything else (Void and other

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -88,6 +88,17 @@ inline int getIntValueBitSize(IntegerLiteralValue val)
 // the maximum supported value of 64 is returned instead.
 int getMaximumTypeBitSize(Type* t);
 
+// Decompose a builtin scalar/vector/matrix type into its element base type and shape.
+// A scalar reports null rows/cols; a vector reports rows only; a matrix reports rows,
+// columns, and layout. Returns false for non-builtin arithmetic shapes so callers can
+// fall back to normal semantic checking.
+bool getBuiltinCompositeTypeShape(
+    Type* type,
+    BaseType& outBase,
+    IntVal*& outRows,
+    IntVal*& outCols,
+    IntVal** outLayout = nullptr);
+
 // A flat representation of basic types (scalars, vectors and matrices)
 // that can be used as lookup key in caches
 struct BasicTypeKey

--- a/source/slang/slang-ir.cpp
+++ b/source/slang/slang-ir.cpp
@@ -4219,11 +4219,47 @@ static TypeCastStyle _getTypeStyleId(IRType* type)
 
 IRInst* IRBuilder::emitCast(IRType* type, IRInst* value, bool fallbackToBuiltinCast)
 {
-    if (isTypeEqual(type, value->getDataType()))
+    auto valueType = value->getDataType();
+    if (isTypeEqual(type, valueType))
         return value;
 
+    auto sourceVectorType = as<IRVectorType>(valueType);
+    auto sourceMatrixType = as<IRMatrixType>(valueType);
+
+    // Some semantic builtin casts represent constructor-shaped coercions, not just element type
+    // casts. Lower those shapes here so every caller of emitCast gets the same scalar splat and
+    // vector1-to-scalar behavior that the core-module constructors used to provide.
+    if (auto targetVectorType = as<IRVectorType>(type))
+    {
+        if (!sourceVectorType && !sourceMatrixType)
+        {
+            auto scalarVal =
+                emitCast(targetVectorType->getElementType(), value, fallbackToBuiltinCast);
+            if (!scalarVal)
+                return nullptr;
+            return emitMakeVectorFromScalar(type, scalarVal);
+        }
+    }
+    else if (auto targetMatrixType = as<IRMatrixType>(type))
+    {
+        if (!sourceVectorType && !sourceMatrixType)
+        {
+            auto scalarVal =
+                emitCast(targetMatrixType->getElementType(), value, fallbackToBuiltinCast);
+            if (!scalarVal)
+                return nullptr;
+            return emitMakeMatrixFromScalar(type, scalarVal);
+        }
+    }
+    else if (sourceVectorType)
+    {
+        auto elementCount = as<IRIntLit>(sourceVectorType->getElementCount());
+        if (elementCount && elementCount->getValue() == 1)
+            return emitVectorReshape(type, value);
+    }
+
     auto toStyle = _getTypeStyleId(type);
-    auto fromStyle = _getTypeStyleId(value->getDataType());
+    auto fromStyle = _getTypeStyleId(valueType);
 
     if (fromStyle == TypeCastStyle::Void)
     {

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -6936,34 +6936,6 @@ struct ExprLoweringVisitorBase : public ExprVisitor<Derived, LoweredValInfo>
         auto builder = context->irBuilder;
         auto irType = lowerType(context, expr->type);
         auto irVal = getSimpleVal(context, lowerRValueExpr(context, expr->base));
-        auto irValType = irVal->getDataType();
-
-        // Builtin coercion fast paths can now create `BuiltinCastExpr` for conversions
-        // that used to lower through core-module constructors. Recreate those constructor
-        // intrinsics here so scalar splats and vector1-to-scalar casts keep their IR shape.
-        if (auto targetVectorType = as<IRVectorType>(irType))
-        {
-            if (!as<IRVectorType>(irValType))
-            {
-                auto scalarVal = builder->emitCast(targetVectorType->getElementType(), irVal);
-                return LoweredValInfo::simple(builder->emitMakeVectorFromScalar(irType, scalarVal));
-            }
-        }
-        else if (auto targetMatrixType = as<IRMatrixType>(irType))
-        {
-            if (!as<IRMatrixType>(irValType))
-            {
-                auto scalarVal = builder->emitCast(targetMatrixType->getElementType(), irVal);
-                return LoweredValInfo::simple(builder->emitMakeMatrixFromScalar(irType, scalarVal));
-            }
-        }
-        else if (auto sourceVectorType = as<IRVectorType>(irValType))
-        {
-            auto elementCount = as<IRIntLit>(sourceVectorType->getElementCount());
-            if (elementCount && elementCount->getValue() == 1)
-                return LoweredValInfo::simple(builder->emitVectorReshape(irType, irVal));
-        }
-
         return LoweredValInfo::simple(builder->emitCast(irType, irVal));
     }
 

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -6933,9 +6933,38 @@ struct ExprLoweringVisitorBase : public ExprVisitor<Derived, LoweredValInfo>
 
     LoweredValInfo visitBuiltinCastExpr(BuiltinCastExpr* expr)
     {
+        auto builder = context->irBuilder;
         auto irType = lowerType(context, expr->type);
         auto irVal = getSimpleVal(context, lowerRValueExpr(context, expr->base));
-        return LoweredValInfo::simple(context->irBuilder->emitCast(irType, irVal));
+        auto irValType = irVal->getDataType();
+
+        // Builtin coercion fast paths can now create `BuiltinCastExpr` for conversions
+        // that used to lower through core-module constructors. Recreate those constructor
+        // intrinsics here so scalar splats and vector1-to-scalar casts keep their IR shape.
+        if (auto targetVectorType = as<IRVectorType>(irType))
+        {
+            if (!as<IRVectorType>(irValType))
+            {
+                auto scalarVal = builder->emitCast(targetVectorType->getElementType(), irVal);
+                return LoweredValInfo::simple(builder->emitMakeVectorFromScalar(irType, scalarVal));
+            }
+        }
+        else if (auto targetMatrixType = as<IRMatrixType>(irType))
+        {
+            if (!as<IRMatrixType>(irValType))
+            {
+                auto scalarVal = builder->emitCast(targetMatrixType->getElementType(), irVal);
+                return LoweredValInfo::simple(builder->emitMakeMatrixFromScalar(irType, scalarVal));
+            }
+        }
+        else if (auto sourceVectorType = as<IRVectorType>(irValType))
+        {
+            auto elementCount = as<IRIntLit>(sourceVectorType->getElementCount());
+            if (elementCount && elementCount->getValue() == 1)
+                return LoweredValInfo::simple(builder->emitVectorReshape(irType, irVal));
+        }
+
+        return LoweredValInfo::simple(builder->emitCast(irType, irVal));
     }
 
     /// Emit code for a `try` invoke.

--- a/tests/language-feature/operator-overload/builtin-coercion-fastpath.slang
+++ b/tests/language-feature/operator-overload/builtin-coercion-fastpath.slang
@@ -1,0 +1,39 @@
+// Regression/correctness test for the hard-coded builtin scalar/vector/matrix coercion fast path.
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0 0 0], stride=4)
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    int seed = outputBuffer[0] + 3;
+
+    float scalarValue = seed;
+    float3 vectorFromScalar = seed;
+
+    int3 intVector = int3(seed, seed + 1, seed + 2);
+    float3 vectorFromVector = intVector;
+
+    float2x2 matrixFromScalar = seed;
+
+    int2x2 intMatrix = seed;
+    float2x2 matrixFromMatrix = intMatrix;
+
+    vector<int, 1> oneVector = seed + 4;
+    int scalarFromOneVector = oneVector;
+
+    outputBuffer[0] = (int)scalarValue;
+    outputBuffer[1] = (int)(vectorFromScalar.x + vectorFromScalar.y + vectorFromScalar.z);
+    outputBuffer[2] = (int)(vectorFromVector.x + vectorFromVector.y + vectorFromVector.z);
+    outputBuffer[3] = (int)(matrixFromScalar[0][0] + matrixFromScalar[1][1]);
+    outputBuffer[4] = (int)(matrixFromMatrix[0][1] + matrixFromMatrix[1][0]);
+    outputBuffer[5] = scalarFromOneVector;
+
+    // CHECK: 3
+    // CHECK: 9
+    // CHECK: 12
+    // CHECK: 6
+    // CHECK: 6
+    // CHECK: 7
+}


### PR DESCRIPTION
## 1. Motivation

PR #11493 hard-codes builtin scalar/vector/matrix operator resolution, but builtin coercions still fall through the old constructor lookup and overload-resolution path. That means expressions like `float f = intValue`, `float3 v = intValue`, and `float2x2 m = intValue` can bypass operator overload resolution and then immediately pay a similar cost to rediscover the generated core-module conversion constructors.

This stacked PR explores the next step of the same optimization idea: when semantic checking can prove both sides are builtin scalar/vector/matrix types, compute the conversion cost directly and produce a checked `BuiltinCastExpr` instead of building and resolving an initializer overload set.

## 2. Proposed Solution

The scalar base-type conversion ranking is now shared in `getBaseTypeConversionCost(BaseType, BaseType)` so the semantic fast path and the core-module generator use one source of truth. The generator still owns the emitted scalar type list, but it no longer carries its own conversion-cost table.

`_coerce` now extends the builtin shape decomposition added in #11493. For builtin scalar/vector/matrix pairs, it recognizes the constructor shapes that the core module already permits, assigns the same conversion cost, and creates a `BuiltinCastExpr` directly. Unsupported shapes still fall through to normal constructor lookup and overload resolution.

`IRBuilder::emitCast` now recreates scalar-to-vector splats, scalar-to-matrix splats, and vector1-to-scalar forms that used to arrive through core-module constructor intrinsics, so `BuiltinCastExpr` lowering can simply delegate to the builder while preserving the intended IR shape.

## 3. Change Summary

| Area | Files | What |
|---|---|---|
| Shared conversion ranking | `slang-base-type-info.h/.cpp`, `slang-embedded-core-module-source.cpp`, `core.meta.slang` | Moves scalar base-type conversion costs into the main Slang library and has the core-module generator call it by `BaseType`. |
| Semantic coercion | `slang-check-conversion.cpp`, `slang-check-expr.cpp`, `slang-check-impl.h` | Reuses the #11493 builtin composite-shape helper, adds matrix layout reporting, and fast-paths scalar/vector/matrix builtin coercions directly in `_coerce`. |
| IR lowering | `slang-ir.cpp`, `slang-lower-to-ir.cpp` | Moves constructor-shaped cast lowering into `IRBuilder::emitCast` and leaves `visitBuiltinCastExpr` as a direct builder cast call. |
| Tests | `tests/language-feature/operator-overload/builtin-coercion-fastpath.slang` | Covers scalar conversion, scalar-to-vector, vector element conversion, scalar-to-matrix, matrix element conversion, and vector1-to-scalar. |

## 4. Concepts and Vocabulary

- **Builtin coercion fast path** - the `_coerce` path for scalar/vector/matrix builtin types that can mirror a generated core-module constructor without running constructor lookup.
- **`getBaseTypeConversionCost`** - the shared scalar conversion-cost policy used by both semantic checking and `core.meta.slang` generation.
- **Shape decomposition** - the #11493 helper that identifies a builtin scalar/vector/matrix by element `BaseType`, row count, column count, and now optional matrix layout.
- **`BuiltinCastExpr`** - the checked-AST representation used when the fast path has selected a builtin conversion directly.

## 5. Process Report

The scalar conversion table moved out of `slang-embedded-core-module-source.cpp` because duplicating it in semantic checking would make the fast path drift-prone. The shared helper preserves the original rank ordering, including the pointer-sized rank between 32-bit and 64-bit types, and returns `kConversionCost_Impossible` for non-constructor base types.

The coercion logic lives inline in `_coerce` rather than behind a new `_tryGetBuiltinCoercionCost`-style abstraction. That keeps the change visibly tied to the existing constructor fallback and to the `getBuiltinCompositeTypeShape` helper introduced by #11493. The comments document why each handled shape is principled: scalar conversions use the shared core constructor ranking, vector splats mirror `vector<T,N>(T)`, same-shape vector/matrix element casts mirror generated element constructors, vector1-to-scalar mirrors its existing conversion cost, and scalar-to-matrix mirrors the special constructors in `core.meta.slang`.

The diagnostic logic that used to live only in the constructor-overload branch is factored into a file-local `_diagnoseImplicitConversion` helper and reused by the fast path. The helper is documented to explain why conversion probes stay silent until `_coerce` is actually building a converted expression. This keeps overflow warnings, unrecommended implicit conversion warnings, explicit-conversion diagnostics, pointer notes, and float-to-double warnings consistent between the direct path and the fallback path.

The shape-specific IR lowering moved from `visitBuiltinCastExpr` into `IRBuilder::emitCast` after review. `BuiltinCastExpr` is one producer, but the shape semantics belong to cast emission itself: scalar-to-vector/matrix coercions require constructor intrinsics, and vector1-to-scalar requires reshape/extraction before the element cast. Centralizing this in the builder prevents future direct `emitCast` callers from reproducing the same cases.

Input-shape check: builtin scalar/vector/matrix coercions are valid producer shapes for a direct `BuiltinCastExpr` because the old result was already a builtin conversion selected from generated constructors. Unsupported shapes remain valid fallback input and are deliberately left to overload resolution instead of being guessed in the fast path.

### Benchmarks

Baseline is PR #11493 head (`fb6c96054`), compared against this branch's benchmarked fast-path commit (`a89c6beb5`; current head `ae98ce2eb` only addresses review feedback and comment/instruction cleanup without changing the semantic fast-path cost table). Runs are 9 paired, order-balanced Release invocations using `-report-detailed-perf-benchmark`; values below are medians unless noted.

| Workload | SemanticChecking | compileInner |
|---|---:|---:|
| `neural.slang` | 382.34 ms -> 363.31 ms (**-4.98%**) | 618.95 ms -> 599.41 ms (**-3.16%**) |
| micro mixed 200 | 33.10 ms -> 27.64 ms (**-16.50%**) | 153.22 ms -> 145.23 ms (**-5.21%**) |
| micro same 200 | 31.26 ms -> 27.09 ms (**-13.34%**) | 140.78 ms -> 134.40 ms (**-4.53%**) |

Min-run deltas showed the same direction:

| Workload | SemanticChecking min | compileInner min |
|---|---:|---:|
| `neural.slang` | -4.37% | -3.13% |
| micro mixed 200 | -15.89% | -6.98% |
| micro same 200 | -11.51% | -5.74% |

Benchmark artifacts are in `build/perf-coerce-fastpath/paired-summary-refactored.json` in the local checkout.

### Validation

- `cmake.exe --preset vs2026-dev -B build/windows-vs2026-dev`
- `MSBuild.exe build\windows-vs2026-dev\source\slangc\slangc.vcxproj /m /p:Configuration=Release /p:Platform=x64 /p:BuildInParallel=true`
- `MSBuild.exe build\windows-vs2026-dev\tools\slang-test.vcxproj /m /p:Configuration=Release /p:Platform=x64 /p:BuildInParallel=true`
- `build\windows-vs2026-dev\Release\bin\slang-test.exe tests\language-feature\operator-overload\builtin-coercion-fastpath.slang`
- `build\windows-vs2026-dev\Release\bin\slang-test.exe tests\language-feature\operator-overload`
- `git diff --check` on touched source/test files