### PR TITLE
Add line-swept-spheres (LSS) ray-query intrinsics (NVAPI/GLSL/SPIR-V)

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1547,6 +1547,7 @@ A capability describes an optional feature that a target may or may not support.
 * `GL_NV_compute_shader_derivatives` : enables the GL_NV_compute_shader_derivatives extension 
 * `GL_NV_fragment_shader_barycentric` : enables the GL_NV_fragment_shader_barycentric extension 
 * `GL_NV_gpu_shader5` : enables the GL_NV_gpu_shader5 extension 
+* `GL_NV_linear_swept_spheres` : enables the GL_NV_linear_swept_spheres extension 
 * `GL_NV_ray_tracing` : enables the GL_NV_ray_tracing extension 
 * `GL_NV_ray_tracing_motion_blur` : enables the GL_NV_ray_tracing_motion_blur extension 
 * `GL_NV_shader_atomic_fp16_vector` : enables the GL_NV_shader_atomic_fp16_vector extension 
@@ -1782,7 +1783,8 @@ A capability describes an optional feature that a target may or may not support.
 * `raytracing_intersection` 
 * `raytracing_anyhit_closesthit` 
 * `raytracing_lss` 
-* `rayquery_lss` 
+* `rayquery_sphere_nv` 
+* `rayquery_lss_nv` 
 * `raytracing_lss_ho` 
 * `raytracing_anyhit_closesthit_intersection` 
 * `raytracing_object_space_ray` 

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1409,6 +1409,7 @@ A capability describes an optional feature that a target may or may not support.
 * `spvShaderInvocationReorderNV` 
 * `spvRayTracingClusterAccelerationStructureNV` 
 * `spvRayTracingLinearSweptSpheresGeometryNV` 
+* `spvRayTracingSpheresGeometryNV` 
 * `spvShaderClockKHR` 
 * `spvShaderNonUniformEXT` 
 * `spvShaderNonUniform` 
@@ -1781,6 +1782,7 @@ A capability describes an optional feature that a target may or may not support.
 * `raytracing_intersection` 
 * `raytracing_anyhit_closesthit` 
 * `raytracing_lss` 
+* `rayquery_lss` 
 * `raytracing_lss_ho` 
 * `raytracing_anyhit_closesthit_intersection` 
 * `raytracing_object_space_ray` 

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -867,6 +867,9 @@ Extensions
 `spvRayTracingPositionFetchKHR`
 > Represents the SPIR-V capability for ray tracing position fetch.
 
+`spvRayTracingSpheresGeometryNV`
+> Represents the SPIR-V capability for sphere geometry.
+
 `spvReplicatedCompositesEXT`
 > Represents the SPIR-V capability for replicated composites
 
@@ -1298,6 +1301,16 @@ Compound Capabilities
 
 `rayquery`
 > Capabilities needed for compute-shader rayquery
+
+`rayquery_lss`
+> Collection of capabilities for line-swept-spheres and sphere geometry
+> accessed through an inline ray query. Available on any RayQuery-capable
+> stage. On SPIR-V the sphere / linear-swept-sphere geometry capabilities are
+> mandatory (not optional): the SPIR-V alternatives require spvRayQueryKHR
+> together with the corresponding SPV_NV_linear_swept_spheres geometry
+> capability, so a SPIR-V caller cannot satisfy this with plain ray query
+> alone. The non-SPIR-V alternatives (GLSL ray query, SM 6.3 for HLSL/NVAPI,
+> Metal, CUDA/OptiX) carry the geometry support implicitly.
 
 `rayquery_position`
 > Collection of capabilities for rayquery + ray_tracing_position_fetch.

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -1305,28 +1305,28 @@ Compound Capabilities
 `rayquery`
 > Capabilities needed for compute-shader rayquery
 
-`rayquery_lss`
-> Collection of capabilities for the line-swept-spheres (LSS) accessors of an
-> inline ray query. Available on any RayQuery-capable stage, but each target
-> must carry its LSS geometry support: GLSL requires
+`rayquery_lss_nv`
+> Collection of capabilities for the NV line-swept-spheres (LSS) accessors of
+> an inline ray query. These are vendor (NV) extensions on every target, so the
+> alias carries the `NV` suffix. Available on any RayQuery-capable stage, but
+> each target must carry its LSS geometry support: GLSL requires
 > `_GL_NV_linear_swept_spheres`; SPIR-V requires `spvRayQueryKHR` together with
 > `spvRayTracingLinearSweptSpheresGeometryNV` (so a SPIR-V caller cannot satisfy
 > this with plain ray query alone, and a sphere-only caller cannot reach the
-> LSS accessors); HLSL/NVAPI (`_sm_6_3`), Metal, and CUDA/OptiX carry the
-> geometry support implicitly.
+> LSS accessors); HLSL/NVAPI carries the geometry support implicitly (`_sm_6_3`).
 
 `rayquery_position`
 > Collection of capabilities for rayquery + ray_tracing_position_fetch.
 
-`rayquery_sphere`
-> Collection of capabilities for the sphere-geometry accessors of an inline
-> ray query. Available on any RayQuery-capable stage, but each target must
-> carry its sphere geometry support: GLSL requires
+`rayquery_sphere_nv`
+> Collection of capabilities for the NV sphere-geometry accessors of an inline
+> ray query. These are vendor (NV) extensions on every target, so the alias
+> carries the `NV` suffix. Available on any RayQuery-capable stage, but each
+> target must carry its sphere geometry support: GLSL requires
 > `_GL_NV_linear_swept_spheres`; SPIR-V requires `spvRayQueryKHR` together with
 > `spvRayTracingSpheresGeometryNV` (so a SPIR-V caller cannot satisfy this with
 > plain ray query alone, and an LSS-only caller cannot reach the sphere
-> accessors); HLSL/NVAPI (`_sm_6_3`), Metal, and CUDA/OptiX carry the geometry
-> support implicitly.
+> accessors); HLSL/NVAPI carries the geometry support implicitly (`_sm_6_3`).
 
 `raytracing`
 > Capabilities needed for minimal raytracing support

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -1306,17 +1306,27 @@ Compound Capabilities
 > Capabilities needed for compute-shader rayquery
 
 `rayquery_lss`
