### PR TITLE
Rename CI and nightly workflow files

### DIFF
--- a/.github/workflows/check-ir-version.yml
+++ b/.github/workflows/check-ir-version.yml
@@ -1,4 +1,4 @@
-name: Comment IR Version Check Results
+name: Check IR Version
 
 on:
   workflow_run:

--- a/.github/workflows/check-spirv-tools.yml
+++ b/.github/workflows/check-spirv-tools.yml
@@ -1,4 +1,4 @@
-name: Test SPIRV-Tools ToT
+name: Check SPIRV-Tools ToT
 
 # This is a placeholder workflow file.
 # The full implementation will be added in a subsequent PR.

--- a/.github/workflows/ci-materialx-regression-test.yml
+++ b/.github/workflows/ci-materialx-regression-test.yml
@@ -1,4 +1,4 @@
-name: MaterialX Integration Tests
+name: CI MaterialX Regression Test Workflow
 
 on:
   workflow_call:
@@ -20,7 +20,7 @@ on:
         type: string
 
 jobs:
-  materialx-integration:
+  test-materialx-regression:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     timeout-minutes: 15
     defaults:

--- a/.github/workflows/ci-materialx-regression-test.yml
+++ b/.github/workflows/ci-materialx-regression-test.yml
@@ -20,7 +20,7 @@ on:
         type: string
 
 jobs:
-  test-materialx-regression:
+  materialx-integration:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     timeout-minutes: 15
     defaults:

--- a/.github/workflows/ci-mdl-benchmark-test.yml
+++ b/.github/workflows/ci-mdl-benchmark-test.yml
@@ -8,7 +8,7 @@ permissions:
   actions: read
 
 jobs:
-  test-mdl-benchmark:
+  test-benchmark:
     name: Test (Benchmark)
     timeout-minutes: 60
     runs-on: [Windows, self-hosted, benchmark]

--- a/.github/workflows/ci-mdl-benchmark-test.yml
+++ b/.github/workflows/ci-mdl-benchmark-test.yml
@@ -8,7 +8,7 @@ permissions:
   actions: read
 
 jobs:
-  test-benchmark:
+  test-mdl-benchmark:
     name: Test (Benchmark)
     timeout-minutes: 60
     runs-on: [Windows, self-hosted, benchmark]

--- a/.github/workflows/ci-retry-yielded-bot.yml
+++ b/.github/workflows/ci-retry-yielded-bot.yml
@@ -1,4 +1,4 @@
-name: Retry Yielded Bot CI
+name: CI Retry Yielded Bot
 
 on:
   workflow_run:
@@ -14,7 +14,7 @@ on:
     - cron: "17 * * * *"
 
 concurrency:
-  group: retry-yielded-bot-ci
+  group: ci-retry-yielded-bot
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/ci-slang-coverage-test.yml
+++ b/.github/workflows/ci-slang-coverage-test.yml
@@ -1,4 +1,4 @@
-name: CI Coverage Workflow
+name: CI Slang Coverage Test Workflow
 
 on:
   workflow_call:
@@ -276,7 +276,7 @@ jobs:
           # docs/generated/tests/ into the merged coverage report.
           # run-coverage.sh passes -expected-failure-list pointing at
           # docs/generated/tests/_meta/expected-failures.txt, so the
-          # agentic pass uses the same gate as ci-agentic-tests-nightly
+          # agentic pass uses the same gate as nightly-slang-test.yml
           # (only unexpected failures surface, and they're tolerated
           # here so coverage data is collected either way).
           # Retry once on failure to handle intermittent test failures.
@@ -493,7 +493,7 @@ jobs:
         run: |
           # OpenCppCoverage has already produced the Cobertura XML via
           # run-coverage-windows.ps1. Parse it for the JSON summary used by
-          # coverage-nightly.yml's merge step. Only line-level metrics are
+          # nightly-slang-coverage-test.yml's merge step. Only line-level metrics are
           # available from Cobertura (no region/function/branch -- those are
           # llvm-cov-only), so those fields are omitted on Windows.
           $covDir = "build\coverage-data"

