### PR TITLE
Classify PR Source from the source-internal org team

### DIFF
--- a/.github/pr-board-sync-templates/README.md
+++ b/.github/pr-board-sync-templates/README.md
@@ -25,14 +25,15 @@ the reference for what slang runs.
 | `example-pr-maintenance.yml` | `.github/workflows/pr-maintenance.yml` | no | PR lifecycle + reviews (`pull_request_target`, `pull_request_review`, `check_suite`). |
 | `example-pr-checks-complete.yml` | `.github/workflows/pr-checks-complete.yml` | **yes** — list this repo's workflow names | CI / gating-check results via `workflow_run` (Actions CI does not emit usable `check_suite`). |
 | `example-pr-commit-status.yml` | `.github/workflows/pr-commit-status.yml` | no | External commit statuses via the `status` event. |
+| `example-pr-sweep-nightly.yml` | `.github/workflows/pr-sweep-nightly.yml` | no | Nightly / on-demand sweep of every open PR in this repo (`mode: sweep`). |
 | `example-pr-review-fork-bridge.yml` | `.github/workflows/pr-review-fork-bridge.yml` | no | Optional: stage 1 of the real-time fork-PR review relay. |
 | `example-pr-review-fork-apply.yml` | `.github/workflows/pr-review-fork-apply.yml` | no | Optional: stage 2 (privileged) of the fork-PR review relay. |
 
 ## Onboarding a repo
 
-1. Copy `example-pr-maintenance.yml`, `example-pr-commit-status.yml`, and
-   `example-pr-checks-complete.yml` into the repo's `.github/workflows/`
-   (dropping the `example-` prefix).
+1. Copy `example-pr-maintenance.yml`, `example-pr-commit-status.yml`,
+   `example-pr-checks-complete.yml`, and `example-pr-sweep-nightly.yml` into the
+   repo's `.github/workflows/` (dropping the `example-` prefix).
 2. In `pr-checks-complete.yml`, replace the `workflows:` list with **this repo's**
    gating workflow `name:`s (at minimum its CI workflow). `workflow_run` can only
    reference workflows in the same repo, by name. Do **not** list the board-sync's
@@ -45,9 +46,11 @@ the reference for what slang runs.
    secret; the reusable workflow uses it for every call, so callers should keep
    `permissions: {}` to drop the unused `GITHUB_TOKEN` scopes.
 
-The nightly sweep (`pr-sweep-nightly.yml`, `mode: sweep`) remains the idempotent
+The nightly sweep (`pr-sweep-nightly.yml`, `mode: sweep`) is the idempotent
 backstop for anything the per-event path cannot see (missed webhooks, failed runs,
-post-hoc issue links, board drift). See
+post-hoc issue links, board drift). Each consuming repo needs its own copy: the
+reusable workflow sweeps `context.repo` of the **caller**, so a schedule in
+slangpy reconciles slangpy's open PRs, not slang's. See
 [`../workflows/pr-board-sync.md`](../workflows/pr-board-sync.md) for the full
 architecture.
 

--- a/.github/pr-board-sync-templates/example-pr-maintenance.yml
+++ b/.github/pr-board-sync-templates/example-pr-maintenance.yml
@@ -10,6 +10,7 @@ name: PR Maintenance
 # Pair this with the other example callers in this directory for full coverage:
 #   - example-pr-checks-complete.yml  CI / gating-check results -> board
 #   - example-pr-commit-status.yml    external commit statuses -> board
+#   - example-pr-sweep-nightly.yml    nightly / on-demand sweep of open PRs
 #   - example-pr-review-fork-bridge.yml + example-pr-review-fork-apply.yml
 #                                     real-time fork-PR review handling
 #

--- a/.github/pr-board-sync-templates/example-pr-sweep-nightly.yml
+++ b/.github/pr-board-sync-templates/example-pr-sweep-nightly.yml
@@ -1,0 +1,31 @@
+name: PR Board Sweep (nightly)
+
+# Scheduled cadence caller for the reusable board-sync workflow in "sweep" mode.
+# Copy to `.github/workflows/pr-sweep-nightly.yml`.
+#
+# Reconciles every open PR in THIS repo onto the shared "Slang PR Tracking"
+# board. It is the periodic backstop for what the per-event path
+# (pr-maintenance.yml and the other callers) cannot see -- missed webhooks or
+# failed runs, an issue assigned/linked after the fact, board drift -- and
+# shares all per-PR logic with them (only the enumeration differs).
+#
+# Cross-repo safe: the reusable workflow reads `context.repo` of the CALLER, so
+# this schedule in slangpy / slang-rhi / etc. sweeps that repo's open PRs, not
+# slang's. No per-repo customization needed beyond copying the file.
+#
+# Generic -- copy verbatim. (workflow_dispatch allows on-demand runs.)
+
+on:
+  schedule:
+    - cron: "0 7 * * *" # nightly ~07:00 UTC (GitHub may delay under load)
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  board-sweep:
+    uses: shader-slang/slang/.github/workflows/pr-board-sync.yml@master
+    with:
+      mode: sweep
+    secrets:
+      SLANG_PR_BOT_TOKEN: ${{ secrets.SLANG_PR_BOT_TOKEN }}

--- a/.github/scripts/pr-classify.test.js
+++ b/.github/scripts/pr-classify.test.js
@@ -1,5 +1,5 @@
 // Unit tests for Source classification, run against the reconcile copy INLINED
-// in pr-board-sync.yml and extracted at run time. The opened/reopened copy is
+// in pr-board-sync.yml and extracted at run time. The opened/reopened copies are
 // extracted separately and required to contain byte-identical functions.
 // No deps; run with: node .github/scripts/pr-classify.test.js
 "use strict";
