### PR TITLE
CUDA: pass runtime-indexed resource-array entry-point uniforms by reference

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -983,7 +983,7 @@ Result linkAndOptimizeIR(
     if (!isKhronosTarget(targetRequest) && requiredLoweringPassSet.glslSSBO)
         SLANG_PASS(lowerGLSLShaderStorageBufferObjectsToStructuredBuffers, sink);
 
-    SLANG_PASS(translateEntryPointInParamToBorrow, sink);
+    SLANG_PASS(translateEntryPointInParamToBorrow, sink, isCUDATarget(targetRequest));
 
     // Replace any global constants with their values.
     //

--- a/source/slang/slang-ir-transform-params-to-constref.cpp
+++ b/source/slang/slang-ir-transform-params-to-constref.cpp
@@ -428,32 +428,25 @@ SlangResult transformParamsToConstRef(IRModule* module, DiagnosticSink* sink)
     return context.processModule();
 }
 
-// Returns true if `param` is a fixed-size array of resources that is indexed by a runtime
-// (non-literal) value. On a CUDA target such a uniform entry-point parameter is passed by value in
-// the `.param` kernel-argument space, which ptxas cannot dynamically index, so a runtime index
-// (`arr[indices[tid]]`) lowers to a serial `ld.param` chain. Passing the parameter by reference
-// makes `arr[i]` an ordinary dynamically-addressable load. The runtime-index check avoids
-// transforming statically-indexed arrays (e.g. `arr[0]`), which do not suffer the slowdown.
-static bool isRuntimeIndexedResourceArrayParam(IRParam* param)
+// Returns true if `type` is a fixed-size array (not an unsized array) whose elements are, or
+// transitively contain, resources. `isResourceType` unwraps the array and recognizes the resource
+// family. On a CUDA target such a uniform entry-point parameter is otherwise passed by value in the
+// `.param` kernel-argument space, which ptxas cannot dynamically index, so a runtime index
+// (`arr[indices[tid]]`) lowers to a serial `ld.param` chain; passing it by reference makes the
+// index an ordinary dynamically-addressable load.
+//
+// This is intentionally a *type-only* check, not an access-pattern (runtime-vs-static index)
+// analysis. The same decision must be made at two stages that see different information: emit (this
+// pass, which has the function body) and parameter binding / reflection (which lays out the ABI and
+// has no body to inspect). Keying both off the type keeps the reflected layout and the emitted
+// kernel signature in sync. A statically-indexed array therefore also goes by reference — correct,
+// just not a perf win.
+static bool isFixedSizeResourceArrayType(IRType* type)
 {
-    // Fixed-size array only (`IRArrayType`, not `IRUnsizedArrayType`); `isResourceType` unwraps the
-    // array(s) and confirms the element bottoms out in a resource.
-    auto arrayType = as<IRArrayType>(param->getDataType());
+    auto arrayType = as<IRArrayType>(type);
     if (!arrayType)
         return false;
-    if (!isResourceType(arrayType))
-        return false;
-
-    // Require at least one runtime (non-literal) index into the array.
-    for (auto use = param->firstUse; use; use = use->nextUse)
-    {
-        auto getElement = as<IRGetElement>(use->getUser());
-        if (!getElement)
-            continue;
-        if (getElement->getIndex() && !as<IRIntLit>(getElement->getIndex()))
-            return true;
-    }
-    return false;
+    return isResourceType(arrayType);
 }
 
 struct EntryPointInParamToBorrowContext : public TransformParamsToConstRefContext
@@ -506,10 +499,10 @@ struct EntryPointInParamToBorrowContext : public TransformParamsToConstRefContex
         if (!isVaryingParameter(paramLayout))
         {
             // Entry-point uniforms are normally left by value. The one exception is a CUDA
-            // runtime-indexed fixed-size resource array, which must be passed by reference to avoid
-            // the serial `.param` `ld.param` chain (see `isRuntimeIndexedResourceArrayParam`).
+            // fixed-size resource array, which must be passed by reference to avoid the serial
+            // `.param` `ld.param` chain (see `isFixedSizeResourceArrayType`).
             return m_transformCudaResourceArrayUniforms &&
-                   isRuntimeIndexedResourceArrayParam(param);
+                   isFixedSizeResourceArrayType(param->getDataType());
         }
 
         // If we reach here, we are dealing with a varying in parameter.

