### PR TITLE
ci: path-filter the TOC check to docs/user-guide changes

### DIFF
--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -4,6 +4,16 @@ on:
   pull_request:
     branches: [master]
     types: [opened, synchronize, reopened, ready_for_review]
+    # The TOC check only regenerates docs/user-guide/toc.html (see
+    # docs/build_toc.sh), so it is only relevant when the user guide changes.
+    # Path-filtering it keeps it off the ~majority of PRs that touch no docs,
+    # freeing a GitHub-hosted runner slot against the org's 20-concurrent cap.
+    # The workflow file and the generator script are included so changes to the
+    # check's own machinery still trigger it.
+    paths:
+      - "docs/user-guide/**"
+      - "docs/build_toc.sh"
+      - ".github/workflows/check-toc.yml"
 jobs:
   check-formatting:
     if: github.event.pull_request.draft != true


### PR DESCRIPTION
## Motivation

The `Check Table of Contents` workflow runs on **every** PR, consuming a GitHub-hosted runner slot against the org's 20-concurrent-runner cap. But it only regenerates `docs/user-guide/toc.html` (via `docs/build_toc.sh`, which iterates solely over `docs/user-guide/`), so it has no reason to run on the majority of PRs that touch no user-guide docs.

Most of the other standalone per-PR checks (`check-container-consistency`, `check-spirv-generated`, `check-python-core`) are already path-filtered; this closes the remaining gap.

## Proposed solution

Add a `paths:` filter so the check only triggers when the user guide (or the check's own machinery) changes:

```yaml
paths:
  - "docs/user-guide/**"
  - "docs/build_toc.sh"
  - ".github/workflows/check-toc.yml"
```

The generator script and the workflow file are included so changes to the check itself still trigger it.

## Safety

`check-toc` is **not** a required status check (required: `check-formatting`, `check-ci`, `SlangPy Tests`), so skipping it on unrelated PRs does not leave a pending required check and does not block merges.

## Change summary

| File | Change |
|------|--------|
| `.github/workflows/check-toc.yml` | Add `paths:` filter to the `pull_request` trigger. |

---

pr: non-breaking