### PR TITLE
Handle empty logical copies during legalization

### DIFF
--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -2548,6 +2548,10 @@ Result linkAndOptimizeIR(
     //
     SLANG_PASS(legalizeEmptyTypes, targetProgram, sink);
 
+    // Empty-type legalization can leave `Void` placeholders in retained struct shapes. Remove
+    // those placeholders before they reach target-specific legalization and emission.
+    SLANG_PASS(cleanUpVoidType);
+
     // As a late step, we need to take the SSA-form IR and move things *out*
     // of SSA form, by eliminating all "phi nodes" (block parameters) and
     // introducing explicit temporaries instead. Doing this at the IR level

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -2121,14 +2121,6 @@ static LegalVal legalizeInst(
         result = legalizeStore(context, args[0], args[1]);
         break;
 
-    case kIROp_CopyLogical:
-        // Consider a physical-to-logical copy between two empty structs. Empty-type
-        // legalization removes both pointer operands, and there are no fields left to copy.
-        SLANG_RELEASE_ASSERT(args.getCount() >= 2);
-        SLANG_RELEASE_ASSERT(
-            args[0].flavor == LegalVal::Flavor::none && args[1].flavor == LegalVal::Flavor::none);
-        return LegalVal();
-
     case kIROp_Call:
         result = legalizeCall(context, (IRCall*)inst);
         break;

--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -2121,6 +2121,14 @@ static LegalVal legalizeInst(
         result = legalizeStore(context, args[0], args[1]);
         break;
 
+    case kIROp_CopyLogical:
+        // Consider a physical-to-logical copy between two empty structs. Empty-type
+        // legalization removes both pointer operands, and there are no fields left to copy.
+        SLANG_RELEASE_ASSERT(args.getCount() >= 2);
+        SLANG_RELEASE_ASSERT(
+            args[0].flavor == LegalVal::Flavor::none && args[1].flavor == LegalVal::Flavor::none);
+        return LegalVal();
+
     case kIROp_Call:
         result = legalizeCall(context, (IRCall*)inst);
         break;

--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -309,6 +309,9 @@ bool isValueType(IRInst* dataType)
     case kIROp_InterfaceType:
     case kIROp_ClassType:
     case kIROp_VectorType:
+    // Cooperative vectors are first-class numeric values, not handles through which a call can
+    // produce side effects.
+    case kIROp_CoopVectorType:
     case kIROp_MatrixType:
     case kIROp_TupleType:
     case kIROp_ResultType:

--- a/tests/autodiff/coopvec-resource-context-composition.slang
+++ b/tests/autodiff/coopvec-resource-context-composition.slang
@@ -5,9 +5,9 @@
 // CHECK-NEXT: 0.000000
 // CHECK-NEXT: 3.000000
 
-// Resource legalization leaves an empty differential context for `Consumer` after hoisting its
-// resource field. Buffer-element lowering then copies between physical and logical versions of the
-// empty struct. Empty-type legalization must remove that copy after both operands disappear.
+// Exercise the full reverse-mode composition of a CoopVec producer and a resource-backed consumer.
+// `coopvec-resource-context-dce.slang` isolates the dead rematerialization in this composition, and
+// `resource-context-void-cleanup.slang` isolates its empty-context cleanup.
 
 CoopVec<half, 2> customTransform(
     no_diff RWStructuredBuffer<float> gradient,

--- a/tests/autodiff/coopvec-resource-context-composition.slang
+++ b/tests/autodiff/coopvec-resource-context-composition.slang
@@ -1,0 +1,89 @@
+//TEST:SIMPLE: -target spirv -entry computeMain -stage compute -o tests/autodiff/coopvec-resource-context-composition.spv
+
+// Resource legalization leaves an empty differential context for `Consumer` after hoisting its
+// resource field. Buffer-element lowering then copies between physical and logical versions of the
+// empty struct. Empty-type legalization must remove that copy after both operands disappear.
+
+CoopVec<half, 2> customTransform(
+    no_diff RWStructuredBuffer<float> gradient,
+    CoopVec<half, 2> input)
+{
+    return input;
+}
+
+[BackwardDerivativeOf(customTransform)]
+void customTransformBackward(
+    RWStructuredBuffer<float> gradient,
+    inout DifferentialPair<CoopVec<half, 2>> input,
+    CoopVec<half, 2> resultGradient)
+{
+    gradient[0] += float(resultGradient[0]) * float(input.p[0]);
+    input = diffPair(input.p, resultGradient);
+}
+
+struct Identity
+{
+    [Differentiable]
+    CoopVec<half, 2> eval(CoopVec<half, 2> input)
+    {
+        return input;
+    }
+}
+
+struct Consumer
+{
+    RWStructuredBuffer<float> gradient;
+    Identity activation;
+
+    [Differentiable]
+    [NoDiffThis]
+    CoopVec<half, 2> eval(CoopVec<half, 2> input)
+    {
+        return activation.eval(customTransform(gradient, input));
+    }
+}
+
+struct Producer
+{
+    RWStructuredBuffer<float> gradient;
+    uint resolution;
+}
+
+[BackwardDifferentiable]
+CoopVec<half, 2> encode(no_diff Producer producer)
+{
+    CoopVec<half, 2> result;
+    result[0] = half(producer.resolution);
+    result[1] = half(producer.resolution + 1);
+    return result;
+}
+
+[BackwardDerivativeOf(encode)]
+void encodeBackward(Producer producer, CoopVec<half, 2> resultGradient)
+{
+    producer.gradient[0] += float(resultGradient[0]);
+    producer.gradient[1] += float(resultGradient[1]);
+}
+
+struct Model
+{
+    Producer producer;
+    Consumer consumer;
+}
+
+[Differentiable]
+half objective(no_diff Model model, float scale)
+{
+    let encoded = encode(model.producer);
+    let output = model.consumer.eval(encoded);
+    return output[0] * half(scale);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+[require(spvCooperativeVectorNV)]
+void computeMain(uniform Model model)
+{
+    var scale = diffPair(1.0);
+    bwd_diff(objective)(model, scale, half(1.0));
+}

--- a/tests/autodiff/coopvec-resource-context-composition.slang
+++ b/tests/autodiff/coopvec-resource-context-composition.slang
@@ -1,4 +1,9 @@
-//TEST:SIMPLE: -target spirv -entry computeMain -stage compute -o tests/autodiff/coopvec-resource-context-composition.spv
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -render-feature cooperative-vector -output-using-type -g0
+
+// CHECK: type: float
+// CHECK-NEXT: 1.000000
+// CHECK-NEXT: 0.000000
+// CHECK-NEXT: 3.000000
 
 // Resource legalization leaves an empty differential context for `Consumer` after hoisting its
 // resource field. Buffer-element lowering then copies between physical and logical versions of the
@@ -71,6 +76,12 @@ struct Model
     Consumer consumer;
 }
 
+//TEST_INPUT: set model.producer.gradient = ubuffer(data=[0.0 0.0], stride=4)
+//TEST_INPUT: set model.producer.resolution = 3
+//TEST_INPUT: set model.consumer.gradient = ubuffer(data=[0.0], stride=4)
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0.0 0.0 0.0], stride=4)
+RWStructuredBuffer<float> outputBuffer;
+
 [Differentiable]
 half objective(no_diff Model model, float scale)
 {
@@ -86,4 +97,7 @@ void computeMain(uniform Model model)
 {
     var scale = diffPair(1.0);
     bwd_diff(objective)(model, scale, half(1.0));
+    outputBuffer[0] = model.producer.gradient[0];
+    outputBuffer[1] = model.producer.gradient[1];
+    outputBuffer[2] = model.consumer.gradient[0];
 }

--- a/tests/autodiff/coopvec-resource-context-composition.slang
+++ b/tests/autodiff/coopvec-resource-context-composition.slang
@@ -92,7 +92,6 @@ half objective(no_diff Model model, float scale)
 
 [shader("compute")]
 [numthreads(1, 1, 1)]
-[require(spvCooperativeVectorNV)]
 void computeMain(uniform Model model)
 {
     var scale = diffPair(1.0);

--- a/tests/autodiff/coopvec-resource-context-dce.slang
+++ b/tests/autodiff/coopvec-resource-context-dce.slang
@@ -1,0 +1,77 @@
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -render-feature cooperative-vector -output-using-type -g0
+
+// CHECK: type: float
+// CHECK-NEXT: 1.000000
+// CHECK-NEXT: 3.000000
+
+// Reverse-mode AD temporarily rematerializes `Consumer.eval` while differentiating the CoopVec
+// subscript in `objective`. That rematerialization is unused and read-none, so DCE must recognize
+// its CoopVec argument as a value and remove the call before resource and buffer legalization.
+
+CoopVec<half, 1> customTransform(
+    no_diff RWStructuredBuffer<float> gradient,
+    CoopVec<half, 1> input)
+{
+    return input;
+}
+
+[BackwardDerivativeOf(customTransform)]
+void customTransformBackward(
+    RWStructuredBuffer<float> gradient,
+    inout DifferentialPair<CoopVec<half, 1>> input,
+    CoopVec<half, 1> resultGradient)
+{
+    gradient[0] += float(resultGradient[0]);
+    input = diffPair(input.p, resultGradient);
+}
+
+struct Identity
+{
+    [Differentiable]
+    CoopVec<half, 1> eval(CoopVec<half, 1> input)
+    {
+        return input;
+    }
+}
+
+struct Consumer
+{
+    RWStructuredBuffer<float> gradient;
+    Identity activation;
+
+    [Differentiable]
+    [NoDiffThis]
+    CoopVec<half, 1> eval(CoopVec<half, 1> input)
+    {
+        return activation.eval(customTransform(gradient, input));
+    }
+}
+
+struct Model
+{
+    uint value;
+    Consumer consumer;
+}
+
+//TEST_INPUT: set model.value = 3
+//TEST_INPUT: set model.consumer.gradient = ubuffer(data=[0.0], stride=4)
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0.0 0.0], stride=4)
+RWStructuredBuffer<float> outputBuffer;
+
+[Differentiable]
+half objective(no_diff Model model, float scale)
+{
+    CoopVec<half, 1> input;
+    input[0] = half(model.value);
+    return model.consumer.eval(input)[0] * half(scale);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uniform Model model)
+{
+    var scale = diffPair(1.0);
+    bwd_diff(objective)(model, scale, half(1.0));
+    outputBuffer[0] = model.consumer.gradient[0];
+    outputBuffer[1] = scale.d;
+}

--- a/tests/autodiff/resource-context-void-cleanup.slang
+++ b/tests/autodiff/resource-context-void-cleanup.slang
@@ -1,0 +1,73 @@
+//TEST(compute, vulkan):COMPARE_COMPUTE(filecheck-buffer=CHECK): -vk -output-using-type -g0
+
+// CHECK: type: float
+// CHECK-NEXT: 3.000000
+// CHECK-NEXT: 3.000000
+
+// Resource legalization hoists `Consumer.gradient`, so the retained `Consumer` context contains
+// only the empty `Identity` value. Empty-type legalization replaces that value with `Void`; the
+// late void cleanup must remove the placeholder before SPIR-V emission.
+
+float customTransform(no_diff RWStructuredBuffer<float> gradient, float input)
+{
+    return input;
+}
+
+[BackwardDerivativeOf(customTransform)]
+void customTransformBackward(
+    RWStructuredBuffer<float> gradient,
+    inout DifferentialPair<float> input,
+    float resultGradient)
+{
+    gradient[0] += resultGradient * input.p;
+    input = diffPair(input.p, resultGradient);
+}
+
+struct Identity
+{
+    [Differentiable]
+    float eval(float input)
+    {
+        return input;
+    }
+}
+
+struct Consumer
+{
+    RWStructuredBuffer<float> gradient;
+    Identity activation;
+
+    [Differentiable]
+    [NoDiffThis]
+    float eval(float input)
+    {
+        return activation.eval(customTransform(gradient, input));
+    }
+}
+
+struct Model
+{
+    uint value;
+    Consumer consumer;
+}
+
+//TEST_INPUT: set model.value = 3
+//TEST_INPUT: set model.consumer.gradient = ubuffer(data=[0.0], stride=4)
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0.0 0.0], stride=4)
+RWStructuredBuffer<float> outputBuffer;
+
+[Differentiable]
+float objective(no_diff Model model, float scale)
+{
+    return model.consumer.eval(float(model.value)) * scale;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uniform Model model)
+{
+    var scale = diffPair(1.0);
+    bwd_diff(objective)(model, scale, 1.0);
+    outputBuffer[0] = model.consumer.gradient[0];
+    outputBuffer[1] = scale.d;
+}


