### PR TITLE
compile-perf: keep raw samples, and move analysis off the perf runner

### DIFF
--- a/.github/workflows/nightly-mdl-perf-test.yml
+++ b/.github/workflows/nightly-mdl-perf-test.yml
@@ -397,6 +397,12 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          # Same suite-ref/ref priority the nightly job uses, so measurement
+          # and analysis run the SAME suite revision. A backfill dispatch
+          # (ref=<old commit>, suite-ref=<new suite>) would otherwise measure
+          # with one trend.py and judge with another — and the tracking format
+          # is exactly the kind of thing that drifts between them.
+          ref: ${{ github.event.inputs['suite-ref'] || github.event.inputs.ref || github.ref }}
           persist-credentials: false
           # The suite scripts only; no submodules and no history needed.
           fetch-depth: "1"
@@ -422,7 +428,16 @@ jobs:
       # and the series' last point may be a sibling, not this run's.
       - name: Check trend (fail on regression)
         id: trend
-        if: env.PUBLISH == 'true'
+        # The label gate is load-bearing, not belt-and-braces. A step `if`
+        # carries an implicit success() over the steps BEFORE it IN THIS JOB —
+        # which are only the checkouts here, so it no longer means "the sweep
+        # succeeded" the way it did when this step lived in the nightly job.
+        # Without the gate, a night that fails before the sweep reaches
+        # `trend.py --label ""`, which aborts on the empty value; that makes
+        # steps.trend.outcome 'failure', and classify() tests failure BEFORE
+        # job status, so Slack would announce a regression for a night that
+        # never measured anything.
+        if: env.PUBLISH == 'true' && needs.nightly.outputs.perf_label != ''
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/nightly-mdl-perf-test.yml
+++ b/.github/workflows/nightly-mdl-perf-test.yml
@@ -452,6 +452,10 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_COMPILE_PERF }}
+          # 'skipped' here means the sweep never minted a label (the gate
+          # above), i.e. nothing was measured — classify() reaches NOT_RUN for
+          # it only when JOB_STATUS is success, so a failed sweep still reports
+          # as a job failure rather than as a quiet "trend not run".
           TREND_OUTCOME: ${{ steps.trend.outcome }}
           TREND_WARNINGS: ${{ steps.trend.outputs.warnings || '0' }}
           # The MEASUREMENT job's result, not this job's: a regression is

--- a/.github/workflows/nightly-mdl-perf-test.yml
+++ b/.github/workflows/nightly-mdl-perf-test.yml
@@ -67,6 +67,10 @@ jobs:
     # step at the boundary.
     runs-on:
       labels: [Windows, X64, nvrgfx-perf-kernelvm-bridge]
