### PR TITLE
Diagnose unspecialized generic entry points instead of crashing (#10209)

### DIFF
--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -3395,6 +3395,21 @@ RefPtr<ComponentType> createSpecializedGlobalComponentType(EndToEndCompileReques
     return specializedProgram;
 }
 
+/// Diagnose an unspecialized generic entry point, reporting it against the
+/// entry-point function's source location.
+///
+/// A generic entry point is only legal if it is specialized with concrete
+/// generic arguments (via `-specialize` / `addEntryPointEx`). An
+/// *unspecialized* generic entry point cannot be lowered: it would produce an
+/// `IRGeneric` rather than an `IRFunc` and crash IR linking (issue #10209).
+static void diagnoseGenericEntryPoint(EntryPoint* entryPoint, DiagnosticSink* sink)
+{
+    auto funcDecl = entryPoint->getFuncDecl();
+    sink->diagnose(Diagnostics::EntryPointCannotBeGeneric{
+        .entryPoint = funcDecl->getName(),
+        .location = funcDecl->loc});
+}
+
 /// Create a specialized program based on the given compile request.
 ///
 /// The specialized program created here includes both the global
@@ -3470,6 +3485,25 @@ RefPtr<ComponentType> createSpecializedGlobalAndEntryPointsComponentType(
         auto unspecializedEntryPoint =
             unspecializedGlobalAndEntryPointsComponentType->getEntryPoint(ii);
 
+        // A generic entry point must have concrete generic arguments. They can
+        // arrive either bound into the entry-point name (`-entry foo<int>`,
+        // reflected in the func declRef) or as separate specialization-arg
+        // strings (`-specialize`/`addEntryPointEx`, applied below by
+        // `createSpecializedEntryPoint`). If neither is present, the generic is
+        // unspecialized and would lower to an `IRGeneric` rather than an
+        // `IRFunc`, crashing IR linking (issue #10209); reject it here.
+        //
+        // `isSpecialized` walks the whole enclosing decl chain and compares the
+        // declRef's generic args against the defaults, so it correctly accepts
+        // name-bound args (and nested-generic entry points) while still flagging
+        // a genuinely unbound generic.
+        if (!endToEndReq->getLinkage()->isSpecialized(unspecializedEntryPoint->getFuncDeclRef()) &&
+            entryPointInfo.specializationArgStrings.getCount() == 0)
+        {
+            diagnoseGenericEntryPoint(unspecializedEntryPoint, endToEndReq->getSink());
+            continue;
+        }
+
         auto specializedEntryPoint =
             createSpecializedEntryPoint(endToEndReq, unspecializedEntryPoint, entryPointInfo);
         allComponentTypes.add(specializedEntryPoint);
@@ -3492,9 +3526,26 @@ RefPtr<ComponentType> createSpecializedGlobalAndEntryPointsComponentType(
     {
         auto unspecializedEntryPoint =
             unspecializedGlobalAndEntryPointsComponentType->getEntryPoint(ii);
+
+        // These entry points (e.g. discovered via `[shader(...)]`) carry no
+        // specialization arguments, so an unspecialized generic one can never be
+        // specialized and must be rejected (#10209). `isSpecialized` is false
+        // only when the generic args are still the defaults (a discovered
+        // `[shader]` entry point can't bind args via its name either).
+        if (!endToEndReq->getLinkage()->isSpecialized(unspecializedEntryPoint->getFuncDeclRef()))
+        {
+            diagnoseGenericEntryPoint(unspecializedEntryPoint, endToEndReq->getSink());
+            continue;
+        }
+
         allComponentTypes.add(unspecializedEntryPoint);
         outSpecializedEntryPoints.add(unspecializedEntryPoint);
     }
+
+    // Bail out if rejecting a generic entry point above raised an error,
+    // rather than composing a program with a missing entry point.
+    if (endToEndReq->getSink()->getErrorCount() != 0)
+        return nullptr;
 
     RefPtr<ComponentType> composed =
         CompositeComponentType::create(endToEndReq->getLinkage(), allComponentTypes);

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -4059,6 +4059,13 @@ err(
     span { loc = "location", message = "entry point '~entryPoint:Name' cannot return array type '~returnType:Type'" }
 )
 
+err(
+    "entry-point-cannot-be-generic",
+    38014,
+    "generic entry point used without specialization arguments",
+    span { loc = "location", message = "generic entry point '~entryPoint:Name' must be specialized with concrete generic arguments (e.g. via '-specialize' or 'addEntryPointEx'); an unspecialized generic entry point cannot be compiled" }
+)
+
 
 -- Load semantic checking diagnostics (part 10) - Interface Requirements, Global Generics, Differentiation, Modules
 -- (inlined from slang-diagnostics-semantic-checking-10.lua)

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -503,8 +503,15 @@ bool Linkage::isSpecialized(DeclRef<Decl> declRef)
         return true; // no generics => always specialized
 
     auto defaultArgs = getDefaultSubstitutionArgs(getASTBuilder(), &visitor, as<GenericDecl>(decl));
-    auto currentArgs =
-        SubstitutionSet(declRef).findGenericAppDeclRef(as<GenericDecl>(decl))->getArgs();
+
+    // If the declRef carries no generic-application substitution for this
+    // generic at all (e.g. a bare reference to a generic entry point discovered
+    // via `[shader(...)]`), then nothing has been substituted, so it is
+    // unspecialized.
+    auto genericAppDeclRef = SubstitutionSet(declRef).findGenericAppDeclRef(as<GenericDecl>(decl));
+    if (!genericAppDeclRef)
+        return false;
+    auto currentArgs = genericAppDeclRef->getArgs();
 
     if (defaultArgs.getCount() != currentArgs.getCount()) // should really never happen.
         return true;

--- a/tests/diagnostics/entry-point-generic.slang
+++ b/tests/diagnostics/entry-point-generic.slang
@@ -1,0 +1,42 @@
+// Regression test for issue #10209: an *unspecialized* generic entry point
+// used to crash the compiler at IR link time ("expected entry point to be a
+// function") because it lowered to an IRGeneric instead of an IRFunc. It must
+// now be rejected with a clear diagnostic (E38014).
+//
+// A generic entry point that *is* specialized stays valid; those paths are
+// covered elsewhere:
+//   - `-specialize` args:        tests/front-end/generic-workgroup-size.slang
+//   - generic args in the name:  tests/fp-denormal-mode/denorm-mode-generic.slang
+//                                (`-entry "genericEntry<float>"`)
+// The rejection here fires only when the generic is left *unspecialized*.
+//
+// Two directives cover both rejection paths in
+// createSpecializedGlobalAndEntryPointsComponentType: the first lists the
+// entry point explicitly (`-entry main`), exercising the specified-entry-point
+// loop; the second omits `-entry` so `main` is discovered solely via its
+// `[shader("compute")]` attribute, exercising the found-entry-point loop.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target spirv -entry main -stage compute
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target spirv
+
+static T scale_sample<T>(Texture3D<T> texture, int32_t3 coord)
+    where T : ITexelElement, IFloat
+{
+    let value = texture.Load(int32_t4(coord, 0));
+    return value * T(0.1F);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main<T>(
+/*CHECK:
+     ^^^^ E38014
+     ^^^^ generic entry point 'main' must be specialized with concrete generic arguments
+*/
+    uint32_t3 id : SV_DispatchThreadID,
+    Texture3D<T> inputTexture,
+    WTexture3D<T> outputTexture) where T : ITexelElement, IFloat
+{
+    let scaled = scale_sample<T>(inputTexture, int32_t3(0, 0, 0));
+    outputTexture.Store(id, scaled);
+}


### PR DESCRIPTION
An *unspecialized* generic entry point like `void main<T>(...)` crashed at IR link time (`expected entry point to be a function`) because it lowers to an `IRGeneric` rather than an `IRFunc`.

A generic entry point that supplies concrete arguments stays valid, via any of: generic args bound in the entry-point name (`-entry "foo<int>"`), `-specialize` args, or `addEntryPointEx`. The rejection must fire only when the generic is left genuinely unspecialized. `createSpecializedGlobalAndEntryPointsComponentType` now uses `Linkage::isSpecialized(funcDeclRef)` (which compares the declRef's generic args against the defaults and walks the whole enclosing decl chain) together with the presence of specialization-arg strings to decide, and diagnoses E38014 only for the unspecialized case — covering both the explicitly-specified (`-entry`) and `[shader]`-discovered entry-point paths.

Also hardens `Linkage::isSpecialized` against a null-deref: a bare reference to a generic with no generic-application substitution (e.g. a `[shader]`-discovered generic entry point) is now reported as unspecialized instead of crashing.

Fixes #10209.