### PR TITLE
Add no-op probe for windows-11-vs2026-arm hosted runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -13,3 +13,9 @@ self-hosted-runner:
     - regression-test
     - SM80Plus
     - vulkancts
+    # Hosted GitHub partner-runner label for the VS2026 advance-testing
+    # image (see probe-windows-arm-vs2026.yml). Not yet in actionlint's
+    # bundled known-labels dataset since it is a newly added hosted
+    # label, not a self-hosted one — allowlisting it here is the
+    # supported workaround until actionlint's dataset catches up.
+    - windows-11-vs2026-arm

--- a/.github/workflows/probe-windows-arm-vs2026.yml
+++ b/.github/workflows/probe-windows-arm-vs2026.yml
@@ -11,6 +11,10 @@ name: Probe - windows-11-vs2026-arm image availability
 on:
   workflow_dispatch:
 
+concurrency:
+  group: probe-windows-arm-vs2026
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -25,5 +29,22 @@ jobs:
           echo "PROCESSOR_ARCHITECTURE=$env:PROCESSOR_ARCHITECTURE"
           [System.Environment]::OSVersion.VersionString
           Get-CimInstance Win32_OperatingSystem | Select-Object Caption, Version, OSArchitecture
-          where.exe cl.exe 2>$null
           cmake --version
+
+      # cl.exe is not on PATH by default on GitHub-hosted Windows runners;
+      # the Visual Studio dev environment must be initialized first (see
+      # https://github.com/actions/runner-images/blob/main/images/windows/Windows11-VS2026-Arm64-Readme.md).
+      # -HostArch arm64 requests the native arm64-on-arm64 toolchain rather
+      # than the amd64-hosted cross-compiler, matching the native-build goal
+      # this probe exists to validate.
+      - name: Initialize VS dev shell and report cl.exe
+        shell: pwsh
+        run: |
+          $vsDevShell = & "${env:ProgramFiles}\Microsoft Visual Studio\Installer\vswhere.exe" `
+            -latest -prerelease -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 `
+            -find "Common7\Tools\Launch-VsDevShell.ps1"
+          & $vsDevShell -Arch arm64 -HostArch arm64
+
+          $cl = Get-Command cl.exe -ErrorAction Stop
+          Write-Host "cl.exe resolved at: $($cl.Source)"
+          cl.exe /Bv

--- a/.github/workflows/probe-windows-arm-vs2026.yml
+++ b/.github/workflows/probe-windows-arm-vs2026.yml
@@ -1,0 +1,29 @@
+name: Probe - windows-11-vs2026-arm image availability
+
+# No-op capability probe for GitHub's upcoming windows-11-arm image
+# migration to Visual Studio 2026 (rollout 2026-09-21 through
+# 2026-09-30). This is Phase 1 of validating native (non-cross-compiled)
+# Windows-on-ARM builds: before investing in an actual build+test job, we
+# confirm the windows-11-vs2026-arm hosted label is dispatchable and
+# report basic host/toolchain identity. A real build/test trial follows
+# once this is proven to work.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: windows-11-vs2026-arm
+    timeout-minutes: 10
+    steps:
+      - name: Report host identity
+        shell: pwsh
+        run: |
+          echo "PROCESSOR_ARCHITECTURE=$env:PROCESSOR_ARCHITECTURE"
+          [System.Environment]::OSVersion.VersionString
+          Get-CimInstance Win32_OperatingSystem | Select-Object Caption, Version, OSArchitecture
+          where.exe cl.exe 2>$null
+          cmake --version


### PR DESCRIPTION
## Summary
- GitHub is migrating the `windows-11-arm` hosted image to Visual Studio 2026 by default, rolling out 2026-09-21 through 2026-09-30. We currently have no native (non-cross-compiled) Windows ARM64 job in CI — Windows aarch64 today is always built via cross-compilation on an x64 `windows-latest` host (`arch: amd64_arm64`), and those cross-compiled binaries are never executed in CI.
- Before investing in a real native build+test job on `windows-11-vs2026-arm`, this adds a minimal `workflow_dispatch`-only probe that does nothing beyond confirming the label is dispatchable and reporting host/toolchain identity (OS version/arch, `cl.exe` presence, `cmake --version`).
- A follow-up PR will add the actual native build+test trial once this lands on `master` and can be dispatched.

## Test plan
- [ ] After merge, dispatch `Probe - windows-11-vs2026-arm image availability` from the Actions tab and confirm it runs and reports native ARM64 host info.