### PR TITLE
tests _meta: refresh coverage excludes and lint them for staleness

### DIFF
--- a/.github/workflows/ci-slang-coverage-test.yml
+++ b/.github/workflows/ci-slang-coverage-test.yml
@@ -267,8 +267,9 @@ jobs:
             # syn (mtl) — a different test each time, and both pass in isolation, so it
             # is order-dependent and cannot be pinned to a small exclude list (there are
             # ~189 explicit `-mtl` test files). Subtracting the API is the only way to
-            # keep the macOS coverage job producing a report. Tracked upstream; restore
-            # Metal here once that assert is fixed.
+            # keep the macOS coverage job producing a report. Tracked in
+            # https://github.com/shader-slang/slang-rhi/issues/818; restore Metal here
+            # once that assert is fixed.
             test_args+=("-synthesizedTestApi" "-llvm-mtl")
             test_args+=("-api" "-mtl")
           fi

--- a/.github/workflows/ci-slang-coverage-test.yml
+++ b/.github/workflows/ci-slang-coverage-test.yml
@@ -258,7 +258,19 @@ jobs:
             # under coverage instrumentation (for example, parameter-block.slang.6
             # syn (llvm)). Keep explicit LLVM tests and the compile-target synthesis
             # pass, but do not synthesize extra LLVM runtime variants in coverage CI.
-            test_args+=("-synthesizedTestApi" "-llvm")
+            #
+            # Metal is dropped for the same reason: slang-rhi aborts on
+            # `SLANG_RHI_ASSERT(index < m_size)` in src/core/short_vector.h, which kills
+            # the whole slang-test process and the job with it (exit 134). It took out
+            # run 31142891787 on tests/compute/parameter-block.slang.4 (mtl) and run
+            # 31290797198 on tests/language-feature/tuple/tuple-parameter.slang.4
+            # syn (mtl) — a different test each time, and both pass in isolation, so it
+            # is order-dependent and cannot be pinned to a small exclude list (there are
+            # ~189 explicit `-mtl` test files). Subtracting the API is the only way to
+            # keep the macOS coverage job producing a report. Tracked upstream; restore
+            # Metal here once that assert is fixed.
+            test_args+=("-synthesizedTestApi" "-llvm-mtl")
+            test_args+=("-api" "-mtl")
           fi
 
           # Add test server arguments if server count > 1

--- a/docs/generated/tests/_meta/PIPELINE.md
+++ b/docs/generated/tests/_meta/PIPELINE.md
@@ -117,6 +117,18 @@ how that doc's claims were extracted. Shared prompts —
   defects (the audit trail from "agent saw this" to "issue filed").
 - **`_meta/expected-failures.txt`** — tests that fail because of a filed
   (or pending) compiler bug, kept out of the CI failure gate.
+- **`_meta/agentic-coverage-excludes.txt`** — the narrower list of tests
+  the *coverage* run must not execute at all. `nightly-slang-coverage-test.yml`
+  runs the suite in-process (`-server-count 1`, no test server) so that the
+  compiler's own lines are instrumented, which means a test that segfaults
+  `slangc` segfaults `slang-test` and the rest of the suite never runs —
+  `expected-failures.txt` cannot catch that, because there is no surviving
+  process to report a result. Whenever a coverage run reports
+  `agentic-test pass crashed`, take the test that sorts immediately after the
+  last one it printed, add it here with the run URL, and file the crash as a
+  finding. `regenerate.py lint` fails on an entry whose path no longer
+  resolves, since a stale entry excludes nothing and silently re-arms the
+  crash.
 - **`INDEX.md`** — regenerated bundle index (`regenerate.py index --write`).
 - **The nightly CI signal** — `slang-test -test-dir docs/generated/tests`
   runs the whole suite; it is additive and does not gate per-PR.

--- a/docs/generated/tests/_meta/agentic-coverage-excludes.txt
+++ b/docs/generated/tests/_meta/agentic-coverage-excludes.txt
@@ -25,12 +25,27 @@
 # the last-printed test before the crash), so a future maintainer
 # can verify whether the underlying issue is still present.
 #
