### PR TITLE
Fix weekly CMake Options CI: GCC maybe-uninitialized in overload inference failure record, missing ASAN link flags in shader-coverage example

### DIFF
--- a/examples/shader-coverage-image-pipeline/CMakeLists.txt
+++ b/examples/shader-coverage-image-pipeline/CMakeLists.txt
@@ -59,6 +59,11 @@ add_executable(
     vk_compute_demo.h
     vk_compute_demo.cpp
 )
+# Apply the project-default compile/link options, as the bvh-traversal demo
+# does. In particular this adds the SLANG_ENABLE_ASAN sanitizer flags to the
+# link line; without them the executable fails to link against the
+# ASAN-instrumented slang libraries in sanitizer builds.
+set_default_compile_options(shader-coverage-image-pipeline USE_FEWER_WARNINGS)
 add_dependencies(shader-coverage-image-pipeline ${_copy_target})
 
 target_include_directories(

--- a/source/compiler-core/slang-source-loc.h
+++ b/source/compiler-core/slang-source-loc.h
@@ -142,10 +142,11 @@ public:
     {
     }
 
-    SourceLoc(SourceLoc const& loc)
-        : raw(loc.raw)
-    {
-    }
+    // Copying must stay defaulted (not user-provided) so SourceLoc remains
+    // trivially copyable: aggregates that embed a SourceLoc in a union rely on
+    // that to get trivial whole-object copies (see
+    // `GenericArgumentInferenceFailure` in slang-check-impl.h).
+    SourceLoc(SourceLoc const& loc) = default;
 
     SLANG_FORCE_INLINE bool operator==(const ThisType& rhs) const { return raw == rhs.raw; }
     SLANG_FORCE_INLINE bool operator!=(const ThisType& rhs) const { return !(raw == rhs.raw); }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -363,6 +363,14 @@ struct GenericArgumentInferenceFailure
     }
 };
 
+// The zero-filling constructor and the implicitly-defaulted copy operations
+// above rely on the whole type — not just each payload — being trivially
+// copyable; assert it so a user-provided copy operation or a non-trivial
+// member cannot be reintroduced without failing the build.
+static_assert(
+    std::is_trivially_copyable_v<GenericArgumentInferenceFailure>,
+    "GenericArgumentInferenceFailure must be trivially copyable");
+
 DeclRefIntVal* getDeclRefIntValIgnoringCasts(IntVal* intVal);
 bool arePackCountExpectedCountsEqual(ASTBuilder* astBuilder, IntVal* left, IntVal* right);
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -9,6 +9,9 @@
 #include "slang-compiler.h"
 #include "slang-visitor.h"
 
+#include <cstring>
+#include <type_traits>
+
 namespace Slang
 {
 template<typename P, typename... Args>
@@ -215,11 +218,6 @@ struct GenericArgumentInferenceFailure
         GenericParamUnificationConflict,
     };
 
-    // Empty payload type for `Kind::None`.
-    struct NonePayload
-    {
-    };
-
     struct VariadicPackCountMismatch
     {
         SourceLoc location = SourceLoc();
@@ -292,9 +290,6 @@ struct GenericArgumentInferenceFailure
     Kind kind = Kind::None;
     union
     {
-        // Keep `Kind::None` as a real active union member; without this, GCC
-        // reports maybe-uninitialized errors when overload candidates are copied.
-        NonePayload nonePayload;
         VariadicPackCountMismatch variadicPackCountMismatch;
         GenericArityMismatch genericArityMismatch;
         OrdinaryGenericParamNotInferred ordinaryGenericParamNotInferred;
@@ -303,39 +298,32 @@ struct GenericArgumentInferenceFailure
         GenericParamUnificationConflict genericParamUnificationConflict;
     };
 
-    // Every payload must be trivially destructible: that is what makes the
-    // placement-new in `set*()` / `copyActiveMemberFrom` (which never destroys
-    // the previously active member first) well-defined.
+    // Every payload must be trivially copyable: that is what lets this struct
+    // use the implicitly-defaulted (trivial) copy/assignment, which copies the
+    // whole object representation instead of switching on `kind` to copy only
+    // the active member. A kind-switched copy performs conditional reads of
+    // individual payload fields, which GCC's -Werror=maybe-uninitialized
+    // rejects (it cannot prove the read member is the initialized one) once
+    // `OverloadCandidate` values are copied inside standard-library
+    // algorithms. Trivial copyability also implies trivial destructibility,
+    // which is what makes the placement-new in the `set*()` members (which
+    // never destroy the previously active member first) well-defined.
     static_assert(
-        std::is_trivially_destructible_v<NonePayload> &&
-            std::is_trivially_destructible_v<VariadicPackCountMismatch> &&
-            std::is_trivially_destructible_v<GenericArityMismatch> &&
-            std::is_trivially_destructible_v<OrdinaryGenericParamNotInferred> &&
-            std::is_trivially_destructible_v<InterfaceConformanceNotSatisfied> &&
-            std::is_trivially_destructible_v<GenericConstraintNotSatisfied> &&
-            std::is_trivially_destructible_v<GenericParamUnificationConflict>,
-        "GenericArgumentInferenceFailure payloads must be trivially destructible");
+        std::is_trivially_copyable_v<VariadicPackCountMismatch> &&
+            std::is_trivially_copyable_v<GenericArityMismatch> &&
+            std::is_trivially_copyable_v<OrdinaryGenericParamNotInferred> &&
+            std::is_trivially_copyable_v<InterfaceConformanceNotSatisfied> &&
+            std::is_trivially_copyable_v<GenericConstraintNotSatisfied> &&
+            std::is_trivially_copyable_v<GenericParamUnificationConflict>,
+        "GenericArgumentInferenceFailure payloads must be trivially copyable");
 
