### PR TITLE
Fix #7878: diagnose default-construct of opaque handle instead of crashing

### DIFF
--- a/source/slang/slang-ir-check-unsupported-inst.cpp
+++ b/source/slang/slang-ir-check-unsupported-inst.cpp
@@ -192,6 +192,29 @@ void checkUnsupportedInst(TargetRequest* target, IRFunc* func, DiagnosticSink* s
                     }
                 }
                 break;
+            case kIROp_DefaultConstruct:
+                if (rejectOpaqueLocals)
+                {
+                    // There is no default/zero value for an opaque handle (an
+                    // image/sampler/subpass/acceleration-structure has no bit
+                    // pattern we can materialize), so a `defaultConstruct` of such
+                    // a type is invalid output for Khronos/WGSL. This typically
+                    // arises from `Optional<Texture2D>` being lowered when a
+                    // generic wrapper is instantiated with a resource type and a
+                    // `none` payload is default-constructed (issue #7878); the
+                    // front-end `Optional<T>` check does not fire because `T` is
+                    // only known after specialization. Diagnose instead of letting
+                    // the unhandled inst reach spirv-emit and abort.
+                    if (auto handleType = findUnstorableOpaqueHandleType(inst->getDataType()))
+                    {
+                        auto loc =
+                            inst->sourceLoc.isValid() ? inst->sourceLoc : findFirstUseLoc(inst);
+                        sink->diagnose(Diagnostics::OpaqueTypeInLocalVariableNotAllowedOnKhronos{
+                            .type = handleType,
+                            .location = loc});
+                    }
+                }
+                break;
             }
 
             // A `String` value has no valid lowering for a kernel C++/CUDA

--- a/source/slang/slang-ir-lower-optional-type.cpp
+++ b/source/slang/slang-ir-lower-optional-type.cpp
@@ -172,7 +172,11 @@ struct OptionalTypeLoweringContext
             // Synthesize a default-constructed placeholder for the payload.
             // The payload is semantically irrelevant when hasValue == false,
             // but we need a well-formed value to satisfy the struct layout.
+            // Carry the `none`'s source location onto the placeholder so that a
+            // later diagnostic (e.g. rejecting a default-constructed opaque
+            // handle on Khronos targets, issue #7878) points at the user's code.
             auto defaultVal = builder->emitDefaultConstruct(info->valueType);
+            defaultVal->sourceLoc = inst->sourceLoc;
             List<IRInst*> operands;
             operands.add(defaultVal);
             operands.add(builder->getBoolValue(false));

--- a/source/slang/slang-ir-lower-optional-type.cpp
+++ b/source/slang/slang-ir-lower-optional-type.cpp
@@ -172,18 +172,23 @@ struct OptionalTypeLoweringContext
             // Synthesize a default-constructed placeholder for the payload.
             // The payload is semantically irrelevant when hasValue == false,
             // but we need a well-formed value to satisfy the struct layout.
-            auto defaultVal = builder->emitDefaultConstruct(info->valueType);
-            // Carry the `none`'s source location onto the placeholder so that a
+            //
+            // Carry the `none`'s source location onto the synthesized insts so a
             // later diagnostic (e.g. rejecting a default-constructed opaque
             // handle on Khronos targets, issue #7878) points at the user's code.
