### PR TITLE
Fix #11778: diagnose loop-carried uninitialized variable reads

### DIFF
--- a/source/slang/slang-ir-use-uninitialized-values.cpp
+++ b/source/slang/slang-ir-use-uninitialized-values.cpp
@@ -175,9 +175,55 @@ static bool canIgnoreType(IRType* type, IRType* upper)
     return false;
 }
 
-static List<IRInst*> getAliasableInstructions(IRInst* inst)
+// If `argUse` is an *argument* operand of an unconditional branch or loop (i.e. a phi
+// edge value, not one of the branch's target/break/continue block operands), return the
+// target block parameter that receives that argument. Otherwise return null.
+//
+// Branch arguments map positionally to the target block's parameters, so the value passed
+// as the i-th argument becomes the i-th block parameter (the SSA phi) along this edge.
+static IRParam* getBranchArgPhiParam(IRUse* argUse)
 {
-    List<IRInst*> addresses;
+    auto branch = as<IRUnconditionalBranch>(argUse->getUser());
+    if (!branch)
+        return nullptr;
+
+    // `getArgs()` points into the branch's contiguous operand storage and, by
+    // construction, excludes the non-argument operand slots (the target block, plus the
+    // break/continue blocks for an `IRLoop`). So the argument index is just the offset of
+    // `argUse` within that range; anything outside it (e.g. the target/break/continue use)
+    // is not a phi argument.
+    auto args = branch->getArgs();
+    UInt argCount = branch->getArgCount();
+    UInt argIndex = UInt(argUse - args);
+    if (argIndex >= argCount)
+        return nullptr;
+
+    // The target block parameter at the same index receives this argument. In well-formed
+    // IR the target always has at least `argCount` parameters, so `getParamAt` resolves it
+    // (and asserts otherwise).
+    return getParamAt(branch->getTargetBlock(), argIndex);
+}
+
+// Collect all instructions that alias `inst` for the purpose of the uninitialized-use
+// analysis. This follows two kinds of aliasing:
+//
+//  - Address aliasing: instructions like `getElementPtr`/`fieldAddress` produce a
+//    derived reference to the same storage (see `isAliasable`).
+//  - SSA value flow through phis: when `inst` (a value) is passed as a branch/loop
+//    argument, the receiving block parameter is the same value along that edge, so its
+//    uses are uses of `inst`. This is what lets a loop-carried use be seen: an
+//    uninitialized value passed as a loop's initial phi argument flows to the loop-header
+//    parameter, whose first-iteration read is a genuine use of the uninitialized value.
+//
+// A `visited` set guards against the cycles that phi following introduces (a loop-header
+// phi is reachable from its own back-edge argument).
+static void getAliasableInstructionsRec(
+    IRInst* inst,
+    HashSet<IRInst*>& visited,
+    List<IRInst*>& addresses)
+{
+    if (!visited.add(inst))
+        return;
 
     addresses.add(inst);
     for (auto use = inst->firstUse; use; use = use->nextUse)
@@ -185,13 +231,124 @@ static List<IRInst*> getAliasableInstructions(IRInst* inst)
         IRInst* user = use->getUser();
 
         // Meta instructions only use the argument type
-        if (isMetaOp(user) || !isAliasable(user))
+        if (isMetaOp(user))
             continue;
 
-        addresses.addRange(getAliasableInstructions(user));
-    }
+        if (isAliasable(user))
+        {
+            getAliasableInstructionsRec(user, visited, addresses);
+            continue;
+        }
 
