### PR TITLE
Add ASCII check for shipped headers and preludes to formatting CI

### DIFF
--- a/extras/formatting.sh
+++ b/extras/formatting.sh
@@ -401,7 +401,7 @@ markdown_formatting() {
 # Shipped files - the public headers in include/ and the preludes in
 # prelude/ - must be pure ASCII: a non-ASCII byte makes MSVC emit C4819
 # (a /WX hard error) for consumers building with a non-UTF-8 source
-# charset (#12016 / #12018).
+# charset.
 ascii_check() {
   echo "Checking shipped headers and preludes are pure ASCII..." >&2
 

--- a/extras/formatting.sh
+++ b/extras/formatting.sh
@@ -23,7 +23,7 @@ show_help() {
   cat <<EOF
 $me: Format or check formatting of files in this repo
 
-Usage: $me [--check-only] [--no-version-check] [--modified] [--source <path>] [--cpp] [--yaml] [--md] [--sh] [--cmake] [--since <rev>] [-- file1 file2 ...]
+Usage: $me [--check-only] [--no-version-check] [--modified] [--source <path>] [--cpp] [--yaml] [--md] [--sh] [--cmake] [--ascii] [--since <rev>] [-- file1 file2 ...]
 
 Options:
     --check-only       Check formatting without modifying files
@@ -35,6 +35,7 @@ Options:
     --md              Format only markdown files
     --sh              Format only shell script files
     --cmake           Format only CMake files
+    --ascii           Check only that shipped headers/preludes are pure ASCII
     --since <rev>     Only format files since Git revision <rev>
     -- file1 file2    Format only the specified files (auto-detects file types)
 
@@ -56,6 +57,7 @@ run_yaml=0
 run_markdown=0
 run_sh=0
 run_cmake=0
+run_ascii=0
 run_all=1
 explicit_files=()
 
@@ -86,6 +88,10 @@ while [[ "$#" -gt 0 ]]; do
     ;;
   --cmake)
     run_cmake=1
+    run_all=0
+    ;;
+  --ascii)
+    run_ascii=1
     run_all=0
     ;;
   --source)
@@ -224,6 +230,11 @@ if [ ${#explicit_files[@]} -gt 0 ]; then
     *.md) run_markdown=1 ;;
     *.sh) run_sh=1 ;;
     *.cmake | CMakeLists.txt) run_cmake=1 ;;
