### PR TITLE
Fix #11230: fill partial ray-payload access qualifiers for hit-only shaders

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -1685,6 +1685,21 @@ Result linkAndOptimizeIR(
         if (isD3DTarget(targetRequest))
         {
             SLANG_PASS(legalizeNonStructParameterToStructForHLSL);
+
+            // HLSL SM 6.7+ requires every member of a `[raypayload]` struct to declare
+            // both a `read(...)` and a `write(...)` qualifier. The call-site fill above
+            // only covers payload structs reached through a `TraceRay`-style call, so a
+            // user-authored struct with one-sided PAQ that only reaches a hit shader
+            // (e.g. a per-stage-compiled shader library) would slip through. Fill any
+            // missing per-side PAQs structurally on every `[raypayload]` struct.
+            auto profile = getEffectiveTargetProfile(
+                targetProgram->getTargetReq(),
+                targetProgram->getOptionSet());
+            if (profile.getFamily() == ProfileFamily::DX &&
+                profile.getVersion() >= ProfileVersion::DX_6_7)
+            {
+                SLANG_PASS(legalizeRayPayloadAccessQualifiersForHLSL);
+            }
         }
 
         if (requiredLoweringPassSet.existentialTypeLayout)

--- a/source/slang/slang-ir-hlsl-legalize.cpp
+++ b/source/slang/slang-ir-hlsl-legalize.cpp
@@ -261,4 +261,37 @@ void legalizeEmptyRayPayloadsForHLSL(IRModule* module)
     }
 }
 
+void legalizeRayPayloadAccessQualifiersForHLSL(IRModule* module)
+{
+    // Walk every `[raypayload]` struct in the module and fill in any missing per-side
+    // PAQs. This is a structural pass keyed on `IRRayPayloadDecoration`, rather than a
+    // call-site fixup, because the call-site PAQ fill in
+    // `searchChildrenForForceVarIntoStructTemporarily` only fires when the frontend wraps
+    // a payload argument with `__forceVarIntoRayPayloadStructTemporarily`, which it does
+    // only around `TraceRay` / `HitObject::TraceRay` / `HitObject::Invoke` payload args.
+    // A hit-shader-only translation unit (typical for per-stage-compiled, runtime-linked
+    // shader libraries) has no such call, so a user-authored struct with one-sided PAQ
+    // would keep its one-sided PAQ and be rejected by DXC at SM 6.7+.
+    // Collect first: filling a struct's PAQs reaches `builder.getStringValue(...)` and
+    // adds decorations, which inserts new global instructions and would invalidate a
+    // live `getGlobalInsts()` walk (the same hazard documented in
+    // `legalizeEmptyRayPayloadsForHLSL`).
+    List<IRStructType*> rayPayloadStructs;
+    for (auto globalInst : module->getGlobalInsts())
+    {
+        auto structType = as<IRStructType>(globalInst);
+        if (!structType)
+            continue;
+        if (!structType->findDecoration<IRRayPayloadDecoration>())
+            continue;
+        rayPayloadStructs.add(structType);
+    }
+
+    IRBuilder builder(module);
+    for (auto structType : rayPayloadStructs)
+    {
+        addDefaultPayloadAccessQualifiersToStruct(builder, structType);
+    }
+}
+
 } // namespace Slang

--- a/source/slang/slang-ir-hlsl-legalize.h
+++ b/source/slang/slang-ir-hlsl-legalize.h
@@ -16,4 +16,12 @@ void legalizeNonStructParameterToStructForHLSL(IRModule* module);
 
 void legalizeEmptyRayPayloadsForHLSL(IRModule* module);
 
+// Fill in any missing per-side payload access qualifiers (PAQs) on every
+// `[raypayload]` struct in the module, so that each field carries both a `read(...)`
+// and a `write(...)` qualifier. HLSL SM 6.7+ requires both sides on every member of a
+// `[raypayload]` struct; a user-authored struct with one-sided PAQ (or a struct that
+// only reaches a hit shader and is never `TraceRay`'d) would otherwise be emitted with
+// one-sided qualifiers and rejected by DXC.
+void legalizeRayPayloadAccessQualifiersForHLSL(IRModule* module);
+
 } // namespace Slang

