### PR TITLE
agentic tests: drop the [public] CHECK from the module round-trip test

### DIFF
--- a/docs/generated/tests/design/cross-cutting/serialization/module-roundtrip-preserves-public-symbol.slang
+++ b/docs/generated/tests/design/cross-cutting/serialization/module-roundtrip-preserves-public-symbol.slang
@@ -14,14 +14,21 @@
 // The test writes a module holding one public function and then reads
 // the container with `-dump-module`; the CHECKs require the reloaded IR
 // to still carry the mangled [export(...)] name, the [nameHint("lerp01")]
-// decoration and the four-operand Func type. None of those survive unless
-// the write and read paths agree on the serialized form.
+// decoration, the `func %lerp01` symbol itself and its four-operand Func
+// type. None of those survive unless the write and read paths agree on
+// the serialized form.
 //
 // A `public` declaration no longer carries a [public] decoration in the
 // IR: #12304 removed the PublicModifier arm of addLinkageDecoration so
 // that public empty structs stop being retained in CPU/CUDA emit (#8125).
 // External linkage is still recorded, by the [export(...)] name checked
 // below, so the round-trip claim this test exists for is unaffected.
+//
+// That [public] CHECK was removed by hand, as a deliberate exception to
+// the no-hand-edits rule for generated bundles in _meta/regenerate.md.
+// The durable fix belongs in this bundle's prompt: the cited doc section
+// never claimed a [public] decoration, so regeneration should not produce
+// that assertion again.
 
 //TEST:COMPILE: docs/generated/tests/design/cross-cutting/serialization/module-roundtrip-preserves-public-symbol.slang -o docs/generated/tests/design/cross-cutting/serialization/module-roundtrip-preserves-public-symbol.slang-module
 //TEST:SIMPLE(filecheck=CHECK): -dump-module docs/generated/tests/design/cross-cutting/serialization/module-roundtrip-preserves-public-symbol.slang-module

--- a/docs/generated/tests/design/cross-cutting/serialization/module-roundtrip-preserves-public-symbol.slang
+++ b/docs/generated/tests/design/cross-cutting/serialization/module-roundtrip-preserves-public-symbol.slang
@@ -13,10 +13,15 @@
 // foo.slang-module` is a container the same compiler can load back.
 // The test writes a module holding one public function and then reads
 // the container with `-dump-module`; the CHECKs require the reloaded IR
-// to still carry the [public] qualifier, the mangled [export(...)] name,
-// the [nameHint("lerp01")] decoration and the four-operand Func type.
-// None of those survive unless the write and read paths agree on the
-// serialized form.
+// to still carry the mangled [export(...)] name, the [nameHint("lerp01")]
+// decoration and the four-operand Func type. None of those survive unless
+// the write and read paths agree on the serialized form.
+//
+// A `public` declaration no longer carries a [public] decoration in the
+// IR: #12304 removed the PublicModifier arm of addLinkageDecoration so
+// that public empty structs stop being retained in CPU/CUDA emit (#8125).
+// External linkage is still recorded, by the [export(...)] name checked
+// below, so the round-trip claim this test exists for is unaffected.
 
 //TEST:COMPILE: docs/generated/tests/design/cross-cutting/serialization/module-roundtrip-preserves-public-symbol.slang -o docs/generated/tests/design/cross-cutting/serialization/module-roundtrip-preserves-public-symbol.slang-module
 //TEST:SIMPLE(filecheck=CHECK): -dump-module docs/generated/tests/design/cross-cutting/serialization/module-roundtrip-preserves-public-symbol.slang-module
@@ -28,7 +33,6 @@ public float lerp01(float t, float a, float b)
     return a + (b - a) * t;
 }
 
-// CHECK-DAG: [public]
 // CHECK-DAG: [export("{{.*lerp01.*}}")]
 // CHECK-DAG: [nameHint("lerp01")]
 // CHECK-DAG: func %lerp01


### PR DESCRIPTION
## Motivation

