### PR TITLE
Expose `getBuiltinModuleSource` in the WebAssembly bindings

### DIFF
--- a/source/slang-wasm/slang-wasm-bindings.cpp
+++ b/source/slang-wasm/slang-wasm-bindings.cpp
@@ -16,10 +16,8 @@ EMSCRIPTEN_BINDINGS(slang)
     function("getCompileTargets", &slang::wgsl::getCompileTargets);
 
     class_<slang::wgsl::GlobalSession>("GlobalSession")
-        .function(
-            "createSession",
-            &slang::wgsl::GlobalSession::createSession,
-            allow_raw_pointers());
+        .function("createSession", &slang::wgsl::GlobalSession::createSession, allow_raw_pointers())
+        .function("getBuiltinModuleSource", &slang::wgsl::GlobalSession::getBuiltinModuleSource);
 
     function("createGlobalSession", &slang::wgsl::createGlobalSession, allow_raw_pointers());
 

--- a/source/slang-wasm/slang-wasm.cpp
+++ b/source/slang-wasm/slang-wasm.cpp
@@ -98,6 +98,23 @@ Session* GlobalSession::createSession(int compileTarget)
     return new Session(session);
 }
 
+std::string GlobalSession::getBuiltinModuleSource(const std::string& moduleName)
+{
+    Slang::ComPtr<ISlangBlob> blob;
+    SlangResult result = Slang::getBuiltinModuleSource(
+        Slang::UnownedStringSlice(moduleName.c_str()),
+        blob.writeRef());
+    if (result != SLANG_OK)
+    {
+        g_error.type = std::string("INTERNAL");
+        g_error.result = result;
+        g_error.message = std::string("Failed to get the source of builtin module '") + moduleName +
+                          std::string("'");
+        return "";
+    }
+    return std::string((const char*)blob->getBufferPointer(), blob->getBufferSize());
+}
+
 Session::~Session()
 {
     m_componentTypes = {};

--- a/source/slang-wasm/slang-wasm.cpp
+++ b/source/slang-wasm/slang-wasm.cpp
@@ -104,15 +104,11 @@ std::string GlobalSession::getBuiltinModuleSource(const std::string& moduleName)
     SlangResult result = Slang::getBuiltinModuleSource(
         Slang::UnownedStringSlice(moduleName.c_str()),
         blob.writeRef());
-    if (result != SLANG_OK)
-    {
-        g_error.type = std::string("INTERNAL");
-        g_error.result = result;
-        g_error.message = std::string("Failed to get the source of builtin module '") + moduleName +
-                          std::string("'");
-        return "";
-    }
-    return std::string((const char*)blob->getBufferPointer(), blob->getBufferSize());
+    // The callee always succeeds: an unrecognized name yields an empty blob, not a failure.
+    SLANG_ASSERT(result == SLANG_OK);
+    SLANG_UNUSED(result);
+    const char* data = (const char*)blob->getBufferPointer();
+    return data ? std::string(data, blob->getBufferSize()) : std::string();
 }
 
 Session::~Session()

--- a/source/slang-wasm/slang-wasm.cpp
+++ b/source/slang-wasm/slang-wasm.cpp
@@ -107,8 +107,7 @@ std::string GlobalSession::getBuiltinModuleSource(const std::string& moduleName)
     // The callee always succeeds: an unrecognized name yields an empty blob, not a failure.
     SLANG_ASSERT(result == SLANG_OK);
     SLANG_UNUSED(result);
-    const char* data = (const char*)blob->getBufferPointer();
-    return data ? std::string(data, blob->getBufferSize()) : std::string();
+    return std::string((const char*)blob->getBufferPointer(), blob->getBufferSize());
 }
 
 Session::~Session()

--- a/source/slang-wasm/slang-wasm.h
+++ b/source/slang-wasm/slang-wasm.h
@@ -332,7 +332,9 @@ public:
 
     Session* createSession(int compileTarget);
 
-    // Returns the source of the builtin module "core" or "glsl", or an empty string otherwise.
+    // Returns the source of the builtin module "core" or "glsl". The name is matched by prefix,
+    // so "core-extra" also selects core. Any other name returns an empty string and does not
+    // set an error, so an empty result cannot be told apart from a failure via getLastError().
     std::string getBuiltinModuleSource(const std::string& moduleName);
 
     slang::IGlobalSession* interface() const { return m_interface; }

--- a/source/slang-wasm/slang-wasm.h
+++ b/source/slang-wasm/slang-wasm.h
@@ -332,6 +332,9 @@ public:
 
     Session* createSession(int compileTarget);
 
+    // Returns the source of the builtin module "core" or "glsl", or an empty string otherwise.
+    std::string getBuiltinModuleSource(const std::string& moduleName);
+
     slang::IGlobalSession* interface() const { return m_interface; }
 
 private:

