### PR TITLE
Fix #11407: correct stale 30055 diagnostics-catalog test to fire the diagnostic

### DIFF
--- a/docs/generated/tests/design/cross-cutting/diagnostics-catalog/30055-use-of-non-short-circuiting-operator-in-diff-func.slang
+++ b/docs/generated/tests/design/cross-cutting/diagnostics-catalog/30055-use-of-non-short-circuiting-operator-in-diff-func.slang
@@ -11,16 +11,19 @@
 //META: catalog_name=use-of-non-short-circuiting-operator-in-diff-func
 //META: warning=Auto-generated. May drift from source. Do not edit by hand.
 
-// Non-short-circuiting `?:` operator inside a differentiable function triggers the diagnostic.
+// A non-short-circuiting `?:` with a *vector* condition inside a differentiable
+// function triggers E30055. The diagnostic is emitted only on the vector-condition
+// path of `SemanticsExprVisitor::visitSelectExpr`; a scalar (`bool`) condition
+// early-returns with no diagnostic, so the example must use a `bool`N condition.
 
 //DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):
 
 [Differentiable]
-float f(float x, bool b)
+float3 f(float3 x, bool3 b)
 {
-    return b ?: 0.0;
+    return b ? x : float3(0.0);
 }
 
 void main() {}
 
-// CHECK: 30055
+//CHECK: 30055


### PR DESCRIPTION
## Motivation

The generated autodiff diagnostics-catalog test
`docs/generated/tests/design/cross-cutting/diagnostics-catalog/30055-use-of-non-short-circuiting-operator-in-diff-func.slang`
was stale: it used a **scalar** `?:` example that never emits `E30055`, yet
the test still passed — so it asserted nothing.

```slang
[Differentiable]
float f(float x, bool b)
{
    return b ? x : 0.0;   // scalar condition: no diagnostic
}
// CHECK: 30055
```

Two independent reasons it was a no-op:

1. `E30055` (`use-of-non-short-circuiting-operator-in-diff-func`) is emitted
   only on the **vector-condition** path of
   `SemanticsExprVisitor::visitSelectExpr` (`source/slang/slang-check-expr.cpp`).
   A scalar (`BasicExpressionType`) condition early-returns with no diagnostic.
2. The annotation was written `// CHECK: 30055` **with a space**. The
   diagnostic-annotation parser (`DiagnosticAnnotationUtil::parseAnnotations`)
   only recognises the no-space `//CHECK:` line marker, so the annotation was
   silently dropped and the test passed unconditionally.

## Proposed solution

Make the example actually fire the diagnostic and make the assertion active:

- Use a **vector** (`bool3`) condition so `E30055` is emitted.
- Use the recognised `//CHECK:` marker (no space) so the assertion runs.

Verified: with the vector body the test passes; reverting to the scalar body
now correctly fails with "No diagnostics were produced", proving the test is
no longer a false positive.

## Change summary

| File | Change |
|---|---|
| `docs/.../diagnostics-catalog/30055-use-of-non-short-circuiting-operator-in-diff-func.slang` | Vector-condition example + active `//CHECK:` marker; comment explains the scalar-vs-vector distinction. |

## Concepts and vocabulary

- **`visitSelectExpr` vector path** — the only place `E30055` / `E30056` are
  raised; scalar `?:` short-circuits to a plain typed expression with no diagnostic.
- **`//CHECK:` vs `// CHECK:`** — the diagnostic-annotation harness only parses
  the no-space `//CHECK:` form; the spaced form is inert.

## Process report

The file is marked `generated=true`, but its generator is an agentic process
rather than a deterministic script, so the entry is corrected in place to match
real compiler behavior. The corrected example is principled: it exercises the
exact (vector-condition) code path that owns `E30055`, rather than the scalar
path that intentionally has no diagnostic. No compiler code is changed because
the compiler behavior is correct — only the test example and its (previously
inert) annotation were wrong.