### PR TITLE
Add CPU-only Linux build and analytics GCP scaler pools

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,8 +1,10 @@
 self-hosted-runner:
   labels:
+    - analytics
     - benchmark
     - build
     - falcor
+    - GCP
     - GCP-T4
     - GPU
     - nvrgfx-perf

--- a/extras/scaler/README.md
+++ b/extras/scaler/README.md
@@ -1,40 +1,50 @@
 # GCP Runner Scaler
 
-Auto-scales Linux and Windows GPU VMs on GCP based on GitHub Actions job
-queue depth. Uses the [GitHub Actions Scale Set Client](https://github.com/actions/scaleset)
-(no Kubernetes required).
+Auto-scales Linux and Windows VMs on GCP based on GitHub Actions job queue
+depth. Uses the [GitHub Actions Scale Set Client](https://github.com/actions/scaleset)
+(no Kubernetes required). Both GPU test pools and CPU-only build/analytics pools
+are managed the same way.
 
 ## Architecture
 
 ```text
-┌──────────────────────────────────────────┐
-│ e2-small VM (always-on)                  │
-│                                          │
-│  scaler (Windows)                        │
-│   --labels=Windows,self-hosted,GCP-T4    │
-│   --platform=windows                     │
-│       │                                  │
-│  scaler (Linux)                          │
-│   --labels=Linux,self-hosted,GPU,GCP     │
-│   --platform=linux                       │
-│       │                                  │
-│  scaler (Linux SM80Plus)                 │
-│   --labels=Linux,self-hosted,SM80Plus    │
-│   --platform=linux                       │
-└────┬──────────────┬──────────────┬───────┘
-     │              │              │
-     ▼              ▼              ▼
-┌──────────────┐ ┌──────────────┐ ┌──────────────┐
-│ Windows T4   │ │ Linux T4     │ │ Linux L4     │
-│ VMs          │ │ VMs          │ │ VMs          │
-│ - ephemeral  │ │ - ephemeral  │ │ - ephemeral  │
-│ - scale zero │ │ - scale zero │ │ - scale zero │
-└──────────────┘ └──────────────┘ └──────────────┘
+┌─────────────────────────────────────────────────────────────────┐
+│ e2-small VM (always-on)                                          │
+│                                                                  │
+│  scaler (Windows GPU)     --labels=Windows,self-hosted,GCP-T4    │
+│  scaler (Windows build)   --labels=Windows,self-hosted,build     │
+│  scaler (Linux GPU)       --labels=Linux,self-hosted,GPU,GCP     │
+│  scaler (Linux SM80Plus)  --labels=Linux,self-hosted,SM80Plus    │
+│  scaler (Linux build)     --labels=Linux,self-hosted,build,GCP   │
+│  scaler (Linux analytics) --labels=Linux,self-hosted,analytics,GCP│
+└──┬────────────┬────────────┬────────────┬────────────┬──────────┘
+   ▼            ▼            ▼            ▼            ▼
+┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌────────────┐
+│ Win T4   │ │ Linux T4 │ │ Linux L4 │ │ Linux    │ │ Linux      │
+│ + build  │ │ VMs      │ │ VMs      │ │ build    │ │ analytics  │
+│ VMs      │ │ (GPU)    │ │ (GPU)    │ │ n1-std-8 │ │ e2-small   │
+│ ephemeral│ │ ephemeral│ │ ephemeral│ │ no GPU   │ │ no GPU     │
+│ scale 0  │ │ scale 0  │ │ scale 0  │ │ scale 0  │ │ scale 0    │
+└──────────┘ └──────────┘ └──────────┘ └──────────┘ └────────────┘
 ```
 
-Three instances of the same binary run on one control VM, each targeting a
+Several instances of the same binary run on one control VM, each targeting a
 different platform with different instance templates and labels. Zones are
-selected dynamically based on GPU quota availability across US regions.
+selected dynamically based on GPU quota availability across US regions (CPU-only
+pools skip the GPU-quota check via `--gcp-gpu-type=none`).
+
+The CPU-only Linux **build** and **analytics** pools exist to keep work off the
+GitHub-hosted runner pool, which is capped at 20 concurrent jobs org-wide on the
+Free plan. Moving the `ubuntu-22.04` x86_64 build/sanitizer jobs and the
+scheduled CI-analytics jobs onto self-hosted runners removes them from that
+shared cap entirely. (See `slang-ci-docs` for the saturation analysis that
+motivated this.)
+
+Both pools carry the `GCP` label, like the Linux GPU test pool, so jobs pin to
+the GCP scaler explicitly and cannot be picked up by another self-hosted host
+that happens to share the generic `build` label (e.g. an internal bare-metal
+pool). Routing by an unambiguous pool label avoids the silent misrouting that
+the `GCP` label was introduced to prevent.
 
 ## Build
 
@@ -177,9 +187,12 @@ GOOS=linux GOARCH=amd64 go build -o scaler-linux ./cmd/scaler
 |------|---------|
 | `deploy/setup-scaler-host.sh` | One-command deploy: creates VM, uploads binary, installs services |
 | `deploy/update-scaler.sh` | Update binary on existing host |
-| `deploy/scaler-windows.service` | systemd unit for Windows scaler |
-| `deploy/scaler-linux.service` | systemd unit for Linux scaler |
+| `deploy/scaler-windows.service` | systemd unit for Windows GPU scaler |
+| `deploy/scaler-windows-build.service` | systemd unit for Windows build scaler (no GPU) |
+| `deploy/scaler-linux.service` | systemd unit for Linux GPU scaler |
 | `deploy/scaler-linux-sm80plus.service` | systemd unit for Linux SM80Plus scaler |
+| `deploy/scaler-linux-build.service` | systemd unit for Linux build scaler (no GPU) |
+| `deploy/scaler-linux-analytics.service` | systemd unit for Linux analytics scaler (no GPU, tiny VM) |
 | `deploy/scaler.env.example` | Template for GitHub credentials |
 
 ## How It Works
@@ -210,6 +223,25 @@ runner registration via JIT config on each boot.
 - Ubuntu 22.04, NVIDIA Driver, Docker, nvidia-container-toolkit
 - GitHub Actions Runner agent at `/actions-runner`
 
+**Linux build image** (`--gcp-instance-template=linux-build-runner`):
+
+- CPU-only `n1-standard-8` (no GPU attached, `--gcp-gpu-type=none`).
+- The two container build jobs (`build-linux-debug/release-gcc-x86_64`) run the
+  build inside the `linux-gpu-ci` Docker image, so the host only needs Docker —
+  the existing `linux-gpu-runner` base image (Ubuntu 22.04 + Docker, GPU driver
+  unused) is sufficient and is the simplest starting point. The wasm and
+  sanitizer jobs build directly on the host toolchain; confirm the base image
+  carries the toolchain they expect (gcc/clang, CMake, Ninja, Python, sccache)
+  or extend the image before flipping those jobs.
+- GitHub Actions Runner agent at `/actions-runner`.
+
+**Linux analytics image** (`--gcp-instance-template=linux-analytics-runner`):
+
+- Tiny CPU-only `e2-small` (no GPU). Runs only lightweight scheduled jobs
+  (`ci-health`, `ci-analytics`): checkout + Python + `gh api` + GCP auth.
+- Needs Python 3 and the GitHub CLI; a stock Ubuntu 22.04 image plus the runner
+  agent is sufficient.
+
 ## Cost
 
 - Control VM: e2-small (24/7)
@@ -217,5 +249,48 @@ runner registration via JIT config on each boot.
 - Linux GPU test runners: n1-standard-8 + T4 (on-demand)
 - Linux SM80Plus test runners: g2-standard-8 + L4 (on-demand, narrow capability job only)
 - Windows build runners: n1-standard-8, no GPU (on-demand)
+- Linux build runners: n1-standard-8, no GPU (on-demand, `--max-runners=16`)
+- Linux analytics runners: e2-small, no GPU (on-demand, scheduled jobs only)
+
+All on-demand pools scale to zero when idle, so the build and analytics pools
+cost effectively nothing when CI is quiet. `--max-runners=16` for the build pool
+was sized from the observed peak of 12 concurrent x86_64 build jobs (see the
+rollout checklist below); at full burst it uses ~128 vCPU against a 1500 vCPU
+regional quota.
 
 See [GCP pricing](https://cloud.google.com/compute/vm-instance-pricing) for current rates.
+
+## Rollout checklist — Linux build + analytics pools
+
+These pools are inert until their instance templates exist and the corresponding
+workflow jobs are pointed at their labels. Recommended staged rollout:
+
+1. **Create instance templates** (outside this repo, via `gcloud`/packer):
+   - `linux-build-runner` — `n1-standard-8`, no GPU, ~200 GB disk, snapshot of a
+     Linux runner image with Docker + the build toolchain.
+   - `linux-analytics-runner` — `e2-small`, no GPU, small disk, Python 3 + `gh`.
+2. **Start the scalers** (they sit at `min-runners=0`, zero cost until used):
+   ```bash
+   sudo systemctl enable --now scaler-linux-build
+   sudo systemctl enable --now scaler-linux-analytics
+   ```
+3. **Validate** a manual `workflow_dispatch` job on each label lands on a GCP VM
+   and completes (build green, sccache/GCS cache working, analytics auth via
+   Workload Identity working).
+4. **Flip the workflow jobs** in a follow-up PR (these are _not_ part of the
+   infra PR that adds these files):
+   - `.github/workflows/ci.yml`: the four `runs-on: '["ubuntu-22.04"]'` jobs
+     (`build-linux-debug-gcc-x86_64`, `build-linux-release-gcc-x86_64`,
+     `build-linux-release-gcc-wasm`, `sanitizer-linux-clang-x86_64`) →
+     `'["Linux", "self-hosted", "build", "GCP"]'`.
+   - `.github/workflows/ci-health.yml` and `.github/workflows/ci-analytics.yml`:
+     `runs-on: ubuntu-latest` →
+     `runs-on: ["Linux", "self-hosted", "analytics", "GCP"]`.
+   - The `analytics` and `GCP` labels must be registered in
+     `.github/actionlint.yaml` (this PR adds both; `build` was already there).
+   - Confirm fork-PR approval gating covers the new build pool (build jobs run PR
+     code), and that the analytics Workload Identity provider condition does not
+     assert a hosted-runner claim.
+   - aarch64 builds stay on `ubuntu-24.04-arm` (the GCP pool is x86_64).
+5. **Update `slang-ci-docs`** runner/scaler inventory with the two new pools
+   (labels, machine types, `--max-runners`, cost) once deployed.

--- a/extras/scaler/deploy/scaler-linux-analytics.service
+++ b/extras/scaler/deploy/scaler-linux-analytics.service
@@ -1,0 +1,43 @@
+[Unit]
+Description=GCP Runner Scaler (Linux analytics jobs, no GPU, tiny VM)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=scaler
+Group=scaler
+
+ExecReload=/bin/kill -USR1 $MAINPID
+ExecStart=/opt/scaler/scaler \
+    --url=https://github.com/shader-slang/slang \
+    --name=linux-analytics-runners \
+    --labels=Linux,self-hosted,analytics,GCP \
+    --platform=linux \
+    --max-runners=2 \
+    --min-runners=0 \
+    --gcp-project=slang-runners \
+    --gcp-zones=us-east1-c,us-east1-d,us-central1-a,us-west1-a,us-west1-b \
+    --gcp-instance-template=linux-analytics-runner \
+    --gcp-gpu-type=none \
+    --vm-prefix=linux-analytics \
+    --session-max-age=30m
+
+EnvironmentFile=/opt/scaler/scaler.env
+
+Restart=always
+RestartSec=10
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=scaler-linux-analytics
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadOnlyPaths=/opt/scaler
+
+[Install]
+WantedBy=multi-user.target

--- a/extras/scaler/deploy/scaler-linux-build.service
+++ b/extras/scaler/deploy/scaler-linux-build.service
@@ -1,0 +1,43 @@
+[Unit]
+Description=GCP Runner Scaler (Linux x86_64 builds, no GPU)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=scaler
+Group=scaler
+
+ExecReload=/bin/kill -USR1 $MAINPID
+ExecStart=/opt/scaler/scaler \
+    --url=https://github.com/shader-slang/slang \
+    --name=linux-build-runners \
+    --labels=Linux,self-hosted,build,GCP \
+    --platform=linux \
+    --max-runners=16 \
+    --min-runners=0 \
+    --gcp-project=slang-runners \
+    --gcp-zones=us-east1-c,us-east1-d,us-central1-a,us-west1-a,us-west1-b \
+    --gcp-instance-template=linux-build-runner \
+    --gcp-gpu-type=none \
+    --vm-prefix=linux-build \
+    --session-max-age=2h
+
+EnvironmentFile=/opt/scaler/scaler.env
+
+Restart=always
+RestartSec=10
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=scaler-linux-build
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadOnlyPaths=/opt/scaler
+
+[Install]
+WantedBy=multi-user.target

--- a/extras/scaler/deploy/setup-scaler-host.sh
+++ b/extras/scaler/deploy/setup-scaler-host.sh
@@ -111,12 +111,18 @@ gcloud compute scp "${SCALER_DIR}/deploy/scaler-linux-sm80plus.service" "${VM_NA
   --zone="${ZONE}" --project="${PROJECT}"
 gcloud compute scp "${SCALER_DIR}/deploy/scaler-windows-build.service" "${VM_NAME}:/tmp/scaler-windows-build.service" \
   --zone="${ZONE}" --project="${PROJECT}"
+gcloud compute scp "${SCALER_DIR}/deploy/scaler-linux-build.service" "${VM_NAME}:/tmp/scaler-linux-build.service" \
+  --zone="${ZONE}" --project="${PROJECT}"
+gcloud compute scp "${SCALER_DIR}/deploy/scaler-linux-analytics.service" "${VM_NAME}:/tmp/scaler-linux-analytics.service" \
+  --zone="${ZONE}" --project="${PROJECT}"
 
 gcloud compute ssh "${VM_NAME}" --zone="${ZONE}" --project="${PROJECT}" --command="
     sudo mv /tmp/scaler-windows.service /etc/systemd/system/scaler-windows.service
     sudo mv /tmp/scaler-linux.service /etc/systemd/system/scaler-linux.service
     sudo mv /tmp/scaler-linux-sm80plus.service /etc/systemd/system/scaler-linux-sm80plus.service
     sudo mv /tmp/scaler-windows-build.service /etc/systemd/system/scaler-windows-build.service
+    sudo mv /tmp/scaler-linux-build.service /etc/systemd/system/scaler-linux-build.service
+    sudo mv /tmp/scaler-linux-analytics.service /etc/systemd/system/scaler-linux-analytics.service
     sudo systemctl daemon-reload
 "
 echo ""
@@ -151,3 +157,9 @@ echo "  gcloud compute ssh ${VM_NAME} --zone=${ZONE} --project=${PROJECT} --comm
 echo ""
 echo "  # Start Linux SM80Plus scaler (after creating linux-gpu-runner-sm80plus-l4 template)"
 echo "  gcloud compute ssh ${VM_NAME} --zone=${ZONE} --project=${PROJECT} --command='sudo systemctl enable --now scaler-linux-sm80plus'"
+echo ""
+echo "  # Start Linux build scaler (after creating linux-build-runner template)"
+echo "  gcloud compute ssh ${VM_NAME} --zone=${ZONE} --project=${PROJECT} --command='sudo systemctl enable --now scaler-linux-build'"
+echo ""
+echo "  # Start Linux analytics scaler (after creating linux-analytics-runner template)"
+echo "  gcloud compute ssh ${VM_NAME} --zone=${ZONE} --project=${PROJECT} --command='sudo systemctl enable --now scaler-linux-analytics'"

--- a/extras/scaler/deploy/update-scaler.sh
+++ b/extras/scaler/deploy/update-scaler.sh
@@ -42,7 +42,7 @@ echo "Draining and stopping services, replacing binary, restarting..."
 # scaler-linux-sm80plus was added in PR #10967 (2026-04-29) but was missing from
 # this script, so deployments silently left the SM80Plus tier on the old binary
 # until manually restarted.
-SCALER_SERVICES="scaler-windows scaler-linux scaler-linux-sm80plus scaler-windows-build"
+SCALER_SERVICES="scaler-windows scaler-linux scaler-linux-sm80plus scaler-windows-build scaler-linux-build scaler-linux-analytics"
 
 # Drain-then-stop sequence (#11067):
 #   1. systemctl reload sends SIGUSR1 -> scaler enters drain mode, stops

--- a/extras/scaler/internal/gcp/manager.go
+++ b/extras/scaler/internal/gcp/manager.go
@@ -407,6 +407,17 @@ func (m *Manager) CreateVM(ctx context.Context, runnerName, jitConfig string) (s
 		scriptContent = windowsStartupScript
 	}
 
+	// Tell the VM whether this pool expects a GPU, so the startup script can
+	// treat a missing accelerator as a fatal misconfiguration on GPU pools
+	// (where a runner with no device would silently accept GPU-labeled jobs)
+	// while skipping GPU init on the CPU-only build/analytics pools. Derived
+	// from the pool's own --gcp-gpu-type config rather than guessed from the
+	// VM's PCI state, so the expectation is authoritative per pool.
+	expectGPU := "true"
+	if m.config.GPUType == "none" {
+		expectGPU = "false"
+	}
+
 	var stockoutErrors []string
 	for _, candidate := range candidates {
 		zone := candidate.zone
@@ -426,6 +437,10 @@ func (m *Manager) CreateVM(ctx context.Context, runnerName, jitConfig string) (s
 						{
 							Key:   proto.String(scriptKey),
 							Value: proto.String(scriptContent),
+						},
+						{
+							Key:   proto.String("expect-gpu"),
+							Value: proto.String(expectGPU),
 						},
 					},
 				},

--- a/extras/scaler/internal/gcp/manager_test.go
+++ b/extras/scaler/internal/gcp/manager_test.go
@@ -478,6 +478,62 @@ func TestCreateVMStopsOnNonStockoutError(t *testing.T) {
 	}
 }
 
+// TestCreateVMStampsExpectGPUMetadata verifies that CreateVM stamps the
+// "expect-gpu" instance-metadata key from the pool's GPUType: "true" for GPU
+// pools and "false" for CPU-only pools (GPUType == "none"). The Linux startup
+// script reads this to decide whether a missing accelerator is fatal (GPU pool)
+// or expected (CPU-only build/analytics pool), so the contract must be explicit
+// rather than inferred from the VM's PCI state.
+func TestCreateVMStampsExpectGPUMetadata(t *testing.T) {
+	cases := []struct {
+		name    string
+		gpuType string
+		want    string
+	}{
+		{"gpu pool", "nvidia-l4", "true"},
+		{"cpu-only pool", "none", "false"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manager{
+				config: ManagerConfig{
+					Project:          "test-project",
+					Zones:            "us-east1-d",
+					InstanceTemplate: "linux-build-runner",
+					GPUType:          tc.gpuType,
+					Platform:         "linux",
+				},
+				vms: map[string]*vmInfo{},
+			}
+			m.selectZonesFunc = func(context.Context) ([]zoneCandidate, error) {
+				return []zoneCandidate{{zone: "us-east1-d", region: "us-east1", available: 16}}, nil
+			}
+
+			var got string
+			var found bool
+			m.insertVMFunc = func(_ context.Context, req *computepb.InsertInstanceRequest) error {
+				for _, item := range req.GetInstanceResource().GetMetadata().GetItems() {
+					if item.GetKey() == "expect-gpu" {
+						got = item.GetValue()
+						found = true
+					}
+				}
+				return nil
+			}
+
+			if _, err := m.CreateVM(context.Background(), "build-test", "jit-config"); err != nil {
+				t.Fatalf("CreateVM returned error: %v", err)
+			}
+			if !found {
+				t.Fatal("expect-gpu metadata key was not set")
+			}
+			if got != tc.want {
+				t.Fatalf("expect-gpu = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIsZoneResourceExhausted(t *testing.T) {
 	if !isZoneResourceExhausted(errors.New("ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS")) {
 		t.Fatal("expected ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS to be treated as stockout")

--- a/extras/scaler/internal/gcp/startup.sh
+++ b/extras/scaler/internal/gcp/startup.sh
@@ -89,7 +89,7 @@ log() {
   echo "$msg" >>"$LOG_FILE"
 }
 
-log "=== Linux GPU Runner Startup ==="
+log "=== Linux Runner Startup ==="
 log "Runner directory: $RUNNER_DIR"
 log "Runner user: $RUNNER_USER"
 
@@ -166,59 +166,98 @@ if [ "$current_runner_version" != "$RUNNER_VERSION" ]; then
 fi
 
 # Step 0.5: Ensure NVIDIA GPU devices are initialized.
-# On fresh boot, the kernel module may not be loaded yet. Running nvidia-smi
-# loads the module and creates /dev/nvidia* device files that the CI workflow
-# mounts into Docker containers (--device /dev/nvidia-modeset, /dev/dri, etc.)
-log "Initializing NVIDIA GPU..."
-gpu_ready=false
-for attempt in $(seq 1 10); do
-  if nvidia-smi >/dev/null 2>&1; then
-    log "  GPU initialized successfully."
-    gpu_ready=true
-    break
-  fi
-  log "  Attempt ${attempt}/10: nvidia-smi not ready, waiting..."
-  sleep 5
-done
+#
+# This block only applies to GPU pools (the Linux test runners). CPU-only pools
+# (the build and analytics runners) share both this startup script *and* the
+# same base image, so the nvidia-smi tool and driver libraries are present even
+# when no GPU is attached — tool presence is therefore NOT a reliable signal.
+#
+# Whether this pool is *supposed* to have a GPU is authoritative, not inferred:
+# the scaler stamps an "expect-gpu" metadata key from the pool's --gcp-gpu-type
+# config (true for GPU pools, false for CPU-only build/analytics pools). We then
+# combine that contract with the actual hardware, detected by a physically-
+# attached NVIDIA device on the PCI bus (vendor ID 10de — prefer lspci, fall
+# back to the sysfs PCI vendor list if pciutils is absent):
+#   - GPU pool + GPU present     -> initialize the GPU (fatal if init fails).
+#   - GPU pool + GPU MISSING     -> fatal: the accelerator attach failed; a
+#                                   runner here would silently accept GPU jobs.
+#   - CPU-only pool              -> skip GPU init and register as a CPU runner.
+# Defaulting expect-gpu to "true" keeps existing GPU pools fail-safe even if the
+# metadata is somehow absent.
+EXPECT_GPU="$(curl -sf --max-time 10 --connect-timeout 5 \
+  -H "Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/attributes/expect-gpu" 2>/dev/null || echo "true")"
+log "GPU expectation for this pool: expect-gpu=${EXPECT_GPU}"
 
-if [ "$gpu_ready" != "true" ]; then
-  log "ERROR: GPU initialization failed after 10 attempts"
+gpu_present=false
+if command -v lspci >/dev/null 2>&1; then
+  if lspci -d 10de: 2>/dev/null | grep -q .; then
+    gpu_present=true
+  fi
+elif grep -qi '0x10de' /sys/bus/pci/devices/*/vendor 2>/dev/null; then
+  gpu_present=true
+fi
+
+if [ "$EXPECT_GPU" != "false" ] && [ "$gpu_present" != "true" ]; then
+  log "ERROR: This pool expects an NVIDIA GPU but none is attached (accelerator attach failed?). Refusing to register a GPU runner with no device."
   shutdown -h now
   exit 1
 fi
 
-# Create nvidia-modeset device if it doesn't exist (needed for Vulkan)
-if [ ! -e /dev/nvidia-modeset ]; then
-  log "  Creating /dev/nvidia-modeset..."
-  nvidia-modprobe -m 2>/dev/null || modprobe nvidia-modeset 2>/dev/null || true
-fi
+if [ "$gpu_present" = "true" ]; then
+  log "Initializing NVIDIA GPU..."
+  gpu_ready=false
+  for attempt in $(seq 1 10); do
+    if nvidia-smi >/dev/null 2>&1; then
+      log "  GPU initialized successfully."
+      gpu_ready=true
+      break
+    fi
+    log "  Attempt ${attempt}/10: nvidia-smi not ready, waiting..."
+    sleep 5
+  done
 
-# Enable GPU persistence mode to prevent NVML state corruption in containers.
-# Without this, NVML can lose track of GPU processes when they exit inside Docker,
-# causing "Failed to initialize NVML: Unknown Error".
-log "  Enabling GPU persistence mode..."
-if pm_out="$(nvidia-smi -pm 1 2>&1)"; then
-  log "  GPU persistence mode enabled."
+  if [ "$gpu_ready" != "true" ]; then
+    log "ERROR: GPU initialization failed after 10 attempts"
+    shutdown -h now
+    exit 1
+  fi
+
+  # Create nvidia-modeset device if it doesn't exist (needed for Vulkan)
+  if [ ! -e /dev/nvidia-modeset ]; then
+    log "  Creating /dev/nvidia-modeset..."
+    nvidia-modprobe -m 2>/dev/null || modprobe nvidia-modeset 2>/dev/null || true
+  fi
+
+  # Enable GPU persistence mode to prevent NVML state corruption in containers.
+  # Without this, NVML can lose track of GPU processes when they exit inside Docker,
+  # causing "Failed to initialize NVML: Unknown Error".
+  log "  Enabling GPU persistence mode..."
+  if pm_out="$(nvidia-smi -pm 1 2>&1)"; then
+    log "  GPU persistence mode enabled."
+  else
+    log "WARNING: Failed to enable GPU persistence mode: ${pm_out}"
+  fi
+
+  # Create /dev/char symlinks for all NVIDIA device nodes. Recent runc versions
+  # with cgroup v2 require these symlinks to properly inject devices into
+  # containers. Without them, containers can intermittently lose GPU access
+  # with "Failed to initialize NVML: Unknown Error".
+  # See: https://github.com/NVIDIA/nvidia-docker/issues/1730
+  log "  Creating /dev/char symlinks..."
+  if ctk_out="$(nvidia-ctk system create-dev-char-symlinks --create-all 2>&1)"; then
+    log "  /dev/char symlinks created."
+  else
+    log "WARNING: Failed to create /dev/char symlinks: ${ctk_out}"
+  fi
+
+  # Verify GPU devices
+  log "  GPU devices:"
+  ls -la /dev/nvidia* 2>&1 | while read -r line; do log "    $line"; done || true
+  ls -la /dev/dri/* 2>&1 | while read -r line; do log "    $line"; done || true
 else
-  log "WARNING: Failed to enable GPU persistence mode: ${pm_out}"
+  log "No NVIDIA GPU on the PCI bus and none expected; skipping GPU initialization (CPU-only runner)."
 fi
-
-# Create /dev/char symlinks for all NVIDIA device nodes. Recent runc versions
-# with cgroup v2 require these symlinks to properly inject devices into
-# containers. Without them, containers can intermittently lose GPU access
-# with "Failed to initialize NVML: Unknown Error".
-# See: https://github.com/NVIDIA/nvidia-docker/issues/1730
-log "  Creating /dev/char symlinks..."
-if ctk_out="$(nvidia-ctk system create-dev-char-symlinks --create-all 2>&1)"; then
-  log "  /dev/char symlinks created."
-else
-  log "WARNING: Failed to create /dev/char symlinks: ${ctk_out}"
-fi
-
-# Verify GPU devices
-log "  GPU devices:"
-ls -la /dev/nvidia* 2>&1 | while read -r line; do log "    $line"; done || true
-ls -la /dev/dri/* 2>&1 | while read -r line; do log "    $line"; done || true
 
 # Step 1: Read JIT config from GCP instance metadata
 log "Reading JIT config from instance metadata..."


### PR DESCRIPTION
## Motivation

The GitHub-hosted runner pool is capped at **20 concurrent jobs org-wide** on the Free plan (a fixed plan-tier limit, not a settable knob). That cap saturates in bursts. Sampling the live CI-health time series over the last week:

- **At cap (20/20):** ~14% of sampled time (a floor — see below), with deep backlogs (median 26, peaks into the hundreds of queued jobs).
- **When at cap, the `ubuntu-22.04` x86_64 build/sanitizer jobs occupy ~49% of the pool** — the single largest consumer.
- The scheduled CI-analytics jobs (`ci-health`, `ci-analytics`) run on `ubuntu-latest`, so they get **starved by the very congestion they measure** — the 15-min health cron actually fires every ~60–90 min, which is why the 14% figure is a floor rather than an exact number.

macOS and aarch64 jobs cannot move (no GCP Mac; the pool is x86_64), so this targets the offloadable slice: the x86_64 builds and the analytics jobs.

## Proposed solution

Add two **CPU-only Linux scaler pools** that move this work off the shared 20-cap entirely, mirroring the existing CPU-only **Windows build** pool (`scaler-windows-build`). The 20-cap and a pool's `--max-runners` are independent caps — offloaded jobs leave the hosted pool, so capacity is **additive**, not a downgrade.

- **`scaler-linux-build`** (`Linux,self-hosted,build`): `n1-standard-8`, no GPU, `--max-runners=16`.
  - Sized from data: replaying recent merge_group CI runs, peak concurrent x86_64 build demand was **12**; 16 covers it with headroom and uses ~128 vCPU against a 1500-vCPU regional quota at full burst.
- **`scaler-linux-analytics`** (`Linux,self-hosted,analytics`): `e2-small`, no GPU, short `session-max-age`, for the lightweight scheduled jobs. Kept separate from `build` so a 2-minute health probe never queues behind a 20-minute compile — which also restores 15-min sampling fidelity.

Both pools sit at `--min-runners=0` (scale to zero, ~$0 idle).

## Scope of this PR (infra-only)

This PR is **infrastructure-only** and changes no live behavior: it adds the systemd units, wires them into the deploy script, and documents the rollout. The pools are inert until their instance templates exist and the workflow jobs are pointed at the new labels — both deliberately deferred to a follow-up so the build VM image can be validated end-to-end (build green, sccache/GCS LLVM cache working, Workload Identity auth working) **before** any production job depends on it.

The README rollout checklist enumerates the follow-up steps:
1. Create `linux-build-runner` / `linux-analytics-runner` instance templates.
2. Start the scalers (zero cost until used).
3. Validate via `workflow_dispatch` on each label.
4. Flip `runs-on` in `ci.yml` (4 build/sanitizer jobs) and `ci-health.yml` / `ci-analytics.yml`.
5. Update the `slang-ci-docs` runner/scaler inventory.

## Change summary

| File | Change |
|------|--------|
| `extras/scaler/deploy/scaler-linux-build.service` | **New** — Linux build scaler unit (`--max-runners=16`, `--gcp-gpu-type=none`). |
| `extras/scaler/deploy/scaler-linux-analytics.service` | **New** — Linux analytics scaler unit (`e2-small` target, `session-max-age=30m`). |
| `extras/scaler/deploy/setup-scaler-host.sh` | Upload/install the two new systemd units; add start-command help. |
| `extras/scaler/README.md` | Updated architecture diagram, files table, base-image notes (incl. cache behavior), cost, and a rollout checklist. |

## Caching note

No cache regression is expected. The build workflows use `actions/cache` for sccache (keyed by `github.sha`, served over HTTPS by GitHub's cache service — runner-agnostic, works on self-hosted) and `setup-llvm-from-gcs` (public GCS bucket over HTTPS). The Slang **GPU test jobs already run on GCP self-hosted runners** through the same reusable workflows, so this is a proven path; if anything, GCS LLVM fetches are faster from inside the GCP project. The one thing to confirm during validation (step 3) is that sccache is present on the build VM image for the non-container wasm/sanitizer jobs — noted in the README image section.

---

pr: non-breaking