### PR TITLE
Add CPU RayQuery support

### DIFF
--- a/prelude/slang-cpp-ray-query.h
+++ b/prelude/slang-cpp-ray-query.h
@@ -67,6 +67,7 @@ struct RayQueryHit
     float barycentrics[2];
     float objectRayOrigin[3];
     float objectRayDirection[3];
+    // Transforms use the DXR instance layout: three row-major rows of four packed floats.
     float objectToWorld[12];
     float worldToObject[12];
     uint32_t instanceIndex;
@@ -80,6 +81,16 @@ struct RayQueryHit
 
 struct RayQueryState
 {
+    // Generated C++ initializes the query, clears an unconsumed candidate before each Proceed,
+    // and applies shader-side commit or abort operations. The CPU RHI's proceed implementation
+    // advances the traversal cursors, writes candidates, and automatically commits opaque
+    // triangles. Traversal starts in TLAS, temporarily enters BLAS for an instance, returns to
+    // TLAS after that BLAS is exhausted, and ends in COMPLETE. Both sides may transition directly
+    // to COMPLETE for Abort or ACCEPT_FIRST_HIT_AND_END_SEARCH.
+    //
+    // Keeping this protocol in the shared prelude makes RayQueryState the single ABI contract
+    // between generated shaders and the CPU RHI; neither side depends on the other's BVH layout.
+
     // TinyBVH uses these same maximum stack depths for its scalar BVH/TLAS traversal. Keeping the
     // cursor in the query object makes Proceed genuinely resumable without allocating or replaying.
     static const uint32_t kTLASStackCapacity = 64;
@@ -95,10 +106,10 @@ struct RayQueryState
 
     uint32_t rayFlags;
     uint32_t instanceInclusionMask;
-    uint32_t traversalPhase;
-    uint32_t candidatePending;
-    uint32_t candidateType;
-    uint32_t committedStatus;
+    uint32_t traversalPhase;   // One of SLANG_RAY_QUERY_TRAVERSAL_*.
+    uint32_t candidatePending; // A 0/1 flag indicating whether Candidate* is valid.
+    uint32_t candidateType;    // One of SLANG_RAY_QUERY_CANDIDATE_*.
+    uint32_t committedStatus;  // One of SLANG_RAY_QUERY_COMMITTED_*.
 
     uint32_t tlasNode;
     uint32_t tlasLeafOffset;
@@ -115,11 +126,13 @@ struct RayQueryState
     RayQueryHit committed;
 };
 
+// Converts a packed ABI vector to the generated C++ vector type.
 SLANG_FORCE_INLINE float3 _slangRayQueryGetFloat3(const float value[3])
 {
     return float3{value[0], value[1], value[2]};
 }
 
