### PR TITLE
Ask NVRTC which architectures it supports instead of assuming

### DIFF
--- a/source/compiler-core/slang-nvrtc-compiler.cpp
+++ b/source/compiler-core/slang-nvrtc-compiler.cpp
@@ -764,9 +764,16 @@ SlangResult NVRTCDownstreamCompiler::_getSupportedArchs(List<int>& outArchs)
         return SLANG_E_NOT_AVAILABLE;
     }
 
-    // NVRTC documents the result as ascending, and resolveArchAgainstSupported
-    // relies on that for both its scan and its "highest supported" fallback, so
-    // do not take it on trust.
+    // resolveArchAgainstSupported requires ascending order -- both its forward
+    // scan and its "highest supported" fallback depend on it -- and this is the
+    // single point that guarantees it. NVRTC documents its result as ascending,
+    // so this sort is normally a no-op; it is here so the helper's precondition
+    // is enforced by us rather than assumed of a third party.
+    //
+    // The paths below and this ordering guarantee are exercised only indirectly:
+    // reaching them needs a loaded NVRTC, which GPU-less CI does not have. The
+    // resolution logic itself is separated into resolveArchAgainstSupported for
+    // exactly that reason, and is unit-tested there without an NVRTC.
     outArchs.sort();
     return SLANG_OK;
 }

--- a/source/compiler-core/slang-nvrtc-compiler.cpp
+++ b/source/compiler-core/slang-nvrtc-compiler.cpp
@@ -1338,8 +1338,8 @@ SlangResult NVRTCDownstreamCompiler::compile(
         // Absent on NVRTC older than CUDA 11.2, in which case we fall back to
         // the version ladder.
         List<int> supportedArchs;
-        const bool haveSupportedArchs = SLANG_SUCCEEDED(_getSupportedArchs(supportedArchs)) &&
-                                        supportedArchs.getCount() > 0;
+        const bool haveSupportedArchs =
+            SLANG_SUCCEEDED(_getSupportedArchs(supportedArchs)) && supportedArchs.getCount() > 0;
 
         // The lowest supported CUDA architecture version supported
         // by any version of NVRTC we support is `compute_30`.

--- a/source/compiler-core/slang-nvrtc-compiler.cpp
+++ b/source/compiler-core/slang-nvrtc-compiler.cpp
@@ -712,6 +712,29 @@ SlangResult _findFileInIncludePath(
     return SLANG_E_NOT_FOUND;
 }
 
+SemanticVersion NVRTCDownstreamCompilerUtil::resolveArchAgainstSupported(
+    SemanticVersion requested,
+    const List<int>& supportedAscending)
+{
+    if (supportedAscending.getCount() == 0)
+        return requested;
+
+    const auto toVersion = [](int arch) { return SemanticVersion(arch / 10, arch % 10); };
+
+    // Smallest supported architecture that satisfies the request. Rounding the
+    // other way would hand back something that does not provide what the code
+    // asked for.
+    for (Index i = 0; i < supportedAscending.getCount(); ++i)
+    {
+        const SemanticVersion candidate = toVersion(supportedAscending[i]);
+        if (candidate >= requested)
+            return candidate;
+    }
+
+    // Nothing supported satisfies it; the best available is the highest.
+    return toVersion(supportedAscending.getLast());
+}
+
 SlangResult NVRTCDownstreamCompiler::_getSupportedArchs(List<int>& outArchs)
 {
     outArchs.clear();
@@ -730,8 +753,9 @@ SlangResult NVRTCDownstreamCompiler::_getSupportedArchs(List<int>& outArchs)
         return SLANG_E_NOT_AVAILABLE;
     }
 
-    // NVRTC documents the result as ascending, but the callers below depend on
-    // it for the floor and ceiling, so do not take that on trust.
+    // NVRTC documents the result as ascending, and resolveArchAgainstSupported
+    // relies on that for both its scan and its "highest supported" fallback, so
+    // do not take it on trust.
     outArchs.sort();
     return SLANG_OK;
 }