--- a/source/slang/slang-ir-transform-params-to-constref.cpp
+++ b/source/slang/slang-ir-transform-params-to-constref.cpp
@@ -428,10 +428,46 @@ SlangResult transformParamsToConstRef(IRModule* module, DiagnosticSink* sink)
     return context.processModule();
 }
 
+// Returns true if `param` is a fixed-size array of resources that is indexed by a runtime
+// (non-literal) value. On a CUDA target such a uniform entry-point parameter is passed by value in
+// the `.param` kernel-argument space, which ptxas cannot dynamically index, so a runtime index
+// (`arr[indices[tid]]`) lowers to a serial `ld.param` chain. Passing the parameter by reference
+// makes `arr[i]` an ordinary dynamically-addressable load. The runtime-index check avoids
+// transforming statically-indexed arrays (e.g. `arr[0]`), which do not suffer the slowdown.
+static bool isRuntimeIndexedResourceArrayParam(IRParam* param)
+{
+    // Fixed-size array only (`IRArrayType`, not `IRUnsizedArrayType`); `isResourceType` unwraps the
+    // array(s) and confirms the element bottoms out in a resource.
+    auto arrayType = as<IRArrayType>(param->getDataType());
+    if (!arrayType)
+        return false;
+    if (!isResourceType(arrayType))
+        return false;
+
+    // Require at least one runtime (non-literal) index into the array.
+    for (auto use = param->firstUse; use; use = use->nextUse)
+    {
+        auto getElement = as<IRGetElement>(use->getUser());
+        if (!getElement)
+            continue;
+        if (getElement->getIndex() && !as<IRIntLit>(getElement->getIndex()))
+            return true;
+    }
+    return false;
+}
+
 struct EntryPointInParamToBorrowContext : public TransformParamsToConstRefContext
 {
-    EntryPointInParamToBorrowContext(IRModule* module, DiagnosticSink* sink)
+    // When true (CUDA targets), a runtime-indexed fixed-size resource-array uniform is also
+    // rewritten to `borrow in`; see `isRuntimeIndexedResourceArrayParam`.
+    bool m_transformCudaResourceArrayUniforms = false;
+
+    EntryPointInParamToBorrowContext(
+        IRModule* module,
+        DiagnosticSink* sink,
+        bool transformCudaResourceArrayUniforms)
         : TransformParamsToConstRefContext(module, sink)
+        , m_transformCudaResourceArrayUniforms(transformCudaResourceArrayUniforms)
     {
     }
     virtual bool shouldProcessFunction(IRFunc* func) override
@@ -468,7 +504,13 @@ struct EntryPointInParamToBorrowContext : public TransformParamsToConstRefContex
         if (!paramLayout)
             return false;
         if (!isVaryingParameter(paramLayout))
-            return false;
+        {
+            // Entry-point uniforms are normally left by value. The one exception is a CUDA
+            // runtime-indexed fixed-size resource array, which must be passed by reference to avoid
+            // the serial `.param` `ld.param` chain (see `isRuntimeIndexedResourceArrayParam`).
+            return m_transformCudaResourceArrayUniforms &&
+                   isRuntimeIndexedResourceArrayParam(param);
+        }
 
         // If we reach here, we are dealing with a varying in parameter.
         // We need to rewrite it to be a `borrow in` parameter.
@@ -476,9 +518,12 @@ struct EntryPointInParamToBorrowContext : public TransformParamsToConstRefContex
     }
 };
 
-SlangResult translateEntryPointInParamToBorrow(IRModule* module, DiagnosticSink* sink)
+SlangResult translateEntryPointInParamToBorrow(
+    IRModule* module,
+    DiagnosticSink* sink,
+    bool transformCudaResourceArrayUniforms)
 {
-    EntryPointInParamToBorrowContext context(module, sink);
+    EntryPointInParamToBorrowContext context(module, sink, transformCudaResourceArrayUniforms);
     return context.processModule();
 }
 

--- a/source/slang/slang-ir-transform-params-to-constref.h
+++ b/source/slang/slang-ir-transform-params-to-constref.h
@@ -9,6 +9,17 @@ class DiagnosticSink;
 
 SlangResult transformParamsToConstRef(IRModule* module, DiagnosticSink* sink);
 