@@ -14,6 +14,22 @@ const reconcile = extractor.load({
 const onboarding = extractor.load({
   workflow,
   block: "classify-onboarding",
+});
+const reconcileRoster = extractor.load({
+  workflow,
+  block: "team-roster",
+});
+const onboardingRoster = extractor.load({
+  workflow,
+  block: "team-roster-onboarding",
+});
+const reconcileIndex = extractor.load({
+  workflow,
+  block: "source-internal-index",
+});
+const onboardingIndex = extractor.load({
+  workflow,
+  block: "source-internal-index-onboarding",
 });
 const {
   isInternalLogin,
@@ -33,14 +49,21 @@ const SRC = {
 const tests = [];
 const test = (name, fn) => tests.push([name, fn]);
 
-test("onboarding and reconcile helpers are byte-identical", () => {
-  assert.deepStrictEqual(Object.keys(onboarding).sort(), Object.keys(reconcile).sort());
-  for (const name of Object.keys(reconcile)) {
+function assertByteIdentical(label, a, b) {
+  assert.deepStrictEqual(Object.keys(a).sort(), Object.keys(b).sort(), label);
+  for (const name of Object.keys(a)) {
     assert.strictEqual(
-      onboarding[name].toString(),
-      reconcile[name].toString(),
-      `${name} differs between onboarding and reconcile`);
+      a[name].toString(),
+      b[name].toString(),
+      `${label}: ${name} differs between onboarding and reconcile`,
+    );
   }
+}
+
+test("onboarding and reconcile helpers are byte-identical", () => {
+  assertByteIdentical("classify", onboarding, reconcile);
+  assertByteIdentical("team-roster", onboardingRoster, reconcileRoster);
+  assertByteIdentical("source-internal-index", onboardingIndex, reconcileIndex);
 });
 
 test("isInternalLogin: exact match", () => {
@@ -73,18 +96,22 @@ test("repoShortName", () => {
 test("parseTeamScopeRepos", () => {
   assert.deepStrictEqual(
     parseTeamScopeRepos(
-      "Internal team members. Scope: [slangpy, slangpy-samples]"),
-    ["slangpy", "slangpy-samples"]);
+      "Internal team members. Scope: [slangpy, slangpy-samples]",
+    ),
+    ["slangpy", "slangpy-samples"],
+  );
   assert.deepStrictEqual(
     parseTeamScopeRepos("Scope: [shader-slang/slang-rhi]"),
-    ["slang-rhi"]);
+    ["slang-rhi"],
+  );
   assert.deepStrictEqual(
-    parseTeamScopeRepos(
-      "Internal. Scope: [slangpy] Contact: alice, bob"),
-    ["slangpy"]);
+    parseTeamScopeRepos("Internal. Scope: [slangpy] Contact: alice, bob"),
+    ["slangpy"],
+  );
   assert.deepStrictEqual(
     parseTeamScopeRepos("Scope: slangpy, slangpy-samples"),
-    []);
+    [],
+  );
   assert.deepStrictEqual(parseTeamScopeRepos("no scope here"), []);
   assert.deepStrictEqual(parseTeamScopeRepos(""), []);
 });
@@ -111,19 +138,25 @@ test("parseTeamScopeRepos: space before colon is not accepted", () => {
 test("parseTeamScopeRepos: first Scope: wins", () => {
   assert.deepStrictEqual(
     parseTeamScopeRepos("Scope: [slangpy] Scope: [slang-rhi]"),
-    ["slangpy"]);
+    ["slangpy"],
+  );
 });
 
 test("parseTeamScopeRepos: whitespace inside brackets is fine", () => {
   assert.deepStrictEqual(
     parseTeamScopeRepos("Scope: [ slangpy , slang-rhi ]"),
-    ["slangpy", "slang-rhi"]);
+    ["slangpy", "slang-rhi"],
+  );
 });
 
 test("isSourceInternalFamilySlug", () => {
   assert.ok(isSourceInternalFamilySlug("source-internal", "source-internal"));
-  assert.ok(isSourceInternalFamilySlug("source-internal", "source-internal-slangpy"));
-  assert.ok(!isSourceInternalFamilySlug("source-internal", "source-internally"));
+  assert.ok(
+    isSourceInternalFamilySlug("source-internal", "source-internal-slangpy"),
+  );
+  assert.ok(
+    !isSourceInternalFamilySlug("source-internal", "source-internally"),
+  );
   assert.ok(!isSourceInternalFamilySlug("source-internal", "pr-owners"));
 });
 
@@ -148,13 +181,15 @@ test("internalMembersForRepo: unknown when a covering roster is unreadable", () 
     internalMembersForRepo("shader-slang/slangpy", [
       { repos: null, members: null },
     ]),
-    null);
+    null,
+  );
   assert.strictEqual(
     internalMembersForRepo("shader-slang/slangpy", [
       BASE("alice"),
       { repos: ["slangpy"], members: null },
     ]),
-    null);
+    null,
+  );
 });
 
 test("internalMembersForRepo: an unreadable roster for another repo is ignored", () => {
@@ -177,50 +212,92 @@ test("internalMembersForRepo: no configured team is Community, not unknown", () 
 });
 
 test("classifyAuthorSource: bot short-circuit ignores membership", () => {
-  assert.strictEqual(classifyAuthorSource({
-    isBot: true, login: "alice", members: new Set(["alice"]), ...SRC,
-  }), "Bot");
-  assert.strictEqual(classifyAuthorSource({
-    isBot: true, login: "outsider", members: new Set(), ...SRC,
-  }), "Bot");
+  assert.strictEqual(
+    classifyAuthorSource({
+      isBot: true,
+      login: "alice",
+      members: new Set(["alice"]),
+      ...SRC,
+    }),
+    "Bot",
+  );
+  assert.strictEqual(
+    classifyAuthorSource({
+      isBot: true,
+      login: "outsider",
+      members: new Set(),
+      ...SRC,
+    }),
+    "Bot",
+  );
 });
 
 test("classifyAuthorSource: internal team member", () => {
-  assert.strictEqual(classifyAuthorSource({
-    isBot: false, login: "alice", members: new Set(["alice", "bob"]), ...SRC,
-  }), "Internal");
+  assert.strictEqual(
+    classifyAuthorSource({
+      isBot: false,
+      login: "alice",
+      members: new Set(["alice", "bob"]),
+      ...SRC,
+    }),
+    "Internal",
+  );
 });
 
 test("classifyAuthorSource: non-member is Community", () => {
-  assert.strictEqual(classifyAuthorSource({
-    isBot: false, login: "outsider", members: new Set(["alice"]), ...SRC,
-  }), "Community");
+  assert.strictEqual(
+    classifyAuthorSource({
+      isBot: false,
+      login: "outsider",
+      members: new Set(["alice"]),
+      ...SRC,
+    }),
+    "Community",
+  );
 });
 
 test("classifyAuthorSource: empty members is Community", () => {
   // A successful read of a family nobody is on (e.g. no team configured).
-  assert.strictEqual(classifyAuthorSource({
-    isBot: false, login: "alice", members: new Set(), ...SRC,
-  }), "Community");
+  assert.strictEqual(
+    classifyAuthorSource({
+      isBot: false,
+      login: "alice",
+      members: new Set(),
+      ...SRC,
+    }),
+    "Community",
+  );
 });
 
 test("classifyAuthorSource: unknown membership yields no Source", () => {
   // internalMembersForRepo returned null (unreadable roster). The caller must
   // leave Source unset rather than persist a transient error as Community.
-  assert.strictEqual(classifyAuthorSource({
-    isBot: false, login: "alice", members: null, ...SRC,
-  }), null);
-  assert.strictEqual(classifyAuthorSource({
-    isBot: false, login: "alice", members: undefined, ...SRC,
-  }), null);
+  assert.strictEqual(
+    classifyAuthorSource({
+      isBot: false,
+      login: "alice",
+      members: null,
+      ...SRC,
+    }),
+    null,
+  );
+  assert.strictEqual(
+    classifyAuthorSource({
+      isBot: false,
+      login: "alice",
+      members: undefined,
+      ...SRC,
+    }),
+    null,
+  );
 });
 
 test("parseTeamScopeRepos: owner is stripped; short-name matching is cross-org", () => {
   // Scope: [otherorg/slangpy] is stored as "slangpy", so it matches
   // shader-slang/slangpy. Owners in Scope entries are never meaningful.
-  assert.deepStrictEqual(
-    parseTeamScopeRepos("Scope: [otherorg/slangpy]"),
-    ["slangpy"]);
+  assert.deepStrictEqual(parseTeamScopeRepos("Scope: [otherorg/slangpy]"), [
+    "slangpy",
+  ]);
   const members = internalMembersForRepo("shader-slang/slangpy", [
     BASE("alice"),
     { repos: ["slangpy"], members: new Set(["bob"]) },
@@ -229,30 +306,119 @@ test("parseTeamScopeRepos: owner is stripped; short-name matching is cross-org",
 });
 
 test("classifyAuthorSource: a bot stays Bot when membership is unknown", () => {
-  assert.strictEqual(classifyAuthorSource({
-    isBot: true, login: "dependabot", members: null, ...SRC,
-  }), "Bot");
+  assert.strictEqual(
+    classifyAuthorSource({
+      isBot: true,
+      login: "dependabot",
+      members: null,
+      ...SRC,
+    }),
+    "Bot",
+  );
+});
+
+// --- source-internal family assembly ----------------------------------------
+const { loadSourceInternalIndex } = reconcileIndex;
+
+function sourceIndex({
+  teamSpec = "shader-slang/source-internal",
+  teams = [],
+  members = {},
+  unreadableTeams = false,
+} = {}) {
+  const warnings = [];
+  return {
+    warnings,
+    load: () =>
+      loadSourceInternalIndex({
+        teamSpec,
+        listOrgTeams: async () => (unreadableTeams ? null : teams),
+        tryListTeamMembers: async (spec) =>
+          Object.hasOwn(members, spec) ? members[spec] : new Set(),
+        warnOnce: (message) => warnings.push(message),
+        parseTeamScopeRepos,
+        isSourceInternalFamilySlug,
+      }),
+  };
+}
+
+test("loadSourceInternalIndex: no configured team is an empty family", async () => {
+  const s = sourceIndex({ teamSpec: "" });
+  assert.deepStrictEqual(await s.load(), []);
+});
+
+test("loadSourceInternalIndex: unreadable team listing is unknown", async () => {
+  const s = sourceIndex({ unreadableTeams: true });
+  assert.strictEqual(await s.load(), null);
+});
+
+test("loadSourceInternalIndex: absent base team is unknown and warned", async () => {
+  const s = sourceIndex({
+    teams: [
+      { slug: "source-internal-slangpy", description: "Scope: [slangpy]" },
+    ],
+  });
+  assert.strictEqual(await s.load(), null);
+  assert.ok(
+    s.warnings.some(
+      (w) =>
+        w.includes("source-internal") && w.includes("leaving Source unset"),
+    ),
+  );
+});
+
+test("loadSourceInternalIndex: assembles base and scoped sibling", async () => {
+  const base = new Set(["alice"]);
+  const scoped = new Set(["bob"]);
+  const s = sourceIndex({
+    teams: [
+      { slug: "source-internal", description: "" },
+      { slug: "source-internal-slangpy", description: "Scope: [slangpy]" },
+      { slug: "unrelated", description: "Scope: [slangpy]" },
+    ],
+    members: {
+      "shader-slang/source-internal": base,
+      "shader-slang/source-internal-slangpy": scoped,
+    },
+  });
+  assert.deepStrictEqual(await s.load(), [
+    { repos: null, members: base },
+    { repos: ["slangpy"], members: scoped },
+  ]);
+});
+
+test("loadSourceInternalIndex: ignores and warns on unscoped sibling", async () => {
+  const s = sourceIndex({
+    teams: [
+      { slug: "source-internal", description: "" },
+      { slug: "source-internal-slangpy", description: "no scope" },
+    ],
+  });
+  assert.deepStrictEqual(await s.load(), [{ repos: null, members: new Set() }]);
+  assert.ok(s.warnings.some((w) => w.includes("has no 'Scope:")));
 });
 
 // --- team-roster cache (fake paginate, like pr-signal countingGh) -----------
-const { createTeamReadCache } = extractor.load({
-  workflow,
-  block: "team-roster",
-});
+const { createTeamReadCache } = reconcileRoster;
 
 function roster({
   teams = [],
   members = {},
   failTeams = false,
   failMembers = {},
+  failMemberAttempts = {},
   maxAttempts = 2,
+  baseDelayMs = 1000,
 } = {}) {
   const warnings = [];
+  const sleepDelays = [];
   let teamCalls = 0;
   const memberCalls = {};
   const cache = createTeamReadCache({
     maxAttempts,
+    baseDelayMs,
     warn: (m) => warnings.push(m),
+    sleep: async (ms) => sleepDelays.push(ms),
     paginateTeams: async () => {
       teamCalls++;
       if (failTeams) throw { status: 403 };
@@ -261,11 +427,24 @@ function roster({
     paginateMembers: async ({ org, team_slug }) => {
       const key = `${org}/${team_slug}`;
       memberCalls[key] = (memberCalls[key] || 0) + 1;
-      if (failMembers[key]) throw { status: failMembers[key] };
+      if (
+        failMembers[key] &&
+        memberCalls[key] <= (failMemberAttempts[key] ?? Infinity)
+      ) {
+        throw { status: failMembers[key] };
+      }
       return (members[key] || []).map((login) => ({ login }));
     },
   });
-  return { ...cache, warnings, get teamCalls() { return teamCalls; }, memberCalls };
+  return {
+    ...cache,
+    warnings,
+    sleepDelays,
+    get teamCalls() {
+      return teamCalls;
+    },
+    memberCalls,
+  };
 }
 
 test("tryListTeamMembers: bare slug is empty Set, not null", async () => {
@@ -276,9 +455,12 @@ test("tryListTeamMembers: bare slug is empty Set, not null", async () => {
   assert.deepStrictEqual(r.memberCalls, {});
 });
 
-test("tryListTeamMembers: failed read is null", async () => {
-  const r = roster({ failMembers: { "o/t": 403 } });
+test("tryListTeamMembers: exhausted read is null and cached", async () => {
+  const r = roster({ failMembers: { "o/t": 403 }, maxAttempts: 3 });
   assert.strictEqual(await r.tryListTeamMembers("o/t"), null);
+  assert.strictEqual(await r.tryListTeamMembers("o/t"), null);
+  assert.strictEqual(r.memberCalls["o/t"], 3);
+  assert.deepStrictEqual(r.sleepDelays, [1000, 2000]);
   assert.ok(r.warnings.some((w) => w.includes("o/t")));
 });
 
@@ -289,12 +471,24 @@ test("tryListTeamMembers: success is cached", async () => {
   assert.strictEqual(r.memberCalls["o/t"], 1);
 });
 
-test("tryListTeamMembers: attempt budget is exactly maxAttempts", async () => {
+test("tryListTeamMembers: retries inside one call until maxAttempts", async () => {
   const r = roster({ failMembers: { "o/t": 500 }, maxAttempts: 2 });
   assert.strictEqual(await r.tryListTeamMembers("o/t"), null);
-  assert.strictEqual(await r.tryListTeamMembers("o/t"), null);
-  assert.strictEqual(await r.tryListTeamMembers("o/t"), null); // budget spent
   assert.strictEqual(r.memberCalls["o/t"], 2);
+  assert.deepStrictEqual(r.sleepDelays, [1000]);
+});
+
+test("tryListTeamMembers: transient failure recovers and caches success", async () => {
+  const r = roster({
+    members: { "o/t": ["alice"] },
+    failMembers: { "o/t": 500 },
+    failMemberAttempts: { "o/t": 1 },
+    maxAttempts: 3,
+  });
+  assert.ok(isInternalLogin("alice", await r.tryListTeamMembers("o/t")));
+  assert.ok(isInternalLogin("alice", await r.tryListTeamMembers("o/t")));
+  assert.strictEqual(r.memberCalls["o/t"], 2);
+  assert.deepStrictEqual(r.sleepDelays, [1000]);
 });
 
 test("listTeamMembers: null becomes empty Set for owner pools", async () => {
@@ -304,7 +498,7 @@ test("listTeamMembers: null becomes empty Set for owner pools", async () => {
   assert.strictEqual(set.size, 0);
 });
 
-test("listOrgTeams: caches success and budgets failures", async () => {
+test("listOrgTeams: caches success and exhausted failure", async () => {
   const ok = roster({ teams: [{ slug: "source-internal" }] });
   assert.strictEqual((await ok.listOrgTeams("o")).length, 1);
   assert.strictEqual((await ok.listOrgTeams("o")).length, 1);
@@ -315,6 +509,7 @@ test("listOrgTeams: caches success and budgets failures", async () => {
   assert.strictEqual(await bad.listOrgTeams("o"), null);
   assert.strictEqual(await bad.listOrgTeams("o"), null);
   assert.strictEqual(bad.teamCalls, 2);
+  assert.deepStrictEqual(bad.sleepDelays, [1000]);
 });
 
 test("warnOnce only emits once", () => {
@@ -326,10 +521,16 @@ test("warnOnce only emits once", () => {
 });
 
 (async () => {
-  let passed = 0, failed = 0;
+  let passed = 0,
+    failed = 0;
   for (const [name, fn] of tests) {
-    try { await fn(); passed++; }
-    catch (e) { failed++; console.error(`FAIL: ${name}\n  ${(e && e.stack) || e}`); }
+    try {
+      await fn();
+      passed++;
+    } catch (e) {
+      failed++;
+      console.error(`FAIL: ${name}\n  ${(e && e.stack) || e}`);
+    }
   }
   console.log(`${passed} passed, ${failed} failed`);
   process.exit(failed ? 1 : 0);

--- a/.github/scripts/pr-classify.test.js
+++ b/.github/scripts/pr-classify.test.js
@@ -55,11 +55,18 @@ test("repoShortName", () => {
 test("parseTeamScopeRepos", () => {
   assert.deepStrictEqual(
     parseTeamScopeRepos(
-      "Internal team members. Scope: slangpy, slangpy-samples"),
+      "Internal team members. Scope: [slangpy, slangpy-samples]"),
     ["slangpy", "slangpy-samples"]);
   assert.deepStrictEqual(
-    parseTeamScopeRepos("Scope: shader-slang/slang-rhi"),
+    parseTeamScopeRepos("Scope: [shader-slang/slang-rhi]"),
     ["slang-rhi"]);
+  assert.deepStrictEqual(
+    parseTeamScopeRepos(
+      "Internal. Scope: [slangpy] Contact: alice, bob"),
+    ["slangpy"]);
+  assert.deepStrictEqual(
+    parseTeamScopeRepos("Scope: slangpy, slangpy-samples"),
+    []);
   assert.deepStrictEqual(parseTeamScopeRepos("no scope here"), []);
   assert.deepStrictEqual(parseTeamScopeRepos(""), []);
 });
@@ -71,17 +78,53 @@ test("isSourceInternalFamilySlug", () => {
   assert.ok(!isSourceInternalFamilySlug("source-internal", "pr-owners"));
 });
 
+// The base team is the entry with repos === null (it covers every repo); every
+// other entry covers only the repos its Scope: listed. members === null is a
+// team whose roster could not be read.
+const BASE = (...logins) => ({ repos: null, members: new Set(logins) });
+
 test("internalMembersForRepo unions base and matching scoped teams", () => {
-  const members = internalMembersForRepo(
-    "shader-slang/slangpy",
-    new Set(["alice"]),
-    [
-      { repos: ["slangpy", "slangpy-samples"], members: new Set(["bob"]) },
-      { repos: ["slang-rhi"], members: new Set(["carol"]) },
-    ]);
+  const members = internalMembersForRepo("shader-slang/slangpy", [
+    BASE("alice"),
+    { repos: ["slangpy", "slangpy-samples"], members: new Set(["bob"]) },
+    { repos: ["slang-rhi"], members: new Set(["carol"]) },
+  ]);
   assert.ok(isInternalLogin("alice", members));
   assert.ok(isInternalLogin("bob", members));
   assert.ok(!isInternalLogin("carol", members));
+});
+
+test("internalMembersForRepo: unknown when a covering roster is unreadable", () => {
+  assert.strictEqual(
+    internalMembersForRepo("shader-slang/slangpy", [
+      { repos: null, members: null },
+    ]),
+    null);
+  assert.strictEqual(
+    internalMembersForRepo("shader-slang/slangpy", [
+      BASE("alice"),
+      { repos: ["slangpy"], members: null },
+    ]),
+    null);
+});
+
+test("internalMembersForRepo: an unreadable roster for another repo is ignored", () => {
+  const members = internalMembersForRepo("shader-slang/slangpy", [
+    BASE("alice"),
+    { repos: ["slang-rhi"], members: null },
+  ]);
+  assert.ok(isInternalLogin("alice", members));
+  assert.ok(!isInternalLogin("carol", members));
+});
+
+test("internalMembersForRepo: unknown when the family itself is unreadable", () => {
+  assert.strictEqual(internalMembersForRepo("shader-slang/slang", null), null);
+});
+
+test("internalMembersForRepo: no configured team is Community, not unknown", () => {
+  const members = internalMembersForRepo("shader-slang/slang", []);
+  assert.ok(members);
+  assert.ok(!isInternalLogin("alice", members));
 });
 
 test("classifyAuthorSource: bot short-circuit ignores membership", () => {
@@ -105,11 +148,28 @@ test("classifyAuthorSource: non-member is Community", () => {
   }), "Community");
 });
 
-test("classifyAuthorSource: empty members fails safe to Community", () => {
-  // Simulates listTeamMembers returning [] on a read error / unset team.
+test("classifyAuthorSource: empty members is Community", () => {
+  // A successful read of a family nobody is on (e.g. no team configured).
   assert.strictEqual(classifyAuthorSource({
     isBot: false, login: "alice", members: new Set(), ...SRC,
   }), "Community");
+});
+
+test("classifyAuthorSource: unknown membership yields no Source", () => {
+  // internalMembersForRepo returned null (unreadable roster). The caller must
+  // leave Source unset rather than persist a transient error as Community.
+  assert.strictEqual(classifyAuthorSource({
+    isBot: false, login: "alice", members: null, ...SRC,
+  }), null);
+  assert.strictEqual(classifyAuthorSource({
+    isBot: false, login: "alice", members: undefined, ...SRC,
+  }), null);
+});
+
+test("classifyAuthorSource: a bot stays Bot when membership is unknown", () => {
+  assert.strictEqual(classifyAuthorSource({
+    isBot: true, login: "dependabot", members: null, ...SRC,
+  }), "Bot");
 });
 
 (async () => {

--- a/.github/scripts/pr-classify.test.js
+++ b/.github/scripts/pr-classify.test.js
@@ -1,9 +1,20 @@
-// Unit tests for Source classification, run against the copy INLINED in
-// pr-board-sync.yml (the single source of truth), extracted at run time.
+// Unit tests for Source classification, run against the reconcile copy INLINED
+// in pr-board-sync.yml and extracted at run time. The opened/reopened copy is
+// extracted separately and required to contain byte-identical functions.
 // No deps; run with: node .github/scripts/pr-classify.test.js
 "use strict";
 
 const assert = require("node:assert");
+const extractor = require("./extract-workflow-js.js");
+const workflow = ".github/workflows/pr-board-sync.yml";
+const reconcile = extractor.load({
+  workflow,
+  block: "classify",
+});
+const onboarding = extractor.load({
+  workflow,
+  block: "classify-onboarding",
+});
 const {
   isInternalLogin,
   classifyAuthorSource,
@@ -11,10 +22,7 @@ const {
   parseTeamScopeRepos,
   isSourceInternalFamilySlug,
   internalMembersForRepo,
-} = require("./extract-workflow-js.js").load({
-  workflow: ".github/workflows/pr-board-sync.yml",
-  block: "classify",
-});
+} = reconcile;
 
 const SRC = {
   sourceBot: "Bot",
@@ -24,6 +32,16 @@ const SRC = {
 
 const tests = [];
 const test = (name, fn) => tests.push([name, fn]);
+
+test("onboarding and reconcile helpers are byte-identical", () => {
+  assert.deepStrictEqual(Object.keys(onboarding).sort(), Object.keys(reconcile).sort());
+  for (const name of Object.keys(reconcile)) {
+    assert.strictEqual(
+      onboarding[name].toString(),
+      reconcile[name].toString(),
+      `${name} differs between onboarding and reconcile`);
+  }
+});
 
 test("isInternalLogin: exact match", () => {
   assert.ok(isInternalLogin("alice", new Set(["alice", "bob"])));
@@ -69,6 +87,37 @@ test("parseTeamScopeRepos", () => {
     []);
   assert.deepStrictEqual(parseTeamScopeRepos("no scope here"), []);
   assert.deepStrictEqual(parseTeamScopeRepos(""), []);
+});
+
+// Authoritative form is `Scope: [repo, ...]` (no space before the colon).
+// Edges below pin what a team-description author can and cannot write.
+test("parseTeamScopeRepos: case-insensitive label", () => {
+  assert.deepStrictEqual(parseTeamScopeRepos("scope: [slangpy]"), ["slangpy"]);
+  assert.deepStrictEqual(parseTeamScopeRepos("SCOPE: [slangpy]"), ["slangpy"]);
+});
+
+test("parseTeamScopeRepos: empty brackets yield no repos", () => {
+  assert.deepStrictEqual(parseTeamScopeRepos("Scope: []"), []);
+  assert.deepStrictEqual(parseTeamScopeRepos("Scope: [  ]"), []);
+});
+
+test("parseTeamScopeRepos: space before colon is not accepted", () => {
+  // `\bScope:` requires the colon immediately after Scope; a typo like
+  // "Scope : [...]" must not silently match (warn path covers missing Scope).
+  assert.deepStrictEqual(parseTeamScopeRepos("Scope : [slangpy]"), []);
+  assert.deepStrictEqual(parseTeamScopeRepos("Scope :[slangpy]"), []);
+});
+
+test("parseTeamScopeRepos: first Scope: wins", () => {
+  assert.deepStrictEqual(
+    parseTeamScopeRepos("Scope: [slangpy] Scope: [slang-rhi]"),
+    ["slangpy"]);
+});
+
+test("parseTeamScopeRepos: whitespace inside brackets is fine", () => {
+  assert.deepStrictEqual(
+    parseTeamScopeRepos("Scope: [ slangpy , slang-rhi ]"),
+    ["slangpy", "slang-rhi"]);
 });
 
 test("isSourceInternalFamilySlug", () => {

--- a/.github/scripts/pr-classify.test.js
+++ b/.github/scripts/pr-classify.test.js
@@ -398,6 +398,21 @@ test("loadSourceInternalIndex: ignores and warns on unscoped sibling", async () 
   assert.ok(s.warnings.some((w) => w.includes("has no 'Scope:")));
 });
 
+test("loadSourceInternalIndex: unreadable base roster keeps null members", async () => {
+  // Listing succeeds but the base roster read fails: the family still includes
+  // the base entry so internalMembersForRepo can poison the result to unknown
+  // instead of treating "no covering members" as Community.
+  const s = sourceIndex({
+    teams: [{ slug: "source-internal", description: "" }],
+    members: { "shader-slang/source-internal": null },
+  });
+  assert.deepStrictEqual(await s.load(), [{ repos: null, members: null }]);
+  assert.strictEqual(
+    internalMembersForRepo("shader-slang/slang", await s.load()),
+    null,
+  );
+});
+
 // --- team-roster cache (fake paginate, like pr-signal countingGh) -----------
 const { createTeamReadCache } = reconcileRoster;
 

--- a/.github/scripts/pr-classify.test.js
+++ b/.github/scripts/pr-classify.test.js
@@ -1,0 +1,78 @@
+// Unit tests for Source classification, run against the copy INLINED in
+// pr-board-sync.yml (the single source of truth), extracted at run time.
+// No deps; run with: node .github/scripts/pr-classify.test.js
+"use strict";
+
+const assert = require("node:assert");
+const { isInternalLogin, classifyAuthorSource } = require("./extract-workflow-js.js").load({
+  workflow: ".github/workflows/pr-board-sync.yml",
+  block: "classify",
+});
+
+const SRC = {
+  sourceBot: "Bot",
+  sourceInternal: "Internal",
+  sourceCommunity: "Community",
+};
+
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+test("isInternalLogin: exact match", () => {
+  assert.ok(isInternalLogin("alice", new Set(["alice", "bob"])));
+  assert.ok(!isInternalLogin("carol", new Set(["alice", "bob"])));
+});
+
+test("isInternalLogin: case-insensitive", () => {
+  assert.ok(isInternalLogin("Alice", new Set(["alice"])));
+  assert.ok(isInternalLogin("alice", new Set(["Alice"])));
+});
+
+test("isInternalLogin: empty / missing", () => {
+  assert.ok(!isInternalLogin("", new Set(["alice"])));
+  assert.ok(!isInternalLogin(null, new Set(["alice"])));
+  assert.ok(!isInternalLogin("alice", null));
+  assert.ok(!isInternalLogin("alice", new Set()));
+});
+
+test("isInternalLogin: accepts Array members", () => {
+  assert.ok(isInternalLogin("bob", ["alice", "bob"]));
+});
+
+test("classifyAuthorSource: bot short-circuit ignores membership", () => {
+  assert.strictEqual(classifyAuthorSource({
+    isBot: true, login: "alice", members: new Set(["alice"]), ...SRC,
+  }), "Bot");
+  assert.strictEqual(classifyAuthorSource({
+    isBot: true, login: "outsider", members: new Set(), ...SRC,
+  }), "Bot");
+});
+
+test("classifyAuthorSource: internal team member", () => {
+  assert.strictEqual(classifyAuthorSource({
+    isBot: false, login: "alice", members: new Set(["alice", "bob"]), ...SRC,
+  }), "Internal");
+});
+
+test("classifyAuthorSource: non-member is Community", () => {
+  assert.strictEqual(classifyAuthorSource({
+    isBot: false, login: "outsider", members: new Set(["alice"]), ...SRC,
+  }), "Community");
+});
+
+test("classifyAuthorSource: empty members fails safe to Community", () => {
+  // Simulates listTeamMembers returning [] on a read error / unset team.
+  assert.strictEqual(classifyAuthorSource({
+    isBot: false, login: "alice", members: new Set(), ...SRC,
+  }), "Community");
+});
+
+(async () => {
+  let passed = 0, failed = 0;
+  for (const [name, fn] of tests) {
+    try { await fn(); passed++; }
+    catch (e) { failed++; console.error(`FAIL: ${name}\n  ${(e && e.stack) || e}`); }
+  }
+  console.log(`${passed} passed, ${failed} failed`);
+  process.exit(failed ? 1 : 0);
+})();

--- a/.github/scripts/pr-classify.test.js
+++ b/.github/scripts/pr-classify.test.js
@@ -215,10 +215,114 @@ test("classifyAuthorSource: unknown membership yields no Source", () => {
   }), null);
 });
 
+test("parseTeamScopeRepos: owner is stripped; short-name matching is cross-org", () => {
+  // Scope: [otherorg/slangpy] is stored as "slangpy", so it matches
+  // shader-slang/slangpy. Owners in Scope entries are never meaningful.
+  assert.deepStrictEqual(
+    parseTeamScopeRepos("Scope: [otherorg/slangpy]"),
+    ["slangpy"]);
+  const members = internalMembersForRepo("shader-slang/slangpy", [
+    BASE("alice"),
+    { repos: ["slangpy"], members: new Set(["bob"]) },
+  ]);
+  assert.ok(isInternalLogin("bob", members));
+});
+
 test("classifyAuthorSource: a bot stays Bot when membership is unknown", () => {
   assert.strictEqual(classifyAuthorSource({
     isBot: true, login: "dependabot", members: null, ...SRC,
   }), "Bot");
+});
+
+// --- team-roster cache (fake paginate, like pr-signal countingGh) -----------
+const { createTeamReadCache } = extractor.load({
+  workflow,
+  block: "team-roster",
+});
+
+function roster({
+  teams = [],
+  members = {},
+  failTeams = false,
+  failMembers = {},
+  maxAttempts = 2,
+} = {}) {
+  const warnings = [];
+  let teamCalls = 0;
+  const memberCalls = {};
+  const cache = createTeamReadCache({
+    maxAttempts,
+    warn: (m) => warnings.push(m),
+    paginateTeams: async () => {
+      teamCalls++;
+      if (failTeams) throw { status: 403 };
+      return teams;
+    },
+    paginateMembers: async ({ org, team_slug }) => {
+      const key = `${org}/${team_slug}`;
+      memberCalls[key] = (memberCalls[key] || 0) + 1;
+      if (failMembers[key]) throw { status: failMembers[key] };
+      return (members[key] || []).map((login) => ({ login }));
+    },
+  });
+  return { ...cache, warnings, get teamCalls() { return teamCalls; }, memberCalls };
+}
+
+test("tryListTeamMembers: bare slug is empty Set, not null", async () => {
+  const r = roster();
+  const set = await r.tryListTeamMembers("bare");
+  assert.ok(set instanceof Set);
+  assert.strictEqual(set.size, 0);
+  assert.deepStrictEqual(r.memberCalls, {});
+});
+
+test("tryListTeamMembers: failed read is null", async () => {
+  const r = roster({ failMembers: { "o/t": 403 } });
+  assert.strictEqual(await r.tryListTeamMembers("o/t"), null);
+  assert.ok(r.warnings.some((w) => w.includes("o/t")));
+});
+
+test("tryListTeamMembers: success is cached", async () => {
+  const r = roster({ members: { "o/t": ["alice"] } });
+  assert.ok(isInternalLogin("alice", await r.tryListTeamMembers("o/t")));
+  assert.ok(isInternalLogin("alice", await r.tryListTeamMembers("o/t")));
+  assert.strictEqual(r.memberCalls["o/t"], 1);
+});
+
+test("tryListTeamMembers: attempt budget is exactly maxAttempts", async () => {
+  const r = roster({ failMembers: { "o/t": 500 }, maxAttempts: 2 });
+  assert.strictEqual(await r.tryListTeamMembers("o/t"), null);
+  assert.strictEqual(await r.tryListTeamMembers("o/t"), null);
+  assert.strictEqual(await r.tryListTeamMembers("o/t"), null); // budget spent
+  assert.strictEqual(r.memberCalls["o/t"], 2);
+});
+
+test("listTeamMembers: null becomes empty Set for owner pools", async () => {
+  const r = roster({ failMembers: { "o/owners": 403 } });
+  const set = await r.listTeamMembers("o/owners");
+  assert.ok(set instanceof Set);
+  assert.strictEqual(set.size, 0);
+});
+
+test("listOrgTeams: caches success and budgets failures", async () => {
+  const ok = roster({ teams: [{ slug: "source-internal" }] });
+  assert.strictEqual((await ok.listOrgTeams("o")).length, 1);
+  assert.strictEqual((await ok.listOrgTeams("o")).length, 1);
+  assert.strictEqual(ok.teamCalls, 1);
+
+  const bad = roster({ failTeams: true, maxAttempts: 2 });
+  assert.strictEqual(await bad.listOrgTeams("o"), null);
+  assert.strictEqual(await bad.listOrgTeams("o"), null);
+  assert.strictEqual(await bad.listOrgTeams("o"), null);
+  assert.strictEqual(bad.teamCalls, 2);
+});
+
+test("warnOnce only emits once", () => {
+  const r = roster();
+  r.warnOnce("same");
+  r.warnOnce("same");
+  r.warnOnce("other");
+  assert.deepStrictEqual(r.warnings, ["same", "other"]);
 });
 
 (async () => {

--- a/.github/scripts/pr-classify.test.js
+++ b/.github/scripts/pr-classify.test.js
@@ -4,7 +4,14 @@
 "use strict";
 
 const assert = require("node:assert");
-const { isInternalLogin, classifyAuthorSource } = require("./extract-workflow-js.js").load({
+const {
+  isInternalLogin,
+  classifyAuthorSource,
+  repoShortName,
+  parseTeamScopeRepos,
+  isSourceInternalFamilySlug,
+  internalMembersForRepo,
+} = require("./extract-workflow-js.js").load({
   workflow: ".github/workflows/pr-board-sync.yml",
   block: "classify",
 });
@@ -37,6 +44,44 @@ test("isInternalLogin: empty / missing", () => {
 
 test("isInternalLogin: accepts Array members", () => {
   assert.ok(isInternalLogin("bob", ["alice", "bob"]));
+});
+
+test("repoShortName", () => {
+  assert.strictEqual(repoShortName("shader-slang/slangpy"), "slangpy");
+  assert.strictEqual(repoShortName("slang-rhi"), "slang-rhi");
+  assert.strictEqual(repoShortName(""), "");
+});
+
+test("parseTeamScopeRepos", () => {
+  assert.deepStrictEqual(
+    parseTeamScopeRepos(
+      "Internal team members. Scope: slangpy, slangpy-samples"),
+    ["slangpy", "slangpy-samples"]);
+  assert.deepStrictEqual(
+    parseTeamScopeRepos("Scope: shader-slang/slang-rhi"),
+    ["slang-rhi"]);
+  assert.deepStrictEqual(parseTeamScopeRepos("no scope here"), []);
+  assert.deepStrictEqual(parseTeamScopeRepos(""), []);
+});
+
+test("isSourceInternalFamilySlug", () => {
+  assert.ok(isSourceInternalFamilySlug("source-internal", "source-internal"));
+  assert.ok(isSourceInternalFamilySlug("source-internal", "source-internal-slangpy"));
+  assert.ok(!isSourceInternalFamilySlug("source-internal", "source-internally"));
+  assert.ok(!isSourceInternalFamilySlug("source-internal", "pr-owners"));
+});
+
+test("internalMembersForRepo unions base and matching scoped teams", () => {
+  const members = internalMembersForRepo(
+    "shader-slang/slangpy",
+    new Set(["alice"]),
+    [
+      { repos: ["slangpy", "slangpy-samples"], members: new Set(["bob"]) },
+      { repos: ["slang-rhi"], members: new Set(["carol"]) },
+    ]);
+  assert.ok(isInternalLogin("alice", members));
+  assert.ok(isInternalLogin("bob", members));
+  assert.ok(!isInternalLogin("carol", members));
 });
 
 test("classifyAuthorSource: bot short-circuit ignores membership", () => {

--- a/.github/workflows/pr-board-sync.md
+++ b/.github/workflows/pr-board-sync.md
@@ -17,7 +17,8 @@ For each open PR the workflow:
    bot-author config and membership in `source_internal_team` (default
    `shader-slang/source-internal`; direct or nested), plus sibling teams whose
    slug starts with that base plus `-` (e.g. `source-internal-slangpy`) when
-   their description includes `Scope: [repo1, repo2]` for this repository. Repo
+   their description includes `Scope: [repo1, repo2]` for this repository
+   (bare short names or `owner/repo`; matching is by short name). Repo
    write access is **not** used for Source.
 3. Recomputes **Status** from live PR state (`In Review`, `Revising`, `Snagged`,
    `Approved`, `Done`).

--- a/.github/workflows/pr-board-sync.md
+++ b/.github/workflows/pr-board-sync.md
@@ -86,8 +86,14 @@ In implementation terms:
 - Because that written value is never re-derived, an unreadable team roster
   yields no Source at all (`classifyAuthorSource` returns null and the write is
   skipped, as is assignment, which needs Source) rather than a guessed
-  `Community`. A fully-read team family is cached per run; a partial read is not,
-  so a later PR in the same sweep retries.
+  `Community`.
+- Team reads are cached per run at the API level: the org team listing
+  (`listOrgTeams`) and each roster (`tryListTeamMembers`) are each fetched once
+  on success, so a sweep enumerates teams once and rebuilds the source-internal
+  family in memory per PR. A failed read is not cached — a later PR can recover
+  from a transient error — but each read gets an attempt budget
+  (`MAX_TEAM_READ_ATTEMPTS`) so a persistent failure costs a couple of requests
+  per run instead of one per PR.
 - `computeTarget()` maps observed PR state to Status for event and sweep mode.
 - `Done` is terminal: once the board Status is `Done`, later events leave it
   unchanged.

--- a/.github/workflows/pr-board-sync.md
+++ b/.github/workflows/pr-board-sync.md
@@ -15,8 +15,10 @@ For each open PR the workflow:
 1. Adds the PR to the board (idempotent).
 2. Classifies and sets **Source** (`Internal` / `Community` / `Bot`) from
    bot-author config and membership in `source_internal_team` (default
-   `shader-slang/source-internal`; direct or nested). Repo write access is
-   **not** used for Source.
+   `shader-slang/source-internal`; direct or nested), plus sibling teams whose
+   slug starts with that base plus `-` (e.g. `source-internal-slangpy`) when
+   their description includes `Scope: repo1, repo2` for this repository. Repo
+   write access is **not** used for Source.
 3. Recomputes **Status** from live PR state (`In Review`, `Revising`, `Snagged`,
    `Approved`, `Done`).
 4. Backfills **assignee** and **reviewers** when the PR has no owner yet.

--- a/.github/workflows/pr-board-sync.md
+++ b/.github/workflows/pr-board-sync.md
@@ -13,7 +13,10 @@ for copy-me caller templates.
 For each open PR the workflow:
 
 1. Adds the PR to the board (idempotent).
-2. Classifies and sets **Source** (`Internal` / `Community` / `Bot`).
+2. Classifies and sets **Source** (`Internal` / `Community` / `Bot`) from
+   bot-author config and membership in `source_internal_team` (default
+   `shader-slang/source-internal`; direct or nested). Repo write access is
+   **not** used for Source.
 3. Recomputes **Status** from live PR state (`In Review`, `Revising`, `Snagged`,
    `Approved`, `Done`).
 4. Backfills **assignee** and **reviewers** when the PR has no owner yet.
@@ -114,12 +117,13 @@ last approver of the introducing PR). A cheap total-LOC pass ranks candidates; a
 per-file LOC tiebreak runs only when the top two are close.
 
 The ranking/selection logic is inlined in `pr-board-sync.yml` (between
-`extract-js:assignment:begin/end` markers). Unit tests extract that block at run
-time:
+`extract-js:assignment:begin/end` markers); Source classification helpers live
+in `extract-js:classify:begin/end`. Unit tests extract those blocks at run time:
 
 ```bash
 node .github/scripts/pr-signal.test.js
 node .github/scripts/pr-assign.test.js
+node .github/scripts/pr-classify.test.js
 ```
 
 ## CI rollup

--- a/.github/workflows/pr-board-sync.md
+++ b/.github/workflows/pr-board-sync.md
@@ -18,8 +18,10 @@ For each open PR the workflow:
    `shader-slang/source-internal`; direct or nested), plus sibling teams whose
    slug starts with that base plus `-` (e.g. `source-internal-slangpy`) when
    their description includes `Scope: [repo1, repo2]` for this repository
-   (bare short names or `owner/repo`; matching is by short name). Repo
-   write access is **not** used for Source.
+   (bare short names or `owner/repo`; matching is by short name). Write
+   `Scope: [...]` with no space before the colon; the label is
+   case-insensitive and the first `Scope:` wins. Repo write access is **not**
+   used for Source.
 3. Recomputes **Status** from live PR state (`In Review`, `Revising`, `Snagged`,
    `Approved`, `Done`).
 4. Backfills **assignee** and **reviewers** when the PR has no owner yet.

--- a/.github/workflows/pr-board-sync.md
+++ b/.github/workflows/pr-board-sync.md
@@ -60,14 +60,14 @@ flowchart TB
 
 ### Callers in `shader-slang/slang`
 
-| Workflow | Trigger | Mode | Notes |
-| --- | --- | --- | --- |
-| `pr-maintenance.yml` | `pull_request_target`, origin `pull_request_review`, `check_suite` | event | Fork reviews are skipped here and relayed below. |
-| `pr-ci-complete.yml` | `workflow_run` (gating checks completed) | event | Actions CI does not emit usable `check_suite`. |
-| `pr-commit-status.yml` | `status` (non-pending) | event | External statuses (`SlangPy Tests`, `license/cla`, …). |
-| `pr-sweep-nightly.yml` | `schedule`, `workflow_dispatch` | **sweep** | Reconciles every open PR in the repo. |
-| `pr-review-fork-bridge.yml` | fork `pull_request_review` | relay only | No secrets; completes to trigger apply. |
-| `pr-review-fork-apply.yml` | `workflow_run` (bridge completed) | event | Privileged path for fork reviews. |
+| Workflow                    | Trigger                                                            | Mode       | Notes                                                  |
+| --------------------------- | ------------------------------------------------------------------ | ---------- | ------------------------------------------------------ |
+| `pr-maintenance.yml`        | `pull_request_target`, origin `pull_request_review`, `check_suite` | event      | Fork reviews are skipped here and relayed below.       |
+| `pr-ci-complete.yml`        | `workflow_run` (gating checks completed)                           | event      | Actions CI does not emit usable `check_suite`.         |
+| `pr-commit-status.yml`      | `status` (non-pending)                                             | event      | External statuses (`SlangPy Tests`, `license/cla`, …). |
+| `pr-sweep-nightly.yml`      | `schedule`, `workflow_dispatch`                                    | **sweep**  | Reconciles every open PR in the repo.                  |
+| `pr-review-fork-bridge.yml` | fork `pull_request_review`                                         | relay only | No secrets; completes to trigger apply.                |
+| `pr-review-fork-apply.yml`  | `workflow_run` (bridge completed)                                  | event      | Privileged path for fork reviews.                      |
 
 **Event mode** reconciles the single PR (or PRs for a commit SHA) that triggered
 the run. **Sweep mode** lists every open PR in the repo and runs the same per-PR
@@ -88,13 +88,12 @@ In implementation terms:
   yields no Source at all (`classifyAuthorSource` returns null and the write is
   skipped, as is assignment, which needs Source) rather than a guessed
   `Community`.
-- Team reads are cached per run at the API level: the org team listing
-  (`listOrgTeams`) and each roster (`tryListTeamMembers`) are each fetched once
-  on success, so a sweep enumerates teams once and rebuilds the source-internal
-  family in memory per PR. A failed read is not cached — a later PR can recover
-  from a transient error — but each read gets an attempt budget
-  (`MAX_TEAM_READ_ATTEMPTS`) so a persistent failure costs a couple of requests
-  per run instead of one per PR.
+- Team reads use bounded exponential backoff before returning: by default each
+  org-team listing or roster gets three attempts, delayed by 1 then 2 seconds.
+  The settled success or failure is cached in memory for the rest of that
+  workflow run, so a sweep enumerates each team at most once after retries and
+  rebuilds the source-internal family in memory per PR. The next workflow run
+  starts with a fresh cache and retries previously failed reads.
 - `computeTarget()` maps observed PR state to Status for event and sweep mode.
 - `Done` is terminal: once the board Status is `Done`, later events leave it
   unchanged.
@@ -105,9 +104,9 @@ In implementation terms:
 linked-issue sync when already assigned). Skips human drafts (except Bot PRs) and
 merge-queued PRs.
 
-| Source | Assignee | Reviewers |
-| --- | --- | --- |
-| **Internal** | PR author | none |
+| Source              | Assignee             | Reviewers                                                                          |
+| ------------------- | -------------------- | ---------------------------------------------------------------------------------- |
+| **Internal**        | PR author            | none                                                                               |
 | **Community / Bot** | see pick order below | assignee + top collaborator-not-owner, unless a real reviewer is already requested |
 
 **Pick order** (Community/Bot):
@@ -157,11 +156,11 @@ group.
 
 ## Fork PRs on public repos
 
-| Event | Secret for fork PR? | Path |
-| --- | --- | --- |
-| `pull_request_target` | yes | `pr-maintenance.yml` → direct |
-| `pull_request_review` | **no** | `pr-review-fork-bridge.yml` → `pr-review-fork-apply.yml` (`workflow_run`) |
-| `workflow_run`, `status`, `schedule` | yes | respective callers → direct |
+| Event                                | Secret for fork PR? | Path                                                                      |
+| ------------------------------------ | ------------------- | ------------------------------------------------------------------------- |
+| `pull_request_target`                | yes                 | `pr-maintenance.yml` → direct                                             |
+| `pull_request_review`                | **no**              | `pr-review-fork-bridge.yml` → `pr-review-fork-apply.yml` (`workflow_run`) |
+| `workflow_run`, `status`, `schedule` | yes                 | respective callers → direct                                               |
 
 When `SLANG_PR_BOT_TOKEN` is unavailable, privileged steps skip cleanly (`HAS_TOKEN`).
 

--- a/.github/workflows/pr-board-sync.md
+++ b/.github/workflows/pr-board-sync.md
@@ -17,7 +17,7 @@ For each open PR the workflow:
    bot-author config and membership in `source_internal_team` (default
    `shader-slang/source-internal`; direct or nested), plus sibling teams whose
    slug starts with that base plus `-` (e.g. `source-internal-slangpy`) when
-   their description includes `Scope: repo1, repo2` for this repository. Repo
+   their description includes `Scope: [repo1, repo2]` for this repository. Repo
    write access is **not** used for Source.
 3. Recomputes **Status** from live PR state (`In Review`, `Revising`, `Snagged`,
    `Approved`, `Done`).
@@ -83,6 +83,11 @@ In implementation terms:
 
 - The board's Source value is authoritative once set; automation only backfills
   Source when the board has none.
+- Because that written value is never re-derived, an unreadable team roster
+  yields no Source at all (`classifyAuthorSource` returns null and the write is
+  skipped, as is assignment, which needs Source) rather than a guessed
+  `Community`. A fully-read team family is cached per run; a partial read is not,
+  so a later PR in the same sweep retries.
 - `computeTarget()` maps observed PR state to Status for event and sweep mode.
 - `Done` is terminal: once the board Status is `Done`, later events leave it
   unchanged.

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -137,6 +137,10 @@ on:
       source_bot:
         type: string
         default: "Bot"
+      source_internal_team:
+        description: "org/team-slug whose members (direct or nested) are classified as Source Internal."
+        type: string
+        default: "shader-slang/source-internal"
       bot_authors:
         description: "Comma-separated logins always treated as bots."
         type: string
@@ -204,7 +208,7 @@ jobs:
           echo "(Fork-PR head-context event on a public repo, or unconfigured repo.)"
           echo "The nightly sweep / a later pull_request_target / the workflow_run path will reconcile."
 
-      # --- Classify Source (repo write-access read; opened/reopened only) ------
+      # --- Classify Source (source-internal team; opened/reopened only) --------
       - name: Classify PR Source
         id: classify
         if: >-
@@ -217,6 +221,7 @@ jobs:
           SOURCE_INTERNAL: ${{ inputs.source_internal }}
           SOURCE_COMMUNITY: ${{ inputs.source_community }}
           SOURCE_BOT: ${{ inputs.source_bot }}
+          SOURCE_INTERNAL_TEAM: ${{ inputs.source_internal_team }}
         with:
           github-token: ${{ secrets.SLANG_PR_BOT_TOKEN }}
           script: |
@@ -227,31 +232,48 @@ jobs:
             const isBot = user.type === "Bot" ||
               botAuthors.includes((login || "").toLowerCase());
 
-            let source;
-            if (isBot) {
-              source = process.env.SOURCE_BOT;
-            } else {
-              // Internal iff the author has write (push) access to this repo, i.e.
-              // they can approve workflow runs and approve/merge PRs. Everyone else
-              // -- org members without write here, and fork contributors -- is
-              // Community. On any read error, fail safe to Community.
-              let canWrite = false;
+            // Pure helpers mirrored from extract-js:classify in the reconcile step
+            // (that block is the unit-tested source of truth). Keep in sync.
+            function isInternalLogin(authorLogin, members) {
+              if (!authorLogin || !members) return false;
+              const lower = authorLogin.toLowerCase();
+              for (const m of members) {
+                if ((m || "").toLowerCase() === lower) return true;
+              }
+              return false;
+            }
+            function classifyAuthorSource(opts) {
+              if (opts.isBot) return opts.sourceBot;
+              return isInternalLogin(opts.login, opts.members)
+                ? opts.sourceInternal : opts.sourceCommunity;
+            }
+
+            // Internal iff the author is in source_internal_team (direct or nested).
+            // On any read error / unset team, fail safe to Community.
+            let members = new Set();
+            const teamSpec = process.env.SOURCE_INTERNAL_TEAM || "";
+            if (!isBot && teamSpec.includes("/")) {
+              const slash = teamSpec.indexOf("/");
+              const org = teamSpec.slice(0, slash);
+              const slug = teamSpec.slice(slash + 1);
               try {
-                const resp = await github.rest.repos.getCollaboratorPermissionLevel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  username: login,
-                });
-                canWrite = resp.data?.user?.permissions?.push === true;
+                const data = await github.paginate(
+                  github.rest.teams.listMembersInOrg,
+                  { org, team_slug: slug, per_page: 100 });
+                members = new Set(data.map(m => m.login));
               } catch (error) {
                 core.warning(
-                  `could not read ${login} permission (${error.status}); treating as Community`);
+                  `could not list team ${teamSpec} (${error.status}); treating as Community`);
               }
-              source = canWrite
-                ? process.env.SOURCE_INTERNAL
-                : process.env.SOURCE_COMMUNITY;
-              console.log(`PR author ${login}; write access: ${canWrite}`);
             }
+            const source = classifyAuthorSource({
+              isBot, login, members,
+              sourceBot: process.env.SOURCE_BOT,
+              sourceInternal: process.env.SOURCE_INTERNAL,
+              sourceCommunity: process.env.SOURCE_COMMUNITY,
+            });
+            console.log(
+              `PR author ${login}; source-internal member: ${isInternalLogin(login, members)}`);
             core.setOutput("source", source);
 
       # --- Board writes: add + Source + Status (ProjectsV2 PAT) ---------------
@@ -272,6 +294,7 @@ jobs:
           SOURCE_INTERNAL: ${{ inputs.source_internal }}
           SOURCE_COMMUNITY: ${{ inputs.source_community }}
           SOURCE_BOT: ${{ inputs.source_bot }}
+          SOURCE_INTERNAL_TEAM: ${{ inputs.source_internal_team }}
           BOT_AUTHORS: ${{ inputs.bot_authors }}
           IGNORED_REVIEWERS: ${{ inputs.ignored_reviewers }}
           OWNERS_TEAM: ${{ inputs.owners_team }}
@@ -301,6 +324,7 @@ jobs:
             const OWNERS_TEAM = process.env.OWNERS_TEAM || "";
             const BOT_OWNERS_TEAM = process.env.BOT_OWNERS_TEAM || "";
             const MAINTAINER_TEAM = process.env.MAINTAINER_TEAM || "";
+            const SOURCE_INTERNAL_TEAM = process.env.SOURCE_INTERNAL_TEAM || "";
             const FALLBACK_ASSIGNEE = process.env.FALLBACK_ASSIGNEE || "";
 
             // Committer-signal ranking + assignee/reviewer selection, inlined so
@@ -1168,24 +1192,44 @@ jobs:
             }
 
             // Classify a PR's Source from observed state: Bot for a bot author,
-            // else Internal iff the author has repo write access, else Community.
-            // Used when the board has no Source yet and no freshly-classified value
-            // is available (sweep mode or a non-onboarding event). Fails safe to
-            // Community on a read error.
+            // else Internal iff the author is in source_internal_team (direct or
+            // nested membership), else Community. Used when the board has no
+            // Source yet and no freshly-classified value is available (sweep mode
+            // or a non-onboarding event). Fails safe to Community when the team
+            // cannot be read (listTeamMembers returns an empty set).
+            //
+            // Pure helpers below are the unit-tested source of truth
+            // (.github/scripts/pr-classify.test.js extracts this block). The
+            // opened/reopened Classify PR Source step mirrors them.
+            // ----- extract-js:classify:begin -----
+            // True when login is in the source-internal member set (case-insensitive).
+            function isInternalLogin(login, members) {
+              if (!login || !members) return false;
+              const lower = login.toLowerCase();
+              for (const m of members) {
+                if ((m || "").toLowerCase() === lower) return true;
+              }
+              return false;
+            }
+
+            // Classify Source from bot flag + already-fetched team membership.
+            // Pass an empty members set when the team cannot be read so this
+            // fails safe to Community (caller's responsibility).
+            function classifyAuthorSource({ isBot, login, members,
+                                           sourceBot, sourceInternal, sourceCommunity }) {
+              if (isBot) return sourceBot;
+              return isInternalLogin(login, members) ? sourceInternal : sourceCommunity;
+            }
+            // ----- extract-js:classify:end -----
+
+            async function isInternal(login) {
+              return isInternalLogin(login, await listTeamMembers(SOURCE_INTERNAL_TEAM));
+            }
+
             async function classifySource(info) {
               if (info.isBot) return process.env.SOURCE_BOT;
-              let canWrite = false;
-              try {
-                const resp = await github.rest.repos.getCollaboratorPermissionLevel({
-                  owner: context.repo.owner, repo: context.repo.repo,
-                  username: info.authorLogin,
-                });
-                canWrite = resp.data?.user?.permissions?.push === true;
-              } catch (error) {
-                core.warning(
-                  `could not read ${info.authorLogin} permission (${error.status}); treating as Community`);
-              }
-              return canWrite ? SOURCE_INTERNAL : SOURCE_COMMUNITY;
+              return (await isInternal(info.authorLogin))
+                ? SOURCE_INTERNAL : SOURCE_COMMUNITY;
             }
 
             // Numbers of every open PR in this repo (paginated). The sweep's outer

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -63,9 +63,9 @@ name: PR Board Sync (reusable)
 #     workflow makes (so growing its capabilities never changes the caller
 #     contract — you widen this PAT's scopes centrally, callers are untouched).
 #     Scopes needed: org Projects read+write (board) and Members read; repo
-#     Contents read, Pull requests write, Issues write, Metadata read. Reading a
-#     collaborator's permission needs repo read; on any read error the Source
-#     classification fails safe to Community.
+#     Contents read, Pull requests write, Issues write, Metadata read. Members
+#     read is what Source classification needs; when a team roster cannot be
+#     read, no Source is written and the sweep retries.
 #
 # Safety: every job runs only on PR metadata / API calls and never checks out or
 # executes PR code, so `pull_request_target` (secrets available for fork PRs) is
@@ -138,7 +138,7 @@ on:
         type: string
         default: "Bot"
       source_internal_team:
-        description: "Base org/team-slug for Source Internal (default shader-slang/source-internal). Also includes sibling teams whose slug starts with that slug plus '-' (e.g. source-internal-*) when their description has 'Scope: repo1, repo2' listing short names in this org."
+        description: "Base org/team-slug for Source Internal (default shader-slang/source-internal). Also includes sibling teams whose slug starts with that slug plus '-' (e.g. source-internal-*) when their description has 'Scope: [repo1, repo2]' listing short names in this org."
         type: string
         default: "shader-slang/source-internal"
       bot_authors:
@@ -232,8 +232,10 @@ jobs:
             const isBot = user.type === "Bot" ||
               botAuthors.includes((login || "").toLowerCase());
 
-            // Pure helpers mirrored from extract-js:classify in the reconcile step
-            // (that block is the unit-tested source of truth). Keep in sync.
+            // Pure helpers copied VERBATIM from extract-js:classify in the reconcile
+            // step (that block is the unit-tested source of truth) -- this is a
+            // separate github-script invocation, so it cannot share the functions.
+            // Keep the two byte-identical; see their doc comments there.
             function repoShortName(repo) {
               if (!repo) return "";
               const slash = String(repo).lastIndexOf("/");
@@ -241,9 +243,9 @@ jobs:
             }
             function parseTeamScopeRepos(description) {
               if (!description) return [];
-              const match = String(description).match(/\bScope:\s*(.*)$/is);
+              const match = String(description).match(/\bScope:\s*\[([^\]]*)\]/i);
               if (!match) return [];
-              return match[1].split(",").map(s => s.trim()).filter(Boolean).map(s => {
+              return match[1].split(",").map((s) => s.trim()).filter(Boolean).map((s) => {
                 const slash = s.lastIndexOf("/");
                 return (slash >= 0 ? s.slice(slash + 1) : s).toLowerCase();
               });
@@ -252,53 +254,60 @@ jobs:
               if (!baseSlug || !teamSlug) return false;
               return teamSlug === baseSlug || teamSlug.startsWith(baseSlug + "-");
             }
-            function isInternalLogin(authorLogin, members) {
-              if (!authorLogin || !members) return false;
-              const lower = authorLogin.toLowerCase();
+            function isInternalLogin(login, members) {
+              if (!login || !members) return false;
+              const lower = login.toLowerCase();
               for (const m of members) {
                 if ((m || "").toLowerCase() === lower) return true;
               }
               return false;
             }
-            function internalMembersForRepo(repo, baseMembers, scopedTeams) {
+            function internalMembersForRepo(repo, teams) {
+              if (!teams) return null;
               const short = repoShortName(repo);
               const out = new Set();
-              for (const m of (baseMembers || [])) if (m) out.add(m);
-              for (const t of (scopedTeams || [])) {
-                let hit = false;
-                for (const r of (t.repos || [])) {
-                  if ((r || "").toLowerCase() === short) { hit = true; break; }
+              for (const t of teams) {
+                if (t.repos) {
+                  let hit = false;
+                  for (const r of t.repos) {
+                    if ((r || "").toLowerCase() === short) { hit = true; break; }
+                  }
+                  if (!hit) continue;
                 }
-                if (!hit) continue;
-                for (const m of (t.members || [])) if (m) out.add(m);
+                if (!t.members) return null;
+                for (const m of t.members) if (m) out.add(m);
               }
               return out;
             }
-            function classifyAuthorSource(opts) {
-              if (opts.isBot) return opts.sourceBot;
-              return isInternalLogin(opts.login, opts.members)
-                ? opts.sourceInternal : opts.sourceCommunity;
+            function classifyAuthorSource({ isBot, login, members,
+                                           sourceBot, sourceInternal, sourceCommunity }) {
+              if (isBot) return sourceBot;
+              if (!members) return null;
+              return isInternalLogin(login, members) ? sourceInternal : sourceCommunity;
             }
 
-            // Internal iff author is on the base source_internal_team or on a
-            // sibling source-internal-* team whose Scope: includes this repo.
-            // On any read error / unset team, fail safe to Community.
-            let members = new Set();
+            // Internal iff the author is on the base source_internal_team or on a
+            // sibling source-internal-* team whose Scope: includes this repo. Any
+            // roster we could not read leaves membership unknown, and we then set
+            // no output at all: the board's Source is authoritative once written,
+            // so a transient API error must not land there as Community. The sweep
+            // (which retries) fills it in instead.
             const teamSpec = process.env.SOURCE_INTERNAL_TEAM || "";
             const repoName = context.repo.repo;
+            let teamFamily = [];
             if (!isBot && teamSpec.includes("/")) {
               const slash = teamSpec.indexOf("/");
               const org = teamSpec.slice(0, slash);
               const baseSlug = teamSpec.slice(slash + 1);
-              let baseMembers = new Set();
-              const scopedTeams = [];
+              teamFamily = null;
               try {
                 const teams = await github.paginate(
                   github.rest.teams.list, { org, per_page: 100 });
+                const family = [];
                 for (const team of teams) {
                   const slug = team.slug || "";
                   if (!isSourceInternalFamilySlug(baseSlug, slug)) continue;
-                  let teamMembers = new Set();
+                  let teamMembers = null;
                   try {
                     const data = await github.paginate(
                       github.rest.teams.listMembersInOrg,
@@ -309,27 +318,37 @@ jobs:
                       `could not list team ${org}/${slug} (${error.status})`);
                   }
                   if (slug === baseSlug) {
-                    baseMembers = teamMembers;
+                    family.push({ repos: null, members: teamMembers });
                   } else {
                     const repos = parseTeamScopeRepos(team.description || "");
-                    if (repos.length) scopedTeams.push({ repos, members: teamMembers });
+                    if (repos.length) family.push({ repos, members: teamMembers });
                   }
                 }
-                members = internalMembersForRepo(repoName, baseMembers, scopedTeams);
+                if (family.some(t => t.repos === null)) {
+                  teamFamily = family;
+                } else {
+                  core.warning(`team ${teamSpec} not found in ${org}`);
+                }
               } catch (error) {
-                core.warning(
-                  `could not list teams in ${org} (${error.status}); treating as Community`);
+                core.warning(`could not list teams in ${org} (${error.status})`);
               }
             }
+            const members = isBot
+              ? null : internalMembersForRepo(repoName, teamFamily);
             const source = classifyAuthorSource({
               isBot, login, members,
               sourceBot: process.env.SOURCE_BOT,
               sourceInternal: process.env.SOURCE_INTERNAL,
               sourceCommunity: process.env.SOURCE_COMMUNITY,
             });
-            console.log(
-              `PR author ${login}; source-internal for ${repoName}: ${isInternalLogin(login, members)}`);
-            core.setOutput("source", source);
+            if (source) {
+              console.log(
+                `PR author ${login}; source-internal for ${repoName}: ${isInternalLogin(login, members)}`);
+              core.setOutput("source", source);
+            } else {
+              core.warning(
+                `could not determine Source for ${login}; leaving it to the sweep`);
+            }
 
       # --- Board writes: add + Source + Status (ProjectsV2 PAT) ---------------
       - name: Reconcile board (add, Source, Status)
@@ -1035,25 +1054,34 @@ jobs:
               return STATUS.inreview;
             }
 
-            // Member logins of an org team given as "org/slug" (empty for a bare
-            // slug or on any read error -- callers then fall through). Cached per run.
+            // Member logins of an org team given as "org/slug", or null when the
+            // roster could not be read -- so a caller that must not guess (Source
+            // classification) can leave its answer unknown. Empty for a bare slug.
+            // SUCCESSFUL reads are cached per run; failures are not, so a later PR
+            // in the same sweep retries a transient error.
             const teamCache = {};
-            async function listTeamMembers(teamSpec) {
+            async function tryListTeamMembers(teamSpec) {
               if (!teamSpec || !teamSpec.includes("/")) return new Set();
               if (teamCache[teamSpec]) return teamCache[teamSpec];
               const slash = teamSpec.indexOf("/");
               const org = teamSpec.slice(0, slash);
               const slug = teamSpec.slice(slash + 1);
-              let members = new Set();
               try {
                 const data = await github.paginate(
                   github.rest.teams.listMembersInOrg, { org, team_slug: slug, per_page: 100 });
-                members = new Set(data.map(m => m.login));
+                teamCache[teamSpec] = new Set(data.map(m => m.login));
+                return teamCache[teamSpec];
               } catch (error) {
                 core.warning(`could not list team ${teamSpec} (${error.status})`);
+                return null;
               }
-              teamCache[teamSpec] = members;
-              return members;
+            }
+
+            // Member logins of an org team, empty on any read error -- for the
+            // owners / maintainer pools, where an unreadable team just means no
+            // pick from it and must never fail the run.
+            async function listTeamMembers(teamSpec) {
+              return (await tryListTeamMembers(teamSpec)) || new Set();
             }
 
             // Logins with write+ access to this repo (the extra-reviewer pool).
@@ -1251,8 +1279,9 @@ jobs:
             // or a sibling source-internal-* team whose description Scope:
             // includes this repo, else Community. Used when the board has no
             // Source yet and no freshly-classified value is available (sweep mode
-            // or a non-onboarding event). Fails safe to Community when the org
-            // team list cannot be read.
+            // or a non-onboarding event). Yields no Source at all when the team
+            // rosters cannot be read, since the value we write becomes
+            // authoritative and is never re-derived.
             //
             // Pure helpers below are the unit-tested source of truth
             // (.github/scripts/pr-classify.test.js extracts this block). The
@@ -1265,12 +1294,13 @@ jobs:
               return (slash >= 0 ? String(repo).slice(slash + 1) : String(repo)).toLowerCase();
             }
 
-            // Parse "Scope: repo1, repo2" from a team description into short
+            // Parse "Scope: [repo1, repo2]" from a team description into short
             // repo names (lowercased). Bare names and owner/name forms are both
-            // accepted. Returns [] when Scope: is absent.
+            // accepted. Returns [] when Scope: [...] is absent. The brackets
+            // delimit the list so other description text can follow.
             function parseTeamScopeRepos(description) {
               if (!description) return [];
-              const match = String(description).match(/\bScope:\s*(.*)$/is);
+              const match = String(description).match(/\bScope:\s*\[([^\]]*)\]/i);
               if (!match) return [];
               return match[1].split(",").map((s) => s.trim()).filter(Boolean).map((s) => {
                 const slash = s.lastIndexOf("/");
@@ -1295,85 +1325,107 @@ jobs:
               return false;
             }
 
-            // Effective Internal member set for a repo: base team members plus
-            // any scoped sibling team's members whose Scope: includes the repo.
-            function internalMembersForRepo(repo, baseMembers, scopedTeams) {
+            // Effective Internal member set for a repo, from the source-internal
+            // team family: one entry per team, { repos, members }, where
+            // repos === null marks the base team (it covers every repo) and any
+            // other entry covers just the repos its Scope: lists.
+            //
+            // Returns null -- meaning "membership is unknown for this repo" --
+            // when the family is null (the org team list was unreadable) or when
+            // a team that covers this repo has members === null (its roster was
+            // unreadable). Callers must not treat that as "not a member": a
+            // transient API error would then be persisted as Community.
+            function internalMembersForRepo(repo, teams) {
+              if (!teams) return null;
               const short = repoShortName(repo);
               const out = new Set();
-              for (const m of (baseMembers || [])) if (m) out.add(m);
-              for (const t of (scopedTeams || [])) {
-                let hit = false;
-                for (const r of (t.repos || [])) {
-                  if ((r || "").toLowerCase() === short) { hit = true; break; }
+              for (const t of teams) {
+                if (t.repos) {
+                  let hit = false;
+                  for (const r of t.repos) {
+                    if ((r || "").toLowerCase() === short) { hit = true; break; }
+                  }
+                  if (!hit) continue;
                 }
-                if (!hit) continue;
-                for (const m of (t.members || [])) if (m) out.add(m);
+                if (!t.members) return null;
+                for (const m of t.members) if (m) out.add(m);
               }
               return out;
             }
 
-            // Classify Source from bot flag + already-fetched team membership.
-            // Pass an empty members set when the team cannot be read so this
-            // fails safe to Community (caller's responsibility).
+            // Classify Source from bot flag + resolved team membership, or null
+            // when membership could not be determined so the caller leaves Source
+            // unset. members === null is that unknown; an EMPTY set is a
+            // successful read of a family nobody is on, hence Community.
             function classifyAuthorSource({ isBot, login, members,
                                            sourceBot, sourceInternal, sourceCommunity }) {
               if (isBot) return sourceBot;
+              if (!members) return null;
               return isInternalLogin(login, members) ? sourceInternal : sourceCommunity;
             }
             // ----- extract-js:classify:end -----
 
-            // Cached index of base + scoped source-internal teams for this org.
-            // null means the org team list was unreadable (fail safe to Community).
-            let _internalIndex;
+            // The source-internal team family in this org, as the { repos, members }
+            // entries internalMembersForRepo consumes: the base team (repos null,
+            // covering every repo) plus each sibling with a parseable Scope:.
+            // null means the org team list itself was unreadable.
+            //
+            // Only a fully-read family is cached, so a sweep that hit a transient
+            // error on one PR retries on the next rather than reusing a roster it
+            // knows is incomplete. An empty family (no team configured) is a
+            // successful read: every non-bot author is then Community.
+            let _internalTeams;
             async function loadSourceInternalIndex() {
-              if (_internalIndex !== undefined) return _internalIndex;
+              if (_internalTeams) return _internalTeams;
               const teamSpec = SOURCE_INTERNAL_TEAM;
               if (!teamSpec || !teamSpec.includes("/")) {
-                _internalIndex = { baseMembers: new Set(), scopedTeams: [] };
-                return _internalIndex;
+                _internalTeams = [];
+                return _internalTeams;
               }
               const slash = teamSpec.indexOf("/");
               const org = teamSpec.slice(0, slash);
               const baseSlug = teamSpec.slice(slash + 1);
-              let baseMembers = new Set();
-              const scopedTeams = [];
+              let teams;
               try {
-                const teams = await github.paginate(
+                teams = await github.paginate(
                   github.rest.teams.list, { org, per_page: 100 });
-                for (const team of teams) {
-                  const slug = team.slug || "";
-                  if (!isSourceInternalFamilySlug(baseSlug, slug)) continue;
-                  const members = await listTeamMembers(`${org}/${slug}`);
-                  if (slug === baseSlug) {
-                    baseMembers = members;
-                  } else {
-                    const repos = parseTeamScopeRepos(team.description || "");
-                    if (repos.length) scopedTeams.push({ repos, members });
-                  }
-                }
-                _internalIndex = { baseMembers, scopedTeams };
               } catch (error) {
                 core.warning(
-                  `could not list teams in ${org} (${error.status}); treating as Community`);
-                _internalIndex = null;
+                  `could not list teams in ${org} (${error.status}); leaving Source unset`);
+                return null;
               }
-              return _internalIndex;
+              const family = [];
+              for (const team of teams) {
+                const slug = team.slug || "";
+                if (!isSourceInternalFamilySlug(baseSlug, slug)) continue;
+                const members = await tryListTeamMembers(`${org}/${slug}`);
+                if (slug === baseSlug) {
+                  family.push({ repos: null, members });
+                } else {
+                  const repos = parseTeamScopeRepos(team.description || "");
+                  if (repos.length) family.push({ repos, members });
+                }
+              }
+              // A configured base team that is absent from the listing (renamed,
+              // deleted, or invisible to this token) would silently make every
+              // author Community, so treat it as unreadable instead.
+              if (!family.some(t => t.repos === null)) {
+                core.warning(
+                  `team ${teamSpec} not found in ${org}; leaving Source unset`);
+                return null;
+              }
+              if (family.every(t => t.members)) _internalTeams = family;
+              return family;
             }
 
-            // Effective Internal member set for this repo: the base team plus
-            // any scoped sibling covering it. An unreadable org team list yields
-            // an empty set, so classifyAuthorSource fails safe to Community.
-            async function internalMembersForThisRepo() {
-              const index = await loadSourceInternalIndex();
-              if (!index) return new Set();
-              return internalMembersForRepo(
-                context.repo.repo, index.baseMembers, index.scopedTeams);
-            }
-
+            // Classify a PR's Source, or null when membership for this repo could
+            // not be read -- reconcileStatus then leaves Source unset for a later
+            // run rather than persisting a transient error as Community.
             async function classifySource(info) {
               const members = info.isBot
-                ? new Set()
-                : await internalMembersForThisRepo();
+                ? null
+                : internalMembersForRepo(
+                    context.repo.repo, await loadSourceInternalIndex());
               return classifyAuthorSource({
                 isBot: info.isBot, login: info.authorLogin, members,
                 sourceBot: process.env.SOURCE_BOT,
@@ -1423,6 +1475,9 @@ jobs:
               // manual override), else the freshly-classified value (opened/reopened),
               // else classify now (sweep mode or an event without the classify step).
               // Backfill the board when it had none. is_bot is then "Source == Bot".
+              // Classification yields nothing when the source-internal rosters were
+              // unreadable; we then write no Source (and skip assignment, which
+              // depends on it) and leave both to a later sweep.
               let resolvedSource = await itemSingleSelect(itemId, SOURCE_FIELD);
               if (!resolvedSource) {
                 resolvedSource = process.env.SOURCE_VALUE || await classifySource(info);

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -42,7 +42,8 @@ name: PR Board Sync (reusable)
 #   .github/workflows/pr-board-sync.md
 #
 # The inlined committer-signal + assignee block is unit-tested by
-# .github/scripts/{pr-signal,pr-assign}.test.js (via extract-workflow-js.js).
+# .github/scripts/{pr-signal,pr-assign}.test.js, and the Source-classification
+# and team-roster blocks by pr-classify.test.js (via extract-workflow-js.js).
 #
 # Cross-repo reuse: any shader-slang repo adds a thin caller workflow that
 # declares the PR event triggers and calls this one, mapping the single required
@@ -64,8 +65,9 @@ name: PR Board Sync (reusable)
 #     contract — you widen this PAT's scopes centrally, callers are untouched).
 #     Scopes needed: org Projects read+write (board) and Members read; repo
 #     Contents read, Pull requests write, Issues write, Metadata read. Members
-#     read is what Source classification needs; when a team roster cannot be
-#     read, no Source is written and the sweep retries.
+#     read is what Source classification needs; when a team roster remains
+#     unreadable after bounded retries, no Source is written and a later
+#     workflow run retries with a fresh in-memory cache.
 #
 # Safety: every job runs only on PR metadata / API calls and never checks out or
 # executes PR code, so `pull_request_target` (secrets available for fork PRs) is
@@ -232,18 +234,109 @@ jobs:
             const isBot = user.type === "Bot" ||
               botAuthors.includes((login || "").toLowerCase());
 
-            // Pure helpers copied VERBATIM from extract-js:classify in the reconcile
-            // step (that block is the unit-tested source of truth) -- this is a
-            // separate github-script invocation, so it cannot share the functions.
-            // pr-classify.test.js extracts this block and asserts every function is
-            // byte-identical to the tested reconcile copy, so either copy drifting
-            // fails CI.
+            // Shared Source-classification helpers, copied VERBATIM from the
+            // reconcile step's extract-js blocks (that copy is the unit-tested
+            // source of truth). This is a separate github-script invocation, so
+            // it cannot share heap state with reconcile -- but pr-classify.test.js
+            // asserts every extracted function here is byte-identical to the
+            // tested reconcile copy, so drift fails CI.
+            // ----- extract-js:team-roster-onboarding:begin -----
+            const DEFAULT_MAX_TEAM_READ_ATTEMPTS = 3;
+            const DEFAULT_TEAM_READ_BACKOFF_MS = 1000;
+
+            // Build the per-run team-read cache used by Source classification and
+            // by the owners/maintainer pools. paginateTeams({org}) and
+            // paginateMembers({org, team_slug}) return arrays; throw {status}
+            // on failure. warn(message) records a warning. sleep(ms) is injectable
+            // so tests can observe the exponential backoff without actually waiting.
+            //
+            // tryListTeamMembers return shapes:
+            //   - empty Set — bare/blank teamSpec (definitely nobody)
+            //   - null — all retry attempts failed (also "unknown": do not guess
+            //     Source). This settled failure is cached for the rest of the run;
+            //     the next workflow run starts with a fresh cache and retries.
+            //   - non-empty Set — successful read (cached for the run)
+            function createTeamReadCache({
+              paginateTeams, paginateMembers, warn,
+              sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+              maxAttempts = DEFAULT_MAX_TEAM_READ_ATTEMPTS,
+              baseDelayMs = DEFAULT_TEAM_READ_BACKOFF_MS,
+            }) {
+              const warned = {};
+              function warnOnce(message) {
+                if (warned[message]) return;
+                warned[message] = true;
+                warn(message);
+              }
+              async function readWithBackoff(label, read) {
+                let lastError;
+                for (let attempt = 1; attempt <= maxAttempts; ++attempt) {
+                  try {
+                    return await read();
+                  } catch (error) {
+                    lastError = error;
+                    if (attempt === maxAttempts) break;
+                    const delayMs = baseDelayMs * (2 ** (attempt - 1));
+                    warn(
+                      `${label} (${error.status}); retrying in ${delayMs}ms ` +
+                      `(${attempt}/${maxAttempts})`);
+                    await sleep(delayMs);
+                  }
+                }
+                warn(
+                  `${label} after ${maxAttempts} attempts (${lastError?.status})`);
+                return null;
+              }
+              let orgTeams; // undefined = unread; null = retries exhausted
+              async function listOrgTeams(org) {
+                if (orgTeams !== undefined) return orgTeams;
+                orgTeams = await readWithBackoff(
+                  `could not list teams in ${org}`,
+                  () => paginateTeams({ org }));
+                return orgTeams;
+              }
+              const teamCache = {};
+              async function tryListTeamMembers(teamSpec) {
+                if (!teamSpec || !teamSpec.includes("/")) return new Set();
+                if (Object.hasOwn(teamCache, teamSpec)) return teamCache[teamSpec];
+                const slash = teamSpec.indexOf("/");
+                const org = teamSpec.slice(0, slash);
+                const slug = teamSpec.slice(slash + 1);
+                const data = await readWithBackoff(
+                  `could not list team ${teamSpec}`,
+                  () => paginateMembers({ org, team_slug: slug }));
+                teamCache[teamSpec] = data
+                  ? new Set(data.map(m => m.login))
+                  : null;
+                return teamCache[teamSpec];
+              }
+              // Empty on any read error — for owners/maintainer pools, where an
+              // unreadable team just means no pick from it.
+              async function listTeamMembers(teamSpec) {
+                return (await tryListTeamMembers(teamSpec)) || new Set();
+              }
+              return {
+                warnOnce, listOrgTeams, tryListTeamMembers, listTeamMembers,
+                readWithBackoff, maxAttempts,
+              };
+            }
+            // ----- extract-js:team-roster-onboarding:end -----
             // ----- extract-js:classify-onboarding:begin -----
+            // Short repo name (lowercased), from "owner/name" or a bare name.
             function repoShortName(repo) {
               if (!repo) return "";
               const slash = String(repo).lastIndexOf("/");
               return (slash >= 0 ? String(repo).slice(slash + 1) : String(repo)).toLowerCase();
             }
+
+            // Parse "Scope: [repo1, repo2]" from a team description into short
+            // repo names (lowercased). Bare names and owner/name forms are both
+            // accepted; the owner is stripped, so Scope: [otherorg/slangpy]
+            // matches shader-slang/slangpy (short names are unique in practice).
+            // Returns [] when Scope: [...] is absent. The brackets delimit the
+            // list so other description text can follow. The label is
+            // case-insensitive; a space before the colon (e.g. "Scope :") is
+            // not accepted — write `Scope: [...]` exactly.
             function parseTeamScopeRepos(description) {
               if (!description) return [];
               const match = String(description).match(/\bScope:\s*\[([^\]]*)\]/i);
@@ -253,10 +346,15 @@ jobs:
                 return (slash >= 0 ? s.slice(slash + 1) : s).toLowerCase();
               });
             }
+
+            // True when teamSlug is the base source-internal team or a sibling
+            // whose slug starts with "<base>-" (e.g. source-internal-slangpy).
             function isSourceInternalFamilySlug(baseSlug, teamSlug) {
               if (!baseSlug || !teamSlug) return false;
               return teamSlug === baseSlug || teamSlug.startsWith(baseSlug + "-");
             }
+
+            // True when login is in the member set (case-insensitive).
             function isInternalLogin(login, members) {
               if (!login || !members) return false;
               const lower = login.toLowerCase();
@@ -265,6 +363,17 @@ jobs:
               }
               return false;
             }
+
+            // Effective Internal member set for a repo, from the source-internal
+            // team family: one entry per team, { repos, members }, where
+            // repos === null marks the base team (it covers every repo) and any
+            // other entry covers just the repos its Scope: lists.
+            //
+            // Returns null -- meaning "membership is unknown for this repo" --
+            // when the family is null (the org team list was unreadable) or when
+            // a team that covers this repo has members === null (its roster was
+            // unreadable). Callers must not treat that as "not a member": a
+            // transient API error would then be persisted as Community.
             function internalMembersForRepo(repo, teams) {
               if (!teams) return null;
               const short = repoShortName(repo);
@@ -282,6 +391,11 @@ jobs:
               }
               return out;
             }
+
+            // Classify Source from bot flag + resolved team membership, or null
+            // when membership could not be determined so the caller leaves Source
+            // unset. members === null is that unknown; an EMPTY set is a
+            // successful read of a family nobody is on, hence Community.
             function classifyAuthorSource({ isBot, login, members,
                                            sourceBot, sourceInternal, sourceCommunity }) {
               if (isBot) return sourceBot;
@@ -289,61 +403,79 @@ jobs:
               return isInternalLogin(login, members) ? sourceInternal : sourceCommunity;
             }
             // ----- extract-js:classify-onboarding:end -----
+            // ----- extract-js:source-internal-index-onboarding:begin -----
+            async function loadSourceInternalIndex({
+              teamSpec, listOrgTeams, tryListTeamMembers, warnOnce,
+              parseTeamScopeRepos, isSourceInternalFamilySlug,
+            }) {
+              if (!teamSpec || !teamSpec.includes("/")) return [];
+              const slash = teamSpec.indexOf("/");
+              const org = teamSpec.slice(0, slash);
+              const baseSlug = teamSpec.slice(slash + 1);
+              const teams = await listOrgTeams(org);
+              if (!teams) return null;
+              const family = [];
+              for (const team of teams) {
+                const slug = team.slug || "";
+                if (!isSourceInternalFamilySlug(baseSlug, slug)) continue;
+                const members = await tryListTeamMembers(`${org}/${slug}`);
+                if (slug === baseSlug) {
+                  family.push({ repos: null, members });
+                } else {
+                  const repos = parseTeamScopeRepos(team.description || "");
+                  // A sibling with no parseable Scope: [...] contributes nobody, so
+                  // its members would silently look Community. Name it in the log
+                  // rather than letting the misconfiguration pass as a plausible
+                  // Source.
+                  if (repos.length) family.push({ repos, members });
+                  else warnOnce(
+                    `team ${org}/${slug} has no 'Scope: [repo, ...]'; ignoring it`);
+                }
+              }
+              // A configured base team that is absent from the listing (renamed,
+              // deleted, or invisible to this token) would silently make every
+              // author Community, so treat it as unreadable instead.
+              if (!family.some(t => t.repos === null)) {
+                warnOnce(`team ${teamSpec} not found in ${org}; leaving Source unset`);
+                return null;
+              }
+              return family;
+            }
+            // ----- extract-js:source-internal-index-onboarding:end -----
+
+            // Wire the shared helpers to Actions github/core. Same wiring as
+            // reconcile; a one-PR onboarding run still benefits from in-call
+            // backoff retries and caches the settled result for this step.
+            const {
+              warnOnce, listOrgTeams, tryListTeamMembers,
+            } = createTeamReadCache({
+              paginateTeams: ({ org }) => github.paginate(
+                github.rest.teams.list, { org, per_page: 100 }),
+              paginateMembers: ({ org, team_slug }) => github.paginate(
+                github.rest.teams.listMembersInOrg,
+                { org, team_slug, per_page: 100 }),
+              warn: (message) => core.warning(message),
+            });
 
             // Internal iff the author is on the base source_internal_team or on a
             // sibling source-internal-* team whose Scope: includes this repo. Any
             // roster we could not read leaves membership unknown, and we then set
             // no output at all: the board's Source is authoritative once written,
-            // so a transient API error must not land there as Community. The sweep
-            // (which retries) fills it in instead.
+            // so a transient API error must not land there as Community. The
+            // reconcile step / sweep fills it in instead.
             const teamSpec = process.env.SOURCE_INTERNAL_TEAM || "";
             const repoName = context.repo.repo;
-            let teamFamily = [];
-            if (!isBot && teamSpec.includes("/")) {
-              const slash = teamSpec.indexOf("/");
-              const org = teamSpec.slice(0, slash);
-              const baseSlug = teamSpec.slice(slash + 1);
-              teamFamily = null;
-              try {
-                const teams = await github.paginate(
-                  github.rest.teams.list, { org, per_page: 100 });
-                const family = [];
-                for (const team of teams) {
-                  const slug = team.slug || "";
-                  if (!isSourceInternalFamilySlug(baseSlug, slug)) continue;
-                  let teamMembers = null;
-                  try {
-                    const data = await github.paginate(
-                      github.rest.teams.listMembersInOrg,
-                      { org, team_slug: slug, per_page: 100 });
-                    teamMembers = new Set(data.map(m => m.login));
-                  } catch (error) {
-                    core.warning(
-                      `could not list team ${org}/${slug} (${error.status})`);
-                  }
-                  if (slug === baseSlug) {
-                    family.push({ repos: null, members: teamMembers });
-                  } else {
-                    const repos = parseTeamScopeRepos(team.description || "");
-                    // A sibling with no parseable Scope: [...] contributes nobody,
-                    // so its members would silently look Community. Name it in the
-                    // log rather than letting that pass as a plausible Source.
-                    if (repos.length) family.push({ repos, members: teamMembers });
-                    else core.warning(
-                      `team ${org}/${slug} has no 'Scope: [repo, ...]'; ignoring it`);
-                  }
-                }
-                if (family.some(t => t.repos === null)) {
-                  teamFamily = family;
-                } else {
-                  core.warning(`team ${teamSpec} not found in ${org}`);
-                }
-              } catch (error) {
-                core.warning(`could not list teams in ${org} (${error.status})`);
-              }
-            }
             const members = isBot
-              ? null : internalMembersForRepo(repoName, teamFamily);
+              ? null
+              : internalMembersForRepo(
+                  repoName, await loadSourceInternalIndex({
+                    teamSpec,
+                    listOrgTeams,
+                    tryListTeamMembers,
+                    warnOnce,
+                    parseTeamScopeRepos,
+                    isSourceInternalFamilySlug,
+                  }));
             const source = classifyAuthorSource({
               isBot, login, members,
               sourceBot: process.env.SOURCE_BOT,
@@ -351,8 +483,12 @@ jobs:
               sourceCommunity: process.env.SOURCE_COMMUNITY,
             });
             if (source) {
-              console.log(
-                `PR author ${login}; source-internal for ${repoName}: ${isInternalLogin(login, members)}`);
+              if (isBot) {
+                console.log(`PR author ${login}; classified as Bot`);
+              } else {
+                console.log(
+                  `PR author ${login}; source-internal for ${repoName}: ${isInternalLogin(login, members)}`);
+              }
               core.setOutput("source", source);
             } else {
               core.warning(
@@ -1067,23 +1203,26 @@ jobs:
             // fake paginate (see pr-classify.test.js), matching the pr-signal
             // countingGh pattern.
             // ----- extract-js:team-roster:begin -----
-            const DEFAULT_MAX_TEAM_READ_ATTEMPTS = 2;
+            const DEFAULT_MAX_TEAM_READ_ATTEMPTS = 3;
+            const DEFAULT_TEAM_READ_BACKOFF_MS = 1000;
 
             // Build the per-run team-read cache used by Source classification and
             // by the owners/maintainer pools. paginateTeams({org}) and
             // paginateMembers({org, team_slug}) return arrays; throw {status}
-            // on failure. warn(message) records a warning.
+            // on failure. warn(message) records a warning. sleep(ms) is injectable
+            // so tests can observe the exponential backoff without actually waiting.
             //
             // tryListTeamMembers return shapes:
             //   - empty Set — bare/blank teamSpec (definitely nobody)
-            //   - null — roster read failed, OR the per-run attempt budget for
-            //     that team is exhausted (also "unknown": do not guess Source).
-            //     Budget exhaustion suppresses Source for the rest of the sweep
-            //     for any PR whose repo that team covers.
+            //   - null — all retry attempts failed (also "unknown": do not guess
+            //     Source). This settled failure is cached for the rest of the run;
+            //     the next workflow run starts with a fresh cache and retries.
             //   - non-empty Set — successful read (cached for the run)
             function createTeamReadCache({
               paginateTeams, paginateMembers, warn,
+              sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
               maxAttempts = DEFAULT_MAX_TEAM_READ_ATTEMPTS,
+              baseDelayMs = DEFAULT_TEAM_READ_BACKOFF_MS,
             }) {
               const warned = {};
               function warnOnce(message) {
@@ -1091,42 +1230,47 @@ jobs:
                 warned[message] = true;
                 warn(message);
               }
-              const attempts = {};
-              function canAttempt(key) {
-                const used = attempts[key] || 0;
-                if (used >= maxAttempts) return false;
-                attempts[key] = used + 1;
-                return true;
-              }
-              let orgTeams;
-              async function listOrgTeams(org) {
-                if (orgTeams) return orgTeams;
-                if (!canAttempt(`teams:${org}`)) return null;
-                try {
-                  orgTeams = await paginateTeams({ org });
-                  return orgTeams;
-                } catch (error) {
-                  warn(
-                    `could not list teams in ${org} (${error.status}); leaving Source unset`);
-                  return null;
+              async function readWithBackoff(label, read) {
+                let lastError;
+                for (let attempt = 1; attempt <= maxAttempts; ++attempt) {
+                  try {
+                    return await read();
+                  } catch (error) {
+                    lastError = error;
+                    if (attempt === maxAttempts) break;
+                    const delayMs = baseDelayMs * (2 ** (attempt - 1));
+                    warn(
+                      `${label} (${error.status}); retrying in ${delayMs}ms ` +
+                      `(${attempt}/${maxAttempts})`);
+                    await sleep(delayMs);
+                  }
                 }
+                warn(
+                  `${label} after ${maxAttempts} attempts (${lastError?.status})`);
+                return null;
+              }
+              let orgTeams; // undefined = unread; null = retries exhausted
+              async function listOrgTeams(org) {
+                if (orgTeams !== undefined) return orgTeams;
+                orgTeams = await readWithBackoff(
+                  `could not list teams in ${org}`,
+                  () => paginateTeams({ org }));
+                return orgTeams;
               }
               const teamCache = {};
               async function tryListTeamMembers(teamSpec) {
                 if (!teamSpec || !teamSpec.includes("/")) return new Set();
-                if (teamCache[teamSpec]) return teamCache[teamSpec];
-                if (!canAttempt(`members:${teamSpec}`)) return null;
+                if (Object.hasOwn(teamCache, teamSpec)) return teamCache[teamSpec];
                 const slash = teamSpec.indexOf("/");
                 const org = teamSpec.slice(0, slash);
                 const slug = teamSpec.slice(slash + 1);
-                try {
-                  const data = await paginateMembers({ org, team_slug: slug });
-                  teamCache[teamSpec] = new Set(data.map(m => m.login));
-                  return teamCache[teamSpec];
-                } catch (error) {
-                  warn(`could not list team ${teamSpec} (${error.status})`);
-                  return null;
-                }
+                const data = await readWithBackoff(
+                  `could not list team ${teamSpec}`,
+                  () => paginateMembers({ org, team_slug: slug }));
+                teamCache[teamSpec] = data
+                  ? new Set(data.map(m => m.login))
+                  : null;
+                return teamCache[teamSpec];
               }
               // Empty on any read error — for owners/maintainer pools, where an
               // unreadable team just means no pick from it.
@@ -1135,7 +1279,7 @@ jobs:
               }
               return {
                 warnOnce, listOrgTeams, tryListTeamMembers, listTeamMembers,
-                canAttempt, maxAttempts,
+                readWithBackoff, maxAttempts,
               };
             }
             // ----- extract-js:team-roster:end -----
@@ -1447,12 +1591,18 @@ jobs:
             // Both API reads this needs are cached by their own helpers -- the org
             // team listing in listOrgTeams, each roster in tryListTeamMembers -- so
             // for a sweep this is one enumeration for the whole run and a pure
-            // in-memory rebuild per PR after that. Only a roster that FAILED is
-            // re-requested (within its attempt budget), so a later PR can recover
-            // from a transient error. An empty family (no team configured) is a
-            // successful read: every non-bot author is then Community.
-            async function loadSourceInternalIndex() {
-              const teamSpec = SOURCE_INTERNAL_TEAM;
+            // in-memory rebuild per PR after that. A read retries with exponential
+            // backoff before returning; its settled success or failure is cached
+            // for the rest of this run. A new workflow run starts with a fresh
+            // cache. An empty family (no team configured) is a successful read:
+            // every non-bot author is then Community.
+            // Inject API and parsing dependencies so tests exercise the exact
+            // family-assembly code used by both event and sweep reconciliation.
+            // ----- extract-js:source-internal-index:begin -----
+            async function loadSourceInternalIndex({
+              teamSpec, listOrgTeams, tryListTeamMembers, warnOnce,
+              parseTeamScopeRepos, isSourceInternalFamilySlug,
+            }) {
               if (!teamSpec || !teamSpec.includes("/")) return [];
               const slash = teamSpec.indexOf("/");
               const org = teamSpec.slice(0, slash);
@@ -1486,6 +1636,7 @@ jobs:
               }
               return family;
             }
+            // ----- extract-js:source-internal-index:end -----
 
             // Classify a PR's Source, or null when membership for this repo could
             // not be read -- reconcileStatus then leaves Source unset for a later
@@ -1494,7 +1645,14 @@ jobs:
               const members = info.isBot
                 ? null
                 : internalMembersForRepo(
-                    context.repo.repo, await loadSourceInternalIndex());
+                    context.repo.repo, await loadSourceInternalIndex({
+                      teamSpec: SOURCE_INTERNAL_TEAM,
+                      listOrgTeams,
+                      tryListTeamMembers,
+                      warnOnce,
+                      parseTeamScopeRepos,
+                      isSourceInternalFamilySlug,
+                    }));
               return classifyAuthorSource({
                 isBot: info.isBot, login: info.authorLogin, members,
                 sourceBot: process.env.SOURCE_BOT,

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -138,7 +138,7 @@ on:
         type: string
         default: "Bot"
       source_internal_team:
-        description: "org/team-slug whose members (direct or nested) are classified as Source Internal."
+        description: "Base org/team-slug for Source Internal (default shader-slang/source-internal). Also includes sibling teams whose slug starts with that slug plus '-' (e.g. source-internal-*) when their description has 'Scope: repo1, repo2' listing short names in this org."
         type: string
         default: "shader-slang/source-internal"
       bot_authors:
@@ -234,6 +234,24 @@ jobs:
 
             // Pure helpers mirrored from extract-js:classify in the reconcile step
             // (that block is the unit-tested source of truth). Keep in sync.
+            function repoShortName(repo) {
+              if (!repo) return "";
+              const slash = String(repo).lastIndexOf("/");
+              return (slash >= 0 ? String(repo).slice(slash + 1) : String(repo)).toLowerCase();
+            }
+            function parseTeamScopeRepos(description) {
+              if (!description) return [];
+              const match = String(description).match(/\bScope:\s*(.*)$/is);
+              if (!match) return [];
+              return match[1].split(",").map(s => s.trim()).filter(Boolean).map(s => {
+                const slash = s.lastIndexOf("/");
+                return (slash >= 0 ? s.slice(slash + 1) : s).toLowerCase();
+              });
+            }
+            function isSourceInternalFamilySlug(baseSlug, teamSlug) {
+              if (!baseSlug || !teamSlug) return false;
+              return teamSlug === baseSlug || teamSlug.startsWith(baseSlug + "-");
+            }
             function isInternalLogin(authorLogin, members) {
               if (!authorLogin || !members) return false;
               const lower = authorLogin.toLowerCase();
@@ -242,28 +260,65 @@ jobs:
               }
               return false;
             }
+            function internalMembersForRepo(repo, baseMembers, scopedTeams) {
+              const short = repoShortName(repo);
+              const out = new Set();
+              for (const m of (baseMembers || [])) if (m) out.add(m);
+              for (const t of (scopedTeams || [])) {
+                let hit = false;
+                for (const r of (t.repos || [])) {
+                  if ((r || "").toLowerCase() === short) { hit = true; break; }
+                }
+                if (!hit) continue;
+                for (const m of (t.members || [])) if (m) out.add(m);
+              }
+              return out;
+            }
             function classifyAuthorSource(opts) {
               if (opts.isBot) return opts.sourceBot;
               return isInternalLogin(opts.login, opts.members)
                 ? opts.sourceInternal : opts.sourceCommunity;
             }
 
-            // Internal iff the author is in source_internal_team (direct or nested).
+            // Internal iff author is on the base source_internal_team or on a
+            // sibling source-internal-* team whose Scope: includes this repo.
             // On any read error / unset team, fail safe to Community.
             let members = new Set();
             const teamSpec = process.env.SOURCE_INTERNAL_TEAM || "";
+            const repoName = context.repo.repo;
             if (!isBot && teamSpec.includes("/")) {
               const slash = teamSpec.indexOf("/");
               const org = teamSpec.slice(0, slash);
-              const slug = teamSpec.slice(slash + 1);
+              const baseSlug = teamSpec.slice(slash + 1);
+              let baseMembers = new Set();
+              const scopedTeams = [];
               try {
-                const data = await github.paginate(
-                  github.rest.teams.listMembersInOrg,
-                  { org, team_slug: slug, per_page: 100 });
-                members = new Set(data.map(m => m.login));
+                const teams = await github.paginate(
+                  github.rest.teams.list, { org, per_page: 100 });
+                for (const team of teams) {
+                  const slug = team.slug || "";
+                  if (!isSourceInternalFamilySlug(baseSlug, slug)) continue;
+                  let teamMembers = new Set();
+                  try {
+                    const data = await github.paginate(
+                      github.rest.teams.listMembersInOrg,
+                      { org, team_slug: slug, per_page: 100 });
+                    teamMembers = new Set(data.map(m => m.login));
+                  } catch (error) {
+                    core.warning(
+                      `could not list team ${org}/${slug} (${error.status})`);
+                  }
+                  if (slug === baseSlug) {
+                    baseMembers = teamMembers;
+                  } else {
+                    const repos = parseTeamScopeRepos(team.description || "");
+                    if (repos.length) scopedTeams.push({ repos, members: teamMembers });
+                  }
+                }
+                members = internalMembersForRepo(repoName, baseMembers, scopedTeams);
               } catch (error) {
                 core.warning(
-                  `could not list team ${teamSpec} (${error.status}); treating as Community`);
+                  `could not list teams in ${org} (${error.status}); treating as Community`);
               }
             }
             const source = classifyAuthorSource({
@@ -273,7 +328,7 @@ jobs:
               sourceCommunity: process.env.SOURCE_COMMUNITY,
             });
             console.log(
-              `PR author ${login}; source-internal member: ${isInternalLogin(login, members)}`);
+              `PR author ${login}; source-internal for ${repoName}: ${isInternalLogin(login, members)}`);
             core.setOutput("source", source);
 
       # --- Board writes: add + Source + Status (ProjectsV2 PAT) ---------------
@@ -1192,17 +1247,45 @@ jobs:
             }
 
             // Classify a PR's Source from observed state: Bot for a bot author,
-            // else Internal iff the author is in source_internal_team (direct or
-            // nested membership), else Community. Used when the board has no
+            // else Internal iff the author is in source_internal_team (org-wide)
+            // or a sibling source-internal-* team whose description Scope:
+            // includes this repo, else Community. Used when the board has no
             // Source yet and no freshly-classified value is available (sweep mode
-            // or a non-onboarding event). Fails safe to Community when the team
-            // cannot be read (listTeamMembers returns an empty set).
+            // or a non-onboarding event). Fails safe to Community when the org
+            // team list cannot be read.
             //
             // Pure helpers below are the unit-tested source of truth
             // (.github/scripts/pr-classify.test.js extracts this block). The
             // opened/reopened Classify PR Source step mirrors them.
             // ----- extract-js:classify:begin -----
-            // True when login is in the source-internal member set (case-insensitive).
+            // Short repo name (lowercased), from "owner/name" or a bare name.
+            function repoShortName(repo) {
+              if (!repo) return "";
+              const slash = String(repo).lastIndexOf("/");
+              return (slash >= 0 ? String(repo).slice(slash + 1) : String(repo)).toLowerCase();
+            }
+
+            // Parse "Scope: repo1, repo2" from a team description into short
+            // repo names (lowercased). Bare names and owner/name forms are both
+            // accepted. Returns [] when Scope: is absent.
+            function parseTeamScopeRepos(description) {
+              if (!description) return [];
+              const match = String(description).match(/\bScope:\s*(.*)$/is);
+              if (!match) return [];
+              return match[1].split(",").map((s) => s.trim()).filter(Boolean).map((s) => {
+                const slash = s.lastIndexOf("/");
+                return (slash >= 0 ? s.slice(slash + 1) : s).toLowerCase();
+              });
+            }
+
+            // True when teamSlug is the base source-internal team or a sibling
+            // whose slug starts with "<base>-" (e.g. source-internal-slangpy).
+            function isSourceInternalFamilySlug(baseSlug, teamSlug) {
+              if (!baseSlug || !teamSlug) return false;
+              return teamSlug === baseSlug || teamSlug.startsWith(baseSlug + "-");
+            }
+
+            // True when login is in the member set (case-insensitive).
             function isInternalLogin(login, members) {
               if (!login || !members) return false;
               const lower = login.toLowerCase();
@@ -1210,6 +1293,23 @@ jobs:
                 if ((m || "").toLowerCase() === lower) return true;
               }
               return false;
+            }
+
+            // Effective Internal member set for a repo: base team members plus
+            // any scoped sibling team's members whose Scope: includes the repo.
+            function internalMembersForRepo(repo, baseMembers, scopedTeams) {
+              const short = repoShortName(repo);
+              const out = new Set();
+              for (const m of (baseMembers || [])) if (m) out.add(m);
+              for (const t of (scopedTeams || [])) {
+                let hit = false;
+                for (const r of (t.repos || [])) {
+                  if ((r || "").toLowerCase() === short) { hit = true; break; }
+                }
+                if (!hit) continue;
+                for (const m of (t.members || [])) if (m) out.add(m);
+              }
+              return out;
             }
 
             // Classify Source from bot flag + already-fetched team membership.
@@ -1222,13 +1322,55 @@ jobs:
             }
             // ----- extract-js:classify:end -----
 
-            async function isInternal(login) {
-              return isInternalLogin(login, await listTeamMembers(SOURCE_INTERNAL_TEAM));
+            // Cached index of base + scoped source-internal teams for this org.
+            // null means the org team list was unreadable (fail safe to Community).
+            let _internalIndex;
+            async function loadSourceInternalIndex() {
+              if (_internalIndex !== undefined) return _internalIndex;
+              const teamSpec = SOURCE_INTERNAL_TEAM;
+              if (!teamSpec || !teamSpec.includes("/")) {
+                _internalIndex = { baseMembers: new Set(), scopedTeams: [] };
+                return _internalIndex;
+              }
+              const slash = teamSpec.indexOf("/");
+              const org = teamSpec.slice(0, slash);
+              const baseSlug = teamSpec.slice(slash + 1);
+              let baseMembers = new Set();
+              const scopedTeams = [];
+              try {
+                const teams = await github.paginate(
+                  github.rest.teams.list, { org, per_page: 100 });
+                for (const team of teams) {
+                  const slug = team.slug || "";
+                  if (!isSourceInternalFamilySlug(baseSlug, slug)) continue;
+                  const members = await listTeamMembers(`${org}/${slug}`);
+                  if (slug === baseSlug) {
+                    baseMembers = members;
+                  } else {
+                    const repos = parseTeamScopeRepos(team.description || "");
+                    if (repos.length) scopedTeams.push({ repos, members });
+                  }
+                }
+                _internalIndex = { baseMembers, scopedTeams };
+              } catch (error) {
+                core.warning(
+                  `could not list teams in ${org} (${error.status}); treating as Community`);
+                _internalIndex = null;
+              }
+              return _internalIndex;
+            }
+
+            async function isInternal(login, repo) {
+              const index = await loadSourceInternalIndex();
+              if (!index) return false;
+              const members = internalMembersForRepo(
+                repo || context.repo.repo, index.baseMembers, index.scopedTeams);
+              return isInternalLogin(login, members);
             }
 
             async function classifySource(info) {
               if (info.isBot) return process.env.SOURCE_BOT;
-              return (await isInternal(info.authorLogin))
+              return (await isInternal(info.authorLogin, context.repo.repo))
                 ? SOURCE_INTERNAL : SOURCE_COMMUNITY;
             }
 

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -321,7 +321,12 @@ jobs:
                     family.push({ repos: null, members: teamMembers });
                   } else {
                     const repos = parseTeamScopeRepos(team.description || "");
+                    // A sibling with no parseable Scope: [...] contributes nobody,
+                    // so its members would silently look Community. Name it in the
+                    // log rather than letting that pass as a plausible Source.
                     if (repos.length) family.push({ repos, members: teamMembers });
+                    else core.warning(
+                      `team ${org}/${slug} has no 'Scope: [repo, ...]'; ignoring it`);
                   }
                 }
                 if (family.some(t => t.repos === null)) {
@@ -1054,15 +1059,59 @@ jobs:
               return STATUS.inreview;
             }
 
+            // core.warning for a condition that would otherwise repeat for every
+            // PR a sweep walks (a misconfigured team is constant for the run), so
+            // the log names it once instead of hundreds of times.
+            const _warned = {};
+            function warnOnce(message) {
+              if (_warned[message]) return;
+              _warned[message] = true;
+              core.warning(message);
+            }
+
+            // A per-run attempt budget for one team read. Only a SUCCESSFUL read is
+            // cached, so that a transient error on one PR does not poison the whole
+            // sweep; this bounds the other side of that choice, since a persistent
+            // failure (deleted team, token permission gap) would otherwise re-issue
+            // the same request for every one of the hundreds of PRs a sweep walks.
+            const MAX_TEAM_READ_ATTEMPTS = 2;
+            const _teamReadAttempts = {};
+            function canAttemptTeamRead(key) {
+              const used = _teamReadAttempts[key] || 0;
+              if (used >= MAX_TEAM_READ_ATTEMPTS) return false;
+              _teamReadAttempts[key] = used + 1;
+              return true;
+            }
+
+            // Every team in the org, as { slug, description }, or null when the
+            // listing could not be read. This is team metadata, not membership, so
+            // it is always safe to cache once read -- which is what keeps the family
+            // rebuild below a pure in-memory pass rather than a re-enumeration.
+            let _orgTeams;
+            async function listOrgTeams(org) {
+              if (_orgTeams) return _orgTeams;
+              if (!canAttemptTeamRead(`teams:${org}`)) return null;
+              try {
+                _orgTeams = await github.paginate(
+                  github.rest.teams.list, { org, per_page: 100 });
+                return _orgTeams;
+              } catch (error) {
+                core.warning(
+                  `could not list teams in ${org} (${error.status}); leaving Source unset`);
+                return null;
+              }
+            }
+
             // Member logins of an org team given as "org/slug", or null when the
             // roster could not be read -- so a caller that must not guess (Source
             // classification) can leave its answer unknown. Empty for a bare slug.
-            // SUCCESSFUL reads are cached per run; failures are not, so a later PR
-            // in the same sweep retries a transient error.
+            // SUCCESSFUL reads are cached per run; a failure is retried up to the
+            // attempt budget above, so a later PR in the same sweep can recover.
             const teamCache = {};
             async function tryListTeamMembers(teamSpec) {
               if (!teamSpec || !teamSpec.includes("/")) return new Set();
               if (teamCache[teamSpec]) return teamCache[teamSpec];
+              if (!canAttemptTeamRead(`members:${teamSpec}`)) return null;
               const slash = teamSpec.indexOf("/");
               const org = teamSpec.slice(0, slash);
               const slug = teamSpec.slice(slash + 1);
@@ -1368,32 +1417,23 @@ jobs:
             // The source-internal team family in this org, as the { repos, members }
             // entries internalMembersForRepo consumes: the base team (repos null,
             // covering every repo) plus each sibling with a parseable Scope:.
-            // null means the org team list itself was unreadable.
+            // null means the family is unusable (see below).
             //
-            // Only a fully-read family is cached, so a sweep that hit a transient
-            // error on one PR retries on the next rather than reusing a roster it
-            // knows is incomplete. An empty family (no team configured) is a
+            // Both API reads this needs are cached by their own helpers -- the org
+            // team listing in listOrgTeams, each roster in tryListTeamMembers -- so
+            // for a sweep this is one enumeration for the whole run and a pure
+            // in-memory rebuild per PR after that. Only a roster that FAILED is
+            // re-requested (within its attempt budget), so a later PR can recover
+            // from a transient error. An empty family (no team configured) is a
             // successful read: every non-bot author is then Community.
-            let _internalTeams;
             async function loadSourceInternalIndex() {
-              if (_internalTeams) return _internalTeams;
               const teamSpec = SOURCE_INTERNAL_TEAM;
-              if (!teamSpec || !teamSpec.includes("/")) {
-                _internalTeams = [];
-                return _internalTeams;
-              }
+              if (!teamSpec || !teamSpec.includes("/")) return [];
               const slash = teamSpec.indexOf("/");
               const org = teamSpec.slice(0, slash);
               const baseSlug = teamSpec.slice(slash + 1);
-              let teams;
-              try {
-                teams = await github.paginate(
-                  github.rest.teams.list, { org, per_page: 100 });
-              } catch (error) {
-                core.warning(
-                  `could not list teams in ${org} (${error.status}); leaving Source unset`);
-                return null;
-              }
+              const teams = await listOrgTeams(org);
+              if (!teams) return null;
               const family = [];
               for (const team of teams) {
                 const slug = team.slug || "";
@@ -1403,18 +1443,22 @@ jobs:
                   family.push({ repos: null, members });
                 } else {
                   const repos = parseTeamScopeRepos(team.description || "");
+                  // A sibling with no parseable Scope: [...] contributes nobody, so
+                  // its members would silently look Community. Name it in the log
+                  // rather than letting the misconfiguration pass as a plausible
+                  // Source.
                   if (repos.length) family.push({ repos, members });
+                  else warnOnce(
+                    `team ${org}/${slug} has no 'Scope: [repo, ...]'; ignoring it`);
                 }
               }
               // A configured base team that is absent from the listing (renamed,
               // deleted, or invisible to this token) would silently make every
               // author Community, so treat it as unreadable instead.
               if (!family.some(t => t.repos === null)) {
-                core.warning(
-                  `team ${teamSpec} not found in ${org}; leaving Source unset`);
+                warnOnce(`team ${teamSpec} not found in ${org}; leaving Source unset`);
                 return null;
               }
-              if (family.every(t => t.members)) _internalTeams = family;
               return family;
             }
 

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -140,7 +140,7 @@ on:
         type: string
         default: "Bot"
       source_internal_team:
-        description: "Base org/team-slug for Source Internal (default shader-slang/source-internal). Also includes sibling teams whose slug starts with that slug plus '-' (e.g. source-internal-*) when their description has 'Scope: [repo1, repo2]' listing repositories (bare short names or owner/repo; matching is by short name)."
+        description: "Base org/team-slug for Source Internal (default shader-slang/source-internal). Also includes sibling teams whose slug starts with that slug plus '-' (e.g. source-internal-*) when their description has 'Scope: [repo1, repo2]' listing repositories (bare short names or owner/repo; matching is by short name). Scope authoring: label is case-insensitive, first Scope: wins, write 'Scope: [...]' with no space before the colon."
         type: string
         default: "shader-slang/source-internal"
       bot_authors:
@@ -371,9 +371,13 @@ jobs:
             //
             // Returns null -- meaning "membership is unknown for this repo" --
             // when the family is null (the org team list was unreadable) or when
-            // a team that covers this repo has members === null (its roster was
-            // unreadable). Callers must not treat that as "not a member": a
-            // transient API error would then be persisted as Community.
+            // a team that covers this repo has a falsy members (null/undefined;
+            // its roster was unreadable). Relies on loadSourceInternalIndex
+            // always including the base entry (repos === null) in a non-null
+            // family; without that, a repo covered by nothing would look like
+            // Community instead of unknown. Callers must not treat null as
+            // "not a member": a transient API error would then be persisted as
+            // Community.
             function internalMembersForRepo(repo, teams) {
               if (!teams) return null;
               const short = repoShortName(repo);
@@ -394,8 +398,9 @@ jobs:
 
             // Classify Source from bot flag + resolved team membership, or null
             // when membership could not be determined so the caller leaves Source
-            // unset. members === null is that unknown; an EMPTY set is a
-            // successful read of a family nobody is on, hence Community.
+            // unset. Any falsy members (null/undefined) is that unknown; an
+            // EMPTY set is a successful read of a family nobody is on, hence
+            // Community.
             function classifyAuthorSource({ isBot, login, members,
                                            sourceBot, sourceInternal, sourceCommunity }) {
               if (isBot) return sourceBot;
@@ -1550,9 +1555,13 @@ jobs:
             //
             // Returns null -- meaning "membership is unknown for this repo" --
             // when the family is null (the org team list was unreadable) or when
-            // a team that covers this repo has members === null (its roster was
-            // unreadable). Callers must not treat that as "not a member": a
-            // transient API error would then be persisted as Community.
+            // a team that covers this repo has a falsy members (null/undefined;
+            // its roster was unreadable). Relies on loadSourceInternalIndex
+            // always including the base entry (repos === null) in a non-null
+            // family; without that, a repo covered by nothing would look like
+            // Community instead of unknown. Callers must not treat null as
+            // "not a member": a transient API error would then be persisted as
+            // Community.
             function internalMembersForRepo(repo, teams) {
               if (!teams) return null;
               const short = repoShortName(repo);
@@ -1573,8 +1582,9 @@ jobs:
 
             // Classify Source from bot flag + resolved team membership, or null
             // when membership could not be determined so the caller leaves Source
-            // unset. members === null is that unknown; an EMPTY set is a
-            // successful read of a family nobody is on, hence Community.
+            // unset. Any falsy members (null/undefined) is that unknown; an
+            // EMPTY set is a successful read of a family nobody is on, hence
+            // Community.
             function classifyAuthorSource({ isBot, login, members,
                                            sourceBot, sourceInternal, sourceCommunity }) {
               if (isBot) return sourceBot;

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -1360,18 +1360,26 @@ jobs:
               return _internalIndex;
             }
 
-            async function isInternal(login, repo) {
+            // Effective Internal member set for this repo: the base team plus
+            // any scoped sibling covering it. An unreadable org team list yields
+            // an empty set, so classifyAuthorSource fails safe to Community.
+            async function internalMembersForThisRepo() {
               const index = await loadSourceInternalIndex();
-              if (!index) return false;
-              const members = internalMembersForRepo(
-                repo || context.repo.repo, index.baseMembers, index.scopedTeams);
-              return isInternalLogin(login, members);
+              if (!index) return new Set();
+              return internalMembersForRepo(
+                context.repo.repo, index.baseMembers, index.scopedTeams);
             }
 
             async function classifySource(info) {
-              if (info.isBot) return process.env.SOURCE_BOT;
-              return (await isInternal(info.authorLogin, context.repo.repo))
-                ? SOURCE_INTERNAL : SOURCE_COMMUNITY;
+              const members = info.isBot
+                ? new Set()
+                : await internalMembersForThisRepo();
+              return classifyAuthorSource({
+                isBot: info.isBot, login: info.authorLogin, members,
+                sourceBot: process.env.SOURCE_BOT,
+                sourceInternal: SOURCE_INTERNAL,
+                sourceCommunity: SOURCE_COMMUNITY,
+              });
             }
 
             // Numbers of every open PR in this repo (paginated). The sweep's outer

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -235,7 +235,10 @@ jobs:
             // Pure helpers copied VERBATIM from extract-js:classify in the reconcile
             // step (that block is the unit-tested source of truth) -- this is a
             // separate github-script invocation, so it cannot share the functions.
-            // Keep the two byte-identical; see their doc comments there.
+            // pr-classify.test.js extracts this block and asserts every function is
+            // byte-identical to the tested reconcile copy, so either copy drifting
+            // fails CI.
+            // ----- extract-js:classify-onboarding:begin -----
             function repoShortName(repo) {
               if (!repo) return "";
               const slash = String(repo).lastIndexOf("/");
@@ -285,6 +288,7 @@ jobs:
               if (!members) return null;
               return isInternalLogin(login, members) ? sourceInternal : sourceCommunity;
             }
+            // ----- extract-js:classify-onboarding:end -----
 
             // Internal iff the author is on the base source_internal_team or on a
             // sibling source-internal-* team whose Scope: includes this repo. Any
@@ -1346,7 +1350,9 @@ jobs:
             // Parse "Scope: [repo1, repo2]" from a team description into short
             // repo names (lowercased). Bare names and owner/name forms are both
             // accepted. Returns [] when Scope: [...] is absent. The brackets
-            // delimit the list so other description text can follow.
+            // delimit the list so other description text can follow. The label
+            // is case-insensitive; a space before the colon (e.g. "Scope :") is
+            // not accepted — write `Scope: [...]` exactly.
             function parseTeamScopeRepos(description) {
               if (!description) return [];
               const match = String(description).match(/\bScope:\s*\[([^\]]*)\]/i);

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -138,7 +138,7 @@ on:
         type: string
         default: "Bot"
       source_internal_team:
-        description: "Base org/team-slug for Source Internal (default shader-slang/source-internal). Also includes sibling teams whose slug starts with that slug plus '-' (e.g. source-internal-*) when their description has 'Scope: [repo1, repo2]' listing short names in this org."
+        description: "Base org/team-slug for Source Internal (default shader-slang/source-internal). Also includes sibling teams whose slug starts with that slug plus '-' (e.g. source-internal-*) when their description has 'Scope: [repo1, repo2]' listing repositories (bare short names or owner/repo; matching is by short name)."
         type: string
         default: "shader-slang/source-internal"
       bot_authors:
@@ -1063,79 +1063,96 @@ jobs:
               return STATUS.inreview;
             }
 
-            // core.warning for a condition that would otherwise repeat for every
-            // PR a sweep walks (a misconfigured team is constant for the run), so
-            // the log names it once instead of hundreds of times.
-            const _warned = {};
-            function warnOnce(message) {
-              if (_warned[message]) return;
-              _warned[message] = true;
-              core.warning(message);
-            }
+            // Team-roster caching helpers. Extracted so unit tests can inject a
+            // fake paginate (see pr-classify.test.js), matching the pr-signal
+            // countingGh pattern.
+            // ----- extract-js:team-roster:begin -----
+            const DEFAULT_MAX_TEAM_READ_ATTEMPTS = 2;
 
-            // A per-run attempt budget for one team read. Only a SUCCESSFUL read is
-            // cached, so that a transient error on one PR does not poison the whole
-            // sweep; this bounds the other side of that choice, since a persistent
-            // failure (deleted team, token permission gap) would otherwise re-issue
-            // the same request for every one of the hundreds of PRs a sweep walks.
-            const MAX_TEAM_READ_ATTEMPTS = 2;
-            const _teamReadAttempts = {};
-            function canAttemptTeamRead(key) {
-              const used = _teamReadAttempts[key] || 0;
-              if (used >= MAX_TEAM_READ_ATTEMPTS) return false;
-              _teamReadAttempts[key] = used + 1;
-              return true;
-            }
-
-            // Every team in the org, as { slug, description }, or null when the
-            // listing could not be read. This is team metadata, not membership, so
-            // it is always safe to cache once read -- which is what keeps the family
-            // rebuild below a pure in-memory pass rather than a re-enumeration.
-            let _orgTeams;
-            async function listOrgTeams(org) {
-              if (_orgTeams) return _orgTeams;
-              if (!canAttemptTeamRead(`teams:${org}`)) return null;
-              try {
-                _orgTeams = await github.paginate(
-                  github.rest.teams.list, { org, per_page: 100 });
-                return _orgTeams;
-              } catch (error) {
-                core.warning(
-                  `could not list teams in ${org} (${error.status}); leaving Source unset`);
-                return null;
+            // Build the per-run team-read cache used by Source classification and
+            // by the owners/maintainer pools. paginateTeams({org}) and
+            // paginateMembers({org, team_slug}) return arrays; throw {status}
+            // on failure. warn(message) records a warning.
+            //
+            // tryListTeamMembers return shapes:
+            //   - empty Set — bare/blank teamSpec (definitely nobody)
+            //   - null — roster read failed, OR the per-run attempt budget for
+            //     that team is exhausted (also "unknown": do not guess Source).
+            //     Budget exhaustion suppresses Source for the rest of the sweep
+            //     for any PR whose repo that team covers.
+            //   - non-empty Set — successful read (cached for the run)
+            function createTeamReadCache({
+              paginateTeams, paginateMembers, warn,
+              maxAttempts = DEFAULT_MAX_TEAM_READ_ATTEMPTS,
+            }) {
+              const warned = {};
+              function warnOnce(message) {
+                if (warned[message]) return;
+                warned[message] = true;
+                warn(message);
               }
-            }
-
-            // Member logins of an org team given as "org/slug", or null when the
-            // roster could not be read -- so a caller that must not guess (Source
-            // classification) can leave its answer unknown. Empty for a bare slug.
-            // SUCCESSFUL reads are cached per run; a failure is retried up to the
-            // attempt budget above, so a later PR in the same sweep can recover.
-            const teamCache = {};
-            async function tryListTeamMembers(teamSpec) {
-              if (!teamSpec || !teamSpec.includes("/")) return new Set();
-              if (teamCache[teamSpec]) return teamCache[teamSpec];
-              if (!canAttemptTeamRead(`members:${teamSpec}`)) return null;
-              const slash = teamSpec.indexOf("/");
-              const org = teamSpec.slice(0, slash);
-              const slug = teamSpec.slice(slash + 1);
-              try {
-                const data = await github.paginate(
-                  github.rest.teams.listMembersInOrg, { org, team_slug: slug, per_page: 100 });
-                teamCache[teamSpec] = new Set(data.map(m => m.login));
-                return teamCache[teamSpec];
-              } catch (error) {
-                core.warning(`could not list team ${teamSpec} (${error.status})`);
-                return null;
+              const attempts = {};
+              function canAttempt(key) {
+                const used = attempts[key] || 0;
+                if (used >= maxAttempts) return false;
+                attempts[key] = used + 1;
+                return true;
               }
+              let orgTeams;
+              async function listOrgTeams(org) {
+                if (orgTeams) return orgTeams;
+                if (!canAttempt(`teams:${org}`)) return null;
+                try {
+                  orgTeams = await paginateTeams({ org });
+                  return orgTeams;
+                } catch (error) {
+                  warn(
+                    `could not list teams in ${org} (${error.status}); leaving Source unset`);
+                  return null;
+                }
+              }
+              const teamCache = {};
+              async function tryListTeamMembers(teamSpec) {
+                if (!teamSpec || !teamSpec.includes("/")) return new Set();
+                if (teamCache[teamSpec]) return teamCache[teamSpec];
+                if (!canAttempt(`members:${teamSpec}`)) return null;
+                const slash = teamSpec.indexOf("/");
+                const org = teamSpec.slice(0, slash);
+                const slug = teamSpec.slice(slash + 1);
+                try {
+                  const data = await paginateMembers({ org, team_slug: slug });
+                  teamCache[teamSpec] = new Set(data.map(m => m.login));
+                  return teamCache[teamSpec];
+                } catch (error) {
+                  warn(`could not list team ${teamSpec} (${error.status})`);
+                  return null;
+                }
+              }
+              // Empty on any read error — for owners/maintainer pools, where an
+              // unreadable team just means no pick from it.
+              async function listTeamMembers(teamSpec) {
+                return (await tryListTeamMembers(teamSpec)) || new Set();
+              }
+              return {
+                warnOnce, listOrgTeams, tryListTeamMembers, listTeamMembers,
+                canAttempt, maxAttempts,
+              };
             }
+            // ----- extract-js:team-roster:end -----
 
-            // Member logins of an org team, empty on any read error -- for the
-            // owners / maintainer pools, where an unreadable team just means no
-            // pick from it and must never fail the run.
-            async function listTeamMembers(teamSpec) {
-              return (await tryListTeamMembers(teamSpec)) || new Set();
-            }
+            // Wire the extracted helpers to the Actions github/core objects.
+            // Team metadata (listOrgTeams) is always safe to cache once read;
+            // that keeps loadSourceInternalIndex a pure in-memory rebuild per PR.
+            const {
+              warnOnce, listOrgTeams, tryListTeamMembers, listTeamMembers,
+            } = createTeamReadCache({
+              paginateTeams: ({ org }) => github.paginate(
+                github.rest.teams.list, { org, per_page: 100 }),
+              paginateMembers: ({ org, team_slug }) => github.paginate(
+                github.rest.teams.listMembersInOrg,
+                { org, team_slug, per_page: 100 }),
+              warn: (message) => core.warning(message),
+            });
 
             // Logins with write+ access to this repo (the extra-reviewer pool).
             // Empty on access error (listing collaborators needs repo admin/push),
@@ -1349,9 +1366,11 @@ jobs:
 
             // Parse "Scope: [repo1, repo2]" from a team description into short
             // repo names (lowercased). Bare names and owner/name forms are both
-            // accepted. Returns [] when Scope: [...] is absent. The brackets
-            // delimit the list so other description text can follow. The label
-            // is case-insensitive; a space before the colon (e.g. "Scope :") is
+            // accepted; the owner is stripped, so Scope: [otherorg/slangpy]
+            // matches shader-slang/slangpy (short names are unique in practice).
+            // Returns [] when Scope: [...] is absent. The brackets delimit the
+            // list so other description text can follow. The label is
+            // case-insensitive; a space before the colon (e.g. "Scope :") is
             // not accepted — write `Scope: [...]` exactly.
             function parseTeamScopeRepos(description) {
               if (!description) return [];

--- a/docs/maintainers/pr-review-board.md
+++ b/docs/maintainers/pr-review-board.md
@@ -30,8 +30,10 @@ How Source is classified today:
   direct or nested membership, org-wide), **or** of a sibling
   `source-internal-*` team whose description includes `Scope:` listing this
   repository (bare short name or `owner/repo` inside brackets; matching is by
-  short name only, e.g. `Scope: [slangpy, slangpy-samples]`). The author is
-  assigned; no reviewer is auto-requested (they are expected to find one).
+  short name only, e.g. `Scope: [slangpy, slangpy-samples]`). Write
+  `Scope: [...]` with no space before the colon; the label is case-insensitive
+  and the first `Scope:` wins if several appear. The author is assigned; no
+  reviewer is auto-requested (they are expected to find one).
 - **Community** — everyone else who is not a bot. A maintainer is assigned to
   shepherd it and arrange review.
 - **Bot** — opened by an automated coworker. A maintainer is assigned to
@@ -51,13 +53,13 @@ same files, or ask in the team channel.
 
 ## What each `Status` means for you
 
-| Status | What it means | Do you act? |
-|---|---|---|
-| **In Review** | The default for an open PR: awaiting review, CI still running, or a fresh commit not yet reviewed. (A **Bot draft** sits here too, so you can see and shepherd it.) | **Yes** — review it, or make sure a real reviewer is requested. |
-| **Revising** | The author is working: a **human draft**, or a reviewer requested changes. (A **Bot** PR's failed CI also lands here — the bot fixes itself.) | **No** — it's on the author/bot until it moves. |
-| **Snagged** | Needs a human's attention: a human PR's **CI failed**, **CI is awaiting your approval to run** (fork PRs from new contributors), or the PR is **approved + green but not in the merge queue** (it fell out, or needs someone to enqueue/merge it). | **Yes** — approve the CI run, help fix CI, or enqueue/merge. |
-| **Approved** | Not a draft, already has an approving review, and is waiting only on CI or the merge queue. | **No** — automated; nothing to do. |
-| **Done** | The PR is closed (merged or otherwise). Terminal. | No. |
+| Status        | What it means                                                                                                                                                                                                                                      | Do you act?                                                     |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| **In Review** | The default for an open PR: awaiting review, CI still running, or a fresh commit not yet reviewed. (A **Bot draft** sits here too, so you can see and shepherd it.)                                                                                | **Yes** — review it, or make sure a real reviewer is requested. |
+| **Revising**  | The author is working: a **human draft**, or a reviewer requested changes. (A **Bot** PR's failed CI also lands here — the bot fixes itself.)                                                                                                      | **No** — it's on the author/bot until it moves.                 |
+| **Snagged**   | Needs a human's attention: a human PR's **CI failed**, **CI is awaiting your approval to run** (fork PRs from new contributors), or the PR is **approved + green but not in the merge queue** (it fell out, or needs someone to enqueue/merge it). | **Yes** — approve the CI run, help fix CI, or enqueue/merge.    |
+| **Approved**  | Not a draft, already has an approving review, and is waiting only on CI or the merge queue.                                                                                                                                                        | **No** — automated; nothing to do.                              |
+| **Done**      | The PR is closed (merged or otherwise). Terminal.                                                                                                                                                                                                  | No.                                                             |
 
 In short: **`In Review` and `Snagged` are the two columns that want you.**
 `Revising`/`Approved` are waiting on someone/something else, and `Done` is finished.

--- a/docs/maintainers/pr-review-board.md
+++ b/docs/maintainers/pr-review-board.md
@@ -26,17 +26,18 @@ not a final verdict.
 How Source is classified today:
 
 - **Internal** — the author is a member of the org `source-internal` team
-  (direct or nested; one team for all `shader-slang` repos). The author is
+  (direct or nested; org-wide), **or** of a sibling `source-internal-*` team
+  whose description includes `Scope:` listing this repository's short name
+  (comma-separated; e.g. `Scope: slangpy, slangpy-samples`). The author is
   assigned; no reviewer is auto-requested (they are expected to find one).
 - **Community** — everyone else who is not a bot. A maintainer is assigned to
   shepherd it and arrange review.
 - **Bot** — opened by an automated coworker. A maintainer is assigned to
   shepherd it to ready-for-review and merge.
 
-Because Internal membership is org-wide, Source can be wrong for a given repo
-(someone on `source-internal` who does not actually own work here, or the
-reverse). If it is wrong, change Source on the board and reassign / request
-the right reviewers.
+Because Internal membership is org-wide (with optional per-repo scoped teams),
+Source can still be wrong for a given repo. If it is wrong, change Source on
+the board and reassign / request the right reviewers.
 
 If you are the assignee, you are responsible for either driving the PR forward
 or finding the correct assignee (and handing it off). Same idea for Internal

--- a/docs/maintainers/pr-review-board.md
+++ b/docs/maintainers/pr-review-board.md
@@ -25,15 +25,20 @@ not a final verdict.
 
 How Source is classified today:
 
-- **Internal** — the author is a member of the org `source-internal` team
-  (direct or nested; org-wide), **or** of a sibling `source-internal-*` team
-  whose description includes `Scope:` listing this repository's short name
-  (comma-separated; e.g. `Scope: slangpy, slangpy-samples`). The author is
-  assigned; no reviewer is auto-requested (they are expected to find one).
+- **Internal** — the author is a member of the org team the board is configured
+  with (`source_internal_team`, by default `shader-slang/source-internal`;
+  direct or nested membership, org-wide), **or** of a sibling
+  `source-internal-*` team whose description includes `Scope:` listing this
+  repository's short name (comma-separated inside brackets; e.g.
+  `Scope: [slangpy, slangpy-samples]`). The author is assigned; no reviewer is
+  auto-requested (they are expected to find one).
 - **Community** — everyone else who is not a bot. A maintainer is assigned to
   shepherd it and arrange review.
 - **Bot** — opened by an automated coworker. A maintainer is assigned to
   shepherd it to ready-for-review and merge.
+
+If those team rosters cannot be read, automation leaves `Source` (and the
+assignee) blank rather than guessing, and the nightly sweep retries.
 
 Because Internal membership is org-wide (with optional per-repo scoped teams),
 Source can still be wrong for a given repo. If it is wrong, change Source on

--- a/docs/maintainers/pr-review-board.md
+++ b/docs/maintainers/pr-review-board.md
@@ -29,9 +29,9 @@ How Source is classified today:
   with (`source_internal_team`, by default `shader-slang/source-internal`;
   direct or nested membership, org-wide), **or** of a sibling
   `source-internal-*` team whose description includes `Scope:` listing this
-  repository's short name (comma-separated inside brackets; e.g.
-  `Scope: [slangpy, slangpy-samples]`). The author is assigned; no reviewer is
-  auto-requested (they are expected to find one).
+  repository (bare short name or `owner/repo` inside brackets; matching is by
+  short name only, e.g. `Scope: [slangpy, slangpy-samples]`). The author is
+  assigned; no reviewer is auto-requested (they are expected to find one).
 - **Community** — everyone else who is not a bot. A maintainer is assigned to
   shepherd it and arrange review.
 - **Bot** — opened by an automated coworker. A maintainer is assigned to

--- a/docs/maintainers/pr-review-board.md
+++ b/docs/maintainers/pr-review-board.md
@@ -11,26 +11,37 @@ don't need this — see [CONTRIBUTING.md](../../CONTRIBUTING.md).)
 > members (committers)**. Outside contributors can't see it — that's expected;
 > their PRs are still tracked on it by the committers who shepherd them.
 
-You never set the board fields by hand: they are maintained automatically from
-PR activity (open/close, pushes, reviews, CI results, merge-queue changes). Your
-job is to **read the state and act when it asks you to**.
+You never set **Status** by hand: it is maintained automatically from PR
+activity (open/close, pushes, reviews, CI results, merge-queue changes). Your
+job is to **read the state and act when it asks you to**. **Source** is also
+set by automation on first sight, but you may override it when it is wrong
+(see below).
 
 ## How a PR lands on your plate: the `Source` field
 
-Every PR carries a **`Source`** — one of:
+Automation classifies each PR's **`Source`**, then uses that to pick a default
+assignee (and reviewers, when appropriate). That is a best-effort default —
+not a final verdict.
 
-- **Internal** — opened by someone with write access to the repo. The **author
-  drives it**; they're the assignee, and **they are expected to identify and
-  request their own reviewer** (no reviewer is auto-requested for Internal PRs).
-  If you're a newer committer and unsure who to ask, pick someone who has
-  recently touched the same files, or ask in the team channel.
-- **Community** — opened by an outside contributor. A maintainer (you) is
-  assigned to shepherd it and arrange review.
+How Source is classified today:
+
+- **Internal** — the author is a member of the org `source-internal` team
+  (direct or nested; one team for all `shader-slang` repos). The author is
+  assigned; no reviewer is auto-requested (they are expected to find one).
+- **Community** — everyone else who is not a bot. A maintainer is assigned to
+  shepherd it and arrange review.
 - **Bot** — opened by an automated coworker. A maintainer is assigned to
   shepherd it to ready-for-review and merge.
 
-Being the assignee on a **Community** or **Bot** PR means you're responsible for
-moving it forward (or finding the right reviewer).
+Because Internal membership is org-wide, Source can be wrong for a given repo
+(someone on `source-internal` who does not actually own work here, or the
+reverse). If it is wrong, change Source on the board and reassign / request
+the right reviewers.
+
+If you are the assignee, you are responsible for either driving the PR forward
+or finding the correct assignee (and handing it off). Same idea for Internal
+authors who still need a reviewer: pick someone who has recently touched the
+same files, or ask in the team channel.
 
 ## What each `Status` means for you
 


### PR DESCRIPTION
## Motivation

Fixes #12259.

PR board Source (Internal / Community / Bot) was derived from repo **write (push) access**. That has been problematic for assignment: Internal vs Community should not depend on per-repo collaborator bits. Consider an org member who can push in one `shader-slang` repo but not another — they were Internal in one place and Community in another for the same identity.

## Proposed solution

Classify **Internal** from membership in a fixed org team, `shader-slang/source-internal` (direct or nested). Both the opened/reopened onboarding path and the sweep/`classifySource` path use that team via the existing `listTeamMembers` / `teams.listMembersInOrg` helper. Bot short-circuit and fail-safe-to-Community on unreadability are preserved.

Board Source remains authoritative once set; only PRs with no Source yet get the new rule.

## Change summary

| Area | Change |
| --- | --- |
| `pr-board-sync.yml` | New `source_internal_team` input (default `shader-slang/source-internal`); replace push checks with team membership |
| `.github/scripts/pr-classify.test.js` | Unit tests for extracted `classify` helpers |
| `pr-board-sync.md` | Document team-based Source classification |
| `docs/maintainers/pr-review-board.md` | Maintainer-facing Source semantics + override guidance |

## Concepts and vocabulary

- **Source** — board single-select (`Internal` / `Community` / `Bot`) that drives default assignee/reviewer policy.
- **`source_internal_team`** — reusable-workflow input naming the org team used for Internal; distinct from `source_internal`, which is only the option *label* string `"Internal"`.
- **`listTeamMembers`** — existing helper; `teams.listMembersInOrg` includes nested-team members by default.

## Process report

Consider a PR author who is on `source-internal` but lacks push on a particular repo. Under the old rule, onboarding called `getCollaboratorPermissionLevel` and treated `permissions.push === false` as Community, so the board assigned a shepherd and requested reviewers as if they were external. Under the new rule, both classify sites load `source_internal_team` members and treat membership as Internal: the author is assigned and no reviewer is auto-requested.

The onboarding github-script step cannot share functions with the reconcile step, so the pure helpers (`isInternalLogin`, `classifyAuthorSource`) live in an `extract-js:classify` block in reconcile (unit-tested) and are mirrored in the onboarding step. Reconcile routes through `isInternal(login)` → `listTeamMembers(SOURCE_INTERNAL_TEAM)`.

Input-shape check: team membership is the intentional, principled signal for org-wide Internal identity; the old push bit was an accidental proxy and is removed from Source classification. (`repoCollaborators()` still uses push for the *extra-reviewer pool* — unrelated to Source.)

Maintainer doc updated so assignees know automation sets a best-effort default, Source can be wrong because the team is org-wide, and the assignee owns driving or handing off.

## Test plan

- [x] `node .github/scripts/pr-classify.test.js`
- [x] `node .github/scripts/pr-assign.test.js`
- [x] `node .github/scripts/pr-signal.test.js`
- [ ] After merge: confirm an opened Internal PR (source-internal member) gets Source=Internal
- [ ] After merge: confirm a non-member Community PR still classifies as Community
- [ ] Nightly sweep: PRs with no board Source backfill via team membership