+// Converts a packed ABI vector to the generated C++ vector type.
 SLANG_FORCE_INLINE float2 _slangRayQueryGetFloat2(const float value[2])
 {
     return float2{value[0], value[1]};
@@ -130,6 +143,9 @@ SLANG_FORCE_INLINE Matrix<float, ROWS, COLS> _slangRayQueryGetMatrix(
     const float value[12],
     bool transpose)
 {
+    // The ABI always stores a row-major 3x4 matrix with a row stride of four. RayQuery only
+    // instantiates this helper as 3x4 without transposition or 4x3 with transposition, so both
+    // forms address exactly the same twelve packed values.
     Matrix<float, ROWS, COLS> result;
     for (int row = 0; row < ROWS; ++row)
     {
@@ -145,6 +161,21 @@ SLANG_FORCE_INLINE Matrix<float, ROWS, COLS> _slangRayQueryGetMatrix(
 template<uint32_t rayFlagsGeneric>
 struct RayQuery
 {
+    // Generated code uses this object in-place. Consider this example:
+    //
+    //     RayQuery<0> query;
+    //     query.TraceRayInline(scene, flags, mask, ray);
+    //     while (query.Proceed())
+    //     {
+    //         if (query.CandidateType() == SLANG_RAY_QUERY_CANDIDATE_NON_OPAQUE_TRIANGLE)
+    //             query.CommitNonOpaqueTriangleHit();
+    //     }
+    //
+    // TraceRayInline initializes the shared state, each Proceed asks the CPU RHI to resume from
+    // its saved traversal cursors, and a commit copies the current candidate into the committed
+    // hit. This preserves the HLSL RayQuery state machine without exposing the RHI's BVH.
+
+    // Constructs an inactive query with invalid traversal cursors.
     RayQuery()
     {
         state = {};
@@ -152,6 +183,7 @@ struct RayQuery
         state.blasNode = RayQueryState::kInvalidNode;
     }
 
+    // Initializes a new inline traversal and copies the ray parameters into shared ABI state.
     SLANG_FORCE_INLINE void TraceRayInline(
         RaytracingAccelerationStructure accelerationStructure,
         uint32_t rayFlags,
@@ -184,6 +216,7 @@ struct RayQuery
         state.committedStatus = SLANG_RAY_QUERY_COMMITTED_NOTHING;
     }
 
+    // Resumes traversal until a shader-visible candidate is available or traversal completes.
     SLANG_FORCE_INLINE bool Proceed()
     {
         if (!state.accelerationStructure ||
@@ -197,6 +230,7 @@ struct RayQuery
         return state.accelerationStructure->proceed(&state);
     }
 
+    // Completes traversal immediately so subsequent Proceed calls return false.
     SLANG_FORCE_INLINE void Abort()
     {
         state.candidatePending = 0;
@@ -205,6 +239,7 @@ struct RayQuery
         state.blasNode = RayQueryState::kInvalidNode;
     }
 
+    // Commits the current non-opaque triangle when it is closer than the previous committed hit.
     SLANG_FORCE_INLINE void CommitNonOpaqueTriangleHit()
     {
         if (!state.candidatePending ||
@@ -213,15 +248,17 @@ struct RayQuery
             return;
         }
 
+        bool accepted = false;
         if (state.committedStatus == SLANG_RAY_QUERY_COMMITTED_NOTHING ||
             state.candidate.rayT < state.committed.rayT)
         {
             state.committed = state.candidate;
             state.committedStatus = SLANG_RAY_QUERY_COMMITTED_TRIANGLE_HIT;
+            accepted = true;
         }
         state.candidatePending = 0;
 
-        if (state.rayFlags & SLANG_RAY_QUERY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH)
+        if (accepted && (state.rayFlags & SLANG_RAY_QUERY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH))
         {
             state.traversalPhase = SLANG_RAY_QUERY_TRAVERSAL_COMPLETE;
             state.tlasNode = RayQueryState::kInvalidNode;
@@ -229,6 +266,7 @@ struct RayQuery
         }
     }
 
+    // Commits a valid procedural hit when it lies within the ray extent and is the closest hit.
     SLANG_FORCE_INLINE void CommitProceduralPrimitiveHit(float rayT)
     {
         if (!state.candidatePending ||
@@ -257,6 +295,7 @@ struct RayQuery
         }
     }
 
+    // The following accessors expose shader-visible candidate and committed-hit state.
     SLANG_FORCE_INLINE uint32_t CandidateType() const { return state.candidateType; }
     SLANG_FORCE_INLINE uint32_t CommittedStatus() const { return state.committedStatus; }
     SLANG_FORCE_INLINE bool CandidateProceduralPrimitiveNonOpaque() const
@@ -369,6 +408,7 @@ struct RayQuery
         return _slangRayQueryGetMatrix<4, 3>(state.committed.worldToObject, true);
     }
 
+    // The following accessors expose the parameters of the ray being traversed.
     SLANG_FORCE_INLINE uint32_t RayFlags() const { return state.rayFlags; }
     SLANG_FORCE_INLINE float3 WorldRayOrigin() const
     {

--- a/prelude/slang-cpp-ray-query.h
+++ b/prelude/slang-cpp-ray-query.h
@@ -1,0 +1,386 @@
+#ifndef SLANG_PRELUDE_CPP_RAY_QUERY_H
+#define SLANG_PRELUDE_CPP_RAY_QUERY_H
+
+// This header is included from slang-cpp-types.h while SLANG_PRELUDE_NAMESPACE is open.
+// It defines the CPU RayQuery ABI shared by generated C++ and the CPU RHI backend. The ABI is
+// intentionally independent of the acceleration-structure implementation.
+
+struct RayQueryState;
+
+struct IRaytracingAccelerationStructure
+{
+    // Resumes traversal until a non-opaque triangle or procedural primitive candidate is found,
+    // or traversal completes.
+    // All mutable traversal data belongs to `state`; the acceleration structure remains read-only.
+    virtual bool proceed(RayQueryState* state) const = 0;
+};
+
+struct RaytracingAccelerationStructure
+{
+    IRaytracingAccelerationStructure* handle;
+};
+
+struct RayDesc
+{
+    float3 Origin;
+    float TMin;
+    float3 Direction;
+    float TMax;
+};
+
+enum : uint32_t
+{
+    SLANG_RAY_QUERY_FLAG_FORCE_OPAQUE = 0x01,
+    SLANG_RAY_QUERY_FLAG_FORCE_NON_OPAQUE = 0x02,
+    SLANG_RAY_QUERY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH = 0x04,
+    SLANG_RAY_QUERY_FLAG_CULL_BACK_FACING_TRIANGLES = 0x10,
+    SLANG_RAY_QUERY_FLAG_CULL_FRONT_FACING_TRIANGLES = 0x20,
+    SLANG_RAY_QUERY_FLAG_CULL_OPAQUE = 0x40,
+    SLANG_RAY_QUERY_FLAG_CULL_NON_OPAQUE = 0x80,
+    SLANG_RAY_QUERY_FLAG_SKIP_TRIANGLES = 0x100,
+    SLANG_RAY_QUERY_FLAG_SKIP_PROCEDURAL_PRIMITIVES = 0x200,
+};
+
+enum : uint32_t
+{
+    SLANG_RAY_QUERY_COMMITTED_NOTHING = 0,
+    SLANG_RAY_QUERY_COMMITTED_TRIANGLE_HIT = 1,
+    SLANG_RAY_QUERY_COMMITTED_PROCEDURAL_PRIMITIVE_HIT = 2,
+};
+
+enum : uint32_t
+{
+    SLANG_RAY_QUERY_CANDIDATE_NON_OPAQUE_TRIANGLE = 0,
+    SLANG_RAY_QUERY_CANDIDATE_PROCEDURAL_PRIMITIVE = 1,
+};
+
+enum : uint32_t
+{
+    SLANG_RAY_QUERY_TRAVERSAL_COMPLETE = 0,
+    SLANG_RAY_QUERY_TRAVERSAL_TLAS = 1,
+    SLANG_RAY_QUERY_TRAVERSAL_BLAS = 2,
+};
+
+struct RayQueryHit
+{
+    float rayT;
+    float barycentrics[2];
+    float objectRayOrigin[3];
+    float objectRayDirection[3];
+    float objectToWorld[12];
+    float worldToObject[12];
+    uint32_t instanceIndex;
+    uint32_t instanceID;
+    uint32_t instanceContributionToHitGroupIndex;
+    uint32_t geometryIndex;
+    uint32_t primitiveIndex;
+    uint32_t triangleFrontFace;
+    uint32_t proceduralPrimitiveNonOpaque;
+};
+
+struct RayQueryState
+{
+    // TinyBVH uses these same maximum stack depths for its scalar BVH/TLAS traversal. Keeping the
+    // cursor in the query object makes Proceed genuinely resumable without allocating or replaying.
+    static const uint32_t kTLASStackCapacity = 64;
+    static const uint32_t kBLASStackCapacity = 256;
+    static const uint32_t kInvalidNode = 0xffffffffu;
+
+    IRaytracingAccelerationStructure* accelerationStructure;
+
+    float worldRayOrigin[3];
+    float worldRayDirection[3];
+    float rayTMin;
+    float rayTMax;
+
+    uint32_t rayFlags;
+    uint32_t instanceInclusionMask;
+    uint32_t traversalPhase;
+    uint32_t candidatePending;
+    uint32_t candidateType;
+    uint32_t committedStatus;
+
+    uint32_t tlasNode;
+    uint32_t tlasLeafOffset;
+    uint32_t tlasStackSize;
+    uint32_t tlasStack[kTLASStackCapacity];
+
+    uint32_t blasNode;
+    uint32_t blasLeafOffset;
+    uint32_t blasStackSize;
+    uint32_t blasStack[kBLASStackCapacity];
+    uint32_t currentInstanceIndex;
+
+    RayQueryHit candidate;
+    RayQueryHit committed;
+};
+
+SLANG_FORCE_INLINE float3 _slangRayQueryGetFloat3(const float value[3])
+{
+    return float3{value[0], value[1], value[2]};
+}
+
+SLANG_FORCE_INLINE float2 _slangRayQueryGetFloat2(const float value[2])
+{
+    return float2{value[0], value[1]};
+}
+
+template<int ROWS, int COLS>
+SLANG_FORCE_INLINE Matrix<float, ROWS, COLS> _slangRayQueryGetMatrix(
+    const float value[12],
+    bool transpose)
+{
+    Matrix<float, ROWS, COLS> result;
+    for (int row = 0; row < ROWS; ++row)
+    {
+        for (int column = 0; column < COLS; ++column)
+        {
+            result.rows[row][column] =
+                transpose ? value[column * 4 + row] : value[row * 4 + column];
+        }
+    }
+    return result;
+}
+
+template<uint32_t rayFlagsGeneric>
+struct RayQuery
+{
+    RayQuery()
+    {
+        state = {};
+        state.tlasNode = RayQueryState::kInvalidNode;
+        state.blasNode = RayQueryState::kInvalidNode;
+    }
+
+    SLANG_FORCE_INLINE void TraceRayInline(
+        RaytracingAccelerationStructure accelerationStructure,
+        uint32_t rayFlags,
+        uint32_t instanceInclusionMask,
+        const RayDesc& ray)
+    {
+        state = {};
+        state.accelerationStructure = accelerationStructure.handle;
+        state.worldRayOrigin[0] = ray.Origin.x;
+        state.worldRayOrigin[1] = ray.Origin.y;
+        state.worldRayOrigin[2] = ray.Origin.z;
+        state.worldRayDirection[0] = ray.Direction.x;
+        state.worldRayDirection[1] = ray.Direction.y;
+        state.worldRayDirection[2] = ray.Direction.z;
+        state.rayTMin = ray.TMin;
+        state.rayTMax = ray.TMax;
+        state.rayFlags = rayFlags | rayFlagsGeneric;
+        state.instanceInclusionMask = instanceInclusionMask;
+        const bool skipAllGeometry =
+            (state.rayFlags & SLANG_RAY_QUERY_FLAG_SKIP_TRIANGLES) &&
+            (state.rayFlags & SLANG_RAY_QUERY_FLAG_SKIP_PROCEDURAL_PRIMITIVES);
+        state.traversalPhase = state.accelerationStructure && !skipAllGeometry
+                                   ? SLANG_RAY_QUERY_TRAVERSAL_TLAS
+                                   : SLANG_RAY_QUERY_TRAVERSAL_COMPLETE;
+        state.tlasNode = state.traversalPhase == SLANG_RAY_QUERY_TRAVERSAL_TLAS
+                             ? 0
+                             : RayQueryState::kInvalidNode;
+        state.blasNode = RayQueryState::kInvalidNode;
+        state.committed.rayT = ray.TMax;
+        state.committedStatus = SLANG_RAY_QUERY_COMMITTED_NOTHING;
+    }
+
+    SLANG_FORCE_INLINE bool Proceed()
+    {
+        if (!state.accelerationStructure ||
+            state.traversalPhase == SLANG_RAY_QUERY_TRAVERSAL_COMPLETE)
+        {
+            return false;
+        }
+
+        // A pending candidate that was not committed before the next Proceed is ignored.
+        state.candidatePending = 0;
+        return state.accelerationStructure->proceed(&state);
+    }
+
+    SLANG_FORCE_INLINE void Abort()
+    {
+        state.candidatePending = 0;
+        state.traversalPhase = SLANG_RAY_QUERY_TRAVERSAL_COMPLETE;
+        state.tlasNode = RayQueryState::kInvalidNode;
+        state.blasNode = RayQueryState::kInvalidNode;
+    }
+
+    SLANG_FORCE_INLINE void CommitNonOpaqueTriangleHit()
+    {
+        if (!state.candidatePending ||
+            state.candidateType != SLANG_RAY_QUERY_CANDIDATE_NON_OPAQUE_TRIANGLE)
+        {
+            return;
+        }
+
+        if (state.committedStatus == SLANG_RAY_QUERY_COMMITTED_NOTHING ||
+            state.candidate.rayT < state.committed.rayT)
+        {
+            state.committed = state.candidate;
+            state.committedStatus = SLANG_RAY_QUERY_COMMITTED_TRIANGLE_HIT;
+        }
+        state.candidatePending = 0;
+
+        if (state.rayFlags & SLANG_RAY_QUERY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH)
+        {
+            state.traversalPhase = SLANG_RAY_QUERY_TRAVERSAL_COMPLETE;
+            state.tlasNode = RayQueryState::kInvalidNode;
+            state.blasNode = RayQueryState::kInvalidNode;
+        }
+    }
+
+    SLANG_FORCE_INLINE void CommitProceduralPrimitiveHit(float rayT)
+    {
+        if (!state.candidatePending ||
+            state.candidateType != SLANG_RAY_QUERY_CANDIDATE_PROCEDURAL_PRIMITIVE || rayT != rayT ||
+            rayT < state.rayTMin || rayT > state.rayTMax)
+        {
+            return;
+        }
+
+        bool accepted = false;
+        if (state.committedStatus == SLANG_RAY_QUERY_COMMITTED_NOTHING ||
+            rayT < state.committed.rayT)
+        {
+            state.committed = state.candidate;
+            state.committed.rayT = rayT;
+            state.committedStatus = SLANG_RAY_QUERY_COMMITTED_PROCEDURAL_PRIMITIVE_HIT;
+            accepted = true;
+        }
+
+        if (accepted && (state.rayFlags & SLANG_RAY_QUERY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH))
+        {
+            state.candidatePending = 0;
+            state.traversalPhase = SLANG_RAY_QUERY_TRAVERSAL_COMPLETE;
+            state.tlasNode = RayQueryState::kInvalidNode;
+            state.blasNode = RayQueryState::kInvalidNode;
+        }
+    }
+
+    SLANG_FORCE_INLINE uint32_t CandidateType() const { return state.candidateType; }
+    SLANG_FORCE_INLINE uint32_t CommittedStatus() const { return state.committedStatus; }
+    SLANG_FORCE_INLINE bool CandidateProceduralPrimitiveNonOpaque() const
+    {
+        return state.candidate.proceduralPrimitiveNonOpaque != 0;
+    }
+
+    SLANG_FORCE_INLINE float CandidateTriangleRayT() const { return state.candidate.rayT; }
+    SLANG_FORCE_INLINE float CommittedRayT() const { return state.committed.rayT; }
+
+    SLANG_FORCE_INLINE uint32_t CandidateInstanceContributionToHitGroupIndex() const
+    {
+        return state.candidate.instanceContributionToHitGroupIndex;
+    }
+    SLANG_FORCE_INLINE uint32_t CommittedInstanceContributionToHitGroupIndex() const
+    {
+        return state.committed.instanceContributionToHitGroupIndex;
+    }
+
+    SLANG_FORCE_INLINE uint32_t CandidateInstanceIndex() const
+    {
+        return state.candidate.instanceIndex;
+    }
+    SLANG_FORCE_INLINE uint32_t CommittedInstanceIndex() const
+    {
+        return state.committed.instanceIndex;
+    }
+    SLANG_FORCE_INLINE uint32_t CandidateInstanceID() const { return state.candidate.instanceID; }
+    SLANG_FORCE_INLINE uint32_t CommittedInstanceID() const { return state.committed.instanceID; }
+    SLANG_FORCE_INLINE uint32_t CandidatePrimitiveIndex() const
+    {
+        return state.candidate.primitiveIndex;
+    }
+    SLANG_FORCE_INLINE uint32_t CommittedPrimitiveIndex() const
+    {
+        return state.committed.primitiveIndex;
+    }
+    SLANG_FORCE_INLINE uint32_t CandidateGeometryIndex() const
+    {
+        return state.candidate.geometryIndex;
+    }
+    SLANG_FORCE_INLINE uint32_t CommittedGeometryIndex() const
+    {
+        return state.committed.geometryIndex;
+    }
+
+    SLANG_FORCE_INLINE float3 CandidateObjectRayOrigin() const
+    {
+        return _slangRayQueryGetFloat3(state.candidate.objectRayOrigin);
+    }
+    SLANG_FORCE_INLINE float3 CommittedObjectRayOrigin() const
+    {
+        return _slangRayQueryGetFloat3(state.committed.objectRayOrigin);
+    }
+    SLANG_FORCE_INLINE float3 CandidateObjectRayDirection() const
+    {
+        return _slangRayQueryGetFloat3(state.candidate.objectRayDirection);
+    }
+    SLANG_FORCE_INLINE float3 CommittedObjectRayDirection() const
+    {
+        return _slangRayQueryGetFloat3(state.committed.objectRayDirection);
+    }
+    SLANG_FORCE_INLINE bool CandidateTriangleFrontFace() const
+    {
+        return state.candidate.triangleFrontFace != 0;
+    }
+    SLANG_FORCE_INLINE bool CommittedTriangleFrontFace() const
+    {
+        return state.committed.triangleFrontFace != 0;
+    }
+    SLANG_FORCE_INLINE float2 CandidateTriangleBarycentrics() const
+    {
+        return _slangRayQueryGetFloat2(state.candidate.barycentrics);
+    }
+    SLANG_FORCE_INLINE float2 CommittedTriangleBarycentrics() const
+    {
+        return _slangRayQueryGetFloat2(state.committed.barycentrics);
+    }
+
+    SLANG_FORCE_INLINE Matrix<float, 3, 4> CandidateObjectToWorld3x4() const
+    {
+        return _slangRayQueryGetMatrix<3, 4>(state.candidate.objectToWorld, false);
+    }
+    SLANG_FORCE_INLINE Matrix<float, 3, 4> CommittedObjectToWorld3x4() const
+    {
+        return _slangRayQueryGetMatrix<3, 4>(state.committed.objectToWorld, false);
+    }
+    SLANG_FORCE_INLINE Matrix<float, 4, 3> CandidateObjectToWorld4x3() const
+    {
+        return _slangRayQueryGetMatrix<4, 3>(state.candidate.objectToWorld, true);
+    }
+    SLANG_FORCE_INLINE Matrix<float, 4, 3> CommittedObjectToWorld4x3() const
+    {
+        return _slangRayQueryGetMatrix<4, 3>(state.committed.objectToWorld, true);
+    }
+    SLANG_FORCE_INLINE Matrix<float, 3, 4> CandidateWorldToObject3x4() const
+    {
+        return _slangRayQueryGetMatrix<3, 4>(state.candidate.worldToObject, false);
+    }
+    SLANG_FORCE_INLINE Matrix<float, 3, 4> CommittedWorldToObject3x4() const
+    {
+        return _slangRayQueryGetMatrix<3, 4>(state.committed.worldToObject, false);
+    }
+    SLANG_FORCE_INLINE Matrix<float, 4, 3> CandidateWorldToObject4x3() const
+    {
+        return _slangRayQueryGetMatrix<4, 3>(state.candidate.worldToObject, true);
+    }
+    SLANG_FORCE_INLINE Matrix<float, 4, 3> CommittedWorldToObject4x3() const
+    {
+        return _slangRayQueryGetMatrix<4, 3>(state.committed.worldToObject, true);
+    }
+
+    SLANG_FORCE_INLINE uint32_t RayFlags() const { return state.rayFlags; }
+    SLANG_FORCE_INLINE float3 WorldRayOrigin() const
+    {
+        return _slangRayQueryGetFloat3(state.worldRayOrigin);
+    }
+    SLANG_FORCE_INLINE float3 WorldRayDirection() const
+    {
+        return _slangRayQueryGetFloat3(state.worldRayDirection);
+    }
+    SLANG_FORCE_INLINE float RayTMin() const { return state.rayTMin; }
+
+    RayQueryState state;
+};
+
+#endif

--- a/prelude/slang-cpp-types.h
+++ b/prelude/slang-cpp-types.h
@@ -24,6 +24,8 @@ typedef Vector<uint32_t, 2> uint2;
 typedef Vector<uint32_t, 3> uint3;
 typedef Vector<uint32_t, 4> uint4;
 
+#include "slang-cpp-ray-query.h"
+
 // We can just map `NonUniformResourceIndex` type directly to the index type on CPU, as CPU does not
 // require any special handling around such accesses.
 typedef size_t NonUniformResourceIndex;

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -19493,26 +19493,33 @@ static const RAY_FLAG RAY_FLAG_FORCE_OMM_2_STATE = 0x400;
 /// @category raytracing
 __target_intrinsic(hlsl, RayDesc)
 __target_intrinsic(cuda, RayDesc)
+__target_intrinsic(cpp, RayDesc)
 struct RayDesc
 {
     /// Starting point of the ray in world space.
     __target_intrinsic(hlsl, Origin)
     __target_intrinsic(cuda, Origin)
+    __target_intrinsic(cpp, Origin)
     float3 Origin;
 
     /// Minimum distance along the ray to consider intersections.
     __target_intrinsic(hlsl, TMin)
     __target_intrinsic(cuda, TMin)
+    __target_intrinsic(cpp, TMin)
     float  TMin;
 
-    /// Normalized direction vector of the ray in world space.
+    /// Direction vector of the ray in world space. It does not need to be normalized.
+    /// See the DXR functional specification for the definition of a ray:
+    /// https://microsoft.github.io/DirectX-Specs/d3d/Raytracing.html#rays
     __target_intrinsic(hlsl, Direction)
     __target_intrinsic(cuda, Direction)
+    __target_intrinsic(cpp, Direction)
     float3 Direction;
 
     /// Maximum distance along the ray to consider intersections.
     __target_intrinsic(hlsl, TMax)
     __target_intrinsic(cuda, TMax)
+    __target_intrinsic(cpp, TMax)
     float  TMax;
 };
 
@@ -21279,7 +21286,7 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     /// @param ray Description of ray parameters (origin, direction, tMin, tMax)
     [__unsafeForceInlineEarly]
     [mutating]
-    [require(glsl_hlsl_metal_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_metal_spirv, rayquery)]
     void TraceRayInline(
         RaytracingAccelerationStructure accelerationStructure,
         RAY_FLAG                        rayFlags,
@@ -21288,6 +21295,7 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->TraceRayInline($1, $2, $3, $4)";
         case hlsl: __intrinsic_asm ".TraceRayInline";
         case glsl:
         case spirv:
@@ -21322,11 +21330,12 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     /// @remarks When true is returned, use Candidate* methods to evaluate the hit
     __glsl_extension(GL_EXT_ray_query)
     [mutating]
-    [require(glsl_hlsl_metal_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_metal_spirv, rayquery)]
     bool Proceed()
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->Proceed()";
         case hlsl: __intrinsic_asm ".Proceed";
         case glsl: __intrinsic_asm "rayQueryProceedEXT";
         case metal: __intrinsic_asm "$0->next()";
@@ -21341,11 +21350,12 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     /// @remarks Causes subsequent Proceed() calls to return false
     __glsl_extension(GL_EXT_ray_query)
     [mutating]
-    [require(glsl_hlsl_metal_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_metal_spirv, rayquery)]
     void Abort()
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->Abort()";
         case hlsl: __intrinsic_asm ".Abort";
         case glsl: __intrinsic_asm "rayQueryTerminateEXT";
         case metal: __intrinsic_asm "$0->abort()";
@@ -21357,11 +21367,12 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     __glsl_extension(GL_EXT_ray_query)
     [__NoSideEffect]
     [mutating]
-    [require(glsl_hlsl_metal_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_metal_spirv, rayquery)]
     void CommitNonOpaqueTriangleHit()
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->CommitNonOpaqueTriangleHit()";
         case hlsl: __intrinsic_asm ".CommitNonOpaqueTriangleHit";
         case glsl: __intrinsic_asm "rayQueryConfirmIntersectionEXT";
         case metal: __intrinsic_asm "$0->commit_triangle_intersection()";
@@ -21374,11 +21385,12 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     __glsl_extension(GL_EXT_ray_query)
     [__NoSideEffect]
     [mutating]
-    [require(glsl_hlsl_metal_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_metal_spirv, rayquery)]
     void CommitProceduralPrimitiveHit(float t)
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->CommitProceduralPrimitiveHit($1)";
         case hlsl: __intrinsic_asm ".CommitProceduralPrimitiveHit";
         case glsl: __intrinsic_asm "rayQueryGenerateIntersectionEXT";
         case metal: __intrinsic_asm "$0->commit_bounding_box_intersection($1)";
@@ -21398,11 +21410,12 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     __glsl_extension(GL_EXT_ray_query)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_metal_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_metal_spirv, rayquery)]
     CANDIDATE_TYPE CandidateType()
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->CandidateType()";
         case hlsl: __intrinsic_asm ".CandidateType";
         case glsl: __intrinsic_asm "rayQueryGetIntersectionTypeEXT($0, false)";
         case spirv:
@@ -21435,11 +21448,12 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     __glsl_extension(GL_EXT_ray_query)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_metal_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_metal_spirv, rayquery)]
     COMMITTED_STATUS CommittedStatus()
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->CommittedStatus()";
         case hlsl: __intrinsic_asm ".CommittedStatus";
         case glsl: __intrinsic_asm "rayQueryGetIntersectionTypeEXT($0, true)";
         case spirv:
@@ -21472,11 +21486,12 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     __glsl_extension(GL_EXT_ray_query)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_spirv, rayquery)]
     bool CandidateProceduralPrimitiveNonOpaque()
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->CandidateProceduralPrimitiveNonOpaque()";
         case hlsl: __intrinsic_asm ".CandidateProceduralPrimitiveNonOpaque";
         case glsl: __intrinsic_asm "(!rayQueryGetIntersectionCandidateAABBOpaqueEXT($0))";
         case spirv:
@@ -21494,11 +21509,12 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     __glsl_extension(GL_EXT_ray_query)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_metal_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_metal_spirv, rayquery)]
     float CandidateTriangleRayT()
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->CandidateTriangleRayT()";
         case hlsl: __intrinsic_asm ".CandidateTriangleRayT";
         case glsl: __intrinsic_asm "rayQueryGetIntersectionTEXT($0, false)";
         case metal: __intrinsic_asm "$0->get_candidate_triangle_distance()";
