### PR TITLE
Reduce parallel generic entrypoint stress

### DIFF
--- a/tests/expected-failure-github.txt
+++ b/tests/expected-failure-github.txt
@@ -19,6 +19,3 @@ tests/bugs/array-size-groupshared.slang.1 syn (wgpu)
 tests/bugs/generic-groupshared.slang.2 syn (wgpu)
 tests/compute/groupshared.slang.4 syn (wgpu)
 tests/metal/groupshared-threadlocal-same-parameter.slang.4 syn (wgpu)
-
-# JSON RPC failure in GitHub CI. Tracking on github #11759
-slang-unit-test-tool/parallelGenericEntryPointCompile.internal

--- a/tools/slang-unit-test/unit-test-generic-entrypoint.cpp
+++ b/tools/slang-unit-test/unit-test-generic-entrypoint.cpp
@@ -19,7 +19,10 @@ namespace
 
 static int _getParallelGenericEntryPointIterationCount()
 {
-    static constexpr int kDefaultIterationCount = 20;
+    // Keep the default below the Windows Debug test-server RPC timeout on slower CI machines.
+    // Developers can raise this with SLANG_PARALLEL_GENERIC_ENTRYPOINT_ITERATIONS when they need a
+    // longer local stress run.
+    static constexpr int kDefaultIterationCount = 10;
 
     const char* envValue = getenv("SLANG_PARALLEL_GENERIC_ENTRYPOINT_ITERATIONS");
     if (!envValue || !envValue[0])


### PR DESCRIPTION
Fixes #11759

## Motivation

`slang-unit-test-tool/parallelGenericEntryPointCompile.internal` failed in Windows Debug CI through the test-server path with `JSON RPC failure: waitForResult()` and `JSON RPC failure: hasMessage()`. The failure happened when the test-server request exceeded its Windows Debug RPC timeout while running the parallel generic entry-point stress workload.

The motivating case is issue #11759: the test runs HLSL, CUDA, SPIR-V assembly, and Metal source emission over shared session/module state, with 20 worker threads per iteration. At the previous default of 20 iterations per target, that was too expensive for slower Windows Debug CI machines.

## Proposed solution

Keep the test as a parallel backend stress test, but lower the default stress depth from 20 iterations to 10 in `_getParallelGenericEntryPointIterationCount` (`tools/slang-unit-test/unit-test-generic-entrypoint.cpp:20`). This preserves the shape that the test is meant to exercise: each target still starts 20 worker threads at the same gate and still compiles specialized generic entry points concurrently.

The existing `SLANG_PARALLEL_GENERIC_ENTRYPOINT_ITERATIONS` override remains the source of truth for longer local stress runs. That keeps CI below the RPC timeout without weakening the targeted diagnostic workflow for developers investigating backend concurrency.

## Change summary

`tools/slang-unit-test/unit-test-generic-entrypoint.cpp:20` now defaults `parallelGenericEntryPointCompile` to 10 iterations and documents that the default is sized for Windows Debug test-server CI while the environment variable can raise it.

`tests/expected-failure-github.txt:21` no longer lists `slang-unit-test-tool/parallelGenericEntryPointCompile.internal`, because the test should run within the GitHub CI test-server timeout again.

## Concepts and vocabulary

`parallelGenericEntryPointCompile` is a unit test that stresses backend code generation by compiling specialized generic entry points concurrently after front-end component operations have finished.

The test-server RPC timeout is the parent `slang-test` process timeout while it waits for a test-server child to finish a single test request. In Windows Debug builds this timeout is 300 seconds.

## Process report

The failing input shape is valid: the test intentionally shares a session and module across threads after `specialize`, `createCompositeComponentType`, and `link` complete, then gates the threads so concurrent `getEntryPointCode` calls exercise backend emission. The producer should not be changed to use per-thread sessions, because that would avoid the contract the test is meant to cover.

The issue was the amount of stress in the default CI configuration. `_runParallelGenericEntryPointCompileForTarget` keeps the important concurrency shape by using `kThreadCount = 20`, starting every worker through `ParallelThreadGate`, and running each worker through `getEntryPointCode`. Reducing only the default iteration count leaves those code paths intact while cutting the wall time of the single test-server request.

The expected-failure entry was removed after the default was reduced because the test is no longer expected to hit the GitHub Windows Debug RPC timeout. Longer local runs still use the same code path through `SLANG_PARALLEL_GENERIC_ENTRYPOINT_ITERATIONS`, so deeper stress remains available without making every CI run pay that cost.
