### PR TITLE
Coalesce line coverage counters per straight-line region

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -316,7 +316,7 @@ Reports information about checkpoint contexts used for reverse-mode automatic di
 
 <a id="trace-coverage"></a>
 ### -trace-coverage
-Instrument the shader with per-statement line coverage counters. When writing compiled output to a file, slangc also emits `&lt;output&gt;.coverage-manifest.json` mapping source coverage entries to counters. 
+Instrument the shader with per-statement line coverage counters. Statements that provably execute together share one counter and one runtime probe, which keeps instrumented shader code small without changing reported per-line results; the manifest therefore reports fewer counters than source entries. When writing compiled output to a file, slangc also emits `&lt;output&gt;.coverage-manifest.json` mapping source coverage entries to counters. 
 
 
 <a id="trace-function-coverage"></a>

--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -316,7 +316,7 @@ Reports information about checkpoint contexts used for reverse-mode automatic di
 
 <a id="trace-coverage"></a>
 ### -trace-coverage
-Instrument the shader with per-statement line coverage counters. Statements that provably execute together share one counter and one runtime probe, which keeps instrumented shader code small without changing reported per-line results; the manifest therefore reports fewer counters than source entries. When writing compiled output to a file, slangc also emits `&lt;output&gt;.coverage-manifest.json` mapping source coverage entries to counters. 
+Instrument the shader with per-statement line coverage counters. Statements that provably execute together share one counter and one runtime probe, which keeps instrumented shader code small without changing reported per-line results; the manifest therefore reports no more counters than source entries, and fewer whenever a straight-line region is coalesced. When writing compiled output to a file, slangc also emits `&lt;output&gt;.coverage-manifest.json` mapping source coverage entries to counters. 
 
 
 <a id="trace-function-coverage"></a>

--- a/docs/design/shader-coverage-counter-placement.md
+++ b/docs/design/shader-coverage-counter-placement.md
@@ -102,9 +102,8 @@ between them that can abandon the invocation, all execute exactly the
 same number of times. A basic block has one entry and one exit, so
 reaching any instruction in it means reaching all of them.
 
