### PR TITLE
Allow case/default statements only in the switch body

### DIFF
--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -521,7 +521,7 @@ void SemanticsStmtVisitor::visitDefaultStmt(DefaultStmt* stmt)
     if (!switchStmt)
         return;
 
-    // We stash the ID of the target statement in the `case`
+    // We stash the ID of the target statement in the `default`
     // statement so that they can be correlated later, during
     // code generation.
     //

--- a/source/slang/slang-check-stmt.cpp
+++ b/source/slang/slang-check-stmt.cpp
@@ -413,12 +413,11 @@ void SemanticsStmtVisitor::visitSwitchStmt(SwitchStmt* stmt)
 
 void SemanticsStmtVisitor::visitCaseStmt(CaseStmt* stmt)
 {
-    auto switchStmt = FindOuterStmt<SwitchStmt>();
+    // A 'case' statement must be directly enclosed by a 'switch' statement. If
+    // this is not the case, the parser has already diagnosed an error.
+    SwitchStmt* switchStmt = m_outerStmts ? as<SwitchStmt>(m_outerStmts->stmt) : nullptr;
     if (!switchStmt)
-    {
-        getSink()->diagnose(Diagnostics::CaseOutsideSwitch{.stmt = stmt});
         return;
-    }
 
     // Check that the type for the `case` is consistent with the type for the `switch`.
     auto expr = CheckExpr(stmt->expr);
@@ -432,14 +431,11 @@ void SemanticsStmtVisitor::visitCaseStmt(CaseStmt* stmt)
     stmt->expr = expr;
     stmt->exprVal = exprVal;
 
-    if (switchStmt)
-    {
-        // We stash the ID of the target statement in the `case`
-        // statement so that they can be correlated later, during
-        // code generation.
-        //
-        stmt->targetOuterStmtID = switchStmt->uniqueID;
-    }
+    // We stash the ID of the target statement in the `case`
+    // statement so that they can be correlated later, during
+    // code generation.
+    //
+    stmt->targetOuterStmtID = switchStmt->uniqueID;
 }
 
 void SemanticsStmtVisitor::visitTargetSwitchStmt(TargetSwitchStmt* stmt)
@@ -518,19 +514,18 @@ void SemanticsStmtVisitor::visitIntrinsicAsmStmt(IntrinsicAsmStmt* stmt)
 
 void SemanticsStmtVisitor::visitDefaultStmt(DefaultStmt* stmt)
 {
-    auto switchStmt = FindOuterStmt<SwitchStmt>();
+    // A 'default' statement must be directly enclosed by a 'switch'
+    // statement. If this is not the case, the parser has already diagnosed an
+    // error.
+    SwitchStmt* switchStmt = m_outerStmts ? as<SwitchStmt>(m_outerStmts->stmt) : nullptr;
     if (!switchStmt)
-    {
-        getSink()->diagnose(Diagnostics::DefaultOutsideSwitch{.stmt = stmt});
-    }
-    else
-    {
-        // We stash the ID of the target statement in the `case`
-        // statement so that they can be correlated later, during
-        // code generation.
-        //
-        stmt->targetOuterStmtID = switchStmt->uniqueID;
-    }
+        return;
+
+    // We stash the ID of the target statement in the `case`
+    // statement so that they can be correlated later, during
+    // code generation.
+    //
+    stmt->targetOuterStmtID = switchStmt->uniqueID;
 }
 
 void SemanticsStmtVisitor::visitIfStmt(IfStmt* stmt)

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -4008,15 +4008,15 @@ standalone_note(
 err(
     "case-outside-switch",
     39999,
-    "'case' not allowed outside of a 'switch' statement",
-    span { loc = "stmt:Stmt", message = "'case' not allowed outside of a 'switch' statement" }
+    "'case' is not allowed outside a 'switch' body",
+    span { loc = "stmt:Stmt", message = "'case' is only allowed in a 'switch' body" }
 )
 
 err(
     "default-outside-switch",
     39999,
-    "'default' not allowed outside of a 'switch' statement",
-    span { loc = "stmt:Stmt", message = "'default' not allowed outside of a 'switch' statement" }
+    "'default' is not allowed outside a 'switch' body",
+    span { loc = "stmt:Stmt", message = "'default' is only allowed in a 'switch' body" }
 )
 
 err(

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -89,6 +89,12 @@ enum class ParsingStage
     Body,
 };
 
+enum class AllowCaseDefaultStatements : bool
+{
+    Disallow = false,
+    Allow = true,
+};
+
 struct ParserOptions
 {
     bool enableEffectAnnotations = false;
@@ -207,8 +213,11 @@ public:
     Decl* ParseStruct();
     ClassDecl* ParseClass();
     Decl* ParseGLSLInterfaceBlock();
-    Stmt* ParseStatement(Stmt* parentStmt = nullptr);
-    Stmt* parseBlockStatement();
+    Stmt* ParseStatement(
+        Stmt* parentStmt = nullptr,
+        AllowCaseDefaultStatements allowCaseDefault = AllowCaseDefaultStatements::Disallow);
+    Stmt* parseBlockStatement(
+        AllowCaseDefaultStatements allowCaseDefault = AllowCaseDefaultStatements::Disallow);
     Stmt* parseLabelStatement();
     DeclStmt* parseVarDeclrStatement(Modifiers modifiers);
     IfStmt* parseIfStatement();
@@ -6577,7 +6586,7 @@ static Stmt* ParseSwitchStmt(Parser* parser)
     parser->ReadToken(TokenType::LParent);
     stmt->condition = parser->ParseExpression();
     parser->ReadToken(TokenType::RParent);
-    stmt->body = parser->parseBlockStatement();
+    stmt->body = parser->parseBlockStatement(AllowCaseDefaultStatements::Allow);
     return stmt;
 }
 
@@ -6911,7 +6920,7 @@ Stmt* parseCompileTimeStmt(Parser* parser)
     }
 }
 
