### PR TITLE
Allow dereferencing RaytracingAccelerationStructure pointers with SPIR-V

### DIFF
--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -19551,16 +19551,6 @@ struct RaytracingAccelerationStructure
     }
 };
 
-__generic<T, Access access, AddressSpace addrSpace, L:IBufferDataLayout>
-__glsl_extension(GL_EXT_ray_tracing)
-[require(spirv)]
-[ForceInline]
-__prefix Ref<T, access, addrSpace> operator*(Ptr<T, access, addrSpace, L> ptr)
-    where T == RaytracingAccelerationStructure
-{
-    return RaytracingAccelerationStructure(bit_cast<uint64_t>(ptr));
-}
-
 // 10.1.4 - Subobject Definitions
 
 // TODO: We may decide to support these, but their reliance on C++ implicit
@@ -20726,6 +20716,16 @@ uint64_t GetTransformListHandle(uint index)
     {
     case cuda: __intrinsic_asm "optixGetTransformListHandle";
     }
+}
+
+//@ hidden:
+__generic<T, Access access, AddressSpace addrSpace, L:IBufferDataLayout>
+[require(spirv)]
+[ForceInline]
+__prefix RaytracingAccelerationStructure operator*(Ptr<T, access, addrSpace, L> ptr)
+    where T == RaytracingAccelerationStructure
+{
+    return RaytracingAccelerationStructure(bit_cast<uint64_t>(ptr));
 }
 
 //

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -19551,6 +19551,16 @@ struct RaytracingAccelerationStructure
     }
 };
 
+__generic<T, Access access, AddressSpace addrSpace, L:IBufferDataLayout>
+__glsl_extension(GL_EXT_ray_tracing)
+[require(spirv)]
+[ForceInline]
+__prefix Ref<T, access, addrSpace> operator*(Ptr<T, access, addrSpace, L> ptr)
+    where T == RaytracingAccelerationStructure
+{
+    return RaytracingAccelerationStructure(bit_cast<uint64_t>(ptr));
+}
+
 // 10.1.4 - Subobject Definitions
 
 // TODO: We may decide to support these, but their reliance on C++ implicit

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -20718,7 +20718,7 @@ uint64_t GetTransformListHandle(uint index)
     }
 }
 
-//@ hidden:
+//@hidden:
 // This overload allows dereferencing an acceleration structure pointer, as the
 // machinery to do so is available in SPIR-V but does not operate through
 // OpLoad, which is what the regular dereferencing operator would eventually
@@ -20726,7 +20726,7 @@ uint64_t GetTransformListHandle(uint index)
 //
 // The overload is limited to SPIR-V only, because targets other than SPIR-V
 // and GLSL do not allow constructing RaytracingAccelerationStructures from
-// pointers and the GLSL lowering of a buffer device address to
+// pointers and the GLSL lowering of a buffer device address block containing a
 // RaytracingAccelerationStructure is not legal.
 __generic<T, Access access, AddressSpace addrSpace, L:IBufferDataLayout>
 [require(spirv)]
@@ -20734,8 +20734,10 @@ __generic<T, Access access, AddressSpace addrSpace, L:IBufferDataLayout>
 __prefix RaytracingAccelerationStructure operator*(Ptr<T, access, addrSpace, L> ptr)
     where T == RaytracingAccelerationStructure
 {
-    return RaytracingAccelerationStructure(bit_cast<uint64_t>(ptr));
+    return RaytracingAccelerationStructure(uint64_t(ptr));
 }
+
+//@public:
 
 //
 // Shader Model 6.4

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -20719,6 +20719,15 @@ uint64_t GetTransformListHandle(uint index)
 }
 
 //@ hidden:
+// This overload allows dereferencing an acceleration structure pointer, as the
+// machinery to do so is available in SPIR-V but does not operate through
+// OpLoad, which is what the regular dereferencing operator would eventually
+// lower to.
+//
+// The overload is limited to SPIR-V only, because targets other than SPIR-V
+// and GLSL do not allow constructing RaytracingAccelerationStructures from
+// pointers and the GLSL lowering of a buffer device address to
+// RaytracingAccelerationStructure is not legal.
 __generic<T, Access access, AddressSpace addrSpace, L:IBufferDataLayout>
 [require(spirv)]
 [ForceInline]

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -8718,27 +8718,6 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
     SpvInst* emitLoad(SpvInstParent* parent, IRInst* inst, IRInst* ptr)
     {
-        if (inst->getDataType()->getOp() == kIROp_RaytracingAccelerationStructureType)
-        {
-            // We can't load RaytracingAccelerationStructure with OpLoad, but
-            // SpvOpConvertUToAccelerationStructureKHR is equivalent.
-            requireSPIRVAnyCapability({SpvCapabilityRayTracingKHR, SpvCapabilityRayQueryKHR});
-            ensureAnyExtensionDeclaration(
-                {UnownedStringSlice("SPV_KHR_ray_tracing"), UnownedStringSlice("SPV_KHR_ray_query")});
-
-            IRBuilder builder(m_irModule);
-            builder.setInsertInto(m_irModule->getModuleInst());
-            auto addressType = builder.getUInt64Type();
-            auto address = emitOpBitcast(parent, nullptr, addressType, ptr);
-            return emitInst(
-                parent,
-                inst,
-                SpvOpConvertUToAccelerationStructureKHR,
-                inst->getDataType(),
-                kResultID,
-                address);
-        }
-
         requireVariableBufferCapabilityIfNeeded(inst->getDataType());
 
         IRBuilder builder(inst);

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -8718,6 +8718,27 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
     SpvInst* emitLoad(SpvInstParent* parent, IRInst* inst, IRInst* ptr)
     {
+        if (inst->getDataType()->getOp() == kIROp_RaytracingAccelerationStructureType)
+        {
+            // We can't load RaytracingAccelerationStructure with OpLoad, but
+            // SpvOpConvertUToAccelerationStructureKHR is equivalent.
+            requireSPIRVAnyCapability({SpvCapabilityRayTracingKHR, SpvCapabilityRayQueryKHR});
+            ensureAnyExtensionDeclaration(
+                {UnownedStringSlice("SPV_KHR_ray_tracing"), UnownedStringSlice("SPV_KHR_ray_query")});
+
+            IRBuilder builder(m_irModule);
+            builder.setInsertInto(m_irModule->getModuleInst());
+            auto addressType = builder.getUInt64Type();
+            auto address = emitOpBitcast(parent, nullptr, addressType, ptr);
+            return emitInst(
+                parent,
+                inst,
+                SpvOpConvertUToAccelerationStructureKHR,
+                inst->getDataType(),
+                kResultID,
+                address);
+        }
+
         requireVariableBufferCapabilityIfNeeded(inst->getDataType());
 
         IRBuilder builder(inst);

--- a/tests/spirv/acceleration-structure-pointer.slang
+++ b/tests/spirv/acceleration-structure-pointer.slang
@@ -1,5 +1,4 @@
 //TEST:SIMPLE(filecheck=CHECK): -target spirv
-//TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-via-glsl
 
 uniform RaytracingAccelerationStructure* accelStructAddr;
 RWStructuredBuffer<int> output;

--- a/tests/spirv/acceleration-structure-pointer.slang
+++ b/tests/spirv/acceleration-structure-pointer.slang
@@ -1,0 +1,23 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -emit-spirv-via-glsl
+
+uniform RaytracingAccelerationStructure* accelStructAddr;
+RWStructuredBuffer<int> output;
+
+// CHECK: %[[REG:[A-Za-z0-9_]+]] = OpConvertUToAccelerationStructureKHR
+// CHECK: OpRayQueryInitializeKHR %rayQuery{{.*}} %[[REG]]
+
+[numthreads(1,1,1)]
+void main()
+{
+    let accelStruct = *accelStructAddr;
+    RayQuery rayQuery;
+    RayDesc ray;
+    ray.Direction = float3(0, 0, 1);
+    ray.Origin = float3(0, 0, 0);
+    ray.TMax = 1000;
+    ray.TMin = 0;
+    let rs = rayQuery.TraceRayInline(accelStruct, 0, 0, ray);
+    output[0] = rayQuery.CandidateGeometryIndex();
+}
+

--- a/tests/spirv/acceleration-structure-pointer.slang
+++ b/tests/spirv/acceleration-structure-pointer.slang
@@ -16,7 +16,7 @@ void main()
     ray.Origin = float3(0, 0, 0);
     ray.TMax = 1000;
     ray.TMin = 0;
-    let rs = rayQuery.TraceRayInline(accelStruct, 0, 0, ray);
+    rayQuery.TraceRayInline(accelStruct, 0, 0, ray);
     output[0] = rayQuery.CandidateGeometryIndex();
 }
 

--- a/tests/spirv/acceleration-structure-pointer.slang
+++ b/tests/spirv/acceleration-structure-pointer.slang
@@ -3,7 +3,7 @@
 uniform RaytracingAccelerationStructure* accelStructAddr;
 RWStructuredBuffer<int> output;
 
-// CHECK: %[[REGA:[A-Za-z0-9_]+]] = OpBitcast
+// CHECK: %[[REGA:[A-Za-z0-9_]+]] = OpConvertPtrToU
 // CHECK: %[[REGB:[A-Za-z0-9_]+]] = OpConvertUToAccelerationStructureKHR{{.*}} %[[REGA]]
 // CHECK: OpRayQueryInitializeKHR %rayQuery{{.*}} %[[REGB]]
 

--- a/tests/spirv/acceleration-structure-pointer.slang
+++ b/tests/spirv/acceleration-structure-pointer.slang
@@ -3,8 +3,9 @@
 uniform RaytracingAccelerationStructure* accelStructAddr;
 RWStructuredBuffer<int> output;
 
-// CHECK: %[[REG:[A-Za-z0-9_]+]] = OpConvertUToAccelerationStructureKHR
-// CHECK: OpRayQueryInitializeKHR %rayQuery{{.*}} %[[REG]]
+// CHECK: %[[REGA:[A-Za-z0-9_]+]] = OpBitcast
+// CHECK: %[[REGB:[A-Za-z0-9_]+]] = OpConvertUToAccelerationStructureKHR{{.*}} %[[REGA]]
+// CHECK: OpRayQueryInitializeKHR %rayQuery{{.*}} %[[REGB]]
 
 [numthreads(1,1,1)]
 void main()


### PR DESCRIPTION
This PR allows dereferencing a `RaytracingAccelerationStructure*` in SPIR-V. This is pretty straightforward, as there is already a constructor for `RaytracingAccelerationStructure` that constructs an instance from a device address. This PR just aims to enable a nicer, more type-safe syntax to be used.

So now, instead of:
```slang
[shader("raygeneration")]
void my_rt_shader(uint64_t accelstruct_addr)
{
    let accel = RaytracingAccelerationStructure(accelstruct_addr);
    ...
}
```
One can do:
```slang
[shader("raygeneration")]
void my_rt_shader(RaytracingAccelerationStructure* accelstruct_addr)
{
    let accel = *accelstruct_addr;
    ...
}
```

This should be non-breaking, because this pattern produces invalid SPIR-V prior to this PR. This feature is limited to SPIR-V, because GLSL would need more hacks to not emit an `accelerationStructureEXT` in a BDA block and HLSL does not support constructing an acceleration structure from a pointer in the first place.

As to "why not just use `DescriptorHandle<RaytracingAccelerationStructure>` instead", there are a couple of roadblocks. Firstly, I prefer not using that construct at all, because it uses 8 bytes per texture / sampler handle where 4 bytes would suffice. Second, when `spvDescriptorHeapEXT` is enabled, `DescriptorHandle<RaytracingAccelerationStructure>` loads the acceleration structure from the descriptor heap instead of using a pointer directly, which is also not the behavior I want in my use case.