### PR TITLE
Warn when a user operator overload on builtin scalar/vector/matrix operands is shadowed by the builtin-operator fast path

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -717,6 +717,7 @@ struct SemanticsDeclHeaderVisitor : public SemanticsDeclVisitorBase,
     void checkInterfaceRequirement(Decl* decl);
 
     void checkCallableDeclCommon(CallableDecl* decl);
+    void checkForShadowedBuiltinOperatorOverload(CallableDecl* decl);
     void checkPublicCallableOperandVisibility(CallableDecl* decl);
 
     void checkCallableConstraints(CallableDecl* decl);
@@ -14790,6 +14791,76 @@ void SemanticsDeclHeaderVisitor::checkCallableDeclCommon(CallableDecl* decl)
 
     checkInterfaceRequirement(decl);
     checkVisibility(decl);
+
+    // Warn if this is a user operator overload that the builtin-operator fast path will silently
+    // shadow (e.g. `int operator+(int, int)`), so the dead overload does not look effective.
+    checkForShadowedBuiltinOperatorOverload(decl);
+}
+
+void SemanticsDeclHeaderVisitor::checkForShadowedBuiltinOperatorOverload(CallableDecl* decl)
+{
+    // The builtin-operator fast path (`convertToBuiltinArithmeticOp`, slang-check-expr.cpp)
+    // rewrites builtin arithmetic/comparison/bitwise/shift/unary operators on
+    // scalar/vector/matrix operands to a `BuiltinOperatorExpr` *before* operator overload
+    // resolution runs. A user operator overload whose operands are exactly those builtin types is
+    // therefore never selected -- e.g. `int operator+(int, int)` is dead code: `a + b` on `int`
+    // operands is fast-pathed and the overload is silently ignored (before the fast path existed
+    // it would have produced an overload-resolution diagnostic). Warn so the dead overload does
+    // not look effective.
+    //
+    // We warn only when the fast path *would* shadow the overload, using the same
+    // `isBuiltinOperatorFastPathEligible` predicate the fast path itself uses (the single source
+    // of truth). Overloads that still resolve normally therefore do not warn: user operand types
+    // (`operator+(MyStruct, int)`), element types invalid for the operator family
+    // (`operator&(float, float)`), shapes the fast path does not handle (matrix*vector), and
+    // operators with no fast-path form (unary `+`, `&&`/`||`, `?:`, `=`, `()`).
+
+    // The core module (core.meta.slang) and the glsl module declare these operators themselves; a
+    // warning there would be spurious, so only user-module decls are flagged.
+    if (isFromCoreModule(decl))
+        return;
+    if (auto moduleDecl = getModuleDecl(decl))
+    {
+        if (moduleDecl->hasModifier<GLSLModuleModifier>())
+            return;
+    }
+
+    auto name = decl->getName();
+    if (!name)
+        return;
+
+    // An operator overload's parameter list holds its operands directly: one for a unary
+    // operator, two for a binary operator. (A member operator's implicit `this` is not a
+    // parameter, so a builtin-typed member operator declared via an extension would show one
+    // fewer parameter and simply not match below -- a conservative miss, never a false warning.)
+    Type* operandTypes[2] = {nullptr, nullptr};
+    Index paramCount = 0;
+    for (auto paramDecl : decl->getParameters())
+    {
+        if (paramCount < 2)
+            operandTypes[paramCount] = paramDecl->getType();
+        ++paramCount;
+    }
+    if (paramCount != 1 && paramCount != 2)
+        return;
+
+    // The parser stores an operator overload's name as the operator symbol itself (e.g. "+"),
+    // see `ParseDeclName` in slang-parser.cpp. Map (symbol, arity) to a `BuiltinOperationKind`;
+    // a non-operator name, or an operator with no builtin fast-path form, yields `Unknown`. The
+    // arity disambiguates `-` (unary `Neg` vs binary `Sub`).
+    auto arity = (paramCount == 1) ? OperatorArity::Unary : OperatorArity::Binary;
+    auto kind = getBuiltinOperationKindFromString(getText(name).getUnownedSlice(), arity);
+    if (kind == BuiltinOperationKind::Unknown)
+        return;
+
+    // The eligibility predicate lives on `SemanticsExprVisitor`; construct one over the current
+    // semantics context to reach it. `rightType == nullptr` selects the unary check.
+    SemanticsExprVisitor exprVisitor(*this);
+    Type* rightType = (paramCount == 2) ? operandTypes[1] : nullptr;
+    if (exprVisitor.isBuiltinOperatorFastPathEligible(kind, operandTypes[0], rightType))
+    {
+        getSink()->diagnose(Diagnostics::OperatorOverloadOnBuiltinTypeIgnored{.decl = decl});
+    }
 }
 
 void SemanticsDeclHeaderVisitor::checkPublicCallableOperandVisibility(CallableDecl* decl)

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -4567,6 +4567,118 @@ Type* SemanticsExprVisitor::coerceOperandsOfBuiltinBinaryExpr(
     return commonType;
 }
 
