### PR TITLE
Retry fetching a prebuilt shared library, and clean up after a failed fetch

### DIFF
--- a/cmake/FetchedSharedLibrary.cmake
+++ b/cmake/FetchedSharedLibrary.cmake
@@ -30,8 +30,17 @@ function(download_and_extract archive_name url)
             # Retry before giving up: transient HTTP failures are common when many CI
             # jobs fetch release assets from behind a single shared egress address.
             set(max_attempts 3)
+            # A stalled connection has to fail before the retry below can get control
+            # back, so bound it. INACTIVITY_TIMEOUT rather than TIMEOUT: it fires only
+            # when no data is arriving, whereas a wall-clock limit would also abort a
+            # slow but healthy transfer of an archive this size.
+            set(inactivity_timeout_seconds 60)
             foreach(attempt RANGE 1 ${max_attempts})
-                file(DOWNLOAD ${url} ${archive_path} STATUS status)
+                file(
+                    DOWNLOAD ${url} ${archive_path}
+                    STATUS status
+                    INACTIVITY_TIMEOUT ${inactivity_timeout_seconds}
+                )
 
                 list(GET status 0 status_code)
                 list(GET status 1 status_string)

--- a/cmake/FetchedSharedLibrary.cmake
+++ b/cmake/FetchedSharedLibrary.cmake
@@ -29,7 +29,8 @@ function(download_and_extract archive_name url)
             message(STATUS "Downloading ${archive_name} from ${url} ...")
             # Retry before giving up: transient HTTP failures are common when many CI
             # jobs fetch release assets from behind a single shared egress address.
-            # Any failure is retried, so a genuinely missing asset pays the full backoff.
+            # We retry on any kind of failure (transient or a permanent 404) up to
+            # max_attempts, so a genuinely missing asset pays the full backoff first.
             set(max_attempts 3)
             # A stalled connection has to fail before the retry below can get control
             # back, so bound it. INACTIVITY_TIMEOUT rather than TIMEOUT: it fires only

--- a/cmake/FetchedSharedLibrary.cmake
+++ b/cmake/FetchedSharedLibrary.cmake
@@ -29,12 +29,15 @@ function(download_and_extract archive_name url)
             message(STATUS "Downloading ${archive_name} from ${url} ...")
             # Retry before giving up: transient HTTP failures are common when many CI
             # jobs fetch release assets from behind a single shared egress address.
+            # Any failure is retried, so a genuinely missing asset pays the full backoff.
             set(max_attempts 3)
             # A stalled connection has to fail before the retry below can get control
             # back, so bound it. INACTIVITY_TIMEOUT rather than TIMEOUT: it fires only
             # when no data is arriving, whereas a wall-clock limit would also abort a
             # slow but healthy transfer of an archive this size.
             set(inactivity_timeout_seconds 60)
