### PR TITLE
Restore expected sanitizer findings for the TypeLayoutReflection use-after-free (#10893)

### DIFF
--- a/cmake/expected-sanitizer-findings.txt
+++ b/cmake/expected-sanitizer-findings.txt
@@ -56,13 +56,32 @@ LEAK: _replayContext
 # nobody owns them. Surfaced by the repro-validator unit tests.
 LEAK: getPathInfoFromFile
 
+# #10893: Use-after-free of TypeLayoutReflection in the slang-rhi
+# ShaderObjectLayout cache during render-test CPU compute tests. The cache
+# is keyed by raw TypeLayoutReflection*, and under server-count=1 those
+# addresses are recycled across sessions, so a cached entry's
+# m_elementTypeLayout can dangle. All three SUMMARY lines below cascade
+# from that single wild pointer: the ASan overflow is the read in
+# TypeLayout::FindResourceInfo, and the two UBSan findings are the bad
+# vptr on the way into it. All three must be listed, since a log counts
+# as expected only when every SUMMARY line in it matches a pattern.
+#
+# These entries were removed on 2026-07-08 in 70b2d94417 (#11937) after
+# several quiet nightlies, then the finding resurfaced in run 30971112743
+# on 2026-08-05. It is intermittent because it depends on allocator address
+# reuse, so quiet runs do not mean it is fixed -- remove these only when
+# #10893 itself is fixed, not merely when they go unmatched for a while.
+#
+# UBSan SUMMARY lines carry only file:line -- no function name -- so these
+# two are position-dependent against the file's own guidance, and will go
+# stale whenever the surrounding code shifts (the reflection entry has
+# already moved 1384 -> 1401). Update the line numbers when that happens.
+# The begin() entry is function-name based and is the durable one.
+Slang::List<Slang::TypeLayout::ResourceInfo, Slang::StandardAllocator>::begin()
+slang-reflection-api.cpp:1401
+slang-type-layout.h:772
+
 # Historical entries:
 #   #10828 LEAK: _maybeBeginMacroInvocation -- fixed by this PR: the
 #     wrong-arg-count macro invocation error paths now free the
 #     MacroInvocation.
-#   #10893 TypeLayoutReflection use-after-free SUMMARY patterns
-#     (List<ResourceInfo>::begin / slang-reflection-api.cpp /
-#     slang-type-layout.h) -- stale: never matched in recent nightly
-#     runs (e.g. 28644605608 and the scheduled master runs), so the
-#     UBSan finding no longer reproduces there. Re-add (with current
-#     line numbers) if #10893 resurfaces.


### PR DESCRIPTION
## Motivation

The nightly sanitizer workflow went red on 2026-08-05 ([run 30971112743](https://github.com/shader-slang/slang/actions/runs/30971112743)), its first failure since at least 2026-07-25. The three reported findings are a single bug — the use-after-free tracked in #10893:

```
SUMMARY: AddressSanitizer: heap-buffer-overflow source/core/slang-list.h:95:25 in Slang::List<Slang::TypeLayout::ResourceInfo, Slang::StandardAllocator>::begin()
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior source/slang/slang-reflection-api.cpp:1401:29
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior source/slang/slang-type-layout.h:772:25
```

A garbage `TypeLayout*` reaches `spReflectionTypeLayout_GetSize`, survives its `!typeLayout` null check, and UBSan flags the bad vptr twice before ASan flags the out-of-bounds read in `FindResourceInfo`. ASan places the pointer in a redzone 77 bytes past a live 67-byte `StringRepresentation`, consistent with recycled heap.

Because ASan aborts the process, the run stops partway through the suite — so this does not just report a known issue, it truncates nightly coverage.

These patterns were present until 2026-07-08, when `70b2d94417` (#11937) removed them as stale after several quiet nightlies, noting they could be re-added "if #10893 resurfaces". They have now resurfaced.

## Proposed solution

Restore the three patterns, and record why quiet runs are not evidence of a fix. The defect depends on allocator address reuse, so it is intermittent by nature — a run of green nightlies says nothing about whether the underlying cache-keying bug is gone. The comment now says to remove these entries when #10893 is fixed, rather than when they next go unmatched.

This is an interim unblock, not a fix. The root cause in slang-rhi is being worked separately, and #10893's original analysis has since been corrected ([comment](https://github.com/shader-slang/slang/issues/10893#issuecomment-5189791670)) — the cache entry lifetime problem is not the one the issue originally described, and the fix is correspondingly larger than its listed options. That makes restoring these entries worthwhile now rather than waiting for the fix to land.

## Change summary

| File | Change |
| --- | --- |
| `cmake/expected-sanitizer-findings.txt` | Restore the three #10893 SUMMARY patterns; drop the now-obsolete "historical entry" note for them; document the intermittency and the fragility of the line-number-based UBSan entries |

No LEAK patterns were touched — see the process report.

## Concepts and vocabulary

- **Expected finding** — a known sanitizer result accepted by CI so it does not block PRs or nightlies. Distinct from `cmake/lsan-suppressions.txt` (suppresses leak reporting inside LSan) and `cmake/sanitizer-ignorelist.txt` (disables UBSan checks at compile time); this file accepts findings that are still genuinely reported.
- **Stale pattern** — an entry that matched nothing during a run. CI warns about these so entries get cleaned up once the underlying issue is fixed.

## Process report

**Why all three lines are required.** CI classifies a log as expected only when every `SUMMARY:` line in it is covered, via `unexpected=$(echo "$summaries" | grep -vFf "$expected_patterns")` (`.github/workflows/ci-slang-sanitizer.yml:352`). Leaving any one out means the log stays unexpected and still fails the job. Verified against the actual `ubsan.18126` artifact from the failing run: with these three patterns, `grep -vFf` returns nothing.

**Why the UBSan entries use file:line, against this file's own guidance.** The header rightly calls `slang-ir.h:456` a bad pattern. UBSan `SUMMARY` lines carry only a path and a line — there is no function name to match on — so for these two there is no stable alternative that is not also far too broad; matching `slang-type-layout.h` alone would suppress every future UBSan finding in that header. The entries are position-dependent and will go stale on code motion, and the reflection one already drifted 1384 → 1401 while the patterns were absent. Both line numbers were re-verified against current master. The `begin()` entry is function-name based and is the durable one; the comment says so, so a future reader knows which to trust.

**Why no LEAK patterns were removed.** The failing run warned that all four LEAK patterns were stale, which would normally justify deleting them. That is an artifact of the crash: ASan aborted the process, so leak detection at exit never ran and the tests covering those patterns never executed. The last clean run ([30873614829](https://github.com/shader-slang/slang/actions/runs/30873614829), 2026-08-04) reports `FOUND 1 SANITIZER LOG(S): 0 PR-related, 0 pre-existing, 1 expected` with no genuine stale warnings, so all four matched there. Staleness should only be judged from a run that completed — which is the same reasoning error that removed the #10893 entries in July, now recorded in the file so it is not repeated a third time.

## Test Plan

- [x] Patterns validated against the real `ubsan.18126` artifact from run 30971112743 using CI's `grep -vFf` logic — zero unexpected summaries remain
- [x] Both UBSan line numbers re-verified against current master (`slang-reflection-api.cpp:1401`, `slang-type-layout.h:772`)
- [x] `./extras/formatting.sh --check-only` passes
- [ ] Confirmed by the next nightly sanitizer run classifying the finding as expected rather than PR-related
