### PR TITLE
Validate generic struct capability requirements on entry-point params (#9489)

### DIFF
--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -1369,6 +1369,110 @@ static bool _outputDeclHasSemantic(
 }
 
 
+// A user-defined generic struct found in an entry-point signature type, paired
+// with the source location of its use.
+struct GenericStructTypeUse
+{
+    StructDecl* structDecl;
+    SourceLoc useLoc;
+};
+
+// Collect every user-defined generic struct (e.g. `Foo<int>`) reachable from an
+// entry-point signature type `type`, recursing through wrapper/composite types so
+// that `Foo<int>`, `Foo<int>[N]`, `Optional<Foo<int>>`, and
+// `ConstantBuffer<Foo<int>>` are all found. Results are appended to `outUses` and
+// `visited` guards against cycles in the `Val` graph.
+//
+// This is needed because the general capability-inference walk
+// (`SemanticsDeclReferenceVisitor`) records a type's requirements only when its
+// decl-ref is a `DirectDeclRef`; a generic specialization uses a
+// `GenericAppDeclRef` and is skipped, so a `[require(...)]` on a generic struct
+// used in an entry-point signature is otherwise dropped. The non-generic spelling
+// `Foo` is already handled by that walk, so only the generic case is collected
+// here (to avoid duplicate reporting).
+//
+// This deliberately lives in entry-point validation rather than in the general
+// inference walk: inferring a generic struct type's requirements for *every*
+// function that names such a type would require many core-module library
+// functions (e.g. the cooperative vector/matrix/tensor `Load`/`Store` helpers,
+// which take `CoopVec<T,N>` etc.) to redeclare those capabilities. Restricting
+// the check to entry-point signatures matches the reported defect without
+// changing library-function inference.
+//
+// Only the struct decl itself is filtered for `MagicTypeModifier`/
+// `IntrinsicTypeModifier`: builtin generic types (e.g. `LineStream<T>`,
+// `OutputPatch<T,N>`) already have dedicated, more specific entry-point
+// diagnostics, so reporting a generic capability error for them would only
+// duplicate those. Wrapper builtins are still recursed *through* so that a
+// user-defined `Foo<int>` nested inside them is found.
+static void collectGenericStructTypeUses(
+    ASTBuilder* astBuilder,
+    Val* type,
+    SourceLoc useLoc,
+    HashSet<Val*>& visited,
+    List<GenericStructTypeUse>& outUses,
+    UInt recursionDepth = 0)
+{
+    if (!type || !visited.add(type))
+        return;
+
+    // Bound the recursion to avoid overflowing the stack on a legitimately deep
+    // acyclic chain (e.g. `Wrap<Wrap<...<Foo<int>>...>>`), where each level is a
+    // distinct hash-consed `Val` that the visited set does not collapse. This
+    // mirrors the `kMaxTypeNestingDepth` guard used by the other type walks in
+    // this file; a type nested past that limit is already diagnosed with
+    // "maximum type nesting level exceeded" by `validateVaryingType`, which runs
+    // earlier in `validateEntryPoint`, so we simply stop descending here.
+    if (recursionDepth >= kMaxTypeNestingDepth)
+        return;
+
+    if (auto declRefType = as<DeclRefType>(type))
+    {
+        auto structDeclRef = declRefType->getDeclRef().as<StructDecl>();
+        if (structDeclRef && as<GenericAppDeclRef>(declRefType->getDeclRefBase()) &&
+            !structDeclRef.getDecl()->findModifier<MagicTypeModifier>() &&
+            !structDeclRef.getDecl()->findModifier<IntrinsicTypeModifier>())
+        {
+            // Only contribute structs that actually carry a requirement; this keeps
+            // both the aggregation and the diagnostic loop free of null/empty sets.
+            auto* caps = structDeclRef.getDecl()->inferredCapabilityRequirements;
+            if (caps && !caps->isEmpty())
+                outUses.add({structDeclRef.getDecl(), useLoc});
+        }
+        // Recurse through the struct's fields *with substitutions applied*, so a
+        // wrapper like `struct Wrapper<T> { Foo<T> f; }` used as `Wrapper<int>`,
+        // or a non-generic `struct Wrapper { Foo<int> f; }`, still reaches
+        // `Foo<int>` (which the `Val`-operand walk below alone would miss, since
+        // the field type is not an operand of the wrapper type).
+        if (structDeclRef)
+        {
+            for (auto fieldDeclRef :
+                 getFields(astBuilder, structDeclRef, MemberFilterStyle::Instance))
+                collectGenericStructTypeUses(
+                    astBuilder,
+                    getType(astBuilder, fieldDeclRef),
+                    useLoc,
+                    visited,
+                    outUses,
+                    recursionDepth + 1);
+        }
+    }
+
+    // Recurse into the type's `Val` operands (generic arguments, element types,
+    // etc.) so nested user generic structs inside wrappers/arrays are found.
+    for (Index i = 0; i < type->getOperandCount(); i++)
+    {
+        if (type->m_operands[i].kind == ValNodeOperandKind::ValNode)
+            collectGenericStructTypeUses(
+                astBuilder,
+                type->getOperand(i),
+                useLoc,
+                visited,
+                outUses,
+                recursionDepth + 1);
+    }
+}
+
 // Validate that an entry point function conforms to any additional
 // constraints based on the stage (and profile?) it specifies.
 void validateEntryPoint(EntryPoint* entryPoint, DiagnosticSink* sink)
@@ -1923,13 +2027,64 @@ void validateEntryPoint(EntryPoint* entryPoint, DiagnosticSink* sink)
         }
     }
 
