### PR TITLE
CI analytics: surface API failures instead of masking them as healthy data

### DIFF
--- a/.github/workflows/ci-analytics.yml
+++ b/.github/workflows/ci-analytics.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 6 * * *" # Daily at 6 AM UTC
   workflow_dispatch: {} # Manual trigger
 
+concurrency:
+  group: slang-ci-analytics-publish
+  cancel-in-progress: false
+
 jobs:
   collect-and-publish:
     runs-on: ubuntu-latest
@@ -66,7 +70,7 @@ jobs:
 
       - name: Push to analytics repo
         run: |
-          cd ci_analytics_repo
+          cd ci_analytics_repo || exit 1
           # Copy updated monthly data files
           cp /tmp/ci_data/ci_jobs_*.json . 2>/dev/null || true
           if [ -f /tmp/pr_merges.json ]; then
@@ -80,7 +84,18 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git diff --cached --quiet || {
-            git commit -m "Update CI analytics $(date -u +%Y-%m-%d)" &&
-            git push
-          }
+          if ! git diff --cached --quiet; then
+            git commit -m "Update CI analytics $(date -u +%Y-%m-%d)"
+            for attempt in 1 2 3; do
+              if git push; then
+                exit 0
+              fi
+              echo "Push failed on attempt ${attempt}; rebasing before retry..."
+              git pull --rebase || {
+                echo "Failed to rebase CI analytics before retry" >&2
+                exit 1
+              }
+            done
+            echo "Failed to push CI analytics after retries" >&2
+            exit 1
+          fi

--- a/.github/workflows/ci-analytics.yml
+++ b/.github/workflows/ci-analytics.yml
@@ -90,6 +90,9 @@ jobs:
               if git push; then
                 exit 0
               fi
+              if [ "$attempt" -eq 3 ]; then
+                break
+              fi
               echo "Push failed on attempt ${attempt}; rebasing before retry..."
               git pull --rebase || {
                 echo "Failed to rebase CI analytics before retry" >&2

--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -61,6 +61,9 @@ jobs:
               if git push; then
                 exit 0
               fi
+              if [ "$attempt" -eq 3 ]; then
+                break
+              fi
               echo "Push failed on attempt ${attempt}; rebasing before retry..."
               git pull --rebase || {
                 echo "Failed to rebase CI health before retry" >&2

--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -5,6 +5,10 @@ on:
     - cron: "*/15 * * * *" # Every 15 minutes
   workflow_dispatch: {} # Manual trigger
 
+concurrency:
+  group: slang-ci-analytics-publish
+  cancel-in-progress: false
+
 jobs:
   update-health:
     runs-on: ubuntu-latest
@@ -46,12 +50,23 @@ jobs:
 
       - name: Push health page
         run: |
-          cd ci_analytics_repo
+          cd ci_analytics_repo || exit 1
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add health.html status.html
           git add health_snapshots.jsonl 2>/dev/null || true
-          git diff --cached --quiet || {
-            git commit -m "Update CI health $(date -u +%Y-%m-%dT%H:%M)" &&
-            git push
-          }
+          if ! git diff --cached --quiet; then
+            git commit -m "Update CI health $(date -u +%Y-%m-%dT%H:%M)"
+            for attempt in 1 2 3; do
+              if git push; then
+                exit 0
+              fi
+              echo "Push failed on attempt ${attempt}; rebasing before retry..."
+              git pull --rebase || {
+                echo "Failed to rebase CI health before retry" >&2
+                exit 1
+              }
+            done
+            echo "Failed to push CI health after retries" >&2
+            exit 1
+          fi

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -173,6 +173,7 @@ def fetch_gpu_quota(metrics=None):
         for region in config.get("regions", []):
             metrics_by_region.setdefault(region, set()).add(config["metric"])
 
+    errors = []
     for region in metrics_by_region:
         cmd = [
             "gcloud", "compute", "regions", "describe", region,
@@ -187,17 +188,21 @@ def fetch_gpu_quota(metrics=None):
             return None
         except subprocess.TimeoutExpired:
             print(f"Warning: timeout fetching GPU quota for {region}", file=sys.stderr)
+            errors.append(f"{region}: timeout")
             continue
         if result.returncode != 0:
+            error = result.stderr.strip() or f"gcloud exited {result.returncode}"
             print(
-                f"Warning: gcloud failed for {region}: {result.stderr.strip()}",
+                f"Warning: gcloud failed for {region}: {error}",
                 file=sys.stderr,
             )
+            errors.append(f"{region}: {error}")
             continue
         try:
             data = json.loads(result.stdout)
         except json.JSONDecodeError:
             print(f"Warning: invalid GPU quota JSON for {region}", file=sys.stderr)
+            errors.append(f"{region}: invalid JSON")
             continue
 
         wanted_metrics = metrics_by_region[region]
@@ -213,6 +218,7 @@ def fetch_gpu_quota(metrics=None):
                     f"Warning: invalid quota values for {metric} in {region}",
                     file=sys.stderr,
                 )
+                errors.append(f"{region}/{metric}: invalid quota values")
                 continue
             bucket = by_metric[metric]
             bucket["regions"][region] = {"usage": usage, "limit": limit}
@@ -228,6 +234,9 @@ def fetch_gpu_quota(metrics=None):
         return None
 
     result = {"by_metric": by_metric}
+    if errors:
+        result["partial"] = True
+        result["errors"] = errors
     legacy = by_metric.get(GPU_QUOTA_METRIC)
     if legacy:
         result.update({
@@ -317,7 +326,7 @@ def fetch_recent_failures(repo):
         "workflow_runs",
     )
     if err:
-        return []
+        return {"failures": [], "partial": True, "errors": [err]}
 
     cutoff = cutoff_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
     failures = []
@@ -337,7 +346,7 @@ def fetch_recent_failures(repo):
             "created_at": event_time,
             "actor": (run.get("actor") or {}).get("login", ""),
         })
-    return failures[:10]
+    return {"failures": failures[:10], "partial": False, "errors": []}
 
 
 def fetch_merge_queue_status(repo):
@@ -358,7 +367,12 @@ def fetch_merge_queue_status(repo):
         "workflow_runs",
     )
     if err:
