### PR TITLE
[DO NOT MERGE] Test: exercise CI container image publisher validation

### DIFF
--- a/docker/linux-clang-ci.Dockerfile
+++ b/docker/linux-clang-ci.Dockerfile
@@ -8,11 +8,12 @@
 # - .github/workflows/ci-slang-coverage.yml  (future)
 #
 # Build and push:
-#   docker build -f docker/linux-clang-ci.Dockerfile -t ghcr.io/shader-slang/slang-linux-clang-ci:v1.0.1 .
-#   docker push ghcr.io/shader-slang/slang-linux-clang-ci:v1.0.1
+#   docker build -f docker/linux-clang-ci.Dockerfile -t ghcr.io/shader-slang/slang-linux-clang-ci:v1.0.2 .
+#   docker push ghcr.io/shader-slang/slang-linux-clang-ci:v1.0.2
 
 FROM ubuntu:22.04
 
+# TEST: publisher workflow smoke-test marker (reverted before any merge).
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install essential tools required for GitHub Actions


### PR DESCRIPTION
Throwaway PR to smoke-test the `publish-ci-container-images.yml` validation path end-to-end (PRs validate only, never build/push).

Sequence of pushes exercises all version checks:
1. **This commit** — clang Dockerfile input changed WITHOUT tag bump → expect `Validate version bump` to **fail**.
2. Next — bump tag to an already-published `v1.0.1` → expect `Check tag availability` to **fail**.
3. Next — bump tag to a fresh unused semver → expect all checks to **pass**.

Will be closed without merging once validation behavior is confirmed.