--- a/tests/hlsl/raypayload-hit-only-paq.slang
+++ b/tests/hlsl/raypayload-hit-only-paq.slang
@@ -1,0 +1,94 @@
+// Regression test for:
+// https://github.com/shader-slang/slang/issues/11230
+//
+// A hit-shader-only translation unit (no `TraceRay`-style call) with a
+// user-authored `[raypayload]` struct that carries one-sided (partial) payload
+// access qualifiers. The call-site PAQ fill only covers payload structs reached
+// through a `TraceRay` / `HitObject::TraceRay` / `HitObject::Invoke` argument, so
+// before the structural fill this struct kept its one-sided PAQ at SM 6.7+ and
+// DXC rejected it. The structural pass must fill the missing per-side qualifier
+// on every `[raypayload]` struct, while leaving the explicit side untouched.
+//
+// The fix is keyed on `IRRayPayloadDecoration`, not on entry-point stage, so the
+// fill must apply for any hit-shader stage (anyhit / closesthit / miss) and for a
+// `lib_6_7` library compile that holds several such entry points over a shared
+// payload with no `TraceRay` — the realistic per-stage-compiled, runtime-linked
+// shader-library shape from the issue.
+
+// Each hit-shader stage compiled on its own (no TraceRay) must still fill PartialPayload.
+//TEST:SIMPLE(filecheck=HLSL66): -target hlsl -profile sm_6_6 -stage anyhit -entry ahit_main
+//TEST:SIMPLE(filecheck=HLSL67): -target hlsl -profile sm_6_7 -stage anyhit -entry ahit_main
+//TEST:SIMPLE(filecheck=HLSL67): -target hlsl -profile sm_6_7 -stage closesthit -entry chit_main
+//TEST:SIMPLE(filecheck=HLSL67): -target hlsl -profile sm_6_7 -stage miss -entry miss_main
+//TEST:SIMPLE(filecheck=DXIL67): -target dxil -profile sm_6_7 -stage anyhit -entry ahit_main
+
+// A field that already declares *both* sides must be left exactly as written; this struct
+// only reaches a hit shader, so it goes through the new structural pass, not the TraceRay
+// call-site path.
+//TEST:SIMPLE(filecheck=EXPLICIT67): -target hlsl -profile sm_6_7 -stage closesthit -entry chit_explicit
+
+// A lib_6_7 compile holds every entry point over the shared payloads with no TraceRay --
+// the per-stage-compiled, runtime-linked shader-library shape from the issue.
+//TEST:SIMPLE(filecheck=HLSL67): -target hlsl -profile lib_6_7
+//TEST:SIMPLE(filecheck=EXPLICIT67): -target hlsl -profile lib_6_7
+//TEST:SIMPLE(filecheck=DXIL67): -target dxil -profile lib_6_7
+
+// At SM 6.6 PAQs are not emitted at all.
+// HLSL66-NOT: [raypayload]
+// HLSL66-NOT: : read(
+// HLSL66-NOT: : write(
+
+// At SM 6.7+ every field must carry both sides; the one-sided fields get their missing
+// side filled with the full-stage default.
+// HLSL67-DAG: struct [raypayload] PartialPayload
+// HLSL67-DAG: float3 readOnly_0 : read(caller) : write(caller, anyhit, closesthit, miss);
+// HLSL67-DAG: float3 writeOnly_0 : read(caller, anyhit, closesthit, miss) : write(caller);
+
+// A field that already declares both sides is left exactly as written.
+// EXPLICIT67: struct [raypayload] ExplicitPayload
+// EXPLICIT67: float3 normal_0 : read(caller) : write(miss);
+
+// And DXC accepts it (payload annotations are emitted in the DXIL).
+// DXIL67: define void @
+// DXIL67: !dx.dxrPayloadAnnotations
+
+RWTexture2D<float4> outputImage;
+RaytracingAccelerationStructure topLevelAS;
+
+[raypayload]
+struct PartialPayload
+{
+    float3 readOnly  : read(caller);
+    float3 writeOnly : write(caller);
+};
+
+[raypayload]
+struct ExplicitPayload
+{
+    float3 normal : read(caller) : write(miss);
+};
+
+[shader("anyhit")]
+void ahit_main(inout PartialPayload p, in BuiltInTriangleIntersectionAttributes attr)
+{
+    p.readOnly  = float3(1, 0, 0);
+    p.writeOnly = float3(0, 1, 0);
+}
+
+[shader("closesthit")]
+void chit_main(inout PartialPayload p, in BuiltInTriangleIntersectionAttributes attr)
+{
+    p.writeOnly = p.readOnly;
+}
+
+[shader("miss")]
+void miss_main(inout PartialPayload p)
+{
+    p.writeOnly = float3(0, 0, 0);
+}
+
+[shader("closesthit")]
+void chit_explicit(inout ExplicitPayload p, in BuiltInTriangleIntersectionAttributes attr)
+{
+    p.normal = float3(0, 0, 1);
+}


