### PR TITLE
Fix quadratic IR type legalization on straight-line functions

### DIFF
--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -3891,8 +3891,20 @@ struct IRTypeLegalizationPass
         // * `i` is a user of `inst`, or
         // * `i` is a child of `inst`.
         //
+        // When legalization left `inst` unchanged, a user or child that has
+        // already been added or processed does not need to be revisited: its
+        // own legalization consulted (or will consult) a mapping that this
+        // step did not alter. Re-adding unconditionally makes every round of
+        // `processModule` re-legalize almost everything the previous rounds
+        // did, which turns the pass quadratic on long dependence chains
+        // (issue #12040). We only requeue such instructions when this step
+        // actually changed the value they depend on.
+        //
+        bool changed = true;
         if (legalVal.flavor == LegalVal::Flavor::simple)
         {
+            changed = legalVal.irValue != inst;
+
             // The resulting inst may be different from the one we added to the
             // worklist, so ensure that the appropriate flags are set.
             //
@@ -3904,11 +3916,13 @@ struct IRTypeLegalizationPass
         for (auto use = inst->firstUse; use; use = use->nextUse)
         {
             auto user = use->getUser();
-            maybeAddToWorkList(user);
+            if (changed || !hasBeenAddedToWorkListOrProcessed(user))
+                maybeAddToWorkList(user);
         }
         for (auto child : inst->getDecorationsAndChildren())
         {
-            maybeAddToWorkList(child);
+            if (changed || !hasBeenAddedToWorkListOrProcessed(child))
+                maybeAddToWorkList(child);
         }
     }
 

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -3881,6 +3881,13 @@ struct IRTypeLegalizationPass
         // the value had been replaced.
         //
         auto typeBeforeLegalize = inst->getFullType();
+#if _DEBUG
+        // Snapshot the operands so the debug build can enforce the invariant
+        // the change detection below relies on (see the comment there).
+        List<IRInst*> operandsBeforeLegalize;
+        for (UInt i = 0; i < inst->getOperandCount(); i++)
+            operandsBeforeLegalize.add(inst->getOperand(i));
+#endif
 
         LegalVal legalVal = legalizeInst(context, inst);
         registerLegalizedValue(context, inst, legalVal);
@@ -3908,10 +3915,36 @@ struct IRTypeLegalizationPass
         // (issue #12040). We only requeue such instructions when this step
         // actually changed the value they depend on.
         //
