### PR TITLE
Fix abort extension name

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1356,7 +1356,7 @@ A capability describes an optional feature that a target may or may not support.
 * `SPV_KHR_quad_control` : enables the SPV_KHR_quad_control extension 
 * `SPV_KHR_fragment_shader_barycentric` : enables the SPV_KHR_fragment_shader_barycentric extension 
 * `SPV_KHR_non_semantic_info` : enables the SPV_KHR_non_semantic_info extension 
-* `SPV_KHR_shader_abort` : enables the SPV_KHR_shader_abort extension 
+* `SPV_KHR_abort` : enables the SPV_KHR_abort extension 
 * `SPV_KHR_device_group` : enables the SPV_KHR_device_group extension 
 * `SPV_KHR_variable_pointers` : enables the SPV_KHR_variable_pointers extension 
 * `SPV_KHR_ray_tracing` : enables the SPV_KHR_ray_tracing extension 
@@ -1384,6 +1384,7 @@ A capability describes an optional feature that a target may or may not support.
 * `SPV_EXT_descriptor_heap` : enables the SPV_EXT_descriptor_heap extension 
 * `SPV_KHR_untyped_pointers` : enables the SPV_KHR_untyped_pointers extension 
 * `SPV_KHR_bfloat16` : enables the SPV_KHR_bfloat16 extension 
+* `spvAbort` 
 * `spvDeviceGroup` 
 * `spvAtomicFloat32AddEXT` 
 * `spvAtomicFloat16AddEXT` 

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -476,7 +476,7 @@ Extensions
 
 `GL_EXT_shader_abort`
 > Represents the GL_EXT_shader_abort extension for GLSL targets, or the
-> corresponding SPV_KHR_shader_abort extension for SPIR-V targets.
+> corresponding spvAbort capability for SPIR-V targets.
 
 `GL_EXT_shader_atomic_float`
 > Represents the GL_EXT_shader_atomic_float extension.
@@ -638,6 +638,9 @@ Extensions
 `SPV_GOOGLE_user_type`
 > Represents the SPIR-V extension for SPV_GOOGLE_user_type.
 
+`SPV_KHR_abort`
+> Represents the SPIR-V extension for shader abort (SPV_KHR_abort).
+
 `SPV_KHR_bfloat16`
 > Represents the SPIR-V extension for BFloat16 types.
 
@@ -671,9 +674,6 @@ Extensions
 `SPV_KHR_ray_tracing_position_fetch`
 > Represents the SPIR-V extension for ray tracing position fetch.
 > Should be used with either SPV_KHR_ray_query or SPV_KHR_ray_tracing.
-
-`SPV_KHR_shader_abort`
-> Represents the SPIR-V extension for shader abort (VK_KHR_shader_abort).
 
 `SPV_KHR_shader_clock`
 > Represents the SPIR-V extension for shader clock.
@@ -723,6 +723,9 @@ Extensions
 
 `ser_hlsl_native`
 > DXR 1.3 native SER support (SM 6.9, no NVAPI required)
+
+`spvAbort`
+> Represents the SPIR-V AbortKHR capability for OpAbortKHR.
 
 `spvAtomicFloat16AddEXT`
 > Represents the SPIR-V capability for atomic float 16 add operations.

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -575,9 +575,9 @@ def SPV_KHR_fragment_shader_barycentric : _spirv_1_0;
 /// [EXT]
 def SPV_KHR_non_semantic_info : _spirv_1_0;
 
-/// Represents the SPIR-V extension for shader abort (VK_KHR_shader_abort).
+/// Represents the SPIR-V extension for shader abort (SPV_KHR_abort).
 /// [EXT]
-def SPV_KHR_shader_abort : _spirv_1_0;
+def SPV_KHR_abort : _spirv_1_0;
 
 /// Represents the SPIR-V extension for device-group information.
 /// [EXT]
@@ -695,6 +695,10 @@ def SPV_KHR_untyped_pointers : _spirv_1_0;
 def SPV_KHR_bfloat16: _spirv_1_0;
 
 // SPIRV Capabilities.
+
+/// Represents the SPIR-V AbortKHR capability for OpAbortKHR.
+/// [EXT]
+def spvAbort : SPV_KHR_abort;
 
 /// Represents the SPIR-V capability for DeviceGroup.
 /// [EXT]
