### PR TITLE
Fix ASan merge queue failures

### DIFF
--- a/.github/workflows/ci-slang-sanitizer.yml
+++ b/.github/workflows/ci-slang-sanitizer.yml
@@ -49,17 +49,23 @@ jobs:
       - name: Compute PR changed files
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
         run: |
-          if [ "$EVENT_NAME" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "merge_group" ]; then
+            if [ -z "$BASE_SHA" ]; then
+              echo "::error::The $EVENT_NAME event did not provide a base SHA"
+              exit 1
+            fi
             echo "Computing diff against PR base: $BASE_SHA"
             git diff --name-only "$BASE_SHA"...HEAD > /tmp/pr-changed-files.txt
             changed_count=$(wc -l < /tmp/pr-changed-files.txt)
             echo "PR touches $changed_count file(s)"
             cat /tmp/pr-changed-files.txt
+            echo "HAS_PR_CHANGED_FILES=true" >> "$GITHUB_ENV"
           else
             echo "Not a PR event -- all sanitizer findings will be treated as errors"
             : > /tmp/pr-changed-files.txt
+            echo "HAS_PR_CHANGED_FILES=false" >> "$GITHUB_ENV"
           fi
 
       - name: Authenticate to Google Cloud
@@ -174,8 +180,13 @@ jobs:
           int main(void) { volatile int *p = (int*)malloc(sizeof(int)); free((void*)p); return *p; }
           CANARY
           export ASAN_OPTIONS="log_path=/tmp/canary"
-          clang-18 -fsanitize=address -O0 /tmp/asan-canary.c -o /tmp/asan-canary
-          /tmp/asan-canary || true
+          ASAN_RUNTIME=$(clang-18 -print-file-name=libclang_rt.asan-x86_64.so)
+          if [ ! -f "$ASAN_RUNTIME" ]; then
+            echo "::error::Clang shared ASan runtime not found: $ASAN_RUNTIME"
+            exit 1
+          fi
+          clang-18 -fsanitize=address -shared-libsan -O0 /tmp/asan-canary.c -o /tmp/asan-canary
+          LD_PRELOAD="$ASAN_RUNTIME${LD_PRELOAD:+:$LD_PRELOAD}" /tmp/asan-canary || true
           if ls /tmp/canary.* 1>/dev/null 2>&1; then
             echo "Sanitizer runtime verified: log files produced"
           else
@@ -195,6 +206,16 @@ jobs:
           export ASAN_OPTIONS="detect_leaks=1:halt_on_error=0:print_scariness=1:log_path=$PWD/asan-logs/asan"
           export UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0:print_suppressions=0:log_path=$PWD/asan-logs/ubsan"
           export LSAN_OPTIONS="suppressions=$PWD/cmake/lsan-suppressions.txt"
+
+          # CPU tests launch generated host programs that are not themselves
+          # ASan-linked. Preload the shared runtime so those programs load it
+          # before instrumented Slang libraries inherited from this build.
+          ASAN_RUNTIME=$(clang-18 -print-file-name=libclang_rt.asan-x86_64.so)
+          if [ ! -f "$ASAN_RUNTIME" ]; then
+            echo "::error::Clang shared ASan runtime not found: $ASAN_RUNTIME"
+            exit 1
+          fi
+          export LD_PRELOAD="$ASAN_RUNTIME${LD_PRELOAD:+:$LD_PRELOAD}"
 
           export SLANG_RUN_SPIRV_VALIDATION=1
           export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1
@@ -298,10 +319,7 @@ jobs:
             expected_files=""
             pr_related_files=""
             preexisting_files=""
-            has_pr_changed_files=false
-            if [ -s /tmp/pr-changed-files.txt ]; then
-              has_pr_changed_files=true
-            fi
+            has_pr_changed_files=${HAS_PR_CHANGED_FILES:-false}
 
             while IFS= read -r f; do
               # Check if all findings in this log are expected.

