### PR TITLE
Fix shader-coverage demo summarize() to iterate entries, not counters

### DIFF
--- a/examples/shader-coverage-bvh-traversal/main.cpp
+++ b/examples/shader-coverage-bvh-traversal/main.cpp
@@ -628,13 +628,21 @@ CoverageSummary summarize(
     const std::vector<uint64_t>& hits)
 {
     CoverageSummary s = {};
-    const uint32_t n = coverage->getCounterCount();
+    // Iterate entries ([0, getEntryCount())), not counters: several
+    // entries can share one counterIndex once line coverage coalesces
+    // markers, so a counter-indexed loop both under-visits (stops at
+    // getCounterCount() < getEntryCount()) and misattributes hits (entry
+    // i's counter is not generally counter i). Look each entry's counter
+    // up by its own counterIndex instead.
+    const uint32_t n = coverage->getEntryCount();
     for (uint32_t i = 0; i < n; ++i)
     {
         slang::CoverageEntryInfo entry = {};
         if (SLANG_FAILED(coverage->getEntryInfo(i, &entry)))
             continue;
-        const bool covered = hits[i] > 0;
+        const bool covered = entry.counterIndex != slang::kInvalidCoverageCounterIndex &&
+                             entry.counterIndex < (uint32_t)hits.size() &&
+                             hits[entry.counterIndex] > 0;
         switch (entry.kind)
         {
         case slang::CoverageEntryKind::Line:

--- a/examples/shader-coverage-image-pipeline/main.cpp
+++ b/examples/shader-coverage-image-pipeline/main.cpp
@@ -563,13 +563,21 @@ CoverageSummary summarize(
     const std::vector<uint64_t>& hits)
 {
     CoverageSummary s = {};
-    const uint32_t n = coverage->getCounterCount();
+    // Iterate entries ([0, getEntryCount())), not counters: several
+    // entries can share one counterIndex once line coverage coalesces
+    // markers, so a counter-indexed loop both under-visits (stops at
+    // getCounterCount() < getEntryCount()) and misattributes hits (entry
+    // i's counter is not generally counter i). Look each entry's counter
+    // up by its own counterIndex instead, mirroring writeLcov() below.
+    const uint32_t n = coverage->getEntryCount();
     for (uint32_t i = 0; i < n; ++i)
     {
         slang::CoverageEntryInfo entry = {};
         if (SLANG_FAILED(coverage->getEntryInfo(i, &entry)))
             continue;
-        const bool covered = hits[i] > 0;
+        const bool covered = entry.counterIndex != slang::kInvalidCoverageCounterIndex &&
+                             entry.counterIndex < (uint32_t)hits.size() &&
+                             hits[entry.counterIndex] > 0;
         switch (entry.kind)
         {
         case slang::CoverageEntryKind::Line:


### PR DESCRIPTION
## Motivation

Both `shader-coverage-image-pipeline` and `shader-coverage-bvh-traversal` (`examples/`) have a `summarize()` helper that prints the on-screen line/function/branch coverage summary. It loops `i` over `[0, coverage->getCounterCount())` and calls `coverage->getEntryInfo(i, &entry)`, then reads `hits[i]`, effectively treating a *counter* index as an *entry* index.

`ICoverageTracingMetadata::getEntryInfo`'s own contract states the valid range is `[0, getEntryCount())`. This was harmless as long as `getCounterCount() == getEntryCount()`, i.e. every entry had a dedicated counter — true for every existing compile before #12683 (line-coverage counter coalescing) landed. Once counters can be shared by several entries, `getCounterCount() < getEntryCount()`, and the loop both stops early (silently drops the tail of the entries) and reads the wrong slot for entries whose `counterIndex` isn't equal to their own position.

Concretely, running `shader-coverage-image-pipeline --mode=smoke` against a compiler with coalescing enabled prints `function: 7/11, branch: 8/25, line: 37/84` on-screen — the true totals are `11/17`, `12/40`, `55/123`. The `.lcov` file the same run writes is unaffected (its writer already loops entries and looks up `entry.counterIndex` correctly), so this is a display-only bug, but a misleading one for anyone watching the console output.

## Proposed solution

Loop `[0, getEntryCount())` instead, and read `hits[entry.counterIndex]` (guarding `kInvalidCoverageCounterIndex` and bounds) rather than `hits[i]` — mirroring the pattern the same files already use correctly in `writeLcov()`.

## Change summary

| File | Change |
|---|---|
| `examples/shader-coverage-image-pipeline/main.cpp` | Fix `summarize()`'s loop bound and per-entry counter lookup. |
| `examples/shader-coverage-bvh-traversal/main.cpp` | Same fix, identical pre-existing pattern. |

## Process report

This is a pre-existing latent bug (the loop was always technically out of `getEntryInfo`'s documented contract), not something introduced by #12683 — that PR just happens to be the first case where `counterCount != entryCount`, which is what makes the bug produce visibly wrong output. Fixing it here keeps #12683 focused on the coalescing change itself. Verified by rebuilding both demos, confirming the fix is a no-op against an unmodified compiler (counterCount == entryCount, output unchanged), and confirming it restores the correct totals when built against a compiler with coalescing enabled.