### PR TITLE
Default slang-test compiler invocations to -O0

### DIFF
--- a/tests/autodiff/differentiable-interface-return.slang
+++ b/tests/autodiff/differentiable-interface-return.slang
@@ -9,7 +9,7 @@
 // `-target hlsl` and an ICE on `-target spirv`.
 
 //TEST:SIMPLE(filecheck=CHECK_HLSL): -target hlsl -stage compute -entry main
-//TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv-asm -stage compute -entry main
+//TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv-asm -stage compute -entry main -O3
 //TEST:INTERPRET(filecheck=CHECK_INTERP): -entry interpretMain
 
 // The fix should ensure `this_type` (the unresolved IR placeholder) does not

--- a/tests/autodiff/differentiable-interface-return.slang
+++ b/tests/autodiff/differentiable-interface-return.slang
@@ -8,7 +8,7 @@
 // `this_type(...)` leaks all the way to codegen — invalid HLSL on
 // `-target hlsl` and an ICE on `-target spirv`.
 
-//TEST:SIMPLE(filecheck=CHECK_HLSL): -target hlsl -stage compute -entry main
+//TEST:SIMPLE(filecheck=CHECK_HLSL): -target hlsl -stage compute -entry main -O3
 //TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv-asm -stage compute -entry main -O3
 //TEST:INTERPRET(filecheck=CHECK_INTERP): -entry interpretMain
 

--- a/tests/autodiff/path-tracer/pt-loop.slang
+++ b/tests/autodiff/path-tracer/pt-loop.slang
@@ -1,7 +1,7 @@
 //Tests automatic synthesis of Differential type requirement.
 
 //TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj -output-using-type -dx12
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -output-using-type -Xslang -O1
 //TEST(compute):COMPARE_COMPUTE_EX:-cuda -compute -shaderobj -output-using-type
 
 //TEST_INPUT:ubuffer(data=[0 0 0], stride=4):out,name=outputBuffer
@@ -9,7 +9,7 @@ RWStructuredBuffer<float> outputBuffer;
 
 struct PathData : IDifferentiable
 {
-    float3 thp;    
+    float3 thp;
     uint length;
     bool terminated;
     bool isHit;

--- a/tests/autodiff/reverse-loop-immediate-return.slang
+++ b/tests/autodiff/reverse-loop-immediate-return.slang
@@ -1,5 +1,5 @@
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK): -slang -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK): -slang -compute -shaderobj -output-using-type -Xslang -O3
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name=outputBuffer
@@ -36,7 +36,7 @@ void run(
         }
 
         if (idx == 0)
-        { 
+        {
             x = x * 2.0f;
         }
     }
@@ -53,8 +53,8 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     // bwd_diff
     DifferentialPair<float> dpa = DifferentialPair<float>(1.0, 0.0);
     bwd_diff(run)(dispatchThreadID.x, dpa);
-    outputBuffer[dispatchThreadID.x] = dpa.d; 
-    
+    outputBuffer[dispatchThreadID.x] = dpa.d;
+
     // CHECK: type: float
     // CHECK: 2.0
 }

--- a/tests/autodiff/reverse-loop-immediate-return.slang
+++ b/tests/autodiff/reverse-loop-immediate-return.slang
@@ -1,6 +1,6 @@
 
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK): -slang -compute -shaderobj -output-using-type -Xslang -O3
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type -Xslang -O3
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;

--- a/tests/bugs/gh-10774-concrete-return.slang
+++ b/tests/bugs/gh-10774-concrete-return.slang
@@ -5,7 +5,7 @@
 // the interface requirement and the satisfying method. It should compile, but
 // currently fails during interface conformance checking.
 
-//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -emit-spirv-directly -stage compute -entry computeMain
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -emit-spirv-directly -stage compute -entry computeMain -O3
 
 // CHECK: OpCapability RayQueryKHR
 // CHECK: OpRayQueryInitializeKHR

--- a/tests/bugs/gh-6482-interface-method-existential-specialize.slang
+++ b/tests/bugs/gh-6482-interface-method-existential-specialize.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -O3
 
 // This is a test that checks that we can apply partial specialization to a function
 // that takes existential parameters.
@@ -33,7 +33,7 @@ struct Scene : IScene {
 };
 
 public interface IIntegrator {
-    
+
     // This function takes two existential parameters, `scene` and `rng`.
     // if we call this function with `rng` being dynamic, and `scene` being static,
     // we should still be able to specialize the `sample` function with the statically known

--- a/tests/bugs/gh-9916.slang
+++ b/tests/bugs/gh-9916.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -stage fragment -entry fragmentMain
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -stage fragment -entry fragmentMain -O3
 //TEST:SIMPLE(filecheck=CHECK_BINDLESS): -target spirv-asm -stage fragment -entry fragmentMain -capability spvBindlessTextureNV -DUSE_BINDLESS_NV
 
 // A global DescriptorHandle constant lowers to a module-scope descriptor-handle

--- a/tests/bugs/metal-return-value-lost.slang
+++ b/tests/bugs/metal-return-value-lost.slang
@@ -8,12 +8,12 @@
 //TEST:SIMPLE(filecheck=CPP):   -target cpp -entry computeMain -stage compute
 //TEST:SIMPLE(filecheck=WGSL):  -target wgsl -entry computeMain -stage compute
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-d3d12 -compute -shaderobj -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cpu -compute -shaderobj -output-using-type
-//TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-metal -compute -shaderobj -output-using-type
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-wgsl -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-d3d12 -compute -shaderobj -output-using-type -Xslang -O3
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -output-using-type -Xslang -O3
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -output-using-type -Xslang -O3
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cpu -compute -shaderobj -output-using-type -Xslang -O3
+//TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-metal -compute -shaderobj -output-using-type -Xslang -O3
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-wgsl -compute -shaderobj -output-using-type -Xslang -O3
 
 //TEST_INPUT: ubuffer(data=[0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;

--- a/tests/bugs/spirv-opt-SROA-of-globals.slang
+++ b/tests/bugs/spirv-opt-SROA-of-globals.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv -fvk-use-entrypoint-name -enable-experimental-passes
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -fvk-use-entrypoint-name -enable-experimental-passes -O3
 
 // This test checks that spirv-opt is running SROA (scalar replacement of aggregates) to
 // hoist out all member variables of a struct. If this sucsessfully runs, we should not see

--- a/tests/bugs/vk-structured-buffer-load.hlsl
+++ b/tests/bugs/vk-structured-buffer-load.hlsl
@@ -1,6 +1,6 @@
 //TEST:CROSS_COMPILE: -profile glsl_460+GL_NV_ray_tracing -entry HitMain -stage closesthit -target spirv-assembly -O3
-//TEST:SIMPLE(filecheck=DXIL): -target dxil -entry HitMain -stage closesthit -profile sm_6_5
-//TEST:SIMPLE(filecheck=SPV): -target spirv
+//TEST:SIMPLE(filecheck=DXIL): -target dxil -entry HitMain -stage closesthit -profile sm_6_5 -O3
+//TEST:SIMPLE(filecheck=SPV): -target spirv -O3
 
 // DXIL: define void @
 // SPV: OpEntryPoint

--- a/tests/bugs/vk-structured-buffer-load.hlsl
+++ b/tests/bugs/vk-structured-buffer-load.hlsl
@@ -1,4 +1,4 @@
-//TEST:CROSS_COMPILE: -profile glsl_460+GL_NV_ray_tracing -entry HitMain -stage closesthit -target spirv-assembly
+//TEST:CROSS_COMPILE: -profile glsl_460+GL_NV_ray_tracing -entry HitMain -stage closesthit -target spirv-assembly -O3
 //TEST:SIMPLE(filecheck=DXIL): -target dxil -entry HitMain -stage closesthit -profile sm_6_5
 //TEST:SIMPLE(filecheck=SPV): -target spirv
 

--- a/tests/compute/byte-address-buffer-array.slang
+++ b/tests/compute/byte-address-buffer-array.slang
@@ -4,8 +4,8 @@
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -vk -shaderobj -output-using-type
 
 //TEST:SIMPLE(filecheck=CHECK2):-target hlsl -entry computeMain -stage compute
-//TEST:SIMPLE(filecheck=CHECK3):-target spirv -entry computeMain -stage compute
-//TEST:SIMPLE(filecheck=CHECK3):-target spirv -emit-spirv-directly -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=CHECK3):-target spirv -entry computeMain -stage compute -O1
+//TEST:SIMPLE(filecheck=CHECK3):-target spirv -emit-spirv-directly -entry computeMain -stage compute -O1
 
 // Confirm compilation of `(RW)ByteAddressBuffer` with aligned load / stores to wider data types.
 

--- a/tests/compute/half-texture.slang
+++ b/tests/compute/half-texture.slang
@@ -1,6 +1,6 @@
 //TEST:SIMPLE(filecheck=CHECK_SPIRV): -target spirv -entry computeMain -profile cs_6_2 -emit-spirv-via-glsl
 //TEST:SIMPLE(filecheck=CHECK_SPIRV): -target spirv -entry computeMain -profile cs_6_2 -emit-spirv-directly
-//TEST:CROSS_COMPILE: -target dxil-assembly -entry computeMain -profile cs_6_2
+//TEST:CROSS_COMPILE: -target dxil-assembly -entry computeMain -profile cs_6_2 -O3
 //TEST:SIMPLE(filecheck=CHECK_CUDA): -target cuda -entry computeMain -profile cs_6_2
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=16):out
@@ -22,8 +22,8 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     int2 pos = int2(dispatchThreadID.xy);
     float2 uv = pos * (1.0f / 3.0f);
     int2 pos2 = int2(3 - pos.y, 3 - pos.x);
-    
-#if 0 
+
+#if 0
     half  h = halfTexture.Sample(s, uv);
     half2 h2 = halfTexture2.Sample(s, uv);
     half4 h4 = halfTexture4.Sample(s, uv);
@@ -42,7 +42,7 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     halfTexture[pos] = h2.x + h2.y;
     halfTexture2[pos] = h4.xy;
     halfTexture4[pos] = half4(h2, h, h);
-    
+
     int index = pos.x + pos.y * 4;
     outputBuffer[index] = index;
 }

--- a/tests/compute/nonuniformres-as-function-parameter.slang
+++ b/tests/compute/nonuniformres-as-function-parameter.slang
@@ -1,5 +1,5 @@
-//TEST:SIMPLE(filecheck=CHECK_SPV):-target spirv -entry main -stage compute
-//TEST:SIMPLE(filecheck=CHECK_GLSL_SPV):-target spirv -entry main -stage compute -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=CHECK_SPV):-target spirv -entry main -stage compute -O1
+//TEST:SIMPLE(filecheck=CHECK_GLSL_SPV):-target spirv -entry main -stage compute -emit-spirv-via-glsl -O1
 //TEST:SIMPLE(filecheck=CHECK_GLSL):-target glsl -entry main -stage compute
 //TEST:SIMPLE(filecheck=CHECK_HLSL):-target hlsl -entry main -stage compute
 //TEST:SIMPLE(filecheck=CHECK_CUDA):-target cuda -entry main -stage compute

--- a/tests/compute/nonuniformres-nested-rwstructuredbuf.slang
+++ b/tests/compute/nonuniformres-nested-rwstructuredbuf.slang
@@ -1,6 +1,6 @@
 //TEST:SIMPLE(filecheck=CHECK0):-target glsl -entry main -stage compute
 //TEST:SIMPLE(filecheck=CHECK1):-target hlsl -entry main -stage compute
-//TEST:SIMPLE(filecheck=CHECK2):-target spirv -entry main -stage compute -emit-spirv-via-glsl
+//TEST:SIMPLE(filecheck=CHECK2):-target spirv -entry main -stage compute -emit-spirv-via-glsl -O3
 //TEST:SIMPLE(filecheck=CHECK3):-target spirv -entry main -stage compute -emit-spirv-directly
 //TEST:SIMPLE(filecheck=CHECK4):-target cuda -entry main -stage compute -emit-spirv-directly
 
@@ -30,7 +30,7 @@ void main(uint3 dispatchThreadID: SV_DispatchThreadID)
     // CHECK3-DAG: OpDecorate %[[IDX2]] NonUniform
     // CHECK3-DAG: OpDecorate %[[AC2]] NonUniform
     // CHECK3-DAG: %{{.*}} = OpAccessChain %_ptr_StorageBuffer_int %[[AC2]]
