### PR TITLE
ci: upload TestResults.qpa as an artifact on CTS nightly failure

### DIFF
--- a/.github/workflows/nightly-slang-vkglcts-test.yml
+++ b/.github/workflows/nightly-slang-vkglcts-test.yml
@@ -11,6 +11,9 @@ env:
   DISABLE_CTS_SLANG: 0
   ACTIONS_RUNNER_DEBUG: true
   ACTIONS_STEP_DEBUG: true
+  # The only place the CTS release/version is spelled out. Everything else
+  # derives the download name and the extracted directory from this.
+  CTS_PACKAGE: VK-GL-CTS_WithSlang-0.0.9-win64
 jobs:
   build:
     strategy:
@@ -75,11 +78,16 @@ jobs:
             -DSLANG_ENABLE_TESTS=1 \
             "${cmake_launcher_defines[@]}"
           cmake --workflow --preset "${{matrix.config}}"
+      - name: Resolve CTS paths
+        run: |
+          # Forward slashes work for pwsh, deqp-vk and upload-artifact alike.
+          echo "CTS_ZIP=${{ github.workspace }}/${CTS_PACKAGE}.zip" >> "$GITHUB_ENV"
+          echo "CTS_DIR=${{ github.workspace }}/${CTS_PACKAGE}" >> "$GITHUB_ENV"
       - uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
         with:
           latest: true
           repository: "shader-slang/VK-GL-CTS"
-          fileName: "VK-GL-CTS_WithSlang-0.0.9-win64.zip"
+          fileName: "${{ env.CTS_PACKAGE }}.zip"
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: "shader-slang/VK-GL-CTS"
@@ -91,34 +99,38 @@ jobs:
       - name: vkcts setup
         shell: pwsh
         run: |
-          Expand-Archive VK-GL-CTS_WithSlang-0.0.9-win64.zip
+          Expand-Archive -Path $env:CTS_ZIP -DestinationPath $env:CTS_DIR
 
-          copy ${{ github.workspace }}\build\Release\bin\slang-compiler.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64\slang-compiler.dll
-          copy ${{ github.workspace }}\build\Release\bin\slang-glslang.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64\slang-glslang.dll
-          copy ${{ github.workspace }}\build\Release\bin\slang-glsl-module.dll ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64\slang-glsl-module.dll
-          copy ${{ github.workspace }}\build\Release\bin\test-server.exe ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64\test-server.exe
+          copy ${{ github.workspace }}\build\Release\bin\slang-compiler.dll "${env:CTS_DIR}\slang-compiler.dll"
+          copy ${{ github.workspace }}\build\Release\bin\slang-glslang.dll "${env:CTS_DIR}\slang-glslang.dll"
+          copy ${{ github.workspace }}\build\Release\bin\slang-glsl-module.dll "${env:CTS_DIR}\slang-glsl-module.dll"
+          copy ${{ github.workspace }}\build\Release\bin\test-server.exe "${env:CTS_DIR}\test-server.exe"
 
-          copy ${{ github.workspace }}\test-lists\test-lists\slang-passing-tests.txt ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64\slang-passing-tests.txt
-          copy ${{ github.workspace }}\test-lists\test-lists\slang-waiver-tests.xml ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64\slang-waiver-tests.xml
+          copy ${{ github.workspace }}\test-lists\test-lists\slang-passing-tests.txt "${env:CTS_DIR}\slang-passing-tests.txt"
+          copy ${{ github.workspace }}\test-lists\test-lists\slang-waiver-tests.xml "${env:CTS_DIR}\slang-waiver-tests.xml"
 
       - name: dump device info
         shell: pwsh
-        working-directory: ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64
+        working-directory: ${{ env.CTS_DIR }}
         run: |
           .\deqp-vk.exe --deqp-case=dEQP-VK.info.device
           Get-Content -Path TestResults.qpa
 
       - name: vkcts run
         shell: pwsh
-        working-directory: ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64
+        working-directory: ${{ env.CTS_DIR }}
         run: |
