### PR TITLE
Clarify short-circuiting behavior related to `&&` and `||`

### DIFF
--- a/docs/language-reference/expressions-operators.md
+++ b/docs/language-reference/expressions-operators.md
@@ -112,6 +112,12 @@ Description:
 - The **bitwise right shift** operator shifts all bits in `lhs` right by `amount`.
   See [ILogical.shr](../../../core-module-reference/interfaces/ilogical-01/shr.html) for details.
 
+The `&&` and `||` operators short-circuit when their operands are scalars: the right-hand operand is evaluated
+only when it can affect the result. That is, in `lhs && rhs`, `rhs` is evaluated only when `lhs` is `true`. In
+`lhs || rhs`, `rhs` is evaluated only when `lhs` is `false`. When the operands are vectors, `&&` and `||` do
+not short-circuit and evaluate both operands element-wise. Short-circuiting can be disabled globally with the
+`-disable-short-circuit` compiler option.
+
 
 ### Comparison Operators (scalar)
 
@@ -345,6 +351,9 @@ vector or matrix element with the scalar operator.
 The matrix/matrix and matrix/vector multiplication are special, and they follow the matrix multiplication
 rules. See [Vector and Matrix Types](types-vector-and-matrix.md) for details.
 
+> 📝 **Remark:** The short-circuiting behavior of operators `&&`, `||`, and `?:` differs between scalar and
+> vector/matrix operands. See sections _Logical Operators (scalar)_ and _Ternary Conditional Operator_ for
+> details.
 
 ## Non-Overloadable Operators
 

--- a/docs/language-reference/expressions-operators.md
+++ b/docs/language-reference/expressions-operators.md
@@ -114,9 +114,9 @@ Description:
 
 The `&&` and `||` operators short-circuit when their operands are scalars: the right-hand operand is evaluated
 only when it can affect the result. That is, in `lhs && rhs`, `rhs` is evaluated only when `lhs` is `true`. In
-`lhs || rhs`, `rhs` is evaluated only when `lhs` is `false`. When the operands are vectors, `&&` and `||` do
-not short-circuit and evaluate both operands element-wise. Short-circuiting can be disabled globally with the
-`-disable-short-circuit` compiler option.
+`lhs || rhs`, `rhs` is evaluated only when `lhs` is `false`. When the operands are vectors or matrices, `&&`
+and `||` do not short-circuit and evaluate both operands element-wise. Short-circuiting can be disabled
+globally with the `-disable-short-circuit` compiler option.
 
 
 ### Comparison Operators (scalar)

--- a/docs/user-guide/02-conventional-features.md
+++ b/docs/user-guide/02-conventional-features.md
@@ -406,10 +406,21 @@ Slang supports the following expression forms with nearly identical syntax to HL
 * Operators: `-a`, `b + c`, `d++`, `e %= f`
 
 > #### Note ####
-> Like HLSL but unlike most other C-family languages, the `&&` and `||` operators do *not* currently perform "short-circuiting".
-> They evaluate all of their operands unconditionally.
-> However, the `?:` operator does perform short-circuiting if the condition is a scalar. Use of `?:` where the condition is a vector is deprecated in Slang. The vector version of `?:` operator does *not* perform short-circuiting, and the user is advised to call `select` instead.
-> The default behavior of these operators is likely to change in a future Slang release.
+>
+> Like most C-family languages, the `&&` and `||` operators perform "short-circuiting" evaluation when their
+> operands are scalars, and the `?:` operator does so when its condition is a scalar. For `&&` and `||`, the
+> right-hand operand is evaluated only when it can affect the result, and for `?:`, only one of the two
+> expressions on either side of `:` is evaluated. That is, in `a && b`, `b` is not evaluated when `a` is
+> `false`, and in `a || b`, `b` is not evaluated when `a` is `true`. In `a ? b : c`, `b` is evaluated when
+> `a` is `true`, and otherwise, `c` is evaluated.
+>
+> However, when the operands are vectors, `&&` and `||` *do not* short-circuit. Instead, they evaluate both
+> operands unconditionally and combine them element-wise. The vector version of `?:` operator *does not*
+> perform short-circuiting, either. Use of `?:` where the condition is a vector is deprecated in Slang, and
+> the user is advised to call `select` instead.
+>
+> Short-circuiting for `&&` and `||` can be disabled globally with the `-disable-short-circuit` compiler
+> option.
 
 Additional expression forms specific to shading languages follow.
 

--- a/docs/user-guide/02-conventional-features.md
+++ b/docs/user-guide/02-conventional-features.md
@@ -414,10 +414,10 @@ Slang supports the following expression forms with nearly identical syntax to HL
 > `false`, and in `a || b`, `b` is not evaluated when `a` is `true`. In `a ? b : c`, `b` is evaluated when
 > `a` is `true`, and otherwise, `c` is evaluated.
 >
-> However, when the operands are vectors, `&&` and `||` *do not* short-circuit. Instead, they evaluate both
-> operands unconditionally and combine them element-wise. The vector version of `?:` operator *does not*
-> perform short-circuiting, either. Use of `?:` where the condition is a vector is deprecated in Slang, and
-> the user is advised to call `select` instead.
+> However, when the operands are vectors or matrices, `&&` and `||` *do not* short-circuit. Instead, they
+> evaluate both operands unconditionally and combine them element-wise. The vector or matrix variant of the
+> `?:` operator *does not* perform short-circuiting, either. Use of `?:` where the condition is a vector or matrix
+> is deprecated in Slang, and the user is advised to call `select` instead.
 >
 > Short-circuiting for `&&` and `||` can be disabled globally with the `-disable-short-circuit` compiler
 > option.


### PR DESCRIPTION
The user guide was stating incorrectly that `&&` and `||` with scalar operands would not short circuit. This is actually no longer the case, and only the vector operand variants are non-short-circuiting. Update also the text related to `?:`.

Clarify also the behavior in the language reference manual.

This was found while investigating issue #10302