-    GenericArgumentInferenceFailure()
-        : nonePayload()
-    {
-    }
-
-    GenericArgumentInferenceFailure(GenericArgumentInferenceFailure const& other)
-        : kind(other.kind)
-    {
-        copyActiveMemberFrom(other);
-    }
-
-    GenericArgumentInferenceFailure& operator=(GenericArgumentInferenceFailure const& other)
-    {
-        if (this == &other)
-            return *this;
-
-        kind = other.kind;
-        copyActiveMemberFrom(other);
-        return *this;
-    }
+    // Zero the tag and the full union storage so every byte of the object is
+    // initialized from birth and the trivial copy above never reads an
+    // indeterminate byte. `Kind::None` is value zero, so the zeroed tag is the
+    // correct "no failure recorded" state; assert that so a reordering of the
+    // enum cannot silently break this constructor.
+    static_assert(int(Kind::None) == 0, "zero-initialized tag must mean Kind::None");
+    GenericArgumentInferenceFailure() { std::memset(static_cast<void*>(this), 0, sizeof(*this)); }
 
     // Select a union variant and return a reference for the caller to populate.
     // Each setter begins the chosen member's lifetime with placement-new and
@@ -372,48 +360,6 @@ struct GenericArgumentInferenceFailure
     {
         kind = Kind::GenericParamUnificationConflict;
         return *new (&genericParamUnificationConflict) GenericParamUnificationConflict();
-    }
-
-private:
-    // Begin the lifetime of whichever union member `kind` selects, copy-
-    // constructing it from `other`'s active member. The payloads embed a
-    // `SourceLoc`, which has a user-provided copy constructor and so is not
-    // trivially copyable; assigning into a union member whose lifetime has not
-    // begun would be undefined. Placement-new starts that lifetime correctly
-    // for both copy construction (no member live yet) and copy assignment (the
-    // previously active member is trivially destructible, so it needs no
-    // explicit destruction before the new member is constructed in place).
-    void copyActiveMemberFrom(GenericArgumentInferenceFailure const& other)
-    {
-        switch (other.kind)
-        {
-        case Kind::VariadicPackCountMismatch:
-            new (&variadicPackCountMismatch)
-                VariadicPackCountMismatch(other.variadicPackCountMismatch);
-            break;
-        case Kind::GenericArityMismatch:
-            new (&genericArityMismatch) GenericArityMismatch(other.genericArityMismatch);
-            break;
-        case Kind::OrdinaryGenericParamNotInferred:
-            new (&ordinaryGenericParamNotInferred)
-                OrdinaryGenericParamNotInferred(other.ordinaryGenericParamNotInferred);
-            break;
-        case Kind::InterfaceConformanceNotSatisfied:
-            new (&interfaceConformanceNotSatisfied)
-                InterfaceConformanceNotSatisfied(other.interfaceConformanceNotSatisfied);
-            break;
-        case Kind::GenericConstraintNotSatisfied:
-            new (&genericConstraintNotSatisfied)
-                GenericConstraintNotSatisfied(other.genericConstraintNotSatisfied);
-            break;
-        case Kind::GenericParamUnificationConflict:
-            new (&genericParamUnificationConflict)
-                GenericParamUnificationConflict(other.genericParamUnificationConflict);
-            break;
-        case Kind::None:
-            new (&nonePayload) NonePayload(other.nonePayload);
-            break;
-        }
     }
 };
 


### PR DESCRIPTION
## Motivation