+    // Augment the entry point's inferred requirements with the capability
+    // requirements of the *generic* struct types in its signature (parameters and
+    // return type). The general inference walk records a type's requirements only
+    // when its decl-ref is a `DirectDeclRef`, so a non-generic struct such as
+    // `Foo a` is already covered there, but a generic one such as `Foo<int> a`
+    // (whose decl-ref is a `GenericAppDeclRef`) is not. We gather the missing
+    // generic-struct requirements here so a `[require(...)]` on `Foo` is enforced
+    // for both spellings. `signatureStructUses` keeps each contributing struct and
+    // its use location so we can point the diagnostic at the exact use site (the
+    // non-generic case is reported by `diagnoseMissingCapabilityProvenance`).
+    CapabilitySet entryPointInferredCaps{entryPointFuncDecl->inferredCapabilityRequirements};
+    List<GenericStructTypeUse> signatureStructUses;
+    {
+        auto astBuilder = linkage->getASTBuilder();
+        // Use a fresh `visited` set per signature position. `Val` nodes are
+        // hash-consed, so the same specialization `Foo<int>` on two parameters is
+        // the identical `Val*`; a shared set would drop the second use site and the
+        // user would see only one "see using of 'Foo'" note. The per-position set
+        // still guards against cycles within a single type.
+        for (auto param : entryPointFuncDecl->getParameters())
+        {
+            // Prefer the written type-expression location (the `Foo<int>` use
+            // site); fall back to the parameter location if no type syntax was
+            // retained.
+            SourceLoc useLoc = (param->type.exp) ? param->type.exp->loc : param->loc;
+            HashSet<Val*> visited;
+            collectGenericStructTypeUses(
+                astBuilder,
+                param->getType(),
+                useLoc,
+                visited,
+                signatureStructUses);
+        }
+        // The return type has the same silent-compile bug as parameters: a
+        // `Foo<int> main()` whose `Foo` requires an unavailable capability must be
+        // diagnosed too.
+        SourceLoc returnLoc = (entryPointFuncDecl->returnType.exp)
+                                  ? entryPointFuncDecl->returnType.exp->loc
+                                  : entryPointFuncDecl->loc;
+        HashSet<Val*> visited;
+        collectGenericStructTypeUses(
+            astBuilder,
+            entryPointFuncDecl->returnType.type,
+            returnLoc,
+            visited,
+            signatureStructUses);
+    }
+    // Every collected use carries a non-empty requirement (filtered in the
+    // collector), so this join is unconditional.
+    for (auto& use : signatureStructUses)
+        entryPointInferredCaps.nonDestructiveJoin(use.structDecl->inferredCapabilityRequirements);
+
     for (auto target : linkage->targets)
     {
         auto targetCaps = target->getTargetCaps();
         auto stageCapabilitySet = entryPoint->getProfile().getCapabilityName();
         targetCaps.join(stageCapabilitySet);
-        if (targetCaps.isIncompatibleWith(
-                CapabilitySet{entryPointFuncDecl->inferredCapabilityRequirements}))
+        if (targetCaps.isIncompatibleWith(entryPointInferredCaps))
         {
             // Incompatable means we don't support a set of abstract atoms.
             // Diagnose that we lack support for 'stage' and 'target' atoms with our provided
@@ -1952,6 +2107,33 @@ void validateEntryPoint(EntryPoint* entryPoint, DiagnosticSink* sink)
                 sink,
                 entryPointFuncDecl,
                 failedSet);
+
+            // The provenance walk above follows `capabilityRequirementProvenance`,
+            // which does not record generic struct signature types. Point at any
+            // such struct whose requirement is itself incompatible with the
+            // target, mirroring the notes emitted for non-generic structs.
+            for (auto& use : signatureStructUses)
+            {
+                if (!targetCaps.isIncompatibleWith(
+                        CapabilitySet{use.structDecl->inferredCapabilityRequirements}))
+                    continue;
+                maybeDiagnose(
+                    sink,
+                    linkage->m_optionSet,
+                    DiagnosticCategory::Capability,
+                    Diagnostics::SeeUsingOf{.decl = use.structDecl, .location = use.useLoc});
+                maybeDiagnose(
+                    sink,
+                    linkage->m_optionSet,
+                    DiagnosticCategory::Capability,
+                    Diagnostics::SeeDefinitionOf{.decl = use.structDecl});
+                if (auto requireAttr = use.structDecl->findModifier<RequireCapabilityAttribute>())
+                    maybeDiagnose(
+                        sink,
+                        linkage->m_optionSet,
+                        DiagnosticCategory::Capability,
+                        Diagnostics::SeeDeclarationOfModifier{.modifier = requireAttr});
+            }
         }
         else
         {
@@ -1989,13 +2171,11 @@ void validateEntryPoint(EntryPoint* entryPoint, DiagnosticSink* sink)
 
             // Only attempt to error if a specific profile or capability is requested
             if ((specificCapabilityRequested || specificProfileRequested) &&
-                targetCaps.atLeastOneSetImpliedInOther(
-                    CapabilitySet{entryPointFuncDecl->inferredCapabilityRequirements}) ==
+                targetCaps.atLeastOneSetImpliedInOther(entryPointInferredCaps) ==
                     CapabilitySet::ImpliesReturnFlags::NotImplied)
             {
                 CapabilitySet combinedSets = targetCaps;
-                combinedSets.join(
-                    CapabilitySet{entryPointFuncDecl->inferredCapabilityRequirements});
+                combinedSets.join(entryPointInferredCaps);
                 CapabilityAtomSet addedAtoms{};
                 if (auto targetCapSet = targetCaps.getAtomSets())
                 {

--- a/tests/diagnostics/capability-generic-struct-entrypoint-param.slang
+++ b/tests/diagnostics/capability-generic-struct-entrypoint-param.slang
@@ -1,0 +1,253 @@
+// Entry-point signature validation must honor the capability `[require(...)]`
+// of a *generic* struct type the same way it does for a non-generic struct.
+//
+// Regression test for https://github.com/shader-slang/slang/issues/9489:
+// `Foo<int>` used as a `vertex` entry-point parameter, where `Foo` requires the
+// `cpp` capability, previously compiled silently for the `spirv` target. It now
+// reports E36107 just as the non-generic spelling `Foo` always did.
+//
+// Each entry point uses its own diag tag because a `DIAGNOSTIC_TEST` invocation
+// must match every annotation for its tag, and only the compiled entry point's
+// diagnostics fire. All error invocations are non-exhaustive because the entry
+// point also emits "see using/definition of '<entry>'" notes we don't pin.
+// Carets align to the columns of the preceding source line.
+
+// Plain generic parameter.
+//DIAGNOSTIC_TEST:SIMPLE(diag=PARAM,non-exhaustive): -target spirv -emit-spirv-directly -entry main -stage vertex
+// Generic parameter nested inside a builtin wrapper (array).
+//DIAGNOSTIC_TEST:SIMPLE(diag=ARR,non-exhaustive): -target spirv -emit-spirv-directly -entry mainArr -stage vertex
+// Multiple contributing generic structs.
+//DIAGNOSTIC_TEST:SIMPLE(diag=MULTI,non-exhaustive): -target spirv -emit-spirv-directly -entry mainMulti -stage vertex
+// Generic return type.
+//DIAGNOSTIC_TEST:SIMPLE(diag=RET,non-exhaustive): -target spirv -emit-spirv-directly -entry mainRet -stage vertex
+// Same generic struct on two parameters: both use sites must be reported (the
+// hash-consed `Val` for `Foo<int>` must not collapse to a single note).
+//DIAGNOSTIC_TEST:SIMPLE(diag=DUP,non-exhaustive): -target spirv -emit-spirv-directly -entry mainDup -stage vertex
+// Generic struct nested inside a builtin generic wrapper (`ConstantBuffer<...>`).
+//DIAGNOSTIC_TEST:SIMPLE(diag=CB,non-exhaustive): -target spirv -emit-spirv-directly -entry mainCB -stage vertex
+// Generic struct nested inside `Optional<...>`.
+//DIAGNOSTIC_TEST:SIMPLE(diag=OPT,non-exhaustive): -target spirv -emit-spirv-directly -entry mainOpt -stage vertex
+// Generic struct used only as a generic *argument* of a non-requiring user
+// wrapper (`Wrap<Foo<int>>`): the requirement comes solely from the inner `Foo`,
+// exercising the generic-arg recursion path.
+//DIAGNOSTIC_TEST:SIMPLE(diag=NEST,non-exhaustive): -target spirv -emit-spirv-directly -entry mainNest -stage vertex
+// Generic struct reached only via a substituted *field* of a non-requiring user
+// wrapper (`struct Field<T> { Foo<T> f; }` used as `Field<int>`): exercises the
+// field-substitution recursion path.
+//DIAGNOSTIC_TEST:SIMPLE(diag=FIELD,non-exhaustive): -target spirv -emit-spirv-directly -entry mainField -stage vertex
+// Non-generic wrapper whose field is a generic requiring struct
+// (`struct NonGenField { Foo<int> f; }`): also reached via field substitution.
+//DIAGNOSTIC_TEST:SIMPLE(diag=NGFIELD,non-exhaustive): -target spirv -emit-spirv-directly -entry mainNgField -stage vertex
+// `out` parameter direction must be checked the same as `in`.
+//DIAGNOSTIC_TEST:SIMPLE(diag=OUT,non-exhaustive): -target spirv -emit-spirv-directly -entry mainOut -stage vertex
+// `inout` parameter direction must be checked the same as `in`/`out`.
+//DIAGNOSTIC_TEST:SIMPLE(diag=INOUT,non-exhaustive): -target spirv -emit-spirv-directly -entry mainInOut -stage vertex
+// Multi-level wrapper nesting (`Wrap<Wrap<Foo<int>>>`): both recursion arms must
+// keep descending and the depth guard must not fire too early.
+//DIAGNOSTIC_TEST:SIMPLE(diag=DEEP,non-exhaustive): -target spirv -emit-spirv-directly -entry mainDeep -stage vertex
+// Scoping invariant: a *non-entry-point* function taking a requiring generic
+// struct must NOT be diagnosed (only entry-point signatures are checked). Here
+// `mainScope`'s own signature is clean and it calls `helper(Foo<int>)` in its
+// body; no E36107 must fire.
+//DIAGNOSTIC_TEST:SIMPLE(diag=SCOPE,non-exhaustive): -target spirv -emit-spirv-directly -entry mainScope -stage vertex
+//SCOPE-NOT: E36107
+// Positive case: the cpp requirement is satisfied for the cpp target, so the same
+// code must compile. We assert no E36107 *and* that compilation reaches code
+// emission (the entry-point rename warning E40100 only fires on success), so the
+// case cannot pass by failing for some unrelated reason.
+//DIAGNOSTIC_TEST:SIMPLE(diag=CPP): -target cpp -entry main -stage vertex
+//CPP-NOT: E36107
+//CPP: E40100
+// Profile-implicit-upgrade path: a generic struct requiring a higher shader model
+// than the requested profile contributes to the "implicitly upgraded" warning
+// (this path uses the augmented capability set, not the bare entry-point set).
+//DIAGNOSTIC_TEST:SIMPLE(diag=UPGRADE,non-exhaustive): -target hlsl -profile sm_5_0 -capability hlsl -entry mainUpgrade -stage compute
+//UPGRADE: E41012
+//UPGRADE: sm_6_5
+
+[require(cpp)]
+/*PARAM:
+ ^^^^^^^ see declaration of 'require'
+*/
+struct Foo<T>
+/*PARAM:
+       ^^^ see definition of 'Foo'
+*/
+{
+    int x;
+}
+
+[require(cpp)]
+struct Bar<T>
+{
+    int y;
+}
+
+// A generic wrapper with no capability requirement of its own; used to verify the
+// requirement is found when `Foo<int>` appears only as a generic argument.
+struct Wrap<T>
+{
+    T x;
+}
+
+// A generic wrapper with no requirement of its own that *contains* a `Foo<T>`
+// field; used to verify the requirement is found via field substitution.
+struct Field<T>
+{
+    Foo<T> f;
+}
+
+// A non-generic wrapper whose field is a generic requiring struct; the
+// requirement must still be found via the field's substituted type.
+struct NonGenField
+{
+    Foo<int> f;
+}
+
+[shader("vertex")]
+void main(Foo<int> a)
+/*PARAM:
+     ^^^^ unavailable features in entry point
+          ^^^ see using of 'Foo'
+*/
+{
+}
+
+[shader("vertex")]
+void mainArr(Foo<int> a[4])
+/*ARR:
+     ^^^^^^^ unavailable features in entry point
+*/
+//ARR: see using of 'Foo'
+{
+}
+
+[shader("vertex")]
+void mainMulti(Foo<int> a, Bar<int> b)
+/*MULTI:
+     ^^^^^^^^^ unavailable features in entry point
+               ^^^ see using of 'Foo'
+                           ^^^ see using of 'Bar'
+*/
+{
+}
+
+[shader("vertex")]
+void mainDup(Foo<int> a, Foo<int> b)
+/*DUP:
+     ^^^^^^^ unavailable features in entry point
+             ^^^ see using of 'Foo'
+                         ^^^ see using of 'Foo'
+*/
+{
+}
+
+[shader("vertex")]
+void mainCB(ConstantBuffer<Foo<int> > a)
+/*CB:
+     ^^^^^^ unavailable features in entry point
+*/
+//CB: see using of 'Foo'
+{
+}
+
+[shader("vertex")]
+void mainOpt(Optional<Foo<int> > a)
+/*OPT:
+     ^^^^^^^ unavailable features in entry point
+*/
+//OPT: see using of 'Foo'
+{
+}
+
+[shader("vertex")]
+void mainNest(Wrap<Foo<int> > a)
+/*NEST:
+     ^^^^^^^^ unavailable features in entry point
+*/
+//NEST: see using of 'Foo'
+{
+}
+
+[shader("vertex")]
+void mainField(Field<int> a)
+/*FIELD:
+     ^^^^^^^^^ unavailable features in entry point
+*/
+//FIELD: see using of 'Foo'
+{
+}
+
+[shader("vertex")]
+void mainNgField(NonGenField a)
+/*NGFIELD:
+     ^^^^^^^^^^^ unavailable features in entry point
+*/
+//NGFIELD: see using of 'Foo'
+{
+}
+
+[shader("vertex")]
+void mainOut(out Foo<int> a)
+/*OUT:
+     ^^^^^^^ unavailable features in entry point
+*/
+//OUT: see using of 'Foo'
+{
+    a = (Foo<int>)0;
+}
+
+[shader("vertex")]
+void mainInOut(inout Foo<int> a)
+/*INOUT:
+     ^^^^^^^^^ unavailable features in entry point
+*/
+//INOUT: see using of 'Foo'
+{
+}
+
+[shader("vertex")]
+void mainDeep(Wrap<Wrap<Foo<int> > > a)
+/*DEEP:
+     ^^^^^^^^ unavailable features in entry point
+*/
+//DEEP: see using of 'Foo'
+{
+}
+
+// A non-entry-point function whose parameter is a requiring generic struct. The
+// validation is scoped to entry points, so this signature must not be diagnosed.
+void helper(Foo<int> a)
+{
+}
+
+[shader("vertex")]
+void mainScope(int x)
+{
+    helper((Foo<int>)0);
+}
+
+[shader("vertex")]
+Foo<int> mainRet()
+/*RET:
+         ^^^^^^^ unavailable features in entry point
+*/
+//RET: see using of 'Foo'
+{
+    Foo<int> f = { 0 };
+    return f;
+}
+
+// A generic struct requiring a higher shader model; used to exercise the
+// profile-implicit-upgrade path rather than the hard incompatibility path.
+[require(hlsl, sm_6_5)]
+struct NeedsSM65<T>
+{
+    T x;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void mainUpgrade(NeedsSM65<int> p)
+{
+}


### PR DESCRIPTION
Closes #9489

## Motivation

A user-defined generic struct that declares a capability requirement, used in an
entry-point signature, was not validated against the compilation target. It
compiled silently for an incompatible target, while the equivalent non-generic
struct was correctly rejected.

Consider this example:

```slang
[require(cpp)]
struct Foo<T> { int x; }

[shader("vertex")]
void main(Foo<int> a) { }
```

Compiling with `-target spirv` succeeded silently, even though `Foo` requires the
`cpp` capability. The non-generic spelling `struct Foo { int x; }` used the same
way already produced `error 36107` ("unavailable features in entry point").

## Proposed solution

Entry-point validation now also gathers the capability requirements of the
*generic* struct types in the entry point's signature (parameters and return
type, including generic structs nested inside wrapper/composite types such as
arrays, `Optional<...>`, `ConstantBuffer<...>`) and includes them in the
incompatibility check, so `Foo` and `Foo<int>` are treated identically.

The fix lives in entry-point validation rather than in the general
capability-inference walk. Broadening that walk to infer a generic struct type's
requirements for *every* function that names such a type would force many
core-module library functions that take generic struct parameters (e.g. the
cooperative vector/matrix/tensor `Load`/`Store` helpers, which take `CoopVec<T,N>`
etc.) to redeclare those capabilities — it makes the core module fail to build
with ~50 `undeclared capability` errors. Restricting the new check to entry-point
signatures addresses the reported defect without changing library-function
inference.

## Change summary

| Area | What |
| --- | --- |
| `source/slang/slang-check-shader.cpp` | New `collectGenericStructTypeUses` (a recursive `Val` walker collecting user-defined generic struct uses in a signature type, through wrappers/arrays/generic args); `validateEntryPoint` joins those requirements into the entry point's inferred capability set over parameters and the return type, and emits use-site notes for each contributing struct. |
| `tests/diagnostics/capability-generic-struct-entrypoint-param.slang` | Regression test: error cases for a generic param, an array-nested generic param, multiple contributing structs, and a generic return type; plus a positive compile-success case on the cpp target. |

## Concepts and vocabulary

- **`DirectDeclRef` vs `GenericAppDeclRef`** — a non-generic type reference `Foo`
  is a `DeclRefType(DirectDeclRef(Foo))`; a generic specialization `Foo<int>` is a
  `DeclRefType(GenericAppDeclRef(Foo, ...))`. In the latter the inner struct decl
  is operand 0 (a plain decl operand, reached by `getDecl()`), not a `Val`.
- **`MagicTypeModifier`/`IntrinsicTypeModifier`** — mark builtin types (e.g.
  `LineStream`, `OutputPatch`, `Array`, `Optional`). The collector skips emitting
  for such *structs* (they have their own dedicated diagnostics) but still recurses
  *through* them to find user generic structs nested inside.
- **`inferredCapabilityRequirements`** — the capability set a decl needs, derived
  from `[require(...)]` and inherited from parents.
- **`capabilityRequirementProvenance`** — the chain `diagnoseMissingCapabilityProvenance`
  walks to find and point at the source of an incompatible requirement.

## Process report

- **Why the generic case was dropped.** Signature type requirements are gathered
  by the reference visitor in `slang-check-decl.cpp`, which only calls
  `processReferencedDecl` for a `DirectDeclRef` (`visitDirectDeclRef`); every other
  decl-ref flavor falls to `visitVal`, which descends only into `Val` operands. For
  `Foo<int>` the struct decl is operand 0 of the `GenericAppDeclRef` and is a plain
  decl operand, so it is never visited and `Foo`'s `[require(cpp)]` is lost. For
  `Foo` the decl-ref is a `DirectDeclRef`, so its requirement is recorded.
- **Why the fix is at entry-point validation, not the shared walk.** Adding the
  inner-decl processing to the shared visitor (tried first) propagates a generic
  struct type's requirements into *every* function that names it, breaking the core
  module build (~50 `undeclared capability` errors from cooperative
  vector/matrix/tensor helpers). The input shape (a generic struct used as a
  signature type) is valid; the question is which consumers enforce its
  requirement. Per the chosen scope, only entry points enforce it.
- **`collectGenericStructTypeUses`.** A recursive `Val` walker (with a visited set
  for cycle safety) that collects each `DeclRefType` whose decl-ref is a
  `GenericAppDeclRef` to a non-magic/non-intrinsic `StructDecl`, recursing through
  operands so nested user generic structs inside builtin wrappers/arrays are found.
  Non-generic structs are intentionally not collected: they are already covered by
  the shared walk and by `diagnoseMissingCapabilityProvenance`, and collecting them
  produced duplicate notes.
- **Diagnostic provenance.** `diagnoseMissingCapabilityProvenance` follows
  `capabilityRequirementProvenance`, which does not record generic struct signature
  types, so the new code emits the `see using of` / `see definition of` /
  `see declaration of 'require'` notes for each contributing struct directly,
  anchored at the type use site (`param->type.exp->loc` / the return type expr),
  mirroring the non-generic output.

Tested: the new regression test (5 invocations) passes; `tests/diagnostics/`,
`tests/language-feature/capability/`, generics, and related suites pass.
(Pre-existing unrelated failures in `tests/cooperative-*`/`tests/neural/*` are
test-harness `TEST_INPUT` half-float/named-buffer parsing issues that also fail on
master.)