-    
+
     // CHECK4: Array<RWStructuredBuffer<int>>  [[BUFFER:buffer[_0-9]*]];
     // CHECK4: [[GLOBALPARAMS:globalParams[_0-9]*]]->[[BUFFER]][_S{{[0-9]+}}]
     // CHECK4: [[GLOBALPARAMS]]->[[BUFFER]][int(_S{{[0-9]+}})]

--- a/tests/compute/static-const-array.slang
+++ b/tests/compute/static-const-array.slang
@@ -1,8 +1,8 @@
 // static-const-array.slang
 
-//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj
-//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj
-//TEST(compute):COMPARE_COMPUTE_EX:-cpu -slang -compute -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX:-slang -compute -shaderobj -Xslang -O3
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -Xslang -O3
+//TEST(compute):COMPARE_COMPUTE_EX:-cpu -slang -compute -shaderobj -Xslang -O3
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out, name outputBuffer
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/cooperative-vector/layout-structuredbuffer.slang
+++ b/tests/cooperative-vector/layout-structuredbuffer.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK):-target spirv -emit-spirv-directly -entry computeMain -stage compute -capability cooperative_vector
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -emit-spirv-directly -entry computeMain -stage compute -capability cooperative_vector -O3
 
 // Check that cooperative vector StructuredBuffer overloads preserve distinct
 // std140/std430 ArrayStride decorations for runtime arrays and pointers.

--- a/tests/cross-compile/loop-attribs.slang
+++ b/tests/cross-compile/loop-attribs.slang
@@ -1,12 +1,12 @@
 // loop-attribs.slang
 // Test that loop attributes are correctly emitted to the resulting HLSL.
 
-//TEST:CROSS_COMPILE:-target dxil-assembly  -entry main -stage fragment -profile sm_6_0 -loop-inversion
+//TEST:CROSS_COMPILE:-target dxil-assembly  -entry main -stage fragment -profile sm_6_0 -loop-inversion -O3
 
 float4 main() : SV_Target
 {
     float sum = 0.0f;
-    
+
     [loop]
     for (int i = 0; i < 100; i++)
         sum += float(i);

--- a/tests/cross-compile/precise-keyword.slang
+++ b/tests/cross-compile/precise-keyword.slang
@@ -2,7 +2,7 @@
 
 //TEST:SIMPLE(filecheck=SPIRV): -target spirv-assembly -entry main -stage fragment
 //TEST:CROSS_COMPILE:-target dxbc-assembly  -entry main -stage fragment
-//TEST:CROSS_COMPILE:-target dxil-assembly  -entry main -stage fragment -profile sm_6_0
+//TEST:CROSS_COMPILE:-target dxil-assembly  -entry main -stage fragment -profile sm_6_0 -O3
 
 // Test handling of the `precise` keyword
 

--- a/tests/diagnostics/command-line/option-missing-argument.slang
+++ b/tests/diagnostics/command-line/option-missing-argument.slang
@@ -5,5 +5,5 @@
 //DIAGNOSTIC_TEST:SIMPLE(diag=CHECK1):-target -profile ps_4_0
 //CHECK1: unknown code generation target '-profile'
 
-//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK2):-profile ps_4_0 -target
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK2):-profile ps_4_0 -O3 -target
 //CHECK2: expected an argument for command-line option '-target'

--- a/tests/diagnostics/command-line/option-missing-argument.slang
+++ b/tests/diagnostics/command-line/option-missing-argument.slang
@@ -5,5 +5,5 @@
 //DIAGNOSTIC_TEST:SIMPLE(diag=CHECK1):-target -profile ps_4_0
 //CHECK1: unknown code generation target '-profile'
 
-//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK2):-profile ps_4_0 -O3 -target
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK2):-profile ps_4_0 -target
 //CHECK2: expected an argument for command-line option '-target'

--- a/tests/glsl-intrinsic/intrinsic-basic-vector.slang
+++ b/tests/glsl-intrinsic/intrinsic-basic-vector.slang
@@ -1,6 +1,6 @@
 //TEST:SIMPLE(filecheck=CHECK_GLSL): -allow-glsl -stage compute -entry computeMain -target glsl
 //TEST:SIMPLE(filecheck=CHECK_GLSL_SPIRV): -allow-glsl -stage compute -entry computeMain -target spirv -emit-spirv-via-glsl
-//TEST:SIMPLE(filecheck=CHECK_SPIR): -allow-glsl -stage compute -entry computeMain -target spirv -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK_SPIR): -allow-glsl -stage compute -entry computeMain -target spirv -emit-spirv-directly -O1
 //TEST:SIMPLE(filecheck=CHECK_HLSL): -allow-glsl -stage compute -entry computeMain -target hlsl
 
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=BUF):-vk -compute -entry computeMain -allow-glsl -output-using-type -emit-spirv-via-glsl

--- a/tests/glsl-intrinsic/intrinsic-texture.slang
+++ b/tests/glsl-intrinsic/intrinsic-texture.slang
@@ -8,11 +8,11 @@
 //TEST:SIMPLE(filecheck=GLSL_GRADS):    -allow-glsl -stage fragment -entry fragMain -target glsl -DGLSL
 
 // Sampling gradients available. Implicit LOD sampling translates to OpImageSampleImplicitLod and similar
-//TEST:SIMPLE(filecheck=SPIR_GRADS):  -allow-glsl -stage fragment -entry fragMain -target spirv -DSPIRV
-//TEST:SIMPLE(filecheck=SPIR_GRADS):  -allow-glsl -stage compute -entry computeMain -target spirv -DSPIRV -capability SPV_KHR_compute_shader_derivatives
+//TEST:SIMPLE(filecheck=SPIR_GRADS):  -allow-glsl -stage fragment -entry fragMain -target spirv -DSPIRV -O3
+//TEST:SIMPLE(filecheck=SPIR_GRADS):  -allow-glsl -stage compute -entry computeMain -target spirv -DSPIRV -capability SPV_KHR_compute_shader_derivatives -O3
 
 // sampling gradients not available. Implicit LOD sampling translates to OpImageSampleExplicitLod with Lod=0 and similar
-//TEST:SIMPLE(filecheck=SPIR_NOGRADS):  -allow-glsl -stage vertex -entry vertexMain -target spirv -DSPIRV -DVERTEX_STAGE -DNO_GRADS
+//TEST:SIMPLE(filecheck=SPIR_NOGRADS):  -allow-glsl -stage vertex -entry vertexMain -target spirv -DSPIRV -DVERTEX_STAGE -DNO_GRADS -O3
 
 //TEST:SIMPLE(filecheck=CUDA): -allow-glsl -stage compute  -entry computeMain -target cuda -DCUDA
 //TEST:SIMPLE(filecheck=CUDA): -allow-glsl -stage fragment -entry fragMain -target cuda -DCUDA

--- a/tests/glsl/matrix-bool-lowering.slang
+++ b/tests/glsl/matrix-bool-lowering.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -emit-spirv-via-glsl -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -emit-spirv-via-glsl -shaderobj -Xslang -O3
 
 //TEST_INPUT:ubuffer(data=[1 0], stride=4):name inputBuffer
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
@@ -29,7 +29,7 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     // Load true/false values from input buffer to avoid constant folding
     trueVal = inputBuffer[0] != 0;
     falseVal = inputBuffer[1] != 0;
-    
+
     // Test bool matrix construction
     bool2x2 mat1 = bool2x2(trueVal, falseVal, falseVal, trueVal);
     bool3x3 mat2 = bool3x3(
@@ -41,19 +41,19 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
         trueVal, falseVal, trueVal, falseVal,
         trueVal, falseVal, trueVal, falseVal
     );
-    
+
     // Test bool matrix element access
     bool val1 = mat1[0][0];
     bool val2 = mat2[2][1];
-    
+
     // Test bool matrix row access
     bool2 row = mat1[1];
     bool3 row3 = mat2[0];
-    
+
     // Test logical operations
     bool2x2 not_mat = !mat1;
     bool2x2 and_mat = mat1 && bool2x2(trueVal, trueVal, falseVal, falseVal);
-    
+
     // Test element assignment
     mat1[0][1] = trueVal;
     mat2[1][2] = falseVal;
@@ -63,12 +63,12 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 
     // Test structs with bool matrix fields
     matrixWrapper wrapper = {};
-    
+
     // Test any/all operations
     bool2x2 all_true = bool2x2(trueVal, trueVal, trueVal, trueVal);
     bool2x2 all_false = bool2x2(falseVal, falseVal, falseVal, falseVal);
     bool2x2 mixed = bool2x2(trueVal, falseVal, trueVal, falseVal);
-    
+
     bool test_all_true = all(all_true);      // all elements true -> true
     bool test_all_false = all(all_false);    // all elements false -> false
     bool test_all_mixed = all(mixed);        // some elements false -> false
@@ -92,11 +92,11 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     outputBuffer[6] = and_mat[0][0];
     // CHECK-NEXT: 1
     outputBuffer[7] = mat1[0][1];
-    // CHECK-NEXT: 1 
+    // CHECK-NEXT: 1
     outputBuffer[8] = mat3[0][1];
-    // CHECK-NEXT: 0 
+    // CHECK-NEXT: 0
     outputBuffer[9] = anded;
-    // CHECK-NEXT: 0 
+    // CHECK-NEXT: 0
     outputBuffer[10] = wrapper.mat1[0][0] || wrapper.mat2[0][0];
     // CHECK-NEXT: 1
     outputBuffer[11] = test_all_true;
@@ -111,4 +111,4 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     // CHECK-NEXT: 0
     outputBuffer[16] = test_any_mixed;
     // CHECK-NEXT: 1
-} 
+}

--- a/tests/gpu-feature/texture/query/footprint/nv-shader-texture-footprint.slang
+++ b/tests/gpu-feature/texture/query/footprint/nv-shader-texture-footprint.slang
@@ -1,5 +1,5 @@
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry fragmentMain -stage fragment -DENABLE_CLAMP
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry fragmentMain -stage fragment -DENABLE_CLAMP
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -emit-spirv-via-glsl -entry fragmentMain -stage fragment -DENABLE_CLAMP -O3
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry fragmentMain -stage fragment -DENABLE_CLAMP -O3
 //DISABLED_TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry fragmentMain -stage fragment -DENABLE_CLAMP -emit-spirv-directly
 
 //DISABLED_TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry fragmentMain -stage fragment

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-chit.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-chit.slang
@@ -1,5 +1,5 @@
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage closesthit -emit-spirv-via-glsl
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage closesthit
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage closesthit -emit-spirv-via-glsl -O3
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage closesthit -O3
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage closesthit -profile sm_6_5 -DNOMOTION
 

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-miss.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-miss.slang
@@ -1,5 +1,5 @@
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage miss -emit-spirv-via-glsl
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage miss
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage miss -emit-spirv-via-glsl -O3
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage miss -O3
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage miss -profile sm_6_5 -DNOMOTION
 

--- a/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-rgen.slang
+++ b/tests/hlsl-intrinsic/ray-tracing/rt-pipeline-intrinsics-rgen.slang
@@ -1,5 +1,5 @@
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage raygeneration -emit-spirv-via-glsl
-//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage raygeneration
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv-assembly -entry main -stage raygeneration -emit-spirv-via-glsl -O3
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv -entry main -stage raygeneration -O3
 //   Motion rays not supported on HLSL impl currently, so disable with NOMOTION define:
 //TEST:SIMPLE(filecheck=DXIL):-target dxil-assembly -entry main -stage raygeneration -profile sm_6_5 -DNOMOTION
 
