### PR TITLE
CUDA: legalize dynamic indexing into by-value kernel parameters (floor for #11774)

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -64,6 +64,7 @@
 #include "slang-ir-legalize-array-return-type.h"
 #include "slang-ir-legalize-binary-operator.h"
 #include "slang-ir-legalize-composite-select.h"
+#include "slang-ir-legalize-cuda-param-dynamic-index.h"
 #include "slang-ir-legalize-empty-array.h"
 #include "slang-ir-legalize-global-values.h"
 #include "slang-ir-legalize-image-subscript.h"
@@ -2543,6 +2544,17 @@ Result linkAndOptimizeIR(
         // eliminatePhis just took the IR out of SSA form — the emitter
         // expects non-SSA IR at this point.
         SLANG_PASS(simplifyNonSSAIR, targetProgram, fastIRSimplificationOptions, sink);
+    }
+
+    // CUDA kernel parameters live in `.param` space, which ptxas cannot address
+    // dynamically; rewrite runtime-indexed accesses to go through a function-local
+    // copy of the parameter (see slang-ir-legalize-cuda-param-dynamic-index.h).
+    // This must run after the last simplification pass: the local copy is a
+    // once-stored variable, which SSA construction / store forwarding would
+    // otherwise fold right back into a direct dynamic index on the parameter.
+    if (isCUDATarget(targetRequest))
+    {
+        SLANG_PASS(legalizeCUDAKernelParamDynamicIndex);
     }
 
     // We include one final step to (optionally) dump the IR and validate

--- a/source/slang/slang-ir-legalize-cuda-param-dynamic-index.cpp
+++ b/source/slang/slang-ir-legalize-cuda-param-dynamic-index.cpp
@@ -1,0 +1,221 @@
+// slang-ir-legalize-cuda-param-dynamic-index.cpp
+#include "slang-ir-legalize-cuda-param-dynamic-index.h"
+
+#include "slang-ir-insts.h"
+#include "slang-ir.h"
+
+namespace Slang
+{
+
+namespace
+{
+
+/// One step of a value-projection chain rooted at a kernel parameter: either a
+/// struct-field extraction (`key` is the field key) or an array-element extraction
+/// (`key` is the index operand). Recorded while walking from a dynamically-indexed
+/// `GetElement` down to the parameter, then replayed in root-to-leaf order to build
+/// the equivalent address chain off the parameter's local copy.
+struct ProjectionStep
+{
+    enum class Kind
+    {
+        Field,
+        Element,
+    };
+    Kind kind;
+    IRInst* key;
+};
+
+/// A dynamically-indexed access to rewrite: the `GetElement` instruction with the
+/// runtime index, the kernel parameter its base chain roots at, and the projection
+/// steps from the parameter to that instruction (in root-to-leaf order).
+struct DynamicParamAccess
+{
+    IRGetElement* getElement;
+    IRParam* rootParam;
+    List<ProjectionStep> steps;
+};
+
+struct LegalizeCUDAKernelParamDynamicIndexContext
+{
+    IRModule* module;
+
+    // One local copy per parameter, shared by all rewritten accesses in the kernel.
+    Dictionary<IRParam*, IRVar*> mapParamToLocalVar;
+
+    LegalizeCUDAKernelParamDynamicIndexContext(IRModule* module)
+        : module(module)
+    {
+    }
+
+    /// Returns true if `func` has the CUDA kernel ABI, i.e. its parameters are passed
+    /// in `.param` kernel-argument space. Only such parameters exhibit the serial
+    /// dynamic-address load pathology; ordinary `__device__` function parameters live
+    /// in registers/stack and are excluded (and are already pointer-ized by
+    /// `transformParamsToConstRef` anyway).
+    bool isKernelABIFunc(IRFunc* func)
+    {
+        if (!func->isDefinition())
+            return false;
+        for (auto decoration : func->getDecorations())
+        {
+            if (as<IREntryPointDecoration>(decoration) || as<IRCudaKernelDecoration>(decoration) ||
+                as<IRAutoPyBindCudaDecoration>(decoration))
+                return true;
+        }
+        return false;
+    }
+
+    /// If `getElement` is a runtime-indexed array access whose base is a pure
+    /// value-projection chain (`FieldExtract`/`GetElement`) rooted at a by-value
+    /// parameter of `func`, fill in `outAccess` and return true.
+    bool tryMatchDynamicParamAccess(
+        IRFunc* func,
+        IRGetElement* getElement,
+        DynamicParamAccess& outAccess)
+    {
+        // Only a runtime index is pathological; constant indices resolve to static
+        // `.param` offsets, which are the fast path we must not disturb.
+        if (as<IRIntLit>(getElement->getIndex()))
+            return false;
+
+        // Restrict to fixed-size array bases: that is the shape whose dynamic
+        // addressing ptxas serializes (vectors go through the emitter's element
+        // intrinsic already, and unsized arrays cannot be by-value parameters).
+        if (!as<IRArrayType>(getElement->getBase()->getDataType()))
+            return false;
+
+        List<ProjectionStep> reversedSteps;
+        IRInst* inst = getElement;
+        for (;;)
+        {
+            if (auto fieldExtract = as<IRFieldExtract>(inst))
+            {
+                reversedSteps.add({ProjectionStep::Kind::Field, fieldExtract->getField()});
+                inst = fieldExtract->getBase();
+            }
+            else if (auto elementExtract = as<IRGetElement>(inst))
+            {
+                reversedSteps.add({ProjectionStep::Kind::Element, elementExtract->getIndex()});
+                inst = elementExtract->getBase();
+            }
+            else
+                break;
+        }
+
+        auto param = as<IRParam>(inst);
+        if (!param)
+            return false;
+        if (param->getParent() != func->getFirstBlock())
+            return false;
+        // A pointer-typed parameter (e.g. one already rewritten to `borrow in`) is
+        // not in `.param` value space; its loads are dynamically addressable as is.
+        if (as<IRPtrTypeBase>(param->getDataType()))
+            return false;
+
+        outAccess.getElement = getElement;
+        outAccess.rootParam = param;
+        outAccess.steps.clear();
+        for (Index i = reversedSteps.getCount() - 1; i >= 0; --i)
+            outAccess.steps.add(reversedSteps[i]);
+        return true;
+    }
+
+    /// Return the function-local copy of `param`, creating it (a prologue
+    /// var + store) on first use.
+    IRVar* getOrCreateLocalCopy(IRFunc* func, IRParam* param)
+    {
+        IRVar* var = nullptr;
+        if (mapParamToLocalVar.tryGetValue(param, var))
+            return var;
+
+        IRBuilder builder(module);
+        builder.setInsertBefore(func->getFirstBlock()->getFirstOrdinaryInst());
+        var = builder.emitVar(param->getDataType(), AddressSpace::Function);
+        builder.emitStore(var, param);
+        mapParamToLocalVar.set(param, var);
+        return var;
+    }
+
+    void rewriteAccess(IRFunc* func, const DynamicParamAccess& access)
+    {
+        auto var = getOrCreateLocalCopy(func, access.rootParam);
+
+        IRBuilder builder(module);
+        builder.setInsertBefore(access.getElement);
+        IRInst* addr = var;
+        for (auto& step : access.steps)
+        {
+            switch (step.kind)
+            {
+            case ProjectionStep::Kind::Field:
+                addr = builder.emitFieldAddress(addr, step.key);
+                break;
+            case ProjectionStep::Kind::Element:
+                addr = builder.emitElementAddress(addr, step.key);
+                break;
+            }
+        }
+        auto load = builder.emitLoad(addr);
+        access.getElement->replaceUsesWith(load);
+        access.getElement->removeAndDeallocate();
+    }
+
+    void processFunc(IRFunc* func)
+    {
+        mapParamToLocalVar.clear();
+
+        // Collect first, then rewrite: the projection chains are recorded as
+        // (kind, key) pairs while the IR is still unmodified, so rewriting one
+        // access can never invalidate the recorded chain of another (nested
+        // dynamic indices each get their own complete chain off the same copy).
+        List<DynamicParamAccess> accesses;
+        for (auto block : func->getBlocks())
+        {
+            for (auto inst : block->getChildren())
+            {
+                auto getElement = as<IRGetElement>(inst);
+                if (!getElement)
+                    continue;
+                DynamicParamAccess access;
+                if (tryMatchDynamicParamAccess(func, getElement, access))
+                    accesses.add(_Move(access));
+            }
+        }
+
+        // Rewrite in reverse collection order. Within a block, defs precede uses,
+        // so a candidate that appears as another candidate's index operand (e.g.
+        // the inner access in `weights[idx[tid]]`) is always collected earlier.
+        // Iterating in reverse rewrites the consumer (`weights[...]`) before the
+        // producer (`idx[...]`): rebuilding the outer access first creates a fresh
+        // use of the still-live inner GetElement, and when the inner access is then
+        // rewritten its `replaceUsesWith` rewires that use to the inner's load. In
+        // forward order the inner GetElement would be deallocated first, leaving the
+        // outer access's recorded index `key` a dangling pointer.
+        for (Index i = accesses.getCount() - 1; i >= 0; --i)
+            rewriteAccess(func, accesses[i]);
+    }
+
+    void processModule()
+    {
+        for (auto inst : module->getGlobalInsts())
+        {
+            auto func = as<IRFunc>(inst);
+            if (!func)
+                continue;
+            if (!isKernelABIFunc(func))
+                continue;
+            processFunc(func);
+        }
+    }
+};
+
+} // namespace
+
+void legalizeCUDAKernelParamDynamicIndex(IRModule* module)
+{
+    LegalizeCUDAKernelParamDynamicIndexContext context(module);
+    context.processModule();
+}
+
+} // namespace Slang

--- a/source/slang/slang-ir-legalize-cuda-param-dynamic-index.h
+++ b/source/slang/slang-ir-legalize-cuda-param-dynamic-index.h
@@ -1,0 +1,36 @@
+// slang-ir-legalize-cuda-param-dynamic-index.h
+#pragma once
+
+namespace Slang
+{
+
+struct IRModule;
+
+/// Legalize dynamic indexing into by-value kernel parameters on CUDA targets.
+///
+/// A CUDA `__global__` kernel receives its parameters in `.param` (kernel-argument)
+/// space, which ptxas cannot address dynamically: a `GetElement` with a runtime index
+/// whose base is (a projection of) a by-value kernel parameter is lowered to a serial
+/// per-element load chain, costing O(N) dependent loads per access (see issue #11774).
+///
+/// This pass rewrites each such access to go through a function-local copy of the
+/// parameter instead: it materializes one `AddressSpace::Function` variable per
+/// affected parameter in the kernel prologue, stores the parameter into it once, and
+/// rewrites the offending `FieldExtract`/`GetElement` projection chains into address
+/// chains off that variable followed by a single load. Local memory is dynamically
+/// addressable, so each access becomes one O(1) load after a pipelined one-time copy.
+///
+/// For example, for `uniform float weights[256]` indexed as `weights[indices[tid]]`,
+/// the kernel body becomes (in emitted CUDA terms):
+///
+///     FixedArray<float, 256> _w = weights; // one-time prologue copy
+///     ... _w[indices[tid]] ...             // O(1) dynamically addressed load
+///
+/// The transform changes neither the kernel signature nor any reflected layout, so it
+/// is invisible to hosts; it is the CUDA analogue of the SPIR-V legalization in
+/// `SPIRVLegalizationContext::processGetElement` (slang-ir-spirv-legalize.cpp), which
+/// performs the same value-to-addressable-memory materialization because SPIR-V cannot
+/// dynamically index values either. Statically-indexed parameters are left untouched.
+void legalizeCUDAKernelParamDynamicIndex(IRModule* module);
+
+} // namespace Slang

--- a/tests/cuda/kernel-param-dynamic-index-autopybind.slang
+++ b/tests/cuda/kernel-param-dynamic-index-autopybind.slang
@@ -1,0 +1,18 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -line-directive-mode none
+
+// Same dynamic-index legalization for an `[AutoPyBindCUDA] [CudaKernel]` function:
+// the generated `__kernel__`-prefixed wrapper still receives its by-value array
+// parameter in `.param` space, so a runtime index must go through a local copy.
+
+// CHECK: __global__ void __kernel__myKernel(FixedArray<float, 256>{{.*}}weights_0, TensorView idx_0, TensorView output_0)
+// CHECK: FixedArray<float, 256>{{.*}}[[LOCAL:_S[0-9]+]] = weights_0;
+// CHECK-NOT: weights_0[
+// CHECK: [[LOCAL]][
+
+[AutoPyBindCUDA]
+[CudaKernel]
+void myKernel(float weights[256], TensorView<uint> idx, TensorView<float> output)
+{
+    uint tid = cudaThreadIdx().x;
+    output.store(tid, weights[idx.load(tid)]);
+}

--- a/tests/cuda/kernel-param-dynamic-index-cuda-kernel-decoration.slang
+++ b/tests/cuda/kernel-param-dynamic-index-cuda-kernel-decoration.slang
@@ -1,0 +1,18 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -line-directive-mode none
+
+// The dynamic-index legalization keys off the CUDA kernel ABI, not the
+// `[shader("compute")]` entry-point form: a `[CudaKernel]`-attributed function also
+// receives its parameters in `.param` space, so a runtime index into a by-value
+// array parameter must likewise be rewritten through a function-local copy.
+
+// CHECK: __global__ void myKernel(FixedArray<float, 256>{{.*}}weights_0, TensorView idx_0, TensorView output_0)
+// CHECK: FixedArray<float, 256>{{.*}}[[LOCAL:_S[0-9]+]] = weights_0;
+// CHECK-NOT: weights_0[
+// CHECK: [[LOCAL]][
+
+[CudaKernel]
+void myKernel(float weights[256], TensorView<uint> idx, TensorView<float> output)
+{
+    uint tid = cudaThreadIdx().x;
+    output.store(tid, weights[idx.load(tid)]);
+}

--- a/tests/cuda/kernel-param-dynamic-index-feeds-index.slang
+++ b/tests/cuda/kernel-param-dynamic-index-feeds-index.slang
@@ -1,0 +1,30 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+
+// Two dynamically-indexed kernel-parameter accesses where one feeds the other's
+// index: `weights[idx[...]]`. Both `idx[...]` and `weights[...]` are runtime-indexed
+// by-value parameter arrays, so each must be rewritten through its own local copy.
+// The inner `idx` access is the index operand of the outer `weights` access, so the
+// legalization must rebuild the outer access before deallocating the inner one;
+// otherwise the outer access holds a dangling pointer to the freed inner GetElement.
+
+// CHECK: __global__ void computeMain(FixedArray<float, 256>{{.*}}weights_0, FixedArray<uint, 16>{{.*}}idx_0, RWStructuredBuffer<float> output_0)
+// A local copy is materialized for each of the two parameters.
+// CHECK-DAG: FixedArray<float, 256>{{.*}}[[WLOCAL:_S[0-9]+]] = weights_0;
+// CHECK-DAG: FixedArray<uint, 16>{{.*}}[[ILOCAL:_S[0-9]+]] = idx_0;
+// The weights local copy is indexed by a value loaded from the idx local copy;
+// neither parameter is indexed directly. Before the reverse-order fix, the outer
+// access referenced a deallocated inner GetElement and emitted a dangling index.
+// CHECK-NOT: weights_0[
+// CHECK-NOT: idx_0[
+// CHECK: [[WLOCAL]][{{.*}}[[ILOCAL]][
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(
+    uint3 tid: SV_DispatchThreadID,
+    uniform float weights[256],
+    uniform uint idx[16],
+    uniform RWStructuredBuffer<float> output)
+{
+    output[tid.x] = weights[idx[tid.x % 16]];
+}

--- a/tests/cuda/kernel-param-dynamic-index-local-copy.slang
+++ b/tests/cuda/kernel-param-dynamic-index-local-copy.slang
@@ -1,0 +1,27 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+
+// A CUDA kernel parameter lives in `.param` (kernel-argument) space, which ptxas
+// cannot address dynamically: a runtime index into a by-value parameter array is
+// lowered to a serial per-element load chain (issue #11774). Verify that the
+// dynamic-index legalization pass materializes a function-local copy of the
+// parameter in the kernel prologue and indexes the copy instead, and that the
+// kernel signature (the host-visible ABI) is unchanged.
+
+// The signature keeps the by-value array parameter (no ABI change).
+// CHECK: __global__ void computeMain(FixedArray<RWStructuredBuffer<float>, 32>{{.*}}tensors_0, StructuredBuffer<uint> indices_0)
+
+// The prologue copies the parameter into a local, and the runtime index goes
+// through the local copy, not the parameter.
+// CHECK: FixedArray<RWStructuredBuffer<float>, 32>{{.*}}[[LOCAL:_S[0-9]+]] = tensors_0;
+// CHECK-NOT: tensors_0[
+// CHECK: [[LOCAL]][
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(
+    uint3 tid: SV_DispatchThreadID,
+    uniform RWStructuredBuffer<float> tensors[32],
+    uniform StructuredBuffer<uint> indices)
+{
+    tensors[indices[tid.x]][tid.x] = 1.0f;
+}

--- a/tests/cuda/kernel-param-dynamic-index-multi-level.slang
+++ b/tests/cuda/kernel-param-dynamic-index-multi-level.slang
@@ -1,0 +1,23 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+
+// A projection chain with more than one runtime index level: both levels of a
+// nested array parameter are dynamically indexed. Each matched access records its
+// complete chain from the parameter, so the rewrite must produce a single local
+// copy of the parameter with a two-level address chain into it - not a copy per
+// level, and no leftover dynamic indexing on the parameter itself.
+
+// CHECK: __global__ void computeMain(FixedArray<FixedArray<float, 8>{{.*}}grid_0, StructuredBuffer<uint> indices_0, RWStructuredBuffer<float> output_0)
+// CHECK-COUNT-1: = grid_0;
+// CHECK-NOT: grid_0[
+// CHECK: [[LOCAL:_S[0-9]+]][[[I:_S[0-9]+]]][[[J:_S[0-9]+]]]
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(
+    uint3 tid: SV_DispatchThreadID,
+    uniform float grid[8][8],
+    uniform StructuredBuffer<uint> indices,
+    uniform RWStructuredBuffer<float> output)
+{
+    output[tid.x] = grid[indices[tid.x]][indices[tid.x + 1]];
+}

--- a/tests/cuda/kernel-param-dynamic-index-nested-struct.slang
+++ b/tests/cuda/kernel-param-dynamic-index-nested-struct.slang
@@ -1,0 +1,35 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+
+// Same as kernel-param-dynamic-index-local-copy.slang, but with the array nested
+// one struct level down and its elements being pointer-backed structs — the shape
+// SlangPy's functional API generates for a tensor array. The dynamic-index
+// legalization must root the access chain through the parameter's local copy
+// while leaving statically-addressed accesses to the same parameter (the
+// `indices` field here) on the parameter itself.
+
+struct MyTensor
+{
+    float* data;
+    uint stride;
+}
+
+struct CallData
+{
+    MyTensor tensors[32];
+    StructuredBuffer<uint> indices;
+}
+
+// CHECK: __global__ void computeMain(CallData_0 call_0)
+// CHECK: CallData_0 [[LOCAL:_S[0-9]+]] = call_0;
+// The statically-addressed field stays on the parameter (fast `.param` path).
+// CHECK: __ldg((&(call_0.indices_0)
+// The runtime-indexed array goes through the local copy.
+// CHECK-NOT: call_0.tensors_0[
+// CHECK: [[LOCAL]]{{.*}}tensors_0[
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(uint3 tid: SV_DispatchThreadID, uniform CallData call)
+{
+    *(call.tensors[call.indices[tid.x]].data + tid.x) = 1.0f;
+}

--- a/tests/cuda/kernel-param-dynamic-index-plain-array.slang
+++ b/tests/cuda/kernel-param-dynamic-index-plain-array.slang
@@ -1,0 +1,21 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+
+// The CUDA dynamic-index legalization applies to plain-data parameter arrays too
+// (not just resource arrays): any runtime index into `.param` space pays the
+// serial load chain, so the access must be rewritten through a local copy.
+
+// CHECK: __global__ void computeMain(FixedArray<float, 256>{{.*}}weights_0, StructuredBuffer<uint> indices_0, RWStructuredBuffer<float> output_0)
+// CHECK: FixedArray<float, 256>{{.*}}[[LOCAL:_S[0-9]+]] = weights_0;
+// CHECK-NOT: weights_0[
+// CHECK: [[LOCAL]][
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(
+    uint3 tid: SV_DispatchThreadID,
+    uniform float weights[256],
+    uniform StructuredBuffer<uint> indices,
+    uniform RWStructuredBuffer<float> output)
+{
+    output[tid.x] = weights[indices[tid.x]];
+}

--- a/tests/cuda/kernel-param-dynamic-index-single-copy.slang
+++ b/tests/cuda/kernel-param-dynamic-index-single-copy.slang
@@ -1,0 +1,23 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+
+// A single by-value parameter array indexed at two different runtime indices in the
+// body. Both accesses share one function-local copy (created lazily on first use and
+// cached per parameter), so the prologue must emit exactly one copy-init of the
+// parameter, not one per access.
+
+// CHECK: __global__ void computeMain(FixedArray<float, 256>{{.*}}tensors_0, StructuredBuffer<uint> indices_0, RWStructuredBuffer<float> output_0)
+// Exactly one prologue copy of the parameter is materialized.
+// CHECK-COUNT-1: = tensors_0;
+// CHECK-NOT: = tensors_0;
+// CHECK-NOT: tensors_0[
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(
+    uint3 tid: SV_DispatchThreadID,
+    uniform float tensors[256],
+    uniform StructuredBuffer<uint> indices,
+    uniform RWStructuredBuffer<float> output)
+{
+    output[tid.x] = tensors[indices[tid.x]] + tensors[indices[tid.x + 1]];
+}

--- a/tests/cuda/kernel-param-static-index-no-copy.slang
+++ b/tests/cuda/kernel-param-static-index-no-copy.slang
@@ -1,0 +1,19 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+
+// Negative test for the CUDA dynamic-index legalization: a parameter array that is
+// only ever indexed with compile-time-constant indices resolves to static `.param`
+// offsets — the fast path — and must NOT get a local copy.
+
+// CHECK: __global__ void computeMain(FixedArray<RWStructuredBuffer<float>, 4>{{.*}}tensors_0, StructuredBuffer<uint> indices_0)
+// CHECK-NOT: = tensors_0;
+// CHECK: tensors_0[int(2)]
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(
+    uint3 tid: SV_DispatchThreadID,
+    uniform RWStructuredBuffer<float> tensors[4],
+    uniform StructuredBuffer<uint> indices)
+{
+    tensors[2][tid.x] = 1.0f;
+}


### PR DESCRIPTION
Part of the fix for #11774 (CUDA runtime-indexed resource/tensor arrays 10–30× slower than Vulkan/D3D12).

> **This PR is the floor (layer 1): an ABI-invisible dynamic-index legalization.** The by-reference ABI change (layer 2) was split back out into **#11992**, which is stacked on this branch. This PR is `pr: non-breaking`, touches no ABI or reflection, has no slangpy dependency, and can land on its own. Previously these were combined here (with #11941 merged in); they are now separated so the safe floor lands independently of the breaking-change review.

## Motivation

A CUDA `__global__` kernel receives its parameters in `.param` (kernel-argument) space, which ptxas cannot address dynamically: a runtime index into a by-value parameter array lowers to a serial per-element load chain — O(N) *dependent* loads per access:

```slang
[shader("compute")][numthreads(32,1,1)]
void computeMain(uint3 tid: SV_DispatchThreadID,
    uniform RWStructuredBuffer<float> tensors[32], uniform StructuredBuffer<uint> indices)
{ tensors[indices[tid.x]][tid.x] = 1.0f; }   // serial 32-element ld.param chain today
```

## Proposed solution

`legalizeCUDAKernelParamDynamicIndex` — a CUDA analogue of SPIR-V's `processGetElement`. It materializes **one function-local copy per affected parameter** in the kernel prologue and rewrites the offending `FieldExtract`/`GetElement` projection chains into address chains off that copy plus a single load. Local memory is dynamically addressable, so each access becomes O(1) after a pipelined one-time copy. The kernel signature and all reflected layouts are unchanged, so the transform is invisible to hosts and needs zero host coordination.

This is the permanent cover for every shape the by-reference layer (#11992) deliberately skips: plain-data arrays, bare descriptor arrays, `[CudaKernel]`/`[AutoPyBindCUDA]` kernels, and the `-cuda-entry-point-params-by-value` opt-out.

## Change summary

| File | Change |
|---|---|
| `slang-ir-legalize-cuda-param-dynamic-index.{h,cpp}` | the pass |
| `slang-emit.cpp` | invoke for CUDA after the last IR simplification (SSA store-forwarding would otherwise fold the copy away) |
| `tests/cuda/kernel-param-dynamic-index-*.slang` | 9 tests: local-copy, nested-struct, plain-array, static-no-copy (negative), feeds-index (use-after-free regression), single-copy (`CHECK-COUNT-1`), multi-level, `[CudaKernel]`, `[AutoPyBindCUDA]` |

## Process report

- **Pass ordering (cascade found during implementation):** initially ran after `transformParamsToConstRef`; `simplifyIR`'s SSA construction store-forwarded the once-stored local straight back into a dynamic `.param` index. It now runs after the final simplification, with the constraint documented — inherent ordering, not a workaround.
- **Input-shape check:** a dynamic `GetElement` rooted at a by-value kernel parameter is *correct IR*; the CUDA target simply can't execute it efficiently, so target legalization is the right layer (same family as the WGSL `var<private>` fix and SPIR-V `processGetElement`).
- **Review-driven hardening:** use-after-free when one dynamic access feeds another's index (fixed by reverse-order rewriting + `feeds-index` test); single-copy-per-parameter and multi-level dynamic indexing pinned by tests; `[CudaKernel]`/`[AutoPyBindCUDA]` arms of `isKernelABIFunc` exercised.

## Validation

All 46 `tests/cuda` pass on this branch; the floor is perf-neutral on the parameter-size × access-count sweep (slangpy branch `haaggarwal/param-array-copy-benchmark`). The end-to-end 13–29× recovery numbers on #11774 were measured with this floor **plus #11992's by-reference ABI** applied together — see #11992 for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