--- a/.github/workflows/ci-slang-sanitizer.yml
+++ b/.github/workflows/ci-slang-sanitizer.yml
@@ -61,11 +61,9 @@ jobs:
             changed_count=$(wc -l < /tmp/pr-changed-files.txt)
             echo "PR touches $changed_count file(s)"
             cat /tmp/pr-changed-files.txt
-            echo "HAS_PR_CHANGED_FILES=true" >> "$GITHUB_ENV"
           else
             echo "Not a PR event -- all sanitizer findings will be treated as errors"
             : > /tmp/pr-changed-files.txt
-            echo "HAS_PR_CHANGED_FILES=false" >> "$GITHUB_ENV"
           fi
 
       - name: Authenticate to Google Cloud
@@ -319,7 +317,10 @@ jobs:
             expected_files=""
             pr_related_files=""
             preexisting_files=""
-            has_pr_changed_files=${HAS_PR_CHANGED_FILES:-false}
+            has_pr_changed_files=false
+            if [ -s /tmp/pr-changed-files.txt ]; then
+              has_pr_changed_files=true
+            fi
 
             while IFS= read -r f; do
               # Check if all findings in this log are expected.

--- a/.github/workflows/ci-slang-sanitizer.yml
+++ b/.github/workflows/ci-slang-sanitizer.yml
@@ -205,9 +205,9 @@ jobs:
           export UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0:print_suppressions=0:log_path=$PWD/asan-logs/ubsan"
           export LSAN_OPTIONS="suppressions=$PWD/cmake/lsan-suppressions.txt"
 
-          # CPU tests launch generated host programs that are not themselves
-          # ASan-linked. Resolve the runtime here, then preload it only for the
-          # CPU test pass below.
+          # //TEST:EXECUTABLE: cases launch generated host programs that are not
+          # themselves ASan-linked. Resolve the runtime here so slang-test can
+          # preload it only when executing those programs.
           ASAN_RUNTIME=$(clang-18 -print-file-name=libclang_rt.asan-x86_64.so)
           if [ ! -f "$ASAN_RUNTIME" ]; then
             echo "::error::Clang shared ASan runtime not found: $ASAN_RUNTIME"
@@ -240,36 +240,19 @@ jobs:
             slang_test_args+=("-server-count" "$SERVER_COUNT")
           fi
 
-          non_cpu_test_args=("${slang_test_args[@]}" "-api" "-cpu")
-
           # Print the fully-resolved command so the CI log shows exactly which
           # arguments were used (the conditional logic only shows the source).
           printf '+ %q' "$bin_dir/slang-test"
-          printf ' %q' "${non_cpu_test_args[@]}"
+          printf ' %q' "${slang_test_args[@]}"
           printf '\n'
 
           # Non-zero exits are expected (sanitizer errors, test failures); this
           # job gates only on sanitizer log output in the Summary step.