@@ -131,7 +131,7 @@ float CheckSysValueIntrinsics()
 [shader("raygeneration")]
 void main()
 {
-    
+
     float2 dir = (DispatchRaysIndex().xy / DispatchRaysDimensions().xy) * 2.0f - 1.0f;
     float aspectRatio = DispatchRaysDimensions().x / DispatchRaysDimensions().y;
 
@@ -147,7 +147,7 @@ void main()
     float val = 0.0f;
 
     val += CheckTraceRay(payload, rayDesc);
-   
+
     if( val < T_MAX )
     {
         val += CheckSysValueIntrinsics();

--- a/tests/hlsl/texture-mips-operator.slang
+++ b/tests/hlsl/texture-mips-operator.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -O3
 
 // CHECK: OpImageFetch %v4float {{.*}} Lod %int_1
 

--- a/tests/language-feature/dynamic-dispatch/layout-array-2d.slang
+++ b/tests/language-feature/dynamic-dispatch/layout-array-2d.slang
@@ -2,7 +2,7 @@
 // marshalling: the outer array elements are themselves arrays, each of
 // which must be packed element-by-element into AnyValue storage.
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -Xslang -O2
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cpu -compute -shaderobj -output-using-type

--- a/tests/language-feature/dynamic-dispatch/layout-array-field.slang
+++ b/tests/language-feature/dynamic-dispatch/layout-array-field.slang
@@ -2,7 +2,7 @@
 // element-by-element into AnyValue storage. This tests that the marshalling
 // correctly handles arrays of scalars with different element counts and types.
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -Xslang -O3
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cpu -compute -shaderobj -output-using-type

--- a/tests/language-feature/dynamic-dispatch/layout-array-of-structs.slang
+++ b/tests/language-feature/dynamic-dispatch/layout-array-of-structs.slang
@@ -2,7 +2,7 @@
 // marshalling to handle array-of-composite layout: each struct element
 // must be packed field-by-field in array order within the AnyValue.
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -Xslang -O3
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cpu -compute -shaderobj -output-using-type

--- a/tests/language-feature/dynamic-dispatch/layout-array-of-vectors.slang
+++ b/tests/language-feature/dynamic-dispatch/layout-array-of-vectors.slang
@@ -2,7 +2,7 @@
 // per-element vector packing. Each vector element occupies aligned storage,
 // and the array layout must preserve this alignment for every element.
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -Xslang -O3
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cpu -compute -shaderobj -output-using-type

--- a/tests/language-feature/execution-model/varying-array-input.slang
+++ b/tests/language-feature/execution-model/varying-array-input.slang
@@ -8,7 +8,7 @@
 // varyings only; array-typed varyings hit a separate recursion path.
 
 //TEST:SIMPLE(filecheck=CHECK_HLSL): -target hlsl -entry vertexMain -stage vertex
-//TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv-asm -entry vertexMain -stage vertex -emit-spirv-directly
+//TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv-asm -entry vertexMain -stage vertex -emit-spirv-directly -O3
 
 struct VertexOutput
 {

--- a/tests/language-feature/stage-switch.slang
+++ b/tests/language-feature/stage-switch.slang
@@ -1,5 +1,5 @@
 
-//TEST:SIMPLE(filecheck=CHECK):-target spirv
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -O3
 
 float ddx_or(float val, float defaultVal)
 {
@@ -22,7 +22,7 @@ RWStructuredBuffer<float> output;
 [numthreads(1,1,1)]
 void computeMain()
 {
-    // CHECK-LABEL: %computeMain = OpFunction 
+    // CHECK-LABEL: %computeMain = OpFunction
     // CHECK: OpStore %{{.*}} %float_1
     // CHECK: OpFunctionEnd
     output[0] = intermediate(2.0);
@@ -31,7 +31,7 @@ void computeMain()
 [shader("fragment")]
 float4 fragmentMain(float vin) : SV_Target
 {
-    // CHECK-LABEL: %fragmentMain = OpFunction 
+    // CHECK-LABEL: %fragmentMain = OpFunction
     // CHECK: OpDPdx
     // CHECK: OpFunctionEnd
     return intermediate(vin);

--- a/tests/language-feature/swizzles/matrix-swizzle-out-arg-writeback.slang
+++ b/tests/language-feature/swizzles/matrix-swizzle-out-arg-writeback.slang
@@ -1,5 +1,5 @@
 //TEST:SIMPLE(filecheck=CHECK_HLSL): -target hlsl -entry computeMain -stage compute
-//TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv-asm -entry computeMain -stage compute
+//TEST:SIMPLE(filecheck=CHECK_SPV): -target spirv-asm -entry computeMain -stage compute -O1
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK_OUTPUT): -cpu -compute -shaderobj -output-using-type
 
 // Regression test for #10212.

--- a/tests/llvm/printf.slang
+++ b/tests/llvm/printf.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target llvm-host-ir -emit-cpu-via-llvm -whole-program
+//TEST:SIMPLE(filecheck=CHECK): -target llvm-host-ir -emit-cpu-via-llvm -whole-program -O3
 
 struct S2
 {

--- a/tests/optimization/arrray-storage-lowering.slang
+++ b/tests/optimization/arrray-storage-lowering.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=SPV): -target spirv
+//TEST:SIMPLE(filecheck=SPV): -target spirv -O3
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type -emit-spirv-directly
 
 struct DoubleNested

--- a/tests/optimization/buffer-load-defer-bindless.slang
+++ b/tests/optimization/buffer-load-defer-bindless.slang
@@ -1,7 +1,7 @@
 //TEST:SIMPLE(filecheck=CUDA): -target cuda -entry compute_main -stage compute
 //TEST:SIMPLE(filecheck=PTX): -target ptx -entry compute_main -stage compute
 
-//TEST:SIMPLE(filecheck=SPV): -target spirv
+//TEST:SIMPLE(filecheck=SPV): -target spirv -O3
 
 // Check that we can specialize buffer loads through bindless handles, and
 // do not load big struct elements into registers unnecessarily.

--- a/tests/optimization/defer-structured-buffer-load.slang
+++ b/tests/optimization/defer-structured-buffer-load.slang
@@ -1,5 +1,5 @@
 //TEST:SIMPLE(filecheck=CUDA): -target cuda -entry compute_main -stage compute
-//TEST:SIMPLE(filecheck=SPV): -target spirv
+//TEST:SIMPLE(filecheck=SPV): -target spirv -O3
 
 // Test that we can defer loading big structured buffer elements.
 

--- a/tests/pipeline/ray-tracing/ray-query-subroutine.slang
+++ b/tests/pipeline/ray-tracing/ray-query-subroutine.slang
@@ -2,7 +2,7 @@
 
 // Regression test for passing a `RayQuery` value into a subroutine.
 
-//TEST:CROSS_COMPILE: -profile sm_6_5 -stage compute -entry computeMain -target dxil-assembly
+//TEST:CROSS_COMPILE: -profile sm_6_5 -stage compute -entry computeMain -target dxil-assembly -O3
 
 RWStructuredBuffer<int> gOutput;
 RaytracingAccelerationStructure gScene;

--- a/tests/pipeline/ray-tracing/trace-ray-inline.slang
+++ b/tests/pipeline/ray-tracing/trace-ray-inline.slang
@@ -1,6 +1,6 @@
 // trace-ray-inline.slang
 
-//TEST:CROSS_COMPILE:-target dxil-asm -stage compute -profile sm_6_5 -entry main -line-directive-mode none
+//TEST:CROSS_COMPILE:-target dxil-asm -stage compute -profile sm_6_5 -entry main -line-directive-mode none -O3
 //TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -stage compute -profile glsl_460+GL_EXT_ray_query -entry main -line-directive-mode none
 //TEST:SIMPLE(filecheck=METAL):-target metal -stage compute -entry main
 

--- a/tests/spirv/abort-defer.slang
+++ b/tests/spirv/abort-defer.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv -capability abort
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -capability abort -O3
 
 // Verify that defer lowering inserts cleanup before abort(), even though Abort is
 // represented as a normal intrinsic until SPIR-V legalization turns it into a

--- a/tests/spirv/mesh-shader-invert-y.slang
+++ b/tests/spirv/mesh-shader-invert-y.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target spirv -fvk-invert-y
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -fvk-invert-y -O3
 //TEST:SIMPLE(filecheck=POINT): -target spirv -stage mesh -entry pointMain
 
 // CHECK-DAG: OpExecutionMode %main OutputLinesEXT

--- a/tests/vkray/anyhit.slang
+++ b/tests/vkray/anyhit.slang
@@ -1,7 +1,7 @@
 // closesthit.slang
 
 //TEST:SIMPLE(filecheck=GL_SPIRV): -stage anyhit -entry main -target spirv-assembly -emit-spirv-via-glsl
-//TEST:SIMPLE(filecheck=SPIRV): -stage anyhit -entry main -target spirv
+//TEST:SIMPLE(filecheck=SPIRV): -stage anyhit -entry main -target spirv -O3
 
 struct SphereHitAttributes
 {

--- a/tests/wgsl/matrix-bool-lowering.slang
+++ b/tests/wgsl/matrix-bool-lowering.slang
@@ -1,4 +1,4 @@
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -wgsl -shaderobj
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -wgsl -shaderobj -Xslang -O3
 
 //TEST_INPUT:ubuffer(data=[1 0], stride=4):name inputBuffer
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name outputBuffer
@@ -29,7 +29,7 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     // Load true/false values from input buffer to avoid constant folding
     trueVal = inputBuffer[0] != 0;
     falseVal = inputBuffer[1] != 0;
-    
+
     // Test bool matrix construction
     bool2x2 mat1 = bool2x2(trueVal, falseVal, falseVal, trueVal);
     bool3x3 mat2 = bool3x3(
@@ -41,19 +41,19 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
         trueVal, falseVal, trueVal, falseVal,
         trueVal, falseVal, trueVal, falseVal
     );
-    
+
     // Test bool matrix element access
     bool val1 = mat1[0][0];
     bool val2 = mat2[2][1];
-    
+
     // Test bool matrix row access
     bool2 row = mat1[1];
     bool3 row3 = mat2[0];
-    
+
     // Test logical operations
     bool2x2 not_mat = !mat1;
     bool2x2 and_mat = mat1 && bool2x2(trueVal, trueVal, falseVal, falseVal);
-    
+
     // Test element assignment
     mat1[0][1] = trueVal;
     mat2[1][2] = falseVal;
@@ -63,12 +63,12 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
 
     // Test structs with bool matrix fields
     matrixWrapper wrapper = {};
-    
+
     // Test any/all operations
     bool2x2 all_true = bool2x2(trueVal, trueVal, trueVal, trueVal);
     bool2x2 all_false = bool2x2(falseVal, falseVal, falseVal, falseVal);
     bool2x2 mixed = bool2x2(trueVal, falseVal, trueVal, falseVal);
-    
+
     bool test_all_true = all(all_true);      // all elements true -> true
     bool test_all_false = all(all_false);    // all elements false -> false
     bool test_all_mixed = all(mixed);        // some elements false -> false
@@ -92,11 +92,11 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     outputBuffer[6] = and_mat[0][0];
     // CHECK-NEXT: 1
     outputBuffer[7] = mat1[0][1];
-    // CHECK-NEXT: 1 
+    // CHECK-NEXT: 1
     outputBuffer[8] = mat3[0][1];
-    // CHECK-NEXT: 0 
+    // CHECK-NEXT: 0
     outputBuffer[9] = anded;
-    // CHECK-NEXT: 0 
+    // CHECK-NEXT: 0
     outputBuffer[10] = wrapper.mat1[0][0] || wrapper.mat2[0][0];
     // CHECK-NEXT: 1
     outputBuffer[11] = test_all_true;
@@ -111,4 +111,4 @@ void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     // CHECK-NEXT: 0
     outputBuffer[16] = test_any_mixed;
     // CHECK-NEXT: 1
-} 
+}

--- a/tools/slang-test/README.md
+++ b/tools/slang-test/README.md
@@ -139,10 +139,11 @@ The recognized optimization spellings are `-O`, `-O0`, `-Onone`, `-O1`,
 `-Odefault`, `-O2`, `-Ohigh`, `-O3`, and `-Omaximal`. Prefer the lowest level
 that preserves the test's expected output.
 
-For compiler-backed commands, `slang-test` inserts its default at the front of
-the argument list, so directive arguments keep their meaning — in particular, a
-diagnostic test that intentionally leaves a trailing option without its
-required argument still triggers the missing-argument diagnostic.
+`slang-test` inserts its default at the front of the argument list for both
+compiler-backed and render-test-backed commands, so directive arguments keep
+their meaning — in particular, a directive that leaves a trailing option
+without its required argument (intentionally in a diagnostic test, or by
+mistake) cannot consume the inserted default.
 
 ## Unit Tests
 In addition to the above test tools, there are also `slang-unit-test-tool` and `gfx-unit-test-tool`, which are invoked as in the following examples; but note that the unit tests do get run as part of `slang-test` as well.

--- a/tools/slang-test/README.md
+++ b/tools/slang-test/README.md
@@ -106,6 +106,31 @@ Deprecated test types (do not create new tests of these kinds, and we need to sl
 - `HLSL_COMPUTE`: Runs render-test with "-hlsl-rewrite -compute" options and compares text file outputs
 - `CROSS_COMPILE`: Compiles using GLSL pass-through and through Slang, then compares the outputs
 
+## Compiler Optimization in Tests
+
+`slang-test` adds `-O0` when it builds a Slang compiler command line and the
+test directive does not already specify an optimization option. This keeps
+ordinary test runs fast and avoids expected-output churn from optimizer changes.
+
+Compiler-backed tests, such as `SIMPLE`, `CROSS_COMPILE`, and diagnostic tests,
+can opt in to optimized output with a normal slangc option:
+
+```text
+//TEST:SIMPLE: -target spirv -O3
+```
+
+Render-test-backed tests, such as `COMPARE_COMPUTE_EX`, must forward the
+optimization option to slangc:
+
+```text
+//TEST(compute):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -Xslang -O3
+```
+
+For diagnostic tests that intentionally leave an option without its required
+argument, put the explicit optimization option before that dangling option.
+`slang-test` appends its default after the directive arguments, so relying on
+the default in that case can change which option receives the diagnostic.
+
 ## Unit Tests
 In addition to the above test tools, there are also `slang-unit-test-tool` and `gfx-unit-test-tool`, which are invoked as in the following examples; but note that the unit tests do get run as part of `slang-test` as well.
 

--- a/tools/slang-test/README.md
+++ b/tools/slang-test/README.md
@@ -128,9 +128,7 @@ optimization option to slangc:
 
 The recognized optimization spellings are `-O`, `-O0`, `-Onone`, `-O1`,
 `-Odefault`, `-O2`, `-Ohigh`, `-O3`, and `-Omaximal`. Prefer the lowest level
-that preserves the test's expected output. Explicit Metal render-test commands
-using `-mtl` or `-metal` keep render-test's existing optimization behavior
-because they do not invoke `spv-opt`.
+that preserves the test's expected output.
 
 For diagnostic tests that intentionally leave an option without its required
 argument, put the explicit optimization option before that dangling option.

--- a/tools/slang-test/README.md
+++ b/tools/slang-test/README.md
@@ -139,10 +139,10 @@ The recognized optimization spellings are `-O`, `-O0`, `-Onone`, `-O1`,
 `-Odefault`, `-O2`, `-Ohigh`, `-O3`, and `-Omaximal`. Prefer the lowest level
 that preserves the test's expected output.
 
-For diagnostic tests that intentionally leave an option without its required
-argument, put the explicit optimization option before that dangling option.
-`slang-test` appends its default after the directive arguments, so relying on
-the default in that case can change which option receives the diagnostic.
+For compiler-backed commands, `slang-test` inserts its default at the front of
+the argument list, so directive arguments keep their meaning — in particular, a
+diagnostic test that intentionally leaves a trailing option without its
+required argument still triggers the missing-argument diagnostic.
 
 ## Unit Tests
 In addition to the above test tools, there are also `slang-unit-test-tool` and `gfx-unit-test-tool`, which are invoked as in the following examples; but note that the unit tests do get run as part of `slang-test` as well.

--- a/tools/slang-test/README.md
+++ b/tools/slang-test/README.md
@@ -129,8 +129,8 @@ optimization option to slangc:
 The recognized optimization spellings are `-O`, `-O0`, `-Onone`, `-O1`,
 `-Odefault`, `-O2`, `-Ohigh`, `-O3`, and `-Omaximal`. Prefer the lowest level
 that preserves the test's expected output. Explicit Metal render-test commands
-keep render-test's existing optimization behavior because they do not invoke
-`spv-opt`.
+using `-mtl` or `-metal` keep render-test's existing optimization behavior
+because they do not invoke `spv-opt`.
 
 For diagnostic tests that intentionally leave an option without its required
 argument, put the explicit optimization option before that dangling option.

--- a/tools/slang-test/README.md
+++ b/tools/slang-test/README.md
@@ -126,6 +126,12 @@ optimization option to slangc:
 //TEST(compute):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -Xslang -O3
 ```
 
+The recognized optimization spellings are `-O`, `-O0`, `-Onone`, `-O1`,
+`-Odefault`, `-O2`, `-Ohigh`, `-O3`, and `-Omaximal`. Prefer the lowest level
+that preserves the test's expected output. Explicit Metal render-test commands
+keep render-test's existing optimization behavior because they do not invoke
+`spv-opt`.
+
 For diagnostic tests that intentionally leave an option without its required
 argument, put the explicit optimization option before that dangling option.
 `slang-test` appends its default after the directive arguments, so relying on

--- a/tools/slang-test/README.md
+++ b/tools/slang-test/README.md
@@ -126,6 +126,15 @@ optimization option to slangc:
 //TEST(compute):COMPARE_COMPUTE_EX:-vk -compute -shaderobj -Xslang -O3
 ```
 
+Besides `-Xslang <option>`, the forwarding forms `-compile-arg <option>`,
+`-xslang <option>`, and a `-Xslang... <options...> -X.` block are also
+recognized. Prefer the `-Xslang <option>` form shown above for new tests.
+
+Metal render tests are the one exception to the `-O0` default: they receive
+`-Xslang -O1` instead, because the downstream `metal` toolchain that produces
+the metallib is unstable at `-O0` on macOS CI. The generated MSL source is
+identical at every level, so this only affects the downstream compilation.
+
 The recognized optimization spellings are `-O`, `-O0`, `-Onone`, `-O1`,
 `-Odefault`, `-O2`, `-Ohigh`, `-O3`, and `-Omaximal`. Prefer the lowest level
 that preserves the test's expected output.

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -2667,6 +2667,7 @@ TestResult runSimpleTest(TestContext* context, TestInput& input)
             continue;
         cmdLine.addArg(arg);
     }
+
     // If we can't set up for simple compilation, it's because some external resource isn't
     // available such as NVAPI headers. In that case we just ignore the test.
     if (SLANG_FAILED(_initSlangCompiler(context, cmdLine)))

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -62,6 +62,7 @@ using namespace Slang;
 
 // Constants for slang-test specific options
 static const char* kPreserveEmbeddedSourceOption = "-preserve-embedded-source";
+static const char* kTestOptimizationOption = "-O0";
 
 // Options for a particular test
 struct TestOptions
@@ -170,6 +171,60 @@ static void _addRenderTestOptions(
     const Options& options,
     CommandLine& ioCmdLine,
     bool allowCacheRHI);
+
+static bool _isSlangOptimizationArg(const String& arg)
+{
+    return arg.startsWith(UnownedStringSlice::fromLiteral("-O"));
+}
+
+static bool _hasSlangOptimizationArg(const List<String>& args)
+{
+    for (const auto& arg : args)
+    {
+        if (_isSlangOptimizationArg(arg))
+            return true;
+    }
+    return false;
+}
+
+static void _addDefaultSlangOptimization(CommandLine& ioCmdLine)
+{
+    if (!_hasSlangOptimizationArg(ioCmdLine.m_args))
+    {
+        ioCmdLine.addArg(kTestOptimizationOption);
+    }
+}
+
+static bool _hasRenderTestSlangOptimizationArg(const List<String>& args)
+{
+    for (Index i = 0; i < args.getCount(); ++i)
+    {
+        const auto& arg = args[i];
+        if ((arg == "-compile-arg" || arg == "-xslang" || arg == "-Xslang") &&
+            i + 1 < args.getCount() && _isSlangOptimizationArg(args[i + 1]))
+        {
+            return true;
+        }
+        if (arg == "-Xslang...")
+        {
+            for (++i; i < args.getCount() && args[i] != "-X."; ++i)
+            {
+                if (_isSlangOptimizationArg(args[i]))
+                    return true;
+            }
+        }
+    }
+    return false;
+}
+
+static void _addDefaultRenderTestSlangOptimization(CommandLine& ioCmdLine)
+{
+    if (_hasRenderTestSlangOptimizationArg(ioCmdLine.m_args))
+        return;
+
+    ioCmdLine.addArg("-Xslang");
+    ioCmdLine.addArg(kTestOptimizationOption);
+}
 
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!! Functions !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
 
@@ -2123,6 +2178,7 @@ TestResult runDocTest(TestContext* context, TestInput& input)
     {
         cmdLine.addArg(arg);
     }
+    _addDefaultSlangOptimization(cmdLine);
 
     _initSlangCompiler(context, cmdLine);
 
@@ -2252,6 +2308,7 @@ TestResult runExecutableTest(TestContext* context, TestInput& input)
             cmdLine.addArg(arg);
         }
     }
+    _addDefaultSlangOptimization(cmdLine);
     ExecuteResult exeRes;
 
     // TODO(Yong) HACK:
@@ -2664,6 +2721,8 @@ TestResult runSimpleTest(TestContext* context, TestInput& input)
             continue;
         cmdLine.addArg(arg);
     }
+    // Keep compiler-based tests on the default optimization level unless a test opts out.
+    _addDefaultSlangOptimization(cmdLine);
 
     // If we can't set up for simple compilation, it's because some external resource isn't
     // available such as NVAPI headers. In that case we just ignore the test.
@@ -2733,6 +2792,7 @@ TestResult runSimpleLineTest(TestContext* context, TestInput& input)
     {
         cmdLine.addArg(arg);
     }
+    _addDefaultSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -2891,6 +2951,7 @@ TestResult runCompile(TestContext* context, TestInput& input)
             cmdLine.addArg(arg);
         }
     }
