### PR TITLE
Update agent naming guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -73,6 +73,9 @@ Recurring review feedback distilled into rules — following them avoids review 
 govern how code reads and is structured; the Problem-Solving Methodology above governs what to
 change.)
 
+- Function names should reflect the nature of the behavior they implement, including important
+  return-type/reference semantics, rather than the narrow use case that motivated the function.
+
 - **Comment functions as complete sentences: what, then why.** Say what the function does first;
   then, if non-obvious, why it exists. Include a concrete example for non-trivial behavior; avoid
   terse fragment/bullet-only function comments.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,9 @@ Conventions:
 - Use `SLANG_`-prefixed `SCREAMING_SNAKE_CASE` for macros.
 - Prefer comments that explain why code exists.
 
+- Function names should reflect the nature of the behavior they implement, including important
+  return-type/reference semantics, rather than the narrow use case that motivated the function.
+
 Review conventions (recurring review feedback — following them avoids review round-trips):
 
 - Comment functions in complete sentences: what it does first, then why if non-obvious; include a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,9 @@ Recurring review feedback distilled into rules — following them avoids review 
 govern how code reads and is structured; the Problem-Solving Methodology above governs _what_ to
 change.)
 
+- Function names should reflect the nature of the behavior they implement, including important
+  return-type/reference semantics, rather than the narrow use case that motivated the function.
+
 - **Write function comments as complete sentences: what, then why.** State what the function does
   first; then, if the reason it exists isn't obvious from that description, add a brief summary of
   why. For non-trivial behavior, include a concrete example. Avoid terse fragment- or bullet-only


### PR DESCRIPTION
1. **Motivation** - Review feedback on the pack-count PR pointed out that a helper name reflected the narrow motivating use case instead of the behavior it actually implemented. The agent instruction files should capture that lesson so future agent edits avoid the same pattern.

2. **Proposed solution** - Add one naming-guidance bullet to `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` so the three instruction surfaces stay consistent.

3. **Change summary** - Adds the same rule in each instruction file: function names should reflect the behavior they implement, including important return-type or reference semantics, rather than the motivating use case.

4. **Concepts and vocabulary** - Agent instruction files: repository-maintained guidance read by coding agents before making changes.

5. **Process report** - This change is intentionally separated from the generic variadic pack-count implementation PR because it affects repository agent guidance rather than compiler behavior. The only handled input shape is instruction prose in the three canonical agent guidance files, and keeping the wording identical prevents future divergence between agent surfaces.

Validation: not run; documentation/instruction-only change.