### PR TITLE
Harden SLANG_ASSERT environment variable read against unbounded strcpy pattern

### DIFF
--- a/source/core/slang-signal.cpp
+++ b/source/core/slang-signal.cpp
@@ -77,11 +77,18 @@ static bool _readAssertEnvVar(char* buffer, size_t bufferSize)
     return getenv_s(&requiredSize, buffer, bufferSize, "SLANG_ASSERT") == 0 && requiredSize > 0;
 #else
     const char* value = getenv("SLANG_ASSERT");
-    if (!value || strlen(value) >= bufferSize)
+    if (!value)
     {
         return false;
     }
-    strcpy(buffer, value);
+    // Copy with the same length that was bounds-checked, so the check and the copy cannot drift
+    // apart the way a `strlen` guard followed by an unbounded `strcpy` can.
+    const size_t length = strlen(value);
+    if (length >= bufferSize)
+    {
+        return false;
+    }
+    memcpy(buffer, value, length + 1);
     return true;
 #endif
 }


### PR DESCRIPTION
## Motivation

A static analysis scan flagged `_readAssertEnvVar` in `source/core/slang-signal.cpp` for copying
the `SLANG_ASSERT` environment variable into a 64-byte stack buffer with `strcpy`. The code as
written is *not* vulnerable — there is a length guard immediately before the copy:

```cpp
const char* value = getenv("SLANG_ASSERT");
if (!value || strlen(value) >= bufferSize)
{
    return false;
}
strcpy(buffer, value);
```

When the value does not fit, the function returns early and never copies, so no overflow is
reachable. The scan's own verifier reached the same conclusion and rejected the finding.

What the flag does point at correctly is the *shape* of the code rather than a live bug. The bound
is established in one statement (`strlen(value) >= bufferSize`) and then relied upon implicitly by
a different statement (`strcpy`) that carries no bound of its own. Nothing in the copy expresses
which check makes it safe, so an edit to either half — relaxing the comparison, changing
`bufferSize`, adding an early path that skips the guard — silently turns a safe copy into a stack
overflow. This PR removes that coupling.

## Proposed solution

Compute the length once, use that same value for both the bounds check and the copy, and drop
`strcpy` in favor of `memcpy` with an explicit size:

```cpp
const size_t length = strlen(value);
if (length >= bufferSize)
{
    return false;
}
memcpy(buffer, value, length + 1);
```

Now the number that was validated is literally the number of bytes written (plus the terminator
that the validated bound leaves room for), so the check and the copy cannot drift apart. This is
the principled version of the scan's suggestion: it removes the unbounded sink instead of merely
adding a second, redundant bound around it.

I deliberately did **not** apply the scanner's literal recommendation of
`strncpy(buffer, value, bufferSize - 1); buffer[bufferSize - 1] = '\0';`. That would be a behavior
change, not just hardening. `strncpy` truncates rather than rejecting, so an over-long value would
become a valid-looking 63-character string instead of being reported as unset. The function's
documented contract — stated in the comment directly above it — is that an over-long value *is*
reported as unset, and `handleAssert` then compares the buffer against recognized mode names with
`_caseInsensitiveEquals`. A truncated value could compare equal to a recognized name that the user
never actually wrote, so truncation trades a non-existent overflow for a real
misinterpretation. Rejecting over-long input remains the correct behavior; only the copy mechanism
changes.

## Change summary

| File | Change |
| --- | --- |
| `source/core/slang-signal.cpp` | In `_readAssertEnvVar`, hoist `strlen(value)` into a local `length`, check `length >= bufferSize`, and replace `strcpy(buffer, value)` with `memcpy(buffer, value, length + 1)`. |

No new includes are needed; `<string.h>` was already included for the existing `strlen`/`strcpy`.

## Process report

**Why the change exists.** This is a hardening change with no behavioral difference for any
in-contract input, so there is no test that fails without it — I want to be explicit about that
rather than imply a bug was fixed. The justification is not a failing test but the removal of an
unbounded write primitive from a code path whose safety currently depends on a non-local
invariant. The project convention is to make the representation correct so consumers stay simple;
here the "representation" is the bound itself, and passing it explicitly to the copy is what makes
the invariant local and self-evident.

**Why this layer owns the fix.** The input shape in question is an arbitrary-length,
attacker-influenced C string from `getenv`. That shape is entirely valid — an environment variable
genuinely can hold any length, and there is no upstream producer inside Slang that could be fixed
to constrain it. `_readAssertEnvVar` is precisely the boundary that converts unbounded external
input into a bounded internal buffer, so bounds enforcement belongs here and nowhere else. This is
not a guard papering over a malformed value produced elsewhere in the compiler.

**Why the buffer stays a fixed-size stack array.** It would be tempting to sidestep the whole
question with `String` or `StringBuilder`. The comment above `_readAssertEnvVar` explains why that
is not an option: this function runs from `handleAssert`, and Slang's own containers assert
internally, so allocating one here would let an assert inside the container re-enter `handleAssert`
and recurse until the stack overflowed. The function is restricted to C library calls and stack
storage on purpose. Keeping `memcpy` respects that constraint, whereas switching to a Slang
container would reintroduce the re-entrancy hazard the comment warns about.

**Scope of the affected path.** The Windows/MSVC branch already uses `getenv_s`, which takes the
buffer size directly, and is unchanged. Only the POSIX branch is touched. The path executes solely
when `SLANG_ASSERT` is set and an assert fires, so there is no measurable cost consideration; the
change is about the code being obviously correct on inspection.
