### PR TITLE
agentic tests: anchor 04c-layout-ir on the first post-link dump block, not a pass name

### DIFF
--- a/docs/generated/tests/design/pipeline/04c-layout-ir/README.md
+++ b/docs/generated/tests/design/pipeline/04c-layout-ir/README.md
@@ -36,8 +36,12 @@ descriptor-heap placement, and the diagnostics that abort binding.
 module is never dumped under a header of its own; its effects appear once
 link merges it into the post-link IR, so these tests pin `CHECK-NOT`
 patterns to the pre-link `### LOWER-TO-IR:` block and positive `CHECK`
-patterns to the first post-link block,
-`### AFTER validateAndRemoveAssumeAddress:`. Only the _structure_ of the
+patterns to the first post-link block. That block is matched as
+<code>### AFTER &#123;&#123;[A-Za-z0-9_]+&#125;&#125;:</code> rather than
+by pass name, because the claim is about the earliest post-link snapshot
+and not about any particular pass: which pass runs first there changes as
+passes are gated on `RequiredLoweringPassSet` flags and skipped when the
+module holds nothing for them to do. Only the _structure_ of the
 layout instructions is asserted (`varLayout(`, `offset(`,
 `structTypeLayout(`, `parameterGroupTypeLayout(`, `EntryPointLayout(`,
 `[layout(%N)]`); the numeric operands inside them are per-target by

--- a/docs/generated/tests/design/pipeline/04c-layout-ir/_prompt.md
+++ b/docs/generated/tests/design/pipeline/04c-layout-ir/_prompt.md
@@ -45,9 +45,8 @@ The layout IR module itself does **not** get its own `### LAYOUT-IR:`
 dump section. Instead, after the per-translation-unit executable IR is
 emitted (`### LOWER-TO-IR:`), the layout module is merged into the
 post-link IR before the post-link pipeline runs. The **first
-`### AFTER <pass>:` block** in `-dump-ir` output (e.g.
-`### AFTER validateAndRemoveAssumeAddress:`) is therefore the earliest
-post-link snapshot, and the layout decorations attached by
+`### AFTER <pass>:` block** in `-dump-ir` output is therefore the
+earliest post-link snapshot, and the layout decorations attached by
 `createIRModuleForLayout` are visible there as:
 
 - `[layout(%N)]` decorations on stub globals (`global_param`,
@@ -228,10 +227,22 @@ merged in). The `### LOWER-TO-IR:` block (pre-link executable IR) is
 the right place for `CHECK-NOT` patterns asserting the absence of
 layout decorations, since the layout module has not been merged at
 that point. Note that FileCheck patterns are evaluated in order; use
-`// CHECK-LABEL: ### AFTER validateAndRemoveAssumeAddress:` to pin
-subsequent `CHECK` lines to the post-link snapshot. Be aware that
-identifiers inside the IR dump (`%N`) are renumbered at each pass
-boundary, so use FileCheck regex-variable captures
+`// CHECK-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:` to pin subsequent
+`CHECK` lines to the post-link snapshot.
+
+**Never spell out the pass name in that label.** The claim these tests
+make is about a _position_ in the dump — the earliest post-link
+snapshot — not about any particular pass. Which pass happens to run
+first there is an implementation detail that changes: passes get
+gated on `RequiredLoweringPassSet` flags so they are skipped when the
+module holds nothing for them to do (issue #11917), and a gated-out
+pass emits no `### AFTER <pass>:` header at all. Pinning the name
+makes the test fail the day that pass is gated, renamed or reordered,
+even though nothing it asserts has changed. The regex label matches
+whichever pass is first and is immune to all three.
+
+Be aware that identifiers inside the IR dump (`%N`) are renumbered at
+each pass boundary, so use FileCheck regex-variable captures
 (`[[#%layout_id:]]`) when referencing the same instruction across
 multiple `CHECK` lines.
 

--- a/docs/generated/tests/design/pipeline/04c-layout-ir/cbuffer-produces-parameter-group-type-layout.slang
+++ b/docs/generated/tests/design/pipeline/04c-layout-ir/cbuffer-produces-parameter-group-type-layout.slang
@@ -26,5 +26,5 @@ void main()
     result[0] = color;
 }
 