+    _addDefaultSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -2929,6 +2990,7 @@ TestResult runCompileTarget(TestContext* context, TestInput& input)
     }
 
     cmdLine.addArg("-compile-only");
+    _addDefaultRenderTestSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3004,6 +3066,7 @@ TestResult runReflectionTest(TestContext* context, TestInput& input)
     {
         cmdLine.addArg(arg);
     }
+    _addDefaultSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3099,6 +3162,7 @@ static TestResult runCPPCompilerCompile(TestContext* context, TestInput& input)
     {
         cmdLine.addArg(arg);
     }
+    _addDefaultSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3458,6 +3522,7 @@ static TestResult generateExpectedOutput(
     {
         expectedCmdLine.addArg(arg);
     }
+    _addDefaultSlangOptimization(expectedCmdLine);
 
     ExecuteResult expectedExeRes;
     TEST_RETURN_ON_DONE(
@@ -3504,6 +3569,7 @@ TestResult generateActualOutput(
     {
         actualCmdLine.addArg(arg);
     }
+    _addDefaultSlangOptimization(actualCmdLine);
 
     ExecuteResult actualExeRes;
     TEST_RETURN_ON_DONE(
@@ -3621,6 +3687,7 @@ TestResult generateHLSLBaseline(
     cmdLine.addArg(targetFormat);
     cmdLine.addArg("-pass-through");
     cmdLine.addArg(passThroughName);
+    _addDefaultSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3680,6 +3747,7 @@ static TestResult _runHLSLComparisonTest(
 
     cmdLine.addArg("-target");
     cmdLine.addArg(targetFormat);
+    _addDefaultSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3767,6 +3835,7 @@ TestResult doGLSLComparisonTestRun(
     {
         cmdLine.addArg(arg);
     }
+    _addDefaultSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3920,6 +3989,7 @@ TestResult runPerformanceProfile(TestContext* context, TestInput& input)
     {
         cmdLine.addArg(arg);
     }
+    _addDefaultRenderTestSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -4090,6 +4160,7 @@ TestResult runComputeComparisonImpl(
     cmdLine.addArg("-o");
     auto actualOutputFile = outputStem + ".actual.txt";
     cmdLine.addArg(actualOutputFile);
+    _addDefaultRenderTestSlangOptimization(cmdLine);
 
     if (context->isExecuting())
     {
@@ -4194,6 +4265,7 @@ TestResult doRenderComparisonTestRun(
     cmdLine.addArg(langOption);
     cmdLine.addArg("-o");
     cmdLine.addArg(outputStem + outputKind + ".png");
+    _addDefaultRenderTestSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -29,6 +29,7 @@
 #include "directory-util.h"
 #include "options.h"
 #include "parse-diagnostic-util.h"
+#include "slang-test-optimization-options.h"
 #include "slangc-tool.h"
 #include "slangi-tool.h"
 #include "test-context.h"
@@ -62,7 +63,6 @@ using namespace Slang;
 
 // Constants for slang-test specific options
 static const char* kPreserveEmbeddedSourceOption = "-preserve-embedded-source";
-static const char* kTestOptimizationOption = "-O0";
 
 // Options for a particular test
 struct TestOptions
@@ -171,79 +171,6 @@ static void _addRenderTestOptions(
     const Options& options,
     CommandLine& ioCmdLine,
     bool allowCacheRHI);
-
-/// Returns true when an argument is a slangc optimization-level option.
-///
-/// This uses the exact spellings recognized by slangc so unrelated options with a `-O` prefix do
-/// not accidentally opt a test out of the slang-test default.
-static bool _isSlangOptimizationArg(const String& arg)
-{
-    return arg == "-O" || arg == "-O0" || arg == "-Onone" || arg == "-O1" ||
-           arg == "-Odefault" || arg == "-O2" || arg == "-Ohigh" || arg == "-O3" ||
-           arg == "-Omaximal";
-}
-
-/// Returns true when a compiler command line already specifies an optimization level.
-static bool _hasSlangOptimizationArg(const List<String>& args)
-{
-    for (const auto& arg : args)
-    {
-        if (_isSlangOptimizationArg(arg))
-            return true;
-    }
-    return false;
-}
-
-/// Adds the slang-test default optimization level unless the test already specifies one.
-///
-/// Most compiler-based tests do not need optimized output, and keeping them at `-O0` avoids
-/// optimizer time and SPIR-V optimizer output churn.
-static void _addDefaultSlangOptimization(CommandLine& ioCmdLine)
-{
-    if (!_hasSlangOptimizationArg(ioCmdLine.m_args))
-    {
-        ioCmdLine.addArg(kTestOptimizationOption);
-    }
-}
-
-/// Returns true when a render-test command forwards an optimization level to slangc.
-///
-/// Render-test accepts several forwarding forms, including single-argument forwarding and
-/// `-Xslang...` blocks, so slang-test checks each forwarded slangc argument before adding its
-/// default.
-static bool _hasRenderTestSlangOptimizationArg(const List<String>& args)
-{
-    for (Index i = 0; i < args.getCount(); ++i)
-    {
-        const auto& arg = args[i];
-        if ((arg == "-compile-arg" || arg == "-xslang" || arg == "-Xslang") &&
-            i + 1 < args.getCount() && _isSlangOptimizationArg(args[i + 1]))
-        {
-            return true;
-        }
-        if (arg == "-Xslang...")
-        {
-            for (++i; i < args.getCount() && args[i] != "-X."; ++i)
-            {
-                if (_isSlangOptimizationArg(args[i]))
-                    return true;
-            }
-        }
-    }
-    return false;
-}
-
-/// Adds the slang-test default optimization level to render-test commands.
-///
-/// The option is forwarded with `-Xslang` because render-test options are not slangc options.
-static void _addDefaultRenderTestSlangOptimization(CommandLine& ioCmdLine)
-{
-    if (_hasRenderTestSlangOptimizationArg(ioCmdLine.m_args))
-        return;
-
-    ioCmdLine.addArg("-Xslang");
-    ioCmdLine.addArg(kTestOptimizationOption);
-}
 
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!! Functions !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
 
@@ -2197,9 +2124,9 @@ TestResult runDocTest(TestContext* context, TestInput& input)
     {
         cmdLine.addArg(arg);
     }
-    _addDefaultSlangOptimization(cmdLine);
 
     _initSlangCompiler(context, cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -2327,7 +2254,7 @@ TestResult runExecutableTest(TestContext* context, TestInput& input)
             cmdLine.addArg(arg);
         }
     }
-    _addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine);
     ExecuteResult exeRes;
 
     // TODO(Yong) HACK:
@@ -2740,15 +2667,14 @@ TestResult runSimpleTest(TestContext* context, TestInput& input)
             continue;
         cmdLine.addArg(arg);
     }
-    // Keep compiler-based tests on the default optimization level unless a test opts out.
-    _addDefaultSlangOptimization(cmdLine);
-
     // If we can't set up for simple compilation, it's because some external resource isn't
     // available such as NVAPI headers. In that case we just ignore the test.
     if (SLANG_FAILED(_initSlangCompiler(context, cmdLine)))
     {
         return TestResult::Ignored;
     }
+    // Keep compiler-based tests on the default optimization level unless a test opts out.
+    SlangTest::addDefaultSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -2811,7 +2737,7 @@ TestResult runSimpleLineTest(TestContext* context, TestInput& input)
     {
         cmdLine.addArg(arg);
     }
-    _addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -2970,7 +2896,7 @@ TestResult runCompile(TestContext* context, TestInput& input)
             cmdLine.addArg(arg);
         }
     }
-    _addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3009,7 +2935,7 @@ TestResult runCompileTarget(TestContext* context, TestInput& input)
     }
 
     cmdLine.addArg("-compile-only");
-    _addDefaultRenderTestSlangOptimization(cmdLine);
+    SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3085,7 +3011,7 @@ TestResult runReflectionTest(TestContext* context, TestInput& input)
     {
         cmdLine.addArg(arg);
     }
-    _addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3181,7 +3107,7 @@ static TestResult runCPPCompilerCompile(TestContext* context, TestInput& input)
     {
         cmdLine.addArg(arg);
     }
-    _addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3541,7 +3467,7 @@ static TestResult generateExpectedOutput(
     {
         expectedCmdLine.addArg(arg);
     }
-    _addDefaultSlangOptimization(expectedCmdLine);
+    SlangTest::addDefaultSlangOptimization(expectedCmdLine);
 
     ExecuteResult expectedExeRes;
     TEST_RETURN_ON_DONE(
@@ -3588,7 +3514,7 @@ TestResult generateActualOutput(
     {
         actualCmdLine.addArg(arg);
     }
-    _addDefaultSlangOptimization(actualCmdLine);
+    SlangTest::addDefaultSlangOptimization(actualCmdLine);
 
     ExecuteResult actualExeRes;
     TEST_RETURN_ON_DONE(
@@ -3706,7 +3632,7 @@ TestResult generateHLSLBaseline(
     cmdLine.addArg(targetFormat);
     cmdLine.addArg("-pass-through");
     cmdLine.addArg(passThroughName);
-    _addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3766,7 +3692,7 @@ static TestResult _runHLSLComparisonTest(
 
     cmdLine.addArg("-target");
     cmdLine.addArg(targetFormat);
-    _addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3854,7 +3780,7 @@ TestResult doGLSLComparisonTestRun(
     {
         cmdLine.addArg(arg);
     }
-    _addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -4008,7 +3934,7 @@ TestResult runPerformanceProfile(TestContext* context, TestInput& input)
     {
         cmdLine.addArg(arg);
     }
-    _addDefaultRenderTestSlangOptimization(cmdLine);
+    SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -4179,7 +4105,7 @@ TestResult runComputeComparisonImpl(
     cmdLine.addArg("-o");
     auto actualOutputFile = outputStem + ".actual.txt";
     cmdLine.addArg(actualOutputFile);
-    _addDefaultRenderTestSlangOptimization(cmdLine);
+    SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
 
     if (context->isExecuting())
     {
@@ -4284,7 +4210,7 @@ TestResult doRenderComparisonTestRun(
     cmdLine.addArg(langOption);
     cmdLine.addArg("-o");
     cmdLine.addArg(outputStem + outputKind + ".png");
-    _addDefaultRenderTestSlangOptimization(cmdLine);
+    SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -172,11 +172,18 @@ static void _addRenderTestOptions(
     CommandLine& ioCmdLine,
     bool allowCacheRHI);
 
+/// Returns true when an argument is a slangc optimization-level option.
+///
+/// This uses the exact spellings recognized by slangc so unrelated options with a `-O` prefix do
+/// not accidentally opt a test out of the slang-test default.
 static bool _isSlangOptimizationArg(const String& arg)
 {
-    return arg.startsWith(UnownedStringSlice::fromLiteral("-O"));
+    return arg == "-O" || arg == "-O0" || arg == "-Onone" || arg == "-O1" ||
+           arg == "-Odefault" || arg == "-O2" || arg == "-Ohigh" || arg == "-O3" ||
+           arg == "-Omaximal";
 }
 
+/// Returns true when a compiler command line already specifies an optimization level.
 static bool _hasSlangOptimizationArg(const List<String>& args)
 {
     for (const auto& arg : args)
@@ -187,6 +194,10 @@ static bool _hasSlangOptimizationArg(const List<String>& args)
     return false;
 }
 
+/// Adds the slang-test default optimization level unless the test already specifies one.
+///
+/// Most compiler-based tests do not need optimized output, and keeping them at `-O0` avoids
+/// optimizer time and SPIR-V optimizer output churn.
 static void _addDefaultSlangOptimization(CommandLine& ioCmdLine)
 {
     if (!_hasSlangOptimizationArg(ioCmdLine.m_args))
@@ -195,6 +206,11 @@ static void _addDefaultSlangOptimization(CommandLine& ioCmdLine)
     }
 }
 
+/// Returns true when a render-test command forwards an optimization level to slangc.
+///
+/// Render-test accepts several forwarding forms, including single-argument forwarding and
+/// `-Xslang...` blocks, so slang-test checks each forwarded slangc argument before adding its
+/// default.
 static bool _hasRenderTestSlangOptimizationArg(const List<String>& args)
 {
     for (Index i = 0; i < args.getCount(); ++i)
@@ -217,6 +233,9 @@ static bool _hasRenderTestSlangOptimizationArg(const List<String>& args)
     return false;
 }
 
+/// Adds the slang-test default optimization level to render-test commands.
+///
+/// The option is forwarded with `-Xslang` because render-test options are not slangc options.
 static void _addDefaultRenderTestSlangOptimization(CommandLine& ioCmdLine)
 {
     if (_hasRenderTestSlangOptimizationArg(ioCmdLine.m_args))

--- a/tools/slang-test/slang-test-optimization-options.h
+++ b/tools/slang-test/slang-test-optimization-options.h
@@ -58,11 +58,16 @@ inline bool hasSlangOptimizationArg(const List<String>& args)
 ///
 /// Most compiler-based tests do not need optimized output, and keeping them at `-O0` avoids
 /// optimizer time and SPIR-V optimizer output churn.
+///
+/// The default is inserted at the front of the argument list rather than appended, so it can
+/// never change the meaning of the test-provided arguments. For example, a diagnostic test may
+/// intentionally end with a dangling `-target` to provoke a missing-argument diagnostic; an
+/// appended `-O0` would be consumed as that option's argument and change the diagnostic.
 inline void addDefaultSlangOptimization(CommandLine& ioCmdLine)
 {
     if (!hasSlangOptimizationArg(ioCmdLine.m_args))
     {
-        ioCmdLine.addArg(kTestOptimizationOption);
+        ioCmdLine.m_args.insert(0, kTestOptimizationOption);
     }
 }
 

--- a/tools/slang-test/slang-test-optimization-options.h
+++ b/tools/slang-test/slang-test-optimization-options.h
@@ -119,6 +119,10 @@ inline bool hasRenderTestRenderApiArg(const List<String>& args, RenderApiType ap
 /// The option is forwarded with `-Xslang` because render-test options are not slangc options.
 /// Metal render tests receive `-O1` instead of `-O0`; see
 /// `kMetalRenderTestOptimizationOption` for why.
+///
+/// Like `addDefaultSlangOptimization`, the default is inserted at the front of the argument
+/// list rather than appended, so a directive that accidentally leaves an option without its
+/// required parameter cannot consume the inserted default and change the command's meaning.
 inline void addDefaultRenderTestSlangOptimization(CommandLine& ioCmdLine)
 {
     if (hasRenderTestSlangOptimizationArg(ioCmdLine.m_args))
@@ -126,8 +130,10 @@ inline void addDefaultRenderTestSlangOptimization(CommandLine& ioCmdLine)
 
     const bool isMetal = hasRenderTestRenderApiArg(ioCmdLine.m_args, RenderApiType::Metal);
 
-    ioCmdLine.addArg("-Xslang");
-    ioCmdLine.addArg(isMetal ? kMetalRenderTestOptimizationOption : kTestOptimizationOption);
+    ioCmdLine.m_args.insert(0, "-Xslang");
+    ioCmdLine.m_args.insert(
+        1,
+        isMetal ? kMetalRenderTestOptimizationOption : kTestOptimizationOption);
 }
 
 } // namespace SlangTest

--- a/tools/slang-test/slang-test-optimization-options.h
+++ b/tools/slang-test/slang-test-optimization-options.h
@@ -3,7 +3,6 @@
 #define SLANG_TEST_OPTIMIZATION_OPTIONS_H
 
 #include "core/slang-command-line.h"
-#include "core/slang-render-api-util.h"
 #include "core/slang-type-text-util.h"
 
 namespace Slang
@@ -84,33 +83,12 @@ inline bool hasRenderTestSlangOptimizationArg(const List<String>& args)
     return false;
 }
 
-/// Returns true when a render-test command explicitly selects the given API.
-inline bool hasRenderTestRenderApiArg(const List<String>& args, RenderApiType apiType)
-{
-    for (const auto& arg : args)
-    {
-        if (arg.getLength() <= 1 || arg[0] != '-')
-            continue;
-
-        UnownedStringSlice name(arg.getUnownedSlice().begin() + 1, arg.getUnownedSlice().end());
-        if (RenderApiUtil::findApiTypeByName(name) == apiType)
-            return true;
-    }
-
-    return false;
-}
-
 /// Adds the slang-test default optimization level to render-test commands.
 ///
 /// The option is forwarded with `-Xslang` because render-test options are not slangc options.
 inline void addDefaultRenderTestSlangOptimization(CommandLine& ioCmdLine)
 {
     if (hasRenderTestSlangOptimizationArg(ioCmdLine.m_args))
-        return;
-
-    // Metal render-test paths do not invoke spv-opt, and many generated Metal CI variants rely on
-    // the optimized output that render-test/slangc uses by default.
-    if (hasRenderTestRenderApiArg(ioCmdLine.m_args, RenderApiType::Metal))
         return;
 
     ioCmdLine.addArg("-Xslang");

--- a/tools/slang-test/slang-test-optimization-options.h
+++ b/tools/slang-test/slang-test-optimization-options.h
@@ -3,6 +3,7 @@
 #define SLANG_TEST_OPTIMIZATION_OPTIONS_H
 
 #include "core/slang-command-line.h"
+#include "core/slang-render-api-util.h"
 #include "core/slang-type-text-util.h"
 
 namespace Slang
@@ -11,6 +12,15 @@ namespace SlangTest
 {
 
 static constexpr const char* kTestOptimizationOption = "-O0";
+
+/// The default optimization level for Metal render tests.
+///
+/// Metal render tests compile through the downstream `metal` toolchain to produce a metallib,
+/// and macOS CI showed mass flaky failures when that toolchain runs at `-O0` (the generated MSL
+/// itself is identical at every level). `-O1` maps to the toolchain's previous default flags, so
+/// Metal render tests keep the behavior that passed CI while still receiving an explicit
+/// slang-test-controlled level like every other target.
+static constexpr const char* kMetalRenderTestOptimizationOption = "-O1";
 
 /// Returns true when an argument is a slangc optimization-level option.
 ///
@@ -83,16 +93,36 @@ inline bool hasRenderTestSlangOptimizationArg(const List<String>& args)
     return false;
 }
 
+/// Returns true when a render-test command explicitly selects the given API.
+inline bool hasRenderTestRenderApiArg(const List<String>& args, RenderApiType apiType)
+{
+    for (const auto& arg : args)
+    {
+        if (arg.getLength() <= 1 || arg[0] != '-')
+            continue;
+
+        UnownedStringSlice name(arg.getUnownedSlice().begin() + 1, arg.getUnownedSlice().end());
+        if (RenderApiUtil::findApiTypeByName(name) == apiType)
+            return true;
+    }
+
+    return false;
+}
+
 /// Adds the slang-test default optimization level to render-test commands.
 ///
 /// The option is forwarded with `-Xslang` because render-test options are not slangc options.
+/// Metal render tests receive `-O1` instead of `-O0`; see
+/// `kMetalRenderTestOptimizationOption` for why.
 inline void addDefaultRenderTestSlangOptimization(CommandLine& ioCmdLine)
 {
     if (hasRenderTestSlangOptimizationArg(ioCmdLine.m_args))
         return;
 
+    const bool isMetal = hasRenderTestRenderApiArg(ioCmdLine.m_args, RenderApiType::Metal);
+
     ioCmdLine.addArg("-Xslang");
-    ioCmdLine.addArg(kTestOptimizationOption);
+    ioCmdLine.addArg(isMetal ? kMetalRenderTestOptimizationOption : kTestOptimizationOption);
 }
 
 } // namespace SlangTest

--- a/tools/slang-test/slang-test-optimization-options.h
+++ b/tools/slang-test/slang-test-optimization-options.h
@@ -1,0 +1,111 @@
+// slang-test-optimization-options.h
+#ifndef SLANG_TEST_OPTIMIZATION_OPTIONS_H
+#define SLANG_TEST_OPTIMIZATION_OPTIONS_H
+
+#include "core/slang-command-line.h"
+#include "core/slang-render-api-util.h"
+
+namespace Slang
+{
+namespace SlangTest
+{
+
+static constexpr const char* kTestOptimizationOption = "-O0";
+
+/// Returns true when an argument is a slangc optimization-level option.
+///
+/// This uses the exact spellings recognized by slangc so unrelated options with a `-O` prefix do
+/// not accidentally opt a test out of the slang-test default.
+inline bool isSlangOptimizationArg(const String& arg)
+{
+    return arg == "-O" || arg == "-O0" || arg == "-Onone" || arg == "-O1" || arg == "-Odefault" ||
+           arg == "-O2" || arg == "-Ohigh" || arg == "-O3" || arg == "-Omaximal";
+}
+
+/// Returns true when a compiler command line already specifies an optimization level.
+inline bool hasSlangOptimizationArg(const List<String>& args)
+{
+    for (const auto& arg : args)
+    {
+        if (isSlangOptimizationArg(arg))
+            return true;
+    }
+    return false;
+}
+
+/// Adds the slang-test default optimization level unless the test already specifies one.
+///
+/// Most compiler-based tests do not need optimized output, and keeping them at `-O0` avoids
+/// optimizer time and SPIR-V optimizer output churn.
+inline void addDefaultSlangOptimization(CommandLine& ioCmdLine)
+{
+    if (!hasSlangOptimizationArg(ioCmdLine.m_args))
+    {
+        ioCmdLine.addArg(kTestOptimizationOption);
+    }
+}
+
+/// Returns true when a render-test command forwards an optimization level to slangc.
+///
+/// Render-test accepts several forwarding forms, including single-argument forwarding and
+/// `-Xslang...` blocks, so slang-test checks each forwarded slangc argument before adding its
+/// default.
+inline bool hasRenderTestSlangOptimizationArg(const List<String>& args)
+{
+    for (Index i = 0; i < args.getCount(); ++i)
+    {
+        const auto& arg = args[i];
+        if ((arg == "-compile-arg" || arg == "-xslang" || arg == "-Xslang") &&
+            i + 1 < args.getCount() && isSlangOptimizationArg(args[i + 1]))
+        {
+            return true;
+        }
+        if (arg == "-Xslang...")
+        {
+            for (++i; i < args.getCount() && args[i] != "-X."; ++i)
+            {
+                if (isSlangOptimizationArg(args[i]))
+                    return true;
+            }
+        }
+    }
+    return false;
+}
+
+/// Returns true when a render-test command explicitly selects the given API.
+inline bool hasRenderTestRenderApiArg(const List<String>& args, RenderApiType apiType)
+{
+    for (const auto& arg : args)
+    {
+        if (arg.getLength() <= 1 || arg[0] != '-')
+            continue;
+
+        UnownedStringSlice name(arg.getUnownedSlice().begin() + 1, arg.getUnownedSlice().end());
+        if (RenderApiUtil::findApiTypeByName(name) == apiType)
+            return true;
+    }
+
+    return false;
+}
+
+/// Adds the slang-test default optimization level to render-test commands.
+///
+/// The option is forwarded with `-Xslang` because render-test options are not slangc options.
+inline void addDefaultRenderTestSlangOptimization(CommandLine& ioCmdLine)
+{
+    if (hasRenderTestSlangOptimizationArg(ioCmdLine.m_args))
+        return;
+
+    // Metal render-test paths do not invoke spv-opt, and many generated Metal CI variants rely on
+    // the optimized output that render-test/slangc uses by default.
+    if (hasRenderTestRenderApiArg(ioCmdLine.m_args, RenderApiType::Metal))
+        return;
+
+    ioCmdLine.addArg("-Xslang");
+    ioCmdLine.addArg(kTestOptimizationOption);
+}
+
+} // namespace SlangTest
+} // namespace Slang
+
+#endif

--- a/tools/slang-test/slang-test-optimization-options.h
+++ b/tools/slang-test/slang-test-optimization-options.h
@@ -4,6 +4,7 @@
 
 #include "core/slang-command-line.h"
 #include "core/slang-render-api-util.h"
+#include "core/slang-type-text-util.h"
 
 namespace Slang
 {
@@ -14,12 +15,23 @@ static constexpr const char* kTestOptimizationOption = "-O0";
 
 /// Returns true when an argument is a slangc optimization-level option.
 ///
-/// This uses the exact spellings recognized by slangc so unrelated options with a `-O` prefix do
-/// not accidentally opt a test out of the slang-test default.
+/// This uses slangc's optimization-level names so unrelated options with a `-O` prefix do not
+/// accidentally opt a test out of the slang-test default.
 inline bool isSlangOptimizationArg(const String& arg)
 {
-    return arg == "-O" || arg == "-O0" || arg == "-Onone" || arg == "-O1" || arg == "-Odefault" ||
-           arg == "-O2" || arg == "-Ohigh" || arg == "-O3" || arg == "-Omaximal";
+    const auto argSlice = arg.getUnownedSlice();
+    const auto optimizationPrefix = UnownedStringSlice::fromLiteral("-O");
+    if (!argSlice.startsWith(optimizationPrefix))
+        return false;
+
+    const auto levelSlice = argSlice.tail(optimizationPrefix.getLength());
+    if (levelSlice.getLength() == 0)
+        return true;
+
+    return NameValueUtil::findValue(
+               TypeTextUtil::getOptimizationLevelInfos(),
+               levelSlice,
+               ValueInt(-1)) != ValueInt(-1);
 }
 
 /// Returns true when a compiler command line already specifies an optimization level.

--- a/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
+++ b/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
@@ -170,9 +170,9 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 3);
-        SLANG_CHECK(cmdLine.m_args[0] == "-vk");
-        SLANG_CHECK(cmdLine.m_args[1] == "-Xslang");
-        SLANG_CHECK(cmdLine.m_args[2] == SlangTest::kTestOptimizationOption);
+        SLANG_CHECK(cmdLine.m_args[0] == "-Xslang");
+        SLANG_CHECK(cmdLine.m_args[1] == SlangTest::kTestOptimizationOption);
+        SLANG_CHECK(cmdLine.m_args[2] == "-vk");
     }
 
     {
@@ -238,9 +238,9 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 3);
-        SLANG_CHECK(cmdLine.m_args[0] == "-mtl");
-        SLANG_CHECK(cmdLine.m_args[1] == "-Xslang");
-        SLANG_CHECK(cmdLine.m_args[2] == SlangTest::kMetalRenderTestOptimizationOption);
+        SLANG_CHECK(cmdLine.m_args[0] == "-Xslang");
+        SLANG_CHECK(cmdLine.m_args[1] == SlangTest::kMetalRenderTestOptimizationOption);
+        SLANG_CHECK(cmdLine.m_args[2] == "-mtl");
     }
 
     {
@@ -250,9 +250,9 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 3);
-        SLANG_CHECK(cmdLine.m_args[0] == "-metal");
-        SLANG_CHECK(cmdLine.m_args[1] == "-Xslang");
-        SLANG_CHECK(cmdLine.m_args[2] == SlangTest::kMetalRenderTestOptimizationOption);
+        SLANG_CHECK(cmdLine.m_args[0] == "-Xslang");
+        SLANG_CHECK(cmdLine.m_args[1] == SlangTest::kMetalRenderTestOptimizationOption);
+        SLANG_CHECK(cmdLine.m_args[2] == "-metal");
     }
 
     // A Metal render test that already forwards a level keeps it.
@@ -270,10 +270,9 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         SLANG_CHECK(cmdLine.m_args[2] == "-O3");
     }
 
-    // Render-test commands append the default even after a trailing forwarding flag with no
-    // value. Unlike compiler-backed diagnostic tests, render-test directives never leave a
-    // forwarding flag dangling on purpose (such a command line is invalid for render-test), so
-    // appending is the pinned contract for this helper.
+    // The render-test default is inserted at the front, so a directive that accidentally
+    // leaves a forwarding flag without its value cannot consume the inserted default; the
+    // mistake stays visible as a dangling trailing flag.
     {
         CommandLine cmdLine;
         cmdLine.addArg("-vk");
@@ -282,9 +281,9 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 4);
-        SLANG_CHECK(cmdLine.m_args[0] == "-vk");
-        SLANG_CHECK(cmdLine.m_args[1] == "-xslang");
-        SLANG_CHECK(cmdLine.m_args[2] == "-Xslang");
-        SLANG_CHECK(cmdLine.m_args[3] == SlangTest::kTestOptimizationOption);
+        SLANG_CHECK(cmdLine.m_args[0] == "-Xslang");
+        SLANG_CHECK(cmdLine.m_args[1] == SlangTest::kTestOptimizationOption);
+        SLANG_CHECK(cmdLine.m_args[2] == "-vk");
+        SLANG_CHECK(cmdLine.m_args[3] == "-xslang");
     }
 }

--- a/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
+++ b/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
@@ -1,0 +1,154 @@
+// unit-test-slang-test-optimization-options.cpp
+
+#include "../slang-test/slang-test-optimization-options.h"
+#include "unit-test/slang-unit-test.h"
+
+using namespace Slang;
+
+SLANG_UNIT_TEST(slangTestOptimizationArgDetection)
+{
+    const char* optimizationArgs[] = {
+        "-O",
+        "-O0",
+        "-Onone",
+        "-O1",
+        "-Odefault",
+        "-O2",
+        "-Ohigh",
+        "-O3",
+        "-Omaximal",
+    };
+
+    for (const auto arg : optimizationArgs)
+    {
+        SLANG_CHECK(SlangTest::isSlangOptimizationArg(String(arg)));
+    }
+
+    SLANG_CHECK(!SlangTest::isSlangOptimizationArg(String("-Odump")));
+    SLANG_CHECK(!SlangTest::isSlangOptimizationArg(String("-output")));
+
+    {
+        List<String> args;
+        args.add("-target");
+        args.add("spirv");
+
+        SLANG_CHECK(!SlangTest::hasSlangOptimizationArg(args));
+
+        args.add("-O2");
+
+        SLANG_CHECK(SlangTest::hasSlangOptimizationArg(args));
+    }
+}
+
+SLANG_UNIT_TEST(slangTestRenderOptimizationArgDetection)
+{
+    {
+        List<String> args;
+        args.add("-compile-arg");
+        args.add("-O2");
+
+        SLANG_CHECK(SlangTest::hasRenderTestSlangOptimizationArg(args));
+    }
+
+    {
+        List<String> args;
+        args.add("-xslang");
+        args.add("-Ohigh");
+
+        SLANG_CHECK(SlangTest::hasRenderTestSlangOptimizationArg(args));
+    }
+
+    {
+        List<String> args;
+        args.add("-Xslang");
+        args.add("-O3");
+
+        SLANG_CHECK(SlangTest::hasRenderTestSlangOptimizationArg(args));
+    }
+
+    {
+        List<String> args;
+        args.add("-Xslang...");
+        args.add("-target");
+        args.add("spirv");
+        args.add("-Omaximal");
+        args.add("-X.");
+
+        SLANG_CHECK(SlangTest::hasRenderTestSlangOptimizationArg(args));
+    }
+
+    {
+        List<String> args;
+        args.add("-Xslang...");
+        args.add("-target");
+        args.add("spirv");
+        args.add("-X.");
+        args.add("-O3");
+
+        SLANG_CHECK(!SlangTest::hasRenderTestSlangOptimizationArg(args));
+    }
+
+    {
+        List<String> args;
+        args.add("-mtl");
+
+        SLANG_CHECK(SlangTest::hasRenderTestRenderApiArg(args, RenderApiType::Metal));
+        SLANG_CHECK(!SlangTest::hasRenderTestRenderApiArg(args, RenderApiType::Vulkan));
+    }
+}
+
+SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
+{
+    {
+        CommandLine cmdLine;
+
+        SlangTest::addDefaultSlangOptimization(cmdLine);
+
+        SLANG_CHECK(cmdLine.m_args.getCount() == 1);
+        SLANG_CHECK(cmdLine.m_args[0] == SlangTest::kTestOptimizationOption);
+    }
+
+    {
+        CommandLine cmdLine;
+        cmdLine.addArg("-O3");
+
+        SlangTest::addDefaultSlangOptimization(cmdLine);
+
+        SLANG_CHECK(cmdLine.m_args.getCount() == 1);
+        SLANG_CHECK(cmdLine.m_args[0] == "-O3");
+    }
+
+    {
+        CommandLine cmdLine;
+        cmdLine.addArg("-vk");
+
+        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+
+        SLANG_CHECK(cmdLine.m_args.getCount() == 3);
+        SLANG_CHECK(cmdLine.m_args[0] == "-vk");
+        SLANG_CHECK(cmdLine.m_args[1] == "-Xslang");
+        SLANG_CHECK(cmdLine.m_args[2] == SlangTest::kTestOptimizationOption);
+    }
+
+    {
+        CommandLine cmdLine;
+        cmdLine.addArg("-Xslang");
+        cmdLine.addArg("-O3");
+
+        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+
+        SLANG_CHECK(cmdLine.m_args.getCount() == 2);
+        SLANG_CHECK(cmdLine.m_args[0] == "-Xslang");
+        SLANG_CHECK(cmdLine.m_args[1] == "-O3");
+    }
+
+    {
+        CommandLine cmdLine;
+        cmdLine.addArg("-mtl");
+
+        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+
+        SLANG_CHECK(cmdLine.m_args.getCount() == 1);
+        SLANG_CHECK(cmdLine.m_args[0] == "-mtl");
+    }
+}

--- a/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
+++ b/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
@@ -147,6 +147,22 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         SLANG_CHECK(cmdLine.m_args[0] == "-O3");
     }
 
+    // The default is inserted at the front so it cannot be consumed as the argument of a
+    // trailing option that a diagnostic test intentionally leaves dangling.
+    {
+        CommandLine cmdLine;
+        cmdLine.addArg("test.slang");
+        cmdLine.addArg("-profile");
+        cmdLine.addArg("ps_4_0");
+        cmdLine.addArg("-target");
+
+        SlangTest::addDefaultSlangOptimization(cmdLine);
+
+        SLANG_CHECK(cmdLine.m_args.getCount() == 5);
+        SLANG_CHECK(cmdLine.m_args[0] == SlangTest::kTestOptimizationOption);
+        SLANG_CHECK(cmdLine.m_args[4] == "-target");
+    }
+
     {
         CommandLine cmdLine;
         cmdLine.addArg("-vk");

--- a/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
+++ b/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
@@ -124,22 +124,6 @@ SLANG_UNIT_TEST(slangTestRenderOptimizationArgDetection)
 
         SLANG_CHECK(!SlangTest::hasRenderTestSlangOptimizationArg(args));
     }
-
-    {
-        List<String> args;
-        args.add("-mtl");
-
-        SLANG_CHECK(SlangTest::hasRenderTestRenderApiArg(args, RenderApiType::Metal));
-        SLANG_CHECK(!SlangTest::hasRenderTestRenderApiArg(args, RenderApiType::Vulkan));
-    }
-
-    {
-        List<String> args;
-        args.add("-metal");
-
-        SLANG_CHECK(SlangTest::hasRenderTestRenderApiArg(args, RenderApiType::Metal));
-        SLANG_CHECK(!SlangTest::hasRenderTestRenderApiArg(args, RenderApiType::Vulkan));
-    }
 }
 
 SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
@@ -235,8 +219,10 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
 
         SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
 
-        SLANG_CHECK(cmdLine.m_args.getCount() == 1);
+        SLANG_CHECK(cmdLine.m_args.getCount() == 3);
         SLANG_CHECK(cmdLine.m_args[0] == "-mtl");
+        SLANG_CHECK(cmdLine.m_args[1] == "-Xslang");
+        SLANG_CHECK(cmdLine.m_args[2] == SlangTest::kTestOptimizationOption);
     }
 
     {
@@ -245,7 +231,9 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
 
         SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
 
-        SLANG_CHECK(cmdLine.m_args.getCount() == 1);
+        SLANG_CHECK(cmdLine.m_args.getCount() == 3);
         SLANG_CHECK(cmdLine.m_args[0] == "-metal");
+        SLANG_CHECK(cmdLine.m_args[1] == "-Xslang");
+        SLANG_CHECK(cmdLine.m_args[2] == SlangTest::kTestOptimizationOption);
     }
 }

--- a/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
+++ b/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
@@ -213,6 +213,8 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         SLANG_CHECK(cmdLine.m_args[4] == "-X.");
     }
 
+    // Metal render tests receive the Metal-specific default level; see
+    // kMetalRenderTestOptimizationOption for why.
     {
         CommandLine cmdLine;
         cmdLine.addArg("-mtl");
@@ -222,7 +224,7 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         SLANG_CHECK(cmdLine.m_args.getCount() == 3);
         SLANG_CHECK(cmdLine.m_args[0] == "-mtl");
         SLANG_CHECK(cmdLine.m_args[1] == "-Xslang");
-        SLANG_CHECK(cmdLine.m_args[2] == SlangTest::kTestOptimizationOption);
+        SLANG_CHECK(cmdLine.m_args[2] == SlangTest::kMetalRenderTestOptimizationOption);
     }
 
     {
@@ -234,6 +236,21 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         SLANG_CHECK(cmdLine.m_args.getCount() == 3);
         SLANG_CHECK(cmdLine.m_args[0] == "-metal");
         SLANG_CHECK(cmdLine.m_args[1] == "-Xslang");
-        SLANG_CHECK(cmdLine.m_args[2] == SlangTest::kTestOptimizationOption);
+        SLANG_CHECK(cmdLine.m_args[2] == SlangTest::kMetalRenderTestOptimizationOption);
+    }
+
+    // A Metal render test that already forwards a level keeps it.
+    {
+        CommandLine cmdLine;
+        cmdLine.addArg("-mtl");
+        cmdLine.addArg("-Xslang");
+        cmdLine.addArg("-O3");
+
+        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+
+        SLANG_CHECK(cmdLine.m_args.getCount() == 3);
+        SLANG_CHECK(cmdLine.m_args[0] == "-mtl");
+        SLANG_CHECK(cmdLine.m_args[1] == "-Xslang");
+        SLANG_CHECK(cmdLine.m_args[2] == "-O3");
     }
 }

--- a/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
+++ b/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
@@ -1,6 +1,6 @@
 // unit-test-slang-test-optimization-options.cpp
 
-#include "../slang-test/slang-test-optimization-options.h"
+#include "slang-test/slang-test-optimization-options.h"
 #include "unit-test/slang-unit-test.h"
 
 using namespace Slang;
@@ -90,6 +90,43 @@ SLANG_UNIT_TEST(slangTestRenderOptimizationArgDetection)
 
     {
         List<String> args;
+        args.add("-Xslang...");
+        args.add("-target");
+        args.add("spirv");
+
+        SLANG_CHECK(!SlangTest::hasRenderTestSlangOptimizationArg(args));
+    }
+
+    {
+        List<String> args;
+        args.add("-compile-arg");
+
+        SLANG_CHECK(!SlangTest::hasRenderTestSlangOptimizationArg(args));
+    }
+
+    {
+        List<String> args;
+        args.add("-xslang");
+
+        SLANG_CHECK(!SlangTest::hasRenderTestSlangOptimizationArg(args));
+    }
+
+    {
+        List<String> args;
+        args.add("-Xslang");
+
+        SLANG_CHECK(!SlangTest::hasRenderTestSlangOptimizationArg(args));
+    }
+
+    {
+        List<String> args;
+        args.add("-Xslang...");
+
+        SLANG_CHECK(!SlangTest::hasRenderTestSlangOptimizationArg(args));
+    }
+
+    {
+        List<String> args;
         args.add("-mtl");
 
         SLANG_CHECK(SlangTest::hasRenderTestRenderApiArg(args, RenderApiType::Metal));
@@ -140,6 +177,48 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         SLANG_CHECK(cmdLine.m_args.getCount() == 2);
         SLANG_CHECK(cmdLine.m_args[0] == "-Xslang");
         SLANG_CHECK(cmdLine.m_args[1] == "-O3");
+    }
+
+    {
+        CommandLine cmdLine;
+        cmdLine.addArg("-compile-arg");
+        cmdLine.addArg("-O2");
+
+        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+
+        SLANG_CHECK(cmdLine.m_args.getCount() == 2);
+        SLANG_CHECK(cmdLine.m_args[0] == "-compile-arg");
+        SLANG_CHECK(cmdLine.m_args[1] == "-O2");
+    }
+
+    {
+        CommandLine cmdLine;
+        cmdLine.addArg("-xslang");
+        cmdLine.addArg("-Ohigh");
+
+        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+
+        SLANG_CHECK(cmdLine.m_args.getCount() == 2);
+        SLANG_CHECK(cmdLine.m_args[0] == "-xslang");
+        SLANG_CHECK(cmdLine.m_args[1] == "-Ohigh");
+    }
+
+    {
+        CommandLine cmdLine;
+        cmdLine.addArg("-Xslang...");
+        cmdLine.addArg("-target");
+        cmdLine.addArg("spirv");
+        cmdLine.addArg("-O3");
+        cmdLine.addArg("-X.");
+
+        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+
+        SLANG_CHECK(cmdLine.m_args.getCount() == 5);
+        SLANG_CHECK(cmdLine.m_args[0] == "-Xslang...");
+        SLANG_CHECK(cmdLine.m_args[1] == "-target");
+        SLANG_CHECK(cmdLine.m_args[2] == "spirv");
+        SLANG_CHECK(cmdLine.m_args[3] == "-O3");
+        SLANG_CHECK(cmdLine.m_args[4] == "-X.");
     }
 
     {

--- a/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
+++ b/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
@@ -269,4 +269,22 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         SLANG_CHECK(cmdLine.m_args[1] == "-Xslang");
         SLANG_CHECK(cmdLine.m_args[2] == "-O3");
     }
+
+    // Render-test commands append the default even after a trailing forwarding flag with no
+    // value. Unlike compiler-backed diagnostic tests, render-test directives never leave a
+    // forwarding flag dangling on purpose (such a command line is invalid for render-test), so
+    // appending is the pinned contract for this helper.
+    {
+        CommandLine cmdLine;
+        cmdLine.addArg("-vk");
+        cmdLine.addArg("-xslang");
+
+        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+
+        SLANG_CHECK(cmdLine.m_args.getCount() == 4);
+        SLANG_CHECK(cmdLine.m_args[0] == "-vk");
+        SLANG_CHECK(cmdLine.m_args[1] == "-xslang");
+        SLANG_CHECK(cmdLine.m_args[2] == "-Xslang");
+        SLANG_CHECK(cmdLine.m_args[3] == SlangTest::kTestOptimizationOption);
+    }
 }