-            // Only do this when the placeholder is a freshly-created
-            // `DefaultConstruct` inst (the shape produced for opaque/resource
-            // payloads that the diagnostic targets); for primitive payloads
-            // `emitDefaultConstruct` returns a hoisted, deduplicated constant
-            // (e.g. `getIntValue(0)`) shared with unrelated users, and mutating
-            // its `sourceLoc` would corrupt those.
-            if (as<IRDefaultConstruct>(defaultVal))
-                defaultVal->sourceLoc = inst->sourceLoc;
+            // A source-loc scope is used rather than assigning `sourceLoc`
+            // directly because for an aggregate payload `emitDefaultConstruct`
+            // wraps the inner `DefaultConstruct` (the inst the diagnostic keys
+            // on) in a `MakeStruct`/`MakeTuple`/`MakeArray`; the scope applies to
+            // every freshly created inst, including those nested ones. Hoisted,
+            // deduplicated primitive constants (e.g. `getIntValue(0)` for an
+            // `Optional<int>` payload) do not inherit builder source locations,
+            // so shared constants are left untouched.
+            IRInst* defaultVal;
+            {
+                IRBuilderSourceLocRAII sourceLocScope(builder, inst->sourceLoc);
+                defaultVal = builder->emitDefaultConstruct(info->valueType);
+            }
             List<IRInst*> operands;
             operands.add(defaultVal);
             operands.add(builder->getBoolValue(false));

--- a/source/slang/slang-ir-lower-optional-type.cpp
+++ b/source/slang/slang-ir-lower-optional-type.cpp
@@ -172,11 +172,18 @@ struct OptionalTypeLoweringContext
             // Synthesize a default-constructed placeholder for the payload.
             // The payload is semantically irrelevant when hasValue == false,
             // but we need a well-formed value to satisfy the struct layout.
+            auto defaultVal = builder->emitDefaultConstruct(info->valueType);
             // Carry the `none`'s source location onto the placeholder so that a
             // later diagnostic (e.g. rejecting a default-constructed opaque
             // handle on Khronos targets, issue #7878) points at the user's code.
-            auto defaultVal = builder->emitDefaultConstruct(info->valueType);
-            defaultVal->sourceLoc = inst->sourceLoc;
+            // Only do this when the placeholder is a freshly-created
+            // `DefaultConstruct` inst (the shape produced for opaque/resource
+            // payloads that the diagnostic targets); for primitive payloads
+            // `emitDefaultConstruct` returns a hoisted, deduplicated constant
+            // (e.g. `getIntValue(0)`) shared with unrelated users, and mutating
+            // its `sourceLoc` would corrupt those.
+            if (as<IRDefaultConstruct>(defaultVal))
+                defaultVal->sourceLoc = inst->sourceLoc;
             List<IRInst*> operands;
             operands.add(defaultVal);
             operands.add(builder->getBoolValue(false));

--- a/tests/diagnostics/optional-resource-generic-none-aggregate.slang
+++ b/tests/diagnostics/optional-resource-generic-none-aggregate.slang
@@ -1,0 +1,35 @@
+// Issue #7878, aggregate-payload variant. When the Optional payload is a struct
+// (or tuple/array) that transitively contains an opaque handle, the lowering's
+// `emitDefaultConstruct` wraps the inner `DefaultConstruct` in a `MakeStruct`,
+// so the diagnostic keys on that nested inst. This test pins the source location
+// with a caret to verify the source-loc *scope* in the Optional lowering reaches
+// the nested `DefaultConstruct` (a plain `sourceLoc =` on the outer wrapper would
+// miss it and the diagnostic would fall back to `findFirstUseLoc`).
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target spirv
+
+struct Bundle
+{
+    Texture2D tex;
+}
+
+struct Wrapper<T>
+{
+    T value;
+
+    Optional<T> getMaybe()
+    {
+        return none;
+//CHECK:       ^^^^ opaque type in local variable is not supported for Khronos targets
+//CHECK:       ^^^^ a resource or other opaque-typed value ('Texture2D') cannot be placed in a function-local variable for Khronos targets (SPIR-V/GLSL) or WGSL; this usually comes from selecting a resource with control flow (e.g. a '?:' or 'if'/'else') or returning one from a function
+    }
+}
+
+[vk::binding(0, 1)]
+Wrapper<Bundle> wrapper;
+
+[shader("fragment")]
+float4 fs_main() : SV_Target
+{
+    return wrapper.getMaybe().value.tex.Load(int3(0));
+}

