### PR TITLE
Reuse bundled Vulkan headers for slang-rhi

### DIFF
--- a/.github/workflows/ci-slang-build-container.yml
+++ b/.github/workflows/ci-slang-build-container.yml
@@ -150,6 +150,24 @@ jobs:
             ldd build/${cmake_config}/lib/librender-test-tool.so 2>/dev/null || true
           fi
 
+      - name: Verify Vulkan-Headers was not fetched
+        run: |
+          vulkan_headers_fetch_dir="build/_deps/vulkan_headers-src"
+          if [[ -e "$vulkan_headers_fetch_dir" ]]; then
+            echo "::error title=Unexpected Vulkan-Headers download::Found $vulkan_headers_fetch_dir"
+            cat <<'EOF'
+          Slang owns the Vulkan-Headers checkout in external/vulkan. external/CMakeLists.txt sets
+          FETCHCONTENT_SOURCE_DIR_VULKAN_HEADERS so slang-rhi reuses that checkout instead of
+          downloading a second copy. Finding build/_deps/vulkan_headers-src means that redirect
+          stopped working. The two projects could then compile against different Vulkan header
+          versions.
+
+          Check that FETCHCONTENT_SOURCE_DIR_VULKAN_HEADERS is set before add_subdirectory(slang-rhi)
+          and that slang-rhi still declares the FetchContent dependency as vulkan_headers.
+          EOF
+            exit 1
+          fi
+
       - name: Prepare artifacts for upload
         run: |
           # Create a staging directory for artifacts with config-specific subdirectory

--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -248,6 +248,25 @@ jobs:
             ccache --show-stats || true
           fi
 
+      - name: Verify Vulkan-Headers was not fetched
+        if: inputs.platform != 'wasm'
+        run: |
+          vulkan_headers_fetch_dir="build/_deps/vulkan_headers-src"
+          if [[ -e "$vulkan_headers_fetch_dir" ]]; then
+            echo "::error title=Unexpected Vulkan-Headers download::Found $vulkan_headers_fetch_dir"
+            cat <<'EOF'
+          Slang owns the Vulkan-Headers checkout in external/vulkan. external/CMakeLists.txt sets
+          FETCHCONTENT_SOURCE_DIR_VULKAN_HEADERS so slang-rhi reuses that checkout instead of
+          downloading a second copy. Finding build/_deps/vulkan_headers-src means that redirect
+          stopped working. The two projects could then compile against different Vulkan header
+          versions.
+
+          Check that FETCHCONTENT_SOURCE_DIR_VULKAN_HEADERS is set before add_subdirectory(slang-rhi)
+          and that slang-rhi still declares the FetchContent dependency as vulkan_headers.
+          EOF
+            exit 1
+          fi
+
       - name: Check documented compiler versions
         run: bash extras/verify-documented-compiler-version.sh
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -158,6 +158,23 @@ if(NOT TARGET Vulkan::Headers)
     endif()
 endif()
 