@@ -1395,32 +1419,11 @@ SlangResult NVRTCDownstreamCompiler::compile(
         // exists to avoid.
         //
         // What the reported set adds is the upper bound and the exact
-        // membership:
-        //
-        //  * A requirement may name an architecture that does not exist, since
-        //    `__cuda_sm_version` takes an arbitrary version. Round down to the
-        //    greatest supported architecture that satisfies it, rather than
-        //    passing NVRTC something it will reject.
-        //  * A requirement above everything supported is clamped to the highest.
-        //    Passing it through fails the compile with an error naming the
-        //    architecture, which says nothing about the user's shader; clamping
-        //    means NVRTC instead reports the specific construct it cannot
-        //    compile, which is actionable.
+        // membership; see resolveArchAgainstSupported for the semantics.
         if (haveSupportedArchs)
         {
-            const auto toVersion = [](int arch) { return SemanticVersion(arch / 10, arch % 10); };
-
-            SemanticVersion resolved = toVersion(supportedArchs.getLast());
-            for (Index i = supportedArchs.getCount() - 1; i >= 0; --i)
-            {
-                const SemanticVersion candidate = toVersion(supportedArchs[i]);
-                if (candidate <= version)
-                {
-                    resolved = candidate;
-                    break;
-                }
-            }
-            version = resolved;
+            version =
+                NVRTCDownstreamCompilerUtil::resolveArchAgainstSupported(version, supportedArchs);
         }
 
         StringBuilder builder;

--- a/source/compiler-core/slang-nvrtc-compiler.cpp
+++ b/source/compiler-core/slang-nvrtc-compiler.cpp
@@ -163,10 +163,17 @@ protected:
     /// Return the compute capabilities the loaded NVRTC actually accepts, as
     /// `major * 10 + minor` values in ascending order.
     ///
-    /// Returns SLANG_E_NOT_AVAILABLE if this NVRTC is too old to be asked,
-    /// which the caller must distinguish from "the list is empty": the former
-    /// means fall back to assumptions, the latter would mean NVRTC supports
-    /// nothing at all.
+    /// This function owns the decision of whether an answer is usable, so that
+    /// callers have exactly one thing to test. On SLANG_OK the list is
+    /// guaranteed non-empty; anything else means "no usable answer, fall back"
+    /// and carries no further meaning.
+    ///
+    /// SLANG_E_NOT_AVAILABLE therefore covers both the expected case -- an
+    /// NVRTC predating these entry points -- and a successful query reporting
+    /// no architectures. The latter is not a state Slang could act on if it
+    /// occurred, and folding it here is deliberate rather than an oversight:
+    /// distinguishing it would give every caller a second case to handle for no
+    /// behavioural difference.
     SlangResult _getSupportedArchs(List<int>& outArchs);
 
     // Holds list of paths passed in where cuda_fp16.h is found. Does *NOT*
@@ -742,6 +749,10 @@ SlangResult NVRTCDownstreamCompiler::_getSupportedArchs(List<int>& outArchs)
     if (!m_nvrtcGetNumSupportedArchs || !m_nvrtcGetSupportedArchs)
         return SLANG_E_NOT_AVAILABLE;
 
+    // A successful query reporting no architectures would mean this NVRTC can
+    // compile for nothing at all. Treated as "no usable answer" rather than
+    // asserted, because the value comes from a loaded library rather than from
+    // our own invariants.
     int numArchs = 0;
     if (m_nvrtcGetNumSupportedArchs(&numArchs) != NVRTC_SUCCESS || numArchs <= 0)
         return SLANG_E_NOT_AVAILABLE;
@@ -1362,9 +1373,10 @@ SlangResult NVRTCDownstreamCompiler::compile(
         //
         // Absent on NVRTC older than CUDA 11.2, in which case every use below
         // is skipped and behaviour is exactly as before.
+        // On success the list is non-empty; _getSupportedArchs owns that
+        // guarantee, so there is nothing further to test here.
         List<int> supportedArchs;
-        const bool haveSupportedArchs =
-            SLANG_SUCCEEDED(_getSupportedArchs(supportedArchs)) && supportedArchs.getCount() > 0;
+        const bool haveSupportedArchs = SLANG_SUCCEEDED(_getSupportedArchs(supportedArchs));
 
         // The lowest supported CUDA architecture version supported
         // by any version of NVRTC we support is `compute_30`.

--- a/source/compiler-core/slang-nvrtc-compiler.cpp
+++ b/source/compiler-core/slang-nvrtc-compiler.cpp
@@ -49,6 +49,14 @@ typedef struct _nvrtcProgram* nvrtcProgram;
     x(nvrtcResult, nvrtcGetProgramLog, (nvrtcProgram prog, char *log))\
     x(nvrtcResult, nvrtcAddNameExpression, (nvrtcProgram prog, const char * const name_expression)) \
     x(nvrtcResult, nvrtcGetLoweredName, (nvrtcProgram prog, const char *const name_expression, const char** lowered_name))
+
+// Entry points that are not present in every NVRTC we support, and so must not
+// be required for the library to load. `nvrtcGetSupportedArchs` and its
+// companion were added in CUDA 11.2; binding them through SLANG_NVRTC_FUNCS
+// would make Slang refuse to load anything older.
+#define SLANG_NVRTC_OPTIONAL_FUNCS(x) \
+    x(nvrtcResult, nvrtcGetNumSupportedArchs, (int* numArchs)) \
+    x(nvrtcResult, nvrtcGetSupportedArchs, (int* supportedArchs))
 // clang-format on
 
 } // namespace nvrtc
@@ -149,6 +157,17 @@ protected:
 #define SLANG_NVTRC_MEMBER_FUNCS(ret, name, params) ret(*m_##name) params;
 
     SLANG_NVRTC_FUNCS(SLANG_NVTRC_MEMBER_FUNCS);
+    // Null when the loaded NVRTC predates them; see SLANG_NVRTC_OPTIONAL_FUNCS.
+    SLANG_NVRTC_OPTIONAL_FUNCS(SLANG_NVTRC_MEMBER_FUNCS);
+
+    /// Return the compute capabilities the loaded NVRTC actually accepts, as
+    /// `major * 10 + minor` values in ascending order.
+    ///
+    /// Returns SLANG_E_NOT_AVAILABLE if this NVRTC is too old to be asked,
+    /// which the caller must distinguish from "the list is empty": the former
+    /// means fall back to assumptions, the latter would mean NVRTC supports
+    /// nothing at all.
+    SlangResult _getSupportedArchs(List<int>& outArchs);
 
     // Holds list of paths passed in where cuda_fp16.h is found. Does *NOT*
     // include cuda_fp16.h.
@@ -187,6 +206,13 @@ SlangResult NVRTCDownstreamCompiler::init(ISlangSharedLibrary* library)
         return SLANG_FAIL;
 
     SLANG_NVRTC_FUNCS(SLANG_NVTRC_GET_FUNC)
+
+    // Optional entry points are bound the same way but must not fail the load
+    // when absent; each is left null and guarded at the point of use.
+#define SLANG_NVTRC_GET_OPTIONAL_FUNC(ret, name, params) \
+    m_##name = (ret(*) params)library->findFuncByName(#name);
+
+    SLANG_NVRTC_OPTIONAL_FUNCS(SLANG_NVTRC_GET_OPTIONAL_FUNC)
 
     m_sharedLibrary = library;
 
@@ -684,6 +710,30 @@ SlangResult _findFileInIncludePath(
     }
 
     return SLANG_E_NOT_FOUND;
+}
+
+SlangResult NVRTCDownstreamCompiler::_getSupportedArchs(List<int>& outArchs)
+{
+    outArchs.clear();
+
+    if (!m_nvrtcGetNumSupportedArchs || !m_nvrtcGetSupportedArchs)
+        return SLANG_E_NOT_AVAILABLE;
+
+    int numArchs = 0;
+    if (m_nvrtcGetNumSupportedArchs(&numArchs) != NVRTC_SUCCESS || numArchs <= 0)
+        return SLANG_E_NOT_AVAILABLE;
+
+    outArchs.setCount(numArchs);
+    if (m_nvrtcGetSupportedArchs(outArchs.getBuffer()) != NVRTC_SUCCESS)
+    {
+        outArchs.clear();
+        return SLANG_E_NOT_AVAILABLE;
+    }
+
+    // NVRTC documents the result as ascending, but the callers below depend on
+    // it for the floor and ceiling, so do not take that on trust.
+    outArchs.sort();
+    return SLANG_OK;
 }
 
 SlangResult NVRTCDownstreamCompiler::_findCUDAIncludePath(
@@ -1279,13 +1329,31 @@ SlangResult NVRTCDownstreamCompiler::compile(
     }
 
     {
+        // Ask the loaded NVRTC which architectures it actually accepts. This is
+        // authoritative where the ladder below is a hand-maintained guess, and
+        // it is the only way to know the *upper* bound — without it, requesting
+        // an architecture newer than this NVRTC understands is a hard failure
+        // at compile time with no way for a caller to have predicted it.
+        //
+        // Absent on NVRTC older than CUDA 11.2, in which case we fall back to
+        // the version ladder.
+        List<int> supportedArchs;
+        const bool haveSupportedArchs = SLANG_SUCCEEDED(_getSupportedArchs(supportedArchs)) &&
+                                        supportedArchs.getCount() > 0;
+
         // The lowest supported CUDA architecture version supported
         // by any version of NVRTC we support is `compute_30`.
         //
         SemanticVersion version(3);
 
+        if (haveSupportedArchs)
+        {
+            const int lowest = supportedArchs[0];
+            version = SemanticVersion(lowest / 10, lowest % 10);
+        }
         // Newer releases of NVRTC only support newer CUDA architectures.
-        if (m_desc.version.m_major > 12 ||
+        else if (
+            m_desc.version.m_major > 12 ||
             (m_desc.version.m_major == 12 && m_desc.version.m_minor >= 8))
         {
             // NVRTC 12.8+ warns about architectures prior to compute_75 being deprecated
@@ -1319,6 +1387,21 @@ SlangResult NVRTCDownstreamCompiler::compile(
                 {
                     version = capabilityVersion.version;
                 }
+            }
+        }
+
+        // Do not ask for an architecture this NVRTC cannot assemble. Requesting
+        // one fails the whole compile with an error about the architecture,
+        // which tells the user nothing about their shader. Clamping instead
+        // means that if the code genuinely needs a newer architecture, NVRTC
+        // reports the specific construct it cannot compile, which is actionable.
+        if (haveSupportedArchs)
+        {
+            const int highest = supportedArchs.getLast();
+            const SemanticVersion highestVersion(highest / 10, highest % 10);
+            if (version > highestVersion)
+            {
+                version = highestVersion;
             }
         }
 

--- a/source/compiler-core/slang-nvrtc-compiler.cpp
+++ b/source/compiler-core/slang-nvrtc-compiler.cpp
@@ -1423,15 +1423,18 @@ SlangResult NVRTCDownstreamCompiler::compile(
 
         // Resolve the request against the architectures NVRTC actually accepts.
         //
-        // The ladder above is deliberately left in charge of the lower bound.
-        // On NVRTC 12.8+ its floor is a *policy* choice rather than a statement
-        // about capability -- pre-`compute_75` architectures are deprecated but
-        // still accepted, so they are still reported here, and taking the
-        // reported floor would reintroduce the deprecation warning that branch
-        // exists to avoid.
+        // The ladder above proposes a *policy* floor, not a capability one. On
+        // NVRTC 12.8+ it picks `compute_75` because architectures below that are
+        // deprecated rather than removed -- they are still reported here, so
+        // taking the reported floor would reintroduce the deprecation warning
+        // that branch exists to avoid.
         //
-        // What the reported set adds is the upper bound and the exact
-        // membership; see resolveArchAgainstSupported for the semantics.
+        // The reported set then bounds that proposal from above and snaps it to
+        // a real member. Note this can *raise* the floor as well as cap the
+        // request: if a future NVRTC genuinely drops `sm_75` and reports a
+        // minimum of 80, the ladder's 7.5 is rounded up to 8.0, because there is
+        // no longer an architecture matching the policy. See
+        // resolveArchAgainstSupported for the resolution semantics.
         if (haveSupportedArchs)
         {
             version =

--- a/source/compiler-core/slang-nvrtc-compiler.cpp
+++ b/source/compiler-core/slang-nvrtc-compiler.cpp
@@ -1329,14 +1329,15 @@ SlangResult NVRTCDownstreamCompiler::compile(
     }
 
     {
-        // Ask the loaded NVRTC which architectures it actually accepts. This is
-        // authoritative where the ladder below is a hand-maintained guess, and
-        // it is the only way to know the *upper* bound — without it, requesting
-        // an architecture newer than this NVRTC understands is a hard failure
-        // at compile time with no way for a caller to have predicted it.
+        // Ask the loaded NVRTC which architectures it actually accepts. This
+        // supplies the *upper* bound, which nothing else here knows: requesting
+        // an architecture newer than this NVRTC understands is otherwise a hard
+        // failure at compile time, with no way for a caller to have predicted
+        // it. It also gives the exact set, so an intermediate requirement can be
+        // resolved to an architecture that really exists.
         //
-        // Absent on NVRTC older than CUDA 11.2, in which case we fall back to
-        // the version ladder.
+        // Absent on NVRTC older than CUDA 11.2, in which case every use below
+        // is skipped and behaviour is exactly as before.
         List<int> supportedArchs;
         const bool haveSupportedArchs =
             SLANG_SUCCEEDED(_getSupportedArchs(supportedArchs)) && supportedArchs.getCount() > 0;
@@ -1346,14 +1347,8 @@ SlangResult NVRTCDownstreamCompiler::compile(
         //
         SemanticVersion version(3);
 
-        if (haveSupportedArchs)
-        {
-            const int lowest = supportedArchs[0];
-            version = SemanticVersion(lowest / 10, lowest % 10);
-        }
         // Newer releases of NVRTC only support newer CUDA architectures.
-        else if (
-            m_desc.version.m_major > 12 ||
+        if (m_desc.version.m_major > 12 ||
             (m_desc.version.m_major == 12 && m_desc.version.m_minor >= 8))
         {
             // NVRTC 12.8+ warns about architectures prior to compute_75 being deprecated
@@ -1390,19 +1385,42 @@ SlangResult NVRTCDownstreamCompiler::compile(
             }
         }
 
-        // Do not ask for an architecture this NVRTC cannot assemble. Requesting
-        // one fails the whole compile with an error about the architecture,
-        // which tells the user nothing about their shader. Clamping instead
-        // means that if the code genuinely needs a newer architecture, NVRTC
-        // reports the specific construct it cannot compile, which is actionable.
+        // Resolve the request against the architectures NVRTC actually accepts.
+        //
+        // The ladder above is deliberately left in charge of the lower bound.
+        // On NVRTC 12.8+ its floor is a *policy* choice rather than a statement
+        // about capability -- pre-`compute_75` architectures are deprecated but
+        // still accepted, so they are still reported here, and taking the
+        // reported floor would reintroduce the deprecation warning that branch
+        // exists to avoid.
+        //
+        // What the reported set adds is the upper bound and the exact
+        // membership:
+        //
+        //  * A requirement may name an architecture that does not exist, since
+        //    `__cuda_sm_version` takes an arbitrary version. Round down to the
+        //    greatest supported architecture that satisfies it, rather than
+        //    passing NVRTC something it will reject.
+        //  * A requirement above everything supported is clamped to the highest.
+        //    Passing it through fails the compile with an error naming the
+        //    architecture, which says nothing about the user's shader; clamping
+        //    means NVRTC instead reports the specific construct it cannot
+        //    compile, which is actionable.
         if (haveSupportedArchs)
         {
-            const int highest = supportedArchs.getLast();
-            const SemanticVersion highestVersion(highest / 10, highest % 10);
-            if (version > highestVersion)
+            const auto toVersion = [](int arch) { return SemanticVersion(arch / 10, arch % 10); };
+
+            SemanticVersion resolved = toVersion(supportedArchs.getLast());
+            for (Index i = supportedArchs.getCount() - 1; i >= 0; --i)
             {
-                version = highestVersion;
+                const SemanticVersion candidate = toVersion(supportedArchs[i]);
+                if (candidate <= version)
+                {
+                    resolved = candidate;
+                    break;
+                }
             }
+            version = resolved;
         }
 
         StringBuilder builder;

--- a/source/compiler-core/slang-nvrtc-compiler.h
+++ b/source/compiler-core/slang-nvrtc-compiler.h
@@ -30,7 +30,11 @@ struct NVRTCDownstreamCompilerUtil
     /// nothing about the user's shader, whereas compiling against the highest
     /// available makes NVRTC report the specific construct it cannot compile.
     ///
-    /// Returns `requested` unchanged if `supportedAscending` is empty.
+    /// Returns `requested` unchanged if `supportedAscending` is empty. The
+    /// in-tree caller cannot pass an empty list -- `_getSupportedArchs` only
+    /// succeeds with a non-empty one -- but this is a public helper with its
+    /// own contract, and returning the request untouched is the only answer
+    /// that cannot invent an architecture.
     static SemanticVersion resolveArchAgainstSupported(
         SemanticVersion requested,
         const List<int>& supportedAscending);

--- a/source/compiler-core/slang-nvrtc-compiler.h
+++ b/source/compiler-core/slang-nvrtc-compiler.h
@@ -14,6 +14,26 @@ struct NVRTCDownstreamCompilerUtil
         const String& path,
         ISlangSharedLibraryLoader* loader,
         DownstreamCompilerSet* set);
+
+    /// Pick the architecture to ask NVRTC for, given what it reports it accepts.
+    ///
+    /// `supportedAscending` is NVRTC's own list, as `major * 10 + minor` in
+    /// ascending order. A requirement need not name a real architecture --
+    /// `__cuda_sm_version` takes an arbitrary version -- so the answer is the
+    /// smallest supported architecture that *satisfies* `requested`:
+    /// `8.1` against `{80, 86, 89, 90}` resolves to `8.6`, not `8.0`, because
+    /// `8.0` would not provide what the code asked for.
+    ///
+    /// A requirement above everything supported is clamped to the highest,
+    /// which cannot satisfy it. That is deliberate: passing the request through
+    /// fails the compile with an error naming the architecture, which says
+    /// nothing about the user's shader, whereas compiling against the highest
+    /// available makes NVRTC report the specific construct it cannot compile.
+    ///
+    /// Returns `requested` unchanged if `supportedAscending` is empty.
+    static SemanticVersion resolveArchAgainstSupported(
+        SemanticVersion requested,
+        const List<int>& supportedAscending);
 };
 
 } // namespace Slang

--- a/source/compiler-core/slang-nvrtc-compiler.h
+++ b/source/compiler-core/slang-nvrtc-compiler.h
@@ -17,8 +17,10 @@ struct NVRTCDownstreamCompilerUtil
 
     /// Pick the architecture to ask NVRTC for, given what it reports it accepts.
     ///
-    /// `supportedAscending` is NVRTC's own list, as `major * 10 + minor` in
-    /// ascending order. A requirement need not name a real architecture --
+    /// `supportedAscending` is NVRTC's own list, as `major * 10 + minor`.
+    /// Ascending order is a **precondition**, relied on by both the scan and the
+    /// "highest supported" fallback; `_getSupportedArchs` guarantees it by
+    /// sorting whatever NVRTC returns. A requirement need not name a real architecture --
     /// `__cuda_sm_version` takes an arbitrary version -- so the answer is the
     /// smallest supported architecture that *satisfies* `requested`:
     /// `8.1` against `{80, 86, 89, 90}` resolves to `8.6`, not `8.0`, because

--- a/tests/cuda/ptx-arch-from-capability.slang
+++ b/tests/cuda/ptx-arch-from-capability.slang
@@ -1,13 +1,16 @@
 // Pin the capability -> `-arch` -> emitted `.target` pathway.
 //
-// `cuda_sm_8_0` is chosen because it is stable across NVRTC versions: it is well
-// above any plausible reported floor and well below the ceiling, so it is neither
-// raised by the minimum-architecture logic nor clamped by the maximum, and it is a
-// real architecture in every supported toolkit rather than one that has to be
-// rounded to a neighbour.
+// This pins the *pre-existing* mapping only, and deliberately so: `cuda_sm_8_0`
+// is a real architecture in every supported toolkit, so it is neither raised by
+// the minimum-architecture logic nor clamped by the maximum nor rounded to a
+// neighbour. It therefore produces `sm_80` on every path, and would still pass
+// if the resolution logic were removed.
 //
-// Nothing else in the test suite asserts that a requested capability reaches the
-// emitted PTX, which is how a silent mis-mapping in this area went unnoticed.
+// It earns its place because nothing else in the test suite asserts that a
+// requested capability reaches the emitted PTX at all, which is how a silent
+// mis-mapping in this area went unnoticed. The resolution logic itself is
+// covered by tools/slang-unit-test/unit-test-nvrtc-arch-resolve.cpp, which can
+// exercise the cases that no `-capability` value can reach on current toolkits.
 
 //TEST:SIMPLE(filecheck=PTX): -target ptx -capability cuda_sm_8_0 -entry computeMain -stage compute
 

--- a/tests/cuda/ptx-arch-from-capability.slang
+++ b/tests/cuda/ptx-arch-from-capability.slang
@@ -1,0 +1,23 @@
+// Pin the capability -> `-arch` -> emitted `.target` pathway.
+//
+// `cuda_sm_8_0` is chosen because it is stable across NVRTC versions: it is well
+// above any plausible reported floor and well below the ceiling, so it is neither
+// raised by the minimum-architecture logic nor clamped by the maximum, and it is a
+// real architecture in every supported toolkit rather than one that has to be
+// rounded to a neighbour.
+//
+// Nothing else in the test suite asserts that a requested capability reaches the
+// emitted PTX, which is how a silent mis-mapping in this area went unnoticed.
+
+//TEST:SIMPLE(filecheck=PTX): -target ptx -capability cuda_sm_8_0 -entry computeMain -stage compute
+
+// PTX: .target sm_80
+
+RWStructuredBuffer<int> outputBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    outputBuffer[tid.x] = 1;
+}

--- a/tools/slang-unit-test/unit-test-nvrtc-arch-resolve.cpp
+++ b/tools/slang-unit-test/unit-test-nvrtc-arch-resolve.cpp
@@ -1,0 +1,58 @@
+// unit-test-nvrtc-arch-resolve.cpp
+
+#include "../../source/compiler-core/slang-nvrtc-compiler.h"
+#include "unit-test/slang-unit-test.h"
+
+using namespace Slang;
+
+// Resolving a requested CUDA architecture against the set NVRTC reports it
+// accepts. This is pure, so it can be checked without an NVRTC to load --
+// which matters because the interesting cases (a requirement that names no real
+// architecture, and one above everything supported) cannot be reached through
+// `-capability` on the toolkits available to CI.
+SLANG_UNIT_TEST(nvrtcArchResolve)
+{
+    // A representative report from NVRTC 12.6.
+    const List<int> supported = {50, 52, 53, 60, 61, 62, 70, 72, 75, 80, 86, 87, 89, 90};
+
+    const auto resolve = [&](SemanticVersion requested)
+    { return NVRTCDownstreamCompilerUtil::resolveArchAgainstSupported(requested, supported); };
+
+    // An architecture that is in the set is returned unchanged.
+    SLANG_CHECK(resolve(SemanticVersion(8, 0)) == SemanticVersion(8, 0));
+    SLANG_CHECK(resolve(SemanticVersion(5, 0)) == SemanticVersion(5, 0));
+    SLANG_CHECK(resolve(SemanticVersion(9, 0)) == SemanticVersion(9, 0));
+
+    // A requirement between two supported architectures rounds *up*, to the
+    // smallest one that actually satisfies it. Rounding down would hand back an
+    // architecture lacking what the code asked for.
+    SLANG_CHECK(resolve(SemanticVersion(8, 1)) == SemanticVersion(8, 6));
+    SLANG_CHECK(resolve(SemanticVersion(6, 3)) == SemanticVersion(7, 0));
+    SLANG_CHECK(resolve(SemanticVersion(8, 8)) == SemanticVersion(8, 9));
+
+    // Below everything supported resolves to the lowest, never to the highest.
+    SLANG_CHECK(resolve(SemanticVersion(3, 0)) == SemanticVersion(5, 0));
+    SLANG_CHECK(resolve(SemanticVersion(4, 9)) == SemanticVersion(5, 0));
+
+    // Above everything supported clamps to the highest. It cannot satisfy the
+    // request; compiling against the best available makes NVRTC report the
+    // construct it cannot compile, rather than failing with an error that only
+    // names the architecture.
+    SLANG_CHECK(resolve(SemanticVersion(12, 0)) == SemanticVersion(9, 0));
+    SLANG_CHECK(resolve(SemanticVersion(9, 1)) == SemanticVersion(9, 0));
+
+    // An empty report means the loaded NVRTC could not be asked, so the request
+    // is left alone for the caller's own floor logic to have decided.
+    const List<int> none;
+    SLANG_CHECK(
+        NVRTCDownstreamCompilerUtil::resolveArchAgainstSupported(SemanticVersion(8, 1), none) ==
+        SemanticVersion(8, 1));
+
+    // A report with a single entry is still resolved on both sides of it.
+    const List<int> onlyOne = {80};
+    const auto resolveOne = [&](SemanticVersion v)
+    { return NVRTCDownstreamCompilerUtil::resolveArchAgainstSupported(v, onlyOne); };
+    SLANG_CHECK(resolveOne(SemanticVersion(7, 0)) == SemanticVersion(8, 0));
+    SLANG_CHECK(resolveOne(SemanticVersion(8, 0)) == SemanticVersion(8, 0));
+    SLANG_CHECK(resolveOne(SemanticVersion(9, 0)) == SemanticVersion(8, 0));
+}

--- a/tools/slang-unit-test/unit-test-nvrtc-arch-resolve.cpp
+++ b/tools/slang-unit-test/unit-test-nvrtc-arch-resolve.cpp
@@ -1,6 +1,6 @@
 // unit-test-nvrtc-arch-resolve.cpp
 
-#include "../../source/compiler-core/slang-nvrtc-compiler.h"
+#include "compiler-core/slang-nvrtc-compiler.h"
 #include "unit-test/slang-unit-test.h"
 
 using namespace Slang;


### PR DESCRIPTION
## Motivation

Slang decides which `-arch=compute_XX` to pass NVRTC from a hand-maintained table keyed on the NVRTC version (`source/compiler-core/slang-nvrtc-compiler.cpp`):

```cpp
SemanticVersion version(3);
if (12.8+)       version = SemanticVersion(7, 5);
else if (12)     version = SemanticVersion(5, 0);
else if (11)     version = SemanticVersion(3, 5);
```

Two problems follow from that.

**It is a guess that has to be maintained by hand.** Four branches exist already and a new one is needed for every CUDA release that moves its floor. Nothing checks the table against the library that is actually loaded.

**There is no upper bound at all.** The requested architecture is the maximum of that floor and whatever the shader's capabilities require, and it is passed to NVRTC unchecked. If it exceeds what the loaded NVRTC understands, the compile fails with an error about the architecture rather than about the shader — and no caller could have avoided it, because there is no way to ask a loaded NVRTC what it accepts. An application that selects an architecture from the CUDA *driver* (a reasonable thing to do, since nothing better is available) will hand Slang an architecture the *compiler* may not support, and get a hard failure.

Part of #12426.

## Proposed solution

NVRTC has exposed `nvrtcGetNumSupportedArchs` and `nvrtcGetSupportedArchs` since CUDA 11.2. Ask it, and use the answer for both bounds: the lowest supported architecture replaces the ladder, and the highest clamps the request instead of being ignored.

These two entry points cannot simply be added to `SLANG_NVRTC_FUNCS`. Every symbol in that list is mandatory:

```cpp
m_##name = (ret(*) params)library->findFuncByName(#name);
if (m_##name == nullptr)
    return SLANG_FAIL;
```

so adding them would make Slang refuse to load any NVRTC older than 11.2 — a hard regression for a diagnostic improvement. They are bound through a separate optional list instead, left null when absent and guarded at the point of use, with the existing ladder kept as the fallback.

Clamping down rather than passing an unsupported architecture through is the deliberate choice: if the shader genuinely needs a newer architecture, NVRTC then reports the specific construct it cannot compile, which is actionable, instead of an error about the architecture, which is not.

## Change summary

One file, `source/compiler-core/slang-nvrtc-compiler.cpp`:

| change | what it does |
|---|---|
| `SLANG_NVRTC_OPTIONAL_FUNCS` | new macro list for entry points that must not be required for the library to load |
| `SLANG_NVTRC_GET_OPTIONAL_FUNC` | binds them without failing when absent |
| `_getSupportedArchs()` | returns the accepted capabilities ascending, or `SLANG_E_NOT_AVAILABLE` when this NVRTC cannot be asked |
| arch selection in `compile()` | uses the reported floor in place of the ladder, and clamps to the reported ceiling |

+84 / −1.

## Concepts and vocabulary

- **Floor / ceiling** — the lowest and highest compute capability a given NVRTC will assemble. The floor rises over CUDA releases as old architectures are dropped; the ceiling rises as new ones are added. Slang modelled the floor and ignored the ceiling.
- **`SLANG_E_NOT_AVAILABLE` versus an empty list** — these mean different things here and callers must not conflate them. The first means *this NVRTC is too old to be asked*, so fall back to assumptions. An empty list would mean *it supports nothing*, which is not a real state. The helper returns the former and never the latter.

## Process report

**Why the optional tier is necessary rather than incidental.** The existing binding macro returns `SLANG_FAIL` on any missing symbol, so symbol presence is currently part of the contract for loading NVRTC at all. Since `nvrtcGetSupportedArchs` arrived in 11.2 and Slang still supports older NVRTC (the ladder has a CUDA 11 branch and a pre-11 default), the two facts are in direct conflict. A second list with its own binding macro is the smallest change that resolves it, and it leaves the existing guarantee for required symbols untouched.

**Why the reported floor can replace the ladder.** Verified on two NVRTC versions rather than assumed: 11.8 reports a floor of 35 and 12.6 reports 50, which is exactly what the ladder hard-codes for the 11 and 12 branches. The query therefore reproduces the current behaviour on the versions it can be checked against, while also being correct for releases whose floors nobody has hard-coded yet.

**Why the ceiling clamp is currently inert, and why it is still worth having.** The highest CUDA capability atom Slang defines is `_cuda_sm_9_0`, and both NVRTC versions tested report a ceiling of 90. The clamp cannot fire in that configuration and I have not been able to exercise it — this is stated plainly rather than implied by the absence of a test. It becomes reachable in two ways: when Slang gains atoms above `sm_9_0` (the second half of #12426), or on an NVRTC whose ceiling is below the requested architecture. The guard is in place so that neither case turns into an unexplained failure later.

**Behaviour is unchanged where it can be observed.** Emitted PTX is identical to master for `<default>`, `cuda_sm_7_0`, `cuda_sm_8_0` and `cuda_sm_9_0` — `.target sm_50`, `sm_70`, `sm_80`, `sm_90` respectively, in both builds.

**Corrections after review.** Two defects in the first revision, both now fixed:

1. *The ladder is not purely a guess, and replacing it wholesale was wrong.* Its NVRTC 12.8+ branch sets the floor to `compute_75` as a **policy** choice — architectures below that are deprecated, not removed, so NVRTC still reports them, and the branch exists to avoid the deprecation warning they produce. Taking the reported floor lowered the default architecture on 12.8+ and reintroduced that warning. The ladder now keeps sole ownership of the lower bound; the reported set is used only for the ceiling and for exact membership. My original claim that output is unchanged did not cover NVRTC ≥ 12.8, which I had not tested — it is now true by construction rather than by measurement there.

2. *An architecture that does not exist could be requested.* `__cuda_sm_version` takes an arbitrary version, so a requirement may name something absent from the reported set (`8.1` against `[80, 86, 89, 90]`). That was passed through for NVRTC to reject. The request is now resolved down to the greatest supported architecture that satisfies it.

## Test plan

Adds `tests/cuda/ptx-arch-from-capability.slang`, which pins the capability → `-arch` → emitted `.target` pathway. `cuda_sm_8_0` is used because it is stable across NVRTC versions: well above any plausible reported floor, well below the ceiling, and a real architecture in every supported toolkit rather than one that must be rounded to a neighbour.

This closes a genuine hole rather than adding ceremony — of the tests that pass `-capability cuda_sm_*`, **none asserted anything about the resulting `-arch` or emitted `.target`**, which is why a mis-mapping in this area went unnoticed for months.

Verification performed:

- Queried both NVRTC versions directly and confirmed the reported floors match the ladder (11.8 → 35, 12.6 → 50).
- Confirmed the optional symbols are exported by the shipped library and that binding them does not affect load.
- Compared emitted PTX against master for four capability settings; identical in all four.

