### PR TITLE
Zero-initialize bitfield backing storage in synthesized constructor

### DIFF
--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -19737,7 +19737,31 @@ void SemanticsDeclAttributesVisitor::visitStructDecl(StructDecl* structDecl)
             backingMember->nameAndLoc.name =
                 getName(String("$bit_field_backing_") + String(backing_nonce));
             backing_nonce++;
-            backingMember->initExpr = nullptr;
+            // Give the synthesized backing storage an explicit zero initializer.
+            // The backing field is synthesized after the constructor signature has been
+            // collected, so it is never a constructor parameter (not in
+            // `m_membersVisibleInCtor`); with a null `initExpr`,
+            // `synthesizeCtorBodyForMemberVar` early-outs for non-parameter members and
+            // never writes it, so `Foo f = {}` on a struct that mixes bitfields with a
+            // normal field would leave the bitfield members reading uninitialized memory
+            // (issue #11844).
+            // The general per-member default-init loop in
+            // `SemanticsDeclBodyVisitor::visitAggTypeDecl` does not cover this: it is gated
+            // on the struct conforming to `IDefaultInitializable`, which these bitfield
+            // structs do not, so it never fires here. Initializing the backing word at the
+            // point of synthesis is therefore the single, uniform source of its zero
+            // default across every synthesized-constructor path.
+            // A raw `IntegerLiteralExpr(0)` (rather than `constructDefaultInitExprForType`)
+            // is deliberate: the backing type is always a builtin unsigned integer
+            // (selected just above), so a typed zero literal is the simplest provably
+            // correct form, and it lowers to an explicit `store 0` on every target —
+            // whereas a `DefaultConstructExpr` emits `= {}` only for CPP/CUDA and would not
+            // zero the scalar on HLSL-class backends.
+            auto zeroBackingInit = m_astBuilder->create<IntegerLiteralExpr>();
+            zeroBackingInit->type = QualType(backingMember->type.type);
+            zeroBackingInit->value = 0;
+            zeroBackingInit->loc = structDecl->loc;
+            backingMember->initExpr = zeroBackingInit;
             backingMember->parentDecl = structDecl;
             const auto backingMemberDeclRef = DeclRef<VarDecl>(backingMember->getDefaultDeclRef());
 

--- a/tests/language-feature/bitfield/default-init-mixed-diagnostic.slang
+++ b/tests/language-feature/bitfield/default-init-mixed-diagnostic.slang
@@ -1,0 +1,20 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):
+
+// Regression for shader-slang/slang#11844: a struct that mixes bitfields with a
+// trailing normal field must NOT emit warning E41021 ("default initializer will
+// not initialize field '$bit_field_backing_0'") for `{}`. The synthesized
+// constructor now zero-initializes the bitfield backing word, so the field is
+// fully initialized. With exhaustive diagnostic matching (no annotations below),
+// this test fails if any diagnostic — including E41021 — is emitted.
+
+struct Test
+{
+    uint a : 10;
+    uint b : 22;
+    uint c;
+};
+
+void test()
+{
+    Test t = {};
+}

--- a/tests/language-feature/bitfield/default-init-mixed-emit.slang
+++ b/tests/language-feature/bitfield/default-init-mixed-emit.slang
@@ -1,0 +1,19 @@
+//TEST:SIMPLE(filecheck=CHECK):-target hlsl -entry computeMain -stage compute
+
+// Regression for shader-slang/slang#11844: the synthesized constructor for a struct that
+// mixes bitfields with a trailing normal field must store zero into the hidden bitfield
+// backing word. This emit-level check is deterministic and backend-robust (no memory or
+// GPU dependence): the explicit zero initializer lowers to a `store 0` of the backing
+// word in the generated constructor. Before the fix, the constructor wrote only the
+// normal field and left the backing word unwritten.
+
+struct Test { uint a : 10; uint b : 22; uint c; };
+RWStructuredBuffer<Test> outputBuffer;
+
+// CHECK: {{.*}}bit_field_backing{{.*}} = {{.*}}0
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    Test t = {};
+    outputBuffer[0] = t;
+}