+bool SemanticsExprVisitor::isBuiltinOperatorFastPathEligible(
+    BuiltinOperationKind kind,
+    Type* leftType,
+    Type* rightType)
+{
+    // Classify the element base type of a builtin scalar/vector/matrix operand into the
+    // integer/floating-point/bool buckets `convertToBuiltinArithmeticOp` keys on. Returns false
+    // when `type` is not a builtin scalar/vector/matrix (so the operand is a user type and the
+    // fast path must not apply). For a vector/matrix the element base is inspected; for a scalar
+    // the type itself is the element.
+    auto classifyElementBase = [&](Type* type, bool& outInt, bool& outFloat, bool& outBool) -> bool
+    {
+        Type* elementType = type;
+        if (auto v = as<VectorExpressionType>(type))
+            elementType = v->getElementType();
+        else if (auto m = as<MatrixExpressionType>(type))
+            elementType = m->getElementType();
+        auto basic = as<BasicExpressionType>(elementType);
+        if (!basic)
+            return false;
+        auto baseType = basic->getBaseType();
+        auto flags = BaseTypeInfo::getInfo(baseType).flags;
+        outInt = (flags & BaseTypeInfo::Flag::Integer) != 0;
+        outFloat = (flags & BaseTypeInfo::Flag::FloatingPoint) != 0;
+        outBool = (baseType == BaseType::Bool);
+        return true;
+    };
+
+    // Unary operator (`rightType == nullptr`): only negate (`-`), logical-not (`!`), and
+    // bitwise-not (`~`) have a builtin fast-path form. Unary `+` maps to `Add`, which is not a
+    // unary fast-path kind, so it is left to normal resolution and is not reported as shadowed.
+    if (!rightType)
+    {
+        if (!leftType)
+            return false;
+        bool isNeg = (kind == BuiltinOperationKind::Neg);
+        bool isLogicalNot = (kind == BuiltinOperationKind::Not);
+        bool isBitNot = (kind == BuiltinOperationKind::BitNot);
+        if (!isNeg && !isLogicalNot && !isBitNot)
+            return false;
+        // In GLSL operator scope the `glsl` module owns matrix operator semantics, so a matrix
+        // operand goes through that module's overloads rather than the fast path.
+        if (isGLSLOperatorScope() && as<MatrixExpressionType>(leftType))
+            return false;
+        bool isInt = false, isFloat = false, isBool = false;
+        if (!classifyElementBase(leftType, isInt, isFloat, isBool))
+            return false;
+        // `-` => signed/float negate; `~` => integer bitwise-not; `!` => bool logical-not.
+        return isNeg ? (isInt || isFloat) : (isBitNot ? isInt : /*isLogicalNot*/ isBool);
+    }
+
+    // Binary operator. Classify the operator family by kind (enum, not text). `Unknown`, the
+    // short-circuiting `And`/`Or` (`&&`/`||`), `Conditional` (`?:`), and assignment-like
+    // operators have no fast-path form.
+    bool isArithmetic = kind == BuiltinOperationKind::Add || kind == BuiltinOperationKind::Sub ||
+                        kind == BuiltinOperationKind::Mul || kind == BuiltinOperationKind::Div ||
+                        kind == BuiltinOperationKind::Mod;
+    bool isComparison = kind == BuiltinOperationKind::Eql || kind == BuiltinOperationKind::Neq ||
+                        kind == BuiltinOperationKind::Less ||
+                        kind == BuiltinOperationKind::Greater ||
+                        kind == BuiltinOperationKind::Leq || kind == BuiltinOperationKind::Geq;
+    bool isBitwise = kind == BuiltinOperationKind::BitAnd || kind == BuiltinOperationKind::BitOr ||
+                     kind == BuiltinOperationKind::BitXor || kind == BuiltinOperationKind::Lsh ||
+                     kind == BuiltinOperationKind::Rsh;
+    if (!isArithmetic && !isComparison && !isBitwise)
+        return false;
+    if (!leftType)
+        return false;
+    bool isEquality = kind == BuiltinOperationKind::Eql || kind == BuiltinOperationKind::Neq;
+    bool isShift = kind == BuiltinOperationKind::Lsh || kind == BuiltinOperationKind::Rsh;
+
+    // GLSL operator scope only overrides matrix operators (algebraic products) and vector equality
+    // (`vec == vec` / `!=` -> scalar `bool`); those go through the glsl module's overloads, so the
+    // fast path does not apply (and a user overload for them is not shadowed).
+    if (isGLSLOperatorScope())
+    {
+        bool leftMat = as<MatrixExpressionType>(leftType) != nullptr;
+        bool rightMat = as<MatrixExpressionType>(rightType) != nullptr;
+        bool anyVec = as<VectorExpressionType>(leftType) != nullptr ||
+                      as<VectorExpressionType>(rightType) != nullptr;
+        if (leftMat || rightMat)
+            return false;
+        if (isEquality && anyVec)
+            return false;
+    }
+
+    // Shift operators do not promote to a common type (`a << b` keeps the type of `a`), so a
+    // mixed-type shift is left to overload resolution.
+    if (isShift && !leftType->equals(rightType))
+        return false;
+
+    // The operands must promote to a common builtin scalar/vector/matrix type (the usual
+    // arithmetic conversions with scalar/vector/matrix broadcast); null => not both builtin
+    // numeric operands or not broadcast-compatible (e.g. user types, or matrix mixed with vector).
+    Type* operandType = getBuiltinArithmeticCommonType(leftType, rightType);
+    if (!operandType)
+        return false;
+
+    // The common element base must be valid for the operator family, matching the eligibility the
+    // builder below relies on: bitwise/shift on integers only; equality on integer/float/bool;
+    // arithmetic and ordering comparison on integer/float. A `bool` arithmetic or a `float`
+    // bitwise operand therefore falls back to normal resolution.
+    bool isInt = false, isFloat = false, isBool = false;
+    if (!classifyElementBase(operandType, isInt, isFloat, isBool))
+        return false;
+    if (isBitwise)
+        return isInt;
+    if (isEquality)
+        return isInt || isFloat || isBool;
+    return isInt || isFloat;
+}
+
 Expr* SemanticsExprVisitor::convertToBuiltinArithmeticOp(InvokeExpr* expr)
 {
     // Recognize a builtin arithmetic (`+ - * / %`), comparison (`< > <= >=`), equality
@@ -4586,36 +4698,16 @@ Expr* SemanticsExprVisitor::convertToBuiltinArithmeticOp(InvokeExpr* expr)
         auto uKind = getBuiltinOperationKindFromString(
             getText(uVarExpr->name).getUnownedSlice(),
             OperatorArity::Unary);
-        bool isNeg = (uKind == BuiltinOperationKind::Neg);
-        bool isLogicalNot = (uKind == BuiltinOperationKind::Not);
-        bool isBitNot = (uKind == BuiltinOperationKind::BitNot);
-        if (!isNeg && !isLogicalNot && !isBitNot)
-            return nullptr;
 
         auto arg = expr->arguments[0];
         if (!arg->type.type)
             return nullptr;
         Type* uOperandType = arg->type.type;
-        // In GLSL operator scope the `glsl` module owns matrix operator semantics, so leave
-        // matrix operands to normal resolution (see the binary case for the full rationale).
-        if (isGLSLOperatorScope() && as<MatrixExpressionType>(uOperandType))
-            return nullptr;
-        Type* uElementType = uOperandType;
-        if (auto v = as<VectorExpressionType>(uOperandType))
-            uElementType = v->getElementType();
-        else if (auto m = as<MatrixExpressionType>(uOperandType))
-            uElementType = m->getElementType();
-        auto uBasic = as<BasicExpressionType>(uElementType);
-        if (!uBasic)
-            return nullptr;
-        auto uBaseType = uBasic->getBaseType();
-        auto uFlags = BaseTypeInfo::getInfo(uBaseType).flags;
-        bool uInt = (uFlags & BaseTypeInfo::Flag::Integer) != 0;
-        bool uFloat = (uFlags & BaseTypeInfo::Flag::FloatingPoint) != 0;
-        bool uBool = (uBaseType == BaseType::Bool);
-        // `-` => signed/float negate; `~` => integer bitwise-not; `!` => bool logical-not.
-        bool uEligible = isNeg ? (uInt || uFloat) : (isBitNot ? uInt : /*isLogicalNot*/ uBool);
-        if (!uEligible)
+        // Operator-family and builtin operand-type eligibility (including the GLSL-scope matrix
+        // bail) is decided once by `isBuiltinOperatorFastPathEligible`, the shared source of truth
+        // that the decl-check warning also consults. If it declines, fall back to normal
+        // resolution.
+        if (!isBuiltinOperatorFastPathEligible(uKind, uOperandType, nullptr))
             return nullptr;
 
         auto node = m_astBuilder->create<BuiltinOperatorExpr>();
@@ -4646,89 +4738,36 @@ Expr* SemanticsExprVisitor::convertToBuiltinArithmeticOp(InvokeExpr* expr)
         getText(varExpr->name).getUnownedSlice(),
         OperatorArity::Binary);
 
