### PR TITLE
Show argument type mismatch per candidate in overload errors (#7857)

### DIFF
--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -311,6 +311,30 @@ struct OverloadCandidate
     // candidate reports this reason instead of falling back to only the generic
     // "could not specialize" diagnostic.
     GenericArgumentInferenceFailure genericInferenceFailure;
+
+    // Records the first argument that failed to type-check while trying this
+    // candidate, so a "no applicable overload" diagnostic can point the user at
+    // which argument is wrong (issue #7857). `argMismatchArgIndex` is the 0-based
+    // argument index (-1 until a mismatch is recorded); `argMismatchExpectedType`
+    // is the parameter type and `argMismatchActualType` is the argument type.
+    Index argMismatchArgIndex = -1;
+    Type* argMismatchExpectedType = nullptr;
+    Type* argMismatchActualType = nullptr;
+};
+
+struct ResolvedOperatorOverload
+{
+    // The resolved decl.
+    Decl* decl;
+
+    // The cached overload candidate in the current TypeCheckingCache.
+    // Note that a `OverloadCandidate` object is not migratable over different
+    // Linkages (compile sessions), so we will need to use `cacheVersion` to track
+    // if this `candidate` is valid for the current session. If not, we will
+    // recreate it from `decl`.
+    OverloadCandidate candidate;
+    // The version of the TypeCheckingCache for which the cached candidate is valid.
+    int cacheVersion;
 };
 
 struct TypeCheckingCache : public RefObject

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -814,6 +814,33 @@ bool SemanticsVisitor::TryCheckOverloadCandidateTypes(
         return result;
     };
 
