### PR TITLE
CI: make GCP-vs-GitHub-hosted runner selection switchable via repo variables

### DIFF
--- a/.github/workflows/ci-analytics.yml
+++ b/.github/workflows/ci-analytics.yml
@@ -11,7 +11,13 @@ concurrency:
 
 jobs:
   collect-and-publish:
-    runs-on: ["Linux", "self-hosted", "analytics", "GCP"]
+    # RUNNER SELECTION — switchable via the `ANALYTICS_RUNS_ON` repository
+    # variable, WITHOUT a code change (Settings → Secrets and variables →
+    # Actions → Variables): unset (default) → GitHub-hosted `ubuntu-latest`;
+    # set to a runs-on JSON string (e.g. `["Linux", "self-hosted",
+    # "analytics", "GCP"]`) → the GCP analytics pool. Same variable drives
+    # ci-health.yml and the ci.yml wait-for-human-priority gate.
+    runs-on: ${{ vars.ANALYTICS_RUNS_ON && fromJSON(vars.ANALYTICS_RUNS_ON) || fromJSON('["ubuntu-latest"]') }}
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -11,7 +11,19 @@ concurrency:
 
 jobs:
   update-health:
-    runs-on: ["Linux", "self-hosted", "analytics", "GCP"]
+    # RUNNER SELECTION — switchable via the `ANALYTICS_RUNS_ON` repository
+    # variable, WITHOUT a code change (Settings → Secrets and variables →
+    # Actions → Variables): unset (default) → GitHub-hosted `ubuntu-latest`;
+    # set to a runs-on JSON string (e.g. `["Linux", "self-hosted",
+    # "analytics", "GCP"]`) → the GCP analytics pool.
+    #
+    # NOTE: this cap-health monitor was deliberately moved off the GitHub-hosted
+    # pool (June 2026) because running it on `ubuntu-latest` starves it on the
+    # very 20-runner cap it measures, biasing the samples. Prefer keeping it on
+    # the GCP analytics pool (set the variable) unless the Teams-tier cap has
+    # ample headroom. Same variable drives ci-analytics.yml and the ci.yml
+    # wait-for-human-priority gate.
+    runs-on: ${{ vars.ANALYTICS_RUNS_ON && fromJSON(vars.ANALYTICS_RUNS_ON) || fromJSON('["ubuntu-latest"]') }}
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/ci-retry-yielded-bot.yml
+++ b/.github/workflows/ci-retry-yielded-bot.yml
@@ -23,11 +23,16 @@ permissions:
 
 jobs:
   retry:
-    # Lightweight CPU-only GCP analytics pool (checkout + Python + `gh api`),
-    # the same pool ci-health/ci-analytics use — keeps this off the ~20-runner
-    # GitHub-hosted pool. Not latency-sensitive, so a scale-from-zero cold start
-    # here is fine.
-    runs-on: ["Linux", "self-hosted", "analytics", "GCP"]
+    # Lightweight work (checkout + Python + `gh api`); not latency-sensitive.
+    #
+    # RUNNER SELECTION — switchable via the `ANALYTICS_RUNS_ON` repository
+    # variable, WITHOUT a code change (Settings → Secrets and variables →
+    # Actions → Variables): unset (default) → GitHub-hosted `ubuntu-latest`;
+    # set to a runs-on JSON string (e.g. `["Linux", "self-hosted",
+    # "analytics", "GCP"]`) → the GCP analytics pool. Same variable drives
+    # ci-health.yml, ci-analytics.yml, and the ci.yml wait-for-human-priority
+    # gate — keep this in the same group so it doesn't get stranded on GCP.
+    runs-on: ${{ vars.ANALYTICS_RUNS_ON && fromJSON(vars.ANALYTICS_RUNS_ON) || fromJSON('["ubuntu-latest"]') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,22 @@ jobs:
   wait-for-human-priority:
     needs: [filter]
     if: needs.filter.outputs.should-run == 'true'
-    # Run on the lightweight CPU-only GCP analytics pool, not a GitHub-hosted
-    # runner: this gate fires for every PR revision, and the GitHub-hosted pool
-    # is only ~20 runners. That pool image already serves the same shape of work
-    # (checkout + Python + `gh api`, no GPU) for ci-health/ci-analytics.
-    runs-on: ["Linux", "self-hosted", "analytics", "GCP"]
+    # This gate fires for every PR revision and does light work (checkout +
+    # Python + `gh api`, no GPU) — the same shape as ci-health/ci-analytics.
+    #
+    # RUNNER SELECTION — switchable via the `ANALYTICS_RUNS_ON` repository
+    # variable, WITHOUT a code change (Settings → Secrets and variables →
+    # Actions → Variables):
+    #   - variable UNSET (default): run on GitHub-hosted `ubuntu-latest`.
+    #   - variable SET to a runs-on JSON string, e.g.
+    #     `["Linux", "self-hosted", "analytics", "GCP"]`: run on the GCP
+    #     analytics pool.
+    # It was offloaded to the GCP analytics pool in June 2026 to keep it off the
+    # 20-runner org cap. NOTE: ci-health.yml runs on the same variable; keeping
+    # it on GCP avoids the self-starvation blind spot where the cap monitor is
+    # itself starved by the cap it measures — prefer the GCP pool for this group
+    # unless the Teams-tier cap has ample headroom.
+    runs-on: ${{ vars.ANALYTICS_RUNS_ON && fromJSON(vars.ANALYTICS_RUNS_ON) || fromJSON('["ubuntu-latest"]') }}
     timeout-minutes: 10
     # Only reads Actions API state and runs a script; no write access needed.
     permissions:
@@ -103,9 +114,23 @@ jobs:
           echo "::error::priority-gate-yielded: higher-priority CI is active; ci-retry-yielded-bot will rerun this bot CI when quiet"
           exit 1
 
-  # Linux x86_64 builds run in the CI container on the GCP self-hosted build
-  # pool. container-user is the GCP build runner image's UID:GID (1003), which
-  # owns _work; the reusable workflow defaults to 1001 for GitHub-hosted runners.
+  # Linux x86_64 builds run in the CI container.
+  #
+  # RUNNER SELECTION — switchable between GitHub-hosted and the GCP self-hosted
+  # build pool via the `LINUX_BUILD_RUNS_ON` repository variable, WITHOUT a code
+  # change (Settings → Secrets and variables → Actions → Variables):
+  #   - variable UNSET (default): run on GitHub-hosted `ubuntu-22.04`.
+  #   - variable SET to a runs-on JSON string, e.g.
+  #     `["Linux", "self-hosted", "build", "GCP"]`: run on the GCP build pool.
+  # These builds were offloaded to GCP in June 2026 (PR #11738) to relieve the
+  # GitHub-hosted 20-runner org cap; with the Teams-tier 60-runner cap they can
+  # ride the GitHub-hosted pool again by default, while the variable keeps a
+  # zero-code-change escape hatch back to GCP if the cap tightens.
+  #
+  # container-user must track the runner: the GCP build image's runner owns
+  # _work as UID:GID 1003, while GitHub-hosted runners use 1001 (the reusable
+  # workflow's default). It is keyed off the SAME variable so the two never
+  # diverge — set the variable → get the GCP UID; unset → get the hosted UID.
   build-linux-debug-gcc-x86_64:
     needs: [filter, wait-for-human-priority]
     if: >-
@@ -123,9 +148,11 @@ jobs:
       packages: read
     with:
       config: debug
-      runs-on: '["Linux", "self-hosted", "build", "GCP"]'
-      container-user: "1003:1003"
+      runs-on: ${{ vars.LINUX_BUILD_RUNS_ON || '["ubuntu-22.04"]' }}
+      container-user: ${{ vars.LINUX_BUILD_RUNS_ON && '1003:1003' || '1001:1001' }}
 
+  # Runner selection and container-user tracking: see build-linux-debug-gcc-x86_64
+  # above (both keyed off the `LINUX_BUILD_RUNS_ON` repository variable).
   build-linux-release-gcc-x86_64:
     needs: [filter, wait-for-human-priority]
     if: >-
@@ -143,14 +170,19 @@ jobs:
       packages: read
     with:
       config: release
-      runs-on: '["Linux", "self-hosted", "build", "GCP"]'
-      container-user: "1003:1003"
+      runs-on: ${{ vars.LINUX_BUILD_RUNS_ON || '["ubuntu-22.04"]' }}
+      container-user: ${{ vars.LINUX_BUILD_RUNS_ON && '1003:1003' || '1001:1001' }}
 
-  # WASM build runs directly on the host (no container) on the GCP build pool.
-  # The linux-cpu-runner image carries the gcc host toolchain (g++) the native
-  # generators build needs; emsdk is downloaded by the build itself. id-token is
-  # requested for the reusable workflow's GCP Workload Identity auth step (never
-  # part of the default GITHUB_TOKEN).
+  # WASM build runs directly on the host (no container). It needs the gcc host
+  # toolchain (g++) for the native generators build; emsdk is downloaded by the
+  # build itself. Both GitHub-hosted `ubuntu-22.04` and the GCP linux-cpu-runner
+  # image provide g++, so this job runs on either.
+  #
+  # RUNNER SELECTION — switchable via the `LINUX_BUILD_RUNS_ON` repository
+  # variable, same as the x86_64 builds above: unset → GitHub-hosted
+  # `ubuntu-22.04`; set to a runs-on JSON string → the GCP build pool. id-token
+  # is requested for the reusable workflow's GCP Workload Identity auth step
+  # (never part of the default GITHUB_TOKEN); it is harmless on GitHub-hosted.
   build-linux-release-gcc-wasm:
     needs: [filter, wait-for-human-priority]
     if: >-
@@ -167,11 +199,17 @@ jobs:
       compiler: gcc
       platform: wasm
       config: release
-      runs-on: '["Linux", "self-hosted", "build", "GCP"]'
+      runs-on: ${{ vars.LINUX_BUILD_RUNS_ON || '["ubuntu-22.04"]' }}
 
   # Sanitizer build+test (blocking via check-ci, runs on every PR). Runs in the
-  # clang CI container (`--user root`, so no container-user concern) on the GCP
-  # build pool. id-token requested explicitly for GCP Workload Identity auth.
+  # clang CI container as `--user root`, so there is no container-user concern
+  # and no runner-UID coupling — only the runner label switches.
+  #
+  # RUNNER SELECTION — switchable via the `LINUX_BUILD_RUNS_ON` repository
+  # variable, same as the x86_64 builds above: unset → GitHub-hosted
+  # `ubuntu-22.04`; set to a runs-on JSON string → the GCP build pool. id-token
+  # is requested explicitly for GCP Workload Identity auth (never part of the
+  # default GITHUB_TOKEN); it is harmless on GitHub-hosted.
   sanitizer-linux-clang-x86_64:
     needs: [filter, wait-for-human-priority]
     if: >-
@@ -186,7 +224,7 @@ jobs:
       contents: read
       packages: read
     with:
-      runs-on: '["Linux", "self-hosted", "build", "GCP"]'
+      runs-on: ${{ vars.LINUX_BUILD_RUNS_ON || '["ubuntu-22.04"]' }}
 
   # macOS builds
   build-macos-debug-clang-aarch64:

--- a/.github/workflows/publish-ci-container-images.yml
+++ b/.github/workflows/publish-ci-container-images.yml
@@ -35,7 +35,14 @@ jobs:
   validate:
     if: github.repository == 'shader-slang/slang' && (github.event_name != 'pull_request' || github.event.pull_request.draft != true)
     name: Validate tag policy ${{ matrix.name }}
-    runs-on: ["Linux", "self-hosted", "build", "GCP"]
+    # RUNNER SELECTION — switchable via the `CONTAINER_PUBLISH_RUNS_ON`
+    # repository variable, WITHOUT a code change (Settings → Secrets and
+    # variables → Actions → Variables): unset (default) → GitHub-hosted
+    # `ubuntu-latest`; set to a runs-on JSON string (e.g. `["Linux",
+    # "self-hosted", "build", "GCP"]`) → the GCP build pool. Same variable
+    # drives the `publish` job below. This job only reads the tag/version
+    # contract and queries GHCR (no Dockerfile build), so it runs on either.
+    runs-on: ${{ vars.CONTAINER_PUBLISH_RUNS_ON && fromJSON(vars.CONTAINER_PUBLISH_RUNS_ON) || fromJSON('["ubuntu-latest"]') }}
     timeout-minutes: 120
     permissions:
       contents: read # Required for actions/checkout.
@@ -194,7 +201,14 @@ jobs:
     # images, and manual dispatches from non-master refs only run validation.
     if: github.repository == 'shader-slang/slang' && github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
     name: Publish ${{ matrix.name }}
-    runs-on: ["Linux", "self-hosted", "build", "GCP"]
+    # RUNNER SELECTION — switchable via the `CONTAINER_PUBLISH_RUNS_ON`
+    # repository variable (same as the `validate` job above): unset (default) →
+    # GitHub-hosted `ubuntu-latest`; set to a runs-on JSON string (e.g.
+    # `["Linux", "self-hosted", "build", "GCP"]`) → the GCP build pool. This job
+    # does `docker build` + push to GHCR; GitHub-hosted runners have Docker
+    # preinstalled, so it runs on either. NOTE: publishing is master-only, so
+    # this never runs untrusted PR code regardless of runner.
+    runs-on: ${{ vars.CONTAINER_PUBLISH_RUNS_ON && fromJSON(vars.CONTAINER_PUBLISH_RUNS_ON) || fromJSON('["ubuntu-latest"]') }}
     timeout-minutes: 120
     permissions:
       contents: read # Required for actions/checkout.


### PR DESCRIPTION
## Motivation

The June 2026 offload ([PR #11738](https://github.com/shader-slang/slang/pull/11738)) routed the x86_64 Linux builds, the scheduled analytics jobs, and the CI container publish onto the GCP self-hosted pools to relieve the GitHub-hosted **20-runner org cap** (the org was on the GitHub Free plan, where that cap is fixed by tier). The org is now on the **Teams tier (60-runner cap)**, so those jobs can ride the GitHub-hosted pool again by default and free the GCP pools for GPU/test work.

Rather than hard-flip the `runs-on` labels — which would then require another code change + PR to move back to GCP if the cap tightens again — this makes the runner choice a **zero-code-change repository-variable switch**. Both directions stay live-tested; there is no commented-out dead `runs-on` and no history churn to flip.

## Proposed solution

Drive each offloaded job's `runs-on` from a repository variable that **defaults to the GitHub-hosted runner when unset** and selects the GCP pool when set to a `runs-on` JSON string. Three independent switches, grouped by pool so build and analytics can be steered separately:

| Repository variable | Jobs | Unset (default) | Set to flip to GCP |
| --- | --- | --- | --- |
| `LINUX_BUILD_RUNS_ON` | `build-linux-debug-gcc-x86_64`, `build-linux-release-gcc-x86_64`, `build-linux-release-gcc-wasm`, `sanitizer-linux-clang-x86_64` | `["ubuntu-22.04"]` | `["Linux", "self-hosted", "build", "GCP"]` |
| `ANALYTICS_RUNS_ON` | `ci-health`, `ci-analytics`, `wait-for-human-priority`, `ci-retry-yielded-bot` | `["ubuntu-latest"]` | `["Linux", "self-hosted", "analytics", "GCP"]` |
| `CONTAINER_PUBLISH_RUNS_ON` | `publish-ci-container-images` `validate` + `publish` | `["ubuntu-latest"]` | `["Linux", "self-hosted", "build", "GCP"]` |

To flip a group back to GCP, set the variable under **Settings → Secrets and variables → Actions → Variables** — no code change or PR either direction.

This is the principled shape because the runner target is deployment configuration, not source: it varies with cap headroom and pool availability, both of which change without any code change. Repository variables are the GitHub-native mechanism for exactly that, are readable in `runs-on` and in reusable-workflow `with:` inputs, and keep the fallback visible in-tree.

> [!NOTE]
> Recommendation for the `ANALYTICS_RUNS_ON` group: consider leaving it **set to GCP** even after this merges. `ci-health` measures the hosted-runner cap; running it on `ubuntu-latest` starves it on the very cap it monitors and biases the samples — the exact observability blind spot the June offload fixed. The switch defaults to hosted for uniformity, but the analytics group is the one where GCP is arguably still the better home.

## Change summary

| File | Change |
| --- | --- |
| `.github/workflows/ci.yml` | 4 build jobs + `wait-for-human-priority` gate switched to the variable form; `container-user` on the two container builds keyed off the same `LINUX_BUILD_RUNS_ON` variable |
| `.github/workflows/ci-health.yml` | `update-health` job switched to `ANALYTICS_RUNS_ON` |
| `.github/workflows/ci-analytics.yml` | `collect-and-publish` job switched to `ANALYTICS_RUNS_ON` |
| `.github/workflows/ci-retry-yielded-bot.yml` | `retry` job switched to `ANALYTICS_RUNS_ON` (same pool group; folded in so it is not stranded on GCP when the rest fall back) |
| `.github/workflows/publish-ci-container-images.yml` | `validate` + `publish` jobs switched to `CONTAINER_PUBLISH_RUNS_ON` |

Each site carries an explanatory comment: which variable drives it, the unset default, and the JSON string to set for GCP.

## Concepts and vocabulary

- **Repository variable (`vars.*`)** — non-secret config set in repo settings, readable in `runs-on` and in a reusable workflow's `with:` inputs. Distinct from a secret; the runner label is not sensitive.
- **`runs-on` as a reusable-workflow input** — `ci-slang-build.yml`, `ci-slang-build-container.yml`, and `ci-slang-sanitizer.yml` take `runs-on` as a **JSON string** input and `fromJSON` it internally. So callers of those pass a JSON *string* (`vars.X || '["ubuntu-22.04"]'`, no caller-side `fromJSON`), while jobs with a **direct** `runs-on` use `vars.X && fromJSON(vars.X) || fromJSON('["ubuntu-latest"]')`.
- **`container-user`** — the `--user UID:GID` the build container runs as; it must match the user that owns the runner's `_work` directory, or `actions/checkout` fails. The GCP build image's runner is UID 1003; GitHub-hosted runners are 1001.

## Process report

**Variable-driven `runs-on`, two forms.** Jobs with a direct `runs-on` (`wait-for-human-priority`, `ci-health`, `ci-analytics`, `ci-retry-yielded-bot`, and both container-publish jobs) use `${{ vars.X && fromJSON(vars.X) || fromJSON('[...]') }}` — GitHub evaluates `runs-on` expressions and requires the value to resolve to a list, hence `fromJSON` on both arms. The four jobs that pass `runs-on` into a reusable workflow use `${{ vars.X || '[...]' }}` (a bare JSON string), because the reusable workflow already does its own `fromJSON(inputs.runs-on)` — a caller-side `fromJSON` there would double-decode and fail.

**`container-user` keyed off the same variable — the subtle coupling.** The two container builds hard-coded `container-user: "1003:1003"`, correct only on the GCP image. On GitHub-hosted `ubuntu-22.04` the runner owns `_work` as 1001, and the reusable workflow's default is `1001:1001`. A naive `runs-on`-only rollback would leave `container-user` at 1003 and break `actions/checkout` on the hosted runner. So `container-user` is `${{ vars.LINUX_BUILD_RUNS_ON && '1003:1003' || '1001:1001' }}` — the *same* variable that selects the runner also selects the UID, so the two can never diverge. This is the one place the change is more than a label swap, and it is deliberately tied to a single source of truth rather than a second independent variable.

**`ci-retry-yielded-bot` folded into the analytics group.** It was not part of the original two offloaded groups in the task framing, but it shares the analytics pool and is the companion to `wait-for-human-priority` (it reruns yielded bot CI). Left untouched it would be the lone job still pinned to GCP after everything else fell back to hosted. It is `workflow_run` / `workflow_dispatch` / `schedule`-triggered (no fork-PR code), so reading `vars.*` on it is safe. Keying it to `ANALYTICS_RUNS_ON` keeps the whole analytics group switching together.

**Trust boundary is preserved on the publish workflow.** `validate` runs on `pull_request` but is validation-only — the workflow never builds Dockerfiles on PRs (a `RUN` step would execute PR code on a self-hosted runner), as its own header comment states — so defaulting it to GitHub-hosted changes nothing about what code runs. `publish` is master-only (`github.ref == 'refs/heads/master'`), so it never runs untrusted PR code regardless of runner. GitHub-hosted `ubuntu-latest` has Docker preinstalled, so `docker build`/`push` work there.

**Defaults chosen to match the pre-offload runner.** Build jobs default to `ubuntu-22.04` (their label before June 2026); analytics and container-publish default to `ubuntu-latest`. No new labels are introduced, so `.github/actionlint.yaml`'s self-hosted-runner allowlist is unchanged and still covers the GCP labels used in the set-variable path.

All five workflows pass `actionlint` (the only report is a pre-existing `SC2086` info in an untouched `filter` script). No compiler code is touched; there is no test to add — the change is CI runner configuration, verifiable by inspecting the resolved `runs-on` in an Actions run with and without the variable set.