### PR TITLE
Fix anyvalue packing for embedded structs

### DIFF
--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -282,17 +282,8 @@ struct AnyValueMarshallingContext
             {
                 auto structType = cast<IRStructType>(dataType);
 
-                // The packed payload layout must match the natural layout of
-                // the packed type exactly: AnyValue sizes are computed from
-                // natural layout (`getAnyValueSize`), and payload bytes are
-                // produced and consumed at natural offsets by host code and
-                // by `reinterpret`. Leaf values already align themselves to
-                // their natural alignment (which equals their size), and
-                // natural layout adds no trailing padding to structs or
-                // arrays, so the only place this sequential walk can drift
-                // from natural layout is a struct boundary: align the
-                // struct's start to its natural alignment, and pad its end
-                // out to its natural size.
+                // Align the struct's start to its natural alignment, 
+                // and pad its end out to its natural size.
                 IRSizeAndAlignment structLayout;
                 bool hasStructLayout =
                     SLANG_SUCCEEDED(getNaturalSizeAndAlignment(

--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -140,45 +140,19 @@ struct AnyValueMarshallingContext
             bool isBindless,
             IRIntegerValue sizeInBytes) = 0;
 
-        void ensureOffsetAt4ByteBoundary()
-        {
-            if (intraFieldOffset)
-            {
-                fieldOffset++;
-                intraFieldOffset = 0;
-            }
-        }
-        void ensureOffsetAt8ByteBoundary()
-        {
-            ensureOffsetAt4ByteBoundary();
-            if ((fieldOffset & 1) != 0)
-                fieldOffset++;
-        }
-        void ensureOffsetAt2ByteBoundary()
-        {
-            if (intraFieldOffset == 0)
-                return;
-            if (intraFieldOffset <= 2)
-            {
-                intraFieldOffset = 2;
-                return;
-            }
-            fieldOffset++;
-            intraFieldOffset = 0;
-            return;
-        }
-
+        // Round the cursor up to the next multiple of `n` bytes, skipping
+        // the padding bytes the payload layout has at this position. The
+        // fixed-size variants are convenience wrappers.
         void ensureOffsetAtNByteBoundary(int n)
         {
-            if (n == 1)
-                return;
-            else if (n == 2)
-                ensureOffsetAt2ByteBoundary();
-            else if (n == 4)
-                ensureOffsetAt4ByteBoundary();
-            else if (n == 8)
-                ensureOffsetAt8ByteBoundary();
+            SLANG_ASSERT(n > 0);
+            auto alignedByteOffset = (uint32_t)align(fieldOffset * 4 + intraFieldOffset, n);
+            fieldOffset = alignedByteOffset / 4;
+            intraFieldOffset = alignedByteOffset % 4;
         }
+        void ensureOffsetAt2ByteBoundary() { ensureOffsetAtNByteBoundary(2); }
+        void ensureOffsetAt4ByteBoundary() { ensureOffsetAtNByteBoundary(4); }
+        void ensureOffsetAt8ByteBoundary() { ensureOffsetAtNByteBoundary(8); }
 
         void advanceOffset(uint32_t bytes)
         {

--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -284,6 +284,10 @@ struct AnyValueMarshallingContext
                 {
                     auto packedSize = (int64_t)(context->fieldOffset - startFieldOffset) * 4 +
                                       (int64_t)context->intraFieldOffset - startIntraFieldOffset;
+                    // A struct that starts at its natural alignment packs
+                    // within its natural size; a violation means the walk
+                    // and the natural layout have diverged.
+                    SLANG_ASSERT(packedSize <= structLayout.size);
                     if (packedSize < structLayout.size)
                         context->advanceOffset(uint32_t(structLayout.size - packedSize));
                 }

--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -281,6 +281,31 @@ struct AnyValueMarshallingContext
         case kIROp_StructType:
             {
                 auto structType = cast<IRStructType>(dataType);
+
+                // The packed payload layout must match the natural layout of
+                // the packed type exactly: AnyValue sizes are computed from
+                // natural layout (`getAnyValueSize`), and payload bytes are
+                // produced and consumed at natural offsets by host code and
+                // by `reinterpret`. Leaf values already align themselves to
+                // their natural alignment (which equals their size), and
+                // natural layout adds no trailing padding to structs or
+                // arrays, so the only place this sequential walk can drift
+                // from natural layout is a struct boundary: align the
+                // struct's start to its natural alignment, and pad its end
+                // out to its natural size.
+                IRSizeAndAlignment structLayout;
+                bool hasStructLayout =
+                    SLANG_SUCCEEDED(getNaturalSizeAndAlignment(
+                        context->targetRequest,
+                        dataType,
+                        &structLayout)) &&
+                    structLayout.size != IRSizeAndAlignment::kIndeterminateSize &&
+                    structLayout.size >= 0;
+                if (hasStructLayout)
+                    context->ensureOffsetAtNByteBoundary((int)structLayout.alignment);
+                uint32_t startFieldOffset = context->fieldOffset;
+                uint32_t startIntraFieldOffset = context->intraFieldOffset;
+
                 for (auto field : structType->getFields())
                 {
                     auto fieldAddr = builder->emitFieldAddress(
@@ -288,6 +313,15 @@ struct AnyValueMarshallingContext
                         concreteTypedVar,
                         field->getKey());
                     emitMarshallingCode(builder, context, fieldAddr);
+                }
+
+                if (hasStructLayout)
+                {
+                    auto packedSize =
+                        (int64_t)(context->fieldOffset - startFieldOffset) * 4 +
+                        (int64_t)context->intraFieldOffset - startIntraFieldOffset;
+                    if (packedSize < structLayout.size)
+                        context->advanceOffset(uint32_t(structLayout.size - packedSize));
                 }
                 break;
             }

--- a/source/slang/slang-ir-any-value-marshalling.cpp
+++ b/source/slang/slang-ir-any-value-marshalling.cpp
@@ -282,7 +282,7 @@ struct AnyValueMarshallingContext
             {
                 auto structType = cast<IRStructType>(dataType);
 
-                // Align the struct's start to its natural alignment, 
+                // Align the struct's start to its natural alignment,
                 // and pad its end out to its natural size.
                 IRSizeAndAlignment structLayout;
                 bool hasStructLayout =
@@ -308,9 +308,8 @@ struct AnyValueMarshallingContext
 
                 if (hasStructLayout)
                 {
-                    auto packedSize =
-                        (int64_t)(context->fieldOffset - startFieldOffset) * 4 +
-                        (int64_t)context->intraFieldOffset - startIntraFieldOffset;
+                    auto packedSize = (int64_t)(context->fieldOffset - startFieldOffset) * 4 +
+                                      (int64_t)context->intraFieldOffset - startIntraFieldOffset;
                     if (packedSize < structLayout.size)
                         context->advanceOffset(uint32_t(structLayout.size - packedSize));
                 }

--- a/tests/compute/dynamic-dispatch-anyvalue-embedded-alignment.slang
+++ b/tests/compute/dynamic-dispatch-anyvalue-embedded-alignment.slang
@@ -3,24 +3,19 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -output-using-type -shaderobj
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -shaderobj -xslang -force-glsl-scalar-layout
 
-// The offsets used by the generated AnyValue packing and
-// unpacking functions must match the natural layout of the packed type
-// exactly, and the AnyValue size computed for an implementation type must
-// match those offsets.
+// AnyValue payloads must be packed at the *natural* layout offsets of the
+// packed type: host code, `reinterpret`, and `getAnyValueSize` all assume
+// them.
 //
-// The shape below used to break: a `float3` leaves the packing cursor at a
-// 4-mod-8 byte offset, and the old sequential packing walk then placed the
-// following struct (which natural layout aligns to 8 bytes for its
-// `uint64_t` member) at compacted offsets, so every packed field of
-// `Profile` disagreed with its natural-layout offset. The `reinterpret`
-// check observes the packed bytes directly and fails in that case. The
-// `anyValueSize` is an exact natural-layout fit for `Impl`, so a packing
-// walk that needs more bytes than natural layout would silently drop the
-// trailing fields and fail the dynamic-dispatch checks as well.
+// This shape used to break that: the packing walk did not align struct
+// starts, so `Profile` was packed at byte 12 instead of its natural
+// offset 16 (8-aligned for `handle`), shifting every `Profile` field and
+// reading back garbage. (Declaring `profile` before `color` made the
+// layouts coincide and hid the bug.)
 //
-// The packing offsets are defined by the *natural* layout of the packed
-// type and must not change when the target's buffer layout rules change,
-// so the same checks must also hold with `-force-glsl-scalar-layout`
+// The `reinterpret` block fails if any field is packed off its natural
+// offset; the exact-fit `anyValueSize(40)` fails if the size side
+// disagrees with the packing walk.
 
 [anyValueSize(40)]
 interface IInterface

--- a/tests/compute/dynamic-dispatch-anyvalue-embedded-alignment.slang
+++ b/tests/compute/dynamic-dispatch-anyvalue-embedded-alignment.slang
@@ -27,14 +27,14 @@ struct Profile
 {
     float factor;    // natural offset 16 inside Impl
     uint64_t handle; // natural offset 24 (8-byte aligned)
-    uint width;      // natural offset 32
-    uint height;     // natural offset 36
+    uint value;      // natural offset 32
 };
 
 struct Impl : IInterface
 {
     float3 color;    // natural offset 0
     Profile profile; // natural offset 16: aligned to 8 for `handle`
+    uint extra;      // natural offset 36
 
     uint Compute(int which)
     {
@@ -44,8 +44,8 @@ struct Impl : IInterface
         case 1: return uint(profile.factor);
         case 2: return uint(profile.handle);
         case 3: return uint(profile.handle >> 32);
-        case 4: return profile.width;
-        default: return profile.height;
+        case 4: return profile.value;
+        default: return extra;
         }
     }
 };
@@ -71,8 +71,8 @@ void computeMain()
     obj.color = float3(10.0, 20.0, 30.0);
     obj.profile.factor = 4.0;
     obj.profile.handle = 0x1111111122222222ULL;
-    obj.profile.width = 7777;
-    obj.profile.height = 8888;
+    obj.profile.value = 7777;
+    obj.extra = 8888;
 
     // Dynamic dispatch must round-trip every field through the exact-fit
     // AnyValue payload.
@@ -92,8 +92,8 @@ void computeMain()
     outputBuffer[6] = words.w[4];  // factor at byte 16
     outputBuffer[7] = words.w[6];  // handle low word at byte 24
     outputBuffer[8] = words.w[7];  // handle high word at byte 28
-    outputBuffer[9] = words.w[8];  // width at byte 32
-    outputBuffer[10] = words.w[9]; // height at byte 36
+    outputBuffer[9] = words.w[8];  // value at byte 32
+    outputBuffer[10] = words.w[9]; // extra at byte 36
     // CHECK: 1082130432
     // CHECK: 572662306
     // CHECK: 286331153

--- a/tests/compute/dynamic-dispatch-anyvalue-vec3.slang
+++ b/tests/compute/dynamic-dispatch-anyvalue-vec3.slang
@@ -1,0 +1,108 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-dx12 -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -output-using-type -shaderobj -xslang -force-glsl-scalar-layout
+
+// The offsets used by the generated AnyValue packing and
+// unpacking functions must match the natural layout of the packed type
+// exactly, and the AnyValue size computed for an implementation type must
+// match those offsets.
+//
+// The shape below used to break: a `float3` leaves the packing cursor at a
+// 4-mod-8 byte offset, and the old sequential packing walk then placed the
+// following struct (which natural layout aligns to 8 bytes for its
+// `uint64_t` member) at compacted offsets, so every packed field of
+// `Profile` disagreed with its natural-layout offset. The `reinterpret`
+// check observes the packed bytes directly and fails in that case. The
+// `anyValueSize` is an exact natural-layout fit for `Impl`, so a packing
+// walk that needs more bytes than natural layout would silently drop the
+// trailing fields and fail the dynamic-dispatch checks as well.
+//
+// The packing offsets are defined by the *natural* layout of the packed
+// type and must not change when the target's buffer layout rules change,
+// so the same checks must also hold with `-force-glsl-scalar-layout`
+// (last vk test line).
+
+[anyValueSize(40)]
+interface IInterface
+{
+    uint Compute(int which);
+};
+
+struct Profile
+{
+    float factor;    // natural offset 16 inside Impl
+    uint64_t handle; // natural offset 24 (8-byte aligned)
+    uint width;      // natural offset 32
+    uint height;     // natural offset 36
+};
+
+struct Impl : IInterface
+{
+    float3 color;    // natural offset 0
+    Profile profile; // natural offset 16: aligned to 8 for `handle`
+
+    uint Compute(int which)
+    {
+        switch (which)
+        {
+        case 0: return uint(color.x);
+        case 1: return uint(profile.factor);
+        case 2: return uint(profile.handle);
+        case 3: return uint(profile.handle >> 32);
+        case 4: return profile.width;
+        default: return profile.height;
+        }
+    }
+};
+
+uint GenericCompute<T : IInterface>(T obj, int which)
+{
+    return obj.Compute(which);
+}
+
+// One uint per 4 bytes of `Impl`'s natural layout.
+struct Words
+{
+    uint w[10];
+};
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<uint> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    Impl obj;
+    obj.color = float3(10.0, 20.0, 30.0);
+    obj.profile.factor = 4.0;
+    obj.profile.handle = 0x1111111122222222ULL;
+    obj.profile.width = 7777;
+    obj.profile.height = 8888;
+
+    // Dynamic dispatch must round-trip every field through the exact-fit
+    // AnyValue payload.
+    for (int i = 0; i < 6; i++)
+        outputBuffer[i] = GenericCompute<Impl>(obj, i);
+    // CHECK: 10
+    // CHECK: 4
+    // CHECK: 572662306
+    // CHECK: 286331153
+    // CHECK: 7777
+    // CHECK: 8888
+
+    // `reinterpret` packs into an AnyValue and unpacks the raw words, so it
+    // observes the packed byte offsets directly: each field must sit at its
+    // natural-layout offset.
+    Words words = reinterpret<Words>(obj);
+    outputBuffer[6] = words.w[4];  // factor at byte 16
+    outputBuffer[7] = words.w[6];  // handle low word at byte 24
+    outputBuffer[8] = words.w[7];  // handle high word at byte 28
+    outputBuffer[9] = words.w[8];  // width at byte 32
+    outputBuffer[10] = words.w[9]; // height at byte 36
+    // CHECK: 1082130432
+    // CHECK: 572662306
+    // CHECK: 286331153
+    // CHECK: 7777
+    // CHECK: 8888
+}

--- a/tests/compute/dynamic-dispatch-anyvalue-vec3.slang
+++ b/tests/compute/dynamic-dispatch-anyvalue-vec3.slang
@@ -21,7 +21,6 @@
 // The packing offsets are defined by the *natural* layout of the packed
 // type and must not change when the target's buffer layout rules change,
 // so the same checks must also hold with `-force-glsl-scalar-layout`
-// (last vk test line).
 
 [anyValueSize(40)]
 interface IInterface


### PR DESCRIPTION
The anyvalue packing for most parts uses the natural size/alignment of all members (e.g., slang-ir-any-value-inference.cpp, slang-ir-lower-dynamic-dispatch-insts.cpp). When a struct is embedded, the marshalling code (slang-ir-any-value-marshalling.cpp) diverges from this because structs are not aligned based on their own natural alignment but instead just tightly packed. This pr fixes this by using the correct offsets for embedded structs.