### PR TITLE
coverage-html: link footer to renderer README, drop prefix footnote, indent function listing

### DIFF
--- a/tools/coverage-html/slang-coverage-html.py
+++ b/tools/coverage-html/slang-coverage-html.py
@@ -431,18 +431,12 @@ def _dir_depth(dirpath: str) -> int:
     return 0 if dirpath == "" else dirpath.count("/") + 1
 
 
-def _indent_calc(depth: int) -> str:
-    """The CSS length expression for one tree-indent level. Shared by
-    the file/directory rows and the expanded function listing so the
-    listing's name column starts exactly under the file row's
-    chevron."""
-    return f"calc(10px + {1.4 * depth:.2f}em)"
-
-
 def _indent_style(depth: int) -> str:
     """Per-row left padding so the tree shape is visible even when
-    row backgrounds are uniform."""
-    return f"padding-left: {_indent_calc(depth)};"
+    row backgrounds are uniform. Also applied to the expanded
+    function-listing cell so the listing starts under its file row's
+    chevron."""
+    return f"padding-left: calc(10px + {1.4 * depth:.2f}em);"
 
 
 def _index_thead_html(
@@ -646,12 +640,18 @@ def _render_file_functions_row(
         + hashlib.sha1(rec.path.encode("utf-8"), usedforsecurity=False).hexdigest()[:10]
     )
     template_html = _render_inline_functions_table(
-        rec, file_href, show_fns=show_fns, show_br=show_br, indent_depth=file_depth
+        rec, file_href, show_fns=show_fns, show_br=show_br
     )
     row_html = (
         f'            <tr class="fileFunctions" data-dir="{dir_attr}" '
         f'data-depth="{file_depth}" data-fn-tmpl="{tmpl_id}" hidden>\n'
-        f'              <td colspan="{cols_for_empty}"></td>\n'
+        # The same tree indent as the file row above, so the whole
+        # expanded listing starts under that row's chevron. This trades
+        # exact vertical alignment between the listing's metric columns
+        # and the parent table's (the listing shrinks by the indent);
+        # the listing has its own header row, so it stays readable.
+        f'              <td colspan="{cols_for_empty}" '
+        f'style="{_indent_style(file_depth)}"></td>\n'
         f"            </tr>"
     )
     return tmpl_id, template_html, row_html
@@ -927,7 +927,6 @@ def _render_inline_functions_table(
     file_href: str,
     show_fns: bool = False,
     show_br: bool = False,
-    indent_depth: int = 0,
 ) -> str:
     """Render the per-file Functions table embedded in an index
     `<td>` (lazy-loaded via <template>).
