### PR TITLE
Add diagnostic warning levels (-Wall/-Wextra/-Wpedantic)

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -263,7 +263,7 @@ Disable specific warning ids.
 
 **-Wall | -Wextra | -Wpedantic**
 
-Enable the corresponding group of opt-in warnings (additive). Staging: the pedantic group is currently enabled by default, so [-Wpedantic](#wall-1) is a no-op today; a future release will make it opt-in. 
+Enable the corresponding group of opt-in warnings (additive). Staging: the pedantic group is currently enabled by default, so passing the pedantic flag is a no-op today; a future release will make it opt-in. 
 
 
 <a id="w"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -263,7 +263,7 @@ Disable specific warning ids.
 
 **-Wall | -Wextra | -Wpedantic**
 
-Enable the corresponding group of opt-in warnings (additive). 
+Enable the corresponding group of opt-in warnings (additive). Staging: the pedantic group is currently enabled by default, so [-Wpedantic](#wall-1) is a no-op today; a future release will make it opt-in. 
 
 
 <a id="w"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -258,6 +258,14 @@ all - Treat all warnings as errors.
 Disable specific warning ids. 
 
 
+<a id="wall"></a>
+### -Wall, -Wextra, -Wpedantic
+
+**-Wall | -Wextra | -Wpedantic**
+
+Enable the corresponding group of opt-in warnings (additive). 
+
+
 <a id="w"></a>
 ### -W
 

--- a/docs/user-guide/08-compiling.md
+++ b/docs/user-guide/08-compiling.md
@@ -1072,6 +1072,7 @@ meanings of their `CompilerOptionValue` encodings.
 | DisableWarnings    | Specifies a list of warnings to disable. `stringValue0` encodes comma separated list of warning codes or names. |
 | EnableWarning      | Specifies a list of warnings to enable. `stringValue0` encodes comma separated list of warning codes or names. |
 | DisableWarning     | Specify a warning to disable. `stringValue0` encodes the warning code or name. |
+| WarningLevel       | Enable a group of opt-in warnings, modeled on clang/gcc. `intValue0` encodes a `SlangWarningLevel` group (`SLANG_WARNING_LEVEL_ALL`/`_EXTRA`/`_PEDANTIC`). Repeatable and additive, matching the `-Wall`/`-Wextra`/`-Wpedantic` command-line flags. Warnings in the always-on default group are unaffected. |
 | ReportDownstreamTime | Turn on/off downstream compilation time report. `intValue0` encodes a bool value for the setting. |
 | ReportPerfBenchmark | Turn on/off reporting of time spent in different parts of the compiler. `intValue0` encodes a bool value for the setting. |
 | SkipSPIRVValidation | Specifies whether or not to skip the validation step after emitting SPIR-V. `intValue0` encodes a bool value for the setting. |

--- a/docs/user-guide/08-compiling.md
+++ b/docs/user-guide/08-compiling.md
@@ -1072,7 +1072,7 @@ meanings of their `CompilerOptionValue` encodings.
 | DisableWarnings    | Specifies a list of warnings to disable. `stringValue0` encodes comma separated list of warning codes or names. |
 | EnableWarning      | Specifies a list of warnings to enable. `stringValue0` encodes comma separated list of warning codes or names. |
 | DisableWarning     | Specify a warning to disable. `stringValue0` encodes the warning code or name. |
-| WarningLevel       | Enable a group of opt-in warnings, modeled on clang/gcc. `intValue0` encodes a `SlangWarningLevel` group (`SLANG_WARNING_LEVEL_ALL`/`_EXTRA`/`_PEDANTIC`). Repeatable and additive, matching the `-Wall`/`-Wextra`/`-Wpedantic` command-line flags. Warnings in the always-on default group are unaffected. |
+| WarningLevel       | Enable a group of opt-in warnings, modeled on clang/gcc. `intValue0` encodes a `SlangWarningLevel` group (`SLANG_WARNING_LEVEL_ALL`/`_EXTRA`/`_PEDANTIC`). Repeatable and additive, matching the `-Wall`/`-Wextra`/`-Wpedantic` command-line flags. Warnings in the always-on default group are unaffected. (Staging note: the `pedantic` group is currently enabled by default, so `-Wpedantic` is a no-op today; a future change will make it opt-in.) |
 | ReportDownstreamTime | Turn on/off downstream compilation time report. `intValue0` encodes a bool value for the setting. |
 | ReportPerfBenchmark | Turn on/off reporting of time spent in different parts of the compiler. `intValue0` encodes a bool value for the setting. |
 | SkipSPIRVValidation | Specifies whether or not to skip the validation step after emitting SPIR-V. `intValue0` encodes a bool value for the setting. |

--- a/include/slang.h
+++ b/include/slang.h
@@ -585,6 +585,20 @@ typedef uint32_t SlangSizeT;
                 */
     };
 
+    /* A warning "level" (group), modeled on the clang/gcc -Wall/-Wextra/-Wpedantic
+    groups. Each group is enabled independently: a warning tagged with a group is
+    emitted only when that group has been enabled, while warnings in the implicit
+    Default group are always emitted. */
+    typedef int SlangWarningLevelIntegral;
+    enum SlangWarningLevel : SlangWarningLevelIntegral
+    {
+        SLANG_WARNING_LEVEL_DEFAULT = 0,  /**< Always emitted; this is the baseline group and is not
+                                             something a caller enables explicitly. */
+        SLANG_WARNING_LEVEL_ALL = 1,      /**< Warnings enabled by -Wall. */
+        SLANG_WARNING_LEVEL_EXTRA = 2,    /**< Warnings enabled by -Wextra. */
+        SLANG_WARNING_LEVEL_PEDANTIC = 3, /**< Warnings enabled by -Wpedantic. */
+    };
+
     typedef int SlangDiagnosticFlags;
     enum
     {
@@ -1216,6 +1230,11 @@ typedef uint32_t SlangSizeT;
                  //   single heap shared by buffers and images is indexed at the device's unified
                  //   stride. Opt-in; mutually exclusive with a non-zero
                  //   `-spirv-resource-heap-stride` (combining the two is an error).
+
+        // intValue0: a SlangWarningLevel group to enable (e.g. SLANG_WARNING_LEVEL_PEDANTIC).
+        // Repeatable: enabling multiple groups is additive, matching how -Wall/-Wextra/-Wpedantic
+        // combine on the command line. CLI spellings: -Wall, -Wextra, -Wpedantic.
+        WarningLevel = 155,
 
         // Do not assign an explicit value to CountOf. It must remain one past the last option,
         // which it derives implicitly from the preceding (highest-valued) enumerator.

--- a/source/compiler-core/slang-diagnostic-sink.cpp
+++ b/source/compiler-core/slang-diagnostic-sink.cpp
@@ -745,6 +745,13 @@ Severity DiagnosticSink::getEffectiveMessageSeverity(
         if (effectiveSeverity < Severity::Error || *pSeverityOverride >= effectiveSeverity)
             effectiveSeverity = *pSeverityOverride;
     }
+    else if (effectiveSeverity == Severity::Warning && !isWarningLevelEnabled(info.level))
+    {
+        // The warning belongs to an opt-in group (-Wall/-Wextra/-Wpedantic) that has not been
+        // enabled, so it is suppressed. An explicit per-id override (-W<name>/-Wno-<name>) takes
+        // precedence over this group gating, which is why it lives in the `else` branch.
+        effectiveSeverity = Severity::Disable;
+    }
 
     if (isFlagSet(Flag::TreatWarningsAsErrors) && effectiveSeverity == Severity::Warning)
         effectiveSeverity = Severity::Error;
@@ -828,8 +835,12 @@ void DiagnosticSink::overrideDiagnosticSeverity(
     {
         SLANG_ASSERT(info->id == diagnosticId);
 
-        // If the override is the same as the default, we can just remove the override
-        if (info->severity == overrideSeverity)
+        // If the override is the same as the default, we can just remove the override -- but only
+        // for the always-on Default group. For a warning in an opt-in group (-Wall/-Wextra/
+        // -Wpedantic), an explicit override back to its nominal Warning severity is meaningful: it
+        // force-enables the warning even though its group is not enabled, so the override must be
+        // kept (an absent override would let group gating suppress it).
+        if (info->severity == overrideSeverity && info->level == WarningLevel::Default)
         {
             m_severityOverrides.remove(diagnosticId);
             return;

--- a/source/compiler-core/slang-diagnostic-sink.h
+++ b/source/compiler-core/slang-diagnostic-sink.h
@@ -308,17 +308,26 @@ public:
     /// Enable the given warning group (one of the -Wall/-Wextra/-Wpedantic groups). Warnings
     /// tagged with that group will then be emitted. Enabling is additive; `WarningLevel::Default`
     /// warnings are always emitted and need not be enabled.
+    ///
+    /// The bit index is bounds-checked before shifting so that an out-of-range value (which can
+    /// only arrive from a bogus int cast through the public `CompilerOptionName::WarningLevel`
+    /// option) cannot produce an out-of-range shift, which is undefined behavior. Such values are
+    /// ignored here; `applySettingsToDiagnosticSink` also filters them at the API boundary.
     void enableWarningLevel(WarningLevel level)
     {
-        m_enabledWarningLevels |= (uint32_t(1) << uint32_t(level));
+        const auto bit = uint32_t(level);
+        if (bit < 32)
+            m_enabledWarningLevels |= (uint32_t(1) << bit);
     }
 
     /// Test whether a warning belonging to `level` should currently be emitted: true for the
     /// always-on `Default` group, and for any group that has been enabled via enableWarningLevel.
     bool isWarningLevelEnabled(WarningLevel level) const
     {
-        return level == WarningLevel::Default ||
-               (m_enabledWarningLevels & (uint32_t(1) << uint32_t(level))) != 0;
+        if (level == WarningLevel::Default)
+            return true;
+        const auto bit = uint32_t(level);
+        return bit < 32 && (m_enabledWarningLevels & (uint32_t(1) << bit)) != 0;
     }
 
     /// Get the (optional) diagnostic sink lexer. This is used to

--- a/source/compiler-core/slang-diagnostic-sink.h
+++ b/source/compiler-core/slang-diagnostic-sink.h
@@ -20,6 +20,32 @@ enum class Severity
     Internal
 };
 
+// The "level" (group) a warning belongs to, modeled on clang/gcc's -Wall/-Wextra/-Wpedantic
+// groups. Groups are enabled independently (not nested): a warning is emitted only if its group
+// is `Default` (always emitted) or its group has been explicitly enabled on the sink. Most
+// diagnostics use `Default`; only warnings that should be opt-in are tagged with another group.
+enum class WarningLevel
+{
+    Default = 0,
+    All = 1,
+    Extra = 2,
+    Pedantic = 3,
+};
+
+// Keep the internal enum in sync with the public slang.h constants.
+static_assert(
+    SLANG_WARNING_LEVEL_DEFAULT == int(WarningLevel::Default),
+    "mismatched WarningLevel enum values");
+static_assert(
+    SLANG_WARNING_LEVEL_ALL == int(WarningLevel::All),
+    "mismatched WarningLevel enum values");
+static_assert(
+    SLANG_WARNING_LEVEL_EXTRA == int(WarningLevel::Extra),
+    "mismatched WarningLevel enum values");
+static_assert(
+    SLANG_WARNING_LEVEL_PEDANTIC == int(WarningLevel::Pedantic),
+    "mismatched WarningLevel enum values");
+
 // Make sure that the slang.h severity constants match those defined here
 static_assert(SLANG_SEVERITY_DISABLED == int(Severity::Disable), "mismatched Severity enum values");
 static_assert(SLANG_SEVERITY_NOTE == int(Severity::Note), "mismatched Severity enum values");
@@ -60,6 +86,13 @@ struct DiagnosticInfo
     Severity severity;
     char const* name; ///< Unique name
     char const* messageFormat;
+
+    /// The warning group this diagnostic belongs to. Only meaningful for warnings; the default of
+    /// `WarningLevel::Default` means "always emitted". Tagging a warning with another group makes
+    /// it opt-in via the corresponding -Wall/-Wextra/-Wpedantic flag (or the WarningLevel API
+    /// option). Has a default so the many aggregate initializers that predate this field (and the
+    /// `DIAGNOSTIC(...)` macro catalogs) keep compiling unchanged.
+    WarningLevel level = WarningLevel::Default;
 };
 
 class Diagnostic
@@ -272,6 +305,22 @@ public:
         Severity overrideSeverity,
         const DiagnosticInfo* info = nullptr);
 
+    /// Enable the given warning group (one of the -Wall/-Wextra/-Wpedantic groups). Warnings
+    /// tagged with that group will then be emitted. Enabling is additive; `WarningLevel::Default`
+    /// warnings are always emitted and need not be enabled.
+    void enableWarningLevel(WarningLevel level)
+    {
+        m_enabledWarningLevels |= (uint32_t(1) << uint32_t(level));
+    }
+
+    /// Test whether a warning belonging to `level` should currently be emitted: true for the
+    /// always-on `Default` group, and for any group that has been enabled via enableWarningLevel.
+    bool isWarningLevelEnabled(WarningLevel level) const
+    {
+        return level == WarningLevel::Default ||
+               (m_enabledWarningLevels & (uint32_t(1) << uint32_t(level))) != 0;
+    }
+
     /// Get the (optional) diagnostic sink lexer. This is used to
     /// improve quality of highlighting a locations token. If not set, will just have a single
     /// character caret at location
@@ -422,6 +471,10 @@ protected:
     // will share the same override. TODO: Consider keying by DiagnosticInfo* instead for
     // more precise per-diagnostic control.
     Dictionary<int, Severity> m_severityOverrides;
+
+    // Bitmask of enabled warning groups, indexed by `WarningLevel`. The `Default` group is always
+    // on and is not represented here; other groups are opt-in (see enableWarningLevel).
+    uint32_t m_enabledWarningLevels = 0;
 
     RefPtr<SourceWarningStateTrackerBase> m_sourceWarningStateTracker = nullptr;
 

--- a/source/compiler-core/slang-diagnostic-sink.h
+++ b/source/compiler-core/slang-diagnostic-sink.h
@@ -474,7 +474,12 @@ protected:
 
     // Bitmask of enabled warning groups, indexed by `WarningLevel`. The `Default` group is always
     // on and is not represented here; other groups are opt-in (see enableWarningLevel).
-    uint32_t m_enabledWarningLevels = 0;
+    //
+    // The `Pedantic` group is enabled by default for now, so tagging a warning `pedantic` does not
+    // yet change its visibility -- it only records the group. A follow-up will flip pedantic to
+    // off-by-default (and decide which existing warnings belong in each group); this staging lets
+    // the grouping land without silently dropping any warning from today's output.
+    uint32_t m_enabledWarningLevels = (uint32_t(1) << uint32_t(WarningLevel::Pedantic));
 
     RefPtr<SourceWarningStateTrackerBase> m_sourceWarningStateTracker = nullptr;
 

--- a/source/compiler-core/slang-diagnostic-sink.h
+++ b/source/compiler-core/slang-diagnostic-sink.h
@@ -330,6 +330,11 @@ public:
         return bit < 32 && (m_enabledWarningLevels & (uint32_t(1) << bit)) != 0;
     }
 
+    /// Get/set the raw enabled-warning-group bitmask. Used to copy this settings-shaped state
+    /// between sinks (e.g. from a parent sink), mirroring getFlags/setFlags.
+    uint32_t getEnabledWarningLevels() const { return m_enabledWarningLevels; }
+    void setEnabledWarningLevels(uint32_t levels) { m_enabledWarningLevels = levels; }
+
     /// Get the (optional) diagnostic sink lexer. This is used to
     /// improve quality of highlighting a locations token. If not set, will just have a single
     /// character caret at location
@@ -415,6 +420,7 @@ public:
             setFlags(parentSink->getFlags());
             setDiagnosticColorMode(parentSink->getDiagnosticColorMode());
             setEnableUnicode(parentSink->getEnableUnicode());
+            setEnabledWarningLevels(parentSink->getEnabledWarningLevels());
         }
     }
     /// Default Ctor

