### PR TITLE
Avoid conflicting MSVC exception flags

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,16 +5,6 @@
 # PCH header for tools that use slang core types
 set(SLANG_TOOLS_PCH ${slang_SOURCE_DIR}/source/core/slang-basic.h)
 
-# CMake adds /EHsc to CMAKE_CXX_FLAGS for MSVC, but render-test needs /EHa so that it can catch
-# structured exceptions raised by graphics drivers. Select the exception mode per target to avoid
-# passing both options to cl, which diagnoses the intentional override with warning D9025.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    add_compile_options(
-        "$<$<NOT:$<BOOL:$<TARGET_PROPERTY:SLANG_MSVC_ENABLE_ASYNC_EXCEPTIONS>>>:/EHsc>"
-    )
-endif()
-
 add_custom_target(
     all-generators
     COMMENT "meta target which depends on all generators"
@@ -396,45 +386,7 @@ if(SLANG_ENABLE_TESTS AND SLANG_ENABLE_SLANG_RHI)
             ${CMAKE_CURRENT_SOURCE_DIR}/render-test/slang-test-device-cache.cpp
     )
 
-    slang_add_target(
-        render-test
-        MODULE
-        EXCLUDE_FROM_ALL
-        EXTRA_COMPILE_DEFINITIONS_PRIVATE SLANG_SHARED_LIBRARY_TOOL
-        USE_FEWER_WARNINGS
-        LINK_WITH_PRIVATE
-            core
-            compiler-core
-            slang
-            slang-rhi
-            platform
-            stb
-            $<$<BOOL:${SLANG_ENABLE_CUDA}>:CUDA::cuda_driver>
-        INCLUDE_FROM_PRIVATE slang-rhi
-        PRECOMPILE_HEADERS ${SLANG_TOOLS_PCH}
-        EXTRA_COMPILE_DEFINITIONS_PRIVATE
-            $<$<BOOL:${SLANG_ENABLE_CUDA}>:RENDER_TEST_CUDA>
-            $<$<BOOL:${SLANG_ENABLE_OPTIX}>:RENDER_TEST_OPTIX>
-        EXTRA_COMPILE_OPTIONS_PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/EHa>
-        OUTPUT_NAME render-test-tool
-        REQUIRED_BY slang-test
-        FOLDER test/tools
-    )
-    set_target_properties(
-        render-test
-        PROPERTIES SLANG_MSVC_ENABLE_ASYNC_EXCEPTIONS TRUE
-    )
-
-    if(SLANG_HAS_WEBGPU_SUPPORT AND CMAKE_SYSTEM_NAME MATCHES "Linux|Darwin")
-        # slang-rhi loads Dawn from the directory containing the module/executable that
-        # contains RHI. Put render-test beside the runtime sidecar libraries in WGPU builds.
-        set_target_properties(
-            render-test
-            PROPERTIES
-                LIBRARY_OUTPUT_DIRECTORY
-                    "${CMAKE_BINARY_DIR}/$<CONFIG>/${runtime_subdir}"
-        )
-    endif()
+    add_subdirectory(render-test)
 
     slang_add_target(
         slang-unit-test

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,6 +5,16 @@
 # PCH header for tools that use slang core types
 set(SLANG_TOOLS_PCH ${slang_SOURCE_DIR}/source/core/slang-basic.h)
 
+# CMake adds /EHsc to CMAKE_CXX_FLAGS for MSVC, but render-test needs /EHa so that it can catch
+# structured exceptions raised by graphics drivers. Select the exception mode per target to avoid
+# passing both options to cl, which diagnoses the intentional override with warning D9025.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    add_compile_options(
+        "$<$<NOT:$<BOOL:$<TARGET_PROPERTY:SLANG_MSVC_ENABLE_ASYNC_EXCEPTIONS>>>:/EHsc>"
+    )
+endif()
+
 add_custom_target(
     all-generators
     COMMENT "meta target which depends on all generators"
@@ -409,6 +419,10 @@ if(SLANG_ENABLE_TESTS AND SLANG_ENABLE_SLANG_RHI)
         OUTPUT_NAME render-test-tool
         REQUIRED_BY slang-test
         FOLDER test/tools
+    )
+    set_target_properties(
+        render-test
+        PROPERTIES SLANG_MSVC_ENABLE_ASYNC_EXCEPTIONS TRUE
     )
 
     if(SLANG_HAS_WEBGPU_SUPPORT AND CMAKE_SYSTEM_NAME MATCHES "Linux|Darwin")

--- a/tools/render-test/CMakeLists.txt
+++ b/tools/render-test/CMakeLists.txt
@@ -1,0 +1,43 @@
+# CMake adds /EHsc to CMAKE_CXX_FLAGS for MSVC, but render-test needs /EHa so that it can catch
+# structured exceptions raised by graphics drivers. Replace the option only in this directory so
+# that other targets retain their original exception flags.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+endif()
+
+slang_add_target(
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    MODULE
+    TARGET_NAME render-test
+    EXCLUDE_FROM_ALL
+    EXTRA_COMPILE_DEFINITIONS_PRIVATE SLANG_SHARED_LIBRARY_TOOL
+    USE_FEWER_WARNINGS
+    LINK_WITH_PRIVATE
+        core
+        compiler-core
+        slang
+        slang-rhi
+        platform
+        stb
+        $<$<BOOL:${SLANG_ENABLE_CUDA}>:CUDA::cuda_driver>
+    INCLUDE_FROM_PRIVATE slang-rhi
+    PRECOMPILE_HEADERS ${SLANG_TOOLS_PCH}
+    EXTRA_COMPILE_DEFINITIONS_PRIVATE
+        $<$<BOOL:${SLANG_ENABLE_CUDA}>:RENDER_TEST_CUDA>
+        $<$<BOOL:${SLANG_ENABLE_OPTIX}>:RENDER_TEST_OPTIX>
+    EXTRA_COMPILE_OPTIONS_PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/EHa>
+    OUTPUT_NAME render-test-tool
+    REQUIRED_BY slang-test
+    FOLDER test/tools
+)
+
+if(SLANG_HAS_WEBGPU_SUPPORT AND CMAKE_SYSTEM_NAME MATCHES "Linux|Darwin")
+    # slang-rhi loads Dawn from the directory containing the module/executable that contains RHI.
+    # Put render-test beside the runtime sidecar libraries in WGPU builds.
+    set_target_properties(
+        render-test
+        PROPERTIES
+            LIBRARY_OUTPUT_DIRECTORY
+                "${CMAKE_BINARY_DIR}/$<CONFIG>/${runtime_subdir}"
+    )
+endif()

