### PR TITLE
Skip GLSL simplification when inlining makes no changes

### DIFF
--- a/source/slang/slang-ir-glsl-legalize.cpp
+++ b/source/slang/slang-ir-glsl-legalize.cpp
@@ -5147,6 +5147,15 @@ void legalizeConstantBufferLoadForGLSL(IRModule* module)
                         builder.setInsertBefore(load);
                         for (auto field : elementType->getFields())
                         {
+                            if (as<IRVoidType>(field->getFieldType()))
+                            {
+                                // The `cleanUpVoidType` IR pass will remove this field and operand.
+                                // Use the canonical void value to avoid creating a field-address
+                                // and load chain that would otherwise require dead-code
+                                // elimination.
+                                elements.add(builder.getVoidValue());
+                                continue;
+                            }
                             auto fieldAddr = builder.emitFieldAddress(
                                 builder.getPtrType(field->getFieldType()),
                                 load->getPtr(),

--- a/source/slang/slang-ir-inline.cpp
+++ b/source/slang/slang-ir-inline.cpp
@@ -1322,7 +1322,8 @@ void performGLSLResourceReturnFunctionInlining(IRModule* module, TargetProgram* 
     while (changed)
     {
         changed = pass.considerAllCallSites();
-        simplifyIR(module, nullptr, IRSimplificationOptions::getFast(targetProgram));
+        if (changed)
+            simplifyIR(module, nullptr, IRSimplificationOptions::getFast(targetProgram));
     }
 }
 


### PR DESCRIPTION
performGLSLResourceReturnFunctionInlining currently runs simplifyIR after every call-site scan, including scans that do not inline any calls. In that case there are no inlining results to clean up, and simplification does not lead to another scan.

Gating this call exposed that legalizeConstantBufferLoadForGLSL relied on the DCE performed by simplifyIR. It creates field-address and load chains for fields already lowered to void, which remain after the cleanUpVoidType IR pass removes those fields and operands.

Have legalizeConstantBufferLoadForGLSL use the canonical void value instead of loading void fields. cleanUpVoidType removes that value along with the field, avoiding the need for DCE. Run simplifyIR only after resource-return calls are inlined, so productive iterations still simplify before rescanning while unchanged modules avoid an unnecessary whole-module pass.