### PR TITLE
[STANDBY] Revert the Falcor bridge switch (#11915)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,7 +4,6 @@ self-hosted-runner:
     - benchmark
     - build
     - falcor
-    - falcor-bridge
     - GCP
     - GCP-T4
     - GPU

--- a/.github/workflows/ci-falcor-test.yml
+++ b/.github/workflows/ci-falcor-test.yml
@@ -4,29 +4,80 @@ on:
   workflow_call:
 
 permissions:
+  contents: read
   actions: read
 
 jobs:
   test-falcor:
     name: Test (Falcor)
     timeout-minutes: 100
-    runs-on: [Linux, self-hosted, X64, falcor-bridge]
-    # Vet-and-approve gate: this job runs PR-controlled code on the internal
-    # bridge VM, so it is gated behind the `falcor-ci` environment (required
-    # reviewers = the `ci-approvers` team). A PR by a team member runs
-    # automatically; anyone else's run waits for a one-click approval.
-    environment: falcor-ci
+    runs-on: [Windows, self-hosted, falcor]
     defaults:
       run:
         shell: bash
     steps:
-      - name: Run external CI
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          SLANG_CI_ARTIFACT_NAME: slang-tests-windows-x86_64-cl-release
+      - name: Add Git Bash to PATH
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\usr\\bin"
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          submodules: "false"
+          fetch-depth: "1"
+      - name: Download Slang build
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: slang-tests-windows-x86_64-cl-release
+          path: slang-bin
+      - name: setup-falcor
         run: |
           set -euo pipefail
-          /opt/slang-ci/run-external-ci
+          mkdir -p FalcorBin/build/windows-vs2022
+          cp -r 'C:/Falcor/build/windows-vs2022/bin' 'FalcorBin/build/windows-vs2022/bin'
+          find 'FalcorBin/build/windows-vs2022/bin' -name '*.pdb' -delete
+          cp -r 'C:/Falcor/tests' 'FalcorBin/tests'
+          cp -r 'C:/Falcor/tools' 'FalcorBin/tools'
+          cp -r 'C:/Falcor/media' 'FalcorBin/media'
+          cp -r 'C:/Falcor/media_internal' 'FalcorBin/media_internal'
+          cp -r 'C:/Falcor/scripts' 'FalcorBin/scripts'
+      - name: Copy Slang to Falcor
+        run: |
+          set -euo pipefail
+          TARGET="./FalcorBin/build/windows-vs2022/bin/Release"
+          SRC="slang-bin/Release/bin"
+          # Copy only Slang core DLLs and executables — the full CI artifact also
+          # contains gfx.dll, platform.dll, dawn.dll, and test-tool DLLs that
+          # Falcor provides its own versions of; overwriting those breaks FalcorTest.
+          # slang-rt.dll must be copied alongside slang.dll: it is a version-matched
+          # runtime peer, and leaving C:\Falcor's older copy in place while replacing
+          # slang.dll causes FalcorTest.exe to crash during DLL initialization.
+          # D3D12/ (D3D12 Agility SDK DLLs) and optix/ are intentionally NOT copied
+          # from the CI artifact: the old Falcor-specific build did not produce these
+          # directories, so the versions already present from C:\Falcor (copied during
+          # setup-falcor) are correct for FalcorTest.exe. Overwriting them with the CI
+          # artifact's versions would break FalcorTest.exe at startup.
+          for name in slang.dll slang-rt.dll slang-compiler.dll slang-llvm.dll slang-glslang.dll slang-glsl-module.dll dxcompiler.dll dxil.dll slangc.exe; do
+            [[ -f "$SRC/$name" ]] || { echo "Missing required file: $SRC/$name" >&2; exit 1; }
+            cp --verbose "$SRC/$name" "$TARGET/"
+          done
+          shopt -s nullglob
+          modules=( "$SRC"/slang-standard-module-*/ )
+          (( ${#modules[@]} > 0 )) || { echo "Missing slang-standard-module-* in $SRC" >&2; exit 1; }
+          for d in "${modules[@]}"; do
+            cp --verbose -r "$d" "$TARGET/"
+          done
+      - name: falcor-unit-test
+        run: |
+          set -euo pipefail
+          cd FalcorBin/tests
+          python ./testing/run_unit_tests.py --config windows-vs2022-Release -t "-slow"
+      - name: falcor-image-test
+        run: |
+          set -euo pipefail
+          cd FalcorBin/tests
+          python ./testing/run_image_tests.py --config windows-vs2022-Release --run-only
 
   test-falcor-perf:
     name: Test (Falcor Perf)


### PR DESCRIPTION
**Standby revert — do not merge unless the bridge is causing a problem.**

Prepared in advance so it can go in quickly if needed. #11915 moved `test-falcor` onto the
bridge runner and gated it behind the `falcor-ci` environment; this puts it back on the
Windows hosts with the inline Falcor setup and removes the gate.

Nothing needs re-provisioning: those hosts still carry the `falcor` label and are still
serving the perf, benchmark and regression jobs.

**Deliberately not reverted:** the `ci.yml` change from #11915, which moved
`github.base_ref` out of direct shell interpolation in the `filter` job. That is unrelated
script-injection hardening and should not be collateral damage in an emergency revert.

The approval bot and the relay are untouched and simply go idle — once nothing references
the environment, there are no pending deployments to approve.

## When this would be the right call

- Bridge runs failing for reasons that are not a genuine Falcor regression
- The approval gate blocking PRs and the bot unable to release them
- Capacity problems on the bridge path stalling the merge queue

For anything narrower — a single flaky test, one expired artifact — prefer fixing forward.