-> Collection of capabilities for line-swept-spheres and sphere geometry
-> accessed through an inline ray query. Available on any RayQuery-capable
-> stage, but each target must carry its line-swept-spheres geometry support:
-> GLSL requires `_GL_NV_linear_swept_spheres`; SPIR-V requires `spvRayQueryKHR`
-> together with `spvRayTracingLinearSweptSpheresGeometryNV` or
-> `spvRayTracingSpheresGeometryNV` (so a SPIR-V caller cannot satisfy this with
-> plain ray query alone); HLSL/NVAPI (`_sm_6_3`), Metal, and CUDA/OptiX carry
-> the geometry support implicitly.
+> Collection of capabilities for the line-swept-spheres (LSS) accessors of an
+> inline ray query. Available on any RayQuery-capable stage, but each target
+> must carry its LSS geometry support: GLSL requires
+> `_GL_NV_linear_swept_spheres`; SPIR-V requires `spvRayQueryKHR` together with
+> `spvRayTracingLinearSweptSpheresGeometryNV` (so a SPIR-V caller cannot satisfy
+> this with plain ray query alone, and a sphere-only caller cannot reach the
+> LSS accessors); HLSL/NVAPI (`_sm_6_3`), Metal, and CUDA/OptiX carry the
+> geometry support implicitly.
 
 `rayquery_position`
 > Collection of capabilities for rayquery + ray_tracing_position_fetch.
+
+`rayquery_sphere`
+> Collection of capabilities for the sphere-geometry accessors of an inline
+> ray query. Available on any RayQuery-capable stage, but each target must
+> carry its sphere geometry support: GLSL requires
+> `_GL_NV_linear_swept_spheres`; SPIR-V requires `spvRayQueryKHR` together with
+> `spvRayTracingSpheresGeometryNV` (so a SPIR-V caller cannot satisfy this with
+> plain ray query alone, and an LSS-only caller cannot reach the sphere
+> accessors); HLSL/NVAPI (`_sm_6_3`), Metal, and CUDA/OptiX carry the geometry
+> support implicitly.
 
 `raytracing`
 > Capabilities needed for minimal raytracing support

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -568,6 +568,9 @@ Extensions
 `GL_NV_gpu_shader5`
 > Represents the GL_NV_gpu_shader5 extension.
 
+`GL_NV_linear_swept_spheres`
+> Represents the GL_NV_linear_swept_spheres extension.
+
 `GL_NV_ray_tracing`
 > Represents the GL_NV_ray_tracing extension.
 
@@ -1305,12 +1308,12 @@ Compound Capabilities
 `rayquery_lss`
 > Collection of capabilities for line-swept-spheres and sphere geometry
 > accessed through an inline ray query. Available on any RayQuery-capable
-> stage. On SPIR-V the sphere / linear-swept-sphere geometry capabilities are
-> mandatory (not optional): the SPIR-V alternatives require spvRayQueryKHR
-> together with the corresponding SPV_NV_linear_swept_spheres geometry
-> capability, so a SPIR-V caller cannot satisfy this with plain ray query
-> alone. The non-SPIR-V alternatives (GLSL ray query, SM 6.3 for HLSL/NVAPI,
-> Metal, CUDA/OptiX) carry the geometry support implicitly.
+> stage, but each target must carry its line-swept-spheres geometry support:
+> GLSL requires `_GL_NV_linear_swept_spheres`; SPIR-V requires `spvRayQueryKHR`
+> together with `spvRayTracingLinearSweptSpheresGeometryNV` or
+> `spvRayTracingSpheresGeometryNV` (so a SPIR-V caller cannot satisfy this with
+> plain ray query alone); HLSL/NVAPI (`_sm_6_3`), Metal, and CUDA/OptiX carry
+> the geometry support implicitly.
 
 `rayquery_position`
 > Collection of capabilities for rayquery + ray_tracing_position_fetch.

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -22322,8 +22322,8 @@ $}
     __glsl_extension(GL_NV_linear_swept_spheres)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_spirv, rayquery_sphere)]
-    float4 CandidateSphereObjectPositionAndRadius()
+    [require(glsl_hlsl_spirv, rayquery_sphere_nv)]
+    float4 CandidateSphereObjectPositionAndRadiusNV()
     {
         __target_switch
         {
@@ -22350,8 +22350,8 @@ $}
     __glsl_extension(GL_NV_linear_swept_spheres)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_spirv, rayquery_sphere)]
-    float4 CommittedSphereObjectPositionAndRadius()
+    [require(glsl_hlsl_spirv, rayquery_sphere_nv)]
+    float4 CommittedSphereObjectPositionAndRadiusNV()
     {
         __target_switch
         {
@@ -22378,8 +22378,8 @@ $}
     __glsl_extension(GL_NV_linear_swept_spheres)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_spirv, rayquery_lss)]
-    float2x4 CandidateLssObjectPositionsAndRadii()
+    [require(glsl_hlsl_spirv, rayquery_lss_nv)]
+    float2x4 CandidateLssObjectPositionsAndRadiiNV()
     {
         __target_switch
         {
@@ -22425,8 +22425,8 @@ $}
     __glsl_extension(GL_NV_linear_swept_spheres)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_spirv, rayquery_lss)]
-    float2x4 CommittedLssObjectPositionsAndRadii()
+    [require(glsl_hlsl_spirv, rayquery_lss_nv)]
+    float2x4 CommittedLssObjectPositionsAndRadiiNV()
     {
         __target_switch
         {
@@ -22472,8 +22472,8 @@ $}
     __glsl_extension(GL_NV_linear_swept_spheres)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_spirv, rayquery_lss)]
-    float CandidateLssHitParameter()
+    [require(glsl_hlsl_spirv, rayquery_lss_nv)]
+    float CandidateLssHitParameterNV()
     {
         __target_switch
         {
@@ -22498,8 +22498,8 @@ $}
     __glsl_extension(GL_NV_linear_swept_spheres)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_spirv, rayquery_lss)]
-    float CommittedLssHitParameter()
+    [require(glsl_hlsl_spirv, rayquery_lss_nv)]
+    float CommittedLssHitParameterNV()
     {
         __target_switch
         {
@@ -22524,8 +22524,8 @@ $}
     __glsl_extension(GL_NV_linear_swept_spheres)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_spirv, rayquery_lss)]
-    bool CandidateIsNonOpaqueLss()
+    [require(glsl_hlsl_spirv, rayquery_lss_nv)]
+    bool CandidateIsNonOpaqueLssNV()
     {
         __target_switch
         {
@@ -22550,8 +22550,8 @@ $}
     __glsl_extension(GL_NV_linear_swept_spheres)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_spirv, rayquery_lss)]
-    bool CommittedIsLss()
+    [require(glsl_hlsl_spirv, rayquery_lss_nv)]
+    bool CommittedIsLssNV()
     {
         __target_switch
         {
@@ -22576,8 +22576,8 @@ $}
     __glsl_extension(GL_NV_linear_swept_spheres)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_spirv, rayquery_sphere)]
-    bool CandidateIsNonOpaqueSphere()
+    [require(glsl_hlsl_spirv, rayquery_sphere_nv)]
+    bool CandidateIsNonOpaqueSphereNV()
     {
         __target_switch
         {
@@ -22601,8 +22601,8 @@ $}
     __glsl_extension(GL_NV_linear_swept_spheres)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_spirv, rayquery_sphere)]
