### PR TITLE
ci-analytics: add PR link column to pending approvals table

### DIFF
--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -338,6 +338,8 @@ def fetch_pending_approvals(repo):
             )
         except ValueError:
             waited_min = 0
+        prs = run.get("pull_requests") or []
+        pr_number = prs[0].get("number") if prs else None
         pending.append(
             {
                 "run_id": run.get("id"),
@@ -347,6 +349,7 @@ def fetch_pending_approvals(repo):
                 "branch": run.get("head_branch", ""),
                 "title": run.get("display_title", ""),
                 "waited_min": waited_min,
+                "pr_number": pr_number,
             }
         )
     pending.sort(key=lambda p: p["waited_min"], reverse=True)
@@ -1235,7 +1238,7 @@ def render_pending_approvals(data):
 
     html += """
 <table>
-  <tr><th>Waiting</th><th>Run</th><th>Actor</th><th>Trigger</th><th>Branch</th></tr>
+  <tr><th>Waiting</th><th>Run</th><th>PR</th><th>Actor</th><th>Trigger</th><th>Branch</th></tr>
 """
     for p in pending:
         # A merge-queue run holds up the whole queue, not just its own PR.
@@ -1243,10 +1246,13 @@ def render_pending_approvals(data):
         event_cell = (
             f"<strong>{_esc(event)}</strong>" if event == "merge_group" else _esc(event)
         )
+        pr_number = p.get("pr_number")
+        pr_cell = _link(f"https://github.com/shader-slang/slang/pull/{pr_number}", f"#{pr_number}") if pr_number else ""
         html += (
             "  <tr>"
             f"<td>{p['waited_min']} min</td>"
             f"<td>{_link(p['url'], p['title'] or str(p['run_id']))}</td>"
+            f"<td>{pr_cell}</td>"
             f"<td>{_esc(p['actor'])}</td>"
             f"<td>{event_cell}</td>"
             f"<td>{_esc(p['branch'])}</td>"
@@ -1363,6 +1369,7 @@ PENDING_APPROVALS_JS = """
       var now = Date.now();
       var pending = runs.map(function (r) {
         var waited = Math.floor((now - new Date(r.created_at).getTime()) / 60000);
+        var prs = r.pull_requests || [];
         return {
           run_id: r.id,
           url: r.html_url,
@@ -1371,6 +1378,7 @@ PENDING_APPROVALS_JS = """
           branch: r.head_branch || "",
           title: r.display_title || String(r.id),
           waited: waited,
+          pr_number: prs.length ? prs[0].number : null,
         };
       }).sort(function (a, b) { return b.waited - a.waited; });
 
@@ -1396,13 +1404,17 @@ PENDING_APPROVALS_JS = """
         label + '</span><strong style="margin-left:8px">' + esc(summary) + '</strong></div>';
 
       if (pending.length) {
-        html += '<table><tr><th>Waiting</th><th>Run</th><th>Actor</th><th>Trigger</th><th>Branch</th></tr>';
+        html += '<table><tr><th>Waiting</th><th>Run</th><th>PR</th><th>Actor</th><th>Trigger</th><th>Branch</th></tr>';
         pending.forEach(function (p) {
           var event = p.event === "merge_group"
             ? "<strong>merge_group</strong>" : esc(p.event);
+          var pr = p.pr_number
+            ? '<a href="https://github.com/shader-slang/slang/pull/' + p.pr_number + '">#' + p.pr_number + '</a>'
+            : '';
           html += '<tr>' +
             '<td>' + p.waited + ' min</td>' +
             '<td><a href="' + esc(p.url) + '">' + esc(p.title) + '</a></td>' +
+            '<td>' + pr + '</td>' +
             '<td>' + esc(p.actor) + '</td>' +
             '<td>' + event + '</td>' +
             '<td>' + esc(p.branch) + '</td>' +

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -612,6 +612,7 @@ class TestPendingApprovals(unittest.TestCase):
             "branch": "topic",
             "title": "Some PR",
             "waited_min": 5,
+            "pr_number": None,
         }
         row.update(kw)
         return row
@@ -651,6 +652,16 @@ class TestPendingApprovals(unittest.TestCase):
         # A merge_group run holds up the whole queue, not just its own PR.
         html = self._render([self._row(event="merge_group")])
         self.assertIn("<strong>merge_group</strong>", html)
+
+    def test_pr_number_renders_as_link(self):
+        html = self._render([self._row(pr_number=12345)])
+        self.assertIn("/pull/12345", html)
+        self.assertIn("#12345", html)
+
+    def test_no_pr_number_renders_empty_cell(self):
+        html = self._render([self._row(pr_number=None)])
+        # Empty PR cell — no pull URL in the table
+        self.assertNotIn("/pull/", html)
 
     def test_titles_are_escaped_exactly_once(self):
         # _link already escapes, so escaping the title before passing it in
@@ -717,6 +728,18 @@ class TestPendingApprovals(unittest.TestCase):
             data = ci_health.fetch_pending_approvals("shader-slang/slang")
 
         self.assertEqual(data["pending"][0]["waited_min"], 0)
+
+    def test_pr_number_extracted_from_pull_requests(self):
+        run = {"id": 1, "created_at": "2026-08-11T00:00:00Z", "pull_requests": [{"number": 999}]}
+        with mock.patch.object(gh_api, "gh_api_list", side_effect=lambda e, k: ([run], None)):
+            data = ci_health.fetch_pending_approvals("shader-slang/slang")
+        self.assertEqual(data["pending"][0]["pr_number"], 999)
+
+    def test_pr_number_is_none_when_no_pull_requests(self):
+        run = {"id": 1, "created_at": "2026-08-11T00:00:00Z", "pull_requests": []}
+        with mock.patch.object(gh_api, "gh_api_list", side_effect=lambda e, k: ([run], None)):
+            data = ci_health.fetch_pending_approvals("shader-slang/slang")
+        self.assertIsNone(data["pending"][0]["pr_number"])
 
 class TestHealthApiBounds(unittest.TestCase):
     def test_recent_failures_query_is_bounded_by_created_range(self):


### PR DESCRIPTION
Each waiting run now shows a direct link to the PR's code changes alongside the run link, making it easier for approvers to review what they're approving without navigating separately.

The PR number is extracted from the `pull_requests` field in the GitHub API response, which is populated for both `pull_request` and `workflow_dispatch` events when there is an associated PR. Runs with no associated PR show an empty cell.

Both the Python renderer (`render_pending_approvals`) and the client-side JS widget are updated to match. 4 new tests.