### PR TITLE
Record the nvapi front-matter test as a victim of the HLSL prelude leak

### DIFF
--- a/docs/generated/tests/_meta/expected-failures.txt
+++ b/docs/generated/tests/_meta/expected-failures.txt
@@ -197,6 +197,17 @@ docs/generated/tests/design/target-pipelines/hlsl/prelude-nvapi-include-conditio
 # `-target hlsl` directive (`.2`) is affected -- the cuda and cpp directives in
 # the same file do not read the HLSL prelude and must keep reporting.
 docs/generated/tests/design/pipeline/06-emit/preludes-included-by-cuda-cpp-and-hlsl.slang.2
+# Same leak, fifth victim, and the reason it was not listed with the others is
+# the same: it passed when it was generated. It asserts the guarded
+# `#ifdef SLANG_HLSL_ENABLE_NVAPI` / `#include "nvHLSLExtns.h"` block, which is
+# exactly what the blanked prelude drops, so the `CHECK` for the `#ifdef` finds
+# nothing. Failed on nightly runs 31863743484, 31926143161 and 31993906894 with
+# the same FileCheck positions each time (`actual-output:7:34` scanning from,
+# `10:14` possible match), i.e. deterministic rather than flaky. Confirmed to be
+# the ordering leak and not the test: it passes alone under
+# `slang-test -use-test-server -server-count 1`, and fails in the same process
+# when a `-cpu` COMPARE_COMPUTE test is run before it.
+docs/generated/tests/design/target-pipelines/hlsl/nvapi-front-matter-defines-enable-macro.slang
 
 # https://github.com/shader-slang/slang/issues/12443 — `Size(N)` enum
 # construction is rejected inside a generic function's array bound with


### PR DESCRIPTION
## 1. Motivation

`docs/generated/tests/design/target-pipelines/hlsl/nvapi-front-matter-defines-enable-macro.slang`
has failed **every** agentic nightly since it landed, and it is the only
repeating failure in those runs — everything else rotates:

| run | date | failing tests |
| --- | --- | --- |
| [31863743484](https://github.com/shader-slang/slang/actions/runs/31863743484) | 08-15 | 4, incl. this one |
| [31926143161](https://github.com/shader-slang/slang/actions/runs/31926143161) | 08-16 | 2, incl. this one |
| [31993906894](https://github.com/shader-slang/slang/actions/runs/31993906894) | 08-17 | 2, incl. this one |

The FileCheck positions are identical every night (`actual-output:7:34` scanning
from, `10:14` possible intended match), so this is deterministic, not flaky.

## 2. Proposed solution

The cause is the prelude leak already recorded in `expected-failures.txt`
(#12442): render-test blanks the HLSL prelude on the shared global session and
never restores it, so any later test in the same process that reads the prelude
sees it empty. This test asserts the guarded

```hlsl
#ifdef SLANG_HLSL_ENABLE_NVAPI
#include "nvHLSLExtns.h"
```

block — exactly what the blanked prelude drops — so the `CHECK` for the `#ifdef`
matches nothing.

It was not listed alongside the other four victims for the same reason the
fourth was not: it passed when it was generated, and the test ordering only
later put a `-cpu` COMPARE_COMPUTE ahead of it in the same process.

Confirmed to be the ordering leak rather than a defect in the test:

```
nvapi test alone, -use-test-server -server-count 1   ->  passed (588/588)
a -cpu COMPARE_COMPUTE first, same process           ->  FAILED
```

So it is added to the existing #12442 block as the fifth victim, with the
evidence recorded inline. It comes back out when #12442 is fixed, along with the
four above it.

## 3. Change summary

| Area | Change |
| --- | --- |
| `docs/generated/tests/_meta/expected-failures.txt` | One entry added to the existing #12442 block, plus the comment recording why it was not listed earlier and how the ordering dependence was confirmed |

No test, source, or tooling changes.

## 4. Concepts and vocabulary

- **`expected-failures.txt`** — reclassifies listed failures as
  `failed(expected)` so they do not gate the nightly's exit code. It is a
  both-directions gate: a listed test that *passes* is also reported, so a stale
  entry cannot hide silently.
- **The #12442 leak** — render-test sets a blank HLSL prelude on the *shared
  global session*; because the test server runs many tests in one process, every
  later HLSL test in that process inherits the blanked prelude. Hence
  "order-dependent, passes in isolation".

## 5. Process report

**Why list it rather than fix the test.** The test is correct — it asserts
exactly the front-matter contract its bundle documents, and it passes whenever
the prelude is intact. Loosening its `CHECK`s to tolerate a missing
`#ifdef SLANG_HLSL_ENABLE_NVAPI` would delete the only coverage of the "live
NVAPI" path and make the suite agree with a bug. The four sibling entries above
it took the same view.

**Why not fix #12442 here.** That fix belongs in render-test's session handling,
is a different area, and would let all five entries come out at once — it should
be its own change with its own review, not a rider on a one-line list edit.

**Input-shape check.** The shape the test receives — an emitted HLSL file with
no prelude include block — is *not* correct or principled, and the producer
(render-test, leaking a blanked prelude into a shared session) is what should be
fixed. This change does not accommodate that shape anywhere in the test or the
tooling; it only records that the failure is known and attributed, so the
nightly's remaining signal is honest. With this entry, the only failures left in
those runs are the rotating test-server transport hits tracked in #12534.

**Verification.** `regenerate.py lint` 0 errors, `selftest` 0 failures, design
lint 0 errors, `formatting.sh --check-only` clean. The entry resolves as a path
on disk, so `lint_expected_failures` does not flag it.