--- a/.github/workflows/ci-slang-regression-test.yml
+++ b/.github/workflows/ci-slang-regression-test.yml
@@ -8,7 +8,7 @@ permissions:
   actions: read
 
 jobs:
-  test-slang-regression:
+  test-compile-regression:
     name: Test (Compile Regression)
     timeout-minutes: 60
     runs-on: [Windows, self-hosted, regression-test]

--- a/.github/workflows/ci-slang-regression-test.yml
+++ b/.github/workflows/ci-slang-regression-test.yml
@@ -1,4 +1,4 @@
-name: CI Compile Regression Test Workflow
+name: CI Slang Regression Test Workflow
 
 on:
   workflow_call:
@@ -8,7 +8,7 @@ permissions:
   actions: read
 
 jobs:
-  test-compile-regression:
+  test-slang-regression:
     name: Test (Compile Regression)
     timeout-minutes: 60
     runs-on: [Windows, self-hosted, regression-test]

--- a/.github/workflows/ci-slangpy-trigger-test.yml
+++ b/.github/workflows/ci-slangpy-trigger-test.yml
@@ -1,4 +1,4 @@
-name: Trigger SlangPy CI
+name: CI SlangPy Trigger Test
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
   # gate succeeds immediately and the build jobs (which require this job to
   # succeed) proceed normally. When a throttled bot dispatch must yield to
   # human, merge-queue, or older bot CI, a marker step fails this job so it
-  # consumes no expensive build/test runners; retry-yielded-bot-ci then reruns
+  # consumes no expensive build/test runners; ci-retry-yielded-bot then reruns
   # it once CI is quiet.
   #
   # The job deliberately resolves to success or failure, never 'skipped':
@@ -100,7 +100,7 @@ jobs:
       - name: Stop yielded bot CI
         if: steps.priority.outputs.yielded == 'true'
         run: |
-          echo "::error::priority-gate-yielded: higher-priority CI is active; retry-yielded-bot-ci will rerun this bot CI when quiet"
+          echo "::error::priority-gate-yielded: higher-priority CI is active; ci-retry-yielded-bot will rerun this bot CI when quiet"
           exit 1
 
   # Linux x86_64 builds run in the CI container on the GCP self-hosted build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,7 +462,7 @@ jobs:
       runs-on: '["Windows", "self-hosted", "GCP-T4"]'
 
   # MaterialX integration test (Windows only for initial validation).
-  test-materialx-regression-windows-release:
+  test-materialx-windows-release:
     needs: [filter, build-windows-release-cl-x86_64-gpu]
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-materialx-regression-test.yml
@@ -574,7 +574,7 @@ jobs:
       actions: read
     uses: ./.github/workflows/ci-falcor-test.yml
 
-  test-slang-regression:
+  test-compile-regression:
     needs: [filter, build-windows-release-cl-x86_64-gpu]
     if: needs.filter.outputs.should-run == 'true'
     permissions:
@@ -582,7 +582,7 @@ jobs:
       actions: read
     uses: ./.github/workflows/ci-slang-regression-test.yml
 
-  test-mdl-benchmark:
+  test-benchmark:
     needs: [filter, build-windows-release-cl-x86_64-gpu]
     if: needs.filter.outputs.should-run == 'true'
     permissions:
@@ -626,13 +626,13 @@ jobs:
         test-linux-debug-gcc-x86_64-rhi,
         test-linux-release-gcc-aarch64,
         test-linux-debug-gcc-aarch64,
-        test-materialx-regression-windows-release,
+        test-materialx-windows-release,
         sanitizer-linux-clang-x86_64,
         check-cmdline-ref,
         check-capability-atoms-ref,
         test-falcor,
-        test-slang-regression,
-        test-mdl-benchmark,
+        test-compile-regression,
+        test-benchmark,
         wait-for-human-priority,
       ]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,5 @@
 name: CI
 
