### PR TITLE
Fix VM autodiff NativeString capture

### DIFF
--- a/source/slang/slang-emit-vm.cpp
+++ b/source/slang/slang-emit-vm.cpp
@@ -655,17 +655,25 @@ public:
             break;
         case kIROp_Store:
             {
+                auto storeInst = as<IRStore>(inst);
+                IRBuilder builder(inst);
+                // Use the destination type to determine how many bytes the store writes. For
+                // example, a string literal stored into a NativeString field has a zero-sized
+                // literal type, but the destination field holds a pointer-sized NativeString.
+                auto storedType =
+                    tryGetPointedToType(&builder, storeInst->getPtr()->getDataType());
+                SLANG_RELEASE_ASSERT(storedType);
                 IRSizeAndAlignment sizeAlignment = {};
                 getNaturalSizeAndAlignment(
                     codeGenContext->getTargetReq(),
-                    inst->getOperand(1)->getDataType(),
+                    storedType,
                     &sizeAlignment);
                 writeInst(
                     funcBuilder,
                     VMOp::Store,
                     (uint32_t)sizeAlignment.getStride(),
-                    ensureInst(inst->getOperand(0)),
-                    ensureInst(inst->getOperand(1)));
+                    ensureInst(storeInst->getPtr()),
+                    ensureInst(storeInst->getVal()));
             }
             break;
         case kIROp_Add:

--- a/source/slang/slang-emit-vm.cpp
+++ b/source/slang/slang-emit-vm.cpp
@@ -657,16 +657,20 @@ public:
             {
                 auto storeInst = as<IRStore>(inst);
                 IRBuilder builder(inst);
-                // Use the destination type to determine how many bytes the store writes. For
-                // example, a string literal stored into a NativeString field has a zero-sized
-                // literal type, but the destination field holds a pointer-sized NativeString.
-                auto storedType =
+
+                // A HostVM store must have a typed destination. NativePtr/ComPtr are opaque handle
+                // values and RawPointer is untyped, so none is a valid store destination here.
+                auto pointeeType =
                     tryGetPointedToType(&builder, storeInst->getPtr()->getDataType());
-                SLANG_RELEASE_ASSERT(storedType);
+                SLANG_RELEASE_ASSERT(pointeeType);
+
+                // Use the destination type to determine how many bytes the store writes. For
+                // example, StringType has no configured HostVM size, but a NativeString field is
+                // pointer-sized.
                 IRSizeAndAlignment sizeAlignment = {};
                 getNaturalSizeAndAlignment(
                     codeGenContext->getTargetReq(),
-                    storedType,
+                    pointeeType,
                     &sizeAlignment);
                 writeInst(
                     funcBuilder,

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -1618,6 +1618,7 @@ Result linkAndOptimizeIR(
     if (target == CodeGenTarget::HostVM)
     {
         SLANG_PASS(performForceInlining);
+        SLANG_PASS(cleanUpVoidType);
         SLANG_PASS(simplifyIR, targetProgram, defaultIRSimplificationOptions, sink);
         return SLANG_OK;
     }

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -1618,6 +1618,9 @@ Result linkAndOptimizeIR(
     if (target == CodeGenTarget::HostVM)
     {
         SLANG_PASS(performForceInlining);
+        // Autodiff can leave void differential parameters and matching call arguments, but the
+        // bytecode constants section cannot represent void values. Remove them before emission,
+        // as the later target pipelines do.
         SLANG_PASS(cleanUpVoidType);
         SLANG_PASS(simplifyIR, targetProgram, defaultIRSimplificationOptions, sink);
         return SLANG_OK;

--- a/tests/byte-code/autodiff-native-string.slang
+++ b/tests/byte-code/autodiff-native-string.slang
@@ -1,0 +1,36 @@
+//TEST:INTERPRET(filecheck=BC): -disasm
+//TEST:INTERPRET(filecheck=CHECK):
+
+[Differentiable]
+float square(float x, float y)
+{
+    let x2 = x * x;
+    let y2 = debugGrad("y2", y * y);
+    return x2 + y2;
+}
+
+float debugGrad(NativeString label, float x)
+{
+    return x;
+}
+
+[BackwardDerivativeOf(debugGrad)]
+void debugGradBwd(NativeString label, inout DifferentialPair<float> x, float dOut)
+{
+    printf("Gradient of %s is %f\n", label, dOut);
+    x = diffPair(x.p, dOut);
+}
+
+int main()
+{
+    var x = diffPair(3.0, 0.0);
+    var y = diffPair(4.0, 0.0);
+    bwd_diff(square)(x, y, 1.0f);
+    printf("dL/dx: %f, dL/dy: %f\n", x.d, y.d);
+    return 0;
+}
+
+// BC: func s_bwdProp_square
+// BC: call {{.*}}, s_bwdProp_debugGrad
+// CHECK: Gradient of y2 is 1.000000
+// CHECK: dL/dx: 6.000000, dL/dy: 8.000000

--- a/tests/byte-code/autodiff-native-string.slang
+++ b/tests/byte-code/autodiff-native-string.slang
@@ -31,6 +31,7 @@ int main()
 }
 
 // BC: func s_bwdProp_square
+// BC: store.8 {{.*}}, str:"y2"
 // BC: call {{.*}}, s_bwdProp_debugGrad
 // CHECK: Gradient of y2 is 1.000000
 // CHECK: dL/dx: 6.000000, dL/dy: 8.000000


### PR DESCRIPTION
## Motivation

Fixes #12124.

Consider this example:

```slang
[Differentiable]
float square(float x, float y)
{
    let x2 = x * x;
    let y2 = debugGrad("y2", y * y);
    return x2 + y2;
}

float debugGrad(NativeString label, float x) { return x; }

[BackwardDerivativeOf(debugGrad)]
void debugGradBwd(NativeString label, inout DifferentialPair<float> x, float dOut)
{
    printf("Gradient of %s is %f\n", label, dOut);
    x = diffPair(x.p, dOut);
}
```

Reverse-mode autodiff needs to preserve `"y2"` so the generated backward function can pass it to
`debugGradBwd`. Because strings are not differentiable, autodiff also creates an empty `void`
placeholder for the string's derivative.

The HostVM pipeline failed to remove this placeholder. When the VM tried to encode it as a
constant, the resulting operand pointed just past the constants section. Bytecode validation
treated that operand as out of bounds and rejected the program before the backward function could
run.

## Proposed solution

Run the existing `cleanUpVoidType` pass before the HostVM pipeline returns, just as later target
pipelines already do. This removes the autodiff-generated void parameter and its matching call
argument at the canonical IR cleanup boundary instead of teaching the bytecode format to represent
a value that carries no data.

Also make VM stores derive their byte count from the destination pointee type. A string literal is
allowed to initialize a `NativeString` field, but its literal IR type has zero size. The destination
field is the semantic source of truth: it contains a pointer-sized `NativeString`, so the VM must
store that many bytes.

## Change summary

- Run `cleanUpVoidType` in the HostVM early-exit path before the final simplification pass.
- Size VM store instructions from their destination pointee type and assert that a store has a
  valid pointed-to type.
- Add an interpreted/disassembled regression test covering a captured `NativeString`, a custom
  backward derivative, and the resulting gradients.

## Concepts and vocabulary

- **Backward callable context**: the generated struct that preserves primal values needed by a
  reverse-mode propagation function. In this case it contains the `NativeString` label and the
  primal floating-point argument.
- **Void differential**: the `Void` placeholder produced for a nondifferentiable parameter such as
  `NativeString`. It identifies the parameter during autodiff construction but carries no runtime
  data and must not survive target cleanup.
- **HostVM**: the target used by `slangi`; it lowers linked IR to Slang VM bytecode and executes it
  in the interpreter.

## Process report

Autodiff first generates `s_bwdProp_debugGrad` with a backward callable context, a void differential
for `label`, an output differential for `x`, and the output gradient. The caller in
`s_bwdProp_square` therefore initially contains the equivalent of:

```text
call s_bwdProp_debugGrad(context, void_constant, d_x, d_out)
```

This is an intentional intermediate autodiff shape. Other targets reach `cleanUpVoidType`, which
removes both the void function parameter and the corresponding `void_constant` call argument.
HostVM returned earlier from `linkAndOptimizeIR`, immediately after force inlining and
simplification, so the canonical cleanup never ran. `ByteCodeEmitter::addConstantValue` then saw
the surviving `VoidLit`; because it has no serialized payload, the resulting operand pointed at
the end of the constants section. Running the shared cleanup in the HostVM path fixes the producer-
consumer break without adding a VM-only void representation or special-case fallback.

That fix exposed the next issue rather than masking it: the call became valid, but the printed
label was empty. The backward callable context is built by storing `"y2"` through a pointer to its
`NativeString` field. `ByteCodeEmitter::emitInst` previously chose the store width from the source
operand's literal type, whose natural size is zero, and emitted a zero-byte store. The context
shape is valid and intentionally allowed; the bug belongs to bytecode emission. A store's
destination pointee type defines the memory object being written, so using that type produces an
eight-byte store on this host and preserves the captured pointer.

The resulting `store` destination comes from `ExtractPrimalFuncContext::storeInst`, which explicitly
constructs a typed `Ptr<NativeString>` with `emitFieldAddress`. HostVM does not run the C++ pass that
converts entry-point parameters to untyped `RawPointer`, and `NativePtr`/`ComPtr` are opaque handle
values rather than dereferenceable store destinations. A surviving store through any of those types
would therefore violate the HostVM emitter contract; the release assertion documents that invariant.
Falling back to the source value type would recreate the original zero-width string-literal store, so
the destination type remains the only source of truth.

No new equivalence relation, AST/IR representation, fallback, or custom matching helper was added.
I rejected serializing `VoidLit` into the constants section because it would preserve an IR value
that the existing cleanup contract says must be removed. I also rejected a string-literal-only
store special case because destination-based sizing handles the general store invariant and keeps
the type mapping in one place.

Validation after the review fixes:

- Debug build of `slangi` and `slang-test` completed successfully.
- `build/Debug/bin/slang-test tests/byte-code`: 9/9 passed.
- `build/Debug/bin/slang-test slang-unit-test-tool/slangVM`: 29/29 passed.
- `./extras/formatting.sh --check-only -- source/slang/slang-emit-vm.cpp source/slang/slang-emit.cpp` passed.
- The regression disassembly emits pointer-sized `store.8` instructions for `"y2"`, and execution
  prints `Gradient of y2 is 1.000000` followed by `dL/dx: 6.000000, dL/dy: 8.000000`.
