### PR TITLE
Add an `-Os` optimization level that optimizes for size (#12331)

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -1233,6 +1233,7 @@ Optimization Level
 * `1`, `default` : Enable a default level of optimization.This is the default if no [-O](#o-1) options are used. 
 * `2`, `high` : Enable aggressive optimizations for speed. 
 * `3`, `maximal` : Enable further optimizations, which might have a significant impact on compile time, or involve unwanted tradeoffs in terms of code size. 
+* `s`, `size` : Optimize for the size of the generated code rather than for its runtime speed. This is not a further point on the 0..3 scale, it selects a different optimization goal. 
 
 <a id="debug-level"></a>
 ## debug-level

--- a/docs/user-guide/a2-01-spirv-target-specific.md
+++ b/docs/user-guide/a2-01-spirv-target-specific.md
@@ -429,6 +429,10 @@ When targeting SPIR-V, this option emits [SPIR-V NonSemantic Shader DebugInfo In
 Set the optimization level.
 Under `-O0` option, Slang will not perform extensive inlining for all function calls, instead it will preserve the call graph as much as possible to help with understanding the SPIR-V structure and diagnosing any downstream toolchain issues.
 
+`-O0` through `-O3` select increasingly aggressive optimization for runtime speed. `-Os` is different in kind: rather than being a further point on that scale, it asks for the smallest SPIR-V rather than the fastest, which is what you want when the shader cache footprint or module size matters more than peak runtime performance. It runs the same passes as `spirv-opt -Os`.
+
+Individual SPIR-V optimizer passes can still be added on top of any of these levels with `-Xspirv-opt`.
+
 ### -fvk-{b|s|t|u}-shift <N> <space>
 
 For example '-fvk-b-shift <N> <space>' shifts by N the inferred binding

--- a/include/slang.h
+++ b/include/slang.h
@@ -938,6 +938,11 @@ typedef uint32_t SlangSizeT;
         SLANG_OPTIMIZATION_LEVEL_MAXIMAL = 3, /**< Include optimizations that may take a very long
                                                    time, or may involve severe space-vs-speed
                                                    tradeoffs */
+        SLANG_OPTIMIZATION_LEVEL_SIZE = 4,    /**< Optimize for the size of the generated code
+                                                   rather than for its runtime speed. Unlike the
+                                                   levels above this is not a further point on the
+                                                   `none`..`maximal` scale; it selects a different
+                                                   optimization goal. */
     };
 
     enum SlangEmitSpirvMethod

--- a/source/compiler-core/slang-downstream-compiler.h
+++ b/source/compiler-core/slang-downstream-compiler.h
@@ -176,13 +176,23 @@ struct DownstreamCompileOptions
         };
     };
 
+    /// The optimization goal to ask a downstream compiler for.
+    ///
+    /// The values deliberately mirror the public `SlangOptimizationLevel` numbering, because
+    /// `SLANGGlslangCompiler::compile` (slang-glslang-compiler.cpp) passes the level across the
+    /// `slang-glslang` shared-library boundary as a plain `unsigned` cast from this enum, and
+    /// `glslang_optimizeSPIRV` switches on it as a `SlangOptimizationLevel`. Keep the two in sync.
     enum class OptimizationLevel : uint8_t
     {
-        None,    ///< Don't optimize at all.
-        Default, ///< Default optimization level: balance code quality and compilation time.
-        High,    ///< Optimize aggressively.
-        Maximal, ///< Include optimizations that may take a very long time, or may involve severe
-                 ///< space-vs-speed tradeoffs
+        None = SLANG_OPTIMIZATION_LEVEL_NONE,       ///< Don't optimize at all.
+        Default = SLANG_OPTIMIZATION_LEVEL_DEFAULT, ///< Default optimization level: balance code
+                                                    ///< quality and compilation time.
+        High = SLANG_OPTIMIZATION_LEVEL_HIGH,       ///< Optimize aggressively.
+        Maximal = SLANG_OPTIMIZATION_LEVEL_MAXIMAL, ///< Include optimizations that may take a very
+                                                    ///< long time, or may involve severe
+                                                    ///< space-vs-speed tradeoffs
+        Size = SLANG_OPTIMIZATION_LEVEL_SIZE, ///< Optimize for size of the generated code rather
+                                              ///< than for its runtime speed.
     };
 
     enum class DebugInfoType : uint8_t

--- a/source/compiler-core/slang-dxc-compiler.cpp
+++ b/source/compiler-core/slang-dxc-compiler.cpp
@@ -605,6 +605,13 @@ SlangResult DXCDownstreamCompiler::compile(const CompileOptions& inOptions, IArt
     case OptimizationLevel::Maximal:
         args.add(L"-O3");
         break;
+    case OptimizationLevel::Size:
+        // DXC has no optimize-for-size mode, so the best it can do for this level is the
+        // moderate `-O1`; the higher levels unroll and inline more aggressively, which is what a
+        // caller asking for small output is trying to avoid. A cross-target build passing `-Os`
+        // should still compile here rather than be rejected for a target that cannot honor it.
+        args.add(L"-O1");
+        break;
     }
 
     switch (options.debugInfoType)

