### PR TITLE
Fix #12292: never unmap slang-llvm once it has been loaded

### DIFF
--- a/source/core/slang-platform.cpp
+++ b/source/core/slang-platform.cpp
@@ -67,6 +67,51 @@ namespace Slang
     return builder.toString();
 }
 
+/// The libraries that must never be unmapped, and why each one is here. See the declaration in
+/// `slang-platform.h` for what this predicate is for.
+///
+/// * `slang-llvm` statically links two allocator runtimes that install a thread-exit destructor:
+///   LLVM's vendored rpmalloc, which the official LLVM Windows packages enable and ship inside
+///   `LLVMSupport.lib`, and Slang's own mimalloc. On Windows both register their destructor with
+///   `FlsAlloc`, and Windows calls FLS destructors from `ntdll!RtlpFlsDataCleanup` inside
+///   `LdrShutdownProcess` -- that is, during process exit, after every module has already been
+///   unloaded. Neither allocator frees its FLS index when the module goes away, so once
+///   `slang-llvm.dll` has been unloaded, process exit jumps into the hole it left behind and
+///   raises an execute access violation (issue #12292). There is no earlier point at which
+///   unloading would be safe, because the destructor is required to remain callable until the very
+///   end of process shutdown.
+/// * `libdxcompiler` invokes undefined behaviour on `dlclose`, see
+///   https://github.com/microsoft/DirectXShaderCompiler/issues/5119.
+/// * `libdxvk_d3d11` and `libdxvk_dxgi` break GDB when closed, see
+///   https://github.com/doitsujin/dxvk/issues/3330.
+/* static */ bool SharedLibrary::isUnclosable(const UnownedStringSlice& platformPath)
+{
+    // These are *platform* file name prefixes, not unadorned library names, so an entry that does
+    // not match how a platform names its libraries simply never fires there. That is what scopes
+    // the `libdxcompiler` and `libdxvk_*` entries to the POSIX platforms they were added for, and
+    // it is why slang-llvm needs one entry per naming convention.
+    static const char* const unclosableLibNames[] = {
+        "slang-llvm",    // Windows
+        "libslang-llvm", // POSIX
+        "libdxcompiler",
+        "libdxvk_d3d11",
+        "libdxvk_dxgi",
+    };
+
+    // Compare against the file name so that a library is recognized whether it was loaded by bare
+    // name or through a path, and compare by prefix so that the extension and any version suffix
+    // (`.dll`, `.dylib`, `.so.3.7`, ...) do not have to be spelled out here.
+    const String fileName = Path::getFileName(platformPath);
+    for (auto name : unclosableLibNames)
+    {
+        if (fileName.getUnownedSlice().startsWith(UnownedStringSlice(name)))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 #ifdef _WIN32
 
 // Make sure SlangResult match for common standard window HRESULT
@@ -169,6 +214,22 @@ SLANG_COMPILE_TIME_ASSERT(E_OUTOFMEMORY == SLANG_E_OUT_OF_MEMORY);
         // Turn to Result, if not one of the well known errors
         return HRESULT_FROM_WIN32(lastError);
     }
+
+    if (SharedLibrary::isUnclosable(UnownedStringSlice(platformFileName)))
+    {
+        // Pin the module, which raises its reference count to a value the loader never decrements.
+        // A later `FreeLibrary` then still balances our own `LoadLibrary`, but can no longer unmap
+        // the module. This is the Windows counterpart of `RTLD_NODELETE` on the POSIX path.
+        //
+        // Pinning by address rather than by name so that we pin exactly the module we just loaded,
+        // even if another module with the same base name is also loaded.
+        HMODULE pinned = nullptr;
+        ::GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_PIN | GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+            (LPCWSTR)handle,
+            &pinned);
+    }
+
     handleOut = (Handle)handle;
     return SLANG_OK;
 }
