### PR TITLE
Require terminating semicolon in throw statements

### DIFF
--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -7583,6 +7583,7 @@ ThrowStmt* Parser::ParseThrowStatement()
     FillPosition(throwStatement);
     ReadToken("throw");
     throwStatement->expression = ParseExpression();
+    ReadToken(TokenType::Semicolon);
     return throwStatement;
 }
 

--- a/tests/bugs/12326-throw-missing-semicolon-negative.slang
+++ b/tests/bugs/12326-throw-missing-semicolon-negative.slang
@@ -1,0 +1,51 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):
+//
+// Negative regression test for https://github.com/shader-slang/slang/issues/12326
+
+enum ErrorCodes : uint
+{
+    Success = 0,
+    InvalidNegativeValue = 1,
+}
+
+// require that input is positive
+uint validateInput(int n) throws ErrorCodes
+{
+    // throw statement used to not require the terminating semicolon,
+    // accepting erroneous input
+
+    if (n < 0)
+        throw ErrorCodes.InvalidNegativeValue
+
+    return (uint)n;
+/*CHECK:
+    ^^^^^^ unexpected token
+    ^^^^^^ unexpected identifier, expected ';'
+*/
+}
+
+struct Result
+{
+    uint value;
+    uint errorCode; // 0 for success
+}
+
+StructuredBuffer<int> inputBuffer;
+RWStructuredBuffer<Result> outputBuffer;
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    Result res = { };
+
+    do
+    {
+        res.value = try validateInput(inputBuffer[0]);
+    }
+    catch (ErrorCodes err)
+    {
+        res.errorCode = err;
+    }
+
+    outputBuffer[0] = res;
+}

--- a/tests/bugs/12326-throw-requires-semicolon.slang
+++ b/tests/bugs/12326-throw-requires-semicolon.slang
@@ -1,0 +1,50 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -entry computeMain -stage compute -warnings-as-errors all
+
+// Positive regression test for https://github.com/shader-slang/slang/issues/12326
+
+enum ErrorCodes : uint
+{
+    Success = 0,
+    InvalidNegativeValue = 1,
+}
+
+// require that input is positive
+uint validateInput(int n) throws ErrorCodes
+{
+    // throw statement used to not require the terminating semicolon,
+    // causing compilation issues in certain cases. For example,
+    // the below 'if' would fail to compile.
+
+    if (n < 0)
+        throw ErrorCodes.InvalidNegativeValue; // note here
+    else
+        return (uint)n;
+}
+
+struct Result
+{
+    uint value;
+    uint errorCode; // 0 for success
+}
+
+StructuredBuffer<int> inputBuffer;
+RWStructuredBuffer<Result> outputBuffer;
+
+[numthreads(1,1,1)]
+void computeMain()
+{
+    Result res = { };
+
+    do
+    {
+        res.value = try validateInput(inputBuffer[0]);
+    }
+    catch (ErrorCodes err)
+    {
+        res.errorCode = err;
+    }
+
+    outputBuffer[0] = res;
+}
+
+//CHECK: %computeMain = OpFunction


### PR DESCRIPTION
Before this commit, the parser did not require the terminating semicolon in throw statements.

Slangc would fail to compile code such as

    if (n < 0)
        throw ErrorCodes.InvalidNegativeValue;
    else
        return n;

since `;` would be interpreted as an empty statement between then-clause and else-clause.

Fix this by requiring and consuming the terminating semicolon. Add positive and negative regression tests.

**Breaking change note:**

Existing code with a `throw` statement missing the terminating semicolon will now require that terminating semicolon.

Fixes #12326