### PR TITLE
Mark scalar-fp8 (vk) as an expected failure on no-GPU runners

### DIFF
--- a/tests/expected-failure-no-gpu.txt
+++ b/tests/expected-failure-no-gpu.txt
@@ -11,3 +11,7 @@ gfx-unit-test-tool/neuralSlangNetworkConverterCUDA.internal
 
 # CPU gfx smoke imports the gfx module, which is not available on no-GPU hosted runners
 tests/cpu-program/gfx-smoke.slang (cpu)
+
+# fp8 scalar float constants hit an unsupported-width assert in the SPIR-V optimizer
+# (spirv-tools folding_rules.cpp GetWordsFromScalarFloatConstant requires width 16/32/64)
+tests/hlsl-intrinsic/scalar-fp8.slang (vk)


### PR DESCRIPTION
The fp8 scalar test aborts during SPIR-V optimization: an fp8 scalar float constant reaches spirv-tools' constant folder, whose `GetWordsFromScalarFloatConstant` (`folding_rules.cpp`) asserts the float width is 16/32/64 and aborts on width 8.

Add `tests/hlsl-intrinsic/scalar-fp8.slang (vk)` to `tests/expected-failure-no-gpu.txt` so the abort is reported as an expected failure under the test server until fp8 constant folding is supported upstream.

Closes #11767

Follow-up #11766 tracks removing this workaround once spirv-tools supports fp8 constant folding.