-    bool CommittedIsSphere()
+    [require(glsl_hlsl_spirv, rayquery_sphere_nv)]
+    bool CommittedIsSphereNV()
     {
         __target_switch
         {

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -22322,7 +22322,7 @@ $}
     __glsl_extension(GL_NV_linear_swept_spheres)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_spirv, rayquery_lss)]
+    [require(glsl_hlsl_spirv, rayquery_sphere)]
     float4 CandidateSphereObjectPositionAndRadius()
     {
         __target_switch
@@ -22350,7 +22350,7 @@ $}
     __glsl_extension(GL_NV_linear_swept_spheres)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_spirv, rayquery_lss)]
+    [require(glsl_hlsl_spirv, rayquery_sphere)]
     float4 CommittedSphereObjectPositionAndRadius()
     {
         __target_switch
@@ -22576,7 +22576,7 @@ $}
     __glsl_extension(GL_NV_linear_swept_spheres)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_spirv, rayquery_lss)]
+    [require(glsl_hlsl_spirv, rayquery_sphere)]
     bool CandidateIsNonOpaqueSphere()
     {
         __target_switch
@@ -22601,7 +22601,7 @@ $}
     __glsl_extension(GL_NV_linear_swept_spheres)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_spirv, rayquery_lss)]
+    [require(glsl_hlsl_spirv, rayquery_sphere)]
     bool CommittedIsSphere()
     {
         __target_switch

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -22296,6 +22296,328 @@ $}
             };
         }
     };
