### PR TITLE
ci: move the wasm build to the GCP build pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,11 +146,11 @@ jobs:
       runs-on: '["Linux", "self-hosted", "build", "GCP"]'
       container-user: "1003:1003"
 
-  # WASM build runs directly on the host (no container) via ci-slang-build.yml.
-  # Stays on GitHub-hosted ubuntu-22.04 for now: the GCP build image lacks the
-  # gcc host toolchain it needs (the native generators stage fails with
-  # CMAKE_CXX_COMPILER not set — no g++). Moving it requires either adding g++
-  # to the image or running the build in a container; tracked as a follow-up.
+  # WASM build runs directly on the host (no container) on the GCP build pool.
+  # The linux-cpu-runner image carries the gcc host toolchain (g++) the native
+  # generators build needs; emsdk is downloaded by the build itself. id-token is
+  # requested for the reusable workflow's GCP Workload Identity auth step (never
+  # part of the default GITHUB_TOKEN).
   build-linux-release-gcc-wasm:
     needs: [filter, wait-for-human-priority]
     if: >-
@@ -158,12 +158,16 @@ jobs:
       (needs.wait-for-human-priority.result == 'success' ||
        needs.wait-for-human-priority.result == 'skipped')
     uses: ./.github/workflows/ci-slang-build.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
     with:
       os: linux
       compiler: gcc
       platform: wasm
       config: release
-      runs-on: '["ubuntu-22.04"]'
+      runs-on: '["Linux", "self-hosted", "build", "GCP"]'
 
   # Sanitizer build+test (blocking via check-ci, runs on every PR). Runs in the
   # clang CI container (`--user root`, so no container-user concern) on the GCP


### PR DESCRIPTION
## Motivation

Moves one more job off the GitHub-hosted 20-concurrent-runner cap (which saturates at peak). `build-linux-release-gcc-wasm` previously ran on `ubuntu-22.04`. Follows the build-pool offloads in #11736/#11738 and the sanitizer move (#11749).

## Proposed solution

Route `build-linux-release-gcc-wasm` onto the self-hosted build pool (`["Linux", "self-hosted", "build", "GCP"]`).

The wasm build runs **directly on the host** (no container), with a two-stage build: a native-host *generators* build (needs the gcc host toolchain) followed by the `emcmake`/emscripten build. It self-downloads a pinned emsdk. Earlier attempts to move it failed because the build image lacked the host toolchain — first `cmake: command not found`, then `CMAKE_CXX_COMPILER not set` (no `g++`). The `linux-cpu-runner` image now carries `cmake` and `g++`, so the native stage builds.

The reusable workflow authenticates to GCP via Workload Identity, so the caller requests `id-token: write` explicitly (never part of the default `GITHUB_TOKEN`).

## Validation

Dispatched end-to-end on the GCP build pool: the job ran on a `linux-build-*` runner and **completed/success** — checkout, sccache, GCP auth, TypeScript install, and "Build Slang" (native generators + emscripten build + slang-wasm smoke test) all passed, artifact uploaded.

## Change summary

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | `build-linux-release-gcc-wasm` → `build,GCP` pool, with explicit `permissions: id-token: write`. |

---

pr: non-breaking