-        return None
+        return {
+            "recent": [],
+            "summary": {"success": 0, "failure": 0, "cancelled": 0, "in_progress": 0},
+            "partial": True,
+            "errors": [err],
+        }
 
     recent = []
     counts = {"success": 0, "failure": 0, "cancelled": 0, "in_progress": 0}
@@ -397,6 +411,12 @@ def record_snapshot(queue_data, output_dir, gpu_quota=None, mq_data=None, hosted
     snapshot = {"timestamp": now.strftime("%Y-%m-%dT%H:%M:%SZ")}
 
     if queue_data:
+        if queue_data.get("partial"):
+            snapshot["queue_partial"] = True
+            if queue_data.get("list_errors"):
+                snapshot["queue_list_errors"] = queue_data["list_errors"]
+            if queue_data.get("job_fetch_errors"):
+                snapshot["queue_job_fetch_errors"] = queue_data["job_fetch_errors"]
         # Aggregate runner counts by group
         summary = queue_data.get("summary", {})
         snapshot["jobs_queued"] = summary.get("jobs_queued", 0)
@@ -427,6 +447,10 @@ def record_snapshot(queue_data, output_dir, gpu_quota=None, mq_data=None, hosted
 
     # GPU quota per region
     if gpu_quota:
+        if gpu_quota.get("partial"):
+            snapshot["gpu_quota_partial"] = True
+            if gpu_quota.get("errors"):
+                snapshot["gpu_quota_errors"] = gpu_quota["errors"]
         by_metric = _normalize_gpu_quota_by_metric(gpu_quota)
         if by_metric:
             snapshot["gpu_quota_by_metric"] = by_metric
@@ -436,7 +460,12 @@ def record_snapshot(queue_data, output_dir, gpu_quota=None, mq_data=None, hosted
 
     # Merge queue summary
     if mq_data:
-        snapshot["merge_queue"] = mq_data.get("summary", {})
+        if mq_data.get("partial"):
+            snapshot["merge_queue_partial"] = True
+            if mq_data.get("errors"):
+                snapshot["merge_queue_errors"] = mq_data["errors"]
+        else:
+            snapshot["merge_queue"] = mq_data.get("summary", {})
 
     if hosted_runner_usage:
         snapshot["hosted_runner_usage"] = hosted_runner_usage
@@ -568,8 +597,10 @@ def _build_gpu_quota_charts(snapshots):
 
         region_series = {
             region: [
-                quota.get("regions", {}).get(region, {}).get("usage", 0)
-                for quota in metric_snapshots
+                None
+                if snapshots[i].get("gpu_quota_partial")
+                else quota.get("regions", {}).get(region, {}).get("usage", 0)
+                for i, quota in enumerate(metric_snapshots)
             ]
             for region in regions
         }
@@ -726,18 +757,34 @@ def build_history_chart(snapshots):
     gcp_vm_groups = GCP_VM_GROUPS
     palette = GCP_VM_PALETTE
 
-    # Queue depth over time
-    queued_data = [s.get("jobs_queued", 0) for s in snapshots]
-    running_data = [s.get("jobs_running", 0) for s in snapshots]
+    # Queue depth over time. Partial queue samples are known undercounts,
+    # so render them as gaps rather than false-low points.
+    queued_data = [
+        None if s.get("queue_partial") else s.get("jobs_queued", 0)
+        for s in snapshots
+    ]
+    running_data = [
+        None if s.get("queue_partial") else s.get("jobs_running", 0)
+        for s in snapshots
+    ]
 
     # Active CI workflow runs over time
-    runs_in_progress = [s.get("runs_in_progress", 0) for s in snapshots]
-    runs_queued = [s.get("runs_queued", 0) for s in snapshots]
+    runs_in_progress = [
+        None if s.get("queue_partial") else s.get("runs_in_progress", 0)
+        for s in snapshots
+    ]
+    runs_queued = [
+        None if s.get("queue_partial") else s.get("runs_queued", 0)
+        for s in snapshots
+    ]
 
     # Build per-group data series
     group_series = {}
     for g in gcp_vm_groups:
-        group_series[g] = [s.get("runner_groups", {}).get(g, {}).get("total", 0) for s in snapshots]
+        group_series[g] = [
+            None if s.get("queue_partial") else s.get("runner_groups", {}).get(g, {}).get("total", 0)
+            for s in snapshots
+        ]
 
     gpu_quota_charts = _build_gpu_quota_charts(snapshots)
 
@@ -747,9 +794,29 @@ def build_history_chart(snapshots):
 
     # Merge queue cumulative success/failure from snapshots
     # Each snapshot records the running 24h totals; we just plot them over time.
-    mq_success_data = [s.get("merge_queue", {}).get("success", 0) for s in snapshots]
-    mq_failure_data = [s.get("merge_queue", {}).get("failure", 0) for s in snapshots]
+    mq_success_data = [
+        None if s.get("merge_queue_partial") else s.get("merge_queue", {}).get("success", 0)
+        for s in snapshots
+    ]
+    mq_failure_data = [
+        None if s.get("merge_queue_partial") else s.get("merge_queue", {}).get("failure", 0)
+        for s in snapshots
+    ]
     has_mq_snapshots = any(s.get("merge_queue") for s in snapshots)
+    partial_notes = []
+    if any(s.get("queue_partial") for s in snapshots):
+        partial_notes.append("queue")
+    if any(s.get("gpu_quota_partial") for s in snapshots):
+        partial_notes.append("GPU quota")
+    if any(s.get("merge_queue_partial") for s in snapshots):
+        partial_notes.append("merge queue")
+    partial_note_html = ""
+    if partial_notes:
+        partial_note_html = (
+            '<p style="color:#6c757d">Some '
+            + ", ".join(partial_notes)
+            + " samples were partial; affected chart points are rendered as gaps.</p>"
+        )
 
     charts_html = (
         chart_section("runnerHistory", "GCP Runner VMs",
@@ -786,6 +853,7 @@ def build_history_chart(snapshots):
     <option value="24" selected>Last 24 hours</option>
   </select>
 </div>
+{partial_note_html}
 {charts_html}
 <script src="{CHARTJS_CDN}"></script>
 <script>
@@ -1173,6 +1241,12 @@ def generate_health_html(queue_data, failures, output_dir, mq_data=None, hosted_
     queue_html = ""
     if queue_data:
         summary = queue_data.get("summary", {})
+        partial_html = ""
+        if queue_data.get("partial"):
+            partial_html = (
+                '<p style="color:#6c757d">Queue sample is partial and may undercount '
+                "running or queued jobs (GitHub Actions API failure during collection).</p>"
+            )
         queue_html = f"""
 <div>
   <div class="stat-card"><div class="value">{summary.get('jobs_queued', 0)}</div><div class="label">Jobs Queued</div></div>
@@ -1180,6 +1254,7 @@ def generate_health_html(queue_data, failures, output_dir, mq_data=None, hosted_
   <div class="stat-card"><div class="value">{summary.get('runs_queued', 0)}</div><div class="label">Runs Queued</div></div>
   <div class="stat-card"><div class="value">{summary.get('runs_in_progress', 0)}</div><div class="label">Runs In Progress</div></div>
 </div>
+{partial_html}
 """
         # Queue depth by group
         groups = queue_data.get("queue_by_group", [])
@@ -1231,9 +1306,19 @@ def generate_health_html(queue_data, failures, output_dir, mq_data=None, hosted_
 
     # Recent failures section
     failures_html = ""
-    if failures:
+    failures_partial = False
+    failure_entries = failures or []
+    if isinstance(failures, dict):
+        failures_partial = failures.get("partial", False)
+        failure_entries = failures.get("failures", [])
+    if failures_partial:
+        failures_html = (
+            "<p>Recent CI failure data unavailable "
+            "(GitHub Actions API failure during collection).</p>"
+        )
+    elif failure_entries:
         failures_html = '<table><tr><th>Branch</th><th>Actor</th><th>Time</th></tr>\n'
-        for f in failures:
+        for f in failure_entries:
             branch = f.get("branch", "")
             actor = f.get("actor", "")
             url = f.get("url", "")
@@ -1246,7 +1331,12 @@ def generate_health_html(queue_data, failures, output_dir, mq_data=None, hosted_
 
     # Merge queue section
     mq_html = ""
-    if mq_data:
+    if mq_data and mq_data.get("partial"):
+        mq_html = (
+            "<p>Merge queue status unavailable "
+            "(GitHub Actions API failure during collection).</p>"
+        )
+    elif mq_data:
         summary = mq_data.get("summary", {})
         fail_rate = 0
         sf_total = summary.get("success", 0) + summary.get("failure", 0)
@@ -1328,12 +1418,21 @@ def main():
     if gpu_quota:
         for quota in _normalize_gpu_quota_by_metric(gpu_quota).values():
             print(f"  {quota.get('name', 'GPU')} GPUs: {quota['usage']}/{quota['limit']} in use")
+        if gpu_quota.get("partial"):
+            print(
+                f"  Warning: GPU quota sample is partial "
+                f"({len(gpu_quota.get('errors', []))} region errors); "
+                f"chart points will render as gaps.",
+                file=sys.stderr,
+            )
     else:
         print("  GPU quota unavailable (gcloud not configured or not accessible)")
 
     print("Fetching merge queue status...")
     mq_data = fetch_merge_queue_status(args.repo)
-    if mq_data:
+    if mq_data and mq_data.get("partial"):
+        print("  Merge queue data unavailable")
+    elif mq_data:
         s = mq_data["summary"]
         print(f"  24h: {s['success']} passed, {s['failure']} failed, {s['cancelled']} cancelled, {s['in_progress']} in progress")
     else:

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -305,14 +305,21 @@ def fetch_recent_failures(repo):
     sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
     from gh_api import gh_api_list
 
+    now = datetime.now(timezone.utc)
+    cutoff_dt = now - timedelta(hours=3)
+    # Query a wider creation window than the displayed update window so a
+    # longer-running CI job that finishes recently is still eligible.
+    created_from = (cutoff_dt - timedelta(hours=6)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    created_to = now.strftime("%Y-%m-%dT%H:%M:%SZ")
     runs, err = gh_api_list(
-        f"repos/{repo}/actions/runs?status=completed&per_page=20",
+        f"repos/{repo}/actions/runs?status=completed&per_page=100"
+        f"&created={created_from}..{created_to}",
         "workflow_runs",
     )
     if err:
         return []
 
-    cutoff = (datetime.now(timezone.utc) - timedelta(hours=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    cutoff = cutoff_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
     failures = []
     for run in (runs or []):
         if run.get("name") != "CI":
@@ -341,14 +348,18 @@ def fetch_merge_queue_status(repo):
     sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
     from gh_api import gh_api_list, parse_merge_queue_pr_number
 
+    now = datetime.now(timezone.utc)
+    cutoff_dt = now - timedelta(hours=24)
+    cutoff = cutoff_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    created_to = now.strftime("%Y-%m-%dT%H:%M:%SZ")
     runs, err = gh_api_list(
-        f"repos/{repo}/actions/runs?event=merge_group&per_page=50",
+        f"repos/{repo}/actions/runs?event=merge_group&per_page=100"
+        f"&created={cutoff}..{created_to}",
         "workflow_runs",
     )
     if err:
         return None
 
-    cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).strftime("%Y-%m-%dT%H:%M:%SZ")
     recent = []
     counts = {"success": 0, "failure": 0, "cancelled": 0, "in_progress": 0}
     for run in (runs or []):

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -352,7 +352,7 @@ def fetch_recent_failures(repo):
 def fetch_merge_queue_status(repo):
     """Fetch recent merge queue CI runs (last 24 hours).
 
-    Returns a dict with 'recent' (list of runs), 'summary' counts.
+    Returns a dict with 'recent' runs, 'summary' counts, and partial status.
     """
     sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
     from gh_api import gh_api_list, parse_merge_queue_pr_number
@@ -399,7 +399,7 @@ def fetch_merge_queue_status(repo):
             "updated_at": run.get("updated_at", ""),
         })
 
-    return {"recent": recent, "summary": counts}
+    return {"recent": recent, "summary": counts, "partial": False, "errors": []}
 
 
 def record_snapshot(queue_data, output_dir, gpu_quota=None, mq_data=None, hosted_runner_usage=None):

--- a/extras/ci/analytics/ci_job_collector.py
+++ b/extras/ci/analytics/ci_job_collector.py
@@ -300,11 +300,9 @@ def _fetch_runs_window(
     )
 
     if err:
-        print(
-            f"  Warning: API error for {from_str}..{to_str}: {err}",
-            file=sys.stderr,
+        raise DataCompletenessError(
+            f"API error while fetching workflow runs for {from_str}..{to_str}: {err}"
         )
-        return []
 
     if not runs:
         return []

--- a/extras/ci/analytics/ci_post_status.py
+++ b/extras/ci/analytics/ci_post_status.py
@@ -186,34 +186,43 @@ def commit_and_push(repo_dir, message):
         print(f"Error: commit failed:\n{result.stderr}", file=sys.stderr)
         return False
 
-    print("Pushing...")
-    result = run_git(["push"], repo_dir)
-    if result.returncode != 0:
-        stderr = result.stderr.strip()
-        print("\nError: push failed.", file=sys.stderr)
-        if "GH007" in stderr or "email privacy" in stderr:
-            print(
-                "\nGitHub blocked the push due to email privacy settings.\n"
-                "Fix: Go to https://github.com/settings/emails and either:\n"
-                "  1. Uncheck 'Block command line pushes that expose my email', or\n"
-                "  2. Set your git email to your GitHub noreply address:\n"
-                "     git config --global user.email "
-                "'<ID>+<USER>@users.noreply.github.com'",
-                file=sys.stderr,
-            )
-        elif "Permission denied" in stderr or "Authentication failed" in stderr:
-            print(
-                "\nPush access denied. You need write access to\n"
-                f"  {REPO}\n"
-                "Ask a maintainer to add you as a collaborator.",
-                file=sys.stderr,
-            )
-        else:
-            print(stderr, file=sys.stderr)
-        return False
+    result = None
+    for attempt in range(1, 4):
+        print(f"Pushing (attempt {attempt}/3)...")
+        result = run_git(["push"], repo_dir)
+        if result.returncode == 0:
+            print("Pushed successfully.")
+            return True
+        if attempt == 3:
+            break
+        print("Push failed; rebasing before retry...", file=sys.stderr)
+        pull = run_git(["pull", "--rebase"], repo_dir)
+        if pull.returncode != 0:
+            print(f"Error: pull --rebase failed:\n{pull.stderr}", file=sys.stderr)
+            return False
 
-    print("Pushed successfully.")
-    return True
+    stderr = result.stderr.strip() if result else ""
+    print("\nError: push failed.", file=sys.stderr)
+    if "GH007" in stderr or "email privacy" in stderr:
+        print(
+            "\nGitHub blocked the push due to email privacy settings.\n"
+            "Fix: Go to https://github.com/settings/emails and either:\n"
+            "  1. Uncheck 'Block command line pushes that expose my email', or\n"
+            "  2. Set your git email to your GitHub noreply address:\n"
+            "     git config --global user.email "
+            "'<ID>+<USER>@users.noreply.github.com'",
+            file=sys.stderr,
+        )
+    elif "Permission denied" in stderr or "Authentication failed" in stderr:
+        print(
+            "\nPush access denied. You need write access to\n"
+            f"  {REPO}\n"
+            "Ask a maintainer to add you as a collaborator.",
+            file=sys.stderr,
+        )
+    else:
+        print(stderr, file=sys.stderr)
+    return False
 
 
 def cmd_add(args, tmpdir):

--- a/extras/ci/analytics/pr_collector.py
+++ b/extras/ci/analytics/pr_collector.py
@@ -31,6 +31,10 @@ DEFAULT_DAYS = 30
 DEFAULT_OUTPUT = "pr_merges.json"
 
 
+class DataCompletenessError(RuntimeError):
+    """Raised when GitHub API failures prevent complete PR collection."""
+
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Collect merged PR data from GitHub and save as JSON."
@@ -148,9 +152,9 @@ def fetch_merged_prs(repo, since_date, verbose=False):
         )
 
         if err:
-            print(f" error: {err}", file=sys.stderr)
-            current = next_window
-            continue
+            raise DataCompletenessError(
+                f"API error while fetching merged PRs for {from_str}..{to_str}: {err}"
+            )
 
         new_count = 0
         for pr in prs or []:
@@ -205,7 +209,11 @@ def main():
     start_date = get_start_date(args.days, existing, args.verbose)
     print(f"Collecting merged PRs since {start_date.isoformat()}")
 
-    raw_prs = fetch_merged_prs(args.repo, start_date, args.verbose)
+    try:
+        raw_prs = fetch_merged_prs(args.repo, start_date, args.verbose)
+    except DataCompletenessError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(2)
     if not raw_prs:
         print("No merged PRs found in the specified time range.")
         if existing_count > 0:

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -428,6 +428,85 @@ class TestGpuQuota(unittest.TestCase):
         # The chart section HTML should not be present (JS guard is fine)
         self.assertNotIn("T4 GPU Usage", html)
 
+    def test_gpu_quota_partial_snapshot_renders_chart_gap(self):
+        snapshots = [
+            {
+                "timestamp": "2026-03-03T10:00:00Z",
+                "runner_groups": {},
+                "gpu_quota_by_metric": {
+                    "NVIDIA_T4_GPUS": {
+                        "name": "T4",
+                        "usage": 6,
+                        "limit": 8,
+                        "regions": {"us-central1": {"usage": 6, "limit": 8}},
+                    },
+                },
+            },
+            {
+                "timestamp": "2026-03-03T10:15:00Z",
+                "runner_groups": {},
+                "gpu_quota_partial": True,
+                "gpu_quota_by_metric": {
+                    "NVIDIA_T4_GPUS": {
+                        "name": "T4",
+                        "usage": 0,
+                        "limit": 8,
+                        "regions": {"us-central1": {"usage": 0, "limit": 8}},
+                    },
+                },
+            },
+        ]
+
+        charts = ci_health._build_gpu_quota_charts(snapshots)
+
+        self.assertEqual(charts[0]["regionData"]["us-central1"], [6, None])
+
+
+class TestHealthPartialRendering(unittest.TestCase):
+    def test_recent_failures_partial_does_not_render_false_healthy_empty_state(self):
+        queue_data = {
+            "summary": {
+                "jobs_queued": 0,
+                "jobs_running": 0,
+                "runs_queued": 0,
+                "runs_in_progress": 0,
+            },
+            "self_hosted_runners": [],
+            "queue_by_group": [],
+            "longest_waiting_jobs": [],
+        }
+        failures = {"failures": [], "partial": True, "errors": ["HTTP 502"]}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            ci_health.generate_health_html(queue_data, failures, tmp)
+            with open(os.path.join(tmp, "health.html"), encoding="utf-8") as f:
+                html = f.read()
+
+        self.assertIn("Recent CI failure data unavailable", html)
+        self.assertNotIn("No recent CI failures", html)
+
+    def test_queue_partial_renders_warning(self):
+        queue_data = {
+            "summary": {
+                "jobs_queued": 0,
+                "jobs_running": 0,
+                "runs_queued": 0,
+                "runs_in_progress": 0,
+            },
+            "partial": True,
+            "list_errors": ["HTTP 502"],
+            "self_hosted_runners": [],
+            "queue_by_group": [],
+            "longest_waiting_jobs": [],
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            ci_health.generate_health_html(queue_data, [], tmp)
+            with open(os.path.join(tmp, "health.html"), encoding="utf-8") as f:
+                html = f.read()
+
+        self.assertIn("Queue sample is partial", html)
+
 
 class TestHealthApiBounds(unittest.TestCase):
     def test_recent_failures_query_is_bounded_by_created_range(self):
@@ -1084,7 +1163,7 @@ class TestQueueStatusJson(unittest.TestCase):
         with mock.patch.object(
             module,
             "fetch_runs",
-            return_value=[],
+            return_value=([], None),
         ), mock.patch.object(
             module,
             "fetch_runners",
@@ -1105,6 +1184,35 @@ class TestQueueStatusJson(unittest.TestCase):
         self.assertEqual(payload["summary"]["jobs_running"], 0)
         self.assertEqual(payload["queue_by_group"], [])
         self.assertEqual(payload["longest_waiting_jobs"], [])
+
+    def test_json_mode_marks_listing_failures_partial(self):
+        module = load_queue_status_module()
+
+        def fake_runs(repo, status):
+            if status == "queued":
+                return [], "HTTP 502"
+            return [], None
+
+        with mock.patch.object(
+            module,
+            "fetch_runs",
+            side_effect=fake_runs,
+        ), mock.patch.object(
+            module,
+            "fetch_runners",
+            return_value=([], True),
+        ), mock.patch.object(
+            module.sys,
+            "argv",
+            ["ci-queue-status.py", "--json"],
+        ):
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                module.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertTrue(payload["partial"])
+        self.assertEqual(payload["list_errors"], ["HTTP 502"])
 
 
 class TestHostedRunnerUsage(unittest.TestCase):

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -534,13 +534,15 @@ class TestHealthApiBounds(unittest.TestCase):
             return [], None
 
         with mock.patch.object(gh_api, "gh_api_list", side_effect=fake_list):
-            ci_health.fetch_merge_queue_status("shader-slang/slang")
+            result = ci_health.fetch_merge_queue_status("shader-slang/slang")
 
         self.assertEqual(calls[0][1], "workflow_runs")
         self.assertIn("event=merge_group", calls[0][0])
         self.assertIn("per_page=100", calls[0][0])
         self.assertIn("&created=", calls[0][0])
         self.assertIn("..", calls[0][0])
+        self.assertFalse(result["partial"])
+        self.assertEqual(result["errors"], [])
 
 
 class TestStatisticsRunnerNamePrefixes(unittest.TestCase):

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -18,6 +18,7 @@ import ci_health
 import ci_hosted_runner_usage
 import ci_job_collector
 import pr_collector
+import ci_post_status
 import ci_status
 import ci_visualization
 import gh_api
@@ -1213,6 +1214,61 @@ class TestQueueStatusJson(unittest.TestCase):
         payload = json.loads(stdout.getvalue())
         self.assertTrue(payload["partial"])
         self.assertEqual(payload["list_errors"], ["HTTP 502"])
+
+
+class TestStatusPosterPushRetry(unittest.TestCase):
+    def test_commit_and_push_rebases_and_retries_stale_push(self):
+        calls = []
+        push_count = {"value": 0}
+
+        def result(code, stderr="", stdout=""):
+            r = mock.Mock()
+            r.returncode = code
+            r.stdout = stdout
+            r.stderr = stderr
+            return r
+
+        def fake_run_git(args, cwd):
+            calls.append(args)
+            if args == ["config", "user.name"]:
+                return result(0, stdout="Test User\n")
+            if args == ["config", "user.email"]:
+                return result(0, stdout="test@example.com\n")
+            if args[:2] in (["config", "user.name"], ["config", "user.email"]):
+                return result(0)
+            if args == ["add", ci_post_status.STATUS_FILE]:
+                return result(0)
+            if args == ["diff", "--cached", "--quiet"]:
+                return result(1)
+            if args[:1] == ["commit"]:
+                return result(0)
+            if args == ["push"]:
+                push_count["value"] += 1
+                if push_count["value"] == 1:
+                    return result(1, "non-fast-forward")
+                return result(0)
+            if args == ["pull", "--rebase"]:
+                return result(0)
+            return result(0)
+
+        with mock.patch.object(
+            ci_post_status,
+            "get_slang_git_identity",
+            return_value=("Test User", "test@example.com"),
+        ), mock.patch.object(
+            ci_post_status,
+            "get_github_username",
+            return_value=None,
+        ), mock.patch.object(
+            ci_post_status,
+            "run_git",
+            side_effect=fake_run_git,
+        ):
+            ok = ci_post_status.commit_and_push("/tmp/repo", "Status: test")
+
+        self.assertTrue(ok)
+        self.assertEqual(push_count["value"], 2)
+        self.assertIn(["pull", "--rebase"], calls)
 
 
 class TestHostedRunnerUsage(unittest.TestCase):

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -16,6 +16,7 @@ if ANALYTICS_DIR not in sys.path:
 import ci_health
 import ci_hosted_runner_usage
 import ci_job_collector
+import pr_collector
 import ci_status
 import ci_visualization
 
@@ -996,6 +997,40 @@ class TestMonthlySplit(unittest.TestCase):
 
             self.assertEqual({j["id"] for j in feb_data}, {1})
             self.assertEqual({j["id"] for j in mar_data}, {2, 3})
+
+
+class TestCollectionCompleteness(unittest.TestCase):
+    def test_run_listing_error_raises_completeness_error(self):
+        start = datetime(2026, 3, 1, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 3, 2, 0, 0, tzinfo=timezone.utc)
+
+        with mock.patch.object(
+            ci_job_collector,
+            "gh_api_list",
+            return_value=(None, "HTTP 502"),
+        ):
+            with self.assertRaises(ci_job_collector.DataCompletenessError):
+                ci_job_collector._fetch_runs_window(
+                    "shader-slang/slang",
+                    start,
+                    end,
+                    set(),
+                    workflow_id=123,
+                )
+
+    def test_pr_search_error_raises_completeness_error(self):
+        start = datetime(2026, 3, 1, 0, 0, tzinfo=timezone.utc)
+
+        with mock.patch.object(
+            pr_collector,
+            "gh_api_list",
+            return_value=(None, "HTTP 502"),
+        ):
+            with self.assertRaises(pr_collector.DataCompletenessError):
+                pr_collector.fetch_merged_prs(
+                    "shader-slang/slang",
+                    start,
+                )
 
 
 class TestHostedRunnerUsage(unittest.TestCase):

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -1,5 +1,6 @@
 import contextlib
 import io
+import importlib.util
 import json
 import os
 import sys
@@ -19,6 +20,14 @@ import ci_job_collector
 import pr_collector
 import ci_status
 import ci_visualization
+
+
+def load_queue_status_module():
+    path = os.path.join(os.path.dirname(ANALYTICS_DIR), "ci-queue-status.py")
+    spec = importlib.util.spec_from_file_location("ci_queue_status_for_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 class TestRunnerTypeCoverage(unittest.TestCase):
@@ -1031,6 +1040,36 @@ class TestCollectionCompleteness(unittest.TestCase):
                     "shader-slang/slang",
                     start,
                 )
+
+
+class TestQueueStatusJson(unittest.TestCase):
+    def test_json_mode_emits_zero_payload_when_no_active_runs(self):
+        module = load_queue_status_module()
+
+        with mock.patch.object(
+            module,
+            "fetch_runs",
+            return_value=[],
+        ), mock.patch.object(
+            module,
+            "fetch_runners",
+            return_value=([], True),
+        ), mock.patch.object(
+            module.sys,
+            "argv",
+            ["ci-queue-status.py", "--json"],
+        ):
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                module.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["summary"]["runs_queued"], 0)
+        self.assertEqual(payload["summary"]["runs_in_progress"], 0)
+        self.assertEqual(payload["summary"]["jobs_queued"], 0)
+        self.assertEqual(payload["summary"]["jobs_running"], 0)
+        self.assertEqual(payload["queue_by_group"], [])
+        self.assertEqual(payload["longest_waiting_jobs"], [])
 
 
 class TestHostedRunnerUsage(unittest.TestCase):

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -20,6 +20,7 @@ import ci_job_collector
 import pr_collector
 import ci_status
 import ci_visualization
+import gh_api
 
 
 def load_queue_status_module():
@@ -426,6 +427,40 @@ class TestGpuQuota(unittest.TestCase):
         html = ci_health.build_history_chart(snapshots)
         # The chart section HTML should not be present (JS guard is fine)
         self.assertNotIn("T4 GPU Usage", html)
+
+
+class TestHealthApiBounds(unittest.TestCase):
+    def test_recent_failures_query_is_bounded_by_created_range(self):
+        calls = []
+
+        def fake_list(endpoint, key):
+            calls.append((endpoint, key))
+            return [], None
+
+        with mock.patch.object(gh_api, "gh_api_list", side_effect=fake_list):
+            ci_health.fetch_recent_failures("shader-slang/slang")
+
+        self.assertEqual(calls[0][1], "workflow_runs")
+        self.assertIn("status=completed", calls[0][0])
+        self.assertIn("per_page=100", calls[0][0])
+        self.assertIn("&created=", calls[0][0])
+        self.assertIn("..", calls[0][0])
+
+    def test_merge_queue_query_is_bounded_by_created_range(self):
+        calls = []
+
+        def fake_list(endpoint, key):
+            calls.append((endpoint, key))
+            return [], None
+
+        with mock.patch.object(gh_api, "gh_api_list", side_effect=fake_list):
+            ci_health.fetch_merge_queue_status("shader-slang/slang")
+
+        self.assertEqual(calls[0][1], "workflow_runs")
+        self.assertIn("event=merge_group", calls[0][0])
+        self.assertIn("per_page=100", calls[0][0])
+        self.assertIn("&created=", calls[0][0])
+        self.assertIn("..", calls[0][0])
 
 
 class TestStatisticsRunnerNamePrefixes(unittest.TestCase):

--- a/extras/ci/ci-queue-status.py
+++ b/extras/ci/ci-queue-status.py
@@ -89,8 +89,8 @@ def fetch_runs(repo, status):
     )
     if err:
         print(f"Warning: Failed to fetch {status} runs: {err}", file=sys.stderr)
-        return []
-    return data if isinstance(data, list) else []
+        return [], err
+    return data if isinstance(data, list) else [], None
 
 
 def fetch_jobs_for_run(repo, run_id):
@@ -100,8 +100,9 @@ def fetch_jobs_for_run(repo, run_id):
         "jobs",
     )
     if err:
-        return []
-    return data if isinstance(data, list) else []
+        print(f"Warning: Failed to fetch jobs for run {run_id}: {err}", file=sys.stderr)
+        return [], err
+    return data if isinstance(data, list) else [], None
 
 
 def fetch_runners(repo):
@@ -456,7 +457,18 @@ def print_runner_status(runners, all_jobs, runners_available):
             print(line)
 
 
-def build_json_output(queued_runs, inprogress_runs, all_jobs, runners, runners_available, now, repo):
+def build_json_output(
+    queued_runs,
+    inprogress_runs,
+    all_jobs,
+    runners,
+    runners_available,
+    now,
+    repo,
+    partial=False,
+    list_errors=None,
+    job_fetch_errors=0,
+):
     """Build JSON output structure for programmatic consumption."""
     queued_jobs = [j for j in all_jobs if j["status"] in ("queued", "waiting")]
     running_jobs = [j for j in all_jobs if j["status"] == "in_progress"]
@@ -585,7 +597,7 @@ def build_json_output(queued_runs, inprogress_runs, all_jobs, runners, runners_a
                 }
             runner_status.append(entry)
 
-    return {
+    payload = {
         "fetched_at": now.strftime("%Y-%m-%d %H:%M:%S UTC"),
         "repo": repo,
         "summary": {
@@ -601,6 +613,13 @@ def build_json_output(queued_runs, inprogress_runs, all_jobs, runners, runners_a
         "self_hosted_runners": runner_status,
         "runners_available": runners_available,
     }
+    if partial:
+        payload["partial"] = True
+    if list_errors:
+        payload["list_errors"] = list_errors
+    if job_fetch_errors:
+        payload["job_fetch_errors"] = job_fetch_errors
+    return payload
 
 
 def main():
@@ -635,11 +654,12 @@ def main():
         inprogress_future = executor.submit(fetch_runs, repo, "in_progress")
         runners_future = executor.submit(fetch_runners, repo)
 
-        queued_runs = queued_future.result()
-        inprogress_runs = inprogress_future.result()
+        queued_runs, queued_err = queued_future.result()
+        inprogress_runs, inprogress_err = inprogress_future.result()
         runners, runners_available = runners_future.result()
 
     all_runs = queued_runs + inprogress_runs
+    list_errors = [e for e in (queued_err, inprogress_err) if e]
 
     if not all_runs:
         if args.json:
@@ -651,6 +671,8 @@ def main():
                 runners_available,
                 now,
                 repo,
+                partial=bool(list_errors),
+                list_errors=list_errors,
             )
             print(json.dumps(payload, indent=2))
             return
@@ -664,6 +686,7 @@ def main():
         flush=True,
     )
 
+    job_fetch_errors = 0
     with ThreadPoolExecutor(max_workers=8) as executor:
         futures = {
             executor.submit(fetch_jobs_for_run, repo, r["id"]): r
@@ -672,7 +695,9 @@ def main():
         }
         for future in as_completed(futures):
             run = futures[future]
-            jobs = future.result()
+            jobs, err = future.result()
+            if err:
+                job_fetch_errors += 1
             # Annotate jobs with parent run info for display
             for job in jobs:
                 job["_branch"] = run.get("head_branch", "")
@@ -696,6 +721,9 @@ def main():
             runners_available,
             now,
             repo,
+            partial=bool(list_errors or job_fetch_errors),
+            list_errors=list_errors,
+            job_fetch_errors=job_fetch_errors,
         )
         payload["longest_waiting_jobs"] = payload["longest_waiting_jobs"][
             : args.top_waiting

--- a/extras/ci/ci-queue-status.py
+++ b/extras/ci/ci-queue-status.py
@@ -642,6 +642,18 @@ def main():
     all_runs = queued_runs + inprogress_runs
 
     if not all_runs:
+        if args.json:
+            payload = build_json_output(
+                queued_runs,
+                inprogress_runs,
+                [],
+                runners,
+                runners_available,
+                now,
+                repo,
+            )
+            print(json.dumps(payload, indent=2))
+            return
         print("No queued or in-progress runs found.")
         return
 


### PR DESCRIPTION
## Motivation

The CI analytics pipeline silently turned API failures into healthy-looking data. Concretely:

- A swallowed paging error in `ci_job_collector`/`pr_collector` dropped jobs/PRs from the durable monthly files permanently — and the run still reported success.
- `ci-queue-status.py --json` emitted *no JSON* when CI was genuinely idle (it hit the human-readable "No queued runs" path), so `ci_health` couldn't distinguish "idle" from "collection failed."
- An API error in `fetch_recent_failures`/`fetch_merge_queue_status` rendered as "No recent CI failures" / an empty merge-queue panel — a false all-clear. Partial queue samples plotted as `0`, reading as "CI recovered" on the depth chart.
- The daily `ci-analytics` and 15-minute `ci-health` crons race on the same analytics repo; a stale checkout produced non-fast-forward push failures that lost a snapshot.

## Proposed solution

Apply the principle **"an API failure must never masquerade as a healthy/idle state,"** at the right severity per consumer:

- **Durable historical collectors hard-fail.** `ci_job_collector._fetch_runs_window` and `pr_collector.fetch_merged_prs` raise `DataCompletenessError` (exit 2) instead of returning `[]` — better to fail and retry than commit a corrupted month.
- **The live dashboard degrades visibly.** Collectors propagate a `partial` flag + error list; partial chart points render as **gaps** (`None`) rather than false-low zeros, and each affected section shows a warning banner. Idle CI now emits a zero-payload JSON distinct from a listing failure.
- **Queries are bounded** by a `created=` range so recent items can't fall off a single page.
- **Publisher pushes pull-rebase-retry** (3×) and both workflows share a `concurrency` group. The pull-rebase-retry is the actual fix for the stale-checkout race — the concurrency group only reduces how often the race occurs.

## Change summary

| Area | Change |
|------|--------|
| `ci_job_collector.py`, `pr_collector.py` | Raise `DataCompletenessError` on listing errors; `pr_collector.main` exits 2 |
| `ci-queue-status.py` | `fetch_runs`/`fetch_jobs_for_run` return `(data, err)`; emit zero-payload JSON when idle; thread `partial`/`list_errors`/`job_fetch_errors` into JSON |
| `ci_health.py` | Bound failure/merge-queue queries by `created=`; return dicts with `partial`; render gaps + banners in charts and HTML sections |
| `ci_post_status.py` | `commit_and_push` retries push 3× with `pull --rebase`; rebase failure is fatal |
| `ci-analytics.yml`, `ci-health.yml` | Shared `concurrency` group; push step retries with rebase; `cd ... \|\| exit 1` |
| `tests/test_ci_analytics.py` | +tests for completeness errors, idle/partial queue JSON, bounded queries, partial rendering, push retry |

## Concepts and vocabulary

- **partial sample** — a snapshot where at least one upstream API call failed; the value present is a known undercount, so consumers render it as a gap, not a data point.
- **zero-payload vs. partial** — idle CI (`partial=False`, all counts 0) is a real measurement; a listing failure (`partial=True`) is missing data. The distinction drives whether the dashboard shows "0" or a warning.
- **stale-checkout race** — the two crons check out the analytics repo independently; whichever pushes second hits a non-fast-forward. Pull-rebase-retry resolves it; the concurrency group just makes it rarer.

## Process report

Each change is justified by a named failing scenario, and each new return shape was checked against every consumer:

- **`DataCompletenessError` (hard-fail).** `ci_job_collector._fetch_runs_window` and `pr_collector.fetch_merged_prs` previously printed a warning and returned `[]` on a paging error, so a transient `HTTP 502` mid-collection silently dropped a window from the durable monthly `ci_jobs_*.json` / `pr_merges.json` files while the run exited 0. These now raise; `pr_collector.main` catches and exits 2. This is the correct severity asymmetry vs. `ci_health` — the historical record must be complete or absent, never silently truncated.
- **Idle vs. failed queue (`ci-queue-status.py`).** `fetch_runs`/`fetch_jobs_for_run` now return `(data, err)` so `main()` can distinguish a genuine empty result from a listing failure. When idle, `--json` emits a zero-payload (`partial=False`); on a listing error it emits `partial=True` + `list_errors`. Previously the idle path printed human text and emitted no JSON, so `ci_health.fetch_queue_status` got a JSON-decode error and treated idle CI as missing data.
- **Bounded queries (`ci_health.py`).** `fetch_recent_failures`/`fetch_merge_queue_status` add a `created=<from>..<to>` range with `per_page=100`, so a recent run can't fall off an unbounded first page. The failure window widens the *creation* lower bound by 6h so a long-running job that finishes recently is still eligible.
- **Visible degradation (`ci_health.py`).** Both functions now return dicts carrying `partial`; `record_snapshot` records `*_partial` flags; chart builders emit `None` for partial points (rendered as gaps, not false-low zeros) and add a legend note; `generate_health_html` shows per-section warning banners. The new `partial` dict shape is the *correct* representation, not a guard over a malformed one — incompleteness is known at the producer (the collector), so the flag originates there and every consumer reads it by key. Both `main()` callers handle the dict return; `fetch_queue_status` → `record_snapshot`/`generate_health_html` read the exact `partial`/`list_errors`/`job_fetch_errors` keys `ci-queue-status.py` emits.
- **Publisher push retry (`ci_post_status.py`, workflows).** `commit_and_push` retries `git push` up to 3× with `git pull --rebase` between attempts; a rebase failure is treated as fatal (a conflict won't self-heal by repeating the loop). The two workflow push steps mirror this exactly, and a shared `concurrency` group serializes the daily and 15-minute crons.

Verification: `python3 -m unittest extras/ci/analytics/tests/test_ci_analytics.py` (83 passed), `py_compile` of all touched modules, and `shellcheck` of both workflow push blocks — all clean.
