### PR TITLE
reflection-json -  emit uniformSize/uniformStride on struct type layouts

### DIFF
--- a/source/slang/slang-reflection-json.cpp
+++ b/source/slang/slang-reflection-json.cpp
@@ -913,6 +913,23 @@ static void emitReflectionTypeLayoutInfoJSON(
                 writer.maybeComma();
                 emitReflectionNameInfoJSON(writer, name);
             }
+
+            // Emit both keys iff the struct has a nonzero uniform footprint; unlike Array,
+            // size is emitted too since trailing padding makes it underivable from stride.
+            if (structTypeLayout->getSize(SLANG_PARAMETER_CATEGORY_UNIFORM) != 0)
+            {
+                writer.maybeComma();
+                writer << "\"uniformSize\": ";
+                emitReflectionSize(
+                    writer,
+                    structTypeLayout->getSize(SLANG_PARAMETER_CATEGORY_UNIFORM));
+                writer.maybeComma();
+                writer << "\"uniformStride\": ";
+                emitReflectionSize(
+                    writer,
+                    structTypeLayout->getStride(SLANG_PARAMETER_CATEGORY_UNIFORM));
+            }
+
             writer.maybeComma();
             writer << "\"fields\": [\n";
             writer.indent();

--- a/tests/bindings/hlsl-to-vulkan-array.hlsl.expected
+++ b/tests/bindings/hlsl-to-vulkan-array.hlsl.expected
@@ -17,6 +17,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "Data",
+                    "uniformSize": 16,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "tex",

