### PR TITLE
Add public latest capability aliases

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1717,6 +1717,7 @@ A capability describes an optional feature that a target may or may not support.
 * `sm_6_9` 
 * `sm_6_10_version` 
 * `sm_6_10` 
+* `sm_latest` 
 * `DX_4_0` 
 * `DX_4_1` 
 * `DX_5_0` 
@@ -1743,6 +1744,7 @@ A capability describes an optional feature that a target may or may not support.
 * `GLSL_440` : enables the GLSL_440 extension 
 * `GLSL_450` : enables the GLSL_450 extension 
 * `GLSL_460` : enables the GLSL_460 extension 
+* `GLSL_latest` : enables the GLSL_latest extension 
 * `GLSL_410_SPIRV_1_0` : enables the GLSL_410_SPIRV_1_0 extension 
 * `GLSL_420_SPIRV_1_0` : enables the GLSL_420_SPIRV_1_0 extension 
 * `GLSL_430_SPIRV_1_0` : enables the GLSL_430_SPIRV_1_0 extension 

--- a/docs/user-guide/a4-02-reference-capability-atoms.md
+++ b/docs/user-guide/a4-02-reference-capability-atoms.md
@@ -155,6 +155,9 @@ Versions
 `GLSL_460`
 > GLSL 460 and related capabilities of other targets.
 
+`GLSL_latest`
+> Represents the latest GLSL version.
+
 `cuda_sm_1_0`
 > cuda 1.0 and related capabilities of other targets.
 
@@ -358,6 +361,9 @@ Versions
 `sm_6_9_version`
 > HLSL shader model 6.9 and related capabilities of other targets.
 > Does not include related GLSL/SPIRV extensions.
+
+`sm_latest`
+> Represents the latest HLSL shader model version.
 
 `spirv_1_0`
 > Represents SPIR-V 1.0 version.

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -1995,6 +1995,10 @@ alias sm_6_10 = sm_6_10_version
              | sm_6_9
              ;
 
+/// Represents the latest HLSL shader model version.
+/// [Version]
+alias sm_latest = _sm_6_10;
+
 // Profiles
 /// Use `sm_4_0` instead
 /// [Other]
@@ -2198,6 +2202,10 @@ alias GLSL_460 = _GLSL_460
                // previous
                | GLSL_450
                ;
+
+/// Represents the latest GLSL version.
+/// [Version]
+alias GLSL_latest = _GLSL_460;
 
 /// User should not use this capability
 /// [Other]


### PR DESCRIPTION
Fixes #12211

## Motivation

A clean Windows Release build currently stops while generating the capability definitions:

```text
error 20007: All internal '_atom' require a corresponding external 'atom' atom meant for user's use. Offending atom: _GLSL_latest
error 20007: All internal '_atom' require a corresponding external 'atom' atom meant for user's use. Offending atom: _sm_latest
```

The internal aliases were added as stable upper bounds for `getLatestGlslAtom()` and
`getLatestHlslAtom()`, but the capability definition file did not provide the corresponding public
aliases required by the generator.

## Proposed solution

Add `GLSL_latest` and `sm_latest` as documented public aliases for the same concrete version atoms
as their internal partners. This preserves the generator's internal/public pairing invariant at the
capability-definition source of truth, following the existing `spirv_latest` and `metallib_latest`
pattern without weakening validation or adding a generator special case.

## Change summary

- `source/slang/slang-capabilities.capdef:2000` defines `sm_latest` as the public partner of
  `_sm_latest`.
- `source/slang/slang-capabilities.capdef:2208` defines `GLSL_latest` as the public partner of
  `_GLSL_latest`.
- `docs/user-guide/a4-02-reference-capability-atoms.md:158` and
  `docs/user-guide/a4-02-reference-capability-atoms.md:365` contain the regenerated public
  capability reference entries.
- `docs/command-line-slangc-reference.md:1720` and
  `docs/command-line-slangc-reference.md:1747` list the aliases in the generated `slangc -help`
  capability reference.

## Concepts and vocabulary

- **Internal capability atom** — a target-specific capability whose name begins with `_`; the
  generator requires a public name without the leading underscore so diagnostics can suggest a
  capability users are allowed to request.
- **Latest-version alias** — a stable name that maps to the newest concrete version atom, allowing
  the concrete upper bound to move when a new language or shader-model version is added.

## Process report

Consider the HLSL definition `alias _sm_latest = _sm_6_10;`.
`CapabilityDefParser::parseDefs()` reads that alias from `slang-capabilities.capdef`, then
`validateInternalAtomExternalAtomPair()` groups internal and public definitions after stripping the
leading underscore. Before this change the `_sm_latest` group contained only one definition, so the
generator emitted error 20007 before it could produce the generated capability headers. The GLSL
alias followed the same path and failed for the same reason.

The input shape is intentional: `_sm_latest` and `_GLSL_latest` are canonical internal aliases used
by `getLatestHlslAtom()` and `getLatestGlslAtom()` as version-family upper bounds. Their producer was
incomplete because it supplied only the internal half of the required pair. Adding the matching
public aliases in the capability definition fixes that producer data directly. The generator keeps
enforcing the invariant, and the getters continue consuming the same internal aliases.

The public names map directly to `_sm_6_10` and `_GLSL_460`, matching their internal partners rather
than duplicating version-family logic. Their documentation comments are harvested by the same
generator into the capability reference, keeping the `.capdef` file as the single source of truth.
Because public capability aliases also appear in `slangc -help`, regenerating the command-line
reference adds the two corresponding list entries and keeps its checked-in output synchronized.