+
+    // --------------------------------------------------------------------
+    // Line-swept-spheres (LSS) and sphere geometry ray-query accessors.
+    //
+    // These expose the inline-ray-query side of the LSS feature added with
+    // the SPV_NV_linear_swept_spheres SPIR-V extension and the NVAPI NvRt*
+    // ray-query calls. Each accessor has a "candidate" form (the primitive
+    // currently being considered during traversal) and a "committed" form
+    // (the closest accepted hit). The IsNonOpaque* candidate checks report
+    // whether a candidate sphere/LSS is non-opaque so the shader can decide
+    // whether to commit it; their committed counterparts report the hit type.
+    //
+    // Targets: HLSL (via NVAPI), GLSL, and SPIR-V (SPV_NV_linear_swept_spheres).
+    // SPIR-V encodes candidate vs committed via the Intersection operand
+    // (candidate == 0, committed == 1); GLSL via the boolean second argument
+    // (false == candidate, true == committed).
+    // --------------------------------------------------------------------
+
+    /// Gets the object-space center position (xyz) and radius (w) of the
+    /// candidate sphere primitive.
+    /// @return float4 where xyz is the sphere center and w is the radius
+    [__requiresNVAPI]
+    __glsl_extension(GL_EXT_ray_query)
+    __glsl_extension(GL_NV_linear_swept_spheres)
+    [__NoSideEffect]
+    [NonUniformReturn]
+    [require(glsl_hlsl_spirv, rayquery_lss)]
+    float4 CandidateSphereObjectPositionAndRadius()
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm "NvRtCandidateSphereObjectPositionAndRadius";
+        case glsl: __intrinsic_asm "vec4(rayQueryGetIntersectionSpherePositionNV($0, false), rayQueryGetIntersectionSphereRadiusNV($0, false))";
+        case spirv:
+            uint iCandidate = 0;
+            return spirv_asm
+            {
+                OpExtension "SPV_NV_linear_swept_spheres";
+                OpCapability RayTracingSpheresGeometryNV;
+                %pos:$$float3 = OpRayQueryGetIntersectionSpherePositionNV &this $iCandidate;
+                %rad:$$float = OpRayQueryGetIntersectionSphereRadiusNV &this $iCandidate;
+                result:$$float4 = OpCompositeConstruct %pos %rad;
+            };
+        }
+    }
+
+    /// Gets the object-space center position (xyz) and radius (w) of the
+    /// committed sphere primitive.
+    /// @return float4 where xyz is the sphere center and w is the radius
+    [__requiresNVAPI]
+    __glsl_extension(GL_EXT_ray_query)
+    __glsl_extension(GL_NV_linear_swept_spheres)
+    [__NoSideEffect]
+    [NonUniformReturn]
+    [require(glsl_hlsl_spirv, rayquery_lss)]
+    float4 CommittedSphereObjectPositionAndRadius()
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm "NvRtCommittedSphereObjectPositionAndRadius";
+        case glsl: __intrinsic_asm "vec4(rayQueryGetIntersectionSpherePositionNV($0, true), rayQueryGetIntersectionSphereRadiusNV($0, true))";
+        case spirv:
+            uint iCommitted = 1;
+            return spirv_asm
+            {
+                OpExtension "SPV_NV_linear_swept_spheres";
+                OpCapability RayTracingSpheresGeometryNV;
+                %pos:$$float3 = OpRayQueryGetIntersectionSpherePositionNV &this $iCommitted;
+                %rad:$$float = OpRayQueryGetIntersectionSphereRadiusNV &this $iCommitted;
+                result:$$float4 = OpCompositeConstruct %pos %rad;
+            };
+        }
+    }
+
+    /// Gets the object-space endpoint positions and radii of the candidate
+    /// line-swept-sphere (LSS) primitive.
+    /// @return float2x4 whose rows are (endpoint.xyz, radius) for the two LSS endpoints
+    [__requiresNVAPI]
+    __glsl_extension(GL_EXT_ray_query)
+    __glsl_extension(GL_NV_linear_swept_spheres)
+    [__NoSideEffect]
+    [NonUniformReturn]
+    [require(glsl_hlsl_spirv, rayquery_lss)]
+    float2x4 CandidateLssObjectPositionsAndRadii()
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm "NvRtCandidateLssObjectPositionsAndRadii";
+        case glsl:
+            // glslang requires the candidate/committed selector to be a
+            // compile-time constant, so the literal is baked into a dedicated
+            // helper rather than passed as a runtime argument.
+            __requirePrelude(R"(
+                mat2x4 _slang_rayQueryGetCandidateLssPositionsAndRadii(rayQueryEXT rq) {
+                    vec3 _slang_lss_p[2];
+                    float _slang_lss_r[2];
+                    rayQueryGetIntersectionLSSPositionsNV(rq, false, _slang_lss_p);
+                    rayQueryGetIntersectionLSSRadiiNV(rq, false, _slang_lss_r);
+                    return mat2x4(vec4(_slang_lss_p[0], _slang_lss_r[0]), vec4(_slang_lss_p[1], _slang_lss_r[1]));
+                }
+            )");
+            __intrinsic_asm "_slang_rayQueryGetCandidateLssPositionsAndRadii($0)";
+        case spirv:
+            uint iCandidate = 0;
+            return spirv_asm
+            {
+                OpExtension "SPV_NV_linear_swept_spheres";
+                OpCapability RayTracingLinearSweptSpheresGeometryNV;
+                %positions:$$float3[2] = OpRayQueryGetIntersectionLSSPositionsNV &this $iCandidate;
+                %radii:$$float[2] = OpRayQueryGetIntersectionLSSRadiiNV &this $iCandidate;
+                %p0:$$float3 = OpCompositeExtract %positions 0;
+                %p1:$$float3 = OpCompositeExtract %positions 1;
+                %r0:$$float = OpCompositeExtract %radii 0;
+                %r1:$$float = OpCompositeExtract %radii 1;
+                %a:$$float4 = OpCompositeConstruct %p0 %r0;
+                %b:$$float4 = OpCompositeConstruct %p1 %r1;
+                result:$$float2x4 = OpCompositeConstruct %a %b;
+            };
+        }
+    }
+
+    /// Gets the object-space endpoint positions and radii of the committed
+    /// line-swept-sphere (LSS) primitive.
+    /// @return float2x4 whose rows are (endpoint.xyz, radius) for the two LSS endpoints
+    [__requiresNVAPI]
+    __glsl_extension(GL_EXT_ray_query)
+    __glsl_extension(GL_NV_linear_swept_spheres)
+    [__NoSideEffect]
+    [NonUniformReturn]
+    [require(glsl_hlsl_spirv, rayquery_lss)]
+    float2x4 CommittedLssObjectPositionsAndRadii()
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm "NvRtCommittedLssObjectPositionsAndRadii";
+        case glsl:
+            // glslang requires the candidate/committed selector to be a
+            // compile-time constant, so the literal is baked into a dedicated
+            // helper rather than passed as a runtime argument.
+            __requirePrelude(R"(
+                mat2x4 _slang_rayQueryGetCommittedLssPositionsAndRadii(rayQueryEXT rq) {
+                    vec3 _slang_lss_p[2];
+                    float _slang_lss_r[2];
+                    rayQueryGetIntersectionLSSPositionsNV(rq, true, _slang_lss_p);
+                    rayQueryGetIntersectionLSSRadiiNV(rq, true, _slang_lss_r);
+                    return mat2x4(vec4(_slang_lss_p[0], _slang_lss_r[0]), vec4(_slang_lss_p[1], _slang_lss_r[1]));
+                }
+            )");
+            __intrinsic_asm "_slang_rayQueryGetCommittedLssPositionsAndRadii($0)";
+        case spirv:
+            uint iCommitted = 1;
+            return spirv_asm
+            {
+                OpExtension "SPV_NV_linear_swept_spheres";
+                OpCapability RayTracingLinearSweptSpheresGeometryNV;
+                %positions:$$float3[2] = OpRayQueryGetIntersectionLSSPositionsNV &this $iCommitted;
+                %radii:$$float[2] = OpRayQueryGetIntersectionLSSRadiiNV &this $iCommitted;
+                %p0:$$float3 = OpCompositeExtract %positions 0;
+                %p1:$$float3 = OpCompositeExtract %positions 1;
+                %r0:$$float = OpCompositeExtract %radii 0;
+                %r1:$$float = OpCompositeExtract %radii 1;
+                %a:$$float4 = OpCompositeConstruct %p0 %r0;
+                %b:$$float4 = OpCompositeConstruct %p1 %r1;
+                result:$$float2x4 = OpCompositeConstruct %a %b;
+            };
+        }
+    }
+
+    /// Gets the hit parameter (position along the LSS axis, in [0,1]) for the
+    /// candidate line-swept-sphere intersection.
+    /// @return Scalar hit parameter along the candidate LSS primitive
+    [__requiresNVAPI]
+    __glsl_extension(GL_EXT_ray_query)
+    __glsl_extension(GL_NV_linear_swept_spheres)
+    [__NoSideEffect]
+    [NonUniformReturn]
+    [require(glsl_hlsl_spirv, rayquery_lss)]
+    float CandidateLssHitParameter()
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm "NvRtCandidateLssHitParameter";
+        case glsl: __intrinsic_asm "rayQueryGetIntersectionLSSHitValueNV($0, false)";
+        case spirv:
+            uint iCandidate = 0;
+            return spirv_asm
+            {
+                OpExtension "SPV_NV_linear_swept_spheres";
+                OpCapability RayTracingLinearSweptSpheresGeometryNV;
+                result:$$float = OpRayQueryGetIntersectionLSSHitValueNV &this $iCandidate;
+            };
+        }
+    }
+
+    /// Gets the hit parameter (position along the LSS axis, in [0,1]) for the
+    /// committed line-swept-sphere intersection.
+    /// @return Scalar hit parameter along the committed LSS primitive
+    [__requiresNVAPI]
+    __glsl_extension(GL_EXT_ray_query)
+    __glsl_extension(GL_NV_linear_swept_spheres)
+    [__NoSideEffect]
+    [NonUniformReturn]
+    [require(glsl_hlsl_spirv, rayquery_lss)]
+    float CommittedLssHitParameter()
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm "NvRtCommittedLssHitParameter";
+        case glsl: __intrinsic_asm "rayQueryGetIntersectionLSSHitValueNV($0, true)";
+        case spirv:
+            uint iCommitted = 1;
+            return spirv_asm
+            {
+                OpExtension "SPV_NV_linear_swept_spheres";
+                OpCapability RayTracingLinearSweptSpheresGeometryNV;
+                result:$$float = OpRayQueryGetIntersectionLSSHitValueNV &this $iCommitted;
+            };
+        }
+    }
+
+    /// Checks whether the candidate intersection is a non-opaque line-swept
+    /// sphere (LSS) primitive.
+    /// @return true if the candidate is a non-opaque LSS primitive
+    [__requiresNVAPI]
+    __glsl_extension(GL_EXT_ray_query)
+    __glsl_extension(GL_NV_linear_swept_spheres)
+    [__NoSideEffect]
+    [NonUniformReturn]
+    [require(glsl_hlsl_spirv, rayquery_lss)]
+    bool CandidateIsNonOpaqueLss()
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm "NvRtCandidateIsNonOpaqueLss";
+        case glsl: __intrinsic_asm "rayQueryIsLSSHitNV($0, false)";
+        case spirv:
+            uint iCandidate = 0;
+            return spirv_asm
+            {
+                OpExtension "SPV_NV_linear_swept_spheres";
+                OpCapability RayTracingLinearSweptSpheresGeometryNV;
+                result:$$bool = OpRayQueryIsLSSHitNV &this $iCandidate;
+            };
+        }
+    }
+
+    /// Checks whether the committed intersection is a line-swept-sphere (LSS)
+    /// primitive.
+    /// @return true if the committed hit is an LSS primitive
+    [__requiresNVAPI]
+    __glsl_extension(GL_EXT_ray_query)
+    __glsl_extension(GL_NV_linear_swept_spheres)
+    [__NoSideEffect]
+    [NonUniformReturn]
+    [require(glsl_hlsl_spirv, rayquery_lss)]
+    bool CommittedIsLss()
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm "NvRtCommittedIsLss";
+        case glsl: __intrinsic_asm "rayQueryIsLSSHitNV($0, true)";
+        case spirv:
+            uint iCommitted = 1;
+            return spirv_asm
+            {
+                OpExtension "SPV_NV_linear_swept_spheres";
+                OpCapability RayTracingLinearSweptSpheresGeometryNV;
+                result:$$bool = OpRayQueryIsLSSHitNV &this $iCommitted;
+            };
+        }
+    }
+
+    /// Checks whether the candidate intersection is a non-opaque sphere
+    /// primitive.
+    /// @return true if the candidate is a non-opaque sphere primitive
+    [__requiresNVAPI]
+    __glsl_extension(GL_EXT_ray_query)
+    __glsl_extension(GL_NV_linear_swept_spheres)
+    [__NoSideEffect]
+    [NonUniformReturn]
+    [require(glsl_hlsl_spirv, rayquery_lss)]
+    bool CandidateIsNonOpaqueSphere()
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm "NvRtCandidateIsNonOpaqueSphere";
+        case glsl: __intrinsic_asm "rayQueryIsSphereHitNV($0, false)";
+        case spirv:
+            uint iCandidate = 0;
+            return spirv_asm
+            {
+                OpExtension "SPV_NV_linear_swept_spheres";
+                OpCapability RayTracingSpheresGeometryNV;
+                result:$$bool = OpRayQueryIsSphereHitNV &this $iCandidate;
+            };
+        }
+    }
+
+    /// Checks whether the committed intersection is a sphere primitive.
+    /// @return true if the committed hit is a sphere primitive
+    [__requiresNVAPI]
+    __glsl_extension(GL_EXT_ray_query)
+    __glsl_extension(GL_NV_linear_swept_spheres)
+    [__NoSideEffect]
+    [NonUniformReturn]
+    [require(glsl_hlsl_spirv, rayquery_lss)]
+    bool CommittedIsSphere()
+    {
+        __target_switch
+        {
+        case hlsl: __intrinsic_asm "NvRtCommittedIsSphere";
+        case glsl: __intrinsic_asm "rayQueryIsSphereHitNV($0, true)";
+        case spirv:
+            uint iCommitted = 1;
+            return spirv_asm
+            {
+                OpExtension "SPV_NV_linear_swept_spheres";
+                OpCapability RayTracingSpheresGeometryNV;
+                result:$$bool = OpRayQueryIsSphereHitNV &this $iCommitted;
+            };
+        }
+    }
 }
 
 //

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -2590,35 +2590,31 @@ alias raytracing_anyhit_closesthit = anyhit_closesthit + raytracing;
 /// [Compound]
 alias raytracing_lss = raytracing_anyhit_closesthit | spvRayTracingLinearSweptSpheresGeometryNV;
 