+    outputs:
+      # Consumed by the analyze job, which runs elsewhere. The label pins the
+      # trend judgement to the point THIS run registered.
+      perf_label: ${{ steps.sweep.outputs.perf_label }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -161,6 +165,7 @@ jobs:
           token: ${{ secrets.SLANG_COMPILE_PERF_PAT }}
 
       - name: Run nightly sweep + update tracking
+        id: sweep
         shell: bash
         # Inputs arrive via env and are never interpolated into the script, so a
         # value with shell metacharacters can't break out — it's just an argv item.
@@ -193,6 +198,9 @@ jobs:
           # (daily labels share the swept commit's DATE, so several points can
           # share a date and series order alone cannot identify this run's).
           echo "PERF_LABEL=$LABEL" >> "$GITHUB_ENV"
+          # Also a job OUTPUT, not only job-scoped env: the analyze job runs on
+          # a different machine and cannot see this job's $GITHUB_ENV.
+          echo "perf_label=$LABEL" >> "$GITHUB_OUTPUT"
 
           # publish=false: measure only — write results to a workspace dir that
           # the artifact step uploads; no tracking registration.
@@ -362,6 +370,50 @@ jobs:
           git -C "$GITHUB_WORKSPACE/perf-pages" remote set-url origin \
             "https://github.com/${{ env.PERF_RESULTS_REPO }}.git" 2>/dev/null || true
 
+  # Analysis and notification, deliberately NOT on the perf runner.
+  #
+  # Nothing below measures anything: the trend check and the Slack message
+  # only need the results repo, which the nightly job has already pushed. The
+  # perf pool sits behind an egress proxy (192.168.240.1:3128) that denies
+  # CONNECT to hooks.slack.com, so every notification from there failed with
+  # "Tunnel connection failed: 403 Forbidden" while the step still exited 0 by
+  # design. A GitHub-hosted runner has unrestricted egress, so moving the
+  # notification here fixes it without asking anyone to change a proxy ACL we
+  # do not own.
+  #
+  # It is also the first split of the suite along the line we want long term:
+  # the quiesced machine measures, and anything that merely reads results runs
+  # where it is cheap and unrestricted.
+  analyze:
+    needs: nightly
+    # always(): a failed sweep is exactly when the notification matters most.
+    if: always() && needs.nightly.result != 'skipped'
+    runs-on: ubuntu-latest
+    env:
+      # PERF_RESULTS_REPO and PUBLISH are workflow-level and inherited; only
+      # the label has to cross the job boundary, because it is computed during
+      # the sweep rather than declared up front.
+      PERF_LABEL: ${{ needs.nightly.outputs.perf_label }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          # The suite scripts only; no submodules and no history needed.
+          fetch-depth: "1"
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Checkout perf results repo
+        if: env.PUBLISH == 'true'
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          repository: ${{ env.PERF_RESULTS_REPO }}
+          path: "perf-results"
+          token: ${{ secrets.SLANG_COMPILE_PERF_PAT }}
+
       # Runs AFTER the push so the data is stored even when this step fails the
       # job. trend.py exits non-zero (job red + ::error:: annotations) when a
       # primary timer drifts past threshold vs the trailing median. --label
@@ -374,7 +426,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cd "$SUITE"
+          cd "$GITHUB_WORKSPACE/tools/compile-perf"
           python3 trend.py --results "$GITHUB_WORKSPACE/perf-results" --label "${PERF_LABEL:?}"
 
       - name: Notify Slack
@@ -384,7 +436,10 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_COMPILE_PERF }}
           TREND_OUTCOME: ${{ steps.trend.outcome }}
           TREND_WARNINGS: ${{ steps.trend.outputs.warnings || '0' }}
-          JOB_STATUS: ${{ job.status }}
+          # The MEASUREMENT job's result, not this job's: a regression is
+          # reported by TREND_OUTCOME, while JOB_STATUS answers "did the
+          # sweep itself fail", which now happens in a different job.
+          JOB_STATUS: ${{ needs.nightly.result }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           if [ -z "$SLACK_WEBHOOK" ]; then
@@ -403,7 +458,7 @@ jobs:
           # but one process is cheaper and there is no second place to keep in
           # step. A failure warns rather than reds the run, matching the
           # webhook-failure contract below.
-          if ! CLASSIFIED=$(python3 "$SUITE/slack_status.py"); then
+          if ! CLASSIFIED=$(python3 "$GITHUB_WORKSPACE/tools/compile-perf/slack_status.py"); then
             echo "::warning title=Slack notification skipped::slack_status.py failed"
             exit 0
           fi

--- a/.github/workflows/nightly-mdl-perf-test.yml
+++ b/.github/workflows/nightly-mdl-perf-test.yml
@@ -495,8 +495,7 @@ jobs:
                   f'{os.environ[\"ICON\"]} *Compile-perf nightly — {os.environ[\"DATE\"]}*\n'
                   f'{os.environ[\"STATUS\"]}\n'
                   f'• Run: {os.environ[\"RUN_URL\"]}\n'
-                  f'• Report: https://shader-slang.org/slang-compile-perf/ '
-                  f'(may take a few minutes to update after the run)'
+                  f'• Report: https://shader-slang.org/slang-compile-perf/'
               )
           }
           req = urllib.request.Request(

--- a/.github/workflows/nightly-mdl-perf-test.yml
+++ b/.github/workflows/nightly-mdl-perf-test.yml
@@ -452,10 +452,12 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_COMPILE_PERF }}
-          # 'skipped' here means the sweep never minted a label (the gate
-          # above), i.e. nothing was measured — classify() reaches NOT_RUN for
-          # it only when JOB_STATUS is success, so a failed sweep still reports
-          # as a job failure rather than as a quiet "trend not run".
+          # 'skipped' means trend analysis did not run, which has two causes:
+          # publish=false (a measurement-only dispatch, where the sweep DID
+          # succeed) and an empty label (a sweep that failed before minting
+          # one). JOB_STATUS is what separates them — classify() reaches its
+          # quiet "trend did not run" line only when the job also succeeded,
+          # so the failed-sweep case still reports as a job failure.
           TREND_OUTCOME: ${{ steps.trend.outcome }}
           TREND_WARNINGS: ${{ steps.trend.outputs.warnings || '0' }}
           # The MEASUREMENT job's result, not this job's: a regression is

