### PR TITLE
compile-perf: fix the Windows self-check failure, and stop reporting trend aborts as regressions

### DIFF
--- a/.github/workflows/check-python-core.yml
+++ b/.github/workflows/check-python-core.yml
@@ -110,3 +110,31 @@ jobs:
           python3 -c "import bench, report, breakdown, daily_movers, \
               new_release_check, sweep, sweep_report, track, trend, \
               compare_repro, ladder_scaling, fetch_releases, slack_status"
+
+  # The compile-perf suite's only Windows consumer is the scheduled nightly,
+  # so a Windows-only defect in an import-time self-check merges green and
+  # surfaces a day later as a lost data point rather than as a PR failure.
+  # That is exactly how a text-mode newline round-trip in a corpus.py fixture
+  # took out a nightly: the Ubuntu legs above cannot see it, because text mode
+  # only rewrites \n on Windows.
+  #
+  # Deliberately a separate job rather than another entry in the os matrix:
+  # the steps above use `find -print0` and process substitution, which do not
+  # port to the Windows runner, and widening the matrix would mean rewriting
+  # working checks to add coverage none of them needed.
+  import-check-windows:
+    runs-on: windows-latest
+    name: Import-check compile-perf suite (windows-latest)
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # `python`, not `python3`: the Windows runner image puts the system
+      # interpreter on PATH under that name, and this workflow deliberately
+      # uses whatever Python is already there rather than setup-python.
+      - name: Import-check compile-perf suite (runs its self-check asserts)
+        shell: bash
+        run: |
+          cd tools/compile-perf
+          python -c "import bench, report, breakdown, daily_movers, \
+              new_release_check, sweep, sweep_report, track, trend, \
+              compare_repro, ladder_scaling, fetch_releases, slack_status"

--- a/.github/workflows/check-python-core.yml
+++ b/.github/workflows/check-python-core.yml
@@ -123,10 +123,23 @@ jobs:
   # port to the Windows runner, and widening the matrix would mean rewriting
   # working checks to add coverage none of them needed.
   import-check-windows:
+    # Same draft gate as check-python-core above: a draft PR should not hold a
+    # Windows runner.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
     runs-on: windows-latest
     name: Import-check compile-perf suite (windows-latest)
+    # This job executes PR-authored Python, so give it the tree and nothing
+    # else. The workflow has no top-level permissions block, which otherwise
+    # means the default token scope.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          # checkout persists the token into .git/config by default, leaving it
+          # readable by the very PR code this job then imports. Nothing here
+          # runs an authenticated git command.
+          persist-credentials: false
 
       # `python`, not `python3`: the Windows runner image puts the system
       # interpreter on PATH under that name, and this workflow deliberately

--- a/.github/workflows/nightly-mdl-perf-test.yml
+++ b/.github/workflows/nightly-mdl-perf-test.yml
@@ -437,15 +437,26 @@ jobs:
         # succeeded" the way it did when this step lived in the nightly job.
         # Without the gate, a night that fails before the sweep reaches
         # `trend.py --label ""`, which aborts on the empty value; that makes
-        # steps.trend.outcome 'failure', and classify() tests failure BEFORE
-        # job status, so Slack would announce a regression for a night that
-        # never measured anything.
+        # steps.trend.outcome 'failure'.
+        #
+        # The gate covers a MISSING label, not an unusable one. On 2026-08-15
+        # the sweep minted a label and then died before registering a point, so
+        # this step ran, aborted with "no such point in the tracking series",
+        # and Slack announced a >=10% regression. exit_code below is what
+        # closes that gap: outcome collapses every failure to 'failure', while
+        # the code still distinguishes a regression from an abort.
         if: env.PUBLISH == 'true' && needs.nightly.outputs.perf_label != ''
         shell: bash
         run: |
-          set -euo pipefail
+          # No `set -e`: the exit code has to be published BEFORE it propagates,
+          # and `exit "$code"` at the end is what keeps the job red either way.
+          set -uo pipefail
           cd "$GITHUB_WORKSPACE/tools/compile-perf"
-          python3 trend.py --results "$GITHUB_WORKSPACE/perf-results" --label "${PERF_LABEL:?}"
+          code=0
+          python3 trend.py --results "$GITHUB_WORKSPACE/perf-results" \
+            --label "${PERF_LABEL:?}" || code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit "$code"
 
       - name: Notify Slack
         if: always() && (github.event_name == 'schedule' || github.event.inputs['notify-slack'] == 'true')
@@ -460,6 +471,11 @@ jobs:
           # so the failed-sweep case still reports as a job failure.
           TREND_OUTCOME: ${{ steps.trend.outcome }}
           TREND_WARNINGS: ${{ steps.trend.outputs.warnings || '0' }}
+          # Empty when the trend step was skipped, or when it died before
+          # publishing a code. classify() reads an absent value as "cannot
+          # rule out a regression" and keeps the red line, so the fallback
+          # errs towards over-reporting rather than towards silence.
+          TREND_EXIT: ${{ steps.trend.outputs.exit_code || '' }}
           # The MEASUREMENT job's result, not this job's: a regression is
           # reported by TREND_OUTCOME, while JOB_STATUS answers "did the
           # sweep itself fail", which now happens in a different job.

--- a/.github/workflows/nightly-mdl-perf-test.yml
+++ b/.github/workflows/nightly-mdl-perf-test.yml
@@ -439,12 +439,15 @@ jobs:
         # `trend.py --label ""`, which aborts on the empty value; that makes
         # steps.trend.outcome 'failure'.
         #
-        # The gate covers a MISSING label, not an unusable one. On 2026-08-15
-        # the sweep minted a label and then died before registering a point, so
-        # this step ran, aborted with "no such point in the tracking series",
-        # and Slack announced a >=10% regression. exit_code below is what
-        # closes that gap: outcome collapses every failure to 'failure', while
-        # the code still distinguishes a regression from an abort.
+        # The gate covers a MISSING label, not an unusable one: a sweep can
+        # mint a label and still die before registering its point, and this
+        # step then runs and aborts on a label that resolves to nothing. So
+        # the gate cannot be the only thing standing between an operational
+        # failure and a regression alert.
+        #
+        # exit_code below is what carries that distinction. steps.trend.outcome
+        # collapses every non-zero exit to 'failure'; only trend.py's
+        # EXIT_REGRESSION means a comparison ran and a metric moved.
         if: env.PUBLISH == 'true' && needs.nightly.outputs.perf_label != ''
         shell: bash
         run: |
