### PR TITLE
Fix shader-coverage demo launch on Windows

### DIFF
--- a/examples/shader-coverage-bvh-traversal/run_coverage.py
+++ b/examples/shader-coverage-bvh-traversal/run_coverage.py
@@ -69,6 +69,9 @@ def _candidate_paths(slang_root: Path) -> list:
         # Windows .exe variants (multi-config)
         *(slang_root / "build" / "examples" / _TARGET / config / (_TARGET + ".exe")
           for config in ("Release", "Debug", "RelWithDebInfo")),
+        # Windows .exe variants (single-config)
+        *(slang_root / "build" / config / "examples" / _TARGET / (_TARGET + ".exe")
+          for config in ("Release", "Debug", "RelWithDebInfo")),
     ]
 
 
@@ -184,7 +187,21 @@ def main(argv=None):
     binary_cmd = [str(binary), f"--mode={mode}",
                   f"--output-dir={output_dir}", *demo_args]
     print(f"[1/3] running demo: {' '.join(str(a) for a in binary_cmd)}")
-    result = subprocess.run(binary_cmd)
+    # On Windows the runtime DLLs (slang.dll etc.) live in
+    # <build-root>/<config>/bin/, not next to the demo exe. Prepend that
+    # directory to PATH so the loader finds them (otherwise STATUS_DLL_NOT_FOUND).
+    # Multi-config layout: exe at <build>/examples/<target>/<config>/<exe>
+    # Single-config layout: exe at <build>/<config>/examples/<target>/<exe>
+    # In both cases binary.parents[3] is the build root and the config name
+    # sits one level above the exe (multi) or two levels above (single).
+    _WIN_CONFIGS = {"Release", "Debug", "RelWithDebInfo"}
+    demo_env = os.environ.copy()
+    if platform.system() == "Windows" and len(binary.parents) >= 4:
+        config = (binary.parent.name if binary.parent.name in _WIN_CONFIGS
+                  else binary.parents[2].name)
+        dll_dir = binary.parents[3] / config / "bin"
+        demo_env["PATH"] = str(dll_dir) + os.pathsep + demo_env.get("PATH", "")
+    result = subprocess.run(binary_cmd, env=demo_env)
     if result.returncode != 0:
         sys.exit(f"error: demo exited with code {result.returncode}")
 

--- a/examples/shader-coverage-image-pipeline/run_coverage.py
+++ b/examples/shader-coverage-image-pipeline/run_coverage.py
@@ -69,6 +69,9 @@ def _candidate_paths(slang_root: Path) -> list:
         # Windows .exe variants (multi-config)
         *(slang_root / "build" / "examples" / _TARGET / config / (_TARGET + ".exe")
           for config in ("Release", "Debug", "RelWithDebInfo")),
+        # Windows .exe variants (single-config)
+        *(slang_root / "build" / config / "examples" / _TARGET / (_TARGET + ".exe")
+          for config in ("Release", "Debug", "RelWithDebInfo")),
     ]
 
 
@@ -193,7 +196,21 @@ def main(argv=None):
     binary_cmd = [str(binary), f"--mode={mode}",
                   f"--output-dir={output_dir}", *demo_args]
     print(f"[1/2] running demo: {' '.join(str(a) for a in binary_cmd)}")
-    result = subprocess.run(binary_cmd)
+    # On Windows the runtime DLLs (slang.dll etc.) live in
+    # <build-root>/<config>/bin/, not next to the demo exe. Prepend that
+    # directory to PATH so the loader finds them (otherwise STATUS_DLL_NOT_FOUND).
+    # Multi-config layout: exe at <build>/examples/<target>/<config>/<exe>
+    # Single-config layout: exe at <build>/<config>/examples/<target>/<exe>
+    # In both cases binary.parents[3] is the build root and the config name
+    # sits one level above the exe (multi) or two levels above (single).
+    _WIN_CONFIGS = {"Release", "Debug", "RelWithDebInfo"}
+    demo_env = os.environ.copy()
+    if platform.system() == "Windows" and len(binary.parents) >= 4:
+        config = (binary.parent.name if binary.parent.name in _WIN_CONFIGS
+                  else binary.parents[2].name)
+        dll_dir = binary.parents[3] / config / "bin"
+        demo_env["PATH"] = str(dll_dir) + os.pathsep + demo_env.get("PATH", "")
+    result = subprocess.run(binary_cmd, env=demo_env)
     if result.returncode != 0:
         sys.exit(f"error: demo exited with code {result.returncode}")
 


### PR DESCRIPTION
## Motivation

`run_coverage.py` in both shader-coverage demos fails on Windows because
the demo `.exe` lives in `build/examples/<target>/<config>/` but the
Slang runtime DLLs (`slang.dll`, etc.) live in `build/<config>/bin/`.
The Windows loader only searches the exe's own directory, so the process
aborts immediately with `STATUS_DLL_NOT_FOUND` (0xC0000135).

## Changes

Prepend the runtime DLL directory to the child process `PATH` before
launching the demo binary. The directory is derived from the already-known
binary path and handles both CMake generator layouts:

```python
_WIN_CONFIGS = {"Release", "Debug", "RelWithDebInfo"}
demo_env = os.environ.copy()
if platform.system() == "Windows" and len(binary.parents) >= 4:
    config = (binary.parent.name if binary.parent.name in _WIN_CONFIGS
              else binary.parents[2].name)
    dll_dir = binary.parents[3] / config / "bin"
    demo_env["PATH"] = str(dll_dir) + os.pathsep + demo_env.get("PATH", "")
result = subprocess.run(binary_cmd, env=demo_env)
```

- **Multi-config** (Ninja Multi-Config / Visual Studio): exe at
  `<build>/examples/<target>/<config>/<exe>` — config = `binary.parent.name`.
- **Single-config** (plain Ninja / Makefiles): exe at
  `<build>/<config>/examples/<target>/<exe>` — config = `binary.parents[2].name`.
- In both cases `binary.parents[3]` is the build root and the DLL directory
  is `<build-root>/<config>/bin/`.
- No change on POSIX — `rpath` handles DLL resolution there.

Both `examples/shader-coverage-bvh-traversal/run_coverage.py` and
`examples/shader-coverage-image-pipeline/run_coverage.py` receive the
same fix.