+        // Follow SSA value flow through a phi: an argument passed to a branch/loop
+        // becomes the corresponding block parameter, which is the same value along
+        // this edge.
+        if (auto phiParam = getBranchArgPhiParam(use))
+            getAliasableInstructionsRec(phiParam, visited, addresses);
+    }
+}
+
+static List<IRInst*> getAliasableInstructions(IRInst* inst, HashSet<IRInst*>& aliasSet)
+{
+    List<IRInst*> addresses;
+    getAliasableInstructionsRec(inst, aliasSet, addresses);
     return addresses;
+}
+
+static List<IRInst*> getAliasableInstructions(IRInst* inst)
+{
+    HashSet<IRInst*> aliasSet;
+    return getAliasableInstructions(inst, aliasSet);
+}
+
+// Does `inst` depend (transitively, through its operands) on any value in `aliasSet`?
+// Used to tell a genuinely-defined phi argument from one that is merely the tracked
+// uninitialized value carried/derived through computation. For example, with a
+// loop-carried accumulator the back-edge argument is `add(total1, a[i])`, which depends on
+// the loop-header phi `total1` (an alias) and so is *not* a real definition; whereas a
+// conditionally-stored value like `load(candidateProceduralAttrs)` depends on nothing in
+// the alias set and *is* a real definition. A `seen` set bounds the operand walk against
+// cycles (phis can be mutually recursive).
+static bool dependsOnAlias(IRInst* inst, const HashSet<IRInst*>& aliasSet, HashSet<IRInst*>& seen)
+{
+    if (aliasSet.contains(inst))
+        return true;
+    if (!seen.add(inst))
+        return false;
+    // Stop at block boundaries: a block parameter's "operands" are its phi arguments,
+    // which we reach via the predecessors, not via getOperand. Following an alias param is
+    // already handled by aliasSet membership above; any non-alias param is treated as an
+    // independent definition.
+    if (as<IRParam>(inst))
+        return false;
+    for (UInt i = 0, n = inst->getOperandCount(); i < n; i++)
+    {
+        auto operand = inst->getOperand(i);
+        if (operand && dependsOnAlias(operand, aliasSet, seen))
+            return true;
+    }
+    return false;
+}
+
+// Given the set of aliases of the tracked uninitialized value (the values that are the
+// uninitialized value or are it carried along a phi edge), find the phi merge points where
+// a *genuinely defined* value also flows in. Each such incoming argument is reported as a
+// "store": along its edge the variable holds a real, initialized value, so a read reached
+// after it is not a may-init (never-initialized) use.
+//
+// This is what keeps the analysis honest once phi following is enabled. Consider a value
+// that is assigned only on some paths and then read after a loop:
+//
+//     MyAttrs attrs;                       // uninitialized
+//     for (;;) { ...; if (cond) attrs = computed; ... }
+//     use(attrs);                          // reads the loop-header phi
+//
+// The loop-header phi merges the undefined pre-loop value with `computed`. Without this,
+// the post-loop read would be flagged may-init (no IR `store` exists for an SSA value),
+// even though a defined value reaches it on the assigning path — making it a conditional
+// (must-init) situation that the definite-assignment pass deliberately suppresses for
+// zero-trip loops. Registering `computed` as a store lets `cancelLoads` reclassify the read
+// out of may-init. A purely loop-carried accumulator (`total += a[i]`) has no such defined
+// incoming value -- its only non-undefined phi argument, `add(total1, a[i])`, depends on
+// the phi itself -- so `dependsOnAlias` rejects it and the accumulator correctly stays a
+// may-init violation.
+static void collectPhiMergeStores(
+    const HashSet<IRInst*>& aliasSet,
+    const List<IRInst*>& aliases,
+    List<IRInst*>& stores)
+{
+    for (auto alias : aliases)
+    {
+        auto param = as<IRParam>(alias);
+        if (!param)
+            continue;
+        auto block = as<IRBlock>(param->getParent());
+        if (!block)
+            continue;
+        Index paramIndex = getParamIndexInBlock(param);
+        if (paramIndex < 0)
+            continue;
+
+        for (auto pred : block->getPredecessors())
+        {
+            auto branch = as<IRUnconditionalBranch>(pred->getTerminator());
+            if (!branch || UInt(paramIndex) >= branch->getArgCount())
+                continue;
+            auto arg = branch->getArg(UInt(paramIndex));
+            // Only an argument that does not derive from the tracked uninitialized value is
+            // a genuine definition reaching this merge point.
+            HashSet<IRInst*> seen;
+            if (dependsOnAlias(arg, aliasSet, seen))
+                continue;
+            // Record the store at the predecessor edge (its terminator), not at the
+            // argument's definition. The variable becomes initialized only on this incoming
+            // edge; the value `arg` may have been defined earlier (e.g. `float y = 1; if
+            // (cond) x = y;`), and using its definition point as the store would make the
+            // definite-assignment walk treat the unassigned edge as initialized too,
+            // suppressing the legitimate "may be uninitialized" diagnostic.
+            stores.add(branch);
+        }
+    }
 }
 
 enum InstructionUsageType
