### PR TITLE
Centralize docs-only CI skip filter

### DIFF
--- a/.github/workflows/check-pr-label.yml
+++ b/.github/workflows/check-pr-label.yml
@@ -2,12 +2,6 @@ name: Verify PR Labels
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize, ready_for_review]
-    paths-ignore:
-      - "docs/**"
-      - "LICENSES/**"
-      - "LICENSE"
-      - "CONTRIBUTING.md"
-      - "README.md"
 jobs:
   check-pr-label:
     if: github.event.pull_request.draft != true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           shouldRun=true
           if files="$(git diff --name-only $BASE...HEAD)"; then
             # Git diff succeeded, check if non-documentation files were changed
-            if echo "$files" | grep -qvE '^(docs/|LICENSES/|LICENSE$|CONTRIBUTING\.md$|README\.md$)'; then
+            if echo "$files" | grep -qvE '^(docs/|LICENSES/|LICENSE$|\.claude/|[^/]+\.md$|\.coderabbit\.yaml$)'; then
               shouldRun=true
             else
               echo "Only documentation files changed, skipping remaining steps"

--- a/.github/workflows/push-benchmark-results.yml
+++ b/.github/workflows/push-benchmark-results.yml
@@ -4,12 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches: [master]
-    paths-ignore:
-      - "docs/**"
-      - "LICENSES/**"
-      - "LICENSE"
-      - "CONTRIBUTING.md"
-      - "README.md"
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Motivation

Documentation-only PRs should avoid running Slang's full build/test matrix. The existing CI filter skipped `docs/`, license files, and a few named root documentation files, but it still ran full CI for root agent guidance files such as `AGENTS.md` and `CLAUDE.md`, as seen in PR #11697.

## Proposed solution

Centralize the docs-only skip policy in `.github/workflows/ci.yml` and broaden that filter to cover root Markdown files, `.claude/`, and `.coderabbit.yaml`. This keeps full CI focused on code-affecting changes while preserving the existing conservative fallback when the diff cannot be computed.

## Change summary

- `.github/workflows/ci.yml`: extend the filter regex so `docs/`, `LICENSES/`, `LICENSE`, `.claude/`, root `*.md`, and `.coderabbit.yaml` are treated as documentation-only inputs for full CI.
- `.github/workflows/check-pr-label.yml`: remove its duplicated `paths-ignore` list so the lightweight label check can run on documentation-only PRs instead of carrying a second skip policy.
- `.github/workflows/push-benchmark-results.yml`: remove its duplicated `paths-ignore` list to avoid future drift from the main CI skip policy.

## Process report

The root cause was that `.github/workflows/ci.yml` encoded the docs-only policy as a narrow explicit allowlist. Adding one entry at a time would keep repeating the same maintenance problem, so the filter now treats root Markdown files generically with `[^/]+\.md$` while still keeping nested Markdown under source or tests CI-relevant unless it is under `docs/`.

The duplicated `paths-ignore` blocks in the lightweight workflows were removed rather than expanded. That makes `.github/workflows/ci.yml` the only workflow carrying the full-CI skip classification, so future changes to what counts as documentation-only do not need to be synchronized across unrelated workflows.