--- a/tests/diagnostics/optional-resource-generic-none-glsl.slang
+++ b/tests/diagnostics/optional-resource-generic-none-glsl.slang
@@ -1,0 +1,27 @@
+// Issue #7878, GLSL sibling of optional-resource-generic-none.slang. The new
+// `kIROp_DefaultConstruct` rejection is gated on `isKhronosTarget(target)`, which
+// covers both SPIR-V and GLSL. GLSL has a distinct emit path (slang-emit-glsl.cpp)
+// and could regress independently, so pin the diagnostic for `-target glsl` too.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target glsl
+
+struct TextureArray<T>
+{
+    T textures[];
+
+    __subscript() -> Optional<T>
+    {
+        get { return none; }
+//CHECK:             ^^^^ opaque type in local variable is not supported for Khronos targets
+//CHECK:             ^^^^ a resource or other opaque-typed value ('Texture2D') cannot be placed in a function-local variable for Khronos targets (SPIR-V/GLSL) or WGSL; this usually comes from selecting a resource with control flow (e.g. a '?:' or 'if'/'else') or returning one from a function
+    }
+}
+
+[vk::binding(0, 1)]
+TextureArray<Texture2D> textures;
+
+[shader("fragment")]
+float4 fs_main() : SV_Target
+{
+    return textures[].value.Load(int3(0));
+}

--- a/tests/diagnostics/optional-resource-generic-none-hlsl.slang
+++ b/tests/diagnostics/optional-resource-generic-none-hlsl.slang
@@ -1,0 +1,31 @@
+// Issue #7878 polarity test: the default-constructed-opaque-handle rejection in
+// checkUnsupportedInst is specific to Khronos/WGSL. On HLSL/D3D a resource
+// `Optional<T>` with a `none` payload lowers to an (uninitialized) resource
+// local, which is valid HLSL, so the same source that is rejected for SPIR-V
+// must compile cleanly here. This pins the `rejectOpaqueLocals` gate against a
+// polarity regression that would otherwise spuriously reject valid HLSL if the
+// new `kIROp_DefaultConstruct` check were hoisted out of the guard.
+
+//TEST:SIMPLE(filecheck=CHECK):-target hlsl -entry fs_main -stage fragment
+
+struct TextureArray<T>
+{
+    T textures[];
+
+    __subscript() -> Optional<T>
+    {
+        get { return none; }
+    }
+}
+
+[vk::binding(0, 1)]
+TextureArray<Texture2D> textures;
+
+[shader("fragment")]
+float4 fs_main() : SV_Target
+{
+    return textures[].value.Load(int3(0));
+}
+
+// CHECK-NOT: opaque type in local variable
+// CHECK: fs_main

--- a/tests/diagnostics/optional-resource-generic-none-sampler.slang
+++ b/tests/diagnostics/optional-resource-generic-none-sampler.slang
@@ -1,0 +1,32 @@
+// Issue #7878: the default-constructed-opaque-handle rejection is not specific
+// to textures. `findUnstorableOpaqueHandleType` returns the leaf handle for any
+// image/sampler/subpass/acceleration-structure type (recursing into aggregates),
+// so a generic `Optional<T>` specialized to `SamplerState` with a `none` payload
+// must be rejected the same way. This guards against a refactor that regresses a
+// non-`Texture2D` handle category while the texture case still passes. The main
+// optional-resource-generic-none.slang test pins the source location; here we
+// match on the message so the assertion is about the `SamplerState` category.
+
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):-target spirv
+
+struct Wrapper<T>
+{
+    T value;
+
+    Optional<T> getMaybe()
+    {
+        // CHECK: error[E56004]
+        // CHECK: 'SamplerState'
+        return none;
+    }
+}
+
+[vk::binding(0, 1)]
+Wrapper<SamplerState> wrapper;
+Texture2D tex;
+
+[shader("fragment")]
+float4 fs_main() : SV_Target
+{
+    return tex.Sample(wrapper.getMaybe().value, float2(0));
+}

