### PR TITLE
Add regression test for private cross-module constructor (#7152)

### DIFF
--- a/tests/diagnostics/private-init-cross-module-helper.slang
+++ b/tests/diagnostics/private-init-cross-module-helper.slang
@@ -1,0 +1,19 @@
+//TEST_IGNORE_FILE:
+
+module "private-init-cross-module-helper";
+
+public struct B
+{
+    // A single-parameter constructor with default (internal) visibility. This
+    // matches the reproducer in issue #7152: calling it across a module
+    // boundary used to crash the compiler; it must now produce an
+    // accessibility diagnostic instead.
+    __init(float b) {}
+}
+
+public struct C
+{
+    // The same shape with an *explicit* `private` modifier, to also cover the
+    // explicit-visibility resolution path.
+    private __init(float b) {}
+}

--- a/tests/diagnostics/private-init-cross-module.slang
+++ b/tests/diagnostics/private-init-cross-module.slang
@@ -1,0 +1,28 @@
+// Regression test for issue #7152: calling an inaccessible single-parameter
+// constructor of a struct defined in a separate module used to segfault.
+// It must now report an accessibility error rather than crash.
+//
+// `B` uses the implicit (internal) default visibility — matching the issue's
+// reproducer — and `C` uses an explicit `private` modifier, so both
+// visibility-resolution paths are covered.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target spirv
+
+import "private-init-cross-module-helper";
+
+[shader("vertex")]
+float4 foo() : SV_Position
+{
+    B bar = B(0.0);
+//CHECK:     ^ declaration not accessible
+//CHECK:     ^ 'B.init' is not accessible from the current context.
+//CHECK:      ^ type mismatch in expression
+//CHECK:      ^ expected an expression of type 'B', got 'float'
+
+    C baz = C(0.0);
+//CHECK:     ^ declaration not accessible
+//CHECK:     ^ 'C.init' is not accessible from the current context.
+//CHECK:      ^ type mismatch in expression
+//CHECK:      ^ expected an expression of type 'C', got 'float'
+    return float4(1, 1, 1, 1);
+}


### PR DESCRIPTION
Calling a private single-parameter constructor of a struct defined in a separate module used to segfault; it now reports an accessibility error. Adds a regression test, with the struct in an imported module to exercise the cross-module path that originally crashed.

Fixes #7152.