### PR TITLE
coverage CI: mark SlangcCoverageManifestOutput as expected failure on macOS

### DIFF
--- a/tests/expected-failure-coverage.txt
+++ b/tests/expected-failure-coverage.txt
@@ -25,3 +25,12 @@
 # escalates that failure into a SIGSEGV inside the slang-test
 # orchestrator, which kills the rest of the suite.
 docs/generated/tests/design/ir-reference/metadata/unorm-attr-on-buffer-element.slang
+
+# Coverage metadata is not propagated from the upstream Slang IR artifact
+# through the Metal downstream compilation chain (xcrun metallib-asm path),
+# so _maybeWriteCoverageManifest finds no ICoverageTracingMetadata on the
+# final artifact and writes no manifest file. The two MetalLib sub-checks
+# inside this unit test therefore always fail on macOS coverage CI where the
+# Metal toolchain is present. Tracked in: https://github.com/shader-slang/slang/issues/11629
+# On non-Apple CI the sub-checks are skipped via _isMetalLibDownstreamUnavailable.
+slang-unit-test-tool/SlangcCoverageManifestOutput.internal


### PR DESCRIPTION
## Motivation

`slang-unit-test-tool/SlangcCoverageManifestOutput.internal` has been failing on the macOS coverage nightly runner (https://github.com/shader-slang/slang/actions/runs/27591487109/job/81572949146) since the runner gained a Metal toolchain. PR #11610 loosened the manifest content check but did not fix the root cause: coverage metadata (`ICoverageTracingMetadata`) is not propagated through the Metal downstream compilation chain, so `_maybeWriteCoverageManifest` finds no metadata on the final artifact and writes no file at all. The manifest-content check never runs.

On non-Apple CI the two MetalLib sub-checks skip cleanly via `_isMetalLibDownstreamUnavailable`, so the test appeared to pass everywhere before the nightly.

## Proposed solution

Add the unit test to `tests/expected-failure-coverage.txt` so the nightly classifies the known failure as expected rather than breaking the run. The underlying compiler issue (metadata propagation through downstream compilation) is tracked in #11629.

## Change summary

| File | Change |
|---|---|
| `tests/expected-failure-coverage.txt` | Add `slang-unit-test-tool/SlangcCoverageManifestOutput.internal` with a comment linking to #11629 |

## Process report

No code change. The expected-failure entry uses the same `-expected-failure-list` mechanism already in place for other coverage-only skips. The entry is scoped to this file (consumed only by the coverage CI workflow) and does not affect regular CI.