--- a/tests/diagnostics/optional-resource-generic-none-wgsl.slang
+++ b/tests/diagnostics/optional-resource-generic-none-wgsl.slang
@@ -1,0 +1,29 @@
+// Issue #7878, WGSL sibling of optional-resource-generic-none.slang. The new
+// `kIROp_DefaultConstruct` rejection in checkUnsupportedInst is gated on
+// `isKhronosTarget(target) || isWGPUTarget(target)`, so WGSL is behaviorally
+// coupled to this fix: a default-constructed opaque handle (from `Optional<T>`
+// specialized to a resource and a `none` payload) must be rejected here too, not
+// just on SPIR-V/GLSL.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target wgsl
+
+struct TextureArray<T>
+{
+    T textures[];
+
+    __subscript() -> Optional<T>
+    {
+        get { return none; }
+//CHECK:             ^^^^ opaque type in local variable is not supported for Khronos targets
+//CHECK:             ^^^^ a resource or other opaque-typed value ('Texture2D') cannot be placed in a function-local variable for Khronos targets (SPIR-V/GLSL) or WGSL; this usually comes from selecting a resource with control flow (e.g. a '?:' or 'if'/'else') or returning one from a function
+    }
+}
+
+[vk::binding(0, 1)]
+TextureArray<Texture2D> textures;
+
+[shader("fragment")]
+float4 fs_main() : SV_Target
+{
+    return textures[].value.Load(int3(0));
+}

--- a/tests/diagnostics/optional-resource-generic-none.slang
+++ b/tests/diagnostics/optional-resource-generic-none.slang
@@ -5,8 +5,12 @@
 // (E30902) does not fire here because `T` is only known to be `Texture2D` after
 // specialization. The compiler must reject this with a diagnostic rather than
 // crash: there is no default/zero value for an opaque handle on Khronos targets.
+//
+// The caret pins the diagnostic to the user's `none`, exercising the
+// `defaultVal->sourceLoc = inst->sourceLoc` propagation in the Optional lowering;
+// without it the location would fall back to a synthesized inst's use.
 
-//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):-target spirv
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target spirv
 
 struct TextureArray<T>
 {
@@ -14,8 +18,9 @@ struct TextureArray<T>
 
     __subscript() -> Optional<T>
     {
-        // CHECK: error[E56004]
         get { return none; }
+//CHECK:             ^^^^ opaque type in local variable is not supported for Khronos targets
+//CHECK:             ^^^^ a resource or other opaque-typed value ('Texture2D') cannot be placed in a function-local variable for Khronos targets (SPIR-V/GLSL) or WGSL; this usually comes from selecting a resource with control flow (e.g. a '?:' or 'if'/'else') or returning one from a function
     }
 }
 

--- a/tests/diagnostics/optional-resource-generic-none.slang
+++ b/tests/diagnostics/optional-resource-generic-none.slang
@@ -6,7 +6,7 @@
 // specialization. The compiler must reject this with a diagnostic rather than
 // crash: there is no default/zero value for an opaque handle on Khronos targets.
 
-//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target spirv
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):-target spirv
 
 struct TextureArray<T>
 {
@@ -14,9 +14,8 @@ struct TextureArray<T>
 
     __subscript() -> Optional<T>
     {
+        // CHECK: error[E56004]
         get { return none; }
-//CHECK:             ^^^^ opaque type in local variable is not supported for Khronos targets
-//CHECK:             ^^^^ a resource or other opaque-typed value ('Texture2D') cannot be placed in a function-local variable for Khronos targets (SPIR-V/GLSL) or WGSL; this usually comes from selecting a resource with control flow (e.g. a '?:' or 'if'/'else') or returning one from a function
     }
 }
 

