### PR TITLE
Avoid shell execution in benchmark compile script

### DIFF
--- a/tools/benchmark/compile.py
+++ b/tools/benchmark/compile.py
@@ -74,9 +74,9 @@ def run(command, key):
     profile = {}
     for i in range(samples):
         try:
-            results = subprocess.check_output(command, stderr=subprocess.STDOUT, shell=True).decode('utf-8')
+            results = subprocess.check_output(command, stderr=subprocess.STDOUT).decode('utf-8')
         except subprocess.CalledProcessError as exc:
-            print(f"[Error] Failed to run command: {command}")
+            print(f"[Error] Failed to run command: {subprocess.list2cmdline(command)}")
             print(exc.output.decode('utf-8'))
             return  # Return without adding to timings
 
@@ -97,24 +97,24 @@ def run(command, key):
         print(f"[Warning] No timing data collected for {key}")
 
 def compile_cmd(file, output, stage=None, entry=None, emit=False):
-    cmd = f'{slangc} -report-perf-benchmark {file}'
+    cmd = [slangc, '-report-perf-benchmark', file]
 
     if stage:
-        cmd += f' -stage {stage}'
+        cmd += ['-stage', stage]
         if entry:
-            cmd += f' -entry {entry}'
+            cmd += ['-entry', entry]
         else:
-            cmd += f' -entry {stage}'
+            cmd += ['-entry', stage]
 
     if emit:
-        cmd += f' -target {target_ext}'
+        cmd += ['-target', target_ext]
         output += '.' + target_ext
         if target == 'dxil-embedded':
-            cmd += ' -profile lib_6_6'
+            cmd += ['-profile', 'lib_6_6']
     elif embed:
-        cmd += ' -embed-dxil'
+        cmd += ['-embed-dxil']
 
-    cmd += f' -o {output}'
+    cmd += ['-o', output]
 
     return cmd
 


### PR DESCRIPTION
## Motivation

The benchmark helper compiles every local `*.slang` file it finds under `tools/benchmark`.
Before this change, `compile_cmd()` formatted the filename and options into one command string,
and `run()` passed that string to `subprocess.check_output(..., shell=True)`.

Consider a local benchmark file named `example; touch injected #.slang`. The filename comes from
`glob.glob('*.slang')`, but once it is interpolated into a shell command the semicolon is command
syntax instead of filename data. That lets a crafted local benchmark filename execute unrelated
shell commands when the benchmark script is run.

## Proposed solution

The script now keeps the compiler invocation as an argument list from the start. `compile_cmd()`
returns discrete argv entries for `slangc`, flags, input files, and output paths, and `run()`
passes that list directly to `subprocess.check_output()` without a shell. This preserves the
existing command shape while ensuring filenames and paths are treated as literal process
arguments.

## Change summary

- `tools/benchmark/compile.py:73` updates `run()` to execute the argv list directly and formats
  failures with `subprocess.list2cmdline()` only for display.
- `tools/benchmark/compile.py:99` updates `compile_cmd()` to construct the same `slangc`
  invocation as a list instead of a shell command string.

## Process report

The only unsafe input shape was a local filename being reinterpreted by the shell. The producer is
the benchmark script's `glob.glob('*.slang')` loop, and that shape is valid input: local files can
legitimately contain spaces or shell metacharacters in their names, and the compiler command should
receive them as filenames rather than reject or sanitize them.

The right boundary for the fix is the command construction in `compile_cmd()` and execution in
`run()`. No downstream compiler behavior needs to know about this case. Once the command is an argv
list, Python's subprocess layer passes each element as a literal argument, so a filename such as
`example; touch injected #.slang` remains one input path instead of splitting into shell tokens.