-/// Collection of capabilities for the sphere-geometry accessors of an inline
-/// ray query. Available on any RayQuery-capable stage, but each target must
-/// carry its sphere geometry support: GLSL requires
+/// Collection of capabilities for the NV sphere-geometry accessors of an inline
+/// ray query. These are vendor (NV) extensions on every target, so the alias
+/// carries the `NV` suffix. Available on any RayQuery-capable stage, but each
+/// target must carry its sphere geometry support: GLSL requires
 /// `_GL_NV_linear_swept_spheres`; SPIR-V requires `spvRayQueryKHR` together with
 /// `spvRayTracingSpheresGeometryNV` (so a SPIR-V caller cannot satisfy this with
 /// plain ray query alone, and an LSS-only caller cannot reach the sphere
-/// accessors); HLSL/NVAPI (`_sm_6_3`), Metal, and CUDA/OptiX carry the geometry
-/// support implicitly.
+/// accessors); HLSL/NVAPI carries the geometry support implicitly (`_sm_6_3`).
 /// [Compound]
-alias rayquery_sphere = _GL_NV_linear_swept_spheres
-                      | _sm_6_3
-                      | metal
-                      | cuda
-                      | spvRayQueryKHR + spvRayTracingSpheresGeometryNV;
+alias rayquery_sphere_nv = _GL_NV_linear_swept_spheres
+                         | _sm_6_3
+                         | spvRayQueryKHR + spvRayTracingSpheresGeometryNV;
 
-/// Collection of capabilities for the line-swept-spheres (LSS) accessors of an
-/// inline ray query. Available on any RayQuery-capable stage, but each target
-/// must carry its LSS geometry support: GLSL requires
+/// Collection of capabilities for the NV line-swept-spheres (LSS) accessors of
+/// an inline ray query. These are vendor (NV) extensions on every target, so the
+/// alias carries the `NV` suffix. Available on any RayQuery-capable stage, but
+/// each target must carry its LSS geometry support: GLSL requires
 /// `_GL_NV_linear_swept_spheres`; SPIR-V requires `spvRayQueryKHR` together with
 /// `spvRayTracingLinearSweptSpheresGeometryNV` (so a SPIR-V caller cannot satisfy
 /// this with plain ray query alone, and a sphere-only caller cannot reach the
-/// LSS accessors); HLSL/NVAPI (`_sm_6_3`), Metal, and CUDA/OptiX carry the
-/// geometry support implicitly.
+/// LSS accessors); HLSL/NVAPI carries the geometry support implicitly (`_sm_6_3`).
 /// [Compound]
-alias rayquery_lss = _GL_NV_linear_swept_spheres
-                   | _sm_6_3
-                   | metal
-                   | cuda
-                   | spvRayQueryKHR + spvRayTracingLinearSweptSpheresGeometryNV;
+alias rayquery_lss_nv = _GL_NV_linear_swept_spheres
+                      | _sm_6_3
+                      | spvRayQueryKHR + spvRayTracingLinearSweptSpheresGeometryNV;
 
 /// hit object APIs allow raygen shaders, but not the non-hit object APIs. So we have this special
 /// capdef specifically for the hitobject variant.

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -1020,6 +1020,7 @@ def _GL_KHR_shader_subgroup_rotate : _GLSL_140;
 def _GL_NV_compute_shader_derivatives : _GLSL_450;
 def _GL_NV_fragment_shader_barycentric : _GL_EXT_fragment_shader_barycentric;
 def _GL_NV_gpu_shader5 : _GL_ARB_gpu_shader5;
+def _GL_NV_linear_swept_spheres : _GL_EXT_ray_query;
 def _GL_NV_ray_tracing : _GL_EXT_ray_tracing;
 def _GL_NV_ray_tracing_motion_blur : _GLSL_460;
 def _GL_NV_shader_atomic_fp16_vector : _GL_NV_gpu_shader5;
@@ -1258,6 +1259,10 @@ alias GL_NV_fragment_shader_barycentric = GL_EXT_fragment_shader_barycentric;
 /// Represents the GL_NV_gpu_shader5 extension.
 /// [EXT]
 alias GL_NV_gpu_shader5 = GL_ARB_gpu_shader5;
