### PR TITLE
Fix #11297: diagnose String used on kernel C++/CUDA targets

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2087,7 +2087,12 @@ T __attachToNativeRef(NativeRef<T> nativeVal)
 //@public:
 
 /// Represents a string.
-/// This type can only be used on the CPU target.
+/// This type is backed by the Slang core runtime (`Slang::String`), which is
+/// available on host CPU targets (e.g. `-target host-cpp`) and the LLVM-backed
+/// CPU path (`-emit-cpu-via-llvm`). It is explicitly rejected when generating
+/// kernel C++/CUDA output (`-target cpp`, `-target cuda`, `-target ptx`); use
+/// `NativeString` (a null-terminated `const char*`) there instead. On other
+/// GPU/shader targets `String` is not a supported value type.
 __magic_type(StringType)
 __intrinsic_type($(kIROp_StringType))
 struct String

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -5331,6 +5331,13 @@ err(
 )
 
 err(
+    "string-type-not-supported-on-kernel-target",
+    55213,
+    "'String' is not supported on this target",
+    span { loc = "location", message = "the 'String' type and its operations are not supported when generating kernel code for this target; use 'NativeString' for a null-terminated string, or compile for a host target" }
+)
+
+err(
     "unsupported-recursion",
     55201,
     "recursion not allowed",

--- a/source/slang/slang-ir-check-unsupported-inst.cpp
+++ b/source/slang/slang-ir-check-unsupported-inst.cpp
@@ -81,6 +81,72 @@ static IRType* findUnstorableOpaqueHandleType(IRType* type)
     return findUnstorableOpaqueHandleType(type, visited);
 }
 
+// True if `target` is a C++/CUDA *kernel* output target. The `String` type is
+// implemented in terms of the Slang core runtime (`Slang::String`), which is
+// available for host C++ output and for the LLVM-backed CPU path, but not in the
+// C++/CUDA kernel preludes. Emitting a `String` value for one of these targets
+// would reference an undefined `String` type/method (issue #11297), so it must be
+// diagnosed instead. Host C++ and the LLVM CPU path are deliberately excluded
+// because they do provide a `String` runtime. (CUDA/PTX `String` usage is usually
+// also rejected earlier by capability checks, since `String`'s members are
+// `[require(cpp)]`; this is the backend-agnostic safety net.)
+static bool isKernelCPPOrCUDASourceTarget(TargetRequest* target)
+{
+    switch (target->getTarget())
+    {
+    case CodeGenTarget::CPPSource:
+    case CodeGenTarget::CPPHeader:
+    case CodeGenTarget::PyTorchCppBinding:
+    case CodeGenTarget::CUDASource:
+    case CodeGenTarget::CUDAHeader:
+    case CodeGenTarget::PTX:
+        return true;
+    default:
+        return false;
+    }
+}
+
+// True if `funcType` has any parameter or result of type `String`.
+static bool funcTypeReferencesStringType(IRFuncType* funcType)
+{
+    if (as<IRStringType>(funcType->getResultType()))
+        return true;
+    for (UInt i = 0; i < funcType->getParamCount(); i++)
+    {
+        if (as<IRStringType>(funcType->getParamType(i)))
+            return true;
+    }
+    return false;
+}
+
+// True if `inst` produces or consumes a `String` value that requires the (host-
+// only) `String` runtime. This is either an inst whose result type is `String`
+// (e.g. `MakeString`, or reading a `String` local), or a call to a function
+// whose signature takes/returns `String` (e.g. `String.getLength`).
+//
+// We must key a call on the *callee's parameter type*, not on its argument
+// values: a string literal `"..."` has type `String` even when it is implicitly
+// converted to a `NativeString` argument, so `NativeString.getLength("...")`
+// (which is supported) would be misflagged if we looked at argument types.
+// `NativeString.getLength` takes a `NativeString` parameter, so checking the
+// callee's signature correctly distinguishes it from `String.getLength`.
+static bool instReferencesStringType(IRInst* inst)
+{
+    if (as<IRStringType>(inst->getDataType()))
+        return true;
+
+    if (auto call = as<IRCall>(inst))
+    {
+        if (auto callee = call->getCalleeUse()->get())
+        {
+            if (auto funcType = as<IRFuncType>(callee->getFullType()))
+                return funcTypeReferencesStringType(funcType);
+        }
+    }
+
+    return false;
+}
+
 void checkUnsupportedInst(TargetRequest* target, IRFunc* func, DiagnosticSink* sink)
 {
     // Khronos targets (SPIR-V and GLSL) and WGSL cannot place an
@@ -92,6 +158,12 @@ void checkUnsupportedInst(TargetRequest* target, IRFunc* func, DiagnosticSink* s
     // (issue #10526, typically from selecting or returning a resource through
     // control flow); reject it with a diagnostic rather than emitting invalid code.
     const bool rejectOpaqueLocals = isKhronosTarget(target) || isWGPUTarget(target);
+
+    // The `String` type has no runtime representation in kernel C++/CUDA output;
+    // a use there (e.g. `let s : String = "1"; s.getLength();`) would otherwise
+    // emit uncompilable code referencing an undefined `String`/method instead of
+    // any diagnostic.
+    const bool rejectString = isKernelCPPOrCUDASourceTarget(target);
 
     for (auto block : func->getBlocks())
     {
@@ -120,6 +192,16 @@ void checkUnsupportedInst(TargetRequest* target, IRFunc* func, DiagnosticSink* s
                     }
                 }
                 break;
+            }
+
+            // A `String` value has no valid lowering for a kernel C++/CUDA
+            // target. Diagnose a `String`-typed result or a call into a
+            // `String`-signature function (e.g. `String.getLength`) rather than
+            // emitting uncompilable code referencing an undefined `String`.
+            if (rejectString && instReferencesStringType(inst))
+            {
+                auto loc = inst->sourceLoc.isValid() ? inst->sourceLoc : findFirstUseLoc(inst);
+                sink->diagnose(Diagnostics::StringTypeNotSupportedOnKernelTarget{.location = loc});
             }
         }
     }

