### PR TITLE
Split Falcor workflows: build on build pool, test on internal hosts

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,12 @@
+self-hosted-runner:
+  labels:
+    - arc
+    - benchmark
+    - build
+    - falcor
+    - GCP-T4
+    - GPU
+    - perf
+    - regression-test
+    - SM80Plus
+    - vulkancts

--- a/.github/workflows/falcor-compiler-perf-test.yml
+++ b/.github/workflows/falcor-compiler-perf-test.yml
@@ -15,49 +15,77 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   build:
+    name: Build
     if: github.event.pull_request.draft != true
     timeout-minutes: 100
     continue-on-error: false
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows]
-        config: [release]
-        compiler: [cl]
-        platform: [x86_64]
-        include:
-          # Self-hosted falcor tests
-          - warnings-as-errors: true
-            full-gpu-tests: false
-            runs-on: [Windows, self-hosted, perf]
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: [Windows, self-hosted, build]
     defaults:
       run:
         shell: bash
     steps:
+      - name: Add Git Bash to PATH
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          persist-credentials: false
           submodules: "recursive"
           fetch-depth: "0"
-
       - name: Setup
         uses: ./.github/actions/common-setup
         with:
-          os: ${{matrix.os}}
-          compiler: ${{matrix.compiler}}
-          platform: ${{matrix.platform}}
-          config: ${{matrix.config}}
+          os: windows
+          compiler: cl
+          platform: x86_64
+          config: release
           build-llvm: true
-
       - name: Build Slang
         run: |
           cmake --preset default --fresh \
             -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
-            -DCMAKE_COMPILE_WARNING_AS_ERROR=${{matrix.warnings-as-errors}} \
+            -DCMAKE_COMPILE_WARNING_AS_ERROR=true \
             -DSLANG_ENABLE_CUDA=1
-          cmake --workflow --preset "${{matrix.config}}"
+          cmake --workflow --preset release
+      - name: Upload Slang build
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: slang-falcor-perf-build-windows-release
+          path: build/Release/bin/
+          if-no-files-found: error
+          retention-days: 7
+  test:
+    name: Test (Falcor Perf)
+    needs: build
+    if: github.event.pull_request.draft != true
+    timeout-minutes: 100
+    continue-on-error: false
+    runs-on: [Windows, self-hosted, perf]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Add Git Bash to PATH
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          submodules: "false"
+          fetch-depth: "1"
+      - name: Download Slang build
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: slang-falcor-perf-build-windows-release
+          path: build/Release/bin
 
       - uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         id: download
@@ -96,7 +124,7 @@ jobs:
             exit 1
           }
           Expand-Archive $filename -DestinationPath .\falcor-perf-test
-          $env:PATH = ".\build\${{matrix.config}}\bin;" + $env:PATH
+          $env:PATH = ".\build\Release\bin;" + $env:PATH
 
           # View current PATH
           Write-Host "PATH is $env:PATH"

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -58,7 +58,7 @@ jobs:
             -DSLANG_ENABLE_SLANG_RHI=0
           cmake --workflow --preset release
       - name: Upload Slang build
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: slang-falcor-build-windows-release
           path: build/Release/bin/
@@ -80,13 +80,13 @@ jobs:
         run: |
           Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
           Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
           submodules: "false"
           fetch-depth: "1"
       - name: Download Slang build
-        uses: actions/download-artifact@81eafdc926c95ab3a46553696557fe28c599a41a # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: slang-falcor-build-windows-release
           path: slang-bin

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -18,35 +18,73 @@ jobs:
     if: github.event.pull_request.draft != true
     timeout-minutes: 100
     continue-on-error: false
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows]
-        config: [release]
-        compiler: [cl]
-        platform: [x86_64]
-        include:
-          # Self-hosted falcor tests
-          - warnings-as-errors: true
-            full-gpu-tests: false
-            runs-on: [Windows, self-hosted, falcor]
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: [Windows, self-hosted, build]
     defaults:
       run:
         shell: bash
     steps:
+      - name: Add Git Bash to PATH
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          persist-credentials: false
           submodules: "recursive"
           fetch-depth: "0"
       - name: Setup
         uses: ./.github/actions/common-setup
         with:
-          os: ${{matrix.os}}
-          compiler: ${{matrix.compiler}}
-          platform: ${{matrix.platform}}
-          config: ${{matrix.config}}
+          os: windows
+          compiler: cl
+          platform: x86_64
+          config: release
           build-llvm: true
