### PR TITLE
Fix pending-approvals title fallback and drop the STALLED indicator

### DIFF
--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -1220,9 +1220,11 @@ buildCharts(24);
 def render_pending_approvals(data):
     """Render runs paused on a deployment approval, oldest first.
 
-    Age is the number that matters. A run waiting a couple of minutes is the
-    approval bot about to pick it up; one waiting half an hour means nobody is
-    coming, and the job will eventually time out and report as a test failure.
+    Most of these gate the Falcor bridge, which is approved by hand rather
+    than on a bot SLA, so a nonempty queue is the normal state, not an
+    incident -- it just means nobody has vetted the run yet. The indicator
+    only distinguishes "some runs are waiting" (informational) from "the
+    fetch itself failed" (a real problem); it does not escalate on wait time.
     """
     if not data:
         return "<p>Pending approvals unavailable.</p>"
@@ -1237,11 +1239,8 @@ def render_pending_approvals(data):
     elif not pending:
         fg, bg, label = "#198754", "#d1e7dd", "OK"
         summary = "Nothing waiting for approval"
-    elif oldest >= 30:
-        fg, bg, label = "#dc3545", "#f8d7da", "STALLED"
-        summary = f"{len(pending)} waiting, oldest {oldest} min"
     else:
-        fg, bg, label = "#fd7e14", "#fff3cd", "WAITING"
+        fg, bg, label = "#0d6efd", "#cfe2ff", "WAITING"
         summary = f"{len(pending)} waiting, oldest {oldest} min"
 
     html = f"""
@@ -1484,11 +1483,11 @@ PENDING_APPROVALS_JS = """
       var fg, bg, label, summary;
       if (!pending.length) {
         fg = "#198754"; bg = "#d1e7dd"; label = "OK"; summary = "Nothing waiting for approval";
-      } else if (oldest >= 30) {
-        fg = "#dc3545"; bg = "#f8d7da"; label = "STALLED";
-        summary = pending.length + " waiting, oldest " + oldest + " min";
       } else {
-        fg = "#fd7e14"; bg = "#fff3cd"; label = "WAITING";
+        // Most of these gate the Falcor bridge, which is approved by hand
+        // rather than on a bot SLA, so a nonempty queue is normal, not an
+        // incident -- this stays informational regardless of wait time.
+        fg = "#0d6efd"; bg = "#cfe2ff"; label = "WAITING";
         summary = pending.length + " waiting, oldest " + oldest + " min";
       }
 

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -330,6 +330,14 @@ def fetch_pending_approvals(repo):
 
     now = datetime.now(timezone.utc)
     pending = []
+    # Several waiting runs can share one PR (a workflow_dispatch rerun plus a
+    # merge_group run of the same PR, say), so cache title lookups by
+    # pr_number instead of re-fetching per run. Cap the number of distinct
+    # PRs looked up, matching the JS path's MAX_TITLE_LOOKUPS, so a burst of
+    # unresolved titles cannot fire more requests than the retry budget in
+    # gh_api's _run_gh_command can absorb without stalling the report.
+    MAX_TITLE_LOOKUPS = 20
+    title_cache = {}
     for run in runs:
         created = run.get("created_at") or ""
         try:
@@ -361,7 +369,9 @@ def fetch_pending_approvals(repo):
             # carries no PR-title context at trigger time, so GitHub falls
             # back to the workflow's `name:` field (e.g. "CI") even though
             # `pr_number` above proves the run is still tied to that PR.
