### PR TITLE
Handle empty fields in OptiX payload registers

### DIFF
--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -1206,6 +1206,16 @@ struct CUDAEntryPointVaryingParamLegalizeContext : EntryPointVaryingParamLegaliz
             for (auto field : structType->getFields())
             {
                 auto fieldType = field->getFieldType();
+
+                // Empty-type legalization preserves non-optimizable empty fields as `void` so
+                // that field indices stay stable. The field occupies no storage, but make-struct
+                // still needs a matching operand until void cleanup removes both of them.
+                if (as<IRVoidType>(fieldType))
+                {
+                    fieldVals.add(builder->getVoidValue());
+                    continue;
+                }
+
                 // Align to field alignment before reading
                 int fieldAlign = getTypeCppAlignment(fieldType, builder);
                 ioByteOffset = (ioByteOffset + fieldAlign - 1) & ~(fieldAlign - 1);
@@ -1435,6 +1445,11 @@ struct CUDAEntryPointVaryingParamLegalizeContext : EntryPointVaryingParamLegaliz
             for (auto field : structType->getFields())
             {
                 auto fieldType = field->getFieldType();
+
+                // A legalized empty field has no storage, so it contributes no alignment or data.
+                if (as<IRVoidType>(fieldType))
+                    continue;
+
                 // Align to field alignment before writing
                 int fieldAlign = getTypeCppAlignment(fieldType, builder);
                 ioByteOffset = (ioByteOffset + fieldAlign - 1) & ~(fieldAlign - 1);

--- a/tests/optix/optix-payload-registers-empty-field.slang
+++ b/tests/optix/optix-payload-registers-empty-field.slang
@@ -1,0 +1,58 @@
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry missMain -stage miss
+//TEST:SIMPLE(filecheck=CHECK): -target cuda -entry missMain -stage miss -DMAKE_PUBLIC
+
+// Consider this payload, which extends the shape reported in shader-slang/slang#12803 with scalar
+// fields around `Empty`. Empty-type legalization removes `Empty`, but temporarily keeps its field
+// as `void` so field indices still match the source type. CUDA payload lowering must treat that
+// placeholder as zero storage. If it rejects the placeholder and falls back to a payload pointer,
+// raygen passes inline registers while this miss shader interprets the first two registers as a
+// pointer. The final 16-bit field also verifies that the placeholder adds no alignment.
+#ifdef MAKE_PUBLIC
+public struct Empty
+{
+}
+
+public struct Payload
+{
+    public float3 color;
+    public uint8_t low;
+    public Empty empty;
+    public uint16_t high;
+}
+#else
+struct Empty
+{
+}
+
+struct Payload
+{
+    float3 color;
+    uint8_t low;
+    Empty empty;
+    uint16_t high;
+}
+#endif
+
+// CHECK-LABEL: __miss__missMain()
+// CHECK-NOT: getOptiXRayPayloadPtr
+// CHECK: optixGetPayload_0
+// CHECK: optixGetPayload_1
+// CHECK: optixGetPayload_2
+// CHECK: optixGetPayload_3()
+// CHECK: [[HIGH_REG:[A-Za-z_][A-Za-z0-9_]*]] = optixGetPayload_3()
+// CHECK: ushort{{.*}}([[HIGH_REG]] >> 16U) & 65535U
+// CHECK-NOT: getOptiXRayPayloadPtr
+// CHECK: optixSetPayload_0
+// CHECK: optixSetPayload_1
+// CHECK: optixSetPayload_2
+// CHECK: {{.*}} << 16U
+// CHECK: optixSetPayload_3
+// CHECK-NOT: getOptiXRayPayloadPtr
+// CHECK: return;
+[shader("miss")]
+void missMain(inout Payload payload)
+{
+    payload.color = float3(1, 0, 1);
+    payload.low = 1;
+    payload.high = 2;
+}


### PR DESCRIPTION
## Motivation

Consider the public payload from #12803:

```slang
public struct Empty
{
}

public struct Payload
{
    public float3 color;
    public Empty empty;
};

[shader("miss")]
void miss(inout Payload payload)
{
    payload.color = float3(1, 0, 1);
}
```

After `de679fd`, empty-type legalization can remove `Empty` while temporarily retaining the corresponding field as a `void` placeholder. The CUDA layout still reports a small payload, so the generated raygen side passes it through inline OptiX payload registers. The miss-stage reader rejects the `void` field, however, and falls back to interpreting the first two registers as a pointer. Dereferencing that value causes the reported `CUDA_ERROR_ILLEGAL_ADDRESS`.

Fixes #12803.

## Proposed solution

Teach the OptiX structural payload marshaller that a legalized `void` struct field has zero storage. The read path keeps a canonical void operand for the temporary struct value without advancing the byte offset. The write path skips the field before alignment and field extraction.

This preserves the invariant established by empty-type legalization instead of changing the producer or masking the invalid pointer access. The later void-cleanup pass continues to remove the placeholder field and its matching operand as before.

## Change summary

- Handle `IRVoidType` fields in `emitOptiXPayloadRead` by adding a void value without consuming payload bytes.
- Handle the same fields in `emitOptiXPayloadWrite` by emitting no alignment, extraction, or register write.
- Add an OptiX CUDA text regression compiled with both public and ordinary declarations. It verifies register transport, pointer-fallback absence, and the byte offset of a field following the empty field.
- Build `slangc` and `slang-test` in RelWithDebInfo, then run `slang-test -server-count 1 tests/optix`: 9/9 tests passed.

## Concepts and vocabulary

- **Legalized void field**: a temporary `IRVoidType` struct field used to preserve source field positions after an empty field loses its ordinary data.
- **Payload register ABI**: the byte layout shared by the code that passes a ray payload through OptiX registers and the hit/miss shader that reconstructs and writes it back.
- **Void cleanup**: the later `cleanUpVoidType` pass that removes void fields and their matching value operands before final emission.

## Process report

`TupleTypeBuilder::getResult` in `slang-legalize-types.cpp` intentionally gives an empty field `IRVoidType` when its enclosing struct is not optimizable. Keeping that field preserves source field indices for layout lookup. CUDA entry-point varying legalization runs after this transformation and before `cleanUpVoidType`, so `{ float3 color; Empty empty; }` legitimately reaches `createLegalUserVaryingValImpl` as `{ float3 color; void empty; }`.

`computePayloadRegisterCount` sees the ordinary payload size and selects inline registers. `emitOptiXPayloadRead` then recursively reconstructs the struct: it reads `color`, reaches the void field, and previously returned null because void is not one of its supported leaf types. `createLegalUserVaryingValImpl` interpreted that null as a reason to use `getOptiXRayPayloadPtr`. This receiver-only fallback disagreed with the register ABI selected by the raygen-side payload packing.

The read-side change treats the placeholder as the producer defines it: zero storage and no alignment. It still appends `builder->getVoidValue()` because the temporary `emitMakeStruct` must have one operand per field until `cleanUpVoidType` removes both the void field and operand. Merely omitting the operand would create an inconsistent intermediate struct value.

The write-side change applies the same rule before alignment and `emitFieldExtract`. Checking later would be incorrect: the generic alignment fallback for an unhandled type could move the following field, and extracting a void field creates work for a value that has no storage.

The regression extends the reported payload with byte- and half-word fields around `Empty`. In addition to rejecting `getOptiXRayPayloadPtr`, it checks that the final half-word is read and written in register 3 with a 16-bit shift. That proves the placeholder consumes neither bytes nor alignment. The public variant covers #12803 directly on current master; the ordinary variant protects the underlying legalized-IR invariant independently of public-declaration behavior.

The new branches are the only special cases introduced. Moving the fix into empty-type legalization was rejected because the placeholder is an intentional representation used to keep field/layout indices stable. A pointer guard or late alignment correction was also rejected because either would preserve the sender/receiver ABI disagreement instead of making the valid intermediate shape marshal correctly.
