### PR TITLE
Diagnose unbound module-scope type_param instead of crashing (#11316)

### DIFF
--- a/docs/language-guide.md
+++ b/docs/language-guide.md
@@ -165,6 +165,9 @@ M gMaterial;
 Conceptually, you can think of this syntax as wrapping your entire shader program in a generic with parameter `<M : IMaterial>`.
 This isn't beautiful syntax, but it may help when incrementally porting an existing HLSL codebase to use Slang's features.
 
+A global-scope generic parameter must be given a concrete argument before the program can be compiled to a target — for example via the `-specialize` command-line option, by embedding the argument in the entry-point name (`-entry "main<Concrete>"`), or programmatically through `IComponentType::specialize`.
+Using such a parameter directly in shader code that is then compiled without a binding is an error (`E38207`); these declarations are intended for reflection and external specialization, not for direct use in an unspecialized shader body.
+
 ### Associated Types
 
 Sometimes it is difficult to define an interface because each type that implements it might need to make its own choice about some intermediate type.

--- a/docs/language-guide.md
+++ b/docs/language-guide.md
@@ -165,7 +165,7 @@ M gMaterial;
 Conceptually, you can think of this syntax as wrapping your entire shader program in a generic with parameter `<M : IMaterial>`.
 This isn't beautiful syntax, but it may help when incrementally porting an existing HLSL codebase to use Slang's features.
 
-A global-scope generic parameter must be given a concrete argument before the program can be compiled to a target — for example via the `-specialize` command-line option, by embedding the argument in the entry-point name (`-entry "main<Concrete>"`), or programmatically through `IComponentType::specialize`.
+A global-scope generic parameter must be given a concrete argument before the program can be compiled to a target — for example by passing `-specialize <typename>` (after the corresponding `-entry <name>`) on the command line, or programmatically through `IComponentType::specialize`.
 Using such a parameter directly in shader code that is then compiled without a binding is an error (`E38207`); these declarations are intended for reflection and external specialization, not for direct use in an unspecialized shader body.
 
 ### Associated Types

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -4373,6 +4373,13 @@ err(
 )
 
 err(
+    "unspecialized-global-generic-param-with-uses",
+    38207,
+    "global generic parameter used in code without a concrete binding",
+    span { loc = "location", message = "a global generic parameter ('type_param' / '__generic_value_param') cannot be used in shader code without a concrete binding; such global-scope declarations are intended for reflection and external specialization, not direct use in shader bodies" }
+)
+
+err(
     "cannot-use-resource-type-in-structured-buffer",
     38204,
     "resource type in StructuredBuffer",

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -3289,11 +3289,86 @@ struct SpecializationContext
             param->replaceUsesWith(val);
         }
         {
-            // Now that we've replaced any uses of global generic
-            // parameters, we will do a second pass to remove
-            // the parameters and any `bind_global_generic_param`
+            // Before removing anything, diagnose any global generic parameter
+            // (`type_param` or `__generic_value_param`) that still has uses. A
+            // leftover use means the user is referencing the param from shader
+            // code that needs a concrete binding (e.g. interface-method dispatch
+            // on a value typed by the param), which is not a supported
+            // shader-body construct (#5627).
+            //
+            // A single source-level declaration can lower to several
+            // `IRGlobalGenericParam`s: a constrained `type_param T : IFoo`
+            // produces a type-kind param plus a paired *witness-table* param,
+            // and either may retain the leftover use. To emit exactly one
+            // message per source declaration we report the user-written params
+            // (a `type_param`'s type-kind param, or a `__generic_value_param`'s
+            // value-typed param) and skip the synthesized witness-table params,
+            // which never correspond to a separate source declaration — unless a
+            // witness param is the *only* thing left with a use, in which case we
+            // must still report it (handled by the second pass below).
+            //
+            // `diagnosedLeftoverUse` records that this loop actually *emitted* a
+            // diagnostic, so the cleanup loop below can assert "a leftover use
+            // implies it was reported" without depending on the global error
+            // count (which keeps the assert correct even if the diagnostic is
+            // reclassified or suppressed).
+            bool diagnosedLeftoverUse = false;
+            if (sink)
+            {
+                // First pass: report each user-written param (type-kind or value
+                // param). A constrained `type_param T : IFoo` also produces a
+                // synthesized witness-table param; we skip it *here* so the pair
+                // yields a single message.
+                bool reportedNonWitness = false;
+                for (auto inst : moduleInst->getChildren())
+                {
+                    if (inst->getOp() != kIROp_GlobalGenericParam || !inst->firstUse)
+                        continue;
+                    if (inst->getDataType() &&
+                        inst->getDataType()->getOp() == kIROp_WitnessTableType)
+                        continue;
+                    reportedNonWitness = true;
+                    diagnosedLeftoverUse = true;
+                    sink->diagnose(Diagnostics::UnspecializedGlobalGenericParamWithUses{
+                        .location = inst->sourceLoc});
+                }
+
+                // Second pass: if the *only* leftover-use params are
+                // witness-table params (no user-written partner retained a use),
+                // report them too — otherwise such a param would be left in the
+                // IR with no diagnostic, breaking the cleanup loop's invariant.
+                //
+                // A single declaration can produce several witness-table params
+                // (e.g. a conjunction `type_param T : IFoo & IBar`), all sharing
+                // the declaration's source location, so dedup by location to
+                // still emit one message per declaration.
+                if (!reportedNonWitness)
+                {
+                    HashSet<SourceLoc::RawValue> reportedLocs;
+                    for (auto inst : moduleInst->getChildren())
+                    {
+                        if (inst->getOp() != kIROp_GlobalGenericParam || !inst->firstUse)
+                            continue;
+                        diagnosedLeftoverUse = true;
+                        if (inst->sourceLoc.isValid() &&
+                            !reportedLocs.add(inst->sourceLoc.getRaw()))
+                            continue;
+                        sink->diagnose(Diagnostics::UnspecializedGlobalGenericParamWithUses{
+                            .location = inst->sourceLoc});
+                    }
+                }
+            }
+
+            // Now remove the parameters and any `bind_global_generic_param`
             // instructions, since both should be dead/unused.
             //
+            // Exception: leave any still-used param (with its dangling uses) in
+            // place. We have diagnosed an error above, so `linkAndOptimizeIR`
+            // checks the error count right after this pass and discards the
+            // module — removal is unnecessary. And removing a still-used param
+            // here (replacing uses with a hoistable poison keyed on the param's
+            // own type while the param is torn down) corrupts the hoistable-inst
+            // dedup and crashes (issue #11316).
             IRInst* next = nullptr;
             for (auto inst = moduleInst->getFirstChild(); inst; inst = next)
             {
@@ -3305,11 +3380,31 @@ struct SpecializationContext
                     break;
 
                 case kIROp_GlobalGenericParam:
+                    if (inst->firstUse)
+                    {
+                        // A leftover-use param is left in place (not removed):
+                        // we have diagnosed it above, so `linkAndOptimizeIR`
+                        // bails on the error count right after this pass and
+                        // discards the module. Removing it here would replace its
+                        // uses with a hoistable poison keyed on the param's own
+                        // type while the param is torn down, corrupting the
+                        // hoistable-inst dedup and crashing (issue #11316).
+                        //
+                        // Fail loudly if we reach here without having diagnosed:
+                        // the sole production caller (`linkAndOptimizeIR`) always
+                        // supplies a sink, and the diagnose loop above sets
+                        // `diagnosedLeftoverUse` for any leftover-use param, so a
+                        // violation means a contract bug, not user input. Using
+                        // the local flag (not the global error count) keeps this
+                        // correct even if E38207 is reclassified or suppressed.
+                        SLANG_RELEASE_ASSERT(sink && diagnosedLeftoverUse);
+                        break;
+                    }
+                    inst->removeAndDeallocate();
+                    break;
                 case kIROp_BindGlobalGenericParam:
                     // A `bind_global_generic_param` instruction should
-                    // have no uses in the first place, and all the global
-                    // generic parameters should have had their uses replaced.
-                    //
+                    // have no uses in the first place.
                     SLANG_ASSERT(!inst->firstUse);
                     inst->removeAndDeallocate();
                     break;

--- a/tests/bugs/11316-type-param-method-dispatch.slang
+++ b/tests/bugs/11316-type-param-method-dispatch.slang
@@ -1,0 +1,64 @@
+// Regression test for:
+// https://github.com/shader-slang/slang/issues/11316
+//
+// Using a value typed by a global-scope generic parameter in a shader body
+// used to crash deep inside specialization with an assertion / SIGSEGV. The
+// construct is unsupported by policy (#5627); the fix is a clean E38207
+// diagnostic.
+//
+// Three directives cover the distinct lowerings:
+//  - `main`: a *constrained* `type_param T : IFoo` whose value is used via an
+//    interface-method call (the original #11316 reproducer). The constraint
+//    lowers to a type-kind param plus a paired witness-table param; dedup by
+//    source location yields a single E38207.
+//  - `mainUnconstrained`: an *unconstrained* `type_param U` used directly,
+//    exercising the same path with no witness-table param.
+//  - `mainValueParam`: a `__generic_value_param`, which lowers to a *non*
+//    type-kind `IRGlobalGenericParam`; it must also be diagnosed (otherwise the
+//    leftover-use release assert in specialization would fire).
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):-target spirv-asm -entry main -stage compute
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECKU,non-exhaustive):-target spirv-asm -entry mainUnconstrained -stage compute
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECKV,non-exhaustive):-target spirv-asm -entry mainValueParam -stage compute
+
+interface IFoo
+{
+    int get();
+}
+
+RWStructuredBuffer<int> outputBuffer;
+
+type_param T : IFoo;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main()
+{
+    T t;
+    int v = t.get();
+//CHECK: E38207
+//CHECK: cannot be used in shader code without a concrete binding
+}
+
+type_param U;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void mainUnconstrained()
+{
+    U u;
+    outputBuffer[0] = reinterpret<int>(u);
+//CHECKU: E38207
+//CHECKU: cannot be used in shader code without a concrete binding
+}
+
+__generic_value_param N : int;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void mainValueParam()
+{
+    outputBuffer[0] = N;
+//CHECKV: E38207
+//CHECKV: cannot be used in shader code without a concrete binding
+}