--- a/tests/diagnostics/optional-resource-generic-none.slang
+++ b/tests/diagnostics/optional-resource-generic-none.slang
@@ -1,0 +1,30 @@
+// Regression test for issue #7878: returning `none` from a generic wrapper's
+// `Optional<T>` accessor, then instantiating the wrapper with a resource type,
+// used to reach spirv-emit as a `defaultConstruct` of an opaque handle and abort
+// with "Unhandled local inst in spirv-emit". The front-end `Optional<T>` check
+// (E30902) does not fire here because `T` is only known to be `Texture2D` after
+// specialization. The compiler must reject this with a diagnostic rather than
+// crash: there is no default/zero value for an opaque handle on Khronos targets.
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-target spirv
+
+struct TextureArray<T>
+{
+    T textures[];
+
+    __subscript() -> Optional<T>
+    {
+        get { return none; }
+//CHECK:             ^^^^ opaque type in local variable is not supported for Khronos targets
+//CHECK:             ^^^^ a resource or other opaque-typed value ('Texture2D') cannot be placed in a function-local variable for Khronos targets (SPIR-V/GLSL) or WGSL; this usually comes from selecting a resource with control flow (e.g. a '?:' or 'if'/'else') or returning one from a function
+    }
+}
+
+[vk::binding(0, 1)]
+TextureArray<Texture2D> textures;
+
+[shader("fragment")]
+float4 fs_main() : SV_Target
+{
+    return textures[].value.Load(int3(0));
+}


### PR DESCRIPTION
## Motivation

Returning `none` from a generic wrapper's `Optional<T>` accessor and then instantiating the wrapper with a resource type crashes spirv-emit. Minimal reproducer (issue #7878):

```slang
struct TextureArray<T> {
    T textures[];
    __subscript() -> Optional<T> {
        get { return none; }
    }
}

[vk::binding(0, 1)]
TextureArray<Texture2D> textures;

[shader("fragment")]
float4 fs_main() : SV_Target {
    return textures[].value.Load(int3(0));
}
```

```
error 99999: ... unimplemented: Unhandled local inst in spirv-emit:
let  %1 : %2 = defaultConstruct
```

The front-end already rejects a concrete `Optional<resource>` with `E30902`, but that check runs on the type as written. Here `Optional<T>` is generic, so `T` is only known to be `Texture2D` after IR specialization, and the check never fires. The `Optional<Texture2D>` lowering then synthesizes a `defaultConstruct` placeholder for the `none` payload (`slang-ir-lower-optional-type.cpp`), and a `defaultConstruct` of a texture has no valid lowering on Khronos targets, so it reaches the emitter and aborts.

On HLSL (and Metal) the same code compiles — it emits an uninitialized resource local — so this is a Khronos/WGSL-specific legalization limitation, not a universal error.

## Proposed solution