-The `someFunction` example above therefore emits three counters, not
-seven — one for the entry block, one for the loop body, and one for
-`main`:
+The `someFunction` example above therefore emits two counters for its
+six markers — one for the entry block, one for the loop body:
 
 ```slang
 void someFunction(uint N)

--- a/docs/design/shader-coverage-counter-placement.md
+++ b/docs/design/shader-coverage-counter-placement.md
@@ -16,12 +16,18 @@ coverageAtomic("name"); // AtomicAdd(__slang_coverage[slot], 1)
 
 The real compiler first emits marker IR ops during AST lowering. The
 IR coverage pass later assigns numeric counter slots, synthesizes the
-hidden `__slang_coverage` buffer, and rewrites each marker to an
-atomic increment — or, under `-trace-coverage-boolean`, to a plain
+hidden `__slang_coverage` buffer, and rewrites markers to an atomic
+increment — or, under `-trace-coverage-boolean`, to a plain
 non-atomic store of `1` (hit/not-hit). Placement is identical across
 the two rewrite forms; everything in this document applies to both.
 Slot numbers are not part of the placement contract; the metadata maps
 each source coverage entry to the slot chosen for that compile.
+
+Markers and counters are not one-to-one. Line markers that provably
+execute together are coalesced onto a single counter and a single
+runtime probe — see [Counter coalescing](#counter-coalescing) below.
+Every marker still produces its own source coverage entry, so this
+changes how many probes the shader carries, not what gets reported.
 
 Modes are independent. Enabling more than one mode adds the markers
 from each enabled mode into the same counter buffer.
@@ -82,6 +88,81 @@ void someFunction(uint N)
 The marker on the `while` statement counts execution reaching the loop
 statement. It does not count each loop-condition evaluation. Per-arm
 loop condition counts come from branch coverage.
+
+### Counter coalescing
+
+Emitted shader size scales with the number of probe sequences, not with
+counter width: every probe expands to index arithmetic, an address
+computation, and an atomic. Line coverage therefore coalesces markers
+that provably execute together onto one counter and one probe.
+
+The rule is simple because the IR is already in basic-block form when
+the coverage pass runs: markers in the same basic block, with nothing
+between them that can abandon the invocation, all execute exactly the
+same number of times. A basic block has one entry and one exit, so
+reaching any instruction in it means reaching all of them.
+
+The `someFunction` example above therefore emits three counters, not
+seven — one for the entry block, one for the loop body, and one for
+`main`:
+
+```slang
+void someFunction(uint N)
+{
+    // `uint i = 0` and `while` are in the same block: one probe covers
+    // both, and it sits at the last of the two.
+    uint i = 0;
+    coverageAtomic("region: i = 0, while");
+    while (i < N)
+    {
+        // The four body statements are one straight-line region.
+        buf[0] = buf[1] + buf[2];
+        buf[3] = buf[4] + buf[5];
+        buf[6] = buf[7] + buf[8];
+        i++;
+        coverageAtomic("region: loop body");
+    }
+}
+```
+
+Because the block boundary *is* the region boundary, every structural
+split falls out for free: `if` / `else` arms, `switch` cases, loop
+bodies versus loop exits, early `return` / `break` / `continue`, and
+short-circuit operands all begin new blocks during lowering, so none of
+them can be coalesced across.
+
+The probe sits at the **last** marker of a region rather than the
+first. Reaching it proves every earlier marker in the region also
+executed; placing it first would over-report when a region is entered
+but abandoned partway.
+
+Two cases break the "same block means same count" property, and both
+split the region:
+
+- An instruction that can abandon the invocation — `discard`, an abort,
+  or a call to a function that transitively contains one, or that never
+  returns at all. The analysis is a memoized fixpoint over the call
+  graph.
+- A call whose target cannot be resolved statically, such as an
+  interface method dispatched through a witness table. Coverage runs
+  before specialization, so these are common; the pass assumes the
+  worst and splits, since an extra probe costs emitted code while a
+  missed split would cost correctness.
+
+Function and branch markers always take a dedicated counter. They are
+already one probe per function or per arm, and their counts carry
+per-site meaning that sharing would destroy.
+
+Reported results are unaffected. Every source entry survives with its
+own file/line attribution, and hosts accumulate per entry, so several
+entries reading one slot produce exactly the LCOV records that
+dedicated slots did. What changes is `counterCount`, which drops
+markedly below the entry count — roughly half on the bundled demos.
+
+Known gap: the ray-tracing hit terminators (`IgnoreHit`,
+`AcceptHitAndEndSearch`) end the invocation at the target level, but
+Slang's IR models them as ordinary `void` functions that return
+normally, so the analysis cannot currently see them.
 
 ## Function Coverage: `-trace-function-coverage`
 
@@ -417,9 +498,13 @@ in two different compiles.
 
 ## Future Region Coverage
 
-The current modes all use one direct runtime counter per emitted
-source entry. Future source-region coverage may move toward a
-clang-style model where entries describe source ranges and some
-reported counts are derived from other counters. That should extend
-coverage metadata, but it should not change the basic rule that hidden
-resource binding is separate from source attribution.
+Line coverage already shares one counter across the source entries of
+a straight-line region (see [Counter coalescing](#counter-coalescing)),
+but each entry still names a concrete counter and reports a real
+count. Future source-region coverage may move further toward a
+clang-style model where entries describe source *ranges* and some
+reported counts are derived arithmetically from other counters rather
+than read directly. That would extend coverage metadata — most likely
+by using `kInvalidCoverageCounterIndex` for derived entries — but it
+should not change the basic rule that hidden resource binding is
+separate from source attribution.

--- a/docs/design/shader-coverage-counter-placement.md
+++ b/docs/design/shader-coverage-counter-placement.md
@@ -140,8 +140,11 @@ split the region:
 
 - An instruction that can abandon the invocation — `discard`, an abort,
   or a call to a function that transitively contains one, or that never
-  returns at all. The analysis is a memoized fixpoint over the call
-  graph.
+  returns at all. The analysis is a memoized depth-first walk of the
+  call graph, not an iterated fixpoint: a re-entered function is
+  reported as possibly not returning, which breaks cycles conservatively
+  without letting an optimistic answer escape into another function's
+  cached result.
 - A call whose target cannot be resolved statically, such as an
   interface method dispatched through a witness table. Coverage runs
   before specialization, so these are common; the pass assumes the

--- a/docs/design/shader-coverage-counter-placement.md
+++ b/docs/design/shader-coverage-counter-placement.md
@@ -158,10 +158,15 @@ entries reading one slot produce exactly the LCOV records that
 dedicated slots did. What changes is `counterCount`, which drops
 markedly below the entry count — roughly half on the bundled demos.
 
-Known gap: the ray-tracing hit terminators (`IgnoreHit`,
-`AcceptHitAndEndSearch`) end the invocation at the target level, but
-Slang's IR models them as ordinary `void` functions that return
-normally, so the analysis cannot currently see them.
+Known gap: any core-module intrinsic that abandons the invocation lowers
+to a `GenericAsm` terminator like every other intrinsic, and the exit
+analysis treats `GenericAsm` as a normal exit — so the gap is general to
+any present or future abandoning intrinsic modeled that way, not
+specific to a fixed list. The ray-tracing hit terminators `IgnoreHit`
+and `AcceptHitAndEndSearch` are the concrete examples today: they end
+the invocation at the target level, but Slang's IR models them as
+ordinary `void` functions that return normally, so the analysis cannot
+currently see them.
 
 ## Function Coverage: `-trace-function-coverage`
 

--- a/docs/design/shader-coverage-host-interface.md
+++ b/docs/design/shader-coverage-host-interface.md
@@ -60,11 +60,15 @@ or other IR cloning creates multiple executable copies that map to the
 same source location, those entries keep distinct counter slots; LCOV
 export aggregates line entries by `(file, line)`, function entries by
 function name, and branch entries by `(line, branch_site, branch_arm)`.
-Hosts should always map entries to counters through
+Hosts must always map entries to counters through
 `CoverageEntryInfo::counterIndex` rather than assuming entry index
-equals counter index — future source-region coverage may add ranged
-entries with shared or derived counters without changing the binding
-contract. (`getBufferInfo()` remains available as a legacy
+equals counter index: line coverage already shares one counter across
+the entries of a straight-line region, so the entry count and
+`getCounterCount()` differ. Size the readback buffer from
+`getCounterCount()`, and accumulate per entry rather than per counter —
+a counter does not identify a single source location. Future
+source-region coverage may add ranged entries with derived counters
+without changing the binding contract. (`getBufferInfo()` remains available as a legacy
 coverage-specific binding query for ABI compatibility; new hosts
 should bind through `ISyntheticResourceMetadata`, which also reports
 the CPU/CUDA marshaling locations.)

--- a/docs/design/shader-coverage-host-interface.md
+++ b/docs/design/shader-coverage-host-interface.md
@@ -66,8 +66,9 @@ equals counter index: line coverage already shares one counter across
 the entries of a straight-line region, so `getCounterCount()` is never
 larger than the entry count and is usually smaller. The two are equal
 when only function and/or branch coverage is enabled, since those modes
-use dedicated counters -- so rely on `<=`, not on the counts differing. Size the readback buffer from
-`getCounterCount()`, and accumulate per entry rather than per counter —
+use dedicated counters — rely on `<=`, not on the counts differing.
+Size the readback buffer from `getCounterCount()`, and accumulate per
+entry rather than per counter —
 a counter does not identify a single source location. Future
 source-region coverage may add ranged entries with derived counters
 without changing the binding contract. (`getBufferInfo()` remains available as a legacy

--- a/docs/design/shader-coverage-host-interface.md
+++ b/docs/design/shader-coverage-host-interface.md
@@ -63,8 +63,10 @@ function name, and branch entries by `(line, branch_site, branch_arm)`.
 Hosts must always map entries to counters through
 `CoverageEntryInfo::counterIndex` rather than assuming entry index
 equals counter index: line coverage already shares one counter across
-the entries of a straight-line region, so the entry count and
-`getCounterCount()` differ. Size the readback buffer from
+the entries of a straight-line region, so `getCounterCount()` is never
+larger than the entry count and is usually smaller. The two are equal
+when only function and/or branch coverage is enabled, since those modes
+use dedicated counters -- so rely on `<=`, not on the counts differing. Size the readback buffer from
 `getCounterCount()`, and accumulate per entry rather than per counter —
 a counter does not identify a single source location. Future
 source-region coverage may add ranged entries with derived counters

--- a/docs/design/shader-coverage.md
+++ b/docs/design/shader-coverage.md
@@ -418,10 +418,14 @@ category. Per-test attribution and source-region coverage are the
 highest-leverage near-term picks.
 
 `ICoverageTracingMetadata` is intentionally source-entry based rather
-than LCOV-line-only. Today line, function, and branch coverage emit one
-entry per counter, with `counterMode == Count` and `counterIndex`
-pointing at the runtime counter slot. This is an implementation detail
-of the current producers, not a permanent metadata contract. The same
+than LCOV-line-only. Every marker emits one entry, with
+`counterMode == Count` and `counterIndex` pointing at the runtime
+counter slot, but entries and counters are not one-to-one: line
+coverage coalesces the entries of a straight-line region onto a shared
+counter, so `getCounterCount()` is smaller than the entry count.
+Function and branch entries keep dedicated counters. Which entries
+share a counter is an implementation detail of the current producers,
+not a permanent metadata contract. The same
 object already has room for future lower-density region entries:
 source ranges, function names, and branch site/arm ids live on
 `CoverageEntryInfo`, while `getCounterCount()` continues to describe

--- a/docs/design/shader-coverage.md
+++ b/docs/design/shader-coverage.md
@@ -422,7 +422,9 @@ than LCOV-line-only. Every marker emits one entry, with
 `counterMode == Count` and `counterIndex` pointing at the runtime
 counter slot, but entries and counters are not one-to-one: line
 coverage coalesces the entries of a straight-line region onto a shared
-counter, so `getCounterCount()` is smaller than the entry count.
+counter, so `getCounterCount()` is never larger than the entry count,
+and smaller whenever a straight-line region is coalesced. A compile that
+enables only function and/or branch coverage leaves the two equal.
 Function and branch entries keep dedicated counters. Which entries
 share a counter is an implementation detail of the current producers,
 not a permanent metadata contract. The same

--- a/docs/design/shader-coverage.md
+++ b/docs/design/shader-coverage.md
@@ -419,8 +419,10 @@ highest-leverage near-term picks.
 
 `ICoverageTracingMetadata` is intentionally source-entry based rather
 than LCOV-line-only. Every marker emits one entry, with
-`counterMode == Count` and `counterIndex` pointing at the runtime
-counter slot, but entries and counters are not one-to-one: line
+`counterMode` reporting the selected recording mode (`Count` by
+default, `Boolean` under `-trace-coverage-boolean`) and `counterIndex`
+pointing at the runtime counter slot, but entries and counters are not
+one-to-one: line
 coverage coalesces the entries of a straight-line region onto a shared
 counter, so `getCounterCount()` is never larger than the entry count,
 and smaller whenever a straight-line region is coalesced. A compile that

--- a/include/slang.h
+++ b/include/slang.h
@@ -4913,11 +4913,25 @@ struct CoverageEntryInfo
 
     /// Counter slot used by this entry, or
     /// `kInvalidCoverageCounterIndex` when the entry has no runtime
-    /// counter. The current line/function/branch producers use one
-    /// direct counter per entry. Future source-region coverage may use
-    /// `kInvalidCoverageCounterIndex` for entries whose count is
-    /// derived from other counters or represented through tail-extended
-    /// fields.
+    /// counter.
+    ///
+    /// This is NOT unique per entry. Line coverage coalesces entries
+    /// that provably execute together (those in one basic block with
+    /// nothing between them that can abandon the invocation) onto a
+    /// single counter, which is what keeps instrumented shader code
+    /// small. Several entries therefore report the same
+    /// `counterIndex`, and `getCounterCount()` is correspondingly
+    /// smaller than the entry count.
+    ///
+    /// Read results per entry (`counters[entry.counterIndex]` for each
+    /// entry), never per counter: a counter does not identify one
+    /// source location. Sizing a readback buffer from the entry count
+    /// rather than the counter count is a bug.
+    ///
+    /// Function and branch entries always use a dedicated counter.
+    /// Future coverage modes may use `kInvalidCoverageCounterIndex`
+    /// for entries whose count is derived from other counters or
+    /// represented through tail-extended fields.
     uint32_t counterIndex = kInvalidCoverageCounterIndex;
 
     /// Semantic kind of this source coverage entry.

--- a/include/slang.h
+++ b/include/slang.h
@@ -5027,10 +5027,13 @@ struct ICoverageTracingMetadata : public ISlangCastable
         {0x8e, 0x21, 0x3f, 0x7b, 0x82, 0xa3, 0xd9, 0x51})
 
     /// Number of runtime counter slots in the synthesized coverage
-    /// buffer. This is smaller than `getEntryCount()`: line coverage
-    /// shares one counter across the source entries of a straight-line
-    /// region. Size the counter readback buffer from this value, never
-    /// from the entry count.
+    /// buffer. Never larger than `getEntryCount()`, and smaller when
+    /// line coverage shares one counter across the source entries of a
+    /// straight-line region. Function and branch entries always take a
+    /// dedicated counter, so the two counts are equal for a compile that
+    /// enables only those modes, or for line coverage where every marker
+    /// lands in its own basic block. Size the counter readback buffer
+    /// from this value, never from the entry count.
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL getCounterCount() = 0;
 
     /// Populate `outInfo` with attribution info for source coverage

--- a/include/slang.h
+++ b/include/slang.h
@@ -5027,10 +5027,10 @@ struct ICoverageTracingMetadata : public ISlangCastable
         {0x8e, 0x21, 0x3f, 0x7b, 0x82, 0xa3, 0xd9, 0x51})
 
     /// Number of runtime counter slots in the synthesized coverage
-    /// buffer. This can differ from `getEntryCount()` once a coverage
-    /// mode has counterless metadata entries, shares one counter across
-    /// several source entries, or reports entries whose counts are
-    /// derived from other counters.
+    /// buffer. This is smaller than `getEntryCount()`: line coverage
+    /// shares one counter across the source entries of a straight-line
+    /// region. Size the counter readback buffer from this value, never
+    /// from the entry count.
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL getCounterCount() = 0;
 
     /// Populate `outInfo` with attribution info for source coverage
@@ -5059,10 +5059,10 @@ struct ICoverageTracingMetadata : public ISlangCastable
     virtual SLANG_NO_THROW SlangResult SLANG_MCALL getBufferInfo(CoverageBufferInfo* outInfo) = 0;
 
     /// Number of source coverage entries available through
-    /// `getEntryInfo`. The current line/function/branch producers have
-    /// one entry per counter, but future source-region coverage may
-    /// expose entries that do not map one-to-one with runtime counter
-    /// slots.
+    /// `getEntryInfo`. Every coverage marker produces one entry, so
+    /// this is NOT the number of runtime counters: several entries may
+    /// name the same `counterIndex`. Use `getCounterCount()` to size
+    /// the readback buffer.
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL getEntryCount() = 0;
 };
     #define SLANG_UUID_ICoverageTracingMetadata ICoverageTracingMetadata::getTypeGuid()

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -1020,6 +1020,19 @@ struct CoverageFunctionExitAnalysis
         // A body with no normal exit anywhere never returns to its
         // caller, which covers an unconditional exit and a
         // non-terminating loop.
+        //
+        // The scan above is unfiltered: any `IRReturn`/`IRGenericAsm` in
+        // any block sets `sawNormalExit`, with no reachability check. That
+        // is sound only because the front end does not leave an
+        // unreachable normal exit in a body that cannot return -- a
+        // function that never returns has no `IRReturn` to find, which is
+        // what makes `for (;;) {}` reach this branch at all. If that ever
+        // stopped holding, the failure would be in the dangerous
+        // direction: a dead `IRReturn` would set `sawNormalExit`, this
+        // split would be skipped, and callers would coalesce across a call
+        // that does not come back. Restricting the scan to exits reachable
+        // from the entry block would remove the dependence on that
+        // property, at the cost of a reachability walk per function.
         if (!sawNormalExit)
             result = true;
 

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -868,27 +868,19 @@ static bool isCoverageMarkerOp(IROp op)
 // dispatched through a witness table, for instance. Callers must treat
 // null conservatively, since an unresolvable body could do anything.
 //
-// The `specialize` unwrapping matters because coverage instrumentation
-// runs before `specializeModule`: a call to a generic such as
-// `dot(a, b)` reaches this pass as `call specialize(%dot, Float, 3)(...)`
-// rather than as a direct call to an `IRFunc`. Reporting that as
-// unresolvable would split a coalescing region at every generic call —
-// which is most numeric code — for no correctness benefit, because the
-// generic's body is right there to analyze.
+// Generic calls resolve here without any special handling on our part.
+// Coverage instrumentation runs before `specializeModule`, so a call to
+// a generic such as `dot(a, b)` still arrives as
+// `call specialize(%dot, Float, 3)(...)`; `getResolvedInstForDecorations`
+// loops, unwrapping every `IRSpecialize` through its base and every
+// `IRGeneric` through its return value, and only stops once the
+// candidate is neither. Nested multi-parameter generics fall out of the
+// same loop. Reporting such a call as unresolvable would split a
+// coalescing region at every generic call — which is most numeric code —
+// for no correctness benefit.
 static IRFunc* getStaticallyResolvedCallee(IRInst* callee)
 {
-    callee = getResolvedInstForDecorations(callee);
-    if (auto func = as<IRFunc>(callee))
-        return func;
-    if (auto specialize = as<IRSpecialize>(callee))
-    {
-        // `findInnerMostGenericReturnVal` peels every nested
-        // `IRGeneric` layer, so a multi-parameter generic resolves in
-        // one step.
-        if (auto generic = as<IRGeneric>(getResolvedInstForDecorations(specialize->getOperand(0))))
-            return as<IRFunc>(findInnerMostGenericReturnVal(generic));
-    }
-    return nullptr;
+    return as<IRFunc>(getResolvedInstForDecorations(callee));
 }
 
 // Decides whether a call can fail to return to its caller, so that
@@ -918,9 +910,12 @@ static IRFunc* getStaticallyResolvedCallee(IRInst* callee)
 // not. Coalescing all four onto one counter would misreport one side
 // or the other, so the run must be split at the call.
 //
-// Results are memoized per function, and the analysis is a fixpoint
-// over the call graph so an exit deep in a callee still splits the
-// caller's run.
+// Results are memoized per function, and the analysis is a depth-first
+// walk of the call graph — not an iterated fixpoint — so an exit deep in
+// a callee still splits the caller's run. Cycles are broken by reporting
+// the re-entered function as possibly not returning, which keeps the
+// walk terminating without letting an optimistic answer escape into
+// other functions' cached results.
 //
 // Known gap: the ray-tracing hit terminators (`IgnoreHit`,
 // `AcceptHitAndEndSearch`) end the invocation at the target level, but
@@ -981,12 +976,25 @@ struct CoverageFunctionExitAnalysis
             return false;
         }
 
-        // Recursion is rejected for GPU targets by
-        // `checkForRecursiveFunctions` later in the pipeline. Treat a
-        // cycle as returning so the fixpoint terminates; a recursive
-        // program that reaches here is already ill-formed.
+        // Break call cycles conservatively: a function we are still in the
+        // middle of analyzing is reported as possibly not returning.
+        //
+        // Returning `false` here instead would be unsound, not merely
+        // imprecise. The optimistic answer does not stay local — a
+        // *different* function analyzed while this one is in progress
+        // consumes it and then caches its own result below, so one partner
+        // of a mutually recursive pair can be memoized as "returns
+        // normally" when it does not, and the outcome depends on which
+        // function the traversal happened to reach first. `true` cannot go
+        // wrong in that direction: it only ever adds a split.
+        //
+        // Recursion is not ruled out before this point. It is diagnosed by
+        // `checkForRecursiveFunctions`, which runs far later in
+        // `linkAndOptimizeIR` and, more to the point, only for non-CPU
+        // targets (`slang-ir-check-recursion.cpp`) — and CPU is a target
+        // coverage supports.
         if (!inProgress.add(func))
-            return false;
+            return true;
 
         bool result = false;
         bool sawNormalExit = false;
@@ -1073,6 +1081,17 @@ static void assignCoverageCounterSlots(
             auto previousOp = markerOps[openGroup];
             if (previousOp->getParent() == markerOp->getParent())
             {
+                // Two preconditions from `collectCoverageMarkerOps`, which
+                // walks each function's blocks in order and each block's
+                // insts in position order: markers from one block arrive
+                // contiguously, and within a block they arrive in position
+                // order. The walk below relies on the second — it scans
+                // forward from `previousOp` looking for `markerOp`, so if
+                // the two were ever reversed it would run to the end of the
+                // block without finding it and skip the split check
+                // entirely. Assert rather than trust a collection order
+                // defined 200 lines away.
+                SLANG_ASSERT(previousOp != markerOp);
                 // Same block: the run continues unless something
                 // between the two markers can abandon the invocation.
                 joinsOpenGroup = true;

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -863,6 +863,251 @@ static bool isCoverageMarkerOp(IROp op)
     }
 }
 
+// Decides whether a call can fail to return to its caller, so that
+// coverage coalescing knows when a straight-line run of markers is
+// really straight-line.
+//
+// Coalescing replaces several line markers with a single probe, which
+// is only sound when reaching the probe proves every marker it stands
+// for also executed. Inside one basic block that holds automatically
+// for ordinary code, because a block has a single entry and a single
+// exit. It stops holding when an instruction in the middle of the
+// block can abandon the invocation, since the instructions after it
+// then execute fewer times than the ones before it. Consider:
+//
+//     void maybeKill(float v) { if (v < 0.5f) discard; }
+//
+//     float4 main(float2 uv : TEXCOORD) : SV_Target
+//     {
+//         float a = uv.x + 1.0f;   // marker 1
+//         maybeKill(a);            // marker 2
+//         float c = a + 3.0f;      // marker 3
+//         return float4(c);        // marker 4
+//     }
+//
+// All four markers sit in `main`'s entry block, but when `maybeKill`
+// discards, markers 1 and 2 have executed and markers 3 and 4 have
+// not. Coalescing all four onto one counter would misreport one side
+// or the other, so the run must be split at the call.
+//
+// Results are memoized per function, and the analysis is a fixpoint
+// over the call graph so an exit deep in a callee still splits the
+// caller's run.
+//
+// Known gap: the ray-tracing hit terminators (`IgnoreHit`,
+// `AcceptHitAndEndSearch`) end the invocation at the target level, but
+// Slang's IR models them as ordinary `void` core-module functions that
+// return to their caller, so this analysis cannot see them. There is
+// no `[noreturn]` concept in the IR to key off. Marking them in the
+// core module is the principled fix and is tracked separately.
+// Resolve the function body that a call will actually enter, seeing
+// through the `specialize` wrapper that a call to a generic function
+// still carries at this point in the pipeline.
+//
+// Coverage instrumentation runs before `specializeModule`, so a call
+// to a generic such as `dot(a, b)` reaches this pass as
+// `call specialize(%dot, Float, 3)(...)` rather than as a direct call
+// to an `IRFunc`. Treating that as an unknown target would split a
+// coalescing run at every generic call — which is most numeric code —
+// for no correctness benefit, because the generic's body is right
+// there to analyze.
+//
+// Returns null only when the target genuinely cannot be resolved
+// statically, such as an interface method dispatched through a witness
+// table; the caller handles that conservatively.
+static IRFunc* getStaticallyResolvedCallee(IRInst* callee)
+{
+    callee = getResolvedInstForDecorations(callee);
+    if (auto func = as<IRFunc>(callee))
+        return func;
+    if (auto specialize = as<IRSpecialize>(callee))
+    {
+        // `findInnerMostGenericReturnVal` peels every nested
+        // `IRGeneric` layer, so a multi-parameter generic resolves in
+        // one step.
+        if (auto generic = as<IRGeneric>(getResolvedInstForDecorations(specialize->getOperand(0))))
+            return as<IRFunc>(findInnerMostGenericReturnVal(generic));
+    }
+    return nullptr;
+}
+
+struct CoverageFunctionExitAnalysis
+{
+    // `true` when the function may abandon the invocation instead of
+    // returning normally to its caller.
+    Dictionary<IRFunc*, bool> mayNotReturnCache;
+    // Functions currently being computed, used to break call cycles.
+    HashSet<IRFunc*> inProgress;
+
+    // Returns true when executing `inst` may fail to reach the next
+    // instruction in its own block.
+    bool mayNotFallThrough(IRInst* inst)
+    {
+        switch (inst->getOp())
+        {
+        case kIROp_Discard:
+        case kIROp_Abort:
+            return true;
+        case kIROp_Call:
+            {
+                auto callee = getStaticallyResolvedCallee(cast<IRCall>(inst)->getCallee());
+                // An unresolved callee is an indirect or not-yet-
+                // specialized dispatch (coverage instrumentation runs
+                // before `specializeModule`). We cannot see its body,
+                // so assume the worst and split the run: an extra
+                // probe costs emitted code, a missing split costs
+                // correctness.
+                if (!callee)
+                    return true;
+                return mayNotReturn(callee);
+            }
+        default:
+            return false;
+        }
+    }
+
+    // Returns true when `func` may abandon the invocation rather than
+    // returning to its caller.
+    bool mayNotReturn(IRFunc* func)
+    {
+        if (auto found = mayNotReturnCache.tryGetValue(func))
+            return *found;
+
+        // A function with no body is an unlinked declaration. Every
+        // core-module function that can exit an invocation carries a
+        // body by the time this pass runs (linking happens earlier in
+        // `emitEntryPoints`), so a body-less callee here is an
+        // external/host symbol that returns normally.
+        if (!func->getFirstBlock())
+        {
+            mayNotReturnCache[func] = false;
+            return false;
+        }
+
+        // Recursion is rejected for GPU targets by
+        // `checkForRecursiveFunctions` later in the pipeline. Treat a
+        // cycle as returning so the fixpoint terminates; a recursive
+        // program that reaches here is already ill-formed.
+        if (!inProgress.add(func))
+            return false;
+
+        bool result = false;
+        bool sawNormalExit = false;
+        for (auto block : func->getBlocks())
+        {
+            for (auto inst = block->getFirstInst(); inst; inst = inst->getNextInst())
+            {
+                // `IRGenericAsm` is how `__intrinsic_asm` lowers, and it
+                // carries return semantics: it ends the function and
+                // hands the value back, exactly like `IRReturn`. Most
+                // core-module math (`dot`, `lerp`, ...) exits this way,
+                // so counting it as a normal exit is what keeps a call
+                // to an ordinary intrinsic from splitting every run.
+                if (inst->getOp() == kIROp_Return || inst->getOp() == kIROp_GenericAsm)
+                    sawNormalExit = true;
+                if (!result && mayNotFallThrough(inst))
+                    result = true;
+            }
+        }
+        // A body with no normal exit anywhere never returns to its
+        // caller, which covers an unconditional exit and a
+        // non-terminating loop.
+        if (!sawNormalExit)
+            result = true;
+
+        inProgress.remove(func);
+        mayNotReturnCache[func] = result;
+        return result;
+    }
+};
+
+// Assign a counter slot to every collected marker op, coalescing line
+// markers that provably execute together.
+//
+// Line markers in the same basic block, with nothing between them that
+// can abandon the invocation, all execute exactly the same number of
+// times, so they can share one counter and one runtime probe. That is
+// what shrinks emitted shader code: probe count, not counter width, is
+// what scales SPIR-V size.
+//
+// `outSlots[i]` is the counter index for `markerOps[i]`, and
+// `outEmitsProbe[i]` selects the single marker per group that emits
+// the runtime counter update. The probe is placed at the *last* marker
+// of the group so that reaching it proves every earlier marker in the
+// group executed; placing it first would over-report when the group is
+// entered but abandoned partway.
+//
+// Function and branch markers always take a dedicated slot: they are
+// already one probe per function or per arm, and their counts carry
+// per-site meaning that sharing would destroy.
+static void assignCoverageCounterSlots(
+    List<IRInst*> const& markerOps,
+    List<UInt>& outSlots,
+    List<bool>& outEmitsProbe,
+    UInt& outCounterCount)
+{
+    CoverageFunctionExitAnalysis exitAnalysis;
+
+    outSlots.setCount(markerOps.getCount());
+    outEmitsProbe.setCount(markerOps.getCount());
+    for (Index i = 0; i < markerOps.getCount(); ++i)
+        outEmitsProbe[i] = true;
+
+    UInt nextSlot = 0;
+    // Index of the marker that currently owns the open group, or -1
+    // when no group is open.
+    Index openGroup = -1;
+
+    for (Index i = 0; i < markerOps.getCount(); ++i)
+    {
+        auto markerOp = markerOps[i];
+        if (markerOp->getOp() != kIROp_IncrementCoverageCounter)
+        {
+            // Non-line markers neither join nor continue a group, and
+            // they cannot break one: they lower to a counter update,
+            // which always falls through.
+            outSlots[i] = nextSlot++;
+            continue;
+        }
+
+        bool joinsOpenGroup = false;
+        if (openGroup >= 0)
+        {
+            auto previousOp = markerOps[openGroup];
+            if (previousOp->getParent() == markerOp->getParent())
+            {
+                // Same block: the run continues unless something
+                // between the two markers can abandon the invocation.
+                joinsOpenGroup = true;
+                for (auto inst = previousOp->getNextInst(); inst && inst != markerOp;
+                     inst = inst->getNextInst())
+                {
+                    if (exitAnalysis.mayNotFallThrough(inst))
+                    {
+                        joinsOpenGroup = false;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (joinsOpenGroup)
+        {
+            // Hand the probe forward to this marker: the group's probe
+            // always sits at its last marker.
+            outSlots[i] = outSlots[openGroup];
+            outEmitsProbe[openGroup] = false;
+        }
+        else
+        {
+            outSlots[i] = nextSlot++;
+        }
+        openGroup = i;
+    }
+
+    outCounterCount = nextSlot;
+}
+
 // Collect every coverage marker op in the module. Deterministic traversal:
 // module-scope insts in declaration order, then each function's blocks in
 // order, then each block's insts in position order.
@@ -1083,15 +1328,27 @@ struct CoverageInstrumenter
         }
     }
 
-    // Lower a single coverage marker op to an atomic add on
-    // `coverageBuffer[slot]`. Appends the source-entry metadata that
-    // currently points at this direct counter slot, then removes the
-    // marker op.
-    void lowerMarkerOp(IRInst* markerOp, UInt slot)
+    // Lower a single coverage marker op, recording its source-entry
+    // metadata against `slot` and then removing the marker op.
+    //
+    // `emitRuntimeProbe` selects whether this marker also emits the
+    // counter update. Coalesced line markers share one slot and one
+    // probe, so only the last marker of a group emits it while the
+    // others contribute metadata alone — that is what removes probe
+    // sequences from the emitted shader. Every marker still produces
+    // its own entry, so per-line reporting is unchanged.
+    void lowerMarkerOp(IRInst* markerOp, UInt slot, bool emitRuntimeProbe)
     {
         CoverageTracingEntry entry;
         populateEntryForMarker(markerOp, slot, entry);
         outMetadata.m_coverageEntries.add(entry);
+
+        if (!emitRuntimeProbe)
+        {
+            SLANG_ASSERT(!markerOp->hasUses());
+            markerOp->removeAndDeallocate();
+            return;
+        }
 
         IRBuilder builder(module);
         builder.setInsertBefore(markerOp);
@@ -1170,7 +1427,11 @@ struct CoverageInstrumenter
 
     void run(List<IRInst*> const& markerOps)
     {
-        const auto counterCount = markerOps.getCount();
+        List<UInt> slots;
+        List<bool> emitsProbe;
+        UInt coalescedCounterCount = 0;
+        assignCoverageCounterSlots(markerOps, slots, emitsProbe, coalescedCounterCount);
+        const auto counterCount = (Index)coalescedCounterCount;
         // This concerns the counter *index* type, which is independent of
         // the per-slot storage width recorded just below: the public
         // metadata stores counter indices as uint32_t because the
@@ -1205,14 +1466,14 @@ struct CoverageInstrumenter
         default:
             SLANG_UNEXPECTED("coverage counter element type must be uint or uint64_t");
         }
-        outMetadata.m_coverageEntries.reserve(counterCount);
-        // Each marker op gets its own slot: the op's identity IS the
-        // UID, and we assign a consecutive index in traversal order.
-        // Several source entries may later share counters when region
-        // coverage is added; this pass already keeps entry count and
-        // counter count separate through the public metadata API.
-        for (Index slot = 0; slot < counterCount; ++slot)
-            lowerMarkerOp(markerOps[slot], UInt(slot));
+        outMetadata.m_coverageEntries.reserve(markerOps.getCount());
+        // Every marker produces one source entry, but line markers that
+        // provably execute together share a counter slot, so entry count
+        // and counter count now genuinely differ. The public metadata API
+        // has always kept the two separate; hosts size the readback buffer
+        // from the counter count and attribute results per entry.
+        for (Index i = 0; i < markerOps.getCount(); ++i)
+            lowerMarkerOp(markerOps[i], slots[i], emitsProbe[i]);
     }
 };
 

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -926,6 +926,78 @@ static IRFunc* getStaticallyResolvedCallee(IRInst* callee)
 // future abandoning intrinsic modeled the same way. Slang's IR has no
 // `[noreturn]` concept to key off instead. Marking them in the
 // core module is the principled fix and is tracked separately.
+// Returns true when every block reachable from `func`'s entry can still
+// reach a normal exit — an `IRReturn`, or an `IRGenericAsm`, which is how
+// `__intrinsic_asm` lowers and which ends the function the same way.
+//
+// Asking whether a normal exit is *present* is not enough, and the
+// difference is a real under-reporting bug rather than imprecision.
+// Consider:
+//
+//     void h(bool c) { if (c) { for (;;) { } } }
+//
+// The else path lowers to a reachable `return_val`, so a presence check
+// concludes `h` returns and a caller coalesces across the call to it. When
+// `c` is true `h` diverges instead, so a probe placed after the call never
+// fires and the statements before it — which did execute — report zero
+// hits. Reachability catches it: the `for (;;)` block is reachable from
+// entry and can reach no exit at all.
+//
+// The same walk covers the case where lowering leaves a dead `IRReturn` in
+// a body that cannot return, since an unreachable block is never
+// considered.
+static bool everyReachablePathCanExit(IRFunc* func)
+{
+    auto entry = func->getFirstBlock();
+    if (!entry)
+        return true;
+
+    // Blocks that can reach a normal exit, found by walking predecessors
+    // back from every block that terminates in one.
+    HashSet<IRBlock*> canExit;
+    List<IRBlock*> workList;
+    for (auto block : func->getBlocks())
+    {
+        auto terminator = block->getTerminator();
+        if (!terminator)
+            continue;
+        if (terminator->getOp() == kIROp_Return || terminator->getOp() == kIROp_GenericAsm)
+        {
+            if (canExit.add(block))
+                workList.add(block);
+        }
+    }
+    while (workList.getCount())
+    {
+        auto block = workList.getLast();
+        workList.removeLast();
+        for (auto pred : block->getPredecessors())
+        {
+            if (canExit.add(pred))
+                workList.add(pred);
+        }
+    }
+
+    // Walk forward from the entry; any block reached that cannot itself
+    // reach an exit means some execution never returns.
+    HashSet<IRBlock*> visited;
+    visited.add(entry);
+    workList.add(entry);
+    while (workList.getCount())
+    {
+        auto block = workList.getLast();
+        workList.removeLast();
+        if (!canExit.contains(block))
+            return false;
+        for (auto succ : block->getSuccessors())
+        {
+            if (visited.add(succ))
+                workList.add(succ);
+        }
+    }
+    return true;
+}
+
 struct CoverageFunctionExitAnalysis
 {
     // `true` when the function may abandon the invocation instead of
@@ -1000,40 +1072,17 @@ struct CoverageFunctionExitAnalysis
             return true;
 
         bool result = false;
-        bool sawNormalExit = false;
         for (auto block : func->getBlocks())
         {
             for (auto inst = block->getFirstInst(); inst; inst = inst->getNextInst())
             {
-                // `IRGenericAsm` is how `__intrinsic_asm` lowers, and it
-                // carries return semantics: it ends the function and
-                // hands the value back, exactly like `IRReturn`. Most
-                // core-module math (`dot`, `lerp`, ...) exits this way,
-                // so counting it as a normal exit is what keeps a call
-                // to an ordinary intrinsic from splitting every run.
-                if (inst->getOp() == kIROp_Return || inst->getOp() == kIROp_GenericAsm)
-                    sawNormalExit = true;
                 if (!result && mayNotFallThrough(inst))
                     result = true;
             }
         }
-        // A body with no normal exit anywhere never returns to its
-        // caller, which covers an unconditional exit and a
-        // non-terminating loop.
-        //
-        // The scan above is unfiltered: any `IRReturn`/`IRGenericAsm` in
-        // any block sets `sawNormalExit`, with no reachability check. That
-        // is sound only because the front end does not leave an
-        // unreachable normal exit in a body that cannot return -- a
-        // function that never returns has no `IRReturn` to find, which is
-        // what makes `for (;;) {}` reach this branch at all. If that ever
-        // stopped holding, the failure would be in the dangerous
-        // direction: a dead `IRReturn` would set `sawNormalExit`, this
-        // split would be skipped, and callers would coalesce across a call
-        // that does not come back. Restricting the scan to exits reachable
-        // from the entry block would remove the dependence on that
-        // property, at the cost of a reachability walk per function.
-        if (!sawNormalExit)
+        // A path that cannot reach a normal exit means the function may
+        // not return, even when other paths do.
+        if (!everyReachablePathCanExit(func))
             result = true;
 
         inProgress.remove(func);

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -863,6 +863,34 @@ static bool isCoverageMarkerOp(IROp op)
     }
 }
 
+// Return the function body that `callee` will actually enter, or null
+// when the target cannot be resolved statically — an interface method
+// dispatched through a witness table, for instance. Callers must treat
+// null conservatively, since an unresolvable body could do anything.
+//
+// The `specialize` unwrapping matters because coverage instrumentation
+// runs before `specializeModule`: a call to a generic such as
+// `dot(a, b)` reaches this pass as `call specialize(%dot, Float, 3)(...)`
+// rather than as a direct call to an `IRFunc`. Reporting that as
+// unresolvable would split a coalescing region at every generic call —
+// which is most numeric code — for no correctness benefit, because the
+// generic's body is right there to analyze.
+static IRFunc* getStaticallyResolvedCallee(IRInst* callee)
+{
+    callee = getResolvedInstForDecorations(callee);
+    if (auto func = as<IRFunc>(callee))
+        return func;
+    if (auto specialize = as<IRSpecialize>(callee))
+    {
+        // `findInnerMostGenericReturnVal` peels every nested
+        // `IRGeneric` layer, so a multi-parameter generic resolves in
+        // one step.
+        if (auto generic = as<IRGeneric>(getResolvedInstForDecorations(specialize->getOperand(0))))
+            return as<IRFunc>(findInnerMostGenericReturnVal(generic));
+    }
+    return nullptr;
+}
+
 // Decides whether a call can fail to return to its caller, so that
 // coverage coalescing knows when a straight-line run of markers is
 // really straight-line.
@@ -900,37 +928,6 @@ static bool isCoverageMarkerOp(IROp op)
 // return to their caller, so this analysis cannot see them. There is
 // no `[noreturn]` concept in the IR to key off. Marking them in the
 // core module is the principled fix and is tracked separately.
-// Resolve the function body that a call will actually enter, seeing
-// through the `specialize` wrapper that a call to a generic function
-// still carries at this point in the pipeline.
-//
-// Coverage instrumentation runs before `specializeModule`, so a call
-// to a generic such as `dot(a, b)` reaches this pass as
-// `call specialize(%dot, Float, 3)(...)` rather than as a direct call
-// to an `IRFunc`. Treating that as an unknown target would split a
-// coalescing run at every generic call — which is most numeric code —
-// for no correctness benefit, because the generic's body is right
-// there to analyze.
-//
-// Returns null only when the target genuinely cannot be resolved
-// statically, such as an interface method dispatched through a witness
-// table; the caller handles that conservatively.
-static IRFunc* getStaticallyResolvedCallee(IRInst* callee)
-{
-    callee = getResolvedInstForDecorations(callee);
-    if (auto func = as<IRFunc>(callee))
-        return func;
-    if (auto specialize = as<IRSpecialize>(callee))
-    {
-        // `findInnerMostGenericReturnVal` peels every nested
-        // `IRGeneric` layer, so a multi-parameter generic resolves in
-        // one step.
-        if (auto generic = as<IRGeneric>(getResolvedInstForDecorations(specialize->getOperand(0))))
-            return as<IRFunc>(findInnerMostGenericReturnVal(generic));
-    }
-    return nullptr;
-}
-
 struct CoverageFunctionExitAnalysis
 {
     // `true` when the function may abandon the invocation instead of

--- a/source/slang/slang-ir-coverage-instrument.cpp
+++ b/source/slang/slang-ir-coverage-instrument.cpp
@@ -917,11 +917,14 @@ static IRFunc* getStaticallyResolvedCallee(IRInst* callee)
 // walk terminating without letting an optimistic answer escape into
 // other functions' cached results.
 //
-// Known gap: the ray-tracing hit terminators (`IgnoreHit`,
-// `AcceptHitAndEndSearch`) end the invocation at the target level, but
-// Slang's IR models them as ordinary `void` core-module functions that
-// return to their caller, so this analysis cannot see them. There is
-// no `[noreturn]` concept in the IR to key off. Marking them in the
+// Known gap: any core-module intrinsic that abandons the invocation —
+// the ray-tracing hit terminators `IgnoreHit` and `AcceptHitAndEndSearch`
+// are the concrete examples today — lowers to a `GenericAsm` terminator
+// like every other intrinsic, and `mayNotReturn` treats `GenericAsm` as
+// a normal exit (see the comment on that case below). So this is not a
+// gap specific to those two names: it is general to any present or
+// future abandoning intrinsic modeled the same way. Slang's IR has no
+// `[noreturn]` concept to key off instead. Marking them in the
 // core module is the principled fix and is tracked separately.
 struct CoverageFunctionExitAnalysis
 {
@@ -1081,29 +1084,36 @@ static void assignCoverageCounterSlots(
             auto previousOp = markerOps[openGroup];
             if (previousOp->getParent() == markerOp->getParent())
             {
-                // Two preconditions from `collectCoverageMarkerOps`, which
-                // walks each function's blocks in order and each block's
-                // insts in position order: markers from one block arrive
-                // contiguously, and within a block they arrive in position
-                // order. The walk below relies on the second — it scans
-                // forward from `previousOp` looking for `markerOp`, so if
-                // the two were ever reversed it would run to the end of the
-                // block without finding it and skip the split check
-                // entirely. Assert rather than trust a collection order
-                // defined 200 lines away.
-                SLANG_ASSERT(previousOp != markerOp);
                 // Same block: the run continues unless something
                 // between the two markers can abandon the invocation.
+                // The scan below relies on a precondition from
+                // `collectCoverageMarkerOps`, which walks each function's
+                // blocks in order and each block's insts in position
+                // order: markers from one block arrive contiguously and
+                // in position order, so `markerOp` is reachable by
+                // scanning forward from `previousOp`. The assert after
+                // the loop checks that invariant directly — that the
+                // forward scan actually reached `markerOp` whenever it
+                // did not already stop at a split — rather than the
+                // weaker `previousOp != markerOp`, which a reversed pair
+                // would also satisfy while still running off the end of
+                // the block and silently skipping the split check.
                 joinsOpenGroup = true;
-                for (auto inst = previousOp->getNextInst(); inst && inst != markerOp;
-                     inst = inst->getNextInst())
+                bool foundMarkerOp = false;
+                for (auto inst = previousOp->getNextInst(); inst; inst = inst->getNextInst())
                 {
+                    if (inst == markerOp)
+                    {
+                        foundMarkerOp = true;
+                        break;
+                    }
                     if (exitAnalysis.mayNotFallThrough(inst))
                     {
                         joinsOpenGroup = false;
                         break;
                     }
                 }
+                SLANG_ASSERT(foundMarkerOp || !joinsOpenGroup);
             }
         }
 

--- a/source/slang/slang-ir-coverage-instrument.h
+++ b/source/slang/slang-ir-coverage-instrument.h
@@ -27,10 +27,10 @@ static constexpr int kDefaultCoverageCounterByteWidth = 8;
 // layout so the buffer participates in
 // `collectGlobalUniformParameters` packaging on targets that need it
 // (CPU, CUDA), and rewrites coverage marker ops into atomic adds. The
-// current line/function/branch producers assign one direct counter slot
-// per marker op; the metadata keeps entry count and counter count
-// separate so later source-region coverage can use shared or derived
-// counters. Marker kind selects the emitted source-entry metadata:
+// line producer coalesces markers that provably execute together onto
+// one counter slot and one runtime probe, so entry count and counter
+// count differ; function and branch producers keep one dedicated slot
+// per marker. Marker kind selects the emitted source-entry metadata:
 // line, function, branch, and later region coverage all share this
 // path. The pass writes the resulting source coverage entries and the
 // chosen buffer binding into

--- a/source/slang/slang-ir-coverage-instrument.h
+++ b/source/slang/slang-ir-coverage-instrument.h
@@ -28,9 +28,11 @@ static constexpr int kDefaultCoverageCounterByteWidth = 8;
 // `collectGlobalUniformParameters` packaging on targets that need it
 // (CPU, CUDA), and rewrites coverage marker ops into atomic adds. The
 // line producer coalesces markers that provably execute together onto
-// one counter slot and one runtime probe, so entry count and counter
-// count differ; function and branch producers keep one dedicated slot
-// per marker. Marker kind selects the emitted source-entry metadata:
+// one counter slot and one runtime probe, so counter count is never
+// larger than entry count, and smaller whenever a straight-line region
+// is coalesced; function and branch producers keep one dedicated slot
+// per marker, so the two counts are equal when only those modes are
+// enabled. Marker kind selects the emitted source-entry metadata:
 // line, function, branch, and later region coverage all share this
 // path. The pass writes the resulting source coverage entries and the
 // chosen buffer binding into

--- a/source/slang/slang-ir-insts.lua
+++ b/source/slang/slang-ir-insts.lua
@@ -1215,12 +1215,15 @@ local insts = {
 	-- has no operands; its source position is carried on the standard
 	-- per-instruction `sourceLoc` field, which is always preserved and
 	-- never stripped by `stripDebugInfo`. The coverage-instrument IR pass
-	-- later rewrites each coverage marker into an atomic add on the IR-
-	-- synthesized `__slang_coverage` buffer. Line markers that provably
-	-- execute together -- same basic block, nothing between them that can
-	-- abandon the invocation -- are coalesced onto a single counter and a
-	-- single probe, so the lowering is not one-to-one; each marker still
-	-- produces its own source entry. Host-side tooling reads source
+	-- later rewrites coverage markers into an atomic add on the IR-
+	-- synthesized `__slang_coverage` buffer, or a plain store under
+	-- `-trace-coverage-boolean`. Line markers that provably execute
+	-- together -- same basic block, nothing between them that can abandon
+	-- the invocation -- are coalesced onto a single counter, and only the
+	-- last marker of such a region emits the runtime update; the rest are
+	-- removed without emitting one. The lowering is therefore not
+	-- one-to-one, though each marker still produces its own source
+	-- entry. Host-side tooling reads source
 	-- coverage entries and projects them to LCOV records.
 	-- Inherent side-effect semantics keep the optimizer from deleting or
 	-- hoisting these ops.

--- a/source/slang/slang-ir-insts.lua
+++ b/source/slang/slang-ir-insts.lua
@@ -1216,11 +1216,12 @@ local insts = {
 	-- per-instruction `sourceLoc` field, which is always preserved and
 	-- never stripped by `stripDebugInfo`. The coverage-instrument IR pass
 	-- later rewrites each coverage marker into an atomic add on the IR-
-	-- synthesized `__slang_coverage` buffer. The current line/function/
-	-- branch producers assign one direct counter per marker; future
-	-- source-region coverage can keep using marker metadata without
-	-- preserving that one-to-one lowering. Host-side tooling reads
-	-- source coverage entries and projects them to LCOV records.
+	-- synthesized `__slang_coverage` buffer. Line markers that provably
+	-- execute together -- same basic block, nothing between them that can
+	-- abandon the invocation -- are coalesced onto a single counter and a
+	-- single probe, so the lowering is not one-to-one; each marker still
+	-- produces its own source entry. Host-side tooling reads source
+	-- coverage entries and projects them to LCOV records.
 	-- Inherent side-effect semantics keep the optimizer from deleting or
 	-- hoisting these ops.
 	{ IncrementCoverageCounter = {} },

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -627,6 +627,10 @@ void initCommandOptions(CommandOptions& options)
          "-trace-coverage",
          nullptr,
          "Instrument the shader with per-statement line coverage counters. "
+         "Statements that provably execute together share one counter and one "
+         "runtime probe, which keeps instrumented shader code small without "
+         "changing reported per-line results; the manifest therefore reports "
+         "fewer counters than source entries. "
          "When writing compiled output to a file, slangc also emits "
          "`<output>.coverage-manifest.json` mapping source coverage entries to counters."},
         {OptionKind::TraceFunctionCoverage,

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -630,7 +630,8 @@ void initCommandOptions(CommandOptions& options)
          "Statements that provably execute together share one counter and one "
          "runtime probe, which keeps instrumented shader code small without "
          "changing reported per-line results; the manifest therefore reports "
-         "fewer counters than source entries. "
+         "no more counters than source entries, and fewer whenever a "
+         "straight-line region is coalesced. "
          "When writing compiled output to a file, slangc also emits "
          "`<output>.coverage-manifest.json` mapping source coverage entries to counters."},
         {OptionKind::TraceFunctionCoverage,

--- a/tests/language-feature/coverage/coverage-coalesce-boolean.slang
+++ b/tests/language-feature/coverage/coverage-coalesce-boolean.slang
@@ -1,0 +1,33 @@
+// Coalescing and boolean recording are independent choices: boolean mode
+// changes what a probe writes (a plain store of 1 instead of an atomic add),
+// not where probes go. The design states placement is identical across the
+// two rewrite forms, and nothing pinned that -- every other coalescing test
+// uses the default counting mode.
+//
+// If coalescing were skipped under boolean mode, each statement would get its
+// own slot and the emitted shader would carry the probe density the mode is
+// often chosen to avoid.
+
+//TEST:SIMPLE(filecheck=CHECK):-target cpp -stage compute -entry computeMain -trace-coverage -trace-coverage-boolean
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<uint> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    // One straight-line region, exactly as under counting mode.
+    uint a = tid.x;
+    uint b = a + 1;
+    uint c = b + 2;
+    outputBuffer[0] = c;
+}
+
+// A single plain store, on slot 0, for the whole region.
+//CHECK: _slang_coverage_0)[int(0)]) = 1
+
+// No atomics at all: that is what boolean mode buys.
+//CHECK-NOT: _slang_atomic_add
+
+// And no second slot: coalescing is still in effect.
+//CHECK-NOT: _slang_coverage_0)[int(1)]

--- a/tests/language-feature/coverage/coverage-coalesce-boolean.slang
+++ b/tests/language-feature/coverage/coverage-coalesce-boolean.slang
@@ -9,6 +9,7 @@
 // often chosen to avoid.
 
 //TEST:SIMPLE(filecheck=CHECK):-target cpp -stage compute -entry computeMain -trace-coverage -trace-coverage-boolean
+//TEST:SIMPLE(filecheck=ONESTORE):-target cpp -stage compute -entry computeMain -trace-coverage -trace-coverage-boolean
 
 //TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
 RWStructuredBuffer<uint> outputBuffer;
@@ -31,3 +32,9 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
 
 // And no second slot: coalescing is still in effect.
 //CHECK-NOT: _slang_coverage_0)[int(1)]
+
+// Same property on the boolean path: one store for the region, not one per
+// statement sharing the slot. Checking only that slot 1 is absent would pass
+// even if every marker in the region emitted its own store into slot 0.
+//ONESTORE-COUNT-1: _slang_coverage_0)[int(0)]) = 1
+//ONESTORE-NOT: _slang_coverage_0)[int(0)]) = 1

--- a/tests/language-feature/coverage/coverage-coalesce-call-resolution.slang
+++ b/tests/language-feature/coverage/coverage-coalesce-call-resolution.slang
@@ -1,0 +1,63 @@
+// Pins how coalescing treats calls, which is the most fragile part of
+// the region analysis: it decides whether a call keeps a region intact
+// or splits it, and getting either direction wrong is silent.
+//
+// A call to a function that returns normally must NOT split a region.
+// If it did, coalescing would be defeated for essentially all code that
+// calls helpers, while the metadata still looks healthy — entries would
+// still outnumber counters thanks to the call-free statements alone.
+//
+// A call whose target cannot be resolved statically MUST split. Coverage
+// instrumentation runs before `specializeModule`, so an interface method
+// dispatched through a witness table has no visible body here and the
+// pass has to assume it can abandon the invocation.
+
+//TEST:SIMPLE(filecheck=CHECK):-target cpp -stage compute -entry computeMain -trace-coverage
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<float> outputBuffer;
+
+// Ordinary function: returns normally, so calling it preserves a region.
+float doubleIt(float x)
+{
+    return x * 2.0f;
+}
+
+interface IStep { float apply(float x); }
+struct AddOne : IStep { float apply(float x) { return x + 1.0f; } }
+
+float viaInterface(IStep step, float x)
+{
+    // `step.apply` is a witness-table dispatch, so these two statements
+    // are one region and the two after the call are another.
+    float a = x + 1.0f;
+    float b = step.apply(a);
+    float c = b + 1.0f;
+    return c;
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    // All five statements are one region despite the `doubleIt` call
+    // sitting inside it. The trailing `viaInterface` call cannot split
+    // anything, because no marker follows it in this block.
+    float v = (float)tid.x;
+    float w = doubleIt(v);
+    float x = w + 1.0f;
+    AddOne step;
+    outputBuffer[0] = viaInterface(step, x);
+}
+
+// Five regions: `doubleIt`'s body, `viaInterface` either side of the
+// witness dispatch, `computeMain`'s single region, and `AddOne::apply`.
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(0\)}}
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(1\)}}
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(2\)}}
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(3\)}}
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(4\)}}
+
+// Exactly five. A sixth slot means the `doubleIt` call started splitting
+// `computeMain`; slot 4 going missing above means the witness dispatch
+// stopped splitting `viaInterface`. The test fails in both directions.
+//CHECK-NOT: _slang_coverage{{.*int\(5\)}}

--- a/tests/language-feature/coverage/coverage-coalesce-conditional-divergence.slang
+++ b/tests/language-feature/coverage/coverage-coalesce-conditional-divergence.slang
@@ -1,0 +1,51 @@
+// A function that returns on one path and diverges on another must split its
+// caller's region, even though a normal return is present in its body.
+//
+// This is the case a "does the body contain a return?" check gets wrong, and
+// it fails in the dangerous direction. `maybeDiverge` lowers to an `ifElse`
+// whose else path is a reachable `return_val` and whose then path is an
+// `unreachable`-terminated loop, with no discard, abort or unresolvable call
+// anywhere. Treating the present return as proof of return would coalesce the
+// caller across the call; when the loop is taken the probe never fires, and
+// the statements before the call -- which did execute -- report zero hits.
+//
+// The analysis instead asks whether every block reachable from the entry can
+// still reach a normal exit. The loop block can reach none, so the call splits.
+
+//TEST:SIMPLE(filecheck=CHECK):-target cpp -stage compute -entry computeMain -trace-coverage
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<float> outputBuffer;
+
+// Returns when `c` is false; never returns when it is true.
+void maybeDiverge(bool c)
+{
+    if (c)
+    {
+        for (;;)
+        {
+        }
+    }
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    // One region up to and including the call...
+    float a = (float)tid.x;
+    maybeDiverge(tid.x == 0);
+    // ...and a second after it, because the callee may never come back.
+    float b = a + 1.0f;
+    outputBuffer[0] = b;
+}
+
+// Two regions in `maybeDiverge` (the `if` and its body), then the two in
+// `computeMain` either side of the call.
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(0\)}}
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(1\)}}
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(2\)}}
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(3\)}}
+
+// Exactly four. If the present-return check came back, `computeMain` would
+// collapse to one region and slot 3 would disappear.
+//CHECK-NOT: _slang_coverage{{.*int\(4\)}}

--- a/tests/language-feature/coverage/coverage-coalesce-exit-analysis.slang
+++ b/tests/language-feature/coverage/coverage-coalesce-exit-analysis.slang
@@ -1,0 +1,54 @@
+// Covers the two exit-analysis outcomes that the other coalescing tests
+// leave out, both of which fail silently if they regress.
+//
+// 1. A call to ordinary builtin math must NOT split a region. Those bodies
+//    reach this pass unspecialized, so if the analysis reported them
+//    unresolvable, or failed to count their exits as normal, every numeric
+//    call would split its region and coalescing would be defeated for
+//    essentially all real shader code -- with the counter buffer still
+//    looking healthy. `max`, `sqrt` and `clamp` are used because they are
+//    verified not to split; note that not every builtin qualifies, since
+//    a generic whose body dispatches through a witness table (`lerp`,
+//    `dot`) is unresolvable at this point and splits conservatively.
+//
+// 2. A function that never returns normally MUST split. `spin` has no
+//    reachable return at all, which is the one way to reach the
+//    "no normal exit anywhere" branch: a helper with an unconditional
+//    `discard` does not, because lowering still appends an implicit
+//    `return`, so it splits through the abandons-the-invocation path
+//    instead (covered by coverage-coalesce-exit-split.slang).
+
+//TEST:SIMPLE(filecheck=CHECK):-target cpp -stage compute -entry computeMain -trace-coverage
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<float> outputBuffer;
+
+// No reachable return: the region containing a call to this must split.
+float spin(float x)
+{
+    for (;;)
+    {
+    }
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    // One region: the builtin calls do not break it up.
+    float a = (float)tid.x;
+    float b = max(a, 1.0f);
+    float c = sqrt(b);
+    float d = clamp(c, 0.0f, 1.0f);
+    // Second region starts here, because `spin` never returns.
+    float e = spin(d);
+    outputBuffer[0] = e;
+}
+
+// `spin`'s own body, then the two regions of `computeMain`.
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(0\)}}
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(1\)}}
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(2\)}}
+
+// Exactly three. A fourth slot means a builtin call started splitting the
+// first region; slot 2 going missing means `spin` stopped splitting.
+//CHECK-NOT: _slang_coverage{{.*int\(3\)}}

--- a/tests/language-feature/coverage/coverage-coalesce-exit-split.slang
+++ b/tests/language-feature/coverage/coverage-coalesce-exit-split.slang
@@ -1,0 +1,43 @@
+// Verifies that coalescing stops at a call that may abandon the
+// invocation. Statements in one basic block normally execute the same
+// number of times, which is what lets them share a counter — but a
+// callee that discards breaks that: the statements before the call run
+// and the ones after it do not. Merging them onto one counter would
+// misreport one side or the other, so the region must split at the
+// call.
+//
+// The analysis is interprocedural: `maybeKill` discards only on one
+// path, and the split still happens at its call site in `fragMain`.
+
+//TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -stage fragment -entry fragMain -trace-coverage
+
+void maybeKill(float v)
+{
+    if (v < 0.5f)
+        discard;
+}
+
+float4 fragMain(float2 uv : TEXCOORD) : SV_Target
+{
+    // One region up to and including the call...
+    float a = uv.x + 1.0f;
+    float b = a * 2.0f;
+    maybeKill(b);
+    // ...and a second region after it, because `maybeKill` may not
+    // return.
+    float c = b + 3.0f;
+    return float4(c, c, c, 1.0f);
+}
+
+// Four regions total: `maybeKill`'s `if` and its `discard` arm, then
+// `fragMain` split either side of the call. Were the split missing,
+// `fragMain` would contribute one region instead of two and slot 3
+// would not exist.
+//CHECK-DAG: OpAccessChain {{.*}} %__slang_coverage {{.*}} %int_0
+//CHECK-DAG: OpAccessChain {{.*}} %__slang_coverage {{.*}} %int_1
+//CHECK-DAG: OpAccessChain {{.*}} %__slang_coverage {{.*}} %int_2
+//CHECK-DAG: OpAccessChain {{.*}} %__slang_coverage {{.*}} %int_3
+
+// And no fifth region: the split is at the call, not at every
+// statement.
+//CHECK-NOT: %__slang_coverage {{.*}} %int_4

--- a/tests/language-feature/coverage/coverage-coalesce-exit-split.slang
+++ b/tests/language-feature/coverage/coverage-coalesce-exit-split.slang
@@ -10,6 +10,7 @@
 // path, and the split still happens at its call site in `fragMain`.
 
 //TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -stage fragment -entry fragMain -trace-coverage
+//TEST:SIMPLE(filecheck=BOOLEAN):-target spirv-asm -stage fragment -entry fragMain -trace-coverage -trace-coverage-boolean
 
 void maybeKill(float v)
 {
@@ -41,3 +42,12 @@ float4 fragMain(float2 uv : TEXCOORD) : SV_Target
 // And no fifth region: the split is at the call, not at every
 // statement.
 //CHECK-NOT: %__slang_coverage {{.*}} %int_4
+
+// Boolean recording changes what a probe writes, not where regions break, so
+// the split has to survive it. The boolean test elsewhere only shows that a
+// straight-line region still coalesces under this mode; nothing showed the
+// exit analysis still fires, so a regression that split only under counting
+// mode would pass every other test.
+//BOOLEAN-DAG: OpAccessChain {{.*}} %__slang_coverage {{.*}} %int_2
+//BOOLEAN-DAG: OpAccessChain {{.*}} %__slang_coverage {{.*}} %int_3
+//BOOLEAN-NOT: OpAtomicIAdd

--- a/tests/language-feature/coverage/coverage-coalesce-region.slang
+++ b/tests/language-feature/coverage/coverage-coalesce-region.slang
@@ -1,0 +1,45 @@
+// Verifies that line coverage emits one counter per straight-line
+// region rather than one per statement. Emitted shader size scales with
+// the number of probe sequences, so collapsing a run of statements that
+// provably execute together is what keeps instrumented code small.
+//
+// Region boundaries fall out of the IR's basic-block structure: the
+// if/else arms below each begin a new block, so they cannot be merged
+// with the statements before or after them.
+
+//TEST:SIMPLE(filecheck=CHECK):-target cpp -stage compute -entry computeMain -trace-coverage
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<uint> outputBuffer;
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    // These three statements plus the `if` statement itself are one
+    // straight-line region and share a single counter.
+    uint a = tid.x;
+    uint b = a + 1;
+    uint c = b + 2;
+    if (c > 3)
+    {
+        // Separate block, so a separate region.
+        c += 1;
+        c += 2;
+    }
+    else
+    {
+        c += 3;
+    }
+    outputBuffer[0] = c;
+}
+
+// Exactly four regions: the entry run, the then-arm, the else-arm, and
+// the statement after the merge. Slots are assigned in traversal order.
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(0\)}}
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(1\)}}
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(2\)}}
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(3\)}}
+
+// ...and no fifth. If coalescing regresses to one counter per
+// statement, slot 4 appears and this fails.
+//CHECK-NOT: _slang_coverage{{.*int\(4\)}}

--- a/tests/language-feature/coverage/coverage-coalesce-region.slang
+++ b/tests/language-feature/coverage/coverage-coalesce-region.slang
@@ -8,6 +8,7 @@
 // with the statements before or after them.
 
 //TEST:SIMPLE(filecheck=CHECK):-target cpp -stage compute -entry computeMain -trace-coverage
+//TEST:SIMPLE(filecheck=ONEPROBE):-target cpp -stage compute -entry computeMain -trace-coverage
 
 //TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
 RWStructuredBuffer<uint> outputBuffer;
@@ -43,3 +44,12 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
 // ...and no fifth. If coalescing regresses to one counter per
 // statement, slot 4 appears and this fails.
 //CHECK-NOT: _slang_coverage{{.*int\(4\)}}
+
+// Slot count alone does not pin the point of this pass. `outCounterCount` is
+// computed from the slot assignment, independently of which marker emits a
+// probe, so a regression that shared slots correctly but left every marker
+// emitting would produce N redundant atomics into one slot while the counter
+// count, every entry's counterIndex and the LCOV output stayed byte-identical.
+// The region has to emit exactly ONE runtime probe, not just occupy one slot.
+//ONEPROBE-COUNT-1: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(0\)}}
+//ONEPROBE-NOT: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(0\)}}

--- a/tests/language-feature/coverage/coverage-coalesce-void-noreturn.slang
+++ b/tests/language-feature/coverage/coverage-coalesce-void-noreturn.slang
@@ -1,0 +1,49 @@
+// A `void` function that never returns must split its caller's region, the
+// same as a value-returning one.
+//
+// The two reach that conclusion by different routes, which is why this needs
+// its own test. Lowering gives a value-returning body that falls off the end
+// an `IRMissingReturn`, which the exit analysis does not count as a normal
+// exit. A `void` body instead gets an unconditional implicit `emitReturn()`
+// (`slang-lower-to-ir.cpp`), so the concern is that a stray `IRReturn` left in
+// an unreachable block would set `sawNormalExit` and suppress the split --
+// the unsound direction, where the caller coalesces across a call that never
+// comes back and reports the statements before it as never executed.
+//
+// It does not happen: a non-terminating `void` body reaches this pass with
+// `unreachable` as its terminator and no `IRReturn` at all. This test pins
+// that, since the analysis's correctness depends on it and the property lives
+// in lowering rather than here.
+
+//TEST:SIMPLE(filecheck=CHECK):-target cpp -stage compute -entry computeMain -trace-coverage
+
+//TEST_INPUT: set outputBuffer = out ubuffer(data=[0], stride=4)
+RWStructuredBuffer<float> outputBuffer;
+
+// `void`, and no reachable return.
+void spin()
+{
+    for (;;)
+    {
+    }
+}
+
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    // One region up to and including the call...
+    float a = (float)tid.x;
+    spin();
+    // ...and a second after it, because `spin` never returns.
+    float c = a + 3.0f;
+    outputBuffer[0] = c;
+}
+
+// `spin`'s own body, then the two regions of `computeMain`.
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(0\)}}
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(1\)}}
+//CHECK-DAG: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(2\)}}
+
+// Exactly three. If the implicit `void` return ever suppressed the split,
+// `computeMain` would collapse to one region and slot 2 would disappear.
+//CHECK-NOT: _slang_coverage{{.*int\(3\)}}

--- a/tests/language-feature/coverage/coverage-multi-stmt-per-line.slang
+++ b/tests/language-feature/coverage/coverage-multi-stmt-per-line.slang
@@ -1,9 +1,17 @@
-// Locks in the per-inst-UID design: each `IncrementCoverageCounter` op
-// gets its own counter slot, even when multiple ops originate from the
-// same source line. The old design deduplicated slots by (file, line),
-// which would have collapsed the three statements on line 9 below into
-// one or two slots. If someone reintroduces that dedupe, this test
-// regresses.
+// Locks in how multiple statements on one source line are handled.
+//
+// Each `IncrementCoverageCounter` op keeps its own source coverage
+// entry, with its own column, so the metadata never deduplicates by
+// (file, line) — the three statements on line 24 below produce three
+// entries. That entry-level distinctness is asserted by the
+// `coverageTracingMetadata` unit test, which reads the metadata API.
+//
+// What they do *not* each get is a counter. All four statements here
+// sit in one basic block, so they provably execute the same number of
+// times and are coalesced onto a single counter and a single probe.
+// This is what keeps instrumented shader code small; per-line reporting
+// is unaffected, because hosts accumulate per entry and every entry
+// still reads this one slot.
 
 //TEST:SIMPLE(filecheck=CHECK):-target cpp -stage compute -entry computeMain -trace-coverage
 
@@ -17,9 +25,9 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
     outputBuffer[0] = a + b + c;
 }
 
-// The three statements on one source line must each produce a distinct
-// atomic add on a distinct slot. If the compiler dedupes back to
-// (file, line), slots 2 and 3 here would disappear.
-//CHECK: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(1\)}}
-//CHECK: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(2\)}}
-//CHECK: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(3\)}}
+// One straight-line region means exactly one atomic add, on slot 0.
+//CHECK: _slang_atomic_add_u64{{.*}}_slang_coverage{{.*int\(0\)}}
+
+// If coalescing regresses to one counter per statement, slot 1 appears
+// and this fails.
+//CHECK-NOT: _slang_coverage{{.*int\(1\)}}

--- a/tools/shader-coverage/README.md
+++ b/tools/shader-coverage/README.md
@@ -222,13 +222,31 @@ where the width is capped automatically), binds it
 using the hidden binding information reported through
 `ISyntheticResourceMetadata`, dispatches the shader, reads the
 counters back, and consumes the source entries however it likes —
-direct telemetry, a custom LCOV writer, a dashboard, etc. In the
-current line/function/branch producers, entries and counters are
-one-to-one. Future source-region modes may expose source entries that
-are not identical to runtime counter slots, including entries with no
-direct runtime counter of their own. Hosts should use
-`entry.counterIndex` and be prepared for future extended entry data
-rather than assuming the entry index equals the counter index.
+direct telemetry, a custom LCOV writer, a dashboard, etc.
+
+**Entries and counters are not one-to-one.** Line coverage coalesces
+markers that provably execute together — those in one basic block with
+nothing between them that can abandon the invocation — onto a single
+counter and a single runtime probe. This is what keeps instrumented
+shader code small, since emitted size scales with probe count. Several
+entries therefore share a `counterIndex`, and `counterCount` is
+markedly smaller than the entry count (roughly half on the bundled
+demos). Function and branch entries keep a dedicated counter.
+
+Two consequences for hosts:
+
+- Size the readback buffer from `counterCount`, never from the entry
+  count. They are different numbers.
+- Accumulate per entry (`counters[entry.counterIndex]` for each entry),
+  never per counter. A counter no longer identifies one source
+  location, so iterating counters and attributing each to "its" line is
+  wrong.
+
+Both were already the documented contract; coalescing is what makes
+getting them wrong actually break. Future modes may additionally expose
+entries with no direct runtime counter, so hosts should keep using
+`entry.counterIndex` and be prepared for extended entry data rather
+than assuming the entry index equals the counter index.
 
 #### Producing the canonical manifest JSON in-process
 
@@ -347,9 +365,15 @@ effectively never wrap; uint32 slots wrap silently at 2^32 hits per
 slot and read back as small numbers.
 
 Counter slot indices are per-compile: slot `K` does not identify the
-same source location across two compiles or shader variants. Aggregate
-by the source attribution in the manifest or metadata, never by slot
-index.
+same source location across two compiles or shader variants, and one
+slot may serve several source locations. Aggregate by the source
+attribution in the manifest or metadata, never by slot index.
+
+The counter buffer and the manifest must come from the *same* compile.
+`slang-coverage-to-lcov.py` enforces this by requiring the buffer size
+to match `counter_count` exactly; a mismatch is an error rather than a
+silently truncated read, because a prefix of a stale buffer produces
+plausible but wrong hit counts.
 
 ---
 

--- a/tools/shader-coverage/README.md
+++ b/tools/shader-coverage/README.md
@@ -229,9 +229,11 @@ markers that provably execute together — those in one basic block with
 nothing between them that can abandon the invocation — onto a single
 counter and a single runtime probe. This is what keeps instrumented
 shader code small, since emitted size scales with probe count. Several
-entries therefore share a `counterIndex`, and `counterCount` is
-markedly smaller than the entry count (roughly half on the bundled
-demos). Function and branch entries keep a dedicated counter.
+entries therefore share a `counterIndex`, and `counterCount` is never
+larger than the entry count -- roughly half on the bundled demos.
+Function and branch entries keep a dedicated counter, so a compile that
+enables only those modes leaves the two counts equal; do not code
+against a strict inequality.
 
 Two consequences for hosts:
 

--- a/tools/shader-coverage/slang-coverage-to-lcov.py
+++ b/tools/shader-coverage/slang-coverage-to-lcov.py
@@ -11,7 +11,10 @@ Pipeline:
        `-trace-coverage-counter-width 32` is passed (e.g. for
        runtime drivers that lack 64-bit shader atomic add).
        Counter slots are assigned according to the coverage metadata.
-       The current line/function/branch modes use one direct counter
+       Line coverage coalesces entries that execute together onto a
+       shared counter, so several entries may name the same slot and
+       there are fewer counters than entries. Accumulate per entry.
+       Function and branch modes use one direct counter
        per marker op, but consumers must treat the manifest as
        authoritative.
     2. Read the `.coverage-manifest.json` sidecar describing each
@@ -71,23 +74,33 @@ def load_counters_binary(path, count, stride):
     needed = count * stride
     with open(path, "rb") as f:
         raw = f.read()
-    if len(raw) < needed:
+    # Require an exact match rather than a lower bound. A buffer that is
+    # larger than the manifest expects is not harmless padding: it means
+    # the counters were read back for a *different* compile of the shader,
+    # and since slot indices are per-compile, silently using the first
+    # `needed` bytes produces plausible but wrong hit counts. Coalescing
+    # makes this the likely failure mode, because counter_count now drops
+    # sharply between an old and a new compile of the same source.
+    if len(raw) != needed:
         sys.exit(
             f"error: counter file '{path}' is {len(raw)} bytes; "
-            f"manifest expects at least {needed} ({count} slots * {stride} bytes)"
+            f"manifest expects exactly {needed} ({count} slots * {stride} bytes). "
+            f"The counter buffer and the manifest must come from the same compile."
         )
-    return list(struct.unpack(f"<{count}{code}", raw[:needed]))
+    return list(struct.unpack(f"<{count}{code}", raw))
 
 
 def load_counters_text(src, count):
     data = sys.stdin.read() if src == "-" else open(src).read()
     values = [int(tok) for tok in data.split() if tok.strip()]
-    if len(values) < count:
+    # Exact match, for the same reason as the binary path above.
+    if len(values) != count:
         sys.exit(
             f"error: found {len(values)} counter values; "
-            f"manifest expects at least {count}"
+            f"manifest expects exactly {count}. "
+            f"The counter values and the manifest must come from the same compile."
         )
-    return values[:count]
+    return values
 
 
 def get_manifest_version(manifest):
@@ -231,7 +244,8 @@ def main():
         counters = load_counters_text(args.counters_text, total)
 
     # Aggregate by (file, line). Multiple counter slots may map to the
-    # same line because the compiler assigns one slot per counter op;
+    # same line, and one slot may also serve several lines once the
+    # compiler coalesces markers that execute together;
     # LCOV wants line-oriented reporting, so sum them here.
     #
     # GCOV/LCOV-style output only admits real source files and positive

--- a/tools/shader-coverage/test_slang_coverage_to_lcov.py
+++ b/tools/shader-coverage/test_slang_coverage_to_lcov.py
@@ -777,6 +777,93 @@ class SlangCoverageToLcovTests(unittest.TestCase):
         self.assertIn("DA:5,99\n", result.stdout)
         self.assertEqual(result.stderr, "")
 
+    def test_binary_counters_reject_oversized_buffer(self):
+        # A buffer larger than the manifest expects means the counters
+        # were read back from a different compile of the shader. Slot
+        # indices are per-compile, so quietly using a prefix of the
+        # buffer yields plausible but wrong hit counts. Coalescing makes
+        # this the natural mistake, because counter_count drops sharply
+        # between an old and a new compile of the same source.
+        manifest = {
+            "version": 2,
+            "counter_count": 2,
+            "buffer": {"element_type": "uint32", "element_stride": 4},
+            "entries": [
+                {"kind": "line", "counter": 0, "file": "shader.slang", "line": 10},
+                {"kind": "line", "counter": 1, "file": "shader.slang", "line": 11},
+            ],
+        }
+        counters = struct.pack("<4I", 7, 13, 99, 99)
+
+        result = self.run_converter_binary(manifest, counters, check=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("expects exactly 8", result.stderr)
+        self.assertIn("same compile", result.stderr)
+
+    def test_binary_counters_reject_undersized_buffer(self):
+        # The undersized direction was already rejected; pin it so the
+        # move from a lower-bound to an exact check keeps it rejected.
+        manifest = {
+            "version": 2,
+            "counter_count": 4,
+            "buffer": {"element_type": "uint32", "element_stride": 4},
+            "entries": [
+                {"kind": "line", "counter": 0, "file": "shader.slang", "line": 10},
+            ],
+        }
+        counters = struct.pack("<2I", 7, 13)
+
+        result = self.run_converter_binary(manifest, counters, check=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("expects exactly 16", result.stderr)
+
+    def test_text_counters_reject_extra_values(self):
+        # Same contract on the text input path.
+        manifest = {
+            "version": 2,
+            "counter_count": 2,
+            "buffer": {"element_type": "uint32", "element_stride": 4},
+            "entries": [
+                {"kind": "line", "counter": 0, "file": "shader.slang", "line": 10},
+                {"kind": "line", "counter": 1, "file": "shader.slang", "line": 11},
+            ],
+        }
+
+        result = self.run_converter(manifest, counters_text="7 13 99", check=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("expects exactly 2", result.stderr)
+
+    def test_entries_may_share_a_counter_slot(self):
+        # Coalesced line coverage points several source entries at one
+        # counter. The converter must accumulate per *entry*, so a slot
+        # shared by two lines reports that slot's value on each line,
+        # and two entries on the same line still sum — this is what
+        # keeps LCOV output unchanged when coalescing is enabled.
+        manifest = {
+            "version": 2,
+            "counter_count": 1,
+            "buffer": {"element_type": "uint32", "element_stride": 4},
+            "entries": [
+                {"kind": "line", "counter": 0, "file": "shader.slang", "line": 10},
+                {"kind": "line", "counter": 0, "file": "shader.slang", "line": 11},
+                {"kind": "line", "counter": 0, "file": "shader.slang", "line": 12},
+                {"kind": "line", "counter": 0, "file": "shader.slang", "line": 12},
+            ],
+        }
+        counters = struct.pack("<1I", 5)
+
+        result = self.run_converter_binary(manifest, counters)
+
+        self.assertIn("DA:10,5\n", result.stdout)
+        self.assertIn("DA:11,5\n", result.stdout)
+        # Two entries on line 12 sum, exactly as they would with two
+        # dedicated slots holding 5 each.
+        self.assertIn("DA:12,10\n", result.stdout)
+        self.assertEqual(result.stderr, "")
+
     def test_binary_counters_unsupported_stride_errors(self):
         # The converter only handles 4-byte and 8-byte counters today.
         # A 2-byte / 16-byte stride must produce a clear error rather

--- a/tools/slang-unit-test/unit-test-coverage-tracing-metadata.cpp
+++ b/tools/slang-unit-test/unit-test-coverage-tracing-metadata.cpp
@@ -891,6 +891,7 @@ SLANG_UNIT_TEST(coverageTracingMetadata)
         // to catch.
         List<uint32_t> lineSlots;
         List<uint32_t> dedicatedSlots;
+        Index lineEntryCount = 0;
         for (uint32_t i = 0; i < allModesCoverage->getEntryCount(); ++i)
         {
             slang::CoverageEntryInfo entry;
@@ -901,6 +902,7 @@ SLANG_UNIT_TEST(coverageTracingMetadata)
             if (entry.kind == slang::CoverageEntryKind::Line)
             {
                 seenLine = true;
+                lineEntryCount++;
                 if (lineSlots.indexOf(entry.counterIndex) < 0)
                     lineSlots.add(entry.counterIndex);
             }
@@ -926,9 +928,11 @@ SLANG_UNIT_TEST(coverageTracingMetadata)
         SLANG_CHECK(
             lineSlots.getCount() + dedicatedSlots.getCount() ==
             (Index)allModesCoverage->getCounterCount());
-        // Coalescing must actually have happened: more line entries than
-        // line slots.
-        SLANG_CHECK(lineSlots.getCount() < (Index)allModesCoverage->getEntryCount());
+        // Coalescing must actually have happened. Compare against the
+        // line-entry count specifically: `getEntryCount()` includes the
+        // function and branch entries asserted above, so it would exceed
+        // the line-slot count even if line coalescing regressed entirely.
+        SLANG_CHECK(lineSlots.getCount() < lineEntryCount);
     }
 
     // Argument validation on the serializer.

--- a/tools/slang-unit-test/unit-test-coverage-tracing-metadata.cpp
+++ b/tools/slang-unit-test/unit-test-coverage-tracing-metadata.cpp
@@ -243,7 +243,20 @@ SLANG_UNIT_TEST(coverageTracingMetadata)
         const uint32_t entryCount = coverage->getEntryCount();
         SLANG_CHECK(entryCount > 0);
 
+        // Line coverage coalesces the entries of a straight-line region
+        // onto a single counter, so entries outnumber counters and at
+        // least one slot is shared. This is the contract hosts depend on:
+        // size the readback buffer from the counter count, and accumulate
+        // per entry rather than per counter. The shader above has several
+        // straight-line runs (the `accum` init followed by the `for`, and
+        // each switch-case body), so the inequality is not incidental.
+        SLANG_CHECK(entryCount > counterCount);
+
         bool seenAnyStartColumn = false;
+        List<uint32_t> entriesPerCounter;
+        entriesPerCounter.setCount((Index)counterCount);
+        for (uint32_t i = 0; i < counterCount; ++i)
+            entriesPerCounter[(Index)i] = 0;
         for (uint32_t i = 0; i < entryCount; ++i)
         {
             slang::CoverageEntryInfo entry;
@@ -262,8 +275,14 @@ SLANG_UNIT_TEST(coverageTracingMetadata)
             SLANG_CHECK(entry.branchSiteID == 0);
             SLANG_CHECK(entry.branchArmID == 0);
             SLANG_CHECK(entry.branchArmKind == slang::CoverageBranchArmKind::Unknown);
+            entriesPerCounter[(Index)entry.counterIndex]++;
         }
         SLANG_CHECK(seenAnyStartColumn);
+
+        bool sawSharedCounter = false;
+        for (uint32_t i = 0; i < counterCount; ++i)
+            sawSharedCounter = sawSharedCounter || entriesPerCounter[(Index)i] > 1;
+        SLANG_CHECK(sawSharedCounter);
     };
 
     auto cpuBundle = createMetadataBundle(SLANG_CPP_SOURCE, "sm_5_0");
@@ -864,29 +883,52 @@ SLANG_UNIT_TEST(coverageTracingMetadata)
         bool seenLine = false;
         bool seenFunction = false;
         bool seenBranch = false;
-        List<uint32_t> seenCounterSlots;
+        // Line entries may legitimately share a slot: coalescing points
+        // every entry of a straight-line region at one counter. Function
+        // and branch entries must not — each names a distinct site whose
+        // count would be destroyed by sharing — and no slot may be used
+        // by more than one mode, which is the collision this block exists
+        // to catch.
+        List<uint32_t> lineSlots;
+        List<uint32_t> dedicatedSlots;
         for (uint32_t i = 0; i < allModesCoverage->getEntryCount(); ++i)
         {
             slang::CoverageEntryInfo entry;
             SLANG_CHECK(allModesCoverage->getEntryInfo(i, &entry) == SLANG_OK);
             SLANG_CHECK(entry.counterIndex != slang::kInvalidCoverageCounterIndex);
             SLANG_CHECK(entry.counterIndex < allModesCoverage->getCounterCount());
-            for (auto seenCounterSlot : seenCounterSlots)
-                SLANG_CHECK(seenCounterSlot != entry.counterIndex);
-            seenCounterSlots.add(entry.counterIndex);
 
             if (entry.kind == slang::CoverageEntryKind::Line)
+            {
                 seenLine = true;
-            else if (entry.kind == slang::CoverageEntryKind::Function)
-                seenFunction = true;
-            else if (entry.kind == slang::CoverageEntryKind::Branch)
-                seenBranch = true;
+                if (lineSlots.indexOf(entry.counterIndex) < 0)
+                    lineSlots.add(entry.counterIndex);
+            }
+            else
+            {
+                if (entry.kind == slang::CoverageEntryKind::Function)
+                    seenFunction = true;
+                else if (entry.kind == slang::CoverageEntryKind::Branch)
+                    seenBranch = true;
+                SLANG_CHECK(dedicatedSlots.indexOf(entry.counterIndex) < 0);
+                dedicatedSlots.add(entry.counterIndex);
+            }
         }
 
         SLANG_CHECK(seenLine);
         SLANG_CHECK(seenFunction);
         SLANG_CHECK(seenBranch);
-        SLANG_CHECK(seenCounterSlots.getCount() == allModesCoverage->getEntryCount());
+        // The two namespaces must not overlap.
+        for (auto lineSlot : lineSlots)
+            SLANG_CHECK(dedicatedSlots.indexOf(lineSlot) < 0);
+        // Every counter is accounted for by exactly one mode, so the
+        // distinct slots across both namespaces cover the whole buffer.
+        SLANG_CHECK(
+            lineSlots.getCount() + dedicatedSlots.getCount() ==
+            (Index)allModesCoverage->getCounterCount());
+        // Coalescing must actually have happened: more line entries than
+        // line slots.
+        SLANG_CHECK(lineSlots.getCount() < (Index)allModesCoverage->getEntryCount());
     }
 
     // Argument validation on the serializer.


### PR DESCRIPTION
Fixes #12682.

## Motivation

Line coverage emitted one probe per instrumented statement. Each probe is real executable code — compute the slot index, address `__slang_coverage[slot]`, atomic-add — so emitted shader size scaled with the *statement count* rather than with the number of distinct control-flow paths.

Consider this shader:

```slang
void someFunction(uint N)
{
    uint i = 0;
    while (i < N)
    {
        buf[0] = buf[1] + buf[2];
        buf[3] = buf[4] + buf[5];
        buf[6] = buf[7] + buf[8];
        i++;
    }
}
```

That is six markers and six probes. But `uint i = 0` and the `while` statement land in the same basic block, and the four loop-body statements land in another, so there are only ever two distinct execution counts here. Four of the six probes are pure overhead.

This is the dominant cost for RT pipeline-library workflows, where larger SPIR-V inflates driver-resident pipeline-library memory: every retained library object carries the bigger stage code plus its driver compile state.

## Proposed solution

Emit one counter and one probe per straight-line region, attributing every statement in the region to that counter.

This needs no flag and costs nothing in reported results, which is the key claim of the PR. Instructions in one basic block execute the same number of times by construction — one entry, one exit — so the per-statement counts being merged were never distinct. Every marker keeps its own source entry, and hosts already accumulate per entry, so entries sharing a slot produce exactly the LCOV records dedicated slots did.

Grouping by parent `IRBlock` is what makes this principled rather than a pile of special cases. Every boundary that must not be crossed — `if`/`else` arms, `switch` cases, loop body versus loop exit, early `return`/`break`/`continue`, short-circuit operands — already begins a new block during AST lowering. The region boundary *is* the block boundary; there is no separate list of statement kinds to keep in sync.

Two refinements the block rule alone does not give:

- **The probe goes at the last marker of a region**, not the first. Reaching it proves every earlier marker in the region executed. A probe at the front would over-report a region that is entered but abandoned partway, and over-reporting is the dangerous direction for a coverage tool.
- **A region splits at any instruction that can abandon the invocation**, because such an instruction breaks the same-block/same-count property.

### Measured results

Replaying the recorded GPU counter data from the bundled demos through `slang-coverage-to-lcov.py`:

| | before | after | |
| --- | --- | --- | --- |
| image-pipeline line counters | 123 | 63 | −49% |
| image-pipeline SPIR-V | 30,140 B | 25,228 B | −16% total, −30% of coverage overhead |
| bvh-traversal SPIR-V | 28,836 B | 23,620 B | −18% total, −34% of overhead |

LCOV output is byte-identical across both demos and both the `full` and `smoke` runs — 121 `DA`, 40 `BRDA`, 17 `FNDA` records, zero diff.

## Change summary

| File | What it does |
| --- | --- |
| `source/slang/slang-ir-coverage-instrument.cpp` | Adds `CoverageFunctionExitAnalysis` (may-not-return fixpoint over the call graph), `getStaticallyResolvedCallee`, and `assignCoverageCounterSlots`; `run`/`lowerMarkerOp` now drive off the slot assignment and emit a probe only for a region's representative marker. |
| `source/slang/slang-ir-coverage-instrument.h` | Header contract updated: entry count and counter count now genuinely differ. |
| `include/slang.h` | `CoverageEntryInfo::counterIndex` documented as non-unique, with the two host rules (size from counter count; accumulate per entry). |
| `source/slang/slang-ir-insts.lua` | `IncrementCoverageCounter` doc: the marker→counter lowering is no longer one-to-one. |
| `source/slang/slang-options.cpp` | `-trace-coverage` help text notes coalescing and that counters are fewer than entries. |
| `tools/shader-coverage/slang-coverage-to-lcov.py` | Requires the counter buffer to match `counter_count` exactly instead of truncating an oversized one. |
| `tools/shader-coverage/test_slang_coverage_to_lcov.py` | 4 tests: oversized/undersized/extra-text rejection, and entries sharing a slot. |
| `tools/slang-unit-test/unit-test-coverage-tracing-metadata.cpp` | Asserts entries outnumber counters, at least one slot is shared, and function/branch slots stay dedicated and disjoint from line slots. |
| `tests/language-feature/coverage/coverage-coalesce-region.slang` | New: straight-line run collapses; if/else arms do not. |
| `tests/language-feature/coverage/coverage-coalesce-exit-split.slang` | New: a call to a discarding helper splits the region. |
| `tests/language-feature/coverage/coverage-multi-stmt-per-line.slang` | Rewritten (see process report). |
| `docs/design/shader-coverage-counter-placement.md` | New "Counter coalescing" section; "Future Region Coverage" corrected to present tense. |
| `docs/design/shader-coverage.md`, `docs/design/shader-coverage-host-interface.md`, `tools/shader-coverage/README.md` | Entries and counters are no longer one-to-one. |

## Concepts and vocabulary

- **Marker op** — `IncrementCoverageCounter` / `IncrementFunctionCoverageCounter` / `IncrementBranchCoverageCounter`, emitted during AST lowering in `lowerStmt` and rewritten to an atomic by this pass.
- **Probe** — the emitted runtime counter update (slot index, `RWStructuredBufferGetElementPtr`, `AtomicAdd`). Probe count, not counter width, is what scales emitted SPIR-V.
- **Source entry** (`CoverageEntryInfo`) — the host-facing record attributing a `(file, line, column)` to a counter slot. One per marker, always.
- **Region** — a maximal run of line markers within one basic block with nothing between them that can abandon the invocation. Shares one counter and one probe.
- **`GenericAsm`** — how `__intrinsic_asm` lowers. It is an `IRTerminatorInst` but carries *return* semantics: it ends the function and hands back a value, like `IRReturn`. This distinction is load-bearing (see process report).
- **May-not-return** — a function that can abandon the invocation rather than return to its caller.

## Process report

**Why an IR-level pass and not AST lowering.** The design note that preceded this work offered both. AST lowering would need an explicit, maintained list of every construct that breaks a straight-line run. The IR pass needs none: it runs after `lowerStmt` has already turned each of those constructs into control flow, so a basic block *is* a straight-line region. Grouping by `markerOp->getParent()` is the whole boundary rule, which is why there is no `switch` over statement kinds anywhere in the diff.

**Why the probe is placed last.** `assignCoverageCounterSlots` hands the probe forward as it walks a region, clearing `outEmitsProbe` on the previous owner, so only the final marker emits. If a region is entered and then abandoned partway, a probe at the front reports every line covered (false positive, hides untested code); a probe at the end reports none of them (false negative). For a coverage tool the second is the safe failure, and it only occurs where the split analysis below is incomplete.

**Why the exit analysis exists, and the input shape it handles.** Consider:

```slang
void maybeKill(float v) { if (v < 0.5f) discard; }

