### PR TITLE
Fix: wrong SPIR-V ArrayStride on pointers to sized arrays

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -2034,6 +2034,9 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         if (auto arrayType = as<IRUnsizedArrayType>(valueType))
             return getArrayElementStrideValue(arrayType, rule);
 
+        if (auto arrayType = as<IRArrayType>(valueType))
+            return getArrayElementStrideValue(arrayType, rule);
+
         IRSizeAndAlignment sizeAndAlignment;
         getSizeAndAlignment(m_targetRequest, rule, valueType, &sizeAndAlignment);
 

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -2031,10 +2031,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         auto valueType = getSpvPointerValueType(ptrType);
         auto rule = getPointerArrayStrideLayoutRule(ptrType, valueType);
 
-        if (auto arrayType = as<IRUnsizedArrayType>(valueType))
-            return getArrayElementStrideValue(arrayType, rule);
-
-        if (auto arrayType = as<IRArrayType>(valueType))
+        if (auto arrayType = as<IRArrayTypeBase>(valueType))
             return getArrayElementStrideValue(arrayType, rule);
 
         IRSizeAndAlignment sizeAndAlignment;

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -2031,6 +2031,9 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         auto valueType = getSpvPointerValueType(ptrType);
         auto rule = getPointerArrayStrideLayoutRule(ptrType, valueType);
 
+        // Array pointees only ever serve element indexing, so use the element
+        // stride. Whole-object stepping goes through the wrapper pointer,
+        // whose pointee is a struct and falls through to the path below.
         if (auto arrayType = as<IRArrayTypeBase>(valueType))
             return getArrayElementStrideValue(arrayType, rule);
 

