### PR TITLE
Fix #11814: stop debug-capture getString() aliasing the buffer it snapshots

### DIFF
--- a/tools/gfx-unit-test/scoped-core-debug-callback-test.cpp
+++ b/tools/gfx-unit-test/scoped-core-debug-callback-test.cpp
@@ -113,6 +113,35 @@ SLANG_UNIT_TEST(scopedCoreDebugCallbackSeparatesRetainedBridgeScopes)
     SLANG_CHECK(nextCallback.getString() == "next invocation\n");
 }
 
+// Pins the contract that getString() returns storage independent of the bridge's
+// internal buffer, deterministically and without needing a sanitizer.
+//
+// This is the single-threaded safety net for the data race fixed alongside it: the
+// concurrent stress test below only fails under ThreadSanitizer, because the racy
+// aliasing path leaves the old shared buffer immutable via copy-on-write, so a
+// revert of getString() to the buffer-sharing `m_buf.toString()` would still pass
+// every ordinary unit-test run. Here, two back-to-back snapshots taken with no
+// intervening append must each own a distinct StringRepresentation; under the
+// aliasing bug both would share the bridge's representation and compare equal.
+SLANG_UNIT_TEST(coreDebugCallbackGetStringReturnsIndependentStorage)
+{
+    renderer_test::CoreToRHIDebugBridge bridge;
+    renderer_test::CoreDebugCallback callback;
+    {
+        renderer_test::ScopedCoreDebugCallback scopedDebugCallback(bridge, &callback);
+        emitError(bridge, "x");
+    }
+
+    Slang::String first = callback.getString();
+    Slang::String second = callback.getString();
+
+    // Same captured content...
+    SLANG_CHECK(first == "x\n");
+    SLANG_CHECK(first == second);
+    // ...but backed by independent storage, not the bridge's shared buffer.
+    SLANG_CHECK(first.getStringRepresentation() != second.getStringRepresentation());
+}
+
 SLANG_UNIT_TEST(coreDebugBridgeHandlesConcurrentMessages)
 {
     static constexpr int kThreadCount = 4;

--- a/tools/render-test/slang-support.h
+++ b/tools/render-test/slang-support.h
@@ -123,10 +123,22 @@ public:
         m_buf.clear();
     }
 
+    /// Returns a snapshot of the captured messages that does not alias the
+    /// builder's storage, so a concurrent reader can safely inspect it after the
+    /// lock is released.
+    ///
+    /// `Slang::String`'s copy constructor shares the underlying reference-counted
+    /// `StringRepresentation`, so `m_buf.toString()` would hand back a `String`
+    /// pointing into the same char buffer that `handleMessage` keeps appending to.
+    /// Once this method returns and the lock is dropped, a later in-place append
+    /// (`String::appendInPlace`, taken whenever the buffer is uniquely referenced
+    /// again) would then race the reader's access to that buffer. Constructing a
+    /// fresh `String` from the builder's slice forces an independent allocation
+    /// while still under the lock, breaking the alias.
     Slang::String getString()
     {
         std::lock_guard<std::mutex> lock(m_mutex);
-        return m_buf.toString();
+        return Slang::String(m_buf.getUnownedSlice());
     }
 
 private:


### PR DESCRIPTION
Fixes #11814

## Motivation

