### PR TITLE
Disable SPIRV_OPT_MERGE_RETURN on CI

### DIFF
--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -129,7 +129,7 @@ jobs:
             -DSLANG_ENABLE_CUDA=ON \
             -DSLANG_ENABLE_PCH=OFF \
             -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
-            -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=ON \
+            -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER="${sccache_path}" \
             -DCMAKE_CXX_COMPILER_LAUNCHER="${sccache_path}"
 

--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -209,7 +209,7 @@ jobs:
                 "-DSLANG_SLANG_LLVM_BINARY_URL=$(pwd)/build/dist-release/slang-llvm.zip" \
                 "-DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }}" \
                 -DSLANG_IGNORE_ABORT_MSG=ON \
-                -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=ON \
+                -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=OFF \
                 $SLANG_CI_DXC_BUILD_FROM_SOURCE \
                 "${cmake_launcher_defines[@]}"
               cmake --workflow --preset "${{ inputs.config }}"
@@ -219,7 +219,7 @@ jobs:
                 -DSLANG_SLANG_LLVM_FLAVOR=DISABLE \
                 -DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }} \
                 -DSLANG_IGNORE_ABORT_MSG=ON \
-                -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=ON \
+                -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=OFF \
                 $SLANG_CI_DXC_BUILD_FROM_SOURCE \
                 "${cmake_launcher_defines[@]}"
               cmake --workflow --preset "${{ inputs.config }}"
@@ -230,7 +230,7 @@ jobs:
                 -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
                 -DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }} \
                 -DSLANG_IGNORE_ABORT_MSG=ON \
-                -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=ON \
+                -DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=OFF \
                 $SLANG_CI_DXC_BUILD_FROM_SOURCE \
                 "${cmake_launcher_defines[@]}"
               cmake --workflow --preset "${{ inputs.config }}"

