### PR TITLE
Fix CMake options workflow failures

### DIFF
--- a/.github/workflows/cmake-options-build-container.yml
+++ b/.github/workflows/cmake-options-build-container.yml
@@ -115,9 +115,8 @@ jobs:
               cmake --preset default --fresh \
                 -DSLANG_SLANG_LLVM_FLAVOR=DISABLE \
                 -DSLANG_USE_SCCACHE=OFF \
-                -LA 2>/dev/null \
-              | grep -E "^${option}:(BOOL|STRING)=" \
-              | sed 's/.*=//' \
+                -LA \
+              | sed -n -E "s/^${option}:(BOOL|STRING)=//p" \
               | tr '[:upper:]' '[:lower:]'
             )
             case "$defaultVal" in

--- a/.github/workflows/cmake-options-build.yml
+++ b/.github/workflows/cmake-options-build.yml
@@ -141,9 +141,8 @@ jobs:
                 -DSLANG_SLANG_LLVM_FLAVOR=DISABLE \
                 -DSLANG_USE_SCCACHE=OFF \
                 $SLANG_CI_DXC_BUILD_FROM_SOURCE \
-                -LA 2>/dev/null \
-              | grep -E "^${option}:(BOOL|STRING)=" \
-              | sed 's/.*=//' \
+                -LA \
+              | sed -n -E "s/^${option}:(BOOL|STRING)=//p" \
               | tr '[:upper:]' '[:lower:]'
             )
             case "$defaultVal" in

--- a/.github/workflows/cmake-options.yml
+++ b/.github/workflows/cmake-options.yml
@@ -102,7 +102,7 @@ jobs:
       compiler: cl
       platform: x86_64
       config: debug
-      runs-on: '["windows-2025"]'
+      runs-on: '["windows-2022"]'
       buildtool: "Visual Studio 17 2022"
 
   windows-vs2022-release:
@@ -112,7 +112,7 @@ jobs:
       compiler: cl
       platform: x86_64
       config: release
-      runs-on: '["windows-2025"]'
+      runs-on: '["windows-2022"]'
       buildtool: "Visual Studio 17 2022"
 
   windows-vs2026-debug:

--- a/examples/shader-coverage-bvh-traversal/CMakeLists.txt
+++ b/examples/shader-coverage-bvh-traversal/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(
     vk_compute_demo.h
     vk_compute_demo.cpp
 )
+set_default_compile_options(shader-coverage-bvh-traversal USE_FEWER_WARNINGS)
 add_dependencies(shader-coverage-bvh-traversal ${_copy_target})
 
 target_include_directories(

--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -246,6 +246,7 @@ set(slang_build_args
     # a warning is disabled for a memset boundary check.
     # everything looked fine and it is unclear why the checking fails
     $<$<CXX_COMPILER_ID:GNU>:-Wno-error=stringop-overflow>
+    $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<BOOL:${SLANG_ENABLE_ASAN}>>:/bigobj>
     INCLUDE_DIRECTORIES_PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}/slang-version-header
     ${CMAKE_CURRENT_BINARY_DIR}/../standard-modules/slang-standard-module-config-header

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -215,6 +215,11 @@ struct GenericArgumentInferenceFailure
         GenericParamUnificationConflict,
     };
 