+# Reading a crash out of a coverage run
+# -------------------------------------
+# The agentic pass runs sequentially and in-process (`-server-count 1`,
+# no `-use-test-server`), so a compiler SIGSEGV is a slang-test SIGSEGV.
+# slang-test walks the suite in sorted path order and prints each result
+# as it finishes, which makes the crashing test the one that comes
+# immediately AFTER the last `passed test:`/`failed... test:` line before
+# the `Segmentation fault`/`Bus error` message — it never gets to print
+# its own result. Take that next path, add it here, and record the run
+# URL plus the last-printed test in the comment block.
+#
 # Staleness signal
 # ----------------
-# Unlike `-expected-failure-list`, `-exclude-prefix` has no
-# "passing tests that are expected to fail" reporter, so entries
-# here can rot silently once the underlying crash is fixed. To
-# audit the list periodically:
+# `regenerate.py lint` checks that every path below still resolves on
+# disk, so an entry orphaned by a regeneration round that renames or
+# moves its test now fails the lint in nightly-slang-test.yml instead of
+# silently excluding nothing. That catches the rename direction only.
+#
+# In the other direction, `-exclude-prefix` has no "passing tests that
+# are expected to fail" reporter, so entries here can still rot silently
+# once the underlying crash is fixed. To audit the list periodically:
 #   1. Compile slang with coverage instrumentation locally.
 #   2. Remove an entry below and run
 #      `./tools/coverage/run-coverage.sh --with-agentic-tests`
@@ -39,25 +54,43 @@
 #   3. If the run completes without a SIGSEGV in slang-test, the
 #      underlying crash has been fixed — drop the entry for real.
 # A green nightly-slang-test.yml run on the same test is a
-# necessary but NOT sufficient condition: the nightly uses an
-# uninstrumented binary, and the crash here is
-# coverage-instrumentation-specific.
+# necessary but NOT sufficient condition. Two things differ there:
+# the binary is uninstrumented, and the test runs in a subprocess
+# test server, so a crash is reported as a failure rather than
+# taking the orchestrator with it. Entries here fall into both
+# camps — some crash only under coverage instrumentation, others
+# (e.g. the `unorm`/`snorm` pair) crash plain `slangc` too and are
+# merely *survivable* in the nightly because of that isolation.
 
-# Run 26813684019 (sequential reproducer with -server-count 1):
-# SIGSEGV in slang-test immediately after
-# ir-reference/metadata/type-layout-base.slang passes. The same
-# test is already listed in expected-failures.txt (it fails on the
-# uninstrumented Linux nightly); coverage instrumentation
-# escalates that failure into a SIGSEGV inside the slang-test
-# orchestrator, which kills the rest of the suite.
+# `unorm`/`snorm` on a non-texture carrier SIGSEGVs slangc on Linux.
+# Tracked by _meta/findings/metadata-unorm-structured-buffer-element-sigsegv.yaml
+# and _meta/findings/ir-types-unorm-snorm-struct-field-sigsegv.yaml (both
+# `Attributed(Float, ...)` reached from a module-scope uniform; likely one
+# root cause). Both tests are in expected-failures.txt, so the subprocess
+# nightly buckets them as failed(expected); only the in-process coverage
+# pass turns them into an orchestrator SIGSEGV.
 #
