### PR TITLE
ci: skip gpu-printing example on hosted macOS runners

### DIFF
--- a/tests/expected-example-failure-github.txt
+++ b/tests/expected-example-failure-github.txt
@@ -7,6 +7,7 @@ linux:x86_64:(debug|release):ray-tracing-pipeline   # See issue 5520
 linux:x86_64:(debug|release):shader-object          # See issue 5520
 linux:x86_64:(debug|release):shader-toy             # See issue 5520
 linux:x86_64:(debug|release):triangle               # See issue 5520
+macos:aarch64:(debug|release):gpu-printing         # Flaky Metal device init on hosted runners (2026-07-08): exit 255, no output
 macos:aarch64:(debug|release):hello-world           # See issue 5520
 macos:aarch64:(debug|release):model-viewer          # See issue 5520
 macos:aarch64:(debug|release):ray-tracing           # See issue 5520

--- a/tests/expected-example-failure-github.txt
+++ b/tests/expected-example-failure-github.txt
@@ -7,7 +7,7 @@ linux:x86_64:(debug|release):ray-tracing-pipeline   # See issue 5520
 linux:x86_64:(debug|release):shader-object          # See issue 5520
 linux:x86_64:(debug|release):shader-toy             # See issue 5520
 linux:x86_64:(debug|release):triangle               # See issue 5520
-macos:aarch64:(debug|release):gpu-printing         # Flaky Metal device init on hosted runners (2026-07-08): exit 255, no output
+macos:aarch64:(debug|release):gpu-printing         # See issue 11973
 macos:aarch64:(debug|release):hello-world           # See issue 5520
 macos:aarch64:(debug|release):model-viewer          # See issue 5520
 macos:aarch64:(debug|release):ray-tracing           # See issue 5520

--- a/tests/expected-example-failure-github.txt
+++ b/tests/expected-example-failure-github.txt
@@ -7,7 +7,7 @@ linux:x86_64:(debug|release):ray-tracing-pipeline   # See issue 5520
 linux:x86_64:(debug|release):shader-object          # See issue 5520
 linux:x86_64:(debug|release):shader-toy             # See issue 5520
 linux:x86_64:(debug|release):triangle               # See issue 5520
-macos:aarch64:(debug|release):gpu-printing         # See issue 11973
+macos:aarch64:(debug|release):gpu-printing          # See issue 11973
 macos:aarch64:(debug|release):hello-world           # See issue 5520
 macos:aarch64:(debug|release):model-viewer          # See issue 5520
 macos:aarch64:(debug|release):ray-tracing           # See issue 5520


### PR DESCRIPTION
Tracking issue: #11973 (filed 2026-07-07; this extends its evidence with today's occurrences).

## Motivation

Since 2026-07-08 ~06:30 UTC, the `gpu-printing` example intermittently fails on GitHub-hosted macOS runners with exit code 255 and **no output** — Metal device creation fails on some runner instances while others run the identical code fine. It failed the `test-macos-release-clang-aarch64 / test-slang` job on at least three unrelated PRs this morning:

- #11991 — [run 28933028255](https://github.com/shader-slang/slang/actions/runs/28933028255), failed 3× including two reruns
- #11954 — [run 28930867536](https://github.com/shader-slang/slang/actions/runs/28930867536)
- an unrelated CUDA PR — [run 28922546308](https://github.com/shader-slang/slang/actions/runs/28922546308)

while the same job passed at 06:53, ~07:30 (several runs), and ~11:30 on other PRs. The example harness's in-job retry cannot recover because it retries on the same broken runner instance.

## Proposed solution

`gpu-printing` is the only GPU-requiring example not already in the macOS section of `tests/expected-example-failure-github.txt` — `hello-world`, `model-viewer`, `ray-tracing`, and `ray-tracing-pipeline` are all skipped there (issue #5520). Add it the same way. This trades one example's macOS CI coverage for un-blocking every PR from runner roulette; the example remains covered on Windows.

## Change summary

One line added to `tests/expected-example-failure-github.txt` (`macos:aarch64:(debug|release):gpu-printing  # See issue 11973`), consumed by `.github/workflows/ci-examples.sh` via `--skip-file`.

## Process report

The failure signature (device-creation failure on a virtualized-Metal runner instance) is environmental, not a code regression — master has not changed since 2026-07-07 20:05 UTC and the same merge refs pass on healthy instances. The principled fix would be hosted runners with reliable Metal, or harness-level "skip GPU examples when no device can be created" handling; this skip is the same interim measure the repo already applies to the other GPU examples on this platform and can be reverted when #11973 is resolved.