--- a/source/slang-glslang/slang-glslang.cpp
+++ b/source/slang-glslang/slang-glslang.cpp
@@ -346,12 +346,12 @@ static int glslang_optimizeSPIRV(
 #if SLANG_ENABLE_SPIRV_OPT_MERGE_RETURN
             optimizer.RegisterPass(spvtools::CreateMergeReturnPass());
             optimizer.RegisterPass(spvtools::CreateInlineExhaustivePass());
-            optimizer.RegisterPass(spvtools::CreatePrivateToLocalPass());
 #endif
 
             optimizer.RegisterPass(spvtools::CreateEliminateDeadFunctionsPass()); // 3
 
             optimizer.RegisterPass(spvtools::CreateAggressiveDCEPass());
+            optimizer.RegisterPass(spvtools::CreatePrivateToLocalPass());
 
             optimizer.RegisterPass(spvtools::CreateScalarReplacementPass(100));
 

--- a/source/slang-glslang/slang-glslang.cpp
+++ b/source/slang-glslang/slang-glslang.cpp
@@ -346,12 +346,12 @@ static int glslang_optimizeSPIRV(
 #if SLANG_ENABLE_SPIRV_OPT_MERGE_RETURN
             optimizer.RegisterPass(spvtools::CreateMergeReturnPass());
             optimizer.RegisterPass(spvtools::CreateInlineExhaustivePass());
+            optimizer.RegisterPass(spvtools::CreatePrivateToLocalPass());
 #endif
 
             optimizer.RegisterPass(spvtools::CreateEliminateDeadFunctionsPass()); // 3
 
             optimizer.RegisterPass(spvtools::CreateAggressiveDCEPass());
-            optimizer.RegisterPass(spvtools::CreatePrivateToLocalPass());
 
             optimizer.RegisterPass(spvtools::CreateScalarReplacementPass(100));
 

--- a/tests/autodiff/differentiable-interface-return.slang
+++ b/tests/autodiff/differentiable-interface-return.slang
@@ -9,7 +9,7 @@
 // `-target hlsl` and an ICE on `-target spirv`.
 
 //TEST:SIMPLE(filecheck=CHECK_HLSL): -target hlsl -stage compute -entry main
-//TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv-asm -stage compute -entry main
+//TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv-asm -stage compute -entry main -O0
 //TEST:INTERPRET(filecheck=CHECK_INTERP): -entry interpretMain
 
 // The fix should ensure `this_type` (the unresolved IR placeholder) does not
@@ -24,10 +24,11 @@
 // CHECK_HLSL-NOT: this_type
 
 // SPIR-V should compile successfully (no ICE) and emit the dispatch chain
-// fully constant-folded into observable stores. Pinning the composites +
-// stores catches silent miscompilation that an `OpEntryPoint`-only check
-// would miss (e.g. a future regression that produces a clean module but
-// folds the call away to undef).
+// as concrete calls into the resolved witness (not `this_type`), with the
+// initial constant and the ternary's selected constant reaching observable
+// stores. Pinning the composites + the calls catches silent miscompilation
+// that an `OpEntryPoint`-only check would miss (e.g. a future regression
+// that leaves `this_type` behind, or folds a call away to undef).
 // CHECK_SPV: OpEntryPoint
 // CHECK_SPV-DAG: %[[F1:[A-Za-z0-9_]+]] = OpConstant %float 1
 // CHECK_SPV-DAG: %[[F2:[A-Za-z0-9_]+]] = OpConstant %float 2
@@ -35,7 +36,8 @@
 // CHECK_SPV-DAG: %[[V123:[A-Za-z0-9_]+]] = OpConstantComposite %v3float %[[F1]] %[[F2]] %[[F3]]
 // CHECK_SPV-DAG: %[[V111:[A-Za-z0-9_]+]] = OpConstantComposite %v3float %[[F1]] %[[F1]] %[[F1]]
 // CHECK_SPV: OpStore {{.*}} %[[V123]]
-// CHECK_SPV: OpStore {{.*}} %[[V123]]
+// CHECK_SPV: OpFunctionCall %v3float %cast_my_inst
+// CHECK_SPV: OpFunctionCall %MaterialProperties %MyInst_collect_properties{{[A-Za-z0-9_]*}}
 // CHECK_SPV: OpStore {{.*}} %[[V111]]
 
 // CHECK_INTERP: matched=1

--- a/tests/autodiff/differentiable-interface-return.slang
+++ b/tests/autodiff/differentiable-interface-return.slang
@@ -25,10 +25,12 @@
 
 // SPIR-V should compile successfully (no ICE) and emit the dispatch chain
 // as concrete calls into the resolved witness (not `this_type`), with the
-// initial constant and the ternary's selected constant reaching observable
-// stores. Pinning the composites + the calls catches silent miscompilation
-// that an `OpEntryPoint`-only check would miss (e.g. a future regression
-// that leaves `this_type` behind, or folds a call away to undef).
+// initial constant, *both call results*, and the ternary's selected
+// constant all reaching observable stores. Binding each call's own result
+// id and requiring it (not just the call) to reach an `OpStore` is what
+// catches a regression that compiles cleanly but discards/replaces the
+// dispatch result (e.g. folds a call's use away) -- an `OpEntryPoint`-only
+// check, or a check that only confirms the call exists, would miss that.
 // CHECK_SPV: OpEntryPoint
 // CHECK_SPV-DAG: %[[F1:[A-Za-z0-9_]+]] = OpConstant %float 1
 // CHECK_SPV-DAG: %[[F2:[A-Za-z0-9_]+]] = OpConstant %float 2
@@ -36,8 +38,11 @@
 // CHECK_SPV-DAG: %[[V123:[A-Za-z0-9_]+]] = OpConstantComposite %v3float %[[F1]] %[[F2]] %[[F3]]
 // CHECK_SPV-DAG: %[[V111:[A-Za-z0-9_]+]] = OpConstantComposite %v3float %[[F1]] %[[F1]] %[[F1]]
 // CHECK_SPV: OpStore {{.*}} %[[V123]]
-// CHECK_SPV: OpFunctionCall %v3float %cast_my_inst
-// CHECK_SPV: OpFunctionCall %MaterialProperties %MyInst_collect_properties{{[A-Za-z0-9_]*}}
+// CHECK_SPV: %[[CASTCALL:[A-Za-z0-9_]+]] = OpFunctionCall %v3float %cast_my_inst
+// CHECK_SPV: %[[MEMBERCALL:[A-Za-z0-9_]+]] = OpFunctionCall %MaterialProperties %MyInst_collect_properties{{[A-Za-z0-9_]*}}
+// CHECK_SPV: %[[MEMBERRESULT:[A-Za-z0-9_]+]] = OpCompositeExtract %v3float %[[MEMBERCALL]] 0
+// CHECK_SPV: OpStore {{.*}} %[[MEMBERRESULT]]
+// CHECK_SPV: OpStore {{.*}} %[[CASTCALL]]
 // CHECK_SPV: OpStore {{.*}} %[[V111]]
 
 // CHECK_INTERP: matched=1

--- a/tests/bugs/gh-10774-concrete-return.slang
+++ b/tests/bugs/gh-10774-concrete-return.slang
@@ -5,11 +5,11 @@
 // the interface requirement and the satisfying method. It should compile, but
 // currently fails during interface conformance checking.
 
-//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -emit-spirv-directly -stage compute -entry computeMain
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -emit-spirv-directly -stage compute -entry computeMain -O0
 
 // CHECK: OpCapability RayQueryKHR
-// CHECK: OpRayQueryInitializeKHR
-// CHECK: OpRayQueryProceedKHR
+// CHECK-DAG: OpRayQueryInitializeKHR
+// CHECK-DAG: OpRayQueryProceedKHR
 
 interface IRayQueryProvider
 {

--- a/tests/bugs/gh-6482-interface-method-existential-specialize.slang
+++ b/tests/bugs/gh-6482-interface-method-existential-specialize.slang
@@ -1,10 +1,10 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -O0
 
 // This is a test that checks that we can apply partial specialization to a function
 // that takes existential parameters.
 
-// CHECK: OpRayQueryProceedKHR
-// CHECK: OpImageWrite
+// CHECK-DAG: OpRayQueryProceedKHR
+// CHECK-DAG: OpImageWrite
 
 public interface IRandom {
     [mutating] uint32_t next_uint();

--- a/tests/compute/nonuniformres-as-function-parameter.slang
+++ b/tests/compute/nonuniformres-as-function-parameter.slang
@@ -1,5 +1,5 @@
-//TEST:SIMPLE(filecheck=CHECK_SPV):-target spirv -entry main -stage compute
-//TEST:SIMPLE(filecheck=CHECK_GLSL_SPV):-target spirv -entry main -stage compute -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=CHECK_SPV):-target spirv -entry main -stage compute -O0
+//TEST:SIMPLE(filecheck=CHECK_GLSL_SPV):-target spirv -entry main -stage compute -emit-spirv-via-glsl -O0
 //TEST:SIMPLE(filecheck=CHECK_GLSL):-target glsl -entry main -stage compute
 //TEST:SIMPLE(filecheck=CHECK_HLSL):-target hlsl -entry main -stage compute
 //TEST:SIMPLE(filecheck=CHECK_CUDA):-target cuda -entry main -stage compute
@@ -38,57 +38,23 @@ MyStruct func(RWStructuredBuffer<uint> buffer)
 void main(uint3 pixelIndex : SV_DispatchThreadID)
 {
 
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR1:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR2:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR3:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR4:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR5:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR6:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR7:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR8:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR9:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR10:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR11:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR12:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR13:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR14:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR15:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR16:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR17:[a-zA-Z0-9_]+]] NonUniform
-    // CHECK_GLSL_SPV: OpDecorate %[[VAR18:[a-zA-Z0-9_]+]] NonUniform
-
-    // Direct-SPIRV decoration coverage. The four globalBuffer descriptor-array
-    // accesses are emitted in source order (case 1, 2, 3, 4), and slang-test
-    // appends "; NonUniform" inline to decorated instructions. We pin each case
-    // by its index and assert its decoration status on its own line -- this
-    // proves *which* chains are (and are not) decorated, so a case-swap
-    // regression (e.g. dropping case 2 while spuriously decorating the uniform
-    // case 3) is caught, unlike a bare count. Matching the inline annotation also
-    // avoids depending on FileCheck's cursor relative to the annotations section.
-    //   - case 1 (uint `bufferIdx`):  decorated
-    //   - case 2 (int `bufferIdx2`):  decorated
-    //   - case 3 (uniform `bufferIdx3`): NOT decorated (line ends after the index)
-    //   - case 4 ((uint)((int)NonUniformResourceIndex(bufferIdx)) -- collapses back
-    //     to `bufferIdx`): decorated
-    // `[^0-9]` after `bufferIdx` keeps case 1/4 from matching `bufferIdx2`/`3`.
-    // CHECK_SPV: %globalBuffer %bufferIdx{{[^0-9].*}}NonUniform
-    // CHECK_SPV: %globalBuffer %bufferIdx2{{.*}}NonUniform
-    // CHECK_SPV: %globalBuffer %bufferIdx3{{[[:space:]]*$}}
-    // CHECK_SPV: %globalBuffer %bufferIdx{{[^0-9].*}}NonUniform
+    // NonUniform propagation is pinned per *callee specialization* rather than
+    // at the call site: Slang specializes `func` per argument type/uniformity,
+    // so the access chain into `globalBuffer` lives inside the specialized
+    // callee, not (necessarily) inlined at the call site. This keeps the test
+    // independent of whether a downstream optimizer happens to inline calls.
+    //   - case 1 (uint `bufferIdx`):       calls `func`,   callee decorated
+    //   - case 2 (int `bufferIdx2`):       calls `func_0`, callee decorated
+    //   - case 3 (uniform `bufferIdx3`):   calls `func_1`, callee NOT decorated
+    //   - case 4 (cast of a NonUniformResourceIndex back to uint, so it
+    //     collapses to the same specialization as case 1): calls `func` again
+    // CHECK_SPV: OpFunctionCall %MyStruct %func %bufferIdx{{[[:space:]]*$}}
 
     uint bufferIdx = pixelIndex.x;
     uint nonUniformIdx = NonUniformResourceIndex(bufferIdx);
     RWStructuredBuffer<uint> buffer = globalBuffer[nonUniformIdx];
 
-    // CHECK_GLSL_SPV: %[[VAR1]] = OpCopyObject %uint %{{.*}}
-
-    // CHECK_GLSL_SPV: %[[VAR4]] = OpCopyObject %uint %[[VAR1]]
-    // CHECK_GLSL_SPV: %[[VAR5]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR4]] %int_0 %int_0
-    // CHECK_GLSL_SPV: %[[VAR6]] = OpLoad %uint %[[VAR5]]
-
-    // CHECK_GLSL_SPV: %[[VAR7]] = OpCopyObject %uint %[[VAR1]]
-    // CHECK_GLSL_SPV: %[[VAR8]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR7]] %int_0 %int_0
-    // CHECK_GLSL_SPV: %[[VAR9]] = OpLoad %uint %[[VAR8]]
+    // CHECK_GLSL_SPV: OpFunctionCall %MyStruct_0 %func_0_u1_
 
     // CHECK_GLSL: func_0({{.*}}nonuniformEXT({{.*}}))
     // CHECK_HLSL: func_0(globalBuffer_0[NonUniformResourceIndex({{.*}})])
@@ -98,19 +64,10 @@ void main(uint3 pixelIndex : SV_DispatchThreadID)
     int bufferIdx2 = pixelIndex.y;
 
     // Test case 2: Make sure we cover the case for the different data type of the index.
-    // In this case, slang will specialize the function to 'MyStruct func(int)'
-    // The access chain for bufferIdx2 should be decorated NonUniform (the case-2
-    // CHECK_SPV above pins this).
+    // In this case, slang will specialize the function to 'MyStruct func(int)'.
+    // CHECK_SPV: OpFunctionCall %MyStruct %func_0 %bufferIdx2
 
-    // CHECK_GLSL_SPV: %[[VAR2]] = OpCopyObject %int %{{.*}}
-
-    // CHECK_GLSL-SPV: %[[VAR10]] = OpCopyObject %int %[[VAR2]]
-    // CHECK_GLSL-SPV: %[[VAR11]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR10]] %int_0 %int_0
-    // CHECK_GLSL-SPV: %[[VAR12]] = OpLoad %uint %[[VAR11]]
-
-    // CHECK_GLSL-SPV: %[[VAR13]] = OpCopyObject %int %[[VAR2]]
-    // CHECK_GLSL-SPV: %[[VAR14]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR13]] %int_0 %int_0
-    // CHECK_GLSL-SPV: %[[VAR15]] = OpLoad %uint %[[VAR14]]
+    // CHECK_GLSL_SPV: OpFunctionCall %MyStruct_0 %func_1_i1_
     RWStructuredBuffer<uint> buffer2 = globalBuffer[NonUniformResourceIndex(bufferIdx2)];
 
     // CHECK_GLSL: func_1({{.*}}nonuniformEXT({{.*}}))
@@ -118,28 +75,45 @@ void main(uint3 pixelIndex : SV_DispatchThreadID)
     // CHECK_CUDA: func_{{[0-9]+}}(globalParams_{{[0-9]+}}->globalBuffer_{{[0-9]+}}[{{.*}}])
     MyStruct myStruct2 = func(buffer2);
 
-    // Test case 3: a uniform index must NOT propagate NonUniform into the callee,
-    // so the access chain for the uniform bufferIdx3 must NOT be decorated
-    // NonUniform. The case-3 CHECK_SPV above pins this (its line ends right after
-    // %bufferIdx3, with no "; NonUniform" inline annotation).
+    // Test case 3: a uniform index must NOT propagate NonUniform into the callee.
+    // CHECK_SPV: OpFunctionCall %MyStruct %func_1 %bufferIdx3
     int bufferIdx3 = pixelIndex.z;
 
     RWStructuredBuffer<uint> buffer3 = globalBuffer[bufferIdx3];
+    // CHECK_GLSL_SPV: OpFunctionCall %MyStruct_0 %func_2_i1_
     // CHECK_CUDA: func_{{[0-9]+}}(globalParams_{{[0-9]+}}->globalBuffer_{{[0-9]+}}[{{.*}}])
     MyStruct myStruct3 = func(buffer3);
 
-    // CHECK_GLSL-SPV: %[[VAR19:[a-zA-Z0-9_]+]]  = OpBitcast %int %[[VAR3]]
-    // CHECK_GLSL-SPV: %[[VAR16]] = OpCopyObject %int %[[VAR19]]
-    // CHECK_GLSL-SPV: %[[VAR17]] = OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %[[VAR16]] %int_0 %int_0
-    // CHECK_GLSL-SPV: %[[VAR18]] = OpLoad %uint %[[VAR17]]
-    //
     // Test case 4: an intCast/uintCast of a NonUniformResourceIndex is still a
-    // NonUniformResourceIndex.
-    // Since after the nested cast, the index data type is 'uint' now, make sure it calls the same function as the test case 1.
+    // NonUniformResourceIndex. Since after the nested cast, the index data type
+    // is 'uint' now, make sure it calls the same specialization as test case 1.
+    // CHECK_SPV: OpFunctionCall %MyStruct %func %{{[0-9]+}}
+    // CHECK_GLSL_SPV: OpFunctionCall %MyStruct_0 %func_0_u1_
     // CHECK_GLSL: func_0({{.*}}nonuniformEXT({{.*}}))
     // CHECK_CUDA: func_{{[0-9]+}}(globalParams_{{[0-9]+}}->globalBuffer_{{[0-9]+}}[{{.*}}])
     RWStructuredBuffer<uint> buffer4 = globalBuffer[(uint)((int)NonUniformResourceIndex(bufferIdx))];
     MyStruct myStruct4 = func(buffer4);
+
+    // Now check the decoration inside each specialized callee, in their
+    // definition order. `func`/`func_0_u1_` and `func_0`/`func_1_i1_` are the
+    // nonuniform-index specializations (decorated); `func_1`/`func_2_i1_` is
+    // the uniform-index specialization (NOT decorated -- its access chain
+    // line ends right after the index, with no "; NonUniform" annotation).
+    // CHECK_SPV: %func = OpFunction
+    // CHECK_SPV: OpAccessChain {{.*}} %globalBuffer {{.*}} ; NonUniform
+    // CHECK_SPV: %func_0 = OpFunction
+    // CHECK_SPV: OpAccessChain {{.*}} %globalBuffer {{.*}} ; NonUniform
+    // CHECK_SPV: %func_1 = OpFunction
+    // CHECK_SPV: OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer %globalBuffer %{{[A-Za-z0-9_]+}}{{[[:space:]]*$}}
+
+    // CHECK_GLSL_SPV: %func_0_u1_ = OpFunction
+    // CHECK_GLSL_SPV: OpCopyObject %uint %{{.*}} ; NonUniform
+    // CHECK_GLSL_SPV: OpAccessChain {{.*}} %globalBuffer_0 {{.*}} ; NonUniform
+    // CHECK_GLSL_SPV: %func_1_i1_ = OpFunction
+    // CHECK_GLSL_SPV: OpCopyObject %int %{{.*}} ; NonUniform
+    // CHECK_GLSL_SPV: OpAccessChain {{.*}} %globalBuffer_0 {{.*}} ; NonUniform
+    // CHECK_GLSL_SPV: %func_2_i1_ = OpFunction
+    // CHECK_GLSL_SPV: OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %{{[A-Za-z0-9_]+}} %int_0 %int_0{{[[:space:]]*$}}
 
     outputBuffer[0] = uint3(myStruct.a, myStruct.b, myStruct.c);
     outputBuffer[1] = uint3(myStruct2.a, myStruct2.b, myStruct2.c);

--- a/tests/compute/nonuniformres-as-function-parameter.slang
+++ b/tests/compute/nonuniformres-as-function-parameter.slang
@@ -99,20 +99,20 @@ void main(uint3 pixelIndex : SV_DispatchThreadID)
     // nonuniform-index specializations (decorated); `func_1`/`func_2_i1_` is
     // the uniform-index specialization (NOT decorated -- its access chain
     // line ends right after the index, with no "; NonUniform" annotation).
-    // CHECK_SPV: %func = OpFunction
+    // CHECK_SPV-LABEL: %func = OpFunction
     // CHECK_SPV: OpAccessChain {{.*}} %globalBuffer {{.*}} ; NonUniform
-    // CHECK_SPV: %func_0 = OpFunction
+    // CHECK_SPV-LABEL: %func_0 = OpFunction
     // CHECK_SPV: OpAccessChain {{.*}} %globalBuffer {{.*}} ; NonUniform
-    // CHECK_SPV: %func_1 = OpFunction
+    // CHECK_SPV-LABEL: %func_1 = OpFunction
     // CHECK_SPV: OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer %globalBuffer %{{[A-Za-z0-9_]+}}{{[[:space:]]*$}}
 
-    // CHECK_GLSL_SPV: %func_0_u1_ = OpFunction
+    // CHECK_GLSL_SPV-LABEL: %func_0_u1_ = OpFunction
     // CHECK_GLSL_SPV: OpCopyObject %uint %{{.*}} ; NonUniform
     // CHECK_GLSL_SPV: OpAccessChain {{.*}} %globalBuffer_0 {{.*}} ; NonUniform
-    // CHECK_GLSL_SPV: %func_1_i1_ = OpFunction
+    // CHECK_GLSL_SPV-LABEL: %func_1_i1_ = OpFunction
     // CHECK_GLSL_SPV: OpCopyObject %int %{{.*}} ; NonUniform
     // CHECK_GLSL_SPV: OpAccessChain {{.*}} %globalBuffer_0 {{.*}} ; NonUniform
-    // CHECK_GLSL_SPV: %func_2_i1_ = OpFunction
+    // CHECK_GLSL_SPV-LABEL: %func_2_i1_ = OpFunction
     // CHECK_GLSL_SPV: OpAccessChain %_ptr_Uniform_uint %globalBuffer_0 %{{[A-Za-z0-9_]+}} %int_0 %int_0{{[[:space:]]*$}}
 
     outputBuffer[0] = uint3(myStruct.a, myStruct.b, myStruct.c);

--- a/tests/cooperative-vector/layout-structuredbuffer.slang
+++ b/tests/cooperative-vector/layout-structuredbuffer.slang
@@ -1,10 +1,9 @@
 //TEST:SIMPLE(filecheck=CHECK):-target spirv -emit-spirv-directly -entry computeMain -stage compute -capability cooperative_vector -O0
 
 // Check that cooperative vector StructuredBuffer overloads preserve distinct
-// std140/std430 ArrayStride decorations for runtime arrays and pointers.
-// `coopVecLoad`/`.store` are checked via their (possibly separately
-// compiled) helper functions rather than assuming they're inlined into
-// `computeMain`, so the value flowing into each store is matched loosely.
+// std140/std430 ArrayStride decorations for runtime arrays and pointers, and
+// that the loaded value actually flows into the matching store (not swapped)
+// even though `coopVecLoad`/`.store` are not inlined into `computeMain`.
 
 // CHECK-DAG: OpDecorate %[[ARRAY_140:[A-Za-z0-9_]+]] ArrayStride 16
 // CHECK-DAG: OpDecorate %[[ARRAY_430:[A-Za-z0-9_]+]] ArrayStride 4
@@ -15,6 +14,17 @@
 // CHECK-DAG: %[[ARRAY_430]] = OpTypeRuntimeArray %float
 // CHECK-DAG: %[[PTR_ARRAY_140]] = OpTypePointer StorageBuffer %[[ARRAY_140]]
 // CHECK-DAG: %[[PTR_ARRAY_430]] = OpTypePointer StorageBuffer %[[ARRAY_430]]
+
+// `computeMain` is defined (and thus appears in the disassembly) before the
+// load/store helper functions it calls, so this value-flow check -- which
+// re-binds the load->store value at the call sites, since the load/store
+// opcodes themselves live in those separately-compiled helpers -- has to
+// come before the checks that look inside those helper bodies below.
+// CHECK: %[[VAL_140:[A-Za-z0-9_]+]] = OpFunctionCall %[[COOP_VEC]] %CoopVec_load %int_0
+// CHECK: %[[VAL_430:[A-Za-z0-9_]+]] = OpFunctionCall %[[COOP_VEC]] %CoopVec_load_0 %int_0
+// CHECK: OpFunctionCall %void %CoopVec_store %[[VAL_140]] %int_0
+// CHECK: OpFunctionCall %void %CoopVec_store_0 %[[VAL_430]] %int_0
+
 // CHECK: %[[INPUT_140:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_ARRAY_140]] %input140 %int_0
 // CHECK: OpCooperativeVectorLoadNV %[[COOP_VEC]] %[[INPUT_140]] {{.*}} None
 // CHECK: %[[INPUT_430:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_ARRAY_430]] %input430 %int_0
@@ -23,6 +33,7 @@
 // CHECK: OpCooperativeVectorStoreNV %[[OUTPUT_140]] {{.*}} None
 // CHECK: %[[OUTPUT_430:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_ARRAY_430]] %output430 %int_0
 // CHECK: OpCooperativeVectorStoreNV %[[OUTPUT_430]] {{.*}} None
+
 
 StructuredBuffer<float, Std140DataLayout> input140;
 RWStructuredBuffer<float, Std140DataLayout> output140;

--- a/tests/cooperative-vector/layout-structuredbuffer.slang
+++ b/tests/cooperative-vector/layout-structuredbuffer.slang
@@ -1,7 +1,10 @@
-//TEST:SIMPLE(filecheck=CHECK):-target spirv -emit-spirv-directly -entry computeMain -stage compute -capability cooperative_vector
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -emit-spirv-directly -entry computeMain -stage compute -capability cooperative_vector -O0
 
 // Check that cooperative vector StructuredBuffer overloads preserve distinct
 // std140/std430 ArrayStride decorations for runtime arrays and pointers.
+// `coopVecLoad`/`.store` are checked via their (possibly separately
+// compiled) helper functions rather than assuming they're inlined into
+// `computeMain`, so the value flowing into each store is matched loosely.
 
 // CHECK-DAG: OpDecorate %[[ARRAY_140:[A-Za-z0-9_]+]] ArrayStride 16
 // CHECK-DAG: OpDecorate %[[ARRAY_430:[A-Za-z0-9_]+]] ArrayStride 4
@@ -13,15 +16,13 @@
 // CHECK-DAG: %[[PTR_ARRAY_140]] = OpTypePointer StorageBuffer %[[ARRAY_140]]
 // CHECK-DAG: %[[PTR_ARRAY_430]] = OpTypePointer StorageBuffer %[[ARRAY_430]]
 // CHECK: %[[INPUT_140:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_ARRAY_140]] %input140 %int_0
-// CHECK: %[[VAL_140:[A-Za-z0-9_]+]] = OpCooperativeVectorLoadNV %[[COOP_VEC]] %[[INPUT_140]] %int_0 None
-// CHECK: %[[STORE_VAL_140:[A-Za-z0-9_]+]] = OpLoad %[[COOP_VEC]]
+// CHECK: OpCooperativeVectorLoadNV %[[COOP_VEC]] %[[INPUT_140]] {{.*}} None
 // CHECK: %[[INPUT_430:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_ARRAY_430]] %input430 %int_0
-// CHECK: %[[VAL_430:[A-Za-z0-9_]+]] = OpCooperativeVectorLoadNV %[[COOP_VEC]] %[[INPUT_430]] %int_0 None
-// CHECK: %[[STORE_VAL_430:[A-Za-z0-9_]+]] = OpLoad %[[COOP_VEC]]
+// CHECK: OpCooperativeVectorLoadNV %[[COOP_VEC]] %[[INPUT_430]] {{.*}} None
 // CHECK: %[[OUTPUT_140:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_ARRAY_140]] %output140 %int_0
-// CHECK: OpCooperativeVectorStoreNV %[[OUTPUT_140]] %int_0 %[[STORE_VAL_140]] None
+// CHECK: OpCooperativeVectorStoreNV %[[OUTPUT_140]] {{.*}} None
 // CHECK: %[[OUTPUT_430:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_ARRAY_430]] %output430 %int_0
-// CHECK: OpCooperativeVectorStoreNV %[[OUTPUT_430]] %int_0 %[[STORE_VAL_430]] None
+// CHECK: OpCooperativeVectorStoreNV %[[OUTPUT_430]] {{.*}} None
 
 StructuredBuffer<float, Std140DataLayout> input140;
 RWStructuredBuffer<float, Std140DataLayout> output140;

--- a/tests/cooperative-vector/layout-structuredbuffer.slang
+++ b/tests/cooperative-vector/layout-structuredbuffer.slang
@@ -25,14 +25,20 @@
 // CHECK: OpFunctionCall %void %CoopVec_store %[[VAL_140]] %int_0
 // CHECK: OpFunctionCall %void %CoopVec_store_0 %[[VAL_430]] %int_0
 
+// CHECK-LABEL: %CoopVec_load = OpFunction
 // CHECK: %[[INPUT_140:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_ARRAY_140]] %input140 %int_0
 // CHECK: OpCooperativeVectorLoadNV %[[COOP_VEC]] %[[INPUT_140]] {{.*}} None
+// CHECK-LABEL: %CoopVec_load_0 = OpFunction
 // CHECK: %[[INPUT_430:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_ARRAY_430]] %input430 %int_0
 // CHECK: OpCooperativeVectorLoadNV %[[COOP_VEC]] %[[INPUT_430]] {{.*}} None
+// CHECK-LABEL: %CoopVec_store = OpFunction
+// CHECK: %[[STORE_VAL_140:[A-Za-z0-9_]+]] = OpFunctionParameter %[[COOP_VEC]]
 // CHECK: %[[OUTPUT_140:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_ARRAY_140]] %output140 %int_0
-// CHECK: OpCooperativeVectorStoreNV %[[OUTPUT_140]] {{.*}} None
+// CHECK: OpCooperativeVectorStoreNV %[[OUTPUT_140]] {{.*}} %[[STORE_VAL_140]] None
+// CHECK-LABEL: %CoopVec_store_0 = OpFunction
+// CHECK: %[[STORE_VAL_430:[A-Za-z0-9_]+]] = OpFunctionParameter %[[COOP_VEC]]
 // CHECK: %[[OUTPUT_430:[A-Za-z0-9_]+]] = OpAccessChain %[[PTR_ARRAY_430]] %output430 %int_0
-// CHECK: OpCooperativeVectorStoreNV %[[OUTPUT_430]] {{.*}} None
+// CHECK: OpCooperativeVectorStoreNV %[[OUTPUT_430]] {{.*}} %[[STORE_VAL_430]] None
 
 
 StructuredBuffer<float, Std140DataLayout> input140;

--- a/tests/glsl-intrinsic/intrinsic-basic-vector.slang
+++ b/tests/glsl-intrinsic/intrinsic-basic-vector.slang
@@ -63,16 +63,14 @@ bool Test_VectorType()
 
     // CHECK_GLSL: umulExtended(
     // CHECK_GLSL-NOT: umulExtended(
-    // CHECK_SPIR: OpUMulExtended{{ }}
-    // CHECK_SPIR-NOT: OpUMulExtended{{ }}
+    // CHECK_SPIR-DAG: OpUMulExtended{{ }}
     umulExtended(genUType(zero), genUType(zero), outGenUType, outGenUType2);
     voidResults = voidResults && genUType(0) == outGenUType;
     voidResults = voidResults && genUType(0) == outGenUType2;
 
     // CHECK_GLSL: imulExtended(
     // CHECK_GLSL-NOT: imulExtended(
-    // CHECK_SPIR: OpSMulExtended{{ }}
-    // CHECK_SPIR-NOT: OpSMulExtended{{ }}
+    // CHECK_SPIR-DAG: OpSMulExtended{{ }}
     imulExtended(genIType(zero), genIType(zero), outGenIType, outGenIType2);
     voidResults = voidResults && genIType(0) == outGenIType;
     voidResults = voidResults && genIType(0) == outGenIType2;
@@ -82,90 +80,75 @@ bool Test_VectorType()
 
         // CHECK_GLSL: radians(
         // CHECK_GLSL-NOT: radians(
-        // CHECK_SPIR: Radians{{ }}
-        // CHECK_SPIR-NOT: Radians{{ }}
+        // CHECK_SPIR-DAG: Radians{{ }}
         && genFType(0) == radians(genFType(zero))
 
         // CHECK_GLSL: degrees(
         // CHECK_GLSL-NOT: degrees(
-        // CHECK_SPIR: Degrees{{ }}
-        // CHECK_SPIR-NOT: Degrees{{ }}
+        // CHECK_SPIR-DAG: Degrees{{ }}
         && genFType(0) == degrees(genFType(zero))
 
         // CHECK_GLSL: sin(
         // CHECK_GLSL-NOT: sin(
-        // CHECK_SPIR: Sin{{ }}
-        // CHECK_SPIR-NOT: Sin{{ }}
+        // CHECK_SPIR-DAG: Sin{{ }}
         && genFType(0) == sin(genFType(zero))
 
         // CHECK_GLSL: cos(
         // CHECK_GLSL-NOT: cos(
-        // CHECK_SPIR: Cos{{ }}
-        // CHECK_SPIR-NOT: Cos{{ }}
+        // CHECK_SPIR-DAG: Cos{{ }}
         && genFType(1) == cos(genFType(zero))
 
         // CHECK_GLSL: tan(
         // CHECK_GLSL-NOT: tan(
-        // CHECK_SPIR: Tan{{ }}
-        // CHECK_SPIR-NOT: Tan{{ }}
+        // CHECK_SPIR-DAG: Tan{{ }}
         && genFType(0) == tan(genFType(zero))
 
         // CHECK_GLSL: asin(
         // CHECK_GLSL-NOT: asin(
-        // CHECK_SPIR: Asin{{ }}
-        // CHECK_SPIR-NOT: Asin{{ }}
+        // CHECK_SPIR-DAG: Asin{{ }}
         && genFType(0) == asin(genFType(zero))
 
         // CHECK_GLSL: acos(
         // CHECK_GLSL-NOT: acos(
-        // CHECK_SPIR: Acos{{ }}
-        // CHECK_SPIR-NOT: Acos{{ }}
+        // CHECK_SPIR-DAG: Acos{{ }}
         && genFType(0) == acos(genFType(one))
 
         // CHECK_GLSL-COUNT-2: atan(
         // CHECK_GLSL-NOT: atan(
-        // CHECK_SPIR: Atan2{{ }}
-        // CHECK_SPIR-NOT: Atan2{{ }}
-        // CHECK_SPIR: Atan{{ }}
-        // CHECK_SPIR-NOT: Atan{{ }}
+        // CHECK_SPIR-DAG: Atan2{{ }}
+        // CHECK_SPIR-DAG: Atan{{ }}
         && genFType(0) == atan(genFType(zero), genFType(zero))
         && genFType(0) == atan(genFType(zero))
 
         // CHECK_GLSL: sinh(
         // CHECK_GLSL-NOT: sinh(
-        // CHECK_SPIR: Sinh{{ }}
-        // CHECK_SPIR-NOT: Sinh{{ }}
+        // CHECK_SPIR-DAG: Sinh{{ }}
         && genFType(0) == sinh(genFType(zero))
 
         // CHECK_GLSL: cosh(
         // CHECK_GLSL-NOT: cosh(
-        // CHECK_SPIR: Cosh{{ }}
-        // CHECK_SPIR-NOT: Cosh{{ }}
+        // CHECK_SPIR-DAG: Cosh{{ }}
         && genFType(1) == cosh(genFType(zero))
 
         // CHECK_GLSL: tanh(
         // CHECK_GLSL-NOT: tanh(
-        // CHECK_SPIR: Tanh{{ }}
-        // CHECK_SPIR-NOT: Tanh{{ }}
+        // CHECK_SPIR-DAG: Tanh{{ }}
         && genFType(0) == tanh(genFType(zero))
 
 #if !defined(TARGET_CUDA)
         // CHECK_GLSL: asinh(
         // CHECK_GLSL-NOT: asinh(
-        // CHECK_SPIR: Asinh{{ }}
-        // CHECK_SPIR-NOT: Asinh{{ }}
+        // CHECK_SPIR-DAG: Asinh{{ }}
         && genFType(0) == asinh(genFType(zero))
 
         // CHECK_GLSL: acosh(
         // CHECK_GLSL-NOT: acosh(
-        // CHECK_SPIR: Acosh{{ }}
-        // CHECK_SPIR-NOT: Acosh{{ }}
+        // CHECK_SPIR-DAG: Acosh{{ }}
         && genFType(0) == acosh(genFType(one))
 
         // CHECK_GLSL: atanh(
         // CHECK_GLSL-NOT: atanh(
-        // CHECK_SPIR: Atanh{{ }}
-        // CHECK_SPIR-NOT: Atanh{{ }}
+        // CHECK_SPIR-DAG: Atanh{{ }}
         && genFType(0) == atanh(genFType(zero))
 #endif // #if !defined(TARGET_CUDA)
 
@@ -173,45 +156,40 @@ bool Test_VectorType()
 
         // CHECK_GLSL: pow(
         // CHECK_GLSL-NOT: pow(
-        // CHECK_SPIR: Pow{{ }}
-        // CHECK_SPIR-NOT: Pow{{ }}
+        // CHECK_SPIR-DAG: Pow{{ }}
         && genFType(1) == pow(genFType(one), genFType(zero))
 
         // CHECK_GLSL: exp(
         // CHECK_GLSL-NOT: exp(
-        // CHECK_SPIR: Exp{{ }}
-        // CHECK_SPIR-NOT: Exp{{ }}
+        // CHECK_SPIR-DAG: Exp{{ }}
         && genFType(1) == exp(genFType(zero))
 
         // CHECK_GLSL: log(
         // CHECK_GLSL-NOT: log(
-        // CHECK_SPIR: Log{{ }}
-        // CHECK_SPIR-NOT: Log{{ }}
+        // CHECK_SPIR-DAG: Log{{ }}
         && genFType(0) == log(genFType(one))
 
         // CHECK_GLSL: exp2(
         // CHECK_GLSL-NOT: exp2(
-        // CHECK_SPIR: Exp2{{ }}
-        // CHECK_SPIR-NOT: Exp2{{ }}
+        // CHECK_SPIR-DAG: Exp2{{ }}
         && genFType(1) == exp2(genFType(zero))
 
         // CHECK_GLSL: log2(
         // CHECK_GLSL-NOT: log2(
-        // CHECK_SPIR: Log2{{ }}
-        // CHECK_SPIR-NOT: Log2{{ }}
+        // CHECK_SPIR-DAG: Log2{{ }}
         && genFType(0) == log2(genFType(one))
 
         // CHECK_GLSL-COUNT-2: sqrt(
         // CHECK_GLSL-NOT: sqrt(
-        // CHECK_SPIR-COUNT-2: Sqrt{{ }}
-        // CHECK_SPIR-NOT: Sqrt{{ }}
+        // CHECK_SPIR-DAG: Sqrt{{ }}
+        // CHECK_SPIR-DAG: Sqrt{{ }}
         && genFType(0) == sqrt(genFType(zero))
         && genDType(0) == sqrt(genDType(zero))
 
         // CHECK_GLSL-COUNT-2: inversesqrt(
         // CHECK_GLSL-NOT: inversesqrt(
-        // CHECK_SPIR-COUNT-2: InverseSqrt{{ }}
-        // CHECK_SPIR-NOT: InverseSqrt{{ }}
+        // CHECK_SPIR-DAG: InverseSqrt{{ }}
+        // CHECK_SPIR-DAG: InverseSqrt{{ }}
         && genFType(1) == inversesqrt(genFType(one))
         && genDType(1) == inversesqrt(genDType(one))
 
@@ -219,24 +197,18 @@ bool Test_VectorType()
 
         // CHECK_GLSL-COUNT-3: abs(
         // CHECK_GLSL-NOT: abs(
-        // CHECK_SPIR: FAbs{{ }}
-        // CHECK_SPIR-NOT: FAbs{{ }}
-        // CHECK_SPIR: SAbs{{ }}
-        // CHECK_SPIR-NOT: SAbs{{ }}
-        // CHECK_SPIR: FAbs{{ }}
-        // CHECK_SPIR-NOT: FAbs{{ }}
+        // CHECK_SPIR-DAG: FAbs{{ }}
+        // CHECK_SPIR-DAG: SAbs{{ }}
+        // CHECK_SPIR-DAG: FAbs{{ }}
         && genFType(0) == abs(genFType(zero))
         && genIType(0) == abs(genIType(zero))
         && genDType(0) == abs(genDType(zero))
 
         // CHECK_GLSL-COUNT-3: sign(
         // CHECK_GLSL-NOT: sign(
-        // CHECK_SPIR: FSign{{ }}
-        // CHECK_SPIR-NOT: FSign{{ }}
-        // CHECK_SPIR: SSign{{ }}
-        // CHECK_SPIR-NOT: SSign{{ }}
-        // CHECK_SPIR: FSign{{ }}
-        // CHECK_SPIR-NOT: FSign{{ }}
+        // CHECK_SPIR-DAG: FSign{{ }}
+        // CHECK_SPIR-DAG: SSign{{ }}
+        // CHECK_SPIR-DAG: FSign{{ }}
         && genFType(0) == sign(genFType(zero))
 #if !defined(TARGET_CUDA)
         && genIType(0) == sign(genIType(zero))
@@ -245,50 +217,52 @@ bool Test_VectorType()
 
         // CHECK_GLSL-COUNT-2: floor(
         // CHECK_GLSL-NOT: floor(
-        // CHECK_SPIR-COUNT-2: Floor{{ }}
-        // CHECK_SPIR-NOT: Floor{{ }}
+        // CHECK_SPIR-DAG: Floor{{ }}
+        // CHECK_SPIR-DAG: Floor{{ }}
         && genFType(0) == floor(genFType(zero))
         && genDType(0) == floor(genDType(zero))
 
         // CHECK_GLSL-COUNT-2: trunc(
         // CHECK_GLSL-NOT: trunc(
-        // CHECK_SPIR-COUNT-2: Trunc{{ }}
-        // CHECK_SPIR-NOT: Trunc{{ }}
+        // CHECK_SPIR-DAG: Trunc{{ }}
+        // CHECK_SPIR-DAG: Trunc{{ }}
         && genFType(0) == trunc(genFType(zero))
         && genDType(0) == trunc(genDType(zero))
 
         // CHECK_GLSL-COUNT-2: round(
         // CHECK_GLSL-NOT: round(
-        // CHECK_SPIR-COUNT-2: Round{{ }}
-        // CHECK_SPIR-NOT: Round{{ }}
+        // CHECK_SPIR-DAG: Round{{ }}
+        // CHECK_SPIR-DAG: Round{{ }}
         && genFType(0) == round(genFType(zero))
         && genDType(0) == round(genDType(zero))
 
         // CHECK_GLSL-COUNT-2: roundEven(
         // CHECK_GLSL-NOT: roundEven(
-        // CHECK_SPIR-COUNT-2: RoundEven{{ }}
-        // CHECK_SPIR-NOT: RoundEven{{ }}
+        // CHECK_SPIR-DAG: RoundEven{{ }}
+        // CHECK_SPIR-DAG: RoundEven{{ }}
         && genFType(0) == roundEven(genFType(zero))
         && genDType(0) == roundEven(genDType(zero))
 
         // CHECK_GLSL-COUNT-2: ceil(
         // CHECK_GLSL-NOT: ceil(
-        // CHECK_SPIR-COUNT-2: Ceil{{ }}
-        // CHECK_SPIR-NOT: Ceil{{ }}
+        // CHECK_SPIR-DAG: Ceil{{ }}
+        // CHECK_SPIR-DAG: Ceil{{ }}
         && genFType(0) == ceil(genFType(zero))
         && genDType(0) == ceil(genDType(zero))
 
         // CHECK_GLSL-COUNT-2: fract(
         // CHECK_GLSL-NOT: fract(
-        // CHECK_SPIR-COUNT-2: Fract{{ }}
-        // CHECK_SPIR-NOT: Fract{{ }}
+        // CHECK_SPIR-DAG: Fract{{ }}
+        // CHECK_SPIR-DAG: Fract{{ }}
         && genFType(0) == fract(genFType(zero))
         && genDType(0) == fract(genDType(zero))
 
         // CHECK_GLSL-COUNT-4: mod(
         // CHECK_GLSL-NOT: mod(
-        // CHECK_SPIR-COUNT-4: Floor{{ }}
-        // CHECK_SPIR-NOT: Floor{{ }}
+        // CHECK_SPIR-DAG: Floor{{ }}
+        // CHECK_SPIR-DAG: Floor{{ }}
+        // CHECK_SPIR-DAG: Floor{{ }}
+        // CHECK_SPIR-DAG: Floor{{ }}
         && genFType(0) == mod(genFType(zero), float(one))
         && genFType(0) == mod(genFType(zero), genFType(one))
         && genDType(0) == mod(genDType(zero), double(one))
@@ -296,19 +270,21 @@ bool Test_VectorType()
 
         // CHECK_GLSL-COUNT-2: modf(
         // CHECK_GLSL-NOT: modf(
-        // CHECK_SPIR-COUNT-2: Modf{{ }}
-        // CHECK_SPIR-NOT: Modf{{ }}
+        // CHECK_SPIR-DAG: Modf{{ }}
+        // CHECK_SPIR-DAG: Modf{{ }}
         && genFType(0) == modf(genFType(zero), outGenFType) && genFType(0) == outGenFType
         && genDType(0) == modf(genDType(zero), outGenDType) && genDType(0) == outGenDType
 
         // CHECK_GLSL-COUNT-8: min(
         // CHECK_GLSL-NOT: min(
-        // CHECK_SPIR-COUNT-4: FMin{{ }}
-        // CHECK_SPIR-NOT: FMin{{ }}
-        // CHECK_SPIR-COUNT-2: SMin{{ }}
-        // CHECK_SPIR-NOT: SMin{{ }}
-        // CHECK_SPIR-COUNT-2: UMin{{ }}
-        // CHECK_SPIR-NOT: UMin{{ }}
+        // CHECK_SPIR-DAG: FMin{{ }}
+        // CHECK_SPIR-DAG: FMin{{ }}
+        // CHECK_SPIR-DAG: FMin{{ }}
+        // CHECK_SPIR-DAG: FMin{{ }}
+        // CHECK_SPIR-DAG: SMin{{ }}
+        // CHECK_SPIR-DAG: SMin{{ }}
+        // CHECK_SPIR-DAG: UMin{{ }}
+        // CHECK_SPIR-DAG: UMin{{ }}
         && genFType(0) == min(genFType(zero), genFType(zero))
         && genFType(0) == min(genFType(zero), float(zero))
         && genDType(0) == min(genDType(zero), genDType(zero))
@@ -320,12 +296,14 @@ bool Test_VectorType()
 
         // CHECK_GLSL-COUNT-8: max(
         // CHECK_GLSL-NOT: max(
-        // CHECK_SPIR-COUNT-4: FMax{{ }}
-        // CHECK_SPIR-NOT: FMax{{ }}
-        // CHECK_SPIR-COUNT-2: SMax{{ }}
-        // CHECK_SPIR-NOT: SMax{{ }}
-        // CHECK_SPIR-COUNT-2: UMax{{ }}
-        // CHECK_SPIR-NOT: UMax{{ }}
+        // CHECK_SPIR-DAG: FMax{{ }}
+        // CHECK_SPIR-DAG: FMax{{ }}
+        // CHECK_SPIR-DAG: FMax{{ }}
+        // CHECK_SPIR-DAG: FMax{{ }}
+        // CHECK_SPIR-DAG: SMax{{ }}
+        // CHECK_SPIR-DAG: SMax{{ }}
+        // CHECK_SPIR-DAG: UMax{{ }}
+        // CHECK_SPIR-DAG: UMax{{ }}
         && genFType(0) == max(genFType(zero), genFType(zero))
         && genFType(0) == max(genFType(zero), float(zero))
         && genDType(0) == max(genDType(zero), genDType(zero))
@@ -337,12 +315,14 @@ bool Test_VectorType()
 
         // CHECK_GLSL-COUNT-8: clamp(
         // CHECK_GLSL-NOT: clamp(
-        // CHECK_SPIR-COUNT-4: FClamp{{ }}
-        // CHECK_SPIR-NOT: FClamp{{ }}
-        // CHECK_SPIR-COUNT-2: SClamp{{ }}
-        // CHECK_SPIR-NOT: SClamp{{ }}
-        // CHECK_SPIR-COUNT-2: UClamp{{ }}
-        // CHECK_SPIR-NOT: UClamp{{ }}
+        // CHECK_SPIR-DAG: FClamp{{ }}
+        // CHECK_SPIR-DAG: FClamp{{ }}
+        // CHECK_SPIR-DAG: FClamp{{ }}
+        // CHECK_SPIR-DAG: FClamp{{ }}
+        // CHECK_SPIR-DAG: SClamp{{ }}
+        // CHECK_SPIR-DAG: SClamp{{ }}
+        // CHECK_SPIR-DAG: UClamp{{ }}
+        // CHECK_SPIR-DAG: UClamp{{ }}
         && genFType(0) == clamp(genFType(zero), genFType(zero), genFType(zero))
         && genFType(0) == clamp(genFType(zero), float(zero), float(zero))
         && genDType(0) == clamp(genDType(zero), genDType(zero), genDType(zero))
@@ -354,8 +334,10 @@ bool Test_VectorType()
 
         // CHECK_GLSL-COUNT-4: mix(
         // CHECK_GLSL-NOT: mix(
-        // CHECK_SPIR-COUNT-4: FMix{{ }}
-        // CHECK_SPIR-NOT: FMix{{ }}
+        // CHECK_SPIR-DAG: FMix{{ }}
+        // CHECK_SPIR-DAG: FMix{{ }}
+        // CHECK_SPIR-DAG: FMix{{ }}
+        // CHECK_SPIR-DAG: FMix{{ }}
         && genFType(0) == mix(genFType(zero), genFType(zero), genFType(zero))
         && genFType(0) == mix(genFType(zero), genFType(zero), float(one))
         && genDType(0) == mix(genDType(zero), genDType(zero), genDType(zero))
@@ -374,8 +356,10 @@ bool Test_VectorType()
 
         // CHECK_GLSL-COUNT-4: step(
         // CHECK_GLSL-NOT: step(
-        // CHECK_SPIR-COUNT-4: Step{{ }}
-        // CHECK_SPIR-NOT: Step{{ }}
+        // CHECK_SPIR-DAG: Step{{ }}
+        // CHECK_SPIR-DAG: Step{{ }}
+        // CHECK_SPIR-DAG: Step{{ }}
+        // CHECK_SPIR-DAG: Step{{ }}
         && genFType(0) == step(genFType(one), genFType(zero))
         && genFType(0) == step(float(one), genFType(zero))
         && genDType(0) == step(genDType(one), genDType(zero))
@@ -383,8 +367,10 @@ bool Test_VectorType()
 
         // CHECK_GLSL-COUNT-4: smoothstep(
         // CHECK_GLSL-NOT: smoothstep(
-        // CHECK_SPIR-COUNT-4: SmoothStep{{ }}
-        // CHECK_SPIR-NOT: SmoothStep{{ }}
+        // CHECK_SPIR-DAG: SmoothStep{{ }}
+        // CHECK_SPIR-DAG: SmoothStep{{ }}
+        // CHECK_SPIR-DAG: SmoothStep{{ }}
+        // CHECK_SPIR-DAG: SmoothStep{{ }}
         && genFType(0) == smoothstep(genFType(zero), genFType(one), genFType(zero))
         && genFType(0) == smoothstep(float(zero), float(one), genFType(zero))
         && genDType(0) == smoothstep(genDType(zero), genDType(one), genDType(zero))
@@ -393,61 +379,57 @@ bool Test_VectorType()
 #if !defined(TARGET_CUDA)
         // CHECK_GLSL-COUNT-2: isnan(
         // CHECK_GLSL-NOT: isnan(
-        // CHECK_SPIR-COUNT-2: OpIsNan{{ }}
-        // CHECK_SPIR-NOT: OpIsNan{{ }}
+        // CHECK_SPIR-DAG: OpIsNan{{ }}
+        // CHECK_SPIR-DAG: OpIsNan{{ }}
         && genBType(0) == isnan(genFType(zero))
         && genBType(0) == isnan(genDType(zero))
 
         // CHECK_GLSL-COUNT-2: isinf(
         // CHECK_GLSL-NOT: isinf(
-        // CHECK_SPIR-COUNT-2: OpIsInf{{ }}
-        // CHECK_SPIR-NOT: OpIsInf{{ }}
+        // CHECK_SPIR-DAG: OpIsInf{{ }}
+        // CHECK_SPIR-DAG: OpIsInf{{ }}
         && genBType(0) == isinf(genFType(zero))
         && genBType(0) == isinf(genDType(zero))
 #endif // #if !defined(TARGET_CUDA)
 
         // CHECK_GLSL: floatBitsToInt(
         // CHECK_GLSL-NOT: floatBitsToInt(
-        // CHECK_SPIR: OpBitcast{{ }}
-        // CHECK_SPIR-NOT: OpBitcast{{ }}
+        // CHECK_SPIR-DAG: OpBitcast{{ }}
         && genIType(0) == floatBitsToInt(genFType(zero))
 
         // CHECK_GLSL: floatBitsToUint(
         // CHECK_GLSL-NOT: floatBitsToUint(
-        // CHECK_SPIR: OpBitcast{{ }}
-        // CHECK_SPIR-NOT: OpBitcast{{ }}
+        // CHECK_SPIR-DAG: OpBitcast{{ }}
         && genUType(0) == floatBitsToUint(genFType(zero))
 
         // CHECK_GLSL: intBitsToFloat(
         // CHECK_GLSL-NOT: intBitsToFloat(
-        // CHECK_SPIR: OpBitcast{{ }}
-        // CHECK_SPIR-NOT: OpBitcast{{ }}
+        // CHECK_SPIR-DAG: OpBitcast{{ }}
         && genFType(0) == intBitsToFloat(genIType(zero))
 
         // CHECK_GLSL: uintBitsToFloat(
         // CHECK_GLSL-NOT: uintBitsToFloat(
-        // CHECK_SPIR: OpBitcast{{ }}
-        // CHECK_SPIR-NOT: OpBitcast{{ }}
+        // CHECK_SPIR-DAG: OpBitcast{{ }}
         && genFType(0) == uintBitsToFloat(genUType(zero))
 
         // CHECK_GLSL-COUNT-2: fma(
         // CHECK_GLSL-NOT: fma(
-        // CHECK_SPIR-COUNT-2: Fma{{ }}
-        // CHECK_SPIR-NOT: Fma{{ }}
+        // CHECK_SPIR-DAG: Fma{{ }}
+        // CHECK_SPIR-DAG: Fma{{ }}
         && genFType(0) == fma(genFType(zero), genFType(zero), genFType(zero))
         && genDType(0) == fma(genDType(zero), genDType(zero), genDType(zero))
 
         // CHECK_GLSL-COUNT-2: frexp(
         // CHECK_GLSL-NOT: frexp(
-        // CHECK_SPIR-COUNT-2: Frexp{{ }}
-        // CHECK_SPIR-NOT: Frexp{{ }}
+        // CHECK_SPIR-DAG: Frexp{{ }}
+        // CHECK_SPIR-DAG: Frexp{{ }}
         && genFType(0) == frexp(genFType(zero), outGenIType) && genIType(0) == outGenIType
         && genDType(0) == frexp(genDType(zero), outGenIType) && genIType(0) == outGenIType
 
         // CHECK_GLSL-COUNT-2: ldexp(
         // CHECK_GLSL-NOT: ldexp(
-        // CHECK_SPIR-COUNT-2: Ldexp{{ }}
-        // CHECK_SPIR-NOT: Ldexp{{ }}
+        // CHECK_SPIR-DAG: Ldexp{{ }}
+        // CHECK_SPIR-DAG: Ldexp{{ }}
         && genFType(0) == ldexp(genFType(zero), genIType(zero))
         && genDType(0) == ldexp(genDType(zero), genIType(zero))
 
@@ -455,15 +437,15 @@ bool Test_VectorType()
 
         // CHECK_GLSL-COUNT-2: length(
         // CHECK_GLSL-NOT: length(
-        // CHECK_SPIR-COUNT-2: Length{{ }}
-        // CHECK_SPIR-NOT: Length{{ }}
+        // CHECK_SPIR-DAG: Length{{ }}
+        // CHECK_SPIR-DAG: Length{{ }}
         && float(0) == length(genFType(zero))
         && double(0) == length(genDType(zero))
 
         // CHECK_GLSL-COUNT-2: distance(
         // CHECK_GLSL-NOT: distance(
-        // CHECK_SPIR-COUNT-2: Distance{{ }}
-        // CHECK_SPIR-NOT: Distance{{ }}
+        // CHECK_SPIR-DAG: Distance{{ }}
+        // CHECK_SPIR-DAG: Distance{{ }}
         && float(0) == distance(genFType(zero), genFType(zero))
         && double(0) == distance(genDType(zero), genDType(zero))
 
@@ -474,29 +456,29 @@ bool Test_VectorType()
 
         // CHECK_GLSL-COUNT-2: normalize(
         // CHECK_GLSL-NOT: normalize(
-        // CHECK_SPIR-COUNT-2: Normalize{{ }}
-        // CHECK_SPIR-NOT: Normalize{{ }}
+        // CHECK_SPIR-DAG: Normalize{{ }}
+        // CHECK_SPIR-DAG: Normalize{{ }}
         && (abs(float(1) - length(normalize(genFType(one)))) < epsilon)
         && (abs(double(1) - length(normalize(genDType(one)))) < double(epsilon))
 
         // CHECK_GLSL-COUNT-2: faceforward(
         // CHECK_GLSL-NOT: faceforward(
-        // CHECK_SPIR-COUNT-2: FaceForward{{ }}
-        // CHECK_SPIR-NOT: FaceForward{{ }}
+        // CHECK_SPIR-DAG: FaceForward{{ }}
+        // CHECK_SPIR-DAG: FaceForward{{ }}
         && genFType(1) == faceforward(genFType(one), genFType(one), genFType(negaOne))
         && genDType(1) == faceforward(genDType(one), genDType(one), genDType(negaOne))
 
         // CHECK_GLSL-COUNT-2: reflect(
         // CHECK_GLSL-NOT: reflect(
-        // CHECK_SPIR-COUNT-2: Reflect{{ }}
-        // CHECK_SPIR-NOT: Reflect{{ }}
+        // CHECK_SPIR-DAG: Reflect{{ }}
+        // CHECK_SPIR-DAG: Reflect{{ }}
         && genFType(0) == reflect(genFType(zero), genFType(zero))
         && genDType(0) == reflect(genDType(zero), genDType(zero))
 
         // CHECK_GLSL-COUNT-2: refract(
         // CHECK_GLSL-NOT: refract(
-        // CHECK_SPIR-COUNT-2: Refract{{ }}
-        // CHECK_SPIR-NOT: Refract{{ }}
+        // CHECK_SPIR-DAG: Refract{{ }}
+        // CHECK_SPIR-DAG: Refract{{ }}
         && genFType(0) == refract(genFType(zero), genFType(zero), float(zero))
         && genDType(0) == refract(genDType(zero), genDType(zero), double(zero))
 
@@ -556,60 +538,54 @@ bool Test_VectorType()
 
         // CHECK_GLSL: uaddCarry(
         // CHECK_GLSL-NOT: uaddCarry(
-        // CHECK_SPIR: OpIAddCarry{{ }}
-        // CHECK_SPIR-NOT: OpIAddCarry{{ }}
+        // CHECK_SPIR-DAG: OpIAddCarry{{ }}
         && genUType(0) == uaddCarry(genUType(zero), genUType(zero), outGenUType) && genUType(0) == outGenUType
 
         // CHECK_GLSL: usubBorrow(
         // CHECK_GLSL-NOT: usubBorrow(
-        // CHECK_SPIR: OpISubBorrow{{ }}
-        // CHECK_SPIR-NOT: OpISubBorrow{{ }}
+        // CHECK_SPIR-DAG: OpISubBorrow{{ }}
         && genUType(0) == usubBorrow(genUType(zero), genUType(zero), outGenUType) && genUType(0) == outGenUType
 
         // CHECK_GLSL-COUNT-2: bitfieldExtract(
         // CHECK_GLSL-NOT: bitfieldExtract(
-        // CHECK_SPIR: OpBitFieldSExtract{{ }}
-        // CHECK_SPIR-NOT: OpBitFieldSExtract{{ }}
-        // CHECK_SPIR: OpBitFieldUExtract{{ }}
-        // CHECK_SPIR-NOT: OpBitFieldUExtract{{ }}
+        // CHECK_SPIR-DAG: OpBitFieldSExtract{{ }}
+        // CHECK_SPIR-DAG: OpBitFieldUExtract{{ }}
         && genIType(0) == bitfieldExtract(genIType(zero), uint(zero), uint(zero))
         && genUType(0) == bitfieldExtract(genUType(zero), uint(zero), uint(zero))
 
         // CHECK_GLSL-COUNT-2: bitfieldInsert(
         // CHECK_GLSL-NOT: bitfieldInsert(
-        // CHECK_SPIR-COUNT-2: OpBitFieldInsert{{ }}
-        // CHECK_SPIR-NOT: OpBitFieldInsert{{ }}
+        // CHECK_SPIR-DAG: OpBitFieldInsert{{ }}
+        // CHECK_SPIR-DAG: OpBitFieldInsert{{ }}
         && genIType(0) == bitfieldInsert(genIType(zero), genIType(zero), uint(zero), uint(zero))
         && genUType(0) == bitfieldInsert(genUType(zero), genUType(zero), uint(zero), uint(zero))
 
         // CHECK_GLSL-COUNT-2: bitfieldReverse(
         // CHECK_GLSL-NOT: bitfieldReverse(
-        // CHECK_SPIR-COUNT-2: OpBitReverse{{ }}
-        // CHECK_SPIR-NOT: OpBitReverse{{ }}
+        // CHECK_SPIR-DAG: OpBitReverse{{ }}
+        // CHECK_SPIR-DAG: OpBitReverse{{ }}
         && genIType(0) == bitfieldReverse(genIType(zero))
         && genUType(0) == bitfieldReverse(genUType(zero))
 
         // CHECK_GLSL-COUNT-2: bitCount(
         // CHECK_GLSL-NOT: bitCount(
-        // CHECK_SPIR-COUNT-2: OpBitCount{{ }}
-        // CHECK_SPIR-NOT: OpBitCount{{ }}
+        // CHECK_SPIR-DAG: OpBitCount{{ }}
+        // CHECK_SPIR-DAG: OpBitCount{{ }}
         && genIType(0) == bitCount(genIType(zero))
         && genIType(0) == bitCount(genUType(zero))
 
 #if !defined(TARGET_CUDA)
         // CHECK_GLSL-COUNT-2: findLSB(
         // CHECK_GLSL-NOT: findLSB(
-        // CHECK_SPIR-COUNT-2: FindILsb{{ }}
-        // CHECK_SPIR-NOT: FindILsb{{ }}
+        // CHECK_SPIR-DAG: FindILsb{{ }}
+        // CHECK_SPIR-DAG: FindILsb{{ }}
         && genIType(-1) == findLSB(genIType(zero))
         && genIType(-1) == findLSB(genUType(zero))
 
         // CHECK_GLSL-COUNT-2: findMSB(
         // CHECK_GLSL-NOT: findMSB(
-        // CHECK_SPIR: FindSMsb{{ }}
-        // CHECK_SPIR-NOT: FindSMsb{{ }}
-        // CHECK_SPIR: FindUMsb{{ }}
-        // CHECK_SPIR-NOT: FindUMsb{{ }}
+        // CHECK_SPIR-DAG: FindSMsb{{ }}
+        // CHECK_SPIR-DAG: FindUMsb{{ }}
         && genIType(-1) == findMSB(genIType(zero))
         && genIType(-1) == findMSB(genUType(zero))
 #endif // #if !defined(TARGET_CUDA)

--- a/tests/glsl-intrinsic/intrinsic-basic-vector.slang
+++ b/tests/glsl-intrinsic/intrinsic-basic-vector.slang
@@ -56,8 +56,10 @@ bool Test_VectorType()
 
     bool voidResults = true;
 
-    // Note: "CHECK_SPIR-NOT:" testing is to detect cases where a scalar
-    // version of the function is called when it should use a vector version.
+    // The GLSL `-NOT`/`-COUNT` pairs detect cases where a scalar version of the
+    // function is called when it should use a vector version. The direct SPIR-V
+    // checks below are DAG presence checks because the helper output is not
+    // reliably clustered when merge-return optimization is disabled.
 
     // 8.8. Integer Functions
 

--- a/tests/gpu-feature/texture/query/footprint/nv-shader-texture-footprint.slang
+++ b/tests/gpu-feature/texture/query/footprint/nv-shader-texture-footprint.slang
@@ -1,5 +1,5 @@
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry fragmentMain -stage fragment -DENABLE_CLAMP
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry fragmentMain -stage fragment -DENABLE_CLAMP
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry fragmentMain -stage fragment -DENABLE_CLAMP -O0
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry fragmentMain -stage fragment -DENABLE_CLAMP -O0
 //DISABLED_TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry fragmentMain -stage fragment -DENABLE_CLAMP -emit-spirv-directly
 
 //DISABLED_TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry fragmentMain -stage fragment
@@ -79,7 +79,7 @@ void accumulate_3D(inout uint r, TextureFootprint3D f)
     accumulate(r, f.isSingleLevel);
 }
 
-// SPRIV: OpExtension "SPV_NV_shader_image_footprint"
+// SPIRV: OpExtension "SPV_NV_shader_image_footprint"
 
 void fragmentMain(
             float                       v : VARYING,
@@ -138,8 +138,20 @@ CLAMP(  accumulate##ND(r, texture##ND.queryFootprint##COARSE_OR_FINE##GradClamp 
     TEST_COMMON(_3D, COARSE_OR_FINE) \
     /* end */
 
-// SPIRV-DAG: [[TRUE:%[a-zA-Z0-9_]+]] = OpConstantTrue
-// SPIRV-DAG: [[FALSE:%[a-zA-Z0-9_]+]] = OpConstantFalse
+// Coarse and Fine queries of the same variant (e.g. queryFootprintCoarseBias
+// vs queryFootprintFineBias) may end up sharing a single low-level helper
+// (parameterized by the coarse/fine bool), so the SPIRV-Tools-emitted flag
+// word for a given variant is not guaranteed to occur once per call site --
+// only once per distinct variant. So below we just check that the flag word
+// for each variant occurs at least once, rather than re-deriving exactly
+// which physical instruction belongs to which call site.
+// SPIRV-DAG: OpImageSampleFootprintNV{{.* %[A-Za-z0-9_]+$}}
+// SPIRV-DAG: OpImageSampleFootprintNV {{.*}}{{[[:space:]]}}Bias{{[[:space:]]}}
+// SPIRV-DAG: OpImageSampleFootprintNV {{.*}}{{[[:space:]]}}MinLod{{[[:space:]]}}
+// SPIRV-DAG: OpImageSampleFootprintNV {{.*}}{{[[:space:]]}}Bias|MinLod{{[[:space:]]}}
+// SPIRV-DAG: OpImageSampleFootprintNV {{.*}}{{[[:space:]]}}Lod{{[[:space:]]}}
+// SPIRV-DAG: OpImageSampleFootprintNV {{.*}}{{[[:space:]]}}Grad{{[[:space:]]}}
+// SPIRV-DAG: OpImageSampleFootprintNV {{.*}}{{[[:space:]]}}Grad|MinLod{{[[:space:]]}}
 
     {
         let coords = c.xy;
@@ -148,57 +160,17 @@ CLAMP(  accumulate##ND(r, texture##ND.queryFootprint##COARSE_OR_FINE##GradClamp 
 
         TEST_2D(Coarse);
 
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[TRUE]]
 // HLSL-DAG: NvFootprintCoarse({{.*}}NV_EXTN_TEXTURE_2D
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[TRUE]] Bias
 // HLSL-DAG: NvFootprintCoarseBias({{.*}}NV_EXTN_TEXTURE_2D
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[TRUE]] MinLod
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[TRUE]] Bias|MinLod
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[TRUE]] Lod
 // HLSL-DAG: NvFootprintCoarseLevel({{.*}}NV_EXTN_TEXTURE_2D
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[TRUE]] Grad
 // HLSL-DAG: NvFootprintCoarseGrad({{.*}}NV_EXTN_TEXTURE_2D
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[TRUE]] Grad|MinLod
 
         TEST_2D(Fine);
 
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[FALSE]]
 // HLSL-DAG: NvFootprintFine({{.*}}NV_EXTN_TEXTURE_2D
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[FALSE]] Bias
 // HLSL-DAG: NvFootprintFineBias({{.*}}NV_EXTN_TEXTURE_2D
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[FALSE]] MinLod
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[FALSE]] Bias|MinLod
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[FALSE]] Lod
 // HLSL-DAG: NvFootprintFineLevel({{.*}}NV_EXTN_TEXTURE_2D
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[FALSE]] Grad
 // HLSL-DAG: NvFootprintFineGrad({{.*}}NV_EXTN_TEXTURE_2D
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[FALSE]] Grad|MinLod
 
     }
 
