### PR TITLE
Prevent replay directory collisions

### DIFF
--- a/source/slang-record-replay/replay-context.cpp
+++ b/source/slang-record-replay/replay-context.cpp
@@ -4,11 +4,13 @@
 #include "../core/slang-crypto.h"
 #include "../core/slang-io.h"
 #include "../core/slang-platform.h"
+#include "../core/slang-process.h"
 #include "../slang/slang-ast-type.h"
 #include "../slang/slang-compiler-api.h"
 #include "../slang/slang-syntax.h"
 #include "proxy/proxy-component-type.h"
 
+#include <atomic>
 #include <chrono>
 #include <cinttypes>
 #include <cstdio>
@@ -328,6 +330,8 @@ const char* ReplayContext::getCurrentReplayPath() const
 
 String ReplayContext::generateTimestampFolderName()
 {
+    static std::atomic<uint64_t> nextRecordingId = 0;
+
     // Get current time with milliseconds
     auto now = std::chrono::system_clock::now();
     auto time_t_now = std::chrono::system_clock::to_time_t(now);
@@ -340,19 +344,28 @@ String ReplayContext::generateTimestampFolderName()
     localtime_r(&time_t_now, &tm_now);
 #endif
 
-    // Format: YYYY-MM-DD_HH-MM-SS-mmm
-    char buffer[64];
+    // The timestamp keeps directory sorting chronological. The process ID prevents concurrent
+    // recorders from choosing the same directory, and the counter distinguishes recordings made
+    // by one process during the same millisecond.
+    //
+    // Consider two compiler processes that begin recording at 12:00:00.123. A timestamp-only
+    // name sends both processes to the same stream.bin. Including the process and recording IDs
+    // gives each recording its own directory while preserving the timestamp as the primary sort
+    // key used by findLatestReplayFolder().
+    char buffer[96];
     snprintf(
         buffer,
         sizeof(buffer),
-        "%04d-%02d-%02d_%02d-%02d-%02d-%03d",
+        "%04d-%02d-%02d_%02d-%02d-%02d-%03d-%010u-%020" PRIu64,
         tm_now.tm_year + 1900,
         tm_now.tm_mon + 1,
         tm_now.tm_mday,
         tm_now.tm_hour,
         tm_now.tm_min,
         tm_now.tm_sec,
-        static_cast<int>(ms.count()));
+        static_cast<int>(ms.count()),
+        static_cast<unsigned int>(Slang::Process::getId()),
+        nextRecordingId.fetch_add(1, std::memory_order_relaxed));
 
     return String(buffer);
 }
@@ -371,12 +384,35 @@ void ReplayContext::setupRecordingMirror()
     }
     else
     {
-        // Generate timestamped folder path
-        String timestamp = generateTimestampFolderName();
-        m_currentReplayPath = Path::combine(m_replayDirectory, timestamp);
+        // A prior playback can leave its folder in m_currentReplayPath. Clear it before trying to
+        // claim a recording directory so failed attempts cannot reuse the playback folder.
+        m_currentReplayPath = String();
+
+        if (!Path::createDirectoryRecursive(m_replayDirectory))
+        {
+            // If we can't create the base directory, just record without mirroring
+            return;
+        }
+
+        // Claim a new recording directory atomically. The process and recording IDs make a
+        // collision unlikely, while exclusive creation guarantees that an existing directory is
+        // never reused even after process-ID reuse or external directory creation.
+        constexpr int kMaxCreateAttempts = 100;
+        for (int attempt = 0; attempt < kMaxCreateAttempts; ++attempt)
+        {
+            String candidate = Path::combine(m_replayDirectory, generateTimestampFolderName());
+            if (Path::createDirectory(candidate))
+            {
+                m_currentReplayPath = candidate;
+                break;
+            }
+        }
+
+        if (m_currentReplayPath.getLength() == 0)
+            return;
     }
 