--- a/tests/diagnostics/string-type-unsupported-on-kernel-cpp.slang
+++ b/tests/diagnostics/string-type-unsupported-on-kernel-cpp.slang
@@ -1,0 +1,19 @@
+// Regression test for #11297: using the `String` type (and its member
+// operations such as `getLength`) when generating kernel C++ code produced
+// uncompilable output referencing an undefined `String` type/method, with no
+// diagnostic. The `String` type has no runtime representation in kernel
+// C++/CUDA output, so its use must be diagnosed (E55213) at the use site.
+//
+// `NativeString` (which lowers to `const char*`) remains the supported way to
+// work with strings on these targets.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK,non-exhaustive): -target cpp -entry computeMain -stage compute
+
+RWStructuredBuffer<int64_t> output;
+
+void computeMain()
+{
+    let str : String = "123";
+    output[0] = str.getLength();
+//CHECK:                     ^ E55213
+}


### PR DESCRIPTION
## Motivation

Using the `String` type (or a `String` member such as `getLength`) when
generating kernel C++ produced uncompilable output, with no diagnostic:

```slang
RWStructuredBuffer<int64_t> output;
void computeMain()
{
    let str : String = "123";
    output[0] = str.getLength();   // emits  "123".getLength()  -> invalid C++
}
```

`slangc -target cpp` emitted `int64_t _S3 = "123".getLength();`, which does not
compile: there is no `String` runtime class in the kernel C++ prelude, so neither
the `String` type nor its `.getLength()` method exists. `String.getLength` is a
target intrinsic (`[targetIntrinsic(cpp, ".getLength")]`) that emits
`<operand>.getLength()`, but `String` has no kernel representation, so the result
is junk.

## Proposed solution

`String` is implemented on top of the Slang core runtime (`Slang::String`),
which is present for host C++ output and the LLVM-backed CPU path but *not* in
the textual C++/CUDA kernel preludes. So the principled fix is to **diagnose**
`String` usage for those kernel-source targets instead of emitting invalid code.

This is added to the existing per-target validation pass
`checkUnsupportedInst` (`slang-ir-check-unsupported-inst.cpp`), which already
rejects other un-lowerable shapes (opaque locals on Khronos, non-builtin
vector/matrix element types). When the target is a textual C++/CUDA kernel
source target, any inst whose result type is `String`, or any call into a
function whose signature takes/returns `String`, raises a new `E55213` at the
use site.

`NativeString` (which lowers to `const char*`) keeps working — it is the
supported way to use strings on these targets — and host-cpp / `-llvm` keep
working because they provide a real `String` runtime.

## Change summary

| File | Change |
| --- | --- |
| `source/slang/slang-diagnostics.lua` | New `E55213` "'String' is not supported on this target". |
| `source/slang/slang-ir-check-unsupported-inst.cpp` | Detect `String` results / `String`-signature calls on textual C++/CUDA kernel targets and diagnose. |
| `tests/diagnostics/string-type-unsupported-on-kernel-cpp.slang` | New regression test (`-target cpp`). |

## Concepts and vocabulary

- **`String` vs `NativeString`** — `NativeString` is the primitive null-terminated
  `const char*`; `String` is a higher-level type backed by the Slang core runtime,
  which only exists for host/LLVM targets.
- **`checkUnsupportedInst`** — a per-target IR validation pass that rejects shapes
  with no valid lowering for the selected backend, the natural home for this check.

## Process report

The new detection keys a call on the **callee's parameter/return types**, not on
its argument values. *Input-shape check:* a string literal `"..."` has type
`String` in the IR even when it is implicitly converted to a `NativeString`
argument, so checking argument types would misflag the supported
`NativeString.getLength("...")`. The callee's *signature* is the correct,
principled discriminator: `NativeString.getLength` takes a `NativeString`
parameter while `String.getLength` takes a `String`, so keying on the signature
distinguishes supported from unsupported uses. The set of affected targets is
restricted to the textual C++/CUDA kernel source targets
(`CPPSource`/`CPPHeader`/`PyTorchCppBinding`/`CUDASource`/`CUDAHeader`); host-cpp
and `-llvm` are excluded because they ship a `String` runtime (verified:
`tests/llvm/string-type.slang`, which uses `String`/`sizeof(String)`, still
passes). Verified on a rebuilt debug compiler: the issue repro now reports
`E55213` at the use site; `NativeString` on `-target cpp` and `String` on
`-target host-cpp` both still compile; and the full `tests/diagnostics/`,
`tests/llvm/`, and string-using tests pass.

Closes #11297.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear error when `String` is used while generating kernel output for C++/CUDA targets.
  * Error reporting now points to the most relevant source location for easier debugging.

* **Documentation**
  * Expanded `String` type guidance to clarify where it is supported and when to use `NativeString` instead.

* **Tests**
  * Added a regression test covering `String` usage in kernel C++ generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->