+        // The reason a revisit is ever needed: within a round, a user `u` can
+        // be processed before its operand `inst` (readiness is checked
+        // against the add-time flag), so `u` legalizes against a mapping for
+        // `inst` that is not registered yet. Skipping `u`'s requeue here is
+        // safe exactly when `inst` was unchanged, because an unchanged
+        // `simple` result registers the identity mapping — the same answer
+        // `u`'s legalization already assumed on the map miss.
+        //
+        // The change detection relies on an invariant every current
+        // legalizer satisfies: a legalizer returning `LegalVal::simple(inst)`
+        // may signal a change ONLY by returning a different `irValue` or by
+        // mutating the instruction's full type — never by mutating an
+        // operand (or other semantically significant state) in place while
+        // leaving value and type identical. Non-`simple` flavors are always
+        // treated as changed, which is why `changed` defaults to `true`.
+        // The debug build asserts the operand part of the invariant below.
+        //
         bool changed = true;
         if (legalVal.flavor == LegalVal::Flavor::simple)
         {
             changed = legalVal.irValue != inst || inst->getFullType() != typeBeforeLegalize;
+
+#if _DEBUG
+            if (!changed)
+            {
+                SLANG_ASSERT(inst->getOperandCount() == (UInt)operandsBeforeLegalize.getCount());
+                for (UInt i = 0; i < inst->getOperandCount(); i++)
+                    SLANG_ASSERT(inst->getOperand(i) == operandsBeforeLegalize[i]);
+            }
+#endif
 
             // The resulting inst may be different from the one we added to the
             // worklist, so ensure that the appropriate flags are set.

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -3906,31 +3906,16 @@ struct IRTypeLegalizationPass
         // * `i` is a user of `inst`, or
         // * `i` is a child of `inst`.
         //
-        // When legalization left `inst` unchanged, a user or child that has
-        // already been added or processed does not need to be revisited: its
-        // own legalization consulted (or will consult) a mapping that this
-        // step did not alter. Re-adding unconditionally makes every round of
-        // `processModule` re-legalize almost everything the previous rounds
-        // did, which turns the pass quadratic on long dependence chains
-        // (issue #12040). We only requeue such instructions when this step
-        // actually changed the value they depend on.
-        //
-        // The reason a revisit is ever needed: within a round, a user `u` can
-        // be processed before its operand `inst` (readiness is checked
-        // against the add-time flag), so `u` legalizes against a mapping for
-        // `inst` that is not registered yet. Skipping `u`'s requeue here is
-        // safe exactly when `inst` was unchanged, because an unchanged
-        // `simple` result registers the identity mapping — the same answer
-        // `u`'s legalization already assumed on the map miss.
-        //
-        // The change detection relies on an invariant every current
-        // legalizer satisfies: a legalizer returning `LegalVal::simple(inst)`
-        // may signal a change ONLY by returning a different `irValue` or by
-        // mutating the instruction's full type — never by mutating an
-        // operand (or other semantically significant state) in place while
-        // leaving value and type identical. Non-`simple` flavors are always
-        // treated as changed, which is why `changed` defaults to `true`.
-        // The debug build asserts the operand part of the invariant below.
+        // Requeue already-queued users/children only when this step actually
+        // changed `inst`: re-adding them unconditionally re-legalizes almost
+        // everything every round, which is quadratic on long dependence
+        // chains (#12040). The skip is safe because a user processed before
+        // its operand assumed the identity mapping on the map miss, and an
+        // unchanged `simple` result registers exactly that identity. This
+        // relies on an invariant (asserted below in debug builds): a
+        // legalizer signals change only by returning a different `irValue`
+        // or mutating the full type, never by mutating an operand in place;
+        // non-`simple` flavors always count as changed.
         //
         bool changed = true;
         if (legalVal.flavor == LegalVal::Flavor::simple)

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -3874,6 +3874,14 @@ struct IRTypeLegalizationPass
         // register the result of legalization as the proper value
         // for that instruction.
         //
+        // Capture the type before legalization: several legalization paths
+        // (params, local/global vars, funcs) mutate the instruction in place
+        // via `setFullType`/`setDataType` and still return it as a `simple`
+        // value, and such a mutation must count as a change below just as if
+        // the value had been replaced.
+        //
+        auto typeBeforeLegalize = inst->getFullType();
+
         LegalVal legalVal = legalizeInst(context, inst);
         registerLegalizedValue(context, inst, legalVal);
 
@@ -3903,7 +3911,7 @@ struct IRTypeLegalizationPass
         bool changed = true;
         if (legalVal.flavor == LegalVal::Flavor::simple)
         {
-            changed = legalVal.irValue != inst;
+            changed = legalVal.irValue != inst || inst->getFullType() != typeBeforeLegalize;
 
             // The resulting inst may be different from the one we added to the
             // worklist, so ensure that the appropriate flags are set.


### PR DESCRIPTION
## Motivation

Consider a compute shader whose body is a long chain of trivial operations — the shape produced by loop unrolling, aggressive inlining, or machine-generated code:

```hlsl
int acc = int(tid.x);
acc = acc * 1;
acc = acc + 2;
acc = acc ^ 3;
// ... N of these, each using the previous value ...
```

Compiling this scales ~O(N²) even though the module contains nothing to legalize: at N=4000 (one 4000-line function, one `RWStructuredBuffer`), `slangc -target spirv` takes 1166 ms on an M-series MacBook, with ~97% of the growth inside `IRTypeLegalizationPass` — which runs several times per compile (`legalizeExistentialTypeLayout`, `legalizeResourceTypes`, `legalizeEmptyTypes` in `linkAndOptimizeIR`, plus per-backend runs, e.g. `legalizeIRForSPIRV → legalizeEmptyTypes` for SPIRV and all three again for WGSL/Metal). The compile-perf complexity sweep measures the effect as ∝N^1.8–2.0 across the ir_builder, codegen_spirv, emit_wgsl and emit_metal ladders. Full analysis in #12040.

## Proposed solution

`IRTypeLegalizationPass::processModule` drains a dependency-ordered worklist in rounds. After legalizing an instruction, `processInst` walked the instruction's use list and children and re-added **every** user/child via `maybeAddToWorkList` — including instructions already legalized in earlier rounds (the per-round reset of the "added" scratch bit permits the re-add, and the persistent "processed" bit satisfies the operand-readiness checks). Each round therefore re-legalized nearly everything the previous rounds had done, and on a straight-line dependence chain the ready-frontier advances only one instruction per round: O(N) rounds × O(prefix) work ≈ N²/2, plus a full-module `resetScratchDataBit` walk per round.

The revisit exists for one reason: within a round, a user U can be processed *before* its operand X (U's readiness checks pass on X's add-time bit), so U's legalization consults a mapping for X that is not registered yet. If X's legalization then *changes* X, U must be re-processed against the new mapping. But when X's legalization leaves it unchanged — `LegalVal::Flavor::simple` returning X itself — U's earlier result consulted a default identity mapping that is exactly what registration produced, so revisiting U (and every other already-queued user) is pure waste.

The fix makes that distinction: when the legalized value is unchanged, only queue users/children that have **never** been queued (the normal dependency unlock, gated on `hasBeenAddedToWorkListOrProcessed`); when it changed, requeue unconditionally exactly as before. With nothing to legalize, every instruction is now processed exactly once and the round count collapses to ~nesting depth, which also neutralizes the per-round `resetScratchDataBit` walk without touching it.

## Change summary

| File | Change |
| --- | --- |
| `source/slang/slang-ir-legalize-types.cpp` | `IRTypeLegalizationPass::processInst`: compute whether legalization changed the instruction's value; gate the user/child requeue on `changed \|\| !hasBeenAddedToWorkListOrProcessed(...)`. Comment documents the invariant. |

## Concepts and vocabulary

- **Two scratch bits**: `kHasBeenAddedScratchBitIndex` ("added this round", reset by `processModule` each round) and `kHasBeenAddedOrProcessedScratchBitIndex` (persistent). `hasBeenAddedToWorkListOrProcessed` tests either — i.e. "was ever queued".
- **`LegalVal::Flavor::simple`**: legalization result that is a plain single value; `simple` with the same `irValue` as the input means the instruction needed no legalization. All other flavors (tuple, pair, …) mean the value's representation changed.
- **Round**: one iteration of `processModule`'s `while` loop over a moved-out copy of the worklist; adds during a round land in the next round.

## Process report

**Root cause location.** Verified by profiling (macOS `sample`) the sweep ladders at two build points. After #11954 (the analogous simplifyIR fix), ~90% of remaining super-linear samples sit in this pass, split ~55% `processInst`/`maybeAddToWorkList`/`registerLegalizedValue`/`legalizeInst` internals (the re-processing) and ~45% `resetScratchDataBit` (the per-round module walk whose round count the re-processing inflates). All four fast-growing buckets of the sweep's ir_builder ladder decompose to executions of this one pass (two named legalize buckets + `legalizeEmptyTypes` hiding in `linkAndOptimizeIR (self)` and in `generateOutput (self)` via `legalizeIRForSPIRV`).

**Input-shape check.** The requeue-everything behavior is not a representation issue to fix upstream: the worklist bookkeeping itself is the producer of the redundant work. The one input shape that genuinely requires revisiting — user processed before its operand within a round, operand's value then changed — is preserved verbatim (`changed == true` path is byte-for-byte the old behavior). The skip applies only when the operand's registered mapping is the identity that the user's earlier processing already assumed.

**Why not a bigger restructure.** Gating readiness on a processed-time bit (instead of add-time) would give exactly-once processing without any revisit logic, but risks deadlock on operand cycles that the current add-time gating tolerates (the code already special-cases `IRInterfaceRequirementEntry` cycles). The change-gate is minimal and preserves the existing fixpoint semantics for every changed-value path.

**Perf verification** (macOS arm64 Release, warm, `-target spirv` unless noted):

| workload | before | after |
| --- | --- | --- |
| ir_builder N=1000/2000/4000 | 186/406/1166 ms | 126/135/155 ms (linear) |
| codegen N=200/400/800 (wgsl) | 305/846/2670 ms | 202/478/1525 ms |
| loop_unroll N=150/300/600 | 314/414/1303 ms | 175/333/943 ms |

codegen-wgsl and loop_unroll retain known separate super-linear mechanisms (#12040 lists them); the legalization share is gone.

**Correctness verification.** A/B against unmodified master at `824e24f267` on the same machine: `tests/compute/` full suite — failure lists byte-identical (100 failures, all the locally-broken `syn (llvm)` backend, all reproduce on baseline). `tests/language-feature/ tests/ir/ tests/bugs/` with the fix: 382 failures, 381 `syn (llvm)` plus one `syn (mtl)` (`dynamic-dispatch/derived-interface.slang`) — both verified to fail identically on the unmodified baseline. Net: zero behavior change across ~2,400 executed tests, including the associated-type/existential/dynamic-dispatch tests that exercise real legalization work.

**No new test file.** This is a pure performance fix with no behavior change to test via `.slang` semantics; the regression gate is the compile-perf complexity sweep (#12023), whose ir_builder/codegen_spirv/emit_wgsl/emit_metal ladders should drop from ∝N^1.8–2.0 toward linear.

Fixes #12040.