### PR TITLE
Fetch the latest GitHub Actions runner version at boot instead of a pinned constant

### DIFF
--- a/extras/scaler/internal/gcp/startup.ps1
+++ b/extras/scaler/internal/gcp/startup.ps1
@@ -117,10 +117,22 @@ if (-not $latestRunnerVersion) {
 }
 Write-Log "Latest Actions runner version: $latestRunnerVersion"
 
+# GitHub started publishing a "digest" field on every release asset in June
+# 2026 (https://github.blog/changelog/2025-06-03-releases-now-expose-digests-for-release-assets/),
+# so tracking "latest" does not have to give up checksum verification —
+# read it from the same release object already fetched above instead of
+# issuing a second request.
+$runnerAssetName = "actions-runner-win-x64-${latestRunnerVersion}.zip"
+$runnerAsset = $latestRelease.assets | Where-Object { $_.name -eq $runnerAssetName } | Select-Object -First 1
+if (-not $runnerAsset -or -not $runnerAsset.digest) {
+    Stop-WithFailure "Failed to determine SHA-256 digest for ${runnerAssetName} from GitHub API"
+}
+$expectedHash = ($runnerAsset.digest -replace '^sha256:', '').ToLowerInvariant()
+
 if ($installedRunnerVersion -ne $latestRunnerVersion) {
     Write-Log "Updating Actions runner to v${latestRunnerVersion}..."
     $runnerArchive = Join-Path $env:TEMP ("actions-runner-{0}.zip" -f ([guid]::NewGuid().ToString("N")))
-    $runnerUrl = "https://github.com/actions/runner/releases/download/v${latestRunnerVersion}/actions-runner-win-x64-${latestRunnerVersion}.zip"
+    $runnerUrl = "https://github.com/actions/runner/releases/download/v${latestRunnerVersion}/${runnerAssetName}"
 
     # Retry the download a few times to tolerate transient network errors,
     # mirroring the curl --retry 3 behaviour on the Linux side.
@@ -143,10 +155,17 @@ if ($installedRunnerVersion -ne $latestRunnerVersion) {
         Stop-WithFailure "Failed to download Actions runner v${latestRunnerVersion} after ${downloadAttempts} attempts" $runnerArchive
     }
 
-    # No pre-known checksum to verify against when tracking "latest" (GitHub's
-    # release API does not publish one) — integrity relies on TLS plus
-    # GitHub's own asset hosting, same as the extraction step immediately
-    # below trusting the archive it just downloaded over HTTPS.
+    try {
+        $actualHash = (Get-FileHash -Path $runnerArchive -Algorithm SHA256).Hash.ToLowerInvariant()
+    }
+    catch {
+        Stop-WithFailure "Failed to hash Actions runner v${latestRunnerVersion}: $_" $runnerArchive
+    }
+
+    if ($actualHash -ne $expectedHash) {
+        Stop-WithFailure "Actions runner v${latestRunnerVersion} checksum verification failed (expected ${expectedHash}, got ${actualHash})" $runnerArchive
+    }
+
     try {
         Expand-Archive -Path $runnerArchive -DestinationPath $runnerDir -Force
     }

--- a/extras/scaler/internal/gcp/startup.ps1
+++ b/extras/scaler/internal/gcp/startup.ps1
@@ -118,7 +118,7 @@ if (-not $latestRunnerVersion) {
 Write-Log "Latest Actions runner version: $latestRunnerVersion"
 
 # GitHub started publishing a "digest" field on every release asset in June
-# 2026 (https://github.blog/changelog/2025-06-03-releases-now-expose-digests-for-release-assets/),
+# 2025 (https://github.blog/changelog/2025-06-03-releases-now-expose-digests-for-release-assets/),
 # so tracking "latest" does not have to give up checksum verification —
 # read it from the same release object already fetched above instead of
 # issuing a second request.

--- a/extras/scaler/internal/gcp/startup.ps1
+++ b/extras/scaler/internal/gcp/startup.ps1
@@ -3,7 +3,7 @@
 # This script runs when a new ephemeral Windows GPU VM boots. It:
 # 1. Removes any pre-existing runner service from the base image
 # 2. Updates the preinstalled GitHub Actions runner if its version differs
-#    from $RunnerVersion (no-op when the image is already up to date)
+#    from GitHub's latest release (no-op when the image is already current)
 # 3. Reads the JIT (just-in-time) runner config from GCP instance metadata
 # 4. Configures the GitHub Actions runner with the JIT config
 # 5. Runs the runner (executes one job, then exits)
@@ -16,14 +16,6 @@ $ErrorActionPreference = "Stop"
 
 $runnerDir = "C:\actions-runner"
 $logFile = "C:\actions-runner\startup.log"
-
-# When this version differs from the runner binary baked into the GCP image,
-# the script downloads and extracts the matching release before registration.
-# Bumping this constant + redeploying the scaler is enough to roll out a new
-# runner version without rebuilding the GCP image. Image rebakes are an
-# optimization to skip the per-boot download cost.
-$RunnerVersion = "2.334.0"
-$RunnerSha256 = "a0c896f3acf37841cc17f392a38111d39501e56f2990434567f027ee89cf8981"
 
 function Write-Log {
     param([string]$Message)
@@ -97,18 +89,38 @@ catch {
 }
 
 # Step 0.5: Update the runner binary if the image has a stale version.
-# When the baked binary already matches $RunnerVersion this is a sub-second
-# version-check no-op; only mismatched versions pay the download cost.
+# When the baked binary already matches GitHub's latest release this is a
+# sub-second version-check no-op; only mismatched versions pay the download
+# cost.
 $installedRunnerVersion = Get-InstalledRunnerVersion
 if (-not $installedRunnerVersion) {
     $installedRunnerVersion = "unknown"
 }
 Write-Log "Current Actions runner version: $installedRunnerVersion"
 
-if ($installedRunnerVersion -ne $RunnerVersion) {
-    Write-Log "Updating Actions runner to v${RunnerVersion}..."
+# Ask GitHub for the latest release instead of comparing against a hardcoded
+# pin. A hardcoded $RunnerVersion constant previously went stale twice
+# (2026-04-29, 2026-08-11): GitHub deprecates old runner binaries and rejects
+# their registration attempts, so every VM booted with the stale pin baked in
+# died before it could pick up a job, and someone had to notice the outage
+# and bump the constant by hand. Querying "latest" removes that manual step;
+# every boot self-heals against whatever GitHub currently accepts.
+try {
+    $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/actions/runner/releases/latest" -UseBasicParsing -TimeoutSec 30
+    $latestRunnerVersion = $latestRelease.tag_name.TrimStart("v")
+}
+catch {
+    Stop-WithFailure "Failed to determine latest Actions runner version from GitHub API: $_"
+}
+if (-not $latestRunnerVersion) {
+    Stop-WithFailure "Failed to determine latest Actions runner version from GitHub API"
+}
+Write-Log "Latest Actions runner version: $latestRunnerVersion"
+
+if ($installedRunnerVersion -ne $latestRunnerVersion) {
+    Write-Log "Updating Actions runner to v${latestRunnerVersion}..."
     $runnerArchive = Join-Path $env:TEMP ("actions-runner-{0}.zip" -f ([guid]::NewGuid().ToString("N")))
-    $runnerUrl = "https://github.com/actions/runner/releases/download/v${RunnerVersion}/actions-runner-win-x64-${RunnerVersion}.zip"
+    $runnerUrl = "https://github.com/actions/runner/releases/download/v${latestRunnerVersion}/actions-runner-win-x64-${latestRunnerVersion}.zip"
 
     # Retry the download a few times to tolerate transient network errors,
     # mirroring the curl --retry 3 behaviour on the Linux side.
@@ -128,34 +140,26 @@ if ($installedRunnerVersion -ne $RunnerVersion) {
         }
     }
     if (-not $downloadOk) {
-        Stop-WithFailure "Failed to download Actions runner v${RunnerVersion} after ${downloadAttempts} attempts" $runnerArchive
+        Stop-WithFailure "Failed to download Actions runner v${latestRunnerVersion} after ${downloadAttempts} attempts" $runnerArchive
     }
 
-    try {
-        $actualHash = (Get-FileHash -Path $runnerArchive -Algorithm SHA256).Hash.ToLowerInvariant()
-    }
-    catch {
-        Stop-WithFailure "Failed to hash Actions runner v${RunnerVersion}: $_" $runnerArchive
-    }
-
-    $expectedHash = $RunnerSha256.ToLowerInvariant()
-    if ($actualHash -ne $expectedHash) {
-        Stop-WithFailure "Actions runner v${RunnerVersion} checksum verification failed (expected ${RunnerSha256}, got ${actualHash})" $runnerArchive
-    }
-
+    # No pre-known checksum to verify against when tracking "latest" (GitHub's
+    # release API does not publish one) — integrity relies on TLS plus
+    # GitHub's own asset hosting, same as the extraction step immediately
+    # below trusting the archive it just downloaded over HTTPS.
     try {
         Expand-Archive -Path $runnerArchive -DestinationPath $runnerDir -Force
     }
     catch {
-        Stop-WithFailure "Failed to extract Actions runner v${RunnerVersion}: $_" $runnerArchive
+        Stop-WithFailure "Failed to extract Actions runner v${latestRunnerVersion}: $_" $runnerArchive
     }
 
     Remove-Item $runnerArchive -Force -ErrorAction SilentlyContinue
 
     $updatedRunnerVersion = Get-InstalledRunnerVersion
     Write-Log "Actions runner version after update: $(if ($updatedRunnerVersion) { $updatedRunnerVersion } else { 'unknown' })"
-    if ($updatedRunnerVersion -ne $RunnerVersion) {
-        Stop-WithFailure "Runner version mismatch after update (expected ${RunnerVersion}, got $(if ($updatedRunnerVersion) { $updatedRunnerVersion } else { 'unknown' }))"
+    if ($updatedRunnerVersion -ne $latestRunnerVersion) {
+        Stop-WithFailure "Runner version mismatch after update (expected ${latestRunnerVersion}, got $(if ($updatedRunnerVersion) { $updatedRunnerVersion } else { 'unknown' }))"
     }
 }
 

--- a/extras/scaler/internal/gcp/startup.sh
+++ b/extras/scaler/internal/gcp/startup.sh
@@ -14,9 +14,6 @@
 
 set -euo pipefail
 
-RUNNER_VERSION="2.334.0"
-RUNNER_SHA256="048024cd2c848eb6f14d5646d56c13a4def2ae7ee3ad12122bee960c56f3d271"
-
 # Defense in depth: wipe stray actions-runner installs that may be baked into
 # the base image under user accounts other than the canonical "runner" user.
 # A May 2026 SM80Plus outage was caused by /home/<engineer>/actions-runner/
@@ -133,35 +130,50 @@ if [ -z "$current_runner_version" ]; then
 fi
 log "Current Actions runner version: $current_runner_version"
 
-if [ "$current_runner_version" != "$RUNNER_VERSION" ]; then
-  log "Updating Actions runner to v${RUNNER_VERSION}..."
+# Ask GitHub for the latest release instead of comparing against a hardcoded
+# pin. A hardcoded RUNNER_VERSION constant previously went stale twice
+# (2026-04-29, 2026-08-11): GitHub deprecates old runner binaries and rejects
+# their registration attempts, so every VM booted with the stale pin baked in
+# died before it could pick up a job, and someone had to notice the outage
+# and bump the constant by hand. Querying "latest" removes that manual step;
+# every boot self-heals against whatever GitHub currently accepts.
+latest_runner_version="$(curl -fsSL --retry 3 --connect-timeout 10 --max-time 30 \
+  https://api.github.com/repos/actions/runner/releases/latest |
+  grep -o '"tag_name": *"v[^"]*"' | head -n 1 | sed -E 's/.*"v([^"]*)"/\1/')"
+if [ -z "$latest_runner_version" ]; then
+  fail_update_and_shutdown "Failed to determine latest Actions runner version from GitHub API"
+fi
+log "Latest Actions runner version: $latest_runner_version"
+
+if [ "$current_runner_version" != "$latest_runner_version" ]; then
+  log "Updating Actions runner to v${latest_runner_version}..."
   if ! runner_archive="$(mktemp /tmp/actions-runner.XXXXXX.tar.gz)"; then
     fail_update_and_shutdown "Failed to create temporary Actions runner archive"
   fi
-  runner_url="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+  runner_url="https://github.com/actions/runner/releases/download/v${latest_runner_version}/actions-runner-linux-x64-${latest_runner_version}.tar.gz"
 
   if ! curl -fsSL --retry 3 --connect-timeout 10 --max-time 120 "$runner_url" -o "$runner_archive"; then
-    fail_update_and_shutdown "Failed to download Actions runner v${RUNNER_VERSION}"
+    fail_update_and_shutdown "Failed to download Actions runner v${latest_runner_version}"
   fi
 
-  if ! printf '%s  %s\n' "$RUNNER_SHA256" "$runner_archive" | sha256sum -c - >/dev/null 2>&1; then
-    fail_update_and_shutdown "Actions runner v${RUNNER_VERSION} checksum verification failed"
-  fi
-
+  # No pre-known checksum to verify against when tracking "latest" (GitHub's
+  # release API does not publish one) — integrity relies on TLS plus
+  # GitHub's own asset hosting, same as the extraction step immediately
+  # below trusting the archive it just downloaded over HTTPS.
   if ! chown "$RUNNER_USER":"$RUNNER_USER" "$runner_archive"; then
-    fail_update_and_shutdown "Failed to change owner for Actions runner v${RUNNER_VERSION} archive"
+    fail_update_and_shutdown "Failed to change owner for Actions runner v${latest_runner_version} archive"
   fi
 
   if ! sudo -u "$RUNNER_USER" tar xzf "$runner_archive" -C "$RUNNER_DIR"; then
-    fail_update_and_shutdown "Failed to extract Actions runner v${RUNNER_VERSION}"
+    fail_update_and_shutdown "Failed to extract Actions runner v${latest_runner_version}"
   fi
   rm -f "$runner_archive" || true
   runner_archive=""
 
   updated_runner_version="$(runner_version || true)"
   log "Actions runner version after update: ${updated_runner_version:-unknown}"
-  if [ "${updated_runner_version:-}" != "$RUNNER_VERSION" ]; then
-    fail_update_and_shutdown "Runner version mismatch after update (expected ${RUNNER_VERSION}, got ${updated_runner_version:-unknown})"
+  if [ "${updated_runner_version:-}" != "$latest_runner_version" ]; then
+    fail_update_and_shutdown "Runner version mismatch after update (expected ${latest_runner_version}, got ${updated_runner_version:-unknown})"
   fi
 fi
 

--- a/extras/scaler/internal/gcp/startup.sh
+++ b/extras/scaler/internal/gcp/startup.sh
@@ -137,29 +137,56 @@ log "Current Actions runner version: $current_runner_version"
 # died before it could pick up a job, and someone had to notice the outage
 # and bump the constant by hand. Querying "latest" removes that manual step;
 # every boot self-heals against whatever GitHub currently accepts.
-latest_runner_version="$(curl -fsSL --retry 3 --connect-timeout 10 --max-time 30 \
-  https://api.github.com/repos/actions/runner/releases/latest |
-  grep -o '"tag_name": *"v[^"]*"' | head -n 1 | sed -E 's/.*"v([^"]*)"/\1/')"
+#
+# Fetch the release JSON once and reuse it for both the version and the
+# per-asset SHA-256 digest, rather than issuing a second request. GitHub
+# started publishing a "digest" field on every release asset in June 2026
+# (https://github.blog/changelog/2025-06-03-releases-now-expose-digests-for-release-assets/),
+# so tracking "latest" does not have to give up checksum verification.
+if ! release_json="$(mktemp /tmp/runner-release.XXXXXX.json)"; then
+  fail_update_and_shutdown "Failed to create temporary release metadata file"
+fi
+if ! curl -fsSL --retry 3 --connect-timeout 10 --max-time 30 \
+  https://api.github.com/repos/actions/runner/releases/latest -o "$release_json"; then
+  fail_update_and_shutdown "Failed to fetch latest Actions runner release metadata from GitHub API"
+fi
+
+latest_runner_version="$(grep -o '"tag_name": *"v[^"]*"' "$release_json" | head -n 1 | sed -E 's/.*"v([^"]*)"/\1/')"
 if [ -z "$latest_runner_version" ]; then
   fail_update_and_shutdown "Failed to determine latest Actions runner version from GitHub API"
 fi
 log "Latest Actions runner version: $latest_runner_version"
+
+# The asset list is a flat array of objects with "name" before "digest" in
+# GitHub's field order, so scanning forward from the matching asset's "name"
+# line to the next "digest" line reliably finds that asset's own digest
+# rather than a different asset's, without needing a JSON parser.
+runner_asset_name="actions-runner-linux-x64-${latest_runner_version}.tar.gz"
+latest_runner_digest="$(awk -v name="\"name\": \"${runner_asset_name}\"" '
+  index($0, name) { found=1 }
+  found && /"digest":/ { print; exit }
+' "$release_json" | sed -E 's/.*"digest": *"sha256:([a-f0-9]+)".*/\1/')"
+rm -f "$release_json"
+
+if [ -z "$latest_runner_digest" ]; then
+  fail_update_and_shutdown "Failed to determine SHA-256 digest for ${runner_asset_name} from GitHub API"
+fi
 
 if [ "$current_runner_version" != "$latest_runner_version" ]; then
   log "Updating Actions runner to v${latest_runner_version}..."
   if ! runner_archive="$(mktemp /tmp/actions-runner.XXXXXX.tar.gz)"; then
     fail_update_and_shutdown "Failed to create temporary Actions runner archive"
   fi
-  runner_url="https://github.com/actions/runner/releases/download/v${latest_runner_version}/actions-runner-linux-x64-${latest_runner_version}.tar.gz"
+  runner_url="https://github.com/actions/runner/releases/download/v${latest_runner_version}/${runner_asset_name}"
 
   if ! curl -fsSL --retry 3 --connect-timeout 10 --max-time 120 "$runner_url" -o "$runner_archive"; then
     fail_update_and_shutdown "Failed to download Actions runner v${latest_runner_version}"
   fi
 
-  # No pre-known checksum to verify against when tracking "latest" (GitHub's
-  # release API does not publish one) — integrity relies on TLS plus
-  # GitHub's own asset hosting, same as the extraction step immediately
-  # below trusting the archive it just downloaded over HTTPS.
+  if ! printf '%s  %s\n' "$latest_runner_digest" "$runner_archive" | sha256sum -c - >/dev/null 2>&1; then
+    fail_update_and_shutdown "Actions runner v${latest_runner_version} checksum verification failed"
+  fi
+
   if ! chown "$RUNNER_USER":"$RUNNER_USER" "$runner_archive"; then
     fail_update_and_shutdown "Failed to change owner for Actions runner v${latest_runner_version} archive"
   fi

--- a/extras/scaler/internal/gcp/startup.sh
+++ b/extras/scaler/internal/gcp/startup.sh
@@ -140,7 +140,7 @@ log "Current Actions runner version: $current_runner_version"
 #
 # Fetch the release JSON once and reuse it for both the version and the
 # per-asset SHA-256 digest, rather than issuing a second request. GitHub
-# started publishing a "digest" field on every release asset in June 2026
+# started publishing a "digest" field on every release asset in June 2025
 # (https://github.blog/changelog/2025-06-03-releases-now-expose-digests-for-release-assets/),
 # so tracking "latest" does not have to give up checksum verification.
 if ! release_json="$(mktemp /tmp/runner-release.XXXXXX.json)"; then


### PR DESCRIPTION
## Motivation

Both the Linux (`startup.sh`) and Windows (`startup.ps1`) GCP runner boot scripts self-update the GitHub Actions runner binary before registering with GitHub. Until this change, the "current" version to update to was a hardcoded constant (`RUNNER_VERSION` / `$RunnerVersion`) baked into the script.

That constant went stale twice:
- **2026-04-29**: `v2.331.0` was deprecated by GitHub ([actions/runner#4392](https://github.com/actions/runner/issues/4392)); fixed by adding the version-pin self-update mechanism itself.
- **2026-08-11**: `v2.334.0` was deprecated (GitHub's minimum accepted version moved to `v2.336.0`). All Linux GPU runners went offline — VMs booted, the runner binary tried to register with a version GitHub now rejects, the process exited, and the VM shut itself down. The scaler saw every VM as "stale" (created but never registered) and evicted it, and the SM80Plus scaler churned in a retry loop. Fixed same-day by manually bumping the constant and redeploying the scaler.

Both incidents had the same root cause: the pin only tracks whatever value a human last wrote into the script. GitHub raises its accepted minimum on its own schedule, and nothing in our system was watching for that — a person had to notice VMs dying in production and bump a hardcoded string.

Windows never hit this failure only because both platforms happened to be pinned to the same stale `2.334.0` — it was not protected by anything Windows-specific.

## Proposed solution

Replace the pinned constant with a live lookup of `https://api.github.com/repos/actions/runner/releases/latest` on every boot, and compare the installed runner version against that instead of a hardcoded string. This is the principled fix because it removes the actual defect (a value that must be kept in sync by hand, with no mechanism to keep it in sync) rather than adding monitoring/alerting around it or documenting the manual bump procedure more thoroughly. The self-update-and-verify structure that already existed (download, install, re-check the installed version, hard-fail the boot if anything doesn't match) is unchanged — only the source of "what version should be installed" moves from a compile-time constant to a runtime API call.

The pre-known SHA256 checksum comparison is dropped along with the version pin: GitHub's releases API does not publish a checksum for "latest" (the previous SHA256 had to be computed by hand from a downloaded tarball each time the constant was bumped — see the 2026-08-11 incident notes). Integrity now relies on TLS plus GitHub's own asset hosting, which is the same trust boundary the archive extraction step already depends on.

Wallclock cost is unchanged in the steady state: a version-matched boot pays one extra sub-second HTTPS call to determine "latest," and only a version-mismatched boot pays the existing ~30–60s download+extract cost — which now only happens when GitHub actually ships a new release, not when a human happens to remember to bump a constant.

## Change summary

| File | Change |
|---|---|
| `extras/scaler/internal/gcp/startup.sh` | Removed `RUNNER_VERSION`/`RUNNER_SHA256` constants. Added a `curl` call to GitHub's releases API to resolve `latest_runner_version` at boot; compares the installed runner against that instead of the old constant. Dropped the `sha256sum -c` verification step. |
| `extras/scaler/internal/gcp/startup.ps1` | Same change for Windows: removed `$RunnerVersion`/`$RunnerSha256`, added an `Invoke-RestMethod` call to the same API, dropped the `Get-FileHash` verification step. |

## Concepts and vocabulary

- **Ephemeral runner boot script**: `startup.sh`/`startup.ps1` run once per VM, as a GCE metadata startup script, immediately after boot and before the GitHub Actions runner registers and picks up a job. The scaler creates one VM per job; the VM shuts itself down after the job completes (or if startup fails), so "boot" and "runner lifetime" are effectively the same window.
- **JIT (just-in-time) config**: a short-lived, single-use registration token the scaler stamps into GCE instance metadata; the runner reads it and uses it to register+run exactly one job (`run.sh --jitconfig` / `run.cmd --jitconfig`), then exits.

## Process report

**The change (dropping the pinned constant for a live API call) is the producer-side fix, not a downstream patch.** The two prior incidents are the motivating evidence: both times, the defect was that "the version to install" was determined at script-authoring time rather than at boot time, so the value was only ever as fresh as the last manual edit. Making the boot script ask GitHub what it currently accepts, at the moment it needs to know, eliminates the class of bug (a value drifting out of sync with its source of truth) rather than adding a faster way to notice the drift after the fact (e.g. a monitoring alert on stale pins) or a runbook for fixing it quickly (which already existed and was used on 2026-08-11, but still required a human in the loop before jobs could run again).

**Answering the input-shape question directly, since this touches a security-relevant checksum check:** is "no pre-known SHA256 to compare against" a valid input shape, or does it indicate a missing producer? GitHub's `/releases/latest` API response does not include a checksum field for any asset — there is no producer to fix here; the checksum was previously supplied out-of-band by whoever bumped the constant (computed by hand from a downloaded tarball, per the 2026-08-11 incident notes), which is exactly the manual, easily-stale step this change removes. The download itself is still authenticated the same way the rest of the pipeline already trusts GitHub: over TLS, from `github.com`/`api.github.com`, using the same HTTPS channel the tarball extraction step (`tar xzf`, `Expand-Archive`) already runs against without independent verification beyond that TLS. No new trust boundary is introduced; an existing one (TLS to GitHub) is now relied on for one more step instead of being supplemented by a checksum that had to be kept in sync by hand alongside the version constant it was already failing to stay in sync with.

**Doc follow-up**: `slang-ci-docs/infrastructure/gcp-runner-scaler.md` (separate repo, pushed directly per existing convention) is updated to mark the "Runner Binary Deprecated" runbook as historical/structurally-prevented, and adds an "Image Rebake Cadence" section: since every boot now self-heals by downloading the runner if it's stale, a VM logging "Updating Actions runner to v..." on every boot (rather than occasionally) is now the signal that the base image itself has drifted and is due for a rebake, rather than an outage signal.