### PR TITLE
Apply AVX-512 JIT workaround to all CI tests

### DIFF
--- a/.github/workflows/ci-slang-coverage-test.yml
+++ b/.github/workflows/ci-slang-coverage-test.yml
@@ -58,6 +58,10 @@ jobs:
 
     env:
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
+      # LLVM can mis-report AVX-512 support on virtual machines, as observed on
+      # both GitHub-hosted and GCP VMs. Apply the workaround to every coverage
+      # platform so all slang-llvm JIT test processes inherit it (#11062).
+      SLANG_DISABLE_AVX512: "1"
 
     defaults:
       run:
@@ -234,13 +238,6 @@ jobs:
           # Set SPIRV validation environment variables (same as regular CI)
           export SLANG_RUN_SPIRV_VALIDATION=1
           export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1
-
-          # Match regular CPU-only CI's #11062 mitigation. Linux coverage runs
-          # CPU/LLVM and synthesized LLVM test paths on GitHub-hosted runners,
-          # so it can hit the same slang-llvm JIT AVX-512 SIGILL.
-          if [[ "${{ inputs.os }}" == "linux" ]]; then
-            export SLANG_DISABLE_AVX512=1
-          fi
 
           # Build slang-test arguments (same as regular CI)
           test_args=(

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -87,15 +87,16 @@ jobs:
           if [[ "${{ inputs.cpu-only }}" != "true" && "${{ inputs.enable-debug-layers }}" == "true" ]]; then
             export VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation
           fi
-          # Force AVX-512 off in slang-llvm's JIT TargetMachine. The cpu-only
-          # tier runs on GitHub-hosted Azure VMs that intermittently mis-report
-          # AVX-512 support to LLVM's host-detection path, then SIGILL when
-          # the JIT-emitted kmovd / vmovss-with-mask actually executes (#11062).
+          # Force AVX-512 off in slang-llvm's JIT TargetMachine. We have observed
+          # intermittent illegal-instruction failures on both GitHub-hosted and
+          # GCP VMs, indicating that LLVM's host-detection path can mis-report
+          # AVX-512 support on virtual machines generally. Apply the workaround
+          # to every test tier so JIT-emitted kmovd / vmovss-with-mask instructions
+          # cannot fault when the reported features exceed the host capabilities
+          # (#11062).
           # Drop this once the LLVM 22 bump (#11017) fixes the underlying
           # detection.
-          if [[ "${{ inputs.cpu-only }}" == "true" ]]; then
-            export SLANG_DISABLE_AVX512=1
-          fi
+          export SLANG_DISABLE_AVX512=1
           # Build common slang-test arguments
           slang_test_args=(
             "-expected-failure-list" "tests/expected-failure-github.txt"


### PR DESCRIPTION
## Motivation

The `SLANG_DISABLE_AVX512` workaround introduced for #11062 was limited to the Linux CPU-only
test tier and Linux coverage. We have since observed the same intermittent illegal-instruction
failure on GCP-hosted test machines, including Windows runners.

Consider a Slang LLVM test running in a virtual machine: LLVM's host-detection path reports
AVX-512 support, the JIT emits an instruction such as `kmovd` or a masked `vmovss`, and the
physical host rejects that instruction. `slang-test` then terminates with `SIGILL` on Linux or
`EXCEPTION_ILLEGAL_INSTRUCTION` on Windows. Because this has occurred with multiple VM providers,
restricting the workaround to one runner tier leaves other virtualized test jobs exposed.

## Proposed solution

Enable `SLANG_DISABLE_AVX512=1` for every regular Slang CI test tier and every coverage platform.
This keeps the mitigation at the existing CI opt-in boundary while covering all virtualized test
jobs. Production use remains unchanged, and `disableAVX512ForJIT` remains a no-op on non-x86_64
hosts.

For coverage, define the variable once at the job level instead of duplicating Bash and PowerShell
assignments. This gives every coverage test subprocess the same setting regardless of platform.

## Change summary

- `.github/workflows/ci-slang-test.yml` exports `SLANG_DISABLE_AVX512=1` unconditionally in the
  `Test Slang` step instead of limiting it to `inputs.cpu-only`.
- `.github/workflows/ci-slang-coverage-test.yml` defines `SLANG_DISABLE_AVX512=1` in the coverage
  job environment and removes the Linux-only conditional export.

## Concepts and vocabulary

- **JIT TargetMachine** — LLVM's target description for generated machine code. The existing
  `disableAVX512ForJIT` helper replaces its detected CPU with the baseline `x86-64` CPU when the
  workaround is enabled.
- **Test tier** — one regular CI test configuration, such as CPU-only or a platform-specific GPU
  runner. Coverage jobs use a separate reusable workflow and therefore need the same setting.

## Process report

The existing source-side mitigation is already centralized in
`source/slang-llvm/slang-llvm-jit-shared-library.cpp::disableAVX512ForJIT`. The failure is not a
malformed IR shape that should be repaired by a downstream pass; the JIT receives a valid module
but an unreliable virtualized-host feature report. The workflow is therefore the correct boundary
for opting affected test processes into the conservative JIT target.

In `.github/workflows/ci-slang-test.yml`, `Test Slang` previously exported the variable only when
`inputs.cpu-only` was true. That condition described the first affected GitHub-hosted Linux tier,
not an invariant of the failure. Removing it lets the same source-side helper protect Windows and
GCP-backed test tiers without adding platform-specific branches.

Coverage runs through `.github/workflows/ci-slang-coverage-test.yml`, so the regular test workflow
cannot propagate its export there. The old Bash block handled Linux only, while Windows runs in a
separate PowerShell step. Moving the variable to `jobs.coverage.env` makes the job configuration
the single source of truth and ensures both test launch paths inherit it. On macOS aarch64, the
helper checks the target architecture and returns without changing the JIT configuration.
