### PR TITLE
docs/generated: consume test-suite doc gaps in the design-doc workflow

### DIFF
--- a/.github/workflows/check-doc-gaps.yml
+++ b/.github/workflows/check-doc-gaps.yml
@@ -1,0 +1,91 @@
+name: Check generated-docs gap queue (advisory)
+
+# Reports the doc gaps the agentic test suite has found in the generated
+# design docs, and hard-gates the structural lint of both trees.
+#
+# Two things happen here, with deliberately different severities:
+#
+#   * `lint` is a HARD GATE. A lint failure means a structural contract was
+#     broken -- a gap row that names no document, a malformed ledger entry, a
+#     gap-intake report whose action table disagrees with its own counts.
+#     Those are always the author's mistake and are always cheap to fix.
+#
+#   * The gap report is ADVISORY. Open gaps are a work queue, not a defect in
+#     the PR at hand: a source change can legitimately make the docs report
+#     more gaps without the PR being wrong. Blocking on the queue would
+#     pressure authors into hand-editing generated docs, which is the one
+#     thing this whole system forbids.
+#
+# No build is required -- the drivers are pure Python over markdown -- so this
+# runs on a plain ubuntu runner in seconds rather than riding along with the
+# agentic-tests nightly, which needs a full slang build and would make the
+# report hostage to a build failure.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 05:00 UTC, an hour after ci-agentic-tests-nightly's 04:00 slot, so the
+    # queue reported here reflects the suite that just ran.
+    - cron: "0 5 * * *"
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
+    # Only PRs that touch the generated trees or the drivers can change what
+    # this reports.
+    paths:
+      - "docs/generated/**"
+      - "docs/language-reference/**"
+      - ".github/workflows/check-doc-gaps.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  doc-gaps:
+    if: github.event.pull_request.draft != true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      # Hard gate. Both drivers, both trees.
+      - name: Lint the generated design docs
+        run: python3 docs/generated/design/_meta/regenerate.py lint
+
+      - name: Lint the agentic test bundles
+        run: python3 docs/generated/tests/_meta/regenerate.py lint
+
+      - name: Self-check the test driver's lint helpers
+        run: python3 docs/generated/tests/_meta/regenerate.py selftest
+
+      # Advisory from here down. `continue-on-error` keeps a surprise in the
+      # report from failing the check.
+      - name: Report the design-doc gap queue
+        continue-on-error: true
+        run: |
+          python3 docs/generated/design/_meta/regenerate.py gap-status \
+              --only-open --format markdown >> "$GITHUB_STEP_SUMMARY"
+
+      # The language reference is written by hand, so no agent may edit it and
+      # these gaps cannot be worked by the gap-intake stage. They are a human
+      # triage queue: read the table, and file the ones worth acting on.
+      - name: Report the language-reference gap queue
+        continue-on-error: true
+        run: |
+          {
+            echo "### Gaps against the hand-written language reference"
+            echo
+            echo "No agent may edit \`docs/language-reference/\`, so these are a"
+            echo "human triage queue rather than gap-intake work."
+            echo
+            python3 docs/generated/tests/_meta/regenerate.py doc-gaps \
+                --tree language-reference
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/check-doc-gaps.yml
+++ b/.github/workflows/check-doc-gaps.yml
@@ -30,8 +30,11 @@ on:
   pull_request:
     branches: [master]
     types: [opened, synchronize, reopened, ready_for_review]
-    # Only PRs that touch the generated trees or the drivers can change what
-    # this reports.
+    # `docs/generated/**` and this workflow are what can change the reported
+    # numbers. `docs/language-reference/**` cannot -- the language-reference
+    # queue is derived from the test bundles' own tables, not from the spec
+    # source -- and is listed on purpose anyway, so that a spec editor sees
+    # the standing human-triage queue against the pages they are editing.
     paths:
       - "docs/generated/**"
       - "docs/language-reference/**"
@@ -65,6 +68,9 @@ jobs:
 
       - name: Self-check the test driver's lint helpers
         run: python3 docs/generated/tests/_meta/regenerate.py selftest
+
+      - name: Self-check the design driver's ledger helpers
+        run: python3 docs/generated/design/_meta/regenerate.py selftest
 
       # Advisory from here down. `continue-on-error` keeps a surprise in the
       # report from failing the check.

--- a/docs/generated/design/_meta/doc-gap-state.json
+++ b/docs/generated/design/_meta/doc-gap-state.json
@@ -1,0 +1,4 @@
+{
+  "gaps": {},
+  "schema_version": 1
+}

--- a/docs/generated/design/_meta/prompts/_gap-intake.md
+++ b/docs/generated/design/_meta/prompts/_gap-intake.md
@@ -1,0 +1,266 @@
+# Gap-intake prompt for an LLM-generated documentation page
+
+## Identity gate — read first
+
+This prompt is for the **gap-intake** stage of the
+`docs/generated/design/` workflow. Intake edits the generated documents,
+so it must be performed by the same model family that generated them
+(Anthropic Claude), keeping the prose stylistically coherent with the
+rest of the tree.
+
+If you are **not** an Anthropic Claude model (any GPT, Gemini, Llama,
+Mistral, or other family), you **must refuse**. Output exactly the
+following line and stop, with no other content:
+
+```
+REFUSED: non-Claude model detected; the gap-intake step requires the same model family that generated the docs
+```
+
+Do not produce a gap-intake report. Do not apply edits. Do not "explain
+why" you cannot do the work. Just emit the refusal line and stop.
+
+If you are a Claude model (any variant — Opus, Sonnet, Haiku, or any
+future Claude release), proceed.
+
+## What a doc gap is, and why it is not a review finding
+
+The agentic test suite under `docs/generated/tests/` writes tests
+against this document and then runs them. Where a test showed the
+document to be wrong, incomplete, or ambiguous in a way that is not a
+compiler bug, the reporting bundle recorded a row in its README's
+`## Doc gaps observed` table. `regenerate.py doc-gaps` aggregates those
+rows and gives each a stable `gap_id`.
+
+This is evidence the review stage structurally cannot produce. A
+reviewer re-reads the same compiler source the generator read, so the
+two can agree with each other and still both be wrong about what the
+compiler does. A gap is the compiler's own answer, observed by running
+it.
+
+That is also the reason for the central rule below: an observation is
+authoritative about _what happened_, and about nothing else.
+
+## Your task
+
+Act on the open gaps reported against one document. For every gap,
+choose one of five actions, apply it where applicable (edits to the
+target document), and record what you did in a gap-intake report. After
+the report is written, the operator runs `regenerate.py mark-fresh` (if
+the document changed) and `regenerate.py mark-gap-intake`, which writes
+your decisions into `doc-gap-state.json`.
+
+## Inputs you will receive
+
+When invoking an agent against this prompt, the operator passes:
+
+1. The **target document** — its current contents and its manifest key.
+2. The **open gaps** for it — the output of
+
+   ```bash
+   python3 docs/generated/tests/_meta/regenerate.py doc-gaps \
+       --source-doc <target document path> --format json
+   ```
+
+   filtered to those the ledger does not already record a decision for
+   (`regenerate.py gap-status <doc> --show-gaps --only-open`). Treat
+   this as the work queue.
+
+3. The **generation prompt** the document was originally produced from
+   (the per-document prompt plus [`_common.md`](_common.md)). A gap that
+   asks for material the contract forbids is `rejected-out-of-scope`.
+4. The **resolved watched paths** for the target document at the current
+   `HEAD`. Use `regenerate.py show <doc>`.
+5. The **tests that reported each gap** — the `.slang` files in the
+   bundles named by each gap's `reported_by`. These are the evidence;
+   read them when a gap's prose is not self-explanatory.
+6. The current `HEAD` commit SHA.
+
+## The central rule: a `Suggested addition` is a hypothesis
+
+Every gap row carries a `Suggested addition` written by an agent that
+**observed a behaviour**, not by one that read the code producing it.
+It is a proposal, not a specification, and it is wrong often enough to
+matter.
+
+**Before you write any observed behaviour into the document, confirm it
+in the document's watched paths.** Name the file and line in your
+`Evidence` cell. If you cannot find it in the source, you may not
+document it — choose `deferred` (you could not locate it) or
+`escalated-to-finding` (the source says something else) instead.
+
+This is not a formality. These documents are reverse-engineered from
+compiler source and are read as descriptions of intended behaviour. A
+document that absorbs whatever a test happened to observe is how a
+compiler bug becomes documented, blessed behaviour — and the test suite
+will then generate more tests asserting the bug, against a document that
+now agrees with it. The confirmation step is the only thing standing
+between an observation and that outcome.
+
+## `drift-from-source` needs a verdict, not a fix
+
+A gap of kind `drift-from-source` says the document contradicts observed
+behaviour. That has two possible causes, and they need opposite
+responses:
+
+- **The document is wrong.** The source agrees with the observation;
+  the document describes something the compiler does not do. Action:
+  `fixed`.
+- **The compiler is wrong.** The source agrees with the _document_;
+  the compiler does not do what both say. Action:
+  `escalated-to-finding` — this is a compiler defect and belongs in
+  the tests tree's findings channel, not in this document.
+
+Read the watched source and decide which. Do not resolve the
+contradiction by editing the document to match the observation without
+checking; that silently converts a compiler bug into documented
+behaviour, which is the failure mode this whole stage exists to avoid.
+
+The same judgement applies, less sharply, to `undocumented-behavior`:
+behaviour that is real, confirmed in the source, and undocumented should
+be documented — but behaviour that is real and _wrong_ should be a
+finding.
+
+## Action set
+
+Choose exactly one for every gap in the queue:
+
+- **fixed** — You edited the target document so that the gap no longer
+  applies. The `Evidence` cell cites the watched-path file and line that
+  confirms what you wrote. The `Fix summary` cell describes the edit in
+  one short clause. The edit must be the minimum necessary; do not
+  opportunistically rewrite unrelated text.
+- **rejected-bogus** — The gap is incorrect. The document does say the
+  thing the gap claims is missing, the anchor points at the wrong
+  section, or the observation misreads the compiler. The `Evidence` cell
+  must cite what disproves it — a quote from the document, or a source
+  path and line.
+- **rejected-out-of-scope** — The gap is real but is not this
+  document's to fix. Most commonly it belongs to
+  `docs/language-reference/` (the human-written spec, which no agent may
+  edit) or to a peer page. The `Evidence` cell must name the contract
+  clause that excludes the material, or the document that owns it.
+- **deferred** — The gap is real and in scope, but you cannot resolve it
+  now: you could not confirm the behaviour in the watched paths, the fix
+  needs a `watched_paths` expansion, or it needs a rewrite larger than
+  this cycle. The `Evidence` cell states what blocks the fix and what
+  follow-up is needed.
+- **escalated-to-finding** — The disagreement is a compiler defect, not
+  a documentation defect. The `Evidence` cell must state what the source
+  says and why the observed behaviour contradicts it. Name the existing
+  `docs/generated/tests/_meta/findings/<id>.yaml` if one already covers
+  it; if none does, say so, and the operator will have the tests side
+  open one before recording your decision (`mark-gap-intake` requires a
+  finding id for this action).
+
+Every gap in the queue must appear exactly once in the actions table.
+The lint pass enforces this.
+
+## Edit rules
+
+When you apply a `fixed` action:
+
+- **Edit only the target document**, not the compiler source, not peer
+  generated docs, not the test bundles, not the prompt contract.
+- **Never edit a bundle README to remove the gap row.** The row is the
+  test suite's record; it disappears on its own when the bundle is
+  regenerated against your improved text. Editing it by hand fakes the
+  loop closing.
+- **Never run a formatter over the target document.** The generated
+  design docs are not prettier-formatted, and reformatting one rewrites
+  lines throughout it. That is not cosmetic here: every test in the
+  reporting bundle carries a `doc_section_digest` of the section it is
+  anchored to, so a whole-file reformat invalidates every section's
+  digest instead of only the ones you edited, and the "which tests need
+  re-reading" signal the suite gives back is buried. In the first intake
+  cycle this turned a precise 3-section signal into 10. Keep the diff to
+  the lines you actually changed, and match the surrounding style by
+  hand (the tree uses `*emphasis*`, not `_emphasis_`, and wraps prose at
+  roughly 68 columns).
+- **Use the smallest reasonable change.** A sentence, a table row, a
+  short subsection — matched to what the gap asks for.
+- **Write in the document's voice**, not the gap's. The
+  `Suggested addition` is frequently phrased as advice to an author
+  ("Add a note that..."); what lands in the document is the note, not
+  the advice.
+- **Preserve front-matter exactly**, except for `generated_at`,
+  `source_commit`, and `watched_paths_digest`, which the operator
+  refreshes with `regenerate.py mark-fresh`. Do not edit those three
+  yourself.
+- If several gaps touch the same section, apply them as one consolidated
+  edit and reference the other gap ids in the `Fix summary` cell.
+- A gap asking for an example (`missing-example`) wants a **minimal**
+  one — a few lines of Slang that a reader can check, not a program.
+
+## When to skip `mark-fresh`
+
+If no action is `fixed` — the document was not edited — the report is
+still written and `mark-gap-intake` is still run, but `mark-fresh` is
+not. In that case set `target_doc_source_commit_after` equal to
+`target_doc_source_commit_before`.
+
+## Output format
+
+Your outputs are:
+
+- **Zero or more edits to the target document** (only when at least one
+  action is `fixed`).
+- **One gap-intake report**, a Markdown file with the contract below.
+  Filename (informational; the operator decides the path):
+
+```
+docs/generated/design/_meta/gap-intake/<target_doc>.gap-intake.md
+```
+
+Hierarchy under `_meta/gap-intake/` mirrors the manifest key (e.g.
+`_meta/gap-intake/pipeline/05-ir-passes.md.gap-intake.md`).
+
+### Front-matter (mandatory)
+
+```yaml
+---
+gap_intake_report: true
+intake_model: <model identifier, e.g. claude-opus-5>
+intake_at: <ISO 8601 UTC, seconds precision>
+target_doc: <manifest key, e.g. pipeline/05-ir-passes.md>
+target_doc_source_commit_before: <the `source_commit` from the target doc's front-matter at the start of intake>
+target_doc_source_commit_after: <the `source_commit` after `mark-fresh` runs, or same as `_before` when no edits were made>
+gap_count: <number of gaps acted on; must equal the number of rows in the Actions table>
+actions:
+  fixed: <int>
+  rejected_bogus: <int>
+  rejected_out_of_scope: <int>
+  deferred: <int>
+  escalated_to_finding: <int>
+---
+```
+
+The action counts must sum to `gap_count`.
+
+### Body (fixed section order)
+
+1. `# Gap-intake report for <target_doc>` — the title.
+2. `## Summary` — 2-5 sentences stating what was done, with the action
+   breakdown restated in prose. If any gap was escalated, say so here in
+   the first sentence.
+3. `## Escalated gaps` (**only if** `actions.escalated_to_finding > 0`)
+   — a bullet list naming the gap ids, what the source says, and what
+   the compiler does instead. This section appears **before**
+   `## Actions` so a hurried operator sees the compiler bugs first.
+4. `## Actions` — a Markdown table with exactly these columns:
+
+   | Column      | Content                                                                                                                                                                          |
+   | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | Gap ID      | The 12-hex-digit `gap_id` from the aggregator.                                                                                                                                   |
+   | Action      | One of `fixed`, `rejected-bogus`, `rejected-out-of-scope`, `deferred`, `escalated-to-finding`. Use the exact spelling.                                                           |
+   | Evidence    | Required for every action. The watched-path file and line confirming what you wrote (for `fixed`), or the justification described in the action set above. Workspace-relative.   |
+   | Fix summary | Required when `Action = fixed`; one short clause describing the edit (e.g. "added the `[MaxIters]` requirement under Checkpointing"). Use a single em-dash (`—`) for the others. |
+
+   Every gap id from the queue must appear here exactly once.
+
+## Style rules for the report itself
+
+- No emojis.
+- No code blocks larger than 10 lines.
+- Do not copy the full text of the target document or of the gap table.
+- Use workspace-relative paths in all citations.
+- The report is a record, not an essay; keep it dense and actionable.

--- a/docs/generated/design/_meta/regenerate.md
+++ b/docs/generated/design/_meta/regenerate.md
@@ -24,20 +24,21 @@ All commands run from the repository root.
 python3 docs/generated/design/_meta/regenerate.py <subcommand> [args...]
 ```
 
-| Subcommand                                                                | Purpose                                                                                                                  |
-| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `list`                                                                    | Print every doc in the manifest                                                                                          |
-| `list-stale [--include-review]`                                           | Classify each doc as `missing`, `stale`, or `fresh`; with the flag, annotate each row with its review/remediation status |
-| `digest <doc>`                                                            | Compute the current digest of a doc's watched paths                                                                      |
-| `show <doc>`                                                              | Show the manifest entry plus the resolved source files                                                                   |
-| `mark-fresh <doc> [--commit SHA] [--model NAME]`                          | Record a fresh entry                                                                                                     |
-| `lint [<doc>...]`                                                         | Structural linter (front-matter, link resolution, size cap; also lints every review and remediation report)              |
-| `review-status [<doc>...] [--show-counts]`                                | Per-doc review/remediation freshness (see "Review and remediation workflow" below)                                       |
-| `mark-reviewed <doc> [--report PATH]`                                     | Record a review entry from a review report (see below)                                                                   |
-| `mark-remediated <doc> [--report PATH]`                                   | Record a remediation entry from a remediation report (see below)                                                         |
-| `gap-status [<doc>...] [--show-gaps] [--only-open] [--format text\|json]` | Per-doc count of doc gaps the agentic test suite reports against this tree (see "Doc gaps from the test suite" below)    |
-| `mark-gap <gap-id> --status <s> --rationale <text>`                       | Record a decision about one gap by hand                                                                                  |
-| `mark-gap-intake <doc> [--report PATH]`                                   | Write a gap-intake report's decisions into the ledger in bulk                                                            |
+| Subcommand                                                                                          | Purpose                                                                                                                                                |
+| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `list`                                                                                              | Print every doc in the manifest                                                                                                                        |
+| `list-stale [--include-review]`                                                                     | Classify each doc as `missing`, `stale`, or `fresh`; with the flag, annotate each row with its review/remediation status                               |
+| `digest <doc>`                                                                                      | Compute the current digest of a doc's watched paths                                                                                                    |
+| `show <doc>`                                                                                        | Show the manifest entry plus the resolved source files                                                                                                 |
+| `mark-fresh <doc> [--commit SHA] [--model NAME]`                                                    | Record a fresh entry                                                                                                                                   |
+| `lint [<doc>...]`                                                                                   | Structural linter (front-matter, link resolution, size cap; also lints every review and remediation report)                                            |
+| `review-status [<doc>...] [--show-counts]`                                                          | Per-doc review/remediation freshness (see "Review and remediation workflow" below)                                                                     |
+| `mark-reviewed <doc> [--report PATH]`                                                               | Record a review entry from a review report (see below)                                                                                                 |
+| `mark-remediated <doc> [--report PATH]`                                                             | Record a remediation entry from a remediation report (see below)                                                                                       |
+| `gap-status [<doc>...] [--show-gaps] [--only-open] [--format text\|json\|markdown]`                 | Per-doc count of doc gaps the agentic test suite reports against this tree; `markdown` is the form CI posts (see "Doc gaps from the test suite" below) |
+| `mark-gap <gap-id> --status <s> --rationale <text> [--finding <id>] [--report PATH] [--model NAME]` | Record a decision about one gap by hand. `--finding` is **required** when `--status escalated-to-finding`, and must name an existing finding           |
+| `mark-gap-intake <doc> [--report PATH]`                                                             | Write a gap-intake report's decisions into the ledger in bulk                                                                                          |
+| `selftest`                                                                                          | Unit-check the ledger helpers `lint` and `gap-status` depend on                                                                                        |
 
 `<doc>` is the manifest key (e.g. `pipeline/05-ir-passes.md`), not the full
 workspace path.

--- a/docs/generated/design/_meta/regenerate.md
+++ b/docs/generated/design/_meta/regenerate.md
@@ -228,6 +228,29 @@ picks it up, and regenerating the bundle re-tests against the improved
 text. That is the loop closing: the gap row should be gone from the
 regenerated README, and `gap-status` counts the decision as `retired`.
 
+### When a fix does not take
+
+If the row is still there after the bundle has been regenerated, the fix
+did not work, and `gap-status` says so. A `fixed` gap still in the queue
+is classified three ways, because "still reported" on its own means
+nothing:
+
+| Verdict          | Meaning                                                                                                                                                  |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `awaiting-regen` | A reporting bundle has not been regenerated yet, so the claim has not been retested. Expected right after intake.                                        |
+| `reopened`       | Every doc-anchored reporting bundle has been regenerated against the current text and still reports it. **The fix did not take** — re-run intake.        |
+| `unverifiable`   | No reporting bundle is doc-anchored. A `coverage/` bundle records no `source_doc_digest` and is never invalidated by a doc edit, so this route is blind. |
+
+The comparison is the bundle's recorded `source_doc_digest` in
+`docs/generated/tests/_meta/freshness.json` against the current sha256
+of the document. Only `fixed` is checked: the other four statuses make
+no claim about what the suite should observe next — a `deferred` gap is
+_expected_ to keep being reported.
+
+`unverifiable` is worth watching. It is not an error, but it means that
+particular fix can only ever be confirmed by hand, or by the coverage
+bundle happening to be regenerated for its own reasons.
+
 Editing a document here does _not_ invalidate its review: review
 freshness is computed from the `watched_paths` digest, which is over
 compiler source, not over the document's own prose. Gap intake and the

--- a/docs/generated/design/_meta/regenerate.md
+++ b/docs/generated/design/_meta/regenerate.md
@@ -24,17 +24,20 @@ All commands run from the repository root.
 python3 docs/generated/design/_meta/regenerate.py <subcommand> [args...]
 ```
 
-| Subcommand | Purpose |
-| --- | --- |
-| `list` | Print every doc in the manifest |
-| `list-stale [--include-review]` | Classify each doc as `missing`, `stale`, or `fresh`; with the flag, annotate each row with its review/remediation status |
-| `digest <doc>` | Compute the current digest of a doc's watched paths |
-| `show <doc>` | Show the manifest entry plus the resolved source files |
-| `mark-fresh <doc> [--commit SHA] [--model NAME]` | Record a fresh entry |
-| `lint [<doc>...]` | Structural linter (front-matter, link resolution, size cap; also lints every review and remediation report) |
-| `review-status [<doc>...] [--show-counts]` | Per-doc review/remediation freshness (see "Review and remediation workflow" below) |
-| `mark-reviewed <doc> [--report PATH]` | Record a review entry from a review report (see below) |
-| `mark-remediated <doc> [--report PATH]` | Record a remediation entry from a remediation report (see below) |
+| Subcommand                                                                | Purpose                                                                                                                  |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `list`                                                                    | Print every doc in the manifest                                                                                          |
+| `list-stale [--include-review]`                                           | Classify each doc as `missing`, `stale`, or `fresh`; with the flag, annotate each row with its review/remediation status |
+| `digest <doc>`                                                            | Compute the current digest of a doc's watched paths                                                                      |
+| `show <doc>`                                                              | Show the manifest entry plus the resolved source files                                                                   |
+| `mark-fresh <doc> [--commit SHA] [--model NAME]`                          | Record a fresh entry                                                                                                     |
+| `lint [<doc>...]`                                                         | Structural linter (front-matter, link resolution, size cap; also lints every review and remediation report)              |
+| `review-status [<doc>...] [--show-counts]`                                | Per-doc review/remediation freshness (see "Review and remediation workflow" below)                                       |
+| `mark-reviewed <doc> [--report PATH]`                                     | Record a review entry from a review report (see below)                                                                   |
+| `mark-remediated <doc> [--report PATH]`                                   | Record a remediation entry from a remediation report (see below)                                                         |
+| `gap-status [<doc>...] [--show-gaps] [--only-open] [--format text\|json]` | Per-doc count of doc gaps the agentic test suite reports against this tree (see "Doc gaps from the test suite" below)    |
+| `mark-gap <gap-id> --status <s> --rationale <text>`                       | Record a decision about one gap by hand                                                                                  |
+| `mark-gap-intake <doc> [--report PATH]`                                   | Write a gap-intake report's decisions into the ledger in bulk                                                            |
 
 `<doc>` is the manifest key (e.g. `pipeline/05-ir-passes.md`), not the full
 workspace path.
@@ -50,7 +53,7 @@ python3 docs/generated/design/_meta/regenerate.py list-stale
 ```
 
 Run the agent once per doc, in dependency order (a doc that lists
-`depends_on` other docs should be regenerated *after* its dependencies, so
+`depends_on` other docs should be regenerated _after_ its dependencies, so
 that the agent can read them as additional context). For each doc:
 
 1. Open the prompt template at
@@ -105,6 +108,166 @@ generated peer docs as context. This typically:
 The cross-link pass is just a regular regeneration of every doc with an
 expanded context, followed by `lint` and `mark-fresh`.
 
+## Doc gaps from the test suite
+
+The docs in this tree are reverse-engineered from compiler source by
+reading it. The agentic test suite under
+[`docs/generated/tests/`](../../tests) is the one place in the system
+that checks them by _running_ the compiler: each of its bundles is
+anchored to a document, and where a test shows the document is wrong,
+incomplete, or ambiguous in a way that is not a compiler bug, the bundle
+records a row in its README's `## Doc gaps observed` table.
+
+Those rows are this tree's second work queue, alongside review findings,
+and they are evidence of a kind review cannot produce — a reviewer
+re-reads the same source the generator read, so the two can agree and
+still both be wrong about what the compiler does.
+
+```bash
+# What the suite currently reports against this tree, per document.
+python3 docs/generated/design/_meta/regenerate.py gap-status --only-open
+
+# The gaps themselves, for one document.
+python3 docs/generated/tests/_meta/regenerate.py doc-gaps \
+    --source-doc docs/generated/design/pipeline/06-emit.md
+```
+
+Each merged gap carries a `gap_id` (12 hex digits) that the tests driver
+derives from the anchored document, its heading, the gap's kind, and its
+prose. The id is derived rather than stored, so it survives a bundle
+being regenerated and the prose being re-worded — which matters, because
+bundle READMEs are rewritten wholesale and a row has no other stable
+identity.
+
+Decisions are recorded in [doc-gap-state.json](doc-gap-state.json)
+against those ids ([schema](schema/doc-gap-state.schema.json)); a gap
+absent from the ledger is open. One of five statuses applies:
+
+| Status                  | Meaning                                                                                                                              |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `fixed`                 | The document was edited so the gap no longer applies                                                                                 |
+| `rejected-bogus`        | The gap misreads the document or the compiler                                                                                        |
+| `rejected-out-of-scope` | Real, but belongs to another document — commonly the human-written language reference, which no agent may edit                       |
+| `deferred`              | Real and in scope, but not now                                                                                                       |
+| `escalated-to-finding`  | The disagreement is a compiler defect, not a documentation one; `finding_id` names the `docs/generated/tests/_meta/findings/` record |
+
+### The gap-intake stage
+
+Gaps are worked one document at a time by a **Claude-family agent**
+(intake edits the generated documents, so it runs in the family that
+generated them — the same rule, and the same soft refusal layers, as
+remediation).
+
+1. Pick a document with open gaps:
+
+   ```bash
+   python3 docs/generated/design/_meta/regenerate.py gap-status --only-open
+   ```
+
+2. Open the intake prompt at
+   [prompts/\_gap-intake.md](prompts/_gap-intake.md).
+3. Show the agent: the target document, its open gaps
+   (`gap-status <doc> --show-gaps --only-open`, and the full rows from
+   `doc-gaps --source-doc <path> --format json`), the document's
+   generation prompt plus [prompts/\_common.md](prompts/_common.md), the
+   resolved watched paths at the current `HEAD`, and the `.slang` tests
+   in the bundles named by each gap's `reported_by` — those tests are
+   the evidence.
+4. The agent edits the document where appropriate and writes a report to
+   `_meta/gap-intake/<doc>.gap-intake.md` matching the contract in
+   `_gap-intake.md`.
+5. If the document was edited, refresh its digest:
+
+   ```bash
+   python3 docs/generated/design/_meta/regenerate.py mark-fresh <doc> --model <model-id>
+   ```
+
+6. Lint and record. `mark-gap-intake` refuses on any lint error, so a
+   malformed report cannot half-populate the ledger:
+
+   ```bash
+   python3 docs/generated/design/_meta/regenerate.py lint <doc>
+   python3 docs/generated/design/_meta/regenerate.py mark-gap-intake <doc>
+   ```
+
+`mark-gap-intake` writes one ledger entry per row of the report's
+`## Actions` table. An `escalated-to-finding` row must cite a
+`findings/<id>.yaml` in its `Evidence` cell — otherwise the trail from
+"the docs declined to document this" to "someone is fixing the compiler"
+breaks at the point it matters, so the command rejects the report.
+
+For a one-off decision without running an agent — most usefully marking
+a gap `rejected-out-of-scope` because it belongs to the language
+reference — there is a hand path:
+
+```bash
+python3 docs/generated/design/_meta/regenerate.py mark-gap 0a69b5e6dec9 \
+    --status fixed \
+    --rationale "Added the loops-in-differentiable-functions subsection." \
+    --model claude-opus-5
+```
+
+Two rules that keep this channel from doing damage:
+
+- **A gap's `Suggested addition` is a hypothesis, not authority.** It was
+  written by an agent that observed a behaviour, not by one that read the
+  code that produces it. Confirm the behaviour in the document's watched
+  paths before writing it into the document; a design doc that documents
+  what a test happened to observe is how a compiler bug becomes
+  documented behaviour.
+- **`drift-from-source` is the ambiguous kind.** These docs are
+  reverse-engineered and may codify bugs, so a row saying the document
+  contradicts observed behaviour can mean either the document is wrong
+  or the compiler is. When it is the compiler,
+  `--status escalated-to-finding` and let the tests tree's findings
+  channel carry it; do not "fix" the document to match a bug.
+
+Fixing a gap edits the document, which changes the bundle's
+`source_doc_digest` and so makes the bundle stale — `docs/generated/tests/_meta/regenerate.py list-stale`
+picks it up, and regenerating the bundle re-tests against the improved
+text. That is the loop closing: the gap row should be gone from the
+regenerated README, and `gap-status` counts the decision as `retired`.
+
+Editing a document here does _not_ invalidate its review: review
+freshness is computed from the `watched_paths` digest, which is over
+compiler source, not over the document's own prose. Gap intake and the
+review cycle are therefore independent — though the preferred per-document
+order is **gap intake → review → remediation**, so the reviewer reads
+corrected prose instead of re-deriving a finding the test suite already
+proved.
+
+### Gaps against the language reference
+
+The suite also reports gaps against `docs/language-reference/`, the
+hand-written spec. Those are **not** gap-intake work: no agent may edit
+that tree, and `gap-status` deliberately does not count them. They are a
+human triage queue:
+
+```bash
+python3 docs/generated/tests/_meta/regenerate.py doc-gaps \
+    --tree language-reference
+```
+
+Read the table and file the ones worth acting on. A gap-intake agent
+that meets one of these anchored into a design page marks it
+`rejected-out-of-scope` and names the language-reference page that owns
+the material.
+
+### CI
+
+[check-doc-gaps.yml](../../../../.github/workflows/check-doc-gaps.yml)
+runs nightly (an hour after the agentic-tests nightly) and on PRs that
+touch the generated trees. It **hard-gates** `lint` for both trees — a
+lint failure is a broken structural contract, always the author's
+mistake and always cheap to fix — and posts the gap queue to the job
+summary as **advisory** output. The queue is deliberately not a gate: a
+source change can legitimately make the docs report more gaps without
+the PR being wrong, and blocking on it would pressure authors into
+hand-editing generated docs, which is the one thing this system forbids.
+
+The summary table is produced by `gap-status --format markdown`, so what
+CI posts can be reproduced locally with the same command.
+
 ## Review and remediation workflow
 
 Generated docs are subject to a two-stage independent-review process
@@ -127,12 +290,12 @@ out-of-band, just like for generation.
 ### Refusal mechanism (soft, three layers)
 
 - **Prompt banner.** The first lines of
-  [prompts/_review.md](prompts/_review.md) tell a Claude-family model to
+  [prompts/\_review.md](prompts/_review.md) tell a Claude-family model to
   output `REFUSED: Claude model detected; the review step requires a
-  different model family` and stop. The first lines of
-  [prompts/_remediate.md](prompts/_remediate.md) tell a non-Claude model
+different model family` and stop. The first lines of
+  [prompts/\_remediate.md](prompts/_remediate.md) tell a non-Claude model
   to output `REFUSED: non-Claude model detected; the remediation step
-  requires the same model family that generated the docs` and stop.
+requires the same model family that generated the docs` and stop.
 - **Bookkeeping gate.** `mark-reviewed` refuses to record a review whose
   `reviewer_model` looks like Claude/Anthropic; `mark-remediated`
   refuses to record a remediation whose `remediator_model` does not.
@@ -158,10 +321,10 @@ Each row prints one of `unreviewed`, `review-stale`,
 
 For each doc that needs review:
 
-1. Open the review prompt at [prompts/_review.md](prompts/_review.md).
+1. Open the review prompt at [prompts/\_review.md](prompts/_review.md).
 2. Show the agent: the target document (with its front-matter), the
    doc's per-page prompt (the path is in the manifest entry; obtain via
-   `regenerate.py show <doc>`), [prompts/_common.md](prompts/_common.md),
+   `regenerate.py show <doc>`), [prompts/\_common.md](prompts/_common.md),
    the resolved watched files at the doc's recorded `source_commit`,
    and any `depends_on` documents.
 3. Ask the agent to produce a single review report exactly matching the
