### PR TITLE
Lay out a modified type as the type it modifies

### DIFF
--- a/docs/generated/tests/_meta/expected-failures.txt
+++ b/docs/generated/tests/_meta/expected-failures.txt
@@ -140,13 +140,6 @@ docs/generated/tests/design/ast-reference/statements/switchstmt-case-decl-used-i
 # after human triage.)
 docs/generated/tests/design/cross-cutting/core-module/core-int8-min-return-boundary.slang
 
-# Pending: docs/generated/tests/_meta/findings/ir-types-unorm-snorm-struct-field-sigsegv.yaml
-# A struct with a `unorm float` / `snorm float` field used as a module-scope
-# `uniform` segfaults slangc (exit 139) on every target tried (hlsl, glsl,
-# spirv-asm, metal, cpp), with and without `-dump-ir`. (Will become a
-# tracking issue after human triage.)
-docs/generated/tests/design/ir-reference/types/attributed-type-unorm-snorm.slang
-
 # Pending: docs/generated/tests/_meta/findings/metal-append-buffer-params-missing-binding-slot.yaml
 # On `-target metal` the element and counter pointers that
 # `lowerAppendConsumeStructuredBuffers` synthesizes for an
@@ -155,15 +148,6 @@ docs/generated/tests/design/ir-reference/types/attributed-type-unorm-snorm.slang
 # beside them gets `[[buffer(3)]]`. MSL requires an attribute on every
 # kernel argument. (Will become a tracking issue after human triage.)
 docs/generated/tests/design/target-pipelines/metal/append-buffer-params-carry-buffer-slots.slang
-
-# Pending: docs/generated/tests/_meta/findings/metadata-unorm-structured-buffer-element-sigsegv.yaml
-# `RWStructuredBuffer<unorm float>` (and the `snorm` spelling) segfaults
-# slangc (exit 139) on `-target hlsl` and `-target spirv-asm`, with and
-# without `-dump-ir`, while the same modifier on `RWTexture2D<unorm float4>`
-# compiles and emits the attribute. Probably the same root cause as
-# ir-types-unorm-snorm-struct-field-sigsegv. (Will become a tracking issue
-# after human triage.)
-docs/generated/tests/design/ir-reference/metadata/unorm-attr-on-structured-buffer-element.slang
 
 # Pending: docs/generated/tests/_meta/findings/declarations-refaccessor-metal-unknown-addressspace-abort.yaml
 # Pending: docs/generated/tests/_meta/findings/declarations-refaccessor-spirv-invalid-funcall-return-type.yaml

