### PR TITLE
Raise the agentic nightly timeout from 45 to 60 minutes

### DIFF
--- a/.github/workflows/nightly-slang-test.yml
+++ b/.github/workflows/nightly-slang-test.yml
@@ -37,10 +37,10 @@ jobs:
     # it reached. A cancelled job reports as a red X indistinguishable from a
     # real regression, so the cap was costing triage time on a suite that was
     # healthy. 45 was set in #11380 when the suite was first wired in; it has
-    # since grown past 6000 tests without the cap moving. Since this runs once a
-    # night, an over-generous cap costs nothing but the time a genuinely hung job
-    # takes to fail, while a tight one manufactures false alarms.
-    timeout-minutes: 90
+    # since grown past 6000 tests without the cap moving. 60 leaves roughly a
+    # third of the budget spare at current durations; if runs start creeping into
+    # the mid-50s, raise the cap again rather than trimming the suite to fit it.
+    timeout-minutes: 60
     permissions:
       id-token: write # Workload Identity for GCS-cached LLVM
       contents: read

--- a/.github/workflows/nightly-slang-test.yml
+++ b/.github/workflows/nightly-slang-test.yml
@@ -29,7 +29,18 @@ concurrency:
 jobs:
   agentic-tests:
     runs-on: ubuntu-22.04
-    timeout-minutes: 45
+    # Headroom, not a target. This job builds Slang from scratch (~30 min) and
+    # then runs the whole generated suite (~12 min), so it has been finishing in
+    # the low 40s of minutes against the 45 it used to be allowed: 44m37s on
+    # 2026-08-15 and 44m42s on 2026-08-16 both landed under the wire, and a
+    # 2026-08-20 re-run was cancelled at 45m06s having already passed every test
+    # it reached. A cancelled job reports as a red X indistinguishable from a
+    # real regression, so the cap was costing triage time on a suite that was
+    # healthy. 45 was set in #11380 when the suite was first wired in; it has
+    # since grown past 6000 tests without the cap moving. Since this runs once a
+    # night, an over-generous cap costs nothing but the time a genuinely hung job
+    # takes to fail, while a tight one manufactures false alarms.
+    timeout-minutes: 90
     permissions:
       id-token: write # Workload Identity for GCS-cached LLVM
       contents: read


### PR DESCRIPTION
## Motivation

The agentic nightly has been finishing within a minute of its own timeout, so it
has started failing on the clock rather than on the tests.

Recent scheduled runs of `agentic-tests`:

| date | duration | outcome |
| --- | --- | --- |
| 2026-08-15 | 44m37s | finished, ~23s under the cap |
| 2026-08-16 | 44m42s | finished, ~18s under the cap |
| 2026-08-17 | 30m17s | finished |
| 2026-08-20 | 42m28s | finished |
| 2026-08-20 (re-run) | **45m06s** | **cancelled by `timeout-minutes: 45`** |

The re-run is the motivating case. It was started to verify two CPU
differentiation tests that had crashed the test server in the earlier run of the
same commit. On the re-run those tests *passed* — the crash was an ambient event,
not a regression — but the job was cancelled near the end of the suite anyway, and
a cancelled job reports as a red X that is indistinguishable at a glance from a
real failure. So a healthy suite produced a signal that reads like a regression,
which is the specific cost being paid here.

## Proposed solution

Raise `timeout-minutes` for `agentic-tests` from 45 to 60.

`timeout-minutes: 45` was set in #11380 when the suite was first wired into CI.
The suite has since grown past 6000 passing tests while the cap stayed put. A
from-scratch build accounts for roughly 30 minutes and the suite itself for
roughly 12; neither is going to shrink, so the margin will keep narrowing.

60 clears every duration observed above — the worst was 45m06s — leaving roughly a
third of the budget spare, while staying close enough to real cost that a job which
genuinely hangs still fails in reasonable time. A comment on the setting records
the measurements so the next person knows what the number is protecting against and
does not tighten it back on the assumption that 45 was chosen for a reason. It also
says what to do if runs start creeping into the mid-50s: raise the cap again rather
than trimming the suite to fit it.

## Change summary

| File | Change |
| --- | --- |
| `.github/workflows/nightly-slang-test.yml` | `agentic-tests`: `timeout-minutes` 45 → 60, with a comment recording the observed durations and what to do if runs approach the new cap. |

## Concepts and vocabulary

- **Cancelled vs failed (GitHub Actions)** — a job stopped by `timeout-minutes`
  concludes as `cancelled`, not `failure`. Both surface as a red X on the run, so
  a timeout is easy to mistake for a test failure when skimming.

## Process report

**The one-line change.** This is a CI capacity setting, not compiler behaviour, so
there is no input shape to trace and no producer to fix upstream: the cap is
simply lower than the work it bounds. The evidence is the duration series above —
two runs landing under 45 by seconds, and one crossing it — which shows the job is
sitting on the boundary rather than having regressed in cost on any one night.

**Why 60.** It clears every observed run with about a third of the budget to
spare, and keeps the cap meaningful: a cap far above real cost stops acting as a
guard on a job that hangs. The durations are variable (30m to 45m across four
days), so this does not rule out a future slow runner crossing 60 — the comment on
the setting therefore says to raise the cap again if runs reach the mid-50s, rather
than treating the number as a budget the suite has to stay inside. Revisiting a CI
constant is cheap; the failure mode being fixed here is that nobody revisited it
for long enough that it started firing.

**Why the comment is long.** The setting's history is the reason it needed
changing: 45 looked deliberate but was simply never revisited after the suite grew.
Recording the measured durations and the reasoning inline is what stops it being
tightened again on the same assumption.

**Not addressed here.** The ambient test-server deaths from the earlier run are a
separate concern — `slang-test` charges a repeated loss on a freshly spawned server
to the test's input, which misclassifies a machine-level transient that outlives
the respawn. That is a change to `tools/slang-test/slang-test-main.cpp` and is
deliberately kept out of this workflow-only diff.
