### PR TITLE
render-test: resolve cooperative-matrix-2 sub-feature names to a real RHI feature

### DIFF
--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -17,40 +17,50 @@ namespace renderer_test
 {
 using namespace Slang;
 
-// Helper function to check if a feature name is valid
-static bool isValidFeatureName(
-    const UnownedStringSlice& featureName,
-    DiagnosticSink* sink,
-    SourceLoc loc)
+rhi::Feature getRenderFeatureFromName(const UnownedStringSlice& featureName)
 {
-    // WAR: Accept cooperative-matrix-2 sub-features until RHI backend supports them
-    // These features will be gracefully skipped at runtime if hardware doesn't support them
-    if (featureName.startsWith("cooperative-matrix-"))
+    // slang-rhi reports VK_NV_cooperative_matrix2 as one feature, but tests name the individual
+    // sub-features the extension provides. Resolve each of them to that single feature so a test
+    // gated on a sub-feature runs on hardware that supports the extension, rather than being
+    // skipped everywhere.
+    static const UnownedStringSlice kCooperativeMatrix2SubFeatures[] = {
+        UnownedStringSlice::fromLiteral("cooperative-matrix-block-loads"),
+        UnownedStringSlice::fromLiteral("cooperative-matrix-conversions"),
+        UnownedStringSlice::fromLiteral("cooperative-matrix-per-element-operations"),
+        UnownedStringSlice::fromLiteral("cooperative-matrix-reductions"),
+        UnownedStringSlice::fromLiteral("cooperative-matrix-tensor-addressing"),
+    };
+    for (const auto& subFeature : kCooperativeMatrix2SubFeatures)
     {
-        if (sink)
+        if (featureName == subFeature)
         {
-            sink->diagnoseRaw(
-                Severity::Warning,
-                "Using cooperative-matrix-2 feature that is not yet fully supported "
-                "in RHI backend. "
-                "Test will be skipped if hardware doesn't support it.");
+            return rhi::Feature::CooperativeMatrix2;
         }
-        return true;
     }
-#define SLANG_RHI_FEATURES_X(id, name) name,
-    static const char* kValidFeatureNames[] = {SLANG_RHI_FEATURES(SLANG_RHI_FEATURES_X)};
+
+#define SLANG_RHI_FEATURES_X(id, name) {UnownedStringSlice::fromLiteral(name), rhi::Feature::id},
+    struct FeatureNameMapEntry
+    {
+        UnownedStringSlice name;
+        rhi::Feature feature;
+    };
+    static const FeatureNameMapEntry kFeatureNameMap[] = {SLANG_RHI_FEATURES(SLANG_RHI_FEATURES_X)};
 #undef SLANG_RHI_FEATURES_X
 
-    static const int kFeatureCount = sizeof(kValidFeatureNames) / sizeof(kValidFeatureNames[0]);
-
-    for (int i = 0; i < kFeatureCount; i++)
+    for (const auto& entry : kFeatureNameMap)
     {
-        if (featureName == UnownedStringSlice(kValidFeatureNames[i]))
+        if (featureName == entry.name)
         {
-            return true;
+            return entry.feature;
         }
     }
-    return false;
+    return rhi::Feature::_Count;
+}
+
+/// Return true if `featureName` names a feature the runtime requirement check can evaluate.
+static bool isValidFeatureName(const UnownedStringSlice& featureName)
+{
+    return getRenderFeatureFromName(featureName) != rhi::Feature::_Count;
 }
 
 static rhi::DeviceType _toRenderType(Slang::RenderApiType apiType)
@@ -162,7 +172,7 @@ static rhi::DeviceType _toRenderType(Slang::RenderApiType apiType)
             for (const auto& value : values)
             {
                 // Validate that the feature name is recognized
-                if (!isValidFeatureName(value, &sink, featuresArg.loc))
+                if (!isValidFeatureName(value))
                 {
                     sink.diagnose(
                         featuresArg.loc,

--- a/tools/render-test/options.h
+++ b/tools/render-test/options.h
@@ -114,4 +114,15 @@ struct Options
         Options& outOptions);
 };
 
+/// Return the `rhi::Feature` a `-render-feature` name refers to, or `rhi::Feature::_Count` if the
+/// name is not recognized.
+///
+/// This is the single place that maps a test's feature name onto an RHI feature, so that option
+/// parsing (which rejects unknown names) and the runtime requirement check (which decides whether
+/// to skip a test) can never disagree. Besides the names generated from `SLANG_RHI_FEATURES`, it
+/// resolves the individual `VK_NV_cooperative_matrix2` sub-feature names used by tests -- slang-rhi
+/// exposes that extension only as the single `cooperative-matrix-2` feature, so each sub-feature
+/// name maps onto it.
+rhi::Feature getRenderFeatureFromName(const Slang::UnownedStringSlice& featureName);
+
 } // namespace renderer_test

--- a/tools/render-test/render-test-main.cpp
+++ b/tools/render-test/render-test-main.cpp
@@ -193,25 +193,6 @@ static void _outputProfileTime(uint64_t startTicks, uint64_t endTicks)
     out.print("profile-time=%g\n", time);
 }
 
