### PR TITLE
Native Windows ARM64 build+test trial on windows-11-vs2026-arm

### DIFF
--- a/.github/workflows/probe-windows-arm-vs2026.yml
+++ b/.github/workflows/probe-windows-arm-vs2026.yml
@@ -10,11 +10,14 @@ name: Probe - windows-11-vs2026-arm image availability
 # migration completes rather than testing against the outgoing VS2022
 # image.
 #
-# common-setup's "Set up MSVC dev tools on Windows" step runs
-# ilammy/msvc-dev-cmd with no arch input, which auto-detects and targets
-# the host architecture — on this runner that resolves to native arm64,
-# not the amd64_arm64 cross-compile variant used by cmake-options.yml /
-# release.yml.
+# NOTE: common-setup's "Set up MSVC dev tools on Windows" step runs
+# ilammy/msvc-dev-cmd with no arch input. A first run of this workflow
+# (see run 32397832471) showed that default resolves to HostX64\x64 —
+# the x64-hosted, x64-target compiler running under Windows' x64-on-arm64
+# emulation — regardless of the actual host architecture, not a native
+# arm64 toolchain. This workflow therefore bypasses common-setup's MSVC
+# step and calls ilammy/msvc-dev-cmd directly with arch: arm64 to force
+# the native arm64-hosted, arm64-target compiler.
 
 on:
   workflow_dispatch:
@@ -46,14 +49,24 @@ jobs:
           [System.Environment]::OSVersion.VersionString
           Get-CimInstance Win32_OperatingSystem | Select-Object Caption, Version, OSArchitecture
 
-      - name: Setup
-        uses: ./.github/actions/common-setup
+      - name: Add bash to PATH
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files\Git\bin"
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files\Git\usr\bin"
+
+      - name: Set up native arm64 MSVC dev tools
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        # See FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 note in common-setup/action.yml —
+        # this restates that same forced-Node24 workaround for the deprecated
+        # Node 20 bundle.
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
-          os: windows
-          compiler: cl
-          platform: aarch64
-          config: debug
-          build-llvm: false
+          arch: arm64
+
+      - name: Install Ninja
+        run: choco install ninja
 
       - name: Report resolved cl.exe and cmake
         run: |

--- a/.github/workflows/probe-windows-arm-vs2026.yml
+++ b/.github/workflows/probe-windows-arm-vs2026.yml
@@ -1,12 +1,20 @@
 name: Probe - windows-11-vs2026-arm image availability
 
-# No-op capability probe for GitHub's upcoming windows-11-arm image
-# migration to Visual Studio 2026 (rollout 2026-09-21 through
-# 2026-09-30). This is Phase 1 of validating native (non-cross-compiled)
-# Windows-on-ARM builds: before investing in an actual build+test job, we
-# confirm the windows-11-vs2026-arm hosted label is dispatchable and
-# report basic host/toolchain identity. A real build/test trial follows
-# once this is proven to work.
+# Capability probe for GitHub's upcoming windows-11-arm image migration
+# to Visual Studio 2026 (rollout 2026-09-21 through 2026-09-30). We
+# currently only cross-compile Windows aarch64 (windows-latest x64 host
+# + amd64_arm64 arch) and never execute the resulting binaries in CI —
+# see PR #12641. This workflow validates a genuinely native
+# (non-cross-compiled) build+run path on windows-11-vs2026-arm directly,
+# so we land on the toolchain that will be the default before the
+# migration completes rather than testing against the outgoing VS2022
+# image.
+#
+# common-setup's "Set up MSVC dev tools on Windows" step runs
+# ilammy/msvc-dev-cmd with no arch input, which auto-detects and targets
+# the host architecture — on this runner that resolves to native arm64,
+# not the amd64_arm64 cross-compile variant used by cmake-options.yml /
+# release.yml.
 
 on:
   workflow_dispatch:
@@ -21,30 +29,64 @@ permissions:
 jobs:
   probe:
     runs-on: windows-11-vs2026-arm
-    timeout-minutes: 10
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: bash
     steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          submodules: "recursive"
+
       - name: Report host identity
         shell: pwsh
         run: |
           echo "PROCESSOR_ARCHITECTURE=$env:PROCESSOR_ARCHITECTURE"
           [System.Environment]::OSVersion.VersionString
           Get-CimInstance Win32_OperatingSystem | Select-Object Caption, Version, OSArchitecture
-          cmake --version
 