@@ -21516,11 +21532,12 @@ struct RayQuery <let rayFlagsGeneric : RAY_FLAG = RAY_FLAG_NONE>
     __glsl_extension(GL_EXT_ray_query)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_metal_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_metal_spirv, rayquery)]
     float CommittedRayT()
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->CommittedRayT()";
         case hlsl: __intrinsic_asm ".CommittedRayT";
         case glsl: __intrinsic_asm "rayQueryGetIntersectionTEXT($0, true)";
         case metal: __intrinsic_asm "$0->get_committed_distance()";
@@ -22059,11 +22076,12 @@ $}
     __glsl_extension(GL_EXT_ray_query)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_spirv, rayquery)]
     uint $(ccName)InstanceContributionToHitGroupIndex()
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->$(ccName)InstanceContributionToHitGroupIndex()";
         case hlsl: __intrinsic_asm ".$(ccName)InstanceContributionToHitGroupIndex";
         case glsl: __intrinsic_asm "rayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetEXT($0, $(ccTF))";
         case spirv:
@@ -22132,11 +22150,12 @@ $}
     __glsl_extension(GL_EXT_ray_query)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_metal_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_metal_spirv, rayquery)]
     float3x4 $(ccName)$(method.name)3x4()
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->$(ccName)$(method.name)3x4()";
         case glsl: __intrinsic_asm "transpose(rayQueryGetIntersection$(method.name)EXT($0, $(ccTF)))";
         case hlsl: __intrinsic_asm ".$(ccName)$(method.name)3x4";
         case metal: __intrinsic_asm "transpose($0->$(ccNameMetal)$(method.metalName)())";
