### PR TITLE
ci: rebuild a fresh Slang artifact when Falcor testing is approved

### DIFF
--- a/.github/workflows/ci-falcor-test.yml
+++ b/.github/workflows/ci-falcor-test.yml
@@ -2,6 +2,16 @@ name: CI Falcor Test Workflow
 
 on:
   workflow_call:
+    inputs:
+      slang-artifact-name:
+        description: >-
+          Name of the slang-tests-* artifact for the test-falcor job to
+          fetch. Defaults to the regular Windows-release artifact; the
+          caller can point this at a separately-built artifact instead
+          (see build-windows-release-cl-x86_64-gpu-falcor in ci.yml).
+        required: false
+        type: string
+        default: slang-tests-windows-x86_64-cl-release
 
 permissions:
   actions: read
@@ -12,10 +22,16 @@ jobs:
     timeout-minutes: 100
     runs-on: [Linux, self-hosted, X64, falcor-bridge]
     # Vet-and-approve gate: this job runs PR-controlled code on the internal
-    # bridge VM, so it is gated behind the `falcor-ci` environment (required
-    # reviewers = the `ci-approvers` team). A PR by a team member runs
-    # automatically; anyone else's run waits for a one-click approval.
-    environment: falcor-ci
+    # bridge VM, so approval (required reviewers = the `ci-approvers` team)
+    # is required before it runs. The `environment: falcor-ci` gate lives on
+    # falcor-build-approval-gate in ci.yml (upstream of this job, via
+    # build-windows-release-cl-x86_64-gpu-falcor), not here directly --
+    # GitHub charges one approval prompt per job that references an
+    # environment, so putting the gate on both the build and this job would
+    # mean two separate approval clicks per PR for one Falcor run. A PR by a
+    # team member runs automatically; anyone else's run waits for the one
+    # upstream approval, which also covers this job since it cannot start
+    # until the gated build produces its artifact.
     defaults:
       run:
         shell: bash
@@ -23,7 +39,7 @@ jobs:
       - name: Run external CI
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          SLANG_CI_ARTIFACT_NAME: slang-tests-windows-x86_64-cl-release
+          SLANG_CI_ARTIFACT_NAME: ${{ inputs.slang-artifact-name }}
         run: |
           set -euo pipefail
           /opt/slang-ci/run-external-ci

--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -35,6 +35,15 @@ on:
         required: false
         type: boolean
         default: false
