### PR TITLE
Add SpecializationWorkList using IRInst::scratchData

### DIFF
--- a/source/slang/slang-ir-specialization-work-list.h
+++ b/source/slang/slang-ir-specialization-work-list.h
@@ -1,0 +1,82 @@
+// slang-ir-specialization-work-list.h
+#pragma once
+
+#include "slang-ir.h"
+
+namespace Slang
+{
+
+// Stores pending specialization work in LIFO order. Membership only means that an instruction is
+// currently queued, so an intrusive marker avoids the allocation and lookup cost of a HashSet.
+class SpecializationWorkList
+{
+public:
+    // Type legalization and autodiff use bits 0 and 1. Use the next available bit for queued
+    // specialization membership. Whole-word scratchData users such as DCE and serialization must
+    // not overlap queued specialization entries; the DCE calls in processModule() run only after
+    // this work list is drained. Every exit path must clear the marker.
+    static constexpr UInt64 kQueuedScratchDataBit = UInt64(1) << 2;
+
+    explicit SpecializationWorkList(ContainerPool& containerPool)
+        : m_containerPool(containerPool), m_entries(containerPool.getList<IRInst>())
+    {
+    }
+
+    ~SpecializationWorkList()
+    {
+        clear();
+        m_containerPool.free(m_entries);
+    }
+
+    SpecializationWorkList(const SpecializationWorkList&) = delete;
+    SpecializationWorkList& operator=(const SpecializationWorkList&) = delete;
+
+    bool add(IRInst* inst)
+    {
+        if (isQueued(inst))
+        {
+            // A set marker must belong to this queue. This catches stale ownership or overlapping
+            // specialization queues in assertion-enabled builds without adding release overhead.
+#ifdef _DEBUG
+            SLANG_ASSERT(m_entries->indexOf(inst) != Index(-1));
+#endif
+            return false;
+        }
+
+        // Mark before the caller recursively adds users so cycles and duplicate enqueue attempts
+        // observe this instruction as already queued.
+        inst->scratchData |= kQueuedScratchDataBit;
+        m_entries->add(inst);
+        return true;
+    }
+
+    IRInst* pop()
+    {
+        SLANG_ASSERT(m_entries->getCount());
+        auto inst = m_entries->getLast();
+        m_entries->removeLast();
+
+        // Clear immediately before processing so a transformation may requeue the instruction.
+        inst->scratchData &= ~kQueuedScratchDataBit;
+        return inst;
+    }
+
+    void clear()
+    {
+        // Error exits and standalone specializeGeneric() can abandon queued follow-up work. Clear
+        // every surviving marker before discarding the entries.
+        for (auto inst : *m_entries)
+            inst->scratchData &= ~kQueuedScratchDataBit;
+        m_entries->clear();
+    }
+
+    Index getCount() const { return m_entries->getCount(); }
+
+    static bool isQueued(IRInst* inst) { return (inst->scratchData & kQueuedScratchDataBit) != 0; }
+
+private:
+    ContainerPool& m_containerPool;
+    List<IRInst*>* m_entries;
+};
+
+} // namespace Slang

--- a/source/slang/slang-ir-specialize.cpp
+++ b/source/slang/slang-ir-specialize.cpp
@@ -10,6 +10,7 @@
 #include "slang-ir-lower-dynamic-dispatch-insts.h"
 #include "slang-ir-peephole.h"
 #include "slang-ir-sccp.h"
+#include "slang-ir-specialization-work-list.h"
 #include "slang-ir-ssa-simplification.h"
 #include "slang-ir-typeflow-set.h"
 #include "slang-ir-typeflow-specialize.h"
@@ -62,20 +63,14 @@ struct SpecializationContext
 
 
     SpecializationContext(IRModule* inModule, TargetProgram* target, SpecializationOptions options)
-        : workList(*inModule->getContainerPool().getList<IRInst>())
-        , workListSet(*inModule->getContainerPool().getHashSet<IRInst>())
+        : workList(inModule->getContainerPool())
         , cleanInsts(*inModule->getContainerPool().getHashSet<IRInst>())
         , module(inModule)
         , targetProgram(target)
         , options(options)
     {
     }