@@ -1050,9 +1054,9 @@ alias GL_EXT_debug_printf = _GL_EXT_debug_printf | SPV_KHR_non_semantic_info;
 /// [EXT]
 def _GL_EXT_shader_abort : glsl;
 /// Represents the GL_EXT_shader_abort extension for GLSL targets, or the
-/// corresponding SPV_KHR_shader_abort extension for SPIR-V targets.
+/// corresponding spvAbort capability for SPIR-V targets.
 /// [EXT]
-alias GL_EXT_shader_abort = _GL_EXT_shader_abort | SPV_KHR_shader_abort;
+alias GL_EXT_shader_abort = _GL_EXT_shader_abort | spvAbort;
 
 /// Represents the GL_EXT_demote_to_helper_invocation extension.
 /// [EXT]

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -4793,7 +4793,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
     /// decorations (member `Offset`s and `ArrayStride`) the payload requires.
     SpvInst* emitAbort(SpvInstParent* parent, IRInst* inst)
     {
-        ensureExtensionDeclaration(toSlice("SPV_KHR_shader_abort"));
+        ensureExtensionDeclaration(toSlice("SPV_KHR_abort"));
         requireSPIRVCapability(SpvCapabilityAbortKHR);
 
         auto message = inst->getOperand(0);

--- a/tests/autodiff/abort-in-differentiable-rev.slang
+++ b/tests/autodiff/abort-in-differentiable-rev.slang
@@ -1,4 +1,4 @@
-//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target spirv -capability abort -skip-spirv-validation
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -target spirv -capability abort
 
 // Document the current reverse-mode autodiff behavior for abort() in a
 // differentiable function.

--- a/tests/autodiff/abort-in-differentiable.slang
+++ b/tests/autodiff/abort-in-differentiable.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv -capability abort -skip-spirv-validation
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -capability abort
 
 // Verify that abort() is treated as a non-differentiable instruction in
 // forward-mode autodiff, like printf(): differentiating a function that

--- a/tests/diagnostics/abort-format-not-literal.slang
+++ b/tests/diagnostics/abort-format-not-literal.slang
@@ -5,7 +5,7 @@
 // pre-existing secondary error in SPIR-V emit (the same happens with printf), which
 // is not what this test is about.
 
-//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):-target spirv -capability abort -skip-spirv-validation
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):-target spirv -capability abort
 //DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):-target glsl -capability abort
 
 void doAbort(NativeString s)

--- a/tests/diagnostics/abort-pair-arg.slang
+++ b/tests/diagnostics/abort-pair-arg.slang
@@ -6,7 +6,7 @@
 // with the clean E55211 diagnostic instead of emitting an invalidly laid out
 // message payload.
 
-//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):-target spirv -capability abort -skip-spirv-validation
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):-target spirv -capability abort
 
 struct Mixed
 {

--- a/tests/diagnostics/abort-struct-arg.slang
+++ b/tests/diagnostics/abort-struct-arg.slang
@@ -4,7 +4,7 @@
 // be given correct member offsets without cloning it into a physical type,
 // so only scalar and vector arguments are supported.
 
-//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):-target spirv -capability abort -skip-spirv-validation
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):-target spirv -capability abort
 //DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):-target glsl -capability abort
 
 struct Pos

--- a/tests/diagnostics/abort-unsupported-arg-shapes.slang
+++ b/tests/diagnostics/abort-unsupported-arg-shapes.slang
@@ -1,6 +1,6 @@
 // Verify that non-scalar/ordinary-vector abort payload shapes are rejected with E55211.
 
-//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):-target spirv -capability abort -capability cooperative_vector -capability cooperative_matrix -capability subgroup_basic -skip-spirv-validation
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):-target spirv -capability abort -capability cooperative_vector -capability cooperative_matrix -capability subgroup_basic
 
 Texture2D gTexture;
 uniform uint* gPointer;

--- a/tests/diagnostics/abort-unsupported-target.slang
+++ b/tests/diagnostics/abort-unsupported-target.slang
@@ -1,5 +1,5 @@
 // Verify that calling the variadic abort() on a target that does not support the
