### PR TITLE
Exclude FIDDLE headers from GCC PCH

### DIFF
--- a/source/slang/CMakeLists.txt
+++ b/source/slang/CMakeLists.txt
@@ -262,7 +262,10 @@ set(slang_build_args
     generate_standard_module_config_header
     PRECOMPILE_HEADERS
     ${slang_SOURCE_DIR}/source/core/slang-basic.h
-    ${slang_SOURCE_DIR}/source/slang/slang-compiler.h
+    # slang-compiler.h transitively includes generated .fiddle headers whose macros are keyed on
+    # __LINE__. GCC can restore inconsistent FIDDLE macro state from its PCH even in a clean build,
+    # so keep those headers out of the GCC PCH. See #12227.
+    "$<$<NOT:$<CXX_COMPILER_ID:GNU>>:${slang_SOURCE_DIR}/source/slang/slang-compiler.h>"
 )
 set(slang_link_args
     LINK_WITH_PRIVATE


### PR DESCRIPTION
Fixes #12227

## Motivation

Consider the clean Linux GCC Release build reported in #12227. The SlangPy workflow generates the
FIDDLE outputs and then builds `slang-common-objects`, but compilation of
`slang-ir-autodiff-rev.cpp` and `slang-ir-autodiff-unzip.cpp` fails in
`slang-ir-insts.h.fiddle`: a generated `private` member and `friend` declaration are expanded at
namespace scope. All three clean workflow attempts failed with the same signature while consuming
`cmake_pch.hxx.gch`.

`slang-common-objects` currently builds its PCH from `slang-basic.h` and `slang-compiler.h`
(`source/slang/CMakeLists.txt`). The latter transitively includes generated `.fiddle` headers.
Those headers define `FIDDLE` through `FIDDLEX(__LINE__)` and generate line-number-specific macro
bodies. Carrying that transient macro state across GCC's PCH boundary allows a cleanly generated
PCH to restore inconsistent FIDDLE state in a later translation unit.

## Proposed solution

Keep `slang-basic.h` in the PCH on every compiler, but omit `slang-compiler.h` from the GCC PCH.
This keeps generated FIDDLE state out of GCC's PCH by construction, so each GCC translation unit
establishes the applicable FIDDLE macros through its normal includes. MSVC and Clang retain the
existing full PCH configuration because this failure has only been observed with GCC.

This fixes the boundary that admits the unsafe state instead of disabling PCH for the two
translation units that happened to expose it. It therefore also covers any other GCC translation
unit that includes FIDDLE-generated declarations.

## Change summary

- `source/slang/CMakeLists.txt`: make `slang-compiler.h` a non-GNU PCH entry while preserving
  `slang-basic.h` as the common PCH entry.

## Concepts and vocabulary

- **FIDDLE state**: the transient `FIDDLE`, `FIDDLEX`, and `FIDDLEY` definitions, plus generated
  `FIDDLE_<line>` macros, used to inject scraped declarations at source line numbers.
- **PCH boundary**: the set of headers and preprocessor state serialized while constructing a
  precompiled header and later restored into each translation unit.

## Process report

The exact problematic input is a GCC `cmake_pch.hxx.gch` constructed from `slang-compiler.h`.
Through the compiler headers, PCH construction processes generated `.fiddle` files and serializes
their `__LINE__`-keyed macro state. When an affected translation unit later processes
`slang-ir-insts.h`, the restored state can select a generated class-body payload at namespace
scope, producing the `private` and `friend` diagnostics from the clean CI builds.

That state is not a canonical or intentionally supported input for a translation unit: FIDDLE
macros describe the source file currently being processed and should not arrive from a different
preprocessing context. The PCH construction in `source/slang/CMakeLists.txt` is therefore the
producer-side boundary to fix. Keeping `slang-compiler.h` out of the GCC PCH prevents the invalid
shape instead of teaching individual consumers to tolerate it.

The generated Ninja graph already orders `slang-fiddle-output` before
`slang-common-objects`, and the failing clean workflow generated FIDDLE output before compiling
the PCH and object files. Adding another target dependency would duplicate that ordering without
preventing FIDDLE macro state from being serialized. Likewise, applying
`SKIP_PRECOMPILE_HEADERS` only to the two observed autodiff files would be an allowlist: another
FIDDLE-consuming translation unit could expose the same state later.

The remaining `slang-basic.h` PCH does not include Slang's generated FIDDLE headers, so GCC retains
the core-header compilation benefit without carrying the unsafe macro context. Other compilers
keep `slang-compiler.h` in their PCH, limiting the performance tradeoff to the compiler and
configuration where the failure occurs.
