### PR TITLE
[Metal] Fix RayQuery TriangleFrontFace emission

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -22041,7 +22041,8 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
 
 ${
     const char* kCandidateCommitted[] = {"Candidate", "Committed"};
-    const char* kCandidateCommittedMetal[] = {"get_candidate_", "get_committed_"};
+    // Middle piece of the MSL method name. Callers add the "get_" or "is_" prefix.
+    const char* kCandidateCommittedMetal[] = {"candidate_", "committed_"};
 
     // Access Candidate and Committed Matrices.
     for (uint32_t candidateOrCommitted = 0; candidateOrCommitted < 2; candidateOrCommitted++)
@@ -22134,7 +22135,7 @@ $}
         {
         case glsl: __intrinsic_asm "transpose(rayQueryGetIntersection$(method.name)EXT($0, $(ccTF)))";
         case hlsl: __intrinsic_asm ".$(ccName)$(method.name)3x4";
-        case metal: __intrinsic_asm "transpose($0->$(ccNameMetal)$(method.metalName)())";
+        case metal: __intrinsic_asm "transpose($0->get_$(ccNameMetal)$(method.metalName)())";
         case spirv:
             uint iCandidateOrCommitted = $(candidateOrCommitted);
             return spirv_asm
@@ -22158,7 +22159,7 @@ $}
         {
         case glsl: __intrinsic_asm "rayQueryGetIntersection$(method.name)EXT($0, $(ccTF))";
         case hlsl: __intrinsic_asm ".$(ccName)$(method.name)4x3";
-        case metal: __intrinsic_asm "$0->$(ccNameMetal)$(method.metalName)()";
+        case metal: __intrinsic_asm "$0->get_$(ccNameMetal)$(method.metalName)()";
         case spirv:
             uint iCandidateOrCommitted = $(candidateOrCommitted);
             return spirv_asm
@@ -22190,6 +22191,8 @@ ${
         {"float2", "TriangleBarycentrics", "Barycentrics", "triangle_barycentric_coord"},
     };
     for (auto method : rayQueryMethods) {
+        // MSL names boolean queries "is_" and everything else "get_".
+        auto metalPrefix = strcmp(method.type, "bool") == 0 ? "is_" : "get_";
 $}
 
     __glsl_extension(GL_EXT_ray_query)
@@ -22202,7 +22205,7 @@ $}
         {
         case hlsl: __intrinsic_asm ".$(ccName)$(method.hlslName)";
         case glsl: __intrinsic_asm "rayQueryGetIntersection$(method.glslName)EXT($0, $(ccTF))";
-        case metal: __intrinsic_asm "$0->$(ccNameMetal)$(method.metalName)()";
+        case metal: __intrinsic_asm "$0->$(metalPrefix)$(ccNameMetal)$(method.metalName)()";
         case spirv:
             uint iCandidateOrCommitted = $(candidateOrCommitted);
             return spirv_asm

--- a/tests/metal/ray-query-intrinsics.slang
+++ b/tests/metal/ray-query-intrinsics.slang
@@ -1,0 +1,141 @@
+//TEST:SIMPLE(filecheck=MTL): -target metal -stage compute -entry computeMain
+//TEST:SIMPLE(filecheck=LIB): -target metallib -stage compute -entry computeMain
+//TEST(compute, metal):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-metal -compute -output-using-type -render-feature ray-query
+
+// MTL-DAG: get_candidate_instance_id
+// MTL-DAG: get_candidate_user_instance_id
+// MTL-DAG: get_candidate_primitive_id
+// MTL-DAG: get_candidate_geometry_id
+// MTL-DAG: get_candidate_ray_origin
+// MTL-DAG: get_candidate_ray_direction
+// MTL-DAG: is_candidate_triangle_front_facing
+// MTL-DAG: get_candidate_triangle_barycentric_coord
+// MTL-DAG: get_candidate_object_to_world_transform
+// MTL-DAG: get_candidate_world_to_object_transform
+// MTL-DAG: get_committed_instance_id
+// MTL-DAG: get_committed_user_instance_id
+// MTL-DAG: get_committed_primitive_id
+// MTL-DAG: get_committed_geometry_id
+// MTL-DAG: get_committed_ray_origin
+// MTL-DAG: get_committed_ray_direction
+// MTL-DAG: is_committed_triangle_front_facing
+// MTL-DAG: get_committed_triangle_barycentric_coord
+// MTL-DAG: get_committed_object_to_world_transform
+// MTL-DAG: get_committed_world_to_object_transform
+
+// LIB: computeMain
+
+//TEST_INPUT: set accelStruct = AccelerationStructure
+uniform RaytracingAccelerationStructure accelStruct;
+
+//TEST_INPUT: ubuffer(data=[0], stride=4):out,name outputBuffer
+RWStructuredBuffer<uint> outputBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(int3 dispatchThreadID: SV_DispatchThreadID)
+{
+    RayDesc ray;
+    ray.Origin = float3(0.1f, 0.1f, 0.0f);
+    ray.Direction = float3(0.0f, 0.0f, 1.0f);
+    ray.TMin = 0.01f;
+    ray.TMax = 1e4f;
+
+    RayQuery<RAY_FLAG_FORCE_NON_OPAQUE | RAY_FLAG_SKIP_PROCEDURAL_PRIMITIVES> rq;
+    rq.TraceRayInline(accelStruct, RAY_FLAG_NONE, 0xff, ray);
+
+    uint score = 0;
+    if (rq.Proceed())
+    {
+        if (rq.CandidateType() == CANDIDATE_NON_OPAQUE_TRIANGLE)
+        {
+            if (rq.CandidateInstanceIndex() == 0)
+                score += 1;
+
+            if (rq.CandidateInstanceID() == 0)
+                score += 1;
+
+            if (rq.CandidatePrimitiveIndex() == 0)
+                score += 1;
+
+            if (rq.CandidateGeometryIndex() == 0)
+                score += 1;
+
+            float3 oro = rq.CandidateObjectRayOrigin();
+            if (oro.x == 0.1f && oro.y == 0.1f && oro.z == 0.0f)
+                score += 1;
+
+            float3 ord = rq.CandidateObjectRayDirection();
+            if (ord.x == 0.0f && ord.y == 0.0f && ord.z == 1.0f)
+                score += 1;
+
+            if (rq.CandidateTriangleFrontFace() == true)
+                score += 1;
+
+            float2 bary = rq.CandidateTriangleBarycentrics();
+            if (bary.x != 0.0f && bary.y != 0.0f)
+                score += 1;
+
+            if (rq.CandidateObjectToWorld3x4()._11 == 1.0f)
+                score += 1;
+
+            if (rq.CandidateObjectToWorld4x3()._11 == 1.0f)
+                score += 1;
+
+            if (rq.CandidateWorldToObject3x4()._11 == 1.0f)
+                score += 1;
+
+            if (rq.CandidateWorldToObject4x3()._11 == 1.0f)
+                score += 1;
+
+            rq.CommitNonOpaqueTriangleHit();
+            rq.Abort();
+        }
+    }
+
+    if (rq.CommittedStatus() == COMMITTED_TRIANGLE_HIT)
+    {
+        if (rq.CommittedInstanceIndex() == 0)
+            score += 1;
+
+        if (rq.CommittedInstanceID() == 0)
+            score += 1;
+
+        if (rq.CommittedPrimitiveIndex() == 0)
+            score += 1;
+
+        if (rq.CommittedGeometryIndex() == 0)
+            score += 1;
+
+        float3 oro = rq.CommittedObjectRayOrigin();
+        if (oro.x == 0.1f && oro.y == 0.1f && oro.z == 0.0f)
+            score += 1;
+
+        float3 ord = rq.CommittedObjectRayDirection();
+        if (ord.x == 0.0f && ord.y == 0.0f && ord.z == 1.0f)
+            score += 1;
+
+        if (rq.CommittedTriangleFrontFace() == true)
+            score += 1;
+
+        float2 bary = rq.CommittedTriangleBarycentrics();
+        if (bary.x != 0.0f && bary.y != 0.0f)
+            score += 1;
+
+        if (rq.CommittedObjectToWorld3x4()._11 == 1.0f)
+            score += 1;
+
+        if (rq.CommittedObjectToWorld4x3()._11 == 1.0f)
+            score += 1;
+
+        if (rq.CommittedWorldToObject3x4()._11 == 1.0f)
+            score += 1;
+
+        if (rq.CommittedWorldToObject4x3()._11 == 1.0f)
+            score += 1;
+    }
+
+    outputBuffer[0] = score;
+}
+
+// CHECK: 24


### PR DESCRIPTION
The `rayQueryMethods` table emitted every `Candidate` and `Committed` property with a `get_` prefix, but MSL names boolean queries with an `is_` prefix, so `TriangleFrontFace` produced a method name that does not exist. The accessor prefix is now derived from the type of each entry and `kCandidateCommittedMetal` holds only the candidate or committed piece.

Also add `tests/metal/ray-query-intrinsics.slang`. It checks the emitted MSL method names, compiles the output with the Metal compiler through the metallib target, and will run the intrinsics on a Metal device once the test runtime supports ray query.