### PR TITLE
slangc: add support for reflecting through pointers when writing json

### DIFF
--- a/source/slang/slang-reflection-json.cpp
+++ b/source/slang/slang-reflection-json.cpp
@@ -5,6 +5,7 @@
 #include "slang-ast-support-types.h"
 #include "slang.h"
 
+
 template<typename T>
 struct Range
 {
@@ -54,9 +55,30 @@ Range<T> makeRange(T end)
 namespace Slang
 {
 
-static void emitReflectionVarInfoJSON(PrettyWriter& writer, slang::VariableReflection* var);
-static void emitReflectionTypeLayoutJSON(PrettyWriter& writer, slang::TypeLayoutReflection* type);
-static void emitReflectionTypeJSON(PrettyWriter& writer, slang::TypeReflection* type);
+namespace
+{
+class ReflectionTracker
+{
+public:
+    void recordVisitedType(slang::TypeReflection* type)
+    {
+        m_visitedStructTypes.add(type);
+    }
+
+    [[nodiscard]] bool canRecurseIntoType(slang::TypeReflection* type)
+    {
+        return !m_visitedStructTypes.contains(type);
+    }
+
+private:
+    HashSet<slang::TypeReflection*> m_visitedStructTypes;
+};
+} // namespace
+
+static void emitReflectionVarInfoJSON(PrettyWriter& writer, slang::VariableReflection* var, ReflectionTracker& currentReflectionStatus);
+static void emitReflectionTypeLayoutJSON(PrettyWriter& writer, slang::TypeLayoutReflection* type,
+        ReflectionTracker& visitedTypes);
+static void emitReflectionTypeJSON(PrettyWriter& writer, slang::TypeReflection* type, ReflectionTracker& reflectionStatus);
 static slang::ShaderReflection* g_inProgramLayout = nullptr;
 
 static void emitReflectionSize(PrettyWriter& writer, size_t size)
@@ -415,7 +437,8 @@ static slang::TypeLayoutReflection* maybeChangeTypeLayoutToAgumentBufferTier2(
     return nullptr;
 }
 
-static void emitReflectionVarLayoutJSON(PrettyWriter& writer, slang::VariableLayoutReflection* var)
+static void emitReflectionVarLayoutJSON(PrettyWriter& writer, slang::VariableLayoutReflection* var,
+    ReflectionTracker& visitedTypes)
 {
     writer << "{\n";
     writer.indent();
@@ -432,11 +455,11 @@ static void emitReflectionVarLayoutJSON(PrettyWriter& writer, slang::VariableLay
     writer << "\"type\": ";
     if (auto newTypeLayout = maybeChangeTypeLayoutToAgumentBufferTier2(var))
     {
-        emitReflectionTypeLayoutJSON(writer, newTypeLayout);
+        emitReflectionTypeLayoutJSON(writer, newTypeLayout, visitedTypes);
     }
     else
     {
-        emitReflectionTypeLayoutJSON(writer, var->getTypeLayout());
+        emitReflectionTypeLayoutJSON(writer, var->getTypeLayout(), visitedTypes);
     }
 
     if (auto variable = var->getVariable())
@@ -577,7 +600,7 @@ static void emitReflectionResourceTypeBaseInfoJSON(
     }
 }
 
-static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflection* type)
+static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflection* type, ReflectionTracker& reflectionTracker)
 {
     auto kind = type->getKind();
     switch (kind)
@@ -612,7 +635,7 @@ static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflecti
                 {
                     writer.maybeComma();
                     writer << "\"resultType\": ";
-                    emitReflectionTypeJSON(writer, resultType);
+                    emitReflectionTypeJSON(writer, resultType, reflectionTracker);
                 }
                 break;
             }
@@ -624,7 +647,7 @@ static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflecti
         writer << "\"kind\": \"constantBuffer\"";
         writer.maybeComma();
         writer << "\"elementType\": ";
-        emitReflectionTypeJSON(writer, type->getElementType());
+        emitReflectionTypeJSON(writer, type->getElementType(), reflectionTracker);
         break;
 
     case slang::TypeReflection::Kind::ParameterBlock:
@@ -632,7 +655,7 @@ static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflecti
         writer << "\"kind\": \"parameterBlock\"";
         writer.maybeComma();
         writer << "\"elementType\": ";
-        emitReflectionTypeJSON(writer, type->getElementType());
+        emitReflectionTypeJSON(writer, type->getElementType(), reflectionTracker);
         break;
 
     case slang::TypeReflection::Kind::TextureBuffer:
@@ -640,7 +663,7 @@ static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflecti
         writer << "\"kind\": \"textureBuffer\"";
         writer.maybeComma();
         writer << "\"elementType\": ";
-        emitReflectionTypeJSON(writer, type->getElementType());
+        emitReflectionTypeJSON(writer, type->getElementType(), reflectionTracker);
         break;
 
     case slang::TypeReflection::Kind::ShaderStorageBuffer:
@@ -648,7 +671,7 @@ static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflecti
         writer << "\"kind\": \"shaderStorageBuffer\"";
         writer.maybeComma();
         writer << "\"elementType\": ";
-        emitReflectionTypeJSON(writer, type->getElementType());
+        emitReflectionTypeJSON(writer, type->getElementType(), reflectionTracker);
         break;
 
     case slang::TypeReflection::Kind::Scalar:
@@ -666,7 +689,7 @@ static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflecti
         emitReflectionSize(writer, type->getElementCount());
         writer.maybeComma();
         writer << "\"elementType\": ";
-        emitReflectionTypeJSON(writer, type->getElementType());
+        emitReflectionTypeJSON(writer, type->getElementType(), reflectionTracker);
         break;
 
     case slang::TypeReflection::Kind::Matrix:
@@ -680,7 +703,7 @@ static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflecti
         writer << type->getColumnCount();
         writer.maybeComma();
         writer << "\"elementType\": ";
-        emitReflectionTypeJSON(writer, type->getElementType());
+        emitReflectionTypeJSON(writer, type->getElementType(), reflectionTracker);
         break;
 
     case slang::TypeReflection::Kind::Array:
@@ -693,7 +716,7 @@ static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflecti
             emitReflectionSize(writer, arrayType->getElementCount());
             writer.maybeComma();
             writer << "\"elementType\": ";
-            emitReflectionTypeJSON(writer, arrayType->getElementType());
+            emitReflectionTypeJSON(writer, arrayType->getElementType(), reflectionTracker);
         }
         break;
     case slang::TypeReflection::Kind::Pointer:
@@ -703,7 +726,15 @@ static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflecti
             writer << "\"kind\": \"pointer\"";
             writer.maybeComma();
             writer << "\"targetType\": ";
-            emitReflectionTypeJSON(writer, pointerType->getElementType());
+
+            auto pointeeType = pointerType->getElementType();
+            if (reflectionTracker.canRecurseIntoType(pointeeType))
+            {
+                emitReflectionTypeJSON(writer, pointeeType, reflectionTracker);
+            } else
+            {
+                writer.writeEscapedString(UnownedStringSlice(pointeeType->getName()));
+            }
         }
         break;
 
@@ -712,19 +743,27 @@ static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflecti
             writer.maybeComma();
             writer << "\"kind\": \"struct\"";
             writer.maybeComma();
-            writer << "\"fields\": [\n";
-            writer.indent();
 
             auto structType = type;
-            auto fieldCount = structType->getFieldCount();
-            for (uint32_t ff = 0; ff < fieldCount; ++ff)
+            if (reflectionTracker.canRecurseIntoType(structType))
             {
-                if (ff != 0)
-                    writer << ",\n";
-                emitReflectionVarInfoJSON(writer, structType->getFieldByIndex(ff));
+                reflectionTracker.recordVisitedType(structType);
+                writer << "\"fields\": [\n";
+                writer.indent();
+
+                auto fieldCount = structType->getFieldCount();
+                for (uint32_t ff = 0; ff < fieldCount; ++ff)
+                {
+                    if (ff != 0)
+                        writer << ",\n";
+                    emitReflectionVarInfoJSON(writer, structType->getFieldByIndex(ff), reflectionTracker);
+                }
+                writer.dedent();
+                writer << "\n]";
+            } else
+            {
+                writer << "\"valueType\": ";
             }
-            writer.dedent();
-            writer << "\n]";
         }
         break;
 
