### PR TITLE
Fix C++/CUDA emit crash for ParameterBlock of array

### DIFF
--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -282,6 +282,20 @@ SlangResult CPPSourceEmitter::calcTypeName(IRType* type, CodeGenTarget target, S
             out << ">";
             return SLANG_OK;
         }
+    case kIROp_ArrayType:
+        {
+            // Arrays are usually emitted through `_emitType`, but a fixed-size array
+            // can also appear where only a type *name* is valid — e.g. as the element
+            // type of a `ConstantBuffer`/`ParameterBlock` below, which renders as
+            // `FixedArray<T, N>*`.
+            auto arrayType = static_cast<IRArrayType*>(type);
+            out << "FixedArray<";
+            SLANG_RETURN_ON_FAIL(calcTypeName(arrayType->getElementType(), target, out));
+            out << ", ";
+            out << getIntVal(arrayType->getElementCount());
+            out << ">";
+            return SLANG_OK;
+        }
     case kIROp_ConstantBufferType:
     case kIROp_ParameterBlockType:
         {
@@ -1589,8 +1603,17 @@ bool CPPSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inOut
             auto getElementInst = static_cast<IRGetElement*>(inst);
 
             IRInst* baseInst = getElementInst->getBase();
-            IRType* baseType = (IRType*)unwrapAttributedType(
-                as<IRPtrTypeBase>(baseInst->getDataType())->getValueType());
+            // The base is usually a pointer, but can also be a pointer-like type —
+            // e.g. a `ParameterBlock<T[N]>`-typed parameter, which emits as `T*` and
+            // is addressed through the generic dereference path below.
+            IRType* basePointeeType = nullptr;
+            if (auto basePtrType = as<IRPtrTypeBase>(baseInst->getDataType()))
+                basePointeeType = basePtrType->getValueType();
+            else if (auto basePtrLikeType = as<IRPointerLikeType>(baseInst->getDataType()))
+                basePointeeType = basePtrLikeType->getElementType();
+            if (!basePointeeType)
+                return false;
+            IRType* baseType = (IRType*)unwrapAttributedType(basePointeeType);
             if (auto vectorBaseType = as<IRVectorType>(baseType))
             {
                 if (auto intLitIndex = as<IRIntLit>(getElementInst->getIndex()))

--- a/tests/cuda/parameter-block-of-array.slang
+++ b/tests/cuda/parameter-block-of-array.slang
@@ -1,0 +1,21 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+
+// A `ParameterBlock` (or `ConstantBuffer`) whose element is a fixed-size array used
+// to crash the C++/CUDA emitter twice over: `calcTypeName` had no case for array
+// types (E99999), and the `GetElementPtr` special-casing dereferenced the base as an
+// `IRPtrTypeBase` without checking, crashing on a pointer-*like* (parameter group)
+// base. The block must emit as a `FixedArray<T, N>*` parameter indexed through the
+// generic dereference path.
+
+// CHECK: __global__ void computeMain(FixedArray<float, 4>* arr_0, RWStructuredBuffer<float> output_0)
+// CHECK: (*arr_0)[
+
+[shader("compute")]
+[numthreads(4, 1, 1)]
+void computeMain(
+    uint3 tid: SV_DispatchThreadID,
+    uniform ParameterBlock<float[4]> arr,
+    uniform RWStructuredBuffer<float> output)
+{
+    output[tid.x] = arr[tid.x];
+}

--- a/tests/cuda/parameter-block-of-array.slang
+++ b/tests/cuda/parameter-block-of-array.slang
@@ -1,4 +1,6 @@
 //TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+//TEST:SIMPLE(filecheck=CPPCHECK): -target cpp -entry computeMain -stage compute -line-directive-mode none
+//TEST:SIMPLE(filecheck=CBCHECK): -target cuda -entry cbMain -stage compute -line-directive-mode none -DUSE_CB
 
 // A `ParameterBlock` (or `ConstantBuffer`) whose element is a fixed-size array used
 // to crash the C++/CUDA emitter twice over: `calcTypeName` had no case for array
@@ -7,8 +9,15 @@
 // base. The block must emit as a `FixedArray<T, N>*` parameter indexed through the
 // generic dereference path.
 
+// The fix lives in CPPSourceEmitter, shared by the CUDA and CPP targets, and the
+// same emit case handles ConstantBuffer; pin all of those combinations.
 // CHECK: __global__ void computeMain(FixedArray<float, 4>* arr_0, RWStructuredBuffer<float> output_0)
 // CHECK: (*arr_0)[
+// On CPP targets entry-point uniforms are collected into a params struct passed
+// via void*; the block still renders as a FixedArray pointer field there.
+// CPPCHECK: FixedArray<float, 4>* arr_0;
+// CBCHECK: __global__ void cbMain(FixedArray<float, 4>* arr_0, RWStructuredBuffer<float> output_0)
+// CBCHECK: (*arr_0)[
 
 [shader("compute")]
 [numthreads(4, 1, 1)]
@@ -19,3 +28,15 @@ void computeMain(
 {
     output[tid.x] = arr[tid.x];
 }
+
+#ifdef USE_CB
+[shader("compute")]
+[numthreads(4, 1, 1)]
+void cbMain(
+    uint3 tid: SV_DispatchThreadID,
+    uniform ConstantBuffer<float[4]> arr,
+    uniform RWStructuredBuffer<float> output)
+{
+    output[tid.x] = arr[tid.x];
+}
+#endif

--- a/tests/cuda/parameter-block-of-array.slang
+++ b/tests/cuda/parameter-block-of-array.slang
@@ -16,6 +16,7 @@
 // On CPP targets entry-point uniforms are collected into a params struct passed
 // via void*; the block still renders as a FixedArray pointer field there.
 // CPPCHECK: FixedArray<float, 4>* arr_0;
+// CPPCHECK: ->arr_0)[
 // CBCHECK: __global__ void cbMain(FixedArray<float, 4>* arr_0, RWStructuredBuffer<float> output_0)
 // CBCHECK: (*arr_0)[
 


### PR DESCRIPTION
## Motivation

Source-level `ParameterBlock<float[4]>` (or `ConstantBuffer` of an array) as a CUDA entry-point parameter crashes the compiler:

```slang
[shader("compute")][numthreads(4,1,1)]
void computeMain(uint3 tid : SV_DispatchThreadID,
    uniform ParameterBlock<float[4]> arr, uniform RWStructuredBuffer<float> output)
{ output[tid.x] = arr[tid.x]; }   // E99999 / segfault on -target cuda today
```

## Proposed solution

Two independent pre-existing defects in the C++/CUDA emitter, each fixed at the defect site:

1. **`CPPSourceEmitter::calcTypeName` had no case for `kIROp_ArrayType`** — arrays were only handled in the declarator-based `_emitType` path, but a parameter group renders as `<elementTypeName>*`, which needs the element's type *name*. For an array element this hit the `E99999` "unhandled type for C/C++ emit" path. Added the case, emitting `FixedArray<T, N>`.
2. **The `kIROp_GetElementPtr` special-casing in `tryEmitInstExprImpl` dereferenced the base type unchecked**: `as<IRPtrTypeBase>(base->getDataType())->getValueType()`. A parameter-group-typed base is pointer-*like* (`IRPointerLikeType`), not a pointer type, so `as<>` returned null → segfault (read at address 0x4). The pointee type is now computed for both pointer and pointer-like bases, and non-vector/matrix shapes fall through to the generic dereference path, which already handles group bases correctly.

Emitted result: `FixedArray<float, 4>* arr_0` with `(*arr_0)[i]` access.

## Change summary

| File | Change |
|---|---|
| `source/slang/slang-emit-cpp.cpp` | `calcTypeName` array case; safe pointee-type computation in `GetElementPtr` emission |
| `tests/cuda/parameter-block-of-array.slang` | regression test |

## Concepts and vocabulary

- **Pointer-like vs pointer type** — `IRUniformParameterGroupType` (ParameterBlock/ConstantBuffer) is `IRPointerLikeType`: it behaves as an address root throughout the compiler (`getRootAddr`, `isLoadFromImmutableAddress`) but is not an `IRPtrTypeBase`, so `as<IRPtrTypeBase>` on it returns null.

## Process report

- **Input-shape check (per the methodology):** `getElementPtr` directly on a parameter-group-typed value is principled IR — parameter groups are address roots compiler-wide, `FieldAddress(pb, key)` is the standard `ParameterBlock<struct>` access shape, and `getElementPtr(pb, i)` is its exact array analogue. The producer is correct; the consumer (emit) failed to handle a valid input shape, so the fix belongs in emit.
- The two fixes are separable but only observable together (fixing #1 alone exposes #2), hence one PR with one test that locks both.
- Found while developing the CUDA descriptor-array by-reference change (#11941), but independent of it: the crash reproduces on master with the source above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
