### PR TITLE
Draft unified pipeline ray tracing API

### DIFF
--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/CALLABLE_SHADER_CONCERNS.md
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/CALLABLE_SHADER_CONCERNS.md
@@ -1,0 +1,191 @@
+# Callable Shader Concerns
+
+This note records concerns about adding D3D/Vulkan callable shaders to the
+current `TraceProgram` design. The goal is not to reject callable shaders. The
+goal is to keep the risks visible while the core hit/miss/any-hit/intersection
+model is still being shaped.
+
+## Current Intuition
+
+Callable shaders probably fit the broad `TraceProgram` reflection model:
+
+```slang
+struct PrimaryProgram : rt::TraceProgram
+{
+    typealias TraceContext = PrimaryTraceContext;
+    typealias MissGroups = rt::MissGroupList<...>;
+    typealias HitGroups = rt::HitGroupList<...>;
+    typealias CallableGroups = rt::CallableGroupList<...>;
+}
+```
+
+The pipeline build step would compile the possible callable shader entry points
+and the host would build a callable shader table. At runtime, shader code would
+only choose an index into that table.
+
+That broad shape is plausible, but there are several design concerns.
+
+## Concern 1: Callables Are Not Traversal Dispatch
+
+Hit groups and miss groups are selected by ray traversal:
+
+```text
+trace ray -> traversal -> hit/miss SBT selection
+```
+
+Callable shaders are different:
+
+```text
+shader code -> explicit callable-table index -> callable invocation
+```
+
+This means callable shaders can be described by the same reflection container,
+but they should not be modeled as another kind of hit group. They are an
+independent dynamic-call table used from ray tracing shader code.
+
+Design implication:
+
+```slang
+typealias HitGroups = ...;
+typealias MissGroups = ...;
+typealias CallableGroups = ...;
+```
+
+is safer than trying to fold callables into `HitGroupList`.
+
+## Concern 2: Typed Dynamic Indexing Is The Real Safety Problem
+
+A normal device function call is statically typed:
+
+```slang
+evalLambert(hit, material);
+```
+
+A callable shader call is table-indexed:
+
+```slang
+CallShader(material.callableIndex, data);
+```
+
+If `material.callableIndex` is dynamic, every callable reachable through that
+index domain must agree on the call-data type. Otherwise the call site cannot be
+type safe.
+
+Possible API direction:
+
+```slang
+struct MaterialCallableDomain : rt::ICallableDomain
+{
+    typealias Parameter = MaterialCallData;
+}
+
+typealias CallableGroups = rt::CallableGroupList<
+    rt::CallableSlot<MaterialCallableDomain, 0, LambertCallable>,
+    rt::CallableSlot<MaterialCallableDomain, 1, GlassCallable>>;
+```
+
+Then shader code calls a typed domain:
+
+```slang
+rt::CallableTable<MaterialCallableDomain> materialCallables;
+materialCallables.call(material.callableIndex, data);
+```
+
+Open question:
+
+Should callable slots be grouped by a typed callable domain, or should the call
+data type be attached directly to each `CallableGroupList`?
+
+## Concern 3: Reflection Cannot Prove Runtime Indices
+
+Reflection can expose this:
+
+```text
+MaterialCallableDomain
+    slot 0 -> LambertCallable
+    slot 1 -> GlassCallable
+```
+
+Reflection cannot prove this:
+
+```slang
+material.callableIndex < MaterialCallableDomain.slotCount
+```
+
+or this:
+
+```text
+material.callableIndex points at the material shader the asset author intended
+```
+
+Those remain host/data validation problems. The type system can restrict the
+table domain and call-data type, but it cannot fully validate runtime index
+contents.
+
+Design implication:
+
+The proposal should be explicit that `TraceProgram` reflection gives the host a
+finite set of callable slots to build, but runtime index correctness is still an
+engine responsibility.
+
+## Concern 4: Metal Visible Function Tables Are Similar But Not Equivalent
+
+D3D/Vulkan callable shaders are ray tracing shader stages selected from a
+callable shader table.
+
+Metal visible function tables are resource-like typed tables of visible
+functions. They are useful for indirect calls, but they are not the same
+abstraction as a D3D/Vulkan callable shader stage.
+
+Design implication:
+
+We should not define the portable callable API around Metal visible function
+tables. A visible function table may be one Metal lowering strategy for a
+restricted callable pattern, but it should not be treated as semantically
+identical to D3D/Vulkan callable shaders.
+
+## Concern 5: Callable Shaders Have Stack And Scheduling Costs
+
+Callable shaders are not just inlined device functions with different syntax.
+They are separate shader invocations in the ray tracing pipeline model and can
+affect stack size, recursion, scheduling, and optimization.
+
+Design implication:
+
+Callable shaders should not be encouraged as a replacement for ordinary helper
+functions. The API should make the intended use clear:
+
+```text
+Use device functions when the callee is statically known.
+Use callable shaders when the callee must be selected from a shader table.
+```
+
+## Concern 6: This May Distract From The Core Metal Portability Problem
+
+The first-order portability problem is still:
+
+```text
+D3D/Vulkan: native SBT dispatches miss and closest-hit.
+Metal: shader code must perform post-trace miss and closest-hit dispatch.
+```
+
+Callable shaders do not solve that problem. They may fit the same reflection
+framework later, but adding them to the first proposal could make the design
+look broader and less settled than the core hit/miss/hit-group model.
+
+Recommended staging:
+
+1. Finish `TraceProgram` for hit groups and miss groups.
+2. Define Metal lowering for post-trace closest-hit/miss dispatch.
+3. Define host reflection for hit/miss groups.
+4. Add callable shader groups as a follow-up extension if the same structure
+   still feels natural.
+
+## Provisional Position
+
+Callable shaders are compatible with the current direction, but they should be
+modeled as an optional typed callable-table extension to `TraceProgram`, not as
+part of the core dispatch model.
+
+The core proposal should stay focused on the dispatch mismatch that blocks
+Metal support today.

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/PROPOSAL.md
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/PROPOSAL.md
@@ -1,0 +1,1284 @@
+# Slang Pipeline Ray Tracing API Proposal: Structural Dispatch
+
+Status: draft proposal
+
+Scope: pipeline ray tracing only. Inline ray tracing and ray queries are intentionally out of
+scope for this first design.
+
+This proposal sketches a new Slang ray tracing API that treats Metal as a first-class target
+while preserving the D3D and Vulkan pipeline model. The central idea is to make the shader source
+declare a conceptual shader binding table, or SBT, as structured Slang types. D3D and Vulkan can
+continue to use the native host-created SBT. Metal can use the same structure to synthesize the
+post-trace closest-hit and miss dispatch logic that Metal programmers normally write by hand.
+
+Catalog
+-------
+
+- [1. Challenges Extending Current Slang Ray Tracing To Metal](#1-challenges-extending-current-slang-ray-tracing-to-metal)
+  - [1.1 Dispatch Model Gap](#11-dispatch-model-gap)
+  - [1.2 Metal Function Table And Function Buffer Resource Mismatch](#12-metal-function-table-and-function-buffer-resource-mismatch)
+  - [1.3 Metal Tag List And Reachability](#13-metal-tag-list-and-reachability)
+  - [1.4 Reserved Challenges](#14-reserved-challenges)
+- [2. Proposed API Sketch](#2-proposed-api-sketch)
+  - [2.1 Overview](#21-overview)
+  - [2.2 Detailed Component Descriptions](#22-detailed-component-descriptions)
+    - [2.2.1 Resolving The Dispatch Model Gap With A Conceptual SBT](#221-resolving-the-dispatch-model-gap-with-a-conceptual-sbt)
+    - [2.2.2 Resolving The Metal Function Table And Function Buffer Resource Mismatch With TraceProgramDescriptor](#222-resolving-the-metal-function-table-and-function-buffer-resource-mismatch-with-traceprogramdescriptor)
+      - [2.2.2.1 Lowering To `intersection_function_table`](#2221-lowering-to-intersection_function_table)
+      - [2.2.2.2 Lowering To `intersection_function_buffer_arguments`](#2222-lowering-to-intersection_function_buffer_arguments)
+    - [2.2.3 Resolving The Metal Tag-List Issue With Context Types](#223-resolving-the-metal-tag-list-issue-with-context-types)
+  - [2.3 Writing Stages As Interface-Conforming Types](#23-writing-stages-as-interface-conforming-types)
+- [3. Migration Examples](#3-migration-examples)
+  - [3.1 Migrating Existing Metal Code To The New API](#31-migrating-existing-metal-code-to-the-new-api)
+  - [3.2 Migrating Existing Slang D3D/Vulkan Ray Tracing Code](#32-migrating-existing-slang-d3dvulkan-ray-tracing-code)
+  - [3.3 Host Reflection Patterns](#33-host-reflection-patterns)
+- [4. Open Design Questions](#4-open-design-questions)
+
+## 1. Challenges Extending Current Slang Ray Tracing To Metal
+
+### 1.1 Dispatch Model Gap
+
+D3D and Vulkan expose ray tracing as a pipeline-stage model. A trace call enters traversal, and
+the driver or hardware uses host-created SBT records to select miss, any-hit, intersection, and
+closest-hit shaders. The closest-hit function is not directly called from ray-generation source.
+
+Metal exposes a different model. `intersector.intersect(...)` returns an `intersection_result`.
+AnyHit and custom Intersection behavior can still be dispatched during traversal through Metal's
+function table or function buffer, but Miss and ClosestHit are ordinary post-trace shader logic
+written by the user.
+
+Figure 1 shows the key mismatch: D3D/Vulkan assign stage dispatch to the host SBT and the
+driver/hardware, while Metal assigns Miss and ClosestHit dispatch to shader code after
+`intersect(...)` returns. A portable Slang API needs enough structure to synthesize that Metal
+post-trace dispatch without changing the native D3D/Vulkan model.
+
+<a id="fig-dispatch-model-gap"></a>
+![D3D and Vulkan SBT dispatch compared with Metal user-specified post-trace miss and closest-hit dispatch](figures/dispatch-model-gap.svg)
+
+*Figure 1. Dispatch model gap: D3D and Vulkan select pipeline stages through host-created SBT records, while Metal requires user-written post-trace dispatch for Miss and ClosestHit.*
+
+### 1.2 Metal Function Table And Function Buffer Resource Mismatch
+
+Metal introduces `intersection_function_table` resource objects and
+`intersection_function_buffer_arguments` values that are visible to shader code and must be bound
+from host code when traversal needs custom intersection behavior. This is different from the
+D3D/Vulkan SBT model. The SBT is built by host code, but it is not a shader-visible resource and
+shader code does not declare a binding point for it.
+
+This creates an asymmetric programming model. Metal shader code may need a parameter that
+represents a function table or function buffer. D3D/Vulkan shader code has no corresponding
+parameter, even though host code still needs to build SBT records. A portable Slang API therefore
+needs a way to describe this logical binding without forcing D3D/Vulkan targets to expose a fake
+shader resource.
+
+### 1.3 Metal Tag List And Reachability
+
+This proposal uses the term **reachability** to describe the shader binding table entries that a
+single trace call can access. The trace call supplies dispatch parameters, traversal contributes
+geometry and instance information, and the target selects one of the SBT records. Those selectable
+records are the entries reachable from that trace call.
+
+In existing D3D/Vulkan-style ray tracing models, this reachability is determined by host-created
+binding data. The shader source contains the trace call, but the SBT records and the binding edges
+from those records to AnyHit, Intersection, ClosestHit, and Miss shaders are provided by host code.
+Therefore, as shown in Figure 2, the complete reachability set is not known from shader source at
+ordinary compile time.
+
+<a id="fig-reachability-definition"></a>
+![Reachability is the set of SBT entries that one trace call can select](figures/reachability-definition.svg)
+
+*Figure 2. Reachability definition: the reachable entries are the SBT records one trace call can select at runtime, but in the existing model that set is determined by host-created binding data.*
+
+Metal adds a second constraint: each custom intersection function reachable from an intersector
+must have a compatible `[[intersection(...)]]` tag list. Native Metal can validate a mismatch at
+pipeline build time because the user writes both the intersector tags and the function tags in
+source. Figure 3 shows why this works: pipeline build sees the intersector tags, function tags,
+and host bindings together.
+
+<a id="fig-native-metal-tag-validation"></a>
+![Native Metal can validate explicit intersector and custom intersection function tags at pipeline build time](figures/native-metal-tag-validation.svg)
+
+*Figure 3. Native Metal tag validation: the user-authored tag lists give pipeline build enough information to reject incompatible host bindings.*
+
+Slang does not currently expose that Metal tag system. When lowering AnyHit or Intersection entry
+points to Metal, Slang must synthesize `[[intersection(...)]]` tags for the generated Metal
+functions. The compiler can see trace sites and stage entry points, but in the existing model it
+cannot see the host binding edges that determine which stage entries are reachable from each trace
+site.
+
+Figure 4 shows the information-flow problem. If two trace sites lower to different Metal tag
+sets, and several AnyHit or Intersection entries may be bound by the host, the compiler cannot
+know whether a generated function needs tag set A, tag set B, or another tag set. Emitting no tag,
+or emitting a tag inferred from the wrong trace site, can make the generated Metal pipeline fail
+to build.
+
+<a id="fig-slang-tag-synthesis-gap"></a>
+![Slang cannot synthesize Metal intersection tags when host binding data owns reachability](figures/slang-tag-synthesis-gap.svg)
+
+*Figure 4. Slang tag synthesis gap: Slang must emit Metal `[[intersection(...)]]` tags before host binding data reveals which AnyHit or Intersection entries are reachable from each trace site.*
+
+### 1.4 Reserved Challenges
+
+Other details remain important, but they are not the main shape of this proposal:
+
+- Metal has limitations on custom attributes returned from custom intersection functions.
+- Metal has multiple `intersect(...)` overload families, including no-dispatch, function-table,
+  and function-buffer forms.
+- Device user data should be modeled in a way that maps to non-pointer targets.
+
+Those issues can be handled after the dispatch and tag-reachability model is settled.
+
+## 2. Proposed API Sketch
+
+### 2.1 Overview
+
+The proposed API asks shader authors to describe a trace program in source:
+
+1. Define payload and context types.
+2. Write miss, closest-hit, any-hit, and intersection logic as structs that implement Slang
+   interfaces.
+3. Group those stage structs into ordered hit, miss, and callable group lists.
+4. Use `rt::RayTracer<ProgramLayout>`, `rt::RayTraversalDesc`, and
+   `rt::TraceProgramDescriptor<ProgramLayout>` from ray-generation code.
+
+The group declarations are the source-level conceptual SBT. They are visible to the compiler and
+to reflection. Host code can query `ITraceProgramLayout` reflection to build D3D/Vulkan SBT
+records or Metal function tables/function buffers from the same grouping contract, so the grouping
+logic does not need to be duplicated outside shader source. Figure 5 gives a high-level view of
+this API shape.
+
+<a id="fig-api-overview"></a>
+![API overview](figures/api-overview.svg)
+
+*Figure 5. Proposed API overview: users define contexts, stage structs, and grouped dispatch metadata in an `ITraceProgramLayout`; host code uses reflection of that same program layout to build D3D/Vulkan SBT records and Metal function tables/function buffers.*
+
+The running example uses the prototype files in this directory. Older alternative
+sketches outside this directory are design history and are not part of this PR.
+
+### 2.2 Detailed Component Descriptions
+
+#### 2.2.1 Resolving The Dispatch Model Gap With A Conceptual SBT
+
+The dispatch solution is to declare the SBT structure in shader source. At this layer, the key
+concepts are ordered groups, group lists, a trace program layout, a descriptor, and traversal
+parameters. A slot is the zero-based position of a group in its corresponding list.
+
+Simplified API shape:
+
+```slang
+namespace rt
+{
+    public struct RayTraversalDesc
+    {
+        public RayDesc ray;
+        public uint instanceMask;
+        public uint sbtOffset;
+        public uint sbtStride;
+        public uint missIndex;
+    }
+
+    public interface IHitGroup
+    {
+        associatedtype Context : IHitGroupContext;
+        associatedtype ClosestHit : IClosestHitShader<Context>;
+        associatedtype AnyHit : IAnyHitShader<Context>;
+        associatedtype IntersectionAttributes;
+        associatedtype Intersection : IIntersectionShader<Context, IntersectionAttributes>;
+    }
+
+    public interface IMissGroup
+    {
+        associatedtype Context : IMissGroupContext;
+        associatedtype Miss : IMissShader<Context>;
+    }
+
+    public interface ICallableGroup { ... }
+
+    public struct HitGroupList<TraceContext, each HitGroup> { ... }
+    public struct MissGroupList<TraceContext, each MissGroup> { ... }
+    public struct CallableGroupList<TraceContext, each CallableGroup> { ... }
+
+    public interface ITraceProgramLayout
+    {
+        associatedtype TraceContext : ITraceContext;
+        associatedtype MissGroups : IMissGroupList<TraceContext>;
+        associatedtype HitGroups : IHitGroupList<TraceContext>;
+        associatedtype CallableGroups : ICallableGroupList<TraceContext>;
+    }
+
+    public struct TraceProgramDescriptor<ProgramLayout>
+        where ProgramLayout : ITraceProgramLayout
+    {}
+
+    public struct RayTracer<ProgramLayout>
+        where ProgramLayout : ITraceProgramLayout
+    {
+        public void trace(
+            RayTraversalDesc desc,
+            AccelerationStructure<
+                ProgramLayout.TraceContext.ASKind,
+                ProgramLayout.TraceContext.Motion> scene,
+            TraceProgramDescriptor<ProgramLayout> descriptor,
+            inout ProgramLayout.TraceContext.Payload payload);
+    }
+}
+```
+
+This simplified shape omits some details, but keeps the current naming and ownership model:
+`ITraceProgramLayout` is the schema, `TraceProgramDescriptor<ProgramLayout>` is the value-level
+descriptor, and `RayTraversalDesc` carries per-trace SBT-style indices.
+
+The compiler-synthesized closest-hit slot calculation still follows the D3D/Vulkan SBT
+calculation. This is not a user-facing API; it is shown only as the conceptual formula Slang will
+generate for Metal:
+
+```slang
+slot = instanceContribution + geometryContribution * desc.sbtStride + desc.sbtOffset;
+```
+
+For D3D and Vulkan, these fields are mostly descriptive:
+
+- `RayTraversalDesc.sbtOffset` maps to D3D `RayContributionToHitGroupIndex` and Vulkan
+  `sbtRecordOffset`.
+- `RayTraversalDesc.sbtStride` maps to D3D `MultiplierForGeometryContributionToHitGroupIndex` and
+  Vulkan `sbtRecordStride`.
+- `RayTraversalDesc.missIndex` maps to the native miss shader index.
+- The native driver or hardware still performs the SBT lookup.
+
+For Metal, this API becomes executable structure:
+
+- Slang lowers `RayTracer<ProgramLayout>.trace(...)` to `intersector.intersect(...)`.
+- Slang uses `RayTraversalDesc.missIndex` to index generated Miss visible-function dispatch.
+- Slang synthesizes the internal hit-group slot calculation to index generated ClosestHit
+  visible-function dispatch.
+- Slang uses the same hit-group list slots to validate and emit Metal function-table or
+  function-buffer entries for any-hit and custom intersection functions.
+
+Conceptual Metal lowering:
+
+```slang
+// Internal lowering pseudocode, not user-visible rt API.
+let result = metalIntersector.intersect(desc.ray, scene, descriptor, payload);
+
+if (result.isNone)
+{
+    let missFn = descriptor.__generatedMissVisibleFunctions[desc.missIndex];
+    missFn(makeMissInput(...));
+}
+else
+{
+    uint geometryContribution = __rtGetGeometryContribution<ProgramLayout>(result);
+    uint instanceContribution = __rtGetInstanceContribution<ProgramLayout>(result);
+    uint slot = instanceContribution + geometryContribution * desc.sbtStride + desc.sbtOffset;
+
+    let closestHitFn = descriptor.__generatedClosestHitVisibleFunctions[slot];
+    closestHitFn(makeClosestHitInput(...));
+}
+```
+
+The important property is that Metal closest-hit dispatch is not invented independently. It is
+generated from the same conceptual SBT slots that the host uses for D3D and Vulkan.
+
+The generated Metal dispatch should not normally be emitted as a literal `switch` over every
+reachable Miss or ClosestHit body. A switch keeps all selected stage bodies in the same Metal
+shader compilation unit, so an expensive ClosestHit path that is unreachable for a given
+instance can still increase register pressure for a lightweight ClosestHit path compiled in the
+same function. The preferred Metal lowering is therefore to use generated visible-function tables
+for Miss and ClosestHit dispatch. This keeps the source model close to SBT dispatch while giving
+Metal a separate callable target for each reflected stage body. A switch remains useful as
+semantic pseudocode or as a restricted fallback for very small programs or targets where
+visible-function dispatch is not available.
+
+Alternative considered: require users to write a structural Metal-like dispatch function.
+
+```slang
+struct PrimaryClosestHitDispatcher
+{
+    void invoke(rt::ClosestHitInput<PrimaryTraceContext> input)
+    {
+        switch (input.geometryIndex)
+        {
+        case 0: shadeOpaqueTriangle(input); break;
+        case 1: shadeCurve(input); break;
+        case 2: shadeSphere(input); break;
+        }
+    }
+}
+```
+
+Slang could analyze this user-written dispatch logic and reflect enough metadata for D3D/Vulkan
+host code to reconstruct the SBT. This is closer to the normal Metal mental model, but it is a
+harder compiler problem:
+
+- The compiler must recognize and preserve the user's dispatch structure.
+- Reflection depends on successful control-flow analysis.
+- Dynamic dispatch tables, buffer lookups, and helper functions complicate extraction.
+- Small shader-code changes could affect host reflection in surprising ways.
+- If lowered as a literal switch, heavy and light stage bodies can be forced into the same Metal
+  shader compilation unit and interfere through register allocation.
+
+The proposed design chooses the reverse direction: users declare the SBT structure directly, then
+Slang synthesizes Metal dispatch. This is simpler to validate and easier to reflect.
+
+#### 2.2.2 Resolving The Metal Function Table And Function Buffer Resource Mismatch With TraceProgramDescriptor
+
+Metal introduces `intersection_function_table` resource objects and
+`intersection_function_buffer_arguments` values that can be visible to shader code and bound from
+host code. D3D and Vulkan instead use an SBT. The SBT is also built by host code, but it is not a
+shader-visible resource, so shader code does not declare an SBT binding point.
+
+D3D and Vulkan do not expose an equivalent shader-visible function table or function buffer.
+Their comparable structure is the host-created SBT. It is useful to view the SBT as one
+host-side database with separate hit-group, miss, and callable sections. A hit-group record can
+name ClosestHit, AnyHit, and Intersection shaders together, while the miss and callable sections
+are one-dimensional lists.
+
+Figure 6 shows the SBT baseline that the portable layout is trying to preserve. The native
+D3D/Vulkan SBT is one host-side object with hit-group, miss, and callable sections.
+
+<a id="fig-d3d-vulkan-sbt-layout"></a>
+![D3D and Vulkan shader binding table layout](figures/d3d-vulkan-sbt-layout.svg)
+
+*Figure 6. D3D/Vulkan SBT layout: one host-side object contains hit-group, miss, and callable sections, and shader code has no SBT binding point.*
+
+The previous subsection already makes the two sides share the same conceptual layout: the shader
+source declares a `ProgramLayout`, and host code can reflect that layout to build the target-side
+records. The remaining mismatch is purely about binding. Metal needs a shader-visible resource
+for the function table or function buffer path, while D3D/Vulkan need no corresponding shader
+parameter.
+
+The proposed answer is to introduce an opaque resource type:
+
+```slang
+struct TraceProgramDescriptor<ProgramLayout>
+    where ProgramLayout : ITraceProgramLayout
+{
+}
+```
+
+`TraceProgramDescriptor<ProgramLayout>` is described by `ProgramLayout`, but it does not itself
+declare the trace context. Its job is to represent the target-specific descriptor object derived from
+the reflected program layout.
+
+On D3D and Vulkan, `TraceProgramDescriptor<ProgramLayout>` does not need to lower to a shader-visible
+resource. The native SBT remains a host-side object, as shown in Figure 6.
+Host code still uses the same `ProgramLayout` reflection to build hit-group, miss, and callable
+SBT records, but shader code does not receive a Metal-style function-table or function-buffer
+object.
+
+On Metal, `TraceProgramDescriptor<ProgramLayout>` lowers to the physical resources needed by the
+selected Metal traversal path. This proposal does not yet expose an API for users to choose the
+Metal lowering form. For now, assume the Slang compiler and runtime can lower the same opaque
+descriptor to either an ordinary `intersection_function_table` shape or an
+`intersection_function_buffer_arguments` shape. The two shapes have the same source-level contract
+but different target-side binding structure.
+
+##### 2.2.2.1 Lowering To `intersection_function_table`
+
+An ordinary Metal `intersection_function_table` is a shader-visible resource-object table. Figure
+7 shows both the resource layout and the dispatch relationship that Slang needs to synthesize.
+
+<a id="fig-intersection-function-table-layout"></a>
+![Metal intersection function table resource layout with closest-hit dispatch zoom](figures/intersection-function-table-layout.svg)
+
+*Figure 7. Ordinary intersection function table lowering: the left side shows the whole IFT resource, including function entries, buffer bindings, and three visible-function tables; the right side zooms into the paired dispatch between the ClosestHit visible-function table and IFT entries. A 1:1 mapping connects native IFT entries to logical hit slots. Miss and Callable visible-function tables use independent indices.*
+
+**Native Layout**
+
+The ordinary function-table layout has two conceptually separate parts:
+
+```text
+intersection_function_table<generatedTags>
+    function entries:
+        entry metalIFTIndex -> generated candidate-hit function
+                               // AnyHit / custom Intersection behavior only
+                               // mapped 1:1 to a logicalHitSlot
+
+    resource bindings:
+        buffer slot 0 -> generated descriptor data
+                         // records, slot maps, bindless resource handles
+
+        visible-function table slot 0 -> generated Miss functions
+        visible-function table slot 1 -> generated ClosestHit functions
+                                         // indexed by logicalHitSlot
+        visible-function table slot 2 -> generated Callable functions
+```
+
+There are at most three generated visible-function tables associated with the function table:
+`visible_function_table_0` is the Miss table, `visible_function_table_1` is the ClosestHit table,
+and `visible_function_table_2` is the Callable table. These visible-function tables are resource
+bindings of the ordinary Metal function table; they are not the native IFT entries themselves.
+
+**Lowering Strategy**
+
+When the compiler lowers `TraceProgramDescriptor<ProgramLayout>` to this ordinary function-table
+path, it can be thought of as:
+
+```text
+TraceProgramDescriptor<ProgramLayout>
+    intersection_function_table<generatedTags>:
+        function entries -> generated candidate-hit functions
+        buffer slot 0 -> generated descriptor data
+        visible-function table slot 0 -> generated Miss functions
+        visible-function table slot 1 -> generated ClosestHit functions
+        visible-function table slot 2 -> generated Callable functions
+```
+
+The generated Metal-side use can be thought of as:
+
+```slang
+// Internal Metal-shaped pseudocode.
+let table = descriptor.__intersectionFunctionTable;
+let descriptorData = table.get_buffer<__RTDescriptorData*>(0);
+let missFns = table.get_visible_function_table<__RTMissFn>(0);
+let closestHitFns = table.get_visible_function_table<__RTClosestHitFn>(1);
+
+let result = metalIntersector.intersect(desc.ray, scene, table, payload);
+
+if (result.isNone)
+{
+    missFns[desc.missIndex](payload, descriptorData, desc.missIndex);
+}
+else
+{
+    uint logicalHitSlot =
+        instanceOffset + geometryId * desc.sbtStride + desc.sbtOffset;
+
+    closestHitFns[logicalHitSlot](payload, descriptorData, logicalHitSlot, result);
+}
+```
+
+**Gaps, Fixes, And Constraints**
+
+- **Gap 1: Native function-table entries do not dispatch every ray-tracing stage.** The native
+  entries dispatch only candidate-hit behavior: AnyHit filtering and custom Intersection logic.
+  They do not dispatch Miss or ClosestHit. Slang fixes this by lowering Miss and ClosestHit to
+  generated visible-function tables stored as function-table resource bindings.
+
+  **Constraint:** the host or Slang runtime must populate those generated visible-function tables
+  as part of the `TraceProgramDescriptor` lowering. The Miss, ClosestHit, and Callable entries can
+  be queried from the `ProgramLayout` reflection data described in the previous section. Miss uses
+  `desc.missIndex`, ClosestHit uses `logicalHitSlot`, and Callable uses its own callable index.
+
+- **Gap 2: Native function-table indexing is not the portable hit-slot formula.** Ordinary
+  `intersection_function_table` traversal does not use `RayTraversalDesc.sbtOffset` or
+  `RayTraversalDesc.sbtStride` when selecting candidate-hit functions. Metal selects an IFT entry
+  from acceleration-structure offsets:
+
+  ```text
+  metalIFTIndex =
+      geometryIntersectionFunctionTableOffset +
+      instanceIntersectionFunctionTableOffset
+  ```
+
+  Slang treats `logicalHitSlot` as the portable identity of the hit group:
+
+  ```text
+  logicalHitSlot = instanceOffset + geometryId * desc.sbtStride + desc.sbtOffset
+  ```
+
+  **Constraint:** the host must construct acceleration-structure function-table offsets and function
+  table contents so every `metalIFTIndex` selected by traversal maps to exactly one
+  `logicalHitSlot`. The numbers do not need to be equal. What matters is that the selected
+  candidate-hit function and the generated ClosestHit visible function represent the same logical
+  hit group:
+
+  ```text
+  intersection_function_table[metalIFTIndex]
+      -> generated AnyHit / custom Intersection candidate function
+      -> maps to logicalHitSlot
+
+  visible_function_table_1[logicalHitSlot]
+      -> generated ClosestHit function
+  ```
+
+  Separate `TraceProgramDescriptor` values per ray type are also a natural way to keep this
+  mapping simple.
+
+**Concrete Example**
+
+Suppose one trace call uses `desc.sbtStride = 2`, `desc.sbtOffset = 1`, and logical
+`instanceOffset = 0`. The portable logical slots are:
+
+```text
+logicalHitSlot(geometry 0) = 0 + geometryId 0 * 2 + 1 = 1
+logicalHitSlot(geometry 1) = 0 + geometryId 1 * 2 + 1 = 3
+```
+
+The Metal IFT indices do not need to be `1` and `3`. They only need a 1:1 mapping back to logical
+slots `1` and `3`:
+
+```text
+instance:
+    instanceIntersectionFunctionTableOffset = 8
+
+geometry 0:
+    geometryIntersectionFunctionTableOffset = 0
+    metalIFTIndex = 0 + 8 = 8
+    maps to logicalHitSlot 1
+
+geometry 1:
+    geometryIntersectionFunctionTableOffset = 4
+    metalIFTIndex = 4 + 8 = 12
+    maps to logicalHitSlot 3
+
+intersection_function_table[8]  -> candidate function for logicalHitSlot 1
+intersection_function_table[12] -> candidate function for logicalHitSlot 3
+
+visible_function_table_1[1] -> ClosestHit for logicalHitSlot 1
+visible_function_table_1[3] -> ClosestHit for logicalHitSlot 3
+```
+
+##### 2.2.2.2 Lowering To `intersection_function_buffer_arguments`
+
+The Metal 4 function-buffer path represents candidate-hit dispatch with an
+`intersection_function_buffer_arguments` value rather than an ordinary resource-object table.
+Figure 8 shows both the function-buffer layout and the descriptor-side data needed for generated
+Miss, ClosestHit, and Callable dispatch.
+
+<a id="fig-intersection-function-buffer-layout"></a>
+![Metal intersection function buffer arguments layout](figures/intersection-function-buffer-layout.svg)
+
+*Figure 8. Metal function-buffer lowering: `intersection_function_buffer_arguments` carries the candidate-hit table, while descriptor-side data carries records and visible-function dispatch resources for Miss, ClosestHit, and Callable dispatch.*
+
+**Native Layout**
+
+The native function-buffer argument describes the traversal-time candidate-hit table:
+
+```text
+intersection_function_buffer_arguments:
+    intersection_function_buffer      -> raw table of generated candidate-hit functions
+    intersection_function_buffer_size -> byte size of that table
+    intersection_function_stride      -> byte stride between table entries
+```
+
+The function-buffer table still only contains candidate-hit behavior: AnyHit filtering and custom
+Intersection logic. Descriptor-side data carries the rest of the portable trace program state:
+records, slot maps, bindless resources, and generated visible-function tables for Miss,
+ClosestHit, and Callable dispatch.
+
+**Lowering Strategy**
+
+When the compiler lowers `TraceProgramDescriptor<ProgramLayout>` to this function-buffer path, it
+can be thought of as:
+
+```text
+TraceProgramDescriptor<ProgramLayout>
+    intersection_function_buffer_arguments:
+        intersection_function_buffer      -> table of generated candidate-hit functions
+        intersection_function_buffer_size -> byte size of the table
+        intersection_function_stride      -> byte stride between entries
+
+    generated descriptor-side data:
+        records
+        slot maps
+        bindless resource handles
+        visible-function table for Miss
+        visible-function table for ClosestHit
+        visible-function table for Callable
+```
+
+The generated Metal-side use can be thought of as:
+
+```slang
+// Internal Metal-shaped pseudocode.
+let ifbArgs = descriptor.__intersectionFunctionBufferArguments;
+let descriptorData = descriptor.__generatedDescriptorData;
+let missFns = descriptorData.missVisibleFunctions;
+let closestHitFns = descriptorData.closestHitVisibleFunctions;
+
+metalIntersector.set_base_id(desc.sbtOffset);
+metalIntersector.set_geometry_multiplier(desc.sbtStride);
+
+let result = metalIntersector.intersect(desc.ray, scene, ifbArgs, descriptorData, payload);
+
+if (result.isNone)
+{
+    missFns[desc.missIndex](payload, descriptorData, desc.missIndex);
+}
+else
+{
+    uint logicalHitSlot =
+        instanceOffset + geometryId * desc.sbtStride + desc.sbtOffset;
+
+    closestHitFns[logicalHitSlot](payload, descriptorData, logicalHitSlot, result);
+}
+```
+
+**Gaps, Fixes, And Constraints**
+
+- **Gap 1: The function buffer still does not dispatch every ray-tracing stage.** Like ordinary
+  `intersection_function_table`, the function-buffer table dispatches candidate-hit behavior, not
+  Miss or ClosestHit. Slang fixes this by keeping candidate-hit functions in the function buffer
+  and lowering Miss, ClosestHit, and Callable to generated visible-function tables in
+  descriptor-side data.
+
+  **Constraint:** the host or Slang runtime must populate the generated visible-function tables
+  from the `ProgramLayout` reflection data described in the previous section. Miss uses
+  `desc.missIndex`, ClosestHit uses `logicalHitSlot`, and Callable uses its own callable index.
+
+- **Gap 2: The host must still build a target-side candidate-hit table.** The function-buffer form
+  is closer to the D3D/Vulkan SBT model than ordinary `intersection_function_table`, because the
+  table representation includes an explicit stride. Conceptually, this lets the backend model the
+  portable hit slot directly:
+
+  ```text
+  logicalHitSlot = instanceOffset + geometryId * desc.sbtStride + desc.sbtOffset
+  ```
+
+  **Constraint:** the host or Slang runtime must populate the function buffer consistently with the
+  reflected `ProgramLayout` hit groups and with the exact Metal IFB indexing rules. The same
+  logical slot should select both the candidate-hit function and the generated ClosestHit visible
+  function:
+
+  ```text
+  functionBuffer[logicalHitSlot]
+      -> generated AnyHit / custom Intersection candidate function
+
+  visible_function_table_1[logicalHitSlot]
+      -> generated ClosestHit function
+  ```
+
+**Concrete Example**
+
+Suppose one trace call uses `desc.sbtStride = 2`, `desc.sbtOffset = 1`, and logical
+`instanceOffset = 0`. The portable logical slots are the same as in the ordinary function-table
+example:
+
+```text
+logicalHitSlot(geometry 0) = 0 + geometryId 0 * 2 + 1 = 1
+logicalHitSlot(geometry 1) = 0 + geometryId 1 * 2 + 1 = 3
+```
+
+For the function-buffer lowering, the host or Slang runtime can lay out the candidate-hit table by
+logical hit slot:
+
+```text
+functionBuffer[0] -> unused or default candidate function
+functionBuffer[1] -> candidate function for logicalHitSlot 1
+functionBuffer[2] -> unused or default candidate function
+functionBuffer[3] -> candidate function for logicalHitSlot 3
+
+visible_function_table_1[1] -> ClosestHit for logicalHitSlot 1
+visible_function_table_1[3] -> ClosestHit for logicalHitSlot 3
+```
+
+The physical byte address of each function-buffer entry is derived from
+`intersection_function_buffer` plus `logicalHitSlot * intersection_function_stride`, subject to the
+exact Metal IFB traversal rules. The useful difference from ordinary function-table lowering is
+that the function-buffer table can be organized directly around the portable slot calculation,
+instead of requiring a separate `metalIFTIndex` to `logicalHitSlot` mapping.
+
+#### 2.2.3 Resolving The Metal Tag-List Issue With Context Types
+
+With the descriptor abstraction separated, the tag-list issue still needs a way to answer: "which
+trace object, hit shader, and intersection function share the same semantic requirements?" The
+proposed answer is a context type. A trace context defines the properties of a trace family:
+
+```slang
+interface ITraceContext
+{
+    associatedtype Payload;
+    associatedtype ASKind;
+    associatedtype Motion;
+    static const RayDataTags dataTags;
+    static const int maxLevels;
+}
+```
+
+A hit group context can specialize the trace context with a primitive kind and a record type:
+
+```slang
+interface IHitGroupContext
+{
+    associatedtype TraceContext : ITraceContext;
+    associatedtype Primitive : IIntersectionPrimitive;
+    associatedtype Record;
+}
+```
+
+A trace program layout connects the ray tracer and every grouped shader through the same trace
+context:
+
+```slang
+struct PrimaryTraceContext : rt::ITraceContext
+{
+    typealias Payload = RadiancePayload;
+    typealias ASKind = rt::InstanceAS;
+    typealias Motion = rt::NoMotion;
+    static const rt::RayDataTags dataTags = rt::RayDataTags::Triangle;
+    static const int maxLevels = 0;
+}
+
+struct PrimaryTriangleContext : rt::IHitGroupContext
+{
+    typealias TraceContext = PrimaryTraceContext;
+    typealias Primitive = rt::TrianglePrimitive;
+    typealias Record = PrimaryHitRecord;
+}
+
+struct PrimaryMissContext : rt::IMissGroupContext
+{
+    typealias TraceContext = PrimaryTraceContext;
+    typealias Record = PrimaryMissRecord;
+}
+
+struct PrimaryMissGroup : rt::IMissGroup
+{
+    typealias Context = PrimaryMissContext;
+    typealias Miss = PrimaryMiss;
+}
+
+struct PrimaryTriangleGroup : rt::IHitGroup
+{
+    typealias Context = PrimaryTriangleContext;
+    typealias ClosestHit = PrimaryTriangleClosestHit;
+    typealias AnyHit = PrimaryTriangleAnyHit;
+    typealias IntersectionAttributes = rt::NoAttributes;
+    typealias Intersection = rt::NoIntersection<PrimaryTriangleContext>;
+}
+
+struct PrimaryTraceProgramLayout : rt::ITraceProgramLayout
+{
+    typealias TraceContext = PrimaryTraceContext;
+
+    typealias MissGroups = rt::MissGroupList<
+        TraceContext,
+        PrimaryMissGroup>;
+
+    typealias HitGroups = rt::HitGroupList<
+        TraceContext,
+        PrimaryTriangleGroup>;
+
+    typealias CallableGroups = rt::NoCallableGroups<TraceContext>;
+}
+
+rt::TraceProgramDescriptor<PrimaryTraceProgramLayout> gPrimaryDescriptor;
+
+[shader("raygeneration")]
+void rayGen()
+{
+    RadiancePayload payload;
+    rt::RayTracer<PrimaryTraceProgramLayout> tracer;
+    tracer.trace(desc, scene, gPrimaryDescriptor, payload);
+}
+```
+
+This gives the compiler a source-level relationship:
+
+- `RayTracer<PrimaryTraceProgramLayout>` identifies one `ITraceProgramLayout`.
+- `PrimaryTraceProgramLayout.TraceContext` defines the trace-wide Metal tags.
+- Every group in `PrimaryTraceProgramLayout.HitGroups` is constrained to that trace context.
+- Any-hit and intersection stage structs receive input types derived from the same context.
+
+Figure 9 zooms into the handwritten code lines that carry the contract: the trace call names the
+program layout, and each stage `invoke(...)` method names the input context it accepts.
+
+<a id="fig-context-reachability"></a>
+![Context connects ray tracer and hit shaders](figures/context-reachability.svg)
+
+*Figure 9. Context reachability contract: the user-written trace call and stage `invoke(...)` signatures give the compiler a source-visible relationship between `RayTracer<ProgramLayout>`, the trace-wide context, hit groups, and stage input types.*
+
+This does not prove that arbitrary host data is correct. If the host builds an SBT or Metal
+function table that violates the reflected program layout, the program can still be wrong. The
+goal is to make the shader-side contract explicit enough that:
+
+- Slang can generate Metal tags for reachable custom intersection functions.
+- Slang can reject shader declarations that are inconsistent inside the program layout.
+- Reflection can expose the expected table to host code.
+- Validation layers or Slang runtime helpers can compare host records against the reflected
+  contract.
+
+### 2.3 Writing Stages As Interface-Conforming Types
+
+In the new model, miss, closest-hit, any-hit, and intersection logic are not written as independent
+entry points. They are written as ordinary structs that conform to built-in stage interfaces.
+
+Example:
+
+```slang
+struct PrimaryTriangleClosestHit
+    : rt::IClosestHitShader<PrimaryTriangleContext>
+{
+    void invoke(rt::ClosestHitInput<PrimaryTriangleContext> input)
+    {
+        input.payload.color = float4(input.distance, 0.0, 0.0, 1.0);
+    }
+}
+
+struct PrimaryTriangleAnyHit
+    : rt::IAnyHitShader<PrimaryTriangleContext>
+{
+    void invoke(rt::AnyHitInput<PrimaryTriangleContext> input)
+    {
+        if (isTransparent(input.triangle))
+            input.ignoreHit();
+    }
+}
+
+struct PrimarySphereIntersection
+    : rt::IIntersectionShader<PrimarySphereContext, SphereHitAttributes>
+{
+    rt::IntersectionReturn<PrimarySphereContext, SphereHitAttributes>
+    invoke(rt::IntersectionInput<PrimarySphereContext> input)
+    {
+        SphereHitAttributes attr;
+        float t = intersectSphere(input, attr);
+        return rt::IntersectionReturn<PrimarySphereContext, SphereHitAttributes>::accept(t, attr);
+    }
+}
+```
+
+The compiler is responsible for lowering these structs to the target form:
+
+- D3D and Vulkan: generated native entry points and hit groups, connected to SBT records.
+- Metal: generated intersection functions for any-hit/custom-intersection behavior, plus generated
+  post-trace Miss and ClosestHit visible-function dispatch.
+
+The user writes one source-level model. The target backend chooses the appropriate pipeline shape.
+
+## 3. Migration Examples
+
+### 3.1 Migrating Existing Metal Code To The New API
+
+Existing Metal users often write post-trace logic directly:
+
+```metal
+kernel void rayGen(...)
+{
+    intersector<instancing, triangle_data> tracer;
+    tracer.assume_geometry_type(geometry_type::triangle);
+
+    auto result = tracer.intersect(ray, scene, intersectionFunctionBuffer, payload);
+
+    if (result.type == intersection_type::none)
+    {
+        miss(payload);
+    }
+    else
+    {
+        uint slot = result.geometry_id;
+
+        switch (slot)
+        {
+        case 0: shadeOpaqueTriangle(payload, result); break;
+        case 1: shadeAlphaTriangle(payload, result); break;
+        case 2: shadeProceduralSphere(payload, result); break;
+        }
+    }
+}
+```
+
+With the proposed API, the user moves the manually dispatched operations into stage structs and
+declares the trace program layout structurally. The list order defines the portable logical hit
+slots:
+
+```slang
+struct PrimaryMissGroup : rt::IMissGroup
+{
+    typealias Context = PrimaryMissContext;
+    typealias Miss = PrimaryMiss;
+}
+
+struct PrimaryOpaqueTriangleGroup : rt::IHitGroup
+{
+    typealias Context = PrimaryTriangleContext;
+    typealias ClosestHit = PrimaryOpaqueTriangleClosestHit;
+    typealias AnyHit = rt::NoAnyHit<PrimaryTriangleContext>;
+    typealias IntersectionAttributes = rt::NoAttributes;
+    typealias Intersection = rt::NoIntersection<PrimaryTriangleContext>;
+}
+
+struct PrimaryAlphaTriangleGroup : rt::IHitGroup
+{
+    typealias Context = PrimaryTriangleContext;
+    typealias ClosestHit = PrimaryAlphaTriangleClosestHit;
+    typealias AnyHit = PrimaryAlphaTriangleAnyHit;
+    typealias IntersectionAttributes = rt::NoAttributes;
+    typealias Intersection = rt::NoIntersection<PrimaryTriangleContext>;
+}
+
+struct PrimarySphereGroup : rt::IHitGroup
+{
+    typealias Context = PrimarySphereContext;
+    typealias ClosestHit = PrimarySphereClosestHit;
+    typealias AnyHit = rt::NoAnyHit<PrimarySphereContext>;
+    typealias IntersectionAttributes = SphereHitAttributes;
+    typealias Intersection = PrimarySphereIntersection;
+}
+
+struct PrimaryTraceProgramLayout : rt::ITraceProgramLayout
+{
+    typealias TraceContext = PrimaryTraceContext;
+
+    typealias MissGroups = rt::MissGroupList<
+        TraceContext,
+        PrimaryMissGroup>;             // miss[0]
+
+    typealias HitGroups = rt::HitGroupList<
+        TraceContext,
+        PrimaryOpaqueTriangleGroup,     // hitGroup[0]
+        PrimaryAlphaTriangleGroup,      // hitGroup[1]
+        PrimarySphereGroup>;            // hitGroup[2]
+
+    typealias CallableGroups = rt::NoCallableGroups<TraceContext>;
+}
+
+rt::TraceProgramDescriptor<PrimaryTraceProgramLayout> gPrimaryDescriptor;
+```
+
+Ray-generation code becomes:
+
+```slang
+[shader("raygeneration")]
+void rayGen()
+{
+    RadiancePayload payload;
+
+    rt::RayTraversalDesc desc;
+    desc.ray = makeRay();
+    desc.instanceMask = 0xff;
+    desc.sbtOffset = 0;
+    desc.sbtStride = 1;
+    desc.missIndex = 0;
+
+    rt::RayTracer<PrimaryTraceProgramLayout> tracer;
+    tracer.trace(desc, scene, gPrimaryDescriptor, payload);
+}
+```
+
+For Metal, Slang generates code that is equivalent to the user's old post-trace dispatch, but the
+source of truth is now `PrimaryTraceProgramLayout.HitGroups` and
+`PrimaryTraceProgramLayout.MissGroups`. The generated dispatch uses Metal visible functions for
+Miss and ClosestHit rather than emitting one large switch containing every stage body.
+
+Metal host migration:
+
+1. Query `PrimaryTraceProgramLayout` through Slang reflection.
+2. Populate the generated Miss and ClosestHit visible-function tables in the
+   `TraceProgramDescriptor` lowering from the reflected miss and hit-group slots.
+3. Populate the candidate-hit dispatch resource from the reflected hit groups:
+   AnyHit and custom Intersection stages go into either an
+   `intersection_function_buffer_arguments` lowering or an ordinary `intersection_function_table`
+   lowering.
+4. If the lowering uses `intersection_function_buffer_arguments`, lay out the candidate-hit table
+   by the same logical hit slots that `RayTraversalDesc` computes. In this example,
+   `geometry_id` values `0`, `1`, and `2` map directly to logical hit slots `0`, `1`, and `2`.
+5. If the lowering uses ordinary `intersection_function_table`, choose native Metal IFT indices
+   for each reachable logical hit slot and build acceleration-structure function-table offsets so
+   traversal selects the corresponding native index. The native IFT index and logical hit slot do
+   not need to be numerically equal, but the mapping must be 1:1.
+
+This keeps Metal's AnyHit/custom-Intersection dispatch aligned with Slang's generated visible
+function dispatch for Miss and ClosestHit.
+
+### 3.2 Migrating Existing Slang D3D/Vulkan Ray Tracing Code
+
+Existing Slang code usually has independent pipeline entry points:
+
+```slang
+[shader("raygeneration")]
+void rayGen()
+{
+    RadiancePayload payload;
+
+    TraceRay(
+        scene,
+        flags,
+        instanceMask,
+        rayContributionToHitGroupIndex,
+        multiplierForGeometryContributionToHitGroupIndex,
+        missShaderIndex,
+        ray,
+        payload);
+}
+
+[shader("miss")]
+void miss(inout RadiancePayload payload)
+{
+    payload.color = backgroundColor;
+}
+
+[shader("closesthit")]
+void closestHit(inout RadiancePayload payload, BuiltInTriangleIntersectionAttributes attr)
+{
+    payload.color = shadeTriangle(attr);
+}
+```
+
+The migrated shader keeps the same conceptual data, but moves stage bodies into typed structs:
+
+```slang
+struct PrimaryMissContext : rt::IMissGroupContext
+{
+    typealias TraceContext = PrimaryTraceContext;
+    typealias Record = PrimaryMissRecord;
+}
+
+struct PrimaryMiss : rt::IMissShader<PrimaryMissContext>
+{
+    void invoke(rt::MissInput<PrimaryMissContext> input)
+    {
+        input.payload.color = backgroundColor;
+    }
+}
+
+struct PrimaryTriangleClosestHit
+    : rt::IClosestHitShader<PrimaryTriangleContext>
+{
+    void invoke(rt::ClosestHitInput<PrimaryTriangleContext> input)
+    {
+        input.payload.color = shadeTriangle(input.triangle);
+    }
+}
+```
+
+The old trace parameters map directly to fields in `RayTraversalDesc`:
+
+```slang
+rt::TraceProgramDescriptor<PrimaryTraceProgramLayout> gPrimaryDescriptor;
+
+rt::RayTraversalDesc desc;
+desc.ray = ray;
+desc.instanceMask = instanceMask;
+desc.sbtOffset = rayContributionToHitGroupIndex;
+desc.sbtStride = multiplierForGeometryContributionToHitGroupIndex;
+desc.missIndex = missShaderIndex;
+
+rt::RayTracer<PrimaryTraceProgramLayout> tracer;
+tracer.trace(desc, scene, gPrimaryDescriptor, payload);
+```
+
+D3D/Vulkan host migration:
+
+1. Query `PrimaryTraceProgramLayout` through Slang reflection.
+2. For each reflected miss group, add a miss record at its list position.
+3. For each reflected hit group, add a hit group record at its list position.
+4. Populate any reflected shader-record or local-root data associated with the miss, hit, and
+   callable groups.
+5. Use the same application data that previously produced `rayContributionToHitGroupIndex`,
+   `multiplierForGeometryContributionToHitGroupIndex`, and `missShaderIndex`.
+
+The native SBT model is not replaced, and `TraceProgramDescriptor<PrimaryTraceProgramLayout>` does
+not need to become a shader-visible resource on D3D/Vulkan. The new shader declarations make the
+intended SBT layout visible to Slang, which enables Metal lowering and gives host code a single
+reflected contract.
+
+### 3.3 Host Reflection Patterns
+
+The reflection API shape is not finalized. The expected information is:
+
+```cpp
+struct ReflectedTraceProgramLayout
+{
+    TypeReflection* traceContextType;
+    List<ReflectedMissGroup> missGroups;
+    List<ReflectedHitGroup> hitGroups;
+    List<ReflectedCallableGroup> callableGroups;
+};
+
+struct ReflectedMissGroup
+{
+    int slot;
+    TypeReflection* contextType;
+    TypeReflection* recordType;
+    EntryPointReflection* generatedMissEntryPoint;
+};
+
+struct ReflectedHitGroup
+{
+    int slot;
+    TypeReflection* contextType;
+    TypeReflection* recordType;
+    TypeReflection* intersectionAttributesType;
+    EntryPointReflection* generatedClosestHitEntryPoint;
+    EntryPointReflection* generatedAnyHitEntryPoint;
+    EntryPointReflection* generatedIntersectionEntryPoint;
+};
+
+struct ReflectedCallableGroup
+{
+    int slot;
+    TypeReflection* contextType;
+    TypeReflection* recordType;
+    EntryPointReflection* generatedCallableEntryPoint;
+};
+```
+
+The helper names in the following examples are illustrative; the reflection API shape and runtime
+ownership model are still open design questions.
+
+Pattern A: D3D/Vulkan native SBT.
+
+```cpp
+auto programLayout = reflection->findTraceProgramLayout("PrimaryTraceProgramLayout");
+
+for (auto miss : programLayout.missGroups)
+{
+    sbt.setMissRecord(
+        miss.slot,
+        miss.generatedMissEntryPoint,
+        buildShaderRecordData(miss.recordType));
+}
+
+for (auto hit : programLayout.hitGroups)
+{
+    sbt.setHitGroup(
+        hit.slot,
+        hit.generatedClosestHitEntryPoint,
+        hit.generatedAnyHitEntryPoint,
+        hit.generatedIntersectionEntryPoint,
+        buildShaderRecordData(hit.recordType));
+}
+
+for (auto callable : programLayout.callableGroups)
+{
+    sbt.setCallableRecord(
+        callable.slot,
+        callable.generatedCallableEntryPoint,
+        buildShaderRecordData(callable.recordType));
+}
+```
+
+The application still controls geometry contribution, instance contribution, stride, and offset.
+The reflected slots tell the application which shader group belongs at each SBT slot, while the
+reflected record types tell it what local-root/shader-record data each record expects.
+
+Pattern B: Metal intersection function buffer.
+
+```cpp
+auto programLayout = reflection->findTraceProgramLayout("PrimaryTraceProgramLayout");
+
+for (auto miss : programLayout.missGroups)
+{
+    descriptor.setGeneratedMissVisibleFunction(
+        miss.slot,
+        miss.generatedMissEntryPoint);
+    descriptor.setMissRecordData(
+        miss.slot,
+        buildShaderRecordData(miss.recordType));
+}
+
+for (auto hit : programLayout.hitGroups)
+{
+    descriptor.setGeneratedClosestHitVisibleFunction(
+        hit.slot,
+        hit.generatedClosestHitEntryPoint);
+
+    if (hit.generatedAnyHitEntryPoint || hit.generatedIntersectionEntryPoint)
+    {
+        functionBuffer.setFunction(
+            hit.slot,
+            buildGeneratedCandidateHitFunction(hit));
+    }
+
+    descriptor.setHitRecordData(
+        hit.slot,
+        buildShaderRecordData(hit.recordType));
+}
+
+for (auto callable : programLayout.callableGroups)
+{
+    descriptor.setGeneratedCallableVisibleFunction(
+        callable.slot,
+        callable.generatedCallableEntryPoint);
+    descriptor.setCallableRecordData(
+        callable.slot,
+        buildShaderRecordData(callable.recordType));
+}
+```
+
+For function-buffer lowering, the candidate-hit table is organized by the same logical slots used
+by generated ClosestHit dispatch. The host does not author custom post-trace dispatch logic for
+Metal, but the `TraceProgramDescriptor` lowering may expose generated visible-function table and
+record resources that the host or Slang runtime populates from the reflected program layout.
+
+Pattern C: Metal intersection function table.
+
+Metal's ordinary function table path uses the same reflected `ProgramLayout`, but candidate-hit
+selection is driven by acceleration-structure function-table offsets instead of directly by
+`RayTraversalDesc.sbtOffset` and `RayTraversalDesc.sbtStride`. Host setup must therefore align the
+ordinary function-table entries with the logical hit-group slots used by generated ClosestHit
+visible-function dispatch.
+
+```cpp
+auto programLayout = reflection->findTraceProgramLayout("PrimaryTraceProgramLayout");
+
+for (auto miss : programLayout.missGroups)
+{
+    descriptor.setGeneratedMissVisibleFunction(
+        miss.slot,
+        miss.generatedMissEntryPoint);
+    descriptor.setMissRecordData(
+        miss.slot,
+        buildShaderRecordData(miss.recordType));
+}
+
+for (auto hit : programLayout.hitGroups)
+{
+    descriptor.setGeneratedClosestHitVisibleFunction(
+        hit.slot,
+        hit.generatedClosestHitEntryPoint);
+
+    if (hit.generatedAnyHitEntryPoint || hit.generatedIntersectionEntryPoint)
+    {
+        uint metalIFTIndex = engineLayout.chooseMetalFunctionTableIndex(hit.slot);
+        functionTable.setFunction(
+            metalIFTIndex,
+            buildGeneratedCandidateHitFunction(hit));
+
+        engineLayout.recordMetalFunctionTableMapping(
+            hit.slot,
+            metalIFTIndex);
+    }
+
+    descriptor.setHitRecordData(
+        hit.slot,
+        buildShaderRecordData(hit.recordType));
+}
+
+for (auto callable : programLayout.callableGroups)
+{
+    descriptor.setGeneratedCallableVisibleFunction(
+        callable.slot,
+        callable.generatedCallableEntryPoint);
+    descriptor.setCallableRecordData(
+        callable.slot,
+        buildShaderRecordData(callable.recordType));
+}
+```
+
+This is valid when the engine also builds geometry and instance acceleration-structure metadata
+so traversal selects the same `metalIFTIndex` for primitives that post-trace dispatch will map to
+`hit.slot`. The mapping from `metalIFTIndex` to `hit.slot` must be 1:1, but the numbers do not
+need to be equal. Callable and Miss visible-function tables do not use this hit-slot mapping:
+Miss is indexed by `missIndex`, and Callable is indexed by the callable index. The proposal does
+not yet define an API for choosing ordinary function-table lowering versus function-buffer
+lowering; that is left as a backend/runtime policy to revisit.
+
+Pattern D: Manual host construction without reflection.
+
+A developer can still build the table by reading the shader source if the project chooses a fixed
+layout convention:
+
+```slang
+typealias HitGroups = rt::HitGroupList<
+    TraceContext,
+    PrimaryOpaqueTriangleGroup,     // hitGroup[0]
+    PrimaryAlphaTriangleGroup,      // hitGroup[1]
+    PrimarySphereGroup>;            // hitGroup[2]
+```
+
+Reflection is strongly preferred because it removes duplicated source-of-truth in host code and
+enables validation, but the layout is intentionally visible and reviewable in shader source.
+
+## 4. Open Design Questions
+
+- Exact reflection API names and ownership model.
+- Exact generated entry-point naming rules for D3D and Vulkan.
+- Whether Metal ordinary function-table lowering should be a restricted feature or a fully
+  supported path.
+- How to represent custom intersection attributes on Metal when native return-value limits are
+  insufficient.
+- How much runtime validation Slang should provide between reflected `ITraceProgramLayout` data and
+  host-created SBT or Metal function-buffer state.

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/README.md
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/README.md
@@ -1,0 +1,320 @@
+# SBT Structural Dispatch Design
+
+This directory sketches a Metal-first pipeline ray tracing API that still maps
+to D3D/Vulkan's native shader binding table model.
+
+Start with [PROPOSAL.md](PROPOSAL.md) for the formal draft design, including
+problem diagrams, API sketches, and migration examples. Use
+[TUTORIAL.md](TUTORIAL.md) for a step-by-step user-facing walkthrough.
+[SESSION_CONTEXT.md](SESSION_CONTEXT.md) records the compact context and
+candidate-selection rationale for the draft PR.
+
+[CALLABLE_SHADER_CONCERNS.md](CALLABLE_SHADER_CONCERNS.md) records open
+concerns about fitting D3D/Vulkan callable shaders into the `TraceProgram`
+model. It is intentionally separate from the main proposal while that part of
+the design is still being evaluated.
+
+## Problem
+
+D3D and Vulkan have native pipeline ray tracing stages. A trace call can select
+a miss shader, any-hit shader, intersection shader, and closest-hit shader
+through SBT indexing. The shader author writes stage entry points, and the
+driver/hardware performs the dispatch.
+
+Metal is different. Metal traversal can call custom intersection functions
+through an `intersection_function_table` or `intersection_function_buffer`, but
+Metal does not have native closest-hit or miss shader stages. A Metal
+`intersector::intersect(...)` call returns an `intersection_result`, and the
+caller shader must decide what to do next.
+
+That creates the central portability problem:
+
+```text
+D3D/Vulkan:
+    TraceRay(...) dispatches closest-hit for us.
+
+Metal:
+    intersector.intersect(...) returns a result.
+    Slang must synthesize closest-hit and miss dispatch after the trace.
+```
+
+We need an API that lets Slang reconstruct the missing Metal closest-hit/miss
+dispatch without imposing a new host-side model that blocks existing D3D/Vulkan
+users from migrating.
+
+## Design Choice
+
+There are two possible directions.
+
+### Option 1: Analyze User-Written Dispatch Code
+
+The source could let users write ordinary shader logic after `trace(...)`:
+
+```slang
+let result = tracer.trace(...);
+if (result.isNone)
+    shadeMiss(payload);
+else
+    switch (result.geometryIndex)
+    {
+    case 0: shadeTriangle(payload, result); break;
+    case 1: shadeCurve(payload, result); break;
+    }
+```
+
+This is natural for Metal. However, it makes D3D/Vulkan difficult because the
+compiler would need to analyze arbitrary user code, infer the dispatch behavior,
+and expose enough information for the host to reconstruct native SBT records.
+That analysis is brittle, hard to explain, and easy to break with dynamic code.
+
+### Option 2: Declare Structural Hit/Miss Groups
+
+The current design asks the user to declare the grouping explicitly:
+
+```slang
+struct PrimaryProgram : rt::TraceProgram
+{
+    typealias TraceContext = PrimaryTraceContext;
+
+    typealias MissGroups = rt::MissGroupList<...>;
+    typealias HitGroups = rt::HitGroupList<...>;
+}
+```
+
+Each group is assigned a slot:
+
+```slang
+typealias PrimaryTriangleHitSlot = rt::HitGroupSlot<0>;
+
+rt::HitGroup<
+    TraceContext,
+    PrimaryTriangleHitSlot,
+    PrimaryTriangleContext,
+    PrimaryTriangleClosestHit,
+    PrimaryTriangleAnyHit,
+    rt::NoAttributes,
+    rt::NoIntersection<PrimaryTriangleContext>>
+```
+
+This gives the compiler a finite, explicit list of logical hit groups. D3D and
+Vulkan can map those groups to native SBT records. Metal can synthesize a
+post-`intersect(...)` switch over the same slots.
+
+This is the chosen direction for this sketch.
+
+## Slot Model
+
+A slot is a compiled shader-group index. It is not a geometry ID, material ID,
+or primitive ID.
+
+In the example:
+
+```slang
+typealias PrimaryTriangleHitSlot = rt::HitGroupSlot<0>;
+typealias PrimaryCurveHitSlot = rt::HitGroupSlot<1>;
+typealias PrimarySphereHitSlot = rt::HitGroupSlot<2>;
+```
+
+means:
+
+```text
+hit slot 0 -> triangle hit group
+hit slot 1 -> curve hit group
+hit slot 2 -> sphere hit group
+```
+
+The slot is selected by the same SBT-style formula on all targets:
+
+```text
+slot = instanceContribution
+     + geometryContribution * dispatch.sbtStride
+     + dispatch.sbtOffset
+```
+
+The API spells this as:
+
+```slang
+public struct RayDispatch
+{
+    public uint sbtOffset;
+    public uint sbtStride;
+    public uint missIndex;
+}
+```
+
+and:
+
+```slang
+public uint getHitGroupSlot(
+    RayDispatch dispatch,
+    uint geometryContribution,
+    uint instanceContribution)
+{
+    return instanceContribution + geometryContribution * dispatch.sbtStride +
+        dispatch.sbtOffset;
+}
+```
+
+This formula is the load-bearing contract of the design.
+
+## Metal Lowering
+
+On Metal, Slang lowers:
+
+```slang
+rt::RayTracer<PrimaryProgram> tracer;
+tracer.trace(desc, scene, dispatch, payload);
+```
+
+into the shape:
+
+```slang
+metalIntersector.set_geometry_multiplier(dispatch.sbtStride);
+metalIntersector.set_base_id(dispatch.sbtOffset);
+result = metalIntersector.intersect(desc.ray, scene, ...);
+
+if (result.type == none)
+{
+    switch (dispatch.missIndex)
+    {
+    case 0: PrimaryMiss()(missInput); break;
+    }
+}
+else
+{
+    uint geometryContribution =
+        __rtGetGeometryContribution<PrimaryProgram>(result);
+    uint instanceContribution =
+        __rtGetInstanceContribution<PrimaryProgram>(result);
+    uint slot = getHitGroupSlot(
+        dispatch, geometryContribution, instanceContribution);
+
+    switch (slot)
+    {
+    case 0: PrimaryTriangleClosestHit()(triangleInput); break;
+    case 1: PrimaryCurveClosestHit()(curveInput); break;
+    case 2: PrimarySphereClosestHit()(sphereInput); break;
+    }
+}
+```
+
+Metal still dispatches any-hit/intersection logic during traversal through the
+function table or function buffer. Slang only synthesizes the missing
+closest-hit/miss dispatch after traversal.
+
+The key invariant is:
+
+```text
+the slot used for Metal any-hit/intersection dispatch
+must be the same slot used for synthesized closest-hit dispatch
+```
+
+For `intersection_function_buffer`, this maps cleanly:
+
+```text
+dispatch.sbtStride -> intersector::set_geometry_multiplier(...)
+dispatch.sbtOffset -> intersector::set_base_id(...)
+```
+
+The IFB record index and the synthesized closest-hit slot are then the same
+number.
+
+For ordinary `intersection_function_table`, Metal does not expose shader-side
+`base_id` or `geometry_multiplier`. That path only matches the general slot
+model when the acceleration structure's function-table offsets are already
+baked to the same slot numbers, or when the trace uses the restricted layout
+that those baked offsets represent.
+
+## D3D/Vulkan Lowering
+
+D3D and Vulkan already implement this kind of slot selection natively.
+
+Slang lowers:
+
+```slang
+tracer.trace(desc, scene, dispatch, payload);
+```
+
+to native trace parameters:
+
+```text
+dispatch.sbtOffset -> ray contribution / SBT record offset
+dispatch.sbtStride -> geometry contribution multiplier / SBT record stride
+dispatch.missIndex -> miss shader index
+```
+
+The native target dispatches the selected SBT record. Slang does not synthesize
+the closest-hit switch on D3D/Vulkan.
+
+## Host-Side Reflection Model
+
+The host should be able to query `TraceProgram` reflection data and build the
+target-specific dispatch resources from it.
+
+Conceptually, reflection for a trace program exposes:
+
+```text
+TraceProgram
+    TraceContext
+        Payload type
+        Acceleration-structure kind
+        Motion mode
+        Metal data tags / max levels
+
+    MissGroups[]
+        slot index
+        miss shader symbol
+
+    HitGroups[]
+        slot index
+        hit context
+        primitive kind
+        closest-hit shader symbol
+        any-hit shader symbol, or none
+        intersection shader symbol, or none
+        intersection attribute type
+        required Metal intersection tags
+```
+
+### D3D/Vulkan Host Flow
+
+1. Compile or synthesize native entry points for each reflected miss group and
+   hit group.
+2. Build the native ray tracing pipeline from those entry points.
+3. Build SBT records so reflected slot `N` corresponds to native hit/miss record
+   `N`.
+4. Use `RayDispatch.sbtOffset`, `RayDispatch.sbtStride`, and
+   `RayDispatch.missIndex` in trace calls exactly as the existing engine uses
+   native SBT indices.
+
+### Metal Host Flow
+
+1. Compile the generated Metal shader that contains the post-trace miss and
+   closest-hit switches.
+2. For hit groups with any-hit or intersection functions, populate the Metal
+   `intersection_function_buffer` or `intersection_function_table` using the
+   reflected slot numbers.
+3. Build acceleration-structure geometry and instance metadata so the Metal
+   function index contributions match `geometryContribution` and
+   `instanceContribution`.
+4. For IFB, Slang lowering sets `geometry_multiplier` from
+   `RayDispatch.sbtStride` and `base_id` from `RayDispatch.sbtOffset`.
+5. The host uses the same slot layout for Metal function records and for
+   D3D/Vulkan SBT records.
+
+This reflection model is intended to avoid a Metal-only host-side concept. The
+host still thinks in terms of trace programs and hit/miss groups; only the
+target backend decides whether those groups become SBT records or generated
+Metal switch cases.
+
+## Open Issues
+
+- Define precisely how `__rtGetGeometryContribution` and
+  `__rtGetInstanceContribution` are represented on Metal for primitive AS,
+  instance AS, ordinary function tables, and IFB.
+- Decide whether ordinary `intersection_function_table` should be a restricted
+  mode or whether the baseline should require IFB for fully general
+  `sbtOffset/sbtStride`.
+- Define the exact reflection API shape for enumerating `TraceProgram`,
+  `HitGroups`, and `MissGroups`.
+- Define how generated D3D/Vulkan entry-point names are exposed in reflection.

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/SESSION_CONTEXT.md
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/SESSION_CONTEXT.md
@@ -1,0 +1,79 @@
+# Session Context
+
+This file summarizes the design context for the draft PR. It is intentionally
+compact and records only the candidate direction selected for the PR.
+
+## Goal
+
+Design a Slang pipeline ray tracing API that can target D3D/DXR,
+Vulkan/SPIR-V, OptiX, and Metal. The main driver is Metal support: Metal can
+perform traversal and call custom intersection functions, but it does not have
+native miss or closest-hit pipeline stages.
+
+Inline ray tracing and ray queries are out of scope for this first design.
+
+## Source Material
+
+The design was informed by local notes comparing:
+
+- Metal ray tracing intrinsics: `intersector`, `intersection_result`,
+  `intersection_function_table`, Metal 4 intersection function buffers, and
+  Metal tag validity rules.
+- Existing Slang/DXR/Vulkan pipeline intrinsics: `TraceRay`, shader table
+  indexing, payloads, miss/any-hit/intersection/closest-hit stages, and
+  system-value intrinsics.
+
+Those comparison notes are not part of this PR. This PR keeps only the selected
+candidate API sketch and prototype code.
+
+## Selected Candidate
+
+The selected candidate is **SBT structural dispatch**:
+
+- Shader source declares a conceptual SBT through `ITraceProgramLayout`.
+- Hit, miss, and callable groups are represented as ordered Slang type lists.
+- A trace site uses `RayTraversalDesc`, `RayTracer<ProgramLayout>`, and
+  `TraceProgramDescriptor<ProgramLayout>`.
+- The portable hit slot is computed with the same formula as D3D/Vulkan:
+
+```text
+slot = instanceContribution
+     + geometryContribution * sbtStride
+     + sbtOffset
+```
+
+## Key Decisions
+
+- Keep Slang source pipeline-oriented. Users should not have to write
+  Metal-style post-`intersect` dispatch code for portable programs.
+- Lower Metal miss and closest-hit behavior by synthesizing post-trace
+  dispatch from the declared `ITraceProgramLayout`.
+- Use generated Metal visible-function dispatch for miss and closest-hit where
+  possible, with switch lowering only as semantic pseudocode or fallback.
+- Use Metal function tables or function buffers only for traversal-time
+  any-hit/custom-intersection behavior.
+- Avoid exposing Metal's ordered template tag lists as the main Slang user
+  model. Slang should derive Metal tags from trace context, hit group context,
+  primitive kind, motion mode, and descriptor choice.
+- Represent the target-specific binding object with
+  `TraceProgramDescriptor<ProgramLayout>`. On D3D/Vulkan it corresponds to
+  host-side SBT data; on Metal it lowers to the shader-visible function table
+  or function-buffer resources needed for traversal and generated dispatch.
+
+## Alternatives Excluded From This PR
+
+The repository workspace contains other local experiments, including static
+dispatch tables, isolated trace-context contracts, dispatchable contracts,
+standalone Metal stage-lowering sketches, and IFB/user-data samples. They are
+not staged for this PR because they are design history or narrower experiments,
+not the selected candidate.
+
+## Open Items
+
+- Decide how callable shaders fit the `TraceProgram` model.
+- Specify reflection data needed for host-side SBT/function-table construction.
+- Specify exact Metal IFT versus IFB lowering selection.
+- Define diagnostics for incompatible trace contexts, hit groups, primitive
+  kinds, motion modes, and target capabilities.
+- Decide which parts of the prototype `.slang` API should become standard
+  module declarations versus compiler-recognized built-ins.

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/TUTORIAL.md
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/TUTORIAL.md
@@ -1,0 +1,498 @@
+# Tutorial: Building a Ray Tracer with the SBT Structural Dispatch API
+
+This tutorial explains how an application would use the API sketched in this
+directory to build a pipeline ray tracer.
+
+The central idea is:
+
+```text
+Declare the hit/miss groups in shader source.
+Use RayTraversalDesc to select SBT-style slots at trace time.
+
+D3D/Vulkan:
+    native SBT dispatch uses those slots.
+
+Metal:
+    Slang synthesizes equivalent post-intersect visible-function dispatch.
+```
+
+The complete example is in
+[`rt-structural-dispatch-table-example.slang`](rt-structural-dispatch-table-example.slang).
+
+## Step 1: Import the Module
+
+Use the current prototype module:
+
+```slang
+import rt_pipeline;
+```
+
+The module is split into basic ray-tracing types in
+[`rt_basic_types.slang`](rt_basic_types.slang), stage contracts in
+[`rt_stage_contracts.slang`](rt_stage_contracts.slang), and structural
+dispatch-table/descriptor types in
+[`rt_structural_dispatch_table.slang`](rt_structural_dispatch_table.slang).
+
+### Difference from the Old Model
+
+Shader code:
+Old Slang ray tracing code typically uses target-shaped stage entry points such
+as `[shader("closesthit")]`, `[shader("miss")]`, and `[shader("intersection")]`.
+The new API imports a Slang-level library and writes stage logic as typed
+stage structs.
+
+Host code:
+The host no longer discovers only free-standing entry points. It can also query
+an `ITraceProgramLayout` that describes the groups and slots those entry points
+belong to.
+
+## Step 2: Define the Payload
+
+The payload is ordinary user data carried by the ray.
+
+```slang
+struct RadiancePayload
+{
+    float4 color;
+}
+```
+
+### Difference from the Old Model
+
+Shader code:
+The payload is still the application-defined ray payload. The main difference is
+that stage functions access it through input objects:
+
+```slang
+input.payload.color = ...;
+```
+
+instead of receiving target-native stage parameters directly.
+
+Host code:
+The host still needs to know the payload layout for pipeline compilation and
+validation. Reflection should expose the `TraceContext.Payload` type through the
+trace program layout.
+
+## Step 3: Define the Trace Context
+
+The trace context names the payload type and target-independent traversal shape.
+
+```slang
+struct PrimaryTraceContext : rt::ITraceContext
+{
+    typealias Payload = RadiancePayload;
+    typealias ASKind = rt::InstanceAS;
+    typealias Motion = rt::NoMotion;
+
+    static const rt::RayDataTags dataTags =
+        rt::RayDataTags::Triangle | rt::RayDataTags::Curve;
+    static const int maxLevels = 0;
+}
+```
+
+### Difference from the Old Model
+
+Shader code:
+Old code often relies on target builtins and entry-point signatures to imply
+payload, attribute, and acceleration-structure shape. The new API makes that
+shape explicit in a type.
+
+Host code:
+The host can use `TraceContext` reflection to validate that the bound
+acceleration structure, payload layout, and target capabilities match the trace
+program.
+
+## Step 4: Define Group Contexts
+
+Each hit group has a hit context. A hit context connects a trace context to a
+primitive kind and a per-record data type. Miss and callable groups use parallel
+context types.
+
+```slang
+struct PrimaryTriangleContext : rt::IHitGroupContext
+{
+    typealias TraceContext = PrimaryTraceContext;
+    typealias Primitive = rt::TrianglePrimitive;
+    typealias Record = PrimaryHitRecord;
+}
+
+struct PrimarySphereContext : rt::IHitGroupContext
+{
+    typealias TraceContext = PrimaryTraceContext;
+    typealias Primitive = rt::BoundingBoxPrimitive;
+    typealias Record = PrimaryHitRecord;
+}
+
+struct PrimaryMissContext : rt::IMissGroupContext
+{
+    typealias TraceContext = PrimaryTraceContext;
+    typealias Record = PrimaryMissRecord;
+}
+```
+
+### Difference from the Old Model
+
+Shader code:
+Old code usually expresses this through hit-group setup on the host and through
+different closest-hit/any-hit/intersection entry points. The new API also
+expresses it in shader source, so the compiler can type-check stage inputs.
+
+Host code:
+The host can reflect the primitive kind per hit group instead of inferring it
+only from external hit-group setup.
+
+## Step 5: Write Stage Structs
+
+Stages are ordinary structs that implement built-in stage contracts with an
+`invoke(...)` method.
+
+Miss:
+
+```slang
+struct PrimaryMiss : rt::IMissShader<PrimaryMissContext>
+{
+    void invoke(rt::MissInput<PrimaryMissContext> input)
+    {
+        input.payload.color = float4(0.0, 0.0, 0.0, 1.0);
+    }
+}
+```
+
+Closest-hit:
+
+```slang
+struct PrimaryTriangleClosestHit
+    : rt::IClosestHitShader<PrimaryTriangleContext>
+{
+    void invoke(rt::ClosestHitInput<PrimaryTriangleContext> input)
+    {
+        input.payload.color =
+            float4(input.triangle.barycentricCoord, input.distance, 1.0);
+    }
+}
+```
+
+Any-hit:
+
+```slang
+struct PrimaryTriangleAnyHit : rt::IAnyHitShader<PrimaryTriangleContext>
+{
+    void invoke(rt::AnyHitInput<PrimaryTriangleContext> input)
+    {
+        if (!input.triangle.frontFacing)
+        {
+            input.ignoreHit();
+        }
+    }
+}
+```
+
+Procedural intersection:
+
+```slang
+struct SphereHitAttributes
+{
+    float2 uv;
+}
+
+struct PrimarySphereIntersection
+    : rt::IIntersectionShader<PrimarySphereContext, SphereHitAttributes>
+{
+    typealias Attributes = SphereHitAttributes;
+
+    rt::IntersectionReturn<PrimarySphereContext, Attributes> invoke(
+        rt::IntersectionInput<PrimarySphereContext> input)
+    {
+        rt::IntersectionReturn<PrimarySphereContext, Attributes> result;
+        result.acceptIntersection = input.opaque;
+        result.continueSearch = true;
+        result.distance = 1.0;
+        result.attributes.uv = float2(0.25, 0.75);
+        return result;
+    }
+}
+```
+
+### Difference from the Old Model
+
+Shader code:
+Old code declares stage entry points directly. The new API declares stage
+structs. D3D/Vulkan lowering can still synthesize or expose native stage entry
+points from these structs. Metal lowering can call the same `invoke(...)`
+methods from generated code.
+
+Host code:
+The host should not need to manually guess which function belongs to which hit
+group. Reflection over the trace program layout provides that association.
+
+## Step 6: Declare Groups
+
+A slot is the compiled shader-group index used by dispatch. In the current API
+sketch, the slot is implicit: it is the zero-based position of a group in
+`MissGroupList`, `HitGroupList`, or `CallableGroupList`.
+
+```slang
+struct PrimaryMissGroup : rt::IMissGroup
+{
+    typealias Context = PrimaryMissContext;
+    typealias Miss = PrimaryMiss;
+}
+
+struct PrimaryTriangleGroup : rt::IHitGroup
+{
+    typealias Context = PrimaryTriangleContext;
+    typealias ClosestHit = PrimaryTriangleClosestHit;
+    typealias AnyHit = PrimaryTriangleAnyHit;
+    typealias IntersectionAttributes = rt::NoAttributes;
+    typealias Intersection = rt::NoIntersection<PrimaryTriangleContext>;
+}
+
+struct PrimarySphereGroup : rt::IHitGroup
+{
+    typealias Context = PrimarySphereContext;
+    typealias ClosestHit = PrimarySphereClosestHit;
+    typealias AnyHit = rt::NoAnyHit<PrimarySphereContext>;
+    typealias IntersectionAttributes = SphereHitAttributes;
+    typealias Intersection = PrimarySphereIntersection;
+}
+```
+
+These numbers are not geometry IDs. They are logical SBT/function-buffer slots:
+
+```text
+slot 0 -> triangle hit group
+slot 1 -> sphere hit group
+```
+
+### Difference from the Old Model
+
+Shader code:
+Old shader code usually does not declare the SBT slot numbers. They are mostly
+host-side knowledge. The new API makes the slot-to-shader-group association
+visible through group list order in shader source.
+
+Host code:
+The host still builds SBT records or Metal function records, but it can now use
+the reflected group list positions from shader code as the common contract.
+
+## Step 7: Declare the Trace Program Layout
+
+The trace program layout groups miss and hit shaders by slot.
+
+```slang
+struct PrimaryTraceProgramLayout : rt::ITraceProgramLayout
+{
+    typealias TraceContext = PrimaryTraceContext;
+
+    typealias MissGroups = rt::MissGroupList<
+        TraceContext,
+        PrimaryMissGroup>;       // miss[0]
+
+    typealias HitGroups = rt::HitGroupList<
+        TraceContext,
+        PrimaryTriangleGroup,    // hitGroup[0]
+        PrimarySphereGroup>;     // hitGroup[1]
+
+    typealias CallableGroups = rt::NoCallableGroups<TraceContext>;
+}
+
+rt::TraceProgramDescriptor<PrimaryTraceProgramLayout> gPrimaryDescriptor;
+```
+
+### Difference from the Old Model
+
+Shader code:
+Old code lets the host assemble hit groups externally. The new API asks shader
+source to declare the group structure explicitly.
+
+Host code:
+The host can build native target objects from reflected `ITraceProgramLayout`
+data: miss group `0`, hit group `0`, hit group `1`, and their associated
+shaders. This should reduce target-specific guesswork.
+
+## Step 8: Trace Rays
+
+Ray generation code creates a traversal description. It carries both the ray and
+the normalized SBT-style indices.
+
+```slang
+[shader("raygeneration")]
+void rayGenMain()
+{
+    rt::RayTraversalDesc desc;
+    desc.ray = makePrimaryRay(DispatchRaysIndex().xy);
+    desc.instanceMask = 0xff;
+    desc.sbtOffset = 0;
+    desc.sbtStride = 2;
+    desc.missIndex = 0;
+
+    RadiancePayload payload;
+    payload.color = float4(0.0, 0.0, 0.0, 1.0);
+
+    rt::RayTracer<PrimaryTraceProgramLayout> tracer;
+    tracer.trace(desc, gScene, gPrimaryDescriptor, payload);
+}
+```
+
+The hit slot formula is:
+
+```text
+slot = instanceContribution
+     + geometryContribution * desc.sbtStride
+     + desc.sbtOffset
+```
+
+### Difference from the Old Model
+
+Shader code:
+This is close to D3D/Vulkan `TraceRay` arguments, but the names are normalized:
+
+```text
+sbtOffset
+sbtStride
+missIndex
+```
+
+Metal shader code now also uses these concepts, because Slang needs them to
+synthesize ClosestHit visible-function dispatch.
+
+Host code:
+Existing D3D/Vulkan engines already compute these values for native tracing.
+The goal is that they can pass the same values through this API. Metal backends
+use the same values to configure IFB indexing and generated ClosestHit
+visible-function dispatch.
+
+## Step 9: Host Setup for D3D/Vulkan
+
+The host reflects `PrimaryTraceProgramLayout`.
+
+Conceptual reflection:
+
+```text
+MissGroups:
+    slot 0 -> PrimaryMiss
+
+HitGroups:
+    slot 0 -> PrimaryTriangleClosestHit, PrimaryTriangleAnyHit, no intersection
+    slot 1 -> PrimarySphereClosestHit, no any-hit, PrimarySphereIntersection
+```
+
+Host flow:
+
+1. Compile or generate native miss, closest-hit, any-hit, and intersection entry
+   points from the reflected stage structs.
+2. Build the D3D/Vulkan ray tracing pipeline with those entry points.
+3. Build SBT records so slot `N` corresponds to native SBT record `N`.
+4. Lower `RayTraversalDesc.sbtOffset`, `RayTraversalDesc.sbtStride`, and
+   `RayTraversalDesc.missIndex` directly to native trace arguments.
+
+### Difference from the Old Model
+
+Shader code:
+The shader provides group membership explicitly through `ITraceProgramLayout` instead
+of relying on host-only hit-group construction.
+
+Host code:
+The host still builds a normal SBT. The difference is that the SBT layout can be
+driven from reflection over `ITraceProgramLayout` instead of being a separate
+source of truth.
+
+## Step 10: Host Setup for Metal
+
+Metal does not have native closest-hit/miss dispatch. The host and compiler
+cooperate differently.
+
+Host flow:
+
+1. Compile the generated Metal shader that contains post-trace Miss and
+   ClosestHit dispatch through generated visible-function tables.
+2. Populate the generated Miss and ClosestHit visible-function tables from
+   `ITraceProgramLayout` reflection.
+3. For hit groups with any-hit or intersection shaders, populate the Metal
+   `intersection_function_buffer` or `intersection_function_table`.
+4. Use the reflected hit-group slots as the function-record indices.
+5. Build acceleration-structure geometry and instance metadata so the Metal
+   geometry and instance contributions match the slot formula.
+6. For IFB, Slang lowering maps:
+
+```text
+desc.sbtStride -> intersector::set_geometry_multiplier(...)
+desc.sbtOffset -> intersector::set_base_id(...)
+```
+
+Then the IFB record index and the generated closest-hit slot match.
+
+### Difference from the Old Model
+
+Shader code:
+Metal users no longer write all post-intersect closest-hit dispatch manually.
+They declare the same trace program layout groups used by other targets.
+
+The generated Metal code should prefer visible-function dispatch for Miss and
+ClosestHit. A literal switch is a useful semantic explanation, but it can force
+all reachable stage bodies into one shader compilation unit and increase
+register pressure for lightweight handlers when heavyweight handlers are also
+present.
+
+Host code:
+Metal host setup must make the function table or function buffer slot layout
+match `ITraceProgramLayout` reflection. For fully general `sbtOffset/sbtStride`, IFB is
+the clean path because it supports `base_id` and `geometry_multiplier`.
+
+## Step 11: Add More Ray Types or Materials
+
+To add a new ray type, allocate more slots and choose `sbtOffset` per ray.
+
+Example layout:
+
+```text
+geometry contribution 0:
+    slot 0 -> primary triangle
+    slot 1 -> shadow triangle
+
+geometry contribution 1:
+    slot 2 -> primary sphere
+    slot 3 -> shadow sphere
+```
+
+Then:
+
+```slang
+desc.sbtStride = 2;
+desc.sbtOffset = rayType; // 0 for primary, 1 for shadow
+```
+
+To add a new material, add another reflected hit group slot and make host-side
+geometry/instance metadata select that slot through the standard formula.
+
+### Difference from the Old Model
+
+Shader code:
+The shader must declare any new compiled hit groups in `ITraceProgramLayout`. Dynamic
+scene data can still choose among those slots at runtime through AS metadata and
+dispatch values.
+
+Host code:
+The host still controls which geometry/material/ray-type combination maps to
+which slot. The difference is that the target-independent slot meaning comes
+from `ITraceProgramLayout` reflection.
+
+## Debugging Checklist
+
+If the wrong closest-hit shader runs on Metal:
+
+- Check `desc.sbtOffset`.
+- Check `desc.sbtStride`.
+- Check `__rtGetGeometryContribution`.
+- Check `__rtGetInstanceContribution`.
+- Check that Metal IFB uses the same `set_base_id` and
+  `set_geometry_multiplier` values.
+- Check that the host populated IFB/table entries using the reflected slot
+  numbers.
+
+If D3D/Vulkan works but Metal does not, suspect a mismatch between Metal
+function index calculation and Slang's synthesized hit-group slot calculation.
+
+If Metal works but D3D/Vulkan does not, suspect SBT construction or generated
+native entry-point reflection.

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/api-overview.svg
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/api-overview.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="500" viewBox="0 0 1180 500" role="img" aria-label="API overview showing TraceProgramLayout reflection building host SBT and Metal function tables">
+  <style>
+    .title { font: 700 22px sans-serif; fill: #202020; }
+    .label { font: 700 14px sans-serif; fill: #202020; }
+    .small { font: 12px sans-serif; fill: #333333; }
+    .tiny { font: 11px sans-serif; fill: #333333; }
+    .source { fill: #f8fbff; stroke: #336699; stroke-width: 1.5; rx: 7; }
+    .program { fill: #f3fff6; stroke: #2f7d45; stroke-width: 2; rx: 8; }
+    .reflect { fill: #f7f3ff; stroke: #6d4db3; stroke-width: 2; rx: 8; }
+    .host { fill: #fffaf2; stroke: #a65f00; stroke-width: 1.5; rx: 7; }
+    .target { fill: #ffffff; stroke: #555555; stroke-width: 1.5; rx: 7; }
+    .note { fill: #fff4f4; stroke: #b42318; stroke-width: 2; rx: 8; }
+    .arrow { stroke: #333333; stroke-width: 1.8; marker-end: url(#arrow); fill: none; }
+    .greenArrow { stroke: #2f7d45; stroke-width: 2; marker-end: url(#arrowGreen); fill: none; }
+    .purpleArrow { stroke: #6d4db3; stroke-width: 2; marker-end: url(#arrowPurple); fill: none; }
+    .orangeArrow { stroke: #a65f00; stroke-width: 2; marker-end: url(#arrowOrange); fill: none; }
+    .greenText { font: 700 13px sans-serif; fill: #276738; }
+    .purpleText { font: 700 13px sans-serif; fill: #56389a; }
+    .redText { font: 700 13px sans-serif; fill: #8a1f17; }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#333333"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2f7d45"/>
+    </marker>
+    <marker id="arrowPurple" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#6d4db3"/>
+    </marker>
+    <marker id="arrowOrange" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#a65f00"/>
+    </marker>
+  </defs>
+
+  <text x="36" y="38" class="title">Proposed API overview: grouping logic moves into shader source</text>
+
+  <rect x="35" y="80" width="170" height="66" class="source"/>
+  <text x="55" y="106" class="label">Trace context</text>
+  <text x="50" y="128" class="small">payload, AS kind, tags</text>
+
+  <rect x="35" y="190" width="170" height="88" class="source"/>
+  <text x="55" y="216" class="label">Stage structs</text>
+  <text x="50" y="240" class="small">Miss / ClosestHit</text>
+  <text x="50" y="260" class="small">AnyHit / Intersection</text>
+
+  <rect x="265" y="102" width="250" height="160" class="program"/>
+  <text x="325" y="132" class="label">TraceProgramLayout</text>
+  <text x="295" y="162" class="small">TraceContext</text>
+  <text x="295" y="184" class="small">MissGroupList&lt;groups...&gt;</text>
+  <text x="295" y="206" class="small">HitGroupList&lt;groups...&gt;</text>
+  <text x="295" y="235" class="greenText">source-level grouping contract</text>
+
+  <path d="M205 113 L265 145" class="arrow"/>
+  <path d="M205 234 L265 205" class="arrow"/>
+
+  <rect x="610" y="115" width="205" height="112" class="reflect"/>
+  <text x="661" y="144" class="label">Slang reflection</text>
+  <text x="637" y="169" class="small">groups, slots, contexts</text>
+  <text x="637" y="190" class="small">stage entry symbols</text>
+  <text x="637" y="211" class="small">target-specific metadata</text>
+
+  <path d="M515 180 L610 180" class="purpleArrow"/>
+  <text x="525" y="78" class="purpleText">query ProgramLayout</text>
+  <text x="557" y="94" class="purpleText">reflection</text>
+
+  <rect x="950" y="62" width="195" height="108" class="host"/>
+  <text x="981" y="90" class="label">D3D / Vulkan host</text>
+  <text x="970" y="117" class="small">build native SBT</text>
+  <text x="970" y="138" class="small">miss records + hit groups</text>
+  <text x="970" y="158" class="small">from reflected slots</text>
+
+  <rect x="950" y="218" width="195" height="118" class="host"/>
+  <text x="1019" y="246" class="label">Metal host</text>
+  <text x="970" y="273" class="small">build function table</text>
+  <text x="970" y="294" class="small">or function buffer</text>
+  <text x="970" y="315" class="small">from reflected slots</text>
+
+  <path d="M815 145 C860 114 905 108 950 108" class="orangeArrow"/>
+  <text x="850" y="88" class="tiny">reflected</text>
+  <text x="850" y="103" class="tiny">groups</text>
+  <path d="M815 197 C862 236 905 260 950 279" class="orangeArrow"/>
+  <text x="866" y="205" class="tiny">reflected</text>
+  <text x="866" y="220" class="tiny">groups</text>
+
+  <rect x="265" y="335" width="250" height="68" class="source"/>
+  <text x="390" y="374" class="label" text-anchor="middle">RayTracer&lt;ProgramLayout&gt;.trace</text>
+
+  <rect x="610" y="320" width="205" height="96" class="target"/>
+  <text x="661" y="348" class="label">Target lowering</text>
+  <text x="632" y="376" class="small">D3D/Vulkan: native trace</text>
+  <text x="632" y="397" class="small">Metal: post-trace dispatch</text>
+
+  <path d="M390 262 L390 335" class="greenArrow"/>
+  <path d="M515 369 L610 369" class="arrow"/>
+
+  <rect x="35" y="340" width="170" height="92" class="note"/>
+  <text x="50" y="366" class="redText">No duplicated</text>
+  <text x="50" y="384" class="redText">grouping logic</text>
+  <text x="50" y="407" class="small">Change layout;</text>
+  <text x="50" y="426" class="small">host reads it.</text>
+</svg>

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/context-reachability.svg
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/context-reachability.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="430" viewBox="0 0 1080 430" role="img" aria-label="Context reachability shown through handwritten ray tracing code">
+  <style>
+    .title { font: 700 20px sans-serif; fill: #202020; }
+    .label { font: 700 14px sans-serif; fill: #202020; }
+    .small { font: 12px sans-serif; fill: #333333; }
+    .tiny { font: 11px sans-serif; fill: #333333; }
+    .code { font: 12px monospace; fill: #202020; }
+    .codeSmall { font: 11px monospace; fill: #202020; }
+    .layout { fill: #f3fff6; stroke: #2f7d45; stroke-width: 1.8; rx: 8; }
+    .codeBox { fill: #f8fbff; stroke: #336699; stroke-width: 1.6; rx: 7; }
+    .stage { fill: #fffaf2; stroke: #a65f00; stroke-width: 1.5; rx: 7; }
+    .zoom { fill: #ffffff; stroke: #777777; stroke-width: 1.5; rx: 10; }
+    .note { fill: #fff4f4; stroke: #b42318; stroke-width: 2; rx: 8; }
+    .arrow { stroke: #333333; stroke-width: 1.7; marker-end: url(#arrow); fill: none; }
+    .greenArrow { stroke: #2f7d45; stroke-width: 1.9; marker-end: url(#arrowGreen); fill: none; }
+    .orangeArrow { stroke: #a65f00; stroke-width: 1.8; marker-end: url(#arrowOrange); fill: none; }
+    .redText { font: 700 13px sans-serif; fill: #8a1f17; }
+    .greenText { font: 700 13px sans-serif; fill: #276738; }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#333333"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2f7d45"/>
+    </marker>
+    <marker id="arrowOrange" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#a65f00"/>
+    </marker>
+  </defs>
+
+  <text x="35" y="35" class="title">Context reachability is visible in the code users write</text>
+
+  <rect x="42" y="78" width="260" height="124" class="layout"/>
+  <text x="68" y="106" class="label">PrimaryTraceProgramLayout</text>
+  <text x="66" y="132" class="small">declares one trace context</text>
+  <text x="66" y="154" class="small">and ordered hit/miss groups</text>
+  <text x="66" y="181" class="greenText">source-level grouping contract</text>
+
+  <rect x="42" y="258" width="260" height="82" class="note"/>
+  <text x="66" y="287" class="redText">Do not infer this from host SBT</text>
+  <text x="66" y="312" class="small">The shader source names the layout</text>
+  <text x="66" y="332" class="small">at the trace call and stage inputs.</text>
+
+  <path d="M302 140 L370 140" class="greenArrow"/>
+  <text x="319" y="126" class="tiny">zoom</text>
+
+  <rect x="370" y="58" width="666" height="330" class="zoom"/>
+  <text x="394" y="89" class="label">Handwritten code lines that carry the contract</text>
+
+  <rect x="395" y="112" width="288" height="108" class="codeBox"/>
+  <text x="417" y="139" class="label">Ray-generation code</text>
+  <text x="417" y="164" class="codeSmall">rt::RayTracer&lt;</text>
+  <text x="435" y="183" class="codeSmall">PrimaryTraceProgramLayout&gt; tracer;</text>
+  <text x="417" y="205" class="codeSmall">tracer.trace(desc, scene,</text>
+  <text x="435" y="224" class="codeSmall">gPrimaryDescriptor, payload);</text>
+
+  <rect x="724" y="112" width="286" height="108" class="stage"/>
+  <text x="746" y="139" class="label">Closest-hit code</text>
+  <text x="746" y="162" class="codeSmall">void invoke(rt::ClosestHitInput&lt;</text>
+  <text x="764" y="181" class="codeSmall">PrimaryTriangleContext&gt; input)</text>
+  <text x="746" y="204" class="codeSmall">{ shadeTriangle(input); }</text>
+
+  <rect x="395" y="250" width="288" height="98" class="stage"/>
+  <text x="417" y="277" class="label">Any-hit code</text>
+  <text x="417" y="300" class="codeSmall">void invoke(rt::AnyHitInput&lt;</text>
+  <text x="435" y="319" class="codeSmall">PrimaryTriangleContext&gt; input)</text>
+  <text x="417" y="342" class="codeSmall">{ alphaTest(input); }</text>
+
+  <rect x="724" y="250" width="286" height="98" class="stage"/>
+  <text x="746" y="277" class="label">Intersection code</text>
+  <text x="746" y="300" class="codeSmall">void invoke(rt::IntersectionInput&lt;</text>
+  <text x="764" y="319" class="codeSmall">PrimarySphereContext&gt; input)</text>
+  <text x="746" y="342" class="codeSmall">{ return intersectSphere(input); }</text>
+
+  <path d="M683 166 L724 166" class="arrow"/>
+  <path d="M539 220 L539 250" class="orangeArrow"/>
+  <path d="M683 299 L724 299" class="arrow"/>
+
+  <text x="706" y="237" class="small">These names are what Slang links:</text>
+  <text x="706" y="256" class="small">ProgramLayout -> group -> stage input context.</text>
+</svg>

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/d3d-vulkan-sbt-layout.svg
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/d3d-vulkan-sbt-layout.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="430" viewBox="0 0 760 430" role="img" aria-label="D3D and Vulkan shader binding table layout">
+  <style>
+    .title { font: 700 20px sans-serif; fill: #202020; }
+    .label { font: 700 13px sans-serif; fill: #202020; }
+    .small { font: 12px sans-serif; fill: #333333; }
+    .tiny { font: 11px sans-serif; fill: #333333; }
+    .sbt { fill: #ffffff; stroke: #555555; stroke-width: 2; rx: 8; }
+    .hit { fill: #f8fbff; stroke: #336699; stroke-width: 1.5; rx: 6; }
+    .miss { fill: #fffaf2; stroke: #a65f00; stroke-width: 1.5; rx: 6; }
+    .call { fill: #f3fff6; stroke: #2f7d45; stroke-width: 1.5; rx: 6; }
+    .note { fill: #fffaf2; stroke: #a65f00; stroke-width: 1.5; rx: 7; }
+    .header { fill: #e9f2ff; stroke: #667788; stroke-width: 1; }
+    .cell { fill: #ffffff; stroke: #667788; stroke-width: 1; }
+    .highlight { fill: #ffe8e5; stroke: #b42318; stroke-width: 2; }
+    .redNote { font: 700 12px sans-serif; fill: #8a1f17; }
+  </style>
+
+  <text x="34" y="38" class="title">D3D / Vulkan Shader Binding Table</text>
+  <text x="34" y="62" class="small">One host-side object with hit-group, miss, and callable sections.</text>
+
+  <rect x="34" y="88" width="690" height="300" class="sbt"/>
+  <text x="60" y="118" class="label">Shader Binding Table</text>
+  <text x="222" y="118" class="redNote">no shader binding point</text>
+
+  <rect x="60" y="144" width="424" height="188" class="hit"/>
+  <text x="82" y="170" class="label">hit-group section: m x n</text>
+
+  <rect x="82" y="192" width="64" height="28" class="header"/>
+  <text x="97" y="210" class="tiny">row/col</text>
+  <rect x="146" y="192" width="86" height="28" class="header"/>
+  <text x="173" y="210" class="tiny">slot 0</text>
+  <rect x="232" y="192" width="86" height="28" class="header"/>
+  <text x="259" y="210" class="tiny">slot 1</text>
+  <rect x="318" y="192" width="86" height="28" class="header"/>
+  <text x="345" y="210" class="tiny">slot 2</text>
+  <rect x="404" y="192" width="36" height="28" class="header"/>
+  <text x="414" y="210" class="tiny">...</text>
+
+  <rect x="82" y="220" width="64" height="47" class="header"/>
+  <text x="99" y="248" class="tiny">row 0</text>
+  <rect x="146" y="220" width="86" height="47" class="cell"/>
+  <text x="162" y="235" class="tiny">ClosestHit</text>
+  <text x="170" y="250" class="tiny">AnyHit</text>
+  <text x="160" y="264" class="tiny">Intersection</text>
+  <rect x="232" y="220" width="86" height="47" class="cell"/>
+  <text x="248" y="235" class="tiny">ClosestHit</text>
+  <text x="256" y="250" class="tiny">AnyHit</text>
+  <text x="246" y="264" class="tiny">Intersection</text>
+  <rect x="318" y="220" width="86" height="47" class="cell"/>
+  <text x="334" y="235" class="tiny">ClosestHit</text>
+  <text x="342" y="250" class="tiny">AnyHit</text>
+  <text x="332" y="264" class="tiny">Intersection</text>
+  <rect x="404" y="220" width="36" height="47" class="cell"/>
+  <text x="414" y="248" class="tiny">...</text>
+
+  <rect x="82" y="267" width="64" height="47" class="header"/>
+  <text x="99" y="295" class="tiny">row 1</text>
+  <rect x="146" y="267" width="86" height="47" class="cell"/>
+  <text x="162" y="282" class="tiny">ClosestHit</text>
+  <text x="170" y="297" class="tiny">AnyHit</text>
+  <text x="160" y="311" class="tiny">Intersection</text>
+  <rect x="232" y="267" width="86" height="47" class="highlight"/>
+  <text x="248" y="282" class="tiny">ClosestHit</text>
+  <text x="256" y="297" class="tiny">AnyHit</text>
+  <text x="246" y="311" class="tiny">Intersection</text>
+  <rect x="318" y="267" width="86" height="47" class="cell"/>
+  <text x="334" y="282" class="tiny">ClosestHit</text>
+  <text x="342" y="297" class="tiny">AnyHit</text>
+  <text x="332" y="311" class="tiny">Intersection</text>
+  <rect x="404" y="267" width="36" height="47" class="cell"/>
+  <text x="414" y="295" class="tiny">...</text>
+
+  <rect x="500" y="144" width="160" height="86" class="miss"/>
+  <text x="530" y="170" class="label">miss section</text>
+  <rect x="540" y="184" width="80" height="20" class="cell"/>
+  <text x="563" y="198" class="tiny">Miss0</text>
+  <rect x="540" y="204" width="80" height="20" class="cell"/>
+  <text x="573" y="218" class="tiny">...</text>
+
+  <rect x="500" y="246" width="160" height="86" class="call"/>
+  <text x="526" y="272" class="label">callable section</text>
+  <rect x="540" y="286" width="80" height="20" class="cell"/>
+  <text x="562" y="300" class="tiny">Call0</text>
+  <rect x="540" y="306" width="80" height="20" class="cell"/>
+  <text x="573" y="320" class="tiny">...</text>
+
+  <rect x="66" y="348" width="590" height="24" class="note"/>
+  <text x="88" y="365" class="small">Hit-group records can name ClosestHit, AnyHit, and Intersection together.</text>
+</svg>

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/dispatch-model-gap.svg
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/dispatch-model-gap.svg
@@ -1,0 +1,140 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="820" viewBox="0 0 1120 820" role="img" aria-label="D3D and Vulkan SBT dispatch compared with Metal user-specified post-trace dispatch">
+  <style>
+    .title { font: 700 22px sans-serif; fill: #202020; }
+    .subtitle { font: 700 16px sans-serif; fill: #202020; }
+    .label { font: 14px sans-serif; fill: #202020; }
+    .small { font: 12px sans-serif; fill: #333333; }
+    .tiny { font: 11px sans-serif; fill: #333333; }
+    .note { font: 12px sans-serif; fill: #6b2f00; }
+    .gapLabel { font: 700 18px sans-serif; fill: #8a1f17; }
+    .gapNote { font: 14px sans-serif; fill: #8a1f17; }
+    .box { fill: #f8fbff; stroke: #336699; stroke-width: 1.5; rx: 7; }
+    .calc { fill: #f0f6ff; stroke: #336699; stroke-width: 1.5; rx: 7; }
+    .table { fill: #ffffff; stroke: #2f7d45; stroke-width: 1.5; rx: 7; }
+    .tableHeader { fill: #eaf7ef; stroke: #2f7d45; stroke-width: 1; }
+    .row { fill: #ffffff; stroke: #b8d9c2; stroke-width: 1; }
+    .rowAlt { fill: #f8fcf9; stroke: #b8d9c2; stroke-width: 1; }
+    .selected { fill: #fff3cf; stroke: #c98200; stroke-width: 2; }
+    .metal { fill: #fffaf2; stroke: #a65f00; stroke-width: 1.5; rx: 7; }
+    .metalHeader { fill: #fff0d8; stroke: #a65f00; stroke-width: 1; }
+    .problem { fill: #fff4f4; stroke: #b42318; stroke-width: 1.5; rx: 7; }
+    .gapBox { fill: #ffe4e0; stroke: #b42318; stroke-width: 2.5; rx: 8; }
+    .arrow { stroke: #333333; stroke-width: 1.8; marker-end: url(#arrow); fill: none; }
+    .arrowBlue { stroke: #336699; stroke-width: 1.8; marker-end: url(#arrowBlue); fill: none; }
+    .arrowGreen { stroke: #2f7d45; stroke-width: 1.8; marker-end: url(#arrowGreen); fill: none; }
+    .arrowOrange { stroke: #a65f00; stroke-width: 1.8; marker-end: url(#arrowOrange); fill: none; }
+    .dash { stroke: #777777; stroke-width: 1.6; stroke-dasharray: 5 4; marker-end: url(#arrow); fill: none; }
+    .gapArrow { stroke: #b42318; stroke-width: 2.2; stroke-dasharray: 7 4; marker-end: url(#arrowRed); fill: none; }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#333333"/>
+    </marker>
+    <marker id="arrowBlue" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#336699"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2f7d45"/>
+    </marker>
+    <marker id="arrowOrange" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#a65f00"/>
+    </marker>
+    <marker id="arrowRed" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#b42318"/>
+    </marker>
+  </defs>
+
+  <text x="36" y="38" class="title">Dispatch model gap</text>
+  <text x="36" y="62" class="small">D3D/Vulkan have native SBT dispatch for pipeline stages. Metal has traversal dispatch for custom intersection functions,</text>
+  <text x="36" y="80" class="small">but miss and closest-hit are ordinary post-trace shader logic.</text>
+
+  <text x="36" y="105" class="subtitle">D3D / Vulkan: driver or hardware dispatches through SBT records</text>
+
+  <rect x="40" y="130" width="210" height="125" class="box"/>
+  <text x="70" y="158" class="label">Ray-generation shader</text>
+  <text x="62" y="185" class="small">TraceRay / OpTraceRayKHR</text>
+  <text x="62" y="210" class="tiny">missIndex = 1</text>
+  <text x="62" y="229" class="tiny">sbtOffset = 2</text>
+  <text x="62" y="248" class="tiny">sbtStride = 3</text>
+
+  <rect x="292" y="130" width="275" height="125" class="calc"/>
+  <text x="326" y="158" class="label">Native index calculation</text>
+  <text x="312" y="188" class="small">hitSlot = instanceContribution</text>
+  <text x="337" y="207" class="small">+ geometryContribution * sbtStride</text>
+  <text x="337" y="226" class="small">+ sbtOffset</text>
+  <text x="312" y="247" class="tiny">example: 0 + 1 * 3 + 2 = hit slot 5</text>
+
+  <path d="M250 192 L292 192" class="arrowBlue"/>
+
+  <rect x="610" y="100" width="450" height="250" class="table"/>
+  <text x="635" y="126" class="label">Shader Binding Table, host-created</text>
+
+  <rect x="635" y="145" width="165" height="28" class="tableHeader"/>
+  <text x="650" y="164" class="small">Miss table</text>
+  <rect x="635" y="173" width="165" height="25" class="row"/>
+  <text x="650" y="190" class="tiny">Miss[0] background</text>
+  <rect x="635" y="198" width="165" height="25" class="selected"/>
+  <text x="650" y="215" class="tiny">Miss[1] shadow miss</text>
+  <rect x="635" y="223" width="165" height="25" class="row"/>
+  <text x="650" y="240" class="tiny">Miss[2] debug miss</text>
+
+  <rect x="835" y="145" width="195" height="28" class="tableHeader"/>
+  <text x="850" y="164" class="small">Hit-group table</text>
+  <rect x="835" y="173" width="195" height="24" class="row"/>
+  <text x="850" y="190" class="tiny">Slot 0: CH triangle matte</text>
+  <rect x="835" y="197" width="195" height="24" class="rowAlt"/>
+  <text x="850" y="214" class="tiny">Slot 1: CH triangle alpha + AH</text>
+  <rect x="835" y="221" width="195" height="24" class="row"/>
+  <text x="850" y="238" class="tiny">Slot 2: CH curve</text>
+  <rect x="835" y="245" width="195" height="24" class="rowAlt"/>
+  <text x="850" y="262" class="tiny">Slot 3: CH material A</text>
+  <rect x="835" y="269" width="195" height="24" class="row"/>
+  <text x="850" y="286" class="tiny">Slot 4: CH material B</text>
+  <rect x="835" y="293" width="195" height="36" class="selected"/>
+  <text x="850" y="309" class="tiny">Slot 5: CH sphere</text>
+  <text x="850" y="323" class="tiny">         + AH + Intersection</text>
+
+  <path d="M567 192 C585 175 595 165 610 159" class="arrowGreen"/>
+  <path d="M567 225 C590 275 605 303 835 311" class="arrowGreen"/>
+
+  <rect x="610" y="372" width="450" height="72" class="box"/>
+  <text x="635" y="400" class="label">Selected native stages</text>
+  <text x="635" y="422" class="small">Miss[1] if no hit. HitGroup[5] dispatches intersection, any-hit,</text>
+  <text x="635" y="438" class="small">and closest-hit as native pipeline stages.</text>
+  <path d="M835 329 L835 372" class="arrowGreen"/>
+
+  <path d="M650 444 C620 458 610 476 595 496" class="gapArrow"/>
+  <rect x="90" y="458" width="545" height="78" class="gapBox"/>
+  <text x="112" y="488" class="gapLabel">gap: closest-hit dispatch changes ownership</text>
+  <text x="112" y="516" class="gapNote">D3D/Vulkan: host SBT records. Metal: user-specified shader code.</text>
+  <path d="M595 520 C650 548 695 564 730 580" class="gapArrow"/>
+
+  <text x="36" y="562" class="subtitle">Metal: users write miss and closest-hit dispatch after intersect()</text>
+
+  <rect x="40" y="590" width="225" height="120" class="metal"/>
+  <text x="68" y="618" class="label">Ray-generation shader</text>
+  <text x="62" y="645" class="small">intersector.intersect(...)</text>
+  <text x="62" y="670" class="tiny">returns intersection_result</text>
+  <text x="62" y="689" class="tiny">no native miss / closest-hit call</text>
+
+  <rect x="315" y="590" width="230" height="120" class="table"/>
+  <text x="346" y="619" class="label">intersection_result</text>
+  <text x="342" y="646" class="small">hit or none</text>
+  <text x="342" y="669" class="small">distance, ids, tags</text>
+  <text x="342" y="692" class="small">used by user code</text>
+
+  <rect x="600" y="580" width="280" height="140" class="problem"/>
+  <text x="630" y="607" class="label">User-specified post-trace dispatch</text>
+  <text x="622" y="636" class="small">if result.none:</text>
+  <text x="652" y="656" class="small">miss(payload)</text>
+  <text x="622" y="680" class="small">else:</text>
+  <text x="652" y="700" class="small">switch geometry/material/ray type</text>
+
+  <rect x="315" y="742" width="565" height="48" class="metal"/>
+  <text x="335" y="763" class="note">Metal function table/buffer can dispatch AnyHit and Intersection during traversal,</text>
+  <text x="335" y="781" class="note">but not Miss or ClosestHit.</text>
+
+  <path d="M265 650 L315 650" class="arrowOrange"/>
+  <path d="M545 650 L600 650" class="arrowOrange"/>
+  <path d="M152 710 C210 790 260 795 315 790" class="dash"/>
+</svg>

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/intersection-function-buffer-layout.svg
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/intersection-function-buffer-layout.svg
@@ -1,0 +1,101 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="430" viewBox="0 0 820 430" role="img" aria-label="Metal intersection function buffer arguments layout">
+  <style>
+    .title { font: 700 20px sans-serif; fill: #202020; }
+    .label { font: 700 13px sans-serif; fill: #202020; }
+    .small { font: 12px sans-serif; fill: #333333; }
+    .tiny { font: 11px sans-serif; fill: #333333; }
+    .panel { fill: #ffffff; stroke: #777777; stroke-width: 1.5; rx: 8; }
+    .metalTable { fill: #f8fbff; stroke: #336699; stroke-width: 2; rx: 7; }
+    .userData { fill: #f3fff6; stroke: #2f7d45; stroke-width: 2; rx: 7; }
+    .visible { fill: #fffaf2; stroke: #a65f00; stroke-width: 1.5; rx: 6; }
+    .note { fill: #fffaf2; stroke: #a65f00; stroke-width: 1.5; rx: 7; }
+    .header { fill: #e9f2ff; stroke: #667788; stroke-width: 1; }
+    .cell { fill: #ffffff; stroke: #667788; stroke-width: 1; }
+    .highlight { fill: #ffe8e5; stroke: #b42318; stroke-width: 2; }
+    .arrow { stroke: #333333; stroke-width: 1.8; marker-end: url(#arrow); fill: none; }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#333333"/>
+    </marker>
+  </defs>
+
+  <text x="34" y="38" class="title">Metal intersection_function_buffer_arguments Layout</text>
+  <text x="34" y="62" class="small">Candidate-hit dispatch is table-shaped; descriptor-side data carries records and visible-function dispatch resources.</text>
+
+  <rect x="34" y="86" width="752" height="304" class="panel"/>
+
+  <rect x="64" y="122" width="402" height="226" class="metalTable"/>
+  <text x="88" y="149" class="label">function-buffer table: m x n</text>
+  <text x="88" y="170" class="small">one generated candidate-hit function per entry</text>
+
+  <rect x="88" y="194" width="70" height="28" class="header"/>
+  <text x="106" y="212" class="tiny">row/col</text>
+  <rect x="158" y="194" width="84" height="28" class="header"/>
+  <text x="185" y="212" class="tiny">slot 0</text>
+  <rect x="242" y="194" width="84" height="28" class="header"/>
+  <text x="269" y="212" class="tiny">slot 1</text>
+  <rect x="326" y="194" width="84" height="28" class="header"/>
+  <text x="353" y="212" class="tiny">slot 2</text>
+  <rect x="410" y="194" width="34" height="28" class="header"/>
+  <text x="420" y="212" class="tiny">...</text>
+
+  <rect x="88" y="222" width="70" height="44" class="header"/>
+  <text x="106" y="249" class="tiny">row 0</text>
+  <rect x="158" y="222" width="84" height="44" class="cell"/>
+  <text x="169" y="249" class="tiny">IntersectionFn</text>
+  <rect x="242" y="222" width="84" height="44" class="cell"/>
+  <text x="253" y="249" class="tiny">IntersectionFn</text>
+  <rect x="326" y="222" width="84" height="44" class="cell"/>
+  <text x="337" y="249" class="tiny">IntersectionFn</text>
+  <rect x="410" y="222" width="34" height="44" class="cell"/>
+  <text x="420" y="249" class="tiny">...</text>
+
+  <rect x="88" y="266" width="70" height="44" class="header"/>
+  <text x="106" y="293" class="tiny">row 1</text>
+  <rect x="158" y="266" width="84" height="44" class="cell"/>
+  <text x="169" y="293" class="tiny">IntersectionFn</text>
+  <rect x="242" y="266" width="84" height="44" class="highlight"/>
+  <text x="253" y="293" class="tiny">IntersectionFn</text>
+  <rect x="326" y="266" width="84" height="44" class="cell"/>
+  <text x="337" y="293" class="tiny">IntersectionFn</text>
+  <rect x="410" y="266" width="34" height="44" class="cell"/>
+  <text x="420" y="293" class="tiny">...</text>
+
+  <rect x="88" y="310" width="70" height="22" class="header"/>
+  <text x="117" y="325" class="tiny">...</text>
+  <rect x="158" y="310" width="84" height="22" class="cell"/>
+  <text x="194" y="325" class="tiny">...</text>
+  <rect x="242" y="310" width="84" height="22" class="cell"/>
+  <text x="278" y="325" class="tiny">...</text>
+  <rect x="326" y="310" width="84" height="22" class="cell"/>
+  <text x="362" y="325" class="tiny">...</text>
+  <rect x="410" y="310" width="34" height="22" class="cell"/>
+  <text x="420" y="325" class="tiny">...</text>
+
+  <path d="M468 236 L502 236" class="arrow"/>
+  <path d="M468 286 L502 286" class="arrow"/>
+
+  <rect x="506" y="122" width="130" height="226" class="userData"/>
+  <text x="530" y="149" class="label">descriptor data</text>
+  <text x="530" y="184" class="small">hit records</text>
+  <text x="530" y="209" class="small">miss records</text>
+  <text x="530" y="234" class="small">call records</text>
+  <text x="530" y="259" class="small">slot maps</text>
+  <text x="530" y="284" class="small">bindless data</text>
+
+  <rect x="656" y="122" width="104" height="72" class="visible"/>
+  <text x="676" y="148" class="label">Miss</text>
+  <text x="676" y="170" class="tiny">visible funcs</text>
+
+  <rect x="656" y="207" width="104" height="72" class="visible"/>
+  <text x="674" y="233" class="label">ClosestHit</text>
+  <text x="676" y="255" class="tiny">visible funcs</text>
+
+  <rect x="656" y="292" width="104" height="56" class="visible"/>
+  <text x="678" y="318" class="label">Callable</text>
+  <text x="676" y="338" class="tiny">visible funcs</text>
+
+  <rect x="74" y="360" width="644" height="22" class="note"/>
+  <text x="96" y="376" class="small">Miss dispatch uses missIndex; ClosestHit dispatch uses the same logical hit slot as the candidate-hit table.</text>
+</svg>

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/intersection-function-table-layout.svg
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/intersection-function-table-layout.svg
@@ -1,0 +1,162 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="650" viewBox="0 0 1180 650" role="img" aria-label="Metal intersection function table resource and closest hit dispatch zoom">
+  <style>
+    .title { font: 700 20px sans-serif; fill: #202020; }
+    .panelTitle { font: 700 15px sans-serif; fill: #202020; }
+    .label { font: 700 13px sans-serif; fill: #202020; }
+    .small { font: 12px sans-serif; fill: #333333; }
+    .tiny { font: 11px sans-serif; fill: #333333; }
+    .caption { font: 700 13px sans-serif; fill: #202020; }
+    .iftBox { fill: #ffffff; stroke: #555555; stroke-width: 2; rx: 10; }
+    .zoomBox { fill: #ffffff; stroke: #777777; stroke-width: 1.5; rx: 10; }
+    .table { fill: #f8fbff; stroke: #336699; stroke-width: 2; rx: 7; }
+    .buffer { fill: #f3fff6; stroke: #2f7d45; stroke-width: 2; rx: 7; }
+    .miss { fill: #fffaf2; stroke: #a65f00; stroke-width: 2; rx: 7; }
+    .closest { fill: #f3fff6; stroke: #2f7d45; stroke-width: 2; rx: 7; }
+    .callable { fill: #f7f0ff; stroke: #7755aa; stroke-width: 2; rx: 7; }
+    .note { fill: #fff4f4; stroke: #b42318; stroke-width: 2; rx: 7; }
+    .header { fill: #e9f2ff; stroke: #667788; stroke-width: 1; }
+    .cell { fill: #ffffff; stroke: #667788; stroke-width: 1; }
+    .hitCell { fill: #ffe8e5; stroke: #b42318; stroke-width: 2; }
+    .closestCell { fill: #eafff0; stroke: #2f7d45; stroke-width: 2; }
+    .arrow { stroke: #333333; stroke-width: 1.8; marker-end: url(#arrow); fill: none; }
+    .greenArrow { stroke: #2f7d45; stroke-width: 2; marker-end: url(#arrowGreen); fill: none; }
+    .greenBiArrow { stroke: #2f7d45; stroke-width: 2; marker-start: url(#arrowGreenStart); marker-end: url(#arrowGreen); fill: none; }
+    .redText { font: 700 12px sans-serif; fill: #8a1f17; }
+    .greenText { font: 700 12px sans-serif; fill: #1f6d39; }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#333333"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2f7d45"/>
+    </marker>
+    <marker id="arrowGreenStart" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M9,0 L9,6 L0,3 z" fill="#2f7d45"/>
+    </marker>
+  </defs>
+
+  <text x="34" y="38" class="title">Ordinary intersection_function_table lowering</text>
+
+  <rect x="34" y="70" width="444" height="486" class="iftBox"/>
+  <text x="58" y="100" class="panelTitle">intersection_function_table resource</text>
+  <text x="58" y="122" class="small">One shader-visible object with function entries and resource bindings.</text>
+
+  <rect x="62" y="152" width="388" height="118" class="table"/>
+  <text x="84" y="178" class="label">IFT entries</text>
+  <text x="84" y="200" class="small">native Metal traversal table</text>
+  <rect x="84" y="218" width="78" height="28" class="header"/>
+  <text x="104" y="236" class="tiny">index</text>
+  <rect x="162" y="218" width="240" height="28" class="header"/>
+  <text x="214" y="236" class="tiny">candidate-hit function</text>
+  <rect x="84" y="246" width="78" height="18" class="cell"/>
+  <text x="116" y="259" class="tiny">0</text>
+  <rect x="162" y="246" width="240" height="18" class="hitCell"/>
+  <text x="238" y="259" class="tiny">CandidateHit1</text>
+
+  <rect x="62" y="292" width="388" height="58" class="buffer"/>
+  <text x="84" y="318" class="label">buffer slot 0</text>
+  <text x="204" y="318" class="small">generated descriptor data</text>
+  <text x="84" y="338" class="tiny">records, slot maps, bindless handles</text>
+
+  <rect x="62" y="372" width="120" height="92" class="miss"/>
+  <text x="82" y="398" class="label">VFT 0</text>
+  <text x="82" y="420" class="small">Miss</text>
+  <text x="82" y="440" class="tiny">missIndex</text>
+
+  <rect x="196" y="372" width="120" height="92" class="closest"/>
+  <text x="216" y="398" class="label">VFT 1</text>
+  <text x="216" y="420" class="small">ClosestHit</text>
+  <text x="216" y="440" class="tiny">logicalHitSlot</text>
+
+  <rect x="330" y="372" width="120" height="92" class="callable"/>
+  <text x="350" y="398" class="label">VFT 2</text>
+  <text x="350" y="420" class="small">Callable</text>
+  <text x="350" y="440" class="tiny">callable index</text>
+
+  <rect x="62" y="488" width="388" height="42" class="note"/>
+  <text x="84" y="506" class="redText">IFT entries do not dispatch Miss or ClosestHit.</text>
+  <text x="84" y="522" class="small">Those are generated visible-function dispatches.</text>
+
+  <path d="M450 214 C510 214 500 142 560 142" class="arrow"/>
+  <path d="M256 372 C380 332 470 298 560 298" class="greenArrow"/>
+  <text x="494" y="132" class="small">zoom in</text>
+  <text x="416" y="284" class="greenText">aligned by mapping</text>
+
+  <rect x="560" y="70" width="586" height="486" class="zoomBox"/>
+  <text x="584" y="100" class="panelTitle">Dispatch zoom: ClosestHit VFT and IFT entries</text>
+
+  <rect x="584" y="126" width="536" height="54" class="buffer"/>
+  <text x="606" y="149" class="label">logicalHitSlot</text>
+  <text x="740" y="149" class="small">= instanceOffset + geometryId * desc.sbtStride + desc.sbtOffset</text>
+  <text x="606" y="169" class="small">Portable identity of the hit group used by reflection and ClosestHit dispatch.</text>
+
+  <rect x="584" y="214" width="246" height="204" class="closest"/>
+  <text x="606" y="238" class="label">visible_function_table_1</text>
+  <text x="606" y="258" class="small">indexed by logicalHitSlot</text>
+
+  <rect x="606" y="276" width="72" height="28" class="header"/>
+  <text x="630" y="294" class="tiny">slot</text>
+  <rect x="678" y="276" width="126" height="28" class="header"/>
+  <text x="706" y="294" class="tiny">ClosestHit</text>
+
+  <rect x="606" y="304" width="72" height="32" class="header"/>
+  <text x="634" y="325" class="tiny">0</text>
+  <rect x="678" y="304" width="126" height="32" class="closestCell"/>
+  <text x="706" y="325" class="tiny">ClosestHit0</text>
+
+  <rect x="606" y="336" width="72" height="32" class="header"/>
+  <text x="634" y="357" class="tiny">1</text>
+  <rect x="678" y="336" width="126" height="32" class="cell"/>
+  <text x="706" y="357" class="tiny">ClosestHit1</text>
+
+  <rect x="606" y="368" width="72" height="32" class="header"/>
+  <text x="634" y="389" class="tiny">2</text>
+  <rect x="678" y="368" width="126" height="32" class="closestCell"/>
+  <text x="706" y="389" class="tiny">ClosestHit2</text>
+
+  <rect x="874" y="214" width="246" height="204" class="table"/>
+  <text x="896" y="238" class="label">IFT entries</text>
+  <text x="896" y="258" class="small">host maps each slot to a native IFT index</text>
+
+  <rect x="896" y="276" width="58" height="28" class="header"/>
+  <text x="913" y="294" class="tiny">slot</text>
+  <rect x="954" y="276" width="70" height="28" class="header"/>
+  <text x="969" y="294" class="tiny">IFT index</text>
+  <rect x="1024" y="276" width="74" height="28" class="header"/>
+  <text x="1038" y="294" class="tiny">function</text>
+
+  <rect x="896" y="304" width="58" height="32" class="header"/>
+  <text x="918" y="325" class="tiny">0</text>
+  <rect x="954" y="304" width="70" height="32" class="hitCell"/>
+  <text x="973" y="325" class="tiny">idxA</text>
+  <rect x="1024" y="304" width="74" height="32" class="hitCell"/>
+  <text x="1034" y="325" class="tiny">CandFn0</text>
+
+  <rect x="896" y="336" width="58" height="32" class="header"/>
+  <text x="918" y="357" class="tiny">1</text>
+  <rect x="954" y="336" width="70" height="32" class="cell"/>
+  <text x="973" y="357" class="tiny">idxB</text>
+  <rect x="1024" y="336" width="74" height="32" class="cell"/>
+  <text x="1034" y="357" class="tiny">CandFn1</text>
+
+  <rect x="896" y="368" width="58" height="32" class="header"/>
+  <text x="918" y="389" class="tiny">2</text>
+  <rect x="954" y="368" width="70" height="32" class="hitCell"/>
+  <text x="973" y="389" class="tiny">idxC</text>
+  <rect x="1024" y="368" width="74" height="32" class="hitCell"/>
+  <text x="1034" y="389" class="tiny">CandFn2</text>
+
+  <path d="M830 320 C846 320 858 320 874 320" class="greenBiArrow"/>
+  <path d="M830 384 C846 384 858 384 874 384" class="greenBiArrow"/>
+  <text x="830" y="202" class="greenText">1:1 mapping, not equality</text>
+
+  <rect x="584" y="432" width="536" height="120" class="note"/>
+  <text x="606" y="454" class="redText">Metal native index = geometryIntersectionFunctionTableOffset</text>
+  <text x="606" y="472" class="redText">+ instanceIntersectionFunctionTableOffset.</text>
+  <text x="606" y="492" class="small">idxA/B/C are native IFT indices.</text>
+  <text x="606" y="510" class="small">Host setup maps each native IFT entry to one logical hit slot;</text>
+  <text x="606" y="526" class="small">the selected candidate and ClosestHit describe the same hit group.</text>
+
+  <text x="58" y="604" class="caption">The whole IFT resource carries function entries plus buffer and visible-function bindings; the zoom shows the only paired dispatch: candidate hit and ClosestHit.</text>
+</svg>

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/native-metal-tag-validation.svg
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/native-metal-tag-validation.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="370" viewBox="0 0 1120 370" role="img" aria-label="Native Metal tag validation at pipeline build time">
+  <style>
+    .title { font: 700 22px sans-serif; fill: #202020; }
+    .label { font: 700 14px sans-serif; fill: #202020; }
+    .small { font: 12px sans-serif; fill: #333333; }
+    .code { font: 12px monospace; fill: #202020; }
+    .metal { fill: #fffaf2; stroke: #a65f00; stroke-width: 1.5; rx: 7; }
+    .stage { fill: #fffaf2; stroke: #a65f00; stroke-width: 1.5; rx: 7; }
+    .host { fill: #f3fff6; stroke: #2f7d45; stroke-width: 1.5; rx: 7; }
+    .ok { fill: #eaf7ef; stroke: #2f7d45; stroke-width: 2; rx: 8; }
+    .warn { fill: #ffe4e0; stroke: #b42318; stroke-width: 2.4; rx: 8; }
+    .arrow { stroke: #333333; stroke-width: 1.7; marker-end: url(#arrow); fill: none; }
+    .greenArrow { stroke: #2f7d45; stroke-width: 1.8; marker-end: url(#arrowGreen); fill: none; }
+    .redArrow { stroke: #b42318; stroke-width: 2; marker-end: url(#arrowRed); fill: none; }
+    .greenText { font: 700 14px sans-serif; fill: #276738; }
+    .redText { font: 700 14px sans-serif; fill: #8a1f17; }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#333333"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2f7d45"/>
+    </marker>
+    <marker id="arrowRed" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#b42318"/>
+    </marker>
+  </defs>
+
+  <text x="36" y="38" class="title">Native Metal: explicit tags make pipeline validation possible</text>
+  <text x="36" y="62" class="small">The shader author writes tags on both intersectors and custom intersection functions. Host bindings are validated when the pipeline is built.</text>
+
+  <rect x="55" y="105" width="245" height="104" class="metal"/>
+  <text x="78" y="132" class="label">Metal shader source</text>
+  <text x="78" y="160" class="code">intersector&lt;TagA&gt; tracerA;</text>
+  <text x="78" y="184" class="code">intersector&lt;TagB&gt; tracerB;</text>
+
+  <rect x="355" y="92" width="285" height="132" class="stage"/>
+  <text x="377" y="119" class="label">Tagged intersection functions</text>
+  <text x="377" y="148" class="code">[[intersection(TagA)]] fA()</text>
+  <text x="377" y="172" class="code">[[intersection(TagB)]] fB()</text>
+  <text x="377" y="196" class="code">[[intersection(TagB)]] fC()</text>
+
+  <rect x="695" y="96" width="205" height="124" class="host"/>
+  <text x="722" y="124" class="label">Host bindings</text>
+  <text x="722" y="153" class="small">tracerA slot 0 -> fA</text>
+  <text x="722" y="177" class="small">tracerA slot 1 -> fB</text>
+  <text x="722" y="201" class="redText">slot 1 is a mismatch</text>
+
+  <rect x="955" y="96" width="155" height="124" class="ok"/>
+  <text x="983" y="124" class="greenText">Pipeline build</text>
+  <text x="978" y="153" class="small">sees tracer tags,</text>
+  <text x="978" y="174" class="small">function tags,</text>
+  <text x="978" y="195" class="small">and bindings</text>
+
+  <path d="M300 157 L355 157" class="arrow"/>
+  <path d="M640 157 L695 157" class="greenArrow"/>
+  <path d="M900 157 L955 157" class="greenArrow"/>
+
+  <rect x="180" y="270" width="820" height="58" class="warn"/>
+  <text x="210" y="294" class="redText">Late but detectable:</text>
+  <text x="370" y="294" class="small">pipeline build can reject tracerA -> fB because both sides already carry concrete Metal tags.</text>
+  <path d="M802 220 C770 246 730 258 650 270" class="redArrow"/>
+</svg>

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/reachability-definition.svg
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/reachability-definition.svg
@@ -1,0 +1,107 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="450" viewBox="0 0 1080 450" role="img" aria-label="Reachability definition: the SBT entries a trace call can select">
+  <style>
+    .title { font: 700 20px sans-serif; fill: #202020; }
+    .label { font: 700 14px sans-serif; fill: #202020; }
+    .small { font: 12px sans-serif; fill: #333333; }
+    .tiny { font: 11px sans-serif; fill: #333333; }
+    .code { font: 12px monospace; fill: #202020; }
+    .trace { fill: #f8fbff; stroke: #336699; stroke-width: 1.5; rx: 7; }
+    .calc { fill: #f0f6ff; stroke: #336699; stroke-width: 1.5; rx: 7; }
+    .table { fill: #ffffff; stroke: #2f7d45; stroke-width: 1.5; rx: 7; }
+    .row { fill: #f8f8f8; stroke: #d7d7d7; stroke-width: 1; }
+    .reachable { fill: #eaf7ef; stroke: #2f7d45; stroke-width: 2; }
+    .callout { fill: #fffaf2; stroke: #a65f00; stroke-width: 1.5; rx: 7; }
+    .warn { fill: #ffe4e0; stroke: #b42318; stroke-width: 2; rx: 8; }
+    .arrow { stroke: #333333; stroke-width: 1.7; marker-end: url(#arrow); fill: none; }
+    .greenArrow { stroke: #2f7d45; stroke-width: 1.9; marker-end: url(#arrowGreen); fill: none; }
+    .orangeArrow { stroke: #a65f00; stroke-width: 1.8; marker-end: url(#arrowOrange); fill: none; }
+    .redArrow { stroke: #b42318; stroke-width: 2; marker-end: url(#arrowRed); fill: none; }
+    .bracket { stroke: #2f7d45; stroke-width: 2.2; fill: none; }
+    .greenText { font: 700 14px sans-serif; fill: #276738; }
+    .redText { font: 700 13px sans-serif; fill: #8a1f17; }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#333333"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#2f7d45"/>
+    </marker>
+    <marker id="arrowOrange" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#a65f00"/>
+    </marker>
+    <marker id="arrowRed" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#b42318"/>
+    </marker>
+  </defs>
+
+  <text x="34" y="36" class="title">Reachability: which SBT entries can one trace call access?</text>
+
+  <rect x="42" y="78" width="210" height="126" class="trace"/>
+  <text x="68" y="105" class="label">One trace call</text>
+  <text x="64" y="132" class="code">TraceRay(...)</text>
+  <text x="64" y="158" class="tiny">sbtOffset = 2</text>
+  <text x="64" y="176" class="tiny">sbtStride = 3</text>
+  <text x="64" y="194" class="tiny">missIndex = 0</text>
+
+  <rect x="302" y="78" width="236" height="126" class="calc"/>
+  <text x="330" y="105" class="label">Runtime SBT index</text>
+  <text x="322" y="132" class="small">slot = instanceContribution</text>
+  <text x="366" y="151" class="small">+ geometryContribution * stride</text>
+  <text x="366" y="170" class="small">+ offset</text>
+  <text x="322" y="194" class="tiny">over all possible hits from this ray</text>
+
+  <path d="M252 141 L302 141" class="arrow"/>
+
+  <rect x="590" y="42" width="246" height="300" class="table"/>
+  <text x="660" y="68" class="label">Host SBT</text>
+
+  <rect x="615" y="86" width="176" height="26" class="row"/>
+  <text x="628" y="104" class="tiny">slot 0: other ray type</text>
+  <rect x="615" y="112" width="176" height="26" class="row"/>
+  <text x="628" y="130" class="tiny">slot 1: other ray type</text>
+  <rect x="615" y="138" width="176" height="34" class="reachable"/>
+  <text x="628" y="154" class="tiny">slot 2: HitGroup A</text>
+  <text x="646" y="168" class="tiny">AnyHit1, Intersection1</text>
+  <rect x="615" y="172" width="176" height="26" class="row"/>
+  <text x="628" y="190" class="tiny">slot 3: other ray type</text>
+  <rect x="615" y="198" width="176" height="26" class="row"/>
+  <text x="628" y="216" class="tiny">slot 4: other ray type</text>
+  <rect x="615" y="224" width="176" height="34" class="reachable"/>
+  <text x="628" y="240" class="tiny">slot 5: HitGroup B</text>
+  <text x="646" y="254" class="tiny">AnyHit2, Intersection2</text>
+  <rect x="615" y="258" width="176" height="26" class="row"/>
+  <text x="628" y="276" class="tiny">slot 6: other ray type</text>
+  <rect x="615" y="284" width="176" height="34" class="reachable"/>
+  <text x="628" y="300" class="tiny">slot 8: HitGroup C</text>
+  <text x="646" y="314" class="tiny">ClosestHit only</text>
+
+  <path d="M538 141 C565 132 577 135 615 153" class="greenArrow"/>
+  <path d="M538 151 C570 190 582 225 615 241" class="greenArrow"/>
+  <path d="M538 165 C570 242 582 288 615 300" class="greenArrow"/>
+
+  <path d="M808 138 L828 138 L828 318 L808 318" class="bracket"/>
+  <text x="844" y="222" class="greenText">Reachable entries</text>
+  <text x="844" y="244" class="small">the set this trace call</text>
+  <text x="844" y="263" class="small">may select at runtime</text>
+
+  <rect x="42" y="248" width="496" height="104" class="callout"/>
+  <text x="64" y="277" class="label">Definition used by this proposal</text>
+  <text x="64" y="302" class="small">Reachability(trace call) = the SBT hit or miss records</text>
+  <text x="64" y="322" class="small">that can be selected by that trace call.</text>
+  <text x="64" y="342" class="small">Those records determine which shader logic is reachable.</text>
+
+  <rect x="848" y="78" width="190" height="100" class="warn"/>
+  <text x="870" y="106" class="redText">Why this matters for Metal</text>
+  <text x="870" y="132" class="small">Reachable AnyHit and</text>
+  <text x="870" y="151" class="small">Intersection functions need</text>
+  <text x="870" y="170" class="small">the trace call's tag set.</text>
+
+  <path d="M836 154 C854 151 858 144 870 132" class="orangeArrow"/>
+
+  <path d="M715 342 L715 362" class="redArrow"/>
+  <rect x="590" y="362" width="448" height="74" class="warn"/>
+  <text x="612" y="386" class="redText">Existing model: host determines reachability</text>
+  <text x="612" y="407" class="small">Shader compile sees the trace call, but not the host SBT records</text>
+  <text x="612" y="426" class="small">or the binding edges to AnyHit/Intersection entries.</text>
+</svg>

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/slang-tag-synthesis-gap.svg
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/figures/slang-tag-synthesis-gap.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="470" viewBox="0 0 1180 470" role="img" aria-label="Slang Metal tag synthesis reachability gap">
+  <style>
+    .title { font: 700 22px sans-serif; fill: #202020; }
+    .label { font: 700 14px sans-serif; fill: #202020; }
+    .small { font: 12px sans-serif; fill: #333333; }
+    .code { font: 12px monospace; fill: #202020; }
+    .trace { fill: #f8fbff; stroke: #336699; stroke-width: 1.5; rx: 7; }
+    .stage { fill: #fffaf2; stroke: #a65f00; stroke-width: 1.5; rx: 7; }
+    .compile { fill: #f7f3ff; stroke: #6d4db3; stroke-width: 1.5; rx: 7; }
+    .host { fill: #f3fff6; stroke: #2f7d45; stroke-width: 1.5; rx: 7; }
+    .warn { fill: #ffe4e0; stroke: #b42318; stroke-width: 2.4; rx: 8; }
+    .arrow { stroke: #333333; stroke-width: 1.7; marker-end: url(#arrow); fill: none; }
+    .purpleArrow { stroke: #6d4db3; stroke-width: 1.8; marker-end: url(#arrowPurple); fill: none; }
+    .redArrow { stroke: #b42318; stroke-width: 2.1; marker-end: url(#arrowRed); fill: none; }
+    .dash { stroke: #777777; stroke-width: 1.5; stroke-dasharray: 5 4; marker-end: url(#arrow); fill: none; }
+    .redText { font: 700 14px sans-serif; fill: #8a1f17; }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#333333"/>
+    </marker>
+    <marker id="arrowPurple" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#6d4db3"/>
+    </marker>
+    <marker id="arrowRed" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#b42318"/>
+    </marker>
+  </defs>
+
+  <text x="36" y="38" class="title">Slang: host-owned reachability leaves tag synthesis underdetermined</text>
+  <text x="36" y="62" class="small">Slang can see trace sites and stage entry points, but existing shader source does not contain the host binding edges that connect them.</text>
+
+  <rect x="65" y="105" width="250" height="132" class="trace"/>
+  <text x="88" y="132" class="label">Ray-generation code</text>
+  <text x="88" y="160" class="code">intersector1.intersect(...)</text>
+  <text x="88" y="181" class="small">needs Metal tag set A</text>
+  <text x="88" y="210" class="code">intersector2.intersect(...)</text>
+  <text x="88" y="231" class="small">needs Metal tag set B</text>
+
+  <rect x="365" y="92" width="245" height="160" class="stage"/>
+  <text x="388" y="119" class="label">Independent stage entries</text>
+  <text x="388" y="146" class="code">AnyHit1()</text>
+  <text x="388" y="166" class="code">AnyHit2()</text>
+  <text x="388" y="186" class="code">AnyHit3()</text>
+  <text x="388" y="214" class="code">Intersection1()</text>
+  <text x="388" y="234" class="code">Intersection2()</text>
+
+  <rect x="660" y="98" width="210" height="148" class="compile"/>
+  <text x="691" y="125" class="label">Slang Metal codegen</text>
+  <text x="684" y="155" class="small">must emit:</text>
+  <text x="684" y="181" class="code">[[intersection(?)]]</text>
+  <text x="684" y="203" class="code">generatedAnyHit()</text>
+  <text x="684" y="230" class="redText">Which tag set?</text>
+
+  <rect x="950" y="98" width="185" height="148" class="host"/>
+  <text x="978" y="125" class="label">Host bindings</text>
+  <text x="973" y="155" class="small">slot tables decide:</text>
+  <text x="973" y="180" class="small">A -> Intersection2</text>
+  <text x="973" y="202" class="small">B -> AnyHit1</text>
+  <text x="973" y="227" class="redText">Available later</text>
+
+  <path d="M315 171 L365 171" class="dash"/>
+  <path d="M610 172 L660 172" class="purpleArrow"/>
+  <path d="M950 172 C920 172 900 172 870 172" class="redArrow"/>
+  <text x="880" y="161" class="redText">too late</text>
+
+  <rect x="165" y="305" width="860" height="104" class="warn"/>
+  <text x="190" y="334" class="redText">Core problem:</text>
+  <text x="310" y="334" class="small">Slang must synthesize Metal tags before host binding data reveals reachability.</text>
+  <text x="310" y="358" class="small">Without a source-level reachability contract, it cannot know whether each generated</text>
+  <text x="310" y="378" class="small">AnyHit/Intersection function needs tag set A, tag set B, or another tag set.</text>
+
+  <path d="M488 252 C492 278 520 296 560 305" class="redArrow"/>
+  <path d="M765 246 C760 276 735 296 700 305" class="redArrow"/>
+  <path d="M1042 246 C1015 280 960 298 900 305" class="redArrow"/>
+</svg>

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/function_table_abstraction.md
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/function_table_abstraction.md
@@ -1,0 +1,301 @@
+# Function Table Abstraction Brainstorm
+
+This note explores whether Metal `intersection_function_table`, D3D/Vulkan SBT
+records, and callable shader tables can be described by one higher-level
+abstraction.
+
+This is not yet a proposal. The purpose is to stress-test the mental model
+before changing the main design.
+
+## Starting Point
+
+At a high level, all targets have some kind of table-driven dispatch:
+
+- D3D/Vulkan use shader binding tables. Traversal selects miss and hit shader
+  records, and shader code can also call callable shader records.
+- Metal uses `intersection_function_table` for traversal-time custom
+  intersection functions. Metal does not use this table to dispatch closest-hit
+  or miss logic.
+
+The tempting abstraction is:
+
+```text
+TraceProgram describes a conceptual ray dispatch table.
+
+D3D/Vulkan:
+    TraceProgram -> native SBT regions
+
+Metal:
+    TraceProgram -> intersection function table
+                 -> generated post-trace closest-hit/miss dispatch
+```
+
+This direction is plausible, but a few details matter.
+
+## Correction 1: Metal Function Tables Do Not Store AnyHit + Intersection Pairs
+
+A Slang hit group may contain:
+
+```text
+closest-hit | any-hit | intersection
+```
+
+A D3D/Vulkan SBT hit-group record naturally maps to this shape:
+
+```text
+closest-hit | any-hit | intersection
+```
+
+Metal's ordinary `intersection_function_table` does not. Each function entry is
+effectively:
+
+```text
+one selected Metal [[intersection(...)] function
+```
+
+Metal has no native any-hit stage. Therefore, if Slang exposes both `AnyHit`
+and `Intersection`, Metal lowering must represent the traversal-time part of a
+hit group with one Metal intersection function.
+
+Conceptually:
+
+```text
+Slang HitGroup row:
+    closestHit | anyHit | intersection
+
+D3D/Vulkan SBT row:
+    closestHit | anyHit | intersection
+
+Metal traversal table row:
+    generated-or-selected [[intersection(...)]] function
+        represents the anyHit/intersection portion only
+
+Metal post-trace dispatch:
+    selected closestHit runs after intersector.intersect(...) returns
+```
+
+So Metal traversal tables can participate in the same conceptual hit-group
+schema, but they do not store the same per-row stage tuple as D3D/Vulkan.
+
+## Correction 2: Metal Visible Function Tables Are Resource Bindings, Not SBT Sections
+
+It is useful to think of a Metal `intersection_function_table` as having two
+kinds of contents:
+
+```text
+function-entry slots:
+    slot 0 -> selected [[intersection(...)]] function
+    slot 1 -> selected [[intersection(...)]] function
+    ...
+
+resource-binding slots:
+    buffer slot 0 -> material data
+    visible-function-table slot 0 -> alpha-test/helper function table
+    ...
+```
+
+However, a visible function table is not a second traversal-dispatched section
+of the ordinary intersection function table.
+
+Traversal selects the intersection function entry. The selected intersection
+function may then use table-provided resources, including visible function
+tables.
+
+This is different from D3D/Vulkan callable shaders:
+
+```text
+D3D/Vulkan callable shader:
+    ray tracing shader stage selected from callable SBT region
+
+Metal visible function table:
+    resource-like typed table of visible functions used by shader code
+```
+
+They are related as indirect-call mechanisms, but they should not be treated as
+the same semantic object in the portable API.
+
+## Correction 3: Ray Type Is A Layout Convention, Not A First-Class SBT Column
+
+D3D/Vulkan SBT diagrams often look like:
+
+```text
+                    ray type 0                  ray type 1
+geometry 0      hit group 0                 hit group 1
+geometry 1      hit group 2                 hit group 3
+```
+
+That is a useful visualization, but the actual portable contract is index
+arithmetic:
+
+```text
+hitGroupIndex =
+    instanceContribution
+  + geometryContribution * sbtStride
+  + sbtOffset
+```
+
+If an engine chooses:
+
+```text
+sbtStride = rayTypeCount
+sbtOffset = rayType
+```
+
+then the table behaves like a geometry-by-ray-type grid.
+
+The API should expose the arithmetic contract, not hard-code the idea of ray
+type columns.
+
+## Metal Ray-Type Support
+
+The ordinary table selects entries from acceleration-structure offsets:
+
+```text
+primitive AS:
+    functionIndex = geometryIntersectionFunctionTableOffset
+
+instance AS:
+    functionIndex =
+        geometryIntersectionFunctionTableOffset
+      + instanceIntersectionFunctionTableOffset
+```
+
+There is no shader-side `base_id` or `geometry_multiplier` on this path.
+
+This means ordinary function tables do not naturally support the full
+D3D/Vulkan-style dynamic pair:
+
+```text
+sbtOffset
+sbtStride
+```
+
+They can still be useful when the desired slot layout is baked into
+acceleration-structure offsets, when a different table is selected, or when the
+program uses a restricted dispatch layout.
+
+## Proposed Abstraction Boundary
+
+The portable abstraction should not be named or shaped as a Metal function
+table. Instead:
+
+```text
+TraceProgram = shader-visible schema for conceptual ray dispatch tables
+```
+
+`TraceProgram` should describe logical regions:
+
+```slang
+struct PrimaryProgram : rt::TraceProgram
+{
+    typealias TraceContext = PrimaryTraceContext;
+
+    typealias HitGroups = rt::HitGroupList<
+        rt::HitGroup<Slot0, ClosestHit0, AnyHit0, Intersection0>,
+        rt::HitGroup<Slot1, ClosestHit1, NoAnyHit, BuiltinTriangle>>;
+
+    typealias MissGroups = rt::MissGroupList<
+        rt::MissGroup<MissSlot0, PrimaryMiss>>;
+
+    // Optional future extension:
+    // typealias CallableDomains = rt::CallableDomainList<...>;
+}
+```
+
+Reflection over this schema can then expose:
+
+```text
+TraceProgram
+    HitGroups[]
+        slot
+        closest-hit shader
+        any-hit shader, or none
+        intersection shader, or built-in
+        required Metal traversal tags
+
+    MissGroups[]
+        slot
+        miss shader
+
+    CallableDomains[]       // optional future extension
+        domain
+        parameter type
+        callable slots
+```
+
+## Target Mapping
+
+### D3D/Vulkan
+
+```text
+HitGroups      -> native SBT hit-group records
+MissGroups     -> native SBT miss records
+CallableGroups -> native callable SBT region, if added
+```
+
+The target already performs hit/miss dispatch. Slang does not synthesize a
+post-trace closest-hit/miss switch.
+
+### Metal Ordinary Function Table
+
+```text
+HitGroups.anyHit/intersection -> function-table entries
+HitGroups.closestHit          -> generated post-trace switch
+MissGroups                    -> generated post-trace switch
+```
+
+This path only matches the general slot model when the acceleration-structure
+offsets, selected table, and shader dispatch values are constrained to a
+compatible layout. It should not be treated as the fully general baseline for
+`sbtOffset/sbtStride`.
+
+## Host-Side Goal
+
+The host should not have to hand-maintain separate grouping logic for each
+target. It should be able to query `TraceProgram` reflection and build the
+target-specific objects:
+
+```text
+D3D/Vulkan:
+    build ray tracing pipeline
+    build hit/miss/callable SBT records from reflected groups
+
+Metal ordinary table:
+    build function table entries from reflected hit groups
+    ensure AS offsets match reflected slot layout
+    rely on generated post-trace closest-hit/miss dispatch
+```
+
+This keeps the first priority on shader-side portability while still allowing a
+backend such as slang-rhi to hide target-specific host object creation.
+
+## Open Questions
+
+1. Can ordinary Metal `intersection_function_table` support the same practical
+   dispatch patterns as D3D/Vulkan SBT without introducing extra host-side
+   requirements?
+2. Should ordinary Metal `intersection_function_table` be exposed as a
+   restricted lowering mode if it cannot support the full dynamic
+   `RayDispatch.sbtOffset/sbtStride` model?
+3. How should the API express that a target supports only a restricted dispatch
+   layout?
+4. Should callable shader tables be added to `TraceProgram` now, or left as a
+   follow-up extension after hit/miss/hit-group dispatch is stable?
+5. If callables are added later, should they be grouped by typed callable
+   domains rather than one untyped global callable list?
+
+## Provisional Position
+
+The common abstraction should be `TraceProgram` as a dispatch schema, not a
+portable "function table" object.
+
+The schema can map to:
+
+```text
+D3D/Vulkan SBT
+Metal ordinary function table with restrictions
+generated Metal closest-hit/miss dispatch
+```
+
+This keeps the shader-side model target-neutral while acknowledging that the
+underlying target tables are not the same object.

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/rt-structural-dispatch-table-example.slang
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/rt-structural-dispatch-table-example.slang
@@ -1,0 +1,261 @@
+// Part 3 alternative example: structural dispatch table usage.
+//
+// This sketch asks the shader author to provide the selection structure that is
+// otherwise implicit in a native SBT. Metal can lower that structure to ordinary
+// shader-side post-intersect code, while D3D/Vulkan can lower or reflect it as
+// ordinary miss/hit-group entry points.
+
+import rt_pipeline;
+
+struct RadiancePayload
+{
+    float4 color;
+}
+
+struct SphereHitAttributes
+{
+    float2 uv;
+}
+
+struct PrimaryTraceContext : rt::ITraceContext
+{
+    typealias Payload = RadiancePayload;
+    typealias ASKind = rt::InstanceAS;
+    typealias Motion = rt::NoMotion;
+
+    static const rt::RayDataTags dataTags =
+        rt::RayDataTags::Triangle | rt::RayDataTags::Curve;
+    static const int maxLevels = 0;
+}
+
+struct PrimaryTriangleContext : rt::IHitContextFor<PrimaryTraceContext>
+{
+    typealias TraceContext = PrimaryTraceContext;
+    typealias Primitive = rt::TrianglePrimitive;
+}
+
+struct PrimaryCurveContext : rt::IHitContextFor<PrimaryTraceContext>
+{
+    typealias TraceContext = PrimaryTraceContext;
+    typealias Primitive = rt::CurvePrimitive;
+}
+
+struct PrimarySphereContext : rt::IHitContextFor<PrimaryTraceContext>
+{
+    typealias TraceContext = PrimaryTraceContext;
+    typealias Primitive = rt::BoundingBoxPrimitive;
+}
+
+struct PrimaryMiss : rt::IMissShader<PrimaryTraceContext>
+{
+    void operator()(rt::MissInput<PrimaryTraceContext> input)
+    {
+        input.payload.color = float4(0.0, 0.0, 0.0, 1.0);
+    }
+}
+
+struct PrimaryTriangleClosestHit : rt::IClosestHitShader<PrimaryTriangleContext>
+{
+    void operator()(rt::ClosestHitInput<PrimaryTriangleContext> input)
+    {
+        input.payload.color =
+            float4(input.triangle.barycentricCoord, input.distance, 1.0);
+    }
+}
+
+struct PrimaryTriangleAnyHit : rt::IAnyHitShader<PrimaryTriangleContext>
+{
+    void invoke(rt::AnyHitInput<PrimaryTriangleContext> input)
+    {
+        if (!input.triangle.frontFacing)
+        {
+            input.ignoreHit();
+        }
+    }
+}
+
+
+
+
+struct PrimaryCurveClosestHit : rt::IClosestHitShader<PrimaryCurveContext>
+{
+    void operator()(rt::ClosestHitInput<PrimaryCurveContext> input)
+    {
+        input.payload.color = float4(input.curve.parameter, input.distance, 0.0, 1.0);
+    }
+}
+
+struct PrimarySphereIntersection : rt::IIntersectionShader<PrimarySphereContext, SphereHitAttributes>
+{
+    typealias Attributes = SphereHitAttributes;
+
+    rt::IntersectionReturn<PrimarySphereContext, Attributes> operator()(
+        rt::IntersectionInput<PrimarySphereContext> input)
+    {
+        rt::IntersectionReturn<PrimarySphereContext, Attributes> result;
+        result.acceptIntersection = input.opaque;
+        result.continueSearch = true;
+        result.distance = 1.0;
+        result.attributes.uv = float2(0.25, 0.75);
+        return result;
+    }
+}
+
+struct PrimarySphereClosestHit : rt::IClosestHitShader<PrimarySphereContext>
+{
+    void operator()(rt::ClosestHitInput<PrimarySphereContext> input)
+    {
+        SphereHitAttributes attr = input.getCustomAttributes<SphereHitAttributes>();
+        input.payload.color = float4(attr.uv, input.distance, 1.0);
+    }
+}
+
+// These are compiled shader-slot IDs, not scene geometry IDs. The compiled
+// program has a finite set of hit groups. D3D/Vulkan select these slots through
+// native SBT indexing, and Metal lowering synthesizes the same indexing formula
+// after intersector::intersect(...) returns.
+typealias PrimaryTriangleHitSlot = rt::HitGroupSlot<0>;
+typealias PrimaryCurveHitSlot = rt::HitGroupSlot<1>;
+typealias PrimarySphereHitSlot = rt::HitGroupSlot<2>;
+
+struct PrimaryProgram : rt::TraceProgram
+{
+    typealias TraceContext = PrimaryTraceContext;
+
+    typealias MissGroups = rt::MissGroupList<
+        TraceContext,
+
+        // dispatch.missIndex == 0
+        rt::MissGroup<
+            TraceContext,
+            rt::MissSlot<0>,
+            PrimaryMiss>>;
+
+    typealias HitGroups = rt::HitGroupList<
+        TraceContext,
+
+        // hit slot 0. Runtime geometry/ray-type data may select this slot.
+        rt::HitGroup<
+            TraceContext,
+            PrimaryTriangleHitSlot,
+            PrimaryTriangleContext,
+            PrimaryTriangleClosestHit,
+            PrimaryTriangleAnyHit,
+            rt::NoAttributes,
+            rt::NoIntersection<PrimaryTriangleContext>>,
+
+        // hit slot 1. Runtime geometry/ray-type data may select this slot.
+        rt::HitGroup<
+            TraceContext,
+            PrimaryCurveHitSlot,
+            PrimaryCurveContext,
+            PrimaryCurveClosestHit,
+            rt::NoAnyHit<PrimaryCurveContext>,
+            rt::NoAttributes,
+            rt::NoIntersection<PrimaryCurveContext>>,
+
+        // hit slot 2. Runtime geometry/ray-type data may select this slot.
+        rt::HitGroup<
+            TraceContext,
+            PrimarySphereHitSlot,
+            PrimarySphereContext,
+            PrimarySphereClosestHit,
+            rt::NoAnyHit<PrimarySphereContext>,
+            SphereHitAttributes,
+            PrimarySphereIntersection>>;
+}
+
+rt::AccelerationStructure<rt::InstanceAS, rt::NoMotion> gScene;
+
+rt::RayDesc makePrimaryRay(uint2 pixel)
+{
+    rt::RayDesc ray;
+    ray.origin = float3(0.0, 0.0, -1.0);
+    ray.tMin = 0.001;
+    ray.direction = normalize(float3(float(pixel.x), float(pixel.y), 1.0));
+    ray.tMax = 10000.0;
+    return ray;
+}
+
+[shader("raygeneration")]
+void rayGenMain()
+{
+    uint2 pixel = DispatchRaysIndex().xy;
+
+    rt::RayTraversalDesc desc;
+    desc.ray = makePrimaryRay(pixel);
+    desc.instanceMask = 0xff;
+
+    rt::RayDispatch dispatch;
+    dispatch.sbtOffset = 0;
+    dispatch.sbtStride = 3;
+    dispatch.missIndex = 0;
+
+    RadiancePayload payload;
+    payload.color = float4(0.0, 0.0, 0.0, 1.0);
+
+    rt::RayTracer<PrimaryProgram> tracer;
+    tracer.trace(desc, gScene, dispatch, payload);
+}
+
+
+
+// Conceptual Metal lowering:
+//
+// metalIntersector.set_geometry_multiplier(dispatch.sbtStride);
+// metalIntersector.set_base_id(dispatch.sbtOffset);
+// result = metalIntersector.intersect(desc.ray, gScene, ...);
+//
+// if (result.type == none)
+// {
+//     switch (dispatch.missIndex)
+//     {
+//     case 0: PrimaryMiss()(MissInput<PrimaryTraceContext>(payload)); break;
+//     }
+// }
+// else
+// {
+//     uint geometryContribution =
+//         __rtGetGeometryContribution<PrimaryProgram>(result);
+//     uint instanceContribution =
+//         __rtGetInstanceContribution<PrimaryProgram>(result);
+//     uint slot = getHitGroupSlot(
+//         dispatch, geometryContribution, instanceContribution);
+//
+//     switch (slot)
+//     {
+//     case 0:
+//         PrimaryTriangleClosestHit()(
+//             ClosestHitInput<PrimaryTriangleContext>(payload, result));
+//         break;
+//     case 1:
+//         PrimaryCurveClosestHit()(
+//             ClosestHitInput<PrimaryCurveContext>(payload, result));
+//         break;
+//     case 2:
+//         PrimarySphereClosestHit()(
+//             ClosestHitInput<PrimarySphereContext>(payload, result));
+//         break;
+//     }
+// }
+//
+// Conceptual D3D/Vulkan lowering:
+//
+// - dispatch.sbtOffset, dispatch.sbtStride, and dispatch.missIndex lower to
+//   native trace parameters.
+// - MissGroups[0] becomes the native miss shader for miss slot 0.
+// - HitGroups[0..2] become native SBT hit groups with closest-hit, optional
+//   any-hit, and optional intersection entry points.
+// - Existing host-side SBT construction can keep using the same slot numbers.
+//
+// Metal consistency requirement:
+//
+// - For intersection_function_buffer, dispatch.sbtStride must be the value used
+//   with set_geometry_multiplier(...), and dispatch.sbtOffset must be the value
+//   used with set_base_id(...). The synthesized closest-hit slot and Metal's IFB
+//   record index are then the same.
+// - For ordinary intersection_function_table, Metal has no shader-side base ID
+//   or geometry multiplier. It can use this model only when the acceleration
+//   structure's function-table offsets are already baked to the same slot
+//   numbers, or when the trace uses the restricted stride/offset pattern that
+//   those baked offsets represent.

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/rt_basic_types.slang
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/rt_basic_types.slang
@@ -1,0 +1,196 @@
+implementing rt_pipeline;
+
+namespace rt
+{
+
+public interface IRayASKind {}
+public struct InstanceAS : IRayASKind {}
+
+public interface IRayMotion {}
+public struct NoMotion : IRayMotion {}
+
+public enum RayDataTags : uint
+{
+    None = 0,
+    Triangle = 0x1,
+    Curve = 0x4,
+};
+
+public struct RayDesc
+{
+    public float3 origin;
+    public float tMin;
+    public float3 direction;
+    public float tMax;
+}
+
+public struct RayTraversalDesc
+{
+    public RayDesc ray;
+    public uint instanceMask;
+}
+
+public struct AccelerationStructure<TKind : IRayASKind, TMotion : IRayMotion>
+{
+}
+
+public interface IIntersectionPrimitive {}
+public struct TrianglePrimitive : IIntersectionPrimitive {}
+public struct BoundingBoxPrimitive : IIntersectionPrimitive {}
+public struct CurvePrimitive : IIntersectionPrimitive {}
+
+public struct TriangleHitAttributes
+{
+    public float2 barycentricCoord;
+    public bool frontFacing;
+}
+
+public struct CurveHitAttributes
+{
+    public float parameter;
+}
+
+public struct IntersectionResult<
+    TKind : IRayASKind,
+    let dataTags : RayDataTags,
+    TMotion : IRayMotion,
+    let maxLevels : int>
+{
+    public bool isNone;
+    public float distance;
+    public uint primitiveIndex;
+    public uint geometryIndex;
+}
+
+public interface ITraceContext
+{
+    associatedtype Payload;
+    associatedtype ASKind : IRayASKind;
+    associatedtype Motion : IRayMotion;
+
+    static const RayDataTags dataTags;
+    static const int maxLevels;
+}
+
+public interface IHitContext
+{
+    associatedtype TraceContext : ITraceContext;
+    associatedtype Primitive : IIntersectionPrimitive;
+}
+
+// Marker interface that lets table declarations express "this hit context
+// belongs to this trace context" without relying on associated-type equality
+// clauses.
+public interface IHitContextFor<TTraceContext : ITraceContext> : IHitContext
+{
+}
+
+
+void AnyHit(AnyHit<Tcontext> xx)
+{
+
+}
+
+[[intersection(, tag_list)]]
+
+public struct ClosestHitInput<TContext : IHitContext>
+{
+    public TContext.TraceContext.Payload payloadStorage;
+    public IntersectionResult<
+        TContext.TraceContext.ASKind,
+        TContext.TraceContext.dataTags,
+        TContext.TraceContext.Motion,
+        TContext.TraceContext.maxLevels> intersectionResult;
+
+    public property TContext.TraceContext.Payload payload
+    {
+        ref { return payloadStorage; }
+    }
+
+    public property float distance
+    {
+        get { return intersectionResult.distance; }
+    }
+
+    public property TriangleHitAttributes triangle
+    {
+        get { return __rtClosestHitTriangle<TContext>(); }
+    }
+
+    public property CurveHitAttributes curve
+    {
+        get { return __rtClosestHitCurve<TContext>(); }
+    }
+
+    public TAttributes getCustomAttributes<TAttributes>()
+    {
+        return __rtClosestHitCustomAttributes<TContext, TAttributes>();
+    }
+}
+
+public struct AnyHitInput<TContext : IHitContext>
+{
+    public TContext.TraceContext.Payload payloadStorage;
+
+    public property TContext.TraceContext.Payload payload
+    {
+        ref { return payloadStorage; }
+    }
+
+    public property TriangleHitAttributes triangle
+    {
+        get { return __rtAnyHitTriangle<TContext>(); }
+    }
+
+    public void ignoreHit()
+    {
+        __rtIgnoreHit<TContext>();
+    }
+}
+
+public struct MissInput<TTraceContext : ITraceContext>
+{
+    public TTraceContext.Payload payloadStorage;
+
+    public property TTraceContext.Payload payload
+    {
+        ref { return payloadStorage; }
+    }
+}
+
+public struct IntersectionInput<TContext : IHitContext>
+{
+    public RayDesc ray;
+    public uint primitiveIndex;
+    public uint geometryIndex;
+
+    public property bool opaque
+    {
+        get { return __rtIntersectionOpaque<TContext>(); }
+    }
+}
+
+public struct NoAttributes
+{
+}
+
+public struct IntersectionReturn<TContext : IHitContext, TAttributes>
+{
+    public bool acceptIntersection;
+    public bool continueSearch;
+    public float distance;
+    public TAttributes attributes;
+}
+
+// Compiler-known hooks used by the public input structs above.
+
+TriangleHitAttributes __rtClosestHitTriangle<TContext : IHitContext>();
+CurveHitAttributes __rtClosestHitCurve<TContext : IHitContext>();
+TAttributes __rtClosestHitCustomAttributes<TContext : IHitContext, TAttributes>();
+
+TriangleHitAttributes __rtAnyHitTriangle<TContext : IHitContext>();
+void __rtIgnoreHit<TContext : IHitContext>();
+
+bool __rtIntersectionOpaque<TContext : IHitContext>();
+
+} // namespace rt

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/rt_pipeline.slang
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/rt_pipeline.slang
@@ -1,0 +1,19 @@
+/**
+Draft pipeline ray tracing API for Slang.
+
+This module sketches a Metal-first pipeline ray tracing model that still maps to
+D3D/Vulkan native SBT dispatch. It includes basic ray tracing types, stage
+functor contracts, and a structural dispatch table based on native SBT slot
+indexing.
+
+@remarks EXPERIMENTAL: This module is design-workspace code and is not a
+production API.
+
+@category raytracing
+*/
+[ExperimentalModule]
+module rt_pipeline;
+
+__include "rt_basic_types";
+__include "rt_stage_contracts";
+__include "rt_structural_dispatch_table";

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/rt_stage_contracts.slang
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/rt_stage_contracts.slang
@@ -1,0 +1,51 @@
+implementing rt_pipeline;
+
+namespace rt
+{
+
+// Stage contracts. These are ordinary functor structs in this sketch, but they
+// correspond to the pipeline stages that would become native entry points on
+// D3D/Vulkan and generated helper functions on Metal.
+
+public interface IClosestHitShader<TContext : IHitContext>
+    : IFunc<void, ClosestHitInput<TContext>>
+{
+}
+
+public interface IAnyHitShader<TContext : IHitContext>
+    : IFunc<void, AnyHitInput<TContext>>
+{
+}
+
+public interface IIntersectionShader<TContext : IHitContext, TAttributes>
+    : IFunc<IntersectionReturn<TContext, TAttributes>, IntersectionInput<TContext>>
+{
+}
+
+public interface IMissShader<TTraceContext : ITraceContext>
+    : IFunc<void, MissInput<TTraceContext>>
+{
+}
+
+public struct NoAnyHit<TContext : IHitContext> : IAnyHitShader<TContext>
+{
+    public void operator()(AnyHitInput<TContext> input)
+    {
+    }
+}
+
+public struct NoIntersection<TContext : IHitContext> : IIntersectionShader<TContext, NoAttributes>
+{
+    public typealias Attributes = NoAttributes;
+
+    public IntersectionReturn<TContext, Attributes> operator()(IntersectionInput<TContext> input)
+    {
+        IntersectionReturn<TContext, Attributes> result;
+        result.acceptIntersection = false;
+        result.continueSearch = true;
+        result.distance = 0.0;
+        return result;
+    }
+}
+
+} // namespace rt

--- a/docs/design/rt-api-workspace/design-sbt-structural-dispatch/rt_structural_dispatch_table.slang
+++ b/docs/design/rt-api-workspace/design-sbt-structural-dispatch/rt_structural_dispatch_table.slang
@@ -1,0 +1,169 @@
+// Draft Slang-side structural ray dispatch table.
+//
+// This fragment adds structural dispatch cases to the rt_pipeline module. The
+// cases can lower in two ways:
+//
+// - Metal: generate a post-intersect closest-hit/miss dispatch switch.
+// - D3D/Vulkan: generate or reflect native miss/hit-group entry points.
+
+implementing rt_pipeline;
+
+namespace rt
+{
+
+public interface IHitGroupSlot
+{
+    static const int index;
+}
+
+public struct HitGroupSlot<let indexValue : int> : IHitGroupSlot
+{
+    public static const int index = indexValue;
+}
+
+public interface IMissSlot
+{
+    static const int index;
+}
+
+public struct MissSlot<let indexValue : int> : IMissSlot
+{
+    public static const int index = indexValue;
+}
+
+public struct RayDispatch
+{
+    // D3D: RayContributionToHitGroupIndex.
+    // Vulkan: sbtRecordOffset.
+    // Metal IFB: intersector::set_base_id(...).
+    public uint sbtOffset;
+
+    // D3D: MultiplierForGeometryContributionToHitGroupIndex.
+    // Vulkan: sbtRecordStride.
+    // Metal IFB: intersector::set_geometry_multiplier(...).
+    public uint sbtStride;
+
+    public uint missIndex;
+}
+
+public uint getHitGroupSlot(
+    RayDispatch dispatch,
+    uint geometryContribution,
+    uint instanceContribution)
+{
+    return instanceContribution + geometryContribution * dispatch.sbtStride +
+        dispatch.sbtOffset;
+}
+
+public interface IHitGroup<TTraceContext : ITraceContext>
+{
+}
+
+public interface IMissGroup<TTraceContext : ITraceContext>
+{
+}
+
+public struct HitGroup<
+    TTraceContext : ITraceContext,
+    TSlot : IHitGroupSlot,
+    TContext : IHitContextFor<TTraceContext>,
+    TClosestHit : IClosestHitShader<TContext>,
+    TAnyHit : IAnyHitShader<TContext>,
+    TIntersectionAttributes,
+    TIntersection : IIntersectionShader<TContext, TIntersectionAttributes>>
+    : IHitGroup<TTraceContext>
+{
+    public typealias Slot = TSlot;
+    public typealias Context = TContext;
+    public typealias ClosestHit = TClosestHit;
+    public typealias AnyHit = TAnyHit;
+    public typealias IntersectionAttributes = TIntersectionAttributes;
+    public typealias Intersection = TIntersection;
+}
+
+public struct MissGroup<
+    TTraceContext : ITraceContext,
+    TSlot : IMissSlot,
+    TMiss : IMissShader<TTraceContext>>
+    : IMissGroup<TTraceContext>
+{
+    public typealias Slot = TSlot;
+    public typealias Miss = TMiss;
+}
+
+public interface IHitGroupList<TTraceContext : ITraceContext>
+{
+    static const int count;
+}
+
+public interface IMissGroupList<TTraceContext : ITraceContext>
+{
+    static const int count;
+}
+
+public struct HitGroupList<
+    TTraceContext : ITraceContext,
+    each TGroup : IHitGroup<TTraceContext>>
+    : IHitGroupList<TTraceContext>
+{
+    public static const int count = countof(TGroup);
+}
+
+public struct MissGroupList<
+    TTraceContext : ITraceContext,
+    each TGroup : IMissGroup<TTraceContext>>
+    : IMissGroupList<TTraceContext>
+{
+    public static const int count = countof(TGroup);
+}
+
+public interface TraceProgram
+{
+    associatedtype TraceContext : ITraceContext;
+    associatedtype MissGroups : IMissGroupList<TraceContext>;
+    associatedtype HitGroups : IHitGroupList<TraceContext>;
+}
+
+uint __rtGetInstanceContribution<TProgram : TraceProgram>(
+    IntersectionResult<
+        TProgram.TraceContext.ASKind,
+        TProgram.TraceContext.dataTags,
+        TProgram.TraceContext.Motion,
+        TProgram.TraceContext.maxLevels> intersectionResult);
+
+uint __rtGetGeometryContribution<TProgram : TraceProgram>(
+    IntersectionResult<
+        TProgram.TraceContext.ASKind,
+        TProgram.TraceContext.dataTags,
+        TProgram.TraceContext.Motion,
+        TProgram.TraceContext.maxLevels> intersectionResult);
+
+public struct RayTracer<TProgram : TraceProgram>
+{
+    public void trace(
+        RayTraversalDesc desc,
+        AccelerationStructure<TProgram.TraceContext.ASKind, TProgram.TraceContext.Motion> scene,
+        RayDispatch dispatch,
+        inout TProgram.TraceContext.Payload payload)
+    {
+        __rtTraceRayWithProgram<TProgram>(desc, scene, dispatch, payload);
+    }
+}
+
+void __rtTraceRayWithProgram<TProgram : TraceProgram>(
+    RayTraversalDesc desc,
+    AccelerationStructure<TProgram.TraceContext.ASKind, TProgram.TraceContext.Motion> scene,
+    RayDispatch dispatch,
+    inout TProgram.TraceContext.Payload payload);
+
+} // namespace rt
+
+
+
+
+
+// ClostHit -> TRIANGLE/PROC
+struct TriClosetHit : IClosetHit<Context>
+{
+    ///
+}

--- a/docs/design/unified-pipeline-ray-tracing-api.md
+++ b/docs/design/unified-pipeline-ray-tracing-api.md
@@ -1,0 +1,52 @@
+# Unified Pipeline Ray Tracing API Draft
+
+Status: draft PR entry point.
+
+This document points to the selected candidate design for a unified Slang
+pipeline ray tracing API. The proposal targets D3D/DXR, Vulkan/SPIR-V, OptiX,
+and Metal while keeping inline ray tracing and ray queries out of scope.
+
+## Selected Candidate
+
+The current candidate is **SBT structural dispatch**:
+
+- Shader source declares a conceptual shader binding table through Slang types.
+- Hit, miss, and callable groups are ordered type lists in an
+  `ITraceProgramLayout`.
+- Trace sites use `RayTraversalDesc`, `RayTracer<ProgramLayout>`, and
+  `TraceProgramDescriptor<ProgramLayout>`.
+- D3D and Vulkan can map the layout to native SBT records.
+- Metal can use the same layout to synthesize the miss and closest-hit dispatch
+  that Metal does not provide as native ray tracing stages.
+
+Start here:
+
+- [Structural Dispatch Proposal](
+  rt-api-workspace/design-sbt-structural-dispatch/PROPOSAL.md)
+- [Tutorial](
+  rt-api-workspace/design-sbt-structural-dispatch/TUTORIAL.md)
+- [Session Context](
+  rt-api-workspace/design-sbt-structural-dispatch/SESSION_CONTEXT.md)
+
+Prototype source:
+
+- [`rt_pipeline.slang`](
+  rt-api-workspace/design-sbt-structural-dispatch/rt_pipeline.slang)
+- [`rt_basic_types.slang`](
+  rt-api-workspace/design-sbt-structural-dispatch/rt_basic_types.slang)
+- [`rt_stage_contracts.slang`](
+  rt-api-workspace/design-sbt-structural-dispatch/rt_stage_contracts.slang)
+- [`rt_structural_dispatch_table.slang`](
+  rt-api-workspace/design-sbt-structural-dispatch/rt_structural_dispatch_table.slang)
+- [`rt-structural-dispatch-table-example.slang`](
+  rt-api-workspace/design-sbt-structural-dispatch/rt-structural-dispatch-table-example.slang)
+
+## PR Scope
+
+This PR intentionally excludes local background notes and alternate experiments,
+including detailed Metal intrinsic notes, current Slang pipeline intrinsic
+notes, static dispatch table sketches, standalone trace-context experiments,
+isolated Metal stage-lowering sketches, and IFB/user-data samples.
+
+Those files can remain useful design history, but they are not part of the
+candidate being proposed here.


### PR DESCRIPTION
## Summary

- Add a draft entry point for the unified pipeline ray tracing API design.
- Add the selected SBT structural dispatch candidate proposal, tutorial, diagrams, and prototype Slang source.
- Add compact session context that records goals, selected decisions, excluded alternatives, and open items.

## Session context

Goal: design a pipeline ray tracing API for Slang that can support D3D/DXR, Vulkan/SPIR-V, OptiX, and Metal. Inline ray tracing and ray queries are explicitly out of scope.

Selected candidate: SBT structural dispatch. Shader source declares `ITraceProgramLayout` with ordered hit, miss, and callable groups. Trace sites use `RayTraversalDesc`, `RayTracer<ProgramLayout>`, and `TraceProgramDescriptor<ProgramLayout>`.

Key decision: keep Slang source pipeline-oriented. D3D/Vulkan can use native SBT dispatch. Metal lowering synthesizes miss and closest-hit dispatch after `intersector.intersect(...)`, while using Metal function tables or function buffers for traversal-time any-hit and custom intersection behavior.

Excluded from this PR: detailed local Metal intrinsic notes, current Slang pipeline intrinsic notes, static dispatch table experiments, isolated trace-context experiments, standalone Metal stage-lowering sketches, and IFB/user-data samples.

## Testing

Not run. This is a docs and design-workspace prototype PR.