### PR TITLE
fix: Allow specialization-constant [numthreads] with compute derivative

### DIFF
--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -2469,25 +2469,23 @@ void verifyComputeDerivativeGroupModifiers(
             Diagnostics::OnlyOneOfDerivativeGroupLinearOrQuadCanBeSet{.location = errorLoc});
     }
 
-    IRIntegerValue x = 1;
-    IRIntegerValue y = 1;
-    IRIntegerValue z = 1;
-    if (numThreadsDecor->getX())
-        x = numThreadsDecor->getX()->getValue();
-    if (numThreadsDecor->getY())
-        y = numThreadsDecor->getY()->getValue();
-    if (numThreadsDecor->getZ())
-        z = numThreadsDecor->getZ()->getValue();
+    // A thread-group axis can only be validated when it is a compile-time literal.
+    // Specialization constants (`OpExecutionModeId LocalSizeId`) must be validated at
+    // pipeline creation time.
+    IRIntLit* xLit = numThreadsDecor->getX();
+    IRIntLit* yLit = numThreadsDecor->getY();
+    IRIntLit* zLit = numThreadsDecor->getZ();
 
     if (quadAttr)
     {
-        if (x % 2 != 0 || y % 2 != 0)
+        if ((xLit && xLit->getValue() % 2 != 0) || (yLit && yLit->getValue() % 2 != 0))
             sink->diagnose(
                 Diagnostics::DerivativeGroupQuadMustBeMultiple2ForXyThreads{.location = errorLoc});
     }
     else if (linearAttr)
     {
-        if ((x * y * z) % 4 != 0)
+        if (xLit && yLit && zLit &&
+            (xLit->getValue() * yLit->getValue() * zLit->getValue()) % 4 != 0)
             sink->diagnose(Diagnostics::DerivativeGroupLinearMustBeMultiple4ForTotalThreadCount{
                 .location = errorLoc});
     }

--- a/tests/glsl-intrinsic/compute-derivative/derivative-mode-spec-constant-numthreads.slang
+++ b/tests/glsl-intrinsic/compute-derivative/derivative-mode-spec-constant-numthreads.slang
@@ -9,22 +9,32 @@
 // GLSL `local_size_*_id`) is allowed with compute derivative groups; Vulkan
 // validates the resolved size at pipeline creation time.
 
-// CHECK_SPV_QUAD-DAG: OpExecutionModeId %computeMain LocalSizeId
+// CHECK_SPV_QUAD-DAG: OpExecutionModeId %computeMain LocalSizeId %[[SX:[0-9A-Za-z_]+]] %[[SY:[0-9A-Za-z_]+]] %[[SZ:[0-9A-Za-z_]+]]
+// CHECK_SPV_QUAD-DAG: OpDecorate %[[SX]] SpecId 0
+// CHECK_SPV_QUAD-DAG: OpDecorate %[[SY]] SpecId 1
+// CHECK_SPV_QUAD-DAG: %[[SZ]] = OpConstant %{{u?}}int 1
 // CHECK_SPV_QUAD-DAG: OpExecutionMode %computeMain DerivativeGroupQuads{{NV|KHR}}
 
-// CHECK_SPV_LINEAR-DAG: OpExecutionModeId %computeMain LocalSizeId
+// CHECK_SPV_LINEAR-DAG: OpExecutionModeId %computeMain LocalSizeId %[[SX:[0-9A-Za-z_]+]] %[[SY:[0-9A-Za-z_]+]] %[[SZ:[0-9A-Za-z_]+]]
+// CHECK_SPV_LINEAR-DAG: OpDecorate %[[SX]] SpecId 0
+// CHECK_SPV_LINEAR-DAG: OpDecorate %[[SY]] SpecId 1
+// CHECK_SPV_LINEAR-DAG: %[[SZ]] = OpConstant %{{u?}}int 1
 // CHECK_SPV_LINEAR-DAG: OpExecutionMode %computeMain DerivativeGroupLinear{{NV|KHR}}
 
 // CHECK_GLSL_QUAD-DAG: layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z = 1) in;
 // CHECK_GLSL_QUAD-DAG: layout(derivative_group_quadsNV) in;
 