-// `abort` capability (which expands to GL_EXT_shader_abort | SPV_KHR_shader_abort,
+// `abort` capability (which expands to GL_EXT_shader_abort,
 // i.e. GLSL and SPIR-V only) produces a clean capability diagnostic instead of an
 // unresolved overload or an internal error. The target exclusion is intentional:
 // VK_KHR_shader_abort has no HLSL/Metal/WGSL/CUDA/CPU counterpart wired up.

--- a/tests/spirv/abort-after-branch.slang
+++ b/tests/spirv/abort-after-branch.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv -capability abort -skip-spirv-validation
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -capability abort
 
 // OpAbortKHR is a block terminator. When abort() is called on one arm of a
 // branch, the SPIRV legalization pass must strip the abort block's original

--- a/tests/spirv/abort-after-loop.slang
+++ b/tests/spirv/abort-after-loop.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv -capability abort -skip-spirv-validation
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -capability abort
 
 // OpAbortKHR is a block terminator. When abort() is called from a loop body,
 // SPIRV legalization must strip the abort block's original branch so the loop

--- a/tests/spirv/abort-after-switch.slang
+++ b/tests/spirv/abort-after-switch.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv -capability abort -skip-spirv-validation -O3
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -capability abort -O3
 
 // OpAbortKHR is a block terminator. When abort() is called from one switch arm,
 // SPIRV legalization must strip the abort block's original branch so the switch

--- a/tests/spirv/abort-defer.slang
+++ b/tests/spirv/abort-defer.slang
@@ -1,6 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv -capability abort -skip-spirv-validation
-// Note: -skip-spirv-validation is required because the bundled spirv-val does not yet
-// know about SPV_KHR_shader_abort. Remove this flag once the validator is updated.
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -capability abort
 
 // Verify that defer lowering inserts cleanup before abort(), even though Abort is
 // represented as a normal intrinsic until SPIR-V legalization turns it into a

--- a/tests/spirv/abort-existential.slang
+++ b/tests/spirv/abort-existential.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv -capability abort -skip-spirv-validation
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -capability abort
 
 // End-to-end coverage for abort() inside code using an interface-typed
 // (existential) value: the `t.val()` condition uses dynamic interface dispatch,

--- a/tests/spirv/abort.slang
+++ b/tests/spirv/abort.slang
@@ -1,7 +1,5 @@
-//TEST:SIMPLE(filecheck=CHECK_SPIRV): -target spirv -capability abort -skip-spirv-validation
+//TEST:SIMPLE(filecheck=CHECK_SPIRV): -target spirv -capability abort
 //TEST:SIMPLE(filecheck=CHECK_GLSL): -target glsl -capability abort
-// Note: -skip-spirv-validation is required because the bundled spirv-val does not yet
-// know about SPV_KHR_shader_abort. Remove this flag once the validator is updated.
 
 // Verify that abort() emits OpAbortKHR for SPIR-V with the required capability and
 // extension, packaging the format string + args into an explicitly laid out struct,
@@ -24,7 +22,7 @@
 // - packed format words are emitted little-endian and include the null terminator
 
 // CHECK_SPIRV: OpCapability AbortKHR
-// CHECK_SPIRV: OpExtension "SPV_KHR_shader_abort"
+// CHECK_SPIRV: OpExtension "SPV_KHR_abort"
 
 // CHECK_SPIRV: OpDecorate {{.*}} ArrayStride 4
 // CHECK_SPIRV: OpMemberDecorate %AbortMessage 0 Offset 0


### PR DESCRIPTION
## Motivation

The abort intrinsic emits the SPIR-V `OpAbortKHR` instruction. That instruction is provided by the Khronos SPIR-V extension named `SPV_KHR_abort`, but this PR previously emitted and documented the non-registry spelling `SPV_KHR_shader_abort`. A concrete failure mode is `tests/spirv/abort.slang:24`: the test expects `OpCapability AbortKHR` and an `OpExtension` declaration before the `OpAbortKHR` instructions, and the validator only recognizes the canonical `SPV_KHR_abort` extension name.

The same spelling mismatch also existed in Slang's capability source of truth, so `source/slang/slang-capabilities.capdef` exposed a SPIR-V extension atom named `SPV_KHR_shader_abort` while `emitAbort` needed to emit `SPV_KHR_abort`. That left two names for one SPIR-V extension.

## Proposed solution

