### PR TITLE
Split command-line process unit test

### DIFF
--- a/tools/slang-unit-test/unit-test-process.cpp
+++ b/tools/slang-unit-test/unit-test-process.cpp
@@ -480,7 +480,7 @@ static SlangResult _testServerParentMonitorIntegrationTest(UnitTestContext* cont
     slangTestCmdLine.addArg("-use-test-server");
     slangTestCmdLine.addArg("-server-count");
     slangTestCmdLine.addArg("1");
-    slangTestCmdLine.addArg("slang-unit-test-tool/CommandLineProcessReadCompleteLargeOutput");
+    slangTestCmdLine.addArg("slang-unit-test-tool/CommandLineProcessReadLargeStreamToCompletion");
 
     PROCESS_INFORMATION slangTestProcessInfo;
     {
@@ -633,7 +633,7 @@ static SlangResult _reflectTest(UnitTestContext* context)
     return SLANG_OK;
 }
 
-SLANG_UNIT_TEST(CommandLineProcessReadCompleteOutput)
+SLANG_UNIT_TEST(CommandLineProcessReadToCompletion)
 {
     SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 1)));
     SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 10)));
@@ -641,34 +641,35 @@ SLANG_UNIT_TEST(CommandLineProcessReadCompleteOutput)
     SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 10000)));
 }
 
-SLANG_UNIT_TEST(CommandLineProcessReadImmediateCrash)
+SLANG_UNIT_TEST(CommandLineProcessReadAfterImmediateCrash)
 {
-    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 1, 0)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 1, 1 / 2)));
 }
 
-SLANG_UNIT_TEST(CommandLineProcessReadCrashAtIndexFiveOutput)
+// Crash halfway through increasingly large output streams to exercise partial pipe reads.
+SLANG_UNIT_TEST(CommandLineProcessReadAfterSmallStreamCrash)
 {
-    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 10, 5)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 10, 10 / 2)));
 }
 
-SLANG_UNIT_TEST(CommandLineProcessReadCrashAtIndexFiveHundredOutput)
+SLANG_UNIT_TEST(CommandLineProcessReadAfterMediumStreamCrash)
 {
-    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 1000, 500)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 1000, 1000 / 2)));
 }
 
-SLANG_UNIT_TEST(CommandLineProcessReadCrashAtIndexFiveThousandOutput)
+SLANG_UNIT_TEST(CommandLineProcessReadAfterLargeStreamCrash)
 {
-    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 10000, 5000)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 10000, 10000 / 2)));
 }
 
-SLANG_UNIT_TEST(CommandLineProcessReadCompleteLargeOutput)
+SLANG_UNIT_TEST(CommandLineProcessReadLargeStreamToCompletion)
 {
     SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 100000)));
 }
 
-SLANG_UNIT_TEST(CommandLineProcessReadCrashAtIndexFiftyThousandOutput)
+SLANG_UNIT_TEST(CommandLineProcessReadAfterVeryLargeStreamCrash)
 {
-    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 100000, 50000)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 100000, 100000 / 2)));
 }
 
 SLANG_UNIT_TEST(CommandLineProcessReflect)
@@ -687,12 +688,12 @@ SLANG_UNIT_TEST(HTTPPacketConnectionPeerCrash)
 }
 
 #if defined(_WIN32)
-SLANG_UNIT_TEST(TestServerParentMonitorParentTermination)
+SLANG_UNIT_TEST(TestServerParentMonitorForcefulTermination)
 {
     SLANG_CHECK(SLANG_SUCCEEDED(_parentMonitorParentExitTest(unitTestContext, true)));
 }
 
-SLANG_UNIT_TEST(TestServerParentMonitorParentExit)
+SLANG_UNIT_TEST(TestServerParentMonitorGracefulExit)
 {
     SLANG_CHECK(SLANG_SUCCEEDED(_parentMonitorParentExitTest(unitTestContext, false)));
 }

