### PR TITLE
Fix #12540: don't graft entries onto a dedup-hit witness table in cloneInst

### DIFF
--- a/source/slang/slang-ir-clone.cpp
+++ b/source/slang/slang-ir-clone.cpp
@@ -386,24 +386,14 @@ IRInst* cloneInst(IRCloneEnv* env, IRBuilder* builder, IRInst* oldInst)
     if (newInst == oldInst)
         return newInst;
 
-    // `cloneInstAndOperands` routes hoistable ops (e.g. `IRWitnessTable`) through
-    // global value numbering: if an inst with the same op/type/operands already
-    // exists, that pre-existing inst is returned instead of a fresh one. Such an
-    // inst was already fully populated by whichever earlier `cloneInst` call first
-    // created it, so grafting `oldInst`'s decorations/children onto it here would
-    // append a second, unrelated set of entries rather than merging anything
-    // meaningful. This matters for witness tables in particular: entries are not
-    // part of the dedup key (`IRInstKey::operator==` only compares op/type/
-    // operands), so a generic conformance witness specialized to a type that
-    // lowers to the same underlying representation as another, unrelated
-    // conformance (e.g. an enum's witness for an interface, specialized at its
-    // `__Tag` type, colliding with that same underlying type's own witness) can
-    // dedup onto that unrelated table. Appending the generic's entries onto it
-    // would then leave two entries for the same requirement key, and
-    // `findWitnessTableEntry`'s first-match lookup could resolve to the wrong,
-    // self-referential one. A pre-existing hoistable inst is recognized by
-    // already having decorations/children at this point, since a freshly created
-    // one is always empty until the caller populates it below.
+    // `cloneInstAndOperands` may also return a *different*, pre-existing
+    // hoistable inst via global value numbering (e.g. two witness tables with
+    // the same op/type/operands but different entries, since entries aren't
+    // part of the dedup key). That inst is already fully populated, so
+    // grafting `oldInst`'s children onto it here would add a duplicate,
+    // unrelated entry instead of merging anything. Detect this the same way:
+    // a freshly created hoistable inst is empty until populated below, so one
+    // that already has children here must be a pre-existing dedup hit.
     //
     if (getIROpInfo(newInst->getOp()).isHoistable() && newInst->getFirstDecorationOrChild())
         return newInst;

--- a/source/slang/slang-ir-clone.cpp
+++ b/source/slang/slang-ir-clone.cpp
@@ -386,6 +386,28 @@ IRInst* cloneInst(IRCloneEnv* env, IRBuilder* builder, IRInst* oldInst)
     if (newInst == oldInst)
         return newInst;
 
+    // `cloneInstAndOperands` routes hoistable ops (e.g. `IRWitnessTable`) through
+    // global value numbering: if an inst with the same op/type/operands already
+    // exists, that pre-existing inst is returned instead of a fresh one. Such an
+    // inst was already fully populated by whichever earlier `cloneInst` call first
+    // created it, so grafting `oldInst`'s decorations/children onto it here would
+    // append a second, unrelated set of entries rather than merging anything
+    // meaningful. This matters for witness tables in particular: entries are not
+    // part of the dedup key (`IRInstKey::operator==` only compares op/type/
+    // operands), so a generic conformance witness specialized to a type that
+    // lowers to the same underlying representation as another, unrelated
+    // conformance (e.g. an enum's witness for an interface, specialized at its
+    // `__Tag` type, colliding with that same underlying type's own witness) can
+    // dedup onto that unrelated table. Appending the generic's entries onto it
+    // would then leave two entries for the same requirement key, and
+    // `findWitnessTableEntry`'s first-match lookup could resolve to the wrong,
+    // self-referential one. A pre-existing hoistable inst is recognized by
+    // already having decorations/children at this point, since a freshly created
+    // one is always empty until the caller populates it below.
+    //
+    if (getIROpInfo(newInst->getOp()).isHoistable() && newInst->getFirstDecorationOrChild())
+        return newInst;
+
     cloneInstDecorationsAndChildren(env, builder->getModule(), oldInst, newInst);
 
     return newInst;