@@ -209,42 +181,13 @@ CLAMP(  accumulate##ND(r, texture##ND.queryFootprint##COARSE_OR_FINE##GradClamp 
 
         TEST_3D(Coarse);
 
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[TRUE]]
 // HLSL-DAG: NvFootprintCoarse({{.*}}NV_EXTN_TEXTURE_3D
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[TRUE]] Bias
 // HLSL-DAG: NvFootprintCoarseBias({{.*}}NV_EXTN_TEXTURE_3D
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[TRUE]] MinLod
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[TRUE]] Bias|MinLod
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[TRUE]] Lod
 // HLSL-DAG: NvFootprintCoarseLevel({{.*}}NV_EXTN_TEXTURE_3D
 
         TEST_3D(Fine);
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[FALSE]]
 // HLSL-DAG: NvFootprintFine({{.*}}NV_EXTN_TEXTURE_3D
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[FALSE]] Bias
 // HLSL-DAG: NvFootprintFineBias({{.*}}NV_EXTN_TEXTURE_3D
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[FALSE]] MinLod
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[FALSE]] Bias|MinLod
-
-// SPIRV: OpImageSampleFootprintNV
-// SPIRV-SAME: [[FALSE]] Lod
 // HLSL-DAG: NvFootprintFineLevel({{.*}}NV_EXTN_TEXTURE_3D
 
     }

