### PR TITLE
Split Falcor workflow: build on build pool, test on falcor pool

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,12 @@
+self-hosted-runner:
+  labels:
+    - arc
+    - benchmark
+    - build
+    - falcor
+    - GCP-T4
+    - GPU
+    - perf
+    - regression-test
+    - SM80Plus
+    - vulkancts

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -18,35 +18,73 @@ jobs:
     if: github.event.pull_request.draft != true
     timeout-minutes: 100
     continue-on-error: false
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows]
-        config: [release]
-        compiler: [cl]
-        platform: [x86_64]
-        include:
-          # Self-hosted falcor tests
-          - warnings-as-errors: true
-            full-gpu-tests: false
-            runs-on: [Windows, self-hosted, falcor]
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: [Windows, self-hosted, build]
     defaults:
       run:
         shell: bash
     steps:
+      - name: Add Git Bash to PATH
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: "recursive"
           fetch-depth: "0"
       - name: Setup
         uses: ./.github/actions/common-setup
         with:
-          os: ${{matrix.os}}
-          compiler: ${{matrix.compiler}}
-          platform: ${{matrix.platform}}
-          config: ${{matrix.config}}
+          os: windows
+          compiler: cl
+          platform: x86_64
+          config: release
           build-llvm: true
+      - name: Build Slang
+        run: |
+          cmake --preset default --fresh \
+            -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
+            -DCMAKE_COMPILE_WARNING_AS_ERROR=true \
+            -DSLANG_ENABLE_CUDA=1 \
+            -DSLANG_ENABLE_EXAMPLES=0 \
+            -DSLANG_ENABLE_GFX=0 \
+            -DSLANG_ENABLE_TESTS=0 \
+            -DSLANG_EXCLUDE_DAWN=1 \
+            -DSLANG_EXCLUDE_TINT=1 \
+            -DSLANG_ENABLE_SLANG_RHI=0
+          cmake --workflow --preset release
+      - name: Upload Slang build
+        uses: actions/upload-artifact@v4
+        with:
+          name: slang-falcor-build-windows-release
+          path: build/Release/bin/
+  test:
+    name: Test (Falcor)
+    needs: build
+    if: github.event.pull_request.draft != true
+    timeout-minutes: 100
+    continue-on-error: false
+    runs-on: [Windows, self-hosted, falcor]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Add Git Bash to PATH
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          submodules: "false"
+          fetch-depth: "1"
+      - name: Download Slang build
+        uses: actions/download-artifact@v4
+        with:
+          name: slang-falcor-build-windows-release
+          path: slang-bin
       - name: setup-falcor
         shell: pwsh
         run: |
@@ -59,22 +97,9 @@ jobs:
           Copy-Item -Path 'C:\Falcor\media_internal' -Destination '.\' -Recurse
           Copy-Item -Path 'C:\Falcor\scripts' -Destination '.\' -Recurse
           cd ..\
-      - name: Build Slang
-        run: |
-          cmake --preset default --fresh \
-            -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
-            -DCMAKE_COMPILE_WARNING_AS_ERROR=${{matrix.warnings-as-errors}} \
-            -DSLANG_ENABLE_CUDA=1 \
-            -DSLANG_ENABLE_EXAMPLES=0 \
-            -DSLANG_ENABLE_GFX=0 \
-            -DSLANG_ENABLE_TESTS=0 \
-            -DSLANG_EXCLUDE_DAWN=1 \
-            -DSLANG_EXCLUDE_TINT=1 \
-            -DSLANG_ENABLE_SLANG_RHI=0
-          cmake --workflow --preset "${{matrix.config}}"
       - name: Copy Slang to Falcor
         run: |