Reject the invalid IR with a diagnostic in `checkUnsupportedInst` — the existing target-gated pass whose job is to reject opaque-typed output that Khronos/WGSL cannot legalize (it already handles `Var` of an opaque handle from control-flow selection, issue #10526). A `defaultConstruct` whose result type is (or transitively contains) an unstorable opaque handle is the same class of invalid output, so it's diagnosed with the same `OpaqueTypeInLocalVariableNotAllowedOnKhronos` diagnostic. This keeps the emitter simple and matches the guidance from the issue that `defaultConstruct` should never appear for a non-default-constructable opaque type.

To give the diagnostic a good source location, the `none`-payload placeholder synthesized in `processMakeOptionalNone` is emitted inside an `IRBuilderSourceLocRAII` scope carrying the `IRMakeOptionalNone`'s location. This propagates to every freshly-created inst, including the inner `DefaultConstruct` that `emitDefaultConstruct` wraps in a `MakeStruct`/`MakeTuple`/`MakeArray` for aggregate payloads, while deduplicated primitive constants (which bypass `_maybeSetSourceLoc`) stay untouched.

## Change summary

| File | Change |
|---|---|
| `source/slang/slang-ir-check-unsupported-inst.cpp` | Add a `kIROp_DefaultConstruct` case that diagnoses when the result type contains an unstorable opaque handle (Khronos/WGSL only). |
| `source/slang/slang-ir-lower-optional-type.cpp` | Emit the synthesized default-construct placeholder inside a source-loc scope carrying the `none` location (covers nested aggregate default-constructs; leaves shared constants untouched). |
| `tests/diagnostics/optional-resource-generic-none.slang` | SPIR-V regression test; caret pins the source location. |
| `tests/diagnostics/optional-resource-generic-none-wgsl.slang` | WGSL sibling (the new check is gated on WGSL too). |
| `tests/diagnostics/optional-resource-generic-none-glsl.slang` | GLSL sibling (the `isKhronosTarget` gate covers GLSL, distinct emit path). |
| `tests/diagnostics/optional-resource-generic-none-hlsl.slang` | HLSL must-compile polarity test, guarding the `rejectOpaqueLocals` gate. |
| `tests/diagnostics/optional-resource-generic-none-sampler.slang` | Covers the `SamplerState` leaf handle category. |
| `tests/diagnostics/optional-resource-generic-none-aggregate.slang` | Covers a struct-containing-`Texture2D` payload; caret verifies the nested default-construct gets the precise location. |

## Concepts and vocabulary

- **`findUnstorableOpaqueHandleType`** (`slang-ir-check-unsupported-inst.cpp`): returns the leaf opaque handle (image/sampler/subpass/acceleration-structure) that SPIR-V/GLSL forbid from living in a function-local variable, recursing into aggregate element/field types; deliberately narrower than `isOpaqueType` (buffer-backed resources and pointers are allowed).
- **`OpaqueTypeInLocalVariableNotAllowedOnKhronos`** (E56004): existing diagnostic for opaque-typed values that can't be legalized on Khronos/WGSL, typically from selecting or returning a resource through control flow.
- **`IRBuilderSourceLocRAII` / `_maybeSetSourceLoc`**: an RAII scope that makes the builder stamp a source location onto every non-constant inst it creates; deduplicated constants created via `_findOrEmitConstant` do not go through `_maybeSetSourceLoc`, so they never inherit it.

## Process report

The offending inst is created in `processMakeOptionalNone` (`slang-ir-lower-optional-type.cpp`): when lowering `Optional<Texture2D> none`, the pass builds a struct `{ payload, hasValue=false }` and needs a value for `payload`, so it calls `emitDefaultConstruct(Texture2D)`. That inst feeds a `MakeStruct`, so `removeRawDefaultConstructors` (which only strips store-only or struct-typed default constructs) leaves it in place, and `emitLocalInst` in `slang-emit-spirv.cpp` hits its `default:` case and calls `SLANG_UNIMPLEMENTED_X`.

Is that inst shape correct and principled, or should its producer be fixed? The `defaultConstruct` itself is a legitimate representation — the lowering genuinely needs *some* payload value to satisfy the struct layout, and the payload is semantically dead when `hasValue == false`. What is invalid is the *type* it is applied to: there is no default/zero value for an opaque handle on Khronos/WGSL. Diagnosing `Optional<resource>` at the type level is already the front end's job (E30902); the only gap is generic instantiation, which is resolved after the front end during IR specialization. So the correct layer for the *specialized* case is an IR check after specialization, and `checkUnsupportedInst` is exactly that pass — it already rejects the sibling case (an opaque handle forced into a local by control flow). Adding a `DefaultConstruct` case there is consistent with the pass's existing contract rather than a new special case bolted onto emit.

The source-location handling is a diagnostic-quality change; the synthesized placeholder previously had no location, so the fallback would point at an unrelated use. It uses a source-loc scope rather than a direct `sourceLoc` assignment because (a) for aggregate payloads the inner `DefaultConstruct` (the inst the diagnostic keys on) is nested inside a `MakeStruct`, and (b) `emitDefaultConstruct` returns a shared, deduplicated constant for primitive payloads (`Optional<int>`, …) whose `sourceLoc` must not be mutated. The scope satisfies both: it reaches nested insts and skips constants, which don't inherit builder locations.