--- a/.github/workflows/nightly-mdl-perf-test.yml
+++ b/.github/workflows/nightly-mdl-perf-test.yml
@@ -384,6 +384,14 @@ jobs:
   # It is also the first split of the suite along the line we want long term:
   # the quiesced machine measures, and anything that merely reads results runs
   # where it is cheap and unrestricted.
+  # No setup-python here, deliberately: ubuntu-latest ships Python 3, the suite
+  # is stdlib-only, and check-python-core.yml already exercises these same
+  # scripts against the system interpreter on ubuntu-22.04/24.04 (its step is
+  # named "Verify using system Python (no setup-python)"). Pinning an
+  # interpreter here would add a network-dependent download to a job whose
+  # value is being cheap and reliable, and would test a version the suite is
+  # not otherwise verified against. The nightly job keeps its own setup-python
+  # because the Windows perf runner does need it.
   analyze:
     needs: nightly
     # always(): a failed sweep is exactly when the notification matters most.
@@ -406,11 +414,6 @@ jobs:
           persist-credentials: false
           # The suite scripts only; no submodules and no history needed.
           fetch-depth: "1"
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.12"
 
       - name: Checkout perf results repo
         if: env.PUBLISH == 'true'

--- a/tools/compile-perf/bench.py
+++ b/tools/compile-perf/bench.py
@@ -83,7 +83,13 @@ def stats(values):
         "mean": round(statistics.mean(values), 4),
         "stdev": round(statistics.stdev(values), 4) if len(values) > 1 else 0.0,
         "n": len(values),
-        "samples": [round(v, 4) for v in values],
+        # NOT rounded, unlike the summary fields above. Rounding the samples
+        # would defeat their purpose twice over: a consumer recomputing
+        # statistics would be working from altered measurements, and where a
+        # consumer checks our summary against its own (BenchView does, within
+        # 1e-9) a summary derived from RAW values will not match one derived
+        # from rounded samples — measured at ~80% of five-sample sets.
+        "samples": list(values),
     }
 
 

--- a/tools/compile-perf/bench.py
+++ b/tools/compile-perf/bench.py
@@ -561,15 +561,24 @@ def main():
 # surface only as silently altered measurements — and as a rejected BenchView
 # submission, since a summary computed from raw values does not match one
 # recomputed from rounded samples.
-_s = stats([1.23456, 2.0, 3.0])
-assert _s["samples"] == [1.23456, 2.0, 3.0], \
+# Both extrema carry a 5th decimal so that dropping their round() is
+# observable. A value that is already exact at 4 places (3.0, say) asserts
+# nothing about rounding: it compares equal either way, so the check would
+# pass through the very edit it exists to catch.
+_s = stats([1.23456, 2.0, 3.98769])
+assert _s["samples"] == [1.23456, 2.0, 3.98769], \
     "samples must be stored RAW; rounding them alters what a consumer recomputes"
-assert _s["min"] == 1.2346 and _s["max"] == 3.0, \
+assert _s["min"] == 1.2346 and _s["max"] == 3.9877, \
     "summary fields ARE rounded, and max is reported alongside min"
 assert _s["n"] == 3
 assert stats([]) is None, "no measurements yields no stats, not an empty summary"
 assert stats([5.0])["stdev"] == 0.0, "a single sample has zero deviation, not None"
-assert stats([1.0, None, 2.0])["n"] == 2, "None samples are dropped, not counted"
+# Pins the sample list, not just n: both are built from the same filtered
+# list today, so n alone would still hold if a later edit archived the
+# unfiltered argument, letting a None reach a consumer that cannot take one.
+assert stats([1.0, None, 2.0])["samples"] == [1.0, 2.0], \
+    "None samples are dropped from the archive, not merely uncounted"
+assert stats([1.0, None, 2.0])["n"] == 2
 del _s
 
 

--- a/tools/compile-perf/bench.py
+++ b/tools/compile-perf/bench.py
@@ -58,15 +58,32 @@ def parse_timers(text):
 
 
 def stats(values):
