### PR TITLE
[Metal][WGSL] Enable AppendStructuredBuffer

### DIFF
--- a/docs/user-guide/a2-03-wgsl-target-specific.md
+++ b/docs/user-guide/a2-03-wgsl-target-specific.md
@@ -95,6 +95,7 @@ ConstantBuffer, (RW/RasterizerOrdered)StructuredBuffer, (RW/RasterizerOrdered)By
 ConstantBuffer translates to the `uniform` address space with `read` access mode in WGSL.
 ByteAddressBuffer and RWByteAddressBuffer translate to `array<u32>` in the `storage` address space, with the `read` and `read_write` access modes in WGSL, respectively.
 StructuredBuffer and RWStructuredBuffer with struct type T translate to `array<T>` in the `storage` address space, with the `read` and `read_write` access modes in WGSL, respectively.
+AppendStructuredBuffer with element type T translates to two bindings in the `storage` address space, an `array<T>` that holds the elements and an `array<atomic<i32>>` that holds the append counter. The Append method updates this counter with the WGSL `atomicAdd` built-in.
 
 Interlocked operations
 ----------------------

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -78,7 +78,7 @@ struct GLSLShaderStorageBuffer {}
 
 __generic<T,L:IBufferDataLayout>
 __intrinsic_op($(kIROp_StructuredBufferGetDimensions))
-[require(cpp_cuda_glsl_hlsl_spirv_llvm, appendstructuredbuffer)]
+[require(cpp_cuda_glsl_hlsl_spirv_wgsl_llvm, appendstructuredbuffer)]
 uint2 __structuredBufferGetDimensions(AppendStructuredBuffer<T,L> buffer);
 
 __generic<T,L:IBufferDataLayout>
@@ -121,7 +121,7 @@ When generating code for other targets, this parameter is ignored and has no eff
 __generic<T, L:IBufferDataLayout=DefaultDataLayout>
 __magic_type(HLSLAppendStructuredBufferType)
 __intrinsic_type($(kIROp_HLSLAppendStructuredBufferType))