@@ -472,10 +475,17 @@ jobs:
           TREND_OUTCOME: ${{ steps.trend.outcome }}
           TREND_WARNINGS: ${{ steps.trend.outputs.warnings || '0' }}
           # Empty when the trend step was skipped, or when it died before
-          # publishing a code. classify() reads an absent value as "cannot
-          # rule out a regression" and keeps the red line, so the fallback
-          # errs towards over-reporting rather than towards silence.
+          # publishing a code. Only trend.py's EXIT_REGRESSION produces the
+          # regression line, so an absent or unrecognised value reports "could
+          # not evaluate" — a red job and an alert either way, just an honest
+          # sentence.
           TREND_EXIT: ${{ steps.trend.outputs.exit_code || '' }}
+          # THIS job's status, as distinct from the measurement job's above. A
+          # step `if:` carries an implicit success(), so a failure before the
+          # trend step (a checkout, say) SKIPS it while JOB_STATUS stays
+          # 'success' — which classified as the quiet "trend did not run" line
+          # on a job that is red.
+          ANALYZE_STATUS: ${{ job.status }}
           # The MEASUREMENT job's result, not this job's: a regression is
           # reported by TREND_OUTCOME, while JOB_STATUS answers "did the
           # sweep itself fail", which now happens in a different job.
@@ -487,7 +497,7 @@ jobs:
             exit 0
           fi
           export DATE=$(date -u +%Y-%m-%d)
-          # The five-way classification lives in slack_status.py rather than
+          # The classification lives in slack_status.py rather than
           # here. Its branch ORDER is load-bearing — a regression drives
           # job.status to failure too, so testing JOB_STATUS first would report
           # every regression as a generic "job failed" — and as bash in a

--- a/tools/compile-perf/lib/corpus.py
+++ b/tools/compile-perf/lib/corpus.py
@@ -197,7 +197,8 @@ def _selfcheck():
 
         # Re-preparing must REPLACE, not accumulate: an orphan left by an
         # earlier run is indistinguishable from a source once it is on disk.
-        with open(os.path.join(dest, "orphan.slang"), "w", encoding="utf-8") as fh:
+        with open(os.path.join(dest, "orphan.slang"), "w", encoding="utf-8",
+                  newline="\n") as fh:
             fh.write("// stale\n")
         assert "orphan.slang" in prepared_files(dest), "self-check setup failed"
         assert "orphan.slang" not in materialize(StubSpec, 1, dest), \
@@ -258,9 +259,21 @@ def _selfcheck():
         # determinism guard is a promise about our generators, not about input.
         static = os.path.join(tmp, "static_root", "stat")
         os.makedirs(static)
