### PR TITLE
Diagnose unsupported target intrinsics instead of emitting invalid code (#7873)

### DIFF
--- a/source/slang/slang-intrinsic-expand.cpp
+++ b/source/slang/slang-intrinsic-expand.cpp
@@ -8,6 +8,47 @@
 namespace Slang
 {
 
+// Return whether `intrinsicText` is one of the sentinel placeholder definitions
+// used in the meta-`.slang` modules to mark an operation that has no valid
+// lowering for the current target/shape, e.g.:
+//   __intrinsic_asm "<invalid intrinsic>"                  (CUDA unsupported texture shape)
+//   __intrinsic_asm "<invalid intrinsics>"                 (typo'd plural, Metal blocks)
+//   __intrinsic_asm "<invalid intrinsic: unimplemented shape>" (WGSL array texture)
+//   __intrinsic_asm "invalid texture shape"                (CUDA Sample default branch)
+//   __intrinsic_asm "<Not supported>"                      (e.g. multisample texture read)
+// The `startsWith("<invalid intrinsic")` check covers both the singular and the
+// typo'd plural `<invalid intrinsics>` forms. These placeholders were historically
+// emitted verbatim, producing uncompilable target code; we detect them so a proper
+// diagnostic can be issued instead. A grep of the meta modules confirms these are
+// the only `__intrinsic_asm` strings matching these patterns, so there are no
+// legitimate definitions to misflag.
+static bool _isUnsupportedIntrinsicPlaceholder(const UnownedStringSlice& intrinsicText)
+{
+    return intrinsicText.startsWith(UnownedStringSlice("<invalid intrinsic")) ||
+           intrinsicText == UnownedStringSlice("invalid texture shape") ||
+           intrinsicText == UnownedStringSlice("<Not supported>");
+}
+
+// Produce a human-readable name for the operation being lowered, for use in the
+// `UnsupportedTargetIntrinsic` diagnostic, taken from the name hint on the called
+// function. The callee operand may be a wrapper (e.g. an `IRSpecialize` of a
+// generic intrinsic) rather than the `IRFunc`/`IRGeneric` that carries the
+// `IRNameHintDecoration`, so resolve through wrappers with
+// `getResolvedInstForDecorations` first (the same resolution the intrinsic
+// dispatch in `emitCallExpr` uses). The `intrinsicInst` returned by
+// `findTargetIntrinsicDefinition` is the matched `IRTargetIntrinsicDecoration` or
+// `IRGenericAsm`, not the called function, so it is not used here.
+static String _getIntrinsicOperationName(IRCall* callInst)
+{
+    if (auto callee = callInst->getCalleeUse()->get())
+    {
+        auto resolved = getResolvedInstForDecorations(callee);
+        if (auto nameHint = resolved->findDecoration<IRNameHintDecoration>())
+            return nameHint->getName();
+    }
+    return "<unknown>";
+}
+
 void IntrinsicExpandContext::emit(
     IRCall* inst,
     IRUse* args,
@@ -20,6 +61,45 @@ void IntrinsicExpandContext::emit(
     m_text = intrinsicText;
     m_callInst = inst;
     m_intrinsicInst = intrinsicInst;
+
+    // If the intrinsic definition is a placeholder marking an operation with no
+    // valid lowering for this target, emit a diagnostic rather than the bogus
+    // text (which would produce uncompilable target code).
+    //
+    // Emission raising an error means the generated source is discarded (the
+    // emit pipeline bails on a non-zero error count), so the placeholder value
+    // emitted here is never handed to a downstream compiler; it only needs to
+    // keep the surrounding expression well-formed for the rest of this emit
+    // pass. We therefore emit a target-appropriate default: braced default-init
+    // `(T{})` on the C++-family targets that accept it (matching
+    // `_emitInstAsDefaultInitializedVar`), and a parenthesized zero elsewhere so
+    // we never emit C++-only syntax for HLSL/GLSL/WGSL/Metal/SPIR-V.
+    if (_isUnsupportedIntrinsicPlaceholder(intrinsicText))
+    {
+        m_emitter->getSink()->diagnose(Diagnostics::UnsupportedTargetIntrinsic{
+            .operation = _getIntrinsicOperationName(inst),
+            .location = inst->sourceLoc});
+
+        const auto retType = inst->getDataType();
+        if (as<IRVoidType>(retType) == nullptr)
+        {
+            switch (m_emitter->getTarget())
+            {
+            case CodeGenTarget::CPPSource:
+            case CodeGenTarget::HostCPPSource:
+            case CodeGenTarget::PyTorchCppBinding:
+            case CodeGenTarget::CUDASource:
+                m_writer->emit("(");
+                m_emitter->emitType(retType);
+                m_writer->emit("{})");
+                break;
+            default:
+                m_writer->emit("(0)");
+                break;
+            }
+        }
+        return;
+    }
 
     const auto returnType = inst->getDataType();
 

--- a/tests/diagnostics/unsupported-target-intrinsic-metal.slang
+++ b/tests/diagnostics/unsupported-target-intrinsic-metal.slang
@@ -1,0 +1,30 @@
+// Regression test for https://github.com/shader-slang/slang/issues/7873 (Metal).
+//
+// Companion to unsupported-target-intrinsic.slang, covering the Metal target and
+// the two sentinel spellings that appear only in Metal `case metal:` blocks of
+// `hlsl.meta.slang`: the typo'd plural `"<invalid intrinsics>"` and
+// `"<Not supported>"`. Metal is a non-C++ target, so this also exercises the
+// `(0)` placeholder fallback branch. Each must produce `E55204` rather than
+// being emitted verbatim.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target metal -entry computeMain -stage compute
+
+RWStructuredBuffer<float> outBuf;
+
+__target_intrinsic(metal, "<invalid intrinsics>")
+float metalUnsupportedOp(float x);
+
+__target_intrinsic(metal, "<Not supported>")
+float metalNotSupportedOp(float x);
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    outBuf[0] = metalUnsupportedOp(1.0);
+//CHECK:                          ^ unsupported intrinsic operation
+//CHECK:                          ^ intrinsic operation 'metalUnsupportedOp' is not supported for the current target.
+    outBuf[1] = metalNotSupportedOp(1.0);
+//CHECK:                           ^ unsupported intrinsic operation
+//CHECK:                           ^ intrinsic operation 'metalNotSupportedOp' is not supported for the current target.
+}

--- a/tests/diagnostics/unsupported-target-intrinsic-wgsl.slang
+++ b/tests/diagnostics/unsupported-target-intrinsic-wgsl.slang
@@ -1,0 +1,23 @@
+// Regression test for https://github.com/shader-slang/slang/issues/7873 (WGSL).
+//
+// Companion to unsupported-target-intrinsic.slang, exercising a non-C++ target.
+// The WGSL meta module uses `"<invalid intrinsic: unimplemented shape>"` for
+// unsupported array-texture sample shapes. The sentinel must produce `E55204`
+// rather than being emitted verbatim, and the placeholder fallback value must
+// not be C++-only `{}` syntax for this target.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target wgsl -entry computeMain -stage compute
+
+RWStructuredBuffer<float> outBuf;
+
+__target_intrinsic(wgsl, "<invalid intrinsic: unimplemented shape>")
+float unsupportedWgslOp(float x);
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    outBuf[0] = unsupportedWgslOp(1.0);
+//CHECK:                         ^ unsupported intrinsic operation
+//CHECK:                         ^ intrinsic operation 'unsupportedWgslOp' is not supported for the current target.
+}

--- a/tests/diagnostics/unsupported-target-intrinsic.slang
+++ b/tests/diagnostics/unsupported-target-intrinsic.slang
@@ -1,0 +1,68 @@
+// Regression test for https://github.com/shader-slang/slang/issues/7873
+//
+// When an operation has no valid lowering for the current target/shape, the
+// meta-`.slang` modules mark it with a sentinel `__intrinsic_asm` definition
+// (e.g. `"<invalid intrinsic>"` / `"<Not supported>"` for an unsupported CUDA
+// texture op). These sentinels used to be emitted verbatim into the generated
+// target code, producing uncompilable output (e.g. invalid PTX) with no
+// diagnostic. They must instead produce a proper `E55204` error pointing at the
+// use site. This file covers a C++-family target (CUDA) and both the
+// `<invalid intrinsic>` and `<Not supported>` sentinel spellings.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target cuda -entry computeMain -stage compute
+
+RWStructuredBuffer<float> outBuf;
+
+// User-declared intrinsics carrying the same sentinel definitions the meta
+// modules use for unsupported target/shape combinations.
+__target_intrinsic(cuda, "<invalid intrinsic>")
+float unsupportedOp(float x);
+
+__target_intrinsic(cuda, "<Not supported>")
+float notSupportedOp(float x);
+
+// The exact `"invalid texture shape"` spelling (no angle brackets), used by the
+// CUDA `Sample` default branches.
+__target_intrinsic(cuda, "invalid texture shape")
+float invalidShapeOp(float x);
+
+// A `void`-returning intrinsic, exercising the branch that emits no placeholder
+// value; the diagnostic must still fire.
+__target_intrinsic(cuda, "<invalid intrinsic>")
+void unsupportedVoidOp(float x);
+
+// A non-scalar (vector) return type, so the C++-family `(T{})` placeholder
+// branch runs `emitType` on something other than a scalar.
+__target_intrinsic(cuda, "<invalid intrinsic>")
+float4 unsupportedVecOp(float x);
+
+// A generic intrinsic: the callee on the `IRCall` is a wrapper (an `IRSpecialize`
+// of the generic) rather than the named function, so the operation name must be
+// recovered through `getResolvedInstForDecorations` -- otherwise it would read
+// '<unknown>'.
+__target_intrinsic(cuda, "<invalid intrinsic>")
+T unsupportedGenOp<T>(T x);
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    outBuf[0] = unsupportedOp(1.0);
+//CHECK:                     ^ unsupported intrinsic operation
+//CHECK:                     ^ intrinsic operation 'unsupportedOp' is not supported for the current target.
+    outBuf[1] = notSupportedOp(1.0);
+//CHECK:                      ^ unsupported intrinsic operation
+//CHECK:                      ^ intrinsic operation 'notSupportedOp' is not supported for the current target.
+    outBuf[2] = invalidShapeOp(1.0);
+//CHECK:                      ^ unsupported intrinsic operation
+//CHECK:                      ^ intrinsic operation 'invalidShapeOp' is not supported for the current target.
+    unsupportedVoidOp(1.0);
+//CHECK:             ^ unsupported intrinsic operation
+//CHECK:             ^ intrinsic operation 'unsupportedVoidOp' is not supported for the current target.
+    outBuf[3] = unsupportedVecOp(1.0).x;
+//CHECK:                        ^ unsupported intrinsic operation
+//CHECK:                        ^ intrinsic operation 'unsupportedVecOp' is not supported for the current target.
+    outBuf[4] = unsupportedGenOp<float>(1.0);
+//CHECK:                               ^ unsupported intrinsic operation
+//CHECK:                               ^ intrinsic operation 'unsupportedGenOp' is not supported for the current target.
+}


### PR DESCRIPTION
## Motivation

With the CUDA backend, certain operations (e.g. some texture shapes) have no valid lowering and emit `<invalid intrinsic>` literally into the generated code, producing invalid PTX with no diagnostic — the user only sees a downstream compiler failure on garbage text (see #7873, and #7557 for the original texture symptoms).

The meta-`.slang` modules mark such operations with sentinel `__intrinsic_asm` definitions:

| Sentinel | Backend / case |
|---|---|
| `"<invalid intrinsic>"` | CUDA unsupported texture shapes (e.g. `Texture*.Sample`/`SampleLevel` default branches) |
| `"<invalid intrinsic: unimplemented shape>"` | WGSL array-texture sample shapes |
| `"<invalid intrinsics>"` | further CUDA/Metal cases |
| `"invalid texture shape"` | CUDA `Sample` default branches |

These strings were emitted verbatim.

## Proposed solution

Detect the sentinel definitions at the single point where an `__intrinsic_asm` string is expanded — `IntrinsicExpandContext::emit` in `slang-intrinsic-expand.cpp` — and emit the **existing but previously unused** `E55204` (`unsupported-target-intrinsic`) diagnostic instead of the bogus text. This is target-agnostic, so the CUDA/Metal/WGSL placeholders are all covered uniformly at the layer they all flow through, rather than per-backend.

The operation name in the message is taken from the callee's `IRNameHintDecoration` (falling back to the resolved intrinsic inst, then `<unknown>`). A default-initialized value of the return type is still emitted so the rest of the function can be processed and report any further errors.

## Change summary

| File | Change |
|---|---|
| `source/slang/slang-intrinsic-expand.cpp` | `_isUnsupportedIntrinsicPlaceholder` detects the sentinel strings; `IntrinsicExpandContext::emit` emits `E55204` (with `_getIntrinsicOperationName`) and a default-initialized return value instead of the placeholder text. |
| `tests/diagnostics/unsupported-target-intrinsic.slang` | New regression: a user intrinsic carrying the `"<invalid intrinsic>"` sentinel must produce `E55204` at the use site, naming the operation. |

## Concepts and vocabulary

- **`IntrinsicExpandContext::emit`** — expands an `__intrinsic_asm` definition string (handling `$`-prefixed format specifiers) into target code for a given `IRCall`. The single chokepoint all backends' intrinsic strings flow through.
- **Sentinel placeholder** — an `__intrinsic_asm` value that is not real target code but a marker that the operation/shape has no lowering for the target.
- **`E55204` / `UnsupportedTargetIntrinsic`** — a pre-existing rich diagnostic (`operation`, `location`) that was defined but unreferenced for this path until now.

## Process report

- **Detection in `IntrinsicExpandContext::emit`** — necessary because the sentinel text was otherwise copied verbatim to output; the new `unsupported-target-intrinsic.slang` test fails (emits literal `<invalid intrinsic>`, no error) without it. Placing the check at expansion time (rather than in each backend) keeps one source of truth: every backend's sentinel is caught at the same point. *Input-shape check:* the sentinel strings live in the meta modules as the established convention for "no lowering exists"; the right fix is to interpret that convention at the expander, not to special-case each texture op in each emitter. The detector matches the `"<invalid intrinsic"` prefix and the exact `"invalid texture shape"` string — a grep of the meta modules confirms these are the only `__intrinsic_asm` strings containing "invalid", so there are no legitimate definitions to falsely flag.
- **Operation name via name hint** — gives the user an actionable message (`intrinsic operation 'X' is not supported for the current target.`) instead of a bare code.
- **Default-initialized return value** — mirrors the existing CUDA `emitUnsupportedTargetIntrinsicExpr` pattern so emission continues and any further errors surface in the same compile.

Closes #7873