@@ -979,12 +978,7 @@ def _render_inline_functions_table(
         )
 
     return (
-        # --fn-indent aligns the Function column's text with the parent
-        # file row's chevron; the CSS rules on td.coverFn and the
-        # Function header consume it, so the metric columns keep their
-        # vertical alignment with the parent table.
-        f'<table class="fnInner" style="--fn-indent: {_indent_calc(indent_depth)};" '
-        'cellpadding="1" cellspacing="1" border="0">\n'
+        '<table class="fnInner" cellpadding="1" cellspacing="1" border="0">\n'
         + _fn_inner_colgroup(show_fns, show_br)
         + "\n"
         + _fn_inner_thead(show_fns, show_br)

--- a/tools/coverage-html/slang-coverage-html.py
+++ b/tools/coverage-html/slang-coverage-html.py
@@ -888,7 +888,7 @@ def _fn_inner_colgroup(show_fns: bool, show_br: bool, indent_depth: int = 0) -> 
     indent = _indent_calc(indent_depth)
     cols = [
         f'          <col class="fnIndentCol" style="width: {indent};">',
-        f'          <col class="fnNameCol" style="width: calc(43% - {indent});">',
+        f'          <col class="fnNameCol" style="width: calc(48% - {indent});">',
         '          <col class="fnLineCol">',
         '          <col class="colLBar">',
         '          <col class="colLRate">',

--- a/tools/coverage-html/slang-coverage-html.py
+++ b/tools/coverage-html/slang-coverage-html.py
@@ -431,12 +431,18 @@ def _dir_depth(dirpath: str) -> int:
     return 0 if dirpath == "" else dirpath.count("/") + 1
 
 
+def _indent_calc(depth: int) -> str:
+    """The CSS length expression for one tree-indent level. Shared by
+    the file/directory rows and the expanded function listing's spacer
+    column, so the listing's left edge sits exactly under the file
+    row's chevron."""
+    return f"calc(10px + {1.4 * depth:.2f}em)"
+
+
 def _indent_style(depth: int) -> str:
     """Per-row left padding so the tree shape is visible even when
-    row backgrounds are uniform. Also applied to the expanded
-    function-listing cell so the listing starts under its file row's
-    chevron."""
-    return f"padding-left: calc(10px + {1.4 * depth:.2f}em);"
+    row backgrounds are uniform."""
+    return f"padding-left: {_indent_calc(depth)};"
 
 
 def _index_thead_html(
@@ -640,18 +646,12 @@ def _render_file_functions_row(
         + hashlib.sha1(rec.path.encode("utf-8"), usedforsecurity=False).hexdigest()[:10]
     )
     template_html = _render_inline_functions_table(
-        rec, file_href, show_fns=show_fns, show_br=show_br
+        rec, file_href, show_fns=show_fns, show_br=show_br, indent_depth=file_depth
     )
     row_html = (
         f'            <tr class="fileFunctions" data-dir="{dir_attr}" '
         f'data-depth="{file_depth}" data-fn-tmpl="{tmpl_id}" hidden>\n'
-        # The same tree indent as the file row above, so the whole
-        # expanded listing starts under that row's chevron. This trades
-        # exact vertical alignment between the listing's metric columns
-        # and the parent table's (the listing shrinks by the indent);
-        # the listing has its own header row, so it stays readable.
-        f'              <td colspan="{cols_for_empty}" '
-        f'style="{_indent_style(file_depth)}"></td>\n'
+        f'              <td colspan="{cols_for_empty}"></td>\n'
         f"            </tr>"
     )
     return tmpl_id, template_html, row_html
@@ -876,13 +876,19 @@ def _fn_branch_coverage_cells(b_total: int, b_hit: int) -> str:
     )
 
 
-def _fn_inner_colgroup(show_fns: bool, show_br: bool) -> str:
+def _fn_inner_colgroup(show_fns: bool, show_br: bool, indent_depth: int = 0) -> str:
     """Colgroup for fnInner: subdivides parent's File column into
-    Name + Line, then reuses the parent's colgroup classes for the
-    metric cells (so column widths line up vertically with the
-    file-summary row above)."""
+    Indent + Name + Line, then reuses the parent's colgroup classes
+    for the metric cells (so column widths line up vertically with
+    the file-summary row above). The leading spacer column carries the
+    file row's tree indent and the Name column gives up exactly that
+    width, so the listing's visible left edge starts under the file
+    row's chevron while every metric column keeps its parent-aligned
+    position."""
+    indent = _indent_calc(indent_depth)
     cols = [
-        '          <col class="fnNameCol">',
+        f'          <col class="fnIndentCol" style="width: {indent};">',
+        f'          <col class="fnNameCol" style="width: calc(43% - {indent});">',
         '          <col class="fnLineCol">',
         '          <col class="colLBar">',
         '          <col class="colLRate">',
@@ -912,6 +918,7 @@ def _fn_inner_thead(show_fns: bool, show_br: bool) -> str:
         extra += '          <td class="tableHead" colspan="3">Branch Coverage</td>\n'
     return (
         "        <tr>\n"
+        '          <td class="fnIndentSpacer"></td>\n'
         '          <td class="tableHead">Function</td>\n'
         '          <td class="tableHead">Line</td>\n'
         '          <td class="tableHead" colspan="2">Line Coverage</td>\n'
@@ -927,6 +934,7 @@ def _render_inline_functions_table(
     file_href: str,
     show_fns: bool = False,
     show_br: bool = False,
+    indent_depth: int = 0,
 ) -> str:
     """Render the per-file Functions table embedded in an index
     `<td>` (lazy-loaded via <template>).
@@ -971,6 +979,7 @@ def _render_inline_functions_table(
 
         rows.append(
             "        <tr>"
+            '<td class="fnIndentSpacer"></td>'
             f'<td class="coverFn">{html.escape(name)}</td>'
             f'<td class="coverNumDflt">{line_cell}</td>'
             f"{line_cells}{fn_cells}{br_cells}"
@@ -979,7 +988,7 @@ def _render_inline_functions_table(
 
     return (
         '<table class="fnInner" cellpadding="1" cellspacing="1" border="0">\n'
-        + _fn_inner_colgroup(show_fns, show_br)
+        + _fn_inner_colgroup(show_fns, show_br, indent_depth)
         + "\n"
         + _fn_inner_thead(show_fns, show_br)
         + "\n"

--- a/tools/coverage-html/slang-coverage-html.py
+++ b/tools/coverage-html/slang-coverage-html.py
@@ -48,7 +48,10 @@ from llvm_cov_json import is_json_input, parse_llvm_cov_json  # noqa: E402
 
 MARKER_NAME = "slang-coverage-html.marker"
 GENERATOR_NAME = "slang-coverage-html"
-GENERATOR_URL = "https://github.com/shader-slang/slang"
+GENERATOR_URL = (
+    "https://github.com/shader-slang/slang"
+    "/blob/master/tools/coverage-html/README.md"
+)
 
 # ---------------------------------------------------------------------------
 # Style constants
@@ -428,10 +431,18 @@ def _dir_depth(dirpath: str) -> int:
     return 0 if dirpath == "" else dirpath.count("/") + 1
 
 
+def _indent_calc(depth: int) -> str:
+    """The CSS length expression for one tree-indent level. Shared by
+    the file/directory rows and the expanded function listing so the
+    listing's name column starts exactly under the file row's
+    chevron."""
+    return f"calc(10px + {1.4 * depth:.2f}em)"
+
+
 def _indent_style(depth: int) -> str:
     """Per-row left padding so the tree shape is visible even when
     row backgrounds are uniform."""
-    return f"padding-left: calc(10px + {1.4 * depth:.2f}em);"
+    return f"padding-left: {_indent_calc(depth)};"
 
 
 def _index_thead_html(
@@ -635,7 +646,7 @@ def _render_file_functions_row(
         + hashlib.sha1(rec.path.encode("utf-8"), usedforsecurity=False).hexdigest()[:10]
     )
     template_html = _render_inline_functions_table(
-        rec, file_href, show_fns=show_fns, show_br=show_br
+        rec, file_href, show_fns=show_fns, show_br=show_br, indent_depth=file_depth
     )
     row_html = (
         f'            <tr class="fileFunctions" data-dir="{dir_attr}" '
@@ -705,13 +716,6 @@ def render_index(
             f'style="text-align:center">No coverage data found in input.</td></tr>'
         )
 
-    prefix_note = ""
-    if prefix:
-        prefix_note = (
-            f'        <tr><td colspan="{cols_for_empty}" class="footnote">'
-            f"Common path prefix: <code>{html.escape(prefix)}</code></td></tr>\n"
-        )
-
     # Out-of-table <template>s for each file's expanded function
     # listing. Browsers parse <template> children as a DocumentFragment
     # without painting them, so initial DOM stays small even when we
@@ -736,7 +740,7 @@ def render_index(
     </thead>
     <tbody>
 {chr(10).join(rows_html)}
-{prefix_note}    </tbody>
+    </tbody>
   </table>
 {templates_html}
 """
@@ -923,6 +927,7 @@ def _render_inline_functions_table(
     file_href: str,
     show_fns: bool = False,
     show_br: bool = False,
+    indent_depth: int = 0,
 ) -> str:
     """Render the per-file Functions table embedded in an index
     `<td>` (lazy-loaded via <template>).
@@ -974,7 +979,12 @@ def _render_inline_functions_table(
         )
 
     return (
-        '<table class="fnInner" cellpadding="1" cellspacing="1" border="0">\n'
+        # --fn-indent aligns the Function column's text with the parent
+        # file row's chevron; the CSS rules on td.coverFn and the
+        # Function header consume it, so the metric columns keep their
+        # vertical alignment with the parent table.
+        f'<table class="fnInner" style="--fn-indent: {_indent_calc(indent_depth)};" '
+        'cellpadding="1" cellspacing="1" border="0">\n'
         + _fn_inner_colgroup(show_fns, show_br)
         + "\n"
         + _fn_inner_thead(show_fns, show_br)

--- a/tools/coverage-html/style.css
+++ b/tools/coverage-html/style.css
@@ -231,6 +231,11 @@ table.fnInner td.tableHead { font-family: -apple-system, BlinkMacSystemFont,
    vertically with the file-summary row above. */
 table.fnInner col.fnNameCol  { width: 43%; }
 table.fnInner col.fnLineCol  { width: 4%; }
+/* The spacer column that indents the listing's visible left edge to
+   the parent file row's chevron; its width (and the matching
+   reduction of fnNameCol) is set inline per table by the renderer.
+   Transparent so the page background reads as indentation. */
+table.fnInner td.fnIndentSpacer { background: transparent; padding: 0; }
 
 .sourceUnavailable { color: var(--slang-orange); font-style: italic;
                      padding: 8px; }

--- a/tools/coverage-html/style.css
+++ b/tools/coverage-html/style.css
@@ -231,6 +231,13 @@ table.fnInner td.tableHead { font-family: -apple-system, BlinkMacSystemFont,
    vertically with the file-summary row above. */
 table.fnInner col.fnNameCol  { width: 43%; }
 table.fnInner col.fnLineCol  { width: 4%; }
+/* Indent the Function column (names and its header) to the parent
+   file row's chevron position — the renderer sets --fn-indent per
+   table to the same tree-indent calc the file row uses. Only the
+   name column shifts; metric columns keep their vertical alignment
+   with the parent table. */
+table.fnInner td.coverFn { padding-left: var(--fn-indent, 10px); }
+table.fnInner td.tableHead:first-child { padding-left: var(--fn-indent, 10px); }
 
 .sourceUnavailable { color: var(--slang-orange); font-style: italic;
                      padding: 8px; }

--- a/tools/coverage-html/style.css
+++ b/tools/coverage-html/style.css
@@ -215,10 +215,11 @@ span.fnToggle:focus, span.dirToggle:focus { outline: 1px dotted var(--slang-oran
 tr.fileFunctions[hidden]  { display: none; }
 tr.fileSummary[hidden]    { display: none; }
 /* fileFunctions row's <td> matches the parent indexTable edges
-   (body padding already provides the 24px window inset).  A 3px
-   teal stripe on the left visually marks the expanded region. */
-tr.fileFunctions > td   { background-color: #fdfdfe; padding: 6px 0;
-                          border-left: 3px solid var(--slang-teal); }
+   (body padding already provides the 24px window inset). The teal
+   stripe marking the expanded region lives on the listing's spacer
+   column (below), not here — this cell still spans the full table
+   width, but the listing's visible edge starts at the tree indent. */
+tr.fileFunctions > td   { padding: 6px 0; }
 
 /* Embedded function table inside an expanded file row. The colgroup
    widths mirror the parent indexTable so cells line up vertically
@@ -244,7 +245,8 @@ table.fnInner col.fnLineCol  { width: 4%; }
    the parent file row's chevron; its width (and the matching
    reduction of fnNameCol) is set inline per table by the renderer.
    Transparent so the page background reads as indentation. */
-table.fnInner td.fnIndentSpacer { background: transparent; padding: 0; }
+table.fnInner td.fnIndentSpacer { background: transparent; padding: 0;
+                                  border-right: 3px solid var(--slang-teal); }
 
 .sourceUnavailable { color: var(--slang-orange); font-style: italic;
                      padding: 8px; }

--- a/tools/coverage-html/style.css
+++ b/tools/coverage-html/style.css
@@ -85,9 +85,17 @@ td.headerCovTableEntry    { text-align: right; color: var(--text); font-weight: 
    margin. Both the file-summary table and any embedded fnInner
    share these column widths so the same metric column lines up
    vertically across the file row and its expanded function rows. */
+/* Fixed layout so the colgroup widths below actually govern the
+   columns. Under auto layout the browser sizes the File column to its
+   content and the percentages are ignored — which also made it
+   impossible for an expanded function listing (table.fnInner, which IS
+   fixed-layout) to line its metric columns up under these. */
 table.indexTable { margin: 0 auto; width: 100%;
-                   border-collapse: collapse; }
-table.indexTable col.colFile   { width: 47%; }
+                   border-collapse: collapse; table-layout: fixed; }
+/* Column percentages sum to exactly 100% so fixed layout has no
+   leftover width to distribute — the same boundaries then hold in the
+   embedded fnInner tables, whose columns use the same classes. */
+table.indexTable col.colFile   { width: 52%; }
 table.indexTable col.colLBar   { width: 9%; }
 table.indexTable col.colLRate  { width: 5%; }
 table.indexTable col.colLTotal { width: 4%; }
@@ -225,11 +233,12 @@ table.fnInner   { border-collapse: collapse; margin: 0; width: 100%;
 table.fnInner td { overflow-wrap: break-word; }
 table.fnInner td.tableHead { font-family: -apple-system, BlinkMacSystemFont,
                              "Segoe UI", Roboto, sans-serif; }
-/* fn-specific cols subdivide the parent's File column (47%) into
-   Name (43%) + Line (4%). The remaining cols reuse the parent's
+/* fn-specific cols subdivide the parent's File column (52%) into
+   Indent + Name (48% minus the indent, set inline per table) +
+   Line (4%). The remaining cols reuse the parent's
    classes so the line-coverage / fn / branch columns line up
    vertically with the file-summary row above. */
-table.fnInner col.fnNameCol  { width: 43%; }
+table.fnInner col.fnNameCol  { width: 48%; }
 table.fnInner col.fnLineCol  { width: 4%; }
 /* The spacer column that indents the listing's visible left edge to
    the parent file row's chevron; its width (and the matching

--- a/tools/coverage-html/style.css
+++ b/tools/coverage-html/style.css
@@ -231,13 +231,6 @@ table.fnInner td.tableHead { font-family: -apple-system, BlinkMacSystemFont,
    vertically with the file-summary row above. */
 table.fnInner col.fnNameCol  { width: 43%; }
 table.fnInner col.fnLineCol  { width: 4%; }
-/* Indent the Function column (names and its header) to the parent
-   file row's chevron position — the renderer sets --fn-indent per
-   table to the same tree-indent calc the file row uses. Only the
-   name column shifts; metric columns keep their vertical alignment
-   with the parent table. */
-table.fnInner td.coverFn { padding-left: var(--fn-indent, 10px); }
-table.fnInner td.tableHead:first-child { padding-left: var(--fn-indent, 10px); }
 
 .sourceUnavailable { color: var(--slang-orange); font-style: italic;
                      padding: 8px; }


### PR DESCRIPTION
## Motivation

Three small presentation issues in the HTML coverage report's index page (`tools/coverage-html/slang-coverage-html.py`), all visible in any generated report such as the shader-coverage example demos:

1. The footer's "Generated by: slang-coverage-html" link pointed at the repository root, which tells a report reader nothing about the tool that produced the page.
2. Every index page ended with a "Common path prefix: `<code>/Users/.../examples/shader-coverage-bvh-traversal/</code>`" footnote — noise that also leaks a machine-local absolute path into a report that may be published (CI artifacts, shared HTML).
3. Expanding a file's function listing (the chevron before the filename) rendered the function table flush against the page's left edge, visually detached from the indented file row it belongs to.

## Proposed solution

1. Point `GENERATOR_URL` at the renderer's own README (`tools/coverage-html/README.md` on master), which documents usage, inputs, and options — the right landing page for "what generated this?".
2. Remove the footnote row. The prefix *stripping* logic (`_common_dir_prefix` / `_display_path`) is untouched — displayed paths stay short; only the footnote that printed the stripped prefix is gone.
3. Indent the expanded function listing's left edge to the file row's chevron, with the metric columns exactly aligned under the parent table's and the Function name column narrower by exactly the indent. Getting there exposed a real layout bug: `table.indexTable` declared colgroup percentages but used **auto table layout**, so browsers sized the File column to its content and ignored the percentages — the embedded listings (fixed layout) could never align under it, and never had. Two root-cause fixes make the declared geometry real: `table-layout: fixed` on the index table, and column percentages normalized to sum to exactly 100 (File 47%→52%, listing name column 43%→48%) so fixed layout has no leftover width to distribute (the two tables previously distributed the missing 5% differently, skewing boundaries ~19px). The listing itself gains a leading transparent spacer column of the file row's tree-indent width (shared `_indent_calc()` expression) with the name column narrowed by the same amount. The 3px teal stripe that marks the expanded region moves from the containing cell's left border (which spans the full width and would dangle at the far left) to the spacer column's right edge, so it runs along the listing's visible, indented edge.

## Change summary

| File | Change |
| --- | --- |
| `tools/coverage-html/slang-coverage-html.py` | `GENERATOR_URL` → renderer README; remove the `prefix_note` row; `_fn_inner_colgroup()` gains a leading spacer column of the file row's tree-indent width and narrows the name column by the same amount (`calc(48% - indent)`); each listing row and its header row gain the matching spacer cell. |

| `tools/coverage-html/style.css` | `table-layout: fixed` on the index table; column percentages normalized to a 100% sum; spacer-cell rule (`td.fnIndentSpacer`: transparent, zero padding); comments updated to the real geometry. |

## Concepts and vocabulary

- **`fnInner` table** — the per-file function listing lazily cloned from a `<template>` when a file row's chevron is expanded. Its `colgroup` mirrors the parent index table's column widths so metric cells line up vertically across the file row and its expanded listing; this PR preserves that invariant exactly by paying the indent out of the name column's width.
- **Tree indent** — file/directory rows carry `padding-left: calc(10px + 1.4·depth em)` per nesting level; the chevron is the first thing after that padding.

## Process report

All three changes are presentation-only; no data model or CLI behavior changes.

- **Footer link**: constant change only. The README URL uses the `blob/master` form so it renders as documentation.
- **Footnote removal**: the input shape (`prefix` computed by `_common_dir_prefix`) remains a valid and used input — `_display_path` still consumes it for every displayed path. Only the display of the prefix itself was removed, because it repeats machine-local information the report reader cannot use. No test asserted the footnote; the `_common_dir_prefix` unit tests (which cover the stripping behavior that remains) still pass.
- **Function-listing indent**: the depth is already computed at the only call site (`_render_file_functions_row` has `file_depth` for the hidden row it renders); passing it into `_render_inline_functions_table` uses the producer's existing value. The shared `_indent_calc()` keeps one source of truth for the indent expression, so the chevron position, the spacer width, and the name-column reduction cannot drift apart. Two rejected iterations are worth recording: padding only the name column's text left the listing's visible box at the page edge (no apparent change), and padding the listing's containing cell shrank the embedded table, breaking the metric columns' vertical alignment with the parent. The spacer-column form achieves both goals — indented left edge, exactly aligned metric columns — with the cost paid entirely by the name column's width, which is the column that had slack.

Verified by regenerating `examples/shader-coverage-bvh-traversal`'s report and measuring in headless Chrome: every metric column boundary in an expanded listing sits within 1px of the parent row's, the listing's left edge starts under the chevron, and the footer/prefix changes render as described. Renderer test suite: 148/149 pass, unchanged from master — the one failure (`test_real_lcov_renders_inline_branch_column`) fails identically on clean master in this environment and is unrelated (branch gutter in the source view).




