### PR TITLE
Disable AVX-512 for sanitizer tests

### DIFF
--- a/.github/workflows/ci-slang-sanitizer.yml
+++ b/.github/workflows/ci-slang-sanitizer.yml
@@ -198,6 +198,10 @@ jobs:
 
           export SLANG_RUN_SPIRV_VALIDATION=1
           export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1
+          # Sanitizer tests exercise the LLVM JIT on GCP runners that can
+          # mis-report AVX-512 support and emit instructions the host cannot
+          # execute (#11831).
+          export SLANG_DISABLE_AVX512=1
 
           echo "=== Pre-flight checks ==="
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"


### PR DESCRIPTION
Fixes #11831

## Motivation

The Linux sanitizer workflow runs `slang-test` CPU and LLVM test paths on the GCP runner pool. When a runner reports AVX-512 support that its host cannot reliably execute, slang-llvm can emit AVX-512 instructions and the test process can terminate with `SIGILL` instead of completing the sanitizer run.

The regular CPU-only and Linux coverage workflows already opt into Slang's AVX-512 mitigation, but the sanitizer workflow did not.

## Proposed solution

Set `SLANG_DISABLE_AVX512=1` only for the sanitizer workflow's main test step. This reuses the existing CI-specific mitigation in `disableAVX512ForJIT()` rather than changing production code generation or disabling CPU tests.

## Change summary

- `.github/workflows/ci-slang-sanitizer.yml:201` exports `SLANG_DISABLE_AVX512=1` before invoking `slang-test`.
- The adjacent comment records why the GCP sanitizer runners require the mitigation and links the tracking issue.

## Concepts and vocabulary

- `SLANG_DISABLE_AVX512`: An opt-in CI setting consumed by slang-llvm when it constructs an LLVM JIT target machine. It pins x86-64 JIT code generation to the baseline CPU when set to `1`.

## Process report

`Run Tests with Sanitizers` launches `slang-test`, which exercises CPU/LLVM and synthesized LLVM test paths. Those paths construct an LLVM JIT through `createAVX512SafeLLJIT()` in `source/slang-llvm/slang-llvm-jit-shared-library.cpp`. The helper calls `disableAVX512ForJIT()`, reads `SLANG_DISABLE_AVX512`, and pins the JIT target to baseline `x86-64` when the value is `1`.

Exporting the variable in this test step means it is inherited by `slang-test` and its test-server child processes, while builds and production uses retain normal host feature detection. The separate `slangc` smoke-test step only compiles source and does not execute the LLVM JIT, so it does not need the setting.

This is runner policy rather than a new AST, IR, or input-shape special case. The tested CPU/LLVM shapes remain valid; the change only prevents unreliable runner capability reporting from selecting instructions outside the effective host contract.
