### PR TITLE
tests _meta: lint doc_section_digest against the section it names

### DIFF
--- a/docs/generated/tests/_meta/regenerate.py
+++ b/docs/generated/tests/_meta/regenerate.py
@@ -1289,6 +1289,103 @@ def _github_slug(title: str) -> str:
     return slug.replace(" ", "-")
 
 
+_DOC_SECTION_DIGEST_MOD = None
+
+
+def _doc_section_digest_module():
+    """Return `_meta/doc-section-digest.py` loaded as a module, or None.
+
+    That script is the canonical implementation of the `doc_section_digest`
+    rule and is what agents run to produce the value, so the lint has to use
+    it rather than re-deriving the rule. The two are not interchangeable:
+    the script's `slug` keeps backticks and link syntax, while `_github_slug`
+    here strips them for link checking, so a heading like ``## `Foo` bar``
+    hashes under a different anchor in each. Importing the one that generated
+    the value is what makes the comparison meaningful.
+
+    Returns None when the script is missing, so the lint degrades to skipping
+    the check rather than erroring on every test.
+    """
+    global _DOC_SECTION_DIGEST_MOD
+    if _DOC_SECTION_DIGEST_MOD is None:
+        path = REPO_ROOT / "docs/generated/tests/_meta/doc-section-digest.py"
+        if not path.is_file():
+            _DOC_SECTION_DIGEST_MOD = False
+        else:
+            import importlib.util
+
+            spec = importlib.util.spec_from_file_location("_doc_section_digest", path)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            _DOC_SECTION_DIGEST_MOD = mod
+    return _DOC_SECTION_DIGEST_MOD or None
+
+
+def lint_doc_section_digests(specs: list) -> list[LintIssue]:
+    """Report doc sections whose text has drifted from the tests anchored to them.
+
+    `doc_section_digest` is the sha256 of the cited section's body, so editing a
+    section invalidates every test that cites it. Nothing notices today:
+    `_REQUIRED_TEST_META_KEYS` only asserts the key is *present*, never that it
+    matches, so a doc edit silently leaves those tests claiming to have been
+    written against text that no longer exists. All 16 tests anchored to
+    `grammar.md#statements` went stale that way when the `ThrowStmt` production
+    was corrected, and nothing flagged it.
+
+    Reported per doc section rather than per test, because the section is the
+    unit of work: one edit invalidates a whole group, and 386 individual lines
+    would bury the ~40 sections that actually drifted.
+
+    Warning, not error. A stale digest does not mean the test is wrong -- it
+    means nobody has re-read the claim since the prose moved, which is a review
+    task, not a build failure. Note that refreshing the digest without re-reading
+    is worse than leaving it stale: it launders the drift and destroys the only
+    record that the claim and the prose were ever checked against each other.
+    """
+    mod = _doc_section_digest_module()
+    if mod is None:
+        return []
+    # (doc target, anchor) -> [test paths]
+    stale: dict[tuple[str, str], list[str]] = {}
+    for spec in specs:
+        if not spec.is_doc_anchored:
+            continue
+        for tf in sorted((REPO_ROOT / spec.dir).glob("*.slang")):
+            meta = parse_test_meta(tf.read_text(encoding="utf-8", errors="replace"))
+            recorded = (meta.get("doc_section_digest") or "").strip()
+            doc_ref = (meta.get("doc_ref") or "").strip()
+            if not recorded or "#" not in doc_ref:
+                continue
+            target, _, anchor = doc_ref.partition("#")
+            doc = REPO_ROOT / target
+            if not doc.is_file():
+                continue
+            try:
+                body = mod.section_text(str(doc), anchor)
+            except SystemExit:
+                # Unresolvable anchor; already reported by the per-file lint.
+                continue
+            if hashlib.sha256(body.encode("utf-8")).hexdigest() != recorded:
+                stale.setdefault((target, anchor), []).append(
+                    str(tf.relative_to(REPO_ROOT))
+                )
+    issues: list[LintIssue] = []
+    for (target, anchor), tests in sorted(stale.items()):
+        sample = ", ".join(Path(t).name for t in tests[:3])
+        more = f", +{len(tests) - 3} more" if len(tests) > 3 else ""
+        issues.append(
+            LintIssue(
+                f"{target}#{anchor}",
+                "warning",
+                f"section changed since {len(tests)} test(s) were anchored to it"
+                f" ({sample}{more}). Re-read those claims against the current"
+                f" text, then refresh their //META doc_section_digest with"
+                f" `_meta/doc-section-digest.py {target} {anchor}`.",
+            )
+        )
+    return issues
+
+
 _HEADING_SLUG_CACHE: dict[Path, set[str]] = {}
 
 
