### PR TITLE
CUDA: pass descriptor-table entry-point uniforms by reference (split from #11939; supersedes #11941)

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -967,6 +967,11 @@ Enable GLSL as an input language.
 Enable experimental compiler passes 
 
 
+<a id="cuda-entry-point-params-by-value"></a>
+### -cuda-entry-point-params-by-value
+Pass CUDA entry-point uniform parameters containing fixed-size descriptor arrays by value in kernel-argument space (the legacy ABI), instead of by reference as an implicit ParameterBlock 
+
+
 <a id="enable-experimental-dynamic-dispatch"></a>
 ### -enable-experimental-dynamic-dispatch
 Enable experimental dynamic dispatch features 

--- a/docs/cuda-target.md
+++ b/docs/cuda-target.md
@@ -86,27 +86,52 @@ void computeMain(
 This will be turned into a CUDA entry point with
 
 ```
-struct UniformEntryPointParams
-{
-    Thing thing;
-    Thing thing2;
-};
-
-struct UniformState
+struct GlobalParams
 {
     CUtexObject tex;                // This is the combination of a texture and a sampler(!)
     SamplerState sampler;           // This variable exists within the layout, but it's value is not used.
     RWStructuredBuffer<int32_t> outputBuffer;    // This is implemented as a template in the CUDA prelude. It's just a pointer, and a size
     Thing* thing3;                  // Constant buffers map to pointers
 };
+extern "C" __constant__ GlobalParams SLANG_globalParams;
 
 // [numthreads(4, 1, 1)]
-extern "C" __global__  void computeMain(UniformEntryPointParams* params, UniformState* uniformState)
+extern "C" __global__ void computeMain(Thing thing, Thing thing2)
 ```
+
+Global-scope shader parameters are collected into a single struct stored in the
+module's `__constant__ SLANG_globalParams` symbol; the host writes it once per
+module (or per dispatch, as it sees fit). Entry-point `uniform` parameters are
+passed *by value* as CUDA kernel arguments (the buffer handed to
+`cuLaunchKernel`), acting as root constants.
+
+There is one exception to the by-value rule. CUDA kernel-argument (`.param`)
+space cannot be dynamically indexed efficiently: a runtime index into a by-value
+parameter lowers to a serial per-element load chain. A compute entry-point
+`uniform` parameter of struct type that carries a *descriptor table* — a
+fixed-size array whose elements are (or contain) resources or pointers — is
+therefore passed *by reference*: it is laid out and reflected as an implicit
+`ParameterBlock`, and the kernel receives one 8-byte device pointer whose
+payload lives in device global memory.
+
+```
+struct TensorList { RWStructuredBuffer<float> tensors[32]; };
+
+void computeMain(uniform TensorList list, ...)
+// becomes
+extern "C" __global__ void computeMain(TensorList* list, ...)
+```
+
+Reflection reports such a parameter as a `ParameterBlock` sub-object occupying 8
+bytes of the kernel-argument buffer, so reflection-driven hosts (e.g. slang-rhi)
+bind it like any other parameter block: allocate a device buffer for the
+element, write the descriptors into it, and place the buffer's address at the
+parameter's kernel-argument offset. The `-cuda-entry-point-params-by-value`
+compiler option restores the legacy all-by-value ABI.
 
 With CUDA - the caller specifies how threading is broken up, so `[numthreads]` is available through reflection, and in a comment in output source code but does not produce varying code.
 
-The UniformState and UniformEntryPointParams struct typically vary by shader. UniformState holds 'normal' bindings, whereas UniformEntryPointParams hold the uniform entry point parameters. Where specific bindings or parameters are located can be determined by reflection. The structures for the example above would be something like the following...
+Where specific bindings or parameters are located can be determined by reflection. The types in the structures above map to CUDA types as follows...
 
 `StructuredBuffer<T>`,`RWStructuredBuffer<T>` become
 

--- a/docs/user-guide/09-targets.md
+++ b/docs/user-guide/09-targets.md
@@ -387,6 +387,10 @@ Second, each loaded module of GPU code may contain pre-allocated "constant memor
 Because types like blocks or textures are not special in CUDA, either of these mechanisms can be utilized to pass any kind of data including references to pointer-based data structures stored in the GPU virtual address space.
 The use of "slots" or "blocks" or "root constants" is a matter of application policy instead of API mechanism.
 
+Slang maps global-scope shader parameters to a single struct held in the module's constant memory (`SLANG_globalParams`), and entry-point `uniform` parameters to by-value kernel arguments (root constants).
+One exception: because kernel-argument memory cannot be dynamically indexed efficiently, a compute entry-point `uniform` parameter of struct type that contains a fixed-size array of resources or pointer-backed structs (a descriptor table) is instead passed by reference — laid out and reflected as an implicit `ParameterBlock`, with the kernel receiving one device pointer to the payload in global memory.
+The `-cuda-entry-point-params-by-value` compiler option restores the legacy all-by-value ABI.
+
 OptiX supports use of constant memory storage for ray tracing pipelines, where all the stages in a ray tracing pipeline share that storage.
 OptiX uses a shader table for managing kernels and hit groups, and allows kernels to access the bytes of their shader table entry via a pointer.
 Similar to the compute pipeline, application code can layer many different policies on top of these mechanisms.

--- a/include/slang.h
+++ b/include/slang.h
@@ -1236,6 +1236,15 @@ typedef uint32_t SlangSizeT;
         // combine on the command line. CLI spellings: -Wall, -Wextra, -Wpedantic.
         WarningLevel = 155,
 
+        CudaEntryPointParamsByValue =
+            156, // bool: restore the legacy CUDA ABI where an entry-point `uniform`
+                 //   parameter containing a fixed-size array of descriptors (resources
+                 //   or pointer-backed structs) is passed by value in kernel-argument
+                 //   space. By default such parameters are passed by reference — laid
+                 //   out and reflected as an implicit `ParameterBlock` whose payload
+                 //   lives in device global memory — because kernel-argument space
+                 //   cannot be dynamically indexed efficiently.
+
         // Do not assign an explicit value to CountOf. It must remain one past the last option,
         // which it derives implicitly from the preceding (highest-valued) enumerator.
         CountOf,

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -36,6 +36,7 @@
 #include "slang-ir-collect-global-uniforms.h"
 #include "slang-ir-com-interface.h"
 #include "slang-ir-coverage-instrument.h"
+#include "slang-ir-cuda-byref-entry-point-params.h"
 #include "slang-ir-cuda-immutable-load.h"
 #include "slang-ir-dce.h"
 #include "slang-ir-defer-buffer-load.h"
@@ -1197,6 +1198,12 @@ Result linkAndOptimizeIR(
         case CodeGenTarget::CUDASource:
         case CodeGenTarget::CUDAHeader:
             SLANG_PASS(collectOptiXEntryPointUniformParams);
+            // Reconcile compute entry-point uniform parameters to the by-reference
+            // (implicit ParameterBlock) layout that parameter binding decided for
+            // descriptor-table-bearing parameters; the pass consumes the recorded
+            // layout, it does not re-derive the decision (see
+            // slang-ir-cuda-byref-entry-point-params.h).
+            SLANG_PASS(reconcileCUDAByRefEntryPointParams, codeGenContext->getSink());
             validateIRModuleIfEnabled(codeGenContext, irModule);
             break;
 

--- a/source/slang/slang-ir-cuda-byref-entry-point-params.cpp
+++ b/source/slang/slang-ir-cuda-byref-entry-point-params.cpp
@@ -1,0 +1,75 @@
+// slang-ir-cuda-byref-entry-point-params.cpp
+#include "slang-ir-cuda-byref-entry-point-params.h"
+
+#include "slang-ir-insts.h"
+#include "slang-ir-transform-params-to-constref.h"
+#include "slang-ir.h"
+
+namespace Slang
+{
+
+/// Returns the parameter-group type layout recorded for `param` at parameter-binding
+/// time, or null if the parameter was not laid out as a parameter group.
+static IRParameterGroupTypeLayout* findParameterGroupTypeLayout(IRParam* param)
+{
+    auto layoutDecoration = param->findDecoration<IRLayoutDecoration>();
+    if (!layoutDecoration)
+        return nullptr;
+    auto varLayout = as<IRVarLayout>(layoutDecoration->getLayout());
+    if (!varLayout)
+        return nullptr;
+    return as<IRParameterGroupTypeLayout>(varLayout->getTypeLayout());
+}
+
+void reconcileCUDAByRefEntryPointParams(IRModule* module, DiagnosticSink* sink)
+{
+    // The pass only replays a layout decision already recorded at parameter-binding
+    // time and performs no user-facing validation, so `sink` is currently unused. It
+    // is kept in the signature so a future diagnostic can be added here without an
+    // API change to every caller.
+    SLANG_UNUSED(sink);
+
+    IRBuilder builder(module);
+    for (auto inst : module->getGlobalInsts())
+    {
+        auto func = as<IRFunc>(inst);
+        if (!func)
+            continue;
+        if (!func->isDefinition())
+            continue;
+        if (!func->findDecoration<IREntryPointDecoration>())
+            continue;
+
+        bool changed = false;
+        for (auto param : func->getParams())
+        {
+            auto groupTypeLayout = findParameterGroupTypeLayout(param);
+            if (!groupTypeLayout)
+                continue;
+
+            // A parameter that is already group-typed (a source-written
+            // `ParameterBlock<T>` / `ConstantBuffer<T>`) already agrees with its
+            // layout and flows through the existing pipeline unchanged.
+            if (as<IRUniformParameterGroupType>(param->getDataType()))
+                continue;
+
+            // The layout says "parameter group" but the IR still passes the element
+            // by value: this is a binding-time by-reference decision (see the pass
+            // header comment); retype the parameter and rewrite its value uses into
+            // loads through addresses.
+            auto paramBlockType = builder.getType(kIROp_ParameterBlockType, param->getDataType());
+            param->setFullType((IRType*)paramBlockType);
+            rewriteValueUsesToAddrUses(builder, param);
+            changed = true;
+
+            // The reconciled parameter must now agree with its recorded layout;
+            // anything else means the layout and the IR describe different ABIs.
+            SLANG_RELEASE_ASSERT(as<IRUniformParameterGroupType>(param->getDataType()));
+        }
+
+        if (changed)
+            fixUpFuncType(func);
+    }
+}
+
+} // namespace Slang

--- a/source/slang/slang-ir-cuda-byref-entry-point-params.h
+++ b/source/slang/slang-ir-cuda-byref-entry-point-params.h
@@ -1,0 +1,34 @@
+// slang-ir-cuda-byref-entry-point-params.h
+#pragma once
+
+namespace Slang
+{
+
+struct IRModule;
+class DiagnosticSink;
+
+/// Reconcile CUDA entry-point parameters to the by-reference layout decision made at
+/// parameter binding.
+///
+/// On CUDA compute targets, parameter binding lays out an entry-point `uniform`
+/// parameter that carries a descriptor table (a fixed-size array of resources or
+/// pointer-backed structs) as an implicit `ParameterBlock<T>`: one 8-byte device
+/// pointer in kernel-argument space, payload in device global memory (see
+/// `shouldPassCUDAEntryPointUniformParamByRef` in slang-parameter-binding.cpp for the
+/// rationale and the predicate — that is the single site where the decision is made).
+///
+/// This pass makes the IR match what the recorded layout already declares: for each
+/// entry-point parameter whose `IRVarLayout` reports a parameter-group type layout
+/// while the parameter's IR type is still the by-value element type, it retypes the
+/// parameter to `ParameterBlock<T>` and rewrites the body's value uses into loads
+/// through addresses. It never evaluates the predicate itself — it consumes the
+/// layout decision — so the emitted kernel signature and the reflected layout cannot
+/// disagree (the failure mode that sank earlier emit-stage attempts at this fix).
+///
+/// For example, `void main(uniform TensorList list)` whose layout says
+/// parameter-group emits as `__global__ void main(TensorList_0* list_0)`, and a
+/// runtime index `list.tensors[i]` becomes an ordinary dynamically-addressed global
+/// load instead of a serial `.param`-space load chain (issue #11774).
+void reconcileCUDAByRefEntryPointParams(IRModule* module, DiagnosticSink* sink);
+
+} // namespace Slang

--- a/source/slang/slang-ir-transform-params-to-constref.cpp
+++ b/source/slang/slang-ir-transform-params-to-constref.cpp
@@ -7,6 +7,136 @@
 namespace Slang
 {
 
+void rewriteValueUsesToAddrUses(IRBuilder& builder, IRInst* newAddrInst)
+{
+    // The overall strategy here is as follows:
+    //
+    // - First, insert IRLoad() in front of all uses of newAddrInst. This
+    //   is a value parameter turned into pointer to value. Add all IRLoad()
+    //   instructions in the working set
+    // - Then, for every inserted IRLoad() instruction, search for
+    //   IRFieldExtract(IRLoad(ptr), ...) and IRGetElement(IRLoad(ptr), ...) patterns,
+    //   and transform these to IRLoad(IRFieldAddress(ptr, ...)) and
+    //   IRLoad(IRGetElementPtr(ptr, ...)), and insert the new IRLoad()
+    //   instructions in the working set
+    //   - Remove also stores to write-once temporary variables that are
+    //     immediately passed into a constref location in a call (see below)
+    //   - If all uses of the inserted IRLoad() were translated, remove the
+    //     IRLoad() to keep this pass clean
+
+    List<IRLoad*> workList;
+
+    traverseUses(
+        newAddrInst,
+        [&](IRUse* use)
+        {
+            auto user = use->getUser();
+            builder.setInsertBefore(user);
+            IRLoad* loadInst = as<IRLoad>(builder.emitLoad(newAddrInst));
+            use->set(loadInst);
+
+            workList.add(loadInst);
+        });
+
+    for (Index i = 0; i < workList.getCount(); i++)
+    {
+        IRLoad* loadInst = workList[i];
+        bool allUsesTranslated = true;
+
+        traverseUses(
+            loadInst,
+            [&](IRUse* use)
+            {
+                IRInst* userInst = use->getUser();
+                bool useTranslated = false;
+
+                switch (userInst->getOp())
+                {
+                case kIROp_FieldExtract:
+                    {
+                        if (isUseBaseAddrOperand(use, userInst))
+                        {
+                            // Transform IRFieldExtract(IRLoad(ptr), x)
+                            //           ==>
+                            //           IRLoad(IRFieldAddr(ptr), x)
+
+                            auto fieldExtract = as<IRFieldExtract>(userInst);
+                            builder.setInsertBefore(fieldExtract);
+                            auto fieldAddr = builder.emitFieldAddress(
+                                builder.getPtrType(userInst->getDataType()),
+                                loadInst->getPtr(),
+                                fieldExtract->getField());
+                            auto loadFieldAddr = as<IRLoad>(builder.emitLoad(fieldAddr));
+                            fieldExtract->replaceUsesWith(loadFieldAddr);
+                            fieldExtract->removeAndDeallocate();
+
+                            workList.add(loadFieldAddr);
+                            useTranslated = true;
+                        }
+                        break;
+                    }
+
+                case kIROp_GetElement:
+                    {
+                        if (isUseBaseAddrOperand(use, userInst))
+                        {
+                            // Transform IRGetElement(IRLoad(ptr), x)
+                            //           ==>
+                            //           IRLoad(IRGetElementPtr(ptr), x)
+
+                            auto getElement = as<IRGetElement>(userInst);
+                            builder.setInsertBefore(getElement);
+                            auto getElementPtr = builder.emitElementAddress(
+                                builder.getPtrType(userInst->getDataType()),
+                                loadInst->getPtr(),
+                                getElement->getIndex());
+                            auto loadElementPtr = as<IRLoad>(builder.emitLoad(getElementPtr));
+                            getElement->replaceUsesWith(loadElementPtr);
+                            getElement->removeAndDeallocate();
+
+                            workList.add(loadElementPtr);
+                            useTranslated = true;
+                        }
+                        break;
+                    }
+
+                case kIROp_Store:
+                    {
+                        // If the current value is being stored into a write-once temp var that
+                        // is immediately passed into a constref location in a call, we can get
+                        // rid of the temp var and replace it with `inst` directly.
+                        // (such temp var can be introduced during `updateCallSites` when we
+                        // were processing the callee.)
+
+                        // Transform IRStore(storeDest, load(ptr)) where storeDest has attribute
+                        //                                     TempCallArgImmutableVarDecoration
+                        //           IRInst(storeDest)
+                        //           ==>
+                        //           IRInst(ptr)
+
+                        auto storeInst = as<IRStore>(userInst);
+                        auto storeDest = storeInst->getPtr();
+
+                        if (storeInst->getValUse() == use &&
+                            storeDest->findDecorationImpl(kIROp_TempCallArgImmutableVarDecoration))
+                        {
+                            storeDest->replaceUsesWith(loadInst->getPtr());
+                            userInst->removeAndDeallocate();
+                            storeDest->removeAndDeallocate();
+                            useTranslated = true;
+                        }
+                        break;
+                    }
+                }
+
+                allUsesTranslated = allUsesTranslated && useTranslated;
+            });
+
+        if (allUsesTranslated)
+            loadInst->removeAndDeallocate();
+    }
+}
+
 struct TransformParamsToConstRefContext
 {
     IRModule* module;
@@ -43,133 +173,7 @@ struct TransformParamsToConstRefContext
 
     void rewriteValueUsesToAddrUses(IRInst* newAddrInst)
     {
-        // The overall strategy here is as follows:
-        //
-        // - First, insert IRLoad() in front of all uses of newAddrInst. This
-        //   is a value parameter turned into pointer to value. Add all IRLoad()
-        //   instructions in the working set
-        // - Then, for every inserted IRLoad() instruction, search for
-        //   IRFieldExtract(IRLoad(ptr), ...) and IRGetElement(IRLoad(ptr), ...) patterns,
-        //   and transform these to IRLoad(IRFieldAddress(ptr, ...)) and
-        //   IRLoad(IRGetElementPtr(ptr, ...)), and insert the new IRLoad()
-        //   instructions in the working set
-        //   - Remove also stores to write-once temporary variables that are
-        //     immediately passed into a constref location in a call (see below)
-        //   - If all uses of the inserted IRLoad() were translated, remove the
-        //     IRLoad() to keep this pass clean
-
-        List<IRLoad*> workList;
-
-        traverseUses(
-            newAddrInst,
-            [&](IRUse* use)
-            {
-                auto user = use->getUser();
-                builder.setInsertBefore(user);
-                IRLoad* loadInst = as<IRLoad>(builder.emitLoad(newAddrInst));
-                use->set(loadInst);
-
-                workList.add(loadInst);
-            });
-
-        for (Index i = 0; i < workList.getCount(); i++)
-        {
-            IRLoad* loadInst = workList[i];
-            bool allUsesTranslated = true;
-
-            traverseUses(
-                loadInst,
-                [&](IRUse* use)
-                {
-                    IRInst* userInst = use->getUser();
-                    bool useTranslated = false;
-
-                    switch (userInst->getOp())
-                    {
-                    case kIROp_FieldExtract:
-                        {
-                            if (isUseBaseAddrOperand(use, userInst))
-                            {
-                                // Transform IRFieldExtract(IRLoad(ptr), x)
-                                //           ==>
-                                //           IRLoad(IRFieldAddr(ptr), x)
-
-                                auto fieldExtract = as<IRFieldExtract>(userInst);
-                                builder.setInsertBefore(fieldExtract);
-                                auto fieldAddr = builder.emitFieldAddress(
-                                    builder.getPtrType(userInst->getDataType()),
-                                    loadInst->getPtr(),
-                                    fieldExtract->getField());
-                                auto loadFieldAddr = as<IRLoad>(builder.emitLoad(fieldAddr));
-                                fieldExtract->replaceUsesWith(loadFieldAddr);
-                                fieldExtract->removeAndDeallocate();
-
-                                workList.add(loadFieldAddr);
-                                useTranslated = true;
-                            }
-                            break;
-                        }
-
-                    case kIROp_GetElement:
-                        {
-                            if (isUseBaseAddrOperand(use, userInst))
-                            {
-                                // Transform IRGetElement(IRLoad(ptr), x)
-                                //           ==>
-                                //           IRLoad(IRGetElementPtr(ptr), x)
-
-                                auto getElement = as<IRGetElement>(userInst);
-                                builder.setInsertBefore(getElement);
-                                auto getElementPtr = builder.emitElementAddress(
-                                    builder.getPtrType(userInst->getDataType()),
-                                    loadInst->getPtr(),
-                                    getElement->getIndex());
-                                auto loadElementPtr = as<IRLoad>(builder.emitLoad(getElementPtr));
-                                getElement->replaceUsesWith(loadElementPtr);
-                                getElement->removeAndDeallocate();
-
-                                workList.add(loadElementPtr);
-                                useTranslated = true;
-                            }
-                            break;
-                        }
-
-                    case kIROp_Store:
-                        {
-                            // If the current value is being stored into a write-once temp var that
-                            // is immediately passed into a constref location in a call, we can get
-                            // rid of the temp var and replace it with `inst` directly.
-                            // (such temp var can be introduced during `updateCallSites` when we
-                            // were processing the callee.)
-
-                            // Transform IRStore(storeDest, load(ptr)) where storeDest has attribute
-                            //                                     TempCallArgImmutableVarDecoration
-                            //           IRInst(storeDest)
-                            //           ==>
-                            //           IRInst(ptr)
-
-                            auto storeInst = as<IRStore>(userInst);
-                            auto storeDest = storeInst->getPtr();
-
-                            if (storeInst->getValUse() == use &&
-                                storeDest->findDecorationImpl(
-                                    kIROp_TempCallArgImmutableVarDecoration))
-                            {
-                                storeDest->replaceUsesWith(loadInst->getPtr());
-                                userInst->removeAndDeallocate();
-                                storeDest->removeAndDeallocate();
-                                useTranslated = true;
-                            }
-                            break;
-                        }
-                    }
-
-                    allUsesTranslated = allUsesTranslated && useTranslated;
-                });
-
-            if (allUsesTranslated)
-                loadInst->removeAndDeallocate();
-        }
+        Slang::rewriteValueUsesToAddrUses(builder, newAddrInst);
     }
 
     void rewriteParamUseSitesToSupportConstRefUsage(HashSet<IRParam*>& updatedParams)

--- a/source/slang/slang-ir-transform-params-to-constref.h
+++ b/source/slang/slang-ir-transform-params-to-constref.h
@@ -11,4 +11,12 @@ SlangResult transformParamsToConstRef(IRModule* module, DiagnosticSink* sink);
 
 SlangResult translateEntryPointInParamToBorrow(IRModule* module, DiagnosticSink* sink);
 
+/// Rewrite all uses of `addrInst` from value uses into address uses, after `addrInst`
+/// has been retyped from a value type to an address-like type (e.g. `borrow in T` or a
+/// parameter-group type). Each direct use is first wrapped in a load; then
+/// `FieldExtract(load, key)` / `GetElement(load, index)` patterns are rewritten into
+/// `Load(FieldAddress(addrInst, key))` / `Load(GetElementPtr(addrInst, index))`
+/// chains, and loads whose uses were all rewritten are removed.
+void rewriteValueUsesToAddrUses(IRBuilder& builder, IRInst* addrInst);
+
 } // namespace Slang

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -1193,6 +1193,12 @@ void initCommandOptions(CommandOptions& options)
          "-enable-experimental-passes",
          nullptr,
          "Enable experimental compiler passes"},
+        {OptionKind::CudaEntryPointParamsByValue,
+         "-cuda-entry-point-params-by-value",
+         nullptr,
+         "Pass CUDA entry-point uniform parameters containing fixed-size descriptor arrays by "
+         "value in kernel-argument space (the legacy ABI), instead of by reference as an "
+         "implicit ParameterBlock"},
         {OptionKind::EnableExperimentalDynamicDispatch,
          "-enable-experimental-dynamic-dispatch",
          nullptr,
@@ -2799,6 +2805,7 @@ SlangResult OptionsParser::_parse(int argc, char const* const* argv)
         case OptionKind::PreserveParameters:
         case OptionKind::UseMSVCStyleBitfieldPacking:
         case OptionKind::ExperimentalFeature:
+        case OptionKind::CudaEntryPointParamsByValue:
             linkage->m_optionSet.set(optionKind, true);
             break;
         case OptionKind::EnableRichDiagnostics:

--- a/source/slang/slang-parameter-binding.cpp
+++ b/source/slang/slang-parameter-binding.cpp
@@ -2,6 +2,7 @@
 #include "slang-parameter-binding.h"
 
 #include "../compiler-core/slang-artifact-desc-util.h"
+#include "slang-check-impl.h"
 #include "slang-compiler.h"
 #include "slang-ir-string-hash.h"
 #include "slang-ir-util.h"
@@ -2943,6 +2944,191 @@ static RefPtr<TypeLayout> processEntryPointVaryingParameter(
     return processParamOfType(_Move(processParamOfType), type);
 }
 
+/// Returns true if any field of `structDecl` (reached through `declRefType`, so that
+/// field types are resolved with the struct's generic arguments substituted in)
+/// satisfies `predicate`, a callable `bool(Type*)` invoked on each resolved field
+/// type. `seen` is a recursion guard shared with `predicate`: the struct is added
+/// before the walk and removed after, so a type that transitively contains itself is
+/// treated as not matching rather than recursing forever. This factors out the
+/// identical field-iteration shared by the descriptor-detection walkers below; each
+/// passes itself (bound to `seen`) as the predicate to recurse into field types.
+template<typename F>
+static bool anyStructFieldSatisfies(
+    ASTBuilder* astBuilder,
+    DeclRefType* declRefType,
+    StructDecl* structDecl,
+    HashSet<Decl*>& seen,
+    F&& predicate)
+{
+    if (!seen.add(structDecl))
+        return false;
+    for (auto field : structDecl->getFields())
+    {
+        auto fieldDeclRef =
+            astBuilder->getMemberDeclRef(declRefType->getDeclRef(), field).as<VarDeclBase>();
+        auto fieldType = fieldDeclRef ? getType(astBuilder, fieldDeclRef) : field->type.type;
+        if (fieldType && predicate(fieldType))
+            return true;
+    }
+    seen.remove(structDecl);
+    return false;
+}
+
+/// Returns true if `type` is, or transitively contains (through struct fields and
+/// array elements), a descriptor-carrying leaf: an opaque resource/handle type
+/// (texture, sampler, buffer, parameter group — see `isOpaqueHandleType`) or a
+/// pointer. E.g. `RWStructuredBuffer<float>` and `struct MyTensor { float* data; }`
+/// match; `uint`, `float3`, and `float4x4` do not.
+static bool typeContainsDescriptorLeaf(ASTBuilder* astBuilder, Type* type, HashSet<Decl*>& seen)
+{
+    while (auto modifiedType = as<ModifiedType>(type))
+        type = modifiedType->getBase();
+
+    if (isOpaqueHandleType(type))
+        return true;
+    if (as<PtrTypeBase>(type))
+        return true;
+
+    if (auto arrayType = as<ArrayExpressionType>(type))
+        return typeContainsDescriptorLeaf(astBuilder, arrayType->getElementType(), seen);
+
+    if (auto declRefType = as<DeclRefType>(type))
+    {
+        if (auto structDecl = as<StructDecl>(declRefType->getDeclRef().getDecl()))
+            return anyStructFieldSatisfies(
+                astBuilder,
+                declRefType,
+                structDecl,
+                seen,
+                [&](Type* fieldType)
+                { return typeContainsDescriptorLeaf(astBuilder, fieldType, seen); });
+    }
+    return false;
+}
+
+/// Returns true if `type` transitively contains (through struct fields and array
+/// elements) a fixed-size array whose element type transitively contains a
+/// descriptor-carrying leaf — i.e. the type carries a *descriptor table*, an indexed
+/// collection of resources or pointer-backed structs. E.g.
+/// `struct TensorList { RWTensor<float,2> tensors[8]; }` matches (the element holds a
+/// pointer); `struct Args { uint counts[8]; }` and a single non-arrayed tensor struct
+/// do not.
+static bool typeContainsDescriptorBearingFixedArray(
+    ASTBuilder* astBuilder,
+    Type* type,
+    HashSet<Decl*>& seen)
+{
+    while (auto modifiedType = as<ModifiedType>(type))
+        type = modifiedType->getBase();
+
+    if (auto arrayType = as<ArrayExpressionType>(type))
+    {
+        auto elementType = arrayType->getElementType();
+        if (!arrayType->isUnsized())
+        {
+            HashSet<Decl*> leafSeen;
+            if (typeContainsDescriptorLeaf(astBuilder, elementType, leafSeen))
+                return true;
+        }
+        return typeContainsDescriptorBearingFixedArray(astBuilder, elementType, seen);
+    }
+
+    if (auto declRefType = as<DeclRefType>(type))
+    {
+        if (auto structDecl = as<StructDecl>(declRefType->getDeclRef().getDecl()))
+            return anyStructFieldSatisfies(
+                astBuilder,
+                declRefType,
+                structDecl,
+                seen,
+                [&](Type* fieldType)
+                { return typeContainsDescriptorBearingFixedArray(astBuilder, fieldType, seen); });
+    }
+    return false;
+}
+
+/// Decide whether a CUDA compute entry-point `uniform` parameter should be passed by
+/// reference — laid out as an implicit `ParameterBlock<paramType>` whose payload lives
+/// in device global memory — instead of by value in kernel-argument (`.param`) space.
+///
+/// CUDA kernel-argument space cannot be dynamically indexed: a runtime index into a
+/// by-value parameter is lowered by ptxas to a serial per-element load chain, making a
+/// runtime-indexed descriptor array 10-30x slower than the same data placed behind a
+/// pointer in global memory (issue #11774). A parameter that carries a descriptor
+/// table (see `typeContainsDescriptorBearingFixedArray`) is therefore passed as one
+/// 8-byte device pointer. Plain-data parameters — including plain-data arrays — keep
+/// the by-value fast path (their dynamic-index long tail is handled ABI-invisibly by
+/// `legalizeCUDAKernelParamDynamicIndex`).
+///
+/// This is the single site where the by-reference decision is made; the layout it
+/// produces is recorded in reflection, and the IR is reconciled to it by
+/// `reconcileCUDAByRefEntryPointParams` (slang-ir-cuda-byref-entry-point-params.cpp),
+/// which consumes the recorded layout rather than re-deriving a predicate — so the
+/// emitted kernel signature and the reflected layout cannot disagree.
+///
+/// The decision is currently restricted to struct-typed parameters: a struct wrapped
+/// in a `ParameterBlock` reflects as a parameter-group sub-object that existing hosts
+/// (slang-rhi) already bind correctly, whereas `ParameterBlock<T[N]>` is a group
+/// shape hosts do not yet represent. Bare descriptor-array parameters keep the
+/// by-value layout and rely on the dynamic-index legalization above.
+static bool shouldPassCUDAEntryPointUniformParamByRef(
+    ParameterBindingContext* context,
+    EntryPointParameterState const& state,
+    Type* paramType)
+{
+    if (!isCUDATarget(context->getTargetRequest()))
+        return false;
+    if (context->getTargetRequest()->getOptionSet().getBoolOption(
+            CompilerOptionName::CudaEntryPointParamsByValue))
+        return false;
+
+    // Ray-tracing stages pass entry-point uniforms through the shader binding table
+    // (see collectOptiXEntryPointUniformParams); only ordinary compute kernels use
+    // CUDA kernel-argument space.
+    if (state.stage != Stage::Compute)
+        return false;
+
+    // Torch/AutoPyBind/CudaKernel entry points have generated host-side launch code
+    // that passes arguments by value; their ABI is owned by that generated code.
+    if (auto entryPointLayout = context->entryPointLayout)
+    {
+        if (auto entryPointFuncDecl = entryPointLayout->entryPoint.getDecl())
+        {
+            if (entryPointFuncDecl->hasModifier<TorchEntryPointAttribute>() ||
+                entryPointFuncDecl->hasModifier<CudaKernelAttribute>() ||
+                entryPointFuncDecl->hasModifier<AutoPyBindCudaAttribute>())
+                return false;
+        }
+    }
+
+    // The shape checks below must see through type modifiers, matching the walkers
+    // (which already strip `ModifiedType` at each level); otherwise a modified
+    // struct type would silently keep the by-value layout.
+    Type* unwrappedParamType = paramType;
+    while (auto modifiedType = as<ModifiedType>(unwrappedParamType))
+        unwrappedParamType = modifiedType->getBase();
+
+    // A parameter that is already an explicit parameter group is passed by reference
+    // through the existing path; do not double-wrap.
+    if (as<UniformParameterGroupType>(unwrappedParamType))
+        return false;
+
+    // See the doc comment: only struct-typed parameters are converted. Note that a
+    // bare array must be rejected explicitly: `T[N]` is itself a `DeclRefType` of the
+    // core-module `Array` struct, so a plain "is a struct decl-ref" test would match.
+    if (as<ArrayExpressionType>(unwrappedParamType))
+        return false;
+    auto declRefType = as<DeclRefType>(unwrappedParamType);
+    if (!declRefType || !as<StructDecl>(declRefType->getDeclRef().getDecl()))
+        return false;
+
+    HashSet<Decl*> seen;
+    return typeContainsDescriptorBearingFixedArray(
+        context->getASTBuilder(),
+        unwrappedParamType,
+        seen);
+}
+
 /// Compute the type layout for a parameter declared directly on an entry point.
 static RefPtr<TypeLayout> computeEntryPointParameterTypeLayout(
     ParameterBindingContext* context,
@@ -2959,6 +3145,18 @@ static RefPtr<TypeLayout> computeEntryPointParameterTypeLayout(
         // a uniform shader parameter passed via the implicitly-defined
         // constant buffer (e.g., the `$Params` constant buffer seen in fxc/dxc output).
         //
+        // On CUDA, a parameter that carries a descriptor table is passed by
+        // reference instead: wrapping it in an implicit `ParameterBlock` here makes
+        // the standard layout machinery below produce the parameter-group layout
+        // (an 8-byte device pointer in kernel-argument space) that both reflection
+        // and the emitted kernel signature then agree on. See
+        // `shouldPassCUDAEntryPointUniformParamByRef` for the full rationale.
+        //
+        if (shouldPassCUDAEntryPointUniformParamByRef(context, state, paramType))
+        {
+            paramType = context->getASTBuilder()->getParameterBlockType(paramType);
+        }
+
         LayoutRulesImpl* layoutRules = nullptr;
         if (isKhronosTarget(context->getTargetRequest()))
         {

--- a/tests/cuda/entry-point-uniform-byref-autopybind-excluded.slang
+++ b/tests/cuda/entry-point-uniform-byref-autopybind-excluded.slang
@@ -1,0 +1,28 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -line-directive-mode none
+
+// Companion to entry-point-uniform-byref-cuda-kernel-excluded.slang for the
+// [AutoPyBindCUDA] arm of the by-reference gate's kernel-attribute exclusion: the
+// parameter matches the descriptor-table predicate (struct carrying a fixed-size
+// array of pointer-backed structs), but the auto-generated Python binding launches
+// the kernel with by-value arguments, so the parameter must stay by value.
+
+struct MyTensor
+{
+    float* data;
+    uint stride;
+}
+
+struct TensorList
+{
+    MyTensor tensors[32];
+}
+
+// CHECK: __global__ void __kernel__myKernel(TensorList_0 list_0, TensorView output_0)
+
+[AutoPyBindCUDA]
+[CudaKernel]
+void myKernel(TensorList list, TensorView<float> output)
+{
+    uint tid = cudaThreadIdx().x;
+    output.store(tid, *(list.tensors[tid % 32].data));
+}

--- a/tests/cuda/entry-point-uniform-byref-cuda-kernel-excluded.slang
+++ b/tests/cuda/entry-point-uniform-byref-cuda-kernel-excluded.slang
@@ -1,0 +1,30 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+
+// Positive-shape lock for the by-reference gate's kernel-attribute exclusion: this
+// parameter matches the descriptor-table predicate (struct carrying a fixed-size
+// array of pointer-backed structs), but the entry point carries [CudaKernel], whose
+// generated host launch code owns the by-value ABI — so the parameter must stay by
+// value. Without this test, deleting the attribute exclusion would fail nothing:
+// the other by-ref tests use plain [shader("compute")] entry points, and the floor
+// tests use bare arrays that the struct-only gate rejects anyway.
+
+struct MyTensor
+{
+    float* data;
+    uint stride;
+}
+
+struct TensorList
+{
+    MyTensor tensors[32];
+}
+
+// CHECK: __global__ void computeMain(TensorList_0 list_0, RWStructuredBuffer<float> output_0)
+
+[CudaKernel]
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(uint3 tid: SV_DispatchThreadID, uniform TensorList list, uniform RWStructuredBuffer<float> output)
+{
+    output[tid.x] = *(list.tensors[tid.x].data);
+}

--- a/tests/cuda/entry-point-uniform-byref-execution.slang
+++ b/tests/cuda/entry-point-uniform-byref-execution.slang
@@ -1,0 +1,41 @@
+// Execute the by-reference descriptor-table ABI end-to-end on a real CUDA device:
+// the host (slang-rhi) must allocate the payload buffer from the pooled global
+// upload, write the four buffer descriptors into it, patch the device pointer at
+// the parameter's kernel-argument offset, and the kernel must read correct values
+// through a runtime index. The second run compiles the same shader with
+// -cuda-entry-point-params-by-value, executing the legacy by-value ABI (whose
+// runtime indexing goes through the dynamic-index local-copy legalization
+// instead) - the two ABIs must produce identical results.
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type -shaderobj
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type -shaderobj -xslang -cuda-entry-point-params-by-value
+
+struct TensorList
+{
+    RWStructuredBuffer<float> tensors[4];
+}
+
+//TEST_INPUT:ubuffer(data=[10.0 20.0 30.0 40.0], stride=4):name=list.tensors[0]
+//TEST_INPUT:ubuffer(data=[11.0 21.0 31.0 41.0], stride=4):name=list.tensors[1]
+//TEST_INPUT:ubuffer(data=[12.0 22.0 32.0 42.0], stride=4):name=list.tensors[2]
+//TEST_INPUT:ubuffer(data=[13.0 23.0 33.0 43.0], stride=4):name=list.tensors[3]
+//TEST_INPUT:ubuffer(data=[3 1 2 0], stride=4):name=indices
+//TEST_INPUT:ubuffer(data=[0 0 0 0], stride=4):out,name=output
+
+// output[i] = tensors[indices[i]][i]:
+// CHECK: 13.0
+// CHECK: 21.0
+// CHECK: 32.0
+// CHECK: 40.0
+
+[shader("compute")]
+[numthreads(4, 1, 1)]
+void computeMain(
+    uint3 tid: SV_DispatchThreadID,
+    uniform TensorList list,
+    uniform StructuredBuffer<uint> indices,
+    uniform RWStructuredBuffer<float> output)
+{
+    uint i = tid.x;
+    output[i] = list.tensors[indices[i]][i];
+}

--- a/tests/cuda/entry-point-uniform-byref-negative.slang
+++ b/tests/cuda/entry-point-uniform-byref-negative.slang
@@ -1,0 +1,41 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+
+// Negative locks for the CUDA by-reference conversion: parameters that do NOT carry
+// a descriptor table keep the by-value kernel-argument fast path, and a
+// source-written ParameterBlock is not double-wrapped.
+//
+// - `single` is a pointer-backed struct but holds no fixed-size descriptor array;
+// - `opts` contains only plain data (including a plain-data array);
+// - `block` is already an explicit parameter group.
+
+struct MyTensor
+{
+    float* data;
+    uint stride;
+}
+
+struct Options
+{
+    uint counts[8];
+    float scale;
+}
+
+struct BlockArgs
+{
+    RWStructuredBuffer<float> buffers[4];
+}
+
+// CHECK: __global__ void computeMain(MyTensor_0 single_0, Options_0 opts_0, BlockArgs_0* block_0, RWStructuredBuffer<float> output_0)
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(
+    uint3 tid: SV_DispatchThreadID,
+    uniform MyTensor single,
+    uniform Options opts,
+    uniform ParameterBlock<BlockArgs> block,
+    uniform RWStructuredBuffer<float> output)
+{
+    output[tid.x] = *(single.data + tid.x) * opts.scale + opts.counts[tid.x % 8] +
+                    block.buffers[tid.x % 4][tid.x];
+}

--- a/tests/cuda/entry-point-uniform-byref-opt-out.slang
+++ b/tests/cuda/entry-point-uniform-byref-opt-out.slang
@@ -1,0 +1,30 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none -cuda-entry-point-params-by-value
+
+// With -cuda-entry-point-params-by-value the legacy ABI is restored: the
+// descriptor-table-bearing parameter is passed by value in kernel-argument space
+// (and its runtime indexing is covered by the dynamic-index local-copy floor
+// instead — see kernel-param-dynamic-index-nested-struct.slang).
+
+struct MyTensor
+{
+    float* data;
+    uint stride;
+}
+
+struct TensorList
+{
+    MyTensor tensors[32];
+}
+
+// CHECK: __global__ void computeMain(TensorList_0 list_0, StructuredBuffer<uint> indices_0, RWStructuredBuffer<float> output_0)
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(
+    uint3 tid: SV_DispatchThreadID,
+    uniform TensorList list,
+    uniform StructuredBuffer<uint> indices,
+    uniform RWStructuredBuffer<float> output)
+{
+    output[tid.x] = *(list.tensors[indices[tid.x]].data + tid.x);
+}

--- a/tests/cuda/entry-point-uniform-descriptor-array-byref.slang
+++ b/tests/cuda/entry-point-uniform-descriptor-array-byref.slang
@@ -1,0 +1,50 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+//TEST:REFLECTION(filecheck=REFLECT): -stage compute -entry computeMain -target cuda -no-codegen
+
+// A CUDA compute entry-point `uniform` parameter that carries a descriptor table —
+// here a struct nesting a fixed-size array of pointer-backed tensor structs, the
+// shape SlangPy's functional API generates — is passed by reference: parameter
+// binding lays it out as an implicit ParameterBlock (one 8-byte device pointer in
+// kernel-argument space, payload in global memory), and the IR is reconciled to
+// that recorded layout. A runtime index into the array is then an ordinary
+// dynamically-addressed global load instead of a serial `.param`-space load chain
+// (issue #11774).
+
+struct MyTensor
+{
+    float* data;
+    uint stride;
+}
+
+struct TensorList
+{
+    MyTensor tensors[32];
+}
+
+// The kernel receives the parameter as a pointer, and the runtime index goes
+// through it; the remaining parameters keep the by-value kernel-argument path.
+// CHECK: __global__ void computeMain(TensorList_0* list_0, StructuredBuffer<uint> indices_0, RWStructuredBuffer<float> output_0)
+// CHECK: list_0->tensors_0[
+
+// Reflection reports the truth about the ABI: the parameter is a parameter block
+// occupying 8 bytes of kernel-argument space, its element preserving the full
+// array layout (count and stride), and the following parameter starts after the
+// pointer.
+// REFLECT: "name": "list"
+// REFLECT: "binding": {"kind": "uniform", "offset": 0, "size": 8
+// REFLECT: "kind": "parameterBlock"
+// REFLECT: "kind": "array"
+// REFLECT: "elementCount": 32
+// REFLECT: "name": "indices"
+// REFLECT: "binding": {"kind": "uniform", "offset": 8
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(
+    uint3 tid: SV_DispatchThreadID,
+    uniform TensorList list,
+    uniform StructuredBuffer<uint> indices,
+    uniform RWStructuredBuffer<float> output)
+{
+    output[tid.x] = *(list.tensors[indices[tid.x]].data + tid.x);
+}

--- a/tests/cuda/entry-point-uniform-resource-array-byref.slang
+++ b/tests/cuda/entry-point-uniform-resource-array-byref.slang
@@ -1,0 +1,20 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+
+// The by-reference conversion applies equally when the descriptor array's elements
+// are true resource types (structured buffers) rather than pointer-backed structs,
+// as long as the array is carried by a struct-typed parameter.
+
+struct Args
+{
+    RWStructuredBuffer<float> tensors[8];
+}
+
+// CHECK: __global__ void computeMain(Args_0* args_0, StructuredBuffer<uint> indices_0)
+// CHECK: args_0->tensors_0[
+
+[shader("compute")]
+[numthreads(32, 1, 1)]
+void computeMain(uint3 tid: SV_DispatchThreadID, uniform Args args, uniform StructuredBuffer<uint> indices)
+{
+    args.tensors[indices[tid.x]][tid.x] = 1.0f;
+}

--- a/tests/cuda/kernel-param-dynamic-index-nested-struct.slang
+++ b/tests/cuda/kernel-param-dynamic-index-nested-struct.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry computeMain -stage compute -line-directive-mode none -cuda-entry-point-params-by-value
 
 // Same as kernel-param-dynamic-index-local-copy.slang, but with the array nested
 // one struct level down and its elements being pointer-backed structs — the shape
@@ -6,6 +6,11 @@
 // legalization must root the access chain through the parameter's local copy
 // while leaving statically-addressed accesses to the same parameter (the
 // `indices` field here) on the parameter itself.
+//
+// By default this parameter shape is passed by reference instead (see
+// entry-point-uniform-descriptor-array-byref.slang); the local-copy floor tested
+// here is what covers it under the `-cuda-entry-point-params-by-value` legacy ABI
+// (and kernels excluded from the by-reference gate, e.g. [CudaKernel] functions).
 
 struct MyTensor
 {


### PR DESCRIPTION
> **This is the by-reference layer of the #11774 fix, split back out of #11939 and stacked on it.** Base branch = `haaggarwal/cuda-param-dynamic-index-floor` (#11939, the ABI-invisible floor); this PR is only the breaking ABI change. It supersedes #11941, which was previously merged into #11939's branch and cannot be reopened (GitHub blocks reopening merged PRs). Review this against #11939 as its base — the diff shown is by-ref only.

Fixes #11774 (with #11939).

## Motivation

#11939's local-copy legalization is the floor: it makes runtime-indexed by-value parameters correct and O(1)-per-access, but the host still ships the full descriptor blob by value per dispatch and every thread pays a prologue copy. The measured regression — SlangPy `test_tensor_sum_indirect`, 13–29× slower than Vulkan on L40S — is a `uniform TensorList<N>` struct nesting `RWTensor<float,2>[N]` in `.param`. On every other target, indexed resource collections live in dynamically-indexable descriptor memory; this PR gives CUDA the same placement.

## Proposed solution

A compute entry-point `uniform` struct parameter that carries a **descriptor table** (a fixed-size array whose elements are or contain resources/pointers) is passed **by reference** — laid out and reflected as an implicit `ParameterBlock`, so the kernel receives one 8-byte device pointer and the payload lives in pooled device global memory:

```cpp
__global__ void main(TensorList_0* list_0, ...)   // was: TensorList_0 list_0 (by value)
```

The decision is made **once, at parameter binding** (`shouldPassCUDAEntryPointUniformParamByRef`), where reflection is computed; the post-link IR pass `reconcileCUDAByRefEntryPointParams` *consumes* the recorded layout rather than re-deriving a predicate — so the emitted signature and the reflected layout cannot disagree, eliminating by construction the ABI-desync class that sank the earlier `__constant__`-hoist attempt (#11747). Zero emit changes (`ParameterBlock` params already render as `T*`), zero slang-rhi changes (entry-point-parented PB sub-objects are an existing, tested path). `-cuda-entry-point-params-by-value` restores the legacy ABI.

Scope: struct-typed params only (bare descriptor arrays would reflect as `ParameterBlock<array>`, a shape hosts don't yet represent — they keep the by-value layout and rely on #11939's floor). Excluded: RT stages, torch/`[AutoPyBindCUDA]`/`[CudaKernel]` kernels, explicit parameter groups, plain-data params.

## Change summary

| Area | Files |
|---|---|
| Decision site | `slang-parameter-binding.cpp` |
| IR reconciliation | `slang-ir-cuda-byref-entry-point-params.{h,cpp}`; `rewriteValueUsesToAddrUses` hoisted to `slang-ir-transform-params-to-constref.{h,cpp}`; invocation in `slang-emit.cpp` |
| Option | `include/slang.h` (`CudaEntryPointParamsByValue`), `slang-options.cpp`, `docs/command-line-slangc-reference.md` |
| Docs | `docs/cuda-target.md` (Binding rewritten), `docs/user-guide/09-targets.md` |
| Tests | `tests/cuda/entry-point-uniform-*.slang` — emit + reflection-JSON + opt-out + exclusions + a GPU execution test |

## Validation

**All perf/nsys numbers on record were measured with this PR + #11939 applied together (floor + by-ref), since the two land as a stack.** Runtime-indexed descriptor tables 13–29× faster on L40S + RTX 5090, CUDA beating Vulkan (0.173 vs 0.199 ms at count=32); command stream adds exactly one async pooled `cuMemcpyHtoDAsync` per command buffer (nsys A/B 31:31:0 vs by-value control); slangpy CUDA canaries green with shader-slang/slangpy#1045. All 53 `tests/cuda` pass on the stacked branch (46 on #11939 alone).

## Landing order

Label **pr: breaking change**. Merge order: #11939 (non-breaking floor) → **shader-slang/slangpy#1045** (host reference-safety, before slangpy bumps its Slang pin) → this PR → close #11774.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
