### PR TITLE
ci: clean up GHCR auth now that CI container images are public

### DIFF
--- a/.github/workflows/ci-agentic-tests-nightly.yml
+++ b/.github/workflows/ci-agentic-tests-nightly.yml
@@ -36,9 +36,6 @@ jobs:
       packages: read # CI container images are public, so this is not strictly required; kept for consistency and in case they revert to private
     container:
       image: ghcr.io/shader-slang/slang-linux-clang-ci:v1.0.1
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
       options: --user root
 
     env:

--- a/.github/workflows/ci-agentic-tests-nightly.yml
+++ b/.github/workflows/ci-agentic-tests-nightly.yml
@@ -33,7 +33,7 @@ jobs:
     permissions:
       id-token: write # Workload Identity for GCS-cached LLVM
       contents: read
-      packages: read # Pull slang-linux-clang-ci container from GHCR
+      packages: read # CI container images are public, so this is not strictly required; kept for consistency and in case they revert to private
     container:
       image: ghcr.io/shader-slang/slang-linux-clang-ci:v1.0.1
       credentials:

--- a/.github/workflows/ci-rhi-test-container.yml
+++ b/.github/workflows/ci-rhi-test-container.yml
@@ -18,7 +18,7 @@ jobs:
 
     permissions:
       contents: read
-      packages: read
+      packages: read # CI container images are public, so this is not strictly required; kept for consistency and in case they revert to private
 
     container:
       image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.6.1

--- a/.github/workflows/ci-rhi-test-container.yml
+++ b/.github/workflows/ci-rhi-test-container.yml
@@ -22,9 +22,6 @@ jobs:
 
     container:
       image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.6.1
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
       options: >-
         --gpus all
         --user root

--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       id-token: write # Required for Workload Identity
       contents: read
-      packages: read # slang-linux-gpu-ci is public, so this is not strictly required; kept for consistency and in case it reverts to private
+      packages: read # CI container images are public, so this is not strictly required; kept for consistency and in case they revert to private
     container:
       image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.6.1
       # EXPERIMENT: drop --user root and -v /:/host_root mount; host cleanup

--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       id-token: write # Required for Workload Identity
       contents: read
-      packages: read # Required to pull container from ghcr.io
+      packages: read # slang-linux-gpu-ci is public, so this is not strictly required; kept for consistency and in case it reverts to private
     container:
       image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.6.1
       # EXPERIMENT: drop --user root and -v /:/host_root mount; host cleanup

--- a/.github/workflows/ci-slang-sanitizer.yml
+++ b/.github/workflows/ci-slang-sanitizer.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      packages: read
+      packages: read # CI container images are public, so this is not strictly required; kept for consistency and in case they revert to private
 
     container:
       image: ghcr.io/shader-slang/slang-linux-clang-ci:v1.0.1

--- a/.github/workflows/ci-slang-sanitizer.yml
+++ b/.github/workflows/ci-slang-sanitizer.yml
@@ -26,9 +26,6 @@ jobs:
 
     container:
       image: ghcr.io/shader-slang/slang-linux-clang-ci:v1.0.1
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
       options: --user root
 
     env:

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -43,9 +43,6 @@ jobs:
 
     container:
       image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.6.1
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
       options: >-
         --gpus all
         --user root

--- a/.github/workflows/ci-slang-test-container.yml
+++ b/.github/workflows/ci-slang-test-container.yml
@@ -39,7 +39,7 @@ jobs:
 
     permissions:
       contents: read
-      packages: read
+      packages: read # CI container images are public, so this is not strictly required; kept for consistency and in case they revert to private
 
     container:
       image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.6.1

--- a/.github/workflows/cmake-options-build-container.yml
+++ b/.github/workflows/cmake-options-build-container.yml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 180
     permissions:
       contents: read
-      packages: read # slang-linux-gpu-ci is public, so this is not strictly required; kept for consistency and in case it reverts to private
+      packages: read # CI container images are public, so this is not strictly required; kept for consistency and in case they revert to private
     container:
       image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.6.1
       # Current callers use GitHub-hosted Ubuntu, where the mounted workspace is

--- a/.github/workflows/cmake-options-build-container.yml
+++ b/.github/workflows/cmake-options-build-container.yml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 180
     permissions:
       contents: read
-      packages: read # Required to pull container from ghcr.io
+      packages: read # slang-linux-gpu-ci is public, so this is not strictly required; kept for consistency and in case it reverts to private
     container:
       image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.6.1
       # Current callers use GitHub-hosted Ubuntu, where the mounted workspace is

--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -13,7 +13,7 @@ concurrency:
 permissions:
   id-token: write # Required for Workload Identity (GCS auth)
   contents: read # Read slang repo
-  packages: read # Pull container images from ghcr.io
+  packages: read # CI container images are public, so this is not strictly required; kept for consistency and in case they revert to private
   pull-requests: write # For PR comments (if needed)
 
 jobs:


### PR DESCRIPTION
## Motivation

#11366 was resolved by making the CI container packages **public** — both `slang-linux-gpu-ci` and `slang-linux-clang-ci`. With public images, two pieces of GHCR auth in the workflows are now redundant:

1. Comments like `# Required to pull container from ghcr.io` on `packages: read` — misleading, since a public image pulls anonymously.
2. Explicit `container.credentials` (`github.actor` + `GITHUB_TOKEN`) on several jobs — a docker-login that a public pull doesn't need.

## Proposed solution

- **Standardize the `packages: read` comment** across all seven container-pulling workflows to note the permission is kept for consistency (and as a safety net if a package's visibility ever reverts to private), not because the pull requires it. The permission itself is retained — it's a harmless read-only scope, and keeping it avoids breakage on a revert.
- **Remove the now-redundant `container.credentials` blocks** from the four jobs that still passed them. A public image pulls without authentication, so the explicit login is dead weight.

## Change summary

| File | Image | Comment standardized | credentials removed |
|---|---|:--:|:--:|
| `ci-slang-build-container.yml` | gpu | ✅ | (none) |
| `cmake-options-build-container.yml` | gpu | ✅ | (none) |
| `ci-rhi-test-container.yml` | gpu | ✅ | ✅ |
| `ci-slang-test-container.yml` | gpu | ✅ | ✅ |
| `ci-slang-sanitizer.yml` | clang | ✅ | ✅ |
| `coverage-nightly.yml` | clang | ✅ | (none) |
| `ci-agentic-tests-nightly.yml` | clang | ✅ | ✅ |

## Concepts and vocabulary

- **`packages: read`** — a `GITHUB_TOKEN` scope granting read access to GHCR packages within the token's own scope. Required only for *private* package pulls; public packages pull anonymously (and a fork PR's token can't read the org's private packages at all — the root cause of #11366).
- **`container.credentials`** — explicit registry login for a job's container image. Needed only for a private registry/image; harmless but redundant for a public image.

## Process report

All edits are confined to the `permissions` comment and the `container` block. Removing `credentials` is safe because both images are now public — verified via the GHCR API (`visibility: public`) and an anonymous manifest pull (HTTP 200) for each. The permissions blocks are otherwise unchanged; `packages: read` is deliberately retained so a future revert-to-private doesn't silently break the pull, and to avoid churn/risk on `workflow_call` permission inheritance for the reusable container workflows. A CodeRabbit review inferred the clang image was still private from the presence of these `credentials` blocks; that inference was incorrect (the image is public), but it correctly surfaced the redundancy, which this PR removes.