### PR TITLE
agentic tests: pin only what the anchored claim depends on

### DIFF
--- a/docs/generated/tests/_meta/prompts/_claims.md
+++ b/docs/generated/tests/_meta/prompts/_claims.md
@@ -178,8 +178,13 @@ disciplined way to read an authoritative source for the variants it
 
 5. **`CHECK` tightness.** Pin the token that *identifies the cell* — the
    specific op (`OpAtomicAnd`), decoration (`ArrayStride 2`), or layout
-   token — tightly, and leave incidental names / IDs / registers wild
-   (`%{{[0-9]+}}`, `a_{{[0-9]+}}`). A cell whose distinguishing token you
+   token — tightly, and leave everything the claim does not rest on wild:
+   names / IDs / registers (`%{{[0-9]+}}`, `a_{{[0-9]+}}`), and equally
+   the declaration specifiers and qualifiers around the token under test
+   (`__device__`, `__noinline__`, `inline`, `static`). Those are stable
+   rather than volatile, so they read as safe to pin, but they are not
+   what the claim is about — see [`_common.md`](_common.md) § FileCheck /
+   CHECK pattern hygiene, rule 8. A cell whose distinguishing token you
    cannot name is a cell you have not differentiated — fold it back into
    the collapse step above.
 

--- a/docs/generated/tests/_meta/prompts/_common.md
+++ b/docs/generated/tests/_meta/prompts/_common.md
@@ -635,10 +635,39 @@ match: ...`, `see declaration of ...`). Rules:
      **not** omit it when unannotated diagnostics remain — exhaustive mode
      then fails.
 
+8. **Pin only what the claim depends on.** Rules 1–7 ask whether a token
+   is _volatile_. This one asks whether it is _relevant_. A token can be
+   perfectly stable and still not belong in the CHECK, and pinning it
+   makes the test fail on unrelated compiler changes that leave the claim
+   true. Before pinning a token, ask: **if this token changed, would the
+   anchored claim be false?** If no, wildcard it or leave it out.
+
+   The recurring offenders are declaration specifiers and qualifiers
+   sitting next to the thing under test — `__device__`, `__global__`,
+   `__noinline__`, `inline`, `static`, `precise` — and decorations the
+   claim never mentions.
+
+   For a claim that `in` parameters are passed **by value**, the CUDA
+   signature line is about the parameter list, not the specifiers:
+
+   - ✅ `// CUDA: void readImplicit_{{[0-9]+}}(int val_{{[0-9]+}})`
+   - ❌ `// CUDA: __device__ void readImplicit_{{[0-9]+}}(int val_{{[0-9]+}})`
+
+   The second broke when `[noinline]` started emitting `__noinline__`
+   between `__device__` and `void`. Every parameter was still passed by
+   value, so the claim was untouched and only the scaffolding moved.
+
+   This is not licence to loosen the token that _carries_ the claim. In
+   that same test the `(int val_...)` shape — no `*`, no `&` — **is** the
+   assertion and must stay tight. Loosen the scaffolding, never the
+   subject. (Rule 6 forbids weakening a CHECK to force green; that is
+   about the subject. This rule is about everything around it.)
+
 **Bottom line:** keep patterns loose (`{{...}}`, `-DAG`, error codes,
-opcodes) and structural. Every time you are tempted to write an exact id,
-name, ordering, or full message string, ask "will codegen or the harness
-render this differently?" — if yes, loosen it.
+opcodes) and structural. Ask two questions of every token you are tempted
+to pin: "will codegen or the harness render this differently?" (rules 1–7)
+and "does the anchored claim actually depend on it?" (rule 8). Loosen it
+if the answer is yes to the first or no to the second.
 
 If a claim is genuinely unobservable through any `slang-test`
 directive even with full runner access (e.g., the claim is about a

--- a/docs/generated/tests/_meta/prompts/_review.md
+++ b/docs/generated/tests/_meta/prompts/_review.md
@@ -65,6 +65,11 @@ For each test in the bundle:
      (callees emit before entry points) where `CHECK-DAG` was meant;
    - an optimization-dependent assertion (inlined/folded away) without
      `-O1` on the directive (slang-test defaults to `-O0`);
+   - a pinned token the anchored claim does not depend on — typically a
+     declaration specifier or qualifier next to the subject (`__device__`,
+     `__noinline__`, `inline`, `static`) or a decoration the claim never
+     mentions. Ask of each pinned token: if it changed, would the claim be
+     false? If no, it should be wild or absent (rule 8);
    - a feature asserted on a target that does not support it;
    - a `DIAGNOSTIC_TEST` with an invented message string, a mis-aligned
      caret, or a wrong `non-exhaustive` (present when all diagnostics are

--- a/docs/generated/tests/conformance/basics-memory-model-special-topics/in-default-direction-glsl-emission.slang
+++ b/docs/generated/tests/conformance/basics-memory-model-special-topics/in-default-direction-glsl-emission.slang
@@ -53,11 +53,11 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
 // MTL: void readExplicit_{{[0-9]+}}(int val_{{[0-9]+}}
 // MTL-NOT: int thread*
 
-// CUDA: __device__ void readImplicit_{{[0-9]+}}(int val_{{[0-9]+}})
-// CUDA: __device__ void readExplicit_{{[0-9]+}}(int val_{{[0-9]+}})
+// CUDA: void readImplicit_{{[0-9]+}}(int val_{{[0-9]+}})
+// CUDA: void readExplicit_{{[0-9]+}}(int val_{{[0-9]+}})
 
-// CPP: static void readImplicit_{{[0-9]+}}(int32_t val_{{[0-9]+}}
-// CPP: static void readExplicit_{{[0-9]+}}(int32_t val_{{[0-9]+}}
+// CPP: void readImplicit_{{[0-9]+}}(int32_t val_{{[0-9]+}}
+// CPP: void readExplicit_{{[0-9]+}}(int32_t val_{{[0-9]+}}
 
 // WGSL: fn readImplicit_{{[0-9]+}}( val_{{[0-9]+}} : i32)
 // WGSL: fn readExplicit_{{[0-9]+}}( val_{{[0-9]+}} : i32)

--- a/docs/generated/tests/conformance/basics-memory-model-special-topics/in-parameter-multiple-reads-glsl-emission.slang
+++ b/docs/generated/tests/conformance/basics-memory-model-special-topics/in-parameter-multiple-reads-glsl-emission.slang
@@ -45,10 +45,10 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
 // MTL: void sumOfReads_{{[0-9]+}}(int val_{{[0-9]+}}
 // MTL: val_{{[0-9]+}} + val_{{[0-9]+}} + val_{{[0-9]+}}
 
-// CUDA: __device__ void sumOfReads_{{[0-9]+}}(int val_{{[0-9]+}})
+// CUDA: void sumOfReads_{{[0-9]+}}(int val_{{[0-9]+}})
 // CUDA: val_{{[0-9]+}} + val_{{[0-9]+}} + val_{{[0-9]+}}
 
-// CPP: static void sumOfReads_{{[0-9]+}}(int32_t val_{{[0-9]+}}
+// CPP: void sumOfReads_{{[0-9]+}}(int32_t val_{{[0-9]+}}
 // CPP: val_{{[0-9]+}} + val_{{[0-9]+}} + val_{{[0-9]+}}
 
 // WGSL: fn sumOfReads_{{[0-9]+}}( val_{{[0-9]+}} : i32)

--- a/docs/generated/tests/conformance/basics-memory-model-special-topics/inout-parameter-glsl-emission.slang
+++ b/docs/generated/tests/conformance/basics-memory-model-special-topics/inout-parameter-glsl-emission.slang
@@ -47,10 +47,10 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
 // MTL: void multiReadWrite_{{[0-9]+}}(int thread* val_{{[0-9]+}})
 // MTL: *val_{{[0-9]+}} =
 
-// CUDA: __device__ void multiReadWrite_{{[0-9]+}}(int {{.*}}val_{{[0-9]+}})
+// CUDA: void multiReadWrite_{{[0-9]+}}(int {{.*}}val_{{[0-9]+}})
 // CUDA: *val_{{[0-9]+}} =
 
-// CPP: static void multiReadWrite_{{[0-9]+}}(int32_t {{.*}}val_{{[0-9]+}}
+// CPP: void multiReadWrite_{{[0-9]+}}(int32_t {{.*}}val_{{[0-9]+}}
 // CPP: *val_{{[0-9]+}} =
 
 // WGSL: fn multiReadWrite_{{[0-9]+}}( val_{{[0-9]+}} : ptr<function, i32>)

--- a/docs/generated/tests/conformance/basics-memory-model-special-topics/out-parameter-glsl-emission.slang
+++ b/docs/generated/tests/conformance/basics-memory-model-special-topics/out-parameter-glsl-emission.slang
@@ -44,10 +44,10 @@ void computeMain(uint3 tid : SV_DispatchThreadID)
 // MTL: void writeOut_{{[0-9]+}}(int thread* result_{{[0-9]+}},
 // MTL: *result_{{[0-9]+}} =
 
-// CUDA: __device__ void writeOut_{{[0-9]+}}(int {{.*}}result_{{[0-9]+}},
+// CUDA: void writeOut_{{[0-9]+}}(int {{.*}}result_{{[0-9]+}},
 // CUDA: *result_{{[0-9]+}} =
 
-// CPP: static void writeOut_{{[0-9]+}}(int32_t {{.*}}result_{{[0-9]+}},
+// CPP: void writeOut_{{[0-9]+}}(int32_t {{.*}}result_{{[0-9]+}},
 // CPP: *result_{{[0-9]+}} =
 
 // WGSL: fn writeOut_{{[0-9]+}}( result_{{[0-9]+}} : ptr<function, i32>


### PR DESCRIPTION
## Motivation

The agentic nightly has been red since 2026-08-22 —
[three](https://github.com/shader-slang/slang/actions/runs/32551102125)
[nights](https://github.com/shader-slang/slang/actions/runs/32617386685)
[running](https://github.com/shader-slang/slang/actions/runs/32689472527) — on four
tests in `conformance/basics-memory-model-special-topics`:

```
// CUDA: __device__ void readImplicit_{{[0-9]+}}(int val_{{[0-9]+}})
                                                    ^ expected string not found

actual: __device__ __noinline__ void readImplicit_0(int val_0)
```

#12419 started emitting `__noinline__` for CUDA device functions, and the CHECK
allowed nothing between `__device__` and `void`.

**The compiler is right and the tests were wrong.** #12419 is gated on
`inst->findDecoration<IRNoInlineDecoration>()` and excludes kernels, and each of
these four tests marks its own functions `[noinline]` in its source — CUDA emit had
simply been dropping the request. More importantly, these bundles are anchored to a
claim about **parameter direction**: implicit and explicit `in` parameters are
emitted as plain value parameters. Whether the function is inlinable cannot make
that claim true or false, so the CHECK was asserting something outside its claim.

This is the **second failure of this shape in four days** — the `[public]` CHECK
removed in #12679 was the first, and also asserted a token its doc anchor never
mentioned. Two instances of one pattern means the fix belongs in the generator, not
just in the bundle.

## Proposed solution

`_common.md` § *FileCheck / CHECK pattern hygiene* had seven rules. Every one tests
whether a token is **volatile** — generated ids, mangled names, escaping, emission
order — and the section closes with:

> ask "will codegen or the harness render this differently?" — if yes, loosen it.

For `__device__` the answer is *no*: it is perfectly stable. So the existing
guidance actively endorsed pinning it. Nothing asked whether the token was
**relevant**.

**Rule 8** adds that orthogonal question:

> if this token changed, would the anchored claim be false? If no, wildcard it or
> leave it out.

It names the offender class (declaration specifiers and qualifiers next to the
subject; decorations the claim never mentions), carries this failure as its worked
example, and draws an explicit line against rule 6 — *loosen the scaffolding, never
the subject* — so it cannot be read as licence to weaken the assertion that carries
the claim.

## Change summary

| File | Change |
| --- | --- |
| `_meta/prompts/_common.md` | New rule 8 in the FileCheck hygiene section; "Bottom line" now asks both the volatility and the relevance question. |
| `_meta/prompts/_claims.md` | Rule 5 illustrated "incidental" with names/IDs/registers only, which is why specifiers read as safe to pin; now covers them, with the reason and a cross-ref to rule 8. |
| `_meta/prompts/_review.md` | §4b gains the mirror check, so the review pass catches an over-pinned token instead of a nightly. |
| `conformance/basics-memory-model-special-topics/*-glsl-emission.slang` (4 files) | Regenerated under rule 8: 10 CHECK lines lose a specifier — 5 CUDA `__device__`, 5 C++ `static`. |

## Concepts and vocabulary

- **Volatile vs. incidental token** — the distinction rule 8 turns on. A *volatile*
  token is rendered differently by codegen or the harness (`%29`, `_S3`). An
  *incidental* one is stable but not what the claim is about (`__device__`,
  `static`). Rules 1–7 catch the first class; only rule 8 catches the second.
- **Anchored claim** — the doc assertion named by a test's `//META: doc_ref`. It is
  what decides which token is the subject and which is scaffolding.

## Process report

**Why the bundle change is a regeneration, not a patch.** The four failing tests are
generated bundles, and `_meta/regenerate.md`'s hand-edit policy directs fixes to the
prompt rather than the `.slang`. This PR does that first, then applies the resulting
rule to the bundle — so the bundle edit is the rule's output, not a workaround, and
a future regeneration should reproduce it.

**Why ten lines and not four.** Only the five CUDA `__device__` pins fail today. The
five C++ `static` pins are the same defect and would break the first time C++ emit
gains a specifier. Fixing only what is red would leave the rule half-applied in the
bundle that motivated it.

**What deliberately stays tight.** The parameter shapes. `(int {{.*}}val_{{[0-9]+}})`
still distinguishes `int * val_0` from `int val_0`, which is the claim under test.
The revert run below confirms this is still asserted: the failing output it
reproduces reads `__device__ __noinline__ void multiReadWrite_0(int * val_0)` — the
`int *` was never in question, only the specifiers ahead of it.

**Verification, with a control.** I built Release at this branch's base (which
contains #12419) and confirmed it reproduces the CI condition directly —
`__device__ __noinline__ void readImplicit_0(int val_0)`. Then ran the bundle both
ways through `_meta/regenerate.py verify`:

| bundle state | result |
| --- | --- |
| master CHECKs (pinning `__device__`) | **85/89, 4 FAILED** — the exact nightly failures |
| regenerated under rule 8 | **89/89, 0 FAILED** |

The revert reproduces the four failures precisely, so the pass is attributable to
the CHECK change rather than to anything else in the build. `lint` reports 0 errors;
its 305 warnings are pre-existing catalog-digest drift in unrelated bundles.

**Scope limits.** The prompt change governs *future* generation only — the rest of
the suite keeps its existing CHECKs until regenerated, so this does not claim to
have swept the suite. Sizing that exposure is a grep for specifier tokens in CHECK
lines, deliberately left out of this diff.
