### PR TITLE
Replace native assert with SLANG_ASSERT and drop <assert.h> from source/ and tools/

### DIFF
--- a/include/slang-com-helper.h
+++ b/include/slang-com-helper.h
@@ -7,6 +7,7 @@
 #include "slang.h"
 
 #include <algorithm>
+#include <assert.h>
 #include <atomic>
 #include <iterator>
 

--- a/include/slang-com-ptr.h
+++ b/include/slang-com-ptr.h
@@ -3,7 +3,6 @@
 
 #include "slang-com-helper.h"
 
-#include <assert.h>
 #include <cstddef>
 
 namespace Slang

--- a/include/slang-gfx.h
+++ b/include/slang-gfx.h
@@ -4,7 +4,6 @@
 #include "slang-com-ptr.h"
 #include "slang.h"
 
-#include <assert.h>
 #include <float.h>
 
 

--- a/source/compiler-core/slang-token.cpp
+++ b/source/compiler-core/slang-token.cpp
@@ -1,7 +1,6 @@
 // slang-token.cpp
 #include "slang-token.h"
 
-// #include <assert.h>
 
 namespace Slang
 {

--- a/source/core/slang-common.h
+++ b/source/core/slang-common.h
@@ -3,7 +3,6 @@
 #include "slang-signal.h"
 #include "slang.h"
 
-#include <assert.h>
 #include <cstddef>
 #include <cstring>
 #include <stdint.h>

--- a/source/core/slang-free-list.cpp
+++ b/source/core/slang-free-list.cpp
@@ -34,7 +34,7 @@ void FreeList::_init(size_t elementSize, size_t alignment, size_t elemsPerBlock)
     alignment = (alignment < sizeof(void*)) ? sizeof(void*) : alignment;
 
     // Alignment must be a power of 2
-    assert(((alignment - 1) & alignment) == 0);
+    SLANG_ASSERT(((alignment - 1) & alignment) == 0);
 
     // The elementSize must at least be at least the same size as the alignment
     elementSize = (elementSize >= alignment) ? elementSize : alignment;

--- a/source/core/slang-free-list.h
+++ b/source/core/slang-free-list.h
@@ -144,7 +144,7 @@ SLANG_FORCE_INLINE void* FreeList::allocate()
 // --------------------------------------------------------------------------
 SLANG_FORCE_INLINE void FreeList::deallocate(void* data)
 {
-    assert(isValidAllocation(data));
+    SLANG_ASSERT(isValidAllocation(data));
 
     SLANG_FREE_LIST_INIT_DEALLOCATE(data)
 

--- a/source/core/slang-memory-arena.cpp
+++ b/source/core/slang-memory-arena.cpp
@@ -41,7 +41,7 @@ void MemoryArena::init(size_t blockPayloadSize, size_t blockAlignment)
 void MemoryArena::_initialize(size_t blockPayloadSize, size_t alignment)
 {
     // Alignment must be a power of 2
-    assert(((alignment - 1) & alignment) == 0);
+    SLANG_ASSERT(((alignment - 1) & alignment) == 0);
 
     // Ensure it's alignment is at least kMinAlignment
     alignment = (alignment < kMinAlignment) ? kMinAlignment : alignment;
@@ -111,7 +111,7 @@ void MemoryArena::_setCurrentBlock(Block* block)
     m_start = block->m_start;
     m_current = m_start;
 
-    assert(m_usedBlocks == block);
+    SLANG_ASSERT(m_usedBlocks == block);
 }
 
 void MemoryArena::_deallocateBlocksPayload(Block* start)
@@ -242,15 +242,15 @@ MemoryArena::Block* MemoryArena::_newNormalBlock()
 
     Block* block = _newBlock(m_blockAllocSize, m_blockAlignment);
     // Check that every normal block has m_blockPayloadSize space
-    assert(size_t(block->m_end - block->m_start) >= m_blockPayloadSize);
+    SLANG_ASSERT(size_t(block->m_end - block->m_start) >= m_blockPayloadSize);
     return block;
 }
 
 MemoryArena::Block* MemoryArena::_newBlock(size_t allocSize, size_t alignment)
 {
-    assert(alignment >= m_blockAlignment);
+    SLANG_ASSERT(alignment >= m_blockAlignment);
     // Alignment must be a power of 2
-    assert(((alignment - 1) & alignment) == 0);
+    SLANG_ASSERT(((alignment - 1) & alignment) == 0);
 
     // Allocate block
     Block* block = (Block*)m_blockFreeList.allocate();
@@ -330,9 +330,9 @@ void* MemoryArena::_allocateAlignedFromNewBlockAndZero(size_t sizeInBytes, size_
 void* MemoryArena::_allocateAlignedFromNewBlock(size_t size, size_t alignment)
 {
     // Make sure init has been called (or has been set up in parameterized constructor)
-    assert(m_blockAllocSize > 0);
+    SLANG_ASSERT(m_blockAllocSize > 0);
     // Alignment must be a power of 2
-    assert(((alignment - 1) & alignment) == 0);
+    SLANG_ASSERT(((alignment - 1) & alignment) == 0);
 
     // Alignment must at a minimum be block alignment (such if reused the constraints hold)
     alignment = (alignment < m_blockAlignment) ? m_blockAlignment : alignment;
@@ -365,7 +365,7 @@ void* MemoryArena::_allocateAlignedFromNewBlock(size_t size, size_t alignment)
     else
     {
         // Must be allocatable within a normal block
-        assert(allocSize <= m_blockAllocSize);
+        SLANG_ASSERT(allocSize <= m_blockAllocSize);
         block = _newNormalBlock();
     }
 
@@ -382,11 +382,11 @@ void* MemoryArena::_allocateAlignedFromNewBlock(size_t size, size_t alignment)
     uint8_t* memory = (uint8_t*)((size_t(m_current) + alignMask) & ~alignMask);
 
     // It must be aligned
-    assert((size_t(memory) & alignMask) == 0);
+    SLANG_ASSERT((size_t(memory) & alignMask) == 0);
 
     // Do the aligned allocation (which must fit) by aligning the pointer
     // It must fit if the previous code is correct...
-    assert(memory + size <= m_end);
+    SLANG_ASSERT(memory + size <= m_end);
     // Move the current pointer
     m_current = memory + size;
     return memory;
@@ -425,7 +425,7 @@ void MemoryArena::_rewindToCursor(const void* cursorIn)
 
     // Find the block that contains the allocation
     Block* cursorBlock = _findNonCurrent(cursorIn);
-    assert(cursorBlock);
+    SLANG_ASSERT(cursorBlock);
     if (!cursorBlock)
     {
         // If not found it means this address is NOT part any of the active used heap!
@@ -450,7 +450,7 @@ void MemoryArena::_rewindToCursor(const void* cursorIn)
 
     const uint8_t* cursor = (const uint8_t*)cursorIn;
     // Must be in the range of the currently set block
-    assert(cursor >= m_start && cursor <= m_end);
+    SLANG_ASSERT(cursor >= m_start && cursor <= m_end);
 
     // Set the current position where the cursor is
     m_current = const_cast<uint8_t*>(cursor);

--- a/source/core/slang-memory-arena.h
+++ b/source/core/slang-memory-arena.h
@@ -247,7 +247,7 @@ private:
 // --------------------------------------------------------------------------
 SLANG_FORCE_INLINE bool MemoryArena::isValid(const void* data, size_t size) const
 {
-    assert(size);
+    SLANG_ASSERT(size);
     uint8_t* ptr = (uint8_t*)data;
     return (ptr >= m_start && ptr + size <= m_current) || _findNonCurrent(data, size) != nullptr;
 }
@@ -255,7 +255,7 @@ SLANG_FORCE_INLINE bool MemoryArena::isValid(const void* data, size_t size) cons
 // --------------------------------------------------------------------------
 SLANG_FORCE_INLINE void* MemoryArena::allocateUnaligned(size_t sizeInBytes)
 {
-    assert(sizeInBytes > 0);
+    SLANG_ASSERT(sizeInBytes > 0);
 
     if (!m_current)
     {
@@ -301,7 +301,7 @@ SLANG_FORCE_INLINE void* MemoryArena::allocateCurrentUnaligned(size_t sizeInByte
 // --------------------------------------------------------------------------
 SLANG_FORCE_INLINE void* MemoryArena::allocate(size_t sizeInBytes)
 {
-    assert(sizeInBytes > 0);
+    SLANG_ASSERT(sizeInBytes > 0);
 
     if (!m_current)
     {
@@ -326,7 +326,7 @@ SLANG_FORCE_INLINE void* MemoryArena::allocate(size_t sizeInBytes)
 // --------------------------------------------------------------------------
 SLANG_FORCE_INLINE void* MemoryArena::allocateAndZero(size_t sizeInBytes)
 {
-    assert(sizeInBytes > 0);
+    SLANG_ASSERT(sizeInBytes > 0);
 
     if (!m_current)
     {
@@ -354,9 +354,9 @@ SLANG_FORCE_INLINE void* MemoryArena::allocateAndZero(size_t sizeInBytes)
 // --------------------------------------------------------------------------
 SLANG_FORCE_INLINE void* MemoryArena::allocateAligned(size_t sizeInBytes, size_t alignment)
 {
-    assert(sizeInBytes > 0);
+    SLANG_ASSERT(sizeInBytes > 0);
     // Alignment must be a power of 2
-    assert(((alignment - 1) & alignment) == 0);
+    SLANG_ASSERT(((alignment - 1) & alignment) == 0);
 
     if (!m_current)
     {
@@ -472,7 +472,7 @@ inline void MemoryArena::adjustToBlockAlignment()
         // Set the position
         m_current = ptr;
     }
-    assert(size_t(m_current) & alignMask);
+    SLANG_ASSERT(size_t(m_current) & alignMask);
 }
 // --------------------------------------------------------------------------
 SLANG_FORCE_INLINE void MemoryArena::rewindToCursor(const void* cursor)

--- a/source/core/slang-random-generator.h
+++ b/source/core/slang-random-generator.h
@@ -43,7 +43,7 @@ public:
     /// Returns value up to BUT NOT INCLUDING maxValue.
     int32_t nextInt32UpTo(int32_t maxValue)
     {
-        assert(maxValue > 0);
+        SLANG_ASSERT(maxValue > 0);
         return (maxValue <= 1) ? 0 : (nextPositiveInt32() % maxValue);
     }
 
@@ -56,7 +56,7 @@ public:
     /// Returns value up to BUT NOT INCLUDING maxValue
     int64_t nextInt64UpTo(int64_t maxValue)
     {
-        assert(maxValue > 0);
+        SLANG_ASSERT(maxValue > 0);
         return (maxValue <= 1) ? 0 : (nextPositiveInt64() % maxValue);
     }
 

--- a/source/core/slang-secure-crt.h
+++ b/source/core/slang-secure-crt.h
@@ -1,7 +1,6 @@
 #if !defined(_WIN32) || defined(__MINGW32__) || defined(__CYGWIN__)
 #ifndef SLANG_CORE_SECURE_CRT_H
 #define SLANG_CORE_SECURE_CRT_H
-#include <assert.h>
 #include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/source/core/slang-signal.cpp
+++ b/source/core/slang-signal.cpp
@@ -1,8 +1,11 @@
 #include "slang-signal.h"
 
 #include "slang-exception.h"
-#include "slang-platform.h"
-#include "stdio.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #if _WIN32 && defined(_MSC_VER)
 #include <cassert>
@@ -48,16 +51,49 @@ String _getMessage(SignalType type, char const* message)
     return buf.produceString();
 }
 
+// Returns true if the NUL-terminated strings `a` and `b` are equal ignoring ASCII case.
+static bool _caseInsensitiveEquals(const char* a, const char* b)
+{
+    for (; *a && *b; ++a, ++b)
+    {
+        if (tolower((unsigned char)*a) != tolower((unsigned char)*b))
+        {
+            return false;
+        }
+    }
+    return *a == *b;
+}
+
+/// Reads the `SLANG_ASSERT` environment variable into `buffer`, returning true if it was set and
+/// fit. An over-long value is reported as unset, which is harmless since no mode name is that long.
+///
+/// Uses only C library calls and stack storage: Slang's own containers assert internally, so
+/// building a `StringBuilder` here would let an assert inside them re-enter `handleAssert`
+/// and recurse until the stack overflowed.
+static bool _readAssertEnvVar(char* buffer, size_t bufferSize)
+{
+#if _WIN32 && defined(_MSC_VER)
+    size_t requiredSize = 0;
+    return getenv_s(&requiredSize, buffer, bufferSize, "SLANG_ASSERT") == 0 && requiredSize > 0;
+#else
+    const char* value = getenv("SLANG_ASSERT");
+    if (!value || strlen(value) >= bufferSize)
+    {
+        return false;
+    }
+    strcpy(buffer, value);
+    return true;
+#endif
+}
+
 void handleAssert(char const* message, char const* file, int line, bool isReleaseAssert)
 {
-    StringBuilder envValue;
-    if (SLANG_SUCCEEDED(
-            PlatformUtil::getEnvironmentVariable(UnownedStringSlice("SLANG_ASSERT"), envValue)))
+    // Sized generously past the longest recognized mode name, "release-asserts-only".
+    char envValue[64];
+    if (_readAssertEnvVar(envValue, sizeof(envValue)))
     {
-        UnownedStringSlice envSlice = envValue.getUnownedSlice();
-        if (envSlice.caseInsensitiveEquals(
-                UnownedStringSlice::fromLiteral("release-asserts-only")) ||
-            envSlice.caseInsensitiveEquals(UnownedStringSlice::fromLiteral("release-assert-only")))
+        if (_caseInsensitiveEquals(envValue, "release-asserts-only") ||
+            _caseInsensitiveEquals(envValue, "release-assert-only"))
         {
             // Ignore the assert and continue execution.
             // This is to mimic the behavior of Release build with Debug build.
@@ -67,11 +103,11 @@ void handleAssert(char const* message, char const* file, int line, bool isReleas
             }
         }
 #if _WIN32 && defined(_MSC_VER)
-        else if (envSlice.caseInsensitiveEquals(UnownedStringSlice::fromLiteral("system")))
+        else if (_caseInsensitiveEquals(envValue, "system"))
         {
             assert(!"SLANG_ASSERT triggered");
         }
-        else if (envSlice.caseInsensitiveEquals(UnownedStringSlice::fromLiteral("debugbreak")))
+        else if (_caseInsensitiveEquals(envValue, "debugbreak"))
         {
             if (IsDebuggerPresent())
             {
@@ -109,14 +145,11 @@ void handleAssert(char const* message, char const* file, int line, bool isReleas
 // handling scenarios) as well as a choke point to set a breakpoint to catch 'signal' types
 [[noreturn]] void handleSignal(SignalType type, char const* message)
 {
-    StringBuilder buf;
-    const char* const typeText = _getSignalTypeAsText(type);
-    buf << typeText << ": " << message;
-
     g_lastSignalMessage = _getMessage(type, message);
 
     // Can be useful to enable during debug when problem is on CI
-    if (false)
+    static bool enableSignalPrint = false;
+    if (enableSignalPrint)
     {
         printf("%s\n", g_lastSignalMessage.getBuffer());
     }

--- a/source/core/slang-string.h
+++ b/source/core/slang-string.h
@@ -173,7 +173,7 @@ public:
 
     const char& operator[](Index i) const
     {
-        assert(i >= 0 && i < Index(m_end - m_begin));
+        SLANG_ASSERT(i >= 0 && i < Index(m_end - m_begin));
         return m_begin[i];
     }
 

--- a/source/slang-glslang/slang-glslang.cpp
+++ b/source/slang-glslang/slang-glslang.cpp
@@ -596,7 +596,7 @@ static int spirv_Optimize_1_3(const glslang_CompileRequest_1_3& request)
     return err;
 }
 
-static glslang::EShTargetLanguageVersion _makeTargetLanguageVersion(
+static constexpr glslang::EShTargetLanguageVersion _makeTargetLanguageVersion(
     int majorVersion,
     int minorVersion)
 {
@@ -705,7 +705,7 @@ static spv_target_env _getUniversalTargetEnv(glslang::EShTargetLanguageVersion i
 static int glslang_compileGLSLToSPIRV(glslang_CompileRequest_1_3 request)
 {
     // Check that the encoding matches
-    assert(glslang::EShTargetSpv_1_4 == _makeTargetLanguageVersion(1, 4));
+    SLANG_COMPILE_TIME_ASSERT(glslang::EShTargetSpv_1_4 == _makeTargetLanguageVersion(1, 4));
 
     EShLanguage glslangStage;
     switch (request.slangStage)

--- a/source/slang/slang-ast-builder.cpp
+++ b/source/slang/slang-ast-builder.cpp
@@ -5,7 +5,6 @@
 #include "slang-compiler.h"
 #include "slang-syntax.h"
 
-#include <assert.h>
 
 namespace Slang
 {

--- a/source/slang/slang-ast-decl.cpp
+++ b/source/slang/slang-ast-decl.cpp
@@ -5,7 +5,6 @@
 #include "slang-ast-dispatch.h"
 #include "slang-syntax.h"
 
-#include <assert.h>
 
 namespace Slang
 {

--- a/source/slang/slang-ast-dump.cpp
+++ b/source/slang/slang-ast-dump.cpp
@@ -5,7 +5,6 @@
 #include "slang-ast-dispatch.h"
 #include "slang-compiler.h"
 
-#include <assert.h>
 #include <limits>
 
 namespace Slang

--- a/source/slang/slang-ast-support-types.h
+++ b/source/slang/slang-ast-support-types.h
@@ -10,7 +10,6 @@
 #include "slang-type-system-shared.h"
 #include "slang.h"
 
-#include <assert.h>
 #include <type_traits>
 
 //

--- a/source/slang/slang-ast-type.cpp
+++ b/source/slang/slang-ast-type.cpp
@@ -7,7 +7,6 @@
 #include "slang-check.h"
 #include "slang-syntax.h"
 
-#include <assert.h>
 #include <typeinfo>
 namespace Slang
 {

--- a/source/slang/slang-ast-val.cpp
+++ b/source/slang/slang-ast-val.cpp
@@ -12,7 +12,6 @@
 #include "slang-rich-diagnostics.h"
 #include "slang-syntax.h"
 
-#include <assert.h>
 #include <typeinfo>
 
 namespace Slang

--- a/source/slang/slang-emit-c-like.cpp
+++ b/source/slang/slang-emit-c-like.cpp
@@ -27,7 +27,6 @@
 #include "slang-visitor.h"
 #include "slang/slang-ir.h"
 
-#include <assert.h>
 
 namespace Slang
 {

--- a/source/slang/slang-emit-cpp.cpp
+++ b/source/slang/slang-emit-cpp.cpp
@@ -10,7 +10,6 @@
 #include "slang-ir-util.h"
 #include "slang-rich-diagnostics.h"
 
-#include <assert.h>
 
 /*
 ABI

--- a/source/slang/slang-emit-cuda.cpp
+++ b/source/slang/slang-emit-cuda.cpp
@@ -5,7 +5,6 @@
 #include "slang-emit-source-writer.h"
 #include "slang-rich-diagnostics.h"
 
-#include <assert.h>
 
 namespace Slang
 {

--- a/source/slang/slang-emit-glsl.cpp
+++ b/source/slang/slang-emit-glsl.cpp
@@ -11,7 +11,6 @@
 #include "slang-rich-diagnostics.h"
 #include "slang/slang-ir.h"
 
-#include <assert.h>
 
 namespace Slang
 {

--- a/source/slang/slang-emit-hlsl.cpp
+++ b/source/slang/slang-emit-hlsl.cpp
@@ -7,7 +7,6 @@
 #include "slang-ir-util.h"
 #include "slang-rich-diagnostics.h"
 
-#include <assert.h>
 
 namespace Slang
 {

--- a/source/slang/slang-emit-metal.cpp
+++ b/source/slang/slang-emit-metal.cpp
@@ -8,7 +8,6 @@
 #include "slang-ir-util.h"
 #include "slang-rich-diagnostics.h"
 
-#include <assert.h>
 
 namespace Slang
 {

--- a/source/slang/slang-emit-torch.cpp
+++ b/source/slang/slang-emit-torch.cpp
@@ -4,7 +4,6 @@
 #include "core/slang-writer.h"
 #include "slang-emit-source-writer.h"
 
-#include <assert.h>
 
 namespace Slang
 {

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -143,7 +143,6 @@
 #include "slang-visitor.h"
 #include "slang-vm-bytecode.h"
 
-#include <assert.h>
 #include <limits>
 Slang::String get_slang_cpp_host_prelude();
 Slang::String get_slang_torch_prelude();

--- a/source/slang/slang-module-library.cpp
+++ b/source/slang/slang-module-library.cpp
@@ -5,7 +5,6 @@
 #include "core/slang-riff.h"
 #include "core/slang-type-text-util.h"
 
-#include <assert.h>
 
 // Serialization
 #include "slang-serialize-container.h"

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -33,7 +33,6 @@
 #include "slang-serialize-ir.h"
 #include "slang.h"
 
-#include <assert.h>
 #ifdef _WIN32
 #include <fcntl.h>
 #include <io.h>

--- a/source/slang/slang-parser.cpp
+++ b/source/slang/slang-parser.cpp
@@ -10,7 +10,6 @@
 #include "slang-rich-diagnostics.h"
 #include "slang-visitor.h"
 
-#include <assert.h>
 #include <climits>
 #include <cmath>
 #include <float.h>

--- a/source/slang/slang-preprocessor.cpp
+++ b/source/slang/slang-preprocessor.cpp
@@ -16,7 +16,6 @@
 #include "slang-diagnostics.h"
 #include "slang-rich-diagnostics.h"
 
-#include <assert.h>
 
 namespace Slang
 {

--- a/source/slang/slang-reflection-api.cpp
+++ b/source/slang/slang-reflection-api.cpp
@@ -11,7 +11,6 @@
 #include "slang-type-layout.h"
 #include "slang.h"
 
-#include <assert.h>
 
 // Don't signal errors for stuff we don't implement here,
 // and instead just try to return things defensively

--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -4,7 +4,6 @@
 #include "slang-compiler.h"
 #include "slang-visitor.h"
 
-#include <assert.h>
 #include <typeinfo>
 
 namespace Slang

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -7,7 +7,6 @@
 #include "slang-mangle.h"
 #include "slang-syntax.h"
 
-#include <assert.h>
 
 namespace Slang
 {

--- a/source/slangc/main.cpp
+++ b/source/slangc/main.cpp
@@ -7,7 +7,6 @@
 
 using namespace Slang;
 
-#include <assert.h>
 
 #ifdef _WIN32
 #define MAIN slangc_main
@@ -163,7 +162,7 @@ int wmain(int argc, wchar_t** argv)
 
     int memleakDetected = _CrtDumpMemoryLeaks();
     SLANG_UNUSED(memleakDetected);
-    assert(!memleakDetected);
+    SLANG_ASSERT(!memleakDetected);
 #endif
 
     return result;

--- a/tools/gfx-unit-test/gfx-test-texture-util.cpp
+++ b/tools/gfx-unit-test/gfx-test-texture-util.cpp
@@ -202,7 +202,7 @@ void generateTextureData(RefPtr<TextureInfo> texture, ValidationTextureFormatBas
             uint32_t mipDepth = std::max(extent.depth >> mip, 1u);
             uint32_t mipSize = mipWidth * mipHeight * mipDepth * texelSize;
             subresource->textureData = ::malloc(mipSize);
-            assert(subresource->textureData != nullptr);
+            SLANG_ASSERT(subresource->textureData != nullptr);
 
             subresource->extent.width = mipWidth;
             subresource->extent.height = mipHeight;

--- a/tools/gfx-unit-test/gfx-test-texture-util.h
+++ b/tools/gfx-unit-test/gfx-test-texture-util.h
@@ -80,7 +80,7 @@ struct ValidationTextureFormat : ValidationTextureFormatBase
             temp[3] = (T)mip;
             break;
         default:
-            assert("component count should be no greater than 4");
+            SLANG_ASSERT("component count should be no greater than 4");
             SLANG_CHECK_ABORT(false);
         }
     }
@@ -168,9 +168,9 @@ struct ValidationTextureData : RefObject
 
     void* getBlockAt(uint32_t x, uint32_t y, uint32_t z)
     {
-        assert(x < extent.width);
-        assert(y < extent.height);
-        assert(z < extent.depth);
+        SLANG_ASSERT(x < extent.width);
+        SLANG_ASSERT(y < extent.height);
+        SLANG_ASSERT(z < extent.depth);
 
         char* layerData = (char*)textureData + z * pitches.z;
         char* rowData = layerData + y * pitches.y;

--- a/tools/gfx-unit-test/gfx-test-util.cpp
+++ b/tools/gfx-unit-test/gfx-test-util.cpp
@@ -295,7 +295,7 @@ void initializeRenderDoc()
         pRENDERDOC_GetAPI RENDERDOC_GetAPI =
             (pRENDERDOC_GetAPI)GetProcAddress(mod, "RENDERDOC_GetAPI");
         int ret = RENDERDOC_GetAPI(eRENDERDOC_API_Version_1_1_2, (void**)&rdoc_api);
-        assert(ret == 1);
+        SLANG_ASSERT(ret == 1);
     }
 }
 void renderDocBeginFrame()

--- a/tools/gfx-unit-test/texture-types-tests.cpp
+++ b/tools/gfx-unit-test/texture-types-tests.cpp
@@ -94,7 +94,7 @@ struct BaseTextureViewTest
             shape = "Cube";
             break;
         default:
-            assert(!"Invalid texture shape");
+            SLANG_ASSERT_FAILURE("Invalid texture shape");
             SLANG_CHECK_ABORT(false);
         }
 
@@ -113,7 +113,7 @@ struct BaseTextureViewTest
             view = "Unordered";
             break;
         default:
-            assert(!"Invalid resource view");
+            SLANG_ASSERT_FAILURE("Invalid resource view");
             SLANG_CHECK_ABORT(false);
         }
 

--- a/tools/gfx/cuda/cuda-command-queue.cpp
+++ b/tools/gfx/cuda/cuda-command-queue.cpp
@@ -43,7 +43,7 @@ SLANG_NO_THROW void SLANG_MCALL CommandQueueImpl::executeCommandBuffers(
 {
     SLANG_UNUSED(valueToSignal);
     // TODO: implement fence.
-    assert(fence == nullptr);
+    SLANG_ASSERT(fence == nullptr);
     for (GfxIndex i = 0; i < count; i++)
     {
         execute(static_cast<CommandBufferImpl*>(commandBuffers[i]));

--- a/tools/gfx/d3d/d3d-util.cpp
+++ b/tools/gfx/d3d/d3d-util.cpp
@@ -423,7 +423,7 @@ D3DUtil::calcResourceFormat(UsageType usage, Int usageFlags, DXGI_FORMAT format)
         }
     }
 
-    assert(!"Not reachable");
+    SLANG_ASSERT_FAILURE("Not reachable");
     return DXGI_FORMAT_UNKNOWN;
 }
 

--- a/tools/gfx/d3d11/d3d11-device.cpp
+++ b/tools/gfx/d3d11/d3d11-device.cpp
@@ -1241,9 +1241,9 @@ void DeviceImpl::setVertexBuffers(
     const Offset* offsetsIn)
 {
     static const int kMaxVertexBuffers = 16;
-    assert(slotCount <= kMaxVertexBuffers);
-    assert(m_currentPipelineState); // The pipeline state should be created before setting vertex
-                                    // buffers.
+    SLANG_ASSERT(slotCount <= kMaxVertexBuffers);
+    SLANG_ASSERT(m_currentPipelineState); // The pipeline state should be created before setting
+                                          // vertex buffers.
 
     UINT vertexStrides[kMaxVertexBuffers];
     UINT vertexOffsets[kMaxVertexBuffers];
@@ -1279,7 +1279,7 @@ void DeviceImpl::setIndexBuffer(IBufferResource* buffer, Format indexFormat, Off
 void DeviceImpl::setViewports(GfxCount count, Viewport const* viewports)
 {
     static const int kMaxViewports = D3D11_VIEWPORT_AND_SCISSORRECT_MAX_INDEX + 1;
-    assert(count <= kMaxViewports);
+    SLANG_ASSERT(count <= kMaxViewports);
 
     D3D11_VIEWPORT dxViewports[kMaxViewports];
     for (GfxIndex ii = 0; ii < count; ++ii)
@@ -1301,7 +1301,7 @@ void DeviceImpl::setViewports(GfxCount count, Viewport const* viewports)
 void DeviceImpl::setScissorRects(GfxCount count, ScissorRect const* rects)
 {
     static const int kMaxScissorRects = D3D11_VIEWPORT_AND_SCISSORRECT_MAX_INDEX + 1;
-    assert(count <= kMaxScissorRects);
+    SLANG_ASSERT(count <= kMaxScissorRects);
 
     D3D11_RECT dxRects[kMaxScissorRects];
     for (GfxIndex ii = 0; ii < count; ++ii)

--- a/tools/gfx/d3d11/d3d11-helper-functions.cpp
+++ b/tools/gfx/d3d11/d3d11-helper-functions.cpp
@@ -75,7 +75,7 @@ int _calcResourceAccessFlags(MemoryType memType)
     case MemoryType::Upload:
         return D3D11_CPU_ACCESS_WRITE;
     default:
-        assert(!"Invalid flags");
+        SLANG_ASSERT_FAILURE("Invalid flags");
         return 0;
     }
 }
@@ -236,7 +236,7 @@ D3D11_BLEND_OP translateBlendOp(BlendOp op)
     switch (op)
     {
     default:
-        assert(!"unimplemented");
+        SLANG_ASSERT_FAILURE("unimplemented");
         return (D3D11_BLEND_OP)-1;
 
 #define CASE(FROM, TO)  \
@@ -256,7 +256,7 @@ D3D11_BLEND translateBlendFactor(BlendFactor factor)
     switch (factor)
     {
     default:
-        assert(!"unimplemented");
+        SLANG_ASSERT_FAILURE("unimplemented");
         return (D3D11_BLEND)-1;
 
 #define CASE(FROM, TO)      \
@@ -327,7 +327,7 @@ void initSrvDesc(
             descOut.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE3D;
             break;
         default:
-            assert(!"Unknown dimension");
+            SLANG_ASSERT_FAILURE("Unknown dimension");
         }
 
         descOut.Texture2D.MipLevels = textureDesc.numMipLevels;
@@ -354,7 +354,7 @@ void initSrvDesc(
     }
     else
     {
-        assert(textureDesc.size.depth > 1 || arraySize > 1);
+        SLANG_ASSERT(textureDesc.size.depth > 1 || arraySize > 1);
 
         switch (textureDesc.type)
         {
@@ -369,7 +369,7 @@ void initSrvDesc(
             break;
 
         default:
-            assert(!"Unknown dimension");
+            SLANG_ASSERT_FAILURE("Unknown dimension");
         }
 
         descOut.Texture2DArray.ArraySize = std::max(textureDesc.size.depth, arraySize);

--- a/tools/gfx/d3d12/d3d12-command-encoder.cpp
+++ b/tools/gfx/d3d12/d3d12-command-encoder.cpp
@@ -31,7 +31,7 @@ int PipelineCommandEncoder::getBindPointIndex(PipelineType type)
     case PipelineType::RayTracing:
         return 2;
     default:
-        assert(!"unknown pipeline type.");
+        SLANG_ASSERT_FAILURE("unknown pipeline type.");
         return -1;
     }
 }
@@ -130,7 +130,7 @@ Result PipelineCommandEncoder::_bindRenderState(
             m_commandBuffer->bindDescriptorHeaps();
             break;
         default:
-            assert(!"shouldn't be here");
+            SLANG_ASSERT_FAILURE("shouldn't be here");
             return SLANG_FAIL;
         }
 
@@ -342,7 +342,7 @@ void ResourceCommandEncoderImpl::uploadTextureData(
             stagingBufferOffset,
             MemoryType::Upload,
             true);
-        assert(stagingBufferOffset == 0);
+        SLANG_ASSERT(stagingBufferOffset == 0);
         BufferResourceImpl* bufferImpl = static_cast<BufferResourceImpl*>(stagingBuffer);
         uint8_t* bufferData = nullptr;
         D3D12_RANGE mapRange = {0, 0};
@@ -576,7 +576,7 @@ void ResourceCommandEncoderImpl::copyTextureToBuffer(
     ITextureResource::Offset3D srcOffset,
     ITextureResource::Extents extent)
 {
-    assert(srcSubresource.mipLevelCount <= 1);
+    SLANG_ASSERT(srcSubresource.mipLevelCount <= 1);
 
     auto srcTexture = static_cast<TextureResourceImpl*>(src);
     auto dstBuffer = static_cast<BufferResourceImpl*>(dst);
@@ -643,7 +643,7 @@ void ResourceCommandEncoderImpl::copyTextureToBuffer(
             footprint.Footprint.Depth = Math::Max(1, (textureSize.depth >> mipLevel)) - srcOffset.z;
         }
 
-        assert(dstRowStride % D3D12_TEXTURE_DATA_PITCH_ALIGNMENT == 0);
+        SLANG_ASSERT(dstRowStride % D3D12_TEXTURE_DATA_PITCH_ALIGNMENT == 0);
         footprint.Footprint.RowPitch = (UINT)dstRowStride;
 
         auto bufferSize =
@@ -953,7 +953,7 @@ Result RenderCommandEncoderImpl::bindPipelineWithRootObject(
 void RenderCommandEncoderImpl::setViewports(GfxCount count, const Viewport* viewports)
 {
     static const int kMaxViewports = D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE;
-    assert(count <= kMaxViewports && count <= kMaxRTVCount);
+    SLANG_ASSERT(count <= kMaxViewports && count <= kMaxRTVCount);
     for (GfxIndex ii = 0; ii < count; ++ii)
     {
         auto& inViewport = viewports[ii];
@@ -972,7 +972,7 @@ void RenderCommandEncoderImpl::setViewports(GfxCount count, const Viewport* view
 void RenderCommandEncoderImpl::setScissorRects(GfxCount count, const ScissorRect* rects)
 {
     static const int kMaxScissorRects = D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE;
-    assert(count <= kMaxScissorRects && count <= kMaxRTVCount);
+    SLANG_ASSERT(count <= kMaxScissorRects && count <= kMaxRTVCount);
 
     for (GfxIndex ii = 0; ii < count; ++ii)
     {
@@ -1327,7 +1327,7 @@ Result ComputeCommandEncoderImpl::bindRootObjectAsCompute(
             m_commandBuffer->bindDescriptorHeaps();
             break;
         default:
-            assert(!"unexpected descriptor heap type");
+            SLANG_ASSERT_FAILURE("unexpected descriptor heap type");
             return SLANG_FAIL;
         }
 

--- a/tools/gfx/d3d12/d3d12-descriptor-heap.h
+++ b/tools/gfx/d3d12/d3d12-descriptor-heap.h
@@ -145,7 +145,7 @@ public:
         int index = m_allocator.alloc(1);
         if (index < 0)
         {
-            assert(!"descriptor allocation failed");
+            SLANG_ASSERT_FAILURE("descriptor allocation failed");
             return SLANG_FAIL;
         }
 
@@ -207,7 +207,7 @@ public:
             else
                 return (int)m;
         }
-        assert(
+        SLANG_ASSERT(
             m_subHeapStartingIndex[l] <= descriptorIndex &&
             m_subHeapStartingIndex[l] + m_subHeaps[l]->getSize() > descriptorIndex);
         return (int)l;
@@ -255,7 +255,7 @@ public:
         int index = allocate(1);
         if (index < 0)
         {
-            assert(!"descriptor allocation failed");
+            SLANG_ASSERT_FAILURE("descriptor allocation failed");
             return SLANG_FAIL;
         }
 
@@ -333,8 +333,8 @@ public:
             newSubHeap();
             return allocate(count);
         }
-        assert(result <= 0xFFFFFF);
-        assert(m_subHeapIndex <= 255);
+        SLANG_ASSERT(result <= 0xFFFFFF);
+        SLANG_ASSERT(m_subHeapIndex <= 255);
         return (m_subHeapIndex << 24) + result;
     }
 
@@ -344,9 +344,9 @@ public:
         return m_subHeaps[subHeapIndex].getCpuHandle(index & 0xFFFFFF);
     }
 
-    void free(int index, int count) { assert(0 && "not supported"); }
+    void free(int index, int count) { SLANG_ASSERT_FAILURE("not supported"); }
 
-    void free(D3D12Descriptor descriptor) { assert(0 && "not supported"); }
+    void free(D3D12Descriptor descriptor) { SLANG_ASSERT_FAILURE("not supported"); }
 
     void freeAll()
     {
@@ -508,7 +508,7 @@ int D3D12DescriptorHeap::allocate(int numDescriptors)
 // ---------------------------------------------------------------------------
 SLANG_FORCE_INLINE int D3D12DescriptorHeap::placeAt(int index)
 {
-    assert(index >= 0 && index < m_totalSize);
+    SLANG_ASSERT(index >= 0 && index < m_totalSize);
     m_currentIndex = index + 1;
     return index;
 }
@@ -516,7 +516,7 @@ SLANG_FORCE_INLINE int D3D12DescriptorHeap::placeAt(int index)
 // ---------------------------------------------------------------------------
 SLANG_FORCE_INLINE D3D12_CPU_DESCRIPTOR_HANDLE D3D12DescriptorHeap::getCpuHandle(int index) const
 {
-    assert(index >= 0 && index < m_totalSize);
+    SLANG_ASSERT(index >= 0 && index < m_totalSize);
     D3D12_CPU_DESCRIPTOR_HANDLE start = m_heap->GetCPUDescriptorHandleForHeapStart();
     D3D12_CPU_DESCRIPTOR_HANDLE dst;
     dst.ptr = start.ptr + m_descriptorSize * index;
@@ -525,7 +525,7 @@ SLANG_FORCE_INLINE D3D12_CPU_DESCRIPTOR_HANDLE D3D12DescriptorHeap::getCpuHandle
 // ---------------------------------------------------------------------------
 SLANG_FORCE_INLINE D3D12_GPU_DESCRIPTOR_HANDLE D3D12DescriptorHeap::getGpuHandle(int index) const
 {
-    assert(index >= 0 && index < m_totalSize);
+    SLANG_ASSERT(index >= 0 && index < m_totalSize);
     D3D12_GPU_DESCRIPTOR_HANDLE start = m_heap->GetGPUDescriptorHandleForHeapStart();
     D3D12_GPU_DESCRIPTOR_HANDLE dst;
     dst.ptr = start.ptr + m_descriptorSize * index;

--- a/tools/gfx/d3d12/d3d12-device.cpp
+++ b/tools/gfx/d3d12/d3d12-device.cpp
@@ -148,7 +148,7 @@ Result DeviceImpl::createBuffer(
     switch (memoryType)
     {
     case MemoryType::ReadBack:
-        assert(!srcData);
+        SLANG_ASSERT(!srcData);
 
         heapProps.Type = D3D12_HEAP_TYPE_READBACK;
         desc.Flags = D3D12_RESOURCE_FLAG_NONE;
@@ -1267,7 +1267,7 @@ Result DeviceImpl::createTextureResource(
                     mipSize.height = int(D3DUtil::calcAligned(mipSize.height, 4));
                 }
 
-                assert(
+                SLANG_ASSERT(
                     footprint.Width == mipSize.width && footprint.Height == mipSize.height &&
                     footprint.Depth == mipSize.depth);
 
@@ -2269,7 +2269,7 @@ Result DeviceImpl::createAccelerationStructure(
     IAccelerationStructure** outAS)
 {
 #if SLANG_GFX_HAS_DXR_SUPPORT
-    assert(desc.buffer != nullptr);
+    SLANG_ASSERT(desc.buffer != nullptr);
     RefPtr<AccelerationStructureImpl> result = new AccelerationStructureImpl();
     result->m_device5 = m_device5;
     result->m_buffer = static_cast<BufferResourceImpl*>(desc.buffer);

--- a/tools/gfx/d3d12/d3d12-helper-functions.cpp
+++ b/tools/gfx/d3d12/d3d12-helper-functions.cpp
@@ -251,7 +251,7 @@ void initSrvDesc(
             descOut.Texture3D.MostDetailedMip = subresourceRange.mipLevel;
             break;
         default:
-            assert(!"Unknown dimension");
+            SLANG_ASSERT_FAILURE("Unknown dimension");
         }
     }
     else if (resourceType == IResource::Type::TextureCube)
@@ -283,7 +283,7 @@ void initSrvDesc(
     }
     else
     {
-        assert(desc.DepthOrArraySize > 1);
+        SLANG_ASSERT(desc.DepthOrArraySize > 1);
 
         switch (desc.Dimension)
         {
@@ -323,7 +323,7 @@ void initSrvDesc(
             }
             else
             {
-                assert(descOut.ViewDimension == D3D12_SRV_DIMENSION_TEXTURE2DMSARRAY);
+                SLANG_ASSERT(descOut.ViewDimension == D3D12_SRV_DIMENSION_TEXTURE2DMSARRAY);
                 descOut.Texture2DMSArray.FirstArraySlice = subresourceRange.baseArrayLayer;
                 descOut.Texture2DMSArray.ArraySize = subresourceRange.layerCount == 0
                                                          ? desc.DepthOrArraySize
@@ -340,7 +340,7 @@ void initSrvDesc(
             break;
 
         default:
-            assert(!"Unknown dimension");
+            SLANG_ASSERT_FAILURE("Unknown dimension");
         }
     }
 }

--- a/tools/gfx/d3d12/d3d12-resource-views.cpp
+++ b/tools/gfx/d3d12/d3d12-resource-views.cpp
@@ -65,7 +65,7 @@ SlangResult createD3D12BufferDescriptor(
             {
                 FormatInfo sizeInfo;
                 gfxGetFormatInfo(desc.format, &sizeInfo);
-                assert(sizeInfo.pixelsPerBlock == 1);
+                SLANG_ASSERT(sizeInfo.pixelsPerBlock == 1);
                 uavDesc.Buffer.FirstElement = offset / sizeInfo.blockSizeInBytes;
                 uavDesc.Buffer.NumElements = UINT(size / sizeInfo.blockSizeInBytes);
             }
@@ -113,7 +113,7 @@ SlangResult createD3D12BufferDescriptor(
             {
                 FormatInfo sizeInfo;
                 gfxGetFormatInfo(desc.format, &sizeInfo);
-                assert(sizeInfo.pixelsPerBlock == 1);
+                SLANG_ASSERT(sizeInfo.pixelsPerBlock == 1);
                 srvDesc.Buffer.FirstElement = offset / sizeInfo.blockSizeInBytes;
                 srvDesc.Buffer.NumElements = UINT(size / sizeInfo.blockSizeInBytes);
             }

--- a/tools/gfx/d3d12/d3d12-resource.cpp
+++ b/tools/gfx/d3d12/d3d12-resource.cpp
@@ -10,7 +10,7 @@ using namespace Slang;
 
 void D3D12BarrierSubmitter::_flush()
 {
-    assert(m_numBarriers > 0);
+    SLANG_ASSERT(m_numBarriers > 0);
 
     if (m_commandList)
     {

--- a/tools/gfx/d3d12/d3d12-shader-table.cpp
+++ b/tools/gfx/d3d12/d3d12-shader-table.cpp
@@ -52,7 +52,7 @@ RefPtr<BufferResource> ShaderTableImpl::createDeviceBuffer(
     transientHeapImpl
         ->allocateStagingBuffer(tableSize, stagingBuffer, stagingBufferOffset, MemoryType::Upload);
 
-    assert(stagingBuffer);
+    SLANG_ASSERT(stagingBuffer);
     void* stagingPtr = nullptr;
     stagingBuffer->map(nullptr, &stagingPtr);
 

--- a/tools/gfx/immediate-renderer-base.cpp
+++ b/tools/gfx/immediate-renderer-base.cpp
@@ -667,7 +667,7 @@ public:
                     (GfxIndex)cmd.operands[1]);
                 break;
             default:
-                assert(!"unknown command");
+                SLANG_ASSERT_FAILURE("unknown command");
                 break;
             }
         }
@@ -706,7 +706,7 @@ public:
         uint64_t valueToSignal) override
     {
         // TODO: implement fence signal.
-        assert(fence == nullptr);
+        SLANG_ASSERT(fence == nullptr);
 
         CommandBufferInfo info = {};
         for (GfxIndex i = 0; i < count; i++)

--- a/tools/gfx/metal/metal-command-encoder.cpp
+++ b/tools/gfx/metal/metal-command-encoder.cpp
@@ -124,7 +124,7 @@ void ResourceCommandEncoder::copyTextureToBuffer(
     ITextureResource::Offset3D srcOffset,
     ITextureResource::Extents extent)
 {
-    assert(srcSubresource.mipLevelCount <= 1);
+    SLANG_ASSERT(srcSubresource.mipLevelCount <= 1);
 
     auto encoder = m_commandBuffer->getMetalBlitCommandEncoder();
     auto& desc = *static_cast<TextureResourceImpl*>(src)->getDesc();
@@ -473,7 +473,7 @@ void RenderCommandEncoder::setIndexBuffer(
         m_indexBufferType = MTL::IndexTypeUInt32;
         break;
     default:
-        assert(!"unsupported index format");
+        SLANG_ASSERT_FAILURE("unsupported index format");
     }
 }
 

--- a/tools/gfx/metal/metal-device.cpp
+++ b/tools/gfx/metal/metal-device.cpp
@@ -384,7 +384,7 @@ Result DeviceImpl::createTextureResource(
     const MTL::PixelFormat pixelFormat = MetalUtil::translatePixelFormat(desc.format);
     if (pixelFormat == MTL::PixelFormat::PixelFormatInvalid)
     {
-        assert(!"Unsupported texture format");
+        SLANG_ASSERT_FAILURE("Unsupported texture format");
         return SLANG_FAIL;
     }
 
@@ -440,7 +440,7 @@ Result DeviceImpl::createTextureResource(
         textureDesc->setDepth(descIn.size.depth);
         break;
     default:
-        assert("!Unsupported texture type");
+        SLANG_ASSERT_FAILURE("Unsupported texture type");
         return SLANG_FAIL;
     }
 

--- a/tools/gfx/metal/metal-render-pass.cpp
+++ b/tools/gfx/metal/metal-render-pass.cpp
@@ -52,7 +52,7 @@ Result RenderPassLayoutImpl::init(DeviceImpl* device, const IRenderPassLayout::D
 
     FramebufferLayoutImpl* framebufferLayout =
         static_cast<FramebufferLayoutImpl*>(desc.framebufferLayout);
-    assert(framebufferLayout);
+    SLANG_ASSERT(framebufferLayout);
 
     // Initialize render pass descriptor, filling in attachment metadata, but leaving texture data
     // unbound.

--- a/tools/gfx/mutable-shader-object.h
+++ b/tools/gfx/mutable-shader-object.h
@@ -107,7 +107,7 @@ public:
         Slang::Index subObjectCount = layoutImpl->getSubObjectCount();
         this->m_objects.setCount(subObjectCount);
         auto dataSize = layoutImpl->getElementTypeLayout()->getSize();
-        assert(dataSize >= 0);
+        SLANG_ASSERT(dataSize >= 0);
         this->m_data.setCount(dataSize);
         memset(this->m_data.getBuffer(), 0, dataSize);
         return SLANG_OK;

--- a/tools/gfx/open-gl/render-gl.cpp
+++ b/tools/gfx/open-gl/render-gl.cpp
@@ -1815,7 +1815,7 @@ void GLDevice::debugCallback(
     switch (format)
     {
     default:
-        assert(!"unexpected");
+        SLANG_ASSERT_FAILURE("unexpected");
         return VertexAttributeFormat();
 
 #define CASE(NAME, COUNT, TYPE, NORMALIZED)                           \
@@ -1848,7 +1848,7 @@ void GLDevice::bindBufferImpl(
         BufferResourceImpl* buffer = static_cast<BufferResourceImpl*>(buffers[ii]);
         GLuint bufferID = buffer ? buffer->m_handle : 0;
 
-        assert(!offsets || !offsets[ii]);
+        SLANG_ASSERT(!offsets || !offsets[ii]);
 
         glBindBufferBase(target, (GLuint)slot, bufferID);
     }
@@ -2831,7 +2831,7 @@ void GLDevice::setIndexBuffer(IBufferResource* buffer, Format indexFormat, Offse
 
 void GLDevice::setViewports(GfxCount count, Viewport const* viewports)
 {
-    assert(count == 1);
+    SLANG_ASSERT(count == 1);
     auto viewport = viewports[0];
     glViewport(
         (GLint)viewport.originX,
@@ -2843,7 +2843,7 @@ void GLDevice::setViewports(GfxCount count, Viewport const* viewports)
 
 void GLDevice::setScissorRects(GfxCount count, ScissorRect const* rects)
 {
-    assert(count <= 1);
+    SLANG_ASSERT(count <= 1);
     if (count)
     {
         // TODO: this isn't goign to be quite right because of the

--- a/tools/gfx/render.cpp
+++ b/tools/gfx/render.cpp
@@ -486,7 +486,7 @@ extern "C"
             }
         default:
             {
-                assert(!"Not handled");
+                SLANG_ASSERT_FAILURE("Not handled");
             }
         }
     }

--- a/tools/gfx/vulkan/glslang-module.cpp
+++ b/tools/gfx/vulkan/glslang-module.cpp
@@ -1,7 +1,6 @@
 // glslang-module.cpp
 #include "glslang-module.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/tools/gfx/vulkan/vk-api.cpp
+++ b/tools/gfx/vulkan/vk-api.cpp
@@ -35,7 +35,7 @@ bool VulkanApi::areDefined(ProcType type) const
         return VK_API_CHECK_FUNCTIONS(VK_API_DEVICE_PROCS);
     default:
         {
-            assert(!"Unhandled type");
+            SLANG_ASSERT_FAILURE("Unhandled type");
             return false;
         }
     }
@@ -58,7 +58,7 @@ Slang::Result VulkanApi::initGlobalProcs(const VulkanModule& module)
 
 Slang::Result VulkanApi::initInstanceProcs(VkInstance instance)
 {
-    assert(instance && vkGetInstanceProcAddr != nullptr);
+    SLANG_ASSERT(instance && vkGetInstanceProcAddr != nullptr);
 
 #define VK_API_GET_INSTANCE_PROC(x) x = (PFN_##x)vkGetInstanceProcAddr(instance, #x);
 
@@ -79,7 +79,7 @@ Slang::Result VulkanApi::initInstanceProcs(VkInstance instance)
 
 Slang::Result VulkanApi::initPhysicalDevice(VkPhysicalDevice physicalDevice)
 {
-    assert(m_physicalDevice == VK_NULL_HANDLE);
+    SLANG_ASSERT(m_physicalDevice == VK_NULL_HANDLE);
     m_physicalDevice = physicalDevice;
 
     vkGetPhysicalDeviceProperties(m_physicalDevice, &m_deviceProperties);
@@ -91,7 +91,7 @@ Slang::Result VulkanApi::initPhysicalDevice(VkPhysicalDevice physicalDevice)
 
 Slang::Result VulkanApi::initDeviceProcs(VkDevice device)
 {
-    assert(m_instance && device && vkGetDeviceProcAddr != nullptr);
+    SLANG_ASSERT(m_instance && device && vkGetDeviceProcAddr != nullptr);
 
 #define VK_API_GET_DEVICE_PROC(x) x = (PFN_##x)vkGetDeviceProcAddr(device, #x);
 
@@ -116,7 +116,7 @@ Slang::Result VulkanApi::initDeviceProcs(VkDevice device)
 
 int VulkanApi::findMemoryTypeIndex(uint32_t typeBits, VkMemoryPropertyFlags properties) const
 {
-    assert(typeBits);
+    SLANG_ASSERT(typeBits);
 
     const int numMemoryTypes = int(m_deviceMemoryProperties.memoryTypeCount);
 
@@ -138,7 +138,7 @@ int VulkanApi::findMemoryTypeIndex(uint32_t typeBits, VkMemoryPropertyFlags prop
 
 int VulkanApi::findQueue(VkQueueFlags reqFlags) const
 {
-    assert(m_physicalDevice != VK_NULL_HANDLE);
+    SLANG_ASSERT(m_physicalDevice != VK_NULL_HANDLE);
 
     uint32_t numQueueFamilies = 0;
     vkGetPhysicalDeviceQueueFamilyProperties(m_physicalDevice, &numQueueFamilies, nullptr);

--- a/tools/gfx/vulkan/vk-buffer.cpp
+++ b/tools/gfx/vulkan/vk-buffer.cpp
@@ -22,7 +22,7 @@ Result VKBufferHandleRAII::init(
     bool isShared,
     VkExternalMemoryHandleTypeFlagsKHR extMemHandleType)
 {
-    assert(!isInitialized());
+    SLANG_ASSERT(!isInitialized());
 
     m_api = &api;
     m_memory = VK_NULL_HANDLE;
@@ -48,7 +48,7 @@ Result VKBufferHandleRAII::init(
     api.vkGetBufferMemoryRequirements(api.m_device, m_buffer, &memoryReqs);
 
     int memoryTypeIndex = api.findMemoryTypeIndex(memoryReqs.memoryTypeBits, reqMemoryProperties);
-    assert(memoryTypeIndex >= 0);
+    SLANG_ASSERT(memoryTypeIndex >= 0);
 
     VkMemoryPropertyFlags actualMemoryProperites =
         api.m_deviceMemoryProperties.memoryTypes[memoryTypeIndex].propertyFlags;
@@ -97,7 +97,7 @@ Result VKBufferHandleRAII::init(
 BufferResourceImpl::BufferResourceImpl(const IBufferResource::Desc& desc, DeviceImpl* renderer)
     : Parent(desc), m_renderer(renderer)
 {
-    assert(renderer);
+    SLANG_ASSERT(renderer);
 }
 
 BufferResourceImpl::~BufferResourceImpl()

--- a/tools/gfx/vulkan/vk-command-encoder.cpp
+++ b/tools/gfx/vulkan/vk-command-encoder.cpp
@@ -32,7 +32,7 @@ int PipelineCommandEncoder::getBindPointIndex(VkPipelineBindPoint bindPoint)
     case VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR:
         return 2;
     default:
-        assert(!"unknown pipeline type.");
+        SLANG_ASSERT_FAILURE("unknown pipeline type.");
         return -1;
     }
 }
@@ -752,7 +752,7 @@ void ResourceCommandEncoder::clearResourceView(
                 break;
             case ResourceViewImpl::ViewType::PlainBuffer:
                 {
-                    assert(
+                    SLANG_ASSERT(
                         clearValue->color.uintValues[1] == clearValue->color.uintValues[0] &&
                         clearValue->color.uintValues[2] == clearValue->color.uintValues[0] &&
                         clearValue->color.uintValues[3] == clearValue->color.uintValues[0]);
@@ -771,7 +771,7 @@ void ResourceCommandEncoder::clearResourceView(
                 break;
             case ResourceViewImpl::ViewType::TexelBuffer:
                 {
-                    assert(
+                    SLANG_ASSERT(
                         clearValue->color.uintValues[1] == clearValue->color.uintValues[0] &&
                         clearValue->color.uintValues[2] == clearValue->color.uintValues[0] &&
                         clearValue->color.uintValues[3] == clearValue->color.uintValues[0]);
@@ -874,7 +874,7 @@ void ResourceCommandEncoder::copyTextureToBuffer(
     ITextureResource::Offset3D srcOffset,
     ITextureResource::Extents extent)
 {
-    assert(srcSubresource.mipLevelCount <= 1);
+    SLANG_ASSERT(srcSubresource.mipLevelCount <= 1);
 
     auto image = static_cast<TextureResourceImpl*>(src);
     auto desc = image->getDesc();
@@ -1016,7 +1016,7 @@ Result RenderCommandEncoder::bindPipelineWithRootObject(
 void RenderCommandEncoder::setViewports(GfxCount count, const Viewport* viewports)
 {
     static const int kMaxViewports = 8; // TODO: base on device caps
-    assert(count <= kMaxViewports);
+    SLANG_ASSERT(count <= kMaxViewports);
 
     m_viewports.setCount(count);
     for (GfxIndex ii = 0; ii < count; ++ii)
@@ -1039,7 +1039,7 @@ void RenderCommandEncoder::setViewports(GfxCount count, const Viewport* viewport
 void RenderCommandEncoder::setScissorRects(GfxCount count, const ScissorRect* rects)
 {
     static const int kMaxScissorRects = 8; // TODO: base on device caps
-    assert(count <= kMaxScissorRects);
+    SLANG_ASSERT(count <= kMaxScissorRects);
 
     m_scissorRects.setCount(count);
     for (GfxIndex ii = 0; ii < count; ++ii)
@@ -1075,8 +1075,8 @@ void RenderCommandEncoder::setPrimitiveTopology(PrimitiveTopology topology)
         default:
             // We are using a non-list topology, but we don't have dynmaic state
             // extension, error out.
-            assert(!"Non-list topology requires VK_EXT_extended_dynamic_states, which "
-                    "is not present.");
+            SLANG_ASSERT_FAILURE("Non-list topology requires VK_EXT_extended_dynamic_states, which "
+                                 "is not present.");
             break;
         }
     }
@@ -1122,7 +1122,7 @@ void RenderCommandEncoder::setIndexBuffer(
         indexType = VK_INDEX_TYPE_UINT32;
         break;
     default:
-        assert(!"unsupported index format");
+        SLANG_ASSERT_FAILURE("unsupported index format");
     }
 
     BufferResourceImpl* bufferImpl = static_cast<BufferResourceImpl*>(buffer);

--- a/tools/gfx/vulkan/vk-descriptor-allocator.cpp
+++ b/tools/gfx/vulkan/vk-descriptor-allocator.cpp
@@ -79,7 +79,7 @@ VulkanDescriptorSet DescriptorSetAllocator::allocate(VkDescriptorSetLayout layou
         return rs;
     }
     // Failed to allocate from a new pool, we are in trouble.
-    assert(!"descriptor set allocation failed.");
+    SLANG_ASSERT_FAILURE("descriptor set allocation failed.");
     return rs;
 }
 } // namespace gfx

--- a/tools/gfx/vulkan/vk-device-queue.cpp
+++ b/tools/gfx/vulkan/vk-device-queue.cpp
@@ -1,7 +1,6 @@
 // vk-device-queue.cpp
 #include "vk-device-queue.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -36,7 +35,7 @@ void VulkanDeviceQueue::destroy()
 
 SlangResult VulkanDeviceQueue::init(const VulkanApi& api, VkQueue queue, int queueIndex)
 {
-    assert(m_api == nullptr);
+    SLANG_ASSERT(m_api == nullptr);
 
     for (int i = 0; i < int(EventType::CountOf); ++i)
     {
@@ -203,7 +202,7 @@ VkSemaphore VulkanDeviceQueue::getSemaphore(EventType eventType)
 
 VkSemaphore VulkanDeviceQueue::makeCurrent(EventType eventType)
 {
-    assert(!isCurrent(eventType));
+    SLANG_ASSERT(!isCurrent(eventType));
     VkSemaphore semaphore = m_semaphores[int(eventType)];
     m_currentSemaphores[int(eventType)] = semaphore;
     return semaphore;

--- a/tools/gfx/vulkan/vk-device.cpp
+++ b/tools/gfx/vulkan/vk-device.cpp
@@ -953,7 +953,7 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
     }
 
     m_queueFamilyIndex = m_api.findQueue(VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT);
-    assert(m_queueFamilyIndex >= 0);
+    SLANG_ASSERT(m_queueFamilyIndex >= 0);
 
 #if defined(GFX_NV_AFTERMATH)
     VkDeviceDiagnosticsConfigCreateInfoNV aftermathInfo = {};
@@ -1489,7 +1489,7 @@ Result DeviceImpl::getTextureAllocationInfo(
     const VkFormat format = VulkanUtil::getVkFormat(desc.format);
     if (format == VK_FORMAT_UNDEFINED)
     {
-        assert(!"Unhandled image format");
+        SLANG_ASSERT_FAILURE("Unhandled image format");
         return SLANG_FAIL;
     }
     const int arraySize = calcEffectiveArraySize(desc);
@@ -1521,7 +1521,7 @@ Result DeviceImpl::getTextureAllocationInfo(
     case IResource::Type::Texture3D:
         {
             // Can't have an array and 3d texture
-            assert(desc.arraySize <= 1);
+            SLANG_ASSERT(desc.arraySize <= 1);
 
             imageInfo.imageType = VK_IMAGE_TYPE_3D;
             imageInfo.extent = VkExtent3D{
@@ -1532,7 +1532,7 @@ Result DeviceImpl::getTextureAllocationInfo(
         }
     default:
         {
-            assert(!"Unhandled type");
+            SLANG_ASSERT_FAILURE("Unhandled type");
             return SLANG_FAIL;
         }
     }
@@ -1618,7 +1618,7 @@ Result DeviceImpl::createTextureResource(
     const VkFormat format = VulkanUtil::getVkFormat(desc.format);
     if (format == VK_FORMAT_UNDEFINED)
     {
-        assert(!"Unhandled image format");
+        SLANG_ASSERT_FAILURE("Unhandled image format");
         return SLANG_FAIL;
     }
 
@@ -1655,7 +1655,7 @@ Result DeviceImpl::createTextureResource(
     case IResource::Type::Texture3D:
         {
             // Can't have an array and 3d texture
-            assert(desc.arraySize <= 1);
+            SLANG_ASSERT(desc.arraySize <= 1);
 
             imageInfo.imageType = VK_IMAGE_TYPE_3D;
             imageInfo.extent = VkExtent3D{
@@ -1666,7 +1666,7 @@ Result DeviceImpl::createTextureResource(
         }
     default:
         {
-            assert(!"Unhandled type");
+            SLANG_ASSERT_FAILURE("Unhandled type");
             return SLANG_FAIL;
         }
     }
@@ -1705,7 +1705,7 @@ Result DeviceImpl::createTextureResource(
     VkMemoryPropertyFlags reqMemoryProperties = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     int memoryTypeIndex =
         m_api.findMemoryTypeIndex(memRequirements.memoryTypeBits, reqMemoryProperties);
-    assert(memoryTypeIndex >= 0);
+    SLANG_ASSERT(memoryTypeIndex >= 0);
 
     VkMemoryPropertyFlags actualMemoryProperites =
         m_api.m_deviceMemoryProperties.memoryTypes[memoryTypeIndex].propertyFlags;
@@ -1774,7 +1774,7 @@ Result DeviceImpl::createTextureResource(
             VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT));
 
-        assert(mipSizes.getCount() == numMipMaps);
+        SLANG_ASSERT(mipSizes.getCount() == numMipMaps);
 
         // Copy into upload buffer
         {
@@ -2425,7 +2425,7 @@ Result DeviceImpl::createBufferView(
     switch (desc.type)
     {
     default:
-        assert(!"unhandled");
+        SLANG_ASSERT_FAILURE("unhandled");
         return SLANG_FAIL;
 
     case IResourceView::Type::UnorderedAccess:
@@ -2476,7 +2476,7 @@ Result DeviceImpl::createBufferView(
                 }
                 else
                 {
-                    assert(!"unhandled");
+                    SLANG_ASSERT_FAILURE("unhandled");
                 }
 
                 SLANG_VK_RETURN_ON_FAIL(m_api.vkCreateBufferView(m_device, &info, nullptr, &view));

--- a/tools/gfx/vulkan/vk-helper-functions.cpp
+++ b/tools/gfx/vulkan/vk-helper-functions.cpp
@@ -96,7 +96,7 @@ VkImageLayout translateImageLayout(ResourceState state)
     case ResourceState::Present:
         return VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
     default:
-        assert(!"Unsupported");
+        SLANG_ASSERT_FAILURE("Unsupported");
         return VK_IMAGE_LAYOUT_UNDEFINED;
     }
 }
@@ -147,7 +147,7 @@ VkAccessFlagBits calcAccessFlags(ResourceState state)
     case ResourceState::General:
         return VkAccessFlagBits(VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT);
     default:
-        assert(!"Unsupported");
+        SLANG_ASSERT_FAILURE("Unsupported");
         return VkAccessFlagBits(0);
     }
 }
@@ -158,7 +158,7 @@ VkPipelineStageFlagBits calcPipelineStageFlags(ResourceState state, bool src)
     {
     case ResourceState::Undefined:
     case ResourceState::PreInitialized:
-        assert(src);
+        SLANG_ASSERT(src);
         return VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
     case ResourceState::VertexBuffer:
     case ResourceState::IndexBuffer:
@@ -205,7 +205,7 @@ VkPipelineStageFlagBits calcPipelineStageFlags(ResourceState state, bool src)
     case ResourceState::AccelerationStructureBuildInput:
         return VkPipelineStageFlagBits(VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR);
     default:
-        assert(!"Unsupported");
+        SLANG_ASSERT_FAILURE("Unsupported");
         return VkPipelineStageFlagBits(0);
     }
 }
@@ -236,7 +236,7 @@ VkBufferUsageFlagBits _calcBufferUsageFlags(ResourceState state)
     case ResourceState::DepthRead:
     case ResourceState::DepthWrite:
         {
-            assert(!"Invalid resource state for buffer resource.");
+            SLANG_ASSERT_FAILURE("Invalid resource state for buffer resource.");
             return VkBufferUsageFlagBits(0);
         }
     case ResourceState::UnorderedAccess:
@@ -305,7 +305,7 @@ VkImageUsageFlagBits _calcImageUsageFlags(ResourceState state)
         return (VkImageUsageFlagBits)0;
     default:
         {
-            assert(!"Unsupported");
+            SLANG_ASSERT_FAILURE("Unsupported");
             return VkImageUsageFlagBits(0);
         }
     }
@@ -324,7 +324,7 @@ VkImageViewType _calcImageViewType(ITextureResource::Type type, const ITextureRe
     case IResource::Type::Texture3D:
         {
             // Can't have an array and 3d texture
-            assert(desc.arraySize <= 1);
+            SLANG_ASSERT(desc.arraySize <= 1);
             if (desc.arraySize <= 1)
             {
                 return VK_IMAGE_VIEW_TYPE_3D;
@@ -395,7 +395,7 @@ VkAccessFlags calcAccessFlagsFromImageLayout(VkImageLayout layout)
     case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
         return VK_ACCESS_TRANSFER_WRITE_BIT;
     default:
-        assert(!"Unsupported VkImageLayout");
+        SLANG_ASSERT_FAILURE("Unsupported VkImageLayout");
         return (VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT);
     }
 }
@@ -428,7 +428,7 @@ VkPipelineStageFlags calcPipelineStageFlagsFromImageLayout(VkImageLayout layout)
         return (
             VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT);
     default:
-        assert(!"Unsupported VkImageLayout");
+        SLANG_ASSERT_FAILURE("Unsupported VkImageLayout");
         return VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
     }
 }

--- a/tools/gfx/vulkan/vk-module.cpp
+++ b/tools/gfx/vulkan/vk-module.cpp
@@ -1,7 +1,6 @@
 // module.cpp
 #include "vk-module.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -55,7 +54,7 @@ Slang::Result VulkanModule::init(bool useSoftwareImpl)
 
 PFN_vkVoidFunction VulkanModule::getFunction(const char* name) const
 {
-    assert(m_module);
+    SLANG_ASSERT(m_module);
     if (!m_module)
     {
         return nullptr;

--- a/tools/gfx/vulkan/vk-render-pass.cpp
+++ b/tools/gfx/vulkan/vk-render-pass.cpp
@@ -29,7 +29,7 @@ Result RenderPassLayoutImpl::init(DeviceImpl* renderer, const IRenderPassLayout:
 
     // Create render pass using load/storeOp and layouts info from `desc`.
     auto framebufferLayout = static_cast<FramebufferLayoutImpl*>(desc.framebufferLayout);
-    assert(desc.renderTargetCount == framebufferLayout->m_renderTargetCount);
+    SLANG_ASSERT(desc.renderTargetCount == framebufferLayout->m_renderTargetCount);
 
     // We need extra space if we have depth buffer
     Array<VkAttachmentDescription, kMaxTargets> targetDescs;

--- a/tools/gfx/vulkan/vk-shader-object.cpp
+++ b/tools/gfx/vulkan/vk-shader-object.cpp
@@ -794,7 +794,7 @@ Result ShaderObjectImpl::allocateDescriptorSets(
     BindingOffset const& offset,
     ShaderObjectLayoutImpl* specializedLayout)
 {
-    assert(specializedLayout->getOwnDescriptorSets().getCount() <= 1);
+    SLANG_ASSERT(specializedLayout->getOwnDescriptorSets().getCount() <= 1);
     // The number of sets to allocate and their layouts was already pre-computed
     // as part of the shader object layout, so we use that information here.
     //
@@ -844,7 +844,7 @@ Result ShaderObjectImpl::bindAsParameterBlock(
     //
     SLANG_RETURN_ON_FAIL(allocateDescriptorSets(encoder, context, offset, specializedLayout));
 
-    assert(offset.bindingSet < (uint32_t)context.descriptorSets->getCount());
+    SLANG_ASSERT(offset.bindingSet < (uint32_t)context.descriptorSets->getCount());
     SLANG_RETURN_ON_FAIL(bindAsConstantBuffer(encoder, context, offset, specializedLayout));
 
     return SLANG_OK;

--- a/tools/gfx/vulkan/vk-shader-table.cpp
+++ b/tools/gfx/vulkan/vk-shader-table.cpp
@@ -56,7 +56,7 @@ RefPtr<BufferResource> ShaderTableImpl::createDeviceBuffer(
     transientHeapImpl
         ->allocateStagingBuffer(tableSize, stagingBuffer, stagingBufferOffset, MemoryType::Upload);
 
-    assert(stagingBuffer);
+    SLANG_ASSERT(stagingBuffer);
     void* stagingPtr = nullptr;
     stagingBuffer->map(nullptr, &stagingPtr);
 

--- a/tools/gfx/vulkan/vk-util.cpp
+++ b/tools/gfx/vulkan/vk-util.cpp
@@ -287,7 +287,7 @@ VkShaderStageFlags VulkanUtil::getShaderStage(SlangStage stage)
     case SLANG_STAGE_AMPLIFICATION:
         return VK_SHADER_STAGE_TASK_BIT_EXT;
     default:
-        assert(!"unsupported stage.");
+        SLANG_ASSERT_FAILURE("unsupported stage.");
         return VkShaderStageFlags(-1);
     }
 }
@@ -344,7 +344,7 @@ VkSampleCountFlagBits VulkanUtil::translateSampleCount(uint32_t sampleCount)
     case 64:
         return VK_SAMPLE_COUNT_64_BIT;
     default:
-        assert(!"Unsupported sample count");
+        SLANG_ASSERT_FAILURE("Unsupported sample count");
         return VK_SAMPLE_COUNT_1_BIT;
     }
 }
@@ -360,7 +360,7 @@ VkCullModeFlags VulkanUtil::translateCullMode(CullMode cullMode)
     case CullMode::Back:
         return VK_CULL_MODE_BACK_BIT;
     default:
-        assert(!"Unsupported cull mode");
+        SLANG_ASSERT_FAILURE("Unsupported cull mode");
         return VK_CULL_MODE_NONE;
     }
 }
@@ -374,7 +374,7 @@ VkFrontFace VulkanUtil::translateFrontFaceMode(FrontFaceMode frontFaceMode)
     case FrontFaceMode::Clockwise:
         return VK_FRONT_FACE_CLOCKWISE;
     default:
-        assert(!"Unsupported front face mode");
+        SLANG_ASSERT_FAILURE("Unsupported front face mode");
         return VK_FRONT_FACE_CLOCKWISE;
     }
 }
@@ -388,7 +388,7 @@ VkPolygonMode VulkanUtil::translateFillMode(FillMode fillMode)
     case FillMode::Wireframe:
         return VK_POLYGON_MODE_LINE;
     default:
-        assert(!"Unsupported fill mode");
+        SLANG_ASSERT_FAILURE("Unsupported fill mode");
         return VK_POLYGON_MODE_FILL;
     }
 }
@@ -433,7 +433,7 @@ VkBlendFactor VulkanUtil::translateBlendFactor(BlendFactor blendFactor)
         return VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA;
 
     default:
-        assert(!"Unsupported blend factor");
+        SLANG_ASSERT_FAILURE("Unsupported blend factor");
         return VK_BLEND_FACTOR_ONE;
     }
 }
@@ -453,7 +453,7 @@ VkBlendOp VulkanUtil::translateBlendOp(BlendOp op)
     case BlendOp::Max:
         return VK_BLEND_OP_MAX;
     default:
-        assert(!"Unsupported blend op");
+        SLANG_ASSERT_FAILURE("Unsupported blend op");
         return VK_BLEND_OP_ADD;
     }
 }
@@ -471,7 +471,7 @@ VkPrimitiveTopology VulkanUtil::translatePrimitiveTypeToListTopology(PrimitiveTy
     case PrimitiveType::Patch:
         return VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
     default:
-        assert(!"unknown topology type.");
+        SLANG_ASSERT_FAILURE("unknown topology type.");
         return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
     }
 }
@@ -652,15 +652,15 @@ CooperativeVectorComponentType VulkanUtil::translateCooperativeVectorComponentTy
 {
     if (res != VK_SUCCESS)
     {
-        assert(!"Vulkan returned a failure");
+        SLANG_ASSERT_FAILURE("Vulkan returned a failure");
     }
     return toSlangResult(res);
 }
 
 /* static */ void VulkanUtil::checkFail(VkResult res)
 {
-    assert(res != VK_SUCCESS);
-    assert(!"Vulkan check failed");
+    SLANG_ASSERT(res != VK_SUCCESS);
+    SLANG_ASSERT_FAILURE("Vulkan check failed");
 }
 
 /* static */ VkPrimitiveTopology VulkanUtil::getVkPrimitiveTopology(PrimitiveTopology topology)
@@ -680,7 +680,7 @@ CooperativeVectorComponentType VulkanUtil::translateCooperativeVectorComponentTy
     default:
         break;
     }
-    assert(!"Unknown topology");
+    SLANG_ASSERT_FAILURE("Unknown topology");
     return VK_PRIMITIVE_TOPOLOGY_MAX_ENUM;
 }
 

--- a/tools/render-test/slang-support.cpp
+++ b/tools/render-test/slang-support.cpp
@@ -10,7 +10,6 @@
 #include "core/slang-test-tool-util.h"
 #include "options.h"
 
-#include <assert.h>
 #include <stdio.h>
 
 namespace renderer_test

--- a/tools/slang-generate/main.cpp
+++ b/tools/slang-generate/main.cpp
@@ -513,7 +513,7 @@ void emitRaw(FILE* stream, char const* begin, char const* end)
             }
             else
             {
-                assert(false);
+                SLANG_ASSERT_FAILURE("non-printable character in string literal");
             }
         }
     }

--- a/tools/slang-reflection-test/slang-reflection-test-main.cpp
+++ b/tools/slang-reflection-test/slang-reflection-test-main.cpp
@@ -8,7 +8,6 @@
 #include "slang-com-helper.h"
 #include "slang.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
## Motivation

The codebase has two parallel assertion mechanisms. Slang has its own `SLANG_ASSERT` /
`SLANG_RELEASE_ASSERT` / `SLANG_ASSERT_FAILURE`, which route through `Slang::handleAssert`
(`source/core/slang-signal.cpp:51`) and therefore honor the `SLANG_ASSERT` environment variable
documented in `CLAUDE.md` — `system`, `debugbreak`, and `release-assert-only`. That last mode is
what lets an unattended or LLM-driven run continue past debug-only assertions instead of hanging on
a modal dialog.

Alongside that, 145 call sites still used the C library `assert`, which honors none of it. A
`assert(!"Unsupported texture format")` in the Vulkan backend could not be routed, suppressed, or
made to break into a debugger, and it silently vanished under `NDEBUG`.

The two mechanisms were also entangled. `source/core/slang-common.h` — the header that *defines*
`SLANG_ASSERT` — itself included `<assert.h>`, leaking the C `assert` into essentially every
translation unit in the compiler and making the native spelling the path of least resistance.

## Proposed solution

Convert the native call sites to the project macros and remove the includes that fed them, so that
`SLANG_ASSERT` is the only assertion mechanism reachable in `source/` and `tools/`:

- `assert(expr)` → `SLANG_ASSERT(expr)`
- `assert(!"msg")` → `SLANG_ASSERT_FAILURE("msg")`
- `assert(0 && "msg")` → `SLANG_ASSERT_FAILURE("msg")`

`SLANG_ASSERT_FAILURE` is not a new idiom introduced here. `tools/gfx/d3d/d3d-util.cpp` already
used it six times, directly alongside a native `assert(!"Not reachable")`; this makes the file
internally consistent rather than inventing a convention.

Two `<cassert>` includes are kept deliberately, because in both cases the native assert is the
correct answer rather than an oversight — see the process report.

## Change summary

| Area | Change |
| --- | --- |
| `source/core/slang-common.h` | Drop `<assert.h>`. The `SLANG_ASSERT` macros expand to `Slang::handleAssert` and never needed it; this was the main source of transitive leakage. |
| `source/`, `tools/` (29 files) | Remove `#include <assert.h>`, plus a commented-out one in `slang-token.cpp:4`. |
| `source/`, `tools/` (145 call sites) | 92 → `SLANG_ASSERT`, 53 → `SLANG_ASSERT_FAILURE`. |
| `source/core/slang-signal.cpp` | Keep `<cassert>` for the `SLANG_ASSERT=system` mode. Move the env-var handling off Slang's own string containers. Delete a dead `StringBuilder`. |
| `source/slang-glslang/slang-glslang.cpp` | Keep `<cassert>` (does not link slang-core). Make `_makeTargetLanguageVersion` `constexpr` and promote one runtime check to `SLANG_COMPILE_TIME_ASSERT`. |
| `include/slang-com-helper.h` | Add the `<assert.h>` it always needed but never included. |
| `include/slang-com-ptr.h`, `include/slang-gfx.h` | Drop `<assert.h>`; neither references `assert`. |
| `tools/gfx/metal/metal-device.cpp` | Fix a typo'd assert that could never fire. |

## Concepts and vocabulary

- **`SLANG_ASSERT` vs. `SLANG_ASSERT_FAILURE`** — `SLANG_ASSERT(x)` checks `x` in debug builds and
  expands to `SLANG_ASSUME(x)` in release. `SLANG_ASSERT_FAILURE(msg)` is unconditional: it always
  calls `handleAssert`. It is the counterpart of the `assert(!"msg")` idiom, where there is no
  condition to test because control simply should not have reached that point.
- **`SLANG_ASSUME`** — an optimization hint (`[[assume]]` / `__builtin_assume` / `__assume`). It is
  *not* a check: a false condition in release is undefined behavior, not a diagnostic.
- **`release-assert-only`** — a `SLANG_ASSERT` env-var mode in which `handleAssert` returns early
  for debug-only assertions (`slang-signal.cpp:64`) so a debug build can mimic release behavior.
  This is exactly the routing a native `assert` cannot participate in.

## Process report

**Why the conversions belong at the call sites rather than behind a compatibility shim.** An
alternative would have been to `#define assert SLANG_ASSERT` somewhere central. That was rejected:
it would leave the misleading native spelling in the source, and it would break any third-party
header that legitimately expects the C `assert`. Converting the call sites keeps one spelling per
concept, per the "one source of truth" rule.

**`source/core/slang-common.h` (the root cause).** This is the change the rest depends on. The
`SLANG_ASSERT` definition at `slang-common.h:365` expands to `::Slang::handleAssert(...)` and the
release form to `SLANG_ASSUME` — neither touches the C `assert`. The include was therefore already
dead in the file that owned it, while transitively supplying `assert` to most of the compiler. With
it gone, a stray native `assert` in `source/slang/` now fails to compile rather than silently
working, which is what keeps this cleanup from regressing.

**`include/slang-com-helper.h` — a latent bug the cleanup exposed.** Removing the unused
`<assert.h>` from `include/slang-com-ptr.h` broke the build at
`tools/gfx/d3d11/d3d11-device.cpp:1584`. The cause is that `SLANG_ASSERT_ON_FAIL` and
`SLANG_ASSERT_VOID_ON_FAIL` (`slang-com-helper.h:66` and `:76`) expand to `assert(false)`, but that
header never included `<assert.h>` — it worked only because `slang-com-ptr.h` includes
`slang-com-helper.h` and happened to include `<assert.h>` itself.

On the input-shape question: the right layer here is the producer, not the consumer. The fix is not
to restore the include where it was unused, which would preserve the accidental coupling; it is to
make the header that *uses* `assert` self-contained. These are public headers, so they cannot use
`SLANG_ASSERT` (which lives in `source/core` and needs `handleAssert` at link time), and the system
assert is the only portable option. Note this preserves source compatibility for external
consumers: `slang-gfx.h` → `slang-com-ptr.h` → `slang-com-helper.h` still delivers `<assert.h>`
transitively.

**`source/core/slang-signal.cpp` — keeping the assert path off Slang's own containers.**
`handleAssert` read its environment variable with `StringBuilder` plus
`PlatformUtil::getEnvironmentVariable` and compared with
`UnownedStringSlice::caseInsensitiveEquals`. That is a re-entrancy hazard, because
`PlatformUtil::getEnvironmentVariable` (`slang-platform.cpp:303`) constructs a `String` and appends
to a `StringBuilder`, and those containers assert internally — `slang-list.h:100` (`m_count > 0`),
`slang-string.h:59`, `slang-array-view.h:25`. If any of those fired while an assertion was being
reported, it would re-enter `handleAssert`, build another `StringBuilder`, and recurse until the
stack overflowed, destroying the original diagnostic.

That risk is exactly what the existing `char locMsg[1024]` stack buffer at `slang-signal.cpp:102`
was already guarding against — its comment reads *"avoid heap allocation on the assertion path,
which could mask the original failure if the heap is corrupted"* — but the `StringBuilder` above it
defeated the intent. This replaces it with `_readAssertEnvVar` (`getenv_s`/`getenv` into a 64-byte
stack buffer) and a local `_caseInsensitiveEquals`, so nothing before the final `handleSignal` call
touches Slang's containers. `slang-platform.h` is no longer needed and is dropped.

This narrows the window rather than closing it: `handleSignal` still builds `String`s for
`g_lastSignalMessage` and for the exception constructors. Fully closing it needs a re-entrancy
guard or exception types that do not carry `String`, which is a larger change left out of scope
here.

**Dead `StringBuilder` in `handleSignal`.** The function opened by building
`buf << typeText << ": " << message` and then never reading `buf`. It duplicated `_getMessage`
(`slang-signal.cpp:38`), which is called on the very next line and is the more correct version
because it null-checks `message`. Left over from the refactor that extracted `_getMessage`; it
escaped warnings because the variable is written, just never read.

**`source/slang-glslang/slang-glslang.cpp` — why `<cassert>` stays.** This target links only
glslang and SPIRV-Tools (`source/slang-glslang/CMakeLists.txt`), not slang-core, so `SLANG_ASSERT`
would be an unresolved reference to `Slang::handleAssert`. Its two remaining runtime checks are
genuine and stay on the system assert. The third was different in kind:
`assert(glslang::EShTargetSpv_1_4 == _makeTargetLanguageVersion(1, 4))` verifies a pure encoding
invariant between two compile-time constants, so it was a runtime check of something knowable at
build time. Making `_makeTargetLanguageVersion` `constexpr` lets it become
`SLANG_COMPILE_TIME_ASSERT` (from the public `slang.h`, already included), moving the failure to
build time and removing a check from every compile call.

**`source/core/slang-signal.cpp` — why `<cassert>` stays.** The `SLANG_ASSERT=system` mode exists
precisely so the CRT assert fires and shows its modal dialog, letting a developer attach a
debugger (`slang-signal.cpp:70` and `:83`). The native assert is the feature, not an oversight.

**`prelude/*.h` — why `<assert.h>` stays.** These three includes look dead to a grep for `assert(`,
but are not. `prelude/slang-cpp-types-core.h:6` defines `SLANG_PRELUDE_ASSERT(VALUE)` as
`assert(VALUE)` under `SLANG_PRELUDE_ENABLE_ASSERT`, and that header does not include `<assert.h>`
itself — it relies on its includers to supply it. Removing them would break the bounds checks
(`SLANG_BOUND_ASSERT`, `slang-cpp-types-core.h:18`) in generated CPU and Torch code.

**`tools/gfx/metal/metal-device.cpp` — a typo fixed in passing.** The line read
`assert("!Unsupported texture type")` with the `!` inside the quotes, so the condition was a
non-null string literal and the assertion could never fire. It is now
`SLANG_ASSERT_FAILURE("Unsupported texture type")`, matching its sibling at `metal-device.cpp:387`.
Flagging it explicitly because it is the one place where the conversion changes behavior beyond the
release-build note below: this assertion now actually reports.

**Behavioral note for reviewers.** `assert(!"…")` compiled to nothing under `NDEBUG`, whereas
`SLANG_ASSERT_FAILURE` calls `handleAssert` unconditionally. Release builds will therefore now
signal on gfx paths such as "Unsupported texture format" or "unknown topology type" that previously
fell through silently. This is the intended reading of those sites — they sit in `default:` labels
that then return a failure code — and it matches how `SLANG_ASSERT_FAILURE` already behaved in the
same files. It is called out because it is the one semantic change in an otherwise mechanical
rename, and because `release-assert-only` remains available to suppress it.

**Scope note.** `examples/` still uses the native `assert` (3 files). That is deliberate: examples
demonstrate the *public* API, and `SLANG_ASSERT` is internal to `source/core`.

**Validation.** Debug and release both build clean with `-DCMAKE_COMPILE_WARNING_AS_ERROR=ON`,
which matters here because `SLANG_ASSERT` expands to a check in debug but to `SLANG_ASSUME` in
release — two genuinely different compile paths. `slang-test slang-unit-test-tool/` passes 524/524.