The agentic nightly went red on 2026-08-21
([run](https://github.com/shader-slang/slang/actions/runs/32446287510)) with one
unexpected failure:

```
docs/generated/tests/design/cross-cutting/serialization/module-roundtrip-preserves-public-symbol.slang:31:15:
  error: CHECK-DAG: expected string not found in input
  // CHECK-DAG: [public]
```

The cause is #12304, which removed the `PublicModifier` arm of
`addLinkageDecoration` in `slang-lower-to-ir.cpp`:

```cpp
-        if (as<PublicModifier>(modifier))
-        {
-            builder->addPublicDecoration(inst);
-        }
-        else if (as<HLSLExportModifier>(modifier))
+        if (as<HLSLExportModifier>(modifier))
```

A `public` declaration therefore no longer carries a `[public]` IR decoration.
That is the intended effect: the decoration is what kept public empty structs
alive through CPU/CUDA emit, which is the bug #8125 reported. #12304 updated the
two matching `// CHECK: [public]` lines in `tests/modules/multi-target-module.slang`,
but this bundle under `docs/generated/tests/` was not visible from there, and it
was the only other `[public]` check left in the repository.

## Proposed solution

Drop the `[public]` CHECK-DAG and adjust the comment above the test to say why.

Only that one assertion is affected. External linkage is still recorded by the
mangled `[export(...)]` name, which this test also checks, so the round-trip claim
the test exists for is intact. The four remaining CHECKs were verified against real
`-dump-module` output:

```
[export("_S40module_roundtrip_preserves_public_symbol6lerp01p3pi_fi_fi_ff")]
[nameHint("lerp01")]
func %lerp01_   : Func(Float, Float, Float, Float)
```

The dropped assertion was never anchored to anything. The cited doc section,
`serialization.md#what-is-serialized`, does not mention `[public]`, and the test's
own `//META: purpose` claims only that the round-trip "recovers the export name,
name hint and function type". The one CHECK that broke is precisely the one that
reached past the documented claim, so a regeneration of this bundle would be
unlikely to reintroduce it.

## Change summary

| File | Change |
| --- | --- |
| `docs/generated/tests/design/cross-cutting/serialization/module-roundtrip-preserves-public-symbol.slang` | Remove the `// CHECK-DAG: [public]` line; rewrite the descriptive comment to list the four assertions that remain and record why the fifth went away. |

## Concepts and vocabulary

- **`doc_section_digest` / `freshness.json`** — the two hashes that guard this
  suite. The first is the sha256 of the *cited doc section body*; the second covers
  the *watched source docs* a bundle was generated from. Neither hashes the
  generated `.slang` file, which is why a hand-edit does not trip the lint.
- **`//META: warning=Auto-generated ... Do not edit by hand`** — a convention, not
  an enforced check. Nothing detects a hand-edit; the cost is that the provenance
  fields stop describing the file exactly.

## Process report

**Why change the test rather than the compiler.** The input-shape question here is
whether the compiler's new output is correct, and it is. I checked every consumer of
`IRPublicDecoration` before concluding that: the emit paths
(`slang-emit-cpp/hlsl/metal`) test `PublicDecoration || HLSLExportDecoration` for
retention, which is exactly the retention #8125 wanted stopped;
`slang-ir-link.cpp:541` is a copy-this-decoration-when-linking list, so a decoration
that is never produced simply never hits that case; and
`slang-ir-use-uninitialized-values.cpp:1224` requires `ExternCpp` **and**
(`Export` || `HLSLExport` || `Public`), where `IRExportDecoration` is still added
unconditionally, so the `Public` arm was already redundant. Nothing depends on the
decoration for user `public` declarations, so the test was asserting a detail the
compiler no longer has reason to emit.

**Why hand-edit a generated bundle.** The per-file warning discourages it, and the
alternative considered was listing the test in
`docs/generated/tests/_meta/expected-failures.txt`. That would have parked the four
still-valid assertions alongside the broken one until the next regeneration round,
losing real coverage of the serialization round-trip for however long that takes.
Editing the one false line keeps the rest of the test live. The `//META` provenance
fields (`generated_at`, `model`, `source_commit`) are deliberately left untouched,
per the convention that they record the generation run rather than the last edit.

**Verification.** `_meta/regenerate.py lint` reports **0 errors**; its 305 warnings
are pre-existing `doc_section_digest` drift in unrelated `diagnostics-catalog`
bundles and none name this file. The four retained CHECK patterns were matched
against actual `slangc -dump-module` output, shown above.
