### PR TITLE
Pin the dxvk-remix clone in the nightly Remix test

### DIFF
--- a/.github/workflows/nightly-remix-test.yml
+++ b/.github/workflows/nightly-remix-test.yml
@@ -110,14 +110,32 @@ jobs:
             exit 1
           fi
 
-      # Clone dxvk-remix with all submodules (pinned to specific commit for stability)
+      # Clone dxvk-remix at a pinned commit.
+      #
+      # The pin is load-bearing, not just a reproducibility nicety.
+      # dxvk-remix 673dc2af ("[HdRemix] Use USD without Python") switched
+      # the OpenUSD dependency to the `open_usd` packman package, which is
+      # published only to NVIDIA's internal NVGTL remote. `packman pull`
+      # then fails with "the environment variable 'NVM_GTLAPI_TOKEN' must
+      # be set to use NVGTL", which public CI cannot and should not
+      # satisfy. a6c0b547 is the last commit this workflow ran green
+      # against. See shader-slang/slang#12617.
+      #
+      # To bump: pick a dxvk-remix commit whose packman-external.xml
+      # resolves entirely from the public remotes (cloudfront /
+      # rtx-remix-external), then re-run this workflow to confirm.
       - name: Clone dxvk-remix repository
+        env:
+          DXVK_REMIX_COMMIT: a6c0b547306a8d3c97630de58c27635173b12c9a
         run: |
-          echo "Cloning dxvk-remix repository..."
-          git clone --recursive --depth 1 https://github.com/NVIDIAGameWorks/dxvk-remix.git
+          echo "Cloning dxvk-remix at $DXVK_REMIX_COMMIT..."
+          git init -q dxvk-remix
           cd dxvk-remix
-          commit=$(git rev-parse HEAD)
-          echo "Using dxvk-remix commit: $commit"
+          git remote add origin https://github.com/NVIDIAGameWorks/dxvk-remix.git
+          git fetch -q --depth 1 origin "$DXVK_REMIX_COMMIT"
+          git checkout -q FETCH_HEAD
+          git submodule update --init --recursive --depth 1
+          echo "Using dxvk-remix commit: $(git rev-parse HEAD)"
 
       # Cache packman packages between runs to save ~2-5 minutes
       - name: Cache Packman packages


### PR DESCRIPTION
## Summary

- Pins the `dxvk-remix` clone in `Nightly Remix Test` to `a6c0b547`, the last commit the workflow ran green against.
- Restores the nightly, which has failed since 2026-08-19.
- Replaces `git clone --depth 1` with a shallow single-commit fetch, since a depth-1 clone cannot check out an arbitrary commit.

Fixes #12617.

## Motivation

The job cloned dxvk-remix's **default branch, unpinned**, so an upstream dependency change broke it the same night it landed:

```
Package 'open_usd' at version '25.11+07744417-windows-x86_64-release-nopython' is missing from local storage.
packman(ERROR): The environment variable 'NVM_GTLAPI_TOKEN' must be set to use NVGTL
```

dxvk-remix [`673dc2af`](https://github.com/NVIDIAGameWorks/dxvk-remix/commit/673dc2af) ("[HdRemix] Use USD without Python", 2026-08-18 22:07 UTC) replaced the OpenUSD packages with `open_usd`, which is published only to NVIDIA's internal NVGTL remote. `packman` resolves `cloudfront -> rtx-remix-external -> gtl`; the old `usd.py311.*` packages are on the public CDN, `open_usd` is on neither public remote, so it falls through to `gtl` and demands a token. Public CI cannot and should not supply one.

The nightly fired at 03:20 UTC, five hours later, after 11 consecutive green nights.

Note the comment this replaces was already wrong — it claimed the clone was pinned when it was not.

## Technical Details

`a6c0b547` (2026-08-14) is chosen deliberately over `673dc2af~1`. The latter is merely the parent of the breaking commit and has never been exercised here; `a6c0b547` is the SHA echoed by the last green run ([32095047146](https://github.com/shader-slang/slang/actions/runs/32095047146)), so it is validated end to end. Its `packman-external.xml` still resolves entirely from public remotes.

`git clone --depth 1` cannot check out an arbitrary commit, so the step now does `git init` + `git fetch --depth 1 origin <sha>` + `checkout FETCH_HEAD`, which keeps the clone shallow. GitHub permits fetching by commit SHA. If that ever stops working, the fallback is a full clone followed by `git checkout <sha>`.

A stable manifest also stabilises the packman cache. The key is `hashFiles('dxvk-remix/packman-external.xml')`, so every upstream manifest change previously invalidated it — the failing run shows a cold-cache miss for exactly this reason.

This is a stopgap. The durable fixes are upstream: publish `open_usd` to a public remote, or give dxvk-remix a shaders-only configure path that does not need USD at all. I investigated whether we could simply build without USD and [recorded on #12617](https://github.com/shader-slang/slang/issues/12617#issuecomment-5339573327) why the stub-directory trick used for `rtx-remix-ngx_sdk_dlfg` does not transfer: USD is reached through 27 `find_library()` calls at configure time, which need real `.lib` files, not just a directory.

## Test Plan

- [x] YAML parses; `prettier --check` clean
- [x] Dispatched `Nightly Remix Test` on this branch — [run 32234163843](https://github.com/shader-slang/slang/actions/runs/32234163843) **passed, every step green**

The dispatched run verifies the fix end to end. The clone step reports `Using dxvk-remix commit: a6c0b547306a8d3c97630de58c27635173b12c9a`, confirming both the pin and the new fetch-by-SHA logic; *Download external dependencies (packman)* now succeeds where it previously aborted; and *Build shaders using build_shaders_only.ps1* and *Verify shader compilation* both pass.

This could not be validated by the PR checks themselves, since the workflow only runs on schedule/dispatch. The branch was pushed to `shader-slang` as well so the dispatch could target it.

## Suggested reviewers

- **@jkwak-work** and **@expipiplus1** — most frequent recent authors of CI workflow changes.


