### PR TITLE
Revert "Pin nightly coverage macOS job to macos-15"

### DIFF
--- a/.github/workflows/nightly-slang-coverage-test.yml
+++ b/.github/workflows/nightly-slang-coverage-test.yml
@@ -38,10 +38,7 @@ jobs:
       compiler: clang
       platform: aarch64
       config: relwithdebinfo
-      # macos-latest includes different runner images; macos-15 is the
-      # one where Metal gfx tests work (macos-26 fails on a Metal 4 vs
-      # toolchain skew, see #11985). Unpin once #11985 is resolved.
-      runs-on: '["macos-15"]'
+      runs-on: '["macos-latest"]'
       build-llvm: true
       deploy-pages: false
       server-count: 1


### PR DESCRIPTION
Reverts shader-slang/slang#12075

Because a fix for #11985 is merged:
- https://github.com/shader-slang/slang/pull/12009

Closes https://github.com/shader-slang/slang/issues/11985