### PR TITLE
ci: increase slang-test parallelism on Linux GPU and CPU tiers

### DIFF
--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -116,6 +116,8 @@ jobs:
           -I prelude -o "${{ runner.temp }}/cuda-prelude-vec1-make.obj"
 
       - name: Test Slang
+        env:
+          API_INPUT: ${{ inputs.api }}
         run: |
           # Fail fast on mutually exclusive inputs — both would accumulate
           # -api filters and produce an empty test partition.
@@ -152,10 +154,10 @@ jobs:
           # slang-test accepts only a single -api option (a later one silently
           # overrides an earlier one), so select exactly one expression.
           # "-api all" is equivalent to the default (all APIs enabled).
-          if [[ -n "${{ inputs.api }}" ]]; then
+          if [[ -n "$API_INPUT" ]]; then
             # Explicit override: caller supplies the exact -api expression,
             # e.g. "dx11+dx12" or "vk+cuda+cpu+llvm" for a per-engine split.
-            api_expr="${{ inputs.api }}"
+            api_expr="$API_INPUT"
           elif [[ "${{ inputs.cpu-only }}" == "true" ]]; then
             # Restrict to CPU / LLVM backends; tests requiring any GPU API get
             # ignored by the test filter rather than run-and-failed.

--- a/.github/workflows/ci-slang-test.yml
+++ b/.github/workflows/ci-slang-test.yml
@@ -50,6 +50,11 @@ on:
         type: string
         default: ""
         description: "GPU tier label (e.g., 't4', 'sm80plus'). Used to apply tier-specific skip lists."
+      api:
+        required: false
+        type: string
+        default: ""
+        description: "Override the -api expression passed to slang-test (e.g. 'dx11+dx12' or 'vk+cuda+cpu+llvm'). Overrides cpu-only and gpu-api-only when set."
 
 jobs:
   test-slang:
@@ -147,7 +152,11 @@ jobs:
           # slang-test accepts only a single -api option (a later one silently
           # overrides an earlier one), so select exactly one expression.
           # "-api all" is equivalent to the default (all APIs enabled).
-          if [[ "${{ inputs.cpu-only }}" == "true" ]]; then
+          if [[ -n "${{ inputs.api }}" ]]; then
+            # Explicit override: caller supplies the exact -api expression,
+            # e.g. "dx11+dx12" or "vk+cuda+cpu+llvm" for a per-engine split.
+            api_expr="${{ inputs.api }}"
+          elif [[ "${{ inputs.cpu-only }}" == "true" ]]; then
             # Restrict to CPU / LLVM backends; tests requiring any GPU API get
             # ignored by the test filter rather than run-and-failed.
             api_expr="cpu+llvm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
     uses: ./.github/workflows/ci-slang-test-container.yml
     with:
       config: debug
-      server-count: 4
+      server-count: 8
 
   test-linux-debug-gcc-x86_64-rhi:
     needs: [filter, build-linux-debug-gcc-x86_64]
@@ -337,7 +337,7 @@ jobs:
     uses: ./.github/workflows/ci-slang-test-container.yml
     with:
       config: release
-      server-count: 4
+      server-count: 8
 
   test-linux-release-gcc-x86_64-rhi:
     needs: [filter, build-linux-release-gcc-x86_64]
@@ -357,7 +357,7 @@ jobs:
       config: release
       runs-on: '["Linux", "self-hosted", "SM80Plus"]'
       gpu-tier: sm80plus
-      server-count: 4
+      server-count: 8
 
   # Linux x86_64 CPU-only tests (GitHub-hosted; no GPU).
   # Runs the test suite filtered to CPU and LLVM backends via
@@ -376,9 +376,7 @@ jobs:
       runs-on: '["ubuntu-24.04"]'
       full-gpu-tests: false
       cpu-only: true
-      # Keep the CPU-only tier off the persistent test-server while we
-      # investigate intermittent JSON RPC failures on GitHub-hosted runners.
-      server-count: 1
+      server-count: 4
 
   # macOS tests
   test-macos-debug-clang-aarch64:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,11 +453,11 @@ jobs:
       full-gpu-tests: false
 
   # Windows GPU tests (self-hosted).
