### PR TITLE
Fix stale test debug callback

### DIFF
--- a/tools/gfx-unit-test/scoped-core-debug-callback-test.cpp
+++ b/tools/gfx-unit-test/scoped-core-debug-callback-test.cpp
@@ -1,11 +1,28 @@
 #include "../render-test/slang-support.h"
 #include "unit-test/slang-unit-test.h"
 
+#include <atomic>
+#include <thread>
+
 namespace
 {
 void emitError(renderer_test::CoreToRHIDebugBridge& bridge, const char* message)
 {
     bridge.handleMessage(rhi::DebugMessageType::Error, rhi::DebugMessageSource::Layer, message);
+}
+
+renderer_test::CoreToRHIDebugBridge& getStaticBridgeAfterStackCallbackScope()
+{
+    static renderer_test::CoreToRHIDebugBridge bridge;
+
+    renderer_test::CoreDebugCallback callback;
+    {
+        renderer_test::ScopedCoreDebugCallback scopedDebugCallback(bridge, &callback);
+        emitError(bridge, "static scope");
+    }
+    SLANG_CHECK(callback.getString() == "static scope\n");
+
+    return bridge;
 }
 } // namespace
 
@@ -80,4 +97,63 @@ SLANG_UNIT_TEST(scopedCoreDebugCallbackClearsBridgeOnException)
 
     SLANG_CHECK(firstCallback.getString() == "before throw\n");
     SLANG_CHECK(secondCallback.getString() == "next iteration\n");
+}
+
+SLANG_UNIT_TEST(scopedCoreDebugCallbackClearsStaticBridgeAfterStackCallback)
+{
+    renderer_test::CoreToRHIDebugBridge& bridge = getStaticBridgeAfterStackCallbackScope();
+
+    emitError(bridge, "after stack callback");
+
+    renderer_test::CoreDebugCallback nextCallback;
+    {
+        renderer_test::ScopedCoreDebugCallback scopedDebugCallback(bridge, &nextCallback);
+        emitError(bridge, "next invocation");
+    }
+    SLANG_CHECK(nextCallback.getString() == "next invocation\n");
+}
+
+SLANG_UNIT_TEST(coreDebugBridgeHandlesConcurrentMessages)
+{
+    static constexpr int kThreadCount = 4;
+    static constexpr int kMessageCount = 64;
+
+    renderer_test::CoreToRHIDebugBridge bridge;
+    renderer_test::CoreDebugCallback callback;
+    {
+        renderer_test::ScopedCoreDebugCallback scopedDebugCallback(bridge, &callback);
+
+        std::atomic<bool> keepReading(true);
+        std::thread readerThread(
+            [&]()
+            {
+                while (keepReading.load(std::memory_order_acquire))
+                {
+                    callback.getString();
+                }
+            });
+
+        std::thread writerThreads[kThreadCount];
+        for (int threadIndex = 0; threadIndex < kThreadCount; ++threadIndex)
+        {
+            writerThreads[threadIndex] = std::thread(
+                [&]()
+                {
+                    for (int messageIndex = 0; messageIndex < kMessageCount; ++messageIndex)
+                    {
+                        emitError(bridge, "x");
+                    }
+                });
+        }
+
+        for (auto& writerThread : writerThreads)
+        {
+            writerThread.join();
+        }
+
+        keepReading.store(false, std::memory_order_release);
+        readerThread.join();
+    }
+
+    SLANG_CHECK(callback.getString().getLength() == kThreadCount * kMessageCount * 2);
 }

--- a/tools/gfx-unit-test/scoped-core-debug-callback-test.cpp
+++ b/tools/gfx-unit-test/scoped-core-debug-callback-test.cpp
@@ -1,0 +1,51 @@
+#include "../render-test/slang-support.h"
+
+#include "unit-test/slang-unit-test.h"
+
+namespace
+{
+void emitError(renderer_test::CoreToRHIDebugBridge& bridge, const char* message)
+{
+    bridge.handleMessage(rhi::DebugMessageType::Error, rhi::DebugMessageSource::Layer, message);
+}
+} // namespace
+
+SLANG_UNIT_TEST(scopedCoreDebugCallbackClearsBridgeOnExit)
+{
+    renderer_test::CoreToRHIDebugBridge bridge;
+
+    {
+        renderer_test::CoreDebugCallback callback;
+        {
+            renderer_test::ScopedCoreDebugCallback scopedDebugCallback(bridge, &callback);
+            emitError(bridge, "inside scope");
+            SLANG_CHECK(callback.getString() == "inside scope\n");
+        }
+
+        emitError(bridge, "after scope");
+        SLANG_CHECK(callback.getString() == "inside scope\n");
+    }
+
+    emitError(bridge, "after callback");
+    SLANG_CHECK(true);
+}
+
+SLANG_UNIT_TEST(scopedCoreDebugCallbackDoesNotLeakAcrossScopes)
+{
+    renderer_test::CoreToRHIDebugBridge bridge;
+    renderer_test::CoreDebugCallback firstCallback;
+    renderer_test::CoreDebugCallback secondCallback;
+
+    {
+        renderer_test::ScopedCoreDebugCallback scopedDebugCallback(bridge, &firstCallback);
+        emitError(bridge, "first");
+    }
+
+    {
+        renderer_test::ScopedCoreDebugCallback scopedDebugCallback(bridge, &secondCallback);
+        emitError(bridge, "second");
+    }
+
+    SLANG_CHECK(firstCallback.getString() == "first\n");
+    SLANG_CHECK(secondCallback.getString() == "second\n");
+}