+# Reuse Slang's Vulkan-Headers checkout when slang-rhi requests the same dependency through
+# FetchContent. Callers can still provide their own FetchContent source directory explicitly.
+if(
+    NOT DEFINED FETCHCONTENT_SOURCE_DIR_VULKAN_HEADERS
+    AND NOT SLANG_USE_SYSTEM_VULKAN_HEADERS
+)
+    if(NOT SLANG_OVERRIDE_VULKAN_HEADERS_PATH)
+        set(FETCHCONTENT_SOURCE_DIR_VULKAN_HEADERS
+            "${CMAKE_CURRENT_SOURCE_DIR}/vulkan"
+        )
+    else()
+        set(FETCHCONTENT_SOURCE_DIR_VULKAN_HEADERS
+            "${SLANG_OVERRIDE_VULKAN_HEADERS_PATH}/vulkan"
+        )
+    endif()
+endif()
+
 # metal-cpp headers
 add_library(metal-cpp INTERFACE)
 target_include_directories(


### PR DESCRIPTION
## Motivation

The macOS CI intermittency tracked in #11985 exposed an avoidable network dependency in an
otherwise source-complete checkout. Consider a normal native build:

```console
cmake --preset default --fresh
cmake --workflow --preset release
```

Slang first adds `external/vulkan` for its own Vulkan headers, but slang-rhi later calls
`FetchPackage(vulkan_headers)` and downloads another Vulkan-Headers archive into
`build/_deps/vulkan_headers-src`. The second copy was previously necessary: Slang pinned header
version 307 while slang-rhi requires version 347, so redirecting slang-rhi to the older checkout
failed on version-347 symbols. Once both consumers use version 347, retaining the second download
only adds a network failure mode and allows the header versions to drift again.

## Proposed solution

Advance Slang's Vulkan-Headers submodule to the same v1.4.347 release required by slang-rhi, then
set CMake's `FETCHCONTENT_SOURCE_DIR_VULKAN_HEADERS` before adding slang-rhi. This makes the checked
out source the single versioned input for both projects while preserving explicit caller overrides
and the existing system-header configuration.

Add post-build CI assertions that reject `build/_deps/vulkan_headers-src`. The directory is the
observable result of FetchContent populating a second source tree, so checking it verifies the
intended dependency flow rather than relying only on a successful compile.

## Change summary

- `external/vulkan` advances from v1.4.307 to v1.4.347, matching
  `SLANG_RHI_VULKAN_HEADERS_URL` in `external/slang-rhi/CMakeLists.txt`.
- `external/CMakeLists.txt:145` selects the bundled or override-supplied Vulkan-Headers checkout,
  and `external/CMakeLists.txt:161` forwards that source to slang-rhi through
  `FETCHCONTENT_SOURCE_DIR_VULKAN_HEADERS`.
- `.github/workflows/ci-slang-build.yml:251` verifies native CI builds do not populate a second
  Vulkan-Headers source tree. WASM is excluded because it disables slang-rhi and cannot exercise
  this dependency path.
- `.github/workflows/ci-slang-build-container.yml:153` applies the same verification to the CUDA
  container build.

## Concepts and vocabulary

- `vulkan_headers` is slang-rhi's FetchContent dependency name. CMake derives the uppercase
  override variable `FETCHCONTENT_SOURCE_DIR_VULKAN_HEADERS` from that name.
- `SLANG_OVERRIDE_VULKAN_HEADERS_PATH` selects a caller-supplied Vulkan-Headers checkout for Slang.
  The same selected checkout now flows to slang-rhi.
- `build/_deps/vulkan_headers-src` is FetchContent's populated source directory. It should not
  exist when CMake is correctly redirected to `external/vulkan`.

## Process report

In the default configuration, top-level CMake calls `add_subdirectory(external)`. The Vulkan block
in `external/CMakeLists.txt` adds `external/vulkan`, then the slang-rhi block later calls
`add_subdirectory(slang-rhi)`. During that second call, slang-rhi's
`FetchPackage(vulkan_headers)` declares and makes its Vulkan-Headers content available. CMake
inherits `FETCHCONTENT_SOURCE_DIR_VULKAN_HEADERS` from the parent directory, returns
`external/vulkan` as `vulkan_headers_SOURCE_DIR`, and skips the archive download and population
steps. Both Slang's `Vulkan::Headers` target and slang-rhi's `slang-rhi-vulkan-headers` interface
therefore expose headers from the same checkout.

Redirecting the previous v1.4.307 checkout was rejected because that source shape was not valid
input for the current slang-rhi revision. For example, slang-rhi uses v1.4.347 declarations such as
`VK_EXT_SHADER_FLOAT8_EXTENSION_NAME` and `VK_KHR_SHADER_BFLOAT16_EXTENSION_NAME`; keeping the
consumer simple requires updating the canonical producer checkout rather than teaching slang-rhi
to tolerate or reconstruct missing declarations. Advancing `external/vulkan` to the exact release
already pinned by slang-rhi makes the redirected source intentional and canonical.

The CMake conditions preserve each supported input shape. A bundled build forwards
`external/vulkan`; `SLANG_OVERRIDE_VULKAN_HEADERS_PATH` forwards the caller's selected checkout; an
explicit `FETCHCONTENT_SOURCE_DIR_VULKAN_HEADERS` remains authoritative; and
`SLANG_USE_SYSTEM_VULKAN_HEADERS` leaves slang-rhi's existing pinned-fetch behavior unchanged
because a package target does not provide the source directory FetchPackage expects.

Finally, both native build workflows check for FetchContent's populated source directory after the
build. If the dependency name changes or the parent variable stops reaching slang-rhi, the build
might still succeed after downloading another archive. The explicit assertion catches that
regression and explains the single-source invariant and the two wiring points a maintainer should
inspect.