-static rhi::Feature _getFeatureFromName(const UnownedStringSlice& featureName)
-{
-    struct FeatureNameMapEntry
-    {
-        const char* name;
-        rhi::Feature feature;
-    };
-
-#define SLANG_RHI_FEATURES_X(id, name) {name, rhi::Feature::id},
-    static const FeatureNameMapEntry kFeatureNameMap[] = {SLANG_RHI_FEATURES(SLANG_RHI_FEATURES_X)};
-#undef SLANG_RHI_FEATURES_X
-
-    for (auto& entry : kFeatureNameMap)
-        if (featureName == UnownedStringSlice(entry.name))
-            return entry.feature;
-
-    return rhi::Feature::_Count;
-}
-
 class ProgramVars;
 
 struct ShaderOutputPlan
@@ -1918,7 +1899,7 @@ static SlangResult _innerMain(
 
         List<rhi::Feature> requiredFeatureList;
         for (auto& name : options.renderFeatures)
-            requiredFeatureList.add(_getFeatureFromName(name.getUnownedSlice()));
+            requiredFeatureList.add(getRenderFeatureFromName(name.getUnownedSlice()));
 
         desc.requiredFeatures = requiredFeatureList.getBuffer();
         desc.requiredFeatureCount = (int)requiredFeatureList.getCount();


### PR DESCRIPTION
## 1. Motivation

Six test files gate themselves on cooperative-matrix-2 sub-features:

```
tests/cooperative-matrix/reduce.slang                    -render-feature cooperative-matrix-reductions
tests/cooperative-matrix/transpose.slang                 -render-feature cooperative-matrix-conversions
tests/cooperative-matrix/map-element-single.slang        -render-feature cooperative-matrix-per-element-operations
tests/cooperative-matrix/map-element-tuple.slang         -render-feature cooperative-matrix-per-element-operations
tests/cooperative-matrix/load-store-tensorview.slang     -render-feature cooperative-matrix-block-loads
tests/cooperative-matrix/load-store-tensorlayout.slang   -render-feature cooperative-matrix-tensor-addressing
```

**None of these 23 test invocations has ever executed, on any device.** Not on lavapipe, not on
NVIDIA hardware that implements `VK_NV_cooperative_matrix2`. They are reported as *ignored*, which
reads as "this machine can't run it" — so nothing has ever drawn attention to it.

The cause is two mappings that disagreed about what a feature name means.

Option parsing accepted these names through a deliberate work-around in
`tools/render-test/options.cpp`:

```cpp
// WAR: Accept cooperative-matrix-2 sub-features until RHI backend supports them
// These features will be gracefully skipped at runtime if hardware doesn't support them
if (featureName.startsWith("cooperative-matrix-"))
{
    ... warning ...
    return true;
}
```

The stated intent is the reasonable one: let the name through, and let the runtime decide. But the
runtime check used a *different* mapping, `_getFeatureFromName()` in `render-test-main.cpp`, built
only from the `SLANG_RHI_FEATURES` X-macro. None of these five names is in that list, so it
returned the sentinel `rhi::Feature::_Count`, which was then pushed onto `requiredFeatures`. And in
slang-rhi:

```cpp
bool Device::hasFeature(Feature feature)
{
    return size_t(feature) < size_t(Feature::_Count) ? m_featureSet[size_t(feature)] : false;
}
```

`_Count` is never `< _Count`, so `hasFeature()` returns **false unconditionally**, on every device.
render-test then returns `SLANG_E_NOT_AVAILABLE` and the test is ignored — always, everywhere.

The names were never valid: `grep`ping slang-rhi's entire git history for
`cooperative-matrix-reductions` and friends returns nothing. They correspond to the sub-features of
`VK_NV_cooperative_matrix2` (reductions, conversions, per-element ops, block loads, tensor
addressing), which slang-rhi exposes as the single feature `cooperative-matrix-2`.

## 2. Proposed solution

Give the mapping one owner.

`getRenderFeatureFromName()` becomes the single place that turns a `-render-feature` name into an
`rhi::Feature`, and both callers use it:

- option validation asks "does this resolve?" — `isValidFeatureName()` is now just
  `getRenderFeatureFromName(name) != _Count`;
- the runtime requirement check calls the same function.

They can no longer disagree, because there is nothing left to disagree about.

Within that one function, the five sub-feature names resolve to `Feature::CooperativeMatrix2`,
since that is the feature slang-rhi actually reports for the extension providing them. A test gated
on `cooperative-matrix-reductions` now runs on hardware implementing `VK_NV_cooperative_matrix2`
and is skipped elsewhere — which is what the work-around's comment said should happen.

Removing the prefix escape hatch also restores loud failure for typos: `cooperative-matrix-foo` is
rejected at option-parse time again, instead of being accepted and silently disabling the test.

## 3. Change summary

| File | What changed |
|---|---|
| `tools/render-test/options.h` | Declares `getRenderFeatureFromName()`, with a comment on why one shared resolver exists |
| `tools/render-test/options.cpp` | Implements it (sub-feature aliases + `SLANG_RHI_FEATURES` table); `isValidFeatureName()` reduced to a call to it; the `startsWith("cooperative-matrix-")` work-around removed |
| `tools/render-test/render-test-main.cpp` | Deletes the duplicate `_getFeatureFromName()`; the requirement check calls the shared resolver |

## 4. Concepts and vocabulary

- **`rhi::Feature::_Count`** — the terminal enumerator of slang-rhi's feature enum, used here as a
  "not recognized" sentinel. It is not a feature, and `hasFeature(_Count)` is false by construction.
- **`SLANG_RHI_FEATURES`** — the X-macro in `slang-rhi.h` pairing each `Feature` enumerator with its
  string name; both the old mappings were generated from it, which is why both were blind to any
  name outside it.
- **`VK_NV_cooperative_matrix2`** — the Vulkan extension providing the five sub-features named by
  these tests. slang-rhi surfaces it as one feature, `cooperative-matrix-2`.

## 5. Process report

**Is the input shape — an unrecognized feature name — valid, or should its producer be fixed?**
Both, and the split matters. A name like `cooperative-matrix-reductions` appearing in a test is a
*legitimate* thing for a test author to write: it names a real capability the test depends on. What
was not legitimate was resolving it to a sentinel and treating that as "device lacks support". So
the producer (the test files) is left untouched, and the consumer is fixed to resolve the name to
the feature that actually represents it. A name that resolves to nothing is genuinely
out-of-contract, and is now rejected loudly at parse time rather than silently degraded — matching
the project's "fail loudly on out-of-contract input" rule.

**Why not add the five sub-features to slang-rhi instead?** That is the better long-term shape and
is the real fix if per-sub-feature granularity is wanted: slang-rhi already reads
`cooperativeMatrix2Features` in `vk-device.cpp` and could expose each boolean. But slang-rhi is a
separate repository and submodule, so it cannot land in this PR, and until it does these tests
remain dead. Resolving to `cooperative-matrix-2` restores execution now and stays correct
afterwards: if slang-rhi later exposes the granular features, the alias entries are deleted and the
generated table picks the names up with no other change. It is deliberately a mapping in one place,
not logic sprinkled across two.

**Why `_Count` as the sentinel is kept.** The signature returns `_Count` for "unknown" rather than
adding a new error path, because that is what the existing `_getFeatureFromName()` already did and
what `hasFeature()` already tolerates. The change is that no caller now *stores* `_Count` into a
requirement list: parsing rejects such names before they reach it.

## 6. Verification

Mesa lavapipe 25.2.8 (implements neither `VK_KHR_cooperative_matrix` nor `VK_NV_cooperative_matrix2`),
Ubuntu 24.04, Release, clang-18.

| Case | Result |
|---|---|
| `-render-feature cooperative-matrix-reductions` | accepted; resolves to `CooperativeMatrix2`; test *ignored* on lavapipe — correct, the device lacks it |
| `-render-feature cooperative-matrix-nonexistent` | **`error 1006: invalid render feature name`** — previously accepted silently by the work-around |
| `-render-feature totally-bogus-feature` | `error 1006` (unchanged behaviour, confirms no regression) |
| `map-element-single.slang`, `reduce.slang` on lavapipe | exit 0, ignored, no crash |
| Build | `render-test` + `slang-test` compile clean |

⚠️ **The consequence a reviewer must weigh.** On hardware implementing `VK_NV_cooperative_matrix2`,
23 test invocations that have never run will begin running. They may fail — they have never been
validated against a real implementation, and nothing here can predict that. That is the point of
the change, but it means this PR should be landed with NVIDIA-hardware CI watched, and it is
reasonable to want those tests triaged before merge rather than after. No such hardware was
available in this environment.