--- a/tools/gfx-unit-test/scoped-core-debug-callback-test.cpp
+++ b/tools/gfx-unit-test/scoped-core-debug-callback-test.cpp
@@ -11,18 +11,18 @@ void emitError(renderer_test::CoreToRHIDebugBridge& bridge, const char* message)
     bridge.handleMessage(rhi::DebugMessageType::Error, rhi::DebugMessageSource::Layer, message);
 }
 
-renderer_test::CoreToRHIDebugBridge& getStaticBridgeAfterStackCallbackScope()
+renderer_test::CoreToRHIDebugBridge* getRetainedBridgeAfterStackCallbackScope()
 {
-    static renderer_test::CoreToRHIDebugBridge bridge;
+    auto bridge = renderer_test::createRetainedCoreToRHIDebugBridge();
 
     renderer_test::CoreDebugCallback callback;
     {
-        renderer_test::ScopedCoreDebugCallback scopedDebugCallback(bridge, &callback);
-        emitError(bridge, "static scope");
+        renderer_test::ScopedCoreDebugCallback scopedDebugCallback(*bridge, &callback);
+        emitError(*bridge, "retained scope");
     }
-    SLANG_CHECK(callback.getString() == "static scope\n");
+    SLANG_CHECK(callback.getString() == "retained scope\n");
 
-    return bridge;
+    return bridge.Ptr();
 }
 } // namespace
 
@@ -99,16 +99,16 @@ SLANG_UNIT_TEST(scopedCoreDebugCallbackClearsBridgeOnException)
     SLANG_CHECK(secondCallback.getString() == "next iteration\n");
 }
 
-SLANG_UNIT_TEST(scopedCoreDebugCallbackClearsStaticBridgeAfterStackCallback)
+SLANG_UNIT_TEST(scopedCoreDebugCallbackSeparatesRetainedBridgeScopes)
 {
-    renderer_test::CoreToRHIDebugBridge& bridge = getStaticBridgeAfterStackCallbackScope();
-
-    emitError(bridge, "after stack callback");
+    renderer_test::CoreToRHIDebugBridge* oldBridge = getRetainedBridgeAfterStackCallbackScope();
+    auto nextBridge = renderer_test::createRetainedCoreToRHIDebugBridge();
 
     renderer_test::CoreDebugCallback nextCallback;
     {
-        renderer_test::ScopedCoreDebugCallback scopedDebugCallback(bridge, &nextCallback);
-        emitError(bridge, "next invocation");
+        renderer_test::ScopedCoreDebugCallback scopedDebugCallback(*nextBridge, &nextCallback);
+        emitError(*oldBridge, "after stack callback");
+        emitError(*nextBridge, "next invocation");
     }
     SLANG_CHECK(nextCallback.getString() == "next invocation\n");
 }
@@ -116,44 +116,61 @@ SLANG_UNIT_TEST(scopedCoreDebugCallbackClearsStaticBridgeAfterStackCallback)
 SLANG_UNIT_TEST(coreDebugBridgeHandlesConcurrentMessages)
 {
     static constexpr int kThreadCount = 4;
-    static constexpr int kMessageCount = 64;
+    static constexpr int kMessageCount = 1024;
 
     renderer_test::CoreToRHIDebugBridge bridge;
     renderer_test::CoreDebugCallback callback;
-    {
-        renderer_test::ScopedCoreDebugCallback scopedDebugCallback(bridge, &callback);
+    std::atomic<bool> startWriting(false);
+    std::atomic<bool> keepReading(true);
 
-        std::atomic<bool> keepReading(true);
-        std::thread readerThread(
+    std::thread readerThread(
+        [&]()
+        {
+            while (keepReading.load(std::memory_order_acquire))
+            {
+                callback.getString();
+            }
+        });
+
+    std::thread writerThreads[kThreadCount];
+    for (int threadIndex = 0; threadIndex < kThreadCount; ++threadIndex)
+    {
+        writerThreads[threadIndex] = std::thread(
             [&]()
             {
-                while (keepReading.load(std::memory_order_acquire))
+                while (!startWriting.load(std::memory_order_acquire))
                 {
-                    callback.getString();
+                    std::this_thread::yield();
+                }
+
+                for (int messageIndex = 0; messageIndex < kMessageCount; ++messageIndex)
+                {
+                    emitError(bridge, "x");
                 }
             });
-
-        std::thread writerThreads[kThreadCount];
-        for (int threadIndex = 0; threadIndex < kThreadCount; ++threadIndex)
-        {
-            writerThreads[threadIndex] = std::thread(
-                [&]()
-                {
-                    for (int messageIndex = 0; messageIndex < kMessageCount; ++messageIndex)
-                    {
-                        emitError(bridge, "x");
-                    }
-                });
-        }
-
-        for (auto& writerThread : writerThreads)
-        {
-            writerThread.join();
-        }
-
-        keepReading.store(false, std::memory_order_release);
-        readerThread.join();
     }
 
-    SLANG_CHECK(callback.getString().getLength() == kThreadCount * kMessageCount * 2);
+    {
+        renderer_test::ScopedCoreDebugCallback scopedDebugCallback(bridge, &callback);
+        startWriting.store(true, std::memory_order_release);
+        for (int spinCount = 0; spinCount < 100000 && callback.getString().getLength() == 0;
+             ++spinCount)
+        {
+            std::this_thread::yield();
+        }
+        SLANG_CHECK(callback.getString().getLength() > 0);
+    }
+
+    for (auto& writerThread : writerThreads)
+    {
+        writerThread.join();
+    }
+
+    keepReading.store(false, std::memory_order_release);
+    readerThread.join();
+
+    auto capturedLength = callback.getString().getLength();
+    SLANG_CHECK(capturedLength > 0);
+    SLANG_CHECK(capturedLength <= kThreadCount * kMessageCount * 2);
+    SLANG_CHECK((capturedLength % 2) == 0);
 }

--- a/tools/gfx-unit-test/scoped-core-debug-callback-test.cpp
+++ b/tools/gfx-unit-test/scoped-core-debug-callback-test.cpp
@@ -1,5 +1,4 @@
 #include "../render-test/slang-support.h"
-
 #include "unit-test/slang-unit-test.h"
 
 namespace
@@ -27,7 +26,13 @@ SLANG_UNIT_TEST(scopedCoreDebugCallbackClearsBridgeOnExit)
     }
 
     emitError(bridge, "after callback");
-    SLANG_CHECK(true);
+
+    renderer_test::CoreDebugCallback nextCallback;
+    {
+        renderer_test::ScopedCoreDebugCallback scopedDebugCallback(bridge, &nextCallback);
+        emitError(bridge, "next scope");
+    }
+    SLANG_CHECK(nextCallback.getString() == "next scope\n");
 }
 
 SLANG_UNIT_TEST(scopedCoreDebugCallbackDoesNotLeakAcrossScopes)
