### PR TITLE
scaler: create VMs concurrently when scaling up

### DIFF
--- a/extras/scaler/cmd/scaler/main.go
+++ b/extras/scaler/cmd/scaler/main.go
@@ -489,30 +489,49 @@ func (s *gcpRunnerScaler) HandleDesiredRunnerCount(ctx context.Context, count in
 		scaleUp := targetCount - currentCount
 		s.logger.Info("scaling up", "current", currentCount, "target", targetCount, "creating", scaleUp)
 
+		// Create the VMs concurrently. Each CreateVM blocks on the GCP insert
+		// operation (op.Wait), so doing them serially made a burst of N jobs
+		// wait up to N × ~2-3 min for the last VM — the build pool routinely
+		// gets several jobs at once, so the last build sat queued for ~10 min.
+		// CreateVM already guards its shared state (the VM tracker and zone
+		// selection are mutex-locked), so it is safe to call in parallel.
+		// Bound the fan-out so we don't issue an unbounded burst of GCP API
+		// inserts at once (rate-limit safety).
+		const maxConcurrentCreates = 8
+		sem := make(chan struct{}, maxConcurrentCreates)
+		var wg sync.WaitGroup
 		for range scaleUp {
-			name := fmt.Sprintf("%s-%s", s.vmPrefix, uuid.NewString()[:8])
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
 
-			jit, err := s.scalesetClient.GenerateJitRunnerConfig(
-				ctx,
-				&scaleset.RunnerScaleSetJitRunnerSetting{Name: name},
-				s.scaleSetID,
-			)
-			if err != nil {
-				s.logger.Error("failed to generate JIT config", "error", err)
-				continue
-			}
+				name := fmt.Sprintf("%s-%s", s.vmPrefix, uuid.NewString()[:8])
 
-			vmName, err := s.vmManager.CreateVM(ctx, name, jit.EncodedJITConfig)
-			if err != nil {
-				s.logger.Error("failed to create VM", "error", err)
-				// JIT config was generated (runner registered) but VM
-				// creation failed. Clean up the stale runner entry.
-				s.removeRunnerFromGitHub(ctx, name)
-				continue
-			}
+				jit, err := s.scalesetClient.GenerateJitRunnerConfig(
+					ctx,
+					&scaleset.RunnerScaleSetJitRunnerSetting{Name: name},
+					s.scaleSetID,
+				)
+				if err != nil {
+					s.logger.Error("failed to generate JIT config", "error", err)
+					return
+				}
 
-			s.logger.Info("created runner VM", "vm", vmName, "runner", name)
+				vmName, err := s.vmManager.CreateVM(ctx, name, jit.EncodedJITConfig)
+				if err != nil {
+					s.logger.Error("failed to create VM", "error", err)
+					// JIT config was generated (runner registered) but VM
+					// creation failed. Clean up the stale runner entry.
+					s.removeRunnerFromGitHub(ctx, name)
+					return
+				}
+
+				s.logger.Info("created runner VM", "vm", vmName, "runner", name)
+			}()
 		}
+		wg.Wait()
 	case targetCount == currentCount:
 		// No scaling needed
 	default:

--- a/extras/scaler/cmd/scaler/main.go
+++ b/extras/scaler/cmd/scaler/main.go
@@ -496,15 +496,15 @@ func (s *gcpRunnerScaler) HandleDesiredRunnerCount(ctx context.Context, count in
 		// CreateVM already guards its shared state (the VM tracker and zone
 		// selection are mutex-locked), so it is safe to call in parallel.
 		// Bound the fan-out so we don't issue an unbounded burst of GCP API
-		// inserts at once (rate-limit safety).
+		// inserts at once or launch a goroutine per queued job.
 		const maxConcurrentCreates = 8
 		sem := make(chan struct{}, maxConcurrentCreates)
 		var wg sync.WaitGroup
 		for range scaleUp {
+			sem <- struct{}{}
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				sem <- struct{}{}
 				defer func() { <-sem }()
 
 				name := fmt.Sprintf("%s-%s", s.vmPrefix, uuid.NewString()[:8])

--- a/extras/scaler/internal/gcp/manager.go
+++ b/extras/scaler/internal/gcp/manager.go
@@ -90,7 +90,9 @@ type Manager struct {
 
 	mu sync.Mutex
 	// runnerName -> vmInfo
-	vms map[string]*vmInfo
+	vms            map[string]*vmInfo
+	pendingCreates map[string]zoneCandidate
+	nextNonGPUZone int
 }
 
 // NewManager creates a new GCP VM manager.
@@ -126,6 +128,7 @@ func NewManager(ctx context.Context, cfg ManagerConfig) (*Manager, error) {
 		cancelCleanup:   cancelCleanup,
 		nowFunc:         time.Now,
 		vms:             make(map[string]*vmInfo),
+		pendingCreates:  make(map[string]zoneCandidate),
 	}
 
 	// Start background loop to clean up TERMINATED VMs.
@@ -163,20 +166,25 @@ func (m *Manager) Close() {
 	m.regionsClient.Close()
 }
 
-// ActiveCount returns the number of VMs currently tracked.
+// ActiveCount returns the number of VMs currently tracked or being created.
 func (m *Manager) ActiveCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return len(m.vms)
+	return len(m.vms) + len(m.pendingCreates)
 }
 
 // ActiveRunnerNames returns the names of all tracked runners.
 func (m *Manager) ActiveRunnerNames() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	names := make([]string, 0, len(m.vms))
+	names := make([]string, 0, len(m.vms)+len(m.pendingCreates))
 	for name := range m.vms {
 		names = append(names, name)
+	}
+	for name := range m.pendingCreates {
+		if _, ok := m.vms[name]; !ok {
+			names = append(names, name)
+		}
 	}
 	return names
 }
@@ -245,13 +253,15 @@ func (m *Manager) selectZones(ctx context.Context) ([]zoneCandidate, error) {
 		return nil, err
 	}
 
-	// Non-GPU VMs: simple round-robin, no quota check needed
+	// Non-GPU VMs: all configured zones are candidates. CreateVM reserves
+	// one under the manager lock, so concurrent creates still round-robin
+	// instead of all observing the same active VM count.
 	if m.config.GPUType == "none" {
-		m.mu.Lock()
-		count := len(m.vms)
-		m.mu.Unlock()
-		zone := zones[count%len(zones)]
-		return []zoneCandidate{{zone: zone, region: zoneRegion(zone)}}, nil
+		candidates := make([]zoneCandidate, 0, len(zones))
+		for _, zone := range zones {
+			candidates = append(candidates, zoneCandidate{zone: zone, region: zoneRegion(zone)})
+		}
+		return candidates, nil
 	}
 
 	// GPU VMs: select zone by quota availability
@@ -419,7 +429,11 @@ func (m *Manager) CreateVM(ctx context.Context, runnerName, jitConfig string) (s
 	}
 
 	var stockoutErrors []string