+    // Empty payload type for `Kind::None`.
+    struct NonePayload
+    {
+    };
+
     struct VariadicPackCountMismatch
     {
         SourceLoc location = SourceLoc();
@@ -287,6 +292,9 @@ struct GenericArgumentInferenceFailure
     Kind kind = Kind::None;
     union
     {
+        // Keep `Kind::None` as a real active union member; without this, GCC
+        // reports maybe-uninitialized errors when overload candidates are copied.
+        NonePayload nonePayload;
         VariadicPackCountMismatch variadicPackCountMismatch;
         GenericArityMismatch genericArityMismatch;
         OrdinaryGenericParamNotInferred ordinaryGenericParamNotInferred;
@@ -299,7 +307,8 @@ struct GenericArgumentInferenceFailure
     // placement-new in `set*()` / `copyActiveMemberFrom` (which never destroys
     // the previously active member first) well-defined.
     static_assert(
-        std::is_trivially_destructible_v<VariadicPackCountMismatch> &&
+        std::is_trivially_destructible_v<NonePayload> &&
+            std::is_trivially_destructible_v<VariadicPackCountMismatch> &&
             std::is_trivially_destructible_v<GenericArityMismatch> &&
             std::is_trivially_destructible_v<OrdinaryGenericParamNotInferred> &&
             std::is_trivially_destructible_v<InterfaceConformanceNotSatisfied> &&
@@ -308,7 +317,7 @@ struct GenericArgumentInferenceFailure
         "GenericArgumentInferenceFailure payloads must be trivially destructible");
 
     GenericArgumentInferenceFailure()
-        : variadicPackCountMismatch()
+        : nonePayload()
     {
     }
 
@@ -320,6 +329,9 @@ struct GenericArgumentInferenceFailure
 
     GenericArgumentInferenceFailure& operator=(GenericArgumentInferenceFailure const& other)
     {
+        if (this == &other)
+            return *this;
+
         kind = other.kind;
         copyActiveMemberFrom(other);
         return *this;
@@ -399,6 +411,7 @@ private:
                 GenericParamUnificationConflict(other.genericParamUnificationConflict);
             break;
         case Kind::None:
+            new (&nonePayload) NonePayload(other.nonePayload);
             break;
         }
     }


### PR DESCRIPTION
Fixes #11806

**Motivation**

The CMake Options workflow failed in https://github.com/shader-slang/slang/actions/runs/28324396568 for several independent reasons that showed up across the matrix. A representative VS2022 row failed before configure because the job asked CMake for the `Visual Studio 17 2022` generator while running on a Windows image that only exposed the VS2026 toolchain. Most Linux aarch64 release rows then failed under `-Werror=maybe-uninitialized` while sorting overload candidates that copy `GenericArgumentInferenceFailure`. The ASAN rows exposed missing link flags in one raw example target and an MSVC object-size limit in compiler sources.

**Proposed solution**

Keep the workflow matrix aligned with the toolchains it requests and make option default probing report real CMake failures instead of hiding them behind a silent pipeline failure. For the build failures, fix the underlying target setup: make the `GenericArgumentInferenceFailure::None` state a real union alternative, apply `/bigobj` to Slang compiler objects only for MSVC ASAN builds, and route the BVH traversal example through the common option helper so ASAN link flags are attached consistently.

**Change summary**

- Move the VS2022 CMake option jobs back to `windows-2022` so `Visual Studio 17 2022` exists on the runner.
- Harden CMake option default probing in both host and container workflows by removing stderr suppression and replacing the `grep | sed` path with a single cache-line extraction.
- Give `GenericArgumentInferenceFailure::Kind::None` a `NonePayload` union member and copy it like the other tagged-union members.
- Add MSVC `/bigobj` to the Slang compiler target options only when `SLANG_ENABLE_ASAN` is enabled.
- Apply `set_default_compile_options` to `shader-coverage-bvh-traversal`.

**Concepts and vocabulary**

A CMake option sweep is one matrix row that configures Slang with one option flipped from its default. `GenericArgumentInferenceFailure` is a tagged union carried by overload candidates so failed speculative candidates can defer detailed diagnostics until overload resolution selects them. `NonePayload` is the empty union member that represents `Kind::None`, the state where no deferred generic-inference diagnostic has been captured.

**Process report**

The VS2022 failures were configuration mismatches, not Slang build failures. The workflow passed `-G "Visual Studio 17 2022"`, but the failing runner image was `windows-2025`, whose setup step exposed a VS2026 installation. Moving only the VS2022 jobs to `windows-2022` restores the invariant that the runner image contains the requested generator; the VS2026 jobs still use `windows-2025`.

The default-value probe previously ran `cmake ... -LA 2>/dev/null | grep ... | sed ...`. When CMake itself failed, the useful error went to suppressed stderr, and when the cache line was absent, `grep` made the step fail before the workflow printed the option-specific diagnostic. The replacement keeps CMake stderr visible and uses `sed -n -E` to extract only the requested cache value. If CMake succeeds but the option is still missing, the existing explicit `ERROR: could not detect default` branch reports the option name. This is also the intended fix path for `SLANG_EXCLUDE_TINT`: because its default is `OFF`, the matrix does not need a hardcoded value and should naturally test `ON` after probing the default.

The run also showed a host-runner OptiX download failure before one row could test the requested option. This PR does not change CUDA/OptiX auto-enablement; that failure is recorded in the issue as a follow-up so this PR can stay focused on the runner mismatch, default-probe behavior, and direct build failures.

The aarch64 warning was rooted in `GenericArgumentInferenceFailure` itself. Overload resolution stores this value inside `OverloadCandidate`, and the failing build sorted those candidates, forcing copies and moves through the tagged union. `Kind::None` was an intentional state meaning that no deferred diagnostic had been captured yet, but the union had no corresponding active member for that state. The fix makes `None` construct and copy a trivial `NonePayload` member, preserving the existing invariant that `kind` names the live union member. This is producer-side cleanup of the representation, not a downstream warning suppression.

The Linux ASAN link failure came from `examples/shader-coverage-bvh-traversal`, which used raw `add_executable` setup and therefore missed the common helper that supplies sanitizer-related compile and link options. Applying `set_default_compile_options` to that target puts it on the same path as other Slang targets. The Windows ASAN failure was MSVC's section-count limit while compiling large compiler sources with instrumentation enabled, so `/bigobj` is gated on both `CXX_COMPILER_ID:MSVC` and `SLANG_ENABLE_ASAN`. Normal MSVC builds keep their previous compile options.

Validation run locally: JSON parsing for `.github/cmake-options-matrix.json`, YAML parsing for the touched workflows, `git diff --check`, and a VS2026 MSVC configure plus `slang-common-objects` build with CUDA/OptiX, Dawn, and Tint disabled. I also configured VS2026 twice with `SLANG_ENABLE_ASAN=ON` and `SLANG_ENABLE_ASAN=OFF`; the generated Slang project contains `/bigobj` only in the ASAN-on build. A separate local default Clang configure/build attempt was blocked by the machine pairing Clang 18 with the VS2026 STL, which requires Clang 20 or newer.