### PR TITLE
Select initial MSVC tools from the runner architecture

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -47,10 +47,11 @@ runs:
       with:
         # No arch input defaults to the x64-hosted, x64-target compiler
         # regardless of host architecture, so a native arm64 host would
-        # silently build under x64 emulation. Force arm64 on native arm64
-        # Windows hosts; every other Windows platform in the current matrix
-        # (x86_64 only — no 32-bit x86 caller exists) falls back to x64.
-        arch: ${{ (inputs.os == 'windows' && inputs.platform == 'aarch64') && 'arm64' || 'x64' }}
+        # silently build under x64 emulation. Select this initial toolchain
+        # from the runner's host architecture, not the requested target:
+        # release jobs use it to build host generators before switching to
+        # their explicit cross-compilation toolchain.
+        arch: ${{ (inputs.os == 'windows' && runner.arch == 'ARM64') && 'arm64' || 'x64' }}
 
     - name: Install dependencies (Linux only)
       if: inputs.os == 'linux'


### PR DESCRIPTION
## Motivation

Consider the Windows ARM64 entry in the release workflow. It runs on an x64
`windows-latest` host, first builds generators that must run on that host, and only then switches to
the `amd64_arm64` toolchain to cross-compile the release binaries.

`common-setup` currently selects native ARM64 MSVC whenever the requested target platform is
`aarch64`. That gives the x64 release runner an ARM64-hosted compiler before it builds the host
generators. In release validation run
[33188646072](https://github.com/shader-slang/slang/actions/runs/33188646072/job/98908130989),
`VSCMD_ARG_HOST_ARCH` was consequently `arm64`, and CMake failed with `Could not find the compiler
specified in the environment variable CC: cl`. The two preceding validation runs failed the same
way.

## Proposed solution

Select the initial MSVC environment from `runner.arch`, which is the source of truth for the host
that will execute the generators. An x64 release runner now starts with x64 MSVC and later switches
to its explicit `amd64_arm64` cross toolchain. A native ARM64 CI runner still starts with native
ARM64 MSVC.

## Change summary

- `.github/actions/common-setup/action.yml`: choose the initial MSVC architecture from the runner
  host architecture and document why release cross-compilation needs that distinction.

## Concepts and vocabulary

- **Host generators**: utilities built first and executed during the target build; they must match
  the runner architecture even when the final Slang binaries target another architecture.
- **`platform` vs. `runner.arch`**: `platform` is the requested output architecture, while
  `runner.arch` describes the machine executing the workflow.

## Process report

The exact failing shape is `runner.arch == X64` with `platform == aarch64`, produced by the Windows
ARM64 release matrix entry. `release.yml` calls `common-setup`, immediately runs the `generators`
CMake workflow, and only afterward invokes `msvc-dev-cmd` with `matrix.arch == amd64_arm64` for the
target build. The initial toolchain therefore belongs to the host-generator phase, not the target
phase.

The previous expression used `inputs.platform` as an accidental alternative spelling of the host
architecture. This change fixes that producer directly by using the existing GitHub runner context.
It does not add a release-only fallback or reconstruct architecture information elsewhere. Moving
the explicit cross-toolchain setup before the generator build was rejected because that would build
ARM64 generators that the x64 host cannot execute. Special-casing `release.yml` was also rejected
because `common-setup` is the single source of truth for the initial host toolchain.

Validation performed:

- repository-pinned `actionlint` v1.7.12 over all workflows;
- YAML parsing of the changed composite action;
- `git diff --check`;
- input-shape audit for x64-host/ARM64-target release jobs and native ARM64 CI jobs.

After this reaches `master`, the release workflow should be dispatched again to exercise the exact
regression path before creating a release tag.