### PR DESCRIPTION
Fixes #12664.

## Motivation

Consider this reduced form of the original regression:

```slang
struct Identity
{
    [Differentiable]
    CoopVec<half, 1> eval(CoopVec<half, 1> input) { return input; }
}

struct Consumer
{
    RWStructuredBuffer<float> gradient;
    Identity activation;

    [Differentiable]
    [NoDiffThis]
    CoopVec<half, 1> eval(CoopVec<half, 1> input)
    {
        return activation.eval(customTransform(gradient, input));
    }
}

[Differentiable]
half objective(no_diff Model model, float scale)
{
    CoopVec<half, 1> input;
    input[0] = half(model.value);
    return model.consumer.eval(input)[0] * half(scale);
}
```

Reverse-mode autodiff creates a rematerialization function for `Consumer.eval`. While
differentiating the CoopVec subscript in `objective`, it temporarily leaves an unused call to that
rematerialization function. The callee is read-none, so dead-code elimination should remove the
call.

It did not. `areCallArgumentsSideEffectFree` asks `isValueType` whether each argument can be a
handle through which the callee mutates state. Cooperative-vector types were missing from that
classification, so the analysis conservatively treated the CoopVec argument as a possible handle
and kept the call. Later force inlining and resource/buffer legalization expanded that dead call
into an empty physical-to-logical aggregate copy. Late empty-type legalization then failed with:

