### PR TITLE
Unwrap no_diff element types for autodiff updates

### DIFF
--- a/source/slang/slang-ir-autodiff-fwd.cpp
+++ b/source/slang/slang-ir-autodiff-fwd.cpp
@@ -1915,17 +1915,20 @@ struct ForwardDiffTranslationContext
             {
                 diffBase = getDifferentialZeroOfType(builder, origBase->getDataType());
             }
+
+            // TODO: Unwrapping the attributed type here is a workaround. Lowering should instead
+            // emit an explicit instruction such as IRNoDiffCast for the conversion to `no_diff`.
+            // AD could then use the differentiable type on the other side of that instruction to
+            // form the zero without implicitly discarding the conversion here.
+            auto primalElementType = (IRType*)unwrapAttributedType(primalVal->getDataType());
             if (auto diffVal = findOrTranslateDiffInst(builder, origVal))
             {
-                auto primalElementType = primalVal->getDataType();
-
                 diffUpdateElement =
                     builder->emitUpdateElement(diffBase, diffAccessChain.getArrayView(), diffVal);
                 builder->addPrimalElementTypeDecoration(diffUpdateElement, primalElementType);
             }
             else
             {
-                auto primalElementType = primalVal->getDataType();
                 auto zeroElementDiff = getDifferentialZeroOfType(builder, primalElementType);
                 diffUpdateElement = builder->emitUpdateElement(
                     diffBase,

--- a/tests/autodiff/coopvec.slang
+++ b/tests/autodiff/coopvec.slang
@@ -151,6 +151,10 @@
 // CHECK-NEXT: 20.000000
 // CHECK-NEXT: 200.000000
 // CHECK-NEXT: 2000.000000
+// CHECK-NEXT: 1.000000
+// CHECK-NEXT: 10.000000
+// CHECK-NEXT: 100.000000
+// CHECK-NEXT: 1000.000000
 
 typealias FloatCoopVec4 = CoopVec<float, 4>;
 typealias DPFloatCoopVec4 = DifferentialPair<FloatCoopVec4>;
@@ -227,7 +231,17 @@ FloatCoopVec4 testInitializerListConstructor(float a, float b, float c, float d)
     return result * FloatCoopVec4(2.0);
 }
 
-//TEST_INPUT:ubuffer(data=[0], stride=4, count=148):out,name=outputBuffer
+// Exercises reverse-mode element updates when the assigned value has a `no_diff` attributed type.
+[Differentiable]
+FloatCoopVec4 testNoDiffElementUpdates(FloatCoopVec4 x, no_diff float value)
+{
+    FloatCoopVec4 result;
+    for (int i = 0; i < 4; ++i)
+        result[i] = value;
+    return x + result;
+}
+
+//TEST_INPUT:ubuffer(data=[0], stride=4, count=152):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 [numthreads(1, 1, 1)]
@@ -462,5 +476,15 @@ void computeMain()
 
         result.p.store(outputBuffer, 560);
         result.d.store(outputBuffer, 576);
+    }
+
+    {
+        // The no_diff value contributes no gradient, while the CoopVec input receives dOut.
+        let x = FloatCoopVec4(2.0, 2.0, 2.0, 2.0);
+        let dOut = FloatCoopVec4(1.0, 10.0, 100.0, 1000.0);
+        var dx = DPFloatCoopVec4(x, FloatCoopVec4(0.0, 0.0, 0.0, 0.0));
+        bwd_diff(testNoDiffElementUpdates)(dx, 3.0f, dOut);
+
+        dx.d.store(outputBuffer, 592);
     }
 }


### PR DESCRIPTION
## Motivation

Consider this shader:

```slang
[Differentiable]
CoopVec<float, 4> scaleByLoop(CoopVec<float, 4> v, no_diff float factor)
{
    CoopVec<float, 4> bcast;
    for (int i = 0; i < 4; ++i)
        bcast[i] = factor;
    return v + bcast;
}
```

The `bcast[i] = factor` assignment updates a differentiable aggregate, but the assigned value has
the attributed type `no_diff float`. Forward AD emits a differential `UpdateElement` containing a
zero for that lane and records the attributed type as the primal element type. Reverse transposition
then tries to find `dzero` for `no_diff float` and asserts at
`slang-ir-autodiff.cpp(729): zeroMethod`.

## Proposed solution

As a scoped workaround, unwrap the assigned primal value's attributed type before recording the
primal element type on the differential `UpdateElement`. Reverse transposition can then form the
required zero from the underlying differentiable type.

The principled follow-up is to make the `no_diff` conversion explicit during lowering with an IR
instruction such as `IRNoDiffCast`. One side of that instruction would retain the differentiable
type that owns `dzero`, while the other side would represent the `no_diff` value. AD could then
derive the zero from the explicit conversion instead of stripping the attributed type here.

## Change summary

- `source/slang/slang-ir-autodiff-fwd.cpp`: unwrap the attributed element type used by differential
  `UpdateElement` metadata and document the `IRNoDiffCast`-style lowering fix that should replace
  this workaround.
- `tests/autodiff/coopvec.slang`: cover a `no_diff` scalar assigned to every lane of a `CoopVec` and
  verify that reverse mode propagates the output gradient to the differentiable vector input.
  
- Issue for more principled fix: https://github.com/shader-slang/slang/issues/10888

## Concepts and vocabulary

- **Differential `UpdateElement`**: the forward-AD instruction that mirrors an immutable aggregate
  element update in the tangent value.
- **Primal element type decoration**: metadata on a differential `UpdateElement` that tells reverse
  transposition which primal element type owns `dzero`.
- **Attributed type**: the IR type wrapper used here to carry `no_diff` on the scalar parameter.
- **`IRNoDiffCast`**: a proposed explicit IR boundary between a differentiable value type and its
  `no_diff` use; this change documents it as follow-up work rather than introducing the opcode.

## Process report

`ForwardDiffTranslationContext::translateUpdateElement` translates the primal base, access chain,
and assigned value, then creates the primal `UpdateElement`. Because the full result type is
`CoopVec<float, 4>`, it also creates a differential `UpdateElement`. The assigned `factor` has no
differential value, so forward AD fills the updated tangent lane with zero.

Previously the forward pass attached an `IRPrimalElementTypeDecoration` for `no_diff float`. During
backward derivative generation, `DiffTransposePass::transposeUpdateElement` read that decoration
and called `DifferentiableTypeConformanceContext::emitDZeroOfDiffInstType`. The attributed type is
intentionally non-differentiable, so it has no `DifferentialZero` association and the lookup
asserted.

This input shape is valid: assigning a non-differentiable value into a differentiable aggregate
must overwrite the corresponding tangent lane with zero. Passing the old aggregate differential
through unchanged would preserve a stale dependency in that lane, so the differential
`UpdateElement` remains necessary.

The current IR does not explicitly represent the conversion from the `no_diff` value to the
differentiable element position. The workaround therefore unwraps the assigned primal value's
attributed type when producing the decoration, allowing the existing zero lookup to use the base
`float` associations. The code carries a TODO because this is not the canonical representation:
lowering should emit an explicit `IRNoDiffCast`-style instruction, and AD should obtain the zero
type from that instruction's differentiable side.

The regression checks the motivating CoopVec loop and its gradient. Debug validation included:

- `tests/autodiff/coopvec.slang` passing Vulkan, CPU, and CUDA syntax coverage; and
- the full Vulkan autodiff suite passing 305/305 tests, with 528 non-Vulkan directives ignored.