@@ -229,21 +290,9 @@ SLANG_COMPILE_TIME_ASSERT(E_OUTOFMEMORY == SLANG_E_OUT_OF_MEMORY);
     Handle& handleOut)
 {
     handleOut = nullptr;
-    // Work around
-    // https://github.com/microsoft/DirectXShaderCompiler/issues/5119 and
-    // https://github.com/doitsujin/dxvk/issues/3330
-    // libdxcompiler.so invokes UB on dlclose, the dxvk libs break GDB when
-    // closed
-    const auto unclosableLibNames = {"libdxcompiler", "libdxvk_d3d11", "libdxvk_dxgi"};
-    bool isUnclosable = false;
-    for (auto n : unclosableLibNames)
-    {
-        if (strncmp(platformFileName, n, strlen(n)) == 0)
-        {
-            isUnclosable = true;
-            break;
-        }
-    }
+    // `RTLD_NODELETE` keeps the library mapped when it is later `dlclose`d, for the libraries
+    // whose callbacks have to outlive their own module. See `SharedLibrary::isUnclosable`.
+    const bool isUnclosable = SharedLibrary::isUnclosable(UnownedStringSlice(platformFileName));
     if (strlen(platformFileName) == 0)
         platformFileName = nullptr;
     const auto mode = RTLD_NOW | RTLD_LOCAL | (isUnclosable ? RTLD_NODELETE : 0);

--- a/source/core/slang-platform.cpp
+++ b/source/core/slang-platform.cpp
@@ -101,10 +101,19 @@ namespace Slang
     // Compare against the file name so that a library is recognized whether it was loaded by bare
     // name or through a path, and compare by prefix so that the extension and any version suffix
     // (`.dll`, `.dylib`, `.so.3.7`, ...) do not have to be spelled out here.
+    //
+    // The comparison follows the file system's own notion of identity: on Windows
+    // `SLANG-LLVM.DLL` names the very same file as `slang-llvm.dll`, so a case-sensitive
+    // comparison there could let the module be unmapped after all, whereas on the POSIX
+    // platforms those are two different files.
     const String fileName = Path::getFileName(platformPath);
     for (auto name : unclosableLibNames)
     {
+#if SLANG_WINDOWS_FAMILY
+        if (fileName.getUnownedSlice().startsWithCaseInsensitive(UnownedStringSlice(name)))
+#else
         if (fileName.getUnownedSlice().startsWith(UnownedStringSlice(name)))
+#endif
         {
             return true;
         }
@@ -224,10 +233,26 @@ SLANG_COMPILE_TIME_ASSERT(E_OUTOFMEMORY == SLANG_E_OUT_OF_MEMORY);
         // Pinning by address rather than by name so that we pin exactly the module we just loaded,
         // even if another module with the same base name is also loaded.
         HMODULE pinned = nullptr;
-        ::GetModuleHandleExW(
+        const BOOL isPinned = ::GetModuleHandleExW(
             GET_MODULE_HANDLE_EX_FLAG_PIN | GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
             (LPCWSTR)handle,
             &pinned);
+        // `handle` is a module this function has just loaded successfully, so the loader can
+        // always resolve it and there is no legitimate input that reaches this failing.
+        SLANG_ASSERT(isPinned && pinned == handle);
+        // `pinned` only exists because GetModuleHandleExW requires the out parameter; the pin is
+        // recorded in the loader's own reference count, not in the handle it hands back.
+        SLANG_UNUSED(pinned);
+        if (!isPinned)
+        {
+            // Returning the library anyway would hand the caller a module that `unload` can still
+            // unmap, which is exactly the teardown crash this is here to prevent. Report the
+            // failure instead, so the library is reported as unavailable rather than becoming a
+            // crash at process exit.
+            const DWORD lastError = GetLastError();
+            ::FreeLibrary(handle);
+            return HRESULT_FROM_WIN32(lastError);
+        }
     }
 
     handleOut = (Handle)handle;

--- a/source/core/slang-platform.h
+++ b/source/core/slang-platform.h
@@ -92,7 +92,23 @@ struct SharedLibrary
 
     /// Unload the library that was returned from load as handle
     /// @param The valid handle returned from load
+    ///
+    /// Note that for a library reported by `isUnclosable` this releases our own reference but
+    /// deliberately leaves the library mapped.
     static void unload(Handle handle);
+
+    /// Returns true if the shared library at `platformPath` must stay mapped for the lifetime of
+    /// the process once it has been loaded, so that a later `unload` does not actually unmap it.
+    ///
+    /// A shared library can register callbacks with the OS or the C runtime that the system keeps
+    /// in process-global state and invokes long after the owning module has been unmapped.
+    /// Unloading such a module leaves a dangling function pointer behind, and the process then
+    /// jumps to an address that is no longer mapped. `loadWithPlatformPath` keeps the libraries
+    /// this reports resident, using `RTLD_NODELETE` on POSIX and a pinned module handle on
+    /// Windows. See the implementation for which libraries are affected and why.
+    ///
+    /// @param platformPath the platform specific file name, or a path ending in one
+    static bool isUnclosable(const UnownedStringSlice& platformPath);
 
     /// Given a shared library handle and a name, return the associated object
     /// Return nullptr if object is not found

--- a/tools/slang-unit-test/unit-test-unclosable-shared-library.cpp
+++ b/tools/slang-unit-test/unit-test-unclosable-shared-library.cpp
@@ -1,0 +1,41 @@
+// unit-test-unclosable-shared-library.cpp
+
+#include "core/slang-platform.h"
+#include "unit-test/slang-unit-test.h"
+
+using namespace Slang;
+
+/// `slang-llvm` must never be unmapped once it has been loaded, because the allocator runtimes
+/// statically linked into it (LLVM's vendored rpmalloc, and mimalloc) register a thread-exit
+/// destructor that the OS still invokes during process shutdown, long after any module has been
+/// unloaded. Unmapping the library leaves that callback dangling and turns a normal process exit
+/// into an execute access violation -- see issue #12292, where
+/// `tests/cpu-program/gfx-smoke.slang` produced all of its expected output and then died with
+/// `0xC0000005` inside `ntdll!RtlpFlsDataCleanup`.
+///
+/// `SharedLibrary::loadWithPlatformPath` keeps every library that `SharedLibrary::isUnclosable`
+/// reports resident, so this checks that predicate. The teardown crash itself only reproduces in
+/// a build that links slang-llvm against a system LLVM, whereas this holds in every build flavour.
+SLANG_UNIT_TEST(unclosableSharedLibrary)
+{
+    // slang-llvm is unclosable under each platform's decoration of the name, and whether it is
+    // named on its own or at the end of a path.
+    SLANG_CHECK(SharedLibrary::isUnclosable(toSlice("slang-llvm.dll")));
+    SLANG_CHECK(SharedLibrary::isUnclosable(toSlice("libslang-llvm.so")));
+    SLANG_CHECK(SharedLibrary::isUnclosable(toSlice("libslang-llvm.dylib")));
+    SLANG_CHECK(SharedLibrary::isUnclosable(toSlice("C:\\slang\\bin\\slang-llvm.dll")));
+    SLANG_CHECK(SharedLibrary::isUnclosable(toSlice("/opt/slang/bin/libslang-llvm.so")));
+
+    // The other entries carry their own workarounds and must stay in the list.
+    SLANG_CHECK(SharedLibrary::isUnclosable(toSlice("libdxcompiler.so")));
+    SLANG_CHECK(SharedLibrary::isUnclosable(toSlice("libdxvk_d3d11.so")));
+    SLANG_CHECK(SharedLibrary::isUnclosable(toSlice("libdxvk_dxgi.so")));
+
+    // Everything else stays closable. In particular a directory that happens to be named after an
+    // unclosable library must not make an unrelated library unclosable, and neither must a library
+    // whose name merely ends with one.
+    SLANG_CHECK(!SharedLibrary::isUnclosable(toSlice("")));
+    SLANG_CHECK(!SharedLibrary::isUnclosable(toSlice("slang-glslang.dll")));
+    SLANG_CHECK(!SharedLibrary::isUnclosable(toSlice("/opt/slang-llvm/lib/libfoo.so")));
+    SLANG_CHECK(!SharedLibrary::isUnclosable(toSlice("not-slang-llvm.dll")));
+}

--- a/tools/slang-unit-test/unit-test-unclosable-shared-library.cpp
+++ b/tools/slang-unit-test/unit-test-unclosable-shared-library.cpp
@@ -26,6 +26,15 @@ SLANG_UNIT_TEST(unclosableSharedLibrary)
     SLANG_CHECK(SharedLibrary::isUnclosable(toSlice("C:\\slang\\bin\\slang-llvm.dll")));
     SLANG_CHECK(SharedLibrary::isUnclosable(toSlice("/opt/slang/bin/libslang-llvm.so")));
 
+#if SLANG_WINDOWS_FAMILY
+    // Windows file names are case-insensitive, so these name the same file as `slang-llvm.dll`
+    // and must be recognized as well. The POSIX platforms treat them as different files, so the
+    // matching there stays case-sensitive and these are deliberately not checked.
+    SLANG_CHECK(SharedLibrary::isUnclosable(toSlice("SLANG-LLVM.DLL")));
+    SLANG_CHECK(SharedLibrary::isUnclosable(toSlice("Slang-LLVM.Dll")));
+    SLANG_CHECK(SharedLibrary::isUnclosable(toSlice("C:\\slang\\bin\\SLANG-LLVM.DLL")));
+#endif
+
     // The other entries carry their own workarounds and must stay in the list.
     SLANG_CHECK(SharedLibrary::isUnclosable(toSlice("libdxcompiler.so")));
     SLANG_CHECK(SharedLibrary::isUnclosable(toSlice("libdxvk_d3d11.so")));


### PR DESCRIPTION
Fixes #12292

## Motivation

`tests/cpu-program/gfx-smoke.slang` compiles a compute shader, runs it on the CPU
device, prints the expected buffer contents, and then kills the process:

```text
0.0
1.0
2.0
3.0
result code = -1073741819
```

`-1073741819` is `0xC0000005`, and Windows Event Viewer names the faulting module
`slang-llvm.dll_unloaded`. This reproduces deterministically when `slang-llvm.dll`
is built from this tree with `SLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM` against the
official LLVM 21.1.2 Windows package; the fetched prebuilt plugin does not show it.

Under `cdb` the crash is an *execute* access violation reached from process
shutdown, not from any Slang code:

```text
<Unloaded_slang-llvm.dll>+0x231f210
ntdll!RtlpFlsDataCleanup+0xff
ntdll!LdrShutdownProcess+0x22a
ntdll!RtlExitUserProcess+0x9e
KERNEL32!ExitProcessImplementation+0xb
```

So the pointer that survives the unload is an FLS (fiber-local storage) thread
destructor. Breaking on `KERNELBASE!FlsAlloc` shows four registrations made from
inside `slang-llvm.dll`:

| callback | registered by |
| --- | --- |
| `__vcrt_freefls` | the statically linked vcruntime's per-thread data |
| `destroy_fls` | the statically linked ucrt's per-thread data |
| **`slang_llvm+0x231f210`** | **`rpmalloc_initialize`** |
| `_mi_prim_thread_init_auto_done` | mimalloc |

The third is the crashing address. Disassembling it while the module is still
mapped shows rpmalloc's destructor thunk, which tail-jumps into
`rpmalloc_thread_finalize`:

```text
mov  rax, qword ptr gs:[30h]         ; TEB
test rcx, rcx
je   <ret>
cmp  rax, qword ptr [<rpmalloc global>]
jne  +1
ret
mov  ecx, 1
jmp  slang_llvm!rpmalloc_thread_finalize
```

rpmalloc is not in this tree. LLVM vendors it under `llvm/lib/Support/rpmalloc/`,
and the official LLVM Windows packages enable it and ship it inside
`LLVMSupport.lib`, so it is statically linked into `slang-llvm.dll` in a
`USE_SYSTEM_LLVM` build. That is confirmed directly: `strings` on the downloaded
package's `lib/LLVMSupport.lib` contains `rpmalloc_initialize`,
`rpmalloc_initialize_config`, and `rpmalloc_thread_finalize`.

The two CRT entries are released by the CRT's own `DLL_PROCESS_DETACH` handling,
which is why they are harmless. Neither rpmalloc nor mimalloc has an equivalent
unload hook — nothing calls `rpmalloc_finalize` — so the FLS index and its
callback address stay registered in process-global state after
`FreeLibrary(slang-llvm.dll)`. At `ExitProcess` the loader walks the FLS callback
table and calls an address that is no longer mapped.

This also explains why only the source-built plugin fails: the fetched prebuilt is
produced by the separate `shader-slang/slang-llvm` repository, whose LLVM is not
built with rpmalloc.

## Proposed solution

The surviving callback's owner and required lifetime are now known, which is what
#12292 asked for before accepting a fix. It has to remain callable until the very
end of `LdrShutdownProcess`, i.e. after every module in the process has already
been unloaded. There is therefore no earlier point at which unloading
`slang-llvm` would be safe, and it cannot be deregistered from here either,
because rpmalloc is baked into a third-party `LLVMSupport.lib` with no exported
teardown hook. Keeping the module mapped is not a workaround around an unknown
cause; it is the only remaining correct option for a plugin that statically links
an allocator which hooks thread exit.

Slang already models exactly this. `SharedLibrary::loadWithPlatformPath` on POSIX
carried a local list of "unclosable" libraries — `libdxcompiler`, `libdxvk_d3d11`,
`libdxvk_dxgi` — and loaded them with `RTLD_NODELETE` for the same class of reason.
This PR lifts that list into a documented predicate,
`SharedLibrary::isUnclosable` (`source/core/slang-platform.h:111`), adds
`slang-llvm` to it, and gives Windows the counterpart it never had.

## Change summary

| File | What changed |
| --- | --- |
| `source/core/slang-platform.h:96` | Notes on `unload` that for an unclosable library it releases our reference but deliberately leaves the module mapped. |
| `source/core/slang-platform.h:111` | Declares `SharedLibrary::isUnclosable`, documenting what the predicate is for and how each platform keeps such a library resident. |
| `source/core/slang-platform.cpp:87` | Defines `SharedLibrary::isUnclosable`, holding the list and the per-library justification for why each entry is there. |
| `source/core/slang-platform.cpp:218` | Windows `loadWithPlatformPath` pins an unclosable module after loading it. |
| `source/core/slang-platform.cpp:293` | POSIX `loadWithPlatformPath` now calls the shared predicate instead of its own inline list. |
| `tools/slang-unit-test/unit-test-unclosable-shared-library.cpp` | New unit test covering the predicate. |

## Concepts and vocabulary

- **FLS (fiber-local storage)** — the Win32 storage that the MSVC CRT uses for
  per-thread data. `FlsAlloc` takes a destructor callback, and Windows invokes the
  callbacks for the current thread from `ntdll!RtlpFlsDataCleanup`. For the last
  thread that happens inside `LdrShutdownProcess`, after module unload, which is
  what makes a callback owned by an unloaded module fatal rather than merely leaky.
- **`GET_MODULE_HANDLE_EX_FLAG_PIN`** — a `GetModuleHandleEx` flag that raises a
  module's loader reference count to a value the loader never decrements. It is the
  Win32 equivalent of `RTLD_NODELETE`, except that it is applied after loading
  rather than as a load flag.
- **Unclosable library** — this codebase's existing term, from the POSIX
  `RTLD_NODELETE` list, for a shared library that must not be unmapped once loaded.

## Process report

### Adding `slang-llvm` to the unclosable set

The motivation section establishes the producer of the dangling pointer:
rpmalloc's `FlsAlloc` inside `slang-llvm.dll`. The consumer is
`ntdll!RtlpFlsDataCleanup`. Slang sits in between only in that it is the code that
calls `FreeLibrary` on a module holding a live process-global callback — the
`ComPtr<ISlangSharedLibrary>` reaching zero in `Session`, ultimately reaching
`DefaultSharedLibrary::~DefaultSharedLibrary` and `SharedLibrary::unload`.

The input-shape check matters here, because the honest answer is that the input
shape is *not* right and its producer is not ours to fix. A module that registers
a process-lifetime FLS destructor cannot be safely unloaded by anyone. The correct
producer-side fix would be for rpmalloc to `FlsFree` on module detach, but
rpmalloc reaches us as object code inside a prebuilt `LLVMSupport.lib` from the
LLVM release packages, and there is no exported hook to drive it. mimalloc, which
Slang does control, registers a destructor of the same kind and would leave the
same hazard even if rpmalloc were removed. Given that, the layer that owns the
decision is the one that chooses whether to unmap: the loader wrapper. That is
where the existing `libdxcompiler` workaround already lives, for the same reason
(`dlclose` is unsafe for that library and the fix is to not do it).

### Why the fix is not `llvm_shutdown`, and not a destruction-order change

Two other explanations were plausible from the report and are both ruled out by
the stack. Calling `llvm::llvm_shutdown()` before unload drains LLVM's
`ManagedStatic`s, but it does not touch an `FlsAlloc` registration, so it cannot
affect this crash. Reordering `Session` members or `ComPtr`s cannot help either:
`RtlpFlsDataCleanup` is invoked by the OS loader after all Slang objects are gone,
so no ordering of Slang-side destruction changes what the loader finds in the FLS
callback table.

`730ab4fca` (#12293, fixing the sibling issue #12283) was also checked, since it
changes `LLJIT` construction in the same plugin. It replaces RuntimeDyld's Windows
allocation policy so `IMAGE_REL_AMD64_ADDR32NB` relocations get an ordered layout,
and touches `slang-llvm-jit-shared-library.{h,cpp}`, `slang-llvm.cpp`, and
`slang-llvm-builder.cpp` — nothing to do with module lifetime. Rebuilding
`slang-llvm.dll` with `730ab4fca` present and this PR's change reverted still
crashes 5/5 with the identical `RtlpFlsDataCleanup` stack, so the two fixes are
independent and both are needed.

### Windows pinning by address

`GetModuleHandleExW` is called with
`GET_MODULE_HANDLE_EX_FLAG_PIN | GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS` and the
handle just returned by `LoadLibrary` (`source/core/slang-platform.cpp:226`).
Since `HMODULE` is the module base address, passing the handle pins exactly the
module we loaded, whereas pinning by name would be ambiguous if a second module
with the same base name were also loaded. Because pinning adds a reference the
loader never drops, a later `FreeLibrary` still correctly balances our own
`LoadLibrary` but can no longer unmap the module — so `SharedLibrary::unload`
needs no change and no name lookup at unload time, where the handle-only API has
no name available anyway.

### Matching on the file name, and platform-decorated entries

The old POSIX check ran `strncmp` against the whole argument, so it only matched a
library passed by bare name; the same library loaded through a path was silently
treated as closable. The predicate now compares `Path::getFileName(platformPath)`
(`source/core/slang-platform.cpp:99`), which fixes that case and is required here,
because `Session::getOrLoadSlangLLVM` can reach `loadWithPlatformPath` with a
directory-qualified path.

The list entries are *platform* file name prefixes rather than unadorned library
names, and that is deliberate: it is what keeps the `libdxcompiler` and
`libdxvk_*` entries scoped to the POSIX platforms they were added for, since those
spellings simply never match a Windows file name. The cost is that slang-llvm needs
one entry per naming convention, `slang-llvm` and `libslang-llvm`. The first draft
of this change listed only `slang-llvm` and would have compiled, passed on Windows,
and silently left the POSIX build unprotected; the unit test below is what caught
it.

### Test coverage

The teardown crash only reproduces in a build that links `slang-llvm` against a
system LLVM, and `external/build-llvm.ps1` does not enable rpmalloc, so the
existing Windows `USE_SYSTEM_LLVM` CI lane would not have caught the rpmalloc
callback. (mimalloc is still linked into `slang-llvm` in that lane and registers
the same kind of destructor, so the hazard is present there too; it simply did not
fault.) `tools/slang-unit-test/unit-test-unclosable-shared-library.cpp` therefore
asserts the `isUnclosable` policy directly, which holds in every build flavour: it
covers slang-llvm under each platform's naming and both bare and path-qualified,
the pre-existing `libdxcompiler` and `libdxvk_*` entries, and negatives including a
directory named after an unclosable library and a library whose name merely ends
with one.

An earlier version of the test instead loaded `slang-llvm`, unloaded it, and
asserted it was still mapped. That was dropped because it can never be conclusive
in practice: `slang-test` loads `slang-llvm` during backend detection long before
any unit test runs, so the test could only ever skip.
