### PR TITLE
Harden ci-slang-build.yml against workflow template injection

### DIFF
--- a/.github/workflows/ci-slang-build.yml
+++ b/.github/workflows/ci-slang-build.yml
@@ -149,6 +149,18 @@ jobs:
           fi
 
       - name: Build Slang
+        # Pass the workflow inputs in through `env:` rather than interpolating
+        # `${{ inputs.* }}` directly into the script below. GitHub expands
+        # `${{ }}` as raw text before bash ever sees the script, so an input
+        # carrying shell metacharacters would be executed as code; read as
+        # ordinary shell variables the values stay data.
+        env:
+          INPUT_OS: ${{ inputs.os }}
+          INPUT_PLATFORM: ${{ inputs.platform }}
+          INPUT_CONFIG: ${{ inputs.config }}
+          INPUT_BUILD_LLVM: ${{ inputs.build-llvm }}
+          INPUT_SAVE_SCCACHE: ${{ inputs.save-sccache }}
+          INPUT_WARNINGS_AS_ERRORS: ${{ inputs.warnings-as-errors }}
         run: |
           echo "cmake version: $(cmake --version)"
 
@@ -165,7 +177,7 @@ jobs:
             echo "ℹ️  No cache available"
           fi
 
-          if [[ "${{ inputs.platform }}" == "wasm" ]]; then
+          if [[ "$INPUT_PLATFORM" == "wasm" ]]; then
             git clone https://github.com/emscripten-core/emsdk.git
             pushd emsdk
               # Pin emsdk to a known-good version. An unpinned `latest`
@@ -206,12 +218,12 @@ jobs:
             fi
 
             # When save-sccache is requested, sccache must be available
-            if [[ "${{ inputs.save-sccache }}" == "true" && -z "${sccache_path:-}" ]]; then
+            if [[ "$INPUT_SAVE_SCCACHE" == "true" && -z "${sccache_path:-}" ]]; then
               echo "::error::save-sccache is true but sccache is not available"
               exit 1
             fi
 
-            if [[ "${{ inputs.os }}" =~ "windows" && "${{ inputs.config }}" == "debug" && "${{ inputs.build-llvm }}" != "false" ]]; then
+            if [[ "$INPUT_OS" =~ "windows" && "$INPUT_CONFIG" == "debug" && "$INPUT_BUILD_LLVM" != "false" ]]; then
               # A debug build would try to link against a release-built llvm,
               # which is a problem on Windows, so when llvm is wanted, build
               # slang-llvm in release config first and feed it back in as
@@ -222,33 +234,33 @@ jobs:
               cmake --preset default --fresh \
                 -DSLANG_SLANG_LLVM_FLAVOR=FETCH_BINARY \
                 "-DSLANG_SLANG_LLVM_BINARY_URL=$(pwd)/build/dist-release/slang-llvm.zip" \
-                "-DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }}" \
+                "-DCMAKE_COMPILE_WARNING_AS_ERROR=$INPUT_WARNINGS_AS_ERRORS" \
                 -DSLANG_IGNORE_ABORT_MSG=ON \
                 $SLANG_CI_DXC_BUILD_FROM_SOURCE \
                 "${cmake_launcher_defines[@]}"
-              cmake --workflow --preset "${{ inputs.config }}"
-            elif [[ "${{ inputs.build-llvm }}" = "false" ]]; then
+              cmake --workflow --preset "$INPUT_CONFIG"
+            elif [[ "$INPUT_BUILD_LLVM" = "false" ]]; then
               # LLVM was explicitly not requested for this platform/config
               # (e.g. linux/aarch64 cannot build it at all; other callers
               # may opt out for other reasons — see build-llvm's call sites
               # in ci.yml).
               cmake --preset default --fresh \
                 -DSLANG_SLANG_LLVM_FLAVOR=DISABLE \
-                -DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }} \
+                "-DCMAKE_COMPILE_WARNING_AS_ERROR=$INPUT_WARNINGS_AS_ERRORS" \
                 -DSLANG_IGNORE_ABORT_MSG=ON \
                 $SLANG_CI_DXC_BUILD_FROM_SOURCE \
                 "${cmake_launcher_defines[@]}"