-// Verufy that glslang also accepts spec-constant local size combined with a
+// Verify that glslang also accepts spec-constant local size combined with a
 // derivative-group layout qualifier.
+// CHECK_VIA_GLSL_QUAD-DAG: OpExecutionModeId %main LocalSizeId %[[GSX:[0-9A-Za-z_]+]] %[[GSY:[0-9A-Za-z_]+]] %[[GSZ:[0-9A-Za-z_]+]]
 // CHECK_VIA_GLSL_QUAD-DAG: OpExecutionMode %main DerivativeGroupQuads{{NV|KHR}}
-// CHECK_VIA_GLSL_QUAD-DAG: SpecId 0
+// CHECK_VIA_GLSL_QUAD-DAG: OpDecorate %[[GSX]] SpecId 0
+// CHECK_VIA_GLSL_QUAD-DAG: OpDecorate %[[GSY]] SpecId 1
 
+// CHECK_VIA_GLSL_LINEAR-DAG: OpExecutionModeId %main LocalSizeId %[[GSX:[0-9A-Za-z_]+]] %[[GSY:[0-9A-Za-z_]+]] %[[GSZ:[0-9A-Za-z_]+]]
 // CHECK_VIA_GLSL_LINEAR-DAG: OpExecutionMode %main DerivativeGroupLinear{{NV|KHR}}
-// CHECK_VIA_GLSL_LINEAR-DAG: SpecId 0
+// CHECK_VIA_GLSL_LINEAR-DAG: OpDecorate %[[GSX]] SpecId 0
+// CHECK_VIA_GLSL_LINEAR-DAG: OpDecorate %[[GSY]] SpecId 1
 
 // A literal axis that violates the quad constraint is still diagnosed even
 // when another axis is a specialization constant.

--- a/tests/glsl-intrinsic/compute-derivative/derivative-mode-spec-constant-numthreads.slang
+++ b/tests/glsl-intrinsic/compute-derivative/derivative-mode-spec-constant-numthreads.slang
@@ -3,22 +3,16 @@
 //TEST:SIMPLE(filecheck=CHECK_GLSL_QUAD): -stage compute -entry computeMain -target glsl -DQUAD
 //TEST:SIMPLE(filecheck=CHECK_VIA_GLSL_QUAD): -stage compute -entry computeMain -target spirv -emit-spirv-via-glsl -DQUAD
 //TEST:SIMPLE(filecheck=CHECK_VIA_GLSL_LINEAR): -stage compute -entry computeMain -target spirv -emit-spirv-via-glsl -DLINEAR
-//TEST:SIMPLE(filecheck=CHECK_ERR): -stage compute -entry computeMain -target spirv -DQUAD_ODD_X
+//TEST:SIMPLE(diag=CHECK_ERR): -stage compute -entry computeMain -target spirv -DQUAD_ODD_X
 
 // A workgroup size given by specialization constants (SPIR-V `LocalSizeId`,
 // GLSL `local_size_*_id`) is allowed with compute derivative groups; Vulkan
 // validates the resolved size at pipeline creation time.
 
-// CHECK_SPV_QUAD-DAG: OpExecutionModeId %computeMain LocalSizeId %[[SX:[0-9A-Za-z_]+]] %[[SY:[0-9A-Za-z_]+]] %[[SZ:[0-9A-Za-z_]+]]
-// CHECK_SPV_QUAD-DAG: OpDecorate %[[SX]] SpecId 0
-// CHECK_SPV_QUAD-DAG: OpDecorate %[[SY]] SpecId 1
-// CHECK_SPV_QUAD-DAG: %[[SZ]] = OpConstant %{{u?}}int 1
+// CHECK_SPV_QUAD-DAG: OpExecutionModeId %computeMain LocalSizeId
 // CHECK_SPV_QUAD-DAG: OpExecutionMode %computeMain DerivativeGroupQuads{{NV|KHR}}
 