-    // Create the directory structure
+    // An explicit SLANG_RECORD_PATH may include parent directories that do not exist yet.
     if (!Path::createDirectoryRecursive(m_currentReplayPath))
     {
         // If we can't create the directory, just record without mirroring

--- a/source/slang-record-replay/replay-context.cpp
+++ b/source/slang-record-replay/replay-context.cpp
@@ -4,10 +4,10 @@
 #include "../core/slang-crypto.h"
 #include "../core/slang-io.h"
 #include "../core/slang-platform.h"
-#include "../core/slang-process.h"
 #include "../slang/slang-ast-type.h"
 #include "../slang/slang-compiler-api.h"
 #include "../slang/slang-syntax.h"
+#include "core/slang-process.h"
 #include "proxy/proxy-component-type.h"
 
 #include <atomic>
@@ -352,6 +352,8 @@ String ReplayContext::generateTimestampFolderName()
     // name sends both processes to the same stream.bin. Including the process and recording IDs
     // gives each recording its own directory while preserving the timestamp as the primary sort
     // key used by findLatestReplayFolder().
+    // The maximum formatted name is 55 characters plus the null terminator. The process ID is
+    // only a disambiguator; exclusive directory creation below remains the uniqueness guarantee.
     char buffer[96];
     snprintf(
         buffer,
@@ -379,8 +381,14 @@ void ReplayContext::setupRecordingMirror()
             envPath)) &&
         envPath.getLength() > 0)
     {
-        // Use the explicit path directly
+        // An explicit path may include parent directories that do not exist yet.
         m_currentReplayPath = envPath.toString();
+        if (!Path::createDirectoryRecursive(m_currentReplayPath))
+        {
+            // If we can't create the directory, just record without mirroring
+            m_currentReplayPath = String();
+            return;
+        }
     }
     else
     {
@@ -394,9 +402,11 @@ void ReplayContext::setupRecordingMirror()
             return;
         }
 
-        // Claim a new recording directory atomically. The process and recording IDs make a
-        // collision unlikely, while exclusive creation guarantees that an existing directory is
-        // never reused even after process-ID reuse or external directory creation.
+        // Claim a new recording directory atomically. The process and recording IDs should make
+        // the first candidate unique. Retrying handles preexisting directories left after
+        // process-ID reuse or created externally, while the bound avoids looping indefinitely
+        // when the filesystem refuses every create attempt. Exhaustion intentionally follows the
+        // existing mirror-error policy and records only in memory.
         constexpr int kMaxCreateAttempts = 100;
         for (int attempt = 0; attempt < kMaxCreateAttempts; ++attempt)
         {
@@ -410,14 +420,6 @@ void ReplayContext::setupRecordingMirror()
 
         if (m_currentReplayPath.getLength() == 0)
             return;
-    }
-
-    // An explicit SLANG_RECORD_PATH may include parent directories that do not exist yet.
-    if (!Path::createDirectoryRecursive(m_currentReplayPath))
-    {
-        // If we can't create the directory, just record without mirroring
-        m_currentReplayPath = String();
-        return;
     }
 
     // Set up mirror file for main stream

--- a/tools/slang-unit-test/unit-test-replay-common.h
+++ b/tools/slang-unit-test/unit-test-replay-common.h
@@ -6,6 +6,7 @@
 // Include cpp files directly to access internal symbols not exported from slang DLL
 #include "../../source/core/slang-file-system.h"
 #include "../../source/core/slang-io.h"
+#include "../../source/core/slang-process.h"
 #include "../../source/slang-record-replay/proxy/proxy-base.h"
 #include "../../source/slang-record-replay/proxy/proxy-global-session.h"
 #include "../../source/slang-record-replay/replay-context.h"
@@ -27,6 +28,40 @@ public:
     ScopedReplayContext() { ctx().reset(); }
 
     ~ScopedReplayContext() { ctx().reset(); }
