### PR TITLE
Default the shader-coverage demos to batched dispatch in full mode

### DIFF
--- a/examples/shader-coverage-bvh-traversal/README.md
+++ b/examples/shader-coverage-bvh-traversal/README.md
@@ -29,11 +29,14 @@ The traversal kernel has several rarely-fired branches:
 
 The host driver generates a procedural mesh, builds a BVH on CPU,
 uploads, and dispatches 4096×4096 = 16.7M rays from a synthetic camera.
-By default all rays are submitted in a single dispatch. Pass
-`--batch-size=N` to split them into batches of N rays per submission,
-which keeps each batch short and avoids OS watchdog resets (Windows TDR)
-under coverage instrumentation; `--batch-size=262144` (512×512) is a
-safe starting point on any GPU.
+`--batch-size=N` splits the rays into batches of N per submission, which
+keeps each batch short and avoids OS watchdog resets (Windows TDR /
+`VK_ERROR_DEVICE_LOST`) under coverage instrumentation. Full mode
+defaults to batches of 262144 (512×512) — a safe value on any GPU —
+because its single 16.7M-ray coverage-instrumented dispatch is long
+enough to trip the watchdog; smoke mode defaults to a single dispatch.
+Pass an explicit value to tune, or `--batch-size=0` for a single
+dispatch in full mode.
 
 ```bash
 ./shader-coverage-bvh-traversal --mode=smoke    # clean icosphere, Diffuse only
@@ -45,9 +48,11 @@ safe starting point on any GPU.
 # Hit/miss mode — non-atomic, no execution counts but same coverage map:
 ./shader-coverage-bvh-traversal --mode=full --coverage-mode=boolean
 
-# Batch dispatch to avoid GPU watchdog resets (Windows TDR) under heavy
-# coverage load. 262144 (512×512) is a safe starting point on any GPU:
-./shader-coverage-bvh-traversal --mode=full --batch-size=262144
+# Tune the batch size (full mode already batches by default; smaller if
+# you still observe TDR, larger for fewer submissions on fast hardware),
+# or force a single unbatched dispatch:
+./shader-coverage-bvh-traversal --mode=full --batch-size=65536
+./shader-coverage-bvh-traversal --mode=full --batch-size=0
 
 # Write the coverage artifacts somewhere other than the demo's source
 # directory (the default). `--output-dir` creates the directory if needed:

--- a/examples/shader-coverage-bvh-traversal/main.cpp
+++ b/examples/shader-coverage-bvh-traversal/main.cpp
@@ -715,11 +715,17 @@ int main(int argc, char** argv)
         // `--batch-size=N`: split the ray grid into batches of N rays,
         // each dispatched as a separate GPU submission. Keeps individual
         // submissions short to avoid OS watchdog resets (Windows TDR /
-        // VK_ERROR_DEVICE_LOST) under coverage instrumentation. Default
-        // is 0 (all rays in a single dispatch). A value of 262144
-        // (512×512) is a safe starting point on any GPU; reduce if you
-        // observe TDR, increase for fewer submissions on fast hardware.
-        uint32_t batchSize = 0; // 0 = single dispatch
+        // VK_ERROR_DEVICE_LOST) under coverage instrumentation. Full mode
+        // defaults to 262144 rays (512×512) per batch — a safe value on
+        // any GPU — because its denser mesh makes a single 16M-ray
+        // coverage-instrumented dispatch long enough to trip the watchdog.
+        // Smoke mode is quick and defaults to a single dispatch. Pass an
+        // explicit value to tune (smaller if you still observe TDR, larger
+        // for fewer submissions on fast hardware), or `--batch-size=0` to
+        // force a single dispatch in full mode.
+        constexpr uint32_t kBatchSizeUnset = UINT32_MAX;
+        constexpr uint32_t kFullModeBatchSize = 262144;
+        uint32_t batchSize = kBatchSizeUnset; // resolved per mode after parsing
         constexpr std::string_view kOutputDirFlag = "--output-dir=";
         constexpr std::string_view kDemoDirFlag = "--demo-dir=";
         constexpr std::string_view kBatchSizeFlag = "--batch-size=";
@@ -754,6 +760,12 @@ int main(int argc, char** argv)
                 return 1;
             }
         }
+
+        // Resolve the batch-size default per mode (see the flag comment
+        // above): full mode batches by default, smoke mode does not. An
+        // explicit `--batch-size=` always wins, including `=0`.
+        if (batchSize == kBatchSizeUnset)
+            batchSize = (mode == "full") ? kFullModeBatchSize : 0;
 
         // Publish the `--demo-dir` override to file-scope storage so
         // `getDemoDirectory()` (called from `compileShader` and from
@@ -909,12 +921,12 @@ int main(int argc, char** argv)
         // Both patterns are the same WAR for GPU watchdog timeouts on
         // coverage-instrumented kernels.
         //
-        // `--batch-size=N` sets the rays-per-batch; omitting the flag submits
-        // all rays in a single dispatch (fast, no TDR protection). A value of
-        // 262144 (512×512) is a safe starting point on any GPU.
+        // `--batch-size=N` sets the rays-per-batch; full mode defaults to
+        // 262144 (512×512), smoke mode and `--batch-size=0` submit all rays
+        // in a single dispatch (fast, no TDR protection).
         const uint32_t totalRays = (uint32_t)rays.size();
-        // Resolve 0 (the "no flag" sentinel) to the full ray count so the loop
-        // always runs exactly one iteration by default.
+        // Resolve 0 (single dispatch) to the full ray count so the loop
+        // always runs exactly one iteration in that case.
         const uint32_t effectiveBatchSize = (batchSize == 0) ? totalRays : batchSize;
         uint32_t batchCount = 0;
         std::cout << "dispatching " << totalRays << " rays";
@@ -994,6 +1006,16 @@ int main(int argc, char** argv)
         ctx.destroyPipeline(pipe);
         std::cout << "done\n";
         return 0;
+    }
+    catch (const vkdemo::VulkanError& e)
+    {
+        std::cerr << "fatal: " << e.what() << "\n";
+        if (e.result == VK_ERROR_DEVICE_LOST)
+            std::cerr << "The GPU was likely reset by the OS watchdog (TDR) during a long "
+                         "coverage-instrumented dispatch. Rerun with a smaller --batch-size "
+                         "(e.g. --batch-size=65536), or use --coverage-mode=boolean, which "
+                         "removes the atomic-counter cost.\n";
+        return 1;
     }
     catch (const std::exception& e)
     {

--- a/examples/shader-coverage-bvh-traversal/vk_compute_demo.h
+++ b/examples/shader-coverage-bvh-traversal/vk_compute_demo.h
@@ -127,11 +127,26 @@ public:
 // inline in the header because they're tiny and need to be reachable
 // from main.cpp without dragging in the rest of the implementation
 // unit.
+
+// The exception `check` throws on a failing Vulkan call. Carries the
+// failing VkResult so callers can react to specific failures — the
+// demos catch VK_ERROR_DEVICE_LOST to suggest batching remedies for
+// OS watchdog resets — without parsing the message text.
+struct VulkanError : std::runtime_error
+{
+    VkResult result;
+    VulkanError(VkResult r, const std::string& message)
+        : std::runtime_error(message), result(r)
+    {
+    }
+};
+
 inline void check(VkResult r, const char* what)
 {
     if (r != VK_SUCCESS)
     {
-        throw std::runtime_error(
+        throw VulkanError(
+            r,
             std::string("Vulkan error in ") + what + ": " + std::to_string(int(r)));
     }
 }

--- a/examples/shader-coverage-image-pipeline/README.md
+++ b/examples/shader-coverage-image-pipeline/README.md
@@ -32,9 +32,11 @@ The coverage delta between the two runs is the demo's headline.
 # measurement):
 ./shader-coverage-image-pipeline --mode=full --no-coverage
 
-# Tile each config into 128-row horizontal bands to avoid GPU watchdog
-# resets (Windows TDR) under count mode on the hot bilateral filter:
-./shader-coverage-image-pipeline --mode=full --tile-rows=128
+# Tune the tile height (full mode already tiles into 128-row bands by
+# default to avoid GPU watchdog resets under count mode on the hot
+# bilateral filter), or force whole-image dispatch:
+./shader-coverage-image-pipeline --mode=full --tile-rows=64
+./shader-coverage-image-pipeline --mode=full --tile-rows=0
 
 # Write the coverage artifacts somewhere other than the demo's source
 # directory (the default). `--output-dir` creates the directory if
@@ -85,8 +87,9 @@ preserves). Pick `count` when you need exact execution counts; pick
 
 `--tile-rows=N` splits each config dispatch into horizontal bands of N
 rows. The shader recovers the real pixel row as `tid.y + tileOriginY`.
-Default (no flag) is whole-image: each config is a single submission
-with `tileOriginY = 0`.
+Full mode defaults to 128-row bands; smoke mode (quick enough not to
+need tiling) and `--tile-rows=0` dispatch the whole image per config,
+a single submission with `tileOriginY = 0`.
 
 The bilateral filter's inner loop creates heavy atomic contention on a
 handful of counter slots — millions of threads all increment the same
@@ -99,7 +102,8 @@ Tiling caps per-submission GPU time without affecting coverage results:
 bands partition the image, every pixel is processed exactly once, and
 counters accumulate across all bands and configs.
 
-`--tile-rows=128` is a safe starting point. Alternatives:
+The default `--tile-rows=128` is a safe height on any GPU; reduce it if
+you still observe TDR. Alternatives:
 
 - `--coverage-mode=boolean`: removes all atomic contention (non-atomic
   stores of `1`), so whole-image dispatch is safe without tiling.

--- a/examples/shader-coverage-image-pipeline/main.cpp
+++ b/examples/shader-coverage-image-pipeline/main.cpp
@@ -636,11 +636,18 @@ int main(int argc, char** argv)
         bool coverageBoolean = false;
         // `--tile-rows=N`: split each config dispatch into horizontal bands
         // of N rows to avoid OS watchdog resets (Windows TDR /
-        // VK_ERROR_DEVICE_LOST) on coverage-instrumented runs. Default is 0
-        // (whole-image dispatch). The bilateral filter's inner loop creates
-        // heavy atomic contention on a few counters; if TDR occurs under
-        // count mode, try --tile-rows=128 or switch to --coverage-mode=boolean.
-        uint32_t tileRows = 0; // 0 = whole-image
+        // VK_ERROR_DEVICE_LOST) on coverage-instrumented runs. The
+        // bilateral filter's inner loop creates heavy atomic contention on
+        // a few counters, and full mode's parameter sweep makes each config
+        // dispatch long enough to trip the watchdog, so full mode defaults
+        // to 128-row tiles — a safe height on any GPU. Smoke mode is quick
+        // and defaults to whole-image dispatch. Pass an explicit value to
+        // tune (smaller if you still observe TDR), or `--tile-rows=0` to
+        // force whole-image dispatch in full mode. --coverage-mode=boolean
+        // also eliminates TDR risk without tiling.
+        constexpr uint32_t kTileRowsUnset = UINT32_MAX;
+        constexpr uint32_t kFullModeTileRows = 128;
+        uint32_t tileRows = kTileRowsUnset; // resolved per mode after parsing
         constexpr std::string_view kTileRowsFlag = "--tile-rows=";
         // `--output-dir=<path>`: explicit output location for the three
         // coverage artifacts (manifest JSON, LCOV, raw counter buffer).
@@ -690,6 +697,12 @@ int main(int argc, char** argv)
                 return 1;
             }
         }
+
+        // Resolve the tile-rows default per mode (see the flag comment
+        // above): full mode tiles by default, smoke mode does not. An
+        // explicit `--tile-rows=` always wins, including `=0`.
+        if (tileRows == kTileRowsUnset)
+            tileRows = (mode == "full") ? kFullModeTileRows : 0;
 
         // Publish the `--demo-dir` override to file-scope storage so
         // `getDemoDirectory()` (called from `compileShader` and from
@@ -821,13 +834,13 @@ int main(int argc, char** argv)
                 (uint32_t)shader.coverageBinding,
                 coverageBuf);
 
-        // Default: whole-image dispatch (tileOriginY = 0, single submission
-        // per config). Pass `--tile-rows=N` to split each config into
-        // horizontal bands of N rows; the shader recovers the real pixel row
-        // as `tid.y + tileOriginY`. Tiling caps the per-submission GPU time,
+        // `--tile-rows=N` splits each config into horizontal bands of N
+        // rows; the shader recovers the real pixel row as
+        // `tid.y + tileOriginY`. Tiling caps the per-submission GPU time,
         // which prevents OS watchdog resets (Windows TDR /
         // VK_ERROR_DEVICE_LOST) under coverage count mode on this demo's hot
-        // bilateral filter. --tile-rows=128 is a safe starting point;
+        // bilateral filter. Full mode defaults to 128-row tiles; smoke mode
+        // and `--tile-rows=0` dispatch the whole image per config.
         // --coverage-mode=boolean also eliminates TDR risk without tiling.
         //
         // Neither shape affects coverage results: tiles partition the image,
@@ -938,6 +951,16 @@ int main(int argc, char** argv)
         ctx.destroyPipeline(pipe);
         std::cout << "done\n";
         return 0;
+    }
+    catch (const vkdemo::VulkanError& e)
+    {
+        std::cerr << "fatal: " << e.what() << "\n";
+        if (e.result == VK_ERROR_DEVICE_LOST)
+            std::cerr << "The GPU was likely reset by the OS watchdog (TDR) during a long "
+                         "coverage-instrumented dispatch. Rerun with smaller tiles "
+                         "(e.g. --tile-rows=64), or use --coverage-mode=boolean, which "
+                         "removes the atomic-counter cost.\n";
+        return 1;
     }
     catch (const std::exception& e)
     {

--- a/examples/shader-coverage-image-pipeline/vk_compute_demo.h
+++ b/examples/shader-coverage-image-pipeline/vk_compute_demo.h
@@ -127,11 +127,26 @@ public:
 // inline in the header because they're tiny and need to be reachable
 // from main.cpp without dragging in the rest of the implementation
 // unit.
+
+// The exception `check` throws on a failing Vulkan call. Carries the
+// failing VkResult so callers can react to specific failures — the
+// demos catch VK_ERROR_DEVICE_LOST to suggest batching remedies for
+// OS watchdog resets — without parsing the message text.
+struct VulkanError : std::runtime_error
+{
+    VkResult result;
+    VulkanError(VkResult r, const std::string& message)
+        : std::runtime_error(message), result(r)
+    {
+    }
+};
+
 inline void check(VkResult r, const char* what)
 {
     if (r != VK_SUCCESS)
     {
-        throw std::runtime_error(
+        throw VulkanError(
+            r,
             std::string("Vulkan error in ") + what + ": " + std::to_string(int(r)));
     }
 }


### PR DESCRIPTION
## Motivation

Running either GPU shader-coverage example in full mode with no extra flags crashes on Windows:

```
$ ./shader-coverage-bvh-traversal --mode=full
...
dispatching 16777216 rays (coverage=on)
fatal: Vulkan error in vkQueueWaitIdle: -4
```

`-4` is `VK_ERROR_DEVICE_LOST`: the single 16.7M-ray coverage-instrumented dispatch runs long enough (coverage count mode is 20–30× slower than uninstrumented code due to atomic-counter contention) to trip the OS GPU watchdog (Windows TDR, ~2 s), which resets the device. The image-pipeline demo has the same failure shape on its 48-config full sweep. Both demos already ship the remedy — `--batch-size=N` (bvh-traversal) and `--tile-rows=N` (image-pipeline) split the work into short submissions — and both code comments and READMEs name safe values (262144 rays, 128 rows). Only the default was unsafe: the out-of-the-box full-mode experience was a crash, with a raw error code and no pointer to the flag that fixes it.

## Proposed solution

Two complementary changes, applied symmetrically to both demos:

1. **Full mode batches/tiles by default.** `--mode=full` now defaults to the documented safe values (`--batch-size=262144`, `--tile-rows=128`); smoke mode is quick and keeps its single dispatch. An explicit flag always wins, including `=0` to force the old single-submission behavior (useful for timing runs on hardware without an aggressive watchdog). The default is resolved after argument parsing via an "unset" sentinel, so flag order doesn't matter and an explicit `=0` is distinguishable from "no flag".

2. **Device loss now names the remedy.** The `check` helper throws a new `VulkanError` (derived from `std::runtime_error`) carrying the failing `VkResult`, and each demo's `main` catches it to append actionable guidance on `VK_ERROR_DEVICE_LOST`: rerun with a smaller batch/tile value, or switch to `--coverage-mode=boolean`, which removes the atomic-counter cost entirely. This covers whoever opts out of batching with `=0` or still hits TDR on very slow hardware.

Verified on Windows 11 / NVIDIA: `--mode=full` on both demos previously device-lost and now completes (bvh-traversal: 64 batches at ~59 ms/batch; image-pipeline: 432 tiled dispatches at ~290 ms/submission), producing the same coverage summaries as before. Smoke mode still runs as a single dispatch on both.

## Change summary

| File | Change |
|---|---|
| `examples/shader-coverage-bvh-traversal/main.cpp` | Full-mode default `--batch-size=262144` via unset-sentinel resolution after parsing; `VK_ERROR_DEVICE_LOST` catch with remedy message; comments updated |
| `examples/shader-coverage-image-pipeline/main.cpp` | Same, with `--tile-rows=128` |
| `examples/shader-coverage-{bvh-traversal,image-pipeline}/vk_compute_demo.h` | `check` throws `VulkanError` carrying the `VkResult` (identical copies, per the header's own duplication convention) |
| `examples/shader-coverage-{bvh-traversal,image-pipeline}/README.md` | Document the full-mode defaults and the `=0` opt-out |

## Concepts and vocabulary

- **TDR (Timeout Detection and Recovery)** — the Windows GPU watchdog: any single submission exceeding ~2 s gets the device reset, surfacing as `VK_ERROR_DEVICE_LOST` on the next queue operation. Linux/macOS have equivalent (laxer) watchdogs.
- **Coverage count mode** — the default `-trace-coverage` instrumentation: an atomic add per executed statement. Hot inner loops funnel millions of threads into a few counter slots, which is what makes full-mode submissions long enough to trip the watchdog. Boolean mode (`--coverage-mode=boolean`) uses plain stores and has no such contention.
- **Batching / tiling** — splitting one logical dispatch into several short GPU submissions (by ray range or image bands). Counters accumulate across submissions, so coverage results are identical; only per-submission wall time changes.

## Process report

**Why default-on batching rather than detect-and-retry or a Windows-only default.** After `VK_ERROR_DEVICE_LOST` the `VkDevice` is unusable, so auto-retry means tearing down and re-initializing the entire context while the driver is at its least stable — too much robustness machinery for examples whose lesson is coverage analysis. A Windows-only (`_WIN32`) default was considered and rejected: other platforms have watchdogs too, and a platform-dependent default makes the READMEs and observed behavior diverge between machines for no benefit. The batch/tile values are exactly the ones the demos' own comments already called safe on any GPU.

**Why the sentinel (`kBatchSizeUnset = UINT32_MAX`) instead of defaulting the variable to the safe value.** `--batch-size=0` / `--tile-rows=0` are meaningful user inputs (force single-submission). Initializing the variable to the safe value would make an explicit `=0` indistinguishable from... nothing — it would still be overwritten only if the flag appeared, so `=0` would work, but `--mode=full` appearing *after* `--batch-size=262144` (or any reordering) must not re-trigger the default either. Resolving once after the parse loop, only when no flag was seen, makes the precedence rule ("explicit flag always wins, mode decides otherwise") hold for every argument order.

**Why `VulkanError` instead of matching on the message.** The demos need to react to one specific `VkResult` in the top-level catch. The existing `check` helper threw `std::runtime_error` with the numeric code embedded in text; branching on `e.what()` containing `"-4"` would be string-parsing a formatted message. Carrying the `VkResult` in the exception type is the input-shape-correct fix at the producer: `check` is the single place every Vulkan result funnels through, and the derived-from-`runtime_error` shape keeps every existing `catch (const std::exception&)` working unchanged. The header is duplicated verbatim across the two demo directories by that file's own documented convention; both copies stay byte-identical.

**Input-shape check.** The out-of-contract input here is a GPU submission long enough to exceed the OS watchdog budget — produced by the demos' own default dispatch shape, not by user error or a compiler bug. The principled fix is therefore at the producer (the default dispatch shape), not deeper handling of the resulting device loss; the `VK_ERROR_DEVICE_LOST` message is a diagnostic for the explicit opt-out path, not a recovery mechanism.