-# Reusable workflow files called from CI and nightly aggregators follow this
-# naming shape:
-#   {ci,nightly}-{repo}[-{name}]-{build|test|build-container|test-container}.yml
-# `repo` is the owning/integrated project, such as slang, falcor, rhi, remix,
-# slangpy, mdl, or materialx. `name` is used for a specific suite or purpose,
-# such as perf, vkglcts, sascha, sanitizer, regression, coverage, trigger, or benchmark.
-
 on:
   workflow_dispatch:
   merge_group:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: CI
 
+# Reusable workflow files called from CI and nightly aggregators follow this
+# naming shape:
+#   {ci,nightly}-{repo}[-{name}]-{build|test|build-container|test-container}.yml
+# `repo` is the owning/integrated project, such as slang, falcor, rhi, remix,
+# slangpy, mdl, or materialx. `name` is used for a specific suite or purpose,
+# such as perf, vkglcts, sascha, sanitizer, regression, coverage, trigger, or benchmark.
+
 on:
   workflow_dispatch:
   merge_group:
@@ -461,11 +468,11 @@ jobs:
       config: release
       runs-on: '["Windows", "self-hosted", "GCP-T4"]'
 
-  # MaterialX Integration Tests (Windows only for initial validation)
-  test-materialx-windows-release:
+  # MaterialX integration test (Windows only for initial validation).
+  test-materialx-regression-windows-release:
     needs: [filter, build-windows-release-cl-x86_64-gpu]
     if: needs.filter.outputs.should-run == 'true'
-    uses: ./.github/workflows/materialx-test.yml
+    uses: ./.github/workflows/ci-materialx-regression-test.yml
     with:
       os: windows
       compiler: cl
@@ -574,21 +581,21 @@ jobs:
       actions: read
     uses: ./.github/workflows/ci-falcor-test.yml
 
-  test-compile-regression:
+  test-slang-regression:
     needs: [filter, build-windows-release-cl-x86_64-gpu]
     if: needs.filter.outputs.should-run == 'true'
     permissions:
       contents: read
       actions: read
-    uses: ./.github/workflows/ci-compile-test.yml
+    uses: ./.github/workflows/ci-slang-regression-test.yml
 
-  test-benchmark:
+  test-mdl-benchmark:
     needs: [filter, build-windows-release-cl-x86_64-gpu]
     if: needs.filter.outputs.should-run == 'true'
     permissions:
       contents: read
       actions: read
-    uses: ./.github/workflows/ci-benchmark-test.yml
+    uses: ./.github/workflows/ci-mdl-benchmark-test.yml
 
   # Aggregate gate required by branch protection / the merge queue.
   #
@@ -626,13 +633,13 @@ jobs:
         test-linux-debug-gcc-x86_64-rhi,
         test-linux-release-gcc-aarch64,
         test-linux-debug-gcc-aarch64,
-        test-materialx-windows-release,
+        test-materialx-regression-windows-release,
         sanitizer-linux-clang-x86_64,
         check-cmdline-ref,
         check-capability-atoms-ref,
         test-falcor,
-        test-compile-regression,
-        test-benchmark,
+        test-slang-regression,
+        test-mdl-benchmark,
         wait-for-human-priority,
       ]
     runs-on: ubuntu-latest

--- a/.github/workflows/compile-perf-release-sweep.yml
+++ b/.github/workflows/compile-perf-release-sweep.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: "shader-slang/MDL-SDK"
-          # Pin to the same commit as compile-perf-nightly.yml so release-history
+          # Pin to the same commit as nightly-mdl-perf-test.yml so release-history
           # and daily ToT runs use an identical corpus — a corpus change would
           # otherwise make historical vs daily comparisons invalid.
           ref: "446562493bed1b175e7cf105425ca3596764652f"

--- a/.github/workflows/nightly-mdl-perf-test.yml
+++ b/.github/workflows/nightly-mdl-perf-test.yml
@@ -1,4 +1,4 @@
-name: Compile Perf — Nightly ToT
+name: Nightly MDL Perf Test
 
 # Daily tip-of-tree compile-time sweep. Builds master HEAD on the dedicated
 # benchmark runner, runs the perf suite, stores the day's results in the
