### PR TITLE
ci: migrate GitHub Actions off deprecated Node 20 runtime

### DIFF
--- a/.github/actions/claude-code-runner/action.yml
+++ b/.github/actions/claude-code-runner/action.yml
@@ -483,7 +483,7 @@ runs:
     - name: Execute Claude Code Action (NV Inference)
       id: claude-action-nv
       if: steps.auth-token.outputs.auth-provider == 'nv-inference'
-      uses: anthropics/claude-code-action@v1
+      uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca # v1.0.144
       env:
         # NV Inference Portal uses custom base URL - SDK redirects API calls there
         ANTHROPIC_BASE_URL: ${{ inputs.nv-inference-url }}
@@ -532,7 +532,7 @@ runs:
     - name: Execute Claude Code Action (LLMGW)
       id: claude-action-llmgw
       if: steps.auth-token.outputs.auth-provider == 'llmgw'
-      uses: anthropics/claude-code-action@v1
+      uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca # v1.0.144
       env:
         # Use Bedrock with bearer token auth (not AWS SigV4)
         ANTHROPIC_BEDROCK_BASE_URL: ${{ inputs.bedrock-base-url || 'https://prod.api.nvidia.com/llm/v1/aws' }}

--- a/.github/actions/claude-code-runner/action.yml
+++ b/.github/actions/claude-code-runner/action.yml
@@ -147,7 +147,11 @@ runs:
     # Windows-specific setup: MSVC dev tools
     - name: Set up MSVC dev tools (Windows)
       if: runner.os == 'Windows'
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      # msvc-dev-cmd has no Node 24 release yet (upstream ilammy/msvc-dev-cmd#105);
+      # force its node20 runtime onto node24 to clear the deprecation warning.
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     # Install dependencies not present in act/self-hosted (pre-installed on GitHub runners)
     - name: Install Linux dependencies

--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -36,7 +36,11 @@ runs:
         min-disk-gb: ${{ inputs.min-disk-gb }}
 
     - name: Set up MSVC dev tools on Windows
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      # msvc-dev-cmd has no Node 24 release yet (upstream ilammy/msvc-dev-cmd#105);
+      # force its node20 runtime onto node24 to clear the deprecation warning.
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     - name: Install dependencies (Linux only)
       if: inputs.os == 'linux'
@@ -47,7 +51,7 @@ runs:
 
     - name: Setup Node.js (Linux only)
       if: inputs.os == 'linux'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: "20.x"
 

--- a/.github/actions/common-test-setup/action.yml
+++ b/.github/actions/common-test-setup/action.yml
@@ -31,7 +31,7 @@ runs:
         config: ${{ inputs.config }}
         build-llvm: false
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
       with:
         name: slang-tests-${{ inputs.os }}-${{ inputs.platform }}-${{ inputs.compiler }}-${{ inputs.config }}${{ inputs.artifact-suffix }}
         path: github_artifact

--- a/.github/workflows/add-issue-labels.yml
+++ b/.github/workflows/add-issue-labels.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Check if issue creator is in Nvidia dev team
         id: check_team
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.SLANGBOT_MEMBERS_READONLY }}
           script: |
@@ -44,7 +44,7 @@ jobs:
 
       - name: Add Dev Opened Label
         if: steps.check_team.outputs.is_team_member == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.SLANGBOT_ISSUES_WRITE }}
           script: |

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Check if PR author is in shader-slang org
         id: check_org
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.SLANGBOT_MEMBERS_READONLY }}
           script: |
@@ -53,7 +53,7 @@ jobs:
             core.setOutput('source', source);
 
       - name: Add PR to project board and set Source field
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           SOURCE: ${{ steps.check_org.outputs.source }}
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,14 +24,14 @@ jobs:
     env:
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           fetch-depth: "0"
 
       - name: Authenticate to Google Cloud
         if: env.IS_FORK_PR != 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: "projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider"
           service_account: "github-ci@slang-runners.iam.gserviceaccount.com"
@@ -48,7 +48,7 @@ jobs:
         run: |
           cmake --preset default --fresh -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM -DCMAKE_COMPILE_WARNING_AS_ERROR=false
           cmake --workflow --preset release
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: "shader-slang/MDL-SDK"
           path: "external/MDL-SDK"

--- a/.github/workflows/check-cmdline-ref.yml
+++ b/.github/workflows/check-cmdline-ref.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
 