-            title = get_pr_title(repo, pr_number) or title
+            if pr_number not in title_cache and len(title_cache) < MAX_TITLE_LOOKUPS:
+                title_cache[pr_number] = get_pr_title(repo, pr_number)
+            title = title_cache.get(pr_number) or title
         pending.append(
             {
                 "run_id": run.get("id"),

--- a/extras/ci/analytics/ci_health.py
+++ b/extras/ci/analytics/ci_health.py
@@ -319,7 +319,7 @@ def fetch_pending_approvals(repo):
     is a PR that sits until its job timeout and then reports as a test failure.
     """
     sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
-    from gh_api import find_pr_number_by_head, gh_api_list
+    from gh_api import find_pr_number_by_head, get_pr_title, gh_api_list, parse_merge_queue_pr_number
 
     runs, err = gh_api_list(
         f"repos/{repo}/actions/runs?status=waiting&per_page=100",
@@ -338,22 +338,38 @@ def fetch_pending_approvals(repo):
             )
         except ValueError:
             waited_min = 0
+        event = run.get("event", "")
+        branch = run.get("head_branch", "")
         prs = run.get("pull_requests") or []
         pr_number = prs[0].get("number") if prs else None
-        if pr_number is None and run.get("event") == "pull_request":
+        if pr_number is None and event == "pull_request":
             # A run triggered from a fork branch has an empty `pull_requests`
             # field (GitHub only populates it for same-repo branches), so the
             # PR has to be looked up by head owner/branch instead.
             head_owner = ((run.get("head_repository") or {}).get("owner") or {}).get("login")
-            pr_number = find_pr_number_by_head(repo, head_owner, run.get("head_branch"))
+            pr_number = find_pr_number_by_head(repo, head_owner, branch)
+        elif pr_number is None and event == "merge_group":
+            # A merge-queue run's `pull_requests` field is never populated by
+            # GitHub, but the branch name itself encodes the PR number.
+            merge_pr = parse_merge_queue_pr_number(branch)
+            pr_number = int(merge_pr) if merge_pr else None
+        title = run.get("display_title", "")
+        if pr_number and title == run.get("name", ""):
+            # `display_title` is only the PR subject line for the run
+            # triggered directly by the `pull_request` event. A
+            # `workflow_dispatch` rerun or a `merge_group` run of the same PR
+            # carries no PR-title context at trigger time, so GitHub falls
+            # back to the workflow's `name:` field (e.g. "CI") even though
+            # `pr_number` above proves the run is still tied to that PR.
+            title = get_pr_title(repo, pr_number) or title
         pending.append(
             {
                 "run_id": run.get("id"),
                 "url": run.get("html_url", ""),
                 "actor": (run.get("actor") or {}).get("login", "?"),
-                "event": run.get("event", ""),
-                "branch": run.get("head_branch", ""),
-                "title": run.get("display_title", ""),
+                "event": event,
+                "branch": branch,
+                "title": title,
                 "waited_min": waited_min,
                 "pr_number": pr_number,
             }
@@ -1376,6 +1392,14 @@ PENDING_APPROVALS_JS = """
       var pending = runs.map(function (r) {
         var waited = Math.floor((now - new Date(r.created_at).getTime()) / 60000);
         var prs = r.pull_requests || [];
+        var prNumber = prs.length ? prs[0].number : null;
+        if (prNumber === null && r.event === "merge_group") {
+          // A merge-queue run's `pull_requests` field is never populated by
+          // GitHub, but the branch name encodes the PR number:
+          // gh-readonly-queue/master/pr-NNNN-SHA.
+          var m = /^gh-readonly-queue\/[^/]+\/pr-(\d+)-/.exec(r.head_branch || "");
+          if (m) prNumber = parseInt(m[1], 10);
+        }
         return {
           run_id: r.id,
           url: r.html_url,
@@ -1383,9 +1407,10 @@ PENDING_APPROVALS_JS = """
           event: r.event || "",
           branch: r.head_branch || "",
           head_owner: ((r.head_repository || {}).owner || {}).login || "",
+          name: r.name || "",
           title: r.display_title || String(r.id),
           waited: waited,
-          pr_number: prs.length ? prs[0].number : null,
+          pr_number: prNumber,
         };
       }).sort(function (a, b) { return b.waited - a.waited; });
 
@@ -1423,7 +1448,36 @@ PENDING_APPROVALS_JS = """
           .catch(function () {});
       });
 
-      return Promise.all(lookups).then(function () { return pending; });
+      return Promise.all(lookups).then(function () {
+        // `display_title` is only the PR subject line for the run
+        // triggered directly by the `pull_request` event. A
+        // `workflow_dispatch` rerun or a `merge_group` run of the same PR
+        // carries no PR-title context at trigger time, so GitHub falls
+        // back to the workflow's `name:` field (e.g. "CI") even though
+        // `pr_number` above proves the run is still tied to that PR. Look
+        // the real title up from the PR itself, deduped and capped the
+        // same way as the head-branch lookups above.
+        var MAX_TITLE_LOOKUPS = 20;
+        var seenPrs = {};
+        var titleTargets = [];
+        pending.forEach(function (p) {
+          if (!p.pr_number || p.title !== p.name || seenPrs[p.pr_number]) return;
+          seenPrs[p.pr_number] = true;
+          if (titleTargets.length < MAX_TITLE_LOOKUPS) titleTargets.push(p.pr_number);
+        });
+        var titleLookups = titleTargets.map(function (prNumber) {
+          return fetch("https://api.github.com/repos/" + repo + "/pulls/" + prNumber)
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (pr) {
+              if (!pr || !pr.title) return;
+              pending.forEach(function (p) {
+                if (p.pr_number === prNumber && p.title === p.name) p.title = pr.title;
+              });
+            })
+            .catch(function () {});
+        });
+        return Promise.all(titleLookups).then(function () { return pending; });
+      });
     })
     .then(function (pending) {
       var oldest = pending.length ? pending[0].waited : 0;

--- a/extras/ci/gh_api.py
+++ b/extras/ci/gh_api.py
@@ -147,6 +147,25 @@ def find_pr_number_by_head(repo, head_owner, head_branch):
     return data[0].get("number")
 
 
+def get_pr_title(repo, pr_number):
+    """Look up a PR's title by number. Returns the title, or None on error.
+
+    GitHub only sets a workflow run's `display_title` to the PR's subject
+    line for the run triggered directly by the `pull_request` event. A
+    later `workflow_dispatch` rerun or a `merge_group` run of the same PR
+    carries no PR-title context at trigger time, so `display_title` falls
+    back to the workflow's `name:` field (e.g. "CI") even though the run is
+    still tied to that PR. Callers that already resolved `pr_number` for
+    such a run can use this to recover the real title.
+    """
+    if not pr_number:
+        return None
+    data, err = gh_api(f"repos/{repo}/pulls/{pr_number}")
+    if err or not data:
+        return None
+    return data.get("title")
+
+
 def coerce_jobs_data(data):
     """Normalize various input formats into a flat jobs list."""
     if isinstance(data, dict):


### PR DESCRIPTION
## Motivation

In the CI analytics page's pending-approvals list, some run links showed the real PR subject line while others showed only the workflow's own name, "CI". Example on the same branch/PR:

- `pull_request`-triggered run: `display_title` = "Fix #12711: skip void fields in byte-address struct load/store"
- `workflow_dispatch` rerun of the same PR: `display_title` = "CI"

GitHub's `display_title` heuristic only carries the PR subject line for the run triggered directly by the `pull_request` event. A later `workflow_dispatch` rerun, or a `merge_group` run, of that same PR has no PR-title context at trigger time, so GitHub falls back to the workflow's `name:` field. The run is still genuinely tied to the PR (its resolved `pr_number` proves this), but the title looked disconnected from any PR.

Separately, the section's indicator bar escalated to a red "STALLED" state once the oldest pending run passed 30 minutes waiting. Falcor-bridge approvals are vetted by hand rather than on a bot SLA, so a nonempty queue is the expected steady state, not an incident -- the red escalation was a false alarm on normal wait times.

## Proposed solution

1. Where a run's `pr_number` is resolved but its `title` still equals the workflow's own `name` (i.e. the `display_title` fallback fired), look up the real title from the PR itself via `GET /pulls/{pr_number}`. Applied to both the Python collector (`fetch_pending_approvals`) and the client-side JS renderer (`PENDING_APPROVALS_JS`), each deduped/capped the same way the existing fork-branch PR-number lookup already is. Also added `merge_group` PR-number resolution via the merge-queue branch name pattern (`gh-readonly-queue/.../pr-NNNN-*`), reusing the existing `parse_merge_queue_pr_number` parser on the Python side that this function wasn't yet using.
2. Collapsed the two nonempty indicator states (orange "WAITING" under 30 min, red "STALLED" at or over 30 min) into a single neutral, informational "WAITING" tier that no longer escalates on wait time.

## Change summary

| File | Change |
|---|---|
| `extras/ci/gh_api.py` | Added `get_pr_title(repo, pr_number)` helper |
| `extras/ci/analytics/ci_health.py` | `fetch_pending_approvals`: resolve real PR title when `display_title` fell back to the workflow name; resolve `merge_group` PR numbers via branch name. `PENDING_APPROVALS_JS`: mirrored both fixes client-side. `render_pending_approvals` and the JS renderer: dropped the red "STALLED" tier, single "WAITING" tier regardless of wait time. |

## Concepts and vocabulary

- **`display_title`**: a field on a GitHub Actions workflow run object. For `pull_request`/`merge_group`-triggered runs GitHub resolves it to the PR's subject line; otherwise it falls back to the workflow's own `name:` (`"CI"` in this repo's `ci.yml`).
- **`pull_requests` field**: lists PRs associated with a run's head branch, but only for same-repo branches with an *open* PR -- empty for fork branches (handled by the existing `find_pr_number_by_head` lookup) and empty once the PR merges/closes (an existing, out-of-scope edge case; a stale rerun on an already-merged branch still shows "CI" since there's no principled way to recover a closed PR's title from a branch name).
- **Merge-queue branch name**: `gh-readonly-queue/<base>/pr-<NNNN>-<sha>` -- encodes the PR number for `merge_group` runs, which never get a `pull_requests` entry from GitHub.

## Process report

**Title fallback (item 1):** The run's `pr_number` was already being resolved correctly before this change (via `run.pull_requests` or the fork-branch lookup) -- the bug was purely in what got displayed as `title`, which passed `display_title` through unmodified regardless of whether it was a real PR title or the workflow-name fallback. This is a case where the *representation* consumed downstream (`title`) didn't match what was already known to be true (`pr_number` proves PR association) -- the producer (`display_title` from GitHub) simply doesn't carry a title for these events, so the fix fetches the title from the source of truth (the PR itself) rather than trying to reconstruct or guess it. The `merge_group` PR-number gap was a straightforward oversight: `parse_merge_queue_pr_number` already existed and was used elsewhere in this codebase, just not wired into this function.

**Indicator tier removal (item 2):** Not a code-correctness fix but a signal-fidelity one -- the 30-minute red escalation encoded an assumption (fast bot-driven approval) that doesn't hold for Falcor-bridge approvals, which require a human to look at each run. Escalating color/label on elapsed time alone produced a chronic false-positive "STALLED" state for expected behavior, which erodes the value of the indicator for the cases that are genuinely worth alarming on (the `partial`/fetch-failure state, still gray "PARTIAL"). Removing the time-based escalation, rather than just raising the threshold, follows directly from the underlying fact that there is no wait-time threshold that reliably distinguishes "normal, nobody's looked yet" from "actually stuck" when approval is manual and unscheduled.