### PR TITLE
Use `-Og` optimization level for GCC/Clang debug builds

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -172,6 +172,17 @@ function(set_default_compile_options target)
         )
     endif()
 
+    # Use `-Og` for Debug builds on GCC/Clang. `-Og` enables the
+    # optimizations that do not interfere with debugging, producing
+    # noticeably faster Debug binaries while keeping a faithful
+    # step-through/inspection experience.
+    #
+    # Note that MSVC has no `-Og` equivalent, so we'll keep the
+    # default optimization level (`/Od`) for now.
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(${target} PRIVATE $<$<CONFIG:Debug>:-Og>)
+    endif()
+
     if(NOT WIN32)
         # these options are for ELF specific and not for Windows
         add_supported_cxx_linker_flags(

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -177,9 +177,15 @@ function(set_default_compile_options target)
     # noticeably faster Debug binaries while keeping a faithful
     # step-through/inspection experience.
     #
-    # Note that MSVC has no `-Og` equivalent, so we'll keep the
-    # default optimization level (`/Od`) for now.
-    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    # This is appended after `CMAKE_CXX_FLAGS_DEBUG` (which is `-O0 -g` for
+    # GCC/Clang), so `-Og` overrides CMake's default `-O0` by last-`-O`-wins
+    # semantics.
+    #
+    # The `NOT MSVC` guard excludes the MSVC-compatible frontend: `clang-cl`
+    # reports `CMAKE_CXX_COMPILER_ID` as `Clang` but expects MSVC-style flags,
+    # so it must keep the default `/Od` optimization level rather than receive
+    # the GNU-style `-Og`. Plain MSVC (`cl`) has no `-Og` equivalent either.
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND NOT MSVC)
         target_compile_options(${target} PRIVATE $<$<CONFIG:Debug>:-Og>)
     endif()
 

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -185,6 +185,13 @@ function(set_default_compile_options target)
     # reports `CMAKE_CXX_COMPILER_ID` as `Clang` but expects MSVC-style flags,
     # so it must keep the default `/Od` optimization level rather than receive
     # the GNU-style `-Og`. Plain MSVC (`cl`) has no `-Og` equivalent either.
+    #
+    # `-Og` is applied with a raw `target_compile_options` rather than through
+    # `add_supported_cxx_flags`: that helper feature-tests via
+    # `check_cxx_compiler_flag`, which operates on a literal flag string and
+    # cannot see through the `$<$<CONFIG:Debug>:...>` generator expression
+    # needed to condition `-Og` on the Debug config. Hardcoding is safe since
+    # `-Og` has been supported by GCC since 4.8 and by Clang for years.
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" AND NOT MSVC)
         target_compile_options(${target} PRIVATE $<$<CONFIG:Debug>:-Og>)
     endif()


### PR DESCRIPTION
`-Og` enables the optimizations that do not interfere with debugging, producing noticeably faster Debug binaries while keeping a faithful step-through/inspection experience.

On my local machine (Ubuntu 24.04 LTS, GCC 13.3.0), I recorded the following times for full `slang-test` runs (single-threaded, no job server):

Debug build: (before this PR)
real    95m2,292s
user    88m53,916s
sys     7m27,829s

Debug build: (after this PR)
real    21m29,354s
user    15m2,473s
sys     6m42,842s

Release build:
real    15m45,729s
user    9m20,037s
sys     6m35,941s