### PR TITLE
ci-analytics: link pending-approval PRs to Files changed tab

### DIFF
--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -1247,7 +1247,7 @@ def render_pending_approvals(data):
             f"<strong>{_esc(event)}</strong>" if event == "merge_group" else _esc(event)
         )
         pr_number = p.get("pr_number")
-        pr_cell = _link(f"https://github.com/shader-slang/slang/pull/{pr_number}", f"#{pr_number}") if pr_number else ""
+        pr_cell = _link(f"https://github.com/shader-slang/slang/pull/{pr_number}/files", f"#{pr_number}") if pr_number else ""
         html += (
             "  <tr>"
             f"<td>{p['waited_min']} min</td>"
@@ -1409,7 +1409,7 @@ PENDING_APPROVALS_JS = """
           var event = p.event === "merge_group"
             ? "<strong>merge_group</strong>" : esc(p.event);
           var pr = p.pr_number
-            ? '<a href="https://github.com/shader-slang/slang/pull/' + p.pr_number + '">#' + p.pr_number + '</a>'
+            ? '<a href="https://github.com/shader-slang/slang/pull/' + p.pr_number + '/files">#' + p.pr_number + '</a>'
             : '';
           html += '<tr>' +
             '<td>' + p.waited + ' min</td>' +

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -1247,7 +1247,7 @@ def render_pending_approvals(data):
             f"<strong>{_esc(event)}</strong>" if event == "merge_group" else _esc(event)
         )
         pr_number = p.get("pr_number")
-        pr_cell = _link(f"https://github.com/shader-slang/slang/pull/{pr_number}/files", f"#{pr_number}") if pr_number else ""
+        pr_cell = _link(f"https://github.com/shader-slang/slang/pull/{pr_number}/changes", f"#{pr_number}") if pr_number else ""
         html += (
             "  <tr>"
             f"<td>{p['waited_min']} min</td>"
@@ -1409,7 +1409,7 @@ PENDING_APPROVALS_JS = """
           var event = p.event === "merge_group"
             ? "<strong>merge_group</strong>" : esc(p.event);
           var pr = p.pr_number
-            ? '<a href="https://github.com/shader-slang/slang/pull/' + p.pr_number + '/files">#' + p.pr_number + '</a>'
+            ? '<a href="https://github.com/shader-slang/slang/pull/' + p.pr_number + '/changes">#' + p.pr_number + '</a>'
             : '';
           html += '<tr>' +
             '<td>' + p.waited + ' min</td>' +

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -319,7 +319,7 @@ def fetch_pending_approvals(repo):
     is a PR that sits until its job timeout and then reports as a test failure.
     """
     sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
-    from gh_api import gh_api_list
+    from gh_api import find_pr_number_by_head, gh_api_list
 
     runs, err = gh_api_list(
         f"repos/{repo}/actions/runs?status=waiting&per_page=100",
@@ -340,6 +340,12 @@ def fetch_pending_approvals(repo):
             waited_min = 0
         prs = run.get("pull_requests") or []
         pr_number = prs[0].get("number") if prs else None
+        if pr_number is None and run.get("event") == "pull_request":
+            # A run triggered from a fork branch has an empty `pull_requests`
+            # field (GitHub only populates it for same-repo branches), so the
+            # PR has to be looked up by head owner/branch instead.
+            head_owner = ((run.get("head_repository") or {}).get("owner") or {}).get("login")
+            pr_number = find_pr_number_by_head(repo, head_owner, run.get("head_branch"))
         pending.append(
             {
                 "run_id": run.get("id"),
@@ -1376,12 +1382,30 @@ PENDING_APPROVALS_JS = """
           actor: (r.actor || {}).login || "?",
           event: r.event || "",
           branch: r.head_branch || "",
+          head_owner: ((r.head_repository || {}).owner || {}).login || "",
           title: r.display_title || String(r.id),
           waited: waited,
           pr_number: prs.length ? prs[0].number : null,
         };
       }).sort(function (a, b) { return b.waited - a.waited; });
 