@@ -190,9 +353,9 @@ output as `reviewed-pending-remediation`.
 For each doc:
 
 1. Open the remediation prompt at
-   [prompts/_remediate.md](prompts/_remediate.md).
+   [prompts/\_remediate.md](prompts/_remediate.md).
 2. Show the agent: the target document, the review report from Step 1,
-   the doc's per-page prompt + [prompts/_common.md](prompts/_common.md),
+   the doc's per-page prompt + [prompts/\_common.md](prompts/_common.md),
    and the resolved watched files at the current `HEAD`.
 3. The agent edits the target document where appropriate and produces
    a remediation report at
@@ -208,6 +371,7 @@ For each doc:
    so the doc's `watched_paths_digest` is refreshed. (If the doc was
    not edited — every action was a rejection / deferral / escalation —
    skip `mark-fresh`.)
+
 5. Lint and record the remediation:
 
    ```bash
@@ -216,7 +380,7 @@ For each doc:
    ```
 
    `mark-remediated` reads the default report path; pass `--report
-   PATH` to override. It refuses to record the entry if
+PATH` to override. It refuses to record the entry if
    `remediator_model` does not contain `claude` or `anthropic`.
 
 ### Apply manifest changes before recording reviews, not after
@@ -272,7 +436,7 @@ A document is computed as:
   the doc has not been regenerated, and its watched set has not changed,
   since the last review.
 
-  Note that the comparison deliberately does *not* use the digest in the
+  Note that the comparison deliberately does _not_ use the digest in the
   document's own front-matter. `mark-fresh` records the real value in
   `freshness.json` without rewriting the document, so the front-matter
   copy is only as current as whatever the generating agent last wrote,
@@ -280,6 +444,7 @@ A document is computed as:
   unstabilizable by construction. Both `mark-reviewed` and the status
   computation therefore read `freshness.json`; `mark-reviewed` warns and
   substitutes the authoritative value if a review report disagrees.
+
 - **remediation-fresh** iff review-fresh **and**
   `last_remediated.review_report_ref` points at the same review report
   that is currently in `last_reviewed`.
@@ -389,7 +554,7 @@ should remind the PR author to schedule a documentation refresh, not
 block the PR.
 
 The reason for the soft-warning policy is that documentation drift is a
-*reviewable* property of a change, not a *blocking* one — most source
+_reviewable_ property of a change, not a _blocking_ one — most source
 changes do not warrant a same-PR doc refresh, especially if the change is
 self-contained or temporary. Hard-failing PRs on doc staleness would
 either incentivize hand-editing the generated docs (defeating the
@@ -409,15 +574,15 @@ on:
   pull_request:
     branches: [master]
     paths:
-      - 'source/**'
-      - 'prelude/**'
-      - 'include/**'
-      - 'docs/generated/design/**'
+      - "source/**"
+      - "prelude/**"
+      - "include/**"
+      - "docs/generated/design/**"
 jobs:
   check-llm-doc-freshness:
     if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
-    continue-on-error: true   # advisory: never blocks the PR
+    continue-on-error: true # advisory: never blocks the PR
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
@@ -435,7 +600,7 @@ Notes for whoever enables this later:
   what makes the check advisory rather than blocking. Removing that flag
   would convert it to a hard gate; do not do that without revisiting the
   policy above.
-- The `lint` step *should* be a hard gate, because lint failures
+- The `lint` step _should_ be a hard gate, because lint failures
   indicate structurally invalid docs (broken links, missing front-matter)
   rather than drift. It runs without `|| true`.
 - The workflow does not regenerate anything. Regeneration remains

--- a/docs/generated/design/_meta/regenerate.py
+++ b/docs/generated/design/_meta/regenerate.py
@@ -2279,11 +2279,16 @@ def cmd_mark_gap_intake(args, manifest: Manifest) -> int:
 
 FINDINGS_DIR = REPO_ROOT / "docs/generated/tests/_meta/findings"
 
-# `(?<![\w/])` keeps the path form from matching inside a longer token -- a
-# URL such as `https://…/findings/filed/test.yaml/comments` would otherwise
-# yield `test`. `(?![\w.])` does the same on the right.
+# `(?<!\w)` stops `myfindings/x.yaml` from matching, but deliberately allows a
+# leading `/`: the documented spelling is the full workspace path
+# `docs/generated/tests/_meta/findings/<id>.yaml`, so excluding `/` here would
+# reject the very form the contract asks agents to write.
+#
+# The real guard against a spurious match -- including the URL case,
+# `https://…/findings/filed/test.yaml/comments` -- is `_finding_exists`: an id
+# that names no file is not a reference, however it was spelled.
 _FINDING_REF_RE = re.compile(
-    r"(?<![\w/])findings/(?:filed/)?([A-Za-z0-9][A-Za-z0-9._-]*)\.yaml(?![\w.])"
+    r"(?<!\w)findings/(?:filed/)?([A-Za-z0-9][A-Za-z0-9._-]*)\.yaml"
 )
 _FINDING_ID_RE = re.compile(r"`([a-z0-9][a-z0-9-]{4,})`")
 
@@ -2531,10 +2536,33 @@ def cmd_selftest(args, manifest: Manifest) -> int:
         real = cand.stem
     if real:
         check("finding path form", _finding_ref(f"see findings/{real}.yaml"), real)
-        check("finding bare id", _finding_ref(f"covered by `{real}`"), real)
+        # The documented spelling is the full workspace path. An earlier
+        # anchoring attempt rejected exactly this, breaking three real
+        # reports, so it is pinned here.
         check(
-            "finding embedded in URL is not a match",
+            "finding full workspace path",
+            _finding_ref(f"Existing finding: `docs/generated/tests/_meta/findings/{real}.yaml`."),
+            real,
+        )
+        check(
+            "finding path inside prose",
+            _finding_ref(f"tracked in docs/generated/tests/_meta/findings/{real}.yaml today"),
+            real,
+        )
+        check("finding bare id", _finding_ref(f"covered by `{real}`"), real)
+        # A URL that happens to name a real finding still names it, and the
+        # ledger only needs an id someone can follow. What must not resolve
+        # is a spelling that names no file -- checked just below. Pinning the
+        # URL case as a *match* records that this is the intended reading
+        # rather than an oversight.
+        check(
+            "finding named inside a URL still resolves, since the file exists",
             _finding_ref(f"https://x/findings/{real}.yaml/comments"),
+            real,
+        )
+        check(
+            "URL naming a nonexistent finding does not resolve",
+            _finding_ref("https://x/findings/not-a-real-finding.yaml/comments"),
             None,
         )
     check("finding missing path rejected", _finding_ref("see findings/nope.yaml"), None)

--- a/docs/generated/design/_meta/regenerate.py
+++ b/docs/generated/design/_meta/regenerate.py
@@ -2231,7 +2231,10 @@ def cmd_mark_gap_intake(args, manifest: Manifest) -> int:
     return 0
 
 
+FINDINGS_DIR = REPO_ROOT / "docs/generated/tests/_meta/findings"
+
 _FINDING_REF_RE = re.compile(r"findings/(?:filed/)?([A-Za-z0-9][A-Za-z0-9._-]*)\.yaml")
+_FINDING_ID_RE = re.compile(r"`([a-z0-9][a-z0-9-]{4,})`")
 
 
 def _finding_ref(evidence: str) -> str | None:
@@ -2242,9 +2245,27 @@ def _finding_ref(evidence: str) -> str | None:
     because it is relevant to exactly one of the five actions, and a
     column that is an em-dash four times out of five is noise in every
     report.
