### PR TITLE
Inherit PR assignees from linked issues via source-internal membership

### DIFF
--- a/.github/scripts/pr-assign.test.js
+++ b/.github/scripts/pr-assign.test.js
@@ -14,13 +14,17 @@ const {
 });
 
 const OWNERS = new Set(["owner1", "owner2"]);
+// Source-internal for this repo: overlaps owners, plus an Internal-only login
+// who is eligible for linked-issue inheritance but not for committer-signal.
+const INTERNAL = new Set(["owner1", "owner2", "internal1"]);
 const COLLAB = new Set(["owner1", "owner2", "dev1", "dev2"]); // owners are also collaborators
 const MAINT = "maintainer";
 
 function select(issue, committers, extra) {
   return selectAssigneeAndReviewers({
     issueAssignees: issue, committersBySignal: committers,
-    owners: OWNERS, collaborators: COLLAB, author: "author", maintainer: MAINT,
+    owners: OWNERS, internalMembers: INTERNAL, collaborators: COLLAB,
+    author: "author", maintainer: MAINT,
     ...(extra || {}),
   });
 }
@@ -28,10 +32,34 @@ function select(issue, committers, extra) {
 const tests = [];
 const test = (name, fn) => tests.push([name, fn]);
 
-test("issue assignee wins", () => {
+test("issue assignee wins when source-internal", () => {
   const { assignee, autoRequestedReviewer } = select(["owner2"], ["owner1", "dev1"]);
   assert.strictEqual(assignee, "owner2");
   assert.strictEqual(autoRequestedReviewer, "owner2");
+});
+
+test("issue assignee wins when Internal but not on owners team", () => {
+  const { assignee, autoRequestedReviewer } = select(
+    ["internal1"], ["owner1", "dev1"]);
+  assert.strictEqual(assignee, "internal1");
+  assert.strictEqual(autoRequestedReviewer, "internal1");
+});
+
+test("issue assignee ignored when not source-internal", () => {
+  const { assignee } = select(["dev1"], ["owner1", "dev1"]);
+  assert.strictEqual(assignee, "owner1");
+});
+
+test("issue assignee ignored when internal roster unknown", () => {
+  const { assignee } = select(["owner2"], ["owner1"], { internalMembers: null });
+  assert.strictEqual(assignee, "owner1");
+});
+
+test("issue assignee match is case-insensitive", () => {
+  const { assignee } = select(["Internal1"], ["owner1"], {
+    internalMembers: new Set(["internal1"]),
+  });
+  assert.strictEqual(assignee, "Internal1");
 });
 
 test("commit-signal owner when no issue", () => {
@@ -84,6 +112,7 @@ test("author shepherd is not auto-requested; top collaborator is suggested", () 
       issueAssignees: [],
       committersBySignal: ["dev1", "owner1"],
       owners: OWNERS,
+      internalMembers: INTERNAL,
       collaborators: COLLAB,
       author: "owner1",
       maintainer: MAINT,

--- a/.github/workflows/pr-board-sync.md
+++ b/.github/workflows/pr-board-sync.md
@@ -113,19 +113,23 @@ merge-queued PRs.
 
 **Pick order** (Community/Bot assignee / shepherd):
 
-1. Linked-issue assignee who is in the owners team.
-2. Top **committer-signal** owner from changed files.
+1. Linked-issue assignee who is **source-internal for this repository** (member
+   of `source_internal_team`, or of a sibling `source-internal-*` team whose
+   `Scope:` includes this repo — the same criteria used for Source Internal).
+2. Top **committer-signal** owner from changed files (still gated by the owners
+   team: `pr-owners` for Community, `bot-pr-owners` for Bot).
 3. Maintainer team member (or `fallback_assignee`).
 
-The owners allowlist (`pr-owners` for Community, `bot-pr-owners` for Bot) gates
-who may be chosen as shepherd. Auto-request is that shepherd only when they are
-not the PR author, not on the ignored-reviewers list, and no real reviewer is
-already requested. A collaborator with stronger committer signal than the
-auto-requested reviewer (or the top other collaborator when nobody was
-auto-requested) may be named in the assignment comment as an optional
-additional reviewer for a human to consider, but is never `requestReviewers`'d —
-so they are not notified unless someone follows up. The comment is labeled as an
-automated notice and asks recipients not to reply.
+Linked-issue inheritance and committer-signal use different allowlists on
+purpose: an Internal person who owns the issue should shepherd the PR even when
+they are not on `pr-owners` / `bot-pr-owners`. Auto-request is that shepherd only
+when they are not the PR author, not on the ignored-reviewers list, and no real
+reviewer is already requested. A collaborator with stronger committer signal than
+the auto-requested reviewer (or the top other collaborator when nobody was
+auto-requested) may be named in the assignment comment as an optional additional
+reviewer for a human to consider, but is never `requestReviewers`'d — so they are
+not notified unless someone follows up. The comment is labeled as an automated
+notice and asks recipients not to reply.
 
 **Community PRs** also co-assign the external author (separate API call, best-effort).
 

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -7,10 +7,11 @@ name: PR Board Sync (reusable)
 #   - advances its Status (In Review / Revising / Snagged / Approved / Done)
 #     on the event-driven happy path,
 #   - backfills the assignee + auto-requested reviewer (an Internal PR's author;
-#     otherwise a linked-issue owner, else the top committer-signal owner, else
-#     the maintainer) and auto-requests that shepherd only when they are not the
-#     author / not ignored / no real reviewer already present; a higher-signal
-#     collaborator is suggested in a PR comment (no @), never auto-requested,
+#     otherwise a linked-issue assignee who is source-internal for this repo,
+#     else the top committer-signal owner, else the maintainer) and auto-requests
+#     that shepherd only when they are not the author / not ignored / no real
+#     reviewer already present; a higher-signal collaborator is suggested in a
+#     PR comment (no @), never auto-requested,
 #   - when a PR has an owner, assigns any still-unassigned linked (closing)
 #     issues to that same owner (the PR's primary assignee, not the co-assigned
 #     community author), and
@@ -154,11 +155,11 @@ on:
         type: string
         default: "bmillsNV"
       owners_team:
-        description: "org/team-slug whose members may be inherited as a Community PR's assignee from a linked issue."
+        description: "org/team-slug whose members may be chosen as a Community PR's assignee/reviewer from the committer-signal ranking (not used for linked-issue inheritance; that uses source_internal_team)."
         type: string
         default: "shader-slang/pr-owners"
       bot_owners_team:
-        description: "org/team-slug whose members may be inherited as a Bot PR's assignee from a linked issue."
+        description: "org/team-slug whose members may be chosen as a Bot PR's assignee/reviewer from the committer-signal ranking (not used for linked-issue inheritance; that uses source_internal_team)."
         type: string
         default: "shader-slang/bot-pr-owners"
       maintainer_team:
@@ -911,6 +912,19 @@ jobs:
               return x instanceof Set ? x : new Set(x || []);
             }
 
+            // Case-insensitive membership in a Set/iterable of logins. Matches
+            // isInternalLogin: a null/undefined members set means "unknown" and
+            // yields false (no linked-issue inheritance), while an empty set is
+            // a successful read of a family nobody is on.
+            function _setHasCI(members, login) {
+              if (!login || !members) return false;
+              const lower = login.toLowerCase();
+              for (const m of members) {
+                if ((m || "").toLowerCase() === lower) return true;
+              }
+              return false;
+            }
+
             // Among committersBySignal (highest first), pick the first collaborator
             // who is not the author / shepherd / auto-requested reviewer / bot and
             // who outranks the auto-requested reviewer. committersBySignal must be
@@ -998,6 +1012,13 @@ jobs:
               return body;
             }
 
+            // Pick assignee + auto-requested reviewer for a Community/Bot PR.
+            // Priority: (1) linked-issue assignee who is source-internal for this
+            // repo, (2) top committer-signal login in the owners team, (3)
+            // maintainer. `internalMembers` is the repo's effective Internal set
+            // (base source-internal team + scoped siblings); null means the
+            // roster was unreadable and linked-issue inheritance is skipped.
+            // Distinct from `owners`, which still gates committer-signal picks.
             function selectAssigneeAndReviewers(opts) {
               const {
                 issueAssignees = [],
@@ -1008,6 +1029,7 @@ jobs:
                 botAuthors = [],
               } = opts;
               const owners = _toSet(opts.owners);
+              const internalMembers = opts.internalMembers;
               const collaborators = _toSet(opts.collaborators);
               const ignoredLower = new Set([..._toSet(opts.ignoredReviewers)].map((r) => r.toLowerCase()));
               const excluded = (author || "").toLowerCase();
@@ -1015,12 +1037,13 @@ jobs:
               // Linked-issue assignees who are the PR author are skipped here; they
               // can still become shepherd via ownerCommitters if they are on the
               // owners team.
-              const issueOwnerAssignees = issueAssignees.filter(
-                (a) => owners.has(a) && a.toLowerCase() !== excluded && !a.toLowerCase().endsWith("[bot]"));
+              const issueInternalAssignees = issueAssignees.filter(
+                (a) => _setHasCI(internalMembers, a)
+                  && a.toLowerCase() !== excluded && !a.toLowerCase().endsWith("[bot]"));
               const ownerCommitters = committersBySignal.filter((c) => owners.has(c));
 
               let assignee;
-              if (issueOwnerAssignees.length) assignee = issueOwnerAssignees[0];
+              if (issueInternalAssignees.length) assignee = issueInternalAssignees[0];
               else if (ownerCommitters.length) assignee = ownerCommitters[0];
               else assignee = maintainer;
 
@@ -1477,18 +1500,18 @@ jobs:
               }
             }
 
-            // Backfill a PR's assignee + reviewers (issue-owner -> committer-signal
-            // owner -> maintainer). For Community/Bot: auto-request the shepherd
-            // only when they are not the PR author, not ignored, and no real
-            // reviewer is already present; a collaborator with stronger committer
-            // signal than that auto-requested reviewer (or the top collaborator
-            // when nobody was auto-requested) is named in a one-shot comment, not
-            // auto-requested. Internal PRs go to the author with no requested
-            // reviewer and no comment. PR assignment is idempotent: only ever
-            // touches an UNASSIGNED PR (so the comment also fires at most once).
-            // Linked-issue assignment is also idempotent: only unassigned issues
-            // are updated, including when the PR was assigned earlier or the
-            // issue was linked later.
+            // Backfill a PR's assignee + reviewers (linked-issue Internal assignee
+            // -> committer-signal owner -> maintainer). For Community/Bot:
+            // auto-request the shepherd only when they are not the PR author, not
+            // ignored, and no real reviewer is already present; a collaborator
+            // with stronger committer signal than that auto-requested reviewer (or
+            // the top collaborator when nobody was auto-requested) is named in a
+            // one-shot comment, not auto-requested. Internal PRs go to the author
+            // with no requested reviewer and no comment. PR assignment is
+            // idempotent: only ever touches an UNASSIGNED PR (so the comment also
+            // fires at most once). Linked-issue assignment is also idempotent:
+            // only unassigned issues are updated, including when the PR was
+            // assigned earlier or the issue was linked later.
             async function postAssignmentComment(number, {
               source, assignee, suggestedReviewer,
               autoRequestedReviewer, autoRequestedHasSignal,
@@ -1530,14 +1553,23 @@ jobs:
                 // Internal: the author drives; assign them, request no reviewers.
                 assignee = info.authorLogin;
               } else {
-                // Community/Bot: full committer-signal selection against the
-                // relevant owners pool, with the maintainer as the final fallback.
+                // Community/Bot: inherit a linked-issue assignee who is
+                // source-internal for this repo; else committer-signal against the
+                // relevant owners pool; maintainer is the final fallback.
                 const ownersTeam =
                   (source === process.env.SOURCE_BOT) ? BOT_OWNERS_TEAM : OWNERS_TEAM;
-                const [owners, collaborators, maintainer] = await Promise.all([
+                const [owners, collaborators, maintainer, internalMembers] = await Promise.all([
                   listTeamMembers(ownersTeam),
                   repoCollaborators(),
                   resolveMaintainer(),
+                  loadSourceInternalIndex({
+                    teamSpec: SOURCE_INTERNAL_TEAM,
+                    listOrgTeams,
+                    tryListTeamMembers,
+                    warnOnce,
+                    parseTeamScopeRepos,
+                    isSourceInternalFamilySlug,
+                  }).then((family) => internalMembersForRepo(context.repo.repo, family)),
                 ]);
                 const ranking = await computeCommitterRanking(
                   ghAdapter, `${context.repo.owner}/${context.repo.repo}`, info.authorLogin, {
@@ -1558,6 +1590,7 @@ jobs:
                     issueAssignees: info.issueAssignees,
                     committersBySignal: ranking,
                     owners,
+                    internalMembers,
                     collaborators,
                     author: info.authorLogin,
                     maintainer,

--- a/docs/maintainers/pr-review-board.md
+++ b/docs/maintainers/pr-review-board.md
@@ -28,17 +28,18 @@ sometimes a reviewer). Treat that as a starting point — change it if it's wron
   team under it), or on a `source-internal-*` team whose description lists this
   repo in `Scope: [...]` (for example `Scope: [slangpy, slang-rhi]`). The author
   is assigned and no reviewer is auto-requested; they should find one themselves.
-- **Community** — a human author who isn't Internal. A shepherd is chosen from
-  `pr-owners`, asked to review (unless they *are* the author), and a short
-  comment is posted on the PR. If someone else looks like a better reviewer
-  from recent commits on the changed files, the comment names them — without
-  `@`-mentioning or auto-requesting them.
+- **Community** — a human author who isn't Internal. A shepherd is chosen (see
+  below), asked to review (unless they *are* the author), and a short comment is
+  posted on the PR. If someone else looks like a better reviewer from recent
+  commits on the changed files, the comment names them — without `@`-mentioning
+  or auto-requesting them.
 - **Bot** — same shepherd / review / comment behavior as Community, but the
-  allowlist is `bot-pr-owners` instead of `pr-owners`.
+  committer-signal allowlist is `bot-pr-owners` instead of `pr-owners`.
 
-**How the Community/Bot shepherd is chosen:** linked-issue assignee on the
-owners team, else whoever on that team has the strongest recent commit signal
-on the PR's files, else the maintainer fallback.
+**How the Community/Bot shepherd is chosen:** linked-issue assignee who is
+source-internal for this repo (same criteria as Source Internal above), else
+whoever on the owners team (`pr-owners` / `bot-pr-owners`) has the strongest
+recent commit signal on the PR's files, else the maintainer fallback.
 
 If the team rosters can't be read, Source and assignee stay blank and the
 nightly sweep retries. Internal membership is org-wide (with optional per-repo


### PR DESCRIPTION
## Motivation

For Community/Bot PRs, board sync preferred a linked-issue assignee only when
that person was on `pr-owners` / `bot-pr-owners`. Someone who is source-internal
for the repo (and already owns the issue) could still be skipped, and the PR
would go to a committer-signal owner or the maintainer instead.

Consider an issue assigned to an Internal contributor who is not on
`pr-owners`. A Community/Bot PR that closes that issue should land on their
plate, matching the Source Internal membership rules already used for author
classification.

## Proposed solution

Keep the Community/Bot pick order, but change step 1's allowlist:

1. Linked-issue assignee who is **source-internal for this repository** (base
   `source-internal` team, or a `source-internal-*` sibling whose `Scope:`
   includes this repo) — same criteria as Source Internal.
2. Top committer-signal login still gated by `pr-owners` / `bot-pr-owners`.
3. Maintainer / `fallback_assignee`.

Internal PRs are unchanged (author assigned). Committer-signal and reviewer
auto-request behavior are unchanged aside from who step 1 can select.

## Change summary

| Area | Change |
| --- | --- |
| `pr-board-sync.yml` `selectAssigneeAndReviewers` | Filter linked-issue assignees with `internalMembers` (case-insensitive), not `owners`. |
| `pr-board-sync.yml` `reconcileAssignment` | Load `internalMembersForRepo` via the existing source-internal index and pass it in. |
| `pr-assign.test.js` | Cover Internal-not-on-owners win, non-Internal skip, unknown roster, case-insensitivity. |
| `pr-board-sync.md`, `pr-review-board.md`, input descriptions | Document the split allowlists. |

## Concepts and vocabulary

- **Source-internal for a repo** — membership in `shader-slang/source-internal` (covers every repo) or in a sibling `source-internal-*` team whose description has `Scope: [repo, ...]` listing this repository's short name.
- **Owners team** — `pr-owners` (Community) / `bot-pr-owners` (Bot); still the allowlist for committer-signal shepherd picks only.
- **Linked-issue inheritance** — step 1 of Community/Bot assignee selection, reading `closingIssuesReferences` assignees on an unassigned PR.

## Process report

**Why change linked-issue eligibility and not committer-signal.** The bug report
is specifically about issue owners who are Internal for the repo but absent from
`pr-owners`. Committer-signal already means "recent work on these files among the
owners pool"; widening that pool to all Internal members would change shepherd
selection for PRs with no linked issue, which is out of scope. The input shape
(linked-issue assignee logins) is correct and intentional; only the allowlist
predicate was wrong for the product rule we want.

**Why reuse `internalMembersForRepo` rather than a new team.** Source
classification already builds the effective Internal set for this repo from the
source-internal family. Reusing that set keeps "who is Internal here" as one
source of truth and avoids a third parallel roster (`pr-owners` vs
`source-internal` vs a new inheritance team).

**Unknown roster.** When the source-internal index cannot be read,
`internalMembers` is null and linked-issue inheritance is skipped (same as an
empty eligible set), falling through to committer-signal / maintainer. That
matches treating unknown membership as "do not guess," consistent with leaving
Source unset when rosters are unreadable.

**Tests.** `node .github/scripts/pr-assign.test.js` (and classify/signal suites)
pass locally.

## Test plan

- [x] `node .github/scripts/pr-assign.test.js`
- [x] `node .github/scripts/pr-classify.test.js`
- [x] `node .github/scripts/pr-signal.test.js`
- [ ] After merge: open/reopen an unassigned Community or Bot PR linked to an
      issue assigned to a source-internal person who is **not** on `pr-owners` /
      `bot-pr-owners`, and confirm they become the PR shepherd.