-          cp --verbose --recursive --target-directory ./FalcorBin/build/windows-vs2022/bin/Release build/Release/bin/*
+          cp --verbose --recursive --target-directory ./FalcorBin/build/windows-vs2022/bin/Release slang-bin/*
       - name: falcor-unit-test
         shell: pwsh
         run: |

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -13,6 +13,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   build:
     name: Build

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -63,6 +63,7 @@ jobs:
           name: slang-falcor-build-windows-release
           path: build/Release/bin/
           if-no-files-found: error
+          retention-days: 7
   test:
     name: Test (Falcor)
     needs: build
@@ -107,16 +108,22 @@ jobs:
       - name: falcor-unit-test
         shell: pwsh
         run: |
-          $ErrorActionPreference = "SilentlyContinue"
+          $ErrorActionPreference = "Stop"
           cd .\FalcorBin\tests
           python ./testing/run_unit_tests.py --config windows-vs2022-Release -t "-slow"
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
           cd ../../
           #Get-ChildItem .\FalcorBin\build\windows-vs2022\bin\Release\FalcorTest*.log -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "=== $($_.FullName) ===" ; Get-Content $_ }
       - name: falcor-image-test
         shell: pwsh
         run: |
-          $ErrorActionPreference = "SilentlyContinue"
+          $ErrorActionPreference = "Stop"
           cd .\FalcorBin\tests
           python ./testing/run_image_tests.py --config windows-vs2022-Release --run-only
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
           cd ../../
           #Get-ChildItem .\FalcorBin\build\windows-vs2022\bin\Release\FalcorTest*.log -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "=== $($_.FullName) ===" ; Get-Content $_ }

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -63,7 +63,7 @@ jobs:
           name: slang-falcor-build-windows-release
           path: build/Release/bin/
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 1
   test:
     name: Test (Falcor)
     needs: build

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -15,6 +15,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build:
+    name: Build
     if: github.event.pull_request.draft != true
     timeout-minutes: 100
     continue-on-error: false
@@ -28,7 +29,7 @@ jobs:
         run: |
           Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
           Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           submodules: "recursive"
@@ -55,10 +56,11 @@ jobs:
             -DSLANG_ENABLE_SLANG_RHI=0
           cmake --workflow --preset release
       - name: Upload Slang build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v4
         with:
           name: slang-falcor-build-windows-release
           path: build/Release/bin/
+          if-no-files-found: error
   test:
     name: Test (Falcor)
     needs: build
@@ -75,13 +77,13 @@ jobs:
         run: |
           Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
           Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           submodules: "false"
           fetch-depth: "1"
       - name: Download Slang build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@81eafdc926c95ab3a46553696557fe28c599a41a # v4
         with:
           name: slang-falcor-build-windows-release
           path: slang-bin


### PR DESCRIPTION
Fixes #11495

## Motivation

The self-hosted Falcor CI machine has been a bottleneck for CI turnaround. Before this change, the single `falcor-test.yml` job ran on the `[Windows, self-hosted, falcor]` runner and spent a substantial portion of its time building Slang from source (the `Build Slang` step: a fresh CMake configure plus a full release build) before any Falcor test could start. The Falcor runner is the scarce resource — only it has the Falcor binaries and GPU environment — so every minute it spends compiling is a minute no Falcor test can run.

## Proposed solution

Split the workflow into two jobs so each runner pool does what only it can do:

- A `build` job on the `[Windows, self-hosted, build]` pool (which has the CUDA toolkit required by `-DSLANG_ENABLE_CUDA=1`) performs the checkout and Slang build, then publishes `build/Release/bin/` as an artifact via pinned `actions/upload-artifact` v4.
- A `test` job on the `[Windows, self-hosted, falcor]` pool (declared with `needs: build`) downloads the artifact via pinned `actions/download-artifact` v4 into `slang-bin/`, copies the binaries into the Falcor installation, and runs the Falcor unit tests as before.

This is the principled split: the build is target-machine-agnostic and belongs on the general build pool, while the Falcor machine focuses solely on testing. The build/test steps themselves are unchanged — they are relocated, not rewritten.

## Change summary

- `.github/workflows/falcor-test.yml`:
  - The former single job is split into `build` (runs-on `[Windows, self-hosted, build]`) and `test` (`name: Test (Falcor)`, runs-on `[Windows, self-hosted, falcor]`, `needs: build`).
  - The single-entry `strategy.matrix` (os/config/compiler/platform each had exactly one value) is removed; the values are inlined into the `common-setup` action inputs and the CMake invocation (`-DCMAKE_COMPILE_WARNING_AS_ERROR=true`, `--preset release`).
  - Artifact handoff: `upload-artifact` with `path: build/Release/bin/` in `build`; `download-artifact` into `slang-bin` in `test`, and the `Copy Slang to Falcor` step now copies from `slang-bin/*` instead of `build/Release/bin/*`.
  - The `test` job checkout uses `submodules: "false"` and `fetch-depth: "1"` since it only needs the workflow scripts, not the full source tree with submodules.
  - `persist-credentials: false` is added to both checkouts to avoid leaving the GitHub token in the on-disk git config on self-hosted runners.
  - The workflow declares `permissions: contents: read` so the `GITHUB_TOKEN` is limited to the read scope needed by checkout.
  - External `actions/*` references in this workflow are pinned to the repo's existing v4 commit SHAs, and the artifact upload now uses `if-no-files-found: error` plus `retention-days: 1`.
  - The Falcor PowerShell test steps now use `ErrorActionPreference = "Stop"` and explicitly exit with `$LASTEXITCODE` when a Python test runner fails.
- `.github/actionlint.yaml`:
  - Records the repository's custom self-hosted runner labels, including the `build` and `falcor` pools used by this workflow.

## Concepts and vocabulary

- **Falcor runner** — the Windows self-hosted machine with the Falcor binaries and GPU test environment.
- **Build pool** — the Windows self-hosted runner pool used for Slang compilation work that does not require the Falcor installation.
- **Artifact handoff** — the GitHub Actions artifact produced by `build` and consumed by `test`.

## Process report

Every change is part of the build/test split or directly related workflow review hardening; there is no compiler or source code change.

- **Job split and runner assignment.** The `Build Slang` step needs the CUDA toolkit (`-DSLANG_ENABLE_CUDA=1`) but no GPU or Falcor install; the test steps need the Falcor install and GPU but no toolchain. Assigning `build` to the `build` pool and `test` to the `falcor` pool matches each job's actual requirements, which is why this is a split rather than a cache or shortcut on the Falcor machine.
- **Artifact `path: build/Release/bin/` (not a `**` glob).** With a directory path, `upload-artifact` strips the `build/Release/bin/` prefix, so after `download-artifact` into `slang-bin` the binaries sit directly under `slang-bin/` and the existing `cp --recursive --target-directory ... slang-bin/*` copy is correct. A glob form would have preserved the directory prefix and broken the copy.
- **Missing artifact fails in the producing job.** `if-no-files-found: error` makes the upload step fail immediately if `build/Release/bin/` is missing or empty, which points the failure at the Slang build output instead of letting the Falcor test job fail later with a missing binary. A successful build is expected to produce this directory, so this is enforcing the valid producer/consumer contract rather than masking a malformed artifact.
- **Pinned external actions.** The workflow uses the same pinned v4 commit SHAs already present elsewhere in the repository for `actions/checkout`, `actions/upload-artifact`, and `actions/download-artifact`. This does not change workflow behavior, but it prevents tag movement from changing the implementation used by this workflow.
- **Actionlint self-hosted labels.** The new `.github/actionlint.yaml` records the custom runner labels already used by this repository (`build`, `falcor`, `benchmark`, `perf`, and related GPU/regression labels). The `build` and `falcor` labels in this workflow are intentional runner-pool selectors, so the lint configuration is the right layer to represent that known CI topology.
- **Matrix removal.** The old matrix had exactly one combination (windows/release/cl/x86_64), so it provided no fan-out — only indirection through `${{matrix.*}}` expressions. With the job split, keeping a one-entry matrix on both jobs would duplicate that indirection; inlining the constant values keeps one source of truth for the configuration.
- **Shallow, submodule-free checkout in `test`.** The test job consumes prebuilt binaries, so it does not need submodules (`external/`) or history; `fetch-depth: "1"` and `submodules: "false"` reduce checkout time on the Falcor machine, which is the resource being protected.
- **`persist-credentials: false`.** Both jobs run on self-hosted runners where the workspace persists between runs; not persisting the checkout credential prevents the token from outliving the job. It is independent of the split but applies to both new checkout blocks introduced by it.
- **Least-privilege workflow token.** `permissions: contents: read` gives checkout the repository read permission it needs without inheriting broader repository defaults on self-hosted runners. The workflow does not write repository contents, statuses, issues, or pull requests, so no broader `GITHUB_TOKEN` scope is required.
- **Short artifact retention.** The Slang artifact is a handoff between jobs in one workflow run, not a release asset. Keeping it for one day matches other short-lived handoff artifacts in this repository while avoiding the default longer retention period.
- **Explicit Falcor test failure propagation.** The test steps now stop on PowerShell command errors and explicitly exit with the Python runner's `$LASTEXITCODE`. This keeps the consumer-side test job simple while making the valid input shape clear: a failing Falcor unit or image test is a workflow failure, not a suppressed PowerShell warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