@@ -48,4 +53,31 @@ SLANG_UNIT_TEST(scopedCoreDebugCallbackDoesNotLeakAcrossScopes)
 
     SLANG_CHECK(firstCallback.getString() == "first\n");
     SLANG_CHECK(secondCallback.getString() == "second\n");
+}
+
+SLANG_UNIT_TEST(scopedCoreDebugCallbackClearsBridgeOnException)
+{
+    renderer_test::CoreToRHIDebugBridge bridge;
+    renderer_test::CoreDebugCallback firstCallback;
+
+    try
+    {
+        renderer_test::ScopedCoreDebugCallback scopedDebugCallback(bridge, &firstCallback);
+        emitError(bridge, "before throw");
+        throw 1;
+    }
+    catch (...)
+    {
+    }
+
+    emitError(bridge, "after exception");
+
+    renderer_test::CoreDebugCallback secondCallback;
+    {
+        renderer_test::ScopedCoreDebugCallback scopedDebugCallback(bridge, &secondCallback);
+        emitError(bridge, "next iteration");
+    }
+
+    SLANG_CHECK(firstCallback.getString() == "before throw\n");
+    SLANG_CHECK(secondCallback.getString() == "next iteration\n");
 }

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -1770,7 +1770,9 @@ static SlangResult _innerMain(
     }
 
     static renderer_test::CoreToRHIDebugBridge debugCallback;
-    debugCallback.setCoreCallback(stdWriters->getDebugCallback());
+    renderer_test::ScopedCoreDebugCallback scopedDebugCallback(
+        debugCallback,
+        stdWriters->getDebugCallback());
 
     // Use the profile name set on options if set
     input.profile = options.profileName.getLength() ? options.profileName : input.profile;

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -1769,9 +1769,9 @@ static SlangResult _innerMain(
         }
     }
 
-    static renderer_test::CoreToRHIDebugBridge debugCallback;
+    auto debugCallback = renderer_test::createRetainedCoreToRHIDebugBridge();
     renderer_test::ScopedCoreDebugCallback scopedDebugCallback(
-        debugCallback,
+        *debugCallback,
         stdWriters->getDebugCallback());
 
     // Use the profile name set on options if set
@@ -1909,7 +1909,7 @@ static SlangResult _innerMain(
         desc.deviceType = options.deviceType;
 
         desc.enableValidation = options.enableDebugLayers;
-        desc.debugCallback = &debugCallback;
+        desc.debugCallback = debugCallback.Ptr();
 
         desc.slang.lineDirectiveMode = SLANG_LINE_DIRECTIVE_MODE_NONE;
         if (options.generateSPIRVDirectly)

--- a/tools/render-test/slang-support.h
+++ b/tools/render-test/slang-support.h
@@ -1,6 +1,7 @@
 // slang-support.h
 #pragma once
 
+#include "core/slang-basic.h"
 #include "core/slang-std-writers.h"
 #include "options.h"
 #include "shader-input-layout.h"
@@ -17,7 +18,7 @@ namespace renderer_test
 /// RHI backends may invoke debug callbacks from backend or driver threads, so
 /// binding changes and forwarded messages are serialized.
 /// TODO: We should replace rhi::IDebugCallback with Slang::IDebugCallback.
-class CoreToRHIDebugBridge : public rhi::IDebugCallback
+class CoreToRHIDebugBridge : public Slang::RefObject, public rhi::IDebugCallback
 {
 public:
     void setCoreCallback(Slang::IDebugCallback* coreCallback)
@@ -47,6 +48,24 @@ private:
     std::mutex m_mutex;
     Slang::IDebugCallback* m_coreCallback = nullptr;
 };
+
+/// Creates an RHI debug bridge that remains alive for process teardown.
+///
+/// Device descriptors store debug callbacks as raw pointers, and retained RHI
+/// state may emit messages after the harness invocation that created a device.
+/// Each invocation gets a distinct bridge so old emitters can only reach their
+/// own cleared bridge, not the next invocation's callback.
+inline Slang::RefPtr<CoreToRHIDebugBridge> createRetainedCoreToRHIDebugBridge()
+{
+    static std::mutex* mutex = new std::mutex;
+    static Slang::List<Slang::RefPtr<CoreToRHIDebugBridge>>* bridges =
+        new Slang::List<Slang::RefPtr<CoreToRHIDebugBridge>>();
+
+    Slang::RefPtr<CoreToRHIDebugBridge> bridge = new CoreToRHIDebugBridge();
+    std::lock_guard<std::mutex> lock(*mutex);
+    bridges->add(bridge);
+    return bridge;
+}
 
 /// Binds an RHI debug bridge to a core callback for one active test invocation.
 ///

--- a/tools/render-test/slang-support.h
+++ b/tools/render-test/slang-support.h
@@ -37,6 +37,31 @@ private:
     Slang::IDebugCallback* m_coreCallback = nullptr;
 };
 
