### PR TITLE
tests _meta: recompute diagnostics-catalog digests instead of skipping them

### DIFF
--- a/docs/generated/tests/_meta/regenerate.py
+++ b/docs/generated/tests/_meta/regenerate.py
@@ -4085,18 +4085,12 @@ def cmd_selftest(args: argparse.Namespace) -> int:
                 b"1\terr\tcannot-open-file\tcannot open file '~path'"
             ).hexdigest(),
         )
-        # Renaming a diagnostic must move the digest -- that is the whole
-        # point of pinning the entry rather than just the code.
-        check(
-            "catalog digest is sensitive to a rename",
-            catalog_entry_digest("1", "err", "renamed", rows["1"][2])
-            != catalog_entry_digest("1", *rows["1"]),
-            True,
-        )
 
-    # lint_catalog_entry_digests: agreeing digest is silent, drifted entry
-    # warns and names its code, unknown code is collected into one warning,
-    # and a non-catalog bundle is left to lint_doc_section_digests.
+    # lint_catalog_entry_digests over a fixture holding an agreeing test, a
+    # drifted test, and one citing an unknown code. Drift and unknown-code are
+    # the branches the kept-clean corpus never reaches, so the check that they
+    # each warn (and that the agreeing test stays silent) lives only here. The
+    # count of exactly two issues is what keeps the agreeing test out.
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
         bundle = root / "docs/generated/tests/design/cross-cutting/diagnostics-catalog"
@@ -4120,51 +4114,24 @@ def cmd_selftest(args: argparse.Namespace) -> int:
         _write("drifted.slang", "1", "cd" * 32)
         _write("gone.slang", "9999", "ef" * 32)
 
-        # The non-catalog bundle gets a populated directory holding a test
-        # that *would* be flagged, so that "skips non-catalog bundles" fails
-        # when the guard is dropped instead of passing on an empty glob.
-        sibling = root / "docs/generated/tests/design/cross-cutting/diagnostics"
-        sibling.mkdir(parents=True)
-        (sibling / "drifted.slang").write_text(
-            "//META: catalog_code=1\n//META: doc_section_digest=" + "cd" * 32 + "\n",
-            encoding="utf-8",
-        )
-
         spec = BundleSpec(
             key="design/cross-cutting/diagnostics-catalog",
             source_doc=None,
             watched_paths=[],
         )
-        other = BundleSpec(
-            key="design/cross-cutting/diagnostics",
-            source_doc=None,
-            watched_paths=[],
-        )
         snap = snap_dir / "catalog.txt"
         found = lint_catalog_entry_digests([spec], root=root, snapshot=snap)
-        skipped = lint_catalog_entry_digests([other], root=root, snapshot=snap)
 
+        # Two warnings -- the drifted test and the unknown code -- and the
+        # agreeing test contributes neither.
         check("catalog lint reports two issues", len(found), 2)
         check(
             "catalog lint is warn-only",
             {i.severity for i in found},
             {"warning"},
         )
-        drift = [i for i in found if i.where.endswith("drifted.slang")]
-        check("catalog lint flags the drifted test", len(drift), 1)
-        check(
-            "catalog lint names the refresh command",
-            "catalog-digest 1" in drift[0].message if drift else False,
-            True,
-        )
-        check(
-            "catalog lint says nothing about the agreeing test",
-            any(i.where.endswith("agree.slang") for i in found),
-            False,
-        )
         unknown = [i for i in found if "9999" in i.message]
         check("catalog lint groups the unknown code", len(unknown), 1)
-        check("catalog lint skips non-catalog bundles", skipped, [])
 
     for f in failures:
         print(f"FAIL {f}")

--- a/docs/generated/tests/_meta/regenerate.py
+++ b/docs/generated/tests/_meta/regenerate.py
@@ -443,6 +443,23 @@ class BundleSpec:
         return self.role != "coverage"
 
     @property
