### PR TITLE
Fix Windows flake in SLANG_TEST_SERVER_GARBLE_ON_REQUEST test-server hook

### DIFF
--- a/source/core/slang-http.cpp
+++ b/source/core/slang-http.cpp
@@ -431,4 +431,9 @@ SlangResult HTTPPacketConnection::write(const void* content, size_t sizeInBytes)
     return SLANG_OK;
 }
 
+SlangResult HTTPPacketConnection::writeRaw(const void* bytes, size_t sizeInBytes)
+{
+    return m_writeStream->write(bytes, sizeInBytes);
+}
+
 } // namespace Slang

--- a/source/core/slang-http.h
+++ b/source/core/slang-http.h
@@ -148,10 +148,15 @@ public:
     /// Write. Will potentially block if write stream is blocking.
     SlangResult write(const void* content, size_t sizeInBytes);
 
-    /// Write bytes directly to the backing stream without HTTP framing.
+    /// Write `sizeInBytes` bytes from `bytes` directly to the backing stream, with no
+    /// Content-Length header and no other framing added -- unlike write(), whose `content`
+    /// argument is exactly the framed packet's payload.
     ///
-    /// This bypasses the packet protocol and should only be used by tests that need to provoke
-    /// malformed input at the peer, for example to drive ReadError::InvalidHeader.
+    /// This bypasses the packet protocol and exists only for tests that need to provoke
+    /// malformed input at the peer, for example to drive ReadError::InvalidHeader by writing
+    /// bytes that do not parse as an HTTP header. Returns whatever the backing stream's write()
+    /// returns; on failure the connection should be treated as unusable, the same as a failed
+    /// write().
     SlangResult writeRaw(const void* bytes, size_t sizeInBytes);
 
     /// Blocks until some result - a packet, closure, or some kind of error or timeout.

--- a/source/core/slang-http.h
+++ b/source/core/slang-http.h
@@ -148,6 +148,12 @@ public:
     /// Write. Will potentially block if write stream is blocking.
     SlangResult write(const void* content, size_t sizeInBytes);
 
+    /// Write bytes directly to the backing stream without HTTP framing.
+    ///
+    /// This bypasses the packet protocol and should only be used by tests that need to provoke
+    /// malformed input at the peer, for example to drive ReadError::InvalidHeader.
+    SlangResult writeRaw(const void* bytes, size_t sizeInBytes);
+
     /// Blocks until some result - a packet, closure, or some kind of error or timeout.
     /// TimeOut of -1 means no timeout.
     SlangResult waitForResult(Int timeOutInMs = -1);

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -802,15 +802,14 @@ SlangResult TestServer::execute()
 #endif
         }
 
-        // Written to stdout directly rather than through m_connection, which would frame it
-        // correctly -- the one thing this must not do. The flush is load-bearing: it puts
-        // these bytes ahead of the reply the connection writes next, which is what makes the
-        // client read them as the start of that reply.
+        // Written through the same transport stream as the real reply, but without HTTP
+        // framing. Mixing stdio with the transport handle can let platform buffering change
+        // the bytes on the wire; this needs to be a malformed header, not a buffering test.
         if (garbleOnRequest && servedCount == garbleOnRequest - 1)
         {
             const char garbage[] = "this-is-not-a-jsonrpc-header\r\n\r\n";
-            fwrite(garbage, 1, sizeof(garbage) - 1, stdout);
-            fflush(stdout);
+            SLANG_RETURN_ON_FAIL(
+                m_connection->getUnderlyingConnection()->writeRaw(garbage, sizeof(garbage) - 1));
         }
 
         // Failure doesn't make the execution terminate

--- a/tools/test-server/test-server-main.cpp
+++ b/tools/test-server/test-server-main.cpp
@@ -802,9 +802,19 @@ SlangResult TestServer::execute()
 #endif
         }
 
