### PR TITLE
Move compile-perf workflows to the VM-based perf runner bridge

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,7 +7,7 @@ self-hosted-runner:
     - GCP
     - GCP-T4
     - GPU
-    - nvrgfx-perf
+    - nvrgfx-perf-kernelvm-bridge
     - perf
     - regression-test
     - SM80Plus

--- a/.github/workflows/compile-perf-release-sweep.yml
+++ b/.github/workflows/compile-perf-release-sweep.yml
@@ -37,11 +37,14 @@ permissions:
 
 jobs:
   release-sweep:
-    # NVIDIA RGFX perf pool (runner group nvrgfx) — same machines as the nightly
-    # + PR-gate jobs, so release-history timings stay comparable.
+    # NVIDIA RGFX perf pool via the VM-based GitHub bridge (rtrci github-bridge
+    # target shader-slang/slang:windows-x64-perf) — same pool as the nightly
+    # job, so release-history timings stay comparable. The pre-VM pool (runner
+    # group nvrgfx, label nvrgfx-perf) was retired 2026-07; a re-sweep on this
+    # pool is needed to rebuild a baseline comparable with post-migration
+    # nightly points.
     runs-on:
-      group: nvrgfx
-      labels: [Windows, X64, nvrgfx-perf]
+      labels: [Windows, X64, nvrgfx-perf-kernelvm-bridge]
     steps:
       - name: Add bash to PATH (Windows)
         shell: pwsh

--- a/.github/workflows/compile-perf-release-sweep.yml
+++ b/.github/workflows/compile-perf-release-sweep.yml
@@ -205,6 +205,11 @@ jobs:
           mv report_per_workload.html index.html
           # _combined_index.json is a derived intermediate — no need to serve it
           rm -f _combined_index.json
+          # Serve files verbatim: without this marker GitHub Pages runs the
+          # generated report through legacy Jekyll, whose builds have failed
+          # or hung on this content. Must be re-created on every deploy
+          # because the `git rm -rf .` above removes it.
+          touch .nojekyll
 
           git add -A
           if git diff --cached --quiet; then echo "no changes"; exit 0; fi

--- a/.github/workflows/nightly-mdl-perf-test.yml
+++ b/.github/workflows/nightly-mdl-perf-test.yml
@@ -35,11 +35,14 @@ permissions:
 
 jobs:
   nightly:
-    # The quiesced NVIDIA RGFX perf pool (runner group nvrgfx) — the SAME runner
-    # the release history is swept on, so absolute timings stay comparable.
+    # The NVIDIA RGFX perf pool, reached through the VM-based GitHub bridge
+    # (rtrci github-bridge target shader-slang/slang:windows-x64-perf) — the
+    # SAME pool the release history sweep targets, so absolute timings stay
+    # comparable. The pre-VM pool (runner group nvrgfx, label nvrgfx-perf)
+    # was retired 2026-07; timings recorded before the migration may show a
+    # step at the boundary.
     runs-on:
-      group: nvrgfx
-      labels: [Windows, X64, nvrgfx-perf]
+      labels: [Windows, X64, nvrgfx-perf-kernelvm-bridge]
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -70,7 +73,7 @@ jobs:
           # at the release->daily boundary rather than a real regression.
           # SLANG_STANDARD_MODULE_DEVELOP_BUILD=OFF also matches release.yml.
           # LLVM is disabled: the prebuilt slang-llvm artifact links against a newer
-          # MSVC CRT than is available on the nvrgfx-perf runner, causing LNK2001
+          # MSVC CRT than is available on the perf runner, causing LNK2001
           # linker errors. The perf suite only uses SPIRV/Metal/WGSL targets which
           # do not need the LLVM backend.
           cmake --preset default --fresh `

--- a/.github/workflows/nightly-mdl-perf-test.yml
+++ b/.github/workflows/nightly-mdl-perf-test.yml
@@ -12,7 +12,9 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "commit SHA or branch to build (blank = master HEAD)"
+        # actions/checkout resolves branches, tags, and full 40-char SHAs
+        # only; a short SHA fails with "branch or tag not found".
+        description: "full commit SHA or branch to build (blank = master HEAD)"
         default: ""
       samples:
         description: "timed samples per run"

--- a/.github/workflows/nightly-mdl-perf-test.yml
+++ b/.github/workflows/nightly-mdl-perf-test.yml
@@ -220,6 +220,11 @@ jobs:
           mv report_per_workload.html index.html
           # _combined_index.json is a derived intermediate — no need to serve it
           rm -f _combined_index.json
+          # Serve files verbatim: without this marker GitHub Pages runs the
+          # generated report through legacy Jekyll, whose builds have failed
+          # or hung on this content. Must be re-created on every deploy
+          # because the `git rm -rf .` above removes it.
+          touch .nojekyll
 
           git add -A
           if git diff --cached --quiet; then echo "no changes"; exit 0; fi


### PR DESCRIPTION
## Motivation

The compile-perf nightly (`nightly-mdl-perf-test.yml`) has not produced a data point since 2026-07-02: the NVIDIA RGFX perf runners moved to the VM-based GitHub bridge, and no runner serves the old `group: nvrgfx` + `nvrgfx-perf` label pair anymore. Every scheduled run since 2026-07-03 sat `queued` until cancelled by the next night's run. The release-sweep workflow (`compile-perf-release-sweep.yml`) targets the same retired pool and would fail the same way when next used.

## Proposed solution

Target the new bridge. The rtrci github-bridge now has dedicated `shader-slang/slang:windows-x64-perf` / `:linux-x64-perf` targets; the `runs-on` shape follows the slangpy benchmark workflow that already runs on the equivalent slangpy perf targets:

```yaml
runs-on:
  labels: [Windows, X64, nvrgfx-perf-kernelvm-bridge]
```

(no `group:` key — the bridge matches on labels).

## Change summary

| File | Change |
|---|---|
| `.github/workflows/nightly-mdl-perf-test.yml` | New runner labels; comment documents the bridge target and the timing-comparability boundary at the migration date. |
| `.github/workflows/compile-perf-release-sweep.yml` | Same label change; comment notes a re-sweep on the new pool is needed to rebuild a baseline comparable with post-migration nightly points. |
| `.github/actionlint.yaml` | Replace `nvrgfx-perf` with `nvrgfx-perf-kernelvm-bridge` in the allowed self-hosted labels. |

## Timing comparability caveat

The perf series' absolute timings are only comparable within one machine pool. The release history was swept on the retired pre-VM pool, so the daily series will likely show a step at the migration boundary that is a machine change, not a compiler regression. Mitigation (follow-up, not this PR): re-run the release sweep on the new pool to rebuild the baseline; both workflow comments point this out.

## Test plan

- Validation dispatch of the nightly workflow from this branch with `ref=master` — confirms the bridge target picks up the job and produces a normal daily point (also backfills the missing days' gap with today's point).