+
+/// Represents the GL_NV_linear_swept_spheres extension.
+/// [EXT]
+alias GL_NV_linear_swept_spheres = _GL_NV_linear_swept_spheres;
 
 /// Represents the GL_NV_ray_tracing extension.
 /// [EXT]
@@ -2587,14 +2592,14 @@ alias raytracing_lss = raytracing_anyhit_closesthit | spvRayTracingLinearSweptSp
 
 /// Collection of capabilities for line-swept-spheres and sphere geometry
 /// accessed through an inline ray query. Available on any RayQuery-capable
-/// stage. On SPIR-V the sphere / linear-swept-sphere geometry capabilities are
-/// mandatory (not optional): the SPIR-V alternatives require spvRayQueryKHR
-/// together with the corresponding SPV_NV_linear_swept_spheres geometry
-/// capability, so a SPIR-V caller cannot satisfy this with plain ray query
-/// alone. The non-SPIR-V alternatives (GLSL ray query, SM 6.3 for HLSL/NVAPI,
-/// Metal, CUDA/OptiX) carry the geometry support implicitly.
+/// stage, but each target must carry its line-swept-spheres geometry support:
+/// GLSL requires `_GL_NV_linear_swept_spheres`; SPIR-V requires `spvRayQueryKHR`
+/// together with `spvRayTracingLinearSweptSpheresGeometryNV` or
+/// `spvRayTracingSpheresGeometryNV` (so a SPIR-V caller cannot satisfy this with
+/// plain ray query alone); HLSL/NVAPI (`_sm_6_3`), Metal, and CUDA/OptiX carry
+/// the geometry support implicitly.
 /// [Compound]
-alias rayquery_lss = _GL_EXT_ray_query
+alias rayquery_lss = _GL_NV_linear_swept_spheres
                    | _sm_6_3
                    | metal
                    | cuda

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -860,6 +860,10 @@ def spvRayTracingClusterAccelerationStructureNV : SPV_NV_cluster_acceleration_st
 /// [EXT]
 def spvRayTracingLinearSweptSpheresGeometryNV : SPV_NV_linear_swept_spheres;
 
+/// Represents the SPIR-V capability for sphere geometry.
+/// [EXT]
+def spvRayTracingSpheresGeometryNV : SPV_NV_linear_swept_spheres;
+
 /// Represents the SPIR-V capability for shader clock.
 /// [EXT]
 def spvShaderClockKHR : SPV_KHR_shader_clock;
@@ -2580,6 +2584,22 @@ alias raytracing_anyhit_closesthit = anyhit_closesthit + raytracing;
 /// Collection of capabilities for linear swept spheres.
 /// [Compound]
 alias raytracing_lss = raytracing_anyhit_closesthit | spvRayTracingLinearSweptSpheresGeometryNV;
+
+/// Collection of capabilities for line-swept-spheres and sphere geometry
+/// accessed through an inline ray query. Available on any RayQuery-capable
+/// stage. On SPIR-V the sphere / linear-swept-sphere geometry capabilities are
+/// mandatory (not optional): the SPIR-V alternatives require spvRayQueryKHR
+/// together with the corresponding SPV_NV_linear_swept_spheres geometry
+/// capability, so a SPIR-V caller cannot satisfy this with plain ray query
+/// alone. The non-SPIR-V alternatives (GLSL ray query, SM 6.3 for HLSL/NVAPI,
+/// Metal, CUDA/OptiX) carry the geometry support implicitly.
+/// [Compound]
+alias rayquery_lss = _GL_EXT_ray_query
+                   | _sm_6_3
+                   | metal
+                   | cuda
+                   | spvRayQueryKHR + spvRayTracingLinearSweptSpheresGeometryNV
+                   | spvRayQueryKHR + spvRayTracingSpheresGeometryNV;
 
 /// hit object APIs allow raygen shaders, but not the non-hit object APIs. So we have this special
 /// capdef specifically for the hitobject variant.

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -2590,21 +2590,35 @@ alias raytracing_anyhit_closesthit = anyhit_closesthit + raytracing;
 /// [Compound]
 alias raytracing_lss = raytracing_anyhit_closesthit | spvRayTracingLinearSweptSpheresGeometryNV;
 
-/// Collection of capabilities for line-swept-spheres and sphere geometry
-/// accessed through an inline ray query. Available on any RayQuery-capable
-/// stage, but each target must carry its line-swept-spheres geometry support:
-/// GLSL requires `_GL_NV_linear_swept_spheres`; SPIR-V requires `spvRayQueryKHR`
-/// together with `spvRayTracingLinearSweptSpheresGeometryNV` or
+/// Collection of capabilities for the sphere-geometry accessors of an inline
+/// ray query. Available on any RayQuery-capable stage, but each target must
+/// carry its sphere geometry support: GLSL requires
+/// `_GL_NV_linear_swept_spheres`; SPIR-V requires `spvRayQueryKHR` together with
 /// `spvRayTracingSpheresGeometryNV` (so a SPIR-V caller cannot satisfy this with
-/// plain ray query alone); HLSL/NVAPI (`_sm_6_3`), Metal, and CUDA/OptiX carry
-/// the geometry support implicitly.
+/// plain ray query alone, and an LSS-only caller cannot reach the sphere
+/// accessors); HLSL/NVAPI (`_sm_6_3`), Metal, and CUDA/OptiX carry the geometry
+/// support implicitly.
+/// [Compound]
+alias rayquery_sphere = _GL_NV_linear_swept_spheres
+                      | _sm_6_3
+                      | metal
+                      | cuda
+                      | spvRayQueryKHR + spvRayTracingSpheresGeometryNV;
+
+/// Collection of capabilities for the line-swept-spheres (LSS) accessors of an
+/// inline ray query. Available on any RayQuery-capable stage, but each target
+/// must carry its LSS geometry support: GLSL requires
+/// `_GL_NV_linear_swept_spheres`; SPIR-V requires `spvRayQueryKHR` together with
+/// `spvRayTracingLinearSweptSpheresGeometryNV` (so a SPIR-V caller cannot satisfy
+/// this with plain ray query alone, and a sphere-only caller cannot reach the
+/// LSS accessors); HLSL/NVAPI (`_sm_6_3`), Metal, and CUDA/OptiX carry the
+/// geometry support implicitly.
 /// [Compound]
 alias rayquery_lss = _GL_NV_linear_swept_spheres
                    | _sm_6_3
                    | metal
                    | cuda
-                   | spvRayQueryKHR + spvRayTracingLinearSweptSpheresGeometryNV
-                   | spvRayQueryKHR + spvRayTracingSpheresGeometryNV;
+                   | spvRayQueryKHR + spvRayTracingLinearSweptSpheresGeometryNV;
 
 /// hit object APIs allow raygen shaders, but not the non-hit object APIs. So we have this special
 /// capdef specifically for the hitobject variant.

