### PR TITLE
Fix #11664: diagnose operator name used as a variable name

### DIFF
--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -873,6 +873,13 @@ err(
 )
 
 err(
+    "operator-name-used-as-variable-name",
+    20020,
+    "operator name used as variable name",
+    span { loc = "location", message = "an operator name cannot be used as the name of a variable; an 'operator' declaration must be a function" }
+)
+
+err(
     "invalid-spirv-version",
     20012,
     "invalid SPIR-V version",

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -1405,12 +1405,21 @@ static NodeBase* parseModuleDeclarationDecl(Parser* parser, void* /*userData*/)
     return decl;
 }
 
-static NameLoc ParseDeclName(Parser* parser)
+// Parse a declaration name, which may be an ordinary identifier or an
+// `operator <op>` name. When `outIsValidOperatorName` is non-null, it is set to
+// true only if an `operator` keyword was followed by a *valid* operator token
+// (so a malformed `operator <garbage>`, which already reports `InvalidOperator`,
+// is not additionally flagged downstream).
+static NameLoc ParseDeclName(Parser* parser, bool* outIsValidOperatorName = nullptr)
 {
+    if (outIsValidOperatorName)
+        *outIsValidOperatorName = false;
+
     Token nameToken;
     if (AdvanceIf(parser, "operator"))
     {
         nameToken = parser->ReadToken();
+        bool isValidOperator = true;
         switch (nameToken.type)
         {
         case TokenType::OpAdd:
@@ -1466,8 +1475,12 @@ static NameLoc ParseDeclName(Parser* parser)
             parser->sink->diagnose(Diagnostics::InvalidOperator{
                 .op = nameToken.getContent(),
                 .location = nameToken.loc});
+            isValidOperator = false;
             break;
         }
+
+        if (outIsValidOperatorName)
+            *outIsValidOperatorName = isValidOperator;
 
         if (nameToken.type == TokenType::LParent)
             return NameLoc(getName(parser, "()"), nameToken.loc);
@@ -1497,6 +1510,11 @@ struct Declarator : RefObject
 struct NameDeclarator : Declarator
 {
     NameLoc nameAndLoc;
+
+    // True if the name came from `operator <op>` syntax. Such a name is only
+    // valid for a function declaration; using it for a variable is diagnosed in
+    // `CompleteVarDecl`.
+    bool isOperatorName = false;
 };
 
 // A declarator that declares a pointer type
@@ -1527,6 +1545,10 @@ struct DeclaratorInfo
     NameLoc nameAndLoc;
     Modifiers semantics;
     Expr* initializer = nullptr;
+
+    // True if `nameAndLoc` came from `operator <op>` syntax (see
+    // `NameDeclarator::isOperatorName`).
+    bool isOperatorName = false;
 };
 
 // Add a member declaration to its container, and ensure that its
@@ -2436,6 +2458,20 @@ static void CompleteVarDecl(Parser* parser, VarDeclBase* decl, DeclaratorInfo co
 {
     parser->FillPosition(decl);
 
+    // An `operator <op>` name only makes sense for a function declaration. If we
+    // reach here the declarator was completed as a variable (e.g.
+    // `int operator+ = 10;`), which is not valid; without this the malformed
+    // declaration is accepted silently and only surfaces as a confusing error at
+    // a later use site. `CompleteVarDecl` is shared with traditional parameter
+    // parsing, so exclude `ParamDecl` (whose "operator name used as a variable
+    // name" message would be inaccurate); a parameter named with an operator is a
+    // separate, rarer case left to its own handling.
+    if (declaratorInfo.isOperatorName && !as<ParamDecl>(decl))
+    {
+        parser->sink->diagnose(
+            Diagnostics::OperatorNameUsedAsVariableName{.location = declaratorInfo.nameAndLoc.loc});
+    }
+
     if (!declaratorInfo.nameAndLoc.name)
     {
         // HACK(tfoley): we always give a name, even if the declarator didn't include one... :(
@@ -2515,9 +2551,15 @@ static RefPtr<Declarator> parseDirectAbstractDeclarator(
     case TokenType::Identifier:
     case TokenType::CompletionRequest:
         {
+            // A valid `operator <op>` name is only legal when this declarator
+            // turns out to be a function. Remember whether `ParseDeclName`
+            // actually parsed a valid operator name so a later variable
+            // completion can reject it (see `CompleteVarDecl`). A malformed
+            // `operator <garbage>` already reports `InvalidOperator`, so it is
+            // not flagged again.
             auto nameDeclarator = new NameDeclarator();
             nameDeclarator->flavor = Declarator::Flavor::name;
-            nameDeclarator->nameAndLoc = ParseDeclName(parser);
+            nameDeclarator->nameAndLoc = ParseDeclName(parser, &nameDeclarator->isOperatorName);
             maybeDiagnoseKeywordUsedAsName(parser, nameDeclarator->nameAndLoc);
             declarator = nameDeclarator;
         }
@@ -2708,6 +2750,7 @@ static void UnwrapDeclarator(
             {
                 auto nameDeclarator = (NameDeclarator*)declarator.Ptr();
                 ioInfo->nameAndLoc = nameDeclarator->nameAndLoc;
+                ioInfo->isOperatorName = nameDeclarator->isOperatorName;
                 return;
             }
             break;

--- a/tests/diagnostics/operator-name-as-variable.slang
+++ b/tests/diagnostics/operator-name-as-variable.slang
@@ -1,0 +1,14 @@
+// Regression test for #11664: using an operator name (e.g. `operator+`) as the
+// name of a variable was accepted silently and only surfaced as a confusing
+// error at a later use site. It should be diagnosed at the declaration.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive):
+
+void computeMain()
+{
+    int operator+ = 10;
+    //CHECK: E20020
+
+    int operator*= = 20;
+    //CHECK: E20020
+}


### PR DESCRIPTION
## Motivation

An operator name could be used as the name of a variable and was accepted
silently:

```slang
void computeMain()
{
    int operator+ = 10;   // accepted with no diagnostic
}
```

The malformed declaration only surfaced later (and confusingly) at a use site —
e.g. `int a = 10 + 12;` then reported `no call operation found for type 'int'` —
or not at all. The expected behavior is a clear error at the declaration.

## Proposed solution

The C-style declarator parser (`ParseDeclName` in `slang-parser.cpp`) is shared
between function and variable declarations and accepts `operator <op>` names,
because at that point the parser does not yet know whether a parameter list
(making it a function) will follow. The fix records that a declarator's name came
from `operator` syntax, then rejects it once the declarator is completed as a
*variable* in `CompleteVarDecl` with a new diagnostic, `E20020`. Operator
*function* declarations (the only valid use of an `operator` name) flow through
`parseTraditionalFuncDecl` instead and are unaffected.

This is the principled layer: fixity/operator-ness is known at parse time, and
`CompleteVarDecl` is exactly the point where we have committed to "this is a
variable", so it is where an operator-named variable should be rejected.

## Change summary

| File | Change |
| --- | --- |
| `source/slang/slang-diagnostics.lua` | New `E20020` "operator name used as variable name". |
| `source/slang/slang-parser.cpp` | Record `isOperatorName` on `NameDeclarator`/`DeclaratorInfo` when the declarator name came from `operator` syntax; diagnose it in `CompleteVarDecl`. |
| `tests/diagnostics/operator-name-as-variable.slang` | New regression test for `operator+` and `operator*=` used as variable names. |

## Concepts and vocabulary

- **`ParseDeclName`** — parses a declarator's name, including `operator <op>`
  forms; shared by function and variable declaration parsing.
- **`CompleteVarDecl`** — finalizes a `VarDeclBase` once the parser has decided
  the declarator is a variable (no following parameter list), the natural place
  to reject an operator name.

## Process report

The only new state is a boolean `isOperatorName` threaded from the declarator
(`NameDeclarator`) into `DeclaratorInfo` and checked in `CompleteVarDecl`.
*Input-shape check:* the shape being rejected — a completed *variable*
declaration whose name originated from `operator` syntax — is genuinely invalid
input, not an accidental representation that an upstream producer should have
avoided: the parser legitimately cannot decide function-vs-variable until after
the name is parsed, so detecting the misuse at variable completion (rather than
forbidding the `operator` name earlier) is the correct layer. The flag is set by
peeking for the `operator` keyword at the single declarator-name parse site, so
no `ParseDeclName` callers change. Operator function declarations are unaffected
because they never reach `CompleteVarDecl`. Verified on a rebuilt debug compiler:
`int operator+ = 10;` and `int operator*= = 20;` now report `E20020` at the
declaration; user operator *function* declarations still compile; modern `let
operator+ : int = ...` still errors as before; and the full `tests/diagnostics/`
sweep passes plus the new test.