### PR TITLE
Document native host tool names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,12 @@ default unless the user explicitly asks for the WSL/Linux version.
 - If a required `.exe` tool is unavailable, stop and report it instead of silently falling back
   to the WSL/Linux tool.
 
+## Native Linux and macOS Tooling
+
+When working in this repository on native Linux or macOS, use the platform-native tools without
+the Windows `.exe` extension. For example, use `git`, `gh`, `cmake`, and `python`, not `git.exe`,
+`gh.exe`, `cmake.exe`, or `python.exe`.
+
 ## Build, Test, and Development Commands
 
 Slang build setup is platform-specific, especially under WSL. For compiler builds, use the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ default unless the user explicitly asks for the WSL/Linux version.
 ## Native Linux and macOS Tooling
 
 When working in this repository on native Linux or macOS, use the platform-native tools without
-the Windows `.exe` extension. For example, use `git`, `gh`, `cmake`, and `python`, not `git.exe`,
+the Windows `.exe` extension. For example, use `git`, `gh`, `cmake`, and `python3`, not `git.exe`,
 `gh.exe`, `cmake.exe`, or `python.exe`.
 
 ## Build, Test, and Development Commands


### PR DESCRIPTION
## Motivation

The repository explains that WSL should use Windows-native executables such as `gh.exe`, but it does not state the corresponding rule for native Linux and macOS. This can cause an agent working on native Ubuntu to spend time resolving whether a Windows executable is required.

Consider a clarity-review workflow that needs GitHub CLI. On native Ubuntu the executable is `gh`; `gh.exe` is the Windows-hosted form intended for Windows or WSL.

## Proposed solution

Add an adjacent native Linux and macOS tooling section to `AGENTS.md`. The section explicitly selects extensionless platform-native tools while leaving the existing WSL guidance unchanged.

## Change summary

- `AGENTS.md`: document that native Linux and macOS use `git`, `gh`, `cmake`, and `python` rather than their `.exe` forms.

## Concepts and vocabulary

- Native host: a Linux or macOS installation running its own platform tools, rather than invoking Windows-hosted tools through WSL.
- Windows-hosted tool: an executable with the `.exe` suffix invoked from Windows or WSL when Windows paths, toolchains, or credentials are required.

## Process report

The ambiguity comes from an asymmetric instruction boundary. `AGENTS.md` already tells WSL users to select Windows-native tools, so the principled location for the inverse rule is immediately after that section. This keeps host-tool selection in one document and avoids changing individual review skills to hardcode either platform.

No compiler behavior or skill workflow changed. Validation was limited to `git diff --check` because this is an instruction-only documentation change.