### PR TITLE
ci: make test-falcor non-required in check-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -850,9 +850,10 @@ jobs:
 
   # Deliberately NOT added to check-ci's required needs list below: the
   # Falcor 1 bridge (vet/approve flow, KVM environment, approval gate) is
-  # still being tuned, so it still runs and reports status on every PR, but
-  # its result does not yet block merge. Promote it back to required once
-  # the vet/approve balance has settled.
+  # still being tuned, so it still runs and reports status on every PR that
+  # runs CI at all (see the `filter` job above for what skips CI entirely),
+  # but its result does not yet block merge. Promote it back to required
+  # once the vet/approve balance has settled.
   test-falcor:
     needs: [filter, build-windows-release-cl-x86_64-gpu-falcor]
     if: needs.filter.outputs.should-run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -848,6 +848,11 @@ jobs:
             exit 1
           fi
 
+  # Deliberately NOT added to check-ci's required needs list below: the
+  # Falcor 1 bridge (vet/approve flow, KVM environment, approval gate) is
+  # still being tuned, so it still runs and reports status on every PR, but
+  # its result does not yet block merge. Promote it back to required once
+  # the vet/approve balance has settled.
   test-falcor:
     needs: [filter, build-windows-release-cl-x86_64-gpu-falcor]
     if: needs.filter.outputs.should-run == 'true'
@@ -940,7 +945,6 @@ jobs:
         sanitizer-linux-clang-x86_64,
         check-cmdline-ref,
         check-capability-atoms-ref,
-        test-falcor,
         test-falcor-perf,
         test-compile-regression,
         test-benchmark,


### PR DESCRIPTION
## Summary
- The Falcor 1 bridge (vet/approve flow, KVM environment, approval gate) has been required in `check-ci` since PR #11605 (merged 2026-06-16), and the team is still tuning the vet/approve balance based on offline discussion.
- Removes `test-falcor` from `check-ci`'s required `needs` list so PRs and the merge queue no longer block on it, while leaving the `test-falcor` job itself, its dedicated build (`build-windows-release-cl-x86_64-gpu-falcor`), the approval gate, and the KVM environment fully intact — it still runs and reports status on every PR that runs CI at all (docs-only PRs still skip it, same as the rest of CI, per the `filter` job).
- `test-falcor-perf` is unaffected and remains required.

## Test plan
- Verified the modified `check-ci` `needs` list and comment via `git diff`.
- Validated `.github/workflows/ci.yml` still parses as valid YAML.
- Ran `./extras/formatting.sh --check-only` (no issues in the changed file).