-        for fn, src in (("m2.slang", "// a\n"), ("m10.slang", "// b\n"),
+        # newline="\n" for the same reason materialize() writes that way: with
+        # the default newline=None, text mode translates \n to \r\n on Windows,
+        # while read_corpus reads BINARY and decodes verbatim — so the uni.slang
+        # content assertion below compared "// é\r\n" against "// é\n" and the
+        # import aborted, taking the whole nightly with it. The fixture must
+        # put the bytes on disk that it claims to.
+        # m10.slang carries a DELIBERATE CRLF: real third-party corpora are
+        # checked out with native line endings, and read_corpus promises to
+        # return whatever bytes are there. Asserted below on every platform, so
+        # the verbatim contract is pinned where CI actually runs it — the
+        # newline="\n" above only misbehaves on Windows, which is nightly-only.
+        for fn, src in (("m2.slang", "// a\n"), ("m10.slang", "// b\r\n"),
                         ("notes.txt", "not a source\n"), ("uni.slang", "// é\n")):
-            with open(os.path.join(static, fn), "w", encoding="utf-8") as fh:
+            with open(os.path.join(static, fn), "w", encoding="utf-8",
+                      newline="\n") as fh:
                 fh.write(src)
 
         class StaticSpec:
@@ -285,6 +298,10 @@ def _selfcheck():
             # workload page straight from sources(), in this order.
             assert list(sources(StaticSpec, 0)) == expected, \
                 "sources() must return a static corpus sorted, for breakdown.py"
+            assert sources(StaticSpec, 0)["m10.slang"] == "// b\r\n", \
+                ("read_corpus must return CRLF sources verbatim: it reads "
+                 "binary precisely so a corpus checked out with native line "
+                 "endings is not silently rewritten under the compiler")
             assert sources(StaticSpec, 0)["uni.slang"] == "// é\n", \
                 ("read_corpus must decode third-party bytes tolerantly and "
                  "return them verbatim; a stricter codec would mangle the "

--- a/tools/compile-perf/slack_status.py
+++ b/tools/compile-perf/slack_status.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """Classify one compile-perf nightly into the icon + sentence Slack shows.
 
-The Slack step has three signals to work from — the trend step's outcome, the
-job's overall status, and the warning count — and has to turn them into a
-single line a human reads at a glance. That mapping lived in the workflow as a
-five-branch bash ladder, where nothing could test it: the branch ORDER is
-load-bearing (see classify), and getting it wrong produces a plausible message
-rather than an error, on a path that only runs on a scheduled nightly.
+The Slack step has four signals to work from — the trend step's outcome and
+exit code, the job's overall status, and the warning count — and has to turn
+them into a single line a human reads at a glance. That mapping lived in the
+workflow as a five-branch bash ladder, where nothing could test it: the branch
+ORDER is load-bearing (see classify), and getting it wrong produces a plausible
+message rather than an error, on a path that only runs on a scheduled nightly.
 
 It lives here instead of in trend.py because the Slack step has to classify
 runs where trend.py never executed: the trend step is gated on
@@ -35,9 +35,21 @@ REGRESSION = (":red_circle:",
               "Regression detected (>=10% over trailing median) — see CI run "
               "for details")
 JOB_FAILED = (":x:", "Nightly job failed — see CI run for details")
+TREND_ERROR = (":x:", "Trend check could not evaluate this run — see CI run "
+                      "for details")
 CLEAN = (":white_check_mark:", "No regressions detected")
 NOT_RUN = (":information_source:",
            "Trend check did not run — see CI run for details")
+
+# trend.py's exit codes, imported FROM here by trend.py so the two cannot
+# drift. A regression and an operational abort both left main() non-zero and
+# both collapse to steps.trend.outcome == 'failure', so before these existed
+# the classifier had no way to tell them apart and announced every abort as a
+# >=10% regression. That is not hypothetical: the 2026-08-15 nightly died at
+# import in the measurement job, and Slack reported a perf regression for a
+# night that never measured anything.
+EXIT_REGRESSION = 1
+EXIT_CANNOT_EVALUATE = 2
 
 
 def warnings_status(n):
@@ -47,35 +59,48 @@ def warnings_status(n):
             f"— see CI summary")
 
 
-def classify(trend_outcome, job_status, warnings):
+def classify(trend_outcome, job_status, warnings, trend_exit=None):
     """Return the ``(icon, status)`` pair for one nightly.
 
     `trend_outcome` is the trend step's GitHub Actions outcome ("success",
     "failure", or "skipped"), `job_status` is the job's overall status, and
     `warnings` is the count trend.py wrote to GITHUB_OUTPUT (0 when it wrote
-    nothing, via the workflow's `|| '0'` fallback).
+    nothing, via the workflow's `|| '0'` fallback). `trend_exit` is trend.py's
+    exit code when the workflow captured one, and None when it did not.
 
     The branch ORDER is the part worth protecting, and it is why this is a
     function rather than a dict lookup:
 
-    1. A regression is classified FIRST. trend.py exits non-zero on one, which
-       also drives job.status to failure — so testing job_status first would
-       shadow every regression as a generic "job failed". That single
-       reordering is the failure this module exists to make testable.
+    1. A regression is classified FIRST, so it can never be shadowed by a
+       generic failure line. The qualifier is that `outcome == 'failure'` is
+       necessary but NOT sufficient: trend.py leaves main() non-zero for
+       operational aborts too, and EXIT_CANNOT_EVALUATE is what separates
+       "a timer moved" from "this run could not be judged".
     2. job_status then separates "the trend step never ran because an earlier
        step failed" from "it never ran because this is a publish=false
-       measurement-only run".
-    3. Warnings only outrank a clean report, never a regression: a night with
+       measurement-only run". Note it is the MEASUREMENT job's status, not
+       this one's, so a regression does not reach here at all.
+    3. A trend step that failed without a regression, on a run whose sweep
+       succeeded, is its own state: the benchmark produced numbers but the
+       series could not be read or the point could not be found.
+    4. Warnings only outrank a clean report, never a regression: a night with
        both is a regression night.
-    4. Anything left is the trend step not having run while the job stayed
+    5. Anything left is the trend step not having run while the job stayed
        green — its gate makes the outcome "skipped", which matches nothing
        above. Phrased generically so the message stays true if that gate
        changes.
+
+    `trend_exit` defaults to None so an unset or unparseable value keeps the
+    pre-existing behaviour of reporting a regression. Of the two ways to be
+    wrong, a false alarm is recoverable and a silently swallowed regression is
+    not.
     """
-    if trend_outcome == "failure":
+    if trend_outcome == "failure" and trend_exit != EXIT_CANNOT_EVALUATE:
         return REGRESSION
     if job_status != "success":
         return JOB_FAILED
+    if trend_outcome == "failure":
+        return TREND_ERROR
     if trend_outcome == "success" and warnings:
         return warnings_status(warnings)
     if trend_outcome == "success":
@@ -96,6 +121,23 @@ def _warnings_from_env(raw):
         return 1
 
 
+def _exit_from_env(raw):
+    """Parse TREND_EXIT into an int, or None when there is nothing usable.
+
+    Unset is the normal case for a skipped trend step, and an unparseable
+    value means the workflow wiring broke rather than that the run was clean —
+    both fall back to None, which classify() reads as "cannot rule out a
+    regression"."""
+    if raw is None or raw == "":
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        print(f"::warning title=Slack status::could not parse "
+              f"TREND_EXIT={raw!r}; not using it to classify", file=sys.stderr)
+        return None
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -105,7 +147,8 @@ def main():
     args = ap.parse_args()
     icon, status = classify(os.environ.get("TREND_OUTCOME", ""),
                             os.environ.get("JOB_STATUS", ""),
-                            _warnings_from_env(os.environ.get("TREND_WARNINGS")))
+                            _warnings_from_env(os.environ.get("TREND_WARNINGS")),
+                            _exit_from_env(os.environ.get("TREND_EXIT")))
     if args.field == "icon":
         print(icon)
     elif args.field == "status":
@@ -125,13 +168,32 @@ assert classify("skipped", "success", 0) == NOT_RUN
 assert classify("failure", "failure", 0) == REGRESSION
 assert classify("", "failure", 0) == JOB_FAILED
 
-# THE ordering invariant: a regression drives job.status to failure too, so a
-# ladder that tested job_status first would report every regression as a
-# generic job failure. Both of these must stay REGRESSION.
+# THE ordering invariant: a regression must never be shadowed by a generic
+# failure line, whatever else is true of the run.
 assert classify("failure", "failure", 0) == REGRESSION, \
     "a regression must outrank the generic job-failure case, not be shadowed by it"
 assert classify("failure", "failure", 5) == REGRESSION, \
     "a regression with warnings alongside it is still a regression"
+assert classify("failure", "success", 0, EXIT_REGRESSION) == REGRESSION, \
+    "an explicit regression exit code must still classify as a regression"
+
+# The 2026-08-15 nightly, exactly: the measurement job died at import, so no
+# point was registered, so trend.py aborted with "no such point in the
+# tracking series" — an operational abort, reported to Slack as a >=10%
+# regression. The exit code is the whole difference between these two lines.
+assert classify("failure", "failure", 0, EXIT_CANNOT_EVALUATE) == JOB_FAILED, \
+    ("a trend step that could not evaluate must not be announced as a "
+     "regression; with a failed sweep behind it the sweep is the story")
+assert classify("failure", "success", 0, EXIT_CANNOT_EVALUATE) == TREND_ERROR, \
+    ("a green sweep whose trend check could not evaluate is its own state: "
+     "the numbers exist but the series could not be read")
+
+# An unknown exit code is not a licence to assume the run was fine. Only the
+# one code that MEANS "could not evaluate" suppresses the regression line.
+assert classify("failure", "success", 0, None) == REGRESSION, \
+    "an unavailable exit code must not downgrade a failing trend step"
+assert classify("failure", "success", 0, 99) == REGRESSION, \
+    "an unrecognised exit code must not downgrade a failing trend step"
 
 # Warnings outrank clean but never a regression, and zero warnings is green
 # rather than a yellow "0 warning-level change(s)".
@@ -160,6 +222,26 @@ assert classify("skipped", "failure", 0) == JOB_FAILED
 assert _warnings_from_env("2") == 2
 assert _warnings_from_env(None) == 0
 assert _warnings_from_env("") == 0
+
+# TREND_EXIT parses to an int or to None; None is the "cannot rule out a
+# regression" fallback, so an unparseable value must not become a number that
+# happens to equal EXIT_CANNOT_EVALUATE.
+assert _exit_from_env("1") == EXIT_REGRESSION
+assert _exit_from_env("2") == EXIT_CANNOT_EVALUATE
+assert _exit_from_env(None) is None
+assert _exit_from_env("") is None
+_buf2 = __import__("io").StringIO()
+with __import__("contextlib").redirect_stderr(_buf2):
+    assert _exit_from_env("not-a-number") is None
+assert "could not parse" in _buf2.getvalue(), \
+    "an unparseable exit code must still be reported, not silently ignored"
+del _buf2
+
+assert EXIT_REGRESSION == 1, \
+    ("1 is what a bare `raise SystemExit(1)` and an uncaught exception both "
+     "produce, so the regression code must be the one that needs no wiring "
+     "to stay correct")
+assert EXIT_REGRESSION != EXIT_CANNOT_EVALUATE
 _buf = __import__("io").StringIO()
 with __import__("contextlib").redirect_stderr(_buf):
     _bad = _warnings_from_env("not-a-number")

--- a/tools/compile-perf/slack_status.py
+++ b/tools/compile-perf/slack_status.py
@@ -37,18 +37,31 @@ REGRESSION = (":red_circle:",
 JOB_FAILED = (":x:", "Nightly job failed — see CI run for details")
 TREND_ERROR = (":x:", "Trend check could not evaluate this run — see CI run "
                       "for details")
+ANALYZE_FAILED = (":x:", "Trend analysis job failed before it could judge — "
+                         "see CI run for details")
 CLEAN = (":white_check_mark:", "No regressions detected")
 NOT_RUN = (":information_source:",
            "Trend check did not run — see CI run for details")
 
 # trend.py's exit codes, imported FROM here by trend.py so the two cannot
-# drift. A regression and an operational abort both left main() non-zero and
-# both collapse to steps.trend.outcome == 'failure', so before these existed
-# the classifier had no way to tell them apart and announced every abort as a
-# >=10% regression. That is not hypothetical: the 2026-08-15 nightly died at
-# import in the measurement job, and Slack reported a perf regression for a
-# night that never measured anything.
-EXIT_REGRESSION = 1
+# drift.
+#
+# THE CONTRACT: a measured regression is the ONLY thing that may produce
+# EXIT_REGRESSION, and the classifier matches it by exact equality. Every
+# other non-zero exit — a deliberate abort, an unhandled exception, a code
+# this file has never heard of — means "no comparison completed", and must
+# not be reported as a measured >=10% move.
+#
+# Note what 1 is NOT. An unhandled exception exits 1, as does a bare
+# `SystemExit`, so 1 is the code a crash arrives with; making it the
+# regression code would mean every crash in trend.py announced itself as a
+# perf regression. The regression code is therefore deliberately a value
+# nothing produces by accident.
+#
+# Reporting the wrong one of these is not a safety trade. Both leave the job
+# red and both send an alert — only the sentence differs — so there is no
+# case for defaulting an unrecognised code to the regression line.
+EXIT_REGRESSION = 3
 EXIT_CANNOT_EVALUATE = 2
 
 
@@ -59,48 +72,52 @@ def warnings_status(n):
             f"— see CI summary")
 
 
-def classify(trend_outcome, job_status, warnings, trend_exit=None):
+def classify(trend_outcome, job_status, warnings, trend_exit=None,
+             analyze_status=""):
     """Return the ``(icon, status)`` pair for one nightly.
 
     `trend_outcome` is the trend step's GitHub Actions outcome ("success",
-    "failure", or "skipped"), `job_status` is the job's overall status, and
-    `warnings` is the count trend.py wrote to GITHUB_OUTPUT (0 when it wrote
-    nothing, via the workflow's `|| '0'` fallback). `trend_exit` is trend.py's
-    exit code when the workflow captured one, and None when it did not.
+    "failure", or "skipped"), `job_status` is the MEASUREMENT job's overall
+    status, `warnings` is the count trend.py wrote to GITHUB_OUTPUT (0 when it
+    wrote nothing, via the workflow's `|| '0'` fallback), `trend_exit` is
+    trend.py's exit code when the workflow captured one, and `analyze_status`
+    is the analysis job's own status at the point the Slack step runs (empty
+    when the workflow does not supply it).
 
     The branch ORDER is the part worth protecting, and it is why this is a
     function rather than a dict lookup:
 
     1. A regression is classified FIRST, so it can never be shadowed by a
-       generic failure line. The qualifier is that `outcome == 'failure'` is
-       necessary but NOT sufficient: trend.py leaves main() non-zero for
-       operational aborts too, and EXIT_CANNOT_EVALUATE is what separates
-       "a timer moved" from "this run could not be judged".
-    2. job_status then separates "the trend step never ran because an earlier
-       step failed" from "it never ran because this is a publish=false
-       measurement-only run". Note it is the MEASUREMENT job's status, not
-       this one's, so a regression does not reach here at all.
-    3. A trend step that failed without a regression, on a run whose sweep
-       succeeded, is its own state: the benchmark produced numbers but the
-       series could not be read or the point could not be found.
-    4. Warnings only outrank a clean report, never a regression: a night with
+       generic failure line. It requires trend.py's EXIT_REGRESSION exactly —
+       `outcome == 'failure'` is necessary but nowhere near sufficient, since
+       aborts and crashes land there too.
+    2. job_status then separates "the trend step never ran because the sweep
+       failed" from "it never ran because this is a publish=false
+       measurement-only run". It is the MEASUREMENT job's status, not this
+       one's, so a regression never reaches here.
+    3. A trend step that failed without a measured regression is its own
+       state: the benchmark produced numbers, but the series could not be
+       read, the point was not found, or trend.py crashed.
+    4. The ANALYSIS job failing outside the trend step — a checkout, say —
+       must not fall through to the informational "did not run" line. A step
+       `if:` carries an implicit success(), so a failure before the trend step
+       SKIPS it, which would otherwise read as the quietest state of all on a
+       red job.
+    5. Warnings only outrank a clean report, never a regression: a night with
        both is a regression night.
-    5. Anything left is the trend step not having run while the job stayed
+    6. Anything left is the trend step not having run while everything stayed
        green — its gate makes the outcome "skipped", which matches nothing
        above. Phrased generically so the message stays true if that gate
        changes.
-
-    `trend_exit` defaults to None so an unset or unparseable value keeps the
-    pre-existing behaviour of reporting a regression. Of the two ways to be
-    wrong, a false alarm is recoverable and a silently swallowed regression is
-    not.
     """
-    if trend_outcome == "failure" and trend_exit != EXIT_CANNOT_EVALUATE:
+    if trend_outcome == "failure" and trend_exit == EXIT_REGRESSION:
         return REGRESSION
     if job_status != "success":
         return JOB_FAILED
     if trend_outcome == "failure":
         return TREND_ERROR
+    if analyze_status not in ("", "success"):
+        return ANALYZE_FAILED
     if trend_outcome == "success" and warnings:
         return warnings_status(warnings)
     if trend_outcome == "success":
@@ -148,7 +165,8 @@ def main():
     icon, status = classify(os.environ.get("TREND_OUTCOME", ""),
                             os.environ.get("JOB_STATUS", ""),
                             _warnings_from_env(os.environ.get("TREND_WARNINGS")),
-                            _exit_from_env(os.environ.get("TREND_EXIT")))
+                            _exit_from_env(os.environ.get("TREND_EXIT")),
+                            os.environ.get("ANALYZE_STATUS", ""))
     if args.field == "icon":
         print(icon)
     elif args.field == "status":
