### PR TITLE
Allow arithmetic in lifted differentiable constraints

### DIFF
--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -3529,14 +3529,19 @@ bool SemanticsVisitor::TryUnifyVals(
         auto fstParam = getDeclRefIntValIgnoringCasts(fstInt);
         auto sndParam = getDeclRefIntValIgnoringCasts(sndInt);
 
-        bool okay = false;
         if (fstParam)
-            okay |=
-                TryUnifyIntParam(constraints, unificationOptions, fstParam->getDeclRef(), sndInt);
+            TryUnifyIntParam(constraints, unificationOptions, fstParam->getDeclRef(), sndInt);
         if (sndParam)
-            okay |=
-                TryUnifyIntParam(constraints, unificationOptions, sndParam->getDeclRef(), fstInt);
-        return okay;
+            TryUnifyIntParam(constraints, unificationOptions, sndParam->getDeclRef(), fstInt);
+
+        // Direct generic value parameters above can add inference facts such as `N = M + 1`.
+        // Other non-constant integer values are harder: this routine does not solve arithmetic
+        // equations or prove symbolic inequality. For example, `N + 1` and `M + 1` may become
+        // equal after substitution, while `N + 1` and `N + 2` cannot; both are outside what this
+        // inference pass can decide. Since distinct constants were already rejected above, leave
+        // unresolved non-constant pairs to the later checking/proof path instead of rejecting them
+        // here.
+        return true;
     }
 
     if (auto fstWit = as<DeclaredSubtypeWitness>(fst))