--- a/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
+++ b/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
@@ -132,6 +132,14 @@ SLANG_UNIT_TEST(slangTestRenderOptimizationArgDetection)
         SLANG_CHECK(SlangTest::hasRenderTestRenderApiArg(args, RenderApiType::Metal));
         SLANG_CHECK(!SlangTest::hasRenderTestRenderApiArg(args, RenderApiType::Vulkan));
     }
+
+    {
+        List<String> args;
+        args.add("-metal");
+
+        SLANG_CHECK(SlangTest::hasRenderTestRenderApiArg(args, RenderApiType::Metal));
+        SLANG_CHECK(!SlangTest::hasRenderTestRenderApiArg(args, RenderApiType::Vulkan));
+    }
 }
 
 SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
@@ -229,5 +237,15 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 1);
         SLANG_CHECK(cmdLine.m_args[0] == "-mtl");
+    }
+
+    {
+        CommandLine cmdLine;
+        cmdLine.addArg("-metal");
+
+        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+
+        SLANG_CHECK(cmdLine.m_args.getCount() == 1);
+        SLANG_CHECK(cmdLine.m_args[0] == "-metal");
     }
 }


### PR DESCRIPTION
Fixes #11804
Closes #11146

## Motivation

Release `slang-test` runs spend substantial time compiling tests with optimization enabled even though most tests only need stable codegen or execution coverage. In the measured Release build, defaulting test compiler invocations to `-O0` reduced a full run from 34 min 9 sec to 11 min 24 sec.