@@ -2365,6 +2462,7 @@ def cmd_lint(args: argparse.Namespace) -> int:
         issues.extend(lint_findings())
         issues.extend(lint_expected_failures())
         issues.extend(lint_agentic_coverage_excludes())
+        issues.extend(lint_doc_section_digests(specs))
     errors = [i for i in issues if i.severity == "error"]
     warnings = [i for i in issues if i.severity == "warning"]
     for i in issues:


### PR DESCRIPTION
## Motivation

`doc_section_digest` records the sha256 of the doc section a generated test was written against. It is the suite's only record that a claim and the prose it came from were ever checked against each other.

Nothing validates it. `_REQUIRED_TEST_META_KEYS` asserts the key is *present*; no check compares it to the section it names. So editing a doc section silently invalidates every test anchored to it, and the tests go on claiming provenance they no longer have.

This is not hypothetical. Correcting the `ThrowStmt` production in #12444 left all 16 tests anchored to `grammar.md#statements` pinning the pre-edit hash, and it took a reviewer noticing to catch it. Running the check against master shows the backlog is much larger: **40 doc sections have drifted from the 386 tests anchored to them.**

## What it does

```
warning docs/generated/design/syntax-reference/grammar.md#statements: section changed
since 16 test(s) were anchored to it (stmt-break-continue.slang,
stmt-compile-time-for.slang, stmt-continue-label-rejected.slang, +13 more). Re-read
those claims against the current text, then refresh their //META doc_section_digest
with `_meta/doc-section-digest.py docs/generated/design/syntax-reference/grammar.md statements`.
```

## Three design decisions worth stating

**It imports the canonical implementation instead of re-deriving the rule.** `_meta/doc-section-digest.py` is what agents run to produce the value, so the lint calls its `section_text` via `importlib`. The two available slug functions are *not* interchangeable — that script's `slug` keeps backticks and link syntax, while `_github_slug` in `regenerate.py` strips them for link checking, so a heading like ``## `Foo` bar`` hashes under a different anchor in each. Comparing against the implementation that produced the value is the only comparison that means anything. A second copy of the rule here would be a bug generator.

**Reported per doc section, not per test.** The section is the unit of work: one edit invalidates a whole group, and the fix is to re-read that group together. Per-test reporting produced 386 lines that buried the 40 sections that actually drifted.

**Warning, not error.** Two reasons. The 40-section backlog means erroring would fail the nightly lint on day one, for drift that predates this change. And a stale digest does not mean a test is wrong — it means nobody has re-read the claim since the prose moved, which is a review task rather than a build failure.

The message deliberately says *re-read, then refresh*. Refreshing a digest without re-reading is worse than leaving it stale: it launders the drift and destroys the only signal that the claim was ever verified against the text. That is also why this PR does not bulk-refresh the 386 existing digests — doing so would assert a review that never happened.

## No selftest case

Deliberate, and the opposite call from the one I declined on #12436. The linters that walk clean corpora only ever prove their happy path, which is what `selftest` exists to compensate for. This check's failure branch is exercised by the committed corpus on every single run — 40 sections trip it today — so a synthetic case would add nothing CI does not already do.

## Verification

Revert drill on the motivating case — apply #12444's `ThrowStmt` edit to `grammar.md`, and the check names exactly the 16 affected tests; revert it and the warning disappears:

```
$ # with grammar.md#statements edited
warning ...grammar.md#statements: section changed since 16 test(s) were anchored to it
$ # reverted
0
```

`regenerate.py lint` on master: 0 errors, 178 warnings (138 pre-existing + 40 new section-level ones). `regenerate.py selftest`: 0 failures. `./extras/formatting.sh --check-only` clean.

## Merge order

Independent of the other open PRs, but it touches `cmd_lint` in `regenerate.py`, which #12436 also touches, so merging #12436 first avoids a trivial conflict. Merging this before #12444 is also fine and slightly better — #12444 refreshes the 16 grammar digests, so with this check in place CI would confirm that rather than take it on trust.