@@ -22,7 +22,7 @@ on:
         default: ""
 
 concurrency:
-  group: compile-perf-nightly
+  group: nightly-mdl-perf-test
   cancel-in-progress: false # never cancel a running benchmark — timing must be clean
 
 env:

--- a/.github/workflows/nightly-remix-test.yml
+++ b/.github/workflows/nightly-remix-test.yml
@@ -1,4 +1,4 @@
-name: RTX Remix Shaders (Nightly)
+name: Nightly Remix Test
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly-slang-coverage-test.yml
+++ b/.github/workflows/nightly-slang-coverage-test.yml
@@ -1,4 +1,4 @@
-name: Coverage (Nightly)
+name: Nightly Slang Coverage Test
 
 on:
   workflow_dispatch:
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   coverage-linux:
-    uses: ./.github/workflows/ci-slang-coverage.yml
+    uses: ./.github/workflows/ci-slang-coverage-test.yml
     with:
       os: linux
       compiler: clang-18
@@ -32,7 +32,7 @@ jobs:
     secrets: inherit
 
   coverage-macos:
-    uses: ./.github/workflows/ci-slang-coverage.yml
+    uses: ./.github/workflows/ci-slang-coverage-test.yml
     with:
       os: macos
       compiler: clang
@@ -45,7 +45,7 @@ jobs:
     secrets: inherit
 
   coverage-windows:
-    uses: ./.github/workflows/ci-slang-coverage.yml
+    uses: ./.github/workflows/ci-slang-coverage-test.yml
     with:
       os: windows
       compiler: cl
@@ -153,7 +153,7 @@ jobs:
 
           # Locate the per-OS gzipped LCOV artifacts. The compiler-suffixed
           # artifact names (e.g. coverage-lcov-linux-x86_64-clang-18) are set
-          # by ci-slang-coverage.yml's "Upload LCOV Report" step.
+          # by ci-slang-coverage-test.yml's "Upload LCOV Report" step.
           shopt -s nullglob
           LINUX_GZ=( $ART/coverage-lcov-linux-*/coverage.lcov.gz )
           MACOS_GZ=( $ART/coverage-lcov-macos-*/coverage.lcov.gz )

--- a/.github/workflows/nightly-slang-sanitizer-test.yml
+++ b/.github/workflows/nightly-slang-sanitizer-test.yml
@@ -1,4 +1,4 @@
-name: Nightly Sanitizer
+name: Nightly Slang Sanitizer Test
 
 on:
   schedule:

--- a/.github/workflows/nightly-slang-sascha-test.yml
+++ b/.github/workflows/nightly-slang-sascha-test.yml
@@ -1,4 +1,4 @@
-name: Sascha Willems Vulkan Shaders (Nightly)
+name: Nightly Slang Sascha Test
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly-slang-test.yml
+++ b/.github/workflows/nightly-slang-test.yml
@@ -1,4 +1,4 @@
-name: Agentic Tests (Nightly)
+name: Nightly Slang Agentic Test
 
 # Runs the LLM-generated, doc-anchored test bundles under
 # docs/generated/tests/ via `slang-test -test-dir docs/generated/tests`.
@@ -16,7 +16,7 @@ name: Agentic Tests (Nightly)
 on:
   workflow_dispatch:
   schedule:
-    # Run nightly at 4:00 AM UTC, after coverage-nightly's 02:00 slot
+    # Run nightly at 4:00 AM UTC, after nightly-slang-coverage-test's 02:00 slot
     # (which has a 240-min timeout) so they don't fight for the same
     # Linux runner pool. Matches the schedule documented in
     # docs/generated/tests/_meta/regenerate.md § CI integration.

--- a/.github/workflows/nightly-slang-test.yml
+++ b/.github/workflows/nightly-slang-test.yml
@@ -1,4 +1,4 @@
-name: Nightly Slang Agentic Test
+name: Nightly Slang Test
 
 # Runs the LLM-generated, doc-anchored test bundles under
 # docs/generated/tests/ via `slang-test -test-dir docs/generated/tests`.