+};
+
+/// Gives a filesystem replay test a directory that no other test-server process will use.
+///
+/// The test name separates replay tests within one process, while the process ID separates
+/// parallel test servers and independently launched slang-test processes. Cleanup resets the
+/// context first so that no mirror files remain open when the directory is removed.
+class ScopedReplayTestDirectory
+{
+public:
+    explicit ScopedReplayTestDirectory(const char* testName)
+    {
+        m_previousReplayDirectory = ctx().getReplayDirectory();
+
+        StringBuilder builder;
+        builder << ".slang-replays-test-" << testName << "-" << Process::getId();
+        m_path = builder.produceString();
+
+        Path::removeNonEmpty(m_path);
+        ctx().setReplayDirectory(m_path.getBuffer());
+    }
+
+    ~ScopedReplayTestDirectory()
+    {
+        ctx().reset();
+        Path::removeNonEmpty(m_path);
+        ctx().setReplayDirectory(m_previousReplayDirectory.getBuffer());
+    }
+
+    const String& getPath() const { return m_path; }
+
+private:
+    String m_path;
+    String m_previousReplayDirectory;
 };
 
 

--- a/tools/slang-unit-test/unit-test-replay-common.h
+++ b/tools/slang-unit-test/unit-test-replay-common.h
@@ -6,10 +6,10 @@
 // Include cpp files directly to access internal symbols not exported from slang DLL
 #include "../../source/core/slang-file-system.h"
 #include "../../source/core/slang-io.h"
-#include "../../source/core/slang-process.h"
 #include "../../source/slang-record-replay/proxy/proxy-base.h"
 #include "../../source/slang-record-replay/proxy/proxy-global-session.h"
 #include "../../source/slang-record-replay/replay-context.h"
+#include "core/slang-process.h"
 #include "unit-test/slang-unit-test.h"
 
 #include <cstring>

--- a/tools/slang-unit-test/unit-test-replay-filesystem.cpp
+++ b/tools/slang-unit-test/unit-test-replay-filesystem.cpp
@@ -21,10 +21,13 @@ SLANG_UNIT_TEST(replayFileSystemProxyLoadFile)
     ComPtr<MutableFileSystemProxy> fsProxy(new MutableFileSystemProxy(osFileSystem));
 
     // Define test file content and write it out (using non-recorded FS)
-    const char* testFileName = ".slang-test-temp-file.txt";
+    StringBuilder testFileNameBuilder;
+    testFileNameBuilder << ".slang-test-temp-file-" << Process::getId() << ".txt";
+    String testFileName = testFileNameBuilder.produceString();
     const char* testContent = "Hello from file system proxy test!\nLine 2\nLine 3";
     size_t testContentSize = strlen(testContent);
-    SlangResult writeResult = osFileSystem->saveFile(testFileName, testContent, testContentSize);
+    SlangResult writeResult =
+        osFileSystem->saveFile(testFileName.getBuffer(), testContent, testContentSize);
     SLANG_CHECK(SLANG_SUCCEEDED(writeResult));
 
     // Enable recording - this creates the replay directory
@@ -35,14 +38,14 @@ SLANG_UNIT_TEST(replayFileSystemProxyLoadFile)
 
     // Load the file through the proxy - this should capture its content
     ComPtr<ISlangBlob> blob;
-    SlangResult result = fsProxy->loadFile(testFileName, blob.writeRef());
+    SlangResult result = fsProxy->loadFile(testFileName.getBuffer(), blob.writeRef());
     SLANG_CHECK(SLANG_SUCCEEDED(result));
     SLANG_CHECK(blob != nullptr);
     SLANG_CHECK(blob->getBufferSize() == testContentSize);
     SLANG_CHECK(memcmp(blob->getBufferPointer(), testContent, testContentSize) == 0);
 
     // Delete the file (using non-recorded FS)
-    SlangResult removeResult = osFileSystem->remove(testFileName);
+    SlangResult removeResult = osFileSystem->remove(testFileName.getBuffer());
     SLANG_CHECK(SLANG_SUCCEEDED(removeResult));
 
     // Switch to playback - the file system proxy should serve from captured files
@@ -52,7 +55,7 @@ SLANG_UNIT_TEST(replayFileSystemProxyLoadFile)
 
     // Should be able to replay, even though the file is gone.
     ComPtr<ISlangBlob> replayedBlob;
