### PR TITLE
Language reference: clarify (non-)short-circuiting behavior of ternary conditional

### DIFF
--- a/docs/language-reference/expressions-operators.md
+++ b/docs/language-reference/expressions-operators.md
@@ -69,12 +69,12 @@ Description:
 
 ### Logical Operators (scalar)
 
-| Operator  | Operator function               | Description                                  |
+| Operator  | Operator function                   | Description                                  |
 |-----------|-------------------------------------|----------------------------------------------|
-| `!`       | `__prefix T operator ! (T val)` | logical NOT                                  |
+| `!`       | `__prefix T operator ! (T val)`     | logical NOT                                  |
 | `&&`      | `T operator && (T lhs, T rhs)`      | logical AND                                  |
 | `\|\|`    | `T operator \|\| (T lhs, T rhs)`    | logical OR                                   |
-| `~`       | `__prefix T operator ~ (T val)` | bitwise NOT                                  |
+| `~`       | `__prefix T operator ~ (T val)`     | bitwise NOT                                  |
 | `&`       | `T operator & (T lhs, T rhs)`       | bitwise AND                                  |
 | `^`       | `T operator ^ (T lhs, T rhs)`       | bitwise XOR                                  |
 | `\|`      | `T operator \| (T lhs, T rhs)`      | bitwise OR                                   |

--- a/docs/language-reference/expressions-operators.md
+++ b/docs/language-reference/expressions-operators.md
@@ -227,11 +227,14 @@ condition is `true`, `trueVal` is returned. Otherwise, `falseVal` is returned.
 
 The default ternary conditional operator is provided for all copyable types.
 
-> ⚠️ **Warning:** Unlike C, C++, GLSL, and most other C-family languages, Slang currently follows the precedent
-> of HLSL where `?:` does not short-circuit. That is, both `trueVal` and `falseVal` are evaluated before
-> either is selected. This is subject to change in future Slang language versions. It is recommended to write
-> code that does not depend on whether `?:` short-circuits or not. When short-circuiting is required,
-> use an `if`/`else` construct instead.
+The ternary conditional operator is short-circuiting for a scalar condition.
+
+> ⚠️ **Warning:** The ternary conditional operator is also defined for vector condition operands for legacy
+> reasons. In this deprecated form, the condition vector length must match the `trueVal` and `falseVal` vector
+> lengths, and for each element, the corresponding element of the condition selects the corresponding
+> element of either `trueVal` or `falseVal`. However, this form is non-short-circuiting. Use
+> [select()](../../../core-module-reference/global-decls/select.html) instead to make the non-short-circuiting
+> behavior explicit.
 
 ### Call Expression
 

--- a/tests/language-feature/scalar-ternary-op-short-and-non-short-circuit.slang
+++ b/tests/language-feature/scalar-ternary-op-short-and-non-short-circuit.slang
@@ -9,6 +9,9 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute  -shaderobj -output-using-type -xslang -Wno-30056
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-mtl -compute  -shaderobj -output-using-type -xslang -Wno-30056
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type -xslang -Wno-30056
+//
+//DISABLE_TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-wgpu -compute  -shaderobj -output-using-type -xslang -Wno-30056
+// See https://github.com/shader-slang/slang/issues/12173
 
 
 //TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=output

--- a/tests/language-feature/scalar-ternary-op-short-and-non-short-circuit.slang
+++ b/tests/language-feature/scalar-ternary-op-short-and-non-short-circuit.slang
@@ -1,0 +1,64 @@
+// Verify that:
+// - The ternary conditional operator with a scalar condition
+//   evaluates only the taken branch.
+// - The ternary conditional operator with a vector condition
+//   evaluates both branches
+//
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cpu -compute -shaderobj -output-using-type -xslang -Wno-30056
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-slang -compute -shaderobj -output-using-type -xslang -Wno-30056
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -compute  -shaderobj -output-using-type -xslang -Wno-30056
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-mtl -compute  -shaderobj -output-using-type -xslang -Wno-30056
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type -xslang -Wno-30056
+
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=output
+RWStructuredBuffer<uint> output;
+
+static uint thenBranches = 0U;
+static uint elseBranches = 0U;
+
+static uint4 thenBranchesV = { 0, 0, 0, 0 };
+static uint4 elseBranchesV = { 0, 0, 0, 0 };
+
+uint4 incV(inout uint4 v)
+{
+    v = v + uint4(1U, 0U, 0U, 0U);
+    return v;
+}
+
+
+[numthreads(4,1,1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    // first: check that '?:' does what it's supposed to do for a scalar
+    output[tid.x] = tid.x >= 2U ? 4242U : 0U;
+
+    //CHECK: 0
+    //CHECK-NEXT: 0
+    //CHECK-NEXT: 4242
+    //CHECK-NEXT: 4242
+
+    // then: check that '?:' for a scalar is short-circuiting
+    (void)(tid.x >= 2U ? thenBranches++ : elseBranches++);
+    output[tid.x + 4U] = (thenBranches * 1000U) + (elseBranches * 2U);
+
+    // CHECK-NEXT: 2
+    // CHECK-NEXT: 2
+    // CHECK-NEXT: 1000
+    // CHECK-NEXT: 1000
+
+    // now check that '?:' does what it's suppose to do for a vector
+    output[tid.x + 8U] = (uint4(tid.x) >= uint4(2U) ? 6767U * incV(thenBranchesV) : 1111U * incV(elseBranchesV)).x;
+    // CHECK-NEXT: 1111
+    // CHECK-NEXT: 1111
+    // CHECK-NEXT: 6767
+    // CHECK-NEXT: 6767
+
+    // and finally, check that '?:' for a vector is non-short-circuiting
+    output[tid.x + 12U] = (thenBranchesV.x * 1000U) + (elseBranchesV.x * 2U);
+
+    // CHECK-NEXT: 1002
+    // CHECK-NEXT: 1002
+    // CHECK-NEXT: 1002
+    // CHECK-NEXT: 1002
+}


### PR DESCRIPTION
Clarify the short-circuiting/non-short-circuiting behavior of the ternary conditional operator:

- For a scalar condition, the behavior is short-circuiting.
- For a vector condition, the behavior is non-short-circuiting. This form is deprecated.

Add a test to verify the stated behavior.

In addition, improve the source formatting slightly of the _Logical Operators (scalar)_ table. This has no impact on the rendered output.

Fixes #10302