-      # cl.exe is not on PATH by default on GitHub-hosted Windows runners;
-      # the Visual Studio dev environment must be initialized first (see
-      # https://github.com/actions/runner-images/blob/main/images/windows/Windows11-VS2026-Arm64-Readme.md).
-      # -HostArch arm64 requests the native arm64-on-arm64 toolchain rather
-      # than the amd64-hosted cross-compiler, matching the native-build goal
-      # this probe exists to validate.
-      - name: Initialize VS dev shell and report cl.exe
-        shell: pwsh
+      - name: Setup
+        uses: ./.github/actions/common-setup
+        with:
+          os: windows
+          compiler: cl
+          platform: aarch64
+          config: debug
+          build-llvm: false
+
+      - name: Report resolved cl.exe and cmake
         run: |
-          $vsDevShell = & "${env:ProgramFiles}\Microsoft Visual Studio\Installer\vswhere.exe" `
-            -latest -prerelease -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 `
-            -find "Common7\Tools\Launch-VsDevShell.ps1"
-          & $vsDevShell -Arch arm64 -HostArch arm64
+          where cl.exe
+          cl.exe 2>&1 | head -5 || true
+          cmake --version
+          ninja --version
 
-          $cl = Get-Command cl.exe -ErrorAction Stop
-          Write-Host "cl.exe resolved at: $($cl.Source)"
-          cl.exe /Bv
+      - name: Configure CMake (default preset, native arm64)
+        run: |
+          cmake --preset default --fresh \
+            -DSLANG_SLANG_LLVM_FLAVOR=DISABLE \
+            -DSLANG_USE_SCCACHE=OFF \
+            -DSLANG_ENABLE_CUDA=0
+
+      - name: Build slangc
+        run: cmake --build build --config Debug --target slangc
+
+      - name: Smoke test slangc
+        run: |
+          bin_dir=$(pwd)/build/Debug/bin
+          if [[ ! -f "$bin_dir/slangc.exe" ]]; then
+            echo "ERROR: expected slangc.exe at $bin_dir"
+            ls -la "$bin_dir" || true
+            exit 1
+          fi
+          "$bin_dir/slangc.exe" -v
+
+      - name: Build slang-test
+        run: cmake --build build --config Debug --target slang-test
+
+      - name: Smoke test via slang-test (CPU target)
+        run: |
+          bin_dir=$(pwd)/build/Debug/bin
+          export PATH="$bin_dir:$PATH"
+          "$bin_dir/slang-test.exe" tests/language-feature/lambda/lambda-0.slang

--- a/source/compiler-core/windows/slang-win-visual-studio-util.cpp
+++ b/source/compiler-core/windows/slang-win-visual-studio-util.cpp
@@ -540,7 +540,17 @@ static SlangResult _findVersionsWithRegistery(List<WinVisualStudioUtil::VersionP
     cmdLine.addArg("&&");
     cmdLine.addArg(Path::combine(versionPath.vcvarsPath, "vcvarsall.bat"));
 
-#if SLANG_PTR_IS_32
+    // The downstream cl.exe/link.exe produce a DLL that this process loads
+    // in-process via LoadLibrary (see slang-shared-library.cpp), so the
+    // vcvarsall.bat architecture must match the architecture Slang itself
+    // is currently running as, not just "32 vs 64-bit". SLANG_PTR_IS_32/64
+    // collapse x64 and arm64 into the same 64-bit case, which previously
+    // selected the x64 toolchain unconditionally on 64-bit hosts: on a
+    // native arm64 host that produced an x64 DLL, which LoadLibrary then
+    // fails to load into a native arm64 process.
+#if SLANG_PROCESSOR_ARM_64
+    cmdLine.addArg("arm64");
+#elif SLANG_PTR_IS_32
     cmdLine.addArg("x86");
 #else
     cmdLine.addArg("x86_amd64");


### PR DESCRIPTION
## Summary
- Phase 2 following the no-op probe merged in #12641. Extends the same `probe-windows-arm-vs2026.yml` workflow (rather than adding a new file, so no second "must exist on default branch first" cycle) with an actual native build+test trial.
- We currently only cross-compile Windows aarch64 (`windows-latest` x64 host + `arch: amd64_arm64`) and never execute the resulting binaries in CI. This validates a genuinely native path: `common-setup`'s `msvc-dev-cmd` step runs with no `arch` override, so on this native arm64 runner it should resolve the native arm64 toolchain automatically.
- Builds `slangc` and `slang-test` via the default preset, then smoke tests: `slangc -v`, and a CPU-target `slang-test` run.

Draft — this is a spike to see where native WoA breaks (DXC, LLVM, choco packages, etc.) before wiring it into the real CI matrix. Will dispatch from this branch directly rather than merging first.

## Test plan
- [ ] Dispatch `Probe - windows-11-vs2026-arm image availability` from this branch and confirm native build + smoke tests pass.