### PR TITLE
CUDA: pass descriptor-table entry-point uniforms by reference, decided at parameter binding

### DIFF
--- a/docs/cuda-target.md
+++ b/docs/cuda-target.md
@@ -86,27 +86,52 @@ void computeMain(
 This will be turned into a CUDA entry point with
 
 ```
-struct UniformEntryPointParams
-{
-    Thing thing;
-    Thing thing2;
-};
-
-struct UniformState
+struct GlobalParams
 {
     CUtexObject tex;                // This is the combination of a texture and a sampler(!)
     SamplerState sampler;           // This variable exists within the layout, but it's value is not used.
     RWStructuredBuffer<int32_t> outputBuffer;    // This is implemented as a template in the CUDA prelude. It's just a pointer, and a size
     Thing* thing3;                  // Constant buffers map to pointers
 };
+extern "C" __constant__ GlobalParams SLANG_globalParams;
 
 // [numthreads(4, 1, 1)]
-extern "C" __global__  void computeMain(UniformEntryPointParams* params, UniformState* uniformState)
+extern "C" __global__ void computeMain(Thing thing, Thing thing2)
 ```
+
+Global-scope shader parameters are collected into a single struct stored in the
+module's `__constant__ SLANG_globalParams` symbol; the host writes it once per
+module (or per dispatch, as it sees fit). Entry-point `uniform` parameters are
+passed *by value* as CUDA kernel arguments (the buffer handed to
+`cuLaunchKernel`), acting as root constants.
+
+There is one exception to the by-value rule. CUDA kernel-argument (`.param`)
+space cannot be dynamically indexed efficiently: a runtime index into a by-value
+parameter lowers to a serial per-element load chain. A compute entry-point
+`uniform` parameter of struct type that carries a *descriptor table* — a
+fixed-size array whose elements are (or contain) resources or pointers — is
+therefore passed *by reference*: it is laid out and reflected as an implicit
+`ParameterBlock`, and the kernel receives one 8-byte device pointer whose
+payload lives in device global memory.
+
+```
+struct TensorList { RWStructuredBuffer<float> tensors[32]; };
+
+void computeMain(uniform TensorList list, ...)
+// becomes
+extern "C" __global__ void computeMain(TensorList* list, ...)
+```
+
+Reflection reports such a parameter as a `ParameterBlock` sub-object occupying 8
+bytes of the kernel-argument buffer, so reflection-driven hosts (e.g. slang-rhi)
+bind it like any other parameter block: allocate a device buffer for the
+element, write the descriptors into it, and place the buffer's address at the
+parameter's kernel-argument offset. The `-cuda-entry-point-params-by-value`
+compiler option restores the legacy all-by-value ABI.
 
 With CUDA - the caller specifies how threading is broken up, so `[numthreads]` is available through reflection, and in a comment in output source code but does not produce varying code.
 
-The UniformState and UniformEntryPointParams struct typically vary by shader. UniformState holds 'normal' bindings, whereas UniformEntryPointParams hold the uniform entry point parameters. Where specific bindings or parameters are located can be determined by reflection. The structures for the example above would be something like the following...
+Where specific bindings or parameters are located can be determined by reflection. The types in the structures above map to CUDA types as follows...
 
 `StructuredBuffer<T>`,`RWStructuredBuffer<T>` become
 

--- a/docs/user-guide/09-targets.md
+++ b/docs/user-guide/09-targets.md
@@ -387,6 +387,10 @@ Second, each loaded module of GPU code may contain pre-allocated "constant memor
 Because types like blocks or textures are not special in CUDA, either of these mechanisms can be utilized to pass any kind of data including references to pointer-based data structures stored in the GPU virtual address space.
 The use of "slots" or "blocks" or "root constants" is a matter of application policy instead of API mechanism.
 
+Slang maps global-scope shader parameters to a single struct held in the module's constant memory (`SLANG_globalParams`), and entry-point `uniform` parameters to by-value kernel arguments (root constants).
+One exception: because kernel-argument memory cannot be dynamically indexed efficiently, a compute entry-point `uniform` parameter of struct type that contains a fixed-size array of resources or pointer-backed structs (a descriptor table) is instead passed by reference — laid out and reflected as an implicit `ParameterBlock`, with the kernel receiving one device pointer to the payload in global memory.
+The `-cuda-entry-point-params-by-value` compiler option restores the legacy all-by-value ABI.
+
 OptiX supports use of constant memory storage for ray tracing pipelines, where all the stages in a ray tracing pipeline share that storage.
 OptiX uses a shader table for managing kernels and hit groups, and allows kernels to access the bytes of their shader table entry via a pointer.
 Similar to the compute pipeline, application code can layer many different policies on top of these mechanisms.

--- a/include/slang.h
+++ b/include/slang.h
@@ -1203,6 +1203,14 @@ typedef uint32_t SlangSizeT;
                  //   of `1`, eliminating atomic contention (much faster, and avoids the GPU
                  //   watchdog timeouts heavy coverage can trigger) at the cost of exact
                  //   counts. Off by default.
+        CudaEntryPointParamsByValue =
+            153, // bool: restore the legacy CUDA ABI where an entry-point `uniform`
+                 //   parameter containing a fixed-size array of descriptors (resources
+                 //   or pointer-backed structs) is passed by value in kernel-argument
+                 //   space. By default such parameters are passed by reference — laid
+                 //   out and reflected as an implicit `ParameterBlock` whose payload
+                 //   lives in device global memory — because kernel-argument space
+                 //   cannot be dynamically indexed efficiently.
 
         CountOf,
     };

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -36,6 +36,7 @@
 #include "slang-ir-collect-global-uniforms.h"
 #include "slang-ir-com-interface.h"
 #include "slang-ir-coverage-instrument.h"
+#include "slang-ir-cuda-byref-entry-point-params.h"
 #include "slang-ir-cuda-immutable-load.h"
 #include "slang-ir-dce.h"
 #include "slang-ir-defer-buffer-load.h"
