### PR TITLE
Fix #11878: don't treat the same field of different objects as aliasing

### DIFF
--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -4050,14 +4050,16 @@ static bool _exprsDefinitelyAlias(Expr* a, Expr* b)
     if (!a || !b)
         return false;
 
-    // Same declaration reference.
-    if (auto aDeclRef = as<DeclRefExpr>(a))
-    {
-        auto bDeclRef = as<DeclRefExpr>(b);
-        return bDeclRef && aDeclRef->declRef.getDecl() == bDeclRef->declRef.getDecl();
-    }
-
-    // Same member of the same base: s.x vs s.x.
+    // Same member of the same base: s.x vs s.x, but not s.x vs t.x.
+    //
+    // This must be checked before the bare-DeclRefExpr case below, because
+    // MemberExpr derives from DeclRefExpr. If we let the DeclRefExpr branch
+    // catch a MemberExpr it would compare only the member declaration and
+    // ignore the base object, so `a.minBounds` and `b.minBounds` (same field
+    // of two different objects) would be wrongly reported as aliasing. We
+    // must recurse into the base expressions to confirm they are the same
+    // storage. (DerefMemberExpr for buffer-element member access derives from
+    // MemberExpr, so it is handled here too.)
     if (auto aMember = as<MemberExpr>(a))
     {
         auto bMember = as<MemberExpr>(b);
@@ -4066,6 +4068,15 @@ static bool _exprsDefinitelyAlias(Expr* a, Expr* b)
         if (aMember->declRef.getDecl() != bMember->declRef.getDecl())
             return false;
         return _exprsDefinitelyAlias(aMember->baseExpression, bMember->baseExpression);
+    }
+
+    // Same bare declaration reference: a bare variable (VarExpr) or static
+    // member (StaticMemberExpr), which have no base object to compare.
+    if (auto aDeclRef = as<DeclRefExpr>(a))
+    {
+        auto bDeclRef = as<DeclRefExpr>(b);
+        return bDeclRef && !as<MemberExpr>(b) &&
+               aDeclRef->declRef.getDecl() == bDeclRef->declRef.getDecl();
     }
 
     // Same element of the same base: arr[0] vs arr[0].

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -4039,10 +4039,11 @@ static Expr* _peelCastsAndParens(Expr* expr)
 }
 
 // Check whether two expressions refer to the same storage location by
