### PR TITLE
Capabilities: rename NVAPI atoms to nvapi* convention (deprecation aliases)

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1356,7 +1356,7 @@ A capability describes an optional feature that a target may or may not support.
 * `metallib_3_0` 
 * `metallib_3_1` 
 * `metallib_4_0` 
-* `hlsl_nvapi` 
+* `nvapi` 
 * `nvapiHitObjects` 
 * `hlsl_2018` 
 * `optix_coopvec` 
@@ -1475,6 +1475,7 @@ A capability describes an optional feature that a target may or may not support.
 * `spvShader64BitIndexingEXT` 
 * `ser_hlsl_native` 
 * `metallib_latest` 
+* `hlsl_nvapi` 
 * `dxil_lib` 
 * `any_target` 
 * `any_textual_target` 
@@ -1603,8 +1604,8 @@ A capability describes an optional feature that a target may or may not support.
 * `GL_NV_shader_texture_footprint` : enables the GL_NV_shader_texture_footprint extension 
 * `GL_NV_cluster_acceleration_structure` : enables the GL_NV_cluster_acceleration_structure extension 
 * `GL_NV_cooperative_vector` : enables the GL_NV_cooperative_vector extension 
-* `nvapi` 
 * `raytracing` 
+* `nvapiSer` 
 * `ser_nvapi` 
 * `ser_dxr` 
 * `ser` 
@@ -1759,6 +1760,7 @@ A capability describes an optional feature that a target may or may not support.
 * `METAL_4_0` 
 * `appendstructuredbuffer` 
 * `atomic_hlsl` 
+* `nvapiAtomic` 
 * `atomic_hlsl_nvapi` 
 * `atomic_hlsl_sm_6_6` 
 * `byteaddressbuffer` 

--- a/docs/user-guide/a4-02-reference-capability-atoms.md
+++ b/docs/user-guide/a4-02-reference-capability-atoms.md
@@ -219,7 +219,7 @@ Versions
 > Represent HLSL compatibility support.
 
 `hlsl_nvapi`
-> Represents HLSL NVAPI support.
+> Deprecated: use `nvapi`. Kept as an alias for source compatibility with `-capability hlsl_nvapi`.
 
 `metallib_2_3`
 > Represents MetalLib 2.3.
@@ -238,6 +238,9 @@ Versions
 
 `metallib_latest`
 > Represents the latest MetalLib version.
+
+`nvapi`
+> NVAPI support (HLSL). Canonical name for the NVAPI capability family (nvapi*).
 
 `sm_4_0`
 > HLSL shader model 4.0 and related capabilities of other targets.
@@ -1025,7 +1028,7 @@ Compound Capabilities
 > (hlsl only) Capabilities required to use hlsl atomic operations
 
 `atomic_hlsl_nvapi`
-> (hlsl only) Capabilities required to use hlsl NVAPI atomics
+> Deprecated: use `nvapiAtomic`.
 
 `atomic_hlsl_sm_6_6`
 > (hlsl only) Capabilities required to use hlsl sm_6_6 atomics
@@ -1320,8 +1323,11 @@ Compound Capabilities
 `nonuniformqualifier`
 > Capabilities required to use NonUniform qualifier
 
-`nvapi`
-> NVAPI capability for HLSL
+`nvapiAtomic`
+> (hlsl only) Capabilities required to use hlsl NVAPI atomics
+
+`nvapiSer`
+> Capabilities needed for shader-execution-reordering (NVAPI path for HLSL)
 
 `pack_vector`
 > Capabilities required to use pack/unpack intrinsics on packed vector data
@@ -1482,7 +1488,7 @@ Compound Capabilities
 > NVIDIA-specific SER for raygen, closesthit, miss stages (GLSL/SPIRV NV paths)
 
 `ser_nvapi`
-> Capabilities needed for shader-execution-reordering (NVAPI path for HLSL)
+> Deprecated: use `nvapiSer`.
 
 `ser_raygen`
 > Collection of capabilities for raytracing + shader execution reordering and the shader stage of raygen.

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -224,9 +224,13 @@ def _sm_6_8 : _sm_6_7;
 def _sm_6_9 : _sm_6_8;
 def _sm_6_10 : _sm_6_9;
 
-/// Represents HLSL NVAPI support.
+/// NVAPI support (HLSL). Canonical name for the NVAPI capability family (nvapi*).
 /// [Version]
-def hlsl_nvapi : hlsl;
+def nvapi : hlsl;
+
+/// Deprecated: use `nvapi`. Kept as an alias for source compatibility with `-capability hlsl_nvapi`.
+/// [Version]
+alias hlsl_nvapi = nvapi;
 
 /// Explicit opt-in to the NVAPI HitObject ABI for HLSL shader-execution-reordering. This is the
 /// vendor-specific selector for HitObject, kept deliberately distinct from the coarse hlsl_nvapi
