### PR TITLE
Remove gh auth precondition from IR version check

### DIFF
--- a/extras/check-inst-version-changes.sh
+++ b/extras/check-inst-version-changes.sh
@@ -17,17 +17,13 @@ if [[ -z "${GITHUB_ACTIONS:-}" ]]; then
   exit 0
 fi
 
-# Check for required tools
-if ! command -v gh &>/dev/null; then
-  echo "Error: GitHub CLI (gh) is not installed"
-  exit 1
-fi
-
-# Verify GitHub authentication
-if ! gh auth status &>/dev/null; then
-  echo "Error: Not authenticated with GitHub CLI"
-  exit 1
-fi
+# Note: this script makes no GitHub API calls — it only inspects the diff with
+# `git` and writes an artifact (pr-number.txt + comment-body.txt) for the
+# privileged `comment-ir-version-check.yml` workflow_run job to consume and post
+# (via SLANGBOT_PAT). It therefore must not require `gh` or an authenticated
+# token. Requiring `gh auth status` here used to hard-fail on fork PRs, which
+# only get a restricted GITHUB_TOKEN with no `gh` auth — exactly the PRs this
+# check is meant to run on.
 
 # Function to check if module ir version constants were modified
 check_module_versions_modified() {


### PR DESCRIPTION
## Motivation

Fork PRs fail the `build` job at `./extras/check-inst-version-changes.sh` with `Error: Not authenticated with GitHub CLI` (e.g. #11537). Fork `pull_request` runs get a restricted `GITHUB_TOKEN` and no `gh` auth by design, so the script's `gh auth status` gate hard-fails exactly the PRs it should run on.

## Proposed solution

The script makes no GitHub API calls — it inspects the diff with `git` and writes an artifact (`pr-number.txt` + `comment-body.txt`). The comment is posted by the separate privileged `comment-ir-version-check.yml` (`workflow_run`, `peter-evans/create-or-update-comment` + `SLANGBOT_PAT`). The `gh` gate guarded a dependency the script doesn't have, so remove it; the analysis then runs uniformly on fork and same-repo PRs.

## Change summary

| File | Change |
| --- | --- |
| `extras/check-inst-version-changes.sh` | Remove the `command -v gh` / `gh auth status` precondition; add a comment noting the script only emits an artifact for the privileged job to post. |

## Process report

`rg '\bgh\b'` confirms those two checks were the only `gh` references; the rest is `git diff` + artifact writing. The failing input (fork PR, restricted token, no `gh` auth) is GitHub's intended security model — correct and principled — so the fix belongs in the consumer, not upstream. Verified the script exits 0 with no `gh` on PATH and no token. This PR is itself a fork PR, so its `build` job exercises the previously-failing path.