-    // Classify the operator by kind (enum, not text). `Unknown` covers operators with no
-    // builtin fast-path form, notably the short-circuiting `&&`/`||`.
-    bool isArithmetic = kind == BuiltinOperationKind::Add || kind == BuiltinOperationKind::Sub ||
-                        kind == BuiltinOperationKind::Mul || kind == BuiltinOperationKind::Div ||
-                        kind == BuiltinOperationKind::Mod;
-    bool isComparison = kind == BuiltinOperationKind::Eql || kind == BuiltinOperationKind::Neq ||
-                        kind == BuiltinOperationKind::Less ||
-                        kind == BuiltinOperationKind::Greater ||
-                        kind == BuiltinOperationKind::Leq || kind == BuiltinOperationKind::Geq;
-    bool isBitwise = kind == BuiltinOperationKind::BitAnd || kind == BuiltinOperationKind::BitOr ||
-                     kind == BuiltinOperationKind::BitXor || kind == BuiltinOperationKind::Lsh ||
-                     kind == BuiltinOperationKind::Rsh;
-    if (!isArithmetic && !isComparison && !isBitwise)
-        return nullptr;
-    bool isEquality = kind == BuiltinOperationKind::Eql || kind == BuiltinOperationKind::Neq;
-    bool isShift = kind == BuiltinOperationKind::Lsh || kind == BuiltinOperationKind::Rsh;
-
     auto leftArg = expr->arguments[0];
     auto rightArg = expr->arguments[1];
     if (!leftArg->type.type || !rightArg->type.type)
         return nullptr;
 