+      - name: Build Slang
+        run: |
+          cmake --preset default --fresh \
+            -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
+            -DCMAKE_COMPILE_WARNING_AS_ERROR=true \
+            -DSLANG_ENABLE_CUDA=1 \
+            -DSLANG_ENABLE_EXAMPLES=0 \
+            -DSLANG_ENABLE_GFX=0 \
+            -DSLANG_ENABLE_TESTS=0 \
+            -DSLANG_EXCLUDE_DAWN=1 \
+            -DSLANG_EXCLUDE_TINT=1 \
+            -DSLANG_ENABLE_SLANG_RHI=0
+          cmake --workflow --preset release
+      - name: Upload Slang build
+        uses: actions/upload-artifact@v4
+        with:
+          name: slang-falcor-build-windows-release
+          path: build/Release/bin/
+  test:
+    name: Test (Falcor)
+    needs: build
+    if: github.event.pull_request.draft != true
+    timeout-minutes: 100
+    continue-on-error: false
+    runs-on: [Windows, self-hosted, falcor]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Add Git Bash to PATH
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          submodules: "false"
+          fetch-depth: "1"
+      - name: Download Slang build
+        uses: actions/download-artifact@v4
+        with:
+          name: slang-falcor-build-windows-release
+          path: slang-bin
       - name: setup-falcor
         shell: pwsh
         run: |
@@ -59,22 +97,9 @@ jobs:
           Copy-Item -Path 'C:\Falcor\media_internal' -Destination '.\' -Recurse
           Copy-Item -Path 'C:\Falcor\scripts' -Destination '.\' -Recurse
           cd ..\
-      - name: Build Slang
-        run: |
-          cmake --preset default --fresh \
-            -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
-            -DCMAKE_COMPILE_WARNING_AS_ERROR=${{matrix.warnings-as-errors}} \
-            -DSLANG_ENABLE_CUDA=1 \
-            -DSLANG_ENABLE_EXAMPLES=0 \
-            -DSLANG_ENABLE_GFX=0 \
-            -DSLANG_ENABLE_TESTS=0 \
-            -DSLANG_EXCLUDE_DAWN=1 \
-            -DSLANG_EXCLUDE_TINT=1 \
-            -DSLANG_ENABLE_SLANG_RHI=0
-          cmake --workflow --preset "${{matrix.config}}"
       - name: Copy Slang to Falcor
         run: |