-        // Written through the same transport stream as the real reply, but without HTTP
-        // framing. Mixing stdio with the transport handle can let platform buffering change
-        // the bytes on the wire; this needs to be a malformed header, not a buffering test.
+        // Written through writeRaw() on the same transport stream the framed reply uses next,
+        // rather than through a separate fwrite/fflush(stdout). Mixing a C-stdio write with the
+        // transport's own Stream (WinPipeStream/UnixPipeStream) does not guarantee the two end
+        // up ordered on the wire the way this hook needs -- the failure this line exists to
+        // reproduce is a malformed header at the client, not a race with platform buffering.
+        // Going through the same Stream as _executeSingle()'s reply below keeps both writes on
+        // one path, so the garbage is always ahead of the reply in write order.
+        //
+        // Checked with SLANG_RETURN_ON_FAIL rather than ignored: a failed writeRaw() means the
+        // transport is already broken (e.g. the peer closed its read end), in which case
+        // _executeSingle()'s own write below would fail identically. Falling through to attempt
+        // it anyway would not serve the request any more successfully; it would just replace a
+        // clear write failure here with a second, redundant one.
         if (garbleOnRequest && servedCount == garbleOnRequest - 1)
         {
             const char garbage[] = "this-is-not-a-jsonrpc-header\r\n\r\n";


### PR DESCRIPTION
## 1. Motivation

Two Windows debug GPU merge-queue jobs (VK and DX) recently failed on the same tests:
`slang-unit-test-tool/testServerProtocolErrorInnocentTestIsNotBlamed.internal` and
`testServerProtocolErrorPersistentGarbleFailsTheRun.internal`. Both are new tests added by
#12573, which introduced a `SLANG_TEST_SERVER_GARBLE_ON_REQUEST` fault-injection hook in
`test-server-main.cpp` to make the test server write an unparseable reply on the Nth request.

The CI logs did not show the expected `ProtocolError`. Instead they showed a plain timeout:

```
test server did not answer in waitForResult on request #4 of this connection
(it had answered 3): no reply within the timeout, server process still running
```

`TimedOut` is not retryable (`isRetryable` in `slang-test-main.cpp` only retries `Lost`,
`StartFailed`, and `ProtocolError`), so the test failed outright on the first attempt instead of
exercising the recovery path the new tests exist to verify.

**Confirmed root cause (see #12598, which lands independently and reaches the same mechanism):**
the hook wrote its garbage bytes through the C runtime's `stdout` `FILE*`:

```cpp
const char garbage[] = "this-is-not-a-jsonrpc-header\r\n\r\n";
fwrite(garbage, 1, sizeof(garbage) - 1, stdout);
fflush(stdout);
```

On Windows, the CRT's `stdout` defaults to **text mode**, which rewrites every `\n` (`0x0A`) to
`\r\n` (`0x0D 0x0A`) on write. The hook's terminator `\r\n\r\n` (bytes `0D 0A 0D 0A`) is therefore
emitted on the wire as `0D 0D 0A 0D 0D 0A` -- which no longer contains the `\r\n\r\n` sequence
`HTTPHeader::findHeaderEnd` (`source/core/slang-http.cpp:52`) scans for. The client never finds a
header terminator, so it never reaches the parse-failure path that classifies the reply as
`ProtocolError`; it just keeps polling until the outer RPC timeout fires. This happens only on
Windows because the real reply is written via a completely different channel --
`HTTPPacketConnection::write` -> the test server's own `Stream` (`WinPipeStream` calling
`::WriteFile` directly on Windows, `UnixPipeStream` on Unix) -- which is binary and untouched by
CRT text-mode translation. The garble hook is the only thing in the test server that writes to
`stdout` through the CRT rather than through that `Stream`.

## 2. Proposed solution

#12598 fixes this by putting the CRT's `stdout` into binary mode at process startup
(`_setmode(_fileno(stdout), _O_BINARY)`), so the existing `fwrite`/`fflush` call stops being
translated.

This PR takes a different angle on the same root cause: instead of correcting the CRT stream's
mode, it stops writing the garble bytes through the CRT at all, and routes them through the same
`Stream` the real reply already uses. A new narrow `HTTPPacketConnection::writeRaw()` forwards
straight to `m_writeStream->write(...)` with no HTTP framing added:

```cpp
SlangResult HTTPPacketConnection::writeRaw(const void* bytes, size_t sizeInBytes)
{
    return m_writeStream->write(bytes, sizeInBytes);
}
```

The hook now calls `m_connection->getUnderlyingConnection()->writeRaw(garbage, ...)`. Both the
garbage and the real reply that follows go out through the same `Stream`/handle, in the same
order, with no CRT stdio layer involved anywhere in the path -- so there is no text-mode
translation to disable in the first place, and no similar mismatch can be reintroduced later by
a different writer reaching for `stdout` instead of the connection.

I'd defer to a maintainer on which of the two is preferred as the long-term fix; they are not
mutually exclusive; see the "Relationship to #12598" note below.

## 3. Change summary

| File | Change |
| --- | --- |
| `source/core/slang-http.h` | Declares `HTTPPacketConnection::writeRaw()`, documented as a test-only escape hatch that bypasses HTTP framing, with its failure contract spelled out |
| `source/core/slang-http.cpp` | Implements `writeRaw()` as a direct forward to `m_writeStream->write(...)` |
| `tools/test-server/test-server-main.cpp` | `SLANG_TEST_SERVER_GARBLE_ON_REQUEST` now writes through `writeRaw()` on the real transport connection instead of `fwrite`/`fflush(stdout)`; comment explains both the channel-split rationale and why the write is now checked with `SLANG_RETURN_ON_FAIL` |

No test files changed -- the existing `testServerProtocolErrorInnocentTestIsNotBlamed` and
`testServerProtocolErrorPersistentGarbleFailsTheRun` unit tests in
`unit-test-test-server-loss.cpp` (from #12573) assert on the classification outcome
(`ProtocolError` recovery vs. persistent-garble failure), which is unchanged by this fix.

## 4. Concepts and vocabulary

- **`RPCAttemptOutcome`** -- how one RPC attempt ended (`Ok`, `Lost`, `StartFailed`, `TimedOut`,
  `ProtocolError`, `SendFailed`), introduced by #12471 and extended by #12573.
- **`HTTPPacketConnection`** -- the packet-framing layer in `slang-http.cpp` that reads/writes
  `Content-Length`-delimited HTTP-style packets over an arbitrary `Stream`; `writeRaw()` is a
  narrow bypass of its normal framed `write()`.
- **CRT text mode** -- the Windows C runtime's default `stdout` mode, which silently rewrites
  `\n` to `\r\n` on write. `#12598` disables it; this PR avoids the CRT stream for this write
  entirely.

## 5. Process report

**Why this is the right layer.** The classification logic in `slang-test-main.cpp` and the
header/JSON parsing in `slang-http.cpp`/`slang-json-rpc-connection.cpp` already correctly map a
malformed header to `ReadError::InvalidHeader` -> `ReadError::Protocol` ->
`RPCAttemptOutcome::ProtocolError` (verified by re-running the two garble unit tests locally, 5/5
consecutive passes with this change). The defect is entirely in how the fault-injection hook
produced its malformed bytes, not in how the client interprets them, so the fix is scoped to the
hook and one small, clearly-documented addition to the transport's write surface.

**Input-shape check.** The "malformed header bytes on the wire" shape is intentional test input
(that's the whole point of the hook, mirroring the real-world corruption described in #12534) --
it is not an accidental representation that needs eliminating. What was wrong is *how* those
bytes reached the wire: through a code path (the CRT `stdout` `FILE*`) that the rest of the
transport never uses and that silently transforms bytes on Windows, rather than through the
`Stream` abstraction that owns write ordering, flushing, and byte-exactness for every other
reply. Routing the injected bytes through that same abstraction removes the platform-dependent
transformation without changing the shape of the fault being tested, and without depending on a
process-wide CRT mode setting staying correct.

**Why a new method instead of reusing `write()`.** `HTTPPacketConnection::write()` always emits a
correct `Content-Length` header before its content -- it cannot produce an unframed, unparseable
header, which is the specific shape this test needs. `writeRaw()` is deliberately narrow (no
framing logic at all) and documented as test-fault-injection-only so it isn't mistaken for a
general-purpose write API.

**Why `SLANG_RETURN_ON_FAIL` on the garble write, unlike the original fire-and-forget
`fwrite`.** A failed `writeRaw()` means the transport `Stream` is already broken (e.g. the peer
closed its read end). `_executeSingle()`'s own write immediately below would fail identically in
that case, so continuing past a `writeRaw()` failure would not serve the request any more
successfully -- it would just replace a clear, attributable write failure with a second,
redundant one on the same broken stream.

**Relationship to #12598.** Both PRs trace the same underlying mechanism (a Windows-only CRT
text-mode transform corrupting the garble hook's bytes) but fix it at different points: #12598 at
the CRT stream-mode boundary, this PR by removing the CRT stdio path from the hook entirely. They
are not mutually exclusive -- #12598's binary-mode fix is harmless if this PR also lands, since
this PR's `writeRaw()` never touches CRT `stdout`. If only one should land, I'd lean toward this
PR's approach since it removes the CRT-stdio/transport-stream split as a class, rather than
correcting one property (text mode) of one call site; but I defer to a maintainer's judgment on
which is preferred, or whether to keep both as belt-and-suspenders.

**Verification.** Built `slangc`, `slang-test`, `test-server`, and `libslang-unit-test-tool` in
Debug on macOS. `slang-unit-test-tool/testServerProtocolErrorInnocentTestIsNotBlamed` and
`testServerProtocolErrorPersistentGarbleFailsTheRun` pass, 5/5 repeated runs. Sibling
`testServerLoss*` tests (7/7 combined) unaffected. `formatting.sh --check-only` clean.

This could not be reproduced locally on macOS (the original failure was Windows-only), so
Windows CI on this PR is the actual confirmation; #12598's own Windows-debug CI run and babysitter
occurrence tracking are independent evidence for the shared root cause.

Related: #12573 (introduced the hook and the two unit tests this fixes), #12534 (the original
malformed-reply corruption this hook simulates), #12598 (fixes the same root cause via CRT binary
mode instead of avoiding the CRT path).