### PR TITLE
ci: move the sanitizer build to the GCP build pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-slang-sanitizer.yml
     permissions:
+      # Required by ci-slang-sanitizer.yml's GCP Workload Identity auth step;
+      # id-token is never part of the default GITHUB_TOKEN.
       id-token: write
       contents: read
       packages: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,11 @@ jobs:
       runs-on: '["Linux", "self-hosted", "build", "GCP"]'
       container-user: "1003:1003"
 
-  # NOTE: wasm stays on GitHub-hosted for now. It builds directly on the host
-  # (no container) via ci-slang-build.yml, and the GCP build runner image lacks
-  # the host build toolchain (cmake), so it fails there with "cmake: command not
-  # found". Moving it onto the build pool requires running it in the CI
-  # container like the other Linux builds — tracked as a follow-up.
+  # WASM build runs directly on the host (no container) via ci-slang-build.yml.
+  # Stays on GitHub-hosted ubuntu-22.04 for now: the GCP build image lacks the
+  # gcc host toolchain it needs (the native generators stage fails with
+  # CMAKE_CXX_COMPILER not set — no g++). Moving it requires either adding g++
+  # to the image or running the build in a container; tracked as a follow-up.
   build-linux-release-gcc-wasm:
     needs: [filter]
     if: needs.filter.outputs.should-run == 'true'
@@ -99,14 +99,18 @@ jobs:
       runs-on: '["ubuntu-22.04"]'
 
   # Sanitizer build+test (blocking via check-ci, runs on every PR). Runs in the
-  # clang CI container; kept on GitHub-hosted until validated on the GCP build
-  # pool (tracked with the wasm container follow-up).
+  # clang CI container (`--user root`, so no container-user concern) on the GCP
+  # build pool. id-token requested explicitly for GCP Workload Identity auth.
   sanitizer-linux-clang-x86_64:
     needs: [filter]
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-slang-sanitizer.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
     with:
-      runs-on: '["ubuntu-22.04"]'
+      runs-on: '["Linux", "self-hosted", "build", "GCP"]'
 
   # macOS builds
   build-macos-debug-clang-aarch64:


### PR DESCRIPTION
## Motivation

The GitHub-hosted runner pool is capped at **20 concurrent jobs org-wide** and saturates in bursts. This moves one more job off that shared cap: `sanitizer-linux-clang-x86_64` previously ran on `ubuntu-22.04`. It follows #11736/#11738, which added the CPU-only GCP build pool and moved the x86_64 container builds onto it.

## Proposed solution

Route `sanitizer-linux-clang-x86_64` onto the self-hosted build pool (`["Linux", "self-hosted", "build", "GCP"]`), off the GitHub-hosted cap. It runs in the clang CI container as `--user root`, so there is no container-user / `_work`-ownership concern (unlike the container builds, which need `container-user: 1003`).

The reusable sanitizer workflow authenticates to GCP via Workload Identity, so the caller requests `id-token: write` explicitly — that scope is never part of the default `GITHUB_TOKEN` even when the repo default is `write`.

## Validation

Dispatched end-to-end on the GCP build pool: the job ran on a `linux-build-*` runner and **completed/success** — container init, checkout, GCP auth, "Build Slang with Sanitizers", "Verify sanitizer runtime is active", "Run Tests with Sanitizers", and the slangc sanitizer tests all passed. sccache + LLVM-from-GCS work as on the existing pool.

## Change summary

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | `sanitizer-linux-clang-x86_64` → `build,GCP` pool, with explicit `permissions: id-token: write`. wasm comment refreshed (it stays put — see below). |

## Out of scope (wasm stays on ubuntu-22.04)

`build-linux-release-gcc-wasm` is **not** moved here. It builds directly on the host (no container) and the GCP build image lacks the gcc host toolchain — the native generators stage fails with `CMAKE_CXX_COMPILER not set` (no `g++`). Moving wasm needs either `g++` added to the runner image or the build run in a container; tracked as a separate follow-up.

---

pr: non-breaking