@@ -774,6 +813,7 @@ static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflecti
 static void emitReflectionParameterGroupTypeLayoutInfoJSON(
     PrettyWriter& writer,
     slang::TypeLayoutReflection* typeLayout,
+    ReflectionTracker& visitedTypes,
     const char* kind)
 {
     // Go through the comma tracker so a key appended after this object (e.g. `sizes`) is
@@ -790,11 +830,11 @@ static void emitReflectionParameterGroupTypeLayoutInfoJSON(
     {
         // If we are in argument buffer tier 2, we need to use the new type layout
         // that has the correct binding information.
-        emitReflectionTypeLayoutJSON(writer, newElementTypeLayout);
+        emitReflectionTypeLayoutJSON(writer, newElementTypeLayout, visitedTypes);
     }
     else
     {
-        emitReflectionTypeLayoutJSON(writer, typeLayout->getElementTypeLayout());
+        emitReflectionTypeLayoutJSON(writer, typeLayout->getElementTypeLayout(), visitedTypes);
     }
 
     // Note: There is a subtle detail below when it comes to the
@@ -839,17 +879,18 @@ static void emitReflectionParameterGroupTypeLayoutInfoJSON(
     }
 
     writer << ",\n\"elementVarLayout\": ";
-    emitReflectionVarLayoutJSON(writer, typeLayout->getElementVarLayout());
+    emitReflectionVarLayoutJSON(writer, typeLayout->getElementVarLayout(), visitedTypes);
 }
 
 static void emitReflectionTypeLayoutKindInfoJSON(
     PrettyWriter& writer,
-    slang::TypeLayoutReflection* typeLayout)
+    slang::TypeLayoutReflection* typeLayout,
+    ReflectionTracker currentReflectionStatus)
 {
     switch (typeLayout->getKind())
     {
     default:
-        emitReflectionTypeInfoJSON(writer, typeLayout->getType());
+        emitReflectionTypeInfoJSON(writer, typeLayout->getType(), currentReflectionStatus);
         break;
 
     case slang::TypeReflection::Kind::Pointer:
@@ -859,18 +900,22 @@ static void emitReflectionTypeLayoutKindInfoJSON(
 
             writer.maybeComma();
             writer << "\"kind\": \"pointer\"";
-
             writer.maybeComma();
             writer << "\"valueType\": ";
 
             auto typeName = valueTypeLayout->getType()->getName();
-
+            auto valueType = valueTypeLayout->getType();
             if (typeName && typeName[0])
             {
-                // TODO(JS):
-                // We can't emit the type layout, because the type could contain
-                // a pointer and we end up in a recursive loop. For now we output the typename.
-                writer.writeEscapedString(UnownedStringSlice(typeName));
+                if (valueType->getScalarType() == slang::TypeReflection::None
+                    && currentReflectionStatus.canRecurseIntoType(valueType))
+                {
+                    currentReflectionStatus.recordVisitedType(valueType);
+                    emitReflectionTypeLayoutJSON(writer, typeLayout->getElementTypeLayout(),currentReflectionStatus);
+                } else
+                {
+                    writer.writeEscapedString(UnownedStringSlice(typeName));
+                }
             }
             else
             {
@@ -899,7 +944,7 @@ static void emitReflectionTypeLayoutKindInfoJSON(
 
             writer.maybeComma();
             writer << "\"elementType\": ";
-            emitReflectionTypeLayoutJSON(writer, elementTypeLayout);
+            emitReflectionTypeLayoutJSON(writer, elementTypeLayout, currentReflectionStatus);
 
             if (arrayTypeLayout->getSize(SLANG_PARAMETER_CATEGORY_UNIFORM) != 0)
             {
@@ -915,7 +960,7 @@ static void emitReflectionTypeLayoutKindInfoJSON(
     case slang::TypeReflection::Kind::Struct:
         {
             auto structTypeLayout = typeLayout;
-
+            currentReflectionStatus.recordVisitedType(structTypeLayout->getType());
             writer.maybeComma();
             writer << "\"kind\": \"struct\"";
             if (auto name = structTypeLayout->getName())
@@ -932,7 +977,7 @@ static void emitReflectionTypeLayoutKindInfoJSON(
             {
                 if (ff != 0)
                     writer << ",\n";
-                emitReflectionVarLayoutJSON(writer, structTypeLayout->getFieldByIndex(ff));
+                emitReflectionVarLayoutJSON(writer, structTypeLayout->getFieldByIndex(ff), currentReflectionStatus);
             }
             writer.dedent();
             writer << "\n]";
@@ -941,19 +986,19 @@ static void emitReflectionTypeLayoutKindInfoJSON(
         break;
 
     case slang::TypeReflection::Kind::ConstantBuffer:
-        emitReflectionParameterGroupTypeLayoutInfoJSON(writer, typeLayout, "constantBuffer");
+        emitReflectionParameterGroupTypeLayoutInfoJSON(writer, typeLayout, currentReflectionStatus, "constantBuffer");
         break;
 
     case slang::TypeReflection::Kind::OutputStream:
-        emitReflectionParameterGroupTypeLayoutInfoJSON(writer, typeLayout, "outputStream");
+        emitReflectionParameterGroupTypeLayoutInfoJSON(writer, typeLayout, currentReflectionStatus, "outputStream");
         break;
 
     case slang::TypeReflection::Kind::ParameterBlock:
-        emitReflectionParameterGroupTypeLayoutInfoJSON(writer, typeLayout, "parameterBlock");
+        emitReflectionParameterGroupTypeLayoutInfoJSON(writer, typeLayout, currentReflectionStatus, "parameterBlock");
         break;
 
     case slang::TypeReflection::Kind::TextureBuffer:
-        emitReflectionParameterGroupTypeLayoutInfoJSON(writer, typeLayout, "textureBuffer");
+        emitReflectionParameterGroupTypeLayoutInfoJSON(writer, typeLayout, currentReflectionStatus, "textureBuffer");
         break;
 
     case slang::TypeReflection::Kind::ShaderStorageBuffer:
@@ -962,7 +1007,7 @@ static void emitReflectionTypeLayoutKindInfoJSON(
 
         writer.maybeComma();
         writer << "\"elementType\": ";
-        emitReflectionTypeLayoutJSON(writer, typeLayout->getElementTypeLayout());
+        emitReflectionTypeLayoutJSON(writer, typeLayout->getElementTypeLayout(), currentReflectionStatus);
         break;
     case slang::TypeReflection::Kind::GenericTypeParameter:
         writer.maybeComma();
@@ -999,7 +1044,7 @@ static void emitReflectionTypeLayoutKindInfoJSON(
                 {
                     writer.maybeComma();
                     writer << "\"resultType\": ";
-                    emitReflectionTypeLayoutJSON(writer, resultTypeLayout);
+                    emitReflectionTypeLayoutJSON(writer, resultTypeLayout, currentReflectionStatus);
                 }
             }
             else if (shape & SLANG_TEXTURE_FEEDBACK_FLAG)
@@ -1010,12 +1055,12 @@ static void emitReflectionTypeLayoutKindInfoJSON(
                 {
                     writer.maybeComma();
                     writer << "\"resultType\": ";
-                    emitReflectionTypeJSON(writer, resultType);
+                    emitReflectionTypeJSON(writer, resultType, currentReflectionStatus);
                 }
             }
             else
             {
-                emitReflectionTypeInfoJSON(writer, type);
+                emitReflectionTypeInfoJSON(writer, type, currentReflectionStatus);
             }
         }
         break;
@@ -1064,35 +1109,37 @@ static void emitReflectionTypeLayoutSizeInfoJSON(
 
 static void emitReflectionTypeLayoutInfoJSON(
     PrettyWriter& writer,
-    slang::TypeLayoutReflection* typeLayout)
+    slang::TypeLayoutReflection* typeLayout,
+    ReflectionTracker& visitedTypes)
 {
-    emitReflectionTypeLayoutKindInfoJSON(writer, typeLayout);
+    emitReflectionTypeLayoutKindInfoJSON(writer, typeLayout, visitedTypes);
     emitReflectionTypeLayoutSizeInfoJSON(writer, typeLayout);
 }
 
 static void emitReflectionTypeLayoutJSON(
     PrettyWriter& writer,
-    slang::TypeLayoutReflection* typeLayout)
+    slang::TypeLayoutReflection* typeLayout,
+    ReflectionTracker& visitedTypes)
 {
     CommaTrackerRAII commaTracker(writer);
     writer << "{\n";
     writer.indent();
-    emitReflectionTypeLayoutInfoJSON(writer, typeLayout);
+    emitReflectionTypeLayoutInfoJSON(writer, typeLayout, visitedTypes);
     writer.dedent();
     writer << "\n}";
 }
 
-static void emitReflectionTypeJSON(PrettyWriter& writer, slang::TypeReflection* type)
+static void emitReflectionTypeJSON(PrettyWriter& writer, slang::TypeReflection* type, ReflectionTracker& reflectionStatus)
 {
     CommaTrackerRAII commaTracker(writer);
     writer << "{\n";
     writer.indent();
-    emitReflectionTypeInfoJSON(writer, type);
+    emitReflectionTypeInfoJSON(writer, type, reflectionStatus);
     writer.dedent();
     writer << "\n}";
 }
 
-static void emitReflectionVarInfoJSON(PrettyWriter& writer, slang::VariableReflection* var)
+static void emitReflectionVarInfoJSON(PrettyWriter& writer, slang::VariableReflection* var, ReflectionTracker& currentReflectionStatus)
 {
     emitReflectionNameInfoJSON(writer, var->getName());
 
@@ -1100,10 +1147,11 @@ static void emitReflectionVarInfoJSON(PrettyWriter& writer, slang::VariableRefle
 
     writer << ",\n";
     writer << "\"type\": ";
-    emitReflectionTypeJSON(writer, var->getType());
+    emitReflectionTypeJSON(writer, var->getType(), currentReflectionStatus);
 }
 
-static void emitReflectionParamJSON(PrettyWriter& writer, slang::VariableLayoutReflection* param)
+static void emitReflectionParamJSON(PrettyWriter& writer, slang::VariableLayoutReflection* param,
+    ReflectionTracker& visitedTypes)
 {
     // TODO: This function is likely redundant with `emitReflectionVarLayoutJSON`
     // and we should try to collapse them into one.
@@ -1128,7 +1176,7 @@ static void emitReflectionParamJSON(PrettyWriter& writer, slang::VariableLayoutR
 
     writer.maybeComma();
     writer << "\"type\": ";
-    emitReflectionTypeLayoutJSON(writer, param->getTypeLayout());
+    emitReflectionTypeLayoutJSON(writer, param->getTypeLayout(), visitedTypes);
 
     writer.dedent();
     writer << "\n}";
@@ -1140,7 +1188,8 @@ static void emitReflectionParamJSON(PrettyWriter& writer, slang::VariableLayoutR
 // which correctly yields `"parameters": []`.
 static void emitReflectionScopeParametersJSON(
     PrettyWriter& writer,
-    slang::TypeLayoutReflection* structTypeLayout)
+    slang::TypeLayoutReflection* structTypeLayout,
+    ReflectionTracker& visitedTypes)
 {
     SLANG_ASSERT(structTypeLayout->getKind() == slang::TypeReflection::Kind::Struct);
 
@@ -1152,7 +1201,7 @@ static void emitReflectionScopeParametersJSON(
     {
         if (pp != 0)
             writer << ",\n";
-        emitReflectionParamJSON(writer, structTypeLayout->getFieldByIndex(pp));
+        emitReflectionParamJSON(writer, structTypeLayout->getFieldByIndex(pp), visitedTypes);
     }
     writer.dedent();
     writer << "\n]";
@@ -1171,7 +1220,8 @@ static void emitReflectionScopeParametersJSON(
 // parameter-group layout whose element var-layout is that same struct (`kind: "constantBuffer"`).
 static void emitReflectionScopeJSON(
     PrettyWriter& writer,
-    slang::VariableLayoutReflection* scopeVarLayout)
+    slang::VariableLayoutReflection* scopeVarLayout,
+    ReflectionTracker& visitedTypes)
 {
     writer << "{\n";
     writer.indent();
@@ -1183,7 +1233,7 @@ static void emitReflectionScopeJSON(
     case slang::TypeReflection::Kind::Struct:
         writer.maybeComma();
         writer << "\"kind\": \"none\"";
-        emitReflectionScopeParametersJSON(writer, scopeTypeLayout);
+        emitReflectionScopeParametersJSON(writer, scopeTypeLayout, visitedTypes);
         break;
 
     case slang::TypeReflection::Kind::ConstantBuffer:
@@ -1194,7 +1244,8 @@ static void emitReflectionScopeJSON(
 
         emitReflectionScopeParametersJSON(
             writer,
-            scopeTypeLayout->getElementVarLayout()->getTypeLayout());
+            scopeTypeLayout->getElementVarLayout()->getTypeLayout(),
+            visitedTypes);
         break;
 
     default:
@@ -1230,7 +1281,7 @@ static void emitEntryPointParamJSON(
 
 static void emitReflectionTypeParamJSON(
     PrettyWriter& writer,
-    slang::TypeParameterReflection* typeParam)
+    slang::TypeParameterReflection* typeParam, ReflectionTracker& currentReflectionStatus)
 {
     writer << "{\n";
     writer.indent();
@@ -1247,7 +1298,7 @@ static void emitReflectionTypeParamJSON(
         writer << "{\n";
         writer.indent();
         CommaTrackerRAII commaTracker(writer);
-        emitReflectionTypeInfoJSON(writer, typeParam->getConstraintByIndex(ee));
+        emitReflectionTypeInfoJSON(writer, typeParam->getConstraintByIndex(ee), currentReflectionStatus);
         writer.dedent();
         writer << "\n}";
     }
@@ -1263,6 +1314,7 @@ static void emitReflectionEntryPointJSON(
     slang::ShaderReflection* programReflection,
     int entryPointIndex)
 {
+    ReflectionTracker visitedTypes;
     slang::EntryPointReflection* entryPoint =
         programReflection->getEntryPointByIndex(entryPointIndex);
 
@@ -1305,7 +1357,7 @@ static void emitReflectionEntryPointJSON(
     }
 
     writer << ",\n\"scope\": ";
-    emitReflectionScopeJSON(writer, entryPoint->getVarLayout());
+    emitReflectionScopeJSON(writer, entryPoint->getVarLayout(), visitedTypes);
 
     auto entryPointParameterCount = entryPoint->getParameterCount();
     if (entryPointParameterCount)
@@ -1319,7 +1371,7 @@ static void emitReflectionEntryPointJSON(
                 writer << ",\n";
 
             auto parameter = entryPoint->getParameterByIndex(pp);
-            emitReflectionParamJSON(writer, parameter);
+            emitReflectionParamJSON(writer, parameter, visitedTypes);
         }
 
         writer.dedent();
@@ -1332,7 +1384,7 @@ static void emitReflectionEntryPointJSON(
     if (auto resultVarLayout = entryPoint->getResultVarLayout())
     {
         writer << ",\n\"result\": ";
-        emitReflectionParamJSON(writer, resultVarLayout);
+        emitReflectionParamJSON(writer, resultVarLayout, visitedTypes);
     }
 
     if (entryPoint->getStage() == SLANG_STAGE_COMPUTE)
@@ -1381,6 +1433,7 @@ static void emitReflectionJSON(
     SlangCompileRequest* request,
     slang::ShaderReflection* programReflection)
 {
+    ReflectionTracker visitedTypes;
     writer << "{\n";
     writer.indent();
 
@@ -1397,14 +1450,14 @@ static void emitReflectionJSON(
             writer << ",\n";
 
         auto parameter = programReflection->getParameterByIndex(pp);
-        emitReflectionParamJSON(writer, parameter);
+        emitReflectionParamJSON(writer, parameter, visitedTypes);
     }
 
     writer.dedent();
     writer << "\n]";
 
     writer << ",\n\"globalScope\": ";
-    emitReflectionScopeJSON(writer, programReflection->getGlobalParamsVarLayout());
+    emitReflectionScopeJSON(writer, programReflection->getGlobalParamsVarLayout(), visitedTypes);
 
     auto entryPointCount = programReflection->getEntryPointCount();
     if (entryPointCount)
@@ -1436,7 +1489,7 @@ static void emitReflectionJSON(
                 writer << ",\n";
 
             auto typeParam = programReflection->getTypeParameterByIndex(ee);
-            emitReflectionTypeParamJSON(writer, typeParam);
+            emitReflectionTypeParamJSON(writer, typeParam, visitedTypes);
         }
         writer.dedent();
         writer << "\n]";

--- a/source/slang/slang-reflection-json.cpp
+++ b/source/slang/slang-reflection-json.cpp
@@ -57,28 +57,36 @@ namespace Slang
 
 namespace
 {
+// Small helper class to avoid recursing into the same type more than once on the active path.
+// When emitting a struct the struct type gets stored in the ReflectionTracker to avoid
+// infinite recursion in the case that the struct stores a pointer to itself.
 class ReflectionTracker
 {
 public:
-    void recordVisitedType(slang::TypeReflection* type)
-    {
-        m_visitedStructTypes.add(type);
-    }
+    void recordVisitedType(slang::TypeReflection* type) { m_visitedTypes.add(type); }
 
-    [[nodiscard]] bool canRecurseIntoType(slang::TypeReflection* type)
+    [[nodiscard]] bool canRecurseIntoType(slang::TypeReflection* type) const
     {
-        return !m_visitedStructTypes.contains(type);
+        return !m_visitedTypes.contains(type);
     }
 
 private:
-    HashSet<slang::TypeReflection*> m_visitedStructTypes;
+    HashSet<slang::TypeReflection*> m_visitedTypes;
 };
 } // namespace
 
-static void emitReflectionVarInfoJSON(PrettyWriter& writer, slang::VariableReflection* var, ReflectionTracker& currentReflectionStatus);
-static void emitReflectionTypeLayoutJSON(PrettyWriter& writer, slang::TypeLayoutReflection* type,
-        ReflectionTracker& visitedTypes);
-static void emitReflectionTypeJSON(PrettyWriter& writer, slang::TypeReflection* type, ReflectionTracker& reflectionStatus);
+static void emitReflectionVarInfoJSON(
+    PrettyWriter& writer,
+    slang::VariableReflection* var,
+    ReflectionTracker& currentReflectionStatus);
+static void emitReflectionTypeLayoutJSON(
+    PrettyWriter& writer,
+    slang::TypeLayoutReflection* type,
+    ReflectionTracker& reflectionTracker);
+static void emitReflectionTypeJSON(
+    PrettyWriter& writer,
+    slang::TypeReflection* type,
+    ReflectionTracker& reflectionTracker);
 static slang::ShaderReflection* g_inProgramLayout = nullptr;
 
 static void emitReflectionSize(PrettyWriter& writer, size_t size)
@@ -437,8 +445,10 @@ static slang::TypeLayoutReflection* maybeChangeTypeLayoutToAgumentBufferTier2(
     return nullptr;
 }
 
-static void emitReflectionVarLayoutJSON(PrettyWriter& writer, slang::VariableLayoutReflection* var,
-    ReflectionTracker& visitedTypes)
+static void emitReflectionVarLayoutJSON(
+    PrettyWriter& writer,
+    slang::VariableLayoutReflection* var,
+    ReflectionTracker& reflectionTracker)
 {
     writer << "{\n";
     writer.indent();
@@ -455,11 +465,11 @@ static void emitReflectionVarLayoutJSON(PrettyWriter& writer, slang::VariableLay
     writer << "\"type\": ";
     if (auto newTypeLayout = maybeChangeTypeLayoutToAgumentBufferTier2(var))
     {
-        emitReflectionTypeLayoutJSON(writer, newTypeLayout, visitedTypes);
+        emitReflectionTypeLayoutJSON(writer, newTypeLayout, reflectionTracker);
     }
     else
     {
-        emitReflectionTypeLayoutJSON(writer, var->getTypeLayout(), visitedTypes);
+        emitReflectionTypeLayoutJSON(writer, var->getTypeLayout(), reflectionTracker);
     }
 
     if (auto variable = var->getVariable())
@@ -600,7 +610,10 @@ static void emitReflectionResourceTypeBaseInfoJSON(
     }
 }
 
-static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflection* type, ReflectionTracker& reflectionTracker)
+static void emitReflectionTypeInfoJSON(
+    PrettyWriter& writer,
+    slang::TypeReflection* type,
+    ReflectionTracker& reflectionTracker)
 {
     auto kind = type->getKind();
     switch (kind)
@@ -731,7 +744,8 @@ static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflecti
             if (reflectionTracker.canRecurseIntoType(pointeeType))
             {
                 emitReflectionTypeJSON(writer, pointeeType, reflectionTracker);
-            } else
+            }
+            else
             {
                 writer.writeEscapedString(UnownedStringSlice(pointeeType->getName()));
             }
@@ -756,13 +770,20 @@ static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflecti
                 {
                     if (ff != 0)
                         writer << ",\n";
-                    emitReflectionVarInfoJSON(writer, structType->getFieldByIndex(ff), reflectionTracker);
+                    emitReflectionVarInfoJSON(
+                        writer,
+                        structType->getFieldByIndex(ff),
+                        reflectionTracker);
                 }
                 writer.dedent();
                 writer << "\n]";
-            } else
+            }
+            else
             {
+                auto structName = structType->getName();
+                SLANG_RELEASE_ASSERT(structName != nullptr && structName[0] != '\0');
                 writer << "\"valueType\": ";
+                writer.writeEscapedString(UnownedStringSlice(structName));
             }
         }
         break;
@@ -813,7 +834,7 @@ static void emitReflectionTypeInfoJSON(PrettyWriter& writer, slang::TypeReflecti
 static void emitReflectionParameterGroupTypeLayoutInfoJSON(
     PrettyWriter& writer,
     slang::TypeLayoutReflection* typeLayout,
-    ReflectionTracker& visitedTypes,
+    ReflectionTracker& reflectionTracker,
     const char* kind)
 {
     // Go through the comma tracker so a key appended after this object (e.g. `sizes`) is
@@ -830,11 +851,11 @@ static void emitReflectionParameterGroupTypeLayoutInfoJSON(
     {
         // If we are in argument buffer tier 2, we need to use the new type layout
         // that has the correct binding information.
-        emitReflectionTypeLayoutJSON(writer, newElementTypeLayout, visitedTypes);
+        emitReflectionTypeLayoutJSON(writer, newElementTypeLayout, reflectionTracker);
     }
     else
     {
-        emitReflectionTypeLayoutJSON(writer, typeLayout->getElementTypeLayout(), visitedTypes);
+        emitReflectionTypeLayoutJSON(writer, typeLayout->getElementTypeLayout(), reflectionTracker);
     }
 
     // Note: There is a subtle detail below when it comes to the
@@ -879,18 +900,18 @@ static void emitReflectionParameterGroupTypeLayoutInfoJSON(
     }
 
     writer << ",\n\"elementVarLayout\": ";
-    emitReflectionVarLayoutJSON(writer, typeLayout->getElementVarLayout(), visitedTypes);
+    emitReflectionVarLayoutJSON(writer, typeLayout->getElementVarLayout(), reflectionTracker);
 }
 
 static void emitReflectionTypeLayoutKindInfoJSON(
     PrettyWriter& writer,
     slang::TypeLayoutReflection* typeLayout,
-    ReflectionTracker currentReflectionStatus)
+    ReflectionTracker& reflectionTracker)
 {
     switch (typeLayout->getKind())
     {
     default:
-        emitReflectionTypeInfoJSON(writer, typeLayout->getType(), currentReflectionStatus);
+        emitReflectionTypeInfoJSON(writer, typeLayout->getType(), reflectionTracker);
         break;
 
     case slang::TypeReflection::Kind::Pointer:
@@ -907,12 +928,19 @@ static void emitReflectionTypeLayoutKindInfoJSON(
             auto valueType = valueTypeLayout->getType();
             if (typeName && typeName[0])
             {
-                if (valueType->getScalarType() == slang::TypeReflection::None
-                    && currentReflectionStatus.canRecurseIntoType(valueType))
+                // Avoid recursing into a pointer to self.
+                // Additionally, if the pointer points to a scalar type avoid expanding the type
+                // int* p becomes -> { "kind": "pointer", "valueType": "int" }
+                if (reflectionTracker.canRecurseIntoType(valueType) &&
+                    valueType->getKind() == slang::TypeReflection::Kind::Struct)
                 {
-                    currentReflectionStatus.recordVisitedType(valueType);
-                    emitReflectionTypeLayoutJSON(writer, typeLayout->getElementTypeLayout(),currentReflectionStatus);
-                } else
+                    reflectionTracker.recordVisitedType(valueType);
+                    emitReflectionTypeLayoutJSON(
+                        writer,
+                        typeLayout->getElementTypeLayout(),
+                        reflectionTracker);
+                }
+                else
                 {
                     writer.writeEscapedString(UnownedStringSlice(typeName));
                 }
@@ -944,7 +972,7 @@ static void emitReflectionTypeLayoutKindInfoJSON(
 
             writer.maybeComma();
             writer << "\"elementType\": ";
-            emitReflectionTypeLayoutJSON(writer, elementTypeLayout, currentReflectionStatus);
+            emitReflectionTypeLayoutJSON(writer, elementTypeLayout, reflectionTracker);
 
             if (arrayTypeLayout->getSize(SLANG_PARAMETER_CATEGORY_UNIFORM) != 0)
             {
@@ -960,7 +988,7 @@ static void emitReflectionTypeLayoutKindInfoJSON(
     case slang::TypeReflection::Kind::Struct:
         {
             auto structTypeLayout = typeLayout;
-            currentReflectionStatus.recordVisitedType(structTypeLayout->getType());
+            reflectionTracker.recordVisitedType(structTypeLayout->getType());
             writer.maybeComma();
             writer << "\"kind\": \"struct\"";
             if (auto name = structTypeLayout->getName())
@@ -977,7 +1005,10 @@ static void emitReflectionTypeLayoutKindInfoJSON(
             {
                 if (ff != 0)
                     writer << ",\n";
-                emitReflectionVarLayoutJSON(writer, structTypeLayout->getFieldByIndex(ff), currentReflectionStatus);
+                emitReflectionVarLayoutJSON(
+                    writer,
+                    structTypeLayout->getFieldByIndex(ff),
+                    reflectionTracker);
             }
             writer.dedent();
             writer << "\n]";
@@ -986,19 +1017,35 @@ static void emitReflectionTypeLayoutKindInfoJSON(
         break;
 
     case slang::TypeReflection::Kind::ConstantBuffer:
-        emitReflectionParameterGroupTypeLayoutInfoJSON(writer, typeLayout, currentReflectionStatus, "constantBuffer");
+        emitReflectionParameterGroupTypeLayoutInfoJSON(
+            writer,
+            typeLayout,
+            reflectionTracker,
+            "constantBuffer");
         break;
 
     case slang::TypeReflection::Kind::OutputStream:
-        emitReflectionParameterGroupTypeLayoutInfoJSON(writer, typeLayout, currentReflectionStatus, "outputStream");
+        emitReflectionParameterGroupTypeLayoutInfoJSON(
+            writer,
+            typeLayout,
+            reflectionTracker,
+            "outputStream");
         break;
 
     case slang::TypeReflection::Kind::ParameterBlock:
-        emitReflectionParameterGroupTypeLayoutInfoJSON(writer, typeLayout, currentReflectionStatus, "parameterBlock");
+        emitReflectionParameterGroupTypeLayoutInfoJSON(
+            writer,
+            typeLayout,
+            reflectionTracker,
+            "parameterBlock");
         break;
 
     case slang::TypeReflection::Kind::TextureBuffer:
-        emitReflectionParameterGroupTypeLayoutInfoJSON(writer, typeLayout, currentReflectionStatus, "textureBuffer");
+        emitReflectionParameterGroupTypeLayoutInfoJSON(
+            writer,
+            typeLayout,
+            reflectionTracker,
+            "textureBuffer");
         break;
 
     case slang::TypeReflection::Kind::ShaderStorageBuffer:
@@ -1007,7 +1054,7 @@ static void emitReflectionTypeLayoutKindInfoJSON(
 
         writer.maybeComma();
         writer << "\"elementType\": ";
-        emitReflectionTypeLayoutJSON(writer, typeLayout->getElementTypeLayout(), currentReflectionStatus);
+        emitReflectionTypeLayoutJSON(writer, typeLayout->getElementTypeLayout(), reflectionTracker);
         break;
     case slang::TypeReflection::Kind::GenericTypeParameter:
         writer.maybeComma();
@@ -1044,7 +1091,7 @@ static void emitReflectionTypeLayoutKindInfoJSON(
                 {
                     writer.maybeComma();
                     writer << "\"resultType\": ";
-                    emitReflectionTypeLayoutJSON(writer, resultTypeLayout, currentReflectionStatus);
+                    emitReflectionTypeLayoutJSON(writer, resultTypeLayout, reflectionTracker);
                 }
             }
             else if (shape & SLANG_TEXTURE_FEEDBACK_FLAG)
@@ -1055,12 +1102,12 @@ static void emitReflectionTypeLayoutKindInfoJSON(
                 {
                     writer.maybeComma();
                     writer << "\"resultType\": ";
-                    emitReflectionTypeJSON(writer, resultType, currentReflectionStatus);
+                    emitReflectionTypeJSON(writer, resultType, reflectionTracker);
                 }
             }
             else
             {
-                emitReflectionTypeInfoJSON(writer, type, currentReflectionStatus);
+                emitReflectionTypeInfoJSON(writer, type, reflectionTracker);
             }
         }
         break;
@@ -1110,36 +1157,42 @@ static void emitReflectionTypeLayoutSizeInfoJSON(
 static void emitReflectionTypeLayoutInfoJSON(
     PrettyWriter& writer,
     slang::TypeLayoutReflection* typeLayout,
-    ReflectionTracker& visitedTypes)
+    ReflectionTracker& reflectionTracker)
 {
-    emitReflectionTypeLayoutKindInfoJSON(writer, typeLayout, visitedTypes);
+    emitReflectionTypeLayoutKindInfoJSON(writer, typeLayout, reflectionTracker);
     emitReflectionTypeLayoutSizeInfoJSON(writer, typeLayout);
 }
 
 static void emitReflectionTypeLayoutJSON(
     PrettyWriter& writer,
     slang::TypeLayoutReflection* typeLayout,
-    ReflectionTracker& visitedTypes)
+    ReflectionTracker& reflectionTracker)
 {
     CommaTrackerRAII commaTracker(writer);
     writer << "{\n";
     writer.indent();
-    emitReflectionTypeLayoutInfoJSON(writer, typeLayout, visitedTypes);
+    emitReflectionTypeLayoutInfoJSON(writer, typeLayout, reflectionTracker);
     writer.dedent();
     writer << "\n}";
 }
 
-static void emitReflectionTypeJSON(PrettyWriter& writer, slang::TypeReflection* type, ReflectionTracker& reflectionStatus)
+static void emitReflectionTypeJSON(
+    PrettyWriter& writer,
+    slang::TypeReflection* type,
+    ReflectionTracker& reflectionTracker)
 {
     CommaTrackerRAII commaTracker(writer);
     writer << "{\n";
     writer.indent();
-    emitReflectionTypeInfoJSON(writer, type, reflectionStatus);
+    emitReflectionTypeInfoJSON(writer, type, reflectionTracker);
     writer.dedent();
     writer << "\n}";
 }
 
-static void emitReflectionVarInfoJSON(PrettyWriter& writer, slang::VariableReflection* var, ReflectionTracker& currentReflectionStatus)
+static void emitReflectionVarInfoJSON(
+    PrettyWriter& writer,
+    slang::VariableReflection* var,
+    ReflectionTracker& currentReflectionStatus)
 {
     emitReflectionNameInfoJSON(writer, var->getName());
 
@@ -1150,8 +1203,10 @@ static void emitReflectionVarInfoJSON(PrettyWriter& writer, slang::VariableRefle
     emitReflectionTypeJSON(writer, var->getType(), currentReflectionStatus);
 }
 
-static void emitReflectionParamJSON(PrettyWriter& writer, slang::VariableLayoutReflection* param,
-    ReflectionTracker& visitedTypes)
+static void emitReflectionParamJSON(
+    PrettyWriter& writer,
+    slang::VariableLayoutReflection* param,
+    ReflectionTracker& reflectionTracker)
 {
     // TODO: This function is likely redundant with `emitReflectionVarLayoutJSON`
     // and we should try to collapse them into one.
@@ -1176,7 +1231,7 @@ static void emitReflectionParamJSON(PrettyWriter& writer, slang::VariableLayoutR
 
     writer.maybeComma();
     writer << "\"type\": ";
-    emitReflectionTypeLayoutJSON(writer, param->getTypeLayout(), visitedTypes);
+    emitReflectionTypeLayoutJSON(writer, param->getTypeLayout(), reflectionTracker);
 
     writer.dedent();
     writer << "\n}";
@@ -1189,7 +1244,7 @@ static void emitReflectionParamJSON(PrettyWriter& writer, slang::VariableLayoutR
 static void emitReflectionScopeParametersJSON(
     PrettyWriter& writer,
     slang::TypeLayoutReflection* structTypeLayout,
-    ReflectionTracker& visitedTypes)
+    ReflectionTracker& reflectionTracker)
 {
     SLANG_ASSERT(structTypeLayout->getKind() == slang::TypeReflection::Kind::Struct);
 
@@ -1201,7 +1256,7 @@ static void emitReflectionScopeParametersJSON(
     {
         if (pp != 0)
             writer << ",\n";
-        emitReflectionParamJSON(writer, structTypeLayout->getFieldByIndex(pp), visitedTypes);
+        emitReflectionParamJSON(writer, structTypeLayout->getFieldByIndex(pp), reflectionTracker);
     }
     writer.dedent();
     writer << "\n]";
@@ -1221,7 +1276,7 @@ static void emitReflectionScopeParametersJSON(
 static void emitReflectionScopeJSON(
     PrettyWriter& writer,
     slang::VariableLayoutReflection* scopeVarLayout,
-    ReflectionTracker& visitedTypes)
+    ReflectionTracker& reflectionTracker)
 {
     writer << "{\n";
     writer.indent();
@@ -1233,7 +1288,7 @@ static void emitReflectionScopeJSON(
     case slang::TypeReflection::Kind::Struct:
         writer.maybeComma();
         writer << "\"kind\": \"none\"";
-        emitReflectionScopeParametersJSON(writer, scopeTypeLayout, visitedTypes);
+        emitReflectionScopeParametersJSON(writer, scopeTypeLayout, reflectionTracker);
         break;
 
     case slang::TypeReflection::Kind::ConstantBuffer:
@@ -1245,7 +1300,7 @@ static void emitReflectionScopeJSON(
         emitReflectionScopeParametersJSON(
             writer,
             scopeTypeLayout->getElementVarLayout()->getTypeLayout(),
-            visitedTypes);
+            reflectionTracker);
         break;
 
     default:
@@ -1281,7 +1336,8 @@ static void emitEntryPointParamJSON(
 
 static void emitReflectionTypeParamJSON(
     PrettyWriter& writer,
-    slang::TypeParameterReflection* typeParam, ReflectionTracker& currentReflectionStatus)
+    slang::TypeParameterReflection* typeParam,
+    ReflectionTracker& currentReflectionStatus)
 {
     writer << "{\n";
     writer.indent();
@@ -1298,7 +1354,10 @@ static void emitReflectionTypeParamJSON(
         writer << "{\n";
         writer.indent();
         CommaTrackerRAII commaTracker(writer);
-        emitReflectionTypeInfoJSON(writer, typeParam->getConstraintByIndex(ee), currentReflectionStatus);
+        emitReflectionTypeInfoJSON(
+            writer,
+            typeParam->getConstraintByIndex(ee),
+            currentReflectionStatus);
         writer.dedent();
         writer << "\n}";
     }
@@ -1314,7 +1373,7 @@ static void emitReflectionEntryPointJSON(
     slang::ShaderReflection* programReflection,
     int entryPointIndex)
 {
-    ReflectionTracker visitedTypes;
+    ReflectionTracker reflectionTracker;
     slang::EntryPointReflection* entryPoint =
         programReflection->getEntryPointByIndex(entryPointIndex);
 
@@ -1357,7 +1416,7 @@ static void emitReflectionEntryPointJSON(
     }
 
     writer << ",\n\"scope\": ";
-    emitReflectionScopeJSON(writer, entryPoint->getVarLayout(), visitedTypes);
+    emitReflectionScopeJSON(writer, entryPoint->getVarLayout(), reflectionTracker);
 
     auto entryPointParameterCount = entryPoint->getParameterCount();
     if (entryPointParameterCount)
@@ -1371,7 +1430,7 @@ static void emitReflectionEntryPointJSON(
                 writer << ",\n";
 
             auto parameter = entryPoint->getParameterByIndex(pp);
-            emitReflectionParamJSON(writer, parameter, visitedTypes);
+            emitReflectionParamJSON(writer, parameter, reflectionTracker);
         }
 
         writer.dedent();
@@ -1384,7 +1443,7 @@ static void emitReflectionEntryPointJSON(
     if (auto resultVarLayout = entryPoint->getResultVarLayout())
     {
         writer << ",\n\"result\": ";
-        emitReflectionParamJSON(writer, resultVarLayout, visitedTypes);
+        emitReflectionParamJSON(writer, resultVarLayout, reflectionTracker);
     }
 
     if (entryPoint->getStage() == SLANG_STAGE_COMPUTE)
@@ -1433,7 +1492,7 @@ static void emitReflectionJSON(
     SlangCompileRequest* request,
     slang::ShaderReflection* programReflection)
 {
-    ReflectionTracker visitedTypes;
+    ReflectionTracker reflectionTracker;
     writer << "{\n";
     writer.indent();
 
@@ -1450,14 +1509,17 @@ static void emitReflectionJSON(
             writer << ",\n";
 
         auto parameter = programReflection->getParameterByIndex(pp);
-        emitReflectionParamJSON(writer, parameter, visitedTypes);
+        emitReflectionParamJSON(writer, parameter, reflectionTracker);
     }
 
     writer.dedent();
     writer << "\n]";
 
     writer << ",\n\"globalScope\": ";
-    emitReflectionScopeJSON(writer, programReflection->getGlobalParamsVarLayout(), visitedTypes);
+    emitReflectionScopeJSON(
+        writer,
+        programReflection->getGlobalParamsVarLayout(),
+        reflectionTracker);
 
     auto entryPointCount = programReflection->getEntryPointCount();
     if (entryPointCount)
@@ -1489,7 +1551,7 @@ static void emitReflectionJSON(
                 writer << ",\n";
 
             auto typeParam = programReflection->getTypeParameterByIndex(ee);
-            emitReflectionTypeParamJSON(writer, typeParam, visitedTypes);
+            emitReflectionTypeParamJSON(writer, typeParam, reflectionTracker);
         }
         writer.dedent();
         writer << "\n]";

--- a/source/slang/slang-reflection-json.cpp
+++ b/source/slang/slang-reflection-json.cpp
@@ -78,7 +78,7 @@ private:
 static void emitReflectionVarInfoJSON(
     PrettyWriter& writer,
     slang::VariableReflection* var,
-    ReflectionTracker& currentReflectionStatus);
+    ReflectionTracker& reflectionTracker);
 static void emitReflectionTypeLayoutJSON(
     PrettyWriter& writer,
     slang::TypeLayoutReflection* type,
@@ -759,32 +759,22 @@ static void emitReflectionTypeInfoJSON(
             writer.maybeComma();
 
             auto structType = type;
-            if (reflectionTracker.canRecurseIntoType(structType))
-            {
-                reflectionTracker.recordVisitedType(structType);
-                writer << "\"fields\": [\n";
-                writer.indent();
+            reflectionTracker.recordVisitedType(structType);
+            writer << "\"fields\": [\n";
+            writer.indent();
 
-                auto fieldCount = structType->getFieldCount();
-                for (uint32_t ff = 0; ff < fieldCount; ++ff)
-                {
-                    if (ff != 0)
-                        writer << ",\n";
-                    emitReflectionVarInfoJSON(
-                        writer,
-                        structType->getFieldByIndex(ff),
-                        reflectionTracker);
-                }
-                writer.dedent();
-                writer << "\n]";
-            }
-            else
+            auto fieldCount = structType->getFieldCount();
+            for (uint32_t ff = 0; ff < fieldCount; ++ff)
             {
-                auto structName = structType->getName();
-                SLANG_RELEASE_ASSERT(structName != nullptr && structName[0] != '\0');
-                writer << "\"valueType\": ";
-                writer.writeEscapedString(UnownedStringSlice(structName));
+                if (ff != 0)
+                    writer << ",\n";
+                emitReflectionVarInfoJSON(
+                    writer,
+                    structType->getFieldByIndex(ff),
+                    reflectionTracker);
             }
+            writer.dedent();
+            writer << "\n]";
         }
         break;
 
@@ -929,7 +919,7 @@ static void emitReflectionTypeLayoutKindInfoJSON(
             if (typeName && typeName[0])
             {
                 // Avoid recursing into a pointer to self.
-                // Additionally, if the pointer points to a scalar type avoid expanding the type
+                // Additionally, only expand when the pointer points to a struct
                 // int* p becomes -> { "kind": "pointer", "valueType": "int" }
                 if (reflectionTracker.canRecurseIntoType(valueType) &&
                     valueType->getKind() == slang::TypeReflection::Kind::Struct)
@@ -1192,7 +1182,7 @@ static void emitReflectionTypeJSON(
 static void emitReflectionVarInfoJSON(
     PrettyWriter& writer,
     slang::VariableReflection* var,
-    ReflectionTracker& currentReflectionStatus)
+    ReflectionTracker& reflectionTracker)
 {
     emitReflectionNameInfoJSON(writer, var->getName());
 
@@ -1200,7 +1190,7 @@ static void emitReflectionVarInfoJSON(
 
     writer << ",\n";
     writer << "\"type\": ";
-    emitReflectionTypeJSON(writer, var->getType(), currentReflectionStatus);
+    emitReflectionTypeJSON(writer, var->getType(), reflectionTracker);
 }
 
 static void emitReflectionParamJSON(
@@ -1337,7 +1327,7 @@ static void emitEntryPointParamJSON(
 static void emitReflectionTypeParamJSON(
     PrettyWriter& writer,
     slang::TypeParameterReflection* typeParam,
-    ReflectionTracker& currentReflectionStatus)
+    ReflectionTracker& reflectionTracker)
 {
     writer << "{\n";
     writer.indent();
@@ -1354,10 +1344,7 @@ static void emitReflectionTypeParamJSON(
         writer << "{\n";
         writer.indent();
         CommaTrackerRAII commaTracker(writer);
-        emitReflectionTypeInfoJSON(
-            writer,
-            typeParam->getConstraintByIndex(ee),
-            currentReflectionStatus);
+        emitReflectionTypeInfoJSON(writer, typeParam->getConstraintByIndex(ee), reflectionTracker);
         writer.dedent();
         writer << "\n}";
     }

--- a/tests/reflection/attribute.slang
+++ b/tests/reflection/attribute.slang
@@ -60,6 +60,20 @@ D param3;
 [StructVarParam(1)] int globalInt2;
 
 
+[__AttributeUsage(_AttributeTargets.Struct)]
+struct ReflectThroughPointerAttribute {}
+
+[ReflectThroughPointer]
+struct StructWithAttribute {
+
+};
+
+struct StructWithPointer {
+    StructWithAttribute* attrib;
+};
+
+StructWithPointer po;
+
 [MyStruct(2, 3.0, "main")]
 [MyStruct(-2, -3.0, "")]
 [numthreads(1, 1, 1)]

--- a/tests/reflection/attribute.slang.expected
+++ b/tests/reflection/attribute.slang.expected
@@ -655,24 +655,7 @@ standard output = {
                             "name": "attrib",
                             "type": {
                                 "kind": "pointer",
-                                "valueType": {
-                                    "kind": "struct",
-                                    "name": "StructWithAttribute",
-                                    "fields": [
-
-                                    ],
-                                    "userAttribs": [
-                                        {
-                                            "name": "ReflectThroughPointer",
-                                            "arguments": [
-
-                                            ]
-                                        }
-                                    ],
-                                    "sizes": [
-
-                                    ]
-                                },
+                                "valueType": "StructWithAttribute",
                                 "sizes": [
 
                                 ]

--- a/tests/reflection/attribute.slang.expected
+++ b/tests/reflection/attribute.slang.expected
@@ -302,6 +302,45 @@ standard output = {
                     {"kind": "uniform", "value": 4, "alignment": 4}
                 ]
             }
+        },
+        {
+            "name": "po",
+            "type": {
+                "kind": "struct",
+                "name": "StructWithPointer",
+                "fields": [
+                    {
+                        "name": "attrib",
+                        "type": {
+                            "kind": "pointer",
+                            "valueType": {
+                                "kind": "struct",
+                                "name": "StructWithAttribute",
+                                "fields": [
+
+                                ],
+                                "userAttribs": [
+                                    {
+                                        "name": "ReflectThroughPointer",
+                                        "arguments": [
+
+                                        ]
+                                    }
+                                ],
+                                "sizes": [
+
+                                ]
+                            },
+                            "sizes": [
+
+                            ]
+                        }
+                    }
+                ],
+                "sizes": [
+
+                ]
+            }
         }
     ],
     "globalScope": {
@@ -603,6 +642,45 @@ standard output = {
                     "scalarType": "int32",
                     "sizes": [
                         {"kind": "uniform", "value": 4, "alignment": 4}
+                    ]
+                }
+            },
+            {
+                "name": "po",
+                "type": {
+                    "kind": "struct",
+                    "name": "StructWithPointer",
+                    "fields": [
+                        {
+                            "name": "attrib",
+                            "type": {
+                                "kind": "pointer",
+                                "valueType": {
+                                    "kind": "struct",
+                                    "name": "StructWithAttribute",
+                                    "fields": [
+
+                                    ],
+                                    "userAttribs": [
+                                        {
+                                            "name": "ReflectThroughPointer",
+                                            "arguments": [
+
+                                            ]
+                                        }
+                                    ],
+                                    "sizes": [
+
+                                    ]
+                                },
+                                "sizes": [
+
+                                ]
+                            }
+                        }
+                    ],
+                    "sizes": [
+
                     ]
                 }
             }

--- a/tests/reflection/ptr/ptr-generic.slang.expected
+++ b/tests/reflection/ptr/ptr-generic.slang.expected
@@ -10,7 +10,105 @@ standard output = {
             "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0},
             "type": {
                 "kind": "pointer",
-                "valueType": "GenericStruct",
+                "valueType": {
+                    "kind": "struct",
+                    "name": "GenericStruct",
+                    "fields": [
+                        {
+                            "name": "someT",
+                            "type": {
+                                "kind": "scalar",
+                                "scalarType": "int32",
+                                "sizes": [
+                                    {"kind": "uniform", "value": 4, "alignment": 4}
+                                ]
+                            },
+                            "binding": {"kind": "uniform", "offset": 0, "size": 4, "elementStride": 0}
+                        },
+                        {
+                            "name": "values",
+                            "type": {
+                                "kind": "array",
+                                "elementCount": 4,
+                                "elementType": {
+                                    "kind": "scalar",
+                                    "scalarType": "int32",
+                                    "sizes": [
+                                        {"kind": "uniform", "value": 4, "alignment": 4}
+                                    ]
+                                },
+                                "uniformStride": 4,
+                                "sizes": [
+                                    {"kind": "uniform", "value": 16, "alignment": 4}
+                                ]
+                            },
+                            "binding": {"kind": "uniform", "offset": 4, "size": 16, "elementStride": 4}
+                        },
+                        {
+                            "name": "genericPtr",
+                            "type": {
+                                "kind": "pointer",
+                                "valueType": {
+                                    "kind": "struct",
+                                    "name": "GenericStruct",
+                                    "fields": [
+                                        {
+                                            "name": "someT",
+                                            "type": {
+                                                "kind": "scalar",
+                                                "scalarType": "float32",
+                                                "sizes": [
+                                                    {"kind": "uniform", "value": 4, "alignment": 4}
+                                                ]
+                                            },
+                                            "binding": {"kind": "uniform", "offset": 0, "size": 4, "elementStride": 0}
+                                        },
+                                        {
+                                            "name": "values",
+                                            "type": {
+                                                "kind": "array",
+                                                "elementCount": 2,
+                                                "elementType": {
+                                                    "kind": "scalar",
+                                                    "scalarType": "int32",
+                                                    "sizes": [
+                                                        {"kind": "uniform", "value": 4, "alignment": 4}
+                                                    ]
+                                                },
+                                                "uniformStride": 4,
+                                                "sizes": [
+                                                    {"kind": "uniform", "value": 8, "alignment": 4}
+                                                ]
+                                            },
+                                            "binding": {"kind": "uniform", "offset": 4, "size": 8, "elementStride": 4}
+                                        },
+                                        {
+                                            "name": "genericPtr",
+                                            "type": {
+                                                "kind": "pointer",
+                                                "valueType": "GenericStruct",
+                                                "sizes": [
+                                                    {"kind": "uniform", "value": 8, "alignment": 8}
+                                                ]
+                                            },
+                                            "binding": {"kind": "uniform", "offset": 16, "size": 8, "elementStride": 0}
+                                        }
+                                    ],
+                                    "sizes": [
+                                        {"kind": "uniform", "value": 24, "alignment": 8}
+                                    ]
+                                },
+                                "sizes": [
+                                    {"kind": "uniform", "value": 8, "alignment": 8}
+                                ]
+                            },
+                            "binding": {"kind": "uniform", "offset": 24, "size": 8, "elementStride": 0}
+                        }
+                    ],
+                    "sizes": [
+                        {"kind": "uniform", "value": 32, "alignment": 8}
+                    ]
+                },
                 "sizes": [
                     {"kind": "uniform", "value": 8, "alignment": 8}
                 ]
@@ -45,7 +143,105 @@ standard output = {
                 "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0},
                 "type": {
                     "kind": "pointer",
-                    "valueType": "GenericStruct",
+                    "valueType": {
+                        "kind": "struct",
+                        "name": "GenericStruct",
+                        "fields": [
+                            {
+                                "name": "someT",
+                                "type": {
+                                    "kind": "scalar",
+                                    "scalarType": "int32",
+                                    "sizes": [
+                                        {"kind": "uniform", "value": 4, "alignment": 4}
+                                    ]
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 4, "elementStride": 0}
+                            },
+                            {
+                                "name": "values",
+                                "type": {
+                                    "kind": "array",
+                                    "elementCount": 4,
+                                    "elementType": {
+                                        "kind": "scalar",
+                                        "scalarType": "int32",
+                                        "sizes": [
+                                            {"kind": "uniform", "value": 4, "alignment": 4}
+                                        ]
+                                    },
+                                    "uniformStride": 4,
+                                    "sizes": [
+                                        {"kind": "uniform", "value": 16, "alignment": 4}
+                                    ]
+                                },
+                                "binding": {"kind": "uniform", "offset": 4, "size": 16, "elementStride": 4}
+                            },
+                            {
+                                "name": "genericPtr",
+                                "type": {
+                                    "kind": "pointer",
+                                    "valueType": {
+                                        "kind": "struct",
+                                        "name": "GenericStruct",
+                                        "fields": [
+                                            {
+                                                "name": "someT",
+                                                "type": {
+                                                    "kind": "scalar",
+                                                    "scalarType": "float32",
+                                                    "sizes": [
+                                                        {"kind": "uniform", "value": 4, "alignment": 4}
+                                                    ]
+                                                },
+                                                "binding": {"kind": "uniform", "offset": 0, "size": 4, "elementStride": 0}
+                                            },
+                                            {
+                                                "name": "values",
+                                                "type": {
+                                                    "kind": "array",
+                                                    "elementCount": 2,
+                                                    "elementType": {
+                                                        "kind": "scalar",
+                                                        "scalarType": "int32",
+                                                        "sizes": [
+                                                            {"kind": "uniform", "value": 4, "alignment": 4}
+                                                        ]
+                                                    },
+                                                    "uniformStride": 4,
+                                                    "sizes": [
+                                                        {"kind": "uniform", "value": 8, "alignment": 4}
+                                                    ]
+                                                },
+                                                "binding": {"kind": "uniform", "offset": 4, "size": 8, "elementStride": 4}
+                                            },
+                                            {
+                                                "name": "genericPtr",
+                                                "type": {
+                                                    "kind": "pointer",
+                                                    "valueType": "GenericStruct",
+                                                    "sizes": [
+                                                        {"kind": "uniform", "value": 8, "alignment": 8}
+                                                    ]
+                                                },
+                                                "binding": {"kind": "uniform", "offset": 16, "size": 8, "elementStride": 0}
+                                            }
+                                        ],
+                                        "sizes": [
+                                            {"kind": "uniform", "value": 24, "alignment": 8}
+                                        ]
+                                    },
+                                    "sizes": [
+                                        {"kind": "uniform", "value": 8, "alignment": 8}
+                                    ]
+                                },
+                                "binding": {"kind": "uniform", "offset": 24, "size": 8, "elementStride": 0}
+                            }
+                        ],
+                        "sizes": [
+                            {"kind": "uniform", "value": 32, "alignment": 8}
+                        ]
+                    },
                     "sizes": [
                         {"kind": "uniform", "value": 8, "alignment": 8}
                     ]

--- a/tests/reflection/ptr/ptr-revisit.slang
+++ b/tests/reflection/ptr/ptr-revisit.slang
@@ -1,0 +1,15 @@
+//TEST(64-bit):REFLECTION:-stage compute -no-codegen -target host-callable -entry computeMain
+
+struct Inner  { int x; }
+struct Middle { Inner a; Inner b; }   // two fields of the SAME struct type
+struct Holder { Middle* p; }
+
+RWStructuredBuffer<Holder> inputBuffer;
+
+RWStructuredBuffer<int> outputBuffer;
+
+[numthreads(4, 1, 1)]
+void computeMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    outputBuffer[dispatchThreadID.x] = int(dispatchThreadID.x);
+}

--- a/tests/reflection/ptr/ptr-revisit.slang.expected
+++ b/tests/reflection/ptr/ptr-revisit.slang.expected
@@ -6,57 +6,42 @@ standard output = {
     "version": "1.1",
     "parameters": [
         {
-            "name": "genericPtr",
-            "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0},
+            "name": "inputBuffer",
+            "binding": {"kind": "uniform", "offset": 0, "size": 16, "elementStride": 0},
             "type": {
-                "kind": "pointer",
-                "valueType": {
+                "kind": "resource",
+                "baseShape": "structuredBuffer",
+                "access": "readWrite",
+                "resultType": {
                     "kind": "struct",
-                    "name": "GenericStruct",
+                    "name": "Holder",
                     "fields": [
                         {
-                            "name": "someT",
-                            "type": {
-                                "kind": "scalar",
-                                "scalarType": "int32",
-                                "sizes": [
-                                    {"kind": "uniform", "value": 4, "alignment": 4}
-                                ]
-                            },
-                            "binding": {"kind": "uniform", "offset": 0, "size": 4, "elementStride": 0}
-                        },
-                        {
-                            "name": "values",
-                            "type": {
-                                "kind": "array",
-                                "elementCount": 4,
-                                "elementType": {
-                                    "kind": "scalar",
-                                    "scalarType": "int32",
-                                    "sizes": [
-                                        {"kind": "uniform", "value": 4, "alignment": 4}
-                                    ]
-                                },
-                                "uniformStride": 4,
-                                "sizes": [
-                                    {"kind": "uniform", "value": 16, "alignment": 4}
-                                ]
-                            },
-                            "binding": {"kind": "uniform", "offset": 4, "size": 16, "elementStride": 4}
-                        },
-                        {
-                            "name": "genericPtr",
+                            "name": "p",
                             "type": {
                                 "kind": "pointer",
                                 "valueType": {
                                     "kind": "struct",
-                                    "name": "GenericStruct",
+                                    "name": "Middle",
                                     "fields": [
                                         {
-                                            "name": "someT",
+                                            "name": "a",
                                             "type": {
-                                                "kind": "scalar",
-                                                "scalarType": "float32",
+                                                "kind": "struct",
+                                                "name": "Inner",
+                                                "fields": [
+                                                    {
+                                                        "name": "x",
+                                                        "type": {
+                                                            "kind": "scalar",
+                                                            "scalarType": "int32",
+                                                            "sizes": [
+                                                                {"kind": "uniform", "value": 4, "alignment": 4}
+                                                            ]
+                                                        },
+                                                        "binding": {"kind": "uniform", "offset": 0, "size": 4, "elementStride": 0}
+                                                    }
+                                                ],
                                                 "sizes": [
                                                     {"kind": "uniform", "value": 4, "alignment": 4}
                                                 ]
@@ -64,59 +49,53 @@ standard output = {
                                             "binding": {"kind": "uniform", "offset": 0, "size": 4, "elementStride": 0}
                                         },
                                         {
-                                            "name": "values",
+                                            "name": "b",
                                             "type": {
-                                                "kind": "array",
-                                                "elementCount": 2,
-                                                "elementType": {
-                                                    "kind": "scalar",
-                                                    "scalarType": "int32",
-                                                    "sizes": [
-                                                        {"kind": "uniform", "value": 4, "alignment": 4}
-                                                    ]
-                                                },
-                                                "uniformStride": 4,
+                                                "kind": "struct",
+                                                "name": "Inner",
+                                                "fields": [
+                                                    {
+                                                        "name": "x",
+                                                        "type": {
+                                                            "kind": "scalar",
+                                                            "scalarType": "int32",
+                                                            "sizes": [
+                                                                {"kind": "uniform", "value": 4, "alignment": 4}
+                                                            ]
+                                                        },
+                                                        "binding": {"kind": "uniform", "offset": 0, "size": 4, "elementStride": 0}
+                                                    }
+                                                ],
                                                 "sizes": [
-                                                    {"kind": "uniform", "value": 8, "alignment": 4}
+                                                    {"kind": "uniform", "value": 4, "alignment": 4}
                                                 ]
                                             },
-                                            "binding": {"kind": "uniform", "offset": 4, "size": 8, "elementStride": 4}
-                                        },
-                                        {
-                                            "name": "genericPtr",
-                                            "type": {
-                                                "kind": "pointer",
-                                                "valueType": "GenericStruct",
-                                                "sizes": [
-                                                    {"kind": "uniform", "value": 8, "alignment": 8}
-                                                ]
-                                            },
-                                            "binding": {"kind": "uniform", "offset": 16, "size": 8, "elementStride": 0}
+                                            "binding": {"kind": "uniform", "offset": 4, "size": 4, "elementStride": 0}
                                         }
                                     ],
                                     "sizes": [
-                                        {"kind": "uniform", "value": 24, "alignment": 8}
+                                        {"kind": "uniform", "value": 8, "alignment": 4}
                                     ]
                                 },
                                 "sizes": [
                                     {"kind": "uniform", "value": 8, "alignment": 8}
                                 ]
                             },
-                            "binding": {"kind": "uniform", "offset": 24, "size": 8, "elementStride": 0}
+                            "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0}
                         }
                     ],
                     "sizes": [
-                        {"kind": "uniform", "value": 32, "alignment": 8}
+                        {"kind": "uniform", "value": 8, "alignment": 8}
                     ]
                 },
                 "sizes": [
-                    {"kind": "uniform", "value": 8, "alignment": 8}
+                    {"kind": "uniform", "value": 16, "alignment": 8}
                 ]
             }
         },
         {
             "name": "outputBuffer",
-            "binding": {"kind": "uniform", "offset": 8, "size": 16, "elementStride": 0},
+            "binding": {"kind": "uniform", "offset": 16, "size": 16, "elementStride": 0},
             "type": {
                 "kind": "resource",
                 "baseShape": "structuredBuffer",
@@ -139,19 +118,40 @@ standard output = {
         "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0},
         "parameters": [
             {
-                "name": "genericPtr",
-                "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0},
+                "name": "inputBuffer",
+                "binding": {"kind": "uniform", "offset": 0, "size": 16, "elementStride": 0},
                 "type": {
-                    "kind": "pointer",
-                    "valueType": "GenericStruct",
+                    "kind": "resource",
+                    "baseShape": "structuredBuffer",
+                    "access": "readWrite",
+                    "resultType": {
+                        "kind": "struct",
+                        "name": "Holder",
+                        "fields": [
+                            {
+                                "name": "p",
+                                "type": {
+                                    "kind": "pointer",
+                                    "valueType": "Middle",
+                                    "sizes": [
+                                        {"kind": "uniform", "value": 8, "alignment": 8}
+                                    ]
+                                },
+                                "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0}
+                            }
+                        ],
+                        "sizes": [
+                            {"kind": "uniform", "value": 8, "alignment": 8}
+                        ]
+                    },
                     "sizes": [
-                        {"kind": "uniform", "value": 8, "alignment": 8}
+                        {"kind": "uniform", "value": 16, "alignment": 8}
                     ]
                 }
             },
             {
                 "name": "outputBuffer",
-                "binding": {"kind": "uniform", "offset": 8, "size": 16, "elementStride": 0},
+                "binding": {"kind": "uniform", "offset": 16, "size": 16, "elementStride": 0},
                 "type": {
                     "kind": "resource",
                     "baseShape": "structuredBuffer",

--- a/tests/reflection/ptr/ptr-struct.slang.expected
+++ b/tests/reflection/ptr/ptr-struct.slang.expected
@@ -99,7 +99,48 @@ standard output = {
                             "name": "anotherPtr",
                             "type": {
                                 "kind": "pointer",
-                                "valueType": "AnotherStruct",
+                                "valueType": {
+                                    "kind": "struct",
+                                    "name": "AnotherStruct",
+                                    "fields": [
+                                        {
+                                            "name": "a",
+                                            "type": {
+                                                "kind": "scalar",
+                                                "scalarType": "float32",
+                                                "sizes": [
+                                                    {"kind": "uniform", "value": 4, "alignment": 4}
+                                                ]
+                                            },
+                                            "binding": {"kind": "uniform", "offset": 0, "size": 4, "elementStride": 0}
+                                        },
+                                        {
+                                            "name": "b",
+                                            "type": {
+                                                "kind": "scalar",
+                                                "scalarType": "int32",
+                                                "sizes": [
+                                                    {"kind": "uniform", "value": 4, "alignment": 4}
+                                                ]
+                                            },
+                                            "binding": {"kind": "uniform", "offset": 4, "size": 4, "elementStride": 0}
+                                        },
+                                        {
+                                            "name": "ptrC",
+                                            "type": {
+                                                "kind": "pointer",
+                                                "valueType": "int",
+                                                "sizes": [
+                                                    {"kind": "uniform", "value": 8, "alignment": 8}
+                                                ]
+                                            },
+                                            "binding": {"kind": "uniform", "offset": 8, "size": 8, "elementStride": 0}
+                                        }
+                                    ],
+                                    "sizes": [
+                                        {"kind": "uniform", "value": 16, "alignment": 8}
+                                    ]
+                                },
                                 "sizes": [
                                     {"kind": "uniform", "value": 8, "alignment": 8}
                                 ]
@@ -234,7 +275,48 @@ standard output = {
                                 "name": "anotherPtr",
                                 "type": {
                                     "kind": "pointer",
-                                    "valueType": "AnotherStruct",
+                                    "valueType": {
+                                        "kind": "struct",
+                                        "name": "AnotherStruct",
+                                        "fields": [
+                                            {
+                                                "name": "a",
+                                                "type": {
+                                                    "kind": "scalar",
+                                                    "scalarType": "float32",
+                                                    "sizes": [
+                                                        {"kind": "uniform", "value": 4, "alignment": 4}
+                                                    ]
+                                                },
+                                                "binding": {"kind": "uniform", "offset": 0, "size": 4, "elementStride": 0}
+                                            },
+                                            {
+                                                "name": "b",
+                                                "type": {
+                                                    "kind": "scalar",
+                                                    "scalarType": "int32",
+                                                    "sizes": [
+                                                        {"kind": "uniform", "value": 4, "alignment": 4}
+                                                    ]
+                                                },
+                                                "binding": {"kind": "uniform", "offset": 4, "size": 4, "elementStride": 0}
+                                            },
+                                            {
+                                                "name": "ptrC",
+                                                "type": {
+                                                    "kind": "pointer",
+                                                    "valueType": "int",
+                                                    "sizes": [
+                                                        {"kind": "uniform", "value": 8, "alignment": 8}
+                                                    ]
+                                                },
+                                                "binding": {"kind": "uniform", "offset": 8, "size": 8, "elementStride": 0}
+                                            }
+                                        ],
+                                        "sizes": [
+                                            {"kind": "uniform", "value": 16, "alignment": 8}
+                                        ]
+                                    },
                                     "sizes": [
                                         {"kind": "uniform", "value": 8, "alignment": 8}
                                     ]

--- a/tests/reflection/ptr/ptr-struct.slang.expected
+++ b/tests/reflection/ptr/ptr-struct.slang.expected
@@ -99,48 +99,7 @@ standard output = {
                             "name": "anotherPtr",
                             "type": {
                                 "kind": "pointer",
-                                "valueType": {
-                                    "kind": "struct",
-                                    "name": "AnotherStruct",
-                                    "fields": [
-                                        {
-                                            "name": "a",
-                                            "type": {
-                                                "kind": "scalar",
-                                                "scalarType": "float32",
-                                                "sizes": [
-                                                    {"kind": "uniform", "value": 4, "alignment": 4}
-                                                ]
-                                            },
-                                            "binding": {"kind": "uniform", "offset": 0, "size": 4, "elementStride": 0}
-                                        },
-                                        {
-                                            "name": "b",
-                                            "type": {
-                                                "kind": "scalar",
-                                                "scalarType": "int32",
-                                                "sizes": [
-                                                    {"kind": "uniform", "value": 4, "alignment": 4}
-                                                ]
-                                            },
-                                            "binding": {"kind": "uniform", "offset": 4, "size": 4, "elementStride": 0}
-                                        },
-                                        {
-                                            "name": "ptrC",
-                                            "type": {
-                                                "kind": "pointer",
-                                                "valueType": "int",
-                                                "sizes": [
-                                                    {"kind": "uniform", "value": 8, "alignment": 8}
-                                                ]
-                                            },
-                                            "binding": {"kind": "uniform", "offset": 8, "size": 8, "elementStride": 0}
-                                        }
-                                    ],
-                                    "sizes": [
-                                        {"kind": "uniform", "value": 16, "alignment": 8}
-                                    ]
-                                },
+                                "valueType": "AnotherStruct",
                                 "sizes": [
                                     {"kind": "uniform", "value": 8, "alignment": 8}
                                 ]
@@ -275,48 +234,7 @@ standard output = {
                                 "name": "anotherPtr",
                                 "type": {
                                     "kind": "pointer",
-                                    "valueType": {
-                                        "kind": "struct",
-                                        "name": "AnotherStruct",
-                                        "fields": [
-                                            {
-                                                "name": "a",
-                                                "type": {
-                                                    "kind": "scalar",
-                                                    "scalarType": "float32",
-                                                    "sizes": [
-                                                        {"kind": "uniform", "value": 4, "alignment": 4}
-                                                    ]
-                                                },
-                                                "binding": {"kind": "uniform", "offset": 0, "size": 4, "elementStride": 0}
-                                            },
-                                            {
-                                                "name": "b",
-                                                "type": {
-                                                    "kind": "scalar",
-                                                    "scalarType": "int32",
-                                                    "sizes": [
-                                                        {"kind": "uniform", "value": 4, "alignment": 4}
-                                                    ]
-                                                },
-                                                "binding": {"kind": "uniform", "offset": 4, "size": 4, "elementStride": 0}
-                                            },
-                                            {
-                                                "name": "ptrC",
-                                                "type": {
-                                                    "kind": "pointer",
-                                                    "valueType": "int",
-                                                    "sizes": [
-                                                        {"kind": "uniform", "value": 8, "alignment": 8}
-                                                    ]
-                                                },
-                                                "binding": {"kind": "uniform", "offset": 8, "size": 8, "elementStride": 0}
-                                            }
-                                        ],
-                                        "sizes": [
-                                            {"kind": "uniform", "value": 16, "alignment": 8}
-                                        ]
-                                    },
+                                    "valueType": "AnotherStruct",
                                     "sizes": [
                                         {"kind": "uniform", "value": 8, "alignment": 8}
                                     ]


### PR DESCRIPTION
Currently, `slangc --reflecting-json` doesn't traverse pointers:
given the following source code compiled with `slangc repro.slang -entry vertex -target spirv -profile spirv_1_6 -reflection-json out.json -no-codegen`
<details>
<summary>repro.slang</summary>

```slang
[__AttributeUsage(_AttributeTargets.Struct)]
struct MaterialParametersAttribute {
}

[MaterialParameters]
struct MaterialParams {
    float4 color;
}

[[vk_push_constant]]
cbuffer PushConstantData {
    MaterialParams* materialParameters;
};


[shader("vertex")]
float4 vertex(uint index : SV_VertexID) {
    return materialParameters[0].color;
}
```

</details>

the resulting json is
<details>
<summary>out.json - before my change</summary>

```json
{
    "version": "1.1",
    "parameters": [
        {
            "name": "PushConstantData",
            "binding": {"kind": "pushConstantBuffer", "index": 0},
            "type": {
                "kind": "constantBuffer",
                "elementType": {
                    "kind": "struct",
                    "fields": [
                        {
                            "name": "materialParameters",
                            "type": {
                                "kind": "pointer",
                                "valueType": "MaterialParams",
                                "sizes": [
                                    {"kind": "uniform", "value": 8, "alignment": 8}
                                ]
                            },
                            "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0}
                        }
                    ],
                    "sizes": [
                        {"kind": "uniform", "value": 8, "alignment": 8}
                    ]
                },
                "containerVarLayout": {
                    "binding": {"kind": "pushConstantBuffer", "index": 0}
                },
                "elementVarLayout": {
                    "type": {
                        "kind": "struct",
                        "fields": [
                            {
                                "name": "materialParameters",
                                "type": {
                                    "kind": "pointer",
                                    "valueType": "MaterialParams",
                                    "sizes": [
                                        {"kind": "uniform", "value": 8, "alignment": 8}
                                    ]
                                },
                                "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0}
                            }
                        ],
                        "sizes": [
                            {"kind": "uniform", "value": 8, "alignment": 8}
                        ]
                    },
                    "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0}
                },
                "sizes": [
                    {"kind": "pushConstantBuffer", "value": 1}
                ]
            }
        }
    ],
    "globalScope": {
        "kind": "none",
        "parameters": [
            {
                "name": "PushConstantData",
                "binding": {"kind": "pushConstantBuffer", "index": 0},
                "type": {
                    "kind": "constantBuffer",
                    "elementType": {
                        "kind": "struct",
                        "fields": [
                            {
                                "name": "materialParameters",
                                "type": {
                                    "kind": "pointer",
                                    "valueType": "MaterialParams",
                                    "sizes": [
                                        {"kind": "uniform", "value": 8, "alignment": 8}
                                    ]
                                },
                                "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0}
                            }
                        ],
                        "sizes": [
                            {"kind": "uniform", "value": 8, "alignment": 8}
                        ]
                    },
                    "containerVarLayout": {
                        "binding": {"kind": "pushConstantBuffer", "index": 0}
                    },
                    "elementVarLayout": {
                        "type": {
                            "kind": "struct",
                            "fields": [
                                {
                                    "name": "materialParameters",
                                    "type": {
                                        "kind": "pointer",
                                        "valueType": "MaterialParams",
                                        "sizes": [
                                            {"kind": "uniform", "value": 8, "alignment": 8}
                                        ]
                                    },
                                    "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0}
                                }
                            ],
                            "sizes": [
                                {"kind": "uniform", "value": 8, "alignment": 8}
                            ]
                        },
                        "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0}
                    },
                    "sizes": [
                        {"kind": "pushConstantBuffer", "value": 1}
                    ]
                }
            }
        ]
    },
    "entryPoints": [
        {
            "name": "vertex",
            "stage": "vertex",
            "scope": {
                "kind": "none",
                "parameters": [
                    {
                        "name": "index",
                        "semanticName": "SV_VERTEXID",
                        "type": {
                            "kind": "scalar",
                            "scalarType": "uint32",
                            "sizes": [

                            ]
                        }
                    }
                ]
            },
            "parameters": [
                {
                    "name": "index",
                    "semanticName": "SV_VERTEXID",
                    "type": {
                        "kind": "scalar",
                        "scalarType": "uint32",
                        "sizes": [

                        ]
                    }
                }
            ],
            "result": {
                "stage": "vertex",
                "binding": {"kind": "varyingOutput", "index": 0},
                "type": {
                    "kind": "vector",
                    "elementCount": 4,
                    "elementType": {
                        "kind": "scalar",
                        "scalarType": "float32"
                    },
                    "sizes": [
                        {"kind": "varyingOutput", "value": 1}
                    ]
                }
            }
        }
    ],
    "bindlessSpaceIndex": 0
}
```

</details>

which has two issues:
1. There's no mention of the `MaterialParameters` attribute anywhere in the json;
2. The layout for `MaterialParams` is missing.

With my changes, the json now becomes

<details>
<summary>out.json - after my changes</summary>

```json
{
    "version": "1.1",
    "parameters": [
        {
            "name": "PushConstantData",
            "binding": {"kind": "pushConstantBuffer", "index": 0},
            "type": {
                "kind": "constantBuffer",
                "elementType": {
                    "kind": "struct",
                    "fields": [
                        {
                            "name": "materialParameters",
                            "type": {
                                "kind": "pointer",
                                "valueType": {
                                    "kind": "struct",
                                    "name": "MaterialParams",
                                    "fields": [
                                        {
                                            "name": "color",
                                            "type": {
                                                "kind": "vector",
                                                "elementCount": 4,
                                                "elementType": {
                                                    "kind": "scalar",
                                                    "scalarType": "float32"
                                                },
                                                "sizes": [
                                                    {"kind": "uniform", "value": 16, "alignment": 4}
                                                ]
                                            },
                                            "binding": {"kind": "uniform", "offset": 0, "size": 16, "elementStride": 4}
                                        }
                                    ],
                                    "userAttribs": [
                                        {
                                            "name": "MaterialParameters",
                                            "arguments": [

                                            ]
                                        }
                                    ],
                                    "sizes": [
                                        {"kind": "uniform", "value": 16, "alignment": 4}
                                    ]
                                },
                                "sizes": [
                                    {"kind": "uniform", "value": 8, "alignment": 8}
                                ]
                            },
                            "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0}
                        }
                    ],
                    "sizes": [
                        {"kind": "uniform", "value": 8, "alignment": 8}
                    ]
                },
                "containerVarLayout": {
                    "binding": {"kind": "pushConstantBuffer", "index": 0}
                },
                "elementVarLayout": {
                    "type": {
                        "kind": "struct",
                        "fields": [
                            {
                                "name": "materialParameters",
                                "type": {
                                    "kind": "pointer",
                                    "valueType": {
                                        "kind": "struct",
                                        "name": "MaterialParams",
                                        "fields": [
                                            {
                                                "name": "color",
                                                "type": {
                                                    "kind": "vector",
                                                    "elementCount": 4,
                                                    "elementType": {
                                                        "kind": "scalar",
                                                        "scalarType": "float32"
                                                    },
                                                    "sizes": [
                                                        {"kind": "uniform", "value": 16, "alignment": 4}
                                                    ]
                                                },
                                                "binding": {"kind": "uniform", "offset": 0, "size": 16, "elementStride": 4}
                                            }
                                        ],
                                        "userAttribs": [
                                            {
                                                "name": "MaterialParameters",
                                                "arguments": [

                                                ]
                                            }
                                        ],
                                        "sizes": [
                                            {"kind": "uniform", "value": 16, "alignment": 4}
                                        ]
                                    },
                                    "sizes": [
                                        {"kind": "uniform", "value": 8, "alignment": 8}
                                    ]
                                },
                                "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0}
                            }
                        ],
                        "sizes": [
                            {"kind": "uniform", "value": 8, "alignment": 8}
                        ]
                    },
                    "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0}
                },
                "sizes": [
                    {"kind": "pushConstantBuffer", "value": 1}
                ]
            }
        }
    ],
    "globalScope": {
        "kind": "none",
        "parameters": [
            {
                "name": "PushConstantData",
                "binding": {"kind": "pushConstantBuffer", "index": 0},
                "type": {
                    "kind": "constantBuffer",
                    "elementType": {
                        "kind": "struct",
                        "fields": [
                            {
                                "name": "materialParameters",
                                "type": {
                                    "kind": "pointer",
                                    "valueType": {
                                        "kind": "struct",
                                        "name": "MaterialParams",
                                        "fields": [
                                            {
                                                "name": "color",
                                                "type": {
                                                    "kind": "vector",
                                                    "elementCount": 4,
                                                    "elementType": {
                                                        "kind": "scalar",
                                                        "scalarType": "float32"
                                                    },
                                                    "sizes": [
                                                        {"kind": "uniform", "value": 16, "alignment": 4}
                                                    ]
                                                },
                                                "binding": {"kind": "uniform", "offset": 0, "size": 16, "elementStride": 4}
                                            }
                                        ],
                                        "userAttribs": [
                                            {
                                                "name": "MaterialParameters",
                                                "arguments": [

                                                ]
                                            }
                                        ],
                                        "sizes": [
                                            {"kind": "uniform", "value": 16, "alignment": 4}
                                        ]
                                    },
                                    "sizes": [
                                        {"kind": "uniform", "value": 8, "alignment": 8}
                                    ]
                                },
                                "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0}
                            }
                        ],
                        "sizes": [
                            {"kind": "uniform", "value": 8, "alignment": 8}
                        ]
                    },
                    "containerVarLayout": {
                        "binding": {"kind": "pushConstantBuffer", "index": 0}
                    },
                    "elementVarLayout": {
                        "type": {
                            "kind": "struct",
                            "fields": [
                                {
                                    "name": "materialParameters",
                                    "type": {
                                        "kind": "pointer",
                                        "valueType": {
                                            "kind": "struct",
                                            "name": "MaterialParams",
                                            "fields": [
                                                {
                                                    "name": "color",
                                                    "type": {
                                                        "kind": "vector",
                                                        "elementCount": 4,
                                                        "elementType": {
                                                            "kind": "scalar",
                                                            "scalarType": "float32"
                                                        },
                                                        "sizes": [
                                                            {"kind": "uniform", "value": 16, "alignment": 4}
                                                        ]
                                                    },
                                                    "binding": {"kind": "uniform", "offset": 0, "size": 16, "elementStride": 4}
                                                }
                                            ],
                                            "userAttribs": [
                                                {
                                                    "name": "MaterialParameters",
                                                    "arguments": [

                                                    ]
                                                }
                                            ],
                                            "sizes": [
                                                {"kind": "uniform", "value": 16, "alignment": 4}
                                            ]
                                        },
                                        "sizes": [
                                            {"kind": "uniform", "value": 8, "alignment": 8}
                                        ]
                                    },
                                    "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0}
                                }
                            ],
                            "sizes": [
                                {"kind": "uniform", "value": 8, "alignment": 8}
                            ]
                        },
                        "binding": {"kind": "uniform", "offset": 0, "size": 8, "elementStride": 0}
                    },
                    "sizes": [
                        {"kind": "pushConstantBuffer", "value": 1}
                    ]
                }
            }
        ]
    },
    "entryPoints": [
        {
            "name": "vertex",
            "stage": "vertex",
            "scope": {
                "kind": "none",
                "parameters": [
                    {
                        "name": "index",
                        "semanticName": "SV_VERTEXID",
                        "type": {
                            "kind": "scalar",
                            "scalarType": "uint32",
                            "sizes": [

                            ]
                        }
                    }
                ]
            },
            "parameters": [
                {
                    "name": "index",
                    "semanticName": "SV_VERTEXID",
                    "type": {
                        "kind": "scalar",
                        "scalarType": "uint32",
                        "sizes": [

                        ]
                    }
                }
            ],
            "result": {
                "stage": "vertex",
                "binding": {"kind": "varyingOutput", "index": 0},
                "type": {
                    "kind": "vector",
                    "elementCount": 4,
                    "elementType": {
                        "kind": "scalar",
                        "scalarType": "float32"
                    },
                    "sizes": [
                        {"kind": "varyingOutput", "value": 1}
                    ]
                }
            }
        }
    ],
    "bindlessSpaceIndex": 0
}
```

</details>

which correctly reports the user attribute and `MaterialParams`'s members.

I had to change the tests `tests/reflection/ptr/ptr-struct` and `tests/reflection/ptr/ptr-generic` to reflect the new behavior, and added a small section to `tests/reflection/attribute.slang.expected` to make sure that attributes are visible when reflecting through a pointer