--- a/source/compiler-core/slang-fxc-compiler.cpp
+++ b/source/compiler-core/slang-fxc-compiler.cpp
@@ -293,6 +293,11 @@ SlangResult FXCDownstreamCompiler::compile(const CompileOptions& inOptions, IArt
     case OptimizationLevel::Maximal:
         flags |= D3DCOMPILE_OPTIMIZATION_LEVEL3;
         break;
+    case OptimizationLevel::Size:
+        // FXC has no optimize-for-size mode; see the same case in slang-dxc-compiler.cpp for why
+        // this maps to the moderate level rather than being rejected.
+        flags |= D3DCOMPILE_OPTIMIZATION_LEVEL1;
+        break;
     }
 
     switch (options.debugInfoType)

--- a/source/compiler-core/slang-gcc-compiler-util.cpp
+++ b/source/compiler-core/slang-gcc-compiler-util.cpp
@@ -1022,7 +1022,12 @@ static SlangResult _parseGCCFamilyLine(
         }
     case OptimizationLevel::Default:
         {
-            cmdLine.addArg("-Os");
+            // `Default` asks for a balance of code quality and compilation time, which is what
+            // gcc/clang `-O1` provides. This used to pass `-Os`, but `-Os` is gcc/clang's
+            // optimize-for-size mode and now belongs to `OptimizationLevel::Size` below; leaving
+            // it here would make two distinct Slang levels produce the same flag and would keep
+            // the default trading speed for size without being asked to.
+            cmdLine.addArg("-O1");
             break;
         }
     case OptimizationLevel::High:
@@ -1033,6 +1038,11 @@ static SlangResult _parseGCCFamilyLine(
     case OptimizationLevel::Maximal:
         {
             cmdLine.addArg("-O3");
+            break;
+        }
+    case OptimizationLevel::Size:
+        {
+            cmdLine.addArg("-Os");
             break;
         }
     default:

--- a/source/compiler-core/slang-visual-studio-compiler-util.cpp
+++ b/source/compiler-core/slang-visual-studio-compiler-util.cpp
@@ -202,6 +202,12 @@ static void _addFile(
             cmdLine.addArg("/Ox");
             break;
         }
+    case OptimizationLevel::Size:
+        {
+            // `/O1` is MSVC's "maximum optimizations, favor size".
+            cmdLine.addArg("/O1");
+            break;
+        }
     default:
         break;
     }

--- a/source/core/slang-type-text-util.cpp
+++ b/source/core/slang-type-text-util.cpp
@@ -206,6 +206,10 @@ static const NamesDescriptionValue s_optimizationLevels[] = {
      "3,maximal",
      "Enable further optimizations, which might have a significant impact on compile time, or "
      "involve unwanted tradeoffs in terms of code size."},