--- a/tools/render-test/CMakeLists.txt
+++ b/tools/render-test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMake adds /EHsc to CMAKE_CXX_FLAGS for MSVC, but render-test needs /EHa so that it can catch
 # structured exceptions raised by graphics drivers. Replace the option only in this directory so
 # that other targets retain their original exception flags.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+if(MSVC)
     string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
@@ -10,7 +10,6 @@ slang_add_target(
     MODULE
     TARGET_NAME render-test
     EXCLUDE_FROM_ALL
-    EXTRA_COMPILE_DEFINITIONS_PRIVATE SLANG_SHARED_LIBRARY_TOOL
     USE_FEWER_WARNINGS
     LINK_WITH_PRIVATE
         core
@@ -23,9 +22,10 @@ slang_add_target(
     INCLUDE_FROM_PRIVATE slang-rhi
     PRECOMPILE_HEADERS ${SLANG_TOOLS_PCH}
     EXTRA_COMPILE_DEFINITIONS_PRIVATE
+        SLANG_SHARED_LIBRARY_TOOL
         $<$<BOOL:${SLANG_ENABLE_CUDA}>:RENDER_TEST_CUDA>
         $<$<BOOL:${SLANG_ENABLE_OPTIX}>:RENDER_TEST_OPTIX>
-    EXTRA_COMPILE_OPTIONS_PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/EHa>
+    EXTRA_COMPILE_OPTIONS_PRIVATE $<$<BOOL:${MSVC}>:/EHa>
     OUTPUT_NAME render-test-tool
     REQUIRED_BY slang-test
     FOLDER test/tools


### PR DESCRIPTION
## Motivation

When MSVC compiles `render-test`, CMake's default exception option and the target's explicit option
currently produce a command shaped like this:

```text
cl.exe ... /EHsc ... /EHa ... render-test/diagnostics.cpp
```

MSVC accepts the last option, but reports warning D9025 for every source file because `/EHa`
overrides the synchronous-exception behavior selected by `/EHsc`. The `/EHa` setting is intentional:
`render-test` uses its catch-all handler to recover from structured exceptions raised by graphics
drivers, so replacing it with `/EHsc` would remove existing fault handling.

## Proposed solution

Give `render-test` its own CMake directory scope. That scope removes an inherited `/EHsc`, when
present, and the target continues to add its required `/EHa` explicitly. No other target's flags are
rewritten, and a caller that omits `/EHsc` does not have it synthesized elsewhere.

## Change summary

- `tools/CMakeLists.txt:389` delegates construction of `render-test` to its source directory.
- `tools/render-test/CMakeLists.txt:1` removes an inherited `/EHsc` only within that directory and
  defines `render-test` with its existing explicit `/EHa` option.

## Concepts and vocabulary

- `/EHsc` enables synchronous C++ exception handling and assumes `extern "C"` functions do not
  throw C++ exceptions.
- `/EHa` additionally allows C++ catch handlers to catch Windows structured exceptions.

## Process report

The warning originates at CMake generation rather than in a C++ producer. CMake initializes
`CMAKE_CXX_FLAGS` with `/EHsc`, then `slang_add_target(render-test, ...)` appends the target's
required `/EHa`. That produces two valid but conflicting spellings in every `render-test` compile
command, and `cl` reports D9025 when it resolves them.

The new `tools/render-test` CMake directory inherits the caller's flags, removes `/EHsc` from its
local copy when present, and defines only the `render-test` target. The CMake `MSVC` abstraction
selects this behavior for both Microsoft's compiler and compatible drivers such as clang-cl. The
target retains its explicit `/EHa`, so its compile command contains one exception mode. The parent
`tools` directory and every other target keep the caller's flags unchanged. In particular, when a
caller configures with an empty `CMAKE_CXX_FLAGS`, the replacement is a no-op: `render-test`
receives `/EHa`, while ordinary targets receive no new `/EH*` option.

This target shape is intentional rather than malformed input: graphics-driver calls make structured
exceptions a valid condition for `render-test`, while applying `/EHa` to every Slang tool would
unnecessarily broaden exception semantics and affect optimization. The dedicated directory records
that ownership at the construction boundary, where CMake assembles the target's compile command,
without rewriting sibling targets. Suppressing D9025 would only hide the contradictory command line,
and removing `/EHa` would regress the catch-all behavior, so neither alternative preserves the
intended invariant that `render-test` receives exactly one exception model.

## Reviewer Directives (maintained by agent)

- [LLM CodeRabbit] Use CMake's `MSVC` abstraction for both the inherited-flag replacement and the
  target's `/EHa` option so clang-cl follows the same cl-compatible behavior.
  (https://github.com/shader-slang/slang/pull/12166#discussion_r3623746482)