+    esac
+    # Separate case: shipped files also get the ASCII check, on top of
+    # whatever type-based formatter matched above (bash case is first-match).
+    case "$file" in
+    include/* | prelude/*) run_ascii=1 ;;
     esac
   done
 fi
@@ -385,6 +396,31 @@ markdown_formatting() {
   prettier_formatting
 }
 
+# Check that the files we ship to consumers - the public headers in include/
+# and the preludes in prelude/, which get compiled into downstream projects -
+# contain only ASCII bytes. A non-ASCII byte (such as an em-dash in a comment)
+# makes MSVC emit C4819 for consumers who build with a non-UTF-8 source
+# charset (e.g. /source-charset:.932), which /WX promotes to a hard error;
+# see issue #12016 / PR #12018. There is no auto-fix: the right ASCII
+# replacement depends on the text, so this check fails in both modes and the
+# offending characters must be edited by hand.
+ascii_check() {
+  echo "Checking shipped headers and preludes are pure ASCII..." >&2
+
+  read_lines < <(list_files 'include/*' 'prelude/*')
+  [ ${#files[@]} -gt 0 ] || return 0
+
+  local matches
+  for file in "${files[@]}"; do
+    # LC_ALL=C makes grep match raw bytes rather than decoded characters.
+    if matches=$(LC_ALL=C $GREP_BIN -nP '[^\x00-\x7F]' "$file"); then
+      echo "error: non-ASCII bytes in shipped file $file (breaks MSVC consumers using a non-UTF-8 source charset, see #12016):" >&2
+      echo "$matches" >&2
+      exit_code=1
+    fi
+  done
+}
+
 sh_formatting() {
   echo "Formatting sh files..." >&2
 
@@ -403,6 +439,7 @@ sh_formatting() {
   fi
 }
 
+((run_all || run_ascii)) && ascii_check
 ((run_all || run_sh)) && sh_formatting
 ((run_all || run_cmake)) && cmake_formatting
 ((run_all || run_yaml)) && yaml_json_formatting

--- a/extras/formatting.sh
+++ b/extras/formatting.sh
@@ -412,7 +412,7 @@ ascii_check() {
   for file in "${files[@]}"; do
     # LC_ALL=C makes grep match raw bytes rather than decoded characters.
     if matches=$(LC_ALL=C $GREP_BIN -nP '[^\x00-\x7F]' "$file"); then
-      echo "error: non-ASCII bytes in shipped file $file (breaks MSVC consumers using a non-UTF-8 source charset, see #12016):" >&2
+      echo "error: non-ASCII bytes in shipped file $file (breaks MSVC consumers using a non-UTF-8 source charset):" >&2
       echo "$matches" >&2
       exit_code=1
     fi

--- a/extras/formatting.sh
+++ b/extras/formatting.sh
@@ -104,7 +104,9 @@ while [[ "$#" -gt 0 ]]; do
     ;;
   --)
     shift
-    explicit_files=("$@")
+    # Strip a leading ./ from each path so the anchored path-prefix patterns
+    # below (include/*, prelude/*) match however the caller spelled the path.
+    explicit_files=("${@#./}")
     break
     ;;
   *)

--- a/extras/formatting.sh
+++ b/extras/formatting.sh
@@ -398,14 +398,10 @@ markdown_formatting() {
   prettier_formatting
 }
 
-# Check that the files we ship to consumers - the public headers in include/
-# and the preludes in prelude/, which get compiled into downstream projects -
-# contain only ASCII bytes. A non-ASCII byte (such as an em-dash in a comment)
-# makes MSVC emit C4819 for consumers who build with a non-UTF-8 source
-# charset (e.g. /source-charset:.932), which /WX promotes to a hard error;
-# see issue #12016 / PR #12018. There is no auto-fix: the right ASCII
-# replacement depends on the text, so this check fails in both modes and the
-# offending characters must be edited by hand.
+# Shipped files - the public headers in include/ and the preludes in
+# prelude/ - must be pure ASCII: a non-ASCII byte makes MSVC emit C4819
+# (a /WX hard error) for consumers building with a non-UTF-8 source
+# charset (#12016 / #12018).
 ascii_check() {
   echo "Checking shipped headers and preludes are pure ASCII..." >&2
 


### PR DESCRIPTION
## Summary

- Adds an `ascii_check` stage to `extras/formatting.sh` that fails when any file under `include/` or `prelude/` contains a non-ASCII byte, reporting each offending `file:line`.
- Runs as part of the default invocation, so the existing `check-formatting` workflow (`formatting.sh --check-only`) enforces it with no workflow change; also selectable alone via `--ascii`.

## Motivation

Non-ASCII bytes in shipped files break downstream consumers: MSVC emits C4819 for a translation unit that includes `slang.h` under a non-UTF-8 source charset (e.g. `/source-charset:.932`), and `/WX` promotes that to a hard error (#12016). The preludes are compiled into generated CPU/CUDA output, so they hit the same failure. This regressed twice before being fixed in #12018, whose process report explicitly deferred a CI guard as follow-up — this PR is that follow-up.

Fixes #12038.

## Technical Details

The check lives in `formatting.sh` rather than a new workflow step so the same guard runs locally for developers and in CI, matching how every other format check here works. Scope is deliberately only `include/` and `prelude/` — the two trees whose bytes reach downstream compilers; repository-internal sources are compiled by our own toolchains with known charsets, and sweeping them would flag existing benign comment punctuation without protecting any consumer.

Matching is `LC_ALL=C grep -nP '[^\x00-\x7F]'` per file (byte-wise, so it cannot be confused by the locale's decoding). GNU grep is already a hard requirement of the script (`ggrep` on macOS), so no new tool dependency. There is intentionally no auto-fix and the check fails in both `--check-only` and fix modes: the correct ASCII replacement is context-dependent prose editing (`—` → ` - `, `→` → `->`, etc., per #12018), not something a formatter should guess.

Explicit-file invocations (`formatting.sh -- <files>`) also trigger the check for arguments under the two shipped trees, via a second `case` statement since the existing type-based `case` is first-match and `*.h` would otherwise shadow the path match on Bash 3.2.

## Test Plan

- [x] Clean tree passes: `./extras/formatting.sh --ascii` exits 0 (tree is ASCII-clean since #12018).
- [x] Detection: appending a UTF-8 em-dash to `include/slang.h` makes the check exit 1 and print `include/slang.h:6023` with the offending line; reverted after the test.
- [x] Explicit-file mode: `./extras/formatting.sh --check-only -- include/slang.h` runs the ASCII check.
- [x] Script hygiene: `shfmt --indent 2 --diff` clean, `bash -n` clean.

Suggested reviewers: @jkwak-work (most recent changes to `extras/formatting.sh`), @expipiplus1 (author of the script's structure and check-only machinery).