--- a/tests/bugs/11316-type-param-method-dispatch.slang
+++ b/tests/bugs/11316-type-param-method-dispatch.slang
@@ -16,14 +16,24 @@
 //  - `mainValueParam`: a `__generic_value_param`, which lowers to a *non*
 //    type-kind `IRGlobalGenericParam`; it must also be diagnosed (otherwise the
 //    leftover-use release assert in specialization would fire).
+//  - `mainConjunction`: a *multi-constraint* `type_param TT : IFoo & IBar`,
+//    which lowers to a type-kind param plus *two* witness-table params. A plain
+//    FileCheck directive pins that exactly one E38207 is reported (not one per
+//    witness param), guarding the dedup.
 
 //DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):-target spirv-asm -entry main -stage compute
 //DIAGNOSTIC_TEST:SIMPLE(diag=CHECKU,non-exhaustive):-target spirv-asm -entry mainUnconstrained -stage compute
 //DIAGNOSTIC_TEST:SIMPLE(diag=CHECKV,non-exhaustive):-target spirv-asm -entry mainValueParam -stage compute
+//TEST:SIMPLE(filecheck=CHECKC):-target spirv-asm -entry mainConjunction -stage compute
 
 interface IFoo
 {
     int get();
+}
+
+interface IBar
+{
+    int bar();
 }
 
 RWStructuredBuffer<int> outputBuffer;