-              cmake --workflow --preset "${{ inputs.config }}"
+              cmake --workflow --preset "$INPUT_CONFIG"
             else
               # Otherwise, use the "system" llvm we have just build or got from the
               # cache in the setup phase
               cmake --preset default --fresh \
                 -DSLANG_SLANG_LLVM_FLAVOR=USE_SYSTEM_LLVM \
-                -DCMAKE_COMPILE_WARNING_AS_ERROR=${{ inputs.warnings-as-errors }} \
+                "-DCMAKE_COMPILE_WARNING_AS_ERROR=$INPUT_WARNINGS_AS_ERRORS" \
                 -DSLANG_IGNORE_ABORT_MSG=ON \
                 $SLANG_CI_DXC_BUILD_FROM_SOURCE \
                 "${cmake_launcher_defines[@]}"
-              cmake --workflow --preset "${{ inputs.config }}"
+              cmake --workflow --preset "$INPUT_CONFIG"
             fi
           fi
 
@@ -284,6 +296,10 @@ jobs:
         run: bash extras/verify-documented-compiler-version.sh
 
       - name: Prepare artifacts for upload
+        # Same reasoning as the "Build Slang" step: read the input as a shell
+        # variable so its value can never be parsed as script.
+        env:
+          INPUT_OS: ${{ inputs.os }}
         run: |
           # Create a staging directory for artifacts with config-specific subdirectory
           mkdir -p "artifacts-staging/${cmake_config}"
@@ -299,7 +315,7 @@ jobs:
 
               cp -r "build/${cmake_config}/bin/D3D12" "artifacts-staging/${cmake_config}/bin/" || echo "Failed to copy bin/D3D12 directory"
               cp -r "build/${cmake_config}/bin/optix" "artifacts-staging/${cmake_config}/bin/" || echo "Failed to copy bin/optix directory"
-              if [[ "${{ inputs.os }}" == "windows" ]]; then
+              if [[ "$INPUT_OS" == "windows" ]]; then
                 # Copy the standard module directory (name includes version, e.g., slang-standard-module-2025.15.1)
                 # Use a loop to handle glob pattern expansion properly
                 found_module=false


### PR DESCRIPTION
Fixes #12771

## Motivation

Every `${{ ... }}` expression in a workflow is expanded by GitHub Actions as raw
text *before* the resulting script is handed to bash. So a step like the "Build
Slang" step in `.github/workflows/ci-slang-build.yml`, which wrote

```bash
if [[ "${{ inputs.os }}" =~ "windows" && "${{ inputs.config }}" == "debug" && "${{ inputs.build-llvm }}" != "false" ]]; then
```

is not comparing a variable against a string — it is pasting the value of
`inputs.os` into the script source. An input whose value contained shell
metacharacters would be *executed*, not compared. `zizmor` (surfaced via
CodeRabbit during review of #12687) flags this as template injection.

This is defense-in-depth rather than a live vulnerability. The inputs involved —
`os`, `platform`, `config`, `build-llvm`, `save-sccache`, `warnings-as-errors` —
are all supplied by hardcoded literals at `ci.yml`'s call sites (`"windows"`,
`"debug"`, `true`/`false`), never from PR-author-controlled content such as a
branch name, PR title, or comment body. There is no attacker-reachable path into
them today. The point of the change is that nothing about the current call sites
*enforces* that, so a future call site could introduce one silently.

## Proposed solution

Use the standard mitigation: bind the inputs to a step-level `env:` block, and
have the script read them as ordinary shell variables. The value then arrives
through the environment as data and is never parsed as script, regardless of what
it contains.

This is the right layer for the fix because the problem is in *how the script
obtains its inputs*, not in what it does with them. Sanitizing or quoting at each
of the nine use sites would leave the interpolation — and therefore the injection
point — in place; moving the values into `env:` removes the interpolation from
the script body entirely, so there is no site left to get wrong.

## Change summary

