### PR TITLE
Pin nightly coverage macOS job to macos-15

### DIFF
--- a/.github/workflows/nightly-slang-coverage-test.yml
+++ b/.github/workflows/nightly-slang-coverage-test.yml
@@ -38,9 +38,9 @@ jobs:
       compiler: clang
       platform: aarch64
       config: relwithdebinfo
-      # Pinned: on macos-26 images (a macos-latest lottery) Metal gfx
-      # tests fail on a Metal 4 vs toolchain skew. Unpin once #11985
-      # is resolved.
+      # macos-latest includes different runner images; macos-15 is the
+      # one where Metal gfx tests work (macos-26 fails on a Metal 4 vs
+      # toolchain skew, see #11985). Unpin once #11985 is resolved.
       runs-on: '["macos-15"]'
       build-llvm: true
       deploy-pages: false

--- a/.github/workflows/nightly-slang-coverage-test.yml
+++ b/.github/workflows/nightly-slang-coverage-test.yml
@@ -38,7 +38,14 @@ jobs:
       compiler: clang
       platform: aarch64
       config: relwithdebinfo
-      runs-on: '["macos-latest"]'
+      # Pinned to macos-15: macos-latest currently serves a mix of
+      # macos-15 and macos-26 images, and on macos-26 slang-rhi's
+      # OS-version capability detection claims metallib_4_0 while the
+      # image's Metal toolchain cannot compile Metal 4 MSL, failing
+      # four Metal gfx tests (see issue #11985). A nondeterministic
+      # image also skews nightly coverage deltas. Unpin once #11985
+      # is resolved.
+      runs-on: '["macos-15"]'
       build-llvm: true
       deploy-pages: false
       server-count: 1

--- a/.github/workflows/nightly-slang-coverage-test.yml
+++ b/.github/workflows/nightly-slang-coverage-test.yml
@@ -38,12 +38,8 @@ jobs:
       compiler: clang
       platform: aarch64
       config: relwithdebinfo
-      # Pinned to macos-15: macos-latest currently serves a mix of
-      # macos-15 and macos-26 images, and on macos-26 slang-rhi's
-      # OS-version capability detection claims metallib_4_0 while the
-      # image's Metal toolchain cannot compile Metal 4 MSL, failing
-      # four Metal gfx tests (see issue #11985). A nondeterministic
-      # image also skews nightly coverage deltas. Unpin once #11985
+      # Pinned: on macos-26 images (a macos-latest lottery) Metal gfx
+      # tests fail on a Metal 4 vs toolchain skew. Unpin once #11985
       # is resolved.
       runs-on: '["macos-15"]'
       build-llvm: true


### PR DESCRIPTION
## Motivation

The Nightly Slang Coverage Test macOS job (`coverage-macos`) has been flapping since 2026-07-07: pass on 07-06, fail 07-07/07-08, pass 07-09 03:00, fail 07-10 through 07-12. All failures share one signature — four Metal gfx tests (`pointerInBufferRoundtripMetal`, `pointerInBufferDoublePtrRoundtripMetal`, `pointerInParamBlockRoundtripMetal`, `neuralSlangNetworkConverterMetal`) fail at `createComputePipeline` with:

```
error: 'required_threads_per_threadgroup' attribute requires Metal language standard metal4.0 or higher
```

Comparing runs directly: the passing 07-09 run executed on a `macos-15-arm64` image, the failing 07-10 run on `macos-26-arm64`, with no Metal-relevant commits between them. `runs-on: macos-latest` currently includes both runner image types; macos-15 is the one where these tests work.

## Proposed solution

Pin the job to `macos-15` until the underlying skew is fixed. On macos-26 images, slang-rhi (since slang-rhi#795, bumped in via ef06ca406 on 07-07 — one hour before the first failing nightly) detects `metallib_4_0` from the OS version and injects it into the Slang session, so the Metal emitter emits the Metal-4-only `[[required_threads_per_threadgroup]]` attribute (#10592); but the image's effective `metal` CLI is the Xcode 16-era compiler (32023.883 — Xcode 26 ships only a stub Metal toolchain), which rejects it. The OS claims Metal 4; the toolchain cannot compile it. That root cause is tracked in #11985 and is not this workflow's to fix.

Pinning (rather than installing the Metal Toolchain component on macos-26, or expected-failure-listing the tests) fits this workflow's purpose: it measures C++ compiler coverage, and a varying runner image skews nightly coverage deltas — failing tests execute different code paths, so run-to-run coverage changes would partly reflect which image type the run received. The pin comment references #11985 for the unpin condition.

## Change summary

| File | Change |
| --- | --- |
| `.github/workflows/nightly-slang-coverage-test.yml` | `coverage-macos` `runs-on` pinned from `macos-latest` to `macos-15`, with a comment explaining why and when to unpin. |

## Concepts and vocabulary

- **Runner image mix** — `macos-latest` resolves to either `macos-15-arm64` or `macos-26-arm64` during GitHub's ongoing migration; job outcome differs by image, and macos-15 is the one where the Metal gfx tests pass.
- **OS-vs-toolchain skew** — slang-rhi derives `metallib_4_0` capability from `operatingSystemVersion`, which describes the Metal *runtime*; the MSL is compiled by the installed Xcode `metal` CLI, which on macos-26 images predates Metal 4.

## Process report

- Evidence for the image correlation: nightly run 28990922896 (2026-07-09, `macos-15-arm64`, success) vs run 29065886182 (2026-07-10, `macos-26-arm64`, failure), with only docs/test-infra commits between their SHAs (`0a02eae1b..caa2ff456` contains no Metal or slang-rhi changes).
- Timeline for the trigger: the slang-rhi bump `ef06ca406` (containing slang-rhi#795's OS-version capability detection) merged 2026-07-07 02:01 UTC; the first failing nightly is 2026-07-07 03:00 UTC.
- This is a mitigation at the right layer for this workflow: the product bug (capability detection over-claiming compile capability) is owned by #11985; the same failure family on other macOS lanes was mitigated there by disabling an example test (#11995, re-enable tracked in #11999). #11985 remains the tracking issue for the root cause and for unpinning this lane.