float4 fragMain(float2 uv : TEXCOORD) : SV_Target
{
    float a = uv.x + 1.0f;   // marker 1
    float b = a * 2.0f;      // marker 2
    maybeKill(b);            // marker 3
    float c = b + 3.0f;      // marker 4
    return float4(c);        // marker 5
}
```

All five markers sit in `fragMain`'s entry block. `discard` is *not* an `IRTerminatorInst` in Slang's IR — it sits outside the `TerminatorInst` group in `slang-ir-insts.lua` — so nothing about the block structure reveals that markers 4 and 5 execute fewer times than 1–3 when `maybeKill` discards.

Is that input shape correct, or should the producer be fixed? It is correct. A basic block whose interior can abandon the invocation is a legitimate IR shape — `discard`'s SPIR-V lowering is target-dependent (`OpKill` versus `OpDemoteToHelperInvocation`, per `shouldEmitDiscardAsDemote`), and forcing a block split in the front end would encode one target's semantics into the shared representation. So the consumer is the right layer: this pass needs the property "can control reach the next instruction", which is exactly what `CoverageFunctionExitAnalysis` computes. `tests/language-feature/coverage/coverage-coalesce-exit-split.slang` fails without it — `fragMain` collapses to one region and slot 3 disappears.

**Why unresolved callees are treated as may-not-return.** `instrumentCoverage` runs at `slang-emit.cpp:1216`, before `specializeModule`, so an interface method dispatched through a witness table has no visible body. The pass assumes the worst and splits. This is deliberate asymmetry: an unnecessary split costs a probe, a missed split costs correctness. It is also why the numbers above are 63 line counters rather than the 58 a block-only grouping would give.

**Two bugs found by measuring rather than reasoning, both worth recording.**

*First:* the analysis initially treated a `GenericAsm` terminator as an abort, on the theory that it is how the RT hit terminators are represented. It is not — `GenericAsm` is how `__intrinsic_asm` lowers, and it carries return semantics. Because `dot`'s SPIR-V path ends in one, every function calling `dot` was classified may-not-return, and every call to such a function split a region. Caught by the counter count not moving when it should have.

*Second:* a call to a generic function reaches this pass as `call specialize(%dot, Float, 3)(...)`, not as a direct `IRFunc` call. Without `getStaticallyResolvedCallee` peeling the `specialize`, every generic call — most numeric code — hit the unresolved-callee path and split. The generic's body is right there to analyse, so resolving it is not graph-walking to recover lost context; it is reading the operand the call already carries.

**Why `coverage-multi-stmt-per-line.slang` was rewritten rather than deleted.** It pinned three statements on one source line to three *counters*, guarding against an older design that deduplicated slots by `(file, line)`. Coalescing legitimately merges those three (same block), so the counter-level assertion had to go — but the invariant it protected, that markers are not deduplicated by source position, is still true and still worth pinning. It now asserts one probe for the straight-line run, and the entry-level distinctness moved to `unit-test-coverage-tracing-metadata.cpp`, which can see the metadata API and assert that the three entries survive with distinct columns.

**Why the converter change is in this PR.** `load_counters_binary` validated only a lower bound and truncated the rest, so a counter buffer read back from a *different* compile produced plausible but wrong LCOV — no error. That looseness predates this PR, but coalescing halves `counter_count` for every shader at once, on exactly the upgrade where stale `.bin` artifacts are lying around, which turns a latent trap into the likely failure mode. Verified: feeding the old 180-slot buffer against the new manifest previously produced 348 silently changed records and exit 0.

**Known gap.** `IgnoreHit` and `AcceptHitAndEndSearch` end the invocation at the target level, but Slang models them as ordinary `void` core-module functions that return normally, and there is no `[noreturn]` concept in the IR to key off. An anyhit shader with `AcceptHitAndEndSearch()` followed by further statements in the same block would over-report. The principled fix is a core-module marker on those two functions, which would also give other passes the same information; it is out of scope here and recorded in both the code and `shader-coverage-counter-placement.md`.

**Host-visible behaviour change.** No ABI or language break, so this is labelled non-breaking — but `counter_count` now falls well below the entry count. A host that sized its readback buffer from the entry count worked incidentally until now and will read short. `slang.h` has always documented `counterIndex` as shareable and the two counts as separate; this PR makes the distinction load-bearing and says so in the header, the README, and the CLI help.

## Test Plan

- [x] New: `tests/language-feature/coverage/coverage-coalesce-region.slang` (region collapses, if/else arms do not)
- [x] New: `tests/language-feature/coverage/coverage-coalesce-exit-split.slang` (call to a discarding helper splits)
- [x] Rewritten: `coverage-multi-stmt-per-line.slang`
- [x] `slang-test tests/language-feature/coverage/` — 74/74
- [x] `slang-test tests/diagnostics/command-line/` — 55/55
- [x] `slang-test slang-unit-test-tool/coverageTracingMetadata` — passes
- [x] `pytest tools/shader-coverage/test_slang_coverage_to_lcov.py` — 31/31
- [x] LCOV output byte-identical vs. the demos' recorded counter data (image-pipeline and bvh-traversal, `full` and `smoke`)
- [x] `./extras/formatting.sh --modified --check-only` clean

Not run locally: GPU-backed tests (no GPU on this machine). One pre-existing unrelated failure, `testServerLossHealthyRunIsUnaffected`, traces to `tests/preprocessor/line-macro.slang.1 syn (llvm)` failing on unmodified master on this machine.