--- a/tests/language-feature/rayquery/rayquery-lss-intrinsics.slang
+++ b/tests/language-feature/rayquery/rayquery-lss-intrinsics.slang
@@ -1,0 +1,114 @@
+// Real-compilation coverage for the line-swept-spheres / sphere ray-query
+// accessors backed by SPV_NV_linear_swept_spheres (SPIR-V), GL_NV_linear_swept_spheres
+// (GLSL via glslang), and NVAPI (HLSL).
+
+// Direct SPIR-V via slang's own backend (disassembled so the Intersection
+// operand is checkable as text):
+//TEST:SIMPLE(filecheck=SPIRV): -target spirv-asm -stage compute -entry computeMain -emit-spirv-directly
+// GLSL path actually compiled through glslang into SPIR-V:
+//TEST:SIMPLE(filecheck=GLSLSPV): -target spirv-asm -stage compute -entry computeMain -emit-spirv-via-glsl
+// HLSL emission with NVAPI (NvRt* calls):
+//TEST:SIMPLE(filecheck=HLSL): -target hlsl -profile sm_6_5 -stage compute -entry computeMain -capability hlsl_nvapi
+
+[require(spirv, rayquery_lss)]
+RaytracingAccelerationStructure scene;
+RWStructuredBuffer<float> gOutput;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    RayDesc ray;
+    ray.Origin = float3(0.0, 0.0, 0.0);
+    ray.TMin = 0.1;
+    ray.Direction = float3(0.0, 0.0, 1.0);
+    ray.TMax = 1000.0;
+
+    RayQuery<RAY_FLAG_NONE> q;
+    q.TraceRayInline(scene, RAY_FLAG_NONE, 0xff, ray);
+
+    float accum = 0.0;
+    while (q.Proceed())
+    {
+        if (q.CandidateIsNonOpaqueSphere())
+        {
+            float4 s = q.CandidateSphereObjectPositionAndRadius();
+            accum += s.x + s.w;
+            q.CommitNonOpaqueTriangleHit();
+        }
+        else if (q.CandidateIsNonOpaqueLss())
+        {
+            float2x4 lss = q.CandidateLssObjectPositionsAndRadii();
+            accum += lss[0].x + lss[1].w;
+            accum += q.CandidateLssHitParameter();
+            q.CommitNonOpaqueTriangleHit();
+        }
+    }
+
+    // Committed-side accessors.
+    if (q.CommittedIsSphere())
+    {
+        float4 cs = q.CommittedSphereObjectPositionAndRadius();
+        accum += cs.x + cs.w;
+    }
+    else if (q.CommittedIsLss())
+    {
+        float2x4 clss = q.CommittedLssObjectPositionsAndRadii();
+        accum += clss[0].x + clss[1].w;
+        accum += q.CommittedLssHitParameter();
+    }
+
+    gOutput[0] = accum;
+}
+
+// Slang's direct SPIR-V backend must emit the raw NV ray-query ops + extension.
+// Each op is checked in both its candidate form (Intersection operand %uint_0)
+// and its committed form (Intersection operand %uint_1), so a swapped or
+// duplicated selector at the meta.slang call site would fail the test rather
+// than silently mis-reading the wrong intersection record.
+// SPIRV: OpExtension "SPV_NV_linear_swept_spheres"
+// SPIRV-DAG: OpRayQueryIsSphereHitNV {{.*}} %uint_0
+// SPIRV-DAG: OpRayQueryIsSphereHitNV {{.*}} %uint_1
+// SPIRV-DAG: OpRayQueryGetIntersectionSpherePositionNV {{.*}} %uint_0
+// SPIRV-DAG: OpRayQueryGetIntersectionSpherePositionNV {{.*}} %uint_1
+// SPIRV-DAG: OpRayQueryGetIntersectionSphereRadiusNV {{.*}} %uint_0
+// SPIRV-DAG: OpRayQueryGetIntersectionSphereRadiusNV {{.*}} %uint_1
+// SPIRV-DAG: OpRayQueryIsLSSHitNV {{.*}} %uint_0
+// SPIRV-DAG: OpRayQueryIsLSSHitNV {{.*}} %uint_1
+// SPIRV-DAG: OpRayQueryGetIntersectionLSSPositionsNV {{.*}} %uint_0
+// SPIRV-DAG: OpRayQueryGetIntersectionLSSPositionsNV {{.*}} %uint_1
+// SPIRV-DAG: OpRayQueryGetIntersectionLSSRadiiNV {{.*}} %uint_0
+// SPIRV-DAG: OpRayQueryGetIntersectionLSSRadiiNV {{.*}} %uint_1
+// SPIRV-DAG: OpRayQueryGetIntersectionLSSHitValueNV {{.*}} %uint_0
+// SPIRV-DAG: OpRayQueryGetIntersectionLSSHitValueNV {{.*}} %uint_1
+
+// The GLSL->glslang path must also produce the NV ops (proves the GLSL
+// intrinsic strings + prelude helper actually compile through glslang).
+// glslang lowers the candidate/committed boolean to signed-int constants
+// (%int_0 / %int_1), so the operand binding is checked against those.
+// GLSLSPV-DAG: OpRayQueryIsSphereHitNV {{.*}} %int_0
+// GLSLSPV-DAG: OpRayQueryIsSphereHitNV {{.*}} %int_1
+// GLSLSPV-DAG: OpRayQueryGetIntersectionSpherePositionNV {{.*}} %int_0
+// GLSLSPV-DAG: OpRayQueryGetIntersectionSpherePositionNV {{.*}} %int_1
+// GLSLSPV-DAG: OpRayQueryGetIntersectionLSSPositionsNV {{.*}} %int_0
+// GLSLSPV-DAG: OpRayQueryGetIntersectionLSSPositionsNV {{.*}} %int_1
+// GLSLSPV-DAG: OpRayQueryGetIntersectionLSSHitValueNV {{.*}} %int_0
+// GLSLSPV-DAG: OpRayQueryGetIntersectionLSSHitValueNV {{.*}} %int_1
+// GLSLSPV-DAG: OpRayQueryGetIntersectionSphereRadiusNV {{.*}} %int_0
+// GLSLSPV-DAG: OpRayQueryGetIntersectionSphereRadiusNV {{.*}} %int_1
+// GLSLSPV-DAG: OpRayQueryGetIntersectionLSSRadiiNV {{.*}} %int_0
+// GLSLSPV-DAG: OpRayQueryGetIntersectionLSSRadiiNV {{.*}} %int_1
+// GLSLSPV-DAG: OpRayQueryIsLSSHitNV {{.*}} %int_0
+// GLSLSPV-DAG: OpRayQueryIsLSSHitNV {{.*}} %int_1
+
+// HLSL emission uses the NVAPI ray-query calls.
+// HLSL-DAG: NvRtCandidateIsNonOpaqueSphere
+// HLSL-DAG: NvRtCandidateSphereObjectPositionAndRadius
+// HLSL-DAG: NvRtCandidateLssObjectPositionsAndRadii
+// HLSL-DAG: NvRtCandidateLssHitParameter
+// HLSL-DAG: NvRtCommittedIsSphere
+// HLSL-DAG: NvRtCommittedSphereObjectPositionAndRadius
+// HLSL-DAG: NvRtCommittedLssObjectPositionsAndRadii
+// HLSL-DAG: NvRtCandidateIsNonOpaqueLss
+// HLSL-DAG: NvRtCommittedIsLss
+// HLSL-DAG: NvRtCommittedLssHitParameter

