### PR TITLE
Deprecate generic parameter count overload ranking

### DIFF
--- a/docs/user-guide/11-language-version.md
+++ b/docs/user-guide/11-language-version.md
@@ -65,9 +65,18 @@ Slang language version 2026 brings these changes on top of Slang 2025:
 Slang language version 202c brings these changes on top of Slang 2026:
 
 - The generic-parameter-count overload tie-breaker has been removed.
-  In earlier language versions, when all ordinary ranking rules left generic overloads tied, Slang selected the candidate with fewer required generic parameters and emitted a deprecation warning.
-  When the current compiler operates in a pre-202c mode, ordinary rules such as scope and `OverloadRank` run first and may silently select a different candidate than an older compiler selected.
-  The warning is emitted only when every ordinary rule leaves the candidates tied and the generic-parameter-count fallback then selects a unique candidate.
+  Older compilers treated required generic-parameter count as an ordinary ranking rule and
+  preferred the candidate with fewer required parameters at that fixed point in overload
+  resolution.
+  When the current compiler operates in a pre-202c language mode, ordinary rules such as scope and
+  `OverloadRank` run first.
+  Only when every ordinary rule leaves the candidates tied does it use generic-parameter count as a
+  compatibility fallback and emit a deprecation warning if that fallback selects a unique
+  candidate.
+  This reordering can silently select a different candidate than an older compiler when an ordinary
+  rule now resolves the call before the compatibility fallback is reached.
+  The warning is diagnostic `40021`; suppress it with `-warnings-disable 40021` or promote it to an
+  error with `-warnings-as-errors 40021`.
   Such a call is ambiguous in Slang 202c unless another ranking rule distinguishes the candidates.
   A non-generic overload is more specific than an otherwise-equivalent specialization of a
   generic, including when all of the generic parameters have defaults; that ordinary rule applies

--- a/docs/user-guide/11-language-version.md
+++ b/docs/user-guide/11-language-version.md
@@ -66,6 +66,7 @@ Slang language version 202c brings these changes on top of Slang 2026:
 
 - The generic-parameter-count overload tie-breaker has been removed.
   In earlier language versions, when all ordinary ranking rules left generic overloads tied, Slang selected the candidate with fewer required generic parameters and emitted a deprecation warning.
+  Those earlier versions now apply the compatibility tie-breaker only after ordinary rules such as scope and `OverloadRank`, so an ordinary rule can select a different candidate than older compilers selected without emitting this warning.
   Such a call is ambiguous in Slang 202c unless another ranking rule distinguishes the candidates.
 - Casting a literal `0` to a user-defined struct type (e.g., `(MyStruct)0`) has lost its special meaning, and
   it is now a regular conversion. To maintain the previous semantics, a constructor call with no arguments can

--- a/docs/user-guide/11-language-version.md
+++ b/docs/user-guide/11-language-version.md
@@ -68,6 +68,7 @@ Slang language version 202c brings these changes on top of Slang 2026:
   In earlier language versions, when all ordinary ranking rules left generic overloads tied, Slang selected the candidate with fewer required generic parameters and emitted a deprecation warning.
   Those earlier versions now apply the compatibility tie-breaker only after ordinary rules such as scope and `OverloadRank`, so an ordinary rule can select a different candidate than older compilers selected without emitting this warning.
   Such a call is ambiguous in Slang 202c unless another ranking rule distinguishes the candidates.
+  A non-generic overload remains more specific than an otherwise-equivalent specialization of a generic; that ordinary rule is unchanged in Slang 202c.
 - Casting a literal `0` to a user-defined struct type (e.g., `(MyStruct)0`) has lost its special meaning, and
   it is now a regular conversion. To maintain the previous semantics, a constructor call with no arguments can
   be used instead (e.g., `MyStruct()`). See GitHub issue

--- a/docs/user-guide/11-language-version.md
+++ b/docs/user-guide/11-language-version.md
@@ -64,6 +64,9 @@ Slang language version 2026 brings these changes on top of Slang 2025:
 
 Slang language version 202c brings these changes on top of Slang 2026:
 
+- The generic-parameter-count overload tie-breaker has been removed.
+  In earlier language versions, when all ordinary ranking rules left generic overloads tied, Slang selected the candidate with fewer required generic parameters and emitted a deprecation warning.
+  Such a call is ambiguous in Slang 202c unless another ranking rule distinguishes the candidates.
 - Casting a literal `0` to a user-defined struct type (e.g., `(MyStruct)0`) has lost its special meaning, and
   it is now a regular conversion. To maintain the previous semantics, a constructor call with no arguments can
   be used instead (e.g., `MyStruct()`). See GitHub issue

--- a/docs/user-guide/11-language-version.md
+++ b/docs/user-guide/11-language-version.md
@@ -66,7 +66,8 @@ Slang language version 202c brings these changes on top of Slang 2026:
 
 - The generic-parameter-count overload tie-breaker has been removed.
   In earlier language versions, when all ordinary ranking rules left generic overloads tied, Slang selected the candidate with fewer required generic parameters and emitted a deprecation warning.
-  Those earlier versions now apply the compatibility tie-breaker only after ordinary rules such as scope and `OverloadRank`, so an ordinary rule can select a different candidate than older compilers selected without emitting this warning.
+  When the current compiler operates in a pre-202c mode, ordinary rules such as scope and `OverloadRank` run first and may silently select a different candidate than an older compiler selected.
+  The warning is emitted only when every ordinary rule leaves the candidates tied and the generic-parameter-count fallback then selects a unique candidate.
   Such a call is ambiguous in Slang 202c unless another ranking rule distinguishes the candidates.
   A non-generic overload remains more specific than an otherwise-equivalent specialization of a generic; that ordinary rule is unchanged in Slang 202c.
 - Casting a literal `0` to a user-defined struct type (e.g., `(MyStruct)0`) has lost its special meaning, and

--- a/docs/user-guide/11-language-version.md
+++ b/docs/user-guide/11-language-version.md
@@ -69,7 +69,9 @@ Slang language version 202c brings these changes on top of Slang 2026:
   When the current compiler operates in a pre-202c mode, ordinary rules such as scope and `OverloadRank` run first and may silently select a different candidate than an older compiler selected.
   The warning is emitted only when every ordinary rule leaves the candidates tied and the generic-parameter-count fallback then selects a unique candidate.
   Such a call is ambiguous in Slang 202c unless another ranking rule distinguishes the candidates.
-  A non-generic overload remains more specific than an otherwise-equivalent specialization of a generic; that ordinary rule is unchanged in Slang 202c.
+  A non-generic overload is more specific than an otherwise-equivalent specialization of a
+  generic, including when all of the generic parameters have defaults; that ordinary rule applies
+  in every language version.
 - Casting a literal `0` to a user-defined struct type (e.g., `(MyStruct)0`) has lost its special meaning, and
   it is now a regular conversion. To maintain the previous semantics, a constructor call with no arguments can
   be used instead (e.g., `MyStruct()`). See GitHub issue

--- a/source/slang/glsl.meta.slang
+++ b/source/slang/glsl.meta.slang
@@ -225,30 +225,6 @@ public in float2 gl_SamplePosition : SV_VulkanSamplePosition;
 
 // Override operator* behavior to compute algebric product of matrices and vectors.
 
-[OverloadRank(15)]
-[ForceInline]
-[require(cpp_cuda_glsl_hlsl_spirv_llvm, sm_4_0_version)]
-public matrix<float, N, N> operator*<let N:int>(matrix<float, N, N> m1, matrix<float, N, N> m2)
-{
-    return mul(m2, m1);
-}
-
-[OverloadRank(15)]
-[ForceInline]
-[require(cpp_cuda_glsl_hlsl_spirv_llvm, sm_4_0_version)]
-public matrix<half, N, N> operator*<let N:int>(matrix<half, N, N> m1, matrix<half, N, N> m2)
-{
-    return mul(m2, m1);
-}
-
-[OverloadRank(15)]
-[ForceInline]
-[require(cpp_cuda_glsl_hlsl_spirv_llvm, sm_4_0_version)]
-public matrix<double, N, N> operator*<let N:int>(matrix<double, N, N> m1, matrix<double, N, N> m2)
-{
-    return mul(m2, m1);
-}
-
 [ForceInline]
 [OverloadRank(15)]
 [require(cpp_cuda_glsl_hlsl_spirv_llvm, sm_4_0_version)]
@@ -357,22 +333,6 @@ public bool operator!=<T:__BuiltinArithmeticType, let N:int>(vector<T, N> left, 
 [ForceInline]
 [OverloadRank(14)]
 [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm)]
-public bool operator==<T:__BuiltinFloatingPointType, let N:int>(vector<T, N> left, vector<T, N> right)
-{
-    return all(equal(left, right));
-}
-
-[ForceInline]
-[OverloadRank(14)]
-[require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm)]
-public bool operator!=<T:__BuiltinFloatingPointType, let N:int>(vector<T, N> left, vector<T, N> right)
-{
-    return any(notEqual(left, right));
-}
-
-[ForceInline]
-[OverloadRank(14)]
-[require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm)]
 public bool operator==<T:__BuiltinLogicalType, let N:int>(vector<T, N> left, vector<T, N> right)
 {
     return all(equal(left, right));
@@ -385,30 +345,6 @@ public bool operator!=<T:__BuiltinLogicalType, let N:int>(vector<T, N> left, vec
 {
     return any(notEqual(left, right));
 }
-
-${
-for (auto type : kBaseTypes) {
-    char const* typeName = type.name;
-    if (!type.flags) continue;
-$}
-[ForceInline]
-[OverloadRank(15)]
-[require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm)]
-public bool operator==<let N:int>(vector<$(typeName), N> left, vector<$(typeName), N> right)
-{
-    return all(equal(left, right));
-}
-
-[ForceInline]
-[OverloadRank(15)]
-[require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm)]
-public bool operator!=<let N:int>(vector<$(typeName), N> left, vector<$(typeName), N> right)
-{
-    return any(notEqual(left, right));
-}
-${
-}
-$}
 
 /// Array length
 __generic<T, let N : int>

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -2634,6 +2634,17 @@ bool SemanticsVisitor::_coerce(
         AddTypeOverloadCandidates(toType, overloadContext);
     }
 
+    bool usedLegacyGenericParameterCount =
+        tryResolveOverloadUsingLegacyGenericParameterCount(overloadContext);
+    // Cost probes call `_coerce` without asking it to construct an expression. Apply the
+    // compatibility rule during a probe so its cost remains usable, but wait until the conversion
+    // is reified before warning at the source expression.
+    if (usedLegacyGenericParameterCount && outToExpr && sink)
+    {
+        sink->diagnose(Diagnostics::DeprecatedGenericParameterCountOverloadTieBreaker{
+            .location = overloadContext.loc});
+    }
+
     // After all of the overload candidates have been added
     // to the context and processed, we need to see whether
     // there was one best overload or not.
@@ -2936,8 +2947,10 @@ bool SemanticsVisitor::_coerce(
 
             // TODO: Register associated differentiable methods & types here as well.
         }
