### PR TITLE
CI: don't fail the build when sccache cache restore errors

### DIFF
--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -74,7 +74,11 @@ jobs:
           min-disk-gb: "5"
 
       # Restore sccache local cache from master
+      # sccache is a build accelerator, not a correctness input: a cache miss
+      # or a transient cache-service error must degrade to a slower (cold)
+      # build, never fail the job.
       - name: Restore sccache cache
+        continue-on-error: true
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/.cache/sccache

--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -69,8 +69,13 @@ jobs:
           fetch-depth: "250"
           fetch-tags: true
 
-      # Restore sccache local cache from master
+      # Restore sccache local cache from master. sccache is a build
+      # accelerator, not a correctness input: a cache miss or a transient
+      # cache-service error must degrade to a slower (cold) build, never fail
+      # the job. Without continue-on-error a 5xx/timeout from the cache backend
+      # fails the build step, which in the merge queue evicts the whole batch.
       - name: Restore sccache cache
+        continue-on-error: true
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ inputs.os == 'windows' && 'C:/sccache' || '/tmp/.cache/sccache' }}

--- a/.github/workflows/ci-slang-sanitizer.yml
+++ b/.github/workflows/ci-slang-sanitizer.yml
@@ -74,7 +74,11 @@ jobs:
         with:
           platform: linux
 
+      # sccache is a build accelerator, not a correctness input: a cache miss
+      # or a transient cache-service error must degrade to a slower (cold)
+      # build, never fail the job.
       - name: Restore sccache cache
+        continue-on-error: true
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/.cache/sccache


### PR DESCRIPTION
## Motivation

PRs were being evicted from the merge queue despite their own checks passing green. Tracing a concrete case (#11832 and its batchmates on 2026-07-01), the merge-queue batch's Windows GPU build job failed after only ~86 seconds — far too short to be a compile or test failure. The step breakdown showed the failure was at step 4, **"Restore sccache cache"**, with every subsequent step (including `Build Slang`) skipped:

| step | result |
|------|--------|
| Set up job | ✅ |
| Checkout | ✅ |
| **Restore sccache cache** | ❌ failure |
| Build Slang … | ⏭ skipped |

sccache is a build *accelerator*, not a correctness input. A restore miss — or a transient 5xx/timeout from the cache-service backend — should degrade to a slower cold build, never fail the job. But `actions/cache/restore` throws on a backend error, and without `continue-on-error` that failure kills the build step.

In the merge queue this is especially damaging. Under the `ALLGREEN` merging strategy a single failed job fails the whole batch, so GitHub evicts *every* PR in that batch — including ones whose checks were already green (e.g. #11839, evicted at 13:57 with two fully-green queue-CI runs). The evicted PRs are then re-batched and re-tested from scratch (~2h each), amplifying queue congestion and producing more opportunities for the next flake.

## Proposed solution

Make the cache-restore step non-fatal. Adding `continue-on-error: true` to the `Restore sccache cache` step means a restore miss or a cache-backend error is logged but does not fail the job; the build step still runs (cold, i.e. slower) and produces a correct result. This is the principled layer: the failure is in an optimization step, and the fix expresses the invariant that the optimization is never allowed to gate correctness.

## Change summary

| File | Change |
|------|--------|
| `.github/workflows/ci-slang-build.yml` | `continue-on-error: true` on `Restore sccache cache` (the Windows/Linux/macOS build matrix, incl. the GPU build that triggered the eviction cascade) |
| `.github/workflows/ci-slang-sanitizer.yml` | same, for the sanitizer build |
| `.github/workflows/ci-slang-build-container.yml` | same, for the Linux CUDA container build |

## Concepts and vocabulary

- **`ALLGREEN` merging strategy** — GitHub merge-queue mode where the entire batch's checks must be green to merge; one failed job invalidates the batch and re-tests everyone. (Contrast `HEADGREEN`.)
- **Batch eviction** — when a queued PR is removed by `github-merge-queue[bot]` because its batch's merge commit failed a required check, even if the PR's own checks passed.

## Process report

The only change is adding `continue-on-error: true` to the three `Restore sccache cache` steps. This is not a guard papering over a malformed input — it is the correct contract for an optimization step: a cache restore that misses or errors must not fail the build.

- **Input-shape check.** The "shape" here is a step failure from `actions/cache/restore`. That failure is legitimately possible (cold cache, or transient cache-backend 5xx/timeout) and is *not* something to fix upstream — cache availability is inherently best-effort. The right handling is to treat it as non-fatal, which is what `continue-on-error: true` does. The producer (the cache service) cannot be made never to fail.
- **No downstream dependency.** No step reads the restore step's `id`, `outcome`, or `cache-hit` output, so making it non-fatal has no side effects beyond the intended one: the build proceeds cold on a restore failure.
- **Verified.** `actionlint` passes on all three files (the only findings are pre-existing shellcheck notes on unrelated `run:` blocks).