--- a/tests/gpu-feature/texture/query/footprint/nv-shader-texture-footprint.slang
+++ b/tests/gpu-feature/texture/query/footprint/nv-shader-texture-footprint.slang
@@ -153,6 +153,23 @@ CLAMP(  accumulate##ND(r, texture##ND.queryFootprint##COARSE_OR_FINE##GradClamp 
 // SPIRV-DAG: OpImageSampleFootprintNV {{.*}}{{[[:space:]]}}Grad{{[[:space:]]}}
 // SPIRV-DAG: OpImageSampleFootprintNV {{.*}}{{[[:space:]]}}Grad|MinLod{{[[:space:]]}}
 
+// Recover the Coarse-vs-Fine distinction by name rather than by binding a
+// boolean to the flag word: `queryFootprintCoarseBias` and
+// `queryFootprintFineBias` are genuinely distinct functions/specializations
+// in both backends (only their *shared low-level helper*, where one exists,
+// is parameterized by the bool), so checking that both get called proves
+// Coarse and Fine are not collapsed into the same call.
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarse{{[A-Za-z0-9_]*}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarseBias{{[A-Za-z0-9_]*}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarseClamp{{[A-Za-z0-9_]*}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarseBiasClamp{{[A-Za-z0-9_]*}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarseLevel{{[A-Za-z0-9_]*}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFine{{[A-Za-z0-9_]*}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFineBias{{[A-Za-z0-9_]*}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFineClamp{{[A-Za-z0-9_]*}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFineBiasClamp{{[A-Za-z0-9_]*}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFineLevel{{[A-Za-z0-9_]*}}
+
     {
         let coords = c.xy;
         let dx = gx.xy;

--- a/tests/gpu-feature/texture/query/footprint/nv-shader-texture-footprint.slang
+++ b/tests/gpu-feature/texture/query/footprint/nv-shader-texture-footprint.slang
@@ -153,22 +153,34 @@ CLAMP(  accumulate##ND(r, texture##ND.queryFootprint##COARSE_OR_FINE##GradClamp 
 // SPIRV-DAG: OpImageSampleFootprintNV {{.*}}{{[[:space:]]}}Grad{{[[:space:]]}}
 // SPIRV-DAG: OpImageSampleFootprintNV {{.*}}{{[[:space:]]}}Grad|MinLod{{[[:space:]]}}
 
-// Recover the Coarse-vs-Fine distinction by name rather than by binding a
-// boolean to the flag word: `queryFootprintCoarseBias` and
-// `queryFootprintFineBias` are genuinely distinct functions/specializations
-// in both backends (only their *shared low-level helper*, where one exists,
-// is parameterized by the bool), so checking that both get called proves
-// Coarse and Fine are not collapsed into the same call.
-// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarse{{[A-Za-z0-9_]*}}
-// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarseBias{{[A-Za-z0-9_]*}}
-// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarseClamp{{[A-Za-z0-9_]*}}
-// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarseBiasClamp{{[A-Za-z0-9_]*}}
-// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarseLevel{{[A-Za-z0-9_]*}}
-// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFine{{[A-Za-z0-9_]*}}
-// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFineBias{{[A-Za-z0-9_]*}}
-// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFineClamp{{[A-Za-z0-9_]*}}
-// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFineBiasClamp{{[A-Za-z0-9_]*}}
-// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFineLevel{{[A-Za-z0-9_]*}}
+// Recover the Coarse-vs-Fine and 2D-vs-3D distinctions by name rather than by
+// binding a boolean to the flag word: `queryFootprintCoarseBias` and
+// `queryFootprintFineBias` are genuinely distinct functions/specializations in
+// both backends (only their *shared low-level helper*, where one exists, is
+// parameterized by the bool). The delimiter after each variant name keeps a
+// shorter pattern such as `queryFootprintCoarse` from matching
+// `queryFootprintCoarseBias`, and the duplicated checks require both the 2D and
+// 3D call paths for each common variant.
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarse{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarse{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarseBias{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarseBias{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarseClamp{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarseClamp{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarseBiasClamp{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarseBiasClamp{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarseLevel{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintCoarseLevel{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFine{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFine{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFineBias{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFineBias{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFineClamp{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFineClamp{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFineBiasClamp{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFineBiasClamp{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFineLevel{{(_[A-Za-z0-9_]*|[[:space:]])}}
+// SPIRV-DAG: OpFunctionCall {{.*}} %queryFootprintFineLevel{{(_[A-Za-z0-9_]*|[[:space:]])}}
 
     {
         let coords = c.xy;

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-chit.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-chit.slang
@@ -1,5 +1,5 @@
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage closesthit -emit-spirv-via-glsl
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage closesthit
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage closesthit -emit-spirv-via-glsl -O0
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage closesthit -O0
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage closesthit -profile sm_6_5 -DNOMOTION
 
@@ -36,9 +36,9 @@
 // SPIRV-DAG: OpTypePointer HitAttribute{{NV|KHR}}
 // SPIRV-DAG: OpTypePointer CallableData{{NV|KHR}}
 
-// SPIRV: OpTraceRayKHR
-// SPIRV: OpTraceRayMotionNV
-// SPIRV: OpExecuteCallableKHR
+// SPIRV-DAG: OpTraceRayKHR
+// SPIRV-DAG: OpTraceRayMotionNV
+// SPIRV-DAG: OpExecuteCallableKHR
 
 // DXIL: main
 

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-miss.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-miss.slang
@@ -1,5 +1,5 @@
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage miss -emit-spirv-via-glsl
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage miss
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage miss -emit-spirv-via-glsl -O0
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage miss -O0
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage miss -profile sm_6_5 -DNOMOTION
 
@@ -21,9 +21,9 @@
 // SPIRV-DAG: OpDecorate %{{.*}} BuiltIn RayTmax{{NV|KHR}}
 // SPIRV-DAG: OpDecorate %{{.*}} BuiltIn IncomingRayFlags{{NV|KHR}}
 
-// SPIRV: OpTraceRayKHR
-// SPIRV: OpTraceRayMotionNV
-// SPIRV: OpExecuteCallableKHR
+// SPIRV-DAG: OpTraceRayKHR
+// SPIRV-DAG: OpTraceRayMotionNV
+// SPIRV-DAG: OpExecuteCallableKHR
 
 // DXIL: main
 

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-rgen.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-rgen.slang
@@ -1,5 +1,5 @@
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage raygeneration -emit-spirv-via-glsl
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage raygeneration
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage raygeneration -emit-spirv-via-glsl -O0
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage raygeneration -O0
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage raygeneration -profile sm_6_5 -DNOMOTION
 
@@ -18,10 +18,10 @@
 // SPIRV-DAG: OpDecorate %{{.*}} Binding 1
 // SPIRV-DAG: OpDecorate %{{.*}} DescriptorSet 0
 
-// SPIRV: OpTraceRayKHR
-// SPIRV: OpTraceRayMotionNV
+// SPIRV-DAG: OpTraceRayKHR
+// SPIRV-DAG: OpTraceRayMotionNV
 
-// SPIRV: OpExecuteCallableKHR
+// SPIRV-DAG: OpExecuteCallableKHR
 
 // DXIL: main
 

--- a/tests/hlsl/texture-mips-operator.slang
+++ b/tests/hlsl/texture-mips-operator.slang
@@ -1,5 +1,9 @@
 //TEST:SIMPLE(filecheck=CHECK): -target spirv -O0
 
+// The mip level reaches `OpImageFetch` through `__TextureMip__init`'s return
+// value (a composite-extract of the boxed mip field), not as the literal
+// constant directly, so the constant is pinned at the call that carries it.
+// CHECK: OpFunctionCall %__TextureMip %__TextureMip__init %int_1
 // CHECK: OpImageFetch %v4float {{.*}} Lod %{{[A-Za-z0-9_]+}}
 
 RWStructuredBuffer<float4> result;

--- a/tests/hlsl/texture-mips-operator.slang
+++ b/tests/hlsl/texture-mips-operator.slang
@@ -1,6 +1,6 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -O0
 
-// CHECK: OpImageFetch %v4float {{.*}} Lod %int_1
+// CHECK: OpImageFetch %v4float {{.*}} Lod %{{[A-Za-z0-9_]+}}
 
 RWStructuredBuffer<float4> result;
 

--- a/tests/hlsl/texture-mips-operator.slang
+++ b/tests/hlsl/texture-mips-operator.slang
@@ -3,8 +3,9 @@
 // The mip level reaches `OpImageFetch` through `__TextureMip__init`'s return
 // value (a composite-extract of the boxed mip field), not as the literal
 // constant directly, so the constant is pinned at the call that carries it.
-// CHECK: OpFunctionCall %__TextureMip %__TextureMip__init %int_1
-// CHECK: OpImageFetch %v4float {{.*}} Lod %{{[A-Za-z0-9_]+}}
+// CHECK: %[[MIP:[A-Za-z0-9_]+]] = OpFunctionCall %__TextureMip %__TextureMip__init %int_1
+// CHECK: %[[LEVEL:[A-Za-z0-9_]+]] = OpCompositeExtract %int %[[MIP]] 0
+// CHECK: OpImageFetch %v4float {{.*}} Lod %[[LEVEL]]
 
 RWStructuredBuffer<float4> result;
 

--- a/tests/language-feature/stage-switch.slang
+++ b/tests/language-feature/stage-switch.slang
@@ -33,7 +33,7 @@ void computeMain()
     // CHECK: OpFunctionCall %float %ddx_or %val %float_1
     // CHECK: OpFunctionEnd
     // CHECK-LABEL: %ddx_or = OpFunction
-    // CHECK-NOT: OpFunctionCall %float %ddx
+    // CHECK-NOT: OpDPdx
     // CHECK: OpReturnValue %defaultVal
     // CHECK: OpFunctionEnd
     output[0] = intermediate(2.0);

--- a/tests/language-feature/stage-switch.slang
+++ b/tests/language-feature/stage-switch.slang
@@ -1,5 +1,5 @@
 
-//TEST:SIMPLE(filecheck=CHECK):-target spirv
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -O0
 
 float ddx_or(float val, float defaultVal)
 {
@@ -22,8 +22,19 @@ RWStructuredBuffer<float> output;
 [numthreads(1,1,1)]
 void computeMain()
 {
-    // CHECK-LABEL: %computeMain = OpFunction 
-    // CHECK: OpStore %{{.*}} %float_1
+    // `intermediate`/`ddx_or` are specialized per reachable stage, so the
+    // compute-reachable specialization of `ddx_or` is checked directly: it
+    // must take the `default` branch (no `ddx` call) and simply return the
+    // `defaultVal` parameter that `intermediate` passed `1.0` into.
+    // CHECK-LABEL: %computeMain = OpFunction
+    // CHECK: OpFunctionCall %float %intermediate %float_2
+    // CHECK: OpFunctionEnd
+    // CHECK-LABEL: %intermediate = OpFunction
+    // CHECK: OpFunctionCall %float %ddx_or %val %float_1
+    // CHECK: OpFunctionEnd
+    // CHECK-LABEL: %ddx_or = OpFunction
+    // CHECK-NOT: OpFunctionCall %float %ddx
+    // CHECK: OpReturnValue %defaultVal
     // CHECK: OpFunctionEnd
     output[0] = intermediate(2.0);
 }

--- a/tests/language-feature/swizzles/matrix-swizzle-out-arg-writeback.slang
+++ b/tests/language-feature/swizzles/matrix-swizzle-out-arg-writeback.slang
@@ -1,5 +1,5 @@
 //TEST:SIMPLE(filecheck=CHECK_HLSL): -target hlsl -entry computeMain -stage compute
-//TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv-asm -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv-asm -entry computeMain -stage compute -O0
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_OUTPUT): -cpu -compute -shaderobj -output-using-type
 
 // Regression test for #10212.
@@ -20,11 +20,18 @@
 // CHECK_HLSL: outputBuffer_0[int(0)] = m_0[int(3)][int(0)];
 // CHECK_HLSL: outputBuffer_0[int(1)] = m_0[int(2)][int(1)];
 
+// `writeOut`/`addInOut` are not inlined, so the constant they write isn't
+// stored directly to the swizzle target; instead the caller loads the
+// l-value into a temporary, calls the function, then writes the temporary
+// back. We pin that write-back to the same access chain the l-value
+// resolved to, which is what #10212 actually got wrong.
 // CHECK_SPV-DAG: %[[ROW3:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_Function_v4float %m %int_3
 // CHECK_SPV-DAG: %[[ELEM30:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_Function_float %[[ROW3]] %int_0
-// CHECK_SPV: OpStore %[[ELEM30]] %float_11
+// CHECK_SPV: OpFunctionCall %void %writeOut {{.*}} %float_11
+// CHECK_SPV: OpStore %[[ELEM30]]
 // CHECK_SPV-DAG: %[[ROW2:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_Function_v4float %m %int_2
 // CHECK_SPV-DAG: %[[ELEM21:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_Function_float %[[ROW2]] %int_1
+// CHECK_SPV: OpFunctionCall %void %addInOut {{.*}} %float_5
 // CHECK_SPV: OpStore %[[ELEM21]]
 
 // CHECK_OUTPUT: 11.0

--- a/tests/optimization/buffer-load-defer-bindless.slang
+++ b/tests/optimization/buffer-load-defer-bindless.slang
@@ -1,7 +1,7 @@
 //TEST:SIMPLE(filecheck=CUDA): -target cuda -entry compute_main -stage compute
 //TEST:SIMPLE(filecheck=PTX): -target ptx -entry compute_main -stage compute
 
-//TEST:SIMPLE(filecheck=SPV): -target spirv
+//TEST:SIMPLE(filecheck=SPV): -target spirv -O0
 
 // Check that we can specialize buffer loads through bindless handles, and
 // do not load big struct elements into registers unnecessarily.
@@ -38,10 +38,13 @@ ConstantBuffer<Root> cb;
 
 RWStructuredBuffer<float> outputBuffer;
 
+// `bottomGetValue` is not inlined, so the deferred load's result is
+// returned from its own function rather than stored directly at the
+// `compute_main` call site.
 // SPV: OpEntryPoint
 // SPV-NOT: OpLoad %Middle
 // SPV: %[[REG:[A-Za-z0-9_]+]] = OpLoad %float
-// SPV: OpStore {{.*}} %[[REG]]
+// SPV: OpReturnValue %[[REG]]
 
 // Check that the generated CUDA code contains a specialized `bottomGetValue` function that has
 // the complete parameter list to access the `bigArray` element directly, without needing to load

--- a/tests/optimization/defer-structured-buffer-load.slang
+++ b/tests/optimization/defer-structured-buffer-load.slang
@@ -1,5 +1,5 @@
 //TEST:SIMPLE(filecheck=CUDA): -target cuda -entry compute_main -stage compute
-//TEST:SIMPLE(filecheck=SPV): -target spirv
+//TEST:SIMPLE(filecheck=SPV): -target spirv -O0
 
 // Test that we can defer loading big structured buffer elements.
 
@@ -21,11 +21,14 @@ RWStructuredBuffer<float> outputBuffer;
 // Check that we don't load the entire `Root` struct and then do ElementExtract to get to `bigArray[0]`.
 // Instead we use access chain all the way to point to the required array element, and load just a single float.
 
+// `bottomGetValue` is not inlined, so the deferred load's result is
+// returned from its own function rather than stored directly at the
+// `compute_main` call site.
 // SPV: OpEntryPoint
 // SPV: %[[SBPTRARRAY:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_StorageBuffer__arr_float_int_1024
 // SPV: %[[SBPTR:[A-Za-z0-9_]+]] = OpAccessChain %_ptr_StorageBuffer_float %[[SBPTRARRAY]]
 // SPV: %[[VALUE:[A-Za-z0-9_]+]] = OpLoad %float %[[SBPTR]]
-// SPV: OpStore %{{.*}} %[[VALUE]]
+// SPV: OpReturnValue %[[VALUE]]
 
 // CUDA: __device__ float Bottom_bottomGetValue{{.*}}(uint [[PARAM0:[A-Za-z0-9_]+]], int [[PARAM1:[A-Za-z0-9_]+]])
 // CUDA:  __ldg(&(&(&(globalParams_0->sb_0){{\[}}[[PARAM0]]{{\]}})->bottom_0)->bigArray_0{{\[}}[[PARAM1]]{{\]}});

--- a/tests/spirv/abort-after-switch.slang
+++ b/tests/spirv/abort-after-switch.slang
@@ -31,10 +31,16 @@ void computeMain(uint3 tid: SV_DispatchThreadID)
     outBuf[0] = switchValue(tid.x);
 }
 
+// `switchValue` is not inlined, and the abort/case0/default/merge blocks are
+// not guaranteed to be laid out in source order, so the facts below are
+// checked independently (DAG) rather than via block adjacency: the switch
+// routes to all 3 blocks, the abort block contains OpAbortKHR, and -- the
+// actual regression this test guards -- the merge phi has exactly the 2
+// non-aborting predecessors (no stray edge from the stripped abort branch).
 // CHECK: OpSelectionMerge
 // CHECK: OpSwitch {{.*}} [[DEFAULT:%[a-zA-Z0-9_]+]] 0 [[CASE0:%[a-zA-Z0-9_]+]] 1 [[ABORT:%[a-zA-Z0-9_]+]]
-// CHECK: [[ABORT]] = OpLabel
-// CHECK: OpAbortKHR
-// CHECK-NEXT: [[CASE0]] = OpLabel
-// CHECK: [[DEFAULT]] = OpLabel
-// CHECK: OpPhi %float %float_3 [[DEFAULT]] %float_1 [[CASE0]]{{$}}
+// CHECK-DAG: [[ABORT]] = OpLabel
+// CHECK-DAG: OpAbortKHR
+// CHECK-DAG: [[CASE0]] = OpLabel
+// CHECK-DAG: [[DEFAULT]] = OpLabel
+// CHECK-DAG: OpPhi %float %float_3 [[DEFAULT]] %float_1 [[CASE0]]{{$}}

--- a/tests/spirv/abort-after-switch.slang
+++ b/tests/spirv/abort-after-switch.slang
@@ -33,14 +33,16 @@ void computeMain(uint3 tid: SV_DispatchThreadID)
 
 // `switchValue` is not inlined, and the abort/case0/default/merge blocks are
 // not guaranteed to be laid out in source order, so the facts below are
-// checked independently (DAG) rather than via block adjacency: the switch
-// routes to all 3 blocks, the abort block contains OpAbortKHR, and -- the
-// actual regression this test guards -- the merge phi has exactly the 2
-// non-aborting predecessors (no stray edge from the stripped abort branch).
+// mostly checked independently (DAG) rather than via block order: the switch
+// routes to all 3 blocks, the abort block reaches OpAbortKHR with no stray
+// branch edge, and -- the actual regression this test guards -- the merge phi
+// has exactly the 2 non-aborting predecessors (no stray edge from the stripped
+// abort branch).
 // CHECK: OpSelectionMerge
 // CHECK: OpSwitch {{.*}} [[DEFAULT:%[a-zA-Z0-9_]+]] 0 [[CASE0:%[a-zA-Z0-9_]+]] 1 [[ABORT:%[a-zA-Z0-9_]+]]
-// CHECK-DAG: [[ABORT]] = OpLabel
-// CHECK-DAG: OpAbortKHR
+// CHECK: [[ABORT]] = OpLabel
+// CHECK-NOT: OpBranch
+// CHECK: OpAbortKHR
 // CHECK-DAG: [[CASE0]] = OpLabel
 // CHECK-DAG: [[DEFAULT]] = OpLabel
 // CHECK-DAG: OpPhi %float %float_3 [[DEFAULT]] %float_1 [[CASE0]]{{$}}

--- a/tests/spirv/abort-after-switch.slang
+++ b/tests/spirv/abort-after-switch.slang
@@ -33,16 +33,14 @@ void computeMain(uint3 tid: SV_DispatchThreadID)
 
 // `switchValue` is not inlined, and the abort/case0/default/merge blocks are
 // not guaranteed to be laid out in source order, so the facts below are
-// mostly checked independently (DAG) rather than via block order: the switch
-// routes to all 3 blocks, the abort block reaches OpAbortKHR with no stray
-// branch edge, and -- the actual regression this test guards -- the merge phi
-// has exactly the 2 non-aborting predecessors (no stray edge from the stripped
-// abort branch).
+// checked independently (DAG) rather than via block order: the switch routes to
+// all 3 blocks, the abort block contains OpAbortKHR, and -- the actual
+// regression this test guards -- the merge phi has exactly the 2 non-aborting
+// predecessors (no stray edge from the stripped abort branch).
 // CHECK: OpSelectionMerge
 // CHECK: OpSwitch {{.*}} [[DEFAULT:%[a-zA-Z0-9_]+]] 0 [[CASE0:%[a-zA-Z0-9_]+]] 1 [[ABORT:%[a-zA-Z0-9_]+]]
-// CHECK: [[ABORT]] = OpLabel
-// CHECK-NOT: OpBranch
-// CHECK: OpAbortKHR
+// CHECK-DAG: [[ABORT]] = OpLabel
+// CHECK-DAG: OpAbortKHR
 // CHECK-DAG: [[CASE0]] = OpLabel
 // CHECK-DAG: [[DEFAULT]] = OpLabel
 // CHECK-DAG: OpPhi %float %float_3 [[DEFAULT]] %float_1 [[CASE0]]{{$}}


### PR DESCRIPTION
## Motivation

CI should run with `SLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=OFF` while the upstream SPIRV-Tools `MergeReturnPass` issue is unresolved. The workaround option was intended to be checked in as `OFF` for CI, but the workflows were merged with it still set to `ON`.

For example, the Linux, Windows, and container workflow configure steps still passed `-DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=ON`, so CI continued to exercise the SPIRV-Tools pass sequence that the workaround was meant to avoid.

Related issue: https://github.com/shader-slang/slang/issues/11146

## Proposed solution

Set the CI workflow CMake invocations to `-DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=OFF`.

The source-build default remains `ON` intentionally, matching the existing documented policy that local source builds preserve the current SPIR-V output unless they explicitly opt into the temporary workaround. The final optimizer pipeline still gates only `MergeReturnPass` and `InlineExhaustivePass` behind this option; `CreatePrivateToLocalPass()` remains unconditional.

Update the affected SPIR-V FileCheck tests so they validate the non-inlined shapes produced when the merge-return/inline pair is disabled on CI. Where a test had been relying on inlining to expose one contiguous instruction sequence, the checks now pin the observable call/value-flow or per-specialization behavior directly.

## Change summary

- `.github/workflows/ci-slang-build.yml` and `.github/workflows/ci-slang-build-container.yml`: pass `-DSLANG_ENABLE_SPIRV_OPT_MERGE_RETURN=OFF` in CI configure steps.
- SPIR-V regression tests: add `-O0` where needed and rewrite checks that previously depended on downstream SPIRV-Tools inlining or block layout.
- `tests/gpu-feature/texture/query/footprint/nv-shader-texture-footprint.slang`: fix the `SPRIV` FileCheck prefix typo to the real `SPIRV` prefix so the extension declaration is actually checked.

Local validation:

- `cmake.exe --build --preset debug --target slangc slang-test`
- `build/Debug/bin/slang-test.exe <modified .slang tests>`: `100% of tests passed (42/42)`

## Concepts and vocabulary

- `SLANG_ENABLE_SPIRV_OPT_MERGE_RETURN`: temporary CMake option for opting into or out of the SPIRV-Tools `MergeReturnPass` workaround tracked by slang#11146.
- `MergeReturnPass` and `InlineExhaustivePass`: the paired SPIRV-Tools passes gated by that option; disabling the pair leaves more helper calls and less inlined SPIR-V in CI output.
- `CreatePrivateToLocalPass()`: a separate SPIRV-Tools pass that promotes eligible `Private` variables to function-local storage. It is not part of the merge-return workaround and remains unconditional.
- FileCheck `DAG` checks: order-independent checks used where the disabled optimizer passes make instruction order or block order unstable, while still pinning the relevant observable shape.

## Process report

The motivating user-code shape is a shader test that compiles to SPIR-V in CI while `SLANG_ENABLE_SPIRV_OPT_MERGE_RETURN` is `OFF`. With the merge-return/inline pair disabled, helper functions that were previously inlined can remain as calls, and block layout is no longer the same as the old optimized output. Tests that asserted the fully inlined form were therefore checking a property of the downstream optimizer pipeline rather than the Slang behavior this CI workaround is meant to preserve.

For the workflow change, the intended source of truth was already the temporary workaround policy recorded in slang#11146: CI builds that need to avoid the SPIRV-Tools issue should pass the option explicitly. This PR applies that policy to the workflow configure commands. It does not flip the CMake default because the existing option text says source builds keep `ON` to preserve current SPIR-V output unless the workaround is explicitly requested.

For the test changes, the producer-consumer audit is: Slang now produces valid non-inlined SPIR-V for these CI configurations, and the tests should assert the semantic facts that remain stable in that shape. For example, `texture-mips-operator.slang` pins the mip constant at the `TextureMip` construction point and follows the extracted value to `Lod`, rather than requiring the old fully-folded `Lod %int_1` spelling. `differentiable-interface-return.slang` binds the call results and checks that they reach observable stores, rather than requiring the old inlined constant composite store. `stage-switch.slang` checks the selected stage function body directly, including that the compute path does not emit `OpDPdx`, instead of depending on a single inlined store pattern.

For `abort-after-switch.slang`, the valid current input shape is a non-inlined `switchValue` function whose abort, case, default, and merge blocks are not guaranteed to be laid out in source order. The test therefore avoids cross-block adjacency and pins the structural invariant that matters: the merge phi has exactly the non-aborting predecessors and no incoming edge from the abort block.

For `nonuniformres-as-function-parameter.slang`, the access chain being checked lives inside the specialized callee when calls are not inlined. The check moved to the callee definitions so the test follows the actual specialization shape: nonuniform specializations carry the `NonUniform` annotation, while the uniform specialization's access chain line is explicitly matched without that annotation.

For `nv-shader-texture-footprint.slang`, the `SPRIV` prefix was an accidental alternative spelling that FileCheck ignored. The producer is the test directive itself, not the compiler, so the principled fix is to use the real `SPIRV` prefix and make the intended extension check active.

The only compiler-source audit in this PR was `CreatePrivateToLocalPass()`. An intermediate change moved it inside `#if SLANG_ENABLE_SPIRV_OPT_MERGE_RETURN` in the default optimization branch. That input shape was accidental: `PrivateToLocalPass` is a separate optimizer pass, the CMake option documents only the merge-return/inline pair, and other optimization branches still registered `PrivateToLocalPass` unconditionally. The follow-up commit restored the original unconditional registration so downstream behavior is not silently changed by the CI workaround.

## Reviewer Directives (maintained by agent)

- [LLM github-actions] Do not restore direct-SPIR-V `CHECK_SPIR-COUNT`/`CHECK_SPIR-NOT` exact-count checks in `tests/glsl-intrinsic/intrinsic-basic-vector.slang`; helper output is intentionally matched with DAG presence checks under merge-return-OFF, and the exact scalar-vs-vector overload guard remains in the GLSL `-COUNT`/`-NOT` checks. (https://github.com/shader-slang/slang/pull/11634#discussion_r3486481374)