+    """Summarize repeated measurements, keeping the raw samples alongside.
+
+    The samples are retained, not only the summary, because any summary is
+    lossy in a way that cannot be undone: a bimodal five-sample run and a
+    tight one can share a median and a stdev, and only the samples tell them
+    apart. results.json is the archive, so a question that needs them later
+    cannot be answered by re-deriving them. They also let a consumer compute
+    statistics under its own definition instead of trusting ours — the
+    BenchView submission format, for one, computes its own summary from
+    samples and treats that as authoritative.
+
+    `max` is reported for symmetry with `min`: without it the spread cannot
+    be bounded from the summary alone, and consumers that accept a summary in
+    place of samples generally require both extrema.
+    """
     values = [v for v in values if v is not None]
     if not values:
         return None
     return {
         "median": round(statistics.median(values), 4),
         "min": round(min(values), 4),
+        "max": round(max(values), 4),
         "mean": round(statistics.mean(values), 4),
         "stdev": round(statistics.stdev(values), 4) if len(values) > 1 else 0.0,
         "n": len(values),
+        "samples": [round(v, 4) for v in values],
     }
 
 

--- a/tools/compile-perf/bench.py
+++ b/tools/compile-perf/bench.py
@@ -2,8 +2,8 @@
 """Slang compile-time perf-suite runner.
 
 Drives a given slangc over the workloads in manifest.py, parses the per-phase
-timers emitted by -report-perf-benchmark, and writes tidy per-run JSON
-(median/min/mean/stdev per timer; merge-on-write).
+timers emitted by -report-perf-benchmark, and writes per-run JSON: a summary
+(median/min/max/mean/stdev/n) AND the raw samples per timer; merge-on-write.
 
 Stdlib only (no prettytable / numpy) so it runs unchanged against any release's
 slangc.
@@ -542,7 +542,7 @@ def main():
     with analyze.open_output(jpath) as fh:
         json.dump(records, fh, indent=2)
 
-    # results.json is the single source of truth (all of median/min/mean/stdev per
+    # results.json is the single source of truth (summary AND raw samples per
     # timer); the analysis/report tools read it directly. No CSV is emitted.
     if not args.gen_dir:
         shutil.rmtree(gen_root, ignore_errors=True)
@@ -552,6 +552,25 @@ def main():
     print(f"wrote {jpath}")
     if n_ok != len(this_run):
         sys.exit(1)
+
+
+# Import-time self-checks (the directory idiom), run by check-python-core.yml
+# on every PR touching these files. bench.py had none, which mattered here:
+# the samples are stored RAW deliberately, and nothing else in the suite reads
+# them yet, so a future edit rounding them would import cleanly, merge, and
+# surface only as silently altered measurements — and as a rejected BenchView
+# submission, since a summary computed from raw values does not match one
+# recomputed from rounded samples.
+_s = stats([1.23456, 2.0, 3.0])
+assert _s["samples"] == [1.23456, 2.0, 3.0], \
+    "samples must be stored RAW; rounding them alters what a consumer recomputes"
+assert _s["min"] == 1.2346 and _s["max"] == 3.0, \
+    "summary fields ARE rounded, and max is reported alongside min"
+assert _s["n"] == 3
+assert stats([]) is None, "no measurements yields no stats, not an empty summary"
+assert stats([5.0])["stdev"] == 0.0, "a single sample has zero deviation, not None"
+assert stats([1.0, None, 2.0])["n"] == 2, "None samples are dropped, not counted"
+del _s
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Two problems, one direction of travel.

**The Slack notification is not working.** Every scheduled nightly since #11745 merged reports the same thing, and the step still exits 0:

```
##[warning]<urlopen error Tunnel connection failed: 403 Forbidden>
```

The webhook secret is set (`SLACK_WEBHOOK: ***` in the env block) and the classification is correct (`TREND_OUTCOME: success / TREND_WARNINGS: 0 / JOB_STATUS: success`). The POST is refused by the network: job log line 10 says *"Runner is running behind proxy server 'http://192.168.240.1:3128' for all HTTPS requests"*, and a 403 on `CONNECT` is that proxy's ACL denying `hooks.slack.com` — a 407 would mean missing credentials. GitHub itself is allowed through the same proxy, so it is host-specific, and it is not an ACL we own.

**We keep no raw measurements.** `bench.py` collects per-sample lists and then discards them in `stats()`, keeping only a summary.

## Proposed solution

**Keep the samples.** They already exist in memory; only the discard is deliberate. A summary is lossy in a way that cannot be undone — a bimodal five-sample run and a tight one can share a median and a stdev, and only the samples tell them apart — and `results.json` is the archive, so a question that needs them later cannot be answered by re-deriving. `slang-compile-perf` is public, so carrying samples there answers Chris's ask with a URL rather than new infrastructure. `max` is added for symmetry with `min`.

**Split the nightly into `nightly` (measure) and `analyze` (read).** Nothing after "Push results" measures anything — the trend check and the notification only consume the results repo, which has already been pushed. Moving them to `ubuntu-latest` fixes the notification, because a GitHub-hosted runner has unrestricted egress.

The split is also forced by topology in *both* directions, which is worth recording:

| destination | GitHub-hosted | perf runner |
| --- | --- | --- |
| `hooks.slack.com` → 52.29.238.212 (public) | ✅ | ❌ proxy 403 |
| `rtrci.nvidia.com` → 10.124.10.95 (RFC1918) | ❌ no route | ✅ |

So when BenchView submission lands it belongs on the *internal* job, not this one. Neither job can do the other's network work.

## Change summary

| File | Change |
| --- | --- |
| `tools/compile-perf/bench.py` | `stats()` keeps raw `samples` and reports `max` |
| `.github/workflows/nightly-mdl-perf-test.yml` | New `analyze` job on `ubuntu-latest` holding the trend check and Slack step; `perf_label` exposed as a job output |

## Concepts and vocabulary

- **Perf pool** — the quiesced NVIDIA RGFX machine the nightly measures on, reached through the VM bridge. Quiescence is what makes the timings trustworthy, and it is also what puts the runner behind the corporate egress proxy.
- **`PERF_LABEL`** — the `<date>-<sha>` label the sweep registers. `trend.py --label` needs it because daily labels are keyed by the swept commit's *date*, so several points can share one and series order alone cannot identify this run's point.

## Process report

**Why `stats()` and not a parallel field.** The samples belong with the summary they describe; a sibling `timer_samples` map would let the two drift and would need every consumer to join them. Adding keys inside the stats dict is additive — everything reads `["median"]` and is unaffected.

**Why every timer, not a curated subset.** A subset is the thing a consumer has to come back and ask us to widen, and the request here was explicitly for raw data. Cost measured against a published point: `results.json` 141 KiB → 239 KiB (+69%), ≈35 MiB/year against a 21 MiB repo. Flagging that explicitly as the tradeoff being accepted.

**What changes across the job boundary, and why each is necessary.** Three things, and getting any of them wrong is quiet rather than loud:

1. `PERF_LABEL` was written only to `$GITHUB_ENV`, which is job-scoped. It is computed *during* the sweep (it embeds the swept commit), so it cannot be declared up front like config — it is now also a job output.
2. `JOB_STATUS` was `job.status`. Split apart, the question the message asks is "did the *measurement* fail", which is `needs.nightly.result`. Left as `job.status` it would describe the analyze job and report a failed sweep as clean.
3. `$SUITE` is resolved on the perf runner and accounts for the backfill checkout at `suite-src/`. The analyze job has a plain checkout and uses `$GITHUB_WORKSPACE/tools/compile-perf`.

`PUBLISH` and `PERF_RESULTS_REPO` are workflow-level `env` and inherited by every job, so they need no plumbing. An earlier draft passed `publish` as a second job output; that was removed once I confirmed it was inherited — it also avoided relying on the `env` context being available inside a job-`outputs` expression, which if unavailable would have silently emptied the output and skipped the trend check every night.

`slack_status.py` needed no changes at all. Only its inputs moved — which is the payoff from having lifted that classification out of workflow bash in #11745.

**Input-shape check.** Nothing here guards or special-cases a shape. The stats change adds fields to a record we produce; the workflow change relocates steps without altering their logic.

## Test Plan

- [x] `report.py`, `trend.py` and `track.py` all run clean over a copy of the published series (28 releases + 30 daily) rewritten with the new stats shape — no consumer trips on the added keys
- [x] `stats()` output checked, including that two runs with the same median and stdev are distinguishable by their samples
- [x] Archive cost measured on a real point rather than estimated (+69%, ≈35 MiB/year)
- [x] Workflow parses; job graph resolves; every `needs.*.outputs.*` reference is declared; the `analyze` job does not reference `$SUITE`
- [x] All five Slack states classify correctly under the new inputs, including `trend=skipped` + `nightly=failure` → `:x:` (sweep failure, not a clean night)
- [x] `./extras/formatting.sh --check-only` passes
- [x] **Notification confirmed end to end** — needs a `workflow_dispatch` with `notify-slack=true`; cannot be run locally