+    // Record the first argument that fails to match, so that a "no applicable
+    // overload" diagnostic can point at the offending argument (issue #7857).
+    // Only the first failure is kept, since type checking of a candidate stops at
+    // that point.
+    //
+    // The reported index is the *argument* index (`argIndex - 1`: `readArg` has
+    // already advanced `argIndex` past the just-read argument), not `paramIndex`.
+    // These differ for a `ConcreteTypePack` parameter, where several arguments
+    // are consumed against a single fixed `paramIndex` -- using `paramIndex`
+    // there would point at the wrong argument number.
+    //
+    // Only record when the underlying types actually differ. A failure where the
+    // types are equal but the qualifiers differ (e.g. an l-value/`inout`
+    // mismatch) has its own dedicated diagnostics; recording it here would
+    // produce a confusing "expected 'T', got 'T'" note that names only the bare
+    // types.
+    auto recordArgMismatch = [&](QualType paramType, QualType argType)
+    {
+        if (candidate.argMismatchArgIndex < 0 && paramType.type && argType.type &&
+            !paramType.type->equals(argType.type))
+        {
+            candidate.argMismatchArgIndex = argIndex - 1;
+            candidate.argMismatchExpectedType = paramType.type;
+            candidate.argMismatchActualType = argType.type;
+        }
+    };
+
     auto coerceArgToParam = [&](Arg arg, QualType paramType) -> Arg
     {
         auto argType = QualType(arg.type, paramType.isLeftValue);
@@ -828,10 +855,14 @@ bool SemanticsVisitor::TryCheckOverloadCandidateTypes(
             {
                 // We need an exact match in this case.
                 if (!paramType->equals(argType))
+                {
+                    recordArgMismatch(paramType, argType);
                     return {nullptr, nullptr};
+                }
             }
             else if (!canCoerce(paramType, argType, arg.argExpr, &cost))
             {
+                recordArgMismatch(paramType, argType);
                 return {nullptr, nullptr};
             }
             candidate.conversionCostSum += cost;
@@ -3354,6 +3385,80 @@ Expr* SemanticsVisitor::ResolveInvoke(InvokeExpr* expr)
             {
                 getSink()->diagnose(
                     Diagnostics::NoApplicableWithArgs{.args = argsList, .expr = expr});
+            }
+
+            // For each candidate, show its signature and, when we recorded one,
+            // which argument failed to match. This helps the user see precisely
+            // why no overload applied (issue #7857).
+            {
+                Index maxCandidatesToPrint = 10;
+
+                // Order by check status, with the declaration's source location
+                // as a deterministic tie-breaker so candidates with equal status
+                // are not reordered arbitrarily by the sort (which would make the
+                // diagnostic output nondeterministic across builds/platforms).
+                context.bestCandidates.sort(
+                    [](const OverloadCandidate& c1, const OverloadCandidate& c2)
+                    {
+                        if (c1.status != c2.status)
+                            return c1.status < c2.status;
+                        return c1.item.declRef.getLoc().getRaw() <
+                               c2.item.declRef.getLoc().getRaw();
+                    });
+
+                // `bestCandidates` can contain the same candidate more than once
+                // (e.g. a synthesized constructor reached via several lookup
+                // paths); report each once. Dedup by the rendered signature
+                // string rather than by `Decl*`: `declRef.getDecl()` strips
+                // substitutions, so two distinct specializations of the same
+                // generic (e.g. `foo<float>` vs `foo<int>`) share a `Decl*` and
+                // would wrongly collapse into one note, hiding a genuinely
+                // different per-argument mismatch. The signature string is what
+                // the user sees and distinguishes specializations. A single pass
+                // prints up to `maxCandidatesToPrint` unique candidates and
+                // counts any further unique ones so the trailing "N more" note is
+                // accurate.
+                HashSet<String> seenCandidates;
+                Index printedCount = 0;
+                Index remainingCount = 0;
+                for (const auto& candidate : context.bestCandidates)
+                {
+                    if (!candidate.item.declRef.getDecl())
+                        continue;
+
+                    String declString =
+                        ASTPrinter::getDeclSignatureString(candidate.item, m_astBuilder);
+                    if (!seenCandidates.add(declString))
+                        continue;
+
+                    if (printedCount >= maxCandidatesToPrint)
+                    {
+                        remainingCount++;
+                        continue;
+                    }
+
+                    getSink()->diagnose(Diagnostics::OverloadCandidate{
+                        .candidate = declString,
+                        .location = candidate.item.declRef.getLoc()});
+
+                    if (candidate.argMismatchArgIndex >= 0 && candidate.argMismatchExpectedType &&
+                        candidate.argMismatchActualType)
+                    {
+                        getSink()->diagnose(Diagnostics::OverloadCandidateArgumentTypeMismatch{
+                            .argIndex = (int64_t)candidate.argMismatchArgIndex,
+                            .expectedType = candidate.argMismatchExpectedType,
+                            .actualType = candidate.argMismatchActualType,
+                            .location = candidate.item.declRef.getLoc()});
+                    }
+
+                    printedCount++;
+                }
+                if (remainingCount > 0)
+                {
+                    getSink()->diagnose(Diagnostics::MoreOverloadCandidates{
+                        .count = (int64_t)remainingCount,
+                        .location = expr->loc});
+                }
             }
         }
         else

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -3772,6 +3772,13 @@ standalone_note(
     span { loc = "location" }
 )
 
+standalone_note(
+    "overload-candidate-argument-type-mismatch",
+    40018,
+    "argument ~argIndex:Int does not match: expected '~expectedType:Type', got '~actualType:Type'",
+    span { loc = "location" }
+)
+
 err(
     "case-outside-switch",
     39999,

--- a/tests/autodiff/differential-type-syntheize-diagnostics.slang
+++ b/tests/autodiff/differential-type-syntheize-diagnostics.slang
@@ -2,6 +2,9 @@
 //DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target cuda -line-directive-mode none
 
 struct PartlyDiffable : IDifferentiable
+/*CHECK:
+       ^^^^^^^^^^^^^^ candidate: PartlyDiffable.Differential.init(float)
+*/
 {
     no_diff float noDiffMember;
     float diffMember;

--- a/tests/diagnostics/bad-operator-call.slang
+++ b/tests/diagnostics/bad-operator-call.slang
@@ -1,8 +1,13 @@
 // bad-operator-call.slang
 
-//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):
 
 // Test that bad calls to operators produce reasonable diagnostic messages.
+//
+// This test is `non-exhaustive` because a failed call to a builtin operator
+// now also emits a per-candidate "argument N does not match" note (E40018) for
+// each of the operator's many overloads (issue #7857); enumerating all of them
+// here would be unwieldy and brittle.
 
 struct S {}
 
@@ -22,10 +27,21 @@ void test()
 /*CHECK:
           ^ no overload for '+' applicable to arguments of type (int, S)
 */
+    // The binary-operator failure path (NoApplicableWithArgs, no funcName) must
+    // still emit the per-candidate argument-mismatch note (E40018) from issue
+    // #7857. Matched loosely (operators have many overloads, so the exact
+    // expected type varies); this guards against the note being suppressed on the
+    // operator path.
+//CHECK: does not match: expected
 	a = ~b;
 /*CHECK:
      ^ no overload for '~' applicable to arguments of type (S)
 */
+    // ...and the unary-operator path must emit it too. This ordered `CHECK`
+    // follows the '~' error above, so the argument-0 mismatch note it matches is
+    // the one for the unary '~' rejection — guarding against E40018 being
+    // suppressed specifically on the unary path while kept on the binary path.
+//CHECK: argument 0 does not match: expected
 
 	vector<int, 4> c;
     vector<float, 3> d;

--- a/tests/diagnostics/overload-argument-type-mismatch-argindex.slang
+++ b/tests/diagnostics/overload-argument-type-mismatch-argindex.slang
@@ -1,0 +1,30 @@
+// Regression test for https://github.com/shader-slang/slang/issues/7857
+//
+// Companion to overload-argument-type-mismatch.slang. Exercises the per-candidate
+// mismatch note (E40018) reporting a *non-zero* argument index and a member call
+// (which flows through `MemberExpr`), so a regression in the `paramIndex`
+// accounting or the member-lookup path would be caught.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):
+
+struct Test {}
+
+struct Widget
+{
+    // The first argument matches; the mismatch is on argument 1.
+    float poke(float x, float2 y) { return 0; }
+    float poke(float x, float3 y) { return 0; }
+}
+
+float test()
+{
+    Widget w;
+    return w.poke(1.0, Test());
+//CHECK: no overload for 'poke' applicable to arguments of type (float, Test)
+}
+
+// Both candidates report the mismatch at argument index 1.
+//CHECK: candidate: func Widget.poke(float, float2) -> float
+//CHECK: argument 1 does not match: expected 'vector<float,2>', got 'Test'
+//CHECK: candidate: func Widget.poke(float, float3) -> float
+//CHECK: argument 1 does not match: expected 'vector<float,3>', got 'Test'

--- a/tests/diagnostics/overload-argument-type-mismatch-many.slang
+++ b/tests/diagnostics/overload-argument-type-mismatch-many.slang
@@ -1,0 +1,45 @@
+// Regression test for https://github.com/shader-slang/slang/issues/7857
+//
+// Companion to overload-argument-type-mismatch.slang. With more than
+// `maxCandidatesToPrint` (10) distinct candidates, the candidate notes are
+// capped and a trailing "N more overload candidates" note (E40015) reports the
+// remainder. This pins the interaction between dedup, the cap, and the
+// `remainingCount` accounting.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):
+
+struct Test {}
+struct Other {}
+
+// Twelve distinct overloads, all of which fail to match because argument 0 is a
+// `Test` and every candidate's first parameter is `Other`.
+float many(Other x, float a) { return 0; }
+float many(Other x, float2 a) { return 0; }
+float many(Other x, float3 a) { return 0; }
+float many(Other x, float4 a) { return 0; }
+float many(Other x, int a) { return 0; }
+float many(Other x, int2 a) { return 0; }
+float many(Other x, int3 a) { return 0; }
+float many(Other x, int4 a) { return 0; }
+float many(Other x, uint a) { return 0; }
+float many(Other x, uint2 a) { return 0; }
+float many(Other x, uint3 a) { return 0; }
+float many(Other x, uint4 a) { return 0; }
+
+float test()
+{
+    return many(Test(), 0.0);
+//CHECK: no overload for 'many' applicable to arguments of type (Test, float)
+}
+
+// The candidate notes appear in a deterministic order: equal-status candidates
+// are ordered by source location (the sort's tie-breaker), i.e. declaration
+// order. These ordered `CHECK`s pin that, so a regression that dropped the
+// tie-breaker (making the order arbitrary across builds/platforms) would fail.
+//CHECK: candidate: func many(Other, float) -> float
+//CHECK: candidate: func many(Other, float2) -> float
+//CHECK: candidate: func many(Other, float3) -> float
+//CHECK: candidate: func many(Other, float4) -> float
+
+// At most 10 candidate notes are printed, then the remaining 2 are summarized.
+//CHECK: 2 more overload candidates

--- a/tests/diagnostics/overload-argument-type-mismatch-qualifier.slang
+++ b/tests/diagnostics/overload-argument-type-mismatch-qualifier.slang
@@ -1,0 +1,25 @@
+// Regression test for https://github.com/shader-slang/slang/issues/7857
+//
+// Negative companion to overload-argument-type-mismatch.slang. When a candidate
+// is rejected only because of a qualifier/direction mismatch (the underlying
+// types are equal), the per-candidate E40018 "argument N does not match:
+// expected 'T', got 'T'" note must NOT be emitted -- that case has its own
+// dedicated diagnostics. This pins the suppression in `recordArgMismatch`
+// (`!paramType.type->equals(argType.type)`).
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):
+
+void f(out int x) { x = 0; }
+void f(inout int x, int y) { x = y; }
+
+void test()
+{
+    // `3` is not an l-value, so neither `out`/`inout` overload applies, but the
+    // underlying parameter type (int) matches the argument type (int).
+    f(3);
+//CHECK: l-value
+}
+
+// The confusing "expected 'int', got 'int'" note must never appear.
+//CHECK-NOT: E40018
+//CHECK-NOT: does not match

--- a/tests/diagnostics/overload-argument-type-mismatch.slang
+++ b/tests/diagnostics/overload-argument-type-mismatch.slang
@@ -1,0 +1,29 @@
+// Regression test for https://github.com/shader-slang/slang/issues/7857
+//
+// When no overload of a function applies to the given arguments, each candidate
+// note should also report which argument failed to match and the expected vs.
+// actual type, so the user can see precisely why the call did not resolve.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):
+
+struct Test {}
+
+float overloaded(float2 x, float y) { return 0; }
+/*CHECK:
+      ^^^^^^^^^^ candidate: func overloaded(float2, float) -> float
+      ^^^^^^^^^^ argument 0 does not match: expected 'vector<float,2>', got 'Test'
+*/
+
+float overloaded(float3 x, float y) { return 0; }
+/*CHECK:
+      ^^^^^^^^^^ candidate: func overloaded(float3, float) -> float
+      ^^^^^^^^^^ argument 0 does not match: expected 'vector<float,3>', got 'Test'
+*/
+
+float test()
+{
+    return overloaded(Test(), 0);
+/*CHECK:
+                     ^ no overload for 'overloaded' applicable to arguments of type (Test, int)
+*/
+}


### PR DESCRIPTION
## Motivation

When a call matches no overload, the error lists candidate signatures but says nothing about *which* argument rejected each candidate. With many candidates and/or many parameters this is hard to act on. For:

```slang
struct Test {};
float overloaded(float2 x, float y) {}
float overloaded(float3 x, float y) {}
float test() { return overloaded(Test(), 0); }
```

the user wants, per the issue, something like `expected an expression of type 'vector<float,2>', got 'Test'`.

## Proposed solution

During the JustTrying phase of overload resolution (`TryCheckOverloadCandidateTypes`), record on each `OverloadCandidate` the **first** parameter whose argument failed to coerce — its index and the expected (parameter) and actual (argument) types. In the no-applicable-overload branch of `ResolveInvoke`, after the top-level error, print each candidate's signature followed by a new note (`E40018`):

```
note: candidate: func overloaded(float2, float) -> float
note: argument 0 does not match: expected 'vector<float,2>', got 'Test'
```

First-failure only (type checking of a candidate stops at the first bad argument), always-on (no flag).

## Change summary

| File | Change |
|---|---|
| `source/slang/slang-check-impl.h` | Add `argMismatchParamIndex` / `argMismatchExpectedType` / `argMismatchActualType` to `OverloadCandidate`. |
| `source/slang/slang-check-overload.cpp` | `recordArgMismatch` captures the first failing arg in `TryCheckOverloadCandidateTypes`; the no-applicable path in `ResolveInvoke` now prints (de-duplicated, capped-at-10) candidate signatures plus the new mismatch note. |
| `source/slang/slang-diagnostics.lua` | New note `overload-candidate-argument-type-mismatch` (`E40018`). |
| `tests/diagnostics/overload-argument-type-mismatch.slang` | New regression (the issue's example). |
| `tests/diagnostics/bad-operator-call.slang` | Marked `non-exhaustive` (builtin operators now emit a per-candidate note for each overload). |
| `tests/autodiff/differential-type-syntheize-diagnostics.slang` | Gains the expected candidate note. |

## Concepts and vocabulary

- **JustTrying vs ForReal** — `TryCheckOverloadCandidateTypes` runs in `JustTrying` mode while ranking candidates (no diagnostics emitted, failures just reject the candidate) and in `ForReal` mode when committing to the chosen one. The mismatch is recorded in `JustTrying`, where the candidate is rejected.
- **`bestCandidates`** — the set of equally-ranked-but-unusable candidates reported when nothing applies. It may list the same `Decl` more than once (e.g. a synthesized constructor reached via multiple lookup paths), hence the de-duplication.

## Process report

- **New `OverloadCandidate` fields + `recordArgMismatch`** — needed because nothing previously tracked *where* a candidate failed; only `conversionCostSum` was kept. Recorded at the exact rejection points in `coerceArgToParam` (the `!paramType->equals(argType)` and `!canCoerce(...)` branches), where both `paramIndex` and the type pair are in scope. *Input-shape check:* this records data about an already-valid candidate during normal type checking; it does not alter resolution behavior (ranking, selection) — only diagnostics.
- **De-duplication by `Decl`** — without it the autodiff test surfaced the same synthesized `Differential.init(float)` candidate note twice, because `bestCandidates` contained duplicate entries. De-duping in the reporting loop is the minimal, correct fix for the diagnostic; it does not change which candidates are considered. The cap of 10 plus the existing `MoreOverloadCandidates` note keeps output bounded.
- **`bad-operator-call.slang` → non-exhaustive** — failed builtin-operator calls now legitimately emit a per-candidate note for each of the operator's many overloads; enumerating them all would be brittle, so exhaustive mode is dropped for that test while the key error checks remain.

Closes #7857