-    ~SpecializationContext()
-    {
-        module->getContainerPool().free(&workList);
-        module->getContainerPool().free(&workListSet);
-        module->getContainerPool().free(&cleanInsts);
-    }
+    ~SpecializationContext() { module->getContainerPool().free(&cleanInsts); }
 
     bool isUnsimplifiedArithmeticInst(IRInst* inst)
     {
@@ -283,16 +278,12 @@ struct SpecializationContext
     // to be considered for specialization or simplification,
     // whether generic, existential, etc.
     //
-    List<IRInst*>& workList;
-    HashSet<IRInst*>& workListSet;
+    SpecializationWorkList workList;
     HashSet<IRInst*>& cleanInsts;
     void addToWorkList(IRInst* inst)
     {
-        if (workListSet.add(inst))
+        if (workList.add(inst))
         {
-            workList.add(inst);
-
-
             addUsersToWorkList(inst);
         }
     }
@@ -1802,10 +1793,7 @@ struct SpecializationContext
                 break;
             }
 
-            IRInst* inst = workList.getLast();
-
-            workList.removeLast();
-            workListSet.remove(inst);
+            IRInst* inst = workList.pop();
 
             if (!inst->getParent() && inst->getOp() != kIROp_ModuleInst)
                 continue;

--- a/source/slang/slang-serialize-ir.cpp
+++ b/source/slang/slang-serialize-ir.cpp
@@ -457,6 +457,12 @@ static void serializeAsFlatModule(const IRWriteSerializer& serializer, IRModuleI
     Dictionary<IRInst*, Int64> instMap;
     instMap.add(nullptr, -1);
     List<IRInst*> insts;
+    SLANG_DEFER({
+        // Serialization temporarily owns the whole scratch word for instruction indices. Clear
+        // those indices at the pass boundary so later passes can safely use individual bits.
+        for (auto inst : insts)
+            inst->scratchData = 0;
+    });
 
     traverseInstsInSerializationOrder(
         moduleInst,

--- a/tools/slang-unit-test/unit-test-specialization-work-list.cpp
+++ b/tools/slang-unit-test/unit-test-specialization-work-list.cpp
@@ -1,0 +1,97 @@
+// unit-test-specialization-work-list.cpp
+
+#include "slang/slang-ir-specialization-work-list.h"
+#include "unit-test/slang-unit-test.h"
+
+using namespace Slang;
+
+SLANG_UNIT_TEST(specializationWorkListDeduplicatesDuplicateEnqueue)
+{
+    ContainerPool pool;
+    SpecializationWorkList workList(pool);
+    IRInst inst = {};
+
+    SLANG_CHECK(workList.add(&inst));
+    SLANG_CHECK(!workList.add(&inst));
+    SLANG_CHECK(workList.getCount() == 1);
+    SLANG_CHECK(workList.pop() == &inst);
+    SLANG_CHECK(!SpecializationWorkList::isQueued(&inst));
+}
+
+SLANG_UNIT_TEST(specializationWorkListAllowsRequeueAfterPop)
+{
+    ContainerPool pool;
+    SpecializationWorkList workList(pool);
+    IRInst inst = {};
+
+    SLANG_CHECK(workList.add(&inst));
+    SLANG_CHECK(workList.pop() == &inst);
+    SLANG_CHECK(workList.add(&inst));
+    SLANG_CHECK(workList.getCount() == 1);
+    SLANG_CHECK(workList.pop() == &inst);
+}
+
+SLANG_UNIT_TEST(specializationWorkListDeduplicatesCyclesAndPreservesLifo)
+{
+    ContainerPool pool;
+    SpecializationWorkList workList(pool);
+    IRInst first = {};
+    IRInst second = {};
+
+    auto addWithUsers = [&](auto&& self, IRInst* inst) -> void
+    {
+        if (!workList.add(inst))
+            return;
+        self(self, inst == &first ? &second : &first);
+    };
+
+    addWithUsers(addWithUsers, &first);
+    SLANG_CHECK(workList.getCount() == 2);
+    SLANG_CHECK(workList.pop() == &second);
+    SLANG_CHECK(workList.pop() == &first);
+}
+
+SLANG_UNIT_TEST(specializationWorkListClearsEveryMarkerOnEarlyExit)
+{
+    ContainerPool pool;
+    SpecializationWorkList workList(pool);
+    IRInst first = {};
+    IRInst second = {};
+    constexpr UInt64 kUnrelatedBits = (UInt64(1) << 63) | (UInt64(1) << 62) | (UInt64(1) << 1);
+    first.scratchData = kUnrelatedBits;
+    second.scratchData = kUnrelatedBits;
+
+    SLANG_CHECK(workList.add(&first));
+    SLANG_CHECK(workList.add(&second));
+    workList.clear();
+
+    SLANG_CHECK(workList.getCount() == 0);
+    SLANG_CHECK(first.scratchData == kUnrelatedBits);
+    SLANG_CHECK(second.scratchData == kUnrelatedBits);
+}
+
+SLANG_UNIT_TEST(specializationWorkListDestructionCleansDiscardedFollowUpWork)
+{
+    ContainerPool pool;
+    IRInst inst = {};
+    constexpr UInt64 kUnrelatedBits = UInt64(1) << 62;
+    inst.scratchData = kUnrelatedBits;
+
+    {
+        SpecializationWorkList firstContext(pool);
+        SLANG_CHECK(firstContext.add(&inst));
+        SLANG_CHECK(SpecializationWorkList::isQueued(&inst));
+        // Model standalone specializeGeneric(): queued follow-up work is intentionally discarded
+        // when its temporary SpecializationContext is destroyed.
+    }
+
+    SLANG_CHECK(inst.scratchData == kUnrelatedBits);
+
+    {
+        SpecializationWorkList secondContext(pool);
+        SLANG_CHECK(secondContext.add(&inst));
+        SLANG_CHECK(secondContext.pop() == &inst);
+    }
+
+    SLANG_CHECK(inst.scratchData == kUnrelatedBits);
+}


### PR DESCRIPTION
## Motivation

When specialization recursively queues an instruction's users, the same `IRInst` can be reached more than once or through a cycle. The pass currently keeps pending instructions in a LIFO list and separately tracks membership in a `HashSet`. That preserves the required deduplication and requeue behavior, but adds allocation and lookup cost to specialization.

On the specialization compile-performance workload, removing that separate set reduced total measured compile time by about 4% and specialization time by over 10%.

## Proposed solution

Replace the list-plus-set pair with `SpecializationWorkList`, which keeps the existing pooled LIFO list and records queued membership with an intrusive bit in `IRInst::scratchData`.

Set the marker before recursively adding users so duplicate paths and cycles are deduplicated. Clear it when an instruction is popped so transformations can requeue it, and clear all remaining markers when pending work is abandoned. Preserve every unrelated scratch bit.

Serialization temporarily uses the entire `scratchData` word for instruction indices, so clear those temporary values at the serialization boundary before later passes use individual bits.

## Change summary

- Add `SpecializationWorkList` with pooled storage, intrusive membership tracking, and cleanup on every exit path.
- Update `SpecializationContext` to use the new work list instead of a separate `List` and `HashSet`.
- Clear serialization's temporary instruction indices when `serializeAsFlatModule()` finishes.
- Add focused tests for duplicate enqueue, requeue after pop, cycle deduplication with LIFO order, early-exit cleanup, and consecutive specialization contexts.

## Concepts and vocabulary

- **Queued marker:** Bit 2 of `IRInst::scratchData`, set only while an instruction is present in a `SpecializationWorkList`.
- **Whole-word scratch user:** A pass such as serialization that temporarily stores a complete value in `scratchData` instead of reserving an individual bit.

## Process report

`SpecializationContext::addToWorkList()` now calls `SpecializationWorkList::add()`. `add()` sets the queued marker before calling code recursively adds users, so reaching the same instruction through a duplicate edge or a cycle does not add a second list entry. The specialization loop calls `pop()`, which removes the last entry and clears its marker before processing it; this preserves the old LIFO order and allows that instruction to be queued again if processing changes its users.

Error exits and standalone `specializeGeneric()` calls can discard follow-up work before the list is drained. `clear()` removes the marker from every remaining entry, and the work-list destructor calls it before returning the pooled list. Both `pop()` and `clear()` mask only the queued bit, preserving scratch bits owned by other passes.

The queued marker is bit 2 because type legalization and autodiff use bits 0 and 1. DCE's whole-word use runs only after specialization has drained the list. Serialization is different: `serializeAsFlatModule()` intentionally writes instruction indices into the whole scratch word. That is valid temporary state, so the serializer now clears the values it owns on exit rather than making specialization interpret stale serialization indices. This keeps the ownership boundary at the producer and leaves the work-list consumer simple.

The unit tests directly cover duplicate suppression, requeue after `pop()`, cycles and LIFO order, cleanup when work is abandoned, preservation of unrelated bits, and reuse by a later specialization context.
