### PR TITLE
ci: add nightly Falcor CI run against master, no approval gate

### DIFF
--- a/.github/workflows/nightly-falcor-test.yml
+++ b/.github/workflows/nightly-falcor-test.yml
@@ -1,0 +1,95 @@
+name: Nightly Falcor Test
+
+# Runs the Falcor CI bridge test against origin/master on a schedule,
+# without the falcor-ci approval gate that PR-triggered runs require.
+#
+# ci.yml's test-falcor job sits behind falcor-build-approval-gate because
+# a pull_request-triggered run executes the workflow YAML from the PR's
+# own branch: a hostile PR could edit ci.yml to strip the gate before it
+# ever reaches the internal KernelVM bridge, so approval (required
+# reviewers = the ci-approvers team, auto-approved by
+# slang-ci-approver-bot once the PR carries a matching-SHA approval
+# review) is mandatory. A schedule-triggered workflow has no such
+# PR-controlled input: GitHub always resolves a schedule event's workflow
+# file from the default branch, and this workflow only ever checks out
+# origin/master, so there is no way for untrusted code to reach the
+# bridge through this trigger. The trust boundary the gate defends does
+# not exist here, so this workflow omits it by design (see
+# falcor-build-approval-gate's comment in ci.yml and
+# slang-ci-docs/plans/falcor1-ci-bridge.md § Approval gate).
+#
+# This exists because test-falcor is not a required check on PRs (see
+# check-ci in ci.yml): PR approval is treated as covering vet+approve for
+# Falcor CI too, so PRs can merge without ever having run the Falcor
+# bridge. This nightly run is master's backstop -- it is the only place
+# Falcor CI runs unconditionally.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run nightly at 5:00 AM UTC, after the other nightly-* Windows/Linux
+    # suites so it isn't competing with them for the same self-hosted
+    # runner pools (falcor-bridge and the Windows GPU build runner).
+    - cron: "0 5 * * *"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # No filter/should-run gating here (unlike ci.yml's PR-scoped jobs):
+  # every scheduled run always builds and tests master, regardless of
+  # which files last changed.
+  build-windows-release-cl-x86_64-gpu-falcor:
+    permissions:
+      id-token: write # Required for Workload Identity
+      contents: read
+    uses: ./.github/workflows/ci-slang-build.yml
+    with:
+      os: windows
+      compiler: cl
+      platform: x86_64
+      config: release
+      runs-on: '["Windows", "self-hosted", "build"]'
+      artifact-name-suffix: "-falcor"
+
+  test-falcor:
+    needs: [build-windows-release-cl-x86_64-gpu-falcor]
+    permissions:
+      contents: read
+      actions: read
+    uses: ./.github/workflows/ci-falcor-test.yml
+    with:
+      slang-artifact-name: slang-tests-windows-x86_64-cl-release-falcor
+
+  # Post the nightly's result to Slack. Scheduled runs only, so manual
+  # workflow_dispatch verification runs stay quiet.
+  notify:
+    needs: [test-falcor]
+    if: always() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Success notification
+        if: needs.test-falcor.result == 'success'
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        with:
+          payload: |
+            {
+              "Falcor-Nightly": ":green-check-mark: Falcor nightly: clean (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_FALCOR_NIGHTLY }}
+
+      - name: Failure notification
+        if: needs.test-falcor.result != 'success'
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        with:
+          payload: |
+            {
+              "Falcor-Nightly": ":alert: Falcor nightly: ${{ needs.test-falcor.result }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_FALCOR_NIGHTLY }}


### PR DESCRIPTION
## Motivation

`test-falcor` is not required in `check-ci` (#12775): PRs and the merge queue no longer block on
it, so a PR can merge without the Falcor bridge ever having run against its final content. The
approach the team has settled on is to treat PR approval (an "OK to merge" review) as also
covering vet+approve for Falcor CI, rather than requiring a second, blocking Falcor pass per PR.

That leaves a gap: nothing guarantees Falcor CI runs against `master` on any regular cadence.
A change that individually looked safe enough to approve without a green `test-falcor` run could
still, in combination with other recently-merged PRs, break the Falcor bridge — and today nothing
would catch that until the next PR happens to touch Falcor-relevant code and trigger `test-falcor`
again.

## Proposed solution

Add a new `nightly-falcor-test.yml` workflow that runs the same Falcor build+test job pair
`ci.yml` uses (`ci-slang-build.yml` for the Windows release Falcor artifact, then
`ci-falcor-test.yml` against it) on a `schedule` trigger, checking out `origin/master`. This is
`master`'s backstop: it is now the only place Falcor CI runs unconditionally, independent of
which PRs happened to touch Falcor-relevant paths.

The workflow deliberately does not reuse `ci.yml`'s `falcor-build-approval-gate`. That gate exists
because a `pull_request`-triggered run executes the workflow YAML from the PR's own branch: a
hostile PR could edit `ci.yml` to strip the gate before its code ever reaches the internal
KernelVM bridge, so a human/bot approval step is required before PR-controlled code touches that
compute. A `schedule`-triggered workflow has no such PR-controlled input — GitHub always resolves
a `schedule` event's workflow file from the default branch, and this workflow only ever checks out
`origin/master` — so the trust boundary the gate defends does not exist here. Reusing the gate
would just add an unattended approval prompt nightly for no security benefit.

## Change summary

| File | Change |
| --- | --- |
| `.github/workflows/nightly-falcor-test.yml` | New workflow. `schedule` (05:00 UTC, staggered after the other `nightly-*` suites) + `workflow_dispatch` triggers. Calls `ci-slang-build.yml` for the `-falcor`-suffixed Windows release artifact, then `ci-falcor-test.yml` against it — no approval gate in between. Posts success/failure to Slack via `SLACK_WEBHOOK_FALCOR_NIGHTLY` on scheduled runs only (mirrors `nightly-slang-test.yml`'s notify pattern). |

## Concepts and vocabulary

- **`falcor-ci` environment / `falcor-build-approval-gate`**: the GitHub Environment with required
  reviewers that gates `ci.yml`'s Falcor build+test on `pull_request` runs. This PR's workflow
  intentionally does not use it — see Proposed solution.
- **Falcor bridge / KernelVM (KVM)**: the internal, sealed compute this workflow's `test-falcor`
  job relays to via `/opt/slang-ci/run-external-ci` (`ci-falcor-test.yml`), running on
  `[Linux, self-hosted, X64, falcor-bridge]`.
- **`schedule` event**: fires on `cron`, always evaluating the workflow file from the repository's
  default branch, never from a PR head — this is the property the whole design leans on.

## Process report

**New file, no changes to `ci.yml`.** The nightly run reuses `ci.yml`'s two reusable
`workflow_call` workflows (`ci-slang-build.yml`, `ci-falcor-test.yml`) directly rather than
duplicating their steps, so there is exactly one source of truth for how the Falcor build and test
are actually performed; only the trigger and the presence/absence of the approval gate differ
between the PR-time and nightly-time callers.

**Input-shape check: is "no approval gate" a valid shape for this trigger, or should the gate be
reused unconditionally?** `falcor-build-approval-gate`'s entire purpose is to stop PR-controlled
code from reaching Falcor compute without a human or allowlisted-bot look. A `schedule`-triggered
run's code is never PR-controlled — GitHub Actions resolves the on-disk workflow file for a
`schedule` event from the repository's default branch only (documented behavior; this is also
already relied on by `nightly-slang-test.yml`, `nightly-remix-test.yml`, and the other `nightly-*`
workflows checking out `master` without any equivalent gate). So skipping the gate here is the
correct, principled shape for this trigger, not a special-case workaround: applying the gate
would be reusing a mechanism outside the exact class of input it was built to police.

**Concurrency group + `cancel-in-progress`.** Matches every other `nightly-*` workflow's pattern
(`${{ github.workflow }}-${{ github.ref }}`), so a manual `workflow_dispatch` re-run replaces
rather than queues behind an in-flight scheduled run.

**Notify job scoped to `github.event_name == 'schedule'`.** Manual `workflow_dispatch` runs (used
to verify the workflow itself) stay quiet, matching `nightly-slang-test.yml`'s existing rationale
comment for the same guard.