### PR TITLE
Fix #12728: preserve front-end pointer literals during linking

### DIFF
--- a/source/slang/slang-ir-link.cpp
+++ b/source/slang/slang-ir-link.cpp
@@ -389,8 +389,13 @@ IRInst* IRSpecContext::maybeCloneValue(IRInst* originalValue)
     case kIROp_PtrLit:
         {
             IRConstant* c = (IRConstant*)originalValue;
-            SLANG_RELEASE_ASSERT(c->value.ptrVal == nullptr);
-            return builder->getNullPtrValue(cloneType(this, c->getFullType()));
+            // Non-null pointer literals are used by front-end-only decorations to retain an AST
+            // declaration for diagnostics. Linking stays within the same compiler session, so the
+            // declaration remains valid and must be preserved until the mandatory passes consume
+            // it. Front-end-only instructions are stripped before target legalization and emit.
+            return builder->getPtrValue(
+                cloneType(this, c->getFullType()),
+                c->value.ptrVal);
         }
         break;
 


### PR DESCRIPTION
Fixes #12728.

Non-null `IRPtrLit` values carry AST declaration pointers for front-end-only diagnostic
decorations. Linking happens within the same compiler session, so preserve those values while
cloning IR instead of asserting that every pointer literal is null. The existing front-end strip
still removes these declarations before target legalization and emission.

The blocking reproduction is the structural ray-tracing runtime pipeline being developed in draft
PR #12691: composing its explicit raygen, closest-hit, and miss components previously asserted
during Vulkan pipeline creation. That pipeline is used to validate this fix because the structural
entry synthesis that exposes the defect is still under review.
