### PR TITLE
Make CoopVec vector and array constructors differentiable

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -31682,6 +31682,30 @@ extension<T : __BuiltinArithmeticType, let N : int> CoopVec<T, N>
 // The direct [Differentiable] annotation lets autodiff synthesize the constructor derivative.
 extension<T : __BuiltinFloatingPointType, let N : int> CoopVec<T, N>
 {
+    [ForceInline]
+    [require(cooperative_vector)]
+    [Differentiable]
+    __init(vector<T, N> value)
+    {
+        [ForceUnroll]
+        for (int i = 0; i < N; ++i)
+        {
+            this[i] = value[i];
+        }
+    }
+
+    [ForceInline]
+    [require(cooperative_vector)]
+    [Differentiable]
+    __init(T[N] value)
+    {
+        [ForceUnroll]
+        for (int i = 0; i < N; ++i)
+        {
+            this[i] = value[i];
+        }
+    }
+
     [OverloadRank(1)]
     [ForceInline]
     [require(cooperative_vector)]

--- a/tests/autodiff/coopvec.slang
+++ b/tests/autodiff/coopvec.slang
@@ -155,6 +155,38 @@
 // CHECK-NEXT: 10.000000
 // CHECK-NEXT: 100.000000
 // CHECK-NEXT: 1000.000000
+// CHECK-NEXT: 2.000000
+// CHECK-NEXT: 4.000000
+// CHECK-NEXT: 6.000000
+// CHECK-NEXT: 8.000000
+// CHECK-NEXT: 2.000000
+// CHECK-NEXT: 20.000000
+// CHECK-NEXT: 200.000000
+// CHECK-NEXT: 2000.000000
+// CHECK-NEXT: 2.000000
+// CHECK-NEXT: 4.000000
+// CHECK-NEXT: 6.000000
+// CHECK-NEXT: 8.000000
+// CHECK-NEXT: 2.000000
+// CHECK-NEXT: 20.000000
+// CHECK-NEXT: 200.000000
+// CHECK-NEXT: 2000.000000
+// CHECK-NEXT: 2.000000
+// CHECK-NEXT: 4.000000
+// CHECK-NEXT: 6.000000
+// CHECK-NEXT: 8.000000
+// CHECK-NEXT: 2.000000
+// CHECK-NEXT: 20.000000
+// CHECK-NEXT: 200.000000
+// CHECK-NEXT: 2000.000000
+// CHECK-NEXT: 2.000000
+// CHECK-NEXT: 4.000000
+// CHECK-NEXT: 6.000000
+// CHECK-NEXT: 8.000000
+// CHECK-NEXT: 2.000000
+// CHECK-NEXT: 20.000000
+// CHECK-NEXT: 200.000000
+// CHECK-NEXT: 2000.000000
 
 typealias FloatCoopVec4 = CoopVec<float, 4>;
 typealias DPFloatCoopVec4 = DifferentialPair<FloatCoopVec4>;
@@ -241,7 +273,22 @@ FloatCoopVec4 testNoDiffElementUpdates(FloatCoopVec4 x, no_diff float value)
     return x + result;
 }
 
-//TEST_INPUT:ubuffer(data=[0], stride=4, count=152):out,name=outputBuffer
+// Exercises the CoopVec constructor from a vector value in reverse and forward AD.
+[Differentiable]
+FloatCoopVec4 testVectorConstructor(float4 value)
+{
+    return FloatCoopVec4(value) * FloatCoopVec4(2.0);
+}
+
+// Exercises the CoopVec constructor from an array value in reverse and forward AD.
+[Differentiable]
+FloatCoopVec4 testArrayConstructor(float a, float b, float c, float d)
+{
+    float values[4] = { a, b, c, d };
+    return FloatCoopVec4(values) * FloatCoopVec4(2.0);
+}
+
+//TEST_INPUT:ubuffer(data=[0], stride=4, count=184):out,name=outputBuffer
 RWStructuredBuffer<float> outputBuffer;
 
 [numthreads(1, 1, 1)]
@@ -486,5 +533,62 @@ void computeMain()
         bwd_diff(testNoDiffElementUpdates)(dx, 3.0f, dOut);
 
         dx.d.store(outputBuffer, 592);