-SlangResult translateEntryPointInParamToBorrow(IRModule* module, DiagnosticSink* sink);
+/// Rewrite an entry point's varying `in` parameters to `borrow in` (pointer-backed) parameters.
+///
+/// When `transformCudaResourceArrayUniforms` is true (CUDA targets), this also rewrites a
+/// *uniform* parameter that is a runtime-indexed fixed-size array of resources to `borrow in`.
+/// Such a uniform is otherwise passed by value in the un-indexable CUDA `.param` space, so a
+/// runtime index (`arr[indices[tid]]`) lowers to a serial `ld.param` chain; passing it by
+/// reference makes the index an ordinary dynamically-addressable load. Other entry-point uniforms
+/// are left by value.
+SlangResult translateEntryPointInParamToBorrow(
+    IRModule* module,
+    DiagnosticSink* sink,
+    bool transformCudaResourceArrayUniforms);
 
 } // namespace Slang

--- a/source/slang/slang-ir-transform-params-to-constref.h
+++ b/source/slang/slang-ir-transform-params-to-constref.h
@@ -12,11 +12,13 @@ SlangResult transformParamsToConstRef(IRModule* module, DiagnosticSink* sink);
 /// Rewrite an entry point's varying `in` parameters to `borrow in` (pointer-backed) parameters.
 ///
 /// When `transformCudaResourceArrayUniforms` is true (CUDA targets), this also rewrites a
-/// *uniform* parameter that is a runtime-indexed fixed-size array of resources to `borrow in`.
-/// Such a uniform is otherwise passed by value in the un-indexable CUDA `.param` space, so a
-/// runtime index (`arr[indices[tid]]`) lowers to a serial `ld.param` chain; passing it by
-/// reference makes the index an ordinary dynamically-addressable load. Other entry-point uniforms
-/// are left by value.
+/// *uniform* parameter that is a fixed-size array of resources to `borrow in`. Such a uniform is
+/// otherwise passed by value in the un-indexable CUDA `.param` space, so a runtime index
+/// (`arr[indices[tid]]`) lowers to a serial `ld.param` chain; passing it by reference makes the
+/// index an ordinary dynamically-addressable load. The predicate is type-only (see
+/// `isFixedSizeResourceArrayType`) so the same decision can be made at parameter binding /
+/// reflection, keeping the reflected ABI in sync with the emitted kernel. Other entry-point
+/// uniforms are left by value.
 SlangResult translateEntryPointInParamToBorrow(
     IRModule* module,
     DiagnosticSink* sink,

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -2648,6 +2648,31 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
     return processParamOfType(_Move(processParamOfType), type);
 }
 
+/// Returns true if `type` is a fixed-size array whose (possibly nested) leaf element is a resource.
+///
+/// This mirrors the IR-side predicate `isFixedSizeResourceArrayType`
+/// (slang-ir-transform-params-to-constref.cpp): the decision to pass such a CUDA entry-point
+/// uniform by reference must agree at this stage (reflection / parameter binding) and at emit, and
+/// neither stage can see the other's representation, so both key off the same type shape. See that
+/// file for the full rationale (the by-value `.param` serial-`ld.param` slowdown this avoids).
+static bool isFixedSizeResourceArrayTypeAST(Type* type)
+{
+    auto arrayType = as<ArrayExpressionType>(type);
+    if (!arrayType || arrayType->isUnsized())
+        return false;
+    // Unwrap nested fixed-size arrays to the leaf element (mirrors `isResourceType`'s array
+    // unwrap).
+    Type* elementType = arrayType->getElementType();
+    while (auto innerArray = as<ArrayExpressionType>(elementType))
+    {
+        if (innerArray->isUnsized())
+            return false;
+        elementType = innerArray->getElementType();
+    }
+    return as<ResourceType>(elementType) || as<HLSLStructuredBufferTypeBase>(elementType) ||
+           as<UntypedBufferResourceType>(elementType) || as<SamplerStateType>(elementType);
+}
+
 /// Compute the type layout for a parameter declared directly on an entry point.
 static RefPtr<TypeLayout> computeEntryPointParameterTypeLayout(
     ParameterBindingContext* context,
@@ -2678,7 +2703,25 @@ static RefPtr<TypeLayout> computeEntryPointParameterTypeLayout(
                 context->getTargetRequest()->getOptionSet(),
                 paramType);
         }
