### PR TITLE
Fix segfault on empty capability switch case

### DIFF
--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9371,7 +9371,8 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
             if (!mapCaseStmtToBlock.tryGetValue(targetCase->body, caseBlock))
             {
                 caseBlock = builder->emitBlock();
-                if (targetCase->body != nullptr) {
+                if (targetCase->body != nullptr)
+                {
                     lowerStmt(context, targetCase->body);
                 }
                 mapCaseStmtToBlock.add(targetCase->body, caseBlock);
@@ -9450,7 +9451,8 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
             if (!mapCaseStmtToBlock.tryGetValue(targetCase->body, caseBlock))
             {
                 caseBlock = builder->emitBlock();
-                if (targetCase->body != nullptr) {
+                if (targetCase->body != nullptr)
+                {
                     lowerStmt(context, targetCase->body);
                 }
                 mapCaseStmtToBlock.add(targetCase->body, caseBlock);

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -9371,7 +9371,9 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
             if (!mapCaseStmtToBlock.tryGetValue(targetCase->body, caseBlock))
             {
                 caseBlock = builder->emitBlock();
-                lowerStmt(context, targetCase->body);
+                if (targetCase->body != nullptr) {
+                    lowerStmt(context, targetCase->body);
+                }
                 mapCaseStmtToBlock.add(targetCase->body, caseBlock);
                 if (!builder->getBlock()->getTerminator())
                     builder->emitBranch(breakLabel);
@@ -9448,7 +9450,9 @@ struct StmtLoweringVisitor : StmtVisitor<StmtLoweringVisitor>
             if (!mapCaseStmtToBlock.tryGetValue(targetCase->body, caseBlock))
             {
                 caseBlock = builder->emitBlock();
-                lowerStmt(context, targetCase->body);
+                if (targetCase->body != nullptr) {
+                    lowerStmt(context, targetCase->body);
+                }
                 mapCaseStmtToBlock.add(targetCase->body, caseBlock);
                 if (!builder->getBlock()->getTerminator())
                     builder->emitBranch(breakLabel);

--- a/tests/bugs/segfault_on_empty_capability_switch_case.slang
+++ b/tests/bugs/segfault_on_empty_capability_switch_case.slang
@@ -1,5 +1,6 @@
 /*
 There was once a bug where all of these capability switch statements caused a segfault.
+https://github.com/shader-slang/slang/pull/12357
 */
 
 //TEST:SIMPLE(filecheck=CHECK): -target metal

--- a/tests/bugs/segfault_on_empty_capability_switch_case.slang
+++ b/tests/bugs/segfault_on_empty_capability_switch_case.slang
@@ -1,0 +1,85 @@
+/*
+There was once a bug where all of these capability switch statements caused a segfault.
+*/
+
+//TEST:SIMPLE(filecheck=CHECK): -target metal
+//TEST:SIMPLE(filecheck=CHECK): -target spirv
+//TEST:SIMPLE(filecheck=CHECK): -target wgsl
+
+//CHECK: comp
+
+[shader("compute")]
+[numthreads(9, 1, 1)]
+void comp() {
+    {// Test __target_switch
+        __target_switch {
+        case metal:
+        }
+
+        __target_switch {
+        case spirv:
+            int six_seven = 67;
+        case metal:
+        }
+
+        __target_switch {
+        case spirv:
+            int six_seven = 67;
+        case metal:
+        case wgsl:
+        }
+
+        __target_switch {
+        default:
+        }
+
+        __target_switch {
+        case spirv:
+            int six_seven = 67;
+        default:
+        }
+
+        __target_switch {
+        case spirv:
+            int six_seven = 67;
+        case metal:
+        default:
+        }
+    }
+
+    {// Test __stage_switch
+        __stage_switch {
+        case compute:
+        }
+
+        __stage_switch {
+        case fragment:
+            int six_seven = 67;
+        case compute:
+        }
+
+        __stage_switch {
+        case fragment:
+            int six_seven = 67;
+        case compute:
+        case mesh:
+        }
+
+        __stage_switch {
+        default:
+        }
+
+        __stage_switch {
+        case fragment:
+            int six_seven = 67;
+        default:
+        }
+
+        __stage_switch {
+        case fragment:
+            int six_seven = 67;
+        case compute:
+        default:
+        }
+    }
+}


### PR DESCRIPTION
Hello.

The compiler segfaults when a capability switch statement ends with an empty case. For example, this segfaults:
```slang
__target_switch {
case spirv:
    int six_seven = 67;
case metal:
}
```

The segfault is caused by trying to lower an empty case statement body. I fixed it with an if statement. I also added a regression test.