-    // GLSL operator scope only overrides matrix operators (algebraic products) and vector
-    // equality (`vec == vec` / `!=` -> scalar `bool`); bail to normal resolution for those so
-    // the glsl module's overloads apply. Everything else is identical to HLSL and stays
-    // fast-pathed.
-    if (isGLSLOperatorScope())
-    {
-        bool leftMat = as<MatrixExpressionType>(leftArg->type.type) != nullptr;
-        bool rightMat = as<MatrixExpressionType>(rightArg->type.type) != nullptr;
-        bool anyVec = as<VectorExpressionType>(leftArg->type.type) != nullptr ||
-                      as<VectorExpressionType>(rightArg->type.type) != nullptr;
-        if (leftMat || rightMat)
-            return nullptr;
-        if (isEquality && anyVec)
-            return nullptr;
-    }
-
-    // Shift operators do not promote to a common type: `a << b` keeps the type of `a` (the
-    // shift amount `b` is converted independently). That asymmetry is not modeled by the
-    // common-type rule, so leave mixed-type shifts to overload resolution.
-    if (isShift && !leftArg->type.type->equals(rightArg->type.type))
+    // Operator-family, builtin operand types, common-type promotion, element-type validity, and
+    // the GLSL-scope bails are all decided once by `isBuiltinOperatorFastPathEligible`, the shared
+    // source of truth that the decl-check warning also consults. If it declines, fall back to
+    // normal overload resolution (which finds a user overload or produces the right diagnostic).
+    if (!isBuiltinOperatorFastPathEligible(kind, leftArg->type.type, rightArg->type.type))
         return nullptr;