-        return createTypeLayoutWith(context->layoutContext, layoutRules, paramType);
+        auto arrayLayout = createTypeLayoutWith(context->layoutContext, layoutRules, paramType);
+
+        // On CUDA a fixed-size resource-array uniform is passed by reference (a pointer) rather
+        // than by value in the un-indexable `.param` kernel-argument space; the matching emit-stage
+        // transform is in slang-ir-transform-params-to-constref.cpp. Reflect it as an 8-byte
+        // pointer (the by-reference ABI) whose pointee is the array layout, so the host binds a
+        // device pointer instead of packing the descriptor array inline.
+        if (isCUDATarget(context->getTargetRequest()) && isFixedSizeResourceArrayTypeAST(paramType))
+        {
+            RefPtr<PointerTypeLayout> ptrLayout = new PointerTypeLayout();
+            const auto info = layoutRules->GetPointerLayout(context->layoutContext);
+            ptrLayout->type = paramType;
+            ptrLayout->rules = layoutRules;
+            ptrLayout->uniformAlignment = info.alignment;
+            ptrLayout->addResourceUsage(info.kind, info.size);
+            ptrLayout->valueTypeLayout = arrayLayout;
+            return ptrLayout;
+        }
+        return arrayLayout;
     }
     else
     {

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -2703,25 +2703,20 @@ static RefPtr<TypeLayout> computeEntryPointParameterTypeLayout(
                 context->getTargetRequest()->getOptionSet(),
                 paramType);
         }
-        auto arrayLayout = createTypeLayoutWith(context->layoutContext, layoutRules, paramType);
-
-        // On CUDA a fixed-size resource-array uniform is passed by reference (a pointer) rather
-        // than by value in the un-indexable `.param` kernel-argument space; the matching emit-stage
-        // transform is in slang-ir-transform-params-to-constref.cpp. Reflect it as an 8-byte
-        // pointer (the by-reference ABI) whose pointee is the array layout, so the host binds a
-        // device pointer instead of packing the descriptor array inline.
+        // On CUDA a fixed-size resource-array uniform is passed by reference (a pointer) rather than
+        // by value in the un-indexable `.param` kernel-argument space; the matching emit-stage
+        // transform is in slang-ir-transform-params-to-constref.cpp. Lay it out as a
+        // `ParameterBlock<array>` sub-object so it reflects as a parameter group the slang-rhi host
+        // already recurses into — allocating a device buffer, writing the descriptors, and packing
+        // an 8-byte device pointer at the uniform offset, which is exactly the by-reference binding.
+        // (A bare pointer layout instead collapses the array's resource binding ranges, leaving the
+        // host with no descriptors to bind.)
         if (isCUDATarget(context->getTargetRequest()) && isFixedSizeResourceArrayTypeAST(paramType))
         {
-            RefPtr<PointerTypeLayout> ptrLayout = new PointerTypeLayout();
-            const auto info = layoutRules->GetPointerLayout(context->layoutContext);
-            ptrLayout->type = paramType;
-            ptrLayout->rules = layoutRules;
-            ptrLayout->uniformAlignment = info.alignment;
-            ptrLayout->addResourceUsage(info.kind, info.size);
-            ptrLayout->valueTypeLayout = arrayLayout;
-            return ptrLayout;
+            auto paramBlockType = context->getASTBuilder()->getParameterBlockType(paramType);
+            return createTypeLayoutWith(context->layoutContext, layoutRules, paramBlockType);
         }
