### PR TITLE
Fetch git tags in the CMake Options workflows

### DIFF
--- a/.github/workflows/cmake-options-build-container.yml
+++ b/.github/workflows/cmake-options-build-container.yml
@@ -67,7 +67,8 @@ jobs:
         with:
           persist-credentials: false
           submodules: "recursive"
-          fetch-depth: "2"
+          fetch-depth: "250"
+          fetch-tags: true
 
       - name: Configure Git safe directory
         run: |

--- a/.github/workflows/cmake-options-build.yml
+++ b/.github/workflows/cmake-options-build.yml
@@ -83,7 +83,8 @@ jobs:
         with:
           persist-credentials: false
           submodules: "recursive"
-          fetch-depth: "2"
+          fetch-depth: "250"
+          fetch-tags: true
 
       - name: Setup
         uses: ./.github/actions/common-setup


### PR DESCRIPTION
The CMake Options build jobs checked out with `fetch-depth: 2` and no tags, so `cmake/GitVersion.cmake` could not run `git describe --tags` and every configure fell back to version `0.0.0-unknown` with a CMake warning. Match ci-slang-build.yml and check out with depth 250 plus tags.