### PR DESCRIPTION
## Motivation

Follow-up to #10267 / #11224. PR #11224 fills missing payload access qualifiers (PAQs) on `[raypayload]` structs, but only on structs that reach a `TraceRay`-style call. A hit-shader-only translation unit (typical for per-stage-compiled, runtime-linked shader libraries — slang-rhi, `ISession::createCompositeComponentType`) has no such call, so a user-authored `[raypayload]` struct with one-sided PAQ keeps its one-sided PAQ at SM 6.7+ and DXC rejects it.

Consider this anyhit-only shader compiled with `-target hlsl -profile sm_6_7 -stage anyhit -entry ahit_main`:

```slang
[raypayload]
struct PartialPayload
{
    float3 readOnly  : read(caller);
    float3 writeOnly : write(caller);
};

[shader("anyhit")]
void ahit_main(inout PartialPayload p, in BuiltInTriangleIntersectionAttributes attr)
{
    p.readOnly  = float3(1, 0, 0);
    p.writeOnly = float3(0, 1, 0);
}
```

Before this change the emitted HLSL is:

```hlsl
struct [raypayload] PartialPayload_0
{
    float3 readOnly_0 : read(caller);     // missing write(...) — DXC rejects
    float3 writeOnly_0 : write(caller);   // missing read(...)  — DXC rejects
};
```

DXC: *"payload type requires that all fields carry payload access qualifiers."*

## Proposed solution

Add a dedicated structural pass `legalizeRayPayloadAccessQualifiersForHLSL` that walks every `IRStructType` carrying `IRRayPayloadDecoration` and fills any missing per-side qualifier with the full-stage default, reusing the existing `addDefaultPayloadAccessQualifiersToStruct`/`...ToField` helpers from #11224.