@@ -62,3 +72,17 @@ void mainValueParam()
 //CHECKV: E38207
 //CHECKV: cannot be used in shader code without a concrete binding
 }
+
+type_param TT : IFoo & IBar;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void mainConjunction()
+{
+    TT t;
+    outputBuffer[0] = t.get() + t.bar();
+}
+// The conjunction lowers to one type-kind param plus two witness-table params,
+// but the dedup must collapse them to exactly one E38207.
+//CHECKC-COUNT-1: error{{.*}}38207
+//CHECKC-NOT: error{{.*}}38207

--- a/tools/slang-unit-test/unit-test-global-type-param-specialize.cpp
+++ b/tools/slang-unit-test/unit-test-global-type-param-specialize.cpp
@@ -1,0 +1,94 @@
+// unit-test-global-type-param-specialize.cpp
+
+#include "slang-com-ptr.h"
+#include "slang.h"
+#include "unit-test/slang-unit-test.h"
+
+#include <string.h>
+
+using namespace Slang;
+
+// Positive companion to the E38207 diagnostic from #11316: a module-scope
+// `type_param T : IFoo` that *is* given a concrete binding via
+// `IComponentType::specialize` must compile cleanly (no E38207) and produce
+// code. This exercises the success path of `specializeGlobalGenericParameters`
+// — the loop that the diagnostic change touches — which is otherwise only
+// covered by GPU/disabled compute tests.
+SLANG_UNIT_TEST(globalTypeParamSpecialize)
+{
+    const char* userSourceBody = R"(
+        interface IFoo { int get(); }
+        struct FooImpl : IFoo { int get() { return 42; } }
+
+        // Module-scope generic parameter (global `type_param`).
+        type_param T : IFoo;
+
+        RWStructuredBuffer<int> outputBuffer;
+
+        [shader("compute")]
+        [numthreads(1, 1, 1)]
+        void computeMain()
+        {
+            T t;
+            outputBuffer[0] = t.get();
+        }
+        )";
+
+    ComPtr<slang::IGlobalSession> globalSession;
+    SLANG_CHECK_ABORT(
+        slang_createGlobalSession(SLANG_API_VERSION, globalSession.writeRef()) == SLANG_OK);
+    slang::TargetDesc targetDesc = {};
+    targetDesc.format = SLANG_SPIRV;
+    targetDesc.profile = globalSession->findProfile("spirv_1_5");
+    slang::SessionDesc sessionDesc = {};
+    sessionDesc.targetCount = 1;
+    sessionDesc.targets = &targetDesc;
+    ComPtr<slang::ISession> session;
+    SLANG_CHECK_ABORT(globalSession->createSession(sessionDesc, session.writeRef()) == SLANG_OK);
+
+    ComPtr<slang::IBlob> diagnosticBlob;
+    auto module = session->loadModuleFromSourceString(
+        "m",
+        "m.slang",
+        userSourceBody,
+        diagnosticBlob.writeRef());
+    SLANG_CHECK_ABORT(module != nullptr);
+
+    ComPtr<slang::IEntryPoint> entryPoint;
+    SLANG_CHECK_ABORT(
+        SLANG_SUCCEEDED(module->findEntryPointByName("computeMain", entryPoint.writeRef())));
+
+    // Compose the module + entry point so the program carries the module-scope
+    // `type_param` as a specialization parameter.
+    slang::IComponentType* components[] = {module, entryPoint};
+    ComPtr<slang::IComponentType> program;
+    SLANG_CHECK_ABORT(
+        SLANG_SUCCEEDED(session->createCompositeComponentType(components, 2, program.writeRef())));
+
+    // The global `type_param T` shows up as a specialization parameter.
+    SLANG_CHECK(program->getSpecializationParamCount() == 1);
+
+    // Bind it to a conforming type and confirm specialization succeeds.
+    slang::SpecializationArg specArgs[] = {
+        slang::SpecializationArg::fromType(program->getLayout()->findTypeByName("FooImpl"))};
+    ComPtr<slang::IComponentType> specialized;
+    diagnosticBlob = nullptr;
+    auto result =
+        program->specialize(specArgs, 1, specialized.writeRef(), diagnosticBlob.writeRef());
+    SLANG_CHECK(SLANG_SUCCEEDED(result));
+    SLANG_CHECK_ABORT(specialized != nullptr);
+
+    ComPtr<slang::IComponentType> linkedProgram;
+    SLANG_CHECK_ABORT(SLANG_SUCCEEDED(specialized->link(linkedProgram.writeRef())));
+
+    // Code generation must succeed and emit no E38207 diagnostic.
+    ComPtr<slang::IBlob> code;
+    diagnosticBlob = nullptr;
+    linkedProgram->getEntryPointCode(0, 0, code.writeRef(), diagnosticBlob.writeRef());
+    SLANG_CHECK_ABORT(code != nullptr && code->getBufferSize() != 0);
+    if (diagnosticBlob && diagnosticBlob->getBufferPointer())
+    {
+        const char* diagnostics = (const char*)diagnosticBlob->getBufferPointer();
+        SLANG_CHECK(strstr(diagnostics, "38207") == nullptr);
+    }
+}


### PR DESCRIPTION
Closes #11316

Reopened from bot-authored #11326 (under my account to clear the CLA) plus a clang-format fix. slangc previously SIGSEGV'd after lower-to-IR on an unspecialized module-scope `type_param`; it now emits a diagnostic instead.