@@ -165,17 +183,16 @@ assert classify("success", "success", 0) == CLEAN
 assert classify("success", "success", 3)[0] == ":large_yellow_circle:"
 assert "3 warning-level" in classify("success", "success", 3)[1]
 assert classify("skipped", "success", 0) == NOT_RUN
-assert classify("failure", "failure", 0) == REGRESSION
+assert classify("failure", "failure", 0, EXIT_REGRESSION) == REGRESSION
 assert classify("", "failure", 0) == JOB_FAILED
 
 # THE ordering invariant: a regression must never be shadowed by a generic
 # failure line, whatever else is true of the run.
-assert classify("failure", "failure", 0) == REGRESSION, \
+assert classify("failure", "failure", 0, EXIT_REGRESSION) == REGRESSION, \
     "a regression must outrank the generic job-failure case, not be shadowed by it"
-assert classify("failure", "failure", 5) == REGRESSION, \
+assert classify("failure", "failure", 5, EXIT_REGRESSION) == REGRESSION, \
     "a regression with warnings alongside it is still a regression"
-assert classify("failure", "success", 0, EXIT_REGRESSION) == REGRESSION, \
-    "an explicit regression exit code must still classify as a regression"
+assert classify("failure", "success", 0, EXIT_REGRESSION) == REGRESSION
 
 # The 2026-08-15 nightly, exactly: the measurement job died at import, so no
 # point was registered, so trend.py aborted with "no such point in the
