### PR TITLE
Fix dropped alignment operand in byteAddressBufferLoad specialization

### DIFF
--- a/source/slang/slang-ir-specialize-function-call.cpp
+++ b/source/slang/slang-ir-specialize-function-call.cpp
@@ -623,6 +623,23 @@ struct FunctionParameterSpecializationContext
 
             ioInfo.newArgs.add(oldIndex);
         }
+        else if (oldArg->getOp() == kIROp_ByteAddressBufferLoad)
+        {
+            // Like the element-access case above, but `alignment` is a `constexpr`
+            // operand and must stay an `IRIntLit` for byte-address legalization,
+            // so it is baked into the specialization key instead of passed as an
+            // argument.
+            auto ops = unpackByteAddressBufferLoad(oldArg);
+
+            getCallInfoForArg(ioInfo, ops.buffer);
+
+            // Byte offset is a plain scalar (not a resource-array index), so it goes
+            // in the key as its bare data type; no `NonUniformAttr` handling needed.
+            ioInfo.key.vals.add(ops.offset->getDataType());
+            ioInfo.newArgs.add(ops.offset);
+
+            ioInfo.key.vals.add(ops.alignment);
+        }
         else if (isFieldAccessInst(oldArg))
         {
             // This is the case where the `oldArg` is
@@ -806,7 +823,6 @@ struct FunctionParameterSpecializationContext
         case kIROp_GetElement:
         case kIROp_RWStructuredBufferGetElementPtr:
         case kIROp_StructuredBufferLoad:
-        case kIROp_ByteAddressBufferLoad:
             return true;
         }
         return false;
@@ -824,6 +840,25 @@ struct FunctionParameterSpecializationContext
             return true;
         }
         return false;
+    }
+
+    struct ByteAddressBufferLoadOperands
+    {
+        IRInst* buffer;
+        IRInst* offset;
+        IRIntLit* alignment;
+    };
+
+    // Split a `byteAddressBufferLoad` into its (buffer, offset, alignment) operands.
+    // `alignment` is `constexpr` at the front end and must remain an `IRIntLit` for
+    // byte-address legalization; assert that invariant here so a violation surfaces at
+    // the specialization boundary rather than downstream.
+    static ByteAddressBufferLoadOperands unpackByteAddressBufferLoad(IRInst* load)
+    {
+        SLANG_RELEASE_ASSERT(load->getOperandCount() >= 3);
+        auto alignment = as<IRIntLit>(load->getOperand(2));
+        SLANG_RELEASE_ASSERT(alignment);
+        return {load->getOperand(0), load->getOperand(1), alignment};
     }
 
     IRInst* getSpecializedValueForArg(FuncSpecializationInfo& ioInfo, IRInst* oldArg)
@@ -911,6 +946,27 @@ struct FunctionParameterSpecializationContext
             IRInst* newOperands[] = {newBase, newIndex};
             auto newVal =
                 builder->emitIntrinsicInst(oldArg->getFullType(), oldArg->getOp(), 2, newOperands);
+
+            return newVal;
+        }
+        else if (oldArg->getOp() == kIROp_ByteAddressBufferLoad)
+        {
+            // Parallel to the element-access case above. `gatherCallInfoForArg` bakes
+            // the `alignment` literal into the specialization key, so here we reuse
+            // it directly in the reconstructed load rather than turning it into a
+            // runtime param -- downstream legalization still sees an `IRIntLit`.
+            auto ops = unpackByteAddressBufferLoad(oldArg);
+
+            auto newBuffer = getSpecializedValueForArg(ioInfo, ops.buffer);
+
+            auto builder = getBuilder();
+            auto newOffset = builder->createParam(ops.offset->getFullType());
+            ioInfo.newParams.add(newOffset);
+
+            builder->setInsertInto(ioInfo.newBodyInsts);
+            IRInst* newOperands[] = {newBuffer, newOffset, ops.alignment};
+            auto newVal =
+                builder->emitIntrinsicInst(oldArg->getFullType(), oldArg->getOp(), 3, newOperands);
 
             return newVal;
         }

