### PR TITLE
.gitmodules: add branch = v2.1.7 for external/mimalloc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -67,3 +67,7 @@
 [submodule "external/mimalloc"]
 	path = external/mimalloc
 	url = https://github.com/microsoft/mimalloc.git
+	# The pinned commit (8c532c3, v2.1.7) is not reachable from microsoft/mimalloc's
+	# default branch (main3). It is reachable from the v2.1.7 tag, so this override
+	# is required: without it the pin check resolves the remote default and fails.
+	branch = v2.1.7


### PR DESCRIPTION
## Motivation

The submodule pin check (`extras/check-submodule-commits.sh`) verifies that each pinned commit is reachable from the submodule's tracked ref. When no `branch =` is set in `.gitmodules`, it resolves the **remote default branch**. microsoft/mimalloc's default branch is `main3`, and the pinned commit `8c532c32` (v2.1.7) is not reachable from it — it is only reachable via `refs/tags/v2.1.7`.

This caused the `check-submodules` CI job to fail for every merge queue entry since #12107 landed.

## Proposed solution

Add `branch = v2.1.7` to the mimalloc submodule entry so the check tests reachability from the tag instead of `main3`. The script already handles tag names as branch overrides (it tries both `refs/heads/<name>` and `refs/tags/<name>`). This is the same pattern already used for `external/fast_float` (`branch = v8.2.7`) and `external/lua` (`branch = v5.4`).

#12107's PR description correctly noted that the pin was reachable from `refs/tags/v2.1.7`, but the `branch =` line was not added to `.gitmodules`.

## Change summary

| File | Change |
|------|--------|
| `.gitmodules` | Add `branch = v2.1.7` to the `external/mimalloc` submodule entry with an explanatory comment. |

Fixes the CI regression introduced by #12107.