### PR TITLE
Add slang-test optimization option

### DIFF
--- a/tools/slang-test/README.md
+++ b/tools/slang-test/README.md
@@ -11,6 +11,7 @@ slang-test [options] [test-prefix...]
 If no test prefix is specified, all tests will be run. Test prefixes can be used to filter which tests to run, and include the path with directories separated by '/'.
 
 Example:
+
 ```bash
 slang-test -bindir path/to/bin -category full tests/compute/array-param
 ```
@@ -18,6 +19,7 @@ slang-test -bindir path/to/bin -category full tests/compute/array-param
 ## Command Line Options
 
 ### Core Options
+
 - `-h, --help`: Show help message
 - `-bindir <path>`: Set directory for binaries (default: the path to the slang-test executable)
 - `-test-dir <path>`: Set directory for test files (default: tests/)
@@ -26,10 +28,12 @@ slang-test -bindir path/to/bin -category full tests/compute/array-param
 - `-hide-ignored`: Hide results from ignored tests
 
 ### Test Selection and Categories
+
 - `-category <name>`: Only run tests in specified category
 - `-exclude <name>`: Exclude tests in specified category
 
 Available test categories:
+
 - `full`: All tests
 - `quick`: Quick tests
 - `smoke`: Basic smoke tests
@@ -41,14 +45,16 @@ Available test categories:
 A test may be in one or more categories. The categories are specified on top of a test, for example: //TEST(smoke,compute):COMPARE_COMPUTE:
 
 ### API Control Options
+
 - `-api <expr>`: Enable specific APIs (e.g., 'vk+dx12' or '+dx11')
 - `-api-only`: Only run tests that use specified APIs
 - `-synthesizedTestApi <expr>`: Set APIs for synthesized tests
 - `-skip-api-detection`: Skip API availability detection
 
 API expression syntax:
+
 - Use `+` or `-` to add or remove APIs from defaults
-- Examples: 
+- Examples:
   - `vk`: Vulkan only
   - `+vk`: Add Vulkan to defaults
   - `-dx12`: Remove DirectX 12 from defaults
@@ -57,18 +63,21 @@ API expression syntax:
   - `gl+dx11`: Only OpenGL and DirectX 11
 
 Available APIs:
+
 - OpenGL: `gl`, `ogl`, `opengl`
 - Vulkan: `vk`, `vulkan`
 - DirectX 12: `dx12`, `d3d12`
 - DirectX 11: `dx11`, `d3d11`
 
 ### Test Execution Options
+
 - `-server-count <n>`: Set number of test servers (default: 1)
 - `-use-shared-library`: Run tests in-process using shared library
 - `-use-test-server`: Run tests using test server
 - `-use-fully-isolated-test-server`: Run each test in isolated server
 
 ### Output Options
+
 - `-appveyor`: Use AppVeyor output format
 - `-travis`: Use Travis CI output format
 - `-teamcity`: Use TeamCity output format
@@ -77,6 +86,7 @@ Available APIs:
 - `-show-adapter-info`: Show detailed adapter information
 
 ### Other Options
+
 - `-generate-hlsl-baselines`: Generate HLSL test baselines
 - `-emit-spirv-via-glsl`: Emit SPIR-V through GLSL instead of directly
 - `-expected-failure-list <file>`: Specify file containing expected failures
@@ -90,6 +100,7 @@ Tests are identified by a special comment at the start of the test file: `//TEST
 To ignore a test, use `//DISABLE_TEST` instead of `//TEST`.
 
 Available test types:
+
 - `SIMPLE`: Runs the slangc compiler with specified options after the command
 - `REFLECTION`: Runs slang-reflection-test with the options specified after the command
 - `COMPARE_COMPUTE`: Runs render-test to execute a compute shader and writes the result to a text file. The test passes if the output matches the expected content
@@ -98,6 +109,7 @@ Available test types:
 - `LANG_SERVER`: Tests Language Server Protocol features by sending requests (like completion, hover, signatures) and comparing responses with expected outputs
 
 Deprecated test types (do not create new tests of these kinds, and we need to slowly migrate existing tests to use SIMPLE, COMPARE_COMPUTE(_EX) or COMPARE_RENDER_COMPUTE instead):
