### PR TITLE
Fix Metal pointer cast precedence

### DIFF
--- a/source/slang/slang-emit-metal.cpp
+++ b/source/slang/slang-emit-metal.cpp
@@ -870,11 +870,15 @@ bool MetalSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inO
             if (toIsPointer || fromIsPointer)
             {
                 // C-style cast for pointer conversions
+                auto outerPrec = inOuterPrec;
+                auto prec = getInfo(EmitOp::Prefix);
+                bool needClose = maybeEmitParens(outerPrec, prec);
                 m_writer->emit("(");
                 emitType(toType);
                 m_writer->emit(")(");
                 emitOperand(inst->getOperand(0), getInfo(EmitOp::General));
                 m_writer->emit(")");
+                maybeCloseParens(needClose);
             }
             else
             {

--- a/tests/metal/metal-pointer-bitcast.slang
+++ b/tests/metal/metal-pointer-bitcast.slang
@@ -13,11 +13,19 @@
 // The intermediate variable may be fully renamed (e.g. ptrValue -> _S1).
 // CHECK-DAG: (int device*)(
 
+// A folded pointer cast must be parenthesized before a postfix member access.
+// CHECK-DAG: ((Data_0 device*)({{.*}}))->value_0
+
 // Make sure as_type is NOT used for any pointer conversions
 // CHECK-NOT: as_type<{{.*}}device{{.*}}\*>
 // CHECK-NOT: as_type<{{.*}}\*>
 
 uniform int* inputPtr;
+
+struct Data
+{
+    uint value;
+}
 
 //TEST_INPUT: ubuffer(data=[0 0 0], stride=4):out,name=outputBuffer
 RWStructuredBuffer<uint> outputBuffer;
@@ -38,4 +46,6 @@ void computeMain(uint3 threadId : SV_DispatchThreadID)
     outputBuffer[0] = ptr2[0];
     outputBuffer[1] = uint(ptrValue & 0xFFFFFFFF);
     outputBuffer[2] = uint(ptr3[0]);
+    // Test 4: Pointer cast used directly as the base of a member access.
+    outputBuffer[3] = bit_cast<Data*>(inputPtr)->value;
 }


### PR DESCRIPTION
Fixes #12732.

Metal pointer bitcasts use C-style casts because `as_type` does not support pointer conversions. The Metal-specific emitter path did not account for the surrounding expression precedence, so a folded cast used by `->` produced invalid MSL.

This change applies the same prefix-expression parenthesization used by the generic C-like emitter and extends the existing Metal pointer-bitcast test with a postfix member access.
