### PR TITLE
docs: record the environment an ASan build needs

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -608,6 +608,49 @@ Downstream packaging may or may not choose to distribute them, at their
 discretion. **We strongly encourage downstream users of Slang to move to the
 new library names as soon as they are able.**
 
+## Building with AddressSanitizer
+
+Configuring with `-DSLANG_ENABLE_ASAN=ON` needs two environment settings that are easy to miss,
+because without them the build fails partway through for reasons that do not mention the sanitizer.
+
+```bash
+# 1. The build compiles and then *runs* its own generators (slang-embed, slang-fiddle). Under
+#    SLANG_ENABLE_ASAN they are instrumented and link the ASan runtime dynamically, so the runtime
+#    must be locatable or they fail to start:
+#        slang-embed: error while loading shared libraries: libclang_rt.asan-x86_64.so:
+#        cannot open shared object file: No such file or directory
+export LD_LIBRARY_PATH="$(clang -print-runtime-dir):$LD_LIBRARY_PATH"
+
+# 2. Those same generators leak, and LeakSanitizer's non-zero exit status fails the build:
+#        ERROR: LeakSanitizer: detected memory leaks
+#        SUMMARY: AddressSanitizer: 828842 byte(s) leaked in 3661 allocation(s)
+#    They are short-lived build tools, so leak detection is not meaningful for them.
+export ASAN_OPTIONS=detect_leaks=0
+
+cmake --preset default -DSLANG_ENABLE_ASAN=ON
+cmake --build --preset release
+```
+
+When _running_ the resulting binaries, put the build's own `lib/` directory on `LD_LIBRARY_PATH` as
+well. `slang-test` loads its tools (`librender-test-tool.so` and friends) with `dlopen`, and if that
+fails the affected tests are reported as **ignored** rather than failed — so a missing path silently
+removes coverage instead of producing an error.
+
+This is needed only for sanitizer builds. Normally that `dlopen` resolves through the executable's
+`$ORIGIN/../lib` runpath without any help; under a sanitizer the call is intercepted by the
+sanitizer runtime and issued from _its_ object, which has no runpath, so `$ORIGIN/../lib` is never
+searched. Setting `LD_LIBRARY_PATH` for the runtime alone is therefore not enough — it must also
+name the build's `lib/`:
+
+```bash
+export LD_LIBRARY_PATH="$PWD/build/Release/lib:$(clang -print-runtime-dir):$LD_LIBRARY_PATH"
+```
+
+The same applies to `-DSLANG_ENABLE_TSAN=ON`, with `libclang_rt.tsan-x86_64.so` in place of the ASan
+runtime; `ASAN_OPTIONS=detect_leaks=0` is not needed there, as ThreadSanitizer has no leak checker.
+
+The equivalent settings for CI are in `.github/workflows/ci-slang-sanitizer.yml`.
+
 ## Notes
 
 [^1] below 3.25, CMake lacks the ability to mark directories as being


### PR DESCRIPTION
## 1. Motivation

`-DSLANG_ENABLE_ASAN=ON` does not build out of the box, and neither failure mentions the sanitizer,
so the cause is not obvious. Both were hit on a plain Ubuntu 24.04 host with clang-18:

```
slang-embed: error while loading shared libraries: libclang_rt.asan-x86_64.so:
cannot open shared object file: No such file or directory
```

```
==54966==ERROR: LeakSanitizer: detected memory leaks
SUMMARY: AddressSanitizer: 828842 byte(s) leaked in 3661 allocation(s).
ninja: build stopped: subcommand failed.
```

The build compiles its own generators (`slang-embed`, `slang-fiddle`) and then *runs* them. Under
ASan they are instrumented and link the runtime dynamically, so they cannot start unless it is
locatable; and they leak, so LeakSanitizer's non-zero exit fails the build. Both are already handled
in CI (`ci-slang-sanitizer.yml:134` and `:144`), but nothing in the docs says so, so anyone
reproducing a sanitizer finding locally rediscovers them.

The first of these is recorded in issue #12707 as a container-specific gotcha. It is not
container-specific — it reproduced on an ordinary host at the identical runtime path. The
LeakSanitizer one is not recorded anywhere.

## 2. Proposed solution

Add a short "Building with AddressSanitizer" section to `docs/building.md` giving the two exports
and the error each one prevents, and point at the CI workflow as the authoritative copy.

It also documents a third, run-time requirement that is more insidious than either build failure:
the build's `lib/` directory must be on `LD_LIBRARY_PATH` when running the binaries. `slang-test`
`dlopen`s its tools, and when that fails the affected tests are reported **ignored**, not failed —
so the run appears to succeed while silently testing nothing. I hit exactly this and briefly
concluded that ASan was incompatible with Vulkan before finding the real cause.

The section explains *why* this is specific to sanitizer builds, which is the part that makes it
memorable rather than a rule to copy: normally that `dlopen` resolves through the executable's
`$ORIGIN/../lib` runpath unaided, but under a sanitizer the call is intercepted and issued from the
sanitizer runtime's own object, which has no runpath — so `$ORIGIN/../lib` is never searched. Setting
`LD_LIBRARY_PATH` to the runtime directory alone is therefore not sufficient, which is the trap,
since that is exactly what the first build-time fix tells you to do.

A closing note covers `-DSLANG_ENABLE_TSAN=ON`, where the same two `LD_LIBRARY_PATH` requirements
apply with the TSan runtime, and `ASAN_OPTIONS=detect_leaks=0` is unnecessary because
ThreadSanitizer has no leak checker. I re-encountered the trap on a TSan build after it had already
been diagnosed on ASan, which is the reason for making the generality explicit.

`clang -print-runtime-dir` is used rather than a hardcoded path so the snippet does not rot across
clang versions.

## 3. Change summary

| File | What changed |
|---|---|
| `docs/building.md` | New "Building with AddressSanitizer" section before "Notes": the two build-time exports with the error each prevents, the run-time `lib/` requirement with its silent-ignore failure mode and the runpath reason it is sanitizer-specific, and a note carrying all of it over to `SLANG_ENABLE_TSAN` |

## 4. Concepts and vocabulary

- **`slang-embed` / `slang-fiddle`** — host tools the build compiles and then executes to generate
  sources. Being instrumented themselves is what makes them sensitive to the ASan runtime.
- **ignored vs failed** — slang-test reports a test whose tool could not be loaded, or whose device
  is unavailable, as *ignored*. Ignored tests do not fail a run, which is why a missing
  `LD_LIBRARY_PATH` entry removes coverage silently.

## 5. Process report

Documentation only; no behaviour change and nothing to root-cause. The values are not invented —
each is copied from what `ci-slang-sanitizer.yml` already does, so the docs and CI agree, and the
section says so to keep CI as the single source of truth.

Whether the leaks in `slang-fiddle` should be fixed rather than suppressed is a separate question,
deliberately not addressed here: `detect_leaks=0` is already CI's chosen behaviour for the build
step, and changing it is not a documentation matter.

## 6. Verification

Both exports were required, in sequence, to get a working ASan build on this host — the build failed
at object 511/1188 without the first and at 516/1188 without the second, and completed with both.
The run-time `lib/` requirement was confirmed by observing `Check vk,vulkan: Not Supported` and 0
tests executing without it, versus vk tests passing with it.