-          cp --verbose --recursive --target-directory ./FalcorBin/build/windows-vs2022/bin/Release build/Release/bin/*
+          cp --verbose --recursive --target-directory ./FalcorBin/build/windows-vs2022/bin/Release slang-bin/*
       - name: falcor-unit-test
         shell: pwsh
         run: |

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -15,6 +15,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build:
+    name: Build
     if: github.event.pull_request.draft != true
     timeout-minutes: 100
     continue-on-error: false
@@ -55,10 +56,11 @@ jobs:
             -DSLANG_ENABLE_SLANG_RHI=0
           cmake --workflow --preset release
       - name: Upload Slang build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v4
         with:
           name: slang-falcor-build-windows-release
           path: build/Release/bin/
+          if-no-files-found: error
   test:
     name: Test (Falcor)
     needs: build
@@ -75,13 +77,13 @@ jobs:
         run: |
           Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
           Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           submodules: "false"
           fetch-depth: "1"
       - name: Download Slang build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@81eafdc926c95ab3a46553696557fe28c599a41a # v4
         with:
           name: slang-falcor-build-windows-release
           path: slang-bin

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -13,6 +13,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   build:
     name: Build

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -63,6 +63,7 @@ jobs:
           name: slang-falcor-build-windows-release
           path: build/Release/bin/
           if-no-files-found: error
+          retention-days: 7
   test:
     name: Test (Falcor)
     needs: build
@@ -107,16 +108,22 @@ jobs:
       - name: falcor-unit-test
         shell: pwsh
         run: |
-          $ErrorActionPreference = "SilentlyContinue"
+          $ErrorActionPreference = "Stop"
           cd .\FalcorBin\tests
           python ./testing/run_unit_tests.py --config windows-vs2022-Release -t "-slow"
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
           cd ../../
           #Get-ChildItem .\FalcorBin\build\windows-vs2022\bin\Release\FalcorTest*.log -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "=== $($_.FullName) ===" ; Get-Content $_ }
       - name: falcor-image-test
         shell: pwsh
         run: |
-          $ErrorActionPreference = "SilentlyContinue"
+          $ErrorActionPreference = "Stop"
           cd .\FalcorBin\tests
           python ./testing/run_image_tests.py --config windows-vs2022-Release --run-only
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
           cd ../../
           #Get-ChildItem .\FalcorBin\build\windows-vs2022\bin\Release\FalcorTest*.log -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "=== $($_.FullName) ===" ; Get-Content $_ }


### PR DESCRIPTION
Fixes #11495

Supersedes #11547 (closed unmerged). This PR carries that PR's `falcor-test.yml` commits (authored by @jkwak-work) and adds the same split for the perf-test workflow, so both Falcor workflows land together.

## Motivation

Both Falcor CI workflows ran their full Slang build on the scarce internal `[Windows, self-hosted, *]` hosts before any test could start:

- `falcor-test.yml` built on the `falcor` host.
- `falcor-compiler-perf-test.yml` built on the `perf` host.

These hosts are two static physical machines (`SLANGWIN4`, `SLANGWIN5`, shared across the `falcor`/`perf`/`benchmark`/`regression-test` labels) — they are **not** auto-scaled, so every minute spent compiling is a minute no Falcor test can run. With ~20 open PRs each needing Falcor + perf testing, the queue on those two machines runs many hours to days deep (one Falcor run was observed starved since late May). The build is the half that doesn't need these machines at all.

## Proposed solution

Split each workflow into a `build` job and a `test` job:

- **`build`** runs on the scaler-managed `[Windows, self-hosted, build]` GCP pool (which has the CUDA toolkit for `-DSLANG_ENABLE_CUDA=1` but no GPU/Falcor install), compiles Slang, and publishes `build/Release/bin/` as an artifact.
- **`test`** runs on the internal `falcor` / `perf` host (`needs: build`), downloads the artifact, and runs the Falcor unit/image tests / `falcor_perftest.exe` exactly as before.

This is the principled split: the build is target-machine-agnostic and belongs on the general build pool, while the scarce internal hosts focus solely on testing. The benchmark in particular **stays on the dedicated `perf` host** so its timings remain comparable run-to-run (ephemeral GCP VMs are the wrong substrate for performance measurement); only the build moves. The artifact handoff does not pollute the measurement — `falcor_perftest.exe` times Slang compilation internally and the download completes before it runs.

## Change summary

- `.github/workflows/falcor-test.yml` (from #11547): single job split into `build` (`[Windows, self-hosted, build]`) and `test` (`[Windows, self-hosted, falcor]`, `needs: build`); single-entry matrix inlined; artifact `slang-falcor-build-windows-release`; pinned `actions/*` v4 SHAs; `persist-credentials: false`; `permissions: contents: read`; shallow submodule-free test checkout; `if-no-files-found: error` + `retention-days: 7`; PowerShell test steps stop on error and propagate `$LASTEXITCODE`.
- `.github/workflows/falcor-compiler-perf-test.yml`: same split — `build` on `[Windows, self-hosted, build]`, `test` on `[Windows, self-hosted, perf]`; artifact `slang-falcor-perf-build-windows-release` (distinct name to avoid same-SHA collision with the falcor-test artifact); same hardening. Also fixes a latent PATH-casing bug: `.\build\Release\bin` (was lowercase `release`, which only worked by Windows case-insensitivity).
- `.github/actionlint.yaml` (from #11547): records the repository's custom self-hosted runner labels, including `build`, `falcor`, and `perf`.

## Concepts and vocabulary

- **Build pool** — scaler-managed `[Windows, self-hosted, build]` GCP VMs (`win-build-*`, no GPU) used for compilation that doesn't need a GPU or the Falcor install.
- **`falcor` / `perf` hosts** — two static internal Windows machines that hold the Falcor binaries / serve as the stable benchmark environment; not auto-scaled.
- **Artifact handoff** — `build/Release/bin/` uploaded by `build` and downloaded by `test`.

## Verification

Both `build` jobs succeeded on the GCP build pool (proving the artifact upload; `if-no-files-found: error` would fail an empty upload). The `test` jobs download the artifact on the internal hosts and were queued behind the deep shared-host backlog at the time of writing.