-    // Promote mixed-type operands to the common operand type (and carry the coerced operands
-    // back onto the expression). Null => not a fast-pathable pair of builtin numeric operands.
+
+    // The result shape depends only on whether the operator is a comparison (boolean result) or
+    // value-preserving; re-derive that classification here for building the result type.
+    bool isComparison = kind == BuiltinOperationKind::Eql || kind == BuiltinOperationKind::Neq ||
+                        kind == BuiltinOperationKind::Less ||
+                        kind == BuiltinOperationKind::Greater ||
+                        kind == BuiltinOperationKind::Leq || kind == BuiltinOperationKind::Geq;
+
+    // Promote mixed-type operands to the common operand type (and carry the coerced operands back
+    // onto the expression). The predicate already established broadcast-compatibility, so a null
+    // here means a coercion failed; abandon the fast path without mutating the operands.
     Type* operandType = coerceOperandsOfBuiltinBinaryExpr(leftArg, rightArg, leftArg, rightArg);
     if (!operandType)
         return nullptr;
     expr->arguments[0] = leftArg;
     expr->arguments[1] = rightArg;
 
-    Type* elementType = operandType;
-    VectorExpressionType* vecType = nullptr;
-    MatrixExpressionType* matType = nullptr;
-    if ((vecType = as<VectorExpressionType>(operandType)))
-        elementType = vecType->getElementType();
-    else if ((matType = as<MatrixExpressionType>(operandType)))
-        elementType = matType->getElementType();
-    auto basicElementType = as<BasicExpressionType>(elementType);
-    if (!basicElementType)
-        return nullptr;
-    auto baseType = basicElementType->getBaseType();
-    auto baseFlags = BaseTypeInfo::getInfo(baseType).flags;
-    bool isIntegerBase = (baseFlags & BaseTypeInfo::Flag::Integer) != 0;
-    bool isFloatBase = (baseFlags & BaseTypeInfo::Flag::FloatingPoint) != 0;
-    bool isBoolBase = (baseType == BaseType::Bool);
-    // Some operators do not apply to every element type. For example, it is invalid to apply a
-    // bitwise operator to a floating-point operand, and arithmetic does not apply to `bool`. When
-    // the element type is not valid for the operator family we return null, so the expression
-    // falls back to normal overload resolution (which will either find a user-provided overload
-    // or produce the appropriate diagnostic) instead of being lowered as a builtin operation.
-    //   - bitwise/shift (`& | ^ << >> ~`): integer only;
-    //   - equality (`== !=`): integer, floating-point, or bool;
-    //   - arithmetic (`+ - * / %`) and ordering comparison (`< > <= >=`): integer or float.
-    bool eligible;
-    if (isBitwise)
-        eligible = isIntegerBase;
-    else if (isEquality)
-        eligible = isIntegerBase || isFloatBase || isBoolBase;
-    else
-        eligible = isIntegerBase || isFloatBase;
-    if (!eligible)
-        return nullptr;
+    VectorExpressionType* vecType = as<VectorExpressionType>(operandType);
+    MatrixExpressionType* matType = as<MatrixExpressionType>(operandType);
 
     // Result type: arithmetic/bitwise preserve the operand type; comparison yields a
     // boolean of matching shape (scalar -> bool, vector<T,N> -> vector<bool,N>,

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -3632,6 +3632,20 @@ public:
     // completeness / idempotent re-checks.
     Expr* visitBuiltinOperatorExpr(BuiltinOperatorExpr* expr);
 
