### PR TITLE
Fail example tests on compiler diagnostics

### DIFF
--- a/.github/workflows/ci-examples.sh
+++ b/.github/workflows/ci-examples.sh
@@ -130,6 +130,10 @@ summary=()
 failure_count=0
 skip_count=0
 sample_count=0
+# Keep the captured output in the invocation directory. The absolute path remains valid while
+# each example runs from bin_dir below.
+sample_output_file=$(mktemp "$PWD/ci-examples.XXXXXX")
+trap 'rm -f "$sample_output_file"' EXIT
 
 function skip {
   local p
@@ -151,9 +155,19 @@ function skip {
   return 1
 }
 
+# Return success when the output contains a rendered Slang warning or error. Match both the
+# current `warning[E41017]:` form and the legacy `warning 41017:` form so that testing older
+# compiler configurations cannot silently accept diagnostics.
+function contains_compiler_diagnostic {
+  local diagnostic_pattern
+  diagnostic_pattern='(^|[^[:alnum:]_])(warning|error)(\[E[[:digit:]]+\]|[[:space:]]+[[:digit:]]+):'
+  LC_ALL=C grep -Eq "$diagnostic_pattern" "$1"
+}
+
 function run_sample {
   local sample
   local args
+  local result
   sample="$1"
   shift
   args=("$@")
@@ -167,18 +181,23 @@ function run_sample {
   fi
   echo "Running '$sample ${args[*]}'..."
   result=0
+  : >"$sample_output_file"
   pushd "$bin_dir" 1>/dev/null 2>&1
   if [[ ! "$dry_run" = true ]]; then
-    ./"$sample" "${args[@]}" || result=$?
+    ./"$sample" "${args[@]}" >"$sample_output_file" 2>&1 || result=$?
     if [[ -f ./"log-$sample.txt" ]]; then
-      cat ./"log-$sample.txt"
+      cat ./"log-$sample.txt" >>"$sample_output_file"
     fi
   fi
-  if [[ $result -eq 0 ]]; then
-    summary=("${summary[@]}" "  success")
-  else
+  cat "$sample_output_file"
+  if [[ $result -ne 0 ]]; then
     summary=("${summary[@]}" "  failure (exit code: $result)")
     failure_count=$((failure_count + 1))
+  elif contains_compiler_diagnostic "$sample_output_file"; then
+    summary=("${summary[@]}" "  failure (compiler diagnostics found)")
+    failure_count=$((failure_count + 1))
+  else
+    summary=("${summary[@]}" "  success")
   fi
   popd 1>/dev/null 2>&1
 }


### PR DESCRIPTION
Fixes #11989

## Motivation

Example programs are expected to be clean reference code, but the CI example runner previously
treated an example as successful whenever its process returned zero. For example,
`cpu-com-example` could emit `warning[E41017]: use of uninitialized global variable` and still be
reported as successful. That allowed compiler warnings and other non-fatal diagnostics to remain
hidden in otherwise-green example runs.

## Proposed solution

Capture each example's combined standard output and standard error, append its existing Windows
crash log when present, and inspect the complete output before reporting success. A zero-exit
example now fails when it emits a rendered Slang warning or error, while nonzero exits retain their
existing failure reason.

The diagnostic check recognizes both the current `warning[E41017]:` format and the legacy
`warning 41017:` format. This keeps the runner effective when CI exercises older compiler
configurations without broadly treating arbitrary uses of the words "warning" or "error" as
compiler failures.

## Change summary

- `.github/workflows/ci-examples.sh:135` creates one capture file in the invocation directory and
  removes it when the runner exits.
- `contains_compiler_diagnostic` at `.github/workflows/ci-examples.sh:161` classifies current and
  legacy rendered Slang diagnostics.
- `run_sample` at `.github/workflows/ci-examples.sh:167` captures both process streams, includes
  `log-<sample>.txt`, preserves the captured output in the CI log, and fails successful processes
  that emitted compiler diagnostics.

## Concepts and vocabulary

- **Example log**: `log-<sample>.txt`, the file used by Windows GUI examples to record structured
  exception details and a stack trace. The example runner already printed this file when present.
- **Rendered diagnostic**: the textual warning or error produced by Slang, including its stable
  diagnostic code, such as `warning[E41017]:`.

## Process report

`run_sample` used to invoke the example directly and retain only `$?`. Its stdout and stderr were
visible in the job log but unavailable when the runner decided whether the sample had passed. The
runner now redirects both streams to `sample_output_file`, then prints that file so the observable
CI output is preserved.

The capture file is created under `$PWD`, rather than a system temporary directory, so the same
path works in Git Bash on Windows. It is stored as an absolute path because `run_sample` changes to
`bin_dir` before invoking each example. Reusing one file keeps the lifecycle simple; truncating it
before every run prevents output from one example from affecting the next, and the exit trap
removes it on both success and failure.

Windows GUI examples can write exception information to `log-<sample>.txt` instead of their
standard streams. The existing runner printed that log after the process exited, so it remains a
valid output source and is appended to the same capture before inspection.

Finally, `run_sample` checks the process result first. A nonzero process therefore continues to
report its exit code, regardless of its text output. Only a process that would otherwise be marked
successful is passed to `contains_compiler_diagnostic`. The two accepted diagnostic shapes are
intentional compiler output formats, not alternative compiler representations produced by a
broken phase, so the CI boundary is the correct layer to classify them.