@@ -1165,6 +1166,12 @@ Result linkAndOptimizeIR(
         case CodeGenTarget::CUDASource:
         case CodeGenTarget::CUDAHeader:
             SLANG_PASS(collectOptiXEntryPointUniformParams);
+            // Reconcile compute entry-point uniform parameters to the by-reference
+            // (implicit ParameterBlock) layout that parameter binding decided for
+            // descriptor-table-bearing parameters; the pass consumes the recorded
+            // layout, it does not re-derive the decision (see
+            // slang-ir-cuda-byref-entry-point-params.h).
+            SLANG_PASS(reconcileCUDAByRefEntryPointParams, codeGenContext->getSink());
             validateIRModuleIfEnabled(codeGenContext, irModule);
             break;
 

--- a/source/slang/slang-ir-cuda-byref-entry-point-params.cpp
+++ b/source/slang/slang-ir-cuda-byref-entry-point-params.cpp
@@ -1,0 +1,71 @@
+// slang-ir-cuda-byref-entry-point-params.cpp
+#include "slang-ir-cuda-byref-entry-point-params.h"
+
+#include "slang-ir-insts.h"
+#include "slang-ir-transform-params-to-constref.h"
+#include "slang-ir.h"
+
+namespace Slang
+{
+
+/// Returns the parameter-group type layout recorded for `param` at parameter-binding
+/// time, or null if the parameter was not laid out as a parameter group.
+static IRParameterGroupTypeLayout* findParameterGroupTypeLayout(IRParam* param)
+{
+    auto layoutDecoration = param->findDecoration<IRLayoutDecoration>();
+    if (!layoutDecoration)
+        return nullptr;
+    auto varLayout = as<IRVarLayout>(layoutDecoration->getLayout());
+    if (!varLayout)
+        return nullptr;
+    return as<IRParameterGroupTypeLayout>(varLayout->getTypeLayout());
+}
+
+void reconcileCUDAByRefEntryPointParams(IRModule* module, DiagnosticSink* sink)
+{
+    SLANG_UNUSED(sink);
+
+    IRBuilder builder(module);
+    for (auto inst : module->getGlobalInsts())
+    {
+        auto func = as<IRFunc>(inst);
+        if (!func)
+            continue;
+        if (!func->isDefinition())
+            continue;
+        if (!func->findDecoration<IREntryPointDecoration>())
+            continue;
+
+        bool changed = false;
+        for (auto param : func->getParams())
+        {
+            auto groupTypeLayout = findParameterGroupTypeLayout(param);
+            if (!groupTypeLayout)
+                continue;
+
+            // A parameter that is already group-typed (a source-written
+            // `ParameterBlock<T>` / `ConstantBuffer<T>`) already agrees with its
+            // layout and flows through the existing pipeline unchanged.
+            if (as<IRUniformParameterGroupType>(param->getDataType()))
+                continue;
+
+            // The layout says "parameter group" but the IR still passes the element
+            // by value: this is a binding-time by-reference decision (see the pass
+            // header comment); retype the parameter and rewrite its value uses into
+            // loads through addresses.
+            auto paramBlockType = builder.getType(kIROp_ParameterBlockType, param->getDataType());
+            param->setFullType((IRType*)paramBlockType);
+            rewriteValueUsesToAddrUses(builder, param);
+            changed = true;
+
+            // The reconciled parameter must now agree with its recorded layout;
+            // anything else means the layout and the IR describe different ABIs.
+            SLANG_RELEASE_ASSERT(as<IRUniformParameterGroupType>(param->getDataType()));
+        }
+
+        if (changed)
+            fixUpFuncType(func);
+    }
+}
+
+} // namespace Slang

--- a/source/slang/slang-ir-cuda-byref-entry-point-params.h
+++ b/source/slang/slang-ir-cuda-byref-entry-point-params.h
@@ -1,0 +1,34 @@
+// slang-ir-cuda-byref-entry-point-params.h
+#pragma once
+
+namespace Slang
+{
+
+struct IRModule;
+class DiagnosticSink;
+
+/// Reconcile CUDA entry-point parameters to the by-reference layout decision made at
+/// parameter binding.
+///
+/// On CUDA compute targets, parameter binding lays out an entry-point `uniform`
+/// parameter that carries a descriptor table (a fixed-size array of resources or
+/// pointer-backed structs) as an implicit `ParameterBlock<T>`: one 8-byte device
+/// pointer in kernel-argument space, payload in device global memory (see
+/// `shouldPassCUDAEntryPointUniformParamByRef` in slang-parameter-binding.cpp for the
+/// rationale and the predicate — that is the single site where the decision is made).
+///
+/// This pass makes the IR match what the recorded layout already declares: for each
+/// entry-point parameter whose `IRVarLayout` reports a parameter-group type layout
+/// while the parameter's IR type is still the by-value element type, it retypes the
+/// parameter to `ParameterBlock<T>` and rewrites the body's value uses into loads
+/// through addresses. It never evaluates the predicate itself — it consumes the
+/// layout decision — so the emitted kernel signature and the reflected layout cannot
+/// disagree (the failure mode that sank earlier emit-stage attempts at this fix).
+///
+/// For example, `void main(uniform TensorList list)` whose layout says
+/// parameter-group emits as `__global__ void main(TensorList_0* list_0)`, and a
+/// runtime index `list.tensors[i]` becomes an ordinary dynamically-addressed global
+/// load instead of a serial `.param`-space load chain (issue #11774).
+void reconcileCUDAByRefEntryPointParams(IRModule* module, DiagnosticSink* sink);
+
+} // namespace Slang

--- a/source/slang/slang-ir-transform-params-to-constref.cpp
+++ b/source/slang/slang-ir-transform-params-to-constref.cpp
@@ -7,6 +7,136 @@
 namespace Slang
 {
 
+void rewriteValueUsesToAddrUses(IRBuilder& builder, IRInst* newAddrInst)
+{
+    // The overall strategy here is as follows:
+    //
+    // - First, insert IRLoad() in front of all uses of newAddrInst. This
+    //   is a value parameter turned into pointer to value. Add all IRLoad()
+    //   instructions in the working set
+    // - Then, for every inserted IRLoad() instruction, search for
+    //   IRFieldExtract(IRLoad(ptr), ...) and IRGetElement(IRLoad(ptr), ...) patterns,
+    //   and transform these to IRLoad(IRFieldAddress(ptr, ...)) and
+    //   IRLoad(IRGetElementPtr(ptr, ...)), and insert the new IRLoad()
+    //   instructions in the working set
+    //   - Remove also stores to write-once temporary variables that are
+    //     immediately passed into a constref location in a call (see below)
+    //   - If all uses of the inserted IRLoad() were translated, remove the
+    //     IRLoad() to keep this pass clean
+
+    List<IRLoad*> workList;
+
+    traverseUses(
+        newAddrInst,
+        [&](IRUse* use)
+        {
+            auto user = use->getUser();
+            builder.setInsertBefore(user);
+            IRLoad* loadInst = as<IRLoad>(builder.emitLoad(newAddrInst));
+            use->set(loadInst);
+
+            workList.add(loadInst);
+        });
+
+    for (Index i = 0; i < workList.getCount(); i++)
+    {
+        IRLoad* loadInst = workList[i];
+        bool allUsesTranslated = true;
+
+        traverseUses(
+            loadInst,
+            [&](IRUse* use)
+            {
+                IRInst* userInst = use->getUser();
+                bool useTranslated = false;
+
+                switch (userInst->getOp())
+                {
+                case kIROp_FieldExtract:
+                    {
+                        if (isUseBaseAddrOperand(use, userInst))
+                        {
+                            // Transform IRFieldExtract(IRLoad(ptr), x)
+                            //           ==>
+                            //           IRLoad(IRFieldAddr(ptr), x)
+
+                            auto fieldExtract = as<IRFieldExtract>(userInst);
+                            builder.setInsertBefore(fieldExtract);
+                            auto fieldAddr = builder.emitFieldAddress(
+                                builder.getPtrType(userInst->getDataType()),
+                                loadInst->getPtr(),
+                                fieldExtract->getField());
+                            auto loadFieldAddr = as<IRLoad>(builder.emitLoad(fieldAddr));
+                            fieldExtract->replaceUsesWith(loadFieldAddr);
+                            fieldExtract->removeAndDeallocate();
+
+                            workList.add(loadFieldAddr);
+                            useTranslated = true;
+                        }
+                        break;
+                    }
+
+                case kIROp_GetElement:
+                    {
+                        if (isUseBaseAddrOperand(use, userInst))
+                        {
+                            // Transform IRGetElement(IRLoad(ptr), x)
+                            //           ==>
+                            //           IRLoad(IRGetElementPtr(ptr), x)
+
+                            auto getElement = as<IRGetElement>(userInst);
+                            builder.setInsertBefore(getElement);
+                            auto getElementPtr = builder.emitElementAddress(
+                                builder.getPtrType(userInst->getDataType()),
+                                loadInst->getPtr(),
+                                getElement->getIndex());
+                            auto loadElementPtr = as<IRLoad>(builder.emitLoad(getElementPtr));
+                            getElement->replaceUsesWith(loadElementPtr);
+                            getElement->removeAndDeallocate();
+
+                            workList.add(loadElementPtr);
+                            useTranslated = true;
+                        }
+                        break;
+                    }
+
+                case kIROp_Store:
+                    {
+                        // If the current value is being stored into a write-once temp var that
+                        // is immediately passed into a constref location in a call, we can get
+                        // rid of the temp var and replace it with `inst` directly.
+                        // (such temp var can be introduced during `updateCallSites` when we
+                        // were processing the callee.)
+
+                        // Transform IRStore(storeDest, load(ptr)) where storeDest has attribute
+                        //                                     TempCallArgImmutableVarDecoration
+                        //           IRInst(storeDest)
+                        //           ==>
+                        //           IRInst(ptr)
+
+                        auto storeInst = as<IRStore>(userInst);
+                        auto storeDest = storeInst->getPtr();
+
+                        if (storeInst->getValUse() == use &&
+                            storeDest->findDecorationImpl(kIROp_TempCallArgImmutableVarDecoration))
+                        {
+                            storeDest->replaceUsesWith(loadInst->getPtr());
+                            userInst->removeAndDeallocate();
+                            storeDest->removeAndDeallocate();
+                            useTranslated = true;
+                        }
+                        break;
+                    }
+                }
+
+                allUsesTranslated = allUsesTranslated && useTranslated;
+            });
+
+        if (allUsesTranslated)
+            loadInst->removeAndDeallocate();
+    }
+}
+
 struct TransformParamsToConstRefContext
 {
     IRModule* module;
@@ -43,133 +173,7 @@ struct TransformParamsToConstRefContext
 
     void rewriteValueUsesToAddrUses(IRInst* newAddrInst)
     {
-        // The overall strategy here is as follows:
-        //
-        // - First, insert IRLoad() in front of all uses of newAddrInst. This
-        //   is a value parameter turned into pointer to value. Add all IRLoad()
-        //   instructions in the working set
-        // - Then, for every inserted IRLoad() instruction, search for
-        //   IRFieldExtract(IRLoad(ptr), ...) and IRGetElement(IRLoad(ptr), ...) patterns,
-        //   and transform these to IRLoad(IRFieldAddress(ptr, ...)) and
-        //   IRLoad(IRGetElementPtr(ptr, ...)), and insert the new IRLoad()
-        //   instructions in the working set
-        //   - Remove also stores to write-once temporary variables that are
-        //     immediately passed into a constref location in a call (see below)
-        //   - If all uses of the inserted IRLoad() were translated, remove the
-        //     IRLoad() to keep this pass clean
-
-        List<IRLoad*> workList;
-
-        traverseUses(
-            newAddrInst,
-            [&](IRUse* use)
-            {
-                auto user = use->getUser();
-                builder.setInsertBefore(user);
-                IRLoad* loadInst = as<IRLoad>(builder.emitLoad(newAddrInst));
-                use->set(loadInst);
-
-                workList.add(loadInst);
-            });
-
-        for (Index i = 0; i < workList.getCount(); i++)
-        {
-            IRLoad* loadInst = workList[i];
-            bool allUsesTranslated = true;
-
-            traverseUses(
-                loadInst,
-                [&](IRUse* use)
-                {
-                    IRInst* userInst = use->getUser();
-                    bool useTranslated = false;
-
-                    switch (userInst->getOp())
-                    {
-                    case kIROp_FieldExtract:
-                        {
-                            if (isUseBaseAddrOperand(use, userInst))
-                            {
-                                // Transform IRFieldExtract(IRLoad(ptr), x)
-                                //           ==>
-                                //           IRLoad(IRFieldAddr(ptr), x)
-
-                                auto fieldExtract = as<IRFieldExtract>(userInst);
-                                builder.setInsertBefore(fieldExtract);
-                                auto fieldAddr = builder.emitFieldAddress(
-                                    builder.getPtrType(userInst->getDataType()),
-                                    loadInst->getPtr(),
-                                    fieldExtract->getField());
-                                auto loadFieldAddr = as<IRLoad>(builder.emitLoad(fieldAddr));
-                                fieldExtract->replaceUsesWith(loadFieldAddr);
-                                fieldExtract->removeAndDeallocate();
-
-                                workList.add(loadFieldAddr);
-                                useTranslated = true;
-                            }
-                            break;
-                        }
-
-                    case kIROp_GetElement:
-                        {
-                            if (isUseBaseAddrOperand(use, userInst))
-                            {
-                                // Transform IRGetElement(IRLoad(ptr), x)
-                                //           ==>
-                                //           IRLoad(IRGetElementPtr(ptr), x)
-
-                                auto getElement = as<IRGetElement>(userInst);
-                                builder.setInsertBefore(getElement);
-                                auto getElementPtr = builder.emitElementAddress(
-                                    builder.getPtrType(userInst->getDataType()),
-                                    loadInst->getPtr(),
-                                    getElement->getIndex());
-                                auto loadElementPtr = as<IRLoad>(builder.emitLoad(getElementPtr));
-                                getElement->replaceUsesWith(loadElementPtr);
-                                getElement->removeAndDeallocate();
-
-                                workList.add(loadElementPtr);
-                                useTranslated = true;
-                            }
-                            break;
-                        }
-
-                    case kIROp_Store:
-                        {
-                            // If the current value is being stored into a write-once temp var that
-                            // is immediately passed into a constref location in a call, we can get
-                            // rid of the temp var and replace it with `inst` directly.
-                            // (such temp var can be introduced during `updateCallSites` when we
-                            // were processing the callee.)
-
-                            // Transform IRStore(storeDest, load(ptr)) where storeDest has attribute
-                            //                                     TempCallArgImmutableVarDecoration
-                            //           IRInst(storeDest)
-                            //           ==>
-                            //           IRInst(ptr)
-
-                            auto storeInst = as<IRStore>(userInst);
-                            auto storeDest = storeInst->getPtr();
-
-                            if (storeInst->getValUse() == use &&
-                                storeDest->findDecorationImpl(
-                                    kIROp_TempCallArgImmutableVarDecoration))
-                            {
-                                storeDest->replaceUsesWith(loadInst->getPtr());
-                                userInst->removeAndDeallocate();
-                                storeDest->removeAndDeallocate();
-                                useTranslated = true;
-                            }
-                            break;
-                        }
-                    }
-
-                    allUsesTranslated = allUsesTranslated && useTranslated;
-                });
-
-            if (allUsesTranslated)
-                loadInst->removeAndDeallocate();
-        }
+        Slang::rewriteValueUsesToAddrUses(builder, newAddrInst);
     }
 
     void rewriteParamUseSitesToSupportConstRefUsage(HashSet<IRParam*>& updatedParams)

--- a/source/slang/slang-ir-transform-params-to-constref.h
+++ b/source/slang/slang-ir-transform-params-to-constref.h
@@ -11,4 +11,12 @@ SlangResult transformParamsToConstRef(IRModule* module, DiagnosticSink* sink);
 
 SlangResult translateEntryPointInParamToBorrow(IRModule* module, DiagnosticSink* sink);
 
+/// Rewrite all uses of `addrInst` from value uses into address uses, after `addrInst`
+/// has been retyped from a value type to an address-like type (e.g. `borrow in T` or a
+/// parameter-group type). Each direct use is first wrapped in a load; then
+/// `FieldExtract(load, key)` / `GetElement(load, index)` patterns are rewritten into
+/// `Load(FieldAddress(addrInst, key))` / `Load(GetElementPtr(addrInst, index))`
+/// chains, and loads whose uses were all rewritten are removed.
+void rewriteValueUsesToAddrUses(IRBuilder& builder, IRInst* addrInst);
+
 } // namespace Slang

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -1150,6 +1150,12 @@ void initCommandOptions(CommandOptions& options)
          "-enable-experimental-passes",
          nullptr,
          "Enable experimental compiler passes"},
+        {OptionKind::CudaEntryPointParamsByValue,
+         "-cuda-entry-point-params-by-value",
+         nullptr,
+         "Pass CUDA entry-point uniform parameters containing fixed-size descriptor arrays by "
+         "value in kernel-argument space (the legacy ABI), instead of by reference as an "
+         "implicit ParameterBlock"},
         {OptionKind::EnableExperimentalDynamicDispatch,
          "-enable-experimental-dynamic-dispatch",
          nullptr,
@@ -2654,6 +2660,7 @@ SlangResult OptionsParser::_parse(int argc, char const* const* argv)
         case OptionKind::PreserveParameters:
         case OptionKind::UseMSVCStyleBitfieldPacking:
         case OptionKind::ExperimentalFeature:
+        case OptionKind::CudaEntryPointParamsByValue:
             linkage->m_optionSet.set(optionKind, true);
             break;
         case OptionKind::EnableRichDiagnostics:

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -2,6 +2,7 @@
 #include "slang-parameter-binding.h"
 
 #include "../compiler-core/slang-artifact-desc-util.h"
+#include "slang-check-impl.h"
 #include "slang-compiler.h"
 #include "slang-ir-string-hash.h"
 #include "slang-ir-util.h"
@@ -2634,6 +2635,166 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
     return processParamOfType(_Move(processParamOfType), type);
 }
 
+/// Returns true if `type` is, or transitively contains (through struct fields and
+/// array elements), a descriptor-carrying leaf: an opaque resource/handle type
+/// (texture, sampler, buffer, parameter group — see `isOpaqueHandleType`) or a
+/// pointer. E.g. `RWStructuredBuffer<float>` and `struct MyTensor { float* data; }`
+/// match; `uint`, `float3`, and `float4x4` do not.
+static bool typeContainsDescriptorLeaf(ASTBuilder* astBuilder, Type* type, HashSet<Decl*>& seen)
+{
+    while (auto modifiedType = as<ModifiedType>(type))
+        type = modifiedType->getBase();
+
+    if (isOpaqueHandleType(type))
+        return true;
+    if (as<PtrTypeBase>(type))
+        return true;
+
+    if (auto arrayType = as<ArrayExpressionType>(type))
+        return typeContainsDescriptorLeaf(astBuilder, arrayType->getElementType(), seen);
+
+    if (auto declRefType = as<DeclRefType>(type))
+    {
+        if (auto structDecl = as<StructDecl>(declRefType->getDeclRef().getDecl()))
+        {
+            if (!seen.add(structDecl))
+                return false;
+            for (auto field : structDecl->getFields())
+            {
+                auto fieldDeclRef = astBuilder->getMemberDeclRef(declRefType->getDeclRef(), field)
+                                        .as<VarDeclBase>();
+                auto fieldType =
+                    fieldDeclRef ? getType(astBuilder, fieldDeclRef) : field->type.type;
+                if (fieldType && typeContainsDescriptorLeaf(astBuilder, fieldType, seen))
+                    return true;
+            }
+            seen.remove(structDecl);
+        }
+    }
+    return false;
+}
+
+/// Returns true if `type` transitively contains (through struct fields and array
+/// elements) a fixed-size array whose element type transitively contains a
+/// descriptor-carrying leaf — i.e. the type carries a *descriptor table*, an indexed
+/// collection of resources or pointer-backed structs. E.g.
+/// `struct TensorList { RWTensor<float,2> tensors[8]; }` matches (the element holds a
+/// pointer); `struct Args { uint counts[8]; }` and a single non-arrayed tensor struct
+/// do not.
+static bool typeContainsDescriptorBearingFixedArray(
+    ASTBuilder* astBuilder,
+    Type* type,
+    HashSet<Decl*>& seen)
+{
+    while (auto modifiedType = as<ModifiedType>(type))
+        type = modifiedType->getBase();
+
+    if (auto arrayType = as<ArrayExpressionType>(type))
+    {
+        auto elementType = arrayType->getElementType();
+        if (!arrayType->isUnsized())
+        {
+            HashSet<Decl*> leafSeen;
+            if (typeContainsDescriptorLeaf(astBuilder, elementType, leafSeen))
+                return true;
+        }
+        return typeContainsDescriptorBearingFixedArray(astBuilder, elementType, seen);
+    }
+
+    if (auto declRefType = as<DeclRefType>(type))
+    {
+        if (auto structDecl = as<StructDecl>(declRefType->getDeclRef().getDecl()))
+        {
+            if (!seen.add(structDecl))
+                return false;
+            for (auto field : structDecl->getFields())
+            {
+                auto fieldDeclRef = astBuilder->getMemberDeclRef(declRefType->getDeclRef(), field)
+                                        .as<VarDeclBase>();
+                auto fieldType =
+                    fieldDeclRef ? getType(astBuilder, fieldDeclRef) : field->type.type;
+                if (fieldType &&
+                    typeContainsDescriptorBearingFixedArray(astBuilder, fieldType, seen))
+                    return true;
+            }
+            seen.remove(structDecl);
+        }
+    }
+    return false;
+}
+
+/// Decide whether a CUDA compute entry-point `uniform` parameter should be passed by
+/// reference — laid out as an implicit `ParameterBlock<paramType>` whose payload lives
+/// in device global memory — instead of by value in kernel-argument (`.param`) space.
+///
+/// CUDA kernel-argument space cannot be dynamically indexed: a runtime index into a
+/// by-value parameter is lowered by ptxas to a serial per-element load chain, making a
+/// runtime-indexed descriptor array 10-30x slower than the same data placed behind a
+/// pointer in global memory (issue #11774). A parameter that carries a descriptor
+/// table (see `typeContainsDescriptorBearingFixedArray`) is therefore passed as one
+/// 8-byte device pointer. Plain-data parameters — including plain-data arrays — keep
+/// the by-value fast path (their dynamic-index long tail is handled ABI-invisibly by
+/// `legalizeCUDAKernelParamDynamicIndex`).
+///
+/// This is the single site where the by-reference decision is made; the layout it
+/// produces is recorded in reflection, and the IR is reconciled to it by
+/// `reconcileCUDAByRefEntryPointParams` (slang-ir-cuda-byref-entry-point-params.cpp),
+/// which consumes the recorded layout rather than re-deriving a predicate — so the
+/// emitted kernel signature and the reflected layout cannot disagree.
+///
+/// The decision is currently restricted to struct-typed parameters: a struct wrapped
+/// in a `ParameterBlock` reflects as a parameter-group sub-object that existing hosts
+/// (slang-rhi) already bind correctly, whereas `ParameterBlock<T[N]>` is a group
+/// shape hosts do not yet represent. Bare descriptor-array parameters keep the
+/// by-value layout and rely on the dynamic-index legalization above.
+static bool shouldPassCUDAEntryPointUniformParamByRef(
+    ParameterBindingContext* context,
+    EntryPointParameterState const& state,
+    Type* paramType)
+{
+    if (!isCUDATarget(context->getTargetRequest()))
+        return false;
+    if (context->getTargetRequest()->getOptionSet().getBoolOption(
+            CompilerOptionName::CudaEntryPointParamsByValue))
+        return false;
+
+    // Ray-tracing stages pass entry-point uniforms through the shader binding table
+    // (see collectOptiXEntryPointUniformParams); only ordinary compute kernels use
+    // CUDA kernel-argument space.
+    if (state.stage != Stage::Compute)
+        return false;
+
+    // Torch/AutoPyBind/CudaKernel entry points have generated host-side launch code
+    // that passes arguments by value; their ABI is owned by that generated code.
+    if (auto entryPointLayout = context->entryPointLayout)
+    {
+        if (auto entryPointFuncDecl = entryPointLayout->entryPoint.getDecl())
+        {
+            if (entryPointFuncDecl->hasModifier<TorchEntryPointAttribute>() ||
+                entryPointFuncDecl->hasModifier<CudaKernelAttribute>() ||
+                entryPointFuncDecl->hasModifier<AutoPyBindCudaAttribute>())
+                return false;
+        }
+    }
+
+    // A parameter that is already an explicit parameter group is passed by reference
+    // through the existing path; do not double-wrap.
+    if (as<UniformParameterGroupType>(paramType))
+        return false;
+
+    // See the doc comment: only struct-typed parameters are converted. Note that a
+    // bare array must be rejected explicitly: `T[N]` is itself a `DeclRefType` of the
+    // core-module `Array` struct, so a plain "is a struct decl-ref" test would match.
+    if (as<ArrayExpressionType>(paramType))
+        return false;
+    auto declRefType = as<DeclRefType>(paramType);
+    if (!declRefType || !as<StructDecl>(declRefType->getDeclRef().getDecl()))
+        return false;
+
+    HashSet<Decl*> seen;
+    return typeContainsDescriptorBearingFixedArray(context->getASTBuilder(), paramType, seen);
+}
+
 /// Compute the type layout for a parameter declared directly on an entry point.
 static RefPtr<TypeLayout> computeEntryPointParameterTypeLayout(
     ParameterBindingContext* context,
@@ -2650,6 +2811,18 @@ static RefPtr<TypeLayout> computeEntryPointParameterTypeLayout(
         // a uniform shader parameter passed via the implicitly-defined
         // constant buffer (e.g., the `$Params` constant buffer seen in fxc/dxc output).
         //
+        // On CUDA, a parameter that carries a descriptor table is passed by
+        // reference instead: wrapping it in an implicit `ParameterBlock` here makes
+        // the standard layout machinery below produce the parameter-group layout
+        // (an 8-byte device pointer in kernel-argument space) that both reflection
+        // and the emitted kernel signature then agree on. See
+        // `shouldPassCUDAEntryPointUniformParamByRef` for the full rationale.
+        //
+        if (shouldPassCUDAEntryPointUniformParamByRef(context, state, paramType))
+        {
+            paramType = context->getASTBuilder()->getParameterBlockType(paramType);
+        }
+
         LayoutRulesImpl* layoutRules = nullptr;
         if (isKhronosTarget(context->getTargetRequest()))
         {

--- a/tests/cuda/entry-point-uniform-byref-negative.slang
+++ b/tests/cuda/entry-point-uniform-byref-negative.slang
@@ -1,0 +1,41 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+
+// Negative locks for the CUDA by-reference conversion: parameters that do NOT carry
+// a descriptor table keep the by-value kernel-argument fast path, and a
+// source-written ParameterBlock is not double-wrapped.
+//
+// - `single` is a pointer-backed struct but holds no fixed-size descriptor array;
+// - `opts` contains only plain data (including a plain-data array);
+// - `block` is already an explicit parameter group.
+
+struct MyTensor
+{
+    float* data;
+    uint stride;
+}
+
+struct Options
+{
+    uint counts[8];
+    float scale;
+}
+
+struct BlockArgs
+{
+    RWStructuredBuffer<float> buffers[4];
+}
+
+// CHECK: __global__ void computeMain(MyTensor_0 single_0, Options_0 opts_0, BlockArgs_0* block_0, RWStructuredBuffer<float> output_0)
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(
+    uint3 tid: SV_DispatchThreadID,
+    uniform MyTensor single,
+    uniform Options opts,
+    uniform ParameterBlock<BlockArgs> block,
+    uniform RWStructuredBuffer<float> output)
+{
+    output[tid.x] = *(single.data + tid.x) * opts.scale + opts.counts[tid.x % 8] +
+                    block.buffers[tid.x % 4][tid.x];
+}

--- a/tests/cuda/entry-point-uniform-byref-opt-out.slang
+++ b/tests/cuda/entry-point-uniform-byref-opt-out.slang
@@ -1,0 +1,30 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none -cuda-entry-point-params-by-value
+
+// With -cuda-entry-point-params-by-value the legacy ABI is restored: the
+// descriptor-table-bearing parameter is passed by value in kernel-argument space
+// (and its runtime indexing is covered by the dynamic-index local-copy floor
+// instead — see kernel-param-dynamic-index-nested-struct.slang).
+
+struct MyTensor
+{
+    float* data;
+    uint stride;
+}
+
+struct TensorList
+{
+    MyTensor tensors[32];
+}
+
+// CHECK: __global__ void computeMain(TensorList_0 list_0, StructuredBuffer<uint> indices_0, RWStructuredBuffer<float> output_0)
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(
+    uint3 tid: SV_DispatchThreadID,
+    uniform TensorList list,
+    uniform StructuredBuffer<uint> indices,
+    uniform RWStructuredBuffer<float> output)
+{
+    output[tid.x] = *(list.tensors[indices[tid.x]].data + tid.x);
+}

--- a/tests/cuda/entry-point-uniform-descriptor-array-byref.slang
+++ b/tests/cuda/entry-point-uniform-descriptor-array-byref.slang
@@ -1,0 +1,50 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+//TEST:REFLECTION(filecheck=REFLECT): -stage compute -entry computeMain -target cuda -no-codegen
+
+// A CUDA compute entry-point `uniform` parameter that carries a descriptor table —
+// here a struct nesting a fixed-size array of pointer-backed tensor structs, the
+// shape SlangPy's functional API generates — is passed by reference: parameter
+// binding lays it out as an implicit ParameterBlock (one 8-byte device pointer in
+// kernel-argument space, payload in global memory), and the IR is reconciled to
+// that recorded layout. A runtime index into the array is then an ordinary
+// dynamically-addressed global load instead of a serial `.param`-space load chain
+// (issue #11774).
+
+struct MyTensor
+{
+    float* data;
+    uint stride;
+}
+
+struct TensorList
+{
+    MyTensor tensors[32];
+}
+
+// The kernel receives the parameter as a pointer, and the runtime index goes
+// through it; the remaining parameters keep the by-value kernel-argument path.
+// CHECK: __global__ void computeMain(TensorList_0* list_0, StructuredBuffer<uint> indices_0, RWStructuredBuffer<float> output_0)
+// CHECK: list_0->tensors_0[
+
+// Reflection reports the truth about the ABI: the parameter is a parameter block
+// occupying 8 bytes of kernel-argument space, its element preserving the full
+// array layout (count and stride), and the following parameter starts after the
+// pointer.
+// REFLECT: "name": "list"
+// REFLECT: "binding": {"kind": "uniform", "offset": 0, "size": 8
+// REFLECT: "kind": "parameterBlock"
+// REFLECT: "kind": "array"
+// REFLECT: "elementCount": 32
+// REFLECT: "name": "indices"
+// REFLECT: "binding": {"kind": "uniform", "offset": 8
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(
+    uint3 tid: SV_DispatchThreadID,
+    uniform TensorList list,
+    uniform StructuredBuffer<uint> indices,
+    uniform RWStructuredBuffer<float> output)
+{
+    output[tid.x] = *(list.tensors[indices[tid.x]].data + tid.x);
+}

--- a/tests/cuda/entry-point-uniform-resource-array-byref.slang
+++ b/tests/cuda/entry-point-uniform-resource-array-byref.slang
@@ -1,0 +1,20 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+
+// The by-reference conversion applies equally when the descriptor array's elements
+// are true resource types (structured buffers) rather than pointer-backed structs,
+// as long as the array is carried by a struct-typed parameter.
+
+struct Args
+{
+    RWStructuredBuffer<float> tensors[8];
+}
+
+// CHECK: __global__ void computeMain(Args_0* args_0, StructuredBuffer<uint> indices_0)
+// CHECK: args_0->tensors_0[
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(uint3 tid: SV_DispatchThreadID, uniform Args args, uniform StructuredBuffer<uint> indices)
+{
+    args.tensors[indices[tid.x]][tid.x] = 1.0f;
+}

--- a/tests/cuda/kernel-param-dynamic-index-nested-struct.slang
+++ b/tests/cuda/kernel-param-dynamic-index-nested-struct.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none -cuda-entry-point-params-by-value
 
 // Same as kernel-param-dynamic-index-local-copy.slang, but with the array nested
 // one struct level down and its elements being pointer-backed structs — the shape
@@ -6,6 +6,11 @@
 // legalization must root the access chain through the parameter's local copy
 // while leaving statically-addressed accesses to the same parameter (the
 // `indices` field here) on the parameter itself.
+//
+// By default this parameter shape is passed by reference instead (see
+// entry-point-uniform-descriptor-array-byref.slang); the local-copy floor tested
+// here is what covers it under the `-cuda-entry-point-params-by-value` legacy ABI
+// (and kernels excluded from the by-reference gate, e.g. [CudaKernel] functions).
 
 struct MyTensor
 {


### PR DESCRIPTION
> **Stacked on #11939** (base branch is `haaggarwal/cuda-param-dynamic-index-floor`); the diff shown here is only this PR's commit. Fixes the compiler-side root cause of #11774.

## Motivation

The local-copy legalization in #11939 is a floor, not the fix: the host still ships the full descriptor blob by value on every dispatch, every thread pays a prologue copy, and the placement remains wrong for what a descriptor array *is*. The measured regression (#11774: SlangPy `test_tensor_sum_indirect`, 24×/13× slower than Vulkan on L40S) is:

```slang
struct TensorList { RWTensor<float,2> tensors[4]; }  // elements are pointer-backed structs
void main(..., uniform TensorList tensor_list, ...)  // by value in .param → serial ld.param chain
{ ... tensor_list.tensors[tensor_indices[i]] ... }
```

On every other target, indexed resource collections live in dynamically-indexable descriptor memory (descriptor heaps) — which is why Vulkan/D3D12 never regressed. On CUDA the equivalent placement is *payload in global memory behind one pointer*: exactly what `ParameterBlock` already produces, and measured **faster than Vulkan** (0.173 ms vs 0.199 ms on RTX 5090 for the forced-PB variant of this workload).

## Proposed solution

Model descriptor-table-carrying entry-point uniforms as what they semantically are — parameter blocks — with **one decision site, at parameter binding**, where reflection is computed:

1. **Layout (the only predicate evaluation)** — in `computeEntryPointParameterTypeLayout`: on CUDA compute entry points, a `uniform` struct parameter transitively containing a fixed-size array whose elements carry descriptors (resources or pointers; `typeContainsDescriptorBearingFixedArray`) is wrapped: `paramType = astBuilder->getParameterBlockType(paramType)`. The standard layout machinery then yields the parameter-group layout — an 8-byte pointer container, element layout preserving all binding ranges — which reflection reports truthfully.
2. **IR consumes the decision** — new post-link pass `reconcileCUDAByRefEntryPointParams`: any entry-point parameter whose recorded `IRVarLayout` is a parameter-group layout while the parameter is still value-typed is retyped to `IRParameterBlockType(T)` and its body value-uses rewritten to loads-through-addresses (via `rewriteValueUsesToAddrUses`, hoisted from the constref pass into a shared utility). The pass evaluates **no predicate**, so the emitted kernel signature and the reflected layout cannot disagree — the ABI-desync failure class (`CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES`) that sank the emit-stage attempts (#11747, and the emit-side half of #11830) is impossible by construction. This follows the #9869 precedent (entry-point parameter-passing conventions rewritten by a dedicated post-link IR pass).
3. **Zero emit changes, zero slang-rhi changes** — `IRParameterBlockType` entry-point params already emit as `T*`, and slang-rhi's CUDA backend deliberately supports parameter-block sub-objects whose parent is an entry point (*"Sub-objects are always written to global memory, even if the parent represents an entry-point"*, cuda-shader-object.cpp), allocating the payload and patching the device pointer at the reflected kernel-argument offset.
4. **Escape hatch** — new `-cuda-entry-point-params-by-value` option (`CompilerOptionName::CudaEntryPointParamsByValue`, appended before `CountOf`) restores the legacy all-by-value ABI; it gates the binding decision, so layout and IR flip together.

Emitted result for the motivating shape:

```cpp
extern "C" __global__ void computeMain(TensorList_0* list_0, ...)
{ ... *((&list_0->tensors_0[_S3])->data_0 + _S1) ... }  // O(1) global load
```

Reflection reports the parameter as `kind: parameterBlock`, 8 bytes at its kernel-argument offset, element preserving the array (count N, stride 16); the next parameter starts after the pointer.

## Change summary

| File | Change |
|---|---|
| `source/slang/slang-parameter-binding.cpp` | predicate + gate + wrap at the single decision site |
| `source/slang/slang-ir-cuda-byref-entry-point-params.{h,cpp}` | layout-consuming IR reconciliation pass |
| `source/slang/slang-ir-transform-params-to-constref.{h,cpp}` | hoist `rewriteValueUsesToAddrUses` to a shared free function (pure move) |
| `source/slang/slang-emit.cpp` | invoke the pass in the CUDA arm after `collectOptiXEntryPointUniformParams` |
| `include/slang.h`, `source/slang/slang-options.cpp` | the opt-out option |
| `tests/cuda/entry-point-uniform-descriptor-array-byref.slang` | emit + reflection-JSON lock for the motivating shape |
| `tests/cuda/entry-point-uniform-resource-array-byref.slang` | true resource array in a struct converts too |
| `tests/cuda/entry-point-uniform-byref-negative.slang` | negatives: single tensor struct, plain-data struct, source-written PB (no double-wrap) |
| `tests/cuda/entry-point-uniform-byref-opt-out.slang` | the flag restores the legacy ABI |
| `tests/cuda/kernel-param-dynamic-index-nested-struct.slang` | repurposed: floor behavior under the legacy ABI |
| `docs/cuda-target.md`, `docs/user-guide/09-targets.md` | document the actual ABI rule |

## Concepts and vocabulary

- **Descriptor table** — an indexed collection of resource descriptors; every binding model places these in dynamically-indexable memory. Distinct from **root constants** (small plain data), whose canonical CUDA home genuinely is `.param` — the predicate preserves that distinction, which is why entry-point args remain meaningful (and fast) after this change.
- **Layout-consuming pass** — the IR pass reads `IRLayoutDecoration` and reconciles the IR to it; it re-derives nothing. Single source of truth for the ABI.
- **E5 shape** — a source-written `uniform ParameterBlock<S>` entry-point parameter, which compiles, reflects, and binds correctly today; this PR makes binding *produce* that existing canonical form, adding no new representation to the system.

## Process report

- **Why binding, not emit:** reflection is finalized at parameter-binding time; any later ABI decision is invisible to hosts — the #11747 crash class. The wrap happens where reflection is computed; the IR pass consumes the recorded result. There is no second predicate kept in sync by discipline (the flaw in #11830's split).
- **Why struct-typed parameters only (staged scope):** a bare descriptor array would reflect as `ParameterBlock<T[N]>`, a group shape slang-rhi's `_unwrapParameterGroups` cannot represent (silently collapses to 1 slot on the sub-object path). Struct-wrapped groups take its `default:` path and bind N slots on **already-shipped** slang-rhi binaries. Bare arrays keep the by-value layout (covered by #11939's local copy); this covers 100% of the measured regression — including the issue's hand-written reproducer, which also nests its array in a struct. The end state for bare arrays (synthesized wrapper struct vs slang-rhi group-of-array support) is left as an explicit maintainer decision rather than decided implicitly here.
- **Cascading issue found during implementation:** the first "struct-typed" check (`as<DeclRefType>` + `as<StructDecl>`) also matched bare arrays — `T[N]` *is* a `DeclRefType` of the core-module `Array` struct — converting `uniform RWStructuredBuffer<float> t[32]` into the unsupported `ParameterBlock<array>` shape and crashing emit downstream. Fixed with an explicit `as<ArrayExpressionType>` rejection (commented); the underlying emit crash is fixed independently in #11940 since source-written `ParameterBlock<float[4]>` crashes master today.
- **Input-shape check (per the methodology):** `uniform TensorList<N>` living by value in `.param` was never a chosen representation — CUDA compute is the arm where `moveEntryPointUniformParamsToGlobalScope` is skipped and no placement pass runs; the placement was the *absence* of a decision (`collectOptiXEntryPointUniformParams` returns immediately for compute). This PR adds the decision at the layer that owns parameter placement. Each exclusion names the component that owns that shape instead: RT stages → the OptiX SBT pass; torch/`[AutoPyBindCUDA]`/`[CudaKernel]` → their generated host launch code; explicit parameter groups → already by-reference.
- **Predicate scope:** descriptor-bearing arrays only, *not* "any array" — on CUDA every SlangPy tensor contains `uint[D]` shape/stride arrays and the functional API emits `int[2]` metadata parameters; a broad predicate would convert essentially every parameter into a sub-object allocation, destroying the root-constant fast path that entry-point parameters exist to provide. Plain-data dynamic indexing is served ABI-invisibly by #11939.
- `rewriteValueUsesToAddrUses` hoisting is a pure move (the context method now delegates). `isLoadFromImmutableAddress` already treats `ParameterBlockType` as an immutable address root, so the downstream `transformParamsToConstRef` passes these addresses into device functions without re-materializing copies — the whole-array copy cannot be silently reintroduced.
- Verified locally: emit FileCheck + reflection JSON across all shapes and the opt-out; all `tests/cuda` pass; full `slang-test` suite clean vs a pre-change build. **Needs GPU CI / manual L40S verification:** slangpy `test_benchmark_tensor.py::test_tensor_sum_indirect` parity with the forced-PB numbers (≈0.026/≈0.195 ms for count 16/32) with the slangpy#1030 heuristic disabled, the `test_array.py` CUDA suite (the #11747 crash canaries), and `ptxas -v` no-spill + no dynamic-address `ld.param` chain. Landing order: shader-slang/slangpy#1045 must merge before slangpy bumps to a Slang containing this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
