### PR TITLE
Diagnose slangi global-parameter limitation instead of internal error (#10677)

### DIFF
--- a/docs/user-guide/07-autodiff.md
+++ b/docs/user-guide/07-autodiff.md
@@ -8,6 +8,7 @@ permalink: /user-guide/autodiff
 To support differentiable graphics systems such as Gaussian splatters, neural radiance fields, differentiable path tracers, and more,
 Slang provides first-class support for differentiable programming.
 An overview:
+
 - Slang supports the `fwd_diff` and `bwd_diff` operators that can generate the forward-mode and backward-mode derivative propagation functions for any valid Slang function annotated with the `[Differentiable]` attribute.
 - The `DifferentialPair<T>` built-in generic type is used to pass derivatives associated with each function input.
 - The `IDifferentiable` and the experimental `IDifferentiablePtrType` interfaces denote differentiable value and pointer types respectively, and allow finer control over how types behave under differentiation.
@@ -17,7 +18,9 @@ An overview:
 ## Auto-diff operations `fwd_diff` and `bwd_diff`
 
 In Slang, `fwd_diff` and `bwd_diff` are higher-order functions used to transform Slang functions into their forward or backward derivative methods. To better understand what these methods do, here is a small refresher on differentiable calculus:
+
 ### Mathematical overview: Jacobian and its vector products
+
 Forward and backward derivative methods are two different ways of computing a dot product with the Jacobian of a given function.
 Parts of this overview are based on [JAX's auto-diff cookbook](https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html#how-it-s-made-two-foundational-autodiff-functions). The relevant [Wikipedia article](https://en.wikipedia.org/wiki/Automatic_differentiation) is also a great resource for understanding auto-diff.
 
@@ -39,13 +42,13 @@ $$ \mathbf{f}(x, y) = \begin{bmatrix} f_0(x, y) & f_1(x, y) & f_2(x, y) \end{bma
 
 Here, $$D\mathbf{f}$$ is a 3x2 matrix with each element containing a partial derivative:
 
-$$ D\mathbf{f}(x, y) = \begin{bmatrix} 
-\partial f_0 / \partial x & \partial f_0 / \partial y \\  
+$$ D\mathbf{f}(x, y) = \begin{bmatrix}
+\partial f_0 / \partial x & \partial f_0 / \partial y \\
 \partial f_1 / \partial x & \partial f_1 / \partial y \\
 \partial f_2 / \partial x & \partial f_2 / \partial y
-\end{bmatrix} = 
-\begin{bmatrix} 
-3x^2  & 0   \\  
+\end{bmatrix} =
+\begin{bmatrix}
+3x^2  & 0   \\
 y^2   & 2yx \\
 0     & 3y^2
 \end{bmatrix} $$
@@ -86,8 +89,8 @@ For forward-diff, to pass the vector $$\mathbf{v}$$ and receive the outputs, we 
 Example of `fwd_diff`:
 ```csharp
 [Differentiable] // Auto-diff requires that functions are marked differentiable
-float2 foo(float a, float b) 
-{ 
+float2 foo(float a, float b)
+{
     return float2(a * b * b, a * a);
 }
 
@@ -130,8 +133,8 @@ The one extra rule is that the derivative corresponding to the return value of t
 Example:
 ```csharp
 [Differentiable] // Auto-diff requires that functions are marked differentiable
-float2 foo(float a, float b) 
-{ 
+float2 foo(float a, float b)
+{
     return float2(a * b * b, a * a);
 }
 
@@ -212,7 +215,7 @@ For instance, for `MyType`, Slang can infer the differential trivially:
 ```csharp
 struct MyType : IDifferentiable
 {
-    // Automatically inserted by Slang from the fact that 
+    // Automatically inserted by Slang from the fact that
     // MyType has 2 floats which are both differentiable
     //
     typealias Differential = MyType;
@@ -227,7 +230,7 @@ struct MyPartialDiffType : IDifferentiable
 {
     // Automatically inserted by Slang based on which fields are differentiable.
     typealias Differential = syn_MyPartialDiffType_Differential;
-    
+
     float x;
     uint y;
 };
@@ -325,6 +328,11 @@ For types conforming to `IDifferentiablePtrType`, the corresponding pair to use 
 #### Example of defining and using an `IDifferentiablePtrType` object.
 Here is an example of creating a differentiable buffer pointer type, and using it within a differentiable function.
 You can find an interactive sample on the Slang playground [here](https://shader-slang.org/slang-playground/?target=WGSL&code=eJy1VF1v2kAQfPevWEWKYhfkmFdMkBrRSpHKhyBSpdIIHfgcTjFn9z4gEeK_d-_ONsZp1L6UF8MxOzszuz62K3KhoMjI27PINU9iTyqhNwrGb_c6TamY5YwrKqAPDyNmDihXjKwzOlPi8a2g3tED_NzewuOWQnKGZFAQpGYSCM_VFikYl4rwDYU8bdOHlkQhH8kYkTBq8ty10bFn4fPvC6tVC5q4_wdplhM1hLVOYwvRiMd2qaQq9k5Yhzq_Mf4CBDZaqnwHCRVsTxTbU295TzYvByKSUX3mI1-yWh-S4Mmz3GAO_HY4Rdd1Yjyhr0EZiaCojEMRopplEToV0HGgJ5Rj1UxyRUFtkRkzgnWpoCELJHvmxJg0WUrFsgwThRvGb9pxM8xxn7MEKtV-M0cc2Awhg5b44aX6LjifyVSryknbrmm7KpTAyRRh4pKuzqzb-kfLNHTuLLE1v7zcpypgqXfTdPFLE0HlIMPiCe4e9h2-T73SVxbmEgVFYVqux3JMXh8QJ_0JTs_icgG-s2qQMT4GMMFHpxNYgKM7U-5JtjJQO3SMiQVxjTDt0I6DfHJP9-_Ja84fcc7u-SXr9-efJyO_F6Guj5eY8UIrrL2s_PFlPl38rdRujym121AItDwmjPsfDdTN8ug6diE6OSO20L_6yoRU0IuMR01lH37yqzKIPybaixqRNniukz5cp1iMQXbLTJUwqQblyErgQu_MHSHdEpivaVtCyXOxLL1oaAhrtndra1Ip9_boInJeqxtsRiTeVvZFMk0LV4dH0g3D3VL4Xq3Mgvvt5oFfO_6X986Zr0UF3bq6F0Zlvs1UzreSEYc9dabgEIrQXR3_ZT61unJKp98JDfhi).
+
+This example uses GPU resource types (`RWStructuredBuffer`) and global shader
+parameters, so compile it with `slangc` to a GPU target (e.g. SPIR-V, DXIL, or
+CUDA). It cannot be run with the `slangi` CPU interpreter, which does not
+support global parameters or GPU resource types.
 ```csharp
 struct MyBufferPointer : IDifferentiablePtrType
 {
@@ -370,7 +378,7 @@ RWStructuredBuffer<float> derivs;
 void main()
 {
     MyBufferPointer ptr = {inputs, 0};
-    print("Sum of squares of first 10 values: ", sumOfSquares<10>(ptr));
+    printf("Sum of squares of first 10 values: %f\n", sumOfSquares<10>(ptr));
 
     MyBufferPointer deriv_ptr = {derivs, 0};
 
@@ -378,10 +386,10 @@ void main()
     bwd_diff(sumOfSquares<10>)(
         DifferentialPtrPair<MyBufferPointer>(ptr, deriv_ptr),
         1.0);
-    
-    print("Derivative of result w.r.t the 10 values: \n");
+
+    printf("Derivative of result w.r.t the 10 values: \n");
     for (uint i = 0; i < 10; i++)
-        print("%d: %f\n", i, load(deriv_ptr, i));
+        printf("%d: %f\n", i, load(deriv_ptr, i));
 }
 ```
 
@@ -482,7 +490,7 @@ void main()
     // But you can also be explicit with < >
     bwd_diff(calcFoo<float4>)(dpa, float4(1.f));
 
-    // x is differentiable for calcBar because 
+    // x is differentiable for calcBar because
     // __BuiltinFloatingPointType : IDifferentiable
     //
     DifferentialPair<double> dpb = /* .. */;
@@ -543,11 +551,11 @@ struct FooImpl2 : IFoo
 float compute(float x, uint obj_id)
 {
     // Create an instance of either FooImpl1 or FooImpl2
-    IFoo foo = createDynamicObject<IFoo>(obj_id); 
-    
+    IFoo foo = createDynamicObject<IFoo>(obj_id);
+
     // Dynamic dispatch to appropriate 'calc'.
     //
-    // Note that foo itself is non-differentiable, and 
+    // Note that foo itself is non-differentiable, and
     // has no differential data, but 'x' and 'result'
     // will carry derivatives.
     //
@@ -576,7 +584,7 @@ interface IFoo : IDifferentiable
 [Differentiable]
 float calc(float x)
 {
-    // Note that since IFoo is differentiable, 
+    // Note that since IFoo is differentiable,
     // any data in the IFoo implementation is differentiable
     // and will carry derivatives.
     //
@@ -601,9 +609,9 @@ The following is a small snippet with bilinear texture sampling. For a full exam
 
 ```csharp
 [PrimalSubstitute(sampleTextureBilinear_reference)]
-float4 sampleTextureBilinear(Texture2D<float4> x, float2 loc) 
-{ 
-    // HW-accelerated sampling intrinsics. 
+float4 sampleTextureBilinear(Texture2D<float4> x, float2 loc)
+{
+    // HW-accelerated sampling intrinsics.
     // Slang does not have access to the body, so cannot differentiate.
     //
     x.Sample(/*...*/)
@@ -621,7 +629,7 @@ float computePixel(Texture2D<float> x, float a, float b)
 {
     // Slang will use HW-accelerated sampleTextureBilinear for standard function
     // call, but differentiate the SW reference interpolation during backprop.
-    // 
+    //
     float4 sample1 = sampleTextureBilinear(x, float2(a, 1));
 }
 ```
@@ -904,3 +912,4 @@ The following built-in functions are differentiable and both their forward and b
 - Matrix transforms: `mul(matrix, vector)`, `mul(vector, matrix)`, `mul(matrix, matrix)`
 - Matrix operations: `transpose`, `determinant`
 - Legacy blending and lighting intrinsics: `dst`, `lit`
+$$

--- a/docs/user-guide/07-autodiff.md
+++ b/docs/user-guide/07-autodiff.md
@@ -8,7 +8,6 @@ permalink: /user-guide/autodiff
 To support differentiable graphics systems such as Gaussian splatters, neural radiance fields, differentiable path tracers, and more,
 Slang provides first-class support for differentiable programming.
 An overview:
-
 - Slang supports the `fwd_diff` and `bwd_diff` operators that can generate the forward-mode and backward-mode derivative propagation functions for any valid Slang function annotated with the `[Differentiable]` attribute.
 - The `DifferentialPair<T>` built-in generic type is used to pass derivatives associated with each function input.
 - The `IDifferentiable` and the experimental `IDifferentiablePtrType` interfaces denote differentiable value and pointer types respectively, and allow finer control over how types behave under differentiation.
@@ -18,9 +17,7 @@ An overview:
 ## Auto-diff operations `fwd_diff` and `bwd_diff`
 
 In Slang, `fwd_diff` and `bwd_diff` are higher-order functions used to transform Slang functions into their forward or backward derivative methods. To better understand what these methods do, here is a small refresher on differentiable calculus:
-
 ### Mathematical overview: Jacobian and its vector products
-
 Forward and backward derivative methods are two different ways of computing a dot product with the Jacobian of a given function.
 Parts of this overview are based on [JAX's auto-diff cookbook](https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html#how-it-s-made-two-foundational-autodiff-functions). The relevant [Wikipedia article](https://en.wikipedia.org/wiki/Automatic_differentiation) is also a great resource for understanding auto-diff.
 
@@ -42,13 +39,13 @@ $$ \mathbf{f}(x, y) = \begin{bmatrix} f_0(x, y) & f_1(x, y) & f_2(x, y) \end{bma
 
 Here, $$D\mathbf{f}$$ is a 3x2 matrix with each element containing a partial derivative:
 
-$$ D\mathbf{f}(x, y) = \begin{bmatrix}
-\partial f_0 / \partial x & \partial f_0 / \partial y \\
+$$ D\mathbf{f}(x, y) = \begin{bmatrix} 
+\partial f_0 / \partial x & \partial f_0 / \partial y \\  
 \partial f_1 / \partial x & \partial f_1 / \partial y \\
 \partial f_2 / \partial x & \partial f_2 / \partial y
-\end{bmatrix} =
-\begin{bmatrix}
-3x^2  & 0   \\
+\end{bmatrix} = 
+\begin{bmatrix} 
+3x^2  & 0   \\  
 y^2   & 2yx \\
 0     & 3y^2
 \end{bmatrix} $$
@@ -89,8 +86,8 @@ For forward-diff, to pass the vector $$\mathbf{v}$$ and receive the outputs, we 
 Example of `fwd_diff`:
 ```csharp
 [Differentiable] // Auto-diff requires that functions are marked differentiable
-float2 foo(float a, float b)
-{
+float2 foo(float a, float b) 
+{ 
     return float2(a * b * b, a * a);
 }
 
@@ -133,8 +130,8 @@ The one extra rule is that the derivative corresponding to the return value of t
 Example:
 ```csharp
 [Differentiable] // Auto-diff requires that functions are marked differentiable
-float2 foo(float a, float b)
-{
+float2 foo(float a, float b) 
+{ 
     return float2(a * b * b, a * a);
 }
 
@@ -215,7 +212,7 @@ For instance, for `MyType`, Slang can infer the differential trivially:
 ```csharp
 struct MyType : IDifferentiable
 {
-    // Automatically inserted by Slang from the fact that
+    // Automatically inserted by Slang from the fact that 
     // MyType has 2 floats which are both differentiable
     //
     typealias Differential = MyType;
@@ -230,7 +227,7 @@ struct MyPartialDiffType : IDifferentiable
 {
     // Automatically inserted by Slang based on which fields are differentiable.
     typealias Differential = syn_MyPartialDiffType_Differential;
-
+    
     float x;
     uint y;
 };
@@ -386,7 +383,7 @@ void main()
     bwd_diff(sumOfSquares<10>)(
         DifferentialPtrPair<MyBufferPointer>(ptr, deriv_ptr),
         1.0);
-
+    
     printf("Derivative of result w.r.t the 10 values: \n");
     for (uint i = 0; i < 10; i++)
         printf("%d: %f\n", i, load(deriv_ptr, i));
@@ -490,7 +487,7 @@ void main()
     // But you can also be explicit with < >
     bwd_diff(calcFoo<float4>)(dpa, float4(1.f));
 
-    // x is differentiable for calcBar because
+    // x is differentiable for calcBar because 
     // __BuiltinFloatingPointType : IDifferentiable
     //
     DifferentialPair<double> dpb = /* .. */;
@@ -551,11 +548,11 @@ struct FooImpl2 : IFoo
 float compute(float x, uint obj_id)
 {
     // Create an instance of either FooImpl1 or FooImpl2
-    IFoo foo = createDynamicObject<IFoo>(obj_id);
-
+    IFoo foo = createDynamicObject<IFoo>(obj_id); 
+    
     // Dynamic dispatch to appropriate 'calc'.
     //
-    // Note that foo itself is non-differentiable, and
+    // Note that foo itself is non-differentiable, and 
     // has no differential data, but 'x' and 'result'
     // will carry derivatives.
     //
@@ -584,7 +581,7 @@ interface IFoo : IDifferentiable
 [Differentiable]
 float calc(float x)
 {
-    // Note that since IFoo is differentiable,
+    // Note that since IFoo is differentiable, 
     // any data in the IFoo implementation is differentiable
     // and will carry derivatives.
     //
@@ -609,9 +606,9 @@ The following is a small snippet with bilinear texture sampling. For a full exam
 
 ```csharp
 [PrimalSubstitute(sampleTextureBilinear_reference)]
-float4 sampleTextureBilinear(Texture2D<float4> x, float2 loc)
-{
-    // HW-accelerated sampling intrinsics.
+float4 sampleTextureBilinear(Texture2D<float4> x, float2 loc) 
+{ 
+    // HW-accelerated sampling intrinsics. 
     // Slang does not have access to the body, so cannot differentiate.
     //
     x.Sample(/*...*/)
@@ -629,7 +626,7 @@ float computePixel(Texture2D<float> x, float a, float b)
 {
     // Slang will use HW-accelerated sampleTextureBilinear for standard function
     // call, but differentiate the SW reference interpolation during backprop.
-    //
+    // 
     float4 sample1 = sampleTextureBilinear(x, float2(a, 1));
 }
 ```
@@ -912,4 +909,3 @@ The following built-in functions are differentiable and both their forward and b
 - Matrix transforms: `mul(matrix, vector)`, `mul(vector, matrix)`, `mul(matrix, matrix)`
 - Matrix operations: `transpose`, `determinant`
 - Legacy blending and lighting intrinsics: `dst`, `lit`
-$$

--- a/docs/user-guide/07-autodiff.md
+++ b/docs/user-guide/07-autodiff.md
@@ -327,9 +327,9 @@ Here is an example of creating a differentiable buffer pointer type, and using i
 You can find an interactive sample on the Slang playground [here](https://shader-slang.org/slang-playground/?target=WGSL&code=eJy1VF1v2kAQfPevWEWKYhfkmFdMkBrRSpHKhyBSpdIIHfgcTjFn9z4gEeK_d-_ONsZp1L6UF8MxOzszuz62K3KhoMjI27PINU9iTyqhNwrGb_c6TamY5YwrKqAPDyNmDihXjKwzOlPi8a2g3tED_NzewuOWQnKGZFAQpGYSCM_VFikYl4rwDYU8bdOHlkQhH8kYkTBq8ty10bFn4fPvC6tVC5q4_wdplhM1hLVOYwvRiMd2qaQq9k5Yhzq_Mf4CBDZaqnwHCRVsTxTbU295TzYvByKSUX3mI1-yWh-S4Mmz3GAO_HY4Rdd1Yjyhr0EZiaCojEMRopplEToV0HGgJ5Rj1UxyRUFtkRkzgnWpoCELJHvmxJg0WUrFsgwThRvGb9pxM8xxn7MEKtV-M0cc2Awhg5b44aX6LjifyVSryknbrmm7KpTAyRRh4pKuzqzb-kfLNHTuLLE1v7zcpypgqXfTdPFLE0HlIMPiCe4e9h2-T73SVxbmEgVFYVqux3JMXh8QJ_0JTs_icgG-s2qQMT4GMMFHpxNYgKM7U-5JtjJQO3SMiQVxjTDt0I6DfHJP9-_Ja84fcc7u-SXr9-efJyO_F6Guj5eY8UIrrL2s_PFlPl38rdRujym121AItDwmjPsfDdTN8ug6diE6OSO20L_6yoRU0IuMR01lH37yqzKIPybaixqRNniukz5cp1iMQXbLTJUwqQblyErgQu_MHSHdEpivaVtCyXOxLL1oaAhrtndra1Ip9_boInJeqxtsRiTeVvZFMk0LV4dH0g3D3VL4Xq3Mgvvt5oFfO_6X986Zr0UF3bq6F0Zlvs1UzreSEYc9dabgEIrQXR3_ZT61unJKp98JDfhi).
 
 This example uses GPU resource types (`RWStructuredBuffer`) and global shader
-parameters, so compile it with `slangc` to a GPU target (e.g. SPIR-V, DXIL, or
-CUDA). It cannot be run with the `slangi` CPU interpreter, which does not
-support global parameters or GPU resource types.
+parameters, so compile it with `slangc` to a GPU target. It cannot be run with
+the `slangi` CPU interpreter, which does not support global parameters or GPU
+resource types.
 ```csharp
 struct MyBufferPointer : IDifferentiablePtrType
 {

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -5284,7 +5284,7 @@ err(
 err(
     "global-param-not-supported-by-interpreter",
     52013,
-    "global shader parameter '~name' is not supported by the Slang interpreter (slangi), which runs on the CPU and does not support global parameters or GPU resource types; compile this program with slangc to a GPU target (e.g. SPIR-V, DXIL, CUDA) instead."
+    "global shader parameter '~name' is not supported by the Slang interpreter (slangi), which runs on the CPU and does not support global parameters or GPU resource types; compile this program with slangc to a GPU target instead."
 )
 
 warning(

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -5281,6 +5281,12 @@ err(
     span { loc = "location", message = "'ref' accessor returning type '~valueType:Type' is incompatible with dynamic dispatch because interface types require AnyValue marshalling." }
 )
 
+err(
+    "global-param-not-supported-by-interpreter",
+    52013,
+    "global shader parameter '~name' is not supported by the Slang interpreter (slangi), which runs on the CPU and does not support global parameters or GPU resource types; compile this program with slangc to a GPU target (e.g. SPIR-V, DXIL, CUDA) instead."
+)
+
 warning(
     "mesh-output-must-be-out",
     54001,

--- a/source/slang/slang-emit-vm.cpp
+++ b/source/slang/slang-emit-vm.cpp
@@ -287,15 +287,26 @@ public:
     // itself.
     IRGlobalParam* findReferencedGlobalParam(IRInst* inst)
     {
+        HashSet<IRInst*> visited;
+        return findReferencedGlobalParam(inst, visited);
+    }
+
+    // Worker for findReferencedGlobalParam. `visited` guards against re-walking
+    // shared operands in the global-scope graph, which a global initializer can
+    // reference from several places.
+    IRGlobalParam* findReferencedGlobalParam(IRInst* inst, HashSet<IRInst*>& visited)
+    {
         if (auto globalParam = as<IRGlobalParam>(inst))
             return globalParam;
         // Only global-scope instructions are followed here; an operand at function
         // scope is an ordinary value that ensureInst handles through its normal paths.
         if (!as<IRModuleInst>(inst->getParent()))
             return nullptr;
+        if (!visited.add(inst))
+            return nullptr;
         for (UInt i = 0; i < inst->getOperandCount(); i++)
         {
-            if (auto found = findReferencedGlobalParam(inst->getOperand(i)))
+            if (auto found = findReferencedGlobalParam(inst->getOperand(i), visited))
                 return found;
         }
         return nullptr;

--- a/source/slang/slang-emit-vm.cpp
+++ b/source/slang/slang-emit-vm.cpp
@@ -243,7 +243,11 @@ public:
 
     VMOperand ensureInst(IRInst* inst)
     {
-        VMOperand operand;
+        // Zero-initialize: the global-parameter branch below diagnoses and returns
+        // without computing a real operand, so it must start from a well-defined
+        // value rather than indeterminate stack bytes (which writeInst would copy
+        // byte-for-byte into the code buffer).
+        VMOperand operand = {};
         if (mapInstToOperand.tryGetValue(inst, operand))
             return operand;
 

--- a/source/slang/slang-emit-vm.cpp
+++ b/source/slang/slang-emit-vm.cpp
@@ -3,6 +3,7 @@
 #include "slang-ir-call-graph.h"
 #include "slang-ir-layout.h"
 #include "slang-ir-util.h"
+#include "slang-rich-diagnostics.h"
 
 using namespace slang;
 
@@ -28,6 +29,10 @@ public:
     };
     Dictionary<ConstKey, VMOperand> mapConstantIntToOperand;
     Dictionary<IRFunc*, int> mapFuncToId;
+
+    // Global parameters already reported via diagnoseGlobalParam, so the same
+    // unsupported parameter is diagnosed once rather than once per reference.
+    HashSet<IRGlobalParam*> diagnosedGlobalParams;
 
     VMByteCodeBuilder& byteCodeBuilder;
     CodeGenContext* codeGenContext;
@@ -258,11 +263,85 @@ public:
             operand.size *= (uint32_t)constantVector->getOperandCount();
             mapInstToOperand[inst] = operand;
         }
+        else if (auto globalParam = findReferencedGlobalParam(inst))
+        {
+            // A global parameter (possibly reached through a global-scope instruction
+            // such as a load of the parameter) has arrived at value emission. The
+            // interpreter cannot represent it, so report the limitation and return the
+            // (unused) default operand; emission fails once an error has been reported.
+            diagnoseGlobalParam(globalParam);
+            mapInstToOperand[inst] = operand;
+        }
         else
         {
             SLANG_UNEXPECTED("unsupported global inst for vm bytecode emit");
         }
         return operand;
+    }
+
+    // Return the global shader parameter that `inst` is, or that it references
+    // through its operands (transitively), or null if there is none. Used to detect
+    // values the interpreter cannot represent: a `uniform float` used in a function
+    // body, for example, lowers to a global-scope `load` of the parameter, so the
+    // unsupported value reaching the emitter is the load rather than the parameter
+    // itself.
+    IRGlobalParam* findReferencedGlobalParam(IRInst* inst)
+    {
+        if (auto globalParam = as<IRGlobalParam>(inst))
+            return globalParam;
+        // Only global-scope instructions are followed here; an operand at function
+        // scope is an ordinary value that ensureInst handles through its normal paths.
+        if (!as<IRModuleInst>(inst->getParent()))
+            return nullptr;
+        for (UInt i = 0; i < inst->getOperandCount(); i++)
+        {
+            if (auto found = findReferencedGlobalParam(inst->getOperand(i)))
+                return found;
+        }
+        return nullptr;
+    }
+
+    // Report that a global shader parameter is not supported by the interpreter. The
+    // interpreter runs on the CPU and has no concept of global parameters or GPU
+    // resource types (e.g. RWStructuredBuffer), so a program referencing one cannot
+    // be interpreted. This is the single source of truth for the diagnostic; the two
+    // detection points below feed into it.
+    void diagnoseGlobalParam(IRGlobalParam* globalParam)
+    {
+        if (!diagnosedGlobalParams.add(globalParam))
+            return;
+        codeGenContext->getSink()->diagnose(
+            Diagnostics::GlobalParamNotSupportedByInterpreter{.name = getName(globalParam)});
+    }
+
+    // Report a clean diagnostic if any instruction of a function body has a global
+    // parameter as a direct operand, and return true in that case.
+    //
+    // This complements the check in ensureInst: every emitted *value* flows through
+    // ensureInst and is caught there, but a few instruction handlers (and the
+    // unimplemented-instruction fallback in emitInst) abort before calling ensureInst
+    // on their global-parameter operand. Checking operands up front, before emitting
+    // any instruction of the function, catches those cases and lets the failure
+    // propagate out of emitVMByteCodeForEntryPoints as a clean error instead of an
+    // internal abort.
+    bool diagnoseGlobalParamReferences(IRFunc* func)
+    {
+        bool diagnosed = false;
+        for (auto block : func->getBlocks())
+        {
+            for (auto inst : block->getChildren())
+            {
+                for (UInt i = 0; i < inst->getOperandCount(); i++)
+                {
+                    if (auto globalParam = as<IRGlobalParam>(inst->getOperand(i)))
+                    {
+                        diagnoseGlobalParam(globalParam);
+                        diagnosed = true;
+                    }
+                }
+            }
+        }
+        return diagnosed;
     }
 
     void writeInst(
@@ -1078,6 +1157,12 @@ public:
 
     void emitFunction(IRFunc* func)
     {
+        // Bail out with a clean diagnostic before emitting any instruction if this
+        // function references a global shader parameter, which the interpreter does
+        // not support.
+        if (diagnoseGlobalParamReferences(func))
+            return;
+
         VMByteCodeFunctionBuilder funcBuilder;
         funcBuilder.name = addStringLiteral(getName(func).getUnownedSlice());
 
@@ -1193,8 +1278,18 @@ SlangResult emitVMByteCodeForEntryPoints(
     LinkedIR& linkedIR,
     VMByteCodeBuilder& byteCode)
 {
+    auto sink = codeGenContext->getSink();
+    int errorCountBefore = sink->getErrorCount();
+
     ByteCodeEmitter emitter(byteCode, codeGenContext);
     emitter.emitEntryPoints(linkedIR);
+
+    // If emission reported a diagnostic (e.g. an unsupported global parameter),
+    // fail cleanly so the emitted bytecode is not used, rather than returning
+    // success with malformed output.
+    if (sink->getErrorCount() != errorCountBefore)
+        return SLANG_FAIL;
+
     return SLANG_OK;
 }
 

--- a/source/slang/slang-emit-vm.cpp
+++ b/source/slang/slang-emit-vm.cpp
@@ -340,11 +340,21 @@ public:
         bool diagnosed = false;
         for (auto block : func->getBlocks())
         {
+            // Mirror emitFunction, which skips unreachable blocks; an operand reference
+            // in a block that is never emitted cannot cause an abort.
+            if (isUnreachableBlock(block))
+                continue;
+
             for (auto inst : block->getChildren())
             {
                 for (UInt i = 0; i < inst->getOperandCount(); i++)
                 {
-                    if (auto globalParam = as<IRGlobalParam>(inst->getOperand(i)))
+                    // Use findReferencedGlobalParam (not a direct as<IRGlobalParam>) so
+                    // this mirrors the detection in ensureInst: an operand can be a
+                    // global-scope load of the parameter rather than the parameter
+                    // itself, and the consuming instruction's handler may abort before
+                    // ensureInst is reached.
+                    if (auto globalParam = findReferencedGlobalParam(inst->getOperand(i)))
                     {
                         diagnoseGlobalParam(globalParam);
                         diagnosed = true;

--- a/tests/byte-code/global-param-diagnostic-uniform.slang
+++ b/tests/byte-code/global-param-diagnostic-uniform.slang
@@ -21,7 +21,10 @@ void main()
     // The old internal-error path (E99999/E99997) must stay gone.
     //CHECK-NOT: error[E99999]
     //CHECK-NOT: error[E99997]
+    // The legalized parameter name is substituted into the message (the '~name'
+    // placeholder renders a real, non-empty name).
     //CHECK: error[E52013]
+    //CHECK-SAME: 'globalParams'
     //CHECK-SAME: not supported by the Slang interpreter
     //CHECK-SAME: compile this program with slangc
     //CHECK-NOT: error[E99999]

--- a/tests/byte-code/global-param-diagnostic-uniform.slang
+++ b/tests/byte-code/global-param-diagnostic-uniform.slang
@@ -1,3 +1,5 @@
+//TEST:INTERPRET(filecheck=CHECK):
+
 // A program that references a global shader parameter (here a plain uniform)
 // cannot be run by the slangi CPU interpreter. The interpreter should report a
 // clean diagnostic (error 52013) explaining the limitation, rather than aborting
@@ -9,8 +11,6 @@
 // recovers the underlying parameter. Complements global-param-diagnostic.slang,
 // which exercises the emitFunction pre-scan path.
 
-//TEST:INTERPRET(filecheck=CHECK):
-
 uniform float gScale;
 
 void main()
@@ -18,8 +18,13 @@ void main()
     // A non-zero result code confirms the diagnostic propagated as a clean
     // compilation failure (SLANG_FAIL) rather than producing usable bytecode.
     //CHECK: result code = 1
+    // The old internal-error path (E99999/E99997) must stay gone.
+    //CHECK-NOT: error[E99999]
+    //CHECK-NOT: error[E99997]
     //CHECK: error[E52013]
     //CHECK-SAME: not supported by the Slang interpreter
     //CHECK-SAME: compile this program with slangc
+    //CHECK-NOT: error[E99999]
+    //CHECK-NOT: error[E99997]
     printf("%f\n", gScale * 2.0f);
 }

--- a/tests/byte-code/global-param-diagnostic-uniform.slang
+++ b/tests/byte-code/global-param-diagnostic-uniform.slang
@@ -1,0 +1,25 @@
+// A program that references a global shader parameter (here a plain uniform)
+// cannot be run by the slangi CPU interpreter. The interpreter should report a
+// clean diagnostic (error 52013) explaining the limitation, rather than aborting
+// with an internal error (error 99999/99997). See issue #10677.
+//
+// This exercises the ensureInst detection path: a uniform read lowers to a
+// global-scope load of the parameter, so the unsupported value reaching value
+// emission is the load rather than the parameter itself, and findReferencedGlobalParam
+// recovers the underlying parameter. Complements global-param-diagnostic.slang,
+// which exercises the emitFunction pre-scan path.
+
+//TEST:INTERPRET(filecheck=CHECK):
+
+uniform float gScale;
+
+void main()
+{
+    // A non-zero result code confirms the diagnostic propagated as a clean
+    // compilation failure (SLANG_FAIL) rather than producing usable bytecode.
+    //CHECK: result code = 1
+    //CHECK: error[E52013]
+    //CHECK-SAME: not supported by the Slang interpreter
+    //CHECK-SAME: compile this program with slangc
+    printf("%f\n", gScale * 2.0f);
+}

--- a/tests/byte-code/global-param-diagnostic.slang
+++ b/tests/byte-code/global-param-diagnostic.slang
@@ -1,3 +1,5 @@
+//TEST:INTERPRET(filecheck=CHECK):
+
 // A program that references a GPU resource global (here a RWStructuredBuffer)
 // cannot be run by the slangi CPU interpreter. The interpreter should report a
 // clean diagnostic (error 52013) explaining the limitation, rather than aborting
@@ -8,8 +10,6 @@
 // so the global parameter is caught as a direct operand up front. The buffer is
 // referenced twice to confirm the diagnostic is reported once per parameter.
 
-//TEST:INTERPRET(filecheck=CHECK):
-
 RWStructuredBuffer<float> inputs;
 
 float load(uint index)
@@ -19,9 +19,14 @@ float load(uint index)
 
 void main()
 {
+    // The old internal-error path (E99999/E99997) must stay gone.
+    //CHECK-NOT: error[E99999]
+    //CHECK-NOT: error[E99997]
     //CHECK: error[E52013]
     //CHECK-SAME: not supported by the Slang interpreter
     //CHECK-SAME: compile this program with slangc
     //CHECK-NOT: error[E52013]
+    //CHECK-NOT: error[E99999]
+    //CHECK-NOT: error[E99997]
     printf("%f\n", load(0) + load(1));
 }

--- a/tests/byte-code/global-param-diagnostic.slang
+++ b/tests/byte-code/global-param-diagnostic.slang
@@ -1,0 +1,21 @@
+// Programs that reference a global shader parameter or a GPU resource type
+// cannot be run by the slangi CPU interpreter. The interpreter should report a
+// clean diagnostic (error 52013) explaining the limitation, rather than aborting
+// with an internal error (error 99999/99997). See issue #10677.
+
+//TEST:INTERPRET(filecheck=CHECK):
+
+RWStructuredBuffer<float> inputs;
+
+float load(uint index)
+{
+    return inputs[index];
+}
+
+void main()
+{
+    //CHECK: error[E52013]
+    //CHECK-SAME: not supported by the Slang interpreter
+    //CHECK-SAME: compile this program with slangc
+    printf("%f\n", load(0));
+}

--- a/tests/byte-code/global-param-diagnostic.slang
+++ b/tests/byte-code/global-param-diagnostic.slang
@@ -19,10 +19,16 @@ float load(uint index)
 
 void main()
 {
+    // A non-zero result code confirms the diagnostic propagated as a clean
+    // compilation failure (SLANG_FAIL) rather than producing usable bytecode.
+    //CHECK: result code = 1
     // The old internal-error path (E99999/E99997) must stay gone.
     //CHECK-NOT: error[E99999]
     //CHECK-NOT: error[E99997]
+    // The legalized parameter name is substituted into the message (the '~name'
+    // placeholder renders a real, non-empty name).
     //CHECK: error[E52013]
+    //CHECK-SAME: 'globalParams'
     //CHECK-SAME: not supported by the Slang interpreter
     //CHECK-SAME: compile this program with slangc
     //CHECK-NOT: error[E52013]

--- a/tests/byte-code/global-param-diagnostic.slang
+++ b/tests/byte-code/global-param-diagnostic.slang
@@ -1,7 +1,12 @@
-// Programs that reference a global shader parameter or a GPU resource type
+// A program that references a GPU resource global (here a RWStructuredBuffer)
 // cannot be run by the slangi CPU interpreter. The interpreter should report a
 // clean diagnostic (error 52013) explaining the limitation, rather than aborting
 // with an internal error (error 99999/99997). See issue #10677.
+//
+// This exercises the pre-scan detection path in emitFunction: the structured-buffer
+// access lowers to an instruction whose handler aborts before reaching ensureInst,
+// so the global parameter is caught as a direct operand up front. The buffer is
+// referenced twice to confirm the diagnostic is reported once per parameter.
 
 //TEST:INTERPRET(filecheck=CHECK):
 
@@ -17,5 +22,6 @@ void main()
     //CHECK: error[E52013]
     //CHECK-SAME: not supported by the Slang interpreter
     //CHECK-SAME: compile this program with slangc
-    printf("%f\n", load(0));
+    //CHECK-NOT: error[E52013]
+    printf("%f\n", load(0) + load(1));
 }


### PR DESCRIPTION
Fixes #10677.

## 1. Motivation

A user copied the `IDifferentiablePtrType` example from the [autodiff user guide](https://docs.shader-slang.org/en/latest/external/slang/docs/user-guide/07-autodiff.html) into `diffPtr.slang` and ran it through `slangi`, the experimental CPU byte-code interpreter. Instead of a useful message they got an internal-error abort:

```
(0): error 99999: Slang compilation aborted due to an exception of N5Slang13InternalErrorE:
unexpected: unsupported global inst for vm bytecode emit
```

`slangi` runs on the CPU and, by design, supports only a small subset of Slang — it has no concept of global shader parameters or GPU resource types such as `RWStructuredBuffer`. So this program genuinely cannot be interpreted. The bug is that the interpreter *aborts internally* (E99999/E99997) instead of telling the user that, and that the user guide presents a GPU example as if `slangi` could run it.

The trigger minimizes away from autodiff entirely — any module-scope global parameter referenced by a function body reproduces it. For example, a plain uniform:

```slang
uniform float gScale;
void main() { printf("%f\n", gScale * 2.0f); }
```

or a structured buffer:

```slang
RWStructuredBuffer<float> inputs;
float load(uint index) { return inputs[index]; }
void main() { printf("%f\n", load(0)); }
```

both abort identically today.

## 2. Proposed solution

This is a UX fix at the interpreter's byte-code emit layer, not a request to add GPU-resource support to the VM (which can't meaningfully run on the CPU). When the emitter encounters a reference to a global shader parameter, it now reports a clean diagnostic — **error 52013** — that names the limitation and points the user at `slangc` and a GPU target, and the emit entry point fails cleanly rather than letting the internal `SLANG_UNEXPECTED`/`SLANG_UNIMPLEMENTED_X` abort surface as E99999/E99997.

A global parameter can reach the emitter through more than one path, so detection sits at the two places those paths converge, both feeding one diagnostic helper (`diagnoseGlobalParam`, deduplicated so each parameter is reported once):

- **`findReferencedGlobalParam` inside `ensureInst`** — every emitted *value* flows through `ensureInst`. A `uniform float` used in a body lowers to a global-scope `load` of the parameter, so the unsupported value arriving at the emitter is the load, not the parameter; this walks global-scope operands transitively to find the underlying `IRGlobalParam`.
- **`diagnoseGlobalParamReferences` pre-scan in `emitFunction`** — a few instruction handlers (and the unimplemented-instruction fallback in `emitInst`) abort *before* calling `ensureInst` on their global-parameter operand. A `RWStructuredBuffer` access is one such case. Checking operands up front, before emitting any instruction, catches these.

Both checks are load-bearing: with the pre-scan disabled, the `RWStructuredBuffer` test regresses to E99997; with only the pre-scan, the `uniform`-via-`load` case regresses (the parameter is not a direct operand of a body instruction). They are complementary, not redundant.

The user guide is also corrected: the example now states it is a `slangc`/GPU example that cannot run under `slangi`, and `print` is fixed to `printf`.

The literal full autodiff example still cannot run under `slangi` — it also uses a `defaultConstruct` of a resource-bearing struct, an instruction the VM does not implement, which is a separate by-design gap. Making *every* unimplemented VM instruction a clean diagnostic was intentionally left out of scope; this change addresses the global-parameter root cause (the common minimization) and the doc clarifies that the example is not meant for `slangi`.

## 3. Change summary

| File | Change |
| --- | --- |
| `source/slang/slang-emit-vm.cpp` | Detect references to global parameters at the two convergence points, report E52013 via one deduplicated helper, and return `SLANG_FAIL` from `emitVMByteCodeForEntryPoints` when a diagnostic was reported. Adds `slang-rich-diagnostics.h` include. |
| `source/slang/slang-diagnostics.lua` | New error `global-param-not-supported-by-interpreter` (52013). |
| `docs/user-guide/07-autodiff.md` | Note that the `IDifferentiablePtrType` example is a `slangc`/GPU example, not a `slangi` one; fix `print` → `printf`. |
| `tests/byte-code/global-param-diagnostic.slang` | New `INTERPRET` regression test asserting E52013 for a `RWStructuredBuffer` global. |

## 4. Concepts and vocabulary

- **`slangi`** — the experimental CPU byte-code interpreter. `emitHostVMCode` → `emitVMByteCodeForEntryPoints` lowers linked IR to VM byte code (`CodeGenTarget::HostVM`).
- **`ensureInst`** — the VM emitter routine through which every operand *value* is materialized into a `VMOperand`. Its `else` branch previously `SLANG_UNEXPECTED`-aborted on anything that was neither an `IRConstant` nor an `IRMakeVector` — this is where the E99999 originated.
- **`emitInst`** — the per-instruction byte-code emission switch; its `default` case `SLANG_UNIMPLEMENTED_X`-aborts (E99997) on instructions the VM does not implement.
- **global parameter (`IRGlobalParam`)** — a module-scope shader parameter. Distinct user parameters are legalized into one aggregate (`globalParams`), which is the name surfaced in the diagnostic.

## 5. Process report

**`slang-diagnostics.lua` — new diagnostic 52013.** Added in the 5xxxx target-code-generation block alongside the existing "not supported on this target" diagnostics (e.g. `interface-typed-entry-point-param-not-supported`). It is a location-free `err()` (no `span`): the referencing instruction's `sourceLoc` is generally invalid for legalized global-scope insts, and a `span { loc, message }` diagnostic only renders its detailed `message` when it has a valid location — so the full, actionable text lives in the always-shown summary instead. Verified empirically that with a `span`+invalid-loc form only the brief summary printed, whereas the location-free form prints the full guidance.

**`slang-emit-vm.cpp` — `findReferencedGlobalParam` in `ensureInst`.** The `multibreak` case (`printf("%f\n", gScale)`) was confirmed by instrumentation to reach `ensureInst`'s `else` branch with op `load` — a *global-scope* `IRLoad` whose pointer is the parameter. The input shape here is correct and principled: the front end legitimately lowers a `uniform` read to a load, and that load is a real global-scope value the emitter is asked to materialize. The fix does not paper over a malformed shape; it recognizes a value the interpreter cannot represent and diagnoses it. The walk is restricted to global-scope operands (`as<IRModuleInst>(inst->getParent())`) so function-scope operands stay on `ensureInst`'s normal paths.

**`slang-emit-vm.cpp` — `diagnoseGlobalParamReferences` pre-scan in `emitFunction`.** Instrumentation showed the `RWStructuredBuffer` access reaches the `emitInst` `default` and aborts via `SLANG_UNIMPLEMENTED_X` *before* `ensureInst` is called on the parameter operand. Rather than special-casing each resource-access opcode in `emitInst` (chasing symptoms), the function is scanned for any instruction whose direct operand is an `IRGlobalParam` before emission begins, and emission is skipped for that function. This is the principled layer: the cause is the parameter reference, diagnosed once at the point of reference regardless of which downstream consumer would have aborted. The revert drill confirms it is necessary, not dead code — disabling it regresses the `RWStructuredBuffer` test to E99997.

**`slang-emit-vm.cpp` — single diagnostic helper + dedup.** Both detection points call `diagnoseGlobalParam`, the one place that maps a parameter to error 52013, guarded by a `HashSet<IRGlobalParam*>` so a parameter referenced many times is reported once. One source of truth for the message; no second representation.

**`slang-emit-vm.cpp` — `SLANG_FAIL` in `emitVMByteCodeForEntryPoints`.** Reporting a diagnostic alone would still return `SLANG_OK` with incomplete byte code. The entry point now compares the sink's error count before and after emission and returns `SLANG_FAIL` if it grew, so the failure propagates and the bad byte code is never used. This mirrors how diagnose-then-fail flows elsewhere (e.g. the existing `getErrorCount` checks).

**Testing.** New `tests/byte-code/global-param-diagnostic.slang` (`INTERPRET`, filecheck) asserts E52013 and the guidance text. All 6 `tests/byte-code` tests pass (5 pre-existing + the new one) and the lambda `INTERPRET` tests pass, confirming no regression to normal interpreter programs. Formatted with `./extras/formatting.sh`.