-    SlangResult replayResult = fsProxy->loadFile(testFileName, replayedBlob.writeRef());
+    SlangResult replayResult = fsProxy->loadFile(testFileName.getBuffer(), replayedBlob.writeRef());
     SLANG_CHECK(SLANG_SUCCEEDED(replayResult));
     SLANG_CHECK(replayedBlob != nullptr);
     SLANG_CHECK(replayedBlob->getBufferSize() == testContentSize);

--- a/tools/slang-unit-test/unit-test-replay-filesystem.cpp
+++ b/tools/slang-unit-test/unit-test-replay-filesystem.cpp
@@ -14,8 +14,7 @@ SLANG_UNIT_TEST(replayFileSystemProxyLoadFile)
 {
     REPLAY_TEST;
 
-    // Use a unique test directory for this test's replays
-    ctx().setReplayDirectory(".slang-replays-fs-test");
+    ScopedReplayTestDirectory replayDirectory("file-system-proxy-load-file");
 
     // Create a file system proxy wrapping the OS file system
     auto osFileSystem = Slang::OSFileSystem::getMutableSingleton();
@@ -58,10 +57,6 @@ SLANG_UNIT_TEST(replayFileSystemProxyLoadFile)
     SLANG_CHECK(replayedBlob != nullptr);
     SLANG_CHECK(replayedBlob->getBufferSize() == testContentSize);
     SLANG_CHECK(memcmp(replayedBlob->getBufferPointer(), testContent, testContentSize) == 0);
-
-    // Clean up
-    ctx().reset();
-    ctx().setReplayDirectory(".slang-replays");
 }
 
 // =============================================================================

--- a/tools/slang-unit-test/unit-test-replay-integration.cpp
+++ b/tools/slang-unit-test/unit-test-replay-integration.cpp
@@ -307,6 +307,18 @@ SLANG_UNIT_TEST(replayContextLoadLatestReplay)
 
     SLANG_CHECK(readValue1 == 123);
     SLANG_CHECK(readValue2 == 3.14f);
+
+    // A failed transition back to recording must not retain the loaded playback path. Put a file
+    // where the new base directory needs a parent directory so mirror setup fails
+    // deterministically.
+    String playbackPath(ctx().getCurrentReplayPath());
+    String blockingFile = Path::combine(replayDirectory.getPath(), "recording-blocker");
+    SLANG_CHECK(SLANG_SUCCEEDED(File::writeAllBytes(blockingFile, "x", 1)));
+    String unavailableReplayDirectory = Path::combine(blockingFile, "child");
+    ctx().setReplayDirectory(unavailableReplayDirectory.getBuffer());
+    ctx().setMode(Mode::Record);
+    SLANG_CHECK(ctx().getCurrentReplayPath() == nullptr);
+    SLANG_CHECK(playbackPath.getLength() > 0);
 }
 
 SLANG_UNIT_TEST(replayContextFindLatestFolder)

--- a/tools/slang-unit-test/unit-test-replay-integration.cpp
+++ b/tools/slang-unit-test/unit-test-replay-integration.cpp
@@ -3,9 +3,6 @@
 
 #include "unit-test-replay-common.h"
 
-#include <chrono>
-#include <thread>
-
 // =============================================================================
 // Integration Test: Record actual API calls and verify exact bytes
 // =============================================================================
@@ -250,8 +247,7 @@ SLANG_UNIT_TEST(replayContextMirrorFileCreation)
     REPLAY_TEST;
     SLANG_UNUSED(unitTestContext);
 
-    // Use a unique test directory
-    ctx().setReplayDirectory(".slang-replays-test");
+    ScopedReplayTestDirectory replayDirectory("mirror-file-creation");
 
     // Enable recording - this should create the mirror file
     ctx().setMode(Mode::Record);
@@ -261,7 +257,7 @@ SLANG_UNIT_TEST(replayContextMirrorFileCreation)
     SLANG_CHECK(replayPath != nullptr);
 
     // The path should contain our test directory
-    SLANG_CHECK(strstr(replayPath, ".slang-replays-test") != nullptr);
+    SLANG_CHECK(strstr(replayPath, replayDirectory.getPath().getBuffer()) != nullptr);
 
     // Record some data
     int32_t value = 42;