-          "$bin_dir/slang-test" "${non_cpu_test_args[@]}" && non_cpu_test_exit=0 || non_cpu_test_exit=$?
-
-          # Preloading ASan for the entire suite also injects it into uninstrumented
-          # GCC and linker subprocesses, causing their process-lifetime allocations
-          # to appear as leaks. Keep leak detection enabled above, but disable it for
-          # this CPU-only pass where preloading is required. ASan memory checks and
-          # UBSan checks remain active.
-          cpu_test_args=("${slang_test_args[@]}" "-api" "cpu" "-api-only")
-          printf '+ %q' "$bin_dir/slang-test"
-          printf ' %q' "${cpu_test_args[@]}"
-          printf '\n'
-          cpu_asan_options=${ASAN_OPTIONS/detect_leaks=1/detect_leaks=0}
-          ASAN_OPTIONS="$cpu_asan_options" \
-            LD_PRELOAD="$ASAN_RUNTIME${LD_PRELOAD:+:$LD_PRELOAD}" \
-            "$bin_dir/slang-test" "${cpu_test_args[@]}" && cpu_test_exit=0 || cpu_test_exit=$?
-
-          slang_test_exit=$non_cpu_test_exit
-          if [ "$slang_test_exit" -eq 0 ]; then
-            slang_test_exit=$cpu_test_exit
-          fi
+          # Keep LD_PRELOAD out of slang-test's environment so uninstrumented
+          # compiler and linker subprocesses do not produce LeakSanitizer noise.
+          # slang-test converts this value to LD_PRELOAD only for generated executables.
+          SLANG_TEST_EXECUTABLE_LD_PRELOAD="$ASAN_RUNTIME${LD_PRELOAD:+:$LD_PRELOAD}" \
+            "$bin_dir/slang-test" "${slang_test_args[@]}" && slang_test_exit=0 || slang_test_exit=$?
           echo "SLANG_TEST_EXIT=$slang_test_exit" >> "$GITHUB_ENV"
           if [ "$slang_test_exit" -ne 0 ]; then
             echo "::warning::slang-test exited with code $slang_test_exit"

--- a/.github/workflows/ci-slang-sanitizer.yml
+++ b/.github/workflows/ci-slang-sanitizer.yml
@@ -206,14 +206,13 @@ jobs:
           export LSAN_OPTIONS="suppressions=$PWD/cmake/lsan-suppressions.txt"
 
           # CPU tests launch generated host programs that are not themselves
-          # ASan-linked. Preload the shared runtime so those programs load it
-          # before instrumented Slang libraries inherited from this build.
+          # ASan-linked. Resolve the runtime here, then preload it only for the
+          # CPU test pass below.
           ASAN_RUNTIME=$(clang-18 -print-file-name=libclang_rt.asan-x86_64.so)
           if [ ! -f "$ASAN_RUNTIME" ]; then
             echo "::error::Clang shared ASan runtime not found: $ASAN_RUNTIME"
             exit 1
           fi
-          export LD_PRELOAD="$ASAN_RUNTIME${LD_PRELOAD:+:$LD_PRELOAD}"
 
           export SLANG_RUN_SPIRV_VALIDATION=1
           export SLANG_USE_SPV_SOURCE_LANGUAGE_UNKNOWN=1
@@ -241,15 +240,36 @@ jobs:
             slang_test_args+=("-server-count" "$SERVER_COUNT")
           fi
 
+          non_cpu_test_args=("${slang_test_args[@]}" "-api" "-cpu")
+
           # Print the fully-resolved command so the CI log shows exactly which
           # arguments were used (the conditional logic only shows the source).
           printf '+ %q' "$bin_dir/slang-test"
-          printf ' %q' "${slang_test_args[@]}"
+          printf ' %q' "${non_cpu_test_args[@]}"
           printf '\n'
 
           # Non-zero exits are expected (sanitizer errors, test failures); this
           # job gates only on sanitizer log output in the Summary step.
-          "$bin_dir/slang-test" "${slang_test_args[@]}" && slang_test_exit=0 || slang_test_exit=$?
+          "$bin_dir/slang-test" "${non_cpu_test_args[@]}" && non_cpu_test_exit=0 || non_cpu_test_exit=$?
+
+          # Preloading ASan for the entire suite also injects it into uninstrumented
+          # GCC and linker subprocesses, causing their process-lifetime allocations
+          # to appear as leaks. Keep leak detection enabled above, but disable it for
+          # this CPU-only pass where preloading is required. ASan memory checks and
+          # UBSan checks remain active.
+          cpu_test_args=("${slang_test_args[@]}" "-api" "cpu" "-api-only")
+          printf '+ %q' "$bin_dir/slang-test"
+          printf ' %q' "${cpu_test_args[@]}"
+          printf '\n'
+          cpu_asan_options=${ASAN_OPTIONS/detect_leaks=1/detect_leaks=0}
+          ASAN_OPTIONS="$cpu_asan_options" \
+            LD_PRELOAD="$ASAN_RUNTIME${LD_PRELOAD:+:$LD_PRELOAD}" \
+            "$bin_dir/slang-test" "${cpu_test_args[@]}" && cpu_test_exit=0 || cpu_test_exit=$?
+
+          slang_test_exit=$non_cpu_test_exit
+          if [ "$slang_test_exit" -eq 0 ]; then
+            slang_test_exit=$cpu_test_exit
+          fi
           echo "SLANG_TEST_EXIT=$slang_test_exit" >> "$GITHUB_ENV"
           if [ "$slang_test_exit" -ne 0 ]; then
             echo "::warning::slang-test exited with code $slang_test_exit"

