### PR TITLE
ci: update CTS nightly to VK-GL-CTS 0.0.9

### DIFF
--- a/.github/workflows/nightly-slang-vkglcts-test.yml
+++ b/.github/workflows/nightly-slang-vkglcts-test.yml
@@ -77,10 +77,9 @@ jobs:
           cmake --workflow --preset "${{matrix.config}}"
       - uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:
-          tag: "VK-GL-CTS_WithSlang-0.0.9-win64"
+          latest: true
           repository: "shader-slang/VK-GL-CTS"
           fileName: "VK-GL-CTS_WithSlang-0.0.9-win64.zip"
-          preRelease: true
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: "shader-slang/VK-GL-CTS"

--- a/.github/workflows/nightly-slang-vkglcts-test.yml
+++ b/.github/workflows/nightly-slang-vkglcts-test.yml
@@ -77,9 +77,10 @@ jobs:
           cmake --workflow --preset "${{matrix.config}}"
       - uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:
-          latest: true
+          tag: "VK-GL-CTS_WithSlang-0.0.9-win64"
           repository: "shader-slang/VK-GL-CTS"
-          fileName: "VK-GL-CTS_WithSlang-0.0.7-win64.zip"
+          fileName: "VK-GL-CTS_WithSlang-0.0.9-win64.zip"
+          preRelease: true
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: "shader-slang/VK-GL-CTS"
@@ -91,33 +92,33 @@ jobs:
       - name: vkcts setup
         shell: pwsh
         run: |
-          Expand-Archive VK-GL-CTS_WithSlang-0.0.7-win64.zip
+          Expand-Archive VK-GL-CTS_WithSlang-0.0.9-win64.zip
 
-          copy ${{ github.workspace }}\build\Release\bin\slang-compiler.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64\slang-compiler.dll
-          copy ${{ github.workspace }}\build\Release\bin\slang-glslang.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64\slang-glslang.dll
-          copy ${{ github.workspace }}\build\Release\bin\slang-glsl-module.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64\slang-glsl-module.dll
-          copy ${{ github.workspace }}\build\Release\bin\test-server.exe ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64\test-server.exe
+          copy ${{ github.workspace }}\build\Release\bin\slang-compiler.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64\slang-compiler.dll
+          copy ${{ github.workspace }}\build\Release\bin\slang-glslang.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64\slang-glslang.dll
+          copy ${{ github.workspace }}\build\Release\bin\slang-glsl-module.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64\slang-glsl-module.dll
+          copy ${{ github.workspace }}\build\Release\bin\test-server.exe ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64\test-server.exe
 
-          copy ${{ github.workspace }}\test-lists\test-lists\slang-passing-tests.txt ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64\slang-passing-tests.txt
-          copy ${{ github.workspace }}\test-lists\test-lists\slang-waiver-tests.xml ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64\slang-waiver-tests.xml
+          copy ${{ github.workspace }}\test-lists\test-lists\slang-passing-tests.txt ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64\slang-passing-tests.txt
+          copy ${{ github.workspace }}\test-lists\test-lists\slang-waiver-tests.xml ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64\slang-waiver-tests.xml
 
       - name: dump device info
         shell: pwsh
-        working-directory: ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64
+        working-directory: ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64
         run: |
           .\deqp-vk.exe --deqp-case=dEQP-VK.info.device
           Get-Content -Path TestResults.qpa
 
       - name: vkcts run
         shell: pwsh
-        working-directory: ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64
+        working-directory: ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64
         run: |
-          .\deqp-vk.exe --deqp-archive-dir=${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64 --deqp-caselist-file=${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64\slang-passing-tests.txt --deqp-waiver-file=${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64\slang-waiver-tests.xml
+          .\deqp-vk.exe --deqp-archive-dir=${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64 --deqp-caselist-file=${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64\slang-passing-tests.txt --deqp-waiver-file=${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64\slang-waiver-tests.xml
 
       - name: Dump TestResults.qpa if failed
         shell: pwsh
         if: ${{ !success() }}
-        working-directory: ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.7-win64
+        working-directory: ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64
         run: Get-Content TestResults.qpa -Tail 1000
 
       - name: success notification


### PR DESCRIPTION
## Motivation

The CTS nightly was using VK-GL-CTS 0.0.7. That release predates the fix for `LoadLibraryA("slang.dll")` — Slang renamed its DLL to `slang-compiler.dll` but the CTS binary was not updated until [VK-GL-CTS PR #17](https://github.com/shader-slang/VK-GL-CTS/pull/17), which is included in 0.0.9.

`dEQP-VK.descriptor_indexing.storage_image_minNonUniform` was found to fail with 0.0.9 (the upstream Vulkan CTS test changed between the two releases). Added to `slang-waiver-tests.xml` in VK-GL-CTS; the underlying Slang issue is tracked in #12364.

## Change summary

| File | Change |
| --- | --- |
| `.github/workflows/nightly-slang-vkglcts-test.yml` | Update from VK-GL-CTS 0.0.7 to 0.0.9 |