+    // True when the builtin-operator fast path (`convertToBuiltinArithmeticOp`) would intercept an
+    // application of `kind` to operands of the given builtin types and rewrite it to a
+    // `BuiltinOperatorExpr`, bypassing generic `operator OP` overload resolution. This is the
+    // single source of truth for fast-path eligibility: `convertToBuiltinArithmeticOp` consults it
+    // to decide whether to take over, and `checkCallableDeclCommon` consults it to warn about a
+    // user operator overload the fast path would silently shadow (e.g. `int operator+(int, int)`).
+    // Pass `rightType == nullptr` for a unary operator; for a binary operator both `leftType` and
+    // `rightType` must be non-null. Pure predicate: it inspects types only and never coerces or
+    // mutates. (Public so `SemanticsDeclHeaderVisitor` can reach it via a temporary expr visitor.)
+    bool isBuiltinOperatorFastPathEligible(
+        BuiltinOperationKind kind,
+        Type* leftType,
+        Type* rightType);
+
     Expr* visitSelectExpr(SelectExpr* expr);
 
     Expr* visitVarExpr(VarExpr* expr);

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -3695,6 +3695,13 @@ err(
     span { loc = "expr:Expr", message = "ambiguous call to overloaded operation with arguments of type ~args" }
 )
 
+warning(
+    "operator-overload-on-builtin-type-ignored",
+    39073,
+    "operator overload on builtin scalar/vector/matrix operands is ignored",
+    span { loc = "decl:Decl", message = "this operator overload on builtin scalar/vector/matrix operands has no effect: the compiler evaluates these operators directly and will not call this overload" }
+)
+
 standalone_note(
     "overload-candidate",
     40011,

--- a/tests/language-feature/operator-overload/builtin-operator-overload-no-warning.slang
+++ b/tests/language-feature/operator-overload/builtin-operator-overload-no-warning.slang
@@ -1,0 +1,39 @@
+// Companion to `builtin-operator-overload-warning.slang`. These operator overloads are NOT
+// shadowed by the builtin-operator fast path (`convertToBuiltinArithmeticOp`): the fast path
+// leaves each to normal overload resolution, so the user overload is still reachable and must
+// NOT be flagged as ignored. Exhaustive mode (no `non-exhaustive`): any spurious diagnostic --
+// including a wrongly-emitted shadowing warning -- fails the test.
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target hlsl
+
+struct S
+{
+    int v;
+}
+
+// User operand type: the fast path is gated on builtin operands, so this resolves normally.
+S operator+(S a, int b)
+{
+    return a;
+}
+
+// Bitwise on floating-point operands is not a valid builtin operation, so the fast path declines
+// and this overload still resolves.
+float operator&(float a, float b)
+{
+    return a;
+}
+
+// Unary `+` has no builtin fast-path form (only unary `-`/`!`/`~` do), so it is not shadowed.
+int operator+(int a)
+{
+    return a;
+}
+
+// matrix * vector is not a builtin component-wise operation (no common broadcast type), so the
+// fast path declines and this overload is reachable.
+float3 operator*(float3x3 m, float3 v)
+{
+    return v;
+}
+
+void main() {}

--- a/tests/language-feature/operator-overload/builtin-operator-overload-warning.slang
+++ b/tests/language-feature/operator-overload/builtin-operator-overload-warning.slang
@@ -1,0 +1,39 @@
+// A user operator overload whose operands are builtin scalar/vector/matrix types is silently
+// shadowed by the builtin-operator fast path (`convertToBuiltinArithmeticOp` in
+// slang-check-expr.cpp), which rewrites `a + b` etc. to a `BuiltinOperatorExpr` before operator
+// overload resolution runs. The overload is therefore dead code; this test verifies the warning
+// fires for the builtin arithmetic / unary / vector / comparison forms.
+//
+// Non-exhaustive: we only assert that each declaration warns. The companion test
+// `builtin-operator-overload-no-warning.slang` exhaustively verifies the non-shadowed forms stay
+// silent.
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):-target hlsl
+
+int operator+(int a, int b)
+{
+    return a;
+}
+//CHECK: operator overload on builtin scalar/vector/matrix operands is ignored
+
+float3 operator*(float3 a, float3 b)
+{
+    return a;
+}
+//CHECK: operator overload on builtin scalar/vector/matrix operands is ignored
+
+// Unary negate on a builtin scalar is also fast-pathed.
+int operator-(int a)
+{
+    return a;
+}
+//CHECK: operator overload on builtin scalar/vector/matrix operands is ignored
+
+// Equality on vector operands is fast-pathed too (the operand types, not the return type, gate
+// the warning).
+bool operator==(float2 a, float2 b)
+{
+    return false;
+}
+//CHECK: operator overload on builtin scalar/vector/matrix operands is ignored
+
+void main() {}


