### PR TITLE
Restrict WaveGetWaveIndex / WaveGetNumWaves to compute-class stages via capability

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1772,6 +1772,7 @@ A capability describes an optional feature that a target may or may not support.
 * `shader5_sm_5_0` 
 * `pack_vector` 
 * `subgroup_basic` 
+* `subgroup_workgroup_index` 
 * `subgroup_ballot` 
 * `subgroup_ballot_activemask` 
 * `subgroup_basic_ballot` 

--- a/docs/user-guide/a3-02-reference-capability-atoms.md
+++ b/docs/user-guide/a3-02-reference-capability-atoms.md
@@ -2,8 +2,7 @@
 layout: user-guide
 ---
 
-Capability Atoms
-============================
+# Capability Atoms
 
 ### Sections:
 
@@ -14,1661 +13,2191 @@ Capability Atoms
 5. [Compound Capabilities](#compound-capabilities)
 6. [Other](#other)
 
-Targets
-----------------------
-*Capabilities to specify code generation targets (`glsl`, `spirv`...)*
+## Targets
+
+_Capabilities to specify code generation targets (`glsl`, `spirv`...)_
 
 `c`
+
 > Represents the C programming language code generation target.
 
 `cpp`
+
 > Represents the C++ programming language code generation target.
 
 `cuda`
+
 > Represents the CUDA code generation target.
 
 `glsl`
+
 > Represents the GLSL code generation target.
 
 `hlsl`
+
 > Represents the HLSL code generation target.
 
 `llvm`
+
 > Represents the LLVM IR target.
 
 `metal`
+
 > Represents the Metal programming language code generation target.
 
 `slangvm`
+
 > Represents the Slang VM bytecode target.
 
 `spirv`
+
 > Represents the SPIR-V code generation target.
 
 `textualTarget`
+
 > Represents a non-assembly code generation target.
 
 `wgsl`
+
 > Represents the WebGPU shading language code generation target.
 
-Stages
-----------------------
-*Capabilities to specify code generation stages (`vertex`, `fragment`...)*
+## Stages
+
+_Capabilities to specify code generation stages (`vertex`, `fragment`...)_
 
 `amplification`
+
 > Amplification shader stage & mesh shader capabilities
 
 `anyhit`
+
 > Any-Hit shader stage & ray-tracing capabilities
 
 `callable`
+
 > Callable shader stage & ray-tracing capabilities
 
 `closesthit`
+
 > Closest-Hit shader stage & ray-tracing capabilities
 
 `compute`
+
 > Compute shader stage
 
 `dispatch`
+
 > Dispatch shader stage
 
 `domain`
+
 > Domain shader stage
 
 `fragment`
+
 > Fragment shader stage
 
 `geometry`
+
 > Geometry shader stage
 
 `hull`
+
 > Hull shader stage
 
 `intersection`
+
 > Intersection shader stage & ray-tracing capabilities
 
 `mesh`
+
 > Mesh shader stage & mesh shader capabilities
 
 `miss`
+
 > Ray-Miss shader stage & ray-tracing capabilities
 
 `pixel`
+
 > Pixel shader stage
 
 `raygen`
+
 > Ray-Generation shader stage & ray-tracing capabilities
 
 `raygeneration`
+
 > Ray-Generation shader stage & ray-tracing capabilities
 
 `task`
+
 > Task shader stage & mesh shader capabilities
 
 `tesscontrol`
+
 > Tessellation Control shader stage
 
 `tesseval`
+
 > Tessellation Evaluation shader stage
 
 `vertex`
+
 > Vertex shader stage
 
-Versions
-----------------------
-*Capabilities to specify versions of a code generation target (`sm_5_0`, `GLSL_400`...)*
+## Versions
+
+_Capabilities to specify versions of a code generation target (`sm_5_0`, `GLSL_400`...)_
 
 `GLSL_130`
+
 > GLSL 130 and related capabilities of other targets.
 
 `GLSL_140`
+
 > GLSL 140 and related capabilities of other targets.
 
 `GLSL_150`
+
 > GLSL 150 and related capabilities of other targets.
 
 `GLSL_330`
+
 > GLSL 330 and related capabilities of other targets.
 
 `GLSL_400`
+
 > GLSL 400 and related capabilities of other targets.
 
 `GLSL_410`
+
 > GLSL 410 and related capabilities of other targets.
 
 `GLSL_420`
+
 > GLSL 420 and related capabilities of other targets.
 
 `GLSL_430`
+
 > GLSL 430 and related capabilities of other targets.
 
 `GLSL_440`
+
 > GLSL 440 and related capabilities of other targets.
 
 `GLSL_450`
+
 > GLSL 450 and related capabilities of other targets.
 
 `GLSL_460`
+
 > GLSL 460 and related capabilities of other targets.
 
 `cuda_sm_1_0`
+
 > cuda 1.0 and related capabilities of other targets.
 
 `cuda_sm_2_0`
+
 > cuda 2.0 and related capabilities of other targets.
 
 `cuda_sm_3_0`
+
 > cuda 3.0 and related capabilities of other targets.
 
 `cuda_sm_3_5`
+
 > cuda 3.5 and related capabilities of other targets.
 
 `cuda_sm_4_0`
+
 > cuda 4.0 and related capabilities of other targets.
 
 `cuda_sm_5_0`
+
 > cuda 5.0 and related capabilities of other targets.
 
 `cuda_sm_6_0`
+
 > cuda 6.0 and related capabilities of other targets.
 
 `cuda_sm_7_0`
+
 > cuda 7.0 and related capabilities of other targets.
 
 `cuda_sm_8_0`
+
 > cuda 8.0 and related capabilities of other targets.
 
 `cuda_sm_8_9`
-> cuda 8.9 (Ada Lovelace) and related capabilities of other targets.  Required
+
+> cuda 8.9 (Ada Lovelace) and related capabilities of other targets. Required
 > for PTX features that landed in PTX ISA 8.7 / SM 8.9, notably the
 > `mma.sync.m16n8k16` instruction with `.e4m3` / `.e5m2` floating-point inputs
 > (FP8 cooperative matrices).
 
 `cuda_sm_9_0`
+
 > cuda 9.0 and related capabilities of other targets.
 
 `dxil_lib`
+
 > Represents capabilities required for DXIL Library compilation.
 
 `glsl_spirv_1_0`
+
 > Represents SPIR-V 1.0 through glslang.
 
 `glsl_spirv_1_1`
+
 > Represents SPIR-V 1.1 through glslang.
 
 `glsl_spirv_1_2`
+
 > Represents SPIR-V 1.2 through glslang.
 
 `glsl_spirv_1_3`
+
 > Represents SPIR-V 1.3 through glslang.
 
 `glsl_spirv_1_4`
+
 > Represents SPIR-V 1.4 through glslang.
 
 `glsl_spirv_1_5`
+
 > Represents SPIR-V 1.5 through glslang.
 
 `glsl_spirv_1_6`
+
 > Represents SPIR-V 1.6 through glslang.
 
 `hlsl_2018`
+
 > Represent HLSL compatibility support.
 
 `hlsl_nvapi`
+
 > Represents HLSL NVAPI support.
 
 `metallib_2_3`
+
 > Represents MetalLib 2.3.
 
 `metallib_2_4`
+
 > Represents MetalLib 2.4.
 
 `metallib_3_0`
+
 > Represents MetalLib 3.0.
 
 `metallib_3_1`
+
 > Represents MetalLib 3.1.
 
 `metallib_4_0`
+
 > Represents MetalLib 4.0.
 
 `metallib_latest`
+
 > Represents the latest MetalLib version.
 
 `sm_4_0`
+
 > HLSL shader model 4.0 and related capabilities of other targets.
 > Includes related GLSL/SPIRV extensions.
 
 `sm_4_0_version`
+
 > HLSL shader model 4.0 and related capabilities of other targets.
 > Does not include related GLSL/SPIRV extensions.
 
 `sm_4_1`
+
 > HLSL shader model 4.1 and related capabilities of other targets.
 > Includes related GLSL/SPIRV extensions.
 
 `sm_4_1_version`
+
 > HLSL shader model 4.1 and related capabilities of other targets.
 > Does not include related GLSL/SPIRV extensions.
 
 `sm_5_0`
+
 > HLSL shader model 5.0 and related capabilities of other targets.
 > Includes related GLSL/SPIRV extensions.
 
 `sm_5_0_version`
+
 > HLSL shader model 5.0 and related capabilities of other targets.
 > Does not include related GLSL/SPIRV extensions.
 
 `sm_5_1`
+
 > HLSL shader model 5.1 and related capabilities of other targets.
 > Includes related GLSL/SPIRV extensions.
 
 `sm_5_1_version`
+
 > HLSL shader model 5.1 and related capabilities of other targets.
 > Does not include related GLSL/SPIRV extensions.
 
 `sm_6_0`
+
 > HLSL shader model 6.0 and related capabilities of other targets.
 > Includes related GLSL/SPIRV extensions.
 
 `sm_6_0_version`
+
 > HLSL shader model 6.0 and related capabilities of other targets.
 > Does not include related GLSL/SPIRV extensions.
 
 `sm_6_1`
+
 > HLSL shader model 6.1 and related capabilities of other targets.
 > Includes related GLSL/SPIRV extensions.
 
 `sm_6_10`
+
 > HLSL shader model 6.10 and related capabilities of other targets.
 > Includes related GLSL/SPIRV extensions.
 
 `sm_6_10_version`
+
 > HLSL shader model 6.10 and related capabilities of other targets.
 > Does not include related GLSL/SPIRV extensions.
 
 `sm_6_1_version`
+
 > HLSL shader model 6.1 and related capabilities of other targets.
 > Does not include related GLSL/SPIRV extensions.
 
 `sm_6_2`
+
 > HLSL shader model 6.2 and related capabilities of other targets.
 > Includes related GLSL/SPIRV extensions.
 
 `sm_6_2_version`
+
 > HLSL shader model 6.2 and related capabilities of other targets.
 > Does not include related GLSL/SPIRV extensions.
 
 `sm_6_3`
+
 > HLSL shader model 6.3 and related capabilities of other targets.
 > Includes related GLSL/SPIRV extensions.
 
 `sm_6_3_version`
+
 > HLSL shader model 6.3 and related capabilities of other targets.
 > Does not include related GLSL/SPIRV extensions.
 
 `sm_6_4`
+
 > HLSL shader model 6.4 and related capabilities of other targets.
 > Includes related GLSL/SPIRV extensions.
 
 `sm_6_4_version`
+
 > HLSL shader model 6.4 and related capabilities of other targets.
 > Does not include related GLSL/SPIRV extensions.
 
 `sm_6_5`
+
 > HLSL shader model 6.5 and related capabilities of other targets.
 > Includes related GLSL/SPIRV extensions.
 
 `sm_6_5_version`
+
 > HLSL shader model 6.5 and related capabilities of other targets.
 > Does not include related GLSL/SPIRV extensions.
 
 `sm_6_6`
+
 > HLSL shader model 6.6 and related capabilities of other targets.
 > Includes related GLSL/SPIRV extensions.
 
 `sm_6_6_version`
+
 > HLSL shader model 6.6 and related capabilities of other targets.
 > Does not include related GLSL/SPIRV extensions.
 
 `sm_6_7`
+
 > HLSL shader model 6.7 and related capabilities of other targets.
 > Includes related GLSL/SPIRV extensions.
 
 `sm_6_7_version`
+
 > HLSL shader model 6.7 and related capabilities of other targets.
 > Does not include related GLSL/SPIRV extensions.
 
 `sm_6_8`
+
 > HLSL shader model 6.8 and related capabilities of other targets.
 > Includes related GLSL/SPIRV extensions.
 
 `sm_6_8_version`
+
 > HLSL shader model 6.8 and related capabilities of other targets.
 > Does not include related GLSL/SPIRV extensions.
 
 `sm_6_9`
+
 > HLSL shader model 6.9 and related capabilities of other targets.
 > Includes related GLSL/SPIRV extensions.
 
 `sm_6_9_version`
+
 > HLSL shader model 6.9 and related capabilities of other targets.
 > Does not include related GLSL/SPIRV extensions.
 
 `spirv_1_0`
+
 > Represents SPIR-V 1.0 version.
 
 `spirv_1_1`
+
 > Represents SPIR-V 1.1 version, which includes SPIR-V 1.0.
 
 `spirv_1_2`
+
 > Represents SPIR-V 1.2 version, which includes SPIR-V 1.1.
 
 `spirv_1_3`
+
 > Represents SPIR-V 1.3 version, which includes SPIR-V 1.2.
 
 `spirv_1_4`
+
 > Represents SPIR-V 1.4 version, which includes SPIR-V 1.3.
 
 `spirv_1_5`
+
 > Represents SPIR-V 1.5 version, which includes SPIR-V 1.4 and additional extensions.
 
 `spirv_1_6`
+
 > Represents SPIR-V 1.6 version, which includes SPIR-V 1.5 and additional extensions.
 
 `spirv_latest`
+
 > Represents the latest SPIR-V version.
 
-Extensions
-----------------------
-*Capabilities to specify extensions (`GL_EXT`, `SPV_EXT`...)*
+## Extensions
+
+_Capabilities to specify extensions (`GL_EXT`, `SPV_EXT`...)_
 
 `GL_ARB_derivative_control`
+
 > Represents the GL_ARB_derivative_control extension.
 
 `GL_ARB_fragment_shader_interlock`
+
 > Represents the GL_ARB_fragment_shader_interlock extension.
 
 `GL_ARB_gpu_shader5`
+
 > Represents the GL_ARB_gpu_shader5 extension.
 
 `GL_ARB_gpu_shader_int64`
+
 > Represents the GL_ARB_gpu_shader_int64 extension.
 
 `GL_ARB_shader_clock`
+
 > Represents the GL_ARB_shader_clock extension.
 
 `GL_ARB_shader_clock64`
+
 > Represents the GL_ARB_shader_clock64 extension.
 
 `GL_ARB_shader_image_load_store`
+
 > Represents the GL_ARB_shader_image_load_store extension.
 
 `GL_ARB_shader_image_size`
+
 > Represents the GL_ARB_shader_image_size extension.
 
 `GL_ARB_shader_texture_image_samples`
+
 > Represents the GL_ARB_shader_texture_image_samples extension.
 
 `GL_ARB_sparse_texture`
+
 > Represents the GL_ARB_sparse_texture extension.
 
 `GL_ARB_sparse_texture2`
+
 > Represents the GL_ARB_sparse_texture2 extension.
 
 `GL_ARB_sparse_texture_clamp`
+
 > Represents the GL_ARB_sparse_texture_clamp extension.
 
 `GL_ARB_texture_gather`
+
 > Represents the GL_ARB_texture_gather extension.
 
 `GL_ARB_texture_multisample`
+
 > Represents the GL_ARB_texture_multisample extension.
 
 `GL_ARB_texture_query_levels`
+
 > Represents the GL_ARB_texture_query_levels extension.
 
 `GL_EXT_buffer_reference`
+
 > Represents the GL_EXT_buffer_reference extension.
 
 `GL_EXT_buffer_reference_uvec2`
+
 > Represents the GL_EXT_buffer_reference_uvec2 extension.
 
 `GL_EXT_debug_printf`
+
 > Represents the GL_EXT_debug_printf extension.
 
 `GL_EXT_demote_to_helper_invocation`
+
 > Represents the GL_EXT_demote_to_helper_invocation extension.
 
 `GL_EXT_device_group`
+
 > Represents the GL_EXT_device_group extension.
 
 `GL_EXT_fragment_shader_barycentric`
+
 > Represents the GL_EXT_fragment_shader_barycentric extension.
 
 `GL_EXT_maximal_reconvergence`
+
 > Represents the GL_EXT_maximal_reconvergence extension.
 
 `GL_EXT_mesh_shader`
+
 > Represents the GL_EXT_mesh_shader extension.
 
 `GL_EXT_nonuniform_qualifier`
+
 > Represents the GL_EXT_nonuniform_qualifier extension.
 
 `GL_EXT_ray_query`
+
 > Represents the GL_EXT_ray_query extension.
 
 `GL_EXT_ray_tracing`
+
 > Represents the GL_EXT_ray_tracing extension.
 
 `GL_EXT_ray_tracing_position_fetch`
+
 > Represents the GL_EXT_ray_tracing_position_fetch extension.
 
 `GL_EXT_ray_tracing_position_fetch_ray_query`
+
 > Represents the GL_EXT_ray_tracing_position_fetch_ray_query extension.
 
 `GL_EXT_ray_tracing_position_fetch_ray_tracing`
+
 > Represents the GL_EXT_ray_tracing_position_fetch_ray_tracing extension.
 
 `GL_EXT_samplerless_texture_functions`
+
 > Represents the GL_EXT_samplerless_texture_functions extension.
 
 `GL_EXT_shader_abort`
+
 > Represents the GL_EXT_shader_abort extension for GLSL targets, or the
 > corresponding spvAbort capability for SPIR-V targets.
 
 `GL_EXT_shader_atomic_float`
+
 > Represents the GL_EXT_shader_atomic_float extension.
 
 `GL_EXT_shader_atomic_float2`
+
 > Represents the GL_EXT_shader_atomic_float2 extension.
 
 `GL_EXT_shader_atomic_float_min_max`
+
 > Represents the GL_EXT_shader_atomic_float_min_max extension.
 
 `GL_EXT_shader_atomic_int64`
+
 > Represents the GL_EXT_shader_atomic_int64 extension.
 
 `GL_EXT_shader_explicit_arithmetic_types`
+
 > Represents the GL_EXT_shader_explicit_arithmetic_types extension.
 
 `GL_EXT_shader_explicit_arithmetic_types_int64`
+
 > Represents the GL_EXT_shader_explicit_arithmetic_types_int64 extension.
 
 `GL_EXT_shader_image_load_store`
+
 > Represents the GL_EXT_shader_image_load_store extension.
 
 `GL_EXT_shader_invocation_reorder`
+
 > Represents the GL_EXT_shader_invocation_reorder extension (cross-vendor standard).
 
 `GL_EXT_shader_invocation_reorder_motion`
+
 > Represents the GL_EXT_shader_invocation_reorder + motion blur combined extension (cross-vendor SER with NV motion blur).
 > Used for motion blur variants of EXT SER functions.
 
 `GL_EXT_shader_quad_control`
+
 > Represents the GL_EXT_shader_quad_control extension.
 
 `GL_EXT_shader_realtime_clock`
+
 > Represents the GL_EXT_shader_realtime_clock extension.
 
 `GL_EXT_texture_query_lod`
+
 > Represents the GL_EXT_texture_query_lod extension.
 
 `GL_EXT_texture_shadow_lod`
+
 > Represents the GL_EXT_texture_shadow_lod extension.
 
 `GL_KHR_memory_scope_semantics`
+
 > Represents the GL_KHR_memory_scope_semantics extension.
 
 `GL_KHR_shader_subgroup_arithmetic`
+
 > Represents the GL_KHR_shader_subgroup_arithmetic extension.
 
 `GL_KHR_shader_subgroup_ballot`
+
 > Represents the GL_KHR_shader_subgroup_ballot extension.
 
 `GL_KHR_shader_subgroup_basic`
+
 > Represents the GL_KHR_shader_subgroup_basic extension.
 
 `GL_KHR_shader_subgroup_clustered`
+
 > Represents the GL_KHR_shader_subgroup_clustered extension.
 
 `GL_KHR_shader_subgroup_quad`
+
 > Represents the GL_KHR_shader_subgroup_quad extension.
 
 `GL_KHR_shader_subgroup_rotate`
+
 > Represents the GL_KHR_shader_subgroup_rotate extension.
 
 `GL_KHR_shader_subgroup_shuffle`
+
 > Represents the GL_KHR_shader_subgroup_shuffle extension.
 
 `GL_KHR_shader_subgroup_shuffle_relative`
+
 > Represents the GL_KHR_shader_subgroup_shuffle_relative extension.
 
 `GL_KHR_shader_subgroup_vote`
+
 > Represents the GL_KHR_shader_subgroup_vote extension.
 
 `GL_NV_cluster_acceleration_structure`
+
 > Represents the GL_NV_cluster_acceleration_structure extension.
 
 `GL_NV_compute_shader_derivatives`
+
 > Represents the GL_NV_compute_shader_derivatives extension.
-> 
+>
 > This capability enables the use of implicit derivatives in compute, ray tracing, and mesh stages.
-> 
+>
 > This capability changes the interpretation of GLSL implicit-LOD texture sampling functions as follows, matching
 > the GLSL shader specification:
+>
 > - Derivatives enabled: Implicit-LOD `texture()` functions are assumed to use implicit LOD.
 > - Derivatives disabled: Implicit-LOD `texture()` functions are assumed to use the base texture.
-> 
+>
 > This applies to GLSL as both source and target.
 
 `GL_NV_cooperative_vector`
+
 > Represents the GL_NV_cooperative_vector extension.
 
 `GL_NV_fragment_shader_barycentric`
+
 > Represents the GL_NV_fragment_shader_barycentric extension.
 
 `GL_NV_gpu_shader5`
+
 > Represents the GL_NV_gpu_shader5 extension.
 
 `GL_NV_ray_tracing`
+
 > Represents the GL_NV_ray_tracing extension.
 
 `GL_NV_ray_tracing_motion_blur`
+
 > Represents the GL_NV_ray_tracing_motion_blur extension.
 
 `GL_NV_shader_atomic_fp16_vector`
+
 > Represents the GL_NV_shader_atomic_fp16_vector extension.
 
 `GL_NV_shader_invocation_reorder`
+
 > Represents the GL_NV_shader_invocation_reorder extension (NVIDIA-specific).
 
 `GL_NV_shader_invocation_reorder_motion`
+
 > Represents the GL_NV_shader_invocation_reorder + motion blur combined extension (NVIDIA-specific).
 > Used for motion blur variants of SER functions that require both extensions.
 
 `GL_NV_shader_subgroup_partitioned`
+
 > Represents the GL_NV_shader_subgroup_partitioned extension.
 
 `GL_NV_shader_texture_footprint`
+
 > Represents the GL_NV_shader_texture_footprint extension.
 
 `SPV_EXT_demote_to_helper_invocation`
+
 > Represents the SPIR-V extension for demoting to helper invocation.
 
 `SPV_EXT_descriptor_heap`
+
 > Represents the SPIR-V extension for descriptor heaps.
 
 `SPV_EXT_descriptor_indexing`
+
 > Represents the SPIR-V extension for descriptor indexing.
 
 `SPV_EXT_float8`
+
 > Represents the SPIR-V extension for SPV_EXT_float8.
 
 `SPV_EXT_fragment_fully_covered`
+
 > Represents the SPIR-V extension for SPV_EXT_fragment_fully_covered.
 
 `SPV_EXT_fragment_shader_interlock`
+
 > Represents the SPIR-V extension for fragment shader interlock operations.
 
 `SPV_EXT_mesh_shader`
+
 > Represents the SPIR-V extension for mesh shaders.
 
 `SPV_EXT_physical_storage_buffer`
+
 > Represents the SPIR-V extension for physical storage buffer.
 
 `SPV_EXT_replicated_composites`
+
 > Represents the SPIR-V extension for SPV_EXT_replicated_composites.
 
 `SPV_EXT_shader_atomic_float16_add`
+
 > Represents the SPIR-V extension for atomic float16 add operations.
 
 `SPV_EXT_shader_atomic_float_add`
+
 > Represents the SPIR-V extension for atomic float add operations.
 
 `SPV_EXT_shader_atomic_float_min_max`
+
 > Represents the SPIR-V extension for atomic float min/max operations.
 
 `SPV_EXT_shader_invocation_reorder`
+
 > Represents the SPIR-V extension for shader invocation reorder (cross-vendor standard).
 > Requires SPV_KHR_ray_tracing and SPIR-V 1.5 (which includes physical storage buffer).
 > Note: Spec allows SPIR-V 1.4 + physical_storage_buffer extension, but we require 1.5 for simplicity.
 
 `SPV_GOOGLE_user_type`
+
 > Represents the SPIR-V extension for SPV_GOOGLE_user_type.
 
 `SPV_KHR_abort`
+
 > Represents the SPIR-V extension for shader abort (SPV_KHR_abort).
 
 `SPV_KHR_bfloat16`
+
 > Represents the SPIR-V extension for BFloat16 types.
 
 `SPV_KHR_compute_shader_derivatives`
+
 > Represents the SPIR-V extension for compute shader derivatives.
 
 `SPV_KHR_cooperative_matrix`
+
 > Represents the SPIR-V extension for SPV_KHR_cooperative_matrix.
 
 `SPV_KHR_device_group`
+
 > Represents the SPIR-V extension for device-group information.
 
 `SPV_KHR_fragment_shader_barycentric`
+
 > Represents the SPIR-V extension for fragment shader barycentric.
 
 `SPV_KHR_maximal_reconvergence`
+
 > Represents the SPIR-V extension for maximal reconvergence.
 
 `SPV_KHR_non_semantic_info`
+
 > Represents the SPIR-V extension for non-semantic information.
 
 `SPV_KHR_quad_control`
+
 > Represents the SPIR-V extension for quad group control.
 
 `SPV_KHR_ray_query`
+
 > Represents the SPIR-V extension for ray queries.
 
 `SPV_KHR_ray_tracing`
+
 > Represents the SPIR-V extension for ray tracing.
 
 `SPV_KHR_ray_tracing_position_fetch`
+
 > Represents the SPIR-V extension for ray tracing position fetch.
 > Should be used with either SPV_KHR_ray_query or SPV_KHR_ray_tracing.
 
 `SPV_KHR_shader_clock`
+
 > Represents the SPIR-V extension for shader clock.
 
 `SPV_KHR_subgroup_rotate`
+
 > Represents the SPIR-V extension enables rotating values across invocations within a subgroup.
 
 `SPV_KHR_untyped_pointers`
+
 > Represents the SPIR-V extension for untyped pointers.
 
 `SPV_KHR_vulkan_memory_model`
+
 > Represents the SPIR-V extension for SPV_KHR_vulkan_memory_model.
 
 `SPV_NV_bindless_texture`
+
 > Represents the SPIR-V extension for SPV_NV_bindless_texture.
 
 `SPV_NV_cluster_acceleration_structure`
+
 > Represents the SPIR-V extension for cluster acceleration structure.
 
 `SPV_NV_compute_shader_derivatives`
+
 > Represents the SPIR-V extension for compute shader derivatives.
 
 `SPV_NV_cooperative_matrix2`
+
 > Represents the SPIR-V extension for SPV_NV_cooperative_matrix2.
 
 `SPV_NV_cooperative_vector`
+
 > Represents the SPIR-V extension for SPV_NV_cooperative_vector.
 
 `SPV_NV_linear_swept_spheres`
+
 > Represents the SPIR-V extension for linear swept spheres.
 
 `SPV_NV_ray_tracing_motion_blur`
+
 > Represents the SPIR-V extension for ray tracing motion blur.
 
 `SPV_NV_shader_image_footprint`
+
 > Represents the SPIR-V extension for shader image footprint.
 
 `SPV_NV_shader_invocation_reorder`
+
 > Represents the SPIR-V extension for shader invocation reorder (NVIDIA-specific).
 > Inherits from SPV_EXT_shader_invocation_reorder so NV implies EXT.
 
 `SPV_NV_shader_subgroup_partitioned`
+
 > Represents the SPIR-V extension for shader subgroup partitioned.
 
 `SPV_NV_tensor_addressing`
+
 > Represents the SPIR-V extension for SPV_NV_tensor_addressing.
 
 `ser_hlsl_native`
+
 > DXR 1.3 native SER support (SM 6.9, no NVAPI required)
 
 `spvAbort`
+
 > Represents the SPIR-V AbortKHR capability for OpAbortKHR.
 
 `spvAtomicFloat16AddEXT`
+
 > Represents the SPIR-V capability for atomic float 16 add operations.
 
 `spvAtomicFloat16MinMaxEXT`
+
 > Represents the SPIR-V capability for atomic float 16 min/max operations.
 
 `spvAtomicFloat32AddEXT`
+
 > Represents the SPIR-V capability for atomic float 32 add operations.
 
 `spvAtomicFloat32MinMaxEXT`
+
 > Represents the SPIR-V capability for atomic float 32 min/max operations.
 
 `spvAtomicFloat64AddEXT`
+
 > Represents the SPIR-V capability for atomic float 64 add operations.
 
 `spvAtomicFloat64MinMaxEXT`
+
 > Represents the SPIR-V capability for atomic float 64 min/max operations.
 
 `spvBFloat16KHR`
+
 > Represents the SPIR-V capability for using bf16 floating point type.
 
 `spvBindlessTextureNV`
+
 > Represents the SPIR-V capability for the bindless texture.
 
 `spvCooperativeMatrixBlockLoadsNV`
+
 > Represents the SPIR-V capability for cooperative matrix 2
 
 `spvCooperativeMatrixConversionsNV`
+
 > Represents the SPIR-V capability for cooperative matrix 2
 
 `spvCooperativeMatrixKHR`
+
 > Represents the SPIR-V capability for cooperative matrices
 
 `spvCooperativeMatrixPerElementOperationsNV`
+
 > Represents the SPIR-V capability for cooperative matrix 2
 
 `spvCooperativeMatrixReductionsNV`
+
 > Represents the SPIR-V capability for cooperative matrix 2
 
 `spvCooperativeMatrixTensorAddressingNV`
+
 > Represents the SPIR-V capability for cooperative matrix 2
 
 `spvCooperativeVectorNV`
+
 > Represents the SPIR-V capability for cooperative vectors
 
 `spvCooperativeVectorTrainingNV`
+
 > Represents the SPIR-V capability for cooperative vector training
 
 `spvDemoteToHelperInvocation`
+
 > Represents the SPIR-V capability for demoting to helper invocation.
 
 `spvDemoteToHelperInvocationEXT`
+
 > Represents the SPIR-V capability for demoting to helper invocation.
 
 `spvDerivativeControl`
+
 > Represents the SPIR-V capability for 'derivative control' operations.
 
 `spvDescriptorHeapEXT`
+
 > Represents the SPIR-V capability for descriptor heaps.
 
 `spvDeviceGroup`
+
 > Represents the SPIR-V capability for DeviceGroup.
 
 `spvFloat8EXT`
+
 > Represents the SPIR-V capability for using 8-bit floating point types.
 
 `spvFragmentBarycentricKHR`
+
 > Represents the SPIR-V capability for using SPV_KHR_fragment_shader_barycentric.
 
 `spvFragmentFullyCoveredEXT`
+
 > Represents the SPIR-V capability for using SPV_EXT_fragment_fully_covered functionality.
 
 `spvFragmentShaderPixelInterlockEXT`
+
 > Represents the SPIR-V capability for using SPV_EXT_fragment_shader_interlock.
 
 `spvGroupNonUniform`
+
 > Represents the SPIR-V GroupNonUniform capability (basic subgroup operations).
 
 `spvGroupNonUniformArithmetic`
+
 > Represents the SPIR-V capability for group non-uniform arithmetic operations.
 
 `spvGroupNonUniformBallot`
+
 > Represents the SPIR-V capability for group non-uniform ballot operations.
 
 `spvGroupNonUniformClustered`
+
 > Represents the SPIR-V capability for group non-uniform clustered operations.
 
 `spvGroupNonUniformPartitionedNV`
+
 > Represents the SPIR-V capability for group non-uniform partitioned operations.
 
 `spvGroupNonUniformQuad`
+
 > Represents the SPIR-V capability for group non-uniform quad operations.
 
 `spvGroupNonUniformRotateKHR`
+
 > Represents the SPIR-V capability for group non-uniform rotate operations.
 
 `spvGroupNonUniformShuffle`
+
 > Represents the SPIR-V capability for group non-uniform shuffle operations.
 
 `spvGroupNonUniformShuffleRelative`
+
 > Represents the SPIR-V capability for group non-uniform shuffle relative operations.
 
 `spvGroupNonUniformVote`
+
 > Represents the SPIR-V capability for group non-uniform vote operations.
 
 `spvImageFootprintNV`
+
 > Represents the SPIR-V capability for image footprint.
 
 `spvImageGatherExtended`
+
 > Represents the SPIR-V capability for extended image gather operations.
 
 `spvImageQuery`
+
 > Represents the SPIR-V capability for image query operations.
 
 `spvInt64Atomics`
+
 > Represents the SPIR-V capability for 64-bit integer atomics.
 
 `spvMaximalReconvergenceKHR`
+
 > Represents the SPIR-V capability for maximal reconvergence.
 
 `spvMeshShadingEXT`
+
 > Represents the SPIR-V capability for mesh shading.
 
 `spvMinLod`
+
 > Represents the SPIR-V capability for using minimum LOD operations.
 
 `spvQuadControlKHR`
+
 > Represents the SPIR-V capability for quad group control.
 
 `spvRayQueryKHR`
+
 > Represents the SPIR-V capability for ray query.
 
 `spvRayQueryPositionFetchKHR`
+
 > Represents the SPIR-V capability for ray query position fetch.
 
 `spvRayTracingClusterAccelerationStructureNV`
+
 > Represents the SPIR-V capability for cluster acceleration structure.
 
 `spvRayTracingKHR`
+
 > Represents the SPIR-V capability for ray tracing.
 
 `spvRayTracingLinearSweptSpheresGeometryNV`
+
 > Represents the SPIR-V capability for linear swept spheres.
 
 `spvRayTracingMotionBlurNV`
+
 > Represents the SPIR-V capability for ray tracing motion blur.
 
 `spvRayTracingPositionFetchKHR`
+
 > Represents the SPIR-V capability for ray tracing position fetch.
 
 `spvReplicatedCompositesEXT`
+
 > Represents the SPIR-V capability for replicated composites
 
 `spvShaderClockKHR`
+
 > Represents the SPIR-V capability for shader clock.
 
 `spvShaderInvocationReorderEXT`
+
 > Represents the SPIR-V capability for shader invocation reorder (cross-vendor standard).
 
 `spvShaderInvocationReorderMotionEXT`
+
 > Represents the SPIR-V capability for shader invocation reorder EXT + motion blur (cross-vendor SER with NV motion blur).
 > Used for motion blur variants of EXT SER functions.
 
 `spvShaderInvocationReorderMotionNV`
+
 > Represents the SPIR-V capability for shader invocation reorder + motion blur (NVIDIA-specific).
 > Used for motion blur variants of SER functions that require both extensions.
 
 `spvShaderInvocationReorderNV`
+
 > Represents the SPIR-V capability for shader invocation reorder (NVIDIA-specific).
 > Inherits from spvShaderInvocationReorderEXT so that NV implies EXT capability.
 
 `spvShaderNonUniform`
+
 > Represents the SPIR-V capability for non-uniform resource indexing.
 
 `spvShaderNonUniformEXT`
+
 > Represents the SPIR-V capability for non-uniform resource indexing.
 
 `spvSparseResidency`
+
 > Represents the SPIR-V capability for sparse residency.
 
 `spvTensorAddressingNV`
+
 > Represents the SPIR-V capability for tensor addressing
 
 `spvVulkanMemoryModelDeviceScopeKHR`
+
 > Represents the SPIR-V capability for vulkan memory model.
 
 `spvVulkanMemoryModelKHR`
+
 > Represents the SPIR-V capability for vulkan memory model.
 
-Compound Capabilities
-----------------------
-*Capabilities to specify capabilities created by other capabilities (`raytracing`, `meshshading`...)*
+## Compound Capabilities
+
+_Capabilities to specify capabilities created by other capabilities (`raytracing`, `meshshading`...)_
 
 `abort`
+
 > Capabilities required to use 'abort'
 
 `amplification_mesh`
+
 > Collection of shader stages
 
 `any_cpp_target`
+
 > All "cpp syntax" code-gen targets
 
 `any_gfx_target`
+
 > All slang-gfx compatible code-gen targets
 
 `any_stage`
+
 > Collection of all shader stages
 
 `any_target`
+
 > All code-gen targets
 
 `any_textual_target`
+
 > All non-asm code-gen targets
 
 `anyhit_closesthit`
+
 > Collection of shader stages
 
 `anyhit_closesthit_intersection`
+
 > Collection of shader stages
 
 `anyhit_closesthit_intersection_miss`
+
 > Collection of shader stages
 
 `anyhit_intersection`
+
 > Collection of shader stages (for OptiX ObjectRayOrigin/Direction which excludes closesthit)
 
 `appendstructuredbuffer`
+
 > Capabilities required to use AppendStructuredBuffer
 
 `atomic64`
+
 > Capabilities needed for int64/uint64 atomic operations
 
 `atomic_bfloat16`
+
 > Atomic operations on BFloat16 types. Requires SM 9.0 (Hopper) or higher on CUDA.
 
 `atomic_glsl`
+
 > (GLSL/SPIRV) Capabilities required to use GLSL-400 atomic operations
 
 `atomic_glsl_float1`
+
 > (GLSL/SPIRV) Capabilities required to use GLSL-tier-1 float-atomic operations
 
 `atomic_glsl_float2`
+
 > (GLSL/SPIRV) Capabilities required to use GLSL-tier-2 float-atomic operations
 
 `atomic_glsl_halfvec`
+
 > (GLSL/SPIRV) Capabilities required to use NVAPI GLSL-fp16 float-atomic operations
 
 `atomic_glsl_hlsl_cuda9_int64`
+
 > (All implemented targets) Capabilities required to use atomic operations (cuda_sm_9 tier atomics)
 
 `atomic_glsl_hlsl_cuda_metal`
+
 > (All implemented targets) Capabilities required to use atomic operations
 
 `atomic_glsl_hlsl_nvapi_cuda5_int64`
+
 > (All implemented targets) Capabilities required to use atomic operations of int64 (cuda_sm_5 tier atomics)
 
 `atomic_glsl_hlsl_nvapi_cuda6_int64`
+
 > (All implemented targets) Capabilities required to use atomic operations of int64 (cuda_sm_6 tier atomics)
 
 `atomic_glsl_hlsl_nvapi_cuda9_int64`
+
 > (All implemented targets) Capabilities required to use atomic operations of int64 (cuda_sm_9 tier atomics)
 
 `atomic_glsl_hlsl_nvapi_cuda_metal_float1`
+
 > (All implemented targets) Capabilities required to use atomic operations of GLSL tier-1 float atomics
 
 `atomic_glsl_int64`
+
 > (GLSL/SPIRV) Capabilities required to use int64/uint64 atomic operations
 
 `atomic_hlsl`
+
 > (hlsl only) Capabilities required to use hlsl atomic operations
 
 `atomic_hlsl_nvapi`
+
 > (hlsl only) Capabilities required to use hlsl NVAPI atomics
 
 `atomic_hlsl_sm_6_6`
+
 > (hlsl only) Capabilities required to use hlsl sm_6_6 atomics
 
 `atomic_reduce`
+
 > Atomic reduction operations using PTX `red` instruction. Requires SM 7.0 on CUDA.
 > On non-CUDA targets, falls back to regular atomic operations with no additional requirement.
 
 `atomicfloat`
+
 > Capabilities needed to use GLSL-tier-1 float-atomic operations
 
 `atomicfloat2`
+
 > Capabilities needed to use GLSL-tier-2 float-atomic operations
 
 `breakpoint`
+
 > Capabilities required to enable shader breakpoints
 
 `bufferreference`
+
 > Capabilities needed to use GLSL buffer-reference's
 
 `bufferreference_int64`
+
 > Capabilities needed to use GLSL buffer-reference's with int64
 
 `byteaddressbuffer`
+
 > Capabilities required to use ByteAddressBuffer
 
 `byteaddressbuffer_rw`
+
 > Capabilities required to use RWByteAddressBuffer
 
 `compute_fragment`
+
 > Collection of shader stages
 
 `compute_fragment_geometry_vertex`
+
 > Collection of shader stages
 
 `compute_tesscontrol_tesseval`
+
 > Collection of shader stages
 
 `consumestructuredbuffer`
+
 > Capabilities required to use ConsumeStructuredBuffer
 
 `cooperative_matrix`
+
 > Capabilities needed to use cooperative matrices
 
 `cooperative_matrix_2`
+
 > Capabilities needed to use tensor addressing
 
 `cooperative_matrix_block_load`
+
 > Capabilities needed to use decodeFunc with cooperative matrix load
 
 `cooperative_matrix_conversion`
+
 > Capabilities needed to convert cooperative matrices, all the conversions can be supported by cuda
 
 `cooperative_matrix_map_element`
+
 > Capabilities needed to use MapElement operation with cooperative matrix
 
 `cooperative_matrix_reduction`
+
 > Capabilities needed to use reduction operations with cooperative matrix
 
 `cooperative_matrix_spirv`
+
 > Capabilities needed to use reduction operations with cooperative matrix
 
 `cooperative_matrix_tensor_addressing`
+
 > Capabilities needed to load or store with tensor_addressing extension
 
 `cooperative_vector`
+
 > Capabilities needed to use cooperative vectors
 > Note that cpp and cuda are supported via a fallback non-cooperative implementation
 > No HLSL shader model bound yet
 
 `cooperative_vector_training`
+
 > Capabilities needed to train cooperative vectors
 
 `cpp_cuda`
+
 > CPP and CUDA code-gen targets
 
 `cpp_cuda_glsl_hlsl`
+
 > CPP, CUDA, GLSL, and HLSL code-gen targets
 
 `cpp_cuda_glsl_hlsl_llvm`
+
 > CPP, CUDA, GLSL, HLSL, and LLVM code-gen targets
 
 `cpp_cuda_glsl_hlsl_metal_spirv`
+
 > CPP, CUDA, GLSL, HLSL, Metal and SPIRV code-gen targets
 
 `cpp_cuda_glsl_hlsl_metal_spirv_llvm`
+
 > CPP, CUDA, GLSL, HLSL, Metal, SPIRV, and LLVM code-gen targets
 
 `cpp_cuda_glsl_hlsl_metal_spirv_wgsl`
+
 > CPP, CUDA, GLSL, HLSL, Metal, SPIRV and WGSL code-gen targets
 
 `cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm`
+
 > CPP, CUDA, GLSL, HLSL, Metal, SPIRV, WGSL and LLVM code-gen targets
 
 `cpp_cuda_glsl_hlsl_spirv`
+
 > CPP, CUDA, GLSL, HLSL, and SPIRV code-gen targets
 
 `cpp_cuda_glsl_hlsl_spirv_llvm`
+
 > CPP, CUDA, GLSL, HLSL, SPIRV, and LLVM code-gen targets
 
 `cpp_cuda_glsl_hlsl_spirv_wgsl`
+
 > CPP, CUDA, GLSL, HLSL, SPIRV and WGSL code-gen targets
 
 `cpp_cuda_glsl_hlsl_spirv_wgsl_llvm`
+
 > CPP, CUDA, GLSL, HLSL, SPIRV, WGSL and LLVM code-gen targets
 
 `cpp_cuda_glsl_spirv`
+
 > CPP, CUDA, GLSL and SPIRV code-gen targets
 
 `cpp_cuda_hlsl`
+
 > CPP, CUDA, and HLSL code-gen targets
 
 `cpp_cuda_hlsl_metal_spirv`
+
 > CPP, CUDA, HLSL, Metal, and SPIRV code-gen targets
 
 `cpp_cuda_hlsl_spirv`
+
 > CPP, CUDA, HLSL, and SPIRV code-gen targets
 
 `cpp_cuda_llvm`
+
 > CPP, CUDA and LLVM code-gen targets
 
 `cpp_cuda_metal_spirv`
+
 > CPP, CUDA, Metal, and SPIRV code-gen targets
 
 `cpp_cuda_metal_spirv_llvm`
+
 > CPP, CUDA, Metal, SPIRV, and LLVM code-gen targets
 
 `cpp_cuda_spirv`
+
 > CPP, CUDA and SPIRV code-gen targets
 
 `cpp_cuda_spirv_llvm`
+
 > CPP, CUDA, SPIRV and LLVM code-gen targets
 
 `cpp_glsl`
+
 > CPP, and GLSL code-gen targets
 
 `cpp_glsl_hlsl_metal_spirv`
+
 > CPP, GLSL, HLSL, Metal, and SPIRV code-gen targets
 
 `cpp_glsl_hlsl_metal_spirv_wgsl`
+
 > CPP, GLSL, HLSL, Metal, SPIRV and WGSL code-gen targets
 
 `cpp_glsl_hlsl_spirv`
+
 > CPP, GLSL, HLSL, and SPIRV code-gen targets
 
 `cpp_glsl_hlsl_spirv_wgsl`
+
 > CPP, GLSL, HLSL, SPIRV and WGSL code-gen targets
 
 `cpp_hlsl`
+
 > CPP, and HLSL code-gen targets
 
 `cpp_llvm`
+
 > CPP and LLVM code-gen targets
 
 `cuda_glsl_hlsl`
+
 > CUDA, GLSL, and HLSL code-gen targets
 
 `cuda_glsl_hlsl_metal_spirv`
+
 > CUDA, GLSL, HLSL, Metal, and SPIRV code-gen targets
 
 `cuda_glsl_hlsl_metal_spirv_wgsl`
+
 > CUDA, GLSL, HLSL, Metal, SPIRV and WGSL code-gen targets
 
 `cuda_glsl_hlsl_spirv`
+
 > CUDA, GLSL, HLSL, and SPIRV code-gen targets
 
 `cuda_glsl_hlsl_spirv_llvm`
+
 > CUDA, GLSL, HLSL, SPIRV, and LLVM code-gen targets
 
 `cuda_glsl_hlsl_spirv_wgsl`
+
 > CUDA, GLSL, HLSL, SPIRV, and WGSL code-gen targets
 
 `cuda_glsl_metal_spirv`
+
 > CUDA, GLSL, Metal, and SPIRV code-gen targets
 
 `cuda_glsl_metal_spirv_wgsl`
+
 > CUDA, GLSL, Metal, SPIRV and WGSL code-gen targets
 
 `cuda_glsl_metal_spirv_wgsl_llvm`
+
 > CUDA, GLSL, Metal, SPIRV, WGSL and LLVM code-gen targets
 
 `cuda_glsl_nvapi`
+
 > CUDA, GLSL, and NVAPI code-gen targets
 
 `cuda_glsl_spirv`
+
 > CUDA, GLSL, and SPIRV code-gen targets
 
 `cuda_hlsl`
+
 > CUDA, and HLSL code-gen targets
 
 `cuda_hlsl_metal_spirv`
+
 > CUDA, HLSL, Metal, and SPIRV code-gen targets
 
 `cuda_hlsl_spirv`
+
 > CUDA, HLSL, SPIRV code-gen targets
 
 `cuda_metal_spirv`
+
 > CUDA, Metal and SPIRV code-gen targets
 
 `cuda_spirv`
+
 > CUDA and SPIRV code-gen targets
 
 `descriptor_handle`
+
 > Targets that support DescriptorHandle types for bindless descriptor access.
 
 `domain_hull`
+
 > Collection of shader stages
 
 `fragmentprocessing`
+
 > Capabilities required to use fragment derivative operations (without GLSL derivativecontrol)
 
 `fragmentprocessing_derivativecontrol`
+
 > Capabilities required to use fragment derivative operations (with GLSL derivativecontrol)
 
 `fragmentshaderbarycentric`
+
 > Capabilities needed to use fragment-shader-barycentric's
 
 `fragmentshaderinterlock`
+
 > Capabilities needed for interlocked-fragment operations
 
 `getattributeatvertex`
+
 > Capabilities required to use 'getAttributeAtVertex'
 
 `glsl_hlsl_metal_spirv`
+
 > GLSL, HLSL, Metal, and SPIRV code-gen targets
 
 `glsl_hlsl_metal_spirv_wgsl`
+
 > GLSL, HLSL, Metal, SPIRV and WGSL code-gen targets
 
 `glsl_hlsl_spirv`
+
 > GLSL, HLSL, and SPIRV code-gen targets
 
 `glsl_hlsl_spirv_wgsl`
+
 > GLSL, HLSL, SPIRV and WGSL code-gen targets
 
 `glsl_metal_spirv`
+
 > GLSL, Metal, and SPIRV code-gen targets
 
 `glsl_metal_spirv_wgsl`
+
 > GLSL, Metal, SPIRV and WGSL code-gen targets
 
 `glsl_spirv`
+
 > GLSL, and SPIRV code-gen targets
 
 `glsl_spirv_wgsl`
+
 > GLSL, SPIRV, and WGSL code-gen targets
 
 `helper_lane`
+
 > Capabilities required to enable helper-lane demotion
 
 `hlsl_spirv`
+
 > HLSL, and SPIRV code-gen targets
 
 `image_loadstore`
+
 > (GLSL/SPIRV) Capabilities required to use image load/image store operations
 
 `image_samples`
+
 > Capabilities required to query image (RWTexture) sample info
 
 `image_size`
+
 > Capabilities required to query image (RWTexture) size info
 
 `implicit_derivatives_sampling`
+
 > Capabilities required for implicit derivatives sampling.
-> 
+>
 > This capability is required by texture sampling functions such as `_Texture.Sample()`
 > where the level of detail is determined by implicit derivatives.
-> 
+>
 > @remark In GLSL, implicit level-of-detail `texture()` functions use the base texture when
 > the implicit derivatives are unavailable. When this capability is not present, invocations of
 > these functions are translated to invocations of `_Texture.SampleLevelZero()`.
-> 
+>
 > @remark Implicit derivatives for the compute stage can be enabled by declaring capability `GL_NV_compute_shader_derivatives` (GLSL),
 > `SPV_KHR_compute_shader_derivatives` (SPIR-V), or profile `cs_6_6` (HLSL).
-> 
 
 `mem_model`
+
 > Capabilities needed to use memory model
 
 `memorybarrier`
+
 > Capabilities required to use sm_5_0 style memory barriers
 
 `meshshading`
+
 > Ccapabilities required to use mesh shading features
 
 `motionblur_nv`
+
 > Capabilities needed for raytracing-motionblur (NVIDIA-specific)
 
 `nonuniformqualifier`
+
 > Capabilities required to use NonUniform qualifier
 
 `nvapi`
+
 > NVAPI capability for HLSL
 
 `pack_vector`
+
 > Capabilities required to use pack/unpack intrinsics on packed vector data
 
 `printf`
+
 > Capabilities required to use 'printf'
 
 `quad_control`
+
 > Capabilities required to enable quad group control
 
 `raygen_closesthit_miss`
+
 > Collection of shader stages
 
 `raygen_closesthit_miss_callable`
+
 > Collection of shader stages
 
 `rayquery`
+
 > Capabilities needed for compute-shader rayquery
 
 `rayquery_position`
+
 > Collection of capabilities for rayquery + ray_tracing_position_fetch.
 
 `raytracing`
+
 > Capabilities needed for minimal raytracing support
 
 `raytracing_allstages`
+
 > Collection of capabilities for raytracing with all raytracing stages.
 
 `raytracing_anyhit`
+
 > Collection of capabilities for raytracing with the shader stage of anyhit.
 
 `raytracing_anyhit_closesthit`
+
 > Collection of capabilities for raytracing with the shader stages of anyhit and closesthit.
 
 `raytracing_anyhit_closesthit_intersection`
+
 > Collection of capabilities for raytracing with the shader stages of anyhit, closesthit, and intersection.
 
 `raytracing_anyhit_closesthit_intersection_miss`
+
 > Collection of capabilities for raytracing with the shader stages of anyhit, closesthit, intersection, and miss.
 
 `raytracing_intersection`
+
 > Collection of capabilities for raytracing with the shader stage of intersection.
 
 `raytracing_lss`
+
 > Collection of capabilities for linear swept spheres.
 
 `raytracing_lss_ho`
+
 > hit object APIs allow raygen shaders, but not the non-hit object APIs. So we have this special
 > capdef specifically for the hitobject variant.
 > Collection of capabilities for linear swept spheres.
 
 `raytracing_motionblur`
+
 > Capabilities needed for compute-shader rayquery and motion-blur
 
 `raytracing_motionblur_anyhit_closesthit_intersection_miss`
+
 > Collection of capabilities for raytracing + motion blur and the shader stages of anyhit, closesthit, intersection, and miss.
 
 `raytracing_motionblur_raygen_closesthit_miss`
+
 > Collection of capabilities for raytracing + motion blur and the shader stages of raygen, closesthit, and miss.
 
 `raytracing_object_space_ray`
+
 > Collection of capabilities for ObjectRayOrigin/ObjectRayDirection.
 > CUDA/OptiX only supports anyhit and intersection stages, while other targets also support closesthit.
 
 `raytracing_position`
+
 > Collection of capabilities for raytracing + ray_tracing_position_fetch and the shader stages of anyhit and closesthit.
 
 `raytracing_raygen_closesthit_miss`
+
 > Collection of capabilities for raytracing with the shader stages of raygen, closesthit, and miss.
 
 `raytracing_raygen_closesthit_miss_callable`
+
 > Collection of capabilities for raytracing the shader stages of raygen, closesthit, miss, and callable.
 
 `raytracing_stages`
+
 > Collection of shader stages
 
 `raytracingstages_compute`
+
 > Collection of shader stages
 
 `raytracingstages_compute_amplification_mesh`
+
 > Collection of shader stages
 
 `raytracingstages_compute_fragment`
+
 > Collection of shader stages
 
 `raytracingstages_compute_fragment_geometry_vertex`
+
 > Collection of shader stages
 
 `raytracingstages_fragment`
+
 > Collection of shader stages
 
 `ser`
+
 > Capabilities needed for shader-execution-reordering (all paths)
 > Defaults SPIR-V/GLSL to the cross-vendor standard EXT path; explicit NV still satisfies this
 > through the NV-to-EXT capability hierarchy. Use ser_nv for APIs that require NV opcodes.
 
 `ser_any_closesthit_intersection_miss`
+
 > Collection of capabilities for raytracing + shader execution reordering and the shader stages of anyhit, closesthit, intersection, and miss.
 
 `ser_anyhit_closesthit`
+
 > Collection of capabilities for raytracing + shader execution reordering and the shader stages of anyhit and closesthit.
 
 `ser_anyhit_closesthit_intersection`
+
 > Collection of capabilities for raytracing + shader execution reordering and the shader stages of anyhit, closesthit, and intersection.
 
 `ser_dxr`
+
 > Capabilities needed for shader-execution-reordering (native DXR 1.3 path)
 
 `ser_dxr_raygen`
+
 > Collection of capabilities for DXR 1.3 native SER (HLSL only) with raygen stage.
 
 `ser_dxr_raygen_closesthit_miss`
+
 > Collection of capabilities for DXR 1.3 native SER (HLSL only) with raygen, closesthit, miss stages.
 
 `ser_motion`
+
 > Capabilities needed for shader-execution-reordering and motion-blur
 
 `ser_motion_raygen`
+
 > Collection of capabilities for raytracing raytracing + motion blur + shader execution reordering and the shader stage of raygen.
 
 `ser_motion_raygen_closesthit_miss`
+
 > Collection of capabilities for raytracing + motion blur + shader execution reordering and the shader stages of raygen, closesthit, and miss.
 
 `ser_nv`
+
 > NVIDIA-specific SER capabilities (excludes cross-vendor EXT)
 > Includes GL_NV_shader_invocation_reorder (GLSL/SPIRV) and CUDA paths
 
 `ser_nv_motion`
+
 > NVIDIA-specific SER + motion blur
 
 `ser_nv_motion_raygen_closesthit_miss`
+
 > NVIDIA-specific SER + motion blur for raygen, closesthit, miss stages
 
 `ser_nv_raygen`
+
 > NVIDIA-specific SER for raygen stage (GLSL/SPIRV NV paths)
 
 `ser_nv_raygen_closesthit_miss`
+
 > NVIDIA-specific SER for raygen, closesthit, miss stages (GLSL/SPIRV NV paths)
 
 `ser_nvapi`
+
 > Capabilities needed for shader-execution-reordering (NVAPI path for HLSL)
 
 `ser_raygen`
+
 > Collection of capabilities for raytracing + shader execution reordering and the shader stage of raygen.
 
 `ser_raygen_closesthit_miss`
+
 > Collection of capabilities for raytracing + shader execution reordering and the shader stages of raygen, closesthit, and miss.
 
 `shader5_sm_4_0`
+
 > Capabilities required to use sm_4_0 features apart of GL_ARB_gpu_shader5
 
 `shader5_sm_5_0`
+
 > Capabilities required to use sm_5_0 features apart of GL_ARB_gpu_shader5
 
 `shaderclock`
+
 > Capabilities needed for realtime clocks
 
 `shaderinvocationgroup`
+
 > Capabilities required to use GLSL-style subgroup operations 'subgroup_vote'
 
 `shadermemorycontrol`
+
 > (gfx targets) Capabilities needed to use memory barriers
 
 `shadermemorycontrol_compute`
+
 > (gfx targets) Capabilities required to use memory barriers that only work for raytracing & compute shader stages
 
 `structuredbuffer`
+
 > Capabilities required to use StructuredBuffer
 
 `structuredbuffer_rw`
+
 > Capabilities required to use RWStructuredBuffer
 
 `subgroup_arithmetic`
+
 > Capabilities required to use GLSL-style subgroup operations 'subgroup_arithmetic'
 
 `subgroup_ballot`
+
 > Capabilities required to use GLSL-style subgroup operations 'subgroup_ballot'
 
 `subgroup_ballot_activemask`
+
 > Capabilities required to use GLSL-style subgroup operations 'subgroup_ballot_activemask'
 
 `subgroup_basic`
+
 > Capabilities required to use GLSL-style subgroup operations 'subgroup_basic'
 
 `subgroup_basic_ballot`
+
 > Capabilities required to use GLSL-style subgroup operations 'subgroup_basic_ballot'
 
 `subgroup_clustered`
+
 > Capabilities required to use GLSL-style subgroup operations 'subgroup_clustered'
 
 `subgroup_partitioned`
+
 > Capabilities required to use GLSL-style subgroup operations 'subgroup_partitioned'
 
 `subgroup_quad`
+
 > Capabilities required to use GLSL-style subgroup operations 'subgroup_quad'
 
 `subgroup_rotate`
+
 > Capabilities required to use GLSL-style subgroup rotate operations 'subgroup_rotate'
 
 `subgroup_shuffle`
+
 > Capabilities required to use GLSL-style subgroup operations 'subgroup_shuffle'
 
 `subgroup_shufflerelative`
+
 > Capabilities required to use GLSL-style subgroup operations 'subgroup_shuffle_relative'
 
 `subgroup_vote`
+
 > Capabilities required to use GLSL-style subgroup operations 'subgroup_vote'
 
+`subgroup_workgroup_index`
+
+> Capabilities required to use the subgroup-within-workgroup queries
+> 'WaveGetWaveIndex' / 'WaveGetNumWaves'. These lower to GLSL
+> gl_SubgroupID / gl_NumSubgroups and SPIR-V BuiltIn SubgroupId /
+> NumSubgroups, which the GLSL and Vulkan SPIR-V environment specs
+> restrict to compute-class execution models (compute, mesh,
+> amplification/task); the restriction is encoded here so misuse is
+> caught by the capability system rather than producing invalid
+> GLSL / SPIR-V.
+
 `subpass`
+
 > Capabilities required to use Subpass-Input's
 
 `tensor_addressing`
+
 > Capabilities needed to use tensor addressing
 
 `texture_gather`
+
 > Capabilities required to use 'vertex/fragment/geometry shader only' texture gather operations
 
 `texture_querylevels`
+
 > Capabilities required to query texture level info
 
 `texture_querylod`
+
 > Capabilities required to query texture LOD info
 
 `texture_shadowgrad`
+
 > Capabilities required for shadow texture sampling with bias and gradients.
 > New in HLSL SM6.8 but existed in older GLSL and SPIRV targets.
 
 `texture_shadowlod`
+
 > Capabilities required for shadow texture LOD sampling on types
 > natively supported by GLSL 1.50 (sampler1DShadow, sampler1DArrayShadow,
 > sampler2DShadow).
 
 `texture_shadowlod_ext`
+
 > Capabilities required for shadow texture LOD sampling on types
 > that need GL_EXT_texture_shadow_lod (sampler2DArrayShadow, samplerCubeShadow,
 > samplerCubeArrayShadow).
 
 `texture_size`
+
 > Capabilities required to query texture sample info
 
 `texture_sm_4_0`
+
 > Capabilities required to use sm_4_0 texture operations
 
 `texture_sm_4_0_fragment`
+
 > Capabilities required to use 'fragment shader only' texture operations
 
 `texture_sm_4_1`
+
 > Capabilities required to use sm_4_1 texture operations
 
 `texture_sm_4_1_clamp_fragment`
+
 > Capabilities required to use 'fragment shader only' texture clamp operations
 
 `texture_sm_4_1_compute_fragment`
+
 > Capabilities required to use 'compute/fragment shader only' texture operations.
 > We do not require 'compute'/'fragment' shader capabilities since this seems to be incorrect behavior despite what official documentation says.
 
 `texture_sm_4_1_samplerless`
+
 > Capabilities required to use sm_4_1 samplerless texture operations
 
 `texture_sm_4_1_vertex_fragment_geometry`
+
 > Capabilities required to use 'fragment/geometry shader only' texture clamp operations
 
 `texturefootprint`
+
 > Capabilities required to use basic TextureFootprint operations
 
 `texturefootprintclamp`
+
 > Capabilities required to use TextureFootprint clamp operations
 
 `vk_mem_model`
+
 > Capabilities needed to use vulkan memory model
 
-Other
-----------------------
-*Capabilities which may be deprecated*
+## Other
+
+_Capabilities which may be deprecated_
 
 `DX_4_0`
+
 > Use `sm_4_0` instead
 
 `DX_4_1`
+
 > Use `sm_4_1` instead
 
 `DX_5_0`
+
 > Use `sm_5_0` instead
 
 `DX_5_1`
+
 > Use `sm_5_1` instead
 
 `DX_6_0`
+
 > Use `sm_6_0` instead
 
 `DX_6_1`
+
 > Use `sm_6_1` instead
 
 `DX_6_10`
+
 > Use `sm_6_10` instead
 
 `DX_6_2`
+
 > Use `sm_6_2` instead
 
 `DX_6_3`
+
 > Use `sm_6_3` instead
 
 `DX_6_4`
+
 > Use `sm_6_4` instead
 
 `DX_6_5`
+
 > Use `sm_6_5` instead
 
 `DX_6_6`
+
 > Use `sm_6_6` instead
 
 `DX_6_7`
+
 > Use `sm_6_7` instead
 
 `DX_6_8`
+
 > Use `sm_6_8` instead
 
 `DX_6_9`
+
 > Use `sm_6_9` instead
 
 `GLSL_410_SPIRV_1_0`
+
 > User should not use this capability
 
 `GLSL_420_SPIRV_1_0`
+
 > User should not use this capability
 
 `GLSL_430_SPIRV_1_0`
+
 > User should not use this capability
 
 `GLSL_430_SPIRV_1_0_compute`
+
 > User should not use this capability
 
 `METAL_2_3`
+
 > Use `metallib_2_3` instead
 
 `METAL_2_4`
+
 > Use `metallib_2_4` instead
 
 `METAL_3_0`
+
 > Use `metallib_3_0` instead
 
 `METAL_3_1`
+
 > Use `metallib_3_1` instead
 
 `METAL_4_0`
+
 > Use `metallib_4_0` instead
 
 `SPIRV_1_0`
+
 > Use `spirv_1_0` instead
 
 `SPIRV_1_1`
+
 > Use `spirv_1_1` instead
 
 `SPIRV_1_2`
+
 > Use `spirv_1_2` instead
 
 `SPIRV_1_3`
+
 > Use `spirv_1_3` instead
 
 `SPIRV_1_4`
+
 > Use `spirv_1_4` instead
 
 `SPIRV_1_5`
+
 > Use `spirv_1_5` instead
 
 `SPIRV_1_6`
+
 > Use `spirv_1_6` instead
 
 `SPV_KHR_variable_pointers`
+
 > Represents the SPIRV-V Variable Pointers extension.
 
 `all`
+
 > User should not use this capability
 
 `optix_coopvec`
+
 > Represents capabilities required for optix cooperative vector support.
 
 `optix_multilevel_traversal`
+
 > Represents capabilities required for optix multi-level traversal support.

--- a/docs/wave-intrinsics.md
+++ b/docs/wave-intrinsics.md
@@ -1,46 +1,42 @@
-
-Wave Intrinsics
-===============
+# Wave Intrinsics
 
 Slang has support for Wave intrinsics introduced to HLSL in [SM6.0](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/hlsl-shader-model-6-0-features-for-direct3d-12) and [SM6.5](https://github.com/microsoft/DirectX-Specs/blob/master/d3d/HLSL_ShaderModel6_5.md). All intrinsics are available on D3D12 and Vulkan.
 
-On GLSL targets such as Vulkan wave intrinsics map to ['subgroup' extension] (https://github.com/KhronosGroup/GLSL/blob/master/extensions/khr/GL_KHR_shader_subgroup.txt).  Vulkan supports a number of masked wave operations through `SPV_NV_shader_subgroup_partitioned` that are not supported by HLSL.
+On GLSL targets such as Vulkan wave intrinsics map to ['subgroup' extension] (https://github.com/KhronosGroup/GLSL/blob/master/extensions/khr/GL_KHR_shader_subgroup.txt). Vulkan supports a number of masked wave operations through `SPV_NV_shader_subgroup_partitioned` that are not supported by HLSL.
 
 There is no subgroup support for Matrix types, and currently this means that Matrix is not a supported type for Wave intrinsics on Vulkan, but may be in the future.
 
-
-Also introduced are some 'non standard' Wave intrinsics which are only available on Slang. All WaveMask intrinsics are non standard. Other non standard intrinsics expose more accurately different behaviours which are either not distinguished on HLSL, or perhaps currently unavailable. Two examples would be `WaveShuffle` and `WaveBroadcastLaneAt`. 
+Also introduced are some 'non standard' Wave intrinsics which are only available on Slang. All WaveMask intrinsics are non standard. Other non standard intrinsics expose more accurately different behaviours which are either not distinguished on HLSL, or perhaps currently unavailable. Two examples would be `WaveShuffle` and `WaveBroadcastLaneAt`.
 
 There are three styles of wave intrinsics...
 
 ## WaveActive
 
-The majority of 'regular' HLSL Wave intrinsics which operate on implicit 'active' lanes. 
+The majority of 'regular' HLSL Wave intrinsics which operate on implicit 'active' lanes.
 
 In the [DXC Wiki](https://github.com/Microsoft/DirectXShaderCompiler/wiki/Wave-Intrinsics) active lanes are described as
 
 > These intrinsics are dependent on active lanes and therefore flow control. In the model of this document, implementations
 > must enforce that the number of active lanes exactly corresponds to the programmer’s view of flow control.
- 
-In practice this appears to imply that the programming model is that all lanes operate in 'lock step'. That the 'active lanes' are the lanes doing processing at a particular point in the control flow. On some hardware this may match how processing actually works. There is also a large amount of hardware in the field that doesn't follow this model, and allows lanes to diverge and not necessarily on flow control. On this style of hardware Active intrinsics may act to also converge lanes to give the appearance of 'in step' ness. 
- 
+
+In practice this appears to imply that the programming model is that all lanes operate in 'lock step'. That the 'active lanes' are the lanes doing processing at a particular point in the control flow. On some hardware this may match how processing actually works. There is also a large amount of hardware in the field that doesn't follow this model, and allows lanes to diverge and not necessarily on flow control. On this style of hardware Active intrinsics may act to also converge lanes to give the appearance of 'in step' ness.
+
 ## WaveMask
 
 The WaveMask intrinsics take an explicit mask of lanes to operate on, in the same vein as CUDA. Requesting data from a from an inactive lane, can lead to undefined behavior, that includes locking up the shader. The WaveMask is an integer type that can hold the maximum amount of active lanes for this model - currently 32. In the future the WaveMask type may be made an opaque type, but can largely be operated on as if it is an integer.
 
 Using WaveMask intrinsics is generally more verbose and prone to error than the 'Active' style, but it does have a few advantages
 
-* It works across all supported targets - including CUDA (currently WaveActive intrinics do not)
-* Gives more fine control
-* Might allow for higher performance (for example it gives more control of divergence)
-* Maps most closely to CUDA
+- It works across all supported targets - including CUDA (currently WaveActive intrinics do not)
+- Gives more fine control
+- Might allow for higher performance (for example it gives more control of divergence)
+- Maps most closely to CUDA
 
 For this to work across targets including CUDA, the mask must be calculated such that it exactly matches that of HLSL defined 'active' lanes, else the behavior is undefined.
 
-On D3D12 and Vulkan the WaveMask intrinsics can be used, but the mask may be ignored depending on target's support for partitioned/masked wave intrinsics. SPIRV provides support for a wide variety of operations through the `SPV_NV_shader_subgroup_partitioned` extension while HLSL only provides a small subset of operations through `WaveMultiPrefix*` intrinsics. The difference between Slang's `WaveMask`  and these targets' partitioned wave intrinsics is that they accept a `uint4` mask instead of a `uint` mask. `WaveMask*` intrinsics effectively gets translated  to `WaveMulti*` intrinsics when targeting SPIRV/GLSL and HLSL. Please consult [Wave Multi Intrinsics](#wave-multi-intrinsics) for more details, including what masked operations are supported by each target.
+On D3D12 and Vulkan the WaveMask intrinsics can be used, but the mask may be ignored depending on target's support for partitioned/masked wave intrinsics. SPIRV provides support for a wide variety of operations through the `SPV_NV_shader_subgroup_partitioned` extension while HLSL only provides a small subset of operations through `WaveMultiPrefix*` intrinsics. The difference between Slang's `WaveMask` and these targets' partitioned wave intrinsics is that they accept a `uint4` mask instead of a `uint` mask. `WaveMask*` intrinsics effectively gets translated to `WaveMulti*` intrinsics when targeting SPIRV/GLSL and HLSL. Please consult [Wave Multi Intrinsics](#wave-multi-intrinsics) for more details, including what masked operations are supported by each target.
 
-
-The WaveMask intrinsics are a non standard Slang feature, and may change in the future. 
+The WaveMask intrinsics are a non standard Slang feature, and may change in the future.
 
 ```
 RWStructuredBuffer<int> outputBuffer;
@@ -49,36 +45,36 @@ RWStructuredBuffer<int> outputBuffer;
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     // It is the programmers responsibility to determine the initial mask, and that is dependent on the launch
-    // It's common to launch such that all lanes are active - with CUDA this would mean 32 lanes. 
+    // It's common to launch such that all lanes are active - with CUDA this would mean 32 lanes.
     // Here the launch only has 4 lanes active, and so the initial mask is 0xf.
     const WaveMask mask0 = 0xf;
-    
+
     int idx = int(dispatchThreadID.x);
-    
+
     int value = 0;
-    
+
     // When there is a conditional/flow control we typically need to work out a new mask.
     // This can be achieved by calling WaveMaskBallot with the current mask, and the condition
     // used in the flow control - here the subsequent 'if'.
     const WaveMask mask1 = WaveMaskBallot(mask0, idx == 2);
-    
+
     if (idx == 2)
     {
-        // At this point the mask is `mask1`, although no WaveMask intrinsics are used along this path, 
+        // At this point the mask is `mask1`, although no WaveMask intrinsics are used along this path,
         // so it's not used.
-    
+
         // diverge
         return;
     }
-    
+
     // If we get here, the active lanes must be the opposite of mask1 (because we took the other side of the condition), but cannot include
     // any lanes which were not active before. We can calculate this as mask0 & ~mask1.
-    
+
     const WaveMask mask2 = mask0 & ~mask1;
-    
+
     // mask2 holds the correct active mask to use with WaveMaskMin
     value = WaveMaskMin(mask2, idx + 1);
-    
+
     // Write out the result
     outputBuffer[idx] = value;
 }
@@ -86,7 +82,7 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 
 Many of the nuances of writing code in this way are discussed in the [CUDA documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#warp-vote-functions).
 
-The above example written via the regular intrinsics is significantly simpler, as we do not need to track 'active lanes' in the masks. 
+The above example written via the regular intrinsics is significantly simpler, as we do not need to track 'active lanes' in the masks.
 
 ```
 RWStructuredBuffer<int> outputBuffer;
@@ -95,30 +91,29 @@ RWStructuredBuffer<int> outputBuffer;
 void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     int idx = int(dispatchThreadID.x);
-    
+
     int value = 0;
-    
+
     if (idx == 2)
-    {    
+    {
         // diverge
         return;
     }
-    
+
     value = WaveActiveMin(idx + 1);
-    
+
     // Write out the result
     outputBuffer[idx] = value;
 }
 ```
+
 ## WaveMulti
 
 The standard 'Multi' intrinsics were added to HLSL is SM 6.5 and are available in SPIRV through `SPV_NV_shader_subgroup_partitioned`, they can specify a mask of lanes via uint4. SPIRV provide non-prefix (reduction) and prefix (scan) intrinsics for arithmetic and min/max operations, while HLSL only provides a subset of these, namely exclusive prefix arithmetic operations.
 
+# Standard Wave intrinsics
 
-Standard Wave intrinsics
-=========================
-
-The Wave Intrinsics supported on Slang are listed below. Note that typically T generic types also include vector and matrix forms. 
+The Wave Intrinsics supported on Slang are listed below. Note that typically T generic types also include vector and matrix forms.
 
 ```
 // Lane info
@@ -191,8 +186,7 @@ T WaveMultiPrefixProduct<T>(T value, uint4 mask);
 T WaveMultiPrefixSum<T>(T value, uint4 mask);
 ```
 
-Non Standard Wave Intrinsics
-============================
+# Non Standard Wave Intrinsics
 
 The following intrinsics are not part of the HLSL Wave intrinsics standard, but were added to Slang for a variety of reasons. Within the following signatures T can be scalar, vector or matrix, except on Vulkan which doesn't (currently) support Matrix.
 
@@ -205,9 +199,9 @@ uint4 WaveGetActiveMulti();
 
 uint4 WaveGetConvergedMulti();
 
-uint WaveGetNumWaves();  // Number of waves in workgroup (equivalent to GLSL gl_NumSubgroups)
+uint WaveGetNumWaves();  // Number of waves in workgroup (GLSL gl_NumSubgroups; compute-class stages only: compute/mesh/amplification)
 
-uint WaveGetWaveIndex(); // Wave index in workgroup (GLSL gl_SubgroupID, WGSL subgroup_id, Metal simdgroup_index_in_threadgroup; HLSL/WGSL compute only)
+uint WaveGetWaveIndex(); // Wave index in workgroup (GLSL gl_SubgroupID, WGSL subgroup_id, Metal simdgroup_index_in_threadgroup; compute-class stages only: compute/mesh/amplification)
 
 // Prefix (exclusive scan operations, equivalent to GLSL subgroupExclusive*)
 
@@ -221,7 +215,7 @@ T WavePrefixBitOr<T>(T expr);   // Exclusive prefix bitwise OR
 
 T WavePrefixBitXor<T>(T expr);  // Exclusive prefix bitwise XOR
 
-// Barriers 
+// Barriers
 
 void AllMemoryBarrierWithWaveSync();
 
@@ -234,34 +228,32 @@ void GroupMemoryBarrierWithWaveSync();
 T WaveBroadcastLaneAt<T>(T value, constexpr int lane);
 ```
 
-All lanes receive the value specified in lane. Lane must be an active lane, otherwise the result is undefined. 
-This is a more restrictive version of `WaveReadLaneAt` - which can take a non constexpr lane, *but* must be the same value for all lanes in the warp. Or 'dynamically uniform' as described in the HLSL documentation.
+All lanes receive the value specified in lane. Lane must be an active lane, otherwise the result is undefined.
+This is a more restrictive version of `WaveReadLaneAt` - which can take a non constexpr lane, _but_ must be the same value for all lanes in the warp. Or 'dynamically uniform' as described in the HLSL documentation.
 
 ```
 T WaveShuffle<T>(T value, int lane);
 ```
 
-Shuffle is a less restrictive version of `WaveReadLaneAt` in that it has no restriction on the lane value - it does *not* require the value to be same on all lanes. 
+Shuffle is a less restrictive version of `WaveReadLaneAt` in that it has no restriction on the lane value - it does _not_ require the value to be same on all lanes.
 
 There isn't explicit support for WaveShuffle in HLSL, and for now it will emit `WaveReadLaneAt`. As it turns out for a sizable set of hardware WaveReadLaneAt does work correctly when the lane is not 'dynamically uniform'. This is not necessarily the case for hardware general though, so if targeting HLSL it is important to make sure that this does work correctly on your target hardware.
 
-Our intention is that Slang will support the appropriate HLSL mechanism that makes this work on all hardware when it's available.  
+Our intention is that Slang will support the appropriate HLSL mechanism that makes this work on all hardware when it's available.
 
 ```
 void AllMemoryBarrierWithWaveSync();
 ```
 
-Synchronizes all lanes to the same AllMemoryBarrierWithWaveSync in program flow. Orders all memory accesses such that accesses after the barrier can be seen by writes before.  
+Synchronizes all lanes to the same AllMemoryBarrierWithWaveSync in program flow. Orders all memory accesses such that accesses after the barrier can be seen by writes before.
 
 ```
 void GroupMemoryBarrierWithWaveSync();
 ```
 
-Synchronizes all lanes to the same GroupMemoryBarrierWithWaveSync in program flow. Orders group shared memory accesses such that accesses after the barrier can be seen by writes before.  
+Synchronizes all lanes to the same GroupMemoryBarrierWithWaveSync in program flow. Orders group shared memory accesses such that accesses after the barrier can be seen by writes before.
 
-
-Wave Rotate Intrinsics
-======================
+# Wave Rotate Intrinsics
 
 These intrinsics are specific to Slang and were added to support the subgroup rotate functionalities provided by SPIRV (through the `GroupNonUniformRotateKHR` capability), GLSL (through the `GL_KHR_shader_subgroup_rotate
 ` extension), and Metal.
@@ -274,12 +266,12 @@ T WaveRotate(T value, uint delta);
 T WaveClusteredRotate(T value, uint delta, constexpr uint clusterSize);
 ```
 
-Wave Multi Intrinsics
-======================
+# Wave Multi Intrinsics
 
-`WaveMulti` intrinsics take an explicit  `uint4` mask of lanes to operate on. They correspond to the subgroup partitioned intrinsics provided by `SPV_NV_shader_subgroup_partitioned`  and the `WaveMultiPrefix*` intrinsics provided by HLSL SM 6.5.  HLSL's `WaveMulti*` intrinsics only provide operations for exclusive prefix arithmetic operations, while Vulkan's `SPV_NV_shader_subgroup_partitioned` provides operations for both inclusive/exclusive prefix (scan) and non-prefix (reduction) arithmetic and min/max operations. 
+`WaveMulti` intrinsics take an explicit `uint4` mask of lanes to operate on. They correspond to the subgroup partitioned intrinsics provided by `SPV_NV_shader_subgroup_partitioned` and the `WaveMultiPrefix*` intrinsics provided by HLSL SM 6.5. HLSL's `WaveMulti*` intrinsics only provide operations for exclusive prefix arithmetic operations, while Vulkan's `SPV_NV_shader_subgroup_partitioned` provides operations for both inclusive/exclusive prefix (scan) and non-prefix (reduction) arithmetic and min/max operations.
 
-Slang adds new `WaveMulti*` intrinsics in addition to HLSL's  `WaveMultiPrefix*` to allow generating all partitioned intrinsics supported in SPIRV. The new, non-standard HLSL,  `WaveMulti*` intrinsics are only supported when targeting SPIRV, GLSL and CUDA. The inclusive variants of HLSL's `WaveMultiPrefix*` intrinsics are emulated by Slang by performing an additional operation in the current invocation. Metal and WGSL targets do not support `WaveMulti` intrinsics.
+Slang adds new `WaveMulti*` intrinsics in addition to HLSL's `WaveMultiPrefix*` to allow generating all partitioned intrinsics supported in SPIRV. The new, non-standard HLSL, `WaveMulti*` intrinsics are only supported when targeting SPIRV, GLSL and CUDA. The inclusive variants of HLSL's `WaveMultiPrefix*` intrinsics are emulated by Slang by performing an additional operation in the current invocation. Metal and WGSL targets do not support `WaveMulti` intrinsics.
+
 ```
 // Across lane ops. These are only supported when targeting SPIRV, GLSL and CUDA.
 
@@ -334,15 +326,13 @@ T WaveMultiPrefixExclusiveMin(T value, uint4 mask);
 T WaveMultiPrefixExclusiveMax(T value, uint4 mask);
 ```
 
+# Wave Mask Intrinsics
 
-Wave Mask Intrinsics
-====================
-
-CUDA has a different programming model for inter warp/wave communication based around masks of active lanes. This is because the CUDA programming model allows for divergence that is more granualar than just on program flow, and that there isn't implied reconvergence at the end of a conditional. 
+CUDA has a different programming model for inter warp/wave communication based around masks of active lanes. This is because the CUDA programming model allows for divergence that is more granualar than just on program flow, and that there isn't implied reconvergence at the end of a conditional.
 
 In the future Slang may have the capability to work out the masks required such that the regular HLSL Wave intrinsics work. As it stands there does not appear to be any way to implement the regular Wave intrinsics directly. To work around this problem we introduce 'WaveMask' intrinsics, which are essentially the same as the regular HLSL Wave intrinsics with the first parameter as the WaveMask which identifies the participating lanes.
 
-The WaveMask intrinsics will work across targets, but *only* if on CUDA targets the mask captures exactly the same lanes as the 'Active' lanes concept in HLSL. If the masks deviate then the behavior is undefined. On non CUDA based targets currently the mask *may* be ignored depending on the intrinsics supported by the target.
+The WaveMask intrinsics will work across targets, but _only_ if on CUDA targets the mask captures exactly the same lanes as the 'Active' lanes concept in HLSL. If the masks deviate then the behavior is undefined. On non CUDA based targets currently the mask _may_ be ignored depending on the intrinsics supported by the target.
 
 Most of the `WaveMask` functions are identical to the regular Wave intrinsics, but they take a WaveMask as the first parameter, and the intrinsic name starts with `WaveMask`. Also note that the `WaveMask` functions are introduced in Slang before the `WaveMulti` intrinsics, and they effectively function the same other than the mask width in bits (`uint` vs `uint4`). The `WaveMulti` intrinsics map closer to SPIRV and HLSL, and are recommended to be used over `WaveMask` intrinsics whenever possible. We plan to deprecate the `WaveMask` intrinsics some time in the future.
 
@@ -350,24 +340,24 @@ Most of the `WaveMask` functions are identical to the regular Wave intrinsics, b
 WaveMask WaveGetConvergedMask();
 ```
 
-Gets the mask of lanes which are converged within the Wave. Note that this is *not* the same as Active threads, and may be some subset of that. It is equivalent to the `__activemask()` in CUDA.
+Gets the mask of lanes which are converged within the Wave. Note that this is _not_ the same as Active threads, and may be some subset of that. It is equivalent to the `__activemask()` in CUDA.
 
-On non CUDA targets the the function will return all lanes as active - even though this is not the case. This is 'ok' in so far as on non CUDA targets the mask is ignored. It is *not* okay if the code uses the value other than as a superset of the 'really converged' lanes. For example testing the bit's and changing behavior would likely not work correctly on non CUDA targets. 
+On non CUDA targets the the function will return all lanes as active - even though this is not the case. This is 'ok' in so far as on non CUDA targets the mask is ignored. It is _not_ okay if the code uses the value other than as a superset of the 'really converged' lanes. For example testing the bit's and changing behavior would likely not work correctly on non CUDA targets.
 
 ```
 void AllMemoryBarrierWithWaveMaskSync(WaveMask mask);
 ```
 
-Same as AllMemoryBarrierWithWaveSync but takes a mask of active lanes to sync with. 
+Same as AllMemoryBarrierWithWaveSync but takes a mask of active lanes to sync with.
 
 ```
 void GroupMemoryBarrierWithWaveMaskSync(WaveMask mask);
 ```
 
-Same as GroupMemoryBarrierWithWaveSync but takes a mask of active lanes to sync with. 
- 
-The intrinsics that make up the Slang `WaveMask` extension. 
- 
+Same as GroupMemoryBarrierWithWaveSync but takes a mask of active lanes to sync with.
+
+The intrinsics that make up the Slang `WaveMask` extension.
+
 ```
 // Lane info
 

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -7280,19 +7280,21 @@ void setupExtForSubgroupBallotBuiltIn() {
     }
 }
 
+[require(glsl_spirv, subgroup_workgroup_index)]
 public property uint gl_NumSubgroups
 {
     [ForceInline]
-    [require(glsl_spirv, subgroup_basic)]
+    [require(glsl_spirv, subgroup_workgroup_index)]
     get {
         return WaveGetNumWaves();
     }
 }
 
+[require(glsl_spirv, subgroup_workgroup_index)]
 public property uint gl_SubgroupID
 {
     [ForceInline]
-    [require(glsl_spirv, subgroup_basic)]
+    [require(glsl_spirv, subgroup_workgroup_index)]
     get {
         return WaveGetWaveIndex();
     }

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -17237,10 +17237,14 @@ uint WaveGetLaneIndex()
 
 /// Returns the number of waves (subgroups) in the current workgroup.
 /// Equivalent to GLSL gl_NumSubgroups.
+///
+/// On GLSL and SPIR-V this lowers to gl_NumSubgroups / BuiltIn NumSubgroups,
+/// which are restricted to compute-class execution models (compute, mesh,
+/// amplification); using it from any other stage is a capability error.
 /// @category wave
 __glsl_extension(GL_KHR_shader_subgroup_basic)
 __spirv_version(1.3)
-[require(cuda_glsl_hlsl_metal_spirv_wgsl, subgroup_basic)]
+[require(cuda_glsl_hlsl_metal_spirv_wgsl, subgroup_workgroup_index)]
 uint WaveGetNumWaves()
 {
     __target_switch
@@ -17273,12 +17277,16 @@ uint WaveGetNumWaves()
 
 /// Returns the index of the current wave (subgroup) within the workgroup.
 /// Equivalent to GLSL gl_SubgroupID / Metal simdgroup_index_in_threadgroup.
+///
+/// On GLSL and SPIR-V this lowers to gl_SubgroupID / BuiltIn SubgroupId,
+/// which are restricted to compute-class execution models (compute, mesh,
+/// amplification); using it from any other stage is a capability error.
 /// @category wave
 __glsl_extension(GL_KHR_shader_subgroup_basic)
 __spirv_version(1.3)
 [NonUniformReturn]
 [ForceInline]
-[require(cuda_glsl_hlsl_metal_spirv_wgsl, subgroup_basic)]
+[require(cuda_glsl_hlsl_metal_spirv_wgsl, subgroup_workgroup_index)]
 uint WaveGetWaveIndex()
 {
     __target_switch

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -2454,6 +2454,23 @@ alias subgroup_basic = GL_KHR_shader_subgroup_basic
                      | wgsl
                      | metal
                      ;
+/// Capabilities required to use the subgroup-within-workgroup queries
+/// 'WaveGetWaveIndex' / 'WaveGetNumWaves'. These lower to GLSL
+/// gl_SubgroupID / gl_NumSubgroups and SPIR-V BuiltIn SubgroupId /
+/// NumSubgroups, which the GLSL and Vulkan SPIR-V environment specs
+/// restrict to compute-class execution models (compute, mesh,
+/// amplification/task); the restriction is encoded here so misuse is
+/// caught by the capability system rather than producing invalid
+/// GLSL / SPIR-V.
+/// [Compound]
+alias subgroup_workgroup_index = GL_KHR_shader_subgroup_basic + compute
+                               | GL_KHR_shader_subgroup_basic + mesh
+                               | GL_KHR_shader_subgroup_basic + amplification
+                               | _sm_6_0
+                               | _cuda_sm_7_0
+                               | wgsl
+                               | metal
+                               ;
 /// Capabilities required to use GLSL-style subgroup operations 'subgroup_ballot'
 /// [Compound]
 alias subgroup_ballot = spirv_1_0 + GL_KHR_shader_subgroup_ballot

--- a/tests/glsl/subgroup-id-num-subgroups-raytracing.slang
+++ b/tests/glsl/subgroup-id-num-subgroups-raytracing.slang
@@ -1,0 +1,26 @@
+// Negative-path test for #11303: the GLSL-compatibility builtins gl_SubgroupID
+// and gl_NumSubgroups (in glsl.meta.slang) wrap WaveGetWaveIndex() /
+// WaveGetNumWaves() and carry the same subgroup_workgroup_index capability.
+// Reading them from a raytracing stage must be rejected at compile time with a
+// capability error rather than emitting BuiltIn SubgroupId / NumSubgroups, which
+// the Vulkan SPIR-V environment spec restricts to compute-class execution models
+// (VUID-SubgroupId-SubgroupId-04367 / VUID-NumSubgroups-04293).
+//
+// The capability is declared on the property declarations themselves (not only
+// their getters) so that a property read, which resolves to the PropertyDecl,
+// propagates the requirement to the entry point.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK, non-exhaustive): -target spirv -entry main -stage raygeneration -emit-spirv-directly -allow-glsl
+
+RWStructuredBuffer<uint> output;
+
+[shader("raygeneration")]
+void main()
+/*CHECK:
+     ^^^^ E36107
+     ^^^^ uses features that are not available in '_raygen' stage
+*/
+{
+    output[0] = gl_SubgroupID;
+    output[1] = gl_NumSubgroups;
+}

--- a/tests/spirv/wave-get-wave-index-mesh-amplification.slang
+++ b/tests/spirv/wave-get-wave-index-mesh-amplification.slang
@@ -1,0 +1,39 @@
+// Positive-path test for #11303: WaveGetWaveIndex() / WaveGetNumWaves() are
+// permitted on the mesh and amplification (task) execution models in addition
+// to compute, matching the compute-class restriction of BuiltIn SubgroupId /
+// NumSubgroups (VUID-SubgroupId-SubgroupId-04367 / VUID-NumSubgroups-04293).
+//
+// This pins the supported stage set so a future change that re-tightens
+// `subgroup_workgroup_index` to compute-only would fail CI.
+
+//TEST:SIMPLE(filecheck=MESH): -target spirv-asm -entry meshMain -stage mesh -emit-spirv-directly
+//TEST:SIMPLE(filecheck=AMP): -target spirv-asm -entry ampMain -stage amplification -emit-spirv-directly
+
+RWStructuredBuffer<uint> output;
+
+struct Vertex
+{
+    float4 pos : SV_Position;
+}
+
+[shader("mesh")]
+[numthreads(1, 1, 1)]
+[outputtopology("triangle")]
+void meshMain(out vertices Vertex verts[3], out indices uint3 tris[1])
+{
+    SetMeshOutputCounts(3, 1);
+    // MESH: OpLoad {{.*}} %SubgroupId
+    output[0] = WaveGetWaveIndex();
+    // MESH: OpLoad {{.*}} %NumSubgroups
+    output[1] = WaveGetNumWaves();
+}
+
+[shader("amplification")]
+[numthreads(1, 1, 1)]
+void ampMain()
+{
+    // AMP: OpLoad {{.*}} %SubgroupId
+    output[0] = WaveGetWaveIndex();
+    // AMP: OpLoad {{.*}} %NumSubgroups
+    output[1] = WaveGetNumWaves();
+}

--- a/tests/spirv/wave-get-wave-index-raytracing.slang
+++ b/tests/spirv/wave-get-wave-index-raytracing.slang
@@ -1,0 +1,27 @@
+// Verify that WaveGetWaveIndex() and WaveGetNumWaves() are rejected at compile
+// time when used from a raytracing stage targeting SPIR-V or GLSL.
+//
+// Both lower to GLSL gl_SubgroupID / gl_NumSubgroups and SPIR-V BuiltIn
+// SubgroupId / NumSubgroups, which the GLSL and Vulkan SPIR-V environment specs
+// restrict to compute-class execution models (compute/mesh/task). Using them
+// from a raygeneration entry point previously emitted SPIR-V that fails
+// spirv-val with VUID-SubgroupId-SubgroupId-04367 (and the analogous
+// NumSubgroups VUID). The `subgroup_workgroup_index` capability now encodes that
+// stage restriction so the misuse is caught by the capability system at compile
+// time on both targets. See issue #11303.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK, non-exhaustive): -target spirv -entry main -stage raygeneration -emit-spirv-directly
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK, non-exhaustive): -target glsl -entry main -stage raygeneration
+
+RWStructuredBuffer<uint> output;
+
+[shader("raygeneration")]
+void main()
+/*CHECK:
+     ^^^^ E36107
+     ^^^^ uses features that are not available in '_raygen' stage
+*/
+{
+    output[0] = WaveGetWaveIndex();
+    output[1] = WaveGetNumWaves();
+}


### PR DESCRIPTION
## Motivation

`WaveGetWaveIndex()` and `WaveGetNumWaves()` emit spec-invalid SPIR-V (and invalid GLSL) when called from a raytracing entry point. Repro:

```slang
RWStructuredBuffer<uint> output;
[shader("raygeneration")]
void main() {
    output[0] = WaveGetWaveIndex();
    output[1] = WaveGetNumWaves();
}
```

```
SLANG_RUN_SPIRV_VALIDATION=1 slangc -target spirv -entry main -stage raygeneration -emit-spirv-directly -o out.spv repro.slang
```

```
[VUID-SubgroupId-SubgroupId-04367] Vulkan spec allows BuiltIn SubgroupId to be used
only with GLCompute, MeshNV, TaskNV, MeshEXT or TaskEXT execution model.
```

Both lower to GLSL `gl_SubgroupID` / `gl_NumSubgroups` and SPIR-V `BuiltIn SubgroupId` / `NumSubgroups`, which the GLSL and Vulkan SPIR-V environment specs restrict to compute-class execution models (VUID-SubgroupId-SubgroupId-04367 / VUID-NumSubgroups-NumSubgroups-04293). The failure only surfaced downstream at `spirv-val` time.

## Proposed solution

Encode the stage restriction in the **capability system** rather than with a `static_assert` in the intrinsic body (per maintainer feedback that this class of error belongs to the capability system, not static-assert / IR checking).

Add a `subgroup_workgroup_index` capability that, on `glsl`/`spirv`, only permits compute-class stages (`compute`, `mesh`, `amplification`) while keeping the existing atoms for the other targets (`_sm_6_0`, `_cuda_sm_7_0`, `wgsl`, `metal`, which retain their own compute-only `__stage_switch` handling). `[require(...)]` it on the two intrinsics, and propagate it to the `gl_NumSubgroups` / `gl_SubgroupID` GLSL compatibility properties that wrap them. Misuse from any other stage is now a capability diagnostic (`E36107`) at compile time:

```
error[E36107]: unavailable features in entry point
 --> repro.slang:4:6
  |
4 | void main()
  |      ^^^^ entrypoint 'main' uses features that are not available in '_raygen' stage for 'spirv' compilation target.
```

This mirrors the existing `WorkgroupCount()` precedent (`[require(glsl_spirv, GLSL_430_SPIRV_1_0_compute)]` + `[require(glsl_spirv, meshshading)]`), and unlike amending `subgroup_basic` directly it does **not** over-restrict the many other subgroup intrinsics (`WaveGetLaneIndex`, ballot/vote/arithmetic ops) that are valid in all stages.

## Change summary

| File | Change |
| --- | --- |
| `source/slang/slang-capabilities.capdef` | Add `subgroup_workgroup_index` capability: compute-class-only on glsl/spirv, unchanged elsewhere. |
| `source/slang/hlsl.meta.slang` | `WaveGetWaveIndex` / `WaveGetNumWaves` now `[require(..., subgroup_workgroup_index)]`; docstrings note the stage restriction. |
| `source/slang/glsl.meta.slang` | `gl_NumSubgroups` / `gl_SubgroupID` properties require `subgroup_workgroup_index` so the restriction propagates through the GLSL-compat layer. |
| `docs/user-guide/a3-02-reference-capability-atoms.md` | Regenerated capability reference (new atom entry). |
| `tests/spirv/wave-get-wave-index-raytracing.slang` | New `DIAGNOSTIC_TEST` asserting the `E36107` capability diagnostic from a raygeneration entry point. |

## Concepts and vocabulary

- **Capability atom / `[require(target, feature)]`**: a function declares the target+feature capabilities its body needs. `getDeclaredCapabilitySet` (slang-check-decl.cpp) unions the requirements; `processLateRequireCapabilityInsts` (slang-ir-late-require-capability.cpp) checks an entry point's stage/target against them and emits `entry-point-uses-unavailable-capability` (E36107) on a mismatch.
- **Stage "keyhole"**: an entry point carries exactly one stage atom (e.g. `_raygen`); a `+ compute`/`+ mesh`/`+ amplification` conjunction in the required set means the set is unsatisfiable for any other stage, which is what produces the diagnostic.
- **`subgroup_workgroup_index`**: the new atom. On glsl/spirv it is `GL_KHR_shader_subgroup_basic + {compute|mesh|amplification}`; on the other targets it is the same disjuncts `subgroup_basic` uses.

## Process report

The defect is that `WaveGetWaveIndex`/`WaveGetNumWaves` advertised, via `[require(..., subgroup_basic)]`, that they work on every stage `subgroup_basic` allows, when on glsl/spirv they are only valid on compute-class stages. The principled fix is to make the declared capability match reality, so the capability checker (which already exists for exactly this purpose) rejects misuse — instead of detecting it with a `static_assert` in the lowering body, which is the wrong layer.

`subgroup_basic` itself is shared by many subgroup intrinsics that *are* valid in fragment/vertex/etc., so restricting it would be wrong (over-restriction). Hence a dedicated `subgroup_workgroup_index` atom applied only to the two affected intrinsics. Verified that `WaveGetLaneIndex` (still `subgroup_basic`) continues to pass the capability check in a fragment shader, confirming the new atom is correctly scoped.

The capability change exposed a real dependency in the core module: the GLSL-compat properties `gl_NumSubgroups` / `gl_SubgroupID` (glsl.meta.slang) call these intrinsics and previously declared `[require(glsl_spirv, subgroup_basic)]`. After the change the checker reported `E36117 'dependencies not compatible on stage'` for them — correctly, since a wrapper that claims all-stage support cannot call a compute-class-only callee. These GLSL builtins carry the same spec restriction, so propagating `subgroup_workgroup_index` to them is the correct fix, not a workaround.

Verified on a debug build: raygeneration → `E36107`; compute and mesh → valid SPIR-V under `SLANG_RUN_SPIRV_VALIDATION=1`. Tests: `tests/spirv/` (463), `tests/*wave*` (106), `tests/*capability*` (128) all pass.

Fixes #11303