-# Path note: PR #11421 reorganized the agentic suite under
-# `docs/generated/tests/design/...` and `.../conformance/...`. The
-# entry below uses the post-reorg path; the pre-reorg form
-# `docs/generated/tests/ir-reference/...` no longer matches anything
-# and silently disabled the exclude until run 26992984934 reproduced
-# the crash and surfaced the staleness.
-docs/generated/tests/design/ir-reference/metadata/unorm-attr-on-buffer-element.slang
+# Identified in coverage run 31235323797, job 93046595145 (linux):
+# `Segmentation fault (core dumped)` on both attempts immediately after
+# ir-reference/metadata/unorm-attr-on-rwtexture-element.slang passed, i.e.
+# on the next test in sorted order, unorm-attr-on-structured-buffer-element.
+# The whole tail of the suite (the rest of ir-reference, pipeline,
+# syntax-reference, target-pipelines) never ran and produced no coverage.
+#
+# Path note: this entry used to read
+# `.../metadata/unorm-attr-on-buffer-element.slang`. The 2026-08-04
+# regeneration round (source_commit 7e725f1) split that bundle's unorm
+# test into an rwtexture case and a structured-buffer case, which orphaned
+# the entry and re-enabled the crash — the same silent-rot failure mode
+# PR #11421's directory move caused earlier. `regenerate.py lint` now
+# fails on an exclude path that does not resolve.
+#
+# attributed-type-unorm-snorm.slang is excluded pre-emptively: the coverage
+# suite died in `metadata` before reaching `types`, so it has not been
+# observed crashing a coverage run, but its finding records the same exit
+# 139 on `-target hlsl` and it sits in the untested tail.
+docs/generated/tests/design/ir-reference/metadata/unorm-attr-on-structured-buffer-element.slang
+docs/generated/tests/design/ir-reference/types/attributed-type-unorm-snorm.slang
 
 # Local coverage reproducer (RelWithDebInfo + -fprofile-instr-generate,
 # sequential -server-count 1): SIGSEGV in slang-test immediately after
@@ -74,6 +107,23 @@ docs/generated/tests/design/ir-reference/metadata/unorm-attr-on-buffer-element.s
 # still buckets it as failed(expected) via expected-failures.txt.
 docs/generated/tests/design/ir-reference/misc/string-hash-stable-value-cpu.slang
 
+# `getStringHash` on a String that does not fold to a literal SIGSEGVs
+# slangc during compilation instead of reporting E41023; tracked by
+# _meta/findings/getstringhash-nonliteral-argument-sigsegv.yaml. This is a
+# distinct crash from string-hash-stable-value-cpu.slang above (that one
+# dies while *executing* a CPU kernel whose argument IS a literal).
+#
+# Identified in coverage run 31235323797, job 93046595167 (macos):
+# `Bus error: 10` on both attempts immediately after
+# ir-reference/misc/string-hash-fold-emitted-constant.slang.6 passed, i.e.
+# on the next test in sorted order. Confirmed locally on macOS aarch64 —
+# `slangc string-hash-non-literal-diagnostic.slang -target hlsl -entry main
+# -stage compute` exits 138 (128 + SIGBUS). The test arrived in the
+# 2026-08-04 regeneration round and sorts between .6 and the already-listed
+# string-hash-stable-value-cpu.slang, so it became the new first crasher in
+# this directory.
+docs/generated/tests/design/ir-reference/misc/string-hash-non-literal-diagnostic.slang
+
 # In-process HLSL-prelude state leak (NOT a crash). These four tests assert
 # that emitted HLSL contains the standard prelude's NVAPI guard
 # (`#ifdef SLANG_HLSL_ENABLE_NVAPI` / `#include "nvHLSLExtns.h"`). They pass
@@ -89,7 +139,19 @@ docs/generated/tests/design/ir-reference/misc/string-hash-stable-value-cpu.slang
 # nightly). This is a pre-existing in-process compiler/session-state leak in the
 # CPU host-callable downstream path; the exclude is a coverage-stability hack
 # until that leak is fixed. Identified locally 2026-07-09.
-docs/generated/tests/design/pipeline/06-emit/preludes-included-by-c-and-cuda.slang
+#
+# Update 2026-08-09: the three `target-pipelines/hlsl` tests below now fail on
+# nightly-slang-test.yml too (run 31294644845, which uses `-use-test-server
+# -server-count 4`), so the "they pass in the nightly" half of the paragraph
+# above no longer holds and the leak is probably not in-process-only. That is a
+# nightly problem to triage on its own; the excludes stay because the coverage
+# pass still cannot distinguish the failure from a real one.
+#
+# Path note: the first entry used to read
+# `.../06-emit/preludes-included-by-c-and-cuda.slang`. The 2026-08-04
+# regeneration round renamed it to `preludes-included-by-cuda-cpp-and-hlsl.slang`
+# (the bundle grew an HLSL directive), orphaning the entry.
+docs/generated/tests/design/pipeline/06-emit/preludes-included-by-cuda-cpp-and-hlsl.slang
 docs/generated/tests/design/target-pipelines/hlsl/nvapi-guard-present-without-nv-intrinsic.slang
 docs/generated/tests/design/target-pipelines/hlsl/nvapi-guard-with-wave-intrinsic.slang
 docs/generated/tests/design/target-pipelines/hlsl/prelude-nvapi-include-conditional.slang