+      artifact-name-suffix:
+        description: >-
+          Optional suffix appended to the build/tests artifact names, so a
+          second call site can produce distinctly-named artifacts from the
+          same build steps (e.g. a Falcor-only rebuild that must not share
+          an artifact name with the regular Windows-release build).
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build:
@@ -334,14 +343,14 @@ jobs:
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: slang-build-${{ inputs.os }}-${{ inputs.platform }}-${{ inputs.compiler }}-${{ inputs.config }}
+          name: slang-build-${{ inputs.os }}-${{ inputs.platform }}-${{ inputs.compiler }}-${{ inputs.config }}${{ inputs.artifact-name-suffix }}
           path: |
             build/dist-${{inputs.config}}/**/ZIP/slang/*
             build.em/Release
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: slang-tests-${{ inputs.os }}-${{ inputs.platform }}-${{ inputs.compiler }}-${{ inputs.config }}
+          name: slang-tests-${{ inputs.os }}-${{ inputs.platform }}-${{ inputs.compiler }}-${{ inputs.config }}${{ inputs.artifact-name-suffix }}
           path: artifacts-staging/
           retention-days: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,43 @@ jobs:
       config: release
       runs-on: '["Windows", "self-hosted", "build"]'
 
+  # Vet-and-approve gate for the Falcor-only rebuild below. A job that
+  # calls a reusable workflow via `uses:` cannot itself carry
+  # `environment:` (GitHub only allows name/uses/with/secrets/needs/if/
+  # permissions on such jobs), so the approval gate has to live on this
+  # plain job instead, with the build depending on it.
+  falcor-build-approval-gate:
+    needs: [filter]
+    if: needs.filter.outputs.should-run == 'true'
+    environment: falcor-ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Approved
+        run: echo "Falcor rebuild approved."
+
+  # A separate build for test-falcor, gated behind the same falcor-ci
+  # approval as the test job itself. The regular Windows-release build
+  # above runs eagerly and its slang-tests-* artifact expires (1-day
+  # retention, and GitHub's download URLs are short-lived signed URLs)
+  # long before a PR sitting in the Falcor approval queue gets looked at.
+  # Building again here, only once approved, means the artifact this job
+  # produces is always fresh when test-falcor actually needs it. The
+  # other six consumers of build-windows-release-cl-x86_64-gpu's artifact
+  # (dx/vk/cuda/rhi tests, MaterialX, compile-regression, benchmark) are
+  # unaffected -- they keep using the eagerly-built, ungated artifact.
+  build-windows-release-cl-x86_64-gpu-falcor:
+    needs: [filter, falcor-build-approval-gate]
+    if: needs.filter.outputs.should-run == 'true'
+    uses: ./.github/workflows/ci-slang-build.yml
+    with:
+      os: windows
+      compiler: cl
+      platform: x86_64
+      config: release
+      runs-on: '["Windows", "self-hosted", "build"]'
+      artifact-name-suffix: "-falcor"
+
   # Linux tests (self-hosted GPU runner, containerized)
   test-linux-debug-gcc-x86_64:
     needs: [filter, build-linux-debug-gcc-x86_64]
@@ -672,12 +709,14 @@ jobs:
           fi
 
   test-falcor:
-    needs: [filter, build-windows-release-cl-x86_64-gpu]
+    needs: [filter, build-windows-release-cl-x86_64-gpu-falcor]
     if: needs.filter.outputs.should-run == 'true'
     permissions:
       contents: read
       actions: read
     uses: ./.github/workflows/ci-falcor-test.yml
+    with:
+      slang-artifact-name: slang-tests-windows-x86_64-cl-release-falcor
 
   test-compile-regression:
     needs: [filter, build-windows-release-cl-x86_64-gpu]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,8 @@ jobs:
     environment: falcor-ci
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Only runs `echo`; no GITHUB_TOKEN scopes are needed.
+    permissions: {}
     steps:
       - name: Approved
         run: echo "Falcor rebuild approved."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,19 @@ jobs:
   # other six consumers of build-windows-release-cl-x86_64-gpu's artifact
   # (dx/vk/cuda/rhi tests, MaterialX, compile-regression, benchmark) are
   # unaffected -- they keep using the eagerly-built, ungated artifact.
+  #
+  # If test-falcor fails on a stale/inaccessible artifact from this job
+  # (observed: the bridge relay's own GitHub API artifact lookup can fail
+  # for an unrelated attempt/token reason even when the artifact itself is
+  # neither expired nor deleted -- see PR #12614 discussion), GitHub's
+  # "Re-run failed jobs" will NOT rebuild here: re-run only ever
+  # propagates to jobs downstream of a failure, never to an upstream job
+  # that already succeeded (confirmed by a GitHub Actions maintainer,
+  # https://github.com/actions/runner/issues/1961). Use "Re-run all jobs"
+  # instead in that case, which forces this job to run fresh. This is a
+  # known, accepted cost: a real Falcor regression needing a code fix
+  # already forces a full re-run via a new commit, so this only affects
+  # the narrower case of a transient retry with no code change.
   build-windows-release-cl-x86_64-gpu-falcor:
     needs: [filter, falcor-build-approval-gate]
     if: needs.filter.outputs.should-run == 'true'


### PR DESCRIPTION
## Motivation
`test-falcor` consumes the `slang-tests-windows-x86_64-cl-release` artifact built by `build-windows-release-cl-x86_64-gpu`, which runs eagerly before the `falcor-ci` approval gate. That artifact has 1-day retention (`ci-slang-build.yml`), and GitHub's artifact download URLs are themselves short-lived signed URLs on top of that. A PR that sits waiting for Falcor approval can find its artifact expired (`410 Artifact has expired`) by the time an approver acts, regardless of how quickly the Falcor-side job itself runs once triggered — this is a previously-observed failure mode during the Falcor bridge rollout.

## Proposed solution
Build a second, Falcor-only artifact gated *behind* approval instead of before it, so the artifact's retention/URL-expiry clock starts from the moment of approval, not from whenever CI first ran on the PR. This intentionally pays for a redundant Windows release build on every Falcor approval, in exchange for the artifact always being fresh when `test-falcor` needs it.

The existing `build-windows-release-cl-x86_64-gpu` job is left completely untouched — it's shared by six other consumers (dx/vk/cuda/rhi tests, MaterialX, compile-regression, benchmark) that must keep running eagerly and are unrelated to the Falcor approval gate.

## Change summary
- **`ci.yml`**: adds `falcor-build-approval-gate` (a plain job carrying `environment: falcor-ci`) and `build-windows-release-cl-x86_64-gpu-falcor` (depends on the gate, rebuilds the same Windows release configuration, producing a distinctly-named artifact). `test-falcor` now depends on the new build job instead of the original one.
- **`ci-slang-build.yml`**: adds an optional `artifact-name-suffix` input, appended to both `upload-artifact` `name:` values, so a second call site can produce a differently-named artifact from the same build steps without duplicating the job body.
- **`ci-falcor-test.yml`**: adds a `slang-artifact-name` input (defaults to the original artifact name for backward compatibility) used for the `SLANG_CI_ARTIFACT_NAME` env var. Removes `environment: falcor-ci` from `test-falcor` itself.

## Concepts and vocabulary
- **`environment:` on a job vs a `uses:` job**: GitHub Actions only allows `name`/`uses`/`with`/`secrets`/`needs`/`if`/`permissions` on a job that calls a reusable workflow via `uses:` — `environment:` isn't one of them. That's why the approval gate has to live on a separate plain job (`falcor-build-approval-gate`) rather than directly on the build job.
- **Per-job approval, not per-run**: GitHub generates one "Review deployments" prompt per job that references a protected environment, even when multiple jobs in the same run reference the same environment name — approving one does not auto-approve another. This is why `test-falcor` no longer carries `environment: falcor-ci` itself: keeping it on both the gate and the test would mean two separate approval clicks per PR for one Falcor run.

## Process report
- **Why `falcor-build-approval-gate` exists as a separate job**: `build-windows-release-cl-x86_64-gpu-falcor` calls `ci-slang-build.yml` via `uses:`, which cannot carry `environment:` directly (verified with `actionlint`, which flags this as a syntax error). The gate is a minimal plain job (single `echo` step, `ubuntu-latest`, 5-minute timeout) whose only purpose is to hold the environment protection; the build job depends on it via `needs:`.
- **Why `test-falcor` no longer has its own `environment:`**: originally it did, because it's the job that runs PR-controlled code on the internal bridge VM (a genuine security boundary, not just an artifact-freshness concern). Verified via research that GitHub approval is scoped per-job, not per-environment-per-run, so keeping the gate on both jobs would double the required clicks per PR. Since `test-falcor` cannot start until `build-windows-release-cl-x86_64-gpu-falcor` completes, and that build cannot start until the gate is approved, the single upstream approval still gates `test-falcor`'s execution on the bridge VM — it's just checked once, earlier in the chain, rather than twice.
- **Why the artifact needs a distinct name (`artifact-name-suffix`)**: without it, the Falcor-only rebuild would upload to the same `slang-tests-windows-x86_64-cl-release` name already produced (and consumed by six other jobs) from the original eager build, causing a name collision within the same workflow run. The `-falcor` suffix is a caller-supplied string appended raw in `ci-slang-build.yml`, so the six other consumers of the original artifact name are entirely unaffected.
- **Why the other six consumers of `build-windows-release-cl-x86_64-gpu` are untouched**: they aren't part of the Falcor approval-gate flow and must keep running eagerly and ungated for normal CI turnaround; only `test-falcor`'s dependency changed.