### PR TITLE
Reject invalid HTTP Content-Length

### DIFF
--- a/source/core/slang-http.cpp
+++ b/source/core/slang-http.cpp
@@ -102,7 +102,10 @@ void HTTPHeader::reset()
         if (key == g_contentLength)
         {
             Index length;
-            SLANG_RETURN_ON_FAIL(StringUtil::parseInt(value, length) || length < 0);
+            if (SLANG_FAILED(StringUtil::parseInt(value, length)) || length < 0)
+            {
+                return SLANG_FAIL;
+            }
 
             out.m_contentLength = length;
         }

--- a/tools/slang-unit-test/unit-test-process.cpp
+++ b/tools/slang-unit-test/unit-test-process.cpp
@@ -127,6 +127,20 @@ static SlangResult _httpCrashTest(UnitTestContext* context)
     return SLANG_OK;
 }
 
+static void _checkHTTPHeaderContentLengthValidation()
+{
+    HTTPHeader header;
+
+    SLANG_CHECK(SLANG_SUCCEEDED(
+        HTTPHeader::parse(UnownedStringSlice("Content-Length: 4\r\n\r\n"), header)));
+    SLANG_CHECK(header.m_contentLength == 4);
+
+    SLANG_CHECK(
+        SLANG_FAILED(HTTPHeader::parse(UnownedStringSlice("Content-Length: -1\r\n\r\n"), header)));
+    SLANG_CHECK(SLANG_FAILED(
+        HTTPHeader::parse(UnownedStringSlice("Content-Length: not-a-number\r\n\r\n"), header)));
+}
+
 #if defined(_WIN32)
 struct ScopedWinHandle
 {
@@ -648,6 +662,11 @@ SLANG_UNIT_TEST(CommandLineProcess)
 #if defined(_WIN32)
     SLANG_CHECK(SLANG_SUCCEEDED(_parentMonitorTest(unitTestContext)));
 #endif
+}
+
+SLANG_UNIT_TEST(HTTPHeaderContentLengthValidation)
+{
+    _checkHTTPHeaderContentLengthValidation();
 }
 
 #if defined(_WIN32)


### PR DESCRIPTION
## Motivation

The LSP transport reads HTTP-style headers before consuming a JSON-RPC payload. A malformed client can send a header such as:

```text
Content-Length: -1
```

Before this change, `HTTPHeader::parse` in `source/core/slang-http.cpp:105` passed a boolean expression to `SLANG_RETURN_ON_FAIL`. `StringUtil::parseInt` can successfully parse `-1`, and the `length < 0` side of the expression then made the expression evaluate to `true`. That boolean value becomes `1`, which is a successful `SlangResult`, so the parser accepted the invalid length. Assigning that negative `Index` to the `size_t` field `HTTPHeader::m_contentLength` in `source/core/slang-http.cpp:110` wrapped it to a very large byte count, causing `HTTPPacketConnection::_handleContent` to wait for content that will never arrive.

The same expression also treated parse failures as success, because a failing `SlangResult` is truthy in the `||` expression and is then collapsed to boolean `true`.

## Proposed solution

Validate the two conditions separately at the parser boundary: first require `StringUtil::parseInt` to succeed, then reject negative lengths before assigning to `m_contentLength`. This keeps the representation invariant simple: once `HTTPHeader::parse` succeeds, `HTTPHeader::m_contentLength` is a non-negative byte count that fits the parser's signed `Index` intermediate.

This is the right layer for the check because HTTP/LSP headers are untrusted stream input. Negative and non-numeric `Content-Length` values are possible input shapes at the protocol boundary, but they are not valid parsed headers.

## Change summary

- `source/core/slang-http.cpp:105` now uses an explicit `SLANG_FAILED(StringUtil::parseInt(...)) || length < 0` check and returns `SLANG_FAIL` before storing the content length.
- `tools/slang-unit-test/unit-test-process.cpp:130` adds focused coverage for valid, negative, and non-numeric `Content-Length` values through `HTTPHeader::parse`.

## Concepts and vocabulary

- `SlangResult`: Slang's integer result code convention. Negative values fail, while `0` and positive values succeed.
- `Index`: Slang's signed size/index type used as the parse intermediate before assigning to the unsigned `HTTPHeader::m_contentLength`.

## Process report

Consider this concrete input from an LSP client:

```text
Content-Length: -1

{}
```

`HTTPHeader::parse` splits the header into key/value pairs, recognizes `Content-Length`, and parses the value through `StringUtil::parseInt`. For `-1`, parsing succeeds and stores `length == -1`. The old code then evaluated `StringUtil::parseInt(value, length) || length < 0`; because the right side was true, the whole expression became boolean `true`, which converted to result code `1`. `SLANG_RETURN_ON_FAIL` only returns for failing result codes, so parsing continued and assigned `-1` into the unsigned `m_contentLength` field.

The fix keeps the same parser flow but stops before that representation change. `HTTPHeader::parse` now treats a failed parse and a negative parsed value as invalid protocol data and returns `SLANG_FAIL`. No downstream consumer needs to know about the malformed spelling: `HTTPPacketConnection::_handleContent` can continue comparing the buffered byte count with `m_contentLength` as a valid size.

The regression test calls `HTTPHeader::parse` directly because the bug is in the header parser contract, not in subprocess I/O. It verifies that `Content-Length: 4` still succeeds, while `Content-Length: -1` and `Content-Length: not-a-number` fail. The non-numeric case is included because the old boolean expression also converted parse failures into a successful positive `SlangResult`.