-        return arrayLayout;
+        return createTypeLayoutWith(context->layoutContext, layoutRules, paramType);
     }
     else
     {

--- a/tests/cuda/entrypoint-resource-array-byref.slang
+++ b/tests/cuda/entrypoint-resource-array-byref.slang
@@ -1,0 +1,25 @@
+// Verifies the CUDA by-reference transform for runtime-indexed resource-array entry-point uniforms.
+//
+// Slang passes entry-point parameters by value, so a fixed-size resource array uniform
+// (`RWStructuredBuffer<float> tensors[8]`) becomes a by-value `FixedArray<...>` kernel argument in
+// the CUDA `.param` space. ptxas cannot dynamically index `.param`, so `tensors[indices[tid]]`
+// (a runtime index) lowers to a serial `ld.param` chain. `EntryPointInParamToBorrowContext` now
+// passes such a uniform by reference (a pointer), so the index becomes an ordinary
+// dynamically-addressable load through the pointer.
+
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -line-directive-mode none -stage compute -entry main
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main(
+    uint tid: SV_DispatchThreadID,
+    RWStructuredBuffer<float> tensors[8],
+    StructuredBuffer<uint> indices)
+{
+    tensors[indices[tid]][tid] = 1.0f;
+}
+
+// The runtime-indexed resource array `tensors` is a pointer parameter (by reference), and is
+// indexed through the pointer rather than copied by value into the kernel `.param` bank.
+// CHECK: void main{{.*}}* tensors
+// CHECK: (*tensors{{.*}})[


### PR DESCRIPTION
## Motivation

A CUDA compute entry point with a fixed-size resource-array uniform indexed by a **runtime** value compiles to a serial `ld.param` chain (~10–30× slower than Vulkan/D3D12 for the same kernel):

```slang
[shader("compute")][numthreads(1, 1, 1)]
void main(uint tid: SV_DispatchThreadID, RWStructuredBuffer<float> tensors[8], StructuredBuffer<uint> indices)
{
    tensors[indices[tid]][tid] = 1.0f;   // `tensors` indexed by a RUNTIME value
}
```

Slang passes entry-point parameters by value, so `tensors` becomes a by-value `FixedArray<RWStructuredBuffer<float>, 8>` kernel argument in CUDA `.param` space. ptxas cannot dynamically index `.param`, so `tensors[indices[tid]]` serializes into an O(N) `ld.param` chain. Vulkan/D3D12 never regressed because they keep resource arrays in dynamically-indexable descriptor heaps, not a by-value argument blob.

## Proposed solution

Pass *this* uniform **by reference** — a pointer to a device buffer of N descriptors — so the runtime index becomes an ordinary dynamically-addressable load. Slang's by-value parameter ABI is deliberate, so this is a narrow, CUDA-gated special case, not a general ABI change.

The by-reference decision is made at two stages that cannot see each other's representation — **emit** (has the function body) and **parameter binding / reflection** (lays out the ABI, has no body) — so both key off the same *type-only* predicate, keeping the reflected layout and the emitted kernel signature in sync.

## Change summary

| File | Change |
|------|--------|
| `slang-ir-transform-params-to-constref.{h,cpp}` | CUDA-gated: rewrite a fixed-size resource-array entry-point uniform to `borrow in` (pointer-backed), reusing the existing `IRGetElement(IRLoad(ptr))` → `IRLoad(IRGetElementPtr(ptr))` use-rewrite. Adds the type-only predicate `isFixedSizeResourceArrayType`. |
| `slang-emit.cpp` | Wire `isCUDATarget(...)` into the pass so the transform only runs for CUDA. |
| `slang-parameter-binding.cpp` | Reflect the by-ref uniform as a `ParameterBlock<array>` sub-object (matching AST predicate `isFixedSizeResourceArrayTypeAST`) so the slang-rhi host allocates a device buffer, writes the descriptors, and packs an 8-byte device pointer at the uniform offset. |
| `tests/cuda/entrypoint-resource-array-byref.slang` | FileCheck regression: pointer kernel param + load-through-pointer. |

## Concepts and vocabulary

- **`borrow in` / `IRBorrowInParamType`** — a pointer-backed parameter mode. The existing `transformParamsToConstRef` pass already converts by-value composites to it for ordinary functions and **skips entry points** (the deliberate by-value ABI). This PR carves a CUDA-only exception for the qualifying uniform.
- **`.param` space** — CUDA kernel-argument memory; ptxas cannot dynamically index it, which is the direct cause of the serial chain (the chain is ptxas's consequence, not Slang-emitted).

## Process report

- **Emit transform** (`EntryPointInParamToBorrowContext`): the function-level entry-point skip is correct in general (the by-value ABI is intentional), so the fix is a *per-parameter* exception, not un-skipping the whole function — `processFunc` would otherwise convert the entire ABI. The uniform branch transforms only a param whose type satisfies `isFixedSizeResourceArrayType`.
- **Type-only predicate, not use-analysis:** a statically-indexed array also goes by reference (correct, just not a perf win). This is intentional — the binding/reflection stage has no function body to inspect access patterns, so a use-based gate could not be matched there, and the two stages must agree on the ABI.
- **Input-shape check (reflection layout):** a bare pointer layout (`PointerTypeLayout`, 8 B) was tried first and rejected — it collapses the array's resource binding ranges, so reflection loses the element count and the host has no descriptors to bind. `ParameterBlock<array>` is the principled shape: it preserves the nested binding ranges the host already recurses into to bind a resource array, while still passing a single pointer to the kernel.

## ⚠️ Draft — pairs with a slang-rhi host change

This compiler change alters the **reflected CUDA layout** for a fixed-size resource-array entry-point uniform (now a `ParameterBlock` sub-object). It is functionally complete only together with the matching slang-rhi binding change (size the sub-object element as `array[N]` and write the N contiguous descriptors). **Held as draft until that host PR is up**, so the two land in lockstep and existing CUDA resource-array binding is not regressed.

<sub>🤖 Generated by an automated SlangPy coworker — may be inaccurate. A human maintainer should verify.</sub>