@@ -634,7 +791,8 @@ static void cancelLoadsByDefiniteAssignment(
 
 static void collectAliasableLoadStores(IRInst* inst, List<IRInst*>& stores, List<IRInst*>& loads)
 {
-    auto addresses = getAliasableInstructions(inst);
+    HashSet<IRInst*> aliasSet;
+    auto addresses = getAliasableInstructions(inst, aliasSet);
 
     for (auto alias : addresses)
     {
@@ -642,6 +800,11 @@ static void collectAliasableLoadStores(IRInst* inst, List<IRInst*>& stores, List
         for (auto use = alias->firstUse; use; use = use->nextUse)
             collectInstructionByUsage(stores, loads, use->getUser(), alias);
     }
+
+    // A defined value flowing into a phi alias is a store of an initialized value reaching
+    // that merge point; record it so reads after it are not mistaken for never-initialized
+    // (may-init) uses.
+    collectPhiMergeStores(aliasSet, addresses, stores);
 }
 
 static List<IRInst*> getUnresolvedParamLoads(

--- a/tests/diagnostics/uninitialized-local-variables.slang
+++ b/tests/diagnostics/uninitialized-local-variables.slang
@@ -2,11 +2,12 @@
 
 float f(float) { return 1; }
 
-// k0 and k1 are only conditionally assigned (inside if).
-// Note: this case is optimized away by constexpr propagation before
-// the uninit check runs, so no warning is produced at IR level.
-// The must-init warning (41035) catches this pattern when the variable
-// survives optimization (e.g. structs, out params).
+// k0 and k1 are only conditionally assigned (inside if), so on the `mode != 1`
+// path they are still uninitialized when read at `return k0 + k1`. The
+// conditionally-assigned value reaches the use through an if-merge phi; the
+// uninitialized-use analysis follows that phi and, because a defined value reaches
+// the merge on the assigning path, reports a must-init ("may be uninitialized on
+// some paths") diagnostic rather than a never-initialized one.
 float3 unconditional(int mode)
 {
     float k0;
@@ -23,6 +24,10 @@ float3 unconditional(int mode)
     }
 
     return k0 + k1;
+//CHK:        ^ possible use of uninitialized variable
+//CHK:        ^ variable 'k0' may be uninitialized on some paths; it is only conditionally assigned
+//CHK:        ^ possible use of uninitialized variable
+//CHK:        ^ variable 'k1' may be uninitialized on some paths; it is only conditionally assigned
 }
 
 // Warn here for branches using the variables

--- a/tests/diagnostics/uninitialized-loop-carried.slang
+++ b/tests/diagnostics/uninitialized-loop-carried.slang
@@ -1,0 +1,107 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHK): -target cpp -entry computeMain -stage compute
+
+// Regression test for https://github.com/shader-slang/slang/issues/11778
+//
+// A local that is accumulated across loop iterations (loop-carried) is
+// uninitialized on the first iteration. After SSA construction the variable
+// becomes a loop-header phi merging the undefined pre-loop value with each
+// iteration's update, so the first-iteration read happens through that phi.
+// The uninitialized-use analysis must follow the undefined value through the
+// phi to report the read.
+
+RWStructuredBuffer<float> outputBuffer;
+
+void normalize_array(inout float a[3])
+{
+    float total;
+    for (int i = 0; i < 3; i++)
+        total += a[i];
+//CHK:        ^^ use of uninitialized variable
+//CHK:        ^^ use of uninitialized variable 'total'
+    for (int i = 0; i < 3; i++)
+        a[i] /= total;
+//CHK:       ^^ use of uninitialized variable
+//CHK:       ^^ use of uninitialized variable 'total'
+}
+
+// Nested loops produce two loop-header phis, so the undefined value flows
+// var -> outer-header-phi -> inner-header-phi. This exercises the multi-hop phi
+// following and the cycle guard on both back-edges.
+float nested_loop_accum(float a[2][3])
+{
+    float total;
+    for (int i = 0; i < 2; i++)
+        for (int j = 0; j < 3; j++)
+            total += a[i][j];
+//CHK:            ^^ use of uninitialized variable
+//CHK:            ^^ use of uninitialized variable 'total'
+    return total;
+/*CHK:
+    ^^^^^^ use of uninitialized variable
+    ^^^^^^ use of uninitialized variable 'total'
+*/
+}
+
+// Must NOT warn: the accumulator is initialized before the loop. After SSA it is
+// still a loop-header phi, but the preheader phi argument is the initializing
+// constant rather than an undefined value, so phi following finds no undefined
+// source. Exhaustive diagnostic checking fails the test if this over-warns.
+float sum_initialized(float a[3])
+{
+    float total = 0;
+    for (int i = 0; i < 3; i++)
+        total += a[i];
+    return total;
+}
+
+struct Attrs { float v; };
+
+// Must NOT warn (and must not be a never-initialized may-init report): `committed` is
+// assigned only on some loop paths and then read after the loop. The loop-header phi
+// merges the undefined pre-loop value with the genuinely-defined `cand`, so a real
+// definition reaches the merge. That makes this a conditional (must-init) case, which the
+// definite-assignment pass suppresses for a possibly-zero-trip loop -- the same shape as a
+// RayQuery commit-then-read-committed loop. This pins the boundary that phi following does
+// not turn such a read into a spurious "use of uninitialized variable".
+float cond_assigned_in_loop(float a[3], int n)
+{
+    Attrs committed;
+    for (int i = 0; i < n; i++)
+    {
+        if (a[i] > 0)
+        {
+            Attrs cand = { a[i] };
+            committed = cand;
+        }
+    }
+    return committed.v;
+}
+
+// A `do`-while loop lowers to a different loop topology than `for` (the body is the loop
+// target and is entered unconditionally on the first iteration), so the undefined value
+// reaches the body phi along the preheader edge in a structurally distinct shape. The
+// first-iteration read of the accumulator is still a genuine uninitialized use.
+float do_while_accum(int n)
+{
+    float total;
+    int i = 0;
+    do
+    {
+        total += float(i);
+//CHK:        ^^ use of uninitialized variable
+//CHK:        ^^ use of uninitialized variable 'total'
+        i++;
+    } while (i < n);
+    return total;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    float a[3] = {1, 2, 3};
+    normalize_array(a);
+    float b[2][3] = {{1, 2, 3}, {4, 5, 6}};
+    outputBuffer[0] = a[0] + nested_loop_accum(b) + sum_initialized(a) +
+                      cond_assigned_in_loop(a, 3) + do_while_accum(3);
+}


### PR DESCRIPTION
## Motivation

`slangc` does not warn (`E41016`) when an uninitialized local is accumulated across loop iterations, even though it warns for the non-loop and loop-invariant cases:

```hlsl
void normalize_array(inout float a[3]) {
    float total;                                  // uninitialized
    for (int i = 0; i < 3; i++) total += a[i];    // reads uninitialized `total` on first iter
    for (int i = 0; i < 3; i++) a[i] /= total;
}
```

The first `total += a[i]` reads `total` while it is still uninitialized, but no diagnostic is produced. Reported in #11778.

## Proposed solution

The uninitialized-use analysis (`checkForUsingUninitializedValues`) runs after SSA construction. A loop-carried variable becomes a loop-header **phi** (block parameter) that merges the undefined pre-loop value with each iteration's update. The first-iteration read therefore happens through that phi.

`getAliasableInstructions` already follows *address* aliases (`getElementPtr`/`fieldAddress`), but it did not follow *SSA value flow* through phis, so the undefined value's only recorded use was the loop's branch argument — classified as neither a load nor a store — and the genuine read on the phi parameter was never examined.

The fix follows the undefined value into the block parameter it feeds: when a value is passed as the i-th argument of an unconditional branch or loop, the receiving block's i-th parameter is the same value along that edge, so its uses are uses of the original value. This is the principled completion of the existing aliasing walk, not a special case — a phi is exactly a value alias along its incoming edge. Because phi following introduces cycles (a loop-header phi is reachable from its own back-edge argument), the walk now carries a `visited` set.

## Change summary

| File | Change |
| --- | --- |
| `source/slang/slang-ir-use-uninitialized-values.cpp` | Add `getBranchArgPhiParam` (maps a branch/loop argument use to its target block parameter); make `getAliasableInstructions` follow that phi edge, guarded by a `visited` set against back-edge cycles. |
| `tests/diagnostics/uninitialized-loop-carried.slang` | New regression test for the loop-carried accumulator (CPU target, no GPU). |
| `tests/diagnostics/uninitialized-local-variables.slang` | The conditional-then-use case (`k0`/`k1` assigned only inside an `if`, read after the merge) is now correctly diagnosed; annotate the four new warnings and replace the stale "optimized away, no warning" comment. |

## Concepts and vocabulary

- **phi / block parameter** — in Slang's SSA IR there are no explicit phi nodes; a value that differs per predecessor is a *block parameter*, and each predecessor's terminator (an `IRUnconditionalBranch`, or its `IRLoop` subclass) supplies the value positionally as a branch *argument*. The i-th argument feeds the i-th block parameter.
- **`LoadFromUninitializedMemory`** — a member of the `IRUndefined` op family (`as<IRUndefined>` matches it). SSA construction produces it for the value of a local along paths where it was never stored, precisely so the front-end can diagnose uninitialized reads.

## Process report

**Root cause.** Consider the repro. After `constructSSA` (run in the optimization loop in `lowerToIR` before `checkForUsingUninitializedValues`), the IR for the first loop is:

```
let %total : Float = LoadFromUninitializedMemory
loop(..., 0 : Int, %total)            // %total supplied as the loop's initial phi argument
block(param %i : Int, param %total1 : Float):
    ...
    let %total2 : Float = add(%total1, %elem)   // the `total += a[i]` read
    ...
    unconditionalBranch(..., %inc, %total2)     // back-edge feeds %total1 next iteration
```

`checkUninitializedValues` iterates insts, finds the `LoadFromUninitializedMemory` (`isUninitializedValue` → true), and calls `getUninitializedUseLoads` → `collectAliasableLoadStores` → `getAliasableInstructions(%total)`. Before this change that returned just `[%total]`, and `collectInstructionByUsage` over `%total`'s single use — the `loop` argument — returns `None` (branches are explicitly `None` in `getInstructionUsageType`). So no load was recorded and no warning fired.

The genuine read is `add(%total1, %elem)`, a use of the loop-header parameter `%total1`, not of `%total` directly. The two are the same value along the preheader edge, which is exactly the SSA phi relationship.

**Fix and why it is at the right layer.** `getBranchArgPhiParam(use)` recognizes when `use` is an argument operand of an `IRUnconditionalBranch`/`IRLoop` (excluding the target-block operand via `getTargetBlockUse`) and returns the target block parameter at the matching index. `getAliasableInstructionsRec` now, for a non-aliasable user, follows that phi param. So `%total1` is added as an alias of `%total`, its `add` use is classified as a `Load`, and — with no store ever reaching it — it survives `cancelLoads` as a may-init violation.

This is a producer-faithful fix: the input shape (undefined value → loop phi argument → header parameter → read) is the *correct, canonical* SSA representation a loop-carried read must have; nothing upstream is malformed. The analysis was simply incomplete in not traversing value flow that the SSA form makes explicit. Following the phi reports exactly the reads that are reachable while undefined, so it does not over-warn: a `LoadFromUninitializedMemory` only exists where some path leaves the variable unwritten, and any phi consuming it is undefined along that incoming edge.

**Cascading effect on `uninitialized-local-variables.slang`.** The same gap hid the conditional case there (`k0`/`k1` written only inside `if (mode == 1)`, then `return k0 + k1`). With phi following, the undefined value flows through the if-merge parameter to the `return` and is now reported — a true positive the test's old comment explicitly acknowledged as missed. The test is updated to annotate the four new diagnostics and drop the stale comment.

**Testing.** New `uninitialized-loop-carried.slang` passes; full `tests/diagnostics/` passes (486/486). The broader suite is regression-clean against this change; the only failures on this machine are pre-existing GPU/CUDA and half-float `TEST_INPUT` harness limitations unrelated to this analysis.