### PR TITLE
Clarify PR board sync assignment comments as automated

### DIFF
--- a/.github/scripts/pr-assign.test.js
+++ b/.github/scripts/pr-assign.test.js
@@ -178,7 +178,9 @@ test("formatAssignmentComment always notes assignee; suggestion has no @", () =>
       autoRequestedReviewer: "jkwak-work",
       autoRequestedHasSignal: true,
     }),
-    "**PR board sync:** auto-assigned @jkwak-work as shepherd for this Bot PR.",
+    "<!-- pr-board-sync-assignment -->\n" +
+      "**Automated notice** (PR board sync) — do not reply to this comment.\n\n" +
+      "Auto-assigned @jkwak-work as shepherd for this Bot PR.",
   );
   const withRequested = formatAssignmentComment({
     source: "Community",
@@ -187,14 +189,17 @@ test("formatAssignmentComment always notes assignee; suggestion has no @", () =>
     autoRequestedReviewer: "alice",
     autoRequestedHasSignal: true,
   });
+  assert.match(withRequested, /Automated notice.*do not reply to this comment/s);
   assert.match(
     withRequested,
-    /^\*\*PR board sync:\*\* auto-assigned @alice as shepherd for this Community PR\./,
+    /Auto-assigned @alice as shepherd for this Community PR\./,
   );
   assert.match(
     withRequested,
     /higher for skallweitNV than for the auto-requested reviewer \(alice\)/,
   );
+  assert.match(withRequested, /a human may optionally add them as a reviewer/);
+  assert.doesNotMatch(withRequested, /consider requesting/);
   assert.doesNotMatch(withRequested, /@skallweitNV/);
 
   const withoutRequested = formatAssignmentComment({
@@ -208,6 +213,7 @@ test("formatAssignmentComment always notes assignee; suggestion has no @", () =>
     withoutRequested,
     /highest for dev1 among collaborators other than the assignee/,
   );
+  assert.match(withoutRequested, /a human may optionally add them as a reviewer/);
   assert.doesNotMatch(withoutRequested, /@dev1/);
 
   // Auto-requested maintainer with no measured signal: do not claim they have

--- a/.github/workflows/pr-board-sync.md
+++ b/.github/workflows/pr-board-sync.md
@@ -109,7 +109,7 @@ merge-queued PRs.
 | Source              | Assignee             | Auto-requested reviewer                                      | Comment |
 | ------------------- | -------------------- | ------------------------------------------------------------ | ------- |
 | **Internal**        | PR author            | none                                                         | none |
-| **Community / Bot** | see pick order below | shepherd if they are not the PR author; otherwise none       | one-shot note naming the assignee; may suggest a higher-signal collaborator without `@` |
+| **Community / Bot** | see pick order below | shepherd if they are not the PR author; otherwise none       | one-shot automated notice naming the assignee (explicitly: do not reply); may FYI a higher-signal collaborator without `@` |
 
 **Pick order** (Community/Bot assignee / shepherd):
 
@@ -122,9 +122,10 @@ who may be chosen as shepherd. Auto-request is that shepherd only when they are
 not the PR author, not on the ignored-reviewers list, and no real reviewer is
 already requested. A collaborator with stronger committer signal than the
 auto-requested reviewer (or the top other collaborator when nobody was
-auto-requested) may be named in the assignment comment as a suggested
-additional reviewer, but is never `requestReviewers`'d — so they are not
-notified unless someone follows up.
+auto-requested) may be named in the assignment comment as an optional
+additional reviewer for a human to consider, but is never `requestReviewers`'d —
+so they are not notified unless someone follows up. The comment is labeled as an
+automated notice and asks recipients not to reply.
 
 **Community PRs** also co-assign the external author (separate API call, best-effort).
 

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -960,7 +960,9 @@ jobs:
             // Body for the one-shot comment posted when a Community/Bot PR is
             // first auto-assigned. Mentions the assignee (already notified by
             // GitHub's assign event) but never @-mentions the suggested
-            // reviewer, so the suggestion does not ping them.
+            // reviewer, so the suggestion does not ping them. Wording is
+            // informational only: clear that the note is automated and that
+            // recipients must not reply (so bot authors do not treat it as a task).
             // autoRequestedReviewer must be the login we actually intend to
             // requestReviewers (or null). autoRequestedHasSignal is true only
             // when that login appears in committersBySignal; otherwise we avoid
@@ -970,24 +972,27 @@ jobs:
               autoRequestedReviewer, autoRequestedHasSignal,
             }) {
               let body =
-                `**PR board sync:** auto-assigned @${assignee} as shepherd ` +
-                `for this ${source} PR.`;
+                `<!-- pr-board-sync-assignment -->\n` +
+                `**Automated notice** (PR board sync) — do not reply to this comment.\n\n` +
+                `Auto-assigned @${assignee} as shepherd for this ${source} PR.`;
               if (suggestedReviewer) {
                 if (autoRequestedReviewer && autoRequestedHasSignal) {
                   body +=
-                    `\n\nCommitter signal on the changed files is higher for ` +
-                    `${suggestedReviewer} than for the auto-requested reviewer ` +
-                    `(${autoRequestedReviewer}) — consider requesting a review ` +
-                    `from them as well. They were not auto-requested.`;
+                    `\n\nFYI for maintainers: committer signal on the changed ` +
+                    `files is higher for ${suggestedReviewer} than for the ` +
+                    `auto-requested reviewer (${autoRequestedReviewer}). They ` +
+                    `were not auto-requested; a human may optionally add them ` +
+                    `as a reviewer.`;
                 } else {
                   // Assignee (and author / auto-requested when present) were
                   // excluded from the pick, so this is highest among remaining
                   // eligible collaborators — not among all collaborators.
                   body +=
-                    `\n\nCommitter signal on the changed files is highest for ` +
-                    `${suggestedReviewer} among collaborators other than the ` +
-                    `assignee — consider requesting a review from them. They ` +
-                    `were not auto-requested.`;
+                    `\n\nFYI for maintainers: committer signal on the changed ` +
+                    `files is highest for ${suggestedReviewer} among ` +
+                    `collaborators other than the assignee. They were not ` +
+                    `auto-requested; a human may optionally add them as a ` +
+                    `reviewer.`;
                 }
               }
               return body;


### PR DESCRIPTION
## Motivation

On bot-authored PRs such as #12413, the PR board sync posts a one-shot shepherd assignment comment. The previous wording (“consider requesting a review…”) read like a human task, and the bot author replied at length even though no response was desired.

## Proposed solution

Reword the assignment notice so it is unmistakably automated and explicitly asks recipients not to reply. Soften the optional reviewer suggestion into an FYI for maintainers rather than an actionable request to the PR author.

Example after this change:

```text
<!-- pr-board-sync-assignment -->
**Automated notice** (PR board sync) — do not reply to this comment.

Auto-assigned @shepherd as shepherd for this Bot PR.

FYI for maintainers: committer signal on the changed files is higher for other-dev than for the auto-requested reviewer (shepherd). They were not auto-requested; a human may optionally add them as a reviewer.
```

## Change summary

| File | What changed |
| --- | --- |
| `.github/workflows/pr-board-sync.yml` | Update `formatAssignmentComment` header and suggestion wording |
| `.github/scripts/pr-assign.test.js` | Cover the new automated / do-not-reply wording |
| `.github/workflows/pr-board-sync.md` | Document the notice policy |

## Concepts and vocabulary

- **Shepherd** — the Community/Bot PR owner assignee chosen by board sync.
- **Assignment comment** — the one-shot note posted only when that owner is first auto-assigned.

## Process report

Consider this example from #12413: board sync auto-assigned a shepherd and mentioned a higher-signal collaborator with “consider requesting a review from them as well.” The bot PR author treated that as a request directed at it and posted a long reply explaining it could not act.

The comment text is produced only by `formatAssignmentComment` in the default-branch `pr-board-sync` workflow. Changing that producer is the right layer: consumers (humans and bot authors) should not need special-case ignore rules for an ambiguous notice. The new header states the comment is automated and says “do not reply to this comment,” and the suggestion body is framed as “FYI for maintainers” / “a human may optionally add them,” so it no longer sounds like an instruction to the PR author.

Input-shape check: the comment body is intentional workflow output, not a malformed shape from an upstream producer. Handling belongs here.

## Test plan

- [x] `node .github/scripts/pr-assign.test.js` (15 passed)
- [ ] Confirm the next Community/Bot PR auto-assign posts the new wording