### PR TITLE
compile-perf: read suite files as explicit UTF-8 everywhere

### DIFF
--- a/tools/compile-perf/bench.py
+++ b/tools/compile-perf/bench.py
@@ -245,7 +245,7 @@ def run_once(cmd):
     rss = None
     if memfile:
         try:
-            with open(memfile) as fh:
+            with open(memfile, encoding="utf-8", errors="replace") as fh:
                 for line in fh:
                     if "Maximum resident set size" in line:
                         rss = float(line.rsplit(":", 1)[1].strip())  # kbytes
@@ -510,7 +510,7 @@ def main():
     this_run = records  # workloads run this invocation (for the summary/exit)
     merged = {}
     if os.path.exists(jpath):
-        with open(jpath) as fh:
+        with open(jpath, encoding="utf-8") as fh:
             for r in json.load(fh):
                 merged[(r["workload"], r["size"])] = r
     for r in records:

--- a/tools/compile-perf/breakdown.py
+++ b/tools/compile-perf/breakdown.py
@@ -183,7 +183,7 @@ def _runs(results_dir, label, metric):
     if not os.path.exists(path):
         raise SystemExit(f"no results at {path}")
     out = []
-    for r in analyze.canonical_runs(json.load(open(path))):
+    for r in analyze.canonical_runs(analyze.read_json(path)):
         timers = {k: v[metric] for k, v in r["timers"].items() if v}
         out.append((r["workload"], r.get("size", 0), timers))
     return out
@@ -367,7 +367,7 @@ def coarse_buckets(timers):
 
 def _series(results_dir, index_path, metric, bucket_fn):
     """(order_tags, {workload: [bucketdict|None per release]}) using bucket_fn."""
-    index = json.load(open(index_path))
+    index = analyze.read_json(index_path)
     order, per = [], {}
     for rec in index:
         if "slangc" not in rec:
@@ -377,7 +377,7 @@ def _series(results_dir, index_path, metric, bucket_fn):
         if not os.path.exists(path):
             continue
         order.append(tag)
-        for r in analyze.canonical_runs(json.load(open(path))):
+        for r in analyze.canonical_runs(analyze.read_json(path)):
             timers = {k: v[metric] for k, v in r["timers"].items() if v}
             per.setdefault(r["workload"], {})[tag] = bucket_fn(timers)
     return order, {wl: [bytag.get(t) for t in order] for wl, bytag in per.items()}
