### PR TITLE
[devin-review-only] docs: no-op probe for review tooling (draft, do not merge)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,3 +33,5 @@ The Slang project is based on a long history of research work. While understandi
 
 A [paper](http://graphics.cs.cmu.edu/projects/slang/) on the Slang system was accepted into SIGGRAPH 2018, and it provides an overview of the language and the compiler implementation.
 Yong He's [dissertation](http://graphics.cs.cmu.edu/projects/renderergenerator/yong_he_thesis.pdf) provided more detailed discussion of the design of the Slang system.
+
+<!-- devin-review tooling probe (R0): no-op docs edit; draft, do not merge. -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,3 +35,5 @@ A [paper](http://graphics.cs.cmu.edu/projects/slang/) on the Slang system was ac
 Yong He's [dissertation](http://graphics.cs.cmu.edu/projects/renderergenerator/yong_he_thesis.pdf) provided more detailed discussion of the design of the Slang system.
 
 <!-- devin-review tooling probe (R0): no-op docs edit; draft, do not merge. -->
+
+<!-- devin-review tooling probe (R1): second no-op edit to trigger re-analysis. -->


### PR DESCRIPTION
**Draft — do not merge. Review-tooling probe.**

Trivial docs-only edit (one comment line in `docs/README.md`) opened to give Devin Review a live PR to analyze while validating fixes to the `slang-pr-review-runner` `devin-fetch.sh` scraper — specifically the R0→R1 follow-up-commit refresh path, capture of Devin "Informational" findings, transient Chrome-launch retry, and lingering-"in progress" done-detection. No code or behavior change. Will be closed once tooling verification completes.
