### PR TITLE
Fix #11197: accept SV_PrimitiveID as input in intersection, any-hit, and closest-hit shaders

### DIFF
--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -5182,10 +5182,17 @@ semantic sv_pointcoord
 
 semantic sv_primitiveid
 {
+    // GLSL_EXT_ray_tracing allows `gl_PrimitiveID` as an input in the
+    // intersection, any-hit, and closest-hit stages, so we accept
+    // `SV_PrimitiveID` there in addition to the rasterization stages.
+    // It maps to the same value as the `PrimitiveIndex()` intrinsic.
     [require(fragment)]
     [require(geometry)]
     [require(hull)]
     [require(domain)]
+    [require(intersection)]
+    [require(anyhit)]
+    [require(closesthit)]
     get : uint;
 
     [require(geometry)]

--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -3131,6 +3131,14 @@ void consolidateRayTracingParameters(GLSLLegalizationContext* context, IRFunc* f
         auto paramLayout = findVarLayout(param);
         if (!isVaryingParameter(paramLayout))
             continue;
+        // A parameter with a system-value semantic (e.g. `SV_PrimitiveID` in an
+        // intersection shader) is an ordinary builtin input rather than a
+        // ray-tracing payload/attributes parameter, so it must not be turned
+        // into a plain global here. It is legalized by the standard varying
+        // path in `legalizeEntryPointParameterForGLSL`, which maps it to the
+        // corresponding builtin (e.g. `gl_PrimitiveID`).
+        if (paramLayout && paramLayout->findSystemValueSemanticAttr())
+            continue;
         builder->setInsertBefore(firstBlock->getFirstOrdinaryInst());
         if (as<IROutParamType>(param->getDataType()) ||
             as<IRBorrowInOutParamType>(param->getDataType()))
@@ -4247,7 +4255,15 @@ void legalizeEntryPointParameterForGLSL(
     case Stage::Intersection:
     case Stage::Miss:
     case Stage::RayGeneration:
-        return;
+        // The exception is a parameter with a system-value semantic (e.g.
+        // `SV_PrimitiveID` in an intersection shader): it is an ordinary
+        // builtin input rather than a payload/attributes parameter (those
+        // were already legalized by `consolidateRayTracingParameters`), so
+        // it takes the default varying-input path below, which maps it to
+        // the corresponding builtin (e.g. `gl_PrimitiveID`).
+        if (!(paramLayout && paramLayout->findSystemValueSemanticAttr()))
+            return;
+        break;
     }
 
     // Is the parameter type a special pointer type

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -1978,6 +1978,14 @@ SimpleSemanticInfo decomposeSimpleSemantic(HLSLSimpleSemantic* semantic)
     return info;
 }
 
+// Return true if a lowercased semantic name denotes a system-value semantic,
+// operating under the assumption that *any* semantic with an `SV_` or `NV_`
+// prefix is a system value.
+static bool isSystemValueSemanticName(String const& loweredSemanticName)
+{
+    return loweredSemanticName.startsWith("sv_") || loweredSemanticName.startsWith("nv_");
+}
+
 static RefPtr<TypeLayout> processSimpleEntryPointParameter(
     ParameterBindingContext* context,
     Type* type,
@@ -1996,11 +2004,9 @@ static RefPtr<TypeLayout> processSimpleEntryPointParameter(
 
     RefPtr<TypeLayout> typeLayout;
 
-    // First we check for a system-value semantic, operating
-    // under the assumption that *any* semantic with an `SV_`
-    // or `NV_` prefix is a system value.
+    // First we check for a system-value semantic.
     //
-    if (sn.startsWith("sv_") || sn.startsWith("nv_"))
+    if (isSystemValueSemanticName(sn))
     {
         // Fragment shader color/render target outputs need to be handled
         // specially, because they are declared with an `SV`-prefixed
@@ -2316,6 +2322,35 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameterDecl(
     return typeLayout;
 }
 
+// Return true if an entry-point parameter in a ray-tracing stage plays one of
+// the ray-tracing-specific varying roles (ray payload, callable payload, or hit
+// attributes) rather than being an ordinary system-value input.
+//
+// Ray-tracing parameters are identified by direction and position rather than
+// by semantic, so a parameter with no semantic (or a user-defined semantic)
+// takes a ray-tracing role. The `SV_RayPayload` and `SV_IntersectionAttributes`
+// semantics explicitly mark those same roles, so they do too. Any other
+// system-value semantic instead marks a builtin input that is valid in the
+// stage, as in:
+//
+//      [shader("intersection")]
+//      void main(uint primitiveId : SV_PrimitiveID) { ... }
+//
+// where `primitiveId` must be laid out by the regular system-value logic
+// (consuming no varying resources) rather than being mistaken for a payload or
+// hit-attributes parameter.
+static bool isRayTracingPayloadOrAttributesParameter(EntryPointParameterState const& state)
+{
+    if (!state.optSemanticName)
+        return true;
+
+    String sn = state.optSemanticName->toLower();
+    if (!isSystemValueSemanticName(sn))
+        return true;
+
+    return sn == "sv_raypayload" || sn == "sv_intersectionattributes";
+}
+
 // Returns nullptr when `type` is not valid in a varying parameter position
 // (e.g. interface types, textures, samplers, constant buffers).
 static RefPtr<TypeLayout> processEntryPointVaryingParameter(
@@ -2377,73 +2412,82 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
     // "varying" input/output parameters, since they don't have the same
     // idea of previous/next stage as the rasterization shader types.
     //
-    if (state.directionMask & kEntryPointParameterDirection_Output)
+    // That interpretation only applies to parameters that play a
+    // ray-tracing-specific role (ray payload, callable payload, or hit
+    // attributes). A parameter that carries an ordinary system-value semantic
+    // (e.g. `SV_PrimitiveID` in an intersection shader) is a builtin input,
+    // and is laid out by the regular system-value logic below.
+    //
+    if (isRayTracingPayloadOrAttributesParameter(state))
     {
-        // Note: we are silently treating `out` parameters as if they
-        // were `in out` for this test, under the assumption that
-        // an `out` parameter represents a write-only payload.
-
-        switch (state.stage)
+        if (state.directionMask & kEntryPointParameterDirection_Output)
         {
-        default:
-            // Not a raytracing shader.
-            break;
+            // Note: we are silently treating `out` parameters as if they
+            // were `in out` for this test, under the assumption that
+            // an `out` parameter represents a write-only payload.
 
-        case Stage::Intersection:
-        case Stage::RayGeneration:
-            // Don't expect this case to have any `in out` parameters.
-            getSink(context)->diagnose(Diagnostics::DontExpectOutParametersForStage{
-                .stage = getStageName(state.stage),
-                .location = state.loc});
-            break;
+            switch (state.stage)
+            {
+            default:
+                // Not a raytracing shader.
+                break;
 
-        case Stage::AnyHit:
-        case Stage::ClosestHit:
-        case Stage::Miss:
-            // `in out` or `out` parameter is payload
-            return createTypeLayoutWith(
-                context->layoutContext,
-                context->getRulesFamily()->getRayPayloadParameterRules(),
-                type);
+            case Stage::Intersection:
+            case Stage::RayGeneration:
+                // Don't expect this case to have any `in out` parameters.
+                getSink(context)->diagnose(Diagnostics::DontExpectOutParametersForStage{
+                    .stage = getStageName(state.stage),
+                    .location = state.loc});
+                break;
 
-        case Stage::Callable:
-            // `in out` or `out` parameter is payload
-            return createTypeLayoutWith(
-                context->layoutContext,
-                context->getRulesFamily()->getCallablePayloadParameterRules(),
-                type);
+            case Stage::AnyHit:
+            case Stage::ClosestHit:
+            case Stage::Miss:
+                // `in out` or `out` parameter is payload
+                return createTypeLayoutWith(
+                    context->layoutContext,
+                    context->getRulesFamily()->getRayPayloadParameterRules(),
+                    type);
+
+            case Stage::Callable:
+                // `in out` or `out` parameter is payload
+                return createTypeLayoutWith(
+                    context->layoutContext,
+                    context->getRulesFamily()->getCallablePayloadParameterRules(),
+                    type);
+            }
         }
-    }
-    else
-    {
-        switch (state.stage)
+        else
         {
-        default:
-            // Not a raytracing shader.
-            break;
+            switch (state.stage)
+            {
+            default:
+                // Not a raytracing shader.
+                break;
 
-        case Stage::Intersection:
-        case Stage::RayGeneration:
-        case Stage::Miss:
-        case Stage::Callable:
-            // Don't expect this case to have any `in` parameters.
-            //
-            // TODO: For a miss or callable shader we could interpret
-            // an `in` parameter as indicating a payload that the
-            // programmer doesn't intend to write to.
-            //
-            getSink(context)->diagnose(Diagnostics::DontExpectInParametersForStage{
-                .stage = getStageName(state.stage),
-                .location = state.loc});
-            break;
+            case Stage::Intersection:
+            case Stage::RayGeneration:
+            case Stage::Miss:
+            case Stage::Callable:
+                // Don't expect this case to have any `in` parameters.
+                //
+                // TODO: For a miss or callable shader we could interpret
+                // an `in` parameter as indicating a payload that the
+                // programmer doesn't intend to write to.
+                //
+                getSink(context)->diagnose(Diagnostics::DontExpectInParametersForStage{
+                    .stage = getStageName(state.stage),
+                    .location = state.loc});
+                break;
 
-        case Stage::AnyHit:
-        case Stage::ClosestHit:
-            // `in` parameter is hit attributes
-            return createTypeLayoutWith(
-                context->layoutContext,
-                context->getRulesFamily()->getHitAttributesParameterRules(),
-                type);
+            case Stage::AnyHit:
+            case Stage::ClosestHit:
+                // `in` parameter is hit attributes
+                return createTypeLayoutWith(
+                    context->layoutContext,
+                    context->getRulesFamily()->getHitAttributesParameterRules(),
+                    type);
+            }
         }
     }
 

--- a/tests/diagnostics/execution-model/sv-primitive-id-invalid-rt-stage.slang
+++ b/tests/diagnostics/execution-model/sv-primitive-id-invalid-rt-stage.slang
@@ -1,0 +1,13 @@
+// Diagnostic: `SV_PrimitiveID` is readable in the intersection, any-hit,
+// and closest-hit stages (see tests/vkray/intersection-primitive-id.slang),
+// but there is no current primitive in the raygeneration and miss stages,
+// so it must still be rejected there.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target spirv -entry missMain
+
+//CHECK: E30702
+[shader("miss")]
+void missMain(inout float3 payload, uint primitiveId: SV_PrimitiveID)
+{
+    payload.x = primitiveId;
+}

--- a/tests/vkray/intersection-primitive-id.slang
+++ b/tests/vkray/intersection-primitive-id.slang
@@ -1,0 +1,56 @@
+// intersection-primitive-id.slang
+
+// Regression test for https://github.com/shader-slang/slang/issues/11197:
+// `SV_PrimitiveID` must be accepted as an input to the intersection, any-hit,
+// and closest-hit stages, matching `gl_PrimitiveID` in GLSL_EXT_ray_tracing,
+// and must map to the `PrimitiveId` builtin in SPIR-V.
+
+//TEST:SIMPLE(filecheck=CHECK_INTERSECTION): -emit-spirv-directly -stage intersection -entry mainIntersection -target spirv-assembly
+//TEST:SIMPLE(filecheck=CHECK_ANYHIT): -emit-spirv-directly -stage anyhit -entry mainAnyHit -target spirv-assembly
+//TEST:SIMPLE(filecheck=CHECK_CLOSESTHIT): -emit-spirv-directly -stage closesthit -entry mainClosestHit -target spirv-assembly
+//TEST:SIMPLE(filecheck=CHECK_GLSL): -stage intersection -entry mainIntersection -target glsl
+
+struct Payload
+{
+    float3 hitValue;
+};
+
+struct Attributes
+{
+    float2 bary;
+};
+
+// The builtin must be an Input-storage-class variable (not Private, which
+// fails SPIR-V validation for BuiltIn PrimitiveId).
+
+// CHECK_INTERSECTION: OpEntryPoint Intersection{{NV|KHR}} %mainIntersection
+// CHECK_INTERSECTION: OpDecorate %[[VAR:[a-zA-Z0-9_]+]] BuiltIn PrimitiveId
+// CHECK_INTERSECTION: %[[VAR]] = OpVariable %_ptr_Input_int Input
+// CHECK_INTERSECTION: OpReportIntersectionKHR
+
+// CHECK_GLSL: gl_PrimitiveID
+[shader("intersection")]
+void mainIntersection(uint primitiveId: SV_PrimitiveID)
+{
+    Attributes attr = {};
+    attr.bary.x = primitiveId;
+    ReportHit<Attributes>(1, 0, attr);
+}
+
+// CHECK_ANYHIT: OpEntryPoint AnyHit{{NV|KHR}} %mainAnyHit
+// CHECK_ANYHIT: OpDecorate %[[VAR:[a-zA-Z0-9_]+]] BuiltIn PrimitiveId
+// CHECK_ANYHIT: %[[VAR]] = OpVariable %_ptr_Input_int Input
+[shader("anyhit")]
+void mainAnyHit(inout Payload payload, in Attributes attr, uint primitiveId: SV_PrimitiveID)
+{
+    payload.hitValue.x = primitiveId;
+}
+
+// CHECK_CLOSESTHIT: OpEntryPoint ClosestHit{{NV|KHR}} %mainClosestHit
+// CHECK_CLOSESTHIT: OpDecorate %[[VAR:[a-zA-Z0-9_]+]] BuiltIn PrimitiveId
+// CHECK_CLOSESTHIT: %[[VAR]] = OpVariable %_ptr_Input_int Input
+[shader("closesthit")]
+void mainClosestHit(inout Payload payload, in Attributes attr, uint primitiveId: SV_PrimitiveID)
+{
+    payload.hitValue.x = primitiveId;
+}


### PR DESCRIPTION
Fixes #11197

## Motivation

GLSL_EXT_ray_tracing allows `gl_PrimitiveID` as an input in the intersection, any-hit, and closest-hit stages, but Slang rejects the equivalent `SV_PrimitiveID` input. Consider this example (the reproducer from #11197):

```slang
struct Attributes {}

[shader("intersection")]
void main(int primitiveId : SV_PrimitiveID) {
    Attributes attr = {};
    ReportHit<Attributes>(1, 0, attr);
}
```

Compiling this to SPIR-V fails with:

```
error[E30702]: system value semantic 'SV_PrimitiveID' cannot be used as input in 'intersection' shader stage
```

The only workaround is the `PrimitiveIndex()` intrinsic, which maps to the same value but is hard to discover for users porting GLSL ray-tracing shaders that read `gl_PrimitiveID`.

## Proposed solution

Fixing the reported error exposed two more issues cascading behind it; each is fixed at the layer that produces the wrong representation, so no consumer needs to patch around it:

1. **Front-end validation** (the reported E30702): the `sv_primitiveid` semantic declaration in `core.meta.slang` is the source of truth for which stages may read a system value. Its `get` accessor only listed the rasterization stages, so the fix is to extend it with `[require(intersection)]`, `[require(anyhit)]`, and `[require(closesthit)]` — exactly the three stages where GLSL_EXT_ray_tracing permits `gl_PrimitiveID`. Stages with no current primitive (raygeneration, miss, callable) remain rejected.

2. **Parameter binding** (cascading E39018): entry-point layout interpreted *every* ray-tracing entry-point parameter as a payload/hit-attributes parameter by direction and position, before the system-value classification could run. The fix teaches the ray-tracing interpretation that a parameter carrying an ordinary system-value semantic is not a ray-tracing-role parameter; it takes the regular system-value layout path that every other stage already uses.

3. **GLSL/SPIR-V legalization** (invalid SPIR-V): the ray-tracing entry-point legalization turned every varying parameter into a plain global parameter (correct for payload/attributes, wrong for system values — it produced a `Private`-storage variable decorated `BuiltIn PrimitiveId`, which fails SPIR-V validation). The fix routes system-value parameters through the standard varying-input legalization, which maps them to a proper `Input`-class builtin — the same machinery a fragment-shader `SV_PrimitiveID` input uses.

With all three fixes, the downstream SPIR-V emitter needs no changes: `maybeEmitSystemVal` (slang-emit-spirv.cpp:7624) already maps `sv_primitiveid` to `BuiltIn PrimitiveId` and already exempts the intersection/any-hit/closest-hit stages from the `Geometry` capability requirement, so the emit side had anticipated this input all along.

## Change summary

| File | Change |
| --- | --- |
| `source/slang/core.meta.slang` | Added `[require(intersection)]`, `[require(anyhit)]`, `[require(closesthit)]` to the `get : uint` accessor of `semantic sv_primitiveid`. |
| `source/slang/slang-parameter-binding.cpp` | New predicate `isRayTracingPayloadOrAttributesParameter` gates the ray-tracing payload/attributes interpretation in `processEntryPointVaryingParameter`; extracted `isSystemValueSemanticName` so the `sv_`/`nv_` prefix rule has one source of truth (also used by `processSimpleEntryPointParameter`). |
| `source/slang/slang-ir-glsl-legalize.cpp` | `consolidateRayTracingParameters` skips parameters whose `IRVarLayout` carries a system-value semantic; the ray-tracing early-return in `legalizeEntryPointParameterForGLSL` lets those parameters continue to the standard varying-input path. |
| `tests/vkray/intersection-primitive-id.slang` | Positive test: all three stages read `SV_PrimitiveID`; checks SPIR-V `BuiltIn PrimitiveId` on an `Input`-storage-class variable and `gl_PrimitiveID` in GLSL output. |
| `tests/diagnostics/execution-model/sv-primitive-id-invalid-rt-stage.slang` | Negative test: `SV_PrimitiveID` input in a miss shader still produces E30702. |

## Concepts and vocabulary

- **Semantic accessor table**: system-value semantics are declared in `core.meta.slang` as `semantic sv_*` declarations whose `get`/`set` accessors carry `[require(stage)]` attributes; `validateSystemValueSemanticForType` (slang-check-shader.cpp) walks these accessors to decide whether a semantic is readable/writable in a given stage. This table — not the validation code — owns the per-stage policy.
- **Ray-tracing varying roles**: ray-tracing entry-point parameters are identified by direction and position, not by semantic: an `inout`/`out` parameter is the ray payload (or callable payload), an `in` parameter of a hit shader is the hit attributes. `SV_RayPayload` and `SV_IntersectionAttributes` are SV-prefixed semantics that *explicitly* mark these same roles (see `tests/spirv/c-layout-buffer-2.slang`).
- **System-value layout**: `processSimpleEntryPointParameter` gives a system-value parameter a layout that consumes no varying location slots and records the semantic in `varLayout->systemValueSemantic`, which lowers to `IRSystemValueSemanticAttr` on the parameter's `IRVarLayout`.

## Process report

**Change 1 — `core.meta.slang` accessor stages (the reported error).**
`validateSystemValueSemanticForType` (slang-check-shader.cpp:116) looks up `semantic sv_primitiveid` and walks its accessors; for each `get` accessor it checks the merged `[require(...)]` capability set against the entry point's stage via `capabilitySet->isIncompatibleWith(getAtomFromStage(stage))`. The accessor listed only `fragment`, `geometry`, `hull`, and `domain`, so for an intersection shader no accessor matched and the E30702 diagnostic fired. The `intersection`/`anyhit`/`closesthit` capability aliases (slang-capabilities.capdef:1476-1484) expand to the `_intersection`/`_anyhit`/`_closesthit` stage atoms joined with the `raytracing` targets, so adding those three `[require(...)]` attributes makes the stage check pass exactly where the GLSL spec allows `gl_PrimitiveID`. The reproducer declares `int` while the accessor declares `uint`; `isSemanticTypeCompatible` (slang-check-shader.cpp:78) accepts this because `int` coerces to `uint` with matching scalar shape. No new stage is opened for writing (`set` remains geometry/mesh), and a new diagnostic test pins that miss/raygeneration inputs still fail.

**Change 2 — parameter binding (cascading E39018).**
With change 1 alone, the reproducer fails with `error[E39018]: the 'intersection' stage does not support 'in' entry point parameters`. The producer is `processEntryPointVaryingParameter` (slang-parameter-binding.cpp): for ray-tracing stages it classifies parameters by direction — input in a hit shader becomes hit attributes, input in intersection/raygeneration/miss/callable is diagnosed, output becomes payload — and this runs *before* `processSimpleEntryPointParameter` ever sees the `SV_` prefix.

Input-shape check: is "an entry-point parameter with a system-value semantic in a ray-tracing stage" a shape this branch should claim? No. The ray-tracing interpretation exists to assign the payload/attributes *roles*, which are marked either implicitly (no semantic, or a user semantic, resolved by direction and position) or explicitly by `SV_RayPayload`/`SV_IntersectionAttributes`. A parameter carrying any *other* system-value semantic is a builtin input, and the per-stage policy for builtins is already owned by the accessor table from change 1. So the correct producer-side fix is for the layout code to leave such parameters to the regular system-value path — not for any downstream consumer to undo a payload/attributes misclassification.

The new `isRayTracingPayloadOrAttributesParameter` encodes exactly that rule and gates the existing if/else. Behavior is unchanged for every previously-accepted program: parameters without semantics or with user semantics keep the ray-tracing path (e.g. `tests/diagnostics/execution-model/stage-incompatible-out-param.slang`, where `out float3 x : MY_SEMANTIC` in an intersection shader still produces E39017), and `SV_RayPayload`/`SV_IntersectionAttributes` keep it too (e.g. `tests/spirv/c-layout-buffer-2.slang`). Non-ray-tracing stages are unaffected because both gated switches were no-ops for them. The `sv_`/`nv_` prefix test previously appeared inline in `processSimpleEntryPointParameter`; it is extracted into `isSystemValueSemanticName` so the classification rule lives in one place.

**Change 3 — GLSL/SPIR-V legalization (invalid SPIR-V).**
With changes 1 and 2, compilation succeeds but SPIR-V validation fails: `Vulkan spec allows BuiltIn PrimitiveId to be only used for variables with Input or Output storage class ... uses storage class Private`, and the GLSL target emits a bare `uint primitiveId_0;` global instead of `gl_PrimitiveID`. The producer is the ray-tracing branch of the GLSL legalization pass: `consolidateRayTracingParameters` (slang-ir-glsl-legalize.cpp:3118) claims every varying parameter of a ray-tracing entry point and hands it to `handleSingleParam`, which creates a *plain* global parameter — correct for payload/attributes (their storage classes come from their own decorations) but wrong for a system value, which needs the builtin mapping. Meanwhile `legalizeEntryPointParameterForGLSL` early-returns for ray-tracing stages, so the standard varying path — `createGLSLGlobalVaryings`, whose `getGLSLSystemValueInfo` (slang-ir-glsl-legalize.cpp:730) maps `sv_primitiveid` to `gl_PrimitiveID` with required type `int` and an `Input`-class builtin variable — never runs.

Input-shape check: same answer as change 2, applied at the IR layer. The canonical representation of a system-value input is the varying layout with `IRSystemValueSemanticAttr` produced by parameter binding; the ray-tracing consolidation should not rewrite it into a plain global. Both edits consult that existing attribute (`paramLayout->findSystemValueSemanticAttr()`) rather than re-deriving anything: the consolidation skips such parameters, and the early-return lets them continue into the same default varying-input path a fragment-shader `SV_PrimitiveID` input takes. After this, the SPIR-V emitter's existing `maybeEmitSystemVal` handling produces `%gl_PrimitiveID = OpVariable %_ptr_Input_int Input` decorated `BuiltIn PrimitiveId`, and validation passes; the GLSL target emits `gl_PrimitiveID` with the int→uint adaptation.

**Target notes.**
- CUDA/OptiX: the reproducer is rejected by a pre-existing capability diagnostic on `ReportHit` (E36107) independent of this change; `PrimitiveIndex()` → `optixGetPrimitiveIndex` remains the OptiX route.
- HLSL/DXIL: DXR forbids extra entry-point parameters, and Slang emits the parameter as-is (DXC rejects it downstream). This matches the existing behavior of Khronos-only semantics such as `SV_PointCoord` and `SV_DrawIndex` on D3D targets. Legalizing ray-tracing system-value parameters into `PrimitiveIndex()` calls on D3D would require a varying-parameter legalization pass for HLSL, which does not exist today; left as a follow-up.

**Validation.** Full `slang-test` run: 11150/11151 passed; the one failure (`tests/dispatcher/smoke.slang`) was a local build-scope artifact (the `slang` dispatcher binary had not been built) and passes after building it.