-// CHECK-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CHECK-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // CHECK: parameterGroupTypeLayout(

--- a/docs/generated/tests/design/pipeline/04c-layout-ir/entry-point-func-gets-layout-decoration.slang
+++ b/docs/generated/tests/design/pipeline/04c-layout-ir/entry-point-func-gets-layout-decoration.slang
@@ -25,6 +25,6 @@ void main(uint3 tid : SV_DispatchThreadID)
     buf[0] = int(tid.x);
 }
 
-// CHECK-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CHECK-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // CHECK: [layout(%{{[0-9]+}})]
 // CHECK: func %main

--- a/docs/generated/tests/design/pipeline/04c-layout-ir/entry-point-func-keeps-export-decoration.slang
+++ b/docs/generated/tests/design/pipeline/04c-layout-ir/entry-point-func-keeps-export-decoration.slang
@@ -25,7 +25,7 @@ void main(uint3 tid : SV_DispatchThreadID)
     buf[0] = int(tid.x);
 }
 
-// CHECK-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CHECK-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // CHECK: [export("{{.*}}main{{.*}}")]
 // CHECK: [layout(%{{[0-9]+}})]
 // CHECK: func %main

--- a/docs/generated/tests/design/pipeline/04c-layout-ir/entry-point-layout-encodes-stage-and-semantic.slang
+++ b/docs/generated/tests/design/pipeline/04c-layout-ir/entry-point-layout-encodes-stage-and-semantic.slang
@@ -25,6 +25,6 @@ void main(uint3 tid : SV_DispatchThreadID)
     buf[0] = int(tid.x);
 }
 
-// CHECK-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CHECK-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // CHECK: stage(
 // CHECK: systemValueSemantic("SV_DispatchThreadID"

--- a/docs/generated/tests/design/pipeline/04c-layout-ir/entry-point-layout-has-param-and-result-operands.slang
+++ b/docs/generated/tests/design/pipeline/04c-layout-ir/entry-point-layout-has-param-and-result-operands.slang
@@ -24,7 +24,7 @@ void main(uint3 tid : SV_DispatchThreadID)
     buf[0] = int(tid.x);
 }
 
-// CHECK-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CHECK-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // CHECK: EntryPointLayout(%{{[0-9]+}}, %{{[0-9]+}})
 // CHECK: varLayout(
 // CHECK: varLayout(

--- a/docs/generated/tests/design/pipeline/04c-layout-ir/global-param-gets-layout-decoration.slang
+++ b/docs/generated/tests/design/pipeline/04c-layout-ir/global-param-gets-layout-decoration.slang
@@ -26,6 +26,6 @@ void main(uint3 tid : SV_DispatchThreadID)
     buf[0] = int(tid.x);
 }
 
-// CHECK-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CHECK-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // CHECK: [layout(%{{[0-9]+}})]
 // CHECK: global_param

--- a/docs/generated/tests/design/pipeline/04c-layout-ir/global-param-varlayout-has-offset-operand.slang
+++ b/docs/generated/tests/design/pipeline/04c-layout-ir/global-param-varlayout-has-offset-operand.slang
@@ -25,6 +25,6 @@ void main(uint3 tid : SV_DispatchThreadID)
     buf[0] = int(tid.x);
 }
 
-// CHECK-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CHECK-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // CHECK: varLayout(
 // CHECK: offset(

--- a/docs/generated/tests/design/pipeline/04c-layout-ir/global-scope-struct-type-layout-built.slang
+++ b/docs/generated/tests/design/pipeline/04c-layout-ir/global-scope-struct-type-layout-built.slang
@@ -25,6 +25,6 @@ void main(uint3 tid : SV_DispatchThreadID)
     buf[0] = int(tid.x);
 }
 