--- a/source/slang/slang-compiler-options.cpp
+++ b/source/slang/slang-compiler-options.cpp
@@ -430,6 +430,13 @@ void applySettingsToDiagnosticSink(
                 Severity::Warning,
                 Severity::Error);
     }
+    // Enable each requested warning group (-Wall/-Wextra/-Wpedantic). These are additive, so a
+    // diagnostic tagged with any enabled group becomes visible.
+    auto warningLevelArray = options.getArray(CompilerOptionName::WarningLevel);
+    for (auto& element : warningLevelArray)
+    {
+        targetSink->enableWarningLevel((WarningLevel)element.intValue);
+    }
     if (options.shouldEmitRichDiagnostics())
     {
         targetSink->setFlag(DiagnosticSink::Flag::AlwaysGenerateRichDiagnostics);

--- a/source/slang/slang-compiler-options.cpp
+++ b/source/slang/slang-compiler-options.cpp
@@ -216,6 +216,7 @@ bool CompilerOptionSet::allowDuplicate(CompilerOptionName name)
     case CompilerOptionName::DisableWarning:
     case CompilerOptionName::DisableWarnings:
     case CompilerOptionName::EnableWarning:
+    case CompilerOptionName::WarningLevel:
     case CompilerOptionName::Capability:
     case CompilerOptionName::DownstreamArgs:
     case CompilerOptionName::VulkanBindShift:
@@ -431,11 +432,22 @@ void applySettingsToDiagnosticSink(
                 Severity::Error);
     }
     // Enable each requested warning group (-Wall/-Wextra/-Wpedantic). These are additive, so a
