### PR TITLE
ci: enable read-only sccache on Falcor builds

### DIFF
--- a/.github/workflows/falcor-compiler-perf-test.yml
+++ b/.github/workflows/falcor-compiler-perf-test.yml
@@ -38,6 +38,21 @@ jobs:
           persist-credentials: false
           submodules: "recursive"
           fetch-depth: "0"
+      # Restore (read-only) the Windows-release sccache populated on master by
+      # populate-sccache.yml. We deliberately do not save a new cache entry, so
+      # this adds zero pressure on the 10 GB GitHub Actions cache budget and
+      # cannot evict the populate caches.
+      - name: Restore sccache cache (read-only)
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: C:/sccache
+          key: sccache-windows-cl-x86_64-release-${{ github.sha }}
+          restore-keys: |
+            sccache-windows-cl-x86_64-release-
+      - name: Setup sccache
+        uses: ./.github/actions/setup-sccache
+        with:
+          platform: windows
       - name: Setup
         uses: ./.github/actions/common-setup
         with:
@@ -48,11 +63,18 @@ jobs:
           build-llvm: true
       - name: Build Slang
         run: |
+          echo "📊 sccache statistics (pre-build):"
+          sccache --show-stats || true
           cmake --preset default --fresh \
             -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
             -DCMAKE_COMPILE_WARNING_AS_ERROR=true \
-            -DSLANG_ENABLE_CUDA=1
+            -DSLANG_ENABLE_CUDA=1 \
+            -DCMAKE_C_COMPILER_LAUNCHER="${sccache_path}" \
+            -DCMAKE_CXX_COMPILER_LAUNCHER="${sccache_path}" \
+            -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
           cmake --workflow --preset release
+          echo "📊 sccache statistics (post-build):"
+          sccache --show-stats || true
       - name: Upload Slang build
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:

--- a/.github/workflows/falcor-test.yml
+++ b/.github/workflows/falcor-test.yml
@@ -36,6 +36,23 @@ jobs:
           persist-credentials: false
           submodules: "recursive"
           fetch-depth: "0"
+      # Restore (read-only) the Windows-release sccache populated on master by
+      # populate-sccache.yml. The Falcor build uses a reduced CMake config, so
+      # only the core compiler translation units whose command line is
+      # unaffected by the Falcor-specific -D flags will hit; we deliberately do
+      # not save a new cache entry, so this adds zero pressure on the 10 GB
+      # GitHub Actions cache budget and cannot evict the populate caches.
+      - name: Restore sccache cache (read-only)
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: C:/sccache
+          key: sccache-windows-cl-x86_64-release-${{ github.sha }}
+          restore-keys: |
+            sccache-windows-cl-x86_64-release-
+      - name: Setup sccache
+        uses: ./.github/actions/setup-sccache
+        with:
+          platform: windows
       - name: Setup
         uses: ./.github/actions/common-setup
         with:
@@ -46,6 +63,8 @@ jobs:
           build-llvm: true
       - name: Build Slang
         run: |
+          echo "📊 sccache statistics (pre-build):"
+          sccache --show-stats || true
           cmake --preset default --fresh \
             -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
             -DCMAKE_COMPILE_WARNING_AS_ERROR=true \
@@ -55,8 +74,13 @@ jobs:
             -DSLANG_ENABLE_TESTS=0 \
             -DSLANG_EXCLUDE_DAWN=1 \
             -DSLANG_EXCLUDE_TINT=1 \
-            -DSLANG_ENABLE_SLANG_RHI=0
+            -DSLANG_ENABLE_SLANG_RHI=0 \
+            -DCMAKE_C_COMPILER_LAUNCHER="${sccache_path}" \
+            -DCMAKE_CXX_COMPILER_LAUNCHER="${sccache_path}" \
+            -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
           cmake --workflow --preset release
+          echo "📊 sccache statistics (post-build):"
+          sccache --show-stats || true
       - name: Upload Slang build
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:


### PR DESCRIPTION
#11562 (the Falcor build/test split) is now **merged**; this PR is rebased onto master and contains only the sccache change.

## Motivation

The Falcor `build` and perf-test `build` jobs (both on the `[Windows, self-hosted, build]` GCP pool, after #11562) compile Slang from scratch every run. Meanwhile `populate-sccache.yml` already maintains a fresh Windows-release sccache in the GitHub Actions cache every 30 minutes. These builds can reuse it for free.

## Proposed solution — restore-only

Add to each Falcor `build` job:
- `actions/cache/restore` keyed on the existing `sccache-windows-cl-x86_64-release-` prefix,
- the `setup-sccache` action,
- the sccache compiler launcher (`-DCMAKE_C/CXX_COMPILER_LAUNCHER`, `-DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON`) on the build, with pre/post `sccache --show-stats`.

**No `cache/save` step.** Because nothing is written back, this adds **zero** pressure on the 10 GB GitHub Actions cache budget (already at ~4–8 GB across the populate tiers) and **cannot evict** the populate caches. The Falcor jobs are pure consumers of a cache the populate cron maintains.

## Caveat — this is a measurement, not a guaranteed win

The Falcor build uses a **reduced CMake config** (`-DSLANG_ENABLE_GFX=0`, `-DSLANG_ENABLE_TESTS=0`, `-DSLANG_EXCLUDE_DAWN=1`, etc.). The GHA-cache *restore* matches by prefix and succeeds, but the per-translation-unit sccache hash depends on the exact compile command. Only core compiler TUs whose command line is unaffected by those `-D` flags will hit; flag-perturbed TUs miss and compile fresh.

The hit rate is therefore **partial and unknown until measured** — that is why this is a separate PR from the split, and why pre/post `--show-stats` is included. Decide whether to keep it on the reported number: if the hit rate is worthwhile, keep; if negligible, the change is three steps to revert.

## Change summary

- `.github/workflows/falcor-test.yml` — restore-only sccache on the `build` job.
- `.github/workflows/falcor-compiler-perf-test.yml` — same.

Action pins (`actions/cache/restore@…#v5`, `checkout@…#v5`, artifact `v6`/`v7`) match the repo's post-#11557 Node-24 pins.

## Measured results (first run, both builds)

Both Falcor `build` jobs restored the existing `sccache-windows-cl-x86_64-release-`
cache (~88 MB) and achieved a **100% hit rate on all cacheable compilations,
zero misses**:

| Build | Cacheable hits | Hit rate | Misses | Build Slang step |
|---|---|---|---|---|
| Falcor Tests | 300 / 300 | 100% | 0 | ~12.5 min |
| Falcor Perf | 544 / 544 | 100% | 0 | ~17.5 min |

The wall-clock saving is **modest, not dramatic**: the cacheable compiles are
~38–40% of total compile requests (300/786 and 544/1351); the remainder are
non-cacheable (the CUDA/`nvcc` path, linking) plus the LLVM setup / CMake
configure / link phases that sccache never touches. So this trims compile time
at **zero storage cost** — a clean keep, not a transformative speedup.

Notably the perf-test build uses the **fuller** CMake config (no
gfx/tests/rhi/dawn/tint exclusions) yet still hit 100% against the same
Release populate cache — confirming the existing tier already covers both
Falcor configs.

### Decision: do NOT add Falcor builds to `populate-sccache.yml`

A dedicated Falcor populate tier was considered and **rejected**: both builds
already hit 100% with **zero misses** against the existing Release cache, so a
writer tier would capture nothing new, while adding two more entries (~88 MB+
each, every 30 min) that compete for GitHub's 10 GB cache cap and risk
LRU-evicting the main Release/Debug tiers the whole CI matrix depends on.
Strictly worse: more eviction pressure, no measurable hit-rate gain. Restore-only
is the correct design.