--- a/tools/slang-unit-test/unit-test-process.cpp
+++ b/tools/slang-unit-test/unit-test-process.cpp
@@ -480,8 +480,7 @@ static SlangResult _testServerParentMonitorIntegrationTest(UnitTestContext* cont
     slangTestCmdLine.addArg("-use-test-server");
     slangTestCmdLine.addArg("-server-count");
     slangTestCmdLine.addArg("1");
-    slangTestCmdLine.addArg(
-        "slang-unit-test-tool/CommandLineProcessReadCompleteLargeOutput");
+    slangTestCmdLine.addArg("slang-unit-test-tool/CommandLineProcessReadCompleteLargeOutput");
 
     PROCESS_INFORMATION slangTestProcessInfo;
     {

--- a/tools/slang-unit-test/unit-test-process.cpp
+++ b/tools/slang-unit-test/unit-test-process.cpp
@@ -430,14 +430,6 @@ static SlangResult _parentMonitorParentExitTest(UnitTestContext* context, bool t
     return SLANG_OK;
 }
 
-static SlangResult _parentMonitorTest(UnitTestContext* context)
-{
-    SLANG_RETURN_ON_FAIL(_parentMonitorParentExitTest(context, true));
-    SLANG_RETURN_ON_FAIL(_parentMonitorParentExitTest(context, false));
-    SLANG_RETURN_ON_FAIL(_parentMonitorFailureModeTests(context));
-    return SLANG_OK;
-}
-
 static SlangResult _findChildTestServerProcessIds(DWORD parentProcessId, List<DWORD>& outProcessIds)
 {
     ScopedWinHandle snapshot(CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0));
@@ -488,7 +480,8 @@ static SlangResult _testServerParentMonitorIntegrationTest(UnitTestContext* cont
     slangTestCmdLine.addArg("-use-test-server");
     slangTestCmdLine.addArg("-server-count");
     slangTestCmdLine.addArg("1");
-    slangTestCmdLine.addArg("slang-unit-test-tool/CommandLineProcess");
+    slangTestCmdLine.addArg(
+        "slang-unit-test-tool/CommandLineProcessReadCompleteLargeOutput");
 
     PROCESS_INFORMATION slangTestProcessInfo;
     {
@@ -611,18 +604,6 @@ static SlangResult _countTest(UnitTestContext* context, Index size, Index crashI
     return v == endIndex ? SLANG_OK : SLANG_FAIL;
 }
 
-static SlangResult _countTests(UnitTestContext* context)
-{
-    const Index sizes[] = {1, 10, 1000, 1000, 10000, 100000};
-    for (auto size : sizes)
-    {
-        SLANG_RETURN_ON_FAIL(_countTest(context, size));
-        SLANG_RETURN_ON_FAIL(_countTest(context, size, size / 2));
-    }
-
-    return SLANG_OK;
-}
-
 static SlangResult _reflectTest(UnitTestContext* context)
 {
     RefPtr<Process> process;
@@ -653,16 +634,75 @@ static SlangResult _reflectTest(UnitTestContext* context)
     return SLANG_OK;
 }
 
-SLANG_UNIT_TEST(CommandLineProcess)
+SLANG_UNIT_TEST(CommandLineProcessReadCompleteOutput)
 {
-    SLANG_CHECK(SLANG_SUCCEEDED(_countTests(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_reflectTest(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_httpReflectTest(unitTestContext)));
-    SLANG_CHECK(SLANG_SUCCEEDED(_httpCrashTest(unitTestContext)));
-#if defined(_WIN32)
-    SLANG_CHECK(SLANG_SUCCEEDED(_parentMonitorTest(unitTestContext)));
-#endif
+    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 1)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 10)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 1000)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 10000)));
 }