@@ -238,7 +242,7 @@ def hlsl_nvapi : hlsl;
 /// method consult this one decision, so a HitObject never mixes the two ABIs, while
 /// "native-DXR HitObject + NVAPI atomics" stays a legal, non-mixing combination on SM 6.9.
 /// [EXT]
-def nvapiHitObjects : hlsl_nvapi;
+def nvapiHitObjects : nvapi;
 
 
 /// Represent HLSL compatibility support.
@@ -405,7 +409,7 @@ alias cuda_glsl_hlsl = cuda | glsl | hlsl;
 
 /// CUDA, GLSL, and NVAPI code-gen targets
 /// [Compound]
-alias cuda_glsl_nvapi = cuda | glsl | hlsl_nvapi;
+alias cuda_glsl_nvapi = cuda | glsl | nvapi;
 
 /// CUDA and GLSL code-gen targets.
 /// [Compound]
@@ -1354,16 +1358,16 @@ alias GL_NV_cooperative_vector = _GL_NV_cooperative_vector | spvCooperativeVecto
 
 // Define feature names not reliant on shader stages
 
-/// NVAPI capability for HLSL
-/// [Compound]
-alias nvapi = hlsl_nvapi;
 
 /// Capabilities needed for minimal raytracing support
 /// [Compound]
 alias raytracing = GL_EXT_ray_tracing | _sm_6_3 | cuda;
 /// Capabilities needed for shader-execution-reordering (NVAPI path for HLSL)
 /// [Compound]
-alias ser_nvapi = raytracing + hlsl_nvapi;
+alias nvapiSer = raytracing + nvapi;
+/// Deprecated: use `nvapiSer`.
+/// [Compound]
+alias ser_nvapi = nvapiSer;
 
 /// DXR 1.3 native SER support (SM 6.9, no NVAPI required)
 /// [EXT]
@@ -2307,7 +2311,10 @@ alias appendstructuredbuffer = sm_5_0_version;
 alias atomic_hlsl = _sm_4_0;
 /// (hlsl only) Capabilities required to use hlsl NVAPI atomics
 /// [Compound]
-alias atomic_hlsl_nvapi = _sm_4_0 + hlsl_nvapi;
+alias nvapiAtomic = _sm_4_0 + nvapi;
+/// Deprecated: use `nvapiAtomic`.
+/// [Compound]
+alias atomic_hlsl_nvapi = nvapiAtomic;
 /// (hlsl only) Capabilities required to use hlsl sm_6_6 atomics
 /// [Compound]
 alias atomic_hlsl_sm_6_6 = _sm_6_6;


### PR DESCRIPTION
Follow-up to #12089 (**stacked on `ser-abi-single-source`**; rebase to `master` once #12089 lands).

## Motivation
Per the @jkwak-work / @csyonghe discussion, NVAPI capability atoms should follow the `nvapiXxxYyy` convention (mirroring the `spv*` atoms) instead of the inconsistent `*_nvapi` snake_case. #12089 introduced `nvapiHitObjects` in that style; this unifies the pre-existing atoms.

## Proposed solution
Make the `nvapi*` spellings **canonical** and keep the old names as **deprecated aliases**, so nothing downstream breaks (`-capability hlsl_nvapi` still works):

| old | new (canonical) | alias kept |
|---|---|---|
| `hlsl_nvapi` | `nvapi` | `hlsl_nvapi = nvapi` |
| `ser_nvapi` | `nvapiSer` | `ser_nvapi = nvapiSer` |
| `atomic_hlsl_nvapi` | `nvapiAtomic` | `atomic_hlsl_nvapi = nvapiAtomic` |

## Change summary
- `slang-capabilities.capdef`: rename defs/aliases + add deprecation aliases; `nvapiHitObjects`/`cuda_glsl_nvapi` derive from `nvapi`.
- Regenerated `a4-02-reference-capability-atoms.md` and `command-line-slangc-reference.md`.

## Process report
No C++ `CapabilityName::` references `hlsl_nvapi`/`ser_nvapi`/`atomic_hlsl_nvapi` (only `nvapiHitObjects`/`_sm_6_9`), so this is capdef + docs only — zero enum risk. The ~38 existing `hlsl_nvapi` uses (atomics, shaderclock, texturefootprint, meta.slang cases) resolve through the alias. Verified: `-capability nvapi` and `-capability hlsl_nvapi` both compile; SER + ray-tracing + atomics suites 89/89.

**Open decision for @jkwak-work/@csyonghe:** base atom name `nvapi` (chosen, since it was already the umbrella alias) vs `nvapiHlsl`.