--- a/tests/wasm/smoke/smoke-test.js
+++ b/tests/wasm/smoke/smoke-test.js
@@ -135,7 +135,22 @@ async function runSmokeTest() {
             throw new Error(`Unexpected default-value blob contents: 0x${answer.toString(16)}`);
         }
         console.log('Default-value blob reflection smoke test passed');
-        
+
+        const coreSource = globalSession.getBuiltinModuleSource('core');
+        for (const marker of ['public module core;', 'struct RayDesc', 'struct NullDifferential']) {
+            if (!coreSource.includes(marker)) {
+                throw new Error(`Core builtin module source is missing: ${marker}`);
+            }
+        }
+        const glslSource = globalSession.getBuiltinModuleSource('glsl');
+        if (!glslSource.includes('#define highp')) {
+            throw new Error('GLSL builtin module source is missing expected content');
+        }
+        if (globalSession.getBuiltinModuleSource('nonexistent') !== '') {
+            throw new Error('Unknown builtin module name should return an empty string');
+        }
+        console.log('Builtin module source smoke test passed');
+
         // Clean up
         linkedProgram.delete();
         program.delete();

--- a/tests/wasm/smoke/smoke-test.js
+++ b/tests/wasm/smoke/smoke-test.js
@@ -142,9 +142,12 @@ async function runSmokeTest() {
                 throw new Error(`Core builtin module source is missing: ${marker}`);
             }
         }
-        const glslSource = globalSession.getBuiltinModuleSource('glsl');
-        if (!glslSource.includes('#define highp')) {
-            throw new Error('GLSL builtin module source is missing expected content');
+        // Prefix-matching contract: names beginning with core/glsl select that module.
+        if (globalSession.getBuiltinModuleSource('core-extra') !== coreSource) {
+            throw new Error('Prefix-matched "core-extra" should return the same source as "core"');
+        }
+        if (!globalSession.getBuiltinModuleSource('glsl-450').includes('#define highp')) {
+            throw new Error('Prefix-matched "glsl-450" should return GLSL source');
         }
         if (globalSession.getBuiltinModuleSource('nonexistent') !== '') {
             throw new Error('Unknown builtin module name should return an empty string');

--- a/tests/wasm/smoke/smoke-test.js
+++ b/tests/wasm/smoke/smoke-test.js
@@ -142,15 +142,22 @@ async function runSmokeTest() {
                 throw new Error(`Core builtin module source is missing: ${marker}`);
             }
         }
+        const glslSource = globalSession.getBuiltinModuleSource('glsl');
+        if (!glslSource.includes('#define highp')) {
+            throw new Error('GLSL builtin module source is missing: #define highp');
+        }
         // Prefix-matching contract: names beginning with core/glsl select that module.
         if (globalSession.getBuiltinModuleSource('core-extra') !== coreSource) {
             throw new Error('Prefix-matched "core-extra" should return the same source as "core"');
         }
-        if (!globalSession.getBuiltinModuleSource('glsl-450').includes('#define highp')) {
-            throw new Error('Prefix-matched "glsl-450" should return GLSL source');
+        if (globalSession.getBuiltinModuleSource('glsl-450') !== glslSource) {
+            throw new Error('Prefix-matched "glsl-450" should return the same source as "glsl"');
         }
         if (globalSession.getBuiltinModuleSource('nonexistent') !== '') {
             throw new Error('Unknown builtin module name should return an empty string');
+        }
+        if (globalSession.getBuiltinModuleSource('') !== '') {
+            throw new Error('Empty builtin module name should return an empty string');
         }
         console.log('Builtin module source smoke test passed');
 


### PR DESCRIPTION
Right-clicking → "Peak Definition" on any builtin (dot, RayDesc, Texture2D, …) in the Slang playground opens a blank popup, but with real source lines to core source. However, the same operation works just fine for the vscode slang extension.

When gotoDefinition resolves a symbol whose source location is inside a builtin module, `LanguageServerCore::gotoDefinition` can't just return a file://URI, so instead the language server returns a synthetic URI, `slang-synth://core/core.builtin` 
- See source/slang/slang-language-server.cpp:1212-1216

That synthetic URI tells the client "hey, you should just fetch this built-source using `Session::getBuiltInModuleSource`, because it's not a real file", and that's basically what the slang vscode extension today does. 

So in _theory_, Slang playground (or any slang wasm thing) should be able to call that exact same function, but it doesn't, because we don't yet expose it. Still, we already compile the text of these core definitions into the WebAssembly file, so the only blocking issue really is enabling the client to query it through Javascript. 

And so in this PR we expose that getBuiltInModuleSource through wasm, so that it can be called within Slang playground to give the user hints about the definitions behind built-in stuff.