+/// Binds an RHI debug bridge to a core callback for one active test invocation.
+class ScopedCoreDebugCallback
+{
+public:
+    ScopedCoreDebugCallback(CoreToRHIDebugBridge& bridge, Slang::IDebugCallback* coreCallback)
+        : m_bridge(&bridge)
+    {
+        m_bridge->setCoreCallback(coreCallback);
+    }
+
+    ~ScopedCoreDebugCallback()
+    {
+        if (m_bridge)
+        {
+            m_bridge->setCoreCallback(nullptr);
+        }
+    }
+
+    ScopedCoreDebugCallback(const ScopedCoreDebugCallback&) = delete;
+    ScopedCoreDebugCallback& operator=(const ScopedCoreDebugCallback&) = delete;
+
+private:
+    CoreToRHIDebugBridge* m_bridge;
+};
+
 /// Core debug callback that captures debug messages in a string buffer
 class CoreDebugCallback : public Slang::IDebugCallback
 {

--- a/tools/render-test/slang-support.h
+++ b/tools/render-test/slang-support.h
@@ -6,6 +6,7 @@
 #include "shader-input-layout.h"
 #include "slang.h"
 
+#include <mutex>
 #include <slang-rhi.h>
 
 namespace renderer_test
@@ -17,32 +18,40 @@ namespace renderer_test
 class CoreToRHIDebugBridge : public rhi::IDebugCallback
 {
 public:
-    void setCoreCallback(Slang::IDebugCallback* coreCallback) { m_coreCallback = coreCallback; }
+    void setCoreCallback(Slang::IDebugCallback* coreCallback)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_coreCallback = coreCallback;
+    }
 
     virtual SLANG_NO_THROW void SLANG_MCALL handleMessage(
         rhi::DebugMessageType type,
         rhi::DebugMessageSource source,
         const char* message) override
     {
-        if (m_coreCallback)
+        std::lock_guard<std::mutex> lock(m_mutex);
+
+        auto coreCallback = m_coreCallback;
+        if (coreCallback)
         {
             // Convert RHI types to core types
             Slang::DebugMessageType coreType = static_cast<Slang::DebugMessageType>(type);
             Slang::DebugMessageSource coreSource = static_cast<Slang::DebugMessageSource>(source);
-            m_coreCallback->handleMessage(coreType, coreSource, message);
+            coreCallback->handleMessage(coreType, coreSource, message);
         }
     }
 
 private:
+    std::mutex m_mutex;
     Slang::IDebugCallback* m_coreCallback = nullptr;
 };
 
 /// Binds an RHI debug bridge to a core callback for one active test invocation.
 ///
 /// The bridge may be retained by RHI device state after this scope exits, but the
-/// per-test core callback must not be retained. Messages that arrive after the
-/// scope exits are intentionally dropped by the bridge instead of being written
-/// to a dead callback or the next test's callback.
+/// per-test core callback must not be retained. Messages that arrive while no
+/// scoped callback is active are intentionally dropped by the bridge instead of
+/// being written to dead callback storage.
 class ScopedCoreDebugCallback
 {
 public:
@@ -75,6 +84,7 @@ public:
         // Only capture error messages
         if (type == Slang::DebugMessageType::Error)
         {
+            std::lock_guard<std::mutex> lock(m_mutex);
             m_buf << message;
             if (message[strlen(message) - 1] != '\n')
             {
@@ -83,10 +93,20 @@ public:
         }
     }
 
-    void clear() { m_buf.clear(); }
-    Slang::String getString() { return m_buf.toString(); }
+    void clear()
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_buf.clear();
+    }
+
+    Slang::String getString()
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_buf.toString();
+    }
 
 private:
+    std::mutex m_mutex;
     Slang::StringBuilder m_buf;
 };
 