@@ -272,9 +268,6 @@ SLANG_UNIT_TEST(replayContextMirrorFileCreation)
 
     // Current replay path should be nullptr now
     SLANG_CHECK(ctx().getCurrentReplayPath() == nullptr);
-
-    // Restore default directory
-    ctx().setReplayDirectory(".slang-replays");
 }
 
 SLANG_UNIT_TEST(replayContextLoadLatestReplay)
@@ -282,8 +275,7 @@ SLANG_UNIT_TEST(replayContextLoadLatestReplay)
     REPLAY_TEST;
     SLANG_UNUSED(unitTestContext);
 
-    // Use a unique test directory
-    ctx().setReplayDirectory(".slang-replays-test");
+    ScopedReplayTestDirectory replayDirectory("load-latest-replay");
 
     // Create a recording
     ctx().setMode(Mode::Record);
@@ -315,10 +307,6 @@ SLANG_UNIT_TEST(replayContextLoadLatestReplay)
 
     SLANG_CHECK(readValue1 == 123);
     SLANG_CHECK(readValue2 == 3.14f);
-
-    // Clean up - reset and restore default directory
-    ctx().reset();
-    ctx().setReplayDirectory(".slang-replays");
 }
 
 SLANG_UNIT_TEST(replayContextFindLatestFolder)
@@ -326,10 +314,9 @@ SLANG_UNIT_TEST(replayContextFindLatestFolder)
     REPLAY_TEST;
     SLANG_UNUSED(unitTestContext);
 
-    // Test that the timestamp sorting works correctly
-    // We'll create two recordings with a small delay between them
-
-    ctx().setReplayDirectory(".slang-replays-test");
+    // Test that recording names are unique and sort chronologically even when the clock does not
+    // advance between recordings.
+    ScopedReplayTestDirectory replayDirectory("find-latest-folder");
 
     // First recording
     ctx().setMode(Mode::Record);
@@ -337,9 +324,6 @@ SLANG_UNIT_TEST(replayContextFindLatestFolder)
     ctx().record(RecordFlag::None, val1);
     String firstPath(ctx().getCurrentReplayPath());
     ctx().disable();
-
-    // Small delay to ensure different timestamp
-    std::this_thread::sleep_for(std::chrono::milliseconds(5));
 
     // Second recording
     ctx().setMode(Mode::Record);
@@ -352,15 +336,11 @@ SLANG_UNIT_TEST(replayContextFindLatestFolder)
     SLANG_CHECK(firstPath != secondPath);
 
     // Find latest should return the second one's folder name
-    String latest = ReplayContext::findLatestReplayFolder(".slang-replays-test");
+    String latest = ReplayContext::findLatestReplayFolder(replayDirectory.getPath().getBuffer());
     SLANG_CHECK(latest.getLength() > 0);
 
     // The full second path should end with the latest folder name
     SLANG_CHECK(secondPath.endsWith(latest));
-
-    // Clean up
-    ctx().reset();
-    ctx().setReplayDirectory(".slang-replays");
 }
 
 SLANG_UNIT_TEST(replayContextRejectsInvalidBlobHash)
@@ -368,7 +348,8 @@ SLANG_UNIT_TEST(replayContextRejectsInvalidBlobHash)
     REPLAY_TEST;
     SLANG_UNUSED(unitTestContext);
 
-    const char* replayDirectory = ".slang-replays-security-test";
+    ScopedReplayTestDirectory scopedReplayDirectory("reject-invalid-blob-hash");
+    const char* replayDirectory = scopedReplayDirectory.getPath().getBuffer();
     const char* sensitiveFileName = "sensitive-blob.bin";
     const char* sensitiveContent = "content outside the replay blob store";
 
@@ -384,8 +365,6 @@ SLANG_UNIT_TEST(replayContextRejectsInvalidBlobHash)
         {"0123456789aBcDeFfedcba9876543210AbCdEf01", "mixed-case hash content"},
     };
 