--- a/.github/workflows/nightly-slang-vkglcts-test.yml
+++ b/.github/workflows/nightly-slang-vkglcts-test.yml
@@ -1,4 +1,4 @@
-name: VK-GL-CTS Nightly
+name: Nightly Slang VKGLCTS Test
 
 on:
   workflow_dispatch:

--- a/.github/workflows/regenerate-format.yml
+++ b/.github/workflows/regenerate-format.yml
@@ -1,4 +1,4 @@
-name: Format
+name: Regenerate Format
 on:
   repository_dispatch:
     types: [format-command]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Slang
 =====
 ![CI Status](https://github.com/shader-slang/slang/actions/workflows/ci.yml/badge.svg?branch=master)
-![CTS Status](https://github.com/shader-slang/slang/actions/workflows/vk-gl-cts-nightly.yml/badge.svg)
+![CTS Status](https://github.com/shader-slang/slang/actions/workflows/nightly-slang-vkglcts-test.yml/badge.svg)
 
 Slang is a shading language that makes it easier to build and maintain large shader codebases in a modular and extensible fashion, while also maintaining the highest possible performance on modern GPUs and graphics APIs.
 Slang is based on years of collaboration between researchers at NVIDIA, Carnegie Mellon University, Stanford, MIT, UCSD and the University of Washington.

--- a/docker/linux-clang-ci.Dockerfile
+++ b/docker/linux-clang-ci.Dockerfile
@@ -5,7 +5,7 @@
 #
 # Used by:
 # - .github/workflows/ci-slang-sanitizer.yml
-# - .github/workflows/ci-slang-coverage-test.yml  (future)
+# - .github/workflows/ci-slang-coverage.yml  (future)
 #
 # Build and push:
 #   docker build -f docker/linux-clang-ci.Dockerfile -t ghcr.io/shader-slang/slang-linux-clang-ci:v1.0.1 .

--- a/docker/linux-clang-ci.Dockerfile
+++ b/docker/linux-clang-ci.Dockerfile
@@ -5,7 +5,7 @@
 #
 # Used by:
 # - .github/workflows/ci-slang-sanitizer.yml
-# - .github/workflows/ci-slang-coverage.yml  (future)
+# - .github/workflows/ci-slang-coverage-test.yml  (future)
 #
 # Build and push:
 #   docker build -f docker/linux-clang-ci.Dockerfile -t ghcr.io/shader-slang/slang-linux-clang-ci:v1.0.1 .

--- a/docs/generated/tests/_meta/agentic-coverage-excludes.txt
+++ b/docs/generated/tests/_meta/agentic-coverage-excludes.txt
@@ -7,7 +7,7 @@
 # the tail of the suite down with it, so we exclude those tests up
 # front to keep the rest of the suite running and producing coverage.
 #
-# This file is NOT consulted by ci-agentic-tests-nightly.yml — those
+# This file is NOT consulted by nightly-slang-test.yml — those
 # tests still run in the nightly against the uninstrumented binary,
 # where they bucket as `failed(expected)` via expected-failures.txt
 # where appropriate. The exclude is purely a coverage-stability hack.
@@ -38,7 +38,7 @@
 #      entry removed).
 #   3. If the run completes without a SIGSEGV in slang-test, the
 #      underlying crash has been fixed — drop the entry for real.
-# A green ci-agentic-tests-nightly run on the same test is a
+# A green nightly-slang-test.yml run on the same test is a
 # necessary but NOT sufficient condition: the nightly uses an
 # uninstrumented binary, and the crash here is
 # coverage-instrumentation-specific.

--- a/docs/generated/tests/_meta/regenerate.md
+++ b/docs/generated/tests/_meta/regenerate.md
@@ -104,7 +104,7 @@ files as additional context):
 ## Phase B2 — Slang-test wiring
 
 Landed via
-`.github/workflows/ci-agentic-tests-nightly.yml`. The nightly job
+`.github/workflows/nightly-slang-test.yml`. The nightly job
 invokes `regenerate.py verify`, which wraps `slang-test` with
 `-test-dir docs/generated/tests` and applies the suite-level
 expected-failures list + `requires-tool` filtering. The nightly is
@@ -185,8 +185,8 @@ Then `regenerate.py mark-fresh <bundle>`.
 
 The intended attachment points:
 
-- **Nightly run.** `ci-agentic-tests-nightly.yml`, scheduled
-  `0 4 * * *` (after `coverage-nightly`'s `02:00` slot), runs
+- **Nightly run.** `nightly-slang-test.yml`, scheduled
+  `0 4 * * *` (after `nightly-slang-coverage-test.yml`'s `02:00` slot), runs
   `regenerate.py verify` which wraps
   `slang-test -test-dir docs/generated/tests`. Advisory only; never
   blocks PRs.

--- a/extras/check-inst-version-changes.sh
+++ b/extras/check-inst-version-changes.sh
@@ -19,7 +19,7 @@ fi
 
 # Note: this script makes no GitHub API calls — it only inspects the diff with
 # `git` and writes an artifact (pr-number.txt + comment-body.txt) for the
-# privileged `comment-ir-version-check.yml` workflow_run job to consume and post
+# privileged `check-ir-version.yml` workflow_run job to consume and post
 # (via SLANGBOT_PAT). It therefore must not require `gh` or an authenticated
 # token. Requiring `gh auth status` here used to hard-fail on fork PRs, which
 # only get a restricted GITHUB_TOKEN with no `gh` auth — exactly the PRs this

--- a/extras/repro-remix.md
+++ b/extras/repro-remix.md
@@ -1,6 +1,6 @@
 # RTX Remix Shader Compilation Reproduction Script
 
-This script (`repro-remix.sh`) helps reproduce issues from the [RTX Remix nightly workflow](../.github/workflows/compile-rtx-remix-shaders-nightly.yml) locally.
+This script (`repro-remix.sh`) helps reproduce issues from the [RTX Remix nightly workflow](../.github/workflows/nightly-remix-test.yml) locally.
 
 ## Purpose
 
@@ -257,7 +257,7 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
 ## Related Documentation
 
-- [Main workflow file](../.github/workflows/compile-rtx-remix-shaders-nightly.yml)
+- [Main workflow file](../.github/workflows/nightly-remix-test.yml)
 - [Building Slang](../docs/building.md)
 - [SPIRV debugging guide](../CLAUDE.md#slangc-with--target-spirv-asm)
 - [dxvk-remix repository](https://github.com/NVIDIAGameWorks/dxvk-remix)

--- a/extras/repro-remix.sh
+++ b/extras/repro-remix.sh
@@ -2,7 +2,7 @@
 #
 # repro-remix.sh - Reproduce RTX Remix shader compilation workflow
 #
-# This script replicates the steps from .github/workflows/compile-rtx-remix-shaders-nightly.yml
+# This script replicates the steps from .github/workflows/nightly-remix-test.yml
 # to help debug issues when the nightly workflow fails.
 #
 # Prerequisites: Slang must already be built in Debug configuration at build/Debug/bin/

--- a/tests/expected-failure-coverage.txt
+++ b/tests/expected-failure-coverage.txt
@@ -8,7 +8,7 @@
 # any classification step.
 #
 # Crash-mode skips therefore live elsewhere: as workflow-level filters in
-# `.github/workflows/ci-slang-coverage.yml`. As of writing:
+# `.github/workflows/ci-slang-coverage-test.yml`. As of writing:
 #   - slang-unit-test-tool/RecordReplayApiTypeOperations  (Windows / OCC)
 #   - tests/autodiff/global-param-hoisting                (Windows / OCC,
 #                                                          intermittent crash)

--- a/tools/compile-perf/DESIGN.md
+++ b/tools/compile-perf/DESIGN.md
@@ -36,7 +36,7 @@ timing trustworthy. They store results in a separate repo,
 `shader-slang/slang-compile-perf`, authenticated with the `SLANG_COMPILE_PERF_PAT`
 secret (the `PERF_RESULTS_REPO` env overrides the target).
 
-- **`compile-perf-nightly.yml`** — builds tip-of-tree, sweeps into
+- **`nightly-mdl-perf-test.yml`** — builds tip-of-tree, sweeps into
   `daily/<date>-<sha>/`, runs `track.py register` (stamp + rebuild the tracking
   series), pushes the results repo, then runs `trend.py`. **Manual
   `workflow_dispatch` only right now — the daily `schedule` is commented out;**

--- a/tools/coverage/README.md
+++ b/tools/coverage/README.md
@@ -20,7 +20,7 @@ Slang-specific:
 
 - **Linux / macOS**: LLVM coverage tools (`llvm-profdata`, `llvm-cov`) installed
 - **Windows**:
-  - [OpenCppCoverage](https://github.com/OpenCppCoverage/OpenCppCoverage/releases) (the `ci-slang-coverage.yml` workflow installs it via `choco install opencppcoverage --version 0.9.9.0`; for local dev either install the `.exe` from GitHub releases or `winget install --id OpenCppCoverage.OpenCppCoverage`).
+  - [OpenCppCoverage](https://github.com/OpenCppCoverage/OpenCppCoverage/releases) (the `ci-slang-coverage-test.yml` workflow installs it via `choco install opencppcoverage --version 0.9.9.0`; for local dev either install the `.exe` from GitHub releases or `winget install --id OpenCppCoverage.OpenCppCoverage`).
   - [ReportGenerator](https://github.com/danielpalme/ReportGenerator) for HTML rendering. Install via `dotnet tool install -g dotnet-reportgenerator-globaltool` and make sure `$env:USERPROFILE\.dotnet\tools` is on `PATH`. Requires a .NET SDK; the workflow uses the SDK preinstalled on `windows-latest`.
 
 ## Quick Start (HTML report)

--- a/tools/coverage/run-coverage-local.ps1
+++ b/tools/coverage/run-coverage-local.ps1
@@ -73,7 +73,7 @@ if (-not $SkipTest) {
         '-skip-reference-image-generation'
         '-show-adapter-info'
         '-enable-debug-layers', 'true'
-        # Match ci-slang-coverage.yml: RecordReplayApiTypeOperations.internal
+        # Match ci-slang-coverage-test.yml: RecordReplayApiTypeOperations.internal
         # crashes with EXCEPTION_ILLEGAL_INSTRUCTION under OpenCppCoverage and
         # leaves a dead child that slang-test waits on. Without this exclusion
         # a local run can hang indefinitely with no visible error.

--- a/tools/coverage/run-coverage.sh
+++ b/tools/coverage/run-coverage.sh
@@ -136,7 +136,7 @@ else
   # same merged profdata as the main pass.
   #
   # Failures are tolerated — the suite is still being de-bugged (see
-  # docs/generated/tests/_meta/findings/) and ci-agentic-tests-nightly.yml
+  # docs/generated/tests/_meta/findings/) and nightly-slang-test.yml
   # is the authoritative pass/fail gate. We're here for the coverage
   # numbers, not the verdict.
   if [[ "$WITH_AGENTIC_TESTS" == "true" ]]; then
@@ -229,7 +229,7 @@ else
     # one -exclude-prefix flag per entry. These are tests that crash
     # slang-test under coverage instrumentation (the orchestrator dies
     # SIGSEGV and loses the tail of the suite); they still run in
-    # ci-agentic-tests-nightly against the uninstrumented binary.
+    # nightly-slang-test.yml against the uninstrumented binary.
     AGENTIC_COVERAGE_EXCLUDES_FILE="$REPO_ROOT/docs/generated/tests/_meta/agentic-coverage-excludes.txt"
     if [ -f "$AGENTIC_COVERAGE_EXCLUDES_FILE" ]; then
       while IFS= read -r line || [ -n "$line" ]; do
@@ -273,7 +273,7 @@ else
     if [ "$AGENTIC_EXIT" -gt 128 ]; then
       echo "Warning: agentic-test pass crashed on all $AGENTIC_MAX_ATTEMPTS attempts (signal $((AGENTIC_EXIT - 128))). Partial coverage data still collected."
     elif [ "$AGENTIC_EXIT" -ne 0 ]; then
-      echo "Note: agentic-test pass had unexpected test failures (exit code $AGENTIC_EXIT). Coverage data still collected; see ci-agentic-tests-nightly.yml for the authoritative pass/fail gate."
+      echo "Note: agentic-test pass had unexpected test failures (exit code $AGENTIC_EXIT). Coverage data still collected; see nightly-slang-test.yml for the authoritative pass/fail gate."
     fi
   fi
 

--- a/tools/coverage/slangc-ignore-patterns.sh
+++ b/tools/coverage/slangc-ignore-patterns.sh
@@ -7,7 +7,7 @@
 #   - Record-replay instrumentation
 #   - Language server, documentation generator, unmaintained debug features
 #
-# Shared by run-coverage.sh and ci-slang-coverage.yml to keep the filter
+# Shared by run-coverage.sh and ci-slang-coverage-test.yml to keep the filter
 # definition in a single place.
 
 SLANGC_IGNORE_ARGS=(


### PR DESCRIPTION
## Motivation

The GitHub workflow directory had several inconsistent file names that made it harder to distinguish reusable CI components, standalone scheduled nightly jobs, and maintenance/regeneration workflows. For example, nightly jobs used names such as `coverage-nightly.yml`, `ci-agentic-tests-nightly.yml`, and `vk-gl-cts-nightly.yml`, while related reusable CI workflows used a separate naming style.

## Proposed solution

Rename workflow files and update their callers and documentation references while keeping the existing workflow behavior intact. In particular, the nightly jobs remain standalone scheduled workflows rather than being consolidated into a single nightly fanout.

## Change summary

- Rename reusable CI workflow files such as `ci-compile-test.yml`, `ci-benchmark-test.yml`, `ci-slang-coverage.yml`, and `ci-trigger-slangpy.yml`, and update the `ci.yml` callers.
- Rename standalone scheduled nightly workflows such as `ci-agentic-tests-nightly.yml`, `coverage-nightly.yml`, `vk-gl-cts-nightly.yml`, `compile-perf-nightly.yml`, the RTX Remix workflow, and the Sascha Willems shader workflow.
- Rename maintenance workflows for IR version comments, SPIR-V Tools checks, and formatting regeneration.
- Update references in README and related workflow/tooling documentation so badges and local reproduction notes point at the new workflow filenames.

## Process report

This change is intentionally limited to workflow file organization. The scheduled nightly workflows continue to own their own `schedule` and `workflow_dispatch` triggers, and reusable CI workflows still live directly under `.github/workflows` so GitHub Actions can call them with `workflow_call`.

The MaterialX workflow remains part of `ci.yml`: the caller now points to `ci-materialx-regression-test.yml`, reflecting that MaterialX is the external integration surface and the workflow is a regression test rather than an MDL test.

The CI caller job IDs and reusable workflow job IDs that can feed required status checks are intentionally kept at their previous names. For example, `ci.yml` still exposes `test-materialx-windows-release`, `test-compile-regression`, and `test-benchmark`; this keeps branch-protection status identities stable while only the workflow filenames change.

The former agentic nightly is intentionally named `nightly-slang-test.yml` with the display name `Nightly Slang Test`. Under the selected workflow naming pattern, this is the default Slang nightly test workflow rather than a separate named suite; the `agentic-tests` job name and workflow comments keep the generated-test implementation detail visible.

The compile-perf workflow remains a standalone nightly publisher under `nightly-mdl-perf-test.yml`; the separate release sweep workflow is left outside the nightly rename set because it has a different cache/history-population purpose.

The `docker/linux-clang-ci.Dockerfile` comment that mentions the future coverage workflow is intentionally left unchanged. This repository treats any Dockerfile edit as a container image input change and requires an image tag bump, which would be unrelated to this workflow-file rename PR.