--- a/tests/cpu-program/odd-sized-buffer-init.slang
+++ b/tests/cpu-program/odd-sized-buffer-init.slang
@@ -1,7 +1,8 @@
 //TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 
-// The render-test host stores initialization data in uint32_t words. This 142-byte buffer exceeds
-// List's initial capacity and checks that the final partial word is present when the RHI copies it.
+// List's initial capacity is 16 uint32_t words (64 bytes). This 142-byte buffer therefore forces
+// the old code to allocate only 35 words (140 bytes), so ASan detects the RHI's two-byte over-read;
+// the shader checks alone cannot observe this host-side allocation bug.
 //TEST_INPUT:ubuffer(data=[0], count=71, stride=2):out,name=outputBuffer
 RWStructuredBuffer<uint16_t> outputBuffer;
 

--- a/tests/cpu-program/odd-sized-buffer-init.slang
+++ b/tests/cpu-program/odd-sized-buffer-init.slang
@@ -1,8 +1,8 @@
 //TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
 
-// The render-test host stores initialization data in uint32_t words. This six-byte buffer checks
-// that the final partial word is present when the RHI copies the exact logical buffer size.
-//TEST_INPUT:ubuffer(data=[0], count=3, stride=2):out,name=outputBuffer
+// The render-test host stores initialization data in uint32_t words. This 142-byte buffer exceeds
+// List's initial capacity and checks that the final partial word is present when the RHI copies it.
+//TEST_INPUT:ubuffer(data=[0], count=71, stride=2):out,name=outputBuffer
 RWStructuredBuffer<uint16_t> outputBuffer;
 
 [numthreads(1, 1, 1)]

--- a/tests/cpu-program/odd-sized-buffer-init.slang
+++ b/tests/cpu-program/odd-sized-buffer-init.slang
@@ -1,0 +1,18 @@
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type
+
+// The render-test host stores initialization data in uint32_t words. This six-byte buffer checks
+// that the final partial word is present when the RHI copies the exact logical buffer size.
+//TEST_INPUT:ubuffer(data=[0], count=3, stride=2):out,name=outputBuffer
+RWStructuredBuffer<uint16_t> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    // CHECK: type: uint16_t
+    outputBuffer[0] = 1;
+    // CHECK-NEXT: 1
+    outputBuffer[1] = 2;
+    // CHECK-NEXT: 2
+    outputBuffer[2] = 3;
+    // CHECK-NEXT: 3
+}

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -494,7 +494,8 @@ struct AssignValsFromLayoutContext
         const size_t bufferSize = Math::Max(
             (size_t)bufferData.getCount() * sizeof(uint32_t),
             (size_t)(srcBuffer.elementCount * srcBuffer.stride));
-        // The RHI copies bufferSize bytes, so keep the final partial word initialized too.
+        // Round the backing storage up to a complete word because the RHI copies bufferSize bytes,
+        // including the final partial word.
         const size_t wordSize = sizeof(uint32_t);
         const size_t bufferWordCount = bufferSize / wordSize + (bufferSize % wordSize != 0);
         bufferData.reserve(bufferWordCount);

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -494,8 +494,11 @@ struct AssignValsFromLayoutContext
         const size_t bufferSize = Math::Max(
             (size_t)bufferData.getCount() * sizeof(uint32_t),
             (size_t)(srcBuffer.elementCount * srcBuffer.stride));