+
+    An agent that names the finding by its bare id rather than its path
+    has still named it, so the bare form is accepted too -- but only when
+    it resolves to a file that actually exists under `findings/`. That
+    keeps the check precise rather than merely lenient: the point of
+    requiring a reference at all is that someone can follow it, and a
+    filesystem hit proves they can. The first cycle to escalate anything
+    was rejected over exactly this spelling difference, with the finding
+    sitting in the directory the whole time.
     """
     m = _FINDING_REF_RE.search(evidence or "")
-    return m.group(1) if m else None
+    if m:
+        return m.group(1)
+    for candidate in _FINDING_ID_RE.findall(evidence or ""):
+        for path in (
+            FINDINGS_DIR / f"{candidate}.yaml",
+            FINDINGS_DIR / "filed" / f"{candidate}.yaml",
+        ):
+            if path.exists():
+                return candidate
+    return None
 
 
 def lint_doc_gap_state() -> list[LintIssue]:

--- a/docs/generated/design/_meta/regenerate.py
+++ b/docs/generated/design/_meta/regenerate.py
@@ -429,6 +429,80 @@ def load_gap_queue(source_doc: str | None = None) -> dict[str, list[dict]]:
     return json.loads(proc.stdout)
 
 
+TESTS_FRESHNESS_PATH = REPO_ROOT / "docs/generated/tests/_meta/freshness.json"
+
+
+def load_bundle_source_doc_digests() -> dict[str, str | None]:
+    """Return each test bundle's recorded `source_doc_digest`.
+
+    Read straight out of the tests tree's freshness ledger rather than by
+    asking its driver, because this is a lookup of recorded state rather
+    than a computation, and because the `None` a `coverage/` bundle
+    records is itself the answer to a question asked below.
+    """
+    if not TESTS_FRESHNESS_PATH.exists():
+        return {}
+    try:
+        state = json.loads(TESTS_FRESHNESS_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return {
+        key: entry.get("source_doc_digest")
+        for key, entry in (state.get("bundles") or {}).items()
+    }
+
+
+def _verify_fixed_gap(
+    doc: str, reported_by: list[str], bundle_digests: dict[str, str | None]
+) -> str:
+    """Say whether a gap the ledger calls `fixed` has actually been retested.
+
+    Fixing a gap edits the document, which changes the reporting bundle's
+    `source_doc_digest` and marks it stale; regenerating the bundle
+    re-tests the claim against the improved text, and the row should then
+    be gone. So a `fixed` gap that is *still* in the queue means one of
+    three different things, and reporting them as one would make the
+    ledger lie in both directions:
+
+    - `reopened` — every doc-anchored bundle that reported it has since
+      been regenerated against the current text of the document, and
+      still reports it. The fix did not take.
+    - `awaiting-regen` — at least one reporting bundle has not been
+      regenerated yet, so the claim has not been retested and its
+      continued presence means nothing.
+    - `unverifiable` — no reporting bundle is doc-anchored. A
+      `coverage/` bundle records no `source_doc_digest` and is never
+      invalidated by a document edit, so this route cannot ever confirm
+      the fix; it needs a human, or a bundle regenerated for its own
+      reasons.
+
+    The check is deliberately limited to `fixed`. The other four statuses
+    make no claim about what the suite should observe next -- a
+    `deferred` gap is *expected* to keep being reported.
+    """
+    doc_path = REPO_ROOT / doc
+    if not doc_path.exists():
+        return "unverifiable"
+    current = hashlib.sha256(doc_path.read_bytes()).hexdigest()
+    anchored = [b for b in reported_by if bundle_digests.get(_bundle_key(b))]
+    if not anchored:
+        return "unverifiable"
+    for bundle in anchored:
+        if bundle_digests.get(_bundle_key(bundle)) != current:
+            return "awaiting-regen"
+    return "reopened"
+
+
+def _bundle_key(bundle_dir: str) -> str:
+    """Map a bundle's workspace-relative directory to its manifest key.
+
+    `doc-gaps` reports a bundle as `docs/generated/tests/design/x`, while
+    both freshness ledgers key on `design/x`.
+    """
+    prefix = "docs/generated/tests/"
+    return bundle_dir[len(prefix) :] if bundle_dir.startswith(prefix) else bundle_dir
+
+
 def _gap_status(gap_id: str, ledger_gaps: dict) -> str:
     """Return the recorded status of one gap, or `open` if undecided.
 
@@ -1614,6 +1688,7 @@ def cmd_gap_status(args, manifest: Manifest) -> int:
                 return 2
     ledger_gaps = load_doc_gap_state().get("gaps", {})
     queue = load_gap_queue()