@@ -22156,11 +22175,12 @@ $}
     __glsl_extension(GL_EXT_ray_query)
     [__readNone]
     [NonUniformReturn]
-    [require(glsl_hlsl_metal_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_metal_spirv, rayquery)]
     float4x3 $(ccName)$(method.name)4x3()
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->$(ccName)$(method.name)4x3()";
         case glsl: __intrinsic_asm "rayQueryGetIntersection$(method.name)EXT($0, $(ccTF))";
         case hlsl: __intrinsic_asm ".$(ccName)$(method.name)4x3";
         case metal: __intrinsic_asm "$0->$(ccNameMetal)$(method.metalName)()";
@@ -22200,11 +22220,12 @@ $}
     __glsl_extension(GL_EXT_ray_query)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_metal_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_metal_spirv, rayquery)]
     $(method.type) $(ccName)$(method.hlslName)()
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->$(ccName)$(method.hlslName)()";
         case hlsl: __intrinsic_asm ".$(ccName)$(method.hlslName)";
         case glsl: __intrinsic_asm "rayQueryGetIntersection$(method.glslName)EXT($0, $(ccTF))";
         case metal: __intrinsic_asm "$0->$(ccNameMetal)$(method.metalName)()";
@@ -22226,11 +22247,12 @@ $}
     __glsl_extension(GL_EXT_ray_query)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_metal_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_metal_spirv, rayquery)]
     uint RayFlags()
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->RayFlags()";
         case hlsl: __intrinsic_asm ".RayFlags";
         case glsl: __intrinsic_asm "rayQueryGetRayFlagsEXT";
         case metal:
@@ -22279,11 +22301,12 @@ $}
     __glsl_extension(GL_EXT_ray_query)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_metal_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_metal_spirv, rayquery)]
     float3 WorldRayOrigin()
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->WorldRayOrigin()";
         case hlsl: __intrinsic_asm ".WorldRayOrigin";
         case glsl: __intrinsic_asm "rayQueryGetWorldRayOriginEXT";
         case metal: __intrinsic_asm "$0->get_world_space_ray_origin()";
@@ -22300,11 +22323,12 @@ $}
     __glsl_extension(GL_EXT_ray_query)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_metal_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_metal_spirv, rayquery)]
     float3 WorldRayDirection()
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->WorldRayDirection()";
         case hlsl: __intrinsic_asm ".WorldRayDirection";
         case glsl: __intrinsic_asm "rayQueryGetWorldRayDirectionEXT";
         case metal: __intrinsic_asm "$0->get_world_space_ray_direction()";
@@ -22322,11 +22346,12 @@ $}
     __glsl_extension(GL_EXT_ray_query)
     [__NoSideEffect]
     [NonUniformReturn]
-    [require(glsl_hlsl_metal_spirv, rayquery)]
+    [require(cpp_glsl_hlsl_metal_spirv, rayquery)]
     float RayTMin()
     {
         __target_switch
         {
+        case cpp: __intrinsic_asm "$0->RayTMin()";
         case hlsl: __intrinsic_asm ".RayTMin";
         case glsl: __intrinsic_asm "rayQueryGetRayTMinEXT";
         case metal: __intrinsic_asm "$0->get_ray_min_distance()";

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -22322,7 +22322,7 @@ $}
     }
 
     /// Gets the world-space direction of the ray.