+
 - `COMPARE_HLSL`: Runs the slangc compiler with forced DXBC output and compares with a file having the '.expected' extension
 - `COMPARE_HLSL_RENDER`: Runs render-test to generate two images - one using HLSL (expected) and one using Slang, saving both as .png files. The test passes if the images match
 - `COMPARE_HLSL_CROSS_COMPILE_RENDER`: Runs render-test to generate two images - one using Slang and one using -glsl-cross. The test passes if the images match
@@ -111,6 +123,14 @@ Deprecated test types (do not create new tests of these kinds, and we need to sl
 `slang-test` adds `-O0` when it builds a Slang compiler command line and the
 test directive does not already specify an optimization option. This keeps
 ordinary test runs fast and avoids expected-output churn from optimizer changes.
+
+Pass `-OX`, where X is between 0 and 3, to `slang-test` to change that default for
+a selected test run. For example, this compiles tests that do not specify their own
+level with `-O2`:
+
+```text
+slang-test tests/render*/smo* -O2
+```
 
 Compiler-backed tests, such as `SIMPLE`, `CROSS_COMPILE`, and diagnostic tests,
 can opt in to optimized output with a normal slangc option:
@@ -146,6 +166,7 @@ without its required argument (intentionally in a diagnostic test, or by
 mistake) cannot consume the inserted default.
 
 ## Unit Tests
+
 In addition to the above test tools, there are also `slang-unit-test-tool` and `gfx-unit-test-tool`, which are invoked as in the following examples; but note that the unit tests do get run as part of `slang-test` as well.
 
 To ignore a unit test, use the `SLANG_IGNORE_TEST` macro:
@@ -163,15 +184,18 @@ SLANG_UNIT_TEST(foo)
 ```
 
 ### slang-unit-test-tool
+
 ```bash
 # Regular unit tests
 slang-test slang-unit-test-tool/<test-name>
 # e.g. run the `byteEncode` test.
 slang-test slang-unit-test-tool/byteEncode
 ```
+
 These tests are located in the [tools/slang-unit-test](https://github.com/shader-slang/slang/tree/master/tools/slang-unit-test) directory, and defined with macros like `SLANG_UNIT_TEST(byteEncode)`.
 
 ### gfx-unit-test-tool
+
 ```bash
 # Graphics unit tests
 slang-test gfx-unit-test-tool/<test-name>
@@ -179,4 +203,5 @@ slang-test gfx-unit-test-tool/<test-name>
 # e.g. run the `precompiledTargetModule2Vulkan` test.
 slang-test gfx-unit-test-tool/precompiledTargetModule2Vulkan
 ```
+
 These tests are located in [tools/gfx-unit-test](https://github.com/shader-slang/slang/tree/master/tools/gfx-unit-test), and likewise defined using macros like `SLANG_UNIT_TEST(precompiledTargetModule2Vulkan)`.

--- a/tools/slang-test/options.cpp
+++ b/tools/slang-test/options.cpp
@@ -3,6 +3,7 @@
 
 #include "../../source/core/slang-io.h"
 #include "../../source/core/slang-string-util.h"
+#include "slang-test-optimization-options.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -86,6 +87,8 @@ static bool _isSubCommand(const char* arg)
         "  -skip-api-detection            Skip API availability detection\n"
         "  -only-api-detection            Only run API detection and print results, then exit\n"
         "  -server-count <n>              Set number of test servers (default: 1)\n"
+        "  -OX                            Set the default slangc optimization level for tests,\n"
+        "                                 where X is between 0 and 3\n"
         "  -show-adapter-info             Show detailed adapter information\n"
         "  -generate-hlsl-baselines       Generate HLSL test baselines\n"
         "  -skip-reference-image-generation Skip generating reference images for render tests\n"
@@ -372,6 +375,10 @@ static bool _isSubCommand(const char* arg)
             {
                 optionsOut->serverCount = 1;
             }
+        }
+        else if (SlangTest::isSlangTestOptimizationArg(UnownedStringSlice(arg)))
+        {
+            optionsOut->defaultOptimizationLevel = arg;
         }
         else if (strcmp(arg, "-appveyor") == 0)
         {

--- a/tools/slang-test/options.h
+++ b/tools/slang-test/options.h
@@ -134,6 +134,10 @@ struct Options
     // Maximum number of test servers to run.
     int serverCount = 1;
 
+    // The slangc optimization-level argument injected for tests that do not specify their own
+    // optimization level. It can be set from "-O0" through "-O3" and defaults to "-O0".
+    Slang::String defaultOptimizationLevel = "-O0";
+
     bool emitSPIRVDirectly = true;
 
     // Whether to enable RHI device caching in render-test (default: true in slang-test)

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -2154,7 +2154,7 @@ TestResult runDocTest(TestContext* context, TestInput& input)
     }
 
     _initSlangCompiler(context, cmdLine);
-    SlangTest::addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine, context->options.defaultOptimizationLevel);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -2282,7 +2282,7 @@ TestResult runExecutableTest(TestContext* context, TestInput& input)
             cmdLine.addArg(arg);
         }
     }
-    SlangTest::addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine, context->options.defaultOptimizationLevel);
     ExecuteResult exeRes;
 
     // TODO(Yong) HACK:
@@ -2696,7 +2696,7 @@ TestResult runSimpleTest(TestContext* context, TestInput& input)
         return TestResult::Ignored;
     }
     // Keep compiler-based tests on the default optimization level unless a test opts out.
-    SlangTest::addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine, context->options.defaultOptimizationLevel);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -2759,7 +2759,7 @@ TestResult runSimpleLineTest(TestContext* context, TestInput& input)
     {
         cmdLine.addArg(arg);
     }
-    SlangTest::addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine, context->options.defaultOptimizationLevel);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -2918,7 +2918,7 @@ TestResult runCompile(TestContext* context, TestInput& input)
             cmdLine.addArg(arg);
         }
     }
-    SlangTest::addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine, context->options.defaultOptimizationLevel);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -2957,7 +2957,9 @@ TestResult runCompileTarget(TestContext* context, TestInput& input)
     }
 
     cmdLine.addArg("-compile-only");
-    SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+    SlangTest::addDefaultRenderTestSlangOptimization(
+        cmdLine,
+        context->options.defaultOptimizationLevel);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3033,7 +3035,7 @@ TestResult runReflectionTest(TestContext* context, TestInput& input)
     {
         cmdLine.addArg(arg);
     }
-    SlangTest::addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine, context->options.defaultOptimizationLevel);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3129,7 +3131,7 @@ static TestResult runCPPCompilerCompile(TestContext* context, TestInput& input)
     {
         cmdLine.addArg(arg);
     }
-    SlangTest::addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine, context->options.defaultOptimizationLevel);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3489,7 +3491,9 @@ static TestResult generateExpectedOutput(
     {
         expectedCmdLine.addArg(arg);
     }
-    SlangTest::addDefaultSlangOptimization(expectedCmdLine);
+    SlangTest::addDefaultSlangOptimization(
+        expectedCmdLine,
+        context->options.defaultOptimizationLevel);
 
     ExecuteResult expectedExeRes;
     TEST_RETURN_ON_DONE(
@@ -3536,7 +3540,9 @@ TestResult generateActualOutput(
     {
         actualCmdLine.addArg(arg);
     }
-    SlangTest::addDefaultSlangOptimization(actualCmdLine);
+    SlangTest::addDefaultSlangOptimization(
+        actualCmdLine,
+        context->options.defaultOptimizationLevel);
 
     ExecuteResult actualExeRes;
     TEST_RETURN_ON_DONE(
@@ -3654,7 +3660,7 @@ TestResult generateHLSLBaseline(
     cmdLine.addArg(targetFormat);
     cmdLine.addArg("-pass-through");
     cmdLine.addArg(passThroughName);
-    SlangTest::addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine, context->options.defaultOptimizationLevel);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3714,7 +3720,7 @@ static TestResult _runHLSLComparisonTest(
 
     cmdLine.addArg("-target");
     cmdLine.addArg(targetFormat);
-    SlangTest::addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine, context->options.defaultOptimizationLevel);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3802,7 +3808,7 @@ TestResult doGLSLComparisonTestRun(
     {
         cmdLine.addArg(arg);
     }
-    SlangTest::addDefaultSlangOptimization(cmdLine);
+    SlangTest::addDefaultSlangOptimization(cmdLine, context->options.defaultOptimizationLevel);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -3956,7 +3962,9 @@ TestResult runPerformanceProfile(TestContext* context, TestInput& input)
     {
         cmdLine.addArg(arg);
     }
-    SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+    SlangTest::addDefaultRenderTestSlangOptimization(
+        cmdLine,
+        context->options.defaultOptimizationLevel);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));
@@ -4127,7 +4135,9 @@ TestResult runComputeComparisonImpl(
     cmdLine.addArg("-o");
     auto actualOutputFile = outputStem + ".actual.txt";
     cmdLine.addArg(actualOutputFile);
-    SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+    SlangTest::addDefaultRenderTestSlangOptimization(
+        cmdLine,
+        context->options.defaultOptimizationLevel);
 
     if (context->isExecuting())
     {
@@ -4232,7 +4242,9 @@ TestResult doRenderComparisonTestRun(
     cmdLine.addArg(langOption);
     cmdLine.addArg("-o");
     cmdLine.addArg(outputStem + outputKind + ".png");
-    SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+    SlangTest::addDefaultRenderTestSlangOptimization(
+        cmdLine,
+        context->options.defaultOptimizationLevel);
 
     ExecuteResult exeRes;
     TEST_RETURN_ON_DONE(spawnAndWait(context, outputStem, input.spawnType, cmdLine, exeRes));

--- a/tools/slang-test/slang-test-optimization-options.h
+++ b/tools/slang-test/slang-test-optimization-options.h
@@ -43,6 +43,15 @@ inline bool isSlangOptimizationArg(const String& arg)
                ValueInt(-1)) != ValueInt(-1);
 }
 
+/// Returns true when an argument is a slang-test suite optimization-level option.
+///
+/// slang-test deliberately exposes only the numeric `-OX` spellings where X is from 0 to 3,
+/// while test directives may continue to use every optimization spelling accepted by slangc.
+inline bool isSlangTestOptimizationArg(const UnownedStringSlice& arg)
+{
+    return arg.getLength() == 3 && arg[0] == '-' && arg[1] == 'O' && arg[2] >= '0' && arg[2] <= '3';
+}
+
 /// Returns true when a compiler command line already specifies an optimization level.
 inline bool hasSlangOptimizationArg(const List<String>& args)
 {
@@ -59,15 +68,18 @@ inline bool hasSlangOptimizationArg(const List<String>& args)
 /// Most compiler-based tests do not need optimized output, and keeping them at `-O0` avoids
 /// optimizer time and SPIR-V optimizer output churn.
 ///
+/// `defaultLevel` controls the suite default. Test-provided optimization options still take
+/// precedence.
+///
 /// The default is inserted at the front of the argument list rather than appended, so it can
 /// never change the meaning of the test-provided arguments. For example, a diagnostic test may
 /// intentionally end with a dangling `-target` to provoke a missing-argument diagnostic; an
 /// appended `-O0` would be consumed as that option's argument and change the diagnostic.
-inline void addDefaultSlangOptimization(CommandLine& ioCmdLine)
+inline void addDefaultSlangOptimization(CommandLine& ioCmdLine, const String& defaultLevel)
 {
     if (!hasSlangOptimizationArg(ioCmdLine.m_args))
     {
-        ioCmdLine.m_args.insert(0, kTestOptimizationOption);
+        ioCmdLine.m_args.insert(0, defaultLevel);
     }
 }
 
@@ -120,20 +132,25 @@ inline bool hasRenderTestRenderApiArg(const List<String>& args, RenderApiType ap
 /// Metal render tests receive `-O1` instead of `-O0`; see
 /// `kMetalRenderTestOptimizationOption` for why.
 ///
+/// `defaultLevel` controls the suite default for non-Metal tests. Test-provided optimization
+/// options still take precedence.
+///
 /// Like `addDefaultSlangOptimization`, the default is inserted at the front of the argument
 /// list rather than appended, so a directive that accidentally leaves an option without its
 /// required parameter cannot consume the inserted default and change the command's meaning.
-inline void addDefaultRenderTestSlangOptimization(CommandLine& ioCmdLine)
+inline void addDefaultRenderTestSlangOptimization(
+    CommandLine& ioCmdLine,
+    const String& defaultLevel)
 {
     if (hasRenderTestSlangOptimizationArg(ioCmdLine.m_args))
         return;
 
     const bool isMetal = hasRenderTestRenderApiArg(ioCmdLine.m_args, RenderApiType::Metal);
+    const String optimizationOption =
+        isMetal ? String(kMetalRenderTestOptimizationOption) : defaultLevel;
 
     ioCmdLine.m_args.insert(0, "-Xslang");
-    ioCmdLine.m_args.insert(
-        1,
-        isMetal ? kMetalRenderTestOptimizationOption : kTestOptimizationOption);
+    ioCmdLine.m_args.insert(1, optimizationOption);
 }
 
 } // namespace SlangTest

--- a/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
+++ b/tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp
@@ -27,6 +27,16 @@ SLANG_UNIT_TEST(slangTestOptimizationArgDetection)
     SLANG_CHECK(!SlangTest::isSlangOptimizationArg(String("-Odump")));
     SLANG_CHECK(!SlangTest::isSlangOptimizationArg(String("-output")));
 
+    const char* testOptimizationArgs[] = {"-O0", "-O1", "-O2", "-O3"};
+    for (const auto arg : testOptimizationArgs)
+    {
+        SLANG_CHECK(SlangTest::isSlangTestOptimizationArg(UnownedStringSlice(arg)));
+    }
+
+    SLANG_CHECK(!SlangTest::isSlangTestOptimizationArg(UnownedStringSlice("-O")));
+    SLANG_CHECK(!SlangTest::isSlangTestOptimizationArg(UnownedStringSlice("-O4")));
+    SLANG_CHECK(!SlangTest::isSlangTestOptimizationArg(UnownedStringSlice("-Ohigh")));
+
     {
         List<String> args;
         args.add("-target");
@@ -131,7 +141,7 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
     {
         CommandLine cmdLine;
 
-        SlangTest::addDefaultSlangOptimization(cmdLine);
+        SlangTest::addDefaultSlangOptimization(cmdLine, String(SlangTest::kTestOptimizationOption));
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 1);
         SLANG_CHECK(cmdLine.m_args[0] == SlangTest::kTestOptimizationOption);
@@ -141,7 +151,7 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         CommandLine cmdLine;
         cmdLine.addArg("-O3");
 
-        SlangTest::addDefaultSlangOptimization(cmdLine);
+        SlangTest::addDefaultSlangOptimization(cmdLine, String(SlangTest::kTestOptimizationOption));
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 1);
         SLANG_CHECK(cmdLine.m_args[0] == "-O3");
@@ -156,7 +166,7 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         cmdLine.addArg("ps_4_0");
         cmdLine.addArg("-target");
 
-        SlangTest::addDefaultSlangOptimization(cmdLine);
+        SlangTest::addDefaultSlangOptimization(cmdLine, String(SlangTest::kTestOptimizationOption));
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 5);
         SLANG_CHECK(cmdLine.m_args[0] == SlangTest::kTestOptimizationOption);
@@ -167,7 +177,9 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         CommandLine cmdLine;
         cmdLine.addArg("-vk");
 
-        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+        SlangTest::addDefaultRenderTestSlangOptimization(
+            cmdLine,
+            String(SlangTest::kTestOptimizationOption));
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 3);
         SLANG_CHECK(cmdLine.m_args[0] == "-Xslang");
@@ -180,7 +192,9 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         cmdLine.addArg("-Xslang");
         cmdLine.addArg("-O3");
 
-        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+        SlangTest::addDefaultRenderTestSlangOptimization(
+            cmdLine,
+            String(SlangTest::kTestOptimizationOption));
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 2);
         SLANG_CHECK(cmdLine.m_args[0] == "-Xslang");
@@ -192,7 +206,9 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         cmdLine.addArg("-compile-arg");
         cmdLine.addArg("-O2");
 
-        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+        SlangTest::addDefaultRenderTestSlangOptimization(
+            cmdLine,
+            String(SlangTest::kTestOptimizationOption));
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 2);
         SLANG_CHECK(cmdLine.m_args[0] == "-compile-arg");
@@ -204,7 +220,9 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         cmdLine.addArg("-xslang");
         cmdLine.addArg("-Ohigh");
 
-        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+        SlangTest::addDefaultRenderTestSlangOptimization(
+            cmdLine,
+            String(SlangTest::kTestOptimizationOption));
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 2);
         SLANG_CHECK(cmdLine.m_args[0] == "-xslang");
@@ -219,7 +237,9 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         cmdLine.addArg("-O3");
         cmdLine.addArg("-X.");
 
-        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+        SlangTest::addDefaultRenderTestSlangOptimization(
+            cmdLine,
+            String(SlangTest::kTestOptimizationOption));
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 5);
         SLANG_CHECK(cmdLine.m_args[0] == "-Xslang...");
@@ -235,7 +255,9 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         CommandLine cmdLine;
         cmdLine.addArg("-mtl");
 
-        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+        SlangTest::addDefaultRenderTestSlangOptimization(
+            cmdLine,
+            String(SlangTest::kTestOptimizationOption));
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 3);
         SLANG_CHECK(cmdLine.m_args[0] == "-Xslang");
@@ -247,7 +269,9 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         CommandLine cmdLine;
         cmdLine.addArg("-metal");
 
-        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+        SlangTest::addDefaultRenderTestSlangOptimization(
+            cmdLine,
+            String(SlangTest::kTestOptimizationOption));
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 3);
         SLANG_CHECK(cmdLine.m_args[0] == "-Xslang");
@@ -262,7 +286,9 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         cmdLine.addArg("-Xslang");
         cmdLine.addArg("-O3");
 
-        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+        SlangTest::addDefaultRenderTestSlangOptimization(
+            cmdLine,
+            String(SlangTest::kTestOptimizationOption));
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 3);
         SLANG_CHECK(cmdLine.m_args[0] == "-mtl");
@@ -278,12 +304,64 @@ SLANG_UNIT_TEST(slangTestDefaultOptimizationInsertion)
         cmdLine.addArg("-vk");
         cmdLine.addArg("-xslang");
 
-        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine);
+        SlangTest::addDefaultRenderTestSlangOptimization(
+            cmdLine,
+            String(SlangTest::kTestOptimizationOption));
 
         SLANG_CHECK(cmdLine.m_args.getCount() == 4);
         SLANG_CHECK(cmdLine.m_args[0] == "-Xslang");
         SLANG_CHECK(cmdLine.m_args[1] == SlangTest::kTestOptimizationOption);
         SLANG_CHECK(cmdLine.m_args[2] == "-vk");
         SLANG_CHECK(cmdLine.m_args[3] == "-xslang");
+    }
+}
+
+SLANG_UNIT_TEST(slangTestDefaultOptimizationOverride)
+{
+    // A compiler test with no pinned level takes the command-line override.
+    {
+        CommandLine cmdLine;
+
+        SlangTest::addDefaultSlangOptimization(cmdLine, String("-O2"));
+
+        SLANG_CHECK(cmdLine.m_args.getCount() == 1);
+        SLANG_CHECK(cmdLine.m_args[0] == "-O2");
+    }
+
+    // An optimization level in the test directive remains the source of truth.
+    {
+        CommandLine cmdLine;
+        cmdLine.addArg("-O1");
+
+        SlangTest::addDefaultSlangOptimization(cmdLine, String("-O2"));
+
+        SLANG_CHECK(cmdLine.m_args.getCount() == 1);
+        SLANG_CHECK(cmdLine.m_args[0] == "-O1");
+    }
+
+    // Render-test must forward the override to slangc.
+    {
+        CommandLine cmdLine;
+        cmdLine.addArg("-vk");
+
+        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine, String("-O2"));
+
+        SLANG_CHECK(cmdLine.m_args.getCount() == 3);
+        SLANG_CHECK(cmdLine.m_args[0] == "-Xslang");
+        SLANG_CHECK(cmdLine.m_args[1] == "-O2");
+        SLANG_CHECK(cmdLine.m_args[2] == "-vk");
+    }
+
+    // Metal render tests keep the stable downstream-toolchain level.
+    {
+        CommandLine cmdLine;
+        cmdLine.addArg("-metal");
+
+        SlangTest::addDefaultRenderTestSlangOptimization(cmdLine, String("-O2"));
+
+        SLANG_CHECK(cmdLine.m_args.getCount() == 3);
+        SLANG_CHECK(cmdLine.m_args[0] == "-Xslang");
+        SLANG_CHECK(cmdLine.m_args[1] == SlangTest::kMetalRenderTestOptimizationOption);
+        SLANG_CHECK(cmdLine.m_args[2] == "-metal");
     }
 }


### PR DESCRIPTION
Fixes #11988

## Motivation

`slang-test` currently injects `-O0` into compiler invocations unless an individual test pins a different optimization level. That keeps the ordinary test suite fast, but it leaves no way to run a selected group or the full suite with optimization enabled from the command line.

Consider this command:

```text
slang-test.exe tests/render*/smo* -O2
```

The test runner previously rejected `-O2` as an unknown option. A nightly job therefore could not enable the optimized SPIR-V path suite-wide without editing individual `//TEST` directives.

## Proposed solution

Accept `-OX` on the `slang-test` command line, where X is from 0 through 3, and store the selected value as the suite's default compiler optimization level. Keep `-O0` as the default when the user does not specify the option.

Every compiler-backed command receives the selected level directly. Every render-test-backed command receives it through `-Xslang`, which is render-test's existing mechanism for forwarding an argument to slangc. An explicit optimization level in a test directive remains authoritative, and Metal render tests retain their existing `-O1` stability exception.

## Change summary

- `Options::defaultOptimizationLevel` in `tools/slang-test/options.h:139` stores the selected level and initializes it to `-O0`; `Options::parse` in `tools/slang-test/options.cpp:379` recognizes the four supported suite options.
- `isSlangTestOptimizationArg` in `tools/slang-test/slang-test-optimization-options.h:50` defines the exact `-O0` through `-O3` command-line contract. The existing broader slangc option recognition remains the source of truth for optimization levels written inside test directives.
- `addDefaultSlangOptimization` and `addDefaultRenderTestSlangOptimization` in `tools/slang-test/slang-test-optimization-options.h:78` and `:141` take the selected level explicitly. All command builders in `tools/slang-test/slang-test-main.cpp` pass `context->options.defaultOptimizationLevel`.
- `tools/slang-unit-test/unit-test-slang-test-optimization-options.cpp:8` covers acceptance of all four suite spellings and rejection of out-of-contract forms. The override coverage at `:319` verifies direct compiler and render-test forwarding, directive precedence, and the Metal exception.
- `tools/slang-test/README.md` documents `-OX` and the motivating command.

## Concepts and vocabulary

- A compiler-backed test invokes slangc directly, so its optimization level appears as `-OX` on that command line.
- A render-test-backed test invokes `render-test`, so the same setting must appear as `-Xslang -OX` to reach slangc.
- A suite default applies only when a test directive does not already specify an optimization level. This preserves tests whose expected output or runtime behavior depends on a particular level.

## Process report

The input starts in `Options::parse`. The accepted shape is intentionally narrow: exactly three characters, `-O` followed by a digit from 0 through 3. `isSlangTestOptimizationArg` validates that shape at the producer boundary, and `Options::defaultOptimizationLevel` then carries the complete slangc argument rather than introducing a second enum or mapping. The default field value is the complete `-O0` argument, so downstream helpers always receive a concrete level and do not need a fallback or default-valued parameter.

For a direct `SIMPLE` test, `runSimpleTest` builds the complete slangc command and then calls `addDefaultSlangOptimization`. That helper first checks the directive arguments with `hasSlangOptimizationArg`; if the test did not pin a level, it inserts the suite level at the front. Front insertion preserves the existing diagnostic-test invariant: a deliberately dangling final option such as `-target` cannot consume the injected value as its operand.

For a `COMPARE_COMPUTE` test, `runComputeComparisonImpl` builds a render-test command and then calls `addDefaultRenderTestSlangOptimization`. The helper checks all supported forwarding forms before inserting `-Xslang` and the suite level at the front. This is the canonical representation expected by render-test, so the change forwards compiler configuration instead of teaching render-test a second optimization option.

The only special input shape is a Metal render command. `hasRenderTestRenderApiArg` already identifies that shape, and the existing `-O1` exception remains at the same command-construction boundary because it protects the downstream Metal toolchain from known `-O0` instability. The new suite option does not move or duplicate that target-specific policy.
