### PR TITLE
Mark vector subscript accessors differentiable

### DIFF
--- a/source/standard-modules/neural/accelerate-vector-coopmat.slang
+++ b/source/standard-modules/neural/accelerate-vector-coopmat.slang
@@ -93,9 +93,11 @@ public struct WaveTangledVector<T, ShMemSize : ISharedMemorySize, int N, int Sub
     public __subscript(int index) -> T
     {
         [ForceInline]
+        [Differentiable]
         get { return this.data[index]; }
 
         [ForceInline]
+        [Differentiable]
         set { this.data[index] = newValue; }
     }
 

--- a/source/standard-modules/neural/ivector.slang
+++ b/source/standard-modules/neural/ivector.slang
@@ -19,9 +19,14 @@ public interface IVector<T> : IDifferentiable, IArrayAccessor<T>
     /// The compile-time size of the vector.
     public static const int Size;
 
-    /// The differential type for automatic differentiation.
-    /// @remarks Ensures the differential is also a vector with the same structure.
-    public associatedtype Differential : IVector<T>;
+    /// Ensures the differential is also a vector with the same structure.
+    __constraint Differential : IVector<T>;
+
+    public __subscript(int index) -> T
+    {
+        [Differentiable] get;
+        [Differentiable] set;
+    }
 
     /// Default constructor - initializes vector to zero.
     public __init();

--- a/tests/neural/vector-autodiff-subscript.slang
+++ b/tests/neural/vector-autodiff-subscript.slang
@@ -1,0 +1,121 @@
+// Test automatic differentiation through the subscript getter and setter of both vector
+// implementations.
+//
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-vk -compute -shaderobj -xslang -experimental-feature -output-using-type -emit-spirv-directly
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=BUFFER):-cuda -compute -shaderobj -xslang -experimental-feature -output-using-type -capability cuda_sm_7_0
+
+import slang.neural;
+
+//TEST_INPUT: ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name=testResult
+RWStructuredBuffer<uint> testResult;
+
+static const int VectorSize = 3;
+static const int SubgroupSize = 32;
+
+typealias TestShMemSize = SharedMemorySize<
+    float,
+    TargetEnum.CUDA,
+    ExecutionMode.Training,
+    SubgroupSize,
+    1,
+    VectorSize,
+    VectorSize>;
+typealias InlineTestVector = InlineVector<float, VectorSize>;
+typealias WaveTangledTestVector =
+    WaveTangledVector<float, TestShMemSize, VectorSize, SubgroupSize, 1>;
+
+[Differentiable]
+float readElement<Vector>(Vector value)
+    where Vector : IVector<float>
+{
+    return value[1];
+}
+
+[Differentiable]
+Vector writeElement<Vector>(Vector value, float newValue)
+    where Vector : IVector<float>
+{
+    value[1] = newValue;
+    return value;
+}
+
+bool[4] testVectorAutodiffSubscript<Vector>(
+    DifferentialPair<Vector> value,
+    Vector.Differential zero,
+    Vector.Differential dOutput)
+    where Vector : IVector<float>
+{
+    bool results[4];
+
+    let getterForwardResult = fwd_diff(readElement<Vector>)(value);
+    results[0] = getterForwardResult.p == 2.0 && getterForwardResult.d == 3.0;
+
+    var getterBackwardValue = DifferentialPair<Vector>(value.p, zero);
+    bwd_diff(readElement<Vector>)(getterBackwardValue, 1.0);
+    let getterBackwardDiff = getterBackwardValue.d;
+    results[1] = getterBackwardDiff[0] == 0.0 &&
+                 getterBackwardDiff[1] == 1.0 &&
+                 getterBackwardDiff[2] == 0.0;
+
+    let setterForwardResult =
+        fwd_diff(writeElement<Vector>)(value, diffPair(4.0, 7.0));
+    let setterForwardDiff = setterForwardResult.d;
+    results[2] = setterForwardResult.p[0] == 1.0 &&
+                 setterForwardResult.p[1] == 4.0 &&
+                 setterForwardResult.p[2] == 3.0 &&
+                 setterForwardDiff[0] == 2.0 &&
+                 setterForwardDiff[1] == 7.0 &&
+                 setterForwardDiff[2] == 5.0;
+
+    var setterBackwardValue = DifferentialPair<Vector>(value.p, zero);
+    var newValue = diffPair(4.0);
+    bwd_diff(writeElement<Vector>)(setterBackwardValue, newValue, dOutput);
+    let setterBackwardDiff = setterBackwardValue.d;
+    results[3] = setterBackwardDiff[0] == 2.0 &&
+                 setterBackwardDiff[1] == 0.0 &&
+                 setterBackwardDiff[2] == 5.0 &&
+                 newValue.d == 3.0;
+
+    return results;
+}
+
+[shader("compute")]
+[numthreads(SubgroupSize, 1, 1)]
+void computeMain(uint tid : SV_DispatchThreadID)
+{
+    float[VectorSize] data = {1.0, 2.0, 3.0};
+    float[VectorSize] dData = {2.0, 3.0, 5.0};
+    float[VectorSize] dOutputData = {2.0, 3.0, 5.0};
+
+    let inlineResults = testVectorAutodiffSubscript<InlineTestVector>(
+        diffPair(InlineTestVector(data), InlineTestVector(dData)),
+        InlineTestVector(),
+        InlineTestVector(dOutputData));
+    let waveTangledResults =
+        testVectorAutodiffSubscript<WaveTangledTestVector>(
+            diffPair(WaveTangledTestVector(data), WaveTangledTestVector(dData)),
+            WaveTangledTestVector(),
+            WaveTangledTestVector(dOutputData));
+
+    bool results[8];
+    for (int i = 0; i < 4; i++)
+    {
+        results[i] = WaveActiveAllTrue(inlineResults[i]);
+        results[i + 4] = WaveActiveAllTrue(waveTangledResults[i]);
+    }
+
+    if (tid == 0)
+    {
+        for (int i = 0; i < 8; i++)
+            testResult[i] = results[i];
+    }
+
+    // BUFFER: 1
+    // BUFFER-NEXT: 1
+    // BUFFER-NEXT: 1
+    // BUFFER-NEXT: 1
+    // BUFFER-NEXT: 1
+    // BUFFER-NEXT: 1
+    // BUFFER-NEXT: 1
+    // BUFFER-NEXT: 1
+}


### PR DESCRIPTION
## Summary

- mark the `WaveTangledVector` subscript getter and setter `[Differentiable]`
- expose the differentiable subscript requirement through the public `IVector` contract
- refine the inherited `IDifferentiable.Differential` associated type instead of redeclaring it
- add one generic Slang regression test instantiated for both `InlineVector` and `WaveTangledVector`
- cover getter and setter differentiation in both forward and reverse mode on Vulkan and CUDA

Fixes #12025.

## Why the existing tests missed this

Existing cooperative-vector tests either perform primal subscript reads or differentiate higher-level layer and matrix operations with custom or trivial derivative implementations. They therefore never ask autodiff to synthesize a derivative for the `WaveTangledVector` subscript getter or setter itself.

The new test directly differentiates generic read and write helpers, preventing the two `IVector` implementations from drifting again.

## Testing

- Debug neural suite with 8 test servers: 243/243 passed, 59 ignored
- Release build with 8 jobs: succeeded
- Release neural suite with 8 test servers: 230/230 passed, 72 ignored