-[require(cpp_cuda_glsl_hlsl_spirv_llvm, appendstructuredbuffer)]
+[require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, appendstructuredbuffer)]
 struct AppendStructuredBuffer
 {
     __intrinsic_op($(kIROp_StructuredBufferAppend))
@@ -133,6 +133,7 @@ struct AppendStructuredBuffer
     ///@param numStructs The number of elements in the buffer.
     ///@param stride The stride of the buffer.
     [ForceInline]
+    [require(cpp_cuda_glsl_hlsl_spirv_wgsl_llvm, appendstructuredbuffer)]
     void GetDimensions(
         out uint numStructs,
         out uint stride)

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -2127,11 +2127,7 @@ Result linkAndOptimizeIR(
     case CodeGenTarget::WGSLSPIRV:
     case CodeGenTarget::WGSLSPIRVAssembly:
         {
-            SLANG_PASS(
-                legalizeIRForWGSL,
-                targetProgram,
-                sink,
-                requiredLoweringPassSet);
+            SLANG_PASS(legalizeIRForWGSL, targetProgram, sink, requiredLoweringPassSet);
         }
         break;
 

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -2127,7 +2127,11 @@ Result linkAndOptimizeIR(
     case CodeGenTarget::WGSLSPIRV:
     case CodeGenTarget::WGSLSPIRVAssembly:
         {
-            SLANG_PASS(legalizeIRForWGSL, targetProgram, sink);
+            SLANG_PASS(
+                legalizeIRForWGSL,
+                targetProgram,
+                sink,
+                requiredLoweringPassSet.appendConsumeStructuredBuffer);
         }
         break;
 

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -2131,7 +2131,7 @@ Result linkAndOptimizeIR(
                 legalizeIRForWGSL,
                 targetProgram,
                 sink,
-                requiredLoweringPassSet.appendConsumeStructuredBuffer);
+                requiredLoweringPassSet);
         }
         break;
 

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -3538,11 +3538,15 @@ static LegalVal declareVars(
                 {
                     auto simpleElementVar = tupleVal->elements[0].val.getSimple();
                     auto simpleCounterVar = tupleVal->elements[1].val.getSimple();
-                    IRBuilder builder(simpleElementVar);
-                    builder.addDecoration(
-                        simpleElementVar,
-                        kIROp_CounterBufferDecoration,
-                        simpleCounterVar);
+                    // Only SPIR-V consumes this; elsewhere it pins a dead counter global.
+                    if (isSPIRV(context->targetProgram->getTargetReq()->getTarget()))
+                    {
+                        IRBuilder builder(simpleElementVar);
+                        builder.addDecoration(
+                            simpleElementVar,
+                            kIROp_CounterBufferDecoration,
+                            simpleCounterVar);
+                    }
                     // Clone decorations from leafVar to both element and counter var.
                     cloneDecorationToVar(leafVar, simpleElementVar);
                     cloneDecorationToVar(leafVar, simpleCounterVar);

--- a/source/slang/slang-ir-wgsl-legalize.cpp
+++ b/source/slang/slang-ir-wgsl-legalize.cpp
@@ -1,5 +1,6 @@
 #include "slang-ir-wgsl-legalize.h"
 
+#include "slang-code-gen.h"
 #include "slang-ir-insts.h"
 #include "slang-ir-legalize-binary-operator.h"
 #include "slang-ir-legalize-global-values.h"
@@ -294,7 +295,7 @@ void legalizeIRForWGSL(
     IRModule* module,
     TargetProgram* targetProgram,
     DiagnosticSink* sink,
-    bool hasAppendConsumeStructuredBuffer)
+    const RequiredLoweringPassSet& requiredLoweringPassSet)
 {
     List<EntryPointInfo> entryPoints;
     for (auto inst : module->getGlobalInsts())
@@ -317,7 +318,7 @@ void legalizeIRForWGSL(
     // Go through every instruction in the module and legalize them as needed.
     processInst(module->getModuleInst(), targetProgram, sink);
 
-    if (hasAppendConsumeStructuredBuffer)
+    if (requiredLoweringPassSet.appendConsumeStructuredBuffer)
         legalizeAtomicCounterBuffersForWGSL(module);
 
     // Some global insts are illegal, e.g. function calls.

--- a/source/slang/slang-ir-wgsl-legalize.cpp
+++ b/source/slang/slang-ir-wgsl-legalize.cpp
@@ -212,6 +212,84 @@ struct GlobalInstInliningContext : public GlobalInstInliningContextGeneric
     }
 };
 
+static bool isAtomicOp(IROp op)
+{
+    switch (op)
+    {
+    case kIROp_AtomicLoad:
+    case kIROp_AtomicStore:
+    case kIROp_AtomicExchange:
+    case kIROp_AtomicCompareExchange:
+    case kIROp_AtomicAdd:
+    case kIROp_AtomicSub:
+    case kIROp_AtomicAnd:
+    case kIROp_AtomicOr:
+    case kIROp_AtomicXor:
+    case kIROp_AtomicMin:
+    case kIROp_AtomicMax:
+    case kIROp_AtomicInc:
+    case kIROp_AtomicDec:
+        return true;
+    default:
+        return false;
+    }
+}
+
+// WGSL atomic built-ins take a `ptr<AS, atomic<T>>`, so a buffer accessed
+// atomically must have an atomic element type. Collect buffers that don't.
+static void collectAtomicStructuredBuffers(IRInst* inst, List<IRInst*>& buffers)
+{
+    if (isAtomicOp(inst->getOp()))
+    {
+        if (auto gep = as<IRRWStructuredBufferGetElementPtr>(inst->getOperand(0)))
+        {
+            auto buffer = gep->getOperand(0);
+            if (auto bufferType = as<IRHLSLStructuredBufferTypeBase>(buffer->getDataType()))
+            {
+                if (!as<IRAtomicType>(bufferType->getElementType()) && !buffers.contains(buffer))
+                    buffers.add(buffer);
+            }
+        }
+    }
+    for (auto child : inst->getChildren())
+        collectAtomicStructuredBuffers(child, buffers);
+}
+
+static void promoteAtomicStructuredBuffer(IRInst* buffer)
+{
+    IRBuilder builder(buffer);
+    auto bufferType = as<IRHLSLStructuredBufferTypeBase>(buffer->getDataType());
+    auto atomicElementType = builder.getType(kIROp_AtomicType, bufferType->getElementType());
+
+    // Rebuild the buffer type, preserving the remaining operands (e.g. layout).
+    List<IRInst*> operands;
+    operands.add(atomicElementType);
+    for (UInt i = 1; i < bufferType->getOperandCount(); i++)
+        operands.add(bufferType->getOperand(i));
+    buffer->setFullType(
+        builder.getType(bufferType->getOp(), (UInt)operands.getCount(), operands.getBuffer()));
+
+    // Retype every element pointer derived from this buffer.
+    for (auto use = buffer->firstUse; use; use = use->nextUse)
+    {
+        auto user = use->getUser();
+        if (user->getOp() != kIROp_RWStructuredBufferGetElementPtr)
+            continue;
+        if (user->getOperand(0) != buffer)
+            continue;
+        if (auto oldPtrType = as<IRPtrTypeBase>(user->getDataType()))
+            user->setFullType(builder.getPtrType(atomicElementType, oldPtrType));
+    }
+}
+
+static void legalizeAtomicCounterBuffersForWGSL(IRModule* module)
+{
+    List<IRInst*> buffers;
+    collectAtomicStructuredBuffers(module->getModuleInst(), buffers);
+    for (auto buffer : buffers)
+        promoteAtomicStructuredBuffer(buffer);
+}
+
 void legalizeIRForWGSL(IRModule* module, TargetProgram* targetProgram, DiagnosticSink* sink)
 {
     List<EntryPointInfo> entryPoints;
@@ -234,6 +312,9 @@ void legalizeIRForWGSL(IRModule* module, TargetProgram* targetProgram, Diagnosti
 
     // Go through every instruction in the module and legalize them as needed.
     processInst(module->getModuleInst(), targetProgram, sink);
+
+    // Buffers accessed by atomics must use an atomic element type in WGSL.
+    legalizeAtomicCounterBuffersForWGSL(module);
 
     // Some global insts are illegal, e.g. function calls.
     // We need to inline and remove those.

--- a/source/slang/slang-ir-wgsl-legalize.cpp
+++ b/source/slang/slang-ir-wgsl-legalize.cpp
@@ -290,7 +290,11 @@ static void legalizeAtomicCounterBuffersForWGSL(IRModule* module)
         promoteAtomicStructuredBuffer(buffer);
 }
 
-void legalizeIRForWGSL(IRModule* module, TargetProgram* targetProgram, DiagnosticSink* sink)
+void legalizeIRForWGSL(
+    IRModule* module,
+    TargetProgram* targetProgram,
+    DiagnosticSink* sink,
+    bool hasAppendConsumeStructuredBuffer)
 {
     List<EntryPointInfo> entryPoints;
     for (auto inst : module->getGlobalInsts())
@@ -313,8 +317,8 @@ void legalizeIRForWGSL(IRModule* module, TargetProgram* targetProgram, Diagnosti
     // Go through every instruction in the module and legalize them as needed.
     processInst(module->getModuleInst(), targetProgram, sink);
 
-    // Buffers accessed by atomics must use an atomic element type in WGSL.
-    legalizeAtomicCounterBuffersForWGSL(module);
+    if (hasAppendConsumeStructuredBuffer)
+        legalizeAtomicCounterBuffersForWGSL(module);
 
     // Some global insts are illegal, e.g. function calls.
     // We need to inline and remove those.

--- a/source/slang/slang-ir-wgsl-legalize.h
+++ b/source/slang/slang-ir-wgsl-legalize.h
@@ -6,12 +6,13 @@ namespace Slang
 {
 class DiagnosticSink;
 class TargetProgram;
+struct RequiredLoweringPassSet;
 
 void legalizeIRForWGSL(
     IRModule* module,
     TargetProgram* targetProgram,
     DiagnosticSink* sink,
-    bool hasAppendConsumeStructuredBuffer);
+    const RequiredLoweringPassSet& requiredLoweringPassSet);
 
 void specializeAddressSpaceForWGSL(IRModule* module);
 

--- a/source/slang/slang-ir-wgsl-legalize.h
+++ b/source/slang/slang-ir-wgsl-legalize.h
@@ -7,7 +7,11 @@ namespace Slang
 class DiagnosticSink;
 class TargetProgram;
 
-void legalizeIRForWGSL(IRModule* module, TargetProgram* targetProgram, DiagnosticSink* sink);
+void legalizeIRForWGSL(
+    IRModule* module,
+    TargetProgram* targetProgram,
+    DiagnosticSink* sink,
+    bool hasAppendConsumeStructuredBuffer);
 
 void specializeAddressSpaceForWGSL(IRModule* module);
 

--- a/tests/metal/append-structured-buffer.slang
+++ b/tests/metal/append-structured-buffer.slang
@@ -1,13 +1,28 @@
+//TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-metal -compute -output-using-type
 //TEST:SIMPLE(filecheck=METAL): -target metal -stage compute -entry computeMain
+//TEST:SIMPLE(filecheck=METALLIB): -target metallib -stage compute -entry computeMain
 
+//TEST_INPUT:set inBuffer = ubuffer(data=[1 2 3 4], stride=4)
 RWStructuredBuffer<int> inBuffer;
 
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4, counter=0):out,name=outputBuffer
 AppendStructuredBuffer<int> outputBuffer;
 
-// Metal implements the append counter by reinterpret-casting the counter
-// pointer to atomic_int and using atomic_fetch_add.
-// METAL: atomic_fetch_add_explicit
-// METAL: atomic_int
+// METAL: atomic_fetch_add_explicit(((atomic_int device*)
+// METAL: AppendStructuredBuffer_Append_0(outputBuffer_elements{{.*}}, outputBuffer_counter
+
+// METALLIB: define void @computeMain
+// METALLIB: call {{.*}}.atomic.global.add.s.i32
+
+// BUF: type: int32_t
+// BUF-DAG: 1
+// BUF-DAG: 2
+// BUF-DAG: 3
+// BUF-DAG: 4
+// BUF: 0
+// BUF: 0
+// BUF: 0
+// BUF: 0
 
 [numthreads(4, 1, 1)]
 void computeMain(uint i : SV_GroupIndex)

--- a/tests/metal/append-structured-buffer.slang
+++ b/tests/metal/append-structured-buffer.slang
@@ -1,0 +1,16 @@
+//TEST:SIMPLE(filecheck=METAL): -target metal -stage compute -entry computeMain
+
+RWStructuredBuffer<int> inBuffer;
+
+AppendStructuredBuffer<int> outputBuffer;
+
+// Metal implements the append counter by reinterpret-casting the counter
+// pointer to atomic_int and using atomic_fetch_add.
+// METAL: atomic_fetch_add_explicit
+// METAL: atomic_int
+
+[numthreads(4, 1, 1)]
+void computeMain(uint i : SV_GroupIndex)
+{
+    outputBuffer.Append(inBuffer[i]);
+}

--- a/tests/wgsl/append-structured-buffer.slang
+++ b/tests/wgsl/append-structured-buffer.slang
@@ -1,0 +1,16 @@
+//TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage compute -entry computeMain
+
+RWStructuredBuffer<int> inBuffer;
+
+AppendStructuredBuffer<int> outputBuffer;
+
+// WGSL atomic built-ins take a `ptr<AS, atomic<T>>`, so the append counter must
+// be emitted with an atomic element type and appended to with atomicAdd.
+// WGSL: array<atomic<i32>>
+// WGSL: atomicAdd
+
+[numthreads(4, 1, 1)]
+void computeMain(uint i : SV_GroupIndex)
+{
+    outputBuffer.Append(inBuffer[i]);
+}

--- a/tests/wgsl/append-structured-buffer.slang
+++ b/tests/wgsl/append-structured-buffer.slang
@@ -1,13 +1,24 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=BUF):-slang -compute -wgpu -output-using-type
 //TEST:SIMPLE(filecheck=WGSL): -target wgsl -stage compute -entry computeMain
 
+//TEST_INPUT:set inBuffer = ubuffer(data=[1 2 3 4], stride=4)
 RWStructuredBuffer<int> inBuffer;
 
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4, counter=0):out,name=outputBuffer
 AppendStructuredBuffer<int> outputBuffer;
 
-// WGSL atomic built-ins take a `ptr<AS, atomic<T>>`, so the append counter must
-// be emitted with an atomic element type and appended to with atomicAdd.
 // WGSL: array<atomic<i32>>
 // WGSL: atomicAdd
+
+// BUF: type: int32_t
+// BUF-DAG: 1
+// BUF-DAG: 2
+// BUF-DAG: 3
+// BUF-DAG: 4
+// BUF: 0
+// BUF: 0
+// BUF: 0
+// BUF: 0
 
 [numthreads(4, 1, 1)]
 void computeMain(uint i : SV_GroupIndex)


### PR DESCRIPTION
Add `metal` and `wgsl` to the AppendStructuredBuffer capability so `.Append()` lowers on both targets, plus three fixes this exposed.

`GetDimensions` has no valid Metal lowering. Give the member and the `__structuredBufferGetDimensions` overload an explicit capability that adds `wgsl` but omits `metal`, so Metal reports the same E36107 as other buffer types while WGSL still works.

Gate the `CounterBuffer` decoration re-add in `declareVars()` on `isSPIRV()`. Only SPIR-V consumes it (`OpDecorateCounterBuffer` under `-fspv-reflect`); on other targets it pinned a dead counter global (a stray `int device*` on Metal) and could trip the IR emitter. Layout and binding cloning is unchanged.

WGSL atomic built-ins take a `ptr<AS, atomic<T>>`, so the plain-`int` append counter emitted invalid WGSL (`atomicAdd` on a non-atomic `array<i32>`). In `legalizeIRForWGSL`, promote structured buffers reached by an atomic op to an `Atomic<T>` element type so the counter emits as `array<atomic<i32>>`. This is WGSL-only; Metal keeps its `atomic_int` reinterpret-cast.

Add Metal and WGSL codegen tests covering `.Append()`.