The weekly scheduled "CMake Options" workflow has been failing on `master` (run [28701060130](https://github.com/shader-slang/slang/actions/runs/28701060130)). Two independent code problems account for the failures (a third failing job, `linux-release / SLANG_LIB_TYPE STATIC`, was runner disk exhaustion — infra, not addressed here):

**1. All 30 `linux-aarch64-release` jobs fail to compile** `slang-check-overload.cpp` with GCC `-Werror=maybe-uninitialized`:

```
slang-source-loc.h:146: '...OverloadCandidate::genericInferenceFailure...SourceLoc::raw'
    may be used uninitialized [-Werror=maybe-uninitialized]
slang-check-impl.h:256: '...VariadicPackCountMismatch::expectedCount' may be used uninitialized
slang-check-impl.h:284: '...GenericParamUnificationConflict::secondVal' may be used uninitialized
```

`GenericArgumentInferenceFailure` (introduced in #11571) is a hand-rolled tagged union whose copy constructor and copy assignment switch on `kind` and copy only the active union member (`copyActiveMemberFrom`). When an `OverloadCandidate` containing this struct is copied inside a standard-library algorithm during overload resolution, GCC sees conditional reads of individual payload fields on an object whose other union bytes are legitimately uninitialized, and it cannot prove that the member being read is the one that was initialized — so it reports `maybe-uninitialized`. Only the aarch64 jobs hit this because they run on `ubuntu-24.04-arm` with a newer GCC than the x64 jobs; and because this workflow runs weekly, regular PR CI never caught it.

This is the second attempt at this warning: #11807 (commit `502f1a8d9`, merged June 29) added a `NonePayload` union member so `Kind::None` would be a real active member copied like the others. That did not work — the failing July 4 run's head (`8ac9e49a5`) already contains `502f1a8d9`, and GCC reports the same errors. The workaround addressed only the `None` case, but GCC's objection is to the kind-switched copy itself: at each conditional read it cannot prove the member being read is the initialized one, whichever kind is active.

**2. The `linux-debug / SLANG_ENABLE_ASAN` job fails to link** the `shader-coverage-image-pipeline` example:

```
undefined reference to symbol '__asan_stack_malloc_0'
libasan.so.6: error adding symbols: DSO missing from command line
```

The example links the ASAN-instrumented `slang` / `core` libraries but never receives the `-fsanitize=address` link flag itself, so the sanitizer runtime is missing from its link line.

## Proposed solution

**For the GCC error**, fix the producer rather than suppressing the warning. The reason the payloads are not trivially copyable — which is what forced the kind-switched copy in the first place — is that `SourceLoc` carries a user-provided copy constructor that does exactly what the defaulted one would do (`raw(loc.raw)`). Defaulting it makes `SourceLoc`, and therefore every failure payload, trivially copyable. `GenericArgumentInferenceFailure` can then drop its user-provided copy constructor, copy assignment, and `copyActiveMemberFrom` entirely and rely on the implicitly-defaulted *trivial* copy, which copies the whole object representation with no conditional per-field reads — the exact pattern GCC was rejecting no longer exists in the code. The default constructor zeroes the entire object (tag plus full union storage) so the trivial copy never reads an indeterminate byte. Two `static_assert`s pin the invariants so they cannot silently regress: every payload must remain trivially copyable, and `Kind::None` must remain value zero.

This is a net deletion of ~70 lines of special-case copy machinery, replaced by compiler-generated copies.

**For the ASAN link failure**, apply the project-default compile/link options to the example — the same one-line `set_default_compile_options(... USE_FEWER_WARNINGS)` call its sibling demo `shader-coverage-bvh-traversal` already makes (`examples/shader-coverage-bvh-traversal/CMakeLists.txt:60`). That helper is what attaches the `SLANG_ENABLE_ASAN` sanitizer flags (`cmake/CompilerFlags.cmake:236`).

## Change summary

| File | Change |
| --- | --- |
| `source/compiler-core/slang-source-loc.h` | `SourceLoc`'s copy constructor is now `= default` (it was user-provided but semantically identical), making `SourceLoc` trivially copyable; a comment pins why this must stay defaulted. |
| `source/slang/slang-check-impl.h` | `GenericArgumentInferenceFailure`: deleted the user-provided copy constructor, copy assignment, `copyActiveMemberFrom`, and the `NonePayload` workaround member; the default constructor now zero-fills the whole object; the `static_assert` upgraded from trivially-destructible to trivially-copyable payloads, plus a new assert that `Kind::None == 0`. Added `<cstring>`/`<type_traits>` includes. |
| `examples/shader-coverage-image-pipeline/CMakeLists.txt` | Added `set_default_compile_options(shader-coverage-image-pipeline USE_FEWER_WARNINGS)`, matching the bvh-traversal sibling, so ASAN builds put `-fsanitize=address` on the example's link line. |

## Concepts and vocabulary

- **`GenericArgumentInferenceFailure`** — a tagged union recorded on `OverloadCandidate` by the generic solver, capturing the first concrete reason a generic candidate failed inference; `CompleteOverloadCandidate` formats it into a focused diagnostic only if that candidate is ultimately selected.
- **Trivially copyable** — a type the compiler may copy as raw bytes (memcpy semantics). A user-provided copy constructor disqualifies a type even when its body is identical to the defaulted one; that disqualification propagates to every aggregate containing the type, and to unions it forces user-written member-wise copy code.

## Process report

**`SourceLoc` copy constructor (`slang-source-loc.h`).** Input-shape check: the "shape" GCC objected to — a union copied member-by-member under a runtime tag — existed only because `SourceLoc`'s user-provided copy constructor made the payloads non-trivially-copyable. That constructor (`SourceLoc(SourceLoc const& loc) : raw(loc.raw)`) is byte-for-byte what the defaulted one does, so the non-triviality was accidental, not a modeled invariant. Defaulting it is the producer-side fix; everything downstream simplifies as a consequence. No behavior changes: copy semantics are identical. (`SourceLoc` is internal to the compiler — `source/compiler-core/` — not part of the public `include/` API, so there is no ABI-compatibility concern.)

**`GenericArgumentInferenceFailure` copy machinery removal (`slang-check-impl.h`).** With trivially copyable payloads, the union's implicitly-defaulted copy operations are trivial and correct: a whole-object byte copy preserves the tag and the active member's bytes regardless of which member is active. The kind-switched `copyActiveMemberFrom` therefore became dead weight, and per the one-source-of-truth rule it is deleted rather than kept alongside.

**Why removing `NonePayload` does not regress #11807.** `NonePayload` was added by #11807 for this same warning, so its removal deserves an explicit justification. (1) Its purpose was to silence this warning, and the July 4 run — whose head includes #11807 — proves it did not. (2) The invariant it preserved ("every `kind`, including `None`, names a live union member") existed to serve `copyActiveMemberFrom`, which needed a member to copy in every `switch` case; with that copy machinery deleted, the trivial whole-object copy does not depend on which member is live, and the zeroing default constructor guarantees the copied bytes are never indeterminate. (3) No consumer reads a payload for `Kind::None`: every payload access in `CompleteOverloadCandidate` (`slang-check-overload.cpp:1529`) sits inside the `switch (kind)` case matching that payload, and `None` reads nothing. The invariant "`kind` names the live union member" still holds for every kind that has a payload, maintained by the unchanged `set*()` setters.

The zero-filling default constructor is what makes the trivial copy warning-free *and* fully defined: without it, copying a `Kind::None` object would read the union's indeterminate bytes. `std::memset(static_cast<void*>(this), 0, sizeof(*this))` initializes every byte once at construction; `Kind::None` is value zero, so the zeroed tag is the correct initial state, and a `static_assert(int(Kind::None) == 0)` fails the build if the enum is ever reordered. The trivially-copyable `static_assert` (which subsumes the old trivially-destructible one — trivially copyable implies trivially destructible, keeping the placement-new `set*()` members well-defined) fails the build if a future payload gains a non-trivial member and would silently reintroduce the problem.

The `set*()` setters are unchanged: they still placement-new the chosen member and update `kind` in lockstep, so the "`kind` names the live union member" invariant continues to hold by construction at every capture site (`slang-check-constraint.cpp`, `slang-check-overload.cpp`).

Verified locally (Windows/MSVC debug build): the two diagnostic regression tests that exercise the refactored union still emit the expected focused diagnostics — `tests/diagnostics/generic-specialization-variadic-pack-count-constraint.slang` (`VariadicPackCountMismatch`) and `tests/diagnostics/generic-parameter-unification-conflict.slang` (`GenericParamUnificationConflict`), the two payload kinds named in the CI errors. The aarch64 GCC warning itself cannot be reproduced on this machine; the CI run on this PR's base workflows is the final proof, but the flagged pattern (conditional per-field union reads during copy) no longer exists in the code.

**Example CMake fix (`examples/shader-coverage-image-pipeline/CMakeLists.txt`).** Input-shape check: the example's raw `add_executable` deliberately deviates from the standard `example()` helper (documented at the top of that file — it is raw-Vulkan-based pending a slang-rhi feature), so per-target option application is the intended mechanism here, and the sibling bvh-traversal demo already calls `set_default_compile_options` for exactly this purpose. The image-pipeline demo simply omitted the call; adding it restores consistency and gives ASAN builds the sanitizer link flags. The test that fails without it is the `linux-debug SLANG_ENABLE_ASAN=ON` CMake-options CI job.