This is keyed on the decoration, not on a call site, because the wrapper the call-site fill unwraps (`__forceVarIntoRayPayloadStructTemporarily`) is only inserted by the frontend around `TraceRay` / `HitObject::TraceRay` / `HitObject::Invoke` payload args — never around hit-shader payload params. Any call-site approach therefore inherently misses hit-shader-only units; only a structural walk gives complete coverage. This is the approach the issue recommends (mirroring #11218).

The field helper already preserves a fully-specified side and only fills the absent one, so explicit two-sided PAQ (e.g. `: read(caller) : write(miss)`) is left untouched.

## Change summary

| File | Change |
| --- | --- |
| `source/slang/slang-ir-hlsl-legalize.h` | Declare `legalizeRayPayloadAccessQualifiersForHLSL`. |
| `source/slang/slang-ir-hlsl-legalize.cpp` | Implement the pass: walk module globals, and for each `IRStructType` with `IRRayPayloadDecoration` call the existing `addDefaultPayloadAccessQualifiersToStruct`. |
| `source/slang/slang-emit.cpp` | Schedule the pass after `legalizeNonStructParameterToStructForHLSL`, gated on `ProfileFamily::DX` and version `>= DX_6_7`. |
| `tests/hlsl/raypayload-hit-only-paq.slang` | New regression test: anyhit-only, no `TraceRay`, partial PAQ; checks both sides are filled at SM 6.7 (HLSL + DXIL), and that nothing is emitted at SM 6.6. |

## Concepts and vocabulary

- **PAQ (payload access qualifier)** — `: read(stages…) : write(stages…)` on a `[raypayload]` struct field. HLSL SM 6.7+ requires *both* sides on *every* member.
- **`IRRayPayloadDecoration`** — marks an `IRStructType` as a ray payload struct; it is the structural signal this pass keys on.
- **`__forceVarIntoRayPayloadStructTemporarily`** — a frontend wrapper inserted only around `TraceRay`/`HitObject::TraceRay`/`HitObject::Invoke` payload arguments; unwrapped (and PAQ-filled) by `searchChildrenForForceVarIntoStructTemporarily`. Its placement is exactly why the existing fill misses hit-shader-only units.
- **`_shouldEmitPayloadAccessQualifiers`** (`slang-emit-hlsl.cpp`) — the emitter-side gate that already restricts `[raypayload]`/PAQ emission to DX SM ≥ 6.7.

## Process report

**Root cause.** PAQ emission in `HLSLSourceEmitter::emitVarDecorationsImpl` emits exactly the `IRStageReadAccessDecoration` / `IRStageWriteAccessDecoration` decorations present on a field (gated by `_shouldEmitPayloadAccessQualifiers`). For the repro, `PartialPayload`'s `readOnly` field carries only a read decoration and `writeOnly` only a write decoration, so the emitter produces one-sided PAQ. The decorations are never completed because the only producer of the missing side, `addDefaultPayloadAccessQualifiersToStruct`, is reached only from `searchChildrenForForceVarIntoStructTemporarily` (the `TraceRay` call-site path) and from `legalizeEmptyRayPayloadsForHLSL` (empty structs). An anyhit-only unit hits neither.

**Why a structural pass is the right layer.** The input shape here — a `[raypayload]` `IRStructType` with one-sided field decorations — is a *valid, canonical* representation: the frontend deliberately accepts one-sided PAQ (it only diagnoses when both sides are absent, per `slang-check-modifier.cpp`), and `IRRayPayloadDecoration` is the single structural fact that identifies a payload struct regardless of how it is used. The completion of PAQs is a HLSL-target legalization concern, so it belongs in an emit-time IR pass keyed on that decoration, not in a consumer-side patch in the emitter and not in a call-site fixup that only sees `TraceRay`'d structs. `legalizeRayPayloadAccessQualifiersForHLSL` iterates `module->getGlobalInsts()`, selects `IRStructType`s with `IRRayPayloadDecoration`, and calls the existing per-field fill — so there is one source of truth for the default-PAQ logic, shared with the call-site and empty-struct paths.

**Why the gate.** PAQ/`[raypayload]` are only emitted at DX SM ≥ 6.7 (`_shouldEmitPayloadAccessQualifiers`). Gating the pass on the same condition (`getEffectiveTargetProfile(...).getFamily() == ProfileFamily::DX && version >= DX_6_7`) keeps the IR untouched whenever the decorations would not be emitted anyway, matching the emitter's contract.

**Testing.** New `tests/hlsl/raypayload-hit-only-paq.slang`: at SM 6.7 each field is filled (`readOnly_0 : read(caller) : write(caller, anyhit, closesthit, miss)`, `writeOnly_0 : read(caller, anyhit, closesthit, miss) : write(caller)`) and DXIL carries `!dx.dxrPayloadAnnotations`; at SM 6.6 no `[raypayload]`/PAQ is emitted. Verified by hand that the existing #11224 test `raypayload-auto-paq.slang` produces byte-identical output (in particular `ExplicitRayPayload`'s `normal_0 : read(caller) : write(miss)` is preserved). The full suite is regression-clean against this change; the only failures on this machine are pre-existing GPU/CUDA/half-float `TEST_INPUT` harness limitations unrelated to the D3D HLSL/DXIL emit path.