--- a/docs/generated/tests/_meta/agentic-coverage-excludes.txt
+++ b/docs/generated/tests/_meta/agentic-coverage-excludes.txt
@@ -124,28 +124,25 @@ docs/generated/tests/design/ir-reference/misc/string-hash-stable-value-cpu.slang
 # this directory.
 docs/generated/tests/design/ir-reference/misc/string-hash-non-literal-diagnostic.slang
 
-# In-process HLSL-prelude state leak (NOT a crash). These four tests assert
-# that emitted HLSL contains the standard prelude's NVAPI guard
-# (`#ifdef SLANG_HLSL_ENABLE_NVAPI` / `#include "nvHLSLExtns.h"`). They pass
-# in isolation and in nightly-slang-test.yml, but FAIL in the coverage agentic
-# pass because it runs sequentially IN-PROCESS (`-server-count 1`) reusing one
-# GlobalSession: a preceding `//TEST:COMPARE_COMPUTE(...):-cpu` test poisons the
-# shared session so the NEXT `-target hlsl` compile omits the HLSL prelude
-# entirely (reproduced: a single `-cpu` compute test before an nvapi test drops
-# the guard; a non-cpu HLSL-emit test before it does not). Because many `-cpu`
-# tests exist throughout the suite there is no single "leaker" to exclude, and
-# the tests themselves are correct — so they are neither weakened nor added to
-# expected-failures.txt (that would wrongly fail them on the subprocess-isolated
-# nightly). This is a pre-existing in-process compiler/session-state leak in the
-# CPU host-callable downstream path; the exclude is a coverage-stability hack
-# until that leak is fixed. Identified locally 2026-07-09.
+# HLSL-prelude state leak (NOT a crash). These four tests assert that emitted
+# HLSL contains the standard prelude's NVAPI guard
+# (`#ifdef SLANG_HLSL_ENABLE_NVAPI` / `#include "nvHLSLExtns.h"`). All four pass
+# in isolation and fail here, because a preceding
+# `//TEST:COMPARE_COMPUTE(...):-cpu` test poisons the session they share so the
+# NEXT `-target hlsl` compile omits the HLSL prelude entirely (reproduced: a
+# single `-cpu` compute test before an nvapi test drops the guard; a non-cpu
+# HLSL-emit test before it does not). Because many `-cpu` tests exist throughout
+# the suite there is no single "leaker" to exclude, and the tests themselves are
+# correct, so they are excluded rather than weakened.
 #
-# Update 2026-08-09: the three `target-pipelines/hlsl` tests below now fail on
-# nightly-slang-test.yml too (run 31294644845, which uses `-use-test-server
-# -server-count 4`), so the "they pass in the nightly" half of the paragraph
-# above no longer holds and the leak is probably not in-process-only. That is a
-# nightly problem to triage on its own; the excludes stay because the coverage
-# pass still cannot distinguish the failure from a real one.
+# The leak is not specific to the coverage pass being in-process. The three
+# `target-pipelines/hlsl` tests fail on nightly-slang-test.yml as well (run
+# 31294644845, `-use-test-server -server-count 4`), because the test server is
+# equally long-lived and reuses one GlobalSession across the tests it handles.
+# The `06-emit` test still passes there. They are not in expected-failures.txt
+# because whether they fail depends on what ran before them on the same server,
+# so an entry would report as spuriously-passing about as often as it applied.
+# First identified locally 2026-07-09; nightly behaviour confirmed 2026-08-09.
 #
 # Path note: the first entry used to read
 # `.../06-emit/preludes-included-by-c-and-cuda.slang`. The 2026-08-04

--- a/docs/generated/tests/_meta/agentic-coverage-excludes.txt
+++ b/docs/generated/tests/_meta/agentic-coverage-excludes.txt
@@ -135,14 +135,17 @@ docs/generated/tests/design/ir-reference/misc/string-hash-non-literal-diagnostic
 # the suite there is no single "leaker" to exclude, and the tests themselves are
 # correct, so they are excluded rather than weakened.
 #