+    }
+
+    {
+        // Vector construction should transpose the CoopVec output gradient back
+        // to the source vector lanes.
+        let value = float4(1.0, 2.0, 3.0, 4.0);
+        let dOut = FloatCoopVec4(1.0, 10.0, 100.0, 1000.0);
+        let primal = testVectorConstructor(value);
+        var dValue = diffPair(value, float4(0.0, 0.0, 0.0, 0.0));
+        bwd_diff(testVectorConstructor)(dValue, dOut);
+
+        primal.store(outputBuffer, 608);
+        outputBuffer[156] = dValue.d.x;
+        outputBuffer[157] = dValue.d.y;
+        outputBuffer[158] = dValue.d.z;
+        outputBuffer[159] = dValue.d.w;
+    }
+
+    {
+        // Array construction should transpose the CoopVec output gradient back
+        // to the array elements.
+        let dOut = FloatCoopVec4(1.0, 10.0, 100.0, 1000.0);
+        let primal = testArrayConstructor(1.0, 2.0, 3.0, 4.0);
+        var da = diffPair(1.0, 0.0);
+        var db = diffPair(2.0, 0.0);
+        var dc = diffPair(3.0, 0.0);
+        var dd = diffPair(4.0, 0.0);
+        bwd_diff(testArrayConstructor)(da, db, dc, dd, dOut);
+
+        primal.store(outputBuffer, 640);
+        outputBuffer[164] = da.d;
+        outputBuffer[165] = db.d;
+        outputBuffer[166] = dc.d;
+        outputBuffer[167] = dd.d;
+    }
+
+    {
+        // Forward-mode mirror for vector construction links vector tangents to
+        // CoopVec lanes.
+        let result = fwd_diff(testVectorConstructor)(
+            diffPair(float4(1.0, 2.0, 3.0, 4.0), float4(1.0, 10.0, 100.0, 1000.0)));
+
+        result.p.store(outputBuffer, 672);
+        result.d.store(outputBuffer, 688);
+    }
+
+    {
+        // Forward-mode mirror for array construction links scalar tangents to
+        // CoopVec lanes through the temporary array.
+        let result = fwd_diff(testArrayConstructor)(
+            diffPair(1.0, 1.0),
+            diffPair(2.0, 10.0),
+            diffPair(3.0, 100.0),
+            diffPair(4.0, 1000.0));
+
+        result.p.store(outputBuffer, 704);
+        result.d.store(outputBuffer, 720);
     }
 }


### PR DESCRIPTION
## Motivation

Floating `CoopVec<T, N>` already had differentiable coverage for scalar, value-pack, and initializer-list construction paths, but constructing from an existing vector or array did not expose a differentiable constructor. User code that moves data through those shapes could compile as ordinary code while failing once autodiff needed to synthesize the derivative.

## Proposed solution

Add focused differentiable constructors for floating cooperative vectors from `vector<T, N>` and `T[N]`. Each constructor performs a direct lane copy, so autodiff can derive the expected lane-wise transpose/JVP behavior without introducing a second representation for cooperative-vector construction.

## Change summary

- `source/slang/hlsl.meta.slang`: adds `[Differentiable]` floating `CoopVec` constructors from `vector<T, N>` and `T[N]`.
- `tests/autodiff/coopvec.slang`: extends the CoopVec compute test to validate reverse- and forward-mode results for vector and array construction.

## Concepts and vocabulary

- `CoopVec<T, N>`: Slang cooperative-vector type with element-wise lane access.
- Constructor transpose: in reverse mode, gradients from each CoopVec lane flow back to the corresponding source vector lane or array element.

## Process report

Consider this shape:

```slang
[Differentiable]
CoopVec<float, 4> f(float4 value)
{
    return CoopVec<float, 4>(value) * CoopVec<float, 4>(2.0);
}
```

The constructor is semantically just a lane-wise copy from `value[i]` into `this[i]`. The existing scalar/value-pack/initializer-list paths had differentiable coverage, but this vector-shaped source did not. The fix keeps the representation at the construction boundary: the metadata now defines the vector and array constructors directly in terms of lane stores, which lets the existing autodiff machinery synthesize the reverse and forward derivatives from ordinary differentiable Slang code.

The test writes real compute results so the constructor must both type-check and produce the right derivative data. For reverse mode, a CoopVec output gradient of `(1, 10, 100, 1000)` through a `* 2` result is expected to produce source gradients `(2, 20, 200, 2000)`. For forward mode, source tangents with the same values produce CoopVec tangents with the same doubled values. The test covers both the `float4` constructor and the temporary `float[4]` array constructor.

Validation:

- `cmake.exe --build build/windows-vs2022-dev --config Debug --target slang -- /m:8`
- `cmake.exe --build build/windows-vs2022-dev --config Debug --target slang-glsl-module -- /m:8`
- `.\build\windows-vs2022-dev\Debug\bin\slang-test.exe -bindir .\build\windows-vs2022-dev\Debug\bin -api vk tests\autodiff\coopvec.slang`
- `.\build\windows-vs2022-dev\Debug\bin\slang-test.exe -bindir .\build\windows-vs2022-dev\Debug\bin -api cpu tests\autodiff\coopvec.slang`