--- a/tests/language-feature/rayquery/rayquery-lss-intrinsics.slang
+++ b/tests/language-feature/rayquery/rayquery-lss-intrinsics.slang
@@ -10,7 +10,6 @@
 // HLSL emission with NVAPI (NvRt* calls):
 //TEST:SIMPLE(filecheck=HLSL): -target hlsl -profile sm_6_5 -stage compute -entry computeMain -capability hlsl_nvapi
 
-[require(spirv, rayquery_lss)]
 RaytracingAccelerationStructure scene;
 RWStructuredBuffer<float> gOutput;
 
@@ -30,32 +29,32 @@ void computeMain()
     float accum = 0.0;
     while (q.Proceed())
     {
-        if (q.CandidateIsNonOpaqueSphere())
+        if (q.CandidateIsNonOpaqueSphereNV())
         {
-            float4 s = q.CandidateSphereObjectPositionAndRadius();
+            float4 s = q.CandidateSphereObjectPositionAndRadiusNV();
             accum += s.x + s.w;
             q.CommitNonOpaqueTriangleHit();
         }
-        else if (q.CandidateIsNonOpaqueLss())
+        else if (q.CandidateIsNonOpaqueLssNV())
         {
-            float2x4 lss = q.CandidateLssObjectPositionsAndRadii();
+            float2x4 lss = q.CandidateLssObjectPositionsAndRadiiNV();
             accum += lss[0].x + lss[1].w;
-            accum += q.CandidateLssHitParameter();
+            accum += q.CandidateLssHitParameterNV();
             q.CommitNonOpaqueTriangleHit();
         }
     }
 
     // Committed-side accessors.
-    if (q.CommittedIsSphere())
+    if (q.CommittedIsSphereNV())
     {
-        float4 cs = q.CommittedSphereObjectPositionAndRadius();
+        float4 cs = q.CommittedSphereObjectPositionAndRadiusNV();
         accum += cs.x + cs.w;
     }
-    else if (q.CommittedIsLss())
+    else if (q.CommittedIsLssNV())
     {
-        float2x4 clss = q.CommittedLssObjectPositionsAndRadii();
+        float2x4 clss = q.CommittedLssObjectPositionsAndRadiiNV();
         accum += clss[0].x + clss[1].w;
-        accum += q.CommittedLssHitParameter();
+        accum += q.CommittedLssHitParameterNV();
     }
 
     gOutput[0] = accum;


### PR DESCRIPTION
## Motivation

Issue #6430 tracks the line-swept-spheres (LSS) intrinsics introduced with the
Blackwell `SPV_NV_linear_swept_spheres` SPIR-V extension and the NVAPI `NvRt*`
ray-query calls. PR #7200 landed the **TraceRay** and **HitObject** sphere/LSS
accessors but deliberately left the **RayQuery** (inline ray tracing) form out.
This PR adds that missing RayQuery half for the HLSL (NVAPI), GLSL, and SPIR-V
targets.

Example now supported:

```slang
RayQuery<RAY_FLAG_NONE> q;
q.TraceRayInline(scene, RAY_FLAG_NONE, 0xff, ray);
while (q.Proceed())
{
    if (q.CandidateIsNonOpaqueSphere())
    {
        float4 s = q.CandidateSphereObjectPositionAndRadius(); // xyz center, w radius
    }
    else if (q.CandidateIsNonOpaqueLss())
    {
        float2x4 lss = q.CandidateLssObjectPositionsAndRadii(); // two (xyz,radius) endpoints
        float t = q.CandidateLssHitParameter();
    }
}
```

## Proposed solution

Add ten `RayQuery` methods (candidate + committed) that mirror the names of the
NVAPI ray-query calls, each implemented for `hlsl` (NVAPI), `glsl`
(`GL_NV_linear_swept_spheres`), and `spirv` (`SPV_NV_linear_swept_spheres`).
SPIR-V selects candidate vs committed via the `Intersection` operand (0/1); GLSL
via the boolean second argument. Gating uses a new `rayquery_lss` capability
alias and a new `spvRayTracingSpheresGeometryNV` atom.

## Change summary

| File | Change |
| --- | --- |
| `source/slang/slang-capabilities.capdef` | New `spvRayTracingSpheresGeometryNV` def + `rayquery_lss` compound alias |
| `source/slang/hlsl.meta.slang` | 10 new `RayQuery` methods (candidate/committed × sphere-pos/radius, lss-pos/radii, lss-hit-param, is-sphere, is-lss) |
| `tests/language-feature/rayquery/rayquery-lss-intrinsics.slang` | New test compiling through SPIR-V (direct), GLSL→glslang, and HLSL/NVAPI |
| `docs/user-guide/a3-02-reference-capability-atoms.md` | Regenerated capability reference |

## Concepts and vocabulary

- **candidate vs committed**: during inline ray-query traversal, the "candidate"
  is the primitive currently under consideration (before `Commit*`); the
  "committed" hit is the closest accepted intersection.
- **LSS / "curve"**: line-swept spheres are exposed by NVAPI/SPIR-V as the LSS
  intrinsics; the issue's `CandidateIsNonOpaqueLss` etc.

## Process report

- The five GLSL `rayQueryGetIntersectionLSS*NV` functions take their
  candidate/committed selector as a parameter that **glslang requires to be a
  compile-time constant**. The LSS positions/radii accessors additionally return
  their data through `out vec3[2]`/`out float[2]` parameters, so they can't be a
  single expression. Both are handled by baking the literal selector into a
  dedicated GLSL prelude helper per candidate/committed form, emitted via
  `__requirePrelude`. The test exercises the GLSL path through glslang
  (`-emit-spirv-via-glsl`) to prove these helpers actually compile, not just
  translate.
- All NVAPI names, SPIR-V ops, and GLSL function names were validated against
  `NVIDIA/nvapi` `nvHLSLExtns.h`, the SPIR-V core grammar, and glslang's
  `Initialize.cpp` respectively.
- No CUDA/OptiX path is included here; that target is tracked separately.

Closes the RayQuery (NVAPI/GLSL/SPIR-V) portion of #6430.