```text
error[E99997]: Slang compilation aborted due to an exception of class
Slang::InternalError unexpected: non-simple operand(s)!
```

There is a second, independent issue in the same pipeline. Resource legalization can legitimately
leave an ordinary context containing only an empty value. Late empty-type legalization represents
that value temporarily with `Void`/`void_constant`; those placeholders must be cleaned before
SPIR-V emission. An existing `cleanUpVoidType` invocation runs earlier in the normal target
pipeline, before this late empty-type pass creates those new placeholders, so it cannot clean them.

## Proposed solution

Classify `IRCoopVectorType` as a first-class value type, alongside ordinary vectors and matrices.
This lets the existing side-effect analysis prove that a read-none call taking a CoopVec cannot
mutate through that argument, so ordinary DCE removes the unused rematerialization call at its
source.

With the dead call gone, force inlining never materializes its body and buffer lowering never sees
the accidental empty-copy shape. The final PR therefore does not add special handling for
`copyLogical` in empty-type legalization. That downstream approach was evaluated during
development, but it would recognize an artifact that should have been eliminated upstream.

Add a second `cleanUpVoidType` invocation immediately after late `legalizeEmptyTypes`. Unlike the
empty copy, retained `Void` placeholders are an intentional intermediate representation produced
by that pass. The existing earlier invocation remains necessary: it removes void function
parameters and matching call arguments produced by autodiff and `Optional` lowering before the
intervening target-lowering passes. The new invocation removes a later generation of void struct
fields and constructor operands. Each cleanup therefore runs immediately after a different
producer boundary.

