### PR TITLE
Resolve requirements through lookup-backed witnesses

### DIFF
--- a/source/slang/slang-syntax.cpp
+++ b/source/slang/slang-syntax.cpp
@@ -738,6 +738,36 @@ RequirementWitness tryLookUpRequirementWitness(
 
     if (auto declaredSubtypeWitness = as<DeclaredSubtypeWitness>(subtypeWitness))
     {
+        if (as<LookupDeclRef>(declaredSubtypeWitness->getDeclRef().declRefBase))
+        {
+            // Consider this example:
+            //
+            //     interface IPrimitive { associatedtype Attributes; }
+            //     interface ICustomPrimitive : IPrimitive {}
+            //     interface IContext { associatedtype Primitive : IPrimitive; }
+            //     struct Attributes {}
+            //     struct Primitive<T> : ICustomPrimitive { typealias Attributes = T; }
+            //     struct Context : IContext { typealias Primitive = ::Primitive<::Attributes>; }
+            //
+            // The selected `Primitive<Attributes> : IPrimitive` conformance follows the inherited
+            // `ICustomPrimitive : IPrimitive` requirement. The checker represents that path as a
+            // declared witness whose declaration reference looks up the inherited requirement in
+            // the parent conformance table. Follow that checked path to its nested witness table,
+            // then apply every substitution recorded along the same path.
+            auto unspecializedEntry =
+                getUnspecializedLookupRec(astBuilder, requirementKey, declaredSubtypeWitness);
+            if (unspecializedEntry.getFlavor() != RequirementWitness::Flavor::none)
+            {
+                // Requirements can be values, declaration references, or nested witness tables.
+                // `RequirementWitness::specialize` handles every concrete flavor, so forward all
+                // of them through the substitutions recorded by the lookup-backed conformance.
+                return specializeLookedUpRec(
+                    astBuilder,
+                    declaredSubtypeWitness,
+                    unspecializedEntry);
+            }
+        }
+
         if (auto inheritanceDeclRef = declaredSubtypeWitness->getDeclRef().as<InheritanceDecl>())
         {
             // A conformance that was declared as part of an inheritance clause

--- a/tools/slang-static-unit-test/unit-test-lookup-backed-requirement-witness.cpp
+++ b/tools/slang-static-unit-test/unit-test-lookup-backed-requirement-witness.cpp
@@ -1,0 +1,171 @@
+// unit-test-lookup-backed-requirement-witness.cpp
+//
+// Tests requirement lookup through the checked AST witness shape from issue #12751.
+
+#include "slang/slang-ast-builder.h"
+#include "slang/slang-module.h"
+#include "slang/slang-syntax.h"
+#include "static-unit-test-env.h"
+#include "unit-test/slang-unit-test.h"
+
+using namespace Slang;
+
+namespace
+{
+
+/// Find the first direct member of `containerDecl` of type `T` whose name matches.
+template<typename T>
+T* findMemberDecl(ContainerDecl* containerDecl, const char* name = nullptr)
+{
+    for (auto member : containerDecl->getDirectMemberDecls())
+    {
+        auto typedMember = as<T>(member);
+        if (!typedMember)
+            continue;
+        if (!name)
+            return typedMember;
+        if (typedMember->getName() && typedMember->getName()->text == name)
+            return typedMember;
+    }
+    return nullptr;
+}
+
+/// Find the direct constraint whose subtype names `associatedTypeDecl`.
+GenericTypeConstraintDecl* findAssociatedTypeConstraint(
+    InterfaceDecl* interfaceDecl,
+    AssocTypeDecl* associatedTypeDecl)
+{
+    for (auto constraint : interfaceDecl->getDirectMemberDeclsOfType<GenericTypeConstraintDecl>())
+    {
+        auto subType = as<DeclRefType>(constraint->sub.type);
+        if (subType && subType->getDeclRef().getDecl() == associatedTypeDecl)
+            return constraint;
+    }
+    return nullptr;
+}
+
+} // namespace
+
+SLANG_UNIT_TEST(lookupBackedRequirementWitness)
+{
+    StaticUnitTestEnv env(unitTestContext);
+    ASTBuilder* astBuilder = env.getASTBuilder();
+    SLANG_AST_BUILDER_RAII(astBuilder);
+
+    String diagnostics;
+    Module* module = env.checkModuleFromSource(
+        "lookupBackedRequirementWitness",
+        R"(
+            interface IPrimitive
+            {
+                associatedtype Attributes;
+            }
+
+            interface ICustomPrimitive : IPrimitive {}
+
+            interface IContext
+            {
+                associatedtype Primitive : IPrimitive;
+            }
+
+            struct Attributes {}
+
+            struct Primitive<T> : ICustomPrimitive
+            {
+                typealias Attributes = T;
+            }
+
+            struct Context : IContext
+            {
+                typealias Primitive = ::Primitive<::Attributes>;
+            }
+        )",
+        &diagnostics);
+    if (!module && diagnostics.getLength())
+        getTestReporter()->message(TestMessageType::Info, diagnostics.getBuffer());
+    SLANG_CHECK_ABORT(module != nullptr);
+
+    ModuleDecl* moduleDecl = module->getModuleDecl();
+    auto primitiveInterface = findMemberDecl<InterfaceDecl>(moduleDecl, "IPrimitive");
+    auto customPrimitiveInterface = findMemberDecl<InterfaceDecl>(moduleDecl, "ICustomPrimitive");
+    auto contextInterface = findMemberDecl<InterfaceDecl>(moduleDecl, "IContext");
+    auto attributesDecl = findMemberDecl<StructDecl>(moduleDecl, "Attributes");
+    auto contextDecl = findMemberDecl<StructDecl>(moduleDecl, "Context");
+    SLANG_CHECK_ABORT(primitiveInterface != nullptr);
+    SLANG_CHECK_ABORT(customPrimitiveInterface != nullptr);
+    SLANG_CHECK_ABORT(contextInterface != nullptr);
+    SLANG_CHECK_ABORT(attributesDecl != nullptr);
+    SLANG_CHECK_ABORT(contextDecl != nullptr);
+
+    auto attributesRequirement = findMemberDecl<AssocTypeDecl>(primitiveInterface, "Attributes");
+    auto primitiveRequirement = findMemberDecl<AssocTypeDecl>(contextInterface, "Primitive");
+    SLANG_CHECK_ABORT(primitiveRequirement != nullptr);
+    auto primitiveConstraint = findAssociatedTypeConstraint(contextInterface, primitiveRequirement);
+    auto customPrimitiveInheritance = findMemberDecl<InheritanceDecl>(customPrimitiveInterface);
+    auto contextInheritance = findMemberDecl<InheritanceDecl>(contextDecl);
+    SLANG_CHECK_ABORT(attributesRequirement != nullptr);
+    SLANG_CHECK_ABORT(primitiveConstraint != nullptr);
+    SLANG_CHECK_ABORT(customPrimitiveInheritance != nullptr);
+    SLANG_CHECK_ABORT(contextInheritance != nullptr);
+
+    // Consider `Context` above. Its `IContext` table stores both the selected `Primitive` type and
+    // the proof that this selected type implements `IPrimitive`. Select that proof by its exact
+    // constraint key; witness-table entries are keyed data, so their order and representation are
+    // not a valid way to identify one.
+    WitnessTable* contextWitnessTable = contextInheritance->witnessTable;
+    SLANG_CHECK_ABORT(contextWitnessTable != nullptr);
+    RequirementWitness rawPrimitiveRequirement;
+    SLANG_CHECK_ABORT(contextWitnessTable->getRequirementDictionary().tryGetValue(
+        primitiveConstraint,
+        rawPrimitiveRequirement));
+    SLANG_CHECK_ABORT(rawPrimitiveRequirement.getFlavor() == RequirementWitness::Flavor::val);
+    auto primitiveWitness = as<DeclaredSubtypeWitness>(rawPrimitiveRequirement.getVal());
+    SLANG_CHECK_ABORT(primitiveWitness != nullptr);
+    auto primitiveLookup = as<LookupDeclRef>(primitiveWitness->getDeclRef().declRefBase);
+    SLANG_CHECK_ABORT(primitiveLookup != nullptr);
+    SLANG_CHECK_ABORT(primitiveLookup->getDecl() == customPrimitiveInheritance);
+
+    auto parentPrimitiveWitness = as<DeclaredSubtypeWitness>(primitiveLookup->getWitness());
+    SLANG_CHECK_ABORT(parentPrimitiveWitness != nullptr);
+    SLANG_CHECK_ABORT(
+        as<LookupDeclRef>(parentPrimitiveWitness->getDeclRef().declRefBase) == nullptr);
+    SLANG_CHECK_ABORT(parentPrimitiveWitness->getDeclRef().as<InheritanceDecl>());
+
+    // The lookup declaration records the exact parent witness and requirement key used to reach
+    // the nested conformance table. Querying that pair proves the shared direct-inheritance path
+    // still supplies the intermediate witness table needed by the recursive lookup.
+    auto intermediateWitness = tryLookUpRequirementWitness(
+        astBuilder,
+        primitiveLookup->getWitness(),
+        primitiveLookup->getDecl());
+    SLANG_CHECK_ABORT(intermediateWitness.getFlavor() == RequirementWitness::Flavor::witnessTable);
+    auto intermediateTable = intermediateWitness.getWitnessTable();
+    SLANG_CHECK(intermediateTable->witnessedType->equals(primitiveWitness->getSub()));
+    SLANG_CHECK(intermediateTable->baseType->equals(primitiveWitness->getSup()));
+
+    auto attributesRequirementWitness =
+        tryLookUpRequirementWitness(astBuilder, primitiveWitness, attributesRequirement);
+    SLANG_CHECK_ABORT(attributesRequirementWitness.getFlavor() == RequirementWitness::Flavor::val);
+    auto attributesType = as<DeclRefType>(attributesRequirementWitness.getVal());
+    SLANG_CHECK_ABORT(attributesType != nullptr);
+    SLANG_CHECK(attributesType->getDeclRef().getDecl() == attributesDecl);
+
+    // `ThisType` and `ThisTypeConstraint` are synthesized requirements rather than table entries.
+    // A failed ordinary lookup must reach these shared fallbacks instead of returning `none` from
+    // the lookup-backed path.
+    auto thisTypeRequirement = primitiveInterface->getThisTypeDecl();
+    SLANG_CHECK_ABORT(thisTypeRequirement != nullptr);
+    auto thisTypeConstraintRequirement =
+        findMemberDecl<ThisTypeConstraintDecl>(thisTypeRequirement);
+    SLANG_CHECK_ABORT(thisTypeConstraintRequirement != nullptr);
+
+    auto thisTypeWitness =
+        tryLookUpRequirementWitness(astBuilder, primitiveWitness, thisTypeRequirement);
+    SLANG_CHECK_ABORT(thisTypeWitness.getFlavor() == RequirementWitness::Flavor::val);
+    SLANG_CHECK(thisTypeWitness.getVal() == primitiveWitness->getSub());
+
+    auto thisTypeConstraintWitness =
+        tryLookUpRequirementWitness(astBuilder, primitiveWitness, thisTypeConstraintRequirement);
+    SLANG_CHECK_ABORT(thisTypeConstraintWitness.getFlavor() == RequirementWitness::Flavor::val);
+    SLANG_CHECK(thisTypeConstraintWitness.getVal() == primitiveWitness);
+}


### PR DESCRIPTION
## Motivation

The defect is externally observable through `slangc` on the structural ray-tracing work in #12691.
At the archived pre-fix commit
[`f7c3a2ef099db5d8537cfbbe1dea9cdd7062e8cd`](https://github.com/kaizhangNV/slang/commit/f7c3a2ef099db5d8537cfbbe1dea9cdd7062e8cd),
run:

```bash
build/Debug/bin/slangc \
  tests/ray-tracing-2/target/portable/stage-input-hit-attributes.slang \
  -experimental-feature \
  -entry ClosestHit \
  -stage closesthit \
  -target hlsl \
  -o out.hlsl
```

The complete reproducer is
[`stage-input-hit-attributes.slang`](https://github.com/kaizhangNV/slang/blob/f7c3a2ef099db5d8537cfbbe1dea9cdd7062e8cd/tests/ray-tracing-2/target/portable/stage-input-hit-attributes.slang).
Its relevant source is:

```slang
import slang.raytracing;

struct TestPayload { float value; }
struct TestRecord {}

struct TestTraceContext : rt::ITraceContext
{
    typealias Payload = TestPayload;
    typealias AccelerationStructure = rt::AccelerationStructure;
    typealias Motion = rt::NoMotion;
}

struct CustomAttributes { float2 value; }

struct HitContext : rt::IHitContext
{
    typealias TraceContext = TestTraceContext;
    typealias Primitive = rt::BoundingBoxPrimitive<CustomAttributes>;
    typealias Record = TestRecord;
}

struct ClosestHit : rt::IClosestHitShader<HitContext>
{
    void invoke(rt::ClosestHitInput<HitContext> input)
    {
        input.payload.value = input.attributes.value.x;
    }
}
```

Without this fix, `slangc` exits with status 255 and reports E99999 at `ClosestHit`. With the fix, it
exits successfully and emits the HLSL closest-hit entry with a `CustomAttributes` intersection
attribute. No GPU or downstream HLSL compiler is required.

Current `master` does not contain #12691's structural associated-type consumer, so there is no
known master-only command-line reproduction. Issue #12751 records that scope and the exact external
reproduction rather than presenting a source fragment that merely constructs a latent AST shape.

## Proposed solution

Handle the lookup-backed form at the existing requirement-lookup boundary. Use
`getUnspecializedLookupRec` to follow the checked lookup path to the requirement entry, then use
`specializeLookedUpRec` to apply the substitutions recorded by that path. These are the same
canonical helpers used by `LookupDeclRef::tryResolve`.

Return immediately only when the lookup finds a concrete entry. A miss continues to the existing
direct-witness and synthesized `ThisType`/`ThisTypeConstraint` handling. The direct
`InheritanceDecl` path remains unchanged.

## Change summary

- Extend `tryLookUpRequirementWitness` for `LookupDeclRef`-backed declared subtype witnesses.
- Add `lookupBackedRequirementWitness` to `slang-static-unit-test`, using the checked internal AST
  to exercise the exact witness shape and generic specialization.

## Concepts and vocabulary

- **Lookup-backed witness**: a `DeclaredSubtypeWitness` whose declaration reference selects an
  inherited conformance through another witness table.
- **Requirement key**: the declaration used to index a witness table. The test selects the
  `Primitive : IPrimitive` constraint by its exact `GenericTypeConstraintDecl`, not by entry order
  or value shape.
- **Nested witness table**: the witness-table entry for an inherited-interface requirement; in the
  reduced test it records `Primitive<Attributes> : IPrimitive` inside the parent
  `ICustomPrimitive` conformance.
- **Synthesized `This` requirements**: the implicit `ThisType` and `ThisTypeConstraint` results that
  `tryLookUpRequirementWitness` supplies outside the ordinary witness-table dictionary.

## Process report

In the public reproduction, `rt::BoundingBoxPrimitive<CustomAttributes>` reaches
`rt::IIntersectionPrimitive` through `rt::ICustomIntersectionPrimitive`. Structural entry-point
discovery follows this path:

```text
findStructuralRayTracingEntryPointByName
  -> _populateStructuralEntryPointInfo
  -> StructuralRayTracingDeclRegistry::resolveAssociatedTypeConstraint(HitPrimitive)
  -> StructuralRayTracingDeclRegistry::resolveAssociatedType(PrimitiveAttributes)
  -> tryLookUpRequirementWitness(IIntersectionPrimitive.Attributes)
```

The first registry lookup returns the exact checked witness for
`HitContext.Primitive : IIntersectionPrimitive`. The second asks that witness for `Attributes`.
Without this change it returns `none`, leaving `hitAttributesType` null and causing the entry-point
ICE.

The standalone test reduces that path to ordinary language concepts:

```slang
interface IPrimitive { associatedtype Attributes; }
interface ICustomPrimitive : IPrimitive {}
interface IContext { associatedtype Primitive : IPrimitive; }
struct Attributes {}
struct Primitive<T> : ICustomPrimitive { typealias Attributes = T; }
struct Context : IContext { typealias Primitive = ::Primitive<::Attributes>; }
```

`SemanticsVisitor::checkInterfaceConformance` asks
`SemanticsVisitor::findWitnessForInterfaceRequirement` to populate the conformance tables. The
`Context : IContext` table stores its primitive-conformance proof under the exact associated-type
constraint key. That proof is a `DeclaredSubtypeWitness`. Its `LookupDeclRef` names the
`ICustomPrimitive : IPrimitive` `InheritanceDecl`, and its parent witness is the direct declared
`Primitive<Attributes> : ICustomPrimitive` conformance. The parent table maps that inheritance key
to the nested `Primitive<Attributes> : IPrimitive` table, whose `Attributes` entry was originally
checked as `T`.

This is a canonical checked-AST shape, not an alternate spelling to repair at the producer. The
intermediate requirement has `witnessTable` flavor, so the path cannot collapse to one value.
Ordinary `LookupDeclRef` resolution already traverses it with `getUnspecializedLookupRec` and
`specializeLookedUpRec`. Reusing those helpers lets the requirement lookup select
`IPrimitive.Attributes` from the nested table and apply `T -> Attributes`, preserving the witness
table as the semantic source of truth.

The regression belongs in `slang-static-unit-test` because current `master` has no public consumer
that makes the missing result observable. Ordinary associated-type sources can encounter symbolic
lookup-backed witnesses, but canonicalization resolves them through another path; removing this
change leaves their diagnostics and generated HLSL unchanged. A plain `.slang` test would therefore
pass without the fix. The static test still compiles the reduced Slang source, then extracts the
exact checked constraint entry and calls the affected internal consumer directly without exporting
compiler internals from the shared library.

The test verifies the producer shape before testing the consumer: it selects the exact constraint
key, verifies the lookup target is the inherited-interface declaration, verifies the parent is a
non-lookup declared inheritance witness, and verifies the intermediate result is the expected
nested witness table. It then checks that the final associated type is the concrete top-level
`Attributes`, proving that the generic substitution was applied. Finally, it queries both
synthesized `This` requirements.

I kept the existing direct-`InheritanceDecl` branch instead of consolidating both paths. The shared
helper eagerly resolves `val`/`declRef` entries and normalizes generic requirement keys, while the
direct branch has its existing specialization order. Changing that behavior is unrelated to this
bug and has no dedicated regression coverage.

The revert drill was intentionally two-part:

- Replacing the new lookup result with `none` makes the static test fail at the final `Attributes`
  flavor check. On the #12691 pre-fix state, the public command above exits 255 with E99999.
- Restoring the lookup but restoring the old early return on a miss makes the static test fail at
  the `ThisType` flavor check.

With the final implementation, the full static internal suite passes (26 passed, 0 failed, 6
intentionally ignored), as do the interface suite (16 passed, 69 ignored) and generic suite (81
passed, 183 ignored). Both Debug and static configurations build successfully.

Fixes #12751.