-        if (!cachedMethod)
+        if (!cachedMethod && !usedLegacyGenericParameterCount)
         {
+            // Do not cache a compatibility-selected conversion during a cost probe. The later
+            // source-level conversion must resolve it again so that it can emit the warning above.
             // We can only cache the method if it is a public, otherwise we may not be able to
             // use this method depending on where we are performing the coercion.
             if (overloadContext.bestCandidate->item.declRef &&

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -2634,18 +2634,15 @@ bool SemanticsVisitor::_coerce(
         AddTypeOverloadCandidates(toType, overloadContext);
     }
 
-    bool usedLegacyGenericParameterCountFallback =
-        tryResolveOverloadUsingLegacyGenericParameterCountFallback(overloadContext);
     // `canCoerce` performs a speculative cost probe by passing a null `outToExpr`; materialized
     // conversions pass storage for the result. Apply the legacy compatibility fallback in both
-    // cases, but warn only for a materialized conversion with a diagnostic sink. A null sink
-    // explicitly requests a non-diagnostic operation, so there is nowhere to report the
-    // deprecation.
-    if (usedLegacyGenericParameterCountFallback && outToExpr && sink)
-    {
-        sink->diagnose(Diagnostics::DeprecatedGenericParameterCountOverloadTieBreaker{
-            .location = overloadContext.loc});
-    }
+    // cases, but supply the sink only for a materialized conversion. A null sink explicitly
+    // requests a non-diagnostic operation, so there is nowhere to report the deprecation.
+    bool usedLegacyGenericParameterCountFallback =
+        tryResolveOverloadUsingLegacyGenericParameterCountFallback(
+            overloadContext,
+            overloadContext.loc,
+            outToExpr ? sink : nullptr);
 
     // After all of the overload candidates have been added
     // to the context and processed, we need to see whether

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -2634,13 +2634,14 @@ bool SemanticsVisitor::_coerce(
         AddTypeOverloadCandidates(toType, overloadContext);
     }
 
-    bool usedLegacyGenericParameterCount =
-        tryResolveOverloadUsingLegacyGenericParameterCount(overloadContext);
+    bool usedLegacyGenericParameterCountFallback =
+        tryResolveOverloadUsingLegacyGenericParameterCountFallback(overloadContext);
     // `canCoerce` performs a speculative cost probe by passing a null `outToExpr`; materialized
-    // conversions pass storage for the result. Apply the compatibility rule in both cases, but
-    // warn only for a materialized conversion with a diagnostic sink. A null sink explicitly
-    // requests a non-diagnostic operation, so there is nowhere to report the deprecation.
-    if (usedLegacyGenericParameterCount && outToExpr && sink)
+    // conversions pass storage for the result. Apply the legacy compatibility fallback in both
+    // cases, but warn only for a materialized conversion with a diagnostic sink. A null sink
+    // explicitly requests a non-diagnostic operation, so there is nowhere to report the
+    // deprecation.
+    if (usedLegacyGenericParameterCountFallback && outToExpr && sink)
     {
         sink->diagnose(Diagnostics::DeprecatedGenericParameterCountOverloadTieBreaker{
             .location = overloadContext.loc});
@@ -2948,10 +2949,11 @@ bool SemanticsVisitor::_coerce(
 
             // TODO: Register associated differentiable methods & types here as well.
         }
-        if (!cachedMethod && !usedLegacyGenericParameterCount)
+        if (!cachedMethod && !usedLegacyGenericParameterCountFallback)
         {
-            // Do not cache a compatibility-selected conversion during a cost probe. The later
-            // source-level conversion must resolve it again so that it can emit the warning above.
+            // Never cache a conversion selected by the legacy compatibility fallback. A cost probe
+            // must not hide a later source-level warning, and every materialized source occurrence
+            // must resolve and report its own use of the deprecated rule.
             // We can only cache the method if it is a public, otherwise we may not be able to
             // use this method depending on where we are performing the coercion.
             if (overloadContext.bestCandidate->item.declRef &&

--- a/source/slang/slang-check-conversion.cpp
+++ b/source/slang/slang-check-conversion.cpp
@@ -2636,9 +2636,10 @@ bool SemanticsVisitor::_coerce(
 
     bool usedLegacyGenericParameterCount =
         tryResolveOverloadUsingLegacyGenericParameterCount(overloadContext);
-    // Cost probes call `_coerce` without asking it to construct an expression. Apply the
-    // compatibility rule during a probe so its cost remains usable, but wait until the conversion
-    // is reified before warning at the source expression.
+    // `canCoerce` performs a speculative cost probe by passing a null `outToExpr`; materialized
+    // conversions pass storage for the result. Apply the compatibility rule in both cases, but
+    // warn only for a materialized conversion with a diagnostic sink. A null sink explicitly
+    // requests a non-diagnostic operation, so there is nowhere to report the deprecation.
     if (usedLegacyGenericParameterCount && outToExpr && sink)
     {
         sink->diagnose(Diagnostics::DeprecatedGenericParameterCountOverloadTieBreaker{

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -351,14 +351,12 @@ static bool isAssociatedTypeDecl(Decl* decl)
 
 bool isSlang2026OrLater(SemanticsVisitor* visitor)
 {
-    return visitor->getShared()->m_module->getModuleDecl()->languageVersion >=
-           SLANG_LANGUAGE_VERSION_2026;
+    return visitor->getShared()->getLanguageVersion() >= SLANG_LANGUAGE_VERSION_2026;
 }
 
 bool isSlang202cOrLater(SemanticsVisitor* visitor)
 {
-    return visitor->getShared()->m_module->getModuleDecl()->languageVersion >=
-           SLANG_LANGUAGE_VERSION_202C;
+    return visitor->getShared()->getLanguageVersion() >= SLANG_LANGUAGE_VERSION_202C;
 }
 
 static bool allowExperimentalDynamicDispatch(

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -3405,6 +3405,10 @@ public:
     // so that the better candidate compares as less-than the other
     int CompareOverloadCandidates(OverloadCandidate* left, OverloadCandidate* right);
 
+    /// Applies the pre-202c generic-parameter-count tie-breaker after all ordinary ranking rules.
+    /// Returns true only when the compatibility rule selects a unique candidate.
+    bool tryResolveOverloadUsingLegacyGenericParameterCount(OverloadResolveContext& context);
+
     /// If `declRef` representations a specialization of a generic, returns the number of
     /// specialized generic arguments. Otherwise, returns zero.
     ///

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -955,9 +955,7 @@ public:
         Linkage* linkage,
         SlangLanguageVersion languageVersion,
         DiagnosticSink* sink)
-        : m_linkage(linkage)
-        , m_languageVersion(languageVersion)
-        , m_sink(sink)
+        : m_linkage(linkage), m_languageVersion(languageVersion), m_sink(sink)
     {
         SLANG_RELEASE_ASSERT(languageVersion != SLANG_LANGUAGE_VERSION_UNKNOWN);
     }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -3459,10 +3459,10 @@ public:
     /// On failure, leaves `context` unchanged and returns false.
     ///
     /// The final source-level call sites are `ResolveInvoke` and `_coerce`. A caller must emit the
-    /// deprecation warning when this returns true and it is materializing a source-level expression.
-    /// `ResolveInvoke` always materializes; `_coerce` does so only when it receives both `outToExpr`
-    /// and `sink`. A speculative conversion-cost probe must stay silent and let the eventual
-    /// materialization warn. Any new caller must follow the same policy.
+    /// deprecation warning when this returns true and it is materializing a source-level
+    /// expression. `ResolveInvoke` always materializes; `_coerce` does so only when it receives
+    /// both `outToExpr` and `sink`. A speculative conversion-cost probe must stay silent and let
+    /// the eventual materialization warn. Any new caller must follow the same policy.
     bool tryResolveOverloadUsingLegacyGenericParameterCountFallback(
         OverloadResolveContext& context);
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1297,6 +1297,10 @@ public:
         }
     }
 
+    // This context stores a non-owning pointer. Reject a temporary owner so that its destruction
+    // cannot leave `m_shared` dangling; callers with a `RefPtr` must keep that owner in a local.
+    SemanticsContext(RefPtr<SharedSemanticsContext>&&) = delete;
+
     SharedSemanticsContext* getShared() { return m_shared; }
     CompilerOptionSet& getOptionSet() { return getShared()->getOptionSet(); }
     ASTBuilder* getASTBuilder() { return m_astBuilder; }
@@ -1642,6 +1646,9 @@ struct SemanticsVisitor : public SemanticsContext
         : Super(shared)
     {
     }
+
+    // Keep direct visitor construction subject to the ownership rule on `SemanticsContext`.
+    SemanticsVisitor(RefPtr<SharedSemanticsContext>&&) = delete;
 
     SemanticsVisitor(SemanticsContext const& context)
         : Super(context)
@@ -3451,9 +3458,11 @@ public:
     /// `context.bestCandidate` at that storage, clears `context.bestCandidates`, and returns true.
     /// On failure, leaves `context` unchanged and returns false.
     ///
-    /// The final source-level callers, `ResolveInvoke` and `_coerce`, must emit the deprecation
-    /// warning when this returns true. Speculative conversion-cost probes must defer the warning
-    /// until they materialize the conversion. Any new caller must follow the same policy.
+    /// The final source-level call sites are `ResolveInvoke` and `_coerce`. A caller must emit the
+    /// deprecation warning when this returns true and it is materializing a source-level expression.
+    /// `ResolveInvoke` always materializes; `_coerce` does so only when it receives both `outToExpr`
+    /// and `sink`. A speculative conversion-cost probe must stay silent and let the eventual
+    /// materialization warn. Any new caller must follow the same policy.
     bool tryResolveOverloadUsingLegacyGenericParameterCountFallback(
         OverloadResolveContext& context);
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -965,19 +965,19 @@ public:
         SLANG_RELEASE_ASSERT(languageVersion != SLANG_LANGUAGE_VERSION_UNKNOWN);
     }
 
-    /// Creates a context for a producer where the primary module is legitimately optional.
+    /// Creates a context for an ad hoc checking operation whose primary module may be absent.
     ///
-    /// A present module supplies the source language policy. Otherwise, the producer must provide
-    /// the language version that applies to its ad hoc checking operation.
+    /// A present module supplies the source-language policy and the moduleless version is ignored.
+    /// Otherwise, the caller must provide the version for the ad hoc operation.
     static RefPtr<SharedSemanticsContext> createForOptionalModule(
         Linkage* linkage,
         Module* module,
-        SlangLanguageVersion fallbackLanguageVersion,
+        SlangLanguageVersion modulelessLanguageVersion,
         DiagnosticSink* sink)
     {
         if (module)
             return new SharedSemanticsContext(linkage, module, sink);
-        return new SharedSemanticsContext(linkage, fallbackLanguageVersion, sink);
+        return new SharedSemanticsContext(linkage, modulelessLanguageVersion, sink);
     }
 
     Session* getSession() { return m_linkage->getSessionImpl(); }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -953,7 +953,8 @@ public:
         , m_sink(sink)
         , m_environmentModules(environmentModules)
         , m_translationUnitRequest(translationUnit)
-    {}
+    {
+    }
 
     SharedSemanticsContext(
         Linkage* linkage,

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -861,6 +861,13 @@ struct SharedSemanticsContext : public RefObject
     /// The (optional) "primary" module that is the parent to everything that will be checked.
     Module* m_module = nullptr;
 
+    /// The Slang language version whose rules apply to this checking session.
+    ///
+    /// Normal module checking derives this value from the primary module. Ad hoc checking that
+    /// has no primary module must instead choose a version explicitly when it constructs the
+    /// context.
+    SlangLanguageVersion m_languageVersion = SLANG_LANGUAGE_VERSION_UNKNOWN;
+
     DiagnosticSink* m_sink = nullptr;
 
     // Whether the current module has imported the GLSL module.
@@ -935,10 +942,24 @@ public:
         TranslationUnitRequest* translationUnit = nullptr)
         : m_linkage(linkage)
         , m_module(module)
+        , m_languageVersion(
+              module ? module->getModuleDecl()->languageVersion : SLANG_LANGUAGE_VERSION_UNKNOWN)
         , m_sink(sink)
         , m_environmentModules(environmentModules)
         , m_translationUnitRequest(translationUnit)
     {
+        SLANG_RELEASE_ASSERT(module);
+    }
+
+    SharedSemanticsContext(
+        Linkage* linkage,
+        SlangLanguageVersion languageVersion,
+        DiagnosticSink* sink)
+        : m_linkage(linkage)
+        , m_languageVersion(languageVersion)
+        , m_sink(sink)
+    {
+        SLANG_RELEASE_ASSERT(languageVersion != SLANG_LANGUAGE_VERSION_UNKNOWN);
     }
 
     Session* getSession() { return m_linkage->getSessionImpl(); }
@@ -946,6 +967,8 @@ public:
     Linkage* getLinkage() { return m_linkage; }
 
     Module* getModule() { return m_module; }
+
+    SlangLanguageVersion getLanguageVersion() const { return m_languageVersion; }
 
     TranslationUnitRequest* getTranslationUnitRequest() { return m_translationUnitRequest; }
 
@@ -3407,6 +3430,8 @@ public:
 
     /// Applies the pre-202c generic-parameter-count tie-breaker after all ordinary ranking rules.
     /// Returns true only when the compatibility rule selects a unique candidate.
+    /// A source-level caller that acts on a true result must emit the deprecation warning;
+    /// speculative cost probes defer that warning until they materialize the conversion.
     bool tryResolveOverloadUsingLegacyGenericParameterCount(OverloadResolveContext& context);
 
     /// If `declRef` representations a specialization of a generic, returns the number of

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -3447,9 +3447,13 @@ public:
     int CompareOverloadCandidates(OverloadCandidate* left, OverloadCandidate* right);
 
     /// Applies the pre-202c generic-parameter-count tie-breaker after all ordinary ranking rules.
-    /// Returns true only when the legacy compatibility fallback selects a unique candidate.
-    /// A source-level caller that acts on a true result must emit the deprecation warning;
-    /// speculative cost probes defer that warning until they materialize the conversion.
+    /// On success, moves the unique selected candidate into `context.bestCandidateStorage`, points
+    /// `context.bestCandidate` at that storage, clears `context.bestCandidates`, and returns true.
+    /// On failure, leaves `context` unchanged and returns false.
+    ///
+    /// The final source-level callers, `ResolveInvoke` and `_coerce`, must emit the deprecation
+    /// warning when this returns true. Speculative conversion-cost probes must defer the warning
+    /// until they materialize the conversion. Any new caller must follow the same policy.
     bool tryResolveOverloadUsingLegacyGenericParameterCountFallback(
         OverloadResolveContext& context);
 

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -933,6 +933,13 @@ public:
                m_isGLSLModuleImported;
     }
 
+private:
+    static SlangLanguageVersion _getModuleLanguageVersion(Module* module)
+    {
+        SLANG_RELEASE_ASSERT(module);
+        return module->getModuleDecl()->languageVersion;
+    }
+
 public:
     SharedSemanticsContext(
         Linkage* linkage,
@@ -942,14 +949,11 @@ public:
         TranslationUnitRequest* translationUnit = nullptr)
         : m_linkage(linkage)
         , m_module(module)
-        , m_languageVersion(
-              module ? module->getModuleDecl()->languageVersion : SLANG_LANGUAGE_VERSION_UNKNOWN)
+        , m_languageVersion(_getModuleLanguageVersion(module))
         , m_sink(sink)
         , m_environmentModules(environmentModules)
         , m_translationUnitRequest(translationUnit)
-    {
-        SLANG_RELEASE_ASSERT(module);
-    }
+    {}
 
     SharedSemanticsContext(
         Linkage* linkage,
@@ -958,6 +962,21 @@ public:
         : m_linkage(linkage), m_languageVersion(languageVersion), m_sink(sink)
     {
         SLANG_RELEASE_ASSERT(languageVersion != SLANG_LANGUAGE_VERSION_UNKNOWN);
+    }
+
+    /// Creates a context for a producer where the primary module is legitimately optional.
+    ///
+    /// A present module supplies the source language policy. Otherwise, the producer must provide
+    /// the language version that applies to its ad hoc checking operation.
+    static RefPtr<SharedSemanticsContext> createForOptionalModule(
+        Linkage* linkage,
+        Module* module,
+        SlangLanguageVersion fallbackLanguageVersion,
+        DiagnosticSink* sink)
+    {
+        if (module)
+            return new SharedSemanticsContext(linkage, module, sink);
+        return new SharedSemanticsContext(linkage, fallbackLanguageVersion, sink);
     }
 
     Session* getSession() { return m_linkage->getSessionImpl(); }

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -1298,7 +1298,8 @@ public:
     }
 
     // This context stores a non-owning pointer. Reject a temporary owner so that its destruction
-    // cannot leave `m_shared` dangling; callers with a `RefPtr` must keep that owner in a local.
+    // cannot leave `m_shared` dangling. An lvalue `RefPtr` intentionally reaches the raw-pointer
+    // constructor through its implicit conversion while the caller keeps that owner in a local.
     SemanticsContext(RefPtr<SharedSemanticsContext>&&) = delete;
 
     SharedSemanticsContext* getShared() { return m_shared; }
@@ -1647,7 +1648,8 @@ struct SemanticsVisitor : public SemanticsContext
     {
     }
 
-    // Keep direct visitor construction subject to the ownership rule on `SemanticsContext`.
+    // Keep direct visitor construction subject to the ownership rule on `SemanticsContext`; an
+    // lvalue `RefPtr` still reaches the raw-pointer constructor through its implicit conversion.
     SemanticsVisitor(RefPtr<SharedSemanticsContext>&&) = delete;
 
     SemanticsVisitor(SemanticsContext const& context)
@@ -3454,21 +3456,23 @@ public:
     int CompareOverloadCandidates(OverloadCandidate* left, OverloadCandidate* right);
 
     /// Applies the pre-202c generic-parameter-count tie-breaker after all ordinary ranking rules.
-    /// On success, moves the unique selected candidate into `context.bestCandidateStorage`, points
+    /// On success, copies the unique selected candidate into `context.bestCandidateStorage`, points
     /// `context.bestCandidate` at that storage, clears `context.bestCandidates`, and returns true.
+    /// When `warningSink` is non-null, also emits the deprecation warning at `warningLocation`.
     /// On failure, leaves `context` unchanged and returns false.
     ///
-    /// The final source-level call sites are `ResolveInvoke` and `_coerce`. A caller must emit the
-    /// deprecation warning when this returns true and it is materializing a source-level
-    /// expression. `ResolveInvoke` always materializes; `_coerce` does so only when it receives
-    /// both `outToExpr` and `sink`. A speculative conversion-cost probe must stay silent and let
-    /// the eventual materialization warn. Any new caller must follow the same policy.
+    /// The final source-level call sites are `ResolveInvoke` and `_coerce`. `ResolveInvoke` always
+    /// materializes an expression and passes its sink. `_coerce` passes its sink only when it also
+    /// receives `outToExpr`; a speculative conversion-cost probe passes null so that the eventual
+    /// materialization reports the warning.
     bool tryResolveOverloadUsingLegacyGenericParameterCountFallback(
-        OverloadResolveContext& context);
+        OverloadResolveContext& context,
+        SourceLoc warningLocation,
+        DiagnosticSink* warningSink);
 
-    /// Returns the number of required parameters on the generic specialized by `declRef`, or zero
-    /// when `declRef` is not the inner declaration of a generic.
-    Int getSpecializedParamCount(DeclRef<Decl> const& declRef);
+    /// Returns the required parameter count of the generic whose inner declaration `declRef`
+    /// names, or zero when `declRef` does not name a generic's inner declaration.
+    Int getRequiredGenericParameterCount(DeclRef<Decl> const& declRef);
 
     /// Compare items `left` and `right` produced by lookup, to see if one should be favored for
     /// overloading.

--- a/source/slang/slang-check-impl.h
+++ b/source/slang/slang-check-impl.h
@@ -3447,14 +3447,14 @@ public:
     int CompareOverloadCandidates(OverloadCandidate* left, OverloadCandidate* right);
 
     /// Applies the pre-202c generic-parameter-count tie-breaker after all ordinary ranking rules.
-    /// Returns true only when the compatibility rule selects a unique candidate.
+    /// Returns true only when the legacy compatibility fallback selects a unique candidate.
     /// A source-level caller that acts on a true result must emit the deprecation warning;
     /// speculative cost probes defer that warning until they materialize the conversion.
-    bool tryResolveOverloadUsingLegacyGenericParameterCount(OverloadResolveContext& context);
+    bool tryResolveOverloadUsingLegacyGenericParameterCountFallback(
+        OverloadResolveContext& context);
 
-    /// If `declRef` representations a specialization of a generic, returns the number of
-    /// specialized generic arguments. Otherwise, returns zero.
-    ///
+    /// Returns the number of required parameters on the generic specialized by `declRef`, or zero
+    /// when `declRef` is not the inner declaration of a generic.
     Int getSpecializedParamCount(DeclRef<Decl> const& declRef);
 
     /// Compare items `left` and `right` produced by lookup, to see if one should be favored for

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -2194,14 +2194,6 @@ int SemanticsVisitor::compareOverloadCandidateSpecificity(
     // to implement, but actually implementing that full check here
     // could make overload resolution far more expensive.
     //
-    // For now we are going to do something far simpler and hackier,
-    // which is to say that a candidate with more generic parameters
-    // is always preferred over one with fewer.
-    //
-    // TODO: We could extend this definition to account for constraints
-    // on generic parameters in the count, which would handle the
-    // need to prefer a more-constrained generic when possible.
-    //
     // TODO: In the long run we should clearly replace this with
     // the more general "does A being applicable imply B being applicable"
     // test.
@@ -2211,11 +2203,6 @@ int SemanticsVisitor::compareOverloadCandidateSpecificity(
     // in some cases disambiguation of which declaration should be
     // preferred will depend on knowing the actual arguments.
     //
-    auto leftSpecCount = getSpecializedParamCount(left.declRef);
-    auto rightSpecCount = getSpecializedParamCount(right.declRef);
-    if (leftSpecCount != rightSpecCount)
-        return int(leftSpecCount - rightSpecCount);
-
     return 0;
 }
 
@@ -2437,6 +2424,57 @@ int SemanticsVisitor::CompareOverloadCandidates(OverloadCandidate* left, Overloa
     }
 
     return 0;
+}
+
+bool SemanticsVisitor::tryResolveOverloadUsingLegacyGenericParameterCount(
+    OverloadResolveContext& context)
+{
+    if (isSlang202cOrLater(this) || context.bestCandidates.getCount() < 2 ||
+        context.bestCandidates[0].status != OverloadCandidate::Status::Applicable)
+    {
+        return false;
+    }
+
+    // Before Slang 202c, generic parameter count was used as a proxy for specificity. Consider
+    // this example:
+    //
+    //      int select<T>(vector<T, 3> value);
+    //      int select<T, let N : int>(vector<T, N> value);
+    //
+    // Given a `float3`, preferring fewer required generic parameters happens to choose the
+    // fixed-size overload. The proxy is not valid in general, though: constraints can make a
+    // declaration with more generic parameters applicable to a narrower set of arguments.
+    // `bestCandidates` contains exactly the candidates that remain tied after every ordinary
+    // ranking criterion, so applying the legacy rule here makes it the final compatibility
+    // fallback instead of allowing it to override a meaningful comparison such as `OverloadRank`.
+    Index bestCandidateIndex = 0;
+    Int bestGenericParameterCount =
+        getSpecializedParamCount(context.bestCandidates[bestCandidateIndex].item.declRef);
+    bool hasUniqueBestCandidate = true;
+
+    for (Index i = 1; i < context.bestCandidates.getCount(); ++i)
+    {
+        Int genericParameterCount =
+            getSpecializedParamCount(context.bestCandidates[i].item.declRef);
+        if (genericParameterCount < bestGenericParameterCount)
+        {
+            bestCandidateIndex = i;
+            bestGenericParameterCount = genericParameterCount;
+            hasUniqueBestCandidate = true;
+        }
+        else if (genericParameterCount == bestGenericParameterCount)
+        {
+            hasUniqueBestCandidate = false;
+        }
+    }
+
+    if (!hasUniqueBestCandidate)
+        return false;
+
+    context.bestCandidateStorage = context.bestCandidates[bestCandidateIndex];
+    context.bestCandidate = &context.bestCandidateStorage;
+    context.bestCandidates.clear();
+    return true;
 }
 
 void SemanticsVisitor::AddOverloadCandidateInner(
@@ -3463,6 +3501,12 @@ Expr* SemanticsVisitor::ResolveInvoke(InvokeExpr* expr)
     if (!context.bestCandidate && !typeOverloadChecked)
     {
         AddOverloadCandidates(funcExpr, context);
+    }
+
+    if (tryResolveOverloadUsingLegacyGenericParameterCount(context))
+    {
+        getSink()->diagnose(
+            Diagnostics::DeprecatedGenericParameterCountOverloadTieBreaker{.location = expr->loc});
     }
 
     if (context.bestCandidates.getCount() > 0)

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1834,7 +1834,7 @@ bool isInterfaceRequirement(ASTBuilder* builder, DeclRef<Decl> const& declRef)
 }
 
 /// Returns the parent generic when `declRef` names that generic's inner declaration.
-static DeclRef<GenericDecl> _getSpecializedGenericParent(DeclRef<Decl> const& declRef)
+static DeclRef<GenericDecl> _getGenericParentOfInnerDeclRef(DeclRef<Decl> const& declRef)
 {
     if (!declRef)
         return DeclRef<GenericDecl>();
@@ -1858,11 +1858,11 @@ static DeclRef<GenericDecl> _getSpecializedGenericParent(DeclRef<Decl> const& de
     return parentGeneric;
 }
 
-/// Returns the number of required parameters on the generic specialized by `declRef`.
-/// Returns zero when `declRef` is not the inner declaration of a generic.
-Int SemanticsVisitor::getSpecializedParamCount(DeclRef<Decl> const& declRef)
+/// Returns the required parameter count of the generic whose inner declaration `declRef` names.
+/// Returns zero when `declRef` does not name a generic's inner declaration.
+Int SemanticsVisitor::getRequiredGenericParameterCount(DeclRef<Decl> const& declRef)
 {
-    auto parentGeneric = _getSpecializedGenericParent(declRef);
+    auto parentGeneric = _getGenericParentOfInnerDeclRef(declRef);
     if (!parentGeneric)
         return 0;
 
@@ -2163,10 +2163,10 @@ int SemanticsVisitor::compareOverloadCandidateSpecificity(
     // does not. Preserve that semantic relationship as an ordinary ranking rule; unlike comparing
     // two generics' parameter counts, it is not a compatibility heuristic and remains valid in
     // Slang 202c.
-    bool leftIsSpecializedGeneric = _getSpecializedGenericParent(left.declRef) != nullptr;
-    bool rightIsSpecializedGeneric = _getSpecializedGenericParent(right.declRef) != nullptr;
-    if (leftIsSpecializedGeneric != rightIsSpecializedGeneric)
-        return int(leftIsSpecializedGeneric) - int(rightIsSpecializedGeneric);
+    bool leftIsGenericInnerDecl = _getGenericParentOfInnerDeclRef(left.declRef) != nullptr;
+    bool rightIsGenericInnerDecl = _getGenericParentOfInnerDeclRef(right.declRef) != nullptr;
+    if (leftIsGenericInnerDecl != rightIsGenericInnerDecl)
+        return int(leftIsGenericInnerDecl) - int(rightIsGenericInnerDecl);
 
     // A principled specificity comparison would determine whether one candidate's accepted
     // argument domain is a strict subset of the other's. Slang does not implement that comparison
@@ -2400,7 +2400,9 @@ int SemanticsVisitor::CompareOverloadCandidates(OverloadCandidate* left, Overloa
 }
 
 bool SemanticsVisitor::tryResolveOverloadUsingLegacyGenericParameterCountFallback(
-    OverloadResolveContext& context)
+    OverloadResolveContext& context,
+    SourceLoc warningLocation,
+    DiagnosticSink* warningSink)
 {
     if (isSlang202cOrLater(this) || context.bestCandidates.getCount() < 2)
     {
@@ -2411,6 +2413,8 @@ bool SemanticsVisitor::tryResolveOverloadUsingLegacyGenericParameterCountFallbac
     // candidates for which that comparison returns zero, so a frontier is homogeneous. A tied
     // frontier of failed candidates is useful for the ordinary overload diagnostic, but the
     // compatibility fallback must not turn one of those failures into a selected declaration.
+    // Every candidate in `bestCandidates` has the same status, so element zero represents the
+    // entire frontier.
     auto candidateStatus = context.bestCandidates[0].status;
     for (auto& candidate : context.bestCandidates)
         SLANG_ASSERT(candidate.status == candidateStatus);
@@ -2431,13 +2435,13 @@ bool SemanticsVisitor::tryResolveOverloadUsingLegacyGenericParameterCountFallbac
     // overriding a meaningful comparison such as `OverloadRank`.
     Index bestCandidateIndex = 0;
     Int bestGenericParameterCount =
-        getSpecializedParamCount(context.bestCandidates[bestCandidateIndex].item.declRef);
+        getRequiredGenericParameterCount(context.bestCandidates[bestCandidateIndex].item.declRef);
     bool hasUniqueBestCandidate = true;
 
     for (Index i = 1; i < context.bestCandidates.getCount(); ++i)
     {
         Int genericParameterCount =
-            getSpecializedParamCount(context.bestCandidates[i].item.declRef);
+            getRequiredGenericParameterCount(context.bestCandidates[i].item.declRef);
         if (genericParameterCount < bestGenericParameterCount)
         {
             bestCandidateIndex = i;
@@ -2456,6 +2460,11 @@ bool SemanticsVisitor::tryResolveOverloadUsingLegacyGenericParameterCountFallbac
     context.bestCandidateStorage = context.bestCandidates[bestCandidateIndex];
     context.bestCandidate = &context.bestCandidateStorage;
     context.bestCandidates.clear();
+    if (warningSink)
+    {
+        warningSink->diagnose(Diagnostics::DeprecatedGenericParameterCountOverloadTieBreaker{
+            .location = warningLocation});
+    }
     return true;
 }
 
@@ -3485,13 +3494,7 @@ Expr* SemanticsVisitor::ResolveInvoke(InvokeExpr* expr)
         AddOverloadCandidates(funcExpr, context);
     }
 
-    if (tryResolveOverloadUsingLegacyGenericParameterCountFallback(context))
-    {
-        // `ResolveInvoke` is final source-level resolution, never a speculative cost probe, so a
-        // successful legacy compatibility fallback always reports its deprecation here.
-        getSink()->diagnose(
-            Diagnostics::DeprecatedGenericParameterCountOverloadTieBreaker{.location = expr->loc});
-    }
+    tryResolveOverloadUsingLegacyGenericParameterCountFallback(context, expr->loc, getSink());
 
     if (context.bestCandidates.getCount() > 0)
     {

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -2404,7 +2404,8 @@ bool SemanticsVisitor::tryResolveOverloadUsingLegacyGenericParameterCountFallbac
         return false;
     }
 
-    // Candidate status is an ordinary ranking criterion, so a frontier is homogeneous. A tied
+    // `CompareOverloadCandidates` ranks status first, and `AddOverloadCandidateInner` retains only
+    // candidates for which that comparison returns zero, so a frontier is homogeneous. A tied
     // frontier of failed candidates is useful for the ordinary overload diagnostic, but the
     // compatibility fallback must not turn one of those failures into a selected declaration.
     auto candidateStatus = context.bestCandidates[0].status;

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -2429,10 +2429,18 @@ int SemanticsVisitor::CompareOverloadCandidates(OverloadCandidate* left, Overloa
 bool SemanticsVisitor::tryResolveOverloadUsingLegacyGenericParameterCount(
     OverloadResolveContext& context)
 {
-    if (isSlang202cOrLater(this) || context.bestCandidates.getCount() < 2 ||
-        context.bestCandidates[0].status != OverloadCandidate::Status::Applicable)
+    if (isSlang202cOrLater(this) || context.bestCandidates.getCount() < 2)
     {
         return false;
+    }
+
+    // `bestCandidates` normally contains candidates with the same status because candidate status
+    // is itself an ordinary ranking criterion. Check every candidate here instead of making that
+    // representation invariant part of the compatibility rule's contract.
+    for (auto& candidate : context.bestCandidates)
+    {
+        if (candidate.status != OverloadCandidate::Status::Applicable)
+            return false;
     }
 
     // Before Slang 202c, generic parameter count was used as a proxy for specificity. Consider

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -2163,8 +2163,8 @@ int SemanticsVisitor::compareOverloadCandidateSpecificity(
     // does not. Preserve that semantic relationship as an ordinary ranking rule; unlike comparing
     // two generics' parameter counts, it is not a compatibility heuristic and remains valid in
     // Slang 202c.
-    bool leftIsGenericInnerDecl = _getGenericParentOfInnerDeclRef(left.declRef) != nullptr;
-    bool rightIsGenericInnerDecl = _getGenericParentOfInnerDeclRef(right.declRef) != nullptr;
+    bool leftIsGenericInnerDecl = bool(_getGenericParentOfInnerDeclRef(left.declRef));
+    bool rightIsGenericInnerDecl = bool(_getGenericParentOfInnerDeclRef(right.declRef));
     if (leftIsGenericInnerDecl != rightIsGenericInnerDecl)
         return int(leftIsGenericInnerDecl) - int(rightIsGenericInnerDecl);
 

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -2404,14 +2404,14 @@ bool SemanticsVisitor::tryResolveOverloadUsingLegacyGenericParameterCountFallbac
         return false;
     }
 
-    // `bestCandidates` normally contains candidates with the same status because candidate status
-    // is itself an ordinary ranking criterion. Check every candidate here instead of making that
-    // representation invariant part of the legacy compatibility fallback's contract.
+    // Candidate status is an ordinary ranking criterion, so a frontier is homogeneous. A tied
+    // frontier of failed candidates is useful for the ordinary overload diagnostic, but the
+    // compatibility fallback must not turn one of those failures into a selected declaration.
+    auto candidateStatus = context.bestCandidates[0].status;
     for (auto& candidate : context.bestCandidates)
-    {
-        if (candidate.status != OverloadCandidate::Status::Applicable)
-            return false;
-    }
+        SLANG_ASSERT(candidate.status == candidateStatus);
+    if (candidateStatus != OverloadCandidate::Status::Applicable)
+        return false;
 
     // Before Slang 202c, generic parameter count was used as a proxy for specificity. Consider
     // this example:

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1833,13 +1833,11 @@ bool isInterfaceRequirement(ASTBuilder* builder, DeclRef<Decl> const& declRef)
     return false;
 }
 
-/// If `declRef` representations a specialization of a generic, returns the number of specialized
-/// generic arguments. Otherwise, returns zero.
-///
-Int SemanticsVisitor::getSpecializedParamCount(DeclRef<Decl> const& declRef)
+/// Returns the parent generic when `declRef` names that generic's inner declaration.
+static DeclRef<GenericDecl> _getSpecializedGenericParent(DeclRef<Decl> const& declRef)
 {
     if (!declRef)
-        return 0;
+        return DeclRef<GenericDecl>();
 
     // A specialization of a generic must point at the
     // "inner" declaration of a generic. That means that
@@ -1847,7 +1845,7 @@ Int SemanticsVisitor::getSpecializedParamCount(DeclRef<Decl> const& declRef)
     //
     auto parentGeneric = declRef.getParent().as<GenericDecl>();
     if (!parentGeneric)
-        return 0;
+        return DeclRef<GenericDecl>();
     //
     // Furthermore, the declaration we are considering
     // must be the single "inner" declaration of the
@@ -1855,6 +1853,17 @@ Int SemanticsVisitor::getSpecializedParamCount(DeclRef<Decl> const& declRef)
     // parameter).
     //
     if (parentGeneric.getDecl()->inner != declRef.getDecl())
+        return DeclRef<GenericDecl>();
+
+    return parentGeneric;
+}
+
+/// Returns the number of required parameters on the generic specialized by `declRef`.
+/// Returns zero when `declRef` is not the inner declaration of a generic.
+Int SemanticsVisitor::getSpecializedParamCount(DeclRef<Decl> const& declRef)
+{
+    auto parentGeneric = _getSpecializedGenericParent(declRef);
+    if (!parentGeneric)
         return 0;
 
     return CountParameters(parentGeneric).required;
@@ -2147,6 +2156,15 @@ int SemanticsVisitor::compareOverloadCandidateSpecificity(
     if (left.declRef.equals(right.declRef))
         return -1;
 
+    // A non-generic declaration accepts a strict subset of the calls accepted by an otherwise
+    // equivalent generic specialization. Preserve that semantic relationship as an ordinary
+    // ranking rule; unlike comparing two generics' parameter counts, it is not a compatibility
+    // heuristic and remains valid in Slang 202c.
+    bool leftIsSpecializedGeneric = _getSpecializedGenericParent(left.declRef) != nullptr;
+    bool rightIsSpecializedGeneric = _getSpecializedGenericParent(right.declRef) != nullptr;
+    if (leftIsSpecializedGeneric != rightIsSpecializedGeneric)
+        return int(leftIsSpecializedGeneric) - int(rightIsSpecializedGeneric);
+
     // A principled specificity comparison would determine whether one candidate's accepted
     // argument domain is a strict subset of the other's. Slang does not implement that comparison
     // yet, so structural relationships such as `vector<T, 3>` versus `vector<T, N>` remain tied
@@ -2378,7 +2396,7 @@ int SemanticsVisitor::CompareOverloadCandidates(OverloadCandidate* left, Overloa
     return 0;
 }
 
-bool SemanticsVisitor::tryResolveOverloadUsingLegacyGenericParameterCount(
+bool SemanticsVisitor::tryResolveOverloadUsingLegacyGenericParameterCountFallback(
     OverloadResolveContext& context)
 {
     if (isSlang202cOrLater(this) || context.bestCandidates.getCount() < 2)
@@ -2388,7 +2406,7 @@ bool SemanticsVisitor::tryResolveOverloadUsingLegacyGenericParameterCount(
 
     // `bestCandidates` normally contains candidates with the same status because candidate status
     // is itself an ordinary ranking criterion. Check every candidate here instead of making that
-    // representation invariant part of the compatibility rule's contract.
+    // representation invariant part of the legacy compatibility fallback's contract.
     for (auto& candidate : context.bestCandidates)
     {
         if (candidate.status != OverloadCandidate::Status::Applicable)
@@ -2405,8 +2423,8 @@ bool SemanticsVisitor::tryResolveOverloadUsingLegacyGenericParameterCount(
     // fixed-size overload. The proxy is not valid in general, though: constraints can make a
     // declaration with more generic parameters applicable to a narrower set of arguments.
     // `bestCandidates` contains exactly the candidates that remain tied after every ordinary
-    // ranking criterion, so applying the legacy rule here makes it the final compatibility
-    // fallback instead of allowing it to override a meaningful comparison such as `OverloadRank`.
+    // ranking criterion, so applying the legacy compatibility fallback here prevents it from
+    // overriding a meaningful comparison such as `OverloadRank`.
     Index bestCandidateIndex = 0;
     Int bestGenericParameterCount =
         getSpecializedParamCount(context.bestCandidates[bestCandidateIndex].item.declRef);
@@ -3463,8 +3481,10 @@ Expr* SemanticsVisitor::ResolveInvoke(InvokeExpr* expr)
         AddOverloadCandidates(funcExpr, context);
     }
 
-    if (tryResolveOverloadUsingLegacyGenericParameterCount(context))
+    if (tryResolveOverloadUsingLegacyGenericParameterCountFallback(context))
     {
+        // `ResolveInvoke` is final source-level resolution, never a speculative cost probe, so a
+        // successful legacy compatibility fallback always reports its deprecation here.
         getSink()->diagnose(
             Diagnostics::DeprecatedGenericParameterCountOverloadTieBreaker{.location = expr->loc});
     }

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -2147,62 +2147,14 @@ int SemanticsVisitor::compareOverloadCandidateSpecificity(
     if (left.declRef.equals(right.declRef))
         return -1;
 
-    // There is a very general rule that we would like to enforce
-    // in principle:
+    // A principled specificity comparison would determine whether one candidate's accepted
+    // argument domain is a strict subset of the other's. Slang does not implement that comparison
+    // yet, so structural relationships such as `vector<T, 3>` versus `vector<T, N>` remain tied
+    // here. The pre-202c generic-parameter-count compatibility fallback runs only after every
+    // ordinary ranking rule has also left the candidates tied.
     //
-    // Given candidates A and B, if A being applicable to some
-    // arguments implies that B is also applicable, but not vice versa,
-    // then A is a more specific/specialized candidate than B.
-    //
-    // A number of conclusions follow from this general rule.
-    // For example, a non-generic declaration will always be
-    // more specific than a generic declaration that was specialized
-    // to matching types:
-    //
-    //      int doThing(int a);
-    //      T doThing<T>(T a);
-    //
-    // It is clear that if the non-generic `doThing` is applicable
-    // to an argument `x`, then `doThing<int>` is also applicable to
-    // `x`. However, knowing that the generic `doThing` was applicable
-    // to some `y` doesn't tell us that the non-generic `doThing` can
-    // be called on `y`, because `y` could have some type that can't
-    // convert to `int`.
-    //
-    // Similarly, a generic declaration with a subset of the parameters
-    // of another generic is always more specialized:
-    //
-    //      int doThing<T>(vector<T,3> value);
-    //      int doThing<T, let N : int>(vector<T,N> value);
-    //
-    // Here we know that both overloads can apply to `float3`, but only
-    // one can apply to `float4`, so the first overload is more
-    // specialized/specific.
-    //
-    // As a final example, a generic which places more constraints
-    // on its generic parameters is more specific, all other things
-    // being equal:
-    //
-    //      int doThing<T : IFoo>( T value );
-    //      int doThing<T>(T value);
-    //
-    // In this case we know that the first overload is applicable
-    // to a strict subset of the types that the second overload can
-    // apply to.
-    //
-    // The above rules represent the idealized principles we want
-    // to implement, but actually implementing that full check here
-    // could make overload resolution far more expensive.
-    //
-    // TODO: In the long run we should clearly replace this with
-    // the more general "does A being applicable imply B being applicable"
-    // test.
-    //
-    // TODO: The principle stated here doesn't take the actual
-    // arguments or their types into account, and it might be that
-    // in some cases disambiguation of which declaration should be
-    // preferred will depend on knowing the actual arguments.
-    //
+    // TODO: Replace this with an applicability-subset comparison that accounts for generic
+    // constraints and, where necessary, the actual argument types.
     return 0;
 }
 

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -2157,9 +2157,12 @@ int SemanticsVisitor::compareOverloadCandidateSpecificity(
         return -1;
 
     // A non-generic declaration accepts a strict subset of the calls accepted by an otherwise
-    // equivalent generic specialization. Preserve that semantic relationship as an ordinary
-    // ranking rule; unlike comparing two generics' parameter counts, it is not a compatibility
-    // heuristic and remains valid in Slang 202c.
+    // equivalent generic specialization. This relationship depends on whether the declaration is
+    // generic, not on how many of its parameters are required: a generic whose parameters all have
+    // defaults still accepts explicit specialization arguments that the non-generic declaration
+    // does not. Preserve that semantic relationship as an ordinary ranking rule; unlike comparing
+    // two generics' parameter counts, it is not a compatibility heuristic and remains valid in
+    // Slang 202c.
     bool leftIsSpecializedGeneric = _getSpecializedGenericParent(left.declRef) != nullptr;
     bool rightIsSpecializedGeneric = _getSpecializedGenericParent(right.declRef) != nullptr;
     if (leftIsSpecializedGeneric != rightIsSpecializedGeneric)

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -3528,8 +3528,7 @@ RefPtr<ComponentType::SpecializationInfo> EntryPoint::_validateSpecializationArg
     RefPtr<SharedSemanticsContext> sharedSemanticsContext;
     if (entryPointModule)
     {
-        sharedSemanticsContext =
-            new SharedSemanticsContext(getLinkage(), entryPointModule, sink);
+        sharedSemanticsContext = new SharedSemanticsContext(getLinkage(), entryPointModule, sink);
         for (auto module : getModuleDependencies())
         {
             auto moduleDecl = module->getModuleDecl();
@@ -3844,10 +3843,7 @@ Type* Linkage::specializeType(
     // TODO: We should cache and re-use specialized types
     // when the exact same arguments are provided again later.
 
-    SharedSemanticsContext sharedSemanticsContext(
-        this,
-        m_optionSet.getLanguageVersion(),
-        sink);
+    SharedSemanticsContext sharedSemanticsContext(this, m_optionSet.getLanguageVersion(), sink);
     SemanticsVisitor visitor(&sharedSemanticsContext);
 
     SpecializationParams specializationParams;
@@ -4006,10 +4002,8 @@ RefPtr<ComponentType> createSpecializedGlobalComponentType(EndToEndCompileReques
     // applying the global generic arguments (if any) to the
     // unspecialized program.
     //
-    auto specializedProgram = _createSpecializedProgramImpl(
-        unspecializedProgram,
-        globalSpecializationArgs,
-        sink);
+    auto specializedProgram =
+        _createSpecializedProgramImpl(unspecializedProgram, globalSpecializationArgs, sink);
 
     // If anything went wrong with the global generic
     // arguments, then bail out now.

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -3474,7 +3474,10 @@ static void _extractSpecializationArgs(
 {
     auto linkage = componentType->getLinkage();
 
-    SharedSemanticsContext semanticsContext(linkage, nullptr, sink);
+    SharedSemanticsContext semanticsContext(
+        linkage,
+        linkage->m_optionSet.getLanguageVersion(),
+        sink);
     SemanticsVisitor semanticsVisitor(&semanticsContext);
 
     auto argCount = argExprs.getCount();
@@ -3519,20 +3522,29 @@ RefPtr<ComponentType::SpecializationInfo> EntryPoint::_validateSpecializationArg
     // primary module's own extensions come along -- this is the same
     // point-of-view an in-body generic call has.
     //
-    // When the entry point has no owning module (`getModule()` is null) we pass
-    // `nullptr` and fall back to the prior module-less behavior.
+    // When the entry point has no owning module (`getModule()` is null), retain the prior
+    // module-less behavior and use the linkage's effective language version.
     auto entryPointModule = getModule();
-    SharedSemanticsContext sharedSemanticsContext(getLinkage(), entryPointModule, sink);
+    RefPtr<SharedSemanticsContext> sharedSemanticsContext;
     if (entryPointModule)
     {
+        sharedSemanticsContext =
+            new SharedSemanticsContext(getLinkage(), entryPointModule, sink);
         for (auto module : getModuleDependencies())
         {
             auto moduleDecl = module->getModuleDecl();
-            if (sharedSemanticsContext.importedModulesSet.add(moduleDecl))
-                sharedSemanticsContext.importedModulesList.add(moduleDecl);
+            if (sharedSemanticsContext->importedModulesSet.add(moduleDecl))
+                sharedSemanticsContext->importedModulesList.add(moduleDecl);
         }
     }
-    SemanticsVisitor visitor(&sharedSemanticsContext);
+    else
+    {
+        sharedSemanticsContext = new SharedSemanticsContext(
+            getLinkage(),
+            getLinkage()->m_optionSet.getLanguageVersion(),
+            sink);
+    }
+    SemanticsVisitor visitor(sharedSemanticsContext);
 
     // The last N arguments will be for the implicit existential arguments
     // of the entry point (if it has any).
@@ -3793,7 +3805,10 @@ void parseSpecializationArgStrings(
     auto linkage = endToEndReq->getLinkage();
     auto sink = endToEndReq->getSink();
 
-    SharedSemanticsContext sharedSemanticsContext(linkage, nullptr, sink);
+    SharedSemanticsContext sharedSemanticsContext(
+        linkage,
+        linkage->m_optionSet.getLanguageVersion(),
+        sink);
     SemanticsVisitor semantics(&sharedSemanticsContext);
 
     // We will be looping over the generic argument strings
@@ -3829,7 +3844,10 @@ Type* Linkage::specializeType(
     // TODO: We should cache and re-use specialized types
     // when the exact same arguments are provided again later.
 
-    SharedSemanticsContext sharedSemanticsContext(this, nullptr, sink);
+    SharedSemanticsContext sharedSemanticsContext(
+        this,
+        m_optionSet.getLanguageVersion(),
+        sink);
     SemanticsVisitor visitor(&sharedSemanticsContext);
 
     SpecializationParams specializationParams;
@@ -3872,7 +3890,6 @@ Type* Linkage::specializeType(
 
 /// Shared implementation logic for the `_createSpecializedProgram*` entry points.
 static RefPtr<ComponentType> _createSpecializedProgramImpl(
-    Linkage* linkage,
     ComponentType* unspecializedProgram,
     List<Expr*> const& specializationArgExprs,
     DiagnosticSink* sink)
@@ -3899,8 +3916,6 @@ static RefPtr<ComponentType> _createSpecializedProgramImpl(
     // We have an appropriate number of arguments for the global specialization parameters,
     // and now we need to check that the arguments conform to the declared constraints.
     //
-    SharedSemanticsContext visitor(linkage, nullptr, sink);
-
     List<SpecializationArg> specializationArgs;
     _extractSpecializationArgs(
         unspecializedProgram,
@@ -3971,7 +3986,6 @@ RefPtr<ComponentType> createSpecializedGlobalComponentType(EndToEndCompileReques
     // global or entry-point generic parameters.
     //
     auto unspecializedProgram = endToEndReq->getUnspecializedGlobalComponentType();
-    auto linkage = endToEndReq->getLinkage();
     auto sink = endToEndReq->getSink();
 
     // First, let's parse the specialization argument strings that were
@@ -3993,7 +4007,6 @@ RefPtr<ComponentType> createSpecializedGlobalComponentType(EndToEndCompileReques
     // unspecialized program.
     //
     auto specializedProgram = _createSpecializedProgramImpl(
-        linkage,
         unspecializedProgram,
         globalSpecializationArgs,
         sink);

--- a/source/slang/slang-check-shader.cpp
+++ b/source/slang/slang-check-shader.cpp
@@ -1785,8 +1785,12 @@ void validateEntryPoint(EntryPoint* entryPoint, DiagnosticSink* sink)
     {
         // Use the existing getTypeTags functionality to check for resource types
         // Create a temporary SemanticsVisitor to access getTypeTags
-        SharedSemanticsContext shared(linkage, module, sink);
-        SemanticsVisitor visitor(&shared);
+        auto shared = SharedSemanticsContext::createForOptionalModule(
+            linkage,
+            module,
+            linkage->m_optionSet.getLanguageVersion(),
+            sink);
+        SemanticsVisitor visitor(shared);
 
         auto typeTags = visitor.getTypeTags(returnType);
         bool hasResourceOrUnsizedTypes = (((int)typeTags & (int)TypeTag::Opaque) != 0) ||
@@ -1974,8 +1978,12 @@ void validateEntryPoint(EntryPoint* entryPoint, DiagnosticSink* sink)
     // accessor it resolves to, so a need like `fragmentshaderbarycentric` on `SV_Barycentrics`
     // must be gathered here.
     {
-        SharedSemanticsContext shared(linkage, module, sink);
-        SemanticsVisitor visitor(&shared);
+        auto shared = SharedSemanticsContext::createForOptionalModule(
+            linkage,
+            module,
+            linkage->m_optionSet.getLanguageVersion(),
+            sink);
+        SemanticsVisitor visitor(shared);
 
         // Use the session's coreLanguageScope which contains the SemanticDecl definitions
         // The module's own scope may not include the core module (e.g., when loading from

--- a/source/slang/slang-check-type.cpp
+++ b/source/slang/slang-check-type.cpp
@@ -9,7 +9,10 @@ namespace Slang
 {
 Type* checkProperType(Linkage* linkage, TypeExp typeExp, DiagnosticSink* sink)
 {
-    SharedSemanticsContext sharedSemanticsContext(linkage, nullptr, sink);
+    SharedSemanticsContext sharedSemanticsContext(
+        linkage,
+        linkage->m_optionSet.getLanguageVersion(),
+        sink);
     SemanticsVisitor visitor(&sharedSemanticsContext);
 
     SLANG_AST_BUILDER_RAII(linkage->getASTBuilder());

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -4051,6 +4051,16 @@ standalone_note(
     span { loc = "location" }
 )
 
+warning(
+    "deprecated-generic-parameter-count-overload-tie-breaker",
+    40021,
+    "deprecated generic-parameter-count overload tie-breaker",
+    span {
+        loc = "location",
+        message = "overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c"
+    }
+)
+
 err(
     "case-outside-switch",
     39999,

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -4057,7 +4057,7 @@ warning(
     "deprecated generic-parameter-count overload tie-breaker",
     span {
         loc = "location",
-        message = "overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c"
+        message = "overload resolution selected an otherwise ambiguous candidate by preferring the single candidate with the fewest required generic parameters; this tie-breaker is removed in Slang 202c"
     }
 )
 

--- a/source/slang/slang-language-server.cpp
+++ b/source/slang/slang-language-server.cpp
@@ -377,8 +377,12 @@ String getDeclSignatureString(DeclRef<Decl> declRef, WorkspaceVersion* version)
             else if (initExpr)
             {
                 DiagnosticSink sink;
-                SharedSemanticsContext semanticContext(version->linkage, module, &sink);
-                SemanticsVisitor semanticsVisitor(&semanticContext);
+                auto semanticContext = SharedSemanticsContext::createForOptionalModule(
+                    version->linkage,
+                    module,
+                    version->linkage->m_optionSet.getLanguageVersion(),
+                    &sink);
+                SemanticsVisitor semanticsVisitor(semanticContext);
                 if (auto intVal = semanticsVisitor.tryFoldIntegerConstantExpression(
                         declRef.substitute(version->linkage->getASTBuilder(), initExpr),
                         SemanticsVisitor::ConstantFoldingKind::LinkTime,
@@ -704,13 +708,14 @@ LanguageServerResult<LanguageServerProtocol::Hover> LanguageServerCore::hover(
             if (auto funcDecl = as<FunctionDeclBase>(declRef.getDecl()))
             {
                 DiagnosticSink sink;
-                SharedSemanticsContext semanticContext(
+                auto semanticContext = SharedSemanticsContext::createForOptionalModule(
                     version->linkage,
                     getModule(funcDecl),
+                    version->linkage->m_optionSet.getLanguageVersion(),
                     &sink);
-                SemanticsVisitor semanticsVisitor(&semanticContext);
+                SemanticsVisitor semanticsVisitor(semanticContext);
 
-                auto assocDecls = semanticContext.getAssociatedDeclsForDecl(funcDecl);
+                auto assocDecls = semanticContext->getAssociatedDeclsForDecl(funcDecl);
                 Decl* bwdDiff = nullptr;
                 Decl* fwdDiff = nullptr;
                 Decl* primalSubst = nullptr;

--- a/source/slang/slang-language-server.cpp
+++ b/source/slang/slang-language-server.cpp
@@ -1840,7 +1840,13 @@ LanguageServerResult<LanguageServerProtocol::SignatureHelp> LanguageServerCore::
     // on the best candidate.
     //
     DiagnosticSink sink;
-    SharedSemanticsContext semanticsContext(version->linkage, nullptr, &sink);
+    // Signature help performs ad hoc checking without a primary module so that extension lookup
+    // retains its existing linkage-wide point of view. Its language rules still come from the
+    // parsed document module, including any `#language` directive in that file.
+    SharedSemanticsContext semanticsContext(
+        version->linkage,
+        parsedModule->getModuleDecl()->languageVersion,
+        &sink);
     SemanticsVisitor semanticsVisitor(&semanticsContext);
 
     auto addDeclRef = [&](DeclRef<Decl> declRef)

--- a/source/slang/slang-linkable.cpp
+++ b/source/slang/slang-linkable.cpp
@@ -865,7 +865,8 @@ Type* ComponentType::getTypeFromString(String const& typeStr, DiagnosticSink* si
 Expr* ComponentType::tryResolveOverloadedExpr(Expr* exprIn)
 {
     auto linkage = getLinkage();
-    SemanticsContext context(linkage->getSemanticsForReflection());
+    auto sharedSemanticsContext = linkage->getSemanticsForReflection();
+    SemanticsContext context(sharedSemanticsContext);
     SemanticsVisitor visitor(context);
     return visitor.maybeResolveOverloadedExpr(exprIn, LookupMask::Function, nullptr);
 }
@@ -969,7 +970,8 @@ Expr* ComponentType::findDeclFromString(String const& name, DiagnosticSink* sink
 
     Expr* expr = linkage->parseTermString(name, scope);
 
-    SemanticsContext context(linkage->getSemanticsForReflection());
+    auto sharedSemanticsContext = linkage->getSemanticsForReflection();
+    SemanticsContext context(sharedSemanticsContext);
     context = context.allowStaticReferenceToNonStaticMember().withSink(sink);
 
     SemanticsVisitor visitor(context);
@@ -1039,7 +1041,8 @@ Expr* ComponentType::findDeclFromStringInType(
     {
         expr = linkage->parseTermString(name, scope);
     }
-    SemanticsContext context(linkage->getSemanticsForReflection());
+    auto sharedSemanticsContext = linkage->getSemanticsForReflection();
+    SemanticsContext context(sharedSemanticsContext);
     context = context.allowStaticReferenceToNonStaticMember().withSink(sink);
 
     SemanticsVisitor visitor(context);
@@ -1117,7 +1120,8 @@ Expr* ComponentType::findDeclFromStringInType(
 
 bool ComponentType::isSubType(Type* subType, Type* superType)
 {
-    SemanticsContext context(getLinkage()->getSemanticsForReflection());
+    auto sharedSemanticsContext = getLinkage()->getSemanticsForReflection();
+    SemanticsContext context(sharedSemanticsContext);
     SemanticsVisitor visitor(context);
 
     return (visitor.isSubtype(subType, superType, IsSubTypeOptions::None) != nullptr);

--- a/source/slang/slang-linkable.cpp
+++ b/source/slang/slang-linkable.cpp
@@ -419,7 +419,10 @@ SLANG_NO_THROW SlangResult SLANG_MCALL ComponentType::specialize(
                 if (!parsedExpr)
                     return SLANG_FAIL;
 
-                SharedSemanticsContext sharedSemanticsContext(getLinkage(), nullptr, &sink);
+                SharedSemanticsContext sharedSemanticsContext(
+                    getLinkage(),
+                    getLinkage()->m_optionSet.getLanguageVersion(),
+                    &sink);
                 SemanticsVisitor visitor(&sharedSemanticsContext);
                 auto checkedExpr = visitor.CheckTerm(parsedExpr);
                 if (auto typeType = as<TypeType>(checkedExpr->type.type))
@@ -842,7 +845,10 @@ Type* ComponentType::getTypeFromString(String const& typeStr, DiagnosticSink* si
     SLANG_AST_BUILDER_RAII(linkage->getASTBuilder());
 
     Expr* typeExpr = linkage->parseTermString(typeStr, scope);
-    SharedSemanticsContext sharedSemanticsContext(linkage, nullptr, sink);
+    SharedSemanticsContext sharedSemanticsContext(
+        linkage,
+        linkage->m_optionSet.getLanguageVersion(),
+        sink);
     SemanticsVisitor visitor(&sharedSemanticsContext);
     type = visitor.TranslateTypeNode(typeExpr);
     auto typeOut = visitor.tryCoerceToProperType(TypeExp(type));

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -82,7 +82,7 @@ Linkage::Linkage(Session* session, ASTBuilder* astBuilder, Linkage* builtinLinka
     }
 }
 
-SharedSemanticsContext* Linkage::getSemanticsForReflection()
+RefPtr<SharedSemanticsContext> Linkage::getSemanticsForReflection()
 {
     // Linkage options are populated after the `Linkage` constructor runs. Defer construction so
     // ad hoc reflection checking observes the language version configured on the session or
@@ -96,7 +96,7 @@ SharedSemanticsContext* Linkage::getSemanticsForReflection()
     {
         m_semanticsForReflection = new SharedSemanticsContext(this, languageVersion, nullptr);
     }
-    return m_semanticsForReflection.get();
+    return m_semanticsForReflection;
 }
 
 SLANG_NO_THROW SlangResult SLANG_MCALL
@@ -528,7 +528,8 @@ bool Linkage::isSpecialized(DeclRef<Decl> declRef)
     //
     // If it's not specialized, then declRef will be the one with default substitutions.
     //
-    SemanticsVisitor visitor(getSemanticsForReflection());
+    auto sharedSemanticsContext = getSemanticsForReflection();
+    SemanticsVisitor visitor(sharedSemanticsContext);
 
     auto decl = declRef.getDecl();
     while (decl && !as<GenericDecl>(decl))
@@ -580,7 +581,8 @@ DeclRef<Decl> Linkage::specializeWithArgTypes(
     List<Type*> argTypes,
     DiagnosticSink* sink)
 {
-    SemanticsVisitor visitor(getSemanticsForReflection());
+    auto sharedSemanticsContext = getSemanticsForReflection();
+    SemanticsVisitor visitor(sharedSemanticsContext);
     SemanticsVisitor::ExprLocalScope scope;
     visitor = visitor.withSink(sink).withExprLocalScope(&scope);
 
@@ -639,7 +641,8 @@ DeclRef<Decl> Linkage::specializeGeneric(
     SLANG_AST_BUILDER_RAII(getASTBuilder());
     SLANG_ASSERT(declRef);
 
-    SemanticsVisitor visitor(getSemanticsForReflection());
+    auto sharedSemanticsContext = getSemanticsForReflection();
+    SemanticsVisitor visitor(sharedSemanticsContext);
     visitor = visitor.withSink(sink);
 
     auto genericDeclRef = getGenericParentDeclRef(getASTBuilder(), &visitor, declRef);
@@ -707,7 +710,8 @@ SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL Linkage::getContainerType(
         {
         case slang::ContainerType::ConstantBuffer:
             {
-                SemanticsVisitor visitor(getSemanticsForReflection());
+                auto sharedSemanticsContext = getSemanticsForReflection();
+                SemanticsVisitor visitor(sharedSemanticsContext);
                 auto layoutType = getASTBuilder()->getDefaultLayoutType();
                 Type* cbType = visitor.getConstantBufferType(type, layoutType);
                 containerTypeReflection = cbType;
@@ -864,7 +868,8 @@ SLANG_NO_THROW SlangResult SLANG_MCALL Linkage::createTypeConformanceComponentTy
 
     try
     {
-        SemanticsVisitor visitor(getSemanticsForReflection());
+        auto sharedSemanticsContext = getSemanticsForReflection();
+        SemanticsVisitor visitor(sharedSemanticsContext);
         visitor = visitor.withSink(&sink);
 
         auto witness = visitor.isSubtype(

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -80,7 +80,6 @@ Linkage::Linkage(Session* session, ASTBuilder* astBuilder, Linkage* builtinLinka
         for (const auto& nameToMod : builtinLinkage->mapNameToLoadedModules)
             mapNameToLoadedModules.add(nameToMod);
     }
-
 }
 
 SharedSemanticsContext* Linkage::getSemanticsForReflection()
@@ -91,10 +90,8 @@ SharedSemanticsContext* Linkage::getSemanticsForReflection()
     std::lock_guard<std::recursive_mutex> lock(getComponentTypeOperationMutex());
     if (!m_semanticsForReflection)
     {
-        m_semanticsForReflection = new SharedSemanticsContext(
-            this,
-            m_optionSet.getLanguageVersion(),
-            nullptr);
+        m_semanticsForReflection =
+            new SharedSemanticsContext(this, m_optionSet.getLanguageVersion(), nullptr);
     }
     return m_semanticsForReflection.get();
 }

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -86,12 +86,16 @@ SharedSemanticsContext* Linkage::getSemanticsForReflection()
 {
     // Linkage options are populated after the `Linkage` constructor runs. Defer construction so
     // ad hoc reflection checking observes the language version configured on the session or
-    // compile request instead of unconditionally capturing the compiler default.
+    // compile request instead of unconditionally capturing the compiler default. A legacy compile
+    // request can also process a new `-std` option after reflection has started, so replace a
+    // cached context whose effective version no longer matches the linkage.
     std::lock_guard<std::recursive_mutex> lock(getComponentTypeOperationMutex());
-    if (!m_semanticsForReflection)
+    auto languageVersion = m_optionSet.getLanguageVersion();
+    if (!m_semanticsForReflection ||
+        m_semanticsForReflection->getLanguageVersion() != languageVersion)
     {
         m_semanticsForReflection =
-            new SharedSemanticsContext(this, m_optionSet.getLanguageVersion(), nullptr);
+            new SharedSemanticsContext(this, languageVersion, nullptr);
     }
     return m_semanticsForReflection.get();
 }

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -96,6 +96,9 @@ RefPtr<SharedSemanticsContext> Linkage::getSemanticsForReflection()
     {
         m_semanticsForReflection = new SharedSemanticsContext(this, languageVersion, nullptr);
     }
+    // A `SemanticsVisitor` stores only a raw pointer to its shared context. Callers must retain this
+    // returned `RefPtr` in a local for the entire checking operation instead of constructing a
+    // visitor from a temporary, because a later option change can replace the cached member.
     return m_semanticsForReflection;
 }
 

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -94,8 +94,7 @@ SharedSemanticsContext* Linkage::getSemanticsForReflection()
     if (!m_semanticsForReflection ||
         m_semanticsForReflection->getLanguageVersion() != languageVersion)
     {
-        m_semanticsForReflection =
-            new SharedSemanticsContext(this, languageVersion, nullptr);
+        m_semanticsForReflection = new SharedSemanticsContext(this, languageVersion, nullptr);
     }
     return m_semanticsForReflection.get();
 }

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -81,11 +81,21 @@ Linkage::Linkage(Session* session, ASTBuilder* astBuilder, Linkage* builtinLinka
             mapNameToLoadedModules.add(nameToMod);
     }
 
-    m_semanticsForReflection = new SharedSemanticsContext(this, nullptr, nullptr);
 }
 
 SharedSemanticsContext* Linkage::getSemanticsForReflection()
 {
+    // Linkage options are populated after the `Linkage` constructor runs. Defer construction so
+    // ad hoc reflection checking observes the language version configured on the session or
+    // compile request instead of unconditionally capturing the compiler default.
+    std::lock_guard<std::recursive_mutex> lock(getComponentTypeOperationMutex());
+    if (!m_semanticsForReflection)
+    {
+        m_semanticsForReflection = new SharedSemanticsContext(
+            this,
+            m_optionSet.getLanguageVersion(),
+            nullptr);
+    }
     return m_semanticsForReflection.get();
 }
 

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -96,9 +96,9 @@ RefPtr<SharedSemanticsContext> Linkage::getSemanticsForReflection()
     {
         m_semanticsForReflection = new SharedSemanticsContext(this, languageVersion, nullptr);
     }
-    // A `SemanticsVisitor` stores only a raw pointer to its shared context. Callers must retain
-    // this returned `RefPtr` in a local for the entire checking operation instead of constructing a
-    // visitor from a temporary, because a later option change can replace the cached member.
+    // A `SemanticsVisitor` stores only a raw pointer to its shared context. Its constructors reject
+    // a temporary `RefPtr`, and callers retain this returned owner in a local for the entire
+    // checking operation because a later option change can replace the cached member.
     return m_semanticsForReflection;
 }
 

--- a/source/slang/slang-session.cpp
+++ b/source/slang/slang-session.cpp
@@ -96,8 +96,8 @@ RefPtr<SharedSemanticsContext> Linkage::getSemanticsForReflection()
     {
         m_semanticsForReflection = new SharedSemanticsContext(this, languageVersion, nullptr);
     }
-    // A `SemanticsVisitor` stores only a raw pointer to its shared context. Callers must retain this
-    // returned `RefPtr` in a local for the entire checking operation instead of constructing a
+    // A `SemanticsVisitor` stores only a raw pointer to its shared context. Callers must retain
+    // this returned `RefPtr` in a local for the entire checking operation instead of constructing a
     // visitor from a temporary, because a later option change can replace the cached member.
     return m_semanticsForReflection;
 }

--- a/source/slang/slang-session.h
+++ b/source/slang/slang-session.h
@@ -440,8 +440,11 @@ public:
 
     void _stopRetainingParentSession() { m_retainedSession = nullptr; }
 
-    // Get shared semantics information for reflection purposes.
-    SharedSemanticsContext* getSemanticsForReflection();
+    /// Gets a snapshot of the shared semantic state used by reflection operations.
+    ///
+    /// The strong reference keeps that snapshot alive if a later `-std` change replaces the
+    /// linkage's cached context.
+    RefPtr<SharedSemanticsContext> getSemanticsForReflection();
 
 private:
     /// The global Slang library session that this linkage is a child of

--- a/tests/language-feature/generics/generic-parameter-count-implicit-conversion-202c.slang
+++ b/tests/language-feature/generics/generic-parameter-count-implicit-conversion-202c.slang
@@ -1,0 +1,50 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -std 202c
+
+// Confirm that conversion-cost queries honor Slang 202c overload-resolution rules.
+
+interface IWidth<let N : int>
+{
+}
+
+__generic<T, let N : int>
+extension vector<T, N> : IWidth<N>
+{
+}
+
+struct Converted
+{
+}
+
+extension Converted
+{
+    __implicit_conversion(100)
+    __init<T : IFloat>(T value)
+/*CHECK:
+    ^^^^^^ see declaration of 'Converted.init'
+*/
+    {
+    }
+}
+
+extension Converted
+{
+    __implicit_conversion(100)
+    __init<T : IFloat, let N : int>(T value)
+/*CHECK:
+    ^^^^^^ see declaration of 'Converted.init'
+*/
+        where T : IWidth<N>
+    {
+    }
+}
+
+void acceptConverted(Converted value)
+{
+}
+
+void test()
+{
+    acceptConverted(float3(0.0));
+//CHECK:                  ^ ambiguous conversion
+//CHECK:                  ^ more than one conversion exists from 'vector<float,3>' to 'Converted'
+}

--- a/tests/language-feature/generics/generic-parameter-count-implicit-conversion-legacy.slang
+++ b/tests/language-feature/generics/generic-parameter-count-implicit-conversion-legacy.slang
@@ -41,11 +41,11 @@ void test()
 {
     acceptConverted(float3(0.0));
 //CHECK:                  ^ deprecated generic-parameter-count overload tie-breaker
-//CHECK:                  ^ overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
+//CHECK:                  ^ overload resolution selected an otherwise ambiguous candidate by preferring the single candidate with the fewest required generic parameters; this tie-breaker is removed in Slang 202c
 
     // A compatibility-selected conversion must not enter the implicit-cast cache. This second
     // conversion therefore resolves the tie again and emits its own warning.
     acceptConverted(float3(1.0));
 //CHECK:                  ^ deprecated generic-parameter-count overload tie-breaker
-//CHECK:                  ^ overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
+//CHECK:                  ^ overload resolution selected an otherwise ambiguous candidate by preferring the single candidate with the fewest required generic parameters; this tie-breaker is removed in Slang 202c
 }

--- a/tests/language-feature/generics/generic-parameter-count-implicit-conversion-legacy.slang
+++ b/tests/language-feature/generics/generic-parameter-count-implicit-conversion-legacy.slang
@@ -1,0 +1,45 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK): -std 2026
+
+// Confirm that a speculative conversion-cost query does not suppress the compatibility warning
+// when overload resolution later materializes the selected conversion.
+
+interface IWidth<let N : int>
+{
+}
+
+__generic<T, let N : int>
+extension vector<T, N> : IWidth<N>
+{
+}
+
+struct Converted
+{
+}
+
+extension Converted
+{
+    __implicit_conversion(100)
+    __init<T : IFloat>(T value)
+    {
+    }
+}
+
+extension Converted
+{
+    __implicit_conversion(100)
+    __init<T : IFloat, let N : int>(T value)
+        where T : IWidth<N>
+    {
+    }
+}
+
+void acceptConverted(Converted value)
+{
+}
+
+void test()
+{
+    acceptConverted(float3(0.0));
+//CHECK:                  ^ deprecated generic-parameter-count overload tie-breaker
+//CHECK:                  ^ overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
+}

--- a/tests/language-feature/generics/generic-parameter-count-implicit-conversion-legacy.slang
+++ b/tests/language-feature/generics/generic-parameter-count-implicit-conversion-legacy.slang
@@ -42,4 +42,10 @@ void test()
     acceptConverted(float3(0.0));
 //CHECK:                  ^ deprecated generic-parameter-count overload tie-breaker
 //CHECK:                  ^ overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
+
+    // A compatibility-selected conversion must not enter the implicit-cast cache. This second
+    // conversion therefore resolves the tie again and emits its own warning.
+    acceptConverted(float3(1.0));
+//CHECK:                  ^ deprecated generic-parameter-count overload tie-breaker
+//CHECK:                  ^ overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
 }

--- a/tests/language-feature/generics/generic-parameter-count-overload-ranking.slang
+++ b/tests/language-feature/generics/generic-parameter-count-overload-ranking.slang
@@ -1,0 +1,54 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=LEGACY): -std 2026
+//DIAGNOSTIC_TEST:SIMPLE(diag=SLANG202C): -std 202c
+
+struct BroadResult
+{
+}
+
+struct ShapedResult
+{
+}
+
+struct RankedResult
+{
+}
+
+BroadResult choose<T : IFloat>(T value)
+//SLANG202C:^^^^^^ candidate: func choose<vector<float,3>>(float3) -> BroadResult
+{
+    return BroadResult();
+}
+
+__generic<T : __BuiltinFloatingPointType, let N : int>
+ShapedResult choose(vector<T, N> value)
+//SLANG202C: ^^^^^^ candidate: func choose<float, 3>(float3) -> ShapedResult
+{
+    return ShapedResult();
+}
+
+BroadResult rankedChoose<T : IFloat>(T value)
+{
+    return BroadResult();
+}
+
+__generic<T : __BuiltinFloatingPointType, let N : int>
+[OverloadRank(1)]
+RankedResult rankedChoose(vector<T, N> value)
+{
+    return RankedResult();
+}
+
+void test()
+{
+    // Slang 2026 preserves the existing behavior and selects the overload with fewer required
+    // generic parameters, but warns that this compatibility rule is going away. In Slang 202c,
+    // the parameter count no longer breaks the tie.
+    BroadResult result = choose(float3(0.0));
+//LEGACY: deprecated generic-parameter-count overload tie-breaker
+//LEGACY: overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
+//SLANG202C: ambiguous call to 'choose' with arguments of type (vector<float,3>)
+
+    // OverloadRank is an ordinary ranking criterion, so it resolves this call before the legacy
+    // fallback is considered in both language versions.
+    RankedResult rankedResult = rankedChoose(float3(0.0));
+}

--- a/tests/language-feature/generics/generic-parameter-count-overload-ranking.slang
+++ b/tests/language-feature/generics/generic-parameter-count-overload-ranking.slang
@@ -67,6 +67,16 @@ GenericResult preferNonGeneric<T>(T value)
     return GenericResult();
 }
 
+NonGenericResult preferNonGenericWithDefault(int value)
+{
+    return NonGenericResult();
+}
+
+GenericResult preferNonGenericWithDefault<T = int>(int value)
+{
+    return GenericResult();
+}
+
 void equalGenericCount<T>(T first, float3 second)
 {
 }
@@ -152,6 +162,11 @@ void test()
     // use or warn about the compatibility fallback. The distinct result types make the assignment
     // verify which overload was selected.
     NonGenericResult nonGenericResult = preferNonGeneric(1);
+
+    // The non-generic rule depends on the presence of a generic specialization, not its number of
+    // required parameters. Even though `T` has a default, the generic declaration also accepts
+    // explicit specialization arguments and therefore has the broader domain.
+    NonGenericResult defaultedNonGenericResult = preferNonGenericWithDefault(1);
 
     // OverloadRank is an ordinary ranking criterion, so it resolves this call before the legacy
     // fallback is considered in both language versions. The distinct result types make the

--- a/tests/language-feature/generics/generic-parameter-count-overload-ranking.slang
+++ b/tests/language-feature/generics/generic-parameter-count-overload-ranking.slang
@@ -1,6 +1,6 @@
 //DIAGNOSTIC_TEST:SIMPLE(diag=LEGACY): -std 2026
 //DIAGNOSTIC_TEST:SIMPLE(diag=SLANG202C): -std 202c
-//DIAGNOSTIC_TEST:SIMPLE(diag=ERROR): -std 2026 -warnings-as-errors 40021
+//DIAGNOSTIC_TEST:SIMPLE(filecheck=ERROR): -std 2026 -warnings-as-errors 40021
 //DIAGNOSTIC_TEST:SIMPLE(diag=DISABLED): -std 2026 -warnings-disable 40021
 
 struct BroadResult
@@ -67,6 +67,14 @@ GenericResult preferNonGeneric<T>(T value)
     return GenericResult();
 }
 
+void equalGenericCount<T>(T first, float3 second)
+{
+}
+
+void equalGenericCount<T>(float3 first, T second)
+{
+}
+
 BroadResult rankedChoose<T : IFloat>(T value)
 {
     return BroadResult();
@@ -87,7 +95,7 @@ void test()
     BroadResult result = choose(float3(0.0));
 //LEGACY: deprecated generic-parameter-count overload tie-breaker
 //LEGACY: overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
-//ERROR: deprecated generic-parameter-count overload tie-breaker
+//ERROR: error[E40021]: deprecated generic-parameter-count overload tie-breaker
 //ERROR: overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
 //SLANG202C: ambiguous call to 'choose' with arguments of type (vector<float,3>)
 
@@ -97,16 +105,33 @@ void test()
     FixedShapeResult shapeResult = chooseShape(float3(0.0));
 //LEGACY: deprecated generic-parameter-count overload tie-breaker
 //LEGACY: overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
-//ERROR: deprecated generic-parameter-count overload tie-breaker
+//ERROR: error[E40021]: deprecated generic-parameter-count overload tie-breaker
 //ERROR: overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
 //SLANG202C: ambiguous call to 'chooseShape' with arguments of type (vector<float,3>)
 
+    // Equal required generic-parameter counts cannot select a unique compatibility candidate. The
+    // call therefore remains ambiguous in every language and warning mode, without diagnostic
+    // 40021.
+    equalGenericCount(float3(0.0), float3(0.0));
+//LEGACY: ambiguous call to 'equalGenericCount' with arguments of type (vector<float,3>, vector<float,3>)
+//LEGACY: candidate: func equalGenericCount<vector<float,3>>(float3, float3) -> void
+//LEGACY: candidate: func equalGenericCount<vector<float,3>>(float3, float3) -> void
+//SLANG202C: ambiguous call to 'equalGenericCount' with arguments of type (vector<float,3>, vector<float,3>)
+//SLANG202C: candidate: func equalGenericCount<vector<float,3>>(float3, float3) -> void
+//SLANG202C: candidate: func equalGenericCount<vector<float,3>>(float3, float3) -> void
+//ERROR: ambiguous call to 'equalGenericCount' with arguments of type (vector<float,3>, vector<float,3>)
+//DISABLED: ambiguous call to 'equalGenericCount' with arguments of type (vector<float,3>, vector<float,3>)
+//DISABLED: candidate: func equalGenericCount<vector<float,3>>(float3, float3) -> void
+//DISABLED: candidate: func equalGenericCount<vector<float,3>>(float3, float3) -> void
+
     // An otherwise-equivalent non-generic declaration accepts a strict subset of the generic
     // overload's domain. This ordinary specificity rule is unchanged in Slang 202c and does not
-    // use or warn about the compatibility fallback.
+    // use or warn about the compatibility fallback. The distinct result types make the assignment
+    // verify which overload was selected.
     NonGenericResult nonGenericResult = preferNonGeneric(1);
 
     // OverloadRank is an ordinary ranking criterion, so it resolves this call before the legacy
-    // fallback is considered in both language versions.
+    // fallback is considered in both language versions. The distinct result types make the
+    // assignment verify which overload was selected.
     RankedResult rankedResult = rankedChoose(float3(0.0));
 }

--- a/tests/language-feature/generics/generic-parameter-count-overload-ranking.slang
+++ b/tests/language-feature/generics/generic-parameter-count-overload-ranking.slang
@@ -13,6 +13,14 @@ struct RankedResult
 {
 }
 
+struct FixedShapeResult
+{
+}
+
+struct VariableShapeResult
+{
+}
+
 BroadResult choose<T : IFloat>(T value)
 //SLANG202C:^^^^^^ candidate: func choose<vector<float,3>>(float3) -> BroadResult
 {
@@ -24,6 +32,19 @@ ShapedResult choose(vector<T, N> value)
 //SLANG202C: ^^^^^^ candidate: func choose<float, 3>(float3) -> ShapedResult
 {
     return ShapedResult();
+}
+
+FixedShapeResult chooseShape<T>(vector<T, 3> value)
+//SLANG202C:     ^^^^^^^^^^^ candidate: func chooseShape<float>(float3) -> FixedShapeResult
+{
+    return FixedShapeResult();
+}
+
+__generic<T, let N : int>
+VariableShapeResult chooseShape(vector<T, N> value)
+//SLANG202C:        ^^^^^^^^^^^ candidate: func chooseShape<float, 3>(float3) -> VariableShapeResult
+{
+    return VariableShapeResult();
 }
 
 BroadResult rankedChoose<T : IFloat>(T value)
@@ -47,6 +68,14 @@ void test()
 //LEGACY: deprecated generic-parameter-count overload tie-breaker
 //LEGACY: overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
 //SLANG202C: ambiguous call to 'choose' with arguments of type (vector<float,3>)
+
+    // The fixed-size overload accepts a strict subset of the variable-size overload's domain, but
+    // Slang does not yet implement that semantic specificity comparison. The legacy fallback
+    // happens to choose the fixed-size declaration; Slang 202c conservatively reports ambiguity.
+    FixedShapeResult shapeResult = chooseShape(float3(0.0));
+//LEGACY: deprecated generic-parameter-count overload tie-breaker
+//LEGACY: overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
+//SLANG202C: ambiguous call to 'chooseShape' with arguments of type (vector<float,3>)
 
     // OverloadRank is an ordinary ranking criterion, so it resolves this call before the legacy
     // fallback is considered in both language versions.

--- a/tests/language-feature/generics/generic-parameter-count-overload-ranking.slang
+++ b/tests/language-feature/generics/generic-parameter-count-overload-ranking.slang
@@ -1,5 +1,7 @@
 //DIAGNOSTIC_TEST:SIMPLE(diag=LEGACY): -std 2026
 //DIAGNOSTIC_TEST:SIMPLE(diag=SLANG202C): -std 202c
+//DIAGNOSTIC_TEST:SIMPLE(diag=ERROR): -std 2026 -warnings-as-errors 40021
+//DIAGNOSTIC_TEST:SIMPLE(diag=DISABLED): -std 2026 -warnings-disable 40021
 
 struct BroadResult
 {
@@ -67,6 +69,8 @@ void test()
     BroadResult result = choose(float3(0.0));
 //LEGACY: deprecated generic-parameter-count overload tie-breaker
 //LEGACY: overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
+//ERROR: deprecated generic-parameter-count overload tie-breaker
+//ERROR: overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
 //SLANG202C: ambiguous call to 'choose' with arguments of type (vector<float,3>)
 
     // The fixed-size overload accepts a strict subset of the variable-size overload's domain, but
@@ -75,6 +79,8 @@ void test()
     FixedShapeResult shapeResult = chooseShape(float3(0.0));
 //LEGACY: deprecated generic-parameter-count overload tie-breaker
 //LEGACY: overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
+//ERROR: deprecated generic-parameter-count overload tie-breaker
+//ERROR: overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
 //SLANG202C: ambiguous call to 'chooseShape' with arguments of type (vector<float,3>)
 
     // OverloadRank is an ordinary ranking criterion, so it resolves this call before the legacy

--- a/tests/language-feature/generics/generic-parameter-count-overload-ranking.slang
+++ b/tests/language-feature/generics/generic-parameter-count-overload-ranking.slang
@@ -23,6 +23,14 @@ struct VariableShapeResult
 {
 }
 
+struct NonGenericResult
+{
+}
+
+struct GenericResult
+{
+}
+
 BroadResult choose<T : IFloat>(T value)
 //SLANG202C:^^^^^^ candidate: func choose<vector<float,3>>(float3) -> BroadResult
 {
@@ -47,6 +55,16 @@ VariableShapeResult chooseShape(vector<T, N> value)
 //SLANG202C:        ^^^^^^^^^^^ candidate: func chooseShape<float, 3>(float3) -> VariableShapeResult
 {
     return VariableShapeResult();
+}
+
+NonGenericResult preferNonGeneric(int value)
+{
+    return NonGenericResult();
+}
+
+GenericResult preferNonGeneric<T>(T value)
+{
+    return GenericResult();
 }
 
 BroadResult rankedChoose<T : IFloat>(T value)
@@ -82,6 +100,11 @@ void test()
 //ERROR: deprecated generic-parameter-count overload tie-breaker
 //ERROR: overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
 //SLANG202C: ambiguous call to 'chooseShape' with arguments of type (vector<float,3>)
+
+    // An otherwise-equivalent non-generic declaration accepts a strict subset of the generic
+    // overload's domain. This ordinary specificity rule is unchanged in Slang 202c and does not
+    // use or warn about the compatibility fallback.
+    NonGenericResult nonGenericResult = preferNonGeneric(1);
 
     // OverloadRank is an ordinary ranking criterion, so it resolves this call before the legacy
     // fallback is considered in both language versions.

--- a/tests/language-feature/generics/generic-parameter-count-overload-ranking.slang
+++ b/tests/language-feature/generics/generic-parameter-count-overload-ranking.slang
@@ -75,6 +75,14 @@ void equalGenericCount<T>(float3 first, T second)
 {
 }
 
+void failedInference<T>(float value)
+{
+}
+
+void failedInference<T, U>(float value)
+{
+}
+
 BroadResult rankedChoose<T : IFloat>(T value)
 {
     return BroadResult();
@@ -123,6 +131,21 @@ void test()
 //DISABLED: ambiguous call to 'equalGenericCount' with arguments of type (vector<float,3>, vector<float,3>)
 //DISABLED: candidate: func equalGenericCount<vector<float,3>>(float3, float3) -> void
 //DISABLED: candidate: func equalGenericCount<vector<float,3>>(float3, float3) -> void
+
+    // Both candidates fail generic inference, so the tied frontier is intentionally retained for
+    // the ordinary overload diagnostic. Unequal generic counts must not let the compatibility
+    // fallback promote either failed candidate or emit diagnostic 40021.
+    failedInference(0.0);
+//LEGACY: no overload for 'failedInference' applicable to arguments of type (float)
+//LEGACY: candidate: func failedInference<T> -> void
+//LEGACY: candidate: func failedInference<T, U> -> void
+//SLANG202C: no overload for 'failedInference' applicable to arguments of type (float)
+//SLANG202C: candidate: func failedInference<T> -> void
+//SLANG202C: candidate: func failedInference<T, U> -> void
+//ERROR: error[E39999]: no overload for 'failedInference' applicable to arguments of type (float)
+//DISABLED: no overload for 'failedInference' applicable to arguments of type (float)
+//DISABLED: candidate: func failedInference<T> -> void
+//DISABLED: candidate: func failedInference<T, U> -> void
 
     // An otherwise-equivalent non-generic declaration accepts a strict subset of the generic
     // overload's domain. This ordinary specificity rule is unchanged in Slang 202c and does not

--- a/tests/language-feature/generics/generic-parameter-count-overload-ranking.slang
+++ b/tests/language-feature/generics/generic-parameter-count-overload-ranking.slang
@@ -112,9 +112,9 @@ void test()
     // the parameter count no longer breaks the tie.
     BroadResult result = choose(float3(0.0));
 //LEGACY: deprecated generic-parameter-count overload tie-breaker
-//LEGACY: overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
+//LEGACY: overload resolution selected an otherwise ambiguous candidate by preferring the single candidate with the fewest required generic parameters; this tie-breaker is removed in Slang 202c
 //ERROR: error[E40021]: deprecated generic-parameter-count overload tie-breaker
-//ERROR: overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
+//ERROR: overload resolution selected an otherwise ambiguous candidate by preferring the single candidate with the fewest required generic parameters; this tie-breaker is removed in Slang 202c
 //SLANG202C: ambiguous call to 'choose' with arguments of type (vector<float,3>)
 
     // The fixed-size overload accepts a strict subset of the variable-size overload's domain, but
@@ -122,9 +122,9 @@ void test()
     // happens to choose the fixed-size declaration; Slang 202c conservatively reports ambiguity.
     FixedShapeResult shapeResult = chooseShape(float3(0.0));
 //LEGACY: deprecated generic-parameter-count overload tie-breaker
-//LEGACY: overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
+//LEGACY: overload resolution selected an otherwise ambiguous candidate by preferring the single candidate with the fewest required generic parameters; this tie-breaker is removed in Slang 202c
 //ERROR: error[E40021]: deprecated generic-parameter-count overload tie-breaker
-//ERROR: overload resolution selected an otherwise ambiguous candidate by preferring fewer required generic parameters; this tie-breaker is removed in Slang 202c
+//ERROR: overload resolution selected an otherwise ambiguous candidate by preferring the single candidate with the fewest required generic parameters; this tie-breaker is removed in Slang 202c
 //SLANG202C: ambiguous call to 'chooseShape' with arguments of type (vector<float,3>)
 
     // Equal required generic-parameter counts cannot select a unique compatibility candidate. The

--- a/tests/language-feature/operator-overload/import-glsl-overloads-without-generic-count.slang
+++ b/tests/language-feature/operator-overload/import-glsl-overloads-without-generic-count.slang
@@ -1,0 +1,38 @@
+//TEST:SIMPLE: -std 202c -no-codegen
+//TEST:SIMPLE(filecheck=CHECK): -std 202c -target spirv-asm -entry computeMain -stage compute
+
+// Slang 202c does not use generic parameter count to rank overloads. The surviving GLSL
+// declarations must therefore beat the core-module operators through OverloadRank alone.
+import glsl;
+
+RWStructuredBuffer<float> outputBuffer;
+
+void typeCheckRemovedOverloads(
+    half2x2 halfMatrix,
+    double2x2 doubleMatrix,
+    matrix<float, 2, 3> rectangularLeft,
+    matrix<float, 4, 2> rectangularRight,
+    int4 intVector,
+    bool4 boolVector)
+{
+    half2x2 halfProduct = halfMatrix * halfMatrix;
+    double2x2 doubleProduct = doubleMatrix * doubleMatrix;
+    matrix<float, 4, 3> rectangularProduct = rectangularLeft * rectangularRight;
+    bool intsEqual = intVector == intVector;
+    bool boolsNotEqual = boolVector != boolVector;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    float2x2 left = float2x2(1.0, 2.0, 3.0, 4.0);
+    float2x2 identity = float2x2(1.0, 0.0, 0.0, 1.0);
+    float2x2 product = left * identity;
+
+    float4 vectorValue = float4(1.0, 2.0, 3.0, 4.0);
+    bool vectorsEqual = vectorValue == vectorValue;
+    outputBuffer[0] = vectorsEqual ? product[0][1] : 0.0;
+}
+
+// CHECK: OpMatrixTimesMatrix

--- a/tests/language-feature/operator-overload/import-glsl-overloads-without-generic-count.slang
+++ b/tests/language-feature/operator-overload/import-glsl-overloads-without-generic-count.slang
@@ -37,10 +37,15 @@ void computeMain()
     half2x2 halfIdentity = half2x2(1.0h, 0.0h, 0.0h, 1.0h);
     half2x2 halfProduct = halfLeft * halfIdentity;
 
+    double2x2 doubleLeft = double2x2(1.0, 2.0, 3.0, 4.0);
+    double2x2 doubleRight = double2x2(5.0, 6.0, 7.0, 8.0);
+    double2x2 doubleProduct = doubleLeft * doubleRight;
+
     float4 vectorValue = float4(1.0, 2.0, 3.0, 4.0);
     bool vectorsEqual = vectorValue == vectorValue;
     outputBuffer[0] = vectorsEqual ? product[0][1] : 0.0;
     outputBuffer[1] = halfProduct[0][1];
+    outputBuffer[2] = float(doubleProduct[0][1]);
 }
 
-// CHECK-COUNT-2: OpMatrixTimesMatrix
+// CHECK-COUNT-3: OpMatrixTimesMatrix

--- a/tests/language-feature/operator-overload/import-glsl-overloads-without-generic-count.slang
+++ b/tests/language-feature/operator-overload/import-glsl-overloads-without-generic-count.slang
@@ -8,6 +8,8 @@ import glsl;
 
 RWStructuredBuffer<float> outputBuffer;
 
+// These formerly overlapping operations only need to type-check unambiguously in both language
+// modes; code generation is covered separately by `computeMain`.
 void typeCheckRemovedOverloads(
     half2x2 halfMatrix,
     double2x2 doubleMatrix,

--- a/tests/language-feature/operator-overload/import-glsl-overloads-without-generic-count.slang
+++ b/tests/language-feature/operator-overload/import-glsl-overloads-without-generic-count.slang
@@ -1,4 +1,4 @@
-//TEST:SIMPLE: -no-codegen
+//TEST:SIMPLE: -std 2026 -warnings-as-errors 40021 -no-codegen
 //TEST:SIMPLE: -std 202c -no-codegen
 //TEST:SIMPLE(filecheck=CHECK): -std 202c -target spirv-asm -entry computeMain -stage compute
 

--- a/tests/language-feature/operator-overload/import-glsl-overloads-without-generic-count.slang
+++ b/tests/language-feature/operator-overload/import-glsl-overloads-without-generic-count.slang
@@ -1,3 +1,4 @@
+//TEST:SIMPLE: -no-codegen
 //TEST:SIMPLE: -std 202c -no-codegen
 //TEST:SIMPLE(filecheck=CHECK): -std 202c -target spirv-asm -entry computeMain -stage compute
 

--- a/tests/language-feature/operator-overload/import-glsl-overloads-without-generic-count.slang
+++ b/tests/language-feature/operator-overload/import-glsl-overloads-without-generic-count.slang
@@ -33,9 +33,14 @@ void computeMain()
     float2x2 identity = float2x2(1.0, 0.0, 0.0, 1.0);
     float2x2 product = left * identity;
 
+    half2x2 halfLeft = half2x2(1.0h, 2.0h, 3.0h, 4.0h);
+    half2x2 halfIdentity = half2x2(1.0h, 0.0h, 0.0h, 1.0h);
+    half2x2 halfProduct = halfLeft * halfIdentity;
+
     float4 vectorValue = float4(1.0, 2.0, 3.0, 4.0);
     bool vectorsEqual = vectorValue == vectorValue;
     outputBuffer[0] = vectorsEqual ? product[0][1] : 0.0;
+    outputBuffer[1] = halfProduct[0][1];
 }
 
-// CHECK: OpMatrixTimesMatrix
+// CHECK-COUNT-2: OpMatrixTimesMatrix

--- a/tests/language-server/ctor-signature-2026.slang
+++ b/tests/language-server/ctor-signature-2026.slang
@@ -1,5 +1,5 @@
 //TEST:LANG_SERVER(filecheck=CHECK):
-#language 202c
+#language 2026
 
 interface IWidth<let N : int>
 {
@@ -57,8 +57,6 @@ void test()
     choose(float3(0.0));
 }
 
-// In 2026 mode the legacy fallback makes the float3-to-Converted conversion viable and selects
-// that lower-cost signature. In 202c that conversion is ambiguous, while the higher-cost Fallback
-// conversion remains viable and is selected. This expectation therefore fails if signature help
-// ignores the document version.
-// CHECK: (selected) func choose(Fallback value) -> void
+// Both conversions are viable in 2026. The lower-cost Converted conversion must win, providing
+// the positive counterpart to the 202c document's Fallback selection.
+// CHECK: (selected) func choose(Converted value) -> void

--- a/tests/language-server/ctor-signature-202c.slang
+++ b/tests/language-server/ctor-signature-202c.slang
@@ -50,7 +50,8 @@ void test()
 }
 
 // In 2026 mode the legacy fallback makes the float3-to-Converted conversion viable and selects
-// the second signature. In 202c both candidates are unmatched, so signature help retains the first
-// declaration. This expectation therefore fails if signature help ignores the document version.
+// that signature. In 202c both candidates are unmatched, so signature help retains signature-list
+// index zero, which lookup order fills with Unavailable. This expectation therefore fails if
+// signature help ignores the document version.
 // CHECK: activeSignature: 0
 // CHECK: (selected) func choose(Unavailable value) -> void

--- a/tests/language-server/ctor-signature-202c.slang
+++ b/tests/language-server/ctor-signature-202c.slang
@@ -1,0 +1,10 @@
+//TEST:LANG_SERVER(filecheck=CHECK):
+#language 202c
+
+void test()
+{
+//SIGNATURE:7,25
+    let v = float3(1.0, )
+}
+
+// CHECK: (selected) float3.init(float x, float

--- a/tests/language-server/ctor-signature-202c.slang
+++ b/tests/language-server/ctor-signature-202c.slang
@@ -1,10 +1,56 @@
 //TEST:LANG_SERVER(filecheck=CHECK):
 #language 202c
 
-void test()
+interface IWidth<let N : int>
 {
-//SIGNATURE:7,25
-    let v = float3(1.0, )
 }
 
-// CHECK: (selected) float3.init(float x, float
+__generic<T, let N : int>
+extension vector<T, N> : IWidth<N>
+{
+}
+
+struct Unavailable
+{
+}
+
+struct Converted
+{
+}
+
+extension Converted
+{
+    __implicit_conversion(100)
+    __init<T : IFloat>(T value)
+    {
+    }
+}
+
+extension Converted
+{
+    __implicit_conversion(100)
+    __init<T : IFloat, let N : int>(T value)
+        where T : IWidth<N>
+    {
+    }
+}
+
+void choose(Converted value)
+{
+}
+
+void choose(Unavailable value)
+{
+}
+
+void test()
+{
+//SIGNATURE:49,23
+    choose(float3(0.0));
+}
+
+// In 2026 mode the legacy fallback makes the float3-to-Converted conversion viable and selects
+// the second signature. In 202c both candidates are unmatched, so signature help retains the first
+// declaration. This expectation therefore fails if signature help ignores the document version.
+// CHECK: activeSignature: 0
+// CHECK: (selected) func choose(Unavailable value) -> void

--- a/tools/slang-unit-test/unit-test-function-reflection.cpp
+++ b/tools/slang-unit-test/unit-test-function-reflection.cpp
@@ -34,26 +34,40 @@ static const char* kLanguageVersionOverloadSource = R"(
     {
         return ShapedResult();
     }
+
+    public BroadResult rankedChoose<T : IFloat>(T value)
+    {
+        return BroadResult();
+    }
+
+    __generic<T : __BuiltinFloatingPointType, let N : int>
+    [OverloadRank(1)]
+    public ShapedResult rankedChoose(vector<T, N> value)
+    {
+        return ShapedResult();
+    }
 )";
 
-// Resolves the return type selected for `choose(float3)` in `layout`.
-static String resolveChooseReturnType(slang::ProgramLayout* layout)
+// Resolves the return type selected for `functionName(float3)` in `layout`.
+static String resolveFunctionReturnType(slang::ProgramLayout* layout, const char* functionName)
 {
     SLANG_CHECK_ABORT(layout != nullptr);
-    auto choose = layout->findFunctionByName("choose");
-    SLANG_CHECK_ABORT(choose != nullptr);
+    auto function = layout->findFunctionByName(functionName);
+    SLANG_CHECK_ABORT(function != nullptr);
     auto float3Type = layout->findTypeByName("float3");
     SLANG_CHECK_ABORT(float3Type != nullptr);
 
     slang::TypeReflection* argTypes[] = {float3Type};
-    auto resolved = choose->specializeWithArgTypes(1, argTypes);
+    auto resolved = function->specializeWithArgTypes(1, argTypes);
     return resolved ? getTypeFullName(resolved->getReturnType()) : String();
 }
 
-// Resolves the return type of `choose(float3)` through reflection in a fresh session configured
-// for `languageVersion`. A fresh session isolates the version policy under test from module and
+// Resolves `functionName(float3)` through reflection in a fresh session configured for
+// `languageVersion`. A fresh session isolates the version policy under test from module and
 // reflection caches created by the other case.
-static String resolveChooseReturnTypeForLanguageVersion(SlangLanguageVersion languageVersion)
+static String resolveFunctionReturnTypeForLanguageVersion(
+    SlangLanguageVersion languageVersion,
+    const char* functionName)
 {
     ComPtr<slang::IGlobalSession> globalSession;
     SLANG_CHECK_ABORT(
@@ -84,7 +98,7 @@ static String resolveChooseReturnTypeForLanguageVersion(SlangLanguageVersion lan
         diagnostics.writeRef());
     SLANG_CHECK_ABORT(module != nullptr);
 
-    return resolveChooseReturnType(module->getLayout());
+    return resolveFunctionReturnType(module->getLayout(), functionName);
 }
 
 // Test that the reflection API provides correct info about entry point and ordinary functions.
@@ -293,11 +307,19 @@ SLANG_UNIT_TEST(functionReflection)
 SLANG_UNIT_TEST(reflectionOverloadUsesSessionLanguageVersion)
 {
     SLANG_CHECK(
-        resolveChooseReturnTypeForLanguageVersion(SLANG_LANGUAGE_VERSION_2026) == "BroadResult");
-    // The diagnostics test proves that the 202c overload set is ambiguous. This assertion only
-    // verifies that reflection applies that language policy instead of selecting the 2026 result.
+        resolveFunctionReturnTypeForLanguageVersion(SLANG_LANGUAGE_VERSION_2026, "choose") ==
+        "BroadResult");
+    // The public reflection specialization API reports failure as null and does not expose its
+    // diagnostic sink. First prove that 202c reflection can resolve this same pair of candidate
+    // shapes when the ordinary OverloadRank rule distinguishes them. The diagnostics test proves
+    // that the otherwise-identical `choose` overload set fails specifically because it is
+    // ambiguous, while the final assertion verifies that reflection applies that policy.
     SLANG_CHECK(
-        resolveChooseReturnTypeForLanguageVersion(SLANG_LANGUAGE_VERSION_202C).getLength() == 0);
+        resolveFunctionReturnTypeForLanguageVersion(SLANG_LANGUAGE_VERSION_202C, "rankedChoose") ==
+        "ShapedResult");
+    SLANG_CHECK(
+        resolveFunctionReturnTypeForLanguageVersion(SLANG_LANGUAGE_VERSION_202C, "choose")
+            .getLength() == 0);
 }
 
 // Legacy compile requests can process command-line options after reflection has initialized its
@@ -319,13 +341,13 @@ SLANG_UNIT_TEST(reflectionRefreshesChangedLanguageVersion)
     SLANG_CHECK_ABORT(spCompile(request) == SLANG_OK);
 
     auto layout = slang::ShaderReflection::get(request);
-    SLANG_CHECK(resolveChooseReturnType(layout) == "BroadResult");
+    SLANG_CHECK(resolveFunctionReturnType(layout, "choose") == "BroadResult");
 
     const char* slang202cArgs[] = {"-std", "202c"};
     SLANG_CHECK_ABORT(
         spProcessCommandLineArguments(request, slang202cArgs, SLANG_COUNT_OF(slang202cArgs)) ==
         SLANG_OK);
-    SLANG_CHECK(resolveChooseReturnType(layout).getLength() == 0);
+    SLANG_CHECK(resolveFunctionReturnType(layout, "choose").getLength() == 0);
 
     spDestroyCompileRequest(request);
     spDestroySession(session);

--- a/tools/slang-unit-test/unit-test-function-reflection.cpp
+++ b/tools/slang-unit-test/unit-test-function-reflection.cpp
@@ -218,6 +218,77 @@ SLANG_UNIT_TEST(functionReflection)
     SLANG_CHECK(ctor != nullptr);
 }
 
+// Reflection overload resolution has no primary source module, but it still needs an effective
+// Slang language version. Verify that it uses the session option: Slang 2026 applies the deprecated
+// final fallback, while Slang 202c leaves the otherwise-tied candidates ambiguous.
+SLANG_UNIT_TEST(reflectionOverloadUsesSessionLanguageVersion)
+{
+    const char* source = R"(
+        module reflectionVersion;
+
+        public struct BroadResult {}
+        public struct ShapedResult {}
+
+        public BroadResult choose<T : IFloat>(T value)
+        {
+            return BroadResult();
+        }
+
+        __generic<T : __BuiltinFloatingPointType, let N : int>
+        public ShapedResult choose(vector<T, N> value)
+        {
+            return ShapedResult();
+        }
+    )";
+
+    auto resolveReturnType = [&](SlangLanguageVersion languageVersion) -> String
+    {
+        ComPtr<slang::IGlobalSession> globalSession;
+        SLANG_CHECK_ABORT(
+            slang_createGlobalSession(SLANG_API_VERSION, globalSession.writeRef()) == SLANG_OK);
+
+        slang::CompilerOptionEntry languageVersionEntry = {};
+        languageVersionEntry.name = slang::CompilerOptionName::LanguageVersion;
+        languageVersionEntry.value.kind = slang::CompilerOptionValueKind::Int;
+        languageVersionEntry.value.intValue0 = languageVersion;
+
+        slang::TargetDesc targetDesc = {};
+        targetDesc.format = SLANG_HLSL;
+        targetDesc.profile = globalSession->findProfile("sm_5_0");
+
+        slang::SessionDesc sessionDesc = {};
+        sessionDesc.targetCount = 1;
+        sessionDesc.targets = &targetDesc;
+        sessionDesc.compilerOptionEntryCount = 1;
+        sessionDesc.compilerOptionEntries = &languageVersionEntry;
+        ComPtr<slang::ISession> session;
+        SLANG_CHECK_ABORT(
+            globalSession->createSession(sessionDesc, session.writeRef()) == SLANG_OK);
+
+        ComPtr<slang::IBlob> diagnostics;
+        auto module = session->loadModuleFromSourceString(
+            "reflectionVersion",
+            "reflection-version.slang",
+            source,
+            diagnostics.writeRef());
+        SLANG_CHECK_ABORT(module != nullptr);
+
+        auto layout = module->getLayout();
+        SLANG_CHECK_ABORT(layout != nullptr);
+        auto choose = layout->findFunctionByName("choose");
+        SLANG_CHECK_ABORT(choose != nullptr);
+        auto float3Type = layout->findTypeByName("float3");
+        SLANG_CHECK_ABORT(float3Type != nullptr);
+
+        slang::TypeReflection* argTypes[] = {float3Type};
+        auto resolved = choose->specializeWithArgTypes(1, argTypes);
+        return resolved ? getTypeFullName(resolved->getReturnType()) : String();
+    };
+
+    SLANG_CHECK(resolveReturnType(SLANG_LANGUAGE_VERSION_2026) == "BroadResult");
+    SLANG_CHECK(resolveReturnType(SLANG_LANGUAGE_VERSION_202C).getLength() == 0);
+}
+
 // Regression test for shader-slang/slang#11277. `ModifiedType` wrappers
 // (e.g. the auto-`no_diff` synthesized on a `[Differentiable]` generic's
 // signature, or an explicit `no_diff` on a struct field) used to leak out

--- a/tools/slang-unit-test/unit-test-function-reflection.cpp
+++ b/tools/slang-unit-test/unit-test-function-reflection.cpp
@@ -18,6 +18,75 @@ static String getTypeFullName(slang::TypeReflection* type)
     return String((const char*)blob->getBufferPointer());
 }
 
+static const char* kLanguageVersionOverloadSource = R"(
+    module reflectionVersion;
+
+    public struct BroadResult {}
+    public struct ShapedResult {}
+
+    public BroadResult choose<T : IFloat>(T value)
+    {
+        return BroadResult();
+    }
+
+    __generic<T : __BuiltinFloatingPointType, let N : int>
+    public ShapedResult choose(vector<T, N> value)
+    {
+        return ShapedResult();
+    }
+)";
+
+// Resolves the return type selected for `choose(float3)` in `layout`.
+static String resolveChooseReturnType(slang::ProgramLayout* layout)
+{
+    SLANG_CHECK_ABORT(layout != nullptr);
+    auto choose = layout->findFunctionByName("choose");
+    SLANG_CHECK_ABORT(choose != nullptr);
+    auto float3Type = layout->findTypeByName("float3");
+    SLANG_CHECK_ABORT(float3Type != nullptr);
+
+    slang::TypeReflection* argTypes[] = {float3Type};
+    auto resolved = choose->specializeWithArgTypes(1, argTypes);
+    return resolved ? getTypeFullName(resolved->getReturnType()) : String();
+}
+
+// Resolves the return type of `choose(float3)` through reflection in a fresh session configured
+// for `languageVersion`. A fresh session isolates the version policy under test from module and
+// reflection caches created by the other case.
+static String resolveChooseReturnTypeForLanguageVersion(SlangLanguageVersion languageVersion)
+{
+    ComPtr<slang::IGlobalSession> globalSession;
+    SLANG_CHECK_ABORT(
+        slang_createGlobalSession(SLANG_API_VERSION, globalSession.writeRef()) == SLANG_OK);
+
+    slang::CompilerOptionEntry languageVersionEntry = {};
+    languageVersionEntry.name = slang::CompilerOptionName::LanguageVersion;
+    languageVersionEntry.value.kind = slang::CompilerOptionValueKind::Int;
+    languageVersionEntry.value.intValue0 = languageVersion;
+
+    slang::TargetDesc targetDesc = {};
+    targetDesc.format = SLANG_HLSL;
+    targetDesc.profile = globalSession->findProfile("sm_5_0");
+
+    slang::SessionDesc sessionDesc = {};
+    sessionDesc.targetCount = 1;
+    sessionDesc.targets = &targetDesc;
+    sessionDesc.compilerOptionEntryCount = 1;
+    sessionDesc.compilerOptionEntries = &languageVersionEntry;
+    ComPtr<slang::ISession> session;
+    SLANG_CHECK_ABORT(globalSession->createSession(sessionDesc, session.writeRef()) == SLANG_OK);
+
+    ComPtr<slang::IBlob> diagnostics;
+    auto module = session->loadModuleFromSourceString(
+        "reflectionVersion",
+        "reflection-version.slang",
+        kLanguageVersionOverloadSource,
+        diagnostics.writeRef());
+    SLANG_CHECK_ABORT(module != nullptr);
+
+    return resolveChooseReturnType(module->getLayout());
+}
+
 // Test that the reflection API provides correct info about entry point and ordinary functions.
 
 SLANG_UNIT_TEST(functionReflection)
@@ -223,70 +292,41 @@ SLANG_UNIT_TEST(functionReflection)
 // final fallback, while Slang 202c leaves the otherwise-tied candidates ambiguous.
 SLANG_UNIT_TEST(reflectionOverloadUsesSessionLanguageVersion)
 {
-    const char* source = R"(
-        module reflectionVersion;
+    SLANG_CHECK(
+        resolveChooseReturnTypeForLanguageVersion(SLANG_LANGUAGE_VERSION_2026) == "BroadResult");
+    SLANG_CHECK(
+        resolveChooseReturnTypeForLanguageVersion(SLANG_LANGUAGE_VERSION_202C).getLength() == 0);
+}
 
-        public struct BroadResult {}
-        public struct ShapedResult {}
+// Legacy compile requests can process command-line options after reflection has initialized its
+// ad hoc semantic context. Verify that changing `-std` replaces that context instead of retaining
+// overload rules from its originally cached language version.
+SLANG_UNIT_TEST(reflectionRefreshesChangedLanguageVersion)
+{
+    auto session = spCreateSession();
+    auto request = spCreateCompileRequest(session);
 
-        public BroadResult choose<T : IFloat>(T value)
-        {
-            return BroadResult();
-        }
+    spAddCodeGenTarget(request, SLANG_HLSL);
+    int translationUnitIndex =
+        spAddTranslationUnit(request, SLANG_SOURCE_LANGUAGE_SLANG, "reflectionVersion");
+    spAddTranslationUnitSourceString(
+        request,
+        translationUnitIndex,
+        "reflection-version.slang",
+        kLanguageVersionOverloadSource);
+    SLANG_CHECK_ABORT(spCompile(request) == SLANG_OK);
 
-        __generic<T : __BuiltinFloatingPointType, let N : int>
-        public ShapedResult choose(vector<T, N> value)
-        {
-            return ShapedResult();
-        }
-    )";
+    auto layout = slang::ShaderReflection::get(request);
+    SLANG_CHECK(resolveChooseReturnType(layout) == "BroadResult");
 
-    auto resolveReturnType = [&](SlangLanguageVersion languageVersion) -> String
-    {
-        ComPtr<slang::IGlobalSession> globalSession;
-        SLANG_CHECK_ABORT(
-            slang_createGlobalSession(SLANG_API_VERSION, globalSession.writeRef()) == SLANG_OK);
+    const char* slang202cArgs[] = {"-std", "202c"};
+    SLANG_CHECK_ABORT(
+        spProcessCommandLineArguments(request, slang202cArgs, SLANG_COUNT_OF(slang202cArgs)) ==
+        SLANG_OK);
+    SLANG_CHECK(resolveChooseReturnType(layout).getLength() == 0);
 
-        slang::CompilerOptionEntry languageVersionEntry = {};
-        languageVersionEntry.name = slang::CompilerOptionName::LanguageVersion;
-        languageVersionEntry.value.kind = slang::CompilerOptionValueKind::Int;
-        languageVersionEntry.value.intValue0 = languageVersion;
-
-        slang::TargetDesc targetDesc = {};
-        targetDesc.format = SLANG_HLSL;
-        targetDesc.profile = globalSession->findProfile("sm_5_0");
-
-        slang::SessionDesc sessionDesc = {};
-        sessionDesc.targetCount = 1;
-        sessionDesc.targets = &targetDesc;
-        sessionDesc.compilerOptionEntryCount = 1;
-        sessionDesc.compilerOptionEntries = &languageVersionEntry;
-        ComPtr<slang::ISession> session;
-        SLANG_CHECK_ABORT(
-            globalSession->createSession(sessionDesc, session.writeRef()) == SLANG_OK);
-
-        ComPtr<slang::IBlob> diagnostics;
-        auto module = session->loadModuleFromSourceString(
-            "reflectionVersion",
-            "reflection-version.slang",
-            source,
-            diagnostics.writeRef());
-        SLANG_CHECK_ABORT(module != nullptr);
-
-        auto layout = module->getLayout();
-        SLANG_CHECK_ABORT(layout != nullptr);
-        auto choose = layout->findFunctionByName("choose");
-        SLANG_CHECK_ABORT(choose != nullptr);
-        auto float3Type = layout->findTypeByName("float3");
-        SLANG_CHECK_ABORT(float3Type != nullptr);
-
-        slang::TypeReflection* argTypes[] = {float3Type};
-        auto resolved = choose->specializeWithArgTypes(1, argTypes);
-        return resolved ? getTypeFullName(resolved->getReturnType()) : String();
-    };
-
-    SLANG_CHECK(resolveReturnType(SLANG_LANGUAGE_VERSION_2026) == "BroadResult");
-    SLANG_CHECK(resolveReturnType(SLANG_LANGUAGE_VERSION_202C).getLength() == 0);
+    spDestroyCompileRequest(request);
+    spDestroySession(session);
 }
 
 // Regression test for shader-slang/slang#11277. `ModifiedType` wrappers

--- a/tools/slang-unit-test/unit-test-function-reflection.cpp
+++ b/tools/slang-unit-test/unit-test-function-reflection.cpp
@@ -294,6 +294,8 @@ SLANG_UNIT_TEST(reflectionOverloadUsesSessionLanguageVersion)
 {
     SLANG_CHECK(
         resolveChooseReturnTypeForLanguageVersion(SLANG_LANGUAGE_VERSION_2026) == "BroadResult");
+    // The diagnostics test proves that the 202c overload set is ambiguous. This assertion only
+    // verifies that reflection applies that language policy instead of selecting the 2026 result.
     SLANG_CHECK(
         resolveChooseReturnTypeForLanguageVersion(SLANG_LANGUAGE_VERSION_202C).getLength() == 0);
 }


### PR DESCRIPTION
## Motivation

Slang currently breaks some otherwise-unresolved overload ties by preferring the candidate with fewer required generic parameters.
Consider this example:

```slang
BroadResult choose<T : IFloat>(T value);

__generic<T : __BuiltinFloatingPointType, let N : int>
ShapedResult choose(vector<T, N> value);

BroadResult result = choose(float3(0.0));
```

Both candidates infer successfully and have equal argument-conversion cost.
The current heuristic selects the broad `T : IFloat` overload solely because it has one required generic parameter instead of two.
Generic-parameter count does not establish a semantic specificity relationship between the accepted argument domains, so this rule can select a broader or less appropriate declaration.
The same arbitrary choice can interfere with declaration association that reuses overload resolution, including `[ForwardDerivativeOf(...)]` lookup.

Checking the 202c policy also exposed an invalid assumption in semantic-checking infrastructure.
Some ad hoc checking operations, including reflection overload specialization and LSP signature help, intentionally have no primary module.
The original language-version query obtained its version by dereferencing that optional module, so these public API and editor paths could crash as soon as overload resolution reached the compatibility rule.

The rule also became an accidental dependency of `import glsl;`.
Some redundant GLSL matrix-multiplication and vector-comparison declarations only avoided ambiguity because their generic-parameter counts differed from overlapping declarations.

Closes #12829.

## Proposed solution

Treat required generic-parameter count as a compatibility fallback instead of an ordinary overload-ranking criterion.
For current language modes, apply it only after argument conversion cost, lookup ranking, structural rules, scope ranking, `OverloadRank`, and every other ordinary criterion have failed to select a unique candidate.
Emit a default-on warning whenever this fallback changes an ambiguity into a selection, so affected code can be found before migrating to Slang 202c.
Keep the principled rule that an otherwise-equivalent non-generic declaration is more specific than a specialized generic as an ordinary criterion in every language version.

Slang 202c removes the fallback completely and reports the ambiguity.

Make the effective language version required state on every `SharedSemanticsContext`.
Module-bound contexts derive it from their required primary module, while moduleless contexts must provide it explicitly.
Reflection and other API string-checking operations use the linkage option, which defaults exactly as an ordinary compilation does.
The cached reflection context is replaced if a legacy compile request later changes that option through `spProcessCommandLineArguments`.
Reflection operations retain a strong snapshot of the selected context, so a later refresh cannot invalidate an in-flight caller.
LSP signature help remains moduleless for its existing linkage-wide extension lookup, but obtains its language version from the parsed document module so that `#language` and the configured predefined language version are honored.
Ad hoc operations whose declaration may legitimately have no owning module use an explicit optional-module construction path and fall back to the linkage's effective version.

Remove the redundant GLSL declarations that depended on the old ordering.
The surviving general matrix-multiplication overloads and arithmetic/logical vector-comparison overloads already cover those operations and use the existing `OverloadRank` mechanism to take precedence over core-module semantics.

These changes belong in one PR because removing the compatibility rule in 202c exposes the redundant GLSL overload ambiguities immediately; the GLSL cleanup is what makes the language-version change independently usable.

## Change summary

- Remove generic-parameter count from `compareOverloadCandidateSpecificity`.
- Preserve non-generic-over-specialized-generic specificity independently of parameter count.
- Add a final compatibility-resolution step over the tied `bestCandidates` frontier for language modes before Slang 202c.
- Diagnose warning `E40021`, `deprecated-generic-parameter-count-overload-tie-breaker`, when the fallback selects a candidate.
- Apply the same final fallback to initializer-based implicit-conversion overload resolution without caching a speculative compatibility selection.
- Store the effective language version directly in `SharedSemanticsContext`, with distinct construction paths for module-bound and moduleless checking.
- Make reflection checking lazily capture the configured session language version, refresh its cached context if that version changes, and return strong snapshots that remain valid across a later refresh.
- Give every other moduleless context an explicit version policy, including dynamic declaration checks where an owning module is legitimately optional.
- Use the parsed document module's language version for moduleless LSP signature-help checking.
- Delete redundant square-only GLSL matrix multiplication, floating-point vector comparison, and generated concrete vector comparison overloads.
- Document the 202c behavior change.
- Add regressions for the legacy warning, the Slang 202c ambiguity, exact-versus-variable vector shapes, `OverloadRank` precedence, speculative implicit-conversion cost checking, reflection overload specialization and cache refresh, LSP signature help, and GLSL operator selection in both default and 202c modes.

## Concepts and vocabulary

A *required generic parameter* is a generic parameter without a default argument.
The legacy heuristic counts required parameters on each specialized generic declaration; it does not compare constraints, parameter shapes, or accepted type domains.

The *candidate frontier* is `OverloadResolveContext::bestCandidates`, the set that remains tied after ordinary candidate comparisons.
Applying compatibility policy to this frontier makes the policy a true last criterion instead of letting it prevent later ranking rules from running.

`OverloadRank` is an existing explicit priority attached to declarations.
The GLSL module already uses it to place GLSL-flavored operators above overlapping core-module operators.

The *effective language version* is the language policy used by one semantic-checking context.
It normally comes from the primary source module, but an API operation that checks a standalone string or reflected declaration has no such module and must instead choose the linkage's configured default deliberately.

## Process report

Consider `choose(float3(0.0))` in the motivating example.
Generic inference specializes the first declaration with `T = float3` and the second with `T = float, N = 3`.
`TryCheckOverloadCandidate` finds both applicable with equal conversion cost.
Previously, `CompareOverloadCandidates` called `compareOverloadCandidateSpecificity`, which compared the required generic counts before reaching later criteria such as `OverloadRank`.
The comparison obtained `1` and `2` and selected the first declaration even though the counts say nothing reliable about which accepted domain is narrower.

The new flow leaves generic count out of `CompareOverloadCandidates`.
`AddOverloadCandidateInner` therefore constructs the frontier using only ordinary ranking policy.
After `AddOverloadCandidates` has completed, `tryResolveOverloadUsingLegacyGenericParameterCountFallback` inspects that frontier.
In a pre-202c language mode it preserves compatibility only when one candidate has a unique minimum required-parameter count, and the helper emits the warning at the source expression when its caller supplies a materialization sink.
In Slang 202c the helper declines to select anything, so the existing ambiguity diagnostic handles the call.
Because candidate status participates in ordinary ranking, the frontier is homogeneous; the helper asserts that invariant and declines to apply compatibility policy to an all-failed frontier that the ordinary overload diagnostic still needs.
An equal-count regression proves that a tied minimum remains ambiguous in every language and warning mode without emitting `E40021`.
A second regression creates two generic declarations with unequal parameter counts whose unused type parameters both fail inference.
It proves that the all-failed frontier remains an ordinary no-applicable-overload diagnostic with both candidate notes instead of being promoted by the compatibility fallback.
The regression also gives the shaped overload `[OverloadRank(1)]`; both language modes select it without a compatibility warning, proving that `OverloadRank` now runs first.
It separately compares `vector<T, 3>` with `vector<T, N>`.
That pair documents a specificity relationship Slang does not yet implement: the legacy fallback happens to select the fixed-shape declaration, while Slang 202c conservatively reports the unresolved ambiguity.

Consider the separate overload pair `f(int)` and `f<T>(T)` called with an `int`.
The non-generic declaration accepts a strict subset of the generic declaration's domain, and generic inference produces an otherwise-equivalent `f<int>(int)` candidate.
`compareOverloadCandidateSpecificity` detects the presence of a specialized generic through its parent `GenericDecl` and keeps the non-generic declaration as the ordinary winner in both legacy and 202c modes.
The regression also covers `f(int)` against `f<T = int>(int)`.
Even though the generic has no required parameters, it accepts explicit specialization arguments that the non-generic declaration does not, so the non-generic declaration remains more specific.
This comparison deliberately detects whether a candidate specializes a generic instead of inspecting or ranking its parameter count, preserving the principled relationship without retaining the arbitrary generic-vs-generic heuristic.

The frontier is the intentional source of truth for unresolved overload candidates, not an accidental alternate AST representation.
The helper does not reconstruct syntax, introduce a custom type-equivalence relation, or walk substitution graphs.
It acts at the overload finalization boundary and converts an intentionally ambiguous frontier into the existing single-candidate representation only for legacy compatibility.
Its declaration documents the exact success and failure postconditions, and the helper centralizes warning emission through an explicit optional sink.
`ResolveInvoke` always supplies its sink, while `_coerce` supplies one only when it is materializing an output expression; a speculative probe therefore cannot emit the warning by accident.

Initializer-based implicit conversions use the same candidate comparison machinery in `_coerce`.
A cost probe can invoke `_coerce` without requesting an output expression before the source-level conversion is reified.
That probe is a valid compiler input shape, so the compatibility fallback must participate in its cost, but diagnosing there would report a speculative use.
The implementation warns only when an expression is constructed and avoids caching a compatibility-selected conversion during the probe; the later real conversion therefore resolves the tie again and reports the warning at the actual source location.
A pair of focused tests passes `float3` to a parameter with two equally costly generic conversion initializers.
The 2026 test proves the probe does not suppress the eventual warning, while the 202c test proves the same conversion remains ambiguous.

Consider a user who loads a module through `ISession`, finds an overloaded `choose` function through reflection, and calls `specializeWithArgTypes(float3)`.
The reflection operation calls overload resolution through a shared semantic context that has no primary module because the operation is not checking one source file.
This moduleless shape is intentional, but an unknown language version is not: the session already owns the compiler option that defines how its strings and reflected operations are interpreted.
`SharedSemanticsContext` now stores that version directly.
Its module constructor requires a non-null module and derives the version from `ModuleDecl::languageVersion`; its moduleless constructor requires an explicit non-unknown version.
Each producer therefore owns its policy, and `isSlang2026OrLater` and `isSlang202cOrLater` no longer infer context indirectly through an optional pointer.

The reflection context must be created lazily because `Linkage` construction precedes population of the session's compiler options.
`Linkage::getSemanticsForReflection` creates it on first use under the existing component-operation mutex, after the configured language version is available.
The legacy compile-request API can also process `-std` after reflection has initialized this context.
The cache owner therefore compares the stored and current linkage versions and replaces a stale context at the same construction boundary.
`getSemanticsForReflection` returns a strong reference, and each checking operation retains that snapshot for the lifetime of its visitor.
`SemanticsContext` and `SemanticsVisitor` delete construction from a temporary `RefPtr`, so the unsafe pattern cannot compile; a caller must retain an owner explicitly instead of relying only on convention.
The caller therefore observes one consistent language-version policy even if a later operation replaces the linkage's cached context.
One reflection unit test creates 2026 and 202c sessions and verifies that the same tied overload set resolves only in the compatibility language mode.
Because the public reflection specialization API reports failure as null without exposing its diagnostic sink, the test first proves that 202c reflection resolves an otherwise-identical pair when `OverloadRank` distinguishes it; the focused source diagnostic test independently proves that the unranked pair is ambiguous.
A second test reflects in the default mode, applies `-std 202c` to the same legacy request, and verifies that the next query observes the new ambiguity instead of reusing the compatibility policy.

Some entry-point validation and LSP presentation operations begin with a declaration and obtain its module dynamically.
Those declarations can legitimately have no owning module, so forcing them through the module-bound constructor would turn a valid input shape into an assertion failure.
`createForOptionalModule` makes that shape explicit: it derives policy from a present module and otherwise requires the producer to supply the linkage's effective version.
The strict module constructor still rejects null, preserving one construction invariant instead of reintroducing an unknown-version state.

LSP signature help also intentionally uses a moduleless context so that extension lookup retains its linkage-wide point of view.
Unlike a reflection string, however, it has a parsed document module at the call site.
Passing that module's effective version preserves the existing lookup shape while honoring the document's `#language` directive; when there is no directive, parsing has already applied the workspace's `slang.predefinedLanguageVersion` setting or the ordinary compiler default.
A paired version-sensitive signature-help regression uses a tied implicit-conversion set plus an always-viable higher-cost fallback.
In 2026 the compatibility rule makes the lower-cost `Converted` parameter viable and selected; in 202c that conversion is ambiguous, so the viable `Fallback` parameter is selected instead.
Both expectations are positive candidate matches and therefore do not depend on signature-list ordering or the compiler's default language version.

The default-initializer overload-finalization path was audited for the same compatibility fallback.
A zero-argument generic constructor with required ordinary generic parameters fails inference rather than entering the applicable-candidate frontier, while defaulted generic parameters have a required count of zero.
Variadic generic constructor probes likewise either failed inference or were distinguished by ordinary ranking before finalization.
Because no current-language source shape reaches that path with an applicable tied frontier and a unique minimum required-generic count, adding an untestable hook would be dead policy rather than a compatibility fix.
The fallback remains at the finalization sites for which a regression can demonstrate that it changes an otherwise ambiguous result.

Generic application was audited separately because it retains tied applicable candidates in an `OverloadedExpr2` for a later invocation to disambiguate.
A revert drill temporarily restored the old comparator and exercised an explicit generic invocation whose declarations have different required generic-parameter counts.
The generic application retains the same tied candidate set in both implementations, and the invocation is then resolved by ordinary rules.
Because the removed comparison does not change this path's candidate result, adding a compatibility fallback there would not preserve an observable legacy behavior.

For `import glsl;`, the square-only `float`, `half`, and `double` matrix overloads are strict subsets of the surviving `operator*<T, L, C, R>` declaration and have identical bodies and requirements.
Similarly, `__BuiltinArithmeticType` includes the floating and integer scalar families, while `__BuiltinLogicalType` includes integer and Boolean families.
Those two generic vector-comparison overload groups cover the removed floating-only and generated concrete declarations.
Deleting the duplicates leaves one GLSL declaration per semantic operation, and their existing `OverloadRank` values select them over the core-module operations without the compatibility heuristic.

A new GLSL-only ranking attribute was considered but would have added another one-off language rule when the existing explicit rank is sufficient.
Adding new core-module interfaces or splitting the builtin modules more aggressively would enlarge the public surface and is not needed for this cleanup.

Validation performed:

- Built the Debug `slangc`, `slang-unit-test`, and `slangd` targets, including regenerated embedded core and GLSL modules.
- Passed the legacy, 202c, and warning-disabled generic-count diagnostic runs, 3/3 locally applicable tests.
  Directly verified that the warnings-as-errors invocation emits `error[E40021]` at both compatibility selections and that the equal-count call remains an ordinary ambiguity without `E40021`; CI runs the raw-FileCheck form of this fourth mode.
- Passed the focused implicit-conversion regressions in 2026 and 202c mode, 2/2.
  The 2026 case performs two conversions and requires a separate warning for each, proving the compatibility-selected method was not cached.
- Passed all locally applicable compile-only front-end tests in `tests/language-feature/generics`, 60/60; the raw-FileCheck warnings-as-errors case is the one locally ignored test.
- Passed all compile-only front-end tests in `tests/language-feature/operator-overload`, 3/3.
- Ran the legacy `import glsl;` operator regression under Slang 2026 with diagnostic `40021`
  promoted to an error, proving the surviving GLSL overloads resolve through ordinary ranking.
- Passed the reflection language-version and cache-refresh regressions plus the existing focused function-reflection unit tests, 4/4.
- Passed the focused entry-point diagnostics, 44/44 applicable tests.
- Compiled the GLSL regression directly to SPIR-V assembly under Slang 202c and confirmed three separate `OpMatrixTimesMatrix` instructions for `float2x2`, `half2x2`, and `double2x2` products.
- Verified the warning is default-on, suppressible by name, and promoted by warnings-as-errors.
- Documented diagnostic `40021` and its `-warnings-disable` and `-warnings-as-errors` controls in the 202c migration note.
- Verified existing generic-overload and legacy `import glsl;` checks compile without the new warning.
- Passed `git diff --check`; the repository-requested clang-format 17 is not installed locally, so CI remains authoritative for the new formatting check.

Ran both committed LSP signature-help requests through the local harness without FileCheck and confirmed that 202c selects `Fallback` while 2026 selects `Converted`.
Both candidates are selected through conversion-cost matching, so the pair proves the checked expectation depends on the document language version without relying on lookup order.
FileCheck itself is unavailable locally, so CI remains authoritative for matching the committed LSP directive.
Executable CPU tests were not available in this partial build because the local checkout lacks the RHI dependencies needed to rebuild the full test target.