### PR DESCRIPTION
## Motivation

PR #11493 added a hard-coded fast path for builtin operators. In `visitInvokeExpr`
([slang-check-expr.cpp](source/slang/slang-check-expr.cpp)), `convertToBuiltinArithmeticOp`
recognizes an arithmetic/comparison/bitwise/shift/unary operator on builtin scalar/vector/matrix
operands and rewrites it to a `BuiltinOperatorExpr` **before** generic `operator OP` overload
resolution runs.

A side effect is that a user-declared operator overload whose operands are exactly those builtin
types is now **silently ignored**. For example:

```slang
int operator+(int a, int b) { return a * 1000; } // user overload
...
int c = a + b;   // a, b are int -> fast-pathed; the overload above is NEVER called
```

Before the fast path, this same code produced a salient overload-resolution diagnostic (the user
overload conflicted with the core-module `operator+`). After the fast path it compiles with no
diagnostic at all, so the dead overload looks effective. This was raised in review of #11493.

## Proposed solution

Emit a **warning** at decl-check time whenever a user declares an operator overload that the fast
path will shadow. It is a warning, not an error, so it is **non-breaking**: such a declaration still
compiles (it is merely dead), and existing user modules are not rejected.

The key requirement is that the warning fire **exactly** when the fast path shadows the overload —
no false positives. To guarantee that, the eligibility decision in `convertToBuiltinArithmeticOp`
is factored out into a single shared predicate, `isBuiltinOperatorFastPathEligible`, which both the
fast path and the new decl-check consult. They cannot drift: if the fast path would take over an
expression, the warning fires for the matching overload, and vice versa. Overloads the fast path
leaves alone — user operand types, element types invalid for the operator family
(`operator&(float, float)`), shapes it does not handle (matrix × vector), and operators with no
fast-path form (unary `+`, `&&`/`||`, `?:`, `=`, `()`) — do **not** warn.

## Change summary

| File | Change |
| --- | --- |
| `source/slang/slang-check-impl.h` | Declare `SemanticsExprVisitor::isBuiltinOperatorFastPathEligible` (public, so the decl-header visitor can reach it). |
| `source/slang/slang-check-expr.cpp` | Add `isBuiltinOperatorFastPathEligible` (the shared eligibility predicate, extracted from `convertToBuiltinArithmeticOp`), and refactor the unary and binary branches of `convertToBuiltinArithmeticOp` to gate on it. |
| `source/slang/slang-check-decl.cpp` | Add `checkForShadowedBuiltinOperatorOverload`, called from `checkCallableDeclCommon`; it maps an operator decl's name + arity to a `BuiltinOperationKind` and diagnoses when the predicate says the fast path would shadow it. |
| `source/slang/slang-diagnostics.lua` | New warning `operator-overload-on-builtin-type-ignored` (code 39073). |
| `tests/language-feature/operator-overload/builtin-operator-overload-warning.slang` | Positive cases: warning fires for `int`/vector arithmetic, unary negate, vector equality. |
| `tests/language-feature/operator-overload/builtin-operator-overload-no-warning.slang` | Negative cases (exhaustive): user operand type, bitwise-on-float, unary `+`, matrix × vector all stay silent. |

## Concepts and vocabulary

- **Fast path / `convertToBuiltinArithmeticOp`** — the routine added in #11493 that rewrites a
  builtin operator expression directly to a `BuiltinOperatorExpr`, bypassing overload resolution.
- **`BuiltinOperationKind` / `getBuiltinOperationKindFromString`** — the enum the fast path keys on,
  and the (operator-symbol, arity) → kind mapping. `OperatorArity` disambiguates unary `-` (`Neg`)
  from binary `-` (`Sub`). `Unknown` is returned for operators with no builtin fast-path form.