+
+SLANG_UNIT_TEST(CommandLineProcessReadImmediateCrash)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 1, 0)));
+}
+
+SLANG_UNIT_TEST(CommandLineProcessReadCrashAtIndexFiveOutput)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 10, 5)));
+}
+
+SLANG_UNIT_TEST(CommandLineProcessReadCrashAtIndexFiveHundredOutput)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 1000, 500)));
+}
+
+SLANG_UNIT_TEST(CommandLineProcessReadCrashAtIndexFiveThousandOutput)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 10000, 5000)));
+}
+
+SLANG_UNIT_TEST(CommandLineProcessReadCompleteLargeOutput)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 100000)));
+}
+
+SLANG_UNIT_TEST(CommandLineProcessReadCrashAtIndexFiftyThousandOutput)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_countTest(unitTestContext, 100000, 50000)));
+}
+
+SLANG_UNIT_TEST(CommandLineProcessReflect)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_reflectTest(unitTestContext)));
+}
+
+SLANG_UNIT_TEST(HTTPPacketConnectionReflect)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_httpReflectTest(unitTestContext)));
+}
+
+SLANG_UNIT_TEST(HTTPPacketConnectionPeerCrash)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_httpCrashTest(unitTestContext)));
+}
+
+#if defined(_WIN32)
+SLANG_UNIT_TEST(TestServerParentMonitorParentTermination)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_parentMonitorParentExitTest(unitTestContext, true)));
+}
+
+SLANG_UNIT_TEST(TestServerParentMonitorParentExit)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_parentMonitorParentExitTest(unitTestContext, false)));
+}
+
+SLANG_UNIT_TEST(TestServerParentMonitorInvalidArguments)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(_parentMonitorFailureModeTests(unitTestContext)));
+}
+#endif
 
 SLANG_UNIT_TEST(HTTPHeaderContentLengthValidation)
 {


### PR DESCRIPTION
## Motivation

Running `slang-unit-test-tool/CommandLineProcess.internal` reports one unit test that can take
unusually long to complete. The test combined unrelated process behaviors: collecting output from
multiple child processes, reflecting data over stdin/stdout, exchanging HTTP packets, handling a
peer crash, and monitoring a parent process on Windows. The output-collection portion alone launched
twelve child processes and took 105 seconds when isolated, so the aggregate name did not identify
which behavior was slow.

## Proposed solution

Register each independent behavior as its own unit test. Separate every intentionally crashing
`count` child because the crash handling, rather than the amount of output, accounts for most of the
runtime. Keep the successful output cases grouped where they complete quickly, and retain a separate
100,000-line case for large-pipe coverage.

This preserves every unique scenario while making timing and failures attributable to a specific
behavior. It also removes one exact duplicate of the 1,000-line normal/crash pair, which repeated the
same deterministic work without adding coverage.

## Change summary

- `tools/slang-unit-test/unit-test-process.cpp:637` replaces the aggregate
  `CommandLineProcess` registration with focused output, reflection, HTTP packet, and Windows parent
  monitor registrations.
- `tools/slang-unit-test/unit-test-process.cpp:480` makes the parent-monitor integration fixture run
  the single non-crashing `CommandLineProcessReadLargeStreamToCompletion` test.
- The aggregate `_countTests` and `_parentMonitorTest` helpers are removed because their only purpose
  was to combine cases that now need independent reporting.

## Concepts and vocabulary

An intentionally crashing `count` child writes numbered lines through redirected stdout and exits at
a requested index. `_countTest` then verifies that `ProcessUtil::readUntilTermination` retained every
line produced before termination.

The parent-monitor integration fixture starts `slang-test` with one test server, terminates the
parent, and verifies that the test server also exits. Its selected unit test is only a workload that
keeps the process alive long enough to observe the server; the fixture is not responsible for
running all command-line process coverage.

## Process report

`_countTests` previously iterated over `1`, `10`, `1000`, `1000`, `10000`, and `100000`, running both
normal completion and intentional crash variants for every value. `_countTest` creates a
`test-process count` child, `ProcessUtil::readUntilTermination` drains its redirected streams, and the
line parser checks the complete sequence. Successful children complete quickly even at 100,000
lines, so the smaller successful cases remain together and the 100,000-line pipe-stress case has its
own registration. Each crashing child now has a separate registration because process crash handling
is independently slow. The second 1,000-line pair was identical to the first and is removed.

The stdin/stdout reflection path, HTTP reflection path, HTTP peer-crash path, and Windows parent
monitor paths call different helpers and validate different contracts. Giving `_reflectTest`,
`_httpReflectTest`, `_httpCrashTest`, `_parentMonitorParentExitTest`, and
`_parentMonitorFailureModeTests` their own registrations makes a failure or timeout name the contract
being exercised instead of reporting the generic `CommandLineProcess` name.

`_testServerParentMonitorIntegrationTest` formerly selected the aggregate test to keep its nested
`slang-test` process active. After removing that registration, it selects
`CommandLineProcessReadLargeStreamToCompletion`. This input is intentional: it is a deterministic,
non-crashing workload long enough for the ready-event handshake and child-process lookup. Adding all
new test prefixes would test unrelated behavior and is unnecessary because the outer unit-test run
already schedules those registrations independently.

## Reviewer Directives (maintained by agent)

- [LLM Claude PR Review] Name the parent-monitor tests by their forceful-termination and
  graceful-exit mechanisms so the distinction is visible in test listings.
  (https://github.com/shader-slang/slang/pull/12123#discussion_r3589395416)
- [LLM Claude PR Review] Name crash tests consistently by stream behavior and keep the mid-stream
  crash index explicitly tied to half the requested count.
  (https://github.com/shader-slang/slang/pull/12123#discussion_r3589395930)