--- a/tools/render-test/slang-support.h
+++ b/tools/render-test/slang-support.h
@@ -12,8 +12,10 @@
 namespace renderer_test
 {
 
-/// Bridge from core debug callback to RHI debug callback
-/// This allows core callbacks to receive messages from RHI systems
+/// Bridge from core debug callback to RHI debug callback.
+///
+/// RHI backends may invoke debug callbacks from backend or driver threads, so
+/// binding changes and forwarded messages are serialized.
 /// TODO: We should replace rhi::IDebugCallback with Slang::IDebugCallback.
 class CoreToRHIDebugBridge : public rhi::IDebugCallback
 {
@@ -70,7 +72,10 @@ private:
     CoreToRHIDebugBridge& m_bridge;
 };
 
-/// Core debug callback that captures debug messages in a string buffer
+/// Core debug callback that captures debug messages in a string buffer.
+///
+/// Message capture is thread-safe so backend debug callbacks can report while
+/// the test harness reads the collected messages.
 class CoreDebugCallback : public Slang::IDebugCallback
 {
 public:

--- a/tools/render-test/slang-support.h
+++ b/tools/render-test/slang-support.h
@@ -42,24 +42,18 @@ class ScopedCoreDebugCallback
 {
 public:
     ScopedCoreDebugCallback(CoreToRHIDebugBridge& bridge, Slang::IDebugCallback* coreCallback)
-        : m_bridge(&bridge)
+        : m_bridge(bridge)
     {
-        m_bridge->setCoreCallback(coreCallback);
+        m_bridge.setCoreCallback(coreCallback);
     }
 
-    ~ScopedCoreDebugCallback()
-    {
-        if (m_bridge)
-        {
-            m_bridge->setCoreCallback(nullptr);
-        }
-    }
+    ~ScopedCoreDebugCallback() { m_bridge.setCoreCallback(nullptr); }
 
     ScopedCoreDebugCallback(const ScopedCoreDebugCallback&) = delete;
     ScopedCoreDebugCallback& operator=(const ScopedCoreDebugCallback&) = delete;
 
 private:
-    CoreToRHIDebugBridge* m_bridge;
+    CoreToRHIDebugBridge& m_bridge;
 };
 
 /// Core debug callback that captures debug messages in a string buffer

--- a/tools/render-test/slang-support.h
+++ b/tools/render-test/slang-support.h
@@ -38,6 +38,11 @@ private:
 };
 
 /// Binds an RHI debug bridge to a core callback for one active test invocation.
+///
+/// The bridge may be retained by RHI device state after this scope exits, but the
+/// per-test core callback must not be retained. Messages that arrive after the
+/// scope exits are intentionally dropped by the bridge instead of being written
+/// to a dead callback or the next test's callback.
 class ScopedCoreDebugCallback
 {
 public:

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1876,6 +1876,11 @@ String getOutput(const ExecuteResult& exeRes, bool removeEmbeddedSource = false)
     return actualOutputBuilder.produceString();
 }
 
+static bool _hasDebugLayerError(const ExecuteResult& exeRes)
+{
+    return exeRes.debugLayer.getLength() > 0;
+}
+
 // Finds the specialized or default path for expected data for a test.
 // If neither are found, will return an empty string
 String findExpectedPath(const TestInput& input, const char* postFix)
@@ -2713,7 +2718,7 @@ TestResult runSimpleTest(TestContext* context, TestInput& input)
         context,
         input,
         actualOutput,
-        false,
+        _hasDebugLayerError(exeRes),
         "result code = 0\nstandard error = {\n}\nstandard output = {\n}\n",
         [&input](auto e, auto a) { return _areResultsEqual(input.testOptions->type, e, a); });
 }
@@ -2827,7 +2832,7 @@ TestResult runInterpreterTest(TestContext* context, TestInput& input)
         context,
         input,
         actualOutput,
-        false,
+        _hasDebugLayerError(exeRes),
         "result code = 0\nstandard error = {\n}\nstandard output = {\n}\n",
         [&input](auto e, auto a) { return _areResultsEqual(input.testOptions->type, e, a); });
 }
@@ -2862,7 +2867,7 @@ TestResult runDispatcherTest(TestContext* context, TestInput& input)
         context,
         input,
         actualOutput,
-        false,
+        _hasDebugLayerError(exeRes),
         "result code = 0\nstandard error = {\n}\nstandard output = {\n}\n",
         [&input](auto e, auto a) { return _areResultsEqual(input.testOptions->type, e, a); });
 }
@@ -3061,7 +3066,11 @@ TestResult runReflectionTest(TestContext* context, TestInput& input)
         }
     }
 
-    return _validateOutput(context, input, actualOutput);
+    return _validateOutput(
+        context,
+        input,
+        actualOutput,
+        _hasDebugLayerError(exeRes));
 }
 
 static String _calcSummary(IArtifactDiagnostics* inDiagnostics)
@@ -3719,7 +3728,11 @@ static TestResult _runHLSLComparisonTest(
     // Always fail if the compilation produced a failure, just
     // to catch situations where, e.g., command-line options parsing
     // caused the same error in both the Slang and fxc cases.
-    return _validateOutput(context, input, actualOutput, resultCode != 0);
+    return _validateOutput(
+        context,
+        input,
+        actualOutput,
+        resultCode != 0 || _hasDebugLayerError(exeRes));
 }
 
 static TestResult runDXBCComparisonTest(TestContext* context, TestInput& input)
@@ -4112,7 +4125,7 @@ TestResult runComputeComparisonImpl(
         context,
         input,
         actualOutput,
-        false,
+        _hasDebugLayerError(exeRes),
         "result code = 0\nstandard error = {\n}\nstandard output = {\n}\n");
 
     // check against reference output
