### PR TITLE
Keep LLVM JIT COFF sections ordered

### DIFF
--- a/source/slang-llvm/slang-llvm-builder.cpp
+++ b/source/slang-llvm/slang-llvm-builder.cpp
@@ -2323,9 +2323,9 @@ SlangResult LLVMBuilder::generateJITLibrary(IArtifact** outArtifact)
 
     std::unique_ptr<llvm::orc::LLJIT> jit;
     {
-        // Construct the LLJIT with AVX-512 disabled in the JIT TargetMachine;
-        // see #11062 and the docstring for createAVX512SafeLLJIT.
-        llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> expectJit = createAVX512SafeLLJIT();
+        // Construct the LLJIT with Slang's platform configuration; see the
+        // createSlangLLJIT docstring.
+        llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> expectJit = createSlangLLJIT();
 
         if (!expectJit)
         {

--- a/source/slang-llvm/slang-llvm-jit-shared-library.cpp
+++ b/source/slang-llvm/slang-llvm-jit-shared-library.cpp
@@ -1,6 +1,6 @@
 #include "slang-llvm-jit-shared-library.h"
 
-#if SLANG_WINDOWS_FAMILY && SLANG_PROCESSOR_X86_64
+#if SLANG_WINDOWS_FAMILY && SLANG_PTR_IS_64
 #include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/RTDyldMemoryManager.h"
 #include "llvm/Support/Memory.h"
@@ -17,7 +17,7 @@
 namespace slang_llvm
 {
 
-#if SLANG_WINDOWS_FAMILY && SLANG_PROCESSOR_X86_64
+#if SLANG_WINDOWS_FAMILY && SLANG_PTR_IS_64
 namespace
 {
 
@@ -250,14 +250,14 @@ void disableAVX512ForJIT(llvm::orc::LLJITBuilder& jitBuilder)
     jitBuilder.setJITTargetMachineBuilder(std::move(*expectJTMB));
 }
 
-static void configureRTDyldForWindowsX64(llvm::orc::LLJITBuilder& jitBuilder)
+static void configureRTDyldForWindows64(llvm::orc::LLJITBuilder& jitBuilder)
 {
-#if SLANG_WINDOWS_FAMILY && SLANG_PROCESSOR_X86_64
+#if SLANG_WINDOWS_FAMILY && SLANG_PTR_IS_64
     // LLVM 21's default LLJIT layer uses RuntimeDyld with a separate SectionMemoryManager for
     // each object. SectionMemoryManager makes separate virtual-memory allocations for code,
     // read-only data, and writable data. Windows can place a later allocation below the first
-    // one, but IMAGE_REL_AMD64_ADDR32NB relocations require every target to have a non-negative
-    // 32-bit offset from the image base.
+    // one, but COFF ADDR32NB relocations require every target to have a non-negative 32-bit offset
+    // from the image base.
     //
     // Keep RuntimeDyld's established COFF behavior, but give each object one contiguous allocation
     // in the order required by its relocation model: code, read-only data, then writable data.
@@ -283,7 +283,7 @@ llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> createSlangLLJIT()
 {
     llvm::orc::LLJITBuilder jitBuilder;
     disableAVX512ForJIT(jitBuilder);
-    configureRTDyldForWindowsX64(jitBuilder);
+    configureRTDyldForWindows64(jitBuilder);
     return jitBuilder.create();
 }
 

--- a/source/slang-llvm/slang-llvm-jit-shared-library.cpp
+++ b/source/slang-llvm/slang-llvm-jit-shared-library.cpp
@@ -21,6 +21,9 @@ namespace slang_llvm
 namespace
 {
 
+// Places each JIT object's code, read-only data, and writable data in one contiguous mapping in
+// that order. This keeps every COFF ADDR32NB target at a non-negative 32-bit offset from the
+// object's image base.
 class OrderedRTDyldMemoryManager : public llvm::RTDyldMemoryManager
 {
 public:

--- a/source/slang-llvm/slang-llvm-jit-shared-library.cpp
+++ b/source/slang-llvm/slang-llvm-jit-shared-library.cpp
@@ -1,6 +1,7 @@
 #include "slang-llvm-jit-shared-library.h"
 
 #if SLANG_WINDOWS_FAMILY && SLANG_PTR_IS_64
+#include "llvm/Config/llvm-config.h"
 #include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/RTDyldMemoryManager.h"
 #include "llvm/Support/Memory.h"
@@ -20,6 +21,13 @@ namespace slang_llvm
 #if SLANG_WINDOWS_FAMILY && SLANG_PTR_IS_64
 namespace
 {
+
+// TODO: LLVM 23 switches LLJIT's default object layer from RuntimeDyld to JITLink, whose
+// InProcessMemoryManager should not need this Windows SectionMemoryManager workaround.
+static_assert(
+    LLVM_VERSION_MAJOR < 23,
+    "Remove OrderedRTDyldMemoryManager when upgrading to LLVM 23 or later; LLJIT uses JITLink's "
+    "InProcessMemoryManager by default");
 
 // Places each JIT object's code, read-only data, and writable data in one contiguous mapping in
 // that order. This keeps every COFF ADDR32NB target at a non-negative 32-bit offset from the

--- a/source/slang-llvm/slang-llvm-jit-shared-library.cpp
+++ b/source/slang-llvm/slang-llvm-jit-shared-library.cpp
@@ -1,5 +1,11 @@
 #include "slang-llvm-jit-shared-library.h"
 
+#if SLANG_WINDOWS_FAMILY && SLANG_PROCESSOR_X86_64
+#include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
+#include "llvm/ExecutionEngine/RTDyldMemoryManager.h"
+#include "llvm/Support/Memory.h"
+#include "llvm/Support/Process.h"
+#endif
 #include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
@@ -10,6 +16,190 @@
 
 namespace slang_llvm
 {
+
+#if SLANG_WINDOWS_FAMILY && SLANG_PROCESSOR_X86_64
+namespace
+{
+
+class OrderedRTDyldMemoryManager : public llvm::RTDyldMemoryManager
+{
+public:
+    ~OrderedRTDyldMemoryManager()
+    {
+        if (m_memory.base())
+            llvm::sys::Memory::releaseMappedMemory(m_memory);
+    }
+
+    bool needsToReserveAllocationSpace() override { return true; }
+
+    void reserveAllocationSpace(
+        uintptr_t codeSize,
+        llvm::Align codeAlign,
+        uintptr_t readOnlyDataSize,
+        llvm::Align readOnlyDataAlign,
+        uintptr_t readWriteDataSize,
+        llvm::Align readWriteDataAlign) override
+    {
+        SLANG_ASSERT(!m_memory.base());
+
+        const uintptr_t pageSize = llvm::sys::Process::getPageSizeEstimate();
+        const uintptr_t codeAlignment = std::max(pageSize, codeAlign.value());
+        const uintptr_t readOnlyDataAlignment = std::max(pageSize, readOnlyDataAlign.value());
+        const uintptr_t readWriteDataAlignment = std::max(pageSize, readWriteDataAlign.value());
+        const uintptr_t allocationAlignment =
+            std::max(codeAlignment, std::max(readOnlyDataAlignment, readWriteDataAlignment));
+
+        // ADDR32NB can only represent positions within the first 4 GiB of the image. Checking each
+        // layout step against that limit also makes the additions in _alignUp safe on a 64-bit
+        // host.
+        if (codeSize > UINT32_MAX || readOnlyDataSize > UINT32_MAX ||
+            readWriteDataSize > UINT32_MAX || allocationAlignment > UINT32_MAX)
+        {
+            m_error = "JIT object is too large for 32-bit image-relative relocations";
+            return;
+        }
+
+        const uintptr_t readOnlyDataOffset = _alignUp(codeSize, readOnlyDataAlignment);
+        if (readOnlyDataOffset > UINT32_MAX || readOnlyDataSize > UINT32_MAX - readOnlyDataOffset)
+        {
+            m_error = "JIT object is too large for 32-bit image-relative relocations";
+            return;
+        }
+        const uintptr_t readWriteDataOffset =
+            _alignUp(readOnlyDataOffset + readOnlyDataSize, readWriteDataAlignment);
+        if (readWriteDataOffset > UINT32_MAX ||
+            readWriteDataSize > UINT32_MAX - readWriteDataOffset)
+        {
+            m_error = "JIT object is too large for 32-bit image-relative relocations";
+            return;
+        }
+        const uintptr_t imageSize = _alignUp(readWriteDataOffset + readWriteDataSize, pageSize);
+
+        // allocateMappedMemory only guarantees allocation-granularity alignment. Reserve enough
+        // prefix space to align the image for any larger section alignment too.
+        const uintptr_t allocationSize = imageSize + allocationAlignment - 1;
+        std::error_code error;
+        m_memory = llvm::sys::Memory::allocateMappedMemory(
+            allocationSize,
+            nullptr,
+            llvm::sys::Memory::MF_READ | llvm::sys::Memory::MF_WRITE,
+            error);
+        if (error)
+        {
+            m_error = error.message();
+            return;
+        }
+
+        uint8_t* imageBase =
+            reinterpret_cast<uint8_t*>(_alignUp(uintptr_t(m_memory.base()), allocationAlignment));
+        uint8_t* readOnlyDataBase = imageBase + readOnlyDataOffset;
+        uint8_t* readWriteDataBase = imageBase + readWriteDataOffset;
+        m_code = {imageBase, imageBase, readOnlyDataBase, codeAlign.value()};
+        m_readOnlyData =
+            {readOnlyDataBase, readOnlyDataBase, readWriteDataBase, readOnlyDataAlign.value()};
+        m_readWriteData = {
+            readWriteDataBase,
+            readWriteDataBase,
+            imageBase + imageSize,
+            readWriteDataAlign.value()};
+    }
+
+    uint8_t* allocateCodeSection(uintptr_t size, unsigned alignment, unsigned, llvm::StringRef)
+        override
+    {
+        return _allocate(m_code, size, alignment);
+    }
+
+    uint8_t* allocateDataSection(
+        uintptr_t size,
+        unsigned alignment,
+        unsigned,
+        llvm::StringRef,
+        bool isReadOnly) override
+    {
+        return _allocate(isReadOnly ? m_readOnlyData : m_readWriteData, size, alignment);
+    }
+
+    bool finalizeMemory(std::string* errorMessage) override
+    {
+        if (!m_error.empty())
+        {
+            if (errorMessage)
+                *errorMessage = m_error;
+            return true;
+        }
+
+        if (_protect(m_code, llvm::sys::Memory::MF_READ | llvm::sys::Memory::MF_EXEC, errorMessage))
+            return true;
+        if (_protect(m_readOnlyData, llvm::sys::Memory::MF_READ, errorMessage))
+            return true;
+
+        llvm::sys::Memory::InvalidateInstructionCache(
+            m_code.begin,
+            uintptr_t(m_code.cursor - m_code.begin));
+        return false;
+    }
+
+private:
+    struct Segment
+    {
+        uint8_t* begin = nullptr;
+        uint8_t* cursor = nullptr;
+        uint8_t* end = nullptr;
+        uintptr_t alignment = 1;
+    };
+
+    static uintptr_t _alignUp(uintptr_t value, uintptr_t alignment)
+    {
+        SLANG_ASSERT(alignment && !(alignment & (alignment - 1)));
+        return (value + alignment - 1) & ~(alignment - 1);
+    }
+
+    uint8_t* _allocate(Segment& segment, uintptr_t size, uintptr_t alignment)
+    {
+        if (!m_error.empty() || !segment.begin)
+            return nullptr;
+
+        if (!alignment)
+            alignment = 16;
+        SLANG_ASSERT(!(alignment & (alignment - 1)));
+        SLANG_ASSERT(alignment <= segment.alignment);
+
+        uintptr_t address = _alignUp(uintptr_t(segment.cursor), alignment);
+        if (address > uintptr_t(segment.end) || size > uintptr_t(segment.end) - address)
+        {
+            m_error = "LLVM requested more JIT section memory than it reserved";
+            return nullptr;
+        }
+
+        segment.cursor = reinterpret_cast<uint8_t*>(address + size);
+        return reinterpret_cast<uint8_t*>(address);
+    }
+
+    static bool _protect(Segment& segment, unsigned permissions, std::string* errorMessage)
+    {
+        if (segment.begin == segment.end)
+            return false;
+
+        llvm::sys::MemoryBlock block(segment.begin, uintptr_t(segment.end - segment.begin));
+        if (std::error_code error = llvm::sys::Memory::protectMappedMemory(block, permissions))
+        {
+            if (errorMessage)
+                *errorMessage = error.message();
+            return true;
+        }
+        return false;
+    }
+
+    llvm::sys::MemoryBlock m_memory;
+    Segment m_code;
+    Segment m_readOnlyData;
+    Segment m_readWriteData;
+    std::string m_error;
+};
+
+} // namespace
+#endif
 
 void disableAVX512ForJIT(llvm::orc::LLJITBuilder& jitBuilder)
 {
@@ -60,10 +250,40 @@ void disableAVX512ForJIT(llvm::orc::LLJITBuilder& jitBuilder)
     jitBuilder.setJITTargetMachineBuilder(std::move(*expectJTMB));
 }
 
-llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> createAVX512SafeLLJIT()
+static void configureRTDyldForWindowsX64(llvm::orc::LLJITBuilder& jitBuilder)
+{
+#if SLANG_WINDOWS_FAMILY && SLANG_PROCESSOR_X86_64
+    // LLVM 21's default LLJIT layer uses RuntimeDyld with a separate SectionMemoryManager for
+    // each object. SectionMemoryManager makes separate virtual-memory allocations for code,
+    // read-only data, and writable data. Windows can place a later allocation below the first
+    // one, but IMAGE_REL_AMD64_ADDR32NB relocations require every target to have a non-negative
+    // 32-bit offset from the image base.
+    //
+    // Keep RuntimeDyld's established COFF behavior, but give each object one contiguous allocation
+    // in the order required by its relocation model: code, read-only data, then writable data.
+    jitBuilder.setObjectLinkingLayerCreator(
+        [](llvm::orc::ExecutionSession& executionSession)
+            -> llvm::Expected<std::unique_ptr<llvm::orc::ObjectLayer>>
+        {
+            auto getMemoryManager = [](const llvm::MemoryBuffer&)
+            { return std::make_unique<OrderedRTDyldMemoryManager>(); };
+            auto layer = std::make_unique<llvm::orc::RTDyldObjectLinkingLayer>(
+                executionSession,
+                std::move(getMemoryManager));
+            layer->setOverrideObjectFlagsWithResponsibilityFlags(true);
+            layer->setAutoClaimResponsibilityForObjectSymbols(true);
+            return std::unique_ptr<llvm::orc::ObjectLayer>(std::move(layer));
+        });
+#else
+    SLANG_UNUSED(jitBuilder);
+#endif
+}
+
+llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> createSlangLLJIT()
 {
     llvm::orc::LLJITBuilder jitBuilder;
     disableAVX512ForJIT(jitBuilder);
+    configureRTDyldForWindowsX64(jitBuilder);
     return jitBuilder.create();
 }
 

--- a/source/slang-llvm/slang-llvm-jit-shared-library.h
+++ b/source/slang-llvm/slang-llvm-jit-shared-library.h
@@ -32,7 +32,7 @@ void disableAVX512ForJIT(llvm::orc::LLJITBuilder& jitBuilder);
 /// Construct an LLJIT using Slang's platform configuration.
 ///
 /// `disableAVX512ForJIT` only fires when SLANG_DISABLE_AVX512=1 is set in
-/// the environment. On Windows x86-64, RuntimeDyld uses one ordered allocation
+/// the environment. On 64-bit Windows, RuntimeDyld uses one ordered allocation
 /// per object so COFF image-relative relocations always have valid offsets.
 /// Use this from every LLJIT construction site in slang-llvm so neither
 /// configuration can be forgotten.

--- a/source/slang-llvm/slang-llvm-jit-shared-library.h
+++ b/source/slang-llvm/slang-llvm-jit-shared-library.h
@@ -18,7 +18,7 @@ namespace slang_llvm
 /// recognise, then hands it to the LLJITBuilder. On non-x86_64 hosts (or
 /// without the env var) this is a no-op.
 ///
-/// Prefer `createAVX512SafeLLJIT()` over calling this helper directly: it
+/// Prefer `createSlangLLJIT()` over calling this helper directly: it
 /// pairs the disable step with `LLJITBuilder::create()` so a future caller
 /// can't accidentally construct an LLJIT without the mitigation. See
 /// https://github.com/shader-slang/slang/issues/11062.
@@ -29,18 +29,14 @@ namespace slang_llvm
 /// remove this helper entirely.
 void disableAVX512ForJIT(llvm::orc::LLJITBuilder& jitBuilder);
 
-/// Construct an LLJIT with AVX-512 conditionally disabled in its JIT
-/// TargetMachine. Equivalent to:
-///
-///   LLJITBuilder b;
-///   disableAVX512ForJIT(b);
-///   return b.create();
+/// Construct an LLJIT using Slang's platform configuration.
 ///
 /// `disableAVX512ForJIT` only fires when SLANG_DISABLE_AVX512=1 is set in
-/// the environment; otherwise this is a plain `LLJITBuilder().create()`.
-/// Use this from every LLJIT construction site in slang-llvm so the
-/// mitigation can't be forgotten. See #11062.
-llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> createAVX512SafeLLJIT();
+/// the environment. On Windows x86-64, RuntimeDyld uses one ordered allocation
+/// per object so COFF image-relative relocations always have valid offsets.
+/// Use this from every LLJIT construction site in slang-llvm so neither
+/// configuration can be forgotten.
+llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> createSlangLLJIT();
 
 /* This implementation uses atomic ref counting to ensure the shared libraries lifetime can outlive
 the LLVMDownstreamCompileResult and the compilation that created it */

--- a/source/slang-llvm/slang-llvm.cpp
+++ b/source/slang-llvm/slang-llvm.cpp
@@ -907,7 +907,7 @@ SlangResult LLVMDownstreamCompiler::compile(
                 // from the IR builder JIT path; the wrapper pairs disable
                 // with create() so a future caller can't accidentally
                 // construct an LLJIT with AVX-512 enabled.
-                Expected<std::unique_ptr<llvm::orc::LLJIT>> expectJit = createAVX512SafeLLJIT();
+                Expected<std::unique_ptr<llvm::orc::LLJIT>> expectJit = createSlangLLJIT();
                 if (!expectJit)
                 {
                     /* JS: NOTE!


### PR DESCRIPTION
Fixes #12283

## Motivation

Consider a Debug test run that uses several long-lived `test-server.exe` workers. A worker can
terminate while compiling an otherwise valid LLVM target, and the test that appears to trigger the
termination changes between runs. The crash is an intentional LLVM abort with this diagnostic:

```text
IMAGE_REL_AMD64_ADDR32NB relocation requires an ordered section layout
```

LLVM 21's default `LLJIT` creates an `RTDyldObjectLinkingLayer` with a separate
`SectionMemoryManager` for every object. On Windows, that manager requests independent virtual-memory
regions for code, read-only data, and writable data. If Windows cannot satisfy a near-allocation
hint, it may place a later region below the first one. An `IMAGE_REL_AMD64_ADDR32NB` relocation
cannot encode that layout because it stores an unsigned 32-bit offset from the image base.

## Proposed solution

Keep Slang's existing RuntimeDyld linker and replace only its 64-bit Windows allocation policy.
`OrderedRTDyldMemoryManager` uses RuntimeDyld's allocation-reservation callback to obtain the
complete requirements for one object, reserves one contiguous mapping, and lays out code,
read-only data, and writable data in increasing address order. It applies the final page
permissions after relocation and rejects objects that cannot fit in the COFF 32-bit image-relative
range. The policy applies to both x86-64 and ARM64 hosts because both COFF architectures use
32-bit image-relative relocations.
A compile-time guard rejects LLVM 23 and later so the upgrade removes this workaround and uses LLJIT’s new default JITLink path instead.

This fixes the invalid memory layout at its construction boundary. It does not suppress LLVM's
relocation check, retry a failed test, or change valid COFF input into a different representation.

## Change summary

- `OrderedRTDyldMemoryManager` in
  `source/slang-llvm/slang-llvm-jit-shared-library.cpp:24` reserves, allocates, protects, and releases
  one ordered mapping for each RuntimeDyld object.
- `configureRTDyldForWindows64` in
  `source/slang-llvm/slang-llvm-jit-shared-library.cpp:253` installs that manager while preserving
  LLVM's existing COFF symbol-flag behavior.
- `createSlangLLJIT` in
  `source/slang-llvm/slang-llvm-jit-shared-library.cpp:282` centralizes both the existing optional
  AVX-512 mitigation and the Windows RuntimeDyld configuration.
- The downstream compiler and IR-builder JIT construction sites now call `createSlangLLJIT` in
  `source/slang-llvm/slang-llvm.cpp:910` and
  `source/slang-llvm/slang-llvm-builder.cpp:2328`.

## Concepts and vocabulary

- **ADDR32NB** — a COFF relocation used by AMD64 and ARM64 whose value is an unsigned 32-bit address
  relative to the image base. Its target must be at or above that base and within the first 4 GiB
  of the image.
- **RuntimeDyld** — LLVM's runtime object linker used by Slang's current `LLJIT` configuration.
- **Allocation reservation** — RuntimeDyld's pre-allocation callback that reports upper bounds for
  all code, read-only-data, and writable-data sections, including section padding, stubs, GOT
  entries, and common symbols.

## Process report

The failure initially looked correlated with individual tests and server count, but the crashing
test varied. The stable evidence came from the worker crash dump: LLVM called its fatal-error
handler while applying an `IMAGE_REL_AMD64_ADDR32NB` relocation. The AVX-512 workaround is a
different path—it changes generated instructions to avoid an illegal-instruction fault, whereas
this failure occurs while linking an object and ends in an explicit LLVM abort.

`RuntimeDyldImpl::computeTotalAllocSize` computes the complete upper bound for each allocation
category before it loads the object. `OrderedRTDyldMemoryManager::reserveAllocationSpace` consumes
those bounds and constructs the layout once. Each later `allocateCodeSection` or
`allocateDataSection` request advances a cursor only within its reserved segment. Because the
segments share one mapping in code/read-only/writable order, every valid image-relative target has a
non-negative offset from the code image base.

The input-shape check belongs at this layer. The COFF object and its `ADDR32NB` relocation are valid;
the accidental alternative shape is the unordered set of virtual-memory allocations produced by
the default `SectionMemoryManager` after a Windows near-allocation fallback. The producer of that
shape is the memory manager, so the fix replaces its Windows allocation policy rather than adding a
special case to relocation application or code generation.

The manager aligns segment boundaries for both page protection and the maximum requested section
alignment. It bounds each layout step by `UINT32_MAX`, which matches the relocation's representable
range, and reports allocation or capacity errors through RuntimeDyld's existing finalization
contract. Finalization changes code pages to read/execute and read-only-data pages to read-only,
leaves writable data writable, and invalidates the instruction cache before execution.

Switching the entire Windows path to JITLink was considered, but that changes the linker and its
runtime behavior in addition to the faulty allocation policy. Retaining RuntimeDyld keeps existing
symbol resolution, COFF handling, and unwind registration intact while correcting the specific
producer invariant.

## Reviewer Directives (maintained by agent)

- [human @juliusikkala] Remove the ordered RuntimeDyld workaround when upgrading to LLVM 23 or later; LLJIT uses JITLink and InProcessMemoryManager by default there. (https://github.com/shader-slang/slang/pull/12293#pullrequestreview-4820879936)