-// CHECK-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CHECK-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // CHECK: structTypeLayout(
 // CHECK-LABEL: func %main

--- a/docs/generated/tests/design/pipeline/04c-layout-ir/global-scope-wrapped-in-parameter-group-on-cuda-and-cpp.slang
+++ b/docs/generated/tests/design/pipeline/04c-layout-ir/global-scope-wrapped-in-parameter-group-on-cuda-and-cpp.slang
@@ -27,14 +27,14 @@ void main(uint3 tid : SV_DispatchThreadID)
     buf[0] = int(tid.x);
 }
 
-// SPV-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// SPV-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // SPV: {{^}}varLayout(
 // SPV-NEXT: structTypeLayout(
 
-// CUDA-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CUDA-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // CUDA: {{^}}varLayout(
 // CUDA-NEXT: parameterGroupTypeLayout(
 
-// CPP-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CPP-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // CPP: {{^}}varLayout(
 // CPP-NEXT: parameterGroupTypeLayout(

--- a/docs/generated/tests/design/pipeline/04c-layout-ir/layout-ir-module-built-for-every-target.slang
+++ b/docs/generated/tests/design/pipeline/04c-layout-ir/layout-ir-module-built-for-every-target.slang
@@ -32,43 +32,43 @@ void main(uint3 tid : SV_DispatchThreadID)
     buf[0] = int(tid.x);
 }
 
-// SPV-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// SPV-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // SPV-DAG: varLayout(
 // SPV-DAG: offset(
 // SPV-DAG: EntryPointLayout(
 // SPV-DAG: [layout(%{{[0-9]+}})]
 
-// HLSL-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// HLSL-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // HLSL-DAG: varLayout(
 // HLSL-DAG: offset(
 // HLSL-DAG: EntryPointLayout(
 // HLSL-DAG: [layout(%{{[0-9]+}})]
 
-// GLSL-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// GLSL-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // GLSL-DAG: varLayout(
 // GLSL-DAG: offset(
 // GLSL-DAG: EntryPointLayout(
 // GLSL-DAG: [layout(%{{[0-9]+}})]
 
-// METAL-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// METAL-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // METAL-DAG: varLayout(
 // METAL-DAG: offset(
 // METAL-DAG: EntryPointLayout(
 // METAL-DAG: [layout(%{{[0-9]+}})]
 
-// WGSL-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// WGSL-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // WGSL-DAG: varLayout(
 // WGSL-DAG: offset(
 // WGSL-DAG: EntryPointLayout(
 // WGSL-DAG: [layout(%{{[0-9]+}})]
 
-// CUDA-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CUDA-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // CUDA-DAG: varLayout(
 // CUDA-DAG: offset(
 // CUDA-DAG: EntryPointLayout(
 // CUDA-DAG: [layout(%{{[0-9]+}})]
 
-// CPP-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CPP-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // CPP-DAG: varLayout(
 // CPP-DAG: offset(
 // CPP-DAG: EntryPointLayout(

--- a/docs/generated/tests/design/pipeline/04c-layout-ir/layout-module-merged-by-linkir.slang
+++ b/docs/generated/tests/design/pipeline/04c-layout-ir/layout-module-merged-by-linkir.slang
@@ -28,7 +28,7 @@ void main(uint3 tid : SV_DispatchThreadID)
 // CHECK-LABEL: ### LOWER-TO-IR:
 // CHECK-NOT: [layout(
 // CHECK-NOT: EntryPointLayout(
-// CHECK-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CHECK-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // CHECK: EntryPointLayout(
 // CHECK: [layout(%{{[0-9]+}})]
 // CHECK: global_param

