### PR TITLE
Support SM 6.10 in gfx D3D12 shader model table; prefer NVAPI HitObject over DXR 1.3 native

### DIFF
--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -1969,17 +1969,17 @@ void HLSLSourceEmitter::emitSimpleTypeImpl(IRType* type)
             auto nvapiCapabilitySet = CapabilitySet(CapabilityName::hlsl_nvapi);
             auto sm69CapabilitySet = CapabilitySet(CapabilityName::_sm_6_9);
 
-            if (targetCaps.implies(sm69CapabilitySet))
+            if (targetCaps.implies(nvapiCapabilitySet))
             {
-                // DXR 1.3 native: use dx::HitObject namespace
-                m_writer->emit("dx::HitObject");
-            }
-            else if (targetCaps.implies(nvapiCapabilitySet))
-            {
-                // NVAPI extension: use NvHitObject
+                // NVAPI extension: use NvHitObject (matches `case hlsl_nvapi:` calls)
                 m_writer->emit("NvHitObject");
                 // Ensure NVAPI header is included when using NvHitObject type
                 m_extensionTracker->m_requiresNVAPI = true;
+            }
+            else if (targetCaps.implies(sm69CapabilitySet))
+            {
+                // DXR 1.3 native: use dx::HitObject namespace
+                m_writer->emit("dx::HitObject");
             }
             else
             {

--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -57,9 +57,33 @@ static ShaderModelInfo kKnownShaderModels[] = {
     }
     SHADER_MODEL_INFO_DXBC(5, 1),
 #undef SHADER_MODEL_INFO_DXBC
-#define SHADER_MODEL_INFO_DXIL(major, minor)                                    \
-    {                                                                           \
-        (D3D_SHADER_MODEL)0x##major##minor, SLANG_DXIL, "sm_" #major "_" #minor \
+// Minor versions >= 10 must be encoded as a hex digit (D3D_SHADER_MODEL_6_10 == 0x6a),
+// so we run the minor through a lookup table before token-pasting. Two-level indirection
+// is required because `##` does not expand its operands.
+#define _SM_HEX_DIGIT_0 0
+#define _SM_HEX_DIGIT_1 1
+#define _SM_HEX_DIGIT_2 2
+#define _SM_HEX_DIGIT_3 3
+#define _SM_HEX_DIGIT_4 4
+#define _SM_HEX_DIGIT_5 5
+#define _SM_HEX_DIGIT_6 6
+#define _SM_HEX_DIGIT_7 7
+#define _SM_HEX_DIGIT_8 8
+#define _SM_HEX_DIGIT_9 9
+#define _SM_HEX_DIGIT_10 a
+#define _SM_HEX_DIGIT_11 b
+#define _SM_HEX_DIGIT_12 c
+#define _SM_HEX_DIGIT_13 d
+#define _SM_HEX_DIGIT_14 e
+#define _SM_HEX_DIGIT_15 f
+#define _SM_HEX_DIGIT_INDIRECT(x) _SM_HEX_DIGIT_##x
+#define _SM_HEX_DIGIT(x) _SM_HEX_DIGIT_INDIRECT(x)
+#define _SM_CONCAT_PASTE(a, b, c) a##b##c
+#define _SM_CONCAT(a, b, c) _SM_CONCAT_PASTE(a, b, c)
+#define SHADER_MODEL_INFO_DXIL(major, minor)                                          \
+    {                                                                                 \
+        (D3D_SHADER_MODEL)_SM_CONCAT(0x, major, _SM_HEX_DIGIT(minor)),                \
+            SLANG_DXIL, "sm_" #major "_" #minor                                       \
     }
     SHADER_MODEL_INFO_DXIL(6, 0),
     SHADER_MODEL_INFO_DXIL(6, 1),
@@ -70,7 +94,8 @@ static ShaderModelInfo kKnownShaderModels[] = {
     SHADER_MODEL_INFO_DXIL(6, 6),
     SHADER_MODEL_INFO_DXIL(6, 7),
     SHADER_MODEL_INFO_DXIL(6, 8),
-    SHADER_MODEL_INFO_DXIL(6, 9)
+    SHADER_MODEL_INFO_DXIL(6, 9),
+    SHADER_MODEL_INFO_DXIL(6, 10)
 #undef SHADER_MODEL_INFO_DXIL
 };
 

--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -97,6 +97,26 @@ static ShaderModelInfo kKnownShaderModels[] = {
     SHADER_MODEL_INFO_DXIL(6, 9),
     SHADER_MODEL_INFO_DXIL(6, 10)
 #undef SHADER_MODEL_INFO_DXIL
+#undef _SM_CONCAT
+#undef _SM_CONCAT_PASTE
+#undef _SM_HEX_DIGIT
+#undef _SM_HEX_DIGIT_INDIRECT
+#undef _SM_HEX_DIGIT_15
+#undef _SM_HEX_DIGIT_14
+#undef _SM_HEX_DIGIT_13
+#undef _SM_HEX_DIGIT_12
+#undef _SM_HEX_DIGIT_11
+#undef _SM_HEX_DIGIT_10
+#undef _SM_HEX_DIGIT_9
+#undef _SM_HEX_DIGIT_8
+#undef _SM_HEX_DIGIT_7
+#undef _SM_HEX_DIGIT_6
+#undef _SM_HEX_DIGIT_5
+#undef _SM_HEX_DIGIT_4
+#undef _SM_HEX_DIGIT_3
+#undef _SM_HEX_DIGIT_2
+#undef _SM_HEX_DIGIT_1
+#undef _SM_HEX_DIGIT_0
 };
 
 Result DeviceImpl::createBuffer(

--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -60,30 +60,30 @@ static ShaderModelInfo kKnownShaderModels[] = {
 // Minor versions >= 10 must be encoded as a hex digit (D3D_SHADER_MODEL_6_10 == 0x6a),
 // so we run the minor through a lookup table before token-pasting. Two-level indirection
 // is required because `##` does not expand its operands.
-#define _SM_HEX_DIGIT_0 0
-#define _SM_HEX_DIGIT_1 1
-#define _SM_HEX_DIGIT_2 2
-#define _SM_HEX_DIGIT_3 3
-#define _SM_HEX_DIGIT_4 4
-#define _SM_HEX_DIGIT_5 5
-#define _SM_HEX_DIGIT_6 6
-#define _SM_HEX_DIGIT_7 7
-#define _SM_HEX_DIGIT_8 8
-#define _SM_HEX_DIGIT_9 9
-#define _SM_HEX_DIGIT_10 a
-#define _SM_HEX_DIGIT_11 b
-#define _SM_HEX_DIGIT_12 c
-#define _SM_HEX_DIGIT_13 d
-#define _SM_HEX_DIGIT_14 e
-#define _SM_HEX_DIGIT_15 f
-#define _SM_HEX_DIGIT_INDIRECT(x) _SM_HEX_DIGIT_##x
-#define _SM_HEX_DIGIT(x) _SM_HEX_DIGIT_INDIRECT(x)
-#define _SM_CONCAT_PASTE(a, b, c) a##b##c
-#define _SM_CONCAT(a, b, c) _SM_CONCAT_PASTE(a, b, c)
-#define SHADER_MODEL_INFO_DXIL(major, minor)                                        \
-    {                                                                               \
-        (D3D_SHADER_MODEL) _SM_CONCAT(0x, major, _SM_HEX_DIGIT(minor)), SLANG_DXIL, \
-            "sm_" #major "_" #minor                                                 \
+#define SM_HEX_DIGIT_0 0
+#define SM_HEX_DIGIT_1 1
+#define SM_HEX_DIGIT_2 2
+#define SM_HEX_DIGIT_3 3
+#define SM_HEX_DIGIT_4 4
+#define SM_HEX_DIGIT_5 5
+#define SM_HEX_DIGIT_6 6
+#define SM_HEX_DIGIT_7 7
+#define SM_HEX_DIGIT_8 8
+#define SM_HEX_DIGIT_9 9
+#define SM_HEX_DIGIT_10 a
+#define SM_HEX_DIGIT_11 b
+#define SM_HEX_DIGIT_12 c
+#define SM_HEX_DIGIT_13 d
+#define SM_HEX_DIGIT_14 e
+#define SM_HEX_DIGIT_15 f
+#define SM_HEX_DIGIT_INDIRECT(x) SM_HEX_DIGIT_##x
+#define SM_HEX_DIGIT(x) SM_HEX_DIGIT_INDIRECT(x)
+#define SM_CONCAT_PASTE(a, b, c) a##b##c
+#define SM_CONCAT(a, b, c) SM_CONCAT_PASTE(a, b, c)
+#define SHADER_MODEL_INFO_DXIL(major, minor)                                      \
+    {                                                                             \
+        (D3D_SHADER_MODEL) SM_CONCAT(0x, major, SM_HEX_DIGIT(minor)), SLANG_DXIL, \
+            "sm_" #major "_" #minor                                               \
     }
     SHADER_MODEL_INFO_DXIL(6, 0),
     SHADER_MODEL_INFO_DXIL(6, 1),
@@ -97,26 +97,26 @@ static ShaderModelInfo kKnownShaderModels[] = {
     SHADER_MODEL_INFO_DXIL(6, 9),
     SHADER_MODEL_INFO_DXIL(6, 10)
 #undef SHADER_MODEL_INFO_DXIL
-#undef _SM_CONCAT
-#undef _SM_CONCAT_PASTE
-#undef _SM_HEX_DIGIT
-#undef _SM_HEX_DIGIT_INDIRECT
-#undef _SM_HEX_DIGIT_15
-#undef _SM_HEX_DIGIT_14
-#undef _SM_HEX_DIGIT_13
-#undef _SM_HEX_DIGIT_12
-#undef _SM_HEX_DIGIT_11
-#undef _SM_HEX_DIGIT_10
-#undef _SM_HEX_DIGIT_9
-#undef _SM_HEX_DIGIT_8
-#undef _SM_HEX_DIGIT_7
-#undef _SM_HEX_DIGIT_6
-#undef _SM_HEX_DIGIT_5
-#undef _SM_HEX_DIGIT_4
-#undef _SM_HEX_DIGIT_3
-#undef _SM_HEX_DIGIT_2
-#undef _SM_HEX_DIGIT_1
-#undef _SM_HEX_DIGIT_0
+#undef SM_CONCAT
+#undef SM_CONCAT_PASTE
+#undef SM_HEX_DIGIT
+#undef SM_HEX_DIGIT_INDIRECT
+#undef SM_HEX_DIGIT_15
+#undef SM_HEX_DIGIT_14
+#undef SM_HEX_DIGIT_13
+#undef SM_HEX_DIGIT_12
+#undef SM_HEX_DIGIT_11
+#undef SM_HEX_DIGIT_10
+#undef SM_HEX_DIGIT_9
+#undef SM_HEX_DIGIT_8
+#undef SM_HEX_DIGIT_7
+#undef SM_HEX_DIGIT_6
+#undef SM_HEX_DIGIT_5
+#undef SM_HEX_DIGIT_4
+#undef SM_HEX_DIGIT_3
+#undef SM_HEX_DIGIT_2
+#undef SM_HEX_DIGIT_1
+#undef SM_HEX_DIGIT_0
 };
 
 Result DeviceImpl::createBuffer(

--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -80,10 +80,10 @@ static ShaderModelInfo kKnownShaderModels[] = {
 #define _SM_HEX_DIGIT(x) _SM_HEX_DIGIT_INDIRECT(x)
 #define _SM_CONCAT_PASTE(a, b, c) a##b##c
 #define _SM_CONCAT(a, b, c) _SM_CONCAT_PASTE(a, b, c)
-#define SHADER_MODEL_INFO_DXIL(major, minor)                                          \
-    {                                                                                 \
-        (D3D_SHADER_MODEL)_SM_CONCAT(0x, major, _SM_HEX_DIGIT(minor)),                \
-            SLANG_DXIL, "sm_" #major "_" #minor                                       \
+#define SHADER_MODEL_INFO_DXIL(major, minor)                                        \
+    {                                                                               \
+        (D3D_SHADER_MODEL) _SM_CONCAT(0x, major, _SM_HEX_DIGIT(minor)), SLANG_DXIL, \
+            "sm_" #major "_" #minor                                                 \
     }
     SHADER_MODEL_INFO_DXIL(6, 0),
     SHADER_MODEL_INFO_DXIL(6, 1),


### PR DESCRIPTION
## Motivation

The D3D12 gfx backend should report Shader Model 6.10 as a known DXIL shader model.
That table currently builds the `D3D_SHADER_MODEL` value for each DXIL entry by
token-pasting the major and minor version. That works for `sm_6_9`, but not for
`sm_6_10`: the D3D enum encodes that version as `0x6a`, not as a decimal-looking
`0x610`.

The same capability area also has a consistency problem for `HitObject`. When an
HLSL target has both the NVAPI capability and the SM 6.9 DXR 1.3 capability, the
`HitObject` intrinsics prefer the NVAPI path, but the HLSL type emitter previously
preferred `dx::HitObject`. That can make the emitted type disagree with the emitted
operations for the same target capability set.

## Proposed solution

Teach the D3D12 shader-model table to map DXIL minor versions through a hex-digit
lookup before token-pasting the enum value, then add the `sm_6_10` table entry.
This keeps `kKnownShaderModels` as the single source of truth for D3D12 shader
model discovery while making the macro representation match the D3D enum encoding.

For `HitObject`, check `hlsl_nvapi` before `_sm_6_9` in
`HLSLSourceEmitter::emitSimpleTypeImpl`. That matches the target-switch ordering
used by the `HitObject` intrinsics, so a target that intentionally enables both
capabilities consistently emits the NVAPI type and NVAPI calls.

## Change summary

`tools/gfx/d3d12/d3d12-device.cpp:60` adds a small hex-digit lookup used by
`SHADER_MODEL_INFO_DXIL`, registers `SHADER_MODEL_INFO_DXIL(6, 10)` in
`kKnownShaderModels`, and undefines the local macros immediately after the table.

`source/slang/slang-emit-hlsl.cpp:1972` changes the `kIROp_HitObjectType` emission
branch to prefer `NvHitObject` when `hlsl_nvapi` is present, falling back to
`dx::HitObject` for SM 6.9+ targets without NVAPI.

## Concepts and vocabulary

`D3D_SHADER_MODEL` encodes DXIL shader model versions as hex nibbles, so minor
version 10 is represented by `a`.

`hlsl_nvapi` is the NVIDIA HLSL extension path for SER `HitObject` support.
`_sm_6_9` is the native DXR 1.3 path that uses `dx::HitObject`.

## Process report

Consider a D3D12 device that supports Shader Model 6.10. `kKnownShaderModels` in
`tools/gfx/d3d12/d3d12-device.cpp` is the table that `DeviceImpl` uses when it
enumerates known D3D shader models. The existing `SHADER_MODEL_INFO_DXIL(6, 9)`
form can paste `0x69`, but using the same spelling for `SHADER_MODEL_INFO_DXIL(6, 10)`
would paste the wrong token. The producer of the value is this table macro, so the
fix belongs at the table construction site: the minor version is converted to the
hex digit required by the D3D enum before token-pasting, and `sm_6_10` can then be
listed next to the older DXIL profiles.

Consider a shader that uses `HitObject` while targeting HLSL with both NVAPI and
SM 6.9 capabilities enabled. The `HitObject` operations in `hlsl.meta.slang`
dispatch through `case hlsl_nvapi:` before the native HLSL path; for example,
`HitObject.MakeHit` enters the NVAPI branch first. The type emitter receives the
same valid target capability shape in `HLSLSourceEmitter::emitSimpleTypeImpl`.
That shape is intentional, not malformed input from an earlier compiler phase: a
target can advertise both the vendor extension and the native DXR capability. The
emitter owns choosing the HLSL spelling for `kIROp_HitObjectType`, so it now uses
the same priority as the intrinsics and emits `NvHitObject` when NVAPI is present.