@@ -3547,6 +3552,7 @@ bool SemanticsVisitor::TryUnifyVals(
             auto constraintDecl2 = sndWit->getDeclRef().as<TypeConstraintDecl>();
             SLANG_ASSERT(constraintDecl1);
             SLANG_ASSERT(constraintDecl2);
+
             return TryUnifyTypes(
                 constraints,
                 unificationOptions,

--- a/tests/autodiff/generic-container-arithmetic-constraint.slang
+++ b/tests/autodiff/generic-container-arithmetic-constraint.slang
@@ -1,0 +1,140 @@
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
+
+// A differentiable method is registered through a synthesized extension that copies the generic
+// constraints of its enclosing type. The copied constraint uses fresh generic parameters, so
+// matching the extension must treat the two declared witnesses as inference hints and leave the
+// final proof to generic argument solving.
+
+interface IModel<T>
+{}
+
+struct Model : IModel<float[2]>
+{}
+
+interface IArrayModel<TInput, TOutput>
+{}
+
+struct ReportShapeModel : IArrayModel<float[5], float[15]>
+{}
+
+struct DefaultShapeModel : IModel<float[7]>
+{}
+
+struct MixedShapeModel : IModel<float[17]>
+{}
+
+interface IFunction
+{
+    [BackwardDifferentiable]
+    float forward(float input);
+}
+
+struct Wrapper<int N, T : IModel<float[1 + N]>> : IFunction
+{
+    [BackwardDifferentiable]
+    float forward(float input)
+    {
+        return input * float(1 + N);
+    }
+}
+
+// This matches the shape from the original report: the constraint contains multiple arithmetic
+// expressions and one of them depends on a value parameter with an arithmetic default.
+struct Sampler<
+    int LatentCount,
+    int LobeCount,
+    int SpecularCount = LobeCount - 1,
+    Network : IArrayModel<float[3 + LatentCount], float[3 + 6 * SpecularCount]>> : IFunction
+{
+    [BackwardDifferentiable]
+    float forward(float input)
+    {
+        return input * float((3 + LatentCount) + (3 + 6 * SpecularCount));
+    }
+}
+
+// Put the default last so the specialization below can omit it. This verifies that a dependent
+// subtraction default can flow into a lifted constraint that also contains multiplication.
+struct DefaultedWrapper<int Size, T, int TrimmedSize = Size - 1> : IFunction
+    where T : IModel<float[2 * TrimmedSize + 1]>
+{
+    [BackwardDifferentiable]
+    float forward(float input)
+    {
+        return input * float(2 * TrimmedSize + 1);
+    }
+}
+
+// Division and remainder use BuiltinOperationIntVal rather than PolynomialIntVal. Parentheses and
+// unary negation should also survive lifting and fold after specialization.
+struct MixedArithmeticWrapper<
+    int N,
+    T : IModel<float[10 + (-N) + ((N * 6) / 2) + (N % 2)]>> : IFunction
+{
+    [BackwardDifferentiable]
+    float forward(float input)
+    {
+        return input * float(10 + (-N) + ((N * 6) / 2) + (N % 2));
+    }
+}
+
+[BackwardDifferentiable]
+float evaluate(Wrapper<1, Model> wrapper, float input)
+{
+    return wrapper.forward(input);
+}
+
+[BackwardDifferentiable]
+float evaluateSampler(Sampler<2, 3, 2, ReportShapeModel> sampler, float input)
+{
+    return sampler.forward(input);
+}
+
+[BackwardDifferentiable]
+float evaluateDefaulted(DefaultedWrapper<4, DefaultShapeModel> wrapper, float input)
+{
+    return wrapper.forward(input);
+}
+
+[BackwardDifferentiable]
+float evaluateMixed(MixedArithmeticWrapper<3, MixedShapeModel> wrapper, float input)
+{
+    return wrapper.forward(input);
+}
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    Wrapper<1, Model> wrapper;
+    outputBuffer[0] = evaluate(wrapper, 3.0f); // CHECK: 6.0
+
+    var input = diffPair(3.0f);
+    bwd_diff(evaluate)(wrapper, input, 1.0f);
+    outputBuffer[1] = input.d; // CHECK: 2.0
+
+    Sampler<2, 3, 2, ReportShapeModel> sampler;
+    outputBuffer[2] = evaluateSampler(sampler, 2.0f); // CHECK: 40.0
+
+    var samplerInput = diffPair(2.0f);
+    bwd_diff(evaluateSampler)(sampler, samplerInput, 1.0f);
+    outputBuffer[3] = samplerInput.d; // CHECK: 20.0
+
+    DefaultedWrapper<4, DefaultShapeModel> defaultedWrapper;
+    outputBuffer[4] = evaluateDefaulted(defaultedWrapper, 2.0f); // CHECK: 14.0
+
+    var defaultedInput = diffPair(2.0f);
+    bwd_diff(evaluateDefaulted)(defaultedWrapper, defaultedInput, 1.0f);
+    outputBuffer[5] = defaultedInput.d; // CHECK: 7.0
+
+    MixedArithmeticWrapper<3, MixedShapeModel> mixedWrapper;
+    outputBuffer[6] = evaluateMixed(mixedWrapper, 2.0f); // CHECK: 34.0
+
+    var mixedInput = diffPair(2.0f);
+    bwd_diff(evaluateMixed)(mixedWrapper, mixedInput, 1.0f);
+    outputBuffer[7] = mixedInput.d; // CHECK: 17.0
+}


### PR DESCRIPTION
## Motivation

Consider this example:

```slang
interface IModel<TInput, TOutput> {}

struct Sampler<
    int LatentCount,
    int LobeCount,
    int SpecularCount = LobeCount - 1,
    Network : IModel<float[3 + LatentCount], float[3 + 6 * SpecularCount]>> : IFunction
{
    [BackwardDifferentiable]
    float forward(float input) { return input; }
}
```

A differentiable method is registered by synthesizing generic extensions for its forward- and backward-differentiability conformances. Before this change, the lifted extension for `forward` could not be applied when an enclosing constraint contained arithmetic such as `3 + LatentCount` or `3 + 6 * SpecularCount`. As a result, conformance checking reported that the visibly `[BackwardDifferentiable]` method did not provide the required differentiability.

## Proposed solution

Make generic integer-value unification distinguish "known mismatch" from "not decomposed by this helper." Distinct integer constants still fail immediately, and direct generic value parameters still produce ordinary-argument constraints. If both sides are integer values but neither path proves a mismatch or adds a direct binding, unification now returns success without adding a constraint.

This matches how the rest of generic unification is used: it should return `false` when it has a definite local mismatch, not when it merely lacks an algebraic proof for dependent expressions. A pair such as `N + 1` and `M + 1` might become equal after surrounding generic arguments are known, while a pair such as `N + 1` and `N + 2` will be rejected by the later checking/proof path rather than by this inference helper.

This keeps the checked semantic values produced by `liftDeclFromGenericContainers` as the source of truth. It does not reconstruct arithmetic syntax, add a custom equivalence relation for integer expressions, or weaken final generic-constraint validation.

## Change summary

- Update `SemanticsVisitor::TryUnifyVals` so non-constant integer values that cannot be decomposed into a direct generic-parameter binding are treated as compatible inference hints instead of immediate failures.
- Add a Vulkan-capable compute regression covering primal and backward results for addition, subtraction, multiplication, division, remainder, symbolic unary negation, parentheses, multiple model arguments, and a dependent default generic value.

## Concepts and vocabulary

- **Lifted extension**: the module-scope generic extension synthesized for a differentiable method nested in one or more generic containers.
- **Declared subtype witness**: the semantic proof argument associated with a source constraint such as `Network : IModel<...>`.
- **Inference hint**: information collected while matching a generic target; unlike a proof, it may be incomplete until other generic arguments are solved.
- **PolynomialIntVal / BuiltinOperationIntVal**: canonical semantic representations used for symbolic integer arithmetic. Addition, subtraction, multiplication, and negation use the former; operations such as division and remainder use the latter.

## Process report

`SemanticsDeclHeaderVisitor::checkDifferentiableCallableCommon` synthesizes differentiability extensions through `extendContainerDecl`. Because the method is nested in `Sampler`, `liftDeclFromGenericContainers` clones the enclosing generic parameters and constraints. The cloned constraint is intentionally expressed using fresh parameters, so the original witness contains arithmetic over `LatentCount` while the lifted witness contains the same canonical arithmetic over a fresh lifted parameter.

When `applyExtensionToType` matches the synthesized extension back to the method's function type, `TryUnifyTypes` reaches `tryUnifyGenericAppDeclRef`. The generic applications include their declared constraint witnesses. `TryUnifyVals` compares the witnesses' supertypes to discover ordinary-argument relationships and to reject real shape mismatches.

Without this change, that recursive comparison fails inside the arithmetic `IntVal` sub-expression. For example, the repro hits `TryUnifyVals` with the witness supertypes `IModel<float[N+1]>` and `IModel<float[N+1]>`, and then with their array-size values `N+1` and `N+1`. The printed expressions are the same, but their `N` operands come from different generic declarations. Because the values are `PolynomialIntVal` / `BuiltinOperationIntVal` rather than direct `DeclRefIntVal`s, `getDeclRefIntValIgnoringCasts` finds no parameter on either whole expression and ordinary integer unification used to return false. That false bubbled back through the declared-witness comparison, so the valid lifted extension was discarded before the generic solver could substitute inferred arguments and prove the witness.

The input shape is canonical and intentional: lifting must create fresh generic parameters, and `PolynomialIntVal` / `BuiltinOperationIntVal` already preserve and substitute the checked arithmetic correctly. Fixing the producer or rebuilding an expression would create a second representation of the same semantic value. A custom arithmetic matcher would duplicate canonicalization and generic solving. The fix therefore keeps the existing direct-parameter inference path, preserves constant mismatch rejection, and treats all remaining integer-value pairs as potentially unifiable.

The regression fails without the `TryUnifyVals` change and passes with it. Validation performed:

- Debug `slang` target built successfully.
- `tests/autodiff/generic-container-arithmetic-constraint` passes with `-api vk`.
- Focused related checks pass with `-api vk`: `tests/autodiff/callable-constraint-witness-rollback`, `tests/autodiff/autodiff-generic-where-clause`, `tests/bugs/polynomial-int-subst`, and `tests/autodiff/dynamic-dispatch-autodiff-static-generic-uint`.
- `tests/language-feature/generics` passes with `-api vk`: 149/149 passed, 86 ignored.
- Full `tests/autodiff` Vulkan run: 307/309 passed; the two failures are the existing `fwd-diff-forceinline` debug-info checks.
- Repository formatting check and `git diff --check` pass.