-    // diagnostic tagged with any enabled group becomes visible.
+    // diagnostic tagged with any enabled group becomes visible. `intValue` is embedder-controlled
+    // through the public WarningLevel option, so validate it here at the API boundary and ignore
+    // anything outside the known groups (Default is the always-on baseline and needs no enabling).
     auto warningLevelArray = options.getArray(CompilerOptionName::WarningLevel);
     for (auto& element : warningLevelArray)
     {
-        targetSink->enableWarningLevel((WarningLevel)element.intValue);
+        switch (element.intValue)
+        {
+        case SLANG_WARNING_LEVEL_ALL:
+        case SLANG_WARNING_LEVEL_EXTRA:
+        case SLANG_WARNING_LEVEL_PEDANTIC:
+            targetSink->enableWarningLevel((WarningLevel)element.intValue);
+            break;
+        default:
+            break;
+        }
     }
     if (options.shouldEmitRichDiagnostics())
     {

--- a/source/slang/slang-diagnostics-helpers.lua
+++ b/source/slang/slang-diagnostics-helpers.lua
@@ -1,5 +1,16 @@
 -- Helper functions for defining diagnostics
 
+-- Warning-level (group) sentinels. These are passed positionally to warning()/err() alongside
+-- the spans (e.g. `warning("my-warning", 123, "msg", span{...}, pedantic)`), and recognised by
+-- add_diagnostic so they don't get mistaken for a span. They mirror the clang/gcc groups: a
+-- warning tagged with one of these is emitted only when the matching -Wall/-Wextra/-Wpedantic
+-- flag is enabled. Untagged warnings stay in the always-on "default" group.
+-- (There is no `default` sentinel because `default` is a Lua keyword and the absence of any
+-- sentinel already means the default group.)
+local warning_all = { is_warning_level = true, level = "all" }
+local warning_extra = { is_warning_level = true, level = "extra" }
+local warning_pedantic = { is_warning_level = true, level = "pedantic" }
+
 -- Calculate Levenshtein edit distance between two strings
 local function edit_distance(s1, s2)
   local len1, len2 = #s1, #s2
@@ -378,6 +389,8 @@ local function add_diagnostic(name, code, severity, message, primary_span, ...)
     severity = severity,
     message = message,
     primary_span = primary_span,
+    -- Warning group; "default" (always emitted) unless a sentinel below overrides it.
+    level = "default",
   }
 
   local extra_spans = { ... }