-    /// @return Normalized direction vector in world space
+    /// @return Direction vector supplied to `TraceRayInline`; it is not necessarily normalized.
     __glsl_extension(GL_EXT_ray_query)
     [__NoSideEffect]
     [NonUniformReturn]

--- a/source/slang/slang-capabilities.capdef
+++ b/source/slang/slang-capabilities.capdef
@@ -1383,7 +1383,7 @@ alias ser_nv = raytracing + GL_NV_shader_invocation_reorder | cuda;
 alias motionblur_nv = GL_NV_ray_tracing_motion_blur | cuda;
 /// Capabilities needed for compute-shader rayquery
 /// [Compound]
-alias rayquery = GL_EXT_ray_query | _sm_6_3 | metal;
+alias rayquery = GL_EXT_ray_query | _sm_6_3 | metal | cpp;
 /// Capabilities needed for compute-shader rayquery and motion-blur
 /// [Compound]
 alias raytracing_motionblur =  raytracing + motionblur_nv | cuda;

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -282,6 +282,13 @@ SlangResult CPPSourceEmitter::calcTypeName(IRType* type, CodeGenTarget target, S
             out << ">";
             return SLANG_OK;
         }
+    case kIROp_RayQueryType:
+        {
+            out << "RayQuery<";
+            out << getIntVal(type->getOperand(0));
+            out << ">";
+            return SLANG_OK;
+        }
     case kIROp_ConstantBufferType:
     case kIROp_ParameterBlockType:
         {

--- a/tests/bugs/ray-query-in-generic.slang
+++ b/tests/bugs/ray-query-in-generic.slang
@@ -1,6 +1,7 @@
 
 //TEST(compute):COMPARE_COMPUTE:-d3d12 -output-using-type -profile sm_6_5 -render-feature ray-query
 //TEST(compute):COMPARE_COMPUTE:-vk -output-using-type -render-feature ray-query
+//TEST(compute):COMPARE_COMPUTE:-cpu -output-using-type -render-feature ray-query
 
 //TEST_INPUT: set scene = AccelerationStructure
 uniform RaytracingAccelerationStructure scene;

--- a/tests/language-feature/rayquery/cpu-ray-query-procedural.slang
+++ b/tests/language-feature/rayquery/cpu-ray-query-procedural.slang
@@ -1,0 +1,21 @@
+//TEST:SIMPLE(filecheck=CPP): -target cpp -entry computeMain -stage compute
+// CPP: CandidateType
+// CPP: CandidateProceduralPrimitiveNonOpaque
+// CPP: CommitProceduralPrimitiveHit
+
+RaytracingAccelerationStructure scene;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    RayDesc ray = {float3(0.0), 0.0, float3(0.0, 0.0, 1.0), 10.0};
+    RayQuery<RAY_FLAG_NONE> query;
+    query.TraceRayInline(scene, RAY_FLAG_NONE, 0xff, ray);
+    while (query.Proceed())
+    {
+        if (query.CandidateType() == CANDIDATE_PROCEDURAL_PRIMITIVE &&
+            query.CandidateProceduralPrimitiveNonOpaque())
+            query.CommitProceduralPrimitiveHit(1.0);
+    }
+}

