### PR TITLE
Rename PR-label workflow job and file to check-pr-label

### DIFF
--- a/.github/workflows/check-pr-label.yml
+++ b/.github/workflows/check-pr-label.yml
@@ -9,7 +9,7 @@ on:
       - "CONTRIBUTING.md"
       - "README.md"
 jobs:
-  label:
+  check-pr-label:
     if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Fixes #11587

## Motivation

The `master` branch protection currently requires three checks: `check-formatting`, `check-ci`, and `SlangPy Tests`. We want to also require the workflow that verifies every PR carries exactly one of the `pr: non-breaking` / `pr: breaking change` labels. However, that workflow's job key — which is what GitHub uses as the status-check context name in branch protection — is just `label`, which is too generic for a human maintainer to understand what the required check actually does.

## Proposed solution

Rename the job key from `label` to `check-pr-label`, so the required-check name reads consistently alongside the existing required checks `check-formatting` and `check-ci`. Rename the workflow file from `ensure-pr-label.yml` to `check-pr-label.yml` to match the job name, so the file is easy to find from the check name.

## Change summary

- `.github/workflows/ensure-pr-label.yml` → `.github/workflows/check-pr-label.yml` (renamed): job key `label` renamed to `check-pr-label` (line 12). No other behavior changes — triggers, draft-PR skip condition, permissions, and the required-labels action pin are untouched.

## Process report

Both changes are pure renames with no behavioral effect on the workflow itself:

1. **Job key `label` → `check-pr-label`**: GitHub derives the status-check context name from the job key (or its `name:` if set; this job has none), so this is the rename that makes the required check human-readable in the branch-protection list. `check-pr-label` was chosen to match the naming pattern of the other required checks (`check-formatting`, `check-ci`).
2. **File `ensure-pr-label.yml` → `check-pr-label.yml`**: keeps the filename in sync with the job name so a maintainer can navigate from the check name to the workflow file directly. No other file in the repository references the old filename (verified by grep).

### Required follow-up after merge (maintainer action)

The rename changes the status-check context name from `label` to `check-pr-label`. A maintainer must update the `master` branch-protection required-checks list to add `check-pr-label` (and remove `label` if it was already listed). The workflow only runs on non-draft PRs (`if: github.event.pull_request.draft != true`), so requiring it will not block draft PRs.