@@ -386,7 +399,11 @@ local function add_diagnostic(name, code, severity, message, primary_span, ...)
     local notes = {}
 
     for _, s in ipairs(extra_spans) do
-      if s.is_note then
+      if s.is_warning_level then
+        -- A warning-level sentinel (all/extra/pedantic): record the group and skip it; it is
+        -- not a span or note.
+        diag.level = s.level
+      elseif s.is_note then
         table.insert(notes, {
           location = s.location,
           message = s.message,
@@ -1055,6 +1072,7 @@ local function process_diagnostics(diagnostics_table)
         name = diag.name,
         code = diag.code,
         severity = diag.severity,
+        level = diag.level or "default",
         message = diag.message,
         message_parts = main_parts,
         message_required_params = main_required,
@@ -1110,6 +1128,10 @@ return {
   warning = warning,
   internal = internal,
   fatal = fatal,
+  -- Warning-level (group) sentinels passed positionally to warning()/err().
+  all = warning_all,
+  extra = warning_extra,
+  pedantic = warning_pedantic,
   process_diagnostics = process_diagnostics,
   -- Utility functions for typo suggestions
   edit_distance = edit_distance,

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -122,11 +122,11 @@ local err = helpers.err
 local warning = helpers.warning
 local internal = helpers.internal
 local fatal = helpers.fatal
--- Warning-level (group) sentinels: pass one positionally to warning() to make that warning
--- opt-in behind -Wall/-Wextra/-Wpedantic respectively, e.g.
+-- Warning-level (group) sentinel: pass one positionally to warning() to make that warning
+-- opt-in behind a -W group flag, e.g.
 --   warning("my-warning", 123, "message", span{...}, pedantic)
-local all = helpers.all
-local extra = helpers.extra
+-- Only `pedantic` is used today; `helpers.all` and `helpers.extra` exist for the other groups
+-- and can be bound here when a diagnostic needs them.
 local pedantic = helpers.pedantic
 
 --

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -945,7 +945,10 @@ warning(
     "keyword-used-as-name",
     20103,
     "keyword used as a name",
-    span { loc = "location", message = "'~name:Name' is a type keyword; using it as a name may make the name ambiguous or impossible to reference in some contexts" }
+    span { loc = "location", message = "'~name:Name' is a type keyword; using it as a name may make the name ambiguous or impossible to reference in some contexts" },
+    -- Pedantic: using a type keyword as a name is legal and usually works; this is a
+    -- style/portability hint rather than a likely bug, so it belongs in the pedantic group.
+    pedantic
 )
 
 err(
@@ -1678,14 +1681,11 @@ warning(
     span { loc = "expr:Expr", message = "implicit conversion from '~fromType:Type' to '~toType:Type' is not recommended" }
 )
 
--- Pedantic: this is a purely advisory performance hint (the conversion is well-defined and
--- correct), so it is opt-in behind -Wpedantic rather than emitted by default.
 warning(
     "implicit-conversion-to-double",
     30082,
     "implicit float-to-double conversion",
-    span { loc = "expr:Expr", message = "implicit float-to-double conversion may cause unexpected performance issues, use explicit cast if intended." },
-    pedantic
+    span { loc = "expr:Expr", message = "implicit float-to-double conversion may cause unexpected performance issues, use explicit cast if intended." }
 )
 
 -- try/throw diagnostics

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -122,6 +122,12 @@ local err = helpers.err
 local warning = helpers.warning
 local internal = helpers.internal
 local fatal = helpers.fatal
+-- Warning-level (group) sentinels: pass one positionally to warning() to make that warning
+-- opt-in behind -Wall/-Wextra/-Wpedantic respectively, e.g.
+--   warning("my-warning", 123, "message", span{...}, pedantic)
+local all = helpers.all
+local extra = helpers.extra
+local pedantic = helpers.pedantic
 
 --
 -- 0xxxx - Command line and interaction with host platform APIs.
@@ -1672,11 +1678,14 @@ warning(
     span { loc = "expr:Expr", message = "implicit conversion from '~fromType:Type' to '~toType:Type' is not recommended" }
 )
 
+-- Pedantic: this is a purely advisory performance hint (the conversion is well-defined and
+-- correct), so it is opt-in behind -Wpedantic rather than emitted by default.
 warning(
     "implicit-conversion-to-double",
     30082,
     "implicit float-to-double conversion",
-    span { loc = "expr:Expr", message = "implicit float-to-double conversion may cause unexpected performance issues, use explicit cast if intended." }
+    span { loc = "expr:Expr", message = "implicit float-to-double conversion may cause unexpected performance issues, use explicit cast if intended." },
+    pedantic
 )
 
 -- try/throw diagnostics

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -585,6 +585,10 @@ void initCommandOptions(CommandOptions& options)
          "-warnings-disable",
          "-warnings-disable <id>[,<id>...]",
          "Disable specific warning ids."},
+        {OptionKind::WarningLevel,
+         "-Wall,-Wextra,-Wpedantic",
+         "-Wall | -Wextra | -Wpedantic",
+         "Enable the corresponding group of opt-in warnings (additive)."},
         {OptionKind::EnableWarning, "-W...", "-W<id>", "Enable a warning with the specified id."},
         {OptionKind::DisableWarning, "-Wno-...", "-Wno-<id>", "Disable warning with <id>"},
         {OptionKind::DumpWarningDiagnostics,
@@ -3048,6 +3052,28 @@ SlangResult OptionsParser::_parse(int argc, char const* const* argv)
                 // Enable the warning
                 // SLANG_RETURN_ON_FAIL(_overrideDiagnostic(name, Severity::Warning,
                 // Severity::Warning));
+                break;
+            }
+        case OptionKind::WarningLevel:
+            {
+                // The flag spelling (-Wall/-Wextra/-Wpedantic) selects which warning group to
+                // enable. Exact-match options take priority over the -W<id> prefix, so these are
+                // never confused with `-W<name>`.
+                auto flag = argValue.getUnownedSlice();
+                SlangWarningLevel level;
+                if (flag == "-Wall")
+                    level = SLANG_WARNING_LEVEL_ALL;
+                else if (flag == "-Wextra")
+                    level = SLANG_WARNING_LEVEL_EXTRA;
+                else if (flag == "-Wpedantic")
+                    level = SLANG_WARNING_LEVEL_PEDANTIC;
+                else
+                {
+                    // Only the three exact flags above are registered for WarningLevel, so any
+                    // other spelling reaching here is a wiring bug, not user input.
+                    SLANG_UNEXPECTED("unhandled -W warning-level flag");
+                }
+                linkage->m_optionSet.add(OptionKind::WarningLevel, (int)level);
                 break;
             }
         case OptionKind::VerifyDebugSerialIr:

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -588,7 +588,9 @@ void initCommandOptions(CommandOptions& options)
         {OptionKind::WarningLevel,
          "-Wall,-Wextra,-Wpedantic",
          "-Wall | -Wextra | -Wpedantic",
-         "Enable the corresponding group of opt-in warnings (additive)."},
+         "Enable the corresponding group of opt-in warnings (additive). Staging: the pedantic "
+         "group is currently enabled by default, so -Wpedantic is a no-op today; a future release "
+         "will make it opt-in."},
         {OptionKind::EnableWarning, "-W...", "-W<id>", "Enable a warning with the specified id."},
         {OptionKind::DisableWarning, "-Wno-...", "-Wno-<id>", "Disable warning with <id>"},
         {OptionKind::DumpWarningDiagnostics,

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -589,8 +589,8 @@ void initCommandOptions(CommandOptions& options)
          "-Wall,-Wextra,-Wpedantic",
          "-Wall | -Wextra | -Wpedantic",
          "Enable the corresponding group of opt-in warnings (additive). Staging: the pedantic "
-         "group is currently enabled by default, so -Wpedantic is a no-op today; a future release "
-         "will make it opt-in."},
+         "group is currently enabled by default, so passing the pedantic flag is a no-op today; a "
+         "future release will make it opt-in."},
         {OptionKind::EnableWarning, "-W...", "-W<id>", "Enable a warning with the specified id."},
         {OptionKind::DisableWarning, "-Wno-...", "-Wno-<id>", "Disable warning with <id>"},
         {OptionKind::DumpWarningDiagnostics,

--- a/source/slang/slang-rich-diagnostics.cpp
+++ b/source/slang/slang-rich-diagnostics.cpp
@@ -26,7 +26,7 @@ namespace Diagnostics
 %     local class_name = lua_module.toPascalCase(diagnostic.name)
 %     -- Escape quotes and backslashes in the message
 %     local escaped_message = diagnostic.message:gsub('\\', '\\\\'):gsub('"', '\\"')
-const DiagnosticInfo $(camel_name)Info = {$(diagnostic.code), $(lua_module.getSeverityEnum(diagnostic.severity)), "$(camel_name)", "$(escaped_message)"};
+const DiagnosticInfo $(camel_name)Info = {$(diagnostic.code), $(lua_module.getSeverityEnum(diagnostic.severity)), "$(camel_name)", "$(escaped_message)", $(lua_module.getWarningLevelEnum(diagnostic.level))};
 const DiagnosticInfo* $(class_name)::getInfo() { return &$(camel_name)Info; }
 % end
 

--- a/source/slang/slang-rich-diagnostics.h.lua
+++ b/source/slang/slang-rich-diagnostics.h.lua
@@ -236,6 +236,33 @@ function M.getSeverityEnum(severity_name)
 	return mapped
 end
 
+-- Helper function to convert warning-level (group) names to C++ WarningLevel enum values.
+local warning_level_map = {
+	["default"] = "WarningLevel::Default",
+	["all"] = "WarningLevel::All",
+	["extra"] = "WarningLevel::Extra",
+	["pedantic"] = "WarningLevel::Pedantic",
+}
+
+function M.getWarningLevelEnum(level_name)
+	-- Default to the always-on group when a diagnostic carries no explicit level.
+	local mapped = warning_level_map[level_name or "default"]
+	if not mapped then
+		local supported = {}
+		for key in pairs(warning_level_map) do
+			supported[#supported + 1] = key
+		end
+		table.sort(supported)
+		error(
+			"Unknown warning level '"
+				.. tostring(level_name)
+				.. "'. Supported levels: "
+				.. table.concat(supported, ", ")
+		)
+	end
+	return mapped
+end
+
 -- Get all processed diagnostic definitions
 function M.getDiagnostics()
 	return diagnostics_module

--- a/tests/diagnostics/warning-levels.slang
+++ b/tests/diagnostics/warning-levels.slang
@@ -15,7 +15,12 @@
 //DIAGNOSTIC_TEST:SIMPLE(diag=ON): -Wall -target hlsl -entry computeMain -stage compute
 //DIAGNOSTIC_TEST:SIMPLE(diag=ON): -Wextra -target hlsl -entry computeMain -stage compute
 
-// 4. An explicit per-id disable suppresses it regardless of the group being enabled.
+// 4. All three flags on one command line: each exact spelling wins over the -W<id> prefix, and
+// the WarningLevel option is additive (allowDuplicate), so passing several does not error or
+// collapse. The pedantic warning is still emitted.
+//DIAGNOSTIC_TEST:SIMPLE(diag=ON): -Wall -Wextra -Wpedantic -target hlsl -entry computeMain -stage compute
+
+// 5. An explicit per-id disable suppresses it regardless of the group being enabled.
 //DIAGNOSTIC_TEST:SIMPLE(diag=OFF): -Wno-keyword-used-as-name -target hlsl -entry computeMain -stage compute
 
 RWStructuredBuffer<int> outputBuffer;

--- a/tests/diagnostics/warning-levels.slang
+++ b/tests/diagnostics/warning-levels.slang
@@ -1,0 +1,35 @@
+// Tests the warning-level (group) mechanism. `implicit-conversion-to-double` (E30082) is tagged
+// as a "pedantic" group warning, so it is suppressed by default and only emitted when its group
+// is enabled. Each directive below is a separate slangc run with its own diagnostic-check buffer;
+// the two runs that should emit the warning share the `WON` buffer so they check one annotation.
+
+// 1. Default: the pedantic warning is suppressed, so the run is diagnostic-free.
+//DIAGNOSTIC_TEST:SIMPLE(diag=DEFAULT): -target cpp -entry cs -stage compute
+
+// 2. -Wall enables a different group, so the pedantic warning is still suppressed.
+//DIAGNOSTIC_TEST:SIMPLE(diag=WALL): -Wall -target cpp -entry cs -stage compute
+
+// 3. -Wpedantic enables the group, so the warning is emitted.
+//DIAGNOSTIC_TEST:SIMPLE(diag=WON): -Wpedantic -target cpp -entry cs -stage compute
+
+// 4. An explicit per-id enable also turns it on, even without enabling the whole group.
+//DIAGNOSTIC_TEST:SIMPLE(diag=WON): -Wimplicit-conversion-to-double -target cpp -entry cs -stage compute
+
+// 5. Enabling the group but disabling this id keeps it suppressed (-Wno wins).
+//DIAGNOSTIC_TEST:SIMPLE(diag=WNO): -Wpedantic -Wno-implicit-conversion-to-double -target cpp -entry cs -stage compute
+
+double sink_d(double x)
+{
+    return x;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void cs()
+{
+    float f = 1.0f;
+    double d = sink_d(f);
+//WON:                ^ implicit float-to-double conversion
+//WON:                ^ implicit float-to-double conversion may cause unexpected performance issues, use explicit cast if intended.
+    printf("%f\n", d);
+}

--- a/tests/diagnostics/warning-levels.slang
+++ b/tests/diagnostics/warning-levels.slang
@@ -1,35 +1,27 @@
-// Tests the warning-level (group) mechanism. `implicit-conversion-to-double` (E30082) is tagged
-// as a "pedantic" group warning, so it is suppressed by default and only emitted when its group
-// is enabled. Each directive below is a separate slangc run with its own diagnostic-check buffer;
-// the two runs that should emit the warning share the `WON` buffer so they check one annotation.
+// Tests the warning-level (group) mechanism. `keyword-used-as-name` (E20103) is tagged as a
+// "pedantic" group warning. The pedantic group is enabled by default for now, so the warning is
+// still emitted by default; -Wpedantic is therefore redundant here but must be accepted, and an
+// explicit -Wno-<id> must still suppress the warning. Each directive is a separate slangc run; the
+// two runs that emit the warning share the `ON` check buffer.
 
-// 1. Default: the pedantic warning is suppressed, so the run is diagnostic-free.
-//DIAGNOSTIC_TEST:SIMPLE(diag=DEFAULT): -target cpp -entry cs -stage compute
+// 1. Default: pedantic group is on by default, so the warning is emitted.
+//DIAGNOSTIC_TEST:SIMPLE(diag=ON): -target hlsl -entry computeMain -stage compute
 
-// 2. -Wall enables a different group, so the pedantic warning is still suppressed.
-//DIAGNOSTIC_TEST:SIMPLE(diag=WALL): -Wall -target cpp -entry cs -stage compute
+// 2. -Wpedantic explicitly enables the (already-on) pedantic group; still emitted.
+//DIAGNOSTIC_TEST:SIMPLE(diag=ON): -Wpedantic -target hlsl -entry computeMain -stage compute
 
-// 3. -Wpedantic enables the group, so the warning is emitted.
-//DIAGNOSTIC_TEST:SIMPLE(diag=WON): -Wpedantic -target cpp -entry cs -stage compute
+// 3. An explicit per-id disable suppresses it regardless of the group being enabled.
+//DIAGNOSTIC_TEST:SIMPLE(diag=OFF): -Wno-keyword-used-as-name -target hlsl -entry computeMain -stage compute
 
-// 4. An explicit per-id enable also turns it on, even without enabling the whole group.
-//DIAGNOSTIC_TEST:SIMPLE(diag=WON): -Wimplicit-conversion-to-double -target cpp -entry cs -stage compute
+RWStructuredBuffer<int> outputBuffer;
 
-// 5. Enabling the group but disabling this id keeps it suppressed (-Wno wins).
-//DIAGNOSTIC_TEST:SIMPLE(diag=WNO): -Wpedantic -Wno-implicit-conversion-to-double -target cpp -entry cs -stage compute
-
-double sink_d(double x)
-{
-    return x;
-}
+static int enum = 0;
+//ON:      ^^^^ keyword used as a name
+//ON:      ^^^^ 'enum' is a type keyword; using it as a name may make the name ambiguous or impossible to reference in some contexts
 
 [shader("compute")]
 [numthreads(1, 1, 1)]
-void cs()
+void computeMain()
 {
-    float f = 1.0f;
-    double d = sink_d(f);
-//WON:                ^ implicit float-to-double conversion
-//WON:                ^ implicit float-to-double conversion may cause unexpected performance issues, use explicit cast if intended.
-    printf("%f\n", d);
+    outputBuffer[0] = 0;
 }

--- a/tests/diagnostics/warning-levels.slang
+++ b/tests/diagnostics/warning-levels.slang
@@ -10,7 +10,12 @@
 // 2. -Wpedantic explicitly enables the (already-on) pedantic group; still emitted.
 //DIAGNOSTIC_TEST:SIMPLE(diag=ON): -Wpedantic -target hlsl -entry computeMain -stage compute
 
-// 3. An explicit per-id disable suppresses it regardless of the group being enabled.
+// 3. -Wall / -Wextra exercise the other two flag spellings; they enable different groups, so the
+// pedantic warning is unaffected (and still emitted, since pedantic is on by default).
+//DIAGNOSTIC_TEST:SIMPLE(diag=ON): -Wall -target hlsl -entry computeMain -stage compute
+//DIAGNOSTIC_TEST:SIMPLE(diag=ON): -Wextra -target hlsl -entry computeMain -stage compute
+
+// 4. An explicit per-id disable suppresses it regardless of the group being enabled.
 //DIAGNOSTIC_TEST:SIMPLE(diag=OFF): -Wno-keyword-used-as-name -target hlsl -entry computeMain -stage compute
 
 RWStructuredBuffer<int> outputBuffer;

--- a/tools/slang-unit-test/unit-test-diagnostic-warning-level.cpp
+++ b/tools/slang-unit-test/unit-test-diagnostic-warning-level.cpp
@@ -14,7 +14,7 @@
 // production warning is tagged with yet, so a regression that ignored
 // `DiagnosticInfo::level` would be caught here.
 
-#include "../../source/compiler-core/slang-diagnostic-sink.h"
+#include "compiler-core/slang-diagnostic-sink.h"
 #include "unit-test/slang-unit-test.h"
 
 using namespace Slang;

--- a/tools/slang-unit-test/unit-test-diagnostic-warning-level.cpp
+++ b/tools/slang-unit-test/unit-test-diagnostic-warning-level.cpp
@@ -102,6 +102,24 @@ SLANG_UNIT_TEST(warningLevelWarningsAsErrorsInteraction)
     SLANG_CHECK(sink.getErrorCount() == 2);
 }
 
+// A child sink built from a parent inherits the parent's enabled warning groups. Sinks are
+// spun up per-translation-unit / per-module from a parent sink via the parent-copying ctor,
+// so an opt-in group enabled on the parent must carry over to nested/downstream compilations.
+SLANG_UNIT_TEST(warningLevelInheritedFromParentSink)
+{
+    DiagnosticSink parent;
+    parent.enableWarningLevel(WarningLevel::All);
+
+    // The parent-copying ctor forwards the enabled-group bitmask alongside flags/color/unicode.
+    DiagnosticSink child(nullptr, nullptr, &parent);
+
+    SLANG_CHECK(child.isWarningLevelEnabled(WarningLevel::All) == true);
+    SLANG_CHECK(emitted(child, makeWarning(3, WarningLevel::All)) == true);
+    // A group the parent did not enable is not inherited either.
+    SLANG_CHECK(child.isWarningLevelEnabled(WarningLevel::Extra) == false);
+    SLANG_CHECK(emitted(child, makeWarning(4, WarningLevel::Extra)) == false);
+}
+
 // Out-of-range group values (only reachable via a bogus int cast through the public
 // WarningLevel option) must not trigger an out-of-range shift / undefined behavior.
 SLANG_UNIT_TEST(warningLevelOutOfRangeIsSafe)

--- a/tools/slang-unit-test/unit-test-diagnostic-warning-level.cpp
+++ b/tools/slang-unit-test/unit-test-diagnostic-warning-level.cpp
@@ -1,0 +1,115 @@
+// unit-test-diagnostic-warning-level.cpp
+//
+// Contract under test
+// -------------------
+// `DiagnosticSink` supports clang/gcc-style warning groups. Each `DiagnosticInfo`
+// carries a `WarningLevel`; the always-on `Default` group is emitted unconditionally,
+// while the `All`/`Extra`/`Pedantic` groups are opt-in via `enableWarningLevel`.
+// Group gating is applied during `diagnose`, after per-id overrides and before the
+// treat-warnings-as-errors flag.
+//
+// These tests drive the public `diagnose` API and observe the result via its return
+// value (false when a diagnostic is suppressed) and `getErrorCount` (for the
+// warnings-as-errors interaction). They exercise the off-by-default groups that no
+// production warning is tagged with yet, so a regression that ignored
+// `DiagnosticInfo::level` would be caught here.
+
+#include "../../source/compiler-core/slang-diagnostic-sink.h"
+#include "unit-test/slang-unit-test.h"
+
+using namespace Slang;
+
+namespace
+{
+// Build a warning `DiagnosticInfo` in the given group. The id is arbitrary but distinct
+// per group so a per-id override in one test does not leak into another.
+DiagnosticInfo makeWarning(int id, WarningLevel level)
+{
+    DiagnosticInfo info{id, Severity::Warning, "test-warning", "test warning message", level};
+    return info;
+}
+
+// True if the diagnostic was emitted (not suppressed by group gating / overrides).
+bool emitted(DiagnosticSink& sink, const DiagnosticInfo& info)
+{
+    return sink.diagnose(SourceLoc(), info);
+}
+} // namespace
+
+// Default state: Default and Pedantic groups are emitted; All and Extra are suppressed.
+SLANG_UNIT_TEST(warningLevelDefaultGating)
+{
+    DiagnosticSink sink;
+
+    SLANG_CHECK(emitted(sink, makeWarning(1, WarningLevel::Default)) == true);
+    SLANG_CHECK(emitted(sink, makeWarning(2, WarningLevel::Pedantic)) == true);
+    SLANG_CHECK(emitted(sink, makeWarning(3, WarningLevel::All)) == false);
+    SLANG_CHECK(emitted(sink, makeWarning(4, WarningLevel::Extra)) == false);
+}
+
+// Enabling a group is additive and affects only that group.
+SLANG_UNIT_TEST(warningLevelEnableIsAdditive)
+{
+    DiagnosticSink sink;
+    sink.enableWarningLevel(WarningLevel::All);
+
+    SLANG_CHECK(emitted(sink, makeWarning(3, WarningLevel::All)) == true);
+    // Extra was not enabled, so it stays suppressed.
+    SLANG_CHECK(emitted(sink, makeWarning(4, WarningLevel::Extra)) == false);
+
+    sink.enableWarningLevel(WarningLevel::Extra);
+    SLANG_CHECK(emitted(sink, makeWarning(4, WarningLevel::Extra)) == true);
+}
+
+// An explicit per-id enable (e.g. -W<name>) force-enables a grouped warning even when its
+// group is off, and a per-id disable (-Wno-<name>) suppresses one even when the group is on.
+SLANG_UNIT_TEST(warningLevelPerIdOverrideWins)
+{
+    DiagnosticSink sink;
+
+    // -W<name> on an off-by-default group warning: the override is kept (the cascading
+    // overrideDiagnosticSeverity fix) and forces the warning on.
+    auto allWarning = makeWarning(3, WarningLevel::All);
+    sink.overrideDiagnosticSeverity(allWarning.id, Severity::Warning, &allWarning);
+    SLANG_CHECK(emitted(sink, allWarning) == true);
+
+    // -Wno-<name> on an on-by-default pedantic warning: suppressed despite the group being on.
+    auto pedanticWarning = makeWarning(2, WarningLevel::Pedantic);
+    sink.overrideDiagnosticSeverity(pedanticWarning.id, Severity::Disable, &pedanticWarning);
+    SLANG_CHECK(emitted(sink, pedanticWarning) == false);
+}
+
+// Treat-warnings-as-errors runs after group gating: a suppressed grouped warning stays
+// suppressed (does not become an error), but once its group is enabled it becomes an error.
+SLANG_UNIT_TEST(warningLevelWarningsAsErrorsInteraction)
+{
+    DiagnosticSink sink;
+    sink.setFlag(DiagnosticSink::Flag::TreatWarningsAsErrors);
+
+    // A default-group warning becomes an error.
+    SLANG_CHECK(sink.getErrorCount() == 0);
+    emitted(sink, makeWarning(1, WarningLevel::Default));
+    SLANG_CHECK(sink.getErrorCount() == 1);
+
+    // An off-by-default group warning is gated out before warnings-as-errors applies, so it
+    // is neither emitted nor counted as an error.
+    SLANG_CHECK(emitted(sink, makeWarning(3, WarningLevel::All)) == false);
+    SLANG_CHECK(sink.getErrorCount() == 1);
+
+    // Once its group is enabled, it does become an error.
+    sink.enableWarningLevel(WarningLevel::All);
+    emitted(sink, makeWarning(3, WarningLevel::All));
+    SLANG_CHECK(sink.getErrorCount() == 2);
+}
+
+// Out-of-range group values (only reachable via a bogus int cast through the public
+// WarningLevel option) must not trigger an out-of-range shift / undefined behavior.
+SLANG_UNIT_TEST(warningLevelOutOfRangeIsSafe)
+{
+    DiagnosticSink sink;
+    const auto bogus = (WarningLevel)9999;
+    sink.enableWarningLevel(bogus); // must be a no-op, not UB
+    SLANG_CHECK(sink.isWarningLevelEnabled(bogus) == false);
+    // Valid groups are unaffected by the bogus call.
+    SLANG_CHECK(emitted(sink, makeWarning(1, WarningLevel::Default)) == true);
+}


### PR DESCRIPTION
Fixes #11012.

## Motivation

The diagnostic system had no notion of warning "levels": every warning was either always on, or had to be individually disabled with `-Wno-<id>`. There was no way to group advisory/stylistic warnings the way clang/gcc do with `-Wall`/`-Wextra`/`-Wpedantic`.

## Proposed solution

Add clang/gcc-style warning groups. Following that model the groups are **independent** (not nested): a warning tagged with a group is emitted only when that group is enabled, while untagged warnings stay in the always-on **default** group. Most warnings need no annotation; only opt-in warnings are tagged.

A warning is tagged in `slang-diagnostics.lua` by passing an `all`/`extra`/`pedantic` sentinel positionally to `warning()`, alongside its spans:

```lua
warning("keyword-used-as-name", 20103,
    "keyword used as a name",
    span { loc = "location", message = "..." },
    pedantic)
```

The level rides on `DiagnosticInfo` and gating happens in one place, `DiagnosticSink::getEffectiveMessageSeverity`. Explicit per-id overrides (`-W<name>`/`-Wno-<name>`/`-warnings-as-errors`) continue to take precedence over group gating.

Control is exposed via the `-Wall`/`-Wextra`/`-Wpedantic` CLI flags and the `WarningLevel` compiler-API option (`SlangWarningLevel`).

**Staging — pedantic is enabled by default for now.** As the first example, `keyword-used-as-name` (E20103) is tagged `pedantic`: using a type keyword as a name is legal and usually works, so it is a style/portability hint rather than a likely bug. To avoid silently dropping any warning from today's output, the `pedantic` group is enabled by default in this PR, so tagging only records the group and changes nothing observable yet. A follow-up will flip `pedantic` to off-by-default and assign groups to the rest of the catalog.

## Change summary

| File | Change |
| --- | --- |
| `include/slang.h` | New `SlangWarningLevel` enum (Default/All/Extra/Pedantic) and `CompilerOptionName::WarningLevel = 155` (appended; intValue0 is the group to enable, repeatable). |
| `source/compiler-core/slang-diagnostic-sink.h` | New internal `WarningLevel` enum (static-asserted against the public one), a `level` field on `DiagnosticInfo` (defaulted so existing aggregate/`DIAGNOSTIC(...)` initializers keep compiling), `enableWarningLevel`/`isWarningLevelEnabled`, and the enabled-groups bitmask (pedantic on by default for now). |
| `source/compiler-core/slang-diagnostic-sink.cpp` | Gate opt-in warnings in `getEffectiveMessageSeverity`; keep an explicit "enable" override for grouped warnings (see Process report). |
| `source/slang/slang-diagnostics-helpers.lua` | Define the `all`/`extra`/`pedantic` sentinels, recognise them in `add_diagnostic`, carry `level` through to the processed entry, and export them. |
| `source/slang/slang-diagnostics.lua` | Import the sentinels; tag `keyword-used-as-name` as `pedantic`. |
| `source/slang/slang-rich-diagnostics.h.lua` / `.cpp` | `getWarningLevelEnum` mapping and emit the level as the 5th `DiagnosticInfo` field. |
| `source/slang/slang-options.cpp` | Register `-Wall`/`-Wextra`/`-Wpedantic` (one option, three names) and map each to a `WarningLevel` group value. |
| `source/slang/slang-compiler-options.cpp` | Apply the `WarningLevel` option array to the sink in `applySettingsToDiagnosticSink`. |
| `tests/diagnostics/warning-levels.slang` | End-to-end test of the flag wiring and `-Wno` precedence. |

## Concepts and vocabulary

- **Warning group / level**: the `all`/`extra`/`pedantic` bucket a warning belongs to, mirroring the clang/gcc groups. `Default` is the implicit always-on group.
- **`DiagnosticInfo`**: the static descriptor for each diagnostic (id, severity, name, message — now also `level`). The Lua catalog generates these for the rich diagnostics; the compiler-core `DIAGNOSTIC(...)` macro catalogs generate the rest.
- **`getEffectiveMessageSeverity`**: the single chokepoint (used by both the legacy and rich diagnostic paths) that resolves a diagnostic's nominal severity into its effective severity after pragmas, per-id overrides, group gating, and warnings-as-errors.
- **per-id override** (`m_severityOverrides`): the map behind `-W<name>`/`-Wno-<name>`/`-warnings-as-errors`, keyed by diagnostic id.

## Process report

**Where the level lives, and why.** The Lua catalog is the single source of truth for diagnostics, so the group is declared there and flows to `DiagnosticInfo::level`. The sink reads `info.level` directly rather than maintaining a side table. The `level` field has a default member initializer (`WarningLevel::Default`); this is what lets the existing 4-element aggregate initializers — both the Lua-generated ones and the `DIAGNOSTIC(id, severity, name, msg)` macro catalogs in compiler-core — keep compiling unchanged.

**Gating.** In `getEffectiveMessageSeverity`, after the existing pragma-tracker step, a warning whose group is not enabled is lowered to `Severity::Disable`. This sits in the `else` of the per-id-override check, so an explicit `-W<name>`/`-Wno-<name>` always wins over group gating.

**One cascading fix — keeping the enable override for grouped warnings.** `overrideDiagnosticSeverity` previously dropped any override equal to the diagnostic's nominal severity. With groups that is wrong: a warning whose group is off has an *effective* default of "suppressed", so an explicit `-W<name>` enabling it back to `Warning` is meaningful and must be kept, otherwise group gating would re-suppress it. The fix restricts the "remove when equal to default" shortcut to `WarningLevel::Default` diagnostics, where the nominal and effective defaults still coincide.

**Input-shape check for the CLI handler.** The three flags are registered as a single option with three names, so only `-Wall`/`-Wextra`/`-Wpedantic` ever reach the `WarningLevel` case; any other spelling is a wiring bug, so the fall-through asserts via `SLANG_UNEXPECTED`. Exact-match option lookup takes priority over the `-W<id>` prefix, so these are never confused with `-W<name>`.

**Example chosen conservatively, and no behavior change yet.** Only `keyword-used-as-name` is tagged. Because the `pedantic` group is on by default in this PR, the warning still appears exactly as before (its existing test passes unchanged), and the new `warning-levels.slang` test confirms the flags are accepted and that `-Wno-keyword-used-as-name` still suppresses it. Flipping pedantic off-by-default and grouping the rest of the catalog is intentionally left to follow-up, per the issue.
