### PR TITLE
Fix #11778: diagnose use of loop-carried uninitialized variable

### DIFF
--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -193,7 +193,7 @@ static bool canIgnoreType(IRType* type, IRType* upper)
 // path — a *conditional* (must-init) situation that `cancelLoadsByDefiniteAssignment`
 // already classifies. Following merge phis here would misreport those as unconditional
 // (may-init) reads.
-static IRParam* getLoopArgTargetParam(IRUse* use)
+static IRParam* getLoopArgTargetParam(IRUse* use, IRLoop** outLoop = nullptr)
 {
     auto loop = as<IRLoop>(use->getUser());
     if (!loop)
@@ -216,7 +216,11 @@ static IRParam* getLoopArgTargetParam(IRUse* use)
     for (auto param : target->getParams())
     {
         if (paramIndex == argIndex)
+        {
+            if (outLoop)
+                *outLoop = loop;
             return param;
+        }
         paramIndex++;
     }
     return nullptr;
@@ -232,7 +236,18 @@ static IRParam* getLoopArgTargetParam(IRUse* use)
 // with each iteration's update; the first-iteration read of that phi is a read of the
 // undefined value. Without following the phi the only direct use of the undefined
 // instruction is the loop argument, which records no load, so the read escapes detection.
-static List<IRInst*> getAliasableInstructions(IRInst* inst)
+//
+// When a loop header phi is followed, it is recorded in `loopPhis` (when provided)
+// together with its `IRLoop`. This lets the caller tell a *post-loop* read of the phi
+// apart from an *in-loop* one. A post-loop read — reached only after the loop's break
+// block — sees the undefined value only on the zero-trip path, because the loop body
+// re-defines the variable on every iteration that runs. That is a conditional
+// (must-init) situation, which the established loop-relaxation policy deliberately does
+// not warn on (see `cancelLoadsByDefiniteAssignment`). The genuine first-iteration read
+// *inside* the loop body is not post-loop and is still reported.
+static List<IRInst*> getAliasableInstructions(
+    IRInst* inst,
+    Dictionary<IRInst*, IRLoop*>* loopPhis = nullptr)
 {
     List<IRInst*> addresses;
     HashSet<IRInst*> visited;
@@ -261,11 +276,13 @@ static List<IRInst*> getAliasableInstructions(IRInst* inst)
             {
                 alias = user;
             }
-            else if (auto param = getLoopArgTargetParam(use))
+            else if (IRLoop* loop = nullptr; auto param = getLoopArgTargetParam(use, &loop))
             {
                 // The value flows into a loop header phi; the phi carries it forward
                 // into the loop body.
                 alias = param;
+                if (loopPhis)
+                    loopPhis->addIfNotExists(param, loop);
             }
 
             if (alias && visited.add(alias))
@@ -714,9 +731,13 @@ static void cancelLoadsByDefiniteAssignment(
     }
 }
 
-static void collectAliasableLoadStores(IRInst* inst, List<IRInst*>& stores, List<IRInst*>& loads)
+static void collectAliasableLoadStores(
+    IRInst* inst,
+    List<IRInst*>& stores,
+    List<IRInst*>& loads,
+    Dictionary<IRInst*, IRLoop*>* loopPhis = nullptr)
 {
-    auto addresses = getAliasableInstructions(inst);
+    auto addresses = getAliasableInstructions(inst, loopPhis);
 
     for (auto alias : addresses)
     {
@@ -724,6 +745,38 @@ static void collectAliasableLoadStores(IRInst* inst, List<IRInst*>& stores, List
         for (auto use = alias->firstUse; use; use = use->nextUse)
             collectInstructionByUsage(stores, loads, use->getUser(), alias);
     }
+}
+
+// Returns true if `load` is a *post-loop* read of a loop header phi in `loopPhis`: it
+// uses such a phi and its block is reachable from that phi's loop break block.
+//
+// A loop header phi merges the undefined pre-loop value (loop-entry edge) with the loop
+// body's per-iteration update (back-edge). Reaching a read of the phi only via the break
+// block means every path to it first ran the loop, so the read sees the undefined value
+// only when the loop ran zero times — a conditional (zero-trip) read. The established
+// loop-relaxation policy in `cancelLoadsByDefiniteAssignment` deliberately does not warn
+// on post-loop conditional reads, so the may-init analysis must not report them either.
+// In-loop reads of the phi (the genuine first-iteration read) are not reachable from the
+// break block and are kept.
+static bool isPostLoopPhiRead(
+    ReachabilityContext& reachability,
+    const Dictionary<IRInst*, IRLoop*>& loopPhis,
+    IRInst* load)
+{
+    auto loadBlock = as<IRBlock>(load->getParent());
+    if (!loadBlock)
+        return false;
+
+    for (UInt i = 0; i < load->getOperandCount(); i++)
+    {
+        IRLoop* loop = nullptr;
+        if (!loopPhis.tryGetValue(load->getOperand(i), loop))
+            continue;
+        auto breakBlock = loop->getBreakBlock();
+        if (breakBlock && reachability.isBlockReachable(breakBlock, loadBlock))
+            return true;
+    }
+    return false;
 }
 
 static List<IRInst*> getUnresolvedParamLoads(
@@ -774,13 +827,31 @@ static UninitializedUseLoads getUninitializedUseLoads(
     // Collect the aliasable loads/stores once and derive both violation sets from it.
     List<IRInst*> stores;
     List<IRInst*> allLoads;
-    collectAliasableLoadStores(inst, stores, allLoads);
+    Dictionary<IRInst*, IRLoop*> loopPhis;
+    collectAliasableLoadStores(inst, stores, allLoads, &loopPhis);
 
     UninitializedUseLoads result;
 
     // May-init violations: loads not reachable from any store.
     result.mayInit = allLoads;
     cancelLoads(reachability, stores, result.mayInit);
+
+    // Drop post-loop (zero-trip) reads of a loop-carried phi. The loop body re-defines
+    // the variable every iteration, so such a read is uninitialized only when the loop
+    // ran zero times — a conditional case the loop-relaxation policy does not warn on.
+    // (In SSA the body's per-iteration update is the phi back-edge argument, not an
+    // `IRStore`, so `cancelLoads` above cannot see it; this filter applies the same
+    // policy at the value-flow level.)
+    if (loopPhis.getCount())
+    {
+        for (Index i = 0; i < result.mayInit.getCount();)
+        {
+            if (isPostLoopPhiRead(reachability, loopPhis, result.mayInit[i]))
+                result.mayInit.fastRemoveAt(i);
+            else
+                i++;
+        }
+    }
 
     // Must-init only adds information when there is at least one store (otherwise every
     // load is already a may-init violation) and at least one load.

--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -175,20 +175,102 @@ static bool canIgnoreType(IRType* type, IRType* upper)
     return false;
 }
 
+// If `use` is an initial argument of a `loop` instruction (e.g.
+// `loop(target, break, continue, ..., arg)`), return the loop header parameter (phi)
+// that receives that argument. Returns null otherwise.
+//
+// Loop arguments line up positionally with the header block's parameters, so the
+// argument's offset within the loop's argument list selects the matching header
+// parameter. This lets the uninitialized-value analysis follow an undefined value into
+// the SSA phi a loop introduces for a variable carried across the back-edge, such as a
+// loop-carried accumulator (`float total; for (...) total += a[i];`): the undefined
+// pre-loop value enters the header phi on the loop-entry edge, and the first-iteration
+// read of that phi is a read of the undefined value.
+//
+// Only the `loop`-entry edge is followed, not ordinary merge (`unconditionalBranch`)
+// phis. A merge phi (e.g. the join after `if (c) x = 1;`) carries the undefined value
+// on only one incoming edge, so a use after the merge is read uninitialized on just one
+// path — a *conditional* (must-init) situation that `cancelLoadsByDefiniteAssignment`
+// already classifies. Following merge phis here would misreport those as unconditional
+// (may-init) reads.
+static IRParam* getLoopArgTargetParam(IRUse* use)
+{
+    auto loop = as<IRLoop>(use->getUser());
+    if (!loop)
+        return nullptr;
+
+    // The loop's phi arguments begin at `getArgs()` (operand 3, after the target,
+    // break, and continue blocks). Map the position of `use` within that range to the
+    // corresponding argument index.
+    auto args = loop->getArgs();
+    UInt argCount = loop->getArgCount();
+    if (use < args || use >= args + argCount)
+        return nullptr;
+    UInt argIndex = (UInt)(use - args);
+
+    auto target = loop->getTargetBlock();
+    if (!target)
+        return nullptr;
+
+    UInt paramIndex = 0;
+    for (auto param : target->getParams())
+    {
+        if (paramIndex == argIndex)
+            return param;
+        paramIndex++;
+    }
+    return nullptr;
+}
+
+// Collect `inst` together with every instruction that aliases the same (uninitialized)
+// storage or value: address-derivations like field/element access, and the loop header
+// phi that carries the value into a loop.
+//
+// Following the loop phi is what lets a use of a *loop-carried* variable be seen. When a
+// local is accumulated across loop iterations (`float total; for (...) total += a[i];`),
+// SSA turns `total` into a loop header parameter that merges the undefined pre-loop value
+// with each iteration's update; the first-iteration read of that phi is a read of the
+// undefined value. Without following the phi the only direct use of the undefined
+// instruction is the loop argument, which records no load, so the read escapes detection.
 static List<IRInst*> getAliasableInstructions(IRInst* inst)
 {
     List<IRInst*> addresses;
+    HashSet<IRInst*> visited;
 
-    addresses.add(inst);
-    for (auto use = inst->firstUse; use; use = use->nextUse)
+    List<IRInst*> work;
+    work.add(inst);
+    visited.add(inst);
+
+    while (work.getCount())
     {
-        IRInst* user = use->getUser();
+        IRInst* current = work.getLast();
+        work.removeLast();
+        addresses.add(current);
 
-        // Meta instructions only use the argument type
-        if (isMetaOp(user) || !isAliasable(user))
-            continue;
+        for (auto use = current->firstUse; use; use = use->nextUse)
+        {
+            IRInst* user = use->getUser();
 
-        addresses.addRange(getAliasableInstructions(user));
+            IRInst* alias = nullptr;
+            if (isMetaOp(user))
+            {
+                // Meta instructions only use the argument type.
+                continue;
+            }
+            else if (isAliasable(user))
+            {
+                alias = user;
+            }
+            else if (auto param = getLoopArgTargetParam(use))
+            {
+                // The value flows into a loop header phi; the phi carries it forward
+                // into the loop body.
+                alias = param;
+            }
+
+            if (alias && visited.add(alias))
+                work.add(alias);
+        }
     }
 
     return addresses;

--- a/tests/diagnostics/uninitialized-local-variables.slang
+++ b/tests/diagnostics/uninitialized-local-variables.slang
@@ -44,6 +44,37 @@ int use_undefined_value(int k)
     return x;
 }
 
+// A loop-carried accumulator reads its uninitialized value on the first
+// iteration. SSA turns `total` into a loop block parameter (phi) that merges the
+// undefined pre-loop value with each iteration's update, so the read is of the phi
+// rather than of the undefined instruction directly; the analysis must follow the
+// undefined value through the phi to see it.
+float loop_carried_accumulator(int n)
+{
+    float total;
+    for (int i = 0; i < n; i++)
+        total += float(i);
+//CHK:        ^^ use of uninitialized variable
+//CHK:        ^^ use of uninitialized variable 'total'
+    // The loop may run zero times (n <= 0), so the post-loop read is also
+    // uninitialized on that path.
+    return total;
+/*CHK:
+    ^^^^^^ use of uninitialized variable
+    ^^^^^^ use of uninitialized variable 'total'
+*/
+}
+
+// A loop variable that is fully assigned before any read inside the loop must NOT
+// warn: the literal initializer (not an undefined value) is what flows into the phi.
+float loop_initialized_first(int n)
+{
+    float total = 0.0f;
+    for (int i = 0; i < n; i++)
+        total += float(i);
+    return total;
+}
+
 // We don't know the exact type of T yet.
 // T may not have any members, and it may not need any initialization.
 __generic<T>


### PR DESCRIPTION
Fixes #11778.

## Motivation

`slangc` does not warn (`E41016: use of uninitialized variable`) when an uninitialized local is *accumulated across loop iterations*, even though it warns correctly for the non-loop and loop-invariant cases:

```hlsl
void normalize_array(inout float a[]) {
    float total;                                          // uninitialized
    for (int i = 0; i < a.getCount(); i++) total += a[i]; // reads uninitialized `total` on first iter -- NO WARNING
    for (int i = 0; i < a.getCount(); i++) a[i] /= total;
}
```

The distinguishing factor is that the variable is loop-carried:

| repro | warned before? |
| --- | --- |
| `float total; total += a[0];` (no loop) | yes |
| `float u; for (...) a[i] = u + 1.0;` (loop, `u` read but not accumulated) | yes |
| `float total; for (...) total += a[i];` (loop-carried accumulator) | **no** |

## Proposed solution

After SSA, a loop-carried local becomes a loop *header parameter* (phi) that merges the undefined pre-loop value (on the loop-entry edge) with each iteration's update (on the back-edge). The undefined instruction's only direct use is then the `loop` argument, which records neither a load nor a store, so the in-loop read of the phi was never collected as a use.

The fix makes the analysis follow the undefined value into that loop-entry phi, so the phi's uses (the first-iteration read, and the post-loop read on the zero-trip path) are seen by the existing may-init/must-init machinery.

Only the `loop`-entry edge is followed, not ordinary merge phis. A merge phi (e.g. the join after `if (c) x = 1;`) carries the undefined value on just one incoming edge, so a use after the merge is uninitialized on only one path -- a *conditional* (must-init) situation that `cancelLoadsByDefiniteAssignment` already classifies. Following merge phis would misreport those as unconditional may-init reads.

## Change summary

| File | Change |
| --- | --- |
| `source/slang/slang-ir-use-uninitialized-values.cpp` | Add `getLoopArgTargetParam` (maps a `loop` argument use to the header phi it feeds) and have `getAliasableInstructions` follow the undefined value into that phi. Rewrote the recursion as a worklist with a visited set to avoid revisiting (the loop back-edge can form a cycle). |
| `tests/diagnostics/uninitialized-local-variables.slang` | Add a loop-carried accumulator case (warns in-loop and post-loop) and a negative case where the variable is initialized before the loop (must not warn). |

## Concepts and vocabulary

- **Loop header phi**: the SSA block parameter on a loop's target block. Its incoming value on the loop-entry edge comes from the `loop` instruction's argument list; on the back-edge it comes from the continue block's branch. `IRLoop` stores those arguments starting at operand 3 (after the target/break/continue blocks), lining up positionally with the header block's parameters.
- **may-init vs must-init**: may-init (`E41016`) is a read with *no* store reaching it on some path; must-init (`E41035`) is a read that *some* store reaches but for which a store-free path from entry also reaches it (conditional initialization). The two are computed in `getUninitializedUseLoads` from one shared load/store collection.

## Process report

The undefined value is an `IRLoadFromUninitializedMemory` (an `IRUndefined` subclass produced by the SSA pass for a local with no reaching definition), which `isUninitializedValue` already recognizes. For the motivating shader the lowered IR is:

```
block %153:
    %total = LoadFromUninitializedMemory
    loop(%154, %155, %156, 0, %total)        // %total is the loop-entry phi arg

block %154(param %i, param %total1):          // %total1 is the header phi
    ...
    ifElse(%158, %159, %155, %159)

block %159:
    %total2 = add(%total1, %160)              // first-iteration read of the phi
    unconditionalBranch(%156)

block %156:
    unconditionalBranch(%154, %161, %total2)  // back-edge feeds %total2 into %total1
```

`getAliasableInstructions(%total)` previously returned just `[%total]`: its only use is the `loop` branch argument, and `getInstructionUsageType` returns `None` for `kIROp_Loop`, so no load was recorded and no warning fired. The fix adds `%total1` (the header phi) to the alias set via `getLoopArgTargetParam`, so the phi's uses -- `add(%total1, ...)` and the post-loop read -- are collected as loads. There is no store to the phi (the back-edge feeds the *different* value `%total2`), so `cancelLoads` keeps them and both reads are reported as may-init.

On the input-shape question: the loop-header phi is the canonical SSA representation a loop-carried variable produces; it is the correct producer to read from, not an accidental spelling, so following it (rather than reconstructing anything) is the right layer. The restriction to the `loop`-entry edge is what keeps the change at the may-init layer: merge phis remain the responsibility of the existing definite-assignment (must-init) pass, so no conditional-initialization case is reclassified. This was confirmed by the suite -- the previously-silent conditional case in `uninitialized-local-variables.slang` (`unconditional`) stays silent, and the full `tests/` tree shows no new diagnostics (only pre-existing GPU/infra failures unrelated to this analysis).

The recursion was rewritten as a worklist with a `visited` set because following the loop phi can revisit instructions through the back-edge; the previous purely-DAG address-derivation walk had no cycle.