### PR TITLE
Fix latent stack-use-after-scope in USE_RIFF IR serialization path

### DIFF
--- a/source/slang/slang-serialize-ir.cpp
+++ b/source/slang/slang-serialize-ir.cpp
@@ -786,8 +786,8 @@ void writeSerializedModuleIR(
 
 #if USE_RIFF
     {
-        RIFFSerialWriter writer(cursor.getCurrentChunk());
         IRSerialWriteContext context{sourceLocWriter};
+        RIFFSerialWriter writer(cursor.getCurrentChunk());
         IRWriteSerializer serializer(&writer, &context);
         serialize(serializer, moduleInfo);
     }


### PR DESCRIPTION
## Motivation

An external report flagged an ASAN `stack-use-after-scope` in `writeSerializedModuleIR` (`source/slang/slang-serialize-ir.cpp`) during IR serialization. On current `master` the crash no longer reproduces on the active code path — the reporter was on a Slang version predating #10354 — but the inactive `USE_RIFF` branch of the same function still contains the identical latent bug:

```cpp
#if USE_RIFF
    {
        RIFFSerialWriter writer(cursor.getCurrentChunk());
        IRSerialWriteContext context{sourceLocWriter};   // destroyed BEFORE writer
        IRWriteSerializer serializer(&writer, &context);
        serialize(serializer, moduleInfo);
    }
```

Locals are destroyed in reverse declaration order, so `context` dies before `writer` — yet `~RIFFSerialWriter` still calls back into `context` (trace below), reading a destroyed stack object.

## Proposed solution

Declare `IRSerialWriteContext context` before `RIFFSerialWriter writer` so the context outlives the writer. This is the same fix #10354 applied to the active Fossil (`#else`) branch of this function, restoring symmetry between the two branches. Reordering the declarations fixes the object-lifetime contract itself rather than papering over the callback mechanism.

## Change summary

- `source/slang/slang-serialize-ir.cpp` (`writeSerializedModuleIR`): swap the declaration order of `context` and `writer` in the `USE_RIFF` branch so destruction runs `~serializer`, `~writer` (which flushes deferred callbacks into `context`), then `~context`.

## Process report

The full producer-to-consumer trace of the dangling pointer:

1. `serialize(serializer, moduleInfo)` reaches shared pointers (e.g. the `IRModule*`) via `serializeSharedPtr` (`slang-serialize.h`), which calls `serializer->handleSharedPtr(value, _serializeObjectCallback<S,T>, serializer.getContext())` — the stored `context` argument is the address of the stack-allocated `IRSerialWriteContext`.
2. `RIFFSerialWriter::handleSharedPtr` (`slang-serialize-riff.cpp`) intentionally does not invoke the callback immediately (to avoid unbounded recursion on long pointer chains); it queues `ObjectInfo{ptr, callback, context}` into `_objects` for later processing in `_flush()`.
3. `_flush()` runs only from `~RIFFSerialWriter()` (`slang-serialize-riff.cpp:23`), draining the queue and invoking each callback, which lands in `IRSerialWriteContext::handleIRModule` (`slang-serialize-ir.cpp:752`) — a virtual call on the already-destroyed `context`.

Input-shape check: the deferred-flush design of `RIFFSerialWriter` is intentional and correct (documented in `handleSharedPtr`); the bug is purely the caller violating the implied lifetime requirement that the serialization context outlive the writer. Fixing the declaration order at the call site is therefore the right layer — no changes to the serializer are warranted.

Note: `USE_RIFF` is currently `0` (`slang-serialize-ir.cpp:23`), so this branch is compiled out and the fix is latent-only; the active Fossil branch already has the correct ordering from #10354. No regression test is included because the affected code cannot be compiled or exercised without flipping `USE_RIFF`, and the live path is already covered.

## Related PRs in the past

- #10354 fixed the same declaration-ordering bug in the Fossil (`#else`) branch of `writeSerializedModuleIR`, but left the `USE_RIFF` branch unchanged.