-    Path::removeNonEmpty(String(replayDirectory));
-    ctx().setReplayDirectory(replayDirectory);
     ctx().setMode(Mode::Record);
 
     const char* replayPath = ctx().getCurrentReplayPath();
@@ -491,10 +470,6 @@ SLANG_UNIT_TEST(replayContextRejectsInvalidBlobHash)
     checkNextReplayBlobRejected(); // Empty hash.
     checkNextReplayBlobRejected(); // Windows-style traversal.
     SLANG_CHECK(ctx().getStream().atEnd());
-
-    ctx().reset();
-    Path::removeNonEmpty(String(replayDirectory));
-    ctx().setReplayDirectory(".slang-replays");
 }
 
 // =============================================================================


### PR DESCRIPTION
Fixes #12214.

## Motivation

When `slang-test` runs replay unit tests through multiple test-server processes, the processes
previously shared `.slang-replays-test`. For example, two
`replayContextFindLatestFolder` instances could create timestamp-only recording directories during
the same millisecond. One test could then observe the other process's directory as the latest
recording, causing `secondPath.endsWith(latest)` to fail. If the timestamps were identical, both
recorders could also open the same `stream.bin` and `index.bin`.

## Proposed solution

Give every recording session a name composed of its sortable timestamp, process ID, and a
process-local monotonic counter, then claim that directory with exclusive creation. The extra name
components make collisions unlikely, while exclusive creation is the final authority that prevents
an existing session directory from being reused.

Give filesystem replay tests a scoped directory derived from the test name and process ID, and
process-qualify temporary source files created outside that directory. This keeps each test-server
process from observing or deleting another process's fixtures and removes the timing delay that the
latest-folder test previously needed.

## Change summary

- Update `ReplayContext::generateTimestampFolderName` and
  `ReplayContext::setupRecordingMirror` to generate unique sortable names, clear stale playback
  state, and exclusively claim a recording directory.
- Add `ScopedReplayTestDirectory` to isolate replay filesystem tests and restore the caller's prior
  replay directory when the scope ends.
- Move the replay filesystem and integration tests to the scoped helper, process-qualify their
  external temporary file, verify chronological ordering without sleeping, and cover a failed
  playback-to-record transition.

## Concepts and vocabulary

- A **recording base directory** contains multiple replay sessions.
- A **recording session directory** is the uniquely claimed folder containing one recording's
  `stream.bin`, `index.bin`, and blob data.
- A **test server** is a worker process launched by `slang-test`; several workers can execute
  different unit tests concurrently.

## Process report

The failing shape is intentional: several independent processes may record concurrently beneath
the same base directory. `ReplayContext::setupRecordingMirror` produces the session directory, and
`ReplayContext::findLatestReplayFolder` consumes the lexically sortable names. A millisecond
timestamp was sufficient for ordering but was never a uniqueness guarantee. The producer now
retains the timestamp as the leading field, adds the process ID and monotonic recording ID, and
uses `Path::createDirectory` as an exclusive claim. This preserves the ordering contract for the
consumer without teaching it about parallel tests or adding a fallback around a malformed
recording.

A context can legitimately transition from playback to recording. Playback leaves its selected
folder in `m_currentReplayPath`, so `setupRecordingMirror` now clears that state before attempting
to claim a recording directory. Otherwise, a failed claim could accidentally reuse the prior
playback path. An explicit `SLANG_RECORD_PATH` remains valid input and continues through the
recursive-directory creation path. The regression test makes mirror setup fail deterministically
during a playback-to-record transition and verifies that the playback path is not retained.

The test failures also exposed a separate fixture-ownership problem. Multiple test-server
processes were intentionally valid inputs, but each test inspected a shared base directory as
though it owned it, and one filesystem test also created a shared source file in the working
directory. `ScopedReplayTestDirectory` makes replay-directory ownership explicit at fixture setup,
while the process-qualified source filename prevents one worker from deleting another worker's
input. The helper resets the context before deleting files and restores the previous replay
directory on teardown. The latest-folder test can therefore create consecutive recordings without
a sleep: the monotonic suffix distinguishes them, and lexical ordering still selects the second
recording.