--- a/.github/workflows/check-container-consistency.yml
+++ b/.github/workflows/check-container-consistency.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Check container image consistency
         run: |

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -11,6 +11,6 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/format-setup
       - run: ./extras/formatting.sh --check-only

--- a/.github/workflows/check-python-core.yml
+++ b/.github/workflows/check-python-core.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Parse Python with core Python (${{ matrix.os }})
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Verify using system Python (no setup-python)
         run: |

--- a/.github/workflows/check-spirv-generated.yml
+++ b/.github/workflows/check-spirv-generated.yml
@@ -19,13 +19,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0 # Need full history for git diff
           submodules: false # We'll init them selectively in the script
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.x"
 
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload build artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: spirv-tools-generated-files-expected
           path: |

--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Install Mono
         run: |
           sudo apt-get update

--- a/.github/workflows/ci-agentic-tests-nightly.yml
+++ b/.github/workflows/ci-agentic-tests-nightly.yml
@@ -52,14 +52,14 @@ jobs:
       - name: Configure Git safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           persist-credentials: false
 
       - name: Authenticate to Google Cloud
         if: env.IS_FORK_PR != 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: "projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider"
           service_account: "github-ci@slang-runners.iam.gserviceaccount.com"
@@ -208,7 +208,7 @@ jobs:
 
       - name: Upload slang-test output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: agentic-slang-test-output
           path: slang-test-output.log

--- a/.github/workflows/ci-analytics.yml
+++ b/.github/workflows/ci-analytics.yml
@@ -13,10 +13,10 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Checkout analytics repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: shader-slang/slang-ci-analytics
           path: ci_analytics_repo

--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -14,19 +14,19 @@ jobs:
       id-token: write # Required for Workload Identity
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: "projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider"
           service_account: "github-ci@slang-runners.iam.gserviceaccount.com"
 
       - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
       - name: Checkout analytics repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: shader-slang/slang-ci-analytics
           path: ci_analytics_repo