-	for _, candidate := range candidates {
+	for len(candidates) > 0 {
+		candidate, err := m.reserveCreate(runnerName, candidates)
+		if err != nil {
+			return "", err
+		}
 		zone := candidate.zone
 		slog.Info("selected zone", "zone", zone, "region", candidate.region, "available_gpus", candidate.available)
 
@@ -449,17 +463,17 @@ func (m *Manager) CreateVM(ctx context.Context, runnerName, jitConfig string) (s
 		}
 
 		if err := m.insertVM(ctx, req); err != nil {
+			m.releaseCreate(runnerName)
 			if isZoneResourceExhausted(err) {
 				slog.Warn("zone resource exhausted, trying next candidate zone", "zone", zone, "error", err)
 				stockoutErrors = append(stockoutErrors, fmt.Sprintf("%s: %v", zone, err))
+				candidates = removeZoneCandidate(candidates, zone)
 				continue
 			}
 			return "", err
 		}
 
-		m.mu.Lock()
-		m.vms[runnerName] = &vmInfo{vmName: vmName, zone: zone, createdAt: m.now()}
-		m.mu.Unlock()
+		m.completeCreate(runnerName, vmName, candidate)
 
 		slog.Info("VM created", "vm", vmName, "zone", zone)
 		return vmName, nil
@@ -469,6 +483,79 @@ func (m *Manager) CreateVM(ctx context.Context, runnerName, jitConfig string) (s
 		return "", fmt.Errorf("all candidate zones are out of stock for %s: %s", m.config.GPUType, strings.Join(stockoutErrors, "; "))
 	}
 	return "", fmt.Errorf("no candidate zones available for %s", m.config.GPUType)
+}
+
+func removeZoneCandidate(candidates []zoneCandidate, zone string) []zoneCandidate {
+	filtered := candidates[:0]
+	for _, candidate := range candidates {
+		if candidate.zone != zone {
+			filtered = append(filtered, candidate)
+		}
+	}
+	return filtered
+}
+
+func (m *Manager) reserveCreate(runnerName string, candidates []zoneCandidate) (zoneCandidate, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.vms == nil {
+		m.vms = make(map[string]*vmInfo)
+	}
+	if m.pendingCreates == nil {
+		m.pendingCreates = make(map[string]zoneCandidate)
+	}
+
+	if _, ok := m.vms[runnerName]; ok {
+		return zoneCandidate{}, fmt.Errorf("runner %q is already tracked", runnerName)
+	}
+	if _, ok := m.pendingCreates[runnerName]; ok {
+		return zoneCandidate{}, fmt.Errorf("runner %q already has a pending create", runnerName)
+	}
+	if len(candidates) == 0 {
+		return zoneCandidate{}, fmt.Errorf("no candidate zones available for %s", m.config.GPUType)
+	}
+
+	var selected zoneCandidate
+	if m.config.GPUType == "none" {
+		selected = candidates[m.nextNonGPUZone%len(candidates)]
+		m.nextNonGPUZone++
+	} else {
+		pendingByRegion := make(map[string]int)
+		for _, pending := range m.pendingCreates {
+			pendingByRegion[pending.region]++
+		}
+
+		for _, candidate := range candidates {
+			if candidate.available <= float64(pendingByRegion[candidate.region]) {
+				continue
+			}
+			selected = candidate
+			break
+		}
+		if selected.zone == "" {
+			return zoneCandidate{}, fmt.Errorf("no candidate zones have unreserved %s quota", m.config.GPUType)
+		}
+	}
+
+	m.pendingCreates[runnerName] = selected
+	return selected, nil
+}
+
+func (m *Manager) releaseCreate(runnerName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.pendingCreates, runnerName)
+}
+
+func (m *Manager) completeCreate(runnerName, vmName string, candidate zoneCandidate) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.vms == nil {
+		m.vms = make(map[string]*vmInfo)
+	}
+	delete(m.pendingCreates, runnerName)
+	m.vms[runnerName] = &vmInfo{vmName: vmName, zone: candidate.zone, createdAt: m.now()}
 }
 
 func (m *Manager) insertVM(ctx context.Context, req *computepb.InsertInstanceRequest) error {

--- a/extras/scaler/internal/gcp/manager.go
+++ b/extras/scaler/internal/gcp/manager.go
@@ -516,24 +516,54 @@ func (m *Manager) reserveCreate(runnerName string, candidates []zoneCandidate) (
 		selected = candidates[m.nextNonGPUZone%len(candidates)]
 		m.nextNonGPUZone++
 	} else {
-		pendingByRegion := make(map[string]int)
-		for _, pending := range m.pendingCreates {
-			pendingByRegion[pending.region]++
-		}
-
-		for _, candidate := range candidates {
-			if candidate.available <= float64(pendingByRegion[candidate.region]) {
-				continue
-			}
-			selected = candidate
-			break
-		}
-		if selected.zone == "" {
-			return zoneCandidate{}, fmt.Errorf("no candidate zones have unreserved %s quota", m.config.GPUType)
+		var err error
+		selected, err = m.selectGPUZone(candidates)
+		if err != nil {
+			return zoneCandidate{}, err
 		}
 	}
 
 	m.pendingCreates[runnerName] = selected
+	return selected, nil
+}
+
+// selectGPUZone picks a GPU zone for a new reservation given the quota-ordered
+// candidates from selectZones and the creates already in flight. Quota is
+// enforced per region (GCP's GPU quota is regional), so a region is only
+// eligible while its reported availability exceeds the reservations already
+// pending against it. Among eligible candidates it keeps selectZones' region
+// ordering (most-available region first) but, within the chosen region,
+// spreads onto the zone with the fewest pending reservations — otherwise
+// concurrent creates would all herd onto the first zone in the region and
+// recreate the zonal stockouts this fan-out is meant to avoid. The caller must
+// hold m.mu.
+func (m *Manager) selectGPUZone(candidates []zoneCandidate) (zoneCandidate, error) {
+	pendingByRegion := make(map[string]int)
+	pendingByZone := make(map[string]int)
+	for _, pending := range m.pendingCreates {
+		pendingByRegion[pending.region]++
+		pendingByZone[pending.zone]++
+	}
+
+	var selected zoneCandidate
+	for _, candidate := range candidates {
+		if candidate.available <= float64(pendingByRegion[candidate.region]) {
+			continue
+		}
+		switch {
+		case selected.zone == "":
+			selected = candidate
+		case candidate.region != selected.region:
+			// candidates are region-ordered, so once we leave the
+			// already-selected region there is no better choice.
+			return selected, nil
+		case pendingByZone[candidate.zone] < pendingByZone[selected.zone]:
+			selected = candidate
+		}
+	}
+	if selected.zone == "" {
+		return zoneCandidate{}, fmt.Errorf("no candidate zones have unreserved %s quota", m.config.GPUType)
+	}
 	return selected, nil
 }
 

--- a/extras/scaler/internal/gcp/manager.go
+++ b/extras/scaler/internal/gcp/manager.go
@@ -486,7 +486,7 @@ func (m *Manager) CreateVM(ctx context.Context, runnerName, jitConfig string) (s
 }
 
 func removeZoneCandidate(candidates []zoneCandidate, zone string) []zoneCandidate {
-	filtered := candidates[:0]
+	filtered := make([]zoneCandidate, 0, len(candidates))
 	for _, candidate := range candidates {
 		if candidate.zone != zone {
 			filtered = append(filtered, candidate)
@@ -498,13 +498,6 @@ func removeZoneCandidate(candidates []zoneCandidate, zone string) []zoneCandidat
 func (m *Manager) reserveCreate(runnerName string, candidates []zoneCandidate) (zoneCandidate, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-
-	if m.vms == nil {
-		m.vms = make(map[string]*vmInfo)
-	}
-	if m.pendingCreates == nil {
-		m.pendingCreates = make(map[string]zoneCandidate)
-	}
 
 	if _, ok := m.vms[runnerName]; ok {
 		return zoneCandidate{}, fmt.Errorf("runner %q is already tracked", runnerName)
@@ -518,6 +511,8 @@ func (m *Manager) reserveCreate(runnerName string, candidates []zoneCandidate) (
 
 	var selected zoneCandidate
 	if m.config.GPUType == "none" {
+		// selectZones returns the full configured zone set for non-GPU
+		// pools, so this counter rotates through a stable ring.
 		selected = candidates[m.nextNonGPUZone%len(candidates)]
 		m.nextNonGPUZone++
 	} else {
@@ -551,9 +546,6 @@ func (m *Manager) releaseCreate(runnerName string) {
 func (m *Manager) completeCreate(runnerName, vmName string, candidate zoneCandidate) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.vms == nil {
-		m.vms = make(map[string]*vmInfo)
-	}
 	delete(m.pendingCreates, runnerName)
 	m.vms[runnerName] = &vmInfo{vmName: vmName, zone: candidate.zone, createdAt: m.now()}
 }

--- a/extras/scaler/internal/gcp/manager_test.go
+++ b/extras/scaler/internal/gcp/manager_test.go
@@ -637,6 +637,87 @@ func TestCreateVMConcurrentGPUCreatesRespectPendingQuota(t *testing.T) {
 	}
 }
 
+// TestCreateVMConcurrentGPUCreatesSpreadAcrossZonesInRegion verifies that when
+// a region has multiple zones and enough quota for several VMs, concurrent
+// reservations spread across the zones instead of all herding onto the first
+// one. Without intra-region spreading the burst would pile onto a single zone
+// and turn zonal stockouts into avoidable retries.
+func TestCreateVMConcurrentGPUCreatesSpreadAcrossZonesInRegion(t *testing.T) {
+	m := &Manager{
+		config: ManagerConfig{
+			Project:          "test-project",
+			Zones:            "us-east1-d,us-east1-b",
+			InstanceTemplate: "linux-gpu-runner-sm80plus-l4",
+			GPUType:          "nvidia-l4",
+			Platform:         "linux",
+		},
+		vms:            map[string]*vmInfo{},
+		pendingCreates: map[string]zoneCandidate{},
+	}
+	// One region, two zones, room for two concurrent VMs.
+	m.selectZonesFunc = func(context.Context) ([]zoneCandidate, error) {
+		return []zoneCandidate{
+			{zone: "us-east1-d", region: "us-east1", available: 2},
+			{zone: "us-east1-b", region: "us-east1", available: 2},
+		}, nil
+	}
+
+	const createCount = 2
+	insertEntered := make(chan struct{}, createCount)
+	releaseInserts := make(chan struct{})
+	var mu sync.Mutex
+	var zones []string
+	m.insertVMFunc = func(_ context.Context, req *computepb.InsertInstanceRequest) error {
+		mu.Lock()
+		zones = append(zones, req.GetZone())
+		mu.Unlock()
+		insertEntered <- struct{}{}
+		<-releaseInserts
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, createCount)
+	for i := range createCount {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := m.CreateVM(context.Background(), fmt.Sprintf("linux-sm80plus-%d", i), "jit-config")
+			errs <- err
+		}(i)
+	}
+
+	for i := 0; i < createCount; i++ {
+		select {
+		case <-insertEntered:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for concurrent inserts to start")
+		}
+	}
+
+	close(releaseInserts)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("CreateVM returned error: %v", err)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	gotZoneCounts := map[string]int{}
+	for _, zone := range zones {
+		gotZoneCounts[zone]++
+	}
+	wantZoneCounts := map[string]int{"us-east1-d": 1, "us-east1-b": 1}
+	for zone, want := range wantZoneCounts {
+		if got := gotZoneCounts[zone]; got != want {
+			t.Fatalf("zone %s insert count = %d, want %d (all zones: %v)", zone, got, want, gotZoneCounts)
+		}
+	}
+}
+
 // TestCreateVMStampsExpectGPUMetadata verifies that CreateVM stamps the
 // "expect-gpu" instance-metadata key from the pool's GPUType: "true" for GPU
 // pools and "false" for CPU-only pools (GPUType == "none"). The Linux startup

--- a/extras/scaler/internal/gcp/manager_test.go
+++ b/extras/scaler/internal/gcp/manager_test.go
@@ -360,7 +360,8 @@ func TestCreateVMTryNextZoneAfterStockout(t *testing.T) {
 			GPUType:          "nvidia-l4",
 			Platform:         "linux",
 		},
-		vms: map[string]*vmInfo{},
+		vms:            map[string]*vmInfo{},
+		pendingCreates: map[string]zoneCandidate{},
 	}
 	m.selectZonesFunc = func(context.Context) ([]zoneCandidate, error) {
 		return []zoneCandidate{
@@ -409,7 +410,8 @@ func TestCreateVMAllCandidateZonesStockout(t *testing.T) {
 			GPUType:          "nvidia-l4",
 			Platform:         "linux",
 		},
-		vms: map[string]*vmInfo{},
+		vms:            map[string]*vmInfo{},
+		pendingCreates: map[string]zoneCandidate{},
 	}
 	m.selectZonesFunc = func(context.Context) ([]zoneCandidate, error) {
 		return []zoneCandidate{
@@ -454,7 +456,8 @@ func TestCreateVMStopsOnNonStockoutError(t *testing.T) {
 			GPUType:          "nvidia-l4",
 			Platform:         "linux",
 		},
-		vms: map[string]*vmInfo{},
+		vms:            map[string]*vmInfo{},
+		pendingCreates: map[string]zoneCandidate{},
 	}
 	m.selectZonesFunc = func(context.Context) ([]zoneCandidate, error) {
 		return []zoneCandidate{
@@ -659,7 +662,8 @@ func TestCreateVMStampsExpectGPUMetadata(t *testing.T) {
 					GPUType:          tc.gpuType,
 					Platform:         "linux",
 				},
-				vms: map[string]*vmInfo{},
+				vms:            map[string]*vmInfo{},
+				pendingCreates: map[string]zoneCandidate{},
 			}
 			m.selectZonesFunc = func(context.Context) ([]zoneCandidate, error) {
 				return []zoneCandidate{{zone: "us-east1-d", region: "us-east1", available: 16}}, nil

--- a/extras/scaler/internal/gcp/manager_test.go
+++ b/extras/scaler/internal/gcp/manager_test.go
@@ -3,8 +3,10 @@ package gcp
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -475,6 +477,160 @@ func TestCreateVMStopsOnNonStockoutError(t *testing.T) {
 	}
 	if len(m.vms) != 0 {
 		t.Fatalf("tracked VM count = %d, want 0", len(m.vms))
+	}
+	if got := m.ActiveCount(); got != 0 {
+		t.Fatalf("active count after failed CreateVM = %d, want 0", got)
+	}
+}
+
+func TestCreateVMConcurrentNonGPUCreatesReserveZones(t *testing.T) {
+	m := &Manager{
+		config: ManagerConfig{
+			Project:          "test-project",
+			Zones:            "us-east1-c,us-east1-d,us-central1-a",
+			InstanceTemplate: "linux-build-runner",
+			GPUType:          "none",
+			Platform:         "linux",
+		},
+		vms:            map[string]*vmInfo{},
+		pendingCreates: map[string]zoneCandidate{},
+	}
+
+	const createCount = 5
+	insertEntered := make(chan struct{}, createCount)
+	releaseInserts := make(chan struct{})
+	var releaseInsertsOnce sync.Once
+	releasePendingInserts := func() {
+		releaseInsertsOnce.Do(func() { close(releaseInserts) })
+	}
+	defer releasePendingInserts()
+	var mu sync.Mutex
+	var zones []string
+
+	m.insertVMFunc = func(_ context.Context, req *computepb.InsertInstanceRequest) error {
+		mu.Lock()
+		zones = append(zones, req.GetZone())
+		mu.Unlock()
+
+		insertEntered <- struct{}{}
+		<-releaseInserts
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, createCount)
+	for i := range createCount {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			runnerName := fmt.Sprintf("linux-build-test-%d", i)
+			_, err := m.CreateVM(context.Background(), runnerName, "jit-config")
+			errs <- err
+		}(i)
+	}
+
+	for i := 0; i < createCount; i++ {
+		select {
+		case <-insertEntered:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for concurrent inserts to start")
+		}
+	}
+
+	if got := m.ActiveCount(); got != createCount {
+		t.Fatalf("active count while inserts are pending = %d, want %d", got, createCount)
+	}
+
+	releasePendingInserts()
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("CreateVM returned error: %v", err)
+		}
+	}
+
+	wantZoneCounts := map[string]int{
+		"us-east1-c":    2,
+		"us-east1-d":    2,
+		"us-central1-a": 1,
+	}
+	gotZoneCounts := map[string]int{}
+	mu.Lock()
+	for _, zone := range zones {
+		gotZoneCounts[zone]++
+	}
+	mu.Unlock()
+	if len(zones) != createCount {
+		t.Fatalf("insert count = %d, want %d", len(zones), createCount)
+	}
+	for zone, want := range wantZoneCounts {
+		if got := gotZoneCounts[zone]; got != want {
+			t.Fatalf("zone %s insert count = %d, want %d (all zones: %v)", zone, got, want, gotZoneCounts)
+		}
+	}
+	if got := m.ActiveCount(); got != createCount {
+		t.Fatalf("active count after CreateVM completes = %d, want %d", got, createCount)
+	}
+}
+
+func TestCreateVMConcurrentGPUCreatesRespectPendingQuota(t *testing.T) {
+	m := &Manager{
+		config: ManagerConfig{
+			Project:          "test-project",
+			Zones:            "us-east1-d",
+			InstanceTemplate: "linux-gpu-runner-sm80plus-l4",
+			GPUType:          "nvidia-l4",
+			Platform:         "linux",
+		},
+		vms:            map[string]*vmInfo{},
+		pendingCreates: map[string]zoneCandidate{},
+	}
+	m.selectZonesFunc = func(context.Context) ([]zoneCandidate, error) {
+		return []zoneCandidate{{zone: "us-east1-d", region: "us-east1", available: 1}}, nil
+	}
+
+	insertEntered := make(chan struct{}, 1)
+	releaseInsert := make(chan struct{})
+	m.insertVMFunc = func(context.Context, *computepb.InsertInstanceRequest) error {
+		insertEntered <- struct{}{}
+		<-releaseInsert
+		return nil
+	}
+
+	firstErr := make(chan error, 1)
+	go func() {
+		_, err := m.CreateVM(context.Background(), "linux-sm80plus-a", "jit-config")
+		firstErr <- err
+	}()
+
+	select {
+	case <-insertEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first insert to start")
+	}
+
+	if got := m.ActiveCount(); got != 1 {
+		t.Fatalf("active count while first insert is pending = %d, want 1", got)
+	}
+
+	_, err := m.CreateVM(context.Background(), "linux-sm80plus-b", "jit-config")
+	if err == nil {
+		t.Fatal("second CreateVM should fail while reported GPU quota is fully reserved")
+	}
+	if !strings.Contains(err.Error(), "no candidate zones have unreserved nvidia-l4 quota") {
+		t.Fatalf("second CreateVM error = %q, want unreserved quota error", err)
+	}
+	if got := m.ActiveCount(); got != 1 {
+		t.Fatalf("active count after rejected second create = %d, want 1", got)
+	}
+
+	close(releaseInsert)
+	if err := <-firstErr; err != nil {
+		t.Fatalf("first CreateVM returned error: %v", err)
+	}
+	if got := m.ActiveCount(); got != 1 {
+		t.Fatalf("active count after first CreateVM completes = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Motivation

The scale-up loop in `gcpRunnerScaler.HandleDesiredRunnerCount` created VMs **serially**. Each `CreateVM` blocks on the GCP insert operation (`op.Wait`, ~2-3 min), so a burst of N queued jobs waited up to N × that time for the last VM. On the build pool — which routinely gets several jobs at once — this left the last build queued ~10 min while VMs trickled out one per zone.

## Proposed solution

Fan the creates out across bounded goroutines (cap 8, so we never issue an unbounded burst of GCP API inserts and never spawn a goroutine per queued job). The semaphore token is acquired *before* launching each goroutine, so the cap bounds both in-flight inserts and live goroutines.

Concurrency safety is the hard part, and it is solved at the representation layer rather than papered over: `CreateVM` previously picked a zone by reading `len(m.vms)`, which is only correct when creates are serialized — concurrent calls would all observe the same count and pick the same zone (non-GPU) or over-commit regional quota (GPU). The fix introduces a `pendingCreates` map so an in-flight reservation is visible under the manager lock *before* the insert completes:

- `reserveCreate` atomically picks a zone (round-robin for non-GPU; quota-minus-pending for GPU) and records the reservation.
- `releaseCreate` unwinds the reservation if the insert fails (e.g. stockout fallthrough).
- `completeCreate` promotes a reservation into the live `vms` map on success.

`ActiveCount`/`ActiveRunnerNames` now include pending creates, so the scaler's own accounting reflects VMs that are being created but not yet inserted.

## Change summary

| Area | Change |
|------|--------|
| `cmd/scaler/main.go` | Replace the serial scale-up loop with a bounded (cap 8) goroutine fan-out; acquire the semaphore token before launching each goroutine. |
| `internal/gcp/manager.go` | Add `pendingCreates`/`nextNonGPUZone` state; `reserveCreate`/`releaseCreate`/`completeCreate` move zone selection + tracking under the lock; `selectZones` returns the full candidate set for non-GPU pools; `ActiveCount`/`ActiveRunnerNames` count pending creates. |
| `internal/gcp/manager_test.go` | Add two concurrency tests (non-GPU zone spreading; GPU pending-quota rejection); initialize `pendingCreates` in the `Manager{}`-literal tests. |

## Concepts and vocabulary

- **`pendingCreates`** — runners whose JIT config is registered and whose GCP insert is in flight but not yet complete. A reservation, made under the manager lock, that makes concurrent zone/quota decisions consistent.
- **Reserve → insert → complete/release** — the lifecycle of a single create: `reserveCreate` (pick + record zone), `insertVM` (blocking GCP call, lock released), then `completeCreate` on success or `releaseCreate` on failure.
- **`available <= pendingByRegion[region]`** — GPU quota check: GCP's reported regional quota minus the creates we already have in flight in that region, so concurrent GPU creates don't all spend the same headroom.

## Process report

- **Serial → concurrent fan-out (`main.go`).** The loop body is unchanged per-VM logic moved into a goroutine; `sem <- struct{}{}` before `go func()` bounds in-flight inserts and goroutine count at `maxConcurrentCreates`. `wg.Add(1)` precedes each launch, so `wg.Wait()` joins all of them. The cleanup-on-failure path (`removeRunnerFromGitHub` when JIT was registered but the VM insert failed) is preserved inside the goroutine.

- **`pendingCreates` is the principled fix, not a guard.** The cascading issue: making `CreateVM` concurrent exposed that zone selection read `len(m.vms)` — a count that only became accurate *after* a create finished. Two concurrent non-GPU creates would both see the same count and target the same zone; two GPU creates would both see the same regional quota and over-commit. Rather than serialize behind a coarser lock (which would defeat the latency win), the in-flight state itself is made authoritative: `reserveCreate` records the chosen zone under the lock before releasing it for the slow insert. This is the "make the representation correct so consumers stay simple" path — the zone decision now reads a true picture of in-flight work. The input shape (`pendingCreates` keyed by runner name) is the natural one: a create is uniquely identified by its runner name, which is also the `vms` key, so promotion on success is a `delete` + insert under the same lock.

- **`selectZones` returns the full non-GPU candidate set.** Previously it computed `zones[len(vms)%len(zones)]` itself. With concurrency that single index is wrong; selection moves into `reserveCreate` (using `nextNonGPUZone`, a stable monotonic counter over the fixed zone ring). A comment at the use site records the invariant that non-GPU candidates are always the full configured set.

- **`removeZoneCandidate` allocates a fresh slice.** It is a pure helper used in the stockout-fallthrough loop; an earlier `candidates[:0]` in-place filter mutated the caller's backing array. Allocating avoids a non-obvious aliasing footgun for any future caller.

- **No nil-map guards.** `NewManager` initializes both `vms` and `pendingCreates`, so the helpers rely on the constructor rather than re-checking for nil (which would be a guard never hit under correct construction). The `Manager{}`-literal tests are updated to initialize `pendingCreates`, keeping the "both maps always initialized" invariant genuinely true.

- **Testing.** Two new tests block inside `insertVMFunc` to hold creates in flight and assert `ActiveCount` mid-flight: one verifies concurrent non-GPU creates spread across zones (2/2/1 over three zones), one verifies a second concurrent GPU create is rejected while the single unit of reported quota is reserved. Verified with `go test -race ./internal/gcp/`. `HandleDesiredRunnerCount` itself is not unit-tested — it depends on concrete `vmManager`/`scalesetClient` types that aren't behind interfaces; extracting those is out of scope, and the concurrency safety that the fan-out relies on is covered at the manager layer under `-race`.