-Stmt* Parser::ParseStatement(Stmt* parentStmt)
+Stmt* Parser::ParseStatement(Stmt* parentStmt, AllowCaseDefaultStatements allowCaseDefault)
 {
     auto modifiers = ParseModifiers(this);
 
@@ -6957,9 +6966,19 @@ Stmt* Parser::ParseStatement(Stmt* parentStmt)
     else if (LookAheadToken("__intrinsic_asm"))
         statement = parseIntrinsicAsmStmt(this);
     else if (LookAheadToken("case"))
-        statement = ParseCaseStmt(this);
+    {
+        statement = ParseCaseStmt(this);    // should always return non-null
+        SLANG_RELEASE_ASSERT(statement);    // ... so we'll assert that it's the case
+        if (allowCaseDefault != AllowCaseDefaultStatements::Allow)
+            sink->diagnose(Diagnostics::CaseOutsideSwitch{.stmt = statement});
+    }
     else if (LookAheadToken("default"))
-        statement = ParseDefaultStmt(this);
+    {
+        statement = ParseDefaultStmt(this); // should always return non-null
+        SLANG_RELEASE_ASSERT(statement);    // ... so we'll assert that it's the case
+        if (allowCaseDefault != AllowCaseDefaultStatements::Allow)
+            sink->diagnose(Diagnostics::DefaultOutsideSwitch{.stmt = statement});
+    }
     else if (LookAheadToken("__GPU_FOREACH"))
         statement = ParseGpuForeachStmt(this);
     else if (LookAheadToken(TokenType::Dollar))
@@ -7127,7 +7146,7 @@ bool lookAheadTokenAfterModifiers(Parser* parser, const char* token)
     return false;
 }
 