-// CHECK_SPV_LINEAR-DAG: OpExecutionModeId %computeMain LocalSizeId %[[SX:[0-9A-Za-z_]+]] %[[SY:[0-9A-Za-z_]+]] %[[SZ:[0-9A-Za-z_]+]]
-// CHECK_SPV_LINEAR-DAG: OpDecorate %[[SX]] SpecId 0
-// CHECK_SPV_LINEAR-DAG: OpDecorate %[[SY]] SpecId 1
-// CHECK_SPV_LINEAR-DAG: %[[SZ]] = OpConstant %{{u?}}int 1
+// CHECK_SPV_LINEAR-DAG: OpExecutionModeId %computeMain LocalSizeId
 // CHECK_SPV_LINEAR-DAG: OpExecutionMode %computeMain DerivativeGroupLinear{{NV|KHR}}
 
 // CHECK_GLSL_QUAD-DAG: layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z = 1) in;
@@ -26,19 +20,11 @@
 
 // Verify that glslang also accepts spec-constant local size combined with a
 // derivative-group layout qualifier.
-// CHECK_VIA_GLSL_QUAD-DAG: OpExecutionModeId %main LocalSizeId %[[GSX:[0-9A-Za-z_]+]] %[[GSY:[0-9A-Za-z_]+]] %[[GSZ:[0-9A-Za-z_]+]]
 // CHECK_VIA_GLSL_QUAD-DAG: OpExecutionMode %main DerivativeGroupQuads{{NV|KHR}}
-// CHECK_VIA_GLSL_QUAD-DAG: OpDecorate %[[GSX]] SpecId 0
-// CHECK_VIA_GLSL_QUAD-DAG: OpDecorate %[[GSY]] SpecId 1
+// CHECK_VIA_GLSL_QUAD-DAG: SpecId 0
 
-// CHECK_VIA_GLSL_LINEAR-DAG: OpExecutionModeId %main LocalSizeId %[[GSX:[0-9A-Za-z_]+]] %[[GSY:[0-9A-Za-z_]+]] %[[GSZ:[0-9A-Za-z_]+]]
 // CHECK_VIA_GLSL_LINEAR-DAG: OpExecutionMode %main DerivativeGroupLinear{{NV|KHR}}
-// CHECK_VIA_GLSL_LINEAR-DAG: OpDecorate %[[GSX]] SpecId 0
-// CHECK_VIA_GLSL_LINEAR-DAG: OpDecorate %[[GSY]] SpecId 1
-
-// A literal axis that violates the quad constraint is still diagnosed even
-// when another axis is a specialization constant.
-// CHECK_ERR: error[E31210]
+// CHECK_VIA_GLSL_LINEAR-DAG: SpecId 0
 
 [vk::constant_id(0)]
 const int threadCountX = 8;
@@ -55,10 +41,19 @@ RWStructuredBuffer<float> outputBuffer;
 [DerivativeGroupLinear]
 [numthreads(threadCountX, threadCountY, 1)]
 #elif defined(QUAD_ODD_X)
+// A literal axis that violates the quad constraint is still diagnosed even
+// when another axis is a specialization constant.
 [DerivativeGroupQuad]
 [numthreads(3, threadCountY, 1)]
+// CHECK_ERR: ([[#@LINE-1]]): error 31210: 
+// CHECK_ERR:   [numthreads(3, threadCountY, 1)]
+// CHECK_ERR:               ^
 #endif
 void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+/*CHECK_ERR:
+     ^^^^^^^^^^^ derivative group quad thread count error
+     ^^^^^^^^^^^ compute derivative group quad requires thread dispatch count of X and Y to each be at a multiple of 2
+*/
 {
     outputBuffer[0] = ddx_fine(float(dispatchThreadID.x));
 }

