### PR TITLE
Include license texts in release packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,6 +287,7 @@ jobs:
             cp build.em/Release/bin/slang-wasm.wasm "${base}/slang-wasm.wasm"
             cp build.em/Release/bin/slang-wasm.js "${base}/slang-wasm.js"
             cp build.em/Release/bin/interface.d.ts "${base}/interface.d.ts"
+            cp -R LICENSES "${base}/LICENSES"
             (cd "${base}" && zip -r "../${base}.zip" .)
             echo "SLANG_BINARY_ARCHIVE_ZIP=${base}.zip" >> "$GITHUB_OUTPUT"
 
@@ -299,6 +300,7 @@ jobs:
             cp build.em/external/miniz/Release/libminiz.a "${base_libs}/lib/" 2>/dev/null || true
             cp build.em/external/cmark/src/Release/libcmark-gfm.a "${base_libs}/lib/"
             cp build.em/Release/include/*.h "${base_libs}/include/"
+            cp -R LICENSES "${base_libs}/LICENSES"
             (cd "${base_libs}" && zip -r "../${base_libs}.zip" .)
             echo "SLANG_WASM_LIBS_ARCHIVE=${base_libs}.zip" >> "$GITHUB_OUTPUT"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -625,6 +625,13 @@ install(
     EXCLUDE_FROM_ALL
 )
 install(
+    DIRECTORY "${slang_SOURCE_DIR}/LICENSES"
+    DESTINATION .
+    COMPONENT metadata
+    EXCLUDE_FROM_ALL
+    PATTERN ".*" EXCLUDE
+)
+install(
     DIRECTORY "${slang_SOURCE_DIR}/docs/"
     DESTINATION share/doc/slang
     PATTERN ".*" EXCLUDE


### PR DESCRIPTION
Fixes #12083

## Motivation

A consumer who downloads a Slang binary archive receives the top-level `LICENSE`, but not the
`LICENSES/` directory containing the full license texts referenced by distributed files. For
example, `LICENSES/Apache-2.0.txt` is available in a source checkout but is absent from the Windows,
Linux, macOS, and WASM release packages.

## Proposed solution

Package the existing `LICENSES/` directory without transforming or duplicating its contents. CPack
archives receive it through the same metadata component that already owns `LICENSE` and `README.md`,
while the manually assembled WASM archives copy the directory alongside their binaries, libraries,
and headers.

## Change summary

- `CMakeLists.txt:627` installs `LICENSES/` as release metadata, which covers the platform ZIP and
  tar.gz archives produced by CPack.
- `.github/workflows/release.yml:290` and `.github/workflows/release.yml:303` copy `LICENSES/` into
  the WASM runtime and WASM development-library packages.

## Concepts and vocabulary

The CPack `metadata` component is the release-package component for repository-level documentation
and licensing files. The WASM packages do not use that CPack path; the release workflow assembles
them directly.

## Process report

The missing files originate at the packaging boundary rather than in generated compiler output.
For platform releases, CPack installs the existing metadata component from `CMakeLists.txt`, so the
directory is added there next to the existing top-level license installation. This preserves the
repository's SPDX license layout as the single source of truth and automatically applies to each
platform archive using the standard CPack presets.

The WASM branch in `.github/workflows/release.yml` exits before the CPack commands run and constructs
two ZIP staging directories explicitly. Each staging directory therefore copies the same source
`LICENSES/` directory before it is archived. No downstream archive consumer needs special handling,
and no alternative license representation is introduced.