## Change summary

- Add `IRCoopVectorType` to `isValueType` for call side-effect analysis.
- Add a second `cleanUpVoidType` invocation after late `legalizeEmptyTypes`; retain the existing
  pre-lowering invocation because it cleans an earlier generation of void IR.
- Add the full CoopVec/resource-context composition regression and focused end-to-end Vulkan
  compute tests for the CoopVec/DCE and scalar `Void`-cleanup issues.

## Concepts and vocabulary

- **Rematerialization function**: an autodiff-generated `s_remat_*` function that recomputes primal
  state needed by the reverse pass.
- **Value type**: in `isValueType`, a type whose value cannot act as a pointer or mutable handle
  through which a call produces side effects.
- **Physical/logical buffer types**: distinct target-storage and source-level representations of a
  buffer element.
- **`copyLogical`**: IR that copies between those physical and logical aggregate shapes.
- **`LegalVal::none`**: the type legalizer's representation for a value with no runtime leaves.

## Process report

### How the malformed IR is created

The following sequence uses Slang textual-IR-style notation. SSA names are shortened and comments
are added, but the operations and type relationships match the dumps from the named stages.

1. Reverse-mode autodiff builds `s_remat_Consumer.eval` and leaves an unused call while processing
   the CoopVec subscript:

   ```text
   let %input : CoopVector<Half, 1> = makeCoopVector(%value)

   let %unusedContext : %s_bwdCallableCtx_Consumer.eval
       = call %s_remat_Consumer.eval(%consumer, %input)
   // The call's result has no users. The rematerialization function is read-none.

   let %resultElement : Half = coopVectorGetElement(%actualResult, 0)
   // The derivative uses %actualResult, not %unusedContext.
   ```