The SPIR-V tests also become less sensitive to `spirv-opt` output changes. When SPIR-V submodules are updated, optimizer differences can otherwise change expected output for tests that do not actually mean to exercise optimized SPIR-V. Skipping the optimizer by default makes those updates less noisy, while optimization-sensitive tests can still opt in explicitly.

## Proposed solution

`slang-test` now appends a default `-O0` when it builds a Slang compiler command line and the test did not already provide a recognized optimization option. Compiler-backed paths receive `-O0` directly. Render-test-backed paths receive `-Xslang -O0`, which is the render-test spelling for forwarding the option to Slang.

Every render-test-backed path receives an explicit slang-test-controlled default. Metal render tests receive `-Xslang -O1` instead of `-O0`: the Slang optimization level is never read by Slang's own IR pipeline (the emitted MSL is byte-identical at every level), but it selects the flags passed to the downstream `metal` toolchain that produces the metallib, and macOS CI showed mass flaky failures (650+ tests, differing sets between jobs, fast empty-output failures) when that toolchain runs at `-O0`. `-O1` maps to the toolchain flags that were in effect before this PR, so Metal keeps the exact behavior that passes CI while still getting an explicit level like every other target.

The override detection uses slangc's known optimization spellings instead of treating every `-O...` option as an optimization level. That keeps unrelated future options from accidentally suppressing the slang-test default. Tests whose expected output or runtime behavior depends on optimization opt in explicitly with the lowest optimization level required by that backend.

