### PR TITLE
Notify cmake-options weekly results on Slack

### DIFF
--- a/.github/workflows/cmake-options.yml
+++ b/.github/workflows/cmake-options.yml
@@ -164,3 +164,30 @@ jobs:
             exit 1
           fi
           echo "All CMake option builds completed successfully!"
+
+      - name: success notification
+        id: slack-notify-success
+        if: ${{ github.event_name == 'schedule' && success() }}
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        with:
+          payload: |
+            {
+              "CMake-Options-Weekly": ":green-check-mark: CMake options weekly status: ${{ job.status }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      # TODO: Re-enable the failure notification once this weekly workflow has
+      # proven stable enough that a failure means a real regression. Until
+      # then we only post the success message, so an infrastructure hiccup
+      # does not advertise a false failure to the channel.
+      # - name: failure notification
+      #   id: slack-notify-failure
+      #   if: ${{ github.event_name == 'schedule' && !success() }}
+      #   uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+      #   with:
+      #     payload: |
+      #       {
+      #         "CMake-Options-Weekly": ":alert: :alert: :alert: :alert: :alert: :alert:\nCMake options weekly status: ${{ job.status }}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      #       }
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Motivation

The [CMake Options weekly workflow](https://github.com/shader-slang/slang/actions/workflows/cmake-options.yml)
verifies that each CMake option still compiles when flipped to its non-default
value. It runs on a Saturday cron, and lately it has become reliable enough that
its result is worth acting on. Today, though, nobody finds out what it said
unless they remember to open the Actions tab on a Monday — so a broken option
can sit unnoticed for a week.

Every other scheduled workflow we care about already reports to Slack:
`nightly-slang-vkglcts-test.yml` (CTS), `nightly-slang-sanitizer-test.yml`,
`nightly-slang-sascha-test.yml`, and `nightly-remix-test.yml` all post their
status at the end of the run. This PR gives the cmake-options weekly the same
treatment.

## Proposed solution

Add the notification steps to the existing `check-cmake` job rather than adding
a new `notify` job.

`check-cmake` is already the aggregation point: it `needs` all twelve build jobs,
runs with `if: always()`, and its "Check CI Results" step greps
`toJSON(needs.*.result)` for `"failure"` or `"cancelled"` and exits 1 if it finds
either. That makes the job's own status a faithful one-bit summary of the whole
matrix, which is exactly what the Slack message wants to report — so
`success()` / `!success()` inside that job needs no extra plumbing, and a
separate job would only re-derive the same bit.

The steps follow the CTS nightly verbatim: the same pinned action
(`slackapi/slack-github-action@70cd7be8`, v1.26.0), the same generic
`secrets.SLACK_WEBHOOK_URL` webhook that CTS posts through, and the same
`github.event_name == 'schedule'` gate so ad-hoc `workflow_dispatch` runs — which
people use to validate a CMake change before merging — stay silent.

Only the success notification is enabled for now. The failure notification is
written out in full but left commented out, with a TODO recording the condition
for turning it on. The reasoning is deliberately conservative: this workflow has
*recently* become reliable, and a red run today is still about as likely to be a
runner hiccup as a genuine regression. Advertising a false failure to the channel
teaches people to ignore the channel, which is worse than not posting at all. A
few clean weeks of green messages will tell us whether the failure signal can be
trusted, and re-enabling it is then a matter of deleting comment markers.

Note that suppressing the Slack alert does not suppress the signal itself — the
"Check CI Results" step still `exit 1`s, so a failed or cancelled matrix job
still marks the run red on GitHub.

## Change summary

| File | Change |
| --- | --- |
| `.github/workflows/cmake-options.yml` | Append a "success notification" step and a commented-out "failure notification" step to the `check-cmake` job. |

## Process report

**Why the steps live in `check-cmake` and not a new `notify` job.** The
sanitizer nightly uses a standalone `notify` job because its workflow has no
aggregation job to hang the steps on — it calls one reusable workflow and reads
`needs.sanitizer-nightly.result` directly. `cmake-options.yml` is different: it
fans out to twelve reusable-workflow calls and already funnels them into
`check-cmake` (`.github/workflows/cmake-options.yml:132-166`), which converts
twelve results into one exit code. Adding a second aggregation job would mean a
second copy of the "did anything fail" logic, with the two able to disagree.
Putting the steps in `check-cmake` keeps one source of truth.

**Why `success()` / `!success()` is the right condition.** Within `check-cmake`,
`success()` is false once the "Check CI Results" step has exited 1, which happens
exactly when `toJSON(needs.*.result)` contains `"failure"` or `"cancelled"`. So
the notification condition is derived from the same expression that decides the
job's own verdict, not from a parallel re-reading of `needs.*.result`. This is
also the form the CTS nightly uses
(`.github/workflows/nightly-slang-vkglcts-test.yml:137,148`), so the two
workflows read the same way.

**Why `secrets.SLACK_WEBHOOK_URL` and not a new secret.** The nightlies are split
across per-workflow webhooks (`SLACK_WEBHOOK_SWILLEMS_VK`,
`SLACK_SANITIZER_NIGHTLY_WEBHOOK_URL`, `SLACK_WEBHOOK_RTX_REMIX`,
`SLACK_WEBHOOK_AGENTIC_TESTS`) because each targets its own channel. CTS instead
uses the generic `SLACK_WEBHOOK_URL`. Reusing that one means this PR needs no
repository-secret change to start working, and the cmake-options result lands
next to the CTS result, which is the same audience. The payload key is
`"CMake-Options-Weekly"`, distinct from CTS's `"CTS-Nightly"`, so the two are
distinguishable in the channel.

**Why the `schedule` gate.** `workflow_dispatch` on this workflow exists for
ad-hoc validation — the header comment at
`.github/workflows/cmake-options.yml:9-14` explains that the `merge_group`
trigger was removed precisely because the twelve-job matrix starved the runner
budget, leaving manual dispatch as the on-demand path. Those manual runs are a
developer checking their own change and do not belong in a channel that people
read as "the weekly result". Gating on `github.event_name == 'schedule'` matches
what every other notifying workflow does.

**Why the failure step is committed as a comment rather than omitted.** Deleting
it would mean re-deriving the payload, the emoji convention, and the run-URL
interpolation when we do turn it on, and would leave no record in the file that
the omission was deliberate rather than an oversight. Keeping it commented with a
TODO makes the intent and the re-enable step self-evident to the next reader.
