### PR TITLE
Restrict slangd clang-format execution

### DIFF
--- a/source/slang/slang-language-server-auto-format.cpp
+++ b/source/slang/slang-language-server-auto-format.cpp
@@ -3,26 +3,57 @@
 #include "compiler-core/slang-lexer.h"
 #include "core/slang-char-util.h"
 #include "core/slang-file-system.h"
+#include "core/slang-platform.h"
 
 namespace Slang
 {
 
+static String _findClangFormatOnPath(UnownedStringSlice processName)
+{
+    StringBuilder pathValue;
+    if (SLANG_FAILED(PlatformUtil::getEnvironmentVariable(toSlice("PATH"), pathValue)))
+        return String();
+
+    List<UnownedStringSlice> directories;
+#if SLANG_WINDOWS_FAMILY
+    StringUtil::split(pathValue.getUnownedSlice(), ';', directories);
+#else
+    StringUtil::split(pathValue.getUnownedSlice(), ':', directories);
+#endif
+
+    for (auto directory : directories)
+    {
+        directory = directory.trim();
+        if (directory.startsWith("\"") && directory.endsWith("\""))
+            directory = directory.head(directory.getLength() - 1).tail(1);
+
+        // Relative and empty PATH entries resolve against the current directory, which can be the
+        // workspace opened by the user.
+        if (!Path::isAbsolute(directory))
+            continue;
+
+        String candidate = Path::combine(directory, processName);
+        SlangPathType pathType;
+        if (SLANG_FAILED(Path::getPathType(candidate, &pathType)) ||
+            pathType != SLANG_PATH_TYPE_FILE)
+        {
+            continue;
+        }
+
+        String canonicalCandidate;
+        if (SLANG_SUCCEEDED(Path::getCanonical(candidate, canonicalCandidate)))
+            return canonicalCandidate;
+    }
+    return String();
+}
+
 String findClangFormatTool()
 {
     String processName = String("clang-format") + String(Process::getExecutableSuffix());
-    if (File::exists(processName))
-        return processName;
-    RefPtr<Process> proc;
-    CommandLine cmdLine;
-    cmdLine.setExecutableLocation(ExecutableLocation(processName));
-    if (Process::create(cmdLine, 0, proc) == SLANG_OK)
-    {
-        auto inStream = proc->getStream(StdStreamType::In);
-        if (inStream)
-            inStream->close();
-        proc->kill(0);
-        return processName;
-    }
+    auto pathLocation = _findClangFormatOnPath(processName.getUnownedSlice());
+    if (pathLocation.getLength())
+        return pathLocation;
+
     auto fileName =
         Slang::SharedLibraryUtils::getSharedLibraryFileName((void*)slang_createGlobalSession);
     auto dirName = Slang::Path::getParentDirectory(fileName);
@@ -246,6 +277,9 @@ List<Edit> formatSource(
     List<Edit> edits;
 
     String clangProcessName = options.clangFormatLocation;
+    if (!isSafeClangFormatExecutablePath(clangProcessName.getUnownedSlice()))
+        return edits;
+
     CommandLine cmdLine;
     cmdLine.setExecutableLocation(ExecutableLocation(clangProcessName));
 

--- a/source/slang/slang-language-server-auto-format.h
+++ b/source/slang/slang-language-server-auto-format.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "core/slang-basic.h"
+#include "core/slang-io.h"
+#include "core/slang-process.h"
 #include "slang-workspace-version.h"
 #include "slang.h"
 
@@ -36,6 +38,33 @@ struct FormatOptions
     bool allowLineBreakInRangeFormatting = false;
     FormatBehavior behavior = FormatBehavior::Standard;
 };
+
+/// Returns whether `name` is the canonical clang-format executable name for this platform.
+inline bool isClangFormatExecutableName(UnownedStringSlice name)
+{
+    String expectedName = String("clang-format") + String(Process::getExecutableSuffix());
+#if SLANG_WINDOWS_FAMILY
+    return name.caseInsensitiveEquals(expectedName.getUnownedSlice());
+#else
+    return name == expectedName.getUnownedSlice();
+#endif
+}
+
+/// Returns whether an LSP configuration value can safely select clang-format through `PATH`.
+///
+/// Paths are intentionally rejected because workspace configuration is controlled by the opened
+/// project. Allowing a path here would let that project select its own executable.
+inline bool isSafeClangFormatLocation(UnownedStringSlice location)
+{
+    return !Path::hasPath(location) && isClangFormatExecutableName(location);
+}
+
+/// Returns whether a resolved path is safe to pass to process creation as clang-format.
+inline bool isSafeClangFormatExecutablePath(UnownedStringSlice path)
+{
+    return Path::isAbsolute(path) &&
+           isClangFormatExecutableName(Path::getFileName(path).getUnownedSlice());
+}
 
 String findClangFormatTool();
 

--- a/source/slang/slang-language-server.cpp
+++ b/source/slang/slang-language-server.cpp
@@ -2150,7 +2150,7 @@ LanguageServerResult<List<LanguageServerProtocol::TextEdit>> LanguageServerCore:
     }
     if (m_formatOptions.clangFormatLocation.getLength() == 0)
         m_formatOptions.clangFormatLocation = findClangFormatTool();
-    auto options = getFormatOptions(m_workspace, m_formatOptions);
+    auto options = m_formatOptions;
     options.fileName = canonicalPath;
     List<TextRange> exclusionRange =
         extractFormattingExclusionRanges(doc->getText().getUnownedSlice());
@@ -2195,7 +2195,7 @@ LanguageServerResult<List<LanguageServerProtocol::TextEdit>> LanguageServerCore:
     Index endOffset = doc->getOffset(endLine, endCol);
     if (m_formatOptions.clangFormatLocation.getLength() == 0)
         m_formatOptions.clangFormatLocation = findClangFormatTool();
-    auto options = getFormatOptions(m_workspace, m_formatOptions);
+    auto options = m_formatOptions;
     if (!m_formatOptions.allowLineBreakInRangeFormatting)
         options.behavior = FormatBehavior::PreserveLineBreak;
     List<TextRange> exclusionRange =
@@ -2246,7 +2246,7 @@ LanguageServerResult<List<LanguageServerProtocol::TextEdit>> LanguageServerCore:
     Index line, col;
     doc->zeroBasedUTF16LocToOneBasedUTF8Loc(args.position.line, args.position.character, line, col);
     auto cursorOffset = doc->getOffset(line, col);
-    auto options = getFormatOptions(m_workspace, m_formatOptions);
+    auto options = m_formatOptions;
     if (!m_formatOptions.allowLineBreakInOnTypeFormatting)
         options.behavior = FormatBehavior::PreserveLineBreak;
     List<TextRange> exclusionRange =
@@ -2410,7 +2410,18 @@ void LanguageServer::updateFormattingOptions(
     if (enableFormatOnType.isValid())
         converter.convert(enableFormatOnType, &m_core.m_formatOptions.enableFormatOnType);
     if (clangFormatLoc.isValid())
-        converter.convert(clangFormatLoc, &m_core.m_formatOptions.clangFormatLocation);
+    {
+        String clangFormatLocation;
+        if (SLANG_SUCCEEDED(converter.convert(clangFormatLoc, &clangFormatLocation)) &&
+            isSafeClangFormatLocation(clangFormatLocation.getUnownedSlice()))
+        {
+            m_core.m_formatOptions.clangFormatLocation = findClangFormatTool();
+        }
+        else
+        {
+            m_core.m_formatOptions.clangFormatLocation = String();
+        }
+    }
     if (clangFormatStyle.isValid())
         converter.convert(clangFormatStyle, &m_core.m_formatOptions.style);
     if (clangFormatFallbackStyle.isValid())
@@ -2586,19 +2597,6 @@ void LanguageServer::logMessage(int type, String message)
     args.type = type;
     args.message = message;
     m_connection->sendCall(LanguageServerProtocol::LogMessageParams::methodName, &args);
-}
-
-FormatOptions LanguageServerCore::getFormatOptions(Workspace* workspace, FormatOptions inOptions)
-{
-    FormatOptions result = inOptions;
-    if (workspace->rootDirectories.getCount())
-    {
-        result.clangFormatLocation = StringUtil::replaceAll(
-            result.clangFormatLocation.getUnownedSlice(),
-            toSlice("${workspaceFolder}"),
-            workspace->rootDirectories.getFirst().getUnownedSlice());
-    }
-    return result;
 }
 
 LanguageServerResult<LanguageServerProtocol::Hover> LanguageServerCore::tryGetMacroHoverInfo(

--- a/source/slang/slang-language-server.h
+++ b/source/slang/slang-language-server.h
@@ -156,7 +156,6 @@ public:
 private:
     slang::IGlobalSession* getOrCreateGlobalSession();
 
-    FormatOptions getFormatOptions(Workspace* workspace, FormatOptions inOptions);
     LanguageServerResult<LanguageServerProtocol::Hover> tryGetMacroHoverInfo(
         WorkspaceVersion* version,
         DocumentVersion* doc,

--- a/tools/slang-unit-test/unit-test-language-server-auto-format.cpp
+++ b/tools/slang-unit-test/unit-test-language-server-auto-format.cpp
@@ -1,0 +1,38 @@
+// unit-test-language-server-auto-format.cpp
+
+#include "slang/slang-language-server-auto-format.h"
+#include "unit-test/slang-unit-test.h"
+
+using namespace Slang;
+
+SLANG_UNIT_TEST(languageServerClangFormatLocation)
+{
+    String executableName = String("clang-format") + String(Process::getExecutableSuffix());
+
+    SLANG_CHECK(isClangFormatExecutableName(executableName.getUnownedSlice()));
+    SLANG_CHECK(isSafeClangFormatLocation(executableName.getUnownedSlice()));
+    SLANG_CHECK(!isSafeClangFormatExecutablePath(executableName.getUnownedSlice()));
+
+#if SLANG_WINDOWS_FAMILY
+    SLANG_CHECK(isClangFormatExecutableName(toSlice("ClAnG-FoRmAt.ExE")));
+    SLANG_CHECK(isSafeClangFormatLocation(toSlice("ClAnG-FoRmAt.ExE")));
+#else
+    SLANG_CHECK(!isClangFormatExecutableName(toSlice("ClAnG-FoRmAt")));
+    SLANG_CHECK(!isSafeClangFormatLocation(toSlice("ClAnG-FoRmAt")));
+#endif
+
+    SLANG_CHECK(!isSafeClangFormatLocation(toSlice("")));
+    SLANG_CHECK(!isSafeClangFormatLocation(toSlice("not-clang-format")));
+    SLANG_CHECK(!isSafeClangFormatLocation(toSlice("clang-format-malicious")));
+    SLANG_CHECK(!isSafeClangFormatLocation(
+        (String("${workspaceFolder}/") + executableName).getUnownedSlice()));
+    SLANG_CHECK(!isSafeClangFormatLocation(
+        (String("/workspace/tools/") + executableName).getUnownedSlice()));
+
+#if SLANG_WINDOWS_FAMILY
+    String absoluteLocation = String("C:/tools/") + executableName;
+#else
+    String absoluteLocation = String("/tools/") + executableName;
+#endif
+    SLANG_CHECK(isSafeClangFormatExecutablePath(absoluteLocation.getUnownedSlice()));
+}


### PR DESCRIPTION
## Motivation

Consider a workspace containing this configuration:

```json
{
  "slang.format.clangFormatLocation": "${workspaceFolder}/tools/clang-format.exe"
}
```

Before this change, `LanguageServer::updateFormattingOptions()` copied that value from the LSP
`workspace/configuration` response, `LanguageServerCore::getFormatOptions()` expanded
`${workspaceFolder}`, and `formatSource()` passed the resulting path directly to
`Process::create()`. A repository could therefore provide its own executable and cause slangd to
launch it when the user formatted a document.

Checking only that the filename starts with `clang-format` would not establish trust: the
workspace can name its payload `clang-format.exe`. On Windows, passing even the bare executable
name to process creation can search the current directory before `PATH`, so removing only the
workspace-variable expansion would also leave a workspace-controlled execution path.

## Proposed solution

Treat the configured value as an untrusted request to enable the standard clang-format tool, not
as an executable path. `updateFormattingOptions()` accepts only the canonical bare executable
name and resolves it through slangd's own `findClangFormatTool()` path. Discovery searches only
absolute `PATH` entries and known packaged locations, and `formatSource()` requires the resolved
location to be absolute with the exact platform filename before creating a process.

This keeps the trust decision at the configuration and executable-resolution boundaries. The
formatter itself does not need to infer whether a workspace-derived path is safe.

## Change summary

- `isSafeClangFormatLocation()` and `isSafeClangFormatExecutablePath()` in
  `source/slang/slang-language-server-auto-format.h:57` define the accepted configuration and
  resolved-executable shapes. Windows filename comparison follows Windows case-insensitive
  semantics.
- `_findClangFormatOnPath()` and `findClangFormatTool()` in
  `source/slang/slang-language-server-auto-format.cpp:11` resolve clang-format without executing a
  bare name or accepting relative `PATH` entries.
- `LanguageServer::updateFormattingOptions()` in
  `source/slang/slang-language-server.cpp:2400` no longer stores an LSP-provided path, and the
  `${workspaceFolder}` substitution path has been removed.
- `formatSource()` in `source/slang/slang-language-server-auto-format.cpp:269` validates the final
  absolute executable path immediately before constructing the command line.
- `tools/slang-unit-test/unit-test-language-server-auto-format.cpp` covers canonical names,
  platform case semantics, relative paths, workspace-variable paths, misleading filenames, and
  resolved absolute paths.

## Concepts and vocabulary

- **Configured location**: the untrusted string received through LSP workspace configuration.
- **Resolved executable path**: an absolute path selected by slangd from trusted process
  environment or packaged-tool locations.
- **Relative `PATH` entry**: an empty or relative search-directory entry whose meaning depends on
  the process current directory and can therefore resolve inside the opened workspace.

## Process report

The original producer-consumer chain stored two different kinds of values in
`FormatOptions::clangFormatLocation`: first an untrusted configuration string, then a
workspace-expanded executable path. `formatSource()` could not distinguish that value from one
produced by slangd's own tool discovery and treated both as ready for process creation.

The fix separates those roles at the producer. `updateFormattingOptions()` now accepts only
`clang-format` (or `clang-format.exe` on Windows) and asks `findClangFormatTool()` to produce the
actual location. A configured path is not a valid alternate spelling of the same semantic value:
it selects a different executable under workspace control, so canonicalizing or sanitizing that
path downstream would preserve the broken trust model.

`_findClangFormatOnPath()` replaces the earlier probe that launched a bare `clang-format` name.
It reads `PATH`, rejects empty and relative entries, checks for a regular file under each absolute
directory, and returns a canonical absolute path. Known binaries next to slangd or in the VS Code
C++ extension remain valid because those paths are constructed by slangd rather than supplied by
the workspace.

Finally, `formatSource()` checks the invariant immediately before `Process::create()`: the path
must be absolute and its basename must equal the platform's canonical clang-format name. This is
defense in depth for the process-launch boundary, not a repair for malformed configuration. The
configuration producer and discovery producer already construct the required shape, while the
asserted predicate prevents a future caller from reintroducing a bare or differently named
executable.

## Breaking change

1. Existing editor configurations that set `slang.format.clangFormatLocation` to a custom
   absolute or workspace-relative clang-format path will no longer launch that path.
2. Install `clang-format` in an absolute directory on the slangd process `PATH`, or use a
   clang-format binary packaged next to slangd or in the supported VS Code C++ extension
   location. The setting may be left empty or set to the canonical bare executable name.
