### PR TITLE
Initialize parsed command-line options

### DIFF
--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -3127,7 +3127,7 @@ SlangResult OptionsParser::_parse(int argc, char const* const* argv)
             {
                 // -fvk-{b|s|t|u}-shift <binding-shift> <set>
                 const auto slice = arg.value.getUnownedSlice().subString(5, 1);
-                HLSLToVulkanLayoutOptions::Kind kind;
+                HLSLToVulkanLayoutOptions::Kind kind = HLSLToVulkanLayoutOptions::Kind::Invalid;
                 SLANG_RETURN_ON_FAIL(_getValue(arg, slice, kind));
 
                 Int shift;
@@ -3542,14 +3542,14 @@ SlangResult OptionsParser::_parse(int argc, char const* const* argv)
             }
         case OptionKind::LineDirectiveMode:
             {
-                SlangLineDirectiveMode value;
+                SlangLineDirectiveMode value = SLANG_LINE_DIRECTIVE_MODE_DEFAULT;
                 SLANG_RETURN_ON_FAIL(_expectValue(value));
                 m_compileRequest->setLineDirectiveMode(value);
                 break;
             }
         case OptionKind::FloatingPointMode:
             {
-                FloatingPointMode value;
+                FloatingPointMode value = FloatingPointMode::Default;
                 SLANG_RETURN_ON_FAIL(_expectValue(value));
                 setFloatingPointMode(getCurrentTarget(), value);
                 break;
@@ -3594,7 +3594,7 @@ SlangResult OptionsParser::_parse(int argc, char const* const* argv)
         case OptionKind::FileSystem:
             {
                 typedef TypeTextUtil::FileSystemType FileSystemType;
-                FileSystemType value;
+                FileSystemType value = FileSystemType::Default;
                 SLANG_RETURN_ON_FAIL(_expectValue(value));
 
                 switch (value)


### PR DESCRIPTION
## Motivation

The scheduled CMake Options workflow builds each option combination in several configurations. After Debug builds began using `-Og`, every Linux Debug matrix entry failed while compiling `OptionsParser::_parse()` in `source/slang/slang-options.cpp`. GCC reported that the parsed Vulkan binding kind, line-directive mode, floating-point mode, and file-system type might be used uninitialized, and `-Werror` promoted those diagnostics to build failures.

The four values all follow the same control flow: `_getValue()` or `_expectValue()` writes the output on success, while `SLANG_RETURN_ON_FAIL` immediately returns on failure. The values are therefore initialized before use at runtime, but GCC cannot prove that relationship through the result-returning helper calls under `-Og`.

## Proposed solution

Initialize each affected local with the enum's existing default or invalid sentinel before parsing it. Successful parsing still replaces that value, and failed parsing still returns immediately, so command-line behavior is unchanged. The initialization makes the local invariant explicit to both readers and compiler data-flow analysis without weakening warnings or adding a fallback parse path.

## Change summary

- `OptionsParser::_parse()` in `source/slang/slang-options.cpp:3130` initializes the Vulkan binding kind with `HLSLToVulkanLayoutOptions::Kind::Invalid`.
- The option cases in `source/slang/slang-options.cpp:3545`, `source/slang/slang-options.cpp:3552`, and `source/slang/slang-options.cpp:3597` initialize line-directive, floating-point, and file-system values with their existing defaults.

## Process report

Consider the Vulkan binding-shift case. `OptionsParser::_parse()` declares `kind`, then calls `_getValue(arg, slice, kind)`. The helper converts a recognized command-line value and assigns it to `kind`; if conversion fails, `SLANG_RETURN_ON_FAIL` returns before `kind` reaches the option set. The line-directive, floating-point, and file-system cases use the same producer-consumer shape through `_expectValue()`.

This is an intentionally valid input shape rather than a malformed value produced upstream. The parsing helpers already enforce the correct success/failure contract, and their output remains the source of truth. Initializing the caller locals to the enums' established default or invalid values records the pre-parse state without reconstructing parsed data, accepting invalid input, or changing the downstream consumers. Once parsing succeeds, the parsed value always overwrites the initializer exactly as before.