--- a/docs/generated/tests/design/pipeline/04c-layout-ir/module-instance-has-toplevel-varlayout.slang
+++ b/docs/generated/tests/design/pipeline/04c-layout-ir/module-instance-has-toplevel-varlayout.slang
@@ -25,6 +25,6 @@ void main(uint3 tid : SV_DispatchThreadID)
     buf[0] = int(tid.x);
 }
 
-// CHECK-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CHECK-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // The module-instance varLayout is a top-level statement, no `let` binding.
 // CHECK: {{^}}varLayout(

--- a/docs/generated/tests/design/pipeline/04c-layout-ir/multiple-globals-each-get-layout.slang
+++ b/docs/generated/tests/design/pipeline/04c-layout-ir/multiple-globals-each-get-layout.slang
@@ -27,6 +27,6 @@ void main(uint3 tid : SV_DispatchThreadID)
     bufB[0] = float(tid.y);
 }
 
-// CHECK-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CHECK-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // CHECK: structFieldLayout(%buf{{[A-Z]}}
 // CHECK: structFieldLayout(%buf{{[A-Z]}}

--- a/docs/generated/tests/design/pipeline/04c-layout-ir/per-global-struct-field-layout-entries.slang
+++ b/docs/generated/tests/design/pipeline/04c-layout-ir/per-global-struct-field-layout-entries.slang
@@ -25,5 +25,5 @@ void main(uint3 tid : SV_DispatchThreadID)
     buf[0] = int(tid.x);
 }
 
-// CHECK-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CHECK-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
 // CHECK: structFieldLayout(%buf, %{{[0-9]+}})


### PR DESCRIPTION
## Motivation