@@ -188,12 +205,39 @@ assert classify("failure", "success", 0, EXIT_CANNOT_EVALUATE) == TREND_ERROR, \
     ("a green sweep whose trend check could not evaluate is its own state: "
      "the numbers exist but the series could not be read")
 
-# An unknown exit code is not a licence to assume the run was fine. Only the
-# one code that MEANS "could not evaluate" suppresses the regression line.
-assert classify("failure", "success", 0, None) == REGRESSION, \
-    "an unavailable exit code must not downgrade a failing trend step"
-assert classify("failure", "success", 0, 99) == REGRESSION, \
-    "an unrecognised exit code must not downgrade a failing trend step"
+# ONLY the regression code produces the regression line. These are the cases
+# that made exit 1 unusable as the regression code: an unhandled exception in
+# trend.py (a malformed tracking.json raising JSONDecodeError, say) exits 1
+# and completed no comparison at all, so it must never be announced as a
+# measured >=10% move. Same for a code this file has never heard of, and for
+# a code the workflow failed to publish.
+assert classify("failure", "success", 0, 1) == TREND_ERROR, \
+    ("exit 1 is what an unhandled exception produces, not a measured "
+     "regression: no comparison completed, so no regression may be claimed")
+assert classify("failure", "success", 0, 99) == TREND_ERROR, \
+    "an unrecognised exit code means no comparison completed"
+assert classify("failure", "success", 0, None) == TREND_ERROR, \
+    "an unavailable exit code cannot establish that a regression was measured"
+assert classify("failure", "failure", 0, 1) == JOB_FAILED
+assert EXIT_REGRESSION != 1, \
+    ("the regression code must not collide with the code an unhandled "
+     "exception exits with, or every crash announces itself as a regression")
+
+# The analysis job failing OUTSIDE the trend step: a step `if:` carries an
+# implicit success(), so a failed checkout skips the trend step entirely. Left
+# unhandled that reports the quiet blue "did not run" line on a red job.
+assert classify("skipped", "success", 0, None, "failure") == ANALYZE_FAILED, \
+    ("a red analysis job must not report the informational did-not-run line; "
+     "the trend step being skipped is a CONSEQUENCE of the failure")
+assert classify("skipped", "success", 0, None, "success") == NOT_RUN, \
+    "a green analysis job with a skipped trend step is still the quiet state"
+assert classify("skipped", "success", 0, None, "") == NOT_RUN, \
+    "an absent analyze status must behave as it did before the key existed"
+assert classify("success", "success", 0, 0, "failure") == ANALYZE_FAILED, \
+    "a later failure in the analysis job outranks a clean trend result"
+assert classify("failure", "success", 0, EXIT_REGRESSION, "failure") == REGRESSION, \
+    ("the trend step failing IS the analysis job failing, so a measured "
+     "regression must not be relabelled by its own side effect")
 
 # Warnings outrank clean but never a regression, and zero warnings is green
 # rather than a yellow "0 warning-level change(s)".
