### PR TITLE
Use mimalloc for global C++ new/delete on Windows

### DIFF
--- a/.github/cmake-options-matrix.json
+++ b/.github/cmake-options-matrix.json
@@ -38,6 +38,7 @@
     },
     { "option": "SLANG_EXCLUDE_DAWN" },
     { "option": "SLANG_EXCLUDE_TINT" },
+    { "option": "SLANG_ENABLE_MIMALLOC", "windows_only": "true" },
     { "option": "SLANG_ENABLE_SPIRV_TOOLS_MIMALLOC" },
     { "option": "SLANG_ENABLE_RELEASE_LTO" },
     { "option": "SLANG_IGNORE_ABORT_MSG" },

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,6 +341,27 @@ enum_option(
     "Build slang-compiler as a static library"
 )
 
+set(SLANG_ENABLE_MIMALLOC_DEFAULT OFF)
+if(
+    WIN32
+    AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"
+    AND SLANG_LIB_TYPE STREQUAL "SHARED"
+    AND NOT SLANG_ENABLE_ASAN
+)
+    set(SLANG_ENABLE_MIMALLOC_DEFAULT ON)
+endif()
+advanced_option(
+    SLANG_ENABLE_MIMALLOC
+    "Use mimalloc for global C++ allocation in slang-compiler"
+    ${SLANG_ENABLE_MIMALLOC_DEFAULT}
+)
+if(SLANG_ENABLE_MIMALLOC AND SLANG_ENABLE_ASAN)
+    message(
+        WARNING
+        "SLANG_ENABLE_MIMALLOC is enabled with SLANG_ENABLE_ASAN, but this mimalloc configuration does not enable ASan tracking"
+    )
+endif()
+
 option(
     SLANG_ENABLE_RELEASE_DEBUG_INFO
     "Generate debug info for Release builds"

--- a/docs/building.md
+++ b/docs/building.md
@@ -351,6 +351,7 @@ error if they can't be found.
 | `SLANG_USE_SYSTEM_GLSLANG`          | `FALSE`                              | Build using system glslang library instead of the bundled version in [./external](./external)                               |
 | `SLANG_SPIRV_HEADERS_INCLUDE_DIR`   | ``                                   | Use this specific path to SPIR-V headers instead of the bundled version in [./external](./external)                         |
 | `SLANG_ENABLE_SPIRV_TOOLS_MIMALLOC` | `FALSE` (`TRUE` on Windows)          | Enable mimalloc allocator for SPIRV-Tools to improve compilation performance                                                |
+| `SLANG_ENABLE_MIMALLOC`             | `FALSE` (`TRUE` on shared Windows)   | Override global C++ allocation in `slang-compiler` with mimalloc                                                             |
 | `SLANG_EXCLUDE_DAWN`                | `FALSE` on Windows, `TRUE` elsewhere | Exclude Dawn WebGPU support from the build                                                                                  |
 | `SLANG_EXCLUDE_TINT`                | `FALSE`                              | Exclude slang-tint from the build (only relevant on Windows x64)                                                            |
 | `SLANG_ENABLE_TIME_TRACE`           | `FALSE`                              | Enable Clang time trace profiling for build analysis (Clang only)                                                           |

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -192,6 +192,59 @@ target_include_directories(
     INTERFACE "${_fast_float_include}"
 )
 
+# Slang and SPIRV-Tools share one mimalloc target. Resolve the checkout before either consumer is
+# configured so slang-compiler can use mimalloc even when SPIRV-Tools is disabled or provided by
+# the system.
+set(SLANG_BUILD_MIMALLOC OFF)
+if(SLANG_ENABLE_MIMALLOC)
+    set(SLANG_BUILD_MIMALLOC ON)
+elseif(
+    SLANG_ENABLE_SLANG_GLSLANG
+    AND NOT SLANG_USE_SYSTEM_SPIRV_TOOLS
+    AND SLANG_ENABLE_SPIRV_TOOLS_MIMALLOC
+)
+    set(SLANG_BUILD_MIMALLOC ON)
+endif()
+
+set(SLANG_MIMALLOC_AVAILABLE OFF)
+if(SLANG_BUILD_MIMALLOC)
+    if(NOT SLANG_OVERRIDE_MIMALLOC_PATH)
+        # Place mimalloc in slang/external instead of spirv-tools/external for better organization.
+        set(MIMALLOC_PATH "${CMAKE_CURRENT_SOURCE_DIR}/mimalloc")
+    else()
+        set(MIMALLOC_PATH "${SLANG_OVERRIDE_MIMALLOC_PATH}/mimalloc")
+    endif()
+
+    if(NOT EXISTS "${MIMALLOC_PATH}/CMakeLists.txt")
+        message(
+            STATUS
+            "mimalloc not found at ${MIMALLOC_PATH} - downloading..."
+        )
+        execute_process(
+            COMMAND
+                ${GIT_EXECUTABLE} clone --depth 1 --branch v2.1.7
+                https://github.com/microsoft/mimalloc.git "${MIMALLOC_PATH}"
+            OUTPUT_QUIET
+            ERROR_QUIET
+        )
+    endif()
+
+    if(EXISTS "${MIMALLOC_PATH}/CMakeLists.txt")
+        set(mimalloc_SOURCE_DIR "${MIMALLOC_PATH}")
+        set(SLANG_MIMALLOC_AVAILABLE ON)
+    elseif(SLANG_ENABLE_MIMALLOC)
+        message(
+            FATAL_ERROR
+            "SLANG_ENABLE_MIMALLOC requires mimalloc, but it was not found at ${MIMALLOC_PATH} and could not be downloaded"
+        )
+    else()
+        message(
+            WARNING
+            "mimalloc was not found at ${MIMALLOC_PATH}. Building without mimalloc support."
+        )
+    endif()
+endif()
+
 # SPIRV-Headers
 # Avoid using ${system} intentionally in `add_subdirectory`, because if we do, it will end up using
 # spirv.h installed in the system directory on MacOS.
@@ -239,56 +292,20 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
 
         # Enable mimalloc for SPIRV-Tools to improve compilation performance
         # Based on SPIRV-Tools PR #6267: https://github.com/KhronosGroup/SPIRV-Tools/pull/6267
-        if(SLANG_ENABLE_SPIRV_TOOLS_MIMALLOC)
-            if(NOT SLANG_OVERRIDE_MIMALLOC_PATH)
-                # Place mimalloc in slang/external instead of spirv-tools/external for better organization
-                set(MIMALLOC_PATH "${CMAKE_CURRENT_SOURCE_DIR}/mimalloc")
-            else()
-                set(MIMALLOC_PATH "${SLANG_OVERRIDE_MIMALLOC_PATH}/mimalloc")
-            endif()
-
-            # Download mimalloc if it's not available
-            if(NOT EXISTS "${MIMALLOC_PATH}/CMakeLists.txt")
-                message(
-                    STATUS
-                    "mimalloc not found at ${MIMALLOC_PATH} - downloading..."
-                )
-                execute_process(
-                    COMMAND
-                        ${GIT_EXECUTABLE} clone --depth 1 --branch v2.1.7
-                        https://github.com/microsoft/mimalloc.git
-                        "${MIMALLOC_PATH}"
-                    RESULT_VARIABLE git_result
-                    OUTPUT_QUIET
-                    ERROR_QUIET
-                )
-                if(git_result EQUAL 0)
-                    # Point SPIRV-Tools to our mimalloc location
-                    set(mimalloc_SOURCE_DIR "${MIMALLOC_PATH}")
-                    set(SPIRV_TOOLS_USE_MIMALLOC ON)
-                    set(SPIRV_TOOLS_USE_MIMALLOC_IN_STATIC_BUILD ON)
-                    # set(MI_INSTALL_TOPLEVEL OFF)
-                    message(
-                        STATUS
-                        "Successfully downloaded and enabled mimalloc for SPIRV-Tools at ${MIMALLOC_PATH}"
-                    )
-                else()
-                    message(
-                        WARNING
-                        "Failed to download mimalloc. Building SPIRV-Tools without mimalloc support."
-                    )
-                endif()
-            endif()
-
-            # Check if mimalloc is available now
-            if(EXISTS "${MIMALLOC_PATH}/CMakeLists.txt")
-                # Point SPIRV-Tools to our mimalloc location
-                set(mimalloc_SOURCE_DIR "${MIMALLOC_PATH}")
-                set(SPIRV_TOOLS_USE_MIMALLOC ON)
-                # Also enable mimalloc in static builds for better performance
-                set(SPIRV_TOOLS_USE_MIMALLOC_IN_STATIC_BUILD ON)
-                # Disable mimalloc installation to avoid install target conflicts
-                # set(MI_INSTALL_TOPLEVEL OFF)
+        if(SLANG_MIMALLOC_AVAILABLE)
+            set(SPIRV_TOOLS_USE_MIMALLOC
+                ${SLANG_ENABLE_SPIRV_TOOLS_MIMALLOC}
+                CACHE BOOL
+                "Executables and shared libraries use mimalloc instead of the default allocator"
+                FORCE
+            )
+            set(SPIRV_TOOLS_USE_MIMALLOC_IN_STATIC_BUILD
+                ${SLANG_ENABLE_SPIRV_TOOLS_MIMALLOC}
+                CACHE BOOL
+                "Static SPIRV-Tools libraries use mimalloc instead of the default allocator"
+                FORCE
+            )
+            if(SLANG_ENABLE_SPIRV_TOOLS_MIMALLOC)
                 message(
                     STATUS
                     "Enabling mimalloc for SPIRV-Tools (including static builds) from ${MIMALLOC_PATH}"
@@ -325,6 +342,21 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
             )
         endif()
     endif()
+endif()
+
+# SPIRV-Tools normally creates mimalloc-static. Create it here when slang-compiler needs it and
+# SPIRV-Tools did not, while keeping the global allocation override in Slang-owned source code.
+if(SLANG_ENABLE_MIMALLOC AND NOT TARGET mimalloc-static)
+    function(_slang_add_mimalloc_target)
+        set(MI_OVERRIDE OFF)
+        set(MI_BUILD_SHARED OFF)
+        set(MI_BUILD_STATIC ON)
+        set(MI_BUILD_OBJECT OFF)
+        set(MI_BUILD_TESTS OFF)
+        set(MI_INSTALL_TOPLEVEL OFF)
+        add_subdirectory("${mimalloc_SOURCE_DIR}" mimalloc EXCLUDE_FROM_ALL)
+    endfunction()
+    _slang_add_mimalloc_target()
 endif()
 
 if(

--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -354,6 +354,27 @@ else()
     )
 endif()
 
+if(SLANG_ENABLE_MIMALLOC)
+    if(NOT TARGET mimalloc-static)
+        message(
+            FATAL_ERROR
+            "SLANG_ENABLE_MIMALLOC requires the mimalloc-static target"
+        )
+    endif()
+
+    # Without the embedded core module, the normal source glob already adds this file to slang.
+    # With the embedded core module, the glob belongs to slang-common-objects, where this file
+    # remains empty, so compile the active override directly in slang.
+    if(SLANG_EMBED_CORE_MODULE)
+        target_sources(slang PRIVATE slang-mimalloc.cpp)
+    endif()
+    target_compile_definitions(
+        slang
+        PRIVATE SLANG_MIMALLOC_OVERRIDE_NEW_DELETE=1
+    )
+    target_link_libraries(slang PRIVATE mimalloc-static)
+endif()
+
 set_target_properties(
     slang
     PROPERTIES

--- a/source/slang/slang-mimalloc.cpp
+++ b/source/slang/slang-mimalloc.cpp
@@ -1,0 +1,14 @@
+#if defined(SLANG_MIMALLOC_OVERRIDE_NEW_DELETE)
+
+// Override global C++ allocation in slang-compiler with mimalloc.
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4559)
+#endif
+#include "mimalloc-new-delete.h"
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+#endif


### PR DESCRIPTION
Add SLANG_ENABLE_MIMALLOC to route global C++ new/delete in slang-compiler through mimalloc. Enable it by default for shared MSVC Windows builds, while allowing other untested configurations to opt in.

Reuse the mimalloc target created by SPIRV-Tools when available, and create a minimal static target otherwise. Compile the replacement operators directly into slang-compiler so they are retained by the linker.

Warn when enabling mimalloc with ASan because this mimalloc configuration does not enable ASan tracking.

Partially addresses #11925