### PR TITLE
Add benchmark runner label to ci-benchmark-test.yml

### DIFF
--- a/.github/workflows/ci-benchmark-test.yml
+++ b/.github/workflows/ci-benchmark-test.yml
@@ -11,7 +11,7 @@ jobs:
   test-benchmark:
     name: Test (Benchmark)
     timeout-minutes: 60
-    runs-on: [Windows, self-hosted]
+    runs-on: [Windows, self-hosted, benchmark]
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Fixes #11649

## Motivation

In PR #11640 the MDL benchmark CI test was split out into
`.github/workflows/ci-benchmark-test.yml`, and the `benchmark` runner label
was dropped from the `test-benchmark` job, which currently runs on:

```yaml
runs-on: [Windows, self-hosted]
```

The nightly benchmark update workflow
(`.github/workflows/push-benchmark-results.yml`) runs only on runners
carrying the `benchmark` label (`runs-on: [Windows, self-hosted, benchmark]`).
Because `test-benchmark` runs on a broader, unlabeled pool of self-hosted
Windows runners, it can pass on CI while the nightly benchmark workflow later
fails on a runner-specific difference that only exists on the `benchmark`-
labeled machines.

## Proposed solution

Add the `benchmark` label to `test-benchmark`'s `runs-on` so it executes on
the same machines as the nightly benchmark workflow, surfacing
runner-specific issues in CI before they can affect the nightly run.

## Change summary

| File | Change |
| --- | --- |
| `.github/workflows/ci-benchmark-test.yml` | Changed `runs-on: [Windows, self-hosted]` to `runs-on: [Windows, self-hosted, benchmark]` for the `test-benchmark` job. |

## Process report

The only change is adding the `benchmark` label to the `runs-on` array at
`.github/workflows/ci-benchmark-test.yml:14`, matching the label already used
by `push-benchmark-results.yml:19`. This is not a workaround for a code
defect; it aligns the runner pool used by the CI test with the runner pool
used by the nightly workflow it is meant to validate against, per the request
in #11649.
