### PR TITLE
[codex] Remove operator overload type-checking cache

### DIFF
--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -194,81 +194,6 @@ struct BasicTypeKeyPair
     HashCode getHashCode() const { return combineHash(type1.getRaw(), type2.getRaw()); }
 };
 
-struct OperatorOverloadCacheKey
-{
-    int32_t operatorName;
-    bool isGLSLMode;
-    BasicTypeKey args[2];
-    bool operator==(OperatorOverloadCacheKey key) const
-    {
-        return operatorName == key.operatorName && args[0] == key.args[0] &&
-               args[1] == key.args[1] && isGLSLMode == key.isGLSLMode;
-    }
-    HashCode getHashCode() const
-    {
-        return combineHash(operatorName, args[0].getRaw(), args[1].getRaw(), isGLSLMode ? 1 : 0);
-    }
-    bool fromOperatorExpr(OperatorExpr* opExpr)
-    {
-        // First, lets see if the argument types are ones
-        // that we can encode in our space of keys.
-        args[0] = BasicTypeKey::invalid();
-        args[1] = BasicTypeKey::invalid();
-        if (opExpr->arguments.getCount() > 2)
-            return false;
-
-        for (Index i = 0; i < opExpr->arguments.getCount(); i++)
-        {
-            auto key = makeBasicTypeKey(opExpr->arguments[i]->type, opExpr->arguments[i]);
-            if (key.getRaw() == BasicTypeKey::invalid().getRaw())
-            {
-                return false;
-            }
-            args[i] = key;
-        }
-
-        // Next, lets see if we can find an intrinsic opcode
-        // attached to an overloaded definition (filtered for
-        // definitions that could conceivably apply to us).
-        //
-        // TODO: This should really be parsed on the operator name
-        // plus fixity, rather than the intrinsic opcode...
-        //
-        // We will need to reject postfix definitions for prefix
-        // operators, and vice versa, to ensure things work.
-        //
-        auto prefixExpr = as<PrefixExpr>(opExpr);
-        auto postfixExpr = as<PostfixExpr>(opExpr);
-
-        if (auto overloadedBase = as<OverloadedExpr>(opExpr->functionExpr))
-        {
-            for (auto item : overloadedBase->lookupResult2)
-            {
-                // Look at a candidate definition to be called and
-                // see if it gives us a key to work with.
-                //
-                Decl* funcDecl = item.declRef.getDecl();
-                if (auto genDecl = as<GenericDecl>(funcDecl))
-                    funcDecl = genDecl->inner;
-
-                // Reject definitions that have the wrong fixity.
-                //
-                if (prefixExpr && !funcDecl->findModifier<PrefixModifier>())
-                    continue;
-                if (postfixExpr && !funcDecl->findModifier<PostfixModifier>())
-                    continue;
-
-                if (auto intrinsicOp = funcDecl->findModifier<IntrinsicOpModifier>())
-                {
-                    operatorName = intrinsicOp->op;
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-};
-
 struct OverloadCandidate
 {
     enum class Flavor
@@ -336,28 +261,9 @@ struct OverloadCandidate
     Index explicitGenericArgCount = -1;
 };
 
-struct ResolvedOperatorOverload
-{
-    // The resolved decl.
-    Decl* decl;
-
-    // The cached overload candidate in the current TypeCheckingCache.
-    // Note that a `OverloadCandidate` object is not migratable over different
-    // Linkages (compile sessions), so we will need to use `cacheVersion` to track
-    // if this `candidate` is valid for the current session. If not, we will
-    // recreate it from `decl`.
-    OverloadCandidate candidate;
-    // The version of the TypeCheckingCache for which the cached candidate is valid.
-    int cacheVersion;
-};
-
 struct TypeCheckingCache : public RefObject
 {
-    Dictionary<OperatorOverloadCacheKey, ResolvedOperatorOverload> resolvedOperatorOverloadCache;
     Dictionary<BasicTypeKeyPair, ConversionCost> conversionCostCache;
-
-    // The version used to invalidate the cached declRefs in ResolvedOperatorOverload entries.
-    int version = 0;
 };
 
 enum class CoercionSite

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -3158,43 +3158,6 @@ Expr* SemanticsVisitor::ResolveInvoke(InvokeExpr* expr)
     context.sourceScope = m_outerScope;
     context.baseExpr = GetBaseExpr(funcExpr);
 
-    // check if this is a core module operator call, if so we want to use cached results
-    // to speed up compilation
-    bool shouldAddToCache = false;
-    OperatorOverloadCacheKey key;
-    TypeCheckingCache* typeCheckingCache = getLinkage()->getTypeCheckingCache();
-    if (auto opExpr = as<OperatorExpr>(expr))
-    {
-        if (key.fromOperatorExpr(opExpr))
-        {
-            key.isGLSLMode = getShared()->glslModuleDecl != nullptr;
-            ResolvedOperatorOverload candidate;
-            if (typeCheckingCache->resolvedOperatorOverloadCache.tryGetValue(key, candidate))
-            {
-                // We should only use the cached candidate if it is persistent direct declref
-                // created from GlobalSession's ASTBuilder, or it is created in the current
-                // Linkage.
-                if (candidate.cacheVersion == typeCheckingCache->version ||
-                    findNextOuterGeneric(candidate.decl) == nullptr)
-                {
-                    context.bestCandidateStorage = candidate.candidate;
-                    context.bestCandidate = &context.bestCandidateStorage;
-                }
-                else
-                {
-                    LookupResultItem overloadCandidate = {};
-                    overloadCandidate.declRef = getOuterGenericOrSelf(candidate.decl);
-                    AddDeclRefOverloadCandidates(overloadCandidate, context, 0);
-                    shouldAddToCache = true;
-                }
-            }
-            else
-            {
-                shouldAddToCache = true;
-            }
-        }
-    }
-
     // We run a special case here where an `InvokeExpr`
     // with a single argument where the base/func expression names
     // a type should always be treated as an explicit type coercion
@@ -3421,20 +3384,6 @@ Expr* SemanticsVisitor::ResolveInvoke(InvokeExpr* expr)
         // applicable in the end.
         // We will report errors for this one candidate, then, to give
         // the user the most help we can.
-        if (shouldAddToCache)
-        {
-            if (isFromCoreModule(context.bestCandidate->item.declRef.getDecl()) ||
-                getShared()->glslModuleDecl ==
-                    getModuleDecl(context.bestCandidate->item.declRef.getDecl()))
-            {
-                ResolvedOperatorOverload overloadResult;
-                overloadResult.candidate = *context.bestCandidate;
-                overloadResult.decl = context.bestCandidate->item.declRef.getDecl();
-                overloadResult.cacheVersion = typeCheckingCache->version;
-                typeCheckingCache->resolvedOperatorOverloadCache[key] = overloadResult;
-            }
-        }
-
         // Now that we have resolved the overload candidate, we need to undo an
         // `openExistential` operation that was applied to `out` arguments.
         //

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -112,11 +112,10 @@ Linkage::~Linkage()
         auto globalSession = getSessionImpl();
         std::lock_guard<std::mutex> lock(globalSession->m_typeCheckingCacheMutex);
         if (!globalSession->m_typeCheckingCache ||
-            globalSession->getTypeCheckingCache()->resolvedOperatorOverloadCache.getCount() <
-                getTypeCheckingCache()->resolvedOperatorOverloadCache.getCount())
+            globalSession->getTypeCheckingCache()->conversionCostCache.getCount() <
+                getTypeCheckingCache()->conversionCostCache.getCount())
         {
             globalSession->m_typeCheckingCache = m_typeCheckingCache;
-            getTypeCheckingCache()->version++;
         }
         destroyTypeCheckingCache();
     }


### PR DESCRIPTION
## Motivation

PR #11493 added `convertToBuiltinArithmeticOp` so common builtin scalar/vector/matrix operators such as `a + b`, `v * s`, and `-x` bypass generic `operator OP` overload resolution. After that change, the old resolved-operator-overload cache in `TypeCheckingCache` is no longer the hot-path mechanism for those builtin operators.

A concrete example is `tests/language-feature/operator-overload/builtin-operator-fastpath.slang`: builtin integer/vector operators are rewritten to `BuiltinOperatorExpr` before `ResolveInvoke` needs to rank core-module operator overloads. The remaining fallback overload path should be the normal candidate collection and ranking path, not a second cross-linkage cache for a special core-module operator case.

## Proposed solution

Remove only the resolved operator-overload cache from `TypeCheckingCache` and leave the basic conversion-cost cache intact.

This is the principled layer for the cleanup because the hard-coded builtin-operator producer now handles the common builtin operator shape before fallback overload resolution. `ResolveInvoke` should only resolve the invocations that still genuinely need overload resolution. The remaining `conversionCostCache` stores only `BasicTypeKeyPair -> ConversionCost`, so it does not need the old versioning that existed to validate cached `OverloadCandidate` objects across `Linkage` copies.

## Change summary

- `source/slang/slang-check-impl.h`: removes `OperatorOverloadCacheKey`, `ResolvedOperatorOverload`, `TypeCheckingCache::resolvedOperatorOverloadCache`, and the `TypeCheckingCache::version` field. `TypeCheckingCache` now contains only `conversionCostCache`.
- `source/slang/slang-check-overload.cpp`: removes the special read/write path in `SemanticsVisitor::ResolveInvoke` that reused cached core-module operator candidates before normal overload candidate collection.
- `source/slang/slang-session.cpp`: keeps session-level type-checking cache promotion, but bases the comparison on `conversionCostCache.getCount()` because that is now the only cache payload.

## Concepts and vocabulary

- `BuiltinOperatorExpr`: the checked AST node produced by the builtin-operator fast path for supported builtin scalar/vector/matrix operators.
- `TypeCheckingCache`: linkage/session-shared semantic cache data. After this change it only caches basic conversion costs.
- `OverloadCandidate`: a candidate selected or ranked by fallback overload resolution. These objects can include linkage-local decl-ref/substitution state.
- `Linkage`: the per-session compilation context that previously copied cached overload candidates from a global session cache.

## Process report

The motivating input shape is a builtin operator on builtin scalar/vector/matrix operands, for example the operators exercised by `tests/language-feature/operator-overload/builtin-operator-fastpath.slang`. That shape is correct and principled, but its producer is now `SemanticsExprVisitor::convertToBuiltinArithmeticOp` in `source/slang/slang-check-expr.cpp`, which returns a `BuiltinOperatorExpr` before the expression reaches fallback overload resolution. Because the producer is now explicit, the fallback resolver no longer needs an extra cache that assumes core-module operator overloads are the common builtin path.

The removed `OperatorOverloadCacheKey` encoded an operator intrinsic plus up to two `BasicTypeKey` operands. That key existed to identify core-module builtin operator overloads after an `OperatorExpr` had already entered `SemanticsVisitor::ResolveInvoke`. With the builtin fast path in place, keeping that key would preserve a second, narrower representation of builtin operator dispatch. Deleting it from `source/slang/slang-check-impl.h` keeps one source of truth: builtin operators are handled by the fast-path AST node when eligible, while all other calls use normal overload resolution.

The removed `ResolvedOperatorOverload` stored an `OverloadCandidate` and a `Decl*`. The candidate portion is why `TypeCheckingCache::version` existed: an `OverloadCandidate` can carry linkage-local candidate state, so the old cache had to detect whether a cached candidate could be reused directly or reconstructed through `getOuterGenericOrSelf` in `ResolveInvoke`. Once the overload cache entries are gone, no remaining `TypeCheckingCache` value has that lifetime issue. `conversionCostCache` stores only `BasicTypeKeyPair` and `ConversionCost`, so there is no `DeclRef`, substitution set, or AST-builder-owned candidate to invalidate.

In `source/slang/slang-check-overload.cpp`, `SemanticsVisitor::ResolveInvoke` now proceeds directly from argument setup into the existing type-constructor special case and normal overload candidate collection. This is a cleanup, not a behavioral guard: there is no new input shape being accepted or rejected. User-defined operators, GLSL-specific operators, short-circuit logical operators, and other fallback cases still flow through the same overload machinery as before; they simply do not have a special cache shortcut.

In `source/slang/slang-session.cpp`, `Linkage::~Linkage` still promotes the best available type-checking cache back to the global session. The comparison now uses `conversionCostCache.getCount()` because that is the only remaining cache data. This keeps the surviving cache behavior while removing the obsolete overload-candidate version bump.

Validation performed locally:

- Built `slangc` Debug with VS 2026: `cmake --build build --config Debug --target slangc --verbose`.
- Ran `build\Debug\bin\slangc.exe tests\language-feature\overload-resolution.slang -target hlsl -stage compute -entry main -o NUL`.
- Ran `build\Debug\bin\slangc.exe tests\language-feature\overload-resolution-signed-unsigned.slang -target hlsl -stage compute -entry main -o NUL`.
- Ran `git diff --check`.