--- a/tests/bindings/hlsl-to-vulkan-shift-implicit.hlsl.expected
+++ b/tests/bindings/hlsl-to-vulkan-shift-implicit.hlsl.expected
@@ -35,6 +35,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "Data",
+                    "uniformSize": 16,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "a",
@@ -61,6 +63,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "Data",
+                        "uniformSize": 16,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "a",
@@ -110,6 +114,8 @@ standard output = {
                 "resultType": {
                     "kind": "struct",
                     "name": "Data",
+                    "uniformSize": 8,
+                    "uniformStride": 8,
                     "fields": [
                         {
                             "name": "a",

--- a/tests/bindings/hlsl-to-vulkan-shift.hlsl.expected
+++ b/tests/bindings/hlsl-to-vulkan-shift.hlsl.expected
@@ -35,6 +35,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "Data",
+                    "uniformSize": 16,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "a",
@@ -61,6 +63,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "Data",
+                        "uniformSize": 16,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "a",
@@ -110,6 +114,8 @@ standard output = {
                 "resultType": {
                     "kind": "struct",
                     "name": "Data",
+                    "uniformSize": 8,
+                    "uniformStride": 8,
                     "fields": [
                         {
                             "name": "a",

--- a/tests/cross-compile/cpp-resource-reflection.slang.32.expected
+++ b/tests/cross-compile/cpp-resource-reflection.slang.32.expected
@@ -12,6 +12,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "Thing",
+                    "uniformSize": 12,
+                    "uniformStride": 12,
                     "fields": [
                         {
                             "name": "a",
@@ -46,6 +48,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "Thing",
+                        "uniformSize": 12,
+                        "uniformStride": 12,
                         "fields": [
                             {
                                 "name": "a",
@@ -129,6 +133,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "Thing",
+                        "uniformSize": 12,
+                        "uniformStride": 12,
                         "fields": [
                             {
                                 "name": "a",
@@ -163,6 +169,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "Thing",
+                        "uniformSize": 12,
+                        "uniformStride": 12,
                         "fields": [
                             {
                                 "name": "a",

--- a/tests/cross-compile/cpp-resource-reflection.slang.64.expected
+++ b/tests/cross-compile/cpp-resource-reflection.slang.64.expected
@@ -12,6 +12,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "Thing",
+                    "uniformSize": 12,
+                    "uniformStride": 12,
                     "fields": [
                         {
                             "name": "a",
@@ -46,6 +48,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "Thing",
+                        "uniformSize": 12,
+                        "uniformStride": 12,
                         "fields": [
                             {
                                 "name": "a",
@@ -133,6 +137,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "Thing",
+                        "uniformSize": 12,
+                        "uniformStride": 12,
                         "fields": [
                             {
                                 "name": "a",
@@ -167,6 +173,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "Thing",
+                        "uniformSize": 12,
+                        "uniformStride": 12,
                         "fields": [
                             {
                                 "name": "a",

--- a/tests/cuda/cuda-reflection.slang.expected
+++ b/tests/cuda/cuda-reflection.slang.expected
@@ -12,6 +12,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "StructWithArray",
+                    "uniformSize": 48,
+                    "uniformStride": 48,
                     "fields": [
                         {
                             "name": "a",
@@ -21,6 +23,8 @@ standard output = {
                                 "elementType": {
                                     "kind": "struct",
                                     "name": "PadLadenStruct",
+                                    "uniformSize": 16,
+                                    "uniformStride": 16,
                                     "fields": [
                                         {
                                             "name": "a",
@@ -82,6 +86,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "StructWithArray",
+                        "uniformSize": 48,
+                        "uniformStride": 48,
                         "fields": [
                             {
                                 "name": "a",
@@ -91,6 +97,8 @@ standard output = {
                                     "elementType": {
                                         "kind": "struct",
                                         "name": "PadLadenStruct",
+                                        "uniformSize": 16,
+                                        "uniformStride": 16,
                                         "fields": [
                                             {
                                                 "name": "a",
@@ -159,6 +167,8 @@ standard output = {
                 "resultType": {
                     "kind": "struct",
                     "name": "StructWithArray",
+                    "uniformSize": 48,
+                    "uniformStride": 48,
                     "fields": [
                         {
                             "name": "a",
@@ -168,6 +178,8 @@ standard output = {
                                 "elementType": {
                                     "kind": "struct",
                                     "name": "PadLadenStruct",
+                                    "uniformSize": 16,
+                                    "uniformStride": 16,
                                     "fields": [
                                         {
                                             "name": "a",

--- a/tests/reflection/arrays.hlsl.expected
+++ b/tests/reflection/arrays.hlsl.expected
@@ -11,6 +11,8 @@ standard output = {
                 "kind": "constantBuffer",
                 "elementType": {
                     "kind": "struct",
+                    "uniformSize": 168,
+                    "uniformStride": 176,
                     "fields": [
                         {
                             "name": "x",
@@ -49,6 +51,8 @@ standard output = {
                 "elementVarLayout": {
                     "type": {
                         "kind": "struct",
+                        "uniformSize": 168,
+                        "uniformStride": 176,
                         "fields": [
                             {
                                 "name": "x",

--- a/tests/reflection/attribute.slang.expected
+++ b/tests/reflection/attribute.slang.expected
@@ -12,6 +12,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "A",
+                    "uniformSize": 8,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "x",
@@ -56,6 +58,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "A",
+                        "uniformSize": 8,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "x",
@@ -105,6 +109,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "B",
+                    "uniformSize": 8,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "x",
@@ -149,6 +155,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "B",
+                        "uniformSize": 8,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "x",
@@ -212,6 +220,8 @@ standard output = {
             "type": {
                 "kind": "struct",
                 "name": "D",
+                "uniformSize": 4,
+                "uniformStride": 16,
                 "fields": [
                     {
                         "name": "a",

--- a/tests/reflection/binding-gl.hlsl.expected
+++ b/tests/reflection/binding-gl.hlsl.expected
@@ -11,6 +11,8 @@ standard output = {
                 "kind": "constantBuffer",
                 "elementType": {
                     "kind": "struct",
+                    "uniformSize": 192,
+                    "uniformStride": 192,
                     "fields": [
                         {
                             "name": "x",
@@ -49,6 +51,8 @@ standard output = {
                 "elementVarLayout": {
                     "type": {
                         "kind": "struct",
+                        "uniformSize": 192,
+                        "uniformStride": 192,
                         "fields": [
                             {
                                 "name": "x",

--- a/tests/reflection/binding-push-constant-gl.hlsl.expected
+++ b/tests/reflection/binding-push-constant-gl.hlsl.expected
@@ -11,6 +11,8 @@ standard output = {
                 "kind": "constantBuffer",
                 "elementType": {
                     "kind": "struct",
+                    "uniformSize": 192,
+                    "uniformStride": 192,
                     "fields": [
                         {
                             "name": "x",
@@ -49,6 +51,8 @@ standard output = {
                 "elementVarLayout": {
                     "type": {
                         "kind": "struct",
+                        "uniformSize": 192,
+                        "uniformStride": 192,
                         "fields": [
                             {
                                 "name": "x",
@@ -93,6 +97,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "MyPushConstantStruct",
+                    "uniformSize": 8,
+                    "uniformStride": 8,
                     "fields": [
                         {
                             "name": "pushX",
@@ -119,6 +125,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "MyPushConstantStruct",
+                        "uniformSize": 8,
+                        "uniformStride": 8,
                         "fields": [
                             {
                                 "name": "pushX",

--- a/tests/reflection/buffer-layout.slang.1.expected
+++ b/tests/reflection/buffer-layout.slang.1.expected
@@ -12,6 +12,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "S",
+                    "uniformSize": 96,
+                    "uniformStride": 96,
                     "fields": [
                         {
                             "name": "z",
@@ -26,6 +28,8 @@ standard output = {
                             "type": {
                                 "kind": "struct",
                                 "name": "A",
+                                "uniformSize": 16,
+                                "uniformStride": 16,
                                 "fields": [
                                     {
                                         "name": "x",
@@ -89,6 +93,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "S",
+                        "uniformSize": 96,
+                        "uniformStride": 96,
                         "fields": [
                             {
                                 "name": "z",
@@ -103,6 +109,8 @@ standard output = {
                                 "type": {
                                     "kind": "struct",
                                     "name": "A",
+                                    "uniformSize": 16,
+                                    "uniformStride": 16,
                                     "fields": [
                                         {
                                             "name": "x",
@@ -173,6 +181,8 @@ standard output = {
                 "resultType": {
                     "kind": "struct",
                     "name": "S",
+                    "uniformSize": 40,
+                    "uniformStride": 40,
                     "fields": [
                         {
                             "name": "z",
@@ -187,6 +197,8 @@ standard output = {
                             "type": {
                                 "kind": "struct",
                                 "name": "A",
+                                "uniformSize": 8,
+                                "uniformStride": 8,
                                 "fields": [
                                     {
                                         "name": "x",

--- a/tests/reflection/buffer-layout.slang.expected
+++ b/tests/reflection/buffer-layout.slang.expected
@@ -12,6 +12,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "S",
+                    "uniformSize": 60,
+                    "uniformStride": 64,
                     "fields": [
                         {
                             "name": "z",
@@ -26,6 +28,8 @@ standard output = {
                             "type": {
                                 "kind": "struct",
                                 "name": "A",
+                                "uniformSize": 8,
+                                "uniformStride": 16,
                                 "fields": [
                                     {
                                         "name": "x",
@@ -89,6 +93,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "S",
+                        "uniformSize": 60,
+                        "uniformStride": 64,
                         "fields": [
                             {
                                 "name": "z",
@@ -103,6 +109,8 @@ standard output = {
                                 "type": {
                                     "kind": "struct",
                                     "name": "A",
+                                    "uniformSize": 8,
+                                    "uniformStride": 16,
                                     "fields": [
                                         {
                                             "name": "x",
@@ -173,6 +181,8 @@ standard output = {
                 "resultType": {
                     "kind": "struct",
                     "name": "S",
+                    "uniformSize": 36,
+                    "uniformStride": 36,
                     "fields": [
                         {
                             "name": "z",
@@ -187,6 +197,8 @@ standard output = {
                             "type": {
                                 "kind": "struct",
                                 "name": "A",
+                                "uniformSize": 8,
+                                "uniformStride": 8,
                                 "fields": [
                                     {
                                         "name": "x",

--- a/tests/reflection/cross-compile.slang.expected
+++ b/tests/reflection/cross-compile.slang.expected
@@ -34,6 +34,8 @@ standard output = {
                 "kind": "constantBuffer",
                 "elementType": {
                     "kind": "struct",
+                    "uniformSize": 16,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "c",
@@ -55,6 +57,8 @@ standard output = {
                 "elementVarLayout": {
                     "type": {
                         "kind": "struct",
+                        "uniformSize": 16,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "c",

--- a/tests/reflection/global-type-params.slang.expected
+++ b/tests/reflection/global-type-params.slang.expected
@@ -96,6 +96,8 @@ standard output = {
                 "kind": "constantBuffer",
                 "elementType": {
                     "kind": "struct",
+                    "uniformSize": 48,
+                    "uniformStride": 48,
                     "fields": [
                         {
                             "name": "u",
@@ -141,6 +143,8 @@ standard output = {
                 "elementVarLayout": {
                     "type": {
                         "kind": "struct",
+                        "uniformSize": 48,
+                        "uniformStride": 48,
                         "fields": [
                             {
                                 "name": "u",

--- a/tests/reflection/matrix-layout.slang.1.expected
+++ b/tests/reflection/matrix-layout.slang.1.expected
@@ -11,6 +11,8 @@ standard output = {
                 "kind": "constantBuffer",
                 "elementType": {
                     "kind": "struct",
+                    "uniformSize": 156,
+                    "uniformStride": 160,
                     "fields": [
                         {
                             "name": "aa",
@@ -59,6 +61,8 @@ standard output = {
                 "elementVarLayout": {
                     "type": {
                         "kind": "struct",
+                        "uniformSize": 156,
+                        "uniformStride": 160,
                         "fields": [
                             {
                                 "name": "aa",
@@ -112,12 +116,16 @@ standard output = {
                 "kind": "constantBuffer",
                 "elementType": {
                     "kind": "struct",
+                    "uniformSize": 156,
+                    "uniformStride": 160,
                     "fields": [
                         {
                             "name": "b",
                             "type": {
                                 "kind": "struct",
                                 "name": "SB",
+                                "uniformSize": 156,
+                                "uniformStride": 160,
                                 "fields": [
                                     {
                                         "name": "ba",
@@ -170,12 +178,16 @@ standard output = {
                 "elementVarLayout": {
                     "type": {
                         "kind": "struct",
+                        "uniformSize": 156,
+                        "uniformStride": 160,
                         "fields": [
                             {
                                 "name": "b",
                                 "type": {
                                     "kind": "struct",
                                     "name": "SB",
+                                    "uniformSize": 156,
+                                    "uniformStride": 160,
                                     "fields": [
                                         {
                                             "name": "ba",

--- a/tests/reflection/matrix-layout.slang.expected
+++ b/tests/reflection/matrix-layout.slang.expected
@@ -11,6 +11,8 @@ standard output = {
                 "kind": "constantBuffer",
                 "elementType": {
                     "kind": "struct",
+                    "uniformSize": 172,
+                    "uniformStride": 176,
                     "fields": [
                         {
                             "name": "aa",
@@ -59,6 +61,8 @@ standard output = {
                 "elementVarLayout": {
                     "type": {
                         "kind": "struct",
+                        "uniformSize": 172,
+                        "uniformStride": 176,
                         "fields": [
                             {
                                 "name": "aa",
@@ -112,12 +116,16 @@ standard output = {
                 "kind": "constantBuffer",
                 "elementType": {
                     "kind": "struct",
+                    "uniformSize": 172,
+                    "uniformStride": 176,
                     "fields": [
                         {
                             "name": "b",
                             "type": {
                                 "kind": "struct",
                                 "name": "SB",
+                                "uniformSize": 172,
+                                "uniformStride": 176,
                                 "fields": [
                                     {
                                         "name": "ba",
@@ -170,12 +178,16 @@ standard output = {
                 "elementVarLayout": {
                     "type": {
                         "kind": "struct",
+                        "uniformSize": 172,
+                        "uniformStride": 176,
                         "fields": [
                             {
                                 "name": "b",
                                 "type": {
                                     "kind": "struct",
                                     "name": "SB",
+                                    "uniformSize": 172,
+                                    "uniformStride": 176,
                                     "fields": [
                                         {
                                             "name": "ba",

--- a/tests/reflection/mix-explicit-and-implicit-spaces.slang.expected
+++ b/tests/reflection/mix-explicit-and-implicit-spaces.slang.expected
@@ -12,6 +12,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "A",
+                    "uniformSize": 4,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "x",
@@ -33,6 +35,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "A",
+                        "uniformSize": 4,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "x",
@@ -56,6 +60,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "B",
+                    "uniformSize": 4,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "y",
@@ -77,6 +83,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "B",
+                        "uniformSize": 4,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "y",
@@ -100,6 +108,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "C",
+                    "uniformSize": 4,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "z",
@@ -121,6 +131,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "C",
+                        "uniformSize": 4,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "z",

--- a/tests/reflection/multi-file.hlsl.expected
+++ b/tests/reflection/multi-file.hlsl.expected
@@ -34,6 +34,8 @@ standard output = {
                 "kind": "constantBuffer",
                 "elementType": {
                     "kind": "struct",
+                    "uniformSize": 40,
+                    "uniformStride": 48,
                     "fields": [
                         {
                             "name": "vertexCA",
@@ -87,6 +89,8 @@ standard output = {
                 "elementVarLayout": {
                     "type": {
                         "kind": "struct",
+                        "uniformSize": 40,
+                        "uniformStride": 48,
                         "fields": [
                             {
                                 "name": "vertexCA",
@@ -168,6 +172,8 @@ standard output = {
                 "kind": "constantBuffer",
                 "elementType": {
                     "kind": "struct",
+                    "uniformSize": 40,
+                    "uniformStride": 48,
                     "fields": [
                         {
                             "name": "fragmentCA",
@@ -221,6 +227,8 @@ standard output = {
                 "elementVarLayout": {
                     "type": {
                         "kind": "struct",
+                        "uniformSize": 40,
+                        "uniformStride": 48,
                         "fields": [
                             {
                                 "name": "fragmentCA",
@@ -302,6 +310,8 @@ standard output = {
                 "kind": "constantBuffer",
                 "elementType": {
                     "kind": "struct",
+                    "uniformSize": 40,
+                    "uniformStride": 48,
                     "fields": [
                         {
                             "name": "sharedCA",
@@ -355,6 +365,8 @@ standard output = {
                 "elementVarLayout": {
                     "type": {
                         "kind": "struct",
+                        "uniformSize": 40,
+                        "uniformStride": 48,
                         "fields": [
                             {
                                 "name": "sharedCA",

--- a/tests/reflection/parameter-block-explicit-space.slang.expected
+++ b/tests/reflection/parameter-block-explicit-space.slang.expected
@@ -12,6 +12,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "A",
+                    "uniformSize": 16,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "au",
@@ -76,6 +78,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "A",
+                        "uniformSize": 16,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "au",
@@ -146,6 +150,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "B",
+                    "uniformSize": 16,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "bu",
@@ -194,6 +200,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "B",
+                        "uniformSize": 16,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "bu",

--- a/tests/reflection/ptr/ptr-global.slang.expected
+++ b/tests/reflection/ptr/ptr-global.slang.expected
@@ -14,6 +14,8 @@ standard output = {
                 "resultType": {
                     "kind": "struct",
                     "name": "SomeStruct",
+                    "uniformSize": 24,
+                    "uniformStride": 24,
                     "fields": [
                         {
                             "name": "regularGlobal",

--- a/tests/reflection/ptr/ptr-self-reference.slang.expected
+++ b/tests/reflection/ptr/ptr-self-reference.slang.expected
@@ -14,6 +14,8 @@ standard output = {
                 "resultType": {
                     "kind": "struct",
                     "name": "SomeStruct",
+                    "uniformSize": 16,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "payload",

--- a/tests/reflection/ptr/ptr-struct.slang.expected
+++ b/tests/reflection/ptr/ptr-struct.slang.expected
@@ -14,6 +14,8 @@ standard output = {
                 "resultType": {
                     "kind": "struct",
                     "name": "SomeStruct",
+                    "uniformSize": 48,
+                    "uniformStride": 48,
                     "fields": [
                         {
                             "name": "ptrInt",
@@ -44,6 +46,8 @@ standard output = {
                             "type": {
                                 "kind": "struct",
                                 "name": "AnotherStruct",
+                                "uniformSize": 16,
+                                "uniformStride": 16,
                                 "fields": [
                                     {
                                         "name": "a",

--- a/tests/reflection/reflect-imported-code.hlsl.expected
+++ b/tests/reflection/reflect-imported-code.hlsl.expected
@@ -34,6 +34,8 @@ standard output = {
                 "kind": "constantBuffer",
                 "elementType": {
                     "kind": "struct",
+                    "uniformSize": 4,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "c",
@@ -51,6 +53,8 @@ standard output = {
                 "elementVarLayout": {
                     "type": {
                         "kind": "struct",
+                        "uniformSize": 4,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "c",
@@ -96,6 +100,8 @@ standard output = {
                 "kind": "constantBuffer",
                 "elementType": {
                     "kind": "struct",
+                    "uniformSize": 4,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "c_i",
@@ -113,6 +119,8 @@ standard output = {
                 "elementVarLayout": {
                     "type": {
                         "kind": "struct",
+                        "uniformSize": 4,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "c_i",

--- a/tests/reflection/reflect-static.slang.expected
+++ b/tests/reflection/reflect-static.slang.expected
@@ -37,6 +37,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "AnotherThing",
+                    "uniformSize": 8,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "a",
@@ -63,6 +65,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "AnotherThing",
+                        "uniformSize": 8,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "a",

--- a/tests/reflection/reflection0.hlsl.expected
+++ b/tests/reflection/reflection0.hlsl.expected
@@ -34,6 +34,8 @@ standard output = {
                 "kind": "constantBuffer",
                 "elementType": {
                     "kind": "struct",
+                    "uniformSize": 4,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "c",
@@ -51,6 +53,8 @@ standard output = {
                 "elementVarLayout": {
                     "type": {
                         "kind": "struct",
+                        "uniformSize": 4,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "c",

--- a/tests/reflection/resource-in-cbuffer.hlsl.expected
+++ b/tests/reflection/resource-in-cbuffer.hlsl.expected
@@ -15,6 +15,8 @@ standard output = {
                 "kind": "constantBuffer",
                 "elementType": {
                     "kind": "struct",
+                    "uniformSize": 16,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "v",
@@ -67,6 +69,8 @@ standard output = {
                 "elementVarLayout": {
                     "type": {
                         "kind": "struct",
+                        "uniformSize": 16,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "v",

--- a/tests/reflection/structured-buffer.slang.expected
+++ b/tests/reflection/structured-buffer.slang.expected
@@ -41,6 +41,8 @@ standard output = {
                 "resultType": {
                     "kind": "struct",
                     "name": "S",
+                    "uniformSize": 16,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "a",

--- a/tests/reflection/used-parameters.slang.expected
+++ b/tests/reflection/used-parameters.slang.expected
@@ -12,6 +12,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "S",
+                    "uniformSize": 8,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "Size",
@@ -34,6 +36,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "S",
+                        "uniformSize": 8,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "Size",
@@ -61,6 +65,8 @@ standard output = {
                 "elementType": {
                     "kind": "struct",
                     "name": "S",
+                    "uniformSize": 8,
+                    "uniformStride": 16,
                     "fields": [
                         {
                             "name": "Size",
@@ -83,6 +89,8 @@ standard output = {
                     "type": {
                         "kind": "struct",
                         "name": "S",
+                        "uniformSize": 8,
+                        "uniformStride": 16,
                         "fields": [
                             {
                                 "name": "Size",


### PR DESCRIPTION
JSON reflection output emits layout sizing inconsistently. **array** type layouts report their element stride, but **struct** type layouts report only their fields.

So a consumer that needs the size or stride of a struct (e.g.: the element of a
`StructuredBuffer<S>`, to compute where element *i* starts) cannot read it from the reflection.

### Current JSON

```json
"type": {
    "kind": "array",
    "elementCount": 10,
    "elementType": { "kind": "scalar", "scalarType": "float32" },
    "uniformStride": 16
}
```

But a struct type layout stops at its fields — its own extent is simply absent:

```json
"elementType": {
    "kind": "struct",
    "name": "S",
    "fields": [ ... ]
}
```

### Update in this PR:


```json
"elementType": {
    "kind": "struct",
    "name": "S",
    "uniformSize": 60,
    "uniformStride": 64,
    "fields": [ ... ]
}
```