+    {SLANG_OPTIMIZATION_LEVEL_SIZE,
+     "s,size",
+     "Optimize for the size of the generated code rather than for its runtime speed. This is not "
+     "a further point on the 0..3 scale, it selects a different optimization goal."},
 };
 
 static const NamesDescriptionValue s_debugLevels[] = {
@@ -289,6 +293,11 @@ static const NamesDescriptionValue s_fileSystemTypes[] = {
 /* static */ ConstArrayView<NamesDescriptionValue> TypeTextUtil::getOptimizationLevelInfos()
 {
     return makeConstArrayView(s_optimizationLevels);
+}
+
+/* static */ UnownedStringSlice TypeTextUtil::getOptimizationLevelName(SlangOptimizationLevel level)
+{
+    return NameValueUtil::findName(getOptimizationLevelInfos(), level, toSlice("unknown"));
 }
 
 /* static */ ConstArrayView<NamesDescriptionValue> TypeTextUtil::getDebugLevelInfos()

--- a/source/core/slang-type-text-util.h
+++ b/source/core/slang-type-text-util.h
@@ -59,6 +59,11 @@ struct TypeTextUtil
     static ConstArrayView<NamesDescriptionValue> getLineDirectiveInfos();
     /// Get the optimization level info
     static ConstArrayView<NamesDescriptionValue> getOptimizationLevelInfos();
+    /// Get the canonical `-O` suffix for an optimization level, such as "0" for
+    /// `SLANG_OPTIMIZATION_LEVEL_NONE` or "s" for `SLANG_OPTIMIZATION_LEVEL_SIZE`. Returns the
+    /// first (canonical) name from `getOptimizationLevelInfos`, so appending `-O` to it produces
+    /// an option that parses back to the same level.
+    static UnownedStringSlice getOptimizationLevelName(SlangOptimizationLevel level);
     /// Get the file system type infos
     static ConstArrayView<NamesDescriptionValue> getFileSystemTypeInfos();
 

--- a/source/slang-glslang/slang-glslang.cpp
+++ b/source/slang-glslang/slang-glslang.cpp
@@ -264,7 +264,6 @@ extern "C"
 // Apply the SPIRV-Tools optimizer to generated SPIR-V: the passes of the requested optimization
 // level preset, plus any passthrough passes from `request.spirvOptimizationFlags` (`-Xspirv-opt`)
 // registered on top. Returns SLANG_FAIL if a passthrough flag is invalid.
-// TODO: add flag for optimizing SPIR-V size as well
 static int glslang_optimizeSPIRV(
     spv_target_env targetEnv,
     const glslang_CompileRequest_1_3& request,
@@ -517,6 +516,22 @@ static int glslang_optimizeSPIRV(
             optimizer.RegisterPass(spvtools::CreateCompactIdsPass());
             compactPassRun = true;
 
+            break;
+        }
+    case SLANG_OPTIMIZATION_LEVEL_SIZE:
+        {
+            // Use the same passes as `spirv-opt -Os`.
+            //
+            // Unlike the levels above, this preset is delegated to SPIRV-Tools instead of being
+            // spelled out here. `-Os` is a preset that upstream maintains and validates, and its
+            // goal -- smallest output -- is exactly what this level asks for, so re-deriving a
+            // local pass list would only risk drifting from the tool that defines what `-Os`
+            // means. Users who want to depart from it can still add or replace passes with
+            // `-Xspirv-opt`, which is registered on top of this preset below.
+            //
+            // Note this preset does not include a CompactIdsPass, so `compactPassRun` stays
+            // false and the id-bound fallback after `optimizer.Run` still applies.
+            optimizer.RegisterSizePasses();
             break;
         }
     }

--- a/source/slang-llvm/slang-llvm-builder.cpp
+++ b/source/slang-llvm/slang-llvm-builder.cpp
@@ -493,6 +493,12 @@ LLVMBuilder::LLVMBuilder(LLVMBuilderOptions options, IArtifact** outErrorArtifac
     case SLANG_OPTIMIZATION_LEVEL_MAXIMAL:
         optLevel = llvm::CodeGenOptLevel::Aggressive;
         break;
+    case SLANG_OPTIMIZATION_LEVEL_SIZE:
+        // Optimizing for size is expressed in the pass pipeline (see the `llvm::OptimizationLevel`
+        // switch below), not in the codegen level; clang likewise runs `-Os` at the default
+        // codegen level.
+        optLevel = llvm::CodeGenOptLevel::Default;
+        break;
     }
 
     targetMachine = target->createTargetMachine(
@@ -689,6 +695,9 @@ void LLVMBuilder::optimize()
         break;
     case SLANG_OPTIMIZATION_LEVEL_MAXIMAL:
         llvmLevel = llvm::OptimizationLevel::O3;
+        break;
+    case SLANG_OPTIMIZATION_LEVEL_SIZE:
+        llvmLevel = llvm::OptimizationLevel::Os;
         break;
     }
 

--- a/source/slang-llvm/slang-llvm.cpp
+++ b/source/slang-llvm/slang-llvm.cpp
@@ -474,6 +474,10 @@ static int _getOptimizationLevel(DownstreamCompileOptions::OptimizationLevel lev
         return 2;
     case OptimizationLevel::Maximal:
         return 3;
+    case OptimizationLevel::Size:
+        // clang runs `-Os` at optimization level 2 with `OptimizeSize` set; the caller sets
+        // `OptimizeSize` alongside this (see where `opts.OptimizationLevel` is assigned).
+        return 2;
     }
 }
 
@@ -752,6 +756,11 @@ SlangResult LLVMDownstreamCompiler::compile(
 
         // Set to -O optimization level
         opts.OptimizationLevel = _getOptimizationLevel(options.optimizationLevel);
+
+        // `-Os` is level 2 plus the size preference, which clang carries in a separate field.
+        opts.OptimizeSize =
+            (options.optimizationLevel == DownstreamCompileOptions::OptimizationLevel::Size) ? 1
+                                                                                             : 0;
 
         // Copy over the targets CodeModel
         opts.CodeModel = invocation.getTargetOpts().CodeModel;

--- a/source/slang/slang-code-gen.cpp
+++ b/source/slang/slang-code-gen.cpp
@@ -822,6 +822,9 @@ SlangResult CodeGenContext::emitWithDownstreamForEntryPoints(ComPtr<IArtifact>& 
         case OptimizationLevel::Maximal:
             options.optimizationLevel = DownstreamCompileOptions::OptimizationLevel::Maximal;
             break;
+        case OptimizationLevel::Size:
+            options.optimizationLevel = DownstreamCompileOptions::OptimizationLevel::Size;
+            break;
         default:
             SLANG_ASSERT(!"Unhandled optimization level");
             break;

--- a/source/slang/slang-compiler-options.cpp
+++ b/source/slang/slang-compiler-options.cpp
@@ -166,9 +166,14 @@ void CompilerOptionSet::writeCommandLineArgs(Session* globalSession, StringBuild
             }
             break;
         case CompilerOptionName::Optimization:
+            // Write the level's canonical name rather than its raw integer, so that levels whose
+            // spelling is not their number (`-Os` for `SLANG_OPTIMIZATION_LEVEL_SIZE`) round-trip
+            // back through the `-O` parser. The numeric levels are named "0".."3", so their
+            // output is unchanged.
             for (auto v : option.value)
             {
-                sb << " -O" << v.intValue;
+                sb << " -O"
+                   << TypeTextUtil::getOptimizationLevelName(SlangOptimizationLevel(v.intValue));
             }
             break;
         case CompilerOptionName::DownstreamArgs:

--- a/source/slang/slang-compiler.h
+++ b/source/slang/slang-compiler.h
@@ -134,6 +134,7 @@ enum class OptimizationLevel : SlangOptimizationLevelIntegral
     Default = SLANG_OPTIMIZATION_LEVEL_DEFAULT,
     High = SLANG_OPTIMIZATION_LEVEL_HIGH,
     Maximal = SLANG_OPTIMIZATION_LEVEL_MAXIMAL,
+    Size = SLANG_OPTIMIZATION_LEVEL_SIZE,
 };
 
 struct CodeGenContext;

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -3465,6 +3465,9 @@ static SlangResult createArtifactFromIR(
             downstreamOptions.optimizationLevel =
                 DownstreamCompileOptions::OptimizationLevel::Maximal;
             break;
+        case OptimizationLevel::Size:
+            downstreamOptions.optimizationLevel = DownstreamCompileOptions::OptimizationLevel::Size;
+            break;
         default:
             SLANG_ASSERT(!"Unhandled optimization level");
             break;

--- a/source/slang/slang-repro.cpp
+++ b/source/slang/slang-repro.cpp
@@ -1519,6 +1519,9 @@ static SlangResult _calcCommandLine(
         case SLANG_OPTIMIZATION_LEVEL_MAXIMAL:
             cmd.addArg("-O3");
             break;
+        case SLANG_OPTIMIZATION_LEVEL_SIZE:
+            cmd.addArg("-Os");
+            break;
         default:
             break;
         }

--- a/tests/diagnostics/command-line/unknown-optimization-level.slang
+++ b/tests/diagnostics/command-line/unknown-optimization-level.slang
@@ -4,4 +4,4 @@
 // report the canonical `-O` rather than the full token `-Obogus`.
 
 //DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):-Obogus
-//CHECK: unknown value for option '-O'. Valid values are '0, none, 1, default, 2, high, 3, maximal'
+//CHECK: unknown value for option '-O'. Valid values are '0, none, 1, default, 2, high, 3, maximal, s, size'

--- a/tests/spirv/spirv-optimization-size.slang
+++ b/tests/spirv/spirv-optimization-size.slang
@@ -1,0 +1,101 @@
+// Test the `-Os` optimization level, which asks the SPIR-V optimizer for the smallest output
+// rather than the fastest, by running the same passes as `spirv-opt -Os`. See
+// https://github.com/shader-slang/slang/issues/12331
+//
+// `-Os` is not a further point on the `-O0`..`-O3` speed scale, it selects a different
+// optimization goal, so it gets its own arm in `glslang_optimizeSPIRV` (slang-glslang.cpp)
+// rather than being folded into one of the existing levels. Two things need testing here: that
+// the new spellings reach that arm at all, and that the arm registers a real preset instead of
+// falling through to the "no preset" or default behavior.
+//
+// This shader gives both an inter-procedural and an intra-procedural handle on that. `helper` is
+// a separate function, so the preset's inlining and dead-function elimination are observable as
+// the disappearance of `OpFunctionCall` and of `helper`'s own `OpFunction`. The `if`/`else` is a
+// separate handle: the size preset's branch-elimination and CFG-cleanup passes collapse it, so
+// the `OpBranchConditional` disappears and only the `OpSelect` that Slang already emitted for the
+// value remains.
+//
+// `-g2` is deliberately NOT used: it would embed this source file (comments included) as an
+// OpString, and FileCheck would then match the mnemonics in these comments instead of the real
+// instructions.
+
+// The short and long spellings of the level must both select it. `-Osize` is checked separately
+// rather than assumed, because the spellings come from a comma-separated name list
+// (`s_optimizationLevels` in slang-type-text-util.cpp) where only the first entry is canonical.
+//TEST:SIMPLE(filecheck=SIZE): -target spirv-asm -entry computeMain -stage compute -Os
+//TEST:SIMPLE(filecheck=SIZE): -target spirv-asm -entry computeMain -stage compute -Osize
+
+// `-O0` and `-O1` are the contrast cases that make the SIZE checks meaningful. `-O0` registers no
+// preset at all, and `-O1`'s preset does inline but does not include the branch-elimination and
+// CFG-cleanup passes that the size preset runs -- so at both of these the `OpBranchConditional`
+// survives. If `-Os` ever regressed into either of those arms, the SIZE checks below would fail.
+//TEST:SIMPLE(filecheck=O0): -target spirv-asm -entry computeMain -stage compute -O0
+//TEST:SIMPLE(filecheck=O1): -target spirv-asm -entry computeMain -stage compute -O1
+
+// The level also has to survive being written back out as a command line. `CompilerOptionSet::
+// writeCommandLineArgs` records the options into the SPIR-V debug information, and it used to
+// write the level as its raw integer -- which for this level would produce `-O4`, a spelling the
+// `-O` parser rejects. This case is the only place that serialization is observable from a test.
+//
+// This is the one case that uses `-g2`, which embeds this source file (comments included) as an
+// OpString. That is safe here because the check below anchors on the OpString that *starts* with
+// the recorded command line, which no embedded source line can do.
+//TEST:SIMPLE(filecheck=CMDLINE): -target spirv-asm -entry computeMain -stage compute -Os -g2
+
+// A level spelling that does not exist is rejected, and the error lists the valid spellings --
+// including the new `s` and `size`. This is what proves the name table drives the parser, rather
+// than `-Os` being special-cased somewhere in the `-O` parsing.
+//TEST:SIMPLE(filecheck=BADLEVEL): -target spirv-asm -entry computeMain -stage compute -Oz
+
+RWStructuredBuffer<float> outputBuffer;
+
+float helper(float x)
+{
+    return x * 2.0f;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    float v;
+    if (tid.x > 4)
+        v = 1.0f;
+    else
+        v = 2.0f;
+
+    outputBuffer[tid.x] = helper(v);
+}
+
+// Under `-Os` the preset inlines `helper` and eliminates it as dead (so neither the call nor the
+// function definition remains), and collapses the conditional (so no `OpBranchConditional`).
+// Anchoring on `OpEntryPoint` first makes the exclusions scan the rest of the module: the SPIR-V
+// logical layout guarantees `OpEntryPoint` precedes the debug, type and function-body sections,
+// so this is a layout guarantee rather than incidental emitter ordering.
+// SIZE: {{^}}OpEntryPoint
+// SIZE-NOT: {{^}}%helper = OpFunction
+// SIZE-NOT: OpFunctionCall
+// SIZE-NOT: {{^}}{{.*}}OpBranchConditional
+
+// At `-O0` no preset runs: the branch survives and so does the call. The checks follow the order
+// the instructions appear in the function body (the conditional comes before the call that
+// consumes its result), because FileCheck matches positive directives in sequence.
+// O0: {{^}}OpEntryPoint
+// O0: OpBranchConditional
+// O0: OpFunctionCall
+
+// At `-O1` the preset inlines the call, but its pass list stops short of the branch elimination
+// and CFG cleanup the size preset runs, so the conditional branch is still there. This is the
+// check that distinguishes `-Os` from the default preset.
+// O1: {{^}}OpEntryPoint
+// O1-NOT: OpFunctionCall
+// O1: OpBranchConditional
+
+// The recorded command line spells the level `-Os`, not `-O4`. The `-I` argument in between
+// carries an absolute path, so it is skipped with a wildcard.
+// CMDLINE: OpString "-target spirv{{.*}} -Os
+
+// An unknown `-O` value is a hard error listing every valid spelling, so a regression that
+// dropped `s`/`size` from the table would change this line.
+// BADLEVEL: error{{.*}}unknown value for option '-O'
+// BADLEVEL-SAME: 3, maximal, s, size


### PR DESCRIPTION
Fixes #12331

## Motivation

Slang's `-O` levels are all points on one scale: how much runtime speed to buy, and how much
compile time to spend buying it. `-O0` does nothing, `-O1` runs a small preset, and `-O2`/`-O3`
run a large one that is described in the source as "roughly equivalent to
`RegisterPerformancePasses`".

But a real and separate group of users does not want speed. They want the compiled shader to be
*small*, because what they are paying for is shader cache footprint or distributed module size.
Today the only way to ask for that is to know that SPIRV-Tools has a size preset and to reach past
Slang for it:

```
slangc -target spirv -O0 -Xspirv-opt -Os shader.slang
```

That works — `-Xspirv-opt` forwards straight into `Optimizer::RegisterPassesFromFlags`, which
accepts `-Os` — but it requires the user to know a SPIRV-Tools implementation detail, it is
SPIR-V-only, and it is not discoverable from `slangc -h`. The source has carried a `TODO: add
flag for optimizing SPIR-V size as well` on `glslang_optimizeSPIRV` for exactly this.

Measured on this branch (Release build, `slangc`, SPIR-V output size in bytes):

| shader | `-O0` | `-O1` | `-O2` | `-O3` | **`-Os`** |
|---|---|---|---|---|---|
| `tests/cooperative-matrix/flash-attention.slang` | 17052 | 16632 | 13928 | 13928 | **13792** |
| `tests/metal/texture.slang` | 251200 | 219968 | 201252 | 201252 | **201252** |

On the first shader `-Os` beats `-O3` outright; on the second it matches `-O3`. `-Os` also
produces byte-identical output to `-O0 -Xspirv-opt -Os`, confirming it is the same preset, now
reachable by name.

## Proposed solution

Add `SLANG_OPTIMIZATION_LEVEL_SIZE`, spelled `-Os` (or `-Osize`) on the command line, as a fifth
optimization level.

The level is deliberately *not* modelled as "one louder than `-O3`". It is a different
optimization goal, and the public header, the help text and the code comments all say so. It is
appended as the value `4` only because the existing enum is a plain ordinal and the append-only
ABI rule for `include/` requires new enumerators to go at the end; nothing compares levels
relationally, so no ordering assumption is broken. (Every switch on the level in the tree is an
exact-match `switch`; there are no `<`/`>` comparisons on an optimization level anywhere in
`source/` or `tools/`.)

For SPIR-V the level delegates to SPIRV-Tools' own `Optimizer::RegisterSizePasses()` rather than
spelling out a local pass list. That is the deliberate choice: `-Os` is a preset that upstream
maintains and validates, its goal is exactly what this level asks for, and a hand-copied list
would only drift. Users who want to depart from it can still add passes with `-Xspirv-opt`, which
is registered on top of the preset.

For the other backends the level is mapped to each toolchain's nearest equivalent — a real one
where the toolchain has it (`-Os` for gcc/clang, `/O1` for MSVC, `llvm::OptimizationLevel::Os`
for the LLVM JIT), and the moderate level where it does not (DXC, FXC). A cross-target build that
passes `-Os` should compile everywhere rather than be rejected by whichever target cannot honor
the request.

## Change summary

| File | What changed |
|---|---|
| `include/slang.h` | Append `SLANG_OPTIMIZATION_LEVEL_SIZE = 4` to `SlangOptimizationLevel`. |
| `source/slang/slang-compiler.h` | Mirror it as `OptimizationLevel::Size`. |
| `source/compiler-core/slang-downstream-compiler.h` | Add `OptimizationLevel::Size`; pin every enumerator to its `SLANG_OPTIMIZATION_LEVEL_*` value and document why the numbering must match. |
| `source/core/slang-type-text-util.{h,cpp}` | Add the `s,size` spellings to `s_optimizationLevels`; add `getOptimizationLevelName`. |
| `source/slang/slang-compiler-options.cpp` | `writeCommandLineArgs` writes the level's canonical name, not its raw integer. |
| `source/slang/slang-code-gen.cpp`, `slang-emit.cpp` | Map `OptimizationLevel::Size` to the downstream enum. |
| `source/slang-glslang/slang-glslang.cpp` | New `SLANG_OPTIMIZATION_LEVEL_SIZE` arm calling `RegisterSizePasses()`; drop the now-done TODO. |
| `source/compiler-core/slang-gcc-compiler-util.cpp` | `Size` → `-Os`; `Default` moves off `-Os` to `-O1`. |
| `source/compiler-core/slang-visual-studio-compiler-util.cpp` | `Size` → `/O1`. |
| `source/compiler-core/slang-dxc-compiler.cpp`, `slang-fxc-compiler.cpp` | `Size` → the moderate level (neither has a size mode). |
| `source/slang-llvm/slang-llvm.cpp`, `slang-llvm-builder.cpp` | `Size` → clang level 2 + `OptimizeSize`, `CodeGenOptLevel::Default`, `llvm::OptimizationLevel::Os`. |
| `source/slang/slang-repro.cpp` | Reconstruct `-Os` when rebuilding a command line from a repro. |
| `tests/spirv/spirv-optimization-size.slang` | New regression test (6 cases). |
| `tests/diagnostics/command-line/unknown-optimization-level.slang` | Expected valid-value list now includes `s, size`. |
| `docs/command-line-slangc-reference.md` | Regenerated. |
| `docs/user-guide/a2-01-spirv-target-specific.md` | Document `-Os` under `-O<optimization-level>`. |

## Concepts and vocabulary

- **Preset** — the fixed list of SPIRV-Tools passes that `glslang_optimizeSPIRV` registers for a
  given `-O` level. `-O0` has no preset; `-O1` has a 14-pass one; `-O2`/`-O3` share a 46-pass one.
- **`RegisterSizePasses`** — SPIRV-Tools' own size preset, what `spirv-opt -Os` runs.
- **`-Xspirv-opt`** — the passthrough added in #12206: individual pass flags forwarded to the
  SPIRV-Tools optimizer and registered *on top of* the preset, not instead of it.
- **`NamesDescriptionValue` / name table** — the `value → "name1,name2" → description` rows that
  drive option parsing, `-help` output and the "valid values are ..." error text from one place.
  The first name in the list is the canonical one.

## Process report

### The public enum, and why `= 4` is safe

`include/` is ABI-frozen: an enumerator inserted in the middle would shift every following value
and silently break callers compiled against an older header. `SlangOptimizationLevel` has no
count/sentinel member, so appending `SLANG_OPTIMIZATION_LEVEL_SIZE = 4` with an explicit value is
the append-only-safe move.

The uncomfortable part is that this puts a non-ordinal value at the top of an ordinal scale. I
checked whether anything actually depends on the ordering: grepping `source/` and `tools/` for
relational comparisons against an optimization level returns nothing — every consumer is an
exact-match `switch` or an `== None` / `!= None` test (for example
`slang-emit.cpp:3388`). So the appended value cannot be misread as "more than maximal" by any
existing code, and the header comment states plainly that it is a different goal rather than a
further point on the scale.

### Pinning `DownstreamCompileOptions::OptimizationLevel` to the public numbering

`SLANGGlslangCompiler::compile` sends the level across the `slang-glslang` shared-library boundary
like this (`slang-glslang-compiler.cpp:308`):

```cpp
request.optimizationLevel = (unsigned)options.optimizationLevel;
```

and on the other side `glslang_optimizeSPIRV` switches on that `unsigned` using
`SLANG_OPTIMIZATION_LEVEL_*` constants. In other words the two enums have to agree numerically,
and until now they agreed only by accident — `DownstreamCompileOptions::OptimizationLevel` used
implicit `0,1,2,3` and happened to line up.

Adding a fifth value to both would have preserved that accident, but silently. Instead each
enumerator is now written as `= SLANG_OPTIMIZATION_LEVEL_*`, with a comment naming the cast and
the switch that depend on it. This is a one-source-of-truth fix, not a new mechanism: the values
are unchanged, they are just no longer implicit.

### The SPIR-V arm: delegate rather than re-derive

The new arm in `glslang_optimizeSPIRV` is one call:

```cpp
case SLANG_OPTIMIZATION_LEVEL_SIZE:
    optimizer.RegisterSizePasses();
    break;
```

Every other arm in that function spells its passes out by hand. The reason not to follow that
pattern is that the other arms are *tuned* lists — the `-O1` arm's comment records which passes
were combined and why, and it deliberately leaves two of them commented out. There is nothing to
tune here: the user asked for `-Os`, and `-Os` is defined by SPIRV-Tools. Copying the 32-pass
list into this file would create a second definition of "the size preset" that would silently
drift from upstream on the next `external/spirv-tools` bump, which is exactly the
one-source-of-truth problem. The equivalence is verified rather than assumed: `-Os` produces
byte-identical output to `-O0 -Xspirv-opt -Os`.

One detail the arm has to get right: the existing code tracks `compactPassRun`, because two of
the presets register a `CompactIdsPass` and the code after `optimizer.Run` only runs a fallback
compact-ids pass when none was registered and the module blew past the id bound.
`RegisterSizePasses` does *not* include `CompactIdsPass` (see
`external/spirv-tools/source/opt/optimizer.cpp:234-268`), so `compactPassRun` correctly stays
`false` and the fallback still applies. The comment on the arm records this so a future reader
does not have to re-derive it.

### Why `writeCommandLineArgs` had to change

`CompilerOptionSet::writeCommandLineArgs` serialized the level as its integer:

```cpp
sb << " -O" << v.intValue;
```

For levels 0..3 the integer *is* the spelling, so this was correct by coincidence. For the new
level it would emit `-O4`, and `-O4` is not a spelling the parser accepts — the `-O` parser looks
the suffix up in the name table (`slang-options.cpp:3598`), and `4` is not in it. So the option
set would serialize to a command line that cannot be parsed back.

This matters concretely, not just in theory: this function's output is embedded in the SPIR-V
debug information as the recorded compilation command line
(`getDebugInfoCommandLineArgumentForEntryPoint`, `slang-emit-spirv.cpp:4065`). Compiling with
`-Os -g2` before the fix would have recorded `-O4` there.

The fix routes through the name table's first (canonical) name instead of the integer. Levels
0..3 are named `"0".."3"`, so their output is byte-for-byte unchanged; the new level writes `-Os`.
The `CMDLINE` case in the new test asserts this, and it is the test that fails without this
change.

**New helper — `TypeTextUtil::getOptimizationLevelName`.** This is the one helper the change
adds, so it deserves the audit. It does not introduce a new mechanism: it is a three-line
`NameValueUtil::findName` wrapper, identical in shape to the `getDebugInfoFormatName` that already
sits ten lines away in the same file, and it reads from the existing name table rather than
building a parallel mapping. The alternative — adding `"4"` as an extra alias in the name table so
the integer form keeps parsing — was rejected because it would make `-O4` a supported public
spelling for "optimize for size", which is precisely the ordinal reading the whole design is
trying to avoid.

### The `-Os` collision in the GCC/Clang backend

This is the one behavior change in the PR that is not purely additive, so it needs the most
justification.

`slang-gcc-compiler-util.cpp` mapped `OptimizationLevel::Default` to gcc/clang `-Os`:

```cpp
case OptimizationLevel::Default:
    cmdLine.addArg("-Os");
    break;
```

But `-Os` is gcc/clang's optimize-for-size mode, and `Default` is documented as "balance code
quality and compilation time" — so the existing mapping was already making Slang's default trade
speed for size on CPU targets without anyone asking. That was invisible while Slang had no way to
express "optimize for size"; once `OptimizationLevel::Size` exists it stops being invisible,
because `Default` and `Size` would emit the identical flag and the new level would be a no-op for
every CPU target.

Leaving it alone was the smaller diff, and I considered it. I did not take it because it makes the
feature incoherent exactly where the feature is supposed to apply: the issue asks for an
optimization option for small size, and on CPU targets `-Os` would then mean nothing new.

So `Default` moves to `-O1` — gcc/clang's own balanced level, the direct translation of what
`Default` is documented to mean — and `Size` takes `-Os`. **This does change the flags Slang
passes to gcc/clang for a default-optimization CPU compile.** No test in the suite fails either
way (the full suite passes with the change), so I am flagging it explicitly rather than claiming
test coverage I do not have: this is a correctness-of-mapping argument, not a test-driven one, and
it is the change in this PR most worth a second opinion.

### Backends with no size mode

DXC and FXC have no optimize-for-size flag at all. The options were: reject `-Os` for those
targets, or map it to the nearest thing.

Rejecting was tempting on "fail loudly" grounds, but it is the wrong call here. `-Os` is a
whole-compile option, not a per-target one; a build that emits both SPIR-V and DXIL and asks for
small output should not fail because one of its targets cannot fully honor the request. So both
map to the moderate level (`-O1` / `D3DCOMPILE_OPTIMIZATION_LEVEL1`) — a defensible answer, since
the higher levels there unroll and inline more aggressively, which is the opposite of what the
caller asked for. The comment at each site says the toolchain has no size mode, so the mapping is
not mistaken for an exact translation.

MSVC does have one: `/O1` is documented as "maximum optimizations, favor size", so that is a real
translation rather than a fallback. LLVM likewise has `llvm::OptimizationLevel::Os`, and clang
models `-Os` as optimization level 2 plus a separate `OptimizeSize` flag, which is what the
`slang-llvm` path now sets. (Note that `source/slang-llvm/` is normally consumed as a prebuilt
binary and is only compiled under `SLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM`, so those two files
are not covered by the local build I ran.)

### Test design, and what it deliberately does not assert

`tests/spirv/spirv-optimization-size.slang` has six cases:

1. `-Os` runs a real preset — `helper` is inlined and eliminated, and the conditional is collapsed.
2. `-Osize` does the same, checked separately rather than assumed, because only the first name in
   a comma-separated name-table entry is canonical.
3. `-O0` contrast: no preset, so the call and the branch both survive.
4. `-O1` contrast: the default preset inlines the call but does not collapse the branch. This is
   the case that proves `-Os` reached its own arm rather than falling into `default:` (which is
   attached to the `DEFAULT` case in that switch, so a mis-wired level would silently behave like
   `-O1`).
5. `-Os -g2`: the recorded command line says `-Os`, not `-O4`.
6. `-Oz`: rejected, with the valid-value list now including `s, size` — this is what shows the
   name table drives the parser rather than `-Os` being special-cased in the `-O` parsing.

What the test does *not* do is fingerprint the exact upstream pass list — for instance by
constructing a shader that only `EliminateDeadMembers` or the size preset's unlimited-threshold
`ScalarReplacement` can simplify. That would tie the suite to SPIRV-Tools internals and break on
the next `external/spirv-tools` bump for reasons that have nothing to do with Slang. The
`-O0`/`-O1` contrasts test the thing Slang actually owns: that the level is wired to its own
preset.

Two mechanical notes. The `-g2` hazard is real — `-g2` embeds the source file, comments included,
as an `OpString`, so FileCheck can match mnemonics in the test's own comments. Only case 5 uses
`-g2`, and its check anchors on an `OpString` that *starts* with the recorded command line, which
no embedded source line can. And slang-test injects `-O0` into tests that do not specify a level;
`-Os` is recognized as a level automatically because `isSlangOptimizationArg`
(`slang-test-optimization-options.h`) validates the suffix against the same name table, so no
change was needed there.

### Things deliberately left alone

- **The dead `#else` arm at `slang-glslang.cpp:384-446`.** This is a `RegisterSizePasses`-derived
  pass list, dead because the preceding `#elif 1` wins the chain, carrying a recorded tuning log
  and a note that the passes "can cause serious problem on some drivers". It is prior art for this
  issue, and it was tempting to either revive or delete it now that a real size level exists.
  I did neither: reviving it would replace an upstream-maintained preset with a hand-tuned one
  that was rejected on driver-compatibility grounds, and deleting it is an unrelated cleanup that
  would bury this diff. Worth a follow-up to decide whether that driver concern still applies to
  current drivers.
- **`isSlangTestOptimizationArg`** still accepts only `-O0`..`-O3` for slang-test's own
  suite-level sweep. Its comment says that restriction is deliberate; a size level is not a point
  on the sweep.
- **`slang-gfx.h` / `slang-rhi.h`** both carry a `SlangOptimizationLevel` field that is passed
  straight through with no switch, so they need no change.