--- a/.github/workflows/ci-nightly-sanitizer.yml
+++ b/.github/workflows/ci-nightly-sanitizer.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Success notification
         if: needs.sanitizer-nightly.result == 'success'
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |
             {
@@ -36,7 +36,7 @@ jobs:
 
       - name: Failure notification
         if: needs.sanitizer-nightly.result != 'success'
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |
             {

--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -62,7 +62,7 @@ jobs:
           echo "=== Disk space after cleanup ==="
           df -h /host_root || true
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
           submodules: "recursive"
@@ -87,7 +87,7 @@ jobs:
 
       # Restore sccache local cache from master
       - name: Restore sccache cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/.cache/sccache
           key: sccache-linux-gcc-x86_64-${{ inputs.config }}-${{ github.sha }}
@@ -97,7 +97,7 @@ jobs:
       # Authenticate to Google Cloud for LLVM downloads (skip for fork PRs)
       - name: Authenticate to Google Cloud
         if: env.IS_FORK_PR != 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: "projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider"
           service_account: "github-ci@slang-runners.iam.gserviceaccount.com"
@@ -209,12 +209,12 @@ jobs:
       # Save sccache cache (master only, for populate-sccache workflow)
       - name: Save sccache cache (master only)
         if: github.ref == 'refs/heads/master'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/.cache/sccache
           key: sccache-linux-gcc-x86_64-${{ inputs.config }}-${{ github.sha }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: slang-tests-linux-x86_64-gcc-${{ inputs.config }}
           path: artifacts-staging/

--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -63,7 +63,7 @@ jobs:
           Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
           Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           fetch-depth: "250"
@@ -71,7 +71,7 @@ jobs:
 
       # Restore sccache local cache from master
       - name: Restore sccache cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ inputs.os == 'windows' && 'C:/sccache' || '/tmp/.cache/sccache' }}
           key: sccache-${{ inputs.os }}-${{ inputs.compiler }}-${{ inputs.platform }}-${{ inputs.config }}-${{ github.sha }}
@@ -81,7 +81,7 @@ jobs:
       # Authenticate to Google Cloud for LLVM downloads (skip for fork PRs)
       - name: Authenticate to Google Cloud
         if: env.IS_FORK_PR != 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: "projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider"
           service_account: "github-ci@slang-runners.iam.gserviceaccount.com"
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload IR version check results
         if: ${{ steps.check-ir-versions.outputs.artifact_created == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ir-version-check-results
           path: ir-version-check-artifact/
@@ -311,14 +311,14 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: slang-build-${{ inputs.os }}-${{ inputs.platform }}-${{ inputs.compiler }}-${{ inputs.config }}
           path: |
             build/dist-${{inputs.config}}/**/ZIP/slang/*
             build.em/Release
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: slang-tests-${{ inputs.os }}-${{ inputs.platform }}-${{ inputs.compiler }}-${{ inputs.config }}
           path: artifacts-staging/
@@ -327,7 +327,7 @@ jobs:
       # Save sccache cache (only when explicitly requested, e.g. from populate-sccache on master)
       - name: Save sccache cache
         if: inputs.save-sccache && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ inputs.os == 'windows' && 'C:/sccache' || '/tmp/.cache/sccache' }}
           key: sccache-${{ inputs.os }}-${{ inputs.compiler }}-${{ inputs.platform }}-${{ inputs.config }}-${{ github.sha }}

--- a/.github/workflows/ci-slang-coverage.yml
+++ b/.github/workflows/ci-slang-coverage.yml
@@ -660,7 +660,7 @@ jobs:
 
       - name: Report Coverage in PR
         if: ${{ inputs.pr-comment }}
-        uses: zgosalvez/github-actions-report-lcov@v4
+        uses: zgosalvez/github-actions-report-lcov@eda775f552bfb2bffbdedea26f19dfb8c24a1648 # v4
         with:
           coverage-files: coverage.lcov
           minimum-coverage: 0

--- a/.github/workflows/ci-slang-coverage.yml
+++ b/.github/workflows/ci-slang-coverage.yml
@@ -64,7 +64,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           fetch-depth: "0"
@@ -132,7 +132,7 @@ jobs:
       # Authenticate to Google Cloud (skip for fork PRs - no id-token available)
       - name: Authenticate to Google Cloud
         if: env.IS_FORK_PR != 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: "projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider"
           service_account: "github-ci@slang-runners.iam.gserviceaccount.com"
@@ -561,7 +561,7 @@ jobs:
 
       - name: Upload Coverage Artifacts for Merging
         if: ${{ !inputs.deploy-pages }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: coverage-${{ inputs.os }}-${{ inputs.platform }}
           # coverage-html-slangc/ and libslang.* are Linux/macOS-only; the
@@ -584,7 +584,7 @@ jobs:
 
       - name: Checkout Coverage Reports Repository
         if: ${{ inputs.deploy-pages }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: "shader-slang/slang-coverage-reports"
           path: "coverage-repo"
@@ -676,7 +676,7 @@ jobs:
           ls -lh coverage.lcov.gz
 
       - name: Upload LCOV Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: coverage-lcov-${{ inputs.os }}-${{ inputs.platform }}-${{ inputs.compiler }}
           path: coverage.lcov.gz
@@ -714,7 +714,7 @@ jobs:
 
       - name: Upload llvm-cov JSON Export (Linux/macOS only)
         if: inputs.os != 'windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: coverage-json-${{ inputs.os }}-${{ inputs.platform }}-${{ inputs.compiler }}
           path: coverage.json.gz

--- a/.github/workflows/ci-slang-sanitizer.yml
+++ b/.github/workflows/ci-slang-sanitizer.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Configure Git safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           # Need full history to diff PR changes against the base branch
@@ -67,7 +67,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         if: env.IS_FORK_PR != 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: "projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider"
           service_account: "github-ci@slang-runners.iam.gserviceaccount.com"
@@ -78,7 +78,7 @@ jobs:
           platform: linux
 
       - name: Restore sccache cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/.cache/sccache
           key: sccache-linux-clang-18-x86_64-asan-v2-${{ github.sha }}
@@ -158,7 +158,7 @@ jobs:
 
       - name: Save sccache cache
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/.cache/sccache
           key: sccache-linux-clang-18-x86_64-asan-v2-${{ github.sha }}
@@ -620,7 +620,7 @@ jobs:
 
       - name: Upload Sanitizer Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: sanitizer-logs
           path: asan-logs/

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Configure Git safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           fetch-depth: "1"
@@ -86,7 +86,7 @@ jobs:
         uses: ./.github/actions/setup-vulkan-icd
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: slang-tests-linux-x86_64-gcc-${{ inputs.config }}
           path: artifacts
@@ -246,7 +246,7 @@ jobs:
       # sensitive in-memory state.
       - name: Upload core dump backtraces
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: cores-test-slang-${{ inputs.config }}-${{ inputs.gpu-tier }}
           path: backtraces/
@@ -323,7 +323,7 @@ jobs:
       - name: Configure Git safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           fetch-depth: "1"
@@ -332,7 +332,7 @@ jobs:
         uses: ./.github/actions/setup-vulkan-icd
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: slang-tests-linux-x86_64-gcc-${{ inputs.config }}
           path: artifacts
@@ -416,7 +416,7 @@ jobs:
 
       - name: Upload core dump backtraces
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: cores-test-slang-rhi-${{ inputs.config }}
           path: backtraces/

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -60,7 +60,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Common Test Setup
         uses: ./.github/actions/common-test-setup
@@ -218,7 +218,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           fetch-depth: "1"

--- a/.github/workflows/ci-trigger-slangpy.yml
+++ b/.github/workflows/ci-trigger-slangpy.yml
@@ -88,7 +88,7 @@ jobs:
           fi
 
       - name: Post pending status
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -102,7 +102,7 @@ jobs:
             });
 
       - name: Trigger SlangPy CI
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           PR_TITLE: ${{ steps.pr_auto.outputs.title || steps.pr_manual.outputs.title || steps.pr_mq.outputs.title }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       should-run: ${{ steps.filter.outputs.should-run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: "2"
       - id: filter

--- a/.github/workflows/claude-ci-analysis.yml
+++ b/.github/workflows/claude-ci-analysis.yml
@@ -42,14 +42,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get CI failure details
         id: failure_details
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             // Security: Use context.payload.inputs instead of ${{ github.event.inputs }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -60,7 +60,7 @@ jobs:
       # This ensures we never execute untrusted fork code.
       # Claude reads the PR diff via `gh pr diff` and GitHub MCP tools.
       - name: Checkout repository (base branch only)
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
@@ -73,7 +73,7 @@ jobs:
       # Targets both 'claude' (OIDC) and 'github-actions' (fallback) logins.
       - name: Clean up previous Claude reviews
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const prNumber = context.payload.pull_request?.number
@@ -265,7 +265,7 @@ jobs:
       # that no bot review can affect merge eligibility.
       - name: Dismiss unauthorized bot approvals
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const prNumber = context.payload.pull_request?.number

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -153,7 +153,7 @@ jobs:
 
       # Format setup and environment preparation
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           submodules: false

--- a/.github/workflows/cmake-options-build-container.yml
+++ b/.github/workflows/cmake-options-build-container.yml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
           sparse-checkout: .github/cmake-options-matrix.json
@@ -63,7 +63,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
           submodules: "recursive"

--- a/.github/workflows/cmake-options-build.yml
+++ b/.github/workflows/cmake-options-build.yml
@@ -50,7 +50,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           sparse-checkout: .github/cmake-options-matrix.json
           sparse-checkout-cone-mode: false
@@ -78,7 +78,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           fetch-depth: "2"
@@ -102,7 +102,11 @@ jobs:
 
       - name: Set up MSVC cross-compilation
         if: inputs.os == 'windows' && inputs.arch != ''
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        # msvc-dev-cmd has no Node 24 release yet (upstream ilammy/msvc-dev-cmd#105);
+        # force its node20 runtime onto node24 to clear the deprecation warning.
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           arch: ${{ inputs.arch }}
 

--- a/.github/workflows/comment-ir-version-check.yml
+++ b/.github/workflows/comment-ir-version-check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Download artifacts
         id: download
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -56,7 +56,7 @@ jobs:
       - name: Find existing comment
         if: steps.download.outputs.result == 'true'
         id: find-comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
           issue-number: ${{ steps.pr.outputs.number }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Create or update comment
         if: steps.download.outputs.result == 'true'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
           issue-number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/compile-regression-test.yml
+++ b/.github/workflows/compile-regression-test.yml
@@ -49,14 +49,14 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           fetch-depth: "0"
 
       - name: Authenticate to Google Cloud
         if: env.IS_FORK_PR != 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: "projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider"
           service_account: "github-ci@slang-runners.iam.gserviceaccount.com"

--- a/.github/workflows/compile-rtx-remix-shaders-nightly.yml
+++ b/.github/workflows/compile-rtx-remix-shaders-nightly.yml
@@ -343,7 +343,7 @@ jobs:
       - name: Success notification
         id: slack-notify-success
         if: ${{ github.event_name == 'schedule' && success() }}
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |
             {
@@ -355,7 +355,7 @@ jobs:
       - name: Failure notification
         id: slack-notify-failure
         if: ${{ github.event_name == 'schedule' && !success() }}
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |
             {

--- a/.github/workflows/compile-rtx-remix-shaders-nightly.yml
+++ b/.github/workflows/compile-rtx-remix-shaders-nightly.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout Slang repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           fetch-depth: 0 # Need full history for version tags
@@ -50,7 +50,7 @@ jobs:
 
       # Python 3.9+ required by Meson
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 
@@ -64,7 +64,11 @@ jobs:
 
       # Set up MSVC environment (required even for Ninja builds on Windows)
       - name: Setup MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        # msvc-dev-cmd has no Node 24 release yet (upstream ilammy/msvc-dev-cmd#105);
+        # force its node20 runtime onto node24 to clear the deprecation warning.
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
       # Build Slang from checked-out source
       # Note: We only need slangc.exe, so skip the packaging step to avoid CPack errors
@@ -114,7 +118,7 @@ jobs:
 
       # Cache packman packages between runs to save ~2-5 minutes
       - name: Cache Packman packages
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: C:\packman-repo
           key: packman-${{ hashFiles('dxvk-remix/packman-external.xml') }}
@@ -310,7 +314,7 @@ jobs:
       # Upload build logs on failure for debugging
       - name: Upload build logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: rtx-remix-shader-build-logs
           path: |

--- a/.github/workflows/compile-sascha-willems-shaders-nightly.yml
+++ b/.github/workflows/compile-sascha-willems-shaders-nightly.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Success notification
         id: slack-notify-success
         if: ${{ github.event_name == 'schedule' && success() }}
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |
             {
@@ -146,7 +146,7 @@ jobs:
       - name: Failure notification
         id: slack-notify-failure
         if: ${{ github.event_name == 'schedule' && !success() }}
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |
             {

--- a/.github/workflows/compile-sascha-willems-shaders-nightly.yml
+++ b/.github/workflows/compile-sascha-willems-shaders-nightly.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout Slang repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Check disk space
         uses: ./.github/actions/check-disk-space

--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -74,13 +74,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           fetch-depth: "0"
 
       - name: Download Coverage Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: coverage-*
           path: coverage-artifacts
@@ -286,7 +286,7 @@ jobs:
         # Lets feature-branch dispatches inspect the merged + new-renderer
         # output without writing to slang-coverage-reports. Always uploads
         # so we can compare the new and existing renderers across runs.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: coverage-reports-merged
           path: coverage-reports/
@@ -294,7 +294,7 @@ jobs:
 
       - name: Checkout Coverage Reports Repository
         if: github.ref == 'refs/heads/master'
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: "shader-slang/slang-coverage-reports"
           path: "coverage-repo"

--- a/.github/workflows/ensure-pr-label.yml
+++ b/.github/workflows/ensure-pr-label.yml
@@ -16,7 +16,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: mheap/github-action-required-labels@v5
+      - uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5
         with:
           mode: exactly
           count: 1

--- a/.github/workflows/falcor-compiler-perf-test.yml
+++ b/.github/workflows/falcor-compiler-perf-test.yml
@@ -37,7 +37,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           fetch-depth: "0"
@@ -59,7 +59,7 @@ jobs:
             -DSLANG_ENABLE_CUDA=1
           cmake --workflow --preset "${{matrix.config}}"
 
-      - uses: robinraju/release-downloader@v1.12
+      - uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         id: download
         with:
           # The source repository path.

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -35,7 +35,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           fetch-depth: "0"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout target branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: shader-slang/slang
           ref: ${{ github.event.client_payload.pull_request.base.ref }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Create Pull Request
         id: create-pr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
           path: pr-branch
@@ -70,7 +70,7 @@ jobs:
         run: rm -f "${{ runner.temp }}/signing_key"
 
       - name: Comment on PR
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         if: always()
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
@@ -87,7 +87,7 @@ jobs:
 
       - name: Add reaction
         if: steps.format.conclusion == 'success' && steps.create-pr.conclusion == 'success'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
           repository: shader-slang/slang

--- a/.github/workflows/materialx-test.yml
+++ b/.github/workflows/materialx-test.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           fetch-depth: "1"
@@ -37,7 +37,7 @@ jobs:
         uses: ./.github/actions/check-disk-space
 
       - name: Download Slang Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           # Linux uses containerized builds with a different artifact naming pattern
           name: ${{ inputs.os == 'linux' && format('slang-tests-linux-x86_64-gcc-{0}', inputs.config) || format('slang-tests-{0}-{1}-{2}-{3}', inputs.os, inputs.platform, inputs.compiler, inputs.config) }}
@@ -73,7 +73,7 @@ jobs:
           "$SLANGC" --version || echo "Could not get slangc version"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
 
@@ -294,7 +294,7 @@ jobs:
 
       - name: Upload Results on Failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: materialx-test-results-${{ inputs.os }}-${{ inputs.config }}
           path: |

--- a/.github/workflows/populate-sccache.yml
+++ b/.github/workflows/populate-sccache.yml
@@ -20,7 +20,7 @@ jobs:
       should-build: ${{ steps.check.outputs.should-build }}
       last-commit: ${{ steps.check.outputs.last-commit }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 10

--- a/.github/workflows/push-benchmark-results.yml
+++ b/.github/workflows/push-benchmark-results.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: [Windows, self-hosted, benchmark]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "true"
           fetch-depth: "0"
@@ -34,7 +34,7 @@ jobs:
         run: |
           cmake --preset default --fresh -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM -DCMAKE_COMPILE_WARNING_AS_ERROR=false
           cmake --workflow --preset release
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: "shader-slang/MDL-SDK"
           path: "external/MDL-SDK"
@@ -47,7 +47,7 @@ jobs:
           # Pin prettytable; argparse is in the stdlib (3.2+) so it is dropped.
           pip install prettytable==3.17.0
           python compile.py --samples 16 --target dxil
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: "shader-slang/slang-material-modules-benchmark"
           path: "external/slang-material-modules-benchmark"

--- a/.github/workflows/regenerate-cmdline-ref.yml
+++ b/.github/workflows/regenerate-cmdline-ref.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: shader-slang/slang
           ref: ${{ github.event.client_payload.pull_request.base.ref }}
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
@@ -70,7 +70,7 @@ jobs:
           ./build/${{ env.cmake_config }}/bin/slangc -help-style markdown -h > docs/command-line-slangc-reference.md 2>&1
 
       - name: Upload generated reference
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: command-line-reference
           path: pr-branch/docs/command-line-slangc-reference.md
@@ -89,7 +89,7 @@ jobs:
       - name: Checkout PR branch
         id: checkout-pr
         if: needs.generate_cmdline_ref.result == 'success'
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
@@ -99,7 +99,7 @@ jobs:
       - name: Download generated reference
         id: download-doc
         if: needs.generate_cmdline_ref.result == 'success'
-        uses: actions/download-artifact@81eafdc926c95ab3a46553696557fe28c599a41a # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: command-line-reference
           path: generated-docs
@@ -140,7 +140,7 @@ jobs:
       - name: Create Pull Request
         id: create-pr
         if: needs.generate_cmdline_ref.result == 'success'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
           path: pr-branch
@@ -159,7 +159,7 @@ jobs:
         run: rm -f "${{ runner.temp }}/signing_key"
 
       - name: Comment on PR
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         if: always()
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
@@ -176,7 +176,7 @@ jobs:
 
       - name: Add reaction
         if: needs.generate_cmdline_ref.result == 'success' && steps.create-pr.conclusion == 'success'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
           repository: shader-slang/slang

--- a/.github/workflows/regenerate-toc.yml
+++ b/.github/workflows/regenerate-toc.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout target branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: shader-slang/slang
           ref: ${{ github.event.client_payload.pull_request.base.ref }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create Pull Request
         id: create-pr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
           path: pr-branch
@@ -72,7 +72,7 @@ jobs:
         run: rm -f "${{ runner.temp }}/signing_key"
 
       - name: Comment on PR
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         if: always()
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
@@ -89,7 +89,7 @@ jobs:
 
       - name: Add reaction
         if: steps.regen.conclusion == 'success' && steps.create-pr.conclusion == 'success'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
           repository: shader-slang/slang

--- a/.github/workflows/release-linux-glibc-2-27.yml
+++ b/.github/workflows/release-linux-glibc-2-27.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           fetch-depth: "0"
@@ -55,7 +55,7 @@ jobs:
         run: |
           find "build/dist-release" -print0 ! -iname '*.md' ! -iname '*.h' -type f | xargs -0 file
       - name: UploadBinary
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           draft: ${{contains(github.ref, 'draft')}}

--- a/.github/workflows/release-linux-glibc-2-28.yml
+++ b/.github/workflows/release-linux-glibc-2-28.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           fetch-depth: "0"
@@ -68,7 +68,7 @@ jobs:
         run: |
           find "build/dist-release" -type f ! -iname '*.md' ! -iname '*.h' -print0 | xargs -0 file
       - name: UploadBinary
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           draft: ${{contains(github.ref, 'draft')}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "recursive"
           fetch-depth: "0"
@@ -113,7 +113,11 @@ jobs:
 
       - name: Setup Windows dev tools for target architecture
         if: matrix.os == 'windows'
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        # msvc-dev-cmd has no Node 24 release yet (upstream ilammy/msvc-dev-cmd#105);
+        # force its node20 runtime onto node24 to clear the deprecation warning.
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           arch: ${{ matrix.arch }}
 
@@ -349,7 +353,7 @@ jobs:
           find "build/dist-$config" -print0 ! -iname '*.md' ! -iname '*.h' -type f | xargs -0 file
 
       - name: UploadBinary
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           draft: ${{contains(github.ref, 'draft')}}
@@ -366,7 +370,7 @@ jobs:
 
       - name: Checkout stdlib reference
         if: matrix.os == 'windows' && matrix.platform == 'x86_64'
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: shader-slang/stdlib-reference
           path: docs/stdlib-reference/

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Slash Command Dispatch
         id: scd
-        uses: peter-evans/slash-command-dispatch@v4
+        uses: peter-evans/slash-command-dispatch@9bdcd7914ec1b75590b790b844aa3b8eee7c683a # v5.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           reaction-token: ${{ secrets.SLANGBOT_PAT }}
@@ -39,7 +39,7 @@ jobs:
 
       - name: Edit comment with error message
         if: steps.scd.outputs.error-message
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ secrets.SLANGBOT_PAT }}
           comment-id: ${{ github.event.comment.id }}

--- a/.github/workflows/vk-gl-cts-nightly.yml
+++ b/.github/workflows/vk-gl-cts-nightly.yml
@@ -123,7 +123,7 @@ jobs:
       - name: success notification
         id: slack-notify-success
         if: ${{ github.event_name == 'schedule' && success() }}
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |
             {
@@ -134,7 +134,7 @@ jobs:
       - name: failure notification
         id: slack-notify-failure
         if: ${{ github.event_name == 'schedule' && !success() }}
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |
             {

--- a/.github/workflows/vk-gl-cts-nightly.yml
+++ b/.github/workflows/vk-gl-cts-nightly.yml
@@ -35,14 +35,14 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: "true"
           fetch-depth: "0"
       # Authenticate to Google Cloud (skip for fork PRs - no id-token available)
       - name: Authenticate to Google Cloud
         if: env.IS_FORK_PR != 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: "projects/125098404903/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider"
           service_account: "github-ci@slang-runners.iam.gserviceaccount.com"
@@ -75,12 +75,12 @@ jobs:
             -DSLANG_ENABLE_TESTS=1 \
             "${cmake_launcher_defines[@]}"
           cmake --workflow --preset "${{matrix.config}}"
-      - uses: robinraju/release-downloader@v1.11
+      - uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:
           latest: true
           repository: "shader-slang/VK-GL-CTS"
           fileName: "VK-GL-CTS_WithSlang-0.0.7-win64.zip"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: "shader-slang/VK-GL-CTS"
           sparse-checkout: |

--- a/external/spirv-tools-generated/build-version.inc
+++ b/external/spirv-tools-generated/build-version.inc
@@ -1,1 +1,1 @@
-"v2026.2", "SPIRV-Tools v2026.2 v2026.2.rc2-22-g2acb87f8"
+"v2026.2", "SPIRV-Tools v2026.2 v2026.2-22-g2acb87f8"


### PR DESCRIPTION
## Motivation

GitHub is deprecating the Node 20 actions runtime. Workflows already emit warnings such as:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/checkout@v4`, `actions/download-artifact@v4`, `ilammy/msvc-dev-cmd@v1`. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

After **2026-06-16** GitHub force-runs every Node 20 action on Node 24; after **2026-09-16** Node 20 is removed from runners entirely. We should move to the Node-24 versions on our own terms (and pin them) rather than be force-migrated.

## Proposed solution

Bump every action that has a Node-24 release to that version, and **pin to a full commit SHA** (with a `# vX` comment) — both to clear the deprecation and to make the supply chain reproducible, matching the repo's existing SHA-pinned entries (e.g. `actions/download-artifact@81eafdc… # v4`).

I resolved each action's actual runtime via the GitHub API — dereferencing annotated tags to their commit SHA and reading `runs.using` in `action.yml` at that SHA — rather than trusting tag names, because the major→Node-24 boundary is not uniform (e.g. `download-artifact` only moved to node24 at v7, `upload-artifact` at v6).

For `ilammy/msvc-dev-cmd`, which has **no Node-24 release yet**, I use GitHub's documented opt-in env var to run its node20 entrypoint on node24.

## Change summary

**GitHub-owned actions → first Node-24 major, SHA-pinned:**

| Action | → | Node |
|---|---|---|
| `actions/checkout` | v5 | node24 |
| `actions/download-artifact` | v7 | node24 |
| `actions/upload-artifact` | v6 | node24 |
| `actions/cache` (+ `/save`, `/restore`) | v5 | node24 |
| `actions/setup-python` | v6 | node24 |
| `actions/setup-node` | v5 | node24 |
| `actions/github-script` | v8 | node24 |

**Third-party actions with a Node-24 release → bumped, SHA-pinned** (inputs verified unchanged across the bump): `google-github-actions/auth` → v3.0.0, `google-github-actions/setup-gcloud` → v3.0.1, `softprops/action-gh-release` → v3.0.0 (was **node16**), `peter-evans/create-or-update-comment` → v5.0.0, `peter-evans/create-pull-request` → v8.1.1, `peter-evans/find-comment` → v4.0.0, `peter-evans/slash-command-dispatch` → v5.0.2, `robinraju/release-downloader` → v1.13.

**`ilammy/msvc-dev-cmd`** (5 usages — `common-setup`, `claude-code-runner`, `release.yml`, `cmake-options-build.yml`, `compile-rtx-remix-shaders-nightly.yml`): pinned to v1.13.0's SHA + a step-level `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` with an explanatory comment.

46 files changed total.

## Deliberately not bumped

- **`slackapi/slack-github-action`** — kept at `v1.26.0`. All 8 call sites use the v1.x `SLACK_WEBHOOK_URL` + `payload:` incoming-webhook pattern, which **v2+ removes** in favor of explicit `webhook` / `webhook-type` inputs. Bumping without rewriting every payload would silently break Slack notifications; that migration belongs in its own tested change.
- **`zgosalvez/github-actions-report-lcov`** — kept at `v4`; only a `v7.1.0-beta.1` has a node24 runtime, and pinning a beta in CI isn't worth it.
- **`mheap/github-action-required-labels@v5`** is already node24; `anthropics/claude-code-action@v1` is a composite action (no Node runtime) — both untouched.

## Concepts and vocabulary

- **`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`** — GitHub runner env var that runs a JS action's declared `node20` entrypoint on Node 24 without modifying the action. The documented opt-in for actions that have not yet shipped a node24 release.
- **SHA pin** — `uses: owner/action@<40-hex> # vX`. The 40-char commit SHA is the immutable reference the runner resolves; the `# vX` comment is human-readable provenance.
- **`runs.using`** — the field in an action's `action.yml` that declares its runtime (`node20` / `node24` / `composite` / `docker`); this, not the tag name, is what triggers the deprecation warning.

## Process report

- **GitHub-owned + third-party version bumps:** Each was chosen by reading `runs.using` at the resolved commit SHA, not by tag name. The boundary differs per action (`download-artifact` node24 only at v7, `upload-artifact` at v6, `checkout` at v5), so a blanket "+1 major" would have left some on node20. All pins were verified to declare `node24`. The third-party inputs in use (`token`/`path`/`commit-message`/`title`/`body` for create-pull-request; `draft`/`prerelease`/`files` for gh-release; etc.) are unchanged across the major bump, so these are runtime-only upgrades for our usage.
- **`actions/upload-artifact@v6` runner-version floor:** v6 requires Actions Runner ≥ 2.327.1 on self-hosted runners. Our scaler-provisioned and GPU runners auto-update and were already on ≥ 2.331.0, so they clear the floor.
- **`ilammy/msvc-dev-cmd` — why an env var and not a version bump:** the input shape here is *correct* (the action genuinely has no node24 release; upstream issues #99/#105 are open and unmerged), so the right layer to fix is the workflow, not the action. The env var is scoped to the individual step (not the job/workflow) so it forces node24 for exactly that action and nothing else. When upstream ships a node24 release, the env var and comment should be removed and the pin bumped.
- **`slackapi` — why reverted rather than bumped:** I initially bumped it, then reverted. This is the one place where the input shape *would* change: the v1.x webhook pattern is not valid input to v2+, so bumping would be a silent behavior break, not a runtime swap. Kept out of scope to keep this PR a pure runtime migration.