### PR TITLE
Add regression test for spurious 'cannot insert #pragma warning here' across __include (#8166)

### DIFF
--- a/source/slang/slang-preprocessor.cpp
+++ b/source/slang/slang-preprocessor.cpp
@@ -1191,6 +1191,13 @@ struct WarningStateTracker : SourceWarningStateTrackerBase
     Dictionary<int, WarningTimeline> mapDiagnosticIdToTimeline = {};
     List<SourceLoc> stack = {};
 
+    // Running absolute-location counter, persisted across the separate `preprocessSource`
+    // passes that share this tracker (each `__include`d file is preprocessed in its own
+    // pass with a fresh `Preprocessor`). Persisting it keeps the timeline's absolute-location
+    // axis globally monotonic across files, instead of every pass restarting from 0 and
+    // colliding in the shared timeline (shader-slang/slang#11473).
+    SourceLoc::RawValue persistedAbsoluteSourceLocCounter = 0;
+
     WarningStateTracker(SourceManager* sourceManager = nullptr)
         : sourceManager(sourceManager)
     {
@@ -5028,6 +5035,24 @@ TokenList preprocessSource(
     preprocessor.warningStateTracker =
         dynamicCast<preprocessor::WarningStateTracker>(desc.sink->getSourceWarningStateTracker());
 
+    // Continue the absolute-location axis from the previous pass that shared this tracker.
+    //
+    // Correctness relies on a pass-ordering invariant the timeline depends on but cannot check:
+    // `preprocessSource` runs once per file, in include order, so the seeded ranges are disjoint
+    // and absolute-location order matches include/program order. That is exactly what keeps
+    // `WarningTimeline::addEntry`'s strictly-increasing insert guard (`location >
+    // maxKnownLocation`) satisfied across files. Each file is preprocessed at most once per
+    // tracker: `Linkage::findAndIncludeFile` de-dupes via the module's included-source-file map. If
+    // a pass ever ran out of include order, or a file were re-preprocessed against the same
+    // tracker, the seeded range could overlap a prior file's range and `#pragma warning` state
+    // would be mis-resolved *silently* (entries dropped on the `PragmaWarningCannotInsertHere`
+    // path, or a wrong suppression).
+    if (preprocessor.warningStateTracker)
+    {
+        preprocessor.absoluteSourceLocCounter =
+            preprocessor.warningStateTracker->persistedAbsoluteSourceLocCounter;
+    }
+
     // Add builtin macros
     {
         auto namePool = desc.namePool;
@@ -5087,6 +5112,25 @@ TokenList preprocessSource(
     }
 
     finalCheckPragmaWarnings(&preprocessor);
+
+    // Hand the advanced counter back so the next `__include` pass continues the axis. The counter
+    // only ever advances within a pass (pushInputFile/popInputFile add non-negative offsets), so
+    // the value handed back must not be below the value seeded above.
+    //
+    // Use a release assert (not `SLANG_ASSERT`, which is elided / becomes `SLANG_ASSUME` in release
+    // builds): violating monotonicity silently corrupts pragma-warning state in shipping
+    // slangc/slangd. This also guards against `SourceLoc::RawValue` (a `uint32_t`) wrapping once
+    // the counter accumulates across every `__include`d file of a very large translation unit -- on
+    // wrap the new value would be smaller than the persisted one, so the assert fires loudly
+    // instead of re-introducing the cross-file location aliasing this fix removes.
+    if (preprocessor.warningStateTracker)
+    {
+        SLANG_RELEASE_ASSERT(
+            preprocessor.absoluteSourceLocCounter >=
+            preprocessor.warningStateTracker->persistedAbsoluteSourceLocCounter);
+        preprocessor.warningStateTracker->persistedAbsoluteSourceLocCounter =
+            preprocessor.absoluteSourceLocCounter;
+    }
 
     // debugging: build the pre-processed source back together
 #if 0

--- a/tests/autodiff/warn-on-prefer-recompute-side-effects.slang
+++ b/tests/autodiff/warn-on-prefer-recompute-side-effects.slang
@@ -27,7 +27,7 @@ float get_thread_6_value(float v, uint group_thread_id)
     if (group_thread_id == 6)
     {
         s_shared = detach(v);
-        // CHECK-NOT: warning 42050
+        // CHECK-NOT: warning[E42050]
 
     }
     GroupMemoryBarrierWithGroupSync();

--- a/tests/bugs/gh-9109/basic.slang
+++ b/tests/bugs/gh-9109/basic.slang
@@ -19,4 +19,4 @@ void main()
     bar(10.0f, out2);
 }
 
-// CHECK-NOT: warning 15615
+// CHECK-NOT: warning[E15615]

--- a/tests/bugs/gh-9109/main.slang
+++ b/tests/bugs/gh-9109/main.slang
@@ -12,6 +12,6 @@ void main()
     foo(5.0f, b);
 }
 
-// CHECK-NOT: warning 15615
+// CHECK-NOT: warning[E15615]
 // This verifies that pragma warning directives are accepted in all modules
 // regardless of the length of code or comments in other modules.

--- a/tests/diagnostics/nested-pragma-main.slang
+++ b/tests/diagnostics/nested-pragma-main.slang
@@ -6,4 +6,7 @@ module nested_pragma_test;
 
 __include "nested-pragma-impl1.slang";
 
-// CHECK-NOT: warning 30856
+// The root-level disable suppresses 30856 across the nested `__include`s (no push/pop here),
+// so it must not appear. (The diagnostic renders as `warning[E30856]`; match on the `E30856`
+// code so this check is not vacuous.)
+// CHECK-NOT: E30856

--- a/tests/diagnostics/pragma-warning-include-emptypushpop-body.slang
+++ b/tests/diagnostics/pragma-warning-include-emptypushpop-body.slang
@@ -1,0 +1,10 @@
+implementing pragma_emptypushpop_test;
+
+namespace emptypushpop_body
+{
+    interface IConvertibleFrom<From> {}
+
+    // Would emit warning 30856; must stay suppressed by the root module's disable.
+    extension<From : __BuiltinIntegerType, To : IConvertibleFrom<From>, let N : int>
+    vector<To, N> : IConvertibleFrom<vector<From, N>> {}
+}

--- a/tests/diagnostics/pragma-warning-include-emptypushpop-footer.slang
+++ b/tests/diagnostics/pragma-warning-include-emptypushpop-footer.slang
@@ -1,0 +1,5 @@
+implementing pragma_emptypushpop_test;
+
+// An empty push/pop. This must not disturb the root module's disable of 30856.
+#pragma warning(push)
+#pragma warning(pop)

--- a/tests/diagnostics/pragma-warning-include-emptypushpop-main.slang
+++ b/tests/diagnostics/pragma-warning-include-emptypushpop-main.slang
@@ -1,0 +1,32 @@
+//TEST:SIMPLE(filecheck=CHECK):
+
+// Regression test for shader-slang/slang#11473 (the minimal trigger). Part of the
+// cross-`__include` `#pragma warning` family alongside `pragma-warning-multifile-*` and
+// `nested-pragma-*`.
+//
+// Even an EMPTY `#pragma warning(push)/(pop)` in a later `__include`d file must not re-enable a
+// root-level disable for an earlier file's code.
+
+module pragma_emptypushpop_test;
+
+namespace control
+{
+    interface IConvertibleFrom<From> {}
+
+    // Positive control: BEFORE the disable below, so it MUST emit E30856 — guards the `CHECK-NOT`
+    // from passing vacuously. Anchored to this main file's diagnostic site so it cannot be
+    // satisfied by an E30856 from an included file.
+    extension<From : __BuiltinIntegerType, To : IConvertibleFrom<From>, let N : int>
+    vector<To, N> : IConvertibleFrom<vector<From, N>> {}
+}
+// CHECK: warning[E30856]
+// CHECK-NEXT: pragma-warning-include-emptypushpop-main.slang
+
+#pragma warning(disable: 30856)
+
+__include "pragma-warning-include-emptypushpop-body.slang";
+__include "pragma-warning-include-emptypushpop-footer.slang";
+
+// The body file's warning (after the disable) must stay suppressed, so no *second* E30856
+// may appear after the positive control above.
+// CHECK-NOT: E30856

--- a/tests/diagnostics/pragma-warning-include-percluster-atomics.slang
+++ b/tests/diagnostics/pragma-warning-include-percluster-atomics.slang
@@ -1,0 +1,17 @@
+implementing pragma_percluster_test;
+
+// First included file (mirrors slangpy's `atomics.slang`): a self-contained
+// push/disable/pop cluster around code that would otherwise emit E30856.
+// The disable must suppress this file's own warning, and the pop must end the
+// suppression at this file's boundary.
+namespace percluster_atomics
+{
+    interface IConvertibleFrom<From> {}
+
+#pragma warning(push)
+#pragma warning(disable: 30856)
+    // Suppressed by this file's own disable above.
+    extension<From : __BuiltinIntegerType, To : IConvertibleFrom<From>, let N : int>
+    vector<To, N> : IConvertibleFrom<vector<From, N>> {}
+#pragma warning(pop)
+}

--- a/tests/diagnostics/pragma-warning-include-percluster-main.slang
+++ b/tests/diagnostics/pragma-warning-include-percluster-main.slang
@@ -1,0 +1,37 @@
+//TEST:SIMPLE(filecheck=CHECK):
+
+// Regression test for shader-slang/slang#8166. Part of the cross-`__include`
+// `#pragma warning` family alongside `pragma-warning-multifile-*`,
+// `pragma-warning-include-pushpop-*`, and `nested-pragma-*`.
+//
+// #8166: two separate `__include`d files each carry their own self-contained
+// `#pragma warning(push)/(disable)/(pop)` cluster around code that would otherwise
+// warn (mirroring slangpy's `atomics.slang` and `tensor.slang`). The *second* file's
+// directives were spuriously rejected with `warning[E15615] cannot insert pragma here`,
+// because the shared warning timeline keyed entries by an absolute source location whose
+// axis restarted per preprocessing pass and so ran backwards on the later-but-lower file.
+//
+// Correct behaviour: both files' clusters suppress E30856 for their own code, no E15615
+// is emitted, and the suppression does not leak past either file's `pop`.
+
+module pragma_percluster_test;
+
+__include "pragma-warning-include-percluster-atomics.slang";
+__include "pragma-warning-include-percluster-tensor.slang";
+
+namespace control
+{
+    interface IConvertibleFrom<From> {}
+
+    // Positive control AFTER both includes (and after both files have popped their disables):
+    // this extension MUST emit E30856, proving the included clusters' disables were correctly
+    // scoped and did not leak here, and guarding the `CHECK-NOT` below from passing vacuously.
+    extension<From : __BuiltinIntegerType, To : IConvertibleFrom<From>, let N : int>
+    vector<To, N> : IConvertibleFrom<vector<From, N>> {}
+}
+// CHECK: warning[E30856]
+// CHECK-NEXT: pragma-warning-include-percluster-main.slang
+
+// The spurious "cannot insert pragma here" diagnostic from #8166 must never appear, for either
+// included file's directives.
+// CHECK-NOT: E15615

--- a/tests/diagnostics/pragma-warning-include-percluster-tensor.slang
+++ b/tests/diagnostics/pragma-warning-include-percluster-tensor.slang
@@ -1,0 +1,18 @@
+implementing pragma_percluster_test;
+
+// Second included file (mirrors slangpy's `tensor.slang`): the same self-contained
+// push/disable/pop cluster. This is the file whose directives #8166 spuriously rejected
+// with `warning[E15615] cannot insert pragma here`, because its absolute-location range
+// sat below the maximum already recorded by the first included file. Its disable must work
+// just like the first file's.
+namespace percluster_tensor
+{
+    interface IConvertibleFrom<From> {}
+
+#pragma warning(push)
+#pragma warning(disable: 30856)
+    // Suppressed by this file's own disable above; must not trigger E15615.
+    extension<From : __BuiltinIntegerType, To : IConvertibleFrom<From>, let N : int>
+    vector<To, N> : IConvertibleFrom<vector<From, N>> {}
+#pragma warning(pop)
+}

--- a/tests/diagnostics/pragma-warning-include-pushpop-body.slang
+++ b/tests/diagnostics/pragma-warning-include-pushpop-body.slang
@@ -1,0 +1,11 @@
+implementing pragma_pushpop_test;
+
+namespace pushpop_body
+{
+    interface IConvertibleFrom<From> {}
+
+    // This would emit warning 30856, but the root module's `#pragma warning(disable: 30856)`
+    // must suppress it (and must keep suppressing it despite the later footer's push/pop).
+    extension<From : __BuiltinIntegerType, To : IConvertibleFrom<From>, let N : int>
+    vector<To, N> : IConvertibleFrom<vector<From, N>> {}
+}

--- a/tests/diagnostics/pragma-warning-include-pushpop-footer.slang
+++ b/tests/diagnostics/pragma-warning-include-pushpop-footer.slang
@@ -1,0 +1,10 @@
+implementing pragma_pushpop_test;
+
+// A push/pop that touches only an unrelated id (31000 is just some other diagnostic id, not
+// 30856). It still used to disturb the root module's disable of 30856 because
+// `WarningStateTracker::addPragmaPop` restores *every* known id on `pop`, not just the pushed
+// one — so combined with the cross-file location collision, popping here re-enabled 30856 for the
+// earlier body file. After the fix this push/pop must leave the root disable of 30856 intact.
+#pragma warning(push)
+#pragma warning(disable: 31000)
+#pragma warning(pop)

--- a/tests/diagnostics/pragma-warning-include-pushpop-main.slang
+++ b/tests/diagnostics/pragma-warning-include-pushpop-main.slang
@@ -1,0 +1,34 @@
+//TEST:SIMPLE(filecheck=CHECK):
+
+// Regression test for shader-slang/slang#11473. Part of the cross-`__include`
+// `#pragma warning` family alongside `pragma-warning-multifile-*` and `nested-pragma-*`.
+//
+// A root-level `#pragma warning(disable)` must keep suppressing the warning in an earlier
+// `__include`d file even when a *later* `__include`d file performs an unrelated
+// `#pragma warning(push)/(pop)`. The push/pop in the later file must not re-enable the
+// root-level disable for the earlier file's code.
+
+module pragma_pushpop_test;
+
+namespace control
+{
+    interface IConvertibleFrom<From> {}
+
+    // Positive control: this extension is BEFORE the disable below, so it MUST emit E30856.
+    // It guards the `CHECK-NOT` from passing vacuously (e.g. if 30856 ever stops being emitted
+    // for an unrelated reason, this CHECK fails loudly instead). Anchored to this main file's
+    // diagnostic site so it cannot be satisfied by an E30856 from an included file.
+    extension<From : __BuiltinIntegerType, To : IConvertibleFrom<From>, let N : int>
+    vector<To, N> : IConvertibleFrom<vector<From, N>> {}
+}
+// CHECK: warning[E30856]
+// CHECK-NEXT: pragma-warning-include-pushpop-main.slang
+
+#pragma warning(disable: 30856)
+
+__include "pragma-warning-include-pushpop-body.slang";
+__include "pragma-warning-include-pushpop-footer.slang";
+
+// The body file's warning (after the disable) must stay suppressed, so no *second* E30856
+// may appear after the positive control above.
+// CHECK-NOT: E30856

--- a/tests/diagnostics/pragma-warning-multifile-impl2.slang
+++ b/tests/diagnostics/pragma-warning-multifile-impl2.slang
@@ -5,7 +5,10 @@ namespace impl2
 {
     interface IConvertibleFrom<From> {}
 
-    // This should still NOT produce warning 30856 (but currently does due to the bug)
+    // impl1's `#pragma warning(disable: 30856)` is wrapped in push/pop and popped before impl1
+    // ends, so it does not leak here; this extension therefore correctly emits E30856. (Whether a
+    // push/pop-scoped disable should persist across `__include` files is a separate semantic
+    // question — see shader-slang/slang#11479.)
     extension<From : __BuiltinFloatingPointType, To : IConvertibleFrom<From>, let N : int>
     vector<To, N> : IConvertibleFrom<vector<From, N>> {}
 }

--- a/tests/diagnostics/pragma-warning-multifile-main.slang
+++ b/tests/diagnostics/pragma-warning-multifile-main.slang
@@ -5,4 +5,9 @@ module test_pragma_warning;
 __include "pragma-warning-multifile-impl1.slang";
 __include "pragma-warning-multifile-impl2.slang";
 
-// CHECK-NOT: warning 30856
+// impl1 wraps its `#pragma warning(disable: 30856)` in push/pop and pops it before impl1 ends,
+// so the disable is balanced/scoped to impl1 and does not leak into impl2; impl2 has no disable,
+// so its extension correctly emits E30856. (Whether a push/pop-scoped disable SHOULD persist
+// across `__include` files is a separate semantic question — see shader-slang/slang#11479.)
+// CHECK: warning[E30856]
+// CHECK: pragma-warning-multifile-impl2.slang

--- a/tests/language-feature/capability/explicit-shader-stage-9.slang
+++ b/tests/language-feature/capability/explicit-shader-stage-9.slang
@@ -1,7 +1,7 @@
 //TEST:SIMPLE(filecheck=CHECK): -target hlsl -entry main -allow-glsl -stage raygeneration -profile sm_6_5
 
 // Our code compiles here since 'raygeneration' stage implies 'raygen+raytracing' capabilities
-//CHECK-NOT: warning 36113
+//CHECK-NOT: warning[E36113]
 //CHECK: main
 struct RayPayload
 {

--- a/tests/preprocessor/pragma-warning/disable-1.slang
+++ b/tests/preprocessor/pragma-warning/disable-1.slang
@@ -7,7 +7,7 @@ void f()
 {
 	int i;
 #pragma warning (disable : 30081)
-	// CHECK-NOT: ([[# @LINE+1]]): warning 30081:
+	// CHECK-NOT: warning[E30081]
 	i = GetValue();
 }
 

--- a/tests/preprocessor/pragma-warning/multi-specifiers-2.slang
+++ b/tests/preprocessor/pragma-warning/multi-specifiers-2.slang
@@ -7,9 +7,9 @@ void f()
 {
 	int i;
 #pragma warning (disable : 30081 15205)
-	// CHECK-NOT: ([[# @LINE+1]]): warning 30081:
+	// CHECK-NOT: warning[E30081]
 	i = GetValue();
-	// CHECK-NOT: ([[# @LINE+1]]): warning 15205:
+	// CHECK-NOT: warning[E15205]
 #if MY_MACRO
 
 #endif

--- a/tests/preprocessor/pragma-warning/pop-empty.slang
+++ b/tests/preprocessor/pragma-warning/pop-empty.slang
@@ -1,7 +1,7 @@
 //TEST:SIMPLE(filecheck=CHECK):
 // #ifdef support
 
-// CHECK-NOT: ([[# @LINE+1]]): warning 30081:
+// CHECK-NOT: warning[E30081]
 #pragma warning (pop)
 
 // Test that #pragma warning (pop) emits a warning when the stack is empty

--- a/tests/preprocessor/pragma-warning/suppress-1.slang
+++ b/tests/preprocessor/pragma-warning/suppress-1.slang
@@ -6,7 +6,7 @@ int64_t GetValue();
 void f()
 {
 	int i;
-	// CHECK-NOT: ([[# @LINE+2]]): warning 30081:
+	// CHECK-NOT: warning[E30081]
 #pragma warning (suppress : 30081)
 	i = GetValue();
 }

--- a/tests/preprocessor/pragma-warning/with-includes-1.slang
+++ b/tests/preprocessor/pragma-warning/with-includes-1.slang
@@ -7,7 +7,7 @@ int64_t GetValue();
 void f()
 {
 	int i;
-	// CHECK-NOT: ([[# @LINE+1]]): warning 30081:
+	// CHECK-NOT: warning[E30081]
 	i = GetValue();
 }
 


### PR DESCRIPTION
Closes #8166

Adds a cross-`__include` regression test mirroring the slangpy structure from #8166: two `__include`d files each wrap warning-emitting code in their own `#pragma warning(push)/(disable: 30856)/(pop)` cluster. Before #11554 the second file's directives were spuriously rejected with `warning[E15615]`. The test asserts no E15615 and that a positive-control extension after both includes still emits E30856.

Test-only; stacked on #11554 (base is master, so the diff also shows #11554's commit until that merges — review only the `pragma-warning-include-percluster-*` files).