@@ -737,7 +737,7 @@ def render_stacked_sweep(results_dir, label, metric, out, cols=2, panel=(560, 30
     phase sub-counters stacked across sweep sizes N (x-axis linear in N, top edge =
     compileInner), showing how each phase's share scales as the workload grows.
     Pass `names=[wl]` (with cols=1) to render a single workload for its own page."""
-    runs = json.load(open(analyze.results_path(results_dir, label)))
+    runs = analyze.read_json(analyze.results_path(results_dir, label))
     per = {}
     for r in runs:
         if r.get("size", 0) <= 0:

--- a/tools/compile-perf/compare_repro.py
+++ b/tools/compile-perf/compare_repro.py
@@ -26,7 +26,7 @@ def load(run_dir):
         jp = analyze.results_path(run_dir, tag)
         if not os.path.isfile(jp):
             continue
-        for r in json.load(open(jp)):
+        for r in analyze.read_json(jp):
             out[(tag, r["workload"], r["size"])] = r
     return out
 

--- a/tools/compile-perf/daily_movers.py
+++ b/tools/compile-perf/daily_movers.py
@@ -56,9 +56,9 @@ def daily_points(results_dir, metric):
         if not os.path.exists(rpath):
             continue
         mpath = os.path.join(ddir, label, "meta.json")
-        meta = json.load(open(mpath)) if os.path.exists(mpath) else {}
+        meta = analyze.read_json(mpath) if os.path.exists(mpath) else {}
         vals = {}
-        for r in analyze.canonical_runs(json.load(open(rpath))):
+        for r in analyze.canonical_runs(analyze.read_json(rpath)):
             for t, st in (r.get("timers") or {}).items():
                 if st:
                     vals[(r["workload"], t)] = st[metric]

--- a/tools/compile-perf/ladder_scaling.py
+++ b/tools/compile-perf/ladder_scaling.py
@@ -31,7 +31,7 @@ def main():
     ap.add_argument("--metric", default="median", choices=["min", "median", "mean"])
     args = ap.parse_args()
 
-    index = json.load(open(args.index))
+    index = analyze.read_json(args.index)
     rows = []
     for rec in index:
         tag = rec.get("tag")
@@ -41,7 +41,7 @@ def main():
         if not os.path.exists(p):
             continue
         pts = []
-        for r in json.load(open(p)):
+        for r in analyze.read_json(p):
             st = r["timers"].get("compileInner")
             if r["workload"] == args.workload and st and r["size"] > 0:
                 pts.append((r["size"], st[args.metric]))

--- a/tools/compile-perf/lib/analyze.py
+++ b/tools/compile-perf/lib/analyze.py
@@ -42,6 +42,26 @@ def open_output(path, mode="w"):
     return open(path, mode, encoding="utf-8", newline="\n")
 
 
+def read_json(path):
+    """json.load with explicit UTF-8, the read-side twin of open_output.
+
+    Suite files are WRITTEN as UTF-8 (open_output), but a bare open() READS
+    with the platform default — cp1252 on the Windows runner — so any
+    non-ASCII byte (an em dash in a rendered SVG, a smart quote in a compiler
+    diagnostic captured into results.json) raises UnicodeDecodeError there
+    while passing everywhere else. Every suite read goes through here or
+    read_text so the pair cannot drift."""
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def read_text(path):
+    """Read a suite-owned text file (SVG, HTML fragment) as UTF-8. See
+    read_json for why the encoding must be explicit."""
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
 def results_dir_for(results_dir, label):
     """Return the directory that holds `label`'s results.json.
 

--- a/tools/compile-perf/report.py
+++ b/tools/compile-perf/report.py
@@ -47,7 +47,7 @@ def combined_index(release_index, results_dir):
             if not os.path.exists(os.path.join(ddir, label, "results.json")):
                 continue
             mp = os.path.join(ddir, label, "meta.json")
-            meta = json.load(open(mp)) if os.path.exists(mp) else {}
+            meta = analyze.read_json(mp) if os.path.exists(mp) else {}
             recs.append({"tag": label, "date": meta.get("date", label[:10]),
                          "version": meta.get("commit", ""), "slangc": "tot",
                          "kind": "daily",
@@ -226,7 +226,7 @@ def main():
         for cad, ipath, cad_title, note in (
                 ("tot", paths["daily"], "daily tip-of-tree", day_note),
                 ("releases", paths["releases"], "across releases", rel_note)):
-            idx = json.load(open(ipath))
+            idx = analyze.read_json(ipath)
             svg = None
             if idx:
                 svgp = os.path.join(outdir, f"perf_{prefix}_{cad}.svg")

--- a/tools/compile-perf/sweep.py
+++ b/tools/compile-perf/sweep.py
@@ -72,7 +72,7 @@ def main():
             # (non-swept) results.json from a prior run must not mask a pending
             # sweep. Tolerate an unreadable/partial file by re-running.
             try:
-                prev = json.load(open(done))
+                prev = analyze.read_json(done)
             except (json.JSONDecodeError, OSError) as e:
                 prev = []
                 print(f"  (note: unreadable {done} ({e}); re-running)")

--- a/tools/compile-perf/sweep_report.py
+++ b/tools/compile-perf/sweep_report.py
@@ -54,7 +54,7 @@ def load_sweeps(results_dir, label, metric):
     path = analyze.results_path(results_dir, label)
     if not os.path.exists(path):
         raise SystemExit(f"no results at {path}; run bench.py --label {label} --sweep first")
-    runs = json.load(open(path))
+    runs = analyze.read_json(path)
     by_wl = {}
     for r in runs:
         if r["size"] <= 0:
@@ -146,7 +146,7 @@ def bucket_series(results_dir, label, metric):
     The floor is the `minimal` workload's bucket decomposition — the same
     fixed-per-compile canary the top-level panels anchor their linear
     expectation to, split by bucket ({} if minimal wasn't run)."""
-    runs = json.load(open(analyze.results_path(results_dir, label)))
+    runs = analyze.read_json(analyze.results_path(results_dir, label))
     per, floor_b = {}, {}
     for r in runs:
         if not r.get("timers"):
@@ -410,7 +410,7 @@ def write_sweep_pages(results_dir, label, metric, sweeps, floor, outdir):
         breakdown.render_stacked_sweep(
             results_dir, label, metric, svgp, cols=1, names=[wl], panel=(1000, 420),
             title=f"{wl} — phase composition vs N ({label}, {metric} ms)")
-        svg = open(svgp).read()
+        svg = analyze.read_text(svgp)
 
         ft = fit(ci, floor)
         kk, top = ft["k"], ft["top"]
@@ -476,7 +476,7 @@ def _swept_workload_count(path):
     An unreadable file (corrupt json, permission change) counts as unswept
     rather than aborting the scan — matching sweep.py's completeness loader."""
     try:
-        runs = json.load(open(path))
+        runs = analyze.read_json(path)
     except (ValueError, OSError):
         return 0
     per = {}
@@ -504,7 +504,7 @@ def find_swept_labels(results_dir):
     ipath = os.path.join(results_dir, "index.json")
     if os.path.exists(ipath):
         try:
-            order = [r["tag"] for r in json.load(open(ipath))]
+            order = [r["tag"] for r in analyze.read_json(ipath)]
         except (ValueError, OSError):
             order = None
     if os.path.isdir(rdir):
@@ -537,7 +537,7 @@ def render_label(results_dir, label, metric, outdir):
     # build (the suite's floor canary). Subtracted before the power-law fit so the
     # exponent reflects feature work, not the floor. 0 if minimal wasn't run.
     floor = 0.0
-    raw = json.load(open(analyze.results_path(results_dir, label)))
+    raw = analyze.read_json(analyze.results_path(results_dir, label))
     for r in raw:
         if r["workload"] == "minimal" and r["timers"].get("compileInner"):
             floor = r["timers"]["compileInner"][metric]
@@ -549,7 +549,7 @@ def render_label(results_dir, label, metric, outdir):
     links = write_sweep_pages(results_dir, label, metric, sweeps, floor, outdir)
     svg = render_panels(sweeps, metric, os.path.join(outdir, "sweep_curves.svg"),
                         floor, link_for=links)
-    inline = open(svg).read()
+    inline = analyze.read_text(svg)
 
     names = canonical_order(sweeps)
     H = ['<!doctype html><meta charset="utf-8">',

--- a/tools/compile-perf/track.py
+++ b/tools/compile-perf/track.py
@@ -70,7 +70,7 @@ def _point_metrics(results_json_path):
     history and daily points compare like-with-like. The median (not min) is the
     saved/compared value: it reflects the typical run rather than the single
     luckiest one, and is steadier when a build's run-to-run spread shifts."""
-    runs = analyze.canonical_runs(json.load(open(results_json_path)))
+    runs = analyze.canonical_runs(analyze.read_json(results_json_path))
     out = {}
     for r in runs:
         for timer, st in r["timers"].items():
@@ -83,7 +83,7 @@ def _release_points(results_dir, index_path):
     if not os.path.exists(index_path):
         return []
     pts = []
-    for rec in json.load(open(index_path)):
+    for rec in analyze.read_json(index_path):
         rj = analyze.results_path(results_dir, rec.get("tag", ""))
         if "slangc" not in rec or not os.path.exists(rj):
             continue
@@ -105,7 +105,7 @@ def _daily_points(results_dir):
         meta = {}
         mp = os.path.join(ddir, label, "meta.json")
         if os.path.exists(mp):
-            meta = json.load(open(mp))
+            meta = analyze.read_json(mp)
         date = meta.get("date") or label[:10]  # label prefix is YYYY-MM-DD
         pts.append({"label": label, "date": date, "kind": "daily",
                     "commit": meta.get("commit", ""),
@@ -132,7 +132,7 @@ def assemble(results_dir, index_path):
     runner = ""
     rp = os.path.join(results_dir, "runner.json")
     if os.path.exists(rp):
-        runner = json.load(open(rp)).get("fingerprint", "")
+        runner = analyze.read_json(rp).get("fingerprint", "")
     return {"runner": runner, "last_release": rel[-1]["label"] if rel else None,
             "points": rel + tail}
 
@@ -182,10 +182,10 @@ def merge_index(results_dir, new_index_path):
     dest = os.path.join(results_dir, "index.json")
     existing = {}
     if os.path.exists(dest):
-        for r in json.load(open(dest)):
+        for r in analyze.read_json(dest):
             existing[r["tag"]] = r
     n_before = len(existing)
-    for r in json.load(open(new_index_path)):
+    for r in analyze.read_json(new_index_path):
         existing[r["tag"]] = r
     merged = sorted(existing.values(), key=lambda r: r.get("date", ""))
     with analyze.open_output(dest) as fh:

--- a/tools/compile-perf/trend.py
+++ b/tools/compile-perf/trend.py
@@ -99,7 +99,7 @@ def main():
     tpath = os.path.join(args.results, "tracking", "tracking.json")
     if not os.path.exists(tpath):
         raise SystemExit(f"no tracking series at {tpath}; run track.py rebuild first")
-    series = json.load(open(tpath))
+    series = analyze.read_json(tpath)
     pts = series.get("points", [])
     if len(pts) < 2:
         print("not enough points to trend (need >= 2)")


### PR DESCRIPTION
## Summary
- Fixes the sweep-archive page being dropped from today's pages deploy: `sweep_report.py` read an SVG with a bare `open()`, which decodes as cp1252 on the Windows perf runner and raised `UnicodeDecodeError` on the chart's `×` character ([failing step](https://github.com/shader-slang/slang/actions/runs/29409192450/job/87331946374#step:12:84); the step is continue-on-error, so the rest of the pages deployed).
- Closes the whole class: `lib/analyze.py` gains `read_json`/`read_text` — the read-side twins of `open_output`, one place owning the encoding — and all ~26 suite read sites go through them.

## Motivation
The suite writes every file as UTF-8 (`analyze.open_output`, added after trend.py's cp1252 console crash), but reads relied on the platform default encoding. Beyond the SVG that crashed today, `results.json` legitimately embeds compiler diagnostics captured for failure isolation — one smart quote in an MSVC message would poison every consumer on the runner (trend check, tracking rebuild, all report generators).

## Technical Details
Mechanical rewrite of `json.load(open(...))` → `analyze.read_json(...)` across the suite plus the two SVG/text reads → `analyze.read_text(...)`; `bench.py`'s two local reads (GNU-time memfile, results merge) get explicit `encoding=` (the memfile also gets `errors="replace"` since its producer isn't suite-controlled). The helper docstrings record why the encoding must be explicit so the pair can't drift.

## Test Plan
- Full `report.py` render + `sweep_report.py --publish` against the live results repo (24 releases + 14 daily), output identical.
- Import smoke passes (executes every import-time self-check fixture); this also runs as a PR gate via check-python-core.yml.
- After merge: the next pages deploy (release-resync batch or nightly) renders the sweep archive that today's deploy dropped — no data was lost, rendering is derived.