### PR TITLE
Fix missing default constructor in shader-coverage examples

### DIFF
--- a/examples/shader-coverage-bvh-traversal/vk_compute_demo.h
+++ b/examples/shader-coverage-bvh-traversal/vk_compute_demo.h
@@ -82,6 +82,9 @@ public:
     // works. Callers running with `-trace-coverage-counter-width 32`
     // (or with coverage off entirely) leave it false.
     void init(bool requireInt64Atomics = false);
+    // The deleted copy constructor below suppresses the implicit
+    // default constructor, so declare it explicitly.
+    Context() = default;
     ~Context();
     Context(const Context&) = delete;
     Context& operator=(const Context&) = delete;

--- a/examples/shader-coverage-image-pipeline/vk_compute_demo.h
+++ b/examples/shader-coverage-image-pipeline/vk_compute_demo.h
@@ -82,6 +82,9 @@ public:
     // works. Callers running with `-trace-coverage-counter-width 32`
     // (or with coverage off entirely) leave it false.
     void init(bool requireInt64Atomics = false);
+    // The deleted copy constructor below suppresses the implicit
+    // default constructor, so declare it explicitly.
+    Context() = default;
     ~Context();
     Context(const Context&) = delete;
     Context& operator=(const Context&) = delete;


### PR DESCRIPTION
## Motivation

`master` does not compile anywhere CMake can find a Vulkan SDK. PR #11553 added the two `shader-coverage-*` example demos, and both fail with:

```
examples/shader-coverage-bvh-traversal/main.cpp:812:25: error: no matching function for call to 'vkdemo::Context::Context()'
```

The CI run for #11553 showed exactly this failure on `build-linux-{debug,release}-gcc-x86_64` and both Windows build lanes (the runners that have `/opt/vulkan-sdk` installed), but the PR merged anyway because the `check-ci` gate does not observe build-job failures — that gating gap is addressed separately. The macOS lanes passed only because GitHub-hosted macOS runners have no Vulkan SDK, so `find_package(Vulkan)` fails and the examples are skipped.

## Proposed solution

`vkdemo::Context` (in each demo's `vk_compute_demo.h`) declares a deleted copy constructor:

```cpp
Context(const Context&) = delete;
```

Any user-declared constructor — including a deleted copy constructor — suppresses the implicitly-generated default constructor, so `vkdemo::Context ctx;` in each demo's `main()` has no constructor to call. The fix is to declare the default constructor explicitly:

```cpp
Context() = default;
```

This preserves the class's intent exactly: default-constructible (all members have default member initializers), non-copyable.

## Change summary

- `examples/shader-coverage-image-pipeline/vk_compute_demo.h` — add `Context() = default;` with a comment explaining why it must be spelled out.
- `examples/shader-coverage-bvh-traversal/vk_compute_demo.h` — same change; the file is intentionally duplicated verbatim between the two demos (see the header's top comment), so both copies are updated identically.

## Process report

A single, non-cascading change. The input shape here is the C++ language rule itself: a user-declared copy constructor (even `= delete`) suppresses the implicit default constructor, so the original header was simply ill-formed for the `Context ctx;` use in `main()` (`examples/shader-coverage-image-pipeline/main.cpp:743`, `examples/shader-coverage-bvh-traversal/main.cpp:812`). Declaring `Context() = default;` restores the constructor the class was designed to have — all members carry default member initializers (`vk_compute_demo.h:113-120`), so default construction is the intended initialization path and `init()` performs the actual Vulkan setup. No guard or workaround is involved; verified locally by building the previously-failing targets on macOS with MoltenVK.
