### PR TITLE
Stop auto-requesting reviewers outside the owners allowlist

### DIFF
--- a/.github/scripts/pr-assign.test.js
+++ b/.github/scripts/pr-assign.test.js
@@ -40,10 +40,11 @@ test("commit-signal owner when no issue", () => {
 });
 
 test("maintainer fallback", () => {
-  const { assignee, autoRequestedReviewer, suggestedReviewer } =
+  const { assignee, autoRequestedReviewer, autoRequestedHasSignal, suggestedReviewer } =
     select([], ["dev1"]);
   assert.strictEqual(assignee, "maintainer");
   assert.strictEqual(autoRequestedReviewer, "maintainer");
+  assert.strictEqual(autoRequestedHasSignal, false); // absent from ranking
   assert.strictEqual(suggestedReviewer, "dev1");
 });
 
@@ -154,6 +155,20 @@ test("pickSuggestedReviewer with no auto-request takes top non-assignee collabor
   );
 });
 
+test("pickSuggestedReviewer skips a named bot from botAuthors", () => {
+  assert.strictEqual(
+    pickSuggestedReviewer({
+      committersBySignal: ["nv-slang-bot", "dev1", "owner1"],
+      collaborators: new Set(["nv-slang-bot", "dev1", "owner1"]),
+      author: "author",
+      assignee: "owner1",
+      autoRequestedReviewer: "owner1",
+      botAuthors: ["nv-slang-bot"],
+    }),
+    "dev1",
+  );
+});
+
 test("formatAssignmentComment always notes assignee; suggestion has no @", () => {
   assert.strictEqual(
     formatAssignmentComment({
@@ -161,6 +176,7 @@ test("formatAssignmentComment always notes assignee; suggestion has no @", () =>
       assignee: "jkwak-work",
       suggestedReviewer: null,
       autoRequestedReviewer: "jkwak-work",
+      autoRequestedHasSignal: true,
     }),
     "**PR board sync:** auto-assigned @jkwak-work as shepherd for this Bot PR.",
   );
@@ -169,6 +185,7 @@ test("formatAssignmentComment always notes assignee; suggestion has no @", () =>
     assignee: "alice",
     suggestedReviewer: "skallweitNV",
     autoRequestedReviewer: "alice",
+    autoRequestedHasSignal: true,
   });
   assert.match(
     withRequested,
@@ -185,9 +202,22 @@ test("formatAssignmentComment always notes assignee; suggestion has no @", () =>
     assignee: "author-owner",
     suggestedReviewer: "dev1",
     autoRequestedReviewer: null,
+    autoRequestedHasSignal: false,
   });
   assert.match(withoutRequested, /highest for dev1 among collaborators/);
   assert.doesNotMatch(withoutRequested, /@dev1/);
+
+  // Auto-requested maintainer with no measured signal: do not claim they have
+  // "lower" signal than the suggestion.
+  const noSignalBaseline = formatAssignmentComment({
+    source: "Community",
+    assignee: "maintainer",
+    suggestedReviewer: "dev1",
+    autoRequestedReviewer: "maintainer",
+    autoRequestedHasSignal: false,
+  });
+  assert.match(noSignalBaseline, /highest for dev1 among collaborators/);
+  assert.doesNotMatch(noSignalBaseline, /than for the auto-requested reviewer/);
 });
 
 (async () => {

--- a/.github/scripts/pr-assign.test.js
+++ b/.github/scripts/pr-assign.test.js
@@ -204,7 +204,10 @@ test("formatAssignmentComment always notes assignee; suggestion has no @", () =>
     autoRequestedReviewer: null,
     autoRequestedHasSignal: false,
   });
-  assert.match(withoutRequested, /highest for dev1 among collaborators/);
+  assert.match(
+    withoutRequested,
+    /highest for dev1 among collaborators other than the assignee/,
+  );
   assert.doesNotMatch(withoutRequested, /@dev1/);
 
   // Auto-requested maintainer with no measured signal: do not claim they have
@@ -216,7 +219,10 @@ test("formatAssignmentComment always notes assignee; suggestion has no @", () =>
     autoRequestedReviewer: "maintainer",
     autoRequestedHasSignal: false,
   });
-  assert.match(noSignalBaseline, /highest for dev1 among collaborators/);
+  assert.match(
+    noSignalBaseline,
+    /highest for dev1 among collaborators other than the assignee/,
+  );
   assert.doesNotMatch(noSignalBaseline, /than for the auto-requested reviewer/);
 });
 