-# The leak is not specific to the coverage pass being in-process. The three
-# `target-pipelines/hlsl` tests fail on nightly-slang-test.yml as well (run
-# 31294644845, `-use-test-server -server-count 4`), because the test server is
-# equally long-lived and reuses one GlobalSession across the tests it handles.
-# The `06-emit` test still passes there. They are not in expected-failures.txt
-# because whether they fail depends on what ran before them on the same server,
-# so an entry would report as spuriously-passing about as often as it applied.
-# First identified locally 2026-07-09; nightly behaviour confirmed 2026-08-09.
+# The leak is not specific to the coverage pass being in-process. These tests
+# fail on nightly-slang-test.yml as well, because the test server is equally
+# long-lived and reuses one GlobalSession across the tests it handles: the three
+# `target-pipelines/hlsl` tests failed on run 31294644845, and the `06-emit`
+# one, which passed there, failed on run 31361305751. Which of them is hit
+# depends on whether a `-cpu` test happened to run before it on the same server,
+# so the victim set moves between runs. All four are listed in
+# expected-failures.txt for the nightly; slang-test keeps expected failures out
+# of its exit code, and an entry that passes is reported in the step summary
+# rather than failing the job, so a moving victim set is safe to list.
+# First identified locally 2026-07-09; nightly behaviour confirmed 2026-08-10.
 #
 # Path note: the first entry used to read
 # `.../06-emit/preludes-included-by-c-and-cuda.slang`. The 2026-08-04

--- a/docs/generated/tests/_meta/regenerate.py
+++ b/docs/generated/tests/_meta/regenerate.py
@@ -809,6 +809,61 @@ def lint_expected_failures() -> list[LintIssue]:
     return issues
 
 
+def lint_agentic_coverage_excludes() -> list[LintIssue]:
+    """Validate that every path in `_meta/agentic-coverage-excludes.txt` still exists.
+
+    `tools/coverage/run-coverage.sh` turns each entry into a slang-test
+    `-exclude-prefix` flag for the coverage agentic pass, which runs
+    in-process (`-server-count 1`), so a test that segfaults the compiler
+    segfaults the orchestrator and the rest of the suite never runs. The
+    entries here are what keep that from happening.
+
+    `-exclude-prefix` silently matches nothing when its path is wrong, so an
+    entry orphaned by a regeneration round that renames or moves its test
+    stops excluding anything and the crash comes back. That has happened
+    twice: PR #11421's directory reorg, and the 2026-08-04 round that renamed
+    `metadata/unorm-attr-on-buffer-element.slang` (coverage run 31235323797).
+    Resolving each entry as a path on disk turns both into a lint error.
+
+    Directory prefixes are legal — `-exclude-prefix` is a prefix filter, so
+    `.../design/pipeline/` excludes everything under it — and resolve as
+    directories, which is why this checks `exists()` rather than `is_file()`.
+
+    The file is optional; absence is fine.
+    """
+    issues: list[LintIssue] = []
+    path = (
+        REPO_ROOT
+        / "docs"
+        / "generated"
+        / "tests"
+        / "_meta"
+        / "agentic-coverage-excludes.txt"
+    )
+    if not path.is_file():
+        return issues
+    rel = str(path.relative_to(REPO_ROOT))
+
+    for lineno, raw in enumerate(path.read_text().splitlines(), start=1):
+        # Mirror run-coverage.sh's parse: strip a trailing comment, then trim.
+        s = raw.split("#", 1)[0].strip()
+        if not s:
+            continue
+        if not (REPO_ROOT / s).exists():
+            issues.append(
+                LintIssue(
+                    f"{rel}:{lineno}",
+                    "error",
+                    f"agentic-coverage-exclude path does not resolve: {s}."
+                    f" A stale entry excludes nothing, so the crash it was"
+                    f" added for will kill the coverage agentic pass again."
+                    f" Point it at the test's current path, or drop it if the"
+                    f" test is gone.",
+                )
+            )
+    return issues
+
+
 def compute_finding_title(finding: dict) -> str:
     """Return either the explicit title, or derive from scope + summary."""
     explicit = finding.get("title")