+            # Linear backoff between attempts: 5s then 10s, with no wait after the last try.
+            set(retry_base_delay_seconds 5)
             foreach(attempt RANGE 1 ${max_attempts})
                 file(
                     DOWNLOAD ${url} ${archive_path}
@@ -55,7 +58,11 @@ function(download_and_extract archive_name url)
                 file(REMOVE ${archive_path})
 
                 if(attempt LESS max_attempts)
-                    math(EXPR retry_delay "5 * ${attempt}")
+                    math(
+                        EXPR
+                        retry_delay
+                        "${retry_base_delay_seconds} * ${attempt}"
+                    )
                     message(
                         STATUS
                         "Download of ${archive_name} failed (${status_string}), retrying in ${retry_delay}s ..."
@@ -66,6 +73,7 @@ function(download_and_extract archive_name url)
                 endif()
             endforeach()
 
+            # status_code is the last attempt's result: nonzero unless the loop broke on success.
             if(NOT status_code EQUAL 0)
                 message(
                     WARNING

--- a/cmake/FetchedSharedLibrary.cmake
+++ b/cmake/FetchedSharedLibrary.cmake
@@ -27,10 +27,36 @@ function(download_and_extract archive_name url)
             )
         else()
             message(STATUS "Downloading ${archive_name} from ${url} ...")
-            file(DOWNLOAD ${url} ${archive_path} STATUS status)
+            # Retry before giving up: transient HTTP failures are common when many CI
+            # jobs fetch release assets from behind a single shared egress address.
+            set(max_attempts 3)
+            foreach(attempt RANGE 1 ${max_attempts})
+                file(DOWNLOAD ${url} ${archive_path} STATUS status)
 
-            list(GET status 0 status_code)
-            list(GET status 1 status_string)
+                list(GET status 0 status_code)
+                list(GET status 1 status_string)
+                if(status_code EQUAL 0)
+                    break()
+                endif()
+
+                # A failed download still leaves a file behind, and extracting an empty
+                # archive succeeds silently, so the partial file has to be removed. Left
+                # in place it would be picked up by the "existing archive" branch above
+                # on every subsequent configure, and the fetch would never recover.
+                file(REMOVE ${archive_path})
+
+                if(attempt LESS max_attempts)
+                    math(EXPR retry_delay "5 * ${attempt}")
+                    message(
+                        STATUS
+                        "Download of ${archive_name} failed (${status_string}), retrying in ${retry_delay}s ..."
+                    )
+                    execute_process(
+                        COMMAND ${CMAKE_COMMAND} -E sleep ${retry_delay}
+                    )
+                endif()
+            endforeach()
+
             if(NOT status_code EQUAL 0)
                 message(
                     WARNING


### PR DESCRIPTION
## Motivation

`download_and_extract()` in `cmake/FetchedSharedLibrary.cmake` makes a single attempt at `file(DOWNLOAD)`. On failure it warns and returns, and the caller decides what to do. For `slang-llvm` under the default `SLANG_SLANG_LLVM_FLAVOR=FETCH_BINARY_IF_POSSIBLE`, that decision is to configure without LLVM support and carry on.

That is a defensible default — not every platform has a prebuilt binary — but it makes a transient network failure indistinguishable from an unsupported platform, and the consequences show up a long way from the cause. Consider a CI run that hit this:

```
CMake Warning at cmake/FetchedSharedLibrary.cmake:35 (message):
  "HTTP response code said error" with status code 22
CMake Warning at cmake/LLVM.cmake:34 (message):
  Unable to fetch slang-llvm prebuilt binary, configuring without LLVM
```

The build reported success. The test job that consumed it ran 3198 tests with 7414 ignored and failed on `tests/language-feature/coverage/coverage-llvm-skip.slang` with `unable to generate code for target 'host-callable'`. A later run on the *same commit*, with an identical `slang-test` command line, fetched the binary successfully and ran 6236 tests with 4413 ignored, passing that test. The ~3000-test swing is because `slang-test` loads FileCheck out of the `slang-llvm` shared library (`TestContext::locateLLVMFileCheck`), so when the fetch fails every filecheck-based test quietly becomes *ignored*.

Two distinct problems are visible here.

**A single HTTP failure is enough.** Status code 22 is curl's "HTTP response code said error". GitHub rate-limits release-asset downloads per source address, so any CI fleet sharing an egress IP hits this periodically. One unlucky request currently decides the shape of the entire build.

**A failed download is sticky.** This is the more serious one, and it is not obvious from reading the code. When `file(DOWNLOAD)` fails, CMake leaves a file at the destination path — empty, in the case I reproduced. `file(ARCHIVE_EXTRACT)` on an empty archive then *succeeds silently* rather than erroring. So on the next configure, the `elseif(EXISTS ${archive_path})` branch a few lines above reports "Using existing archive", extracts nothing, and the library is never found. Because `cmake --fresh` clears the cache but not that stray file, a single transient failure can leave a build directory permanently without LLVM support, with no message that points at the real cause.

I verified both behaviours directly rather than inferring them: a `file(DOWNLOAD)` of a nonexistent release asset returns status 22 and leaves a zero-byte file, and `file(ARCHIVE_EXTRACT)` on that file exits 0 without a diagnostic.

## Proposed solution

Retry the download up to three times with a short linear backoff (5s, then 10s), and remove the partial file after each failed attempt.

This is the principled layer for the fix because both problems belong to the download itself, not to any particular caller. `download_and_extract()` is what knows a download was attempted and failed; it is the only place that can clean up after itself before returning. Pushing either concern to callers would mean every caller reimplementing retry and remembering that a failed `file(DOWNLOAD)` leaves debris — and the `slang-llvm` caller already demonstrates how easy that is to miss.

Deliberately unchanged: the function still returns after exhausting its attempts, and still emits the same warning with the same wording. Whether a failed fetch is fatal remains the caller's decision, expressed through `IGNORE_FAILURE`. This PR makes the fetch more likely to succeed and guarantees it stays retryable; it does not change anyone's failure policy.

## Change summary

| File | Change |
| --- | --- |
| `cmake/FetchedSharedLibrary.cmake` | Wrap `file(DOWNLOAD)` in a bounded retry loop with linear backoff; `file(REMOVE)` the partial download after each failed attempt. Warning text and control flow on final failure are unchanged. |

## Concepts and vocabulary

- **`SLANG_SLANG_LLVM_FLAVOR`** — how the build obtains `slang-llvm`. `FETCH_BINARY` fails the configure if the prebuilt binary cannot be obtained; `FETCH_BINARY_IF_POSSIBLE` (the default) falls back to building without LLVM support.
- **`IGNORE_FAILURE`** — an option on `copy_fetched_shared_library` / `install_fetched_shared_library` that turns what would be a `SEND_ERROR` into a `STATUS` message, so a missing library disables a feature instead of failing the build.
- **The "existing archive" branch** — the `elseif(EXISTS ${archive_path})` case in `download_and_extract()` that reuses a previously downloaded archive instead of re-fetching it. This is the branch a leftover partial download gets caught by.

## Process report

**Why a retry loop rather than a longer timeout.** The observed failure is an HTTP status error, not a timeout or a stall — the server answered promptly and refused. `INACTIVITY_TIMEOUT` or `TIMEOUT` would not have helped. Rate limiting resolves with time rather than patience within a single request, so re-issuing the request after a delay is the response that matches the failure mode. Three attempts with 5s and 10s waits bounds the worst case at 15s of added latency on a genuinely unavailable URL, which is small next to a full configure.

**Why `file(REMOVE)` is a correctness fix and not tidiness.** The loop alone would not be enough, and would in fact be actively wrong without the removal: attempt 2 would re-enter `file(DOWNLOAD)` with a stale file already at the destination. More importantly it fixes the cross-invocation bug described above, where the leftover file is picked up by the "existing archive" branch on a subsequent configure. That path is silent precisely because extracting an empty archive does not error, so nothing downstream can distinguish "reused a good archive" from "reused a corpse". Removing the file restores the invariant the surrounding code already assumes: if `${archive_path}` exists, it is a complete archive.

**Why this belongs in `download_and_extract` rather than in `cmake/LLVM.cmake`.** `LLVM.cmake` only sees "no target was created" and cannot tell a rate-limited request from a platform with no published binary. It has no access to the partial file, and would have to know the archive-path derivation to clean it up. The input shape here — a failed `file(DOWNLOAD)` — is produced and consumed entirely inside `download_and_extract`, so that is the layer that owns it. Nothing about the fix is `slang-llvm`-specific; any future fetched shared library gets the same guarantee.

**Verification.** I exercised the modified function directly from a scratch `CMakeLists.txt`, since it has no existing test coverage:

- *Failure path* — a nonexistent release asset produces three attempts with the retry messages at 5s and 10s, leaves no file at the archive path, and still emits the original "Failed to download ... with status code 22" warning. An assertion in the harness fails the configure if a leftover file is found.
- *Success path* — a real zip fetched over a `file://` URL still downloads, extracts, and yields the expected library, confirming the `break()` exits the loop cleanly and that the extraction step after the loop is unaffected.

No regression test is included because the repository has no harness for exercising CMake modules in isolation, and the behaviour depends on a failing network fetch. I would rather say that plainly than add a test that does not actually pin the behaviour.

**Formatting.** `gersemi --check` passes on the modified file.