--- a/.github/scripts/pr-assign.test.js
+++ b/.github/scripts/pr-assign.test.js
@@ -29,9 +29,9 @@ const tests = [];
 const test = (name, fn) => tests.push([name, fn]);
 
 test("issue assignee wins", () => {
-  const { assignee, reviewers } = select(["owner2"], ["owner1", "dev1"]);
+  const { assignee, autoRequestedReviewer } = select(["owner2"], ["owner1", "dev1"]);
   assert.strictEqual(assignee, "owner2");
-  assert.deepStrictEqual(reviewers, ["owner2"]);
+  assert.strictEqual(autoRequestedReviewer, "owner2");
 });
 
 test("commit-signal owner when no issue", () => {
@@ -40,45 +40,45 @@ test("commit-signal owner when no issue", () => {
 });
 
 test("maintainer fallback", () => {
-  const { assignee, reviewers, suggestedReviewer, requestedReviewer } =
+  const { assignee, autoRequestedReviewer, suggestedReviewer } =
     select([], ["dev1"]);
   assert.strictEqual(assignee, "maintainer");
-  assert.deepStrictEqual(reviewers, ["maintainer"]);
-  assert.strictEqual(requestedReviewer, "maintainer");
+  assert.strictEqual(autoRequestedReviewer, "maintainer");
   assert.strictEqual(suggestedReviewer, "dev1");
 });
 
 test("auto-request is shepherd only; higher-signal collaborator is suggested", () => {
-  const { assignee, reviewers, suggestedReviewer, requestedReviewer } = select(
+  const { assignee, autoRequestedReviewer, suggestedReviewer } = select(
     [], ["dev2", "owner1", "dev1"]);
   assert.strictEqual(assignee, "owner1");
-  assert.deepStrictEqual(reviewers, ["owner1"]);
-  assert.strictEqual(requestedReviewer, "owner1");
+  assert.strictEqual(autoRequestedReviewer, "owner1");
   assert.strictEqual(suggestedReviewer, "dev2");
 });
 
 test("may suggest another owner who outranks the auto-requested shepherd", () => {
-  const { assignee, reviewers, suggestedReviewer } = select(
+  const { assignee, autoRequestedReviewer, suggestedReviewer } = select(
     ["owner1"], ["owner2", "owner1", "dev1"]);
   assert.strictEqual(assignee, "owner1");
-  assert.deepStrictEqual(reviewers, ["owner1"]);
+  assert.strictEqual(autoRequestedReviewer, "owner1");
   assert.strictEqual(suggestedReviewer, "owner2");
 });
 
 test("no suggestion when auto-requested reviewer has top signal", () => {
-  const { reviewers, suggestedReviewer } = select([], ["owner1", "owner2", "dev1"]);
-  assert.deepStrictEqual(reviewers, ["owner1"]);
+  const { autoRequestedReviewer, suggestedReviewer } =
+    select([], ["owner1", "owner2", "dev1"]);
+  assert.strictEqual(autoRequestedReviewer, "owner1");
   assert.strictEqual(suggestedReviewer, null);
 });
 
 test("no collaborator above reviewer means only assignee", () => {
-  const { reviewers, suggestedReviewer } = select([], ["owner1", "owner2"]);
-  assert.deepStrictEqual(reviewers, ["owner1"]);
+  const { autoRequestedReviewer, suggestedReviewer } =
+    select([], ["owner1", "owner2"]);
+  assert.strictEqual(autoRequestedReviewer, "owner1");
   assert.strictEqual(suggestedReviewer, null);
 });
 
 test("author shepherd is not auto-requested; top collaborator is suggested", () => {
-  const { assignee, reviewers, suggestedReviewer, requestedReviewer } =
+  const { assignee, autoRequestedReviewer, suggestedReviewer } =
     selectAssigneeAndReviewers({
       issueAssignees: [],
       committersBySignal: ["dev1", "owner1"],
@@ -88,50 +88,66 @@ test("author shepherd is not auto-requested; top collaborator is suggested", () 
       maintainer: MAINT,
     });
   assert.strictEqual(assignee, "owner1");
-  assert.deepStrictEqual(reviewers, []);
-  assert.strictEqual(requestedReviewer, null);
+  assert.strictEqual(autoRequestedReviewer, null);
   assert.strictEqual(suggestedReviewer, "dev1");
 });
 
-test("real existing reviewer blocks adding but still suggests", () => {
-  const { assignee, reviewers, suggestedReviewer } = select([], ["dev2", "owner1"], {
-    existingReviewers: ["dave"], ignoredReviewers: new Set(["bmillsNV"]),
-  });
+test("ignored shepherd is not auto-requested; suggestion uses null baseline", () => {
+  const { assignee, autoRequestedReviewer, suggestedReviewer } = select(
+    [], ["dev2"], {
+      maintainer: "bmillsNV",
+      ignoredReviewers: new Set(["bmillsNV"]),
+    });
+  // No owners in ranking → maintainer fallback, but ignored → no auto-request.
+  assert.strictEqual(assignee, "bmillsNV");
+  assert.strictEqual(autoRequestedReviewer, null);
+  assert.strictEqual(suggestedReviewer, "dev2");
+});
+
+test("real existing reviewer clears auto-request but still may suggest", () => {
+  const { assignee, autoRequestedReviewer, suggestedReviewer } = select(
+    [], ["dev2", "owner1"], {
+      existingReviewers: ["dave"], ignoredReviewers: new Set(["bmillsNV"]),
+    });
   assert.strictEqual(assignee, "owner1");
-  assert.deepStrictEqual(reviewers, []);
+  assert.strictEqual(autoRequestedReviewer, null);
+  // Baseline is null, but assignee is excluded from suggestion → next is dev2.
   assert.strictEqual(suggestedReviewer, "dev2");
 });
 
 test("ignored and bot reviewers do not count as existing", () => {
-  const { assignee, reviewers, suggestedReviewer } = select([], ["dev2", "owner1"], {
-    existingReviewers: ["bmillsNV", "copilot[bot]"],
-    botAuthors: ["nv-slang-bot"], ignoredReviewers: new Set(["bmillsNV"]),
-  });
+  const { assignee, autoRequestedReviewer, suggestedReviewer } = select(
+    [], ["dev2", "owner1"], {
+      existingReviewers: ["bmillsNV", "copilot[bot]"],
+      botAuthors: ["nv-slang-bot"], ignoredReviewers: new Set(["bmillsNV"]),
+    });
   assert.strictEqual(assignee, "owner1");
-  assert.deepStrictEqual(reviewers, ["owner1"]);
+  assert.strictEqual(autoRequestedReviewer, "owner1");
   assert.strictEqual(suggestedReviewer, "dev2");
 });
 
-test("pickSuggestedReviewer skips non-collaborators and bots", () => {
+test("pickSuggestedReviewer skips non-collaborators, bots, and assignee", () => {
   assert.strictEqual(
     pickSuggestedReviewer({
       committersBySignal: ["outsider", "bot[bot]", "dev1", "owner1"],
       collaborators: COLLAB,
       author: "author",
-      requestedReviewer: "owner1",
+      assignee: "owner1",
+      autoRequestedReviewer: "owner1",
       botAuthors: [],
     }),
     "dev1",
   );
 });
 
-test("pickSuggestedReviewer with no requested reviewer takes top collaborator", () => {
+test("pickSuggestedReviewer with no auto-request takes top non-assignee collaborator", () => {
   assert.strictEqual(
     pickSuggestedReviewer({
-      committersBySignal: ["dev2", "owner1"],
+      committersBySignal: ["owner1", "dev2"],
       collaborators: COLLAB,
       author: "author",
-      requestedReviewer: null,
+      assignee: "owner1",
+      autoRequestedReviewer: null,
       botAuthors: [],
     }),
     "dev2",
@@ -144,7 +160,7 @@ test("formatAssignmentComment always notes assignee; suggestion has no @", () =>
       source: "Bot",
       assignee: "jkwak-work",
       suggestedReviewer: null,
-      requestedReviewer: "jkwak-work",
+      autoRequestedReviewer: "jkwak-work",
     }),
     "**PR board sync:** auto-assigned @jkwak-work as shepherd for this Bot PR.",
   );
@@ -152,20 +168,23 @@ test("formatAssignmentComment always notes assignee; suggestion has no @", () =>
     source: "Community",
     assignee: "alice",
     suggestedReviewer: "skallweitNV",
-    requestedReviewer: "alice",
+    autoRequestedReviewer: "alice",
   });
   assert.match(
     withRequested,
     /^\*\*PR board sync:\*\* auto-assigned @alice as shepherd for this Community PR\./,
   );
-  assert.match(withRequested, /higher for skallweitNV than for the auto-requested reviewer \(alice\)/);
+  assert.match(
+    withRequested,
+    /higher for skallweitNV than for the auto-requested reviewer \(alice\)/,
+  );
   assert.doesNotMatch(withRequested, /@skallweitNV/);
 
   const withoutRequested = formatAssignmentComment({
     source: "Bot",
     assignee: "author-owner",
     suggestedReviewer: "dev1",
-    requestedReviewer: null,
+    autoRequestedReviewer: null,
   });
   assert.match(withoutRequested, /highest for dev1 among collaborators/);
   assert.doesNotMatch(withoutRequested, /@dev1/);

--- a/.github/scripts/pr-assign.test.js
+++ b/.github/scripts/pr-assign.test.js
@@ -4,7 +4,11 @@
 "use strict";
 
 const assert = require("node:assert");
-const { selectAssigneeAndReviewers } = require("./extract-workflow-js.js").load({
+const {
+  selectAssigneeAndReviewers,
+  pickSuggestedReviewer,
+  formatAssignmentComment,
+} = require("./extract-workflow-js.js").load({
   workflow: ".github/workflows/pr-board-sync.yml",
   block: "assignment",
 });
@@ -36,46 +40,89 @@ test("commit-signal owner when no issue", () => {
 });
 
 test("maintainer fallback", () => {
-  const { assignee, reviewers } = select([], ["dev1"]);
+  const { assignee, reviewers, suggestedReviewer } = select([], ["dev1"]);
   assert.strictEqual(assignee, "maintainer");
-  assert.deepStrictEqual(reviewers, ["maintainer", "dev1"]);
+  assert.deepStrictEqual(reviewers, ["maintainer"]);
+  assert.strictEqual(suggestedReviewer, "dev1");
 });
 
-test("extra reviewer is top collaborator-not-owner", () => {
-  const { assignee, reviewers } = select([], ["dev2", "owner1", "dev1"]);
+test("auto-request is assignee only; non-owner is suggested not requested", () => {
+  const { assignee, reviewers, suggestedReviewer } = select(
+    [], ["dev2", "owner1", "dev1"]);
   assert.strictEqual(assignee, "owner1");
-  assert.deepStrictEqual(reviewers, ["owner1", "dev2"]);
+  assert.deepStrictEqual(reviewers, ["owner1"]);
+  assert.strictEqual(suggestedReviewer, "dev2");
+});
+
+test("no suggestion when assignee has top signal", () => {
+  const { reviewers, suggestedReviewer } = select([], ["owner1", "owner2", "dev1"]);
+  assert.deepStrictEqual(reviewers, ["owner1"]);
+  assert.strictEqual(suggestedReviewer, null);
 });
 
 test("no collaborator committer means only assignee", () => {
-  const { reviewers } = select([], ["owner1", "owner2"]);
+  const { reviewers, suggestedReviewer } = select([], ["owner1", "owner2"]);
   assert.deepStrictEqual(reviewers, ["owner1"]);
+  assert.strictEqual(suggestedReviewer, null);
 });
 
 test("author never requested as reviewer", () => {
-  const { assignee, reviewers } = selectAssigneeAndReviewers({
+  const { assignee, reviewers, suggestedReviewer } = selectAssigneeAndReviewers({
     issueAssignees: [], committersBySignal: ["dev1"], owners: OWNERS,
     collaborators: COLLAB, author: "maintainer", maintainer: "maintainer",
   });
   assert.strictEqual(assignee, "maintainer");
-  assert.deepStrictEqual(reviewers, ["dev1"]); // author(maintainer) excluded
+  assert.deepStrictEqual(reviewers, []); // author(maintainer) excluded from request
+  assert.strictEqual(suggestedReviewer, "dev1");
 });
 
-test("real existing reviewer blocks adding", () => {
-  const { assignee, reviewers } = select([], ["dev2", "owner1"], {
+test("real existing reviewer blocks adding but still suggests", () => {
+  const { assignee, reviewers, suggestedReviewer } = select([], ["dev2", "owner1"], {
     existingReviewers: ["dave"], ignoredReviewers: new Set(["bmillsNV"]),
   });
   assert.strictEqual(assignee, "owner1");
   assert.deepStrictEqual(reviewers, []);
+  assert.strictEqual(suggestedReviewer, "dev2");
 });
 
 test("ignored and bot reviewers do not count as existing", () => {
-  const { assignee, reviewers } = select([], ["dev2", "owner1"], {
+  const { assignee, reviewers, suggestedReviewer } = select([], ["dev2", "owner1"], {
     existingReviewers: ["bmillsNV", "copilot[bot]"],
     botAuthors: ["nv-slang-bot"], ignoredReviewers: new Set(["bmillsNV"]),
   });
   assert.strictEqual(assignee, "owner1");
-  assert.deepStrictEqual(reviewers, ["owner1", "dev2"]);
+  assert.deepStrictEqual(reviewers, ["owner1"]);
+  assert.strictEqual(suggestedReviewer, "dev2");
+});
+
+test("pickSuggestedReviewer skips non-collaborators and bots", () => {
+  assert.strictEqual(
+    pickSuggestedReviewer({
+      committersBySignal: ["outsider", "bot[bot]", "dev1", "owner1"],
+      collaborators: COLLAB,
+      author: "author",
+      assignee: "owner1",
+      botAuthors: [],
+    }),
+    "dev1",
+  );
+});
+
+test("formatAssignmentComment always notes assignee; suggestion has no @", () => {
+  assert.strictEqual(
+    formatAssignmentComment({
+      source: "Bot", assignee: "jkwak-work", suggestedReviewer: null,
+    }),
+    "**PR board sync:** auto-assigned @jkwak-work as shepherd for this Bot PR.",
+  );
+  const withSuggestion = formatAssignmentComment({
+    source: "Community",
+    assignee: "alice",
+    suggestedReviewer: "skallweitNV",
+  });
+  assert.match(withSuggestion, /^\*\*PR board sync:\*\* auto-assigned @alice as shepherd for this Community PR\./);
+  assert.match(withSuggestion, /higher for skallweitNV than/);
+  assert.doesNotMatch(withSuggestion, /@skallweitNV/);
 });
 
 (async () => {

--- a/.github/scripts/pr-assign.test.js
+++ b/.github/scripts/pr-assign.test.js
@@ -31,7 +31,7 @@ const test = (name, fn) => tests.push([name, fn]);
 test("issue assignee wins", () => {
   const { assignee, reviewers } = select(["owner2"], ["owner1", "dev1"]);
   assert.strictEqual(assignee, "owner2");
-  assert.ok(reviewers.includes("owner2"));
+  assert.deepStrictEqual(reviewers, ["owner2"]);
 });
 
 test("commit-signal owner when no issue", () => {
@@ -40,39 +40,56 @@ test("commit-signal owner when no issue", () => {
 });
 
 test("maintainer fallback", () => {
-  const { assignee, reviewers, suggestedReviewer } = select([], ["dev1"]);
+  const { assignee, reviewers, suggestedReviewer, requestedReviewer } =
+    select([], ["dev1"]);
   assert.strictEqual(assignee, "maintainer");
   assert.deepStrictEqual(reviewers, ["maintainer"]);
+  assert.strictEqual(requestedReviewer, "maintainer");
   assert.strictEqual(suggestedReviewer, "dev1");
 });
 
-test("auto-request is assignee only; non-owner is suggested not requested", () => {
-  const { assignee, reviewers, suggestedReviewer } = select(
+test("auto-request is shepherd only; higher-signal collaborator is suggested", () => {
+  const { assignee, reviewers, suggestedReviewer, requestedReviewer } = select(
     [], ["dev2", "owner1", "dev1"]);
   assert.strictEqual(assignee, "owner1");
   assert.deepStrictEqual(reviewers, ["owner1"]);
+  assert.strictEqual(requestedReviewer, "owner1");
   assert.strictEqual(suggestedReviewer, "dev2");
 });
 
-test("no suggestion when assignee has top signal", () => {
+test("may suggest another owner who outranks the auto-requested shepherd", () => {
+  const { assignee, reviewers, suggestedReviewer } = select(
+    ["owner1"], ["owner2", "owner1", "dev1"]);
+  assert.strictEqual(assignee, "owner1");
+  assert.deepStrictEqual(reviewers, ["owner1"]);
+  assert.strictEqual(suggestedReviewer, "owner2");
+});
+
+test("no suggestion when auto-requested reviewer has top signal", () => {
   const { reviewers, suggestedReviewer } = select([], ["owner1", "owner2", "dev1"]);
   assert.deepStrictEqual(reviewers, ["owner1"]);
   assert.strictEqual(suggestedReviewer, null);
 });
 
-test("no collaborator committer means only assignee", () => {
+test("no collaborator above reviewer means only assignee", () => {
   const { reviewers, suggestedReviewer } = select([], ["owner1", "owner2"]);
   assert.deepStrictEqual(reviewers, ["owner1"]);
   assert.strictEqual(suggestedReviewer, null);
 });
 
-test("author never requested as reviewer", () => {
-  const { assignee, reviewers, suggestedReviewer } = selectAssigneeAndReviewers({
-    issueAssignees: [], committersBySignal: ["dev1"], owners: OWNERS,
-    collaborators: COLLAB, author: "maintainer", maintainer: "maintainer",
-  });
-  assert.strictEqual(assignee, "maintainer");
-  assert.deepStrictEqual(reviewers, []); // author(maintainer) excluded from request
+test("author shepherd is not auto-requested; top collaborator is suggested", () => {
+  const { assignee, reviewers, suggestedReviewer, requestedReviewer } =
+    selectAssigneeAndReviewers({
+      issueAssignees: [],
+      committersBySignal: ["dev1", "owner1"],
+      owners: OWNERS,
+      collaborators: COLLAB,
+      author: "owner1",
+      maintainer: MAINT,
+    });
+  assert.strictEqual(assignee, "owner1");
+  assert.deepStrictEqual(reviewers, []);
+  assert.strictEqual(requestedReviewer, null);
   assert.strictEqual(suggestedReviewer, "dev1");
 });
 
@@ -101,28 +118,57 @@ test("pickSuggestedReviewer skips non-collaborators and bots", () => {
       committersBySignal: ["outsider", "bot[bot]", "dev1", "owner1"],
       collaborators: COLLAB,
       author: "author",
-      assignee: "owner1",
+      requestedReviewer: "owner1",
       botAuthors: [],
     }),
     "dev1",
   );
 });
 
+test("pickSuggestedReviewer with no requested reviewer takes top collaborator", () => {
+  assert.strictEqual(
+    pickSuggestedReviewer({
+      committersBySignal: ["dev2", "owner1"],
+      collaborators: COLLAB,
+      author: "author",
+      requestedReviewer: null,
+      botAuthors: [],
+    }),
+    "dev2",
+  );
+});
+
 test("formatAssignmentComment always notes assignee; suggestion has no @", () => {
   assert.strictEqual(
     formatAssignmentComment({
-      source: "Bot", assignee: "jkwak-work", suggestedReviewer: null,
+      source: "Bot",
+      assignee: "jkwak-work",
+      suggestedReviewer: null,
+      requestedReviewer: "jkwak-work",
     }),
     "**PR board sync:** auto-assigned @jkwak-work as shepherd for this Bot PR.",
   );
-  const withSuggestion = formatAssignmentComment({
+  const withRequested = formatAssignmentComment({
     source: "Community",
     assignee: "alice",
     suggestedReviewer: "skallweitNV",
+    requestedReviewer: "alice",
   });
-  assert.match(withSuggestion, /^\*\*PR board sync:\*\* auto-assigned @alice as shepherd for this Community PR\./);
-  assert.match(withSuggestion, /higher for skallweitNV than/);
-  assert.doesNotMatch(withSuggestion, /@skallweitNV/);
+  assert.match(
+    withRequested,
+    /^\*\*PR board sync:\*\* auto-assigned @alice as shepherd for this Community PR\./,
+  );
+  assert.match(withRequested, /higher for skallweitNV than for the auto-requested reviewer \(alice\)/);
+  assert.doesNotMatch(withRequested, /@skallweitNV/);
+
+  const withoutRequested = formatAssignmentComment({
+    source: "Bot",
+    assignee: "author-owner",
+    suggestedReviewer: "dev1",
+    requestedReviewer: null,
+  });
+  assert.match(withoutRequested, /highest for dev1 among collaborators/);
+  assert.doesNotMatch(withoutRequested, /@dev1/);
 });
 
 (async () => {

--- a/.github/workflows/pr-board-sync.md
+++ b/.github/workflows/pr-board-sync.md
@@ -106,23 +106,24 @@ In implementation terms:
 linked-issue sync when already assigned). Skips human drafts (except Bot PRs) and
 merge-queued PRs.
 
-| Source              | Assignee             | Reviewers                                                                 | Comment |
-| ------------------- | -------------------- | ------------------------------------------------------------------------- | ------- |
-| **Internal**        | PR author            | none                                                                      | none |
-| **Community / Bot** | see pick order below | assignee only (owners allowlist), unless a real reviewer is already requested | one-shot note naming the assignee; may suggest a higher-signal collaborator without `@` or auto-request |
+| Source              | Assignee             | Auto-requested reviewer                                      | Comment |
+| ------------------- | -------------------- | ------------------------------------------------------------ | ------- |
+| **Internal**        | PR author            | none                                                         | none |
+| **Community / Bot** | see pick order below | shepherd if they are not the PR author; otherwise none       | one-shot note naming the assignee; may suggest a higher-signal collaborator without `@` |
 
-**Pick order** (Community/Bot):
+**Pick order** (Community/Bot assignee / shepherd):
 
 1. Linked-issue assignee who is in the owners team.
 2. Top **committer-signal** owner from changed files.
 3. Maintainer team member (or `fallback_assignee`).
 
-Auto-requested reviewers are always drawn from the same owners allowlist that
-gates the assignee (`pr-owners` for Community, `bot-pr-owners` for Bot). A
-collaborator with stronger committer signal who is **not** on that list is
-named in the assignment comment as a suggested additional reviewer, but is
-never `requestReviewers`'d — so they are not notified unless someone follows
-up.
+The owners allowlist (`pr-owners` for Community, `bot-pr-owners` for Bot) gates
+who may be chosen as shepherd. Auto-request never goes beyond that shepherd, and
+never requests the PR author. A collaborator with stronger committer signal than
+the auto-requested reviewer (or the top collaborator when nobody was
+auto-requested) may be named in the assignment comment as a suggested
+additional reviewer, but is never `requestReviewers`'d — so they are not
+notified unless someone follows up.
 
 **Community PRs** also co-assign the external author (separate API call, best-effort).
 

--- a/.github/workflows/pr-board-sync.md
+++ b/.github/workflows/pr-board-sync.md
@@ -118,9 +118,10 @@ merge-queued PRs.
 3. Maintainer team member (or `fallback_assignee`).
 
 The owners allowlist (`pr-owners` for Community, `bot-pr-owners` for Bot) gates
-who may be chosen as shepherd. Auto-request never goes beyond that shepherd, and
-never requests the PR author. A collaborator with stronger committer signal than
-the auto-requested reviewer (or the top collaborator when nobody was
+who may be chosen as shepherd. Auto-request is that shepherd only when they are
+not the PR author, not on the ignored-reviewers list, and no real reviewer is
+already requested. A collaborator with stronger committer signal than the
+auto-requested reviewer (or the top other collaborator when nobody was
 auto-requested) may be named in the assignment comment as a suggested
 additional reviewer, but is never `requestReviewers`'d — so they are not
 notified unless someone follows up.

--- a/.github/workflows/pr-board-sync.md
+++ b/.github/workflows/pr-board-sync.md
@@ -106,16 +106,23 @@ In implementation terms:
 linked-issue sync when already assigned). Skips human drafts (except Bot PRs) and
 merge-queued PRs.
 
-| Source              | Assignee             | Reviewers                                                                          |
-| ------------------- | -------------------- | ---------------------------------------------------------------------------------- |
-| **Internal**        | PR author            | none                                                                               |
-| **Community / Bot** | see pick order below | assignee + top collaborator-not-owner, unless a real reviewer is already requested |
+| Source              | Assignee             | Reviewers                                                                 | Comment |
+| ------------------- | -------------------- | ------------------------------------------------------------------------- | ------- |
+| **Internal**        | PR author            | none                                                                      | none |
+| **Community / Bot** | see pick order below | assignee only (owners allowlist), unless a real reviewer is already requested | one-shot note naming the assignee; may suggest a higher-signal collaborator without `@` or auto-request |
 
 **Pick order** (Community/Bot):
 
 1. Linked-issue assignee who is in the owners team.
 2. Top **committer-signal** owner from changed files.
 3. Maintainer team member (or `fallback_assignee`).
+
+Auto-requested reviewers are always drawn from the same owners allowlist that
+gates the assignee (`pr-owners` for Community, `bot-pr-owners` for Bot). A
+collaborator with stronger committer signal who is **not** on that list is
+named in the assignment comment as a suggested additional reviewer, but is
+never `requestReviewers`'d — so they are not notified unless someone follows
+up.
 
 **Community PRs** also co-assign the external author (separate API call, best-effort).
 

--- a/.github/workflows/pr-board-sync.md
+++ b/.github/workflows/pr-board-sync.md
@@ -142,7 +142,10 @@ per-file LOC tiebreak runs only when the top two are close.
 
 The ranking/selection logic is inlined in `pr-board-sync.yml` (between
 `extract-js:assignment:begin/end` markers); Source classification helpers live
-in `extract-js:classify:begin/end`. Unit tests extract those blocks at run time:
+in `extract-js:classify:begin/end`. Unit tests extract those blocks at run time.
+Wiring outside the extract markers (`reconcileAssignment`,
+`postAssignmentComment`, and the `requestReviewers` call site) is not covered by
+those unit tests and is verified manually / after merge.
 
 ```bash
 node .github/scripts/pr-signal.test.js

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -913,9 +913,14 @@ jobs:
 
             // Among committersBySignal (highest first), pick the first collaborator
             // who is not the author / shepherd / auto-requested reviewer / bot and
-            // who outranks the auto-requested reviewer. When nobody was
-            // auto-requested, any such collaborator counts as higher-signal.
-            // Used only for a suggestion comment — never for requestReviewers.
+            // who outranks the auto-requested reviewer. committersBySignal must be
+            // sorted highest-signal-first; the loop stops at the auto-requested
+            // reviewer's index because later entries cannot strictly outrank them.
+            // When nobody was auto-requested, or the auto-requested login is absent
+            // from the ranking (no measured signal on these files — e.g. maintainer
+            // fallback), that baseline is treated as rank −∞ and any eligible
+            // collaborator counts as higher-signal. Used only for a suggestion
+            // comment — never for requestReviewers.
             function pickSuggestedReviewer({
               committersBySignal = [],
               collaborators,
@@ -952,15 +957,18 @@ jobs:
             // GitHub's assign event) but never @-mentions the suggested
             // reviewer, so the suggestion does not ping them.
             // autoRequestedReviewer must be the login we actually intend to
-            // requestReviewers (or null) — not a candidate we later dropped.
+            // requestReviewers (or null). autoRequestedHasSignal is true only
+            // when that login appears in committersBySignal; otherwise we avoid
+            // saying they have "lower" signal when they have none measured.
             function formatAssignmentComment({
-              source, assignee, suggestedReviewer, autoRequestedReviewer,
+              source, assignee, suggestedReviewer,
+              autoRequestedReviewer, autoRequestedHasSignal,
             }) {
               let body =
                 `**PR board sync:** auto-assigned @${assignee} as shepherd ` +
                 `for this ${source} PR.`;
               if (suggestedReviewer) {
-                if (autoRequestedReviewer) {
+                if (autoRequestedReviewer && autoRequestedHasSignal) {
                   body +=
                     `\n\nCommitter signal on the changed files is higher for ` +
                     `${suggestedReviewer} than for the auto-requested reviewer ` +
@@ -1015,6 +1023,10 @@ jobs:
                   && !classifyIsBot(r, botAuthors) && !r.toLowerCase().endsWith("[bot]"));
               if (realExisting.length) autoRequestedReviewer = null;
 
+              const autoRequestedHasSignal = !!(autoRequestedReviewer &&
+                committersBySignal.some(
+                  (c) => c && c.toLowerCase() === autoRequestedReviewer.toLowerCase()));
+
               const suggestedReviewer = pickSuggestedReviewer({
                 committersBySignal,
                 collaborators,
@@ -1024,7 +1036,12 @@ jobs:
                 botAuthors,
               });
 
-              return { assignee, autoRequestedReviewer, suggestedReviewer };
+              return {
+                assignee,
+                autoRequestedReviewer,
+                autoRequestedHasSignal,
+                suggestedReviewer,
+              };
             }
             // ----- extract-js:assignment:end -----
 
@@ -1459,14 +1476,16 @@ jobs:
             // are updated, including when the PR was assigned earlier or the
             // issue was linked later.
             async function postAssignmentComment(number, {
-              source, assignee, suggestedReviewer, autoRequestedReviewer,
+              source, assignee, suggestedReviewer,
+              autoRequestedReviewer, autoRequestedHasSignal,
             }) {
               try {
                 await github.rest.issues.createComment({
                   owner: context.repo.owner, repo: context.repo.repo,
                   issue_number: number,
                   body: formatAssignmentComment({
-                    source, assignee, suggestedReviewer, autoRequestedReviewer,
+                    source, assignee, suggestedReviewer,
+                    autoRequestedReviewer, autoRequestedHasSignal,
                   }),
                 });
                 if (suggestedReviewer) {
@@ -1491,7 +1510,8 @@ jobs:
               if (info.inMergeQueue) return;            // far enough along
               if (info.isDraft && !info.isBot) return;  // human draft: author's "not ready"
 
-              let assignee, autoRequestedReviewer = null, suggestedReviewer = null;
+              let assignee, autoRequestedReviewer = null, autoRequestedHasSignal = false,
+                  suggestedReviewer = null;
               if (source === SOURCE_INTERNAL) {
                 // Internal: the author drives; assign them, request no reviewers.
                 assignee = info.authorLogin;
@@ -1519,7 +1539,7 @@ jobs:
                     cache: SIGNAL_CACHE,
                     since: SIGNAL_SINCE,
                   });
-                ({ assignee, autoRequestedReviewer, suggestedReviewer } =
+                ({ assignee, autoRequestedReviewer, autoRequestedHasSignal, suggestedReviewer } =
                   selectAssigneeAndReviewers({
                     issueAssignees: info.issueAssignees,
                     committersBySignal: ranking,
@@ -1592,7 +1612,8 @@ jobs:
               // synchronize/sweep will not re-post.
               if (source !== SOURCE_INTERNAL) {
                 await postAssignmentComment(number, {
-                  source, assignee, suggestedReviewer, autoRequestedReviewer,
+                  source, assignee, suggestedReviewer,
+                  autoRequestedReviewer, autoRequestedHasSignal,
                 });
               }
 

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -6,11 +6,11 @@ name: PR Board Sync (reusable)
 #   - classifies + sets its Source (Internal / Community / Bot),
 #   - advances its Status (In Review / Revising / Snagged / Approved / Done)
 #     on the event-driven happy path,
-#   - backfills the assignee + reviewers (an Internal PR's author; otherwise a
-#     linked-issue owner, else the top committer-signal owner, else the
-#     maintainer) and auto-requests the shepherd only when they are not the
-#     author; a higher-signal collaborator is suggested in a PR comment (no @),
-#     never auto-requested,
+#   - backfills the assignee + auto-requested reviewer (an Internal PR's author;
+#     otherwise a linked-issue owner, else the top committer-signal owner, else
+#     the maintainer) and auto-requests that shepherd only when they are not the
+#     author / not ignored / no real reviewer already present; a higher-signal
+#     collaborator is suggested in a PR comment (no @), never auto-requested,
 #   - when a PR has an owner, assigns any still-unassigned linked (closing)
 #     issues to that same owner (the PR's primary assignee, not the co-assigned
 #     community author), and
@@ -912,21 +912,24 @@ jobs:
             }
 
             // Among committersBySignal (highest first), pick the first collaborator
-            // who is not the author / auto-requested reviewer / bot and who
-            // outranks the auto-requested reviewer. When nobody was
-            // auto-requested (shepherd is the author), any such collaborator
-            // counts as higher-signal. Used only for a suggestion comment —
-            // never for requestReviewers.
+            // who is not the author / shepherd / auto-requested reviewer / bot and
+            // who outranks the auto-requested reviewer. When nobody was
+            // auto-requested, any such collaborator counts as higher-signal.
+            // Used only for a suggestion comment — never for requestReviewers.
             function pickSuggestedReviewer({
               committersBySignal = [],
               collaborators,
               author,
-              requestedReviewer,
+              assignee,
+              autoRequestedReviewer,
               botAuthors = [],
             }) {
               const collab = _toSet(collaborators);
-              const excluded = (author || "").toLowerCase();
-              const requestedLower = (requestedReviewer || "").toLowerCase();
+              const excluded = new Set(
+                [author, assignee, autoRequestedReviewer]
+                  .filter(Boolean)
+                  .map((login) => login.toLowerCase()));
+              const requestedLower = (autoRequestedReviewer || "").toLowerCase();
               const requestedRank = requestedLower
                 ? committersBySignal.findIndex(
                     (c) => c && c.toLowerCase() === requestedLower)
@@ -936,7 +939,7 @@ jobs:
                 const c = committersBySignal[i];
                 if (!c) continue;
                 const lower = c.toLowerCase();
-                if (lower === excluded || lower === requestedLower) continue;
+                if (excluded.has(lower)) continue;
                 if (lower.endsWith("[bot]") || classifyIsBot(c, botAuthors)) continue;
                 if (!collab.has(c)) continue;
                 return c;
@@ -948,19 +951,21 @@ jobs:
             // first auto-assigned. Mentions the assignee (already notified by
             // GitHub's assign event) but never @-mentions the suggested
             // reviewer, so the suggestion does not ping them.
+            // autoRequestedReviewer must be the login we actually intend to
+            // requestReviewers (or null) — not a candidate we later dropped.
             function formatAssignmentComment({
-              source, assignee, suggestedReviewer, requestedReviewer,
+              source, assignee, suggestedReviewer, autoRequestedReviewer,
             }) {
               let body =
                 `**PR board sync:** auto-assigned @${assignee} as shepherd ` +
                 `for this ${source} PR.`;
               if (suggestedReviewer) {
-                if (requestedReviewer) {
+                if (autoRequestedReviewer) {
                   body +=
                     `\n\nCommitter signal on the changed files is higher for ` +
                     `${suggestedReviewer} than for the auto-requested reviewer ` +
-                    `(${requestedReviewer}) — consider requesting a review from ` +
-                    `them as well. They were not auto-requested.`;
+                    `(${autoRequestedReviewer}) — consider requesting a review ` +
+                    `from them as well. They were not auto-requested.`;
                 } else {
                   body +=
                     `\n\nCommitter signal on the changed files is highest for ` +
@@ -985,6 +990,9 @@ jobs:
               const ignoredLower = new Set([..._toSet(opts.ignoredReviewers)].map((r) => r.toLowerCase()));
               const excluded = (author || "").toLowerCase();
 
+              // Linked-issue assignees who are the PR author are skipped here; they
+              // can still become shepherd via ownerCommitters if they are on the
+              // owners team.
               const issueOwnerAssignees = issueAssignees.filter(
                 (a) => owners.has(a) && a.toLowerCase() !== excluded && !a.toLowerCase().endsWith("[bot]"));
               const ownerCommitters = committersBySignal.filter((c) => owners.has(c));
@@ -994,26 +1002,29 @@ jobs:
               else if (ownerCommitters.length) assignee = ownerCommitters[0];
               else assignee = maintainer;
 
-              // Auto-request the shepherd only when they are not the PR author.
-              // Otherwise leave the review request empty; a stronger collaborator
-              // may still be named via suggestedReviewer.
-              const requestedReviewer =
+              // Single source of truth for who we will requestReviewers: shepherd
+              // if not the author, not ignored, and no real reviewer already present.
+              let autoRequestedReviewer =
                 (assignee && assignee.toLowerCase() !== excluded) ? assignee : null;
-
-              const suggestedReviewer = pickSuggestedReviewer({
-                committersBySignal, collaborators, author, requestedReviewer, botAuthors,
-              });
-
-              // A reviewer who can actually approve already requested? Then add no more.
+              if (autoRequestedReviewer &&
+                  ignoredLower.has(autoRequestedReviewer.toLowerCase())) {
+                autoRequestedReviewer = null;
+              }
               const realExisting = existingReviewers.filter(
                 (r) => r && !ignoredLower.has(r.toLowerCase())
                   && !classifyIsBot(r, botAuthors) && !r.toLowerCase().endsWith("[bot]"));
-              if (realExisting.length) {
-                return { assignee, reviewers: [], suggestedReviewer, requestedReviewer };
-              }
+              if (realExisting.length) autoRequestedReviewer = null;
 
-              const reviewers = requestedReviewer ? [requestedReviewer] : [];
-              return { assignee, reviewers, suggestedReviewer, requestedReviewer };
+              const suggestedReviewer = pickSuggestedReviewer({
+                committersBySignal,
+                collaborators,
+                author,
+                assignee,
+                autoRequestedReviewer,
+                botAuthors,
+              });
+
+              return { assignee, autoRequestedReviewer, suggestedReviewer };
             }
             // ----- extract-js:assignment:end -----
 
@@ -1437,15 +1448,39 @@ jobs:
 
             // Backfill a PR's assignee + reviewers (issue-owner -> committer-signal
             // owner -> maintainer). For Community/Bot: auto-request the shepherd
-            // only when they are not the PR author; a collaborator with stronger
-            // committer signal than that auto-requested reviewer (or the top
-            // collaborator when nobody was auto-requested) is named in a one-shot
-            // comment, not auto-requested. Internal PRs go to the author with no
-            // requested reviewer and no comment. PR assignment is idempotent: only
-            // ever touches an UNASSIGNED PR (so the comment also fires at most once).
+            // only when they are not the PR author, not ignored, and no real
+            // reviewer is already present; a collaborator with stronger committer
+            // signal than that auto-requested reviewer (or the top collaborator
+            // when nobody was auto-requested) is named in a one-shot comment, not
+            // auto-requested. Internal PRs go to the author with no requested
+            // reviewer and no comment. PR assignment is idempotent: only ever
+            // touches an UNASSIGNED PR (so the comment also fires at most once).
             // Linked-issue assignment is also idempotent: only unassigned issues
             // are updated, including when the PR was assigned earlier or the
             // issue was linked later.
+            async function postAssignmentComment(number, {
+              source, assignee, suggestedReviewer, autoRequestedReviewer,
+            }) {
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: number,
+                  body: formatAssignmentComment({
+                    source, assignee, suggestedReviewer, autoRequestedReviewer,
+                  }),
+                });
+                if (suggestedReviewer) {
+                  console.log(
+                    `assignment comment for ${assignee}; suggested ${suggestedReviewer}`);
+                } else {
+                  console.log(`assignment comment for ${assignee}`);
+                }
+              } catch (error) {
+                core.warning(
+                  `could not post assignment comment (${error.status})`);
+              }
+            }
+
             async function reconcileAssignment(info, source, number) {
               if (!source) return;                     // Source unknown -> leave to sweep
               if (info.assignees.length) {
@@ -1456,11 +1491,10 @@ jobs:
               if (info.inMergeQueue) return;            // far enough along
               if (info.isDraft && !info.isBot) return;  // human draft: author's "not ready"
 
-              let assignee, reviewers, suggestedReviewer = null, requestedReviewer = null;
+              let assignee, autoRequestedReviewer = null, suggestedReviewer = null;
               if (source === SOURCE_INTERNAL) {
                 // Internal: the author drives; assign them, request no reviewers.
                 assignee = info.authorLogin;
-                reviewers = [];
               } else {
                 // Community/Bot: full committer-signal selection against the
                 // relevant owners pool, with the maintainer as the final fallback.
@@ -1485,7 +1519,7 @@ jobs:
                     cache: SIGNAL_CACHE,
                     since: SIGNAL_SINCE,
                   });
-                ({ assignee, reviewers, suggestedReviewer, requestedReviewer } =
+                ({ assignee, autoRequestedReviewer, suggestedReviewer } =
                   selectAssigneeAndReviewers({
                     issueAssignees: info.issueAssignees,
                     committersBySignal: ranking,
@@ -1539,45 +1573,27 @@ jobs:
                 });
               }
 
-              // Request only the shepherd when they are not the author. Never
-              // request an ignored non-approver (e.g. the bmillsNV fallback
-              // assignee), which can legitimately leave the reviewer set empty.
-              const toRequest = reviewers.filter(r => !IGNORED.has(r.toLowerCase()));
-              if (toRequest.length) {
+              // autoRequestedReviewer is already filtered (not author, not ignored,
+              // no real existing reviewer) — request that login only.
+              if (autoRequestedReviewer) {
                 try {
                   await github.rest.pulls.requestReviewers({
                     owner: context.repo.owner, repo: context.repo.repo,
-                    pull_number: number, reviewers: toRequest,
+                    pull_number: number, reviewers: [autoRequestedReviewer],
                   });
                 } catch (error) {
                   core.warning(
-                    `could not request reviewers ${toRequest.join(", ")} (${error.status})`);
+                    `could not request reviewers ${autoRequestedReviewer} (${error.status})`);
                 }
               }
 
               // One-shot assignment note for Community/Bot (Internal has no
               // shepherding comment). Runs only on this first-assign path, so
-              // synchronize/sweep will not re-post. Suggested reviewer is plain
-              // text (no @) so they are not notified unless a human requests them.
+              // synchronize/sweep will not re-post.
               if (source !== SOURCE_INTERNAL) {
-                try {
-                  await github.rest.issues.createComment({
-                    owner: context.repo.owner, repo: context.repo.repo,
-                    issue_number: number,
-                    body: formatAssignmentComment({
-                      source, assignee, suggestedReviewer, requestedReviewer,
-                    }),
-                  });
-                  if (suggestedReviewer) {
-                    console.log(
-                      `assignment comment for ${assignee}; suggested ${suggestedReviewer}`);
-                  } else {
-                    console.log(`assignment comment for ${assignee}`);
-                  }
-                } catch (error) {
-                  core.warning(
-                    `could not post assignment comment (${error.status})`);
-                }
+                await postAssignmentComment(number, {
+                  source, assignee, suggestedReviewer, autoRequestedReviewer,
+                });
               }
 
               await syncLinkedIssueAssignees(assignee, info.linkedIssues);

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -921,6 +921,11 @@ jobs:
             // fallback), that baseline is treated as rank −∞ and any eligible
             // collaborator counts as higher-signal. Used only for a suggestion
             // comment — never for requestReviewers.
+            //
+            // Collaborator membership uses raw login equality (same as
+            // selectAssigneeAndReviewers' owners.has / collaborators.has). All three
+            // sets come from GitHub APIs with canonical login casing, so a
+            // case-insensitive check is unnecessary here.
             function pickSuggestedReviewer({
               committersBySignal = [],
               collaborators,
@@ -975,10 +980,14 @@ jobs:
                     `(${autoRequestedReviewer}) — consider requesting a review ` +
                     `from them as well. They were not auto-requested.`;
                 } else {
+                  // Assignee (and author / auto-requested when present) were
+                  // excluded from the pick, so this is highest among remaining
+                  // eligible collaborators — not among all collaborators.
                   body +=
                     `\n\nCommitter signal on the changed files is highest for ` +
-                    `${suggestedReviewer} among collaborators — consider ` +
-                    `requesting a review from them. They were not auto-requested.`;
+                    `${suggestedReviewer} among collaborators other than the ` +
+                    `assignee — consider requesting a review from them. They ` +
+                    `were not auto-requested.`;
                 }
               }
               return body;

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -8,8 +8,9 @@ name: PR Board Sync (reusable)
 #     on the event-driven happy path,
 #   - backfills the assignee + reviewers (an Internal PR's author; otherwise a
 #     linked-issue owner, else the top committer-signal owner, else the
-#     maintainer) and requests the assignee as reviewer only (owners allowlist;
-#     a higher-signal non-owner is suggested in a PR comment, not auto-requested),
+#     maintainer) and auto-requests the shepherd only when they are not the
+#     author; a higher-signal collaborator is suggested in a PR comment (no @),
+#     never auto-requested,
 #   - when a PR has an owner, assigns any still-unassigned linked (closing)
 #     issues to that same owner (the PR's primary assignee, not the co-assigned
 #     community author), and
@@ -911,28 +912,31 @@ jobs:
             }
 
             // Among committersBySignal (highest first), pick the first collaborator
-            // who is not the author/assignee/bot and who outranks the assignee.
-            // When the assignee is absent from the ranking (maintainer fallback),
-            // any such collaborator counts as higher-signal. Used only for a
-            // suggestion comment — never for requestReviewers.
+            // who is not the author / auto-requested reviewer / bot and who
+            // outranks the auto-requested reviewer. When nobody was
+            // auto-requested (shepherd is the author), any such collaborator
+            // counts as higher-signal. Used only for a suggestion comment —
+            // never for requestReviewers.
             function pickSuggestedReviewer({
               committersBySignal = [],
               collaborators,
               author,
-              assignee,
+              requestedReviewer,
               botAuthors = [],
             }) {
               const collab = _toSet(collaborators);
               const excluded = (author || "").toLowerCase();
-              const assigneeLower = (assignee || "").toLowerCase();
-              const assigneeRank = committersBySignal.findIndex(
-                (c) => c && c.toLowerCase() === assigneeLower);
+              const requestedLower = (requestedReviewer || "").toLowerCase();
+              const requestedRank = requestedLower
+                ? committersBySignal.findIndex(
+                    (c) => c && c.toLowerCase() === requestedLower)
+                : -1;
               for (let i = 0; i < committersBySignal.length; ++i) {
-                if (assigneeRank >= 0 && i >= assigneeRank) break;
+                if (requestedRank >= 0 && i >= requestedRank) break;
                 const c = committersBySignal[i];
                 if (!c) continue;
                 const lower = c.toLowerCase();
-                if (lower === excluded || lower === assigneeLower) continue;
+                if (lower === excluded || lower === requestedLower) continue;
                 if (lower.endsWith("[bot]") || classifyIsBot(c, botAuthors)) continue;
                 if (!collab.has(c)) continue;
                 return c;
@@ -944,16 +948,25 @@ jobs:
             // first auto-assigned. Mentions the assignee (already notified by
             // GitHub's assign event) but never @-mentions the suggested
             // reviewer, so the suggestion does not ping them.
-            function formatAssignmentComment({ source, assignee, suggestedReviewer }) {
+            function formatAssignmentComment({
+              source, assignee, suggestedReviewer, requestedReviewer,
+            }) {
               let body =
                 `**PR board sync:** auto-assigned @${assignee} as shepherd ` +
                 `for this ${source} PR.`;
               if (suggestedReviewer) {
-                body +=
-                  `\n\nCommitter signal on the changed files is higher for ` +
-                  `${suggestedReviewer} than for the assignee — consider ` +
-                  `requesting a review from them as well. They were not ` +
-                  `auto-requested (only allowlisted owners are).`;
+                if (requestedReviewer) {
+                  body +=
+                    `\n\nCommitter signal on the changed files is higher for ` +
+                    `${suggestedReviewer} than for the auto-requested reviewer ` +
+                    `(${requestedReviewer}) — consider requesting a review from ` +
+                    `them as well. They were not auto-requested.`;
+                } else {
+                  body +=
+                    `\n\nCommitter signal on the changed files is highest for ` +
+                    `${suggestedReviewer} among collaborators — consider ` +
+                    `requesting a review from them. They were not auto-requested.`;
+                }
               }
               return body;
             }
@@ -981,8 +994,14 @@ jobs:
               else if (ownerCommitters.length) assignee = ownerCommitters[0];
               else assignee = maintainer;
 
+              // Auto-request the shepherd only when they are not the PR author.
+              // Otherwise leave the review request empty; a stronger collaborator
+              // may still be named via suggestedReviewer.
+              const requestedReviewer =
+                (assignee && assignee.toLowerCase() !== excluded) ? assignee : null;
+
               const suggestedReviewer = pickSuggestedReviewer({
-                committersBySignal, collaborators, author, assignee, botAuthors,
+                committersBySignal, collaborators, author, requestedReviewer, botAuthors,
               });
 
               // A reviewer who can actually approve already requested? Then add no more.
@@ -990,25 +1009,11 @@ jobs:
                 (r) => r && !ignoredLower.has(r.toLowerCase())
                   && !classifyIsBot(r, botAuthors) && !r.toLowerCase().endsWith("[bot]"));
               if (realExisting.length) {
-                return { assignee, reviewers: [], suggestedReviewer };
+                return { assignee, reviewers: [], suggestedReviewer, requestedReviewer };
               }
 
-              // Only auto-request allowlisted owners (the assignee). A higher-signal
-              // collaborator outside the owners team is surfaced via suggestedReviewer
-              // for a comment, never via requestReviewers.
-              const reviewers = [assignee];
-
-              // GitHub rejects requesting review from the PR author; then dedupe (order-preserving).
-              const seen = new Set();
-              const deduped = [];
-              for (const r of reviewers) {
-                if (!r || r.toLowerCase() === excluded) continue;
-                if (!seen.has(r.toLowerCase())) {
-                  seen.add(r.toLowerCase());
-                  deduped.push(r);
-                }
-              }
-              return { assignee, reviewers: deduped, suggestedReviewer };
+              const reviewers = requestedReviewer ? [requestedReviewer] : [];
+              return { assignee, reviewers, suggestedReviewer, requestedReviewer };
             }
             // ----- extract-js:assignment:end -----
 
@@ -1431,12 +1436,13 @@ jobs:
             }
 
             // Backfill a PR's assignee + reviewers (issue-owner -> committer-signal
-            // owner -> maintainer; auto-requested reviewers = assignee only, unless a
-            // real reviewer is already requested). A higher-signal collaborator
-            // outside the owners allowlist is named in a one-shot comment, not
-            // auto-requested. Internal PRs go to the author with no requested
-            // reviewer and no comment. PR assignment is idempotent: only ever
-            // touches an UNASSIGNED PR (so the comment also fires at most once).
+            // owner -> maintainer). For Community/Bot: auto-request the shepherd
+            // only when they are not the PR author; a collaborator with stronger
+            // committer signal than that auto-requested reviewer (or the top
+            // collaborator when nobody was auto-requested) is named in a one-shot
+            // comment, not auto-requested. Internal PRs go to the author with no
+            // requested reviewer and no comment. PR assignment is idempotent: only
+            // ever touches an UNASSIGNED PR (so the comment also fires at most once).
             // Linked-issue assignment is also idempotent: only unassigned issues
             // are updated, including when the PR was assigned earlier or the
             // issue was linked later.
@@ -1450,7 +1456,7 @@ jobs:
               if (info.inMergeQueue) return;            // far enough along
               if (info.isDraft && !info.isBot) return;  // human draft: author's "not ready"
 
-              let assignee, reviewers, suggestedReviewer = null;
+              let assignee, reviewers, suggestedReviewer = null, requestedReviewer = null;
               if (source === SOURCE_INTERNAL) {
                 // Internal: the author drives; assign them, request no reviewers.
                 assignee = info.authorLogin;
@@ -1479,17 +1485,18 @@ jobs:
                     cache: SIGNAL_CACHE,
                     since: SIGNAL_SINCE,
                   });
-                ({ assignee, reviewers, suggestedReviewer } = selectAssigneeAndReviewers({
-                  issueAssignees: info.issueAssignees,
-                  committersBySignal: ranking,
-                  owners,
-                  collaborators,
-                  author: info.authorLogin,
-                  maintainer,
-                  existingReviewers: info.requestedReviewers,
-                  botAuthors: BOT_AUTHORS,
-                  ignoredReviewers: [...IGNORED],
-                }));
+                ({ assignee, reviewers, suggestedReviewer, requestedReviewer } =
+                  selectAssigneeAndReviewers({
+                    issueAssignees: info.issueAssignees,
+                    committersBySignal: ranking,
+                    owners,
+                    collaborators,
+                    author: info.authorLogin,
+                    maintainer,
+                    existingReviewers: info.requestedReviewers,
+                    botAuthors: BOT_AUTHORS,
+                    ignoredReviewers: [...IGNORED],
+                  }));
               }
               if (!assignee) return;                    // no owner and no maintainer
 
@@ -1532,11 +1539,9 @@ jobs:
                 });
               }
 
-              // Request only allowlisted owners (the assignee). The selection
-              // already drops the author and the case where a real reviewer is
-              // present. Also never request an ignored non-approver (e.g. the
-              // bmillsNV fallback assignee), which can legitimately leave the
-              // reviewer set empty -- that is fine.
+              // Request only the shepherd when they are not the author. Never
+              // request an ignored non-approver (e.g. the bmillsNV fallback
+              // assignee), which can legitimately leave the reviewer set empty.
               const toRequest = reviewers.filter(r => !IGNORED.has(r.toLowerCase()));
               if (toRequest.length) {
                 try {
@@ -1560,7 +1565,7 @@ jobs:
                     owner: context.repo.owner, repo: context.repo.repo,
                     issue_number: number,
                     body: formatAssignmentComment({
-                      source, assignee, suggestedReviewer,
+                      source, assignee, suggestedReviewer, requestedReviewer,
                     }),
                   });
                   if (suggestedReviewer) {

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -8,7 +8,8 @@ name: PR Board Sync (reusable)
 #     on the event-driven happy path,
 #   - backfills the assignee + reviewers (an Internal PR's author; otherwise a
 #     linked-issue owner, else the top committer-signal owner, else the
-#     maintainer) and requests reviewers,
+#     maintainer) and requests the assignee as reviewer only (owners allowlist;
+#     a higher-signal non-owner is suggested in a PR comment, not auto-requested),
 #   - when a PR has an owner, assigns any still-unassigned linked (closing)
 #     issues to that same owner (the PR's primary assignee, not the co-assigned
 #     community author), and
@@ -909,6 +910,54 @@ jobs:
               return x instanceof Set ? x : new Set(x || []);
             }
 
+            // Among committersBySignal (highest first), pick the first collaborator
+            // who is not the author/assignee/bot and who outranks the assignee.
+            // When the assignee is absent from the ranking (maintainer fallback),
+            // any such collaborator counts as higher-signal. Used only for a
+            // suggestion comment — never for requestReviewers.
+            function pickSuggestedReviewer({
+              committersBySignal = [],
+              collaborators,
+              author,
+              assignee,
+              botAuthors = [],
+            }) {
+              const collab = _toSet(collaborators);
+              const excluded = (author || "").toLowerCase();
+              const assigneeLower = (assignee || "").toLowerCase();
+              const assigneeRank = committersBySignal.findIndex(
+                (c) => c && c.toLowerCase() === assigneeLower);
+              for (let i = 0; i < committersBySignal.length; ++i) {
+                if (assigneeRank >= 0 && i >= assigneeRank) break;
+                const c = committersBySignal[i];
+                if (!c) continue;
+                const lower = c.toLowerCase();
+                if (lower === excluded || lower === assigneeLower) continue;
+                if (lower.endsWith("[bot]") || classifyIsBot(c, botAuthors)) continue;
+                if (!collab.has(c)) continue;
+                return c;
+              }
+              return null;
+            }
+
+            // Body for the one-shot comment posted when a Community/Bot PR is
+            // first auto-assigned. Mentions the assignee (already notified by
+            // GitHub's assign event) but never @-mentions the suggested
+            // reviewer, so the suggestion does not ping them.
+            function formatAssignmentComment({ source, assignee, suggestedReviewer }) {
+              let body =
+                `**PR board sync:** auto-assigned @${assignee} as shepherd ` +
+                `for this ${source} PR.`;
+              if (suggestedReviewer) {
+                body +=
+                  `\n\nCommitter signal on the changed files is higher for ` +
+                  `${suggestedReviewer} than for the assignee — consider ` +
+                  `requesting a review from them as well. They were not ` +
+                  `auto-requested (only allowlisted owners are).`;
+              }
+              return body;
+            }
+
             function selectAssigneeAndReviewers(opts) {
               const {
                 issueAssignees = [],
@@ -932,15 +981,22 @@ jobs:
               else if (ownerCommitters.length) assignee = ownerCommitters[0];
               else assignee = maintainer;
 
+              const suggestedReviewer = pickSuggestedReviewer({
+                committersBySignal, collaborators, author, assignee, botAuthors,
+              });
+
               // A reviewer who can actually approve already requested? Then add no more.
               const realExisting = existingReviewers.filter(
                 (r) => r && !ignoredLower.has(r.toLowerCase())
                   && !classifyIsBot(r, botAuthors) && !r.toLowerCase().endsWith("[bot]"));
-              if (realExisting.length) return { assignee, reviewers: [] };
+              if (realExisting.length) {
+                return { assignee, reviewers: [], suggestedReviewer };
+              }
 
+              // Only auto-request allowlisted owners (the assignee). A higher-signal
+              // collaborator outside the owners team is surfaced via suggestedReviewer
+              // for a comment, never via requestReviewers.
               const reviewers = [assignee];
-              const extra = committersBySignal.filter((c) => collaborators.has(c) && !owners.has(c));
-              if (extra.length && extra[0] !== assignee) reviewers.push(extra[0]);
 
               // GitHub rejects requesting review from the PR author; then dedupe (order-preserving).
               const seen = new Set();
@@ -952,7 +1008,7 @@ jobs:
                   deduped.push(r);
                 }
               }
-              return { assignee, reviewers: deduped };
+              return { assignee, reviewers: deduped, suggestedReviewer };
             }
             // ----- extract-js:assignment:end -----
 
@@ -1303,9 +1359,9 @@ jobs:
               warn: (message) => core.warning(message),
             });
 
-            // Logins with write+ access to this repo (the extra-reviewer pool).
+            // Logins with write+ access to this repo (the suggested-reviewer pool).
             // Empty on access error (listing collaborators needs repo admin/push),
-            // so the extra reviewer is simply skipped -- never a hard failure.
+            // so the suggestion is simply skipped -- never a hard failure.
             // Cached per run.
             let _collabCache;
             async function repoCollaborators() {
@@ -1318,7 +1374,8 @@ jobs:
                 _collabCache = new Set(
                   data.filter(c => c.permissions && c.permissions.push).map(c => c.login));
               } catch (error) {
-                core.warning(`could not list collaborators (${error.status}); no extra reviewer`);
+                core.warning(
+                  `could not list collaborators (${error.status}); no suggested reviewer`);
                 _collabCache = new Set();
               }
               return _collabCache;
@@ -1374,11 +1431,14 @@ jobs:
             }
 
             // Backfill a PR's assignee + reviewers (issue-owner -> committer-signal
-            // owner -> maintainer; reviewers = assignee + top dev-not-owner unless a
-            // real reviewer is already requested). Internal PRs go to the author with
-            // no requested reviewer. PR assignment is idempotent: only ever touches an
-            // UNASSIGNED PR. Linked-issue assignment is also idempotent: only unassigned
-            // issues are updated, including when the PR was assigned earlier or the
+            // owner -> maintainer; auto-requested reviewers = assignee only, unless a
+            // real reviewer is already requested). A higher-signal collaborator
+            // outside the owners allowlist is named in a one-shot comment, not
+            // auto-requested. Internal PRs go to the author with no requested
+            // reviewer and no comment. PR assignment is idempotent: only ever
+            // touches an UNASSIGNED PR (so the comment also fires at most once).
+            // Linked-issue assignment is also idempotent: only unassigned issues
+            // are updated, including when the PR was assigned earlier or the
             // issue was linked later.
             async function reconcileAssignment(info, source, number) {
               if (!source) return;                     // Source unknown -> leave to sweep
@@ -1390,7 +1450,7 @@ jobs:
               if (info.inMergeQueue) return;            // far enough along
               if (info.isDraft && !info.isBot) return;  // human draft: author's "not ready"
 
-              let assignee, reviewers;
+              let assignee, reviewers, suggestedReviewer = null;
               if (source === SOURCE_INTERNAL) {
                 // Internal: the author drives; assign them, request no reviewers.
                 assignee = info.authorLogin;
@@ -1419,7 +1479,7 @@ jobs:
                     cache: SIGNAL_CACHE,
                     since: SIGNAL_SINCE,
                   });
-                ({ assignee, reviewers } = selectAssigneeAndReviewers({
+                ({ assignee, reviewers, suggestedReviewer } = selectAssigneeAndReviewers({
                   issueAssignees: info.issueAssignees,
                   committersBySignal: ranking,
                   owners,
@@ -1472,11 +1532,11 @@ jobs:
                 });
               }
 
-              // Request the selected reviewers (assignee + top dev-not-owner). The
-              // selection already drops the author and the case where a real
-              // reviewer is present. Also never request an ignored non-approver
-              // (e.g. the bmillsNV fallback assignee), which can legitimately leave
-              // the reviewer set empty -- that is fine.
+              // Request only allowlisted owners (the assignee). The selection
+              // already drops the author and the case where a real reviewer is
+              // present. Also never request an ignored non-approver (e.g. the
+              // bmillsNV fallback assignee), which can legitimately leave the
+              // reviewer set empty -- that is fine.
               const toRequest = reviewers.filter(r => !IGNORED.has(r.toLowerCase()));
               if (toRequest.length) {
                 try {
@@ -1487,6 +1547,31 @@ jobs:
                 } catch (error) {
                   core.warning(
                     `could not request reviewers ${toRequest.join(", ")} (${error.status})`);
+                }
+              }
+
+              // One-shot assignment note for Community/Bot (Internal has no
+              // shepherding comment). Runs only on this first-assign path, so
+              // synchronize/sweep will not re-post. Suggested reviewer is plain
+              // text (no @) so they are not notified unless a human requests them.
+              if (source !== SOURCE_INTERNAL) {
+                try {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner, repo: context.repo.repo,
+                    issue_number: number,
+                    body: formatAssignmentComment({
+                      source, assignee, suggestedReviewer,
+                    }),
+                  });
+                  if (suggestedReviewer) {
+                    console.log(
+                      `assignment comment for ${assignee}; suggested ${suggestedReviewer}`);
+                  } else {
+                    console.log(`assignment comment for ${assignee}`);
+                  }
+                } catch (error) {
+                  core.warning(
+                    `could not post assignment comment (${error.status})`);
                 }
               }
 

--- a/docs/maintainers/pr-review-board.md
+++ b/docs/maintainers/pr-review-board.md
@@ -19,83 +19,61 @@ set by automation on first sight, but you may override it when it is wrong
 
 ## How a PR lands on your plate: the `Source` field
 
-Automation classifies each PR's **`Source`**, then uses that to pick a default
-assignee (and reviewers, when appropriate). That is a best-effort default —
-not a final verdict.
+Automation sets each PR's **`Source`**, then picks a default assignee (and
+sometimes a reviewer). Treat that as a starting point — change it if it's wrong.
 
-How Source is classified today:
+**How Source is chosen**
 
-- **Internal** — the author is a member of the org team the board is configured
-  with (`source_internal_team`, by default `shader-slang/source-internal`;
-  direct or nested membership, org-wide), **or** of a sibling
-  `source-internal-*` team whose description includes `Scope:` listing this
-  repository (bare short name or `owner/repo` inside brackets; matching is by
-  short name only, e.g. `Scope: [slangpy, slangpy-samples]`). Write
-  `Scope: [...]` with no space before the colon; the label is case-insensitive
-  and the first `Scope:` wins if several appear. The author is assigned; no
-  reviewer is auto-requested (they are expected to find one).
-- **Community** — everyone else who is not a bot. Automation picks a shepherd
-  from `pr-owners` (linked-issue assignee on that team, else strongest
-  committer-signal owner, else the maintainer fallback), auto-requests that
-  shepherd **only if they are not the PR author**, and posts a one-shot
-  comment. If another collaborator has stronger committer signal than the
-  auto-requested reviewer (or the strongest collaborator signal when nobody
-  was auto-requested), the comment suggests them without `@`-mentioning or
-  auto-requesting review.
-- **Bot** — opened by an automated coworker. Same assignment / review-request /
-  comment rules as Community, but the allowlist is `bot-pr-owners` instead of
-  `pr-owners`.
+- **Internal** — the author is on `shader-slang/source-internal` (or a nested
+  team under it), or on a `source-internal-*` team whose description lists this
+  repo in `Scope: [...]` (for example `Scope: [slangpy, slang-rhi]`). The author
+  is assigned and no reviewer is auto-requested; they should find one themselves.
+- **Community** — a human author who isn't Internal. A shepherd is chosen from
+  `pr-owners`, asked to review (unless they *are* the author), and a short
+  comment is posted on the PR. If someone else looks like a better reviewer
+  from recent commits on the changed files, the comment names them — without
+  `@`-mentioning or auto-requesting them.
+- **Bot** — same shepherd / review / comment behavior as Community, but the
+  allowlist is `bot-pr-owners` instead of `pr-owners`.
 
-If those team rosters cannot be read, automation leaves `Source` (and the
-assignee) blank rather than guessing, and the nightly sweep retries.
+**How the Community/Bot shepherd is chosen:** linked-issue assignee on the
+owners team, else whoever on that team has the strongest recent commit signal
+on the PR's files, else the maintainer fallback.
 
-Because Internal membership is org-wide (with optional per-repo scoped teams),
-Source can still be wrong for a given repo. If it is wrong, change Source on
-the board and reassign / request the right reviewers.
+If the team rosters can't be read, Source and assignee stay blank and the
+nightly sweep retries. Internal membership is org-wide (with optional per-repo
+scoped teams), so Source can still be wrong for a given repo — fix it on the
+board and reassign if needed.
 
-If you are the assignee, you are responsible for either driving the PR forward
-or finding the correct assignee (and handing it off). Same idea for Internal
-authors who still need a reviewer: pick someone who has recently touched the
-same files, or ask in the team channel.
+If you are the assignee, either drive the PR or hand it off. Internal authors
+still need a reviewer: pick someone who has touched the same files recently, or
+ask in the team channel.
 
 ## What each `Status` means for you
 
-| Status        | What it means                                                                                                                                                                                                                                      | Do you act?                                                     |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| **In Review** | The default for an open PR: awaiting review, CI still running, or a fresh commit not yet reviewed. (A **Bot draft** sits here too, so you can see and shepherd it.)                                                                                | **Yes** — review it, or make sure a real reviewer is requested. |
-| **Revising**  | The author is working: a **human draft**, or a reviewer requested changes. (A **Bot** PR's failed CI also lands here — the bot fixes itself.)                                                                                                      | **No** — it's on the author/bot until it moves.                 |
-| **Snagged**   | Needs a human's attention: a human PR's **CI failed**, **CI is awaiting your approval to run** (fork PRs from new contributors), or the PR is **approved + green but not in the merge queue** (it fell out, or needs someone to enqueue/merge it). | **Yes** — approve the CI run, help fix CI, or enqueue/merge.    |
-| **Approved**  | Not a draft, already has an approving review, and is waiting only on CI or the merge queue.                                                                                                                                                        | **No** — automated; nothing to do.                              |
-| **Done**      | The PR is closed (merged or otherwise). Terminal.                                                                                                                                                                                                  | No.                                                             |
+| Status | Meaning | Act? |
+| --- | --- | --- |
+| **In Review** | Waiting on review (or a fresh commit not yet re-reviewed). Bot drafts sit here too so you can shepherd them. | **Yes** — review, or make sure someone is. |
+| **Revising** | Author (or bot) is still working: human draft, changes requested, or a Bot PR with failed CI. | **No** |
+| **Snagged** | Needs a human: CI failed on a human PR, CI needs approval to run, or approved+green but not in the merge queue. | **Yes** — fix CI, approve the run, or enqueue/merge. |
+| **Approved** | Has an approving review; waiting on CI or the merge queue. | **No** |
+| **Done** | Closed (merged or not). Terminal. | **No** |
 
-In short: **`In Review` and `Snagged` are the two columns that want you.**
-`Revising`/`Approved` are waiting on someone/something else, and `Done` is finished.
+**`In Review` and `Snagged` are the columns that want you.** The rest are waiting on someone/something else, or finished.
 
 ## How the state is decided (priority)
 
-When several conditions are true at once, the first matching rule wins:
+Status is recomputed from current PR signals on every event (not walked along edges). First match wins:
 
-1. A reviewer's **changes-request** (made on the current commit) → **Revising**.
-2. **Draft** → **In Review** (Bot) / **Revising** (human).
-3. CI **needs approval** → **Snagged**; CI **failed** → **Revising** (Bot) /
-   **Snagged** (human).
-4. **Approved**: **Snagged** if CI is green and it's not in the merge queue,
-   otherwise **Approved**.
-5. Otherwise → **In Review**.
+1. Changes requested on the **current** commit → **Revising**
+2. Draft → **In Review** (Bot) / **Revising** (human)
+3. CI needs approval → **Snagged**; CI failed → **Revising** (Bot) / **Snagged** (human)
+4. Approved → **Snagged** if green and not in the merge queue, else **Approved**
+5. Otherwise → **In Review**
 
-Two things worth knowing:
-
-- A review only counts while it's on the **current** commit. A new push
-  supersedes earlier feedback, so the PR returns to **In Review** until it's
-  re-reviewed.
-- The **only** difference between the Bot and human flows is what a **CI failure**
-  does (Bot → `Revising`, human → `Snagged`); everything else is identical.
+A new push clears earlier review opinions, so the PR goes back to **In Review** until it is reviewed again. Bot vs human differs for **drafts** and **CI failure**; everything else is the same.
 
 ## The decision, as a flowchart
-
-The board does not move a PR along edges between states — it **recomputes** the
-status from the PR's current signals on every event. So the priority rules above
-are best read as a decision tree (first match wins):
 
 ```mermaid
 flowchart TD

--- a/docs/maintainers/pr-review-board.md
+++ b/docs/maintainers/pr-review-board.md
@@ -34,13 +34,17 @@ How Source is classified today:
   `Scope: [...]` with no space before the colon; the label is case-insensitive
   and the first `Scope:` wins if several appear. The author is assigned; no
   reviewer is auto-requested (they are expected to find one).
-- **Community** — everyone else who is not a bot. A maintainer is assigned to
-  shepherd it and arrange review. Automation auto-requests only that assignee
-  (from `pr-owners`) and posts a one-shot comment; if someone else has higher
-  committer signal on the changed files, the comment suggests them without
-  `@`-mentioning or auto-requesting review.
-- **Bot** — opened by an automated coworker. Same assignment / comment rules as
-  Community, but the allowlist is `bot-pr-owners` instead of `pr-owners`.
+- **Community** — everyone else who is not a bot. Automation picks a shepherd
+  from `pr-owners` (linked-issue assignee on that team, else strongest
+  committer-signal owner, else the maintainer fallback), auto-requests that
+  shepherd **only if they are not the PR author**, and posts a one-shot
+  comment. If another collaborator has stronger committer signal than the
+  auto-requested reviewer (or the strongest collaborator signal when nobody
+  was auto-requested), the comment suggests them without `@`-mentioning or
+  auto-requesting review.
+- **Bot** — opened by an automated coworker. Same assignment / review-request /
+  comment rules as Community, but the allowlist is `bot-pr-owners` instead of
+  `pr-owners`.
 
 If those team rosters cannot be read, automation leaves `Source` (and the
 assignee) blank rather than guessing, and the nightly sweep retries.

--- a/docs/maintainers/pr-review-board.md
+++ b/docs/maintainers/pr-review-board.md
@@ -35,9 +35,12 @@ How Source is classified today:
   and the first `Scope:` wins if several appear. The author is assigned; no
   reviewer is auto-requested (they are expected to find one).
 - **Community** — everyone else who is not a bot. A maintainer is assigned to
-  shepherd it and arrange review.
-- **Bot** — opened by an automated coworker. A maintainer is assigned to
-  shepherd it to ready-for-review and merge.
+  shepherd it and arrange review. Automation auto-requests only that assignee
+  (from `pr-owners`) and posts a one-shot comment; if someone else has higher
+  committer signal on the changed files, the comment suggests them without
+  `@`-mentioning or auto-requesting review.
+- **Bot** — opened by an automated coworker. Same assignment / comment rules as
+  Community, but the allowlist is `bot-pr-owners` instead of `pr-owners`.
 
 If those team rosters cannot be read, automation leaves `Source` (and the
 assignee) blank rather than guessing, and the nightly sweep retries.


### PR DESCRIPTION
## Motivation

On Bot and Community PRs, `selectAssigneeAndReviewers` auto-requested a second reviewer who was a collaborator **not** on the owners allowlist (`bot-pr-owners` / `pr-owners`). That defeated the opt-in lists.

Consider [shader-slang/slang-rhi#809](https://github.com/shader-slang/slang-rhi/pull/809): Source was correctly `Bot`, the assignee came from `bot-pr-owners`, then committer signal on `src/vulkan/vk-device.cpp` pulled in a non-allowlisted collaborator via `requestReviewers`.

## Proposed solution

Use the same selection rule for Bot and Community (only the owners team differs):

1. Auto-request **only the assignee** (owners allowlist / maintainer fallback).
2. Always post a one-shot assignment comment naming the assignee.
3. If a collaborator has **higher** committer signal than the assignee, name them in that comment as a suggested additional reviewer — **without** `@`-mention and **without** `requestReviewers`.

## Change summary

| Area | Change |
| --- | --- |
| `pr-board-sync.yml` | Drop collaborator-not-owner auto-request; add `pickSuggestedReviewer` + `formatAssignmentComment`; post comment on first Community/Bot assign |
| `pr-assign.test.js` | Cover assignee-only request, suggestion cases, and no-`@` comment formatting |
| `pr-board-sync.md` / `pr-review-board.md` | Document the new assignment / suggestion policy |

## Concepts and vocabulary

- **Owners allowlist** — `pr-owners` (Community) or `bot-pr-owners` (Bot); gates who may be auto-assigned / auto-requested.
- **Committer signal** — ranked logins from recent default-branch history on the PR’s changed files (highest first).
- **Suggested reviewer** — highest-signal collaborator who outranks the assignee; surfaced only in the comment.

## Process report

The bug was not in Source classification or slang-rhi’s caller templates (verbatim reuse of the shared workflow). Assignee selection already filtered to the owners team. The broken input shape was intentional Community/Bot behavior that preferred `collaborators ∩ ¬owners` as a second reviewer — valid as “file expert,” but wrong once owners lists are treated as opt-in.

Fix sits in the producer of review requests (`selectAssigneeAndReviewers` / `reconcileAssignment`): stop emitting that second request, and surface the same ranking via a comment instead. Same code path for Bot and Community; only which team fills `owners` differs. The comment runs only on the first-assign path (already idempotent), so synchronize/sweep will not re-post.

## Test plan

- [x] `node .github/scripts/pr-assign.test.js`
- [x] `node .github/scripts/pr-signal.test.js`
- [x] `node .github/scripts/pr-classify.test.js`
- [ ] After merge: open a Bot draft that touches files dominated by a non-`bot-pr-owners` collaborator; confirm assignee-only review request + suggestion comment without `@` on the suggested login