### PR TITLE
ci: give test-falcor room for the approval gate, and fix its comment

### DIFF
--- a/.github/workflows/ci-falcor-test.yml
+++ b/.github/workflows/ci-falcor-test.yml
@@ -9,12 +9,20 @@ permissions:
 jobs:
   test-falcor:
     name: Test (Falcor)
-    timeout-minutes: 100
+    # The Falcor run itself takes ~45 minutes, and this job also waits for the
+    # deployment gate below and for a runner. 100 minutes was set before the
+    # gate existed and leaves little room for an approval that arrives out of
+    # hours. A timeout here also surfaces as a failed Falcor test rather than
+    # as "nobody has approved it yet", which sends people looking in the wrong
+    # place.
+    timeout-minutes: 180
     runs-on: [Linux, self-hosted, X64, falcor-bridge]
     # Vet-and-approve gate: this job runs PR-controlled code on the internal
     # bridge VM, so it is gated behind the `falcor-ci` environment (required
-    # reviewers = the `ci-approvers` team). A PR by a team member runs
-    # automatically; anyone else's run waits for a one-click approval.
+    # reviewers = the `ci-approvers` team). Every run waits for an approval --
+    # including team members' own PRs and merge-queue runs, because environment
+    # protection cannot be scoped to particular actors. Approvals are normally
+    # granted automatically; anything unrecognised waits for a person.
     environment: falcor-ci
     defaults:
       run:

--- a/.github/workflows/ci-falcor-test.yml
+++ b/.github/workflows/ci-falcor-test.yml
@@ -9,12 +9,13 @@ permissions:
 jobs:
   test-falcor:
     name: Test (Falcor)
-    # The Falcor run itself takes ~45 minutes, and this job also waits for the
-    # deployment gate below and for a runner. 100 minutes was set before the
-    # gate existed and leaves little room for an approval that arrives out of
-    # hours. A timeout here also surfaces as a failed Falcor test rather than
-    # as "nobody has approved it yet", which sends people looking in the wrong
-    # place.
+    # This job hands the build to separate compute and waits for a pass/fail
+    # result, so its execution time is however long the Falcor run takes --
+    # ~45 minutes today, plus however long that run queues for a GPU host on
+    # the far side. Waiting for the deployment gate below does not count: the
+    # clock starts when the job begins executing on a runner. 100 minutes left
+    # only one Falcor run plus a short queue, which is thin for a job whose
+    # duration is set elsewhere.
     timeout-minutes: 180
     runs-on: [Linux, self-hosted, X64, falcor-bridge]
     # Vet-and-approve gate: this job runs PR-controlled code on the internal


### PR DESCRIPTION
Two small corrections to `test-falcor` after the bridge switch (#11915).

**`timeout-minutes` 100 → 180.** The Falcor run takes ~45 minutes, and the job now also waits
for the deployment gate and for a runner. It is not settled whether GitHub counts gate-waiting
against the timeout — but either way 100 was set before the gate existed, and it leaves little
room for an approval that arrives out of hours.

The failure mode argues for it on its own: a timeout presents as a **failed Falcor test**, so
someone investigating starts by looking at Falcor rather than at an unapproved deployment.

**Fix the comment above `environment:`.** It claimed a team member's PR runs automatically and
only other people wait. That is wrong on both counts — environment protection cannot be scoped
to particular actors, so *every* run waits, including team members' own PRs and merge-queue
runs. The latter has already blocked a PR in the queue.

`test-falcor-perf` is untouched: it is not gated and does not need the headroom.
