### PR TITLE
cmake-options: post the weekly Slack notification through its own webhook

### DIFF
--- a/.github/workflows/cmake-options.yml
+++ b/.github/workflows/cmake-options.yml
@@ -165,6 +165,12 @@ jobs:
           fi
           echo "All CMake option builds completed successfully!"
 
+      # Requires the SLACK_WEBHOOK_CMAKE_OPTIONS repository secret pointing at
+      # this weekly's own Slack Workflow webhook, whose variable key is
+      # "CMake-Options-Weekly". A dedicated webhook (rather than a shared one)
+      # is needed because a Slack Workflow webhook carries the sender name of
+      # the Slack workflow that owns it, which the payload cannot override,
+      # and it accepts only that workflow's own variable keys.
       - name: success notification
         id: slack-notify-success
         if: ${{ github.event_name == 'schedule' && success() }}
@@ -175,7 +181,7 @@ jobs:
               "CMake-Options-Weekly": ":green-check-mark: CMake options weekly status: ${{ job.status }}"
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_CMAKE_OPTIONS }}
       # TODO: Re-enable the failure notification once this weekly workflow has
       # proven stable enough that a failure means a real regression. Until
       # then we only post the success message, so an infrastructure hiccup
@@ -190,4 +196,4 @@ jobs:
       #         "CMake-Options-Weekly": ":alert: :alert: :alert: :alert: :alert: :alert:\nCMake options weekly status: ${{ job.status }}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       #       }
       #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_CMAKE_OPTIONS }}


### PR DESCRIPTION
## Motivation

The weekly CMake-options workflow posts its result to Slack, but the message
shows up in the channel attributed to a different workflow's notification
sender, not to this weekly.

The cause is that `.github/workflows/cmake-options.yml` sends its payload
through `secrets.SLACK_WEBHOOK_URL`, which is a Slack Workflow Builder webhook
created for a different nightly workflow. Two things follow from that:

1. The sender name displayed in Slack is a property of the Slack workflow that
   owns the webhook. A GitHub Actions payload cannot override it, so this
   weekly's messages are labeled with the other workflow's name.
2. A Workflow Builder webhook accepts only the variable keys declared by its own
   Slack workflow. The payload we send uses the key `"CMake-Options-Weekly"`,
   which that webhook does not declare, so the message text we compose is not
   what reaches the channel.

## Proposed solution

Give this weekly its own Slack Workflow webhook and its own repository secret,
rather than reusing another workflow's.

This is the arrangement the repository already uses for the agentic nightly:
`.github/workflows/nightly-slang-test.yml:266` reads
`secrets.SLACK_WEBHOOK_AGENTIC_TESTS` and sends the matching `"Agentic-Nightly"`
payload key, with the requirement documented in a comment at
`nightly-slang-test.yml:248-251`. One webhook per notifying workflow is the
principled shape here because the identity shown in Slack and the set of
accepted payload keys are both properties of the webhook, so sharing one webhook
across workflows cannot express more than one sender or key.

This PR is the GitHub side of that change. It depends on a repository secret
named `SLACK_WEBHOOK_CMAKE_OPTIONS` holding a Slack Workflow webhook whose
declared variable key is `CMake-Options-Weekly`; the Slack workflow and the
secret are being set up alongside it.

## Change summary

| File | Change |
| --- | --- |
| `.github/workflows/cmake-options.yml` | The `success notification` step (and the commented-out `failure notification` step) now read `secrets.SLACK_WEBHOOK_CMAKE_OPTIONS` instead of the shared `secrets.SLACK_WEBHOOK_URL`. Adds a comment recording which secret is required and why a dedicated webhook is needed. |

## Concepts and vocabulary

- **Slack Workflow webhook** — the trigger URL of a Slack Workflow Builder
  workflow, as used by `slackapi/slack-github-action` via the
  `SLACK_WEBHOOK_URL` environment variable. It is not an app or bot token: the
  posting identity and the message layout belong to the Slack workflow, and the
  JSON body may set only the variables that workflow declares. That is why the
  single top-level payload key in each of these steps (`"CMake-Options-Weekly"`
  here, `"Agentic-Nightly"` in the agentic nightly) has to match the webhook's
  own variable name.

## Process report

The change is a two-line swap of the secret name plus an explanatory comment.

The `success notification` step at `cmake-options.yml:176-186` composes
`{"CMake-Options-Weekly": ...}` but sends it to `secrets.SLACK_WEBHOOK_URL`. The
key and the webhook come from different Slack workflows, so the step is
internally inconsistent: either the key is wrong for the webhook, or the webhook
is wrong for the key. Renaming the payload key to whatever the shared webhook
declares would fix the delivery but not the reported problem, because the sender
name would still be the other workflow's. Only a dedicated webhook fixes both,
which is why the secret reference changes rather than the payload.

The commented-out `failure notification` step at `cmake-options.yml:191-199` gets
the same secret. It is disabled today by an existing TODO that is unrelated to
this change (it waits for the weekly to prove stable before failures are
announced), but leaving it pointing at the old secret would reintroduce the bug
whenever that TODO is acted on.

No input shape is being guarded or special-cased here, so the input-shape check
does not apply; the fix sits at the configuration layer where the wrong value was
supplied.

One consequence worth noting for review: the notification is inert until the
`SLACK_WEBHOOK_CMAKE_OPTIONS` secret exists, since an unset secret expands to an
empty `SLACK_WEBHOOK_URL`. Both steps are also gated on
`github.event_name == 'schedule'`, so `workflow_dispatch` runs stay quiet and the
webhook is best verified by posting the payload directly.