2. DCE queries the call through `IRInst::mightHaveSideEffects`, which reaches
   `areCallArgumentsSideEffectFree`:

   ```text
   // Before this change:
   isValueType(typeOf(%input))                         -> false
   areCallArgumentsSideEffectFree(%unusedContextCall) -> false

   // CoopVector was not recognized as a value, so the analysis assumed that %input might
   // be a handle through which the call writes. The unused call therefore remained alive.
   ```

   This is an accidental alternative spelling of dead IR, not a valid requirement on later
   legalization. The semantic source of truth already exists: the call is read-none and CoopVec is
   a first-class numeric value.

3. The autodiff-generated rematerialization function is marked `ForceInline`. Once the retained
   call is inlined, resource legalization hoists `Consumer.gradient`. The only ordinary field left
   in `Consumer` is the empty `Identity`, so buffer-element lowering creates distinct, empty
   physical and logical representations and emits their conversion:

   ```text
   [nameHint("Consumer_std430_logical")]
   struct %ConsumerLogical : Type
   {
       // No runtime fields remain after resource legalization.
   }

   [nameHint("Consumer_std430")]
   [PhysicalType]
   struct %ConsumerPhysical : Type
   {
       // Also empty, but intentionally a distinct storage type.
   }

   let %physicalConsumer : Ptr(%ConsumerPhysical, ..., DefaultLayout)
       = getFieldAddress(%physicalModel, %consumerKey)
   let %logicalConsumer : Ptr(%ConsumerLogical) = var

   copyLogical(%logicalConsumer, %physicalConsumer)
   // This copy exists only because the dead rematerialization body survived and was inlined.
   ```

4. Late `legalizeEmptyTypes` maps both pointer operands to `LegalVal::none`. The operation still
   has a `Void` result type, so the generic path reaches the non-simple-operand failure:

   ```text
   copyLogical(%logicalConsumer, %physicalConsumer)
   // legalizeOperand(%logicalConsumer)  -> LegalVal::none
   // legalizeOperand(%physicalConsumer) -> LegalVal::none
   // legalizeType(Void)                 -> LegalType::simple(Void)
   // result before this PR              -> SLANG_UNEXPECTED("non-simple operand(s)!")
   ```

### Why the fix belongs in side-effect analysis

After adding `IRCoopVectorType` to the existing value-type switch, the same pipeline takes the
normal dead-code path:

```text
isValueType(typeOf(%input))                         -> true
areCallArgumentsSideEffectFree(%unusedContextCall) -> true

// After DCE:
// <no call to %s_remat_Consumer.eval>

// After force inlining and buffer lowering:
// <no dead rematerialization body>
// <no empty Consumer copyLogical>
```

