### PR TITLE
ci: set the node24 force flag on every msvc-dev-cmd use, and fix its comment

### DIFF
--- a/.github/actions/claude-code-runner/action.yml
+++ b/.github/actions/claude-code-runner/action.yml
@@ -149,7 +149,10 @@ runs:
       if: runner.os == 'Windows'
       uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       # msvc-dev-cmd has no Node 24 release yet (upstream ilammy/msvc-dev-cmd#105);
-      # force its node20 runtime onto node24 to clear the deprecation warning.
+      # run its node20 bundle on the node24 runtime. This restates the
+      # deprecation annotation ("forced to run on Node.js 24") rather than
+      # silencing it — the point is to exercise the runtime that survives the
+      # retirement, so a break surfaces now instead of when Node 20 is removed.
       env:
         FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -38,7 +38,10 @@ runs:
     - name: Set up MSVC dev tools on Windows
       uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       # msvc-dev-cmd has no Node 24 release yet (upstream ilammy/msvc-dev-cmd#105);
-      # force its node20 runtime onto node24 to clear the deprecation warning.
+      # run its node20 bundle on the node24 runtime. This restates the
+      # deprecation annotation ("forced to run on Node.js 24") rather than
+      # silencing it — the point is to exercise the runtime that survives the
+      # retirement, so a break surfaces now instead of when Node 20 is removed.
       env:
         FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/cmake-options-build.yml
+++ b/.github/workflows/cmake-options-build.yml
@@ -107,7 +107,10 @@ jobs:
         if: inputs.os == 'windows' && inputs.arch != ''
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         # msvc-dev-cmd has no Node 24 release yet (upstream ilammy/msvc-dev-cmd#105);
-        # force its node20 runtime onto node24 to clear the deprecation warning.
+        # run its node20 bundle on the node24 runtime. This restates the
+        # deprecation annotation ("forced to run on Node.js 24") rather than
+        # silencing it — the point is to exercise the runtime that survives the
+        # retirement, so a break surfaces now instead of when Node 20 is removed.
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:

--- a/.github/workflows/compile-perf-release-sweep.yml
+++ b/.github/workflows/compile-perf-release-sweep.yml
@@ -72,6 +72,13 @@ jobs:
       # never builds slang). Same pinned action common-setup uses.
       - name: Set up MSVC dev tools on Windows
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        # msvc-dev-cmd has no Node 24 release yet (upstream ilammy/msvc-dev-cmd#105);
+        # run its node20 bundle on the node24 runtime. This restates the
+        # deprecation annotation ("forced to run on Node.js 24") rather than
+        # silencing it — the point is to exercise the runtime that survives the
+        # retirement, so a break surfaces now instead of when Node 20 is removed.
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/nightly-remix-test.yml
+++ b/.github/workflows/nightly-remix-test.yml
@@ -66,7 +66,10 @@ jobs:
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         # msvc-dev-cmd has no Node 24 release yet (upstream ilammy/msvc-dev-cmd#105);
-        # force its node20 runtime onto node24 to clear the deprecation warning.
+        # run its node20 bundle on the node24 runtime. This restates the
+        # deprecation annotation ("forced to run on Node.js 24") rather than
+        # silencing it — the point is to exercise the runtime that survives the
+        # retirement, so a break surfaces now instead of when Node 20 is removed.
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,10 @@ jobs:
         if: matrix.os == 'windows'
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         # msvc-dev-cmd has no Node 24 release yet (upstream ilammy/msvc-dev-cmd#105);
-        # force its node20 runtime onto node24 to clear the deprecation warning.
+        # run its node20 bundle on the node24 runtime. This restates the
+        # deprecation annotation ("forced to run on Node.js 24") rather than
+        # silencing it — the point is to exercise the runtime that survives the
+        # retirement, so a break surfaces now instead of when Node 20 is removed.
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:


### PR DESCRIPTION
## Summary

- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` on the one `msvc-dev-cmd` step of six that was missing it.
- Correct the comment at all six sites, which described an effect the flag does not have.

## Motivation

Every Windows job logs this annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756`

That reads like an unaddressed warning, and our own comment reinforces the misreading by claiming the flag is there "to clear the deprecation warning". It isn't cleared — the annotation above is what a run looks like **with** the flag set. The flag changes the wording and, more importantly, makes the action actually execute on Node 24.

Chasing that annotation turned up the real issue: of the six `msvc-dev-cmd` uses in the tree, `compile-perf-release-sweep.yml` was the only one not setting the flag — even though its comment says *"Same pinned action common-setup uses."* The pin was mirrored; the env block was not. That job is therefore still on the un-forced path, which is the one that breaks outright when GitHub finishes the retirement rather than warning first.

There is no version to upgrade to. `ilammy/msvc-dev-cmd` v1.13.0 (2024-01-01) is the latest release and declares `runs: using: node20`; upstream's default branch still does too. [ilammy/msvc-dev-cmd#105](https://github.com/ilammy/msvc-dev-cmd/issues/105) has been open since 2026-05-12 with one comment.

## Change summary

| File | Change |
|---|---|
| `.github/workflows/compile-perf-release-sweep.yml` | add the missing `env` block |
| `.github/actions/common-setup/action.yml` | comment only |
| `.github/actions/claude-code-runner/action.yml` | comment only |
| `.github/workflows/cmake-options-build.yml` | comment only |
| `.github/workflows/nightly-remix-test.yml` | comment only |
| `.github/workflows/release.yml` | comment only |

No behavioural change to the five that already set the flag.

## Test Plan

Verified by parsing the YAML and walking the step lists rather than by grepping text, so that a correctly-indented-looking `env` attached to the wrong step would be caught:

```
OK .github/actions/claude-code-runner/action.yml -> step 'Set up MSVC dev tools (Windows)' carries the var
OK .github/actions/common-setup/action.yml -> step 'Set up MSVC dev tools on Windows' carries the var
OK .github/workflows/cmake-options-build.yml -> step 'Set up MSVC cross-compilation' carries the var
OK .github/workflows/compile-perf-release-sweep.yml -> step 'Set up MSVC dev tools on Windows' carries the var
OK .github/workflows/nightly-remix-test.yml -> step 'Setup MSVC' carries the var
OK .github/workflows/release.yml -> step 'Setup Windows dev tools for target architecture' carries the var

6/6 msvc-dev-cmd steps verified by parsed structure
```

- [x] All six steps carry the flag, confirmed against the parsed step objects
- [x] `prettier --check` clean on every touched file
- [x] No occurrence of the old "clear the deprecation warning" claim remains

The annotation itself will not disappear until upstream ships a Node 24 release; that is expected, and the revised comment now says so.
