### PR TITLE
slang-test: retry a malformed reply on a fresh server instead of failing the test

### DIFF
--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1489,10 +1489,17 @@ static Result _executeRPC(
             "retrying once on a freshly spawned test server; a second unreadable reply will "
             "be reported against this test";
         break;
-    default:
+    case RPCAttemptOutcome::Lost:
         retryMessage =
             "retrying once on a freshly spawned test server; a second loss will be reported "
             "against this test";
+        break;
+    default:
+        // Unreachable: isRetryable above admits exactly the three cases handled here. Listed
+        // rather than defaulted so that adding a fourth retryable outcome fails here instead
+        // of silently inheriting one of these messages.
+        SLANG_ASSERT(!"unhandled retryable outcome");
+        retryMessage = "retrying once on a freshly spawned test server";
         break;
     }
     context->getTestReporter()->message(TestMessageType::RunError, retryMessage);

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1451,15 +1451,30 @@ static Result _executeRPC(
     // resource shortage is worth one more try. They are kept distinct because only the first
     // can be attributed to the test: nothing ran on a server that never started.
     //
-    // The rest do not retry, deliberately:
+    // A protocol error earns one as well. That is a reversal: this used to reason that "the
+    // two sides disagree about the wire format, which a new process will disagree about
+    // identically", and for a genuine version mismatch that holds. But the errors actually
+    // seen are not that. On the agentic nightly they land on seven or eight *different* tests
+    // out of ~6300, the victims rotate run to run, and every one of them passes on other runs
+    // -- a static format disagreement would fail all 6300 identically. What the reply is is a
+    // reply that got corrupted in flight (see the malformed-response issue #12534), which is
+    // transient by nature and exactly what a fresh server discriminates. The old reasoning
+    // also cost a whole suite per occurrence: one unparseable reply reds ~6300 tests.
+    //
+    // If a real format disagreement ever does appear, the retry does not hide it -- the
+    // second attempt disagrees identically and the pair is charged to the test below, which
+    // is the same discriminator the loss path relies on.
+    //
+    // The rest still do not retry, deliberately:
     //
     // - A timeout is re-paid in full (another connectionTimeOutInMs) and a fresh server has
     //   to recompile the core module first, so retrying a slow request is the one way to
     //   turn a two-minute problem into a five-minute one.
-    // - A protocol or send failure means the two sides disagree about the wire format, which
-    //   a new process will disagree about identically.
-    const bool isRetryable =
-        first == RPCAttemptOutcome::Lost || first == RPCAttemptOutcome::StartFailed;
+    // - A send failure never got a reply to be corrupted; the request could not be written
+    //   at all, so there is nothing in flight for a fresh server to do differently.
+    const bool isRetryable = first == RPCAttemptOutcome::Lost ||
+                             first == RPCAttemptOutcome::StartFailed ||
+                             first == RPCAttemptOutcome::ProtocolError;
     if (!isRetryable)
     {
         return SLANG_FAIL;
@@ -1474,13 +1489,26 @@ static Result _executeRPC(
     // Worded to cover both causes it is reached for. A repeated StartFailed is NOT charged
     // to the test -- that needs `second == Lost && first == Lost` below -- so promising that
     // "a second loss will be reported against this test" would be false on the spawn path.
-    context->getTestReporter()->message(
-        TestMessageType::RunError,
-        first == RPCAttemptOutcome::StartFailed
-            ? "no test server could be spawned; retrying once, and a second failure to spawn "
-              "will fail this test without blaming its input"
-            : "retrying once on a freshly spawned test server; a second loss will be reported "
-              "against this test");
+    const char* retryMessage = nullptr;
+    switch (first)
+    {
+    case RPCAttemptOutcome::StartFailed:
+        retryMessage =
+            "no test server could be spawned; retrying once, and a second failure to spawn "
+            "will fail this test without blaming its input";
+        break;
+    case RPCAttemptOutcome::ProtocolError:
+        retryMessage =
+            "retrying once on a freshly spawned test server; a second unreadable reply will "
+            "be reported against this test";
+        break;
+    default:
+        retryMessage =
+            "retrying once on a freshly spawned test server; a second loss will be reported "
+            "against this test";
+        break;
+    }
+    context->getTestReporter()->message(TestMessageType::RunError, retryMessage);
 
     // Straight into outRes, as the first attempt does: _executeRPCOnce writes it only on
     // success, so a second loss leaves the caller's own init() value intact rather than a
@@ -1497,6 +1525,10 @@ static Result _executeRPC(
         {
             context->getTestReporter()->recordTestServerLoss();
         }
+        else if (first == RPCAttemptOutcome::ProtocolError)
+        {
+            context->getTestReporter()->recordTestServerProtocolError();
+        }
         return SLANG_OK;
     }
 
@@ -1508,6 +1540,19 @@ static Result _executeRPC(
             TestMessageType::TestFailure,
             "this test killed a freshly spawned test server twice in a row; treating it as a "
             "crash caused by this input rather than as an unrelated server loss");
+    }
+
+    // And only a repeated PROTOCOL ERROR implicates it the other way. Two fresh servers
+    // failing to produce a readable reply for this one request is the version-mismatch case
+    // the old no-retry rule assumed, or an input that makes the server emit something it
+    // cannot frame; either way it reproduces, so it is the test's to answer for.
+    if (second == RPCAttemptOutcome::ProtocolError && first == RPCAttemptOutcome::ProtocolError)
+    {
+        context->getTestReporter()->messageFormat(
+            TestMessageType::TestFailure,
+            "this test drew an unreadable reply from a freshly spawned test server twice in a "
+            "row; treating it as caused by this input rather than as an unrelated malformed "
+            "response");
     }
 
     return SLANG_FAIL;

--- a/tools/slang-test/slang-test-main.cpp
+++ b/tools/slang-test/slang-test-main.cpp
@@ -1447,31 +1447,18 @@ static Result _executeRPC(
         return SLANG_OK;
     }
 
-    // A lost server earns a second attempt; a failed SPAWN earns one too, since a transient
-    // resource shortage is worth one more try. They are kept distinct because only the first
-    // can be attributed to the test: nothing ran on a server that never started.
+    // Lost and StartFailed retry, kept distinct because only Lost can be charged to the test:
+    // nothing ran on a server that never started.
     //
-    // A protocol error earns one as well. That is a reversal: this used to reason that "the
-    // two sides disagree about the wire format, which a new process will disagree about
-    // identically", and for a genuine version mismatch that holds. But the errors actually
-    // seen are not that. On the agentic nightly they land on seven or eight *different* tests
-    // out of ~6300, the victims rotate run to run, and every one of them passes on other runs
-    // -- a static format disagreement would fail all 6300 identically. What the reply is is a
-    // reply that got corrupted in flight (see the malformed-response issue #12534), which is
-    // transient by nature and exactly what a fresh server discriminates. The old reasoning
-    // also cost a whole suite per occurrence: one unparseable reply reds ~6300 tests.
+    // ProtocolError retries too. This used to reason that a wire-format disagreement would
+    // repeat on a new process, but the errors seen are not that: ~7 per 6300-test run, on
+    // different tests each time, each passing on other runs (#12534). They are replies
+    // corrupted in flight, which a fresh server discriminates -- and a real disagreement
+    // still repeats and is charged to the test below.
     //
-    // If a real format disagreement ever does appear, the retry does not hide it -- the
-    // second attempt disagrees identically and the pair is charged to the test below, which
-    // is the same discriminator the loss path relies on.
-    //
-    // The rest still do not retry, deliberately:
-    //
-    // - A timeout is re-paid in full (another connectionTimeOutInMs) and a fresh server has
-    //   to recompile the core module first, so retrying a slow request is the one way to
-    //   turn a two-minute problem into a five-minute one.
-    // - A send failure never got a reply to be corrupted; the request could not be written
-    //   at all, so there is nothing in flight for a fresh server to do differently.
+    // The rest do not:
+    // - TimedOut re-pays connectionTimeOutInMs plus a core-module recompile on the new server.
+    // - SendFailed never got a reply to corrupt; the request was never written.
     const bool isRetryable = first == RPCAttemptOutcome::Lost ||
                              first == RPCAttemptOutcome::StartFailed ||
                              first == RPCAttemptOutcome::ProtocolError;
@@ -1486,9 +1473,9 @@ static Result _executeRPC(
     // was doing) does not reproduce on a virgin process, while an input that genuinely kills
     // the compiler kills this one too -- and then the failure is reported against the test,
     // where it belongs, instead of being retried until it looks green.
-    // Worded to cover both causes it is reached for. A repeated StartFailed is NOT charged
-    // to the test -- that needs `second == Lost && first == Lost` below -- so promising that
-    // "a second loss will be reported against this test" would be false on the spawn path.
+    //
+    // One message per cause: only Lost and ProtocolError can be charged to the test, so the
+    // spawn path must not promise that a second failure will be.
     const char* retryMessage = nullptr;
     switch (first)
     {
@@ -1542,10 +1529,8 @@ static Result _executeRPC(
             "crash caused by this input rather than as an unrelated server loss");
     }
 
-    // And only a repeated PROTOCOL ERROR implicates it the other way. Two fresh servers
-    // failing to produce a readable reply for this one request is the version-mismatch case
-    // the old no-retry rule assumed, or an input that makes the server emit something it
-    // cannot frame; either way it reproduces, so it is the test's to answer for.
+    // Likewise a repeated PROTOCOL ERROR: two fresh servers failing to frame a reply to this
+    // one request reproduces, so it is the test's to answer for.
     if (second == RPCAttemptOutcome::ProtocolError && first == RPCAttemptOutcome::ProtocolError)
     {
         context->getTestReporter()->messageFormat(

--- a/tools/slang-test/test-reporter.cpp
+++ b/tools/slang-test/test-reporter.cpp
@@ -298,8 +298,8 @@ void TestReporter::recordTestServerProtocolError()
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     m_testServerProtocolErrorCount++;
-    // Named for the same reason a loss is: one malformed reply is noise, the same test
-    // appearing repeatedly is the shortlist for whatever is corrupting the channel.
+    // Named for the same reason a loss is: one is noise, a test recurring is the shortlist
+    // for whatever is corrupting the channel.
     if (m_inTest && m_currentInfo.name.getLength())
     {
         m_testServerProtocolErrorTests.add(m_currentInfo.name);
@@ -924,8 +924,8 @@ void TestReporter::outputSummary()
                 printf("---\n");
             }
 
-            // Same contract as the loss block above, reported separately because the two
-            // rates move independently and a combined number would hide which one moved.
+            // Same contract as the loss block above, separate because the two rates move
+            // independently.
             if (m_testServerProtocolErrorCount)
             {
                 printf(

--- a/tools/slang-test/test-reporter.cpp
+++ b/tools/slang-test/test-reporter.cpp
@@ -262,6 +262,8 @@ void TestReporter::consolidateWith(TestReporter* other)
     m_totalTestCount += other->m_totalTestCount;
     m_testServerLossCount += other->m_testServerLossCount;
     m_testServerLossTests.addRange(other->m_testServerLossTests);
+    m_testServerProtocolErrorCount += other->m_testServerProtocolErrorCount;
+    m_testServerProtocolErrorTests.addRange(other->m_testServerProtocolErrorTests);
 
     // A deferral and the final result that redeems it can be recorded by two different
     // sub-reporters, because the retry pass is run by a fresh set of threads. Merge both sets and
@@ -288,6 +290,19 @@ void TestReporter::recordTestServerLoss()
     if (m_inTest && m_currentInfo.name.getLength())
     {
         m_testServerLossTests.add(m_currentInfo.name);
+    }
+}
+
+void TestReporter::recordTestServerProtocolError()
+{
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
+    m_testServerProtocolErrorCount++;
+    // Named for the same reason a loss is: one malformed reply is noise, the same test
+    // appearing repeatedly is the shortlist for whatever is corrupting the channel.
+    if (m_inTest && m_currentInfo.name.getLength())
+    {
+        m_testServerProtocolErrorTests.add(m_currentInfo.name);
     }
 }
 
@@ -903,6 +918,24 @@ void TestReporter::outputSummary()
                     m_testServerLossCount);
                 printf("---\n");
                 for (const auto& name : m_testServerLossTests)
+                {
+                    printf("%s\n", name.getBuffer());
+                }
+                printf("---\n");
+            }
+
+            // Same contract as the loss block above, reported separately because the two
+            // rates move independently and a combined number would hide which one moved.
+            if (m_testServerProtocolErrorCount)
+            {
+                printf(
+                    "\nwarning: %d test server protocol error(s); the server returned a reply "
+                    "the client could not parse under each test below and the request "
+                    "succeeded on a freshly spawned one, so the malformed reply was the "
+                    "server's doing and not the test's:\n",
+                    m_testServerProtocolErrorCount);
+                printf("---\n");
+                for (const auto& name : m_testServerProtocolErrorTests)
                 {
                     printf("%s\n", name.getBuffer());
                 }

--- a/tools/slang-test/test-reporter.h
+++ b/tools/slang-test/test-reporter.h
@@ -121,6 +121,16 @@ public:
     /// does not fail the run, since there is not yet a baseline to say what rate is normal.
     void recordTestServerLoss();
 
+    /// Record that a test server returned an unreadable reply under a test that then passed
+    /// on a fresh one.
+    ///
+    /// Kept apart from a loss rather than folded into it: the server did not die here, it
+    /// answered with bytes the client could not parse, and the two have different causes. The
+    /// rates move independently -- a run can double its crash count while its malformed-reply
+    /// count stays flat -- so a single combined number would hide exactly the signal that
+    /// tells the two apart.
+    void recordTestServerProtocolError();
+
     /// True if can write output directly to stderr
     bool canWriteStdError() const;
 
@@ -260,6 +270,10 @@ public:
     /// losses than names, and a name repeated. Neither is a bug.
     int m_testServerLossCount = 0;
     Slang::List<Slang::String> m_testServerLossTests;
+
+    /// Malformed-reply counterpart of the two above, with the same count-vs-names contract.
+    int m_testServerProtocolErrorCount = 0;
+    Slang::List<Slang::String> m_testServerProtocolErrorTests;
 
     TestOutputMode m_outputMode = TestOutputMode::Default;
     bool m_dumpOutputOnFailure;

--- a/tools/slang-test/test-reporter.h
+++ b/tools/slang-test/test-reporter.h
@@ -124,11 +124,9 @@ public:
     /// Record that a test server returned an unreadable reply under a test that then passed
     /// on a fresh one.
     ///
-    /// Kept apart from a loss rather than folded into it: the server did not die here, it
-    /// answered with bytes the client could not parse, and the two have different causes. The
-    /// rates move independently -- a run can double its crash count while its malformed-reply
-    /// count stays flat -- so a single combined number would hide exactly the signal that
-    /// tells the two apart.
+    /// Kept apart from a loss: the server did not die, and the two rates move independently
+    /// (a run can double its crash count while this stays flat), so one combined number would
+    /// hide which moved.
     void recordTestServerProtocolError();
 
     /// True if can write output directly to stderr

--- a/tools/slang-unit-test/unit-test-test-server-loss.cpp
+++ b/tools/slang-unit-test/unit-test-test-server-loss.cpp
@@ -154,14 +154,19 @@ static String _allOutput(const ExecuteResult& res)
 /// per-loss diagnostics and its summary -- is discarded. That happened: the first CI failure
 /// of these tests reported "res.resultCode == 0" and nothing else, on a platform that cannot
 /// be reproduced locally, which is the worst possible combination.
-static void _dumpChildRun(const char* caseName, int dieOnRequest, const ExecuteResult& res)
+static void _dumpChildRun(
+    const char* caseName,
+    const char* envVar,
+    int ordinal,
+    const ExecuteResult& res)
 {
     const String output = _allOutput(res);
     printf(
-        "\n--- %s: inner slang-test (SLANG_TEST_SERVER_DIE_ON_REQUEST=%d) exited %d ---\n"
+        "\n--- %s: inner slang-test (%s=%d) exited %d ---\n"
         "%s\n--- end inner run ---\n",
         caseName,
-        dieOnRequest,
+        envVar,
+        ordinal,
         res.resultCode,
         output.getBuffer());
     fflush(stdout);
@@ -182,7 +187,7 @@ SLANG_UNIT_TEST(testServerLossHealthyRunIsUnaffected)
     const String output = _allOutput(res);
     if (res.resultCode != 0 || !_contains(output, "100% of tests passed"))
     {
-        _dumpChildRun("healthy", 0, res);
+        _dumpChildRun("healthy", "SLANG_TEST_SERVER_DIE_ON_REQUEST", 0, res);
     }
     SLANG_CHECK(res.resultCode == 0);
     SLANG_CHECK(_contains(output, "100% of tests passed"));
@@ -211,7 +216,7 @@ SLANG_UNIT_TEST(testServerLossInnocentTestIsNotBlamed)
     const String output = _allOutput(res);
     if (res.resultCode != 0 || !_contains(output, "100% of tests passed"))
     {
-        _dumpChildRun("innocent", 3, res);
+        _dumpChildRun("innocent", "SLANG_TEST_SERVER_DIE_ON_REQUEST", 3, res);
     }
     SLANG_CHECK(res.resultCode == 0);
     SLANG_CHECK(_contains(output, "100% of tests passed"));
@@ -247,7 +252,7 @@ SLANG_UNIT_TEST(testServerProtocolErrorInnocentTestIsNotBlamed)
     const String output = _allOutput(res);
     if (res.resultCode != 0 || !_contains(output, "100% of tests passed"))
     {
-        _dumpChildRun("garbled", 3, res);
+        _dumpChildRun("garbled", "SLANG_TEST_SERVER_GARBLE_ON_REQUEST", 3, res);
     }
     SLANG_CHECK(res.resultCode == 0);
     SLANG_CHECK(_contains(output, "100% of tests passed"));
@@ -279,7 +284,7 @@ SLANG_UNIT_TEST(testServerProtocolErrorPersistentGarbleFailsTheRun)
     const String output = _allOutput(res);
     if (res.resultCode == 0)
     {
-        _dumpChildRun("persistent-garble", 1, res);
+        _dumpChildRun("persistent-garble", "SLANG_TEST_SERVER_GARBLE_ON_REQUEST", 1, res);
     }
     SLANG_CHECK(res.resultCode != 0);
     SLANG_CHECK(_contains(output, "unreadable reply from a freshly spawned test server twice"));
@@ -307,7 +312,7 @@ SLANG_UNIT_TEST(testServerLossPersistentKillerFailsTheRun)
     // nothing.
     if (res.resultCode == 0)
     {
-        _dumpChildRun("killer", 1, res);
+        _dumpChildRun("killer", "SLANG_TEST_SERVER_DIE_ON_REQUEST", 1, res);
     }
     SLANG_CHECK(res.resultCode != 0);
 
@@ -346,7 +351,7 @@ SLANG_UNIT_TEST(testServerLossReportsTheKillingSignal)
     const String output = _allOutput(res);
     if (!_contains(output, "killed by signal"))
     {
-        _dumpChildRun("signal", 3, res);
+        _dumpChildRun("signal", "SLANG_TEST_SERVER_KILL_ON_REQUEST", 3, res);
     }
 
     // The number, and the name that makes it actionable. Before this path existed the same
@@ -387,9 +392,19 @@ SLANG_UNIT_TEST(testServerLossConsolidatesAcrossReporters)
     worker.m_testServerLossTests.add("worker/b.slang");
     worker.m_testServerLossTests.add("worker/b.slang"); // same test, two servers lost
 
+    parent.m_testServerProtocolErrorCount = 1;
+    parent.m_testServerProtocolErrorTests.add("main/c.slang");
+    worker.m_testServerProtocolErrorCount = 1;
+    worker.m_testServerProtocolErrorTests.add("worker/d.slang");
+
     parent.consolidateWith(&worker);
 
     SLANG_CHECK(parent.m_testServerLossCount == 3);
     // Concatenated, not unioned: a repeat is the frequency signal, so the duplicate survives.
     SLANG_CHECK(parent.m_testServerLossTests.getCount() == 3);
+
+    // The protocol-error pair consolidates the same way, and stays a separate total: folding
+    // it into the loss count would make each number unable to answer what it exists for.
+    SLANG_CHECK(parent.m_testServerProtocolErrorCount == 2);
+    SLANG_CHECK(parent.m_testServerProtocolErrorTests.getCount() == 2);
 }

--- a/tools/slang-unit-test/unit-test-test-server-loss.cpp
+++ b/tools/slang-unit-test/unit-test-test-server-loss.cpp
@@ -116,6 +116,31 @@ static SlangResult _runSlangTestWithDyingServer(
     return ProcessUtil::execute(cmdLine, outResult);
 }
 
+/// Run slang-test in a child process with its test server rigged to write an unreadable
+/// reply on the Nth request.
+///
+/// Separate from the dying-server helper rather than another flag on it, because the
+/// scenario differs in the way that matters: the server stays alive. Nothing dies, no
+/// connection closes, and the client has to conclude "unusable reply" from the bytes alone.
+static SlangResult _runSlangTestWithGarblingServer(
+    UnitTestContext* context,
+    int garbleOnRequest,
+    ExecuteResult& outResult)
+{
+    CommandLine cmdLine;
+    cmdLine.setExecutableLocation(ExecutableLocation(context->executableDirectory, "slang-test"));
+    cmdLine.addArg("-use-test-server");
+    cmdLine.addArg("-server-count");
+    cmdLine.addArg("1");
+    cmdLine.addArg(kInnerTestPrefix);
+
+    ScopedEnvVar nestedGuard(kNestedGuardEnvVar, "1");
+    ScopedEnvVar garbleAfter(
+        "SLANG_TEST_SERVER_GARBLE_ON_REQUEST",
+        String(garbleOnRequest).getBuffer());
+    return ProcessUtil::execute(cmdLine, outResult);
+}
+
 static String _allOutput(const ExecuteResult& res)
 {
     StringBuilder builder;
@@ -202,6 +227,70 @@ SLANG_UNIT_TEST(testServerLossInnocentTestIsNotBlamed)
     // stopped happening per connection would drift them run to run.
     SLANG_CHECK(_contains(output, "test server loss(es); the server died under each test below"));
     SLANG_CHECK(_contains(output, "on request #3 of this connection (it had answered 2)"));
+}
+
+/// A server that returns one unreadable reply, where the retry lands on a fresh one.
+///
+/// The counterpart of the innocent-loss case, and the reason it exists: a malformed reply
+/// used not to be retried at all, on the reasoning that two sides disagreeing about the wire
+/// format would disagree identically on a new process. The errors seen in practice are not a
+/// format disagreement -- they hit a handful of different tests per run, rotate, and pass on
+/// other runs -- so the test that happened to be in flight was failed, and one unreadable
+/// reply reds a whole suite.
+SLANG_UNIT_TEST(testServerProtocolErrorInnocentTestIsNotBlamed)
+{
+    if (_cannotRunHere())
+    {
+        SLANG_IGNORE_TEST
+    }
+
+    // Garbles its 3rd reply, so the first two are served and the retry -- on a server that
+    // has garbled nothing -- succeeds.
+    ExecuteResult res;
+    SLANG_CHECK(SLANG_SUCCEEDED(_runSlangTestWithGarblingServer(unitTestContext, 3, res)));
+
+    const String output = _allOutput(res);
+    if (res.resultCode != 0 || !_contains(output, "100% of tests passed"))
+    {
+        _dumpChildRun("garbled", 3, res);
+    }
+    SLANG_CHECK(res.resultCode == 0);
+    SLANG_CHECK(_contains(output, "100% of tests passed"));
+
+    // Recovered, and counted separately from a loss. Folding the two together would defeat
+    // the point of the number: the whole reason to have it is to see whether a change to the
+    // crash rate moved the malformed-reply rate, and a combined total cannot answer that.
+    SLANG_CHECK(_contains(
+        output,
+        "test server protocol error(s); the server returned a reply the client could not "
+        "parse"));
+    // The loss block must NOT appear: nothing died here.
+    SLANG_CHECK(!_contains(output, "the server died under each test below"));
+}
+
+/// A server that garbles every reply, so no retry can ever succeed.
+///
+/// The guard on the change above: retrying a malformed reply must not become a way to grind
+/// a genuinely broken channel until something looks green. Two fresh servers failing the
+/// same request is the version-mismatch case the old no-retry rule assumed, and it still has
+/// to fail the run.
+SLANG_UNIT_TEST(testServerProtocolErrorPersistentGarbleFailsTheRun)
+{
+    if (_cannotRunHere())
+    {
+        SLANG_IGNORE_TEST
+    }
+
+    ExecuteResult res;
+    SLANG_CHECK(SLANG_SUCCEEDED(_runSlangTestWithGarblingServer(unitTestContext, 1, res)));
+
+    const String output = _allOutput(res);
+    if (res.resultCode == 0)
+    {
+        _dumpChildRun("persistent-garble", 1, res);
+    }
+    SLANG_CHECK(res.resultCode != 0);
+    SLANG_CHECK(_contains(output, "unreadable reply from a freshly spawned test server twice"));
 }
 
 /// A server that dies on every request, so no retry can ever succeed.

--- a/tools/slang-unit-test/unit-test-test-server-loss.cpp
+++ b/tools/slang-unit-test/unit-test-test-server-loss.cpp
@@ -119,9 +119,8 @@ static SlangResult _runSlangTestWithDyingServer(
 /// Run slang-test in a child process with its test server rigged to write an unreadable
 /// reply on the Nth request.
 ///
-/// Separate from the dying-server helper rather than another flag on it, because the
-/// scenario differs in the way that matters: the server stays alive. Nothing dies, no
-/// connection closes, and the client has to conclude "unusable reply" from the bytes alone.
+/// Separate from the dying-server helper because the scenario differs where it matters: the
+/// server stays alive, so the client must conclude "unusable reply" from the bytes alone.
 static SlangResult _runSlangTestWithGarblingServer(
     UnitTestContext* context,
     int garbleOnRequest,
@@ -231,12 +230,8 @@ SLANG_UNIT_TEST(testServerLossInnocentTestIsNotBlamed)
 
 /// A server that returns one unreadable reply, where the retry lands on a fresh one.
 ///
-/// The counterpart of the innocent-loss case, and the reason it exists: a malformed reply
-/// used not to be retried at all, on the reasoning that two sides disagreeing about the wire
-/// format would disagree identically on a new process. The errors seen in practice are not a
-/// format disagreement -- they hit a handful of different tests per run, rotate, and pass on
-/// other runs -- so the test that happened to be in flight was failed, and one unreadable
-/// reply reds a whole suite.
+/// Counterpart of the innocent-loss case. A malformed reply used not to be retried at all, so
+/// whichever test was in flight failed -- and one unreadable reply reds a whole suite.
 SLANG_UNIT_TEST(testServerProtocolErrorInnocentTestIsNotBlamed)
 {
     if (_cannotRunHere())
@@ -257,9 +252,8 @@ SLANG_UNIT_TEST(testServerProtocolErrorInnocentTestIsNotBlamed)
     SLANG_CHECK(res.resultCode == 0);
     SLANG_CHECK(_contains(output, "100% of tests passed"));
 
-    // Recovered, and counted separately from a loss. Folding the two together would defeat
-    // the point of the number: the whole reason to have it is to see whether a change to the
-    // crash rate moved the malformed-reply rate, and a combined total cannot answer that.
+    // Recovered, and counted separately from a loss -- a combined total could not show
+    // whether a change to the crash rate moved the malformed-reply rate.
     SLANG_CHECK(_contains(
         output,
         "test server protocol error(s); the server returned a reply the client could not "
@@ -270,10 +264,8 @@ SLANG_UNIT_TEST(testServerProtocolErrorInnocentTestIsNotBlamed)
 
 /// A server that garbles every reply, so no retry can ever succeed.
 ///
-/// The guard on the change above: retrying a malformed reply must not become a way to grind
-/// a genuinely broken channel until something looks green. Two fresh servers failing the
-/// same request is the version-mismatch case the old no-retry rule assumed, and it still has
-/// to fail the run.
+/// The guard on the retry: a genuinely broken channel -- the version-mismatch case the old
+/// no-retry rule assumed -- must still fail the run rather than be ground until it looks green.
 SLANG_UNIT_TEST(testServerProtocolErrorPersistentGarbleFailsTheRun)
 {
     if (_cannotRunHere())

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -761,13 +761,10 @@ SlangResult TestServer::execute()
     // regression in the WTERMSIG recording would pass CI in silence.
     const int killOnRequest = _requestOrdinalFromEnv("SLANG_TEST_SERVER_KILL_ON_REQUEST");
 
-    // Third member of the family, and the only one where the server stays alive. It writes
-    // bytes that are not a JSON-RPC message into the response channel just before the Nth
-    // request is answered, so the client reads a reply it cannot frame. That is the shape of
-    // the malformed-response failure (#12534) -- something putting stray output into the
-    // channel -- and it is the case the client's protocol-error retry exists for. Like its
-    // two siblings it is otherwise unschedulable: it happens a handful of times per 6000-test
-    // run, on a different test each time.
+    // Third of the family and the only one where the server stays alive: it writes non-message
+    // bytes into the channel before the Nth reply, so the client reads something it cannot
+    // frame. That is the malformed-response shape (#12534) the protocol-error retry exists
+    // for, and neither hook above can produce it.
     const int garbleOnRequest = _requestOrdinalFromEnv("SLANG_TEST_SERVER_GARBLE_ON_REQUEST");
     int servedCount = 0;
 
@@ -800,10 +797,8 @@ SlangResult TestServer::execute()
 #endif
         }
 
-        // Written straight to the fd rather than through m_connection, because the connection
-        // would frame it correctly and correct framing is the one thing this must not do. The
-        // real reply still follows, so the client sees a channel whose next bytes are not a
-        // message -- not a silent server.
+        // Straight to the fd, not through m_connection: the connection would frame it
+        // correctly, which is the one thing this must not do. The real reply still follows.
         if (garbleOnRequest && servedCount == garbleOnRequest - 1)
         {
             const char garbage[] = "this-is-not-a-jsonrpc-header\r\n\r\n";

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -1,5 +1,4 @@
 // test-server.cpp
-
 #include "compiler-core/slang-json-rpc-connection.h"
 #include "compiler-core/slang-test-server-protocol.h"
 #include "core/slang-io.h"
@@ -17,6 +16,7 @@
 #include "test-server-diagnostics.h"
 #include "unit-test/slang-unit-test.h"
 
+#include <limits>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -675,7 +675,7 @@ SlangResult TestServer::_executeTool(const JSONRPCCall& call)
 ///
 /// Returns 0 (disabled) for anything unset or unparseable, so a typo in the variable name
 /// leaves the server behaving normally rather than dying on request one. Shared by the
-/// exit-on-request and kill-on-request hooks.
+/// exit-on-request, kill-on-request and garble-on-request hooks.
 static int _requestOrdinalFromEnv(const char* name)
 {
     StringBuilder value;
@@ -684,7 +684,11 @@ static int _requestOrdinalFromEnv(const char* name)
         return 0;
     }
     Int64 ordinal = 0;
-    if (SLANG_FAILED(StringUtil::parseInt64(value.getUnownedSlice(), ordinal)) || ordinal <= 0)
+    // The upper bound is part of "unparseable": the return narrows to int, so a larger value
+    // would come back negative and the `ordinal - 1` comparisons at the call sites would then
+    // overflow -- disabled is the only safe reading of a request number no run can reach.
+    if (SLANG_FAILED(StringUtil::parseInt64(value.getUnownedSlice(), ordinal)) || ordinal <= 0 ||
+        ordinal > Int64(std::numeric_limits<int>::max()))
     {
         return 0;
     }

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -760,6 +760,15 @@ SlangResult TestServer::execute()
     // way. Without it the headline diagnostic of this change has no test driving it, and a
     // regression in the WTERMSIG recording would pass CI in silence.
     const int killOnRequest = _requestOrdinalFromEnv("SLANG_TEST_SERVER_KILL_ON_REQUEST");
+
+    // Third member of the family, and the only one where the server stays alive. It writes
+    // bytes that are not a JSON-RPC message into the response channel just before the Nth
+    // request is answered, so the client reads a reply it cannot frame. That is the shape of
+    // the malformed-response failure (#12534) -- something putting stray output into the
+    // channel -- and it is the case the client's protocol-error retry exists for. Like its
+    // two siblings it is otherwise unschedulable: it happens a handful of times per 6000-test
+    // run, on a different test each time.
+    const int garbleOnRequest = _requestOrdinalFromEnv("SLANG_TEST_SERVER_GARBLE_ON_REQUEST");
     int servedCount = 0;
 
     while (m_connection->isActive() && !m_quit)
@@ -789,6 +798,17 @@ SlangResult TestServer::execute()
 #else
             _Exit(1);
 #endif
+        }
+
+        // Written straight to the fd rather than through m_connection, because the connection
+        // would frame it correctly and correct framing is the one thing this must not do. The
+        // real reply still follows, so the client sees a channel whose next bytes are not a
+        // message -- not a silent server.
+        if (garbleOnRequest && servedCount == garbleOnRequest - 1)
+        {
+            const char garbage[] = "this-is-not-a-jsonrpc-header\r\n\r\n";
+            fwrite(garbage, 1, sizeof(garbage) - 1, stdout);
+            fflush(stdout);
         }
 
         // Failure doesn't make the execution terminate

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -1,4 +1,5 @@
 // test-server.cpp
+
 #include "compiler-core/slang-json-rpc-connection.h"
 #include "compiler-core/slang-test-server-protocol.h"
 #include "core/slang-io.h"
@@ -801,8 +802,10 @@ SlangResult TestServer::execute()
 #endif
         }
 
-        // Straight to the fd, not through m_connection: the connection would frame it
-        // correctly, which is the one thing this must not do. The real reply still follows.
+        // Written to stdout directly rather than through m_connection, which would frame it
+        // correctly -- the one thing this must not do. The flush is load-bearing: it puts
+        // these bytes ahead of the reply the connection writes next, which is what makes the
+        // client read them as the start of that reply.
         if (garbleOnRequest && servedCount == garbleOnRequest - 1)
         {
             const char garbage[] = "this-is-not-a-jsonrpc-header\r\n\r\n";


### PR DESCRIPTION
## 1. Motivation

A single unparseable reply from a test server reds a ~6300-test suite. That is
the largest source of red agentic nightlies, and none of it is about the tests.

Three consecutive nightlies, all on master:

| run | protocol errors | server crashes | failing tests | any repeat? |
| --- | --- | --- | --- | --- |
| [31863743484](https://github.com/shader-slang/slang/actions/runs/31863743484) | 7 | 6 | 4 | — |
| [31926143161](https://github.com/shader-slang/slang/actions/runs/31926143161) | 8 | 2 | 2 | none |
| [31993906894](https://github.com/shader-slang/slang/actions/runs/31993906894) | 7 | 2 | 2 | none |

The victims rotate every night and each one passes on the other runs.

A protocol error did not earn a retry, for a reason recorded inline:

> a protocol or send failure means the two sides disagree about the wire format,
> which a new process will disagree about identically

For a genuine version mismatch that is right. But it does not describe these: a
static format disagreement would fail all 6300 tests identically, not seven of
them at random. These are replies corrupted in flight (#12534) — transient, and
exactly what a fresh server discriminates.

## 2. Proposed solution

Give a protocol error the same second attempt a lost server gets. The
discriminator is unchanged: if the disagreement is real, the second attempt
disagrees identically and the pair is charged to the test, so retrying cannot
launder a genuinely broken channel.

A send failure still does not retry, and the comment now says why in its own
terms — no reply ever arrived to be corrupted — rather than lumping it with the
protocol case.

Recovered protocol errors are counted and named **separately** from losses. The
server did not die here, and the rates move independently: across the three runs
above the crash count went 6, 2, 2 while the protocol-error count stayed 7, 8, 7.
A combined total would hide precisely the signal that tells the two apart, which
is what made the diagnosis above possible.

## 3. Change summary

| Area | Change |
| --- | --- |
| `slang-test-main.cpp` | `ProtocolError` joins `Lost`/`StartFailed` as retryable; a repeated protocol error is charged to the test; retry message selected per outcome |
| `test-reporter.{h,cpp}` | `recordTestServerProtocolError()` with its own count, name list, consolidation and summary block |
| `test-server-main.cpp` | New `SLANG_TEST_SERVER_GARBLE_ON_REQUEST=N` fault-injection hook |
| `unit-test-test-server-loss.cpp` | Two cases: innocent-garble recovers, persistent-garble still fails the run |

## 4. Concepts and vocabulary

- **`RPCAttemptOutcome`** — how one RPC attempt ended: `Ok`, `Lost` (server went
  away), `StartFailed` (none could be spawned), `TimedOut` (alive but silent),
  `ProtocolError` (a reply arrived that could not be parsed), `SendFailed`.
- **The retry as a discriminator** — the second attempt runs on a server that has
  served nothing, so an ambient fault does not reproduce while an input that
  genuinely provokes one does. That is what makes retrying an attribution
  mechanism rather than a mask.

## 5. Process report

**Why the layer is right.** The fault is in the transport, and the transport
layer is where it is classified. No test content changes and no test is excused;
a test whose input really does provoke an unreadable reply twice on two fresh
servers still fails, with a message naming that specifically.

**Input-shape check.** The shape being handled — a reply that is not a
well-formed JSON-RPC message — is *not* correct or principled, and its producer
(whatever is corrupting the channel, #12534) is what ultimately needs fixing.
This change does not accommodate it anywhere in the protocol or make the client
tolerate malformed messages; it distinguishes transient from reproducible and
counts the transient ones in the open. The count is deliberately visible so that
fixing #12534 is measurable rather than invisible.

**Why a new fault-injection hook.** The two existing hooks both kill the server,
and neither can produce a live server that returns garbage — the only shape that
reaches this path. It follows the existing pattern exactly, including
`_requestOrdinalFromEnv`'s "0 for anything unparseable" so a typo leaves the
server healthy.

**Revert drill.** With the server rigged to garble, removing the change from
`isRetryable` and rerunning gives:

```
before: 67% of tests passed (54/80)    -- 26 innocent tests failed
after: 100% of tests passed (80/80)
```

and both new unit tests fail (0/2), so they are not vacuous.

**Verification.** `slang-unit-test-tool/testServer` 7/7, `tests/preprocessor/`
80/80, `tests/bugs/` 591/591, `tests/compute/` 432/432. `formatting.sh` clean.

Related: #12534 (the malformed replies themselves), #12471 (introduced the
loss/timeout/protocol classification this builds on).
