### PR TITLE
Add conversion tests between all fundamental scalar types

### DIFF
--- a/tests/language-feature/conversions/conversion-to-bool.slang
+++ b/tests/language-feature/conversions/conversion-to-bool.slang
@@ -7,10 +7,7 @@
 // - HLSL has 16-bit integers when enabled (Slang does it automatically for the default profile)
 
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
-
-//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
-// See https://github.com/shader-slang/slang/issues/12019
-
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
 
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1

--- a/tests/language-feature/conversions/conversion-to-bool.slang
+++ b/tests/language-feature/conversions/conversion-to-bool.slang
@@ -223,13 +223,13 @@ void computeMain()
 
     // conversions from half float
     storeValue(0.0hf);
-    storeValue(0.9hf);
+    storeValue(-0.0hf);
     storeValue(126.9hf);
     storeValue(127.0hf);
     storeValue(255.0hf);
     storeValue(255.9hf);
     // CHECK-NEXT: 0
-    // CHECK-NEXT: 1
+    // CHECK-NEXT: 0
     // CHECK-NEXT: 1
     // CHECK-NEXT: 1
     // CHECK-NEXT: 1

--- a/tests/language-feature/conversions/conversion-to-bool.slang
+++ b/tests/language-feature/conversions/conversion-to-bool.slang
@@ -1,0 +1,190 @@
+//DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+// See https://github.com/shader-slang/slang/issues/11996
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
+
+//DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
+// See https://github.com/shader-slang/slang/issues/12019
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+// Conversions to Boolean from all fundamental scalar types
+
+//TEST_INPUT:ubuffer(data=[0], count=65, stride=4):out,name=outputBuffer
+RWStructuredBuffer<uint> outputBuffer;
+
+static uint i = 0;
+
+[noinline] void storeValue(bool     v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+[noinline] void storeValue(int8_t   v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+[noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+[noinline] void storeValue(int16_t  v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+[noinline] void storeValue(uint16_t v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+[noinline] void storeValue(int32_t  v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+[noinline] void storeValue(uint32_t v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+[noinline] void storeValue(int64_t  v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+[noinline] void storeValue(uint64_t v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+[noinline] void storeValue(half     v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+[noinline] void storeValue(float    v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+[noinline] void storeValue(double   v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // conversions from bool
+    storeValue(false);
+    storeValue(true);
+    // CHECK: 0
+    // CHECK-NEXT: 1
+
+    // conversions from int8_t
+    storeValue(int8_t(0));
+    storeValue(int8_t(-128));
+    storeValue(int8_t(127));
+    storeValue(int8_t(42));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+
+    // conversions from uint8_t
+    storeValue(uint8_t(0));
+    storeValue(uint8_t(42));
+    storeValue(uint8_t(128));
+    storeValue(uint8_t(255));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+
+    // conversions from int16_t
+    storeValue(int16_t(-32768));
+    storeValue(int16_t(-4242));
+    storeValue(int16_t(-128));
+    storeValue(int16_t(-1));
+    storeValue(int16_t(0));
+    storeValue(int16_t(1));
+    storeValue(int16_t(67));
+    storeValue(int16_t(127));
+    storeValue(int16_t(6767));
+    storeValue(int16_t(32767));
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+
+    // conversions from uint16_t
+    storeValue(uint16_t(0));
+    storeValue(uint16_t(42));
+    storeValue(uint16_t(128));
+    storeValue(uint16_t(255));
+    storeValue(uint16_t(4242));
+    storeValue(uint16_t(6767));
+    storeValue(uint16_t(65535));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+
+    // conversions from int32_t
+    storeValue(0x00000000);
+    storeValue(0x0000007F);
+    storeValue(0x000000FF);
+    storeValue(0x40414243);
+    storeValue(int32_t(0xFEFDFCFB));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+
+    // conversions from uint32_t
+    storeValue(0x00000000U);
+    storeValue(0x0000007FU);
+    storeValue(0x00800000U);
+    storeValue(0x80000000U);
+    storeValue(0xFEFDFCFBU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+
+    // conversions from int64_t
+    storeValue(0x0000000000000000LL);
+    storeValue(0x000000000000007FLL);
+    storeValue(0x0001000000000000LL);
+    storeValue(int64_t(0x8000000000000000LL));
+    storeValue(int64_t(0xF1F2F3F4FEFDFCFBLL));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+
+    // conversions from uint64_t
+    storeValue(0x0000000000000000LLU);
+    storeValue(0x0000000000000001LLU);
+    storeValue(0x0000080000000000LLU);
+    storeValue(0x8000000000000000LLU);
+    storeValue(0xF1F2F3F4FEFDFCFBLLU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+
+    // conversions from half float
+    storeValue(0.0hf);
+    storeValue(0.9hf);
+    storeValue(126.9hf);
+    storeValue(127.0hf);
+    storeValue(255.0hf);
+    storeValue(255.9hf);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+
+    // conversions from float
+    storeValue(0.0f);
+    storeValue(-0.0f);
+    storeValue(0.1f);
+    storeValue(127.0f);
+    storeValue(255.0f);
+    storeValue(1.0#INFf);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+
+    // conversions from double
+    storeValue(0.0LF);
+    storeValue(-0.0LF);
+    storeValue(1.79769E+308LF);
+    storeValue(-1.79769E+308LF);
+    storeValue(255.0LF);
+    storeValue(1.0#INFLF);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 1
+}

--- a/tests/language-feature/conversions/conversion-to-bool.slang
+++ b/tests/language-feature/conversions/conversion-to-bool.slang
@@ -16,8 +16,10 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1
 // Note: Metal does not have the double type
 
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgsl -compute -output-using-type -xslang -DNO_DOUBLE=1 -xslang -DNO_INT8=1 -xslang -DNO_INT16=1 -xslang -DNO_INT64=1
-// Note: WGSL has only the 32-bit integers and 16-bit and 32-bit floats
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgsl -compute -output-using-type -render-feature half -xslang -DNO_DOUBLE=1 -xslang -DNO_INT8=1 -xslang -DNO_INT16=1 -xslang -DNO_INT64=1
+// Note: WGSL has only the 32-bit integers and 16-bit and 32-bit floats.
+// The 16-bit float (half) requires the f16 WGSL extension, so gate the test
+// on the "half" render feature.
 
 // Conversions to Boolean from all fundamental scalar types
 

--- a/tests/language-feature/conversions/conversion-to-bool.slang
+++ b/tests/language-feature/conversions/conversion-to-bool.slang
@@ -1,14 +1,23 @@
 //DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 // See https://github.com/shader-slang/slang/issues/11996
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -xslang -DNO_INT8=1
+// Notes:
+// - HLSL does not have 8-bit integer types
+// - HLSL has 16-bit integers when enabled (Slang does it automatically for the default profile)
+
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
 
 //DISABLE_TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
 // See https://github.com/shader-slang/slang/issues/12019
 
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1
+// Note: Metal does not have the double type
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgsl -compute -output-using-type -xslang -DNO_DOUBLE=1 -xslang -DNO_INT8=1 -xslang -DNO_INT16=1 -xslang -DNO_INT64=1
+// Note: WGSL has only the 32-bit integers and 16-bit and 32-bit floats
 
 // Conversions to Boolean from all fundamental scalar types
 
@@ -18,17 +27,31 @@ RWStructuredBuffer<uint> outputBuffer;
 static uint i = 0;
 
 [noinline] void storeValue(bool     v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+
+#ifndef NO_INT8
 [noinline] void storeValue(int8_t   v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
 [noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+#endif
+
+#ifndef NO_INT16
 [noinline] void storeValue(int16_t  v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
 [noinline] void storeValue(uint16_t v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+#endif
+
 [noinline] void storeValue(int32_t  v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
 [noinline] void storeValue(uint32_t v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+
+#ifndef NO_INT64
 [noinline] void storeValue(int64_t  v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
 [noinline] void storeValue(uint64_t v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+#endif
+
 [noinline] void storeValue(half     v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
 [noinline] void storeValue(float    v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+
+#ifndef NO_DOUBLE
 [noinline] void storeValue(double   v) { outputBuffer[i++] = ((bool)v) ? 1U : 0U; }
+#endif
 
 
 [numthreads(1, 1, 1)]
@@ -41,26 +64,41 @@ void computeMain()
     // CHECK-NEXT: 1
 
     // conversions from int8_t
+#ifndef NO_INT8
     storeValue(int8_t(0));
     storeValue(int8_t(-128));
     storeValue(int8_t(127));
     storeValue(int8_t(42));
+#else
+    storeValue(0U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 1
     // CHECK-NEXT: 1
     // CHECK-NEXT: 1
 
     // conversions from uint8_t
+#ifndef NO_INT8
     storeValue(uint8_t(0));
     storeValue(uint8_t(42));
     storeValue(uint8_t(128));
     storeValue(uint8_t(255));
+#else
+    storeValue(0U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 1
     // CHECK-NEXT: 1
     // CHECK-NEXT: 1
 
     // conversions from int16_t
+#ifndef NO_INT16
     storeValue(int16_t(-32768));
     storeValue(int16_t(-4242));
     storeValue(int16_t(-128));
@@ -71,6 +109,18 @@ void computeMain()
     storeValue(int16_t(127));
     storeValue(int16_t(6767));
     storeValue(int16_t(32767));
+#else
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(0U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+#endif
     // CHECK-NEXT: 1
     // CHECK-NEXT: 1
     // CHECK-NEXT: 1
@@ -83,6 +133,7 @@ void computeMain()
     // CHECK-NEXT: 1
 
     // conversions from uint16_t
+#ifndef NO_INT16
     storeValue(uint16_t(0));
     storeValue(uint16_t(42));
     storeValue(uint16_t(128));
@@ -90,6 +141,15 @@ void computeMain()
     storeValue(uint16_t(4242));
     storeValue(uint16_t(6767));
     storeValue(uint16_t(65535));
+#else
+    storeValue(0U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 1
     // CHECK-NEXT: 1
@@ -123,11 +183,19 @@ void computeMain()
     // CHECK-NEXT: 1
 
     // conversions from int64_t
+#ifndef NO_INT64
     storeValue(0x0000000000000000LL);
     storeValue(0x000000000000007FLL);
     storeValue(0x0001000000000000LL);
     storeValue(int64_t(0x8000000000000000LL));
     storeValue(int64_t(0xF1F2F3F4FEFDFCFBLL));
+#else
+    storeValue(0U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 1
     // CHECK-NEXT: 1
@@ -135,11 +203,19 @@ void computeMain()
     // CHECK-NEXT: 1
 
     // conversions from uint64_t
+#ifndef NO_INT64
     storeValue(0x0000000000000000LLU);
     storeValue(0x0000000000000001LLU);
     storeValue(0x0000080000000000LLU);
     storeValue(0x8000000000000000LLU);
     storeValue(0xF1F2F3F4FEFDFCFBLLU);
+#else
+    storeValue(0U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 1
     // CHECK-NEXT: 1
@@ -175,12 +251,21 @@ void computeMain()
     // CHECK-NEXT: 1
 
     // conversions from double
+#ifndef NO_DOUBLE
     storeValue(0.0LF);
     storeValue(-0.0LF);
     storeValue(1.79769E+308LF);
     storeValue(-1.79769E+308LF);
     storeValue(255.0LF);
     storeValue(1.0#INFLF);
+#else
+    storeValue(0U);
+    storeValue(0U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+    storeValue(1U);
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 0
     // CHECK-NEXT: 1

--- a/tests/language-feature/conversions/conversion-to-double.slang
+++ b/tests/language-feature/conversions/conversion-to-double.slang
@@ -16,7 +16,7 @@
 
 // Conversions to 64-bit double from all fundamental scalar types
 //
-// In integer-to-half conversions, precisely convertible values are
+// In 64-bit-integer-to-double conversions, precisely convertible values are
 // used to avoid the effects of rounding. The rounding behavior is
 // implementation-defined at least on SPIR-V targets.
 

--- a/tests/language-feature/conversions/conversion-to-double.slang
+++ b/tests/language-feature/conversions/conversion-to-double.slang
@@ -1,11 +1,18 @@
 //DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 // See https://github.com/shader-slang/slang/issues/11996
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -xslang -DNO_INT8=1
+// Notes:
+// - HLSL does not have 8-bit integer types
+// - HLSL has 16-bit integers when enabled (Slang does it automatically for the default profile)
+
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+// Note: Metal does not have the double type, so metal is not tested here
+
+// Note: WGSL does not have the double type, so wgsl is not tested here
 
 // Conversions to 64-bit double from all fundamental scalar types
 //
@@ -19,8 +26,12 @@ RWStructuredBuffer<double> outputBuffer;
 static uint i = 0;
 
 [noinline] void storeValue(bool     v) { outputBuffer[i++] = (double)v; }
+
+#ifndef NO_INT8
 [noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (double)v; }
 [noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (double)v; }
+#endif
+
 [noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (double)v; }
 [noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (double)v; }
 [noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (double)v; }
@@ -42,20 +53,34 @@ void computeMain()
     // CHECK-NEXT: 1.0
 
     // conversions from int8_t
+#ifndef NO_INT8
     storeValue(int8_t(-128));
     storeValue(int8_t(-42));
     storeValue(int8_t(67));
     storeValue(int8_t(127));
+#else
+    storeValue(double(-128.0));
+    storeValue(double(-42.0));
+    storeValue(double(67.0));
+    storeValue(double(127.0));
+#endif
     // CHECK-NEXT: -128.0
     // CHECK-NEXT: -42.0
     // CHECK-NEXT: 67.0
     // CHECK-NEXT: 127.0
 
     // conversions from uint8_t
+#ifndef NO_INT8
     storeValue(uint8_t(0));
     storeValue(uint8_t(42));
     storeValue(uint8_t(128));
     storeValue(uint8_t(255));
+#else
+    storeValue(double(0.0));
+    storeValue(double(42.0));
+    storeValue(double(128.0));
+    storeValue(double(255.0));
+#endif
     // CHECK-NEXT: 0.0
     // CHECK-NEXT: 42.0
     // CHECK-NEXT: 128.0

--- a/tests/language-feature/conversions/conversion-to-double.slang
+++ b/tests/language-feature/conversions/conversion-to-double.slang
@@ -1,0 +1,203 @@
+//DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+// See https://github.com/shader-slang/slang/issues/11996
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+// Conversions to 64-bit double from all fundamental scalar types
+//
+// In integer-to-half conversions, precisely convertible values are
+// used to avoid the effects of rounding. The rounding behavior is
+// implementation-defined at least on SPIR-V targets.
+
+//TEST_INPUT:ubuffer(data=[0], count=71, stride=8):out,name=outputBuffer
+RWStructuredBuffer<double> outputBuffer;
+
+static uint i = 0;
+
+[noinline] void storeValue(bool     v) { outputBuffer[i++] = (double)v; }
+[noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (double)v; }
+[noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (double)v; }
+[noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (double)v; }
+[noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (double)v; }
+[noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (double)v; }
+[noinline] void storeValue(uint32_t v) { outputBuffer[i++] = (double)v; }
+[noinline] void storeValue(int64_t  v) { outputBuffer[i++] = (double)v; }
+[noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (double)v; }
+[noinline] void storeValue(half     v) { outputBuffer[i++] = (double)v; }
+[noinline] void storeValue(float    v) { outputBuffer[i++] = (double)v; }
+[noinline] void storeValue(double   v) { outputBuffer[i++] = (double)v; }
+
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // conversions from bool
+    storeValue(false);
+    storeValue(true);
+    // CHECK: 0.0
+    // CHECK-NEXT: 1.0
+
+    // conversions from int8_t
+    storeValue(int8_t(-128));
+    storeValue(int8_t(-42));
+    storeValue(int8_t(67));
+    storeValue(int8_t(127));
+    // CHECK-NEXT: -128.0
+    // CHECK-NEXT: -42.0
+    // CHECK-NEXT: 67.0
+    // CHECK-NEXT: 127.0
+
+    // conversions from uint8_t
+    storeValue(uint8_t(0));
+    storeValue(uint8_t(42));
+    storeValue(uint8_t(128));
+    storeValue(uint8_t(255));
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 42.0
+    // CHECK-NEXT: 128.0
+    // CHECK-NEXT: 255.0
+
+    // conversions from int16_t
+    storeValue(int16_t(-32768));
+    storeValue(int16_t(-4242));
+    storeValue(int16_t(-128));
+    storeValue(int16_t(-1));
+    storeValue(int16_t(0));
+    storeValue(int16_t(1));
+    storeValue(int16_t(67));
+    storeValue(int16_t(127));
+    storeValue(int16_t(6767));
+    storeValue(int16_t(32767));
+    // CHECK-NEXT: -32768.0
+    // CHECK-NEXT: -4242.0
+    // CHECK-NEXT: -128.0
+    // CHECK-NEXT: -1.0
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 1.0
+    // CHECK-NEXT: 67.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 6767.0
+    // CHECK-NEXT: 32767.0
+
+    // conversions from uint16_t
+    storeValue(uint16_t(0));
+    storeValue(uint16_t(42));
+    storeValue(uint16_t(128));
+    storeValue(uint16_t(255));
+    storeValue(uint16_t(32767));
+    storeValue(uint16_t(32768));
+    storeValue(uint16_t(65535));
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 42.0
+    // CHECK-NEXT: 128.0
+    // CHECK-NEXT: 255.0
+    // CHECK-NEXT: 32767.0
+    // CHECK-NEXT: 32768.0
+    // CHECK-NEXT: 65535.0
+
+    // conversions from int32_t
+    storeValue(0x00000000);
+    storeValue(0x0000007F);
+    storeValue(0x000000FF);
+    storeValue(0x40414243);
+    storeValue(int32_t(0xFEFDFCFB));
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 255.0
+    // CHECK-NEXT: 1078018627.0
+    // CHECK-NEXT: -16909061.0
+
+    // conversions from uint32_t
+    storeValue(0x00000000U);
+    storeValue(0x0000007FU);
+    storeValue(0x000000FFU);
+    storeValue(0x40414243U);
+    storeValue(0xFEFDFCFBU);
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 255.0
+    // CHECK-NEXT: 1078018627.0
+    // CHECK-NEXT: 4278058235.0
+
+    // conversions from int64_t
+    storeValue(0x0000000000000000LL);
+    storeValue(0x000000000000007FLL);
+    storeValue(0x00000000000000FFLL);
+    storeValue(1230066625923858944LL);
+    storeValue(-1012478732629312256LL);
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 255.0
+    // CHECK-NEXT: 1230066625923858944.0
+    // CHECK-NEXT: -1012478732629312256.0
+
+    // conversions from uint64_t
+    storeValue(0x0000000000000000LLU);
+    storeValue(0x000000000000007FLLU);
+    storeValue(0x00000000000000FFLLU);
+    storeValue(1230066625923858944LLU);
+    storeValue(17434265341080240128LLU);
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 255.0
+    // CHECK-NEXT: 1230066625923858944.0
+    // CHECK-NEXT: 17434265341080240128.0
+
+    // conversions from half float
+    storeValue(-65504.0hf);
+    storeValue(-128.0hf);
+    storeValue(-67.25hf);
+    storeValue(127.9375hf);
+    storeValue(42.25hf);
+    storeValue(85.0hf);
+    storeValue(127.0hf);
+    storeValue(65504.0hf);
+    // CHECK-NEXT: -65504.0
+    // CHECK-NEXT: -128.0
+    // CHECK-NEXT: -67.25
+    // CHECK-NEXT: 127.9375
+    // CHECK-NEXT: 42.25
+    // CHECK-NEXT: 85.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 65504.0
+
+    // conversions from float
+    storeValue(-9223372036854775808.0f); // minimum int64_t number is representable by float
+    storeValue(-32768.0f);
+    storeValue(-67.25f);
+    storeValue(127.9375f);
+    storeValue(42.25f);
+    storeValue(85.0f);
+    storeValue(32767.0f);
+    storeValue(9223371487098961920.0f); // maximum int64_t number representable by float
+    // CHECK-NEXT: -9223372036854775808.0
+    // CHECK-NEXT: -32768.0
+    // CHECK-NEXT: -67.25
+    // CHECK-NEXT: 127.9375
+    // CHECK-NEXT: 42.25
+    // CHECK-NEXT: 85.0
+    // CHECK-NEXT: 32767.0
+    // CHECK-NEXT: 9223371487098961920.0
+
+    // conversions from double
+    storeValue(-9223372036854775808.0LF); // minimum int64_t number is representable by double
+    storeValue(-32768.0LF);
+    storeValue(-67.25LF);
+    storeValue(127.9375LF);
+    storeValue(42.25LF);
+    storeValue(85.0LF);
+    storeValue(32767.0LF);
+    storeValue(9223372036854774784.0LF);  // maximum int64_t number representable by double
+    // CHECK-NEXT: -9223372036854775808.0
+    // CHECK-NEXT: -32768.0
+    // CHECK-NEXT: -67.25
+    // CHECK-NEXT: 127.9375
+    // CHECK-NEXT: 42.25
+    // CHECK-NEXT: 85.0
+    // CHECK-NEXT: 32767.0
+    // CHECK-NEXT: 9223372036854774784.0
+}

--- a/tests/language-feature/conversions/conversion-to-float.slang
+++ b/tests/language-feature/conversions/conversion-to-float.slang
@@ -1,11 +1,20 @@
 //DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 // See https://github.com/shader-slang/slang/issues/11996
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -xslang -DNO_INT8=1
+// Notes:
+// - HLSL does not have 8-bit integer types
+// - HLSL has 16-bit integers when enabled (Slang does it automatically for the default profile)
+
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1
+// Note: Metal does not have the double type
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgsl -compute -output-using-type -xslang -DNO_DOUBLE=1 -xslang -DNO_INT8=1 -xslang -DNO_INT16=1 -xslang -DNO_INT64=1
+// Note: WGSL has only the 32-bit integers and 16-bit and 32-bit floats
 
 // Conversions to 32-bit float from all fundamental scalar types
 //
@@ -19,17 +28,31 @@ RWStructuredBuffer<float> outputBuffer;
 static uint i = 0;
 
 [noinline] void storeValue(bool     v) { outputBuffer[i++] = (float)v; }
+
+#ifndef NO_INT8
 [noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (float)v; }
 [noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (float)v; }
+#endif
+
+#ifndef NO_INT16
 [noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (float)v; }
 [noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (float)v; }
+#endif
+
 [noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (float)v; }
 [noinline] void storeValue(uint32_t v) { outputBuffer[i++] = (float)v; }
+
+#ifndef NO_INT64
 [noinline] void storeValue(int64_t  v) { outputBuffer[i++] = (float)v; }
 [noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (float)v; }
+#endif
+
 [noinline] void storeValue(half     v) { outputBuffer[i++] = (float)v; }
 [noinline] void storeValue(float    v) { outputBuffer[i++] = (float)v; }
+
+#ifndef NO_DOUBLE
 [noinline] void storeValue(double   v) { outputBuffer[i++] = (float)v; }
+#endif
 
 
 [numthreads(1, 1, 1)]
@@ -42,26 +65,41 @@ void computeMain()
     // CHECK-NEXT: 1.0
 
     // conversions from int8_t
+#ifndef NO_INT8
     storeValue(int8_t(-128));
     storeValue(int8_t(-42));
     storeValue(int8_t(67));
     storeValue(int8_t(127));
+#else
+    storeValue(float(-128.0));
+    storeValue(float(-42.0));
+    storeValue(float(67.0));
+    storeValue(float(127.0));
+#endif
     // CHECK-NEXT: -128.0
     // CHECK-NEXT: -42.0
     // CHECK-NEXT: 67.0
     // CHECK-NEXT: 127.0
 
     // conversions from uint8_t
+#ifndef NO_INT8
     storeValue(uint8_t(0));
     storeValue(uint8_t(42));
     storeValue(uint8_t(128));
     storeValue(uint8_t(255));
+#else
+    storeValue(float(0.0));
+    storeValue(float(42.0));
+    storeValue(float(128.0));
+    storeValue(float(255.0));
+#endif
     // CHECK-NEXT: 0.0
     // CHECK-NEXT: 42.0
     // CHECK-NEXT: 128.0
     // CHECK-NEXT: 255.0
 
     // conversions from int16_t
+#ifndef NO_INT16
     storeValue(int16_t(-32768));
     storeValue(int16_t(-4242));
     storeValue(int16_t(-128));
@@ -72,6 +110,18 @@ void computeMain()
     storeValue(int16_t(127));
     storeValue(int16_t(6767));
     storeValue(int16_t(32767));
+#else
+    storeValue(float(-32768.0));
+    storeValue(float(-4242.0));
+    storeValue(float(-128.0));
+    storeValue(float(-1.0));
+    storeValue(float(0.0));
+    storeValue(float(1.0));
+    storeValue(float(67.0));
+    storeValue(float(127.0));
+    storeValue(float(6767.0));
+    storeValue(float(32767.0));
+#endif
     // CHECK-NEXT: -32768.0
     // CHECK-NEXT: -4242.0
     // CHECK-NEXT: -128.0
@@ -84,6 +134,7 @@ void computeMain()
     // CHECK-NEXT: 32767.0
 
     // conversions from uint16_t
+#ifndef NO_INT16
     storeValue(uint16_t(0));
     storeValue(uint16_t(42));
     storeValue(uint16_t(128));
@@ -91,6 +142,15 @@ void computeMain()
     storeValue(uint16_t(32767));
     storeValue(uint16_t(32768));
     storeValue(uint16_t(65535));
+#else
+    storeValue(float(0.0));
+    storeValue(float(42.0));
+    storeValue(float(128.0));
+    storeValue(float(255.0));
+    storeValue(float(32767.0));
+    storeValue(float(32768.0));
+    storeValue(float(65535.0));
+#endif
     // CHECK-NEXT: 0.0
     // CHECK-NEXT: 42.0
     // CHECK-NEXT: 128.0
@@ -116,7 +176,7 @@ void computeMain()
     storeValue(0x0000007FU);
     storeValue(0x000000FFU);
     storeValue(1078018688U);
-    storeValue(4278058240);
+    storeValue(4278058240U);
     // CHECK-NEXT: 0.0
     // CHECK-NEXT: 127.0
     // CHECK-NEXT: 255.0
@@ -124,11 +184,19 @@ void computeMain()
     // CHECK-NEXT: 4278058240.0
 
     // conversions from int64_t
+#ifndef NO_INT64
     storeValue(0x0000000000000000LL);
     storeValue(0x000000000000007FLL);
     storeValue(0x00000000000000FFLL);
     storeValue(1230066676385447936LL);
     storeValue(-1012478754087239680LL);
+#else
+    storeValue(float(0.0));
+    storeValue(float(127.0));
+    storeValue(float(255.0));
+    storeValue(float(1230066676385447936.0));
+    storeValue(float(-1012478754087239680.0));
+#endif
     // CHECK-NEXT: 0.0
     // CHECK-NEXT: 127.0
     // CHECK-NEXT: 255.0
@@ -136,11 +204,19 @@ void computeMain()
     // CHECK-NEXT: -1012478754087239680.0
 
     // conversions from uint64_t
+#ifndef NO_INT64
     storeValue(0x0000000000000000LLU);
     storeValue(0x000000000000007FLLU);
     storeValue(0x00000000000000FFLLU);
     storeValue(1230066676385447936LLU);
     storeValue(17434265388341788672LLU);
+#else
+    storeValue(float(0.0));
+    storeValue(float(127.0));
+    storeValue(float(255.0));
+    storeValue(float(1230066676385447936.0));
+    storeValue(float(17434265388341788672.0));
+#endif
     // CHECK-NEXT: 0.0
     // CHECK-NEXT: 127.0
     // CHECK-NEXT: 255.0
@@ -184,6 +260,7 @@ void computeMain()
     // CHECK-NEXT: 9223371487098961920.0
 
     // conversions from double
+#ifndef NO_DOUBLE
     storeValue(-9223372036854775808.0LF); // minimum int64_t number is representable by float
     storeValue(-32768.0LF);
     storeValue(-67.25LF);
@@ -192,6 +269,16 @@ void computeMain()
     storeValue(85.0LF);
     storeValue(32767.0LF);
     storeValue(9223371487098961920.0LF);  // maximum int64_t number representable by float
+#else
+    storeValue(float(-9223372036854775808.0));
+    storeValue(float(-32768.0));
+    storeValue(float(-67.25));
+    storeValue(float(127.9375));
+    storeValue(float(42.25));
+    storeValue(float(85.0));
+    storeValue(float(32767.0));
+    storeValue(float(9223371487098961920.0));
+#endif
     // CHECK-NEXT: -9223372036854775808.0
     // CHECK-NEXT: -32768.0
     // CHECK-NEXT: -67.25

--- a/tests/language-feature/conversions/conversion-to-float.slang
+++ b/tests/language-feature/conversions/conversion-to-float.slang
@@ -1,0 +1,203 @@
+//DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+// See https://github.com/shader-slang/slang/issues/11996
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+// Conversions to 32-bit float from all fundamental scalar types
+//
+// In double-to-float and integer-to-float conversions, precisely
+// convertible values are used to avoid the effects of rounding. The
+// rounding behavior is implementation-defined at least on SPIR-V targets.
+
+//TEST_INPUT:ubuffer(data=[0], count=71, stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+static uint i = 0;
+
+[noinline] void storeValue(bool     v) { outputBuffer[i++] = (float)v; }
+[noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (float)v; }
+[noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (float)v; }
+[noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (float)v; }
+[noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (float)v; }
+[noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (float)v; }
+[noinline] void storeValue(uint32_t v) { outputBuffer[i++] = (float)v; }
+[noinline] void storeValue(int64_t  v) { outputBuffer[i++] = (float)v; }
+[noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (float)v; }
+[noinline] void storeValue(half     v) { outputBuffer[i++] = (float)v; }
+[noinline] void storeValue(float    v) { outputBuffer[i++] = (float)v; }
+[noinline] void storeValue(double   v) { outputBuffer[i++] = (float)v; }
+
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // conversions from bool
+    storeValue(false);
+    storeValue(true);
+    // CHECK: 0.0
+    // CHECK-NEXT: 1.0
+
+    // conversions from int8_t
+    storeValue(int8_t(-128));
+    storeValue(int8_t(-42));
+    storeValue(int8_t(67));
+    storeValue(int8_t(127));
+    // CHECK-NEXT: -128.0
+    // CHECK-NEXT: -42.0
+    // CHECK-NEXT: 67.0
+    // CHECK-NEXT: 127.0
+
+    // conversions from uint8_t
+    storeValue(uint8_t(0));
+    storeValue(uint8_t(42));
+    storeValue(uint8_t(128));
+    storeValue(uint8_t(255));
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 42.0
+    // CHECK-NEXT: 128.0
+    // CHECK-NEXT: 255.0
+
+    // conversions from int16_t
+    storeValue(int16_t(-32768));
+    storeValue(int16_t(-4242));
+    storeValue(int16_t(-128));
+    storeValue(int16_t(-1));
+    storeValue(int16_t(0));
+    storeValue(int16_t(1));
+    storeValue(int16_t(67));
+    storeValue(int16_t(127));
+    storeValue(int16_t(6767));
+    storeValue(int16_t(32767));
+    // CHECK-NEXT: -32768.0
+    // CHECK-NEXT: -4242.0
+    // CHECK-NEXT: -128.0
+    // CHECK-NEXT: -1.0
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 1.0
+    // CHECK-NEXT: 67.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 6767.0
+    // CHECK-NEXT: 32767.0
+
+    // conversions from uint16_t
+    storeValue(uint16_t(0));
+    storeValue(uint16_t(42));
+    storeValue(uint16_t(128));
+    storeValue(uint16_t(255));
+    storeValue(uint16_t(32767));
+    storeValue(uint16_t(32768));
+    storeValue(uint16_t(65535));
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 42.0
+    // CHECK-NEXT: 128.0
+    // CHECK-NEXT: 255.0
+    // CHECK-NEXT: 32767.0
+    // CHECK-NEXT: 32768.0
+    // CHECK-NEXT: 65535.0
+
+    // conversions from int32_t
+    storeValue(0x00000000);
+    storeValue(0x0000007F);
+    storeValue(0x000000FF);
+    storeValue(1078018688);
+    storeValue(-16909060);
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 255.0
+    // CHECK-NEXT: 1078018688.0
+    // CHECK-NEXT: -16909060.0
+
+    // conversions from uint32_t
+    storeValue(0x00000000U);
+    storeValue(0x0000007FU);
+    storeValue(0x000000FFU);
+    storeValue(1078018688U);
+    storeValue(4278058240);
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 255.0
+    // CHECK-NEXT: 1078018688.0
+    // CHECK-NEXT: 4278058240.0
+
+    // conversions from int64_t
+    storeValue(0x0000000000000000LL);
+    storeValue(0x000000000000007FLL);
+    storeValue(0x00000000000000FFLL);
+    storeValue(1230066676385447936LL);
+    storeValue(-1012478754087239680LL);
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 255.0
+    // CHECK-NEXT: 1230066676385447936.0
+    // CHECK-NEXT: -1012478754087239680.0
+
+    // conversions from uint64_t
+    storeValue(0x0000000000000000LLU);
+    storeValue(0x000000000000007FLLU);
+    storeValue(0x00000000000000FFLLU);
+    storeValue(1230066676385447936LLU);
+    storeValue(17434265388341788672LLU);
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 255.0
+    // CHECK-NEXT: 1230066676385447936.0
+    // CHECK-NEXT: 17434265388341788672.0
+
+    // conversions from half float
+    storeValue(-65504.0hf);
+    storeValue(-128.0hf);
+    storeValue(-67.25hf);
+    storeValue(127.9375hf);
+    storeValue(42.25hf);
+    storeValue(85.0hf);
+    storeValue(127.0hf);
+    storeValue(65504.0hf);
+    // CHECK-NEXT: -65504.0
+    // CHECK-NEXT: -128.0
+    // CHECK-NEXT: -67.25
+    // CHECK-NEXT: 127.9375
+    // CHECK-NEXT: 42.25
+    // CHECK-NEXT: 85.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 65504.0
+
+    // conversions from float
+    storeValue(-9223372036854775808.0f); // minimum int64_t number is representable by float
+    storeValue(-32768.0f);
+    storeValue(-67.25f);
+    storeValue(127.9375f);
+    storeValue(42.25f);
+    storeValue(85.0f);
+    storeValue(32767.0f);
+    storeValue(9223371487098961920.0f); // maximum int64_t number representable by float
+    // CHECK-NEXT: -9223372036854775808.0
+    // CHECK-NEXT: -32768.0
+    // CHECK-NEXT: -67.25
+    // CHECK-NEXT: 127.9375
+    // CHECK-NEXT: 42.25
+    // CHECK-NEXT: 85.0
+    // CHECK-NEXT: 32767.0
+    // CHECK-NEXT: 9223371487098961920.0
+
+    // conversions from double
+    storeValue(-9223372036854775808.0LF); // minimum int64_t number is representable by float
+    storeValue(-32768.0LF);
+    storeValue(-67.25LF);
+    storeValue(127.9375LF);
+    storeValue(42.25LF);
+    storeValue(85.0LF);
+    storeValue(32767.0LF);
+    storeValue(9223371487098961920.0LF);  // maximum int64_t number representable by float
+    // CHECK-NEXT: -9223372036854775808.0
+    // CHECK-NEXT: -32768.0
+    // CHECK-NEXT: -67.25
+    // CHECK-NEXT: 127.9375
+    // CHECK-NEXT: 42.25
+    // CHECK-NEXT: 85.0
+    // CHECK-NEXT: 32767.0
+    // CHECK-NEXT: 9223371487098961920.0
+}

--- a/tests/language-feature/conversions/conversion-to-float.slang
+++ b/tests/language-feature/conversions/conversion-to-float.slang
@@ -13,8 +13,10 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1
 // Note: Metal does not have the double type
 
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgsl -compute -output-using-type -xslang -DNO_DOUBLE=1 -xslang -DNO_INT8=1 -xslang -DNO_INT16=1 -xslang -DNO_INT64=1
-// Note: WGSL has only the 32-bit integers and 16-bit and 32-bit floats
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgsl -compute -output-using-type -render-feature half -xslang -DNO_DOUBLE=1 -xslang -DNO_INT8=1 -xslang -DNO_INT16=1 -xslang -DNO_INT64=1
+// Note: WGSL has only the 32-bit integers and 16-bit and 32-bit floats.
+// The 16-bit float (half) requires the f16 WGSL extension, so gate the test
+// on the "half" render feature.
 
 // Conversions to 32-bit float from all fundamental scalar types
 //

--- a/tests/language-feature/conversions/conversion-to-half.slang
+++ b/tests/language-feature/conversions/conversion-to-half.slang
@@ -1,0 +1,203 @@
+//DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+// See https://github.com/shader-slang/slang/issues/11996
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+// Conversions to 16-bit float from all fundamental scalar types
+//
+// In double-to-half, float-to-half, and integer-to-half conversions, precisely
+// convertible values are used to avoid the effects of rounding. The
+// rounding behavior is implementation-defined at least on SPIR-V targets.
+
+//TEST_INPUT:ubuffer(data=[0], count=71, stride=2):out,name=outputBuffer
+RWStructuredBuffer<half> outputBuffer;
+
+static uint i = 0;
+
+[noinline] void storeValue(bool     v) { outputBuffer[i++] = (half)v; }
+[noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (half)v; }
+[noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (half)v; }
+[noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (half)v; }
+[noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (half)v; }
+[noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (half)v; }
+[noinline] void storeValue(uint32_t v) { outputBuffer[i++] = (half)v; }
+[noinline] void storeValue(int64_t  v) { outputBuffer[i++] = (half)v; }
+[noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (half)v; }
+[noinline] void storeValue(half     v) { outputBuffer[i++] = (half)v; }
+[noinline] void storeValue(float    v) { outputBuffer[i++] = (half)v; }
+[noinline] void storeValue(double   v) { outputBuffer[i++] = (half)v; }
+
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // conversions from bool
+    storeValue(false);
+    storeValue(true);
+    // CHECK: 0.0
+    // CHECK-NEXT: 1.0
+
+    // conversions from int8_t
+    storeValue(int8_t(-128));
+    storeValue(int8_t(-42));
+    storeValue(int8_t(67));
+    storeValue(int8_t(127));
+    // CHECK-NEXT: -128.0
+    // CHECK-NEXT: -42.0
+    // CHECK-NEXT: 67.0
+    // CHECK-NEXT: 127.0
+
+    // conversions from uint8_t
+    storeValue(uint8_t(0));
+    storeValue(uint8_t(42));
+    storeValue(uint8_t(128));
+    storeValue(uint8_t(255));
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 42.0
+    // CHECK-NEXT: 128.0
+    // CHECK-NEXT: 255.0
+
+    // conversions from int16_t
+    storeValue(int16_t(-32768));
+    storeValue(int16_t(-4240));
+    storeValue(int16_t(-128));
+    storeValue(int16_t(-1));
+    storeValue(int16_t(0));
+    storeValue(int16_t(1));
+    storeValue(int16_t(67));
+    storeValue(int16_t(127));
+    storeValue(int16_t(6768));
+    storeValue(int16_t(32752));
+    // CHECK-NEXT: -32768.0
+    // CHECK-NEXT: -4240.0
+    // CHECK-NEXT: -128.0
+    // CHECK-NEXT: -1.0
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 1.0
+    // CHECK-NEXT: 67.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 6768.0
+    // CHECK-NEXT: 32752.0
+
+    // conversions from uint16_t
+    storeValue(uint16_t(0));
+    storeValue(uint16_t(42));
+    storeValue(uint16_t(128));
+    storeValue(uint16_t(255));
+    storeValue(uint16_t(32752));
+    storeValue(uint16_t(32768));
+    storeValue(uint16_t(65504));
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 42.0
+    // CHECK-NEXT: 128.0
+    // CHECK-NEXT: 255.0
+    // CHECK-NEXT: 32752.0
+    // CHECK-NEXT: 32768.0
+    // CHECK-NEXT: 65504.0
+
+    // conversions from int32_t
+    storeValue(0x00000000);
+    storeValue(0x0000007F);
+    storeValue(0x000000FF);
+    storeValue(65504);
+    storeValue(-16912);
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 255.0
+    // CHECK-NEXT: 65504.0
+    // CHECK-NEXT: -16912.0
+
+    // conversions from uint32_t
+    storeValue(0x00000000U);
+    storeValue(0x0000007FU);
+    storeValue(0x000000FFU);
+    storeValue(65504U);
+    storeValue(16912U);
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 255.0
+    // CHECK-NEXT: 65504.0
+    // CHECK-NEXT: 16912.0
+
+    // conversions from int64_t
+    storeValue(0x00000000LL);
+    storeValue(0x0000007FLL);
+    storeValue(0x000000FFLL);
+    storeValue(65504LL);
+    storeValue(-16912LL);
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 255.0
+    // CHECK-NEXT: 65504.0
+    // CHECK-NEXT: -16912.0
+
+    // conversions from uint64_t
+    storeValue(0x00000000LLU);
+    storeValue(0x0000007FLLU);
+    storeValue(0x000000FFLLU);
+    storeValue(65504LLU);
+    storeValue(16912LLU);
+    // CHECK-NEXT: 0.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 255.0
+    // CHECK-NEXT: 65504.0
+    // CHECK-NEXT: 16912.0
+
+    // conversions from half float
+    storeValue(-65504.0hf);
+    storeValue(-128.0hf);
+    storeValue(-67.25hf);
+    storeValue(127.9375hf);
+    storeValue(42.25hf);
+    storeValue(85.0hf);
+    storeValue(127.0hf);
+    storeValue(65504.0hf);
+    // CHECK-NEXT: -65504.0
+    // CHECK-NEXT: -128.0
+    // CHECK-NEXT: -67.25
+    // CHECK-NEXT: 127.9375
+    // CHECK-NEXT: 42.25
+    // CHECK-NEXT: 85.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 65504.0
+
+    // conversions from float
+    storeValue(-65504.0f);
+    storeValue(-128.0f);
+    storeValue(-67.25f);
+    storeValue(127.9375f);
+    storeValue(42.25f);
+    storeValue(85.0f);
+    storeValue(127.0f);
+    storeValue(65504.0f);
+    // CHECK-NEXT: -65504.0
+    // CHECK-NEXT: -128.0
+    // CHECK-NEXT: -67.25
+    // CHECK-NEXT: 127.9375
+    // CHECK-NEXT: 42.25
+    // CHECK-NEXT: 85.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 65504.0
+
+    // conversions from double
+    storeValue(-65504.0LF);
+    storeValue(-128.0LF);
+    storeValue(-67.25LF);
+    storeValue(127.9375LF);
+    storeValue(42.25LF);
+    storeValue(85.0LF);
+    storeValue(127.0LF);
+    storeValue(65504.0LF);
+    // CHECK-NEXT: -65504.0
+    // CHECK-NEXT: -128.0
+    // CHECK-NEXT: -67.25
+    // CHECK-NEXT: 127.9375
+    // CHECK-NEXT: 42.25
+    // CHECK-NEXT: 85.0
+    // CHECK-NEXT: 127.0
+    // CHECK-NEXT: 65504.0
+}

--- a/tests/language-feature/conversions/conversion-to-half.slang
+++ b/tests/language-feature/conversions/conversion-to-half.slang
@@ -13,8 +13,10 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1
 // Note: Metal does not have the double type
 
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgsl -compute -output-using-type -xslang -DNO_DOUBLE=1 -xslang -DNO_INT8=1 -xslang -DNO_INT16=1 -xslang -DNO_INT64=1
-// Note: WGSL has only the 32-bit integers and 16-bit and 32-bit floats
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgsl -compute -output-using-type -render-feature half -xslang -DNO_DOUBLE=1 -xslang -DNO_INT8=1 -xslang -DNO_INT16=1 -xslang -DNO_INT64=1
+// Note: WGSL has only the 32-bit integers and 16-bit and 32-bit floats.
+// The 16-bit float (half) requires the f16 WGSL extension, so gate the test
+// on the "half" render feature.
 
 // Conversions to 16-bit float from all fundamental scalar types
 //

--- a/tests/language-feature/conversions/conversion-to-half.slang
+++ b/tests/language-feature/conversions/conversion-to-half.slang
@@ -1,11 +1,20 @@
 //DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 // See https://github.com/shader-slang/slang/issues/11996
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -xslang -DNO_INT8=1
+// Notes:
+// - HLSL does not have 8-bit integer types
+// - HLSL has 16-bit integers when enabled (Slang does it automatically for the default profile)
+
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1
+// Note: Metal does not have the double type
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgsl -compute -output-using-type -xslang -DNO_DOUBLE=1 -xslang -DNO_INT8=1 -xslang -DNO_INT16=1 -xslang -DNO_INT64=1
+// Note: WGSL has only the 32-bit integers and 16-bit and 32-bit floats
 
 // Conversions to 16-bit float from all fundamental scalar types
 //
@@ -19,17 +28,31 @@ RWStructuredBuffer<half> outputBuffer;
 static uint i = 0;
 
 [noinline] void storeValue(bool     v) { outputBuffer[i++] = (half)v; }
+
+#ifndef NO_INT8
 [noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (half)v; }
 [noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (half)v; }
+#endif
+
+#ifndef NO_INT16
 [noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (half)v; }
 [noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (half)v; }
+#endif
+
 [noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (half)v; }
 [noinline] void storeValue(uint32_t v) { outputBuffer[i++] = (half)v; }
+
+#ifndef NO_INT64
 [noinline] void storeValue(int64_t  v) { outputBuffer[i++] = (half)v; }
 [noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (half)v; }
+#endif
+
 [noinline] void storeValue(half     v) { outputBuffer[i++] = (half)v; }
 [noinline] void storeValue(float    v) { outputBuffer[i++] = (half)v; }
+
+#ifndef NO_DOUBLE
 [noinline] void storeValue(double   v) { outputBuffer[i++] = (half)v; }
+#endif
 
 
 [numthreads(1, 1, 1)]
@@ -42,26 +65,41 @@ void computeMain()
     // CHECK-NEXT: 1.0
 
     // conversions from int8_t
+#ifndef NO_INT8
     storeValue(int8_t(-128));
     storeValue(int8_t(-42));
     storeValue(int8_t(67));
     storeValue(int8_t(127));
+#else
+    storeValue(half(-128.0));
+    storeValue(half(-42.0));
+    storeValue(half(67.0));
+    storeValue(half(127.0));
+#endif
     // CHECK-NEXT: -128.0
     // CHECK-NEXT: -42.0
     // CHECK-NEXT: 67.0
     // CHECK-NEXT: 127.0
 
     // conversions from uint8_t
+#ifndef NO_INT8
     storeValue(uint8_t(0));
     storeValue(uint8_t(42));
     storeValue(uint8_t(128));
     storeValue(uint8_t(255));
+#else
+    storeValue(half(0.0));
+    storeValue(half(42.0));
+    storeValue(half(128.0));
+    storeValue(half(255.0));
+#endif
     // CHECK-NEXT: 0.0
     // CHECK-NEXT: 42.0
     // CHECK-NEXT: 128.0
     // CHECK-NEXT: 255.0
 
     // conversions from int16_t
+#ifndef NO_INT16
     storeValue(int16_t(-32768));
     storeValue(int16_t(-4240));
     storeValue(int16_t(-128));
@@ -72,6 +110,18 @@ void computeMain()
     storeValue(int16_t(127));
     storeValue(int16_t(6768));
     storeValue(int16_t(32752));
+#else
+    storeValue(half(-32768.0));
+    storeValue(half(-4240.0));
+    storeValue(half(-128.0));
+    storeValue(half(-1.0));
+    storeValue(half(0.0));
+    storeValue(half(1.0));
+    storeValue(half(67.0));
+    storeValue(half(127.0));
+    storeValue(half(6768.0));
+    storeValue(half(32752.0));
+#endif
     // CHECK-NEXT: -32768.0
     // CHECK-NEXT: -4240.0
     // CHECK-NEXT: -128.0
@@ -84,6 +134,7 @@ void computeMain()
     // CHECK-NEXT: 32752.0
 
     // conversions from uint16_t
+#ifndef NO_INT16
     storeValue(uint16_t(0));
     storeValue(uint16_t(42));
     storeValue(uint16_t(128));
@@ -91,6 +142,15 @@ void computeMain()
     storeValue(uint16_t(32752));
     storeValue(uint16_t(32768));
     storeValue(uint16_t(65504));
+#else
+    storeValue(half(0.0));
+    storeValue(half(42.0));
+    storeValue(half(128.0));
+    storeValue(half(255.0));
+    storeValue(half(32752.0));
+    storeValue(half(32768.0));
+    storeValue(half(65504.0));
+#endif
     // CHECK-NEXT: 0.0
     // CHECK-NEXT: 42.0
     // CHECK-NEXT: 128.0
@@ -124,11 +184,19 @@ void computeMain()
     // CHECK-NEXT: 16912.0
 
     // conversions from int64_t
+#ifndef NO_INT64
     storeValue(0x00000000LL);
     storeValue(0x0000007FLL);
     storeValue(0x000000FFLL);
     storeValue(65504LL);
     storeValue(-16912LL);
+#else
+    storeValue(half(0.0));
+    storeValue(half(127.0));
+    storeValue(half(255.0));
+    storeValue(half(65504.0));
+    storeValue(half(-16912.0));
+#endif
     // CHECK-NEXT: 0.0
     // CHECK-NEXT: 127.0
     // CHECK-NEXT: 255.0
@@ -136,11 +204,19 @@ void computeMain()
     // CHECK-NEXT: -16912.0
 
     // conversions from uint64_t
+#ifndef NO_INT64
     storeValue(0x00000000LLU);
     storeValue(0x0000007FLLU);
     storeValue(0x000000FFLLU);
     storeValue(65504LLU);
     storeValue(16912LLU);
+#else
+    storeValue(half(0.0));
+    storeValue(half(127.0));
+    storeValue(half(255.0));
+    storeValue(half(65504.0));
+    storeValue(half(16912.0));
+#endif
     // CHECK-NEXT: 0.0
     // CHECK-NEXT: 127.0
     // CHECK-NEXT: 255.0
@@ -184,6 +260,7 @@ void computeMain()
     // CHECK-NEXT: 65504.0
 
     // conversions from double
+#ifndef NO_DOUBLE
     storeValue(-65504.0LF);
     storeValue(-128.0LF);
     storeValue(-67.25LF);
@@ -192,6 +269,16 @@ void computeMain()
     storeValue(85.0LF);
     storeValue(127.0LF);
     storeValue(65504.0LF);
+#else
+    storeValue(half(-65504.0));
+    storeValue(half(-128.0));
+    storeValue(half(-67.25));
+    storeValue(half(127.9375));
+    storeValue(half(42.25));
+    storeValue(half(85.0));
+    storeValue(half(127.0));
+    storeValue(half(65504.0));
+#endif
     // CHECK-NEXT: -65504.0
     // CHECK-NEXT: -128.0
     // CHECK-NEXT: -67.25

--- a/tests/language-feature/conversions/conversion-to-int16.slang
+++ b/tests/language-feature/conversions/conversion-to-int16.slang
@@ -1,0 +1,199 @@
+//DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+// See https://github.com/shader-slang/slang/issues/11996
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+// Conversions to 16-bit signed integer from all fundamental scalar types
+
+//TEST_INPUT:ubuffer(data=[0], count=71, stride=2):out,name=outputBuffer
+RWStructuredBuffer<int16_t> outputBuffer;
+
+static uint i = 0;
+
+[noinline] void storeValue(bool     v) { outputBuffer[i++] = (int16_t)v; }
+[noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (int16_t)v; }
+[noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (int16_t)v; }
+[noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (int16_t)v; }
+[noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (int16_t)v; }
+[noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (int16_t)v; }
+[noinline] void storeValue(uint32_t v) { outputBuffer[i++] = (int16_t)v; }
+[noinline] void storeValue(int64_t  v) { outputBuffer[i++] = (int16_t)v; }
+[noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (int16_t)v; }
+[noinline] void storeValue(half     v) { outputBuffer[i++] = (int16_t)v; }
+[noinline] void storeValue(float    v) { outputBuffer[i++] = (int16_t)v; }
+[noinline] void storeValue(double   v) { outputBuffer[i++] = (int16_t)v; }
+
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // conversions from bool
+    storeValue(false);
+    storeValue(true);
+    // CHECK: 0
+    // CHECK-NEXT: 1
+
+    // conversions from int8_t
+    storeValue(int8_t(-128));
+    storeValue(int8_t(-42));
+    storeValue(int8_t(67));
+    storeValue(int8_t(127));
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -42
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 127
+
+    // conversions from uint8_t
+    storeValue(uint8_t(0));
+    storeValue(uint8_t(42));
+    storeValue(uint8_t(128));
+    storeValue(uint8_t(255));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 128
+    // CHECK-NEXT: 255
+
+    // conversions from int16_t
+    storeValue(int16_t(-32768));
+    storeValue(int16_t(-4242));
+    storeValue(int16_t(-128));
+    storeValue(int16_t(-1));
+    storeValue(int16_t(0));
+    storeValue(int16_t(1));
+    storeValue(int16_t(67));
+    storeValue(int16_t(127));
+    storeValue(int16_t(6767));
+    storeValue(int16_t(32767));
+    // CHECK-NEXT: -32768
+    // CHECK-NEXT: -4242
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -1
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 6767
+    // CHECK-NEXT: 32767
+
+    // conversions from uint16_t
+    storeValue(uint16_t(0));
+    storeValue(uint16_t(42));
+    storeValue(uint16_t(128));
+    storeValue(uint16_t(255));
+    storeValue(uint16_t(32767));
+    storeValue(uint16_t(32768));
+    storeValue(uint16_t(65535));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 128
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 32767
+    // CHECK-NEXT: -32768
+    // CHECK-NEXT: -1
+
+    // conversions from int32_t
+    storeValue(0x00000000);
+    storeValue(0x0000007F);
+    storeValue(0x000000FF);
+    storeValue(0x40414243);
+    storeValue(int32_t(0xFEFDFCFB));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 16963
+    // CHECK-NEXT: -773
+
+    // conversions from uint32_t
+    storeValue(0x00000000U);
+    storeValue(0x0000007FU);
+    storeValue(0x000000FFU);
+    storeValue(0x40414243U);
+    storeValue(0xFEFDFCFBU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 16963
+    // CHECK-NEXT: -773
+
+    // conversions from int64_t
+    storeValue(0x0000000000000000LL);
+    storeValue(0x000000000000007FLL);
+    storeValue(0x00000000000000FFLL);
+    storeValue(0x1112131440414243LL);
+    storeValue(int64_t(0xF1F2F3F4FEFDFCFBLL));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 16963
+    // CHECK-NEXT: -773
+
+    // conversions from uint64_t
+    storeValue(0x0000000000000000LLU);
+    storeValue(0x000000000000007FLLU);
+    storeValue(0x00000000000000FFLLU);
+    storeValue(0x1112131440414243LLU);
+    storeValue(0xF1F2F3F4FEFDFCFBLLU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 16963
+    // CHECK-NEXT: -773
+
+    // conversions from half float
+    storeValue(-32768.0hf);
+    storeValue(-128.0hf);
+    storeValue(-67.9hf);
+    storeValue(0.001hf);
+    storeValue(42.9hf);
+    storeValue(85.0hf);
+    storeValue(127.0hf);
+    storeValue(32752.0hf);
+    // CHECK-NEXT: -32768
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -67
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 85
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 32752
+
+    // conversions from float
+    storeValue(-32768.9f);
+    storeValue(-32768.0f);
+    storeValue(-67.9f);
+    storeValue(0.001f);
+    storeValue(42.9f);
+    storeValue(85.0f);
+    storeValue(32767.0f);
+    storeValue(32767.9f);
+    // CHECK-NEXT: -32768
+    // CHECK-NEXT: -32768
+    // CHECK-NEXT: -67
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 85
+    // CHECK-NEXT: 32767
+    // CHECK-NEXT: 32767
+
+    // conversions from double
+    storeValue(-32768.999LF);
+    storeValue(-32768.0LF);
+    storeValue(-67.9LF);
+    storeValue(0.001LF);
+    storeValue(42.9LF);
+    storeValue(85.0LF);
+    storeValue(32767.0LF);
+    storeValue(32767.999LF);
+    // CHECK-NEXT: -32768
+    // CHECK-NEXT: -32768
+    // CHECK-NEXT: -67
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 85
+    // CHECK-NEXT: 32767
+    // CHECK-NEXT: 32767
+}

--- a/tests/language-feature/conversions/conversion-to-int16.slang
+++ b/tests/language-feature/conversions/conversion-to-int16.slang
@@ -1,11 +1,19 @@
 //DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 // See https://github.com/shader-slang/slang/issues/11996
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -xslang -DNO_INT8=1
+// Notes:
+// - HLSL does not have 8-bit integer types
+// - HLSL has 16-bit integers when enabled (Slang does it automatically for the default profile)
+
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1
+// Note: Metal does not have the double type
+
+// Note: WGSL does not have 16-bit integer types, so wgsl is not tested here
 
 // Conversions to 16-bit signed integer from all fundamental scalar types
 
@@ -15,8 +23,12 @@ RWStructuredBuffer<int16_t> outputBuffer;
 static uint i = 0;
 
 [noinline] void storeValue(bool     v) { outputBuffer[i++] = (int16_t)v; }
+
+#ifndef NO_INT8
 [noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (int16_t)v; }
 [noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (int16_t)v; }
+#endif
+
 [noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (int16_t)v; }
 [noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (int16_t)v; }
 [noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (int16_t)v; }
@@ -25,7 +37,10 @@ static uint i = 0;
 [noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (int16_t)v; }
 [noinline] void storeValue(half     v) { outputBuffer[i++] = (int16_t)v; }
 [noinline] void storeValue(float    v) { outputBuffer[i++] = (int16_t)v; }
+
+#ifndef NO_DOUBLE
 [noinline] void storeValue(double   v) { outputBuffer[i++] = (int16_t)v; }
+#endif
 
 
 [numthreads(1, 1, 1)]
@@ -38,20 +53,34 @@ void computeMain()
     // CHECK-NEXT: 1
 
     // conversions from int8_t
+#ifndef NO_INT8
     storeValue(int8_t(-128));
     storeValue(int8_t(-42));
     storeValue(int8_t(67));
     storeValue(int8_t(127));
+#else
+    storeValue(int16_t(-128));
+    storeValue(int16_t(-42));
+    storeValue(int16_t(67));
+    storeValue(int16_t(127));
+#endif
     // CHECK-NEXT: -128
     // CHECK-NEXT: -42
     // CHECK-NEXT: 67
     // CHECK-NEXT: 127
 
     // conversions from uint8_t
+#ifndef NO_INT8
     storeValue(uint8_t(0));
     storeValue(uint8_t(42));
     storeValue(uint8_t(128));
     storeValue(uint8_t(255));
+#else
+    storeValue(int16_t(0));
+    storeValue(int16_t(42));
+    storeValue(int16_t(128));
+    storeValue(int16_t(255));
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 42
     // CHECK-NEXT: 128
@@ -180,6 +209,7 @@ void computeMain()
     // CHECK-NEXT: 32767
 
     // conversions from double
+#ifndef NO_DOUBLE
     storeValue(-32768.999LF);
     storeValue(-32768.0LF);
     storeValue(-67.9LF);
@@ -188,6 +218,16 @@ void computeMain()
     storeValue(85.0LF);
     storeValue(32767.0LF);
     storeValue(32767.999LF);
+#else
+    storeValue(int16_t(-32768));
+    storeValue(int16_t(-32768));
+    storeValue(int16_t(-67));
+    storeValue(int16_t(0));
+    storeValue(int16_t(42));
+    storeValue(int16_t(85));
+    storeValue(int16_t(32767));
+    storeValue(int16_t(32767));
+#endif
     // CHECK-NEXT: -32768
     // CHECK-NEXT: -32768
     // CHECK-NEXT: -67

--- a/tests/language-feature/conversions/conversion-to-int32.slang
+++ b/tests/language-feature/conversions/conversion-to-int32.slang
@@ -1,0 +1,199 @@
+//DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+// See https://github.com/shader-slang/slang/issues/11996
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+// Conversions to 32-bit signed integer from all fundamental scalar types
+
+//TEST_INPUT:ubuffer(data=[0], count=71, stride=4):out,name=outputBuffer
+RWStructuredBuffer<int32_t> outputBuffer;
+
+static uint i = 0;
+
+[noinline] void storeValue(bool     v) { outputBuffer[i++] = (int32_t)v; }
+[noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (int32_t)v; }
+[noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (int32_t)v; }
+[noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (int32_t)v; }
+[noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (int32_t)v; }
+[noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (int32_t)v; }
+[noinline] void storeValue(uint32_t v) { outputBuffer[i++] = (int32_t)v; }
+[noinline] void storeValue(int64_t  v) { outputBuffer[i++] = (int32_t)v; }
+[noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (int32_t)v; }
+[noinline] void storeValue(half     v) { outputBuffer[i++] = (int32_t)v; }
+[noinline] void storeValue(float    v) { outputBuffer[i++] = (int32_t)v; }
+[noinline] void storeValue(double   v) { outputBuffer[i++] = (int32_t)v; }
+
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // conversions from bool
+    storeValue(false);
+    storeValue(true);
+    // CHECK: 0
+    // CHECK-NEXT: 1
+
+    // conversions from int8_t
+    storeValue(int8_t(-128));
+    storeValue(int8_t(-42));
+    storeValue(int8_t(67));
+    storeValue(int8_t(127));
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -42
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 127
+
+    // conversions from uint8_t
+    storeValue(uint8_t(0));
+    storeValue(uint8_t(42));
+    storeValue(uint8_t(128));
+    storeValue(uint8_t(255));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 128
+    // CHECK-NEXT: 255
+
+    // conversions from int16_t
+    storeValue(int16_t(-32768));
+    storeValue(int16_t(-4242));
+    storeValue(int16_t(-128));
+    storeValue(int16_t(-1));
+    storeValue(int16_t(0));
+    storeValue(int16_t(1));
+    storeValue(int16_t(67));
+    storeValue(int16_t(127));
+    storeValue(int16_t(6767));
+    storeValue(int16_t(32767));
+    // CHECK-NEXT: -32768
+    // CHECK-NEXT: -4242
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -1
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 6767
+    // CHECK-NEXT: 32767
+
+    // conversions from uint16_t
+    storeValue(uint16_t(0));
+    storeValue(uint16_t(42));
+    storeValue(uint16_t(128));
+    storeValue(uint16_t(255));
+    storeValue(uint16_t(32767));
+    storeValue(uint16_t(32768));
+    storeValue(uint16_t(65535));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 128
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 32767
+    // CHECK-NEXT: 32768
+    // CHECK-NEXT: 65535
+
+    // conversions from int32_t
+    storeValue(0x00000000);
+    storeValue(0x0000007F);
+    storeValue(0x000000FF);
+    storeValue(0x40414243);
+    storeValue(int32_t(0xFEFDFCFB));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 1078018627
+    // CHECK-NEXT: -16909061
+
+    // conversions from uint32_t
+    storeValue(0x00000000U);
+    storeValue(0x0000007FU);
+    storeValue(0x000000FFU);
+    storeValue(0x40414243U);
+    storeValue(0xFEFDFCFBU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 1078018627
+    // CHECK-NEXT: -16909061
+
+    // conversions from int64_t
+    storeValue(0x0000000000000000LL);
+    storeValue(0x000000000000007FLL);
+    storeValue(0x00000000000000FFLL);
+    storeValue(0x1112131440414243LL);
+    storeValue(int64_t(0xF1F2F3F4FEFDFCFBLL));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 1078018627
+    // CHECK-NEXT: -16909061
+
+    // conversions from uint64_t
+    storeValue(0x0000000000000000LLU);
+    storeValue(0x000000000000007FLLU);
+    storeValue(0x00000000000000FFLLU);
+    storeValue(0x1112131440414243LLU);
+    storeValue(0xF1F2F3F4FEFDFCFBLLU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 1078018627
+    // CHECK-NEXT: -16909061
+
+    // conversions from half float
+    storeValue(-65504.0hf);
+    storeValue(-128.0hf);
+    storeValue(-67.9hf);
+    storeValue(0.001hf);
+    storeValue(42.9hf);
+    storeValue(85.0hf);
+    storeValue(127.0hf);
+    storeValue(65504.0hf);
+    // CHECK-NEXT: -65504
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -67
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 85
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 65504
+
+    // conversions from float
+    storeValue(-2147483648.0f); // minimum int32_t number is representable by float
+    storeValue(-32768.0f);
+    storeValue(-67.9f);
+    storeValue(0.001f);
+    storeValue(42.9f);
+    storeValue(85.0f);
+    storeValue(32767.0f);
+    storeValue(2147483520.0f); // maximum int32_t number representable by float
+    // CHECK-NEXT: -2147483648
+    // CHECK-NEXT: -32768
+    // CHECK-NEXT: -67
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 85
+    // CHECK-NEXT: 32767
+    // CHECK-NEXT: 2147483520
+
+    // conversions from double
+    storeValue(-2147483648.9LF);
+    storeValue(-32768.0LF);
+    storeValue(-67.9LF);
+    storeValue(0.001LF);
+    storeValue(42.9LF);
+    storeValue(85.0LF);
+    storeValue(32767.0LF);
+    storeValue(2147483647.999LF);
+    // CHECK-NEXT: -2147483648
+    // CHECK-NEXT: -32768
+    // CHECK-NEXT: -67
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 85
+    // CHECK-NEXT: 32767
+    // CHECK-NEXT: 2147483647
+}

--- a/tests/language-feature/conversions/conversion-to-int32.slang
+++ b/tests/language-feature/conversions/conversion-to-int32.slang
@@ -13,8 +13,10 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1
 // Note: Metal does not have the double type
 
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgsl -compute -output-using-type -xslang -DNO_DOUBLE=1 -xslang -DNO_INT8=1 -xslang -DNO_INT16=1 -xslang -DNO_INT64=1
-// Note: WGSL has only the 32-bit integers and 16-bit and 32-bit floats
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgsl -compute -output-using-type -render-feature half -xslang -DNO_DOUBLE=1 -xslang -DNO_INT8=1 -xslang -DNO_INT16=1 -xslang -DNO_INT64=1
+// Note: WGSL has only the 32-bit integers and 16-bit and 32-bit floats.
+// The 16-bit float (half) requires the f16 WGSL extension, so gate the test
+// on the "half" render feature.
 
 // Conversions to 32-bit signed integer from all fundamental scalar types
 

--- a/tests/language-feature/conversions/conversion-to-int32.slang
+++ b/tests/language-feature/conversions/conversion-to-int32.slang
@@ -1,11 +1,20 @@
 //DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 // See https://github.com/shader-slang/slang/issues/11996
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -xslang -DNO_INT8=1
+// Notes:
+// - HLSL does not have 8-bit integer types
+// - HLSL has 16-bit integers when enabled (Slang does it automatically for the default profile)
+
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1
+// Note: Metal does not have the double type
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgsl -compute -output-using-type -xslang -DNO_DOUBLE=1 -xslang -DNO_INT8=1 -xslang -DNO_INT16=1 -xslang -DNO_INT64=1
+// Note: WGSL has only the 32-bit integers and 16-bit and 32-bit floats
 
 // Conversions to 32-bit signed integer from all fundamental scalar types
 
@@ -15,17 +24,31 @@ RWStructuredBuffer<int32_t> outputBuffer;
 static uint i = 0;
 
 [noinline] void storeValue(bool     v) { outputBuffer[i++] = (int32_t)v; }
+
+#ifndef NO_INT8
 [noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (int32_t)v; }
 [noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (int32_t)v; }
+#endif
+
+#ifndef NO_INT16
 [noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (int32_t)v; }
 [noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (int32_t)v; }
+#endif
+
 [noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (int32_t)v; }
 [noinline] void storeValue(uint32_t v) { outputBuffer[i++] = (int32_t)v; }
+
+#ifndef NO_INT64
 [noinline] void storeValue(int64_t  v) { outputBuffer[i++] = (int32_t)v; }
 [noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (int32_t)v; }
+#endif
+
 [noinline] void storeValue(half     v) { outputBuffer[i++] = (int32_t)v; }
 [noinline] void storeValue(float    v) { outputBuffer[i++] = (int32_t)v; }
+
+#ifndef NO_DOUBLE
 [noinline] void storeValue(double   v) { outputBuffer[i++] = (int32_t)v; }
+#endif
 
 
 [numthreads(1, 1, 1)]
@@ -38,26 +61,41 @@ void computeMain()
     // CHECK-NEXT: 1
 
     // conversions from int8_t
+#ifndef NO_INT8
     storeValue(int8_t(-128));
     storeValue(int8_t(-42));
     storeValue(int8_t(67));
     storeValue(int8_t(127));
+#else
+    storeValue(int32_t(-128));
+    storeValue(int32_t(-42));
+    storeValue(int32_t(67));
+    storeValue(int32_t(127));
+#endif
     // CHECK-NEXT: -128
     // CHECK-NEXT: -42
     // CHECK-NEXT: 67
     // CHECK-NEXT: 127
 
     // conversions from uint8_t
+#ifndef NO_INT8
     storeValue(uint8_t(0));
     storeValue(uint8_t(42));
     storeValue(uint8_t(128));
     storeValue(uint8_t(255));
+#else
+    storeValue(int32_t(0));
+    storeValue(int32_t(42));
+    storeValue(int32_t(128));
+    storeValue(int32_t(255));
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 42
     // CHECK-NEXT: 128
     // CHECK-NEXT: 255
 
     // conversions from int16_t
+#ifndef NO_INT16
     storeValue(int16_t(-32768));
     storeValue(int16_t(-4242));
     storeValue(int16_t(-128));
@@ -68,6 +106,18 @@ void computeMain()
     storeValue(int16_t(127));
     storeValue(int16_t(6767));
     storeValue(int16_t(32767));
+#else
+    storeValue(int32_t(-32768));
+    storeValue(int32_t(-4242));
+    storeValue(int32_t(-128));
+    storeValue(int32_t(-1));
+    storeValue(int32_t(0));
+    storeValue(int32_t(1));
+    storeValue(int32_t(67));
+    storeValue(int32_t(127));
+    storeValue(int32_t(6767));
+    storeValue(int32_t(32767));
+#endif
     // CHECK-NEXT: -32768
     // CHECK-NEXT: -4242
     // CHECK-NEXT: -128
@@ -80,6 +130,7 @@ void computeMain()
     // CHECK-NEXT: 32767
 
     // conversions from uint16_t
+#ifndef NO_INT16
     storeValue(uint16_t(0));
     storeValue(uint16_t(42));
     storeValue(uint16_t(128));
@@ -87,6 +138,15 @@ void computeMain()
     storeValue(uint16_t(32767));
     storeValue(uint16_t(32768));
     storeValue(uint16_t(65535));
+#else
+    storeValue(int32_t(0));
+    storeValue(int32_t(42));
+    storeValue(int32_t(128));
+    storeValue(int32_t(255));
+    storeValue(int32_t(32767));
+    storeValue(int32_t(32768));
+    storeValue(int32_t(65535));
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 42
     // CHECK-NEXT: 128
@@ -120,11 +180,19 @@ void computeMain()
     // CHECK-NEXT: -16909061
 
     // conversions from int64_t
+#ifndef NO_INT64
     storeValue(0x0000000000000000LL);
     storeValue(0x000000000000007FLL);
     storeValue(0x00000000000000FFLL);
     storeValue(0x1112131440414243LL);
     storeValue(int64_t(0xF1F2F3F4FEFDFCFBLL));
+#else
+    storeValue(int32_t(0));
+    storeValue(int32_t(127));
+    storeValue(int32_t(255));
+    storeValue(int32_t(1078018627));
+    storeValue(int32_t(-16909061));
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 127
     // CHECK-NEXT: 255
@@ -132,11 +200,19 @@ void computeMain()
     // CHECK-NEXT: -16909061
 
     // conversions from uint64_t
+#ifndef NO_INT64
     storeValue(0x0000000000000000LLU);
     storeValue(0x000000000000007FLLU);
     storeValue(0x00000000000000FFLLU);
     storeValue(0x1112131440414243LLU);
     storeValue(0xF1F2F3F4FEFDFCFBLLU);
+#else
+    storeValue(int32_t(0));
+    storeValue(int32_t(127));
+    storeValue(int32_t(255));
+    storeValue(int32_t(1078018627));
+    storeValue(int32_t(-16909061));
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 127
     // CHECK-NEXT: 255
@@ -180,6 +256,7 @@ void computeMain()
     // CHECK-NEXT: 2147483520
 
     // conversions from double
+#ifndef NO_DOUBLE
     storeValue(-2147483648.9LF);
     storeValue(-32768.0LF);
     storeValue(-67.9LF);
@@ -188,6 +265,16 @@ void computeMain()
     storeValue(85.0LF);
     storeValue(32767.0LF);
     storeValue(2147483647.999LF);
+#else
+    storeValue(int32_t(-2147483648));
+    storeValue(int32_t(-32768));
+    storeValue(int32_t(-67));
+    storeValue(int32_t(0));
+    storeValue(int32_t(42));
+    storeValue(int32_t(85));
+    storeValue(int32_t(32767));
+    storeValue(int32_t(2147483647));
+#endif
     // CHECK-NEXT: -2147483648
     // CHECK-NEXT: -32768
     // CHECK-NEXT: -67

--- a/tests/language-feature/conversions/conversion-to-int64.slang
+++ b/tests/language-feature/conversions/conversion-to-int64.slang
@@ -1,11 +1,19 @@
 //DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 // See https://github.com/shader-slang/slang/issues/11996
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -xslang -DNO_INT8=1
+// Notes:
+// - HLSL does not have 8-bit integer types
+// - HLSL has 16-bit integers when enabled (Slang does it automatically for the default profile)
+
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1
+// Note: Metal does not have the double type
+
+// Note: WGSL does not have 64-bit integer types, so wgsl is not tested here
 
 // Conversions to 64-bit signed integer from all fundamental scalar types
 
@@ -15,8 +23,12 @@ RWStructuredBuffer<int64_t> outputBuffer;
 static uint i = 0;
 
 [noinline] void storeValue(bool     v) { outputBuffer[i++] = (int64_t)v; }
+
+#ifndef NO_INT8
 [noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (int64_t)v; }
 [noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (int64_t)v; }
+#endif
+
 [noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (int64_t)v; }
 [noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (int64_t)v; }
 [noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (int64_t)v; }
@@ -25,7 +37,10 @@ static uint i = 0;
 [noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (int64_t)v; }
 [noinline] void storeValue(half     v) { outputBuffer[i++] = (int64_t)v; }
 [noinline] void storeValue(float    v) { outputBuffer[i++] = (int64_t)v; }
+
+#ifndef NO_DOUBLE
 [noinline] void storeValue(double   v) { outputBuffer[i++] = (int64_t)v; }
+#endif
 
 
 [numthreads(1, 1, 1)]
@@ -38,20 +53,34 @@ void computeMain()
     // CHECK-NEXT: 1
 
     // conversions from int8_t
+#ifndef NO_INT8
     storeValue(int8_t(-128));
     storeValue(int8_t(-42));
     storeValue(int8_t(67));
     storeValue(int8_t(127));
+#else
+    storeValue(int64_t(-128));
+    storeValue(int64_t(-42));
+    storeValue(int64_t(67));
+    storeValue(int64_t(127));
+#endif
     // CHECK-NEXT: -128
     // CHECK-NEXT: -42
     // CHECK-NEXT: 67
     // CHECK-NEXT: 127
 
     // conversions from uint8_t
+#ifndef NO_INT8
     storeValue(uint8_t(0));
     storeValue(uint8_t(42));
     storeValue(uint8_t(128));
     storeValue(uint8_t(255));
+#else
+    storeValue(int64_t(0));
+    storeValue(int64_t(42));
+    storeValue(int64_t(128));
+    storeValue(int64_t(255));
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 42
     // CHECK-NEXT: 128
@@ -180,6 +209,7 @@ void computeMain()
     // CHECK-NEXT: 9223371487098961920
 
     // conversions from double
+#ifndef NO_DOUBLE
     storeValue(-9223372036854775808.0LF); // minimum int64_t number is representable by double
     storeValue(-32768.0LF);
     storeValue(-67.9LF);
@@ -188,6 +218,16 @@ void computeMain()
     storeValue(85.0LF);
     storeValue(32767.0LF);
     storeValue(9223372036854774784.0LF);  // maximum int64_t number representable by double
+#else
+    storeValue(int64_t(-9223372036854775808));
+    storeValue(int64_t(-32768));
+    storeValue(int64_t(-67));
+    storeValue(int64_t(0));
+    storeValue(int64_t(42));
+    storeValue(int64_t(85));
+    storeValue(int64_t(32767));
+    storeValue(int64_t(9223372036854774784));
+#endif
     // CHECK-NEXT: -9223372036854775808
     // CHECK-NEXT: -32768
     // CHECK-NEXT: -67

--- a/tests/language-feature/conversions/conversion-to-int64.slang
+++ b/tests/language-feature/conversions/conversion-to-int64.slang
@@ -1,0 +1,199 @@
+//DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+// See https://github.com/shader-slang/slang/issues/11996
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+// Conversions to 64-bit signed integer from all fundamental scalar types
+
+//TEST_INPUT:ubuffer(data=[0], count=71, stride=8):out,name=outputBuffer
+RWStructuredBuffer<int64_t> outputBuffer;
+
+static uint i = 0;
+
+[noinline] void storeValue(bool     v) { outputBuffer[i++] = (int64_t)v; }
+[noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (int64_t)v; }
+[noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (int64_t)v; }
+[noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (int64_t)v; }
+[noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (int64_t)v; }
+[noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (int64_t)v; }
+[noinline] void storeValue(uint32_t v) { outputBuffer[i++] = (int64_t)v; }
+[noinline] void storeValue(int64_t  v) { outputBuffer[i++] = (int64_t)v; }
+[noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (int64_t)v; }
+[noinline] void storeValue(half     v) { outputBuffer[i++] = (int64_t)v; }
+[noinline] void storeValue(float    v) { outputBuffer[i++] = (int64_t)v; }
+[noinline] void storeValue(double   v) { outputBuffer[i++] = (int64_t)v; }
+
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // conversions from bool
+    storeValue(false);
+    storeValue(true);
+    // CHECK: 0
+    // CHECK-NEXT: 1
+
+    // conversions from int8_t
+    storeValue(int8_t(-128));
+    storeValue(int8_t(-42));
+    storeValue(int8_t(67));
+    storeValue(int8_t(127));
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -42
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 127
+
+    // conversions from uint8_t
+    storeValue(uint8_t(0));
+    storeValue(uint8_t(42));
+    storeValue(uint8_t(128));
+    storeValue(uint8_t(255));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 128
+    // CHECK-NEXT: 255
+
+    // conversions from int16_t
+    storeValue(int16_t(-32768));
+    storeValue(int16_t(-4242));
+    storeValue(int16_t(-128));
+    storeValue(int16_t(-1));
+    storeValue(int16_t(0));
+    storeValue(int16_t(1));
+    storeValue(int16_t(67));
+    storeValue(int16_t(127));
+    storeValue(int16_t(6767));
+    storeValue(int16_t(32767));
+    // CHECK-NEXT: -32768
+    // CHECK-NEXT: -4242
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -1
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 6767
+    // CHECK-NEXT: 32767
+
+    // conversions from uint16_t
+    storeValue(uint16_t(0));
+    storeValue(uint16_t(42));
+    storeValue(uint16_t(128));
+    storeValue(uint16_t(255));
+    storeValue(uint16_t(32767));
+    storeValue(uint16_t(32768));
+    storeValue(uint16_t(65535));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 128
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 32767
+    // CHECK-NEXT: 32768
+    // CHECK-NEXT: 65535
+
+    // conversions from int32_t
+    storeValue(0x00000000);
+    storeValue(0x0000007F);
+    storeValue(0x000000FF);
+    storeValue(0x40414243);
+    storeValue(int32_t(0xFEFDFCFB));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 1078018627
+    // CHECK-NEXT: -16909061
+
+    // conversions from uint32_t
+    storeValue(0x00000000U);
+    storeValue(0x0000007FU);
+    storeValue(0x000000FFU);
+    storeValue(0x40414243U);
+    storeValue(0xFEFDFCFBU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 1078018627
+    // CHECK-NEXT: 4278058235
+
+    // conversions from int64_t
+    storeValue(0x0000000000000000LL);
+    storeValue(0x000000000000007FLL);
+    storeValue(0x00000000000000FFLL);
+    storeValue(0x1112131440414243LL);
+    storeValue(int64_t(0xF1F2F3F4FEFDFCFBLL));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 1230066625923859011
+    // CHECK-NEXT: -1012478732629312261
+
+    // conversions from uint64_t
+    storeValue(0x0000000000000000LLU);
+    storeValue(0x000000000000007FLLU);
+    storeValue(0x00000000000000FFLLU);
+    storeValue(0x1112131440414243LLU);
+    storeValue(0xF1F2F3F4FEFDFCFBLLU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 1230066625923859011
+    // CHECK-NEXT: -1012478732629312261
+
+    // conversions from half float
+    storeValue(-65504.0hf);
+    storeValue(-128.0hf);
+    storeValue(-67.9hf);
+    storeValue(0.001hf);
+    storeValue(42.9hf);
+    storeValue(85.0hf);
+    storeValue(127.0hf);
+    storeValue(65504.0hf);
+    // CHECK-NEXT: -65504
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -67
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 85
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 65504
+
+    // conversions from float
+    storeValue(-9223372036854775808.0f); // minimum int64_t number is representable by float
+    storeValue(-32768.0f);
+    storeValue(-67.9f);
+    storeValue(0.001f);
+    storeValue(42.9f);
+    storeValue(85.0f);
+    storeValue(32767.0f);
+    storeValue(9223371487098961920.0f); // maximum int64_t number representable by float
+    // CHECK-NEXT: -9223372036854775808
+    // CHECK-NEXT: -32768
+    // CHECK-NEXT: -67
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 85
+    // CHECK-NEXT: 32767
+    // CHECK-NEXT: 9223371487098961920
+
+    // conversions from double
+    storeValue(-9223372036854775808.0LF); // minimum int64_t number is representable by double
+    storeValue(-32768.0LF);
+    storeValue(-67.9LF);
+    storeValue(0.001LF);
+    storeValue(42.9LF);
+    storeValue(85.0LF);
+    storeValue(32767.0LF);
+    storeValue(9223372036854774784.0LF);  // maximum int64_t number representable by double
+    // CHECK-NEXT: -9223372036854775808
+    // CHECK-NEXT: -32768
+    // CHECK-NEXT: -67
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 85
+    // CHECK-NEXT: 32767
+    // CHECK-NEXT: 9223372036854774784
+}

--- a/tests/language-feature/conversions/conversion-to-int8.slang
+++ b/tests/language-feature/conversions/conversion-to-int8.slang
@@ -1,0 +1,199 @@
+//DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+// See https://github.com/shader-slang/slang/issues/11996
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+// Conversions to 8-bit signed integer from all fundamental scalar types
+
+//TEST_INPUT:ubuffer(data=[0], count=71, stride=1):out,name=outputBuffer
+RWStructuredBuffer<int8_t> outputBuffer;
+
+static uint i = 0;
+
+[noinline] void storeValue(bool     v) { outputBuffer[i++] = (int8_t)v; }
+[noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (int8_t)v; }
+[noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (int8_t)v; }
+[noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (int8_t)v; }
+[noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (int8_t)v; }
+[noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (int8_t)v; }
+[noinline] void storeValue(uint32_t v) { outputBuffer[i++] = (int8_t)v; }
+[noinline] void storeValue(int64_t  v) { outputBuffer[i++] = (int8_t)v; }
+[noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (int8_t)v; }
+[noinline] void storeValue(half     v) { outputBuffer[i++] = (int8_t)v; }
+[noinline] void storeValue(float    v) { outputBuffer[i++] = (int8_t)v; }
+[noinline] void storeValue(double   v) { outputBuffer[i++] = (int8_t)v; }
+
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // conversions from bool
+    storeValue(false);
+    storeValue(true);
+    // CHECK: 0
+    // CHECK-NEXT: 1
+
+    // conversions from int8_t
+    storeValue(int8_t(-128));
+    storeValue(int8_t(-42));
+    storeValue(int8_t(67));
+    storeValue(int8_t(127));
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -42
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 127
+
+    // conversions from uint8_t
+    storeValue(uint8_t(0));
+    storeValue(uint8_t(42));
+    storeValue(uint8_t(128));
+    storeValue(uint8_t(255));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -1
+
+    // conversions from int16_t
+    storeValue(int16_t(-32768));
+    storeValue(int16_t(-4242));
+    storeValue(int16_t(-128));
+    storeValue(int16_t(-1));
+    storeValue(int16_t(0));
+    storeValue(int16_t(1));
+    storeValue(int16_t(67));
+    storeValue(int16_t(127));
+    storeValue(int16_t(6767));
+    storeValue(int16_t(32767));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 110
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -1
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 111
+    // CHECK-NEXT: -1
+
+    // conversions from uint16_t
+    storeValue(uint16_t(0));
+    storeValue(uint16_t(42));
+    storeValue(uint16_t(128));
+    storeValue(uint16_t(255));
+    storeValue(uint16_t(4242));
+    storeValue(uint16_t(6767));
+    storeValue(uint16_t(65535));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -1
+    // CHECK-NEXT: -110
+    // CHECK-NEXT: 111
+    // CHECK-NEXT: -1
+
+    // conversions from int32_t
+    storeValue(0x00000000);
+    storeValue(0x0000007F);
+    storeValue(0x000000FF);
+    storeValue(0x40414243);
+    storeValue(int32_t(0xFEFDFCFB));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: -1
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: -5
+
+    // conversions from uint32_t
+    storeValue(0x00000000U);
+    storeValue(0x0000007FU);
+    storeValue(0x000000FFU);
+    storeValue(0x40414243U);
+    storeValue(0xFEFDFCFBU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: -1
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: -5
+
+    // conversions from int64_t
+    storeValue(0x0000000000000000LL);
+    storeValue(0x000000000000007FLL);
+    storeValue(0x00000000000000FFLL);
+    storeValue(0x1112131440414243LL);
+    storeValue(int64_t(0xF1F2F3F4FEFDFCFBLL));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: -1
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: -5
+
+    // conversions from uint64_t
+    storeValue(0x0000000000000000LLU);
+    storeValue(0x000000000000007FLLU);
+    storeValue(0x00000000000000FFLLU);
+    storeValue(0x1112131440414243LLU);
+    storeValue(0xF1F2F3F4FEFDFCFBLLU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: -1
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: -5
+
+    // conversions from half float
+    storeValue(-128.9hf);
+    storeValue(-128.0hf);
+    storeValue(-67.9hf);
+    storeValue(0.001hf);
+    storeValue(42.9hf);
+    storeValue(85.0hf);
+    storeValue(127.0hf);
+    storeValue(127.9hf);
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -67
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 85
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 127
+
+    // conversions from float
+    storeValue(-128.9f);
+    storeValue(-128.0f);
+    storeValue(-67.9f);
+    storeValue(0.001f);
+    storeValue(42.9f);
+    storeValue(85.0f);
+    storeValue(127.0f);
+    storeValue(127.9f);
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -67
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 85
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 127
+
+    // conversions from double
+    storeValue(-128.9LF);
+    storeValue(-128.0LF);
+    storeValue(-67.9LF);
+    storeValue(0.001LF);
+    storeValue(42.9LF);
+    storeValue(85.0LF);
+    storeValue(127.0LF);
+    storeValue(127.9LF);
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -128
+    // CHECK-NEXT: -67
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 85
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 127
+}

--- a/tests/language-feature/conversions/conversion-to-int8.slang
+++ b/tests/language-feature/conversions/conversion-to-int8.slang
@@ -1,11 +1,16 @@
 //DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 // See https://github.com/shader-slang/slang/issues/11996
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+// Note: HLSL does not have 8-bit integer types, so dx12 is not tested here
+
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1
+// Note: Metal does not have the double type
+
+// Note: WGSL does not have 8-bit integer types, so wgsl is not tested here
 
 // Conversions to 8-bit signed integer from all fundamental scalar types
 
@@ -25,7 +30,10 @@ static uint i = 0;
 [noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (int8_t)v; }
 [noinline] void storeValue(half     v) { outputBuffer[i++] = (int8_t)v; }
 [noinline] void storeValue(float    v) { outputBuffer[i++] = (int8_t)v; }
+
+#ifndef NO_DOUBLE
 [noinline] void storeValue(double   v) { outputBuffer[i++] = (int8_t)v; }
+#endif
 
 
 [numthreads(1, 1, 1)]
@@ -180,6 +188,7 @@ void computeMain()
     // CHECK-NEXT: 127
 
     // conversions from double
+#ifndef NO_DOUBLE
     storeValue(-128.9LF);
     storeValue(-128.0LF);
     storeValue(-67.9LF);
@@ -188,6 +197,16 @@ void computeMain()
     storeValue(85.0LF);
     storeValue(127.0LF);
     storeValue(127.9LF);
+#else
+    storeValue(int8_t(-128));
+    storeValue(int8_t(-128));
+    storeValue(int8_t(-67));
+    storeValue(int8_t(0));
+    storeValue(int8_t(42));
+    storeValue(int8_t(85));
+    storeValue(int8_t(127));
+    storeValue(int8_t(127));
+#endif
     // CHECK-NEXT: -128
     // CHECK-NEXT: -128
     // CHECK-NEXT: -67

--- a/tests/language-feature/conversions/conversion-to-uint16.slang
+++ b/tests/language-feature/conversions/conversion-to-uint16.slang
@@ -1,11 +1,19 @@
 //DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 // See https://github.com/shader-slang/slang/issues/11996
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -xslang -DNO_INT8=1
+// Notes:
+// - HLSL does not have 8-bit integer types
+// - HLSL has 16-bit integers when enabled (Slang does it automatically for the default profile)
+
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1
+// Note: Metal does not have the double type
+
+// Note: WGSL does not have 16-bit integer types, so wgsl is not tested here
 
 // Conversions to 16-bit unsigned integer from all fundamental scalar types
 
@@ -15,8 +23,12 @@ RWStructuredBuffer<uint16_t> outputBuffer;
 static uint i = 0;
 
 [noinline] void storeValue(bool     v) { outputBuffer[i++] = (uint16_t)v; }
+
+#ifndef NO_INT8
 [noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (uint16_t)v; }
 [noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (uint16_t)v; }
+#endif
+
 [noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (uint16_t)v; }
 [noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (uint16_t)v; }
 [noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (uint16_t)v; }
@@ -25,7 +37,10 @@ static uint i = 0;
 [noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (uint16_t)v; }
 [noinline] void storeValue(half     v) { outputBuffer[i++] = (uint16_t)v; }
 [noinline] void storeValue(float    v) { outputBuffer[i++] = (uint16_t)v; }
+
+#ifndef NO_DOUBLE
 [noinline] void storeValue(double   v) { outputBuffer[i++] = (uint16_t)v; }
+#endif
 
 
 [numthreads(1, 1, 1)]
@@ -38,20 +53,34 @@ void computeMain()
     // CHECK-NEXT: 1
 
     // conversions from int8_t
+#ifndef NO_INT8
     storeValue(int8_t(-128));
     storeValue(int8_t(-42));
     storeValue(int8_t(67));
     storeValue(int8_t(127));
+#else
+    storeValue(uint16_t(65408));
+    storeValue(uint16_t(65494));
+    storeValue(uint16_t(67));
+    storeValue(uint16_t(127));
+#endif
     // CHECK-NEXT: 65408
     // CHECK-NEXT: 65494
     // CHECK-NEXT: 67
     // CHECK-NEXT: 127
 
     // conversions from uint8_t
+#ifndef NO_INT8
     storeValue(uint8_t(0));
     storeValue(uint8_t(42));
     storeValue(uint8_t(128));
     storeValue(uint8_t(255));
+#else
+    storeValue(uint16_t(0));
+    storeValue(uint16_t(42));
+    storeValue(uint16_t(128));
+    storeValue(uint16_t(255));
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 42
     // CHECK-NEXT: 128
@@ -172,12 +201,21 @@ void computeMain()
     // CHECK-NEXT: 65535
 
     // conversions from double
+#ifndef NO_DOUBLE
     storeValue(0.0LF);
     storeValue(0.9LF);
     storeValue(126.9LF);
     storeValue(65534.0LF);
     storeValue(65535.0LF);
     storeValue(65535.9LF);
+#else
+    storeValue(uint16_t(0));
+    storeValue(uint16_t(0));
+    storeValue(uint16_t(126));
+    storeValue(uint16_t(65534));
+    storeValue(uint16_t(65535));
+    storeValue(uint16_t(65535));
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 0
     // CHECK-NEXT: 126

--- a/tests/language-feature/conversions/conversion-to-uint16.slang
+++ b/tests/language-feature/conversions/conversion-to-uint16.slang
@@ -1,0 +1,187 @@
+//DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+// See https://github.com/shader-slang/slang/issues/11996
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+// Conversions to 16-bit unsigned integer from all fundamental scalar types
+
+//TEST_INPUT:ubuffer(data=[0], count=65, stride=2):out,name=outputBuffer
+RWStructuredBuffer<uint16_t> outputBuffer;
+
+static uint i = 0;
+
+[noinline] void storeValue(bool     v) { outputBuffer[i++] = (uint16_t)v; }
+[noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (uint16_t)v; }
+[noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (uint16_t)v; }
+[noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (uint16_t)v; }
+[noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (uint16_t)v; }
+[noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (uint16_t)v; }
+[noinline] void storeValue(uint32_t v) { outputBuffer[i++] = (uint16_t)v; }
+[noinline] void storeValue(int64_t  v) { outputBuffer[i++] = (uint16_t)v; }
+[noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (uint16_t)v; }
+[noinline] void storeValue(half     v) { outputBuffer[i++] = (uint16_t)v; }
+[noinline] void storeValue(float    v) { outputBuffer[i++] = (uint16_t)v; }
+[noinline] void storeValue(double   v) { outputBuffer[i++] = (uint16_t)v; }
+
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // conversions from bool
+    storeValue(false);
+    storeValue(true);
+    // CHECK: 0
+    // CHECK-NEXT: 1
+
+    // conversions from int8_t
+    storeValue(int8_t(-128));
+    storeValue(int8_t(-42));
+    storeValue(int8_t(67));
+    storeValue(int8_t(127));
+    // CHECK-NEXT: 65408
+    // CHECK-NEXT: 65494
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 127
+
+    // conversions from uint8_t
+    storeValue(uint8_t(0));
+    storeValue(uint8_t(42));
+    storeValue(uint8_t(128));
+    storeValue(uint8_t(255));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 128
+    // CHECK-NEXT: 255
+
+    // conversions from int16_t
+    storeValue(int16_t(-32768));
+    storeValue(int16_t(-4242));
+    storeValue(int16_t(-128));
+    storeValue(int16_t(-1));
+    storeValue(int16_t(0));
+    storeValue(int16_t(1));
+    storeValue(int16_t(67));
+    storeValue(int16_t(127));
+    storeValue(int16_t(6767));
+    storeValue(int16_t(32767));
+    // CHECK-NEXT: 32768
+    // CHECK-NEXT: 61294
+    // CHECK-NEXT: 65408
+    // CHECK-NEXT: 65535
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 6767
+    // CHECK-NEXT: 32767
+
+    // conversions from uint16_t
+    storeValue(uint16_t(0));
+    storeValue(uint16_t(42));
+    storeValue(uint16_t(128));
+    storeValue(uint16_t(255));
+    storeValue(uint16_t(4242));
+    storeValue(uint16_t(6767));
+    storeValue(uint16_t(65535));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 128
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 4242
+    // CHECK-NEXT: 6767
+    // CHECK-NEXT: 65535
+
+    // conversions from int32_t
+    storeValue(0x00000000);
+    storeValue(0x0000007F);
+    storeValue(0x000000FF);
+    storeValue(0x40414243);
+    storeValue(int32_t(0xFEFDFCFB));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 16963
+    // CHECK-NEXT: 64763
+
+    // conversions from uint32_t
+    storeValue(0x00000000U);
+    storeValue(0x0000007FU);
+    storeValue(0x000000FFU);
+    storeValue(0x40414243U);
+    storeValue(0xFEFDFCFBU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 16963
+    // CHECK-NEXT: 64763
+
+    // conversions from int64_t
+    storeValue(0x0000000000000000LL);
+    storeValue(0x000000000000007FLL);
+    storeValue(0x00000000000000FFLL);
+    storeValue(0x1112131440414243LL);
+    storeValue(int64_t(0xF1F2F3F4FEFDFCFBLL));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 16963
+    // CHECK-NEXT: 64763
+
+    // conversions from uint64_t
+    storeValue(0x0000000000000000LLU);
+    storeValue(0x000000000000007FLLU);
+    storeValue(0x00000000000000FFLLU);
+    storeValue(0x1112131440414243LLU);
+    storeValue(0xF1F2F3F4FEFDFCFBLLU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 16963
+    // CHECK-NEXT: 64763
+
+    // conversions from half float
+    storeValue(0.0hf);
+    storeValue(0.9hf);
+    storeValue(126.9hf);
+    storeValue(127.0hf);
+    storeValue(255.9hf);
+    storeValue(65504.0hf);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 126
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 65504
+
+    // conversions from float
+    storeValue(0.0f);
+    storeValue(0.9f);
+    storeValue(126.9f);
+    storeValue(65534.0f);
+    storeValue(65535.0f);
+    storeValue(65535.9f);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 126
+    // CHECK-NEXT: 65534
+    // CHECK-NEXT: 65535
+    // CHECK-NEXT: 65535
+
+    // conversions from double
+    storeValue(0.0LF);
+    storeValue(0.9LF);
+    storeValue(126.9LF);
+    storeValue(65534.0LF);
+    storeValue(65535.0LF);
+    storeValue(65535.9LF);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 126
+    // CHECK-NEXT: 65534
+    // CHECK-NEXT: 65535
+    // CHECK-NEXT: 65535
+}

--- a/tests/language-feature/conversions/conversion-to-uint32.slang
+++ b/tests/language-feature/conversions/conversion-to-uint32.slang
@@ -1,0 +1,187 @@
+//DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+// See https://github.com/shader-slang/slang/issues/11996
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+// Conversions to 32-bit unsigned integer from all fundamental scalar types
+
+//TEST_INPUT:ubuffer(data=[0], count=65, stride=4):out,name=outputBuffer
+RWStructuredBuffer<uint32_t> outputBuffer;
+
+static uint i = 0;
+
+[noinline] void storeValue(bool     v) { outputBuffer[i++] = (uint32_t)v; }
+[noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (uint32_t)v; }
+[noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (uint32_t)v; }
+[noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (uint32_t)v; }
+[noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (uint32_t)v; }
+[noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (uint32_t)v; }
+[noinline] void storeValue(uint32_t v) { outputBuffer[i++] = (uint32_t)v; }
+[noinline] void storeValue(int64_t  v) { outputBuffer[i++] = (uint32_t)v; }
+[noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (uint32_t)v; }
+[noinline] void storeValue(half     v) { outputBuffer[i++] = (uint32_t)v; }
+[noinline] void storeValue(float    v) { outputBuffer[i++] = (uint32_t)v; }
+[noinline] void storeValue(double   v) { outputBuffer[i++] = (uint32_t)v; }
+
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // conversions from bool
+    storeValue(false);
+    storeValue(true);
+    // CHECK: 0
+    // CHECK-NEXT: 1
+
+    // conversions from int8_t
+    storeValue(int8_t(-128));
+    storeValue(int8_t(-42));
+    storeValue(int8_t(67));
+    storeValue(int8_t(127));
+    // CHECK-NEXT: 4294967168
+    // CHECK-NEXT: 4294967254
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 127
+
+    // conversions from uint8_t
+    storeValue(uint8_t(0));
+    storeValue(uint8_t(42));
+    storeValue(uint8_t(128));
+    storeValue(uint8_t(255));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 128
+    // CHECK-NEXT: 255
+
+    // conversions from int16_t
+    storeValue(int16_t(-32768));
+    storeValue(int16_t(-4242));
+    storeValue(int16_t(-128));
+    storeValue(int16_t(-1));
+    storeValue(int16_t(0));
+    storeValue(int16_t(1));
+    storeValue(int16_t(67));
+    storeValue(int16_t(127));
+    storeValue(int16_t(6767));
+    storeValue(int16_t(32767));
+    // CHECK-NEXT: 4294934528
+    // CHECK-NEXT: 4294963054
+    // CHECK-NEXT: 4294967168
+    // CHECK-NEXT: 4294967295
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 6767
+    // CHECK-NEXT: 32767
+
+    // conversions from uint16_t
+    storeValue(uint16_t(0));
+    storeValue(uint16_t(42));
+    storeValue(uint16_t(128));
+    storeValue(uint16_t(255));
+    storeValue(uint16_t(4242));
+    storeValue(uint16_t(6767));
+    storeValue(uint16_t(65535));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 128
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 4242
+    // CHECK-NEXT: 6767
+    // CHECK-NEXT: 65535
+
+    // conversions from int32_t
+    storeValue(0x00000000);
+    storeValue(0x0000007F);
+    storeValue(0x000000FF);
+    storeValue(0x40414243);
+    storeValue(int32_t(0xFEFDFCFB));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 1078018627
+    // CHECK-NEXT: 4278058235
+
+    // conversions from uint32_t
+    storeValue(0x00000000U);
+    storeValue(0x0000007FU);
+    storeValue(0x000000FFU);
+    storeValue(0x40414243U);
+    storeValue(0xFEFDFCFBU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 1078018627
+    // CHECK-NEXT: 4278058235
+
+    // conversions from int64_t
+    storeValue(0x0000000000000000LL);
+    storeValue(0x000000000000007FLL);
+    storeValue(0x00000000000000FFLL);
+    storeValue(0x1112131440414243LL);
+    storeValue(int64_t(0xF1F2F3F4FEFDFCFBLL));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 1078018627
+    // CHECK-NEXT: 4278058235
+
+    // conversions from uint64_t
+    storeValue(0x0000000000000000LLU);
+    storeValue(0x000000000000007FLLU);
+    storeValue(0x00000000000000FFLLU);
+    storeValue(0x1112131440414243LLU);
+    storeValue(0xF1F2F3F4FEFDFCFBLLU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 1078018627
+    // CHECK-NEXT: 4278058235
+
+    // conversions from half float
+    storeValue(-0.9hf);
+    storeValue(0.9hf);
+    storeValue(126.9hf);
+    storeValue(127.0hf);
+    storeValue(255.9hf);
+    storeValue(65504.0hf); // max half float
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 126
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 65504
+
+    // conversions from float
+    storeValue(-0.9f);
+    storeValue(0.9f);
+    storeValue(126.9f);
+    storeValue(65534.0f);
+    storeValue(65535.0f);
+    storeValue(4294967040.0f); // largest uint32_t value representable by float
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 126
+    // CHECK-NEXT: 65534
+    // CHECK-NEXT: 65535
+    // CHECK-NEXT: 4294967040
+
+    // conversions from double
+    storeValue(-0.9LF);
+    storeValue(0.9LF);
+    storeValue(126.9LF);
+    storeValue(65534.0LF);
+    storeValue(4294967295.0LF);
+    storeValue(4294967295.9LF);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 126
+    // CHECK-NEXT: 65534
+    // CHECK-NEXT: 4294967295
+    // CHECK-NEXT: 4294967295
+}

--- a/tests/language-feature/conversions/conversion-to-uint32.slang
+++ b/tests/language-feature/conversions/conversion-to-uint32.slang
@@ -13,8 +13,10 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1
 // Note: Metal does not have the double type
 
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgsl -compute -output-using-type -xslang -DNO_DOUBLE=1 -xslang -DNO_INT8=1 -xslang -DNO_INT16=1 -xslang -DNO_INT64=1
-// Note: WGSL has only the 32-bit integers and 16-bit and 32-bit floats
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgsl -compute -output-using-type -render-feature half -xslang -DNO_DOUBLE=1 -xslang -DNO_INT8=1 -xslang -DNO_INT16=1 -xslang -DNO_INT64=1
+// Note: WGSL has only the 32-bit integers and 16-bit and 32-bit floats.
+// The 16-bit float (half) requires the f16 WGSL extension, so gate the test
+// on the "half" render feature.
 
 // Conversions to 32-bit unsigned integer from all fundamental scalar types
 

--- a/tests/language-feature/conversions/conversion-to-uint32.slang
+++ b/tests/language-feature/conversions/conversion-to-uint32.slang
@@ -1,11 +1,20 @@
 //DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 // See https://github.com/shader-slang/slang/issues/11996
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -xslang -DNO_INT8=1
+// Notes:
+// - HLSL does not have 8-bit integer types
+// - HLSL has 16-bit integers when enabled (Slang does it automatically for the default profile)
+
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1
+// Note: Metal does not have the double type
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgsl -compute -output-using-type -xslang -DNO_DOUBLE=1 -xslang -DNO_INT8=1 -xslang -DNO_INT16=1 -xslang -DNO_INT64=1
+// Note: WGSL has only the 32-bit integers and 16-bit and 32-bit floats
 
 // Conversions to 32-bit unsigned integer from all fundamental scalar types
 
@@ -15,18 +24,31 @@ RWStructuredBuffer<uint32_t> outputBuffer;
 static uint i = 0;
 
 [noinline] void storeValue(bool     v) { outputBuffer[i++] = (uint32_t)v; }
+
+#ifndef NO_INT8
 [noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (uint32_t)v; }
 [noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (uint32_t)v; }
+#endif
+
+#ifndef NO_INT16
 [noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (uint32_t)v; }
 [noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (uint32_t)v; }
+#endif
+
 [noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (uint32_t)v; }
 [noinline] void storeValue(uint32_t v) { outputBuffer[i++] = (uint32_t)v; }
+
+#ifndef NO_INT64
 [noinline] void storeValue(int64_t  v) { outputBuffer[i++] = (uint32_t)v; }
 [noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (uint32_t)v; }
+#endif
+
 [noinline] void storeValue(half     v) { outputBuffer[i++] = (uint32_t)v; }
 [noinline] void storeValue(float    v) { outputBuffer[i++] = (uint32_t)v; }
-[noinline] void storeValue(double   v) { outputBuffer[i++] = (uint32_t)v; }
 
+#ifndef NO_DOUBLE
+[noinline] void storeValue(double   v) { outputBuffer[i++] = (uint32_t)v; }
+#endif
 
 [numthreads(1, 1, 1)]
 void computeMain()
@@ -38,26 +60,41 @@ void computeMain()
     // CHECK-NEXT: 1
 
     // conversions from int8_t
+#ifndef NO_INT8
     storeValue(int8_t(-128));
     storeValue(int8_t(-42));
     storeValue(int8_t(67));
     storeValue(int8_t(127));
+#else
+    storeValue(4294967168U);
+    storeValue(4294967254U);
+    storeValue(67U);
+    storeValue(127U);
+#endif
     // CHECK-NEXT: 4294967168
     // CHECK-NEXT: 4294967254
     // CHECK-NEXT: 67
     // CHECK-NEXT: 127
 
     // conversions from uint8_t
+#ifndef NO_INT8
     storeValue(uint8_t(0));
     storeValue(uint8_t(42));
     storeValue(uint8_t(128));
     storeValue(uint8_t(255));
+#else
+    storeValue(0U);
+    storeValue(42U);
+    storeValue(128U);
+    storeValue(255U);
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 42
     // CHECK-NEXT: 128
     // CHECK-NEXT: 255
 
     // conversions from int16_t
+#ifndef NO_INT16
     storeValue(int16_t(-32768));
     storeValue(int16_t(-4242));
     storeValue(int16_t(-128));
@@ -68,6 +105,18 @@ void computeMain()
     storeValue(int16_t(127));
     storeValue(int16_t(6767));
     storeValue(int16_t(32767));
+#else
+    storeValue(4294934528U);
+    storeValue(4294963054U);
+    storeValue(4294967168U);
+    storeValue(4294967295U);
+    storeValue(0U);
+    storeValue(1U);
+    storeValue(67U);
+    storeValue(127U);
+    storeValue(6767U);
+    storeValue(32767U);
+#endif
     // CHECK-NEXT: 4294934528
     // CHECK-NEXT: 4294963054
     // CHECK-NEXT: 4294967168
@@ -80,6 +129,7 @@ void computeMain()
     // CHECK-NEXT: 32767
 
     // conversions from uint16_t
+#ifndef NO_INT16
     storeValue(uint16_t(0));
     storeValue(uint16_t(42));
     storeValue(uint16_t(128));
@@ -87,6 +137,15 @@ void computeMain()
     storeValue(uint16_t(4242));
     storeValue(uint16_t(6767));
     storeValue(uint16_t(65535));
+#else
+    storeValue(0U);
+    storeValue(42U);
+    storeValue(128U);
+    storeValue(255U);
+    storeValue(4242U);
+    storeValue(6767U);
+    storeValue(65535U);
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 42
     // CHECK-NEXT: 128
@@ -120,11 +179,19 @@ void computeMain()
     // CHECK-NEXT: 4278058235
 
     // conversions from int64_t
+#ifndef NO_INT64
     storeValue(0x0000000000000000LL);
     storeValue(0x000000000000007FLL);
     storeValue(0x00000000000000FFLL);
     storeValue(0x1112131440414243LL);
     storeValue(int64_t(0xF1F2F3F4FEFDFCFBLL));
+#else
+    storeValue(0U);
+    storeValue(127U);
+    storeValue(255U);
+    storeValue(1078018627U);
+    storeValue(4278058235U);
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 127
     // CHECK-NEXT: 255
@@ -132,11 +199,19 @@ void computeMain()
     // CHECK-NEXT: 4278058235
 
     // conversions from uint64_t
+#ifndef NO_INT64
     storeValue(0x0000000000000000LLU);
     storeValue(0x000000000000007FLLU);
     storeValue(0x00000000000000FFLLU);
     storeValue(0x1112131440414243LLU);
     storeValue(0xF1F2F3F4FEFDFCFBLLU);
+#else
+    storeValue(0U);
+    storeValue(127U);
+    storeValue(255U);
+    storeValue(1078018627U);
+    storeValue(4278058235U);
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 127
     // CHECK-NEXT: 255
@@ -172,12 +247,21 @@ void computeMain()
     // CHECK-NEXT: 4294967040
 
     // conversions from double
+#ifndef NO_DOUBLE
     storeValue(-0.9LF);
     storeValue(0.9LF);
     storeValue(126.9LF);
     storeValue(65534.0LF);
     storeValue(4294967295.0LF);
     storeValue(4294967295.9LF);
+#else
+    storeValue(0U);
+    storeValue(0U);
+    storeValue(126U);
+    storeValue(65534U);
+    storeValue(4294967295U);
+    storeValue(4294967295U);
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 0
     // CHECK-NEXT: 126

--- a/tests/language-feature/conversions/conversion-to-uint64.slang
+++ b/tests/language-feature/conversions/conversion-to-uint64.slang
@@ -1,0 +1,187 @@
+//DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+// See https://github.com/shader-slang/slang/issues/11996
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+// Conversions to 64-bit unsigned integer from all fundamental scalar types
+
+//TEST_INPUT:ubuffer(data=[0], count=65, stride=8):out,name=outputBuffer
+RWStructuredBuffer<uint64_t> outputBuffer;
+
+static uint i = 0;
+
+[noinline] void storeValue(bool     v) { outputBuffer[i++] = (uint64_t)v; }
+[noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (uint64_t)v; }
+[noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (uint64_t)v; }
+[noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (uint64_t)v; }
+[noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (uint64_t)v; }
+[noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (uint64_t)v; }
+[noinline] void storeValue(uint32_t v) { outputBuffer[i++] = (uint64_t)v; }
+[noinline] void storeValue(int64_t  v) { outputBuffer[i++] = (uint64_t)v; }
+[noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (uint64_t)v; }
+[noinline] void storeValue(half     v) { outputBuffer[i++] = (uint64_t)v; }
+[noinline] void storeValue(float    v) { outputBuffer[i++] = (uint64_t)v; }
+[noinline] void storeValue(double   v) { outputBuffer[i++] = (uint64_t)v; }
+
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // conversions from bool
+    storeValue(false);
+    storeValue(true);
+    // CHECK: 0
+    // CHECK-NEXT: 1
+
+    // conversions from int8_t
+    storeValue(int8_t(-128));
+    storeValue(int8_t(-42));
+    storeValue(int8_t(67));
+    storeValue(int8_t(127));
+    // CHECK-NEXT: 18446744073709551488
+    // CHECK-NEXT: 18446744073709551574
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 127
+
+    // conversions from uint8_t
+    storeValue(uint8_t(0));
+    storeValue(uint8_t(42));
+    storeValue(uint8_t(128));
+    storeValue(uint8_t(255));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 128
+    // CHECK-NEXT: 255
+
+    // conversions from int16_t
+    storeValue(int16_t(-32768));
+    storeValue(int16_t(-4242));
+    storeValue(int16_t(-128));
+    storeValue(int16_t(-1));
+    storeValue(int16_t(0));
+    storeValue(int16_t(1));
+    storeValue(int16_t(67));
+    storeValue(int16_t(127));
+    storeValue(int16_t(6767));
+    storeValue(int16_t(32767));
+    // CHECK-NEXT: 18446744073709518848
+    // CHECK-NEXT: 18446744073709547374
+    // CHECK-NEXT: 18446744073709551488
+    // CHECK-NEXT: 18446744073709551615
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 6767
+    // CHECK-NEXT: 32767
+
+    // conversions from uint16_t
+    storeValue(uint16_t(0));
+    storeValue(uint16_t(42));
+    storeValue(uint16_t(128));
+    storeValue(uint16_t(255));
+    storeValue(uint16_t(4242));
+    storeValue(uint16_t(6767));
+    storeValue(uint16_t(65535));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 128
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 4242
+    // CHECK-NEXT: 6767
+    // CHECK-NEXT: 65535
+
+    // conversions from int32_t
+    storeValue(0x00000000);
+    storeValue(0x0000007F);
+    storeValue(0x000000FF);
+    storeValue(0x40414243);
+    storeValue(int32_t(0xFEFDFCFB));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 1078018627
+    // CHECK-NEXT: 18446744073692642555
+
+    // conversions from uint32_t
+    storeValue(0x00000000U);
+    storeValue(0x0000007FU);
+    storeValue(0x000000FFU);
+    storeValue(0x40414243U);
+    storeValue(0xFEFDFCFBU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 1078018627
+    // CHECK-NEXT: 4278058235
+
+    // conversions from int64_t
+    storeValue(0x0000000000000000LL);
+    storeValue(0x000000000000007FLL);
+    storeValue(0x00000000000000FFLL);
+    storeValue(0x1112131440414243LL);
+    storeValue(int64_t(0xF1F2F3F4FEFDFCFBLL));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 1230066625923859011
+    // CHECK-NEXT: 17434265341080239355
+
+    // conversions from uint64_t
+    storeValue(0x0000000000000000LLU);
+    storeValue(0x000000000000007FLLU);
+    storeValue(0x00000000000000FFLLU);
+    storeValue(0x1112131440414243LLU);
+    storeValue(0xF1F2F3F4FEFDFCFBLLU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 1230066625923859011
+    // CHECK-NEXT: 17434265341080239355
+
+    // conversions from half float
+    storeValue(-0.9hf);
+    storeValue(0.9hf);
+    storeValue(126.9hf);
+    storeValue(127.0hf);
+    storeValue(255.9hf);
+    storeValue(65504.0hf); // max half float
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 126
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 65504
+
+    // conversions from float
+    storeValue(-0.9f);
+    storeValue(0.9f);
+    storeValue(126.9f);
+    storeValue(65534.0f);
+    storeValue(65535.0f);
+    storeValue(18446742974197923840.0f); // largest uint64_t value representable by float
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 126
+    // CHECK-NEXT: 65534
+    // CHECK-NEXT: 65535
+    // CHECK-NEXT: 18446742974197923840
+
+    // conversions from double
+    storeValue(0.0LF);
+    storeValue(0.9LF);
+    storeValue(126.9LF);
+    storeValue(65534.0LF);
+    storeValue(4294967295.0LF);
+    storeValue(18446744073709549568.0LF); // largest uint64_t value representable by double
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 126
+    // CHECK-NEXT: 65534
+    // CHECK-NEXT: 4294967295
+    // CHECK-NEXT: 18446744073709549568
+}

--- a/tests/language-feature/conversions/conversion-to-uint64.slang
+++ b/tests/language-feature/conversions/conversion-to-uint64.slang
@@ -1,11 +1,19 @@
 //DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 // See https://github.com/shader-slang/slang/issues/11996
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type -xslang -DNO_INT8=1
+// Notes:
+// - HLSL does not have 8-bit integer types
+// - HLSL has 16-bit integers when enabled (Slang does it automatically for the default profile)
+
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1
+// Note: Metal does not have the double type
+
+// Note: WGSL does not have 64-bit integer types, so wgsl is not tested here
 
 // Conversions to 64-bit unsigned integer from all fundamental scalar types
 
@@ -15,8 +23,12 @@ RWStructuredBuffer<uint64_t> outputBuffer;
 static uint i = 0;
 
 [noinline] void storeValue(bool     v) { outputBuffer[i++] = (uint64_t)v; }
+
+#ifndef NO_INT8
 [noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (uint64_t)v; }
 [noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (uint64_t)v; }
+#endif
+
 [noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (uint64_t)v; }
 [noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (uint64_t)v; }
 [noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (uint64_t)v; }
@@ -25,7 +37,10 @@ static uint i = 0;
 [noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (uint64_t)v; }
 [noinline] void storeValue(half     v) { outputBuffer[i++] = (uint64_t)v; }
 [noinline] void storeValue(float    v) { outputBuffer[i++] = (uint64_t)v; }
+
+#ifndef NO_DOUBLE
 [noinline] void storeValue(double   v) { outputBuffer[i++] = (uint64_t)v; }
+#endif
 
 
 [numthreads(1, 1, 1)]
@@ -38,20 +53,34 @@ void computeMain()
     // CHECK-NEXT: 1
 
     // conversions from int8_t
+#ifndef NO_INT8
     storeValue(int8_t(-128));
     storeValue(int8_t(-42));
     storeValue(int8_t(67));
     storeValue(int8_t(127));
+#else
+    storeValue(uint64_t(18446744073709551488));
+    storeValue(uint64_t(18446744073709551574));
+    storeValue(uint64_t(67));
+    storeValue(uint64_t(127));
+#endif
     // CHECK-NEXT: 18446744073709551488
     // CHECK-NEXT: 18446744073709551574
     // CHECK-NEXT: 67
     // CHECK-NEXT: 127
 
     // conversions from uint8_t
+#ifndef NO_INT8
     storeValue(uint8_t(0));
     storeValue(uint8_t(42));
     storeValue(uint8_t(128));
     storeValue(uint8_t(255));
+#else
+    storeValue(uint64_t(0));
+    storeValue(uint64_t(42));
+    storeValue(uint64_t(128));
+    storeValue(uint64_t(255));
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 42
     // CHECK-NEXT: 128
@@ -172,12 +201,21 @@ void computeMain()
     // CHECK-NEXT: 18446742974197923840
 
     // conversions from double
+#ifndef NO_DOUBLE
     storeValue(0.0LF);
     storeValue(0.9LF);
     storeValue(126.9LF);
     storeValue(65534.0LF);
     storeValue(4294967295.0LF);
     storeValue(18446744073709549568.0LF); // largest uint64_t value representable by double
+#else
+    storeValue(uint64_t(0));
+    storeValue(uint64_t(0));
+    storeValue(uint64_t(126));
+    storeValue(uint64_t(65534));
+    storeValue(uint64_t(4294967295));
+    storeValue(uint64_t(18446744073709549568));
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 0
     // CHECK-NEXT: 126

--- a/tests/language-feature/conversions/conversion-to-uint64.slang
+++ b/tests/language-feature/conversions/conversion-to-uint64.slang
@@ -59,10 +59,10 @@ void computeMain()
     storeValue(int8_t(67));
     storeValue(int8_t(127));
 #else
-    storeValue(uint64_t(18446744073709551488));
-    storeValue(uint64_t(18446744073709551574));
-    storeValue(uint64_t(67));
-    storeValue(uint64_t(127));
+    storeValue(uint64_t(18446744073709551488U));
+    storeValue(uint64_t(18446744073709551574U));
+    storeValue(uint64_t(67U));
+    storeValue(uint64_t(127U));
 #endif
     // CHECK-NEXT: 18446744073709551488
     // CHECK-NEXT: 18446744073709551574
@@ -76,10 +76,10 @@ void computeMain()
     storeValue(uint8_t(128));
     storeValue(uint8_t(255));
 #else
-    storeValue(uint64_t(0));
-    storeValue(uint64_t(42));
-    storeValue(uint64_t(128));
-    storeValue(uint64_t(255));
+    storeValue(uint64_t(0U));
+    storeValue(uint64_t(42U));
+    storeValue(uint64_t(128U));
+    storeValue(uint64_t(255U));
 #endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 42
@@ -209,12 +209,12 @@ void computeMain()
     storeValue(4294967295.0LF);
     storeValue(18446744073709549568.0LF); // largest uint64_t value representable by double
 #else
-    storeValue(uint64_t(0));
-    storeValue(uint64_t(0));
-    storeValue(uint64_t(126));
-    storeValue(uint64_t(65534));
-    storeValue(uint64_t(4294967295));
-    storeValue(uint64_t(18446744073709549568));
+    storeValue(uint64_t(0U));
+    storeValue(uint64_t(0U));
+    storeValue(uint64_t(126U));
+    storeValue(uint64_t(65534U));
+    storeValue(uint64_t(4294967295U));
+    storeValue(uint64_t(18446744073709549568U));
 #endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 0

--- a/tests/language-feature/conversions/conversion-to-uint8.slang
+++ b/tests/language-feature/conversions/conversion-to-uint8.slang
@@ -1,0 +1,187 @@
+//DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+// See https://github.com/shader-slang/slang/issues/11996
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+// Conversions to 8-bit unsigned integer from all fundamental scalar types
+
+//TEST_INPUT:ubuffer(data=[0], count=65, stride=1):out,name=outputBuffer
+RWStructuredBuffer<uint8_t> outputBuffer;
+
+static uint i = 0;
+
+[noinline] void storeValue(bool     v) { outputBuffer[i++] = (uint8_t)v; }
+[noinline] void storeValue(int8_t   v) { outputBuffer[i++] = (uint8_t)v; }
+[noinline] void storeValue(uint8_t  v) { outputBuffer[i++] = (uint8_t)v; }
+[noinline] void storeValue(int16_t  v) { outputBuffer[i++] = (uint8_t)v; }
+[noinline] void storeValue(uint16_t v) { outputBuffer[i++] = (uint8_t)v; }
+[noinline] void storeValue(int32_t  v) { outputBuffer[i++] = (uint8_t)v; }
+[noinline] void storeValue(uint32_t v) { outputBuffer[i++] = (uint8_t)v; }
+[noinline] void storeValue(int64_t  v) { outputBuffer[i++] = (uint8_t)v; }
+[noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (uint8_t)v; }
+[noinline] void storeValue(half     v) { outputBuffer[i++] = (uint8_t)v; }
+[noinline] void storeValue(float    v) { outputBuffer[i++] = (uint8_t)v; }
+[noinline] void storeValue(double   v) { outputBuffer[i++] = (uint8_t)v; }
+
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // conversions from bool
+    storeValue(false);
+    storeValue(true);
+    // CHECK: 0
+    // CHECK-NEXT: 1
+
+    // conversions from int8_t
+    storeValue(int8_t(-128));
+    storeValue(int8_t(-42));
+    storeValue(int8_t(67));
+    storeValue(int8_t(127));
+    // CHECK-NEXT: 128
+    // CHECK-NEXT: 214
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 127
+
+    // conversions from uint8_t
+    storeValue(uint8_t(0));
+    storeValue(uint8_t(42));
+    storeValue(uint8_t(128));
+    storeValue(uint8_t(255));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 128
+    // CHECK-NEXT: 255
+
+    // conversions from int16_t
+    storeValue(int16_t(-32768));
+    storeValue(int16_t(-4242));
+    storeValue(int16_t(-128));
+    storeValue(int16_t(-1));
+    storeValue(int16_t(0));
+    storeValue(int16_t(1));
+    storeValue(int16_t(67));
+    storeValue(int16_t(127));
+    storeValue(int16_t(6767));
+    storeValue(int16_t(32767));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 110
+    // CHECK-NEXT: 128
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 1
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 111
+    // CHECK-NEXT: 255
+
+    // conversions from uint16_t
+    storeValue(uint16_t(0));
+    storeValue(uint16_t(42));
+    storeValue(uint16_t(128));
+    storeValue(uint16_t(255));
+    storeValue(uint16_t(4242));
+    storeValue(uint16_t(6767));
+    storeValue(uint16_t(65535));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 42
+    // CHECK-NEXT: 128
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 146
+    // CHECK-NEXT: 111
+    // CHECK-NEXT: 255
+
+    // conversions from int32_t
+    storeValue(0x00000000);
+    storeValue(0x0000007F);
+    storeValue(0x000000FF);
+    storeValue(0x40414243);
+    storeValue(int32_t(0xFEFDFCFB));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 251
+
+    // conversions from uint32_t
+    storeValue(0x00000000U);
+    storeValue(0x0000007FU);
+    storeValue(0x000000FFU);
+    storeValue(0x40414243U);
+    storeValue(0xFEFDFCFBU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 251
+
+    // conversions from int64_t
+    storeValue(0x0000000000000000LL);
+    storeValue(0x000000000000007FLL);
+    storeValue(0x00000000000000FFLL);
+    storeValue(0x1112131440414243LL);
+    storeValue(int64_t(0xF1F2F3F4FEFDFCFBLL));
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 251
+
+    // conversions from uint64_t
+    storeValue(0x0000000000000000LLU);
+    storeValue(0x000000000000007FLLU);
+    storeValue(0x00000000000000FFLLU);
+    storeValue(0x1112131440414243LLU);
+    storeValue(0xF1F2F3F4FEFDFCFBLLU);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 67
+    // CHECK-NEXT: 251
+
+    // conversions from half float
+    storeValue(0.0hf);
+    storeValue(0.9hf);
+    storeValue(126.9hf);
+    storeValue(127.0hf);
+    storeValue(255.0hf);
+    storeValue(255.9hf);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 126
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 255
+
+    // conversions from float
+    storeValue(0.0f);
+    storeValue(0.9f);
+    storeValue(126.9f);
+    storeValue(127.0f);
+    storeValue(255.0f);
+    storeValue(255.9f);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 126
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 255
+
+    // conversions from double
+    storeValue(0.0LF);
+    storeValue(0.9LF);
+    storeValue(126.9LF);
+    storeValue(127.0LF);
+    storeValue(255.0LF);
+    storeValue(255.9LF);
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 0
+    // CHECK-NEXT: 126
+    // CHECK-NEXT: 127
+    // CHECK-NEXT: 255
+    // CHECK-NEXT: 255
+}

--- a/tests/language-feature/conversions/conversion-to-uint8.slang
+++ b/tests/language-feature/conversions/conversion-to-uint8.slang
@@ -1,11 +1,16 @@
 //DISABLE_TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 // See https://github.com/shader-slang/slang/issues/11996
 
-//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-dx12 -compute -shaderobj -output-using-type
+// Note: HLSL does not have 8-bit integer types, so dx12 is not tested here
+
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-via-glsl
 //TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute -output-using-type -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -compute -output-using-type
-//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-metal -compute -output-using-type -xslang -DNO_DOUBLE=1
+// Note: Metal does not have the double type
+
+// Note: WGSL does not have 8-bit integer types, so wgsl is not tested here
 
 // Conversions to 8-bit unsigned integer from all fundamental scalar types
 
@@ -25,7 +30,10 @@ static uint i = 0;
 [noinline] void storeValue(uint64_t v) { outputBuffer[i++] = (uint8_t)v; }
 [noinline] void storeValue(half     v) { outputBuffer[i++] = (uint8_t)v; }
 [noinline] void storeValue(float    v) { outputBuffer[i++] = (uint8_t)v; }
+
+#ifndef NO_DOUBLE
 [noinline] void storeValue(double   v) { outputBuffer[i++] = (uint8_t)v; }
+#endif
 
 
 [numthreads(1, 1, 1)]
@@ -172,12 +180,21 @@ void computeMain()
     // CHECK-NEXT: 255
 
     // conversions from double
+#ifndef NO_DOUBLE
     storeValue(0.0LF);
     storeValue(0.9LF);
     storeValue(126.9LF);
     storeValue(127.0LF);
     storeValue(255.0LF);
     storeValue(255.9LF);
+#else
+    storeValue(uint8_t(0));
+    storeValue(uint8_t(0));
+    storeValue(uint8_t(126));
+    storeValue(uint8_t(127));
+    storeValue(uint8_t(255));
+    storeValue(uint8_t(255));
+#endif
     // CHECK-NEXT: 0
     // CHECK-NEXT: 0
     // CHECK-NEXT: 126


### PR DESCRIPTION
Explicit conversion tests between the following fundamental scalar types are added:

- Boolean (bool)
- Integer types: uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t
- Floating-point types: half, float, double

These tests essentially form a matrix, testing the well-defined type conversions between all of the above types.

The following backends are added in the tests:
- cpu (but disabled for now due to issue #11996)
- hlsl (8-bit types disabled, HLSL does not have them)
- vk: direct to spirv (double->bool test disabled, issue #12019)
- vk: spirv via glsl
- metal (double disabled, MSL does not have it)
- cuda
- wgsl (only 32-bit integers and 16/32-bit floats are supported)