+      // A run triggered from a fork branch has an empty `pull_requests`
+      // field (GitHub only populates it for same-repo branches), so the PR
+      // has to be looked up separately by head owner/branch.
+      var lookups = pending
+        .filter(function (p) { return p.pr_number === null && p.event === "pull_request" && p.head_owner; })
+        .map(function (p) {
+          var lookupUrl = "https://api.github.com/repos/" + repo + "/pulls?head=" +
+            encodeURIComponent(p.head_owner) + ":" + encodeURIComponent(p.branch) + "&state=open";
+          return fetch(lookupUrl)
+            .then(function (r) { return r.ok ? r.json() : []; })
+            .then(function (prs) { p.pr_number = prs.length ? prs[0].number : null; })
+            .catch(function () {});
+        });
+
+      return Promise.all(lookups).then(function () { return pending; });
+    })
+    .then(function (pending) {
       var oldest = pending.length ? pending[0].waited : 0;
       var fg, bg, label, summary;
       if (!pending.length) {

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -1391,17 +1391,37 @@ PENDING_APPROVALS_JS = """
 
       // A run triggered from a fork branch has an empty `pull_requests`
       // field (GitHub only populates it for same-repo branches), so the PR
-      // has to be looked up separately by head owner/branch.
-      var lookups = pending
-        .filter(function (p) { return p.pr_number === null && p.event === "pull_request" && p.head_owner; })
-        .map(function (p) {
-          var lookupUrl = "https://api.github.com/repos/" + repo + "/pulls?head=" +
-            encodeURIComponent(p.head_owner) + ":" + encodeURIComponent(p.branch) + "&state=open";
-          return fetch(lookupUrl)
-            .then(function (r) { return r.ok ? r.json() : []; })
-            .then(function (prs) { p.pr_number = prs.length ? prs[0].number : null; })
-            .catch(function () {});
-        });
+      // has to be looked up separately by head owner/branch. Dedup by
+      // owner/branch (several waiting runs can share one PR) and cap the
+      // number of lookups so a burst of unresolved fork runs cannot fire
+      // more requests than an unauthenticated client's rate limit allows.
+      var MAX_HEAD_LOOKUPS = 20;
+      var seenKeys = {};
+      var uniqueTargets = [];
+      pending.forEach(function (p) {
+        if (p.pr_number !== null || p.event !== "pull_request" || !p.head_owner) return;
+        var key = p.head_owner + ":" + p.branch;
+        if (seenKeys[key]) return;
+        seenKeys[key] = true;
+        if (uniqueTargets.length < MAX_HEAD_LOOKUPS) uniqueTargets.push(key);
+      });
+
+      var lookups = uniqueTargets.map(function (key) {
+        var lookupUrl = "https://api.github.com/repos/" + repo + "/pulls?head=" +
+          encodeURIComponent(key.split(":")[0]) + ":" + encodeURIComponent(key.split(":").slice(1).join(":")) +
+          "&state=open";
+        return fetch(lookupUrl)
+          .then(function (r) { return r.ok ? r.json() : []; })
+          .then(function (prs) {
+            if (!prs.length) return;
+            pending.forEach(function (p) {
+              if (p.pr_number === null && (p.head_owner + ":" + p.branch) === key) {
+                p.pr_number = prs[0].number;
+              }
+            });
+          })
+          .catch(function () {});
+      });
 
       return Promise.all(lookups).then(function () { return pending; });
     })

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -658,6 +658,12 @@ class TestPendingApprovals(unittest.TestCase):
         self.assertIn("/pull/12345", html)
         self.assertIn("#12345", html)
 
+    def test_pr_link_points_to_changes_tab(self):
+        # Reviewers approving a run want to see the code, not the PR
+        # overview tab, so the link must land on the Files-changed view.
+        html = self._render([self._row(pr_number=12345)])
+        self.assertIn("/pull/12345/changes", html)
+
     def test_no_pr_number_renders_empty_cell(self):
         html = self._render([self._row(pr_number=None)])
         # Empty PR cell — no pull URL in the table
@@ -764,7 +770,9 @@ class TestPendingApprovals(unittest.TestCase):
             data = ci_health.fetch_pending_approvals("shader-slang/slang")
 
         self.assertEqual(data["pending"][0]["pr_number"], 12435)
-        self.assertIn("head=fknfilewalker:fix-assoc-default-init-and-matrix-layout", calls[0])
+        self.assertIn(
+            "head=fknfilewalker%3Afix-assoc-default-init-and-matrix-layout", calls[0]
+        )
 
     def test_pr_number_head_lookup_skipped_for_non_pull_request_events(self):
         # Only pull_request runs have a head branch worth resolving; a
@@ -814,6 +822,21 @@ class TestFindPrNumberByHead(unittest.TestCase):
     def test_returns_none_on_api_error(self):
         with mock.patch.object(gh_api, "gh_api", side_effect=lambda e: (None, "HTTP 502")):
             self.assertIsNone(gh_api.find_pr_number_by_head("o/r", "someone", "topic"))
+
+    def test_branch_name_with_ampersand_is_url_encoded(self):
+        # An unencoded "&" in the branch name would split "head=owner:branch"
+        # into separate query parameters instead of one head value.
+        calls = []
+
+        def fake_gh_api(endpoint):
+            calls.append(endpoint)
+            return [{"number": 1}], None
+
+        with mock.patch.object(gh_api, "gh_api", side_effect=fake_gh_api):
+            gh_api.find_pr_number_by_head("o/r", "someone", "fix&hack")
+
+        self.assertIn("head=someone%3Afix%26hack", calls[0])
+        self.assertNotIn("head=someone:fix&hack", calls[0])
 
 
 class TestHealthApiBounds(unittest.TestCase):
@@ -2411,6 +2434,20 @@ class TestPendingApprovalsLive(unittest.TestCase):
     def test_pending_approvals_placeholder_embeds_repo(self):
         html = self._health_html(repo="shader-slang/slang")
         self.assertIn('data-repo="shader-slang/slang"', html)
+
+    def test_pending_approvals_js_pr_link_points_to_changes_tab(self):
+        # Mirrors test_pr_link_points_to_changes_tab for the server-rendered
+        # table: the client-side widget builds the same link.
+        self.assertIn("/pull/' + p.pr_number + '/changes", ci_health.PENDING_APPROVALS_JS)
+
+    def test_pending_approvals_js_bounds_fork_pr_lookups(self):
+        # A burst of unresolved fork-branch runs must not fire one
+        # unauthenticated fetch per run — that can exceed GitHub's 60
+        # requests/hour anonymous rate limit. The client widget caps and
+        # deduplicates lookups by owner/branch before firing requests.
+        js = ci_health.PENDING_APPROVALS_JS
+        self.assertIn("MAX_HEAD_LOOKUPS", js)
+        self.assertIn("seenKeys", js)
 
     def test_pending_approvals_section_shows_loading_placeholder(self):
         # The placeholder div shows a loading message before JS runs.

--- a/extras/ci/analytics/tests/test_ci_analytics.py
+++ b/extras/ci/analytics/tests/test_ci_analytics.py
@@ -741,6 +741,81 @@ class TestPendingApprovals(unittest.TestCase):
             data = ci_health.fetch_pending_approvals("shader-slang/slang")
         self.assertIsNone(data["pending"][0]["pr_number"])
 
+    def test_pr_number_falls_back_to_head_lookup_for_fork_runs(self):
+        # A run triggered from a fork branch has an empty `pull_requests`
+        # field (GitHub only populates it for same-repo branches), so the PR
+        # number has to be found via a head owner/branch lookup instead.
+        run = {
+            "id": 1,
+            "created_at": "2026-08-11T00:00:00Z",
+            "event": "pull_request",
+            "pull_requests": [],
+            "head_branch": "fix-assoc-default-init-and-matrix-layout",
+            "head_repository": {"owner": {"login": "fknfilewalker"}},
+        }
+        calls = []
+
+        def fake_gh_api(endpoint):
+            calls.append(endpoint)
+            return [{"number": 12435}], None
+
+        with mock.patch.object(gh_api, "gh_api_list", side_effect=lambda e, k: ([run], None)), \
+                mock.patch.object(gh_api, "gh_api", side_effect=fake_gh_api):
+            data = ci_health.fetch_pending_approvals("shader-slang/slang")
+
+        self.assertEqual(data["pending"][0]["pr_number"], 12435)
+        self.assertIn("head=fknfilewalker:fix-assoc-default-init-and-matrix-layout", calls[0])
+
+    def test_pr_number_head_lookup_skipped_for_non_pull_request_events(self):
+        # Only pull_request runs have a head branch worth resolving; a
+        # merge_group run's PR number comes from parse_merge_queue_pr_number
+        # elsewhere, not from this fallback.
+        run = {
+            "id": 1,
+            "created_at": "2026-08-11T00:00:00Z",
+            "event": "merge_group",
+            "pull_requests": [],
+            "head_branch": "gh-readonly-queue/master/pr-1-abcdef",
+            "head_repository": {"owner": {"login": "shader-slang"}},
+        }
+        with mock.patch.object(gh_api, "gh_api_list", side_effect=lambda e, k: ([run], None)), \
+                mock.patch.object(gh_api, "gh_api", side_effect=AssertionError("should not be called")):
+            data = ci_health.fetch_pending_approvals("shader-slang/slang")
+
+        self.assertIsNone(data["pending"][0]["pr_number"])
+
+    def test_pr_number_head_lookup_returns_none_when_no_match(self):
+        run = {
+            "id": 1,
+            "created_at": "2026-08-11T00:00:00Z",
+            "event": "pull_request",
+            "pull_requests": [],
+            "head_branch": "some-branch",
+            "head_repository": {"owner": {"login": "someone"}},
+        }
+        with mock.patch.object(gh_api, "gh_api_list", side_effect=lambda e, k: ([run], None)), \
+                mock.patch.object(gh_api, "gh_api", side_effect=lambda e: ([], None)):
+            data = ci_health.fetch_pending_approvals("shader-slang/slang")
+
+        self.assertIsNone(data["pending"][0]["pr_number"])
+
+
+class TestFindPrNumberByHead(unittest.TestCase):
+    def test_returns_number_from_matching_pr(self):
+        with mock.patch.object(gh_api, "gh_api", side_effect=lambda e: ([{"number": 42}], None)):
+            self.assertEqual(
+                gh_api.find_pr_number_by_head("o/r", "someone", "topic"), 42
+            )
+
+    def test_returns_none_when_no_owner_or_branch(self):
+        self.assertIsNone(gh_api.find_pr_number_by_head("o/r", "", "topic"))
+        self.assertIsNone(gh_api.find_pr_number_by_head("o/r", "someone", ""))
+
+    def test_returns_none_on_api_error(self):
+        with mock.patch.object(gh_api, "gh_api", side_effect=lambda e: (None, "HTTP 502")):
+            self.assertIsNone(gh_api.find_pr_number_by_head("o/r", "someone", "topic"))
+
+
 class TestHealthApiBounds(unittest.TestCase):
     def test_recent_failures_query_is_bounded_by_created_range(self):
         calls = []

--- a/extras/ci/gh_api.py
+++ b/extras/ci/gh_api.py
@@ -127,6 +127,24 @@ def parse_merge_queue_pr_number(branch):
     return ""
 
 
+def find_pr_number_by_head(repo, head_owner, head_branch):
+    """Look up an open PR's number by its head owner and branch name.
+
+    A workflow run's `pull_requests` field is only populated by GitHub when
+    the head branch lives in the same repo as the workflow. For a run
+    triggered from a fork (`head_repository.full_name` differs from `repo`),
+    `pull_requests` is always `[]`, so callers that need the PR number have
+    to look it up separately via `GET /repos/{repo}/pulls?head=owner:branch`.
+    Returns the PR number (int), or None if no open PR matches.
+    """
+    if not head_owner or not head_branch:
+        return None
+    data, err = gh_api(f"repos/{repo}/pulls?head={head_owner}:{head_branch}&state=open")
+    if err or not data:
+        return None
+    return data[0].get("number")
+
+
 def coerce_jobs_data(data):
     """Normalize various input formats into a flat jobs list."""
     if isinstance(data, dict):

--- a/extras/ci/gh_api.py
+++ b/extras/ci/gh_api.py
@@ -9,6 +9,7 @@ import json
 import subprocess
 import sys
 import time
+from urllib.parse import urlencode
 
 MAX_RETRIES = 3
 RETRY_BACKOFF_SECONDS = 2
@@ -139,7 +140,8 @@ def find_pr_number_by_head(repo, head_owner, head_branch):
     """
     if not head_owner or not head_branch:
         return None
-    data, err = gh_api(f"repos/{repo}/pulls?head={head_owner}:{head_branch}&state=open")
+    query = urlencode({"head": f"{head_owner}:{head_branch}", "state": "open"})
+    data, err = gh_api(f"repos/{repo}/pulls?{query}")
     if err or not data:
         return None
     return data[0].get("number")


### PR DESCRIPTION
## Summary
- The Falcor bridge approval dashboard linked each pending run's PR to the PR's main GitHub page. Reviewers approving a run want to see the code change, so link straight to the Files changed tab (`/changes`, which GitHub's UI resolves to `/files`) instead.
- Updates both the server-rendered (Python) and client-rendered (JS) code paths that build this link.
- Fixes a second gap in the same dashboard: for a run triggered from a fork branch (e.g. https://github.com/shader-slang/slang/actions/runs/31907757562, branch `fix-assoc-default-init-and-matrix-layout` from `fknfilewalker/slang`), GitHub's Actions API always returns an empty `pull_requests` field, so the PR column was silently blank. Both code paths now fall back to `GET /repos/{repo}/pulls?head={owner}:{branch}` (using the run's `head_repository` owner and `head_branch`) to resolve the PR number when this happens.