@@ -5556,8 +5569,7 @@ static SlangResult runUnitTestModule(
         return SLANG_FAIL;
 
     renderer_test::CoreDebugCallback coreDebugCallback;
-    renderer_test::CoreToRHIDebugBridge rhiDebugBridge;
-    rhiDebugBridge.setCoreCallback(&coreDebugCallback);
+    static renderer_test::CoreToRHIDebugBridge rhiDebugBridge;
 
     UnitTestContext unitTestContext;
     unitTestContext.slangGlobalSession = context->getSession();
@@ -5687,6 +5699,9 @@ static SlangResult runUnitTestModule(
 
             // Clear any previous debug messages
             coreDebugCallback.clear();
+            renderer_test::ScopedCoreDebugCallback scopedDebugCallback(
+                rhiDebugBridge,
+                &coreDebugCallback);
 
             try
             {

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -5556,6 +5556,8 @@ static SlangResult runUnitTestModule(
         return SLANG_FAIL;
 
     renderer_test::CoreDebugCallback coreDebugCallback;
+    // RHI state can outlive a unit-test invocation, so the bridge must outlive
+    // the stack callback whose binding is controlled below.
     static renderer_test::CoreToRHIDebugBridge rhiDebugBridge;
 
     UnitTestContext unitTestContext;

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1876,11 +1876,6 @@ String getOutput(const ExecuteResult& exeRes, bool removeEmbeddedSource = false)
     return actualOutputBuilder.produceString();
 }
 
-static bool _hasDebugLayerError(const ExecuteResult& exeRes)
-{
-    return exeRes.debugLayer.getLength() > 0;
-}
-
 // Finds the specialized or default path for expected data for a test.
 // If neither are found, will return an empty string
 String findExpectedPath(const TestInput& input, const char* postFix)
@@ -2718,7 +2713,7 @@ TestResult runSimpleTest(TestContext* context, TestInput& input)
         context,
         input,
         actualOutput,
-        _hasDebugLayerError(exeRes),
+        false,
         "result code = 0\nstandard error = {\n}\nstandard output = {\n}\n",
         [&input](auto e, auto a) { return _areResultsEqual(input.testOptions->type, e, a); });
 }
@@ -2832,7 +2827,7 @@ TestResult runInterpreterTest(TestContext* context, TestInput& input)
         context,
         input,
         actualOutput,
-        _hasDebugLayerError(exeRes),
+        false,
         "result code = 0\nstandard error = {\n}\nstandard output = {\n}\n",
         [&input](auto e, auto a) { return _areResultsEqual(input.testOptions->type, e, a); });
 }
@@ -2867,7 +2862,7 @@ TestResult runDispatcherTest(TestContext* context, TestInput& input)
         context,
         input,
         actualOutput,
-        _hasDebugLayerError(exeRes),
+        false,
         "result code = 0\nstandard error = {\n}\nstandard output = {\n}\n",
         [&input](auto e, auto a) { return _areResultsEqual(input.testOptions->type, e, a); });
 }
@@ -3066,11 +3061,7 @@ TestResult runReflectionTest(TestContext* context, TestInput& input)
         }
     }
 
-    return _validateOutput(
-        context,
-        input,
-        actualOutput,
-        _hasDebugLayerError(exeRes));
+    return _validateOutput(context, input, actualOutput);
 }
 
 static String _calcSummary(IArtifactDiagnostics* inDiagnostics)
@@ -3728,11 +3719,7 @@ static TestResult _runHLSLComparisonTest(
     // Always fail if the compilation produced a failure, just
     // to catch situations where, e.g., command-line options parsing
     // caused the same error in both the Slang and fxc cases.
-    return _validateOutput(
-        context,
-        input,
-        actualOutput,
-        resultCode != 0 || _hasDebugLayerError(exeRes));
+    return _validateOutput(context, input, actualOutput, resultCode != 0);
 }
 
 static TestResult runDXBCComparisonTest(TestContext* context, TestInput& input)