This classification is canonical and target-independent: CoopVec is no more a mutable handle than
`VectorType` or `MatrixType`. No new helper or custom equivalence is introduced. During
investigation, a `kIROp_CopyLogical` branch in empty-type legalization was considered as a way to
discard copies after both operands became `LegalVal::none`. The final PR does not include that
branch: its exact input shape was produced only by the missed DCE opportunity, so handling it there
would mask the producer-side invariant break.

The focused `coopvec-resource-context-dce.slang` revert drill demonstrates ownership. Removing only
the CoopVec classification restores `non-simple operand(s)!`; the scalar companion still passes.

### Why cleanup is required at two different boundaries

The scalar `resource-context-void-cleanup.slang` test uses the same resource-backed `Consumer` but
replaces every CoopVec with `float`. Resource legalization hoists `Consumer.gradient`, leaving the
empty `Identity` value in a retained `Model` shape. This input is intentional and does not depend
on the missed CoopVec DCE.

Before resource and buffer lowering, the existing `cleanUpVoidType` invocation removes void
parameters and their matching call and constructor operands. Autodiff produces shapes like:

```text
func %s_bwdProp_Consumer.eval
    : Func(Void, %Context, Void, OutParam(Float), Float)
// The second differentiated parameter has no differential type, so it is represented as Void.

call %s_bwdProp_Consumer.eval(%context, void_constant, %dInput, %dResult)

let %applyResult : %Tuple = makeStruct(%primalResult, void_constant)
```

The earlier cleanup normalizes those signatures and uses before target lowering consumes them:

```text
func %s_bwdProp_Consumer.eval
    : Func(Void, %Context, OutParam(Float), Float)

call %s_bwdProp_Consumer.eval(%context, %dInput, %dResult)

let %applyResult : %Tuple = makeStruct(%primalResult)
```

That invocation predates this PR and cannot simply be removed in favor of the late call. Without
it, those void shapes flow through resource-return inlining, buffer lowering, force inlining, and
simplification; the late cleanup alone does not leave emit-ready IR.

Later, after those passes have run, `legalizeEmptyTypes` creates a new and different void shape:

```text
[nameHint("Model")]
struct %Model : Type
{
    field(%valueKey, UInt)
    field(%consumerKey, Void)
    // legalizeEmptyTypes temporarily preserves the removed Consumer position as Void.
}

let %model : %Model = makeStruct(%value, void_constant)
// The matching placeholder cannot be emitted as a SPIR-V global value.
```

The second `cleanUpVoidType` invocation added by this PR removes that `Void` field and constructor
operand immediately after the pass that creates them:

```text
[nameHint("Model")]
struct %Model : Type
{
    field(%valueKey, UInt)
}

let %model : %Model = makeStruct(%value)
```

The two removal drills demonstrate that neither invocation subsumes the other:

- Removing only the existing earlier invocation, while retaining the new late invocation, makes
  all three PR Vulkan tests fail with `Unhandled global inst in spirv-emit: ... void_constant`.
  The late call removes the surviving void parameters and arguments, but after they have flowed
  through the intervening passes it does not fully normalize the module before SPIR-V emission.
- Removing only the new late invocation leaves the earlier cleanup intact, but the scalar test
  still fails on the `void_constant` introduced by `legalizeEmptyTypes`.

The HostVM path has another `cleanUpVoidType` call before its early return; it is a separate emission
path and is not one of these two normal-target invocations.

Validation:

- Built `slangc` and `slang-test` with the `vs2022-dev-release` preset.
- Passed the full composition test and both focused compute tests on Vulkan through direct SPIR-V
  emission: 3/3.
- Passed the same three tests through Slang-to-GLSL-to-SPIR-V: 3/3.
- Revert drill without the CoopVec classification: only the focused CoopVec test fails with
  `non-simple operand(s)!`.
- Revert drill without the existing pre-lowering `cleanUpVoidType`: all three PR Vulkan tests fail
  on `void_constant`, even with the new late cleanup retained.
- Revert drill without late `cleanUpVoidType`: the scalar test fails on `void_constant`.
