### PR TITLE
compile-perf: allow sweeping patch releases (include-patches dispatch input)

### DIFF
--- a/.github/workflows/compile-perf-release-sweep.yml
+++ b/.github/workflows/compile-perf-release-sweep.yml
@@ -30,6 +30,14 @@ on:
         description: "re-sweep releases already present (set true to resync a new runner)"
         type: boolean
         default: false
+      include-patches:
+        # Off by default: pre-v2026.13 patch releases are deliberately not
+        # backfilled (the tracked history stays at minor granularity before
+        # the cutoff), so a force resync over old windows must not pull them
+        # in. Set true to sweep a patch release such as v2026.13.1.
+        description: "include patch releases (vYYYY.N.M) in the since/until window"
+        type: boolean
+        default: false
 
 concurrency:
   group: compile-perf-release-sweep
@@ -109,6 +117,7 @@ jobs:
           UNTIL: ${{ github.event.inputs.until || '2026-12-31' }}
           SAMPLES: ${{ github.event.inputs.samples || '5' }}
           FORCE_ENABLED: ${{ github.event.inputs.force || 'false' }}
+          INCLUDE_PATCHES: ${{ github.event.inputs.include-patches || 'false' }}
           SWEEP: ${{ github.event.inputs.sweep || 'false' }}
         run: |
           set -euo pipefail
@@ -120,9 +129,10 @@ jobs:
 
           cd "$SUITE"
           force=(); [ "$FORCE_ENABLED" = "true" ] && force=(--force)
+          patches=(); [ "$INCLUDE_PATCHES" = "true" ] && patches=(--include-patches)
           # Prebuilt slangc for each release, matching THIS runner's platform.
           python3 fetch_releases.py --repo "$GITHUB_WORKSPACE" \
-            --since "$SINCE" --until "$UNTIL" "${force[@]}"
+            --since "$SINCE" --until "$UNTIL" "${force[@]}" "${patches[@]}"
           # Sweep every release into the results repo (history baseline).
           # --api: api-path workloads are part of the tracked suite; the driver
           # dlopens each release's libslang, so the whole window gets baselines.


### PR DESCRIPTION
## Summary
- Adds an `include-patches` input (default **false**) to the release-sweep workflow, passing `fetch_releases.py --include-patches` so patch releases can be swept by dispatch.

## Motivation
v2026.13.1 shipped the v2026.13-cycle perf fixes, and its sweep ladders are wanted on the archive next to v2026.13's to show the recovery — but the workflow's window selection only ever listed minor releases, so no dispatch window can currently reach a `vYYYY.N.M` tag. The CLI flag already exists (the nightly's new-release check uses it); this only exposes it.

## Technical Details
Default off deliberately: pre-v2026.13 patch releases are not backfilled (tracked history stays at minor granularity before the cutoff), so `force=true` resyncs over historical windows must not start pulling them in.

## Test Plan
- Workflow-only change; validated by dispatching a v2026.13.1 window with `include-patches=true, sweep=true` after merge (the intended first use).