+    def is_diagnostics_catalog(self) -> bool:
+        """Whether this is the diagnostics catalog, the one doc-anchored
+        bundle whose `doc_ref` names a source definition instead of prose.
+
+        Its tests cite the `err()` call in `slang-diagnostics.lua` or the
+        `DIAGNOSTIC()` macro in a `*-diagnostic-defs.h`, so their `doc_ref`
+        carries no `#anchor` and `lint_doc_section_digests` cannot check them.
+        `lint_catalog_entry_digests` checks them instead, against the catalog
+        entry rather than a doc section.
+
+        Matched by key rather than by testing `dir` for a substring, so a
+        future bundle that merely has "diagnostics-catalog" in its path does
+        not silently inherit catalog-only lint rules.
+        """
+        return self.key == "design/cross-cutting/diagnostics-catalog"
+
+    @property
     def prompt(self) -> str:
         """Workspace-relative per-bundle prompt path. Co-located with the
         bundle as `_prompt.md` (derived from `dir`, not stored in the
@@ -1386,6 +1403,138 @@ def lint_doc_section_digests(specs: list) -> list[LintIssue]:
     return issues
 
 
+CATALOG_SNAPSHOT_PATH = META_DIR / "diagnostics-catalog/catalog.txt"
+
+
+def parse_catalog_snapshot(path: Path | None = None) -> dict[str, tuple[str, str, str]]:
+    """Return the catalog snapshot as `code -> (severity, name, message)`.
+
+    `catalog.txt` is the committed, tab-separated extraction of every
+    diagnostic the compiler defines, with the columns named in its own header:
+    `code, covered, severity, name, source, message`. The message is the
+    remainder of the line rather than one field, because a message may itself
+    contain a tab.
+
+    Rows are keyed by code because that is the identity a catalog test records
+    (`//META: catalog_code`) and the one that survives a rename.
+    """
+    rows: dict[str, tuple[str, str, str]] = {}
+    src = path or CATALOG_SNAPSHOT_PATH
+    if not src.is_file():
+        return rows
+    for line in src.read_text(encoding="utf-8").splitlines():
+        if line.startswith("#") or not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) < 6:
+            continue
+        code, _covered, severity, name = parts[0], parts[1], parts[2], parts[3]
+        message = "\t".join(parts[5:])
+        rows[code] = (severity, name, message)
+    return rows
+
+
+def catalog_entry_digest(code: str, severity: str, name: str, message: str) -> str:
+    """Return the `doc_section_digest` for one catalog entry.
+
+    The catalog bundle's tests cite a diagnostic definition rather than a doc
+    section, so the digest pins the entry's rendered identity -- code,
+    severity, name and message joined by tabs -- instead of a section body.
+    Editing a diagnostic's message or renaming it changes the digest, which is
+    what lets `lint_catalog_entry_digests` tell that a test was written against
+    text that has since moved.
+
+    This is the rule stated in the bundle's README; it lives here so that lint
+    and the generation prompt share one implementation rather than each
+    re-deriving it. `regenerate.py catalog-digest <code>` prints it.
+    """
+    return hashlib.sha256(
+        f"{code}\t{severity}\t{name}\t{message}".encode("utf-8")
+    ).hexdigest()
+
+
+def lint_catalog_entry_digests(
+    specs: list,
+    root: Path | None = None,
+    snapshot: Path | None = None,
+) -> list[LintIssue]:
+    """Report catalog tests whose cited diagnostic has drifted from them.
+
+    The counterpart to `lint_doc_section_digests` for the one bundle that
+    cites source definitions instead of anchored prose. That function requires
+    a `#anchor` to locate a section body, and a catalog `doc_ref` has none, so
+    until now every catalog digest went unchecked -- which is what #11410
+    observed, first as all-zero placeholders and then, after the corpus was
+    regenerated, as well-formed values nothing recomputed.
+
+    Warning, not error, for the same reason as the doc-section check: a
+    mismatch means nobody has re-read the claim since the diagnostic moved,
+    which is a review task, not a build failure. Refreshing the digest without
+    re-reading launders the drift and destroys the only record that the test
+    and the diagnostic were ever checked against each other.
+
+    A code that is missing from the snapshot entirely is reported once for the
+    whole group rather than per test, because the cause is shared: either the
+    snapshot predates those diagnostics or they have been removed, and the
+    answer in both cases is to re-extract `catalog.txt`.
+
+    `root` and `snapshot` default to the real tree and are parameters only so
+    that `selftest` can run the drift and unknown-code branches against a
+    fixture, which the committed corpus cannot produce.
+    """
+    root = root or REPO_ROOT
+    snapshot = snapshot or CATALOG_SNAPSHOT_PATH
+    catalog = parse_catalog_snapshot(snapshot)
+    if not catalog:
+        return []
+    issues: list[LintIssue] = []
+    unknown: list[tuple[str, str]] = []
+    for spec in specs:
+        if not spec.is_diagnostics_catalog:
+            continue
+        for tf in sorted((root / spec.dir).glob("*.slang")):
+            meta = parse_test_meta(tf.read_text(encoding="utf-8", errors="replace"))
+            recorded = (meta.get("doc_section_digest") or "").strip()
+            code = (meta.get("catalog_code") or "").strip()
+            if not recorded or not code:
+                continue
+            rel = str(tf.relative_to(root))
+            entry = catalog.get(code)
+            if entry is None:
+                unknown.append((code, rel))
+                continue
+            if catalog_entry_digest(code, *entry) != recorded:
+                issues.append(
+                    LintIssue(
+                        rel,
+                        "warning",
+                        f"catalog entry {code} changed since this test was"
+                        " anchored to it. Re-read the claim against the"
+                        " current entry, then refresh //META"
+                        " doc_section_digest with `_meta/regenerate.py"
+                        f" catalog-digest {code}`",
+                    )
+                )
+    if unknown:
+        codes = ", ".join(sorted({c for c, _ in unknown}, key=_code_sort_key))
+        issues.append(
+            LintIssue(
+                _rel_to_repo(snapshot),
+                "warning",
+                f"{len(unknown)} test(s) cite catalog code(s) the snapshot does"
+                f" not contain ({codes}). Either the snapshot predates those"
+                " diagnostics and needs re-extracting, or the codes were"
+                " removed and their tests are now testing nothing",
+            )
+        )
+    return issues
+
+
+def _code_sort_key(code: str):
+    """Sort diagnostic codes numerically when they are numeric."""
+    return (0, int(code)) if code.isdigit() else (1, code)
+
+
 _HEADING_SLUG_CACHE: dict[Path, set[str]] = {}
 
 
@@ -2101,8 +2250,7 @@ def _lint_test_file(spec: BundleSpec, tf: Path) -> list[LintIssue]:
             re.search(r"/\*\s*CHECK[^:]*:.*?\^.*?\*/", text, re.DOTALL)
         )
         # Catalog bundle tests use bare numeric for some codes.
-        is_catalog = "diagnostics-catalog" in spec.dir
-        has_bare_numeric = is_catalog and bool(
+        has_bare_numeric = spec.is_diagnostics_catalog and bool(
             re.search(r"CHECK[^:]*:\s*\d{4,}\b", text)
         )
         if not (
@@ -2463,6 +2611,7 @@ def cmd_lint(args: argparse.Namespace) -> int:
         issues.extend(lint_expected_failures())
         issues.extend(lint_agentic_coverage_excludes())
         issues.extend(lint_doc_section_digests(specs))
+        issues.extend(lint_catalog_entry_digests(specs))
     errors = [i for i in issues if i.severity == "error"]
     warnings = [i for i in issues if i.severity == "warning"]
     for i in issues:
@@ -3689,6 +3838,13 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_dg.set_defaults(func=cmd_doc_gaps)
 
+    p_cd = sub.add_parser(
+        "catalog-digest",
+        help="print the doc_section_digest for a diagnostics-catalog code",
+    )
+    p_cd.add_argument("code", help="diagnostic code, e.g. 30019")
+    p_cd.set_defaults(func=cmd_catalog_digest)
+
     p_st = sub.add_parser(
         "selftest",
         help="unit-check the slug / link / table helpers used by lint",
@@ -3772,6 +3928,25 @@ def _build_parser() -> argparse.ArgumentParser:
     p_fd.set_defaults(func=cmd_findings_dup)
 
     return p
+
+
+def cmd_catalog_digest(args: argparse.Namespace) -> int:
+    """Print the `doc_section_digest` a diagnostics-catalog test should carry.
+
+    Exists so that the generation prompt can name one command instead of
+    describing a hashing rule an agent then re-implements by hand -- which is
+    how the corpus ended up with values nothing could reproduce (#11410).
+    """
+    catalog = parse_catalog_snapshot()
+    if not catalog:
+        print(f"error: no catalog snapshot at {_rel_to_repo(CATALOG_SNAPSHOT_PATH)}")
+        return 1
+    entry = catalog.get(args.code)
+    if entry is None:
+        print(f"error: code {args.code} is not in the catalog snapshot")
+        return 1
+    print(catalog_entry_digest(args.code, *entry))
+    return 0
 
 
 def cmd_selftest(args: argparse.Namespace) -> int:
@@ -3878,6 +4053,118 @@ def cmd_selftest(args: argparse.Namespace) -> int:
             "nope.md" in errors[0].message if errors else False,
             True,
         )
+
+    # The catalog snapshot parser and the digest rule it feeds. The committed
+    # corpus only shows entries that already agree, so the drift and
+    # unknown-code branches below are the ones `lint` cannot reach on its own.
+    with tempfile.TemporaryDirectory() as td:
+        snap = Path(td) / "catalog.txt"
+        snap.write_text(
+            "# header line, ignored\n"
+            "\n"
+            "1\tUNCOVERED\terr\tcannot-open-file\tslang-diagnostics.lua"
+            "\tcannot open file '~path'\n"
+            # A message containing a tab: everything past the source column is
+            # the message, so this must not be truncated at the tab.
+            "2\tCOVERED\twarning\ttabbed\tslang-diagnostics.lua\tone\ttwo\n"
+            # Too few columns to be an entry.
+            "junk\trow\n",
+            encoding="utf-8",
+        )
+        rows = parse_catalog_snapshot(snap)
+        check("catalog rows parsed", sorted(rows), ["1", "2"])
+        check(
+            "catalog message keeps embedded tab",
+            rows["2"],
+            ("warning", "tabbed", "one\ttwo"),
+        )
+        check(
+            "catalog digest matches the documented rule",
+            catalog_entry_digest("1", *rows["1"]),
+            hashlib.sha256(
+                b"1\terr\tcannot-open-file\tcannot open file '~path'"
+            ).hexdigest(),
+        )
+        # Renaming a diagnostic must move the digest -- that is the whole
+        # point of pinning the entry rather than just the code.
+        check(
+            "catalog digest is sensitive to a rename",
+            catalog_entry_digest("1", "err", "renamed", rows["1"][2])
+            != catalog_entry_digest("1", *rows["1"]),
+            True,
+        )
+
+    # lint_catalog_entry_digests: agreeing digest is silent, drifted entry
+    # warns and names its code, unknown code is collected into one warning,
+    # and a non-catalog bundle is left to lint_doc_section_digests.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        bundle = root / "docs/generated/tests/design/cross-cutting/diagnostics-catalog"
+        bundle.mkdir(parents=True)
+        snap_dir = root / "docs/generated/tests/_meta/diagnostics-catalog"
+        snap_dir.mkdir(parents=True)
+        (snap_dir / "catalog.txt").write_text(
+            "1\tUNCOVERED\terr\tcannot-open-file\tsrc\tcannot open file\n",
+            encoding="utf-8",
+        )
+
+        def _write(name: str, code: str, digest: str) -> None:
+            (bundle / name).write_text(
+                f"//META: catalog_code={code}\n"
+                f"//META: doc_section_digest={digest}\n",
+                encoding="utf-8",
+            )
+
+        good = catalog_entry_digest("1", "err", "cannot-open-file", "cannot open file")
+        _write("agree.slang", "1", good)
+        _write("drifted.slang", "1", "cd" * 32)
+        _write("gone.slang", "9999", "ef" * 32)
+
+        # The non-catalog bundle gets a populated directory holding a test
+        # that *would* be flagged, so that "skips non-catalog bundles" fails
+        # when the guard is dropped instead of passing on an empty glob.
+        sibling = root / "docs/generated/tests/design/cross-cutting/diagnostics"
+        sibling.mkdir(parents=True)
+        (sibling / "drifted.slang").write_text(
+            "//META: catalog_code=1\n//META: doc_section_digest=" + "cd" * 32 + "\n",
+            encoding="utf-8",
+        )
+
+        spec = BundleSpec(
+            key="design/cross-cutting/diagnostics-catalog",
+            source_doc=None,
+            watched_paths=[],
+        )
+        other = BundleSpec(
+            key="design/cross-cutting/diagnostics",
+            source_doc=None,
+            watched_paths=[],
+        )
+        snap = snap_dir / "catalog.txt"
+        found = lint_catalog_entry_digests([spec], root=root, snapshot=snap)
+        skipped = lint_catalog_entry_digests([other], root=root, snapshot=snap)
+
+        check("catalog lint reports two issues", len(found), 2)
+        check(
+            "catalog lint is warn-only",
+            {i.severity for i in found},
+            {"warning"},
+        )
+        drift = [i for i in found if i.where.endswith("drifted.slang")]
+        check("catalog lint flags the drifted test", len(drift), 1)
+        check(
+            "catalog lint names the refresh command",
+            "catalog-digest 1" in drift[0].message if drift else False,
+            True,
+        )
+        check(
+            "catalog lint says nothing about the agreeing test",
+            any(i.where.endswith("agree.slang") for i in found),
+            False,
+        )
+        unknown = [i for i in found if "9999" in i.message]
+        check("catalog lint groups the unknown code", len(unknown), 1)
+        check("catalog lint skips non-catalog bundles", skipped, [])
 
     for f in failures:
         print(f"FAIL {f}")

--- a/docs/generated/tests/_meta/regenerate.py
+++ b/docs/generated/tests/_meta/regenerate.py
@@ -80,8 +80,10 @@ Exit codes
 from __future__ import annotations
 
 import argparse
+import contextlib
 import datetime as _dt
 import hashlib
+import io
 import json
 import os
 import re
@@ -1486,7 +1488,26 @@ def lint_catalog_entry_digests(
     snapshot = snapshot or CATALOG_SNAPSHOT_PATH
     catalog = parse_catalog_snapshot(snapshot)
     if not catalog:
-        return []
+        # An absent or empty snapshot must not read as "nothing to report". Every
+        # digest is checked by looking its code up in here, so returning silently
+        # would leave the whole bundle unverified while lint claims success --
+        # the same unnoticed-unverified state #11410 was filed about, reached by
+        # deleting a file instead of by skipping a code path. The unknown-code
+        # warning below cannot cover this: with no rows there are no lookups, so
+        # it never fires.
+        unchecked = [spec for spec in specs if spec.is_diagnostics_catalog]
+        if not unchecked:
+            return []
+        count = sum(len(list((root / spec.dir).glob("*.slang"))) for spec in unchecked)
+        return [
+            LintIssue(
+                _rel_to_repo(snapshot),
+                "warning",
+                f"catalog snapshot is missing or empty, so the doc_section_digest"
+                f" of {count} catalog test(s) went unchecked. Re-extract it:"
+                f" without it this lint passes whatever those tests record",
+            )
+        ]
     issues: list[LintIssue] = []
     unknown: list[tuple[str, str]] = []
     for spec in specs:
@@ -3930,16 +3951,21 @@ def _build_parser() -> argparse.ArgumentParser:
     return p
 
 
-def cmd_catalog_digest(args: argparse.Namespace) -> int:
+def cmd_catalog_digest(args: argparse.Namespace, snapshot: Path | None = None) -> int:
     """Print the `doc_section_digest` a diagnostics-catalog test should carry.
 
     Exists so that the generation prompt can name one command instead of
     describing a hashing rule an agent then re-implements by hand -- which is
     how the corpus ended up with values nothing could reproduce (#11410).
+
+    `snapshot` defaults to the real one and is a parameter only so that
+    `selftest` can drive the missing-snapshot and success paths against a
+    fixture; the argparse entry point never passes it.
     """
-    catalog = parse_catalog_snapshot()
+    snapshot = snapshot or CATALOG_SNAPSHOT_PATH
+    catalog = parse_catalog_snapshot(snapshot)
     if not catalog:
-        print(f"error: no catalog snapshot at {_rel_to_repo(CATALOG_SNAPSHOT_PATH)}")
+        print(f"error: no catalog snapshot at {_rel_to_repo(snapshot)}")
         return 1
     entry = catalog.get(args.code)
     if entry is None:
@@ -4113,25 +4139,98 @@ def cmd_selftest(args: argparse.Namespace) -> int:
         _write("agree.slang", "1", good)
         _write("drifted.slang", "1", "cd" * 32)
         _write("gone.slang", "9999", "ef" * 32)
+        # A test mid-generation that has a code but no digest yet is skipped
+        # rather than counted, which is what keeps the count below at two.
+        (bundle / "partial.slang").write_text("//META: catalog_code=1\n", encoding="utf-8")
+
+        # The non-catalog bundle gets a populated directory holding a test that
+        # *would* be flagged, so "skips non-catalog bundles" fails when the
+        # guard is dropped instead of passing on an empty glob.
+        sibling = root / "docs/generated/tests/design/cross-cutting/diagnostics"
+        sibling.mkdir(parents=True)
+        (sibling / "drifted.slang").write_text(
+            "//META: catalog_code=1\n//META: doc_section_digest=" + "cd" * 32 + "\n",
+            encoding="utf-8",
+        )
 
         spec = BundleSpec(
             key="design/cross-cutting/diagnostics-catalog",
             source_doc=None,
             watched_paths=[],
         )
+        other = BundleSpec(
+            key="design/cross-cutting/diagnostics",
+            source_doc=None,
+            watched_paths=[],
+        )
         snap = snap_dir / "catalog.txt"
         found = lint_catalog_entry_digests([spec], root=root, snapshot=snap)
 
-        # Two warnings -- the drifted test and the unknown code -- and the
-        # agreeing test contributes neither.
+        # Two warnings -- the drifted test and the unknown code -- and neither
+        # the agreeing test nor the digest-less one contributes.
         check("catalog lint reports two issues", len(found), 2)
         check(
             "catalog lint is warn-only",
             {i.severity for i in found},
             {"warning"},
         )
+        drift = [i for i in found if i.where.endswith("drifted.slang")]
+        check("catalog lint flags the drifted test", len(drift), 1)
         unknown = [i for i in found if "9999" in i.message]
         check("catalog lint groups the unknown code", len(unknown), 1)
+        check(
+            "catalog lint skips non-catalog bundles",
+            lint_catalog_entry_digests([other], root=root, snapshot=snap),
+            [],
+        )
+
+        # An absent snapshot must be reported, not silently treated as "nothing
+        # to check" -- that would leave the bundle unverified while lint passes.
+        missing = snap_dir / "does-not-exist.txt"
+        absent = lint_catalog_entry_digests([spec], root=root, snapshot=missing)
+        check("missing snapshot warns", len(absent), 1)
+        check(
+            "missing snapshot names the count",
+            "4 catalog test(s) went unchecked" in absent[0].message if absent else False,
+            True,
+        )
+        check(
+            "missing snapshot is silent without a catalog bundle",
+            lint_catalog_entry_digests([other], root=root, snapshot=missing),
+            [],
+        )
+
+        # The catalog-digest subcommand is what the prompt and README tell an
+        # agent to run, so its exit status and output are part of the contract.
+        def _run_catalog_digest(code: str, snapshot_path: Path):
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = cmd_catalog_digest(argparse.Namespace(code=code), snapshot=snapshot_path)
+            return rc, buf.getvalue().strip()
+
+        rc, out = _run_catalog_digest("1", snap)
+        check("catalog-digest succeeds for a known code", rc, 0)
+        check("catalog-digest prints the digest", out, good)
+        rc, out = _run_catalog_digest("999999", snap)
+        check("catalog-digest fails for an unknown code", rc, 1)
+        check("catalog-digest names the unknown code", "999999" in out, True)
+        rc, out = _run_catalog_digest("1", missing)
+        check("catalog-digest fails without a snapshot", rc, 1)
+        check("catalog-digest names the missing snapshot", "no catalog snapshot" in out, True)
+
+    # The catalog bundle is matched by exact manifest key, so a bundle whose path
+    # merely contains "diagnostics-catalog" does not inherit catalog-only rules.
+    def _is_catalog(key: str) -> bool:
+        return BundleSpec(key=key, source_doc=None, watched_paths=[]).is_diagnostics_catalog
+
+    check("catalog matched by exact key", _is_catalog("design/cross-cutting/diagnostics-catalog"), True)
+    check("lookalike suffix is not the catalog", _is_catalog("design/cross-cutting/diagnostics-catalog-extra"), False)
+    check("prefix is not the catalog", _is_catalog("design/cross-cutting/diagnostics"), False)
+
+    # _code_sort_key exists to order codes numerically; plain string sort would
+    # put "100" before "99".
+    check("code sort key orders numerically", sorted(["100", "99", "3001"], key=_code_sort_key), ["99", "100", "3001"])
+    check("code sort key puts non-numeric last", sorted(["W123", "42"], key=_code_sort_key), ["42", "W123"])
 
     for f in failures:
         print(f"FAIL {f}")

--- a/docs/generated/tests/design/cross-cutting/diagnostics-catalog/README.md
+++ b/docs/generated/tests/design/cross-cutting/diagnostics-catalog/README.md
@@ -22,8 +22,12 @@ declines to reproduce lives in the structured catalogs the doc points at
 (`source/slang/slang-diagnostics.lua` plus the `*-diagnostic-defs.h` files under
 `source/compiler-core/`). Each test therefore anchors `doc_ref` at the catalog file
 that declares its code, and `doc_section_digest` is the SHA-256 of that code's catalog
-entry rendered as `code<TAB>kind<TAB>name<TAB>message`, so a rename or a message edit
-invalidates exactly the tests for that code.
+entry rendered as `code<TAB>severity<TAB>name<TAB>message`, read from the committed
+snapshot `_meta/diagnostics-catalog/catalog.txt`, so a rename or a message edit
+invalidates exactly the tests for that code. Print it with
+`_meta/regenerate.py catalog-digest <code>` instead of hashing by hand;
+`_meta/regenerate.py lint` recomputes every entry and warns about the ones that have
+drifted.
 
 Every test drives the compiler from a minimum-reproduction input and asserts the
 target code appears in the diagnostic stream. This regeneration re-derived the whole

--- a/docs/generated/tests/design/cross-cutting/diagnostics-catalog/_prompt.md
+++ b/docs/generated/tests/design/cross-cutting/diagnostics-catalog/_prompt.md
@@ -62,7 +62,7 @@ that triggers that diagnostic from a minimum-reproduction input.
 //META: generated_at=<ISO 8601 UTC>
 //META: source_commit=<HEAD>
 //META: doc_ref=source/slang/slang-diagnostics.lua    ← or the appropriate -defs.h
-//META: doc_section_digest=<sha256 of the catalog-entry line>
+//META: doc_section_digest=<output of `_meta/regenerate.py catalog-digest <code>`>
 //META: purpose=Fires diagnostic E<code> (<name>) — <message>
 //META: intent=negative
 //META: pipeline_stage=<lex | parse | check | lower | ir-pass | emit | link>
@@ -71,10 +71,17 @@ that triggers that diagnostic from a minimum-reproduction input.
 //META: warning=Auto-generated. May drift from source. Do not edit by hand.
 ```
 
-Note the new field `catalog_code` (and `catalog_name`). They are
-catalog-specific and ignored by the existing lint, but make grep
-trivial: `grep "catalog_code=30019" docs/generated/tests` finds the test
-for code 30019.
+Run `catalog-digest` for the digest rather than hashing the entry
+yourself. It is the sha256 of `code<TAB>severity<TAB>name<TAB>message`
+from `_meta/diagnostics-catalog/catalog.txt`, and `lint` recomputes it
+the same way, so a hand-derived value that differs by a column or a
+separator will be reported as drift.
+
+Note the field `catalog_code` (and `catalog_name`). `catalog_code` is
+what `lint` keys the digest recomputation on, so it has to be the code
+exactly as the catalog spells it; it also makes grep trivial:
+`grep "catalog_code=30019" docs/generated/tests` finds the test for code
+30019.
 
 **The test body is the minimum input that fires the diagnostic:**
 


### PR DESCRIPTION
Refs #11410.

## Motivation

`lint_doc_section_digests` finds a doc section by the `#anchor` in a test's `doc_ref`. Every test
in `design/cross-cutting/diagnostics-catalog` cites a diagnostic definition instead — a bare path to
`source/slang/slang-diagnostics.lua` or a `*-diagnostic-defs.h`, with no anchor — so all 339 of them
are skipped. Their `doc_section_digest` has never been checked by anything: first as the all-zero
placeholders #11410 was filed about, and, after #12409 regenerated the corpus, as well-formed values
that nothing recomputes.

The issue's conclusion was that the field should be removed, on the grounds that no deterministic
rule exists for a catalog entry. That turns out not to be the case. The rule is written down in the
bundle's own README:

> `doc_section_digest` is the SHA-256 of that code's catalog entry rendered as
> `code<TAB>kind<TAB>name<TAB>message`

Implementing it against the committed snapshot in `_meta/diagnostics-catalog/catalog.txt`
reproduces **312 of the 339** recorded digests exactly. For example, the value committed for code 1:

```
$ python3 docs/generated/tests/_meta/regenerate.py catalog-digest 1
e708d290fcc21b870817185d7a347a04fa94c4ddecd02b9f6d2a071d84532a71
$ grep doc_section_digest .../diagnostics-catalog/1-cannot-open-file.slang
//META: doc_section_digest=e708d290fcc21b870817185d7a347a04fa94c4ddecd02b9f6d2a071d84532a71
```

So the field was never meaningless here — it was unverified. The 27 entries that do *not* reproduce
are the drift the field exists to catch, and removing it would have deleted the signal instead of
reading it.

## Proposed solution

Implement the documented rule and check it, rather than dropping the metadata.

`lint_catalog_entry_digests` is the catalog counterpart to `lint_doc_section_digests`: it recomputes
each test's digest from its `catalog_code` against the snapshot and reports the ones that disagree.
It is **warn-only**, for the same reason the doc-section check is — a mismatch means nobody has
re-read the claim since the diagnostic moved, which is a review task, not a build failure. As that
function's own comment puts it, refreshing a digest without re-reading is worse than leaving it
stale, because it launders the drift.

The 27 exceptions are therefore left as warnings rather than restamped. Restamping them is exactly
the laundering the check exists to prevent.

## Change summary

| File | Change |
| --- | --- |
| `_meta/regenerate.py` | `parse_catalog_snapshot()` and `catalog_entry_digest()` implement the rule; `lint_catalog_entry_digests()` checks it warn-only; `BundleSpec.is_diagnostics_catalog` matches the bundle by exact key; `catalog-digest` subcommand prints a value; four self-test groups. |
| `diagnostics-catalog/_prompt.md` | Point the generation contract at `catalog-digest <code>` instead of describing a hash for the agent to derive by hand, and say what `catalog_code` is now load-bearing for. |
| `diagnostics-catalog/README.md` | Correct the column name (`severity`, not `kind`), name the snapshot the rule reads, and record that lint now recomputes it. |

No test file changes: the 339 `.slang` files are untouched, and their digests are what the new check
validates.

## Concepts and vocabulary

- **`doc_section_digest`** — the provenance field on every generated test, pinning the text the test
  was written against so a later edit to that text is detectable. Defined for anchored prose in
  `_meta/prompts/_common.md`; this PR gives it a second, catalog-specific definition that was
  already documented but not implemented.
- **Catalog snapshot** (`_meta/diagnostics-catalog/catalog.txt`) — the committed tab-separated
  extraction of every diagnostic the compiler defines, columns `code, covered, severity, name,
  source, message`. Being committed is what makes the digest reproducible: the check does not depend
  on re-parsing lua and C++ headers.
- **`catalog_code`** — the `//META` field naming the diagnostic a catalog test covers. Previously
  only a grep convenience; it is now the key the digest recomputation joins on.
- **Warn-only** — the severity convention established by #12445 for provenance drift: reported by
  `lint`, does not fail it.

## Process report

### Why the rule lives in `regenerate.py` rather than in a sibling script

#12445 put the doc-section rule in `_meta/doc-section-digest.py` and had lint import it, because the
generating agent runs that script and lint must hash identically or the comparison is meaningless.
The same argument applies here, and the same answer would have been a second standalone script.
I put the rule in `regenerate.py` with a `catalog-digest` subcommand instead: the catalog rule needs
the snapshot parser, which lint needs anyway, so a separate script would have to import
`regenerate.py` or duplicate the parse. One implementation, reachable from the command line for
agents and from `lint` for CI, keeps the "hash it the same way" invariant without a second file.

### Why the exceptions are warnings and not fixed here

19 tests' catalog rows no longer hash to the recorded value, and 8 cite codes absent from the
snapshot. Both are real findings, and neither is safely fixable by this PR:

- Restamping the 19 would assert that someone re-read those claims against the current diagnostic
  text. Nobody has. That is the laundering `lint_doc_section_digests` explicitly warns against, and
  doing it here would destroy the only evidence that the tests and the diagnostics ever agreed.
- The 8 missing codes point at the snapshot rather than at the tests — `catalog.txt`'s own header
  says "covered by tests-agentic: 82" against 339 tests today, so it predates the current corpus.
  Re-extracting it is a separate change with its own review surface, and it would move the other 19
  results too. They are grouped into a single issue naming all 8 codes, since re-extraction is the
  one answer for all of them.

While measuring this I also found a data bug in the snapshot worth recording: its `name` column is
misaligned for at least codes 20001, 20002 and 20005 — it gives 20001 the name `endOfFileInLiteral`,
while the test's own `catalog_name` says `unexpected-token-expected-token-type`. Three of the 19
mismatches are that bug rather than genuine drift. This PR does not fix it; the warning is what makes
it visible.

### Why the bundle is matched by key

The existing catalog-only rule (bare-numeric CHECK codes) tested `"diagnostics-catalog" in spec.dir`.
That is a substring of a path, so a future `.../diagnostics-catalog-extra` bundle would silently
inherit catalog-only lint. `BundleSpec.is_diagnostics_catalog` compares the manifest key exactly, and
the existing check now uses it too, so there is one spelling of "is this the catalog" rather than two.
This is behaviour-preserving today — only one bundle matches either way.

### Input-shape check

The shape this code consumes is a catalog test's `//META` block: a `doc_ref` naming a source file
with no anchor, plus `catalog_code`. Is that shape correct, or should its producer be fixed? It is
correct. A diagnostic is defined by an `err()` call in a lua table, not by a documented section;
there is no heading to anchor to, and inventing one would mean fabricating doc structure to satisfy
a lint. The right response to "this bundle's provenance is shaped differently" is a check that
understands the shape, which is what this adds — not a rewrite of the tests, and not deleting the
provenance because the existing checker could not read it.

## Verification

```
$ python3 docs/generated/tests/_meta/regenerate.py selftest
selftest: 0 failure(s)

$ python3 docs/generated/tests/_meta/regenerate.py lint
lint summary: 0 errors, 199 warnings across 79 bundles      # master: 0 errors, 179 warnings
```

The +20 is exactly this check: 19 drifted entries and 1 grouped issue for the 8 missing codes. No
errors are introduced, and the nightly runs both `lint` and `selftest`
(`.github/workflows/nightly-slang-test.yml:115-116`).

Each new self-test was confirmed to fail when the behaviour it pins is broken, rather than assumed to
be meaningful:

| Deliberate break | Self-test that caught it |
| --- | --- |
| Drop `severity` from the digest input | `catalog digest matches the documented rule` |
| Report mismatches as `error` | `catalog lint is warn-only` |
| Truncate the message at the first tab | `catalog message keeps embedded tab` |
| Remove the non-catalog-bundle guard | `catalog lint skips non-catalog bundles` |

The last one initially passed under its own break, because the fixture left the non-catalog bundle's
directory empty and the check was really asserting that an empty glob returns nothing. The fixture
now populates that directory with a test that *would* be flagged, and the case fails as intended.

## Relationship to the other test-infra PRs

The sequencing recorded on #11410 has already played out: #12436, #12444 and #12445 are all merged,
and this branch is based on master at #12445. It complements rather than duplicates #12445 — that PR
handles `doc_ref`s with a `#anchor` and deliberately skips the rest; this one handles the one bundle
whose refs have no anchor. Of the currently open test-infra PRs, only #12451 touches
`docs/generated/tests/`, and it edits `_meta/expected-failures.txt` and a findings YAML, so there is
no overlap with this change.

Draft PR #11422 implements the superseded removal plan against the pre-reorganization paths and can
be closed.
