### PR TITLE
Gate check-ci on build job results so broken builds cannot merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,9 +295,27 @@ jobs:
       config: release
       runs-on: '["windows-latest"]'
 
+  # Aggregate gate required by branch protection / the merge queue.
+  #
+  # The build jobs must be listed in `needs` even though every test job
+  # already depends on a build job: when a needed job fails, GitHub
+  # Actions marks the dependent jobs "skipped" (not "failed"), and
+  # skipped must be allowed here because several test jobs intentionally
+  # skip on plain pull_request events (they only run in the merge queue).
+  # Without the build jobs listed explicitly, a broken build turns all
+  # its test jobs into allowed skips and the gate passes (see #11553).
   check-ci:
     needs:
       [
+        build-linux-debug-gcc-x86_64,
+        build-linux-release-gcc-x86_64,
+        build-linux-release-gcc-wasm,
+        build-linux-debug-gcc-aarch64,
+        build-linux-release-gcc-aarch64,
+        build-macos-debug-clang-aarch64,
+        build-macos-release-clang-aarch64,
+        build-windows-debug-cl-x86_64-gpu,
+        build-windows-release-cl-x86_64-gpu,
         test-windows-release-cl-x86_64-gpu,
         test-windows-debug-cl-x86_64-gpu,
         test-macos-release-clang-aarch64,
@@ -315,47 +333,21 @@ jobs:
     if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft != true)
     steps:
       - name: Check CI Results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
           echo "=== CI Results Summary ==="
-          echo "Windows Release GPU: ${{ needs.test-windows-release-cl-x86_64-gpu.result }}"
-          echo "Windows Debug GPU: ${{ needs.test-windows-debug-cl-x86_64-gpu.result }}"
-          echo "macOS Release ARM64: ${{ needs.test-macos-release-clang-aarch64.result }}"
-          echo "macOS Debug ARM64: ${{ needs.test-macos-debug-clang-aarch64.result }}"
-          echo "Linux Release x64: ${{ needs.test-linux-release-gcc-x86_64.result }}"
-          echo "Linux Release x64 SM80Plus: ${{ needs.test-linux-release-gcc-x86_64-sm80.result }}"
-          echo "Linux Release x64 CPU: ${{ needs.test-linux-release-gcc-x86_64-cpu.result }}"
-          echo "Linux Debug x64: ${{ needs.test-linux-debug-gcc-x86_64.result }}"
-          echo "Linux Release ARM64: ${{ needs.test-linux-release-gcc-aarch64.result }}"
-          echo "Linux Debug ARM64: ${{ needs.test-linux-debug-gcc-aarch64.result }}"
-          echo "MaterialX Windows: ${{ needs.test-materialx-windows-release.result }}"
-          echo "Sanitizer Linux: ${{ needs.sanitizer-linux-clang-x86_64.result }}"
+          echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
 
