### PR TITLE
Add explicit separate debug info output path

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -178,7 +178,7 @@ Set the module name to use when compiling multiple .slang source files into a si
 
 Specify a path where generated output should be written. 
 
-If no [-target](#target-2) or [-stage](#stage-1) is specified, one may be inferred from file extension (see [&lt;file-extension&gt;](#file-extension)). If multiple [-target](#target-2) options and a single [-entry](#entry) are present, each [-o](#o) associates with the first [-target](#target-2) to its left. Otherwise, if multiple [-entry](#entry) options are present, each [-o](#o) associates with the first [-entry](#entry) to its left, and with the [-target](#target-2) that matches the one inferred from &lt;path&gt;. 
+Use `-` to write generated output to stdout. If no [-target](#target-2) or [-stage](#stage-1) is specified, one may be inferred from file extension (see [&lt;file-extension&gt;](#file-extension)). If multiple [-target](#target-2) options and a single [-entry](#entry) are present, each [-o](#o) associates with the first [-target](#target-2) to its left. Otherwise, if multiple [-entry](#entry) options are present, each [-o](#o) associates with the first [-entry](#entry) to its left, and with the [-target](#target-2) that matches the one inferred from &lt;path&gt;. 
 
 
 <a id="profile"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -659,7 +659,15 @@ When generating SPIRV with spvDescriptorHeapEXT, emit each resource descriptor-h
 
 <a id="separate-debug-info"></a>
 ### -separate-debug-info
-Emit debug data to a separate file, and strip it from the main output file. 
+Emit debug data to a separate file, and strip it from the main output file. For backward compatibility, when `-separate-debug-info-output &lt;path&gt;` is omitted, the debug file path falls back to the path derived from the main `-o &lt;path&gt;` output. Specify `-separate-debug-info-output &lt;path&gt;` to override that fallback or when the main artifact is written to stdout.
+
+
+<a id="separate-debug-info-output"></a>
+### -separate-debug-info-output
+
+**-separate-debug-info-output &lt;path&gt;**
+
+Write separate debug information to an explicit sidecar path, overriding the fallback path derived from `-o &lt;path&gt;`. Requires `-separate-debug-info`. Use `-` as the path to write the separate debug information to stdout when the main artifact is written to a file. The main artifact and separate debug information cannot both be written to stdout. When this option is omitted, the legacy `-o`-based path derivation remains in effect.
 
 
 <a id="emit-cpu-via-cpp"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -659,7 +659,7 @@ When generating SPIRV with spvDescriptorHeapEXT, emit each resource descriptor-h
 
 <a id="separate-debug-info"></a>
 ### -separate-debug-info
-Emit debug data to a separate file, and strip it from the main output file. For backward compatibility, when `-separate-debug-info-output &lt;path&gt;` is omitted, the debug file path falls back to the path derived from the main `-o &lt;path&gt;` output. Specify `-separate-debug-info-output &lt;path&gt;` to override that fallback or when the main artifact is written to stdout.
+Emit debug data to a separate file, and strip it from the main output file. By default, the debug file path is derived from the main `-o &lt;path&gt;` output as a fallback. Use `-separate-debug-info-output &lt;path&gt;` to override it or when the main artifact is written to stdout. 
 
 
 <a id="separate-debug-info-output"></a>
@@ -667,7 +667,7 @@ Emit debug data to a separate file, and strip it from the main output file. For 
 
 **-separate-debug-info-output &lt;path&gt;**
 
-Write separate debug information to an explicit sidecar path, overriding the fallback path derived from `-o &lt;path&gt;`. Requires `-separate-debug-info`. Use `-` as the path to write the separate debug information to stdout when the main artifact is written to a file. The main artifact and separate debug information cannot both be written to stdout. When this option is omitted, the legacy `-o`-based path derivation remains in effect.
+Write separate debug information to an explicit sidecar path, overriding the fallback path derived from `-o &lt;path&gt;`. Requires `-separate-debug-info` and allows the main artifact to be written to stdout. Use `-` to write the separate debug information to stdout when the main artifact is written to a file. 
 
 
 <a id="emit-cpu-via-cpp"></a>

--- a/include/slang.h
+++ b/include/slang.h
@@ -1236,6 +1236,14 @@ typedef uint32_t SlangSizeT;
         // combine on the command line. CLI spellings: -Wall, -Wextra, -Wpedantic.
         WarningLevel = 155,
 
+        SeparateDebugInfoOutput =
+            156, // stringValue0: explicit path for the slangc separate-debug-info sidecar.
+                 //   When unset, slangc derives the sidecar path from the main artifact path.
+                 //   This option is output policy only and is excluded from compiler cache keys.
+                 //   It requires EmitSeparateDebug and permits the main artifact to be written to
+                 //   stdout. A value of "-" writes the separate debug information to stdout when
+                 //   the main artifact is written to a file. Query/set with the string option APIs.
+
         // Do not assign an explicit value to CountOf. It must remain one past the last option,
         // which it derives implicitly from the preceding (highest-valued) enumerator.
         CountOf,

--- a/source/slang/slang-compiler-options.cpp
+++ b/source/slang/slang-compiler-options.cpp
@@ -183,10 +183,12 @@ void CompilerOptionSet::buildHash(DigestBuilder<SHA1>& builder)
 {
     for (auto& kv : options)
     {
-        // This is an output-policy knob (manifest sidecar path), not generated shader code.
-        // Locked by _testCoverageManifestOutputDoesNotAffectCompilerOptionHash; re-including it
-        // would invalidate persistent module caches on every sidecar-path change.
-        if (kv.key == CompilerOptionName::CoverageManifestOutput)
+        // These are output-policy sidecar paths, not generated shader code. Locked by
+        // _testCoverageManifestOutputDoesNotAffectCompilerOptionHash and
+        // _testSeparateDebugInfoOutputDoesNotAffectCompilerOptionHash; re-including them would
+        // invalidate persistent module caches on every sidecar-path change.
+        if (kv.key == CompilerOptionName::CoverageManifestOutput ||
+            kv.key == CompilerOptionName::SeparateDebugInfoOutput)
             continue;
 
         // This is a load-time acceptance-policy knob, not generated shader code: it only decides

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -212,6 +212,36 @@ warning(
 )
 
 err(
+    "separate-debug-info-requires-output-path",
+    109,
+    "`-separate-debug-info` requires an output file path; use `-o <path>` or `-separate-debug-info-output <path>`"
+)
+
+err(
+    "separate-debug-info-output-without-separate-debug-info",
+    110,
+    "`-separate-debug-info-output` requires `-separate-debug-info`"
+)
+
+err(
+    "separate-debug-info-output-collides-with-artifact",
+    111,
+    "`-separate-debug-info-output` path '~path' must differ from every other output path emitted by this compile"
+)
+
+err(
+    "separate-debug-info-output-with-container",
+    112,
+    "`-separate-debug-info-output` is not supported when writing a container output"
+)
+
+err(
+    "separate-debug-info-output-without-debug-data",
+    113,
+    "`-separate-debug-info-output` path '~path' was requested, but the selected target did not produce separate debug information"
+)
+
+err(
     "unknown-source-language",
     19,
     "unknown source language '~language'",

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -226,7 +226,7 @@ err(
 err(
     "separate-debug-info-output-collides-with-artifact",
     111,
-    "`-separate-debug-info-output` path '~path' must differ from every other output path emitted by this compile"
+    "`-separate-debug-info-output` path '~path' must differ from output path '~otherPath' emitted by this compile"
 )
 
 err(
@@ -239,6 +239,12 @@ err(
     "separate-debug-info-output-without-debug-data",
     113,
     "`-separate-debug-info-output` path '~path' was requested, but the selected target did not produce separate debug information"
+)
+
+err(
+    "separate-debug-info-output-multiple-artifacts",
+    114,
+    "`-separate-debug-info-output` path '~path' cannot receive multiple separate debug-information artifacts"
 )
 
 err(

--- a/source/slang/slang-end-to-end-request.cpp
+++ b/source/slang/slang-end-to-end-request.cpp
@@ -180,6 +180,18 @@ SlangResult EndToEndCompileRequest::executeActionsInner()
         return SLANG_FAIL;
     }
 
+    const bool hasExplicitSeparateDebugInfoOutputPath = _hasExplicitSeparateDebugInfoOutputPath();
+    if (hasExplicitSeparateDebugInfoOutputPath && !optionSet.shouldEmitSeparateDebugInfo())
+    {
+        getSink()->diagnose(Diagnostics::SeparateDebugInfoOutputWithoutSeparateDebugInfo{});
+        return SLANG_FAIL;
+    }
+    if (hasExplicitSeparateDebugInfoOutputPath && m_containerFormat != ContainerFormat::None)
+    {
+        getSink()->diagnose(Diagnostics::SeparateDebugInfoOutputWithContainer{});
+        return SLANG_FAIL;
+    }
+
     // We only do parsing and semantic checking if we *aren't* doing
     // a pass-through compilation.
     //
@@ -405,7 +417,7 @@ String EndToEndCompileRequest::_getEntryPointPath(TargetRequest* targetReq, Inde
 
 SlangResult EndToEndCompileRequest::_writeArtifact(const String& path, IArtifact* artifact)
 {
-    if (path.getLength() > 0)
+    if (path.getLength() > 0 && path != "-")
     {
         SLANG_RETURN_ON_FAIL(ArtifactOutputUtil::writeToFile(artifact, getSink(), path));
     }
@@ -426,6 +438,16 @@ String EndToEndCompileRequest::_getExplicitCoverageManifestPath()
 bool EndToEndCompileRequest::_hasExplicitCoverageManifestPath()
 {
     return _getExplicitCoverageManifestPath().getLength() != 0;
+}
+
+String EndToEndCompileRequest::_getExplicitSeparateDebugInfoOutputPath()
+{
+    return getOptionSet().getStringOption(CompilerOptionName::SeparateDebugInfoOutput);
+}
+
+bool EndToEndCompileRequest::_hasExplicitSeparateDebugInfoOutputPath()
+{
+    return _getExplicitSeparateDebugInfoOutputPath().getLength() != 0;
 }
 
 // If the artifact carries coverage tracing metadata, write its JSON
@@ -508,6 +530,11 @@ static bool _areOutputPathsEquivalent(const String& left, const String& right)
 #endif
 }
 
+static bool _isStdoutArtifactPath(const String& path)
+{
+    return path.getLength() == 0 || path == "-";
+}
+
 SlangResult EndToEndCompileRequest::_maybeWriteCoverageManifest(
     const String& path,
     IArtifact* artifact)
@@ -524,7 +551,7 @@ SlangResult EndToEndCompileRequest::_maybeWriteCoverageManifest(
     }
     else
     {
-        if (path.getLength() == 0)
+        if (_isStdoutArtifactPath(path))
             return SLANG_OK;
         sidecarPath = path + ".coverage-manifest.json";
     }
@@ -595,7 +622,7 @@ static String _getDebugSpvPath(const String& basePath)
     return basePath + dbgExt;
 }
 
-String EndToEndCompileRequest::_getDebugArtifactPath(
+String EndToEndCompileRequest::_getSeparateDebugInfoOutputPath(
     TargetProgram* targetProgram,
     const String& path,
     IArtifact* artifact)
@@ -603,39 +630,144 @@ String EndToEndCompileRequest::_getDebugArtifactPath(
     if (!targetProgram->getOptionSet().shouldEmitSeparateDebugInfo())
         return String();
 
-    const auto dbgArtifact = getSeparateDbgArtifact(artifact);
-    if (!dbgArtifact)
+    const auto separateDebugInfoArtifact = getSeparateDbgArtifact(artifact);
+    if (!separateDebugInfoArtifact)
         return String();
+
+    const String explicitPath = _getExplicitSeparateDebugInfoOutputPath();
+    if (explicitPath.getLength() != 0)
+        return explicitPath;
+
+    // Preserve the legacy behavior as a fallback: without an explicit debug path, derive the
+    // sidecar location from the main `-o` output file.
+    SLANG_RELEASE_ASSERT(!_isStdoutArtifactPath(path));
 
     // The artifact's name may have been set to the debug build id hash, use
     // it as the filename if it exists.
-    String dbgPath = dbgArtifact->getName();
-    if (dbgPath.getLength() == 0)
-        dbgPath = _getDebugSpvPath(path);
+    String separateDebugInfoOutputPath = separateDebugInfoArtifact->getName();
+    if (separateDebugInfoOutputPath.getLength() == 0)
+    {
+        separateDebugInfoOutputPath = _getDebugSpvPath(path);
+    }
     else
-        dbgPath.append(".dbg.spv");
-    return dbgPath;
+    {
+        separateDebugInfoOutputPath.append(".dbg.spv");
+    }
+    return separateDebugInfoOutputPath;
 }
 
-SlangResult EndToEndCompileRequest::_maybeWriteDebugArtifact(
+SlangResult EndToEndCompileRequest::_validateSeparateDebugInfoOutputPaths()
+{
+    const String explicitPath = _getExplicitSeparateDebugInfoOutputPath();
+    const bool hasExplicitPath = explicitPath.getLength() != 0;
+
+    auto linkage = getLinkage();
+    auto program = getSpecializedGlobalAndEntryPointsComponentType();
+
+    List<String> otherOutputPaths;
+    Index debugArtifactCount = 0;
+    bool missingDerivedPath = false;
+
+    for (auto targetReq : linkage->targets)
+    {
+        auto targetProgram = program->getTargetProgram(targetReq);
+        const bool generateWholeProgram =
+            targetProgram->getOptionSet().getBoolOption(CompilerOptionName::GenerateWholeProgram);
+        const Index artifactCount = generateWholeProgram ? 1 : program->getEntryPointCount();
+
+        for (Index artifactIndex = 0; artifactIndex < artifactCount; ++artifactIndex)
+        {
+            bool needToRecordArtifact = false;
+            String artifactPath;
+            IArtifact* artifact = nullptr;
+
+            if (generateWholeProgram)
+            {
+                artifact = targetProgram->getExistingWholeProgramResult();
+                artifactPath = _getWholeProgramPath(targetReq);
+                needToRecordArtifact = artifact != nullptr;
+            }
+            else
+            {
+                artifact = targetProgram->getExistingEntryPointResult(artifactIndex);
+                artifactPath = _getEntryPointPath(targetReq, artifactIndex);
+                needToRecordArtifact = artifact != nullptr;
+            }
+
+            if (!needToRecordArtifact || !getSeparateDbgArtifact(artifact))
+                continue;
+
+            debugArtifactCount++;
+            if (!hasExplicitPath)
+            {
+                if (_isStdoutArtifactPath(artifactPath))
+                    missingDerivedPath = true;
+                continue;
+            }
+
+            // Normalize both spellings of stdout so an explicit `-` sidecar cannot collide with an
+            // implicit stdout main artifact.
+            otherOutputPaths.add(_isStdoutArtifactPath(artifactPath) ? String("-") : artifactPath);
+
+            if (_findCoverageTracingMetadata(artifact))
+            {
+                String coveragePath = _getExplicitCoverageManifestPath();
+                if (coveragePath.getLength() == 0 && !_isStdoutArtifactPath(artifactPath))
+                    coveragePath = artifactPath + ".coverage-manifest.json";
+                if (coveragePath.getLength() != 0)
+                    otherOutputPaths.add(coveragePath);
+            }
+        }
+    }
+
+    if (missingDerivedPath)
+    {
+        getSink()->diagnose(Diagnostics::SeparateDebugInfoRequiresOutputPath{});
+        return SLANG_FAIL;
+    }
+
+    if (!hasExplicitPath)
+        return SLANG_OK;
+
+    if (debugArtifactCount == 0)
+    {
+        getSink()->diagnose(
+            Diagnostics::SeparateDebugInfoOutputWithoutDebugData{.path = explicitPath});
+        return SLANG_FAIL;
+    }
+    SLANG_RELEASE_ASSERT(debugArtifactCount == 1);
+
+    for (const auto& otherPath : otherOutputPaths)
+    {
+        if (_areOutputPathsEquivalent(explicitPath, otherPath))
+        {
+            getSink()->diagnose(
+                Diagnostics::SeparateDebugInfoOutputCollidesWithArtifact{.path = explicitPath});
+            return SLANG_FAIL;
+        }
+    }
+
+    return SLANG_OK;
+}
+
+SlangResult EndToEndCompileRequest::_maybeWriteSeparateDebugInfoOutput(
     TargetProgram* targetProgram,
     const String& path,
     IArtifact* artifact)
 {
-    if (targetProgram->getOptionSet().shouldEmitSeparateDebugInfo())
-    {
-        const auto dbgArtifact = getSeparateDbgArtifact(artifact);
-        // Check if a debug artifact was actually created (only for SPIR-V targets)
-        if (dbgArtifact)
-        {
-            String dbgPath = _getDebugArtifactPath(targetProgram, path, artifact);
-            return _maybeWriteArtifact(dbgPath, dbgArtifact);
-        }
-        // If no debug artifact exists (e.g., for non-SPIR-V targets), just silently succeed
-        // The warning about unsupported targets is already issued during option parsing
-    }
+    if (!targetProgram->getOptionSet().shouldEmitSeparateDebugInfo())
+        return SLANG_OK;
 
-    return SLANG_OK;
+    const auto separateDebugInfoArtifact = getSeparateDbgArtifact(artifact);
+    // A separate debug-info artifact is currently produced only for SPIR-V targets. The warning
+    // about unsupported targets is already issued during option parsing.
+    if (!separateDebugInfoArtifact)
+        return SLANG_OK;
+
+    String separateDebugInfoOutputPath =
+        _getSeparateDebugInfoOutputPath(targetProgram, path, artifact);
+    SLANG_RELEASE_ASSERT(separateDebugInfoOutputPath.getLength() != 0);
+    return _maybeWriteArtifact(separateDebugInfoOutputPath, separateDebugInfoArtifact);
 }
 
 SlangResult EndToEndCompileRequest::_validateCoverageManifestOutputPaths()
@@ -656,48 +788,47 @@ SlangResult EndToEndCompileRequest::_validateCoverageManifestOutputPaths()
     List<String> emittedArtifactPaths;
     Index coverageArtifactCount = 0;
 
-    // Records paths slangc will emit for this target/artifact pair and counts
-    // coverage-bearing artifacts. The count rejects 0 or 2+ coverage artifacts;
-    // the path list rejects explicit-sidecar collisions.
-    auto recordArtifact =
-        [&](TargetProgram* targetProgram, const String& artifactPath, IArtifact* artifact)
-    {
-        if (!artifact)
-            return;
-        // Stdout artifacts have no file path to collide with.
-        if (artifactPath.getLength() != 0)
-            emittedArtifactPaths.add(artifactPath);
-
-        String dbgPath = _getDebugArtifactPath(targetProgram, artifactPath, artifact);
-        // Targets that did not emit separate debug info have no debug path to collide with.
-        if (dbgPath.getLength() != 0)
-            emittedArtifactPaths.add(dbgPath);
-
-        if (_findCoverageTracingMetadata(artifact))
-            coverageArtifactCount++;
-    };
-
     for (auto targetReq : linkage->targets)
     {
         auto targetProgram = program->getTargetProgram(targetReq);
+        const bool generateWholeProgram =
+            targetProgram->getOptionSet().getBoolOption(CompilerOptionName::GenerateWholeProgram);
+        const Index artifactCount = generateWholeProgram ? 1 : program->getEntryPointCount();
 
-        if (targetProgram->getOptionSet().getBoolOption(CompilerOptionName::GenerateWholeProgram))
+        for (Index artifactIndex = 0; artifactIndex < artifactCount; ++artifactIndex)
         {
-            recordArtifact(
-                targetProgram,
-                _getWholeProgramPath(targetReq),
-                targetProgram->getExistingWholeProgramResult());
-        }
-        else
-        {
-            Index entryPointCount = program->getEntryPointCount();
-            for (Index ee = 0; ee < entryPointCount; ++ee)
+            bool needToRecordArtifact = false;
+            String artifactPath;
+            IArtifact* artifact = nullptr;
+
+            if (generateWholeProgram)
             {
-                recordArtifact(
-                    targetProgram,
-                    _getEntryPointPath(targetReq, ee),
-                    targetProgram->getExistingEntryPointResult(ee));
+                artifact = targetProgram->getExistingWholeProgramResult();
+                artifactPath = _getWholeProgramPath(targetReq);
+                needToRecordArtifact = artifact != nullptr;
             }
+            else
+            {
+                artifact = targetProgram->getExistingEntryPointResult(artifactIndex);
+                artifactPath = _getEntryPointPath(targetReq, artifactIndex);
+                needToRecordArtifact = artifact != nullptr;
+            }
+
+            if (!needToRecordArtifact)
+                continue;
+
+            // Stdout artifacts have no file path to collide with.
+            if (!_isStdoutArtifactPath(artifactPath))
+                emittedArtifactPaths.add(artifactPath);
+
+            String separateDebugInfoOutputPath =
+                _getSeparateDebugInfoOutputPath(targetProgram, artifactPath, artifact);
+            // Targets that did not emit separate debug info have no debug path to collide with.
+            if (separateDebugInfoOutputPath.getLength() != 0)
+                emittedArtifactPaths.add(separateDebugInfoOutputPath);
+
+            if (_findCoverageTracingMetadata(artifact))
+                coverageArtifactCount++;
         }
     }
 
@@ -1004,6 +1135,9 @@ void EndToEndCompileRequest::generateOutput()
 
     if (m_isCommandLineCompile && m_containerFormat == ContainerFormat::None)
     {
+        if (SLANG_FAILED(_validateSeparateDebugInfoOutputPaths()))
+            return;
+
         if (SLANG_FAILED(_validateCoverageManifestOutputPaths()))
             return;
 
@@ -1025,7 +1159,7 @@ void EndToEndCompileRequest::generateOutput()
 
                     // If we are compiling separate debug info, check for the additional
                     // SPIRV artifact and write that if needed.
-                    _maybeWriteDebugArtifact(targetProgram, path, artifact);
+                    _maybeWriteSeparateDebugInfoOutput(targetProgram, path, artifact);
 
                     _maybeWriteCoverageManifest(path, artifact);
                 }
@@ -1043,7 +1177,7 @@ void EndToEndCompileRequest::generateOutput()
 
                         // If we are compiling separate debug info, check for the additional
                         // SPIRV artifact and write that if needed.
-                        _maybeWriteDebugArtifact(targetProgram, path, artifact);
+                        _maybeWriteSeparateDebugInfoOutput(targetProgram, path, artifact);
 
                         _maybeWriteCoverageManifest(path, artifact);
                     }

--- a/source/slang/slang-end-to-end-request.cpp
+++ b/source/slang/slang-end-to-end-request.cpp
@@ -459,24 +459,6 @@ static bool _isStdoutArtifactPath(const String& path)
     return path.getLength() == 0 || path == "-";
 }
 
-struct OutputDestination
-{
-    String path;
-    bool isStdout = false;
-};
-
-// Artifact and reflection writers interpret `-` as stdout. Other output writers, such as coverage
-// manifests and dependency files, treat `-` as a literal file path.
-static OutputDestination _getArtifactOutputDestination(const String& path)
-{
-    return {_isStdoutArtifactPath(path) ? String("-") : path, _isStdoutArtifactPath(path)};
-}
-
-static OutputDestination _getFileOutputDestination(const String& path)
-{
-    return {path, false};
-}
-
 SlangResult EndToEndCompileRequest::_writeArtifact(const String& path, IArtifact* artifact)
 {
     if (!_isStdoutArtifactPath(path))
@@ -592,29 +574,6 @@ static bool _areOutputPathsEquivalent(const String& left, const String& right)
 #endif
 }
 
-static bool _areOutputDestinationsEquivalent(
-    const OutputDestination& left,
-    const OutputDestination& right)
-{
-    if (left.isStdout || right.isStdout)
-        return left.isStdout && right.isStdout;
-    return _areOutputPathsEquivalent(left.path, right.path);
-}
-
-String EndToEndCompileRequest::_getCoverageManifestOutputPath(
-    const String& path,
-    IArtifact* artifact)
-{
-    if (!_findCoverageTracingMetadata(artifact))
-        return String();
-
-    const String explicitSidecarPath = _getExplicitCoverageManifestPath();
-    if (explicitSidecarPath.getLength() != 0)
-        return explicitSidecarPath;
-
-    return _isStdoutArtifactPath(path) ? String() : path + ".coverage-manifest.json";
-}
-
 SlangResult EndToEndCompileRequest::_maybeWriteCoverageManifest(
     const String& path,
     IArtifact* artifact)
@@ -623,9 +582,18 @@ SlangResult EndToEndCompileRequest::_maybeWriteCoverageManifest(
     if (!coverage)
         return SLANG_OK;
 
-    const String sidecarPath = _getCoverageManifestOutputPath(path, artifact);
-    if (sidecarPath.getLength() == 0)
-        return SLANG_OK;
+    const String explicitSidecarPath = _getExplicitCoverageManifestPath();
+    String sidecarPath;
+    if (explicitSidecarPath.getLength() != 0)
+    {
+        sidecarPath = explicitSidecarPath;
+    }
+    else
+    {
+        if (_isStdoutArtifactPath(path))
+            return SLANG_OK;
+        sidecarPath = path + ".coverage-manifest.json";
+    }
 
     ComPtr<ISlangBlob> jsonBlob;
     SLANG_RETURN_ON_FAIL(slang_writeCoverageManifestJson(coverage, jsonBlob.writeRef()));
@@ -737,7 +705,7 @@ SlangResult EndToEndCompileRequest::_validateSeparateDebugInfoOutputPaths()
     // because it has no main output path from which to derive a sidecar path. Explicit mode counts
     // debug artifacts and collects every other destination for the missing-data and collision
     // checks after the loop.
-    List<OutputDestination> otherOutputDestinations;
+    List<String> otherOutputPaths;
     Index debugArtifactCount = 0;
     bool missingDerivedPath = false;
 
@@ -751,15 +719,18 @@ SlangResult EndToEndCompileRequest::_validateSeparateDebugInfoOutputPaths()
         {
             // Normalize both spellings of stdout so an explicit `-` sidecar cannot collide with an
             // implicit stdout main artifact.
-            otherOutputDestinations.add(_getArtifactOutputDestination(outputArtifact.path));
+            otherOutputPaths.add(
+                _isStdoutArtifactPath(outputArtifact.path) ? String("-") : outputArtifact.path);
 
-            String coveragePath =
-                _getCoverageManifestOutputPath(outputArtifact.path, outputArtifact.artifact);
-            if (coveragePath.getLength() != 0)
+            if (_findCoverageTracingMetadata(outputArtifact.artifact))
             {
-                // Coverage manifests always use file paths; unlike artifact and reflection output,
-                // `-` has no stdout meaning for `-coverage-manifest-output`.
-                otherOutputDestinations.add(_getFileOutputDestination(coveragePath));
+                String coveragePath = _getExplicitCoverageManifestPath();
+                if (coveragePath.getLength() == 0 && !_isStdoutArtifactPath(outputArtifact.path))
+                {
+                    coveragePath = outputArtifact.path + ".coverage-manifest.json";
+                }
+                if (coveragePath.getLength() != 0)
+                    otherOutputPaths.add(coveragePath);
             }
         }
 
@@ -785,9 +756,9 @@ SlangResult EndToEndCompileRequest::_validateSeparateDebugInfoOutputPaths()
     const String reflectionPath =
         getOptionSet().getStringOption(CompilerOptionName::EmitReflectionJSON);
     if (reflectionPath.getLength() != 0)
-        otherOutputDestinations.add(_getArtifactOutputDestination(reflectionPath));
+        otherOutputPaths.add(reflectionPath);
     if (m_dependencyOutputPath.getLength() != 0)
-        otherOutputDestinations.add(_getFileOutputDestination(m_dependencyOutputPath));
+        otherOutputPaths.add(m_dependencyOutputPath);
 
     if (debugArtifactCount == 0)
     {
@@ -802,14 +773,13 @@ SlangResult EndToEndCompileRequest::_validateSeparateDebugInfoOutputPaths()
         return SLANG_FAIL;
     }
 
-    const OutputDestination explicitDestination = _getArtifactOutputDestination(explicitPath);
-    for (const auto& otherDestination : otherOutputDestinations)
+    for (const auto& otherPath : otherOutputPaths)
     {
-        if (_areOutputDestinationsEquivalent(explicitDestination, otherDestination))
+        if (_areOutputPathsEquivalent(explicitPath, otherPath))
         {
             getSink()->diagnose(Diagnostics::SeparateDebugInfoOutputCollidesWithArtifact{
                 .path = explicitPath,
-                .otherPath = otherDestination.path});
+                .otherPath = otherPath});
             return SLANG_FAIL;
         }
     }
@@ -851,27 +821,55 @@ SlangResult EndToEndCompileRequest::_validateCoverageManifestOutputPaths()
     if (!m_isCommandLineCompile || m_containerFormat != ContainerFormat::None)
         return SLANG_OK;
 
-    List<OutputDestination> emittedDestinations;
+    auto linkage = getLinkage();
+    auto program = getSpecializedGlobalAndEntryPointsComponentType();
+
+    List<String> emittedArtifactPaths;
     Index coverageArtifactCount = 0;
 
-    List<ExistingOutputArtifact> outputArtifacts;
-    _collectExistingOutputArtifacts(outputArtifacts);
-    for (const auto& outputArtifact : outputArtifacts)
+    // Records paths slangc will emit for this target/artifact pair and counts
+    // coverage-bearing artifacts. The count rejects 0 or 2+ coverage artifacts;
+    // the path list rejects explicit-sidecar collisions.
+    auto recordArtifact =
+        [&](TargetProgram* targetProgram, const String& artifactPath, IArtifact* artifact)
     {
-        emittedDestinations.add(_getArtifactOutputDestination(outputArtifact.path));
+        if (!artifact)
+            return;
+        // Stdout artifacts have no file path to collide with.
+        if (artifactPath.getLength() != 0)
+            emittedArtifactPaths.add(artifactPath);
 
-        String separateDebugInfoOutputPath = _getSeparateDebugInfoOutputPath(
-            outputArtifact.targetProgram,
-            outputArtifact.path,
-            outputArtifact.artifact);
+        String dbgPath = _getSeparateDebugInfoOutputPath(targetProgram, artifactPath, artifact);
         // Targets that did not emit separate debug info have no debug path to collide with.
-        if (separateDebugInfoOutputPath.getLength() != 0)
-        {
-            emittedDestinations.add(_getArtifactOutputDestination(separateDebugInfoOutputPath));
-        }
+        if (dbgPath.getLength() != 0)
+            emittedArtifactPaths.add(dbgPath);
 
-        if (_findCoverageTracingMetadata(outputArtifact.artifact))
+        if (_findCoverageTracingMetadata(artifact))
             coverageArtifactCount++;
+    };
+
+    for (auto targetReq : linkage->targets)
+    {
+        auto targetProgram = program->getTargetProgram(targetReq);
+
+        if (targetProgram->getOptionSet().getBoolOption(CompilerOptionName::GenerateWholeProgram))
+        {
+            recordArtifact(
+                targetProgram,
+                _getWholeProgramPath(targetReq),
+                targetProgram->getExistingWholeProgramResult());
+        }
+        else
+        {
+            Index entryPointCount = program->getEntryPointCount();
+            for (Index ee = 0; ee < entryPointCount; ++ee)
+            {
+                recordArtifact(
+                    targetProgram,
+                    _getEntryPointPath(targetReq, ee),
+                    targetProgram->getExistingEntryPointResult(ee));
+            }
+        }
     }
 
     // Exactly one coverage-instrumented artifact is allowed to claim an
@@ -890,10 +888,9 @@ SlangResult EndToEndCompileRequest::_validateCoverageManifestOutputPaths()
         return SLANG_FAIL;
     }
 
-    const OutputDestination explicitDestination = _getFileOutputDestination(explicitSidecarPath);
-    for (const auto& emittedDestination : emittedDestinations)
+    for (const auto& artifactPath : emittedArtifactPaths)
     {
-        if (_areOutputDestinationsEquivalent(explicitDestination, emittedDestination))
+        if (_areOutputPathsEquivalent(explicitSidecarPath, artifactPath))
         {
             getSink()->diagnose(Diagnostics::CoverageManifestOutputCollidesWithArtifact{
                 .path = explicitSidecarPath});

--- a/source/slang/slang-end-to-end-request.cpp
+++ b/source/slang/slang-end-to-end-request.cpp
@@ -459,6 +459,24 @@ static bool _isStdoutArtifactPath(const String& path)
     return path.getLength() == 0 || path == "-";
 }
 
+struct OutputDestination
+{
+    String path;
+    bool isStdout = false;
+};
+
+// Artifact and reflection writers interpret `-` as stdout. Other output writers, such as coverage
+// manifests and dependency files, treat `-` as a literal file path.
+static OutputDestination _getArtifactOutputDestination(const String& path)
+{
+    return {_isStdoutArtifactPath(path) ? String("-") : path, _isStdoutArtifactPath(path)};
+}
+
+static OutputDestination _getFileOutputDestination(const String& path)
+{
+    return {path, false};
+}
+
 SlangResult EndToEndCompileRequest::_writeArtifact(const String& path, IArtifact* artifact)
 {
     if (!_isStdoutArtifactPath(path))
@@ -574,6 +592,29 @@ static bool _areOutputPathsEquivalent(const String& left, const String& right)
 #endif
 }
 
+static bool _areOutputDestinationsEquivalent(
+    const OutputDestination& left,
+    const OutputDestination& right)
+{
+    if (left.isStdout || right.isStdout)
+        return left.isStdout && right.isStdout;
+    return _areOutputPathsEquivalent(left.path, right.path);
+}
+
+String EndToEndCompileRequest::_getCoverageManifestOutputPath(
+    const String& path,
+    IArtifact* artifact)
+{
+    if (!_findCoverageTracingMetadata(artifact))
+        return String();
+
+    const String explicitSidecarPath = _getExplicitCoverageManifestPath();
+    if (explicitSidecarPath.getLength() != 0)
+        return explicitSidecarPath;
+
+    return _isStdoutArtifactPath(path) ? String() : path + ".coverage-manifest.json";
+}
+
 SlangResult EndToEndCompileRequest::_maybeWriteCoverageManifest(
     const String& path,
     IArtifact* artifact)
@@ -582,18 +623,9 @@ SlangResult EndToEndCompileRequest::_maybeWriteCoverageManifest(
     if (!coverage)
         return SLANG_OK;
 
-    const String explicitSidecarPath = _getExplicitCoverageManifestPath();
-    String sidecarPath;
-    if (explicitSidecarPath.getLength() != 0)
-    {
-        sidecarPath = explicitSidecarPath;
-    }
-    else
-    {
-        if (_isStdoutArtifactPath(path))
-            return SLANG_OK;
-        sidecarPath = path + ".coverage-manifest.json";
-    }
+    const String sidecarPath = _getCoverageManifestOutputPath(path, artifact);
+    if (sidecarPath.getLength() == 0)
+        return SLANG_OK;
 
     ComPtr<ISlangBlob> jsonBlob;
     SLANG_RETURN_ON_FAIL(slang_writeCoverageManifestJson(coverage, jsonBlob.writeRef()));
@@ -705,7 +737,7 @@ SlangResult EndToEndCompileRequest::_validateSeparateDebugInfoOutputPaths()
     // because it has no main output path from which to derive a sidecar path. Explicit mode counts
     // debug artifacts and collects every other destination for the missing-data and collision
     // checks after the loop.
-    List<String> otherOutputPaths;
+    List<OutputDestination> otherOutputDestinations;
     Index debugArtifactCount = 0;
     bool missingDerivedPath = false;
 
@@ -719,18 +751,15 @@ SlangResult EndToEndCompileRequest::_validateSeparateDebugInfoOutputPaths()
         {
             // Normalize both spellings of stdout so an explicit `-` sidecar cannot collide with an
             // implicit stdout main artifact.
-            otherOutputPaths.add(
-                _isStdoutArtifactPath(outputArtifact.path) ? String("-") : outputArtifact.path);
+            otherOutputDestinations.add(_getArtifactOutputDestination(outputArtifact.path));
 
-            if (_findCoverageTracingMetadata(outputArtifact.artifact))
+            String coveragePath =
+                _getCoverageManifestOutputPath(outputArtifact.path, outputArtifact.artifact);
+            if (coveragePath.getLength() != 0)
             {
-                String coveragePath = _getExplicitCoverageManifestPath();
-                if (coveragePath.getLength() == 0 && !_isStdoutArtifactPath(outputArtifact.path))
-                {
-                    coveragePath = outputArtifact.path + ".coverage-manifest.json";
-                }
-                if (coveragePath.getLength() != 0)
-                    otherOutputPaths.add(coveragePath);
+                // Coverage manifests always use file paths; unlike artifact and reflection output,
+                // `-` has no stdout meaning for `-coverage-manifest-output`.
+                otherOutputDestinations.add(_getFileOutputDestination(coveragePath));
             }
         }
 
@@ -753,24 +782,34 @@ SlangResult EndToEndCompileRequest::_validateSeparateDebugInfoOutputPaths()
     if (!hasExplicitPath)
         return SLANG_OK;
 
+    const String reflectionPath =
+        getOptionSet().getStringOption(CompilerOptionName::EmitReflectionJSON);
+    if (reflectionPath.getLength() != 0)
+        otherOutputDestinations.add(_getArtifactOutputDestination(reflectionPath));
+    if (m_dependencyOutputPath.getLength() != 0)
+        otherOutputDestinations.add(_getFileOutputDestination(m_dependencyOutputPath));
+
     if (debugArtifactCount == 0)
     {
         getSink()->diagnose(
             Diagnostics::SeparateDebugInfoOutputWithoutDebugData{.path = explicitPath});
         return SLANG_FAIL;
     }
-    // This preflight runs only for command-line output, whose option parser rejects duplicate
-    // target formats. At most one SPIR-V target (the only format that produces separate debug
-    // information) can therefore reach this point. Direct-SPIR-V output is whole-program, so its
-    // entry points share that target's one separate-debug artifact; other target formats add none.
-    SLANG_RELEASE_ASSERT(debugArtifactCount == 1);
-
-    for (const auto& otherPath : otherOutputPaths)
+    if (debugArtifactCount > 1)
     {
-        if (_areOutputPathsEquivalent(explicitPath, otherPath))
+        getSink()->diagnose(
+            Diagnostics::SeparateDebugInfoOutputMultipleArtifacts{.path = explicitPath});
+        return SLANG_FAIL;
+    }
+
+    const OutputDestination explicitDestination = _getArtifactOutputDestination(explicitPath);
+    for (const auto& otherDestination : otherOutputDestinations)
+    {
+        if (_areOutputDestinationsEquivalent(explicitDestination, otherDestination))
         {
-            getSink()->diagnose(
-                Diagnostics::SeparateDebugInfoOutputCollidesWithArtifact{.path = explicitPath});
+            getSink()->diagnose(Diagnostics::SeparateDebugInfoOutputCollidesWithArtifact{
+                .path = explicitPath,
+                .otherPath = otherDestination.path});
             return SLANG_FAIL;
         }
     }
@@ -794,6 +833,8 @@ SlangResult EndToEndCompileRequest::_maybeWriteSeparateDebugInfoOutput(
 
     String separateDebugInfoOutputPath =
         _getSeparateDebugInfoOutputPath(targetProgram, path, artifact);
+    // The separate-debug preflight runs before emission and rejects every shape for which this
+    // artifact has no destination, including an underivable stdout fallback.
     SLANG_RELEASE_ASSERT(separateDebugInfoOutputPath.getLength() != 0);
     return _maybeWriteArtifact(separateDebugInfoOutputPath, separateDebugInfoArtifact);
 }
@@ -810,16 +851,14 @@ SlangResult EndToEndCompileRequest::_validateCoverageManifestOutputPaths()
     if (!m_isCommandLineCompile || m_containerFormat != ContainerFormat::None)
         return SLANG_OK;
 
-    List<String> emittedArtifactPaths;
+    List<OutputDestination> emittedDestinations;
     Index coverageArtifactCount = 0;
 
     List<ExistingOutputArtifact> outputArtifacts;
     _collectExistingOutputArtifacts(outputArtifacts);
     for (const auto& outputArtifact : outputArtifacts)
     {
-        // Stdout artifacts have no file path to collide with.
-        if (!_isStdoutArtifactPath(outputArtifact.path))
-            emittedArtifactPaths.add(outputArtifact.path);
+        emittedDestinations.add(_getArtifactOutputDestination(outputArtifact.path));
 
         String separateDebugInfoOutputPath = _getSeparateDebugInfoOutputPath(
             outputArtifact.targetProgram,
@@ -827,7 +866,9 @@ SlangResult EndToEndCompileRequest::_validateCoverageManifestOutputPaths()
             outputArtifact.artifact);
         // Targets that did not emit separate debug info have no debug path to collide with.
         if (separateDebugInfoOutputPath.getLength() != 0)
-            emittedArtifactPaths.add(separateDebugInfoOutputPath);
+        {
+            emittedDestinations.add(_getArtifactOutputDestination(separateDebugInfoOutputPath));
+        }
 
         if (_findCoverageTracingMetadata(outputArtifact.artifact))
             coverageArtifactCount++;
@@ -849,9 +890,10 @@ SlangResult EndToEndCompileRequest::_validateCoverageManifestOutputPaths()
         return SLANG_FAIL;
     }
 
-    for (const auto& artifactPath : emittedArtifactPaths)
+    const OutputDestination explicitDestination = _getFileOutputDestination(explicitSidecarPath);
+    for (const auto& emittedDestination : emittedDestinations)
     {
-        if (_areOutputPathsEquivalent(explicitSidecarPath, artifactPath))
+        if (_areOutputDestinationsEquivalent(explicitDestination, emittedDestination))
         {
             getSink()->diagnose(Diagnostics::CoverageManifestOutputCollidesWithArtifact{
                 .path = explicitSidecarPath});

--- a/source/slang/slang-end-to-end-request.cpp
+++ b/source/slang/slang-end-to-end-request.cpp
@@ -415,6 +415,45 @@ String EndToEndCompileRequest::_getEntryPointPath(TargetRequest* targetReq, Inde
     return String();
 }
 
+void EndToEndCompileRequest::_collectExistingOutputArtifacts(
+    List<ExistingOutputArtifact>& outArtifacts)
+{
+    outArtifacts.clear();
+
+    auto linkage = getLinkage();
+    auto program = getSpecializedGlobalAndEntryPointsComponentType();
+    for (auto targetReq : linkage->targets)
+    {
+        auto targetProgram = program->getTargetProgram(targetReq);
+        if (targetProgram->getOptionSet().getBoolOption(CompilerOptionName::GenerateWholeProgram))
+        {
+            if (auto artifact = targetProgram->getExistingWholeProgramResult())
+            {
+                ExistingOutputArtifact outputArtifact;
+                outputArtifact.targetProgram = targetProgram;
+                outputArtifact.path = _getWholeProgramPath(targetReq);
+                outputArtifact.artifact = artifact;
+                outArtifacts.add(outputArtifact);
+            }
+        }
+        else
+        {
+            for (Index entryPointIndex = 0; entryPointIndex < program->getEntryPointCount();
+                 ++entryPointIndex)
+            {
+                if (auto artifact = targetProgram->getExistingEntryPointResult(entryPointIndex))
+                {
+                    ExistingOutputArtifact outputArtifact;
+                    outputArtifact.targetProgram = targetProgram;
+                    outputArtifact.path = _getEntryPointPath(targetReq, entryPointIndex);
+                    outputArtifact.artifact = artifact;
+                    outArtifacts.add(outputArtifact);
+                }
+            }
+        }
+    }
+}
+
 SlangResult EndToEndCompileRequest::_writeArtifact(const String& path, IArtifact* artifact)
 {
     if (path.getLength() > 0 && path != "-")
@@ -639,7 +678,8 @@ String EndToEndCompileRequest::_getSeparateDebugInfoOutputPath(
         return explicitPath;
 
     // Preserve the legacy behavior as a fallback: without an explicit debug path, derive the
-    // sidecar location from the main `-o` output file.
+    // sidecar location from the main `-o` output file. The separate-debug preflight runs before
+    // this helper's coverage-preflight caller and rejects stdout paths that cannot be derived.
     SLANG_RELEASE_ASSERT(!_isStdoutArtifactPath(path));
 
     // The artifact's name may have been set to the debug build id hash, use
@@ -661,63 +701,43 @@ SlangResult EndToEndCompileRequest::_validateSeparateDebugInfoOutputPaths()
     const String explicitPath = _getExplicitSeparateDebugInfoOutputPath();
     const bool hasExplicitPath = explicitPath.getLength() != 0;
 
-    auto linkage = getLinkage();
-    auto program = getSpecializedGlobalAndEntryPointsComponentType();
-
     List<String> otherOutputPaths;
     Index debugArtifactCount = 0;
     bool missingDerivedPath = false;
 
-    for (auto targetReq : linkage->targets)
+    List<ExistingOutputArtifact> outputArtifacts;
+    _collectExistingOutputArtifacts(outputArtifacts);
+    for (const auto& outputArtifact : outputArtifacts)
     {
-        auto targetProgram = program->getTargetProgram(targetReq);
-        const bool generateWholeProgram =
-            targetProgram->getOptionSet().getBoolOption(CompilerOptionName::GenerateWholeProgram);
-        const Index artifactCount = generateWholeProgram ? 1 : program->getEntryPointCount();
-
-        for (Index artifactIndex = 0; artifactIndex < artifactCount; ++artifactIndex)
+        // With an explicit path, compare it against every other output, including outputs from
+        // targets that do not themselves produce separate debug information.
+        if (hasExplicitPath)
         {
-            bool needToRecordArtifact = false;
-            String artifactPath;
-            IArtifact* artifact = nullptr;
-
-            if (generateWholeProgram)
-            {
-                artifact = targetProgram->getExistingWholeProgramResult();
-                artifactPath = _getWholeProgramPath(targetReq);
-                needToRecordArtifact = artifact != nullptr;
-            }
-            else
-            {
-                artifact = targetProgram->getExistingEntryPointResult(artifactIndex);
-                artifactPath = _getEntryPointPath(targetReq, artifactIndex);
-                needToRecordArtifact = artifact != nullptr;
-            }
-
-            if (!needToRecordArtifact || !getSeparateDbgArtifact(artifact))
-                continue;
-
-            debugArtifactCount++;
-            if (!hasExplicitPath)
-            {
-                if (_isStdoutArtifactPath(artifactPath))
-                    missingDerivedPath = true;
-                continue;
-            }
-
             // Normalize both spellings of stdout so an explicit `-` sidecar cannot collide with an
             // implicit stdout main artifact.
-            otherOutputPaths.add(_isStdoutArtifactPath(artifactPath) ? String("-") : artifactPath);
+            otherOutputPaths.add(
+                _isStdoutArtifactPath(outputArtifact.path) ? String("-") : outputArtifact.path);
 
-            if (_findCoverageTracingMetadata(artifact))
+            if (_findCoverageTracingMetadata(outputArtifact.artifact))
             {
                 String coveragePath = _getExplicitCoverageManifestPath();
-                if (coveragePath.getLength() == 0 && !_isStdoutArtifactPath(artifactPath))
-                    coveragePath = artifactPath + ".coverage-manifest.json";
+                if (coveragePath.getLength() == 0 && !_isStdoutArtifactPath(outputArtifact.path))
+                {
+                    coveragePath = outputArtifact.path + ".coverage-manifest.json";
+                }
                 if (coveragePath.getLength() != 0)
                     otherOutputPaths.add(coveragePath);
             }
         }
+
+        if (!getSeparateDbgArtifact(outputArtifact.artifact))
+            continue;
+
+        debugArtifactCount++;
+        // In fallback mode, the only invalid shape is a debug-bearing stdout artifact because it
+        // has no file path from which to derive the sidecar destination.
+        if (!hasExplicitPath && _isStdoutArtifactPath(outputArtifact.path))
+            missingDerivedPath = true;
     }
 
     if (missingDerivedPath)
@@ -735,6 +755,10 @@ SlangResult EndToEndCompileRequest::_validateSeparateDebugInfoOutputPaths()
             Diagnostics::SeparateDebugInfoOutputWithoutDebugData{.path = explicitPath});
         return SLANG_FAIL;
     }
+    // Command-line output mapping permits one output per target, and multi-entry-point SPIR-V
+    // compiles share that target's separate-debug artifact. Duplicate outputs for the same target
+    // are rejected earlier by the option parser, while non-SPIR-V targets produce no debug
+    // artifact.
     SLANG_RELEASE_ASSERT(debugArtifactCount == 1);
 
     for (const auto& otherPath : otherOutputPaths)
@@ -782,54 +806,27 @@ SlangResult EndToEndCompileRequest::_validateCoverageManifestOutputPaths()
     if (!m_isCommandLineCompile || m_containerFormat != ContainerFormat::None)
         return SLANG_OK;
 
-    auto linkage = getLinkage();
-    auto program = getSpecializedGlobalAndEntryPointsComponentType();
-
     List<String> emittedArtifactPaths;
     Index coverageArtifactCount = 0;
 
-    for (auto targetReq : linkage->targets)
+    List<ExistingOutputArtifact> outputArtifacts;
+    _collectExistingOutputArtifacts(outputArtifacts);
+    for (const auto& outputArtifact : outputArtifacts)
     {
-        auto targetProgram = program->getTargetProgram(targetReq);
-        const bool generateWholeProgram =
-            targetProgram->getOptionSet().getBoolOption(CompilerOptionName::GenerateWholeProgram);
-        const Index artifactCount = generateWholeProgram ? 1 : program->getEntryPointCount();
+        // Stdout artifacts have no file path to collide with.
+        if (!_isStdoutArtifactPath(outputArtifact.path))
+            emittedArtifactPaths.add(outputArtifact.path);
 
-        for (Index artifactIndex = 0; artifactIndex < artifactCount; ++artifactIndex)
-        {
-            bool needToRecordArtifact = false;
-            String artifactPath;
-            IArtifact* artifact = nullptr;
+        String separateDebugInfoOutputPath = _getSeparateDebugInfoOutputPath(
+            outputArtifact.targetProgram,
+            outputArtifact.path,
+            outputArtifact.artifact);
+        // Targets that did not emit separate debug info have no debug path to collide with.
+        if (separateDebugInfoOutputPath.getLength() != 0)
+            emittedArtifactPaths.add(separateDebugInfoOutputPath);
 
-            if (generateWholeProgram)
-            {
-                artifact = targetProgram->getExistingWholeProgramResult();
-                artifactPath = _getWholeProgramPath(targetReq);
-                needToRecordArtifact = artifact != nullptr;
-            }
-            else
-            {
-                artifact = targetProgram->getExistingEntryPointResult(artifactIndex);
-                artifactPath = _getEntryPointPath(targetReq, artifactIndex);
-                needToRecordArtifact = artifact != nullptr;
-            }
-
-            if (!needToRecordArtifact)
-                continue;
-
-            // Stdout artifacts have no file path to collide with.
-            if (!_isStdoutArtifactPath(artifactPath))
-                emittedArtifactPaths.add(artifactPath);
-
-            String separateDebugInfoOutputPath =
-                _getSeparateDebugInfoOutputPath(targetProgram, artifactPath, artifact);
-            // Targets that did not emit separate debug info have no debug path to collide with.
-            if (separateDebugInfoOutputPath.getLength() != 0)
-                emittedArtifactPaths.add(separateDebugInfoOutputPath);
-
-            if (_findCoverageTracingMetadata(artifact))
-                coverageArtifactCount++;
-        }
+        if (_findCoverageTracingMetadata(outputArtifact.artifact))
+            coverageArtifactCount++;
     }
 
     // Exactly one coverage-instrumented artifact is allowed to claim an

--- a/source/slang/slang-end-to-end-request.cpp
+++ b/source/slang/slang-end-to-end-request.cpp
@@ -454,9 +454,14 @@ void EndToEndCompileRequest::_collectExistingOutputArtifacts(
     }
 }
 
+static bool _isStdoutArtifactPath(const String& path)
+{
+    return path.getLength() == 0 || path == "-";
+}
+
 SlangResult EndToEndCompileRequest::_writeArtifact(const String& path, IArtifact* artifact)
 {
-    if (path.getLength() > 0 && path != "-")
+    if (!_isStdoutArtifactPath(path))
     {
         SLANG_RETURN_ON_FAIL(ArtifactOutputUtil::writeToFile(artifact, getSink(), path));
     }
@@ -567,11 +572,6 @@ static bool _areOutputPathsEquivalent(const String& left, const String& right)
     // the platform where case aliases are expected and handled explicitly.
     return normalizedLeft == normalizedRight;
 #endif
-}
-
-static bool _isStdoutArtifactPath(const String& path)
-{
-    return path.getLength() == 0 || path == "-";
 }
 
 SlangResult EndToEndCompileRequest::_maybeWriteCoverageManifest(
@@ -701,6 +701,10 @@ SlangResult EndToEndCompileRequest::_validateSeparateDebugInfoOutputPaths()
     const String explicitPath = _getExplicitSeparateDebugInfoOutputPath();
     const bool hasExplicitPath = explicitPath.getLength() != 0;
 
+    // This preflight has two modes. Fallback mode only rejects a debug-bearing stdout artifact,
+    // because it has no main output path from which to derive a sidecar path. Explicit mode counts
+    // debug artifacts and collects every other destination for the missing-data and collision
+    // checks after the loop.
     List<String> otherOutputPaths;
     Index debugArtifactCount = 0;
     bool missingDerivedPath = false;
@@ -755,10 +759,10 @@ SlangResult EndToEndCompileRequest::_validateSeparateDebugInfoOutputPaths()
             Diagnostics::SeparateDebugInfoOutputWithoutDebugData{.path = explicitPath});
         return SLANG_FAIL;
     }
-    // Command-line output mapping permits one output per target, and multi-entry-point SPIR-V
-    // compiles share that target's separate-debug artifact. Duplicate outputs for the same target
-    // are rejected earlier by the option parser, while non-SPIR-V targets produce no debug
-    // artifact.
+    // This preflight runs only for command-line output, whose option parser rejects duplicate
+    // target formats. At most one SPIR-V target (the only format that produces separate debug
+    // information) can therefore reach this point. Direct-SPIR-V output is whole-program, so its
+    // entry points share that target's one separate-debug artifact; other target formats add none.
     SLANG_RELEASE_ASSERT(debugArtifactCount == 1);
 
     for (const auto& otherPath : otherOutputPaths)

--- a/source/slang/slang-end-to-end-request.h
+++ b/source/slang/slang-end-to-end-request.h
@@ -395,10 +395,6 @@ private:
     void _collectExistingOutputArtifacts(List<ExistingOutputArtifact>& outArtifacts);
     String _getExplicitCoverageManifestPath();
     bool _hasExplicitCoverageManifestPath();
-    /// Returns the explicit coverage-manifest path, or the derived sidecar path for a file-backed
-    /// coverage artifact. Returns empty when the artifact has no coverage data or writes to stdout
-    /// without an explicit manifest path.
-    String _getCoverageManifestOutputPath(const String& path, IArtifact* artifact);
     String _getExplicitSeparateDebugInfoOutputPath();
     bool _hasExplicitSeparateDebugInfoOutputPath();
 

--- a/source/slang/slang-end-to-end-request.h
+++ b/source/slang/slang-end-to-end-request.h
@@ -385,18 +385,22 @@ private:
     String _getEntryPointPath(TargetRequest* targetReq, Index entryPointIndex);
     String _getExplicitCoverageManifestPath();
     bool _hasExplicitCoverageManifestPath();
+    String _getExplicitSeparateDebugInfoOutputPath();
+    bool _hasExplicitSeparateDebugInfoOutputPath();
 
     /// Maybe write the artifact to the path (if set), or stdout (if there is no container or path)
     SlangResult _maybeWriteArtifact(const String& path, IArtifact* artifact);
-    /// Returns the path slangc would use for a separate-debug-info artifact for this
-    /// target/artifact pair, or empty if none will be emitted. Used by both the debug artifact
-    /// writer and coverage-manifest preflight collision checks. Empty means either separate debug
-    /// info is disabled or the target did not produce a debug artifact.
-    String _getDebugArtifactPath(
+    /// Returns the explicit separate-debug path when one was requested; otherwise derives the
+    /// sidecar path from the main artifact path. Returns empty when separate debug info is disabled
+    /// or the target did not produce a separate debug-info artifact.
+    String _getSeparateDebugInfoOutputPath(
         TargetProgram* targetProgram,
         const String& path,
         IArtifact* artifact);
-    SlangResult _maybeWriteDebugArtifact(
+    /// Preflight-validates separate-debug output before any artifact write, including stdout and
+    /// path-collision cases.
+    SlangResult _validateSeparateDebugInfoOutputPaths();
+    SlangResult _maybeWriteSeparateDebugInfoOutput(
         TargetProgram* targetProgram,
         const String& path,
         IArtifact* artifact);

--- a/source/slang/slang-end-to-end-request.h
+++ b/source/slang/slang-end-to-end-request.h
@@ -395,6 +395,10 @@ private:
     void _collectExistingOutputArtifacts(List<ExistingOutputArtifact>& outArtifacts);
     String _getExplicitCoverageManifestPath();
     bool _hasExplicitCoverageManifestPath();
+    /// Returns the explicit coverage-manifest path, or the derived sidecar path for a file-backed
+    /// coverage artifact. Returns empty when the artifact has no coverage data or writes to stdout
+    /// without an explicit manifest path.
+    String _getCoverageManifestOutputPath(const String& path, IArtifact* artifact);
     String _getExplicitSeparateDebugInfoOutputPath();
     bool _hasExplicitSeparateDebugInfoOutputPath();
 

--- a/source/slang/slang-end-to-end-request.h
+++ b/source/slang/slang-end-to-end-request.h
@@ -381,8 +381,18 @@ public:
     CompilerOptionSet& getOptionSet() { return m_linkage->m_optionSet; }
 
 private:
+    struct ExistingOutputArtifact
+    {
+        TargetProgram* targetProgram = nullptr;
+        String path;
+        IArtifact* artifact = nullptr;
+    };
+
     String _getWholeProgramPath(TargetRequest* targetReq);
     String _getEntryPointPath(TargetRequest* targetReq, Index entryPointIndex);
+    /// Collects the already-generated whole-program or per-entry-point artifacts that command-line
+    /// output validation and emission will consume.
+    void _collectExistingOutputArtifacts(List<ExistingOutputArtifact>& outArtifacts);
     String _getExplicitCoverageManifestPath();
     bool _hasExplicitCoverageManifestPath();
     String _getExplicitSeparateDebugInfoOutputPath();

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -949,7 +949,17 @@ void initCommandOptions(CommandOptions& options)
         {OptionKind::EmitSeparateDebug,
          "-separate-debug-info",
          nullptr,
-         "Emit debug data to a separate file, and strip it from the main output file."},
+         "Emit debug data to a separate file, and strip it from the main output file. By default, "
+         "the debug file path is derived from the main `-o <path>` output as a fallback. Use "
+         "`-separate-debug-info-output <path>` to override it or when the main artifact is written "
+         "to stdout."},
+        {OptionKind::SeparateDebugInfoOutput,
+         "-separate-debug-info-output",
+         "-separate-debug-info-output <path>",
+         "Write separate debug information to an explicit sidecar path, overriding the fallback "
+         "path derived from `-o <path>`. Requires `-separate-debug-info` and allows the main "
+         "artifact to be written to stdout. Use `-` to write the separate debug information to "
+         "stdout when the main artifact is written to a file."},
         {OptionKind::EmitCPUViaCPP,
          "-emit-cpu-via-cpp",
          nullptr,
@@ -4008,6 +4018,13 @@ SlangResult OptionsParser::_parse(int argc, char const* const* argv)
                 // This will emit a separate debug file, containing all debug info in
                 // a .dbg.spv file. The main output SPIRV will have all debug info stripped.
                 linkage->m_optionSet.set(OptionKind::EmitSeparateDebug, true);
+                break;
+            }
+        case OptionKind::SeparateDebugInfoOutput:
+            {
+                CommandLineArg outputPath;
+                SLANG_RETURN_ON_FAIL(m_reader.expectArg(outputPath));
+                linkage->m_optionSet.set(OptionKind::SeparateDebugInfoOutput, outputPath.value);
                 break;
             }
         case OptionKind::EmitCPUViaCPP:

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -535,6 +535,7 @@ void initCommandOptions(CommandOptions& options)
          "-o",
          "-o <path>",
          "Specify a path where generated output should be written.\n"
+         "Use `-` to write generated output to stdout. "
          "If no -target or -stage is specified, one may be inferred "
          "from file extension (see <file-extension>). "
          "If multiple -target options and a single -entry are present, each -o "

--- a/tests/diagnostics/command-line/separate-debug-info-output-without-separate-debug-info.slang
+++ b/tests/diagnostics/command-line/separate-debug-info-output-without-separate-debug-info.slang
@@ -1,0 +1,10 @@
+// separate-debug-info-output-without-separate-debug-info.slang
+
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage compute -separate-debug-info-output unused.dbg.spv
+
+// CHECK: error[E00110]: `-separate-debug-info-output` requires `-separate-debug-info`
+
+[numthreads(1, 1, 1)]
+void main()
+{
+}

--- a/tests/diagnostics/command-line/separate-debug-info-stdout.slang
+++ b/tests/diagnostics/command-line/separate-debug-info-stdout.slang
@@ -1,0 +1,21 @@
+// separate-debug-info-stdout.slang
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK1):-target spirv -g2 -emit-spirv-directly -separate-debug-info -entry main -stage compute
+//CHECK1: 00109
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK2):-target spirv -g2 -emit-spirv-directly -separate-debug-info -entry main -stage compute -o -
+//CHECK2: 00109
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK3):-target spirv -g2 -emit-spirv-directly -separate-debug-info -whole-program
+//CHECK3: 00109
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK4):-target spirv -g2 -emit-spirv-directly -separate-debug-info -whole-program -o -
+//CHECK4: 00109
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK5, non-exhaustive):-target glsl -o separate-debug-info-stdout.glsl -target spirv -g2 -emit-spirv-directly -separate-debug-info -entry main -stage compute
+//CHECK5: 00109
+
+[numthreads(1, 1, 1)]
+void main()
+{
+}

--- a/tests/spirv/separate-debug.slang
+++ b/tests/spirv/separate-debug.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage compute -g2 -emit-spirv-directly -separate-debug-info -separate-debug-info-output tests/spirv/separate-debug.dbg.spv
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage compute -g2 -emit-spirv-directly -separate-debug-info -separate-debug-info-output build/separate-debug.actual
 
 struct TestType
 {

--- a/tests/spirv/separate-debug.slang
+++ b/tests/spirv/separate-debug.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage compute -g2 -emit-spirv-directly -separate-debug-info
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage compute -g2 -emit-spirv-directly -separate-debug-info -separate-debug-info-output tests/spirv/separate-debug.dbg.spv
 
 struct TestType
 {

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -610,6 +610,7 @@ struct TempCoverageCliFiles
     String metalDisassemblyManifestPath;
     String wgslOutputPath;
     String explicitManifestPath;
+    String explicitDebugPath;
     String containerOutputPath;
 
     ~TempCoverageCliFiles()
@@ -624,6 +625,7 @@ struct TempCoverageCliFiles
         File::remove(metalDisassemblyManifestPath);
         File::remove(wgslOutputPath);
         File::remove(explicitManifestPath);
+        File::remove(explicitDebugPath);
         File::remove(containerOutputPath);
     }
 };
@@ -642,6 +644,7 @@ static SlangResult _createTempCoverageCliFiles(
     out.metalDisassemblyManifestPath = out.metalDisassemblyOutputPath + ".coverage-manifest.json";
     out.wgslOutputPath = out.basePath + ".wgsl";
     out.explicitManifestPath = out.basePath + ".coverage-manifest.json";
+    out.explicitDebugPath = out.basePath + ".explicit.dbg.spv";
     out.containerOutputPath = out.basePath + ".slang-module";
     return File::writeAllText(out.sourcePath, source);
 }
@@ -1171,7 +1174,6 @@ static SlangResult _testCoverageExplicitSidecarCannotOverwriteDebugArtifact(
     ScopedDebugArtifactFile debugArtifact;
     debugArtifact.path = debugArtifactCandidates[0];
     String debugArtifactPath = debugArtifact.path;
-
     File::remove(files.outputPath);
     File::remove(files.autoManifestPath);
     File::remove(debugArtifactPath);
@@ -1199,6 +1201,276 @@ static SlangResult _testCoverageExplicitSidecarCannotOverwriteDebugArtifact(
         return SLANG_FAIL;
 
     return SLANG_OK;
+}
+
+static SlangResult _testSeparateDebugInfoStdoutFailsWithoutWritingSidecar(
+    UnitTestContext* context,
+    bool useExplicitStdout)
+{
+    TempCoverageCliFiles files;
+    SLANG_RETURN_ON_FAIL(_createTempCoverageCliFiles(files));
+
+    List<String> debugFilesBefore;
+    SLANG_RETURN_ON_FAIL(_collectDebugSpvFiles(debugFilesBefore));
+
+    List<String> args;
+    _addCoverageCliCompileArgs(args, files.sourcePath, false);
+    args.add("-g2");
+    args.add("-emit-spirv-directly");
+    args.add("-separate-debug-info");
+    if (useExplicitStdout)
+    {
+        args.add("-o");
+        args.add("-");
+    }
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+    if (!_containsDiagnostic(result, "E00109", "requires an output file path"))
+        return SLANG_FAIL;
+    if (result.standardOutput.getLength() != 0)
+        return SLANG_FAIL;
+
+    List<String> debugFilesAfter;
+    SLANG_RETURN_ON_FAIL(_collectDebugSpvFiles(debugFilesAfter));
+    for (const auto& file : debugFilesAfter)
+    {
+        if (!_containsFileName(debugFilesBefore, file))
+            return SLANG_FAIL;
+    }
+
+    return SLANG_OK;
+}
+
+static SlangResult _testSeparateDebugInfoStdoutWholeProgramFailsWithoutWritingSidecar(
+    UnitTestContext* context,
+    bool useExplicitStdout)
+{
+    TempCoverageCliFiles files;
+    SLANG_RETURN_ON_FAIL(_createTempCoverageCliFiles(files));
+
+    List<String> debugFilesBefore;
+    SLANG_RETURN_ON_FAIL(_collectDebugSpvFiles(debugFilesBefore));
+
+    List<String> args;
+    _addCoverageCliCompileArgs(args, files.sourcePath, false);
+    args.add("-whole-program");
+    args.add("-g2");
+    args.add("-emit-spirv-directly");
+    args.add("-separate-debug-info");
+    if (useExplicitStdout)
+    {
+        args.add("-o");
+        args.add("-");
+    }
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+    if (!_containsDiagnostic(result, "E00109", "requires an output file path"))
+        return SLANG_FAIL;
+    if (result.standardOutput.getLength() != 0)
+        return SLANG_FAIL;
+
+    List<String> debugFilesAfter;
+    SLANG_RETURN_ON_FAIL(_collectDebugSpvFiles(debugFilesAfter));
+    for (const auto& file : debugFilesAfter)
+    {
+        if (!_containsFileName(debugFilesBefore, file))
+            return SLANG_FAIL;
+    }
+
+    return SLANG_OK;
+}
+
+static SlangResult _testSeparateDebugInfoStdoutWritesExplicitSidecar(
+    UnitTestContext* context,
+    bool wholeProgram,
+    bool useExplicitStdout)
+{
+    TempCoverageCliFiles files;
+    SLANG_RETURN_ON_FAIL(_createTempCoverageCliFiles(files));
+
+    List<String> args;
+    _addCoverageCliCompileArgs(args, files.sourcePath, false);
+    if (wholeProgram)
+        args.add("-whole-program");
+    args.add("-g2");
+    args.add("-emit-spirv-directly");
+    args.add("-separate-debug-info");
+    args.add("-separate-debug-info-output");
+    args.add(files.explicitDebugPath);
+    if (useExplicitStdout)
+    {
+        args.add("-o");
+        args.add("-");
+    }
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
+    if (result.resultCode != 0 || result.standardOutput.getLength() == 0)
+        return SLANG_FAIL;
+    if (!File::exists(files.explicitDebugPath) || File::exists(files.outputPath))
+        return SLANG_FAIL;
+
+    List<unsigned char> debugBytes;
+    SLANG_RETURN_ON_FAIL(File::readAllBytes(files.explicitDebugPath, debugBytes));
+    return debugBytes.getCount() != 0 ? SLANG_OK : SLANG_FAIL;
+}
+
+static SlangResult _testSeparateDebugInfoOutputRequiresSeparateDebugInfo(UnitTestContext* context)
+{
+    TempCoverageCliFiles files;
+    SLANG_RETURN_ON_FAIL(_createTempCoverageCliFiles(files));
+
+    List<String> args;
+    _addCoverageCliCompileArgs(args, files.sourcePath, false);
+    args.add("-separate-debug-info-output");
+    args.add(files.explicitDebugPath);
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+    if (!_containsDiagnostic(result, "E00110", "requires `-separate-debug-info`"))
+        return SLANG_FAIL;
+    if (result.standardOutput.getLength() != 0 || File::exists(files.explicitDebugPath))
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
+static SlangResult _testSeparateDebugInfoOutputRejectsArtifactCollision(UnitTestContext* context)
+{
+    TempCoverageCliFiles files;
+    SLANG_RETURN_ON_FAIL(_createTempCoverageCliFiles(files));
+
+    List<String> args;
+    _addCoverageCliCompileArgs(args, files.sourcePath, false);
+    args.add("-g2");
+    args.add("-emit-spirv-directly");
+    args.add("-separate-debug-info");
+    args.add("-separate-debug-info-output");
+    args.add(files.outputPath);
+    args.add("-o");
+    args.add(files.outputPath);
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+    if (!_containsDiagnostic(result, "E00111", "must differ from every other output path"))
+        return SLANG_FAIL;
+    return !File::exists(files.outputPath) ? SLANG_OK : SLANG_FAIL;
+}
+
+static SlangResult _testSeparateDebugInfoOutputRejectsContainer(UnitTestContext* context)
+{
+    TempCoverageCliFiles files;
+    SLANG_RETURN_ON_FAIL(_createTempCoverageCliFiles(files));
+
+    List<String> args;
+    _addCoverageCliCompileArgs(args, files.sourcePath, false);
+    args.add("-g2");
+    args.add("-emit-spirv-directly");
+    args.add("-separate-debug-info");
+    args.add("-separate-debug-info-output");
+    args.add(files.explicitDebugPath);
+    args.add("-o");
+    args.add(files.containerOutputPath);
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+    if (!_containsDiagnostic(result, "E00112", "not supported when writing a container output"))
+        return SLANG_FAIL;
+    if (File::exists(files.containerOutputPath) || File::exists(files.explicitDebugPath))
+        return SLANG_FAIL;
+    return SLANG_OK;
+}
+
+static SlangResult _testSeparateDebugInfoOutputRejectsMissingDebugData(UnitTestContext* context)
+{
+    TempCoverageCliFiles files;
+    SLANG_RETURN_ON_FAIL(_createTempCoverageCliFiles(files));
+
+    List<String> args;
+    _addCoverageCliCompileArgs(args, files.sourcePath, false, "hlsl");
+    args.add("-separate-debug-info");
+    args.add("-separate-debug-info-output");
+    args.add(files.explicitDebugPath);
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+    if (!_containsDiagnostic(result, "E00113", "did not produce separate debug information"))
+        return SLANG_FAIL;
+    return !File::exists(files.explicitDebugPath) ? SLANG_OK : SLANG_FAIL;
+}
+
+static SlangResult _testSeparateDebugInfoOutputWritesToStdout(
+    UnitTestContext* context,
+    bool wholeProgram)
+{
+    TempCoverageCliFiles files;
+    SLANG_RETURN_ON_FAIL(_createTempCoverageCliFiles(files));
+
+    List<String> args;
+    _addCoverageCliCompileArgs(args, files.sourcePath, false);
+    if (wholeProgram)
+        args.add("-whole-program");
+    args.add("-g2");
+    args.add("-emit-spirv-directly");
+    args.add("-separate-debug-info");
+    args.add("-separate-debug-info-output");
+    args.add("-");
+    args.add("-o");
+    args.add(files.outputPath);
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
+    if (result.resultCode != 0 || result.standardOutput.getLength() == 0)
+        return SLANG_FAIL;
+    if (!File::exists(files.outputPath) || File::exists(files.explicitDebugPath))
+        return SLANG_FAIL;
+
+    List<unsigned char> mainOutputBytes;
+    SLANG_RETURN_ON_FAIL(File::readAllBytes(files.outputPath, mainOutputBytes));
+    return mainOutputBytes.getCount() != 0 ? SLANG_OK : SLANG_FAIL;
+}
+
+static SlangResult _testSeparateDebugInfoOutputRejectsStdoutCollision(
+    UnitTestContext* context,
+    bool useExplicitStdout)
+{
+    TempCoverageCliFiles files;
+    SLANG_RETURN_ON_FAIL(_createTempCoverageCliFiles(files));
+
+    List<String> args;
+    _addCoverageCliCompileArgs(args, files.sourcePath, false);
+    args.add("-g2");
+    args.add("-emit-spirv-directly");
+    args.add("-separate-debug-info");
+    args.add("-separate-debug-info-output");
+    args.add("-");
+    if (useExplicitStdout)
+    {
+        args.add("-o");
+        args.add("-");
+    }
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+    if (!_containsDiagnostic(result, "E00111", "must differ from every other output path"))
+        return SLANG_FAIL;
+    return result.standardOutput.getLength() == 0 ? SLANG_OK : SLANG_FAIL;
 }
 
 static SlangResult _testCoverageExplicitSidecarRejectsWholeProgramCollision(
@@ -1490,18 +1762,12 @@ static bool _blobContentEquals(ISlangBlob* left, ISlangBlob* right)
            0;
 }
 
-static SlangResult _getCoverageOptionEntryPointHash(
-    const char* coverageManifestOutput,
-    bool traceCoverage,
+static SlangResult _getOptionEntryPointHash(
+    const slang::CompilerOptionEntry* options,
+    SlangInt optionCount,
+    const char* moduleName,
     ComPtr<ISlangBlob>& outHash)
 {
-    slang::CompilerOptionEntry options[] = {
-        _makeBoolCompilerOption(slang::CompilerOptionName::TraceCoverage, traceCoverage),
-        _makeStringCompilerOption(
-            slang::CompilerOptionName::CoverageManifestOutput,
-            coverageManifestOutput),
-    };
-
     ComPtr<slang::IGlobalSession> globalSession;
     SLANG_RETURN_ON_FAIL(slang_createGlobalSession(SLANG_API_VERSION, globalSession.writeRef()));
 
@@ -1511,7 +1777,7 @@ static SlangResult _getCoverageOptionEntryPointHash(
     slang::SessionDesc sessionDesc = {};
     sessionDesc.targetCount = 1;
     sessionDesc.targets = &targetDesc;
-    sessionDesc.compilerOptionEntryCount = SLANG_COUNT_OF(options);
+    sessionDesc.compilerOptionEntryCount = optionCount;
     sessionDesc.compilerOptionEntries = options;
 
     ComPtr<slang::ISession> session;
@@ -1520,8 +1786,8 @@ static SlangResult _getCoverageOptionEntryPointHash(
     ComPtr<slang::IBlob> diagnostics;
     ComPtr<slang::IModule> module;
     module = session->loadModuleFromSourceString(
-        "coverageHash",
-        "coverage-hash.slang",
+        moduleName,
+        "option-hash.slang",
         kCoverageCliShader,
         diagnostics.writeRef());
     if (!module)
@@ -1549,6 +1815,20 @@ static SlangResult _getCoverageOptionEntryPointHash(
     return outHash ? SLANG_OK : SLANG_FAIL;
 }
 
+static SlangResult _getCoverageOptionEntryPointHash(
+    const char* coverageManifestOutput,
+    bool traceCoverage,
+    ComPtr<ISlangBlob>& outHash)
+{
+    slang::CompilerOptionEntry options[] = {
+        _makeBoolCompilerOption(slang::CompilerOptionName::TraceCoverage, traceCoverage),
+        _makeStringCompilerOption(
+            slang::CompilerOptionName::CoverageManifestOutput,
+            coverageManifestOutput),
+    };
+    return _getOptionEntryPointHash(options, SLANG_COUNT_OF(options), "coverageHash", outHash);
+}
+
 static SlangResult _testCoverageManifestOutputDoesNotAffectCompilerOptionHash()
 {
     ComPtr<ISlangBlob> explicitManifestAHash;
@@ -1564,6 +1844,42 @@ static SlangResult _testCoverageManifestOutputDoesNotAffectCompilerOptionHash()
     SLANG_RETURN_ON_FAIL(
         _getCoverageOptionEntryPointHash("a.json", false, traceCoverageDisabledHash));
     if (_blobContentEquals(explicitManifestAHash, traceCoverageDisabledHash))
+        return SLANG_FAIL;
+
+    return SLANG_OK;
+}
+
+static SlangResult _getSeparateDebugOptionEntryPointHash(
+    const char* separateDebugOutput,
+    bool emitSeparateDebug,
+    ComPtr<ISlangBlob>& outHash)
+{
+    slang::CompilerOptionEntry options[] = {
+        _makeBoolCompilerOption(slang::CompilerOptionName::EmitSeparateDebug, emitSeparateDebug),
+        _makeStringCompilerOption(
+            slang::CompilerOptionName::SeparateDebugInfoOutput,
+            separateDebugOutput),
+    };
+    return _getOptionEntryPointHash(options, SLANG_COUNT_OF(options), "separateDebugHash", outHash);
+}
+
+static SlangResult _testSeparateDebugInfoOutputDoesNotAffectCompilerOptionHash()
+{
+    ComPtr<ISlangBlob> explicitDebugAHash;
+    SLANG_RETURN_ON_FAIL(
+        _getSeparateDebugOptionEntryPointHash("a.dbg.spv", true, explicitDebugAHash));
+
+    ComPtr<ISlangBlob> explicitDebugBHash;
+    SLANG_RETURN_ON_FAIL(
+        _getSeparateDebugOptionEntryPointHash("b.dbg.spv", true, explicitDebugBHash));
+
+    if (!_blobContentEquals(explicitDebugAHash, explicitDebugBHash))
+        return SLANG_FAIL;
+
+    ComPtr<ISlangBlob> separateDebugDisabledHash;
+    SLANG_RETURN_ON_FAIL(
+        _getSeparateDebugOptionEntryPointHash("a.dbg.spv", false, separateDebugDisabledHash));
+    if (_blobContentEquals(explicitDebugAHash, separateDebugDisabledHash))
         return SLANG_FAIL;
 
     return SLANG_OK;
@@ -1598,6 +1914,42 @@ SLANG_UNIT_TEST(SlangcCoverageManifestOutputMetalLib)
     SLANG_CHECK(SLANG_SUCCEEDED(_testCoverageAutoSidecarForMetalLibDisassembly(unitTestContext)));
     SLANG_CHECK(
         SLANG_SUCCEEDED(_testCoverageExplicitSidecarForMetalLibDisassembly(unitTestContext)));
+}
+
+SLANG_UNIT_TEST(SlangcSeparateDebugInfoOutput)
+{
+    SLANG_CHECK(SLANG_SUCCEEDED(
+        _testSeparateDebugInfoStdoutFailsWithoutWritingSidecar(unitTestContext, false)));
+    SLANG_CHECK(SLANG_SUCCEEDED(
+        _testSeparateDebugInfoStdoutFailsWithoutWritingSidecar(unitTestContext, true)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testSeparateDebugInfoStdoutWholeProgramFailsWithoutWritingSidecar(
+        unitTestContext,
+        false)));
+    SLANG_CHECK(SLANG_SUCCEEDED(
+        _testSeparateDebugInfoStdoutWholeProgramFailsWithoutWritingSidecar(unitTestContext, true)));
+    SLANG_CHECK(SLANG_SUCCEEDED(
+        _testSeparateDebugInfoStdoutWritesExplicitSidecar(unitTestContext, false, false)));
+    SLANG_CHECK(SLANG_SUCCEEDED(
+        _testSeparateDebugInfoStdoutWritesExplicitSidecar(unitTestContext, false, true)));
+    SLANG_CHECK(SLANG_SUCCEEDED(
+        _testSeparateDebugInfoStdoutWritesExplicitSidecar(unitTestContext, true, false)));
+    SLANG_CHECK(SLANG_SUCCEEDED(
+        _testSeparateDebugInfoStdoutWritesExplicitSidecar(unitTestContext, true, true)));
+    SLANG_CHECK(
+        SLANG_SUCCEEDED(_testSeparateDebugInfoOutputRequiresSeparateDebugInfo(unitTestContext)));
+    SLANG_CHECK(
+        SLANG_SUCCEEDED(_testSeparateDebugInfoOutputRejectsArtifactCollision(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testSeparateDebugInfoOutputRejectsContainer(unitTestContext)));
+    SLANG_CHECK(
+        SLANG_SUCCEEDED(_testSeparateDebugInfoOutputRejectsMissingDebugData(unitTestContext)));
+    SLANG_CHECK(
+        SLANG_SUCCEEDED(_testSeparateDebugInfoOutputWritesToStdout(unitTestContext, false)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testSeparateDebugInfoOutputWritesToStdout(unitTestContext, true)));
+    SLANG_CHECK(SLANG_SUCCEEDED(
+        _testSeparateDebugInfoOutputRejectsStdoutCollision(unitTestContext, false)));
+    SLANG_CHECK(
+        SLANG_SUCCEEDED(_testSeparateDebugInfoOutputRejectsStdoutCollision(unitTestContext, true)));
+    SLANG_CHECK(SLANG_SUCCEEDED(_testSeparateDebugInfoOutputDoesNotAffectCompilerOptionHash()));
 }
 
 SLANG_UNIT_TEST(SlangcCoverageManifestOutput)

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -608,6 +608,7 @@ struct TempCoverageCliFiles
     String disassemblyManifestPath;
     String metalDisassemblyOutputPath;
     String metalDisassemblyManifestPath;
+    String hlslOutputPath;
     String wgslOutputPath;
     String explicitManifestPath;
     String explicitDebugPath;
@@ -623,6 +624,7 @@ struct TempCoverageCliFiles
         File::remove(disassemblyManifestPath);
         File::remove(metalDisassemblyOutputPath);
         File::remove(metalDisassemblyManifestPath);
+        File::remove(hlslOutputPath);
         File::remove(wgslOutputPath);
         File::remove(explicitManifestPath);
         File::remove(explicitDebugPath);
@@ -642,6 +644,7 @@ static SlangResult _createTempCoverageCliFiles(
     out.disassemblyManifestPath = out.disassemblyOutputPath + ".coverage-manifest.json";
     out.metalDisassemblyOutputPath = out.basePath + ".metallib-asm";
     out.metalDisassemblyManifestPath = out.metalDisassemblyOutputPath + ".coverage-manifest.json";
+    out.hlslOutputPath = out.basePath + ".hlsl";
     out.wgslOutputPath = out.basePath + ".wgsl";
     out.explicitManifestPath = out.basePath + ".coverage-manifest.json";
     out.explicitDebugPath = out.basePath + ".explicit.dbg.spv";
@@ -1367,6 +1370,73 @@ static SlangResult _testSeparateDebugInfoOutputRejectsArtifactCollision(UnitTest
     return !File::exists(files.outputPath) ? SLANG_OK : SLANG_FAIL;
 }
 
+// Verifies that a debug sidecar cannot overwrite an output from a target without debug data.
+static SlangResult _testSeparateDebugInfoOutputRejectsOtherTargetCollision(UnitTestContext* context)
+{
+    TempCoverageCliFiles files;
+    SLANG_RETURN_ON_FAIL(_createTempCoverageCliFiles(files));
+
+    List<String> args;
+    args.add(files.sourcePath);
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("-target");
+    args.add("hlsl");
+    args.add("-o");
+    args.add(files.hlslOutputPath);
+    args.add("-target");
+    args.add("spirv");
+    args.add("-o");
+    args.add(files.outputPath);
+    args.add("-g2");
+    args.add("-emit-spirv-directly");
+    args.add("-separate-debug-info");
+    args.add("-separate-debug-info-output");
+    args.add(files.hlslOutputPath);
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+    if (!_containsDiagnostic(result, "E00111", "must differ from every other output path"))
+        return SLANG_FAIL;
+    if (File::exists(files.hlslOutputPath) || File::exists(files.outputPath))
+        return SLANG_FAIL;
+    return SLANG_OK;
+}
+
+// Verifies that debug and coverage sidecars cannot claim the same destination.
+static SlangResult _testSeparateDebugInfoOutputRejectsCoverageManifestCollision(
+    UnitTestContext* context)
+{
+    TempCoverageCliFiles files;
+    SLANG_RETURN_ON_FAIL(_createTempCoverageCliFiles(files));
+
+    List<String> args;
+    _addCoverageCliCompileArgs(args, files.sourcePath, true);
+    args.add("-g2");
+    args.add("-emit-spirv-directly");
+    args.add("-separate-debug-info");
+    args.add("-separate-debug-info-output");
+    args.add(files.explicitManifestPath);
+    args.add("-coverage-manifest-output");
+    args.add(files.explicitManifestPath);
+    args.add("-o");
+    args.add(files.outputPath);
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+    if (!_containsDiagnostic(result, "E00111", "must differ from every other output path"))
+        return SLANG_FAIL;
+    if (File::exists(files.outputPath) || File::exists(files.explicitManifestPath))
+        return SLANG_FAIL;
+    return SLANG_OK;
+}
+
 static SlangResult _testSeparateDebugInfoOutputRejectsContainer(UnitTestContext* context)
 {
     TempCoverageCliFiles files;
@@ -1939,6 +2009,10 @@ SLANG_UNIT_TEST(SlangcSeparateDebugInfoOutput)
         SLANG_SUCCEEDED(_testSeparateDebugInfoOutputRequiresSeparateDebugInfo(unitTestContext)));
     SLANG_CHECK(
         SLANG_SUCCEEDED(_testSeparateDebugInfoOutputRejectsArtifactCollision(unitTestContext)));
+    SLANG_CHECK(
+        SLANG_SUCCEEDED(_testSeparateDebugInfoOutputRejectsOtherTargetCollision(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(
+        _testSeparateDebugInfoOutputRejectsCoverageManifestCollision(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testSeparateDebugInfoOutputRejectsContainer(unitTestContext)));
     SLANG_CHECK(
         SLANG_SUCCEEDED(_testSeparateDebugInfoOutputRejectsMissingDebugData(unitTestContext)));

--- a/tools/slang-unit-test/unit-test-stdin-compile.cpp
+++ b/tools/slang-unit-test/unit-test-stdin-compile.cpp
@@ -612,6 +612,8 @@ struct TempCoverageCliFiles
     String wgslOutputPath;
     String explicitManifestPath;
     String explicitDebugPath;
+    String reflectionPath;
+    String dependencyPath;
     String containerOutputPath;
 
     ~TempCoverageCliFiles()
@@ -628,6 +630,8 @@ struct TempCoverageCliFiles
         File::remove(wgslOutputPath);
         File::remove(explicitManifestPath);
         File::remove(explicitDebugPath);
+        File::remove(reflectionPath);
+        File::remove(dependencyPath);
         File::remove(containerOutputPath);
     }
 };
@@ -648,6 +652,8 @@ static SlangResult _createTempCoverageCliFiles(
     out.wgslOutputPath = out.basePath + ".wgsl";
     out.explicitManifestPath = out.basePath + ".coverage-manifest.json";
     out.explicitDebugPath = out.basePath + ".explicit.dbg.spv";
+    out.reflectionPath = out.basePath + ".reflection.json";
+    out.dependencyPath = out.basePath + ".d";
     out.containerOutputPath = out.basePath + ".slang-module";
     return File::writeAllText(out.sourcePath, source);
 }
@@ -1365,7 +1371,7 @@ static SlangResult _testSeparateDebugInfoOutputRejectsArtifactCollision(UnitTest
     SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
     if (result.resultCode == 0)
         return SLANG_FAIL;
-    if (!_containsDiagnostic(result, "E00111", "must differ from every other output path"))
+    if (!_containsDiagnostic(result, "E00111", "must differ from output path"))
         return SLANG_FAIL;
     return !File::exists(files.outputPath) ? SLANG_OK : SLANG_FAIL;
 }
@@ -1400,7 +1406,7 @@ static SlangResult _testSeparateDebugInfoOutputRejectsOtherTargetCollision(UnitT
     SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
     if (result.resultCode == 0)
         return SLANG_FAIL;
-    if (!_containsDiagnostic(result, "E00111", "must differ from every other output path"))
+    if (!_containsDiagnostic(result, "E00111", "must differ from output path"))
         return SLANG_FAIL;
     if (File::exists(files.hlslOutputPath) || File::exists(files.outputPath))
         return SLANG_FAIL;
@@ -1430,9 +1436,79 @@ static SlangResult _testSeparateDebugInfoOutputRejectsCoverageManifestCollision(
     SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
     if (result.resultCode == 0)
         return SLANG_FAIL;
-    if (!_containsDiagnostic(result, "E00111", "must differ from every other output path"))
+    if (!_containsDiagnostic(result, "E00111", "must differ from output path"))
         return SLANG_FAIL;
     if (File::exists(files.outputPath) || File::exists(files.explicitManifestPath))
+        return SLANG_FAIL;
+    return SLANG_OK;
+}
+
+// Verifies that outputs written outside the artifact loop are part of the same output namespace.
+static SlangResult _testSeparateDebugInfoOutputRejectsAuxiliaryOutputCollision(
+    UnitTestContext* context,
+    bool useReflectionOutput)
+{
+    TempCoverageCliFiles files;
+    SLANG_RETURN_ON_FAIL(_createTempCoverageCliFiles(files));
+
+    const String collisionPath = useReflectionOutput ? files.reflectionPath : files.dependencyPath;
+    List<String> args;
+    _addCoverageCliCompileArgs(args, files.sourcePath, false);
+    args.add("-g2");
+    args.add("-emit-spirv-directly");
+    args.add("-separate-debug-info");
+    args.add("-separate-debug-info-output");
+    args.add(collisionPath);
+    args.add(useReflectionOutput ? "-reflection-json" : "-depfile");
+    args.add(collisionPath);
+    args.add("-o");
+    args.add(files.outputPath);
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+    if (!_containsDiagnostic(result, "E00111", "must differ from output path"))
+        return SLANG_FAIL;
+    if (File::exists(files.outputPath) || File::exists(files.explicitDebugPath) ||
+        File::exists(collisionPath))
+        return SLANG_FAIL;
+    return SLANG_OK;
+}
+
+// Verifies that one explicit path cannot claim multiple per-entry-point debug artifacts.
+static SlangResult _testSeparateDebugInfoOutputRejectsMultipleArtifacts(UnitTestContext* context)
+{
+    TempCoverageCliFiles files;
+    SLANG_RETURN_ON_FAIL(_createTempCoverageCliFiles(files, kCoverageCliTwoEntryShader));
+
+    List<String> args;
+    args.add(files.sourcePath);
+    args.add("-target");
+    args.add("spirv");
+    args.add("-target");
+    args.add("glsl");
+    args.add("-entry");
+    args.add("main");
+    args.add("-stage");
+    args.add("compute");
+    args.add("-entry");
+    args.add("main2");
+    args.add("-stage");
+    args.add("compute");
+    args.add("-g2");
+    args.add("-emit-spirv-directly");
+    args.add("-separate-debug-info");
+    args.add("-separate-debug-info-output");
+    args.add(files.explicitDebugPath);
+
+    ExecuteResult result;
+    SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
+    if (result.resultCode == 0)
+        return SLANG_FAIL;
+    if (!_containsDiagnostic(result, "E00114", "cannot receive multiple"))
+        return SLANG_FAIL;
+    if (result.standardOutput.getLength() != 0 || File::exists(files.explicitDebugPath))
         return SLANG_FAIL;
     return SLANG_OK;
 }
@@ -1538,7 +1614,7 @@ static SlangResult _testSeparateDebugInfoOutputRejectsStdoutCollision(
     SLANG_RETURN_ON_FAIL(_runSlangc(context, args, result));
     if (result.resultCode == 0)
         return SLANG_FAIL;
-    if (!_containsDiagnostic(result, "E00111", "must differ from every other output path"))
+    if (!_containsDiagnostic(result, "E00111", "must differ from output path"))
         return SLANG_FAIL;
     return result.standardOutput.getLength() == 0 ? SLANG_OK : SLANG_FAIL;
 }
@@ -2013,6 +2089,12 @@ SLANG_UNIT_TEST(SlangcSeparateDebugInfoOutput)
         SLANG_SUCCEEDED(_testSeparateDebugInfoOutputRejectsOtherTargetCollision(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(
         _testSeparateDebugInfoOutputRejectsCoverageManifestCollision(unitTestContext)));
+    SLANG_CHECK(SLANG_SUCCEEDED(
+        _testSeparateDebugInfoOutputRejectsAuxiliaryOutputCollision(unitTestContext, true)));
+    SLANG_CHECK(SLANG_SUCCEEDED(
+        _testSeparateDebugInfoOutputRejectsAuxiliaryOutputCollision(unitTestContext, false)));
+    SLANG_CHECK(
+        SLANG_SUCCEEDED(_testSeparateDebugInfoOutputRejectsMultipleArtifacts(unitTestContext)));
     SLANG_CHECK(SLANG_SUCCEEDED(_testSeparateDebugInfoOutputRejectsContainer(unitTestContext)));
     SLANG_CHECK(
         SLANG_SUCCEEDED(_testSeparateDebugInfoOutputRejectsMissingDebugData(unitTestContext)));


### PR DESCRIPTION
## Motivation

`slangc` currently derives the separate SPIR-V debug sidecar from the main `-o` path. That makes this otherwise useful pipeline impossible:

```console
slangc shader.slang -target spirv -g2 -emit-spirv-directly \
    -separate-debug-info -separate-debug-info-output shader.dbg.spv -o - > shader.spv
```

The main artifact has no file path from which to derive a sidecar name, even though code generation already produced both artifacts. Callers also cannot choose a sidecar location independently of the main artifact. The existing behavior remains useful, so an invocation that only supplies `-separate-debug-info -o shader.spv` must continue deriving the same debug path as before.

## Proposed solution

Add `-separate-debug-info-output <path>` and the matching public `CompilerOptionName::SeparateDebugInfoOutput` string option. When present, it selects the already-produced separate-debug artifact's destination; when absent, the current `-o`-based derivation remains the fallback. A value of `-` writes the debug artifact to stdout as long as the main artifact goes to a file.

Validate the complete output plan before writing anything. This rejects configurations that have no derivable destination, send two artifacts to stdout, assign one explicit path to multiple debug artifacts, alias any main artifact or auxiliary reflection, dependency, or coverage-manifest output, request the option without `-separate-debug-info`, request it for a target that did not produce debug data, or combine it with container output.

## Change summary

- Add the public compiler option and CLI spelling, help text, reference documentation, and focused diagnostics (`include/slang.h:1239`, `source/slang/slang-options.cpp:949`, `source/slang/slang-diagnostics.lua:215`, and `docs/command-line-slangc-reference.md:659`).
- Centralize enumeration of already-generated whole-program and per-entry-point outputs, explicit-versus-derived debug and coverage path selection, destination-aware collision comparison, and preflight before any artifact is written (`EndToEndCompileRequest::_collectExistingOutputArtifacts`, `_getSeparateDebugInfoOutputPath`, `_validateSeparateDebugInfoOutputPaths`, and `_maybeWriteSeparateDebugInfoOutput` in `source/slang/slang-end-to-end-request.cpp:418`).
- Include the selected debug path in coverage-manifest collision validation and treat both implicit stdout and `-` as the same output destination (`source/slang/slang-end-to-end-request.cpp:773`).
- Exclude the destination-only option from compiler cache hashes (`CompilerOptionSet::buildHash` in `source/slang/slang-compiler-options.cpp:182`).
- Cover file/stdout routing, whole-program and entry-point output, multi-artifact rejection, cross-target and auxiliary-output collisions, invalid option combinations, missing debug artifacts, cache hashing, diagnostics, and the existing SPIR-V test (`tools/slang-unit-test/unit-test-stdin-compile.cpp:2001`, `tests/diagnostics/command-line/`, and `tests/spirv/separate-debug.slang:1`).

## Concepts and vocabulary

- **Separate-debug artifact**: the associated SPIR-V artifact returned by `getSeparateDbgArtifact`; it contains debug information stripped from the main artifact.
- **Explicit path**: the destination supplied through `SeparateDebugInfoOutput`. Without it, the legacy path derived from the main artifact remains the source of truth.
- **Output preflight**: validation performed after code generation has created the artifact graph but before any artifact is written, so an invalid plan cannot leave partial output behind.

## Process report

Consider the example above. `OptionsParser::_parse` records `shader.dbg.spv` as output policy while normal code generation still creates the main SPIR-V artifact and associates its separate-debug artifact. `EndToEndCompileRequest::generateOutput` then calls `_validateSeparateDebugInfoOutputPaths` after code generation and before `_maybeWriteArtifact`. `_collectExistingOutputArtifacts` enumerates the existing whole-program result or each existing entry-point result once for both sidecar validators. The separate-debug validator uses `getSeparateDbgArtifact` to determine whether debug output really exists and compares the explicit destination with every main-artifact, reflection, dependency-file, and coverage-manifest destination, including outputs from non-SPIR-V targets. Only after that preflight succeeds does `_maybeWriteSeparateDebugInfoOutput` pass the associated debug artifact to the normal artifact writer.

This is intentionally output routing rather than a new AST, IR, or artifact representation. The back end’s associated separate-debug artifacts remain the semantic source of truth; `ExistingOutputArtifact` only groups the producer-owned target, path, and artifact pointer for validation. A multi-target invocation without a per-target `-o` can intentionally leave direct SPIR-V in per-entry-point mode, so two entry points produce two valid debug artifacts. Because one explicit destination cannot represent both, `_validateSeparateDebugInfoOutputPaths` diagnoses E00114 instead of changing the producer shape or asserting. `OutputDestination` records only whether an existing writer treats `-` as stdout or as a literal file name, preventing collision validation from inventing a second output-routing policy.

The fallback branch in `_getSeparateDebugInfoOutputPath` preserves existing behavior. If no explicit destination is present, it uses the debug artifact's build-ID name when available and otherwise derives `.dbg.spv` from the main file path. A stdout main artifact has no principled derivation input, so preflight diagnoses that case unless the user supplies the new option. Conversely, the shared `_writeArtifact` path recognizes `-` as stdout, and preflight normalizes empty main paths and `-` before collision checks so two binary streams can never be mixed.

Coverage manifests share the same output namespace. `_getCoverageManifestOutputPath` is the single source of truth for explicit and derived manifest paths, while `_validateCoverageManifestOutputPaths` obtains the debug destination through `_getSeparateDebugInfoOutputPath`. Destination-aware comparison preserves the established distinction that artifact and reflection writers treat `-` as stdout, whereas coverage manifests and dependency files treat it as a literal path, before file-backed paths reach the canonical/symlink-aware comparison.

Finally, `CompilerOptionSet::buildHash` excludes `SeparateDebugInfoOutput` because changing a destination does not change generated shader code or the associated debug artifact. The unit test varies only that destination and verifies the entry-point hash remains stable, while still verifying that toggling `EmitSeparateDebug` changes the hash. The remaining unit and diagnostic tests exercise both producers consumed by the output loop, both stdout spellings, collision failures before file creation, unsupported output shapes, and the legacy derived-path flow.

## Reviewer Directives (maintained by agent)

- [LLM Claude PR Review via `github-actions`] Keep separate-debug and coverage validation on one shared enumeration of existing output artifacts so the two preflights cannot drift. (https://github.com/shader-slang/slang/pull/12147#discussion_r3605559098)

- [LLM Claude PR Review via `github-actions`] Keep the validator’s fallback-versus-explicit mode split explicit at the validation boundary. (https://github.com/shader-slang/slang/pull/12147#discussion_r3606166443)
- [LLM Claude PR Review via `github-actions`] Keep stdout routing centralized in `_isStdoutArtifactPath` so empty paths and `-` remain one convention. (https://github.com/shader-slang/slang/pull/12147#discussion_r3606167206)
- [LLM `nv-slang-bot`, independently verified] Treat multi-target, multi-entry direct-SPIR-V output without a per-target `-o` as a valid per-entry-point artifact shape; diagnose one explicit debug path claiming multiple artifacts instead of asserting or changing the producer. (https://github.com/shader-slang/slang/pull/12147#pullrequestreview-4727233731)