--- a/tests/language-feature/interfaces/enum-tag-forwarding-witness-dedup.slang
+++ b/tests/language-feature/interfaces/enum-tag-forwarding-witness-dedup.slang
@@ -1,0 +1,72 @@
+//TEST:COMPARE_COMPUTE(filecheck-buffer=CHECK):-output-using-type -cpu
+
+// Regression for https://github.com/shader-slang/slang/issues/12540.
+//
+// A generic extension can make every enum conform to an interface by forwarding
+// the operation to the enum's underlying `__Tag` type:
+//
+//   __generic<T : __EnumType>
+//   extension T : IValue
+//       where T.__Tag : IValue
+//   {
+//       uint getValue() { return __slang_noop_cast<T.__Tag>(this).getValue(); }
+//   }
+//
+// When this conformance is specialized at a concrete enum `T` whose `__Tag` is
+// e.g. `int`, the resulting witness table for `T : IValue` is structurally
+// identical (same op/type/operands under `IRInstKey::operator==`, which does
+// not compare table entries) to `int`'s own, unrelated `IValue` witness table.
+// Global value numbering (`_findOrEmitHoistableInst`) then deduplicates the two
+// onto a single IR node. Before the fix, `cloneInst` (slang-ir-clone.cpp) would
+// still graft the generic extension's `getValue` entry onto that pre-existing,
+// already-populated table, leaving two entries for the same requirement key;
+// `findWitnessTableEntry`'s first-match lookup could then resolve the forwarded
+// call to itself, producing a genuine IR self-call (diagnosed as `E55201:
+// recursion not allowed`, or left to corrupt codegen silently depending on the
+// call shape). Reaching the conformance only through a concrete-enum direct
+// call bypasses the generic instantiation entirely, so this only reproduces
+// through an `IValue`-typed value obtained via interface dispatch.
+
+interface IValue
+{
+    uint getValue();
+}
+
+extension int : IValue
+{
+    uint getValue()
+    {
+        return asuint(this);
+    }
+}
+
+__generic<T : __EnumType>
+extension T : IValue
+    where T.__Tag : IValue
+{
+    uint getValue()
+    {
+        return __slang_noop_cast<T.__Tag>(this).getValue();
+    }
+}
+
+enum class MyEnum : int
+{
+    value = 42,
+};
+
+uint consume(IValue value)
+{
+    return value.getValue();
+}
+
+//TEST_INPUT: ubuffer(data=[0], stride=4):out,name=outputBuffer
+RWStructuredBuffer<uint> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid: SV_DispatchThreadID)
+{
+    outputBuffer[0] = consume(MyEnum::value);
+}
+
+// CHECK: 42


### PR DESCRIPTION
## Motivation

A generic extension can make every enum conform to an interface by forwarding to its `__Tag` type:

```slang
interface IValue { uint getValue(); }
extension int : IValue { uint getValue() { return asuint(this); } }

__generic<T : __EnumType>
extension T : IValue where T.__Tag : IValue
{
    uint getValue() { return __slang_noop_cast<T.__Tag>(this).getValue(); }
}

enum class MyEnum : int { value = 42 };
void consume(IValue value) { output[0] = value.getValue(); }
void computeMain() { consume(MyEnum::value); }  // dispatch through IValue
```

A direct call compiles fine, but dispatching through `IValue` reports `E55201: recursion not allowed`, or with a different call shape, silently corrupts codegen. This is [#12540](https://github.com/shader-slang/slang/issues/12540) — the corrupted-codegen variant caused an undiagnosed Vulkan crash that broke SlangPy's nightly CI (shader-slang/slangpy#1109) for three days.

## Proposed solution

`cloneInst` (`slang-ir-clone.cpp`) clones a generic's body on specialization, then grafts the original's decorations/children onto the result — guarded only against dedup onto *itself* (`newInst == oldInst`), not dedup onto a *different* pre-existing inst.

`IRInstKey::operator==` compares only op/type/operands, not entries, so `MyEnum`'s specialized `IValue` witness (once `MyEnum` lowers to `int`) can be structurally identical to `int`'s own, unrelated `IValue` witness. Global value numbering returns that pre-existing table, and `cloneInst` grafts the generic's entry onto it anyway, leaving two entries for one requirement key — so `findWitnessTableEntry`'s first-match lookup can resolve to the wrong, self-referential entry.

Fix: skip the graft when the result already has children, since a freshly created hoistable inst is always empty until populated right after — so that signals a pre-existing dedup hit.

## Change summary

| File | Change |
| --- | --- |
| `source/slang/slang-ir-clone.cpp` | `cloneInst`: skip cloning decorations/children onto a hoistable inst that already has them. |
| `tests/language-feature/interfaces/enum-tag-forwarding-witness-dedup.slang` | Regression test (CPU); fails with `E99997: circularity during codegen` without the fix. |

## Concepts and vocabulary

- **Hoistable instruction** — deduplicated by structural identity instead of freshly allocated each time.
- **Global value numbering** — `_findOrEmitHoistableInst` returns an existing structurally-equal hoistable inst, keyed by op+type+operands only (not entries).
- **`findWitnessTableEntry`** — returns a witness table's first entry matching a requirement key.

## Process report

The recursion checker and `findWitnessTableEntry` are correct given their input; the witness table is malformed because `cloneInst` appended a second set of children onto an inst it didn't create — that's the producer, so that's the fix site. The structural collision itself is valid, expected input (two conformances legitimately sharing one lowered representation), so nothing upstream needs to change — only `cloneInst`'s handling of a dedup hit on a different inst.

Verified: reverting the fix reproduces both `E55201` and the new test's `E99997`. With the fix: repro compiles to the correct `42`; new test passes; `generics/`+`interfaces/` 235/235; `autodiff/` 406/406.

Fixes #12540