+    bundle_digests = load_bundle_source_doc_digests()
 
     wanted = (
         {manifest.docs[d].path for d in args.docs}
@@ -1630,9 +1705,20 @@ def cmd_gap_status(args, manifest: Manifest) -> int:
     for doc in docs:
         gaps = queue.get(doc, [])
         counts: dict[str, int] = {}
+        verification: dict[str, str] = {}
         for g in gaps:
             status = _gap_status(g["gap_id"], ledger_gaps)
             counts[status] = counts.get(status, 0) + 1
+            # A `fixed` gap that is still in the queue has not necessarily
+            # failed; whether it has is the question `_verify_fixed_gap`
+            # answers. A gap that has left the queue is counted as
+            # `retired` below and needs no verification -- its absence is
+            # the confirmation.
+            if status == "fixed":
+                verification[g["gap_id"]] = _verify_fixed_gap(
+                    doc, g["reported_by"], bundle_digests
+                )
+        reopened = sum(1 for v in verification.values() if v == "reopened")
         # Decisions whose gap no longer appears in the queue. The healthy
         # cause is a fix that landed and a bundle that was then regenerated,
         # so the row is gone; the other cause is an id that churned when its
@@ -1651,10 +1737,12 @@ def cmd_gap_status(args, manifest: Manifest) -> int:
                 "in_manifest": doc in wanted,
                 "counts": counts,
                 "retired": retired,
+                "reopened": reopened,
                 "gaps": [
                     {
                         "gap_id": g["gap_id"],
                         "status": _gap_status(g["gap_id"], ledger_gaps),
+                        "verification": verification.get(g["gap_id"]),
                         "kind": g["kind"],
                         "anchor": g["anchor_fragment"],
                         "reported_by": g["reported_by"],
@@ -1672,9 +1760,11 @@ def cmd_gap_status(args, manifest: Manifest) -> int:
         return _print_gap_status_markdown(rows, args.only_open)
 
     total_open = 0
+    total_reopened = 0
     for row in rows:
         open_n = row["counts"].get("open", 0)
         total_open += open_n
+        total_reopened += row["reopened"]
         decided = sum(v for k, v in row["counts"].items() if k != "open")
         if not open_n and not decided and not row["retired"] and args.only_open:
             continue
@@ -1683,17 +1773,26 @@ def cmd_gap_status(args, manifest: Manifest) -> int:
             line += f"  {row['retired']:>3} retired"
         else:
             line += " " * 13
+        if row["reopened"]:
+            line += f"  {row['reopened']:>3} REOPENED"
         suffix = "" if row["in_manifest"] else "   (not in manifest)"
         print(f"{line}  {row['doc']}{suffix}")
         if args.show_gaps:
             for g in row["gaps"]:
                 if args.only_open and g["status"] != "open":
                     continue
+                verdict = f"  [{g['verification']}]" if g["verification"] else ""
                 print(
                     f"        {g['gap_id']}  {g['status']:<22}"
-                    f"{g['kind']:<24}{g['anchor']}"
+                    f"{g['kind']:<24}{g['anchor']}{verdict}"
                 )
     print(f"\ntotal open: {total_open}")
+    if total_reopened:
+        print(
+            f"REOPENED: {total_reopened} gap(s) recorded as fixed are still"
+            " reported by a bundle that has since been regenerated -- the fix"
+            " did not take. Re-run gap intake for those documents."
+        )
     return 0
 
 
@@ -1716,6 +1815,7 @@ def _print_gap_status_markdown(rows: list[dict], only_open: bool) -> int:
         or any(k != "open" for k in r["counts"])
         or r["retired"]
     ]
+    total_reopened = sum(r["reopened"] for r in rows)
     print("### Doc gaps reported by the agentic test suite")
     print()
     print(
@@ -1723,16 +1823,32 @@ def _print_gap_status_markdown(rows: list[dict], only_open: bool) -> int:
         f" {len(shown)} document(s)."
     )
     print()
+    if total_reopened:
+        # Loud, because this is the one state in the report that means
+        # something is wrong rather than merely outstanding: a fix was
+        # recorded, the bundle was regenerated against it, and the suite
+        # still reports the gap.
+        print(
+            f"> **{total_reopened} gap(s) reopened.** These were recorded as"
+            " fixed, but a bundle regenerated against the current text still"
+            " reports them, so the fix did not take. Re-run gap intake for the"
+            " documents marked below."
+        )
+        print()
     if not shown:
         print("No gaps are reported against this tree.")
         return 0
-    print("| Document | Open | Decided | Retired |")
-    print("| --- | ---: | ---: | ---: |")
-    for r in sorted(shown, key=lambda r: (-r["counts"].get("open", 0), r["doc"])):
+    print("| Document | Open | Decided | Retired | Reopened |")
+    print("| --- | ---: | ---: | ---: | ---: |")
+    # Reopened first: a failed fix outranks a large queue for attention.
+    for r in sorted(
+        shown, key=lambda r: (-r["reopened"], -r["counts"].get("open", 0), r["doc"])
+    ):
         decided = sum(v for k, v in r["counts"].items() if k != "open")
+        reopened = f"**{r['reopened']}**" if r["reopened"] else "0"
         print(
             f"| `{r['doc']}` | {r['counts'].get('open', 0)} | {decided}"
-            f" | {r['retired']} |"
+            f" | {r['retired']} | {reopened} |"
         )
     print()
     print(

--- a/docs/generated/design/_meta/regenerate.py
+++ b/docs/generated/design/_meta/regenerate.py
@@ -379,6 +379,19 @@ _GAP_STATUSES = (
 
 _GAP_ID_RE = re.compile(r"^[0-9a-f]{12}$")
 
+# Mirrors `_ALLOWED_GAP_KINDS` in the tests driver and the `kind` enum in
+# doc-gap-state.schema.json. Duplicated rather than imported because the two
+# drivers are deliberately separate programs; `lint_doc_gap_state` checks it
+# so the hand-rolled validator and the committed schema cannot disagree.
+_GAP_KINDS = (
+    "missing-example",
+    "missing-surface",
+    "undocumented-behavior",
+    "cascading-only-mention",
+    "ambiguous-claim",
+    "drift-from-source",
+)
+
 
 def load_doc_gap_state() -> dict:
     if not DOC_GAP_STATE_PATH.exists():
@@ -393,8 +406,13 @@ def save_doc_gap_state(state: dict) -> None:
 
 
 def load_gap_queue(source_doc: str | None = None) -> dict[str, list[dict]]:
-    """Return the open-or-not gap rows the test suite currently reports,
-    keyed by the document each is anchored to.
+    """Return every gap row the test suite currently reports, keyed by the
+    document each is anchored to.
+
+    This is the raw queue *before* any ledger decision is applied: it never
+    reads `doc-gap-state.json`. The open/decided split happens in
+    `cmd_gap_status`, which joins this against the ledger. A caller wanting
+    only open gaps has to do that join itself.
 
     Shells out to the tests driver rather than importing it: the two drivers
     are separate programs with separate manifests and separate notions of
@@ -431,6 +449,12 @@ def load_gap_queue(source_doc: str | None = None) -> dict[str, list[dict]]:
 
 TESTS_FRESHNESS_PATH = REPO_ROOT / "docs/generated/tests/_meta/freshness.json"
 
+# The three verdicts `_classify_fixed_gap` returns. Named so the renderers
+# and any future consumer share one spelling rather than repeating literals.
+_FIX_REOPENED = "reopened"
+_FIX_AWAITING_REGEN = "awaiting-regen"
+_FIX_UNVERIFIABLE = "unverifiable"
+
 
 def load_bundle_source_doc_digests() -> dict[str, str | None]:
     """Return each test bundle's recorded `source_doc_digest`.
@@ -452,10 +476,13 @@ def load_bundle_source_doc_digests() -> dict[str, str | None]:
     }
 
 
-def _verify_fixed_gap(
+def _classify_fixed_gap(
     doc: str, reported_by: list[str], bundle_digests: dict[str, str | None]
 ) -> str:
-    """Say whether a gap the ledger calls `fixed` has actually been retested.
+    """Classify whether a gap the ledger calls `fixed` has been retested.
+
+    Returns one of `_FIX_REOPENED` / `_FIX_AWAITING_REGEN` /
+    `_FIX_UNVERIFIABLE` -- a verdict, not a pass/fail.
 
     Fixing a gap edits the document, which changes the reporting bundle's
     `source_doc_digest` and marks it stale; regenerating the bundle
@@ -482,15 +509,15 @@ def _verify_fixed_gap(
     """
     doc_path = REPO_ROOT / doc
     if not doc_path.exists():
-        return "unverifiable"
+        return _FIX_UNVERIFIABLE
     current = hashlib.sha256(doc_path.read_bytes()).hexdigest()
     anchored = [b for b in reported_by if bundle_digests.get(_bundle_key(b))]
     if not anchored:
-        return "unverifiable"
+        return _FIX_UNVERIFIABLE
     for bundle in anchored:
         if bundle_digests.get(_bundle_key(bundle)) != current:
-            return "awaiting-regen"
-    return "reopened"
+            return _FIX_AWAITING_REGEN
+    return _FIX_REOPENED
 
 
 def _bundle_key(bundle_dir: str) -> str:
@@ -1710,15 +1737,15 @@ def cmd_gap_status(args, manifest: Manifest) -> int:
             status = _gap_status(g["gap_id"], ledger_gaps)
             counts[status] = counts.get(status, 0) + 1
             # A `fixed` gap that is still in the queue has not necessarily
-            # failed; whether it has is the question `_verify_fixed_gap`
+            # failed; whether it has is the question `_classify_fixed_gap`
             # answers. A gap that has left the queue is counted as
             # `retired` below and needs no verification -- its absence is
             # the confirmation.
             if status == "fixed":
-                verification[g["gap_id"]] = _verify_fixed_gap(
+                verification[g["gap_id"]] = _classify_fixed_gap(
                     doc, g["reported_by"], bundle_digests
                 )
-        reopened = sum(1 for v in verification.values() if v == "reopened")
+        reopened = sum(1 for v in verification.values() if v == _FIX_REOPENED)
         # Decisions whose gap no longer appears in the queue. The healthy
         # cause is a fix that landed and a bundle that was then regenerated,
         # so the row is gone; the other cause is an id that churned when its
@@ -1769,10 +1796,11 @@ def cmd_gap_status(args, manifest: Manifest) -> int:
         if not open_n and not decided and not row["retired"] and args.only_open:
             continue
         line = f"{open_n:>4} open  {decided:>4} decided"
-        if row["retired"]:
-            line += f"  {row['retired']:>3} retired"
-        else:
-            line += " " * 13
+        retired_field = f"  {row['retired']:>3} retired"
+        # Pad with the retired column's own width so the REOPENED column
+        # stays aligned when a row has none -- derived rather than a magic
+        # constant, so a change to the format above cannot silently drift.
+        line += retired_field if row["retired"] else " " * len(retired_field)
         if row["reopened"]:
             line += f"  {row['reopened']:>3} REOPENED"
         suffix = "" if row["in_manifest"] else "   (not in manifest)"
@@ -1922,7 +1950,18 @@ def cmd_mark_gap(args, manifest: Manifest) -> int:
     if args.report:
         entry["report_path"] = args.report
     if args.finding:
-        entry["finding_id"] = args.finding
+        # Run the operator's spelling through the same resolver the intake
+        # path uses, so the ledger holds one canonical form (a bare id that
+        # resolves under findings/) no matter which command wrote it.
+        canonical = _finding_ref(args.finding) or _finding_ref(f"`{args.finding}`")
+        if not canonical:
+            print(
+                f"error: --finding {args.finding!r} does not resolve to a file"
+                f" under {_rel_to_repo(FINDINGS_DIR)}",
+                file=sys.stderr,
+            )
+            return 2
+        entry["finding_id"] = canonical
     gaps[args.gap_id] = entry
     save_doc_gap_state(state)
     verb = "updated" if prev else "recorded"
@@ -2222,6 +2261,13 @@ def cmd_mark_gap_intake(args, manifest: Manifest) -> int:
             "report_path": report_rel,
             "rationale": row["Evidence"].strip(),
         }
+        # The schema says `rationale` explains the status, and for a fix that
+        # means naming the edit -- which lives in `Fix summary`, not
+        # `Evidence`. Carry it so an intake-written entry says the same kind
+        # of thing a hand-written one does.
+        fix_summary = (row.get("Fix summary") or "").strip()
+        if fix_summary and fix_summary not in ("—", "-"):
+            entry["fix_summary"] = fix_summary
         finding = _finding_ref(row.get("Evidence", ""))
         if finding:
             entry["finding_id"] = finding
@@ -2233,12 +2279,23 @@ def cmd_mark_gap_intake(args, manifest: Manifest) -> int:
 
 FINDINGS_DIR = REPO_ROOT / "docs/generated/tests/_meta/findings"
 
-_FINDING_REF_RE = re.compile(r"findings/(?:filed/)?([A-Za-z0-9][A-Za-z0-9._-]*)\.yaml")
+# `(?<![\w/])` keeps the path form from matching inside a longer token -- a
+# URL such as `https://…/findings/filed/test.yaml/comments` would otherwise
+# yield `test`. `(?![\w.])` does the same on the right.
+_FINDING_REF_RE = re.compile(
+    r"(?<![\w/])findings/(?:filed/)?([A-Za-z0-9][A-Za-z0-9._-]*)\.yaml(?![\w.])"
+)
 _FINDING_ID_RE = re.compile(r"`([a-z0-9][a-z0-9-]{4,})`")
 
 
+def _finding_exists(candidate: str) -> bool:
+    return any(
+        (FINDINGS_DIR / sub / f"{candidate}.yaml").exists() for sub in ("", "filed")
+    )
+
+
 def _finding_ref(evidence: str) -> str | None:
-    """Return the finding id an Evidence cell cites, if any.
+    """Return the finding id an Evidence cell cites, if the finding exists.
 
     Escalations point at `docs/generated/tests/_meta/findings/<id>.yaml`;
     the id is pulled out of the prose rather than given its own column
@@ -2247,24 +2304,21 @@ def _finding_ref(evidence: str) -> str | None:
     report.
 
     An agent that names the finding by its bare id rather than its path
-    has still named it, so the bare form is accepted too -- but only when
-    it resolves to a file that actually exists under `findings/`. That
-    keeps the check precise rather than merely lenient: the point of
-    requiring a reference at all is that someone can follow it, and a
-    filesystem hit proves they can. The first cycle to escalate anything
-    was rejected over exactly this spelling difference, with the finding
-    sitting in the directory the whole time.
+    has still named it, so the bare form is accepted too. Either way the
+    id must resolve to a file that actually exists under `findings/`.
+    That is the whole point of demanding a reference: someone has to be
+    able to follow it, and only a filesystem hit proves they can. A
+    mistyped path is exactly as useless as a mistyped id, so both are
+    checked the same way -- an earlier version trusted the path form
+    unconditionally, which let `findings/typo.yaml` through the
+    escalation gate.
     """
     m = _FINDING_REF_RE.search(evidence or "")
-    if m:
+    if m and _finding_exists(m.group(1)):
         return m.group(1)
     for candidate in _FINDING_ID_RE.findall(evidence or ""):
-        for path in (
-            FINDINGS_DIR / f"{candidate}.yaml",
-            FINDINGS_DIR / "filed" / f"{candidate}.yaml",
-        ):
-            if path.exists():
-                return candidate
+        if _finding_exists(candidate):
+            return candidate
     return None
 
 
@@ -2312,6 +2366,15 @@ def lint_doc_gap_state() -> list[LintIssue]:
                 issues.append(
                     LintIssue(rel, "error", f"{gap_id}: missing {required}")
                 )
+        kind = entry.get("kind")
+        if kind is not None and kind not in _GAP_KINDS:
+            issues.append(
+                LintIssue(
+                    rel,
+                    "error",
+                    f"{gap_id}: kind={kind!r} not in {list(_GAP_KINDS)}",
+                )
+            )
         target = entry.get("target_doc")
         if target and not (REPO_ROOT / target).exists():
             issues.append(
@@ -2438,6 +2501,163 @@ def cmd_lint(args, manifest: Manifest) -> int:
             if issue.severity == "error":
                 any_error = True
     return 1 if any_error else 0
+
+
+def cmd_selftest(args, manifest: Manifest) -> int:
+    """Unit-check the ledger helpers `lint` and `gap-status` depend on.
+
+    `lint` only ever runs these against the committed tree, where
+    `doc-gap-state.json` is valid by construction and every gap-intake
+    report reconciles -- so a green CI run proves the happy path and
+    nothing else. Every contract-enforcing branch below is one that the
+    committed corpus cannot reach: the malformed-ledger cases, the
+    report-validation failures that stop a bad report from
+    half-populating the ledger, and the three-way fixed-gap verdict whose
+    whole purpose is to distinguish "the fix failed" from "not retested
+    yet". A regression inverting any of them would otherwise pass CI.
+    """
+    _ = manifest, args
+    failures: list[str] = []
+
+    def check(what: str, got, want) -> None:
+        if got != want:
+            failures.append(f"{what}: got {got!r}, want {want!r}")
+
+    # -- _finding_ref -------------------------------------------------
+    # Both spellings must resolve, and both must require the file to
+    # exist: a mistyped path is exactly as useless as a mistyped id.
+    real = None
+    for cand in sorted(FINDINGS_DIR.glob("*.yaml"))[:1]:
+        real = cand.stem
+    if real:
+        check("finding path form", _finding_ref(f"see findings/{real}.yaml"), real)
+        check("finding bare id", _finding_ref(f"covered by `{real}`"), real)
+        check(
+            "finding embedded in URL is not a match",
+            _finding_ref(f"https://x/findings/{real}.yaml/comments"),
+            None,
+        )
+    check("finding missing path rejected", _finding_ref("see findings/nope.yaml"), None)
+    check("finding missing bare id rejected", _finding_ref("`no-such-finding`"), None)
+    check("finding absent entirely", _finding_ref("this is a compiler bug"), None)
+
+    # -- _gap_summary -------------------------------------------------
+    check("summary short passthrough", _gap_summary("  a   b "), "a b")
+    long = "word " * 60
+    out = _gap_summary(long)
+    check("summary truncated", len(out) <= _GAP_SUMMARY_CAP + 4, True)
+    check("summary ends on a word boundary", out.endswith(" ..."), True)
+
+    # -- _bundle_key --------------------------------------------------
+    check(
+        "bundle key strips the tests prefix",
+        _bundle_key("docs/generated/tests/design/x"),
+        "design/x",
+    )
+    check("bundle key passes through", _bundle_key("design/x"), "design/x")
+
+    # -- _classify_fixed_gap ------------------------------------------
+    # The verdict turns on whether the reporting bundle has been
+    # regenerated against the document's *current* text.
+    # Resolved against REPO_ROOT, so this needs a real committed document
+    # rather than a temp file.
+    real_doc = next(
+        (
+            spec.path
+            for spec in manifest.docs.values()
+            if (REPO_ROOT / spec.path).exists()
+        ),
+        None,
+    )
+    if real_doc:
+        cur = hashlib.sha256((REPO_ROOT / real_doc).read_bytes()).hexdigest()
+        b = "docs/generated/tests/design/x"
+        check(
+            "fixed gap reopens once its bundle is regenerated",
+            _classify_fixed_gap(real_doc, [b], {"design/x": cur}),
+            _FIX_REOPENED,
+        )
+        check(
+            "fixed gap awaits a stale bundle",
+            _classify_fixed_gap(real_doc, [b], {"design/x": "0" * 64}),
+            _FIX_AWAITING_REGEN,
+        )
+        check(
+            "coverage-only reporter cannot be verified",
+            _classify_fixed_gap(real_doc, [b], {"design/x": None}),
+            _FIX_UNVERIFIABLE,
+        )
+    check(
+        "missing document is unverifiable",
+        _classify_fixed_gap("docs/generated/design/does-not-exist.md", [], {}),
+        _FIX_UNVERIFIABLE,
+    )
+
+    # -- lint_doc_gap_state -------------------------------------------
+    # Each malformed shape must produce an error; the committed ledger
+    # reaches none of these.
+    good = {
+        "status": "fixed",
+        "target_doc": "docs/generated/design/glossary.md",
+        "kind": "missing-example",
+        "decided_at": "2026-08-11T00:00:00Z",
+        "rationale": "because",
+    }
+
+    def lint_state(entries: dict, version: int = 1) -> list[str]:
+        saved = DOC_GAP_STATE_PATH.read_text(encoding="utf-8")
+        try:
+            DOC_GAP_STATE_PATH.write_text(
+                json.dumps({"schema_version": version, "gaps": entries}),
+                encoding="utf-8",
+            )
+            return [i.message for i in lint_doc_gap_state() if i.severity == "error"]
+        finally:
+            DOC_GAP_STATE_PATH.write_text(saved, encoding="utf-8")
+
+    check("ledger accepts a well-formed entry", lint_state({"a" * 12: good}), [])
+    check(
+        "ledger rejects a bad gap id",
+        any("12-hex" in m for m in lint_state({"NOTHEX": good})),
+        True,
+    )
+    check(
+        "ledger rejects an unknown status",
+        any("status=" in m for m in lint_state({"a" * 12: {**good, "status": "x"}})),
+        True,
+    )
+    check(
+        "ledger rejects an unknown kind",
+        any("kind=" in m for m in lint_state({"a" * 12: {**good, "kind": "invented"}})),
+        True,
+    )
+    for missing in ("target_doc", "decided_at", "rationale"):
+        entry = {k: v for k, v in good.items() if k != missing}
+        check(
+            f"ledger requires {missing}",
+            any(missing in m for m in lint_state({"a" * 12: entry})),
+            True,
+        )
+    check(
+        "ledger requires a finding id for an escalation",
+        any(
+            "finding_id" in m
+            for m in lint_state(
+                {"a" * 12: {**good, "status": "escalated-to-finding"}}
+            )
+        ),
+        True,
+    )
+    check(
+        "ledger rejects a wrong schema_version",
+        any("schema_version" in m for m in lint_state({}, version=2)),
+        True,
+    )
+
+    for f in failures:
+        print(f"FAIL {f}")
+    print(f"selftest: {len(failures)} failure(s)")
+    return 1 if failures else 0
 
 
 def _require_doc(manifest: Manifest, key: str) -> DocSpec:
@@ -2579,6 +2799,11 @@ def build_parser() -> argparse.ArgumentParser:
         " _meta/gap-intake/<doc>.gap-intake.md",
     )
 
+    sub.add_parser(
+        "selftest",
+        help="unit-check the ledger helpers lint and gap-status depend on",
+    )
+
     return p
 
 
@@ -2599,6 +2824,7 @@ def main(argv: list[str] | None = None) -> int:
         "gap-status": cmd_gap_status,
         "mark-gap": cmd_mark_gap,
         "mark-gap-intake": cmd_mark_gap_intake,
+        "selftest": cmd_selftest,
     }
     return handlers[args.cmd](args, manifest)
 

--- a/docs/generated/design/_meta/regenerate.py
+++ b/docs/generated/design/_meta/regenerate.py
@@ -85,6 +85,13 @@ FRESHNESS_PATH = META_DIR / "freshness.json"
 REVIEW_STATE_PATH = META_DIR / "review-state.json"
 REVIEWS_DIR = META_DIR / "reviews"
 REMEDIATIONS_DIR = META_DIR / "remediations"
+DOC_GAP_STATE_PATH = META_DIR / "doc-gap-state.json"
+GAP_INTAKE_DIR = META_DIR / "gap-intake"
+
+# The agentic test suite's driver. It owns the gap queue -- gaps are rows in
+# its bundle READMEs -- and this driver owns what was decided about them, so
+# the queue is read from there rather than duplicated here.
+TESTS_DRIVER = REPO_ROOT / "docs/generated/tests/_meta/regenerate.py"
 
 # Soft refusal patterns for the review / remediation model fields.
 # - The reviewer (a different model family) must NOT advertise itself as
@@ -343,6 +350,96 @@ def save_review_state(state: dict) -> None:
     REVIEW_STATE_PATH.write_text(
         json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
+
+
+# --------------------------------------------------------------------------
+# Doc-gap ledger
+#
+# The agentic test suite reports, per bundle, the places where a document and
+# the compiler disagree in a way that is the document's fault -- a claim it
+# never makes, an example it never gives, behaviour it describes wrongly.
+# Those rows are the only evidence in this pipeline that came from running
+# the compiler rather than from reading it, and until this ledger existed
+# there was nothing on the consuming side to record that one had been acted
+# on, so they accumulated unread.
+#
+# The split of responsibilities: the tests driver computes the queue (it is
+# derived from bundle READMEs, and is recomputed every run, so a gap that the
+# suite stops reporting stops being work), and this file records decisions
+# against it. Nothing here writes the queue; nothing there records a decision.
+# --------------------------------------------------------------------------
+
+_GAP_STATUSES = (
+    "fixed",
+    "rejected-bogus",
+    "rejected-out-of-scope",
+    "deferred",
+    "escalated-to-finding",
+)
+
+_GAP_ID_RE = re.compile(r"^[0-9a-f]{12}$")
+
+
+def load_doc_gap_state() -> dict:
+    if not DOC_GAP_STATE_PATH.exists():
+        return {"schema_version": 1, "gaps": {}}
+    return json.loads(DOC_GAP_STATE_PATH.read_text(encoding="utf-8"))
+
+
+def save_doc_gap_state(state: dict) -> None:
+    DOC_GAP_STATE_PATH.write_text(
+        json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def load_gap_queue(source_doc: str | None = None) -> dict[str, list[dict]]:
+    """Return the open-or-not gap rows the test suite currently reports,
+    keyed by the document each is anchored to.
+
+    Shells out to the tests driver rather than importing it: the two drivers
+    are separate programs with separate manifests and separate notions of
+    what a "document" is, and a stray import would couple this file's
+    behaviour to the other's module-level state.
+    """
+    if not TESTS_DRIVER.exists():
+        raise SystemExit(
+            f"tests driver not found at {_rel_to_repo(TESTS_DRIVER)};"
+            " the doc-gap queue is computed from the test bundles"
+        )
+    cmd = [
+        sys.executable,
+        str(TESTS_DRIVER),
+        "doc-gaps",
+        "--tree",
+        "design",
+        "--format",
+        "json",
+    ]
+    if source_doc:
+        cmd += ["--source-doc", source_doc]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        # `--source-doc` with no matching rows exits non-zero, which is not
+        # an error here: a document with no reported gaps is the good case.
+        if source_doc and "no gap rows are anchored to" in proc.stderr:
+            return {}
+        raise SystemExit(
+            f"tests driver `doc-gaps` failed:\n{proc.stderr.strip()}"
+        )
+    return json.loads(proc.stdout)
+
+
+def _gap_status(gap_id: str, ledger_gaps: dict) -> str:
+    """Return the recorded status of one gap, or `open` if undecided.
+
+    Absence from the ledger is the open state rather than an explicit
+    `"status": "open"` entry, so that a newly reported gap is open by
+    construction and no writer has to seed it first.
+    """
+    entry = ledger_gaps.get(gap_id)
+    if not entry:
+        return "open"
+    return entry.get("status", "open")
 
 
 def _yaml_to_str(val) -> str:
@@ -812,7 +909,18 @@ _ACTION_BODY_TO_FM = {
 
 
 def _report_rel(path: Path) -> str:
-    return _rel_to_repo(path)
+    """Name a report file for a lint message.
+
+    `--report` takes an arbitrary path, so a report can legitimately sit
+    outside the repository (a scratch file an operator is iterating on
+    before moving it into `_meta/`). Fall back to the absolute path in
+    that case: the caller only wants something to print, and raising here
+    turned a lint run on an out-of-tree report into a traceback.
+    """
+    try:
+        return _rel_to_repo(path)
+    except ValueError:
+        return str(path)
 
 
 def _coerce_int(val) -> int | None:
@@ -1490,6 +1598,603 @@ def cmd_mark_remediated(args, manifest: Manifest) -> int:
     return 0
 
 
+def cmd_gap_status(args, manifest: Manifest) -> int:
+    """Report, per document, how many test-suite-reported doc gaps are still
+    open and what was decided about the rest.
+
+    This is the queue the doc side works from. It is a join, computed fresh
+    every run, of two things that live apart on purpose: the gaps the test
+    bundles currently report, and the decisions recorded in
+    `doc-gap-state.json`.
+    """
+    if args.docs:
+        for d in args.docs:
+            if d not in manifest.docs:
+                print(f"error: unknown doc {d!r}", file=sys.stderr)
+                return 2
+    ledger_gaps = load_doc_gap_state().get("gaps", {})
+    queue = load_gap_queue()
+
+    wanted = (
+        {manifest.docs[d].path for d in args.docs}
+        if args.docs
+        else {spec.path for spec in manifest.docs.values()}
+    )
+    # A gap can name a design page the manifest does not carry (a page that
+    # was retired, or one added to the tree but not the manifest). Reporting
+    # it under its own path beats dropping it, which would silently shrink
+    # the queue.
+    docs = sorted(wanted | {d for d in queue if not args.docs})
+
+    rows: list[dict] = []
+    for doc in docs:
+        gaps = queue.get(doc, [])
+        counts: dict[str, int] = {}
+        for g in gaps:
+            status = _gap_status(g["gap_id"], ledger_gaps)
+            counts[status] = counts.get(status, 0) + 1
+        # Decisions whose gap no longer appears in the queue. The healthy
+        # cause is a fix that landed and a bundle that was then regenerated,
+        # so the row is gone; the other cause is an id that churned when its
+        # anchored heading was renamed. Either way the decision is no longer
+        # answering anything, so it is counted apart rather than folded into
+        # the totals.
+        retired = sum(
+            1
+            for gid, e in ledger_gaps.items()
+            if e.get("target_doc") == doc
+            and not any(g["gap_id"] == gid for g in gaps)
+        )
+        rows.append(
+            {
+                "doc": doc,
+                "in_manifest": doc in wanted,
+                "counts": counts,
+                "retired": retired,
+                "gaps": [
+                    {
+                        "gap_id": g["gap_id"],
+                        "status": _gap_status(g["gap_id"], ledger_gaps),
+                        "kind": g["kind"],
+                        "anchor": g["anchor_fragment"],
+                        "reported_by": g["reported_by"],
+                    }
+                    for g in gaps
+                ],
+            }
+        )
+
+    if args.format == "json":
+        print(json.dumps(rows, indent=2, sort_keys=True))
+        return 0
+
+    if args.format == "markdown":
+        return _print_gap_status_markdown(rows, args.only_open)
+
+    total_open = 0
+    for row in rows:
+        open_n = row["counts"].get("open", 0)
+        total_open += open_n
+        decided = sum(v for k, v in row["counts"].items() if k != "open")
+        if not open_n and not decided and not row["retired"] and args.only_open:
+            continue
+        line = f"{open_n:>4} open  {decided:>4} decided"
+        if row["retired"]:
+            line += f"  {row['retired']:>3} retired"
+        else:
+            line += " " * 13
+        suffix = "" if row["in_manifest"] else "   (not in manifest)"
+        print(f"{line}  {row['doc']}{suffix}")
+        if args.show_gaps:
+            for g in row["gaps"]:
+                if args.only_open and g["status"] != "open":
+                    continue
+                print(
+                    f"        {g['gap_id']}  {g['status']:<22}"
+                    f"{g['kind']:<24}{g['anchor']}"
+                )
+    print(f"\ntotal open: {total_open}")
+    return 0
+
+
+def _print_gap_status_markdown(rows: list[dict], only_open: bool) -> int:
+    """Render the gap queue as a GitHub-flavored summary table.
+
+    Lives here rather than in the CI workflow so that what CI posts can be
+    reproduced locally with the same command, and so that changing the
+    report does not mean editing YAML.
+    """
+    total_open = sum(r["counts"].get("open", 0) for r in rows)
+    total_decided = sum(
+        v for r in rows for k, v in r["counts"].items() if k != "open"
+    )
+    shown = [
+        r
+        for r in rows
+        if not only_open
+        or r["counts"].get("open", 0)
+        or any(k != "open" for k in r["counts"])
+        or r["retired"]
+    ]
+    print("### Doc gaps reported by the agentic test suite")
+    print()
+    print(
+        f"**{total_open} open**, {total_decided} decided, across"
+        f" {len(shown)} document(s)."
+    )
+    print()
+    if not shown:
+        print("No gaps are reported against this tree.")
+        return 0
+    print("| Document | Open | Decided | Retired |")
+    print("| --- | ---: | ---: | ---: |")
+    for r in sorted(shown, key=lambda r: (-r["counts"].get("open", 0), r["doc"])):
+        decided = sum(v for k, v in r["counts"].items() if k != "open")
+        print(
+            f"| `{r['doc']}` | {r['counts'].get('open', 0)} | {decided}"
+            f" | {r['retired']} |"
+        )
+    print()
+    print(
+        "Work these with the gap-intake stage; see"
+        " `docs/generated/design/_meta/regenerate.md`"
+        " § Doc gaps from the test suite."
+    )
+    return 0
+
+
+def cmd_mark_gap(args, manifest: Manifest) -> int:
+    """Record a decision about one gap in `doc-gap-state.json`.
+
+    The gap-intake stage will write these in bulk from a report; this
+    command is the hand path, for an operator triaging a row without
+    running an agent -- most usefully to mark a gap
+    `rejected-out-of-scope` when it belongs to the language reference.
+    """
+    if not _GAP_ID_RE.match(args.gap_id):
+        print(
+            f"error: {args.gap_id!r} is not a gap id (12 hex digits);"
+            " get one from `doc-gaps`",
+            file=sys.stderr,
+        )
+        return 2
+    if args.status == "escalated-to-finding" and not args.finding:
+        print(
+            "error: --finding is required when status is escalated-to-finding,"
+            " so the compiler-side record can be found from here",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Look the gap up in the live queue rather than trusting the id: a typo
+    # would otherwise be recorded as a decision about nothing and counted as
+    # retired forever after.
+    queue = load_gap_queue()
+    found = None
+    for doc, gaps in queue.items():
+        for g in gaps:
+            if g["gap_id"] == args.gap_id:
+                found = (doc, g)
+                break
+        if found:
+            break
+    if not found:
+        print(
+            f"error: no gap with id {args.gap_id} is currently reported;"
+            " run `doc-gaps` to list the queue",
+            file=sys.stderr,
+        )
+        return 2
+    doc, gap = found
+
+    state = load_doc_gap_state()
+    gaps = state.setdefault("gaps", {})
+    prev = gaps.get(args.gap_id)
+    entry = {
+        "status": args.status,
+        "target_doc": doc,
+        "kind": gap["kind"],
+        "summary": _gap_summary(gap["gap"]),
+        "decided_at": _dt.datetime.now(_dt.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "rationale": args.rationale,
+    }
+    if args.model:
+        entry["decided_by_model"] = args.model
+    if args.report:
+        entry["report_path"] = args.report
+    if args.finding:
+        entry["finding_id"] = args.finding
+    gaps[args.gap_id] = entry
+    save_doc_gap_state(state)
+    verb = "updated" if prev else "recorded"
+    was = f" (was {prev['status']})" if prev else ""
+    print(f"{verb} {args.gap_id} as {args.status}{was} against {doc}")
+    return 0
+
+
+_GAP_SUMMARY_CAP = 160
+
+
+def _gap_summary(prose: str) -> str:
+    """Condense a gap's prose to a line that identifies it in the ledger.
+
+    The ledger is read by humans deciding whether a decision still holds,
+    and a bare 12-hex id tells them nothing; the full prose is a paragraph
+    and would bury the file. Truncation is on a word boundary so the result
+    reads as a sentence fragment rather than a severed word.
+    """
+    prose = re.sub(r"\s+", " ", prose).strip()
+    if len(prose) <= _GAP_SUMMARY_CAP:
+        return prose
+    cut = prose[:_GAP_SUMMARY_CAP].rsplit(" ", 1)[0]
+    return cut + " ..."
+
+
+_GAP_INTAKE_REQUIRED_FM_KEYS = (
+    "gap_intake_report",
+    "intake_model",
+    "intake_at",
+    "target_doc",
+    "target_doc_source_commit_before",
+    "target_doc_source_commit_after",
+    "gap_count",
+    "actions",
+)
+
+# Body spelling of an action -> the front-matter count key. The body
+# spellings are also exactly the ledger's statuses, so a row's Action cell
+# is written into `doc-gap-state.json` verbatim.
+_GAP_ACTION_BODY_TO_FM = {
+    "fixed": "fixed",
+    "rejected-bogus": "rejected_bogus",
+    "rejected-out-of-scope": "rejected_out_of_scope",
+    "deferred": "deferred",
+    "escalated-to-finding": "escalated_to_finding",
+}
+
+
+def _default_gap_intake_report_path(doc_key: str) -> Path:
+    return GAP_INTAKE_DIR / f"{doc_key}.gap-intake.md"
+
+
+def lint_gap_intake_report(
+    path: Path, manifest: Manifest
+) -> tuple[list[LintIssue], dict | None]:
+    """Validate a gap-intake report file.
+
+    The cross-check that matters is against the *live* gap queue rather
+    than against a sibling report: unlike remediation, whose work list is
+    the review report next to it, intake's work list is recomputed from
+    the test bundles every run. So a row naming a gap the suite does not
+    report is an error (it would write a decision about nothing into the
+    ledger), while a gap the suite reports and the report does not
+    mention is a warning (the operator may be working through a document
+    in batches).
+
+    Returns (issues, front_matter_dict_or_None).
+    """
+    rel = _report_rel(path)
+    issues: list[LintIssue] = []
+    if not path.exists():
+        return [LintIssue(rel, "error", "gap-intake report does not exist")], None
+    text = path.read_text(encoding="utf-8")
+    fm = parse_yaml_front_matter(text)
+    if fm is None:
+        return [
+            LintIssue(rel, "error", "missing or malformed YAML front-matter")
+        ], None
+
+    for k in _GAP_INTAKE_REQUIRED_FM_KEYS:
+        if k not in fm:
+            issues.append(LintIssue(rel, "error", f"front-matter missing key: {k}"))
+
+    sentinel = fm.get("gap_intake_report")
+    if sentinel is not True and str(sentinel).lower() != "true":
+        issues.append(
+            LintIssue(rel, "error", "front-matter gap_intake_report must be true")
+        )
+
+    model = fm.get("intake_model")
+    if not isinstance(model, str) or not model.strip():
+        issues.append(
+            LintIssue(rel, "error", "intake_model must be a non-empty string")
+        )
+    elif not _is_claude_family(model):
+        issues.append(
+            LintIssue(
+                rel,
+                "error",
+                f"intake_model {model!r} does not look like a"
+                " Claude/Anthropic model; intake edits the generated"
+                " documents and must run in the family that generated them",
+            )
+        )
+
+    target = fm.get("target_doc")
+    if not isinstance(target, str) or target not in manifest.docs:
+        issues.append(
+            LintIssue(
+                rel, "error", f"target_doc {target!r} is not a known manifest key"
+            )
+        )
+        return issues, fm
+
+    actions = fm.get("actions")
+    action_sum: int | None = 0
+    if not isinstance(actions, dict):
+        issues.append(LintIssue(rel, "error", "actions must be a mapping"))
+        action_sum = None
+    else:
+        for k in _GAP_ACTION_BODY_TO_FM.values():
+            v = _coerce_int(actions.get(k))
+            if v is None or v < 0:
+                issues.append(
+                    LintIssue(
+                        rel, "error", f"actions.{k} must be a non-negative integer"
+                    )
+                )
+                action_sum = None
+            elif action_sum is not None:
+                action_sum += v
+    gap_count = _coerce_int(fm.get("gap_count"))
+    if gap_count is None or gap_count < 0:
+        issues.append(
+            LintIssue(rel, "error", "gap_count must be a non-negative integer")
+        )
+    elif action_sum is not None and action_sum != gap_count:
+        issues.append(
+            LintIssue(
+                rel,
+                "error",
+                f"actions sum to {action_sum} but gap_count is {gap_count}",
+            )
+        )
+
+    body = text[text.find("\n---\n") + 5 :] if "\n---\n" in text else ""
+    sections = _split_sections(body)
+    if "Actions" not in sections:
+        issues.append(LintIssue(rel, "error", "missing `## Actions` section"))
+        return issues, fm
+    table = parse_markdown_table(sections["Actions"])
+    if table is None:
+        issues.append(
+            LintIssue(rel, "error", "`## Actions` must contain a Markdown table")
+        )
+        return issues, fm
+
+    doc_path = manifest.docs[target].path
+    queue_ids = {
+        g["gap_id"] for g in load_gap_queue(doc_path).get(doc_path, [])
+    }
+    seen: set[str] = set()
+    for idx, row in enumerate(table, start=1):
+        gid = row.get("Gap ID", "")
+        if not gid:
+            issues.append(LintIssue(rel, "error", f"row {idx}: missing Gap ID"))
+            continue
+        if not _GAP_ID_RE.match(gid):
+            issues.append(
+                LintIssue(rel, "error", f"{gid}: not a 12-hex-digit gap id")
+            )
+        if gid in seen:
+            issues.append(LintIssue(rel, "error", f"duplicate Gap ID: {gid}"))
+        seen.add(gid)
+        action_v = row.get("Action", "").lower()
+        if action_v not in _GAP_ACTION_BODY_TO_FM:
+            issues.append(
+                LintIssue(
+                    rel,
+                    "error",
+                    f"{gid}: Action {action_v!r} not in"
+                    f" {list(_GAP_ACTION_BODY_TO_FM)}",
+                )
+            )
+        if not row.get("Evidence", "").strip():
+            issues.append(LintIssue(rel, "error", f"{gid}: Evidence cell is empty"))
+        if action_v == "fixed" and not row.get("Fix summary", "").strip():
+            issues.append(
+                LintIssue(
+                    rel, "error", f"{gid}: Fix summary required when Action is `fixed`"
+                )
+            )
+    if gap_count is not None and len(table) != gap_count:
+        issues.append(
+            LintIssue(
+                rel,
+                "error",
+                f"gap_count is {gap_count} but the Actions table has"
+                f" {len(table)} row(s)",
+            )
+        )
+    for gid in sorted(seen - queue_ids):
+        issues.append(
+            LintIssue(
+                rel,
+                "error",
+                f"action row {gid} names a gap the test suite does not report"
+                f" against {target}",
+            )
+        )
+    ledger_gaps = load_doc_gap_state().get("gaps", {})
+    unaddressed = sorted(
+        gid
+        for gid in queue_ids - seen
+        if _gap_status(gid, ledger_gaps) == "open"
+    )
+    if unaddressed:
+        issues.append(
+            LintIssue(
+                rel,
+                "warning",
+                f"{len(unaddressed)} gap(s) still open against {target} are"
+                f" not in this report: {', '.join(unaddressed)}",
+            )
+        )
+    return issues, fm
+
+
+def cmd_mark_gap_intake(args, manifest: Manifest) -> int:
+    """Write a gap-intake report's decisions into `doc-gap-state.json`.
+
+    This is the bulk writer `mark-gap` is the hand equivalent of. It
+    refuses on any lint error, so a malformed report cannot half-populate
+    the ledger.
+    """
+    _require_doc(manifest, args.doc)
+    report_path = (
+        Path(args.report).resolve()
+        if args.report
+        else _default_gap_intake_report_path(args.doc)
+    )
+    issues, fm = lint_gap_intake_report(report_path, manifest)
+    for issue in issues:
+        print(f"{issue.severity}: {issue.doc}: {issue.message}", file=sys.stderr)
+    if any(i.severity == "error" for i in issues):
+        return 1
+    if fm is None or fm.get("target_doc") != args.doc:
+        print(
+            f"error: report target_doc {fm.get('target_doc') if fm else None!r}"
+            f" does not match <doc> {args.doc!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    doc_path = manifest.docs[args.doc].path
+    queue = {g["gap_id"]: g for g in load_gap_queue(doc_path).get(doc_path, [])}
+    text = report_path.read_text(encoding="utf-8")
+    body = text[text.find("\n---\n") + 5 :]
+    table = parse_markdown_table(_split_sections(body)["Actions"]) or []
+
+    # An escalation has to name the compiler-side record, or the trail from
+    # "the docs declined to document this" to "someone is fixing it" is
+    # broken at exactly the point it matters. The report's Evidence cell is
+    # where the agent names it; a bare escalation is rejected here rather
+    # than silently recorded.
+    missing_finding = [
+        row.get("Gap ID", "")
+        for row in table
+        if row.get("Action", "").lower() == "escalated-to-finding"
+        and not _finding_ref(row.get("Evidence", ""))
+    ]
+    if missing_finding:
+        print(
+            "error: escalated-to-finding rows name no findings/<id>.yaml in"
+            f" their Evidence cell: {', '.join(missing_finding)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    state = load_doc_gap_state()
+    state.setdefault("schema_version", 1)
+    gaps = state.setdefault("gaps", {})
+    intake_at = _yaml_to_str(fm["intake_at"])
+    model = _yaml_to_str(fm["intake_model"])
+    report_rel = _report_rel(report_path)
+    for row in table:
+        gid = row["Gap ID"]
+        status = row["Action"].lower()
+        entry = {
+            "status": status,
+            "target_doc": doc_path,
+            "kind": queue[gid]["kind"],
+            "summary": _gap_summary(queue[gid]["gap"]),
+            "decided_at": intake_at,
+            "decided_by_model": model,
+            "report_path": report_rel,
+            "rationale": row["Evidence"].strip(),
+        }
+        finding = _finding_ref(row.get("Evidence", ""))
+        if finding:
+            entry["finding_id"] = finding
+        gaps[gid] = entry
+    save_doc_gap_state(state)
+    print(f"marked gap intake: {args.doc} ({len(table)} gap(s))")
+    return 0
+
+
+_FINDING_REF_RE = re.compile(r"findings/(?:filed/)?([A-Za-z0-9][A-Za-z0-9._-]*)\.yaml")
+
+
+def _finding_ref(evidence: str) -> str | None:
+    """Return the finding id an Evidence cell cites, if any.
+
+    Escalations point at `docs/generated/tests/_meta/findings/<id>.yaml`;
+    the id is pulled out of the prose rather than given its own column
+    because it is relevant to exactly one of the five actions, and a
+    column that is an em-dash four times out of five is noise in every
+    report.
+    """
+    m = _FINDING_REF_RE.search(evidence or "")
+    return m.group(1) if m else None
+
+
+def lint_doc_gap_state() -> list[LintIssue]:
+    """Validate `doc-gap-state.json` against its schema's required shape.
+
+    Hand-rolled for the same reason the report linters are: the driver has
+    no third-party dependencies, so the schema file documents the contract
+    and this enforces it.
+    """
+    issues: list[LintIssue] = []
+    rel = _rel_to_repo(DOC_GAP_STATE_PATH)
+    if not DOC_GAP_STATE_PATH.exists():
+        return issues
+    try:
+        state = json.loads(DOC_GAP_STATE_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return [LintIssue(rel, "error", f"cannot parse: {exc}")]
+    if state.get("schema_version") != 1:
+        issues.append(
+            LintIssue(rel, "error", "schema_version must be 1")
+        )
+    gaps = state.get("gaps")
+    if not isinstance(gaps, dict):
+        return issues + [LintIssue(rel, "error", "`gaps` must be an object")]
+    for gap_id, entry in sorted(gaps.items()):
+        if not _GAP_ID_RE.match(gap_id):
+            issues.append(
+                LintIssue(rel, "error", f"{gap_id}: not a 12-hex-digit gap id")
+            )
+        if not isinstance(entry, dict):
+            issues.append(LintIssue(rel, "error", f"{gap_id}: not an object"))
+            continue
+        status = entry.get("status")
+        if status not in _GAP_STATUSES:
+            issues.append(
+                LintIssue(
+                    rel,
+                    "error",
+                    f"{gap_id}: status={status!r} not in {list(_GAP_STATUSES)}",
+                )
+            )
+        for required in ("target_doc", "decided_at", "rationale"):
+            if not entry.get(required):
+                issues.append(
+                    LintIssue(rel, "error", f"{gap_id}: missing {required}")
+                )
+        target = entry.get("target_doc")
+        if target and not (REPO_ROOT / target).exists():
+            issues.append(
+                LintIssue(
+                    rel,
+                    "warning",
+                    f"{gap_id}: target_doc {target} no longer exists",
+                )
+            )
+        if status == "escalated-to-finding" and not entry.get("finding_id"):
+            issues.append(
+                LintIssue(
+                    rel,
+                    "error",
+                    f"{gap_id}: escalated-to-finding without a finding_id",
+                )
+            )
+    return issues
+
+
 def cmd_digest(args, manifest: Manifest) -> int:
     spec = _require_doc(manifest, args.doc)
     print(compute_digest(spec))
@@ -1574,6 +2279,27 @@ def cmd_lint(args, manifest: Manifest) -> int:
             print(f"{issue.severity}: {issue.doc}: {issue.message}")
             if issue.severity == "error":
                 any_error = True
+    gap_intake_files: list[Path] = []
+    if explicit_targets:
+        for d in args.docs:
+            gp = _default_gap_intake_report_path(d)
+            if gp.exists():
+                gap_intake_files.append(gp)
+    else:
+        gap_intake_files = _iter_report_files(GAP_INTAKE_DIR, ".gap-intake.md")
+    for gp in gap_intake_files:
+        issues, _ = lint_gap_intake_report(gp, manifest)
+        for issue in issues:
+            print(f"{issue.severity}: {issue.doc}: {issue.message}")
+            if issue.severity == "error":
+                any_error = True
+    # The doc-gap ledger is tree-wide, not per-document, so it is checked
+    # only on a full lint run.
+    if not explicit_targets:
+        for issue in lint_doc_gap_state():
+            print(f"{issue.severity}: {issue.doc}: {issue.message}")
+            if issue.severity == "error":
+                any_error = True
     return 1 if any_error else 0
 
 
@@ -1654,6 +2380,68 @@ def build_parser() -> argparse.ArgumentParser:
         " _meta/remediations/<doc>.remediation.md",
     )
 
+    p_gap = sub.add_parser(
+        "gap-status",
+        help="per-document count of open / decided doc gaps reported by the"
+        " agentic test suite",
+    )
+    p_gap.add_argument("docs", nargs="*", help="doc keys; default: all")
+    p_gap.add_argument(
+        "--show-gaps",
+        action="store_true",
+        help="list each gap's id, status, kind and anchor under its document",
+    )
+    p_gap.add_argument(
+        "--only-open",
+        action="store_true",
+        help="hide documents with nothing outstanding, and decided gaps",
+    )
+    p_gap.add_argument(
+        "--format",
+        choices=("text", "json", "markdown"),
+        default="text",
+        help="output format; `markdown` is the CI job-summary table"
+        " (default: text)",
+    )
+
+    p_mark_gap = sub.add_parser(
+        "mark-gap",
+        help="record a decision about one doc gap in doc-gap-state.json",
+    )
+    p_mark_gap.add_argument("gap_id", help="12-hex-digit id from `doc-gaps`")
+    p_mark_gap.add_argument(
+        "--status", required=True, choices=_GAP_STATUSES
+    )
+    p_mark_gap.add_argument(
+        "--rationale",
+        required=True,
+        help="why this status; recorded verbatim in the ledger",
+    )
+    p_mark_gap.add_argument(
+        "--finding",
+        default=None,
+        help="findings/<id>.yaml this was escalated to; required when"
+        " --status escalated-to-finding",
+    )
+    p_mark_gap.add_argument(
+        "--report", default=None, help="gap-intake report that decided this"
+    )
+    p_mark_gap.add_argument(
+        "--model", default=None, help="model or operator that decided this"
+    )
+
+    p_mark_intake = sub.add_parser(
+        "mark-gap-intake",
+        help="write a gap-intake report's decisions into doc-gap-state.json",
+    )
+    p_mark_intake.add_argument("doc")
+    p_mark_intake.add_argument(
+        "--report",
+        default=None,
+        help="path to the gap-intake report; default"
+        " _meta/gap-intake/<doc>.gap-intake.md",
+    )
+
     return p
 
 
@@ -1671,6 +2459,9 @@ def main(argv: list[str] | None = None) -> int:
         "review-status": cmd_review_status,
         "mark-reviewed": cmd_mark_reviewed,
         "mark-remediated": cmd_mark_remediated,
+        "gap-status": cmd_gap_status,
+        "mark-gap": cmd_mark_gap,
+        "mark-gap-intake": cmd_mark_gap_intake,
     }
     return handlers[args.cmd](args, manifest)
 

--- a/docs/generated/design/_meta/schema/doc-gap-state.schema.json
+++ b/docs/generated/design/_meta/schema/doc-gap-state.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shader-slang.github.io/generated/design/doc-gap-state.schema.json",
+  "title": "Doc-gap resolution ledger",
+  "description": "Records what was decided about each doc gap reported by the agentic test suite. A gap is one row of a `## Doc gaps observed` table in a test bundle README, aggregated by `docs/generated/tests/_meta/regenerate.py doc-gaps` and keyed by the `gap_id` that command derives. Gaps absent from this file are open: the ledger records decisions, never the queue itself, which is recomputed from the bundle READMEs on every run so that a gap the suite stops reporting stops being work.",
+  "type": "object",
+  "required": ["schema_version", "gaps"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "gaps": {
+      "type": "object",
+      "description": "Keyed by gap_id, the 12-hex-digit identity `doc-gaps` derives from the anchored document, its heading fragment, the gap kind, and the normalized gap prose.",
+      "propertyNames": {
+        "pattern": "^[0-9a-f]{12}$"
+      },
+      "additionalProperties": { "$ref": "#/$defs/entry" }
+    }
+  },
+  "$defs": {
+    "entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "target_doc", "decided_at", "rationale"],
+      "properties": {
+        "status": {
+          "description": "fixed — the document was edited so the gap no longer applies. rejected-bogus — the gap misreads the document or the compiler. rejected-out-of-scope — real, but belongs to another document (commonly the human-written language reference, which no agent may edit). deferred — real and in scope, but not now. escalated-to-finding — the disagreement is a compiler defect, not a documentation defect, so it belongs in the tests tree's findings channel; `finding_id` names it.",
+          "enum": [
+            "fixed",
+            "rejected-bogus",
+            "rejected-out-of-scope",
+            "deferred",
+            "escalated-to-finding"
+          ]
+        },
+        "target_doc": {
+          "type": "string",
+          "description": "Workspace-relative path of the document the gap is anchored to. Recorded so the ledger stays readable on its own, and so a decision survives the gap dropping out of the aggregation.",
+          "pattern": "^docs/"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "missing-example",
+            "missing-surface",
+            "undocumented-behavior",
+            "cascading-only-mention",
+            "ambiguous-claim",
+            "drift-from-source"
+          ]
+        },
+        "summary": {
+          "type": "string",
+          "description": "Short human-readable restatement of the gap, so a reader of this file need not re-run the aggregator to know what a gap_id refers to."
+        },
+        "decided_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "decided_by_model": {
+          "type": "string",
+          "description": "Model identifier that made the call, or the operator's name for a hand decision."
+        },
+        "report_path": {
+          "type": "string",
+          "description": "Path to the gap-intake report that recorded this action, when one exists. A hand decision made with `mark-gap` has none."
+        },
+        "finding_id": {
+          "type": "string",
+          "description": "Required when status is escalated-to-finding: the `docs/generated/tests/_meta/findings/<id>.yaml` the behaviour was filed under."
+        },
+        "rationale": {
+          "type": "string",
+          "description": "Why this status. Required for every status including `fixed`, where it names the edit that closed the gap, so that a later reader can tell a real fix from a row that was waved through.",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/docs/generated/design/_meta/schema/doc-gap-state.schema.json
+++ b/docs/generated/design/_meta/schema/doc-gap-state.schema.json
@@ -70,12 +70,17 @@
         },
         "finding_id": {
           "type": "string",
-          "description": "Required when status is escalated-to-finding: the `docs/generated/tests/_meta/findings/<id>.yaml` the behaviour was filed under."
+          "description": "Required when status is escalated-to-finding. Always the bare id -- the `<id>` of `docs/generated/tests/_meta/findings/<id>.yaml` -- never a path. Both writers canonicalize to this form and both verify the file exists before recording it.",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
         },
         "rationale": {
           "type": "string",
-          "description": "Why this status. Required for every status including `fixed`, where it names the edit that closed the gap, so that a later reader can tell a real fix from a row that was waved through.",
+          "description": "Why this status, required for every status. The two writers supply different-but-comparable text: `mark-gap` stores the operator's free-text `--rationale`, while `mark-gap-intake` stores the report row's `Evidence` cell -- for a `fixed` row that is the source citation confirming what was written. See `fix_summary` for the edit itself.",
           "minLength": 1
+        },
+        "fix_summary": {
+          "type": "string",
+          "description": "What the edit actually was, carried from a gap-intake report row's `Fix summary` cell. Present only for entries recorded by `mark-gap-intake` whose action was `fixed`; a hand decision made with `mark-gap` has none."
         }
       }
     }

--- a/docs/generated/design/_meta/schema/gap-intake-report.schema.json
+++ b/docs/generated/design/_meta/schema/gap-intake-report.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shader-slang.github.io/generated/design/gap-intake-report.schema.json",
+  "title": "LLM-generated docs gap-intake report front-matter",
+  "description": "Shape of the YAML front-matter for a gap-intake report under docs/generated/design/_meta/gap-intake/. A gap-intake report records what was decided about the doc gaps the agentic test suite reported against one document; `mark-gap-intake` reads it and writes those decisions into doc-gap-state.json. The body of the report (Summary, optional Escalated gaps, Actions table) is not covered by this schema; it is enforced by the lint pass in regenerate.py.",
+  "type": "object",
+  "required": [
+    "gap_intake_report",
+    "intake_model",
+    "intake_at",
+    "target_doc",
+    "target_doc_source_commit_before",
+    "target_doc_source_commit_after",
+    "gap_count",
+    "actions"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "gap_intake_report": {
+      "type": "boolean",
+      "const": true,
+      "description": "Sentinel marking the file as a gap-intake report."
+    },
+    "intake_model": {
+      "type": "string",
+      "description": "Identifier of the model that performed the intake. The lower-cased value MUST start with 'claude' or 'anthropic': intake edits the generated documents, so it runs in the same family that generated them. The bookkeeping gate refuses other families."
+    },
+    "intake_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "target_doc": {
+      "type": "string",
+      "description": "Manifest key of the document the gaps are anchored to (e.g. pipeline/05-ir-passes.md)."
+    },
+    "target_doc_source_commit_before": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{7,64}$",
+      "description": "The source_commit in the target document's front-matter at the start of intake."
+    },
+    "target_doc_source_commit_after": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{7,64}$",
+      "description": "The source_commit in the target document's front-matter after intake; equal to _before when no edits were made."
+    },
+    "gap_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of gaps acted on. Must equal the number of rows in the Actions table, and the sum of the action counts."
+    },
+    "actions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "fixed",
+        "rejected_bogus",
+        "rejected_out_of_scope",
+        "deferred",
+        "escalated_to_finding"
+      ],
+      "properties": {
+        "fixed": { "type": "integer", "minimum": 0 },
+        "rejected_bogus": { "type": "integer", "minimum": 0 },
+        "rejected_out_of_scope": { "type": "integer", "minimum": 0 },
+        "deferred": { "type": "integer", "minimum": 0 },
+        "escalated_to_finding": { "type": "integer", "minimum": 0 }
+      },
+      "description": "The five counts must sum to gap_count; the lint pass enforces this."
+    }
+  }
+}

--- a/docs/generated/tests/README.md
+++ b/docs/generated/tests/README.md
@@ -184,8 +184,14 @@ four canonical sections, in this order:
    (`link-stage-only`, `out-of-bundle`, `deprecated`, …).
 4. `## Doc gaps observed` — `Anchor | Kind | Gap | Suggested
 addition` table. The feedback channel into doc regeneration. Rows
-   are aggregated by `regenerate.py doc-gaps` and consumed by the
-   doc-regen workflow.
+   are aggregated by `regenerate.py doc-gaps`, which groups them by
+   the document the `Anchor` cell points at and gives each a stable
+   `gap_id`; the doc side records what it decided about each id in
+   `docs/generated/design/_meta/doc-gap-state.json` and reports the
+   remaining queue with that tree's `regenerate.py gap-status`.
+   The `Anchor` cell must carry a link to the document, not a bare
+   `#fragment` — a row that names no document cannot be routed to
+   one, and lint rejects it.
 
 Empty sections are filled with `NA` rather than omitted. Bundle-
 specific sections (e.g., `## Sibling-bundle overlap`,

--- a/docs/generated/tests/_meta/PIPELINE.md
+++ b/docs/generated/tests/_meta/PIPELINE.md
@@ -40,7 +40,7 @@ normative rules live in [`prompts/_common.md`](prompts/_common.md),
                        NIGHTLY CI  (slang-test -test-dir docs/generated/tests)
                                       │
    FEEDBACK CHANNELS  ◄───────────────┴──────────────────────────────────────►
-   • ## Doc gaps observed  → regenerate.py doc-gaps   → documentation regeneration
+   • ## Doc gaps observed  → regenerate.py doc-gaps   → design/_meta gap-status → doc fixes
    • findings/*.yaml        → regenerate.py findings file → compiler tracking issues
    • source/watched digests → regenerate.py list-stale → regenerate drifted bundles
    • lang-ref-coverage / expansion-candidates → choose what to generate next
@@ -118,7 +118,7 @@ how that doc's claims were extracted. Shared prompts —
 - **`_meta/expected-failures.txt`** — tests that fail because of a filed
   (or pending) compiler bug, kept out of the CI failure gate.
 - **`_meta/agentic-coverage-excludes.txt`** — the narrower list of tests
-  the *coverage* run must not execute at all. `nightly-slang-coverage-test.yml`
+  the _coverage_ run must not execute at all. `nightly-slang-coverage-test.yml`
   runs the suite in-process (`-server-count 1`, no test server) so that the
   compiler's own lines are instrumented, which means a test that segfaults
   `slangc` segfaults `slang-test` and the rest of the suite never runs —
@@ -157,10 +157,18 @@ autonomous:
 The suite is designed to _improve its own inputs_:
 
 - **Doc gaps → docs.** `regenerate.py doc-gaps` aggregates every
-  `## Doc gaps observed` row by source doc; the doc-regeneration workflow
-  consumes them to fix `docs/generated/design/` and to flag
-  language-reference gaps. A test anchored to the spec that fails is the
-  honest signal that the spec or the compiler is wrong.
+  `## Doc gaps observed` row, grouped by the document the row's `Anchor`
+  cell points at — which is not the same as the reporting bundle's
+  `source_doc`, since a `coverage/` bundle has none and still reports
+  gaps against design pages. Each merged row carries a `gap_id` derived
+  from (anchored document, heading, kind, normalized prose). The doc side
+  records decisions against those ids in
+  `docs/generated/design/_meta/doc-gap-state.json` and reports what is
+  left with `docs/generated/design/_meta/regenerate.py gap-status`;
+  `--tree language-reference` separates the gaps against the
+  human-written spec, which no agent may edit, into a human triage
+  queue. A test anchored to the spec that fails is the honest signal
+  that the spec or the compiler is wrong.
 - **Findings → compiler.** Triaged findings become tracking issues; fixes
   remove the matching `expected-failures.txt` entry.
 - **Drift detection → regeneration.** `source_doc_digest` and
@@ -190,6 +198,6 @@ The suite is designed to _improve its own inputs_:
 | `index --write`                          | regenerate `INDEX.md`                                                 |
 | `lang-ref-coverage`                      | spec coverage odometer                                                |
 | `expansion-candidates` / `coverage-gaps` | rank under-coverage (ranking only)                                    |
-| `doc-gaps`                               | aggregate `## Doc gaps observed` rows for doc regeneration            |
+| `doc-gaps`                               | aggregate `## Doc gaps observed` rows, by anchored doc, with gap ids  |
 | `mark-fresh <bundle>`                    | clear the stale flag after regenerating                               |
 | `findings list/show/file/dup`            | triage + file suspected-compiler-bug findings                         |

--- a/docs/generated/tests/_meta/prompts/_common.md
+++ b/docs/generated/tests/_meta/prompts/_common.md
@@ -74,11 +74,11 @@ is not a word character, a hyphen, or a space, then turn each remaining
 space into a hyphen. Punctuation is **deleted, not replaced**, so the
 spaces around it each still produce a hyphen:
 
-| Heading                                          | Anchor                                             |
-| ------------------------------------------------ | -------------------------------------------------- |
-| `### Builtin operators bypass call lowering`     | `#builtin-operators-bypass-call-lowering`          |
-| `### MemberExpr / StaticMemberExpr`              | `#memberexpr--staticmemberexpr` (two hyphens)      |
-| `### CUDA / Python / FFI attributes`             | `#cuda--python--ffi-attributes`                    |
+| Heading                                      | Anchor                                        |
+| -------------------------------------------- | --------------------------------------------- |
+| `### Builtin operators bypass call lowering` | `#builtin-operators-bypass-call-lowering`     |
+| `### MemberExpr / StaticMemberExpr`          | `#memberexpr--staticmemberexpr` (two hyphens) |
+| `### CUDA / Python / FFI attributes`         | `#cuda--python--ffi-attributes`               |
 
 Copy the anchor out of the source doc's heading; do not reuse an anchor
 quoted in another bundle's README without checking it against the
@@ -212,25 +212,25 @@ strategy (e.g. "one positive + one negative per claim in sections
 
 ## Functional coverage
 
-| Claim                                                                          | Intent     | Anchor                                                               | Tests                                                                    |
-| ------------------------------------------------------------------------------ | ---------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Claim                                                                          | Intent     | Anchor                                                             | Tests                                                                    |
+| ------------------------------------------------------------------------------ | ---------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------ |
 | The more specialized generic wins when both candidates are equally accessible. | functional | [#overload-resolution](<relative-path-to-doc>#overload-resolution) | [`overload-prefer-specialized.slang`](overload-prefer-specialized.slang) |
-| ...                                                                            | ...        | ...                                                                  | ...                                                                      |
+| ...                                                                            | ...        | ...                                                                | ...                                                                      |
 
 ## Untested claims
 
-| Claim                                                                                                                                     | Reason          | Anchor                                                           | Why untested                                                                                                                                     |
-| ----------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Claim                                                                                                                                     | Reason          | Anchor                                                         | Why untested                                                                                                                                     |
+| ----------------------------------------------------------------------------------------------------------------------------------------- | --------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | The doc describes the `serialize(serializer, value)` template pattern that compiler internals use to thread values through serialization. | needs-unit-test | [#serialize-pattern](<relative-path-to-doc>#serialize-pattern) | A C++ idiom invoked from compiler-internal code; no slangc CLI surface reaches it. A C++ unit test against the serializer types could verify it. |
 | The `closesthit` entry point lowers to a DXR `[shader("closesthit")]` HLSL function.                                                      | gpu-dxr         | [#dxr-ray-tracing](<relative-path-to-doc>#dxr-ray-tracing)     | Agent runtime has no GPU; CI nightly has D3D12 + DXR support.                                                                                    |
-| ...                                                                                                                                       | ...             | ...                                                              | ...                                                                                                                                              |
+| ...                                                                                                                                       | ...             | ...                                                            | ...                                                                                                                                              |
 
 ## Doc gaps observed
 
-| Anchor                                                             | Kind            | Gap                                                                                                             | Suggested addition                                                              |
-| ------------------------------------------------------------------ | --------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Anchor                                                           | Kind            | Gap                                                                                                             | Suggested addition                                                              |
+| ---------------------------------------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
 | [#basic-scalar-types](<relative-path-to-doc>#basic-scalar-types) | missing-surface | The doc lists `IntPtr` and `UIntPtr` as opcodes but does not name a Slang surface construct that produces them. | A "user-level surface" column per row, or a note that these are host-side only. |
-| ...                                                                | ...             | ...                                                                                                             | ...                                                                             |
+| ...                                                              | ...             | ...                                                                                                             | ...                                                                             |
 ```
 
 **Functional-coverage table rules:**
@@ -251,13 +251,14 @@ negative | expansion | regression` and matches the test's
   count the `../` steps for the bundle you are actually writing instead
   of copying them from another bundle:
 
-  | Bundle directory                                     | Link to `docs/generated/design/<doc>.md` | Link to `docs/language-reference/<doc>.md` |
-  | ---------------------------------------------------- | ---------------------------------------- | ------------------------------------------ |
-  | `docs/generated/tests/conformance/<bundle>/`         | `../../../design/<doc>.md`               | `../../../../language-reference/<doc>.md`  |
-  | `docs/generated/tests/design/<area>/<bundle>/`       | `../../../../design/<doc>.md`            | `../../../../../language-reference/<doc>.md` |
+  | Bundle directory                               | Link to `docs/generated/design/<doc>.md` | Link to `docs/language-reference/<doc>.md`   |
+  | ---------------------------------------------- | ---------------------------------------- | -------------------------------------------- |
+  | `docs/generated/tests/conformance/<bundle>/`   | `../../../design/<doc>.md`               | `../../../../language-reference/<doc>.md`    |
+  | `docs/generated/tests/design/<area>/<bundle>/` | `../../../../design/<doc>.md`            | `../../../../../language-reference/<doc>.md` |
 
   Lint fails on a README link whose path does not resolve, so check the
   link resolves from the bundle directory before finishing.
+
 - **Tests** is a comma-separated list of clickable filenames in the
   bundle directory, formatted ``[`filename.slang`](filename.slang)``.
   Never repeat a claim across rows — if multiple tests verify the same
@@ -531,7 +532,7 @@ nothing.
 
 ### FileCheck / CHECK pattern hygiene (READ — most CHECK failures come from these)
 
-You are writing a pattern that must match the compiler's *actual*
+You are writing a pattern that must match the compiler's _actual_
 emitted text, which you cannot see while generating. You will guess
 wrong if you pin exact generated output. **Assert stable structure with
 loose patterns; never pin volatile detail.** The rules below each
@@ -539,33 +540,36 @@ correspond to a real, recurring failure class — follow every one.
 
 1. **Never pin a compiler-generated SSA id or mangled name.** IDs like
    SPIR-V `%29`, IR `%1234`, or names like `_S3`, `f_0`, `main_1` are
-   assigned by codegen and *vary*. Worse, the slang-test harness
+   assigned by codegen and _vary_. Worse, the slang-test harness
    disassembles SPIR-V with **friendly names** (so an operand prints as
    `%f_0`, not `%29`) in some run modes and numeric in others — a test
    that pins one form fails in the other. For any id/operand use a
    permissive capture, not a numeric one:
+
    - ✅ `%{{[A-Za-z0-9_]+}} = OpConvertFToS %int %{{[A-Za-z0-9_]+}}`
-   - ❌ `%{{[0-9]+}} = OpConvertFToS %int %{{[0-9]+}}`  (fails on `%f_0`)
-   - ❌ `%29 = OpConvertFToS %int %17`  (pins volatile ids)
-   Match the opcode/structure, not the numbering.
+   - ❌ `%{{[0-9]+}} = OpConvertFToS %int %{{[0-9]+}}` (fails on `%f_0`)
+   - ❌ `%29 = OpConvertFToS %int %17` (pins volatile ids)
+     Match the opcode/structure, not the numbering.
 
 2. **Escape FileCheck metacharacters when the emitted text contains them
-   literally.** `[[...]]` is a FileCheck *variable* reference and
-   `{{...}}` is a *regex*. Emitted Metal/HLSL attributes literally
+   literally.** `[[...]]` is a FileCheck _variable_ reference and
+   `{{...}}` is a _regex_. Emitted Metal/HLSL attributes literally
    contain double brackets (`[[unroll]]`, `[[color(0)]]`, `[[buffer(0)]]`).
    A CHECK line `// CHECK: [[unroll]]` is parsed as a variable and fails
    with `undefined variable: unroll`. Escape:
+
    - ✅ `// CHECK: {{\[\[}}unroll{{\]\]}}`
-   Likewise escape a literal `{{` as `{{\{\{}}`.
+     Likewise escape a literal `{{` as `{{\{\{}}`.
 
 3. **Avoid substring collisions.** FileCheck matches substrings, so a
    short pattern silently matches inside a longer token:
+
    - `CHECK-NOT: OpFunction` fires on `OpFunctionEnd` (present in every
      module) — use the specific token you mean, e.g. `CHECK-NOT: OpFunctionCall`.
    - unanchored `StructuredBuffer` matches inside `RWStructuredBuffer` —
      anchor the read-only spelling: `CHECK-DAG: {{^}}StructuredBuffer`.
-   Prefer the most specific token, anchor with `{{^}}`, or include enough
-   surrounding context to disambiguate.
+     Prefer the most specific token, anchor with `{{^}}`, or include enough
+     surrounding context to disambiguate.
 
 4. **Plain `CHECK`/`CHECK-DAG` order must equal emission order.** Sequential
    `CHECK` lines must appear in the order the compiler emits them. Metal
@@ -589,12 +593,12 @@ correspond to a real, recurring failure class — follow every one.
    pins the diagnostic, or record it in `## Untested claims` — **never**
    weaken the CHECK to force green.
 
-7. **`DIAGNOSTIC_TEST`: annotate the compiler's *actual* message, and use
+7. **`DIAGNOSTIC_TEST`: annotate the compiler's _actual_ message, and use
    `non-exhaustive` deliberately.** Do not invent diagnostic wording —
    most diagnostics emit a **short + long message pair** at the same caret
    span, plus secondary notes (`candidate: ...`, `argument N does not
-   match: ...`, `see declaration of ...`). Rules:
-   - Annotate the *actual* text the compiler emits (a substring is fine),
+match: ...`, `see declaration of ...`). Rules:
+   - Annotate the _actual_ text the compiler emits (a substring is fine),
      not a plausible-sounding guess. If you cannot be sure of the wording,
      assert the **error code** (`//CHECK: E39999`) which is stable.
    - Align the caret (`^`) to the reported column; a multi-caret span
@@ -1283,7 +1287,26 @@ agent_self_assessment:
 - Do **not** call `gh` or otherwise file issues yourself.
 - Do **not** attempt to minimize the repro. The operator does this
   during triage. Your `evidence.source_slang` points at the full
-  `.slang` you were writing; that is enough.
+  `.slang` you were writing; that is enough — **as long as the command
+  you record actually runs that file.**
+- If the failure came from a _scratch variant_ rather than the file you
+  are committing — a `/tmp` file, a one-off edit you did not keep —
+  then `source_slang` alone will not reproduce it, and the scratch path
+  will be gone by the time anyone triages. **Inline the exact failing
+  source in `evidence.repro_source`.** `lint` warns when a command names
+  a scratch path and no `repro_source` is given.
+
+  This is not hypothetical bookkeeping. In one triage pass over 17
+  findings, 7 could not be re-run at all for this reason, and 2 of those
+  produced convincing _false_ "already fixed" results — substituting
+  `source_slang` fed the compiler a different program, which failed for
+  an unrelated reason that looked like the bug being gone. A finding that
+  cannot be re-run cannot be filed, because nobody can confirm it still
+  happens.
+
+  Some inputs cannot ship as a test at all — a compiler crash, for
+  instance. `repro_source` is exactly for those.
+
 - Do **not** populate `evidence.minimized_repro` — that field is
   reserved for the operator.
 - Do **not** speculate about the root cause. Stick to observation:

--- a/docs/generated/tests/_meta/regenerate.md
+++ b/docs/generated/tests/_meta/regenerate.md
@@ -30,39 +30,39 @@ All commands run from the repository root.
 python3 docs/generated/tests/_meta/regenerate.py <subcommand> [args...]
 ```
 
-| Subcommand                                          | Purpose                                                                                             |
-| --------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `list`                                              | Print every bundle in the manifest                                                                  |
-| `list-stale`                                        | Classify each bundle as `missing`, `stale`, or `fresh`                                              |
-| `digest <bundle>`                                   | Compute current watched-paths and source-doc digests                                                |
-| `show <bundle>`                                     | Manifest entry + resolved source files + source doc                                                 |
-| `mark-fresh <bundle> [--commit SHA] [--model NAME]` | Record a fresh entry                                                                                |
-| `lint [<bundle>...]`                                | Structural linter (README.md front-matter, every `.slang` has a `//META` block, `doc_ref` resolves) |
-| `index [--write]`                                   | (Re)generate the suite `INDEX.md` navigation table                                                  |
-| `doc-gaps [--source-doc <path>] [--format md\|json]` | Aggregate doc-gap rows across bundles, grouped by source doc                                       |
-| `coverage-gaps <bundle> [--from <report.txt>]`      | (Phase E support) per-bundle uncovered-target rollup; bundle-level only                             |
-| `expansion-candidates [--from <report.json>]`       | (Phase E) rank bundles by under-coverage; outputs bundle keys + scores only                         |
-| `review-status / mark-reviewed / mark-remediated`   | (Phase D) two-stage review/remediation. Stubs currently.                                            |
-| `findings list [--include-filed]`                   | (Phase F) list pending compiler-bug findings                                                        |
-| `findings show <id>`                                | (Phase F) render the issue body markdown for a finding                                              |
-| `findings file <id> [--dry-run]`                    | (Phase F) `gh issue create` + set project fields; moves YAML to `findings/filed/`                   |
-| `findings dup <id> --of <issue-number>`             | (Phase F) record a finding as duplicate of an existing issue; no filing                             |
+| Subcommand                                                                               | Purpose                                                                                                                                                         |
+| ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list`                                                                                   | Print every bundle in the manifest                                                                                                                              |
+| `list-stale`                                                                             | Classify each bundle as `missing`, `stale`, or `fresh`                                                                                                          |
+| `digest <bundle>`                                                                        | Compute current watched-paths and source-doc digests                                                                                                            |
+| `show <bundle>`                                                                          | Manifest entry + resolved source files + source doc                                                                                                             |
+| `mark-fresh <bundle> [--commit SHA] [--model NAME]`                                      | Record a fresh entry                                                                                                                                            |
+| `lint [<bundle>...]`                                                                     | Structural linter (README.md front-matter, every `.slang` has a `//META` block, `doc_ref` resolves)                                                             |
+| `index [--write]`                                                                        | (Re)generate the suite `INDEX.md` navigation table                                                                                                              |
+| `doc-gaps [--source-doc <path>] [--tree design\|language-reference] [--format md\|json]` | Aggregate doc-gap rows across bundles, grouped by the document each gap is anchored to, each row carrying the `gap_id` the doc side tracks its resolution under |
+| `coverage-gaps <bundle> [--from <report.txt>]`                                           | (Phase E support) per-bundle uncovered-target rollup; bundle-level only                                                                                         |
+| `expansion-candidates [--from <report.json>]`                                            | (Phase E) rank bundles by under-coverage; outputs bundle keys + scores only                                                                                     |
+| `review-status / mark-reviewed / mark-remediated`                                        | (Phase D) two-stage review/remediation. Stubs currently.                                                                                                        |
+| `findings list [--include-filed]`                                                        | (Phase F) list pending compiler-bug findings                                                                                                                    |
+| `findings show <id>`                                                                     | (Phase F) render the issue body markdown for a finding                                                                                                          |
+| `findings file <id> [--dry-run]`                                                         | (Phase F) `gh issue create` + set project fields; moves YAML to `findings/filed/`                                                                               |
+| `findings dup <id> --of <issue-number>`                                                  | (Phase F) record a finding as duplicate of an existing issue; no filing                                                                                         |
 
 `<bundle>` is the manifest key (e.g. `pipeline/03-semantic-check`),
 which equals the bundle directory under `docs/generated/tests/`.
 
 ## Phase status
 
-| Phase | Description | Status |
-| --- | --- | --- |
-| A | Framework scaffold (driver, schemas, base prompts, manifest) | implemented |
-| B1 | Bootstrap generation across 44 behaviorally-normative bundles | implemented |
-| B1.5 / B1.6 / B1.7 / B1.8 | Boundary expansion, coverage-driven metadata refinement, catalog sweep, GPU-target expansion | implemented |
-| B2 | `slang-test` nightly job runs the suite via `-test-dir docs/generated/tests/` | implemented |
-| C | Cross-link pass — bundles consume each other's READMEs | planned |
-| D | Review + remediation against a non-Claude model | scaffolded (schemas + prompts + state file in place) |
-| E | Coverage-driven expansion loop | scaffolded (`coverage-gaps`, `expansion-candidates` stubs the data flow) |
-| F | Structured compiler-bug findings + operator-driven filing | implemented |
+| Phase                     | Description                                                                                  | Status                                                                   |
+| ------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| A                         | Framework scaffold (driver, schemas, base prompts, manifest)                                 | implemented                                                              |
+| B1                        | Bootstrap generation across 44 behaviorally-normative bundles                                | implemented                                                              |
+| B1.5 / B1.6 / B1.7 / B1.8 | Boundary expansion, coverage-driven metadata refinement, catalog sweep, GPU-target expansion | implemented                                                              |
+| B2                        | `slang-test` nightly job runs the suite via `-test-dir docs/generated/tests/`                | implemented                                                              |
+| C                         | Cross-link pass — bundles consume each other's READMEs                                       | planned                                                                  |
+| D                         | Review + remediation against a non-Claude model                                              | scaffolded (schemas + prompts + state file in place)                     |
+| E                         | Coverage-driven expansion loop                                                               | scaffolded (`coverage-gaps`, `expansion-candidates` stubs the data flow) |
+| F                         | Structured compiler-bug findings + operator-driven filing                                    | implemented                                                              |
 
 To check the suite's current state:
 

--- a/docs/generated/tests/_meta/regenerate.py
+++ b/docs/generated/tests/_meta/regenerate.py
@@ -1228,7 +1228,11 @@ def _normalize_gap_prose(text: str) -> str:
     text = re.sub(r"`([^`]*)`", r"\1", text)
     text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
     text = re.sub(r"[*_~]", "", text)
-    text = text.replace("\\|", "|")
+    # No un-escaping of `\|` here: the punctuation strip below maps both the
+    # backslash and the pipe to spaces and the final collapse erases the
+    # difference, so doing it first changes nothing. This is the identity
+    # function for `gap_id`, so it is worth keeping free of steps that only
+    # look like they matter.
     text = re.sub(r"[^\w\s]", " ", text, flags=re.UNICODE)
     return re.sub(r"\s+", " ", text).strip().lower()
 
@@ -3691,6 +3695,11 @@ def cmd_coverage_gaps(args: argparse.Namespace) -> int:
     return 0
 
 
+# The design driver's `load_gap_queue` matches on this text to tell "no gaps
+# for this document" (benign) from a real failure. Named on both sides and
+# pinned by `selftest` so a reword cannot silently break that.
+_NO_GAPS_FOR_DOC = "no gap rows are anchored to {doc!r}"
+
 _GAP_TREES = {
     "design": "docs/generated/design/",
     "language-reference": "docs/language-reference/",
@@ -3737,9 +3746,7 @@ def cmd_doc_gaps(args: argparse.Namespace) -> int:
     if args.source_doc:
         by_doc = {d: rows for d, rows in by_doc.items() if d == args.source_doc}
         if not by_doc:
-            raise SystemExit(
-                f"no gap rows are anchored to {args.source_doc!r}"
-            )
+            raise SystemExit(_NO_GAPS_FOR_DOC.format(doc=args.source_doc))
 
     merged_by_doc = {
         doc: _merge_gap_rows(rows) for doc, rows in sorted(by_doc.items())
@@ -3785,7 +3792,10 @@ def _merge_gap_rows(rows: list[GapRow]) -> list[dict]:
     since each reporter saw the gap from its own test and the proposals
     are usually complementary rather than redundant.
 
-    Sorted by anchor then kind, so the output reads in document order.
+    Sorted by the raw Anchor-cell text then kind. That is *not* document
+    order -- the cell is a markdown link, so this is lexicographic on the
+    link text -- but it is stable and groups rows sharing an anchor, which
+    is what a reader working through one document's gaps wants.
     """
     merged: dict[str, dict] = {}
     for r in rows:
@@ -4302,6 +4312,47 @@ def cmd_selftest(args: argparse.Namespace) -> int:
         "gap merge keeps both suggestions",
         dup[0]["suggested_addition"] if dup else "",
         "Add the rule. // Add an example too.",
+    )
+
+    # `--tree` routing: two production callers depend on this prefix split
+    # (the workflow passes `language-reference`, the design driver always
+    # passes `design`), and a mis-partition would silently send a page's
+    # gaps to the wrong queue.
+    check(
+        "tree prefixes are the two doc trees",
+        sorted(_GAP_TREES),
+        ["design", "language-reference"],
+    )
+    check(
+        "design tree prefix",
+        _GAP_TREES["design"],
+        "docs/generated/design/",
+    )
+    check(
+        "language-reference tree prefix",
+        _GAP_TREES["language-reference"],
+        "docs/language-reference/",
+    )
+    _rows = {
+        "docs/generated/design/a.md": [1],
+        "docs/language-reference/b.md": [1],
+        "coverage/orphan (no source doc)": [1],
+    }
+    for tree, want in (("design", 1), ("language-reference", 1)):
+        pref = _GAP_TREES[tree]
+        check(
+            f"--tree {tree} partitions by prefix",
+            len({d: r for d, r in _rows.items() if d.startswith(pref)}),
+            want,
+        )
+
+    # The design driver recognizes "this document has no gaps" by matching
+    # this exact substring on our stderr. Pin it here so a reword fails
+    # loudly rather than making every gap-status run raise.
+    check(
+        "cross-driver no-gaps message is stable",
+        "no gap rows are anchored to" in _NO_GAPS_FOR_DOC,
+        True,
     )
 
     # The catalog snapshot parser and the digest rule it feeds. The committed

--- a/docs/generated/tests/_meta/regenerate.py
+++ b/docs/generated/tests/_meta/regenerate.py
@@ -1170,9 +1170,98 @@ class GapRow:
     suggested_addition: str
     bundle: str  # bundle key that reported this row
     source_doc: str  # bundle's source_doc, for aggregation
+    # Workspace-relative path of the document the Anchor cell points at, or
+    # "" when the cell carries no resolvable link. This -- not the reporting
+    # bundle's `source_doc` -- is the document a gap is a gap *in*, and it is
+    # what `doc-gaps` groups by. See `_resolve_gap_target`.
+    anchor_target: str = ""
+    # Stable identity of this gap, for the consuming ledger. See
+    # `compute_gap_id`.
+    gap_id: str = ""
 
 
 _GAP_ANCHOR_FRAG_RE = re.compile(r"(#[A-Za-z0-9][A-Za-z0-9_-]*)")
+_GAP_ANCHOR_LINK_RE = re.compile(r"\[[^\]]*\]\((?P<url>[^)\s]+)(?:\s+\"[^\"]*\")?\)")
+
+
+def _resolve_gap_target(bundle_dir: str, anchor_cell: str) -> str:
+    """Return the workspace-relative document an Anchor cell points at.
+
+    A gap is reported by a test bundle but is a defect *in a document*, and
+    the two are not the same thing: a `coverage/` bundle has no `source_doc`
+    at all, yet every gap it reports names a design page in its Anchor cell.
+    Grouping such a row under the bundle leaves it unaddressable by the doc
+    that has to fix it, so the link target is resolved here instead.
+
+    The cell reads `[#some-heading](../../../design/pipeline/06-emit.md#some-heading)`;
+    the link is relative to the bundle directory, so it is resolved against
+    that and made repo-relative. Returns "" if the cell has no link, links
+    to a bare fragment, or points outside the repository -- all of which
+    `lint_bundle` reports, because a row that names no document cannot be
+    routed to one.
+    """
+    m = _GAP_ANCHOR_LINK_RE.search(anchor_cell)
+    if not m:
+        return ""
+    path, _, _frag = m.group("url").partition("#")
+    if not path:
+        return ""
+    try:
+        target = (REPO_ROOT / bundle_dir / unquote(path)).resolve()
+        return str(target.relative_to(REPO_ROOT)).replace(os.sep, "/")
+    except (ValueError, OSError):
+        return ""
+
+
+def _normalize_gap_prose(text: str) -> str:
+    """Reduce a gap's prose to the form its identity is computed from.
+
+    Two agents describing the same gap, or one agent re-describing it on a
+    later regeneration, will not reproduce the sentence verbatim -- they
+    reflow it, add a code span, or repunctuate. Identity has to survive
+    that, or a gap already marked fixed comes back as a new one on the next
+    bundle regeneration, which is exactly the churn the ledger exists to
+    stop. So markup is unwrapped, punctuation is dropped, whitespace is
+    collapsed, and the result is lowercased, leaving the words alone to
+    carry the identity.
+    """
+    text = re.sub(r"`([^`]*)`", r"\1", text)
+    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
+    text = re.sub(r"[*_~]", "", text)
+    text = text.replace("\\|", "|")
+    text = re.sub(r"[^\w\s]", " ", text, flags=re.UNICODE)
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+_GAP_ID_LEN = 12
+
+
+def compute_gap_id(
+    anchor_target: str, anchor_fragment: str, kind: str, gap: str
+) -> str:
+    """Return the stable id a consumer tracks this gap's resolution under.
+
+    Gap rows live in bundle READMEs, which are rewritten wholesale every
+    time a bundle is regenerated, so a row has no natural key -- there is
+    nothing for a ledger to say "this one is fixed" about. The id supplies
+    one, derived from what makes a gap the gap it is: the document section
+    it is against, its kind, and its prose (normalized, see
+    `_normalize_gap_prose`).
+
+    Deriving the id rather than writing it into the README is deliberate:
+    every existing bundle gets an id without being regenerated, and a
+    generating agent cannot mint a colliding or malformed one.
+
+    The trade-off is that renaming the anchored heading, or rewriting the
+    gap prose to say something materially different, mints a new id and
+    retires the old one. That is the intended behaviour for a rewrite; for
+    a heading rename it means one stale ledger entry, which `gap-status`
+    reports as resolved-but-unseen rather than silently dropping.
+    """
+    payload = "\n".join(
+        [anchor_target, anchor_fragment, kind, _normalize_gap_prose(gap)]
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:_GAP_ID_LEN]
 
 
 def parse_gap_rows(text: str, bundle_key: str, source_doc: str) -> list[GapRow]:
@@ -1222,6 +1311,7 @@ def parse_gap_rows(text: str, bundle_key: str, source_doc: str) -> list[GapRow]:
         anchor_cell, kind_cell, gap_cell, suggested_cell = cells[:4]
         frag_match = _GAP_ANCHOR_FRAG_RE.search(anchor_cell)
         anchor_fragment = frag_match.group(1) if frag_match else ""
+        anchor_target = _resolve_gap_target(bundle_key, anchor_cell)
         rows.append(
             GapRow(
                 anchor=anchor_cell,
@@ -1231,6 +1321,10 @@ def parse_gap_rows(text: str, bundle_key: str, source_doc: str) -> list[GapRow]:
                 suggested_addition=suggested_cell,
                 bundle=bundle_key,
                 source_doc=source_doc,
+                anchor_target=anchor_target,
+                gap_id=compute_gap_id(
+                    anchor_target, anchor_fragment, kind_cell, gap_cell
+                ),
             )
         )
         i += 1
@@ -2036,6 +2130,23 @@ def lint_bundle(spec: BundleSpec) -> list[LintIssue]:
                         f"{spec.dir}/README.md",
                         "warning",
                         f"doc-gap row Anchor cell has no #fragment:"
+                        f" {row.anchor!r}",
+                    )
+                )
+            # An Anchor cell that names no document is the one gap defect
+            # that costs the row its whole purpose: `doc-gaps` groups by
+            # the anchored document, so a row without one is filed under
+            # the reporting bundle and never reaches a doc author. The
+            # link's *path* is checked here; `lint_markdown_links` already
+            # covers whether the path and its fragment resolve, so this
+            # does not restate that.
+            if not row.anchor_target:
+                issues.append(
+                    LintIssue(
+                        f"{spec.dir}/README.md",
+                        "error",
+                        f"doc-gap row Anchor cell has no link to a document,"
+                        f" so the gap cannot be routed to one:"
                         f" {row.anchor!r}",
                     )
                 )
@@ -3580,25 +3691,33 @@ def cmd_coverage_gaps(args: argparse.Namespace) -> int:
     return 0
 
 
+_GAP_TREES = {
+    "design": "docs/generated/design/",
+    "language-reference": "docs/language-reference/",
+}
+
+
 def cmd_doc_gaps(args: argparse.Namespace) -> int:
-    """Aggregate ## Doc gaps observed rows across bundles, grouped by source_doc.
+    """Aggregate ## Doc gaps observed rows across bundles, grouped by the
+    document each gap is against.
 
     The output is the feedback artifact the doc-regeneration workflow
     consumes: for each docs/generated/design/<doc>.md, the list of gaps
     that bundles testing against it have reported. Rows reported by
     multiple bundles against the same Anchor + Kind are merged into
     a single row with a `Reported by` cell.
+
+    Grouping follows each row's Anchor cell, not the reporting bundle's
+    `source_doc`. The two agree for a doc-anchored bundle, but a
+    `coverage/` bundle has no `source_doc` while still reporting gaps
+    against design pages; grouping those under the bundle put them
+    somewhere `--source-doc` could not reach, so they were invisible to
+    the only workflow that can act on them.
     """
     manifest = load_manifest()
     specs = list(manifest.bundles.values())
-    if args.source_doc:
-        specs = [s for s in specs if s.source_doc == args.source_doc]
-        if not specs:
-            raise SystemExit(
-                f"no bundle has source_doc={args.source_doc!r}"
-            )
 
-    # source_doc -> list[GapRow]
+    # anchor target doc -> list[GapRow]
     by_doc: dict[str, list[GapRow]] = {}
     for spec in specs:
         bdir = REPO_ROOT / spec.dir
@@ -3606,82 +3725,93 @@ def cmd_doc_gaps(args: argparse.Namespace) -> int:
         if not readme.exists():
             continue
         text = readme.read_text(encoding="utf-8")
-        rows = parse_gap_rows(text, spec.dir, spec.gap_group)
-        if rows:
-            by_doc.setdefault(spec.gap_group, []).extend(rows)
+        for row in parse_gap_rows(text, spec.dir, spec.gap_group):
+            # A row whose Anchor names no document still has to go
+            # somewhere or it would vanish from the report entirely; it
+            # falls back to the reporting bundle, and `lint` errors on it.
+            by_doc.setdefault(row.anchor_target or spec.gap_group, []).append(row)
+
+    if args.tree != "all":
+        prefix = _GAP_TREES[args.tree]
+        by_doc = {d: rows for d, rows in by_doc.items() if d.startswith(prefix)}
+    if args.source_doc:
+        by_doc = {d: rows for d, rows in by_doc.items() if d == args.source_doc}
+        if not by_doc:
+            raise SystemExit(
+                f"no gap rows are anchored to {args.source_doc!r}"
+            )
+
+    merged_by_doc = {
+        doc: _merge_gap_rows(rows) for doc, rows in sorted(by_doc.items())
+    }
 
     if args.format == "json":
         import json
 
-        payload = {
-            doc: [
-                {
-                    "anchor": r.anchor,
-                    "anchor_fragment": r.anchor_fragment,
-                    "kind": r.kind,
-                    "gap": r.gap,
-                    "suggested_addition": r.suggested_addition,
-                    "reported_by": r.bundle,
-                }
-                for r in rows
-            ]
-            for doc, rows in sorted(by_doc.items())
-        }
-        print(json.dumps(payload, indent=2))
+        print(json.dumps(merged_by_doc, indent=2))
         return 0
 
-    for doc in sorted(by_doc):
-        rows = by_doc[doc]
-        # Merge rows by (anchor_fragment, kind, gap-prose), tracking
-        # which bundles reported them.
-        merged: dict[tuple[str, str, str], dict] = {}
-        for r in rows:
-            key = (r.anchor_fragment, r.kind, r.gap)
-            slot = merged.setdefault(
-                key,
-                {
-                    "anchor": r.anchor,
-                    "kind": r.kind,
-                    "gap": r.gap,
-                    "suggested_addition": r.suggested_addition,
-                    "reported_by": [],
-                },
-            )
-            if r.bundle not in slot["reported_by"]:
-                slot["reported_by"].append(r.bundle)
-            # If multiple bundles offer Suggested-addition text,
-            # concatenate distinct contributions.
-            if (
-                r.suggested_addition
-                and r.suggested_addition != slot["suggested_addition"]
-                and r.suggested_addition not in slot["suggested_addition"]
-            ):
-                slot["suggested_addition"] = (
-                    slot["suggested_addition"] + " // " + r.suggested_addition
-                ).strip(" /")
-
+    for doc, merged in merged_by_doc.items():
+        reporters = sorted({b for m in merged for b in m["reported_by"]})
         print(f"# Gaps reported against {doc}")
         print()
-        print(f"Bundle reports: {', '.join(sorted({r.bundle for r in rows}))}")
+        print(f"Bundle reports: {', '.join(reporters)}")
         print()
         print(
-            "| Anchor | Kind | Gap | Suggested addition | Reported by |"
+            "| Gap id | Anchor | Kind | Gap | Suggested addition | Reported by |"
         )
-        print("| --- | --- | --- | --- | --- |")
-        # Sort by anchor fragment, then kind.
-        sorted_rows = sorted(
-            merged.values(), key=lambda m: (m["anchor"], m["kind"])
-        )
-        for m in sorted_rows:
+        print("| --- | --- | --- | --- | --- | --- |")
+        for m in merged:
             reported = ", ".join(m["reported_by"])
             print(
-                f"| {m['anchor']} | {m['kind']} | {m['gap']}"
+                f"| {m['gap_id']} | {m['anchor']} | {m['kind']} | {m['gap']}"
                 f" | {m['suggested_addition']} | {reported} |"
             )
         print()
-    if not by_doc:
+    if not merged_by_doc:
         print("# No doc-gap rows recorded across the selected bundles.")
     return 0
+
+
+def _merge_gap_rows(rows: list[GapRow]) -> list[dict]:
+    """Collapse one document's gap rows to one entry per distinct gap.
+
+    Sibling bundles routinely observe the same hole in a shared page --
+    three bundles anchored to the diagnostics doc all notice the same
+    missing subsection -- and the consumer wants one work item, not three.
+    Rows collapse on `gap_id`, so a re-wording that survives
+    `_normalize_gap_prose` merges too, which the old key (the raw prose)
+    did not. Distinct `Suggested addition` texts are kept and joined,
+    since each reporter saw the gap from its own test and the proposals
+    are usually complementary rather than redundant.
+
+    Sorted by anchor then kind, so the output reads in document order.
+    """
+    merged: dict[str, dict] = {}
+    for r in rows:
+        slot = merged.setdefault(
+            r.gap_id,
+            {
+                "gap_id": r.gap_id,
+                "anchor": r.anchor,
+                "anchor_fragment": r.anchor_fragment,
+                "kind": r.kind,
+                "gap": r.gap,
+                "suggested_addition": r.suggested_addition,
+                "reported_by": [],
+            },
+        )
+        if r.bundle not in slot["reported_by"]:
+            slot["reported_by"].append(r.bundle)
+        if (
+            r.suggested_addition
+            and r.suggested_addition != slot["suggested_addition"]
+            and r.suggested_addition not in slot["suggested_addition"]
+        ):
+            slot["suggested_addition"] = (
+                slot["suggested_addition"] + " // " + r.suggested_addition
+            ).strip(" /")
+    return sorted(merged.values(), key=lambda m: (m["anchor"], m["kind"]))
 
 
 def cmd_review_status(args: argparse.Namespace) -> int:
@@ -3845,11 +3975,22 @@ def _build_parser() -> argparse.ArgumentParser:
 
     p_dg = sub.add_parser(
         "doc-gaps",
-        help="aggregate ## Doc gaps observed rows across bundles, grouped by source_doc",
+        help="aggregate ## Doc gaps observed rows across bundles, grouped by"
+        " the document each gap is anchored to",
     )
     p_dg.add_argument(
         "--source-doc",
-        help="restrict to a single docs/generated/design/<...>.md path",
+        help="restrict to gaps anchored to a single document, by its"
+        " workspace-relative path",
+    )
+    p_dg.add_argument(
+        "--tree",
+        choices=("all", "design", "language-reference"),
+        default="all",
+        help="restrict to gaps against one doc tree. `design` is the queue"
+        " the doc-regeneration workflow can act on; `language-reference`"
+        " is the human-written spec, which no agent may edit, so those"
+        " gaps are a human triage queue (default: all)",
     )
     p_dg.add_argument(
         "--format",
@@ -4079,6 +4220,89 @@ def cmd_selftest(args: argparse.Namespace) -> int:
             "nope.md" in errors[0].message if errors else False,
             True,
         )
+
+    # Doc-gap identity. `doc-gaps` groups by the anchored document and the
+    # consuming ledger keys on `gap_id`, so both have to hold still across
+    # the rewording a bundle regeneration produces -- the corpus, being one
+    # snapshot, cannot show that a re-worded row keeps its id.
+    check(
+        "gap prose ignores markup and punctuation",
+        _normalize_gap_prose("The `Decl` node -- see [x](y.md) -- is *not* documented."),
+        "the decl node see x is not documented",
+    )
+    check(
+        "gap id survives rewording that normalizes away",
+        compute_gap_id("d.md", "#s", "missing-example", "The `foo` case, unstated."),
+        compute_gap_id("d.md", "#s", "missing-example", "The foo case unstated"),
+    )
+    check(
+        "gap id separates distinct kinds",
+        compute_gap_id("d.md", "#s", "missing-example", "x")
+        == compute_gap_id("d.md", "#s", "ambiguous-claim", "x"),
+        False,
+    )
+    check(
+        "gap id separates distinct target docs",
+        compute_gap_id("a.md", "#s", "missing-example", "x")
+        == compute_gap_id("b.md", "#s", "missing-example", "x"),
+        False,
+    )
+
+    # Anchor-cell routing: a coverage bundle has no `source_doc`, so the
+    # link in the cell is the only thing that says which document the gap
+    # is in. A cell with no link routes nowhere, which `lint_bundle` errors
+    # on -- the empty string is that signal, not an incidental default.
+    check(
+        "gap target resolves relative to the bundle dir",
+        _resolve_gap_target(
+            "docs/generated/tests/coverage/autodiff",
+            "[#x](../../../design/ir-reference/differentiation.md#x)",
+        ),
+        "docs/generated/design/ir-reference/differentiation.md",
+    )
+    check(
+        "gap target empty for a bare fragment",
+        _resolve_gap_target("docs/generated/tests/coverage/autodiff", "[#x](#x)"),
+        "",
+    )
+    check(
+        "gap target empty for an unlinked cell",
+        _resolve_gap_target("docs/generated/tests/coverage/autodiff", "#x"),
+        "",
+    )
+
+    # Sibling bundles reporting the same gap collapse to one work item,
+    # keeping both suggestions; the corpus has such pairs but nothing
+    # asserts the merge, and a regression would silently triple the queue.
+    def _mk_gap(bundle: str, prose: str, sugg: str) -> GapRow:
+        target = "docs/generated/design/d.md"
+        return GapRow(
+            anchor="[#s](../../../design/d.md#s)",
+            anchor_fragment="#s",
+            kind="missing-surface",
+            gap=prose,
+            suggested_addition=sugg,
+            bundle=bundle,
+            source_doc="",
+            anchor_target=target,
+            gap_id=compute_gap_id(target, "#s", "missing-surface", prose),
+        )
+
+    merged = _merge_gap_rows(
+        [
+            _mk_gap("b/one", "The rule is unstated.", "Add the rule."),
+            _mk_gap("b/two", "The rule is unstated", "Add an example too."),
+            _mk_gap("b/three", "A different hole entirely.", "Add that."),
+        ]
+    )
+    check("gap merge collapses re-worded duplicates", len(merged), 2)
+    dup = [m for m in merged if len(m["reported_by"]) > 1]
+    check("gap merge records both reporters", len(dup), 1)
+    check(
+        "gap merge keeps both suggestions",
+        dup[0]["suggested_addition"] if dup else "",
+        "Add the rule. // Add an example too.",
+    )
 
     # The catalog snapshot parser and the digest rule it feeds. The committed
     # corpus only shows entries that already agree, so the drift and

--- a/docs/generated/tests/_meta/regenerate.py
+++ b/docs/generated/tests/_meta/regenerate.py
@@ -571,6 +571,15 @@ _REQUIRED_FINDING_KEYS = (
     "provenance",
 )
 _REQUIRED_EVIDENCE_KEYS = ("command", "source_slang", "observed_summary")
+
+# A path in `evidence.command` that will not exist after the session ends. A
+# finding whose command names one of these cannot be re-run later, so it cannot
+# be confirmed still-reproducing before filing -- which is the one thing triage
+# has to do. Seventeen sigsegv findings were triaged in one pass and seven were
+# untestable for exactly this reason; two of those produced convincing false
+# "already fixed" results, because substituting the committed `source_slang`
+# silently fed slangc a different program.
+_SCRATCH_PATH_RE = re.compile(r"(?:^|[\s=])(?:/tmp/|/var/folders/)\S*|<file>|<tmp>")
 _REQUIRED_EXPECTED_KEYS = ("claim", "citation_kind", "citation")
 _REQUIRED_PROVENANCE_KEYS = ("agent_model", "source_commit", "doc_anchor")
 _SUSPECTED_KINDS = {
@@ -621,6 +630,58 @@ def load_finding(path: Path) -> dict:
     return _load_yaml(path.read_text(encoding="utf-8")) or {}
 
 
+def _lint_finding_reproducibility(where: str, ev: dict) -> list[LintIssue]:
+    """Check that a finding can still be re-run after the session that filed it.
+
+    Triage has exactly one job before filing: confirm the failure still
+    happens. That is impossible if the recorded `command` points at a
+    scratch path -- `/tmp/foo.slang`, `<file>` -- because the input is
+    gone. Substituting `evidence.source_slang` is not a fix: when the
+    failing input was a *variant* of the committed test, the substitution
+    silently compiles a different program. In one triage pass that turned
+    two live bugs into apparent "already fixed" results, which is worse
+    than having no result at all.
+
+    So: name a scratch path in the command, and the real input must be
+    inlined in `evidence.repro_source`. This is a warning rather than an
+    error because 28 of the 82 findings committed before the rule predate
+    it; the fix is a sweep, not a gate.
+    """
+    issues: list[LintIssue] = []
+    cmd = str(ev.get("command") or "")
+    scratch = _SCRATCH_PATH_RE.search(cmd)
+    has_inline = bool(str(ev.get("repro_source") or "").strip()) or bool(
+        str(ev.get("minimized_repro") or "").strip()
+    )
+    if scratch and not has_inline:
+        issues.append(
+            LintIssue(
+                where,
+                "warning",
+                f"evidence.command names a scratch path ({scratch.group(0).strip()!r})"
+                " that will not exist later, and no evidence.repro_source is"
+                " given, so this finding cannot be re-run to confirm it still"
+                " reproduces before filing",
+            )
+        )
+    src = str(ev.get("source_slang") or "")
+    if (
+        src.endswith(".slang")
+        and not src.startswith(("/tmp", "<"))
+        and not (REPO_ROOT / src).exists()
+        and not has_inline
+    ):
+        issues.append(
+            LintIssue(
+                where,
+                "warning",
+                f"evidence.source_slang {src!r} does not exist and no"
+                " evidence.repro_source is given; the finding has no runnable input",
+            )
+        )
+    return issues
+
+
 def validate_finding(path: Path, finding: dict) -> list[LintIssue]:
     """Structural validation. Mirrors finding.schema.json required fields."""
     issues: list[LintIssue] = []
@@ -660,6 +721,8 @@ def validate_finding(path: Path, finding: dict) -> list[LintIssue]:
             LintIssue(where, "error", f"title exceeds 80 chars ({len(title)})")
         )
     ev = finding.get("evidence")
+    if isinstance(ev, dict):
+        issues.extend(_lint_finding_reproducibility(where, ev))
     if isinstance(ev, dict):
         for k in _REQUIRED_EVIDENCE_KEYS:
             if k not in ev:
@@ -4312,6 +4375,46 @@ def cmd_selftest(args: argparse.Namespace) -> int:
         "gap merge keeps both suggestions",
         dup[0]["suggested_addition"] if dup else "",
         "Add the rule. // Add an example too.",
+    )
+
+    # Finding reproducibility. A finding whose command names a scratch path
+    # cannot be re-run at triage time; the committed corpus has both shapes,
+    # but only the negative cases prove the check fires.
+    def repro_warns(ev):
+        return [i.message for i in _lint_finding_reproducibility("f", ev)]
+
+    check(
+        "scratch command without inline repro warns",
+        len(repro_warns({"command": "slangc /tmp/x.slang -target hlsl"})),
+        1,
+    )
+    check(
+        "placeholder command without inline repro warns",
+        len(repro_warns({"command": "slangc <file> -target hlsl"})),
+        1,
+    )
+    check(
+        "scratch command with inline repro is accepted",
+        repro_warns({"command": "slangc /tmp/x.slang", "repro_source": "void main(){}"}),
+        [],
+    )
+    check(
+        "operator-minimized repro also satisfies it",
+        repro_warns({"command": "slangc <file>", "minimized_repro": "void main(){}"}),
+        [],
+    )
+    check(
+        "committed input with a clean command is silent",
+        repro_warns({
+            "command": "slangc docs/generated/tests/x.slang -target hlsl",
+            "source_slang": "docs/generated/tests/_meta/regenerate.py",
+        }),
+        [],
+    )
+    check(
+        "missing source_slang with no inline repro warns",
+        len(repro_warns({"command": "slangc a.slang", "source_slang": "docs/nope.slang"})),
+        1,
     )
 
     # `--tree` routing: two production callers depend on this prefix split

--- a/docs/generated/tests/_meta/schema/finding.schema.json
+++ b/docs/generated/tests/_meta/schema/finding.schema.json
@@ -16,7 +16,10 @@
   ],
   "additionalProperties": false,
   "properties": {
-    "schema_version": { "type": "integer", "const": 1 },
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
     "id": {
       "type": "string",
       "pattern": "^[a-z0-9][a-z0-9-]*$",
@@ -63,7 +66,7 @@
         },
         "source_slang": {
           "type": "string",
-          "description": "Workspace-relative path to the .slang test file the agent was writing when it noticed the failure."
+          "description": "Workspace-relative path to the .slang test file the agent was writing when it noticed the failure. If the failing input was a scratch variant rather than this file, `command` will name that scratch path -- in which case inline the real input in `repro_source`, because this path alone will not reproduce it."
         },
         "observed_summary": {
           "type": "string",
@@ -80,6 +83,10 @@
         "minimized_repro": {
           "type": "string",
           "description": "Operator-supplied minimized version of the .slang source. When set, takes precedence over reading source_slang for the issue body. Empty by default."
+        },
+        "repro_source": {
+          "type": "string",
+          "description": "The exact .slang source that triggers the failure, inlined. Required when `command` names a path that is not committed to the repository -- a /tmp scratch file, or a placeholder such as <file>. Those paths do not survive the session, so without this field the finding cannot be re-run later and cannot be confirmed still-reproducing before it is filed. Some inputs (a compiler crash, for instance) cannot ship as a test, which is exactly the case this field exists for."
         }
       }
     },
@@ -126,10 +133,14 @@
       "additionalProperties": false,
       "description": "Optional. Agent's own confidence and what it considered. Not used by triage gating; useful for operator review.",
       "properties": {
-        "confidence": { "enum": ["low", "medium", "high"] },
+        "confidence": {
+          "enum": ["low", "medium", "high"]
+        },
         "alternatives_considered": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         }
       }
     }


### PR DESCRIPTION
## Motivation

The agentic test suite under `docs/generated/tests/` records the documentation
defects it finds while running the compiler — one row per defect in each bundle
README's `## Doc gaps observed` table — and `regenerate.py doc-gaps` aggregates
them. `PIPELINE.md` and `tests/README.md` both stated that the doc-regeneration
workflow consumes those rows.

Before this change there were no references to
`docs/generated/tests`, `doc-gaps`, or "doc gap" anywhere under
`docs/generated/design/` — not in the runbook, the manifest, or any of the three
prompts — and none in any of the 51 review or 51 remediation reports.
`review-status` reported all 51 documents as `remediated`: a full review cycle
had closed on every page while discarding all 452 observations. Every occurrence
of `doc-gaps` in the repository was inside the tests tree, describing a consumer
that did not exist.

That is worth building rather than deleting the claim. The design docs are
written by *reading* compiler source, and the review stage has a second model
*re-read* the same source; the two can agree with each other and still both be
wrong about what the compiler does. The test suite is the only component that
finds out by *running* it, so these rows are the only empirical evidence in the
system — and they were the one input being thrown away.

Four things blocked consumption:

1. **24 rows were unaddressable.** `cmd_doc_gaps` grouped by `spec.gap_group`,
   which falls back to the bundle key when a bundle has no `source_doc`. The
   seven `coverage/*` bundles have none, so their rows grouped under names like
   `coverage/autodiff` despite anchoring at design pages, and
   `doc-gaps --source-doc <design-doc>` could not reach them.
2. **A gap had no identity.** Rows merged on `(anchor_fragment, kind, raw
   prose)`. Bundle READMEs are rewritten wholesale on regeneration, so the same
   gap became a new one whenever its prose was re-worded, and nothing could be
   marked done.
3. **There was no ledger.** Compare the sibling findings channel, which has
   `findings-state.json` plus a `findings file` command tracking a defect from
   observation to filed issue. Doc gaps had no equivalent.
4. **`drift-from-source` is ambiguous by construction.** These docs are
   reverse-engineered and may codify bugs, so a row saying the document
   contradicts observed behaviour can mean the document is wrong *or* the
   compiler is. Handing those to a doc-fixing agent without a triage rule
   launders compiler bugs into documented behaviour.

## Proposed solution

Build the consuming end, splitting responsibility so neither driver writes the
other's half:

- **The tests driver owns the queue.** It is derived from the bundle READMEs and
  recomputed every run, so a gap the suite stops reporting stops being work.
- **The design driver owns the decisions**, in `doc-gap-state.json`, where the
  absence of an entry means the gap is open.

That split is the principled one because the queue is a *derived* fact about the
test suite while a decision is *new* information from the doc side. Persisting
the queue would create a second source of truth able to disagree with the
READMEs; recording decisions in the tests tree would make the suite responsible
for state it cannot compute.

Gaps are then worked by an agent stage mirroring the existing review/remediation
shape — identity gate, schema'd report, bookkeeping command, lint — because the
judgement each gap needs (is this real, is it this page's problem, is it actually
a compiler bug) is the kind remediation already delegates.

## Change summary

| File | What it does |
| --- | --- |
| `tests/_meta/regenerate.py` | Group `doc-gaps` by anchored document; derive a stable `gap_id`; merge on it in both formats; add `--tree`; lint unroutable rows; require findings to stay reproducible; selftests |
| `design/_meta/regenerate.py` | The ledger, `gap-status`, `mark-gap`, `mark-gap-intake`, `selftest`, three validators |
| `design/_meta/doc-gap-state.json` | The decision ledger (empty here; populated by the intake PR) |
| `design/_meta/schema/doc-gap-state.schema.json` | Ledger contract |
| `design/_meta/schema/gap-intake-report.schema.json` | Intake report front-matter contract |
| `design/_meta/prompts/_gap-intake.md` | The agent stage |
| `.github/workflows/check-doc-gaps.yml` | Hard-gates lint + both selftests; posts the queue as advisory |
| `design/_meta/regenerate.md` | New "Doc gaps from the test suite" section — the tree previously had no mention of this channel |
| `tests/_meta/{PIPELINE.md,regenerate.md,README.md}`, `prompts/_common.md`, `schema/finding.schema.json` | Corrected to describe the consumer that now exists; finding reproducibility contract |

## Concepts and vocabulary

- **Doc gap** — a row in a bundle README's `## Doc gaps observed` table: a place
  where a test showed the anchored document wrong, incomplete, or ambiguous in a
  way that is *not* a compiler bug. A suspected compiler bug goes to
  `_meta/findings/` instead; the two channels stay separate on purpose.
- **`gap_id`** — 12 hex digits, `sha256(anchored document ‖ heading fragment ‖
  kind ‖ normalized prose)`. Derived, not stored in the README, so every existing
  bundle gets one without regeneration and a generating agent cannot mint a
  colliding or malformed id.
- **`source_doc_digest`** — the per-bundle digest of the document a bundle's
  claims came from. Fixing a gap edits the document, so this drifts and
  `list-stale` flags the bundle; regenerating it re-tests against the improved
  text. That is how the loop closes.

## Process report

**Grouping by anchor target, not `source_doc`.** The input shape was wrong, not
merely awkward: a gap is a defect *in a document*, and the reporting bundle is
only how it was noticed. `_resolve_gap_target` resolves the Anchor cell's link
relative to the bundle directory. All 452 committed rows resolve (417 to design
pages, 35 to the language reference), so the regrouping loses nothing and
recovers the 24 that were unreachable.

**Why `gap_id` includes normalized prose.** Identity must survive a bundle
regeneration re-wording the row, or a gap already marked fixed reappears as new
and the ledger never converges. Selftests pin both directions — a re-worded row
keeps its id; rows differing only in kind or target document do not collide.

**Reopen detection.** `gap-status` could say a gap was recorded fixed but not
whether the fix worked. The trap is that a fixed gap legitimately stays in the
queue until its bundle is regenerated, so "still reported" alone means nothing.
A `fixed` gap is now classified by comparing the reporting bundle's recorded
`source_doc_digest` against the document's current sha256: `awaiting-regen` (not
retested yet), `reopened` (**the fix did not take**), or `unverifiable` (no
doc-anchored reporter, so a `coverage/` bundle can never confirm it). Only
`fixed` is checked — a `deferred` gap is *expected* to keep being reported, and
flagging it would make the report cry wolf.

**`escalated-to-finding` requires a real finding.** `mark-gap-intake` rejects a
report whose escalation rows cite no existing `findings/<id>.yaml`, because
otherwise the trail from "the docs declined to document this" to "someone is
fixing the compiler" breaks exactly where a compiler bug would be silently
dropped by both channels.

**Review round.** Two defects in the code as first pushed, both found by review
and both real: `_finding_ref` enforced its existence guarantee only on the
bare-id branch, so `findings/typo.yaml` passed the escalation gate; and
`_normalize_gap_prose` carried a `.replace("\|", "|")` that provably does
nothing, sitting in the function that defines `gap_id`. Both fixed. The larger
gap was coverage: the design driver shipped its whole consumer side with no
self-check, and CI could not reach any of it — the committed ledger is
`{"gaps": {}}` and no intake report is committed, so `lint` only ever walked the
happy path. There is now a `selftest` covering every malformed-ledger shape, all
three fixed-gap verdicts, and the finding resolver, wired in as a hard gate and
mutation-checked (inverting any of those checks makes it fail).

**Finding reproducibility.** Triaging 17 findings against this machinery showed
a hole in the *findings* schema: a `command` naming a `/tmp` scratch path cannot
be re-run later, so the failure cannot be confirmed before filing. Substituting
`source_slang` is worse than nothing — when the failing input was a variant of
the committed test, it compiles a different program, which turned two live bugs
into apparent "already fixed" results. `evidence.repro_source` now exists for
inputs that cannot ship as a test, and `lint` warns on the unreproducible shape
(36 of 82 committed findings, including both that produced the false verdicts).
Warning rather than error, because those 36 predate the rule and `lint` is a hard
gate — the fix is a sweep, not a block.

**Verification.** Both drivers lint clean; both selftests pass; every lint branch
of the new validators was exercised against fixtures.
