### PR TITLE
Fix for float matrix comparison operator causing crash in slangc

### DIFF
--- a/source/slang/slang-ir-legalize-matrix-types.cpp
+++ b/source/slang/slang-ir-legalize-matrix-types.cpp
@@ -406,13 +406,8 @@ struct MatrixTypeLoweringContext
         auto matrixTypeA = as<IRMatrixType>(typeA);
         auto matrixTypeB = as<IRMatrixType>(typeB);
 
-        bool shouldLowerA = matrixTypeA && shouldLowerMatrixType(matrixTypeA);
-        bool shouldLowerB = matrixTypeB && shouldLowerMatrixType(matrixTypeB);
-
         // Only matrix-matrix comparisons are supported
-        SLANG_ASSERT(
-            shouldLowerA && shouldLowerB &&
-            "Comparison operations only supported between matrices that need lowering");
+        SLANG_ASSERT(matrixTypeA && matrixTypeB && "Only matrix-matrix comparisons are supported");
 
         // Create IRBuilder at the top level
         IRBuilder builder(inst);


### PR DESCRIPTION
First time contributing, so apologies if I've got anything wrong here!

I encountered crashing in slangc which could be narrowed down to a MRE of the `==` operator between two `float4x4` matrices:
```slang
// Output buffer so the comparison isn't optimised away
RWStructuredBuffer<bool4x4> res;

[shader("compute")]
[numthreads(1, 1, 1)]
void main() 
{
  float4x4 a = float4x4(
      float4(1.0f, 0.0f, 0.0f, 0.0f), 
      float4(0.0f, 1.0f, 0.0f, 0.0f),
      float4(-1.0f, 0.0f, 1.0f, 0.0f), 
      float4(0.0f, 0.0f, 0.0f, 1.0f),
  );
  float4x4 b = float4x4(
      float4(1.0f, 0.0f, -1.0f, 0.0f),
      float4(0.0f, 1.0f, 0.0f, 0.0f),
      float4(0.0f, 0.0f, 1.0f, 0.0f),
      float4(0.0f, 0.0f, 0.0f, 1.0f), 
  );

  res[0] = (a == b);
}
```

This was compiling to the SPIR-V target specifically, but does occur for other targets. It was also only occurring on linux (with the latest slangc 2026.11 release binary). Building from source I didn't get the crash in release (different compiler version I guess), but the assertion mentioned here was being triggered in a debug build.

My proposed fix is to modify this assertion to allow matrix types that don't require lowering (e.g. float matrix). The assertion message stating that comparisons are only supported between matrices that need lowering seemed arbitrary to me, and from what I could gather things work correctly with the simpler assertion. With this change my example then compiles correctly, and I hope this will also be the fix for the crashing in the linux binaries, I assume caused by some heap corruption due to compiler optimisations caused by the `SLANG_ASSUME` emitted for the assertion in a release build.