--- a/tests/language-feature/pointer/ptr-sized-array-dyn-index.slang
+++ b/tests/language-feature/pointer/ptr-sized-array-dyn-index.slang
@@ -1,0 +1,54 @@
+// Regression test for the SPIR-V ArrayStride on pointers to sized arrays.
+//
+// Dynamic indexing into a sized array through a Ptr previously read the wrong
+// memory on drivers that consume the pointer type's ArrayStride decoration
+// (the decoration carried the whole array size instead of the element
+// stride). This test binds a real buffer to a Ptr inside a cbuffer and
+// dynamically indexes into the sized array field, verifying the element
+// addresses at runtime. Also checks whole-object stepping (d + 1 advances by
+// the whole struct).
+
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK): -vk -emit-spirv-directly -compute
+//TEST_INPUT:ubuffer(data=[1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0 4.0 4.0 4.0 4.0 4.0 4.0 4.0 4.0 4.0 4.0 4.0 4.0 4.0 4.0 4.0 4.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 6.0 6.0 6.0 6.0 6.0 6.0 6.0 6.0 6.0 6.0 6.0 6.0 6.0 6.0 6.0 6.0 7.0 7.0 7.0 7.0 7.0 7.0 7.0 7.0 7.0 7.0 7.0 7.0 7.0 7.0 7.0 7.0 8.0 8.0 8.0 8.0 8.0 8.0 8.0 8.0 8.0 8.0 8.0 8.0 8.0 8.0 8.0 8.0], stride=4):name Globals.d
+//TEST_INPUT:set outputBuffer = out ubuffer(data=[0 0 0 0 0 0], stride=4)
+
+struct Data
+{
+    float4x4 mats[4];
+};
+
+cbuffer Globals
+{
+    LayoutPtr<Data, Std430DataLayout> d;
+}
+
+RWStructuredBuffer<int> outputBuffer;
+
+[shader("compute")]
+[numthreads(4, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    uint idx = dispatchThreadID.x & 3;
+
+    // Element indexing through the sized array field: matrix i holds i+1, so
+    // the first component of column 0 is idx + 1.
+    float4x4 m = d.mats[idx];
+    outputBuffer[dispatchThreadID.x] = int(m[0][0]);
+    // CHECK: 1
+    // CHECK: 2
+    // CHECK: 3
+    // CHECK: 4
+
+    // Whole-object stepping: d + 1 advances by sizeof(Data) = 256 bytes, and
+    // dereferencing the stepped pointer reads the second Data (first matrix
+    // holds 5.0). Guarded to a single invocation to avoid overlapping writes.
+    if (dispatchThreadID.x == 0)
+    {
+        outputBuffer[4] = int(reinterpret<uint64_t>(d+1)-reinterpret<uint64_t>(d)) == 256;
+        // CHECK: 1
+        Data next = *(d + 1);
+        float4x4 m2 = next.mats[0];
+        outputBuffer[5] = int(m2[0][0]) == 5;
+        // CHECK: 1
+    }
+}

--- a/tests/spirv/type-layout-memoization.slang
+++ b/tests/spirv/type-layout-memoization.slang
@@ -65,10 +65,10 @@ RWStructuredBuffer<float> outputBuffer;
 // CHECK-DAG: %[[PHYSICAL_140]] = OpTypePointer PhysicalStorageBuffer %[[V2]]
 // CHECK-DAG: %[[PHYSICAL_430]] = OpTypePointer PhysicalStorageBuffer %[[V2]]
 
-// OpTypePointer to a sized array uses the whole array object stride, not the
-// array element stride.
-// CHECK-DAG: OpDecorate %[[PHYSICAL_ARRAY_140:_ptr_PhysicalStorageBuffer__arr_v2float[A-Za-z0-9_]*]] ArrayStride 32
-// CHECK-DAG: OpDecorate %[[PHYSICAL_ARRAY_430:_ptr_PhysicalStorageBuffer__arr_v2float[A-Za-z0-9_]*]] ArrayStride 16
+// OpTypePointer to a sized array carries the array element stride, matching
+// the ArrayStride of the pointee array type.
+// CHECK-DAG: OpDecorate %[[PHYSICAL_ARRAY_140:_ptr_PhysicalStorageBuffer__arr_v2float[A-Za-z0-9_]*]] ArrayStride 16
+// CHECK-DAG: OpDecorate %[[PHYSICAL_ARRAY_430:_ptr_PhysicalStorageBuffer__arr_v2float[A-Za-z0-9_]*]] ArrayStride 8
 // CHECK-DAG: %[[PHYSICAL_ARRAY_140]] = OpTypePointer PhysicalStorageBuffer %[[ARRAY_140]]
 // CHECK-DAG: %[[PHYSICAL_ARRAY_430]] = OpTypePointer PhysicalStorageBuffer %[[ARRAY_430]]
 


### PR DESCRIPTION
### Motivation

When I was working on a personal project a few months ago, I tried to dynamically index a fix-sized array via a `Ptr<T>` when something went wrong, causing glitches to my CSM shadow. When I changed the indexing approach into a switch enumeration this problem was fixed, and I noticed that the problem might be related to dynamic indexing.

Then I went through the emitted `.spv`, finding that every `PhysicalStorageBuffer` pointer type has a `ArrayStride` decoration, and for pointers to fix-sized arrays, the value of it was the size of the entire array (e.g. 256 for float4x4[4]) instead of the size of the element (64 for float4x4).

This might be incorrect because `ArrayStride` is defined as the distance between two elements, not the size of the whole array. When a driver expands the access chain of a dynamic index, some drivers take the stride from the base pointer type instead of the array type. My _previous_ driver was one of them, so it computed idx * 256 instead of idx * 64, and every cascade except the first one was reading wrong memory. That is also why the switch version worked, constant indices get folded by the compiler using the array type stride, so they never go through this dynamic path.

I also checked the spec to be sure. The decoration table says the `ArrayStride` on a pointer type means the stride of the array that the element resides in, and for `OpAccessChain` the result pointer must match the stride of the array type. So 256 on that pointer type is not right under any interpretation.

> ArrayStride: Apply to an array type to specify the stride, in bytes, of the array's elements. Can also apply to a pointer type to an array element. Array Stride is an unsigned 32-bit integer specifying the stride of the array that the element resides in. Must not be applied to any other type. (https://github.com/KhronosGroup/SPIRV-Docs/blob/8c2f1d34511602b11ed09309a2170f2bfa020f5b/specs/binary.adoc?plain=1#L1143)

Mesa ignores the pointer decoration, and glslang does not even emit it, so the module passed spirv-val and ran fine on some machines but broke on mine.

### Proposed solution

Make pointers to fixed size arrays go through the same element stride path as runtime arrays in `getPointerArrayStrideValue`. The whole object stride (256) is still emitted on the `Array<T, N>` wrapper pointer, which is the one used by `OpPtrAccessChain` for `p[i]` and `p + 1` style pointer arithmetic. That behavior is unchanged, I verified it with a small shader exercising pointer arithmetic.

`OpPtrAccessChain` is the one place where the base pointer's `ArrayStride` actually gets consumed, and that is exactly why 256 still belongs on the wrapper pointer. For an array of arrays, stepping the base pointer moves over whole array objects, and per the spec the element address is calculated using the base type's `ArrayStride`:

> For objects in [storage classes](https://github.com/KhronosGroup/SPIRV-Docs/blob/8c2f1d34511602b11ed09309a2170f2bfa020f5b/specs/binary.adoc#L6128) requiring [explicit layout](https://github.com/KhronosGroup/SPIRV-Docs/blob/8c2f1d34511602b11ed09309a2170f2bfa020f5b/specs/binary.adoc#L192), the element's address or location is calculated using a stride, which will be the Base-type's Array Stride if the Base type is decorated with ArrayStride. (https://github.com/KhronosGroup/SPIRV-Docs/blob/8c2f1d34511602b11ed09309a2170f2bfa020f5b/specs/binary.adoc?plain=1#L6141)

The raw array pointer never appears as the base of `OpPtrAccessChain` in our emission, it only ever feeds an element indexing `OpAccessChain`, so its decoration is only ever read by drivers expanding that access chain, where the element stride is the correct value.

Also updated the test that was codifying the old behavior.

### Change summary

- `source/slang/slang-emit-spirv.cpp`: `getPointerArrayStrideValue` now returns the element stride for `IRArrayType` pointees instead of the total size of the array.
- `tests/spirv/type-layout-memoization.slang`: the test was asserting the old behavior. Its comment literally said the pointer "uses the whole array object stride, not the array element stride". Updated it to expect the element stride and fixed the comment.

### Verification

- spirv-val passes. It passed before too, which is part of why this bug was hard to find.
- I ran a GPU repro on RADV with dynamic index, switch and constant index variants. All of them are correct before and after the fix, because mesa never reads the pointer decoration. Expected, but good to confirm.
- Ran `tests/spirv`, `tests/bugs`, `tests/compute`, `tests/language-feature/pointer`, no new failures. On my machine the only failures are pre existing environment issues with the test framework on this driver, missing some features, they fail without my change as well.
- Formatting clean.

### Process report

`getPointerArrayStrideValue` has two paths. Pointers to unsized arrays correctly return the element stride. Everything else falls through to `getSizeAndAlignment` on the pointee, which gives the whole object size for sized arrays and structs. That is correct for the `Array<T, N>` wrapper pointer, because `OpPtrAccessChain` steps whole array objects. But it is wrong for the internal pointer to the array data member, which only ever serves as the base of an element indexing `OpAccessChain`. The fix gives sized arrays the same treatment as unsized arrays, and leaves struct pointers alone.
