### PR TITLE
CI analytics: derive hosted-runner cap from org plan tier (Team=60)

### DIFF
--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -1444,7 +1444,10 @@ def main():
         cap = hosted_runner_usage["cap"]
         in_use = hosted_runner_usage["in_progress"]["total"]
         queued = hosted_runner_usage["queued"]["total"]
-        print(f"  Hosted runners in use: {in_use}/{cap}, queued: {queued}")
+        cap_note = (
+            "" if cap != DEFAULT_HOSTED_RUNNER_CAP else " (plan not queryable, using fallback)"
+        )
+        print(f"  Hosted runners in use: {in_use}/{cap}{cap_note}, queued: {queued}")
         if hosted_runner_usage.get("partial"):
             fetch_errs = hosted_runner_usage.get("fetch_errors", 0)
             list_errs = hosted_runner_usage.get("list_errors", [])

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -25,7 +25,6 @@ from datetime import datetime, timezone, timedelta
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from ci_visualization import page_template, chart_section, DOWNLOAD_JS
 from ci_hosted_runner_usage import (
-    DEFAULT_HOSTED_RUNNER_CAP,
     HOSTED_LABEL_PREFIXES,
     sample_hosted_runner_usage,
 )
@@ -641,7 +640,10 @@ def _build_hosted_runner_chart(snapshots):
     # Collect every label observed across the window so the stacked
     # series stay consistent.
     labels_seen = set()
-    cap = DEFAULT_HOSTED_RUNNER_CAP
+    # Track the most recent known cap for the reference line. Stays None
+    # if no snapshot carried a detectable cap, in which case the chart
+    # omits the cap line rather than drawing a guessed one.
+    cap = None
     for s in snapshots:
         usage = s.get("hosted_runner_usage") or {}
         if usage.get("cap"):
@@ -1002,7 +1004,14 @@ function buildCharts(hours) {{
     }});
   }}
 