-          # Check if any required jobs failed (allow success or skipped)
-          if [[ "${{ needs.test-windows-release-cl-x86_64-gpu.result }}" == "failure" ]] || \
-             [[ "${{ needs.test-windows-debug-cl-x86_64-gpu.result }}" == "failure" ]] || \
-             [[ "${{ needs.test-macos-release-clang-aarch64.result }}" == "failure" ]] || \
-             [[ "${{ needs.test-macos-debug-clang-aarch64.result }}" == "failure" ]] || \
-             [[ "${{ needs.test-linux-release-gcc-x86_64.result }}" == "failure" ]] || \
-             [[ "${{ needs.test-linux-release-gcc-x86_64-sm80.result }}" == "failure" ]] || \
-             [[ "${{ needs.test-linux-release-gcc-x86_64-cpu.result }}" == "failure" ]] || \
-             [[ "${{ needs.test-linux-debug-gcc-x86_64.result }}" == "failure" ]] || \
-             [[ "${{ needs.test-linux-release-gcc-aarch64.result }}" == "failure" ]] || \
-             [[ "${{ needs.test-linux-debug-gcc-aarch64.result }}" == "failure" ]] || \
-             [[ "${{ needs.test-materialx-windows-release.result }}" == "failure" ]] || \
-             [[ "${{ needs.sanitizer-linux-clang-x86_64.result }}" == "failure" ]] || \
-             [[ "${{ needs.test-windows-release-cl-x86_64-gpu.result }}" == "cancelled" ]] || \
-             [[ "${{ needs.test-windows-debug-cl-x86_64-gpu.result }}" == "cancelled" ]] || \
-             [[ "${{ needs.test-macos-release-clang-aarch64.result }}" == "cancelled" ]] || \
-             [[ "${{ needs.test-macos-debug-clang-aarch64.result }}" == "cancelled" ]] || \
-             [[ "${{ needs.test-linux-release-gcc-x86_64.result }}" == "cancelled" ]] || \
-             [[ "${{ needs.test-linux-release-gcc-x86_64-sm80.result }}" == "cancelled" ]] || \
-             [[ "${{ needs.test-linux-release-gcc-x86_64-cpu.result }}" == "cancelled" ]] || \
-             [[ "${{ needs.test-linux-debug-gcc-x86_64.result }}" == "cancelled" ]] || \
-             [[ "${{ needs.test-linux-release-gcc-aarch64.result }}" == "cancelled" ]] || \
-             [[ "${{ needs.test-linux-debug-gcc-aarch64.result }}" == "cancelled" ]] || \
-             [[ "${{ needs.sanitizer-linux-clang-x86_64.result }}" == "cancelled" ]] || \
-             [[ "${{ needs.test-materialx-windows-release.result }}" == "cancelled" ]]; then
-            echo "One or more CI jobs failed or were cancelled"
+          # Allow "success" and "skipped"; fail on "failure" or "cancelled".
+          # Checking the generic `needs` JSON (rather than enumerating each
+          # job) means any job added to `needs` above is gated automatically.
+          failed=$(echo "$NEEDS_JSON" | jq -r 'to_entries[]
+            | select(.value.result == "failure" or .value.result == "cancelled")
+            | .key')
+          if [[ -n "$failed" ]]; then
+            echo "These CI jobs failed or were cancelled:"
+            echo "$failed"
             exit 1
           fi
 


### PR DESCRIPTION
## Motivation

PR #11553 merged through the merge queue even though four build jobs failed to compile, breaking `master` for every environment with a Vulkan SDK. In the merge-queue run (`merge_group` run 27430217125):

- `build-linux-{debug,release}-gcc-x86_64` and `build-windows-{debug,release}-cl-x86_64-gpu` **failed** with a compile error;
- their dependent test jobs (`test-linux-release-gcc-x86_64`, `test-windows-*`, …) were therefore marked **skipped** by GitHub Actions (a failed `needs` dependency skips dependents, it does not fail them);
- the required `check-ci` gate reported **success**, and the merge queue merged the PR.

## Proposed solution

`check-ci` must allow `skipped` results, because several test jobs intentionally skip on plain `pull_request` events (GPU tests only run in the merge queue) and all jobs skip on documentation-only changes. That makes "skipped because my build failed" indistinguishable from "skipped by design" — unless the build jobs themselves are gated.

The fix adds all nine build jobs to `check-ci`'s `needs` list so a build failure fails the gate directly. A build job never skips by design when the `filter` job says to run, so this closes the loophole without disturbing the intentional test-job skips.

The hand-enumerated per-job shell conditions are also replaced with a single generic check over `toJSON(needs)`: any job added to the `needs` list is gated automatically, eliminating the duplicated job list (the `needs` array, the echo lines, the failure conditions, and the cancelled conditions previously each repeated all twelve job names, and keeping four copies in sync is exactly the kind of maintenance hazard that produced this gap).

## Change summary

- `.github/workflows/ci.yml` — `check-ci` job only:
  - add the nine `build-*` jobs to `needs` (alongside the existing test and sanitizer jobs);
  - replace the per-job `echo`/`if` enumeration with a `jq` pass over `toJSON(needs)` that prints every result and fails on any `failure` or `cancelled`;
  - add a comment block documenting why build jobs must be listed even though test jobs depend on them, and why `skipped` remains allowed.

No other job, trigger, or the `retry-on-gpu-failure` follow-on (which keys off `check-ci`'s result via `if: failure()`) changes behavior.

## Concepts and vocabulary

- **`check-ci`** — the aggregate no-op job whose result is the single required status check for branch protection and the merge queue; individual build/test jobs are not required checks by name.
- **skipped-as-pass** — `check-ci`'s policy of treating `skipped` dependencies as success, required because GPU test jobs deliberately skip on `pull_request` events and only run on `merge_group` events.

## Process report

One change with one cause. The gating gap: `check-ci` (`ci.yml:298`) listed only test jobs and the sanitizer in `needs`, and its script failed only on `failure`/`cancelled` results ("allow success or skipped"). Code trace for the escape: `build-linux-release-gcc-x86_64 / build` failed → `test-linux-release-gcc-x86_64` (`needs: [filter, build-linux-release-gcc-x86_64]`, `ci.yml` test section) was set to `skipped` by the Actions runner → `needs.test-linux-release-gcc-x86_64.result == "skipped"` passed the allow-list → `check-ci` exited 0 → merge queue requirement satisfied.

Input-shape check: is "test job skipped" a principled input that `check-ci` should accept? Yes — it is the designed shape for GPU tests on `pull_request` events and for documentation-only changes, so the consumer cannot reject it. The producer-side information that distinguishes the two skip causes is the build job's own result, which was simply not wired into the gate; adding the build jobs to `needs` supplies that information at the right layer rather than trying to infer skip reasons. The `toJSON(needs)`-based check is the one-source-of-truth refactor: the `needs` array becomes the only place a gated job is named, so the previous four-way duplication (and the risk of a job being in one list but not another) is removed.