| Area | Change |
| --- | --- |
| `.github/workflows/ci-slang-build.yml`, "Build Slang" step | Added an `env:` block binding `os`, `platform`, `config`, `build-llvm`, `save-sccache`, and `warnings-as-errors` to `INPUT_*` variables; rewrote the nine `${{ inputs.* }}` uses in the script to read `"$INPUT_…"`. |
| `.github/workflows/ci-slang-build.yml`, "Prepare artifacts for upload" step | Same treatment for its single `${{ inputs.os }}` use. |

After the change no `${{ ... }}` expression remains inside any `run:` script in
this file. (Interpolation in `if:`, `with:`, `env:`, and `path:`/`key:` values is
not affected by this class of issue and is left alone.)

## Concepts and vocabulary

- **Template injection** — the failure mode above: `${{ }}` is textual
  substitution into the script *source*, performed before the shell parses it, so
  an interpolated value is code rather than data. `zizmor`'s
  `template-injection` rule.
- **`zizmor`** — a static analyzer for GitHub Actions workflows. Not currently
  run in this repo's CI; the finding reached us through CodeRabbit's review of
  #12687.

## Process report

**Why an `env:` block rather than per-site quoting.** The interpolation happens
before bash exists, so no amount of quoting *inside* the script can constrain
what the interpolated text is allowed to be — `"${{ inputs.os }}"` is already
whatever `inputs.os` says, quotes included. `env:` is the only mechanism that
keeps the value out of the script source. Nine sites in "Build Slang" and one in
"Prepare artifacts for upload" were converted; none were left partially
mitigated, because a single remaining interpolation would keep the finding (and
the exposure) alive.

**Why the variables are named `INPUT_*` and not `OS`, `CONFIG`, ….** The obvious
naming would shadow real environment variables. In particular `OS` is set to
`Windows_NT` on the Windows runners; binding `OS: ${{ inputs.os }}` would
overwrite it for the whole step and change behavior for anything downstream that
reads it. The `INPUT_` prefix also has no collision with Actions' own
`INPUT_<NAME>` convention here, since that applies to composite-action and `with:`
inputs, not to `workflow_call` job steps.

**Why the `=~` test kept its quoted right-hand side.** The Windows/debug branch
tests `[[ "$INPUT_OS" =~ "windows" ]]`. In bash, a quoted right-hand operand to
`=~` is matched literally rather than as a regex. Rewriting it to an unquoted
`=~ windows` or to `== *windows*` would have been tidier but would change the
matching semantics, which is not this change's business. The quoting was
preserved verbatim.

**Why three `-DCMAKE_COMPILE_WARNING_AS_ERROR` arguments gained quotes.** Only
the Windows-debug branch previously quoted this argument; the `build-llvm=false`
and `USE_SYSTEM_LLVM` branches passed it bare. With `${{ }}` the shell never saw
an unexpanded word there, but with a shell variable an unquoted `$INPUT_…`
undergoes word splitting and globbing — which is exactly the substitution step
the change is meant to eliminate. Quoting all three is what makes the `env:`
indirection actually safe. For today's `true`/`false` values it is a no-op.

**Input-shape check.** This change does not guard or special-case a malformed
input shape, so there is no upstream producer to fix instead: the inputs are
declared `type: string`/`type: boolean` on `workflow_call` and their values are
correct. What was wrong was the *consumption* mechanism in this file — reading
them by textual substitution into a script instead of through the environment —
and that is owned entirely by this workflow. Tightening the producer (`ci.yml`'s
call sites) would not help, because the hazard is structural: it would reappear
the moment any caller passed a computed value.

**Validation.** `zizmor` is not installed in my environment, so I could not
confirm the finding clears; the fix follows the rule's prescribed mitigation
rather than an observed clean run. What I did verify locally: the file parses as
YAML, every `run:` script passes `bash -n`, and a programmatic scan of the parsed
workflow confirms no `${{` survives in any step's `run:` body. There is no test
to add — CI exercising this workflow on the PR itself is the regression check,
and the change is behavior-preserving by construction.