The unit test `gfx-unit-test-tool/coreDebugBridgeHandlesConcurrentMessages.internal`
(added by #11785) fails intermittently in CI. The test-server log shows an RPC
timeout rather than a clean assertion — the worker hangs or crashes:

```
[…coreDebugBridgeHandlesConcurrentMessages.internal] JSON RPC failure: waitForResult()
[…coreDebugBridgeHandlesConcurrentMessages.internal] rpc failed
result code = 0
standard error = { }
FAILED test: '…coreDebugBridgeHandlesConcurrentMessages.internal'
```

It was first noticed on aarch64 but is **not** aarch64-specific — it has also failed
on Linux x86_64 (debug/release/cpu-only), Windows x86_64-gpu, and macOS aarch64.
aarch64's weaker memory model just makes it surface more often.

The test (`tools/gfx-unit-test/scoped-core-debug-callback-test.cpp`) runs 4 writer
threads emitting messages through `CoreToRHIDebugBridge` while a reader thread
repeatedly calls `CoreDebugCallback::getString()`. The capture machinery lives in
`tools/render-test/slang-support.h`.

## Proposed solution

Make `CoreDebugCallback::getString()` return a snapshot that owns **independent**
storage instead of one that aliases the live capture buffer, by constructing a fresh
`Slang::String` from the builder's slice while still holding the lock.

This is the principled fix: the producer of the snapshot is responsible for not
handing out a value that aliases mutable, lock-protected state. Leaving the alias in
place and trying to repair it downstream (e.g. having every reader hold the lock
across all use, or making `Slang::String` internally thread-safe) would push
front-end-specific concurrency assumptions onto a general-purpose string type that
does not, and should not, support lock-free concurrent reads of a shared mutable
buffer.

## Change summary

| File | Change |
| --- | --- |
| `tools/render-test/slang-support.h` | `CoreDebugCallback::getString()` now returns `Slang::String(m_buf.getUnownedSlice())` instead of `m_buf.toString()`, plus a doc comment explaining why the copy must not alias the builder's storage. |

## Concepts and vocabulary

- **`StringRepresentation`** — the reference-counted heap buffer that backs a
  `Slang::String`/`StringBuilder`. Its refcount is `std::atomic`, but the char data
  and the `length` field it stores are plain memory.
- **Copy-on-write / `isUniquelyReferenced()`** — `String::ensureUniqueStorageWithCapacity`
  mutates the buffer in place (`appendInPlace`) only when the `StringRepresentation`
  is uniquely referenced; otherwise it allocates a fresh copy. This guard protects the
  buffer only for the lifetime of any other `String` that currently shares it.
- **`StringBuilder::toString()`** — defined as `return *this;`, i.e. a `String` copy
  that *shares* the same `StringRepresentation` (the copy constructor does
  `m_buffer = str.m_buffer;`), not a deep copy.

## Process report

**The race.** Consider the reader thread doing `String s = cap.getString();` while a
writer does `m_buf << message` from `handleMessage`. `getString()` took the form:

```cpp
Slang::String getString()
{
    std::lock_guard<std::mutex> lock(m_mutex);
    return m_buf.toString();   // == return m_buf; -> shares m_buf's StringRepresentation
}
```

The `std::mutex` serializes each call, but the returned `String` aliases the builder's
buffer, and the reader reads its `getLength()`/data **after** `getString()` returns and
the lock is dropped. On the writer's next append, `ensureUniqueStorageWithCapacity`
(`source/core/slang-string.cpp:400`) sees the buffer is uniquely referenced again
(the reader's temporary having been destroyed) and takes the in-place path
`appendInPlace`, which writes new chars and updates `m_buffer->length`. That is an
unsynchronized write racing the reader's read of the same `StringRepresentation`.
The refcount itself is atomic, so refcounting is not the bug — the race is on the char
buffer and `length` the shared representation exposes once the mutex no longer covers
the access. Corrupted size metadata is what produces the hang/crash seen as the CI RPC
timeout.

**Is the input shape correct, or should the producer be fixed?** The producer is
`getString()` itself. The buffer it shares is correct and intentional state; what is
wrong is handing out a value that *aliases* it. So the fix belongs exactly here, at the
producer of the snapshot:

```cpp
return Slang::String(m_buf.getUnownedSlice());
```

`String(UnownedStringSlice const&)` calls `append`, which allocates fresh unique
storage, so the returned `String` never points into the builder's buffer. The slice is
read while the lock is held, so taking the snapshot is itself safe.

**Verification.** I reproduced the exact pattern (mutex-guarded `StringBuilder`, a
writer appending under the lock, a reader snapshotting then reading length after the
lock is released) under ThreadSanitizer. The old `m_buf.toString()` path corrupts
`StringRepresentation` size metadata (`allocation-size-too-big` in
`createWithCapacityAndLength`) on every run; the slice-copy path is TSan-clean on
every run. The in-tree test
`gfx-unit-test-tool/coreDebugBridgeHandlesConcurrentMessages.internal` now passes
repeatedly, and the four sibling `scopedCoreDebugCallback*` tests still pass.
