### PR TITLE
[codex] Keep zero init off lambda closures

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -11421,8 +11421,11 @@ void SemanticsDeclBasesVisitor::visitStructDecl(StructDecl* decl)
             continue;
         }
 
+        // `visitLambdaExpr` synthesizes `LambdaDecl` closure structs and constructs them with
+        // captured values. Forcing `IDefaultInitializable` onto those implementation-detail structs
+        // makes the closure construction resolve against the zero-argument default constructor.
         if (this->getOptionSet().getBoolOption(CompilerOptionName::ZeroInitialize) &&
-            !isFromCoreModule(decl))
+            !isFromCoreModule(decl) && !as<LambdaDecl>(decl))
         {
             // Force add IDefaultInitializable to any struct missing (transitively)
             // `IDefaultInitializable`.

--- a/tests/language-feature/zero-initialize/lambda-capture.slang
+++ b/tests/language-feature/zero-initialize/lambda-capture.slang
@@ -1,0 +1,13 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -entry computeMain -stage compute -emit-spirv-directly -zero-initialize
+
+// CHECK: OpEntryPoint GLCompute %computeMain
+// CHECK: OpStore
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(RWStructuredBuffer<int> output)
+{
+    int captured = 1;
+    let addCaptured = ((uint row, uint col, int value) => value + captured);
+    output[0] = addCaptured(0, 0, 0);
+}


### PR DESCRIPTION
Fixes #11572.
Related: #11573.

1. **Motivation**

A user reported that a captured lambda used with `CoopMat.MapElement` compiles normally, but fails when the command line includes `-zero-initialize`. A reduced reproducer is a captured lambda by itself:

```slang
int captured = 1;
let addCaptured = ((uint row, uint col, int value) => value + captured);
```

With `-zero-initialize`, semantic checking reports `too many arguments to call (got 1, expected 0)` and points at the lambda, with `_slang_Lambda_* .init()` as the only candidate. This makes a valid captured lambda look like an invalid function call.

2. **Proposed Solution**

Do not force synthesized `LambdaDecl` closure structs through the `-zero-initialize` path that adds `IDefaultInitializable` conformance. Lambda closures are compiler implementation details constructed by `visitLambdaExpr` using the captured values; they should not have their constructor set changed by a frontend compatibility flag.

This keeps existing zero-initialization behavior for ordinary non-core structs while avoiding a semantic change for synthesized closure types. The broader design issue remains tracked in #11573: `-zero-initialize` should eventually be reimplemented as an IR-level transform instead of a frontend/type-system operation.

3. **Change Summary**

- `source/slang/slang-check-decl.cpp`: skip `LambdaDecl` when `SemanticsDeclBasesVisitor::visitStructDecl` force-adds `IDefaultInitializable` under `CompilerOptionName::ZeroInitialize`.
- `tests/language-feature/zero-initialize/lambda-capture.slang`: add a compile-only SPIR-V regression test for a captured lambda with `-zero-initialize`.

4. **Concepts and Vocabulary**

- `LambdaDecl`: the synthesized struct Slang uses to represent a lambda closure.
- Captured field: a field synthesized on `LambdaDecl` for a variable referenced from the enclosing scope.
- Member-init constructor: the synthesized `$init(...)` constructor that receives captured values and initializes the closure fields.
- `IDefaultInitializable`: the frontend interface used by the current `-zero-initialize` implementation to model default construction.

5. **Process Report**

`visitLambdaExpr` in `slang-check-expr.cpp` creates a `LambdaDecl`, registers captured variables as fields, and returns a constructor invocation for the closure object with the captured values as arguments. For the reported shader, the lambda captures `batchOffset`, so closure construction needs the synthesized member-init constructor that accepts that captured value.

When `-zero-initialize` is set, `SemanticsDeclBasesVisitor::visitStructDecl` in `slang-check-decl.cpp` force-adds `IDefaultInitializable` to every non-core struct that does not already satisfy it. Before this change, that included the synthesized `LambdaDecl`. That extra conformance introduced/defaulted a zero-argument initialization path for the closure struct, so the later closure construction with one captured argument resolved against `_slang_Lambda_* .init()` with zero parameters and produced the misleading `too many arguments` diagnostic.

The input shape is not something a consumer should handle as a normal user type: `LambdaDecl` is a compiler-generated closure representation created by `visitLambdaExpr`, and its construction contract is defined by the captures collected in that same flow. The principled local fix is therefore to keep `-zero-initialize` from mutating `LambdaDecl` inheritance/conformance. The producer of the closure shape remains valid, and the `-zero-initialize` compatibility behavior still applies to ordinary user structs.

Validation:

- `D:\git_repo\slang\build\windows-vs2026-dev\Debug\bin\slang-test.exe tests\language-feature\zero-initialize\lambda-capture.slang`
- Original `CoopMat.MapElement` repro compiled with `-target spirv -entry main -stage compute -emit-spirv-directly -capability cooperative_matrix_2 -zero-initialize`.