### PR TITLE
ci: give test-falcor room for the approval gate, and fix its comment

### DIFF
--- a/.github/workflows/ci-falcor-test.yml
+++ b/.github/workflows/ci-falcor-test.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   test-falcor:
     name: Test (Falcor)
-    timeout-minutes: 100
+    timeout-minutes: 180
     runs-on: [Linux, self-hosted, X64, falcor-bridge]
     # Vet-and-approve gate: this job runs PR-controlled code on the internal
     # bridge VM, so approval (required reviewers = the `ci-approvers` team)
@@ -28,10 +28,14 @@ jobs:
     # build-windows-release-cl-x86_64-gpu-falcor), not here directly --
     # GitHub charges one approval prompt per job that references an
     # environment, so putting the gate on both the build and this job would
-    # mean two separate approval clicks per PR for one Falcor run. A PR by a
-    # team member runs automatically; anyone else's run waits for the one
-    # upstream approval, which also covers this job since it cannot start
-    # until the gated build produces its artifact.
+    # mean two separate approval clicks per PR for one Falcor run. Every PR's
+    # run pauses for that one upstream approval -- environment protection has
+    # no actor scoping, so there is no "team member" exemption -- and it also
+    # covers this job, since it cannot start until the gated build produces
+    # its artifact. timeout-minutes only counts execution time once this job
+    # starts on a runner, so it does not need to budget for the approval
+    # wait; it still needs to cover the ~45 minute Falcor run plus that run's
+    # own queue for a GPU host on the far side of the bridge.
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Replaces #12425, which now conflicts: the `falcor-ci` gate has since moved
to `falcor-build-approval-gate` in `ci.yml` (via #12614/#11915), so #12425's
diff no longer applies to the current job shape. The two underlying problems
it raised are still present on master, unrelated to that restructuring.

**`timeout-minutes` 100 → 180.** `timeout-minutes` only counts execution
time once the job starts on a runner -- it does not budget for the
`falcor-ci` approval wait. But `test-falcor`'s actual execution time is the
Falcor run itself (~45 minutes) plus that run's own queue for a GPU host on
the far side of the bridge, and 100 minutes left room for only one run and a
short queue.

**Fix the comment's closing sentence.** It claimed a team member's PR runs
automatically and only other people wait. GitHub environment protection has
no actor scoping, so every run pauses for the same approval -- including
team members' own PRs and merge-queue runs.

`test-falcor-perf` is untouched: it is not gated and does not need the
headroom.