@@ -2309,6 +2364,7 @@ def cmd_lint(args: argparse.Namespace) -> int:
     if not args.bundles:
         issues.extend(lint_findings())
         issues.extend(lint_expected_failures())
+        issues.extend(lint_agentic_coverage_excludes())
     errors = [i for i in issues if i.severity == "error"]
     warnings = [i for i in issues if i.severity == "warning"]
     for i in issues:


### PR DESCRIPTION
## Motivation

The nightly coverage workflow reports success, but the agentic pass inside it has been dying:

```
./tools/coverage/run-coverage.sh: line 273: 11236 Segmentation fault (core dumped) "$SLANG_TEST" "${AGENTIC_TEST_ARGS[@]}"
Warning: agentic-test pass crashed (signal 11) on attempt 2 of 2
Warning: agentic-test pass crashed on all 2 attempts (signal 11). Partial coverage data still collected.
```

That is [run 31235323797](https://github.com/shader-slang/slang/actions/runs/31235323797), job [93046595145](https://github.com/shader-slang/slang/actions/runs/31235323797/job/93046595145) (linux, SIGSEGV) and job [93046595167](https://github.com/shader-slang/slang/actions/runs/31235323797/job/93046595167) (macos, SIGBUS). Both attempts crashed at the same point on both platforms, so this is deterministic, not flake.

`nightly-slang-coverage-test.yml` passes `server-count: 1`, and `ci-slang-coverage-test.yml` only adds `-use-test-server` when that count is greater than 1. The agentic pass therefore runs **in-process**, which is the point — it is how the compiler's own lines get instrumented. The consequence is that a test which segfaults `slangc` segfaults `slang-test` itself, and every test after it never runs and contributes no coverage. Linux died in `design/ir-reference/metadata`, macOS in `design/ir-reference/misc`; the whole tail (the rest of `ir-reference`, plus `pipeline`, `syntax-reference` and `target-pipelines`) was lost on both. `expected-failures.txt` cannot help here: there is no surviving process left to report a result.

`docs/generated/tests/_meta/agentic-coverage-excludes.txt` is the mechanism that already exists for this. `tools/coverage/run-coverage.sh` turns each line into a `-exclude-prefix` flag so the crashing tests never run in the coverage pass, while `nightly-slang-test.yml` keeps running them against a subprocess test server where a crash is merely a failure.

Two of its six entries had gone stale. The 2026-08-04 regeneration round (`source_commit 7e725f1`) renamed the tests they named:

| entry as written | test's actual name after the round |
| --- | --- |
| `design/ir-reference/metadata/unorm-attr-on-buffer-element.slang` | `.../metadata/unorm-attr-on-structured-buffer-element.slang` |
| `design/pipeline/06-emit/preludes-included-by-c-and-cuda.slang` | `.../06-emit/preludes-included-by-cuda-cpp-and-hlsl.slang` |

`slang-test`'s `-exclude-prefix` is a plain `filePath.startsWith(prefix)` scan (`tools/slang-test/slang-test-main.cpp`, `shouldRunTest`). A prefix that matches nothing is not an error and is never reported, so the first of those silently stopped excluding anything and re-armed the crash that killed the Linux job. This is the second time the list has rotted this way — the file's own comment records PR #11421's directory reorg doing it in 2026-06.

## Proposed solution

Repoint the stale entries at the tests' current paths, add the crashers the same round introduced, and then close the hole that let the rot go unnoticed by resolving every entry as a path on disk in `regenerate.py lint`.

The lint is the principled half. The exclude list is a path-keyed side table that has to stay in sync with a directory tree that a generation pipeline rewrites on every round; nothing structural keeps them together, and the consumer treats a wrong path as "matched nothing" rather than as an error. Checking the paths at lint time is what turns a silent no-op back into a signal, and it is where the sibling rule already lives: `lint_expected_failures()` in the same file does exactly this for `expected-failures.txt`. The revert drill is direct — restoring the two stale paths makes `regenerate.py lint` report exactly those two lines as errors, so this change would have caught the regression at the PR that introduced it rather than a nightly later.

I considered instead making `slang-test` warn when an `-exclude-prefix` matches zero tests. That is the complementary check, and it catches the *other* rot direction (an entry that outlives the crash it was added for), which the lint cannot see. It is worth doing, but it is a change to a shared tool for a `docs/generated/tests` bookkeeping problem, so it does not belong in a fix for this outage. The excludes file's "Staleness signal" section still describes the manual audit for that direction.

## Change summary

| File | What changed |
| --- | --- |
| `docs/generated/tests/_meta/agentic-coverage-excludes.txt` | Repointed the two orphaned paths; added the two crashers from the same regeneration round; recorded run URL + last-printed test for each; corrected the header's claim that these crashes are coverage-instrumentation-specific; added a section on how to read a crashing test out of a coverage log |
| `docs/generated/tests/_meta/regenerate.py` | New `lint_agentic_coverage_excludes()`, called from `cmd_lint` alongside `lint_findings()` and `lint_expected_failures()` |
| `docs/generated/tests/_meta/PIPELINE.md` | Documented the excludes file as a pipeline output, why the coverage run needs it when `expected-failures.txt` is not enough, and the rule for identifying the crashing test |

The four excluded tests, and how each was identified:

| Test | Evidence |
| --- | --- |
| `ir-reference/metadata/unorm-attr-on-structured-buffer-element.slang` | Linux job 93046595145: SIGSEGV on both attempts immediately after `metadata/unorm-attr-on-rwtexture-element.slang` printed `passed`. Orphaned rename of the previously-excluded `unorm-attr-on-buffer-element.slang`. Finding: `metadata-unorm-structured-buffer-element-sigsegv.yaml` |
| `ir-reference/misc/string-hash-non-literal-diagnostic.slang` | macOS job 93046595167: `Bus error: 10` on both attempts immediately after `misc/string-hash-fold-emitted-constant.slang.6` printed `passed`. Reproduced locally on macOS aarch64: `slangc … -target hlsl -entry main -stage compute` exits 138. New in the 2026-08-04 round; sorts ahead of the already-excluded `string-hash-stable-value-cpu.slang`, so it became the directory's first crasher. Finding: `getstringhash-nonliteral-argument-sigsegv.yaml` |
| `ir-reference/types/attributed-type-unorm-snorm.slang` | Not observed in a coverage run — both jobs died before reaching `types`. Excluded pre-emptively and labelled as such: its finding records the same exit 139 on the same `Attributed(Float, …)`-from-a-module-scope-uniform shape as the `metadata` crasher, and it is in `expected-failures.txt`, i.e. it does fail on the Linux nightly. Finding: `ir-types-unorm-snorm-struct-field-sigsegv.yaml` |
| `pipeline/06-emit/preludes-included-by-cuda-cpp-and-hlsl.slang` | Orphaned rename of `preludes-included-by-c-and-cuda.slang`; not a crash, this is the pre-existing HLSL-prelude in-process state leak already documented for its three `target-pipelines/hlsl` siblings |

To be sure the list is now complete rather than one-crash-at-a-time, I cross-checked every `_meta/finding` with `suspected_kind: sigsegv` against both job logs. Of the 20, the ones whose test still exists all printed a result in at least one job — so they demonstrably survive the in-process run — except the four above and the already-excluded `string-hash-stable-value-cpu.slang`.

## Concepts and vocabulary

- **agentic pass** — the second `slang-test` invocation inside `run-coverage.sh --with-agentic-tests`, scoped to `-test-dir docs/generated/tests`. It has its own expected-failure list and its own exclude list, separate from the main `tests/` pass.
- **`-exclude-prefix`** — `slang-test` flag taking a path prefix; any test whose path starts with it is skipped. Distinct from `-expected-failure-list`, which lets the test *run* and inverts its verdict. Only the former is any use against a crash.
- **in-process vs test-server** — with `-server-count 1` and no `-use-test-server`, `slang-test` compiles inside its own process against one shared `GlobalSession`. With a test server, each compile is a subprocess, so a compiler crash is contained and reported as a failed test. The same test can therefore be `failed(expected)` in `nightly-slang-test.yml` and fatal in the coverage run.
- **regeneration round** — a pass of the agentic-test pipeline that rewrites bundles from their source docs. Tests are named from their claim, so a round that re-frames a claim renames the file, which is what orphaned the entries here.

## Process report

**Repointing the two stale paths.** The input shape question here is whether a path-keyed side table is the right representation at all, given the tree it indexes is rewritten by a generator. It is, for now: `-exclude-prefix` is the only lever that keeps a test from executing, the set is meant to be small and short-lived (each entry is a compiler bug awaiting a fix), and the alternative — a marker inside the test file — would put coverage-harness bookkeeping into generated content that the next round would overwrite. What was wrong was not the representation but the absence of any check that the key still resolves, which is what the lint adds.

**`lint_agentic_coverage_excludes()`.** It mirrors `lint_expected_failures()` deliberately: same `LintIssue` shape, same `REPO_ROOT`-relative resolution, same optional-file handling, invoked from the same `if not args.bundles` block in `cmd_lint` so it only runs on a full lint. Two intentional differences from its sibling:

- It parses lines the way `run-coverage.sh` does — `line.split("#", 1)[0].strip()`, matching the shell's `line="${line%%#*}"` plus trim — so the lint's idea of what an entry is cannot drift from the consumer's.
- It checks `exists()` rather than `is_file()`. `-exclude-prefix` is a prefix filter, so `.../design/pipeline/` legitimately excludes an entire directory; requiring a file would reject a valid entry. It does not strip the `" (config)"` or `".slang.N"` decorations that `lint_expected_failures` strips, because those are `slang-test` *test names*, and `-exclude-prefix` matches file paths, not test names.

No new helper was extracted: the loop is six lines and its only shared logic with `lint_expected_failures` is `(REPO_ROOT / p).exists()`, which is not worth a named abstraction and would couple two rules that differ in exactly the ways listed above.

**Correcting the header.** The file previously told the reader that "the crash here is coverage-instrumentation-specific", which would send someone auditing the list down the wrong path: they would try to reproduce with an instrumented build, fail to see why plain `slangc` also dies, and mistrust the entry. It is true of some entries and false of the `unorm`/`snorm` pair, whose findings record exit 139 from an ordinary `RelWithDebInfo` `slangc`. Those are survivable in `nightly-slang-test.yml` because of subprocess isolation, not because the binary is uninstrumented. The header now states both cases.

**The `attributed-type-unorm-snorm.slang` entry** is the one change not backed by an observed coverage crash, and I have marked it as such in the file rather than letting it read like the others. The argument for including it now: it is in the tail neither job reached, its finding reports the same exit code on the same IR shape as the confirmed crasher two directories earlier, and it is already in `expected-failures.txt`, so it does fail on Linux. The argument against — that a pre-emptive exclude costs coverage if the prediction is wrong — is bounded by the file's audit procedure, whereas guessing wrong in the other direction costs another whole nightly. If it turns out not to crash, the audit drops it.

**Deliberately not in scope.** `nightly-slang-test.yml` is separately red — 18 unexpected failures in [run 31294644845](https://github.com/shader-slang/slang/actions/runs/31294644845), plus 5 `expected-failures.txt` entries now passing. Three of those 18 are the `target-pipelines/hlsl` nvapi tests whose exclude comment here asserts they "pass in isolation and in nightly-slang-test.yml". That is no longer true, so the in-process-session-leak explanation for them is at best incomplete. I have dated a note to that effect next to the entries rather than rewriting an analysis I have not re-derived; the excludes stay because the coverage pass still cannot tell that failure from a real one. Triaging the nightly is its own change.

## Verification

- `python3 docs/generated/tests/_meta/regenerate.py lint` — 0 errors, 138 warnings across 79 bundles, matching the warning count in the nightly's lint step before this change.
- Revert drill: restoring the two stale paths yields exactly two errors, one per line, and nothing else.
- `python3 docs/generated/tests/_meta/regenerate.py selftest` — 0 failures.
- `./extras/formatting.sh --check-only` — clean.

The real check is a coverage run on this branch getting past `design/ir-reference` without an `agentic-test pass crashed` warning; I will dispatch `nightly-slang-coverage-test.yml` against the branch.