--- a/tests/language-feature/bitfield/default-init-mixed.slang
+++ b/tests/language-feature/bitfield/default-init-mixed.slang
@@ -1,0 +1,55 @@
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type -compile-arg -msvc-style-bitfield-packing
+
+// Regression for shader-slang/slang#11844: empty/partial initialization of a struct
+// that mixes bitfields with a trailing normal field must zero-initialize the hidden
+// bitfield backing storage. The defect is in front-end constructor synthesis and is
+// therefore target-independent, so a -cpu run is sufficient (the local environment has
+// no GPU); the second directive re-runs the same shader under MSVC bit-packing to cover
+// that backing-layout path. The deterministic, backend-robust gates for this fix are the
+// emit-level companion (default-init-mixed-emit.slang) and the E41021 diagnostic test
+// (default-init-mixed-diagnostic.slang); this test additionally exercises the 32-bit,
+// 64-bit (BaseType::UInt64) and two-backing-word lowering branches at runtime.
+
+// CHECK: 0
+// CHECK-NEXT: 0
+// CHECK-NEXT: 0
+// CHECK-NEXT: 0
+// CHECK-NEXT: 0
+// CHECK-NEXT: 7
+// CHECK-NEXT: 0
+// CHECK-NEXT: 0
+// CHECK-NEXT: 0
+// CHECK-NEXT: 0
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<uint> outputBuffer;
+
+// 32-bit backing word + a trailing normal field (the original repro).
+struct Mixed32 { uint a : 10; uint b : 22; uint c; };
+// 64-bit backing word (the BaseType::UInt64 branch) + a trailing normal field.
+struct Mixed64 { uint64_t a : 40; uint64_t b : 20; uint c; };
+// Two backing words: a normal field separates two bitfield runs.
+struct TwoWord { uint x : 8; uint mid; uint y : 8; };
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    Mixed32 m0 = {};   // a, b, c all zero
+    outputBuffer[0] = m0.a;
+    outputBuffer[1] = m0.b;
+    outputBuffer[2] = m0.c;
+
+    Mixed32 m1 = {7};  // c == 7; a, b zero (backing word zero-initialized)
+    outputBuffer[3] = m1.a;
+    outputBuffer[4] = m1.b;
+    outputBuffer[5] = m1.c;
+
+    Mixed64 m2 = {};   // 64-bit backing word zero-initialized
+    outputBuffer[6] = uint(m2.a);
+    outputBuffer[7] = uint(m2.b);
+
+    TwoWord m3 = {};   // both backing words zero-initialized
+    outputBuffer[8] = m3.x;
+    outputBuffer[9] = m3.y;
+}


### PR DESCRIPTION
## Motivation

Default-initializing (`{}`) a struct that **mixes bitfields with a trailing normal field** left the hidden bitfield backing word uninitialized, so the bitfield members read garbage. The compiler even warned about it (`warning[E41021]: default initializer will not initialize field '$bit_field_backing_0'`) — the warning was the accurate messenger of a real correctness bug, not a false positive.

Consider this example:

```slang
struct Test { uint a : 10; uint b : 22; uint c; };

[shader("compute")][numthreads(1,1,1)]
void testMain(RWStructuredBuffer<Test> output)
{
    Test test = {};
    output[0] = test;
}
```

On `master`, `slangc -target hlsl` synthesizes a constructor that writes only `c`:

```hlsl
Test_0 Test_x24init_0(uint c_1)
{
    Test_0 _S1;
    _S1.c_0 = c_1;          // backing word x24bit_field_backing_0_0 is never written
    return _S1;
}
```

so `test.a` / `test.b` read uninitialized memory. Removing `c` (bitfields-only) produced correct zero-init; an all-normal-fields struct was also fine. Only the mixed case was broken.

## Proposed solution

Give the synthesized bitfield backing storage an explicit zero initializer at the point it is created (a producer-side fix). The backing `VarDecl` is synthesized **after** the constructor signature has been collected, so it is never a constructor parameter; giving it a zero `initExpr` makes the synthesized constructor body store `backing = 0` **without** adding a parameter to the public signature. After the fix the same emitted constructor is:

```hlsl
Test_0 Test_x24init_0(uint c_1)
{
    Test_0 _S1;
    _S1.x24bit_field_backing_0_0 = 0U;   // now initialized
    _S1.c_0 = c_1;
    return _S1;
}
```

This is the principled layer: the invariant "the synthesized bitfield backing word defaults to all-zero bits" belongs at the producer that synthesizes the field, not at the consumer (codegen/empty-init lowering). It is the smallest change that fixes both the warning and the uninitialized-data bug, and it does not reorder any compilation phases.

## Change summary

