### PR TITLE
ci-analytics: fix stale hosted-runner chart caption

### DIFF
--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -843,7 +843,9 @@ def build_history_chart(snapshots):
             "hostedRunnerHistory",
             "GitHub-Hosted Runner Usage vs. Cap",
             "Hosted runners in use (stacked by label) and queued hosted-runner jobs, "
-            "sampled every 15 minutes. Dashed line shows the per-org concurrency cap.",
+            "sampled every 15 minutes. Amber/red background bands mark 80%/100% of the "
+            "per-org concurrency cap (auto-detected from the org plan); no bands are "
+            "shown when the cap can't be detected.",
         )
 
     return f"""


### PR DESCRIPTION
## Motivation

PR #11895 (derive hosted-runner cap from org plan tier) reworked the "GitHub-Hosted Runner Usage vs. Cap" chart in `ci_health.py`. Its follow-up commit replaced the full-height **dashed cap line** with amber/red **threshold background bands** (80%/100% of the cap), drawn via the `hostedCapZones` Chart.js plugin, and drawing no bands at all when the cap can't be detected from the org plan.

The chart's caption was not updated to match. It still reads:

> "…sampled every 15 minutes. Dashed line shows the per-org concurrency cap."

So the caption describes a UI element (a dashed line) that the same PR removed. This is misleading to anyone reading the deployed health dashboard.

## Proposed solution

Update the caption to describe what the chart actually renders: amber/red bands at 80%/100% of the per-org concurrency cap, the cap being auto-detected from the org plan, and no bands when the cap is undetectable. This keeps the documentation consistent with the rendering code (`hostedCapZones` plugin) and with the "cap unknown" handling used elsewhere in the file.

Doc-only change; no behavior change.

## Change summary

| File | Change |
|---|---|
| `extras/ci/analytics/ci_health.py` | Rewrite the hosted-runner chart caption to describe the amber/red threshold bands and auto-detected cap instead of the removed dashed line. |

## Concepts and vocabulary

- **`hostedCapZones`** — the Chart.js `beforeDraw` plugin that paints the amber (≥80% of cap) and red (≥100% of cap) background bands relative to the y-scale. It replaced the old dashed cap line (which forced the y-axis up to the cap and crushed the real usage band into a sliver).
- **Cap unknown** — when the org plan can't be queried, `hosted_runner_usage.cap` is `None`; the plugin draws no bands, matching the rest of the file's "unknown cap" treatment.

## Process report

The only change is the caption string passed to `chart_section(...)` for the `hostedRunnerHistory` chart. The prior text was left stale by #11895 when the dashed line was removed in favor of the `hostedCapZones` bands; the new text is a faithful description of the current rendering path (the `capZonesPlugin` in the inline chart script), including its no-bands-when-cap-unknown behavior. The two other "dashed line" references in the file (lines ~836 and ~972) belong to the GPU-quota chart, which legitimately still draws a dashed quota line, and are intentionally left unchanged.