### PR TITLE
ci: route Linux x86_64 builds and analytics jobs to GCP scaler pools

### DIFF
--- a/.github/workflows/ci-analytics.yml
+++ b/.github/workflows/ci-analytics.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   collect-and-publish:
-    runs-on: ubuntu-latest
+    runs-on: ["Linux", "self-hosted", "analytics", "GCP"]
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   update-health:
-    runs-on: ubuntu-latest
+    runs-on: ["Linux", "self-hosted", "analytics", "GCP"]
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -9,6 +9,15 @@ on:
       runs-on:
         required: true
         type: string
+      container-user:
+        # UID:GID the build container runs as. The container must run as the
+        # user that owns the runner's _work directory, or actions/checkout
+        # cannot write the workspace. GitHub-hosted ubuntu runners own _work as
+        # UID 1001, but self-hosted runner images differ (the GCP build pool's
+        # runner is UID 1003), so this is overridable per runner pool.
+        required: false
+        type: string
+        default: "1001:1001"
 
 jobs:
   # Uses nvidia/cuda container for CUDA support.
@@ -21,10 +30,12 @@ jobs:
       packages: read # CI container images are public, so this is not strictly required; kept for consistency and in case they revert to private
     container:
       image: ghcr.io/shader-slang/slang-linux-gpu-ci:v1.6.1
-      # EXPERIMENT: drop --user root and -v /:/host_root mount; host cleanup
-      # step removed below. If disk pressure resurfaces, slim the container
-      # image (issue #11339) rather than bringing host-root access back.
-      options: --user 1001:1001
+      # Drop --user root and -v /:/host_root mount; host cleanup step removed
+      # below. If disk pressure resurfaces, slim the container image (issue
+      # #11339) rather than bringing host-root access back. The UID:GID is an
+      # input because it must match the runner's _work owner, which differs
+      # between GitHub-hosted (1001) and self-hosted runner images.
+      options: --user ${{ inputs.container-user }}
 
     env:
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,14 @@ jobs:
     needs: [filter]
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-slang-build-container.yml
+    # id-token is never part of the default GITHUB_TOKEN even when the repo
+    # default is "write"; it must be requested explicitly for the reusable
+    # workflow's GCP Workload Identity auth step. Set it on the caller so the
+    # token actually carries id-token:write rather than relying on the default.
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
     with:
       config: debug
       runs-on: '["Linux", "self-hosted", "build", "GCP"]'
@@ -61,6 +69,10 @@ jobs:
     needs: [filter]
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-slang-build-container.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
     with:
       config: release
       runs-on: '["Linux", "self-hosted", "build", "GCP"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,17 @@ jobs:
           fi
           echo "should-run=$shouldRun" >> $GITHUB_OUTPUT
 
-  # Linux builds (containerized builds on GitHub-hosted runners)
+  # Linux x86_64 builds run in the CI container on the GCP self-hosted build
+  # pool. container-user is the GCP build runner image's UID:GID (1003), which
+  # owns _work; the reusable workflow defaults to 1001 for GitHub-hosted runners.
   build-linux-debug-gcc-x86_64:
     needs: [filter]
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-slang-build-container.yml
     with:
       config: debug
-      runs-on: '["ubuntu-22.04"]'
+      runs-on: '["Linux", "self-hosted", "build", "GCP"]'
+      container-user: "1003:1003"
 
   build-linux-release-gcc-x86_64:
     needs: [filter]
@@ -60,8 +63,14 @@ jobs:
     uses: ./.github/workflows/ci-slang-build-container.yml
     with:
       config: release
-      runs-on: '["ubuntu-22.04"]'
+      runs-on: '["Linux", "self-hosted", "build", "GCP"]'
+      container-user: "1003:1003"
 
+  # NOTE: wasm stays on GitHub-hosted for now. It builds directly on the host
+  # (no container) via ci-slang-build.yml, and the GCP build runner image lacks
+  # the host build toolchain (cmake), so it fails there with "cmake: command not
+  # found". Moving it onto the build pool requires running it in the CI
+  # container like the other Linux builds — tracked as a follow-up.
   build-linux-release-gcc-wasm:
     needs: [filter]
     if: needs.filter.outputs.should-run == 'true'