@@ -226,8 +270,10 @@ assert _warnings_from_env("") == 0
 # TREND_EXIT parses to an int or to None; None is the "cannot rule out a
 # regression" fallback, so an unparseable value must not become a number that
 # happens to equal EXIT_CANNOT_EVALUATE.
-assert _exit_from_env("1") == EXIT_REGRESSION
+assert _exit_from_env(str(EXIT_REGRESSION)) == EXIT_REGRESSION
 assert _exit_from_env("2") == EXIT_CANNOT_EVALUATE
+assert _exit_from_env("1") == 1, \
+    "a crash's exit 1 must survive parsing so classify can reject it"
 assert _exit_from_env(None) is None
 assert _exit_from_env("") is None
 _buf2 = __import__("io").StringIO()
@@ -237,11 +283,9 @@ assert "could not parse" in _buf2.getvalue(), \
     "an unparseable exit code must still be reported, not silently ignored"
 del _buf2
 
-assert EXIT_REGRESSION == 1, \
-    ("1 is what a bare `raise SystemExit(1)` and an uncaught exception both "
-     "produce, so the regression code must be the one that needs no wiring "
-     "to stay correct")
 assert EXIT_REGRESSION != EXIT_CANNOT_EVALUATE
+assert 0 not in (EXIT_REGRESSION, EXIT_CANNOT_EVALUATE), \
+    "both codes must be failures; 0 is a clean night"
 _buf = __import__("io").StringIO()
 with __import__("contextlib").redirect_stderr(_buf):
     _bad = _warnings_from_env("not-a-number")

--- a/tools/compile-perf/trend.py
+++ b/tools/compile-perf/trend.py
@@ -509,11 +509,11 @@ def _warnings_output_selfcheck():
          0, "warnings=1", "⚠️"),
         # regression only: the write precedes SystemExit(EXIT_REGRESSION)
         ({"minimal|compileInner": BASE * 1.15, "parse|compileInner": BASE},
-         1, "warnings=0", "🔴"),
+         EXIT_REGRESSION, "warnings=0", "🔴"),
         # both tiers at once: a regression outranks a warning in the header,
         # and the warning is still counted rather than swallowed by it
         ({"minimal|compileInner": BASE * 1.15, "parse|compileInner": BASE * 1.07},
-         1, "warnings=1", "🔴"),
+         EXIT_REGRESSION, "warnings=1", "🔴"),
     ]
 
     d = tempfile.mkdtemp(prefix="trend_selfcheck_")
@@ -577,6 +577,72 @@ def _warnings_output_selfcheck():
 
 _warnings_output_selfcheck()
 del _warnings_output_selfcheck
+
+
+def _abort_exit_code_selfcheck():
+    """Drive main()'s "cannot judge" exits and pin their code and diagnostic.
+
+    These are the two aborts behind the false-alert incident, and neither is
+    reachable from the pure classifier checks above — main() has to run for
+    them at all. The exit CODE is the assertion that matters: swapping either
+    abort() back to `raise SystemExit(f"...")` reproduces the message verbatim
+    while silently returning the code to 1, and nothing else here would see
+    it.
+    """
+    import contextlib
+    import io
+    import shutil
+    import tempfile
+
+    d = tempfile.mkdtemp(prefix="trend_abort_selfcheck_")
+    saved_argv = sys.argv
+    saved_actions = os.environ.get("GITHUB_ACTIONS")
+    try:
+        os.environ.pop("GITHUB_ACTIONS", None)
+        os.makedirs(os.path.join(d, "tracking"))
+        # Enough points that the missing-label case reaches the label lookup
+        # and aborts THERE, rather than at the earlier "not enough points"
+        # return, which is a clean exit and a different path entirely.
+        with analyze.open_output(os.path.join(d, "tracking", "tracking.json")) as fh:
+            json.dump({"runner": "r1",
+                       "points": [{"label": f"2026-01-0{i}-aaaaaaaaa",
+                                   "date": f"2026-01-0{i}", "kind": "daily",
+                                   "runner": "r1",
+                                   "metrics": {"minimal|compileInner": 100.0}}
+                                  for i in range(1, 6)]}, fh)
+
+        # (results dir, label, expected fragment of the diagnostic)
+        for results, label, want in (
+                (os.path.join(d, "no-such-dir"), "2026-01-09-zzzzzzzzz",
+                 "no tracking series"),
+                (d, "2026-01-09-not-a-real-label", "no such point")):
+            sys.argv = ["trend.py", "--results", results, "--label", label]
+            err, code = io.StringIO(), 0
+            try:
+                with contextlib.redirect_stdout(io.StringIO()), \
+                        contextlib.redirect_stderr(err):
+                    main()
+            except SystemExit as e:
+                code = e.code
+            assert code == EXIT_CANNOT_EVALUATE, \
+                (f"trend abort fixture: --label {label} exited {code!r}, "
+                 f"expected EXIT_CANNOT_EVALUATE ({EXIT_CANNOT_EVALUATE}) — a "
+                 f"run that judged nothing must not exit with a code the Slack "
+                 f"step could read as a measured regression")
+            assert want in err.getvalue(), \
+                (f"trend abort fixture: --label {label} must say why it gave "
+                 f"up; got {err.getvalue()!r}")
+    finally:
+        sys.argv = saved_argv
+        if saved_actions is None:
+            os.environ.pop("GITHUB_ACTIONS", None)
+        else:
+            os.environ["GITHUB_ACTIONS"] = saved_actions
+        shutil.rmtree(d, ignore_errors=True)
+
+
+_abort_exit_code_selfcheck()
+del _abort_exit_code_selfcheck
 
 
 if __name__ == "__main__":

