### PR TITLE
Skip CI for nested Markdown changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             if echo "$files" | grep -Eqx 'docs/(command-line-slangc-reference.md|user-guide/a4-02-reference-capability-atoms.md)'; then
               echo "Generated reference document changed, running checks"
               shouldRun=true
-            elif echo "$files" | grep -qvE '^(docs/|LICENSES/|LICENSE$|\.claude/|[^/]+\.md$|\.coderabbit\.yaml$)'; then
+            elif echo "$files" | grep -qvE '^(docs/|LICENSES/|LICENSE$|\.claude/|.*\.md$|\.coderabbit\.yaml$)'; then
               shouldRun=true
             else
               echo "Only documentation files changed, skipping remaining steps"


### PR DESCRIPTION
## Motivation

PR #12178 changes only `external/README.md`, but the CI filter classified that path as a
non-documentation change and launched the full build and test matrix. The Markdown exception matched
only files at the repository root, so a document became CI-relevant solely because it lived in a
subdirectory.

## Proposed solution

Match Markdown files at any directory depth. This keeps the classification based on file type rather
than directory layout, while preserving the existing explicit exceptions for generated reference
documents and the rule that any mixed documentation/code change runs CI.

## Change summary

- `.github/workflows/ci.yml:39` broadens the Markdown path alternative from root-level files to paths
  ending in `.md` anywhere in the repository.

## Concepts and vocabulary

- **Generated reference documents** are the two Markdown outputs explicitly checked immediately
  before the general documentation filter. Changes to either still require CI because CI verifies
  that the checked-in output matches its generator.

## Process report

The `filter` job computes the PR's complete changed-file set with `git diff --name-only $BASE...HEAD`.
That producer already returns the correct shape: for PR #12178, it reports
`external/README.md`. The following `grep -qvE` classifier was the broken consumer because its
`[^/]+\.md$` alternative rejected every Markdown path containing a slash.

Changing that alternative to `.*\.md$` makes the valid nested-document shape classify the same way
as a root-level document. The preceding generated-reference check remains the source of truth for
Markdown files that require CI, and `grep -qvE` still returns success when even one changed path is
not documentation. The fix therefore corrects the path classification at its ownership boundary
without changing or reconstructing the diff input.