| File | Change |
| --- | --- |
| `source/slang/slang-check-decl.cpp` | In `SemanticsDeclAttributesVisitor::visitStructDecl`'s bitfield-lowering lambda, the synthesized `$bit_field_backing_N` member now gets a checked zero `IntegerLiteralExpr` (typed to its unsigned-integer backing type) instead of `initExpr = nullptr`. |
| `tests/language-feature/bitfield/default-init-mixed-emit.slang` | New emit-level `SIMPLE(filecheck=CHECK)` test (`-target hlsl`): the synthesized constructor stores `0` into the backing word. Deterministic, backend-robust gate — no memory/GPU dependence. |
| `tests/language-feature/bitfield/default-init-mixed-diagnostic.slang` | New exhaustive `DIAGNOSTIC_TEST`: the mixed struct emits no diagnostics for `{}` (E41021 no longer fires). |
| `tests/language-feature/bitfield/default-init-mixed.slang` | New CPU `COMPARE_COMPUTE` runtime check (default + MSVC packing): `{}`/partial `{7}` init of a 32-bit-backing struct, a 64-bit-backing struct (`BaseType::UInt64` branch) and a two-backing-word struct all read their bitfield members as `0`. |

## Concepts and vocabulary

- **Bitfield backing field** — bitfield members (`a : 10`) are lowered to `PropertyDecl`s (getters/setters with no storage); their bits live in a synthesized `VarDecl` named `$bit_field_backing_N`. A normal field (`uint c;`) is a stored `VarDecl`.
- **`m_membersVisibleInCtor`** — the set of members that become parameters of the synthesized member-wise constructor. It is populated from the *original* declared members before the backing field exists, so the backing field is never in it.

## Process report

Root cause (code trace, `source/slang/slang-check-decl.cpp`):

1. `SemanticsDeclAttributesVisitor::visitStructDecl` synthesizes the constructor signature via `collectInitializableMembers`, which fills `m_membersVisibleInCtor` from the original instance `VarDeclBase` members. Bitfields `a`/`b` are `PropertyDecl`s (excluded); only `c` is added.
2. The bitfield-lowering lambda then creates the backing `VarDecl` and inserts it via `_insertDirectMemberDeclAtIndexForBitfieldPropertyBackingMember` — **after** the signature was collected — so it is never added to `m_membersVisibleInCtor`.
3. In `synthesizeCtorBodyForMemberVar` (`slang-check-decl.cpp:14108`), for the backing field `useParamList = isMemberInitCtor && m_membersVisibleInCtor.contains(backing)` is `false` (`:14127`), so control reaches `if (!varDeclBase->initExpr) return;` (`:14133`). With a null `initExpr` the backing member is **never assigned**, so the member-init ctor `$init(uint c)` stores only `c`. That ctor is non-empty, so it is used for `{}` — leaving the backing word uninitialized.

Why the working cases differ: a **bitfields-only** struct has no stored non-bitfield member visible to the ctor, so the synthesized default-ctor body is empty and is removed; `{}` then falls back to whole-struct zero-init, which covers the backing word. An **all-normal** struct makes every field a parameter, so all are assigned.

Why the general default-init path doesn't already cover it: the per-member default-init loop in `SemanticsDeclBodyVisitor::visitAggTypeDecl` is gated on the struct conforming to `IDefaultInitializable`, which these bitfield structs do not. So that loop never fires for bitfield structs. The `{}` mechanism is the synthesized member-wise/default constructor, and the bitfield backing word's zero default is an invariant of the bitfield lowering itself; expressing it at the producer (synthesis) is the single, uniform source covering every synthesized-constructor path.

The fix sets `backingMember->initExpr` to a zero `IntegerLiteralExpr` typed to the backing member's type. A non-null `initExpr` makes `synthesizeCtorBodyForMemberVar` skip the early-out and store `backing = 0`; the per-member default-init loop only fills members *lacking* an `initExpr`, so there is no double-initialization. A raw `IntegerLiteralExpr(0)` is used rather than `constructDefaultInitExprForType` because the backing type is always a builtin unsigned integer: a typed zero literal is the simplest provably-correct form and lowers to an explicit `store 0` on every target, whereas a `DefaultConstructExpr` emits `= {}` only for CPP/CUDA and would not zero the scalar on HLSL-class backends.

Input-shape check (is this the right layer?): the backing `VarDecl` is a genuine, intentionally-synthesized storage member; the bug is that the producer created it *without* expressing its default value. Fixing the producer is correct — the alternatives are worse: adding the backing field to `m_membersVisibleInCtor` would leak `$bit_field_backing_0` as a public constructor parameter, and forcing whole-struct zero-init for `{}` even when a member-wise ctor exists would change empty-init semantics broadly and mask the producer gap.

Verification: the emitted constructor now writes `_S1.x24bit_field_backing_0_0 = 0U;` and `E41021` no longer fires. `tests/language-feature/bitfield/` and `tests/initializer-list/` pass with no regressions; the existing E41021 positive test `struct-visibility-diagnostic-2.slang` still fires as expected.

Closes #11844.