--- a/tests/glsl-intrinsic/compute-derivative/derivative-mode-spec-constant-numthreads.slang
+++ b/tests/glsl-intrinsic/compute-derivative/derivative-mode-spec-constant-numthreads.slang
@@ -1,0 +1,54 @@
+//TEST:SIMPLE(filecheck=CHECK_SPV_QUAD): -stage compute -entry computeMain -target spirv -DQUAD
+//TEST:SIMPLE(filecheck=CHECK_SPV_LINEAR): -stage compute -entry computeMain -target spirv -DLINEAR
+//TEST:SIMPLE(filecheck=CHECK_GLSL_QUAD): -stage compute -entry computeMain -target glsl -DQUAD
+//TEST:SIMPLE(filecheck=CHECK_VIA_GLSL_QUAD): -stage compute -entry computeMain -target spirv -emit-spirv-via-glsl -DQUAD
+//TEST:SIMPLE(filecheck=CHECK_VIA_GLSL_LINEAR): -stage compute -entry computeMain -target spirv -emit-spirv-via-glsl -DLINEAR
+//TEST:SIMPLE(filecheck=CHECK_ERR): -stage compute -entry computeMain -target spirv -DQUAD_ODD_X
+
+// A workgroup size given by specialization constants (SPIR-V `LocalSizeId`,
+// GLSL `local_size_*_id`) is allowed with compute derivative groups; Vulkan
+// validates the resolved size at pipeline creation time.
+
+// CHECK_SPV_QUAD-DAG: OpExecutionModeId %computeMain LocalSizeId
+// CHECK_SPV_QUAD-DAG: OpExecutionMode %computeMain DerivativeGroupQuads{{NV|KHR}}
+
+// CHECK_SPV_LINEAR-DAG: OpExecutionModeId %computeMain LocalSizeId
+// CHECK_SPV_LINEAR-DAG: OpExecutionMode %computeMain DerivativeGroupLinear{{NV|KHR}}
+
+// CHECK_GLSL_QUAD-DAG: layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z = 1) in;
+// CHECK_GLSL_QUAD-DAG: layout(derivative_group_quadsNV) in;
+
+// Verufy that glslang also accepts spec-constant local size combined with a
+// derivative-group layout qualifier.
+// CHECK_VIA_GLSL_QUAD-DAG: OpExecutionMode %main DerivativeGroupQuads{{NV|KHR}}
+// CHECK_VIA_GLSL_QUAD-DAG: SpecId 0
+
+// CHECK_VIA_GLSL_LINEAR-DAG: OpExecutionMode %main DerivativeGroupLinear{{NV|KHR}}
+// CHECK_VIA_GLSL_LINEAR-DAG: SpecId 0
+
+// A literal axis that violates the quad constraint is still diagnosed even
+// when another axis is a specialization constant.
+// CHECK_ERR: error[E31210]
+
+[vk::constant_id(0)]
+const int threadCountX = 8;
+
+[vk::constant_id(1)]
+const int threadCountY = 8;
+
+RWStructuredBuffer<float> outputBuffer;
+
+#if defined(QUAD)
+[DerivativeGroupQuad]
+[numthreads(threadCountX, threadCountY, 1)]
+#elif defined(LINEAR)
+[DerivativeGroupLinear]
+[numthreads(threadCountX, threadCountY, 1)]
+#elif defined(QUAD_ODD_X)
+[DerivativeGroupQuad]
+[numthreads(3, threadCountY, 1)]
+#endif
+void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
+{
+    outputBuffer[0] = ddx_fine(float(dispatchThreadID.x));
+}


### PR DESCRIPTION
I'm migrating from GLSL to slang and stumbled on this getting falsely rejected:

```slang
[vk::constant_id(0)] const int threadCountX = 1;
[vk::constant_id(1)] const int threadCountY = 1;

[DerivativeGroupQuad]
[numthreads(threadCountX, threadCountY, 1)]
void computeMain(uint3 dispatchThreadID: SV_DispatchThreadID)
{
    ... = ddx_fine(float(dispatchThreadID.x));
}
```

Equivalent GLSL `layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z = 1) in` + `dFdx` is valid with shaderc