- **`getBuiltinArithmeticCommonType`** — computes the common operand type (the usual arithmetic
  conversions with scalar/vector/matrix broadcast) two builtin operands promote to, or null if they
  are not both builtin numeric or are not broadcast-compatible. Reused by the predicate.
- **`isFromCoreModule` / `GLSLModuleModifier`** — markers distinguishing core-module
  (`core.meta.slang`) and `glsl`-module declarations from user code; the core and glsl modules
  declare these operators themselves, so they are excluded.

## Process report

**Shared eligibility predicate — `isBuiltinOperatorFastPathEligible` (slang-check-expr.cpp).**
The decl-check warning must agree exactly with what the fast path does, or it would either warn on
overloads that still work (false positive) or miss shadowed ones. Rather than duplicate the
eligibility rules, I extracted them from `convertToBuiltinArithmeticOp` into one predicate over
types. It encodes the full decision: operator-family classification by `BuiltinOperationKind`
(arithmetic/comparison/bitwise for binary; `Neg`/`Not`/`BitNot` for unary), the GLSL-scope bails
(matrix operators and vector equality, which the `glsl` module owns), the no-mixed-type-shift rule,
broadcast-compatibility via `getBuiltinArithmeticCommonType`, and the per-family element-type
validity (bitwise→int, equality→int/float/bool, arithmetic/ordering→int/float). `convertToBuiltinArithmeticOp`
now calls it as its gate and keeps only the work needed to *build* the node (operand coercion via
`coerceOperandsOfBuiltinBinaryExpr`, result-shape derivation). The existing
`tests/language-feature/operator-overload` suite — including the byte-identical-codegen tests —
passes unchanged, confirming the refactor is behavior-preserving.

One deliberate behavior nuance: previously the binary branch coerced operands and wrote them back
onto the expression *before* the element-type check, so an ineligible mixed-type operand
(e.g. `float & int`) would mutate the arguments and then bail. The predicate now decides
eligibility from types up front, so we no longer mutate operands when declining — the fast path has
no side effect when it falls through. This only affects operators that are invalid anyway and would
error in overload resolution regardless.

**Decl-check — `checkForShadowedBuiltinOperatorOverload` (slang-check-decl.cpp).** Called from
`checkCallableDeclCommon` (where parameter types are already resolved to `ReadyForReference`). It
reads the operand types straight from the parameter list — one param for a unary operator, two for
a binary operator — maps the decl's name (the operator symbol, stored by `ParseDeclName` in
slang-parser.cpp) plus arity to a `BuiltinOperationKind`, and warns when
`isBuiltinOperatorFastPathEligible` says the fast path would intercept those operands. The
predicate is a `SemanticsExprVisitor` method, reached by constructing a temporary expr visitor over
the current context (the same idiom used in slang-check-stmt.cpp).

*Input-shape check.* The shapes this code handles are ordinary checked `FuncDecl`s and their
resolved parameter `Type`s, which are correct and principled inputs — no malformed shape is being
papered over. The two exclusions are deliberately about *which decls* to flag, not about fixing a
bad shape: `isFromCoreModule(decl)` and the `GLSLModuleModifier` check skip the core and glsl
modules, which legitimately declare these operators themselves (flagging them would be a spurious
warning about the standard library, not user code). A member operator declared via an extension on
a builtin type would present one fewer parameter than its arity; that simply fails the
arity/kind match and is a conservative miss (never a false warning), which is acceptable because
builtin-type member operators are not the case #11493's reviewer raised.

**Diagnostic (slang-diagnostics.lua).** `operator-overload-on-builtin-type-ignored` is a warning, on
by default. Code `39073` was chosen because the lua validator requires all diagnostics sharing a
numeric code to share severity, and the `39999` placeholder used by nearby overload diagnostics is
already taken by errors; `39073` is unused and sits next to the related
`binding-attribute-ignored-on-uniform` warning (`39071`).

**Testing.** Two tests under `tests/language-feature/operator-overload/`: a non-exhaustive positive
test asserting the warning fires for the builtin arithmetic / unary / vector / comparison forms, and
an exhaustive negative test (no annotations) asserting the non-shadowed forms — user operand type,
bitwise-on-float, unary `+`, matrix × vector — produce no diagnostic at all. Both pass, and the full
`tests/language-feature` + `tests/diagnostics` sweep shows no new non-environmental failures.