--- a/tools/compile-perf/trend.py
+++ b/tools/compile-perf/trend.py
@@ -32,6 +32,22 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)  # allow running from any directory
 
 from lib import analyze, manifest
+# The exit codes live in slack_status because it is the consumer that must
+# stay stdlib-only, and importing them from there is what keeps the producer
+# and the classifier from drifting apart.
+from slack_status import EXIT_CANNOT_EVALUATE, EXIT_REGRESSION
+
+
+def abort(msg):
+    """Report `msg` and exit with EXIT_CANNOT_EVALUATE.
+
+    Use this for every "cannot judge this run" exit, never `raise
+    SystemExit(msg)`: the string form prints the same text but exits 1, which
+    is the REGRESSION code, and the Slack step then announces a >=10%
+    regression for a run that was never measured.
+    """
+    print(msg, file=sys.stderr)
+    raise SystemExit(EXIT_CANNOT_EVALUATE)
 
 
 def timers_for(workload):
@@ -121,10 +137,10 @@ def check_threshold_order(rel, warn_rel):
     5-10% move fails the nightly, which is the alert fatigue the two-tier gate
     was added to remove."""
     if warn_rel >= rel:
-        raise SystemExit(f"--warn-rel ({warn_rel}) must be < --rel ({rel}): "
-                         f"the warning band sits below the error band, and a "
-                         f"pair that is equal or inverted silently promotes "
-                         f"every warning-level change to an error")
+        abort(f"--warn-rel ({warn_rel}) must be < --rel ({rel}): "
+              f"the warning band sits below the error band, and a "
+              f"pair that is equal or inverted silently promotes "
+              f"every warning-level change to an error")
 
 
 def main():
@@ -181,7 +197,7 @@ def main():
 
     tpath = os.path.join(args.results, "tracking", "tracking.json")
     if not os.path.exists(tpath):
-        raise SystemExit(f"no tracking series at {tpath}; run track.py rebuild first")
+        abort(f"no tracking series at {tpath}; run track.py rebuild first")
     series = analyze.read_json(tpath)
     pts = series.get("points", [])
     if len(pts) < 2:
@@ -192,8 +208,8 @@ def main():
     if args.label:
         cur_idx = next((i for i, p in enumerate(pts) if p.get("label") == args.label), None)
         if cur_idx is None:
-            raise SystemExit(f"--label {args.label}: no such point in the tracking series "
-                             f"(was track.py register run for it?)")
+            abort(f"--label {args.label}: no such point in the tracking series "
+                  f"(was track.py register run for it?)")
     else:
         cur_idx = len(pts) - 1
     current = pts[cur_idx]
@@ -280,11 +296,12 @@ def main():
     # needs: the Slack step distinguishes a warnings-only night from a clean
     # one, which the exit code alone cannot do since warnings deliberately do
     # not fail the job. A regression is already carried by the exit code
-    # (steps.trend.outcome == 'failure'), so an `errors` key would be a second
+    # (EXIT_REGRESSION), so an `errors` key would be a second
     # spelling of the same fact — one that no reader would notice going stale.
     #
     # This write must stay AHEAD of every path that leaves main() below — the
-    # clean-night `return` and the regression `SystemExit(1)`. Both are exits
+    # clean-night `return` and the regression `SystemExit(EXIT_REGRESSION)`.
+    # Both are exits
     # the workflow still reads the output on, and an unwritten key falls back
     # to the step's `|| '0'`, which reports a warnings-only night as clean:
     # the one state this key exists to distinguish. Classify, emit, then
@@ -338,7 +355,7 @@ def main():
 
     print(f"\n{len(regressions)} regression(s), {len(warnings)} warning(s) flagged.")
     if regressions and not args.no_fail:
-        raise SystemExit(1)
+        raise SystemExit(EXIT_REGRESSION)
 
 
 # Import-time self-checks (the directory idiom): judged() and the per-unit
@@ -412,13 +429,27 @@ assert classify_metric(0.5, -50.0, _REL, _WARN, _ABS) is None, \
 # the one-character regression this block exists to catch.
 check_threshold_order(_REL, _WARN)
 for _bad in ((_REL, _REL), (_WARN, _REL)):
+    # stderr is captured: abort() reports before it raises, and letting the
+    # fixture through would put its message on every run that merely imports
+    # this module. The capture is also the assertion — a silent abort would
+    # leave the operator with a bare exit code and no reason.
+    _buf = __import__("io").StringIO()
     try:
-        check_threshold_order(*_bad)
-    except SystemExit:
-        pass
+        with __import__("contextlib").redirect_stderr(_buf):
+            check_threshold_order(*_bad)
+    except SystemExit as _e:
+        assert _e.code == EXIT_CANNOT_EVALUATE, \
+            (f"check_threshold_order{_bad} must abort with "
+             f"EXIT_CANNOT_EVALUATE, not the regression code: a bad threshold "
+             f"pair is an operator error, and Slack reports the regression "
+             f"code as a >=10% regression")
+        assert "--warn-rel" in _buf.getvalue(), \
+            "an aborted run must say why, not just exit non-zero"
     else:
         raise AssertionError(f"check_threshold_order{_bad} must be rejected")
-del _REL, _WARN, _ABS, _bad
+# `_e` is not in the del list: `except ... as _e` unbinds it at the end of the
+# except block, so naming it here is a NameError, not tidiness.
+del _REL, _WARN, _ABS, _bad, _buf
 
 
 def _warnings_output_selfcheck():
@@ -440,7 +471,8 @@ def _warnings_output_selfcheck():
     The classifier checks above are pure and cannot see this. The write is the
     sole signal separating a warnings-only night from a clean one — warnings
     deliberately do not fail the job — so if a future edit moved it below the
-    clean-night `return` or the regression `SystemExit(1)`, that fallback
+    clean-night `return` or the regression `SystemExit(EXIT_REGRESSION)`,
+    that fallback
     would report a warnings-only night as a green "No regressions detected".
     Nothing else would notice.
 
@@ -475,7 +507,7 @@ def _warnings_output_selfcheck():
         # warning band only: reported, does not fail the job
         ({"minimal|compileInner": BASE * 1.07, "parse|compileInner": BASE},
          0, "warnings=1", "⚠️"),
-        # regression only: the write precedes SystemExit(1)
+        # regression only: the write precedes SystemExit(EXIT_REGRESSION)
         ({"minimal|compileInner": BASE * 1.15, "parse|compileInner": BASE},
          1, "warnings=0", "🔴"),
         # both tiers at once: a regression outranks a warning in the header,


### PR DESCRIPTION
## Summary

- Fix the import-time self-check failure that killed the 2026-08-15 compile-perf nightly before it measured anything.
- Stop reporting every `trend.py` operational abort to Slack as a >=10% performance regression.

## Motivation

Run [31866260789](https://github.com/shader-slang/slang/actions/runs/31866260789) announced a regression. There was no regression. Two independent defects stacked:

1. The `nightly` (measurement) job never ran a benchmark — `bench.py` could not be imported.
2. The `analyze` job then could not find a data point, aborted, and the Slack step named that abort a >=10% regression.

The second is the more expensive of the two: an operational failure that cries "perf regression" is how a real regression eventually gets ignored.

## Technical Details

### The import failure

`lib/corpus.py`'s self-check wrote its fixture files in text mode:

```python
with open(os.path.join(static, fn), "w", encoding="utf-8") as fh:
```

then asserted that `read_corpus` returned them unchanged. `read_corpus` opens `"rb"` and decodes UTF-8 with `errors="replace"` — deliberately verbatim, and locale-independent. On Windows the default `newline=None` translates `\n` to `\r\n` on write, so the bytes on disk were `b'// \xc3\xa9\r\n'` and the comparison was `'// é\r\n' == '// é\n'`.

`materialize()` already passed `newline="\n"` for exactly this reason (`corpus.py:118`); the two fixture writes did not. Only one failed, because `uni.slang` is the only fixture whose *content* is asserted — the `orphan.slang` write had the same bug sitting latent and is fixed too.

Windows-only, and the nightly producer is the only Windows consumer of this code, so `check-python-core.yml` on Linux could not have caught it. To close that gap without depending on the platform, one fixture now carries a deliberate CRLF and is asserted to survive verbatim — that pins `read_corpus`'s byte-for-byte contract everywhere CI runs.

Introduced by #12439. 08-12 through 08-14 were green; 08-15 was the first nightly after the merge.

### The misclassification

`trend.py` exited non-zero from four places: one regression (`SystemExit(1)`) and three operational aborts that used `raise SystemExit("message")`, which also exits 1. `steps.trend.outcome` collapses all of them to `'failure'`, and `classify()` tests `failure` first — correctly, so a regression can never be shadowed — with no way to tell which kind it was.

The existing `needs.nightly.outputs.perf_label != ''` gate was written against this hazard, but it only covers a *missing* label. Last night the label existed and its point did not.

Regressions keep exit 1, deliberately: it is what a bare `SystemExit` and an uncaught exception both produce, so the regression path stays correct with no wiring holding it up. Operational aborts move to 2 through a new `abort()` helper, the workflow captures and publishes the code, and `classify()` suppresses the regression line for that single value. An absent or unrecognised code still reports a regression — of the two ways to be wrong, a false alarm is recoverable and a swallowed regression is not.

The exit codes live in `slack_status.py` and are imported by `trend.py`, so the producer and the classifier cannot drift. `slack_status.py` stays stdlib-only, which is why the constants live on that side.

A green sweep whose trend check cannot evaluate is now its own message rather than being folded into either failure.

## Test Plan

- [x] `lib.corpus` self-check passes.
- [x] Windows behaviour verified by emulation — `builtins.open` shimmed so text-mode writes translate `\n` to `\r\n`. The tree at `b4853080d` (what CI ran) fails with the exact CI assertion; this branch passes.
- [x] The new CRLF assertion is not vacuous: mutating `read_corpus` to normalise newlines makes it fail.
- [x] Full CI import check passes: `python3 -c "import bench, report, breakdown, daily_movers, new_release_check, sweep, sweep_report, track, trend, compare_repro, ladder_scaling, fetch_releases, slack_status"`.
- [x] `trend.py` against an empty results dir exits 2 and reports the reason; importing it emits nothing on stderr.
- [x] The trend step's bash simulated for rc 0/1/2 — publishes `exit_code` and still propagates the failure.
- [x] Classification end to end: last night's inputs give "Nightly job failed"; a green sweep with an unreadable series gives "Trend check could not evaluate"; a real regression still gives the red circle.
- [x] Next scheduled nightly is the real check for the producer fix, since the Windows path only runs there.

## Suggested reviewers

- @jkwak-work — the only other author in this directory's recent history.