--- a/tests/language-feature/rayquery/cpu-ray-query-procedural.slang
+++ b/tests/language-feature/rayquery/cpu-ray-query-procedural.slang
@@ -2,6 +2,11 @@
 // CPP: CandidateType
 // CPP: CandidateProceduralPrimitiveNonOpaque
 // CPP: CommitProceduralPrimitiveHit
+//
+// Slang's render-test scene currently contains only opaque triangles, so this test validates C++
+// emission rather than procedural traversal at runtime. The paired slang-rhi PR provides executable
+// CPU coverage for procedural and non-opaque commits, abort/skip behavior, and matrix accessors:
+// https://github.com/shader-slang/slang-rhi/pull/803
 
 RaytracingAccelerationStructure scene;
 

--- a/tests/language-feature/rayquery/cpu-ray-query-targets.slang
+++ b/tests/language-feature/rayquery/cpu-ray-query-targets.slang
@@ -1,0 +1,23 @@
+// The C++ host-callable path has a concrete triangle RayQuery implementation. The direct LLVM
+// path intentionally remains unavailable until it has its own ABI and resumable lowering.
+
+//TEST:SIMPLE(filecheck=CPP): -target cpp -entry computeMain -stage compute
+//DIAGNOSTIC_TEST:SIMPLE(diag=LLVM,non-exhaustive): -target host-callable -emit-cpu-via-llvm -entry computeMain -stage compute
+
+// CPP-NOT: struct RayDesc_
+// CPP: RayDesc
+// CPP: RayQuery<0>
+// LLVM: E36107
+
+RaytracingAccelerationStructure scene;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    RayDesc ray = {float3(0.0), 0.0, float3(0.0, 0.0, 1.0), 10.0};
+    RayQuery<RAY_FLAG_NONE> query;
+    query.TraceRayInline(scene, RAY_FLAG_NONE, 0xff, ray);
+    while (query.Proceed())
+        query.CommitNonOpaqueTriangleHit();
+}

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -1175,7 +1175,7 @@ void RenderTestApp::_initializeRenderPass()
 
 void RenderTestApp::_initializeAccelerationStructure()
 {
-    if (!m_device->hasFeature("ray-tracing"))
+    if (!m_device->hasFeature("ray-tracing") && !m_device->hasFeature("ray-query"))
         return;
     BufferDesc vertexBufferDesc = {};
     vertexBufferDesc.size = kVertexCount * sizeof(Vertex);


### PR DESCRIPTION
Introduce a C++ CPU ray-query ABI and wire it through the compiler and tests.

- Add prelude/slang-cpp-ray-query.h: defines RayQuery, RayDesc, RayQueryState and IRaytracingAccelerationStructure for the CPU ABI.
- Include the new header from prelude/slang-cpp-types.h.
- Expose cpp target intrinsics for RayDesc and RayQuery methods in source/slang/hlsl.meta.slang.
- Add cpp to the rayquery capability alias in source/slang/slang-capabilities.capdef.
- Teach the C++ emitter to print RayQuery<T> types in source/slang/slang-emit-cpp.cpp.
- Add CPU-focused tests to tests/language-feature/rayquery and enable CPU run for an existing bug test.
- Render test updated to treat devices with "ray-query" feature as supporting tests.

These changes enable the host-callable C++ path for ray queries and add coverage for CPU-target behavior.

slang-rhi related pr:
https://github.com/shader-slang/slang-rhi/pull/803

a slang cpu path tracing example
https://github.com/WeakKnight/slangpy/tree/cpu-ray-tracing/examples/cpu_path_tracing
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/2e191bc0-72de-49ce-a246-c67760da231a" />

issues about cpu ray tracing request
https://github.com/shader-slang/slang/issues/2141