## Change summary

- `tools/slang-test/slang-test-optimization-options.h` centralizes the default optimization option, direct compiler override detection, render-test forwarding detection, and render-test default insertion, including the Metal-specific `-O1` default (`kMetalRenderTestOptimizationOption`).
- `tools/slang-test/slang-test-main.cpp` appends the shared default across compiler-backed and render-test-backed command builders, with compiler-backed paths adding it after `_initSlangCompiler()` for consistent duplicate-detection behavior.
- `tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp` covers the accepted optimization spellings, render-test forwarding forms, idempotent default insertion, and the Metal-specific defaulting for `-mtl`/`-metal` spellings including the override case.
- `tools/slang-test/README.md` documents the new default, the compiler-backed opt-in spelling, the render-test-backed forwarding spellings (all four recognized forms), the Metal `-O1` exception, accepted optimization spellings, and the diagnostic-test pitfall.
- Optimization-sensitive tests from the failure log now declare explicit optimization levels in their `//TEST` directives. This includes `tests/autodiff/path-tracer/pt-loop.slang`, whose `-vk` directive opts into `-Xslang -O1` because its unoptimized SPIR-V (spirv-opt skipped at `-O0`) crashed the Linux CI test server.

## Concepts and vocabulary

- Compiler-backed tests build command lines that go directly to the Slang compiler.
- Render-test-backed tests invoke `render-test`, so Slang compiler arguments must be forwarded with render-test options such as `-Xslang`.
- Optimization-sensitive tests are tests whose expected output or runtime result depends on optimization passes being enabled.
- The Slang optimization level (`-O0`..`-O3`) does not change Slang's own IR passes; it controls whether `spirv-opt` runs (skipped entirely at `-O0`) and which flags downstream compilers (dxc, metal, nvrtc, gcc/clang) receive.