@@ -73,7 +82,9 @@ jobs:
       config: release
       runs-on: '["ubuntu-22.04"]'
 
-  # Sanitizer build+test (blocking via check-ci, runs on every PR)
+  # Sanitizer build+test (blocking via check-ci, runs on every PR). Runs in the
+  # clang CI container; kept on GitHub-hosted until validated on the GCP build
+  # pool (tracked with the wasm container follow-up).
   sanitizer-linux-clang-x86_64:
     needs: [filter]
     if: needs.filter.outputs.should-run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
     needs: [filter]
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-slang-build-container.yml
+    # id-token is never part of the default GITHUB_TOKEN even when the repo
+    # default is "write"; it must be requested explicitly for the reusable
+    # workflow's GCP Workload Identity auth step. Set it on the caller so the
+    # token actually carries id-token:write rather than relying on the default.
     permissions:
       id-token: write
       contents: read

--- a/extras/ci/analytics/runner_config.json
+++ b/extras/ci/analytics/runner_config.json
@@ -11,6 +11,16 @@
       "self_hosted": true
     },
     {
+      "labels": ["Linux", "self-hosted", "build"],
+      "name": "Linux Build (GCP)",
+      "self_hosted": true
+    },
+    {
+      "labels": ["Linux", "self-hosted", "analytics"],
+      "name": "Linux Analytics (GCP)",
+      "self_hosted": true
+    },
+    {
       "labels": ["Windows", "self-hosted", "GCP-T4"],
       "name": "Windows GPU (GCP)",
       "self_hosted": true
@@ -110,6 +120,16 @@
     {
       "prefix": "linux-test-",
       "name": "Linux GPU (GCP)",
+      "self_hosted": true
+    },
+    {
+      "prefix": "linux-build-",
+      "name": "Linux Build (GCP)",
+      "self_hosted": true
+    },
+    {
+      "prefix": "linux-analytics-",
+      "name": "Linux Analytics (GCP)",
       "self_hosted": true
     },
     {

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -107,6 +107,34 @@ class TestRunnerTypeCoverage(unittest.TestCase):
             )
             self.assertTrue(self_hosted)
 
+    def test_classify_group_handles_gcp_build_and_analytics_pools(self):
+        """The CPU-only Linux build and analytics scaler pools carry the labels
+        ["Linux","self-hosted","build","GCP"] and
+        ["Linux","self-hosted","analytics","GCP"], and their VMs are named
+        linux-build-* / linux-analytics-*. Both the job-label path and the
+        scale-set runner-name-prefix path (empty labels) must classify into
+        their own GCP groups rather than falling through to "Other". Locks in
+        the shipped config so these pools stay visible in CI analytics.
+        """
+        config = ci_visualization.load_config()
+
+        cases = [
+            (["Linux", "self-hosted", "build", "GCP"], "linux-build-abc123", "Linux Build (GCP)"),
+            (["Linux", "self-hosted", "analytics", "GCP"], "linux-analytics-abc123", "Linux Analytics (GCP)"),
+        ]
+        for labels, runner_name, expected in cases:
+            # Job-label path (no runner name) and the scale-set name-prefix path
+            # (empty labels) must both resolve to the expected GCP group.
+            for name in ("", runner_name):
+                lbls = labels if name == "" else []
+                group, self_hosted = ci_visualization.classify_group(lbls, config, name)
+                self.assertEqual(
+                    group,
+                    expected,
+                    msg=f"misclassified for labels={lbls} runner_name={name!r}",
+                )
+                self.assertTrue(self_hosted)
+
     def test_record_snapshot_counts_all_gcp_runner_types(self):
         queue_data = {
             "summary": {


### PR DESCRIPTION
## Motivation

The GitHub-hosted runner pool is capped at **20 concurrent jobs org-wide** (Free plan). It saturates in bursts (observed at 20/20 with 100+ jobs queued repeatedly), and when it does the `ubuntu-22.04` x86_64 builds occupy a large share of the pool. The scheduled `ci-health` / `ci-analytics` jobs run on `ubuntu-latest`, so they get starved by the very congestion they measure.

The CPU-only GCP scaler pools that absorb this work were added in #11736 (now merged): `linux-build-runners` (`Linux,self-hosted,build,GCP`) and `linux-analytics-runners` (`Linux,self-hosted,analytics,GCP`).

## Proposed solution

Route the offloadable Linux jobs onto those pools, removing them from the shared 20-cap (the cap and a pool's `--max-runners` are independent, so this is additive capacity):

- The two **x86_64 container builds** `build-linux-debug-gcc-x86_64` and `build-linux-release-gcc-x86_64` → `["Linux", "self-hosted", "build", "GCP"]`.
- `ci-health.yml` and `ci-analytics.yml` → `["Linux", "self-hosted", "analytics", "GCP"]`.

The `GCP` label pins these jobs to the GCP scaler pool (like the Linux GPU test pool, #11724) so a host sharing the generic `build` label cannot pick them up.

**Two supporting changes were required for the container builds to run on the pool:**

- **Container UID** — the build runs in the `linux-gpu-ci` container as a non-root user that must own the runner's `_work` dir. GitHub-hosted runners own it as UID 1001, but the GCP build image's runner is **UID 1003**, so a hardcoded `--user 1001:1001` failed `actions/checkout`. Added a `container-user` input to `ci-slang-build-container.yml` (default `1001:1001`) and pass `1003:1003` for the GCP pool.
- **`id-token` permission** — the build jobs authenticate to GCP via Workload Identity, which needs `id-token: write`. That scope is never part of the default `GITHUB_TOKEN` even when the repo default is `write`, so it's requested explicitly on the caller jobs.

**CI analytics** is taught about the new pools (`runner_config.json` label groups + `linux-build-`/`linux-analytics-` VM-name prefixes + regression test) so their jobs are classified as "Linux Build (GCP)" / "Linux Analytics (GCP)" rather than "Other".

## Deliberately left on GitHub-hosted (follow-ups)

- **wasm** (`build-linux-release-gcc-wasm`) builds directly on the host (no container) and the build image lacks the host toolchain (`cmake: command not found`). Moving it requires running it in the CI container — tracked follow-up.
- **sanitizer** (`sanitizer-linux-clang-x86_64`) runs in the clang CI container; kept on GitHub-hosted until validated on the pool (same follow-up).
- **aarch64** builds stay on `ubuntu-24.04-arm` (the GCP pool is x86_64); **macOS** can't move.

## Change summary

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | 2 x86_64 container builds → `build,GCP` pool, with explicit `permissions` + `container-user: "1003:1003"`. |
| `.github/workflows/ci-slang-build-container.yml` | Add `container-user` input (default `1001:1001`). |
| `.github/workflows/ci-health.yml`, `ci-analytics.yml` | `ubuntu-latest` → `analytics,GCP` pool. |
| `extras/ci/analytics/runner_config.json` | Classify the two new pools (label groups + VM-name prefixes). |
| `extras/ci/analytics/tests/test_ci_analytics.py` | Regression test for the new classification. |

## Validation

Dispatched the build jobs on the GCP pool end-to-end: both x86_64 container builds went **green** (release ~15.8 min, debug ~17.1 min — ~40% faster than the GitHub-hosted median of ~28 min, with **99.76% sccache hit**, confirming the GHA-provided cache is runner-agnostic). `actions/checkout` passes with `container-user: 1003`. The scaler provisions, registers, and tears down VMs correctly.

## Notes

- The sccache (`actions/cache`, keyed by `github.sha`) and LLVM-from-GCS caches are runner-agnostic and already work on the existing GCP self-hosted test runners — no cache regression.
- `ci-health` / `ci-analytics` are schedule-triggered, so their routing change takes effect on the next scheduled run after merge; the analytics scaler pool is already running and ready.

---

pr: non-breaking