Use the Khronos extension name everywhere Slang models the SPIR-V extension, and keep the SPIR-V capability as a separate capability atom:

- `source/slang/slang-emit-spirv.cpp:4796` declares `OpExtension "SPV_KHR_abort"` when emitting `OpAbortKHR`.
- `source/slang/slang-capabilities.capdef:580` defines the SPIR-V extension atom as `SPV_KHR_abort`.
- `source/slang/slang-capabilities.capdef:701` adds `spvAbort` for the SPIR-V `AbortKHR` capability, inheriting from `SPV_KHR_abort`.
- `source/slang/slang-capabilities.capdef:1059` maps `GL_EXT_shader_abort` to GLSL's `_GL_EXT_shader_abort` atom or SPIR-V's `spvAbort` atom, preserving the existing `abort = GL_EXT_shader_abort` compound capability at `source/slang/slang-capabilities.capdef:2423`.

With the extension name corrected, the abort-related SPIR-V tests no longer need to bypass SPIR-V validation.

## Change summary

`source/slang/slang-emit-spirv.cpp`: `emitAbort` now emits `SPV_KHR_abort` while still requiring `SpvCapabilityAbortKHR` and emitting `OpAbortKHR` from the already-legalized abort message payload.

`source/slang/slang-capabilities.capdef`: renames the SPIR-V extension atom to `SPV_KHR_abort`, adds `spvAbort` for `AbortKHR`, updates `GL_EXT_shader_abort` to use `spvAbort` for SPIR-V, and keeps the public `abort` compound capability unchanged.

`docs/user-guide/a3-02-reference-capability-atoms.md` and `docs/command-line-slangc-reference.md`: regenerate the capability and command-line references so they list `SPV_KHR_abort` and `spvAbort`, and no longer document `SPV_KHR_shader_abort`.

`tests/spirv/abort.slang`: updates the FileCheck expectation to `OpExtension "SPV_KHR_abort"`.

Abort-related tests under `tests/spirv/`, `tests/diagnostics/`, and `tests/autodiff/`: remove `-skip-spirv-validation` now that the emitted extension string is accepted by the bundled SPIR-V validator. `tests/diagnostics/abort-unsupported-target.slang:2` also updates its explanatory capability comment.

## Concepts and vocabulary

SPIR-V extension atom: a `SPV_*` capability definition in `slang-capabilities.capdef` that names a SPIR-V extension such as `SPV_KHR_abort`.

SPIR-V capability atom: a lower-camel `spv*` capability definition that models a SPIR-V `OpCapability`, such as `spvAbort` for `AbortKHR`.

`abort` compound capability: the user-facing capability used by the abort intrinsic. It remains an alias for `GL_EXT_shader_abort`, which now expands to the GLSL extension atom or the SPIR-V `spvAbort` atom depending on target.

## Process report

The first issue was the emitted SPIR-V module shape. `source/slang/slang-emit-spirv.cpp:4794` handles an `Abort` IR instruction after SPIR-V legalization has already packed the abort message into a payload struct. The input shape is correct: `emitAbort` receives a valid `Abort` instruction and still requires `SpvCapabilityAbortKHR` at `source/slang/slang-emit-spirv.cpp:4797`. The bug was not the IR producer or payload representation; it was the extension declaration string emitted beside a valid `OpAbortKHR`. Updating `ensureExtensionDeclaration` to `SPV_KHR_abort` fixes the backend mapping at the point where SPIR-V syntax is emitted.

That fix exposed a second source-of-truth issue in the capability model. Leaving `SPV_KHR_shader_abort` in `slang-capabilities.capdef` would make Slang document and accept a SPIR-V extension atom whose name does not match the emitted extension. The principled split is to use `SPV_KHR_abort` for the extension atom and `spvAbort` for the SPIR-V `AbortKHR` capability. `GL_EXT_shader_abort` remains the cross-target capability bridge, now mapping to `_GL_EXT_shader_abort` for GLSL and `spvAbort` for SPIR-V.

The test changes follow from the corrected output. `tests/spirv/abort.slang:25` now checks the canonical extension string, and the abort tests that previously passed `-skip-spirv-validation` can use normal SPIR-V validation because the bundled validator recognizes `SPV_KHR_abort`. These are not guards for malformed input; they remove a validation bypass that existed only because Slang was emitting a non-registry extension spelling.
