### PR TITLE
Memoize Val substitutions to avoid exponential compile-time scaling

### DIFF
--- a/source/slang/slang-ast-decl-ref.cpp
+++ b/source/slang/slang-ast-decl-ref.cpp
@@ -3,6 +3,7 @@
 #include "slang-ast-builder.h"
 #include "slang-ast-dispatch.h"
 #include "slang-ast-forward-declarations.h"
+#include "slang-ast-substitution.h"
 #include "slang-check-impl.h"
 
 namespace Slang
@@ -615,7 +616,18 @@ DeclRefBase* GenericAppDeclRef::_getBaseOverride()
 
 DeclRefBase* DeclRefBase::substituteImpl(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
 {
-    SLANG_AST_NODE_VIRTUAL_CALL(DeclRefBase, substituteImpl, (astBuilder, subst, ioDiff));
+    return static_cast<DeclRefBase*>(substituteValWithCache(
+        this,
+        astBuilder,
+        subst,
+        ioDiff,
+        [&](SubstitutionSet cachedSubst, int* cachedDiff) -> Val*
+        {
+            return ASTNodeDispatcher<DeclRefBase, DeclRefBase*>::dispatch(
+                this,
+                [&](auto declRef) -> DeclRefBase*
+                { return declRef->_substituteImplOverride(astBuilder, cachedSubst, cachedDiff); });
+        }));
 }
 
 DeclRefBase* DeclRefBase::getBase()

--- a/source/slang/slang-ast-substitution.h
+++ b/source/slang/slang-ast-substitution.h
@@ -1,0 +1,141 @@
+#pragma once
+
+#include "core/slang-dictionary.h"
+#include "slang-ast-support-types.h"
+
+namespace Slang
+{
+
+/// Caches the completed Val substitutions performed by one substitution operation.
+///
+/// Consider `struct Node<T : IModel> : IModel {}` and a type such as
+/// `Node<Node<Leaf>>`. Each layer contains its inner type both as an ordinary generic argument and
+/// in the declared conformance witness for `T : IModel`. Substitution follows both edges, so
+/// without this cache the shared Val DAG is traversed as if it were a tree. The cache belongs to
+/// the first substituteImpl dispatch on the stack and is propagated through SubstitutionSet copies.
+struct SubstitutionCache
+{
+    struct Key
+    {
+        Val* val = nullptr;
+        int packExpansionIndex = -1;
+
+        bool operator==(const Key& other) const
+        {
+            return val == other.val && packExpansionIndex == other.packExpansionIndex;
+        }
+
+        HashCode getHashCode() const
+        {
+            return combineHash(Slang::getHashCode(val), Slang::getHashCode(packExpansionIndex));
+        }
+    };
+
+    struct Result
+    {
+        Val* val = nullptr;
+        int diff = 0;
+    };
+
+    SubstitutionCache(ASTBuilder* astBuilder, DeclRefBase* substitutionDeclRef)
+        : m_astBuilder(astBuilder), m_substitutionDeclRef(substitutionDeclRef)
+    {
+    }
+
+    void validateContext(ASTBuilder* astBuilder, const SubstitutionSet& subst) const
+    {
+        SLANG_ASSERT(astBuilder == m_astBuilder);
+        SLANG_ASSERT(subst.declRef == m_substitutionDeclRef);
+        SLANG_ASSERT(subst.substitutionCache == this);
+    }
+
+    const Result* tryGet(const Key& key) const
+    {
+        if (m_usesDictionary)
+            return m_entries.tryGetValue(key);
+
+        for (Index i = 0; i < m_inlineEntryCount; ++i)
+        {
+            if (m_inlineEntries[i].key == key)
+                return &m_inlineEntries[i].result;
+        }
+        return nullptr;
+    }
+
+    void add(const Key& key, const Result& result)
+    {
+        if (m_usesDictionary)
+        {
+            m_entries.add(key, result);
+            return;
+        }
+
+        if (m_inlineEntryCount < kInlineEntryCount)
+        {
+            auto& entry = m_inlineEntries[m_inlineEntryCount++];
+            entry.key = key;
+            entry.result = result;
+            return;
+        }
+
+        m_entries.reserve(kInlineEntryCount + 1);
+        for (Index i = 0; i < m_inlineEntryCount; ++i)
+            m_entries.add(m_inlineEntries[i].key, m_inlineEntries[i].result);
+        m_entries.add(key, result);
+        m_usesDictionary = true;
+    }
+
+private:
+    static const Index kInlineEntryCount = 8;
+
+    struct Entry
+    {
+        Key key;
+        Result result;
+    };
+
+    ASTBuilder* m_astBuilder = nullptr;
+    DeclRefBase* m_substitutionDeclRef = nullptr;
+    Entry m_inlineEntries[kInlineEntryCount];
+    Index m_inlineEntryCount = 0;
+    Dictionary<Key, Result> m_entries;
+    bool m_usesDictionary = false;
+};
+
+/// Dispatches a Val substitution through the operation-local cache.
+///
+/// Entries are added only after dispatch returns, so recursive cycles retain their existing
+/// behavior. The saved diff is a delta because substituteImpl is specified to increment ioDiff.
+template<typename TDispatcher>
+Val* substituteValWithCache(
+    Val* val,
+    ASTBuilder* astBuilder,
+    SubstitutionSet subst,
+    int* ioDiff,
+    const TDispatcher& dispatcher)
+{
+    if (!subst.substitutionCache)
+    {
+        SubstitutionCache cache(astBuilder, subst.declRef);
+        subst.substitutionCache = &cache;
+        return substituteValWithCache(val, astBuilder, subst, ioDiff, dispatcher);
+    }
+
+    auto cache = subst.substitutionCache;
+    cache->validateContext(astBuilder, subst);
+
+    SubstitutionCache::Key key = {val, subst.packExpansionIndex};
+    if (auto cachedResult = cache->tryGet(key))
+    {
+        *ioDiff += cachedResult->diff;
+        return cachedResult->val;
+    }
+
+    int diff = 0;
+    auto result = dispatcher(subst, &diff);
+    cache->add(key, {result, diff});
+    *ioDiff += diff;
+    return result;
+}
+
+} // namespace Slang

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -43,6 +43,7 @@ FIDDLE() namespace Slang
     class Val;
 
     class DeclRefBase;
+    struct SubstitutionCache;
     class NodeBase;
     class LookupDeclRef;
     class GenericAppDeclRef;
@@ -780,6 +781,9 @@ FIDDLE() namespace Slang
     struct SubstitutionSet
     {
         DeclRefBase* declRef = nullptr;
+
+        // An operation-local cache shared by recursive copies of this substitution set.
+        SubstitutionCache* substitutionCache = nullptr;
 
         // The element index if the substitution is happening inside a pack expansion.
         // For example, if we are substituting the pattern type of `expand each T`, where

--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -5,6 +5,7 @@
 #include "slang-ast-builder.h"
 #include "slang-ast-dispatch.h"
 #include "slang-ast-natural-layout.h"
+#include "slang-ast-substitution.h"
 #include "slang-check-impl.h"
 #include "slang-diagnostics.h"
 #include "slang-mangle.h"
@@ -43,7 +44,18 @@ Val* Val::substitute(ASTBuilder* astBuilder, SubstitutionSet subst)
 
 Val* Val::substituteImpl(ASTBuilder* astBuilder, SubstitutionSet subst, int* ioDiff)
 {
-    SLANG_AST_NODE_VIRTUAL_CALL(Val, substituteImpl, (astBuilder, subst, ioDiff))
+    return substituteValWithCache(
+        this,
+        astBuilder,
+        subst,
+        ioDiff,
+        [&](SubstitutionSet cachedSubst, int* cachedDiff) -> Val*
+        {
+            return ASTNodeDispatcher<Val, Val*>::dispatch(
+                this,
+                [&](auto value) -> Val*
+                { return value->_substituteImplOverride(astBuilder, cachedSubst, cachedDiff); });
+        });
 }
 
 void Val::toText(StringBuilder& out){SLANG_AST_NODE_VIRTUAL_CALL(Val, toText, (out))}

--- a/tests/language-feature/generics/val-substitution-shared-dag.slang
+++ b/tests/language-feature/generics/val-substitution-shared-dag.slang
@@ -1,0 +1,39 @@
+//TEST(smoke):SIMPLE:
+
+interface IModel
+{}
+
+struct Leaf : IModel
+{}
+
+struct Node<T : IModel> : IModel
+{}
+
+typealias T0 = Leaf;
+typealias T1 = Node<T0>;
+typealias T2 = Node<T1>;
+typealias T3 = Node<T2>;
+typealias T4 = Node<T3>;
+typealias T5 = Node<T4>;
+typealias T6 = Node<T5>;
+typealias T7 = Node<T6>;
+typealias T8 = Node<T7>;
+typealias T9 = Node<T8>;
+typealias T10 = Node<T9>;
+typealias T11 = Node<T10>;
+typealias T12 = Node<T11>;
+
+void inferModel<T : IModel>(T model)
+{}
+
+void consume<U>(T12 model, U value)
+{}
+
+void exercise(T12 model)
+{
+    // Infer the entire constrained tree as a generic argument.
+    inferModel(model);
+
+    // Inferring U also substitutes a generic decl-ref into the already-deep T12 parameter type.
+    consume(model, 0);
+}

--- a/tools/compile-perf/lib/manifest.py
+++ b/tools/compile-perf/lib/manifest.py
@@ -260,6 +260,17 @@ WORKLOADS = [
         sweep_sizes=[125, 250, 500, 1000],
     ),
     WorkloadSpec(
+        name="val_substitution_dag",
+        bucket="sema",
+        gen=workloads.gen_val_substitution_dag,
+        default_size=14,
+        mode="module",
+        # Generic-tree IR lowering has a separate scaling issue, so keep this
+        # workload's signal focused on the Val-substitution path in sema.
+        primary_timers=["SemanticChecking"],
+        sweep_sizes=[6, 8, 10, 12, 14],
+    ),
+    WorkloadSpec(
         name="conformance",
         bucket="sema",
         gen=workloads.gen_conformance,

--- a/tools/compile-perf/lib/workloads.py
+++ b/tools/compile-perf/lib/workloads.py
@@ -443,6 +443,26 @@ def gen_sema_generics(n):
     return {"sema_generics.slang": "".join(s)}
 
 
+def gen_val_substitution_dag(n):
+    """A constrained generic type chain whose conformance witnesses share each
+    inner type with the ordinary generic argument. Inferring the unrelated U in
+    consume<U> substitutes through the fixed deep-tree parameter and measures
+    whether Val substitution visits each unique DAG node once.
+
+    Scaling null: n adds one unique type and witness layer; ideal substitution cost is O(n).
+    """
+    s = [_HEADER]
+    s.append("interface IModel {}\n")
+    s.append("struct Leaf : IModel {}\n")
+    s.append("struct Node<T : IModel> : IModel {}\n\n")
+    s.append("typealias T0 = Leaf;\n")
+    for i in range(1, n + 1):
+        s.append(f"typealias T{i} = Node<T{i - 1}>;\n")
+    s.append(f"\nvoid consume<U>(T{n} model, U value) {{}}\n")
+    s.append(f"void exercise(T{n} model) {{ consume(model, 0); }}\n")
+    return {"val_substitution_dag.slang": "".join(s)}
+
+
 # --------------------------------------------------------------------------- #
 # Type checking: operator overload resolution + implicit conversions
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Motivation

Consider this constrained generic tree and the unrelated generic call at the end:

```slang
interface IModel {}
struct Leaf : IModel {}
struct Node<T : IModel> : IModel {}

typealias T0 = Leaf;
typealias T1 = Node<T0>;
// ...
typealias T16 = Node<T15>;

void consume<U>(T16 model, U value) {}
void exercise(T16 model) { consume(model, 0); }
```

While inferring `U`, overload checking substitutes the candidate's generic declaration reference through the already-known `T16` parameter type. Each constrained `Node` layer shares its inner type between the ordinary generic argument and its declared-subtype witness. Substitution followed all of those edges independently, revisiting the same canonical `Val` nodes and turning a DAG traversal into an approximately `3^depth` tree traversal.

In the isolated reproducer, Release `SemanticChecking` grew from 1.82 ms at depth 7 to 25,294 ms at depth 16.

## Proposed solution

Memoize completed values for the duration of one substitution operation. The cache is created lazily at the first `Val::substituteImpl` or `DeclRefBase::substituteImpl` dispatch and is propagated by existing `SubstitutionSet` copies.

The key is `(Val*, packExpansionIndex)`. The `Val*` identifies a canonical DAG node, while `packExpansionIndex` distinguishes substitutions of the same pack pattern at different element indices. The cache captures and asserts the operation-wide `ASTBuilder*` and substitution `DeclRefBase*`, stores the substituted `Val*` plus the `ioDiff` delta, uses eight inline entries for small operations, and promotes to a `Dictionary` for larger traversals.

Only completed computations are cached, so this does not introduce an in-progress state or alter existing recursive-cycle behavior. The cache is stack-owned and operation-local rather than persistent.

## Change summary

- Add the operation-local substitution cache and connect it to both `Val` and `DeclRefBase` dispatch boundaries.
- Add a smoke test that covers both inferring the full constrained tree as a generic argument and substituting through a fixed deep-tree parameter while inferring an unrelated generic argument.
- Add a compile-perf workload with depths 6, 8, 10, 12, and 14, using `SemanticChecking` as its primary timer.

## Concepts and vocabulary

- **Val DAG:** Semantic `Val` objects are canonicalized/shared by the AST builder, so multiple generic-argument and witness edges can intentionally point to the same object.
- **SubstitutionSet:** The substitution declaration reference plus per-recursion state such as the active pack-expansion element. Recursive code passes it by value.
- **Declared-subtype witness:** The semantic evidence for a constraint such as `T : IModel`; it contains edges to the constrained subtype, supertype, and declaring reference.
- **ioDiff:** An increment-style result that records whether substitution changed a value. Cache entries therefore store and replay the delta produced by one dispatch.

## Process report

For the call in the motivating example, the front-end path is:

`ResolveInvoke -> AddOverloadCandidates -> addOverloadCandidatesForCallToGeneric -> AddDeclRefOverloadCandidates -> AddFuncOverloadCandidate -> AddOverloadCandidate -> TryCheckOverloadCandidateArity -> CountParameters -> getParamValueType -> SubstitutionSet::applyToType -> Val::substituteImpl`.

At every `Node<T : IModel>` layer, `GenericAppDeclRef::_substituteImplOverride` substitutes the base and ordinary arguments, while `DeclaredSubtypeWitness::_substituteImplOverride` substitutes the subtype, supertype, and declaration reference. Those paths converge on shared inner `Val` objects. Before this change, CDB counted `GenericAppDeclRef::_substituteImplOverride` entries of 6, 24, 78, 240, 726, and 2,184 for depths 1 through 6. With memoization, those counts are 6, 12, 18, 24, 30, and 36; declared-witness entries similarly follow `7d + 1`.

This shared shape is canonical and intentional: the existing AST-builder and witness construction paths produce one semantic value and reference it from multiple roles. It is not an accidental alternative representation that should be repaired at a producer. The substitution layer is the first common consumer traversing this DAG, so operation-local memoization there addresses the root cause without changing witness construction, overload resolution, `getFuncType`, or IR lowering.

`packExpansionIndex` is part of the key because `EachType`, `EachSubtypeWitness`, and `EachIntVal` can produce different results from the same input `Val` at different pack indices. The builder and substitution declaration reference remain constant for an operation and are asserted when a cache is reused. Entries are installed only after dispatch completes, and the stored `ioDiff` delta preserves the existing increment contract on cache hits.

Release semantic-checking medians after the change stay between 0.72 ms and 0.95 ms for depths 5 through 16; depth 16 is 0.90 ms instead of 25.3 seconds. The new compile-perf sweep is likewise flat: 0.70, 0.76, 0.74, 0.81, and 0.79 ms at depths 6, 8, 10, 12, and 14. No-call, non-generic, and unconstrained depth-16 controls remain flat. A separate generic-tree IR-lowering scaling issue still affects total compilation and is intentionally outside this front-end fix, so this workload uses `SemanticChecking` as its primary signal.

Small-workload control medians changed by +6.3% for `sema_generics` and +9.0% for `overload_resolution`; the absolute costs remain small, and this tradeoff removes the pathological exponential case. Initial `minimal` and `conformance` controls improved.

Validation performed:

- Debug and Release `slangc` builds pass.
- The new smoke test passes under CDB (1/1).
- Debug variadic/pack tests pass under CDB with `-api vk` (28/28, 23 ignored), including different pack-expansion indices.
- The complete Release generics prefix passes with `-api vk` (150/150, 86 ignored).
- A Release full-suite run with eight Vulkan test servers reported 5,904/6,122 passing, 4,304 ignored, and 218 broad Vulkan concurrency/resource failures. Representative failures from generics, SPIR-V, mesh, and neural tests all passed when rerun individually (9/9 total).