--- a/tests/optimization/buffer-load-specialize-byte-address.slang
+++ b/tests/optimization/buffer-load-specialize-byte-address.slang
@@ -1,0 +1,48 @@
+//TEST:SIMPLE(filecheck=SPV): -target spirv -O0 -fvk-use-scalar-layout
+
+// `byteAddressBufferLoad` has a `constexpr uint alignment` operand; specializing a callee
+// through it must preserve that operand as a literal. Three calls to the same helper with
+// distinct alignments (one via `Load`, two via `LoadAligned`) must yield distinct
+// specializations (alignment is part of the specialization key), and each aligned load
+// must carry the original alignment as a SPIR-V `Aligned` memory operand rather than a
+// runtime value.
+
+struct Frame
+{
+    float4x4 a;
+    float4x4 b;
+    float3 v;
+    float pad;
+};
+
+float3 makeRay(Frame f)
+{
+    float4 w = mul(float4(0, 0, 0, 1), f.b);
+    return w.xyz + f.v;
+}
+
+uniform ByteAddressBuffer buf;
+uniform RWTexture2D<float4> outTexture;
+uniform uint width;
+uniform uint height;
+
+[shader("compute")]
+[numthreads(8, 8, 1)]
+void computeMain(uint3 dtid : SV_DispatchThreadID)
+{
+    if (dtid.x >= width || dtid.y >= height) return;
+    Frame f0 = buf.Load<Frame>(256);
+    Frame f8 = buf.LoadAligned<Frame>(0, 8);
+    Frame f16 = buf.LoadAligned<Frame>(128, 16);
+    outTexture[dtid.xy] = float4(makeRay(f0) + makeRay(f8) + makeRay(f16), 1);
+}
+
+// One specialization of `makeRay` per alignment value (`Load` bakes in 0,
+// `LoadAligned` bakes in 8 and 16). All checks are anchored to file start via
+// `SPV-DAG` so the three `OpFunction` matches and the two `OpLoad` matches
+// can occur in any order and in any specialization's body.
+// SPV-DAG: %{{.*}} = OpFunction %v3float None
+// SPV-DAG: %{{.*}} = OpFunction %v3float None
+// SPV-DAG: %{{.*}} = OpFunction %v3float None
+// SPV-DAG: OpLoad {{.*}} Aligned 8
+// SPV-DAG: OpLoad {{.*}} Aligned 16


### PR DESCRIPTION
## Summary

`specializeFuncsForBufferLoadArgs` lumped `kIROp_ByteAddressBufferLoad` in with the generic two-operand "element access" instructions (`GetElement`, `StructuredBufferLoad`, etc.) in both `gatherCallInfoForArg` and `getSpecializedValueForArg`. `byteAddressBufferLoad` actually has three operands — `(buffer, offset, alignment)` — so the rewritten load inside the specialized callee was constructed with only two operands.

Downstream, `legalizeByteAddressBufferOps::processLoad` unconditionally reads operand index 2 to recover the alignment, hitting:

```
assert failure: slang-ir.h(710): index < getOperandCount()
```

during SPIR-V emission.

### Repro

A struct large enough to trip the buffer-load specialization threshold, loaded via `Buf.Load<T>()` and passed by value into a helper:

```slang
struct Frame
{
    float4x4 a;
    float4x4 b;
    float3 v;
    float pad;
};

float3 makeRay(Frame f)
{
    float4 w = mul(float4(0, 0, 0, 1), f.b);
    return w.xyz + f.v;
}

uniform ByteAddressBuffer buf;
uniform RWTexture2D<float4> outTexture;
uniform uint width;
uniform uint height;

[shader("compute")]
[numthreads(8, 8, 1)]
void computeMain(uint3 dtid : SV_DispatchThreadID)
{
    if (dtid.x >= width || dtid.y >= height) return;
    Frame f = buf.Load<Frame>(0);
    outTexture[dtid.xy] = float4(makeRay(f), 1);
}
```

`slangc repro.slang -target spirv -O0 -fvk-use-scalar-layout` aborts with the assertion above.

### Fix

Give `byteAddressBufferLoad` dedicated handling in both functions so the alignment operand survives specialization, and remove it from `isElementAccessInst` since it doesn't share the two-operand shape.

## Test plan

* New regression test `tests/optimization/buffer-load-specialize-byte-address.slang` exercises the failing pattern on SPIR-V and checks that the specialized helper takes the offset and alignment as separate `uint` parameters.
* No existing tests change.