### PR TITLE
Include <climits> in slang-parser.cpp for INT_MIN

### DIFF
--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -10,6 +10,7 @@
 #include "slang-visitor.h"
 
 #include <assert.h>
+#include <climits>
 #include <float.h>
 #include <optional>
 


### PR DESCRIPTION
Building slang on Fedora 44 fails for me with the following error:

```
[445/508] Building CXX object source/slang/CMakeFiles/slang-common-objects.dir/slang-parser.cpp.o
FAILED: [code=1] source/slang/CMakeFiles/slang-common-objects.dir/slang-parser.cpp.o 
/usr/lib64/ccache/c++ -DCMARK_GFM_STATIC_DEFINE -DNOMINMAX -DSLANG_ENABLE_DXIL_SUPPORT=0 -DSLANG_ENABLE_VALIDATION_VM_BYTECODE=0 -DSLANG_ENABLE_WEBGPU=0 -DSLANG_STATIC -DSTB_IMAGE_STATIC -DUNICODE -DVC_EXTRALEAN -DWIN32_LEAN_AND_MEAN -D_DEBUG -D_UNICODE -I/tmp/slang-test/slang/build/source/slang/slang-version-header -I/tmp/slang-test/slang/build/source/standard-modules/slang-standard-module-config-header -I/tmp/slang-test/slang/source -I/tmp/slang-test/slang/include -I/tmp/slang-test/slang/prelude -I/tmp/slang-test/slang/external/spirv-headers/include -I/tmp/slang-test/slang/build/source/slang/capability -I/tmp/slang-test/slang/source/slang -I/tmp/slang-test/slang/build/source/slang/fiddle -isystem /tmp/slang-test/slang/external/unordered_dense/include -isystem /tmp/slang-test/slang/build/external/cmark/src -isystem /tmp/slang-test/slang/external/cmark/src/include -isystem /tmp/slang-test/slang/external/cmark/extensions/include -g -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -g -Wall -Wno-switch -Wno-parentheses -Wno-unused-local-typedefs -Wno-class-memaccess -Wno-reorder -Wno-invalid-offsetof -Werror=return-local-addr -Wnarrowing -Wextra -fmacro-prefix-map=/tmp/slang-test/slang/= -Wno-error=stringop-overflow -MD -MT source/slang/CMakeFiles/slang-common-objects.dir/slang-parser.cpp.o -MF source/slang/CMakeFiles/slang-common-objects.dir/slang-parser.cpp.o.d -o source/slang/CMakeFiles/slang-common-objects.dir/slang-parser.cpp.o -c /tmp/slang-test/slang/source/slang/slang-parser.cpp
/tmp/slang-test/slang/source/slang/slang-parser.cpp: In function ‘Slang::Expr* Slang::parsePrefixExpr(Parser*)’:
/tmp/slang-test/slang/source/slang/slang-parser.cpp:9848:68: error: ‘INT_MIN’ was not declared in this scope
 9848 |                     if (newLiteral->value == -static_cast<int64_t>(INT_MIN))
      |                                                                    ^~~~~~~
/tmp/slang-test/slang/source/slang/slang-parser.cpp:14:1: note: ‘INT_MIN’ is defined in header ‘<climits>’; this is probably fixable by adding ‘#include <climits>’
   13 | #include <float.h>
  +++ |+#include <climits>
   14 | #include <optional>
```