## Process report

The input shape reaching `slang-test` is the parsed argument list from a `//TEST` directive. That shape is intentional: tests can already specify compiler options, and an explicit optimization option is the right source of truth for optimization-sensitive tests. The helper only checks whether such an override exists before appending the default; it does not reinterpret the test directive or change how other options are parsed.

For compiler-backed commands, `SlangTest::addDefaultSlangOptimization` runs after the command builder has added directive arguments (and after `_initSlangCompiler()` for paths that call it), so its override check sees the full argument list — but it inserts the default `-O0` at the *front* of the argument list rather than appending it. Front insertion makes the default position-independent: slangc option parsing accepts options in any order, while an appended `-O0` could be consumed as the argument of a trailing option a test intentionally leaves dangling. This is why `tests/diagnostics/command-line/option-missing-argument.slang` needs no modification: its `-profile ps_4_0 -target` directive keeps `-target` dangling and still reports the missing-argument diagnostic. The `slangTestDefaultOptimizationInsertion` unit test pins the front-insertion contract with exactly that dangling-`-target` shape.

For render-test-backed commands, `SlangTest::addDefaultRenderTestSlangOptimization` performs the same check through render-test forwarding forms and inserts `-Xslang <level>` at the front of the argument list so the option reaches the Slang compiler rather than being treated as a render-test option. Front insertion here mirrors the compiler-backed path, per review: a directive that accidentally leaves an option without its required parameter cannot consume the inserted default, so the mistake stays visible instead of silently changing the command. This is safe because render-test's parser collects positional arguments in order and `stripDownstreamArgs` handles forwarding pairs position-independently. The helper recognizes `-compile-arg`, `-xslang`, `-Xslang`, and `-Xslang... ... -X.` forms. The unit test locks in those spellings and the front-insertion contract because a directive-level integration test could pass even if a helper accidentally inserted a stray `-O0`.

Metal render tests receive `-O1` instead of `-O0`. This was verified empirically across four CI rounds: commits without a Metal exception (968453a31, 5b4c9df84) failed 650+ Metal tests on macOS with flaky, fast, empty-output failures, while commits with one (ef2ec5f57, eab84de8c) passed. The mechanism was traced in code: Slang's IR pipeline never reads the optimization level (verified by diffing `slangc -target metal` output at `-O0` vs default — byte-identical), so the only Metal-path difference is `GCCDownstreamCompilerUtil::calcArgs` passing `-O0` instead of `-Os` to the `metal` CLI when slang-rhi requests `SLANG_METAL_LIB`. The instability therefore lives in the downstream Metal toolchain/runtime on the macOS runners, not in Slang, and is out of scope for this test-infrastructure PR. Choosing `-O1` (which maps back to `-Os`) keeps the uniform "slang-test always sets an explicit level" invariant while pinning Metal to the previously passing downstream flags. This supersedes the earlier fully-uniform `-O0` approach; see the Reviewer Directives section.

`tests/autodiff/path-tracer/pt-loop.slang` opts its `-vk` directive into `-Xslang -O1`. At `-O0`, `spirv-opt` is skipped entirely (`source/slang-glslang/slang-glslang.cpp`, `SLANG_OPTIMIZATION_LEVEL_NONE` early-out), and this heavy autodiff path-tracer's unoptimized SPIR-V consistently crashed the Linux CI test server (JSON RPC failure) on the NVIDIA driver while passing on Windows GPU. `-O1` restores exactly the pre-PR behavior for this one test, using the opt-in mechanism the issue prescribes.

The remaining tests changed in this PR are the cases exposed by the `-O0` default. Their expected output or runtime behavior depends on optimized Slang IR or downstream optimized codegen, so the directives now opt in explicitly. The opt-in levels are the lowest that keep each test passing, and they are not interchangeable: `tests/language-feature/dynamic-dispatch/layout-array-2d.slang` fails at `-Xslang -O3` because dxc's validator rejects the shader with an uninitialized-value (`undef`) read that only surfaces at the higher downstream optimization level, and `tests/language-feature/swizzles/matrix-swizzle-out-arg-writeback.slang` fails at `-O3` because spirv-opt's aggressive passes flatten the exact `OpAccessChain`/`OpStore` shapes its FileCheck patterns pin, while `-O1` preserves them.


## Reviewer Directives (maintained by agent)

- [human @jkwak-work] Treat all target platforms uniformly for the slang-test optimization default. Source: https://github.com/shader-slang/slang/pull/11805#discussion_r3493215640 — **Amended by CI evidence**: fully-uniform `-O0` demonstrably breaks 650+ Metal tests on macOS CI (see Process report). The current implementation keeps the uniform "always append an explicit level" shape but pins Metal to `-O1` (the previously passing downstream flags). Pending explicit confirmation from @jkwak-work.
- [human @jkwak-work] Do not add directive-level `.slang` regression tests for this command-line default; keep the coverage focused in helper/unit tests instead. Source: https://github.com/shader-slang/slang/pull/11805#discussion_r3488142488
- [human @jkwak-work] Minimize modifications to existing test files; prefer infrastructure-level solutions over editing many `//TEST` directives. (Stated during agent session, 2026-07-01.)
- [human @jkwak-work] Prefer `-O3` for optimization opt-ins where possible (requested for `layout-array-2d.slang` and `matrix-swizzle-out-arg-writeback.slang`). — **Amended by validation evidence**: both tests fail at `-O3` (dxc `undef`-read validation error on dx12; spirv-opt flattening the pinned `OpAccessChain` shapes for spirv-asm), so they remain at `-O2`/`-O1` respectively; see the thread replies for the traces. This also supersedes the earlier session note that `-O2` and `-O3` are equivalent in practice — they map to different downstream dxc levels. Pending confirmation from @jkwak-work.
- [human @jkwak-work] Insert the slang-test default optimization option at the front of the argument list — never append — for both compiler-backed and render-test-backed commands, so a directive with an accidentally missing option parameter cannot consume the inserted default. Source: https://github.com/shader-slang/slang/pull/11805#discussion_r3510402693


