### PR TITLE
Fix Metal nested-existential layout: restore target-uniform uint2 handles, legalize vector<->pointer bit-casts

### DIFF
--- a/source/slang/slang-ir-lower-dynamic-dispatch-insts.cpp
+++ b/source/slang/slang-ir-lower-dynamic-dispatch-insts.cpp
@@ -1679,42 +1679,36 @@ struct ExistentialLoweringContext : public InstPassBase
         return true;
     }
 
-    // Dynamic-dispatch handles are 64-bit, so they need a 64-bit integer carrier.
-    // That carrier is `uint2` (chosen in PR #9386 to avoid requiring the SPIR-V
-    // Int64 capability), except on Metal: MSL cannot cast a vector to a pointer, so
-    // there the carrier is a scalar `ulong` (which can be cast to a `device T*`).
-    // The helpers below own this choice so call sites need not know it. See #11313.
-    bool useUInt64HandleRepresentation() { return isMetalTarget(targetProgram->getTargetReq()); }
+    // Dynamic-dispatch handles are 64-bit values carried as `uint2` (PR #9386; avoids
+    // the SPIR-V Int64 capability). The carrier must be the same on every target:
+    // handles live inside lowered existential tuples whose byte layout is host-visible
+    // ABI, and a scalar 64-bit carrier (natural alignment 8, vs 4 for `uint2`) would
+    // shift nested-existential payload layouts on that target alone (see #11313 and
+    // the nested-existential-in-buffer test). MSL cannot cast a vector to a pointer;
+    // legalizeIRForMetal splits such bit-casts through a scalar `uint64_t` instead of
+    // changing the carrier. The helpers below own the representation.
 
-    // Return the lowered IR type that carries a dynamic-dispatch handle: a scalar
-    // `ulong` on Metal, or a `uint2` elsewhere.
+    // Return the lowered IR type that carries a dynamic-dispatch handle: a `uint2`.
     IRType* getLoweredHandleType(IRBuilder& builder)
     {
-        if (useUInt64HandleRepresentation())
-            return builder.getUInt64Type();
         return builder.getVectorType(
             builder.getUIntType(),
             builder.getIntValue(builder.getIntType(), 2));
     }
 
     // Build a lowered handle value carrying the 32-bit `id` in its low bits, to
-    // match getLoweredHandleType(): zero-extend `id` into a `ulong` on Metal, or
-    // pack it into element 0 of a `uint2` (element 1 = 0) elsewhere.
+    // match getLoweredHandleType(): pack it into element 0 of a `uint2`
+    // (element 1 = 0).
     IRInst* makeHandleFromID(IRBuilder& builder, IRInst* id)
     {
-        if (useUInt64HandleRepresentation())
-            return builder.emitCast(builder.getUInt64Type(), id);
         IRInst* args[] = {id, builder.getIntValue(builder.getUIntType(), 0)};
         return builder.emitMakeVector(getLoweredHandleType(builder), 2, args);
     }
 
     // Read the 32-bit id back out of a lowered handle value produced by
-    // makeHandleFromID(): truncate the `ulong` to `uint` on Metal, or extract
-    // element 0 of the `uint2` elsewhere.
+    // makeHandleFromID(): extract element 0 of the `uint2`.
     IRInst* getIDFromHandle(IRBuilder& builder, IRInst* handle)
     {
-        if (useUInt64HandleRepresentation())
-            return builder.emitCast(builder.getUIntType(), handle);
         UInt index = 0;
         return builder.emitSwizzle(builder.getUIntType(), handle, 1, &index);
     }

--- a/source/slang/slang-ir-lower-dynamic-dispatch-insts.cpp
+++ b/source/slang/slang-ir-lower-dynamic-dispatch-insts.cpp
@@ -1680,13 +1680,11 @@ struct ExistentialLoweringContext : public InstPassBase
     }
 
     // Dynamic-dispatch handles are 64-bit values carried as `uint2` (PR #9386; avoids
-    // the SPIR-V Int64 capability). The carrier must be the same on every target:
-    // handles live inside lowered existential tuples whose byte layout is host-visible
-    // ABI, and a scalar 64-bit carrier (natural alignment 8, vs 4 for `uint2`) would
-    // shift nested-existential payload layouts on that target alone (see #11313 and
-    // the nested-existential-in-buffer test). MSL cannot cast a vector to a pointer;
-    // legalizeIRForMetal splits such bit-casts through a scalar `uint64_t` instead of
-    // changing the carrier. The helpers below own the representation.
+    // the SPIR-V Int64 capability). The carrier is host-visible ABI and must be the
+    // same on every target: a scalar 64-bit carrier aligns to 8 instead of 4 and shifts
+    // nested-existential payload layouts (see the nested-existential-in-buffer test).
+    // MSL can't cast a vector to a pointer; legalizeIRForMetal splits such casts
+    // through a scalar `uint64_t`. The helpers below own the representation.
 
     // Return the lowered IR type that carries a dynamic-dispatch handle: a `uint2`.
     IRType* getLoweredHandleType(IRBuilder& builder)

