### PR TITLE
Fix CMake Options workflow permissions

### DIFF
--- a/.github/workflows/cmake-options.yml
+++ b/.github/workflows/cmake-options.yml
@@ -21,6 +21,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   linux-debug:


### PR DESCRIPTION
## Motivation

The CMake Options workflow has been failing at GitHub Actions startup before any job is created. The caller workflow grants only `contents: read`, while the Linux container reusable workflow requests `packages: read` so it can pull the GHCR CI image. GitHub rejects that permission escalation while expanding the reusable workflow, so the run fails as `startup_failure` with no job logs.

## Proposed solution

Grant `packages: read` in the CMake Options caller workflow. This matches the permission already declared by the called container workflow and lets GitHub expand the reusable workflow legally before scheduling jobs.

## Change summary

| File | Change |
| --- | --- |
| `.github/workflows/cmake-options.yml` | Adds `packages: read` to the top-level workflow permissions. |

## Concepts and vocabulary

- **Reusable workflow** — a workflow with `on.workflow_call`, invoked from another workflow through `uses: ./.github/workflows/<file>.yml`.
- **Caller permissions** — the `GITHUB_TOKEN` permissions granted by the workflow that invokes a reusable workflow. A called workflow can only use permissions that are the same or more restrictive than the caller's permissions.

## Process report

This is a workflow-expansion failure, not a build failure. GitHub never creates jobs for the failing scheduled runs because `cmake-options.yml` grants only `contents: read`, while `cmake-options-build-container.yml` declares `packages: read` on its `build` job. GitHub checks reusable workflow permissions before scheduling jobs, so the fix belongs in the caller permission set rather than in any CMake or build step.