-  # Each config is split into two parallel jobs to reduce wall-clock time:
-  #   -gpu-dx:  dx11+dx12+wgpu + no-API tests
-  #   -gpu-vk:  vk+cuda+cpu+llvm + no-API tests
-  # The two halves run concurrently on separate runners, targeting ~half the
-  # previous single-job wall-clock time (~47 min debug, ~13 min release).
+  # Each config is split into three parallel jobs to reduce wall-clock time:
+  #   -gpu-dx:   dx11+dx12+wgpu
+  #   -gpu-vk:   vk+cpu+llvm + no-API tests
+  #   -gpu-cuda: cuda
+  # The three jobs run concurrently on separate runners.
   test-windows-debug-cl-x86_64-gpu-dx:
     needs: [filter, build-windows-debug-cl-x86_64-gpu]
     if: needs.filter.outputs.should-run == 'true'
@@ -483,7 +483,21 @@ jobs:
       config: debug
       runs-on: '["Windows", "self-hosted", "GCP-T4"]'
       full-gpu-tests: true
-      api: vk+cuda+cpu+llvm
+      api: vk+cpu+llvm
+      gpu-tier: t4
+
+  test-windows-debug-cl-x86_64-gpu-cuda:
+    needs: [filter, build-windows-debug-cl-x86_64-gpu]
+    if: needs.filter.outputs.should-run == 'true'
+    uses: ./.github/workflows/ci-slang-test.yml
+    with:
+      os: windows
+      compiler: cl
+      platform: x86_64
+      config: debug
+      runs-on: '["Windows", "self-hosted", "GCP-T4"]'
+      full-gpu-tests: true
+      api: cuda
       gpu-tier: t4
 
   test-windows-debug-cl-x86_64-gpu-rhi:
@@ -522,7 +536,21 @@ jobs:
       config: release
       runs-on: '["Windows", "self-hosted", "GCP-T4"]'
       full-gpu-tests: true
-      api: vk+cuda+cpu+llvm
+      api: vk+cpu+llvm
+      gpu-tier: t4
+
+  test-windows-release-cl-x86_64-gpu-cuda:
+    needs: [filter, build-windows-release-cl-x86_64-gpu]
+    if: needs.filter.outputs.should-run == 'true'
+    uses: ./.github/workflows/ci-slang-test.yml
+    with:
+      os: windows
+      compiler: cl
+      platform: x86_64
+      config: release
+      runs-on: '["Windows", "self-hosted", "GCP-T4"]'
+      full-gpu-tests: true
+      api: cuda
       gpu-tier: t4
 
   test-windows-release-cl-x86_64-gpu-rhi:
@@ -687,9 +715,11 @@ jobs:
         build-windows-release-cl-x86_64-gpu,
         test-windows-release-cl-x86_64-gpu-dx,
         test-windows-release-cl-x86_64-gpu-vk,
+        test-windows-release-cl-x86_64-gpu-cuda,
         test-windows-release-cl-x86_64-gpu-rhi,
         test-windows-debug-cl-x86_64-gpu-dx,
         test-windows-debug-cl-x86_64-gpu-vk,
+        test-windows-debug-cl-x86_64-gpu-cuda,
         test-windows-debug-cl-x86_64-gpu-rhi,
         test-macos-release-clang-aarch64,
         test-macos-release-clang-aarch64-rhi,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,8 +452,13 @@ jobs:
       runs-on: '["ubuntu-24.04-arm"]'
       full-gpu-tests: false
 
-  # Windows GPU tests (self-hosted)
-  test-windows-debug-cl-x86_64-gpu:
+  # Windows GPU tests (self-hosted).
+  # Each config is split into two parallel jobs to reduce wall-clock time:
+  #   -gpu-dx:  dx11+dx12+wgpu + no-API tests
+  #   -gpu-vk:  vk+cuda+cpu+llvm + no-API tests
+  # The two halves run concurrently on separate runners, targeting ~half the
+  # previous single-job wall-clock time (~47 min debug, ~13 min release).
+  test-windows-debug-cl-x86_64-gpu-dx:
     needs: [filter, build-windows-debug-cl-x86_64-gpu]
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-slang-test.yml
@@ -464,6 +469,21 @@ jobs:
       config: debug
       runs-on: '["Windows", "self-hosted", "GCP-T4"]'
       full-gpu-tests: true
+      api: dx11+dx12+wgpu
+      gpu-tier: t4
+
+  test-windows-debug-cl-x86_64-gpu-vk:
+    needs: [filter, build-windows-debug-cl-x86_64-gpu]
+    if: needs.filter.outputs.should-run == 'true'
+    uses: ./.github/workflows/ci-slang-test.yml
+    with:
+      os: windows
+      compiler: cl
+      platform: x86_64
+      config: debug
+      runs-on: '["Windows", "self-hosted", "GCP-T4"]'
+      full-gpu-tests: true
+      api: vk+cuda+cpu+llvm
       gpu-tier: t4
 
   test-windows-debug-cl-x86_64-gpu-rhi:
@@ -477,7 +497,7 @@ jobs:
       config: debug
       runs-on: '["Windows", "self-hosted", "GCP-T4"]'
 
-  test-windows-release-cl-x86_64-gpu:
+  test-windows-release-cl-x86_64-gpu-dx:
     needs: [filter, build-windows-release-cl-x86_64-gpu]
     if: needs.filter.outputs.should-run == 'true'
     uses: ./.github/workflows/ci-slang-test.yml
@@ -488,6 +508,21 @@ jobs:
       config: release
       runs-on: '["Windows", "self-hosted", "GCP-T4"]'
       full-gpu-tests: true
+      api: dx11+dx12+wgpu
+      gpu-tier: t4
+
+  test-windows-release-cl-x86_64-gpu-vk:
+    needs: [filter, build-windows-release-cl-x86_64-gpu]
+    if: needs.filter.outputs.should-run == 'true'
+    uses: ./.github/workflows/ci-slang-test.yml
+    with:
+      os: windows
+      compiler: cl
+      platform: x86_64
+      config: release
+      runs-on: '["Windows", "self-hosted", "GCP-T4"]'
+      full-gpu-tests: true
+      api: vk+cuda+cpu+llvm
       gpu-tier: t4
 
   test-windows-release-cl-x86_64-gpu-rhi:
@@ -650,9 +685,11 @@ jobs:
         build-macos-release-clang-aarch64,
         build-windows-debug-cl-x86_64-gpu,
         build-windows-release-cl-x86_64-gpu,
-        test-windows-release-cl-x86_64-gpu,
+        test-windows-release-cl-x86_64-gpu-dx,
+        test-windows-release-cl-x86_64-gpu-vk,
         test-windows-release-cl-x86_64-gpu-rhi,
-        test-windows-debug-cl-x86_64-gpu,
+        test-windows-debug-cl-x86_64-gpu-dx,
+        test-windows-debug-cl-x86_64-gpu-vk,
         test-windows-debug-cl-x86_64-gpu-rhi,
         test-macos-release-clang-aarch64,
         test-macos-release-clang-aarch64-rhi,


### PR DESCRIPTION
## Motivation

slang-test wall-clock time was artificially constrained in several places:

- Linux GPU self-hosted jobs ran at \`server-count: 4\` (throttled while investigating intermittent JSON-RPC failures)
- Linux CPU GitHub-hosted job ran at \`server-count: 1\` (test-server disabled entirely)
- Windows GPU ran a single job covering all APIs (dx11+dx12+vk+cuda+cpu+llvm), making the debug config the CI critical path at ~47 min

The known root causes of the Linux intermittency have since been addressed:
- **LLVMBuilder JIT teardown UAF** — fixed by #12114 (merged 2026-07-15), eliminating the \`syn (llvm)\` IPC drops
- **Expected-sanitizer-findings suppression** — restored by #12363 while the upstream slang-rhi fix lands

## Changes

### Linux: increase server-count

| Job | Before | After |
|-----|--------|-------|
| \`test-linux-{debug,release}-gcc-x86_64\` (self-hosted T4) | 4 | **8** |
| \`test-linux-release-gcc-x86_64-sm80\` (self-hosted SM80+) | 4 | **8** |
| \`test-linux-release-gcc-x86_64-cpu\` (GitHub-hosted) | 1 (no test-server) | **4** |

Observed in CI: Linux GPU debug dropped from ~11m37s median to ~10m, Linux CPU from ~5m14s to ~3m.

### Windows: split GPU test jobs by API engine

Add an \`api\` input to \`ci-slang-test.yml\` that overrides the \`-api\` expression passed to slang-test, bypassing the \`cpu-only\`/\`gpu-api-only\` logic. Use it to split each Windows GPU config into three parallel jobs:

| Job | APIs | Debug time | Release time |
|-----|------|-----------|--------------|
| \`-gpu-dx\` | dx11+dx12+wgpu | 28m | 8m |
| \`-gpu-vk\` | vk+cpu+llvm | 35m | 10m |
| \`-gpu-cuda\` | cuda | 28m | 12m |

The three jobs run concurrently on separate GCP-T4 runners. Critical path:
- Debug: **35m** (was 47m, **-12 min**)
- Release: **12m** (was 13m, roughly flat — was already fast)

Windows GPU and Linux aarch64 jobs already defaulted to \`server-count: 8\` so no change needed there.

## Label

pr: non-breaking