-          .\deqp-vk.exe --deqp-archive-dir=${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64 --deqp-caselist-file=${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64\slang-passing-tests.txt --deqp-waiver-file=${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64\slang-waiver-tests.xml
+          .\deqp-vk.exe "--deqp-archive-dir=${env:CTS_DIR}" "--deqp-caselist-file=${env:CTS_DIR}\slang-passing-tests.txt" "--deqp-waiver-file=${env:CTS_DIR}\slang-waiver-tests.xml"
 
-      - name: Dump TestResults.qpa if failed
-        shell: pwsh
-        if: ${{ !success() }}
-        working-directory: ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64
-        run: Get-Content TestResults.qpa -Tail 1000
+      - name: Upload TestResults.qpa if failed
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: vkcts-test-results-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.CTS_DIR }}/TestResults.qpa
+          if-no-files-found: warn
+          retention-days: 7
+          compression-level: 9
 
       - name: success notification
         id: slack-notify-success


### PR DESCRIPTION
## Motivation

When the nightly VK-GL-CTS job fails, the only record of what went wrong is the
last 1000 lines of `TestResults.qpa`, dumped into the job log by the
`Dump TestResults.qpa if failed` step. That is rarely enough: the `.qpa` is a
full per-case log, and the failing cases we actually want to look at are usually
thousands of lines above the tail. See for example
https://github.com/shader-slang/slang/actions/runs/30985159061/job/92238147371 —
the tail shows the run ending, not the cases that failed.

Separately, the CTS package name was spelled out in nine places in the workflow,
once per step that referenced the download or the extracted directory:

```yaml
fileName: "VK-GL-CTS_WithSlang-0.0.9-win64.zip"
...
working-directory: ${{ github.workspace }}\VK-GL-CTS_WithSlang-0.0.9-win64
```

So the routine version bump — the previous one being 20592cc5f, "ci: update CTS
nightly to VK-GL-CTS 0.0.9" — touched every one of those lines, and missing one
would fail in a confusing way: a download of the new version extracted next to a
stale directory that the rest of the steps still point at.

## Proposed solution

Upload the whole `TestResults.qpa` as a build artifact on failure instead of
tailing it into the log, so the complete log is downloadable for the artifact
retention period.

`actions/upload-artifact` already zips what it uploads, so pre-compressing with
`Compress-Archive` would only produce a zip inside a zip — no size win, and a
worse download. The `.qpa` is plain text and compresses well, so the change
instead asks for the maximum `compression-level`.

For the version churn, hoist the package name into a single workflow-level
`CTS_PACKAGE` variable and derive everything else from it. GitHub does not allow
one workflow-level `env` entry to reference another, so a small
`Resolve CTS paths` step writes the derived `CTS_ZIP` and `CTS_DIR` into
`$GITHUB_ENV`; every later step consumes those instead of repeating the literal
name. Bumping the CTS version is now a one-line edit.

## Change summary

| File | Change |
| --- | --- |
| `.github/workflows/nightly-slang-vkglcts-test.yml` | Replace the `Dump TestResults.qpa if failed` step with an `Upload TestResults.qpa if failed` step; add the `CTS_PACKAGE` variable and the `Resolve CTS paths` step, and rewrite the download/setup/run steps to use `CTS_ZIP` / `CTS_DIR`. |

## Process report

**Upload rather than dump.** The removed step was
`Get-Content TestResults.qpa -Tail 1000` under `if: ${{ !success() }}`. The new
step uses `actions/upload-artifact` pinned to the same SHA every other workflow
in this repo uses (`b7c566a…`, v6), with:

- `if: ${{ failure() }}` rather than `!success()`. `!success()` also fires when
  the job is cancelled, where the `.qpa` is a partial log of a run nobody is
  debugging. The two Slack notification steps still use `!success()`
  intentionally — a cancelled nightly is worth notifying about even though its
  `.qpa` is not worth keeping.
- `name: vkcts-test-results-${{ github.run_id }}-${{ github.run_attempt }}`, so
  a re-run does not collide with the artifact from the original attempt.
- `if-no-files-found: warn`. The job can fail before `deqp-vk.exe` ever runs —
  in the build step, or in archive extraction — and in that case there is no
  `.qpa` to upload; failing the upload there would replace the real error with a
  misleading one.
- `compression-level: 9`, as described above.
- `retention-days: 7`, which is long enough to triage a nightly failure.

**One source of truth for the package name.** `CTS_PACKAGE` sits at the workflow
level next to the other `env` entries. The `Resolve CTS paths` step runs under
the job's default `bash` shell and appends to `$GITHUB_ENV`:

```yaml
- name: Resolve CTS paths
  run: |
    echo "CTS_ZIP=${{ github.workspace }}/${CTS_PACKAGE}.zip" >> "$GITHUB_ENV"
    echo "CTS_DIR=${{ github.workspace }}/${CTS_PACKAGE}" >> "$GITHUB_ENV"
```

It is placed before the `release-downloader` step so both `CTS_ZIP` and
`CTS_DIR` are defined for every consumer. The paths use forward slashes because
they are consumed by three different things — `pwsh`, `deqp-vk.exe`, and
`upload-artifact`'s path glob — and forward slashes are the one separator all
three accept on Windows; `upload-artifact` in particular treats a backslash as a
literal character rather than a separator.

**Extraction directory is unchanged.** The old step was
`Expand-Archive VK-GL-CTS_WithSlang-0.0.9-win64.zip` with no `-DestinationPath`,
which PowerShell resolves to a directory named after the archive — exactly
`$CTS_DIR`. The new step spells that out as
`Expand-Archive -Path $env:CTS_ZIP -DestinationPath $env:CTS_DIR`, so the derived
variable and the actual extraction target cannot drift apart.

**PowerShell variable syntax.** The `copy` and `deqp-vk.exe` arguments use the
braced form and are quoted, e.g. `"${env:CTS_DIR}\slang-compiler.dll"` and
`"--deqp-caselist-file=${env:CTS_DIR}\slang-passing-tests.txt"`. The braces make
the end of the variable name unambiguous where a path separator follows it, and
the quotes keep each argument a single token if `github.workspace` ever contains
a space — the previous unquoted literal paths would have broken in that case.

**Verification.** This is a self-hosted, Windows, Vulkan-CTS-runner-only
workflow, so it cannot be exercised locally; the YAML was validated as parsing,
and the change was reviewed against the GitHub Actions and PowerShell semantics
described above. The upload path will be exercised the next time the nightly
fails.