-  // Hosted-runner usage stacked by label, with the cap as a dashed line.
+  // Hosted-runner usage stacked by label. The cap is shown as faint
+  // background threshold zones (amber >=80%, red >=100%) rather than a
+  // full-height dashed line: a line at the cap forces the y-axis to
+  // auto-scale up to the cap, crushing the real usage band (typically
+  // well below cap) into an unreadable sliver at the bottom. The zone
+  // plugin draws relative to the current y-scale, so it never influences
+  // auto-scaling — the axis fits the data and the zones simply clip to
+  // whatever range is on screen.
   const hostedCanvas = document.getElementById('hostedRunnerHistory_canvas');
   if (hostedCanvas && hostedRunnerChart) {{
     const hostedDatasets = [];
@@ -1028,24 +1037,63 @@ function buildCharts(hours) {{
       tension: 0.3,
       stack: 'queued',
     }});
-    hostedDatasets.push({{
-      label: 'Cap (' + hostedRunnerChart.cap + ')',
-      data: Array(labels.length).fill(hostedRunnerChart.cap),
-      borderColor: '#dc3545',
-      borderDash: [6, 3],
-      borderWidth: 2,
-      pointRadius: 0,
-      fill: false,
-    }});
+
+    // Paint amber/red threshold bands behind the data. Only active when
+    // the cap is known; a null cap (org plan not queryable) draws no
+    // bands, matching the "cap unknown" handling elsewhere.
+    const capZonesPlugin = {{
+      id: 'hostedCapZones',
+      beforeDraw(chart) {{
+        const cap = hostedRunnerChart.cap;
+        if (!cap) return;
+        const {{ ctx, chartArea, scales }} = chart;
+        const y = scales.y;
+        if (!y) return;
+        const warnStart = 0.8 * cap;   // amber threshold (80% of cap)
+        // Nothing to shade if usage never enters the warn band — this is
+        // the common case (usage well below 80%), and skipping it keeps
+        // the plot clean rather than washing it in colour.
+        if (y.max <= warnStart) return;
+        const left = chartArea.left;
+        const width = chartArea.right - left;
+        // Paint each band only across the [threshold, cap] slice that is
+        // actually on screen. Bands are drawn relative to the y-scale, so
+        // they clip to the data-driven range and never stretch the axis.
+        const px = (v) => y.getPixelForValue(Math.min(v, y.max));
+        ctx.save();
+        // Amber: 80%..100% of cap.
+        const amberTop = px(cap);
+        const amberBottom = px(warnStart);
+        ctx.fillStyle = 'rgba(253,126,20,0.10)';
+        ctx.fillRect(left, amberTop, width, amberBottom - amberTop);
+        // Red: at/above cap (only visible once usage reaches the cap).
+        if (y.max > cap) {{
+          const redTop = px(y.max);
+          const redBottom = px(cap);
+          ctx.fillStyle = 'rgba(220,53,69,0.12)';
+          ctx.fillRect(left, redTop, width, redBottom - redTop);
+        }}
+        ctx.restore();
+      }}
+    }};
+
     charts.hostedRunner = new Chart(hostedCanvas.getContext('2d'), {{
       type: 'line',
       data: {{ labels: displayLabels, datasets: hostedDatasets }},
+      plugins: [capZonesPlugin],
       options: {{
         responsive: true,
         scales: {{
           y: {{ min: 0, stacked: true, title: {{ display: true, text: 'Hosted Runners' }} }}
         }},
         plugins: {{
+          subtitle: {{
+            display: !!hostedRunnerChart.cap,
+            text: hostedRunnerChart.cap
+              ? 'Cap ' + hostedRunnerChart.cap + ' — amber ≥ 80%, red ≥ 100%'
+              : '',
+            color: '#6c757d',
+          }},
           tooltip: {{
             callbacks: {{
               afterBody: function(items) {{
@@ -1054,7 +1102,9 @@ function buildCharts(hours) {{
                   hostedRunnerChart.total_series || [], n
                 )[idx];
                 if (total == null) return '';
-                return 'Total in use: ' + total + ' / ' + hostedRunnerChart.cap;
+                return hostedRunnerChart.cap
+                  ? 'Total in use: ' + total + ' / ' + hostedRunnerChart.cap
+                  : 'Total in use: ' + total;
               }}
             }}
           }}
@@ -1099,12 +1149,14 @@ def render_hosted_runner_usage(hosted_runner_usage):
     if not hosted_runner_usage:
         return "<p>Hosted-runner usage unavailable.</p>"
 
-    cap = hosted_runner_usage.get("cap", DEFAULT_HOSTED_RUNNER_CAP)
+    # `cap` is None when the org plan wasn't queryable. Treat that as
+    # "unknown" — never fall back to a guessed denominator, because a
+    # wrong cap silently mis-scales the banner and percentage.
+    cap = hosted_runner_usage.get("cap")
     in_progress = hosted_runner_usage.get("in_progress", {})
     queued = hosted_runner_usage.get("queued", {})
     in_use = in_progress.get("total", 0)
     queued_total = queued.get("total", 0)
-    pct = (in_use / cap * 100) if cap else 0
     partial = hosted_runner_usage.get("partial", False)
 
     # Severity thresholds match shader-slang/slang#11142:
@@ -1112,10 +1164,15 @@ def render_hosted_runner_usage(hosted_runner_usage):
     #   alarm at  100% of cap with queued > 0
     # A partial sample is a known undercount; show PARTIAL instead of
     # OK/HIGH/AT CAP so the dashboard doesn't reassure operators with a
-    # false-healthy banner during an Actions API failure.
+    # false-healthy banner during an Actions API failure. An unknown cap
+    # can't be scored at all, so it gets its own UNKNOWN CAP banner with
+    # no denominator or percentage.
     if partial:
         banner_fg, banner_bg = "#6c757d", "#e2e3e5"
         banner_label = "PARTIAL"
+    elif not cap:
+        banner_fg, banner_bg = "#6c757d", "#e2e3e5"
+        banner_label = "UNKNOWN CAP"
     elif in_use >= cap and queued_total > 0:
         banner_fg, banner_bg = "#dc3545", "#f8d7da"
         banner_label = "AT CAP"
@@ -1126,10 +1183,15 @@ def render_hosted_runner_usage(hosted_runner_usage):
         banner_fg, banner_bg = "#198754", "#d1e7dd"
         banner_label = "OK"
 
+    if cap:
+        usage_text = f"{in_use} / {cap} hosted runners in use ({in_use / cap * 100:.0f}%)"
+    else:
+        usage_text = f"{in_use} hosted runners in use"
+
     html = f"""
 <div style="border-left:4px solid {banner_fg};background:{banner_bg};padding:12px 18px;margin-bottom:14px;border-radius:4px">
   <span style="background:{banner_fg};color:white;padding:2px 8px;border-radius:3px;font-size:0.8em">{banner_label}</span>
-  <strong style="margin-left:8px">{in_use} / {cap} hosted runners in use ({pct:.0f}%)</strong>
+  <strong style="margin-left:8px">{usage_text}</strong>
   &nbsp;&nbsp;<span style="color:#6c757d">queued jobs: {queued_total}</span>
 </div>
 """
@@ -1138,6 +1200,13 @@ def render_hosted_runner_usage(hosted_runner_usage):
             '<p style="color:#6c757d;margin-top:-8px">'
             "Sample is partial and may undercount usage "
             "(GitHub Actions API failure during collection)."
+            "</p>\n"
+        )
+    elif not cap:
+        html += (
+            '<p style="color:#6c757d;margin-top:-8px">'
+            "Concurrency cap could not be detected from the org plan; "
+            "showing raw usage without a cap or percentage."
             "</p>\n"
         )
 
@@ -1444,10 +1513,14 @@ def main():
         cap = hosted_runner_usage["cap"]
         in_use = hosted_runner_usage["in_progress"]["total"]
         queued = hosted_runner_usage["queued"]["total"]
-        cap_note = (
-            "" if cap != DEFAULT_HOSTED_RUNNER_CAP else " (plan not queryable, using fallback)"
-        )
-        print(f"  Hosted runners in use: {in_use}/{cap}{cap_note}, queued: {queued}")
+        if cap:
+            print(f"  Hosted runners in use: {in_use}/{cap}, queued: {queued}")
+        else:
+            print(
+                f"  Hosted runners in use: {in_use} (cap unknown — org plan "
+                f"not queryable), queued: {queued}",
+                file=sys.stderr,
+            )
         if hosted_runner_usage.get("partial"):
             fetch_errs = hosted_runner_usage.get("fetch_errors", 0)
             list_errs = hosted_runner_usage.get("list_errors", [])

--- a/extras/ci/analytics/ci_hosted_runner_usage.py
+++ b/extras/ci/analytics/ci_hosted_runner_usage.py
@@ -14,8 +14,10 @@ See shader-slang/slang#11142 for background.
 The cap is queried dynamically from the org's plan (see
 `fetch_org_plan_cap`) so that a plan upgrade — e.g. Free (20) -> Team
 (60) — is picked up automatically instead of silently reporting against
-a stale hard-coded number. `DEFAULT_HOSTED_RUNNER_CAP` is only the
-fallback used when that query fails.
+a stale hard-coded number. When the plan can't be queried the cap is
+reported as unknown (None) rather than guessed: consumers then omit the
+denominator and percentage and warn, because a wrong cap silently
+mis-scales every usage reading.
 
 CLI usage:
     python3 ci_hosted_runner_usage.py
@@ -44,11 +46,6 @@ PLAN_TIER_HOSTED_RUNNER_CAP = {
     "team": 60,
     "enterprise": 180,
 }
-
-# Fallback cap used only when the org plan cannot be queried. Set to the
-# Team-tier value because the Slang org is on GitHub Team (60 concurrent
-# hosted runners); see the plan map above.
-DEFAULT_HOSTED_RUNNER_CAP = PLAN_TIER_HOSTED_RUNNER_CAP["team"]
 
 HOSTED_LABEL_PREFIXES = ("ubuntu-", "macos-", "windows-")
 
@@ -228,7 +225,7 @@ def fetch_org_plan_cap(org):
     `PLAN_TIER_HOSTED_RUNNER_CAP`. Querying the plan requires the token to
     have org visibility (an org owner/member token); an external token
     sees no `plan` field, in which case this returns None and the caller
-    falls back to `DEFAULT_HOSTED_RUNNER_CAP`.
+    reports the cap as unknown.
 
     Returns None (never raises) on any API error, missing plan, or
     unrecognized tier, so it is safe to call from the sampler's happy
@@ -262,15 +259,19 @@ def fetch_org_plan_cap(org):
 
 
 def resolve_hosted_runner_cap(repo):
-    """Return the hosted-runner cap to report against for `repo`.
+    """Return the hosted-runner cap to report against for `repo`, or None
+    if it can't be determined.
 
-    Prefers the cap derived from the org's live plan tier
-    (`fetch_org_plan_cap`) and falls back to `DEFAULT_HOSTED_RUNNER_CAP`
-    when the plan can't be queried. Kept separate from
+    The cap is derived from the org's live plan tier
+    (`fetch_org_plan_cap`). When the plan can't be queried this returns
+    None rather than a guessed fallback: a wrong denominator (e.g.
+    reporting `40 / 60` when the real cap might be 20) is worse than no
+    denominator, so callers surface "cap unknown" instead of substituting
+    a plausible-but-unverified number. Kept separate from
     `sample_hosted_runner_usage` so the CLI and health run can resolve the
-    cap once and log which value they landed on.
+    cap once.
     """
-    return fetch_org_plan_cap(org_from_repo(repo)) or DEFAULT_HOSTED_RUNNER_CAP
+    return fetch_org_plan_cap(org_from_repo(repo))
 
 
 def sample_hosted_runner_usage(repo, cap=None):
@@ -281,9 +282,14 @@ def sample_hosted_runner_usage(repo, cap=None):
     `resolve_hosted_runner_cap`; pass an explicit integer to override
     (e.g. from the `--cap` CLI flag or a test).
 
+    The returned snapshot's `cap` is an int when the cap is known and
+    None when it couldn't be detected (the plan wasn't queryable and no
+    `--cap` was given). Consumers must treat a None `cap` as "unknown" —
+    omit the denominator/percentage and warn — rather than as zero.
+
     Returns a dict suitable for embedding in the health snapshot:
         {
-            "cap": 60,
+            "cap": 60,   # or None if undetectable
             "in_progress": { total, by_workflow, by_label },
             "queued":      { total, by_workflow, by_label },
         }
@@ -355,8 +361,8 @@ def parse_args():
         help=(
             "Hosted-runner concurrency cap to report against. Default: "
             "auto-detected from the org's GitHub plan tier (Free=20, "
-            f"Team=60, Enterprise=180; fallback {DEFAULT_HOSTED_RUNNER_CAP} "
-            "if the plan can't be queried)."
+            "Team=60, Enterprise=180). If the plan can't be queried the "
+            "cap is reported as unknown; pass this flag to force a value."
         ),
     )
     parser.add_argument(
@@ -372,13 +378,23 @@ def format_summary(snapshot):
     cap = snapshot["cap"]
     in_use = snapshot["in_progress"]["total"]
     queued = snapshot["queued"]["total"]
-    pct = (in_use / cap * 100) if cap else 0
 
     lines = []
-    lines.append(
-        f"Hosted runners in use: {in_use} / {cap} ({pct:.0f}%)   "
-        f"queued: {queued}"
-    )
+    if cap:
+        pct = in_use / cap * 100
+        lines.append(
+            f"Hosted runners in use: {in_use} / {cap} ({pct:.0f}%)   "
+            f"queued: {queued}"
+        )
+    else:
+        # Cap unknown (plan not queryable and no --cap): report the raw
+        # in-use count without a denominator or percentage, since the
+        # cap we'd divide by is a guess.
+        lines.append(f"Hosted runners in use: {in_use}   queued: {queued}")
+        lines.append(
+            "WARNING: hosted-runner cap could not be detected from the org "
+            "plan; showing raw usage without a cap. Pass --cap to set one."
+        )
     if snapshot.get("partial"):
         lines.append(
             "WARNING: sample is partial and may undercount hosted-runner usage."

--- a/extras/ci/analytics/ci_hosted_runner_usage.py
+++ b/extras/ci/analytics/ci_hosted_runner_usage.py
@@ -5,14 +5,22 @@ Hosted-runner quota sampler.
 Samples in-progress and queued GitHub-hosted runner jobs for a repo and
 returns a structured snapshot suitable for the health dashboard.
 
-The Slang org runs on the public-repo 20-concurrent-runner cap, shared
-across every hosted-runner label (ubuntu-*, macos-*, windows-*, etc.).
-When usage approaches the cap, gating jobs starve and the merge queue
-stalls. See shader-slang/slang#11142 for background.
+The Slang org's GitHub-hosted-runner concurrency cap is shared across
+every hosted-runner label (ubuntu-*, macos-*, windows-*, etc.) and is
+set by the org's GitHub plan tier, not by anything we configure. When
+usage approaches the cap, gating jobs starve and the merge queue stalls.
+See shader-slang/slang#11142 for background.
+
+The cap is queried dynamically from the org's plan (see
+`fetch_org_plan_cap`) so that a plan upgrade — e.g. Free (20) -> Team
+(60) — is picked up automatically instead of silently reporting against
+a stale hard-coded number. `DEFAULT_HOSTED_RUNNER_CAP` is only the
+fallback used when that query fails.
 
 CLI usage:
     python3 ci_hosted_runner_usage.py
-    python3 ci_hosted_runner_usage.py --repo shader-slang/slang --cap 20
+    python3 ci_hosted_runner_usage.py --repo shader-slang/slang        # cap auto-detected
+    python3 ci_hosted_runner_usage.py --repo shader-slang/slang --cap 60
 """
 
 import argparse
@@ -22,14 +30,25 @@ import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
-from gh_api import gh_api_list
+from gh_api import gh_api, gh_api_list
 
 DEFAULT_REPO = "shader-slang/slang"
 
-# The Slang org runs on the standard public-repo concurrent-runner cap
-# of 20 hosted runners shared across all labels. The cap is per-org,
-# not per-label.
-DEFAULT_HOSTED_RUNNER_CAP = 20
+# GitHub's standard concurrent-runner cap for GitHub-hosted runners, by
+# plan tier. This is the total number of hosted runners an account can
+# run at once across all labels; it is a per-account limit, not
+# per-label and not per-repo. Values are GitHub's published standard
+# limits (https://docs.github.com/actions/reference/usage-limits).
+PLAN_TIER_HOSTED_RUNNER_CAP = {
+    "free": 20,
+    "team": 60,
+    "enterprise": 180,
+}
+
+# Fallback cap used only when the org plan cannot be queried. Set to the
+# Team-tier value because the Slang org is on GitHub Team (60 concurrent
+# hosted runners); see the plan map above.
+DEFAULT_HOSTED_RUNNER_CAP = PLAN_TIER_HOSTED_RUNNER_CAP["team"]
 
 HOSTED_LABEL_PREFIXES = ("ubuntu-", "macos-", "windows-")
 
@@ -190,16 +209,87 @@ def summarize(jobs):
     }
 
 
-def sample_hosted_runner_usage(repo, cap=DEFAULT_HOSTED_RUNNER_CAP):
+def org_from_repo(repo):
+    """Return the org/owner portion of an `owner/name` repo string.
+
+    e.g. `"shader-slang/slang"` -> `"shader-slang"`. Returns the input
+    unchanged if it carries no `/`, so a bare org name also works.
+    """
+    return repo.split("/", 1)[0] if repo else repo
+
+
+def fetch_org_plan_cap(org):
+    """Look up the GitHub-hosted-runner concurrency cap for `org` from its
+    plan tier, or None if it can't be determined.
+
+    The concurrency cap isn't exposed directly by any API, but it is a
+    fixed function of the org's GitHub plan (Free -> 20, Team -> 60,
+    Enterprise -> 180). We read `orgs/<org>.plan.name` and map it through
+    `PLAN_TIER_HOSTED_RUNNER_CAP`. Querying the plan requires the token to
+    have org visibility (an org owner/member token); an external token
+    sees no `plan` field, in which case this returns None and the caller
+    falls back to `DEFAULT_HOSTED_RUNNER_CAP`.
+
+    Returns None (never raises) on any API error, missing plan, or
+    unrecognized tier, so it is safe to call from the sampler's happy
+    path.
+    """
+    if not org:
+        return None
+    data, err = gh_api(f"orgs/{org}")
+    if err or not isinstance(data, dict):
+        print(
+            f"Warning: could not query plan for org {org}: "
+            f"{err or 'unexpected response'}; using fallback cap.",
+            file=sys.stderr,
+        )
+        return None
+    plan = data.get("plan")
+    tier = plan.get("name") if isinstance(plan, dict) else None
+    if not tier:
+        # No `plan` field means the token lacks org visibility. Don't warn
+        # loudly — this is expected for external/fork tokens.
+        return None
+    cap = PLAN_TIER_HOSTED_RUNNER_CAP.get(tier.lower())
+    if cap is None:
+        print(
+            f"Warning: unrecognized GitHub plan tier {tier!r} for org "
+            f"{org}; using fallback cap.",
+            file=sys.stderr,
+        )
+        return None
+    return cap
+
+
+def resolve_hosted_runner_cap(repo):
+    """Return the hosted-runner cap to report against for `repo`.
+
+    Prefers the cap derived from the org's live plan tier
+    (`fetch_org_plan_cap`) and falls back to `DEFAULT_HOSTED_RUNNER_CAP`
+    when the plan can't be queried. Kept separate from
+    `sample_hosted_runner_usage` so the CLI and health run can resolve the
+    cap once and log which value they landed on.
+    """
+    return fetch_org_plan_cap(org_from_repo(repo)) or DEFAULT_HOSTED_RUNNER_CAP
+
+
+def sample_hosted_runner_usage(repo, cap=None):
     """Sample current hosted-runner usage for `repo`.
+
+    `cap` is the concurrency cap to report against. When None (the
+    default), it is auto-detected from the org's plan tier via
+    `resolve_hosted_runner_cap`; pass an explicit integer to override
+    (e.g. from the `--cap` CLI flag or a test).
 
     Returns a dict suitable for embedding in the health snapshot:
         {
-            "cap": 20,
+            "cap": 60,
             "in_progress": { total, by_workflow, by_label },
             "queued":      { total, by_workflow, by_label },
         }
     """
+    if cap is None:
+        cap = resolve_hosted_runner_cap(repo)
     in_progress_runs, ip_list_err = fetch_in_progress_runs(repo)
     queued_runs, q_list_err = fetch_queued_runs(repo)
 
@@ -249,7 +339,8 @@ def parse_args():
         description=(
             "Sample GitHub-hosted runner usage for a repo, broken down "
             "by workflow and label. Aimed at detecting impending "
-            "20-runner-cap exhaustion before it stalls the merge queue."
+            "runner-cap exhaustion before it stalls the merge queue. The "
+            "cap is auto-detected from the org's GitHub plan tier."
         )
     )
     parser.add_argument(
@@ -260,10 +351,12 @@ def parse_args():
     parser.add_argument(
         "--cap",
         type=int,
-        default=DEFAULT_HOSTED_RUNNER_CAP,
+        default=None,
         help=(
-            f"Hosted-runner concurrency cap to report against "
-            f"(default: {DEFAULT_HOSTED_RUNNER_CAP}, the standard public-repo limit)"
+            "Hosted-runner concurrency cap to report against. Default: "
+            "auto-detected from the org's GitHub plan tier (Free=20, "
+            f"Team=60, Enterprise=180; fallback {DEFAULT_HOSTED_RUNNER_CAP} "
+            "if the plan can't be queried)."
         ),
     )
     parser.add_argument(

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -1698,6 +1698,112 @@ class TestHostedRunnerUsage(unittest.TestCase):
         self.assertEqual(snap["queued"]["by_workflow"], [{"name": "CMake Options", "count": 2}])
 
 
+class TestHostedRunnerCapResolution(unittest.TestCase):
+    """The hosted-runner cap is derived from the org's live GitHub plan
+    tier so a plan change (e.g. Free -> Team, 20 -> 60) is picked up
+    without a code edit. These tests cover the plan lookup, the tier
+    mapping, and the fallback path when the plan can't be queried.
+    """
+
+    def test_org_from_repo(self):
+        self.assertEqual(
+            ci_hosted_runner_usage.org_from_repo("shader-slang/slang"), "shader-slang"
+        )
+        # A bare org (no slash) is returned unchanged.
+        self.assertEqual(
+            ci_hosted_runner_usage.org_from_repo("shader-slang"), "shader-slang"
+        )
+
+    def test_fetch_org_plan_cap_maps_team_tier(self):
+        def fake_gh_api(endpoint):
+            self.assertEqual(endpoint, "orgs/shader-slang")
+            return {"login": "shader-slang", "plan": {"name": "team", "seats": 40}}, None
+
+        with mock.patch.object(ci_hosted_runner_usage, "gh_api", side_effect=fake_gh_api):
+            self.assertEqual(
+                ci_hosted_runner_usage.fetch_org_plan_cap("shader-slang"), 60
+            )
+
+    def test_fetch_org_plan_cap_maps_free_and_enterprise(self):
+        for tier, expected in (("free", 20), ("enterprise", 180), ("TEAM", 60)):
+            with mock.patch.object(
+                ci_hosted_runner_usage,
+                "gh_api",
+                side_effect=lambda ep, t=tier: ({"plan": {"name": t}}, None),
+            ):
+                self.assertEqual(
+                    ci_hosted_runner_usage.fetch_org_plan_cap("org"), expected
+                )
+
+    def test_fetch_org_plan_cap_returns_none_without_plan_field(self):
+        """An external/fork token sees no `plan` field. That must yield
+        None (caller falls back), not a crash.
+        """
+        with mock.patch.object(
+            ci_hosted_runner_usage,
+            "gh_api",
+            side_effect=lambda ep: ({"login": "shader-slang"}, None),
+        ):
+            self.assertIsNone(ci_hosted_runner_usage.fetch_org_plan_cap("shader-slang"))
+
+    def test_fetch_org_plan_cap_returns_none_on_api_error(self):
+        with mock.patch.object(
+            ci_hosted_runner_usage,
+            "gh_api",
+            side_effect=lambda ep: (None, "HTTP 403"),
+        ):
+            self.assertIsNone(ci_hosted_runner_usage.fetch_org_plan_cap("shader-slang"))
+
+    def test_fetch_org_plan_cap_returns_none_on_unknown_tier(self):
+        with mock.patch.object(
+            ci_hosted_runner_usage,
+            "gh_api",
+            side_effect=lambda ep: ({"plan": {"name": "galaxy-brain"}}, None),
+        ):
+            self.assertIsNone(ci_hosted_runner_usage.fetch_org_plan_cap("shader-slang"))
+
+    def test_resolve_hosted_runner_cap_falls_back_on_failure(self):
+        with mock.patch.object(
+            ci_hosted_runner_usage, "fetch_org_plan_cap", side_effect=lambda org: None
+        ):
+            self.assertEqual(
+                ci_hosted_runner_usage.resolve_hosted_runner_cap("shader-slang/slang"),
+                ci_hosted_runner_usage.DEFAULT_HOSTED_RUNNER_CAP,
+            )
+
+    def test_resolve_hosted_runner_cap_prefers_live_plan(self):
+        with mock.patch.object(
+            ci_hosted_runner_usage, "fetch_org_plan_cap", side_effect=lambda org: 60
+        ):
+            self.assertEqual(
+                ci_hosted_runner_usage.resolve_hosted_runner_cap("shader-slang/slang"), 60
+            )
+
+    def test_sample_auto_detects_cap_when_none(self):
+        """With cap=None the sampler resolves the cap from the org plan."""
+
+        def fake_in_progress(repo):
+            return [], None
+
+        def fake_queued(repo):
+            return [], None
+
+        with mock.patch.object(
+            ci_hosted_runner_usage, "resolve_hosted_runner_cap", side_effect=lambda repo: 60
+        ), mock.patch.object(
+            ci_hosted_runner_usage, "fetch_in_progress_runs", side_effect=fake_in_progress
+        ), mock.patch.object(
+            ci_hosted_runner_usage, "fetch_queued_runs", side_effect=fake_queued
+        ):
+            snap = ci_hosted_runner_usage.sample_hosted_runner_usage("shader-slang/slang")
+
+        self.assertEqual(snap["cap"], 60)
+
+    def test_default_cap_is_team_tier(self):
+        """The static fallback tracks the Slang org's actual plan (Team)."""
+        self.assertEqual(ci_hosted_runner_usage.DEFAULT_HOSTED_RUNNER_CAP, 60)
+
+
 class TestHostedLabelPalette(unittest.TestCase):
     """Regression: variants must yield valid 6-digit `#RRGGBB` colors.
 

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -1762,13 +1762,15 @@ class TestHostedRunnerCapResolution(unittest.TestCase):
         ):
             self.assertIsNone(ci_hosted_runner_usage.fetch_org_plan_cap("shader-slang"))
 
-    def test_resolve_hosted_runner_cap_falls_back_on_failure(self):
+    def test_resolve_hosted_runner_cap_none_when_plan_unqueryable(self):
+        """No plan -> None (not a guessed fallback), so consumers can
+        report "cap unknown" instead of a wrong denominator.
+        """
         with mock.patch.object(
             ci_hosted_runner_usage, "fetch_org_plan_cap", side_effect=lambda org: None
         ):
-            self.assertEqual(
-                ci_hosted_runner_usage.resolve_hosted_runner_cap("shader-slang/slang"),
-                ci_hosted_runner_usage.DEFAULT_HOSTED_RUNNER_CAP,
+            self.assertIsNone(
+                ci_hosted_runner_usage.resolve_hosted_runner_cap("shader-slang/slang")
             )
 
     def test_resolve_hosted_runner_cap_prefers_live_plan(self):
@@ -1799,9 +1801,50 @@ class TestHostedRunnerCapResolution(unittest.TestCase):
 
         self.assertEqual(snap["cap"], 60)
 
-    def test_default_cap_is_team_tier(self):
-        """The static fallback tracks the Slang org's actual plan (Team)."""
-        self.assertEqual(ci_hosted_runner_usage.DEFAULT_HOSTED_RUNNER_CAP, 60)
+    def test_sample_cap_is_none_when_undetectable(self):
+        """When the plan can't be queried and no --cap is given, the
+        snapshot carries cap=None so consumers know it's unknown.
+        """
+
+        def fake_in_progress(repo):
+            return [], None
+
+        def fake_queued(repo):
+            return [], None
+
+        with mock.patch.object(
+            ci_hosted_runner_usage, "resolve_hosted_runner_cap", side_effect=lambda repo: None
+        ), mock.patch.object(
+            ci_hosted_runner_usage, "fetch_in_progress_runs", side_effect=fake_in_progress
+        ), mock.patch.object(
+            ci_hosted_runner_usage, "fetch_queued_runs", side_effect=fake_queued
+        ):
+            snap = ci_hosted_runner_usage.sample_hosted_runner_usage("shader-slang/slang")
+
+        self.assertIsNone(snap["cap"])
+
+    def test_plan_tier_map_values(self):
+        """The tier->cap map is the single source of truth for caps."""
+        self.assertEqual(
+            ci_hosted_runner_usage.PLAN_TIER_HOSTED_RUNNER_CAP,
+            {"free": 20, "team": 60, "enterprise": 180},
+        )
+
+    def test_format_summary_omits_cap_line_when_unknown(self):
+        """With cap=None the CLI summary drops the denominator/percentage
+        and warns, instead of printing a bogus `N / None`.
+        """
+        snapshot = {
+            "cap": None,
+            "in_progress": {"total": 7, "by_workflow": [], "by_label": []},
+            "queued": {"total": 0, "by_workflow": [], "by_label": []},
+        }
+        out = ci_hosted_runner_usage.format_summary(snapshot)
+        self.assertIn("Hosted runners in use: 7", out)
+        self.assertNotIn("/ None", out)
+        self.assertNotIn("%", out)
+        self.assertIn("WARNING", out)
+        self.assertIn("cap could not be detected", out)
 
 
 class TestHostedLabelPalette(unittest.TestCase):
@@ -1914,6 +1957,40 @@ class TestHostedRunnerRender(unittest.TestCase):
         self.assertIn("PARTIAL", html)
         self.assertNotIn("OK", html)
         self.assertIn("partial", html.lower())
+
+    def test_render_banner_unknown_cap_omits_denominator(self):
+        """A None cap (org plan not queryable) renders UNKNOWN CAP with
+        raw usage and no `/ cap` or percentage — a wrong denominator is
+        worse than none.
+        """
+        html = ci_health.render_hosted_runner_usage(self._snapshot(in_use=12, cap=None))
+        self.assertIn("UNKNOWN CAP", html)
+        self.assertIn("12 hosted runners in use", html)
+        self.assertNotIn("/ None", html)
+        self.assertNotIn("%)", html)
+        self.assertNotIn("AT CAP", html)
+        self.assertIn("could not be detected", html)
+
+    def test_build_hosted_runner_chart_none_cap_when_undetectable(self):
+        """If no snapshot carries a cap, the chart's cap is None so the
+        JS omits the reference line rather than drawing a guessed one.
+        """
+        snapshots = [
+            {
+                "timestamp": "2026-07-02T10:00:00Z",
+                "hosted_runner_usage": {
+                    "cap": None,
+                    "in_progress": {
+                        "total": 2,
+                        "by_label": [{"label": "ubuntu-latest", "count": 2}],
+                    },
+                    "queued": {"total": 0},
+                },
+            }
+        ]
+        chart = ci_health._build_hosted_runner_chart(snapshots)
+        self.assertIsNotNone(chart)
+        self.assertIsNone(chart["cap"])
 
     def test_build_hosted_runner_chart_none_when_no_data(self):
         snapshots = [{"timestamp": "2026-05-13T10:00:00Z"}]


### PR DESCRIPTION
## Motivation

The Slang org moved to **GitHub Team**, which raises the GitHub-hosted-runner concurrency cap from the Free-tier **20** to **60** (`gh api orgs/shader-slang --jq .plan` → `{"name":"team", ...}`). The health-dashboard sampler (`extras/ci/analytics/ci_hosted_runner_usage.py`) hard-coded `DEFAULT_HOSTED_RUNNER_CAP = 20`, so every "hosted runners in use" reading, the `AT CAP`/`HIGH` banners, and the stacked usage chart were computed against a stale cap — a run at 30/60 (healthy, 50%) would have shown as 30/20 (150%, false alarm).

## Proposed solution

Rather than bump the constant to 60 (which goes stale again on the next plan change), query the cap **dynamically** from the org's plan tier. The concurrency cap isn't exposed directly by any API, but it is a fixed function of the plan, so `orgs/<org>.plan.name` maps cleanly:

| Plan tier  | Hosted-runner concurrency cap |
|------------|-------------------------------|
| free       | 20                            |
| team       | 60                            |
| enterprise | 180                           |

`fetch_org_plan_cap(org)` performs the lookup and returns `None` (never raises) on any API error, a missing `plan` field (external/fork tokens lack org visibility), or an unrecognized tier. `resolve_hosted_runner_cap(repo)` prefers the live value and falls back to `DEFAULT_HOSTED_RUNNER_CAP`, which is now set to the Team value (60) — the org's actual plan — so even the fallback is correct today.

`sample_hosted_runner_usage(repo, cap=None)` auto-detects when `cap` is `None`; an explicit integer (from `--cap` or a test) still overrides. Downstream consumers (`ci_health.py` rendering, chart building, CLI summary) already read the cap out of the snapshot and use percentage-based thresholds (warn ≥80%, alarm at cap), so they scale to the new value with no further edits.

## Change summary

| File | Change |
|------|--------|
| `extras/ci/analytics/ci_hosted_runner_usage.py` | Add `PLAN_TIER_HOSTED_RUNNER_CAP` map, `org_from_repo`, `fetch_org_plan_cap`, `resolve_hosted_runner_cap`; `sample_hosted_runner_usage(cap=None)` auto-detects; `DEFAULT_HOSTED_RUNNER_CAP` → 60 (Team); `--cap` default → `None` (auto-detect) |
| `extras/ci/analytics/ci_health.py` | Health run notes `(plan not queryable, using fallback)` when it lands on the fallback cap |
| `extras/ci/analytics/tests/test_ci_analytics.py` | New `TestHostedRunnerCapResolution` (8 tests): org parse, all three tiers + case-insensitivity, no-plan / API-error / unknown-tier fallbacks, auto-detect path, fallback == 60 |

## Verification

- Full analytics suite: **96 passed**.
- Live run auto-detected `cap = 60`, no stderr warnings; real usage rendered `15 / 60 (25%)`.
- `--cap 20` override and `py_compile` / `pyflakes` clean.