### PR TITLE
Preserve linkage on equality requirement keys

### DIFF
--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -12198,7 +12198,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                 // a *conformance* requirement: its witness is a witness table for the bound.
                 // We must lower it with a `WitnessTableType` requirement value, because
                 // consumers of associated-type bounds read the witness-table entry for the bound.
-                // Equality constraints are handled by the generic path below.
+                // Equality constraints are handled separately below.
                 auto genericParent =
                     as<GenericDecl>(relocatedSubtypeConstraint.getDecl()->parentDecl);
                 if (genericParent && genericParent->inner != relocatedSubtypeConstraint.getDecl())
@@ -12247,6 +12247,32 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                         getSup(subContext->astBuilder, relocatedSubtypeConstraint));
                     entry->setRequirementVal(subBuilder->getWitnessTableType(irBaseType));
                 }
+            }
+            else if (
+                relocatedSubtypeConstraint &&
+                relocatedSubtypeConstraint.getDecl()->isEqualityConstraint)
+            {
+                // Equality constraints deliberately keep the representation created above.
+                //
+                // Consider this example:
+                //
+                //     interface IScalar
+                //     {
+                //         associatedtype Mask;
+                //         __constraint Mask == bool;
+                //     }
+                //
+                // An equality constraint lowers to its interface requirement key, and its witness
+                // table entry carries the corresponding `TypeEqualityWitness`. Unlike a method,
+                // the interface requirement entry has no separate requirement value or type.
+                //
+                // The generic path below calls `removeLinkageDecorations` on a requirement value.
+                // For an equality constraint that value would be the requirement key itself. Its
+                // linkage is the stable identity used to defer and retrieve witness-table entries
+                // during linking, so removing it makes multiple equality keys collide under an
+                // empty mangled name. Leave the entry's value null and preserve the key's linkage.
+                SLANG_ASSERT(!entry->getRequirementVal());
+                SLANG_RELEASE_ASSERT(requirementKey->findDecoration<IRLinkageDecoration>());
             }
             else
             {

--- a/tests/language-feature/interfaces/gh-12817.slang
+++ b/tests/language-feature/interfaces/gh-12817.slang
@@ -1,0 +1,103 @@
+// Regression test for https://github.com/shader-slang/slang/issues/12817.
+//
+// An equality constraint is represented by a named interface requirement key with no separate
+// requirement value. Interface lowering previously removed the key's linkage decoration as if
+// the key were a method's requirement value. Two equality constraints therefore collided under
+// an empty mangled name when a generic conformance was linked.
+
+//TEST:SIMPLE: -target hlsl -entry computeMain -stage compute -conformance "ScalarValue:IScalar=0" -o gh-12817.hlsl
+//TEST:SIMPLE: -target spirv -entry computeMain -stage compute -conformance "ScalarValue:IScalar=0" -o gh-12817.spv
+//TEST:SIMPLE: -target cpp -entry computeMain -stage compute -conformance "ScalarValue:IScalar=0" -o gh-12817.cpp
+//TEST:INTERPRET(filecheck=CHECK): -entry interpretMain
+
+interface IShaped
+{
+    associatedtype Scalar;
+    associatedtype Mask;
+}
+
+interface IAggregate : IShaped
+{
+    __constraint Scalar : IScalar;
+}
+
+interface IScalar : IAggregate
+{
+    __constraint Scalar == This;
+    __constraint Mask == bool;
+
+    int getValue();
+}
+
+struct ScalarValue : IScalar
+{
+    typealias Scalar = This;
+    typealias Mask = bool;
+
+    int value;
+    int getValue() { return value; }
+}
+
+struct AggregateValue<S : IScalar> : IAggregate
+{
+    typealias Scalar = S;
+    typealias Mask = bool;
+}
+
+T identity<T : IAggregate>(T value)
+{
+    return value;
+}
+
+T.Scalar asScalar<T : IScalar>(T value)
+{
+    return value;
+}
+
+T asValue<T : IScalar>(T.Scalar value)
+{
+    return value;
+}
+
+T.Mask asMask<T : IScalar>(bool value)
+{
+    return value;
+}
+
+bool asBool<T : IScalar>(T.Mask value)
+{
+    return value;
+}
+
+int readScalar(IScalar value)
+{
+    return value.getValue();
+}
+
+void interpretMain()
+{
+    AggregateValue<ScalarValue> aggregate;
+    aggregate = identity<AggregateValue<ScalarValue>>(aggregate);
+
+    ScalarValue value;
+    value.value = 23;
+    ScalarValue roundTripValue = asValue<ScalarValue>(asScalar<ScalarValue>(value));
+    bool roundTripMask = asBool<ScalarValue>(asMask<ScalarValue>(true));
+
+    // CHECK: 23 1
+    printf("%d %d\n", roundTripValue.value, roundTripMask ? 1 : 0);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    AggregateValue<ScalarValue> value;
+    value = identity<AggregateValue<ScalarValue>>(value);
+
+    ScalarValue scalar;
+    scalar.value = 23;
+    IScalar dynamicScalar =
+        createDynamicObject<IScalar, ScalarValue>(dispatchThreadID.x, scalar);
+    int dynamicValue = readScalar(dynamicScalar);
+}


### PR DESCRIPTION
## Motivation

Consider this interface hierarchy:

```slang
interface IScalar : IAggregate
{
    __constraint Scalar == This;
    __constraint Mask == bool;
}

struct AggregateValue<S : IScalar> : IAggregate
{
    typealias Scalar = S;
    typealias Mask = bool;
}
```

Specializing a generic operation for `AggregateValue<ScalarValue>` aborts during target linking because the two equality-requirement witness entries collide under an empty mangled name.

Closes #12817.

## Proposed solution

Treat interface-level equality constraints as the representation they already use elsewhere in the compiler: a named requirement key with no separate interface requirement value.
Preserve the key's linkage when constructing the interface entry, and let concrete conformances continue to provide `TypeEqualityWitness` values.

This fixes the malformed IR at its producer.
The linker remains simple and continues to assume that ordinary requirement keys have stable mangled identities.

## Change summary

- Preserve linkage on equality-constraint requirement keys during interface lowering.
- Assert that equality entries retain their canonical null value and that their keys retain linkage.
- Add a minimized regression that reproduces generic witness-table linking through HLSL and SPIR-V, exercises C++ existential dispatch, and checks both equality witnesses at runtime with `INTERPRET` and FileCheck.

## Concepts and vocabulary

- **Requirement key** — the stable identity used to match an interface requirement with entries in concrete witness tables.
- **Requirement value** — the type or declaration stored on an interface entry for requirements such as methods, associated types, and subtype-conformance constraints.
- **Equality witness** — a `TypeEqualityWitness` stored in a concrete witness table to establish that the two types named by an equality requirement are identical.

## Process report

`getInterfaceRequirementKey()` creates each ordinary equality requirement as a distinct IR key and adds its linkage decoration.
`visitGenericTypeConstraintDecl()` returns that key when lowering an interface-level equality constraint.

`visitInterfaceDecl()` previously passed the returned instruction through its generic requirement-value path.
That path calls `removeLinkageDecorations()` because method requirement values do not need their own exported names and duplicate names prevent DCE.
For an equality constraint, however, the returned instruction is the requirement key itself.
Removing linkage from the presumed value therefore destroyed the key's stable identity.

The interface entry still received a null value, and concrete witness tables still contained the correct `TypeEqualityWitness` values.
During target linking, `cloneWitnessTableImpl()` deferred both concrete equality entries in a dictionary keyed by `getMangledName(entry->getRequirementKey())`.
Both malformed keys produced the empty name, so the second insertion triggered the duplicate-key assertion.

The new equality-constraint branch preserves the key created by `getInterfaceRequirementKey()` and leaves the interface entry's already-null value unchanged.
This is the canonical input shape: equality requirements have a named key, no separate interface requirement value, and a `TypeEqualityWitness` in each concrete conformance.
Assertions at that producer boundary enforce both parts of the representation so a future lowering change cannot silently recreate the collision.

The regression keeps the original HLSL and SPIR-V compile paths that reproduce the linker failure.
Its C++ lane constructs `IScalar` with `createDynamicObject` and a runtime type ID, then passes that genuinely dynamic existential through `readScalar(IScalar)`. This keeps the null-valued equality entry live until dynamic-interface lowering and verifies that the canonical shape is lowered before C++ interface emission.
Its `interpretMain` entry additionally converts values through `Scalar == This` and `Mask == bool` in both directions, then FileChecks the resulting `23 1` output.
Together these paths verify that preserving two distinct keys resolves each equality witness correctly rather than merely avoiding the duplicate-key assertion.

A linker-side fallback that eagerly cloned every nameless key was rejected.
Builtin requirement keys are intentionally anonymous and already receive that treatment; ordinary equality keys are not.
Extending that exception would conceal this lowering invariant violation and could mask future producers that accidentally strip ordinary key linkage.

Validation:

- Debug `slangc` and `slangi` targets build from the updated head.
- The fresh `slangc` compiles the regression to HLSL, SPIR-V, and C++.
- The fresh `slangi -entry interpretMain` run prints `23 1`.
- `slang-test tests/language-feature/interfaces/gh-12817` passes all three locally available compile cases; the local shared harness lacks its interpreter backend, which was exercised directly with the newly built `slangi` above.