@@ -4125,7 +4112,7 @@ TestResult runComputeComparisonImpl(
         context,
         input,
         actualOutput,
-        _hasDebugLayerError(exeRes),
+        false,
         "result code = 0\nstandard error = {\n}\nstandard output = {\n}\n");
 
     // check against reference output

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -5556,9 +5556,6 @@ static SlangResult runUnitTestModule(
         return SLANG_FAIL;
 
     renderer_test::CoreDebugCallback coreDebugCallback;
-    // RHI state can outlive a unit-test invocation, so the bridge must outlive
-    // the stack callback whose binding is controlled below.
-    static renderer_test::CoreToRHIDebugBridge rhiDebugBridge;
 
     UnitTestContext unitTestContext;
     unitTestContext.slangGlobalSession = context->getSession();
@@ -5569,7 +5566,7 @@ static SlangResult runUnitTestModule(
         context->options.enabledApis & _getAvailableRenderApiFlags(context);
     unitTestContext.enableDebugLayers = context->options.enableDebugLayers;
     unitTestContext.executableDirectory = context->exeDirectoryPath.getBuffer();
-    unitTestContext.debugCallback = &rhiDebugBridge;
+    unitTestContext.debugCallback = nullptr;
 
     auto testCount = testModule->getTestCount();
 
@@ -5688,8 +5685,10 @@ static SlangResult runUnitTestModule(
 
             // Clear any previous debug messages
             coreDebugCallback.clear();
+            auto rhiDebugBridge = renderer_test::createRetainedCoreToRHIDebugBridge();
+            unitTestContext.debugCallback = rhiDebugBridge.Ptr();
             renderer_test::ScopedCoreDebugCallback scopedDebugCallback(
-                rhiDebugBridge,
+                *rhiDebugBridge,
                 &coreDebugCallback);
 
             try

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -543,11 +543,9 @@ SlangResult TestServer::_executeUnitTest(const JSONRPCCall& call)
 
     TestReporter testReporter;
     renderer_test::CoreDebugCallback coreDebugCallback;
-    // RHI state can outlive an RPC invocation, so the bridge must outlive the
-    // stack callback whose binding is controlled by the scoped helper.
-    static renderer_test::CoreToRHIDebugBridge rhiDebugCallback;
+    auto rhiDebugCallback = renderer_test::createRetainedCoreToRHIDebugBridge();
     renderer_test::ScopedCoreDebugCallback scopedDebugCallback(
-        rhiDebugCallback,
+        *rhiDebugCallback,
         &coreDebugCallback);
 
     testModule->setTestReporter(&testReporter);
@@ -565,7 +563,7 @@ SlangResult TestServer::_executeUnitTest(const JSONRPCCall& call)
     unitTestContext.enabledApis = RenderApiFlags(args.enabledApis);
     unitTestContext.executableDirectory = m_exeDirectory.getBuffer();
     unitTestContext.enableDebugLayers = args.enableDebugLayers;
-    unitTestContext.debugCallback = &rhiDebugCallback;
+    unitTestContext.debugCallback = rhiDebugCallback.Ptr();
 
     auto testCount = testModule->getTestCount();
     SLANG_ASSERT(testIndex >= 0 && testIndex < testCount);

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -543,8 +543,10 @@ SlangResult TestServer::_executeUnitTest(const JSONRPCCall& call)
 
     TestReporter testReporter;
     renderer_test::CoreDebugCallback coreDebugCallback;
-    renderer_test::CoreToRHIDebugBridge rhiDebugCallback;
-    rhiDebugCallback.setCoreCallback(&coreDebugCallback);
+    static renderer_test::CoreToRHIDebugBridge rhiDebugCallback;
+    renderer_test::ScopedCoreDebugCallback scopedDebugCallback(
+        rhiDebugCallback,
+        &coreDebugCallback);
 
     testModule->setTestReporter(&testReporter);
 

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -543,6 +543,8 @@ SlangResult TestServer::_executeUnitTest(const JSONRPCCall& call)
 
     TestReporter testReporter;
     renderer_test::CoreDebugCallback coreDebugCallback;
+    // RHI state can outlive an RPC invocation, so the bridge must outlive the
+    // stack callback whose binding is controlled by the scoped helper.
     static renderer_test::CoreToRHIDebugBridge rhiDebugCallback;
     renderer_test::ScopedCoreDebugCallback scopedDebugCallback(
         rhiDebugCallback,


### PR DESCRIPTION
Fixes #11720

## Motivation

Running `slang-test` on Windows with debug layers enabled could fail when tests ran in-process without a test server. The minimized reproducer was `gfx-unit-test-tool/pointerInBufferRoundtripVulkan.internal`, and the broader issue showed later tests such as `tests/preprocessor/duplicate-include/a.slang` failing after earlier GPU/debug-layer output had already been emitted.

The test harness was passing RHI devices a debug callback bridge whose target `CoreDebugCallback` belonged to the currently active test invocation. Some RHI objects and test-tool shared-library state can outlive that invocation, so the bridge could retain a pointer to stale per-test callback storage or forward a late message to the wrong test.

## Proposed solution

Give each harness invocation its own retained RHI-facing bridge anywhere a device or loaded tool can retain the callback, and bind that bridge to the current `CoreDebugCallback` only for the active invocation. `renderer_test::ScopedCoreDebugCallback` sets the inner core callback on entry and clears it on exit, so late debug-layer messages cannot dereference stale callback storage or leak into the next test. Distinct retained bridges also prevent an old RHI emitter from forwarding into a later test's active callback. The bridge serializes binding changes with message forwarding, and `CoreDebugCallback` serializes buffer access, because RHI debug callbacks can be invoked from backend or driver threads.

## Change summary

`tools/render-test/slang-support.h:21` adds a mutex-protected, reference-counted `CoreToRHIDebugBridge`, `tools/render-test/slang-support.h:58` adds `createRetainedCoreToRHIDebugBridge`, `tools/render-test/slang-support.h:70` adds `ScopedCoreDebugCallback`, and `tools/render-test/slang-support.h:111` makes `CoreDebugCallback` buffer access thread-safe. The helper documents that messages arriving while no scoped callback is active are intentionally dropped instead of forwarded to stale per-test callback storage, and its comments record the thread-safety and retained-lifetime contracts.

`tools/render-test/render-test-main.cpp:1772` creates a retained bridge for that render-test invocation, binds it around execution, and passes that same bridge to RHI device creation at `tools/render-test/render-test-main.cpp:1912`.

`runUnitTestModule` in `tools/slang-test/slang-test-main.cpp` creates a retained RHI bridge for each in-process unit test at `tools/slang-test/slang-test-main.cpp:5688`, passes it through `UnitTestContext` at `tools/slang-test/slang-test-main.cpp:5689`, and binds it only around that test at `tools/slang-test/slang-test-main.cpp:5690`.

`tools/test-server/test-server-main.cpp:546` mirrors the unit-test server path by creating a retained RHI bridge per RPC and binding it to the per-RPC `CoreDebugCallback` only while executing that unit test.

`tools/gfx-unit-test/scoped-core-debug-callback-test.cpp:29` covers the bridge lifetime contract: a retained bridge is a no-op after the scoped binding exits, a later scoped binding receives only its own messages, sequential scoped bindings do not leak messages between callbacks, and exception unwinding clears the bridge. `tools/gfx-unit-test/scoped-core-debug-callback-test.cpp:102` mirrors the production shape with distinct retained bridges and stack callbacks, and `tools/gfx-unit-test/scoped-core-debug-callback-test.cpp:116` exercises concurrent debug-message delivery, binding clear, and harness reads.

## Concepts and vocabulary

`CoreToRHIDebugBridge` is the object passed to RHI as an `rhi::IDebugCallback`; it forwards RHI messages into Slang core's `IDebugCallback`. RHI may call this object from backend or driver threads, so binding changes and forwarded messages must be synchronized.

`CoreDebugCallback` is the per-test collector that stores debug-layer error messages so `slang-test` can report them with the originating test result.

The RHI debug layer can emit messages from driver or validation objects whose lifetime is not identical to a single test function call, so the callback object passed to RHI must not be stack storage for a narrower lifetime.

## Reviewer Directives (maintained by agent)

- [LLM github-actions review] Messages delivered to `CoreToRHIDebugBridge` while no scoped callback is active are intentionally dropped; do not forward them to a previous or next per-test callback. (https://github.com/shader-slang/slang/pull/11785#discussion_r3483258769)

## Process report

The relevant input shape is valid: RHI code is allowed to retain the callback pointer for the lifetime of devices and validation/debug objects, and the test infrastructure intentionally reuses loaded tools and can keep RHI state alive beyond a single test invocation. The producer should not be changed to assume every debug message is synchronous with one test function. The harness must instead make the callback object lifetime match the retained pointer.

For render-test execution, `_innerMain` in `tools/render-test/render-test-main.cpp` creates one retained bridge for the invocation and passes that bridge into RHI device creation. The scoped binder clears the bridge's inner core callback before returning to `spawnAndWaitSharedLibrary`, while the retained bridge object itself remains alive for any RHI state that still holds the raw callback pointer.

For in-process unit tests, `runUnitTestModule` in `tools/slang-test/slang-test-main.cpp` previously created the bridge as ordinary local storage and reused one `CoreDebugCallback` while iterating tests. A late RHI message after a test completed could therefore be delivered outside that test's reporting scope, and a retained callback pointer could outlive the local bridge. Creating a retained bridge per test gives retained RHI state a stable callback object without sharing that object with later tests. Binding only around the active test means delayed messages from that test's RHI objects hit that test's cleared bridge and are dropped rather than being attributed to a later test.

For test-server unit tests, `_executeUnitTest` in `tools/test-server/test-server-main.cpp` has the same callback-retention problem across one RPC. The server-side change applies the same lifetime rule: a retained bridge per RPC for RHI, a scoped per-RPC core callback for reporting.

Reviewer feedback noted that RHI callbacks can arrive on backend or driver threads. The bridge now protects its inner callback pointer with a mutex and holds that mutex while forwarding a message, so `ScopedCoreDebugCallback` destruction cannot clear the pointer and let the per-test callback die while an in-flight forwarded message is still using it. `CoreDebugCallback` also protects `handleMessage`, `clear`, and `getString` with a mutex so concurrent RHI messages cannot race on the `StringBuilder`. `coreDebugBridgeHandlesConcurrentMessages` exercises this invariant with concurrent writers, scoped binding teardown while writers are active, and a concurrent reader so sanitizer configurations can catch accidental unsynchronized access.

Reviewer feedback asked whether clearing the bridge silently drops late messages. That drop is intentional and belongs at this layer: while no scoped binding is active there is no current test result that can own the message, and forwarding to a destroyed or subsequent per-test `CoreDebugCallback` is the stale-pointer/cross-test contamination bug this PR fixes. Later feedback pointed out that a single shared retained bridge could still forward an old emitter's delayed message into a later active scope. The fix is therefore one retained bridge per invocation: old emitters call the old bridge, whose scoped binding has been cleared, while the later invocation uses a distinct bridge. The helper now documents that contract, and `scopedCoreDebugCallbackClearsBridgeOnExit`, `scopedCoreDebugCallbackDoesNotLeakAcrossScopes`, `scopedCoreDebugCallbackClearsBridgeOnException`, and `scopedCoreDebugCallbackSeparatesRetainedBridgeScopes` pin the no-op-after-scope, no-cross-scope-leak, exception-unwind, and retained-bridge separation behavior.

Reviewer feedback clarified that `ExecuteResult::debugLayer` is not exclusively RHI validation output for ordinary in-process tool execution: `StdWriters::setDebugCallback` can also route compiler diagnostics into that field. This PR therefore leaves the existing `_validateOutput` force-failure behavior unchanged outside the unit-test debug-layer paths, so negative compile tests that intentionally produce diagnostics are not failed merely because that diagnostic channel is non-empty.