--- a/source/slang/slang-ir-layout.cpp
+++ b/source/slang/slang-ir-layout.cpp
@@ -484,16 +484,18 @@ Result IRTypeLayoutRules::calcSizeAndAlignment(
     case kIROp_AttributedType:
         {
             auto attributedType = cast<IRAttributedType>(type);
-            // Every attribute that can wrap a type is layout-neutral: `no_diff`
+            // The attributes that wrap a type are all layout-neutral: `no_diff`
             // records differentiability, `unorm` / `snorm` record how a texel is
-            // interpreted. None of them change size or alignment, so we measure
-            // the base type. Assert the set rather than trusting it, so a future
+            // interpreted, and `non_uniform` records that an index is not
+            // wave-uniform. None of them change size or alignment, so we measure
+            // the base type. Name the set rather than trusting it, so a future
             // attribute that *does* affect layout has to come here first.
             switch (attributedType->getAttr()->getOp())
             {
             case kIROp_NoDiffAttr:
             case kIROp_UNormAttr:
             case kIROp_SNormAttr:
+            case kIROp_NonUniformAttr:
                 break;
             default:
                 SLANG_UNEXPECTED("unhandled attribute on IRAttributedType in layout");

--- a/source/slang/slang-ir-layout.cpp
+++ b/source/slang/slang-ir-layout.cpp
@@ -484,7 +484,20 @@ Result IRTypeLayoutRules::calcSizeAndAlignment(
     case kIROp_AttributedType:
         {
             auto attributedType = cast<IRAttributedType>(type);
-            SLANG_ASSERT(attributedType->getAttr()->getOp() == kIROp_NoDiffAttr);
+            // Every attribute that can wrap a type is layout-neutral: `no_diff`
+            // records differentiability, `unorm` / `snorm` record how a texel is
+            // interpreted. None of them change size or alignment, so we measure
+            // the base type. Assert the set rather than trusting it, so a future
+            // attribute that *does* affect layout has to come here first.
+            switch (attributedType->getAttr()->getOp())
+            {
+            case kIROp_NoDiffAttr:
+            case kIROp_UNormAttr:
+            case kIROp_SNormAttr:
+                break;
+            default:
+                SLANG_UNEXPECTED("unhandled attribute on IRAttributedType in layout");
+            }
             return getSizeAndAlignment(
                 targetReq,
                 this,

--- a/source/slang/slang-ir-layout.cpp
+++ b/source/slang/slang-ir-layout.cpp
@@ -490,15 +490,24 @@ Result IRTypeLayoutRules::calcSizeAndAlignment(
             // wave-uniform. None of them change size or alignment, so we measure
             // the base type. Name the set rather than trusting it, so a future
             // attribute that *does* affect layout has to come here first.
-            switch (attributedType->getAttr()->getOp())
+            //
+            // A single `IRAttributedType` carries a list, not one attribute:
+            // `visitModifiedType` lowers every modifier on the AST type into one
+            // `getAttributedType(base, attrs)` call, so `unorm no_diff float` is
+            // one type with two attrs. Check all of them.
+            //
+            for (auto attr : attributedType->getAllAttrs())
             {
-            case kIROp_NoDiffAttr:
-            case kIROp_UNormAttr:
-            case kIROp_SNormAttr:
-            case kIROp_NonUniformAttr:
-                break;
-            default:
-                SLANG_UNEXPECTED("unhandled attribute on IRAttributedType in layout");
+                switch (attr->getOp())
+                {
+                case kIROp_NoDiffAttr:
+                case kIROp_UNormAttr:
+                case kIROp_SNormAttr:
+                case kIROp_NonUniformAttr:
+                    break;
+                default:
+                    SLANG_UNEXPECTED("unhandled attribute on IRAttributedType in layout");
+                }
             }
             return getSizeAndAlignment(
                 targetReq,

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -6156,16 +6156,19 @@ static TypeLayoutResult _createTypeLayout(TypeLayoutContext& context, Type* type
     }
     else if (auto modifiedType = as<ModifiedType>(type))
     {
-        // We lay out a modified type as the type it modifies. `unorm` and
-        // `snorm` say how a texel is interpreted, not how storage for it is
-        // reserved, so `unorm float` lays out exactly as `float`.
+        // We lay out a modified type as the type it modifies. This relies on
+        // every type modifier being layout-neutral, which holds for all three
+        // that exist: `unorm` and `snorm` say how a texel is interpreted, and
+        // `no_diff` records differentiability. None change size, alignment or
+        // resource usage, so `unorm float` lays out exactly as `float`. The
+        // matching IR-side assumption is asserted in `slang-ir-layout.cpp`.
         //
         // Reachable for any non-texture carrier, e.g. the element type of
         // `RWStructuredBuffer<unorm float>`, which `createStructuredBufferTypeLayout`
         // recurses into. Without this case that recursion falls through to the
         // catch-all below, which is UB in a release build (issue #12535).
-        // Whether the modifier belongs there at all is issue #8870; layout has
-        // to be total over types either way.
+        // Whether the modifier belongs on such a carrier at all is issue #8870;
+        // until it is rejected earlier, layout must not fall into that sink.
         //
         return _createTypeLayout(context, modifiedType->getBase());
     }

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -6154,6 +6154,21 @@ static TypeLayoutResult _createTypeLayout(TypeLayoutContext& context, Type* type
 
         return createSimpleTypeLayout(SimpleLayoutInfo(), errorType, rules);
     }
+    else if (auto modifiedType = as<ModifiedType>(type))
+    {
+        // We lay out a modified type as the type it modifies. `unorm` and
+        // `snorm` say how a texel is interpreted, not how storage for it is
+        // reserved, so `unorm float` lays out exactly as `float`.
+        //
+        // Reachable for any non-texture carrier, e.g. the element type of
+        // `RWStructuredBuffer<unorm float>`, which `createStructuredBufferTypeLayout`
+        // recurses into. Without this case that recursion falls through to the
+        // catch-all below, which is UB in a release build (issue #12535).
+        // Whether the modifier belongs there at all is issue #8870; layout has
+        // to be total over types either way.
+        //
+        return _createTypeLayout(context, modifiedType->getBase());
+    }
     else if (auto existentialSpecializedType = as<ExistentialSpecializedType>(type))
     {
         ExpandedSpecializationArgs args;

--- a/source/slang/slang-type-layout.cpp
+++ b/source/slang/slang-type-layout.cpp
@@ -6170,6 +6170,21 @@ static TypeLayoutResult _createTypeLayout(TypeLayoutContext& context, Type* type
         // Whether the modifier belongs on such a carrier at all is issue #8870;
         // until it is rejected earlier, layout must not fall into that sink.
         //
+        // Name the layout-neutral set here too, mirroring the IR side, so a
+        // future modifier that does affect layout has to come through both.
+        // `SLANG_UNEXPECTED` and not `SLANG_ASSERT`, because the latter is a
+        // `SLANG_ASSUME` in release builds -- which is the sink this whole case
+        // exists to keep types out of.
+        //
+        for (Index i = 0; i < modifiedType->getModifierCount(); ++i)
+        {
+            auto modifier = modifiedType->getModifier(i);
+            if (!as<UNormModifierVal>(modifier) && !as<SNormModifierVal>(modifier) &&
+                !as<NoDiffModifierVal>(modifier))
+            {
+                SLANG_UNEXPECTED("unhandled type modifier in layout");
+            }
+        }
         return _createTypeLayout(context, modifiedType->getBase());
     }
     else if (auto existentialSpecializedType = as<ExistentialSpecializedType>(type))

--- a/tests/language-feature/types/modifiers/unorm-snorm-non-texture-layout.slang
+++ b/tests/language-feature/types/modifiers/unorm-snorm-non-texture-layout.slang
@@ -22,8 +22,22 @@ struct Plain
     float s;
 }
 
+// A vector carrier too: under std140 a float4 has 16-byte alignment, so this
+// catches a size/alignment mistake the scalar case would not.
+struct NormsVec
+{
+    unorm float4 v;
+}
+
+struct PlainVec
+{
+    float4 v;
+}
+
 uniform Norms n;
 uniform Plain p;
+uniform NormsVec nv;
+uniform PlainVec pv;
 
 // Both modifiers on both carriers: as a buffer element here, as a struct field
 // above.
@@ -34,7 +48,7 @@ RWStructuredBuffer<float> outputBuffer;
 [numthreads(1, 1, 1)]
 void main()
 {
-    outputBuffer[0] = n.u + n.s + p.u + p.s + unormBuf[0] + snormBuf[0];
+    outputBuffer[0] = n.u + n.s + p.u + p.s + nv.v.x + pv.v.x + unormBuf[0] + snormBuf[0];
 }
 
 // HLSL keeps the modifier in the emitted spelling, for DXC compatibility.
@@ -44,9 +58,24 @@ void main()
 // HLSL-DAG: unorm float{{.*}}u_0
 // HLSL-DAG: snorm float{{.*}}s_0
 
-// SPIR-V has no such spelling, so it shows the layout directly. Both structs
-// lower to the same member types and the same offsets, which is the property
-// this fix establishes; the buffer element is a plain float array.
+// SPIR-V has no such spelling, so it shows the layout directly. Each modified
+// struct lowers to the same member types at the same offsets as its plain twin,
+// which is the property this fix establishes.
+
+// SPIRV-DAG: %NormsVec_std140 = OpTypeStruct %v4float
+// SPIRV-DAG: %PlainVec_std140 = OpTypeStruct %v4float
+
+// The four uniform structs sit at 0/16/32/48, so `NormsVec` occupies the same
+// 16 bytes `PlainVec` does -- the alignment-sensitive half of the claim.
+
+// SPIRV-DAG: OpMemberDecorate %GlobalParams_std140 2 Offset 32
+// SPIRV-DAG: OpMemberDecorate %GlobalParams_std140 3 Offset 48
+
+// `calcSizeAndAlignment` is the IR-side half of this fix, and its result is the
+// runtime-array stride, so pin that directly rather than only the element type
+// (which comes from emit unwrapping the attribute, not from the layout code).
+
+// SPIRV-DAG: OpDecorate %_runtimearr_float ArrayStride 4
 
 // SPIRV-DAG: %Norms_std140 = OpTypeStruct %float %float
 // SPIRV-DAG: %Plain_std140 = OpTypeStruct %float %float

--- a/tests/language-feature/types/modifiers/unorm-snorm-non-texture-layout.slang
+++ b/tests/language-feature/types/modifiers/unorm-snorm-non-texture-layout.slang
@@ -25,20 +25,24 @@ struct Plain
 uniform Norms n;
 uniform Plain p;
 
-RWStructuredBuffer<unorm float> inBuf;
+// Both modifiers on both carriers: as a buffer element here, as a struct field
+// above.
+RWStructuredBuffer<unorm float> unormBuf;
+RWStructuredBuffer<snorm float> snormBuf;
 RWStructuredBuffer<float> outputBuffer;
 
 [numthreads(1, 1, 1)]
 void main()
 {
-    outputBuffer[0] = n.u + n.s + p.u + p.s + inBuf[0];
+    outputBuffer[0] = n.u + n.s + p.u + p.s + unormBuf[0] + snormBuf[0];
 }
 
 // HLSL keeps the modifier in the emitted spelling, for DXC compatibility.
 
-// HLSL: RWStructuredBuffer<unorm float
-// HLSL: unorm float{{.*}}u_0
-// HLSL: snorm float{{.*}}s_0
+// HLSL-DAG: RWStructuredBuffer<unorm float
+// HLSL-DAG: RWStructuredBuffer<snorm float
+// HLSL-DAG: unorm float{{.*}}u_0
+// HLSL-DAG: snorm float{{.*}}s_0
 
 // SPIR-V has no such spelling, so it shows the layout directly. Both structs
 // lower to the same member types and the same offsets, which is the property

--- a/tests/language-feature/types/modifiers/unorm-snorm-non-texture-layout.slang
+++ b/tests/language-feature/types/modifiers/unorm-snorm-non-texture-layout.slang
@@ -1,0 +1,41 @@
+// unorm-snorm-non-texture-layout.slang
+
+// `unorm` / `snorm` on a non-texture carrier still has to reach a type layout.
+// A structured-buffer element and a struct field both recurse into the modified
+// type, which used to fall through to the "unimplemented case in type layout"
+// catch-all and crash instead of laying out as the base type (issue #12535).
+
+//TEST:SIMPLE(filecheck=HLSL):-target hlsl -entry main -stage compute
+//TEST:SIMPLE(filecheck=SPIRV):-target spirv-asm -entry main -stage compute
+
+struct Norms
+{
+    unorm float u;
+    snorm float s;
+}
+
+uniform Norms n;
+
+RWStructuredBuffer<unorm float> inBuf;
+RWStructuredBuffer<float> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    outputBuffer[0] = n.u + n.s + inBuf[0];
+}
+
+// HLSL keeps the modifier in the emitted spelling, for DXC compatibility.
+
+// HLSL: RWStructuredBuffer<unorm float
+// HLSL: unorm float{{.*}}u_0
+// HLSL: snorm float{{.*}}s_0
+
+// SPIR-V has no such spelling, so it shows the layout directly: both fields are
+// plain floats at consecutive 4-byte offsets, i.e. exactly the layout the base
+// type would get, and the buffer element is a plain float.
+
+// SPIRV-DAG: OpMemberDecorate %Norms_std140 0 Offset 0
+// SPIRV-DAG: OpMemberDecorate %Norms_std140 1 Offset 4
+// SPIRV-DAG: %Norms_std140 = OpTypeStruct %float %float
+// SPIRV-DAG: %RWStructuredBuffer = OpTypeStruct %_runtimearr_float

--- a/tests/language-feature/types/modifiers/unorm-snorm-non-texture-layout.slang
+++ b/tests/language-feature/types/modifiers/unorm-snorm-non-texture-layout.slang
@@ -8,13 +8,22 @@
 //TEST:SIMPLE(filecheck=HLSL):-target hlsl -entry main -stage compute
 //TEST:SIMPLE(filecheck=SPIRV):-target spirv-asm -entry main -stage compute
 
+// `Norms` and `Plain` differ only in the modifiers, so laying a modified type
+// out as its base means the two must produce identical layouts.
 struct Norms
 {
     unorm float u;
     snorm float s;
 }
 
+struct Plain
+{
+    float u;
+    float s;
+}
+
 uniform Norms n;
+uniform Plain p;
 
 RWStructuredBuffer<unorm float> inBuf;
 RWStructuredBuffer<float> outputBuffer;
@@ -22,7 +31,7 @@ RWStructuredBuffer<float> outputBuffer;
 [numthreads(1, 1, 1)]
 void main()
 {
-    outputBuffer[0] = n.u + n.s + inBuf[0];
+    outputBuffer[0] = n.u + n.s + p.u + p.s + inBuf[0];
 }
 
 // HLSL keeps the modifier in the emitted spelling, for DXC compatibility.
@@ -31,11 +40,14 @@ void main()
 // HLSL: unorm float{{.*}}u_0
 // HLSL: snorm float{{.*}}s_0
 
-// SPIR-V has no such spelling, so it shows the layout directly: both fields are
-// plain floats at consecutive 4-byte offsets, i.e. exactly the layout the base
-// type would get, and the buffer element is a plain float.
+// SPIR-V has no such spelling, so it shows the layout directly. Both structs
+// lower to the same member types and the same offsets, which is the property
+// this fix establishes; the buffer element is a plain float array.
 
+// SPIRV-DAG: %Norms_std140 = OpTypeStruct %float %float
+// SPIRV-DAG: %Plain_std140 = OpTypeStruct %float %float
 // SPIRV-DAG: OpMemberDecorate %Norms_std140 0 Offset 0
 // SPIRV-DAG: OpMemberDecorate %Norms_std140 1 Offset 4
-// SPIRV-DAG: %Norms_std140 = OpTypeStruct %float %float
+// SPIRV-DAG: OpMemberDecorate %Plain_std140 0 Offset 0
+// SPIRV-DAG: OpMemberDecorate %Plain_std140 1 Offset 4
 // SPIRV-DAG: %RWStructuredBuffer = OpTypeStruct %_runtimearr_float

--- a/tests/language-feature/types/modifiers/unorm-snorm-non-texture-layout.slang
+++ b/tests/language-feature/types/modifiers/unorm-snorm-non-texture-layout.slang
@@ -10,16 +10,20 @@
 
 // `Norms` and `Plain` differ only in the modifiers, so laying a modified type
 // out as its base means the two must produce identical layouts.
+// `no_diff` is the third type modifier and takes the same path, so it belongs
+// in the same comparison rather than being assumed to work.
 struct Norms
 {
     unorm float u;
     snorm float s;
+    no_diff float d;
 }
 
 struct Plain
 {
     float u;
     float s;
+    float d;
 }
 
 // A vector carrier too: under std140 a float4 has 16-byte alignment, so this
@@ -48,10 +52,13 @@ RWStructuredBuffer<float> outputBuffer;
 [numthreads(1, 1, 1)]
 void main()
 {
-    outputBuffer[0] = n.u + n.s + p.u + p.s + nv.v.x + pv.v.x + unormBuf[0] + snormBuf[0];
+    outputBuffer[0] = n.u + n.s + n.d + p.u + p.s + p.d + nv.v.x + pv.v.x + unormBuf[0] +
+                      snormBuf[0];
 }
 
-// HLSL keeps the modifier in the emitted spelling, for DXC compatibility.
+// The HLSL half only checks that the modifier survives into the emitted
+// spelling, for DXC compatibility. The layout-equality claim is checked on the
+// SPIR-V side below, which is where layout is observable.
 
 // HLSL-DAG: RWStructuredBuffer<unorm float
 // HLSL-DAG: RWStructuredBuffer<snorm float
@@ -77,10 +84,15 @@ void main()
 
 // SPIRV-DAG: OpDecorate %_runtimearr_float ArrayStride 4
 
-// SPIRV-DAG: %Norms_std140 = OpTypeStruct %float %float
-// SPIRV-DAG: %Plain_std140 = OpTypeStruct %float %float
+// The unorm / snorm / no_diff triple lays out as three bare floats, at the same
+// offsets its unmodified twin gets.
+
+// SPIRV-DAG: %Norms_std140 = OpTypeStruct %float %float %float{{$}}
+// SPIRV-DAG: %Plain_std140 = OpTypeStruct %float %float %float{{$}}
 // SPIRV-DAG: OpMemberDecorate %Norms_std140 0 Offset 0
 // SPIRV-DAG: OpMemberDecorate %Norms_std140 1 Offset 4
+// SPIRV-DAG: OpMemberDecorate %Norms_std140 2 Offset 8
 // SPIRV-DAG: OpMemberDecorate %Plain_std140 0 Offset 0
 // SPIRV-DAG: OpMemberDecorate %Plain_std140 1 Offset 4
+// SPIRV-DAG: OpMemberDecorate %Plain_std140 2 Offset 8
 // SPIRV-DAG: %RWStructuredBuffer = OpTypeStruct %_runtimearr_float


### PR DESCRIPTION
## Summary

- Give `_createTypeLayout` a `ModifiedType` case that lays the type out as the type it modifies, so `unorm float` lays out as `float`.
- Fixes the SIGSEGV on `RWStructuredBuffer<unorm float>` and on a `unorm`/`snorm` struct field of a module-scope uniform.
- Adds a regression test pinning both carriers.

Fixes #12535.

## Motivation

`unorm float` is a `ModifiedType` wrapping the base scalar. `slang-type-layout.cpp` had no case for it, so laying one out matched nothing and fell through to the catch-all at the end of `_createTypeLayout`.

Two carriers reach that path, both through `getTypeLayoutForGlobalShaderParameter`:

```hlsl
RWStructuredBuffer<unorm float> buf;          // createStructuredBufferTypeLayout recurses into the element

struct Norms { unorm float u; snorm float s; }
uniform Norms n;                              // struct field of a module-scope uniform
```

`RWTexture2D<unorm float4>` was unaffected, because the texture path does not recurse into its element type the same way — which is why this went unnoticed.

## Technical Details

The catch-all is:

```cpp
// catch-all case in case nothing matched
SLANG_ASSERT(!"unimplemented case in type layout");
return createSimpleTypeLayout(SimpleLayoutInfo(), type, rules);
```

In a release build that assert is not a check. `slang-common.h:371` maps `SLANG_ASSERT(V)` to `SLANG_ASSUME(V)`, which is `if (!(X)) __builtin_unreachable();` on GCC (`:338`) and `__builtin_assume(...)` on Clang (`:345`). **Reaching it is undefined behavior**, so the symptom depended on the toolchain:

- Release GCC 11.4 (Linux CI) — `__builtin_unreachable()` lets the optimizer drop the fallthrough; execution runs into garbage → SIGSEGV.
- Release Clang (macOS/arm64) — the same UB happens to produce code that returns, so `slangc` exits 0.

That is the whole explanation for a crash that was deterministic in nightly CI and impossible to reproduce locally on macOS. It was found by building with `-DSLANG_ENABLE_ASAN=ON` (which also enables UBSan), where it reports on every platform:

```
source/slang/slang-type-layout.cpp:6199: runtime error: assumption is violated during execution
  #0 _createTypeLayout
  #1 createStructuredBufferTypeLayout
  #2 _createTypeLayout
  #3 createTypeLayoutWith
  #4 getTypeLayoutForGlobalShaderParameter
```

### Why delegate to the base type

`unorm`/`snorm` describe how a texel is *interpreted* when read, not how storage for it is *reserved*. Size, alignment and resource usage are those of the base type, so the layout of a modified type is the layout of its base. The neighbouring `enum` case already does exactly this shape of delegation, laying an enum out as its tag type.

The SPIR-V output in the new test shows this directly: both fields land as plain `%float` at `Offset 0` and `Offset 4`, and the buffer element is `%_runtimearr_float`. HLSL keeps the `unorm`/`snorm` spelling in its emitted source for DXC compatibility, which is unchanged by this PR.

### On the input-shape question

The methodology asks whether the shape reaching this code is correct or whether the producer should be fixed. Here the honest answer is *both are open, and this is the layer that must not fall over either way*: `_createTypeLayout` has to be total over the types it is handed, and today nothing rejects `unorm` on a non-texture carrier.

Whether it *should* be rejected is #8870, where the maintainer direction is a type-system change making `unorm float` a distinct type usable only as a texture element. That is a much larger change and would supersede this case; this PR deliberately does not prejudge it, and the comment in the code says so. Until then the choice is between a correct layout and undefined behavior.

### Follow-up worth considering separately

The catch-all itself is a latent hazard: *any* future unhandled type in `_createTypeLayout` becomes UB in release rather than a diagnosable failure, with a platform-dependent symptom. Making it a `SLANG_RELEASE_ASSERT` (or a real diagnostic) would turn this whole class into a deterministic error everywhere. Left out of this PR to keep it focused, since it changes behavior for every unhandled type rather than just this one.

## Test Plan

- [x] New test added: `tests/language-feature/types/modifiers/unorm-snorm-non-texture-layout.slang` (hlsl + spirv-asm), pinning the struct-field and structured-buffer-element carriers.
- [x] Both issue reproducers exit 0 on `-target hlsl` and `-target spirv-asm`.
- [x] Clean under UBSan: the four repro inputs report 0 runtime errors with the ASan/UBSan build, having previously reported the assumption violation on every one.
- [x] The two generated tests that were crashing nightly CI now pass: `docs/generated/tests/design/ir-reference/types/attributed-type-unorm-snorm.slang` and `.../metadata/unorm-attr-on-structured-buffer-element.slang`. They are still listed in `expected-failures.txt`; those entries should be pruned once this lands, or the both-directions gate will report them as passing-but-expected-to-fail.
- [x] Full suite: 7396/7399 (`slang-test -use-test-server -server-count 4`, macOS arm64). The 3 failures — `cpu-program/gfx-smoke`, `dispatcher/smoke`, `metal/ray-query-intrinsics` — fail identically with the change stashed, so they are pre-existing and unrelated.
- [x] `extras/formatting.sh --check-only` clean on both changed files.

Not verified locally: that the SIGSEGV is gone on Linux/GCC specifically, since this machine is macOS/arm64 and the crash never manifested here. The UBSan result is the platform-independent evidence.

## Suggested reviewers

- **@csyonghe** — set the direction on #8870 for how `unorm`/`snorm` should ultimately be handled, so best placed to say whether this stopgap is the right shape or whether layout should never see a `ModifiedType`.
- **@jkwak-work**, **@pdeayton-nv** — recent authorship in `slang-type-layout.cpp`.
