### PR TITLE
[codex] Support default interface subscript implementations

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -14625,10 +14625,46 @@ void SemanticsDeclHeaderVisitor::checkCallableConstraints(CallableDecl* decl)
     }
 }
 
+// Return true when a property requirement mixes accessor bodies with body-less accessors.
+// Unlike subscripts, properties do not have an `InterfaceDefaultImplDecl` path here, so
+// semantic checking owns the targeted diagnostic for this partial-default shape.
+static bool isPartialPropertyAccessorDefaultImplementation(AccessorDecl* accessorDecl)
+{
+    auto propertyDecl = as<PropertyDecl>(accessorDecl->parentDecl);
+    if (!propertyDecl)
+        return false;
+
+    bool hasAccessorBody = false;
+    bool hasAccessorWithoutBody = false;
+    for (auto siblingAccessorDecl : propertyDecl->getDirectMemberDeclsOfType<AccessorDecl>())
+    {
+        if (siblingAccessorDecl->body)
+            hasAccessorBody = true;
+        else
+            hasAccessorWithoutBody = true;
+    }
+
+    return hasAccessorBody && hasAccessorWithoutBody;
+}
+
 void SemanticsDeclHeaderVisitor::checkInterfaceRequirement(Decl* decl)
 {
     if (isInterfaceRequirement(decl))
     {
+        if (auto accessorDecl = as<AccessorDecl>(decl))
+        {
+            // Subscript accessor defaults are handled by the parser's
+            // `InterfaceDefaultImplDecl` path. Properties do not have that
+            // representation, but a mixed `get; set {}` property is still a
+            // partial accessor default and should get the targeted diagnostic
+            // before the generic non-method-body check below.
+            if (accessorDecl->body && isPartialPropertyAccessorDefaultImplementation(accessorDecl))
+            {
+                getSink()->diagnose(
+                    Diagnostics::PartialInterfaceAccessorDefaultImplementation{.decl = decl});
+                return;
+            }
+        }
         if (auto funcBase = as<FunctionDeclBase>(decl))
         {
             if (!as<FuncDecl>(decl) && funcBase->body != nullptr)

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -9840,8 +9840,6 @@ bool SemanticsVisitor::findDefaultInterfaceImpl(
     // match here, then something went wrong well before this.
     SLANG_ASSERT(doesSignatureMatch);
     return doesSignatureMatch;
-
-    return true;
 }
 
 Type* SemanticsVisitor::getForwardDiffFuncInterfaceType(Type* baseType)

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -8462,6 +8462,16 @@ bool SemanticsVisitor::trySynthesizeSubscriptRequirementWitness(
     // having the exact same information stated twice.
     //
 
+    if (!lookupResult.isValid() && hasDefaultImpl(requiredMemberDeclRef))
+    {
+        // A missing concrete subscript should be satisfied by the interface
+        // default implementation below. The no-lookup synthesis path is for
+        // valid built-in indexing shapes, and applying it here would synthesize
+        // `this[args...]` as the witness for the same requirement, producing a
+        // recursive accessor wrapper.
+        return false;
+    }
+
     List<Expr*> synArgs;
     ThisExpr* synThis;
     auto synSubscriptDecl = synthesizeMethodSignatureForRequirementWitness(
@@ -9747,21 +9757,23 @@ bool SemanticsVisitor::findDefaultInterfaceImpl(
     DeclRef<Decl> requiredMemberDeclRef,
     RefPtr<WitnessTable> witnessTable)
 {
-    // Only functions can have default implemnetation at the moment.
-    DeclRef<FuncDecl> requiredFuncDeclRef = requiredMemberDeclRef.as<FuncDecl>();
-    if (!requiredFuncDeclRef)
+    // Interface default implementations are represented as callable stubs over
+    // `This : Interface`; methods and subscripts both use that representation.
+    DeclRef<CallableDecl> requiredCallableDeclRef = requiredMemberDeclRef.as<CallableDecl>();
+    if (!requiredCallableDeclRef)
     {
-        // If requiredMember is a generic func, form a direct declref to the inner func.
+        // If requiredMember is a generic callable, form a direct declref to the inner callable.
         if (auto requiredGenericDeclRef = requiredMemberDeclRef.as<GenericDecl>())
         {
             auto inner = getInner(requiredGenericDeclRef);
-            if (auto func = as<FuncDecl>(inner))
+            if (auto callable = as<CallableDecl>(inner))
             {
-                requiredFuncDeclRef = m_astBuilder->getMemberDeclRef(requiredGenericDeclRef, func);
+                requiredCallableDeclRef =
+                    m_astBuilder->getMemberDeclRef(requiredGenericDeclRef, callable);
             }
         }
     }
-    if (!requiredFuncDeclRef)
+    if (!requiredCallableDeclRef)
         return false;
 
     // If the interface requirement comes with a default impl, it should have a
@@ -9818,34 +9830,16 @@ bool SemanticsVisitor::findDefaultInterfaceImpl(
         resultDeclRef.as<GenericDecl>(),
         specArgs.getArrayView());
 
-    if (resultDeclRef.as<GenericDecl>())
-    {
-        // Test signature and register in witness table.
-        bool doesSignatureMatch = doesGenericSignatureMatchRequirement(
-            resultDeclRef.as<GenericDecl>(),
-            requiredFuncDeclRef.getParent().as<GenericDecl>(),
-            witnessTable);
+    // Test the signature and register the witness table entries. Going through
+    // the general requirement matcher is important for subscript defaults,
+    // because their accessor requirements need witness entries too.
+    bool doesSignatureMatch =
+        doesMemberSatisfyRequirement(resultDeclRef, requiredMemberDeclRef, witnessTable);
 
-        // If we try to use a registered default decl and the signature
-        // _doesn't_ match here, then something went wrong well before this
-        //
-        SLANG_ASSERT(doesSignatureMatch);
-        return doesSignatureMatch;
-    }
-    else
-    {
-        // Test signature and register in witness table.
-        bool doesSignatureMatch = doesSignatureMatchRequirement(
-            resultDeclRef.as<CallableDecl>(),
-            requiredFuncDeclRef.as<CallableDecl>(),
-            witnessTable);
-
-        // If we try to use a registered default decl and the signature
-        // _doesn't_ match here, then something went wrong well before this
-        //
-        SLANG_ASSERT(doesSignatureMatch);
-        return doesSignatureMatch;
-    }
+    // If we try to use a registered default decl and the signature _doesn't_
+    // match here, then something went wrong well before this.
+    SLANG_ASSERT(doesSignatureMatch);
+    return doesSignatureMatch;
 
     return true;
 }

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -2986,6 +2986,16 @@ err(
 )
 
 err(
+    "partial-interface-accessor-default-implementation",
+    30318,
+    "partial interface accessor default implementation",
+    span {
+        loc = "decl:Decl",
+        message = "interface accessor default implementation is incomplete; define all accessors or none."
+    }
+)
+
+err(
     "interface-requirement-cannot-be-override",
     30312,
     "interface requirement cannot override",

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -5742,6 +5742,36 @@ enum class InterfaceDefaultImplBodyStatus
     Partial,
 };
 
+// Storage declarations such as subscripts and properties represent default bodies on
+// their accessors, so classify the whole accessor set before deciding how to handle it.
+static InterfaceDefaultImplBodyStatus getStorageDeclDefaultImplBodyStatus(
+    ContainerDecl* storageDecl,
+    AccessorDecl** outFirstAccessorWithBody = nullptr)
+{
+    bool hasAccessorBody = false;
+    bool hasAccessorWithoutBody = false;
+    for (auto accessorDecl : storageDecl->getDirectMemberDeclsOfType<AccessorDecl>())
+    {
+        if (accessorDecl->body)
+        {
+            if (!hasAccessorBody && outFirstAccessorWithBody)
+                *outFirstAccessorWithBody = accessorDecl;
+
+            hasAccessorBody = true;
+        }
+        else
+        {
+            hasAccessorWithoutBody = true;
+        }
+    }
+
+    if (hasAccessorBody && hasAccessorWithoutBody)
+        return InterfaceDefaultImplBodyStatus::Partial;
+
+    return hasAccessorBody ? InterfaceDefaultImplBodyStatus::Complete
+                           : InterfaceDefaultImplBodyStatus::None;
+}
+
 static InterfaceDefaultImplBodyStatus getInterfaceDefaultImplBodyStatus(
     CallableDecl* callableDecl,
     AccessorDecl** outFirstAccessorWithBody = nullptr)
@@ -5755,28 +5785,7 @@ static InterfaceDefaultImplBodyStatus getInterfaceDefaultImplBodyStatus(
     if (auto subscriptDecl = as<SubscriptDecl>(callableDecl))
     {
         // A subscript default implementation is represented by accessor bodies.
-        bool hasAccessorBody = false;
-        bool hasAccessorWithoutBody = false;
-        for (auto accessorDecl : subscriptDecl->getDirectMemberDeclsOfType<AccessorDecl>())
-        {
-            if (accessorDecl->body)
-            {
-                if (!hasAccessorBody && outFirstAccessorWithBody)
-                    *outFirstAccessorWithBody = accessorDecl;
-
-                hasAccessorBody = true;
-            }
-            else
-            {
-                hasAccessorWithoutBody = true;
-            }
-        }
-
-        if (hasAccessorBody && hasAccessorWithoutBody)
-            return InterfaceDefaultImplBodyStatus::Partial;
-
-        return hasAccessorBody ? InterfaceDefaultImplBodyStatus::Complete
-                               : InterfaceDefaultImplBodyStatus::None;
+        return getStorageDeclDefaultImplBodyStatus(subscriptDecl, outFirstAccessorWithBody);
     }
 
     return InterfaceDefaultImplBodyStatus::None;

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -5735,29 +5735,51 @@ static bool parseGLSLGlobalDecl(Parser* parser, ContainerDecl* containerDecl)
     return false;
 }
 
-static bool doesCallableDeclHaveInterfaceDefaultImplBody(CallableDecl* callableDecl)
+enum class InterfaceDefaultImplBodyStatus
+{
+    None,
+    Complete,
+    Partial,
+};
+
+static InterfaceDefaultImplBodyStatus getInterfaceDefaultImplBodyStatus(
+    CallableDecl* callableDecl,
+    AccessorDecl** outFirstAccessorWithBody = nullptr)
 {
     if (auto funcDecl = as<FuncDecl>(callableDecl))
-        return funcDecl->body != nullptr;
+    {
+        return funcDecl->body != nullptr ? InterfaceDefaultImplBodyStatus::Complete
+                                         : InterfaceDefaultImplBodyStatus::None;
+    }
 
     if (auto subscriptDecl = as<SubscriptDecl>(callableDecl))
     {
         // A subscript default implementation is represented by accessor bodies.
-        // Only reparse complete accessor defaults here; mixed forms such as a
-        // default `get` plus required `set` need a more explicit partial-default
-        // representation than the existing whole-callable default stub.
         bool hasAccessorBody = false;
+        bool hasAccessorWithoutBody = false;
         for (auto accessorDecl : subscriptDecl->getDirectMemberDeclsOfType<AccessorDecl>())
         {
-            if (!accessorDecl->body)
-                return false;
+            if (accessorDecl->body)
+            {
+                if (!hasAccessorBody && outFirstAccessorWithBody)
+                    *outFirstAccessorWithBody = accessorDecl;
 
-            hasAccessorBody = true;
+                hasAccessorBody = true;
+            }
+            else
+            {
+                hasAccessorWithoutBody = true;
+            }
         }
-        return hasAccessorBody;
+
+        if (hasAccessorBody && hasAccessorWithoutBody)
+            return InterfaceDefaultImplBodyStatus::Partial;
+
+        return hasAccessorBody ? InterfaceDefaultImplBodyStatus::Complete
+                               : InterfaceDefaultImplBodyStatus::None;
     }
 
-    return false;
+    return InterfaceDefaultImplBodyStatus::None;
 }
 
 static void removeInterfaceDefaultImplBodyFromRequirement(Decl* parsedDecl)
@@ -5769,8 +5791,9 @@ static void removeInterfaceDefaultImplBodyFromRequirement(Decl* parsedDecl)
     }
     else if (auto subscriptDecl = as<SubscriptDecl>(requirementDecl))
     {
-        // The parsed interface member remains the abstract requirement. The
-        // duplicate `InterfaceDefaultImplDecl` owns the accessor bodies.
+        // The parsed interface member remains the abstract requirement. Its accessor
+        // bodies either belong to the duplicate `InterfaceDefaultImplDecl` or have
+        // already been diagnosed as an unsupported partial default implementation.
         for (auto accessorDecl : subscriptDecl->getDirectMemberDeclsOfType<AccessorDecl>())
             accessorDecl->body = nullptr;
     }
@@ -5851,12 +5874,28 @@ static void maybeReparseInterfaceCallableAsExplicitGeneric(
     TokenReader tokenReader)
 {
     auto callableDecl = as<CallableDecl>(maybeGetInner(parsedDecl));
-    if (!callableDecl || !doesCallableDeclHaveInterfaceDefaultImplBody(callableDecl))
+    if (!callableDecl)
+        return;
+
+    AccessorDecl* accessorWithDefaultBody = nullptr;
+    auto defaultImplBodyStatus =
+        getInterfaceDefaultImplBodyStatus(callableDecl, &accessorWithDefaultBody);
+    if (defaultImplBodyStatus == InterfaceDefaultImplBodyStatus::None)
         return;
 
     auto interfaceDecl = as<InterfaceDecl>(containerDecl);
     if (!interfaceDecl)
         return;
+
+    if (defaultImplBodyStatus == InterfaceDefaultImplBodyStatus::Partial)
+    {
+        Decl* diagnosticDecl = accessorWithDefaultBody ? static_cast<Decl*>(accessorWithDefaultBody)
+                                                       : static_cast<Decl*>(callableDecl);
+        parser->sink->diagnose(
+            Diagnostics::PartialInterfaceAccessorDefaultImplementation{.decl = diagnosticDecl});
+        removeInterfaceDefaultImplBodyFromRequirement(parsedDecl);
+        return;
+    }
 
     if (parser->sink->getErrorCount() != 0)
         return;

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -5735,13 +5735,54 @@ static bool parseGLSLGlobalDecl(Parser* parser, ContainerDecl* containerDecl)
     return false;
 }
 
-static void parseInterfaceDefaultMethodAsExplicitGeneric(
+static bool doesCallableDeclHaveInterfaceDefaultImplBody(CallableDecl* callableDecl)
+{
+    if (auto funcDecl = as<FuncDecl>(callableDecl))
+        return funcDecl->body != nullptr;
+
+    if (auto subscriptDecl = as<SubscriptDecl>(callableDecl))
+    {
+        // A subscript default implementation is represented by accessor bodies.
+        // Only reparse complete accessor defaults here; mixed forms such as a
+        // default `get` plus required `set` need a more explicit partial-default
+        // representation than the existing whole-callable default stub.
+        bool hasAccessorBody = false;
+        for (auto accessorDecl : subscriptDecl->getDirectMemberDeclsOfType<AccessorDecl>())
+        {
+            if (!accessorDecl->body)
+                return false;
+
+            hasAccessorBody = true;
+        }
+        return hasAccessorBody;
+    }
+
+    return false;
+}
+
+static void removeInterfaceDefaultImplBodyFromRequirement(Decl* parsedDecl)
+{
+    auto requirementDecl = maybeGetInner(parsedDecl);
+    if (auto funcDecl = as<FuncDecl>(requirementDecl))
+    {
+        funcDecl->body = nullptr;
+    }
+    else if (auto subscriptDecl = as<SubscriptDecl>(requirementDecl))
+    {
+        // The parsed interface member remains the abstract requirement. The
+        // duplicate `InterfaceDefaultImplDecl` owns the accessor bodies.
+        for (auto accessorDecl : subscriptDecl->getDirectMemberDeclsOfType<AccessorDecl>())
+            accessorDecl->body = nullptr;
+    }
+}
+
+static void parseInterfaceDefaultCallableAsExplicitGeneric(
     Parser* parser,
     Decl* parsedDecl,
     ContainerDecl* interfaceDecl)
 {
-    // If we parsed an interface method with a body,
-    // parse it again as an explicit generic decl on ThisType.
+    // If we parsed an interface callable with a body, parse it again as an
+    // explicit generic decl on ThisType.
     auto astBuilder = parser->astBuilder;
     InterfaceDefaultImplDecl* genericDecl = astBuilder->create<InterfaceDefaultImplDecl>();
     parser->PushScope(genericDecl);
@@ -5800,19 +5841,17 @@ static void parseInterfaceDefaultMethodAsExplicitGeneric(
     }
 
     // Remove the body from the requirement decl.
-    auto requirementFunc = maybeGetInner(parsedDecl);
-    if (auto funcDecl = as<FuncDecl>(requirementFunc))
-        funcDecl->body = nullptr;
+    removeInterfaceDefaultImplBodyFromRequirement(parsedDecl);
 }
 
-static void maybeReparseInterfaceFuncAsExplicitGeneric(
+static void maybeReparseInterfaceCallableAsExplicitGeneric(
     Parser* parser,
     Decl* parsedDecl,
     ContainerDecl* containerDecl,
     TokenReader tokenReader)
 {
-    auto funcDecl = as<FuncDecl>(maybeGetInner(parsedDecl));
-    if (!funcDecl || !funcDecl->body)
+    auto callableDecl = as<CallableDecl>(maybeGetInner(parsedDecl));
+    if (!callableDecl || !doesCallableDeclHaveInterfaceDefaultImplBody(callableDecl))
         return;
 
     auto interfaceDecl = as<InterfaceDecl>(containerDecl);
@@ -5824,7 +5863,7 @@ static void maybeReparseInterfaceFuncAsExplicitGeneric(
 
     Parser newParser(*parser);
     newParser.tokenReader = tokenReader;
-    parseInterfaceDefaultMethodAsExplicitGeneric(&newParser, parsedDecl, interfaceDecl);
+    parseInterfaceDefaultCallableAsExplicitGeneric(&newParser, parsedDecl, interfaceDecl);
 }
 
 static void parseDecls(Parser* parser, ContainerDecl* containerDecl, MatchedTokenType matchType)
@@ -5885,7 +5924,7 @@ static void parseDecls(Parser* parser, ContainerDecl* containerDecl, MatchedToke
             // as an `UnparsedStmt` at this stage of parsing, which is a relatively simple
             // process. Once we have the functionality to systematically clone AST nodes,
             // we can eliminate this reparsing hack.
-            maybeReparseInterfaceFuncAsExplicitGeneric(
+            maybeReparseInterfaceCallableAsExplicitGeneric(
                 parser,
                 as<Decl>(decl),
                 containerDecl,

--- a/tests/diagnostics/interfaces/interface-override.slang
+++ b/tests/diagnostics/interfaces/interface-override.slang
@@ -17,8 +17,8 @@ interface IDerived : IBase
         get;
 
         set{ }
-//diag: ^^^ interface requirement has body
-//diag: ^^^ non-method interface requirement cannot have a body.
+//diag: ^^^ partial interface accessor default implementation
+//diag: ^^^ interface accessor default implementation is incomplete; define all accessors or none.
     }
 
     __subscript(int index)->int

--- a/tests/diagnostics/interfaces/interface-override.slang
+++ b/tests/diagnostics/interfaces/interface-override.slang
@@ -23,9 +23,7 @@ interface IDerived : IBase
 
     __subscript(int index)->int
     {
-        get{}
-//diag: ^^^ interface requirement has body
-//diag: ^^^ non-method interface requirement cannot have a body.
+        get;
     }
 
     override int f() {}

--- a/tests/diagnostics/interfaces/partial-default-subscript-accessor.slang
+++ b/tests/diagnostics/interfaces/partial-default-subscript-accessor.slang
@@ -1,0 +1,15 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):
+
+interface IFoo<TValue, int Offset>
+{
+    TValue getVal(int index);
+
+    __subscript<TIndex>(TIndex index) -> TValue
+        where TIndex : IInteger
+    {
+        get { return getVal(index.toInt() + Offset); }
+//CHECK:^^^ partial interface accessor default implementation
+//CHECK:^^^ interface accessor default implementation is incomplete; define all accessors or none.
+        set;
+    }
+}

--- a/tests/language-feature/interfaces/default-subscript-generic-interface.slang
+++ b/tests/language-feature/interfaces/default-subscript-generic-interface.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj -output-using-type -cpu
 
 // A generic interface can provide a default implementation for a generic
 // subscript requirement. The conforming type supplies only `getVal`, so both

--- a/tests/language-feature/interfaces/default-subscript-generic-interface.slang
+++ b/tests/language-feature/interfaces/default-subscript-generic-interface.slang
@@ -1,0 +1,42 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj -output-using-type
+
+// A generic interface can provide a default implementation for a generic
+// subscript requirement. The conforming type supplies only `getVal`, so both
+// `run` calls below must use the default `__subscript<TIndex>` body from
+// `IFoo<int, 7>`.
+
+interface IFoo<TValue, int Offset>
+{
+    TValue getVal(int index);
+
+    __subscript<TIndex>(TIndex index) -> TValue
+        where TIndex : IInteger
+    {
+        get { return getVal(index.toInt() + Offset); }
+    }
+}
+
+struct Foo : IFoo<int, 7>
+{
+    int getVal(int index) { return index; }
+}
+
+int run<T : IFoo<int, 7>, TIndex : IInteger>(T t, TIndex index)
+{
+    return t[index];
+}
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0], stride=4)
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    Foo f = {};
+
+    outputBuffer[0] = run(f, 100);
+    // CHECK: 107
+
+    outputBuffer[1] = run(f, uint(3));
+    // CHECK: 10
+}

--- a/tests/language-feature/interfaces/default-subscript-generic-interface.slang
+++ b/tests/language-feature/interfaces/default-subscript-generic-interface.slang
@@ -8,22 +8,33 @@
 interface IFoo<TValue, int Offset>
 {
     TValue getVal(int index);
+    [mutating] void setVal(int index, TValue value);
 
     __subscript<TIndex>(TIndex index) -> TValue
         where TIndex : IInteger
     {
         get { return getVal(index.toInt() + Offset); }
+        set { setVal(index.toInt() + Offset, newValue); }
     }
 }
 
 struct Foo : IFoo<int, 7>
 {
-    int getVal(int index) { return index; }
+    int bias;
+
+    int getVal(int index) { return index + bias; }
+
+    [mutating] void setVal(int index, int value) { bias = value - index; }
 }
 
 int run<T : IFoo<int, 7>, TIndex : IInteger>(T t, TIndex index)
 {
     return t[index];
+}
+
+void write<T : IFoo<int, 7>, TIndex : IInteger>(inout T t, TIndex index, int value)
+{
+    t[index] = value;
 }
 
 //TEST_INPUT: set outputBuffer = out ubuffer(data=[0 0 0 0], stride=4)
@@ -39,4 +50,12 @@ void computeMain()
 
     outputBuffer[1] = run(f, uint(3));
     // CHECK: 10
+
+    write(f, 5, 211);
+    outputBuffer[2] = run(f, 5);
+    // CHECK: 211
+
+    write(f, uint(6), 307);
+    outputBuffer[3] = run(f, uint(6));
+    // CHECK: 307
 }

--- a/tests/language-feature/interfaces/default-subscript-generic-interface.slang
+++ b/tests/language-feature/interfaces/default-subscript-generic-interface.slang
@@ -1,9 +1,9 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK): -shaderobj -output-using-type -cpu
 
 // A generic interface can provide a default implementation for a generic
-// subscript requirement. The conforming type supplies only `getVal`, so both
-// `run` calls below must use the default `__subscript<TIndex>` body from
-// `IFoo<int, 7>`.
+// subscript requirement. The conforming type supplies only the lower-level
+// `getVal` and `setVal` requirements, so the `run` and `write` calls below
+// must use the default `__subscript<TIndex>` accessors from `IFoo<int, 7>`.
 
 interface IFoo<TValue, int Offset>
 {


### PR DESCRIPTION
﻿## Motivation

Interface methods can already provide default implementations, but interface subscripts could not. A generic function constrained by an interface like `IFoo<int, 7>` should be able to call `t[index]` even when the conforming type only implements the lower-level requirements used by the default subscript body.

The motivating regression is a generic interface with a generic default subscript:

```slang
interface IFoo<TValue, int Offset>
{
    TValue getVal(int index);
    [mutating] void setVal(int index, TValue value);
    __subscript<TIndex>(TIndex index) -> TValue where TIndex : IInteger
    {
        get { return getVal(index.toInt() + Offset); }
        set { setVal(index.toInt() + Offset, newValue); }
    }
}
```

On current `master`, accessor bodies on an interface subscript are diagnosed as `non-method interface requirement cannot have a body`, and a conforming type that relies on the default is then reported as missing `operator[]`.

The existing `InterfaceDefaultImplDecl` model represents one default implementation for the whole callable requirement. A mixed accessor declaration such as a default getter plus required setter cannot be represented correctly by that model, so this PR gives that shape a targeted diagnostic instead of falling through to the generic non-method-body error.

## Proposed solution

Extend the existing interface default-method representation to complete subscript accessor defaults. The parser recognizes callable default bodies for both methods and subscripts, reparses them into the existing `InterfaceDefaultImplDecl<This : Interface>` stub, and leaves the original interface member as the abstract requirement.

Conformance checking treats default implementations as callable requirements rather than method-only requirements. It routes the selected default stub through the normal requirement matcher so subscript accessor witness entries are recorded along with the subscript requirement itself.

For accessor defaults, enforce an all-or-none rule: every accessor in the subscript must have a body, or none may have one. Mixed subscript defaults are diagnosed in the parser before the default stub is formed. Mixed property accessors are diagnosed in semantic checking because properties do not have a callable `InterfaceDefaultImplDecl` path in this PR.

## Change summary

- `source/slang/slang-parser.cpp`: generalizes the interface default-body reparse path from functions to callables, including complete subscript accessor defaults, and diagnoses partial subscript accessor defaults.
- `source/slang/slang-check-decl.cpp`: allows default implementations for callable requirements, records subscript accessor witnesses via the general matcher, avoids synthesizing a recursive `this[index]` wrapper when a real interface default subscript exists, and diagnoses partial property accessor defaults.
- `source/slang/slang-diagnostics.lua`: adds `partial-interface-accessor-default-implementation` for mixed default/required accessor declarations.
- `tests/language-feature/interfaces/default-subscript-generic-interface.slang`: adds coverage for a generic interface and a generic default `__subscript<TIndex>` with both getter and setter paths.
- `tests/diagnostics/interfaces/partial-default-subscript-accessor.slang`: covers the new all-or-none accessor diagnostic on a generic default subscript.
- `tests/diagnostics/interfaces/interface-override.slang`: updates the mixed property accessor expectation to the targeted partial-default diagnostic while keeping a body-less subscript requirement in the diagnostics test.

## Concepts and vocabulary

- Interface default implementation: the parser-created `InterfaceDefaultImplDecl` generic over `This : Interface` that owns the default body while the original interface member remains the requirement.
- Accessor requirement: the getter/setter entries associated with a `SubscriptDecl`; these need witness-table entries just like the parent subscript requirement.
- Requirement synthesis: fallback conformance logic that can synthesize wrappers for valid shapes such as built-in indexing.
- Partial accessor default: a storage-style declaration where at least one accessor has a body and at least one accessor is only a requirement, for example `get { ... }` plus `set;`.

## Process report

The parser previously only called `maybeReparseInterfaceFuncAsExplicitGeneric` for `FuncDecl` bodies. A subscript body is stored on its accessor declarations, so `IFoo.__subscript<TIndex>` stayed as an interface requirement whose getter still had a body. `SemanticsDeclHeaderVisitor::checkInterfaceRequirement` then diagnosed the getter as a non-method requirement with a body. The fix updates the parser path to detect complete callable default bodies: `FuncDecl::body` for methods and accessor bodies under `SubscriptDecl` for subscripts. It then removes those bodies from the requirement copy after the default stub is created, matching the method default invariant now used by `parseInterfaceDefaultCallableAsExplicitGeneric`.

After parsing was fixed, conformance still needed to use the default subscript as a witness. `findDefaultInterfaceImpl` only accepted `FuncDecl`, so a `SubscriptDecl` requirement never reached the default implementation path. Generalizing that gate to `CallableDecl` lets generic methods and generic subscripts share the same default-stub mechanism. Using `doesMemberSatisfyRequirement` rather than the method-only signature helper is necessary because subscript matching records both the parent `SubscriptDecl` witness and the accessor witnesses; lowering later resolves `t[index]` and `t[index] = value` through those accessor requirement keys.

One cascading issue appeared after that: `trySynthesizeSubscriptRequirementWitness` has a no-lookup path that builds a wrapper around `this[args...]`. That shape is correct for built-in indexing synthesis, but it is wrong when the only reason lookup failed is that the conforming type is meant to use an interface default implementation. In the motivating test, that path produced a synthesized getter that called itself, and IR recursion checking reported `recursion not allowed`. The new guard declines no-lookup synthesis when the requirement has a default implementation, allowing `findDefaultInterfaceImpl` to install the actual default accessor stub instead.

Partial subscript defaults are a valid user-written input shape, but they are not representable by the current whole-callable `InterfaceDefaultImplDecl` contract. For `a[5]`, semantic checking resolves the expression through the parent `SubscriptDecl` and then records accessor witnesses keyed by the inner accessor declarations. A mixed subscript declaration would need per-accessor default implementation ownership so the getter could use a default while the setter remained an unsatisfied requirement. This PR intentionally does not invent that representation. Instead, `getStorageDeclDefaultImplBodyStatus` detects the mixed subscript shape before semantic checking, emits `PartialInterfaceAccessorDefaultImplementation` on the accessor with a body, and strips the body from the requirement copy only as diagnostic recovery.

Sai pointed out that a mixed property accessor in `interface-override.slang` has the same partial-default user shape. Properties are not `CallableDecl`s here, and this PR does not add property default implementations. The property case therefore belongs in `SemanticsDeclHeaderVisitor::checkInterfaceRequirement`: `isPartialPropertyAccessorDefaultImplementation` detects a property with both body-bearing and body-less accessors, reports the same targeted diagnostic on the accessor body, and then returns before the generic non-method-body diagnostic. This keeps other diagnostics in the same file, such as `__init() {}` and `override int f() {}`, flowing normally.

Validation:

- `cmd.exe /c "call ""C:\Program Files\Microsoft Visual Studio\18\Professional\VC\Auxiliary\Build\vcvarsall.bat"" x64 && cmake.exe --build --preset vs2026-debug --target slang-test"`
- `build\Debug\bin\slang-test.exe tests\diagnostics\interfaces\interface-override`
- `build\Debug\bin\slang-test.exe tests\language-feature\interfaces\default-subscript-generic-interface`
- `build\Debug\bin\slang-test.exe tests\diagnostics\interfaces\partial-default-subscript-accessor`
- `git.exe diff --check official/master..HEAD`