--- a/source/slang/slang-ir-metal-legalize.cpp
+++ b/source/slang/slang-ir-metal-legalize.cpp
@@ -211,6 +211,30 @@ struct MetalAddressSpaceAssigner : InitialAddressSpaceAssigner
     }
 };
 
+// Split a bit-cast between a vector and a pointer through a scalar `uint64_t`:
+// MSL rejects the direct cast (`(device T*)(uint2)` fails with "cannot cast from
+// type 'uint2' ... to pointer type"), but allows vector<->scalar `as_type` casts
+// and scalar<->pointer C-style casts. Such casts arise where a 64-bit value carried
+// as `uint2` for cross-target layout uniformity — a dynamic-dispatch handle
+// (`getLoweredHandleType`) or a pointer packed into an any-value payload
+// (`marshalBasicType`) — is reinterpreted as a real pointer.
+static void legalizeVectorPointerBitCast(IRInst* inst)
+{
+    auto toType = inst->getDataType();
+    auto fromType = inst->getOperand(0)->getDataType();
+    bool toIsPointer = as<IRPtrTypeBase>(toType) || as<IRRawPointerTypeBase>(toType);
+    bool fromIsPointer = as<IRPtrTypeBase>(fromType) || as<IRRawPointerTypeBase>(fromType);
+    bool toIsVector = as<IRVectorType>(toType) != nullptr;
+    bool fromIsVector = as<IRVectorType>(fromType) != nullptr;
+    if (!((toIsPointer && fromIsVector) || (toIsVector && fromIsPointer)))
+        return;
+
+    IRBuilder builder(inst);
+    builder.setInsertBefore(inst);
+    auto scalarHop = builder.emitBitCast(builder.getUInt64Type(), inst->getOperand(0));
+    inst->setOperand(0, scalarHop);
+}
+
 static void processInst(IRInst* inst, TargetProgram* targetProgram, DiagnosticSink* sink)
 {
     switch (inst->getOp())
@@ -238,6 +262,9 @@ static void processInst(IRInst* inst, TargetProgram* targetProgram, DiagnosticSi
         break;
     case kIROp_MeshOutputRef:
         sink->diagnose(Diagnostics::AssignToRefNotSupported{.location = getDiagnosticPos(inst)});
+        break;
+    case kIROp_BitCast:
+        legalizeVectorPointerBitCast(inst);
         break;
     case kIROp_MetalCastToDepthTexture:
         {

--- a/source/slang/slang-ir-metal-legalize.cpp
+++ b/source/slang/slang-ir-metal-legalize.cpp
@@ -211,13 +211,10 @@ struct MetalAddressSpaceAssigner : InitialAddressSpaceAssigner
     }
 };
 
-// Split a bit-cast between a vector and a pointer through a scalar `uint64_t`:
-// MSL rejects the direct cast (`(device T*)(uint2)` fails with "cannot cast from
-// type 'uint2' ... to pointer type"), but allows vector<->scalar `as_type` casts
-// and scalar<->pointer C-style casts. Such casts arise where a 64-bit value carried
-// as `uint2` for cross-target layout uniformity — a dynamic-dispatch handle
-// (`getLoweredHandleType`) or a pointer packed into an any-value payload
-// (`marshalBasicType`) — is reinterpreted as a real pointer.
+// MSL rejects a direct cast between a vector and a pointer, but allows vector<->scalar
+// `as_type` and scalar<->pointer C-style casts — so split the bit-cast through a scalar
+// `uint64_t`. Such casts arise when a 64-bit value carried as `uint2` (a dynamic-dispatch
+// handle, or a pointer packed into an any-value payload) is reinterpreted as a pointer.
 static void legalizeVectorPointerBitCast(IRInst* inst)
 {
     auto toType = inst->getDataType();

--- a/tests/language-feature/dynamic-dispatch/buffer-address-ref.slang
+++ b/tests/language-feature/dynamic-dispatch/buffer-address-ref.slang
@@ -17,6 +17,7 @@
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-vk -emit-spirv-directly -output-using-type
 //TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cuda -output-using-type
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-llvm -compute -shaderobj -output-using-type
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-metal -compute -shaderobj -output-using-type
 
 [anyValueSize(8)]
 interface IValue

--- a/tests/language-feature/dynamic-dispatch/nested-existential-in-buffer.slang
+++ b/tests/language-feature/dynamic-dispatch/nested-existential-in-buffer.slang
@@ -1,0 +1,78 @@
+//TEST:COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cpu -compute -shaderobj -output-using-type
+//TEST:COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-metal -compute -shaderobj -output-using-type
+//TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type -emit-spirv-directly
+//TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
+
+// Interface A (impls A0, A1) and interface B (impls B0, B1), where BOTH impls of A
+// contain an interface-typed (B) member — an existential field nested inside another
+// existential. The IA values are provided directly as the contents of a
+// RWStructuredBuffer<IA>, so dispatch is fully dynamic: the shader only loads them back
+// and calls evaluate(). This exercises (a) a nested existential unpacked straight from the
+// buffer and (b) two different impls in the same dispatch set each binding their own nested
+// existential independently. The buffer data below hardcodes the box layout, so this test
+// also guards the cross-target ABI: a nested box header is packed `uint2` pairs (alignment 4)
+// on every target — a target-specific scalar 64-bit handle carrier would realign it. The
+// single `uint pos` before `inner` is what makes that observable: it puts the nested box at
+// payload offset 4, where an 8-aligned carrier inserts padding (unlike
+// optional-downcast-struct-with-interface-field.slang, whose nested box sits 8-aligned at
+// offset 32 and cannot detect the difference). Keep `pos` a single 4-byte field.
+
+[anyValueSize(32)]
+interface IB
+{
+    uint getValue();
+}
+
+struct B0 : IB
+{
+    uint value;
+    uint getValue() { return value; }
+};
+
+struct B1 : IB
+{
+    uint getValue() { return 99; }
+};
+
+[anyValueSize(64)]
+interface IA
+{
+    uint evaluate();
+}
+
+struct A0 : IA
+{
+    uint pos;
+    IB inner;
+    uint evaluate() { return pos + inner.getValue(); }
+};
+
+struct A1 : IA
+{
+    uint pos;
+    IB inner;
+    uint evaluate() { return inner.getValue(); }
+};
+
+//TEST_INPUT: type_conformance B0:IB = 2
+//TEST_INPUT: type_conformance B1:IB = 1
+//TEST_INPUT: type_conformance A0:IA = 2
+//TEST_INPUT: type_conformance A1:IA = 1
+
+// Two existentials laid out directly in the buffer (20 words each). Every existential —
+// outer and nested — is a 4-word box header (RTTI handle uint2, then witness handle uint2)
+// followed by its payload, and encodes its concrete type with the host-controllable
+// sequential id from `type_conformance` (in the witness handle's low word):
+//TEST_INPUT: set things = ubuffer(data=[0 0 2 0 22 0 0 2 0 11 0 0 0 0 0 0 0 0 0 0  0 0 1 0 5 0 0 1 0 3 0 0 0 0 0 0 0 0 0 0], stride=4)
+RWStructuredBuffer<IA> things;
+//TEST_INPUT: set output = out ubuffer(data=[0 0 0 0], stride=4)
+RWStructuredBuffer<float> output;
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    output[0] = things[0].evaluate();
+    output[1] = things[1].evaluate();
+    // CHECK: 33
+    // CHECK: 99
+}

--- a/tests/language-feature/dynamic-dispatch/nested-existential-in-buffer.slang
+++ b/tests/language-feature/dynamic-dispatch/nested-existential-in-buffer.slang
@@ -3,19 +3,13 @@
 //TEST(compute, vulkan):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-vk -compute -shaderobj -output-using-type -emit-spirv-directly
 //TEST(compute):COMPARE_COMPUTE_EX(filecheck-buffer=CHECK):-cuda -compute -shaderobj -output-using-type
 
-// Interface A (impls A0, A1) and interface B (impls B0, B1), where BOTH impls of A
-// contain an interface-typed (B) member — an existential field nested inside another
-// existential. The IA values are provided directly as the contents of a
-// RWStructuredBuffer<IA>, so dispatch is fully dynamic: the shader only loads them back
-// and calls evaluate(). This exercises (a) a nested existential unpacked straight from the
-// buffer and (b) two different impls in the same dispatch set each binding their own nested
-// existential independently. The buffer data below hardcodes the box layout, so this test
-// also guards the cross-target ABI: a nested box header is packed `uint2` pairs (alignment 4)
-// on every target — a target-specific scalar 64-bit handle carrier would realign it. The
-// single `uint pos` before `inner` is what makes that observable: it puts the nested box at
-// payload offset 4, where an 8-aligned carrier inserts padding (unlike
-// optional-downcast-struct-with-interface-field.slang, whose nested box sits 8-aligned at
-// offset 32 and cannot detect the difference). Keep `pos` a single 4-byte field.
+// Both impls of IA carry an interface-typed (IB) field — an existential nested inside
+// another existential. The IA values come straight from host-written buffer contents, so
+// dispatch is fully dynamic and each impl binds its own nested existential.
+// The hardcoded buffer data also guards the cross-target layout ABI: box headers are
+// packed `uint2` pairs (alignment 4) on every target. The single `uint pos` before
+// `inner` puts the nested box at payload offset 4, where an 8-aligned handle carrier
+// would insert padding — keep `pos` a single 4-byte field.
 
 [anyValueSize(32)]
 interface IB


### PR DESCRIPTION
#11787 (fixing #11313) changed the dynamic-dispatch handle carrier on Metal from `uint2` (#9386) to `ulong`. Both are 8 bytes, but their natural alignment differs: `ulong` aligns to 8, `uint2` to 4. Existential boxes and any-value payloads are laid out by natural alignment, so any struct containing a handle could get different field offsets on Metal than on every other target. These layouts are host-visible ABI: hosts serialize existentials directly into buffers, and data written against the common layout is misread on Metal; dispatch reads a wrong witness id and silently falls to the default arm.