-        bufferData.reserve(bufferSize / sizeof(uint32_t));
-        for (size_t i = bufferData.getCount(); i < bufferSize / sizeof(uint32_t); i++)
+        // The RHI copies bufferSize bytes, so keep the final partial word initialized too.
+        const size_t wordSize = sizeof(uint32_t);
+        const size_t bufferWordCount = bufferSize / wordSize + (bufferSize % wordSize != 0);
+        bufferData.reserve(bufferWordCount);
+        for (size_t i = bufferData.getCount(); i < bufferWordCount; i++)
             bufferData.add(0);
 
         ComPtr<IBuffer> bufferResource;

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -2031,6 +2031,39 @@ static SlangResult _createArtifactFromHexDump(
     return SLANG_OK;
 }
 
+static SlangResult _executeBinaryFile(const UnownedStringSlice& fileName, ExecuteResult& outExeRes)
+{
+    CommandLine cmdLine;
+
+#if SLANG_LINUX_FAMILY
+    // Consider a //TEST:EXECUTABLE: case in sanitizer CI. slangc first invokes an
+    // uninstrumented host compiler to produce the binary, and slang-test then runs it.
+    // Applying LD_PRELOAD to slang-test would also inject the sanitizer into the compiler
+    // and linker. Keep the requested value inert until this exact execution boundary instead.
+    StringBuilder preloadValue;
+    if (SLANG_SUCCEEDED(PlatformUtil::getEnvironmentVariable(
+            UnownedStringSlice("SLANG_TEST_EXECUTABLE_LD_PRELOAD"),
+            preloadValue)) &&
+        preloadValue.getLength())
+    {
+        cmdLine.setExecutableLocation(ExecutableLocation("env"));
+
+        StringBuilder preloadAssignment;
+        preloadAssignment << "LD_PRELOAD=" << preloadValue;
+        cmdLine.addArg(preloadAssignment.produceString());
+        cmdLine.addArg(fileName);
+
+        return ProcessUtil::execute(cmdLine, outExeRes);
+    }
+#endif
+
+    ExecutableLocation exe;
+    exe.setPath(fileName);
+    cmdLine.setExecutableLocation(exe);
+
+    return ProcessUtil::execute(cmdLine, outExeRes);
+}
+
 static SlangResult _executeBinary(const UnownedStringSlice& hexDump, ExecuteResult& outExeRes)
 {
     ComPtr<IArtifact> artifact;
@@ -2046,15 +2079,7 @@ static SlangResult _executeBinary(const UnownedStringSlice& hexDump, ExecuteResu
     SLANG_RETURN_ON_FAIL(artifact->requireFile(ArtifactKeep::Yes, fileRep.writeRef()));
 
     const auto fileName = fileRep->getPath();
-
-    // Execute it
-    ExecutableLocation exe;
-    exe.setPath(fileName);
-
-    CommandLine cmdLine;
-    cmdLine.setExecutableLocation(exe);
-
-    return ProcessUtil::execute(cmdLine, outExeRes);
+    return _executeBinaryFile(UnownedStringSlice(fileName), outExeRes);
 }
 
 static bool _areDiagnosticsEqual(const UnownedStringSlice& a, const UnownedStringSlice& b)
@@ -2277,15 +2302,8 @@ TestResult runExecutableTest(TestContext* context, TestInput& input)
     else
     {
         // Execute the binary and see what we get
-        CommandLine cmdLine;
-
-        ExecutableLocation exe;
-        exe.setPath(moduleExePath);
-
-        cmdLine.setExecutableLocation(exe);
-
         ExecuteResult exeRes;
-        if (SLANG_FAILED(ProcessUtil::execute(cmdLine, exeRes)))
+        if (SLANG_FAILED(_executeBinaryFile(moduleExePath.getUnownedSlice(), exeRes)))
         {
             return TestResult::Fail;
         }


### PR DESCRIPTION
Fixes #11833.

## Motivation

Recent merge-queue runs repeatedly failed the sanitizer job even though the corresponding PR-head
sanitizer job passed. The failure looked like an ASan runtime setup problem, but the sanitizer logs
contained a concrete heap-buffer-overflow in the render-test host.

Consider the buffer shape that exposed it:

```slang
//TEST_INPUT:ubuffer(data=[0], count=71, stride=2):out,name=outputBuffer
RWStructuredBuffer<uint16_t> outputBuffer;
```

This declares a 142-byte buffer. `AssignValsFromLayoutContext::assignBuffer` stores initialization
data in a `List<uint32_t>`, but padded that list with `bufferSize / sizeof(uint32_t)`. Integer
division produced 35 words, or 140 bytes. `ShaderRendererUtil::createBuffer` then correctly passed
the 142-byte logical size to the RHI, and the CPU RHI's `DeviceImpl::createBuffer` copied 142 bytes
from the 140-byte source. ASan therefore reported a two-byte read past the host allocation.

The same finding passed on a PR-head run because its stack frames were outside that PR's changed
files. A `merge_group` event has no `pull_request` payload, however, so the sanitizer workflow
created an empty changed-file list and deliberately treated every finding as PR-related. That made
the existing finding block the merge queue. Separately, generated CPU host programs loaded
instrumented Slang libraries without loading the shared ASan runtime first, producing the loader
ordering diagnostic seen in the same logs.

## Proposed solution

Round only the host initialization storage up to a complete `uint32_t` word. The RHI resource keeps
its exact logical byte size, while its source allocation is large enough for the exact-size copy.
This fixes the producer of the invalid source span instead of weakening the RHI copy or accepting
the sanitizer finding.

Teach the sanitizer workflow to derive changed files from `merge_group.base_sha` as well as the PR
base SHA. Preserve the existing attribution policy for both event types, while continuing to treat
all findings as errors for events without a PR changeset. Finally, run the canary with the same
shared ASan runtime used by Slang and pass that runtime to `slang-test` without setting
`LD_PRELOAD` on the test runner. `slang-test` applies the preload only when it launches a generated
host executable, so those programs inherit a valid loader order without injecting LeakSanitizer
into unrelated compiler subprocesses.

## Change summary

- `AssignValsFromLayoutContext::assignBuffer` in `tools/render-test/render-test-main.cpp:494`
  rounds the initialization word count up without changing `bufferSize`.
- `tests/cpu-program/odd-sized-buffer-init.slang:1` covers a 142-byte buffer whose old 35-word
  backing allocation was two bytes short.
- `.github/workflows/ci-slang-sanitizer.yml:49` computes changed files for both `pull_request` and
  `merge_group` while retaining the existing strict classification for an empty changed-file list.
- `.github/workflows/ci-slang-sanitizer.yml:176` checks the shared sanitizer runtime configuration;
  the test step at `:201` keeps the existing single full-suite invocation and supplies the runtime
  through `SLANG_TEST_EXECUTABLE_LD_PRELOAD`.
- `tools/slang-test/slang-test-main.cpp:2034` converts that value to `LD_PRELOAD` only at the
  generated-executable launch boundary.

## Concepts and vocabulary

- **Logical buffer size** — the exact byte count described to the RHI, such as 142 bytes for 71
  two-byte elements.
- **Initialization backing storage** — the host `List<uint32_t>` whose bytes are copied into the
  RHI buffer. It may be rounded up internally, but that padding is not part of the logical buffer.
- **Merge-group base SHA** — the parent commit recorded in the `merge_group` event. Diffing it
  against the checked-out merge-group head yields the queued PR changes being validated.
- **Shared ASan runtime** — `libclang_rt.asan-x86_64.so`, selected by `-shared-libsan`. It must be
  available through `LD_LIBRARY_PATH` and loaded before instrumented shared libraries.
- **Generated host executable** — a standalone CPU binary produced by a `//TEST:EXECUTABLE:` case.
  It is compiled by a downstream host compiler and then launched by `slang-test`.

## Process report

The source-side fix starts from the valid odd-sized input shape rather than treating it as an RHI
special case. In `AssignValsFromLayoutContext::assignBuffer`, `count=71, stride=2` produces the
correct logical `bufferSize` of 142. The old floor division allocated 140 source bytes. The new
word-count calculation adds one word whenever `bufferSize` has a remainder, producing 144 source
bytes. `ShaderRendererUtil::createBuffer` still receives 142, and
`rhi::cpu::DeviceImpl::createBuffer` still copies exactly the declared 142 bytes. The source span is
now valid, and no downstream consumer needs knowledge of the host's word-packed representation.
Padding the logical RHI buffer to 144 bytes was rejected because it would change the resource shape
to compensate for a host allocation bug. Allowlisting the ASan summary was rejected because the
reported over-read was real.

The regression test uses `count=71, stride=2`. Its 142-byte logical size exceeds `List`'s initial
16-word capacity, so the old 35-word count produced a 140-byte heap allocation and made ASan observe
the two-byte over-read. A smaller input could remain inside `List`'s larger initial allocation and
therefore would not exercise the memory error. The shader writes and checks the first three values
to confirm that preserving the exact logical size does not change buffer behavior.

The attribution fix lives at the event boundary in `ci-slang-sanitizer.yml`. Both a PR and a merge
group intentionally represent proposed PR changes, and both provide a base SHA suitable for the
existing path-based classification. The summary retains the original file-size check, so a PR or
merge group with an empty changed-file list continues to treat every unexpected finding as an
error. Pushes and scheduled runs retain that same strict policy.

The loader-order fix keeps the sanitizer suite as one `slang-test` invocation. Slang binaries use
`-shared-libsan`, so the canary exercises that same form instead of Clang's default static runtime.
The workflow resolves the shared runtime and passes its path as
`SLANG_TEST_EXECUTABLE_LD_PRELOAD`, which has no loader meaning by itself. A
`//TEST:EXECUTABLE:` case first runs `slangc`, which invokes an uninstrumented downstream compiler
and linker. Those processes inherit only the inert variable, so they are not accidentally
instrumented. When `runExecutableTest` reaches the generated binary, `_executeBinaryFile` launches
it through `env LD_PRELOAD=<runtime> <binary>`. The runtime is therefore first in that binary's
loader order, while the existing `detect_leaks=1` setting remains active for the entire suite.

The generated-executable launch is the correct ownership boundary because `slang-test` already
owns both the production and execution of that valid standalone binary. The helper does not change
the generated program or rebuild a semantic representation; it only supplies the runtime required
by the instrumented libraries at process creation. Applying `LD_PRELOAD` to the test runner was
rejected after the first PR run produced 52 LeakSanitizer reports for uninstrumented GCC and linker
processes. A second CPU-only test pass was then tried, but removed at reviewer request. Suppressing
or reclassifying the external-tool leaks was rejected because the workflow itself created them,
and disabling ASan's link-order verification was rejected because that would hide incomplete
sanitizer interception rather than establishing a valid process layout.

## Reviewer Directives (maintained by agent)

- [human @jkwak-work] Close #11833 from this PR.
  (https://github.com/shader-slang/slang/pull/12060#issuecomment-4940862293)
- [human @jkwak-work] Do not add a separate sanitizer test pass for now.
  (https://github.com/shader-slang/slang/pull/12060#discussion_r3571848008)