-// comparing their structure in lockstep. Handles bare variable
-// references, member accesses (s.x == s.x, but not s.x == s.y), and
-// subscripts with matching constant indices (arr[0] == arr[0], but not
-// arr[0] == arr[1]). Returns false for anything it can't prove equal.
+// comparing their structure in lockstep. Handles the implicit object
+// (`this` == `this`), bare variable / static-member references, member
+// accesses (s.x == s.x, but not s.x == s.y), and subscripts with matching
+// constant indices (arr[0] == arr[0], but not arr[0] == arr[1]). Returns
+// false for anything it can't prove equal.
 static bool _exprsDefinitelyAlias(Expr* a, Expr* b)
 {
     a = _peelCastsAndParens(a);
@@ -4081,8 +4082,10 @@ static bool _exprsDefinitelyAlias(Expr* a, Expr* b)
     if (auto aDeclRef = as<DeclRefExpr>(a))
     {
         auto bDeclRef = as<DeclRefExpr>(b);
-        bool bIsStaticMemberExpr = bDeclRef && !as<MemberExpr>(b);
-        return bIsStaticMemberExpr && aDeclRef->declRef.getDecl() == bDeclRef->declRef.getDecl();
+        // A bare DeclRefExpr is a VarExpr or StaticMemberExpr — any DeclRefExpr
+        // that is not a (non-static) MemberExpr, which was already handled above.
+        bool bIsBareDeclRef = bDeclRef && !as<MemberExpr>(b);
+        return bIsBareDeclRef && aDeclRef->declRef.getDecl() == bDeclRef->declRef.getDecl();
     }
 
     // Same element of the same base: arr[0] vs arr[0].

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -4050,6 +4050,16 @@ static bool _exprsDefinitelyAlias(Expr* a, Expr* b)
     if (!a || !b)
         return false;
 
+    // Same implicit object: `this` vs `this`. Inside a method body an
+    // unqualified member `x` is rewritten to `MemberExpr(base=ThisExpr,
+    // decl=x)`, so the MemberExpr recursion below bottoms out here comparing
+    // the two `this` bases. ThisExpr does not derive from DeclRefExpr, so it
+    // needs its own case; both operands referring to `this` are the same
+    // storage. This is what makes `twoInoutInt(x, x)` in a method (i.e.
+    // `this.x` aliasing itself) still be diagnosed.
+    if (as<ThisExpr>(a))
+        return as<ThisExpr>(b) != nullptr;
+
     // Same member of the same base: s.x vs s.x, but not s.x vs t.x.
     //
     // This must be checked before the bare-DeclRefExpr case below, because

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -4050,26 +4050,22 @@ static bool _exprsDefinitelyAlias(Expr* a, Expr* b)
     if (!a || !b)
         return false;
 
-    // Same implicit object: `this` vs `this`. Inside a method body an
-    // unqualified member `x` is rewritten to `MemberExpr(base=ThisExpr,
-    // decl=x)`, so the MemberExpr recursion below bottoms out here comparing
-    // the two `this` bases. ThisExpr does not derive from DeclRefExpr, so it
-    // needs its own case; both operands referring to `this` are the same
-    // storage. This is what makes `twoInoutInt(x, x)` in a method (i.e.
-    // `this.x` aliasing itself) still be diagnosed.
+    // Same implicit object: `this` vs `this`. There is exactly one `this` in a
+    // given method body, so any two `ThisExpr` nodes necessarily refer to the
+    // same object; that is why this returns true without comparing them further
+    // (there is no per-`this` identity to compare, unlike a named variable).
+    // Inside a method an unqualified member `x` is rewritten to
+    // `MemberExpr(base=ThisExpr, decl=x)`, so the MemberExpr recursion below
+    // bottoms out here on the two `this` bases; this is what still diagnoses
+    // `twoInoutInt(x, x)` (i.e. `this.x` aliasing itself). ThisExpr does not
+    // derive from DeclRefExpr, so it needs its own case.
     if (as<ThisExpr>(a))
         return as<ThisExpr>(b) != nullptr;
 
-    // Same member of the same base: s.x vs s.x, but not s.x vs t.x.
-    //
-    // This must be checked before the bare-DeclRefExpr case below, because
-    // MemberExpr derives from DeclRefExpr. If we let the DeclRefExpr branch
-    // catch a MemberExpr it would compare only the member declaration and
-    // ignore the base object, so `a.minBounds` and `b.minBounds` (same field
-    // of two different objects) would be wrongly reported as aliasing. We
-    // must recurse into the base expressions to confirm they are the same
-    // storage. (DerefMemberExpr for buffer-element member access derives from
-    // MemberExpr, so it is handled here too.)
+    // Same member of the same base: s.x vs s.x, but not s.x vs t.x. Checked
+    // before the bare-DeclRefExpr case below because MemberExpr derives from
+    // DeclRefExpr, and that branch would ignore the base object. (DerefMemberExpr
+    // for buffer-element member access derives from MemberExpr, so it lands here.)
     if (auto aMember = as<MemberExpr>(a))
     {
         auto bMember = as<MemberExpr>(b);
@@ -4085,8 +4081,8 @@ static bool _exprsDefinitelyAlias(Expr* a, Expr* b)
     if (auto aDeclRef = as<DeclRefExpr>(a))
     {
         auto bDeclRef = as<DeclRefExpr>(b);
-        return bDeclRef && !as<MemberExpr>(b) &&
-               aDeclRef->declRef.getDecl() == bDeclRef->declRef.getDecl();
+        bool bIsStaticMemberExpr = bDeclRef && !as<MemberExpr>(b);
+        return bIsStaticMemberExpr && aDeclRef->declRef.getDecl() == bDeclRef->declRef.getDecl();
     }
 
     // Same element of the same base: arr[0] vs arr[0].

--- a/tests/diagnostics/aliased-out-inout-parameter.slang
+++ b/tests/diagnostics/aliased-out-inout-parameter.slang
@@ -42,6 +42,32 @@ void twoInoutUint(inout uint a, inout uint b)
 
 void readBoth(int a, int b) {}
 
+// Regression for #11878 review: inside a method an unqualified member `x` is
+// `MemberExpr(base=ThisExpr, decl=x)`. The aliasing check must still diagnose
+// `twoInoutInt(x, x)` (this.x aliasing itself) via the ThisExpr base case,
+// while not flagging `this.x` against a different object's field.
+struct WithMethods
+{
+    int x;
+
+    [mutating]
+    void selfAlias()
+    {
+        // Positive: implicit this.x passed to both inout params.
+        twoInoutInt(x, x);
+//CHECK:            ^ potentially aliased argument to 'out'/'inout'/'ref' parameter
+//CHECK:            ^ passing the same value to both may produce unexpected results
+    }
+
+    [mutating]
+    void otherObject(inout WithMethods other)
+    {
+        // Negative: this.x vs other.x are different objects — no warning
+        // expected (exhaustive mode fails on any spurious diagnostic).
+        twoInoutInt(this.x, other.x);
+    }
+}
+
 struct BoundingBox { int4 minBounds; }
 
 RWStructuredBuffer<BoundingBox> boundingBoxes;

--- a/tests/diagnostics/aliased-out-inout-parameter.slang
+++ b/tests/diagnostics/aliased-out-inout-parameter.slang
@@ -85,6 +85,19 @@ void expandBoundingBox(uint index, BoundingBox bbox)
     InterlockedMin(boundingBoxes[index].minBounds[0], bbox.minBounds[0], unused);
 }
 
+struct WithStatic { static int counter; }
+
+// Regression for #11878: a static member is a StaticMemberExpr, which derives
+// from DeclRefExpr but is not a MemberExpr, so it goes through the bare-DeclRef
+// branch (guarded by `!as<MemberExpr>(b)`). Passing the same static to both
+// inout params refers to the same storage and must still be flagged.
+void staticMemberAlias()
+{
+    twoInoutInt(WithStatic.counter, WithStatic.counter);
+//CHECK:                   ^^^^^^^ potentially aliased argument to 'out'/'inout'/'ref' parameter
+//CHECK:                   ^^^^^^^ argument for 'inout' parameter 'a' may alias argument for 'inout' parameter 'b'; passing the same value to both may produce unexpected results
+}
+
 [numthreads(1,1,1)]
 void computeMain()
 {

--- a/tests/diagnostics/aliased-out-inout-parameter.slang
+++ b/tests/diagnostics/aliased-out-inout-parameter.slang
@@ -42,6 +42,22 @@ void twoInoutUint(inout uint a, inout uint b)
 
 void readBoth(int a, int b) {}
 
+struct BoundingBox { int4 minBounds; }
+
+RWStructuredBuffer<BoundingBox> boundingBoxes;
+
+// Regression for #11878: the same field of two *different* objects must not
+// be reported as aliasing. Before the fix, MemberExpr (which derives from
+// DeclRefExpr) was caught by the bare-DeclRefExpr case, which compared only
+// the field declaration and ignored the base object, so `dest.minBounds[0]`
+// and `bbox.minBounds[0]` were wrongly flagged.
+void expandBoundingBox(uint index, BoundingBox bbox)
+{
+    int unused;
+    InterlockedMin(boundingBoxes[index].minBounds[0], bbox.minBounds[0], unused);
+//CHECK-NOT: potentially aliased
+}
+
 [numthreads(1,1,1)]
 void computeMain()
 {
@@ -95,6 +111,12 @@ void computeMain()
 
     // Negative: distinct struct fields — no warning expected.
     twoInoutInt(s.x, s.y);
+//CHECK-NOT: potentially aliased
+
+    // Negative: same field of two *different* struct objects — no warning
+    // expected (regression for #11878).
+    S s2;
+    twoInoutInt(s.x, s2.x);
 //CHECK-NOT: potentially aliased
 
     // Negative: distinct array elements — no warning expected.

--- a/tests/diagnostics/aliased-out-inout-parameter.slang
+++ b/tests/diagnostics/aliased-out-inout-parameter.slang
@@ -54,8 +54,9 @@ RWStructuredBuffer<BoundingBox> boundingBoxes;
 void expandBoundingBox(uint index, BoundingBox bbox)
 {
     int unused;
+    // NOTE: no aliasing warning expected here. This test runs in exhaustive
+    // mode, so any unannotated diagnostic (e.g. a spurious E30051) fails it.
     InterlockedMin(boundingBoxes[index].minBounds[0], bbox.minBounds[0], unused);
-//CHECK-NOT: potentially aliased
 }
 
 [numthreads(1,1,1)]
@@ -114,10 +115,10 @@ void computeMain()
 //CHECK-NOT: potentially aliased
 
     // Negative: same field of two *different* struct objects — no warning
-    // expected (regression for #11878).
+    // expected (regression for #11878). Exhaustive mode fails the test if a
+    // spurious warning is emitted here.
     S s2;
     twoInoutInt(s.x, s2.x);
-//CHECK-NOT: potentially aliased
 
     // Negative: distinct array elements — no warning expected.
     twoInoutInt(arr[0], arr[1]);

--- a/tests/diagnostics/aliased-out-inout-parameter.slang
+++ b/tests/diagnostics/aliased-out-inout-parameter.slang
@@ -53,7 +53,7 @@ struct WithMethods
     [mutating]
     void selfAlias()
     {
-        // Positive: implicit this.x passed to both inout params.
+        // Implicit this.x passed to both inout params: expect the aliasing warning.
         twoInoutInt(x, x);
 //CHECK:            ^ potentially aliased argument to 'out'/'inout'/'ref' parameter
 //CHECK:            ^ passing the same value to both may produce unexpected results
@@ -62,8 +62,8 @@ struct WithMethods
     [mutating]
     void otherObject(inout WithMethods other)
     {
-        // Negative: this.x vs other.x are different objects — no warning
-        // expected (exhaustive mode fails on any spurious diagnostic).
+        // this.x vs other.x are different objects, so no warning is expected;
+        // exhaustive mode fails the test if a spurious diagnostic is emitted.
         twoInoutInt(this.x, other.x);
     }
 }


### PR DESCRIPTION
## Motivation

Fixes #11878. Slang emitted a false-positive `warning[E30051]: potentially aliased argument to 'out'/'inout'/'ref' parameter` for an atomic whose writable destination is a buffer-element field and whose value comes from a by-value struct parameter:

```slang
struct BoundingBox { int4 minBounds; };
RWStructuredBuffer<BoundingBox> boundingBoxes;

void expandBoundingBox(uint index, BoundingBox bbox)
{
    int unused;
    InterlockedMin(boundingBoxes[index].minBounds[0], bbox.minBounds[0], unused);
}
```

`boundingBoxes[index].minBounds[0]` (the `ref dest`) and `bbox.minBounds[0]` (the `in value`) reference the same *field* `BoundingBox::minBounds`, but of two entirely different objects — a buffer element versus a by-value local parameter. They cannot alias, yet the check flagged them.

## Proposed solution

The aliasing check in `_exprsDefinitelyAlias` (`source/slang/slang-check-expr.cpp`) compares two argument expressions structurally and is supposed to recurse into member bases so that `s.x` matches `s.x` but not `t.x`. The bug is an ordering problem: `MemberExpr` derives from `DeclRefExpr`, and the bare-`DeclRefExpr` case ran *first*, catching any `MemberExpr` and comparing only its field declaration — never looking at the base object. The dedicated `MemberExpr` branch below it was therefore dead code.

The principled fix is to check `MemberExpr` before the bare `DeclRefExpr` case, so a member access always recurses into its base expression and two members only alias when their base objects also alias. The bare-`DeclRefExpr` case is left to handle genuinely base-less references (a `VarExpr`, or a `StaticMemberExpr`, which does not derive from `MemberExpr`).

## Change summary

| File | Change |
|---|---|
| `source/slang/slang-check-expr.cpp` | Reorder `_exprsDefinitelyAlias`: handle `MemberExpr` (recursing into the base) before the bare `DeclRefExpr` case; guard the `DeclRefExpr` case against a `MemberExpr` `b`. |
| `tests/diagnostics/aliased-out-inout-parameter.slang` | Add regression cases: the #11878 buffer-element-field vs by-value-param case, and the same field of two different local structs — both expect no warning. |

## Concepts and vocabulary

- **`_exprsDefinitelyAlias(a, b)`** — a conservative structural comparison used only to emit the `E30051` aliasing warning. It returns `true` only when it can prove two argument expressions name the same storage; anything it cannot prove is treated as non-aliasing (`false`).
- **`MemberExpr` / `DeclRefExpr`** — in the AST, `MemberExpr : public DeclRefExpr`. A `MemberExpr` carries both a `declRef` (the field) and a `baseExpression` (the object). `VarExpr` and `StaticMemberExpr` also derive from `DeclRefExpr` but have no meaningful base object to compare, which is why they are the intended targets of the bare-`DeclRefExpr` case.

## Process report

The only functional change is the reordering inside `_exprsDefinitelyAlias`.

Consider the repro. `InterlockedMin`'s `dest` parameter is `ref`, so the check runs on the pair `(boundingBoxes[index].minBounds[0], bbox.minBounds[0])`. The recursion peels the two `int4[0]` subscripts (matching `IndexExpr` with equal constant indices) and recurses on `boundingBoxes[index].minBounds` versus `bbox.minBounds`. Both are `MemberExpr` for the field `BoundingBox::minBounds`.

Before the fix, the first branch `if (auto aDeclRef = as<DeclRefExpr>(a))` matched — because `MemberExpr` *is a* `DeclRefExpr` — and returned `aDeclRef->declRef.getDecl() == bDeclRef->declRef.getDecl()`, i.e. `true`, since both name the same field declaration. The base objects (`boundingBoxes[index]` vs `bbox`) were never examined, so the warning fired. The dedicated `MemberExpr` branch that recurses into `baseExpression` sat *after* the `DeclRefExpr` branch and was unreachable for any `MemberExpr` — confirmed with a debug trace showing the recursion stopping at the member comparison and never reaching the base recursion.

After the fix, the `MemberExpr` branch runs first: it confirms the field decls match, then recurses on the base expressions. `boundingBoxes[index]` (a buffer-element access) and `bbox` (a `VarExpr`) do not match, so the pair is correctly reported as non-aliasing.

On the input-shape question: the two `MemberExpr` inputs are the correct, canonical shape produced by the checker for `obj.field`; nothing upstream needs fixing. The bug was purely that this consumer inspected the shape in the wrong order (bare-decl before member), so the fix belongs exactly here. The added `!as<MemberExpr>(b)` guard in the bare-`DeclRefExpr` case is defensive: once `a` is known not to be a `MemberExpr`, a `MemberExpr` `b` can never name the same storage as a base-less `a`, so it should not be compared by field decl alone.

The pre-existing conservative behavior is preserved: cases the check cannot prove (e.g. a buffer element aliasing itself through `buf[i]...`, whose base subscript desugars to an `InvokeExpr` the check does not model) continue to return `false`, exactly as before this change — verified against baseline.