The nightly `agentic-tests` job went red on 2026-08-28 ([run 33148436943](https://github.com/shader-slang/slang/actions/runs/33148436943/job/98774612047)) with 22 sub-test failures, all in one bundle and all the same FileCheck error:

```
error: CHECK-LABEL: expected string not found in input
// CHECK-LABEL: ### AFTER validateAndRemoveAssumeAddress:
note: possible intended match here (actual-output:32:1)
### AFTER translateEntryPointInParamToBorrow:
```

Consider what one of those tests is actually trying to say — `docs/generated/tests/design/pipeline/04c-layout-ir/entry-point-func-gets-layout-decoration.slang`:

```slang
//TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -dump-ir -o /dev/null -entry main -stage compute

uniform RWStructuredBuffer<int> buf;

[numthreads(1, 1, 1)]
void main(uint3 tid : SV_DispatchThreadID)
{
    buf[0] = int(tid.x);
}

// CHECK-LABEL: ### AFTER validateAndRemoveAssumeAddress:
// CHECK: [layout(%{{[0-9]+}})]
// CHECK: func %main
```

The claim is about the layout IR module: it is never dumped under a header of its own, so the way to observe it is to look at the earliest IR snapshot taken *after* linking, where `linkIR` has merged it in. The test expresses "the earliest post-link snapshot" by naming whichever pass happened to run first at that point in `linkAndOptimizeIR`.

That is a claim about a *position* in the dump written as a claim about a *pass*, and #12336 broke it. That PR gates `validateAndRemoveAssumeAddress` on a new `RequiredLoweringPassSet::assumeAddress` flag (`source/slang/slang-emit.cpp:1053`):

```cpp
+   if (requiredLoweringPassSet.assumeAddress)
    {
        bool validate = !isCPUTarget(targetRequest) && !isCUDATarget(targetRequest);
        SLANG_PASS(validateAndRemoveAssumeAddress, validate, sink);
    }
```

Every shader in this bundle is a handful of lines with no `__getAddress` anywhere, so no `kIROp_AssumeAddress` is ever created, the flag stays false, and the pass is skipped. The dump header is emitted by `postPassHooks` (`source/slang/slang-pass-wrapper.cpp:68`) from the pass name that `SLANG_PASS(passFunc, ...)` stringified — so a pass that does not run emits no header at all. `translateEntryPointInParamToBorrow` inherited first position, the label the tests were looking for vanished, and 22 sub-tests failed without a single thing they assert having changed.

The gating itself is correct and emitted code is unchanged; that is the whole point of the `RequiredLoweringPassSet` work for #11917. The defect is in how these tests spell their anchor.

## Proposed solution

Say "the first post-link block" directly, as a pattern rather than a name:

```diff
-// CHECK-LABEL: ### AFTER validateAndRemoveAssumeAddress:
+// CHECK-LABEL: ### AFTER {{[A-Za-z0-9_]+}}:
```

`CHECK-LABEL` resolves its pattern against the first match following the previous label block, so this binds to the earliest `### AFTER ...:` section by construction — exactly the property the tests want, and the one their own prose already describes ("the first post-link snapshot", "the merged layout block"). It is immune to the first pass being gated out, renamed, or reordered.

This is the principled layer for the fix. The alternative would be to make the compiler emit a stable, non-pass-derived header for the post-link snapshot — `slang-emit.cpp` still carries an orphaned comment saying it should ("If the user specified the flag that they want us to dump IR, then do it here, for the target-specific, but un-specialized IR", with no dump call after it). I rejected that: it changes `-dump-ir` output for every consumer, and 919 generated tests use `-dump-ir`, several with label-bracketed `CHECK-NOT` regions that a new section would silently move. Adding a compiler-visible artifact to repair a test's phrasing is the wrong direction when the test can simply state what it means.

Nine other generated tests anchor on `### AFTER eliminateDeadCode`, `### AFTER simplifyIR` and similar. Those are deliberately left alone: they test *that pass's effect*, so the pass name is the claim, not a proxy for a position.

## Change summary

| File(s) | Change |
| --- | --- |
| 14 `.slang` files in `docs/generated/tests/design/pipeline/04c-layout-ir/` | Replace the `### AFTER validateAndRemoveAssumeAddress:` label (22 occurrences across `CHECK-LABEL`, `SPV-LABEL`, `CUDA-LABEL`, `CPP-LABEL`, `HLSL-LABEL`, `GLSL-LABEL`, `METAL-LABEL`, `WGSL-LABEL`) with `### AFTER {{[A-Za-z0-9_]+}}:` |
| `04c-layout-ir/README.md` | Describe the anchor as the pattern rather than the pass name, and say why. Written with HTML entities so the bundle README keeps no raw Liquid opener |
| `04c-layout-ir/_prompt.md` | Drop the pass name from the two places it was given as the concrete pin, and add a "never spell out the pass name in that label" rule with the reason, so a regeneration does not reintroduce it |

No compiler source is touched.

## Concepts and vocabulary

- **`RequiredLoweringPassSet`** — a set of booleans computed by `calcRequiredLoweringPassSet` scanning the linked module for the opcodes each backend pass handles. A pass whose flag is false is skipped as a known no-op. #11917 is the umbrella issue for gating passes this way; #11920, #11961, #11987, #12088 and #12336 are the increments.
- **`SLANG_PASS` / `postPassHooks`** — `SLANG_PASS(passFunc, ...)` in `slang-emit.cpp` wraps a pass call and stringifies the function name with `#passFunc`. Under `-dump-ir`, `postPassHooks` prints `### AFTER <that string>:` followed by the module. The dump's section headers are therefore literally C++ function names, and a skipped pass contributes no header.
- **layout IR module** — the per-target module `createIRModuleForLayout` builds to carry binding decisions (`varLayout`, `offset`, `structTypeLayout`, `EntryPointLayout`, `[layout(%N)]`). It has no dump section of its own; `linkIR` merges it into the post-link module, which is why these tests read the first post-link snapshot.
- **`CHECK-LABEL` block** — FileCheck splits input into blocks at `CHECK-LABEL` matches. A label match is searched for after the end of the previous label's block, which is what makes a regex label resolve to the *first* remaining match rather than an arbitrary one. Regex `{{...}}` is permitted in a label; only `[[var]]` capture syntax is not.

## Process report

**Why the pattern label, and not a different pass name.** Re-pinning to `translateEntryPointInParamToBorrow` would make the bundle green today and break again on the next gating PR — #11917 is an ongoing series, and this is the second increment (`a8874f6a1`, then #12336) to land in it. The regex label removes the coupling instead of relocating it.

**Input-shape check: is a pass-named dump header a valid thing for a test to depend on?** For a test asserting what a named pass *does*, yes — the header identifies the pass whose effect is under test, and if the pass stops running that test should fail. For these 14, no: none of them mention `validateAndRemoveAssumeAddress` in their prose, purpose line, or `doc_ref`; every one describes its anchor as "the first post-link snapshot" or "the merged layout block". They were reading an implementation detail as a stand-in for a pipeline position. So the producer (the dump header) is fine and the consumer (the anchor) was wrong, which is why no compiler change is warranted here.

**Verification, against a build of `master` that contains #12336.** I did not take the green run at face value; a label that matched too loosely, or bound to a late section, would also produce 49/49.

1. *Reproduction.* Unmodified `master`: the bundle fails 22 of 49, matching the nightly's failure list exactly. With the change: 49/49. Across the whole `design/pipeline` subtree, 917/940 → 939/940.

2. *The remaining subtree failure is not mine.* `06-emit/preludes-included-by-cuda-cpp-and-hlsl.slang.2` fails identically on unmodified `master` and passes when run alone — a pre-existing cross-test prelude leak, unrelated to this change.

3. *Control for the actual claim — does it survive the next gating PR?* I compiled out `SLANG_PASS(translateEntryPointInParamToBorrow, sink)` to simulate it being gated, which promotes `replaceGlobalConstants` to first position:

   ```
   1:### LOWER-TO-IR:
   30:### AFTER replaceGlobalConstants:
   ```

   All 49 tests still pass. A name-pinned label would have failed here for the second time in two weeks. `slang-emit.cpp` was restored and rebuilt afterwards.

4. *Control for label drift.* `layout-module-merged-by-linkir.slang` puts `CHECK-NOT: [layout(` and `CHECK-NOT: EntryPointLayout(` between `### LOWER-TO-IR:` and the post-link label, so it only passes if the two labels still bracket the pre-link block. Substituting a string that *does* occur pre-link (`func %main`) into that region makes the test fail, which proves the region is real and the regex label did not slide to a later section — a drifted label would have swallowed sections full of `[layout(` and failed instead.

5. *Control for vacuity.* Corrupting a positive check (`structFieldLayout(` → `structFieldLayoutXX(`) in `per-global-struct-field-layout-entries.slang` makes it fail, so the block is not matching trivially.

**Bundle metadata.** `_prompt.md` and `README.md` already described the anchor correctly as "the first `### AFTER <pass>:` block" and used the pass name only as an example, so the regeneration prompt was not itself wrong — but it named the pass in the copy-pasteable instruction, which is how the pin got into 14 files. Both now give the pattern form, and `_prompt.md` states the rule with its reason so a future regeneration does not undo this.

**Lint and formatting.** `docs/generated/tests/_meta/regenerate.py lint` reports 0 errors / 305 warnings, byte-identical to the pre-change baseline. My first README draft did introduce one error — a raw `{{` Liquid opener, caught by the guard added in `ac3617f8c` — and is now written with HTML entities. `./extras/formatting.sh --check-only` is clean.

**Not addressed here.** The same nightly run had two further failures, `ir-reference/differentiation/blocked-derivative-propagation.slang (cpu)` and `pair-opcodes-produce-no-target-code.slang (cpu)`, which kill a freshly spawned test server twice in a row on Linux. They are an independent, recurring problem (also the sole failure of the 2026-08-26 nightly) and are filed separately.