-Stmt* Parser::parseBlockStatement()
+Stmt* Parser::parseBlockStatement(AllowCaseDefaultStatements allowCaseDefault)
 {
     if (!beginMatch(this, MatchedTokenType::CurlyBraces))
     {
@@ -7202,7 +7221,7 @@ Stmt* Parser::parseBlockStatement()
             continue;
         }
 
-        auto stmt = ParseStatement();
+        auto stmt = ParseStatement(nullptr, allowCaseDefault);
 
         if (stmt)
             addStmt(stmt);

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -6967,8 +6967,8 @@ Stmt* Parser::ParseStatement(Stmt* parentStmt, AllowCaseDefaultStatements allowC
         statement = parseIntrinsicAsmStmt(this);
     else if (LookAheadToken("case"))
     {
-        statement = ParseCaseStmt(this);    // should always return non-null
-        SLANG_RELEASE_ASSERT(statement);    // ... so we'll assert that it's the case
+        statement = ParseCaseStmt(this); // should always return non-null
+        SLANG_RELEASE_ASSERT(statement); // ... so we'll assert that it's the case
         if (allowCaseDefault != AllowCaseDefaultStatements::Allow)
             sink->diagnose(Diagnostics::CaseOutsideSwitch{.stmt = statement});
     }

--- a/tests/diagnostics/bad-case-placement.slang
+++ b/tests/diagnostics/bad-case-placement.slang
@@ -1,11 +1,32 @@
+// Various bad case/default statement placements
+//
+// While the parser allows only switch body placements, the various
+// tests here intend to catch potential ICEs related to bad placement.
+
 //DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):
 
 RWStructuredBuffer<int> output;
 
-[numthreads(1, 1, 1)]
-void computeMain(uint3 tid: SV_DispatchThreadID)
+void caseWithoutSwitch()
 {
-    switch (int(tid.x))
+    case 0:
+/*CHECK:
+    ^^^^ 'case' is not allowed outside a 'switch' body
+    ^^^^ 'case' is only allowed in a 'switch' body
+*/
+
+    default:
+/*CHECK:
+    ^^^^^^^ 'default' is not allowed outside a 'switch' body
+    ^^^^^^^ 'default' is only allowed in a 'switch' body
+*/
+
+    return;
+}
+
+void caseInNestedBlock(uint i)
+{
+    switch (i)
     {
     case 0:
 
@@ -20,6 +41,98 @@ void computeMain(uint3 tid: SV_DispatchThreadID)
             output[0] = 1;
         }
         break;
-
     }
+}
+
+void caseInIf(uint i)
+{
+    switch (i)
+    {
+    case 1:
+        if (i > 0U)
+        {
+        case 0U:
+//CHECK:^^^^ 'case' is not allowed outside a 'switch' body
+//CHECK:^^^^ 'case' is only allowed in a 'switch' body
+           break;
+
+        default:
+//CHECK:^^^^^^^ 'default' is not allowed outside a 'switch' body
+//CHECK:^^^^^^^ 'default' is only allowed in a 'switch' body
+
+        }
+    }
+}
+
+void caseInFor(uint i)
+{
+    uint j = 0U;
+    switch (i)
+    {
+    case 1:
+        for (j = 0; j < 10; ++j)
+        {
+        case 0U:
+//CHECK:^^^^ 'case' is not allowed outside a 'switch' body
+//CHECK:^^^^ 'case' is only allowed in a 'switch' body
+            break;
+
+        default:
+//CHECK:^^^^^^^ 'default' is not allowed outside a 'switch' body
+//CHECK:^^^^^^^ 'default' is only allowed in a 'switch' body
+
+        }
+    }
+}
+
+void caseInWhile(uint i)
+{
+    switch (i)
+    {
+    case 1:
+        while (true)
+        {
+        case 0U:
+//CHECK:^^^^ 'case' is not allowed outside a 'switch' body
+//CHECK:^^^^ 'case' is only allowed in a 'switch' body
+
+        default:
+//CHECK:^^^^^^^ 'default' is not allowed outside a 'switch' body
+//CHECK:^^^^^^^ 'default' is only allowed in a 'switch' body
+
+            break;
+        }
+    }
+}
+
+void caseInDoWhile(uint i)
+{
+    switch (i)
+    {
+    case 1:
+        do
+        {
+        case 0U:
+//CHECK:^^^^ 'case' is not allowed outside a 'switch' body
+//CHECK:^^^^ 'case' is only allowed in a 'switch' body
+
+        default:
+//CHECK:^^^^^^^ 'default' is not allowed outside a 'switch' body
+//CHECK:^^^^^^^ 'default' is only allowed in a 'switch' body
+
+            break;
+        }
+        while (true);
+    }
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid: SV_DispatchThreadID)
+{
+    caseWithoutSwitch();
+    caseInNestedBlock(tid.x);
+    caseInIf(tid.x);
+    caseInFor(tid.x);
+    caseInWhile(tid.x);
+    caseInDoWhile(tid.x);
 }

--- a/tests/diagnostics/bad-case-placement.slang
+++ b/tests/diagnostics/bad-case-placement.slang
@@ -1,0 +1,25 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):
+
+RWStructuredBuffer<int> output;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid: SV_DispatchThreadID)
+{
+    switch (int(tid.x))
+    {
+    case 0:
+
+        {
+        case 1:
+//CHECK:^^^^ 'case' is not allowed outside a 'switch' body
+//CHECK:^^^^ 'case' is only allowed in a 'switch' body
+
+        default:
+//CHECK:^^^^^^^ 'default' is not allowed outside a 'switch' body
+//CHECK:^^^^^^^ 'default' is only allowed in a 'switch' body
+            output[0] = 1;
+        }
+        break;
+
+    }
+}

--- a/tests/diagnostics/bad-case-placement.slang
+++ b/tests/diagnostics/bad-case-placement.slang
@@ -54,7 +54,7 @@ void caseInIf(uint i)
         case 0U:
 //CHECK:^^^^ 'case' is not allowed outside a 'switch' body
 //CHECK:^^^^ 'case' is only allowed in a 'switch' body
-           break;
+            break;
 
         default:
 //CHECK:^^^^^^^ 'default' is not allowed outside a 'switch' body


### PR DESCRIPTION
Move case/default statement location check to the parser. Since case/default statements need to be directly in the switch body (and not in a nested block), we can enforce this easily in the parser.

Add a simple diagnostic test to verify that case and default statements are rejected if not in a switch body.

Simplify SemanticsStmtVisitor::visitCaseStmt() and SemanticsStmtVisitor::visitDefaultStmt() a bit.

**Breaking change note:**

Case statements are now only allowed in the switch body. In particular, they are not allowed in nested blocks.

Fixes #12239